### PR TITLE
chore: update model selection guidelines to include Sonnet

### DIFF
--- a/.github/workflows/plugin-pr-checks.yml
+++ b/.github/workflows/plugin-pr-checks.yml
@@ -80,7 +80,7 @@ jobs:
             1. **"When to Use" table**: Does it have a decision table helping Claude choose this skill?
             2. **Agentic Optimizations**: Does it have a compact commands table? (required for CLI/tool skills)
             3. **Description quality**: Does the description match user intents, not just tool jargon?
-            4. **Model selection**: Is `haiku` used for CLI tools and `opus` only for complex reasoning?
+            4. **Model selection**: Is `haiku` used for CLI tools, `sonnet` for development workflows, and `opus` only for deep reasoning?
             5. **Supporting file links**: If REFERENCE.md exists, is it linked with `[REFERENCE.md](REFERENCE.md)`?
 
             For each issue found, leave a specific, actionable review comment on the relevant file.

--- a/.github/workflows/scheduled-audits.yml
+++ b/.github/workflows/scheduled-audits.yml
@@ -184,7 +184,7 @@ jobs:
 
             ### 2. Model Appropriateness
             - Read `model` field from frontmatter of flagged skills
-            - `haiku` for CLI tools, `opus` for complex reasoning
+            - `haiku` for CLI tools, `sonnet` for development workflows, `opus` for deep reasoning
             - Flag potentially misassigned models
 
             ### 3. Description Quality


### PR DESCRIPTION
## Summary
Updated the model selection guidelines in CI/CD workflows to reflect the appropriate use of Claude Sonnet for development workflows, in addition to the existing Haiku and Opus recommendations.

## Key Changes
- **plugin-pr-checks.yml**: Updated the model selection checklist item to specify that `sonnet` should be used for development workflows, alongside `haiku` for CLI tools and `opus` for deep reasoning
- **scheduled-audits.yml**: Updated the model appropriateness audit criteria to include `sonnet` for development workflows in the model assignment guidelines

## Details
These changes clarify the three-tier model selection strategy:
- `haiku`: CLI tools and lightweight operations
- `sonnet`: Development workflows and moderate complexity tasks
- `opus`: Deep reasoning and complex problem-solving

This ensures both automated PR checks and scheduled audits enforce consistent model selection practices across the plugin ecosystem.

https://claude.ai/code/session_01Vawt26FmD2eeK17KiUWp4n