### PR TITLE
feat: implement Claude Code 2.1.7 changelog review updates (issue #78)

### DIFF
--- a/.claude-code-version-check.json
+++ b/.claude-code-version-check.json
@@ -1,8 +1,25 @@
 {
   "lastCheckedVersion": "2.1.7",
-  "lastCheckedDate": "2026-01-14",
+  "lastCheckedDate": "2026-01-20",
   "changelogUrl": "https://raw.githubusercontent.com/anthropics/claude-code/refs/heads/main/CHANGELOG.md",
   "reviewedChanges": [
+    {
+      "version": "2.1.7",
+      "date": "2026-01-20",
+      "relevantChanges": [
+        "SubagentStart hook event with input modification",
+        "Hooks in skill/command frontmatter",
+        "context:fork for agent isolation",
+        "disallowedTools for agent restrictions",
+        "Skills and slash commands merged",
+        "Hot-reload for skills/commands",
+        "SlashCommand tool invocation",
+        "Wildcard permission patterns",
+        "Shell operator protections",
+        "SDK migration to @anthropic-ai/claude-agent-sdk"
+      ],
+      "actionsRequired": []
+    },
     {
       "version": "2.1.7",
       "date": "2026-01-14",

--- a/.claude/rules/skill-development.md
+++ b/.claude/rules/skill-development.md
@@ -1,10 +1,43 @@
 ---
 created: 2025-12-20
-modified: 2025-12-20
-reviewed: 2025-12-20
+modified: 2026-01-20
+reviewed: 2026-01-20
 ---
 
 # Skill Development
+
+## Skills and Commands Unified (Claude Code 2.1.7+)
+
+As of Claude Code 2.1.7, skills and slash commands have been merged into a unified system:
+
+| Feature | Behavior |
+|---------|----------|
+| **Unified invocation** | Both skills and commands use `/name` syntax |
+| **Auto-discovery** | Claude Code automatically discovers skills/commands |
+| **Hot-reload** | Changes to skill/command files take effect immediately |
+| **SlashCommand tool** | Commands can invoke other commands via the SlashCommand tool |
+
+### Hot-Reload
+
+Skills and commands are reloaded automatically when modified:
+- No need to restart Claude Code
+- Changes take effect on the next invocation
+- Useful for iterative development
+
+### SlashCommand Tool Invocation
+
+Commands can invoke other commands programmatically:
+
+```markdown
+## Execution
+
+First, run the setup command:
+Use SlashCommand tool to invoke `/configure:pre-commit`
+
+Then proceed with...
+```
+
+This enables composable command workflows.
 
 ## Skill File Structure
 

--- a/agent-patterns-plugin/.claude-plugin/plugin.json
+++ b/agent-patterns-plugin/.claude-plugin/plugin.json
@@ -12,6 +12,9 @@
     "workflow",
     "primer",
     "hooks",
-    "configuration"
+    "configuration",
+    "context-fork",
+    "disallowedTools",
+    "custom-agents"
   ]
 }

--- a/agent-patterns-plugin/README.md
+++ b/agent-patterns-plugin/README.md
@@ -214,6 +214,33 @@ Configure Claude Code lifecycle hooks with proper timeout settings.
 }
 ```
 
+#### `custom-agent-definitions`
+Define and configure custom agents with context forking and tool restrictions.
+
+**When to use:**
+- Creating custom agent types beyond built-in agents
+- Configuring isolated agent contexts with `context: fork`
+- Restricting agent capabilities with `disallowedTools`
+- Setting up specialized agents for specific workflows
+
+**Key Fields:**
+```yaml
+---
+name: security-auditor
+description: Security-focused code review
+model: sonnet
+context: fork
+allowed-tools: Read, Grep, Glob
+disallowedTools: Bash, Write, Edit
+---
+```
+
+**Features:**
+- Context forking for isolated agent execution
+- Tool whitelisting (`allowed-tools`)
+- Tool blacklisting (`disallowedTools`)
+- Custom agent definitions in plugins
+
 ## Installation
 
 ### Via Plugin System
@@ -309,10 +336,27 @@ MIT License - See LICENSE file for details
 
 Contributions welcome! Please follow existing patterns and conventions.
 
+## Claude Agent SDK Migration
+
+As of Claude Code 2.1.7, the legacy SDK entrypoint has been removed. If you're building custom Claude applications programmatically, migrate to the official package:
+
+```bash
+# Install the official SDK
+npm install @anthropic-ai/claude-agent-sdk
+```
+
+**Migration notes:**
+- Legacy entrypoints have been removed
+- Use `@anthropic-ai/claude-agent-sdk` for all new agent development
+- Existing integrations should update their imports
+
+See the [Claude Agent SDK documentation](https://docs.anthropic.com/claude/docs/claude-agent-sdk) for migration guidance.
+
 ## References
 
 - [Anthropic Prompt Engineering](https://docs.anthropic.com/claude/docs/prompt-engineering)
 - [Claude Code Documentation](https://docs.claude.com/claude-code)
+- [Claude Agent SDK](https://docs.anthropic.com/claude/docs/claude-agent-sdk)
 - [Multi-Agent Systems Patterns](https://en.wikipedia.org/wiki/Multi-agent_system)
 
 ## Version

--- a/agent-patterns-plugin/skills/custom-agent-definitions/SKILL.md
+++ b/agent-patterns-plugin/skills/custom-agent-definitions/SKILL.md
@@ -1,0 +1,292 @@
+---
+name: custom-agent-definitions
+description: |
+  Define and configure custom agents in Claude Code. Covers context forking,
+  agent field specifications, and disallowedTools restrictions. Use when
+  creating custom agent types, configuring agent isolation, or restricting
+  agent capabilities.
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, TodoWrite
+created: 2026-01-20
+modified: 2026-01-20
+reviewed: 2026-01-20
+---
+
+# Custom Agent Definitions
+
+Expert knowledge for defining and configuring custom agents in Claude Code.
+
+## Core Concepts
+
+**Custom Agents** allow you to define specialized agent types beyond the built-in ones (Explore, Plan, Bash, etc.). Each custom agent can have its own model, tools, and context configuration.
+
+## Agent Definition Schema
+
+Custom agents are defined in `.claude/agents/` or via plugin agent directories.
+
+### Basic Structure
+
+```yaml
+---
+name: my-custom-agent
+description: What this agent does
+model: sonnet
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# Agent System Prompt
+
+Instructions and context for the agent...
+```
+
+### Context Forking
+
+The `context` field controls how the agent's context relates to the parent conversation:
+
+| Value | Behavior |
+|-------|----------|
+| `fork` | Creates an independent context copy - agent sees parent history but changes don't affect parent |
+| (default) | Agent shares context with parent and can see/modify conversation state |
+
+**Example: Isolated Research Agent**
+
+```yaml
+---
+name: research-agent
+description: Research questions without modifying main context
+model: sonnet
+context: fork
+allowed-tools: WebSearch, WebFetch, Read
+---
+
+# Research Agent
+
+You are a research specialist. Search for information and provide findings.
+Your research doesn't affect the main conversation context.
+```
+
+**When to use `context: fork`:**
+- Exploratory research that shouldn't pollute main context
+- Parallel investigations with potentially conflicting approaches
+- Isolated experiments or testing
+- Background tasks that run independently
+
+### Agent Field for Delegation
+
+The `agent` field specifies which agent type to use when delegating via the Task tool:
+
+```yaml
+---
+name: code-review-workflow
+description: Comprehensive code review
+agent: security-auditor
+allowed-tools: Read, Grep, Glob, TodoWrite
+---
+```
+
+This allows commands and skills to specify a preferred agent type for delegation.
+
+### Disallowed Tools (Restrictions)
+
+The `disallowedTools` field explicitly prevents an agent from using certain tools:
+
+```yaml
+---
+name: read-only-explorer
+description: Explore codebase without modifications
+model: haiku
+allowed-tools: Bash, Read, Grep, Glob
+disallowedTools: Write, Edit, NotebookEdit
+---
+
+# Read-Only Explorer
+
+Explore and analyze code. Do not make any modifications.
+```
+
+**Disallowed Tools vs Allowed Tools:**
+
+| Field | Purpose | Behavior |
+|-------|---------|----------|
+| `allowed-tools` | Whitelist of permitted tools | Agent can ONLY use these tools |
+| `disallowedTools` | Blacklist of forbidden tools | Agent can use all tools EXCEPT these |
+
+**When to use `disallowedTools`:**
+- Creating read-only agents that can explore but not modify
+- Restricting dangerous capabilities (Bash execution)
+- Sandboxing agents for specific tasks
+- Security-sensitive contexts
+
+### Complete Example
+
+```yaml
+---
+name: security-auditor
+description: Security-focused code review agent
+model: sonnet
+context: fork
+allowed-tools: Read, Grep, Glob, WebSearch, TodoWrite
+disallowedTools: Bash, Write, Edit
+created: 2026-01-20
+modified: 2026-01-20
+reviewed: 2026-01-20
+---
+
+# Security Auditor Agent
+
+You are a security auditor. Analyze code for vulnerabilities.
+
+## Capabilities
+- Read and analyze source code
+- Search for security patterns
+- Research known vulnerabilities
+- Track findings in todo list
+
+## Restrictions
+- Cannot execute code (no Bash)
+- Cannot modify files (no Write/Edit)
+- Work in isolated context
+
+## Focus Areas
+1. SQL injection vulnerabilities
+2. XSS vulnerabilities
+3. Authentication/authorization flaws
+4. Secrets/credentials in code
+5. Insecure dependencies
+```
+
+## Defining Agents in Plugins
+
+Plugins can define custom agents in their `agents/` directory:
+
+```
+my-plugin/
+├── .claude-plugin/
+│   └── plugin.json
+├── agents/
+│   ├── security-auditor.md
+│   ├── performance-analyzer.md
+│   └── accessibility-checker.md
+└── skills/
+    └── ...
+```
+
+Each agent file follows the same YAML frontmatter + markdown body structure.
+
+## Using Custom Agents
+
+### Via Task Tool
+
+```
+Task tool with subagent_type="security-auditor" for security analysis.
+```
+
+### Via Delegation
+
+```bash
+/delegate Audit auth module for security issues
+```
+
+The delegation system matches tasks to appropriate custom agents.
+
+## Best Practices
+
+### 1. Principle of Least Privilege
+Only grant tools the agent actually needs:
+```yaml
+# Good: Minimal tools for the task
+allowed-tools: Read, Grep, Glob
+
+# Avoid: Overly permissive
+allowed-tools: Bash, Read, Write, Edit, Grep, Glob, WebSearch, WebFetch
+```
+
+### 2. Use Context Forking for Isolation
+```yaml
+# Good: Isolated exploratory work
+context: fork
+```
+
+### 3. Combine Allowed and Disallowed
+```yaml
+# Explicit whitelist with safety blacklist
+allowed-tools: Bash, Read, Grep
+disallowedTools: Write, Edit
+```
+
+### 4. Clear Agent Descriptions
+```yaml
+description: |
+  Security auditor for identifying vulnerabilities in authentication
+  and authorization code. Reports findings without modifying code.
+```
+
+### 5. Model Selection
+| Use Case | Model |
+|----------|-------|
+| Quick analysis | haiku |
+| Standard work | sonnet |
+| Complex reasoning | opus |
+
+## Agent Configuration Fields Reference
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Agent identifier |
+| `description` | string | What the agent does |
+| `model` | string | Model to use (haiku, sonnet, opus) |
+| `context` | string | Context mode: `fork` or default |
+| `allowed-tools` | list | Tools the agent can use |
+| `disallowedTools` | list | Tools the agent cannot use |
+| `created` | date | Creation date |
+| `modified` | date | Last modification date |
+| `reviewed` | date | Last review date |
+
+## Common Patterns
+
+### Read-Only Research Agent
+```yaml
+context: fork
+allowed-tools: Read, Grep, Glob, WebSearch, WebFetch
+disallowedTools: Bash, Write, Edit
+```
+
+### Safe Code Executor
+```yaml
+allowed-tools: Bash, Read
+disallowedTools: Write, Edit
+```
+
+### Documentation Writer
+```yaml
+allowed-tools: Read, Write, Edit, Grep, Glob
+disallowedTools: Bash
+```
+
+### Full-Power Developer
+```yaml
+allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
+```
+
+## Agentic Optimizations
+
+| Context | Configuration |
+|---------|---------------|
+| Exploratory research | `context: fork`, `model: haiku` |
+| Security analysis | `context: fork`, `disallowedTools: Bash, Write, Edit` |
+| Quick lookups | `model: haiku`, minimal tools |
+| Complex implementation | `model: sonnet`, full tools |
+
+## Quick Reference
+
+### Context Modes
+| Mode | Isolation | Use Case |
+|------|-----------|----------|
+| (default) | Shared | Normal workflows |
+| `fork` | Isolated | Research, experiments |
+
+### Tool Restriction Patterns
+| Pattern | Fields |
+|---------|--------|
+| Whitelist only | `allowed-tools: Tool1, Tool2` |
+| Blacklist only | `disallowedTools: Tool1, Tool2` |
+| Combined | Both fields specified |

--- a/configure-plugin/.claude-plugin/plugin.json
+++ b/configure-plugin/.claude-plugin/plugin.json
@@ -17,6 +17,9 @@
     "docker",
     "testing",
     "linting",
-    "formatting"
+    "formatting",
+    "security",
+    "permissions",
+    "wildcards"
   ]
 }

--- a/configure-plugin/README.md
+++ b/configure-plugin/README.md
@@ -80,6 +80,7 @@ All commands support two modes:
 | `fvh-pre-commit` | FVH pre-commit hook standards |
 | `fvh-release-please` | FVH release-please standards |
 | `fvh-skaffold` | FVH Skaffold configuration standards |
+| `claude-security-settings` | Claude Code security settings and wildcard permissions |
 
 ## Usage
 

--- a/configure-plugin/skills/claude-security-settings/SKILL.md
+++ b/configure-plugin/skills/claude-security-settings/SKILL.md
@@ -1,0 +1,335 @@
+---
+name: claude-security-settings
+description: |
+  Configure Claude Code security settings including permission wildcards, shell
+  operator protections, and project-level access controls. Use when setting up
+  project permissions, configuring allowed tools, or securing Claude Code workflows.
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, TodoWrite
+created: 2026-01-20
+modified: 2026-01-20
+reviewed: 2026-01-20
+---
+
+# Claude Code Security Settings
+
+Expert knowledge for configuring Claude Code security and permissions.
+
+## Core Concepts
+
+Claude Code provides multiple layers of security:
+1. **Permission wildcards** - Granular tool access control
+2. **Shell operator protections** - Prevents command injection
+3. **Project-level settings** - Scoped configurations
+
+## Permission Configuration
+
+### Settings File Locations
+
+| File | Scope | Priority |
+|------|-------|----------|
+| `~/.claude/settings.json` | User-level (all projects) | Lowest |
+| `.claude/settings.json` | Project-level (committed) | Medium |
+| `.claude/settings.local.json` | Local project (gitignored) | Highest |
+
+### Permission Structure
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(git status:*)",
+      "Bash(npm run:*)"
+    ],
+    "deny": [
+      "Bash(rm -rf:*)",
+      "Bash(sudo:*)"
+    ]
+  }
+}
+```
+
+## Wildcard Permission Patterns
+
+### Syntax
+
+```
+Bash(command:*)
+```
+
+- `Bash()` - Tool identifier
+- `command` - Command prefix to match
+- `:*` - Wildcard suffix matching any arguments
+
+### Pattern Examples
+
+| Pattern | Matches | Does NOT Match |
+|---------|---------|----------------|
+| `Bash(git:*)` | `git status`, `git diff HEAD` | `git-lfs pull` |
+| `Bash(npm run:*)` | `npm run test`, `npm run build` | `npm install` |
+| `Bash(gh pr:*)` | `gh pr view 123`, `gh pr create` | `gh issue list` |
+| `Bash(./scripts/:*)` | `./scripts/test.sh`, `./scripts/build.sh` | `/scripts/other.sh` |
+
+### Pattern Best Practices
+
+**Granular permissions:**
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)"
+    ]
+  }
+}
+```
+
+**Tool-specific patterns:**
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(bun test:*)",
+      "Bash(bun run:*)",
+      "Bash(biome check:*)",
+      "Bash(prettier:*)"
+    ]
+  }
+}
+```
+
+## Shell Operator Protections
+
+Claude Code 2.1.7+ includes built-in protections against dangerous shell operators.
+
+### Protected Operators
+
+| Operator | Risk | Blocked Example |
+|----------|------|-----------------|
+| `&&` | Command chaining | `ls && rm -rf /` |
+| `\|\|` | Conditional execution | `false \|\| malicious` |
+| `;` | Command separation | `safe; dangerous` |
+| `\|` | Piping | `cat /etc/passwd \| curl` |
+| `>` / `>>` | Redirection | `echo x > /etc/passwd` |
+| `$()` | Command substitution | `$(curl evil)` |
+| `` ` `` | Backtick substitution | `` `rm -rf /` `` |
+
+### Security Behavior
+
+When a command contains shell operators:
+1. Permission wildcards won't match
+2. User sees explicit approval prompt
+3. Warning explains the blocked operator
+
+### Safe Compound Commands
+
+For legitimate compound commands, use scripts:
+
+```bash
+#!/bin/bash
+# scripts/deploy.sh
+npm test && npm run build && npm run deploy
+```
+
+Then allow the script:
+```json
+{
+  "permissions": {
+    "allow": ["Bash(./scripts/deploy.sh:*)"]
+  }
+}
+```
+
+## Common Permission Sets
+
+### Read-Only Development
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git branch:*)",
+      "Bash(npm list:*)",
+      "Bash(bun pm ls:*)"
+    ]
+  }
+}
+```
+
+### Full Git Workflow
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git branch:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(git pull:*)",
+      "Bash(git fetch:*)",
+      "Bash(git checkout:*)",
+      "Bash(git merge:*)",
+      "Bash(git rebase:*)"
+    ]
+  }
+}
+```
+
+### CI/CD Operations
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh pr:*)",
+      "Bash(gh run:*)",
+      "Bash(gh issue:*)",
+      "Bash(gh workflow:*)"
+    ]
+  }
+}
+```
+
+### Testing & Linting
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(bun test:*)",
+      "Bash(npm test:*)",
+      "Bash(vitest:*)",
+      "Bash(jest:*)",
+      "Bash(biome:*)",
+      "Bash(eslint:*)",
+      "Bash(prettier:*)"
+    ]
+  }
+}
+```
+
+### Security Scanning
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(pre-commit:*)",
+      "Bash(detect-secrets:*)",
+      "Bash(gitleaks:*)",
+      "Bash(trivy:*)"
+    ]
+  }
+}
+```
+
+## Project Setup Guide
+
+### 1. Create Settings Directory
+
+```bash
+mkdir -p .claude
+```
+
+### 2. Create Project Settings
+
+```bash
+cat > .claude/settings.json << 'EOF'
+{
+  "permissions": {
+    "allow": [
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(npm run:*)"
+    ]
+  }
+}
+EOF
+```
+
+### 3. Add to .gitignore (for local settings)
+
+```bash
+echo ".claude/settings.local.json" >> .gitignore
+```
+
+### 4. Create Local Settings (optional)
+
+```bash
+cat > .claude/settings.local.json << 'EOF'
+{
+  "permissions": {
+    "allow": [
+      "Bash(docker:*)"
+    ]
+  }
+}
+EOF
+```
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| View project settings | `cat .claude/settings.json \| jq '.permissions'` |
+| View user settings | `cat ~/.claude/settings.json \| jq '.permissions'` |
+| Check merged permissions | Review effective settings in Claude Code |
+| Validate JSON | `cat .claude/settings.json \| jq .` |
+
+## Quick Reference
+
+### Permission Priority
+
+Settings merge with this priority (highest wins):
+1. `.claude/settings.local.json` (local)
+2. `.claude/settings.json` (project)
+3. `~/.claude/settings.json` (user)
+
+### Wildcard Syntax
+
+| Syntax | Meaning |
+|--------|---------|
+| `Bash(cmd:*)` | Match `cmd` with any arguments |
+| `Bash(cmd arg:*)` | Match `cmd arg` with any following |
+| `Bash(./script.sh:*)` | Match specific script |
+
+### Deny Patterns
+
+Block specific commands:
+```json
+{
+  "permissions": {
+    "deny": [
+      "Bash(rm -rf:*)",
+      "Bash(sudo:*)",
+      "Bash(chmod 777:*)"
+    ]
+  }
+}
+```
+
+## Error Handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Permission denied | Pattern doesn't match | Add more specific pattern |
+| Shell operator blocked | Contains `&&`, `\|`, etc. | Use script wrapper |
+| Settings not applied | Wrong file location | Check path and syntax |
+| JSON parse error | Invalid JSON | Validate with `jq .` |
+
+## Best Practices
+
+1. **Start restrictive** - Add permissions as needed
+2. **Use project settings** - Keep team aligned
+3. **Avoid broad Bash** - Use specific patterns
+4. **Script compound commands** - For `&&` and `\|` workflows
+5. **Review periodically** - Remove unused permissions


### PR DESCRIPTION
Updates multiple plugins based on changelog review findings:

hooks-plugin:
- Add SubagentStart hook event with input modification
- Document frontmatter hooks support for skills/commands

agent-patterns-plugin:
- New custom-agent-definitions skill with context:fork and disallowedTools
- Add SDK migration guidance for @anthropic-ai/claude-agent-sdk

configure-plugin:
- New claude-security-settings skill for wildcard permissions
- Document shell operator protections

.claude/rules:
- Update agentic-permissions.md with shell operator protections
- Update skill-development.md with skills/commands merge info

Closes #78