### PR TITLE
Reverse engineer ADR documents for reference

### DIFF
--- a/docs/adr/0001-plugin-based-architecture.md
+++ b/docs/adr/0001-plugin-based-architecture.md
@@ -1,0 +1,99 @@
+# ADR-0001: Plugin-Based Architecture
+
+## Status
+
+Accepted
+
+## Date
+
+2024-12 (retroactively documented 2025-12)
+
+## Context
+
+Claude Code configurations (commands, skills, agents) were originally maintained within the [laurigates/dotfiles](https://github.com/laurigates/dotfiles) repository, managed by Chezmoi. As the collection grew to 103+ skills, 76 commands, and 22 agents, several problems emerged:
+
+1. **Monolithic coupling**: All configurations lived in a single `exact_dot_claude/` directory, making it difficult to share subsets of functionality
+2. **Personal-only distribution**: Dotfiles repositories are inherently personal; sharing required copying entire directory structures
+3. **No selective installation**: Users couldn't choose which capabilities they wanted without manual file management
+4. **Discovery challenges**: Finding relevant commands/skills within a massive configuration was increasingly difficult
+5. **Version coupling**: All configurations shared a single version, making independent updates impossible
+
+The Claude Code plugin specification introduced a modular approach where capabilities could be packaged as installable plugins with defined boundaries.
+
+## Decision
+
+Create a standalone repository (`claude-plugins`) organized as a **plugin marketplace** where:
+
+1. Each plugin is a self-contained directory with its own manifest, commands, skills, and agents
+2. Plugins are domain-scoped (language, infrastructure, methodology, etc.)
+3. A central `marketplace.json` provides discovery and installation metadata
+4. Plugins can be installed independently via `/plugin install`
+5. Configurations migrate from dotfiles to logical plugin groupings
+
+### Directory Structure
+
+```
+claude-plugins/
+├── marketplace.json              # Central registry
+├── blueprint-plugin/             # Methodology plugin
+│   ├── .claude-plugin/
+│   │   └── plugin.json          # Plugin manifest
+│   ├── commands/
+│   ├── skills/
+│   └── agents/
+├── python-plugin/                # Language plugin
+├── configure-plugin/             # Infrastructure plugin
+└── ...
+```
+
+## Consequences
+
+### Advantages
+
+- **Selective installation**: Users install only plugins relevant to their work
+- **Independent versioning**: Each plugin can evolve at its own pace
+- **Shareable**: The repository can be public; anyone can install plugins
+- **Discoverable**: Marketplace metadata enables browsing by category, keyword, or purpose
+- **Maintainable**: Domain experts can own specific plugins
+- **Composable**: Plugins can recommend companion plugins without hard dependencies
+
+### Disadvantages
+
+- **Migration overhead**: Existing configurations required reorganization and testing
+- **Potential duplication**: Some skills may logically belong to multiple domains
+- **Learning curve**: Users must understand plugin installation vs. global configuration
+- **Coordination**: Cross-plugin changes require more careful coordination
+
+### Migration Strategy
+
+1. Prioritize high-value, self-contained plugins (blueprint, configure, git, testing)
+2. Track migration status in `MIGRATION.md`
+3. Document companion relationships in plugin READMEs
+4. Deprecate dotfiles versions once plugins are stable
+
+## Alternatives Considered
+
+### 1. Monorepo with Shared CLAUDE.md
+
+Keep everything in dotfiles but with better organization via layered CLAUDE.md files.
+
+**Rejected**: Doesn't solve sharing or selective installation.
+
+### 2. Multiple Dotfiles Repositories
+
+Split into multiple dotfiles repositories (e.g., `claude-python-dotfiles`).
+
+**Rejected**: Chezmoi complexity; users would need multiple source directories.
+
+### 3. Git Submodules
+
+Use git submodules to include plugins in dotfiles.
+
+**Rejected**: Submodule management is notoriously difficult; doesn't provide clean installation UX.
+
+## Related Decisions
+
+- ADR-0002: Domain-Driven Plugin Organization
+- ADR-0003: Auto-Discovery Component Pattern
+- ADR-0004: Marketplace Registry Model
+- Dotfiles ADR-0007: Layered Knowledge Distribution (predecessor approach)

--- a/docs/adr/0002-domain-driven-plugin-organization.md
+++ b/docs/adr/0002-domain-driven-plugin-organization.md
@@ -1,0 +1,114 @@
+# ADR-0002: Domain-Driven Plugin Organization
+
+## Status
+
+Accepted
+
+## Date
+
+2024-12 (retroactively documented 2025-12)
+
+## Context
+
+With the decision to create a plugin-based architecture (ADR-0001), we needed a strategy for organizing 100+ skills, 76 commands, and 22 agents into coherent plugins. Several organizational approaches were considered:
+
+1. **Functional grouping**: By what they do (search, edit, test, deploy)
+2. **Workflow grouping**: By development phase (planning, coding, reviewing, deploying)
+3. **Technology grouping**: By specific tool (ruff, pytest, helm, docker)
+4. **Domain grouping**: By problem domain (language, infrastructure, methodology)
+
+The challenge was balancing granularity (too many small plugins = fragmentation) against comprehensiveness (too few large plugins = back to monolith).
+
+## Decision
+
+Organize plugins by **problem domain**, creating cohesive units that represent a developer's mental model of their work:
+
+### Domain Categories
+
+| Category | Plugins | Purpose |
+|----------|---------|---------|
+| **Language Ecosystems** | python, typescript, rust, bevy | Language-specific development tools |
+| **Development Methodology** | blueprint, project, agent-patterns | Structured development workflows |
+| **Quality & Testing** | testing, code-quality | Test execution and code analysis |
+| **Infrastructure** | configure, container, kubernetes, terraform, github-actions | DevOps and CI/CD |
+| **System Integration** | git, api, sync, communication | External system interaction |
+| **Utilities** | tools, documentation | Cross-cutting utilities |
+| **Specialized** | graphiti, accessibility, dotfiles | Domain-specific expertise |
+
+### Plugin Boundaries
+
+Each plugin should:
+
+1. **Own a coherent domain**: All Python development tools in `python-plugin`, not scattered
+2. **Be independently useful**: A user can install just `git-plugin` and get value
+3. **Have clear boundaries**: If unsure where something belongs, it probably needs its own plugin
+4. **Reference companions**: Document which plugins work well together (e.g., `testing-plugin` + `python-plugin`)
+
+### Example: Python Ecosystem
+
+Rather than separate plugins for `ruff-plugin`, `pytest-plugin`, `uv-plugin`:
+
+```
+python-plugin/
+├── skills/
+│   ├── python-development/
+│   ├── ruff-linting/
+│   ├── ruff-formatting/
+│   ├── pytest-advanced/
+│   ├── uv-project-management/
+│   └── basedpyright-type-checking/
+└── agents/
+    └── python-development.md
+```
+
+This mirrors how developers think: "I'm doing Python work" not "I'm doing ruff work then pytest work."
+
+## Consequences
+
+### Advantages
+
+- **Mental model alignment**: Plugin names match how developers describe their work
+- **Reduced fragmentation**: 23 plugins instead of 100+ micro-plugins
+- **Discoverability**: Category-based browsing in marketplace
+- **Cohesive updates**: Language ecosystem updates happen in one place
+- **Companion clarity**: Easy to say "install python-plugin + testing-plugin"
+
+### Disadvantages
+
+- **Larger plugins**: Some plugins (python, configure) have many components
+- **Cross-domain skills**: Some skills (e.g., `ast-grep`) could belong to multiple domains
+- **Subjective boundaries**: "Does API testing belong in testing-plugin or api-plugin?"
+
+### Cross-Domain Handling
+
+For skills that span domains:
+
+1. **Primary location**: Place in most natural domain
+2. **Documentation**: Reference in related plugin READMEs
+3. **Duplication if necessary**: Some skills may exist in multiple plugins with context-specific variations
+
+## Alternatives Considered
+
+### 1. Technology-Specific Plugins
+
+One plugin per tool (ruff-plugin, pytest-plugin, helm-plugin).
+
+**Rejected**: Too granular; users would need 10+ plugins for basic Python development.
+
+### 2. Workflow-Based Plugins
+
+Plugins for planning, coding, testing, deploying phases.
+
+**Rejected**: Crosses too many technologies; a "testing" plugin would include Python, TypeScript, Rust test tools.
+
+### 3. Single Language Plugin
+
+One `languages-plugin` containing all language ecosystems.
+
+**Rejected**: Too monolithic; Python and Rust developers have very different needs.
+
+## Related Decisions
+
+- ADR-0001: Plugin-Based Architecture
+- ADR-0003: Auto-Discovery Component Pattern
+- Dotfiles ADR-0004: Subagent-First Delegation Strategy (influences agent organization)

--- a/docs/adr/0003-auto-discovery-component-pattern.md
+++ b/docs/adr/0003-auto-discovery-component-pattern.md
@@ -1,0 +1,152 @@
+# ADR-0003: Auto-Discovery Component Pattern
+
+## Status
+
+Accepted
+
+## Date
+
+2024-12 (retroactively documented 2025-12)
+
+## Context
+
+Each Claude Code plugin contains multiple component types: commands, skills, and agents. We needed to decide how these components would be registered and discovered by Claude Code.
+
+Two primary approaches exist:
+
+1. **Explicit registration**: List all components in `plugin.json`
+2. **Convention-based discovery**: Place components in standard directories
+
+The original dotfiles approach used file system conventions, which proved effective for organizing 100+ skills.
+
+## Decision
+
+Use **convention-based auto-discovery** where Claude Code automatically finds components based on directory structure:
+
+### Directory Conventions
+
+```
+<plugin>/
+├── .claude-plugin/
+│   └── plugin.json          # Only manifest metadata (no component listings)
+├── commands/                 # Auto-discovered
+│   ├── commit.md            # → /commit
+│   └── configure/           # Subdirectory grouping
+│       ├── pre-commit.md    # → /configure:pre-commit
+│       └── tests.md         # → /configure:tests
+├── skills/                   # Auto-discovered
+│   └── skill-name/
+│       ├── SKILL.md         # Required: skill definition
+│       ├── reference.md     # Optional: supporting docs
+│       └── templates/       # Optional: templates
+├── agents/                   # Auto-discovered
+│   └── agent-name.md
+└── hooks/                    # Optional
+    └── hooks.json
+```
+
+### Discovery Rules
+
+| Component | Location | Registration |
+|-----------|----------|--------------|
+| Commands | `commands/*.md` | `/command-name` |
+| Grouped Commands | `commands/group/*.md` | `/group:command-name` |
+| Skills | `skills/*/SKILL.md` | Context-activated by description |
+| Agents | `agents/*.md` | Available via `/agents` or context |
+
+### plugin.json Role
+
+The manifest contains only metadata; it does **not** list components:
+
+```json
+{
+  "name": "git-plugin",
+  "version": "1.0.0",
+  "description": "Git workflows, commits, PRs, and repository management",
+  "keywords": ["git", "github", "commit", "pull-request"]
+}
+```
+
+## Consequences
+
+### Advantages
+
+- **Reduced boilerplate**: No need to maintain component lists
+- **Self-documenting structure**: File system shows what's available
+- **Easy additions**: Add a file, get a command (no manifest updates)
+- **Consistent organization**: All plugins use identical structure
+- **IDE support**: File explorers show the full component inventory
+- **Refactoring friendly**: Move/rename files without manifest sync issues
+
+### Disadvantages
+
+- **Implicit registration**: Components exist by convention, not declaration
+- **Discovery overhead**: Claude Code must scan directories at load time
+- **Strict conventions**: Files must follow exact naming patterns
+- **No conditional inclusion**: Can't easily disable a component without removing the file
+
+### Component Metadata
+
+Each component type has its own metadata format:
+
+**Commands** (YAML frontmatter):
+```yaml
+---
+description: "Create a git commit with conventional format"
+allowed-tools: [Bash, Read, Glob]
+argument-hint: "[--amend] [--scope SCOPE]"
+---
+```
+
+**Skills** (YAML frontmatter):
+```yaml
+---
+name: git-commit-workflow
+description: "When committing code. Conventional commits, co-authors."
+---
+```
+
+**Agents** (YAML frontmatter):
+```yaml
+---
+name: commit-review
+model: claude-sonnet-4
+color: "#4CAF50"
+description: "Review commits for quality and conventions"
+tools: Bash, Read, Grep
+---
+```
+
+## Alternatives Considered
+
+### 1. Explicit Component Lists
+
+List all components in `plugin.json`:
+
+```json
+{
+  "commands": ["commands/commit.md", "commands/issue.md"],
+  "skills": ["skills/git-commit-workflow"],
+  "agents": ["agents/commit-review.md"]
+}
+```
+
+**Rejected**: Maintenance burden; easy to forget adding new components.
+
+### 2. Mixed Approach
+
+Auto-discover by default but allow explicit overrides.
+
+**Rejected**: Complexity; unclear which takes precedence.
+
+### 3. Code-Based Registration
+
+Define components in JavaScript/TypeScript.
+
+**Rejected**: Against Claude Code's markdown-first philosophy; increases barrier to contribution.
+
+## Related Decisions
+
+- ADR-0001: Plugin-Based Architecture
+- ADR-0007: Namespace-Based Command Organization
+- Dotfiles ADR-0003: Skill Activation via Trigger Keywords

--- a/docs/adr/0004-marketplace-registry-model.md
+++ b/docs/adr/0004-marketplace-registry-model.md
@@ -1,0 +1,139 @@
+# ADR-0004: Marketplace Registry Model
+
+## Status
+
+Accepted
+
+## Date
+
+2024-12 (retroactively documented 2025-12)
+
+## Context
+
+With 23+ plugins in the repository, users need a way to:
+
+1. **Discover** available plugins by category, keyword, or purpose
+2. **Install** plugins without manually cloning repositories
+3. **Update** plugins when new versions are available
+4. **Browse** plugin metadata before installation
+
+The Claude Code `/plugin install` command supports various sources, including local paths and remote repositories. We needed a way to organize our plugins for easy discovery and installation.
+
+## Decision
+
+Create a **marketplace registry** via `marketplace.json` at the repository root:
+
+### Registry Structure
+
+```json
+{
+  "name": "lgates-claude-plugins",
+  "description": "Curated collection of Claude Code plugins",
+  "owner": {
+    "name": "Lauri Gates"
+  },
+  "homepage": "https://github.com/laurigates/claude-plugins",
+  "plugins": [
+    {
+      "name": "blueprint-plugin",
+      "source": "./blueprint-plugin",
+      "description": "PRD → PRP workflow for structured feature development",
+      "version": "1.1.0",
+      "category": "methodology",
+      "keywords": ["blueprint", "prd", "prp", "requirements"]
+    },
+    {
+      "name": "python-plugin",
+      "source": "./python-plugin",
+      "description": "Python ecosystem: uv, ruff, pytest, basedpyright",
+      "version": "1.0.0",
+      "category": "language",
+      "keywords": ["python", "uv", "ruff", "pytest"]
+    }
+  ]
+}
+```
+
+### Installation Patterns
+
+```bash
+# Install from marketplace
+/plugin install blueprint-plugin@lgates-claude-plugins
+
+# Install directly from GitHub
+/plugin install github:laurigates/claude-plugins/blueprint-plugin
+
+# Install locally (for development)
+/plugin install /path/to/claude-plugins/blueprint-plugin
+```
+
+### Category Taxonomy
+
+| Category | Description |
+|----------|-------------|
+| `language` | Language ecosystem tools |
+| `methodology` | Development workflows |
+| `testing` | Test execution and quality |
+| `infrastructure` | DevOps and CI/CD |
+| `integration` | External system connectivity |
+| `utility` | Cross-cutting tools |
+| `specialized` | Domain-specific expertise |
+
+## Consequences
+
+### Advantages
+
+- **Centralized discovery**: Single file lists all available plugins
+- **Rich metadata**: Version, category, keywords enable filtering
+- **Installation simplicity**: Short names instead of full paths
+- **Browsable**: Users can read `marketplace.json` or render it as documentation
+- **Scriptable**: Automation can parse JSON for bulk operations
+- **Version tracking**: Marketplace reflects current stable versions
+
+### Disadvantages
+
+- **Manual maintenance**: Must update `marketplace.json` when plugins change
+- **Single source**: All plugins in one repository (could split later)
+- **No dependency resolution**: Plugins can recommend but not require companions
+- **Version sync**: Plugin version in `plugin.json` must match `marketplace.json`
+
+### Marketplace vs Plugin Manifest
+
+| File | Purpose | Contains |
+|------|---------|----------|
+| `marketplace.json` | Discovery & installation | All plugins, categories, source paths |
+| `plugin.json` | Plugin identity | Single plugin metadata, keywords |
+
+The marketplace provides overview; individual manifests provide detail.
+
+## Alternatives Considered
+
+### 1. No Central Registry
+
+Users specify full paths or GitHub URLs for every installation.
+
+**Rejected**: Poor UX; requires knowing exact plugin locations.
+
+### 2. NPM/Package Registry
+
+Publish plugins to npm or a custom registry.
+
+**Rejected**: Overhead of publishing; plugins are markdown, not packages.
+
+### 3. GitHub Topics/Releases
+
+Use GitHub repository features for discovery.
+
+**Rejected**: Less structured; requires GitHub API calls for browsing.
+
+### 4. Multiple Marketplaces
+
+Separate registries for different plugin categories.
+
+**Rejected**: Fragmentation; users would need to know which marketplace.
+
+## Related Decisions
+
+- ADR-0001: Plugin-Based Architecture
+- ADR-0002: Domain-Driven Plugin Organization
+- ADR-0008: Semantic Versioning with Manifest

--- a/docs/adr/0005-blueprint-development-methodology.md
+++ b/docs/adr/0005-blueprint-development-methodology.md
@@ -1,0 +1,141 @@
+# ADR-0005: Blueprint Development Methodology
+
+## Status
+
+Accepted
+
+## Date
+
+2024-12 (retroactively documented 2025-12)
+
+## Context
+
+As Claude Code became central to development workflows, a recurring problem emerged: complex features were implemented without sufficient upfront planning, leading to:
+
+1. **Scope creep**: Features expanded beyond original intent
+2. **Inconsistent quality**: No standard for "done"
+3. **Poor documentation**: Implementation details lost
+4. **Unclear requirements**: Ambiguous success criteria
+5. **Difficult handoffs**: Context not preserved between sessions
+
+The `context7` MCP server investigation revealed that even Claude needed structured guidance—official documentation often contradicted assumptions, and best practices evolved faster than implementations.
+
+## Decision
+
+Adopt a **Blueprint Development Methodology** as the core workflow for significant features:
+
+### Three-Phase Workflow
+
+```
+PRD → PRP → Work Order
+```
+
+1. **PRD (Product Requirements Document)**: What we're building and why
+2. **PRP (Product Refinement Proposal)**: How we'll build it, with technical details
+3. **Work Order**: Executable tasks derived from PRP
+
+### Blueprint Plugin Components
+
+| Component | Type | Purpose |
+|-----------|------|---------|
+| `/blueprint-init` | Command | Initialize blueprint structure in project |
+| `/blueprint-generate-commands` | Command | Create project-specific commands from PRD |
+| `/blueprint-generate-skills` | Command | Create project-specific skills from PRP |
+| `/blueprint-work-order` | Command | Generate work order from PRP |
+| `/prp-create` | Command | Create new PRP from PRD |
+| `/prp-execute` | Command | Execute PRP with progress tracking |
+| `blueprint-development` | Skill | Methodology guidance and templates |
+| `confidence-scoring` | Skill | Confidence assessment framework |
+| `requirements-documentation` | Agent | PRD creation specialist |
+
+### Document Flow
+
+```
+blueprints/
+├── .manifest.json           # Version tracking, configuration
+├── PRD-feature-name.md      # Requirements document
+├── PRP-feature-name.md      # Technical proposal
+├── WO-feature-name.md       # Work order (generated)
+└── .claude/
+    └── commands/
+        └── project/         # Generated project-specific commands
+```
+
+### Manifest Tracking (v1.1.0)
+
+The `.manifest.json` tracks:
+- Blueprint format version
+- Creation/update timestamps
+- Project configuration (type, rules mode)
+- Generated artifacts list
+- Upgrade path detection
+
+## Consequences
+
+### Advantages
+
+- **Structured planning**: Complex features get proper design phase
+- **Clear success criteria**: PRD defines "done"
+- **Preserved context**: Documents survive session boundaries
+- **Reproducible**: Work orders can be re-executed
+- **Version awareness**: Manifest enables format upgrades
+- **Auto-generated artifacts**: Commands and skills created from blueprints
+
+### Disadvantages
+
+- **Overhead for small changes**: Simple bug fixes don't need PRDs
+- **Learning curve**: Team must understand methodology
+- **Template maintenance**: Blueprint templates evolve
+- **Potential rigidity**: Some tasks resist structured planning
+
+### When to Use Blueprints
+
+| Use Blueprint | Skip Blueprint |
+|---------------|----------------|
+| New features | Bug fixes |
+| Significant refactors | Documentation updates |
+| Architecture changes | Config changes |
+| Multi-session work | Single-file edits |
+| Team collaboration | Solo exploration |
+
+### Confidence Scoring
+
+The methodology includes confidence assessment:
+
+```
+High (80-100%): Direct experience, verified patterns
+Medium (50-79%): Reasonable inference, some uncertainty
+Low (0-49%): Speculation, needs validation
+```
+
+## Alternatives Considered
+
+### 1. Informal Planning
+
+Use ad-hoc notes or conversation history for planning.
+
+**Rejected**: Context lost between sessions; no standard format.
+
+### 2. Issue-Only Workflow
+
+Rely solely on GitHub issues for requirements.
+
+**Rejected**: Issues lack technical depth; not designed for implementation planning.
+
+### 3. External Tools
+
+Use Notion, Confluence, or similar for documentation.
+
+**Rejected**: Context switching; not integrated with Claude Code.
+
+### 4. Inline Comments
+
+Document plans in code comments.
+
+**Rejected**: Scattered across files; not discoverable.
+
+## Related Decisions
+
+- ADR-0001: Plugin-Based Architecture (blueprint-plugin structure)
+- ADR-0006: FVH Standards Enforcement (standards integration)
+- Dotfiles ADR-0006: Documentation-First Development (predecessor methodology)

--- a/docs/adr/0006-fvh-standards-enforcement.md
+++ b/docs/adr/0006-fvh-standards-enforcement.md
@@ -1,0 +1,147 @@
+# ADR-0006: FVH Standards Enforcement
+
+## Status
+
+Accepted
+
+## Date
+
+2024-12 (retroactively documented 2025-12)
+
+## Context
+
+Professional development requires consistent infrastructure across projects: CI/CD pipelines, pre-commit hooks, test configurations, linting, container definitions, and more. Without standardization:
+
+1. **Inconsistent quality**: Each project had different tool configurations
+2. **Setup overhead**: Repeating configuration work for every new project
+3. **Knowledge silos**: Best practices not shared across projects
+4. **Drift**: Configurations diverge from standards over time
+5. **Onboarding friction**: New contributors face different setups per project
+
+The "FVH" (FastAPI/Vue/Helm) stack emerged as a common pattern, but the principles apply broadly.
+
+## Decision
+
+Create a **standards enforcement plugin** (`configure-plugin`) that provides:
+
+### 30+ Configure Commands
+
+```
+/configure:all              # Apply all applicable standards
+/configure:status           # Check current compliance
+/configure:pre-commit       # Pre-commit hooks
+/configure:release-please   # Automated releases
+/configure:workflows        # GitHub Actions CI/CD
+/configure:dockerfile       # Container definitions
+/configure:tests            # Test infrastructure
+/configure:coverage         # Code coverage
+/configure:linting          # Linter configuration
+/configure:formatting       # Code formatting
+/configure:dead-code        # Dead code detection
+/configure:security         # Security scanning
+/configure:docs             # Documentation setup
+/configure:mcp              # MCP server configuration
+...and more
+```
+
+### Standards Tracking
+
+Projects track their standards compliance in `.fvh-standards.yaml`:
+
+```yaml
+version: "1.0"
+standards:
+  pre-commit:
+    enabled: true
+    configured_at: "2024-12-15"
+  release-please:
+    enabled: true
+    configured_at: "2024-12-15"
+  workflows:
+    enabled: true
+    configured_at: "2024-12-15"
+  testing:
+    enabled: true
+    tiers: [unit, integration]
+```
+
+### Supporting Skills
+
+| Skill | Purpose |
+|-------|---------|
+| `fvh-ci-workflows` | GitHub Actions patterns |
+| `fvh-pre-commit` | Pre-commit hook configurations |
+| `fvh-release-please` | Release automation |
+| `fvh-skaffold` | Kubernetes deployment |
+
+## Consequences
+
+### Advantages
+
+- **One-command setup**: `/configure:all` applies comprehensive standards
+- **Consistency**: All projects follow same patterns
+- **Best practices codified**: Expertise embedded in commands
+- **Compliance visibility**: `/configure:status` shows gaps
+- **Incremental adoption**: Apply standards one at a time
+- **Living documentation**: Commands are executable documentation
+
+### Disadvantages
+
+- **Opinionated**: Standards reflect specific preferences
+- **Maintenance burden**: Standards evolve; commands must update
+- **Override complexity**: Projects with unique needs may conflict
+- **Tool coupling**: Assumes specific toolchain (pre-commit, release-please, etc.)
+
+### Standards Categories
+
+| Category | Standards |
+|----------|-----------|
+| **Quality** | Pre-commit hooks, linting, formatting, dead code |
+| **Testing** | Unit/integration/e2e setup, coverage, memory profiling |
+| **CI/CD** | GitHub Actions, release-please, semantic versioning |
+| **Security** | Secret scanning, dependency auditing, SAST |
+| **Container** | Dockerfile, Skaffold, registry configuration |
+| **Documentation** | README generation, API docs, changelog |
+
+### Context-Aware Configuration
+
+Commands detect project characteristics:
+
+```yaml
+## Context
+- Package manager: !`find . -maxdepth 1 \( -name "pyproject.toml" ... \)`
+- Pre-commit config: !`find . -maxdepth 1 -name ".pre-commit-config.yaml"`
+- CI workflows: !`ls -la .github/workflows/ 2>/dev/null | head -10`
+```
+
+## Alternatives Considered
+
+### 1. Template Repositories
+
+Create GitHub template repos with pre-configured standards.
+
+**Rejected**: No way to update existing projects; drift over time.
+
+### 2. Cookiecutter/Yeoman
+
+Use project scaffolding tools.
+
+**Rejected**: One-time generation; doesn't help existing projects.
+
+### 3. Manual Documentation
+
+Write standards docs; developers implement manually.
+
+**Rejected**: Inconsistent implementation; time-consuming.
+
+### 4. Monorepo Standards
+
+Enforce standards at monorepo level only.
+
+**Rejected**: Many projects are standalone; need project-level standards.
+
+## Related Decisions
+
+- ADR-0005: Blueprint Development Methodology (methodology integration)
+- ADR-0007: Namespace-Based Command Organization (`/configure:*` namespace)
+- Dotfiles ADR-0009: Conventional Commits + Release-Please

--- a/docs/adr/0007-namespace-based-command-organization.md
+++ b/docs/adr/0007-namespace-based-command-organization.md
@@ -1,0 +1,131 @@
+# ADR-0007: Namespace-Based Command Organization
+
+## Status
+
+Accepted
+
+## Date
+
+2024-12 (retroactively documented 2025-12)
+
+## Context
+
+As the command collection grew to 76+ commands across all plugins, usability problems emerged:
+
+1. **Naming conflicts**: Multiple domains wanted `/status`, `/run`, `/check`
+2. **Poor discoverability**: Users couldn't find commands in flat lists
+3. **Cognitive overload**: Tab completion showed dozens of options
+4. **No grouping**: Related commands weren't visually associated
+5. **Ambiguity**: `/test` could mean test execution, test setup, or test review
+
+The dotfiles repository addressed this (see Dotfiles ADR-0005), and the pattern was adopted for plugins.
+
+## Decision
+
+Organize commands into **namespaces** using colon-separated syntax:
+
+### Namespace Convention
+
+```
+/namespace:command
+```
+
+### Directory Structure
+
+```
+commands/
+├── simple-command.md        # → /simple-command (no namespace)
+└── configure/               # Namespace via subdirectory
+    ├── pre-commit.md        # → /configure:pre-commit
+    ├── tests.md             # → /configure:tests
+    └── workflows.md         # → /configure:workflows
+```
+
+### Plugin Namespaces
+
+| Namespace | Plugin | Commands |
+|-----------|--------|----------|
+| `/git:*` | git-plugin | commit, issue, issues, fix-pr, maintain |
+| `/configure:*` | configure-plugin | pre-commit, tests, workflows, dockerfile, ... |
+| `/test:*` | testing-plugin | run, quick, full, setup, consult, report |
+| `/code:*` | code-quality-plugin | review, refactor, antipatterns |
+| `/project:*` | project-plugin | init, new, modernize, continue |
+| `/blueprint:*` | blueprint-plugin | init, status, upgrade, rules |
+
+### Root-Level Commands
+
+Some commands remain at root level for discoverability:
+
+- `/blueprint-init` - High-frequency entry point
+- `/prp-create` - Direct access to PRP creation
+- `/handoffs` - Cross-cutting utility
+
+## Consequences
+
+### Advantages
+
+- **Scoped naming**: Each namespace owns its commands; no conflicts
+- **Logical grouping**: Related commands are visually associated
+- **Tab completion**: Type `/configure:` then tab for subcommands
+- **Scalability**: Supports 200+ commands without chaos
+- **Self-documenting**: Namespace hints at command purpose
+
+### Disadvantages
+
+- **Longer invocation**: `/configure:pre-commit` vs `/pre-commit`
+- **Learning curve**: Users must learn namespace prefixes
+- **Migration**: Existing references to flat commands break
+- **Inconsistency**: Some commands at root, some namespaced
+
+### Namespace Selection Guidelines
+
+| Pattern | Use When |
+|---------|----------|
+| Namespace | Plugin has 3+ related commands |
+| Root level | Command is high-frequency entry point |
+| Root level | Command is unique, unlikely to conflict |
+
+### Migration Pattern
+
+When consolidating commands:
+
+```
+# Before (flat)
+/project-continue
+/project-test-loop
+
+# After (namespaced)
+/project:continue
+/project:test-loop
+```
+
+## Alternatives Considered
+
+### 1. Plugin-Prefixed Commands
+
+Use plugin name as prefix: `/git-plugin:commit`.
+
+**Rejected**: Too verbose; "plugin" redundant in command context.
+
+### 2. Flat with Unique Names
+
+Keep flat structure; make all names unique: `/git-commit`, `/test-run`.
+
+**Rejected**: Doesn't scale; names become very long.
+
+### 3. Slash-Based Nesting
+
+Use slashes: `/configure/pre-commit`.
+
+**Rejected**: Conflicts with path conventions; less distinct.
+
+### 4. Dot-Based Nesting
+
+Use dots: `/configure.pre-commit`.
+
+**Rejected**: Less readable; dots overloaded in programming.
+
+## Related Decisions
+
+- ADR-0003: Auto-Discovery Component Pattern (directory conventions)
+- Dotfiles ADR-0005: Namespace-Based Command Organization (original decision)

--- a/docs/adr/0008-semantic-versioning-with-manifest.md
+++ b/docs/adr/0008-semantic-versioning-with-manifest.md
@@ -1,0 +1,170 @@
+# ADR-0008: Semantic Versioning with Manifest
+
+## Status
+
+Accepted
+
+## Date
+
+2024-12 (retroactively documented 2025-12)
+
+## Context
+
+As plugins evolved, we needed answers to:
+
+1. **What version is installed?** Users need to know if they're current
+2. **What changed?** Breaking changes must be communicated
+3. **Can I upgrade?** Compatibility between versions must be clear
+4. **What artifacts exist?** Generated commands/skills need tracking
+5. **When was this created?** Audit trail for configurations
+
+Without versioning:
+- Users couldn't tell if updates were available
+- Breaking changes surprised users
+- No upgrade path documentation
+- Generated artifacts weren't tracked
+
+## Decision
+
+Implement **semantic versioning** with **manifest tracking** at two levels:
+
+### Plugin-Level Versioning (plugin.json)
+
+Each plugin declares its version:
+
+```json
+{
+  "name": "blueprint-plugin",
+  "version": "1.1.0",
+  "description": "Blueprint Development methodology"
+}
+```
+
+### Project-Level Manifest (.manifest.json)
+
+Projects using blueprint methodology track their state:
+
+```json
+{
+  "version": "1.1.0",
+  "created_at": "2024-12-15T10:30:00Z",
+  "updated_at": "2024-12-17T14:22:00Z",
+  "project": {
+    "type": "team",
+    "rules_mode": "modular"
+  },
+  "artifacts": {
+    "commands": ["project/continue.md", "project/test-loop.md"],
+    "skills": [],
+    "rules": ["development.md", "testing.md"]
+  }
+}
+```
+
+### Versioning Scheme
+
+Following [Semantic Versioning 2.0.0](https://semver.org/):
+
+```
+MAJOR.MINOR.PATCH
+
+MAJOR: Breaking changes (command renames, removed features)
+MINOR: New features, backward compatible
+PATCH: Bug fixes, documentation updates
+```
+
+### Version Tracking Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/blueprint-status` | Display version, configuration, upgrade availability |
+| `/blueprint-upgrade` | Upgrade manifest to latest format |
+
+### Marketplace Sync
+
+The `marketplace.json` reflects plugin versions:
+
+```json
+{
+  "plugins": [
+    {
+      "name": "blueprint-plugin",
+      "version": "1.1.0",
+      ...
+    }
+  ]
+}
+```
+
+## Consequences
+
+### Advantages
+
+- **Clear expectations**: Version numbers communicate stability
+- **Upgrade paths**: Manifest version enables migration scripts
+- **Audit trail**: Timestamps show configuration history
+- **Artifact tracking**: Know what was generated and when
+- **Breaking change awareness**: MAJOR bumps signal caution
+
+### Disadvantages
+
+- **Maintenance overhead**: Must update versions consistently
+- **Sync requirements**: plugin.json ↔ marketplace.json must match
+- **Upgrade complexity**: Migration scripts need writing
+- **Version fatigue**: Many small updates may accumulate
+
+### Version Update Process
+
+1. Make changes to plugin
+2. Update `plugin.json` version
+3. Update `marketplace.json` version
+4. Write migration notes if MAJOR change
+5. Update `/blueprint-upgrade` if manifest format changes
+
+### Breaking Changes (MAJOR)
+
+Examples that require MAJOR version bump:
+- Command renamed or removed
+- Skill activation keywords changed
+- Manifest format incompatible
+- Required configuration added
+
+### New Features (MINOR)
+
+Examples that require MINOR version bump:
+- New command added
+- New skill added
+- New optional configuration
+- Enhanced functionality
+
+## Alternatives Considered
+
+### 1. No Versioning
+
+Plugins are always "latest"; users accept whatever is current.
+
+**Rejected**: No way to communicate breaking changes.
+
+### 2. Date-Based Versioning
+
+Use dates: `2024.12.15`.
+
+**Rejected**: Doesn't convey breaking vs. minor changes.
+
+### 3. Git-Based Versioning
+
+Use commit hashes or tags.
+
+**Rejected**: Not human-readable; hard to compare.
+
+### 4. Per-Component Versioning
+
+Version each command/skill independently.
+
+**Rejected**: Too granular; coordination nightmare.
+
+## Related Decisions
+
+- ADR-0004: Marketplace Registry Model (version in marketplace.json)
+- ADR-0005: Blueprint Development Methodology (manifest usage)
+- Dotfiles ADR-0009: Conventional Commits + Release-Please (versioning automation)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,80 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) documenting significant technical and architectural choices for the claude-plugins repository.
+
+## Purpose
+
+ADRs capture important architectural decisions along with their context, rationale, and consequences. They help current and future maintainers understand why the repository is structured the way it is.
+
+## Background
+
+This repository was created by migrating Claude Code plugin configurations from [laurigates/dotfiles](https://github.com/laurigates/dotfiles) to a standalone, shareable repository. Many architectural decisions were inherited or evolved from that migration, while others were made specifically for the plugin ecosystem.
+
+## ADR Index
+
+| ID | Title | Status | Date |
+|----|-------|--------|------|
+| [0001](0001-plugin-based-architecture.md) | Plugin-Based Architecture | Accepted | 2024-12 |
+| [0002](0002-domain-driven-plugin-organization.md) | Domain-Driven Plugin Organization | Accepted | 2024-12 |
+| [0003](0003-auto-discovery-component-pattern.md) | Auto-Discovery Component Pattern | Accepted | 2024-12 |
+| [0004](0004-marketplace-registry-model.md) | Marketplace Registry Model | Accepted | 2024-12 |
+| [0005](0005-blueprint-development-methodology.md) | Blueprint Development Methodology | Accepted | 2024-12 |
+| [0006](0006-fvh-standards-enforcement.md) | FVH Standards Enforcement | Accepted | 2024-12 |
+| [0007](0007-namespace-based-command-organization.md) | Namespace-Based Command Organization | Accepted | 2024-12 |
+| [0008](0008-semantic-versioning-with-manifest.md) | Semantic Versioning with Manifest | Accepted | 2024-12 |
+
+## Categories
+
+### Core Architecture
+- ADR-0001: Plugin-Based Architecture
+- ADR-0002: Domain-Driven Plugin Organization
+- ADR-0003: Auto-Discovery Component Pattern
+- ADR-0004: Marketplace Registry Model
+
+### Development Methodology
+- ADR-0005: Blueprint Development Methodology
+- ADR-0006: FVH Standards Enforcement
+
+### Organization & Versioning
+- ADR-0007: Namespace-Based Command Organization
+- ADR-0008: Semantic Versioning with Manifest
+
+## ADR Format
+
+Each ADR follows the [Michael Nygard format](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions):
+
+```markdown
+# ADR-NNNN: Title
+
+## Status
+[Proposed | Accepted | Deprecated | Superseded by ADR-NNNN]
+
+## Date
+YYYY-MM
+
+## Context
+The issue motivating this decision and any relevant context.
+
+## Decision
+The change being proposed or made.
+
+## Consequences
+What becomes easier or harder as a result of this decision.
+```
+
+## Related ADRs
+
+The [laurigates/dotfiles](https://github.com/laurigates/dotfiles) repository contains additional ADRs that provide context for many decisions inherited by this repository:
+
+- ADR-0003: Skill Activation via Trigger Keywords
+- ADR-0004: Subagent-First Delegation Strategy
+- ADR-0005: Namespace-Based Command Organization
+- ADR-0006: Documentation-First Development
+- ADR-0007: Layered Knowledge Distribution
+
+## Adding New ADRs
+
+1. Create a new file with the next sequential number: `NNNN-kebab-case-title.md`
+2. Follow the ADR format template above
+3. Update the index table in this README
+4. Consider cross-references to related decisions


### PR DESCRIPTION
Add 8 ADRs documenting key architectural decisions for the claude-plugins repository, reverse-engineered from the codebase structure and history.

ADRs included:
- 0001: Plugin-Based Architecture
- 0002: Domain-Driven Plugin Organization
- 0003: Auto-Discovery Component Pattern
- 0004: Marketplace Registry Model
- 0005: Blueprint Development Methodology
- 0006: FVH Standards Enforcement
- 0007: Namespace-Based Command Organization
- 0008: Semantic Versioning with Manifest

These records capture decisions made during migration from laurigates/dotfiles and provide reference for future changes.