### PR TITLE
Add ArgoCD auto-merge workflow configuration

### DIFF
--- a/configure-plugin/README.md
+++ b/configure-plugin/README.md
@@ -24,6 +24,7 @@ All commands support two modes:
 
 | Command | Description |
 |---------|-------------|
+| `/configure:argocd-automerge` | Auto-merge workflow for ArgoCD Image Updater branches |
 | `/configure:claude-plugins` | Configure Claude Code plugin marketplace and GitHub Actions workflows |
 | `/configure:pre-commit` | Pre-commit hooks for project standards |
 | `/configure:release-please` | Release-please workflow configuration |

--- a/configure-plugin/commands/configure/argocd-automerge.md
+++ b/configure-plugin/commands/configure/argocd-automerge.md
@@ -1,0 +1,160 @@
+---
+model: haiku
+created: 2026-02-03
+modified: 2026-02-03
+reviewed: 2026-02-03
+description: Configure auto-merge workflow for ArgoCD Image Updater branches
+allowed-tools: Glob, Grep, Read, Write, Edit, TodoWrite
+argument-hint: "[--check-only] [--fix]"
+---
+
+# /configure:argocd-automerge
+
+Configure GitHub Actions workflow to automatically create and merge PRs from ArgoCD Image Updater branches.
+
+## Context
+
+ArgoCD Image Updater creates branches matching `image-updater-**` when updating container images. This workflow:
+1. Creates a PR from the image updater branch
+2. Approves the PR (requires PAT for self-approval)
+3. Enables auto-merge with squash
+
+**Prerequisites:**
+- Repository must have auto-merge enabled in settings
+- Branch protection rules must allow auto-merge
+- Optional: `AUTO_MERGE_PAT` secret for self-approval (different from workflow actor)
+
+## Workflow
+
+### Phase 1: Detection
+
+1. Check for `.github/workflows/` directory
+2. Look for existing ArgoCD auto-merge workflow
+3. Check for `image-updater-**` branch pattern handling
+
+### Phase 2: Compliance Check
+
+| Check | Standard | Severity |
+|-------|----------|----------|
+| Workflow exists | argocd-automerge.yml | FAIL if missing |
+| checkout action | v4 | WARN if older |
+| Permissions | contents: write, pull-requests: write | FAIL if missing |
+| Branch pattern | `image-updater-**` | WARN if different |
+| Auto-merge | squash merge | INFO |
+
+### Phase 3: Report
+
+```
+ArgoCD Auto-merge Workflow Status
+======================================
+Workflow: .github/workflows/argocd-automerge.yml
+
+Status:
+  Workflow exists     ✅ PASS
+  checkout action     v4              ✅ PASS
+  Permissions         Explicit        ✅ PASS
+  Branch pattern      image-updater-  ✅ PASS
+  Auto-merge          squash          ✅ PASS
+
+Overall: PASS
+```
+
+### Phase 4: Configuration (If Requested)
+
+If `--fix` flag or user confirms, create/update workflow.
+
+## Standard Template
+
+**File**: `.github/workflows/argocd-automerge.yml`
+
+```yaml
+name: Auto-merge ArgoCD Image Updater branches
+
+on:
+  push:
+    branches:
+      - 'image-updater-**'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-and-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create Pull Request
+        id: create-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "${{ github.ref_name }}" \
+            --title "chore(deps): update container image" \
+            --body "Automated image update by argocd-image-updater.
+
+          Branch: \`${{ github.ref_name }}\`" \
+            2>&1) || true
+
+          # Check if PR already exists
+          if echo "$PR_URL" | grep -q "already exists"; then
+            PR_URL=$(gh pr view "${{ github.ref_name }}" --json url -q .url)
+          fi
+
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+          echo "Created/found PR: $PR_URL"
+
+      - name: Approve PR
+        env:
+          GH_TOKEN: ${{ secrets.AUTO_MERGE_PAT || secrets.GITHUB_TOKEN }}
+        run: gh pr review --approve "${{ github.ref_name }}"
+        continue-on-error: true
+
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "${{ github.ref_name }}"
+```
+
+## Configuration Notes
+
+### Self-Approval
+
+GitHub prevents workflows from approving their own PRs with `GITHUB_TOKEN`. Options:
+
+| Approach | Setup | Notes |
+|----------|-------|-------|
+| `AUTO_MERGE_PAT` | Create PAT with `repo` scope, add as secret | Recommended for full automation |
+| Skip approval | Remove approve step | Requires manual approval or CODEOWNERS bypass |
+| Bot account | Use separate bot user's PAT | Enterprise approach |
+
+### Branch Protection
+
+Ensure branch protection allows:
+- Auto-merge when checks pass
+- Bypass for the workflow (if using CODEOWNERS)
+
+### Customization
+
+| Setting | Default | Alternatives |
+|---------|---------|--------------|
+| Base branch | `main` | `master`, `develop` |
+| Merge strategy | `--squash` | `--merge`, `--rebase` |
+| PR title | `chore(deps): update container image` | Custom format |
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--check-only` | Report status without offering fixes |
+| `--fix` | Create/update workflow automatically |
+
+## See Also
+
+- `/configure:workflows` - GitHub Actions CI/CD workflows
+- `/configure:container` - Container infrastructure
+- `ci-workflows` skill - Workflow patterns


### PR DESCRIPTION
## Summary

Adds a new `/configure:argocd-automerge` command to configure GitHub Actions workflows that automatically create and merge pull requests from ArgoCD Image Updater branches.

## Changes

- **New command documentation**: Added `configure-plugin/commands/configure/argocd-automerge.md` with comprehensive guide for the auto-merge workflow
  - Detection and compliance checking phases
  - Standard workflow template with best practices
  - Configuration notes for self-approval, branch protection, and customization
  - Support for `--check-only` and `--fix` flags

- **Updated README**: Added `/configure:argocd-automerge` to the command table in `configure-plugin/README.md`

- **Updated skill documentation**: Enhanced `configure-plugin/skills/ci-workflows/SKILL.md` with ArgoCD auto-merge workflow details
  - Added as optional workflow (section 3)
  - Included complete workflow template
  - Added to workflow checklist with "Optional (if using ArgoCD Image Updater)" note

## Implementation Details

The workflow:
1. Triggers on `image-updater-**` branches created by ArgoCD Image Updater
2. Creates a PR automatically if one doesn't exist
3. Approves the PR (with optional `AUTO_MERGE_PAT` secret for self-approval)
4. Enables auto-merge with squash strategy

Key features:
- Handles existing PR detection to avoid duplicates
- Supports optional PAT for bypassing GitHub's self-approval restrictions
- Requires repository auto-merge and branch protection configuration
- Includes comprehensive documentation on prerequisites and customization options

https://claude.ai/code/session_012e28DnSh3WLgrAySJbb7xz