### PR TITLE
Add pr-feedback command for addressing PR review comments

### DIFF
--- a/git-plugin/.claude-plugin/plugin.json
+++ b/git-plugin/.claude-plugin/plugin.json
@@ -13,6 +13,8 @@
     "commits",
     "branches",
     "pull-requests",
+    "pr-feedback",
+    "code-review",
     "issues",
     "auto-close",
     "issue-detection",

--- a/git-plugin/README.md
+++ b/git-plugin/README.md
@@ -13,6 +13,7 @@ This plugin provides comprehensive Git workflow automation including conventiona
 | `/git:commit` | Complete workflow from changes to PR - auto-detect issues, create logical commits with proper linkage, push, optionally create PR |
 | `/git:issue` | Process GitHub issues with interactive selection, conflict detection, and parallel work support |
 | `/git:fix-pr` | Analyze and fix failing PR checks |
+| `/git:pr-feedback` | Review PR workflow results and comments, address substantive feedback from reviewers |
 | `/git:maintain` | Repository maintenance and cleanup (prune, gc, verify, branches, stash) |
 | `/git:derive-docs` | Analyze git history to derive undocumented rules, PRDs, ADRs, and PRPs |
 
@@ -92,6 +93,16 @@ Analyzes issues for conflicts and dependencies, implements fixes with TDD workfl
 ```
 
 Analyzes PR #456 check failures and attempts automatic fixes.
+
+### Address PR Feedback
+
+```bash
+/git:pr-feedback              # Use current branch's PR
+/git:pr-feedback 789          # Review PR #789 feedback
+/git:pr-feedback 789 --push   # Address feedback and push fixes
+```
+
+Reviews PR workflow results and reviewer comments, categorizes feedback (blocking, substantive, suggestions), and systematically addresses actionable items.
 
 ### Derive Documentation from History
 

--- a/git-plugin/commands/git/pr-feedback.md
+++ b/git-plugin/commands/git/pr-feedback.md
@@ -1,0 +1,260 @@
+---
+model: opus
+created: 2026-01-30
+modified: 2026-01-30
+reviewed: 2026-01-30
+allowed-tools: Bash(gh pr checks *), Bash(gh pr view *), Bash(gh pr diff *), Bash(gh run view *), Bash(gh run list *), Bash(gh api *), Bash(gh repo view *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git switch *), Bash(git pull *), Bash(pre-commit *), Bash(npm run *), Bash(uv run *), Read, Edit, Write, Grep, Glob, TodoWrite, Task, mcp__github__pull_request_read
+argument-hint: [pr-number] [--commit] [--push]
+description: Review PR workflow results and comments, then address substantive feedback and suggestions from reviewers
+---
+
+## Context
+
+- Repo: !`gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || echo "unknown"`
+- Current branch: !`git branch --show-current`
+- Git status: !`git status --porcelain=v2 --branch 2>/dev/null`
+- Staged changes: !`git diff --cached --numstat 2>/dev/null`
+- Unstaged changes: !`git diff --numstat 2>/dev/null`
+- Recent commits: !`git log --format='%h %s' -n 5`
+
+## Parameters
+
+Parse these parameters from the command (all optional):
+
+| Parameter | Description |
+|-----------|-------------|
+| `$1` | PR number (if not provided, detect from current branch) |
+| `--commit` | Create commit(s) after addressing feedback |
+| `--push` | Push changes after committing (implies --commit) |
+
+## Your Task
+
+Review PR workflow results and reviewer comments, then address substantive feedback.
+
+---
+
+### Step 1: Determine PR
+
+1. **Get PR number** from argument or detect from current branch:
+   ```bash
+   gh pr view --json number -q '.number'
+   ```
+
+2. **Verify branch alignment**: Ensure you're on the correct branch for the PR:
+   ```bash
+   gh pr view $PR --json headRefName -q '.headRefName'
+   ```
+
+3. **Switch to PR branch** if not already on it:
+   ```bash
+   git switch <branch-name>
+   git pull origin <branch-name>
+   ```
+
+---
+
+### Step 2: Gather PR Status
+
+Collect comprehensive information about the PR:
+
+#### 2a. Workflow/Check Results
+
+```bash
+# Get check status summary
+gh pr checks $PR --json name,state,conclusion,detailsUrl
+
+# For failed checks, get detailed logs
+gh run view $RUN_ID --log-failed
+```
+
+**Categorize check results:**
+
+| Status | Action |
+|--------|--------|
+| All passing | Skip to Step 3 (comments) |
+| Failed CI | Analyze failures, may need fixes |
+| Pending | Note status, focus on comments |
+
+#### 2b. PR Reviews and Comments
+
+```bash
+# Get review comments (inline code comments)
+gh api repos/{owner}/{repo}/pulls/$PR/comments --jq '.[] | {path: .path, line: .line, body: .body, user: .user.login, state: .state}'
+
+# Get review summaries (approve/request changes/comment)
+gh api repos/{owner}/{repo}/pulls/$PR/reviews --jq '.[] | {user: .user.login, state: .state, body: .body}'
+
+# Get issue-style comments (general discussion)
+gh api repos/{owner}/{repo}/issues/$PR/comments --jq '.[] | {user: .user.login, body: .body, created_at: .created_at}'
+```
+
+---
+
+### Step 3: Analyze Feedback
+
+Create a structured analysis of all feedback:
+
+#### 3a. Categorize Comments
+
+| Category | Description | Priority |
+|----------|-------------|----------|
+| **Blocking** | "Request changes" reviews, critical bugs | Must address |
+| **Substantive** | Code improvements, logic issues, missing tests | Should address |
+| **Suggestions** | Style preferences, optional enhancements | Consider |
+| **Questions** | Clarification requests | Respond inline |
+| **Nitpicks** | Minor style/formatting | Low priority |
+| **Resolved** | Already addressed or outdated | Skip |
+
+#### 3b. Identify Actionable Items
+
+For each comment, determine:
+
+1. **Is it actionable?** (code change vs discussion)
+2. **Location**: File and line number (for inline comments)
+3. **Scope**: Single line fix vs broader refactor
+4. **Dependencies**: Does it affect other changes?
+
+**Create a todo list** using TodoWrite with all actionable items.
+
+---
+
+### Step 4: Address Feedback
+
+Work through the actionable items systematically:
+
+#### 4a. For Code Review Comments
+
+1. **Read the relevant code** at the specified location
+2. **Understand the context** of the reviewer's concern
+3. **Implement the fix** following their suggestion or your improved approach
+4. **Verify the change** doesn't break existing functionality
+
+#### 4b. For Failed CI Checks
+
+1. **Identify the failure type**:
+   - Linting errors → Run formatters/linters
+   - Type errors → Fix type annotations
+   - Test failures → Fix tests or implementation
+   - Build errors → Resolve dependency/import issues
+
+2. **Run locally** to verify fix:
+   ```bash
+   # Examples based on project type
+   npm run lint -- --fix
+   npm run typecheck
+   npm test
+
+   uv run ruff check --fix .
+   uv run pytest
+   ```
+
+#### 4c. For Questions/Clarifications
+
+If a comment requires explanation rather than code change:
+- Note that you should reply to the comment after pushing
+- Consider if documentation/comments would help future readers
+
+---
+
+### Step 5: Commit Changes (if --commit or --push)
+
+1. **Group related fixes** into logical commits:
+   ```bash
+   # Stage specific files for each commit
+   git add <files-for-fix-1>
+   git commit -m "fix: address review feedback - <specific change>"
+   ```
+
+2. **Commit message format**:
+   ```
+   fix: address PR review feedback
+
+   - <Change 1 description>
+   - <Change 2 description>
+
+   Co-authored-by: <reviewer> (if they provided specific code)
+   ```
+
+3. **Run pre-commit hooks** if configured:
+   ```bash
+   pre-commit run --all-files
+   git add -u  # Stage any formatter changes
+   ```
+
+---
+
+### Step 6: Push Changes (if --push)
+
+```bash
+git push origin HEAD
+```
+
+---
+
+### Step 7: Summary Report
+
+Provide a summary of actions taken:
+
+```markdown
+## PR Feedback Summary
+
+### Workflow Status
+- CI Checks: [PASS/FAIL] - <details>
+- Review Status: [Approved/Changes Requested/Pending]
+
+### Feedback Addressed
+
+| Category | Count | Status |
+|----------|-------|--------|
+| Blocking | N | ✅ Resolved |
+| Substantive | N | ✅ Resolved |
+| Suggestions | N | ✅/⏭️ Addressed/Deferred |
+| Questions | N | 💬 Need response |
+
+### Changes Made
+- <File 1>: <description of change>
+- <File 2>: <description of change>
+
+### Next Steps
+- [ ] Reply to clarification questions on PR
+- [ ] Re-request review from <reviewer>
+- [ ] Monitor CI for new run
+```
+
+---
+
+## Decision Tree: Handling Different Feedback Types
+
+```
+Is it a "Request Changes" review?
+├─ Yes → Must address all blocking concerns
+└─ No → Is it an inline code comment?
+         ├─ Yes → Does it suggest a specific fix?
+         │        ├─ Yes → Implement the suggestion (or better alternative)
+         │        └─ No → Analyze and determine best fix
+         └─ No → Is it a general comment/question?
+                  ├─ Yes → Note for PR reply
+                  └─ No → Is it a resolved/outdated comment?
+                           ├─ Yes → Skip
+                           └─ No → Evaluate importance
+```
+
+---
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Quick check status | `gh pr checks $PR --json name,state,conclusion` |
+| Failed check logs | `gh run view $ID --log-failed` |
+| Review comments | `gh api repos/{owner}/{repo}/pulls/$PR/comments` |
+| Review summaries | `gh api repos/{owner}/{repo}/pulls/$PR/reviews` |
+| PR discussion | `gh api repos/{owner}/{repo}/issues/$PR/comments` |
+
+---
+
+## See Also
+
+- **/git:fix-pr** - Focus on CI failures specifically
+- **gh-cli-agentic** skill - Optimized GitHub CLI patterns
+- **git-branch-pr-workflow** skill - PR workflow patterns


### PR DESCRIPTION
## Summary

Adds a new `/git:pr-feedback` command to the git-plugin that enables developers to systematically review and address PR feedback, including workflow check results and reviewer comments.

## Changes

- **New command**: `/git:pr-feedback` - Reviews PR workflow results and comments, then addresses substantive feedback from reviewers
  - Supports optional PR number argument (detects from current branch if not provided)
  - Optional `--commit` flag to create commits after addressing feedback
  - Optional `--push` flag to push changes (implies `--commit`)

- **Documentation**: Added comprehensive `pr-feedback.md` command guide including:
  - 7-step workflow for gathering PR status, analyzing feedback, and addressing issues
  - Feedback categorization system (blocking, substantive, suggestions, questions, nitpicks, resolved)
  - Decision tree for handling different feedback types
  - Integration with GitHub CLI for retrieving checks, reviews, and comments
  - Support for both code review comments and CI check failures

- **Plugin metadata**: Updated `plugin.json` to register new keywords (`pr-feedback`, `code-review`)

- **README**: Added command documentation with usage examples

## Implementation Details

The command follows a structured 7-step process:
1. Determine and verify the PR number and branch alignment
2. Gather comprehensive PR status (workflow checks and reviews)
3. Analyze and categorize feedback by priority and actionability
4. Address feedback through code changes or CI fixes
5. Create logical commits (if `--commit` flag)
6. Push changes (if `--push` flag)
7. Generate summary report of actions taken

The workflow integrates with GitHub CLI (`gh`) for retrieving PR metadata, check results, and review comments, and supports local testing/fixing of CI failures using common tools (npm, uv, pre-commit).

https://claude.ai/code/session_01Qhcie3S6iWDAnhsYEHAorE