### PR TITLE
fix(github-actions): enable track_progress for review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+# Cancel in-progress reviews when new commits are pushed
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write
@@ -23,6 +28,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
           prompt: |
             Review this pull request. Focus on:
             - Code quality and best practices


### PR DESCRIPTION
## Summary

- Enable `track_progress: true` for the Claude Code Review workflow so PR comments are posted during review
- Add concurrency settings to cancel in-progress reviews when new commits are pushed

## Issue

The `claude-code-action` in agent mode (triggered by `pull_request` events with a `prompt` input) does not post PR comments. Output only goes to the Actions step summary tab. Adding `track_progress: true` forces tag mode, which creates and updates a tracking comment on the PR.

## Test plan

- [ ] Verify next PR triggers the review workflow and posts a tracking comment on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)