### PR TITLE
Update git command chaining example to use modern commands

### DIFF
--- a/hooks-plugin/hooks/bash-antipatterns.sh
+++ b/hooks-plugin/hooks/bash-antipatterns.sh
@@ -133,10 +133,10 @@ fi
 if echo "$COMMAND" | grep -Eq 'git\s+\S+.*&&.*git\s+\S+'; then
     block_with_reminder "REMINDER: Chaining git commands with '&&' can cause index.lock race conditions.
 The lock file from the first command may not be released before the second runs.
-Instead of: git stash && git checkout -b branch
+Instead of: git fetch && git switch -c branch
 Run git commands as separate Bash tool calls:
-1. git stash
-2. git checkout -b branch
+1. git fetch
+2. git switch -c branch
 This avoids race conditions and is more reliable."
 fi
 


### PR DESCRIPTION
## Summary
Updated the bash antipatterns hook to use more modern and relevant git commands in the example that warns against chaining git commands with `&&`.

## Changes
- Replaced `git stash && git checkout -b branch` with `git fetch && git switch -c branch` in the warning message
- Updated the corresponding separate command examples to match the new commands

## Details
The original example used `git stash` and `git checkout -b`, which are older patterns. The updated example uses:
- `git fetch` - a more common operation that developers actually chain
- `git switch -c` - the modern alternative to `git checkout -b` (introduced in Git 2.23)

This makes the warning more relevant to current git workflows while still effectively illustrating the race condition risk when chaining git commands.

https://claude.ai/code/session_01PnuANCRezgtRtbMiTR7qDp