### PR TITLE
Refactor git worktrees to use project-local directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Git worktrees created by agent workflows
+/worktrees/


### PR DESCRIPTION
## Summary
Refactored the git-worktree-agent-workflow skill to store worktrees inside the project directory (`./worktrees/`) instead of as sibling directories (`../project-wt-*`). This simplifies permissions management and keeps all workflow artifacts contained within the project.

## Key Changes

- **Worktree location**: Changed from `../project-wt-issue-N` to `./worktrees/issue-N`
  - Eliminates need for `additionalDirectories` configuration
  - Agents already have permissions to project directory
  - Keeps workflow artifacts self-contained

- **Git ignore**: Added `/worktrees/` to `.gitignore` to prevent tracking worktree contents while keeping the directory structure in the project

- **Command updates**: Replaced `cd` navigation with `git -C` for cleaner, more reliable command execution across all phases:
  - Patch application: `git -C ./worktrees/issue-N am/apply`
  - Status checks: `git -C ./worktrees/issue-N status`
  - Test execution: `cd ./worktrees/issue-N && npm test`

- **Documentation improvements**:
  - Updated agent prompt template to use `{repo_root}/worktrees/issue-{N}` placeholder
  - Added explicit `mkdir -p worktrees` step in Phase 2
  - Clarified why local worktrees are preferred (permissions, containment)
  - Updated command reference table with new paths and `git -C` usage
  - Updated workflow diagram to reflect new directory structure
  - Added cleanup step to remove empty worktrees directory

- **Metadata**: Updated SKILL.md modified and reviewed dates to 2026-02-10

## Implementation Details

The refactoring maintains all existing functionality while improving the workflow's usability:
- Worktrees remain isolated and can be worked on simultaneously
- Git database sharing is preserved for efficiency
- Cleanup is simplified with `rmdir worktrees` after removing individual worktrees
- All commands are more portable and don't rely on relative path navigation

https://claude.ai/code/session_01Ts3EpXLKxM25BxPCDKkNMr