### PR TITLE
Standardize command metadata formatting across plugins

### DIFF
--- a/blueprint-plugin/commands/blueprint-curate-docs.md
+++ b/blueprint-plugin/commands/blueprint-curate-docs.md
@@ -1,10 +1,12 @@
 ---
 model: opus
-created: 2025-12-16
-modified: 2026-01-09
-reviewed: 2025-12-16
 description: "Curate library or project documentation for ai_docs to optimize AI context"
-allowed_tools: [Read, Write, Glob, Bash, WebFetch, WebSearch, AskUserQuestion]
+args: "[library-name|project:pattern-name]"
+argument-hint: "Library name (e.g., redis, pydantic) or project:pattern-name"
+allowed-tools: Read, Write, Glob, Bash, WebFetch, WebSearch, AskUserQuestion
+created: 2025-12-16
+modified: 2026-02-03
+reviewed: 2025-12-16
 ---
 
 Curate documentation for a library or project pattern into an ai_docs entry.

--- a/blueprint-plugin/commands/blueprint-prp-create.md
+++ b/blueprint-plugin/commands/blueprint-prp-create.md
@@ -1,10 +1,12 @@
 ---
 model: opus
-created: 2025-12-16
-modified: 2026-01-17
-reviewed: 2025-12-16
 description: "Create a PRP (Product Requirement Prompt) with systematic research, curated context, and validation gates"
-allowed_tools: [Read, Write, Glob, Bash, WebFetch, WebSearch, Task, AskUserQuestion]
+args: "[feature-name]"
+argument-hint: "Feature name for the PRP (e.g., auth-oauth2, api-rate-limiting)"
+allowed-tools: Read, Write, Glob, Bash, WebFetch, WebSearch, Task, AskUserQuestion
+created: 2025-12-16
+modified: 2026-02-03
+reviewed: 2025-12-16
 ---
 
 Create a comprehensive PRP (Product Requirement Prompt) for a feature or component.

--- a/blueprint-plugin/commands/blueprint-prp-execute.md
+++ b/blueprint-plugin/commands/blueprint-prp-execute.md
@@ -1,10 +1,12 @@
 ---
 model: opus
-created: 2025-12-16
-modified: 2026-01-17
-reviewed: 2025-12-16
 description: "Execute a PRP with validation loop, TDD workflow, and quality gates"
-allowed_tools: [Read, Write, Edit, Glob, Bash, Task, AskUserQuestion]
+args: "[prp-name]"
+argument-hint: "Name of PRP to execute (e.g., feature-auth-oauth2)"
+allowed-tools: Read, Write, Edit, Glob, Bash, Task, AskUserQuestion
+created: 2025-12-16
+modified: 2026-02-03
+reviewed: 2025-12-16
 ---
 
 Execute a PRP (Product Requirement Prompt) with systematic implementation and validation.

--- a/documentation-plugin/commands/docs/sync.md
+++ b/documentation-plugin/commands/docs/sync.md
@@ -1,10 +1,12 @@
 ---
 model: opus
-created: 2025-12-16
-modified: 2025-12-16
-reviewed: 2025-12-16
 description: "Synchronize documentation with actual skills, commands, and agents in the codebase"
-allowed_tools: [Bash, Grep, Glob, Read, Edit, Write, TodoWrite]
+args: "[--scope <type>] [--dry-run] [--verbose]"
+argument-hint: "--scope skills|commands|agents, --dry-run to preview, --verbose for details"
+allowed-tools: Bash, Grep, Glob, Read, Edit, Write, TodoWrite
+created: 2025-12-16
+modified: 2026-02-03
+reviewed: 2025-12-16
 ---
 
 # /docs:sync [OPTIONS]

--- a/project-plugin/commands/project/continue.md
+++ b/project-plugin/commands/project/continue.md
@@ -1,10 +1,12 @@
 ---
 model: opus
-created: 2025-12-16
-modified: 2026-02-01
-reviewed: 2025-12-17
 description: "Analyze project state and continue development where left off"
