### PR TITLE
feat: add model specification to all skills and commands

### DIFF
--- a/.claude/rules/skill-development.md
+++ b/.claude/rules/skill-development.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-20
-modified: 2026-01-20
-reviewed: 2026-01-20
+modified: 2026-01-22
+reviewed: 2026-01-22
 ---
 
 # Skill Development
@@ -47,6 +47,7 @@ Skills live in `plugins/<plugin-name>/skills/<skill-name>/skill.md`.
 
 ```yaml
 ---
+model: <opus|haiku>
 name: <Skill Name>
 description: <1-2 sentence description of capability>
 allowed-tools: <Comma-separated list of tools>
@@ -55,6 +56,20 @@ modified: YYYY-MM-DD
 reviewed: YYYY-MM-DD
 ---
 ```
+
+### Model Selection
+
+Choose the appropriate model based on task complexity:
+
+| Model | Use For |
+|-------|---------|
+| `opus` | Complex reasoning, architecture, code review, debugging methodology, security analysis, advanced testing theory |
+| `haiku` | Simple CLI operations, formatting, configuration, status checks, standard workflows |
+
+**Guidelines:**
+- Default to `haiku` for straightforward, mechanical tasks
+- Use `opus` when the skill requires planning, analysis, or complex decision-making
+- Consider: "Does this need deep reasoning or pattern matching?"
 
 ### Date Fields
 
@@ -141,6 +156,7 @@ Commands live in `plugins/<plugin-name>/commands/<command-name>.md` or nested in
 
 ```yaml
 ---
+model: <opus|haiku>
 description: <What the command does>
 args: <argument specification>
 allowed-tools: <Comma-separated list>
@@ -150,6 +166,8 @@ modified: YYYY-MM-DD
 reviewed: YYYY-MM-DD
 ---
 ```
+
+The `model` field uses the same selection criteria as skills (see Model Selection above).
 
 ### Content Structure
 

--- a/accessibility-plugin/skills/accessibility-implementation/SKILL.md
+++ b/accessibility-plugin/skills/accessibility-implementation/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/accessibility-plugin/skills/design-tokens/SKILL.md
+++ b/accessibility-plugin/skills/design-tokens/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/agent-patterns-plugin/commands/check-negative-examples.md
+++ b/agent-patterns-plugin/commands/check-negative-examples.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/agent-patterns-plugin/commands/delegate.md
+++ b/agent-patterns-plugin/commands/delegate.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/agent-patterns-plugin/commands/meta/assimilate.md
+++ b/agent-patterns-plugin/commands/meta/assimilate.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/agent-patterns-plugin/commands/meta/audit.md
+++ b/agent-patterns-plugin/commands/meta/audit.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/agent-patterns-plugin/commands/workflow-primer.md
+++ b/agent-patterns-plugin/commands/workflow-primer.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-26
 reviewed: 2025-12-26

--- a/agent-patterns-plugin/skills/agent-coordination-patterns/SKILL.md
+++ b/agent-patterns-plugin/skills/agent-coordination-patterns/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/agent-patterns-plugin/skills/agent-file-coordination/SKILL.md
+++ b/agent-patterns-plugin/skills/agent-file-coordination/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/agent-patterns-plugin/skills/agent-handoff-markers/SKILL.md
+++ b/agent-patterns-plugin/skills/agent-handoff-markers/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-26
 reviewed: 2025-12-26

--- a/agent-patterns-plugin/skills/claude-hooks-configuration/SKILL.md
+++ b/agent-patterns-plugin/skills/claude-hooks-configuration/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 name: Claude Code Hooks Configuration
 description: Configure Claude Code lifecycle hooks with proper timeout settings to prevent hook cancellation errors.
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite

--- a/agent-patterns-plugin/skills/command-context-patterns/SKILL.md
+++ b/agent-patterns-plugin/skills/command-context-patterns/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/agent-patterns-plugin/skills/custom-agent-definitions/SKILL.md
+++ b/agent-patterns-plugin/skills/custom-agent-definitions/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 name: custom-agent-definitions
 description: |
   Define and configure custom agents in Claude Code. Covers context forking,

--- a/agent-patterns-plugin/skills/delegation-first/SKILL.md
+++ b/agent-patterns-plugin/skills/delegation-first/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2026-01-21
 modified: 2026-01-21
 reviewed: 2026-01-21

--- a/agent-patterns-plugin/skills/mcp-management/SKILL.md
+++ b/agent-patterns-plugin/skills/mcp-management/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/agent-patterns-plugin/skills/multi-agent-workflows/SKILL.md
+++ b/agent-patterns-plugin/skills/multi-agent-workflows/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/api-plugin/commands/api-tests.md
+++ b/api-plugin/commands/api-tests.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/api-plugin/skills/api-testing/SKILL.md
+++ b/api-plugin/skills/api-testing/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/bevy-plugin/skills/bevy-ecs-patterns/skill.md
+++ b/bevy-plugin/skills/bevy-ecs-patterns/skill.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/bevy-plugin/skills/bevy-game-engine/skill.md
+++ b/bevy-plugin/skills/bevy-game-engine/skill.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/blog-plugin/commands/blog-post.md
+++ b/blog-plugin/commands/blog-post.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 description: Create a blog post about your work with guided prompts and templates
 args: [type] [--project <name>] [--title <title>]
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, TodoWrite, AskUserQuestion

