### PR TITLE
claude/add-failfast-test-command-UbPiu

### DIFF
--- a/testing-plugin/README.md
+++ b/testing-plugin/README.md
@@ -12,6 +12,7 @@ This plugin provides comprehensive testing support including test runners, TDD w
 |---------|-------------|
 | `/test:run` | Universal test runner - auto-detects and runs appropriate testing framework |
 | `/test:quick` | Fast unit tests only (skip slow/integration/E2E) |
+| `/test:focus` | Run single test file with fail-fast mode for rapid iteration |
 | `/test:full` | Complete test suite including integration and E2E tests |
 | `/test:setup` | Configure testing infrastructure with CI/CD integration |
 | `/test:consult` | Consult test-architecture agent for testing strategy |
@@ -61,6 +62,15 @@ The plugin enforces RED → GREEN → REFACTOR:
 ```
 
 Runs only fast unit tests, skipping slow integration and E2E tests.
+
+### Focus on Single File
+
+```bash
+/test:focus login.spec.ts
+/test:focus tests/e2e/auth.spec.ts --serial
+```
+
+Runs a single test file with fail-fast mode. Stops immediately on first failure for rapid iteration. Use `--serial` for tests requiring sequential execution (WebGL, database state).
 
 ### Full Test Suite
 

--- a/testing-plugin/commands/test/focus.md
+++ b/testing-plugin/commands/test/focus.md
@@ -1,0 +1,158 @@
+---
+created: 2026-01-19
+modified: 2026-01-19
+reviewed: 2026-01-19
+allowed-tools: Bash, Read, Grep, Glob, TodoWrite
+argument-hint: "<file-path> [--serial] [--debug]"
+description: Run single test file with fail-fast mode for rapid iteration
+---
+
+## Context
+
+- Project type: !`ls -la pyproject.toml package.json Cargo.toml go.mod 2>/dev/null | head -1`
+- Playwright config: !`ls playwright.config.* 2>/dev/null || echo "none"`
+- Vitest config: !`ls vitest.config.* vite.config.* 2>/dev/null | head -1 || echo "none"`
+- Jest config: !`ls jest.config.* 2>/dev/null || echo "none"`
+- Pytest config: !`grep -l "pytest" pyproject.toml setup.cfg 2>/dev/null | head -1 || echo "none"`
+- Package scripts: !`cat package.json 2>/dev/null | grep -E '"test' | head -5`
+
+## Parameters
+
+- `$1` (required): Test file path or pattern (e.g., `login.spec.ts`, `tests/e2e/auth.spec.ts`)
+- `--serial`: Force sequential execution with single worker (useful for WebGL, database tests)
+- `--debug`: Run in debug/headed mode for visual debugging
+
+## Your task
+
+Run a single test file in **fail-fast mode** for rapid development iteration. Stop immediately on first failure to minimize feedback time.
+
+### 1. Detect test framework and construct command
+
+**Playwright** (if `playwright.config.*` exists):
+```bash
+# Standard fail-fast
+bunx playwright test "$FILE" --max-failures=1 --reporter=line
+
+# With --serial (WebGL, shared state)
+bunx playwright test "$FILE" --max-failures=1 --workers=1 --reporter=line
+
+# With --debug
+bunx playwright test "$FILE" --max-failures=1 --headed --debug
+```
+
+**Vitest** (if `vitest.config.*` or `vite.config.*` exists):
+```bash
+# Standard fail-fast
+bunx vitest run "$FILE" --bail=1 --reporter=dot
+
+# With --serial
+bunx vitest run "$FILE" --bail=1 --pool=forks --poolOptions.threads.singleThread --reporter=dot
+
+# With --debug
+bunx vitest run "$FILE" --bail=1 --inspect-brk
+```
+
+**Jest** (if `jest.config.*` exists):
+```bash
+# Standard fail-fast
+bunx jest "$FILE" --bail --silent
+
+# With --serial
+bunx jest "$FILE" --bail --runInBand --silent
+
+# With --debug
+bunx jest "$FILE" --bail --runInBand
+```
+
+**pytest** (Python projects):
+```bash
+# Standard fail-fast
+python -m pytest "$FILE" -x -v --tb=short
+
+# With --serial (already serial by default)
+python -m pytest "$FILE" -x -v --tb=short
+
+# With --debug
+python -m pytest "$FILE" -x -v --tb=long -s
+```
+
+**Cargo test** (Rust projects):
+```bash
+# Standard fail-fast
+cargo test --test "$FILE" -- --test-threads=1
+
+# With --debug
+cargo test --test "$FILE" -- --test-threads=1 --nocapture
+```
+
+**Go test**:
+```bash
+# Standard fail-fast
+go test -v -failfast "$FILE"
+
+# With --debug
+go test -v -failfast "$FILE" -count=1
+```
+
+### 2. Execute the test
+
+Run the constructed command. Capture and display output.
+
+### 3. Analyze results
+
+If the test **passes**:
+```
+[FILE]: PASSED
+Duration: Xs
+
+Ready for next iteration or file.
+```
+
+If the test **fails**:
+```
+[FILE]: FAILED (stopped at first failure)
+Duration: Xs
+
+First failure:
+  Test: [test name]
+  Error: [brief error message]
+  Location: [file:line]
+
+Quick actions:
+- Fix the issue and re-run: /test:focus [same file]
+- Debug visually: /test:focus [file] --debug
+- See full output: /test:run [file]
+```
+
+### 4. Provide rerun command
+
+Always show the exact command to rerun:
+```
+Rerun: /test:focus $FILE
+```
+
+## Time savings context
+
+Focused testing dramatically reduces feedback time:
+
+| Approach | Typical Duration | Use Case |
+|----------|------------------|----------|
+| `/test:focus` | 2-30 seconds | Iterating on single file |
+| `/test:quick` | 30 seconds | Unit tests after changes |
+| `/test:full` | 5-30 minutes | Before commit/PR |
+
+## Agentic optimizations
+
+| Context | Flags |
+|---------|-------|
+| Playwright fast | `--max-failures=1 --reporter=line` |
+| Playwright WebGL | `--max-failures=1 --workers=1 --reporter=line` |
+| Vitest fast | `--bail=1 --reporter=dot` |
+| Jest fast | `--bail --silent` |
+| pytest fast | `-x -v --tb=short` |
+
+## Error handling
+
+- If file not found: List similar test files with `glob` and suggest corrections
+- If framework not detected: Show available package.json scripts containing "test"
+- If test times out: Suggest `--serial` flag or increasing timeout


### PR DESCRIPTION
Add `/test:focus` command for rapid development iteration:
- Run single test file in isolation
- Stop immediately on first failure (--max-failures=1, --bail, -x)
- Support for --serial flag (WebGL, database tests)
- Support for --debug flag (visual debugging)
- Framework-agnostic: Playwright, Vitest, Jest, pytest, Cargo, Go