### PR TITLE
Switch orchestrator enforcement to opt-in mode

### DIFF
--- a/agent-patterns-plugin/hooks/orchestrator-enforcement.sh
+++ b/agent-patterns-plugin/hooks/orchestrator-enforcement.sh
@@ -6,7 +6,7 @@
 # Subagents (spawned via Task) get full tool access.
 #
 # Configuration:
-#   ORCHESTRATOR_BYPASS=1        - Disable this hook entirely
+#   ORCHESTRATOR_MODE=1          - Enable orchestrator enforcement (disabled by default)
 #   CLAUDE_IS_SUBAGENT=1         - Set by parent to grant full access
 #
 # Exit codes:
@@ -17,8 +17,8 @@
 
 set -euo pipefail
 
-# Bypass check
-[[ "${ORCHESTRATOR_BYPASS:-0}" == "1" ]] && exit 0
+# Opt-in check: if orchestrator mode is not enabled, allow everything
+[[ "${ORCHESTRATOR_MODE:-0}" != "1" ]] && exit 0
 
 # Subagent detection - environment variable set by parent agent
 # When Task spawns subagents, set CLAUDE_IS_SUBAGENT=1 in the environment


### PR DESCRIPTION
## Summary
Changed the orchestrator enforcement hook from an opt-out model (disabled via `ORCHESTRATOR_BYPASS`) to an opt-in model (enabled via `ORCHESTRATOR_MODE`). This makes the enforcement disabled by default, requiring explicit enablement for orchestrator-specific access controls.

## Key Changes
- Renamed configuration variable from `ORCHESTRATOR_BYPASS=1` to `ORCHESTRATOR_MODE=1`
- Inverted the logic: enforcement is now disabled by default and must be explicitly enabled
- Updated the conditional check from `== "1"` (bypass enabled) to `!= "1"` (mode not enabled)
- Updated comments to reflect the new opt-in behavior

## Implementation Details
The change shifts the security model from "opt-out enforcement" to "opt-in enforcement". Previously, the hook would enforce restrictions unless explicitly bypassed. Now, the hook allows full access by default and only enforces restrictions when `ORCHESTRATOR_MODE=1` is set. This provides better backwards compatibility and makes the enforcement behavior more explicit and intentional.

https://claude.ai/code/session_01UH2Rapf6nuFYTs6BjrTV1n