--- a/blog-plugin/skills/blog-post-writing/skill.md
+++ b/blog-plugin/skills/blog-post-writing/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 name: Blog Post Writing
 description: |
   Consistent style guide for writing blog posts about projects and technical work.

--- a/blueprint-plugin/commands/blueprint-adr-validate.md
+++ b/blueprint-plugin/commands/blueprint-adr-validate.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2026-01-15
 modified: 2026-01-18
 reviewed: 2026-01-15

--- a/blueprint-plugin/commands/blueprint-adr.md
+++ b/blueprint-plugin/commands/blueprint-adr.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-22
 modified: 2026-01-15
 reviewed: 2025-12-22

--- a/blueprint-plugin/commands/blueprint-claude-md.md
+++ b/blueprint-plugin/commands/blueprint-claude-md.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-17
 modified: 2026-01-09
 reviewed: 2025-12-17

--- a/blueprint-plugin/commands/blueprint-curate-docs.md
+++ b/blueprint-plugin/commands/blueprint-curate-docs.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2026-01-09
 reviewed: 2025-12-16

--- a/blueprint-plugin/commands/blueprint-execute.md
+++ b/blueprint-plugin/commands/blueprint-execute.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2026-01-14
 modified: 2026-01-17
 reviewed: 2026-01-14

--- a/blueprint-plugin/commands/blueprint-feature-tracker-status.md
+++ b/blueprint-plugin/commands/blueprint-feature-tracker-status.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2026-01-02
 modified: 2026-01-09
 reviewed: 2026-01-02

--- a/blueprint-plugin/commands/blueprint-feature-tracker-sync.md
+++ b/blueprint-plugin/commands/blueprint-feature-tracker-sync.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2026-01-02
 modified: 2026-01-09
 reviewed: 2026-01-02

--- a/blueprint-plugin/commands/blueprint-generate-commands.md
+++ b/blueprint-plugin/commands/blueprint-generate-commands.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-01-09
 reviewed: 2025-01-09

--- a/blueprint-plugin/commands/blueprint-generate-rules.md
+++ b/blueprint-plugin/commands/blueprint-generate-rules.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-01-09
 reviewed: 2025-01-09

--- a/blueprint-plugin/commands/blueprint-import-plans.md
+++ b/blueprint-plugin/commands/blueprint-import-plans.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2026-01-15
 modified: 2026-01-15
 reviewed: 2026-01-15

--- a/blueprint-plugin/commands/blueprint-init.md
+++ b/blueprint-plugin/commands/blueprint-init.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2026-01-17
 reviewed: 2026-01-17

--- a/blueprint-plugin/commands/blueprint-prd.md
+++ b/blueprint-plugin/commands/blueprint-prd.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-22
 modified: 2026-01-09
 reviewed: 2025-12-22

--- a/blueprint-plugin/commands/blueprint-promote.md
+++ b/blueprint-plugin/commands/blueprint-promote.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-22
 modified: 2026-01-09
 reviewed: 2025-12-22

--- a/blueprint-plugin/commands/blueprint-prp-create.md
+++ b/blueprint-plugin/commands/blueprint-prp-create.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2026-01-17
 reviewed: 2025-12-16

--- a/blueprint-plugin/commands/blueprint-prp-execute.md
+++ b/blueprint-plugin/commands/blueprint-prp-execute.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2026-01-17
 reviewed: 2025-12-16

--- a/blueprint-plugin/commands/blueprint-rules.md
+++ b/blueprint-plugin/commands/blueprint-rules.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-17
 modified: 2026-01-09
 reviewed: 2025-12-17

--- a/blueprint-plugin/commands/blueprint-status.md
+++ b/blueprint-plugin/commands/blueprint-status.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-17
 modified: 2026-01-15
 reviewed: 2025-12-22

--- a/blueprint-plugin/commands/blueprint-sync-ids.md
+++ b/blueprint-plugin/commands/blueprint-sync-ids.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2026-01-20
 modified: 2026-01-20
 reviewed: 2026-01-20

--- a/blueprint-plugin/commands/blueprint-sync.md
+++ b/blueprint-plugin/commands/blueprint-sync.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-22
 modified: 2026-01-09
 reviewed: 2025-12-22

--- a/blueprint-plugin/commands/blueprint-upgrade.md
+++ b/blueprint-plugin/commands/blueprint-upgrade.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-17
 modified: 2026-01-09
 reviewed: 2026-01-09

--- a/blueprint-plugin/commands/blueprint-work-order.md
+++ b/blueprint-plugin/commands/blueprint-work-order.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2026-01-09
 reviewed: 2025-12-26

--- a/blueprint-plugin/skills/adr-relationships/skill.md
+++ b/blueprint-plugin/skills/adr-relationships/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 name: ADR Relationships
 description: Domain analysis, conflict detection, and relationship validation for Architecture Decision Records. Use when creating or validating ADRs to ensure consistency.
 allowed-tools: Bash, Read, Grep, Glob, TodoWrite

--- a/blueprint-plugin/skills/blueprint-development/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-development/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2026-01-09
 reviewed: 2025-12-26

--- a/blueprint-plugin/skills/blueprint-migration/skill.md
+++ b/blueprint-plugin/skills/blueprint-migration/skill.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 name: Blueprint Migration
 description: Versioned migration procedures for upgrading blueprint structure between format versions
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion, TodoWrite

