### PR TITLE
feat(tools-plugin): enhance justfile skill with MCP, shebang, and dotenv features

### DIFF
--- a/tools-plugin/skills/justfile-expert/REFERENCE.md
+++ b/tools-plugin/skills/justfile-expert/REFERENCE.md
@@ -8,10 +8,17 @@
 # Load .env file automatically
 set dotenv-load
 
-# Load specific .env file
+# Load specific .env filename (searches in working dir and parents)
 set dotenv-filename := ".env.local"
 
-# Required .env file (fail if missing)
+# Load .env from specific path (absolute or relative to working dir)
+# Takes precedence over dotenv-filename; can override with -E flag
+set dotenv-path := "config/.env"
+
+# Override existing env vars with .env values (default: false)
+set dotenv-override
+
+# Required .env file (fail if missing, default: false)
 set dotenv-required
 
 # Export all variables as environment variables
@@ -134,10 +141,23 @@ config := config_directory()      # Config dir
 data := data_directory()          # Data dir
 
 # String operations
-upper := uppercase('hello')       # "HELLO"
-lower := lowercase('HELLO')       # "hello"
-trim := trim('  hi  ')           # "hi"
-replace := replace('ab', 'a', 'x') # "xb"
+upper := uppercase('hello')              # "HELLO"
+lower := lowercase('HELLO')              # "hello"
+trim := trim('  hi  ')                   # "hi"
+trim_start := trim_start('  hi  ')       # "hi  "
+trim_end := trim_end('  hi  ')           # "  hi"
+replace := replace('ab', 'a', 'x')       # "xb"
+replace_re := replace_regex('a1b2', '\d', 'X')  # "aXbX"
+
+# Case conversion
+snake := snakecase('fooBar')             # "foo_bar"
+kebab := kebabcase('fooBar')             # "foo-bar"
+title := titlecase('hello world')        # "Hello World"
+
+# String building
+prefixed := prepend('prefix_', 'name')   # "prefix_name"
+suffixed := append('name', '_suffix')    # "name_suffix"
+quoted := quote("it's")                  # "'it'\"'\"'s'" (shell-safe)
 
 # Path joining
 full := join('a', 'b', 'c')       # "a/b/c"
@@ -153,9 +173,40 @@ id := uuid()                      # Random UUID
 hash := sha256('content')
 hash_file := sha256_file('path')
 
+# Blake3 hash (faster alternative)
+b3_hash := blake3('content')
+b3_file := blake3_file('path')
+
 # Justfile location
 just_dir := justfile_directory()
 just_path := justfile()
