### PR TITLE
chore: sync plugin config files and remove first-plugin template

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -318,6 +318,68 @@
         "anti-patterns"
       ],
       "category": "automation"
+    },
+    {
+      "name": "blog-plugin",
+      "source": "./blog-plugin",
+      "description": "Blog post creation - project logs, technical write-ups, personal documentation",
+      "version": "1.1.0",
+      "keywords": [
+        "blog",
+        "writing",
+        "documentation",
+        "project-log",
+        "devlog",
+        "technical-writing"
+      ],
+      "category": "documentation"
+    },
+    {
+      "name": "command-analytics-plugin",
+      "source": "./command-analytics-plugin",
+      "description": "Track command and skill usage analytics across all projects",
+      "version": "1.2.0",
+      "keywords": [
+        "analytics",
+        "tracking",
+        "usage",
+        "metrics",
+        "reporting"
+      ],
+      "category": "utilities"
+    },
+    {
+      "name": "langchain-plugin",
+      "source": "./langchain-plugin",
+      "description": "LangChain JS/TS development - agents, chains, LangGraph workflows, and Deep Agents patterns",
+      "version": "1.2.0",
+      "keywords": [
+        "langchain",
+        "langgraph",
+        "deep-agents",
+        "ai-agents",
+        "llm",
+        "typescript",
+        "javascript",
+        "rag",
+        "chains"
+      ],
+      "category": "ai"
+    },
+    {
+      "name": "networking-plugin",
+      "source": "./networking-plugin",
+      "description": "Network diagnostics, reconnaissance, monitoring, and HTTP load testing",
+      "version": "1.2.0",
+      "keywords": [
+        "networking",
+        "diagnostics",
+        "connectivity",
+        "port-scanning",
+        "monitoring",
+        "load-testing"
+      ],
+      "category": "infrastructure"
     }
   ]
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -12,7 +12,6 @@
   "configure-plugin": "1.4.2",
   "container-plugin": "2.3.0",
   "documentation-plugin": "1.1.1",
-  "first-plugin": "1.0.0",
   "git-plugin": "2.7.0",
   "hooks-plugin": "1.3.0",
   "github-actions-plugin": "1.1.0",

--- a/first-plugin/.claude-plugin/plugin.json
+++ b/first-plugin/.claude-plugin/plugin.json
@@ -1,8 +1,0 @@
-{
-"name": "my-first-plugin",
-"description": "A simple greeting plugin to learn the basics",
-"version": "1.0.0",
-"author": {
-"name": "Your Name"
-}
-}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -184,20 +184,6 @@
         {"type": "docs", "section": "Documentation"}
       ]
     },
-    "first-plugin": {
-      "component": "first-plugin",
-      "release-type": "simple",
-      "extra-files": [
-        {"type": "json", "path": ".claude-plugin/plugin.json", "jsonpath": "$.version"}
-      ],
-      "changelog-sections": [
-        {"type": "feat", "section": "Features"},
-        {"type": "fix", "section": "Bug Fixes"},
-        {"type": "perf", "section": "Performance"},
-        {"type": "refactor", "section": "Code Refactoring"},
-        {"type": "docs", "section": "Documentation"}
-      ]
-    },
     "git-plugin": {
       "component": "git-plugin",
       "release-type": "simple",


### PR DESCRIPTION
## Summary

- Add 4 missing plugins to `marketplace.json`: blog-plugin, command-analytics-plugin, langchain-plugin, networking-plugin
- Remove first-plugin template from release-please configuration files
- Delete first-plugin directory

## Test plan

- [ ] Verify all 27 plugins are now listed in marketplace.json
- [ ] Verify release-please configs no longer reference first-plugin
- [ ] Confirm first-plugin directory is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)