### PR TITLE
feat(hooks-plugin): detect excessive pipe chains and test output parsing

### DIFF
--- a/hooks-plugin/README.md
+++ b/hooks-plugin/README.md
@@ -24,6 +24,8 @@ A PreToolUse hook that intercepts Bash commands and blocks those that should use
 | `timeout cmd` | Remove timeout (human approval time exceeds it) |
 | `find` | Use **Glob** tool instead |
 | `grep`/`rg` | Use **Grep** tool instead |
+| 5+ pipe chain | Simplify with JSON output or awk |
+| Multi-grep test parsing | Use `--reporter=json` instead |
 
 ## Installation
 


### PR DESCRIPTION
Add two new anti-pattern detections to bash-antipatterns hook:
- Excessive pipe chains (5+ pipes) - suggests using JSON output or awk
- Multi-grep chains parsing test/task output - suggests --reporter=json

These patterns help Claude avoid fragile text parsing of structured output.