### PR TITLE
fix: remove shell operators from context commands in multiple plugins

### DIFF
--- a/agent-patterns-plugin/commands/delegate.md
+++ b/agent-patterns-plugin/commands/delegate.md
@@ -1,7 +1,7 @@
 ---
 model: opus
 created: 2025-12-16
-modified: 2025-12-16
+modified: 2026-02-03
 reviewed: 2025-12-16
 description: Delegate tasks to specialized agents with automatic task-agent matching and parallel execution
 allowed-tools: Task, TodoWrite, AskUserQuestion
@@ -11,9 +11,9 @@ argument-hint: "<task-description>"
 ## Context
 
 - Working directory: !`pwd`
-- Git status: !`git status --porcelain 2>/dev/null | head -10`
-- Project type: !`ls -1 package.json pyproject.toml Cargo.toml go.mod 2>/dev/null | head -1`
-- Recent files: !`git diff --name-only HEAD~5 2>/dev/null | head -10`
+- Git status: !`git status --porcelain 2>/dev/null`
+- Project files: !`ls -1 package.json pyproject.toml Cargo.toml go.mod 2>/dev/null`
+- Recent files: !`git diff --name-only HEAD~5 2>/dev/null`
 
 ## Parameters
 

--- a/agents-plugin/commands/agents-analyze.md
+++ b/agents-plugin/commands/agents-analyze.md
@@ -5,7 +5,7 @@ args: "[--focus <plugin-name>]"
 allowed-tools: Glob, Grep, Read, Bash(ls *), Bash(wc *), TodoWrite
 argument-hint: "analyze all plugins or --focus <plugin-name>"
 created: 2026-01-24
-modified: 2026-01-24
+modified: 2026-02-03
 reviewed: 2026-01-24
 ---
 
@@ -15,10 +15,10 @@ Analyze the plugin collection to identify where sub-agents would improve workflo
 
 ## Context
 
-- Plugins: !`ls -d */  2>/dev/null | grep -c plugin`
-- Existing agents: !`ls agents-plugin/agents/*.md 2>/dev/null | xargs -I{} basename {} .md | tr '\n' ', '`
-- Total skills: !`find . -path '*/skills/*/skill.md' 2>/dev/null | wc -l`
-- Total commands: !`find . -path '*/commands/*.md' 2>/dev/null | wc -l`
+- Plugin directories: !`ls -d *-plugin/ 2>/dev/null`
+- Existing agents: !`ls agents-plugin/agents/*.md 2>/dev/null`
+- Skills: !`find . -path '*/skills/*/skill.md' 2>/dev/null`
+- Commands: !`find . -path '*/commands/*.md' -not -path './agents-plugin/*' 2>/dev/null`
 
 ## Parameters
 

--- a/code-quality-plugin/commands/code/antipatterns.md
+++ b/code-quality-plugin/commands/code/antipatterns.md
@@ -1,7 +1,7 @@
 ---
 model: opus
 created: 2025-12-16
-modified: 2025-12-16
+modified: 2026-02-03
 reviewed: 2025-12-16
 description: Analyze codebase for anti-patterns, code smells, and quality issues using ast-grep
 allowed-tools: Read, Bash(sg *), Bash(rg *), Glob, Grep, TodoWrite, Task
@@ -11,11 +11,9 @@ argument-hint: "[PATH] [--focus <category>] [--severity <level>]"
 ## Context
 
 - Analysis path: !`echo "${1:-.}"`
-- Languages detected: !`find ${1:-.} -type f \( -name "*.js" -o -name "*.ts" -o -name "*.jsx" -o -name "*.tsx" -o -name "*.vue" -o -name "*.py" \) 2>/dev/null | head -5 | xargs -I {} basename {} | sed 's/.*\.//' | sort -u | tr '\n' ' '`
-- Total source files: !`find ${1:-.} -type f \( -name "*.js" -o -name "*.ts" -o -name "*.jsx" -o -name "*.tsx" -o -name "*.vue" -o -name "*.py" \) 2>/dev/null | wc -l`
-- Has Vue: !`find ${1:-.} -name "*.vue" 2>/dev/null -print -quit`
-- Has React: !`find ${1:-.} -name "*.tsx" -o -name "*.jsx" 2>/dev/null -print -quit`
-- Has Python: !`find ${1:-.} -name "*.py" 2>/dev/null -print -quit`
+- JS/TS files: !`find ${1:-.} -type f \( -name "*.js" -o -name "*.ts" -o -name "*.jsx" -o -name "*.tsx" \) 2>/dev/null`
+- Vue files: !`find ${1:-.} -name "*.vue" 2>/dev/null`
+- Python files: !`find ${1:-.} -name "*.py" 2>/dev/null`
 
 ## Your Task
 

--- a/documentation-plugin/commands/docs/generate.md
+++ b/documentation-plugin/commands/docs/generate.md
@@ -1,7 +1,7 @@
 ---
 model: opus
 created: 2025-12-16
-modified: 2025-12-16
+modified: 2026-02-03
 reviewed: 2025-12-16
 allowed-tools: Task, TodoWrite
 argument-hint: [--api] [--readme] [--changelog]
@@ -10,10 +10,10 @@ description: Update project documentation from code annotations
 
 ## Context
 
