### PR TITLE
Add blueprint version tracking and upgrade system

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,9 +7,9 @@
     {
       "name": "blueprint-plugin",
       "source": "./blueprint-plugin",
-      "description": "Blueprint Development methodology - PRD/PRP workflow for structured feature development",
-      "version": "1.0.0",
-      "keywords": ["blueprint", "prd", "prp", "requirements", "methodology"],
+      "description": "Blueprint Development methodology - PRD/PRP workflow with version tracking, modular rules, and CLAUDE.md management",
+      "version": "1.1.0",
+      "keywords": ["blueprint", "prd", "prp", "requirements", "methodology", "version-tracking", "modular-rules"],
       "category": "development"
     },
     {
@@ -111,9 +111,9 @@
     {
       "name": "project-plugin",
       "source": "./project-plugin",
-      "description": "Project initialization and management - setup, modernization",
-      "version": "1.0.0",
-      "keywords": ["project", "initialization", "setup", "modernization"],
+      "description": "Project initialization and management - setup, modernization, and continuous development workflows",
+      "version": "1.1.0",
+      "keywords": ["project", "initialization", "setup", "modernization", "tdd", "workflow"],
       "category": "development"
     },
     {

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -313,18 +313,18 @@ tools: Tool1, Tool2, mcp__server-name
 
 ---
 
-### 14. project-plugin
+### 14. project-plugin - COMPLETE
 **Purpose:** Project initialization and management
 
 | Type | Name | Status | Notes |
 |------|------|--------|-------|
-| Command | project/init | [ ] | |
-| Command | project/new | [ ] | |
-| Command | project/modernize | [ ] | |
-| Command | project/modernize-exp | [ ] | |
-| Command | project-continue | [ ] | |
-| Command | project-test-loop | [ ] | |
-| Skill | project-discovery | [ ] | |
+| Command | project/init | [x] | Namespaced as `/project:init` |
+| Command | project/new | [x] | Namespaced as `/project:new` |
+| Command | project/modernize | [x] | Namespaced as `/project:modernize` |
+| Command | project/modernize-exp | [x] | Namespaced as `/project:modernize-exp` |
+| Command | project/continue | [x] | Namespaced as `/project:continue` (was `project-continue`) |
+| Command | project/test-loop | [x] | Namespaced as `/project:test-loop` (was `project-test-loop`) |
+| Skill | project-discovery | [x] | |
 
 ---
 

--- a/blueprint-plugin/.claude-plugin/plugin.json
+++ b/blueprint-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "blueprint-plugin",
-  "version": "1.0.0",
-  "description": "Blueprint Development methodology - PRD/PRP workflow for structured feature development with systematic research, validation gates, and work-order generation",
+  "version": "1.1.0",
+  "description": "Blueprint Development methodology - PRD/PRP workflow for structured feature development with version tracking, modular rules, and CLAUDE.md management",
   "author": {
     "name": "Lauri Gates"
   },
@@ -14,6 +14,8 @@
     "requirements",
     "methodology",
     "documentation-first",
-    "work-orders"
+    "work-orders",
+    "version-tracking",
+    "modular-rules"
   ]
 }

