### PR TITLE
claude/fix-git-plugin-permissions-lWDeY

### DIFF
--- a/git-plugin/commands/git/commit.md
+++ b/git-plugin/commands/git/commit.md
@@ -11,12 +11,11 @@ description: Complete workflow from changes to PR - auto-detect related issues, 
 
 - Pre-commit config: !`find . -maxdepth 1 -name ".pre-commit-config.yaml" 2>/dev/null`
 - Current branch: !`git branch --show-current`
-- Git status: !`git status --porcelain=v2 --branch 2>/dev/null | head -20`
+- Git status: !`git status --porcelain=v2 --branch 2>/dev/null`
 - Unstaged changes: !`git diff --numstat 2>/dev/null`
 - Staged changes: !`git diff --cached --numstat 2>/dev/null`
 - Recent commits: !`git log --format='%h %s' -n 10`
 - Remote: !`git remote get-url origin 2>/dev/null || echo "(no remote)"`
-- Upstream tracking: !`git branch -vv --format='%(upstream:track)' 2>/dev/null | head -1`
 - Available labels: !`gh label list --json name --jq '.[].name' --limit 50 2>/dev/null || echo "(no remote)"`
 - Open issues: !`gh issue list --state open --json number,title,labels --jq '.[] | "\(.number): \(.title)"' --limit 30 2>/dev/null || echo "(no remote)"`
 

--- a/git-plugin/commands/git/fix-pr.md
+++ b/git-plugin/commands/git/fix-pr.md
@@ -11,7 +11,7 @@ description: Analyze and fix failing PR checks
 
 - Repo: !`gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "(no remote)"`
 - Current branch: !`git branch --show-current`
-- Git status: !`git status --porcelain=v2 --branch 2>/dev/null | head -20`
+- Git status: !`git status --porcelain=v2 --branch 2>/dev/null`
 - Staged changes: !`git diff --cached --numstat 2>/dev/null`
 - Unstaged changes: !`git diff --numstat 2>/dev/null`
 - Recent commits: !`git log --format='%h %s' -n 5`

--- a/git-plugin/commands/git/issue.md
+++ b/git-plugin/commands/git/issue.md
@@ -11,7 +11,7 @@ argument-hint: [issue-numbers...] [--auto] [--filter <label>] [--limit <n>] [--p
 
 - Repo: !`gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "(no remote)"`
 - Current branch: !`git branch --show-current`
-- Working tree status: !`git status --porcelain=v2 2>/dev/null | wc -l | tr -d ' '`
+- Working tree clean: !`git status --porcelain=v2 2>/dev/null`
 - Open issues: !`gh issue list --state open --json number,title,labels --jq '.[] | "\(.number): \(.title)"' --limit 10 2>/dev/null || echo "(no remote)"`
 - Open PRs: !`gh pr list --state open --json number,title --jq '.[] | "\(.number): \(.title)"' 2>/dev/null || echo "(no remote)"`
 - Available labels: !`gh label list --json name --jq '.[].name' --limit 50 2>/dev/null || echo "(no remote)"`

--- a/git-plugin/commands/git/maintain.md
+++ b/git-plugin/commands/git/maintain.md
@@ -10,7 +10,7 @@ description: Perform repository maintenance and cleanup
 ## Context
 
 - Current branch: !`git branch --show-current`
-- Git status: !`git status --porcelain=v2 --branch 2>/dev/null | head -10`
+- Git status: !`git status --porcelain=v2 --branch 2>/dev/null`
 - Local branches: !`git branch -vv --format='%(refname:short) %(upstream:short) %(upstream:track)'`
 - Stash list: !`git stash list 2>/dev/null`
 - Repository size: !`du -sh .git 2>/dev/null`


### PR DESCRIPTION
Context commands with pipes (e.g., `| head -20`, `| wc -l`) fail permission checks because they are considered multi-operation commands. The `Bash(command:*)` permission pattern only covers single commands.

Changes:
- commit.md: Remove `| head -20` from git status, remove redundant upstream tracking line (info already in git status output)
- fix-pr.md: Remove `| head -20` from git status
- issue.md: Replace `| wc -l | tr -d ' '` with plain git status
- maintain.md: Remove `| head -10` from git status