### PR TITLE
feat(configure-plugin): replace detect-secrets with gitleaks for secret scanning

### DIFF
--- a/.claude/rules/agentic-permissions.md
+++ b/.claude/rules/agentic-permissions.md
@@ -135,7 +135,7 @@ allowed-tools: Bash(gh pr checks *), Bash(gh pr view *), Bash(gh run view *), Ba
 ### Security Checks
 
 ```yaml
-allowed-tools: Bash(detect-secrets *), Bash(pre-commit *), Bash(git status *), Read, Grep, Glob, TodoWrite
+allowed-tools: Bash(gitleaks *), Bash(pre-commit *), Bash(git status *), Read, Grep, Glob, TodoWrite
 ```
 
 ## Machine-Readable Output
@@ -181,7 +181,7 @@ For projects using plugins with these patterns, recommend adding to `.claude/set
       "Bash(git branch *)",
       "Bash(git remote *)",
       "Bash(pre-commit *)",
-      "Bash(detect-secrets *)"
+      "Bash(gitleaks *)"
     ]
   }
 }

--- a/agents-plugin/agents/security-audit.md
+++ b/agents-plugin/agents/security-audit.md
@@ -3,7 +3,7 @@ name: security-audit
 model: opus
 color: "#D32F2F"
 description: Security vulnerability analysis. Scans code for OWASP top 10, secrets exposure, injection risks, auth flaws, and insecure configurations. Use proactively when reviewing security-sensitive code.
-tools: Glob, Grep, LS, Read, Bash(semgrep *), Bash(bandit *), Bash(trufflehog *), Bash(gitleaks *), Bash(detect-secrets *), Bash(npm audit *), Bash(snyk *), Bash(git status *), Bash(git diff *), Bash(git log *), TodoWrite
+tools: Glob, Grep, LS, Read, Bash(semgrep *), Bash(bandit *), Bash(trufflehog *), Bash(gitleaks *), Bash(npm audit *), Bash(snyk *), Bash(git status *), Bash(git diff *), Bash(git log *), TodoWrite
 created: 2026-01-24
 modified: 2026-02-02
 reviewed: 2026-02-02

--- a/api-plugin/skills/api-testing/REFERENCE.md
+++ b/api-plugin/skills/api-testing/REFERENCE.md
@@ -14,7 +14,7 @@ describe('Authentication', () => {
     // Login to get token
     const response = await request(app)
       .post('/api/auth/login')
-      .send({ email: 'user@example.com', password: 'password123' })  // pragma: allowlist secret
+      .send({ email: 'user@example.com', password: 'password123' })  // gitleaks:allow
       .expect(200)
 
     authToken = response.body.token
@@ -70,7 +70,7 @@ describe('Cookie handling', () => {
     // Login sets cookie
     const loginResponse = await request(app)
       .post('/api/auth/login')
-      .send({ email: 'user@example.com', password: 'password' })  // pragma: allowlist secret
+      .send({ email: 'user@example.com', password: 'password' })  // gitleaks:allow
       .expect(200)
 
     const cookies = loginResponse.headers['set-cookie']
@@ -173,7 +173,7 @@ def auth_token(client):
     """Get authentication token"""
     response = client.post(
         "/api/auth/login",
-        json={"email": "user@example.com", "password": "password123"}  # pragma: allowlist secret
+        json={"email": "user@example.com", "password": "password123"}  # gitleaks:allow
     )
     return response.json()["token"]
 
@@ -221,7 +221,7 @@ def authenticated_client():
     # Login
     response = client.post(
         "/api/auth/login",
-        json={"email": "user@example.com", "password": "password123"}  # pragma: allowlist secret
+        json={"email": "user@example.com", "password": "password123"}  # gitleaks:allow
     )
     token = response.json()["token"]
 
@@ -264,7 +264,7 @@ def test_cookie_handling(client):
     # Login sets cookie
     response = client.post(
         "/api/auth/login",
-        json={"email": "user@example.com", "password": "password"}  # pragma: allowlist secret
+        json={"email": "user@example.com", "password": "password"}  # gitleaks:allow
     )
     assert "session" in response.cookies
 
@@ -467,7 +467,7 @@ function createTestUser(overrides = {}) {
 async function authenticateUser(app: Express) {
   const response = await request(app)
     .post('/api/auth/login')
-    .send({ email: 'user@example.com', password: 'password' })  // pragma: allowlist secret
+    .send({ email: 'user@example.com', password: 'password' })  // gitleaks:allow
 
   return response.body.token
 }

--- a/configure-plugin/skills/claude-security-settings/SKILL.md
+++ b/configure-plugin/skills/claude-security-settings/SKILL.md
@@ -225,7 +225,6 @@ Then allow the script:
   "permissions": {
     "allow": [
       "Bash(pre-commit *)",
-      "Bash(detect-secrets *)",
       "Bash(gitleaks *)",
       "Bash(trivy *)"
     ]

--- a/configure-plugin/skills/configure-claude-plugins/SKILL.md
+++ b/configure-plugin/skills/configure-claude-plugins/SKILL.md
@@ -74,7 +74,7 @@ Create or merge into `.claude/settings.json` the following permissions structure
       "Bash(gh run *)",
       "Bash(gh issue *)",
       "Bash(pre-commit *)",
-      "Bash(detect-secrets *)",
+      "Bash(gitleaks *)",
       "mcp__context7",
       "mcp__sequential-thinking"
     ]

--- a/configure-plugin/skills/configure-pre-commit/SKILL.md
+++ b/configure-plugin/skills/configure-pre-commit/SKILL.md
@@ -67,7 +67,7 @@ Execute this pre-commit compliance check:
 2. **conventional-pre-commit**: [GitHub releases](https://github.com/compilerla/conventional-pre-commit/releases)
 3. **biome**: [GitHub releases](https://github.com/biomejs/biome/releases)
 4. **ruff-pre-commit**: [GitHub releases](https://github.com/astral-sh/ruff-pre-commit/releases)
-5. **detect-secrets**: [GitHub releases](https://github.com/Yelp/detect-secrets/releases)
+5. **gitleaks**: [GitHub releases](https://github.com/gitleaks/gitleaks/releases)
 
 ### Step 4: Analyze compliance
 
@@ -85,11 +85,11 @@ Compare existing configuration against project standards (from `pre-commit-stand
 - `tflint`, `helmlint` (gruntwork v0.1.29+)
 - `actionlint` v1.7.7+
 - `helm-docs` v1.14.2+
