### PR TITLE
Simplify plugin.json metadata and remove deprecated config

### DIFF
--- a/sync-plugin/.claude-plugin/plugin.json
+++ b/sync-plugin/.claude-plugin/plugin.json
@@ -2,6 +2,11 @@
   "name": "sync-plugin",
   "version": "1.1.0",
   "description": "External system synchronization - GitHub and Podio integration for task management and daily catch-up workflows",
+  "author": {
+    "name": "Lauri Gates"
+  },
+  "repository": "https://github.com/laurigates/claude-plugins",
+  "license": "MIT",
   "keywords": [
     "sync",
     "github",
@@ -10,34 +15,5 @@
     "daily",
     "workflow",
     "obsidian"
-  ],
-  "author": "lgates",
-  "commands": {
-    "sync:daily": "commands/sync/daily.md",
-    "sync:github-podio": "commands/sync/github-podio.md"
-  },
-  "dependencies": {
-    "mcp-servers": [
-      "github",
-      "podio-mcp"
-    ]
-  },
-  "configuration": {
-    "obsidian": {
-      "vault_path": "~/Documents/FVH Vault",
-      "daily_notes_path": "~/Documents/FVH Vault/Daily Notes",
-      "note_format": "YYYY-MM-DD.md"
-    },
-    "podio": {
-      "default_workspace": {
-        "org_label": "fvh",
-        "space_label": "iot-workspace",
-        "app_label": "datadev-kanban"
-      }
-    },
-    "state": {
-      "directory": "~/.config/claude-code",
-      "daily_state_file": "sync:daily-state.json"
-    }
-  }
+  ]
 }


### PR DESCRIPTION
## Summary
Refactored the sync-plugin configuration to modernize metadata structure and remove deprecated/unused configuration sections that are no longer needed.

## Key Changes
- **Updated author field**: Changed from simple string `"lgates"` to structured object with name `"Lauri Gates"` for better metadata clarity
- **Added repository URL**: Included GitHub repository link (`https://github.com/laurigates/claude-plugins`) for better discoverability
- **Added license field**: Explicitly declared MIT license in plugin metadata
- **Removed deprecated sections**:
  - `commands` object (sync:daily and sync:github-podio commands)
  - `dependencies` object (mcp-servers configuration)
  - `configuration` object (obsidian, podio, and state settings)

## Rationale
These changes align the plugin manifest with modern plugin standards by:
1. Using structured metadata fields for better tooling support
2. Removing configuration that appears to be environment-specific or no longer actively used
3. Keeping only essential plugin information (name, version, description, keywords, author, license, repository)

The removed configuration sections likely belong in environment-specific config files or documentation rather than the plugin manifest itself.