### PR TITLE
feat(github-actions): add monthly agentic quality audit workflow

### DIFF
--- a/.github/workflows/monthly-agentic-audit.yml
+++ b/.github/workflows/monthly-agentic-audit.yml
@@ -1,0 +1,135 @@
+name: Monthly Agentic Quality Audit
+
+on:
+  schedule:
+    - cron: '0 9 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  agentic-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for existing open issue
+        id: check_issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING=$(gh issue list --label "agentic-audit" --state open --json number --jq 'length')
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Found existing open agentic audit issue"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Claude Agentic Quality Audit
+        if: steps.check_issue.outputs.exists == 'false'
+        id: audit
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--model haiku --max-turns 25"
+          direct_prompt: |
+            Perform a monthly agentic quality audit on all skills in this plugin repository.
+            Read .claude/rules/agentic-optimization.md and .claude/rules/skill-quality.md for standards.
+            Output ONLY the issue body in markdown format. Do not create files or make changes.
+
+            ## Checks to perform:
+
+            ### 1. Missing Agentic Optimizations Tables
+            - For each SKILL.md in */skills/*/:
+              - Check if it contains an "Agentic Optimizations" section with a table
+              - CLI/tool skills (those with Bash in allowed-tools) MUST have this table
+              - Flag missing tables
+
+            ### 2. Bare CLI Commands Without Compact Flags
+            - Scan SKILL.md files for CLI command examples
+            - Check if commands use compact/agentic-optimized flags:
+              - Test runners: `--dots`, `--reporter=dot`, `--bail=1`, `-x`
+              - Linters: `--reporter=github`, `--format=unix`, `--output-format=github`
+              - General: `--json`, `-c`, `-q`
+            - Flag commands that could use more compact output
+
+            ### 3. Stale Review Dates
+            - For each SKILL.md, read the `reviewed` date from frontmatter
+            - Flag skills where `reviewed` is >90 days old
+            - These skills should be re-verified against latest tool documentation
+
+            ### 4. Model Appropriateness
+            - For each SKILL.md, read the `model` field from frontmatter
+            - `haiku` should be used for: CLI tool usage, configuration, formatting, standard workflows
+            - `opus` should be used for: architecture decisions, debugging methodology, security analysis, complex reasoning
+            - Flag potentially misassigned models
+
+            ### 5. Description Quality
+            - For each SKILL.md, read the `description` field from frontmatter
+            - Good descriptions: describe user intent, include "Use when..." scenarios
+            - Poor descriptions: only name the tool, use jargon without context
+            - Flag descriptions that could be improved
+
+            Format output as a GitHub issue body:
+
+            ```markdown
+            ## Monthly Agentic Quality Audit: YYYY-MM
+
+            ### Summary
+            | Metric | Value |
+            |--------|-------|
+            | Total skills audited | N |
+            | Missing Agentic Optimizations | N |
+            | Bare CLI commands | N |
+            | Stale reviews (>90d) | N |
+            | Model concerns | N |
+            | Description concerns | N |
+
+            ### Missing Agentic Optimizations Tables
+            | Plugin | Skill | Has Bash? | Priority |
+            |--------|-------|-----------|----------|
+            | ... | ... | Yes/No | High/Medium |
+
+            ### Bare CLI Commands
+            | Plugin | Skill | Command | Suggested Improvement |
+            |--------|-------|---------|----------------------|
+            | ... | ... | `cmd` | `cmd --compact-flag` |
+
+            ### Stale Reviews
+            | Plugin | Skill | Last Reviewed | Days Since |
+            |--------|-------|---------------|------------|
+            | ... | ... | YYYY-MM-DD | N |
+
+            ### Model Concerns
+            | Plugin | Skill | Current | Suggested | Reason |
+            |--------|-------|---------|-----------|--------|
+            | ... | ... | opus | haiku | Simple CLI operations |
+
+            ### Description Quality
+            | Plugin | Skill | Current Description | Issue |
+            |--------|-------|---------------------|-------|
+            | ... | ... | "..." | Missing user intent |
+
+            ### Recommendations
+            - (prioritized actionable items)
+            ```
+
+            Use the current month/year for the report title.
+
+      - name: Create audit issue
+        if: steps.check_issue.outputs.exists == 'false' && steps.audit.outputs.result
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          MONTH=$(date +%Y-%m)
+          echo '${{ steps.audit.outputs.result }}' > /tmp/issue-body.md
+          gh issue create \
+            --title "Monthly Agentic Quality Audit: $MONTH" \
+            --label "agentic-audit,maintenance" \
+            --body-file /tmp/issue-body.md


### PR DESCRIPTION
## Summary

- Add scheduled workflow running 1st of each month at 9am UTC
- Checks: missing Agentic Optimizations tables, bare CLI commands without compact flags, stale review dates (>90d), model appropriateness, description quality
- Creates GitHub issue with `agentic-audit` label
- Duplicate prevention: skips if open issue with same label exists
- Supports `workflow_dispatch` for manual runs

## Test plan

- [ ] Trigger via `workflow_dispatch`
- [ ] Verify issue created with `agentic-audit` label
- [ ] Re-run and confirm no duplicate issue created

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)