### PR TITLE
feat(feedback-plugin): add session feedback analysis skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -219,6 +219,19 @@
       "category": "documentation"
     },
     {
+      "name": "feedback-plugin",
+      "source": "./feedback-plugin",
+      "description": "Session feedback analysis - capture skill bugs, enhancements, and positive patterns as GitHub issues",
+      "version": "1.0.0",
+      "keywords": [
+        "feedback",
+        "session-analysis",
+        "skill-quality",
+        "github-issues"
+      ],
+      "category": "quality"
+    },
+    {
       "name": "finops-plugin",
       "source": "./finops-plugin",
       "description": "GitHub Actions FinOps analysis - billing, cache usage, workflow efficiency, and waste identification",

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -28,6 +28,7 @@
   "tools-plugin": "2.4.7",
   "testing-plugin": "3.7.0",
   "typescript-plugin": "1.5.4",
+  "feedback-plugin": "1.0.0",
   "finops-plugin": "1.0.4",
   "home-assistant-plugin": "1.1.4",
   "workflow-orchestration-plugin": "1.1.4",

--- a/docs/PLUGIN-MAP.md
+++ b/docs/PLUGIN-MAP.md
@@ -187,6 +187,7 @@ Install based on your project's tech stack and domain.
 | accessibility-plugin | WCAG compliance and ARIA patterns |
 | component-patterns-plugin | Reusable UI component patterns |
 | command-analytics-plugin | Tracking skill/command usage metrics |
+| feedback-plugin | Capturing session skill feedback as GitHub issues |
 | tools-plugin | fd, rg, jq, shell, ImageMagick, d2 utilities |
 | workflow-orchestration-plugin | Parallel agent orchestration, CI pipelines, preflight checks, checkpoint refactoring |
 | prose-plugin | Prose style control — distillation, tone, voice, clarity, consistency |

--- a/feedback-plugin/.claude-plugin/plugin.json
+++ b/feedback-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "feedback-plugin",
+  "version": "1.0.0",
+  "description": "Session feedback analysis - capture skill bugs, enhancements, and positive patterns as GitHub issues",
+  "author": {
+    "name": "Lauri Gates",
+    "url": "https://github.com/laurigates"
+  },
+  "repository": "https://github.com/laurigates/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "feedback",
+    "session-analysis",
+    "skill-quality",
+    "github-issues",
+    "continuous-improvement"
+  ]
+}

--- a/feedback-plugin/README.md
+++ b/feedback-plugin/README.md
@@ -1,0 +1,56 @@
+# feedback-plugin
+
+Session feedback analysis - capture skill bugs, enhancements, and positive patterns as GitHub issues.
+
+## Skills
+
+| Skill | Description |
+|-------|-------------|
+| `/feedback:session` | Analyze session for skill feedback and create GitHub issues |
+
+## Usage
+
+```bash
+# Analyze full session
+/feedback:session
+
+# Dry run - see findings without creating issues
+/feedback:session --dry-run
+
+# Only bugs
+/feedback:session --bugs-only
+
+# Only for a specific plugin
+/feedback:session git-plugin
+
+# Only positive feedback
+/feedback:session --positive-only
+```
+
+## Labels
+
+The plugin creates and uses these GitHub labels:
+
+| Label | Color | Purpose |
+|-------|-------|---------|
+| `session-feedback` | Purple | Bugs and enhancements from session analysis |
+| `positive-feedback` | Green | Skills that worked well (stability markers) |
+
+## Issue Format
+
+Issues are created with conventional title format:
+
+```
+feedback(<plugin-name>): <description>
+```
+
+This integrates with the project's conventional commit workflow.
+
+## Workflow
+
+1. Use skills during a session
+2. At end of session, run `/feedback:session`
+3. Review categorized findings
+4. Select which to file as issues
+5. Issues are created with appropriate labels and body
+6. Use `/project:distill` to actually update the skills based on filed issues