-- `detect-secrets` v1.5.0+
+- `gitleaks` v8.22.1+
 
 **Python-specific:**
 - `ruff-pre-commit` v0.8.4+ (ruff, ruff-format)
-- `detect-secrets` v1.5.0+
+- `gitleaks` v8.22.1+
 
 ### Step 5: Generate compliance report
 

--- a/configure-plugin/skills/configure-security/REFERENCE.md
+++ b/configure-plugin/skills/configure-security/REFERENCE.md
@@ -22,7 +22,7 @@ SAST Scanning:
   Bandit (Python)         configured                 [CONFIGURED | MISSING]
 
 Secret Detection:
-  detect-secrets          .secrets.baseline          [CONFIGURED | MISSING]
+  Gitleaks                .gitleaks.toml             [CONFIGURED | MISSING]
   Pre-commit hook         .pre-commit-config.yaml    [CONFIGURED | MISSING]
   TruffleHog              .github/workflows/         [OPTIONAL | MISSING]
   Git history scanned     clean                      [CLEAN | SECRETS FOUND]
@@ -275,17 +275,15 @@ Run: `uv run bandit -r src/ -f json -o bandit-report.json`
 
 ## Secret Detection Templates
 
-### detect-secrets Pre-commit Hook
+### Gitleaks Pre-commit Hook
 
 Add to `.pre-commit-config.yaml`:
 ```yaml
 repos:
-  - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.5.0
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.22.1
     hooks:
-      - id: detect-secrets
-        args: ['--baseline', '.secrets.baseline']
-        exclude: package-lock.json
+      - id: gitleaks
 ```
 
 ### TruffleHog Workflow (`.github/workflows/trufflehog.yml`)
