### PR TITLE
docs: add ADR-0015 and PRP for agent teams migration

### DIFF
--- a/docs/adrs/0015-agent-teams-adoption.md
+++ b/docs/adrs/0015-agent-teams-adoption.md
@@ -1,0 +1,104 @@
+# ADR-0015: Adopt Agent Teams and Deprecate Manual Orchestration
+
+---
+date: 2026-02-07
+created: 2026-02-07
+modified: 2026-02-07
+status: Proposed
+deciders: claude-plugins team
+domain: architecture
+relates-to:
+  - ADR-0009
+github-issues: []
+---
+
+## Context
+
+Claude Code's new **agent teams** feature (documented at code.claude.com/docs/en/agent-teams) provides native support for multi-agent coordination:
+
+| Capability | Description |
+|------------|-------------|
+| **Lead + Teammates** | One session coordinates, others work independently with full context windows |
+| **Shared task list** | With dependencies, self-claiming, file-locking |
+| **Inter-agent messaging** | Direct teammate-to-teammate communication |
+| **Delegate mode** | Restricts lead to coordination-only tools |
+| **Plan approval** | Teammates plan before implementing; lead approves/rejects |
+| **TeammateIdle hook** | Fires when a teammate is about to go idle; can assign more work |
+| **TaskCompleted hook** | Fires when a task is marked complete; can gate completion with validation |
+| **Permissions inheritance** | Teammates inherit lead's permissions; CLAUDE.md loaded by all |
+
+Our `agent-patterns-plugin` (15 skills, 2 hooks) and `agents-plugin` (10 agent definitions) were built to solve these same problems before native support existed. They implement:
+
+- Orchestrator enforcement via PreToolUse hooks
+- File coordination and locking conventions
+- Handoff markers (@AGENT-HANDOFF-MARKER)
+- Delegation patterns
+- Context preservation across compaction (PreCompact hook)
+- Agent definition templates
+
+Most of this is now redundant with the native agent teams feature.
+
+## Decision
+
+**Adopt native agent teams. Deprecate and remove manual orchestration infrastructure that duplicates built-in functionality. Adapt remaining unique value into agent-teams-compatible patterns.**
+
+### What Gets Removed
+
+| Component | Plugin | Reason |
+|-----------|--------|--------|
+| `agent-coordination-patterns` skill | agent-patterns-plugin | Native shared task list + messaging replaces this |
+| `agent-file-coordination` skill | agent-patterns-plugin | Native file-locking replaces this |
+| `agent-handoff-markers` skill | agent-patterns-plugin | Native messaging replaces @AGENT-HANDOFF-MARKER |
+| `delegate` skill | agent-patterns-plugin | Native delegate mode replaces this |
+| `workflow-primer` skill | agent-patterns-plugin | Native context per teammate replaces handoff primers |
+| `orchestrator-enforcement` hook | agent-patterns-plugin | Native delegate mode enforces coordination-only |
+| `pre-compact-primer` hook | agent-patterns-plugin | Evaluate: may still be useful for single-session work |
+| `handoffs` skill | tools-plugin | @AGENT-HANDOFF-MARKER no longer needed |
+| 10 agent definitions | agents-plugin | Convert to teammate templates (see "What Gets Adapted") |
+
+### What Gets Adapted
+
+| Component | Plugin | Adaptation |
+|-----------|--------|------------|
+| `meta-assimilate` skill | agent-patterns-plugin | Keep — project config analysis isn't replaced by teams |
+| `meta-audit` skill | agent-patterns-plugin | Keep — auditing agent configs still valuable |
+| `custom-agent-definitions` skill | agent-patterns-plugin | Adapt to document teammate definition patterns |
+| Agent definitions (10) | agents-plugin | Convert to teammate spawn templates with appropriate tool restrictions |
+| `code-review` skill | code-quality-plugin | Add optional team pattern: spawn security/performance/correctness reviewers |
+| `configure-all` skill | configure-plugin | Add optional team pattern: parallel config checks via teammates |
+| `test-full` skill | testing-plugin | Add optional team pattern: parallel unit/integration/e2e via teammates |
+| `blueprint-prp-execute` skill | blueprint-plugin | Add optional team pattern for large multi-module PRPs |
+| `command-analytics` tracking | command-analytics-plugin | Extend to track teammate context in usage analytics |
+
+### What Stays Unchanged
+
+All domain-specific skills (280+), safety hooks (`bash-antipatterns`, `kubectl-context-validation`), language ecosystem plugins, and focused single-agent workflows remain as-is. Agent teams doesn't change how individual skills work — it changes how multiple agents coordinate.
+
+## Consequences
+
+### Positive
+
+- **Reduced maintenance**: Remove ~12 skills and 2 hooks of custom orchestration code
+- **Better UX**: Native features are more reliable than convention-based patterns
+- **File safety**: Built-in file-locking prevents race conditions (our convention-based approach was advisory only)
+- **Simpler mental model**: Users learn one system (agent teams) instead of our custom patterns + subagents
+- **Plan approval**: Free validation gate that our hooks approximated but couldn't fully enforce
+
+### Negative
+
+- **Breaking change**: Users relying on `agent-patterns-plugin` orchestration skills need to migrate
+- **Feature dependency**: We now depend on agent teams being available (requires Claude Code version with this feature)
+- **PreCompact hook gap**: The `pre-compact-primer` hook for single-session context preservation may still be needed — agent teams doesn't address long single-session compaction
+
+### Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Agent teams feature is experimental/unstable | Phase the migration: deprecate first, remove after feature is GA |
+| Users on older Claude Code versions | Keep agent-patterns-plugin available but mark as deprecated |
+| PreCompact value loss | Test whether agent teams' per-teammate context makes this unnecessary |
+
+## References
+
+- [Agent Teams Documentation](https://code.claude.com/docs/en/agent-teams)
+- [ADR-0009: Task-Focused Agent Consolidation](0009-task-focused-agent-consolidation.md) (prior art for agent organization)

--- a/docs/prps/agent-teams-migration.md
+++ b/docs/prps/agent-teams-migration.md
@@ -1,0 +1,195 @@
+# PRP: Agent Teams Migration
+
+**Created**: 2026-02-07
+**Modified**: 2026-02-07
+**Status**: Draft
+**Priority**: P1 - Architecture Simplification
+**Related ADRs**: [ADR-0015](../adrs/0015-agent-teams-adoption.md), [ADR-0009](../adrs/0009-task-focused-agent-consolidation.md)
+
+---
+
+## Goal
+
+Migrate from custom multi-agent orchestration infrastructure to Claude Code's native agent teams feature. Remove redundant skills/hooks, convert agent definitions to teammate templates, and add optional team patterns to high-value skills.
+
+### Why
+
+The `agent-patterns-plugin` (16 skills, 2 hooks) and `agents-plugin` (10 agent definitions) implement coordination patterns that are now built into Claude Code. Maintaining custom orchestration code that duplicates native functionality creates:
+
+- **Maintenance burden**: 16 orchestration skills to keep current
+- **User confusion**: Two systems for the same purpose (custom patterns vs native teams)
+- **Weaker guarantees**: Our convention-based file locking is advisory; native file-locking is enforced
+- **Context waste**: Loading orchestration skills into context when native features handle it
+
+### Target Users
+
+- Users currently relying on `agent-patterns-plugin` for multi-agent workflows
+- Users of `agents-plugin` agent definitions (test, review, debug, etc.)
+- Users of `/handoffs` command for @AGENT-HANDOFF-MARKER management
+
+---
+
+## Success Criteria
+
+| Criterion | Measurement | Target |
+|-----------|-------------|--------|
+| Skills removed | Count of deprecated orchestration skills removed | >= 12 |
+| Hooks removed | Custom orchestration hooks removed | 1 (orchestrator-enforcement) |
+| Agent conversions | Agent definitions converted to teammate templates | 10/10 |
+| Zero regression | Existing non-orchestration skills unaffected | 100% |
+| Documentation | Migration guide for existing users | Complete |
+
+### Acceptance Tests
+
+1. All removed skills are gone from the plugin directory and marketplace
+2. `agents-plugin` agents work as teammate templates
+3. `meta-assimilate` and `meta-audit` skills still function independently
+4. `pre-compact-primer` hook evaluated and decision documented
+5. Optional team patterns added to `code-review`, `configure-all`, `test-full`
+6. `command-analytics-plugin` tracks teammate context when available
+
+---
+
+## Scope
+
+### Phase 1: Remove Redundant Orchestration (agent-patterns-plugin)
+
+Remove skills whose functionality is now native to agent teams:
+
+| Skill | Native Replacement | Action |
+|-------|--------------------|--------|
+| `agent-coordination-patterns` | Shared task list + messaging | **Remove** |
+| `agent-file-coordination` | Native file-locking | **Remove** |
+| `agent-handoff-markers` | Native inter-agent messaging | **Remove** |
+| `delegate` | Native delegate mode | **Remove** |
+| `delegation-first` | Native delegate mode | **Remove** |
+| `workflow-primer` | Per-teammate context windows | **Remove** |
+| `multi-agent-workflows` | Agent teams configuration | **Remove** |
+| `agentic-patterns-source` | Agent teams docs | **Remove** |
+| `command-context-patterns` | Agent teams context handling | **Remove** |
+| `check-negative-examples` | Plan approval gates bad patterns | **Remove** |
+| `wip-todo` | Shared task list | **Remove** |
+| `claude-hooks-configuration` | Evaluate: may have non-orchestration value | **Evaluate** |
+
+Keep these skills (unique value not replaced by agent teams):
+
+| Skill | Reason to Keep |
+|-------|----------------|
+| `meta-assimilate` | Project config analysis — not an orchestration feature |
+| `meta-audit` | Agent config auditing — adapt to also audit team configs |
+| `custom-agent-definitions` | Adapt to document teammate definition patterns |
+| `mcp-management` | MCP server management — orthogonal to agent teams |
+
+#### Hook Changes
+
+| Hook | Action | Rationale |
+|------|--------|-----------|
+| `orchestrator-enforcement.sh` (PreToolUse) | **Remove** | Native delegate mode enforces coordination-only access |
+| `pre-compact-primer.sh` (PreCompact) | **Keep for now** | Still valuable for single-session long-running work where agent teams isn't active. Re-evaluate after testing whether teammate context windows make this unnecessary. |
+
+#### Metadata Updates
+
+- Update `agent-patterns-plugin/plugin.json`: remove orchestration keywords, update description
+- Update `.claude-plugin/marketplace.json`: update plugin description
+- Update `hooks.json`: remove PreToolUse orchestrator-enforcement entry
+
+### Phase 2: Convert Agent Definitions (agents-plugin)
+
+Convert the 10 agent definitions to teammate-compatible templates:
+
+| Agent | Model | Adaptation Notes |
+|-------|-------|------------------|
+| `test.md` | haiku | Add tool restrictions (testing tools only). Add `allowedTools` for test frameworks. |
+| `review.md` | opus | Natural teammate — can review in parallel with implementation. Add security/performance/correctness specializations. |
+| `debug.md` | opus | Keep as subagent template too — debugging is often a focused single task. |
+| `ci.md` | haiku | Add workflow file permissions. Restrict to `.github/` directory. |
+| `docs.md` | haiku | Add doc directory restrictions. Good teammate for parallel doc generation. |
+| `security-audit.md` | opus | Excellent teammate — can audit in parallel with development. |
+| `refactor.md` | opus | Add file-lock awareness for safe parallel refactoring. |
+| `dependency-audit.md` | haiku | Keep as subagent — typically a quick, focused task. |
+| `research.md` | opus | Excellent teammate — isolates web research from main context. |
+| `performance.md` | opus | Keep as subagent — profiling output is verbose and focused. |
+
+**Decision per agent**: Convert to teammate template if the task benefits from parallel execution and communication. Keep as subagent if the task is focused, short, and doesn't need coordination.
+
+| Best as Teammate | Best as Subagent | Either |
+|------------------|------------------|--------|
+| review, security-audit, research, docs | dependency-audit, performance | test, debug, ci, refactor |
+
+### Phase 3: Remove /handoffs (tools-plugin)
+
+| Component | Action | Rationale |
+|-----------|--------|-----------|
+| `tools-plugin/skills/handoffs/SKILL.md` | **Remove** | @AGENT-HANDOFF-MARKER convention replaced by native messaging |
+
+Update `tools-plugin/plugin.json` and marketplace entry.
+
+### Phase 4: Add Optional Team Patterns
+
+Add team-aware documentation to skills that benefit from parallel execution:
+
+| Skill | Plugin | Team Pattern |
+|-------|--------|-------------|
+| `code-review` | code-quality-plugin | "For comprehensive review, spawn teammates for security, performance, and correctness review in parallel" |
+| `configure-all` | configure-plugin | "Spawn teammates for linting, security, testing, and formatting checks in parallel" |
+| `test-full` | testing-plugin | "Spawn teammates for unit, integration, and e2e test suites in parallel" |
+| `blueprint-prp-execute` | blueprint-plugin | "For multi-module PRPs, spawn teammates per module with shared task list" |
+| `project-continue` | project-plugin | "Spawn research teammate + implementation teammate for large codebases" |
+| `docs-generate` | documentation-plugin | "Spawn teammates for parallel doc generation across modules" |
+
+These are documentation additions, not behavioral changes. Skills continue to work without agent teams.
+
+### Phase 5: Extend Analytics
+
+| Component | Change |
+|-----------|--------|
+| `command-analytics-plugin` | Extend `track-usage.sh` to capture `CLAUDE_TEAM_ROLE` or similar env var when available |
+
+---
+
+## Implementation Order
+
+```
+Phase 1 (Remove orchestration)
+  ├── Remove 11-12 skills from agent-patterns-plugin
+  ├── Remove orchestrator-enforcement hook
+  ├── Update plugin.json, marketplace.json, hooks.json
+  └── Update release-please configs if plugin scope changes significantly
+
+Phase 2 (Convert agents)
+  ├── Add teammate metadata to agent definitions
+  ├── Document which agents are best as teammates vs subagents
+  └── Update agents-plugin README
+
+Phase 3 (Remove handoffs)
+  ├── Remove handoffs skill from tools-plugin
+  └── Update tools-plugin metadata
+
+Phase 4 (Add team patterns)
+  ├── Add "Agent Teams" section to 6 skills
+  └── Documentation only, no behavioral changes
+
+Phase 5 (Extend analytics)
+  └── Update track-usage.sh for teammate context
+```
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Agent teams feature changes/breaks | Skills reference patterns that no longer work | Phase 4 additions are documentation only — easy to update |
+| Users depend on removed orchestration skills | Workflows break | Create migration guide mapping old skills → native features |
+| PreCompact hook removal premature | Context loss in long sessions | Keep hook, evaluate separately |
+| Agent teams not available in all environments | Teammate templates don't work | Keep subagent compatibility in agent definitions |
+
+---
+
+## Out of Scope
+
+- Removing or changing any domain-specific skills (280+ skills across 25 plugins)
+- Modifying safety hooks (bash-antipatterns, kubectl-context-validation)
+- Changing language ecosystem plugins (python, typescript, rust)
+- Modifying blueprint PRP/ADR validation hooks (domain-specific, not orchestration)
+- Refactoring the plugin directory structure itself


### PR DESCRIPTION
Propose adopting Claude Code's native agent teams feature and deprecating
custom orchestration infrastructure in agent-patterns-plugin. Includes
phased migration plan covering skill removal, agent-to-teammate conversion,
and optional team patterns for high-value skills.

https://claude.ai/code/session_011Ms6vfDQCruG58bsW9S6A1