-- Project type: !`ls -la pyproject.toml package.json Cargo.toml go.mod 2>/dev/null | head -1`
+- Project files: !`ls -la pyproject.toml package.json Cargo.toml go.mod 2>/dev/null`
 - Existing docs: !`ls -la README.md docs/ 2>/dev/null`
-- Source files: !`find . -type f \( -name "*.py" -o -name "*.ts" -o -name "*.js" \) | head -10`
-- Docstrings sample: !`grep -r "\"\"\"" --include="*.py" -l 2>/dev/null | head -3`
+- Source files: !`find . -type f \( -name "*.py" -o -name "*.ts" -o -name "*.js" \) 2>/dev/null`
+- Python with docstrings: !`grep -r "\"\"\"" --include="*.py" -l 2>/dev/null`
 
 ## Parameters
 

--- a/git-plugin/commands/git/derive-docs.md
+++ b/git-plugin/commands/git/derive-docs.md
@@ -1,7 +1,7 @@
 ---
 model: opus
 created: 2026-01-24
-modified: 2026-01-24
+modified: 2026-02-03
 reviewed: 2026-01-24
 allowed-tools: Bash(git log *), Bash(git shortlog *), Bash(git diff *), Bash(git branch *),
                Bash(git show *), Bash(git rev-list *), Bash(git diff-tree *),
@@ -14,7 +14,6 @@ description: Analyze git history to derive undocumented rules, PRDs, ADRs, and P
 
 - Current branch: !`git branch --show-current`
 - Commit count: !`git rev-list --count HEAD 2>/dev/null`
-- First commit: !`git log --format='%ai' --reverse 2>/dev/null | head -1`
 - Latest commit: !`git log --format='%ai' -1 2>/dev/null`
 - Existing rules: !`ls .claude/rules/ 2>/dev/null`
 - Existing docs: !`ls docs/prds/ docs/adrs/ docs/prps/ 2>/dev/null`

--- a/testing-plugin/commands/test/focus.md
+++ b/testing-plugin/commands/test/focus.md
@@ -1,7 +1,7 @@
 ---
 model: haiku
 created: 2026-01-19
-modified: 2026-01-19
+modified: 2026-02-03
 reviewed: 2026-01-19
 allowed-tools: Bash, Read, Grep, Glob, TodoWrite
 argument-hint: "<file-path> [--serial] [--debug]"
@@ -10,12 +10,12 @@ description: Run single test file with fail-fast mode for rapid iteration
 
 ## Context
 
-- Project type: !`ls -la pyproject.toml package.json Cargo.toml go.mod 2>/dev/null | head -1`
+- Project files: !`ls -la pyproject.toml package.json Cargo.toml go.mod 2>/dev/null`
 - Playwright config: !`ls playwright.config.* 2>/dev/null`
 - Vitest config: !`ls vitest.config.* vite.config.* 2>/dev/null`
 - Jest config: !`ls jest.config.* 2>/dev/null`
 - Pytest config: !`grep -l "pytest" pyproject.toml setup.cfg 2>/dev/null`
-- Package scripts: !`cat package.json 2>/dev/null | grep -E '"test' | head -5`
+- Package.json: !`cat package.json 2>/dev/null`
 
 ## Parameters
 

--- a/testing-plugin/commands/test/full.md
+++ b/testing-plugin/commands/test/full.md
@@ -1,7 +1,7 @@
 ---
 model: haiku
 created: 2025-12-16
-modified: 2025-12-16
+modified: 2026-02-03
 reviewed: 2025-12-16
 allowed-tools: Task, TodoWrite
 argument-hint: "[--coverage] [--parallel] [--report]"
@@ -10,8 +10,8 @@ description: Complete test suite including integration and E2E tests
 
 ## Context
 
-- Project type: !`ls -la pyproject.toml package.json Cargo.toml go.mod 2>/dev/null | head -1`
-- Test structure: !`find . -type d -name "test*" -o -name "__tests__" 2>/dev/null | head -10`
+- Project files: !`ls -la pyproject.toml package.json Cargo.toml go.mod 2>/dev/null`
+- Test directories: !`find . -type d \( -name "test*" -o -name "__tests__" \) 2>/dev/null`
 - E2E setup: !`ls -la playwright.config.* cypress.config.* 2>/dev/null`
 - CI environment: !`echo "CI=$CI GITHUB_ACTIONS=$GITHUB_ACTIONS"`
 


### PR DESCRIPTION
Context commands using `!` backtick syntax cannot use shell operators
(|, &&, ||, etc.) as they are blocked by Claude Code's shell operator
protections for safety.

Fixed files:
- git-plugin: derive-docs.md - removed pipe to head
- agents-plugin: agents-analyze.md - removed grep/wc pipe chains
- code-quality-plugin: antipatterns.md - simplified find commands
- agent-patterns-plugin: delegate.md - removed head pipe limits
- documentation-plugin: generate.md - removed head pipe limits
- testing-plugin: full.md, focus.md - removed head pipe limits
- home-assistant-plugin: ha-validate.md - replaced Jinja2 pipe syntax

https://claude.ai/code/session_01DZQGzwwKBV2QAVMhP6WnCk