### PR TITLE
Fix markdown formatting in git status code table

### DIFF
--- a/git-plugin/skills/git-cli-agentic/skill.md
+++ b/git-plugin/skills/git-cli-agentic/skill.md
@@ -71,13 +71,13 @@ git status --short --branch
 
 | Code | Meaning |
 |------|---------|
-| `M` | Modified |
-| `A` | Added |
-| `D` | Deleted |
-| `R` | Renamed |
-| `C` | Copied |
-| `?` | Untracked |
-| `!` | Ignored |
+| M | Modified |
+| A | Added |
+| D | Deleted |
+| R | Renamed |
+| C | Copied |
+| ? | Untracked |
+| ! | Ignored |
 
 ### Quick Checks
 


### PR DESCRIPTION
## Summary
Fixed markdown table formatting in the git-cli-agentic skill documentation by removing unnecessary backticks from the status code column.

## Changes
- Removed backtick formatting from single-character status codes in the git status table
- Codes now display as plain text (M, A, D, R, C, ?, !) instead of inline code blocks (`M`, `A`, etc.)
- Improves table readability and maintains consistent markdown styling

## Details
The backticks were unnecessary for single-character codes and created visual clutter in the rendered markdown table. This change simplifies the documentation while maintaining clarity about what each status code represents.

https://claude.ai/code/session_01U9fYzL2q3ZK72wY1aek4Ee