### PR TITLE
Add null checks to refactor command context variables

### DIFF
--- a/code-quality-plugin/commands/code/refactor.md
+++ b/code-quality-plugin/commands/code/refactor.md
@@ -10,9 +10,9 @@ description: Refactor code following SOLID principles and best practices
 
 ## Context
 
-- Target path: !`echo "$1"`
-- File type: !`file "$1" 2>/dev/null`
-- Lines of code: !`wc -l "$1" 2>/dev/null`
+- Target path: !`test -n "$1" && echo "$1" || echo "NOT_PROVIDED"`
+- File type: !`test -n "$1" && file "$1" 2>/dev/null`
+- Lines of code: !`test -n "$1" && wc -l "$1" 2>/dev/null`
 
 ## Parameters
 


### PR DESCRIPTION
## Summary
Enhanced the refactor command's context section with defensive null checks to prevent errors when the target file parameter is not provided.

## Changes
- Added `test -n "$1"` checks before executing commands that depend on the file parameter
- Provides fallback "NOT_PROVIDED" message for the target path when parameter is missing
- Gracefully handles missing file parameter for `file` and `wc -l` commands instead of failing silently or with errors

## Details
The changes ensure that the refactor command context variables are populated safely even when the required file parameter is not supplied. This improves the user experience by providing clear feedback about missing parameters rather than executing commands against undefined variables.

https://claude.ai/code/session_01FdYMMJH2q5Ktd5WCwC8hVK