--- a/feedback-plugin/skills/feedback-session/SKILL.md
+++ b/feedback-plugin/skills/feedback-session/SKILL.md
@@ -1,0 +1,189 @@
+---
+model: opus
+name: feedback-session
+description: |
+  Analyze current session for skill feedback and create GitHub issues. Use when
+  a skill gave wrong guidance, a command failed due to skill advice, you discovered
+  a better pattern, or a skill worked particularly well. Creates labeled issues
+  for tracking.
+args: "[--dry-run] [--bugs-only] [--enhancements-only] [--positive-only] [plugin-name]"
+allowed-tools: Bash(gh issue *), Bash(gh label *), Bash(gh search *), Bash(git status *), Bash(git remote *), Read, Grep, Glob, AskUserQuestion, TodoWrite
+argument-hint: "--dry-run | --bugs-only | plugin-name"
+created: 2026-02-18
+modified: 2026-02-18
+reviewed: 2026-02-18
+---
+
+# /feedback:session
+
+Analyze the current session for skill feedback and create GitHub issues to track bugs, enhancements, and positive patterns.
+
+## When to Use This Skill
+
+| Use this skill when... | Use alternative when... |
+|------------------------|------------------------|
+| A skill gave wrong or outdated guidance | Want to update skills directly -> `/project:distill` |
+| A command failed due to skill advice | Need static skill quality analysis -> `/health:audit` |
+| Discovered a better flag or pattern | Want to capture general learnings -> `/project:distill` |
+| A skill worked particularly well | Want to track command usage stats -> `/analytics-report` |
+| End of session, want to file feedback | Need to fix a skill right now -> edit the SKILL.md directly |
+
+## Context
+
+- Repository: !`git remote get-url origin 2>/dev/null`
+- Open feedback issues: !`gh issue list --label session-feedback --state open --json number,title --jq '.[].title' 2>/dev/null`
+- Open positive issues: !`gh issue list --label positive-feedback --state open --json number,title --jq '.[].title' 2>/dev/null`
+
+## Parameters
+
+Parse these from `$ARGUMENTS`:
+
+| Parameter | Description |
+|-----------|-------------|
+| `--dry-run` | Show findings without creating issues |
+| `--bugs-only` | Only report bugs (wrong/outdated guidance) |
+| `--enhancements-only` | Only report enhancement opportunities |
+| `--positive-only` | Only report positive feedback |
+| `[plugin-name]` | Scope analysis to a specific plugin |
+
+## Execution
+
+Execute this session feedback workflow:
+
+### Step 1: Ensure labels exist
+
+Check and create required labels:
+
+1. Check if `session-feedback` label exists: `gh label list --json name --jq '.[].name' | grep -q session-feedback`
+2. If missing, create it: `gh label create session-feedback --description "Feedback from session analysis" --color "d876e3"`
+3. Check if `positive-feedback` label exists similarly
+4. If missing, create it: `gh label create positive-feedback --description "Skills that worked well" --color "0e8a16"`
+
+### Step 2: Analyze conversation history
+
+Review the entire conversation for feedback signals. Look for these categories:
+
+**Bugs** (label: `session-feedback`, `bug`):
+- Skill gave wrong command syntax or outdated flags
+- Command failed because skill guidance was incorrect
+- Skill recommended a pattern that caused errors
+- Skill was missing a critical caveat or prerequisite
+
+**Enhancements** (label: `session-feedback`, `enhancement`):
+- Discovered a better flag or option than what the skill suggests
+- Found a workflow gap the skill should cover
+- Identified a missing pattern or integration
+- Found a more efficient approach than the skill recommends
+
+**Positive** (label: `positive-feedback`):
+- Skill provided correct, effective guidance
+- Skill's agentic optimizations saved time
+- Skill's decision table correctly directed to the right tool
+- Skill's patterns worked well in practice
+
+For each finding, record:
+- **Category**: bug, enhancement, or positive
+- **Plugin**: which plugin the skill belongs to
+- **Skill**: which specific skill
+- **Description**: what happened
+- **Evidence**: the specific interaction or error that demonstrates it
+
+Filter by `$ARGUMENTS`:
+- If `--bugs-only`: only report bugs
+- If `--enhancements-only`: only report enhancements
+- If `--positive-only`: only report positive feedback
+- If `[plugin-name]` specified: only report for that plugin
+
+### Step 3: Deduplicate against open issues
+
+For each finding, search for existing issues:
+
+```
+gh issue list --label session-feedback --search "<skill-name> <key-phrase>" --json number,title --jq '.[].title'
+```
+
+Skip findings that match an existing open issue title. Note skipped items for the summary.
+
+### Step 4: Present findings for review
+
+Use AskUserQuestion to present categorized findings. Group by category:
+
+Format each finding as:
+```
+[BUG] plugin-name/skill-name: brief description
+[ENH] plugin-name/skill-name: brief description
+[POS] plugin-name/skill-name: brief description
+```
+
+Let the user select which findings to file as issues (use multiSelect).
+
+If `--dry-run`, present findings and stop here.
+
+### Step 5: Create approved issues
+
+For each approved finding, create a GitHub issue:
+
+**Title format**: `feedback(<plugin-name>): <description>`
+
+**Labels**:
+- Bugs: `session-feedback`, `bug`
+- Enhancements: `session-feedback`, `enhancement`
+- Positive: `positive-feedback`
+
+**Body template**:
+```markdown
+## Skill
+
+`<plugin-name>/skills/<skill-name>/SKILL.md`
+
+## Category
+
+<Bug | Enhancement | Positive feedback>
+
+## Description
+
+<What happened during the session>
+
+## Evidence
+
+<Specific interaction, error message, or successful outcome>
+
+## Suggested Action
+
+<What should change in the skill, or what should be preserved>
+```
+
+Create each issue: `gh issue create --title "feedback(<plugin>): <desc>" --label "<labels>" --body "<body>"`
+
+### Step 6: Report summary
+
+Print a summary:
+
+| Metric | Count |
+|--------|-------|
+| Findings identified | N |
+| Duplicates skipped | N |
+| Issues created | N |
+| Skipped by user | N |
+
+List created issue numbers with links.
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| List feedback issues | `gh issue list --label session-feedback --json number,title,labels -q '.[]'` |
+| Search for duplicates | `gh issue list --label session-feedback --search "keyword" --json title -q '.[].title'` |
+| Create label | `gh label create name --description "desc" --color "hex"` |
+| Create issue | `gh issue create --title "t" --label "l1,l2" --body "b"` |
+| Check label exists | `gh label list --json name -q '.[].name'` |
+
+## Quick Reference
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Show findings without creating issues |
+| `--bugs-only` | Only bug reports |
+| `--enhancements-only` | Only enhancement suggestions |
+| `--positive-only` | Only positive feedback |
+| `[plugin-name]` | Scope to specific plugin |

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -212,6 +212,20 @@
         {"type": "docs", "section": "Documentation"}
       ]
     },