--- a/blueprint-plugin/skills/confidence-scoring/SKILL.md
+++ b/blueprint-plugin/skills/confidence-scoring/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/blueprint-plugin/skills/document-detection/skill.md
+++ b/blueprint-plugin/skills/document-detection/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2026-01-09
 modified: 2026-01-15
 reviewed: 2026-01-09

--- a/blueprint-plugin/skills/document-linking/skill.md
+++ b/blueprint-plugin/skills/document-linking/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2026-01-20
 modified: 2026-01-20
 reviewed: 2026-01-20

--- a/blueprint-plugin/skills/feature-tracking/SKILL.md
+++ b/blueprint-plugin/skills/feature-tracking/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2026-01-02
 modified: 2026-01-09
 reviewed: 2026-01-02

--- a/code-quality-plugin/commands/code/antipatterns.md
+++ b/code-quality-plugin/commands/code/antipatterns.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/code-quality-plugin/commands/code/refactor.md
+++ b/code-quality-plugin/commands/code/refactor.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/code-quality-plugin/commands/code/review.md
+++ b/code-quality-plugin/commands/code/review.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/code-quality-plugin/commands/docs/quality-check.md
+++ b/code-quality-plugin/commands/docs/quality-check.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2026-01-08
 modified: 2026-01-08
 reviewed: 2026-01-08

--- a/code-quality-plugin/commands/lint/check.md
+++ b/code-quality-plugin/commands/lint/check.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/code-quality-plugin/commands/refactor.md
+++ b/code-quality-plugin/commands/refactor.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/code-quality-plugin/skills/ast-grep-search/SKILL.md
+++ b/code-quality-plugin/skills/ast-grep-search/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/code-quality-plugin/skills/code-antipatterns-analysis/SKILL.md
+++ b/code-quality-plugin/skills/code-antipatterns-analysis/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/code-quality-plugin/skills/code-review-checklist/SKILL.md
+++ b/code-quality-plugin/skills/code-review-checklist/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 name: Code Review Checklist
 description: Structured code review approach covering security, quality, performance, and consistency.
 allowed-tools: Read, Grep, Glob

--- a/code-quality-plugin/skills/debugging-methodology/SKILL.md
+++ b/code-quality-plugin/skills/debugging-methodology/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 name: Debugging Methodology
 description: Systematic debugging approach with tool recommendations for memory, performance, and system-level issues.
 allowed-tools: Bash, Read, Grep, Glob

--- a/code-quality-plugin/skills/documentation-quality/SKILL.md
+++ b/code-quality-plugin/skills/documentation-quality/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 name: Documentation Quality Analysis
 description: Analyze and validate documentation quality for PRDs, ADRs, PRPs, CLAUDE.md, and .claude/rules/ to ensure standards compliance and freshness
 allowed-tools: Bash, Read, Grep, Glob, TodoWrite

--- a/code-quality-plugin/skills/linter-autofix/SKILL.md
+++ b/code-quality-plugin/skills/linter-autofix/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 name: Linter Autofix Patterns
 description: Cross-language linter autofix commands and common fix patterns for biome, ruff, clippy, shellcheck, and more.
 allowed-tools: Bash, Read, Edit, Grep

--- a/command-analytics-plugin/commands/analytics-clear.md
+++ b/command-analytics-plugin/commands/analytics-clear.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 description: Clear all analytics data and start fresh
 args: "[--confirm]"
 allowed-tools: Bash

--- a/command-analytics-plugin/commands/analytics-export.md
+++ b/command-analytics-plugin/commands/analytics-export.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 description: Export analytics data in various formats
 args: "[format] [output-file]"
 allowed-tools: Bash, Read

--- a/command-analytics-plugin/commands/analytics-report.md
+++ b/command-analytics-plugin/commands/analytics-report.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 description: Display command and skill usage analytics
 args: "[filter]"
 allowed-tools: Bash, Read

--- a/command-analytics-plugin/commands/analytics-unused.md
+++ b/command-analytics-plugin/commands/analytics-unused.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 description: Show commands and skills that have never been used
 args: ""
 allowed-tools: Bash, Read, Glob

--- a/communication-plugin/skills/google-chat-formatting/skill.md
+++ b/communication-plugin/skills/google-chat-formatting/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/communication-plugin/skills/ticket-drafting-guidelines/skill.md
+++ b/communication-plugin/skills/ticket-drafting-guidelines/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/all.md
+++ b/configure-plugin/commands/configure/all.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/api-tests.md
+++ b/configure-plugin/commands/configure/api-tests.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/cache-busting.md
+++ b/configure-plugin/commands/configure/cache-busting.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/container.md
+++ b/configure-plugin/commands/configure/container.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2026-01-19
 reviewed: 2026-01-19

--- a/configure-plugin/commands/configure/coverage.md
+++ b/configure-plugin/commands/configure/coverage.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/dead-code.md
+++ b/configure-plugin/commands/configure/dead-code.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/dockerfile.md
+++ b/configure-plugin/commands/configure/dockerfile.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2026-01-19
 reviewed: 2026-01-19

