### PR TITLE
fix: standardize skill name fields to kebab-case across all plugins

### DIFF
--- a/agent-patterns-plugin/skills/claude-hooks-configuration/SKILL.md
+++ b/agent-patterns-plugin/skills/claude-hooks-configuration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 model: haiku
-name: Claude Code Hooks Configuration
+name: claude-hooks-configuration
 description: |
   Set up Claude Code lifecycle hooks and event handlers in settings.json. Use when you
   want to trigger a script on session start, run a hook before or after tool calls

--- a/agent-patterns-plugin/skills/mcp-code-execution/SKILL.md
+++ b/agent-patterns-plugin/skills/mcp-code-execution/SKILL.md
@@ -1,6 +1,6 @@
 ---
 model: opus
-name: MCP Code Execution Pattern
+name: mcp-code-execution
 description: |
   Design and scaffold the code execution pattern for MCP-based agent systems. Use when
   building agents that interact with many MCP tools, when intermediate data is too large

--- a/agent-patterns-plugin/skills/mcp-management/SKILL.md
+++ b/agent-patterns-plugin/skills/mcp-management/SKILL.md
@@ -3,7 +3,7 @@ model: haiku
 created: 2025-12-16
 modified: 2026-02-05
 reviewed: 2025-12-16
-name: MCP Server Management
+name: mcp-management
 description: |
   Install and configure Model Context Protocol (MCP) servers for Claude Code projects.
   Use when you want to add or enable an MCP server, connect a tool or integration

--- a/bevy-plugin/skills/bevy-ecs-patterns/skill.md
+++ b/bevy-plugin/skills/bevy-ecs-patterns/skill.md
@@ -3,7 +3,7 @@ model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16
-name: Bevy ECS Patterns
+name: bevy-ecs-patterns
 description: Advanced Bevy ECS patterns including complex queries, system scheduling, change detection, entity relationships, and performance optimization. Use when working on advanced Bevy game architecture, optimizing ECS performance, or implementing complex game systems.
 allowed-tools: Glob, Grep, Read, Bash(cargo *), Edit, Write, TodoWrite, WebFetch, WebSearch, BashOutput, KillShell
 ---

--- a/bevy-plugin/skills/bevy-game-engine/skill.md
+++ b/bevy-plugin/skills/bevy-game-engine/skill.md
@@ -3,7 +3,7 @@ model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16
-name: Bevy Game Engine
+name: bevy-game-engine
 description: Bevy game engine development including ECS architecture, rendering, input handling, asset management, and game loop design. Use when building games with Bevy, working with entities/components/systems, or when the user mentions Bevy, game development in Rust, or 2D/3D games.
 allowed-tools: Glob, Grep, Read, Bash(cargo *), Edit, Write, TodoWrite, WebFetch, WebSearch, BashOutput, KillShell
 ---

--- a/blog-plugin/skills/blog-post-writing/skill.md
+++ b/blog-plugin/skills/blog-post-writing/skill.md
@@ -1,6 +1,6 @@
 ---
 model: haiku
-name: Blog Post Writing
+name: blog-post-writing
 description: |
   Consistent style guide for writing blog posts about projects and technical work.
   Supports quick updates, detailed write-ups, retrospectives, and tutorials.

--- a/blueprint-plugin/skills/adr-relationships/skill.md
+++ b/blueprint-plugin/skills/adr-relationships/skill.md
@@ -1,6 +1,6 @@
 ---
 model: haiku
-name: ADR Relationships
+name: adr-relationships
 description: Domain analysis, conflict detection, and relationship validation for Architecture Decision Records. Use when creating or validating ADRs to ensure consistency.
 allowed-tools: Bash, Read, Grep, Glob, TodoWrite
 created: 2026-01-15

--- a/blueprint-plugin/skills/blueprint-migration/skill.md
+++ b/blueprint-plugin/skills/blueprint-migration/skill.md
@@ -1,6 +1,6 @@
 ---
 model: opus
-name: Blueprint Migration
+name: blueprint-migration
 description: Versioned migration procedures for upgrading blueprint structure between format versions
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion, TodoWrite
 created: 2025-12-22

