### PR TITLE
claude/fix-git-permissions-0eH4d

### DIFF
--- a/git-plugin/commands/git/commit.md
+++ b/git-plugin/commands/git/commit.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-16
-modified: 2026-01-16
-reviewed: 2026-01-16
+modified: 2026-01-17
+reviewed: 2026-01-17
 allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(git branch:*), Bash(git remote:*), Bash(gh pr:*), Bash(gh label:*), Bash(gh repo:*), Bash(gh issue:*), Bash(pre-commit:*), Bash(find:*), Read, Edit, Grep, Glob, TodoWrite, mcp__github__create_pull_request, mcp__github__list_issues, mcp__github__get_issue
 argument-hint: [remote-branch] [--push] [--direct] [--pr] [--draft] [--issue <num>] [--no-commit] [--range <start>..<end>] [--skip-issue-detection]
 description: Complete workflow from changes to PR - auto-detect related issues, create logical commits with proper issue linkage, push to remote feature branch, and optionally create pull request
@@ -16,8 +16,8 @@ description: Complete workflow from changes to PR - auto-detect related issues, 
 - Staged changes: !`git diff --cached --numstat 2>/dev/null`
 - Recent commits: !`git log --format='%h %s' -n 10`
 - Remote: !`git remote get-url origin 2>/dev/null || echo "(no remote)"`
-- Available labels: !`gh label list --json name --jq '.[].name' --limit 50 2>/dev/null || echo "(no remote)"`
-- Open issues: !`gh issue list --state open --json number,title,labels --jq '.[] | "\(.number): \(.title)"' --limit 30 2>/dev/null || echo "(no remote)"`
+- Available labels: !`gh label list --json name --limit 50 2>/dev/null || echo "[]"`
+- Open issues: !`gh issue list --state open --json number,title,labels --limit 30 2>/dev/null || echo "[]"`
 
 ## Parameters
 

--- a/git-plugin/commands/git/fix-pr.md
+++ b/git-plugin/commands/git/fix-pr.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-16
-modified: 2025-01-16
-reviewed: 2025-01-16
+modified: 2026-01-17
+reviewed: 2026-01-17
 allowed-tools: Bash(gh pr checks:*), Bash(gh pr view:*), Bash(gh run view:*), Bash(gh run list:*), Bash(gh repo view:*), Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(pre-commit:*), Bash(npm run:*), Bash(uv run:*), Read, Edit, Grep, Glob, TodoWrite, mcp__github__pull_request_read
 argument-hint: [pr-number] [--auto-fix] [--push]
 description: Analyze and fix failing PR checks
@@ -9,7 +9,7 @@ description: Analyze and fix failing PR checks
 
 ## Context
 
-- Repo: !`gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "(no remote)"`
+- Repo: !`gh repo view --json nameWithOwner 2>/dev/null || echo "{}"`
 - Current branch: !`git branch --show-current`
 - Git status: !`git status --porcelain=v2 --branch 2>/dev/null`
 - Staged changes: !`git diff --cached --numstat 2>/dev/null`

--- a/git-plugin/commands/git/issue.md
+++ b/git-plugin/commands/git/issue.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-16
-modified: 2025-01-16
-reviewed: 2025-01-16
+modified: 2026-01-17
+reviewed: 2026-01-17
 allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(git switch:*), Bash(git pull:*), Bash(git stash:*), Bash(gh issue:*), Bash(gh pr:*), Bash(gh repo:*), Bash(gh label:*), Bash(pre-commit:*), Read, Edit, Write, Grep, Glob, TodoWrite, AskUserQuestion, Task, mcp__github__create_pull_request, mcp__github__issue_read, mcp__github__list_issues
 description: Process GitHub issues with interactive selection, conflict detection, and parallel work support
 argument-hint: [issue-numbers...] [--auto] [--filter <label>] [--limit <n>] [--parallel]
@@ -9,12 +9,12 @@ argument-hint: [issue-numbers...] [--auto] [--filter <label>] [--limit <n>] [--p
 
 ## Context
 
-- Repo: !`gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "(no remote)"`
+- Repo: !`gh repo view --json nameWithOwner 2>/dev/null || echo "{}"`
 - Current branch: !`git branch --show-current`
 - Working tree clean: !`git status --porcelain=v2 2>/dev/null`
-- Open issues: !`gh issue list --state open --json number,title,labels --jq '.[] | "\(.number): \(.title)"' --limit 10 2>/dev/null || echo "(no remote)"`
-- Open PRs: !`gh pr list --state open --json number,title --jq '.[] | "\(.number): \(.title)"' 2>/dev/null || echo "(no remote)"`
-- Available labels: !`gh label list --json name --jq '.[].name' --limit 50 2>/dev/null || echo "(no remote)"`
+- Open issues: !`gh issue list --state open --json number,title,labels --limit 10 2>/dev/null || echo "[]"`
+- Open PRs: !`gh pr list --state open --json number,title 2>/dev/null || echo "[]"`
+- Available labels: !`gh label list --json name --limit 50 2>/dev/null || echo "[]"`
 
 ## Parameters
 


### PR DESCRIPTION
Context commands in command files were using --jq with pipe characters (e.g., '.[] | "\(.number): \(.title)"') which the permission checker was interpreting as shell pipes, causing permission failures.

Changed to use --json without --jq expressions, letting Claude parse the JSON directly. This ensures the context commands match the granular Bash permission patterns specified in allowed-tools.

Affected commands:
- git:commit - removed --jq from gh label list and gh issue list
- git:issue - removed --jq from all gh commands
- git:fix-pr - removed --jq from gh repo view