### PR TITLE
feat: introduce three-tier model palette (opus/sonnet/haiku)

### DIFF
--- a/.claude/rules/skill-development.md
+++ b/.claude/rules/skill-development.md
@@ -47,7 +47,7 @@ Skills live in `<plugin-name>/skills/<skill-name>/SKILL.md` (or `skill.md`).
 
 ```yaml
 ---
-model: <opus|haiku>
+model: <opus|sonnet|haiku>
 name: <Skill Name>
 description: <1-2 sentence description of capability>
 allowed-tools: <Comma-separated list of tools>
@@ -63,13 +63,15 @@ Choose the appropriate model based on task complexity:
 
 | Model | Use For |
 |-------|---------|
-| `opus` | Complex reasoning, architecture, code review, debugging methodology, security analysis, advanced testing theory |
-| `haiku` | Simple CLI operations, formatting, configuration, status checks, standard workflows |
+| `opus` | Deep reasoning, architecture decisions, debugging methodology, security analysis, complex code review |
+| `sonnet` | Development workflows requiring judgment, code generation with analysis, framework expertise, multi-step pattern-based reasoning |
+| `haiku` | Simple CLI operations, formatting, configuration, status checks, standard mechanical workflows |
 
 **Guidelines:**
-- Default to `haiku` for straightforward, mechanical tasks
-- Use `opus` when the skill requires planning, analysis, or complex decision-making
-- Consider: "Does this need deep reasoning or pattern matching?"
+- Default to `sonnet` for tasks requiring moderate reasoning or development expertise
+- Use `haiku` for straightforward, mechanical tasks (CLI tools, formatting, status checks)
+- Use `opus` only when the skill requires deep reasoning, security analysis, or complex decision-making
+- Consider: "Does this need deep reasoning (opus), moderate judgment (sonnet), or mechanical execution (haiku)?"
 
 ### Date Fields
 
@@ -154,7 +156,7 @@ Skills that accept arguments use the same frontmatter as other skills, with addi
 
 ```yaml
 ---
-model: <opus|haiku>
+model: <opus|sonnet|haiku>
 name: <skill-name>
 description: <What it does, with trigger phrases>
 args: <argument specification>

--- a/.claude/rules/skill-quality.md
+++ b/.claude/rules/skill-quality.md
@@ -87,10 +87,11 @@ description: |
 
 | Model | Use For |
 |-------|---------|
-| `haiku` | CLI tool usage, configuration, standard workflows, formatting |
-| `opus` | Architecture decisions, debugging methodology, security analysis, complex reasoning |
+| `haiku` | CLI tool usage, configuration, standard mechanical workflows, formatting, status checks |
+| `sonnet` | Development workflows requiring judgment, code generation with analysis, framework expertise, multi-step pattern-based reasoning |
+| `opus` | Deep reasoning, architecture decisions, debugging methodology, security analysis, complex code review |
 
-**Default to `haiku`** unless the skill requires deep reasoning or complex decision-making.
+**Default to `sonnet`** for development tasks requiring moderate reasoning. Use `haiku` for mechanical tasks and `opus` for deep reasoning.
 
 ## Supporting Files Pattern
 
@@ -121,7 +122,7 @@ When reviewing skill/command changes:
 - [ ] Has "When to Use" decision table
 - [ ] Has "Agentic Optimizations" table (for CLI/tool skills)
 - [ ] Description matches user intents (not just tool jargon)
-- [ ] Model is appropriate (`haiku` for tools, `opus` for reasoning)
+- [ ] Model is appropriate (`haiku` for tools, `sonnet` for development workflows, `opus` for deep reasoning)
 - [ ] Reference material extracted to REFERENCE.md if needed
 - [ ] Supporting files referenced with markdown links
 - [ ] No duplicate content with sibling skills

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -42,7 +42,7 @@ Location: `agents/<agent-name>.md`
 ```yaml
 ---
 name: agent-name
-model: claude-opus # or claude-haiku
+model: claude-opus # or claude-sonnet, claude-haiku
 color: "#HEXCOLOR"
 description: Short description for agent selection
 tools: Tool1, Tool2, mcp__server-name

--- a/accessibility-plugin/skills/accessibility-implementation/SKILL.md
+++ b/accessibility-plugin/skills/accessibility-implementation/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: haiku
+model: sonnet
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2026-02-08

--- a/accessibility-plugin/skills/design-tokens/SKILL.md
+++ b/accessibility-plugin/skills/design-tokens/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: haiku
+model: sonnet
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16

--- a/agent-patterns-plugin/skills/custom-agent-definitions/SKILL.md
+++ b/agent-patterns-plugin/skills/custom-agent-definitions/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 name: custom-agent-definitions
 description: |
   Write and configure custom agent definitions in Claude Code's agents/ directory. Use
@@ -222,11 +222,11 @@ description: |
 ```
 
 ### 5. Model Selection