--- a/code-quality-plugin/skills/ast-grep-search/SKILL.md
+++ b/code-quality-plugin/skills/ast-grep-search/SKILL.md
@@ -3,7 +3,7 @@ model: haiku
 created: 2025-12-16
 modified: 2026-01-24
 reviewed: 2026-01-24
-name: ast-grep Structural Code Search & Refactoring
+name: ast-grep-search
 description: Find and replace code patterns structurally using ast-grep. Use when you need to match code by its AST structure (not just text), such as finding all functions with specific signatures, replacing API patterns across files, or detecting code anti-patterns that regex cannot reliably match.
 allowed-tools: Bash(sg *), Bash(ast-grep *), Read, Grep, Glob
 ---

--- a/code-quality-plugin/skills/code-review-checklist/SKILL.md
+++ b/code-quality-plugin/skills/code-review-checklist/SKILL.md
@@ -1,6 +1,6 @@
 ---
 model: opus
-name: Code Review Checklist
+name: code-review-checklist
 description: Structured code review approach covering security, quality, performance, and consistency.
 allowed-tools: Read, Grep, Glob
 created: 2025-12-27

--- a/code-quality-plugin/skills/debugging-methodology/SKILL.md
+++ b/code-quality-plugin/skills/debugging-methodology/SKILL.md
@@ -1,6 +1,6 @@
 ---
 model: opus
-name: Debugging Methodology
+name: debugging-methodology
 description: Systematic debugging approach with tool recommendations for memory, performance, and system-level issues.
 allowed-tools: Bash, Read, Grep, Glob
 created: 2025-12-27

--- a/code-quality-plugin/skills/documentation-quality/SKILL.md
+++ b/code-quality-plugin/skills/documentation-quality/SKILL.md
@@ -1,6 +1,6 @@
 ---
 model: haiku
-name: Documentation Quality Analysis
+name: documentation-quality
 description: Analyze and validate documentation quality for PRDs, ADRs, PRPs, CLAUDE.md, and .claude/rules/ to ensure standards compliance and freshness
 allowed-tools: Bash(markdownlint *), Bash(vale *), Read, Grep, Glob, TodoWrite
 created: 2026-01-08

--- a/code-quality-plugin/skills/linter-autofix/SKILL.md
+++ b/code-quality-plugin/skills/linter-autofix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 model: haiku
-name: Linter Autofix Patterns
+name: linter-autofix
 description: Cross-language linter autofix commands and common fix patterns for biome, ruff, clippy, shellcheck, and more.
 allowed-tools: Bash(ruff *), Bash(eslint *), Bash(biome *), Bash(prettier *), Read, Edit, Grep
 created: 2025-12-27

--- a/component-patterns-plugin/skills/version-badge-pattern/SKILL.md
+++ b/component-patterns-plugin/skills/version-badge-pattern/SKILL.md
@@ -1,6 +1,6 @@
 ---
 model: haiku
-name: Version Badge Pattern
+name: version-badge-pattern
 description: |
   Implement a version badge UI component showing build version, git commit, and
   recent changelog in a tooltip. Use when adding version visibility to applications

--- a/container-plugin/skills/skaffold-filesync/skill.md
+++ b/container-plugin/skills/skaffold-filesync/skill.md
@@ -1,6 +1,6 @@
 ---
 model: haiku
-name: Skaffold File Sync
+name: skaffold-filesync
 description: |
   Fast iterative development with Skaffold file sync - copy changed files to running containers
   without rebuilding images. Use when optimizing the development loop, configuring sync rules,

--- a/container-plugin/skills/skaffold-testing/skill.md
+++ b/container-plugin/skills/skaffold-testing/skill.md
@@ -1,6 +1,6 @@
 ---
 model: haiku
-name: Skaffold Testing
+name: skaffold-testing
 description: |
   Container image validation with Skaffold test and verify stages. Covers container-structure-tests
   for image hygiene, custom tests for security scanning, and post-deployment verification.

