### PR TITLE
fix(ci): skip Claude analysis when npm audit results are empty

### DIFF
--- a/.github/workflows/reusable-security-deps.yml
+++ b/.github/workflows/reusable-security-deps.yml
@@ -129,6 +129,7 @@ jobs:
 
       - name: Claude Dependency Analysis
         id: analyze
+        if: steps.audit-cmd.outputs.results != ''
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- Add conditional check to skip Claude Code analysis step when `npm audit` produces no output
- Prevents test-deps workflow failure when no `package-lock.json` exists in test fixtures

## Test plan

- [ ] Verify test-deps workflow passes when npm audit has no results
- [ ] Verify test-deps workflow still works when npm audit finds vulnerabilities

Fixes #559

🤖 Generated with [Claude Code](https://claude.com/claude-code)