### PR TITLE
docs(git-plugin): remove exclusive git permissions claims from git-ops agent

### DIFF
--- a/git-plugin/agents/git-ops.md
+++ b/git-plugin/agents/git-ops.md
@@ -3,21 +3,21 @@ name: git-ops
 model: haiku
 color: "#F05032"
 description: |
-  ONLY agent with git write access. Handles merge conflicts, interactive rebases, cherry-picks,
-  bisect, commits, and multi-branch workflows. Use for ALL git operations that modify repository
-  state (commit, push, rebase, merge, stash, checkout). Parallel agents cannot do git operations.
+  Specialized agent for git write operations. Handles merge conflicts, interactive rebases, cherry-picks,
+  bisect, commits, and multi-branch workflows. Use for git operations that modify repository
+  state (commit, push, rebase, merge, stash, checkout), especially in parallel agent workflows.
 tools: Glob, Grep, LS, Read, Edit, Write, Bash, TodoWrite
 skills:
   - git-cli-agentic
   - git-commit
 created: 2026-01-24
-modified: 2026-02-02
-reviewed: 2026-02-02
+modified: 2026-02-12
+reviewed: 2026-02-12
 ---
 
 # Git Ops Agent
 
-**The designated git operations agent** - the only agent authorized to perform git write operations.
+**A specialized git operations agent** for complex git workflows requiring careful sequencing.
 
 ## Why This Agent Exists
 
@@ -27,7 +27,7 @@ When multiple agents run in parallel, git operations cause conflicts:
 - **Commits**: Race conditions, lost changes
 - **Rebasing**: Shared history changes mid-operation
 
-This agent centralizes all git write operations to prevent these conflicts.
+This agent specializes in complex git workflows to help avoid these conflicts in parallel execution.
 
 ## Prerequisites
 
@@ -174,7 +174,7 @@ git reset --hard <ref>
 
 ## What This Agent Does
 
-- **ALL git write operations** (the only agent authorized to do so)
+- **Git write operations** (specialized for complex workflows)
 - Commits changes (staging, commit messages, amending)
 - Pushes to remote branches
 - Resolves merge conflicts intelligently


### PR DESCRIPTION
The git-ops agent description claimed it was the "ONLY agent with git write
access" in multiple places. This is no longer accurate as git permissions
are not exclusive to this agent. Updated to position it as a specialized
agent for complex git workflows rather than the sole authorized agent.

https://claude.ai/code/session_01E3L19FqazzSi7SmMF4KUAx