### PR TITLE
feat(blueprint-plugin): add task registry for operational metadata tracking

### DIFF
--- a/blueprint-plugin/skills/blueprint-claude-md/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-claude-md/SKILL.md
@@ -1,7 +1,7 @@
 ---
 model: opus
 created: 2025-12-17
-modified: 2026-02-09
+modified: 2026-02-17
 reviewed: 2026-02-09
 description: "Generate or update CLAUDE.md from project context and blueprint artifacts. Supports @import syntax, CLAUDE.local.md, and auto memory delineation."
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
@@ -232,7 +232,19 @@ Use `@import` to reference existing documentation rather than duplicating conten
    - Track which PRDs contributed
    - Update timestamp
 
-10. **Report**:
+10. **Update task registry**:
+
+    Update the task registry entry in `docs/blueprint/manifest.json`:
+
+    ```bash
+    jq --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      '.task_registry["claude-md"].last_completed_at = $now |
+       .task_registry["claude-md"].last_result = "success" |
+       .task_registry["claude-md"].stats.runs_total = ((.task_registry["claude-md"].stats.runs_total // 0) + 1)' \
+      docs/blueprint/manifest.json > tmp.json && mv tmp.json docs/blueprint/manifest.json
+    ```
+
+11. **Report**:
     ```
     ✅ CLAUDE.md updated!
 
@@ -274,7 +286,7 @@ Use `@import` to reference existing documentation rather than duplicating conten
 - Let auto memory handle "Current Focus", "Key Files", debugging tips
 - Update when PRDs change significantly
 
-11. **Prompt for next action** (use AskUserQuestion):
+12. **Prompt for next action** (use AskUserQuestion):
     ```
     question: "CLAUDE.md updated. What would you like to do next?"
     options:

--- a/blueprint-plugin/skills/blueprint-curate-docs/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-curate-docs/SKILL.md
@@ -5,7 +5,7 @@ args: "[library-name|project:pattern-name]"
 argument-hint: "Library name (e.g., redis, pydantic) or project:pattern-name"
 allowed-tools: Read, Write, Glob, Bash, WebFetch, WebSearch, AskUserQuestion
 created: 2025-12-16
-modified: 2026-02-14
+modified: 2026-02-17
 reviewed: 2026-02-14
 name: blueprint-curate-docs
 ---
@@ -93,7 +93,23 @@ Include copy-paste-ready code snippets from:
 - Stack Overflow solutions
 - Personal implementation experience
 
-### Step 6: Validate and save
+### Step 6: Update task registry
+
+Update the task registry entry in `docs/blueprint/manifest.json`:
+
+```bash
+jq --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --argjson processed "${ITEMS_PROCESSED:-0}" \
+  --argjson created "${ITEMS_CREATED:-0}" \
+  '.task_registry["curate-docs"].last_completed_at = $now |
+   .task_registry["curate-docs"].last_result = "success" |
+   .task_registry["curate-docs"].stats.runs_total = ((.task_registry["curate-docs"].stats.runs_total // 0) + 1) |
+   .task_registry["curate-docs"].stats.items_processed = $processed |
+   .task_registry["curate-docs"].stats.items_created = $created' \
+  docs/blueprint/manifest.json > tmp.json && mv tmp.json docs/blueprint/manifest.json
+```
+
+### Step 7: Validate and save
 
 1. Verify entry is < 200 lines
 2. Verify all code examples are accurate

--- a/blueprint-plugin/skills/blueprint-derive-prd/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-derive-prd/SKILL.md
@@ -1,7 +1,7 @@
 ---
 model: opus
 created: 2025-12-22
-modified: 2026-02-06
+modified: 2026-02-17
 reviewed: 2025-12-22
 description: "Derive PRD from existing project documentation, README, and codebase analysis"
 allowed-tools: Read, Write, Glob, Grep, Bash, AskUserQuestion, Task