-| Use Case | Model |
-|----------|-------|
-| Quick analysis | haiku |
-| Standard work | sonnet |
-| Complex reasoning | opus |
+| Use Case | Model | Model ID |
+|----------|-------|----------|
+| Simple/mechanical tasks | haiku | claude-haiku-4-5 |
+| Development workflows | sonnet | claude-sonnet-4-6 |
+| Deep reasoning/analysis | opus | claude-opus-4-6 |
 
 ## Agent Configuration Fields Reference
 

--- a/agent-patterns-plugin/skills/meta-assimilate/SKILL.md
+++ b/agent-patterns-plugin/skills/meta-assimilate/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/agents-plugin/agents/performance.md
+++ b/agents-plugin/agents/performance.md
@@ -1,6 +1,6 @@
 ---
 name: performance
-model: opus
+model: sonnet
 color: "#E65100"
 description: Performance analysis and profiling. Identifies bottlenecks, analyzes profiler output, benchmarks code, and recommends optimizations. Use when investigating slow code or system performance issues.
 tools: Glob, Grep, LS, Read, Bash(hyperfine *), Bash(py-spy *), Bash(perf *), Bash(time *), Bash(npm run *), Bash(cargo bench *), Bash(go test -bench *), Bash(git status *), Bash(git diff *), TodoWrite

--- a/agents-plugin/agents/refactor.md
+++ b/agents-plugin/agents/refactor.md
@@ -1,6 +1,6 @@
 ---
 name: refactor
-model: opus
+model: sonnet
 color: "#7B1FA2"
 description: Code refactoring specialist. Restructures code for improved readability, maintainability, and SOLID adherence while preserving behavior. Use when code needs structural improvement without changing functionality.
 tools: Glob, Grep, LS, Read, Edit, Write, Bash(npm test *), Bash(npm run *), Bash(yarn test *), Bash(bun test *), Bash(pytest *), Bash(vitest *), Bash(cargo test *), Bash(git status *), Bash(git diff *), Bash(git log *), TodoWrite

--- a/agents-plugin/agents/research.md
+++ b/agents-plugin/agents/research.md
@@ -1,6 +1,6 @@
 ---
 name: research
-model: opus
+model: sonnet
 color: "#00897B"
 description: Technical research and documentation lookup. Investigates APIs, frameworks, libraries, and best practices from web sources and documentation. Use when needing external knowledge to inform decisions.
 tools: Glob, Grep, LS, Read, WebFetch, WebSearch, TodoWrite

--- a/api-plugin/skills/api-tests/SKILL.md
+++ b/api-plugin/skills/api-tests/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2026-02-13
 reviewed: 2025-12-16

--- a/bevy-plugin/skills/bevy-ecs-patterns/skill.md
+++ b/bevy-plugin/skills/bevy-ecs-patterns/skill.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/bevy-plugin/skills/bevy-game-engine/skill.md
+++ b/bevy-plugin/skills/bevy-game-engine/skill.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/blueprint-plugin/skills/blueprint-claude-md/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-claude-md/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-17
 modified: 2026-02-17
 reviewed: 2026-02-09

--- a/blueprint-plugin/skills/blueprint-curate-docs/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-curate-docs/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 description: "Curate library or project documentation for ai_docs to optimize AI context"
 args: "[library-name|project:pattern-name]"
 argument-hint: "Library name (e.g., redis, pydantic) or project:pattern-name"

--- a/blueprint-plugin/skills/blueprint-derive-adr/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-derive-adr/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-22
 modified: 2026-02-06
 reviewed: 2026-02-06

--- a/blueprint-plugin/skills/blueprint-derive-plans/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-derive-plans/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2026-01-15
 modified: 2026-02-17
 reviewed: 2026-02-14

--- a/blueprint-plugin/skills/blueprint-derive-prd/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-derive-prd/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-22
 modified: 2026-02-17
 reviewed: 2025-12-22