@@ -328,8 +326,8 @@ useDefault = true
 [allowlist]
 description = "Allowlist for false positives"
 paths = [
-    '''\.secrets\.baseline$''',
-    '''test/fixtures/.*'''
+    '''test/fixtures/.*''',
+    '''.*\.test\.(ts|js)$'''
 ]
 
 regexes = [
@@ -423,7 +421,7 @@ This project uses:
 
 - **Dependabot**: Automated dependency updates
 - **CodeQL**: Static application security testing
-- **detect-secrets**: Pre-commit secret scanning
+- **Gitleaks**: Pre-commit secret scanning
 - **TruffleHog**: Git history secret scanning
 
 ## Security Advisories
@@ -524,7 +522,7 @@ SAST Scanning:
   Scheduled weekly scans
 
 Secret Detection:
-  detect-secrets baseline created
+  Gitleaks configured with .gitleaks.toml
   Pre-commit hook configured
   TruffleHog workflow added
   Git history scanned: CLEAN

--- a/configure-plugin/skills/configure-security/SKILL.md
+++ b/configure-plugin/skills/configure-security/SKILL.md
@@ -17,7 +17,7 @@ Check and configure security scanning tools for dependency audits, SAST, and sec
 
 | Use this skill when... | Use another approach when... |
 |------------------------|------------------------------|
-| Setting up dependency auditing, SAST, or secret detection for a project | Running a one-off security scan (use `detect-secrets scan` or `npm audit` directly) |
+| Setting up dependency auditing, SAST, or secret detection for a project | Running a one-off security scan (use `gitleaks detect` or `npm audit` directly) |
 | Checking project compliance with security scanning standards | Reviewing code for application-level vulnerabilities (use security-audit agent) |
 | Configuring Dependabot, CodeQL, or TruffleHog in CI/CD | Managing GitHub repository security settings via the web UI |
 | Creating or updating a SECURITY.md policy | Writing security documentation beyond the policy template |
@@ -26,14 +26,12 @@ Check and configure security scanning tools for dependency audits, SAST, and sec
 ## Context
 
 - Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \) 2>/dev/null`
-- Secrets baseline: !`test -f .secrets.baseline && echo "EXISTS" || echo "MISSING"`
+- Gitleaks config: !`test -f .gitleaks.toml && echo "EXISTS" || echo "MISSING"`
 - Pre-commit config: !`test -f .pre-commit-config.yaml && echo "EXISTS" || echo "MISSING"`
 - Workflows dir: !`test -d .github/workflows && echo "EXISTS" || echo "MISSING"`
 - Dependabot config: !`test -f .github/dependabot.yml && echo "EXISTS" || echo "MISSING"`
 - CodeQL workflow: !`find .github/workflows -maxdepth 1 -name 'codeql*' 2>/dev/null`
 - Security policy: !`test -f SECURITY.md && echo "EXISTS" || echo "MISSING"`
-- Gitleaks config: !`test -f .gitleaks.toml && echo "EXISTS" || echo "MISSING"`
-
 **Security scanning layers:**
 1. **Dependency auditing** - Check for known vulnerabilities in dependencies
 2. **SAST (Static Application Security Testing)** - Analyze code for security issues
@@ -57,7 +55,7 @@ Verify latest versions before configuring:
 
 1. **Trivy**: Check [GitHub releases](https://github.com/aquasecurity/trivy/releases)
 2. **Grype**: Check [GitHub releases](https://github.com/anchore/grype/releases)
-3. **detect-secrets**: Check [GitHub releases](https://github.com/Yelp/detect-secrets/releases)
+3. **gitleaks**: Check [GitHub releases](https://github.com/gitleaks/gitleaks/releases)
 4. **pip-audit**: Check [PyPI](https://pypi.org/project/pip-audit/)
 5. **cargo-audit**: Check [crates.io](https://crates.io/crates/cargo-audit)
 6. **CodeQL**: Check [GitHub releases](https://github.com/github/codeql-action/releases)
@@ -73,7 +71,7 @@ Identify project languages and existing security tools:
 | `package.json` | JavaScript/TypeScript | npm audit, Snyk |
 | `pyproject.toml` | Python | pip-audit, safety, bandit |
 | `Cargo.toml` | Rust | cargo-audit, cargo-deny |
-| `.secrets.baseline` | detect-secrets | Secret scanning |
+| `.gitleaks.toml` | gitleaks | Secret scanning |
 | `.github/workflows/` | GitHub Actions | CodeQL, Dependabot |
 
 ### Step 3: Analyze current security state
@@ -94,10 +92,10 @@ Check existing security configuration across three areas:
 - SAST in CI pipeline
 
 **Secret Detection:**
-- detect-secrets baseline exists
+- Gitleaks configured with `.gitleaks.toml`
 - Pre-commit hook configured
 - Git history scanned
-- TruffleHog or Gitleaks configured
+- TruffleHog configured (optional complement)
 
 ### Step 4: Generate compliance report
 
@@ -136,13 +134,13 @@ For CodeQL workflow and Bandit configuration templates, see [REFERENCE.md](REFER
 
 ### Step 7: Configure secret detection (if --fix or user confirms)
 
-1. Install detect-secrets: `pip install detect-secrets`
-2. Create baseline: `detect-secrets scan --baseline .secrets.baseline`
-3. Audit baseline: `detect-secrets audit .secrets.baseline`
+1. Install gitleaks: `brew install gitleaks` (or `go install github.com/gitleaks/gitleaks/v8@latest`)
+2. Create `.gitleaks.toml` with project-specific allowlists
+3. Run initial scan: `gitleaks detect --source .`
 4. Add pre-commit hook to `.pre-commit-config.yaml`
-5. Optionally configure TruffleHog or Gitleaks workflow
+5. Optionally configure TruffleHog workflow for CI
 
-For detect-secrets, TruffleHog, and Gitleaks configuration templates, see [REFERENCE.md](REFERENCE.md).
+For gitleaks, TruffleHog, and CI workflow configuration templates, see [REFERENCE.md](REFERENCE.md).
 
 ### Step 8: Create security policy
 
@@ -195,7 +193,7 @@ For the results report format, see [REFERENCE.md](REFERENCE.md).
 | Dependencies only | `/configure:security --type dependencies` |
 | Secret detection only | `/configure:security --type secrets` |
 | SAST scanning only | `/configure:security --type sast` |
-| Verify secrets baseline | `detect-secrets audit .secrets.baseline` |
+| Verify secrets scan | `gitleaks detect --source . --verbose` |
 
 ## Flags
 
@@ -218,5 +216,5 @@ For the results report format, see [REFERENCE.md](REFERENCE.md).
 - `/configure:pre-commit` - Pre-commit hook configuration
 - `/configure:all` - Run all compliance checks
 - **GitHub Security Features**: https://docs.github.com/en/code-security
-- **detect-secrets**: https://github.com/Yelp/detect-secrets
+- **gitleaks**: https://github.com/gitleaks/gitleaks
 - **CodeQL**: https://codeql.github.com

--- a/configure-plugin/skills/configure-status/SKILL.md
+++ b/configure-plugin/skills/configure-status/SKILL.md
@@ -37,7 +37,7 @@ Display infrastructure standards compliance status without making changes.
 - Test configs: !`find . -maxdepth 1 \( -name 'vitest.config.*' -o -name 'jest.config.*' -o -name 'pytest.ini' \) 2>/dev/null`
 - Linting config: !`find . -maxdepth 1 \( -name 'biome.json' -o -name '.eslintrc*' \) 2>/dev/null`
 - Editor config: !`test -f .editorconfig && echo "EXISTS" || echo "MISSING"`
-- Security baseline: !`test -f .secrets.baseline && echo "EXISTS" || echo "MISSING"`
+- Gitleaks config: !`test -f .gitleaks.toml && echo "EXISTS" || echo "MISSING"`
 - Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' \) 2>/dev/null`
 
 ## Parameters
