### PR TITLE
feat: add PLUGIN-MAP.md validation to plugin sync checks

### DIFF
--- a/.github/workflows/validate-plugin-configs.yml
+++ b/.github/workflows/validate-plugin-configs.yml
@@ -7,6 +7,7 @@ on:
       - 'release-please-config.json'
       - '.release-please-manifest.json'
       - '.claude-plugin/marketplace.json'
+      - 'docs/PLUGIN-MAP.md'
       - 'scripts/sync-plugin-configs.py'
   push:
     branches:
@@ -16,6 +17,7 @@ on:
       - 'release-please-config.json'
       - '.release-please-manifest.json'
       - '.claude-plugin/marketplace.json'
+      - 'docs/PLUGIN-MAP.md'
       - 'scripts/sync-plugin-configs.py'
   workflow_dispatch:
     inputs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ When creating, modifying, or deleting a plugin, update these files:
 | `marketplace.json` | `.claude-plugin/marketplace.json` | Add/update/remove plugin entry |
 | `release-please-config.json` | Root | Add/remove plugin package config |
 | `.release-please-manifest.json` | Root | Add/remove plugin version entry |
+| `PLUGIN-MAP.md` | `docs/PLUGIN-MAP.md` | Add/remove plugin from navigation map |
 
 ### Creating a New Plugin
 

--- a/scripts/sync-plugin-configs.py
+++ b/scripts/sync-plugin-configs.py
@@ -206,6 +206,20 @@ def check_sync(repo_root: Path) -> tuple[list[str], dict]:
             )
             fixes["version_mismatches"].append((name, manifest_version))
 
+    # Check for plugins missing from docs/PLUGIN-MAP.md (informational only)
+    plugin_map_path = repo_root / "docs" / "PLUGIN-MAP.md"
+    fixes["missing_from_plugin_map"] = []
+    if plugin_map_path.exists():
+        plugin_map_text = plugin_map_path.read_text()
+        missing_from_map = [
+            name for name in sorted(plugin_names) if name not in plugin_map_text
+        ]
+        for name in missing_from_map:
+            issues.append(
+                f"Plugin '{name}' missing from docs/PLUGIN-MAP.md (add manually to appropriate section)"
+            )
+            fixes["missing_from_plugin_map"].append(name)
+
     return issues, fixes
 
 


### PR DESCRIPTION
## Summary
- Add CI validation that every marketplace plugin appears in `docs/PLUGIN-MAP.md`
- Check is informational only (no auto-fix) since map placement requires human judgment
- Add `PLUGIN-MAP.md` to plugin lifecycle table in `CLAUDE.md`
- Add `docs/PLUGIN-MAP.md` to CI workflow path triggers

## Test plan
- [x] `python3 scripts/sync-plugin-configs.py` passes with all plugins present
- [x] Removing a plugin name from PLUGIN-MAP.md causes the script to report the missing plugin
- [ ] CI workflow triggers on PLUGIN-MAP.md changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)