--- a/git-plugin/skills/git-repo-detection/SKILL.md
+++ b/git-plugin/skills/git-repo-detection/SKILL.md
@@ -3,7 +3,7 @@ model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16
-name: Git Repository Detection
+name: git-repo-detection
 description: Detect GitHub repository name and owner from git remotes. Use when needing repo identifier for GitHub CLI, API calls, or when working with multiple repositories. Automatically extracts owner/repo format.
 allowed-tools: Bash, Read, Grep
 ---

--- a/github-actions-plugin/skills/claude-code-github-workflows/skill.md
+++ b/github-actions-plugin/skills/claude-code-github-workflows/skill.md
@@ -3,7 +3,7 @@ model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16
-name: Claude Code GitHub Workflows
+name: claude-code-github-workflows
 description: Claude Code workflow design and automation patterns for PR reviews, issue triage, and CI/CD integration. Use when creating or modifying GitHub Actions workflows that integrate Claude Code.
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, WebFetch, mcp__github
 ---

--- a/github-actions-plugin/skills/github-actions-auth-security/skill.md
+++ b/github-actions-plugin/skills/github-actions-auth-security/skill.md
@@ -3,7 +3,7 @@ model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16
-name: GitHub Actions Authentication and Security
+name: github-actions-auth-security
 description: GitHub Actions security and authentication for Claude Code including API keys, OIDC, AWS Bedrock, Google Vertex AI, secrets management, and permission scoping. Use when setting up authentication or discussing security for GitHub Actions workflows.
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, WebFetch
 ---

--- a/github-actions-plugin/skills/github-actions-inspection/skill.md
+++ b/github-actions-plugin/skills/github-actions-inspection/skill.md
@@ -3,7 +3,7 @@ model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16
-name: GitHub Actions Inspection
+name: github-actions-inspection
 description: Inspect GitHub Actions workflow runs, check status, analyze logs, debug failures, and identify root causes. Use when investigating CI/CD failures, checking workflow status, or debugging GitHub Actions issues.
 allowed-tools: Bash, Read, Grep, Glob, mcp__github
 ---

--- a/github-actions-plugin/skills/github-actions-mcp-config/skill.md
+++ b/github-actions-plugin/skills/github-actions-mcp-config/skill.md
@@ -3,7 +3,7 @@ model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16
-name: GitHub Actions MCP Configuration
+name: github-actions-mcp-config
 description: MCP server configuration for GitHub Actions including tool permissions, environment variables, and multi-server setups. Use when configuring MCP servers in GitHub Actions workflows.
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, WebFetch
 ---

--- a/health-plugin/skills/plugin-registry/SKILL.md
+++ b/health-plugin/skills/plugin-registry/SKILL.md
@@ -1,6 +1,6 @@
 ---
 model: haiku
-name: Plugin Registry
+name: plugin-registry
 description: |
   Understanding Claude Code's plugin registry structure, installation scopes,
   and common issues. Use when troubleshooting plugin installation problems,

--- a/health-plugin/skills/settings-configuration/SKILL.md
+++ b/health-plugin/skills/settings-configuration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 model: haiku
-name: Settings Configuration
+name: settings-configuration
 description: |
   Claude Code settings file hierarchy, permission wildcards, and configuration
   patterns. Use when setting up project permissions, debugging settings issues,

--- a/hooks-plugin/skills/hooks-session-start-hook/SKILL.md
+++ b/hooks-plugin/skills/hooks-session-start-hook/SKILL.md
@@ -1,6 +1,6 @@
 ---
 model: haiku
-name: session-start-hook
+name: hooks-session-start-hook
 description: |
   Create a SessionStart hook for Claude Code on the web. Use when setting up a repository
   for remote Claude Code sessions, ensuring dependencies install and tests/linters run

--- a/langchain-plugin/skills/deep-agents/skill.md
+++ b/langchain-plugin/skills/deep-agents/skill.md
@@ -1,6 +1,6 @@
 ---
 model: opus
-name: Deep Agents
+name: deep-agents
 description: |
   Build hierarchical AI agents using the deep-agents TypeScript/npm package. Use when
   you want to create an orchestrator agent that plans and executes multi-step tasks,

--- a/langchain-plugin/skills/langchain-development/skill.md
+++ b/langchain-plugin/skills/langchain-development/skill.md
@@ -1,6 +1,6 @@
 ---
 model: haiku
