### PR TITLE
feat(github-actions): add plugin compliance gate workflow

### DIFF
--- a/.github/workflows/plugin-compliance-gate.yml
+++ b/.github/workflows/plugin-compliance-gate.yml
@@ -1,0 +1,102 @@
+name: Plugin Compliance Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - '*-plugin/**'
+      - '.claude-plugin/marketplace.json'
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  compliance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed plugin files
+        id: changed
+        run: |
+          FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*-plugin/**' '.claude-plugin/marketplace.json' | head -50)
+          echo "files<<EOF" >> $GITHUB_OUTPUT
+          echo "$FILES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+          # Extract unique plugin directories affected
+          PLUGINS=$(echo "$FILES" | grep -oP '^[^/]+-plugin' | sort -u)
+          echo "plugins<<EOF" >> $GITHUB_OUTPUT
+          echo "$PLUGINS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "count=$(echo "$PLUGINS" | grep -c '.' || true)" >> $GITHUB_OUTPUT
+
+      - name: Claude Plugin Compliance Review
+        if: steps.changed.outputs.count != '0'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--model haiku --max-turns 12"
+          prompt: |
+            Review the changed plugin files in this PR for compliance.
+
+            Changed files:
+            ${{ steps.changed.outputs.files }}
+
+            Affected plugins:
+            ${{ steps.changed.outputs.plugins }}
+
+            For each affected plugin, check:
+
+            ### 1. plugin.json Required Fields
+            - Read `<plugin>/.claude-plugin/plugin.json`
+            - Required: `name` (must be kebab-case)
+            - Recommended: `version`, `description`, `keywords`
+            - Verify `name` matches directory name
+
+            ### 2. Skill Frontmatter Completeness
+            - For each SKILL.md in `<plugin>/skills/*/`:
+              - Required: `name`, `description`, `allowed-tools`
+              - Recommended: `model`, `created`, `modified`, `reviewed`
+              - Check `args` and `argument-hint` present together (if either exists)
+
+            ### 3. Skill Quality
+            - SKILL.md under 500 lines
+            - Has "When to Use" decision table (for non-trivial skills)
+            - Has "Agentic Optimizations" table (for CLI/tool skills)
+            - Description matches user intents, not just tool jargon
+
+            ### 4. marketplace.json Entry
+            - Read `.claude-plugin/marketplace.json`
+            - Verify each affected plugin has an entry with: name, source, description, version
+            - Verify `source` path matches plugin directory
+
+            ### 5. release-please Config
+            - Read `release-please-config.json`
+            - Verify each affected plugin has a package entry
+            - Read `.release-please-manifest.json`
+            - Verify each affected plugin has a version entry
+
+            Output a single PR comment:
+
+            ```
+            ## Plugin Compliance Review
+
+            | Plugin | plugin.json | Frontmatter | Quality | Marketplace | Release Config | Overall |
+            |--------|-------------|-------------|---------|-------------|----------------|---------|
+            | name | ✅/❌ | ✅/⚠️/❌ | ✅/⚠️/❌ | ✅/❌ | ✅/❌ | ✅/⚠️/❌ |
+
+            ### Issues Found
+            (details for any non-passing checks)
+
+            ### Recommendations
+            (actionable suggestions)
+            ```
+
+            Use ✅ for pass, ⚠️ for warnings (recommended fields missing), ❌ for failures (required fields missing).
+            Focus ONLY on plugin compliance. Do not suggest unrelated changes.


### PR DESCRIPTION
## Summary

- Add PR workflow triggered when plugin directories or marketplace.json change
- Checks: plugin.json required fields, skill frontmatter completeness, skill quality, marketplace.json entries, release-please config
- Uses `anthropics/claude-code-action@v1` with `--model haiku --max-turns 12`
- Outputs per-plugin compliance table as PR comment

## Test plan

- [ ] Create PR touching a plugin directory; verify compliance comment appears
- [ ] Verify correct detection of missing fields
- [ ] Verify no false positives on compliant plugins

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)