### PR TITLE
Fix blueprint-plugin installation error

### DIFF
--- a/blueprint-plugin/hooks.json
+++ b/blueprint-plugin/hooks.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Blueprint plugin validation hooks - see docs/hook-design-decisions.md",
-  "PreToolUse": [
+  "hooks": {
+    "PreToolUse": [
     {
       "matcher": "Write(docs/prps/**)",
       "hooks": [
@@ -53,4 +54,5 @@
       ]
     }
   ]
+  }
 }


### PR DESCRIPTION
When hooks.json is referenced via "hooks": "./hooks.json" in plugin.json, Claude Code expects the hook definitions to be nested under a "hooks" key. The previous structure had PreToolUse at the root level, causing the error: "Invalid input: expected record, received undefined" at path ["hooks"]