### PR TITLE
ci: add PR title validation for conventional commits

### DIFF
--- a/.github/workflows/enforce-conventional-commits.yml
+++ b/.github/workflows/enforce-conventional-commits.yml
@@ -1,0 +1,76 @@
+name: Enforce Conventional Commits
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate-pr-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Types that trigger release-please version bumps
+          # (feat, fix, perf, refactor, docs) plus standard
+          # conventional commit types that don't trigger releases
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            docs
+            chore
+            ci
+            test
+            style
+            build
+            revert
+          # Plugin scopes matching release-please-config.json packages.
+          # Unscoped titles like "fix: typo" are also allowed since
+          # requireScope is false.
+          scopes: |
+            accessibility-plugin
+            agent-patterns-plugin
+            agents-plugin
+            api-plugin
+            bevy-plugin
+            blog-plugin
+            blueprint-plugin
+            code-quality-plugin
+            communication-plugin
+            component-patterns-plugin
+            command-analytics-plugin
+            configure-plugin
+            container-plugin
+            documentation-plugin
+            finops-plugin
+            git-plugin
+            github-actions-plugin
+            hooks-plugin
+            health-plugin
+            home-assistant-plugin
+            kubernetes-plugin
+            langchain-plugin
+            networking-plugin
+            project-plugin
+            python-plugin
+            rust-plugin
+            terraform-plugin
+            testing-plugin
+            tools-plugin
+            typescript-plugin
+            workflow-orchestration-plugin
+          requireScope: false
+          # Allow ! for breaking changes, e.g. "feat!: remove deprecated API"
+          subjectPattern: ^.+$
+          subjectPatternError: |
+            The subject (after the type/scope prefix) must not be empty.


### PR DESCRIPTION
Enforce conventional commit format on PR titles using
amannn/action-semantic-pull-request. This ensures that when PRs are
squash-merged with PR_TITLE as the default commit message,
release-please can correctly parse the commit type and scope to
determine version bumps.

Allowed types match changelog-sections in release-please-config.json
(feat, fix, perf, refactor, docs) plus standard non-release types
(chore, ci, test, style, build, revert). Scopes are the 31 plugin
names from the monorepo.

https://claude.ai/code/session_01VvYaXraGRgdGGgfPCPyugT