### PR TITLE
Add cclsp MCP server configuration and LSP setup documentation

### DIFF
--- a/configure-plugin/skills/configure-mcp/SKILL.md
+++ b/configure-plugin/skills/configure-mcp/SKILL.md
@@ -1,7 +1,7 @@
 ---
 model: haiku
 created: 2025-12-16
-modified: 2026-02-08
+modified: 2026-02-09
 reviewed: 2026-02-08
 description: Check and configure MCP servers for project integration
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
@@ -178,6 +178,13 @@ Recommendations:
   "sequential-thinking": {
     "command": "npx",
     "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+  },
+  "cclsp": {
+    "command": "npx",
+    "args": ["-y", "cclsp@latest"],
+    "env": {
+      "CCLSP_CONFIG_PATH": "./cclsp.json"
+    }
   }
 }
 ```
@@ -202,6 +209,28 @@ Recommendations:
 4. **Git tracking recommendation**:
    - Personal projects → recommend `.gitignore` (keep API configs local)
    - Team projects → recommend tracking (share MCP setup with team)
+
+5. **cclsp setup** (if cclsp selected):
+   - Create `cclsp.json` in the project root with language servers based on detected project files
+   - Detect project languages by checking for source files:
+
+   | Files Present | Language Server Entry |
+   |---------------|----------------------|
+   | `*.ts`, `*.tsx`, `*.js`, `*.jsx` | `{"extensions": ["js", "ts", "jsx", "tsx", "mjs", "cjs"], "command": ["typescript-language-server", "--stdio"], "rootDir": "."}` |
+   | `*.py` | `{"extensions": ["py", "pyi"], "command": ["pylsp"], "rootDir": "."}` |
+   | `*.go` | `{"extensions": ["go"], "command": ["gopls", "serve"], "rootDir": "."}` |
+   | `*.rs` | `{"extensions": ["rs"], "command": ["rust-analyzer"], "rootDir": "."}` |
+
+   - Write `cclsp.json` with detected servers:
+     ```json
+     {
+       "servers": [
+         // entries based on detected languages
+       ]
+     }
+     ```
+   - Add `cclsp.json` to `.gitignore` (machine-specific language server paths)
+   - Warn user to install required language servers (`npm i -g typescript-language-server`, `pip install python-lsp-server`, etc.)
 
 ### Phase 6: Environment Variable Reference
 
@@ -278,6 +307,9 @@ Tip: Run /configure:mcp again to add more servers anytime.
 
 # Quick add github server
 /configure:mcp --server github
+
+# Install cclsp for LSP code navigation
+/configure:mcp --server cclsp
 ```
 
 ## Error Handling


### PR DESCRIPTION
## Summary
This PR adds support for the `cclsp` MCP server to the configure-mcp skill, including comprehensive documentation for setting up language servers based on detected project languages.

## Key Changes
- **Added cclsp server configuration** to the MCP servers list with npx command and `CCLSP_CONFIG_PATH` environment variable
- **Documented cclsp setup process** (Phase 5) with automatic language server detection based on project file types:
  - TypeScript/JavaScript projects → typescript-language-server
  - Python projects → pylsp
  - Go projects → gopls
  - Rust projects → rust-analyzer
- **Added cclsp.json generation logic** that creates a configuration file with detected language servers
- **Included security best practice** to add cclsp.json to .gitignore (machine-specific paths)
- **Added user warnings** about installing required language servers globally
- **Updated quick reference examples** with cclsp usage command

## Implementation Details
- The cclsp configuration uses environment variable `CCLSP_CONFIG_PATH` to point to the project root configuration
- Language server detection is table-driven, making it easy to extend with additional languages
- The setup maintains consistency with other MCP server configurations in the skill
- Updated modification date to reflect changes (2026-02-09)

https://claude.ai/code/session_01Ng39CPMVFsNxdodQ9A8Htq