### PR TITLE
Update workflow input parameter from direct_prompt to prompt

### DIFF
--- a/.github/workflows/infra-compliance-dashboard.yml
+++ b/.github/workflows/infra-compliance-dashboard.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model haiku --max-turns 30"
-          direct_prompt: |
+          prompt: |
             Perform an infrastructure compliance audit on this plugin repository.
             Output ONLY the issue body in markdown format. Do not create files or make changes.
 

--- a/.github/workflows/monthly-agentic-audit.yml
+++ b/.github/workflows/monthly-agentic-audit.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model haiku --max-turns 25"
-          direct_prompt: |
+          prompt: |
             Perform a monthly agentic quality audit on all skills in this plugin repository.
             Read .claude/rules/agentic-optimization.md and .claude/rules/skill-quality.md for standards.
             Output ONLY the issue body in markdown format. Do not create files or make changes.

--- a/.github/workflows/weekly-blueprint-health.yml
+++ b/.github/workflows/weekly-blueprint-health.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model haiku --max-turns 20"
-          direct_prompt: |
+          prompt: |
             Perform a comprehensive blueprint health check on this plugin repository.
             Output ONLY the issue body in markdown format. Do not create files or make changes.
 


### PR DESCRIPTION
## Summary
Updated three GitHub Actions workflows to use the correct input parameter name `prompt` instead of `direct_prompt` for the Claude Code action.

## Changes
- **infra-compliance-dashboard.yml**: Renamed `direct_prompt` to `prompt` input parameter
- **monthly-agentic-audit.yml**: Renamed `direct_prompt` to `prompt` input parameter
- **weekly-blueprint-health.yml**: Renamed `direct_prompt` to `prompt` input parameter

## Details
This change aligns the workflow configurations with the expected input parameter name for the Claude Code GitHub Action. The `prompt` parameter is the correct interface for passing instructions to the action, ensuring the workflows function as intended.

All three audit workflows maintain their original prompt content and configuration—only the parameter name has been corrected.

https://claude.ai/code/session_01LSUtJgyxcLhKfLcrzaxqS4