### PR TITLE
Update Claude code action to use model parameter in args

### DIFF
--- a/.github/workflows/skill-quality-review.yml
+++ b/.github/workflows/skill-quality-review.yml
@@ -35,8 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: haiku
-          claude_args: "--max-turns 10"
+          claude_args: "--model haiku --max-turns 10"
           prompt: |
             Review the changed skill and command files in this PR for quality compliance.
             Read the rules at .claude/rules/skill-quality.md for the full checklist.


### PR DESCRIPTION
## Summary
Updated the GitHub Actions workflow configuration to pass the model specification through the `claude_args` parameter instead of using a separate `model` input field.

## Changes
- Removed the `model: haiku` input parameter from the Claude code action
- Consolidated model specification into `claude_args` as `--model haiku`
- Maintained the existing `--max-turns 10` configuration in the same parameter

## Details
This change aligns with the Claude code action's expected parameter format, passing model configuration through the command-line arguments rather than as a separate input. The functionality remains the same while improving consistency with how the action processes configuration options.

https://claude.ai/code/session_01BQv1bjyig72Kf16saCugnX