### PR TITLE
Support main-branch development pattern in git-pr and git-push

### DIFF
--- a/git-plugin/skills/git-push/skill.md
+++ b/git-plugin/skills/git-push/skill.md
@@ -1,8 +1,8 @@
 ---
 model: haiku
 created: 2026-01-21
-modified: 2026-01-21
-reviewed: 2026-01-21
+modified: 2026-01-23
+reviewed: 2026-01-23
 name: git-push
 description: |
   Push local commits to remote repositories. Handles branch tracking, upstream setup,
@@ -84,6 +84,19 @@ For regular commits on a tracked branch:
 git push
 ```
 
+### Push to Remote Feature Branch (Main-Branch Development)
+
+When on main with commits to push for a PR, push directly to a remote feature branch without creating a local branch:
+```bash
+# Push main commits to a new remote branch
+git push origin main:<remote-branch-name>
+
+# Push specific commit range to a remote branch
+git push origin <start>^..<end>:<remote-branch-name>
+```
+
+This avoids local branch juggling. After the PR merges, a `git pull` on main syncs cleanly.
+
 ### First Push (New Branch)
 
 For branches without upstream:
@@ -114,13 +127,16 @@ git push --force-with-lease
 3. **No uncommitted changes** - Clean working tree
 4. **Remote reachable** - Network connectivity
 
-### Protected Branch Warning
+### Main Branch Push Behavior
 
 ```bash
 branch=$(git branch --show-current)
 if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
-  echo "WARNING: Pushing directly to $branch"
-  # Prompt for confirmation
+  # Main-branch development: push to remote feature branch for PRs
+  # git push origin main:<feature-branch>  ← expected workflow
+
+  # Direct push to remote main: warn unless explicitly requested
+  # git push origin main  ← requires confirmation
 fi
 ```
 
@@ -134,6 +150,7 @@ This skill **pushes commits only**. For full workflows:
 | "commit and push" | git-commit → git-push |
 | "push and create PR" | git-push → git-pr |
 | "commit, push, and PR" | git-commit → git-push → git-pr |
+| "create PR" (on main) | git-pr handles push + PR creation automatically |
 
 ## Output
 
@@ -178,6 +195,8 @@ Create a feature branch and submit a pull request instead.
 | Scenario | Command |
 |----------|---------|
 | Standard push | `git push` |
+| Main to remote feature branch | `git push origin main:<branch-name>` |
+| Commit range to remote branch | `git push origin <start>^..<end>:<branch>` |
 | New branch | `git push -u origin $(git branch --show-current)` |
 | With tags | `git push --follow-tags` |
 | After rebase | `git push --force-with-lease` |


### PR DESCRIPTION
## Summary

This PR adds support for a main-branch development workflow where commits can be made directly on `main` and automatically pushed to a remote feature branch for PR creation, eliminating the need for local branch juggling.

## Key Changes

**git-pr skill:**
- Added new section (1b) to handle commits on main by automatically pushing to a generated remote feature branch
- Branch name generation from conventional commit messages (e.g., `feat(auth): add OAuth` → `feat/auth-add-oauth`)
- Updated commit analysis to compare against `origin/main` when on main, vs `main` for feature branches
- Modified PR creation to use `--head` flag when on main to target the remote feature branch
- Updated allowed-tools to include `git push`, `git fetch`, and `git rev-list` for main-branch workflow support
- Enhanced error handling to distinguish between feature branches and main branch scenarios
- Updated composability table to reflect automatic push behavior on main

**git-push skill:**
- Added new section documenting push to remote feature branch pattern (`git push origin main:<remote-branch-name>`)
- Updated main branch push behavior documentation to explain the main-branch development workflow
- Added examples for pushing commit ranges to remote branches
- Updated composability to note that `git-pr` on main handles push + PR creation automatically

## Implementation Details

- When on main with commits ahead of `origin/main`, the workflow automatically generates a feature branch name from the primary commit's conventional commit format
- Commits are pushed to the remote feature branch without creating a local branch, keeping the working directory clean
- After PR merge, a simple `git pull` on main syncs cleanly via fast-forward since commits exist on both local and remote
- No history rewriting or branch juggling required
- Updated timestamps (modified/reviewed: 2026-01-23) across both skill files