### PR TITLE
Add check for broad git staging commands (git add -A/--all/.)

### DIFF
--- a/hooks-plugin/README.md
+++ b/hooks-plugin/README.md
@@ -24,6 +24,7 @@ A PreToolUse hook that intercepts Bash commands and blocks those that should use
 | `timeout cmd` | Remove timeout (human approval time exceeds it) |
 | `find` | Use **Glob** tool instead |
 | `grep`/`rg` | Use **Grep** tool instead |
+| `git add -A` / `git add .` | Stage specific files by name instead |
 | 5+ pipe chain | Simplify with JSON output or awk |
 | Multi-grep test parsing | Use `--reporter=json` instead |
 

--- a/hooks-plugin/hooks/README.md
+++ b/hooks-plugin/hooks/README.md
@@ -21,6 +21,7 @@ A PreToolUse hook that intercepts Bash commands and blocks those that should use
 | `ls *pattern*` | Consider **Glob** tool |
 | `cat/tail ...tasks/*.output` | Use **TaskOutput** tool instead |
 | `sleep && cat/tail` | Use **TaskOutput** tool with block parameter |
+| `git add -A` / `git add .` | Stage specific files by name instead of broad staging |
 | `git X && git Y` | Run git commands as separate Bash calls (avoids index.lock race condition) |
 | `git reset --hard` | Use safer alternatives; if truly needed, ask user to run manually |
 

--- a/hooks-plugin/hooks/bash-antipatterns.sh
+++ b/hooks-plugin/hooks/bash-antipatterns.sh
@@ -126,6 +126,20 @@ if echo "$COMMAND" | grep -Eq 'grep.*\|.*grep.*\|.*(sed|cut|awk)' && \
 - For Bun: 'bun test --reporter=json 2>&1 | jq .testResults'"
 fi
 
+# Check for broad git staging commands (git add -A, git add --all, git add .)
+# These can accidentally include sensitive files (.env, credentials) or large binaries.
+# Pattern handles git global flags like -C <path> before the subcommand.
+if echo "$COMMAND" | grep -Eq '^\s*git\s+(.+\s+)?add\s+(-A|--all|\.)(\s|$)'; then
+    block_with_reminder "REMINDER: Avoid broad staging commands like 'git add -A', 'git add --all', or 'git add .'.
+These can accidentally include sensitive files (.env, credentials) or large binaries.
+
+Instead, stage specific files by name:
+  git add src/file1.ts src/file2.ts
+
+Or review what would be staged first:
+  git status --porcelain"
+fi
+
 # Check for chained git commands (git X && git Y)
 # This pattern can cause index.lock race conditions where the lock from the first
 # command hasn't been released before the second command tries to acquire it.


### PR DESCRIPTION
## Summary
Added a new bash antipattern check to prevent accidental staging of sensitive files or large binaries when using broad git staging commands like `git add -A`, `git add --all`, or `git add .`.

## Key Changes
- **New validation rule**: Added check in `bash-antipatterns.sh` to detect and block broad git staging commands
  - Handles git global flags (e.g., `git -C <path> add -A`)
  - Provides helpful reminder with alternatives for staging specific files
  - Suggests using `git status --porcelain` to review changes before staging
- **Documentation updates**: Added the new check to both README files to inform users about this antipattern

## Implementation Details
- Uses regex pattern `^\s*git\s+(.+\s+)?add\s+(-A|--all|\.)(\s|$)` to match the antipattern while accounting for optional git flags before the `add` subcommand
- Follows existing pattern of blocking with a reminder message that educates users on safer alternatives
- Positioned logically after the multi-grep test parsing check and before the chained git commands check

https://claude.ai/code/session_01H4T3q5D8FRV9BvjKfj99XY