### PR TITLE
fix(git-plugin): remove pipe operator from worktree skill context command

### DIFF
--- a/git-plugin/skills/git-worktree-agent-workflow/SKILL.md
+++ b/git-plugin/skills/git-worktree-agent-workflow/SKILL.md
@@ -38,7 +38,7 @@ Start every implementation in an isolated worktree. Each task gets its own direc
 - Current branch: !`git branch --show-current 2>/dev/null`
 - Worktrees: !`git worktree list --porcelain 2>/dev/null`
 - Uncommitted changes: !`git status --porcelain 2>/dev/null`
-- Default branch: !`git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||'`
+- Default branch: !`git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null`
 
 ## Execution
 


### PR DESCRIPTION
## Summary

- Replace `git symbolic-ref | sed` pipe chain with `git symbolic-ref --short` in worktree skill context command
- Fixes the `lint-context-commands` CI check which flags pipe operators as errors (blocked by Claude Code's shell protections)

## Test plan

- [x] `lint-context-commands.sh` passes locally (0 errors, 181 pre-existing warnings)
- [ ] CI lint job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)