--- a/blueprint-plugin/skills/blueprint-derive-rules/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-derive-rules/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2026-01-30
 modified: 2026-02-17
 reviewed: 2026-02-14

--- a/blueprint-plugin/skills/blueprint-development/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-development/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2026-02-14

--- a/blueprint-plugin/skills/blueprint-execute/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-execute/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2026-01-14
 modified: 2026-02-17
 reviewed: 2026-01-30

--- a/blueprint-plugin/skills/blueprint-feature-tracker-status/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-feature-tracker-status/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2026-01-02
 modified: 2026-02-06
 reviewed: 2026-01-02

--- a/blueprint-plugin/skills/blueprint-feature-tracker-sync/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-feature-tracker-sync/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2026-01-02
 modified: 2026-02-17
 reviewed: 2026-02-04

--- a/blueprint-plugin/skills/blueprint-generate-rules/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-generate-rules/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2026-02-17
 reviewed: 2026-02-09

--- a/blueprint-plugin/skills/blueprint-migration/skill.md
+++ b/blueprint-plugin/skills/blueprint-migration/skill.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 name: blueprint-migration
 description: Versioned migration procedures for upgrading blueprint structure between format versions
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion, TodoWrite

--- a/blueprint-plugin/skills/blueprint-promote/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-promote/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-22
 modified: 2026-02-06
 reviewed: 2025-12-22

--- a/blueprint-plugin/skills/blueprint-prp-create/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-prp-create/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 description: "Create a PRP (Product Requirement Prompt) with systematic research, curated context, and validation gates"
 args: "[feature-name]"
 argument-hint: "Feature name for the PRP (e.g., auth-oauth2, api-rate-limiting)"

--- a/blueprint-plugin/skills/blueprint-status/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-status/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-17
 modified: 2026-02-17
 reviewed: 2025-12-22

--- a/blueprint-plugin/skills/blueprint-sync-ids/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-sync-ids/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2026-01-20
 modified: 2026-02-17
 reviewed: 2026-01-20

--- a/blueprint-plugin/skills/blueprint-sync/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-sync/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-22
 modified: 2026-02-07
 reviewed: 2025-12-22

--- a/blueprint-plugin/skills/blueprint-work-order/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-work-order/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2026-02-06
 reviewed: 2025-12-26

--- a/blueprint-plugin/skills/confidence-scoring/SKILL.md
+++ b/blueprint-plugin/skills/confidence-scoring/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: haiku
+model: sonnet
 created: 2025-12-16
 modified: 2026-02-06
 reviewed: 2025-12-16

--- a/code-quality-plugin/skills/code-antipatterns-analysis/SKILL.md
+++ b/code-quality-plugin/skills/code-antipatterns-analysis/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/code-quality-plugin/skills/code-antipatterns/SKILL.md
+++ b/code-quality-plugin/skills/code-antipatterns/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2026-02-03
 reviewed: 2025-12-16

--- a/code-quality-plugin/skills/code-refactor/SKILL.md
+++ b/code-quality-plugin/skills/code-refactor/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/code-quality-plugin/skills/dry-consolidation/SKILL.md
+++ b/code-quality-plugin/skills/dry-consolidation/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 name: dry-consolidation
 description: |
   Find and extract duplicated code into shared abstractions. Use when you see repeated

--- a/code-quality-plugin/skills/refactor/SKILL.md
+++ b/code-quality-plugin/skills/refactor/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/component-patterns-plugin/skills/components-version-badge/SKILL.md
+++ b/component-patterns-plugin/skills/components-version-badge/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-02-03
 modified: 2026-02-10
 reviewed: 2025-02-03

--- a/configure-plugin/skills/configure-all/SKILL.md
+++ b/configure-plugin/skills/configure-all/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2026-02-10
 reviewed: 2025-12-16

--- a/configure-plugin/skills/configure-claude-plugins/SKILL.md
+++ b/configure-plugin/skills/configure-claude-plugins/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2026-01-23
 modified: 2026-02-10
 reviewed: 2026-01-30

--- a/configure-plugin/skills/configure-pre-commit/SKILL.md
+++ b/configure-plugin/skills/configure-pre-commit/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2026-02-10
 reviewed: 2025-12-16

--- a/configure-plugin/skills/configure-workflows/SKILL.md
+++ b/configure-plugin/skills/configure-workflows/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2026-02-13
 reviewed: 2025-12-16

