### PR TITLE
fix: pipe counting in bash-antipatterns to exclude quoted strings and operators

### DIFF
--- a/hooks-plugin/hooks/bash-antipatterns.sh
+++ b/hooks-plugin/hooks/bash-antipatterns.sh
@@ -125,7 +125,11 @@ COMMAND_SHELL_ONLY=$(echo "$COMMAND" | awk '
         if (t == delim) { ih = 0 }
     }
 ')
-PIPE_COUNT=$(echo "$COMMAND_SHELL_ONLY" | tr -cd '|' | wc -c)
+# Strip quoted strings and || operators before counting actual shell pipes
+# - Single-quoted strings contain regex alternation (grep -E '(a|b|c)')
+# - Double-quoted strings may contain literal pipe characters
+# - || is logical OR, not a pipe operator
+PIPE_COUNT=$(echo "$COMMAND_SHELL_ONLY" | sed "s/'[^']*'//g; s/\"[^\"]*\"//g; s/||//g" | tr -cd '|' | wc -c)
 if [ "$PIPE_COUNT" -ge 5 ]; then
     block_with_reminder "REMINDER: This command has $PIPE_COUNT pipes - consider simplifying. Options:
 - Use JSON output from the source (--reporter=json, --format=json) and parse with jq


### PR DESCRIPTION
## Summary
Improved the pipe counting logic in the bash-antipatterns hook to accurately detect actual shell pipe operators while excluding false positives from quoted strings and logical operators.

## Key Changes
- Modified the `PIPE_COUNT` calculation to strip quoted strings (both single and double-quoted) before counting pipes
- Added filtering to exclude `||` (logical OR) operators from the pipe count
- Added explanatory comments documenting why each pattern is stripped

## Implementation Details
The pipe counting now uses `sed` to remove:
1. Single-quoted strings (`'[^']*'`) - which may contain regex alternation patterns like `grep -E '(a|b|c)'`
2. Double-quoted strings (`"[^"]*"`) - which may contain literal pipe characters
3. Logical OR operators (`||`) - which are not pipe operators

This prevents false positives when counting actual shell pipes for the complexity check, ensuring the antipattern reminder only triggers on genuinely complex piped commands.

https://claude.ai/code/session_012VupJXLnXH4UfF56VDhHGL