### PR TITLE
docs(git-plugin): remove obsolete orchestrator mode documentation

### DIFF
--- a/git-plugin/agents/git-ops.md
+++ b/git-plugin/agents/git-ops.md
@@ -35,18 +35,6 @@ Git write permissions (`git add`, `git commit`, `git push`, etc.) must be in the
 `.claude/settings.json` allow list. Without these, subagents cannot execute git commands
 since they cannot prompt the user for approval.
 
-### Orchestrator Mode (optional)
-
-When `ORCHESTRATOR_MODE=1` is set, the orchestrator-enforcement hook restricts git writes
-to agents with `CLAUDE_GIT_AGENT=1`. Since Claude Code doesn't support agent-specific env vars,
-set `CLAUDE_GIT_AGENT=1` globally when using orchestrator workflows:
-
-```bash
-export ORCHESTRATOR_MODE=1 CLAUDE_GIT_AGENT=1
-```
-
-Without orchestrator mode, git permissions are controlled solely by `.claude/settings.json`.
-
 ## Scope
 
 - **Input**: Git operation request (commit, push, rebase, conflict resolution, bisect, cherry-pick, stash)


### PR DESCRIPTION
## Summary

- Remove the "Orchestrator Mode (optional)" section from `git-plugin/agents/git-ops.md`
- The `orchestrator-enforcement` hook and `ORCHESTRATOR_MODE`/`CLAUDE_GIT_AGENT` environment variables were removed during the agent teams migration (ADR-0015)
- Git write permissions are now exclusively controlled via `.claude/settings.json`

## Test plan

- [ ] Verify no references to `ORCHESTRATOR_MODE` or `CLAUDE_GIT_AGENT` in git-plugin
- [ ] Verify historical docs (ADR-0015, agent-teams-migration PRP) are unchanged
- [ ] Confirm git-ops Prerequisites section reads correctly without the removed subsection

🤖 Generated with [Claude Code](https://claude.com/claude-code)