@@ -77,7 +77,7 @@ Check for presence and validity of each configuration:
 | Formatting | `.prettierrc*`, `biome.json`, `pyproject.toml [tool.ruff.format]`, `rustfmt.toml` |
 | Dead Code | `knip.json`, `knip.ts`, `pyproject.toml [tool.vulture]` |
 | Editor | `.editorconfig`, `.vscode/settings.json`, `.vscode/extensions.json` |
-| Security | `.github/workflows/*security*`, `.secrets.baseline`, `pyproject.toml [tool.bandit]` |
+| Security | `.github/workflows/*security*`, `.gitleaks.toml`, `pyproject.toml [tool.bandit]` |
 
 ### Step 3: Determine compliance status
 
@@ -113,7 +113,7 @@ Component Status:
   Formatting      PASS   Biome configured
   Dead Code       WARN   Knip found 3 unused exports
   Editor          PASS   .editorconfig present
-  Security        PASS   detect-secrets + npm audit
+  Security        PASS   gitleaks + npm audit
 
 Summary: [N] warnings, [N] failures
 Run /configure:all to fix issues

--- a/configure-plugin/skills/pre-commit-standards/SKILL.md
+++ b/configure-plugin/skills/pre-commit-standards/SKILL.md
@@ -27,7 +27,7 @@ Standard pre-commit configuration for repository compliance.
 | gruntwork pre-commit | v0.1.29 | helmlint, tflint (infrastructure only) |
 | actionlint | v1.7.7 | GitHub Actions validation (infrastructure only) |
 | helm-docs | v1.14.2 | Helm documentation (infrastructure only) |
-| detect-secrets | v1.5.0 | Secret scanning (recommended) |
+| gitleaks | v8.22.1 | Secret scanning (recommended) |
 
 ## Project Type Configurations
 
