### PR TITLE
claude/standardize-blueprint-execution-gIOFw

### DIFF
--- a/.claude/rules/shell-scripting.md
+++ b/.claude/rules/shell-scripting.md
@@ -1,0 +1,218 @@
+# Shell Scripting Patterns
+
+Safe, portable shell scripting patterns for use in skills and commands.
+
+## Reserved Variable Names
+
+**NEVER use these as variable names** - they are read-only or have special meaning in bash/zsh:
+
+| Variable | Shell | Issue |
+|----------|-------|-------|
+| `status` | zsh | Read-only, holds last command exit status |
+| `PWD` | both | Read-only, current directory |
+| `OLDPWD` | both | Read-only, previous directory |
+| `UID` | both | Read-only, user ID |
+| `EUID` | both | Read-only, effective user ID |
+| `PPID` | both | Read-only, parent process ID |
+| `RANDOM` | both | Special, generates random numbers |
+| `SECONDS` | both | Special, time since shell start |
+| `LINENO` | both | Special, current line number |
+| `HISTCMD` | both | Read-only, history number |
+| `HOSTNAME` | both | May be read-only |
+| `HOSTTYPE` | both | May be read-only |
+| `OSTYPE` | both | May be read-only |
+
+### Safe Alternatives
+
+| Avoid | Use Instead |
+|-------|-------------|
+| `status` | `item_status`, `doc_status`, `prp_status` |
+| `name` | `item_name`, `file_name`, `prp_name` |
+| `type` | `item_type`, `doc_type` |
+| `path` | `file_path`, `doc_path` |
+
+**Convention**: Prefix with a descriptive context (e.g., `prp_`, `adr_`, `doc_`).
+
+## YAML Frontmatter Extraction
+
+### Standard Pattern
+
+Use this consistent pattern for extracting YAML frontmatter fields:
+
+```bash
+# Safe frontmatter field extraction
+# Pattern: grep for field at start of line, extract value, trim whitespace
+extract_field() {
+  local file="$1"
+  local field="$2"
+  head -50 "$file" | grep -m1 "^${field}:" | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r'
+}
+
+# Usage
+doc_status=$(extract_field "$file" "status")
+confidence=$(extract_field "$file" "confidence")
+```
+
+### Inline Extraction (for loops)
+
+```bash
+# Safe inline extraction - prefix all variables
+for prp in docs/prps/*.md; do
+  prp_name=$(basename "$prp")
+  prp_status=$(head -50 "$prp" | grep -m1 "^status:" | sed 's/^[^:]*:[[:space:]]*//')
+  prp_confidence=$(head -50 "$prp" | grep -m1 "^confidence:" | sed 's/^[^:]*:[[:space:]]*//')
+  echo "$prp_name | $prp_status | $prp_confidence"
+done
+```
+
+### Key Patterns
+
+| Purpose | Pattern |
+|---------|---------|
+| First match only | `grep -m1` |
+| Case-insensitive | `grep -im1` |
+| Anchor to line start | `^fieldname:` |
+| Extract value after colon | `sed 's/^[^:]*:[[:space:]]*//'` |
+| Limit to frontmatter | `head -50` (generous) or `head -20` (strict) |
+| Remove carriage returns | `tr -d '\r'` |
+
+### Multi-Value Fields (Arrays)
+
+For YAML arrays like `related:`, extract and parse separately:
+
+```bash
+# Extract array items (assumes - prefix format)
+get_array_field() {
+  local file="$1"
+  local field="$2"
+  awk -v field="$field" '
+    /^---$/ { in_front = !in_front; next }
+    in_front && $0 ~ "^"field":" { capture = 1; next }
+    capture && /^[[:space:]]*-/ { gsub(/^[[:space:]]*-[[:space:]]*/, ""); print }
+    capture && /^[a-z]/ { exit }
+  ' "$file"
+}
+
+# Usage
+related_items=$(get_array_field "$file" "related")
+```
+
+## Error Handling
+
+### Standard Fallback Pattern
+
+```bash
+# Always provide a fallback for missing fields
+prp_status=$(head -50 "$prp" | grep -m1 "^status:" | sed 's/^[^:]*:[[:space:]]*//' || true)
+
+# With default value
+prp_status=${prp_status:-"unknown"}
+```
+
+### Silent Errors for Optional Fields
+
+```bash
+# Suppress errors for missing files or fields
+confidence=$(head -50 "$prp" 2>/dev/null | grep -m1 "^confidence:" | sed 's/^[^:]*:[[:space:]]*//' || echo "")
+```
+
+### Check Before Use
+
+```bash
+# Validate required fields
+if [ -z "$prp_status" ]; then
+  echo "Warning: $prp_name missing status field"
+  continue
+fi
+```
+
+## File Iteration Patterns
+
+### Safe Glob Iteration
+
+```bash
+# Use nullglob behavior - handle empty directories
+shopt -s nullglob 2>/dev/null  # bash
+setopt null_glob 2>/dev/null   # zsh
+
+# Or check for files first
+if ls docs/prps/*.md >/dev/null 2>&1; then
+  for prp in docs/prps/*.md; do
+    # ...
+  done
+else
+  echo "No PRPs found"
+fi
+```
+
+### With find (more portable)
+
+```bash
+# Use find with -print0 for safe filename handling
+find docs/prps -name "*.md" -type f -print0 2>/dev/null | while IFS= read -r -d '' prp; do
+  prp_name=$(basename "$prp")
+  # ...
+done
+```
+
+## Output Formatting
+
+### Table Output
+
+```bash
+# Consistent table format with pipes
+printf "%-30s | %-12s | %s\n" "Name" "Status" "Confidence"
+printf "%-30s | %-12s | %s\n" "----" "------" "----------"
+for prp in docs/prps/*.md; do
+  prp_name=$(basename "$prp" .md)
+  prp_status=$(head -50 "$prp" | grep -m1 "^status:" | sed 's/^[^:]*:[[:space:]]*//' || true)
+  prp_confidence=$(head -50 "$prp" | grep -m1 "^confidence:" | sed 's/^[^:]*:[[:space:]]*//' || true)
+  printf "%-30s | %-12s | %s\n" "$prp_name" "${prp_status:-N/A}" "${prp_confidence:-N/A}"
+done
+```
+
+### JSON Output (for parsing)
+
+```bash
+# Generate JSON array for machine consumption
+echo "["
+first=true
+for prp in docs/prps/*.md; do
+  prp_name=$(basename "$prp" .md)
+  prp_status=$(head -50 "$prp" | grep -m1 "^status:" | sed 's/^[^:]*:[[:space:]]*//' || true)
+
+  $first || echo ","
+  first=false
+  printf '  {"name": "%s", "status": "%s"}' "$prp_name" "${prp_status:-unknown}"
+done
+echo ""
+echo "]"
+```
+
+## Quick Reference
+
+### Frontmatter Extraction One-Liner
+
+```bash
+# Template - replace FIELD and use safe variable name
+item_FIELD=$(head -50 "$file" | grep -m1 "^FIELD:" | sed 's/^[^:]*:[[:space:]]*//' || true)
+```
+
+### Common Extractions
+
+| Field | Safe Variable | Pattern |
+|-------|---------------|---------|
+| status | `doc_status` | `head -50 "$f" \| grep -m1 "^status:" \| sed 's/^[^:]*:[[:space:]]*//'` |
+| confidence | `confidence` | `head -50 "$f" \| grep -m1 "^confidence:" \| sed 's/^[^:]*:[[:space:]]*//'` |
+| domain | `doc_domain` | `head -50 "$f" \| grep -m1 "^domain:" \| sed 's/^[^:]*:[[:space:]]*//'` |
+| created | `created_date` | `head -50 "$f" \| grep -m1 "^created:" \| sed 's/^[^:]*:[[:space:]]*//'` |
+| modified | `modified_date` | `head -50 "$f" \| grep -m1 "^modified:" \| sed 's/^[^:]*:[[:space:]]*//'` |
+
+## Checklist for New Commands
+
+- [ ] Variable names avoid reserved words (especially `status`)
+- [ ] Frontmatter extraction uses `head -50 | grep -m1 "^field:" | sed ...` pattern
+- [ ] Error handling with `|| true` or `|| echo ""`
+- [ ] Default values with `${var:-default}`
+- [ ] File iteration handles empty directories
+- [ ] Output format is consistent (table or JSON)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 ---
 created: 2025-12-20