--- a/blueprint-plugin/commands/blueprint-claude-md.md
+++ b/blueprint-plugin/commands/blueprint-claude-md.md
@@ -1,0 +1,180 @@
+---
+description: "Generate or update CLAUDE.md from project context and blueprint artifacts"
+allowed_tools: [Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion]
+---
+
+Generate or update the project's CLAUDE.md file based on blueprint artifacts, PRDs, and project structure.
+
+**Steps**:
+
+1. **Check current state**:
+   - Look for existing `CLAUDE.md` in project root
+   - Read `.claude/blueprints/.manifest.json` for configuration
+   - Determine `claude_md_mode` (single, modular, or both)
+
+2. **Determine action** (use AskUserQuestion):
+   ```
+   {If CLAUDE.md exists:}
+   question: "CLAUDE.md already exists. What would you like to do?"
+   options:
+     - "Update with latest project info" → merge updates
+     - "Regenerate completely" → overwrite (backup first)
+     - "Add missing sections only" → append new content
+     - "Convert to modular rules" → split into .claude/rules/
+     - "View current structure" → analyze and display
+
+   {If CLAUDE.md doesn't exist:}
+   question: "No CLAUDE.md found. How would you like to create it?"
+   options:
+     - "Generate from project analysis" → auto-generate
+     - "Generate from PRDs" → use blueprint PRDs
+     - "Start with template" → use starter template
+     - "Use modular rules instead" → skip CLAUDE.md, use rules/
+   ```
+
+3. **Gather project context**:
+   - **Project structure**: Detect language, framework, build tools
+   - **PRDs**: Read `.claude/blueprints/prds/*.md` for requirements
+   - **Work overview**: Current phase and progress
+   - **Existing rules**: Content from `.claude/rules/` if present
+   - **Git history**: Recent patterns and conventions
+   - **Dependencies**: Package managers, key libraries
+
+4. **Generate CLAUDE.md sections**:
+
+   **Standard sections**:
+   ```markdown
+   # Project: {name}
+
+   ## Overview
+   {Brief project description from PRDs or detection}
+
+   ## Tech Stack
+   - Language: {detected}
+   - Framework: {detected}
+   - Build: {detected}
+   - Test: {detected}
+
+   ## Development Workflow
+
+   ### Getting Started
+   {Setup commands}
+
+   ### Running Tests
+   {Test commands}
+
+   ### Building
+   {Build commands}
+
+   ## Architecture
+   {Key architectural decisions from PRDs}
+
+   ## Conventions
+
+   ### Code Style
+   {Detected or from PRDs}
+
+   ### Commit Messages
+   {Conventional commits if detected}
+
+   ### Testing Requirements
+   {From PRDs or rules}
+
+   ## Current Focus
+   {From work-overview.md}
+
+   ## Key Files
+   {Important files and their purposes}
+
+   ## See Also
+   {If modular rules enabled:}
+   - `.claude/rules/` - Detailed rules by domain
+   - `.claude/blueprints/prds/` - Product requirements
+   ```
+
+5. **If modular rules mode = "both"**:
+   - Keep CLAUDE.md as high-level overview
+   - Reference `.claude/rules/` for details:
+     ```markdown
+     ## Detailed Rules
+     See `.claude/rules/` for domain-specific guidelines:
+     - `development.md` - Development workflow
+     - `testing.md` - Testing requirements
+     - `frontend/` - Frontend-specific rules
+     - `backend/` - Backend-specific rules
+     ```
+
+6. **If modular rules mode = "modular"**:
+   - Create minimal CLAUDE.md with references
+   - Move detailed content to `.claude/rules/`
+
+7. **Smart update** (for existing CLAUDE.md):
+   - Parse existing sections
+   - Identify outdated content (compare with PRDs, structure)
+   - Offer section-by-section updates:
+     ```
+     question: "Found outdated sections. Which would you like to update?"
+     options: [list of sections]
+     allowMultiSelect: true
+     ```
+
+8. **Sync with modular rules**:
+   - If rules exist in `.claude/rules/`
+   - Detect duplicated content
+   - Offer to deduplicate:
+     ```
+     question: "Found duplicate content between CLAUDE.md and rules/. How to resolve?"
+     options:
+       - "Keep in CLAUDE.md, remove from rules"
+       - "Keep in rules, reference from CLAUDE.md"
+       - "Keep both (may cause confusion)"
+     ```
+
+9. **Update manifest**:
+   - Record CLAUDE.md generation/update
+   - Track which PRDs contributed
+   - Update timestamp
+
+10. **Report**:
+    ```
+    ✅ CLAUDE.md updated!
+
+    {Created | Updated}: CLAUDE.md
+
+    Sections:
+    - Overview ✅
+    - Tech Stack ✅
+    - Development Workflow ✅
+    - Architecture ✅
+    - Conventions ✅
+    - Current Focus ✅
+
+    Sources used:
+    - PRDs: {list}
+    - Rules: {list}
+    - Project detection: {what was detected}
+
+    {If modular mode:}
+    Note: Detailed rules are in .claude/rules/
+    CLAUDE.md serves as overview and quick reference.
+
+    Run `/blueprint-status` to see full configuration.
+    ```
+
+**CLAUDE.md Best Practices**:
+- Keep it concise (< 500 lines ideally)
+- Focus on "what Claude needs to know"
+- Reference modular rules for details
+- Update when PRDs change significantly
+- Include current focus/phase for context
+
+**Template Sections** (customize per project type):
+
+| Project Type | Key Sections |
+|--------------|--------------|
+| Python | Virtual env, pytest, type hints |
+| Node.js | Package manager, test runner, build |
+| Rust | Cargo, clippy, unsafe usage rules |
+| Monorepo | Workspace structure, shared deps |
+| API | Endpoints, auth, error handling |
+| Frontend | Components, state, styling |

--- a/blueprint-plugin/commands/blueprint-generate-commands.md
+++ b/blueprint-plugin/commands/blueprint-generate-commands.md
@@ -30,13 +30,20 @@ Generate workflow commands customized for this project.
    - Check project-specific tools
 
 4. **Generate `/project:continue` command**:
+
+   Create file at `.claude/commands/project/continue.md`:
    ```markdown
    ---
-   description: "Analyze project state and continue development where left off"
+   description: "Continue development on [project-name] (project-specific)"
    allowed_tools: [Read, Bash, Grep, Glob, Edit, Write]
    ---
 
-   Continue project development:
+   Continue project development (customized for this project).
+
+   **Project-specific configuration**:
+   - Test command: `[detected_test_command]`
+   - Build command: `[detected_build_command]`
+   - Dev command: `[detected_dev_command]`
 
    1. **Check current state**:
       - Run `git status` (branch, uncommitted changes)
@@ -64,13 +71,19 @@ Generate workflow commands customized for this project.
    ```
 
 5. **Generate `/project:test-loop` command**:
+
+   Create file at `.claude/commands/project/test-loop.md`:
    ```markdown
    ---
-   description: "Run test → fix → refactor loop with TDD workflow"
+   description: "TDD loop for [project-name] using [test-runner]"
    allowed_tools: [Read, Edit, Bash]
    ---
 
-   Run TDD cycle:
+   Run TDD cycle (customized for this project).
+
+   **Project-specific configuration**:
+   - Test command: `[detected_test_command]`
+   - Watch mode: `[detected_watch_command]` (if available)
 
    1. **Run test suite**: `[detected_test_command]`
    2. **If tests fail**:
@@ -99,13 +112,18 @@ Generate workflow commands customized for this project.
    - If CLI: Commands for building, testing CLI
    - If library: Commands for building, publishing
 
-7. **Report**:
+7. **Update manifest**:
+   - Read `.claude/blueprints/.manifest.json`
+   - Add generated commands to `generated_artifacts.commands`
+   - Update `updated_at` timestamp
+
+8. **Report**:
    ```
    ✅ Workflow commands generated!
 
    Created:
-   - .claude/commands/project-continue.md
-   - .claude/commands/project-test-loop.md
+   - .claude/commands/project/continue.md → /project:continue
+   - .claude/commands/project/test-loop.md → /project:test-loop
    [- Additional project-specific commands]
 
    Detected configuration:
@@ -117,9 +135,9 @@ Generate workflow commands customized for this project.
    Next steps:
    1. Use `/project:continue` to start or resume development
    2. Use `/project:test-loop` for TDD automation
-   3. Use `/blueprint:work-order` to create isolated tasks
+   3. Use `/blueprint-work-order` to create isolated tasks
 
-   All commands are now available via slash syntax!
+   All commands use namespaced pattern (project:*) and are now available!
    ```
 
 **Important**:

--- a/blueprint-plugin/commands/blueprint-init.md
+++ b/blueprint-plugin/commands/blueprint-init.md
@@ -1,6 +1,6 @@
 ---
 description: "Initialize Blueprint Development structure in current project"
-allowed_tools: [Bash, Write, Read]
+allowed_tools: [Bash, Write, Read, AskUserQuestion]
 ---
 
 Initialize Blueprint Development in this project.
@@ -8,20 +8,81 @@ Initialize Blueprint Development in this project.
 **Steps**:
 
 1. **Check if already initialized**:
-   - Look for `.claude/blueprints/` directory
-   - If exists, report and ask if user wants to reinitialize
+   - Look for `.claude/blueprints/.manifest.json`
+   - If exists, read version and ask user:
+     ```
+     Use AskUserQuestion:
+     question: "Blueprint already initialized (v{version}). What would you like to do?"
+     options:
+       - "Check for upgrades" → run /blueprint-upgrade
+       - "Reinitialize (will reset manifest)" → continue with step 2
+       - "Cancel" → exit
+     ```
 
-2. **Create directory structure**:
+2. **Gather project context** (use AskUserQuestion):
    ```