@@ -123,11 +123,10 @@ repos:
         args:
           - --chart-search-root=helm
 
-  - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.5.0
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.22.1
     hooks:
-      - id: detect-secrets
-        args: ['--baseline', '.secrets.baseline']
+      - id: gitleaks
 ```
 
 ### Python Service
@@ -165,11 +164,10 @@ repos:
         args: [--fix]
       - id: ruff-format
 
-  - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.5.0
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.22.1
     hooks:
-      - id: detect-secrets
-        args: ['--baseline', '.secrets.baseline']
+      - id: gitleaks
 ```
 
 ## Compliance Checking

--- a/container-plugin/skills/container-development/REFERENCE.md
+++ b/container-plugin/skills/container-development/REFERENCE.md
@@ -441,7 +441,7 @@ CMD ["node", "server.js"]
 services:
   app:
     environment:
-      DATABASE_URL: postgresql://postgres:password@db:5432/myapp  # pragma: allowlist secret
+      DATABASE_URL: postgresql://postgres:password@db:5432/myapp  # gitleaks:allow
       REDIS_URL: redis://redis:6379
       S3_ENDPOINT: http://minio:9000
 
@@ -994,7 +994,7 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - DATABASE_URL=postgresql://postgres:password@db:5432/myapp  # pragma: allowlist secret
+      - DATABASE_URL=postgresql://postgres:password@db:5432/myapp  # gitleaks:allow
       - REDIS_URL=redis://redis:6379
     depends_on:
       db:

--- a/container-plugin/skills/skaffold-orbstack/SKILL.md
+++ b/container-plugin/skills/skaffold-orbstack/SKILL.md
@@ -283,7 +283,7 @@ spec:
     - port: 5432
 ```
 
-**Connection string**: `postgres://user:pass@postgresql.default.svc.cluster.local:5432/db`  <!-- pragma: allowlist secret -->
+**Connection string**: `postgres://user:pass@postgresql.default.svc.cluster.local:5432/db`  <!-- gitleaks:allow -->
 
 ### Multi-Service Application
 

--- a/git-plugin/README.md
+++ b/git-plugin/README.md
@@ -161,7 +161,7 @@ For seamless command execution without permission prompts, add these permissions
       "Bash(git prune *)",
       "Bash(git fsck *)",
       "Bash(pre-commit *)",
-      "Bash(detect-secrets *)"
+      "Bash(gitleaks *)"
     ]
   }
 }

--- a/git-plugin/skills/git-security-checks/scripts/security-scan.sh
+++ b/git-plugin/skills/git-security-checks/scripts/security-scan.sh
@@ -3,7 +3,7 @@
 # Runs a comprehensive security scan pipeline in one execution.
 # Usage: bash security-scan.sh [--staged-only]
 #
-# Checks: detect-secrets, gitignore patterns, sensitive file detection,
+# Checks: gitleaks, gitignore patterns, sensitive file detection,
 # high-entropy strings in staged files.
 
 set -uo pipefail
@@ -17,36 +17,34 @@ echo ""
 
 findings=0
 
-# Check 1: detect-secrets (if available)
-echo "--- DETECT-SECRETS ---"
-if command -v detect-secrets >/dev/null 2>&1; then
-  if [ -f ".secrets.baseline" ]; then
-    echo "BASELINE=present"
-    scan_output=$(detect-secrets scan --baseline .secrets.baseline 2>&1)
+# Check 1: gitleaks (if available)
+echo "--- GITLEAKS ---"
+if command -v gitleaks >/dev/null 2>&1; then
+  if [ "$STAGED_ONLY" = true ]; then
+    scan_output=$(gitleaks protect --staged --no-banner 2>&1)
     scan_exit=$?
-    if [ $scan_exit -ne 0 ]; then
-      echo "STATUS=new_secrets_found"
-      echo "$scan_output" | head -20
-      findings=$((findings + 1))
-    else
-      echo "STATUS=clean"
-    fi
   else
