### PR TITLE
claude/deployment-change-branch-vXLZ1

### DIFF
--- a/hooks-plugin/hooks/README.md
+++ b/hooks-plugin/hooks/README.md
@@ -21,6 +21,7 @@ A PreToolUse hook that intercepts Bash commands and blocks those that should use
 | `ls *pattern*` | Consider **Glob** tool |
 | `cat/tail ...tasks/*.output` | Use **TaskOutput** tool instead |
 | `sleep && cat/tail` | Use **TaskOutput** tool with block parameter |
+| `git X && git Y` | Run git commands as separate Bash calls (avoids index.lock race condition) |
 
 ### How It Works
 
@@ -62,6 +63,9 @@ echo $?  # Should be 2 (blocked)
 
 echo '{"tool_input": {"command": "git status"}}' | bash .claude/hooks/bash-antipatterns.sh
 echo $?  # Should be 0 (allowed)
+
+echo '{"tool_input": {"command": "git stash && git checkout -b branch"}}' | bash .claude/hooks/bash-antipatterns.sh
+echo $?  # Should be 2 (blocked - chained git commands cause lock race conditions)
 ```
 
 ### Customization


### PR DESCRIPTION
Add antipattern detection for git commands chained with &&. This pattern can cause index.lock race conditions where the lock from the first command hasn't been released before the second tries to acquire it.

The hook reminds to run git commands as separate Bash tool calls instead of chaining them together.