-   .claude/blueprints/
-   ├── prds/                     # Product Requirements Documents
-   ├── work-orders/              # Task packages for subagents
-   │   ├── completed/            # Completed work-orders
-   │   └── archived/             # Obsolete work-orders
-   └── templates/                # Custom templates (optional)
+   question: "What type of project is this?"
+   options:
+     - "Personal/Solo project" → recommend .gitignore for .claude/
+     - "Team project" → recommend committing .claude/ for sharing
+     - "Open source" → recommend .claude/rules/ for contributor guidelines
    ```
 
-3. **Create `work-overview.md`**:
+3. **Ask about modular rules**:
+   ```
+   question: "How would you like to organize project instructions?"
+   options:
+     - "Single CLAUDE.md file" → traditional approach
+     - "Modular rules (.claude/rules/)" → create rules directory structure
+     - "Both" → CLAUDE.md for overview, rules/ for specifics
+   allowMultiSelect: false
+   ```
+
+4. **Create directory structure**:
+   ```
+   .claude/
+   ├── blueprints/
+   │   ├── .manifest.json          # Version tracking (NEW)
+   │   ├── prds/                   # Product Requirements Documents
+   │   ├── work-orders/            # Task packages for subagents
+   │   │   ├── completed/          # Completed work-orders
+   │   │   └── archived/           # Obsolete work-orders
+   │   └── templates/              # Custom templates (optional)
+   └── rules/                      # Modular rules (if selected)
+       ├── development.md          # Development workflow rules
+       └── testing.md              # Testing requirements
+   ```
+
+5. **Create `.manifest.json`**:
+   ```json
+   {
+     "format_version": "1.1.0",
+     "created_at": "[ISO timestamp]",
+     "updated_at": "[ISO timestamp]",
+     "created_by": {
+       "blueprint_plugin": "1.0.0"
+     },
+     "project": {
+       "name": "[detected or asked]",
+       "type": "[personal|team|opensource]"
+     },
+     "structure": {
+       "has_prds": true,
+       "has_work_orders": true,
+       "has_ai_docs": false,
+       "has_templates": false,
+       "has_modular_rules": "[based on user choice]",
+       "claude_md_mode": "[single|modular|both]"
+     },
+     "generated_artifacts": {
+       "commands": [],
+       "skills": [],
+       "rules": []
+     }
+   }
+   ```
+
+6. **Create `work-overview.md`**:
    ```markdown
    # Work Overview: [Project Name]
 
@@ -42,25 +103,40 @@ Initialize Blueprint Development in this project.
    2. [Next step 2]
    ```
 
-4. **Ask about `.gitignore`**:
-   - Ask user if they want to add `.claude/` to `.gitignore`
-   - If personal project → recommend `.gitignore`
-   - If team project → recommend committing `.claude/` for sharing
+7. **Create initial rules** (if modular rules selected):
+   - `development.md`: TDD workflow, commit conventions
+   - `testing.md`: Test requirements, coverage expectations
 
-5. **Report**:
+8. **Handle `.gitignore`** based on project type:
+   - Personal: Add `.claude/` to `.gitignore`
+   - Team: Commit `.claude/` (ask about secrets)
+   - Open source: Commit `.claude/rules/`, gitignore `.claude/blueprints/work-orders/`
+
+9. **Report**:
    ```
-   ✅ Blueprint Development initialized!
+   ✅ Blueprint Development initialized! (v1.1.0)
 
    Created:
+   - .claude/blueprints/.manifest.json (version tracking)
    - .claude/blueprints/prds/
    - .claude/blueprints/work-orders/
    - .claude/blueprints/work-overview.md
+   [- .claude/rules/ (if modular rules enabled)]
+
+   Configuration:
+   - Project type: [personal|team|opensource]
+   - Rules mode: [single|modular|both]
 
    Next steps:
    1. Write PRDs in `.claude/blueprints/prds/`
-   2. Run `/blueprint:generate-skills` to create project-specific skills
-   3. Run `/blueprint:generate-commands` to create workflow commands
-   4. Start development with `/project:continue`
+   2. Run `/blueprint-generate-skills` to create project-specific skills
+   3. Run `/blueprint-generate-commands` to create workflow commands
+   4. Run `/blueprint-rules` to add domain-specific rules
+   5. Start development with `/project:continue`
 
