### PR TITLE
feat: Refactor PR workflow to track post-merge actions as GitHub issues

### DIFF
--- a/git-plugin/skills/git-commit-push-pr/SKILL.md
+++ b/git-plugin/skills/git-commit-push-pr/SKILL.md
@@ -2,8 +2,8 @@
 model: sonnet
 name: git-commit-push-pr
 created: 2025-12-16
-modified: 2026-02-06
-reviewed: 2026-02-06
+modified: 2026-02-20
+reviewed: 2026-02-20
 allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git branch *), Bash(git remote *), Bash(gh pr *), Bash(gh label *), Bash(gh repo *), Bash(gh issue *), Bash(pre-commit *), Bash(find *), Read, Edit, Grep, Glob, TodoWrite, mcp__github__create_pull_request, mcp__github__list_issues, mcp__github__get_issue
 args: "[remote-branch] [--push] [--direct] [--pr] [--draft] [--issue <num>] [--no-commit] [--range <start>..<end>] [--skip-issue-detection]"
 argument-hint: [remote-branch] [--push] [--direct] [--pr] [--draft] [--issue <num>] [--no-commit] [--range <start>..<end>] [--skip-issue-detection]
@@ -135,12 +135,51 @@ git push origin <start>^..<end>:<remote-branch>
 
 ### Step 5: Create PR (if --pr)
 
+**5a. Identify post-merge follow-up actions.**
+
+Before creating the PR, scan commit messages, diff context, and any conversation context for actions that must happen **after** the PR is merged:
+
+| Signal | Examples |
+|--------|---------|
+| Commit messages | "migration", "run after deploy", "manual step", "update config" |
+| File patterns | `*.sql`, migration files, deployment scripts, runbooks |
+| Context | User mentioned a deployment step, documentation update, or announcement |
+
+For each post-merge action identified, create a GitHub issue — **not a PR checklist item**. PR descriptions are closed and buried once a PR merges; issues remain open until resolved.
+
+```bash
+gh issue create \
+  --title "[Chore] DB: Run migration for new schema" \
+  --body "Follow-up to <PR-URL>.\n\nRun: rake db:migrate in production after deploy." \
+  --label "chore"
+# Note the returned issue number for the PR body
+```
+
+Common follow-up types: database migrations, production deployments, manual config changes, external documentation updates, customer-facing announcements, dependent follow-on PRs.
+
+**5b. Create the PR**, including follow-up issue links in the body.
+
 Use `mcp__github__create_pull_request` with:
 - `head`: The remote branch name (e.g., `feat/auth-oauth2`)
 - `base`: `main`
 - `title`: Derived from commit message
-- `body`: Include summary and issue link if --issue provided
+- `body`: Include summary, issue link if --issue provided, and a **Follow-up Issues** section listing any issues created in 5a
 - `draft`: true if --draft flag set
+
+PR body structure when follow-up issues exist:
+
+```markdown
+## Summary
+...
+
+## Follow-up Issues
+<!-- Post-merge actions tracked as issues so they survive PR closure -->
+- #456: run database migration for new schema
+- #457: update production feature-flag config
+
+## Related Issues
+Fixes #123
+```
 
 If `--labels` provided, add labels after PR creation:
 ```bash


### PR DESCRIPTION
## Summary

This change restructures the pull request creation workflow to properly separate pre-merge and post-merge actions. Post-merge follow-ups (database migrations, deployments, config changes, etc.) are now tracked as separate GitHub issues rather than embedded in PR checklists, ensuring they remain visible and actionable after the PR is merged and closed.

## Key Changes

- **Separated pre-merge and post-merge workflows**: Added explicit guidance that PR checklists should only contain pre-merge actions, with a clarified note that post-merge steps must never be included
- **New "Follow-up Issues" section**: Introduced a dedicated section in PR descriptions for linking GitHub issues that track post-merge work
- **New workflow step (Step 3)**: Added "Identify Post-Merge Follow-ups and Create Issues" before PR creation, with examples of creating follow-up issues using `gh issue create`
- **Expanded post-merge documentation**: Added comprehensive "Post-Merge Follow-up Issues" section with:
  - Rationale for using issues instead of PR checklists
  - Table of common post-merge follow-up types (migrations, deployments, config, docs, comms, dependent PRs)
  - Detailed workflow with bash examples
  - Example PR description structure
- **Updated PR template examples**: Modified example PR bodies to show the new Follow-up Issues section
- **Enhanced git-commit-push-pr skill**: Added Step 5a to identify post-merge actions before PR creation, with signal detection table and issue creation guidance
- **Updated command reference**: Added `gh issue create` to the CLI reference section

## Notable Implementation Details

- The change emphasizes that PR descriptions are "closed and buried after merge" and thus unsuitable for tracking follow-up work
- Provides concrete examples of follow-up issue titles using a `[Chore]` prefix convention
- Includes bash command examples for both creating issues and updating PR bodies with issue links
- Maintains backward compatibility with existing PR creation workflows while adding the new optional step

https://claude.ai/code/session_01TKoXTt4KWG1DjkKVRZK36M