-name: LangChain Development
+name: langchain-development
 description: LangChain JS/TS framework for building LLM-powered applications - models, chains, tools, and RAG patterns.
 allowed-tools: Bash(python *), Bash(uv *), BashOutput, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2026-01-08

--- a/langchain-plugin/skills/langgraph-agents/skill.md
+++ b/langchain-plugin/skills/langgraph-agents/skill.md
@@ -1,6 +1,6 @@
 ---
 model: opus
-name: LangGraph Agents
+name: langgraph-agents
 description: |
   Build stateful AI agents in Python using LangGraph's graph-based workflow framework.
   Use when you want to create a state machine agent with checkpoints, define agent

--- a/networking-plugin/skills/dns-tools/skill.md
+++ b/networking-plugin/skills/dns-tools/skill.md
@@ -1,6 +1,6 @@
 ---
 model: haiku
-name: DNS Tools
+name: dns-tools
 description: Modern DNS query tools with focus on dog for readable, colorized output and modern protocol support (DoT/DoH).
 allowed-tools: Bash(dig *), Bash(nslookup *), Bash(host *), Bash(whois *), Read, Grep, Glob, TodoWrite
 created: 2026-01-01

--- a/networking-plugin/skills/http-load-testing/skill.md
+++ b/networking-plugin/skills/http-load-testing/skill.md
@@ -3,7 +3,7 @@ model: haiku
 created: 2026-01-01
 modified: 2026-01-01
 reviewed: 2026-01-01
-name: HTTP Load Testing
+name: http-load-testing
 description: HTTP load testing and stress testing with oha - real-time TUI, latency correction for coordinated omission, and HTTP/2-3 support. Includes comparison with wrk, vegeta, and hey.
 allowed-tools: Bash(hey *), Bash(ab *), Bash(wrk *), Bash(curl *), Read, Grep, Glob, TodoWrite
 ---

--- a/networking-plugin/skills/layer2-discovery/skill.md
+++ b/networking-plugin/skills/layer2-discovery/skill.md
@@ -3,7 +3,7 @@ model: haiku
 created: 2026-01-01
 modified: 2026-01-01
 reviewed: 2026-01-01
-name: Layer 2 Network Discovery
+name: layer2-discovery
 description: Layer 2 network topology mapping and neighbor discovery using LLDP/CDP protocols and ARP scanning. Covers lldpd/lldpcli for switch topology, arp-scan-rs for fast host discovery, and arping for single-host probes.
 allowed-tools: Bash(arp *), Bash(ip *), Bash(bridge *), Bash(ethtool *), Read, Write, Edit, Grep, Glob
 ---

--- a/networking-plugin/skills/network-diagnostics/skill.md
+++ b/networking-plugin/skills/network-diagnostics/skill.md
@@ -3,7 +3,7 @@ model: haiku
 created: 2026-01-01
 modified: 2026-01-01
 reviewed: 2026-01-01
-name: Network Diagnostics
+name: network-diagnostics
 description: Connectivity troubleshooting with modern Rust-based tools - trippy (traceroute/mtr), gping (graphical ping), and ss (socket statistics). Preferred over legacy netstat/traceroute.
 allowed-tools: Bash(ping *), Bash(traceroute *), Bash(mtr *), Bash(netstat *), Bash(ss *), Bash(ip *), Read, Grep, Glob, TodoWrite
 ---

--- a/networking-plugin/skills/network-discovery/skill.md
+++ b/networking-plugin/skills/network-discovery/skill.md
@@ -1,6 +1,6 @@
 ---
 model: haiku
-name: Network Discovery
+name: network-discovery
 description: Host and port discovery using RustScan for fast TCP scanning, arp-scan-rs for local network enumeration, and nmap for deep service analysis.
 allowed-tools: Bash(nmap *), Bash(ping *), Bash(arp *), Bash(ip *), Read, Grep, Glob, TodoWrite
 created: 2026-01-01

--- a/networking-plugin/skills/network-monitoring/skill.md
+++ b/networking-plugin/skills/network-monitoring/skill.md
@@ -3,7 +3,7 @@ model: haiku
 created: 2026-01-01
 modified: 2026-01-01
 reviewed: 2026-01-01