@@ -301,7 +301,21 @@ Update `docs/blueprint/manifest.json`:
 - Mark uncertain sections for user review
 - Keep PRD focused on "what" and "why", not "how"
 
-### 4.3 Prompt for GitHub Issue (use AskUserQuestion):
+### 4.3 Update task registry
+
+Update the task registry entry in `docs/blueprint/manifest.json`:
+
+```bash
+jq --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --argjson created "${PRDS_GENERATED:-1}" \
+  '.task_registry["derive-prd"].last_completed_at = $now |
+   .task_registry["derive-prd"].last_result = "success" |
+   .task_registry["derive-prd"].stats.runs_total = ((.task_registry["derive-prd"].stats.runs_total // 0) + 1) |
+   .task_registry["derive-prd"].stats.items_created = $created' \
+  docs/blueprint/manifest.json > tmp.json && mv tmp.json docs/blueprint/manifest.json
+```
+
+### 4.4 Prompt for GitHub Issue (use AskUserQuestion):
 
 ```
 question: "Create a GitHub issue to track this PRD?"
@@ -338,7 +352,7 @@ Capture issue number and update:
 2. Manifest: add issue to `id_registry.documents[PRD-NNN].github_issues`
 3. Manifest: add mapping to `id_registry.github_issues`
 
-### 4.4 Prompt for next action (use AskUserQuestion):
+### 4.5 Prompt for next action (use AskUserQuestion):
 
 ```
 question: "PRD generated. What would you like to do next?"

--- a/blueprint-plugin/skills/blueprint-execute/REFERENCE.md
+++ b/blueprint-plugin/skills/blueprint-execute/REFERENCE.md
@@ -245,3 +245,38 @@ When feature tracker exists and is stale (> 1 day old), or a PRP was just execut
 6. Report changes made (if any)
 
 Auto-sync is silent when no changes - only reports if something was updated.
+
+## Task Registry Schedule Logic
+
+### Due Calculation
+
+| Schedule | Due When |
+|----------|----------|
+| `daily` | `last_completed_at` is null OR > 24 hours ago |
+| `weekly` | `last_completed_at` is null OR > 7 days ago |
+| `on-change` | Source inputs changed since last run (task-specific) |
+| `on-demand` | Never auto-suggested; only runs on explicit invocation |
+
+### Priority Order for Due Tasks
+
+When multiple tasks are due, execute in this order:
+1. `sync-ids` (fast, foundational)
+2. `feature-tracker-sync` (fast, updates status)
+3. `adr-validate` (fast, read-only check)
+4. `generate-rules` (may modify files)
+5. `derive-rules` (may modify files)
+6. `derive-plans` (longer running)
+7. `claude-md` (depends on other outputs)
+
+### Auto-Run Task Prompt (for due non-auto tasks)
+
+```
+question: "These maintenance tasks are due. Which would you like to run?"
+options:
+  - label: "Run all due tasks"
+    description: "Execute {N} due tasks in priority order"
+  - label: "Choose specific tasks"
+    description: "Select which tasks to run"
+  - label: "Skip maintenance"
+    description: "Continue to other actions"
+```

--- a/blueprint-plugin/skills/blueprint-init/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-init/SKILL.md
@@ -1,7 +1,7 @@
 ---
 model: haiku
 created: 2025-12-16
-modified: 2026-02-06
+modified: 2026-02-17
 reviewed: 2026-01-17
 description: "Initialize Blueprint Development structure in current project"
 allowed-tools: Bash, Write, Read, AskUserQuestion, Glob
@@ -59,7 +59,24 @@ Initialize Blueprint Development in this project.
    b. Create `docs/blueprint/feature-tracker.json` from template
    c. Set `has_feature_tracker: true` in manifest
 
