### PR TITLE
docs: add git workflow and conventional commits guidelines

### DIFF
--- a/.claude/rules/skill-development.md
+++ b/.claude/rules/skill-development.md
@@ -1,6 +1,6 @@
 ---
 created: 2025-12-20
-modified: 2026-01-22
+modified: 2026-02-20
 reviewed: 2026-01-22
 ---
 
@@ -197,3 +197,25 @@ Update `.claude-plugin/plugin.json` when adding skills:
 Update `README.md`:
 - Add skill to skills table
 - Add usage examples for new commands
+
+## Git Workflow
+
+All commits and PR titles **must** follow conventional commit format. See `.claude/rules/conventional-commits.md` for the full standard.
+
+Use the plugin name as the scope:
+
+```bash
+git commit -m "feat(git-plugin): add commit workflow skill"
+git commit -m "fix(configure-plugin): correct frontmatter extraction"
+git commit -m "docs(blueprint-plugin): update skill README"
+```
+
+| Type | When to Use |
+|------|-------------|
+| `feat` | New skill or meaningful new capability |
+| `fix` | Correcting broken skill behaviour |
+| `docs` | README, CHANGELOG, or inline documentation only |
+| `refactor` | Restructuring a skill without behaviour change |
+| `chore` | Metadata updates (plugin.json, marketplace.json) |
+
+PR titles must also follow this format — they become the squash-merge commit message that drives release-please version bumps.

--- a/.claude/rules/skill-quality.md
+++ b/.claude/rules/skill-quality.md
@@ -129,3 +129,5 @@ When reviewing skill/command changes:
 - [ ] Frontmatter has all required fields (name, description, allowed-tools)
 - [ ] Date fields updated (modified, reviewed)
 - [ ] User-invocable skills follow execution structure (see `.claude/rules/skill-execution-structure.md`)
+- [ ] PR title follows conventional commit format: `type(scope): subject` (see `.claude/rules/conventional-commits.md`)
+- [ ] Commit messages follow conventional commit format with plugin name as scope (e.g., `feat(git-plugin): ...`)


### PR DESCRIPTION
## Summary
Added comprehensive documentation for git workflow and conventional commit standards to ensure consistent commit messages and PR titles across the project.

## Key Changes
- **skill-development.md**: Added new "Git Workflow" section documenting:
  - Requirement that all commits and PR titles follow conventional commit format
  - Plugin name as scope convention with practical examples
  - Reference table clarifying commit types (`feat`, `fix`, `docs`, `refactor`, `chore`) and their usage
  - Note that PR titles become squash-merge commit messages driving release-please version bumps

- **skill-quality.md**: Enhanced review checklist with two new items:
  - PR title format validation: `type(scope): subject`
  - Commit message format validation with plugin name scope requirement

## Implementation Details
- Updated modified date in skill-development.md frontmatter to reflect changes
- Maintains consistency with existing `.claude/rules/conventional-commits.md` standard
- Provides clear examples using actual plugin names (git-plugin, configure-plugin, blueprint-plugin)
- Integrates with existing release automation (release-please) workflow

https://claude.ai/code/session_012QArLCCvvmPrtB1H98FAUi