-    echo "BASELINE=missing"
-    echo "HINT: Run 'detect-secrets scan > .secrets.baseline' to create baseline"
-    # Scan without baseline
-    new_secrets=$(detect-secrets scan 2>/dev/null | jq -r '.results | to_entries[] | "\(.key): \(.value | length) potential secrets"' 2>/dev/null | head -10)
-    if [ -n "$new_secrets" ]; then
-      echo "POTENTIAL_SECRETS:"
-      echo "$new_secrets" | sed 's/^/  /'
-      findings=$((findings + 1))
-    else
-      echo "STATUS=clean"
-    fi
+    scan_output=$(gitleaks detect --source . --no-banner 2>&1)
+    scan_exit=$?
+  fi
+  if [ $scan_exit -ne 0 ]; then
+    echo "STATUS=secrets_found"
+    echo "$scan_output" | head -20
+    findings=$((findings + 1))
+  else
+    echo "STATUS=clean"
+  fi
+
+  # Check for .gitleaks.toml config
+  if [ -f ".gitleaks.toml" ]; then
+    echo "CONFIG=present"
+  else
+    echo "CONFIG=missing"
+    echo "HINT: Create .gitleaks.toml for project-specific allowlists"
   fi
 else
   echo "STATUS=not_installed"
-  echo "HINT: pip install detect-secrets"
+  echo "HINT: brew install gitleaks (or go install github.com/gitleaks/gitleaks/v8@latest)"
 fi
 echo ""
 
@@ -138,12 +136,12 @@ echo ""
 echo "--- PRE-COMMIT STATUS ---"
 if [ -f ".pre-commit-config.yaml" ]; then
   echo "CONFIG=present"
-  detect_secrets_hook=$(grep -A2 "detect-secrets" .pre-commit-config.yaml 2>/dev/null | head -3)
-  if [ -n "$detect_secrets_hook" ]; then
-    echo "DETECT_SECRETS_HOOK=configured"
+  gitleaks_hook=$(grep -A2 "gitleaks" .pre-commit-config.yaml 2>/dev/null | head -3)
+  if [ -n "$gitleaks_hook" ]; then
+    echo "GITLEAKS_HOOK=configured"
   else
-    echo "DETECT_SECRETS_HOOK=not_configured"
-    echo "HINT: Add detect-secrets hook to .pre-commit-config.yaml"
+    echo "GITLEAKS_HOOK=not_configured"
+    echo "HINT: Add gitleaks hook to .pre-commit-config.yaml"
   fi
 
   # Check if hooks are installed

--- a/github-actions-plugin/skills/github-actions-auth-security/skill.md
+++ b/github-actions-plugin/skills/github-actions-auth-security/skill.md
@@ -123,7 +123,7 @@ roles/aiplatform.user
 # WRONG - Never hardcode!
 - uses: anthropics/claude-code-action@v1
   with:
-    anthropic_api_key: "sk-ant-api03-..."  # pragma: allowlist secret
+    anthropic_api_key: "sk-ant-api03-..."  # gitleaks:allow
 
 # CORRECT - Always use secrets
 - uses: anthropics/claude-code-action@v1

--- a/health-plugin/skills/settings-configuration/SKILL.md
+++ b/health-plugin/skills/settings-configuration/SKILL.md
@@ -210,7 +210,6 @@ Then allow the script:
   "permissions": {
     "allow": [
       "Bash(pre-commit *)",
-      "Bash(detect-secrets *)",
       "Bash(gitleaks *)",
       "Bash(trivy *)"
     ]

--- a/testing-plugin/skills/test-quality-analysis/REFERENCE.md
+++ b/testing-plugin/skills/test-quality-analysis/REFERENCE.md
@@ -424,7 +424,7 @@ test('user registration flow', async () => {
   // Arrange: Setup test data and dependencies
   const userData = {
     email: 'user@example.com',
-    password: 'secure123',  // pragma: allowlist secret
+    password: 'secure123',  // gitleaks:allow
   }
   const mockEmailService = vi.fn()
 


### PR DESCRIPTION
detect-secrets is effectively in maintenance mode (no new PyPI release in 12+
months) and its interactive audit workflow is incompatible with automated
contexts. Gitleaks provides declarative configuration via .gitleaks.toml,
140+ built-in detection rules, and inline gitleaks:allow comments — all
without requiring a baseline file or interactive auditing.

Changes across 18 files in 7 plugins and rules:
- Rewrote git-security-checks SKILL.md with full gitleaks workflow
- Updated security-scan.sh script to use gitleaks detect/protect
- Replaced detect-secrets pre-commit hooks with gitleaks (v8.22.1)
- Updated all permission patterns from Bash(detect-secrets *) to Bash(gitleaks *)
- Replaced .secrets.baseline references with .gitleaks.toml
- Replaced all pragma: allowlist secret comments with gitleaks:allow
- Updated compliance reports and standards tables

https://claude.ai/code/session_01XUYqQvXSoZgK5HTnmJBQKc