### PR TITLE
docs: add planning documents for reusable GitHub workflows

### DIFF
--- a/docs/adrs/0014-reusable-workflows-in-repository.md
+++ b/docs/adrs/0014-reusable-workflows-in-repository.md
@@ -1,0 +1,165 @@
+# ADR-0014: Reusable GitHub Workflows in Plugin Repository
+
+---
+date: 2026-01-25
+created: 2026-01-25
+modified: 2026-01-25
+status: Accepted
+deciders: claude-plugins team
+domain: ci-cd
+relates-to:
+  - PRD-002
+github-issues: []
+---
+
+## Context
+
+We need to provide reusable GitHub Action workflows that leverage Claude Code and the claude-plugins ecosystem for CI/CD automation. The key architectural decision is where these workflows should live:
+
+1. **In this repository** alongside the plugins
+2. **In a separate repository** dedicated to workflows
+3. **In consumer repositories** via templates or generators
+
+GitHub's reusable workflows have specific constraints documented in [official documentation](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows):
+
+- All reusable workflows must be in `.github/workflows/` (no subdirectories)
+- Max 50 unique reusable workflows per caller
+- Max 10 levels of nesting depth
+- Environment variables do NOT propagate from caller to called workflow
+- Environment secrets cannot be passed via `workflow_call`
+
+## Decision
+
+**Keep reusable workflows in this repository (`claude-plugins`)** alongside the plugins they use.
+
+### Rationale
+
+| Benefit | Explanation |
+|---------|-------------|
+| **Coupled versioning** | Workflow updates ship with plugin updates |
+| **Single source of truth** | No version coordination between repos |
+| **Easier testing** | Test workflow changes against plugin changes in same PR |
+| **Simpler consumption** | Users reference one repo for both plugins and workflows |
+| **Plugin access** | Workflows can reference plugins via `plugin_marketplaces` |
+
+### File Organization
+
+Since subdirectories are not supported, use **naming prefixes** to organize:
+
+```
+.github/workflows/
+├── reusable-security-owasp.yml       # Reusable (external consumption)
+├── reusable-security-secrets.yml
+├── reusable-a11y-wcag.yml
+├── reusable-quality-code-smell.yml
+├── reusable-quality-typescript.yml
+├── ...
+├── release-please.yml                 # Internal (this repo only)
+├── skill-quality-review.yml
+└── claude.yml
+```
+
+**Convention:**
+- `reusable-*` prefix = callable from other repositories
+- No prefix = internal to this repository
+
+### Consumer Reference Pattern
+
+External repositories consume workflows via:
+
+```yaml
+jobs:
+  security:
+    uses: laurigates/claude-plugins/.github/workflows/reusable-security-owasp.yml@v2.0.0
+    secrets: inherit
+```
+
+**Reference options** (in order of recommendation):
+
+| Method | Example | Use When |
+|--------|---------|----------|
+| Release tag | `@v2.0.0` | Production use (recommended) |
+| Commit SHA | `@a1b2c3d4...` | Maximum security/reproducibility |
+| Branch | `@main` | Development/testing only |
+
+### Secrets Handling
+
+**Option 1: Inherit (same organization)**
+```yaml
+secrets: inherit
+```
+
+**Option 2: Pass explicitly**
+```yaml
+secrets:
+  CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+```
+
+## Consequences
+
+### Positive
+
+- **Version lock**: Consumers can pin to a specific release tag for stability
+- **Atomic updates**: Plugin and workflow changes are tested together
+- **Discoverability**: Users find everything in one place
+- **Plugin leverage**: Workflows automatically load plugins from marketplace
+
+### Negative
+
+- **Larger repository**: More files in `.github/workflows/`
+- **Flat structure**: No subdirectories for organization (GitHub constraint)
+- **Release coupling**: Workflow-only fixes still require a release
+- **Naming discipline**: Must maintain `reusable-*` convention manually
+
+### Mitigations
+
+| Issue | Mitigation |
+|-------|------------|
+| Flat structure | Consistent naming prefixes (`reusable-security-*`, `reusable-a11y-*`) |
+| Release coupling | Minor version bumps for workflow-only changes |
+| Naming discipline | PR review checklist, CI validation |
+
+## Options Considered
+
+### Option 1: Workflows in Plugin Repository (CHOSEN)
+
+**Pros:**
+- Coupled versioning
+- Single source of truth
+- Plugin access via marketplace
+
+**Cons:**
+- Larger repository
+- Flat workflow directory
+
+### Option 2: Separate Workflows Repository
+
+**Pros:**
+- Clean separation of concerns
+- Independent release cycle
+
+**Cons:**
+- Version coordination between repos
+- Plugin version pinning complexity
+- Two repos for users to track
+
+### Option 3: Template Generator
+
+**Pros:**
+- Customizable per consumer
+- Full control in consumer repo
+
+**Cons:**
+- No centralized updates
+- Drift between implementations
+- Maintenance burden on consumers
+
+## Related ADRs
+
+- [ADR-0001: Plugin-Based Architecture](0001-plugin-based-architecture.md) - Foundation for plugin ecosystem
+- [ADR-0004: Marketplace Registry Model](0004-marketplace-registry-model.md) - How workflows load plugins
+
+## References
+
+- [GitHub: Reusing workflows](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows)
+- [GitHub Blog: Using reusable workflows](https://github.blog/developer-skills/github/using-reusable-workflows-github-actions/)

--- a/docs/prds/reusable-github-workflows.md
+++ b/docs/prds/reusable-github-workflows.md
@@ -1,0 +1,267 @@
+# Reusable GitHub Action Workflows - Product Requirements Document
+
+---
+id: PRD-002
+created: 2026-01-25
+modified: 2026-01-25
+status: Draft
+version: "1.0"
+relates-to:
+  - ADR-0014
+github-issues: []
+---
+
+## Executive Summary
+
+### Problem Statement
+
+Organizations using Claude Code lack standardized, reusable CI/CD workflows for common code quality, security, and accessibility checks. Teams repeatedly build similar GitHub Actions workflows from scratch, leading to inconsistent quality gates, missed security vulnerabilities, and duplicated effort across repositories.
+
+### Proposed Solution
+
+A collection of 22 reusable GitHub Action workflows powered by Claude Code's haiku model, organized by category (Security, Accessibility, Code Quality, Documentation, Testing, Infrastructure, Maintenance). These workflows are designed for low context usage, fast execution, and actionable output with file:line references.
+
+### Business Impact
+
+- **Reduced setup time**: Teams adopt pre-built workflows instead of creating from scratch
+- **Consistent quality gates**: Standardized security and accessibility checks across repositories
+- **Cost efficiency**: Haiku model with low turn counts minimizes API costs
+- **Plugin leverage**: Workflows utilize existing claude-plugins skills for comprehensive analysis
+- **Reusability**: Single source of truth with versioned releases for external consumption
+
+---
+
+## Stakeholders & Personas
+
+### Stakeholder Matrix
+
+| Role | Name/Team | Responsibility | Contact |
+|------|-----------|----------------|---------|
+| Product Owner | claude-plugins Team | Feature requirements and priorities | - |
+| Developer | Plugin Contributors | Implementation and testing | - |
+| Consumer | External Repository Owners | Adopt and customize workflows | - |
+
+### User Personas
+
+#### Primary: DevOps Engineer
+
+- **Description**: Engineer responsible for CI/CD pipeline configuration
+- **Needs**: Ready-to-use workflows with minimal configuration
+- **Pain Points**: Building Claude integrations from scratch, inconsistent quality gates
+- **Goals**: Standardized, maintainable CI/CD with Claude-powered analysis
+
+#### Secondary: Security-Conscious Developer
+
+- **Description**: Developer prioritizing security and accessibility in PRs
+- **Needs**: Automated security scanning, WCAG compliance checks
+- **Pain Points**: Manual security reviews, missed vulnerabilities
+- **Goals**: Catch security issues before merge with actionable remediation
+
+---
+
+## Functional Requirements
+
+### FR1: Security Workflows
+
+Workflows that detect security vulnerabilities, secrets, and container security issues.
+
+| ID | Feature | Description | Priority |
+|----|---------|-------------|----------|
+| FR1.1 | OWASP Security Scan | Detect OWASP Top 10 vulnerabilities (injection, XSS, SSRF, etc.) | P0 |
+| FR1.2 | Secrets Detection | Pre-merge gate for leaked API keys, tokens, passwords | P0 |
+| FR1.3 | Dependency Security | Audit npm/pip/cargo for known CVEs | P1 |
+| FR1.4 | Container Security | Dockerfile best practices (no root, pinned versions) | P1 |
+
+### FR2: Accessibility Workflows
+
+Workflows that enforce WCAG compliance and ARIA patterns.
+
+| ID | Feature | Description | Priority |
+|----|---------|-------------|----------|
+| FR2.1 | WCAG Compliance | Check WCAG 2.1 AA (alt text, contrast, keyboard) | P0 |
+| FR2.2 | ARIA Patterns | Validate ARIA roles, states, and live regions | P1 |
+
+### FR3: Code Quality Workflows
+
+Workflows that detect code smells, enforce type safety, and validate patterns.
+
+| ID | Feature | Description | Priority |
+|----|---------|-------------|----------|
+| FR3.1 | Code Smell Detection | Long functions, deep nesting, magic numbers | P0 |
+| FR3.2 | TypeScript Strict | `any` usage, non-null assertions, missing return types | P0 |
+| FR3.3 | Async Patterns | Unhandled rejections, floating promises | P1 |
+| FR3.4 | React/Vue Patterns | Missing keys, useEffect deps, props drilling | P1 |
+| FR3.5 | API Contract | Request/response type mismatches, breaking changes | P2 |
+
+### FR4: Documentation Workflows
+
+Workflows that validate documentation accuracy and coverage.
+
+| ID | Feature | Description | Priority |
+|----|---------|-------------|----------|
+| FR4.1 | README Sync | Verify install instructions match package.json | P1 |
+| FR4.2 | Changelog Validation | Enforce Keep a Changelog format | P2 |
+| FR4.3 | API Docs Coverage | JSDoc/docstring coverage for exports | P2 |
+
+### FR5: Testing Workflows
+
+Workflows that enforce test quality and coverage.
+
+| ID | Feature | Description | Priority |
+|----|---------|-------------|----------|
+| FR5.1 | Test Coverage Gate | New code must have tests, no coverage regression | P1 |
+| FR5.2 | Test Quality | Descriptive names, specific assertions, AAA pattern | P2 |
+| FR5.3 | E2E Stability | Explicit waits, stable selectors, test isolation | P2 |
+
+### FR6: Infrastructure Workflows
+
+Workflows that validate IaC and CI/CD configurations.
+
+| ID | Feature | Description | Priority |
+|----|---------|-------------|----------|
+| FR6.1 | Dockerfile Best Practices | Multi-stage builds, layer optimization | P1 |
+| FR6.2 | Terraform Validation | Format, variable descriptions, sensitive marking | P2 |
+| FR6.3 | GitHub Actions Lint | Pinned versions, minimal permissions, caching | P1 |
+
+### FR7: Maintenance Workflows
+
+Scheduled workflows for codebase hygiene.
+
+| ID | Feature | Description | Priority |
+|----|---------|-------------|----------|
+| FR7.1 | Stale Code Detection | Unused exports, dead code, TODO age | P2 |
+| FR7.2 | Dependency Freshness | Major updates, security patches, deprecated packages | P2 |
+
+---
+
+## Non-Functional Requirements
+
+### Performance
+
+| Requirement | Target | Rationale |
+|-------------|--------|-----------|
+| Max turns per workflow | 5-10 | Minimize context usage and API costs |
+| Model | haiku | Cost-efficient, fast execution |
+| File limit per analysis | 30-50 files | Prevent context overflow |
+
+### Reusability
+
+| Requirement | Target | Rationale |
+|-------------|--------|-----------|
+| Workflow location | `.github/workflows/reusable-*.yml` | GitHub requirement for reusable workflows |
+| Input validation | Typed inputs with defaults | Consumer flexibility |
+| Output consistency | Structured outputs (issues-found, critical-count) | Composable job dependencies |
+
+### Security
+
+| Requirement | Target | Rationale |
+|-------------|--------|-----------|
+| Secrets handling | `secrets: inherit` or explicit pass | Organization compatibility |
+| Permissions | Minimal required (contents: read, pull-requests: write) | Least privilege |
+| No secrets in logs | Masked outputs | Prevent leakage |
+
+### Versioning
+
+| Requirement | Target | Rationale |
+|-------------|--------|-----------|
+| Release tags | Semantic versioning (v2.0.0) | Breaking change communication |
+| Compatibility | Workflow version matches plugin version | Coupled releases |
+
+---
+
+## Technical Considerations
+
+### Architecture
+
+Per [ADR-0014](../adrs/0014-reusable-workflows-in-repository.md), reusable workflows live in this repository alongside the plugins they use. This enables:
+- Coupled versioning between workflows and plugins
+- Single source of truth for consumers
+- Easier testing of workflow changes against plugin changes
+
+### GitHub Constraints
+
+| Constraint | Limit |
+|------------|-------|
+| Max reusable workflows per caller | 50 unique workflows |
+| Max nesting depth | 10 levels |
+| Subdirectories | **Not supported** - all in `.github/workflows/` |
+| Environment variables | Do **not** propagate from caller |
+
+### Naming Convention
+
+- `reusable-*` prefix = callable from other repositories
+- No prefix = internal to this repository
+
+### Dependencies
+
+| Dependency | Version | Purpose |
+|------------|---------|---------|
+| anthropics/claude-code-action | v1 | Claude Code integration |
+| actions/checkout | v4 | Repository checkout |
+| code-quality-plugin | latest | Security and code smell patterns |
+| accessibility-plugin | latest | WCAG and ARIA patterns |
+
+---
+
+## Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Workflow adoption | 10+ external repositories | GitHub referrers |
+| Issue detection rate | 90%+ true positives | Manual validation sample |
+| Execution time | < 5 minutes average | Workflow run duration |
+| Cost per run | < $0.10 average | API usage tracking |
+
+---
+
+## Scope
+
+### In Scope
+
+- 22 reusable workflows across 7 categories
+- Documentation for consumer adoption
+- Test fixtures for workflow validation
+- Versioning strategy and release tags
+
+### Out of Scope
+
+- Custom workflow builder UI
+- Workflow metrics dashboard
+- Automatic remediation (analysis only)
+- Non-GitHub CI/CD platforms
+
+---
+
+## Timeline & Phases
+
+### Phase 1: Security Foundation
+
+Priority workflows for security scanning:
+1. `reusable-security-secrets.yml` - Critical pre-merge gate
+2. `reusable-security-owasp.yml` - Comprehensive security
+3. `reusable-security-deps.yml` - Supply chain security
+
+### Phase 2: Code Quality
+
+Quality enforcement workflows:
+4. `reusable-quality-code-smell.yml` - General quality
+5. `reusable-quality-typescript.yml` - Type safety
+6. `reusable-quality-async.yml` - Error handling
+
+### Phase 3: Accessibility
+
+WCAG compliance workflows:
+7. `reusable-a11y-wcag.yml` - WCAG AA compliance
+8. `reusable-a11y-aria.yml` - ARIA correctness
+
+### Phase 4: Testing & Documentation
+
+Coverage and documentation workflows:
+9. `reusable-test-coverage.yml` - Coverage enforcement
+10. `reusable-docs-api.yml` - Documentation quality
+
+### Phase 5: Infrastructure & Maintenance
+
+Final workflows:
+11. `reusable-infra-actions.yml` - Workflow quality
+12. `reusable-maintenance-stale.yml` - Code hygiene

--- a/docs/prps/reusable-workflows-phase1-security.md
+++ b/docs/prps/reusable-workflows-phase1-security.md
@@ -1,0 +1,409 @@
+---
+id: PRP-002
+created: 2026-01-25
+modified: 2026-01-25
+reviewed: 2026-01-25
+status: ready
+confidence: 8/10
+domain: ci-cd
+feature-codes:
+  - FR1.1
+  - FR1.2
+  - FR1.3
+implements:
+  - PRD-002
+relates-to:
+  - ADR-0014
+github-issues: []
+---
+
+# PRP: Reusable Workflows Phase 1 - Security Foundation
+
+## Context Framing
+
+### Goal
+
+Implement the first three reusable GitHub Action workflows focused on security:
+1. `reusable-security-secrets.yml` - Pre-merge secrets detection gate
+2. `reusable-security-owasp.yml` - OWASP Top 10 vulnerability scanning
+3. `reusable-security-deps.yml` - Dependency vulnerability audit
+
+### Why This Phase First
+
+Security workflows provide the highest value with the lowest risk:
+- **Critical pre-merge gates**: Block leaked credentials before they hit main
+- **Immediate ROI**: Every organization needs security scanning
+- **Low turn count**: Security patterns are well-defined, haiku handles efficiently
+- **Plugin leverage**: code-quality-plugin already has security patterns
+
+### Business Justification
+
+- Prevents credential leaks (average cost: $4.24M per breach)
+- Automates security review that would require manual effort
+- Provides consistent security posture across repositories
+
+---
+
+## AI Documentation
+
+### Referenced Skills
+
+| Skill | Plugin | Purpose |
+|-------|--------|---------|
+| code-antipatterns-analysis | code-quality-plugin | Security anti-patterns, ast-grep queries |
+
+### Key Patterns to Use
+
+From `code-quality-plugin/skills/code-antipatterns-analysis/`:
+- SQL injection detection
+- Command injection patterns
+- XSS via innerHTML/dangerouslySetInnerHTML
+- Hardcoded secrets patterns
+
+---
+
+## Implementation Blueprint
+
+### Required Tasks (MVP)
+
+#### Task 1: Create reusable-security-secrets.yml
+
+**Location**: `.github/workflows/reusable-security-secrets.yml`
+
+**Inputs**:
+```yaml
+inputs:
+  file-patterns:
+    description: 'File patterns to scan (space-separated)'
+    required: false
+    type: string
+    default: '**/*'
+  max-turns:
+    description: 'Maximum Claude analysis turns'
+    required: false
+    type: number
+    default: 5
+```
+
+**Outputs**:
+```yaml
+outputs:
+  secrets-found:
+    description: 'Number of potential secrets detected'
+    value: ${{ jobs.scan.outputs.count }}
+```
+
+**Secrets Required**:
+```yaml
+secrets:
+  CLAUDE_CODE_OAUTH_TOKEN:
+    required: true
+```
+
+**Prompt Focus**:
+- API keys: `AKIA*`, `sk_live_*`, `pk_live_*`
+- Tokens: `ghp_*`, `gho_*`, `Bearer [a-zA-Z0-9]`
+- Private keys: `-----BEGIN (RSA|SSH|PGP) PRIVATE KEY-----`
+- Connection strings: `mongodb://`, `postgres://`, `mysql://`
+- Hardcoded passwords: `password = "..."`, `secret: "..."`
+
+**Template**:
+```yaml
+name: Secrets Detection (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      file-patterns:
+        description: 'File patterns to scan'
+        required: false
+        type: string
+        default: '**/*'
+      max-turns:
+        description: 'Maximum Claude turns'
+        required: false
+        type: number
+        default: 5
+    outputs:
+      secrets-found:
+        description: 'Number of potential secrets detected'
+        value: ${{ jobs.scan.outputs.count }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    outputs:
+      count: ${{ steps.analyze.outputs.secrets }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- ${{ inputs.file-patterns }} | head -50)
+          else
+            FILES=$(git diff --name-only HEAD~1 -- ${{ inputs.file-patterns }} | head -50)
+          fi
+          echo "files<<EOF" >> $GITHUB_OUTPUT
+          echo "$FILES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "count=$(echo "$FILES" | grep -c '.' || echo 0)" >> $GITHUB_OUTPUT
+
+      - name: Claude Secrets Scan
+        id: analyze
+        if: steps.changed.outputs.count != '0'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          model: haiku
+          claude_args: "--max-turns ${{ inputs.max-turns }}"
+          prompt: |
+            CRITICAL: Scan for leaked secrets and credentials in these files.
+
+            ## Files to scan
+            ${{ steps.changed.outputs.files }}
+
+            ## Secret Patterns
+            - API keys: AKIA*, sk_live_*, pk_live_*, xox[baprs]-*
+            - Tokens: ghp_*, gho_*, Bearer [a-zA-Z0-9]{20,}
+            - Private keys: -----BEGIN (RSA|SSH|PGP|EC) PRIVATE KEY-----
+            - Connection strings: mongodb://, postgres://, mysql://, redis://
+            - Passwords: password\s*[:=]\s*["'][^"']+["']
+            - AWS: aws_access_key_id, aws_secret_access_key
+            - Generic secrets: api[_-]?key, auth[_-]?token, client[_-]?secret
+
+            ## Output Format
+            For each potential secret:
+            - **File:Line** - Location
+            - **Type** - What kind of secret
+            - **Risk** - Critical (real key) / High (possible key) / Medium (pattern match)
+            - **Context** - Surrounding code (redacted)
+
+            If NO secrets found, respond: "No secrets detected in scanned files."
+
+            Leave a PR comment summarizing findings.
+```
+
+#### Task 2: Create reusable-security-owasp.yml
+
+**Location**: `.github/workflows/reusable-security-owasp.yml`
+
+**Inputs**:
+```yaml
+inputs:
+  file-patterns:
+    description: 'File patterns to analyze'
+    required: false
+    type: string
+    default: '**/*.{js,ts,jsx,tsx,py}'
+  max-turns:
+    description: 'Maximum Claude turns'
+    required: false
+    type: number
+    default: 8
+  fail-on-critical:
+    description: 'Fail workflow if critical issues found'
+    required: false
+    type: boolean
+    default: true
+```
+
+**Outputs**:
+```yaml
+outputs:
+  issues-found:
+    description: 'Total security issues detected'
+    value: ${{ jobs.scan.outputs.issue-count }}
+  critical-count:
+    description: 'Critical severity issues'
+    value: ${{ jobs.scan.outputs.critical-count }}
+```
+
+**Prompt Focus** (OWASP Top 10 2021):
+- A01:2021 Broken Access Control - Path traversal, privilege escalation
+- A02:2021 Cryptographic Failures - Hardcoded secrets, weak crypto
+- A03:2021 Injection - SQL, command, XSS injection
+- A04:2021 Insecure Design - Missing input validation
+- A05:2021 Security Misconfiguration - Debug enabled, default creds
+- A07:2021 Auth Failures - Weak auth, session issues
+- A08:2021 Data Integrity - Insecure deserialization
+- A10:2021 SSRF - User-controlled URLs
+
+#### Task 3: Create reusable-security-deps.yml
+
+**Location**: `.github/workflows/reusable-security-deps.yml`
+
+**Inputs**:
+```yaml
+inputs:
+  package-manager:
+    description: 'Package manager (npm, bun, pip, cargo)'
+    required: false
+    type: string
+    default: 'npm'
+  max-turns:
+    description: 'Maximum Claude turns'
+    required: false
+    type: number
+    default: 6
+```
+
+**Outputs**:
+```yaml
+outputs:
+  vulnerabilities:
+    description: 'Total vulnerabilities found'
+    value: ${{ jobs.audit.outputs.count }}
+  critical:
+    description: 'Critical/High vulnerabilities'
+    value: ${{ jobs.audit.outputs.critical }}
+```
+
+**Prompt Focus**:
+- Run `npm audit --json` / `bun pm audit` / `pip-audit` / `cargo audit`
+- Parse CVE IDs, severity, affected packages
+- Report fixed versions available
+- Prioritize by severity
+
+### Deferred Tasks (Phase 2+)
+
+- Container security workflow (`reusable-security-container.yml`)
+- Custom secret patterns via input
+- SARIF output format for GitHub Security tab
+- Auto-remediation suggestions
+
+### Nice-to-Have
+
+- Slack/Teams notifications on critical findings
+- Historical trend tracking
+- False positive suppression via config file
+
+---
+
+## Test Strategy
+
+### Unit Tests
+
+Not applicable - workflows are integration by nature.
+
+### Integration Tests
+
+Create test fixtures in `test-fixtures/security/`:
+
+```
+test-fixtures/security/
+├── secrets/
+│   ├── fake-api-key.js         # Contains AKIA... pattern
+│   ├── fake-password.py        # Contains password = "..."
+│   └── clean-file.ts           # No secrets
+├── owasp/
+│   ├── sql-injection.js        # String concatenation in query
+│   ├── xss-vulnerable.tsx      # dangerouslySetInnerHTML
+│   ├── command-injection.py    # shell=True with user input
+│   └── clean-code.ts           # Secure patterns
+└── deps/
+    ├── package.json            # With known vulnerable deps
+    └── package-lock.json
+```
+
+### E2E Tests
+
+Test workflow in `.github/workflows/test-reusable-workflows.yml`:
+
+```yaml
+name: Test Reusable Workflows
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/reusable-security-*.yml'
+      - 'test-fixtures/security/**'
+
+jobs:
+  test-secrets:
+    uses: ./.github/workflows/reusable-security-secrets.yml
+    with:
+      file-patterns: 'test-fixtures/security/secrets/**'
+      max-turns: 3
+    secrets: inherit
+
+  test-owasp:
+    uses: ./.github/workflows/reusable-security-owasp.yml
+    with:
+      file-patterns: 'test-fixtures/security/owasp/**'
+      max-turns: 5
+    secrets: inherit
+
+  validate-results:
+    needs: [test-secrets, test-owasp]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check secrets were detected
+        run: |
+          if [ "${{ needs.test-secrets.outputs.secrets-found }}" -lt 2 ]; then
+            echo "Expected at least 2 secrets in test fixtures"
+            exit 1
+          fi
+```
+
+---
+
+## Validation Gates
+
+### Pre-commit
+
+```bash
+# Validate workflow syntax
+yamllint .github/workflows/reusable-security-*.yml
+```
+
+### CI Checks
+
+```bash
+# Test workflow locally with act
+act pull_request -W .github/workflows/test-reusable-workflows.yml \
+  --secret CLAUDE_CODE_OAUTH_TOKEN="$CLAUDE_CODE_OAUTH_TOKEN"
+```
+
+### Post-implementation
+
+```bash
+# Verify workflow is callable
+gh workflow view reusable-security-secrets.yml
+
+# Test from another repo (manual)
+# Create test caller workflow referencing this repo
+```
+
+---
+
+## Success Criteria
+
+| Criterion | Measurement | Target |
+|-----------|-------------|--------|
+| Secrets detection | Detects fake keys in test fixtures | 100% |
+| OWASP detection | Detects vulnerable patterns in test fixtures | >= 80% |
+| False positive rate | Manual review of findings | <= 20% |
+| Execution time | Workflow run duration | < 3 minutes |
+| Output format | PR comment with file:line references | Consistent |
+
+### Definition of Done
+
+- [ ] All three workflows created in `.github/workflows/`
+- [ ] Test fixtures created in `test-fixtures/security/`
+- [ ] Test workflow validates detection
+- [ ] PR comments contain actionable file:line references
+- [ ] Documentation in README updated with consumer usage
+- [ ] Workflows use `reusable-` prefix per ADR-0014

--- a/docs/prps/reusable-workflows-phase2-quality.md
+++ b/docs/prps/reusable-workflows-phase2-quality.md
@@ -1,0 +1,484 @@
+---
+id: PRP-003
+created: 2026-01-25
+modified: 2026-01-25
+reviewed: 2026-01-25
+status: ready
+confidence: 8/10
+domain: ci-cd
+feature-codes:
+  - FR3.1
+  - FR3.2
+  - FR3.3
+implements:
+  - PRD-002
+relates-to:
+  - ADR-0014
+  - PRP-002
+github-issues: []
+---
+
+# PRP: Reusable Workflows Phase 2 - Code Quality
+
+## Context Framing
+
+### Goal
+
+Implement three reusable GitHub Action workflows focused on code quality:
+1. `reusable-quality-code-smell.yml` - Code smell and anti-pattern detection
+2. `reusable-quality-typescript.yml` - TypeScript strictness and type safety
+3. `reusable-quality-async.yml` - Async/await and Promise pattern validation
+
+### Why This Phase Second
+
+After security (Phase 1), code quality provides:
+- **Maintainability improvements**: Catch complexity before it accumulates
+- **Type safety**: Reduce runtime errors with strict TypeScript checks
+- **Error handling**: Proper async patterns prevent unhandled rejections
+- **Plugin leverage**: code-quality-plugin has ast-grep patterns ready
+
+### Prerequisites
+
+- Phase 1 (Security) completed
+- Test workflow infrastructure established
+- `anthropics/claude-code-action@v1` configured
+
+---
+
+## AI Documentation
+
+### Referenced Skills
+
+| Skill | Plugin | Purpose |
+|-------|--------|---------|
+| code-antipatterns-analysis | code-quality-plugin | Code smell patterns, complexity metrics |
+| typescript-strict | typescript-plugin | Type safety patterns |
+
+### Key Patterns to Use
+
+From `code-quality-plugin/skills/code-antipatterns-analysis/`:
+- Long function detection (50+ lines)
+- Deep nesting (4+ levels)
+- Large parameter lists (5+ params)
+- Empty catch blocks
+- Console.log statements
+- Callback hell patterns
+
+---
+
+## Implementation Blueprint
+
+### Required Tasks (MVP)
+
+#### Task 1: Create reusable-quality-code-smell.yml
+
+**Location**: `.github/workflows/reusable-quality-code-smell.yml`
+
+**Inputs**:
+```yaml
+inputs:
+  file-patterns:
+    description: 'File patterns to analyze'
+    required: false
+    type: string
+    default: '**/*.{js,ts,jsx,tsx}'
+  max-turns:
+    description: 'Maximum Claude turns'
+    required: false
+    type: number
+    default: 8
+  severity-threshold:
+    description: 'Minimum severity to report (low, medium, high)'
+    required: false
+    type: string
+    default: 'medium'
+```
+
+**Outputs**:
+```yaml
+outputs:
+  issues-found:
+    description: 'Total code smells detected'
+    value: ${{ jobs.analyze.outputs.count }}
+  high-severity:
+    description: 'High severity issues'
+    value: ${{ jobs.analyze.outputs.high }}
+```
+
+**Prompt Focus**:
+
+```markdown
+Analyze changed files for code smells using ast-grep patterns.
+
+## Complexity Smells (High Severity)
+- Functions over 50 lines
+- Nesting 4+ levels deep
+- 5+ function parameters
+- Cyclomatic complexity > 10
+
+## Maintainability Smells (Medium Severity)
+- Magic numbers in conditionals
+- Empty catch blocks (swallowed errors)
+- console.log/console.error statements
+- Nested callbacks (3+ levels)
+- Duplicated code blocks (10+ lines)
+
+## Style Smells (Low Severity)
+- Inconsistent naming (camelCase vs snake_case)
+- TODO/FIXME comments without issue reference
+- Commented-out code blocks
+
+## Output Format
+For each issue:
+- **File:Line** - Location
+- **Smell** - Category name
+- **Severity** - high/medium/low
+- **Description** - Why it's a problem
+- **Suggestion** - How to refactor
+```
+
+**Template**:
+```yaml
+name: Code Smell Detection (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      file-patterns:
+        description: 'File patterns to analyze'
+        required: false
+        type: string
+        default: '**/*.{js,ts,jsx,tsx}'
+      max-turns:
+        description: 'Maximum Claude turns'
+        required: false
+        type: number
+        default: 8
+      severity-threshold:
+        description: 'Minimum severity to report'
+        required: false
+        type: string
+        default: 'medium'
+    outputs:
+      issues-found:
+        description: 'Total code smells detected'
+        value: ${{ jobs.analyze.outputs.count }}
+      high-severity:
+        description: 'High severity issues'
+        value: ${{ jobs.analyze.outputs.high }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    outputs:
+      count: ${{ steps.scan.outputs.total }}
+      high: ${{ steps.scan.outputs.high }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- ${{ inputs.file-patterns }} | head -30)
+          else
+            FILES=$(git diff --name-only HEAD~1 -- ${{ inputs.file-patterns }} | head -30)
+          fi
+          echo "files<<EOF" >> $GITHUB_OUTPUT
+          echo "$FILES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "count=$(echo "$FILES" | grep -c '.' || echo 0)" >> $GITHUB_OUTPUT
+
+      - name: Claude Code Smell Analysis
+        id: scan
+        if: steps.changed.outputs.count != '0'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          model: haiku
+          claude_args: "--max-turns ${{ inputs.max-turns }}"
+          plugin_marketplaces: |
+            https://github.com/laurigates/claude-plugins.git
+          plugins: |
+            code-quality-plugin@laurigates-plugins
+          prompt: |
+            Analyze these files for code smells. Minimum severity: ${{ inputs.severity-threshold }}
+
+            ## Files
+            ${{ steps.changed.outputs.files }}
+
+            Use ast-grep patterns from code-quality-plugin.
+            Leave a PR comment with findings grouped by severity.
+```
+
+#### Task 2: Create reusable-quality-typescript.yml
+
+**Location**: `.github/workflows/reusable-quality-typescript.yml`
+
+**Inputs**:
+```yaml
+inputs:
+  file-patterns:
+    description: 'TypeScript file patterns'
+    required: false
+    type: string
+    default: '**/*.{ts,tsx}'
+  max-turns:
+    description: 'Maximum Claude turns'
+    required: false
+    type: number
+    default: 6
+  strict-mode:
+    description: 'Enforce strict type checking'
+    required: false
+    type: boolean
+    default: true
+```
+
+**Outputs**:
+```yaml
+outputs:
+  any-count:
+    description: 'Number of any types found'
+    value: ${{ jobs.analyze.outputs.any }}
+  issues-found:
+    description: 'Total type safety issues'
+    value: ${{ jobs.analyze.outputs.total }}
+```
+
+**Prompt Focus**:
+
+```markdown
+Review TypeScript changes for type safety:
+
+## Critical (Block Merge)
+- `any` type usage without justification
+- @ts-ignore without explanation comment
+- @ts-expect-error without explanation
+
+## High Severity
+- Non-null assertions (!) without guard
+- Type assertions (as) that could be type guards
+- Implicit any in function parameters
+
+## Medium Severity
+- Missing return types on exported functions
+- Missing parameter types on callbacks
+- Generic any[] instead of typed arrays
+
+## Output Format
+For each issue:
+- **File:Line** - Location
+- **Issue** - What's wrong
+- **Current** - The problematic code
+- **Suggested** - Type-safe alternative
+```
+
+#### Task 3: Create reusable-quality-async.yml
+
+**Location**: `.github/workflows/reusable-quality-async.yml`
+
+**Inputs**:
+```yaml
+inputs:
+  file-patterns:
+    description: 'File patterns to analyze'
+    required: false
+    type: string
+    default: '**/*.{js,ts,jsx,tsx}'
+  max-turns:
+    description: 'Maximum Claude turns'
+    required: false
+    type: number
+    default: 5
+```
+
+**Outputs**:
+```yaml
+outputs:
+  issues-found:
+    description: 'Total async pattern issues'
+    value: ${{ jobs.analyze.outputs.count }}
+  unhandled-rejections:
+    description: 'Potential unhandled rejections'
+    value: ${{ jobs.analyze.outputs.rejections }}
+```
+
+**Prompt Focus**:
+
+```markdown
+Review async code patterns:
+
+## Critical (Unhandled Rejections)
+- async functions without try-catch AND without caller handling
+- Promises without .catch() AND not awaited in try block
+- Floating promises (not awaited, not stored, no .then/.catch)
+
+## High Severity
+- Promise constructor anti-pattern (new Promise wrapping async)
+- Missing error propagation (catching but not rethrowing)
+- Swallowed errors in catch blocks
+
+## Medium Severity
+- Sequential awaits that could be Promise.all
+- Unnecessary async (function doesn't await anything)
+- Missing finally for cleanup
+
+## Output Format
+For each issue:
+- **File:Line** - Location
+- **Pattern** - Anti-pattern name
+- **Risk** - What could go wrong
+- **Fix** - How to handle properly
+```
+
+### Deferred Tasks (Phase 2+)
+
+- React/Vue specific pattern workflow (`reusable-quality-react.yml`)
+- API contract validation workflow (`reusable-quality-api.yml`)
+- Custom threshold configuration via input
+- Trend tracking across PRs
+
+### Nice-to-Have
+
+- Auto-fix suggestions with code snippets
+- Integration with existing linter configs
+- Complexity score badges
+
+---
+
+## Test Strategy
+
+### Test Fixtures
+
+Create test fixtures in `test-fixtures/quality/`:
+
+```
+test-fixtures/quality/
+├── code-smell/
+│   ├── long-function.ts        # 60+ line function
+│   ├── deep-nesting.js         # 5 levels of nesting
+│   ├── magic-numbers.ts        # if (x === 42)
+│   ├── empty-catch.js          # catch (e) {}
+│   └── clean-code.ts           # Well-structured code
+├── typescript/
+│   ├── any-usage.ts            # const data: any = ...
+│   ├── non-null-assertion.ts   # user!.name
+│   ├── type-assertion.tsx      # as SomeType
+│   ├── missing-return-type.ts  # export function foo()
+│   └── strict-code.ts          # Proper types
+└── async/
+    ├── floating-promise.ts     # fetchData() without await
+    ├── missing-catch.js        # promise.then() no .catch()
+    ├── promise-constructor.ts  # new Promise(async ...)
+    └── proper-async.ts         # Correct patterns
+```
+
+### Test Workflow
+
+Add to `.github/workflows/test-reusable-workflows.yml`:
+
+```yaml
+  test-code-smell:
+    uses: ./.github/workflows/reusable-quality-code-smell.yml
+    with:
+      file-patterns: 'test-fixtures/quality/code-smell/**'
+      max-turns: 5
+    secrets: inherit
+
+  test-typescript:
+    uses: ./.github/workflows/reusable-quality-typescript.yml
+    with:
+      file-patterns: 'test-fixtures/quality/typescript/**'
+      max-turns: 4
+    secrets: inherit
+
+  test-async:
+    uses: ./.github/workflows/reusable-quality-async.yml
+    with:
+      file-patterns: 'test-fixtures/quality/async/**'
+      max-turns: 3
+    secrets: inherit
+
+  validate-quality:
+    needs: [test-code-smell, test-typescript, test-async]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check code smells detected
+        run: |
+          if [ "${{ needs.test-code-smell.outputs.issues-found }}" -lt 3 ]; then
+            echo "Expected at least 3 code smells in test fixtures"
+            exit 1
+          fi
+      - name: Check any types detected
+        run: |
+          if [ "${{ needs.test-typescript.outputs.any-count }}" -lt 1 ]; then
+            echo "Expected at least 1 any type in test fixtures"
+            exit 1
+          fi
+```
+
+---
+
+## Validation Gates
+
+### Pre-commit
+
+```bash
+# Validate workflow syntax
+yamllint .github/workflows/reusable-quality-*.yml
+
+# Check for required inputs
+grep -q "CLAUDE_CODE_OAUTH_TOKEN" .github/workflows/reusable-quality-*.yml
+```
+
+### CI Checks
+
+```bash
+# Test locally with act
+act pull_request -W .github/workflows/test-reusable-workflows.yml \
+  -j test-code-smell \
+  --secret CLAUDE_CODE_OAUTH_TOKEN="$CLAUDE_CODE_OAUTH_TOKEN"
+```
+
+### Post-implementation
+
+```bash
+# Verify workflows are callable
+gh workflow list | grep reusable-quality
+
+# Check documentation updated
+grep -q "reusable-quality" README.md
+```
+
+---
+
+## Success Criteria
+
+| Criterion | Measurement | Target |
+|-----------|-------------|--------|
+| Code smell detection | Detects patterns in test fixtures | >= 80% |
+| TypeScript issues | Detects any/assertions in fixtures | 100% |
+| Async issues | Detects floating promises in fixtures | >= 90% |
+| False positive rate | Manual review of findings | <= 25% |
+| Execution time | Workflow run duration | < 4 minutes |
+
+### Definition of Done
+
+- [ ] All three workflows created in `.github/workflows/`
+- [ ] Test fixtures created in `test-fixtures/quality/`
+- [ ] Test workflow validates detection
+- [ ] PR comments contain actionable suggestions
+- [ ] Severity filtering works via input
+- [ ] Documentation updated with consumer usage

--- a/docs/prps/reusable-workflows-phase3-a11y.md
+++ b/docs/prps/reusable-workflows-phase3-a11y.md
@@ -1,0 +1,530 @@
+---
+id: PRP-004
+created: 2026-01-25
+modified: 2026-01-25
+reviewed: 2026-01-25
+status: ready
+confidence: 7/10
+domain: ci-cd
+feature-codes:
+  - FR2.1
+  - FR2.2
+implements:
+  - PRD-002
+relates-to:
+  - ADR-0014
+  - PRP-002
+  - PRP-003
+github-issues: []
+---
+
+# PRP: Reusable Workflows Phase 3 - Accessibility
+
+## Context Framing
+
+### Goal
+
+Implement two reusable GitHub Action workflows focused on web accessibility:
+1. `reusable-a11y-wcag.yml` - WCAG 2.1/2.2 compliance checking
+2. `reusable-a11y-aria.yml` - ARIA implementation patterns validation
+
+### Why This Phase Third
+
+After security and code quality, accessibility:
+- **Legal compliance**: WCAG AA is required in many jurisdictions
+- **User reach**: Accessibility benefits all users, not just those with disabilities
+- **Frontend focus**: Targets tsx/jsx/vue/html files specifically
+- **Early detection**: Catch a11y issues before they reach production
+
+### Confidence Score Notes
+
+Score: 7/10 - Lower than previous phases because:
+- Accessibility patterns are context-dependent (component vs page)
+- WCAG criteria require human judgment for some checks
+- No existing accessibility-plugin in repository (may need creation)
+
+---
+
+## AI Documentation
+
+### Referenced Skills
+
+| Skill | Plugin | Purpose |
+|-------|--------|---------|
+| TBD | accessibility-plugin | WCAG patterns, ARIA validation |
+
+**Note**: This phase may require creating a new `accessibility-plugin` with WCAG/ARIA patterns, or the workflows can operate without plugin-specific patterns using Claude's built-in knowledge.
+
+### Key WCAG Criteria (AA Level)
+
+**Perceivable:**
+- 1.1.1 Non-text Content - Images need alt, form inputs need labels
+- 1.4.3 Contrast Minimum - 4.5:1 for text, 3:1 for large text
+
+**Operable:**
+- 2.1.1 Keyboard - All functionality via keyboard
+- 2.4.6 Headings and Labels - Descriptive, hierarchical
+- 2.4.7 Focus Visible - Visible focus indicator
+
+**Understandable:**
+- 3.3.2 Labels or Instructions - Form inputs labeled
+
+**Robust:**
+- 4.1.2 Name, Role, Value - ARIA attributes correct
+
+---
+
+## Implementation Blueprint
+
+### Required Tasks (MVP)
+
+#### Task 1: Create reusable-a11y-wcag.yml
+
+**Location**: `.github/workflows/reusable-a11y-wcag.yml`
+
+**Inputs**:
+```yaml
+inputs:
+  file-patterns:
+    description: 'Frontend file patterns'
+    required: false
+    type: string
+    default: '**/*.{tsx,jsx,vue,html}'
+  max-turns:
+    description: 'Maximum Claude turns'
+    required: false
+    type: number
+    default: 8
+  wcag-level:
+    description: 'WCAG conformance level (A, AA, AAA)'
+    required: false
+    type: string
+    default: 'AA'
+```
+
+**Outputs**:
+```yaml
+outputs:
+  issues-found:
+    description: 'Total WCAG violations detected'
+    value: ${{ jobs.analyze.outputs.count }}
+  level-a-issues:
+    description: 'Level A violations (must fix)'
+    value: ${{ jobs.analyze.outputs.level-a }}
+  level-aa-issues:
+    description: 'Level AA violations'
+    value: ${{ jobs.analyze.outputs.level-aa }}
+```
+
+**Prompt Focus**:
+
+```markdown
+Review frontend changes for WCAG 2.1 ${{ inputs.wcag-level }} compliance.
+
+## Level A (Critical - Must Fix)
+
+### 1.1.1 Non-text Content
+- Images without alt attribute
+- img with alt="" on informative images
+- Form inputs without associated labels
+- Icon buttons without accessible names
+
+### 2.1.1 Keyboard Accessible
+- onClick without onKeyDown/onKeyUp handlers
+- Custom controls without keyboard support
+- tabIndex > 0 (disrupts tab order)
+
+### 4.1.2 Name, Role, Value
+- Custom components without ARIA roles
+- Missing aria-label on icon-only buttons
+- Interactive elements without accessible names
+
+## Level AA (Should Fix)
+
+### 1.4.3 Contrast Minimum
+- Note: Static analysis limited, flag hardcoded colors
+- Check for text on background color combinations
+
+### 2.4.6 Headings and Labels
+- Skipped heading levels (h1 -> h3)
+- Generic heading text ("Click here")
+- Form labels not descriptive
+
+### 2.4.7 Focus Visible
+- outline: none without custom focus style
+- Missing focus-visible styles
+
+## Level AAA (Nice to Have)
+
+### 1.4.6 Contrast Enhanced
+- 7:1 for text, 4.5:1 for large text
+
+### 2.4.9 Link Purpose
+- Generic link text ("click here", "read more")
+
+## Output Format
+For each issue:
+- **File:Line** - Location
+- **WCAG Criterion** - e.g., 1.1.1 Non-text Content
+- **Level** - A / AA / AAA
+- **Issue** - What's wrong
+- **Fix** - How to remediate
+
+Prioritize Level A issues at the top.
+```
+
+**Template**:
+```yaml
+name: WCAG Compliance (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      file-patterns:
+        description: 'Frontend file patterns'
+        required: false
+        type: string
+        default: '**/*.{tsx,jsx,vue,html}'
+      max-turns:
+        description: 'Maximum Claude turns'
+        required: false
+        type: number
+        default: 8
+      wcag-level:
+        description: 'WCAG level (A, AA, AAA)'
+        required: false
+        type: string
+        default: 'AA'
+    outputs:
+      issues-found:
+        description: 'Total WCAG violations'
+        value: ${{ jobs.analyze.outputs.count }}
+      level-a-issues:
+        description: 'Level A violations'
+        value: ${{ jobs.analyze.outputs.level-a }}
+      level-aa-issues:
+        description: 'Level AA violations'
+        value: ${{ jobs.analyze.outputs.level-aa }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    outputs:
+      count: ${{ steps.scan.outputs.total }}
+      level-a: ${{ steps.scan.outputs.level-a }}
+      level-aa: ${{ steps.scan.outputs.level-aa }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed frontend files
+        id: changed
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- ${{ inputs.file-patterns }} | head -30)
+          else
+            FILES=$(git diff --name-only HEAD~1 -- ${{ inputs.file-patterns }} | head -30)
+          fi
+          echo "files<<EOF" >> $GITHUB_OUTPUT
+          echo "$FILES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "count=$(echo "$FILES" | grep -c '.' || echo 0)" >> $GITHUB_OUTPUT
+
+      - name: Claude WCAG Analysis
+        id: scan
+        if: steps.changed.outputs.count != '0'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          model: haiku
+          claude_args: "--max-turns ${{ inputs.max-turns }}"
+          prompt: |
+            Review these frontend files for WCAG 2.1 ${{ inputs.wcag-level }} compliance.
+
+            ## Files
+            ${{ steps.changed.outputs.files }}
+
+            Focus on static code analysis patterns.
+            Leave a PR comment with findings grouped by WCAG level.
+```
+
+#### Task 2: Create reusable-a11y-aria.yml
+
+**Location**: `.github/workflows/reusable-a11y-aria.yml`
+
+**Inputs**:
+```yaml
+inputs:
+  file-patterns:
+    description: 'Component file patterns'
+    required: false
+    type: string
+    default: '**/*.{tsx,jsx,vue}'
+  max-turns:
+    description: 'Maximum Claude turns'
+    required: false
+    type: number
+    default: 6
+```
+
+**Outputs**:
+```yaml
+outputs:
+  issues-found:
+    description: 'Total ARIA issues detected'
+    value: ${{ jobs.analyze.outputs.count }}
+  critical-issues:
+    description: 'Critical ARIA misuse'
+    value: ${{ jobs.analyze.outputs.critical }}
+```
+
+**Prompt Focus**:
+
+```markdown
+Audit ARIA implementation in changed components.
+
+## Role Correctness
+
+### Invalid Roles
+- role="button" on <button> (redundant)
+- role="link" on <a> (redundant)
+- Invalid role values
+- role on elements that don't support it
+
+### Missing Roles
+- Custom dropdown without role="listbox" or "menu"
+- Custom toggle without role="switch"
+- Tab components without role="tablist"/"tab"/"tabpanel"
+
+## Required ARIA Attributes
+
+### Interactive Controls
+- role="checkbox" requires aria-checked
+- role="slider" requires aria-valuenow, aria-valuemin, aria-valuemax
+- role="combobox" requires aria-expanded, aria-controls
+
+### State Management
+- Accordions need aria-expanded on triggers
+- Dropdowns need aria-expanded
+- Toggles need aria-pressed or aria-checked
+
+## Labeling
+
+### Missing Labels
+- aria-label on icon-only buttons
+- aria-labelledby for complex widgets
+- aria-describedby for additional context
+
+### Label Quality
+- aria-label repeating visible text
+- Generic labels ("button", "menu")
+
+## Live Regions
+
+### Toast/Alert Notifications
+- Missing role="alert" or aria-live
+- aria-live="assertive" overuse (prefer "polite")
+- Dynamic content without live region
+
+## Focus Management
+
+### Modal/Dialog
+- aria-modal="true" on dialogs
+- Focus trap implementation
+- Focus return on close
+
+### Focus Indicators
+- aria-current for navigation state
+- aria-selected for selections
+
+## Output Format
+For each issue:
+- **File:Line** - Location
+- **Pattern** - ARIA pattern name
+- **Issue** - What's wrong
+- **Reference** - APG (ARIA Authoring Practices Guide) link
+- **Fix** - Correct implementation
+
+Reference: https://www.w3.org/WAI/ARIA/apg/patterns/
+```
+
+### Deferred Tasks (Phase 2+)
+
+- Create accessibility-plugin with ast-grep patterns
+- Color contrast analysis integration (requires runtime)
+- Automated axe-core integration
+- Component-specific pattern libraries (React, Vue, Svelte)
+
+### Nice-to-Have
+
+- ARIA pattern templates in PR comments
+- Links to MDN/APG documentation
+- Severity scoring based on user impact
+
+---
+
+## Test Strategy
+
+### Test Fixtures
+
+Create test fixtures in `test-fixtures/a11y/`:
+
+```
+test-fixtures/a11y/
+├── wcag/
+│   ├── missing-alt.tsx          # <img src="..." />
+│   ├── missing-label.html       # <input type="text" />
+│   ├── skip-heading.tsx         # h1 -> h3 skip
+│   ├── no-keyboard.jsx          # onClick without keyboard
+│   ├── outline-none.css         # :focus { outline: none }
+│   └── accessible.tsx           # Properly accessible component
+└── aria/
+    ├── wrong-role.tsx           # role="button" on <button>
+    ├── missing-expanded.jsx     # Dropdown without aria-expanded
+    ├── missing-label.tsx        # Icon button without aria-label
+    ├── invalid-live.vue         # aria-live misuse
+    └── proper-aria.tsx          # Correct ARIA implementation
+```
+
+### Example Test Fixtures
+
+**missing-alt.tsx**:
+```tsx
+export function Gallery() {
+  return (
+    <div>
+      <img src="/photo1.jpg" />  {/* Missing alt */}
+      <img src="/decorative.png" alt="" />  {/* OK for decorative */}
+      <img src="/info.png" />  {/* Missing alt - informative image */}
+    </div>
+  );
+}
+```
+
+**missing-expanded.jsx**:
+```jsx
+export function Dropdown({ isOpen, items }) {
+  return (
+    <div className="dropdown">
+      <button onClick={toggle}>
+        Menu  {/* Missing aria-expanded */}
+      </button>
+      {isOpen && (
+        <ul>  {/* Missing role="menu" */}
+          {items.map(item => (
+            <li key={item.id}>{item.label}</li>  {/* Missing role="menuitem" */}
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+```
+
+### Test Workflow
+
+Add to `.github/workflows/test-reusable-workflows.yml`:
+
+```yaml
+  test-wcag:
+    uses: ./.github/workflows/reusable-a11y-wcag.yml
+    with:
+      file-patterns: 'test-fixtures/a11y/wcag/**'
+      max-turns: 5
+      wcag-level: 'AA'
+    secrets: inherit
+
+  test-aria:
+    uses: ./.github/workflows/reusable-a11y-aria.yml
+    with:
+      file-patterns: 'test-fixtures/a11y/aria/**'
+      max-turns: 4
+    secrets: inherit
+
+  validate-a11y:
+    needs: [test-wcag, test-aria]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check WCAG issues detected
+        run: |
+          if [ "${{ needs.test-wcag.outputs.level-a-issues }}" -lt 2 ]; then
+            echo "Expected at least 2 Level A issues in test fixtures"
+            exit 1
+          fi
+      - name: Check ARIA issues detected
+        run: |
+          if [ "${{ needs.test-aria.outputs.issues-found }}" -lt 3 ]; then
+            echo "Expected at least 3 ARIA issues in test fixtures"
+            exit 1
+          fi
+```
+
+---
+
+## Validation Gates
+
+### Pre-commit
+
+```bash
+# Validate workflow syntax
+yamllint .github/workflows/reusable-a11y-*.yml
+```
+
+### CI Checks
+
+```bash
+# Test locally with act
+act pull_request -W .github/workflows/test-reusable-workflows.yml \
+  -j test-wcag \
+  --secret CLAUDE_CODE_OAUTH_TOKEN="$CLAUDE_CODE_OAUTH_TOKEN"
+```
+
+### Post-implementation
+
+```bash
+# Verify workflows are callable
+gh workflow list | grep reusable-a11y
+
+# Check outputs are documented
+grep -q "issues-found" .github/workflows/reusable-a11y-wcag.yml
+```
+
+---
+
+## Success Criteria
+
+| Criterion | Measurement | Target |
+|-----------|-------------|--------|
+| WCAG Level A detection | Missing alt, labels in fixtures | 100% |
+| WCAG Level AA detection | Heading hierarchy, focus styles | >= 80% |
+| ARIA pattern detection | Invalid roles, missing states | >= 85% |
+| False positive rate | Manual review | <= 30% |
+| Execution time | Workflow run duration | < 4 minutes |
+
+### Definition of Done
+
+- [ ] Both workflows created in `.github/workflows/`
+- [ ] Test fixtures created in `test-fixtures/a11y/`
+- [ ] Test workflow validates detection
+- [ ] PR comments reference WCAG criteria
+- [ ] ARIA issues link to APG patterns
+- [ ] Documentation updated with consumer usage
+- [ ] WCAG level filtering works via input
+
+---
+
+## References
+
+- [WCAG 2.1 Guidelines](https://www.w3.org/WAI/WCAG21/quickref/)
+- [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/)
+- [MDN ARIA Documentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA)


### PR DESCRIPTION
Add PRD, ADR, and PRPs for the reusable GitHub Action workflows initiative:

- PRD-002: Product requirements for 22 reusable workflows across 7 categories
- ADR-0014: Architecture decision to keep workflows in plugin repository
- PRP-002: Phase 1 implementation - Security workflows (secrets, OWASP, deps)
- PRP-003: Phase 2 implementation - Code quality workflows (smells, TS, async)
- PRP-004: Phase 3 implementation - Accessibility workflows (WCAG, ARIA)

Based on docs/github-workflows-plan.md