### PR TITLE
feat(tools-plugin): add justfile naming conventions and golden template

### DIFF
--- a/tools-plugin/skills/justfile-expert/REFERENCE.md
+++ b/tools-plugin/skills/justfile-expert/REFERENCE.md
@@ -1,5 +1,220 @@
 # Justfile Expert - Detailed Reference
 
+## Golden Justfile Template
+
+Use this template as a starting point for new projects. Uncomment and adapt recipes for your technology stack.
+
+```just
+# Justfile - Project task runner
+# Run `just` or `just help` to see available recipes
+# https://just.systems/
+
+####################
+# Settings
+####################
+
+# set dotenv-load                     # Uncomment if using .env files
+# set positional-arguments            # Uncomment if recipes use $1, $2, etc.
+
+####################
+# Variables
+####################
+
+# PROJECT := "my-project"
+# NAMESPACE := "my-namespace"
+
+####################
+# Metadata
+####################
+
+# Default recipe - show help
+default:
+    @just --list
+
+# Show available recipes with descriptions
+help:
+    @just --list --unsorted
+
+####################
+# Development
+####################
+
+# Start development environment
+dev:
+    echo "TODO: Start dev server"
+    # bun run dev
+    # uv run python manage.py runserver
+    # docker-compose up
+    # skaffold dev --port-forward
+
+# Build for production
+build:
+    echo "TODO: Build project"
+    # bun run build
+    # skaffold build
+    # docker-compose build
+
+# Clean build artifacts
+clean:
+    echo "TODO: Clean artifacts"
+    # rm -rf dist build .next node_modules/.cache
+    # find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+
+####################
+# Code Quality
+####################
+
+# Run linter (read-only)
+lint *args:
+    echo "TODO: Run linter"
+    # bun run lint {{ args }}
+    # uv run ruff check {{ args }}
+
+# Auto-fix lint issues
+# lint-fix:
+#     bun run lint:fix
+#     uv run ruff check --fix .
+
+# Format code (mutating)
+format *args:
+    echo "TODO: Format code"
+    # bun run format {{ args }}
+    # uv run ruff format {{ args }}
+
+# Check code formatting without modifying (non-mutating)
+format-check *args:
+    echo "TODO: Check formatting"
+    # bun run format:check {{ args }}
+    # uv run ruff format --check {{ args }}
+
+# TypeScript/Python type checking
+# typecheck:
+#     bunx tsc --noEmit --skipLibCheck
+#     uv run basedpyright
+
+# Composite: format-check + lint + typecheck (code quality only, no tests)
+# check: format-check lint typecheck
+
+# Check and auto-fix
+# check-fix:
+#     bun run check:fix
+
+####################
+# Testing
+####################
+
+# Run all tests
+test *args:
+    echo "TODO: Run tests"
+    # bun test {{ args }}
+    # uv run pytest -v {{ args }}
+
+# Run unit tests only
+# test-unit *args:
+#     bun run test:unit {{ args }}
+#     uv run pytest -m unit -v {{ args }}
+
+# Run integration tests
+# test-integration *args:
+#     bun run test:integration {{ args }}
+#     uv run pytest -m integration -v {{ args }}
+
+# Run tests with coverage report
+# test-coverage:
+#     bun run test:coverage
+#     uv run pytest --cov --cov-report=html --cov-report=term-missing
+
+####################
+# Workflows
+####################
+
+# Pre-commit checks (fast, non-mutating)
+pre-commit: format-check lint test
+    @echo "Pre-commit checks passed"
+    # With typecheck: pre-commit: format-check lint typecheck test-unit
+
+# Full CI simulation
+ci: format-check lint test build
+    @echo "CI simulation passed"
+    # With typecheck + coverage: ci: check test-coverage build
+
+####################
+# Dependencies
+####################
+
+# Install dependencies
+# install:
+#     bun install --frozen-lockfile
+#     uv sync
+
+# Update all dependencies
+# update:
+#     bun update
+#     uv lock --upgrade
+
+####################
+# Database
+####################
+
+# Run database migrations
+# db-migrate:
+#     uv run python manage.py migrate
+#     bun run db:migrate
+
+# Seed database with test data
+# db-seed:
+#     bun run db:seed
+
+# Reset database (WARNING: destroys data)
+# db-reset:
+#     echo "WARNING: This will delete all database data"
+
+####################
+# Kubernetes
+####################
+
+# Start Skaffold development
+# skaffold:
+#     skaffold dev --port-forward
+
+# Start Skaffold with file sync (hot reload)
+# dev-k8s:
+#     skaffold dev -p dev --port-forward
+
+####################
+# Documentation
+####################
+
+# Generate documentation
+# docs:
+#     bun run docs
+
+# Serve documentation locally
+# docs-serve:
+#     bun run docs:serve
+```
+
+### Naming Rules Summary
+
+- **Hyphen-separated**: `test-unit`, `format-check`, `db-migrate`
+- **Verb-first for actions**: `lint`, `format`, `build`, `test`, `clean`
+- **Noun-first for categories**: `db-migrate`, `db-seed`, `docs-serve`
+- **`_` prefix for private**: `_generate-secrets`, `_setup`
+- **Modifiers after base**: `lint-fix` (not `fix-lint`), `build-release` (not `release-build`)
+- **`-check` suffix**: Read-only verification (`format-check`)
+- **`-fix` suffix**: Auto-correction (`lint-fix`, `check-fix`)
+- **`-watch` suffix**: Watch mode (`test-watch`, `docs-watch`)
+
+### Semantic Definitions
+
+| Recipe | Equals | Description |
+|--------|--------|-------------|
+| `check` | `format-check` + `lint` + `typecheck` | Code quality only, no tests |
+| `pre-commit` | `format-check` + `lint` + `typecheck` + `test-unit` | Non-mutating, fast |
+| `ci` | `check` + `test-coverage` + `build` | Full CI simulation |
+| `clean` | Remove build artifacts | Partial cleanup |
+| `clean-all` | `clean` + remove deps/caches | Full cleanup |
+
 ## Complete Syntax Reference
 
 ### Settings