-4. **Ask about document detection** (use AskUserQuestion):
+4. **Ask about maintenance task scheduling** (use AskUserQuestion):
+   ```
+   question: "How should blueprint maintenance tasks run?"
+   options:
+     - label: "Prompt before running (Recommended)"
+       description: "Always ask before running maintenance tasks like sync, validate"
+     - label: "Auto-run safe tasks"
+       description: "Read-only tasks (validate, sync, status) run automatically when due"
+     - label: "Manual only"
+       description: "Tasks only run when you explicitly invoke them"
+   ```
+
+   Store selection for task_registry defaults:
+   - **Prompt**: all `auto_run: false`, default schedules
+   - **Auto-run safe**: read-only tasks (`adr-validate`, `feature-tracker-sync`, `sync-ids`) get `auto_run: true`; write tasks get `false`
+   - **Manual only**: all `auto_run: false`, all schedules set to `on-demand`
+
+5. **Ask about document detection** (use AskUserQuestion):
    ```
    question: "Would you like to enable automatic document detection?"
    options:
@@ -74,7 +91,7 @@ Initialize Blueprint Development in this project.
    **If modular rules enabled and document detection enabled:**
    Copy `document-management-rule.md` template to `.claude/rules/document-management.md`
 
-5. **Check for root documentation to migrate**:
+6. **Check for root documentation to migrate**:
    ```bash
    # Find markdown files in root that look like documentation (not standard files)
    fd -d 1 -e md . | grep -viE '^\./(README|CHANGELOG|CONTRIBUTING|LICENSE|CODE_OF_CONDUCT|SECURITY)'
@@ -106,7 +123,7 @@ Initialize Blueprint Development in this project.
       - ARCHITECTURE.md → docs/adrs/0001-initial-architecture.md
       ```
 
-6. **Create directory structure**:
+7. **Create directory structure**:
 
    **Blueprint structure (in docs/blueprint/):**
    ```