-allowed_tools: [Read, Bash, Grep, Glob, Edit, Write]
+args: "[--task <id>] [--skip-status]"
+argument-hint: "--task to resume specific task, --skip-status to skip state analysis"
+allowed-tools: Read, Bash, Grep, Glob, Edit, Write
+created: 2025-12-16
+modified: 2026-02-03
+reviewed: 2025-12-17
 ---
 
 Continue project development by analyzing current state and resuming work.

--- a/project-plugin/commands/project/test-loop.md
+++ b/project-plugin/commands/project/test-loop.md
@@ -1,10 +1,12 @@
 ---
 model: haiku
-created: 2025-12-16
-modified: 2026-02-01
-reviewed: 2025-12-17
 description: "Run test → fix → refactor loop with TDD workflow"
-allowed_tools: [Read, Edit, Bash]
+args: "[test-pattern] [--max-cycles <N>]"
+argument-hint: "Test pattern to focus on, --max-cycles to limit iterations"
+allowed-tools: Read, Edit, Bash
+created: 2025-12-16
+modified: 2026-02-03
+reviewed: 2025-12-17
 ---
 
 Run automated TDD cycle: test → fix → refactor.

--- a/testing-plugin/commands/test/analyze.md
+++ b/testing-plugin/commands/test/analyze.md
@@ -1,7 +1,11 @@
 ---
 model: opus
+description: Analyze test results and create systematic fix plan with subagent delegation
+args: "<results-path> [--type <test-type>] [--focus <area>]"
+argument-hint: "Path to test results (e.g., ./test-results/), optional --type and --focus filters"
+allowed-tools: Task, Read, Glob, Grep, TodoWrite
 created: 2025-12-16
-modified: 2025-12-16
+modified: 2026-02-03
 reviewed: 2025-12-16
 ---
 

--- a/typescript-plugin/commands/bun/install.md
+++ b/typescript-plugin/commands/bun/install.md
@@ -1,9 +1,11 @@
 ---
 model: haiku
 description: Install dependencies with Bun package manager
+args: "[--frozen-lockfile] [--production]"
+argument-hint: "--frozen-lockfile for CI, --production for deployment"
 allowed-tools: Bash, Read
 created: 2025-12-20
-modified: 2025-12-20
+modified: 2026-02-03
 reviewed: 2025-12-20
 ---
 

--- a/typescript-plugin/commands/bun/outdated.md
+++ b/typescript-plugin/commands/bun/outdated.md
@@ -1,9 +1,11 @@
 ---
 model: haiku
 description: Check for outdated dependencies
+args: "[package]"
+argument-hint: "Optional package name to check specific dependency"
 allowed-tools: Bash, Read
 created: 2025-12-20
-modified: 2025-12-20
+modified: 2026-02-03
 reviewed: 2025-12-20
 ---
 


### PR DESCRIPTION
## Summary
Standardized the YAML frontmatter formatting in command metadata files across all plugins to improve consistency and readability. This change reorganizes the order of metadata fields and converts array syntax to inline format for better maintainability.

## Key Changes
- **Reordered metadata fields** in all command files to follow a consistent pattern:
  - `model` → `description` → `args` → `argument-hint` → `allowed-tools` → `created` → `modified` → `reviewed`
- **Converted `allowed-tools` format** from YAML array syntax `[item1, item2]` to inline comma-separated format for consistency
- **Added missing metadata fields** to several commands:
  - `args`: Command-line arguments specification
  - `argument-hint`: User-friendly hint for arguments
- **Updated `modified` dates** to 2026-02-03 across all affected files to reflect this standardization effort

## Files Modified
- `blueprint-plugin/commands/`: 3 command files (curate-docs, prp-create, prp-execute)
- `documentation-plugin/commands/docs/`: 1 command file (sync)
- `project-plugin/commands/project/`: 2 command files (continue, test-loop)
- `testing-plugin/commands/test/`: 1 command file (analyze)
- `typescript-plugin/commands/bun/`: 2 command files (install, outdated)

## Benefits
- Improved consistency across the codebase for easier maintenance
- Better documentation of command arguments and usage hints
- Standardized metadata structure enables easier parsing and tooling
- Enhanced user experience with clearer argument documentation

https://claude.ai/code/session_01TzJWUwS6X2NXodyKG9EXF5