--- a/tools-plugin/skills/justfile-expert/SKILL.md
+++ b/tools-plugin/skills/justfile-expert/SKILL.md
@@ -1,8 +1,8 @@
 ---
 model: haiku
 created: 2025-12-16
-modified: 2026-02-01
-reviewed: 2026-02-01
+modified: 2026-02-06
+reviewed: 2026-02-06
 name: justfile-expert
 description: |
   Just command runner expertise, Justfile syntax, recipe development, and cross-platform
@@ -43,10 +43,56 @@ Expert knowledge for Just command runner, recipe development, and task automatio
 - Environment variable integration
 
 **Project Standardization**
-- Standard recipes for consistent workflows
+- Golden template with standard naming and section structure
 - Self-documenting project operations
 - Portable patterns across projects
 - Integration with CI/CD pipelines
+
+## Recipe Naming Conventions
+
+| Rule | Pattern | Examples |
+|------|---------|---------|
+| Hyphen-separated | `word-word` | `test-unit`, `format-check` |
+| Verb-first (actions) | `verb-object` | `lint`, `build`, `clean` |
+| Noun-first (categories) | `noun-verb` | `db-migrate`, `docs-serve` |
+| Private prefix | `_name` | `_generate-secrets`, `_setup` |
+| `-check` suffix | Read-only verification | `format-check` |
+| `-fix` suffix | Auto-correction | `lint-fix`, `check-fix` |
+| `-watch` suffix | Watch mode | `test-watch`, `docs-watch` |
+| Modifiers after base | `base-modifier` | `build-release` (not `release-build`) |
+
+## Semantic Workflow Recipes
+
+Standard composite recipes with defined meanings:
+
+| Recipe | Composition | Purpose |
+|--------|-------------|---------|
+| `check` | `format-check` + `lint` + `typecheck` | Code quality only, no tests |
+| `pre-commit` | `format-check` + `lint` + `typecheck` + `test-unit` | Fast, non-mutating validation |
+| `ci` | `check` + `test-coverage` + `build` | Full CI simulation |
+| `clean` | Remove build artifacts | Partial cleanup |
+| `clean-all` | `clean` + remove deps/caches | Full cleanup |
+
+```just
+# Composite: code quality only (no tests)
+check: format-check lint typecheck
+
+# Pre-commit checks (fast, non-mutating)
+pre-commit: format-check lint typecheck test-unit
+    @echo "Pre-commit checks passed"
+
+# Full CI simulation
+ci: check test-coverage build
+    @echo "CI simulation passed"
+
+# Clean build artifacts
+clean:
+    rm -rf dist build .next
+
+# Clean everything including deps
+clean-all: clean
+    rm -rf node_modules .venv __pycache__
+```
 
 ## Key Capabilities
 
@@ -132,7 +178,7 @@ open:
 
 ## Standard Recipes
 
