### PR TITLE
Bump agents-plugin version to 1.1.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
       "name": "agents-plugin",
       "source": "./agents-plugin",
       "description": "Task-focused agents for test, review, debug, docs, and CI workflows",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "keywords": [
         "agents",
         "testing",


### PR DESCRIPTION
## Summary
This PR updates the agents-plugin version from 1.1.2 to 1.1.3 in the marketplace configuration.

## Changes
- Updated `agents-plugin` version in `.claude-plugin/marketplace.json` from `1.1.2` to `1.1.3`

## Details
This is a patch version bump for the agents-plugin, which provides task-focused agents for test, review, debug, docs, and CI workflows. The version update reflects bug fixes or minor improvements to the plugin.

https://claude.ai/code/session_018gdvtG3VEQvEfoFHQBkFj9