-name: Network Monitoring
+name: network-monitoring
 description: Real-time network traffic monitoring with bandwhich and Sniffnet. Per-process bandwidth tracking, connection analysis, and visual traffic inspection.
 allowed-tools: Bash(iftop *), Bash(nethogs *), Bash(tcpdump *), Bash(ss *), Bash(netstat *), Read, Grep, Glob, TodoWrite
 ---

--- a/python-plugin/skills/ruff-formatting/SKILL.md
+++ b/python-plugin/skills/ruff-formatting/SKILL.md
@@ -3,7 +3,7 @@ model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16
-name: ruff Formatting
+name: ruff-formatting
 description: Python code formatting with ruff format. Fast, Black-compatible formatting for consistent code style. Use when formatting Python files, enforcing style, or checking format compliance.
 allowed-tools: Bash(ruff *), Bash(python *), Bash(uv *), Read, Edit, Write, Grep, Glob
 ---

--- a/python-plugin/skills/ruff-integration/SKILL.md
+++ b/python-plugin/skills/ruff-integration/SKILL.md
@@ -3,7 +3,7 @@ model: haiku
 created: 2025-12-16
 modified: 2026-01-24
 reviewed: 2026-01-24
-name: ruff Integration
+name: ruff-integration
 description: |
   Integrate ruff into development workflows: editor setup, pre-commit hooks, and CI/CD pipelines.
   Use when configuring ruff in VS Code, setting up pre-commit hooks, or adding ruff to GitHub Actions.

--- a/python-plugin/skills/ruff-linting/SKILL.md
+++ b/python-plugin/skills/ruff-linting/SKILL.md
@@ -3,7 +3,7 @@ model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16
-name: ruff Linting
+name: ruff-linting
 description: Python code quality with ruff linter. Fast linting, rule selection, auto-fixing, and configuration. Use when checking Python code quality, enforcing standards, or finding bugs.
 allowed-tools: Bash(ruff *), Bash(python *), Bash(uv *), Read, Edit, Write, Grep, Glob
 ---

--- a/python-plugin/skills/ty-type-checking/SKILL.md
+++ b/python-plugin/skills/ty-type-checking/SKILL.md
@@ -3,7 +3,7 @@ model: haiku
 created: 2026-01-29
 modified: 2026-01-29
 reviewed: 2026-01-29
-name: ty Type Checking
+name: ty-type-checking
 description: |
   Python type checking with ty, Astral's extremely fast type checker (10-100x faster than mypy/Pyright).
   Use when checking Python types, configuring type checking rules, or setting up type checking in projects.

--- a/testing-plugin/skills/playwright-testing/SKILL.md
+++ b/testing-plugin/skills/playwright-testing/SKILL.md
@@ -3,7 +3,7 @@ model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16
-name: Playwright Testing
+name: playwright-testing
 description: |
   Playwright end-to-end testing for web applications. Cross-browser testing (Chromium, Firefox, WebKit),
   visual regression, API testing, mobile emulation. Use when writing E2E tests, testing across browsers,

--- a/testing-plugin/skills/test-quality-analysis/SKILL.md
+++ b/testing-plugin/skills/test-quality-analysis/SKILL.md
@@ -3,7 +3,7 @@ model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16
-name: Test Quality Analysis
+name: test-quality-analysis
 description: Detect test smells, overmocking, flaky tests, and coverage issues. Analyze test effectiveness, maintainability, and reliability. Use when reviewing tests or improving test quality.
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob, TodoWrite
 ---

--- a/testing-plugin/skills/vitest-testing/SKILL.md
+++ b/testing-plugin/skills/vitest-testing/SKILL.md
@@ -3,7 +3,7 @@ model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16
-name: Vitest Testing
+name: vitest-testing
 description: |
   Vitest test runner for JavaScript and TypeScript. Fast, modern alternative to Jest.
   Vite-native, ESM support, watch mode, UI mode, coverage, mocking, snapshot testing.