-   See `.claude/docs/blueprint-development/` for complete documentation.
+   Management commands:
+   - `/blueprint-status` - Check version and configuration
+   - `/blueprint-upgrade` - Upgrade to latest format
+   - `/blueprint-rules` - Manage modular rules
+   - `/blueprint-claude-md` - Update CLAUDE.md
    ```

--- a/blueprint-plugin/commands/blueprint-rules.md
+++ b/blueprint-plugin/commands/blueprint-rules.md
@@ -1,0 +1,171 @@
+---
+description: "Manage modular rules in .claude/rules/ directory"
+allowed_tools: [Read, Write, Edit, Bash, Glob, AskUserQuestion]
+---
+
+Manage modular rules for the project. Rules are markdown files in `.claude/rules/` that provide context-specific instructions to Claude.
+
+**Steps**:
+
+1. **Check blueprint status**:
+   - Read `.claude/blueprints/.manifest.json`
+   - Check if modular rules are enabled
+   - If not enabled, offer to enable:
+     ```
+     Use AskUserQuestion:
+     question: "Modular rules are not enabled. Would you like to enable them?"
+     options:
+       - "Yes, create .claude/rules/ structure" → enable and continue
+       - "No, use single CLAUDE.md" → exit
+     ```
+
+2. **Determine action** (use AskUserQuestion):
+   ```
+   question: "What would you like to do with modular rules?"
+   options:
+     - "List existing rules" → show current rules
+     - "Add a new rule" → create new rule file
+     - "Edit existing rule" → modify rule
+     - "Generate rules from PRDs" → auto-generate from requirements
+     - "Sync rules with CLAUDE.md" → bidirectional sync
+     - "Validate rules" → check for issues
+   ```
+
+3. **List existing rules**:
+   - Scan `.claude/rules/` recursively for `.md` files
+   - Parse frontmatter for `paths` field (if scoped)
+   - Display:
+     ```
+     📜 Modular Rules
+
+     Global Rules (apply to all files):
+     - development.md - TDD workflow and conventions
+     - testing.md - Test requirements
+
+     Scoped Rules (apply to specific paths):
+     - frontend/react.md - paths: ["src/components/**/*.tsx"]
+     - backend/api.md - paths: ["src/api/**/*.ts"]
+
+     Total: 4 rules
+     ```
+
+4. **Add a new rule** (use AskUserQuestion):
+   ```
+   question: "What type of rule would you like to create?"
+   options:
+     - "Development workflow" → development.md template
+     - "Testing requirements" → testing.md template
+     - "Code style/conventions" → code-style.md template
+     - "Architecture patterns" → architecture.md template
+     - "Language-specific" → prompt for language
+     - "Framework-specific" → prompt for framework
+     - "Custom" → blank template with guidance
+   ```
+
+   Then ask:
+   ```
+   question: "Should this rule apply to all files or specific paths?"
+   options:
+     - "All files (global)" → no paths frontmatter
+     - "Specific file patterns" → prompt for glob patterns
+   ```
+
+5. **Rule file templates**:
+
+   **Global rule template**:
+   ```markdown
+   # {Rule Name}
+
+   ## Overview
+   {Brief description of when this rule applies}
+
+   ## Requirements
+   - {Requirement 1}
+   - {Requirement 2}
+
+   ## Examples
+   {Code examples if applicable}
+   ```
+
+   **Scoped rule template**:
+   ```markdown
+   ---
+   paths:
+     - "src/components/**/*.tsx"
+     - "src/components/**/*.ts"
+   ---
+
+   # {Rule Name}
+
+   ## Overview
+   {Brief description - applies only to matched paths}
+
+   ## Requirements
+   - {Requirement 1}
+   - {Requirement 2}
+   ```
+
+6. **Generate rules from PRDs**:
+   - Read all PRDs in `.claude/blueprints/prds/`
+   - Extract key requirements and constraints
+   - Group by domain (testing, architecture, coding standards)
+   - Generate rule files:
+     - `rules/from-prd-testing.md` - Test requirements from PRDs
+     - `rules/from-prd-architecture.md` - Architecture decisions
+     - `rules/from-prd-conventions.md` - Coding conventions
+
+7. **Sync rules with CLAUDE.md**:
+   - Parse existing CLAUDE.md sections
+   - Compare with rules in `.claude/rules/`
+   - Offer sync options:
+     ```
+     question: "How would you like to sync?"
+     options:
+       - "CLAUDE.md → rules (split into modular files)"
+       - "Rules → CLAUDE.md (consolidate)"
+       - "Merge both (combine unique content)"
+     ```
+
+8. **Validate rules**:
+   - Check for syntax errors in frontmatter
+   - Validate glob patterns in `paths` field
+   - Check for conflicting rules
+   - Warn about overly broad or narrow scopes
+   - Report:
+     ```
+     ✅ Rule Validation
+
+     Checked: 4 rules
+     Valid: 4
+     Warnings: 1
+       - frontend/react.md: paths pattern may be too broad
+
+     No errors found.
+     ```
+
+9. **Update manifest**:
+   - Add created/modified rules to `generated_artifacts.rules`
+   - Update `updated_at` timestamp
+
+10. **Report**:
+    ```
+    ✅ Rule management complete!
+
+    {Action summary}
+
+    Current rules: {count} files
+    - Global: {count}
+    - Scoped: {count}
+
+    Run `/blueprint-status` to see full configuration.
+    ```
+
+**Common Rule Patterns**:
+
+| Rule Type | Suggested Path | Scope Pattern |
+|-----------|---------------|---------------|
+| React components | `rules/frontend/react.md` | `["**/*.tsx", "**/*.jsx"]` |
+| API handlers | `rules/backend/api.md` | `["src/api/**/*", "src/routes/**/*"]` |
+| Database models | `rules/backend/models.md` | `["src/models/**/*", "src/db/**/*"]` |
+| Test files | `rules/testing.md` | `["**/*.test.*", "**/*.spec.*"]` |
+| Documentation | `rules/docs.md` | `["**/*.md", "docs/**/*"]` |

--- a/blueprint-plugin/commands/blueprint-status.md
+++ b/blueprint-plugin/commands/blueprint-status.md
@@ -1,0 +1,106 @@
+---
+description: "Show blueprint version, configuration, and check for available upgrades"
+allowed_tools: [Read, Bash, Glob]
+---
+
+Display the current blueprint configuration status and check for upgrades.
+
+**Steps**:
+
+1. **Check if blueprint is initialized**:
+   - Look for `.claude/blueprints/.manifest.json`
+   - If not found, report:
+     ```
+     ❌ Blueprint not initialized in this project.
+     Run `/blueprint-init` to get started.
+     ```
+
+2. **Read manifest and gather information**:
+   - Parse `.manifest.json` for version and configuration
+   - Count PRDs in `.claude/blueprints/prds/`
+   - Count work-orders (pending, completed, archived)
+   - Check for `.claude/rules/` directory and count rules
+   - Check for `CLAUDE.md` file
+
+3. **Check for upgrade availability**:
+   - Compare `format_version` in manifest with current plugin version
+   - Current format version: **1.1.0**
+   - If manifest version < current → upgrade available
+
+4. **Display status report**:
+   ```
+   📋 Blueprint Status
+
+   Version: v{format_version} {upgrade_indicator}
+   Initialized: {created_at}
+   Last Updated: {updated_at}
+
+   Project Configuration:
+   - Name: {project.name}
+   - Type: {project.type}
+   - Rules Mode: {structure.claude_md_mode}
+
+   Content:
+   - PRDs: {count} documents
+   - Work Orders: {pending} pending, {completed} completed, {archived} archived
+   - Generated Commands: {count}
+   - Generated Skills: {count}
+   - Modular Rules: {count} files
+
+   Structure:
+   ✅ .claude/blueprints/.manifest.json
+   {✅|❌} .claude/blueprints/prds/
+   {✅|❌} .claude/blueprints/work-orders/
+   {✅|❌} .claude/blueprints/work-overview.md
+   {✅|❌} .claude/rules/
+   {✅|❌} CLAUDE.md
+
+   {If upgrade available:}
+   ⬆️  Upgrade available: v{current} → v{latest}
+      Run `/blueprint-upgrade` to upgrade.
+
+   {If up to date:}
+   ✅ Blueprint is up to date.
+   ```
+
+5. **Additional checks**:
+   - Warn if work-overview.md is stale (older than latest work-order)
+   - Warn if PRDs exist but no work-orders generated
+   - Warn if modular rules enabled but `.claude/rules/` is empty
+   - Suggest next actions based on state
+
+**Example Output**:
+```
+📋 Blueprint Status
+
+Version: v1.0.0 (upgrade available!)
+Initialized: 2024-01-10T09:00:00Z
+Last Updated: 2024-01-15T14:30:00Z
+
+Project Configuration:
+- Name: my-awesome-project
+- Type: team
+- Rules Mode: both
+
+Content:
+- PRDs: 3 documents
+- Work Orders: 5 pending, 12 completed, 2 archived
+- Generated Commands: 2 (project-continue, project-test-loop)
+- Generated Skills: 4
+- Modular Rules: 3 files
+
+Structure:
+✅ .claude/blueprints/.manifest.json
+✅ .claude/blueprints/prds/
+✅ .claude/blueprints/work-orders/
+✅ .claude/blueprints/work-overview.md
+✅ .claude/rules/
+✅ CLAUDE.md
+
+⬆️  Upgrade available: v1.0.0 → v1.1.0
+   Run `/blueprint-upgrade` to upgrade.
+
+💡 Suggestions:
+- work-overview.md hasn't been updated in 3 days
+- Consider running `/blueprint-claude-md` to sync CLAUDE.md
+```

--- a/blueprint-plugin/commands/blueprint-upgrade.md
+++ b/blueprint-plugin/commands/blueprint-upgrade.md
@@ -1,0 +1,137 @@
+---
+description: "Upgrade blueprint structure to the latest format version"
+allowed_tools: [Read, Write, Edit, Bash, Glob, AskUserQuestion]
+---
+
+Upgrade the blueprint structure to the latest format version.
+
+**Current Format Version**: 1.1.0
+
+**Steps**:
+
+1. **Check current state**:
+   - Read `.claude/blueprints/.manifest.json`
+   - If not found, suggest running `/blueprint-init` instead
+   - Compare versions to determine upgrade path
+
+2. **Display upgrade plan**:
+   ```
+   🔄 Blueprint Upgrade
+
+   Current version: v{current}
+   Target version: v1.1.0
+
+   Changes to be applied:
+   {list of changes based on version delta}
+   ```
+
+3. **Confirm with user** (use AskUserQuestion):
+   ```
+   question: "Ready to upgrade blueprint from v{current} to v1.1.0?"
+   options:
+     - "Yes, upgrade now" → proceed
+     - "Show detailed changes first" → display migration details
+     - "Create backup first" → backup then proceed
+     - "Cancel" → exit
+   ```
+
+4. **Apply migrations based on version**:
+
+   **v1.0.0 → v1.1.0 migrations**:
+   - Create `.manifest.json` if missing (for pre-manifest blueprints)
+   - Add `project` section to manifest
+   - Add `structure.has_modular_rules` field
+   - Add `structure.claude_md_mode` field
+   - Add `generated_artifacts.rules` array
+   - Create `.claude/rules/` directory structure (optional)
+
+   **Pre-1.0.0 → v1.1.0 migrations** (legacy detection):
+   - Detect if `.claude/blueprints/` exists without manifest
+   - Create manifest from detected structure
+   - Preserve existing content
+
+5. **Offer modular rules migration** (use AskUserQuestion):
+   ```
+   question: "Would you like to enable modular rules?"
+   options:
+     - "Yes, create .claude/rules/ structure" → create rules dir
+     - "Yes, and migrate sections from CLAUDE.md" → extract and migrate
+     - "No, keep current setup" → skip
+   ```
+
+6. **If migrating from CLAUDE.md**:
+   - Parse existing CLAUDE.md for major sections
+   - Offer to split into modular rules:
+     - Development workflow → `rules/development.md`
+     - Testing requirements → `rules/testing.md`
+     - Code style → `rules/code-style.md`
+     - Architecture patterns → `rules/architecture.md`
+   - Keep CLAUDE.md as overview, reference rules/
+
+7. **Update manifest**:
+   ```json
+   {
+     "format_version": "1.1.0",
+     "created_at": "[preserved]",
+     "updated_at": "[now]",
+     "upgraded_from": "{previous_version}",
+     "created_by": {
+       "blueprint_plugin": "1.0.0"
+     },
+     "project": {
+       "name": "[detected or asked]",
+       "type": "[detected or asked]"
+     },
+     "structure": {
+       "has_prds": true,
+       "has_work_orders": true,
+       "has_ai_docs": "[detected]",
+       "has_templates": "[detected]",
+       "has_modular_rules": "[user choice]",
+       "claude_md_mode": "[user choice]"
+     },
+     "generated_artifacts": {
+       "commands": "[detected]",
+       "skills": "[detected]",
+       "rules": "[created]"
+     },
+     "upgrade_history": [
+       {
+         "from": "{previous}",
+         "to": "1.1.0",
+         "date": "[now]",
+         "changes": ["list of applied changes"]
+       }
+     ]
+   }
+   ```
+
+8. **Report**:
+   ```
+   ✅ Blueprint upgraded successfully!
+
+   v{previous} → v1.1.0
+
+   Changes applied:
+   - {list of changes}
+
+   New features available:
+   - Version tracking via .manifest.json
+   - Modular rules support (.claude/rules/)
+   - CLAUDE.md management commands
+
+   Run `/blueprint-status` to see current configuration.
+   ```
+
+**Rollback**:
+If upgrade fails:
+- Restore from backup (if created)
+- Report what went wrong
+- Suggest manual fixes
+
+**Version Compatibility Matrix**:
+| From Version | To Version | Migrations |
+|--------------|------------|------------|
+| (none)       | 1.1.0      | Full init with manifest |
+| 1.0.0        | 1.1.0      | Add manifest fields, optional rules migration |
+| 1.1.0        | 1.1.0      | Already up to date |

--- a/project-plugin/.claude-plugin/plugin.json
+++ b/project-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,11 @@
 {
   "name": "project-plugin",
-  "version": "1.0.0",
-  "description": "Project initialization and management - setup, modernization",
-  "keywords": ["project", "initialization", "setup", "modernization"]
+  "version": "1.1.0",
+  "description": "Project initialization and management - setup, modernization, and continuous development workflows",
+  "author": {
+    "name": "Lauri Gates"
+  },
+  "repository": "https://github.com/laurigates/claude-plugins",
+  "license": "MIT",
+  "keywords": ["project", "initialization", "setup", "modernization", "tdd", "workflow"]
 }

--- a/project-plugin/README.md
+++ b/project-plugin/README.md
@@ -68,7 +68,7 @@ Systematically modernize applications to current standards and best practices.
 ### `/project:modernize-exp`
 Experimental version of modernize with latest tooling recommendations. Same features as `/project:modernize` but may include bleeding-edge practices.
 
-### `/project-continue`
+### `/project:continue`
 Analyze project state and continue development where you left off.
 
 **Features:**
@@ -81,12 +81,12 @@ Analyze project state and continue development where you left off.
 
 **Usage:**
 ```bash
