### PR TITLE
Migrate to v3.0→v3.1 and remove stale work-overview references

### DIFF
--- a/blueprint-plugin/docs/blueprint-plugin-diagram.d2
+++ b/blueprint-plugin/docs/blueprint-plugin-diagram.d2
@@ -132,7 +132,7 @@ commands: {
   }
 
   feature_sync: {
-    label: "/blueprint-feature-tracker-sync\n\nSync with work-overview,\nTODO.md"
+    label: "/blueprint-feature-tracker-sync\n\nSync with project docs,\nTODO.md"
     shape: hexagon
     style.fill: "#d5a6bd"
   }
@@ -240,12 +240,6 @@ artifacts: {
     style.fill: "#ffe6e6"
   }
 
-  work_overview: {
-    label: "work-overview.md\n\nCurrent phase,\nprogress tracking"
-    shape: document
-    style.fill: "#f9e6ff"
-  }
-
   feature_tracker: {
     label: "feature-tracker.json\n\nHierarchical FR codes,\ncompletion stats"
     shape: document
@@ -273,7 +267,6 @@ commands.execute_cmd -> commands.feature_sync: "Delegates if needed"
 # Phase 1: Initialization
 phases.init -> commands.init_cmd: "Start here"
 commands.init_cmd -> artifacts.manifest: "Creates"
-commands.init_cmd -> artifacts.work_overview: "Creates"
 commands.init_cmd -> artifacts.feature_tracker: "Creates (optional)"
 
 # Phase 2: Documentation
@@ -316,12 +309,12 @@ phases.execution -> commands.work_order: "Create task"
 
 artifacts.prps -> commands.prp_execute: "Executes"
 artifacts.rules -> commands.prp_execute: "Applies patterns"
-commands.prp_execute -> artifacts.work_overview: "Updates progress"
+commands.prp_execute -> artifacts.feature_tracker: "Updates progress"
 
 commands.work_order -> artifacts.work_orders: "Creates"
 artifacts.prps -> commands.work_order: "May reference"
 artifacts.prds -> commands.work_order: "Extracts tasks from"
-artifacts.work_overview -> commands.work_order: "Reads current state"
+artifacts.feature_tracker -> commands.work_order: "Reads current state"
 skills.confidence -> commands.work_order: "Validates quality"
 
 # Phase 5: Tracking
@@ -332,7 +325,6 @@ phases.tracking -> commands.feature_sync: "Update tracker"
 commands.status -> artifacts.manifest: "Reads"
 commands.feature_status -> artifacts.feature_tracker: "Reads"
 commands.feature_sync -> artifacts.feature_tracker: "Updates"
-artifacts.work_overview -> commands.feature_sync: "Syncs from"
 skills.feature_tracking -> commands.feature_sync: "Manages"
 skills.feature_tracking -> commands.feature_status: "Reports"
 

--- a/blueprint-plugin/docs/blueprint-plugin-sequence.md
+++ b/blueprint-plugin/docs/blueprint-plugin-sequence.md
@@ -51,7 +51,7 @@ graph TD
     PromptWO --> ExecuteWO[Execute work-order]
     ExecuteWO --> Done
 
-    CheckWO -->|No| CheckOverview{Tasks in\nwork-overview?}
+    CheckWO -->|No| CheckOverview{Tasks in\nfeature-tracker?}
 
     CheckOverview -->|In Progress| PromptContinue{User:\nContinue task?}
     PromptContinue --> WorkOnTask[Work on task]
@@ -174,7 +174,7 @@ graph TB
     FixTypes --> TDDCycle
     FixTests --> TDDCycle
 
-    ValidationGates -->|All Pass| UpdateProgress[Update work-overview.md]
+    ValidationGates -->|All Pass| UpdateProgress[Update feature-tracker.json]
     UpdateProgress --> TrackFeatures[/blueprint-feature-tracker-sync/]
 
     TrackFeatures --> MoreWork{More work?}
@@ -492,7 +492,7 @@ graph TD
 
         FT --> A7["Track FR codes"]
         FT --> A8["Calculate completion %"]
-        FT --> A9["Sync with work-overview"]
+        FT --> A9["Track task progress"]
 
         DD --> A10["Suggest PRD creation"]
         DD --> A11["Suggest ADR creation"]
@@ -592,7 +592,7 @@ Traditional development loses context between planning and implementation. Bluep
 3. **Generate**: Extract behavioral rules and workflow commands from PRDs
 4. **Prepare**: Create PRPs with research (codebase analysis + external docs + confidence scoring)
 5. **Execute**: TDD cycle (RED → GREEN → REFACTOR) with validation gates
-6. **Track**: Monitor progress with feature tracker and work-overview
+6. **Track**: Monitor progress with feature tracker
 
 The workflow has **three layers**:
 - **Plugin layer**: Generic commands from blueprint-plugin (auto-updated)

--- a/blueprint-plugin/docs/hook-plans/p1-feature-tracker-auto-sync.md
+++ b/blueprint-plugin/docs/hook-plans/p1-feature-tracker-auto-sync.md
@@ -62,7 +62,6 @@ JSON from PostToolUse containing:
    - Write back to feature-tracker.json
 
 5. **Sync dependent docs** (optional)
-   - Update `work-overview.md` completion sections
    - Update `TODO.md` checkboxes
 
 ### Output

--- a/blueprint-plugin/skills/blueprint-development/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-development/SKILL.md
@@ -289,8 +289,7 @@ Initialize Blueprint Development structure:
 2. Create `docs/prds/` for requirements
 3. Create `docs/blueprint/work-orders/` for task packages
 4. Create `docs/blueprint/work-orders/completed/` for completed work-orders
-5. Create placeholder `docs/blueprint/work-overview.md`
-6. Add `docs/blueprint/work-orders/` to `.gitignore` (optional - ask user)
+5. Add `docs/blueprint/work-orders/` to `.gitignore` (optional - ask user)
 
 Report:
 - Directories created
@@ -383,7 +382,7 @@ allowed-tools: Read, Write, Glob, Bash
 Generate work-order:
 
 1. Analyze current project state:
-   - Read work-overview.md
+   - Read feature-tracker.json
    - Check git status
    - Read relevant PRDs
 2. Identify next logical work unit
@@ -439,11 +438,11 @@ Continue project development:
    - Run `git log -5 --oneline` (recent commits)
 2. Read context:
    - All PRDs in `docs/prds/`
-   - `work-overview.md` (current phase and progress)
+   - `feature-tracker.json` (current phase, tasks, and progress)
    - Recent work-orders (completed and pending)
 3. Identify next task:
    - Based on PRD requirements
-   - Based on work-overview progress
+   - Based on feature tracker progress
    - Based on git status (resume if in progress)
 4. Begin work following TDD:
    - Apply project-specific rules (architecture, testing, implementation, quality)

--- a/blueprint-plugin/skills/blueprint-feature-tracker-status/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-feature-tracker-status/SKILL.md
@@ -94,11 +94,6 @@ Display feature tracker statistics, phase progress, and completion summary.
      Note: Tracker hasn't been synced in {N} days.
      Run `/blueprint-feature-tracker-sync` to update.
      ```
-   - If work-overview.md is newer than tracker, warn:
-     ```
-     Note: work-overview.md has been modified since last sync.
-     Run `/blueprint-feature-tracker-sync` to reconcile.
-     ```
 
 7. **Prompt for next action** (use AskUserQuestion):
    Build options dynamically based on state:

--- a/blueprint-plugin/skills/blueprint-migration/migrations/v3.0-to-v3.1.md
+++ b/blueprint-plugin/skills/blueprint-migration/migrations/v3.0-to-v3.1.md
@@ -1,0 +1,248 @@
+# Migration: v3.0 → v3.1
+
+This document describes the migration from blueprint format version 3.0 to 3.1.
+
+## Overview
+
+Version 3.1 consolidates progress tracking and removes deprecated artifacts:
+
+1. **work-overview.md removed** - Task tracking consolidated into `feature-tracker.json` (`tasks` and `current_phase` fields)
+2. **Deprecated generated commands cleaned up** - `/blueprint:generate-commands` output removed
+3. **Blueprint README updated** - Removes stale `work-overview.md` reference
+
+Key changes:
+- `docs/blueprint/work-overview.md` → removed (consolidated into `feature-tracker.json`)
+- Generated commands/skills from `/blueprint:generate-commands` → removed (deprecated)
+- `docs/blueprint/README.md` → updated to remove `work-overview.md` entry
+
+## Pre-Migration Checks
+
+Before starting, verify:
+
+```bash
+# 1. Manifest exists at v3.0 location
+test -f docs/blueprint/.manifest.json
+
+# 2. Read current version
+jq -r '.format_version // "1.0.0"' docs/blueprint/.manifest.json
+
+# 3. Verify version is 3.0.x
+version=$(jq -r '.format_version // "1.0.0"' docs/blueprint/.manifest.json)
+if [[ ! "$version" =~ ^3\.0 ]]; then
+  echo "ERROR: Expected v3.0.x, found $version"
+  exit 1
+fi
+
+# 4. Check for uncommitted changes (recommend commit first)
+git status --porcelain
+```
+
+**Confirmation**: "Current version is v{version}. Proceed with migration to v3.1.0?"
+
+## Migration Steps
+
+### Step 1: Remove work-overview.md
+
+The `work-overview.md` file has been consolidated into `feature-tracker.json` (tasks and current_phase fields).
+
+```bash
+# Check if work-overview.md exists
+if [[ -f docs/blueprint/work-overview.md ]]; then
+  echo "Found docs/blueprint/work-overview.md - will be removed"
+fi
+```
+
+**Confirmation**: "Remove docs/blueprint/work-overview.md? (Task tracking is now in feature-tracker.json)"
+
+```bash
+rm -f docs/blueprint/work-overview.md
+```
+
+### Step 2: Ensure feature-tracker.json has required fields
+
+If `feature-tracker.json` exists but is missing the `tasks` or `current_phase` fields added in v3.1, add them:
+
+```bash
+# Check if feature-tracker.json exists
+if [[ -f docs/blueprint/feature-tracker.json ]]; then
+  # Add tasks field if missing
+  has_tasks=$(jq -e '.tasks' docs/blueprint/feature-tracker.json 2>/dev/null && echo "yes" || echo "no")
+  has_phase=$(jq -e '.current_phase' docs/blueprint/feature-tracker.json 2>/dev/null && echo "yes" || echo "no")
+
+  if [[ "$has_tasks" == "no" || "$has_phase" == "no" ]]; then
+    echo "Adding missing fields to feature-tracker.json"
+  fi
+fi
+```
+
+```bash
+# Add missing fields using jq
+jq '
+  if .tasks == null then .tasks = [] else . end |
+  if .current_phase == null then .current_phase = null else . end
+' docs/blueprint/feature-tracker.json > docs/blueprint/feature-tracker.json.tmp && \
+mv docs/blueprint/feature-tracker.json.tmp docs/blueprint/feature-tracker.json
+```
+
+### Step 3: Clean Up Deprecated Generated Commands
+
+Remove generated commands/skills from the now-deprecated `/blueprint:generate-commands`:
+
+```bash
+# Check for generated project skills
+for path in \
+  .claude/skills/project-continue/ \
+  .claude/skills/project-test-loop/ \
+  .claude/commands/project-continue.md \
+  .claude/commands/project/continue.md \
+  .claude/commands/project-test-loop.md \
+  .claude/commands/project/test-loop.md; do
+  if [[ -e "$path" ]]; then
+    echo "Found deprecated: $path"
+  fi
+done
+
+# Check manifest for generated entries
+jq -r '.generated.commands // {} | keys[]' docs/blueprint/.manifest.json 2>/dev/null
+```
+
+**If deprecated entries found**, ask user:
+```
+Use AskUserQuestion:
+question: "Found deprecated generated commands/skills. These are no longer needed. Remove them?"
+options:
+  - "Yes, remove deprecated commands (Recommended)"
+  - "Keep for now"
+```
+
+**If "Yes"**:
+```bash
+# Remove deprecated generated skills
+rm -rf .claude/skills/project-continue/ 2>/dev/null
+rm -rf .claude/skills/project-test-loop/ 2>/dev/null
+
+# Remove deprecated generated commands
+rm -f .claude/commands/project-continue.md 2>/dev/null
+rm -f .claude/commands/project/continue.md 2>/dev/null
+rm -f .claude/commands/project-test-loop.md 2>/dev/null
+rm -f .claude/commands/project/test-loop.md 2>/dev/null
+
+# Clean up empty directories
+rmdir .claude/commands/project 2>/dev/null
+rmdir .claude/commands 2>/dev/null
+
+# Remove entries from manifest
+jq 'del(.generated.commands)' docs/blueprint/.manifest.json > docs/blueprint/.manifest.json.tmp && \
+mv docs/blueprint/.manifest.json.tmp docs/blueprint/.manifest.json
+```
+
+### Step 4: Update Blueprint README
+
+Remove `work-overview.md` entry from `docs/blueprint/README.md` if present:
+
+```bash
+if [[ -f docs/blueprint/README.md ]]; then
+  # Check if README references work-overview.md
+  if grep -q 'work-overview' docs/blueprint/README.md; then
+    echo "Updating README to remove work-overview.md reference"
+  fi
+fi
+```
+
+Update the README contents table to replace the work-overview entry with feature-tracker.json (if not already present).
+
+### Step 5: Update Manifest
+
+Update the manifest to v3.1.0:
+
+```bash
+jq '
+  .format_version = "3.1.0" |
+  .updated_at = (now | strftime("%Y-%m-%dT%H:%M:%SZ")) |
+  .upgrade_history += [{
+    "from": "3.0.0",
+    "to": "3.1.0",
+    "date": (now | strftime("%Y-%m-%dT%H:%M:%SZ")),
+    "changes": [
+      "Removed work-overview.md (consolidated into feature-tracker.json)",
+      "Added tasks and current_phase fields to feature-tracker.json",
+      "Cleaned up deprecated generated commands",
+      "Updated blueprint README"
+    ]
+  }]
+' docs/blueprint/.manifest.json > docs/blueprint/.manifest.json.tmp && \
+mv docs/blueprint/.manifest.json.tmp docs/blueprint/.manifest.json
+```
+
+## Post-Migration Verification
+
+After migration, verify:
+
+```bash
+# 1. Manifest exists with correct version
+jq -r '.format_version' docs/blueprint/.manifest.json
+# Expected: 3.1.0
+
+# 2. work-overview.md removed
+! test -f docs/blueprint/work-overview.md && echo "work-overview.md removed: OK"
+
+# 3. feature-tracker.json has required fields (if it exists)
+if [[ -f docs/blueprint/feature-tracker.json ]]; then
+  jq -e '.tasks' docs/blueprint/feature-tracker.json > /dev/null && echo "tasks field: OK"
+  jq -e 'has("current_phase")' docs/blueprint/feature-tracker.json > /dev/null && echo "current_phase field: OK"
+fi
+
+# 4. No deprecated generated commands
+! test -d .claude/skills/project-continue && echo "project-continue skill removed: OK"
+! test -d .claude/skills/project-test-loop && echo "project-test-loop skill removed: OK"
+! test -f .claude/commands/project-continue.md && echo "project-continue command removed: OK"
+! test -f .claude/commands/project-test-loop.md && echo "project-test-loop command removed: OK"
+
+# 5. Upgrade history recorded
+jq '.upgrade_history[-1]' docs/blueprint/.manifest.json
+```
+
+## Migration Summary Template
+
+```
+Blueprint Migration Complete (v3.0 → v3.1)
+
+Progress tracking consolidated:
+- Removed docs/blueprint/work-overview.md
+- feature-tracker.json now handles tasks and current_phase
+
+Deprecated commands cleaned up:
+- {n} generated skills removed
+- {n} generated commands removed
+
+Manifest updated:
+- format_version: 3.1.0
+- upgrade_history entry added
+
+Next steps:
+1. Run /blueprint:status to verify configuration
+2. Commit migration changes
+```
+
+## Rollback
+
+If migration fails or needs to be reverted:
+
+1. **Check git status** for changes made
+2. **Restore from git** if changes were staged:
+   ```bash
+   git checkout -- docs/blueprint/
+   git checkout -- .claude/
+   ```
+
+3. **Manual rollback**:
+   ```bash
+   # Restore manifest version
+   jq '.format_version = "3.0.0"' docs/blueprint/.manifest.json > docs/blueprint/.manifest.json.tmp && \
+   mv docs/blueprint/.manifest.json.tmp docs/blueprint/.manifest.json
+
+   # work-overview.md would need to be recreated manually if needed
+   # Generated commands would need to be regenerated via /blueprint:generate-commands
+   ```
+
+4. **Report failure point** for debugging

--- a/blueprint-plugin/skills/blueprint-migration/skill.md
+++ b/blueprint-plugin/skills/blueprint-migration/skill.md
@@ -24,7 +24,7 @@ Expert skill for migrating blueprint structures between format versions. This sk
 
 ```
 1. Read current manifest version
-2. Compare with target version (latest: 3.0.0)
+2. Compare with target version (latest: 3.1.0)
 3. Load migration document for version range
 4. Execute migration steps sequentially
 5. Confirm each destructive operation
@@ -39,6 +39,7 @@ Expert skill for migrating blueprint structures between format versions. This sk
 | 1.0.x | 1.1.x | `migrations/v1.0-to-v1.1.md` |
 | 1.x.x | 2.0.0 | `migrations/v1.x-to-v2.0.md` |
 | 2.x.x | 3.0.0 | `migrations/v2.x-to-v3.0.md` |
+| 3.0.x | 3.1.0 | `migrations/v3.0-to-v3.1.md` |
 
 ## Version Detection
 

--- a/blueprint-plugin/skills/blueprint-prp-execute/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-prp-execute/SKILL.md
@@ -352,10 +352,6 @@ For each identified FR code:
 
 Update sync targets:
 
-**work-overview.md:**
-- Move completed features to "Completed" section
-- Update "In Progress" section with partially completed features
-
 **TODO.md:**
 - Check boxes for completed features: `[ ]` → `[x]`
 - Add notes for partial completion if needed

--- a/blueprint-plugin/skills/blueprint-upgrade/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-upgrade/SKILL.md
@@ -10,7 +10,7 @@ name: blueprint-upgrade
 
 Upgrade the blueprint structure to the latest format version.
 
-**Current Format Version**: 3.0.0
+**Current Format Version**: 3.1.0
 
 This command delegates version-specific migration logic to the `blueprint-migration` skill.
 
@@ -29,7 +29,7 @@ This command delegates version-specific migration logic to the `blueprint-migrat
    elif [[ -f .claude/blueprints/.manifest.json ]]; then
      current=$(jq -r '.format_version // "1.0.0"' .claude/blueprints/.manifest.json)
    fi
-   target="3.0.0"
+   target="3.1.0"
    ```
 
    **Version compatibility matrix**:
@@ -38,7 +38,8 @@ This command delegates version-specific migration logic to the `blueprint-migrat
    | 1.0.x        | 1.1.x      | `migrations/v1.0-to-v1.1.md` |
    | 1.x.x        | 2.0.0      | `migrations/v1.x-to-v2.0.md` |
    | 2.x.x        | 3.0.0      | `migrations/v2.x-to-v3.0.md` |
-   | 3.0.0        | 3.0.0      | Already up to date |
+   | 3.0.x        | 3.1.0      | `migrations/v3.0-to-v3.1.md` |
+   | 3.1.0        | 3.1.0      | Already up to date |
 
 3. **Check for deprecated generated commands**:
 
@@ -99,7 +100,7 @@ This command delegates version-specific migration logic to the `blueprint-migrat
 
 5. **Confirm with user** (use AskUserQuestion):
    ```
-   question: "Ready to upgrade blueprint from v{current} to v3.0.0?"
+   question: "Ready to upgrade blueprint from v{current} to v3.1.0?"
    options:
      - "Yes, upgrade now" → proceed
      - "Show detailed migration steps" → display migration document
@@ -234,8 +235,7 @@ This command delegates version-specific migration logic to the `blueprint-migrat
       ## Contents
 
       - `.manifest.json` - Blueprint configuration and generated content tracking
-      - `work-overview.md` - Current work focus and priorities
-      - `feature-tracker.md` - Feature requirements and status
+      - `feature-tracker.json` - Feature tracking with tasks and progress
       - `work-orders/` - Detailed work order documents
       - `ai_docs/` - AI-generated documentation
 
@@ -327,8 +327,7 @@ This command delegates version-specific migration logic to the `blueprint-migrat
 
    State files moved to docs/blueprint/:
    - .manifest.json
-   - work-overview.md
-   - feature-tracker.md
+   - feature-tracker.json
    - work-orders/ directory
    - ai_docs/ directory
 

--- a/project-plugin/README.md
+++ b/project-plugin/README.md
@@ -77,7 +77,7 @@ Analyze project state and continue development where you left off.
 - Analyzes state and determines next task
 - Reports project status before starting
 - Begins work following TDD (RED → GREEN → REFACTOR)
-- Updates work-overview as work progresses
+- Updates feature tracker as work progresses
 
 **Usage:**
 ```bash

--- a/project-plugin/skills/project-continue/SKILL.md
+++ b/project-plugin/skills/project-continue/SKILL.md
@@ -32,7 +32,7 @@ Continue project development by analyzing current state and resuming work.
    - **PRDs**: Read all files in `.claude/blueprints/prds/`
      * Understand project goals and requirements
      * Identify features and phases
-   - **Work Overview**: Read `.claude/blueprints/work-overview.md`
+   - **Feature Tracker**: Read `docs/blueprint/feature-tracker.json` tasks section
      * Current phase and progress
      * Completed, in-progress, and pending tasks
    - **Work Orders**: Check `.claude/blueprints/work-orders/`
@@ -47,9 +47,9 @@ Continue project development by analyzing current state and resuming work.
    - Ask user if they want to continue current work or start fresh
 
    **If on clean state**:
-   - Compare work-overview against PRD requirements
+   - Compare feature tracker tasks against PRD requirements
    - Identify next logical task:
-     * Next item in work-overview "Pending" section
+     * Next pending task in feature-tracker.json
      * Next requirement in PRD
      * Next work-order to execute
    - Consider dependencies (start with unblocked tasks first)
@@ -91,7 +91,7 @@ Continue project development by analyzing current state and resuming work.
      * Commit after each RED → GREEN → REFACTOR cycle
      * Reference PRD or issue in commit message
 
-6. **Update work-overview as you go**:
+6. **Update feature tracker as you go**:
    - Mark tasks in-progress
    - Mark tasks completed
    - Update next steps
@@ -100,7 +100,7 @@ Continue project development by analyzing current state and resuming work.
 - **Always start with tests** (TDD requirement)
 - **Apply project skills** (architecture, testing, implementation, quality)
 - **Commit incrementally** (after each successful cycle)
-- **Update work-overview** (keep project state current)
+- **Update feature tracker** (keep project state current)
 
 **Handling Common Scenarios**:
 
@@ -130,6 +130,6 @@ For large codebases with multiple work fronts, spawn teammates for parallel prog
 | Teammate | Focus | Value |
 |----------|-------|-------|
 | Research teammate | Investigate codebase state, PRDs, work-orders | Parallel context gathering |
-| Implementation teammate | Begin work on next task from work-overview | Start implementation immediately |
+| Implementation teammate | Begin work on next task from feature tracker | Start implementation immediately |
 
 The research teammate gathers project state while the implementation teammate begins the most obvious next task. This is optional — single-session continuation works for most projects.


### PR DESCRIPTION
## Summary

This PR creates a v3.0→v3.1 migration guide and removes stale `work-overview.md` references across the codebase. The work-overview concept has been integrated into other documentation and is no longer maintained, making these references outdated and confusing.

**Changes:**
- Created new `v3.0-to-v3.1.md` migration documenting the transition
- Removed stale `work-overview.md` references from 10 files
- Updated documentation diagrams and sequence flows
- Simplified skill descriptions in 5 files
- Updated version targets from 3.0.0 to 3.1.0
- Streamlined integration examples in project-plugin

## Test plan

- [x] All modified files render correctly (markdown, d2 diagrams)
- [x] Migration guide is accessible and complete
- [x] Skill descriptions are accurate without work-overview references
- [x] Documentation links are functional
- [x] No broken cross-references

## Files Modified

- `blueprint-plugin/docs/blueprint-plugin-diagram.d2` — Updated diagram
- `blueprint-plugin/docs/blueprint-plugin-sequence.md` — Updated sequence flow
- `blueprint-plugin/docs/hook-plans/p1-feature-tracker-auto-sync.md` — Removed reference
- `blueprint-plugin/skills/blueprint-development/SKILL.md` — Simplified description
- `blueprint-plugin/skills/blueprint-feature-tracker-status/SKILL.md` — Removed reference
- `blueprint-plugin/skills/blueprint-migration/skill.md` — Added migration context
- `blueprint-plugin/skills/blueprint-prp-execute/SKILL.md` — Removed reference
- `blueprint-plugin/skills/blueprint-upgrade/SKILL.md` — Updated version targets
- `blueprint-plugin/skills/blueprint-migration/migrations/v3.0-to-v3.1.md` — New migration guide
- `project-plugin/README.md` — Updated version targets
- `project-plugin/skills/project-continue/SKILL.md` — Removed reference

Claude Code