### PR TITLE
feat(github-actions): add weekly blueprint health check workflow

### DIFF
--- a/.github/workflows/weekly-blueprint-health.yml
+++ b/.github/workflows/weekly-blueprint-health.yml
@@ -1,0 +1,118 @@
+name: Weekly Blueprint Health Check
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  blueprint-health:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for existing open issue
+        id: check_issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING=$(gh issue list --label "blueprint-health" --state open --json number --jq 'length')
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Found existing open blueprint health issue"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Claude Blueprint Health Check
+        if: steps.check_issue.outputs.exists == 'false'
+        id: health
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--model haiku --max-turns 20"
+          direct_prompt: |
+            Perform a comprehensive blueprint health check on this plugin repository.
+            Output ONLY the issue body in markdown format. Do not create files or make changes.
+
+            ## Checks to perform:
+
+            ### 1. Skill Inventory & Staleness
+            - List all plugins and their skills (find all SKILL.md files under */skills/*/)
+            - For each skill, read the `modified` date from frontmatter
+            - Flag skills not modified in >90 days as stale
+            - Count total skills per plugin
+
+            ### 2. Cross-Plugin Consistency
+            - Verify each plugin directory has `.claude-plugin/plugin.json`
+            - Verify each plugin directory has `README.md`
+            - Check that plugin names in `plugin.json` match directory names
+
+            ### 3. plugin.json Validation
+            - Required field: `name`
+            - Recommended fields: `version`, `description`, `keywords`
+            - Verify `name` is kebab-case
+
+            ### 4. Frontmatter Completeness
+            - For each SKILL.md, check for required frontmatter fields:
+              - `name`, `description`, `allowed-tools`
+            - Check for recommended fields: `model`, `created`, `modified`, `reviewed`
+            - Flag any missing required fields
+
+            ### 5. README Existence
+            - Check each plugin has a README.md
+            - Flag missing READMEs
+
+            Format the output as a GitHub issue body:
+
+            ```markdown
+            ## Weekly Blueprint Health: YYYY-MM-DD
+
+            ### Summary
+            | Metric | Value |
+            |--------|-------|
+            | Total plugins | N |
+            | Total skills | N |
+            | Stale skills (>90d) | N |
+            | Missing plugin.json fields | N |
+            | Missing frontmatter fields | N |
+
+            ### Stale Skills (>90 days since modified)
+            | Plugin | Skill | Last Modified | Days Stale |
+            |--------|-------|---------------|------------|
+            | ... | ... | ... | ... |
+
+            ### Plugin Compliance
+            | Plugin | plugin.json | README | Skills | Issues |
+            |--------|-------------|--------|--------|--------|
+            | ... | ✅/❌ | ✅/❌ | N | N |
+
+            ### Frontmatter Issues
+            | Plugin | Skill | Missing Fields |
+            |--------|-------|----------------|
+            | ... | ... | ... |
+
+            ### Recommendations
+            - (actionable items)
+            ```
+
+            Use today's date for the report title.
+
+      - name: Create health check issue
+        if: steps.check_issue.outputs.exists == 'false' && steps.health.outputs.result
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DATE=$(date +%Y-%m-%d)
+          echo '${{ steps.health.outputs.result }}' > /tmp/issue-body.md
+          gh issue create \
+            --title "Weekly Blueprint Health: $DATE" \
+            --label "blueprint-health,maintenance" \
+            --body-file /tmp/issue-body.md


### PR DESCRIPTION
## Summary

- Add scheduled workflow running every Monday at 9am UTC
- Checks: skill inventory + staleness (>90d), cross-plugin consistency, plugin.json validation, README existence, frontmatter completeness
- Creates GitHub issue with `blueprint-health` label
- Duplicate prevention: skips if open issue with same label exists
- Supports `workflow_dispatch` for manual runs

## Test plan

- [ ] Trigger via `workflow_dispatch`
- [ ] Verify issue created with `blueprint-health` label
- [ ] Re-run and confirm no duplicate issue created

Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)