### PR TITLE
feat(github-actions): add infrastructure compliance dashboard workflow

### DIFF
--- a/.github/workflows/infra-compliance-dashboard.yml
+++ b/.github/workflows/infra-compliance-dashboard.yml
@@ -1,0 +1,145 @@
+name: Infrastructure Compliance Dashboard
+
+on:
+  schedule:
+    - cron: '0 9 1 */2 *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  infra-compliance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for existing open issue
+        id: check_issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING=$(gh issue list --label "infra-compliance" --state open --json number --jq 'length')
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Found existing open infra compliance issue"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Claude Infrastructure Compliance Audit
+        if: steps.check_issue.outputs.exists == 'false'
+        id: compliance
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--model haiku --max-turns 30"
+          direct_prompt: |
+            Perform an infrastructure compliance audit on this plugin repository.
+            Output ONLY the issue body in markdown format. Do not create files or make changes.
+
+            ## Checks to perform:
+
+            ### 1. Plugin Registry Consistency (4-File Sync)
+            For each plugin directory (*-plugin/):
+            - Check `.claude-plugin/plugin.json` exists and has `name` field
+            - Check entry exists in `.claude-plugin/marketplace.json` with matching name and source path
+            - Check entry exists in `release-please-config.json` packages
+            - Check entry exists in `.release-please-manifest.json`
+            - Flag any plugin missing from any of the 4 files
+            - Flag any orphaned entries (in config files but no directory)
+
+            ### 2. Workflow Health
+            For each workflow in `.github/workflows/*.yml`:
+            - Check `actions/checkout` version (should be v4)
+            - Check `anthropics/claude-code-action` version (should be v1)
+            - Check permissions are minimal (not using blanket write-all)
+            - Check path filters are present for PR-triggered workflows
+            - Flag outdated action versions
+
+            ### 3. Version Consistency
+            For each plugin:
+            - Read version from `.claude-plugin/plugin.json`
+            - Read version from `.release-please-manifest.json`
+            - Read version from `.claude-plugin/marketplace.json`
+            - Flag any version mismatches
+
+            ### 4. Skill Coverage
+            For each plugin:
+            - Count skills in `skills/` directory
+            - Check if plugin has at least one skill
+            - Calculate skill-to-plugin ratio across the repo
+
+            ### 5. Security Posture
+            - Scan workflow files for hardcoded secrets or tokens
+            - Verify workflows use `secrets.*` references, not inline values
+            - Check that Bash permission patterns use granular commands (not broad `Bash(*)`)
+            - Scan SKILL.md allowed-tools for overly broad permissions
+
+            Format output as a GitHub issue body:
+
+            ```markdown
+            ## Infrastructure Compliance Dashboard: YYYY-MM
+
+            ### Overall Score: X/100
+
+            ### Registry Consistency
+            | Plugin | plugin.json | marketplace | release-config | manifest | Status |
+            |--------|-------------|-------------|----------------|----------|--------|
+            | ... | ✅/❌ | ✅/❌ | ✅/❌ | ✅/❌ | ✅/❌ |
+
+            Orphaned entries: (list any)
+
+            ### Workflow Health
+            | Workflow | Checkout | Claude Action | Permissions | Filters | Status |
+            |----------|----------|---------------|-------------|---------|--------|
+            | ... | v4/? | v1/? | ✅/⚠️ | ✅/❌ | ✅/⚠️/❌ |
+
+            ### Version Consistency
+            | Plugin | plugin.json | manifest | marketplace | Match? |
+            |--------|-------------|----------|-------------|--------|
+            | ... | X.Y.Z | X.Y.Z | X.Y.Z | ✅/❌ |
+
+            ### Skill Coverage
+            | Plugin | Skills | Has Skills? |
+            |--------|--------|-------------|
+            | ... | N | ✅/❌ |
+
+            Total: N plugins, M skills (avg N.N skills/plugin)
+
+            ### Security Findings
+            | Severity | File | Finding |
+            |----------|------|---------|
+            | 🔴/🟡/🟢 | ... | ... |
+
+            ### Recommendations
+            - (prioritized by severity)
+
+            ### Score Breakdown
+            | Category | Weight | Score | Details |
+            |----------|--------|-------|---------|
+            | Registry sync | 25% | X/25 | ... |
+            | Workflow health | 25% | X/25 | ... |
+            | Version consistency | 20% | X/20 | ... |
+            | Skill coverage | 15% | X/15 | ... |
+            | Security posture | 15% | X/15 | ... |
+            ```
+
+            Calculate the overall score based on the weighted categories.
+            Use the current month/year for the dashboard title.
+
+      - name: Create compliance dashboard issue
+        if: steps.check_issue.outputs.exists == 'false' && steps.compliance.outputs.result
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          MONTH=$(date +%Y-%m)
+          echo '${{ steps.compliance.outputs.result }}' > /tmp/issue-body.md
+          gh issue create \
+            --title "Infrastructure Compliance Dashboard: $MONTH" \
+            --label "infra-compliance,maintenance" \
+            --body-file /tmp/issue-body.md


### PR DESCRIPTION
## Summary

- Add bimonthly scheduled workflow (1st of every other month at 9am UTC)
- Checks: plugin registry consistency (4-file sync), workflow health (action versions, permissions), version consistency, skill coverage per plugin, security posture
- Outputs compliance dashboard with weighted scoring (registry 25%, workflows 25%, versions 20%, coverage 15%, security 15%)
- Creates GitHub issue with `infra-compliance` label
- Duplicate prevention: skips if open issue with same label exists
- Supports `workflow_dispatch` for manual runs

## Test plan

- [ ] Trigger via `workflow_dispatch`
- [ ] Verify issue created with `infra-compliance` label
- [ ] Re-run and confirm no duplicate issue created

Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)