### PR TITLE
Bump git-plugin version to 2.9.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -186,7 +186,7 @@
       "name": "git-plugin",
       "source": "./git-plugin",
       "description": "Git workflows - commits, branches, PRs, and repository management",
-      "version": "2.7.0",
+      "version": "2.9.0",
       "keywords": [
         "git",
         "github",


### PR DESCRIPTION
## Summary
Updates the git-plugin version from 2.7.0 to 2.9.0 in the marketplace configuration.

## Changes
- Incremented git-plugin version to 2.9.0 in `.claude-plugin/marketplace.json`

## Details
This version bump reflects new features and improvements made to the git-plugin, which provides Git workflows functionality including commits, branches, pull requests, and repository management capabilities.

https://claude.ai/code/session_017JSP9zYd15mpKWDQkESL3N