+
+# External command execution
+output := shell('echo hello')           # Execute and capture output
+output := shell('echo', 'hello')        # With separate args
+
+# Executable discovery
+bin_path := which('python3')            # Find in PATH, empty if not found
+required_bin := require('python3')      # Find in PATH, error if missing
+
+# File operations
+exists := path_exists('config.json')    # Boolean check
+contents := read('VERSION')             # Read file contents
+
+# System info
+cpus := num_cpus()                      # Number of CPUs
+
+# Error handling
+error('message')                        # Abort with error message
+
+# Datetime
+now := datetime('%Y-%m-%d')             # Current date/time formatted
+
+# Semantic version matching
+matches := semver_matches('1.2.3', '>=1.0.0')
+
+# Random selection
+pick := choose('a', 'b', 'c')           # Random item from list
 ```
 
 ### Parameter Patterns
@@ -198,6 +249,25 @@ exec *args:
 ## Advanced Patterns
 
 ### Shebang Recipes
+
+Recipes starting with `#!` execute as scripts, saved to a temp file and run with the specified interpreter.
+
+**Platform Behavior:**
+- **Unix/macOS**: OS handles shebang natively
+- **Windows**: Just manually parses the shebang and invokes the interpreter (no native shebang support)
+
+**Using `-S` flag for arguments:**
+```just
+# When interpreter needs arguments, use -S to split them
+process:
+    #!/usr/bin/env -S python3 -u
+    import sys
+    print("Unbuffered output", flush=True)
+
+strict-bash:
+    #!/usr/bin/env -S bash -euo pipefail
+    echo "Running with strict mode"
+```
 
 ```just
 # Python script

--- a/tools-plugin/skills/justfile-expert/SKILL.md
+++ b/tools-plugin/skills/justfile-expert/SKILL.md
@@ -1,20 +1,32 @@
 ---
 model: haiku
 created: 2025-12-16
-modified: 2025-12-16
-reviewed: 2025-12-16
+modified: 2026-02-01
+reviewed: 2026-02-01
 name: justfile-expert
 description: |
   Just command runner expertise, Justfile syntax, recipe development, and cross-platform
-  task automation. Covers recipe patterns, parameters, modules, settings, and workflow
-  integration. Use when user mentions just, justfile, recipes, command runner, task
-  automation, project commands, or needs help writing executable project documentation.
+  task automation. Covers recipe patterns, parameters, modules, settings, shebang recipes
+  for multi-language scripts, and workflow integration. Use when user mentions just,
+  justfile, recipes, command runner, task automation, project commands, or needs help
+  writing executable project documentation.
 allowed-tools: Bash, BashOutput, Grep, Glob, Read, Write, Edit, TodoWrite
 ---
 
 # Justfile Expert
 
 Expert knowledge for Just command runner, recipe development, and task automation with focus on cross-platform compatibility and project standardization.
+
+## When to Use This Skill
+
+| Use this skill when... | Use alternative when... |
+|------------------------|------------------------|
+| Creating/editing justfiles for task automation | Need build system with incremental compilation → Make |
+| Writing cross-platform project commands | Need tool version management bundled → mise tasks |
+| Adding shebang recipes (Python, Node, Ruby, etc.) | Already using mise for all project tooling |
+| Configuring dotenv loading and settings | Simple one-off shell scripts → Bash directly |
+| Setting up CI/CD with just recipes | Project already has extensive Makefile |
+| Standardizing recipes across projects | Need Docker-specific workflows → docker-compose |
 
 ## Core Expertise
 
@@ -56,8 +68,11 @@ Expert knowledge for Just command runner, recipe development, and task automatio
 - **`[private]`**: Hide from `--list` output
 - **`[no-cd]`**: Don't change directory
 - **`[no-exit-message]`**: Suppress exit messages
-- **`[unix]`** / **`[windows]`**: Platform-specific recipes
+- **`[unix]`** / **`[windows]`** / **`[linux]`** / **`[macos]`**: Platform-specific recipes
 - **`[positional-arguments]`**: Per-recipe positional args
+- **`[confirm]`** / **`[confirm("message")]`**: Require confirmation before running
+- **`[group: "name"]`**: Group recipes in `--list` output
+- **`[working-directory: "path"]`**: Run in specific directory
 
 **Module System**
 - **`mod name`**: Declare submodule
@@ -232,6 +247,53 @@ release version:
     git tag -a "v{{version}}" -m "Release {{version}}"
     git push origin "v{{version}}"
 ```
+
+## MCP Integration (just-mcp)
+
+The `just-mcp` MCP server enables AI assistants to discover and execute justfile recipes through the Model Context Protocol, reducing context waste since the AI doesn't need to read the full justfile.
+
+**Installation:**
+```bash
+# Via npm
+npx just-mcp --stdio
+
+# Via pip/uvx
+uvx just-mcp --stdio
+
+# Via cargo
+cargo install just-mcp
+```
+
+**Claude Desktop configuration (`.claude/mcp.json`):**
+```json
+{
+  "mcpServers": {
+    "just-mcp": {
+      "command": "npx",
+      "args": ["-y", "just-mcp", "--stdio"]
+    }
+  }
+}
+```
+
+**Available MCP Tools:**
+- `list_recipes` - Discover all recipes and parameters
+- `run_recipe` - Execute a recipe with arguments
+- `get_recipe_info` - Get detailed recipe documentation
+- `validate_justfile` - Check for syntax errors
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| List all recipes | `just --list` or `just -l` |
+| Dry run (preview) | `just --dry-run recipe` |
+| Show variables | `just --evaluate` |
+| JSON recipe list | `just --dump --dump-format json` |
+| Verbose execution | `just --verbose recipe` |
+| Specific justfile | `just --justfile path recipe` |
+| Working directory | `just --working-directory path recipe` |
+| Choose interactively | `just --choose` |
 
 ## Best Practices
 


### PR DESCRIPTION
Add comprehensive justfile improvements:
- Add 'When to Use' decision table (per skill-quality.md)
- Add just-mcp MCP server integration section with Claude config
- Add Agentic Optimizations table for AI workflows
- Enhance shebang recipes with Windows handling and -S flag
- Add missing dotenv settings (dotenv-path, dotenv-override)
- Add newer built-in functions (shell, require, which, read, etc.)
- Add additional recipe attributes ([confirm], [group], [working-directory])
- Add string functions (snakecase, kebabcase, titlecase, etc.)
- Update metadata dates

https://claude.ai/code/session_018ngaAd7KXAB2Jhb4s6q7Fx