--- a/tools-plugin/skills/binary-analysis/SKILL.md
+++ b/tools-plugin/skills/binary-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 model: haiku
-name: Binary Analysis
+name: binary-analysis
 description: Reverse engineering and binary exploration using strings, binwalk, hexdump, and related tools.
 allowed-tools: Bash(file *), Bash(xxd *), Bash(hexdump *), Bash(strings *), Bash(objdump *), Bash(readelf *), Bash(nm *), Read, Grep, Glob
 created: 2025-12-27

--- a/tools-plugin/skills/d2-diagrams/skill.md
+++ b/tools-plugin/skills/d2-diagrams/skill.md
@@ -1,6 +1,6 @@
 ---
 model: haiku
-name: D2 Diagrams
+name: d2-diagrams
 description: |
   Generate diagrams from declarative text using D2 - modern text-to-diagram language with
   automatic layouts, themes, and advanced styling. Use when creating architecture diagrams,

--- a/tools-plugin/skills/fd-file-finding/SKILL.md
+++ b/tools-plugin/skills/fd-file-finding/SKILL.md
@@ -3,7 +3,7 @@ model: haiku
 created: 2025-12-16
 modified: 2026-01-21
 reviewed: 2025-12-16
-name: fd File Finding
+name: fd-file-finding
 description: Fast file finding using fd command-line tool with smart defaults, gitignore awareness, and parallel execution. Use when searching for files by name, extension, or pattern across directories.
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/tools-plugin/skills/jq-json-processing/SKILL.md
+++ b/tools-plugin/skills/jq-json-processing/SKILL.md
@@ -3,7 +3,7 @@ model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16
-name: jq JSON Processing
+name: jq-json-processing
 description: JSON querying, filtering, and transformation with jq command-line tool. Use when working with JSON data, parsing JSON files, filtering JSON arrays/objects, or transforming JSON structures.
 allowed-tools: Bash(jq *), Bash(cat *), Read, Write, Edit, Grep, Glob
 ---

--- a/tools-plugin/skills/mermaid-diagrams/skill.md
+++ b/tools-plugin/skills/mermaid-diagrams/skill.md
@@ -1,6 +1,6 @@
 ---
 model: haiku
-name: Mermaid Diagrams
+name: mermaid-diagrams
 description: Generate diagrams from text using Mermaid CLI (mmdc) - flowcharts, sequence diagrams, ERDs, class diagrams, state machines, and more.
 allowed-tools: Bash, Read, Write, Grep, Glob, TodoWrite
 created: 2025-12-26

--- a/tools-plugin/skills/nushell-data-processing/skill.md
+++ b/tools-plugin/skills/nushell-data-processing/skill.md
@@ -3,7 +3,7 @@ model: haiku
 created: 2025-12-25
 modified: 2025-12-25
 reviewed: 2025-12-25
-name: Nushell Data Processing
+name: nushell-data-processing
 description: Structured data processing with nushell - native table handling, multi-format parsing (JSON, YAML, TOML, CSV), and pipeline operations. Preferred over jq/yq for complex transformations.
 allowed-tools: Bash(nu *), Read, Write, Edit, Grep, Glob
 ---

--- a/tools-plugin/skills/rg-code-search/SKILL.md
+++ b/tools-plugin/skills/rg-code-search/SKILL.md
@@ -3,7 +3,7 @@ model: haiku
 created: 2025-12-16
 modified: 2026-01-21
 reviewed: 2025-12-16
-name: rg Code Search
+name: rg-code-search
 description: Fast code search using ripgrep (rg) with smart defaults, regex patterns, and file filtering. Use when searching for text patterns, code snippets, or performing multi-file code analysis.
 allowed-tools: Bash(rg *), Read, Grep, Glob
 ---

--- a/tools-plugin/skills/yq-yaml-processing/SKILL.md
+++ b/tools-plugin/skills/yq-yaml-processing/SKILL.md
@@ -3,7 +3,7 @@ model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16
-name: yq YAML Processing
+name: yq-yaml-processing
 description: YAML querying, filtering, and transformation with yq command-line tool. Use when working with YAML files, parsing YAML configuration, modifying Kubernetes manifests, GitHub Actions workflows, or transforming YAML structures.
 allowed-tools: Bash(yq *), Read, Write, Edit, Grep, Glob
 ---

