### PR TITLE
fix(release-please): resolve auto-merge race condition

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,7 +23,7 @@ jobs:
 
   enable-auto-merge:
     runs-on: ubuntu-latest
-    needs: release-please
+    needs: [release-please, sync-release-pr]
     if: ${{ needs.release-please.outputs.prs_created == 'true' }}
     steps:
       - name: Enable auto-merge for release PRs


### PR DESCRIPTION
## Summary

- Sequence `enable-auto-merge` job after `sync-release-pr` to prevent the sync commit from invalidating auto-merge state
- Root cause: both jobs ran in parallel, so a commit pushed by sync could reset the auto-merge flag

## Test plan

- [ ] Verify next release-please PR gets auto-merge enabled after sync commits are pushed
- [ ] Confirm workflow syntax is valid via Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)