### PR TITLE
Fix git commit error when no remote exists

### DIFF
--- a/git-plugin/commands/git/commit.md
+++ b/git-plugin/commands/git/commit.md
@@ -17,7 +17,7 @@ description: Complete workflow from changes to PR - analyze changes, create logi
 - Recent commits: !`git log --oneline -10`
 - Remote status: !`git remote -v | head -1`
 - Upstream status: !`git status -sb | head -1`
-- Available labels: !`gh label list --json name,description --limit 50`
+- Available labels: !`gh label list --json name,description --limit 50 2>/dev/null || echo "(no remote configured)"`
 
 ## Parameters
 

--- a/git-plugin/commands/git/issue.md
+++ b/git-plugin/commands/git/issue.md
@@ -9,11 +9,11 @@ argument-hint: <issue-number>
 
 ## Context
 
-- Repo: !`gh repo view --json nameWithOwner`
+- Repo: !`gh repo view --json nameWithOwner 2>/dev/null || echo "(no remote configured)"`
 - Current branch: !`git branch --show-current`
 - Clean working tree: !`git status --porcelain | wc -l`
-- Open PRs: !`gh pr list --state open --json number,title`
-- Available labels: !`gh label list --json name,description --limit 50`
+- Open PRs: !`gh pr list --state open --json number,title 2>/dev/null || echo "(no remote configured)"`
+- Available labels: !`gh label list --json name,description --limit 50 2>/dev/null || echo "(no remote configured)"`
 
 ## Parameters
 

--- a/git-plugin/commands/git/issues.md
+++ b/git-plugin/commands/git/issues.md
@@ -9,11 +9,11 @@ argument-hint: [--filter <label>] [--limit <n>]
 
 ## Context
 
-- Repo: !`gh repo view --json nameWithOwner`
-- Open issues: !`gh issue list --state open --json number,title,labels`
-- Open PRs: !`gh pr list --state open --json number,title,state`
+- Repo: !`gh repo view --json nameWithOwner 2>/dev/null || echo "(no remote configured)"`
+- Open issues: !`gh issue list --state open --json number,title,labels 2>/dev/null || echo "(no remote configured)"`
+- Open PRs: !`gh pr list --state open --json number,title,state 2>/dev/null || echo "(no remote configured)"`
 - Current branch: !`git branch --show-current`
-- Available labels: !`gh label list --json name,description --limit 50`
+- Available labels: !`gh label list --json name,description --limit 50 2>/dev/null || echo "(no remote configured)"`
 
 ## Parameters
 


### PR DESCRIPTION
Add fallback handling for gh CLI commands in git:commit, git:issue, and git:issues commands. When no git remote is configured, commands now gracefully return "(no remote configured)" instead of failing with "no git remotes found" error.