--- a/configure-plugin/commands/configure/docs.md
+++ b/configure-plugin/commands/configure/docs.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/editor.md
+++ b/configure-plugin/commands/configure/editor.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/feature-flags.md
+++ b/configure-plugin/commands/configure/feature-flags.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/formatting.md
+++ b/configure-plugin/commands/configure/formatting.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/github-pages.md
+++ b/configure-plugin/commands/configure/github-pages.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/integration-tests.md
+++ b/configure-plugin/commands/configure/integration-tests.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/justfile.md
+++ b/configure-plugin/commands/configure/justfile.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/linting.md
+++ b/configure-plugin/commands/configure/linting.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/load-tests.md
+++ b/configure-plugin/commands/configure/load-tests.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/makefile.md
+++ b/configure-plugin/commands/configure/makefile.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/mcp.md
+++ b/configure-plugin/commands/configure/mcp.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/memory-profiling.md
+++ b/configure-plugin/commands/configure/memory-profiling.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/package-management.md
+++ b/configure-plugin/commands/configure/package-management.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/pre-commit.md
+++ b/configure-plugin/commands/configure/pre-commit.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/readme.md
+++ b/configure-plugin/commands/configure/readme.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-17
 modified: 2025-12-17
 reviewed: 2025-12-17

--- a/configure-plugin/commands/configure/release-please.md
+++ b/configure-plugin/commands/configure/release-please.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-22
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/security.md
+++ b/configure-plugin/commands/configure/security.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/select.md
+++ b/configure-plugin/commands/configure/select.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-22
 modified: 2025-12-22
 reviewed: 2025-12-22

--- a/configure-plugin/commands/configure/sentry.md
+++ b/configure-plugin/commands/configure/sentry.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/skaffold.md
+++ b/configure-plugin/commands/configure/skaffold.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/status.md
+++ b/configure-plugin/commands/configure/status.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/tests.md
+++ b/configure-plugin/commands/configure/tests.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/ux-testing.md
+++ b/configure-plugin/commands/configure/ux-testing.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/commands/configure/workflows.md
+++ b/configure-plugin/commands/configure/workflows.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/skills/ci-workflows/SKILL.md
+++ b/configure-plugin/skills/ci-workflows/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/skills/claude-security-settings/SKILL.md
+++ b/configure-plugin/skills/claude-security-settings/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 name: claude-security-settings
 description: |
   Configure Claude Code security settings including permission wildcards, shell

--- a/configure-plugin/skills/go-feature-flag/SKILL.md
+++ b/configure-plugin/skills/go-feature-flag/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/skills/openfeature/SKILL.md
+++ b/configure-plugin/skills/openfeature/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/skills/pre-commit-standards/SKILL.md
+++ b/configure-plugin/skills/pre-commit-standards/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/skills/readme-standards/SKILL.md
+++ b/configure-plugin/skills/readme-standards/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-17
 modified: 2025-12-17
 reviewed: 2025-12-17

--- a/configure-plugin/skills/release-please-standards/SKILL.md
+++ b/configure-plugin/skills/release-please-standards/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/configure-plugin/skills/skaffold-standards/SKILL.md
+++ b/configure-plugin/skills/skaffold-standards/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/container-plugin/commands/deploy/handoff.md
+++ b/container-plugin/commands/deploy/handoff.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/container-plugin/commands/deploy/release.md
+++ b/container-plugin/commands/deploy/release.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/container-plugin/skills/container-development/SKILL.md
+++ b/container-plugin/skills/container-development/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2026-01-19
 reviewed: 2026-01-19

--- a/container-plugin/skills/go-containers/SKILL.md
+++ b/container-plugin/skills/go-containers/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2026-01-15
 modified: 2026-01-15
 reviewed: 2026-01-15

--- a/container-plugin/skills/nodejs-containers/SKILL.md
+++ b/container-plugin/skills/nodejs-containers/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2026-01-15
 modified: 2026-01-15
 reviewed: 2026-01-15

--- a/container-plugin/skills/python-containers/SKILL.md
+++ b/container-plugin/skills/python-containers/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2026-01-15
 modified: 2026-01-15
 reviewed: 2026-01-15

--- a/container-plugin/skills/skaffold-filesync/skill.md
+++ b/container-plugin/skills/skaffold-filesync/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 name: Skaffold File Sync
 description: |
   Fast iterative development with Skaffold file sync - copy changed files to running containers

--- a/container-plugin/skills/skaffold-orbstack/SKILL.md
+++ b/container-plugin/skills/skaffold-orbstack/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/container-plugin/skills/skaffold-testing/skill.md
+++ b/container-plugin/skills/skaffold-testing/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 name: Skaffold Testing
 description: |
   Container image validation with Skaffold test and verify stages. Covers container-structure-tests

--- a/documentation-plugin/commands/docs/decommission.md
+++ b/documentation-plugin/commands/docs/decommission.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/documentation-plugin/commands/docs/generate.md
+++ b/documentation-plugin/commands/docs/generate.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/documentation-plugin/commands/docs/knowledge-graph.md
+++ b/documentation-plugin/commands/docs/knowledge-graph.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/documentation-plugin/commands/docs/sync.md
+++ b/documentation-plugin/commands/docs/sync.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/documentation-plugin/skills/claude-blog-sources/SKILL.md
+++ b/documentation-plugin/skills/claude-blog-sources/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/git-plugin/commands/git/commit.md
+++ b/git-plugin/commands/git/commit.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2026-01-17
 reviewed: 2026-01-17

--- a/git-plugin/commands/git/fix-pr.md
+++ b/git-plugin/commands/git/fix-pr.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2026-01-17
 reviewed: 2026-01-17

