### PR TITLE
fix(github-actions-plugin): add additional_permissions to claude.yml workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -42,6 +42,25 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            Read
+            Write
+            Edit
+            Grep
+            Glob
+            Task
+            TodoWrite
+            Bash(git status *)
+            Bash(git diff *)
+            Bash(git log *)
+            Bash(git show *)
+            Bash(git add *)
+            Bash(git commit *)
+            Bash(git push *)
+            Bash(git checkout *)
+            Bash(git branch *)
+            Bash(gh pr *)
+            Bash(gh issue *)
           plugin_marketplaces: |
             https://github.com/laurigates/claude-plugins.git
           plugins: |


### PR DESCRIPTION
## Summary
- Add `additional_permissions` to the Claude Code Action workflow (`claude.yml`) to grant pre-approved access for file editing and git write operations
- Without these, the agent hits interactive approval walls in CI and cannot commit/push changes (as seen in #641)

## Test plan
- [ ] Trigger the workflow via `@claude` on a PR comment and verify the agent can commit and push changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)