-/project-continue
+/project:continue
 ```
 
-**Note:** Generic template that should be customized per project using `/blueprint:generate-commands`.
+**Note:** Generic template that should be customized per project using `/blueprint-generate-commands`. Project-specific version is generated to `.claude/commands/project/continue.md`.
 
-### `/project-test-loop`
+### `/project:test-loop`
 Run automated TDD cycle: test → fix → refactor.
 
 **Features:**
@@ -98,10 +98,10 @@ Run automated TDD cycle: test → fix → refactor.
 
 **Usage:**
 ```bash
-/project-test-loop
+/project:test-loop
 ```
 
-**Note:** Generic template that should be customized per project using `/blueprint:generate-commands`.
+**Note:** Generic template that should be customized per project using `/blueprint-generate-commands`. Project-specific version is generated to `.claude/commands/project/test-loop.md`.
 
 ## Skills
 
@@ -189,8 +189,8 @@ Follow strict RED → GREEN → REFACTOR workflow:
 ## Integration
 
 ### With Blueprint Plugin
-- `/blueprint:generate-commands` - Creates project-specific versions of generic commands
-- `/blueprint:work-order` - Create work orders before starting features
+- `/blueprint-generate-commands` - Creates project-specific versions of generic commands
+- `/blueprint-work-order` - Create work orders before starting features
 
 ### With Git Plugin
 - `/git:smartcommit` - Conventional commits integration

--- a/project-plugin/commands/project/continue.md
+++ b/project-plugin/commands/project/continue.md
@@ -5,7 +5,7 @@ allowed_tools: [Read, Bash, Grep, Glob, Edit, Write]
 
 Continue project development by analyzing current state and resuming work.
 
-**Note**: This is a generic template. Run `/blueprint:generate-commands` to create a project-specific version.
+**Note**: This is a generic template. Run `/blueprint-generate-commands` to create a project-specific version in `.claude/commands/project/continue.md`.
 
 **Steps**:
 
@@ -98,7 +98,7 @@ Continue project development by analyzing current state and resuming work.
 **Handling Common Scenarios**:
 
 **Scenario: Starting new feature**:
-1. Create work-order first with `/blueprint:work-order`
+1. Create work-order first with `/blueprint-work-order`
 2. Then continue with this command
 
 **Scenario: Blocked by dependency**:

--- a/project-plugin/commands/project/test-loop.md
+++ b/project-plugin/commands/project/test-loop.md
@@ -5,7 +5,7 @@ allowed_tools: [Read, Edit, Bash]
 
 Run automated TDD cycle: test → fix → refactor.
 
-**Note**: This is a generic template. Run `/blueprint:generate-commands` to create a project-specific version with correct test commands.
+**Note**: This is a generic template. Run `/blueprint-generate-commands` to create a project-specific version in `.claude/commands/project/test-loop.md`.
 
 **Steps**:
 


### PR DESCRIPTION
This release introduces comprehensive blueprint version tracking and new management capabilities:

## New Features

### Version Tracking (.manifest.json)
- Tracks blueprint format version (now v1.1.0)
- Records creation/update timestamps
- Stores project configuration (type, rules mode)
- Lists generated artifacts (commands, skills, rules)
- Supports upgrade path detection

### New Commands
- `/blueprint-status` - Display version, configuration, and upgrade availability
- `/blueprint-upgrade` - Upgrade blueprint structure to latest format
- `/blueprint-rules` - Manage modular rules in .claude/rules/
- `/blueprint-claude-md` - Generate/update CLAUDE.md from project context

### Modular Rules Integration
- Support for .claude/rules/ directory structure
- Path-scoped rules with YAML frontmatter
- Sync between CLAUDE.md and modular rules
- Auto-generation from PRDs

### Interactive Workflows
- Uses AskUserQuestion for guided initialization
- Project type selection (personal/team/opensource)
- Rules mode selection (single/modular/both)

## Breaking Changes

### Command Consolidation
- Moved `/project-continue` → `/project:continue` (namespaced)
- Moved `/project-test-loop` → `/project:test-loop` (namespaced)
- Generated commands now use namespaced pattern in .claude/commands/project/

## Version Bumps
- blueprint-plugin: 1.0.0 → 1.1.0
- project-plugin: 1.0.0 → 1.1.0