-Every project should provide these standard recipes:
+Every project should provide these standard recipes, organized by section:
 
 ```just
 # Justfile - Project task runner
@@ -153,42 +199,87 @@ help:
 # Development
 ####################
 
-# Run linters
-lint:
-    # Language-specific lint command
-
-# Format code
-format:
-    # Language-specific format command
-
-# Run tests
-test *args:
-    # Language-specific test command {{args}}
-
-# Development mode with watch
+# Start development environment
 dev:
-    # Start with file watching
+    # bun run dev / uv run uvicorn app:app --reload / skaffold dev
 
-####################
-# Build & Deploy
-####################
-
-# Build project
+# Build for production
 build:
-    # Build command
+    # bun run build / cargo build --release / docker build
 
 # Clean build artifacts
 clean:
-    # Cleanup command
+    # rm -rf dist build .next
 
-# Start service
-start:
-    # Start command
+####################
+# Code Quality
+####################
 
-# Stop service
-stop:
-    # Stop command
+# Run linter (read-only)
+lint *args:
+    # bun run lint / uv run ruff check {{args}}
+
+# Auto-fix lint issues
+lint-fix:
+    # bun run lint:fix / uv run ruff check --fix .
+
+# Format code (mutating)
+format *args:
+    # bun run format / uv run ruff format {{args}}
+
+# Check formatting without modifying (non-mutating)
+format-check *args:
+    # bun run format:check / uv run ruff format --check {{args}}
+
+# Type checking
+typecheck:
+    # bunx tsc --noEmit / uv run basedpyright
+
+####################
+# Testing
+####################
+
+# Run all tests
+test *args:
+    # bun test {{args}} / uv run pytest {{args}}
+
+# Run unit tests only
+test-unit *args:
+    # bun test --grep unit {{args}} / uv run pytest -m unit {{args}}
+
+####################
+# Workflows
+####################
+
+# Composite: code quality (no tests)
+check: format-check lint typecheck
+
+# Pre-commit checks (fast, non-mutating)
+pre-commit: format-check lint typecheck test-unit
+    @echo "Pre-commit checks passed"
+
+# Full CI simulation
+ci: check test-coverage build
+    @echo "CI simulation passed"
 ```
+
+### Section Structure
+
+Organize recipes into these standard sections:
+
+| Section | Recipes | Purpose |
+|---------|---------|---------|
+| **Metadata** | `default`, `help` | Discovery and navigation |
+| **Development** | `dev`, `build`, `clean`, `start`, `stop` | Core dev cycle |
+| **Code Quality** | `lint`, `lint-fix`, `format`, `format-check`, `typecheck` | Code standards |
+| **Testing** | `test`, `test-unit`, `test-integration`, `test-e2e`, `test-watch` | Test tiers |
+| **Workflows** | `check`, `pre-commit`, `ci` | Composite operations |
+| **Dependencies** | `install`, `update` | Package management |
+| **Database** | `db-migrate`, `db-seed`, `db-reset` | Data operations |
+| **Kubernetes** | `skaffold`, `dev-k8s` | Container orchestration |
+| **Documentation** | `docs`, `docs-serve` | Project docs |
+
+Use `####################` comment blocks as section dividers for readability.
 
 ## Common Patterns
 
@@ -339,4 +430,4 @@ cargo install just-mcp
 - Legacy projects with existing Makefiles
 - Build systems requiring incremental compilation
 
-For detailed syntax reference, advanced patterns, and troubleshooting, see REFERENCE.md.
+For the golden justfile template, detailed syntax reference, advanced patterns, and troubleshooting, see [REFERENCE.md](REFERENCE.md).


### PR DESCRIPTION
## Summary

Establishes a standardized justfile structure and naming conventions for the tools-plugin. Provides a golden template and semantic workflow definitions to guide recipe development across projects.

### Changes

- **SKILL.md**: Added Recipe Naming Conventions table with hyphen-separated names, verb-first patterns, and suffix conventions. Introduced Semantic Workflow Recipes section defining composite recipes (check, pre-commit, ci, clean-all) and reorganized Standard Recipes into logical sections (Metadata, Development, Code Quality, Testing, Workflows).

- **REFERENCE.md**: Added Golden Justfile Template section with copy-paste-ready boilerplate, complete Naming Rules Summary, and Semantic Definitions table for composite recipes.

- **Size**: SKILL.md remains under 500-line limit (433 lines)

## Test Plan

- [x] SKILL.md under 500 lines
- [x] REFERENCE.md references correctly from SKILL.md
- [x] Naming conventions table is actionable
- [x] Golden template is copy-paste ready
- [x] All changes scoped to tools-plugin only

🤖 Generated with Claude Code