### PR TITLE
fix(hooks-plugin): allow dotfile staging in bash-antipatterns check

### DIFF
--- a/hooks-plugin/hooks/bash-antipatterns.sh
+++ b/hooks-plugin/hooks/bash-antipatterns.sh
@@ -152,7 +152,7 @@ fi
 # Check for broad git staging commands (git add -A, git add --all, git add .)
 # These can accidentally include sensitive files (.env, credentials) or large binaries.
 # Pattern handles git global flags like -C <path> before the subcommand.
-if echo "$COMMAND" | grep -Eq '^\s*git\s+(.+\s+)?add\s+(-A|--all|\.)(\s|$)'; then
+if echo "$COMMAND" | grep -Eq '^\s*git\s+(.+\s+)?add\s+(-A|--all|\.(\s|$))'; then
     block_with_reminder "REMINDER: Avoid broad staging commands like 'git add -A', 'git add --all', or 'git add .'.
 These can accidentally include sensitive files (.env, credentials) or large binaries.
 


### PR DESCRIPTION
## Summary

- Fix regex in `bash-antipatterns.sh` that incorrectly blocked `git add .env`, `git add .gitignore`, etc.
- Scope the `(\s|$)` anchor to only the standalone `.` alternative in the pattern

## Test plan

- [x] `git add -A` → blocked
- [x] `git add .` → blocked
- [x] `git add --all` → blocked
- [x] `git add .env` → allowed
- [x] `git add .gitignore` → allowed
- [x] `git add .editorconfig` → allowed

Fixes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)