--- a/git-plugin/commands/git/issue.md
+++ b/git-plugin/commands/git/issue.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2026-01-17
 reviewed: 2026-01-17

--- a/git-plugin/commands/git/maintain.md
+++ b/git-plugin/commands/git/maintain.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-01-16
 reviewed: 2025-01-16

--- a/git-plugin/skills/gh-cli-agentic/skill.md
+++ b/git-plugin/skills/gh-cli-agentic/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 name: gh-cli-agentic
 description: GitHub CLI commands optimized for AI agent workflows with JSON output and deterministic execution patterns.
 allowed-tools: Bash(gh pr:*), Bash(gh run:*), Bash(gh issue:*), Bash(gh repo:*), Bash(gh workflow:*), Bash(gh api:*), Read

--- a/git-plugin/skills/gh-workflow-monitoring/skill.md
+++ b/git-plugin/skills/gh-workflow-monitoring/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 name: gh-workflow-monitoring
 description: Monitor GitHub Actions workflow runs using blocking watch commands instead of polling with timeouts.
 allowed-tools: Bash(gh run:*), Bash(gh workflow:*), Bash(gh pr:*), Read

--- a/git-plugin/skills/git-branch-pr-workflow/SKILL.md
+++ b/git-plugin/skills/git-branch-pr-workflow/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2026-01-17
 reviewed: 2025-12-16

