### PR TITLE
Update Claude code review workflow to use additional_permissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,7 @@ jobs:
             IMPORTANT: Use built-in tools (Read, Grep, Glob) for file exploration.
             Do NOT use Bash for find/grep operations - use the dedicated tools instead.
           claude_args: "--max-turns 10"
-          allowed_tools: |
+          additional_permissions: |
             Read
             Grep
             Glob


### PR DESCRIPTION
## Summary
Updated the GitHub Actions workflow configuration for Claude code review to use the correct parameter name for specifying tool permissions.

## Changes
- Renamed `allowed_tools` to `additional_permissions` in the Claude code review workflow
- This aligns with the current API/action specification for granting tool access to Claude

## Details
The parameter name change reflects an update to how the Claude GitHub Action handles tool permissions. The `additional_permissions` parameter is the correct way to specify which built-in tools (Read, Grep, Glob) should be available to Claude during code review operations.