-modified: 2025-12-22
+modified: 2026-01-18
 reviewed: 2025-12-20
 ---
 
@@ -33,6 +33,8 @@ Claude Code plugin collection providing skills, commands, and agents for develop
 | `.claude/rules/skill-development.md` | Skill creation patterns |
 | `.claude/rules/agentic-optimization.md` | CLI output optimization for AI |
 | `.claude/rules/command-naming.md` | Command namespace conventions |
+| `.claude/rules/shell-scripting.md` | Safe shell patterns and frontmatter extraction |
+| `.claude/rules/agentic-permissions.md` | Granular tool permissions for commands |
 
 ## Creating New Skills
 

--- a/blueprint-plugin/commands/blueprint-adr-validate.md
+++ b/blueprint-plugin/commands/blueprint-adr-validate.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-01-15
-modified: 2026-01-15
+modified: 2026-01-18
 reviewed: 2026-01-15
 description: "Validate ADR relationships, detect orphaned references, and check domain consistency"
 allowed_tools: [Read, Bash, Glob, Grep, Edit, AskUserQuestion]
@@ -71,10 +71,11 @@ Validate Architecture Decision Records for relationship consistency, reference i
 
 8. **Group ADRs by domain**:
    ```bash
+   # Note: Use prefixed variable names to avoid shell reserved words (e.g., 'status' in zsh)
    for f in docs/adrs/*.md; do
-     domain=$(grep -m1 "^domain:" "$f" | cut -d: -f2 | tr -d ' ')
-     status=$(grep -m1 "^status:" "$f" | cut -d: -f2 | tr -d ' ')
-     [ -n "$domain" ] && echo "$domain|$status|$f"
+     adr_domain=$(head -30 "$f" | grep -m1 "^domain:" | sed 's/^[^:]*:[[:space:]]*//')
+     adr_status=$(head -30 "$f" | grep -m1 "^status:" | sed 's/^[^:]*:[[:space:]]*//')
+     [ -n "$adr_domain" ] && echo "$adr_domain|$adr_status|$f"
    done | sort
    ```
 


### PR DESCRIPTION
- Add .claude/rules/shell-scripting.md with safe patterns for:
  - Avoiding reserved shell variable names (especially 'status' in zsh)
  - Standardized YAML frontmatter extraction patterns
  - Error handling conventions
  - File iteration best practices

- Fix blueprint-adr-validate.md to use prefixed variable names (adr_status, adr_domain instead of status, domain)

- Update CLAUDE.md rules table with new rules

This prevents "read-only variable: status" errors in zsh and provides consistent patterns for all blueprint commands that parse markdown files.