--- a/git-plugin/skills/git-cli-agentic/skill.md
+++ b/git-plugin/skills/git-cli-agentic/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 name: git-cli-agentic
 description: Git commands optimized for AI agent workflows with porcelain output and deterministic execution patterns.
 allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(git branch:*), Bash(git remote:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(git restore:*), Read

--- a/git-plugin/skills/git-commit-workflow/SKILL.md
+++ b/git-plugin/skills/git-commit-workflow/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2026-01-15
 reviewed: 2026-01-15

--- a/git-plugin/skills/git-commit/skill.md
+++ b/git-plugin/skills/git-commit/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2026-01-21
 modified: 2026-01-21
 reviewed: 2026-01-21

--- a/git-plugin/skills/git-pr/skill.md
+++ b/git-plugin/skills/git-pr/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2026-01-21
 modified: 2026-01-21
 reviewed: 2026-01-21

--- a/git-plugin/skills/git-push/skill.md
+++ b/git-plugin/skills/git-push/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2026-01-21
 modified: 2026-01-21
 reviewed: 2026-01-21

--- a/git-plugin/skills/git-repo-detection/SKILL.md
+++ b/git-plugin/skills/git-repo-detection/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/git-plugin/skills/git-security-checks/SKILL.md
+++ b/git-plugin/skills/git-security-checks/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/git-plugin/skills/github-issue-autodetect/skill.md
+++ b/git-plugin/skills/github-issue-autodetect/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2026-01-15
 modified: 2026-01-15
 reviewed: 2026-01-15

--- a/git-plugin/skills/github-labels/SKILL.md
+++ b/git-plugin/skills/github-labels/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/git-plugin/skills/release-please-configuration/SKILL.md
+++ b/git-plugin/skills/release-please-configuration/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-28
 modified: 2025-12-28
 reviewed: 2025-12-28

--- a/git-plugin/skills/release-please-pr-workflow/skill.md
+++ b/git-plugin/skills/release-please-pr-workflow/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2026-01-09
 modified: 2026-01-09
 reviewed: 2026-01-09

--- a/git-plugin/skills/release-please-protection/SKILL.md
+++ b/git-plugin/skills/release-please-protection/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/github-actions-plugin/commands/workflow/dev-zen.md
+++ b/github-actions-plugin/commands/workflow/dev-zen.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/github-actions-plugin/commands/workflow/dev.md
+++ b/github-actions-plugin/commands/workflow/dev.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/github-actions-plugin/skills/claude-code-github-workflows/skill.md
+++ b/github-actions-plugin/skills/claude-code-github-workflows/skill.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/github-actions-plugin/skills/github-actions-auth-security/skill.md
+++ b/github-actions-plugin/skills/github-actions-auth-security/skill.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/github-actions-plugin/skills/github-actions-inspection/skill.md
+++ b/github-actions-plugin/skills/github-actions-inspection/skill.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/github-actions-plugin/skills/github-actions-mcp-config/skill.md
+++ b/github-actions-plugin/skills/github-actions-mcp-config/skill.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/github-actions-plugin/skills/github-issue-search/skill.md
+++ b/github-actions-plugin/skills/github-issue-search/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-21
 reviewed: 2025-12-16

--- a/github-actions-plugin/skills/github-social-preview/skill.md
+++ b/github-actions-plugin/skills/github-social-preview/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-21
 reviewed: 2025-12-16

--- a/hooks-plugin/skills/hooks-configuration/SKILL.md
+++ b/hooks-plugin/skills/hooks-configuration/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 name: hooks-configuration
 description: |
   Claude Code hooks configuration and development. Covers hook lifecycle events,

--- a/kubernetes-plugin/skills/argocd-login/SKILL.md
+++ b/kubernetes-plugin/skills/argocd-login/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/kubernetes-plugin/skills/helm-chart-development/SKILL.md
+++ b/kubernetes-plugin/skills/helm-chart-development/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/kubernetes-plugin/skills/helm-debugging/SKILL.md
+++ b/kubernetes-plugin/skills/helm-debugging/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/kubernetes-plugin/skills/helm-release-management/SKILL.md
+++ b/kubernetes-plugin/skills/helm-release-management/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/kubernetes-plugin/skills/helm-release-recovery/SKILL.md
+++ b/kubernetes-plugin/skills/helm-release-recovery/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/kubernetes-plugin/skills/helm-values-management/SKILL.md
+++ b/kubernetes-plugin/skills/helm-values-management/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/kubernetes-plugin/skills/kubectl-debugging/SKILL.md
+++ b/kubernetes-plugin/skills/kubectl-debugging/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/kubernetes-plugin/skills/kubernetes-operations/SKILL.md
+++ b/kubernetes-plugin/skills/kubernetes-operations/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/langchain-plugin/commands/langchain-init.md
+++ b/langchain-plugin/commands/langchain-init.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 description: Initialize a new LangChain TypeScript project with recommended configuration
 args: [project-name]
 allowed-tools: Bash, Read, Write, Edit

--- a/langchain-plugin/skills/deep-agents/skill.md
+++ b/langchain-plugin/skills/deep-agents/skill.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 name: Deep Agents
 description: Deep Agents library for building complex, multi-step AI agents with planning, context management, and subagent delegation.
 allowed-tools: Bash, BashOutput, Read, Write, Edit, Grep, Glob, TodoWrite

--- a/langchain-plugin/skills/langchain-development/skill.md
+++ b/langchain-plugin/skills/langchain-development/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 name: LangChain Development
 description: LangChain JS/TS framework for building LLM-powered applications - models, chains, tools, and RAG patterns.
 allowed-tools: Bash, BashOutput, Read, Write, Edit, Grep, Glob, TodoWrite

--- a/langchain-plugin/skills/langgraph-agents/skill.md
+++ b/langchain-plugin/skills/langgraph-agents/skill.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 name: LangGraph Agents
 description: LangGraph framework for building stateful, multi-step AI agents with graph-based workflows, persistence, and human-in-the-loop support.
 allowed-tools: Bash, BashOutput, Read, Write, Edit, Grep, Glob, TodoWrite

--- a/networking-plugin/skills/dns-tools/skill.md
+++ b/networking-plugin/skills/dns-tools/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 name: DNS Tools
 description: Modern DNS query tools with focus on dog for readable, colorized output and modern protocol support (DoT/DoH).
 allowed-tools: Bash, Read, Grep, Glob, TodoWrite

--- a/networking-plugin/skills/http-load-testing/skill.md
+++ b/networking-plugin/skills/http-load-testing/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2026-01-01
 modified: 2026-01-01
 reviewed: 2026-01-01

--- a/networking-plugin/skills/layer2-discovery/skill.md
+++ b/networking-plugin/skills/layer2-discovery/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2026-01-01
 modified: 2026-01-01
 reviewed: 2026-01-01

--- a/networking-plugin/skills/network-diagnostics/skill.md
+++ b/networking-plugin/skills/network-diagnostics/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2026-01-01
 modified: 2026-01-01
 reviewed: 2026-01-01

--- a/networking-plugin/skills/network-discovery/skill.md
+++ b/networking-plugin/skills/network-discovery/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 name: Network Discovery
 description: Host and port discovery using RustScan for fast TCP scanning, arp-scan-rs for local network enumeration, and nmap for deep service analysis.
 allowed-tools: Bash, Read, Grep, Glob, TodoWrite

--- a/networking-plugin/skills/network-monitoring/skill.md
+++ b/networking-plugin/skills/network-monitoring/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2026-01-01
 modified: 2026-01-01
 reviewed: 2026-01-01

--- a/project-plugin/commands/changelog-review.md
+++ b/project-plugin/commands/changelog-review.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 description: Review Claude Code changelog for changes impacting plugins
 args: [--full] [--since <version>] [--update]
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, WebFetch, TodoWrite

--- a/project-plugin/commands/project/continue.md
+++ b/project-plugin/commands/project/continue.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-17
 reviewed: 2025-12-17

--- a/project-plugin/commands/project/init.md
+++ b/project-plugin/commands/project/init.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/project-plugin/commands/project/test-loop.md
+++ b/project-plugin/commands/project/test-loop.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-17
 reviewed: 2025-12-17

--- a/project-plugin/skills/changelog-review/SKILL.md
+++ b/project-plugin/skills/changelog-review/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 name: changelog-review
 description: |
   Analyze Claude Code changelog for changes that impact plugin development.

--- a/project-plugin/skills/project-discovery/SKILL.md
+++ b/project-plugin/skills/project-discovery/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/python-plugin/skills/basedpyright-type-checking/SKILL.md
+++ b/python-plugin/skills/basedpyright-type-checking/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/python-plugin/skills/pytest-advanced/SKILL.md
+++ b/python-plugin/skills/pytest-advanced/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/python-plugin/skills/python-code-quality/SKILL.md
+++ b/python-plugin/skills/python-code-quality/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/python-plugin/skills/python-development/SKILL.md
+++ b/python-plugin/skills/python-development/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/python-plugin/skills/python-packaging/SKILL.md
+++ b/python-plugin/skills/python-packaging/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/python-plugin/skills/python-testing/SKILL.md
+++ b/python-plugin/skills/python-testing/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/python-plugin/skills/ruff-formatting/SKILL.md
+++ b/python-plugin/skills/ruff-formatting/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/python-plugin/skills/ruff-integration/SKILL.md
+++ b/python-plugin/skills/ruff-integration/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/python-plugin/skills/ruff-linting/SKILL.md
+++ b/python-plugin/skills/ruff-linting/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/python-plugin/skills/uv-advanced-dependencies/SKILL.md
+++ b/python-plugin/skills/uv-advanced-dependencies/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/python-plugin/skills/uv-project-management/SKILL.md
+++ b/python-plugin/skills/uv-project-management/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/python-plugin/skills/uv-python-versions/SKILL.md
+++ b/python-plugin/skills/uv-python-versions/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/python-plugin/skills/uv-run/SKILL.md
+++ b/python-plugin/skills/uv-run/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/python-plugin/skills/uv-tool-management/SKILL.md
+++ b/python-plugin/skills/uv-tool-management/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/python-plugin/skills/uv-workspaces/SKILL.md
+++ b/python-plugin/skills/uv-workspaces/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/python-plugin/skills/vulture-dead-code/SKILL.md
+++ b/python-plugin/skills/vulture-dead-code/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/rust-plugin/skills/cargo-llvm-cov/SKILL.md
+++ b/rust-plugin/skills/cargo-llvm-cov/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/rust-plugin/skills/cargo-machete/SKILL.md
+++ b/rust-plugin/skills/cargo-machete/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/rust-plugin/skills/cargo-nextest/SKILL.md
+++ b/rust-plugin/skills/cargo-nextest/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/rust-plugin/skills/clippy-advanced/SKILL.md
+++ b/rust-plugin/skills/clippy-advanced/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/rust-plugin/skills/rust-development/SKILL.md
+++ b/rust-plugin/skills/rust-development/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/sync-plugin/commands/sync/daily.md
+++ b/sync-plugin/commands/sync/daily.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/sync-plugin/commands/sync/github-podio.md
+++ b/sync-plugin/commands/sync/github-podio.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/terraform-plugin/skills/infrastructure-terraform/SKILL.md
+++ b/terraform-plugin/skills/infrastructure-terraform/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2026-01-20
 reviewed: 2025-12-16

--- a/terraform-plugin/skills/tfc-list-runs/SKILL.md
+++ b/terraform-plugin/skills/tfc-list-runs/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/terraform-plugin/skills/tfc-plan-json/SKILL.md
+++ b/terraform-plugin/skills/tfc-plan-json/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/terraform-plugin/skills/tfc-run-logs/SKILL.md
+++ b/terraform-plugin/skills/tfc-run-logs/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/terraform-plugin/skills/tfc-run-status/SKILL.md
+++ b/terraform-plugin/skills/tfc-run-status/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/terraform-plugin/skills/tfc-workspace-runs/SKILL.md
+++ b/terraform-plugin/skills/tfc-workspace-runs/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/testing-plugin/commands/test/analyze.md
+++ b/testing-plugin/commands/test/analyze.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/testing-plugin/commands/test/consult.md
+++ b/testing-plugin/commands/test/consult.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/testing-plugin/commands/test/focus.md
+++ b/testing-plugin/commands/test/focus.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2026-01-19
 modified: 2026-01-19
 reviewed: 2026-01-19

--- a/testing-plugin/commands/test/full.md
+++ b/testing-plugin/commands/test/full.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/testing-plugin/commands/test/quick.md
+++ b/testing-plugin/commands/test/quick.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/testing-plugin/commands/test/report.md
+++ b/testing-plugin/commands/test/report.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/testing-plugin/commands/test/run.md
+++ b/testing-plugin/commands/test/run.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/testing-plugin/commands/test/setup.md
+++ b/testing-plugin/commands/test/setup.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/testing-plugin/skills/hypothesis-testing/SKILL.md
+++ b/testing-plugin/skills/hypothesis-testing/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/testing-plugin/skills/mutation-testing/SKILL.md
+++ b/testing-plugin/skills/mutation-testing/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/testing-plugin/skills/playwright-testing/SKILL.md
+++ b/testing-plugin/skills/playwright-testing/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/testing-plugin/skills/property-based-testing/SKILL.md
+++ b/testing-plugin/skills/property-based-testing/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/testing-plugin/skills/test-quality-analysis/SKILL.md
+++ b/testing-plugin/skills/test-quality-analysis/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/testing-plugin/skills/test-tier-selection/SKILL.md
+++ b/testing-plugin/skills/test-tier-selection/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/testing-plugin/skills/vitest-testing/SKILL.md
+++ b/testing-plugin/skills/vitest-testing/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/tools-plugin/commands/deps/install.md
+++ b/tools-plugin/commands/deps/install.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/tools-plugin/commands/generate-image.md
+++ b/tools-plugin/commands/generate-image.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/tools-plugin/commands/handoffs.md
+++ b/tools-plugin/commands/handoffs.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/tools-plugin/skills/binary-analysis/SKILL.md
+++ b/tools-plugin/skills/binary-analysis/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 name: Binary Analysis
 description: Reverse engineering and binary exploration using strings, binwalk, hexdump, and related tools.
 allowed-tools: Bash, Read, Grep, Glob

--- a/tools-plugin/skills/d2-diagrams/skill.md
+++ b/tools-plugin/skills/d2-diagrams/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 name: D2 Diagrams
 description: Generate diagrams from declarative text using D2 - modern text-to-diagram language with automatic layouts, themes, and advanced styling.
 allowed-tools: Bash, Read, Write, Grep, Glob, TodoWrite

--- a/tools-plugin/skills/fd-file-finding/SKILL.md
+++ b/tools-plugin/skills/fd-file-finding/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2026-01-21
 reviewed: 2025-12-16

--- a/tools-plugin/skills/imagemagick-conversion/SKILL.md
+++ b/tools-plugin/skills/imagemagick-conversion/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/tools-plugin/skills/jq-json-processing/SKILL.md
+++ b/tools-plugin/skills/jq-json-processing/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/tools-plugin/skills/justfile-expert/SKILL.md
+++ b/tools-plugin/skills/justfile-expert/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/tools-plugin/skills/mermaid-diagrams/skill.md
+++ b/tools-plugin/skills/mermaid-diagrams/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 name: Mermaid Diagrams
 description: Generate diagrams from text using Mermaid CLI (mmdc) - flowcharts, sequence diagrams, ERDs, class diagrams, state machines, and more.
 allowed-tools: Bash, Read, Write, Grep, Glob, TodoWrite

--- a/tools-plugin/skills/nushell-data-processing/skill.md
+++ b/tools-plugin/skills/nushell-data-processing/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-25
 modified: 2025-12-25
 reviewed: 2025-12-25

--- a/tools-plugin/skills/rg-code-search/SKILL.md
+++ b/tools-plugin/skills/rg-code-search/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2026-01-21
 reviewed: 2025-12-16

--- a/tools-plugin/skills/shell-expert/SKILL.md
+++ b/tools-plugin/skills/shell-expert/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/tools-plugin/skills/yq-yaml-processing/SKILL.md
+++ b/tools-plugin/skills/yq-yaml-processing/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/typescript-plugin/commands/bun/add.md
+++ b/typescript-plugin/commands/bun/add.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 description: Add package dependency with Bun
 args: <package> [--dev] [--exact]
 allowed-tools: Bash, Read

--- a/typescript-plugin/commands/bun/build.md
+++ b/typescript-plugin/commands/bun/build.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 description: Bundle or compile with Bun
 args: <entry> [--compile] [--minify]
 allowed-tools: Bash, Read

--- a/typescript-plugin/commands/bun/install.md
+++ b/typescript-plugin/commands/bun/install.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 description: Install dependencies with Bun package manager
 allowed-tools: Bash, Read
 created: 2025-12-20

--- a/typescript-plugin/commands/bun/outdated.md
+++ b/typescript-plugin/commands/bun/outdated.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 description: Check for outdated dependencies
 allowed-tools: Bash, Read
 created: 2025-12-20

--- a/typescript-plugin/commands/bun/publish.md
+++ b/typescript-plugin/commands/bun/publish.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 description: Publish package to npm with Bun build
 args: [--dry-run] [--access <level>] [--provenance]
 allowed-tools: Bash, Read

--- a/typescript-plugin/commands/bun/test.md
+++ b/typescript-plugin/commands/bun/test.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 description: Run tests with Bun test runner
 args: [pattern] [--coverage] [--bail] [--watch]
 allowed-tools: Bash, BashOutput, Read

--- a/typescript-plugin/skills/biome-tooling/SKILL.md
+++ b/typescript-plugin/skills/biome-tooling/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/typescript-plugin/skills/bun-development/skill.md
+++ b/typescript-plugin/skills/bun-development/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 name: Bun Development
 description: Bun runtime for running scripts, testing, building, and project initialization - optimized flags for fast feedback and minimal output.
 allowed-tools: Bash, BashOutput, Read, Write, Edit, Grep, Glob, TodoWrite

--- a/typescript-plugin/skills/bun-lockfile-update/SKILL.md
+++ b/typescript-plugin/skills/bun-lockfile-update/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/typescript-plugin/skills/bun-package-manager/skill.md
+++ b/typescript-plugin/skills/bun-package-manager/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 name: Bun Package Manager
 description: Fast JavaScript package management with Bun - install, add, remove, update dependencies with optimized CLI flags for agentic workflows.
 allowed-tools: Bash, Read, Grep, Glob, TodoWrite

--- a/typescript-plugin/skills/bun-publishing/skill.md
+++ b/typescript-plugin/skills/bun-publishing/skill.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 name: Bun npm Publishing
 description: Publish packages to npm with Bun - package.json configuration, CLI packaging, provenance signing, and release automation.
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite

--- a/typescript-plugin/skills/knip-dead-code/SKILL.md
+++ b/typescript-plugin/skills/knip-dead-code/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/typescript-plugin/skills/nodejs-development/SKILL.md
+++ b/typescript-plugin/skills/nodejs-development/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/typescript-plugin/skills/typescript-strict/SKILL.md
+++ b/typescript-plugin/skills/typescript-strict/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16


### PR DESCRIPTION
Add model field (opus/haiku) to all skill and command frontmatters
based on task complexity:

- opus: Complex reasoning tasks (architecture, code review, debugging,
  security analysis, advanced testing theory)
- haiku: Simple operations (CLI wrappers, formatting, configuration,
  status checks, standard workflows)

Also update skill-development.md rule to document the new model field
and provide guidelines for choosing between opus and haiku.

Total: 134 skills + 105 commands updated