+    "feedback-plugin": {
+      "component": "feedback-plugin",
+      "release-type": "simple",
+      "extra-files": [
+        {"type": "json", "path": ".claude-plugin/plugin.json", "jsonpath": "$.version"}
+      ],
+      "changelog-sections": [
+        {"type": "feat", "section": "Features"},
+        {"type": "fix", "section": "Bug Fixes"},
+        {"type": "perf", "section": "Performance"},
+        {"type": "refactor", "section": "Code Refactoring"},
+        {"type": "docs", "section": "Documentation"}
+      ]
+    },
     "finops-plugin": {
       "component": "finops-plugin",
       "release-type": "simple",


### PR DESCRIPTION
## Summary

- Create feedback-plugin to automate session analysis into GitHub issues
- Add `/feedback:session` skill for capturing bugs, enhancements, and positive patterns
- Update plugin metadata (marketplace, release-please, docs)

## Changes

- `feedback-plugin/.claude-plugin/plugin.json` - Plugin manifest
- `feedback-plugin/skills/feedback-session/SKILL.md` - Main skill (opus, ~170 lines)
- `feedback-plugin/README.md` - Plugin documentation
- `.claude-plugin/marketplace.json` - Added entry in quality category
- `release-please-config.json` - Added package configuration
- `.release-please-manifest.json` - Added `"feedback-plugin": "1.0.0"`
- `docs/PLUGIN-MAP.md` - Added to conditional plugins table

## Design

- **Model**: Opus for session analysis requiring complex reasoning
- **Permissions**: GitHub CLI only (no file editing - that's `/project:distill`)
- **Feedback categories**: Bugs (wrong guidance), enhancements (missing patterns), positive (effective skills)
- **User review**: Presents findings for selection before creating issues
- **Labels**: `session-feedback` (purple) for bugs/enhancements, `positive-feedback` (green) for stability markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)