@@ -136,14 +153,14 @@ Initialize Blueprint Development in this project.
    └── skills/                      # Custom skill overrides (optional)
    ```
 
-7. **Create `manifest.json`** (v3.1.0 schema):
+8. **Create `manifest.json`** (v3.2.0 schema):
    ```json
    {
-     "format_version": "3.1.0",
+     "format_version": "3.2.0",
      "created_at": "[ISO timestamp]",
      "updated_at": "[ISO timestamp]",
      "created_by": {
-       "blueprint_plugin": "3.1.0"
+       "blueprint_plugin": "3.2.0"
      },
      "project": {
        "name": "[detected from package.json/pyproject.toml or directory name]",
@@ -172,26 +189,109 @@ Initialize Blueprint Development in this project.
      "custom_overrides": {
        "skills": [],
        "commands": []
+     },
+     "task_registry": {
+       "derive-prd": {
+         "enabled": true,
+         "auto_run": false,
+         "last_completed_at": null,
+         "last_result": null,
+         "schedule": "on-demand",
+         "stats": {},
+         "context": {}
+       },
+       "derive-plans": {
+         "enabled": true,
+         "auto_run": false,
+         "last_completed_at": null,
+         "last_result": null,
+         "schedule": "weekly",
+         "stats": {},
+         "context": {}
+       },
+       "derive-rules": {
+         "enabled": true,
+         "auto_run": false,
+         "last_completed_at": null,
+         "last_result": null,
+         "schedule": "weekly",
+         "stats": {},
+         "context": {}
+       },
+       "generate-rules": {
+         "enabled": true,
+         "auto_run": false,
+         "last_completed_at": null,
+         "last_result": null,
+         "schedule": "on-change",
+         "stats": {},
+         "context": {}
+       },
+       "adr-validate": {
+         "enabled": true,
+         "auto_run": "[based on maintenance task choice: true if auto-run safe, false otherwise]",
+         "last_completed_at": null,
+         "last_result": null,
+         "schedule": "weekly",
+         "stats": {},
+         "context": {}
+       },
+       "feature-tracker-sync": {
+         "enabled": true,
+         "auto_run": "[based on maintenance task choice: true if auto-run safe, false otherwise]",
+         "last_completed_at": null,
+         "last_result": null,
+         "schedule": "daily",
+         "stats": {},
+         "context": {}
+       },
+       "sync-ids": {
+         "enabled": true,
+         "auto_run": "[based on maintenance task choice: true if auto-run safe, false otherwise]",
+         "last_completed_at": null,
+         "last_result": null,
+         "schedule": "on-change",
+         "stats": {},
+         "context": {}
+       },
+       "claude-md": {
+         "enabled": true,
+         "auto_run": false,
+         "last_completed_at": null,
+         "last_result": null,
+         "schedule": "on-change",
+         "stats": {},
+         "context": {}
+       },
+       "curate-docs": {
+         "enabled": false,
+         "auto_run": false,
+         "last_completed_at": null,
+         "last_result": null,
+         "schedule": "on-demand",
+         "stats": {},
+         "context": {}
+       }
      }
    }
    ```
 
    Note: Include `feature_tracker` section only if feature tracking is enabled.
-   Note: As of v3.1.0, progress tracking is consolidated into feature-tracker.json (work-overview.md removed).
+   Note: As of v3.2.0, progress tracking is consolidated into feature-tracker.json (work-overview.md removed).
 
-8. **Create initial rules** (if modular rules selected):
+9. **Create initial rules** (if modular rules selected):
    - `development.md`: TDD workflow, commit conventions
    - `testing.md`: Test requirements, coverage expectations
    - `document-management.md`: Document organization rules (if document detection enabled)
 
-9. **Handle `.gitignore`**:
+10. **Handle `.gitignore`**:
    - Always commit `CLAUDE.md` and `.claude/rules/` (shared project instructions)
    - Add `docs/blueprint/work-orders/` to `.gitignore` (task-specific, may contain sensitive details)
    - If secrets detected in `.claude/`, warn user and suggest `.gitignore` entries
 
-10. **Report**:
+11. **Report**:
    ```
-   Blueprint Development initialized! (v3.1.0)
+   Blueprint Development initialized! (v3.2.0)
 
    Blueprint structure created:
    - docs/blueprint/manifest.json
@@ -213,6 +313,7 @@ Initialize Blueprint Development in this project.
    - Rules mode: [single|modular|both]
    [- Feature tracking: enabled (source: {source_document})]
    [- Document detection: enabled (Claude will prompt for PRD/ADR/PRP creation)]
+   [- Task scheduling: {prompt|auto-run safe|manual only}]
 
    [Migrated documentation:]
    [- {original} → {destination} (for each migrated file)]
@@ -223,7 +324,7 @@ Initialize Blueprint Development in this project.
    - Custom layer: Your overrides in .claude/skills/
    ```
 
-11. **Prompt for next action** (use AskUserQuestion):
+12. **Prompt for next action** (use AskUserQuestion):
     ```
     question: "Blueprint initialized. What would you like to do next?"
     options:

--- a/blueprint-plugin/skills/blueprint-status/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-status/SKILL.md
@@ -1,7 +1,7 @@
 ---
 model: opus
 created: 2025-12-17
-modified: 2026-02-07
+modified: 2026-02-17
 reviewed: 2025-12-22
 description: "Show blueprint version, configuration, and check for available upgrades"
 args: "[--report-only]"
@@ -46,6 +46,13 @@ Display the current blueprint configuration status with three-layer architecture
    - Check for `CLAUDE.md` file
    - Check for `docs/blueprint/feature-tracker.json`
    - If feature tracker exists, read statistics and last_updated
+   - Read `task_registry` from manifest (if present)
+   - For each task, calculate schedule status:
+     - `ok`: Not yet due based on schedule
+     - `due`: Due for execution based on schedule
+     - `overdue`: Past due by more than 1 schedule period (e.g., daily task not run in 2+ days)
+     - `disabled`: `enabled: false`
+     - `never`: `last_completed_at` is null (never tracked)
 
 3. **Check for upgrade availability**:
    - Compare `format_version` in manifest with current plugin version
@@ -108,6 +115,18 @@ Display the current blueprint configuration status with three-layer architecture
    - Last Sync: {last_updated}
    - Phases: {count in_progress} active, {count complete} complete
 
+   {If task_registry exists:}
+   Task Health:
+   - derive-prd          last: {age}  schedule: {schedule}  status: {status}
+   - derive-plans        last: {age}  schedule: {schedule}  status: {status}
+   - derive-rules        last: {age}  schedule: {schedule}  status: {status}
+   - generate-rules      last: {age}  schedule: {schedule}  status: {status}
+   - adr-validate        last: {age}  schedule: {schedule}  status: {status}
+   - feature-tracker-sync last: {age}  schedule: {schedule}  status: {status}
+   - sync-ids            last: {age}  schedule: {schedule}  status: {status}
+   - claude-md           last: {age}  schedule: {schedule}  status: {status}
+   - curate-docs         disabled
+
    Traceability (ID Registry):
    - Total documents: {count} ({x} PRDs, {y} ADRs, {z} PRPs, {w} WOs)
    - With IDs: {count}/{total} ({percent}%)
@@ -154,6 +173,7 @@ Display the current blueprint configuration status with three-layer architecture
    ```
 
 6. **Additional checks**:
+   - Warn if any tasks are overdue (e.g., "3 maintenance tasks overdue - run `/blueprint:execute` to catch up")
    - Warn if feature-tracker.json is stale (> 1 day since last update)
    - Warn if PRDs exist but no generated rules
    - Warn if modular rules enabled but `.claude/rules/` is empty
@@ -185,6 +205,7 @@ Display the current blueprint configuration status with three-layer architecture
    - If ADRs have potential issues → Include "Validate ADRs"
    - If documents without IDs → Include "Sync document IDs"
    - If orphan documents/issues → Include "Link documents to GitHub"
+   - If overdue tasks exist → Include "Run overdue maintenance tasks"
    - Always include "Continue development" and "I'm done"
 
    ```
@@ -209,6 +230,8 @@ Display the current blueprint configuration status with three-layer architecture
        description: "Assign IDs to all documents missing them"
      - label: "Link documents to GitHub" (if orphans exist)
        description: "Create/link GitHub issues for orphan documents"
+     - label: "Run overdue tasks ({N} due)" (if overdue tasks exist)
+       description: "Execute overdue maintenance tasks"
      # Always include these:
      - label: "Continue development"
        description: "Run /project:continue to work on next task"
@@ -226,6 +249,7 @@ Display the current blueprint configuration status with three-layer architecture
    - "Validate ADRs" → Run `/blueprint:adr-validate`
    - "Sync document IDs" → Run `/blueprint:sync-ids`
    - "Link documents to GitHub" → For each orphan, prompt to create/link issue
+   - "Run overdue tasks" → Run `/blueprint:execute` for overdue tasks
    - "Continue development" → Run `/project:continue`
    - "I'm done" → Exit
 
@@ -281,6 +305,17 @@ Feature Tracker:
 - Progress: 22/42 (52.4%)
 - Last Sync: 2024-01-14
 - Phases: 1 active, 2 complete
+
+Task Health:
+  derive-prd          last: 2d ago   schedule: on-demand   status: ok
+  derive-plans        last: 5d ago   schedule: weekly      status: due
+  derive-rules        last: 3d ago   schedule: weekly      status: ok
+  generate-rules      last: 1d ago   schedule: on-change   status: ok
+  adr-validate        last: 4d ago   schedule: weekly      status: ok
+  feature-tracker-sync last: 3d ago  schedule: daily       status: overdue
+  sync-ids            last: 3d ago   schedule: on-change   status: ok
+  claude-md           last: 2d ago   schedule: on-change   status: ok
+  curate-docs         disabled
 
 Traceability (ID Registry):
 - Total documents: 22 (3 PRDs, 5 ADRs, 2 PRPs, 12 WOs)

--- a/blueprint-plugin/skills/blueprint-sync-ids/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-sync-ids/SKILL.md
@@ -1,7 +1,7 @@
 ---
 model: opus
 created: 2026-01-20
-modified: 2026-02-06
+modified: 2026-02-17
 reviewed: 2026-01-20
 description: "Scan all blueprint documents and assign IDs to those missing them, update manifest registry"
 args: "[--dry-run] [--link-issues]"
@@ -254,7 +254,23 @@ gh issue create \
 
 Update document frontmatter and manifest with new issue number.
 
-### Step 11: Final Report
+### Step 11: Update task registry
+
+Update the task registry entry in `docs/blueprint/manifest.json`:
+
+```bash
+jq --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --argjson processed "${DOCS_CHECKED:-0}" \
+  --argjson created "${IDS_ASSIGNED:-0}" \
+  '.task_registry["sync-ids"].last_completed_at = $now |
+   .task_registry["sync-ids"].last_result = "success" |
+   .task_registry["sync-ids"].stats.runs_total = ((.task_registry["sync-ids"].stats.runs_total // 0) + 1) |
+   .task_registry["sync-ids"].stats.items_processed = $processed |
+   .task_registry["sync-ids"].stats.items_created = $created' \
+  docs/blueprint/manifest.json > tmp.json && mv tmp.json docs/blueprint/manifest.json
+```
+
+### Step 12: Final Report
 
 ```
 ID Sync Complete


### PR DESCRIPTION
## Summary

Implement **task_registry** in `manifest.json` to track operational metadata for blueprint maintenance tasks, enabling smart scheduling and incremental operations.

## Features

- **Smart scheduling**: `daily`, `weekly`, `on-change`, `on-demand` schedules
- **Task control**: Enable/disable individual tasks without editing skill files
- **Operational metadata**: Track last run time, result, stats, and context for each task
- **Auto-run preferences**: Configurable per-task with user preference during init
- **Incremental operations**: Store commit cursors, file hashes, etc. for smarter next runs
- **Task health dashboard**: View schedule status and overdue tasks in `/blueprint:status`

## Implementation

### Core Changes

| File | Purpose |
|------|---------|
| `blueprint-init` | New maintenance task scheduling prompt; task_registry schema in manifest |
| `blueprint-upgrade` | v3.1→v3.2 migration with auto-run preference prompt |
| `blueprint-execute` | Read registry, filter by schedule, auto-run due tasks, update after actions |
| `blueprint-status` | Task health dashboard showing per-task status (ok/due/overdue/disabled) |

### Task Skills Updated

All 9 task skills now write completion metadata:
- `blueprint-derive-plans` - commits_analyzed_up_to, count
- `blueprint-derive-prd` - items_created
- `blueprint-derive-rules` - commits_analyzed_up_to
- `blueprint-generate-rules` - source_prd_hashes
- `blueprint-adr-validate` - items_processed
- `blueprint-feature-tracker-sync` - last_todo_hash
- `blueprint-sync-ids` - items_processed, items_created
- `blueprint-claude-md` - basic stats
- `blueprint-curate-docs` - items_processed, items_created

## Schema

\`\`\`json
{
  "task_registry": {
    "derive-plans": {
      "enabled": true,
      "auto_run": false,
      "last_completed_at": "2026-02-17T10:30:00Z",
      "last_result": "success",
      "schedule": "weekly",
      "stats": { "runs_total": 3, "items_processed": 45 },
      "context": { "commits_analyzed_up_to": "abc1234" }
    }
  }
}
\`\`\`

## Version Bump

v3.1.0 → v3.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)