### PR TITLE
Add id-token write permission to GitHub Actions workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,6 +8,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   review:

--- a/.github/workflows/skill-quality-review.yml
+++ b/.github/workflows/skill-quality-review.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 jobs:
   skill-quality:


### PR DESCRIPTION
## Summary
Added `id-token: write` permission to two GitHub Actions workflows to enable OIDC token generation capabilities.

## Changes
- **claude-code-review.yml**: Added `id-token: write` permission to the workflow permissions
- **skill-quality-review.yml**: Added `id-token: write` permission to the workflow permissions

## Details
The `id-token: write` permission allows these workflows to request and use OpenID Connect (OIDC) tokens from GitHub. This is typically needed for:
- Authenticating with external services (AWS, Azure, GCP, etc.) without storing long-lived credentials
- Implementing secure, keyless authentication patterns in CI/CD pipelines

This change follows GitHub's security best practices for workflow authentication.