--- a/container-plugin/skills/deploy-handoff/SKILL.md
+++ b/container-plugin/skills/deploy-handoff/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2026-02-10
 reviewed: 2025-12-16

--- a/container-plugin/skills/deploy-release/SKILL.md
+++ b/container-plugin/skills/deploy-release/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/docs/adrs/0003-auto-discovery-component-pattern.md
+++ b/docs/adrs/0003-auto-discovery-component-pattern.md
@@ -113,7 +113,7 @@ description: "When committing code. Conventional commits, co-authors."
 ```yaml
 ---
 name: commit-review
-model: claude-opus
+model: opus
 color: "#4CAF50"
 description: "Review commits for quality and conventions"
 tools: Bash, Read, Grep

--- a/docs/adrs/0009-task-focused-agent-consolidation.md
+++ b/docs/adrs/0009-task-focused-agent-consolidation.md
@@ -40,20 +40,32 @@ Consolidate 23 role-based agents into 5 task-focused agents that complete bounde
 
 ```
 agents-plugin/agents/
-├── test.md      # Write and run tests (haiku)
-├── review.md    # Code/commit/PR review (opus)
-├── debug.md     # Diagnose and fix bugs (opus)
-├── docs.md      # Generate documentation (haiku)
-└── ci.md        # Pipeline configuration (haiku)
+├── test.md             # Write and run tests (haiku)
+├── review.md           # Code/commit/PR review (opus)
+├── debug.md            # Diagnose and fix bugs (opus)
+├── security-audit.md   # Security vulnerability analysis (opus)
+├── performance.md      # Performance analysis (sonnet)
+├── refactor.md         # Code refactoring (sonnet)
+├── research.md         # Technical research (sonnet)
+├── dependency-audit.md # Dependency health checks (haiku)
+├── docs.md             # Generate documentation (haiku)
+└── ci.md               # Pipeline configuration (haiku)
 ```
 
 ### Model Selection Rationale
+
+Three-tier model palette: opus (deep reasoning), sonnet (moderate judgment), haiku (mechanical tasks).
 
 | Agent | Model | Rationale |
 |-------|-------|-----------|
 | test | haiku | Straightforward: analyze → write tests → run → report |
 | review | opus | Complex reasoning: security analysis, pattern recognition, trade-offs |
 | debug | opus | Complex reasoning: root cause analysis, system-level thinking |
+| security-audit | opus | Complex reasoning: vulnerability analysis, threat modeling |
+| performance | sonnet | Pattern-based analysis: profiling, benchmarking, optimization recommendations |
+| refactor | sonnet | Pattern-based restructuring: follows established refactoring patterns |
+| research | sonnet | Moderate judgment: research, evaluate, and summarize findings |
+| dependency-audit | haiku | Mechanical: scan packages, check versions, report CVEs |
 | docs | haiku | Straightforward: analyze code → generate documentation |
 | ci | haiku | Straightforward: understand requirement → write config |
 
@@ -86,7 +98,7 @@ agents-plugin/agents/
 - **Clarity**: Users know which agent handles their task
 - **Efficiency**: Less context switching, no handoff overhead
 - **Maintainability**: 5 agents to maintain instead of 23
-- **Cost optimization**: Haiku for simple tasks, Opus only where reasoning matters
+- **Cost optimization**: Three-tier model selection — haiku for mechanical tasks, sonnet for moderate reasoning, opus only for deep analysis
 - **Reliability**: Smaller scope means fewer opportunities to lose focus
 
 ### Disadvantages

--- a/docs/prps/agent-teams-migration.md
+++ b/docs/prps/agent-teams-migration.md
@@ -105,10 +105,10 @@ Convert the 10 agent definitions to teammate-compatible templates:
 | `ci.md` | haiku | Add workflow file permissions. Restrict to `.github/` directory. |
 | `docs.md` | haiku | Add doc directory restrictions. Good teammate for parallel doc generation. |
 | `security-audit.md` | opus | Excellent teammate — can audit in parallel with development. |
-| `refactor.md` | opus | Add file-lock awareness for safe parallel refactoring. |
+| `refactor.md` | sonnet | Add file-lock awareness for safe parallel refactoring. |
 | `dependency-audit.md` | haiku | Keep as subagent — typically a quick, focused task. |
-| `research.md` | opus | Excellent teammate — isolates web research from main context. |
-| `performance.md` | opus | Keep as subagent — profiling output is verbose and focused. |
+| `research.md` | sonnet | Excellent teammate — isolates web research from main context. |
+| `performance.md` | sonnet | Keep as subagent — profiling output is verbose and focused. |
 
 **Decision per agent**: Convert to teammate template if the task benefits from parallel execution and communication. Keep as subagent if the task is focused, short, and doesn't need coordination.
 

--- a/documentation-plugin/skills/docs-generate/SKILL.md
+++ b/documentation-plugin/skills/docs-generate/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2026-02-05
 reviewed: 2025-12-16

--- a/documentation-plugin/skills/docs-knowledge-graph/SKILL.md
+++ b/documentation-plugin/skills/docs-knowledge-graph/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/documentation-plugin/skills/docs-latex/SKILL.md
+++ b/documentation-plugin/skills/docs-latex/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 name: docs-latex
 description: |
   Convert Markdown documents to professional LaTeX with TikZ visualizations and compile to PDF.

--- a/documentation-plugin/skills/docs-sync/SKILL.md
+++ b/documentation-plugin/skills/docs-sync/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 description: "Synchronize documentation with actual skills, commands, and agents in the codebase"
 args: "[--scope <type>] [--dry-run] [--verbose]"
 argument-hint: "--scope skills|commands|agents, --dry-run to preview, --verbose for details"

--- a/git-plugin/skills/git-commit-push-pr/SKILL.md
+++ b/git-plugin/skills/git-commit-push-pr/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: haiku
+model: sonnet
 name: git-commit-push-pr
 created: 2025-12-16
 modified: 2026-02-06

--- a/git-plugin/skills/git-derive-docs/SKILL.md
+++ b/git-plugin/skills/git-derive-docs/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2026-01-24
 modified: 2026-02-03
 reviewed: 2026-01-24

--- a/git-plugin/skills/git-fix-pr/SKILL.md
+++ b/git-plugin/skills/git-fix-pr/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: haiku
+model: sonnet
 created: 2025-12-16
 modified: 2026-01-17
 reviewed: 2026-01-17

--- a/git-plugin/skills/git-log-documentation/skill.md
+++ b/git-plugin/skills/git-log-documentation/skill.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2026-01-24
 modified: 2026-01-24
 reviewed: 2026-01-24

--- a/git-plugin/skills/git-pr-feedback/SKILL.md
+++ b/git-plugin/skills/git-pr-feedback/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2026-01-30
 modified: 2026-01-30
 reviewed: 2026-01-30

--- a/git-plugin/skills/git-worktree-agent-workflow/SKILL.md
+++ b/git-plugin/skills/git-worktree-agent-workflow/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2026-02-02
 modified: 2026-02-16
 reviewed: 2026-02-16

--- a/git-plugin/skills/release-please-configuration/SKILL.md
+++ b/git-plugin/skills/release-please-configuration/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-28
 modified: 2025-12-28
 reviewed: 2025-12-28

--- a/git-plugin/skills/release-please-protection/SKILL.md
+++ b/git-plugin/skills/release-please-protection/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2026-02-06
 reviewed: 2025-12-16

--- a/github-actions-plugin/skills/claude-code-github-workflows/skill.md
+++ b/github-actions-plugin/skills/claude-code-github-workflows/skill.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/github-actions-plugin/skills/github-actions-inspection/skill.md
+++ b/github-actions-plugin/skills/github-actions-inspection/skill.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16

--- a/github-actions-plugin/skills/github-actions-mcp-config/skill.md
+++ b/github-actions-plugin/skills/github-actions-mcp-config/skill.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/github-actions-plugin/skills/workflow-dev/SKILL.md
+++ b/github-actions-plugin/skills/workflow-dev/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2026-02-10
 reviewed: 2025-12-16

--- a/health-plugin/skills/health-agentic-audit/SKILL.md
+++ b/health-plugin/skills/health-agentic-audit/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2026-02-05
 modified: 2026-02-10
 reviewed: 2026-02-08

--- a/health-plugin/skills/health-audit/SKILL.md
+++ b/health-plugin/skills/health-audit/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2026-02-05
 modified: 2026-02-10
 reviewed: 2026-02-05

--- a/health-plugin/skills/health-plugins/SKILL.md
+++ b/health-plugin/skills/health-plugins/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2026-02-04
 modified: 2026-02-10
 reviewed: 2026-02-05

--- a/kubernetes-plugin/skills/kubernetes-operations/SKILL.md
+++ b/kubernetes-plugin/skills/kubernetes-operations/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2026-02-05
 reviewed: 2025-12-16

--- a/langchain-plugin/skills/deep-agents/skill.md
+++ b/langchain-plugin/skills/deep-agents/skill.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 name: deep-agents
 description: |
   Build hierarchical AI agents using the deep-agents TypeScript/npm package. Use when

--- a/langchain-plugin/skills/langgraph-agents/skill.md
+++ b/langchain-plugin/skills/langgraph-agents/skill.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 name: langgraph-agents
 description: |
   Build stateful AI agents in Python using LangGraph's graph-based workflow framework.

--- a/project-plugin/skills/project-continue/SKILL.md
+++ b/project-plugin/skills/project-continue/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 description: "Analyze project state and continue development where left off"
 args: "[--task <id>] [--skip-status]"
 argument-hint: "--task to resume specific task, --skip-status to skip state analysis"

--- a/project-plugin/skills/project-discovery/SKILL.md
+++ b/project-plugin/skills/project-discovery/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: haiku
+model: sonnet
 created: 2025-12-16
 modified: 2026-02-10
 reviewed: 2026-02-08

--- a/project-plugin/skills/project-distill/SKILL.md
+++ b/project-plugin/skills/project-distill/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 name: project-distill
 description: |
   Distill session insights into reusable knowledge: Claude rules, skill improvements,

--- a/project-plugin/skills/project-init/SKILL.md
+++ b/project-plugin/skills/project-init/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/project-plugin/skills/project-skill-scripts/SKILL.md
+++ b/project-plugin/skills/project-skill-scripts/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 name: project-skill-scripts
 description: Analyze plugin skills to identify opportunities where supporting scripts would improve performance (fewer tokens, faster execution, consistent results), then optionally create those scripts.
 args: "[--analyze] [--create <plugin/skill>] [--all]"

--- a/prose-plugin/skills/prose-distill/SKILL.md
+++ b/prose-plugin/skills/prose-distill/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 name: prose-distill
 description: |
   Distill verbose text to its concentrated essence. Compress without losing meaning —

--- a/prose-plugin/skills/prose-synthesize/SKILL.md
+++ b/prose-plugin/skills/prose-synthesize/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 name: prose-synthesize
 description: |
   Synthesize unstructured thinking into a structured, actionable plan. Use when user provides

--- a/terraform-plugin/skills/infrastructure-terraform/SKILL.md
+++ b/terraform-plugin/skills/infrastructure-terraform/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2026-01-20
 reviewed: 2025-12-16

--- a/testing-plugin/skills/mutation-testing/SKILL.md
+++ b/testing-plugin/skills/mutation-testing/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16

--- a/testing-plugin/skills/property-based-testing/SKILL.md
+++ b/testing-plugin/skills/property-based-testing/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16

--- a/testing-plugin/skills/test-report/SKILL.md
+++ b/testing-plugin/skills/test-report/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/testing-plugin/skills/test-tier-selection/SKILL.md
+++ b/testing-plugin/skills/test-tier-selection/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/workflow-orchestration-plugin/skills/workflow-checkpoint-refactor/SKILL.md
+++ b/workflow-orchestration-plugin/skills/workflow-checkpoint-refactor/SKILL.md
@@ -1,5 +1,5 @@
 ---
-model: opus
+model: sonnet
 name: workflow-checkpoint-refactor
 description: |
   Multi-phase refactoring with persistent checkpoint files that survive context


### PR DESCRIPTION
Add claude-sonnet-4-6 as a middle-tier model option between opus and
haiku. Previously the palette was binary (opus for complex reasoning,
haiku for simple tasks), but claude-sonnet-4-6 fills the gap for
development workflows requiring moderate judgment.

Model reassignments:
- 67 skills: opus → sonnet (pattern-based workflows, framework expertise)
- 6 skills: haiku → sonnet (tasks requiring analytical judgment)
- 12 skills: remain opus (security, debugging, deep code review)
- 194 skills: remain haiku (CLI tools, config, mechanical tasks)
- 3 agents: opus → sonnet (performance, refactor, research)

Updated rules, ADRs, and documentation to reflect the three-tier
model selection guidance.

https://claude.ai/code/session_017Nm8a4ah6ydithD7fAZcMT