### PR TITLE
Add configure command for README generation

### DIFF
--- a/configure-plugin/commands/configure/readme.md
+++ b/configure-plugin/commands/configure/readme.md
@@ -1,0 +1,428 @@
+---
+description: Check and configure README.md with logo, badges, features, tech stack, and project structure
+allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch
+argument-hint: "[--check-only] [--fix] [--style <minimal|standard|detailed>] [--badges <shields|custom>]"
+---
+
+## Context
+
+- Project root: !`pwd`
+- Project name: !`basename $(pwd)`
+- README exists: !`ls -la README.md 2>/dev/null || echo "Not found"`
+- Package files: !`ls -la package.json pyproject.toml Cargo.toml go.mod 2>/dev/null || echo "None found"`
+- Git remote: !`git remote get-url origin 2>/dev/null || echo "No remote"`
+- License file: !`ls -la LICENSE* 2>/dev/null || echo "None found"`
+- Assets directory: !`ls -d assets/ public/ images/ docs/assets/ 2>/dev/null || echo "None found"`
+- Logo files: !`ls assets/logo* assets/icon* public/logo* images/logo* 2>/dev/null || echo "None found"`
+
+## Parameters
+
+Parse from command arguments:
+
+- `--check-only`: Report README compliance status without modifications (CI/CD mode)
+- `--fix`: Apply fixes automatically without prompting
+- `--style <minimal|standard|detailed>`: README detail level (default: standard)
+- `--badges <shields|custom>`: Badge style preference (default: shields)
+- `--no-logo`: Skip logo section even if assets exist
+
+**Style Levels:**
+- `minimal`: Title, description, badges, basic install/usage
+- `standard`: Logo, badges, features, tech stack, getting started, license (recommended)
+- `detailed`: All of standard plus: architecture diagram, API reference, contributing guide, changelog link
+
+## Your Task
+
+Generate a professional README.md following the FVH standards, with proper branding, badges, and documentation structure inspired by best practices.
+
+### Phase 1: Project Detection
+
+Detect project metadata from multiple sources:
+
+**From package.json (JavaScript/TypeScript):**
+```javascript
+{
+  "name": "project-name",
+  "description": "Project description",
+  "version": "1.0.0",
+  "license": "MIT",
+  "repository": { "url": "github:owner/repo" },
+  "keywords": ["keyword1", "keyword2"]
+}
+```
+
+**From pyproject.toml (Python):**
+```toml
+[project]
+name = "project-name"
+description = "Project description"
+version = "1.0.0"
+license = "MIT"
+keywords = ["keyword1", "keyword2"]
+
+[project.urls]
+Repository = "https://github.com/owner/repo"
+```
+
+**From Cargo.toml (Rust):**
+```toml
+[package]
+name = "project-name"
+description = "Project description"
+version = "1.0.0"
+license = "MIT"
+repository = "https://github.com/owner/repo"
+keywords = ["keyword1", "keyword2"]
+```
+
+**From go.mod (Go):**
+```
+module github.com/owner/repo
+```
+
+**Fallback detection:**
+- Project name: directory name
+- Description: first line of existing README or ask user
+- Repository: git remote URL
+- License: LICENSE file content
+
+### Phase 2: Current State Analysis
+
+Check existing README.md for:
+
+- [ ] Logo/icon present (centered image at top)
+- [ ] Project title (h1)
+- [ ] Description/tagline
+- [ ] Badges row (license, version, CI status, coverage)
+- [ ] Features section
+- [ ] Tech Stack section
+- [ ] Prerequisites section
+- [ ] Installation instructions
+- [ ] Usage examples
+- [ ] Project structure
+- [ ] Contributing guidelines
+- [ ] License section
+
+**Asset Discovery:**
+Check for logo/icon files in common locations:
+- `assets/logo.png`, `assets/icon.png`, `assets/logo.svg`
+- `public/logo.png`, `public/icon.svg`
+- `images/logo.png`, `docs/assets/logo.png`
+- `.github/logo.png`, `.github/images/logo.png`
+
+### Phase 3: Compliance Report
+
+Generate formatted compliance report:
+
+```
+README.md Compliance Report
+===========================
+Project: [name]
+Style Level: [minimal|standard|detailed]
+
+Structure:
+  Logo/Icon              [✅ PASS | ❌ MISSING | ⏭️ N/A (no assets)]
+  Title                  [✅ PASS | ❌ MISSING]
+  Description            [✅ PASS | ❌ MISSING | ⚠️ TOO SHORT]
+  Badges                 [✅ PASS | ⚠️ PARTIAL | ❌ MISSING]
+  Features               [✅ PASS | ❌ MISSING]
+  Tech Stack             [✅ PASS | ❌ MISSING]
+  Getting Started        [✅ PASS | ⚠️ INCOMPLETE | ❌ MISSING]
+  Project Structure      [✅ PASS | ❌ MISSING | ⏭️ N/A (small project)]
+  License                [✅ PASS | ❌ MISSING]
+
+Content Quality:
+  Has code examples      [✅ YES | ❌ NO]
+  Commands are correct   [✅ YES | ⚠️ OUTDATED]
+  Links are valid        [✅ YES | ⚠️ BROKEN LINKS]
+
+Overall: [X issues found]
+```
+
+### Phase 4: Configuration (if --fix or user confirms)
+
+#### README.md Template (Standard Style)
+
+Generate README following this structure:
+
+```markdown
+<div align="center">
+
+<img src="assets/logo.png" alt="PROJECT_NAME Logo" width="128" height="128">
+
+# PROJECT_NAME
+
+**TAGLINE_DESCRIPTION**
+
+[![License](https://img.shields.io/github/license/OWNER/REPO)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/OWNER/REPO)](https://github.com/OWNER/REPO/stargazers)
+[![CI](https://img.shields.io/github/actions/workflow/status/OWNER/REPO/ci.yml?branch=main&label=CI)](https://github.com/OWNER/REPO/actions)
+[![RUNTIME_BADGE](RUNTIME_BADGE_URL)]()
+
+</div>
+
+## Features
+
+- **Feature 1** - Description of the first key feature
+- **Feature 2** - Description of the second key feature
+- **Feature 3** - Description of the third key feature
+- **Feature 4** - Description of the fourth key feature
+
+## Tech Stack
+
+| Category | Technology |
+|----------|------------|
+| Runtime | Node.js / Bun / Python / Rust |
+| Framework | Express / Fastify / FastAPI / Axum |
+| Database | PostgreSQL / SQLite / MongoDB |
+| Testing | Vitest / pytest / cargo-nextest |
+
+## Getting Started
+
+### Prerequisites
+
+- [Prerequisite 1](link) >= version
+- [Prerequisite 2](link) >= version
+
+### Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/OWNER/REPO.git
+cd REPO
+
+# Install dependencies
+INSTALL_COMMAND
+
+# Run the application
+RUN_COMMAND
+```
+
+### Usage
+
+```bash
+# Example command
+EXAMPLE_COMMAND
+```
+
+## Project Structure
+
+```
+PROJECT_NAME/
+├── src/               # Source code
+│   ├── components/    # UI components (if applicable)
+│   └── services/      # Business logic
+├── tests/             # Test files
+├── docs/              # Documentation
+└── README.md
+```
+
+## Development
+
+```bash
+# Run tests
+TEST_COMMAND
+
+# Run linter
+LINT_COMMAND
+
+# Build for production
+BUILD_COMMAND
+```
+
+## Contributing
+
+Contributions are welcome! Please read our [Contributing Guidelines](CONTRIBUTING.md) before submitting a PR.
+
+## License
+
+This project is licensed under the [LICENSE_TYPE](LICENSE) license.
+```
+
+#### Badge Generation
+
+**Standard Shields.io badges:**
+
+| Badge Type | URL Pattern |
+|------------|-------------|
+| License | `https://img.shields.io/github/license/OWNER/REPO` |
+| Stars | `https://img.shields.io/github/stars/OWNER/REPO` |
+| Forks | `https://img.shields.io/github/forks/OWNER/REPO` |
+| Issues | `https://img.shields.io/github/issues/OWNER/REPO` |
+| CI Status | `https://img.shields.io/github/actions/workflow/status/OWNER/REPO/WORKFLOW.yml` |
+| Version | `https://img.shields.io/github/v/release/OWNER/REPO` |
+| npm | `https://img.shields.io/npm/v/PACKAGE` |
+| PyPI | `https://img.shields.io/pypi/v/PACKAGE` |
+| Crates.io | `https://img.shields.io/crates/v/PACKAGE` |
+
+**Runtime/Tech badges:**
+
+| Technology | Badge URL |
+|------------|-----------|
+| Bun | `https://img.shields.io/badge/runtime-Bun-f9f1e1` |
+| Node.js | `https://img.shields.io/badge/node-%3E%3D20-brightgreen` |
+| TypeScript | `https://img.shields.io/badge/TypeScript-5.x-blue` |
+| Python | `https://img.shields.io/badge/python-3.12-blue` |
+| Rust | `https://img.shields.io/badge/rust-1.75+-orange` |
+| Go | `https://img.shields.io/badge/go-1.22-00ADD8` |
+
+### Phase 5: Logo/Asset Handling
+
+If no logo exists but user wants one:
+
+1. **Check for existing assets** in standard locations
+2. **Suggest creating** a simple text-based logo or using a placeholder
+3. **Create assets directory** if needed: `mkdir -p assets`
+
+**Placeholder logo suggestion:**
+```markdown
+<div align="center">
+<h1>🚀 PROJECT_NAME</h1>
+</div>
+```
+
+Or suggest tools:
+- [Shields.io](https://shields.io) for custom badges
+- [Simple Icons](https://simpleicons.org) for technology icons
+- AI image generators for custom logos
+
+### Phase 6: Command Detection
+
+Auto-detect project commands based on package manager/build tool:
+
+**JavaScript/TypeScript (package.json):**
+```json
+{
+  "scripts": {
+    "dev": "...",      -> Development command
+    "build": "...",    -> Build command
+    "test": "...",     -> Test command
+    "lint": "..."      -> Lint command
+  }
+}
+```
+
+**Python (pyproject.toml with uv/poetry):**
+- Install: `uv sync` or `poetry install`
+- Run: `uv run python -m package` or `poetry run python -m package`
+- Test: `uv run pytest` or `poetry run pytest`
+
+**Rust (Cargo.toml):**
+- Build: `cargo build`
+- Run: `cargo run`
+- Test: `cargo test`
+
+**Go (go.mod):**
+- Build: `go build`
+- Run: `go run .`
+- Test: `go test ./...`
+
+### Phase 7: Project Structure Generation
+
+Generate accurate project structure based on actual directory layout:
+
+```bash
+# Use tree or find to generate structure
+tree -L 2 -I 'node_modules|target|__pycache__|.git|dist|build' --dirsfirst
+```
+
+Include only relevant directories, skip:
+- `node_modules/`, `vendor/`
+- `target/`, `dist/`, `build/`
+- `__pycache__/`, `.pytest_cache/`
+- `.git/`, `.venv/`, `venv/`
+
+### Phase 8: Standards Tracking
+
+Update `.fvh-standards.yaml`:
+
+```yaml
+standards_version: "2025.1"
+project_type: "[detected]"
+last_configured: "[timestamp]"
+components:
+  readme: "2025.1"
+  readme_style: "[minimal|standard|detailed]"
+  readme_has_logo: true|false
+  readme_badges: ["license", "stars", "ci", "version"]
+```
+
+### Phase 9: Validation
+
+After generating README, validate:
+
+1. **Markdown lint** - Check for syntax errors
+2. **Link validation** - Verify all links are accessible (warn only)
+3. **Badge URLs** - Ensure shields.io URLs are correctly formatted
+4. **Image paths** - Verify logo/image paths exist
+
+### Phase 10: Updated Compliance Report
+
+```
+README.md Compliance Report (After Configuration)
+=================================================
+Project: [name]
+Style Level: [minimal|standard|detailed]
+
+Changes Made:
+  ✅ Added centered logo section
+  ✅ Generated badge row (license, stars, CI)
+  ✅ Created Features section with 4 highlights
+  ✅ Added Tech Stack table
+  ✅ Generated Getting Started with correct commands
+  ✅ Created Project Structure from actual layout
+  ✅ Added License section
+
+README Location: ./README.md
+Preview: Open in VS Code or view on GitHub
+
+Next Steps:
+  - Review and customize feature descriptions
+  - Add a logo image to assets/ (optional)
+  - Run `/configure:github-pages` to publish documentation
+  - Consider adding CONTRIBUTING.md and CHANGELOG.md
+```
+
+## Detailed Style Additions
+
+When `--style detailed` is specified, also include:
+
+### Architecture Section
+```markdown
+## Architecture
+
+```mermaid
+graph TD
+    A[Client] --> B[API Gateway]
+    B --> C[Service Layer]
+    C --> D[Database]
+```
+```
+
+### API Reference Link
+```markdown
+## API Reference
+
+See the [API Documentation](docs/api.md) for detailed endpoint information.
+```
+
+### Changelog Link
+```markdown
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for version history.
+```
+
+## Output
+
+Provide:
+1. Compliance report with section-by-section status
+2. Generated or updated README.md content
+3. List of detected project metadata
+4. Suggestions for improvement (logo, more features, etc.)
+
+## See Also
+
+- `/configure:docs` - Configure code documentation standards
+- `/configure:github-pages` - Set up documentation hosting
+- `/configure:all` - Run all compliance checks
+- **fvh-readme** skill for README templates and examples

--- a/configure-plugin/skills/fvh-readme/SKILL.md
+++ b/configure-plugin/skills/fvh-readme/SKILL.md
@@ -1,0 +1,455 @@
+# FVH README Standards (v2025.1)
+
+This skill provides README.md templates and standards for FVH projects.
+
+## Overview
+
+A well-structured README is the front door to your project. It should:
+- Immediately communicate what the project does
+- Look professional with proper branding
+- Provide clear getting started instructions
+- Be scannable with good visual hierarchy
+
+## Template Styles
+
+### Minimal Style
+
+Best for: Libraries, small utilities, internal tools
+
+```markdown
+# project-name
+
+[![License](https://img.shields.io/github/license/OWNER/REPO)](LICENSE)
+
+Brief description of what this project does.
+
+## Installation
+
+```bash
+npm install package-name
+```
+
+## Usage
+
+```javascript
+import { feature } from 'package-name';
+feature();
+```
+
+## License
+
+MIT
+```
+
+### Standard Style (Recommended)
+
+Best for: Most projects, applications, services
+
+```markdown
+<div align="center">
+
+<img src="assets/logo.png" alt="Project Logo" width="128">
+
+# Project Name
+
+**A compelling tagline that explains the project's purpose**
+
+[![License](https://img.shields.io/github/license/OWNER/REPO)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/OWNER/REPO)](https://github.com/OWNER/REPO/stargazers)
+[![CI](https://img.shields.io/github/actions/workflow/status/OWNER/REPO/ci.yml?branch=main)](https://github.com/OWNER/REPO/actions)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue)]()
+
+</div>
+
+## Features
+
+- **Feature One** - Description of the first key capability
+- **Feature Two** - Description of the second key capability
+- **Feature Three** - Description of the third key capability
+- **Feature Four** - Description of the fourth key capability
+
+## Tech Stack
+
+| Category | Technology |
+|----------|------------|
+| Runtime | Bun 1.x |
+| Framework | Fastify |
+| Frontend | React 18, Vite |
+| Database | SQLite (Drizzle ORM) |
+| Testing | Vitest, Playwright |
+
+## Getting Started
+
+### Prerequisites
+
+- [Bun](https://bun.sh) >= 1.0
+- [Node.js](https://nodejs.org) >= 20 (optional)
+
+### Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/OWNER/REPO.git
+cd REPO
+
+# Install dependencies
+bun install
+
+# Start development server
+bun run dev
+```
+
+### Development Commands
+
+```bash
+bun run dev      # Start development server
+bun run build    # Build for production
+bun run test     # Run tests
+bun run lint     # Run linter
+```
+
+## Project Structure
+
+```
+project-name/
+├── src/
+│   ├── client/          # Frontend React application
+│   │   ├── components/  # UI components
+│   │   └── stores/      # State management
+│   ├── server/          # Backend Fastify server
+│   │   ├── routes/      # API endpoints
+│   │   └── services/    # Business logic
+│   └── shared/          # Shared types and utilities
+├── tests/               # Test files
+├── docs/                # Documentation
+└── README.md
+```
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).
+```
+
+### Detailed Style
+
+Best for: Open source projects, documentation-heavy projects, developer tools
+
+Includes everything from Standard plus:
+- Architecture diagrams (Mermaid)
+- API reference section
+- Detailed configuration options
+- Changelog link
+- Security policy
+- Code of conduct reference
+
+## Badge Reference
+
+### Repository Status Badges
+
+```markdown
+<!-- License -->
+[![License](https://img.shields.io/github/license/OWNER/REPO)](LICENSE)
+
+<!-- Stars -->
+[![Stars](https://img.shields.io/github/stars/OWNER/REPO)](https://github.com/OWNER/REPO/stargazers)
+
+<!-- Forks -->
+[![Forks](https://img.shields.io/github/forks/OWNER/REPO)](https://github.com/OWNER/REPO/network/members)
+
+<!-- Issues -->
+[![Issues](https://img.shields.io/github/issues/OWNER/REPO)](https://github.com/OWNER/REPO/issues)
+
+<!-- Last Commit -->
+[![Last Commit](https://img.shields.io/github/last-commit/OWNER/REPO)](https://github.com/OWNER/REPO/commits)
+```
+
+### CI/CD Status Badges
+
+```markdown
+<!-- GitHub Actions -->
+[![CI](https://img.shields.io/github/actions/workflow/status/OWNER/REPO/ci.yml?branch=main&label=CI)](https://github.com/OWNER/REPO/actions)
+
+<!-- With specific workflow -->
+[![Build](https://img.shields.io/github/actions/workflow/status/OWNER/REPO/build.yml?branch=main&label=build)](https://github.com/OWNER/REPO/actions/workflows/build.yml)
+
+<!-- Codecov -->
+[![codecov](https://codecov.io/gh/OWNER/REPO/branch/main/graph/badge.svg)](https://codecov.io/gh/OWNER/REPO)
+```
+
+### Package Registry Badges
+
+```markdown
+<!-- npm -->
+[![npm](https://img.shields.io/npm/v/PACKAGE)](https://www.npmjs.com/package/PACKAGE)
+[![npm downloads](https://img.shields.io/npm/dm/PACKAGE)](https://www.npmjs.com/package/PACKAGE)
+
+<!-- PyPI -->
+[![PyPI](https://img.shields.io/pypi/v/PACKAGE)](https://pypi.org/project/PACKAGE/)
+[![Python Version](https://img.shields.io/pypi/pyversions/PACKAGE)](https://pypi.org/project/PACKAGE/)
+
+<!-- Crates.io -->
+[![Crates.io](https://img.shields.io/crates/v/PACKAGE)](https://crates.io/crates/PACKAGE)
+[![docs.rs](https://docs.rs/PACKAGE/badge.svg)](https://docs.rs/PACKAGE)
+
+<!-- Go -->
+[![Go Reference](https://pkg.go.dev/badge/github.com/OWNER/REPO.svg)](https://pkg.go.dev/github.com/OWNER/REPO)
+```
+
+### Technology Badges
+
+```markdown
+<!-- Runtime/Language -->
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white)]()
+[![Python](https://img.shields.io/badge/Python-3.12-3776AB?logo=python&logoColor=white)]()
+[![Rust](https://img.shields.io/badge/Rust-1.75+-DEA584?logo=rust&logoColor=white)]()
+[![Go](https://img.shields.io/badge/Go-1.22-00ADD8?logo=go&logoColor=white)]()
+
+<!-- Runtime -->
+[![Bun](https://img.shields.io/badge/Bun-1.x-f9f1e1?logo=bun&logoColor=black)]()
+[![Node.js](https://img.shields.io/badge/Node.js-20+-339933?logo=node.js&logoColor=white)]()
+[![Deno](https://img.shields.io/badge/Deno-1.x-000000?logo=deno&logoColor=white)]()
+
+<!-- Frameworks -->
+[![React](https://img.shields.io/badge/React-18-61DAFB?logo=react&logoColor=black)]()
+[![Vue](https://img.shields.io/badge/Vue-3-4FC08D?logo=vue.js&logoColor=white)]()
+[![Fastify](https://img.shields.io/badge/Fastify-4-000000?logo=fastify&logoColor=white)]()
+[![FastAPI](https://img.shields.io/badge/FastAPI-0.100+-009688?logo=fastapi&logoColor=white)]()
+```
+
+## Logo Guidelines
+
+### Recommended Specifications
+
+- **Format**: PNG (with transparency) or SVG
+- **Size**: 128x128px to 512x512px
+- **Location**: `assets/logo.png` or `assets/icon.svg`
+
+### Centering Logo
+
+```markdown
+<div align="center">
+<img src="assets/logo.png" alt="Project Name" width="128">
+</div>
+```
+
+### Using Emoji as Placeholder
+
+If no logo exists:
+
+```markdown
+<div align="center">
+
+# 🚀 Project Name
+
+</div>
+```
+
+Common project type emojis:
+- 🚀 - General/deployment tools
+- 🛠️ - Developer tools
+- 📊 - Data/analytics
+- 🔒 - Security
+- 🌐 - Web applications
+- 📱 - Mobile apps
+- 🤖 - AI/ML projects
+- 📦 - Package/library
+
+## Section Guidelines
+
+### Features Section
+
+Write features as benefits, not just capabilities:
+
+**Good:**
+```markdown
+- **Automatic Scanner Detection** - Discovers eSCL-compatible scanners via mDNS without manual configuration
+- **Smart Photo Separation** - Intelligently detects and crops multiple photos from a single scan using edge analysis
+```
+
+**Avoid:**
+```markdown
+- Uses mDNS for scanner discovery
+- Has edge detection algorithm
+```
+
+### Tech Stack Section
+
+Use a table for clarity:
+
+```markdown
+| Category | Technology |
+|----------|------------|
+| Runtime | Bun 1.x |
+| Server | Fastify 4 |
+| Frontend | React 18, Tailwind CSS |
+| Database | SQLite (Drizzle ORM) |
+```
+
+### Getting Started Section
+
+Always include:
+1. Prerequisites with version requirements
+2. Clone instructions
+3. Install dependencies command
+4. Run command
+5. (Optional) Environment setup
+
+### Project Structure Section
+
+- Keep it to 2-3 levels deep
+- Only show meaningful directories
+- Add brief comments for non-obvious folders
+
+```
+project/
+├── src/           # Source code
+├── tests/         # Test files
+├── docs/          # Documentation
+└── scripts/       # Build/dev scripts
+```
+
+## Project Type Specific Templates
+
+### CLI Tool
+
+```markdown
+## Installation
+
+```bash
+# With npm
+npm install -g tool-name
+
+# With Bun
+bun install -g tool-name
+
+# Or run directly
+npx tool-name
+```
+
+## Usage
+
+```bash
+tool-name <command> [options]
+
+Commands:
+  init     Initialize a new project
+  build    Build the project
+  deploy   Deploy to production
+
+Options:
+  -h, --help     Show help
+  -v, --version  Show version
+```
+```
+
+### Library/Package
+
+```markdown
+## Installation
+
+```bash
+npm install package-name
+# or
+bun add package-name
+```
+
+## Usage
+
+```typescript
+import { feature } from 'package-name';
+
+const result = feature({
+  option: 'value'
+});
+```
+
+## API
+
+### `feature(options)`
+
+Description of the function.
+
+**Parameters:**
+- `options.key` (string) - Description
+
+**Returns:** `ReturnType` - Description
+```
+
+### Web Application
+
+```markdown
+## Demo
+
+🌐 [Live Demo](https://demo.example.com)
+
+## Screenshots
+
+<div align="center">
+<img src="docs/screenshots/dashboard.png" alt="Dashboard" width="600">
+</div>
+
+## Environment Variables
+
+Create a `.env` file:
+
+```env
+DATABASE_URL=postgresql://...
+API_KEY=your-api-key
+```
+```
+
+## Compliance Checklist
+
+### Minimal Style
+- [ ] Title (h1)
+- [ ] Description (1-2 sentences)
+- [ ] License badge
+- [ ] Installation instructions
+- [ ] Basic usage example
+- [ ] License section
+
+### Standard Style (all of minimal plus)
+- [ ] Logo or emoji header
+- [ ] 3+ badges (license, stars, CI)
+- [ ] Features section (4+ items)
+- [ ] Tech stack table
+- [ ] Prerequisites
+- [ ] Development commands
+- [ ] Project structure
+- [ ] Contributing mention
+
+### Detailed Style (all of standard plus)
+- [ ] Architecture diagram
+- [ ] API reference or link
+- [ ] Configuration options
+- [ ] Changelog link
+- [ ] Security policy mention
+- [ ] Code of conduct mention
+
+## Cookiecutter Integration
+
+For creating entire new projects from templates, consider using [cookiecutter](https://cookiecutter.readthedocs.io/):
+
+```bash
+# Install cookiecutter
+pip install cookiecutter
+# or
+uv tool install cookiecutter
+
+# Create project from template
+cookiecutter https://github.com/your-org/project-template
+```
+
+Cookiecutter is ideal for:
+- Creating multiple projects with consistent structure
+- Organization-wide project templates
+- Including not just README but entire project scaffolding
+
+The `/configure:readme` command is better for:
+- Updating existing projects
+- Generating README for projects that already have code
+- Compliance checking of existing READMEs


### PR DESCRIPTION
Add /configure:readme command for generating professional README.md files with logos, badges, features, tech stack, and project structure sections.

Includes:
- Three style levels: minimal, standard, detailed
- Auto-detection of project metadata from package files
- Shields.io badge generation
- Project structure generation from actual layout
- FVH README skill with templates and badge reference