--- a/typescript-plugin/skills/biome-tooling/SKILL.md
+++ b/typescript-plugin/skills/biome-tooling/SKILL.md
@@ -3,7 +3,7 @@ model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16
-name: Biome Tooling
+name: biome-tooling
 description: |
   Biome all-in-one formatter and linter for JavaScript, TypeScript, JSX, TSX, JSON, and CSS.
   Zero-config setup, 15-20x faster than ESLint/Prettier. Use when working with modern JavaScript/TypeScript

--- a/typescript-plugin/skills/bun-development/skill.md
+++ b/typescript-plugin/skills/bun-development/skill.md
@@ -1,6 +1,6 @@
 ---
 model: haiku
-name: Bun Development
+name: bun-development
 description: Bun runtime for running scripts, testing, building, and project initialization - optimized flags for fast feedback and minimal output.
 allowed-tools: Bash, BashOutput, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2025-12-20

--- a/typescript-plugin/skills/bun-package-manager/skill.md
+++ b/typescript-plugin/skills/bun-package-manager/skill.md
@@ -1,6 +1,6 @@
 ---
 model: haiku
-name: Bun Package Manager
+name: bun-package-manager
 description: Fast JavaScript package management with Bun - install, add, remove, update dependencies with optimized CLI flags for agentic workflows.
 allowed-tools: Bash, Read, Grep, Glob, TodoWrite
 created: 2025-12-20

--- a/typescript-plugin/skills/bun-publishing/skill.md
+++ b/typescript-plugin/skills/bun-publishing/skill.md
@@ -1,6 +1,6 @@
 ---
 model: haiku
-name: Bun npm Publishing
+name: bun-publishing
 description: Publish packages to npm with Bun - package.json configuration, CLI packaging, provenance signing, and release automation.
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2025-12-21

--- a/typescript-plugin/skills/knip-dead-code/SKILL.md
+++ b/typescript-plugin/skills/knip-dead-code/SKILL.md
@@ -3,7 +3,7 @@ model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16
-name: Knip Dead Code Detection
+name: knip-dead-code
 description: |
   Knip finds unused files, dependencies, exports, and types in JavaScript/TypeScript projects.
   Plugin system for frameworks (React, Next.js, Vite), test runners (Vitest, Jest), and build tools.

--- a/typescript-plugin/skills/typescript-debugging/skill.md
+++ b/typescript-plugin/skills/typescript-debugging/skill.md
@@ -1,5 +1,5 @@
 ---
-name: TypeScript Debugging
+name: typescript-debugging
 description: Modern TypeScript/JavaScript debugging with Bun - inspector flags, web debugger, VSCode integration, memory profiling, and heap analysis.
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2026-01-22

--- a/typescript-plugin/skills/typescript-sentry/skill.md
+++ b/typescript-plugin/skills/typescript-sentry/skill.md
@@ -1,5 +1,5 @@
 ---
-name: TypeScript Sentry
+name: typescript-sentry
 description: Error monitoring and performance tracking with Sentry SDK - error capture, breadcrumbs, performance spans, cron monitoring, and source maps for Bun/Node.js.
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2026-01-22

--- a/typescript-plugin/skills/typescript-strict/SKILL.md
+++ b/typescript-plugin/skills/typescript-strict/SKILL.md
@@ -3,7 +3,7 @@ model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16
-name: TypeScript Strict Mode
+name: typescript-strict
 description: |
   TypeScript strict mode configuration for 2025. Recommended tsconfig.json settings,
   strict flags explained, moduleResolution strategies (Bundler vs NodeNext),


### PR DESCRIPTION
56 skills had human-friendly "Title Case" names in their frontmatter
that didn't match their directory names. Updated all to use kebab-case
matching the directory name, per skill-naming.md conventions.

Affected plugins: agent-patterns, bevy, blog, blueprint, code-quality,
component-patterns, container, git, github-actions, health, hooks,
langchain, networking, python, testing, tools, typescript

https://claude.ai/code/session_011cTyzm8gh54H3KrVGy4KqU