### PR TITLE
fix: remove 2>/dev/null from context commands across all plugins

### DIFF
--- a/.claude/rules/agentic-permissions.md
+++ b/.claude/rules/agentic-permissions.md
@@ -193,24 +193,27 @@ Context commands use `!` backtick syntax and are subject to shell operator prote
 
 ### Context Command Patterns
 
-Use `2>/dev/null` to suppress errors. Empty output is acceptable - commands handle missing context gracefully.
+Context commands must use plain commands without shell operators. The `>` in `2>/dev/null` is blocked by shell operator protections, just like `||`, `&&`, `|`, and `;`.
+
+Commands that fail produce empty output, which is acceptable — the context system handles missing context gracefully.
 
 Use `find` for file/directory discovery (succeeds with empty output when no matches):
 
 ```markdown
 ## Context
 
-- Git status: !`git status --porcelain=v2 --branch 2>/dev/null`
-- PR checks: !`gh pr checks $PR_NUMBER --json name,state,conclusion 2>/dev/null`
-- Current branch: !`git branch --show-current 2>/dev/null`
+- Git status: !`git status --porcelain=v2 --branch`
+- PR checks: !`gh pr checks $PR_NUMBER --json name,state,conclusion`
+- Current branch: !`git branch --show-current`
 - Config exists: !`test -f .config.json`
-- Workflows: !`find .github/workflows -maxdepth 1 -name '*.yml' 2>/dev/null`
-- Directories: !`find . -maxdepth 1 -type d \( -name 'src' -o -name 'lib' \) 2>/dev/null`
-- Config files: !`find . -maxdepth 1 \( -name '*.config.js' -o -name '*.config.ts' \) 2>/dev/null`
+- Workflows: !`find .github/workflows -maxdepth 1 -name '*.yml'`
+- Directories: !`find . -maxdepth 1 -type d \( -name 'src' -o -name 'lib' \)`
+- Config files: !`find . -maxdepth 1 \( -name '*.config.js' -o -name '*.config.ts' \)`
 ```
 
 ### Handling Missing Context
 
+- Commands that fail produce empty output — no error suppression needed
 - Check for empty values before using them
 - Provide defaults in the command logic
 - Use existence checks (`test -f`, `test -d`) for boolean context
@@ -219,7 +222,7 @@ Use `find` for file/directory discovery (succeeds with empty output when no matc
 
 - [ ] Uses granular `Bash(command *)` patterns
 - [ ] Context commands use JSON/porcelain output
-- [ ] Context commands use `2>/dev/null` for error suppression
+- [ ] Context commands contain no shell operators (`>`, `|`, `||`, `&&`, `;`)
 - [ ] Context commands use `find` for file/directory discovery
 - [ ] Only necessary permissions are granted
 - [ ] Matches a standard permission set or documents why custom set is needed

--- a/agents-plugin/skills/agents-analyze/SKILL.md
+++ b/agents-plugin/skills/agents-analyze/SKILL.md
@@ -16,10 +16,10 @@ Analyze the plugin collection to identify where sub-agents would improve workflo
 
 ## Context
 
-- Plugin directories: !`find . -maxdepth 1 -type d -name '*-plugin' 2>/dev/null`
-- Existing agents: !`find agents-plugin/agents -maxdepth 1 -name '*.md' 2>/dev/null`
-- Skills: !`find . -path '*/skills/*/skill.md' 2>/dev/null`
-- Skills (user-invocable): !`find . -path '*/skills/*/SKILL.md' -not -path './agents-plugin/*' 2>/dev/null`
+- Plugin directories: !`find . -maxdepth 1 -type d -name '*-plugin'`
+- Existing agents: !`find agents-plugin/agents -maxdepth 1 -name '*.md'`
+- Skills: !`find . -path '*/skills/*/skill.md'`
+- Skills (user-invocable): !`find . -path '*/skills/*/SKILL.md' -not -path './agents-plugin/*'`
 
 ## Parameters
 

--- a/api-plugin/skills/api-tests/SKILL.md
+++ b/api-plugin/skills/api-tests/SKILL.md
@@ -25,16 +25,16 @@ Check and configure API contract testing infrastructure for validating API contr
 
 ## Context
 
-- Lock files: !`find . -maxdepth 1 \( -name 'bun.lockb' -o -name 'bun.lock' -o -name 'package-lock.json' -o -name 'yarn.lock' \) 2>/dev/null`
-- Project files: !`find . -maxdepth 1 \( -name 'tsconfig.json' -o -name 'pyproject.toml' -o -name 'package.json' \) 2>/dev/null`
-- Pact installed: !`grep -l "pact-foundation/pact\|pact-python" package.json requirements*.txt pyproject.toml 2>/dev/null`
-- OpenAPI spec: !`find . -maxdepth 2 \( -name 'openapi.yaml' -o -name 'openapi.yml' -o -name 'openapi.json' -o -name 'swagger.json' -o -name 'swagger.yaml' \) 2>/dev/null`
-- Schema validator: !`grep -l '"ajv"\|"zod"' package.json 2>/dev/null`
-- OpenAPI validation lib: !`grep -l "swagger-parser\|@apidevtools" package.json 2>/dev/null`
-- Pact contracts dir: !`find . -maxdepth 1 -type d -name \'pacts\' 2>/dev/null`
-- Contract tests: !`find . -maxdepth 3 -type d -name 'contract' 2>/dev/null`
-- API test files: !`find . -maxdepth 4 \( -name '*.pact.*' -o -name '*.openapi.*' -o -name '*.contract.*' \) 2>/dev/null`
-- CI workflows: !`find .github/workflows -maxdepth 1 \( -name '*api*' -o -name '*contract*' -o -name '*pact*' \) 2>/dev/null`
+- Lock files: !`find . -maxdepth 1 \( -name 'bun.lockb' -o -name 'bun.lock' -o -name 'package-lock.json' -o -name 'yarn.lock' \)`
+- Project files: !`find . -maxdepth 1 \( -name 'tsconfig.json' -o -name 'pyproject.toml' -o -name 'package.json' \)`
+- Pact installed: !`grep -l "pact-foundation/pact\|pact-python" package.json requirements*.txt pyproject.toml`
+- OpenAPI spec: !`find . -maxdepth 2 \( -name 'openapi.yaml' -o -name 'openapi.yml' -o -name 'openapi.json' -o -name 'swagger.json' -o -name 'swagger.yaml' \)`
+- Schema validator: !`grep -l '"ajv"\|"zod"' package.json`
+- OpenAPI validation lib: !`grep -l "swagger-parser\|@apidevtools" package.json`
+- Pact contracts dir: !`find . -maxdepth 1 -type d -name \'pacts\'`
+- Contract tests: !`find . -maxdepth 3 -type d -name 'contract'`
+- API test files: !`find . -maxdepth 4 \( -name '*.pact.*' -o -name '*.openapi.*' -o -name '*.contract.*' \)`
+- CI workflows: !`find .github/workflows -maxdepth 1 \( -name '*api*' -o -name '*contract*' -o -name '*pact*' \)`
 
 ## Parameters
 

--- a/blog-plugin/skills/blog-post/SKILL.md
+++ b/blog-plugin/skills/blog-post/SKILL.md
@@ -25,10 +25,10 @@ Create a blog post about your work with minimal friction. Gathers context automa
 
 ## Context
 
-- Blog directory: !`find . -maxdepth 1 -type d \( -name blog -o -name posts -o -name _posts \) -print -quit 2>/dev/null`
-- Project name: !`git remote get-url origin 2>/dev/null`
-- Recent commits: !`git rev-list --count --since="7 days ago" HEAD 2>/dev/null`
-- Current branch: !`git branch --show-current 2>/dev/null`
+- Blog directory: !`find . -maxdepth 1 -type d \( -name blog -o -name posts -o -name _posts \) -print -quit`
+- Project name: !`git remote get-url origin`
+- Recent commits: !`git rev-list --count --since="7 days ago" HEAD`
+- Current branch: !`git branch --show-current`
 
 ## Parameters
 

--- a/blueprint-plugin/skills/blueprint-adr-validate/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-adr-validate/SKILL.md
@@ -26,10 +26,10 @@ Validate Architecture Decision Records for relationship consistency, reference i
 
 ## Context
 
-- ADR directory exists: !`test -d docs/adrs 2>/dev/null`
-- ADR count: !`find docs/adrs -name "*.md" -type f 2>/dev/null`
-- Domain-tagged ADRs: !`grep -l "^domain:" docs/adrs/*.md 2>/dev/null`
-- Flag: !`echo "${1:---}" 2>/dev/null`
+- ADR directory exists: !`test -d docs/adrs`
+- ADR count: !`find docs/adrs -name "*.md" -type f`
+- Domain-tagged ADRs: !`grep -l "^domain:" docs/adrs/*.md`
+- Flag: !`echo "${1:---}"`
 
 ## Parameters
 

--- a/blueprint-plugin/skills/blueprint-curate-docs/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-curate-docs/SKILL.md
@@ -26,10 +26,10 @@ Curate library or project documentation into ai_docs entries optimized for AI ag
 
 ## Context
 
-- ai_docs directory: !`test -d docs/blueprint/ai_docs 2>/dev/null`
-- Existing library docs: !`find docs/blueprint/ai_docs/libraries -name "*.md" -type f 2>/dev/null`
-- Existing project patterns: !`find docs/blueprint/ai_docs/project -name "*.md" -type f 2>/dev/null`
-- Library in dependencies: !`grep -m1 "^$1[\":@=]" package.json pyproject.toml requirements.txt 2>/dev/null`
+- ai_docs directory: !`test -d docs/blueprint/ai_docs`
+- Existing library docs: !`find docs/blueprint/ai_docs/libraries -name "*.md" -type f`
+- Existing project patterns: !`find docs/blueprint/ai_docs/project -name "*.md" -type f`
+- Library in dependencies: !`grep -m1 "^$1[\":@=]" package.json pyproject.toml requirements.txt`
 
 ## Parameters
 

--- a/blueprint-plugin/skills/blueprint-derive-plans/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-derive-plans/SKILL.md
@@ -27,13 +27,13 @@ Retroactively generate Blueprint documentation (PRDs, ADRs, PRPs) from an existi
 
 ## Context
 
-- Git repository: !`git rev-parse --git-dir 2>/dev/null`
-- Blueprint initialized: !`test -f docs/blueprint/manifest.json 2>/dev/null`
-- Total commits: !`git rev-list --count HEAD 2>/dev/null`
-- First commit: !`git log --reverse --format=%ai --max-count=1 2>/dev/null`
-- Latest commit: !`git log --max-count=1 --format=%ai 2>/dev/null`
-- Project type: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' -o -name 'pom.xml' \) -type f -print -quit 2>/dev/null`
-- Documentation files: !`find . -maxdepth 2 \( -name "README.md" -o -name "ARCHITECTURE.md" -o -name "DESIGN.md" \) 2>/dev/null`
+- Git repository: !`git rev-parse --git-dir`
+- Blueprint initialized: !`test -f docs/blueprint/manifest.json`
+- Total commits: !`git rev-list --count HEAD`
+- First commit: !`git log --reverse --format=%ai --max-count=1`
+- Latest commit: !`git log --max-count=1 --format=%ai`
+- Project type: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' -o -name 'pom.xml' \) -type f -print -quit`
+- Documentation files: !`find . -maxdepth 2 \( -name "README.md" -o -name "ARCHITECTURE.md" -o -name "DESIGN.md" \)`
 
 ## Parameters
 

--- a/blueprint-plugin/skills/blueprint-derive-rules/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-derive-rules/SKILL.md
@@ -28,11 +28,11 @@ Extract project decisions from git commit history and codify them as Claude rule
 
 ## Context
 
-- Git repository: !`git rev-parse --git-dir 2>/dev/null`
-- Blueprint initialized: !`test -f docs/blueprint/manifest.json 2>/dev/null`
-- Total commits: !`git rev-list --count HEAD 2>/dev/null`
-- Conventional commits %: !`git log --format="%s" 2>/dev/null`
-- Existing rules: !`find .claude/rules -name "*.md" -type f 2>/dev/null`
+- Git repository: !`git rev-parse --git-dir`
+- Blueprint initialized: !`test -f docs/blueprint/manifest.json`
+- Total commits: !`git rev-list --count HEAD`
+- Conventional commits %: !`git log --format="%s"`
+- Existing rules: !`find .claude/rules -name "*.md" -type f`
 
 ## Parameters
 

--- a/blueprint-plugin/skills/blueprint-derive-tests/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-derive-tests/SKILL.md
@@ -27,12 +27,12 @@ Analyze git history to identify fix and feature commits lacking corresponding te
 
 ## Context
 
-- Git repository: !`git rev-parse --git-dir 2>/dev/null`
-- Blueprint initialized: !`test -f docs/blueprint/manifest.json 2>/dev/null`
-- Total commits: !`git rev-list --count HEAD 2>/dev/null`
-- Test framework: !`find . -maxdepth 3 \( -name 'vitest.config.*' -o -name 'jest.config.*' -o -name 'pytest.ini' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \) -type f -print -quit 2>/dev/null`
-- Test files: !`find . -maxdepth 4 -type f \( -name '*.test.*' -o -name '*.spec.*' -o -name 'test_*' -o -name '*_test.*' \) -print 2>/dev/null`
-- Conventional commits sample: !`git log --format="%s" -n 10 2>/dev/null`
+- Git repository: !`git rev-parse --git-dir`
+- Blueprint initialized: !`test -f docs/blueprint/manifest.json`
+- Total commits: !`git rev-list --count HEAD`
+- Test framework: !`find . -maxdepth 3 \( -name 'vitest.config.*' -o -name 'jest.config.*' -o -name 'pytest.ini' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \) -type f -print -quit`
+- Test files: !`find . -maxdepth 4 -type f \( -name '*.test.*' -o -name '*.spec.*' -o -name 'test_*' -o -name '*_test.*' \) -print`
+- Conventional commits sample: !`git log --format="%s" -n 10`
 
 ## Parameters
 

--- a/blueprint-plugin/skills/blueprint-development/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-development/SKILL.md
@@ -25,11 +25,11 @@ For detailed rule templates, command templates, and generation guidelines, see [
 
 ## Context
 
-- Blueprint initialized: !`test -f docs/blueprint/manifest.json 2>/dev/null`
-- PRDs present: !`find docs/prds -name "*.md" -type f 2>/dev/null`
-- Rules directory: !`test -d .claude/rules 2>/dev/null`
-- Existing rules: !`find .claude/rules -maxdepth 1 -name "*.md" 2>/dev/null`
-- Project type: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \) -type f -print -quit 2>/dev/null`
+- Blueprint initialized: !`test -f docs/blueprint/manifest.json`
+- PRDs present: !`find docs/prds -name "*.md" -type f`
+- Rules directory: !`test -d .claude/rules`
+- Existing rules: !`find .claude/rules -maxdepth 1 -name "*.md"`
+- Project type: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \) -type f -print -quit`
 
 ## Execution
 

--- a/blueprint-plugin/skills/blueprint-prp-create/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-prp-create/SKILL.md
@@ -33,10 +33,10 @@ Create a comprehensive PRP (Product Requirement Prompt) - a self-contained packe
 
 ## Context
 
-- Blueprint initialized: !`test -f docs/blueprint/manifest.json 2>/dev/null`
-- Last PRP ID: !`jq -r '.id_registry.last_prp // 0' docs/blueprint/manifest.json 2>/dev/null`
-- ai_docs available: !`find docs/blueprint/ai_docs -type f -name "*.md" 2>/dev/null`
-- Existing PRDs: !`find docs/prds -name "*.md" -type f 2>/dev/null`
+- Blueprint initialized: !`test -f docs/blueprint/manifest.json`
+- Last PRP ID: !`jq -r '.id_registry.last_prp // 0' docs/blueprint/manifest.json`
+- ai_docs available: !`find docs/blueprint/ai_docs -type f -name "*.md"`
+- Existing PRDs: !`find docs/prds -name "*.md" -type f`
 
 ## Parameters
 

--- a/blueprint-plugin/skills/blueprint-prp-execute/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-prp-execute/SKILL.md
@@ -33,11 +33,11 @@ For detailed report templates, deferred items workflow, feature tracker sync, an
 
 ## Context
 
-- PRP file path: !`find . -maxdepth 1 -name \'docs/prps/${1:-unknown}.md\' 2>/dev/null`
-- PRP confidence score: !`grep -m1 "^confidence:" docs/prps/${1:-unknown}.md 2>/dev/null`
-- Feature tracker enabled: !`test -f docs/blueprint/feature-tracker.json 2>/dev/null`
-- Current branch: !`git rev-parse --abbrev-ref HEAD 2>/dev/null`
-- Uncommitted changes: !`git status --porcelain 2>/dev/null`
+- PRP file path: !`find . -maxdepth 1 -name \'docs/prps/${1:-unknown}.md\'`
+- PRP confidence score: !`grep -m1 "^confidence:" docs/prps/${1:-unknown}.md`
+- Feature tracker enabled: !`test -f docs/blueprint/feature-tracker.json`
+- Current branch: !`git rev-parse --abbrev-ref HEAD`
+- Uncommitted changes: !`git status --porcelain`
 
 ## Parameters
 

--- a/code-quality-plugin/skills/code-antipatterns/SKILL.md
+++ b/code-quality-plugin/skills/code-antipatterns/SKILL.md
@@ -13,9 +13,9 @@ name: code-antipatterns
 ## Context
 
 - Analysis path: `$1` (defaults to current directory if not specified)
-- JS/TS files: !`find . -type f \( -name "*.js" -o -name "*.ts" -o -name "*.jsx" -o -name "*.tsx" \) 2>/dev/null`
-- Vue files: !`find . -name "*.vue" 2>/dev/null`
-- Python files: !`find . -name "*.py" 2>/dev/null`
+- JS/TS files: !`find . -type f \( -name "*.js" -o -name "*.ts" -o -name "*.jsx" -o -name "*.tsx" \)`
+- Vue files: !`find . -name "*.vue"`
+- Python files: !`find . -name "*.py"`
 
 ## Your Task
 

--- a/code-quality-plugin/skills/code-refactor/SKILL.md
+++ b/code-quality-plugin/skills/code-refactor/SKILL.md
@@ -12,9 +12,9 @@ name: code-refactor
 
 ## Context
 
-- Target path: !`echo "$1" 2>/dev/null`
-- File type: !`file "$1" 2>/dev/null`
-- Lines of code: !`wc -l "$1" 2>/dev/null`
+- Target path: !`echo "$1"`
+- File type: !`file "$1"`
+- Lines of code: !`wc -l "$1"`
 
 ## Parameters
 

--- a/code-quality-plugin/skills/code-silent-degradation/SKILL.md
+++ b/code-quality-plugin/skills/code-silent-degradation/SKILL.md
@@ -32,8 +32,8 @@ Detect code patterns where operations complete "successfully" but produce empty 
 ## Context
 
 - Scan path: `$ARGUMENTS` (defaults to current directory if empty)
-- Source files: !`find . -maxdepth 1 \( -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.jsx" -o -name "*.py" -o -name "*.go" -o -name "*.rs" \) -type f 2>/dev/null`
-- Config patterns: !`find . -maxdepth 1 \( -name ".env*" -o -name "config.*" -o -name "settings.*" \) -type f 2>/dev/null`
+- Source files: !`find . -maxdepth 1 \( -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.jsx" -o -name "*.py" -o -name "*.go" -o -name "*.rs" \) -type f`
+- Config patterns: !`find . -maxdepth 1 \( -name ".env*" -o -name "config.*" -o -name "settings.*" \) -type f`
 
 ## Parameters
 

--- a/code-quality-plugin/skills/docs-quality-check/SKILL.md
+++ b/code-quality-plugin/skills/docs-quality-check/SKILL.md
@@ -17,13 +17,13 @@ Analyze and validate documentation quality for a codebase, ensuring PRDs, ADRs, 
 - Target path: `$1` (defaults to current directory if not specified)
 - Blueprint dir exists: !`test -d .claude/blueprints`
 - CLAUDE.md exists: !`test -f CLAUDE.md`
-- Rules directory: !`find .claude/rules -maxdepth 1 -name '*.md' 2>/dev/null`
-- ADRs (docs/adr): !`find docs/adr -maxdepth 1 -name '*.md' 2>/dev/null`
-- ADRs (docs/adrs): !`find docs/adrs -maxdepth 1 -name '*.md' 2>/dev/null`
-- PRDs (docs/prds): !`find docs/prds -maxdepth 1 -name '*.md' 2>/dev/null`
-- PRDs (blueprints): !`find .claude/blueprints/prds -maxdepth 1 -name '*.md' 2>/dev/null`
-- PRPs (docs/prps): !`find docs/prps -maxdepth 1 -name '*.md' 2>/dev/null`
-- PRPs (blueprints): !`find .claude/blueprints/prps -maxdepth 1 -name '*.md' 2>/dev/null`
+- Rules directory: !`find .claude/rules -maxdepth 1 -name '*.md'`
+- ADRs (docs/adr): !`find docs/adr -maxdepth 1 -name '*.md'`
+- ADRs (docs/adrs): !`find docs/adrs -maxdepth 1 -name '*.md'`
+- PRDs (docs/prds): !`find docs/prds -maxdepth 1 -name '*.md'`
+- PRDs (blueprints): !`find .claude/blueprints/prds -maxdepth 1 -name '*.md'`
+- PRPs (docs/prps): !`find docs/prps -maxdepth 1 -name '*.md'`
+- PRPs (blueprints): !`find .claude/blueprints/prps -maxdepth 1 -name '*.md'`
 
 ## Parameters
 

--- a/code-quality-plugin/skills/dry-consolidation/SKILL.md
+++ b/code-quality-plugin/skills/dry-consolidation/SKILL.md
@@ -30,11 +30,11 @@ Systematic extraction of duplicated code into shared, tested abstractions.
 
 ## Context
 
-- Target path: !`echo "$1" 2>/dev/null`
-- Project type: !`find . -maxdepth 1 \( -name "package.json" -o -name "Cargo.toml" -o -name "pyproject.toml" -o -name "go.mod" \) 2>/dev/null`
-- Source directories: !`find . -maxdepth 1 -type d \( -name "src" -o -name "lib" -o -name "app" -o -name "components" -o -name "packages" \) 2>/dev/null`
-- Test framework: !`find . -maxdepth 2 \( -name "vitest.config.*" -o -name "jest.config.*" -o -name "pytest.ini" -o -name "conftest.py" \) 2>/dev/null`
-- Existing shared utilities: !`find . \( -path "*/lib/*" -o -path "*/utils/*" -o -path "*/shared/*" -o -path "*/common/*" -o -path "*/hooks/*" \) -type f -print -quit 2>/dev/null`
+- Target path: !`echo "$1"`
+- Project type: !`find . -maxdepth 1 \( -name "package.json" -o -name "Cargo.toml" -o -name "pyproject.toml" -o -name "go.mod" \)`
+- Source directories: !`find . -maxdepth 1 -type d \( -name "src" -o -name "lib" -o -name "app" -o -name "components" -o -name "packages" \)`
+- Test framework: !`find . -maxdepth 2 \( -name "vitest.config.*" -o -name "jest.config.*" -o -name "pytest.ini" -o -name "conftest.py" \)`
+- Existing shared utilities: !`find . \( -path "*/lib/*" -o -path "*/utils/*" -o -path "*/shared/*" -o -path "*/common/*" -o -path "*/hooks/*" \) -type f -print -quit`
 
 ## Parameters
 

--- a/component-patterns-plugin/skills/components-version-badge/SKILL.md
+++ b/component-patterns-plugin/skills/components-version-badge/SKILL.md
@@ -15,12 +15,12 @@ Implement a version badge component that displays version number, git commit, an
 
 ## Context
 
-- Framework config: !`find . -maxdepth 1 \( -name "next.config.*" -o -name "nuxt.config.*" -o -name "svelte.config.*" -o -name "vite.config.*" \) 2>/dev/null`
-- Package manager: !`find . -maxdepth 1 \( -name "package.json" -o -name "bun.lockb" -o -name "pnpm-lock.yaml" \) 2>/dev/null`
-- Styling: !`find . -maxdepth 1 \( -name "tailwind.config.*" -o -name "postcss.config.*" \) 2>/dev/null`
-- UI library: !`find . -maxdepth 1 -name "components.json" 2>/dev/null`
-- Changelog: !`find . -maxdepth 1 -name \'CHANGELOG.md\' 2>/dev/null`
-- Version: !`jq -r '.version // "unknown"' package.json 2>/dev/null`
+- Framework config: !`find . -maxdepth 1 \( -name "next.config.*" -o -name "nuxt.config.*" -o -name "svelte.config.*" -o -name "vite.config.*" \)`
+- Package manager: !`find . -maxdepth 1 \( -name "package.json" -o -name "bun.lockb" -o -name "pnpm-lock.yaml" \)`
+- Styling: !`find . -maxdepth 1 \( -name "tailwind.config.*" -o -name "postcss.config.*" \)`
+- UI library: !`find . -maxdepth 1 -name "components.json"`
+- Changelog: !`find . -maxdepth 1 -name \'CHANGELOG.md\'`
+- Version: !`jq -r '.version // "unknown"' package.json`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-all/SKILL.md
+++ b/configure-plugin/skills/configure-all/SKILL.md
@@ -25,10 +25,10 @@ Run all infrastructure standards compliance checks.
 
 ## Context
 
-- Project standards: !`find . -maxdepth 1 -name \'.project-standards.yaml\' 2>/dev/null`
-- Project type indicators: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name '*.tf' \) 2>/dev/null`
-- Infrastructure dirs: !`find . -maxdepth 1 -type d \( -name 'terraform' -o -name 'helm' -o -name 'argocd' \) 2>/dev/null`
-- Current standards version: !`grep -m1 "^standards_version:" .project-standards.yaml 2>/dev/null`
+- Project standards: !`find . -maxdepth 1 -name \'.project-standards.yaml\'`
+- Project type indicators: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name '*.tf' \)`
+- Infrastructure dirs: !`find . -maxdepth 1 -type d \( -name 'terraform' -o -name 'helm' -o -name 'argocd' \)`
+- Current standards version: !`grep -m1 "^standards_version:" .project-standards.yaml`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-api-tests/SKILL.md
+++ b/configure-plugin/skills/configure-api-tests/SKILL.md
@@ -26,12 +26,12 @@ Check and configure API contract testing infrastructure for validating API contr
 ## Context
 
 - Project root: !`pwd`
-- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' \) 2>/dev/null`
-- Pact deps: !`grep -l 'pact' package.json pyproject.toml 2>/dev/null`
-- OpenAPI spec: !`find . -maxdepth 1 \( -name 'openapi.yaml' -o -name 'openapi.json' -o -name 'swagger.json' \) 2>/dev/null`
-- Pact dir: !`find . -maxdepth 1 -type d -name 'pacts' 2>/dev/null`
-- Contract tests: !`find tests -maxdepth 2 -type d -name 'contract' 2>/dev/null`
-- Project standards: !`find . -maxdepth 1 -name '.project-standards.yaml' 2>/dev/null`
+- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' \)`
+- Pact deps: !`grep -l 'pact' package.json pyproject.toml`
+- OpenAPI spec: !`find . -maxdepth 1 \( -name 'openapi.yaml' -o -name 'openapi.json' -o -name 'swagger.json' \)`
+- Pact dir: !`find . -maxdepth 1 -type d -name 'pacts'`
+- Contract tests: !`find tests -maxdepth 2 -type d -name 'contract'`
+- Project standards: !`find . -maxdepth 1 -name '.project-standards.yaml'`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-argocd-automerge/SKILL.md
+++ b/configure-plugin/skills/configure-argocd-automerge/SKILL.md
@@ -25,10 +25,10 @@ Configure GitHub Actions workflow to automatically create and merge PRs from Arg
 
 ## Context
 
-- Workflows dir: !`find . -maxdepth 1 -type d -name \'.github/workflows\' 2>/dev/null`
-- Existing automerge workflow: !`find .github/workflows -maxdepth 1 \( -name '*argocd*automerge*' -o -name '*automerge*argocd*' \) 2>/dev/null`
-- Image updater branches: !`git branch -r --list 'origin/image-updater-*' 2>/dev/null`
-- Auto-merge workflow: !`find .github/workflows -maxdepth 1 -name 'argocd-automerge.yml' 2>/dev/null`
+- Workflows dir: !`find . -maxdepth 1 -type d -name \'.github/workflows\'`
+- Existing automerge workflow: !`find .github/workflows -maxdepth 1 \( -name '*argocd*automerge*' -o -name '*automerge*argocd*' \)`
+- Image updater branches: !`git branch -r --list 'origin/image-updater-*'`
+- Auto-merge workflow: !`find .github/workflows -maxdepth 1 -name 'argocd-automerge.yml'`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-cache-busting/SKILL.md
+++ b/configure-plugin/skills/configure-cache-busting/SKILL.md
@@ -22,12 +22,12 @@ name: configure-cache-busting
 ## Context
 
 - Project root: !`pwd`
-- Package files: !`find . -maxdepth 1 -name 'package.json' 2>/dev/null`
-- Next.js config: !`find . -maxdepth 1 -name 'next.config.*' 2>/dev/null`
-- Vite config: !`find . -maxdepth 1 -name 'vite.config.*' 2>/dev/null`
-- Build output: !`find . -maxdepth 1 -type d \( -name '.next' -o -name 'dist' -o -name 'out' \) 2>/dev/null`
-- CDN config: !`find . -maxdepth 2 \( -path './vercel.json' -o -path './_headers' -o -path './_redirects' -o -path './public/_headers' \) 2>/dev/null`
-- Project standards: !`find . -maxdepth 1 -name '.project-standards.yaml' 2>/dev/null`
+- Package files: !`find . -maxdepth 1 -name 'package.json'`
+- Next.js config: !`find . -maxdepth 1 -name 'next.config.*'`
+- Vite config: !`find . -maxdepth 1 -name 'vite.config.*'`
+- Build output: !`find . -maxdepth 1 -type d \( -name '.next' -o -name 'dist' -o -name 'out' \)`
+- CDN config: !`find . -maxdepth 2 \( -path './vercel.json' -o -path './_headers' -o -path './_redirects' -o -path './public/_headers' \)`
+- Project standards: !`find . -maxdepth 1 -name '.project-standards.yaml'`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-claude-plugins/SKILL.md
+++ b/configure-plugin/skills/configure-claude-plugins/SKILL.md
@@ -25,11 +25,11 @@ Configure a project to use the `laurigates/claude-plugins` Claude Code plugin ma
 
 ## Context
 
-- Settings file exists: !`find . -maxdepth 1 -name \'.claude/settings.json\' 2>/dev/null`
-- Workflows: !`find .github/workflows -maxdepth 1 -name 'claude*.yml' 2>/dev/null`
-- Git remote: !`git remote get-url origin 2>/dev/null`
-- Project type indicators: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'Dockerfile' \) 2>/dev/null`
-- Existing workflows dir: !`find . -maxdepth 1 -type d -name \'.github/workflows\' 2>/dev/null`
+- Settings file exists: !`find . -maxdepth 1 -name \'.claude/settings.json\'`
+- Workflows: !`find .github/workflows -maxdepth 1 -name 'claude*.yml'`
+- Git remote: !`git remote get-url origin`
+- Project type indicators: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'Dockerfile' \)`
+- Existing workflows dir: !`find . -maxdepth 1 -type d -name \'.github/workflows\'`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-container/SKILL.md
+++ b/configure-plugin/skills/configure-container/SKILL.md
@@ -25,13 +25,13 @@ Check and configure comprehensive container infrastructure against project stand
 
 ## Context
 
-- Dockerfiles: !`find . -maxdepth 2 \( -name 'Dockerfile' -o -name 'Dockerfile.*' -o -name '*.Dockerfile' \) 2>/dev/null`
-- Docker ignore: !`find . -maxdepth 1 -name '.dockerignore' 2>/dev/null`
-- Container workflows: !`find .github/workflows -maxdepth 1 \( -name '*container*' -o -name '*docker*' -o -name '*build*' \) 2>/dev/null`
-- Devcontainer: !`find .devcontainer -maxdepth 1 -name 'devcontainer.json' 2>/dev/null`
-- Skaffold: !`find . -maxdepth 1 -name 'skaffold.yaml' 2>/dev/null`
-- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \) 2>/dev/null`
-- Project standards: !`find . -maxdepth 1 -name '.project-standards.yaml' 2>/dev/null`
+- Dockerfiles: !`find . -maxdepth 2 \( -name 'Dockerfile' -o -name 'Dockerfile.*' -o -name '*.Dockerfile' \)`
+- Docker ignore: !`find . -maxdepth 1 -name '.dockerignore'`
+- Container workflows: !`find .github/workflows -maxdepth 1 \( -name '*container*' -o -name '*docker*' -o -name '*build*' \)`
+- Devcontainer: !`find .devcontainer -maxdepth 1 -name 'devcontainer.json'`
+- Skaffold: !`find . -maxdepth 1 -name 'skaffold.yaml'`
+- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \)`
+- Project standards: !`find . -maxdepth 1 -name '.project-standards.yaml'`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-coverage/SKILL.md
+++ b/configure-plugin/skills/configure-coverage/SKILL.md
@@ -26,12 +26,12 @@ Check and configure code coverage thresholds and reporting for test frameworks.
 ## Context
 
 - Project root: !`pwd`
-- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' \) 2>/dev/null`
-- Vitest config: !`find . -maxdepth 1 -name 'vitest.config.*' 2>/dev/null`
-- Jest config: !`find . -maxdepth 1 -name 'jest.config.*' 2>/dev/null`
-- Coverage dir: !`find . -maxdepth 1 -type d -name 'coverage' 2>/dev/null`
-- Codecov config: !`find . -maxdepth 1 \( -name 'codecov.yml' -o -name '.codecov.yml' \) 2>/dev/null`
-- Project standards: !`find . -maxdepth 1 -name '.project-standards.yaml' 2>/dev/null`
+- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' \)`
+- Vitest config: !`find . -maxdepth 1 -name 'vitest.config.*'`
+- Jest config: !`find . -maxdepth 1 -name 'jest.config.*'`
+- Coverage dir: !`find . -maxdepth 1 -type d -name 'coverage'`
+- Codecov config: !`find . -maxdepth 1 \( -name 'codecov.yml' -o -name '.codecov.yml' \)`
+- Project standards: !`find . -maxdepth 1 -name '.project-standards.yaml'`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-dead-code/SKILL.md
+++ b/configure-plugin/skills/configure-dead-code/SKILL.md
@@ -26,11 +26,11 @@ Check and configure dead code detection tools.
 ## Context
 
 - Project root: !`pwd`
-- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' \) 2>/dev/null`
-- Knip config: !`find . -maxdepth 1 \( -name 'knip.json' -o -name 'knip.config.*' \) 2>/dev/null`
-- Vulture config: !`find . -maxdepth 1 \( -name '.vulture' -o -name 'vulture.ini' \) 2>/dev/null`
-- Pre-commit: !`find . -maxdepth 1 -name '.pre-commit-config.yaml' 2>/dev/null`
-- Project standards: !`find . -maxdepth 1 -name '.project-standards.yaml' 2>/dev/null`
+- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' \)`
+- Knip config: !`find . -maxdepth 1 \( -name 'knip.json' -o -name 'knip.config.*' \)`
+- Vulture config: !`find . -maxdepth 1 \( -name '.vulture' -o -name 'vulture.ini' \)`
+- Pre-commit: !`find . -maxdepth 1 -name '.pre-commit-config.yaml'`
+- Project standards: !`find . -maxdepth 1 -name '.project-standards.yaml'`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-dockerfile/SKILL.md
+++ b/configure-plugin/skills/configure-dockerfile/SKILL.md
@@ -25,10 +25,10 @@ Check and configure Dockerfile against project standards with emphasis on **mini
 
 ## Context
 
-- Dockerfiles: !`find . -maxdepth 1 \( -name 'Dockerfile' -o -name 'Dockerfile.*' -o -name '*.Dockerfile' \) 2>/dev/null`
-- Dockerignore: !`find . -maxdepth 1 -name \'.dockerignore\' 2>/dev/null`
-- Project type: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \) -print -quit 2>/dev/null`
-- Base images: !`grep -hm5 '^FROM' Dockerfile Dockerfile.* *.Dockerfile 2>/dev/null`
+- Dockerfiles: !`find . -maxdepth 1 \( -name 'Dockerfile' -o -name 'Dockerfile.*' -o -name '*.Dockerfile' \)`
+- Dockerignore: !`find . -maxdepth 1 -name \'.dockerignore\'`
+- Project type: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \) -print -quit`
+- Base images: !`grep -hm5 '^FROM' Dockerfile Dockerfile.* *.Dockerfile`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-docs/SKILL.md
+++ b/configure-plugin/skills/configure-docs/SKILL.md
@@ -26,14 +26,14 @@ Check and configure code documentation standards and generators.
 ## Context
 
 - Project root: !`pwd`
-- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' \) 2>/dev/null`
-- Biome config: !`find . -maxdepth 1 -name 'biome.json' 2>/dev/null`
-- TSDoc config: !`find . -maxdepth 1 \( -name 'tsdoc.json' -o -name 'typedoc.json' \) 2>/dev/null`
-- Python config: !`find . -maxdepth 1 \( -name 'pyproject.toml' -o -name 'ruff.toml' -o -name '.ruff.toml' \) 2>/dev/null`
-- Rust config: !`find . -maxdepth 1 \( -name 'Cargo.toml' -o -name 'clippy.toml' \) 2>/dev/null`
-- Pre-commit: !`find . -maxdepth 1 -name '.pre-commit-config.yaml' 2>/dev/null`
-- Doc generators: !`find . -maxdepth 1 \( -name 'mkdocs.yml' -o -name 'docusaurus.config.*' \) 2>/dev/null`
-- Docs directory: !`find . -maxdepth 1 -type d -name 'docs' 2>/dev/null`
+- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' \)`
+- Biome config: !`find . -maxdepth 1 -name 'biome.json'`
+- TSDoc config: !`find . -maxdepth 1 \( -name 'tsdoc.json' -o -name 'typedoc.json' \)`
+- Python config: !`find . -maxdepth 1 \( -name 'pyproject.toml' -o -name 'ruff.toml' -o -name '.ruff.toml' \)`
+- Rust config: !`find . -maxdepth 1 \( -name 'Cargo.toml' -o -name 'clippy.toml' \)`
+- Pre-commit: !`find . -maxdepth 1 -name '.pre-commit-config.yaml'`
+- Doc generators: !`find . -maxdepth 1 \( -name 'mkdocs.yml' -o -name 'docusaurus.config.*' \)`
+- Docs directory: !`find . -maxdepth 1 -type d -name 'docs'`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-editor/SKILL.md
+++ b/configure-plugin/skills/configure-editor/SKILL.md
@@ -25,13 +25,13 @@ Check and configure editor settings for consistency across the team.
 
 ## Context
 
-- EditorConfig: !`find . -maxdepth 1 -name \'.editorconfig\' 2>/dev/null`
-- VS Code settings: !`find . -maxdepth 1 -name \'.vscode/settings.json\' 2>/dev/null`
-- VS Code extensions: !`find . -maxdepth 1 -name \'.vscode/extensions.json\' 2>/dev/null`
-- VS Code launch: !`find . -maxdepth 1 -name \'.vscode/launch.json\' 2>/dev/null`
-- VS Code tasks: !`find . -maxdepth 1 -name \'.vscode/tasks.json\' 2>/dev/null`
-- Project languages: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'tsconfig.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'biome.json' \) 2>/dev/null`
-- Project standards: !`find . -maxdepth 1 -name \'.project-standards.yaml\' 2>/dev/null`
+- EditorConfig: !`find . -maxdepth 1 -name \'.editorconfig\'`
+- VS Code settings: !`find . -maxdepth 1 -name \'.vscode/settings.json\'`
+- VS Code extensions: !`find . -maxdepth 1 -name \'.vscode/extensions.json\'`
+- VS Code launch: !`find . -maxdepth 1 -name \'.vscode/launch.json\'`
+- VS Code tasks: !`find . -maxdepth 1 -name \'.vscode/tasks.json\'`
+- Project languages: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'tsconfig.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'biome.json' \)`
+- Project standards: !`find . -maxdepth 1 -name \'.project-standards.yaml\'`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-feature-flags/SKILL.md
+++ b/configure-plugin/skills/configure-feature-flags/SKILL.md
@@ -25,14 +25,14 @@ Check and configure feature flag infrastructure using the OpenFeature standard w
 
 ## Context
 
-- Package JSON: !`find . -maxdepth 1 -name \'package.json\' 2>/dev/null`
-- Python project: !`find . -maxdepth 1 -name \'pyproject.toml\' 2>/dev/null`
-- Go project: !`find . -maxdepth 1 -name \'go.mod\' 2>/dev/null`
-- Cargo project: !`find . -maxdepth 1 -name \'Cargo.toml\' 2>/dev/null`
-- OpenFeature SDK: !`grep -l 'openfeature' package.json pyproject.toml Cargo.toml go.mod 2>/dev/null`
-- GOFF config: !`find . -maxdepth 2 -name 'flags.goff.yaml' -o -name 'flags.goff.yml' 2>/dev/null`
-- Docker compose: !`find . -maxdepth 1 -name 'docker-compose*.yml' -o -name 'docker-compose*.yaml' 2>/dev/null`
-- Project standards: !`find . -maxdepth 1 -name \'.project-standards.yaml\' 2>/dev/null`
+- Package JSON: !`find . -maxdepth 1 -name \'package.json\'`
+- Python project: !`find . -maxdepth 1 -name \'pyproject.toml\'`
+- Go project: !`find . -maxdepth 1 -name \'go.mod\'`
+- Cargo project: !`find . -maxdepth 1 -name \'Cargo.toml\'`
+- OpenFeature SDK: !`grep -l 'openfeature' package.json pyproject.toml Cargo.toml go.mod`
+- GOFF config: !`find . -maxdepth 2 -name 'flags.goff.yaml' -o -name 'flags.goff.yml'`
+- Docker compose: !`find . -maxdepth 1 -name 'docker-compose*.yml' -o -name 'docker-compose*.yaml'`
+- Project standards: !`find . -maxdepth 1 -name \'.project-standards.yaml\'`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-formatting/SKILL.md
+++ b/configure-plugin/skills/configure-formatting/SKILL.md
@@ -25,17 +25,17 @@ Check and configure code formatting tools against modern best practices.
 
 ## Context
 
-- Biome config: !`find . -maxdepth 1 -name \'biome.json\' 2>/dev/null`
-- Prettier config: !`find . -maxdepth 1 \( -name '.prettierrc*' -o -name 'prettier.config.*' \) 2>/dev/null`
-- Ruff config: !`grep -l 'tool.ruff.format' pyproject.toml 2>/dev/null`
-- Black config: !`grep -l 'tool.black' pyproject.toml 2>/dev/null`
-- Rustfmt config: !`find . -maxdepth 1 \( -name 'rustfmt.toml' -o -name '.rustfmt.toml' \) 2>/dev/null`
-- EditorConfig: !`find . -maxdepth 1 -name \'.editorconfig\' 2>/dev/null`
-- Package JSON: !`find . -maxdepth 1 -name \'package.json\' 2>/dev/null`
-- Python project: !`find . -maxdepth 1 -name \'pyproject.toml\' 2>/dev/null`
-- Rust project: !`find . -maxdepth 1 -name \'Cargo.toml\' 2>/dev/null`
-- Pre-commit: !`find . -maxdepth 1 -name \'.pre-commit-config.yaml\' 2>/dev/null`
-- Project standards: !`find . -maxdepth 1 -name \'.project-standards.yaml\' 2>/dev/null`
+- Biome config: !`find . -maxdepth 1 -name \'biome.json\'`
+- Prettier config: !`find . -maxdepth 1 \( -name '.prettierrc*' -o -name 'prettier.config.*' \)`
+- Ruff config: !`grep -l 'tool.ruff.format' pyproject.toml`
+- Black config: !`grep -l 'tool.black' pyproject.toml`
+- Rustfmt config: !`find . -maxdepth 1 \( -name 'rustfmt.toml' -o -name '.rustfmt.toml' \)`
+- EditorConfig: !`find . -maxdepth 1 -name \'.editorconfig\'`
+- Package JSON: !`find . -maxdepth 1 -name \'package.json\'`
+- Python project: !`find . -maxdepth 1 -name \'pyproject.toml\'`
+- Rust project: !`find . -maxdepth 1 -name \'Cargo.toml\'`
+- Pre-commit: !`find . -maxdepth 1 -name \'.pre-commit-config.yaml\'`
+- Project standards: !`find . -maxdepth 1 -name \'.project-standards.yaml\'`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-github-pages/SKILL.md
+++ b/configure-plugin/skills/configure-github-pages/SKILL.md
@@ -25,11 +25,11 @@ Check and configure GitHub Pages deployment.
 
 ## Context
 
-- GitHub workflows: !`find .github/workflows -maxdepth 1 \( -name '*doc*.yml' -o -name '*pages*.yml' \) 2>/dev/null`
-- Documentation config: !`find . -maxdepth 1 \( -name 'mkdocs.yml' -o -name 'typedoc.json' -o -name 'docusaurus.config.*' \) 2>/dev/null`
-- Docs directory: !`find . -maxdepth 1 -type d \( -name 'docs' -o -name 'site' \) 2>/dev/null`
-- CNAME file: !`find . -maxdepth 1 -name 'CNAME' 2>/dev/null`
-- Project standards: !`find . -maxdepth 1 -name '.project-standards.yaml' 2>/dev/null`
+- GitHub workflows: !`find .github/workflows -maxdepth 1 \( -name '*doc*.yml' -o -name '*pages*.yml' \)`
+- Documentation config: !`find . -maxdepth 1 \( -name 'mkdocs.yml' -o -name 'typedoc.json' -o -name 'docusaurus.config.*' \)`
+- Docs directory: !`find . -maxdepth 1 -type d \( -name 'docs' -o -name 'site' \)`
+- CNAME file: !`find . -maxdepth 1 -name 'CNAME'`
+- Project standards: !`find . -maxdepth 1 -name '.project-standards.yaml'`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-integration-tests/SKILL.md
+++ b/configure-plugin/skills/configure-integration-tests/SKILL.md
@@ -26,13 +26,13 @@ Check and configure integration testing infrastructure for testing service inter
 ## Context
 
 - Project root: !`pwd`
-- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \) 2>/dev/null`
-- Integration tests dir: !`find tests -maxdepth 1 -type d -name 'integration' 2>/dev/null`
-- Docker compose test: !`find . -maxdepth 1 -name 'docker-compose.test.yml' 2>/dev/null`
-- Vitest integration config: !`find . -maxdepth 1 -name 'vitest.integration.config.*' 2>/dev/null`
-- Supertest dep: !`grep -l 'supertest' package.json 2>/dev/null`
-- Testcontainers dep: !`grep -l 'testcontainers' package.json pyproject.toml 2>/dev/null`
-- Project standards: !`find . -maxdepth 1 -name '.project-standards.yaml' 2>/dev/null`
+- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \)`
+- Integration tests dir: !`find tests -maxdepth 1 -type d -name 'integration'`
+- Docker compose test: !`find . -maxdepth 1 -name 'docker-compose.test.yml'`
+- Vitest integration config: !`find . -maxdepth 1 -name 'vitest.integration.config.*'`
+- Supertest dep: !`grep -l 'supertest' package.json`
+- Testcontainers dep: !`grep -l 'testcontainers' package.json pyproject.toml`
+- Project standards: !`find . -maxdepth 1 -name '.project-standards.yaml'`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-justfile/SKILL.md
+++ b/configure-plugin/skills/configure-justfile/SKILL.md
@@ -26,12 +26,12 @@ Check and configure project Justfile against project standards.
 ## Context
 
 - Project root: !`pwd`
-- Justfile: !`find . -maxdepth 1 \( -name 'justfile' -o -name 'Justfile' \) 2>/dev/null`
-- Makefile: !`find . -maxdepth 1 -name 'Makefile' 2>/dev/null`
-- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \) 2>/dev/null`
-- Docker files: !`find . -maxdepth 1 \( -name 'Dockerfile' -o -name 'docker-compose.yml' \) 2>/dev/null`
-- Env file: !`find . -maxdepth 1 -name '.env' 2>/dev/null`
-- Project standards: !`find . -maxdepth 1 -name '.project-standards.yaml' 2>/dev/null`
+- Justfile: !`find . -maxdepth 1 \( -name 'justfile' -o -name 'Justfile' \)`
+- Makefile: !`find . -maxdepth 1 -name 'Makefile'`
+- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \)`
+- Docker files: !`find . -maxdepth 1 \( -name 'Dockerfile' -o -name 'docker-compose.yml' \)`
+- Env file: !`find . -maxdepth 1 -name '.env'`
+- Project standards: !`find . -maxdepth 1 -name '.project-standards.yaml'`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-linting/SKILL.md
+++ b/configure-plugin/skills/configure-linting/SKILL.md
@@ -26,13 +26,13 @@ Check and configure linting tools against modern best practices.
 ## Context
 
 - Project root: !`pwd`
-- Biome config: !`find . -maxdepth 1 -name 'biome.json' -o -name 'biome.jsonc' 2>/dev/null`
-- Ruff config: !`grep -l 'tool.ruff' pyproject.toml 2>/dev/null`
-- Clippy config: !`grep -l 'lints.clippy' Cargo.toml 2>/dev/null`
-- Legacy linters: !`find . -maxdepth 1 \( -name '.eslintrc*' -o -name '.flake8' -o -name '.pylintrc' \) 2>/dev/null`
-- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' \) 2>/dev/null`
-- Pre-commit config: !`find . -maxdepth 1 -name '.pre-commit-config.yaml' 2>/dev/null`
-- CI workflows: !`find .github/workflows -maxdepth 1 -name '*.yml' 2>/dev/null`
+- Biome config: !`find . -maxdepth 1 -name 'biome.json' -o -name 'biome.jsonc'`
+- Ruff config: !`grep -l 'tool.ruff' pyproject.toml`
+- Clippy config: !`grep -l 'lints.clippy' Cargo.toml`
+- Legacy linters: !`find . -maxdepth 1 \( -name '.eslintrc*' -o -name '.flake8' -o -name '.pylintrc' \)`
+- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' \)`
+- Pre-commit config: !`find . -maxdepth 1 -name '.pre-commit-config.yaml'`
+- CI workflows: !`find .github/workflows -maxdepth 1 -name '*.yml'`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-load-tests/SKILL.md
+++ b/configure-plugin/skills/configure-load-tests/SKILL.md
@@ -26,13 +26,13 @@ Check and configure load and performance testing infrastructure for stress testi
 ## Context
 
 - Project root: !`pwd`
-- k6 tests: !`find . -maxdepth 3 \( -name '*.k6.js' -o -name '*.k6.ts' \) 2>/dev/null`
-- Load test directory: !`find . -maxdepth 2 -type d -name 'load' 2>/dev/null`
-- Artillery config: !`find . -maxdepth 2 -name 'artillery.yml' -o -name 'artillery.yaml' 2>/dev/null`
-- Locust files: !`find . -maxdepth 2 -name 'locustfile.py' 2>/dev/null`
-- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' \) 2>/dev/null`
-- CI workflows: !`find .github/workflows -maxdepth 1 -name '*load*' -o -name '*perf*' 2>/dev/null`
-- k6 binary: !`command -v k6 2>/dev/null`
+- k6 tests: !`find . -maxdepth 3 \( -name '*.k6.js' -o -name '*.k6.ts' \)`
+- Load test directory: !`find . -maxdepth 2 -type d -name 'load'`
+- Artillery config: !`find . -maxdepth 2 -name 'artillery.yml' -o -name 'artillery.yaml'`
+- Locust files: !`find . -maxdepth 2 -name 'locustfile.py'`
+- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' \)`
+- CI workflows: !`find .github/workflows -maxdepth 1 -name '*load*' -o -name '*perf*'`
+- k6 binary: !`command -v k6`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-makefile/SKILL.md
+++ b/configure-plugin/skills/configure-makefile/SKILL.md
@@ -26,11 +26,11 @@ Check and configure project Makefile against project standards.
 ## Context
 
 - Project root: !`pwd`
-- Makefile exists: !`find . -maxdepth 1 -name 'Makefile' 2>/dev/null`
-- Makefile targets: !`grep -E '^[a-zA-Z_-]+:' Makefile 2>/dev/null`
-- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \) 2>/dev/null`
-- Docker files: !`find . -maxdepth 1 \( -name 'Dockerfile' -o -name 'docker-compose.yml' -o -name 'compose.yml' \) 2>/dev/null`
-- Server files: !`find src -maxdepth 1 \( -name 'server.*' -o -name 'main.*' \) 2>/dev/null`
+- Makefile exists: !`find . -maxdepth 1 -name 'Makefile'`
+- Makefile targets: !`grep -E '^[a-zA-Z_-]+:' Makefile`
+- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \)`
+- Docker files: !`find . -maxdepth 1 \( -name 'Dockerfile' -o -name 'docker-compose.yml' -o -name 'compose.yml' \)`
+- Server files: !`find src -maxdepth 1 \( -name 'server.*' -o -name 'main.*' \)`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-mcp/SKILL.md
+++ b/configure-plugin/skills/configure-mcp/SKILL.md
@@ -29,14 +29,14 @@ For server configurations, environment variable reference, and report templates,
 
 ## Context
 
-- Config exists: !`find . -maxdepth 1 -name \'.mcp.json\' 2>/dev/null`
-- Config contents: !`cat .mcp.json 2>/dev/null`
-- Installed servers: !`jq -r '.mcpServers' .mcp.json 2>/dev/null`
-- Git tracking: !`grep '.mcp.json' .gitignore 2>/dev/null`
-- Standards file: !`find . -maxdepth 1 -name \'.project-standards.yaml\' 2>/dev/null`
-- Has playwright config: !`find . -maxdepth 1 -name 'playwright.config.*' -print -quit 2>/dev/null`
-- Has TS/JS files: !`find . -maxdepth 2 \( -name '*.ts' -o -name '*.py' -o -name '*.go' -o -name '*.rs' \) -print -quit 2>/dev/null`
-- Dotfiles registry: !`find . -maxdepth 1 -name \'~/.local/share/chezmoi/.chezmoidata.toml\' 2>/dev/null`
+- Config exists: !`find . -maxdepth 1 -name \'.mcp.json\'`
+- Config contents: !`cat .mcp.json`
+- Installed servers: !`jq -r '.mcpServers' .mcp.json`
+- Git tracking: !`grep '.mcp.json' .gitignore`
+- Standards file: !`find . -maxdepth 1 -name \'.project-standards.yaml\'`
+- Has playwright config: !`find . -maxdepth 1 -name 'playwright.config.*' -print -quit`
+- Has TS/JS files: !`find . -maxdepth 2 \( -name '*.ts' -o -name '*.py' -o -name '*.go' -o -name '*.rs' \) -print -quit`
+- Dotfiles registry: !`find . -maxdepth 1 -name \'~/.local/share/chezmoi/.chezmoidata.toml\'`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-memory-profiling/SKILL.md
+++ b/configure-plugin/skills/configure-memory-profiling/SKILL.md
@@ -26,14 +26,14 @@ Check and configure memory profiling infrastructure for Python projects using py
 ## Context
 
 - Project root: !`pwd`
-- Python project: !`find . -maxdepth 1 \( -name 'pyproject.toml' -o -name 'setup.py' \) 2>/dev/null`
-- pytest-memray installed: !`grep -r 'pytest-memray' pyproject.toml requirements*.txt 2>/dev/null`
-- memray installed: !`grep -r 'memray' pyproject.toml requirements*.txt 2>/dev/null`
-- Conftest fixtures: !`grep -l 'memray' tests/conftest.py 2>/dev/null`
-- Memory test files: !`find tests -maxdepth 2 -name '*memory*' -o -name '*memray*' 2>/dev/null`
-- Benchmark tests: !`find tests -maxdepth 2 -type d -name 'benchmarks' 2>/dev/null`
-- CI workflows: !`find .github/workflows -maxdepth 1 -name '*memory*' 2>/dev/null`
-- Memory reports dir: !`find . -maxdepth 1 -type d -name 'memory-reports' 2>/dev/null`
+- Python project: !`find . -maxdepth 1 \( -name 'pyproject.toml' -o -name 'setup.py' \)`
+- pytest-memray installed: !`grep -r 'pytest-memray' pyproject.toml requirements*.txt`
+- memray installed: !`grep -r 'memray' pyproject.toml requirements*.txt`
+- Conftest fixtures: !`grep -l 'memray' tests/conftest.py`
+- Memory test files: !`find tests -maxdepth 2 -name '*memory*' -o -name '*memray*'`
+- Benchmark tests: !`find tests -maxdepth 2 -type d -name 'benchmarks'`
+- CI workflows: !`find .github/workflows -maxdepth 1 -name '*memory*'`
+- Memory reports dir: !`find . -maxdepth 1 -type d -name 'memory-reports'`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-package-management/SKILL.md
+++ b/configure-plugin/skills/configure-package-management/SKILL.md
@@ -26,11 +26,11 @@ Check and configure modern package managers for optimal development experience.
 ## Context
 
 - Project root: !`pwd`
-- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \) 2>/dev/null`
-- Lock files: !`find . -maxdepth 1 \( -name 'uv.lock' -o -name 'bun.lockb' -o -name 'package-lock.json' -o -name 'yarn.lock' -o -name 'pnpm-lock.yaml' -o -name 'poetry.lock' -o -name 'Pipfile.lock' \) 2>/dev/null`
-- Python venv: !`find . -maxdepth 1 -type d -name '.venv' 2>/dev/null`
-- Legacy files: !`find . -maxdepth 1 \( -name 'requirements.txt' -o -name 'Pipfile' \) 2>/dev/null`
-- Project standards: !`find . -maxdepth 1 -name '.project-standards.yaml' 2>/dev/null`
+- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \)`
+- Lock files: !`find . -maxdepth 1 \( -name 'uv.lock' -o -name 'bun.lockb' -o -name 'package-lock.json' -o -name 'yarn.lock' -o -name 'pnpm-lock.yaml' -o -name 'poetry.lock' -o -name 'Pipfile.lock' \)`
+- Python venv: !`find . -maxdepth 1 -type d -name '.venv'`
+- Legacy files: !`find . -maxdepth 1 \( -name 'requirements.txt' -o -name 'Pipfile' \)`
+- Project standards: !`find . -maxdepth 1 -name '.project-standards.yaml'`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-pre-commit/SKILL.md
+++ b/configure-plugin/skills/configure-pre-commit/SKILL.md
@@ -25,13 +25,13 @@ Check and configure pre-commit hooks against project standards.
 
 ## Context
 
-- Pre-commit config: !`find . -maxdepth 1 -name \'.pre-commit-config.yaml\' 2>/dev/null`
-- Project standards: !`find . -maxdepth 1 -name \'.project-standards.yaml\' 2>/dev/null`
-- Project type in standards: !`grep -m1 "^project_type:" .project-standards.yaml 2>/dev/null`
-- Has terraform: !`find . -maxdepth 2 \( -name '*.tf' -o -type d -name 'terraform' \) -print -quit 2>/dev/null`
-- Has helm: !`find . -maxdepth 2 -type d -name 'helm' -print -quit 2>/dev/null`
-- Has package.json: !`find . -maxdepth 1 -name \'package.json\' 2>/dev/null`
-- Has pyproject.toml: !`find . -maxdepth 1 -name \'pyproject.toml\' 2>/dev/null`
+- Pre-commit config: !`find . -maxdepth 1 -name \'.pre-commit-config.yaml\'`
+- Project standards: !`find . -maxdepth 1 -name \'.project-standards.yaml\'`
+- Project type in standards: !`grep -m1 "^project_type:" .project-standards.yaml`
+- Has terraform: !`find . -maxdepth 2 \( -name '*.tf' -o -type d -name 'terraform' \) -print -quit`
+- Has helm: !`find . -maxdepth 2 -type d -name 'helm' -print -quit`
+- Has package.json: !`find . -maxdepth 1 -name \'package.json\'`
+- Has pyproject.toml: !`find . -maxdepth 1 -name \'pyproject.toml\'`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-readme/SKILL.md
+++ b/configure-plugin/skills/configure-readme/SKILL.md
@@ -23,12 +23,12 @@ name: configure-readme
 
 - Project root: !`pwd`
 - Project name: !`basename $(pwd)`
-- README exists: !`find . -maxdepth 1 -name 'README.md' 2>/dev/null`
-- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \) 2>/dev/null`
-- Git remote: !`git remote get-url origin 2>/dev/null`
-- License file: !`find . -maxdepth 1 -name 'LICENSE*' 2>/dev/null`
-- Assets directory: !`find . -maxdepth 2 -type d \( -name 'assets' -o -name 'public' -o -name 'images' \) 2>/dev/null`
-- Logo files: !`find . -maxdepth 3 -type f \( -name 'logo*' -o -name 'icon*' \) 2>/dev/null`
+- README exists: !`find . -maxdepth 1 -name 'README.md'`
+- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \)`
+- Git remote: !`git remote get-url origin`
+- License file: !`find . -maxdepth 1 -name 'LICENSE*'`
+- Assets directory: !`find . -maxdepth 2 -type d \( -name 'assets' -o -name 'public' -o -name 'images' \)`
+- Logo files: !`find . -maxdepth 3 -type f \( -name 'logo*' -o -name 'icon*' \)`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-release-please/SKILL.md
+++ b/configure-plugin/skills/configure-release-please/SKILL.md
@@ -25,11 +25,11 @@ Check and configure release-please against project standards.
 
 ## Context
 
-- Workflow file: !`find .github/workflows -maxdepth 1 -name 'release-please*' 2>/dev/null`
-- Config file: !`find . -maxdepth 1 -name \'release-please-config.json\' 2>/dev/null`
-- Manifest file: !`find . -maxdepth 1 -name \'.release-please-manifest.json\' 2>/dev/null`
-- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \) 2>/dev/null`
-- Workflows dir: !`find . -maxdepth 1 -type d -name \'.github/workflows\' 2>/dev/null`
+- Workflow file: !`find .github/workflows -maxdepth 1 -name 'release-please*'`
+- Config file: !`find . -maxdepth 1 -name \'release-please-config.json\'`
+- Manifest file: !`find . -maxdepth 1 -name \'.release-please-manifest.json\'`
+- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \)`
+- Workflows dir: !`find . -maxdepth 1 -type d -name \'.github/workflows\'`
 
 **Skills referenced**: `release-please-standards`, `release-please-protection`
 

--- a/configure-plugin/skills/configure-reusable-workflows/SKILL.md
+++ b/configure-plugin/skills/configure-reusable-workflows/SKILL.md
@@ -25,11 +25,11 @@ Install Claude-powered reusable GitHub Actions workflows from claude-plugins int
 
 ## Context
 
-- Workflows dir: !`find . -maxdepth 1 -type d -name \'.github/workflows\' 2>/dev/null`
-- Existing callers: !`find .github/workflows -maxdepth 1 -name 'claude-*' 2>/dev/null`
-- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \) -print -quit 2>/dev/null`
-- TypeScript files: !`find . -maxdepth 2 \( -name '*.ts' -o -name '*.tsx' \) -print -quit 2>/dev/null`
-- Component files: !`find . -maxdepth 3 \( -name '*.jsx' -o -name '*.vue' -o -name '*.svelte' \) -print -quit 2>/dev/null`
+- Workflows dir: !`find . -maxdepth 1 -type d -name \'.github/workflows\'`
+- Existing callers: !`find .github/workflows -maxdepth 1 -name 'claude-*'`
+- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \) -print -quit`
+- TypeScript files: !`find . -maxdepth 2 \( -name '*.ts' -o -name '*.tsx' \) -print -quit`
+- Component files: !`find . -maxdepth 3 \( -name '*.jsx' -o -name '*.vue' -o -name '*.svelte' \) -print -quit`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-security/SKILL.md
+++ b/configure-plugin/skills/configure-security/SKILL.md
@@ -25,13 +25,13 @@ Check and configure security scanning tools for dependency audits, SAST, and sec
 
 ## Context
 
-- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \) 2>/dev/null`
-- Gitleaks config: !`find . -maxdepth 1 -name \'.gitleaks.toml\' 2>/dev/null`
-- Pre-commit config: !`find . -maxdepth 1 -name \'.pre-commit-config.yaml\' 2>/dev/null`
-- Workflows dir: !`find . -maxdepth 1 -type d -name \'.github/workflows\' 2>/dev/null`
-- Dependabot config: !`find . -maxdepth 1 -name \'.github/dependabot.yml\' 2>/dev/null`
-- CodeQL workflow: !`find .github/workflows -maxdepth 1 -name 'codeql*' 2>/dev/null`
-- Security policy: !`find . -maxdepth 1 -name \'SECURITY.md\' 2>/dev/null`
+- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \)`
+- Gitleaks config: !`find . -maxdepth 1 -name \'.gitleaks.toml\'`
+- Pre-commit config: !`find . -maxdepth 1 -name \'.pre-commit-config.yaml\'`
+- Workflows dir: !`find . -maxdepth 1 -type d -name \'.github/workflows\'`
+- Dependabot config: !`find . -maxdepth 1 -name \'.github/dependabot.yml\'`
+- CodeQL workflow: !`find .github/workflows -maxdepth 1 -name 'codeql*'`
+- Security policy: !`find . -maxdepth 1 -name \'SECURITY.md\'`
 **Security scanning layers:**
 1. **Dependency auditing** - Check for known vulnerabilities in dependencies
 2. **SAST (Static Application Security Testing)** - Analyze code for security issues

--- a/configure-plugin/skills/configure-select/SKILL.md
+++ b/configure-plugin/skills/configure-select/SKILL.md
@@ -25,12 +25,12 @@ Interactively select which infrastructure standards checks to run.
 
 ## Context
 
-- Project standards: !`find . -maxdepth 1 -name \'.project-standards.yaml\' 2>/dev/null`
-- Project type: !`grep -m1 "^project_type:" .project-standards.yaml 2>/dev/null`
-- Has terraform: !`find . -maxdepth 2 \( -name '*.tf' -o -type d -name 'terraform' \) -print -quit 2>/dev/null`
-- Has package.json: !`find . -maxdepth 1 -name \'package.json\' 2>/dev/null`
-- Has pyproject.toml: !`find . -maxdepth 1 -name \'pyproject.toml\' 2>/dev/null`
-- Has Cargo.toml: !`find . -maxdepth 1 -name \'Cargo.toml\' 2>/dev/null`
+- Project standards: !`find . -maxdepth 1 -name \'.project-standards.yaml\'`
+- Project type: !`grep -m1 "^project_type:" .project-standards.yaml`
+- Has terraform: !`find . -maxdepth 2 \( -name '*.tf' -o -type d -name 'terraform' \) -print -quit`
+- Has package.json: !`find . -maxdepth 1 -name \'package.json\'`
+- Has pyproject.toml: !`find . -maxdepth 1 -name \'pyproject.toml\'`
+- Has Cargo.toml: !`find . -maxdepth 1 -name \'Cargo.toml\'`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-sentry/SKILL.md
+++ b/configure-plugin/skills/configure-sentry/SKILL.md
@@ -25,15 +25,15 @@ Check and configure Sentry error tracking integration against project standards.
 
 ## Context
 
-- Package.json: !`find . -maxdepth 1 -name \'package.json\' 2>/dev/null`
-- Pyproject.toml: !`find . -maxdepth 1 -name \'pyproject.toml\' 2>/dev/null`
-- Requirements.txt: !`find . -maxdepth 1 -name \'requirements.txt\' 2>/dev/null`
-- Project standards: !`head -20 .project-standards.yaml 2>/dev/null`
-- Sentry in package.json: !`grep -o '"@sentry/[^"]*"' package.json 2>/dev/null`
-- Sentry in pyproject.toml: !`grep 'sentry' pyproject.toml 2>/dev/null`
-- Sentry init files: !`find . -maxdepth 3 -name "*sentry*" -type f 2>/dev/null`
-- Env files referencing DSN: !`grep -rl 'SENTRY_DSN' .env* .github/workflows/ 2>/dev/null`
-- CI workflows: !`find .github/workflows -maxdepth 1 -name '*.yml' 2>/dev/null`
+- Package.json: !`find . -maxdepth 1 -name \'package.json\'`
+- Pyproject.toml: !`find . -maxdepth 1 -name \'pyproject.toml\'`
+- Requirements.txt: !`find . -maxdepth 1 -name \'requirements.txt\'`
+- Project standards: !`head -20 .project-standards.yaml`
+- Sentry in package.json: !`grep -o '"@sentry/[^"]*"' package.json`
+- Sentry in pyproject.toml: !`grep 'sentry' pyproject.toml`
+- Sentry init files: !`find . -maxdepth 3 -name "*sentry*" -type f`
+- Env files referencing DSN: !`grep -rl 'SENTRY_DSN' .env* .github/workflows/`
+- CI workflows: !`find .github/workflows -maxdepth 1 -name '*.yml'`
 
 **Skills referenced**: `sentry` (MCP server for Sentry API)
 

--- a/configure-plugin/skills/configure-skaffold/SKILL.md
+++ b/configure-plugin/skills/configure-skaffold/SKILL.md
@@ -25,14 +25,14 @@ Check and configure Skaffold against project standards.
 
 ## Context
 
-- K8s/Helm directories: !`find . -maxdepth 1 -type d \( -name 'k8s' -o -name 'helm' \) 2>/dev/null`
-- Skaffold config: !`find . -maxdepth 1 -name \'skaffold.yaml\' 2>/dev/null`
-- Skaffold API version: !`grep -m1 apiVersion skaffold.yaml 2>/dev/null`
-- Port forward config: !`grep -m1 address skaffold.yaml 2>/dev/null`
-- Profiles defined: !`grep -m10 'name:' skaffold.yaml 2>/dev/null`
-- Generate-secrets script: !`find . -maxdepth 1 -name \'scripts/generate-secrets.sh\' 2>/dev/null`
-- Dotenvx available: !`command -v dotenvx 2>/dev/null`
-- Project standards: !`head -20 .project-standards.yaml 2>/dev/null`
+- K8s/Helm directories: !`find . -maxdepth 1 -type d \( -name 'k8s' -o -name 'helm' \)`
+- Skaffold config: !`find . -maxdepth 1 -name \'skaffold.yaml\'`
+- Skaffold API version: !`grep -m1 apiVersion skaffold.yaml`
+- Port forward config: !`grep -m1 address skaffold.yaml`
+- Profiles defined: !`grep -m10 'name:' skaffold.yaml`
+- Generate-secrets script: !`find . -maxdepth 1 -name \'scripts/generate-secrets.sh\'`
+- Dotenvx available: !`command -v dotenvx`
+- Project standards: !`head -20 .project-standards.yaml`
 
 **Skills referenced**: `skaffold-standards`, `container-development`, `skaffold-orbstack`
 

--- a/configure-plugin/skills/configure-status/SKILL.md
+++ b/configure-plugin/skills/configure-status/SKILL.md
@@ -25,20 +25,20 @@ Display infrastructure standards compliance status without making changes.
 
 ## Context
 
-- Project standards: !`find . -maxdepth 1 -name \'.project-standards.yaml\' 2>/dev/null`
-- Project type: !`grep -m1 "^project_type:" .project-standards.yaml 2>/dev/null`
-- Standards version: !`grep -m1 "^standards_version:" .project-standards.yaml 2>/dev/null`
-- Last configured: !`grep -m1 "^last_configured:" .project-standards.yaml 2>/dev/null`
-- Pre-commit config: !`find . -maxdepth 1 -name \'.pre-commit-config.yaml\' 2>/dev/null`
-- Workflows: !`find .github/workflows -maxdepth 1 -name '*.yml' 2>/dev/null`
-- Has Dockerfile: !`find . -maxdepth 1 -name 'Dockerfile*' 2>/dev/null -print -quit`
-- Has skaffold: !`find . -maxdepth 1 -name \'skaffold.yaml\' 2>/dev/null`
-- Has helm: !`find . -maxdepth 2 -type d -name 'helm' 2>/dev/null -print -quit`
-- Test configs: !`find . -maxdepth 1 \( -name 'vitest.config.*' -o -name 'jest.config.*' -o -name 'pytest.ini' \) 2>/dev/null`
-- Linting config: !`find . -maxdepth 1 \( -name 'biome.json' -o -name '.eslintrc*' \) 2>/dev/null`
-- Editor config: !`find . -maxdepth 1 -name \'.editorconfig\' 2>/dev/null`
-- Gitleaks config: !`find . -maxdepth 1 -name \'.gitleaks.toml\' 2>/dev/null`
-- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' \) 2>/dev/null`
+- Project standards: !`find . -maxdepth 1 -name \'.project-standards.yaml\'`
+- Project type: !`grep -m1 "^project_type:" .project-standards.yaml`
+- Standards version: !`grep -m1 "^standards_version:" .project-standards.yaml`
+- Last configured: !`grep -m1 "^last_configured:" .project-standards.yaml`
+- Pre-commit config: !`find . -maxdepth 1 -name \'.pre-commit-config.yaml\'`
+- Workflows: !`find .github/workflows -maxdepth 1 -name '*.yml'`
+- Has Dockerfile: !`find . -maxdepth 1 -name 'Dockerfile*' -print -quit`
+- Has skaffold: !`find . -maxdepth 1 -name \'skaffold.yaml\'`
+- Has helm: !`find . -maxdepth 2 -type d -name 'helm' -print -quit`
+- Test configs: !`find . -maxdepth 1 \( -name 'vitest.config.*' -o -name 'jest.config.*' -o -name 'pytest.ini' \)`
+- Linting config: !`find . -maxdepth 1 \( -name 'biome.json' -o -name '.eslintrc*' \)`
+- Editor config: !`find . -maxdepth 1 -name \'.editorconfig\'`
+- Gitleaks config: !`find . -maxdepth 1 -name \'.gitleaks.toml\'`
+- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' \)`
 
 ## Parameters
 

--- a/configure-plugin/skills/configure-tests/SKILL.md
+++ b/configure-plugin/skills/configure-tests/SKILL.md
@@ -25,15 +25,15 @@ Check and configure testing frameworks against best practices (Vitest, Jest, pyt
 
 ## Context
 
-- Package.json: !`find . -maxdepth 1 -name \'package.json\' 2>/dev/null`
-- Pyproject.toml: !`find . -maxdepth 1 -name \'pyproject.toml\' 2>/dev/null`
-- Cargo.toml: !`find . -maxdepth 1 -name \'Cargo.toml\' 2>/dev/null`
-- Test config files: !`find . -maxdepth 1 \( -name 'vitest.config.*' -o -name 'jest.config.*' -o -name 'pytest.ini' -o -name '.nextest.toml' \) 2>/dev/null`
-- Pytest in pyproject: !`grep -c 'tool.pytest' pyproject.toml 2>/dev/null`
-- Test directories: !`find . -maxdepth 2 -type d \( -name 'tests' -o -name '__tests__' -o -name 'test' \) 2>/dev/null`
-- Test scripts in package.json: !`grep -m5 -o '"test[^"]*"' package.json 2>/dev/null`
-- Coverage config: !`grep -l 'coverage' vitest.config.* jest.config.* 2>/dev/null`
-- Project standards: !`head -20 .project-standards.yaml 2>/dev/null`
+- Package.json: !`find . -maxdepth 1 -name \'package.json\'`
+- Pyproject.toml: !`find . -maxdepth 1 -name \'pyproject.toml\'`
+- Cargo.toml: !`find . -maxdepth 1 -name \'Cargo.toml\'`
+- Test config files: !`find . -maxdepth 1 \( -name 'vitest.config.*' -o -name 'jest.config.*' -o -name 'pytest.ini' -o -name '.nextest.toml' \)`
+- Pytest in pyproject: !`grep -c 'tool.pytest' pyproject.toml`
+- Test directories: !`find . -maxdepth 2 -type d \( -name 'tests' -o -name '__tests__' -o -name 'test' \)`
+- Test scripts in package.json: !`grep -m5 -o '"test[^"]*"' package.json`
+- Coverage config: !`grep -l 'coverage' vitest.config.* jest.config.*`
+- Project standards: !`head -20 .project-standards.yaml`
 
 **Modern testing stack preferences:**
 - **JavaScript/TypeScript**: Vitest (preferred) or Jest

--- a/configure-plugin/skills/configure-ux-testing/SKILL.md
+++ b/configure-plugin/skills/configure-ux-testing/SKILL.md
@@ -25,14 +25,14 @@ Check and configure UX testing infrastructure with Playwright as the primary too
 
 ## Context
 
-- Package manager: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'bun.lockb' \) 2>/dev/null`
-- Playwright config: !`find . -maxdepth 1 -name 'playwright.config.*' 2>/dev/null`
-- Playwright installed: !`grep -l '@playwright/test' package.json 2>/dev/null`
-- Axe-core installed: !`grep -l '@axe-core/playwright' package.json 2>/dev/null`
-- E2E test dir: !`find . -maxdepth 2 -type d \( -name 'e2e' -o -name 'tests' \) 2>/dev/null`
-- Visual snapshots: !`find . -maxdepth 4 -type d -name '__snapshots__' 2>/dev/null`
-- MCP config: !`find . -maxdepth 1 -name '.mcp.json' 2>/dev/null`
-- CI workflow: !`find .github/workflows -maxdepth 1 -name 'e2e*' 2>/dev/null`
+- Package manager: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'bun.lockb' \)`
+- Playwright config: !`find . -maxdepth 1 -name 'playwright.config.*'`
+- Playwright installed: !`grep -l '@playwright/test' package.json`
+- Axe-core installed: !`grep -l '@axe-core/playwright' package.json`
+- E2E test dir: !`find . -maxdepth 2 -type d \( -name 'e2e' -o -name 'tests' \)`
+- Visual snapshots: !`find . -maxdepth 4 -type d -name '__snapshots__'`
+- MCP config: !`find . -maxdepth 1 -name '.mcp.json'`
+- CI workflow: !`find .github/workflows -maxdepth 1 -name 'e2e*'`
 
 **UX Testing Stack:**
 - **Playwright** - Cross-browser E2E testing (primary tool)

--- a/configure-plugin/skills/configure-workflows/SKILL.md
+++ b/configure-plugin/skills/configure-workflows/SKILL.md
@@ -25,11 +25,11 @@ Check and configure GitHub Actions CI/CD workflows against project standards.
 
 ## Context
 
-- Workflows dir: !`find . -maxdepth 1 -type d -name \'.github/workflows\' 2>/dev/null`
-- Workflow files: !`find .github/workflows -maxdepth 1 \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null`
-- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \) 2>/dev/null`
-- Dockerfile: !`find . -maxdepth 1 -name 'Dockerfile*' 2>/dev/null`
-- Release-please config: !`find . -maxdepth 1 -name \'release-please-config.json\' 2>/dev/null`
+- Workflows dir: !`find . -maxdepth 1 -type d -name \'.github/workflows\'`
+- Workflow files: !`find .github/workflows -maxdepth 1 \( -name '*.yml' -o -name '*.yaml' \)`
+- Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \)`
+- Dockerfile: !`find . -maxdepth 1 -name 'Dockerfile*'`
+- Release-please config: !`find . -maxdepth 1 -name \'release-please-config.json\'`
 
 **Skills referenced**: `ci-workflows`, `github-actions-auth-security`
 

--- a/container-plugin/skills/deploy-handoff/SKILL.md
+++ b/container-plugin/skills/deploy-handoff/SKILL.md
@@ -15,13 +15,13 @@ Generate professional handoff messages for deployed resources and services with 
 
 ## Context
 
-- Repository: !`git remote get-url origin 2>/dev/null`
-- Branch: !`git branch --show-current 2>/dev/null`
-- Last commit: !`git log --oneline --max-count=1 2>/dev/null`
-- README: !`find . -maxdepth 1 -name \'README.md\' 2>/dev/null`
-- Docker: !`find . -maxdepth 1 \( -name "Dockerfile" -o -name "docker-compose*.yml" \) 2>/dev/null`
-- CI/CD: !`find .github/workflows -maxdepth 1 -name '*.yml' 2>/dev/null`
-- Config files: !`find . -maxdepth 1 \( -name ".env.example" -o -name "*.config.*" \) 2>/dev/null`
+- Repository: !`git remote get-url origin`
+- Branch: !`git branch --show-current`
+- Last commit: !`git log --oneline --max-count=1`
+- README: !`find . -maxdepth 1 -name \'README.md\'`
+- Docker: !`find . -maxdepth 1 \( -name "Dockerfile" -o -name "docker-compose*.yml" \)`
+- CI/CD: !`find .github/workflows -maxdepth 1 -name '*.yml'`
+- Config files: !`find . -maxdepth 1 \( -name ".env.example" -o -name "*.config.*" \)`
 
 ## Parameters
 

--- a/documentation-plugin/skills/docs-generate/SKILL.md
+++ b/documentation-plugin/skills/docs-generate/SKILL.md
@@ -11,10 +11,10 @@ name: docs-generate
 
 ## Context
 
-- Project files: !`find . -maxdepth 1 \( -name 'pyproject.toml' -o -name 'package.json' -o -name 'Cargo.toml' -o -name 'go.mod' \) 2>/dev/null`
-- Existing docs: !`find . -maxdepth 1 \( -name 'README.md' -o -type d -name 'docs' \) 2>/dev/null`
-- Source files: !`find . -type f \( -name "*.py" -o -name "*.ts" -o -name "*.js" \) 2>/dev/null`
-- Python with docstrings: !`grep -r "\"\"\"" --include="*.py" -l 2>/dev/null`
+- Project files: !`find . -maxdepth 1 \( -name 'pyproject.toml' -o -name 'package.json' -o -name 'Cargo.toml' -o -name 'go.mod' \)`
+- Existing docs: !`find . -maxdepth 1 \( -name 'README.md' -o -type d -name 'docs' \)`
+- Source files: !`find . -type f \( -name "*.py" -o -name "*.ts" -o -name "*.js" \)`
+- Python with docstrings: !`grep -r "\"\"\"" --include="*.py" -l`
 
 ## Parameters
 

--- a/documentation-plugin/skills/docs-latex/SKILL.md
+++ b/documentation-plugin/skills/docs-latex/SKILL.md
@@ -28,10 +28,10 @@ Convert Markdown documents to professional LaTeX with advanced typesetting, TikZ
 
 ## Context
 
-- Source file exists: !`test -f "$1" 2>/dev/null`
-- LaTeX installed: !`which pdflatex 2>/dev/null`
+- Source file exists: !`test -f "$1"`
+- LaTeX installed: !`which pdflatex`
 - Current directory: !`pwd`
-- Available .md files: !`find . -maxdepth 2 -name '*.md' -not -name 'CHANGELOG.md' -not -name 'README.md' 2>/dev/null`
+- Available .md files: !`find . -maxdepth 2 -name '*.md' -not -name 'CHANGELOG.md' -not -name 'README.md'`
 
 ## Parameters
 

--- a/feedback-plugin/skills/feedback-session/SKILL.md
+++ b/feedback-plugin/skills/feedback-session/SKILL.md
@@ -30,9 +30,9 @@ Analyze the current session for skill feedback and create GitHub issues to track
 
 ## Context
 
-- Repository: !`git remote get-url origin 2>/dev/null`
-- Open feedback issues: !`gh issue list --label session-feedback --state open --json number,title --jq '.[].title' 2>/dev/null`
-- Open positive issues: !`gh issue list --label positive-feedback --state open --json number,title --jq '.[].title' 2>/dev/null`
+- Repository: !`git remote get-url origin`
+- Open feedback issues: !`gh issue list --label session-feedback --state open --json number,title --jq '.[].title'`
+- Open positive issues: !`gh issue list --label positive-feedback --state open --json number,title --jq '.[].title'`
 
 ## Parameters
 

--- a/finops-plugin/skills/finops-caches/SKILL.md
+++ b/finops-plugin/skills/finops-caches/SKILL.md
@@ -16,8 +16,8 @@ Analyze GitHub Actions cache usage - size breakdown, cache key patterns, branch 
 
 ## Context
 
-- Current repo: !`gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null`
-- Repo owner: !`gh repo view --json owner --jq '.owner.login' 2>/dev/null`
+- Current repo: !`gh repo view --json nameWithOwner --jq '.nameWithOwner'`
+- Repo owner: !`gh repo view --json owner --jq '.owner.login'`
 
 ## Parameters
 

--- a/finops-plugin/skills/finops-overview/SKILL.md
+++ b/finops-plugin/skills/finops-overview/SKILL.md
@@ -16,8 +16,8 @@ Display a quick FinOps summary including org-level billing (if admin) and curren
 
 ## Context
 
-- Current repo: !`gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null`
-- Repo org/owner: !`gh repo view --json owner --jq '.owner.login' 2>/dev/null`
+- Current repo: !`gh repo view --json nameWithOwner --jq '.nameWithOwner'`
+- Repo org/owner: !`gh repo view --json owner --jq '.owner.login'`
 
 ## Parameters
 

--- a/finops-plugin/skills/finops-waste/SKILL.md
+++ b/finops-plugin/skills/finops-waste/SKILL.md
@@ -16,8 +16,8 @@ Identify GitHub Actions waste patterns and provide actionable fix suggestions. A
 
 ## Context
 
-- Current repo: !`gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null`
-- Workflow files: !`find .github/workflows -maxdepth 1 \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null`
+- Current repo: !`gh repo view --json nameWithOwner --jq '.nameWithOwner'`
+- Workflow files: !`find .github/workflows -maxdepth 1 \( -name '*.yml' -o -name '*.yaml' \)`
 
 ## Parameters
 

--- a/finops-plugin/skills/finops-workflows/SKILL.md
+++ b/finops-plugin/skills/finops-workflows/SKILL.md
@@ -16,7 +16,7 @@ Analyze GitHub Actions workflow runs for a repository - frequency, duration, suc
 
 ## Context
 
-- Current repo: !`gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null`
+- Current repo: !`gh repo view --json nameWithOwner --jq '.nameWithOwner'`
 
 ## Parameters
 

--- a/finops-plugin/skills/github-actions-finops/skill.md
+++ b/finops-plugin/skills/github-actions-finops/skill.md
@@ -27,11 +27,11 @@ Analyze GitHub Actions usage, costs, and efficiency across organizations and rep
 
 ## Context
 
-- Current repo: !`gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null`
-- Repo owner: !`gh repo view --json owner --jq '.owner.login' 2>/dev/null`
-- Owner type: !`gh repo view --json owner --jq '.owner.__typename' 2>/dev/null`
-- Workflow files: !`find .github/workflows -maxdepth 1 \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null`
-- Active workflows: !`gh workflow list --json id,name,state 2>/dev/null`
+- Current repo: !`gh repo view --json nameWithOwner --jq '.nameWithOwner'`
+- Repo owner: !`gh repo view --json owner --jq '.owner.login'`
+- Owner type: !`gh repo view --json owner --jq '.owner.__typename'`
+- Workflow files: !`find .github/workflows -maxdepth 1 \( -name '*.yml' -o -name '*.yaml' \)`
+- Active workflows: !`gh workflow list --json id,name,state`
 
 ## Execution
 

--- a/git-plugin/skills/gh-cli-agentic/skill.md
+++ b/git-plugin/skills/gh-cli-agentic/skill.md
@@ -215,8 +215,8 @@ gh api repos/{owner}/{repo}/commits/{sha} -H "Accept: application/vnd.github.pat
 Use `2>/dev/null` to suppress errors in context expressions (do NOT use `||` fallbacks - blocked by Claude Code 2.1.7+):
 
 ```markdown
-- PR checks: !`gh pr checks $PR --json name,state,conclusion 2>/dev/null`
-- Run status: !`gh run view $ID --json status,conclusion 2>/dev/null`
+- PR checks: !`gh pr checks $PR --json name,state,conclusion`
+- Run status: !`gh run view $ID --json status,conclusion`
 ```
 
 ## Field Reference

--- a/git-plugin/skills/gh-workflow-monitoring/skill.md
+++ b/git-plugin/skills/gh-workflow-monitoring/skill.md
@@ -189,8 +189,8 @@ gh run view $RUN_ID --json status 2>/dev/null && gh run watch $RUN_ID --compact
 Use in command frontmatter:
 
 ```markdown
-- In-progress runs: !`gh run list --status in_progress --json databaseId,name --jq '.[0]' 2>/dev/null`
-- Latest run: !`gh run list -L 1 --json databaseId,name,status,conclusion 2>/dev/null`
+- In-progress runs: !`gh run list --status in_progress --json databaseId,name --jq '.[0]'`
+- Latest run: !`gh run list -L 1 --json databaseId,name,status,conclusion`
 ```
 
 ## See Also

--- a/git-plugin/skills/git-api-pr/SKILL.md
+++ b/git-plugin/skills/git-api-pr/SKILL.md
@@ -22,9 +22,9 @@ reviewed: 2026-02-15
 
 ## Context
 
-- Repo: !`gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null`
-- Default branch: !`gh repo view --json defaultBranchRef -q '.defaultBranchRef.name' 2>/dev/null`
-- Auth: !`gh auth status 2>/dev/null`
+- Repo: !`gh repo view --json nameWithOwner -q '.nameWithOwner'`
+- Default branch: !`gh repo view --json defaultBranchRef -q '.defaultBranchRef.name'`
+- Auth: !`gh auth status`
 - Working dir: !`pwd`
 
 ## Parameters

--- a/git-plugin/skills/git-cli-agentic/skill.md
+++ b/git-plugin/skills/git-cli-agentic/skill.md
@@ -292,9 +292,9 @@ git push -u origin HEAD
 Use `2>/dev/null` to suppress errors in context expressions (do NOT use `||` fallbacks - blocked by Claude Code 2.1.7+):
 
 ```markdown
-- Git status: !`git status --porcelain=v2 --branch 2>/dev/null`
-- Current branch: !`git branch --show-current 2>/dev/null`
-- Remote URL: !`git remote get-url origin 2>/dev/null`
+- Git status: !`git status --porcelain=v2 --branch`
+- Current branch: !`git branch --show-current`
+- Remote URL: !`git remote get-url origin`
 ```
 
 ## Combining with GH CLI

--- a/git-plugin/skills/git-commit-push-pr/SKILL.md
+++ b/git-plugin/skills/git-commit-push-pr/SKILL.md
@@ -12,15 +12,15 @@ description: Complete workflow from changes to PR - auto-detect related issues, 
 
 ## Context
 
-- Pre-commit config: !`find . -maxdepth 1 -name ".pre-commit-config.yaml" 2>/dev/null`
+- Pre-commit config: !`find . -maxdepth 1 -name ".pre-commit-config.yaml"`
 - Current branch: !`git branch --show-current`
-- Git status: !`git status --porcelain=v2 --branch 2>/dev/null`
-- Unstaged changes: !`git diff --numstat 2>/dev/null`
-- Staged changes: !`git diff --cached --numstat 2>/dev/null`
+- Git status: !`git status --porcelain=v2 --branch`
+- Unstaged changes: !`git diff --numstat`
+- Staged changes: !`git diff --cached --numstat`
 - Recent commits: !`git log --format='%h %s' -n 10`
-- Remote: !`git remote get-url origin 2>/dev/null`
-- Available labels: !`gh label list --json name --limit 50 2>/dev/null`
-- Open issues: !`gh issue list --state open --json number,title,labels --limit 30 2>/dev/null`
+- Remote: !`git remote get-url origin`
+- Available labels: !`gh label list --json name --limit 50`
+- Open issues: !`gh issue list --state open --json number,title,labels --limit 30`
 
 ## Parameters
 

--- a/git-plugin/skills/git-derive-docs/SKILL.md
+++ b/git-plugin/skills/git-derive-docs/SKILL.md
@@ -15,11 +15,11 @@ name: git-derive-docs
 ## Context
 
 - Current branch: !`git branch --show-current`
-- Commit count: !`git rev-list --count HEAD 2>/dev/null`
-- Latest commit: !`git log --format='%ai' --max-count=1 2>/dev/null`
-- Existing rules: !`find .claude/rules/ -maxdepth 1 -type f 2>/dev/null`
-- Existing docs: !`find docs/prds/ docs/adrs/ docs/prps/ -maxdepth 1 -type f 2>/dev/null`
-- Commit conventions sample: !`git log --format='%s' --max-count=20 2>/dev/null`
+- Commit count: !`git rev-list --count HEAD`
+- Latest commit: !`git log --format='%ai' --max-count=1`
+- Existing rules: !`find .claude/rules/ -maxdepth 1 -type f`
+- Existing docs: !`find docs/prds/ docs/adrs/ docs/prps/ -maxdepth 1 -type f`
+- Commit conventions sample: !`git log --format='%s' --max-count=20`
 
 ## Parameters
 

--- a/git-plugin/skills/git-fix-pr/SKILL.md
+++ b/git-plugin/skills/git-fix-pr/SKILL.md
@@ -12,11 +12,11 @@ name: git-fix-pr
 
 ## Context
 
-- Repo: !`gh repo view --json nameWithOwner 2>/dev/null`
+- Repo: !`gh repo view --json nameWithOwner`
 - Current branch: !`git branch --show-current`
-- Git status: !`git status --porcelain=v2 --branch 2>/dev/null`
-- Staged changes: !`git diff --cached --numstat 2>/dev/null`
-- Unstaged changes: !`git diff --numstat 2>/dev/null`
+- Git status: !`git status --porcelain=v2 --branch`
+- Staged changes: !`git diff --cached --numstat`
+- Unstaged changes: !`git diff --numstat`
 - Recent commits: !`git log --format='%h %s' -n 5`
 
 ## Parameters

--- a/git-plugin/skills/git-issue/SKILL.md
+++ b/git-plugin/skills/git-issue/SKILL.md
@@ -12,12 +12,12 @@ name: git-issue
 
 ## Context
 
-- Repo: !`gh repo view --json nameWithOwner 2>/dev/null`
+- Repo: !`gh repo view --json nameWithOwner`
 - Current branch: !`git branch --show-current`
-- Working tree clean: !`git status --porcelain=v2 2>/dev/null`
-- Open issues: !`gh issue list --state open --json number,title,labels --limit 10 2>/dev/null`
-- Open PRs: !`gh pr list --state open --json number,title 2>/dev/null`
-- Available labels: !`gh label list --json name --limit 50 2>/dev/null`
+- Working tree clean: !`git status --porcelain=v2`
+- Open issues: !`gh issue list --state open --json number,title,labels --limit 10`
+- Open PRs: !`gh pr list --state open --json number,title`
+- Available labels: !`gh label list --json name --limit 50`
 
 ## Parameters
 

--- a/git-plugin/skills/git-maintain/SKILL.md
+++ b/git-plugin/skills/git-maintain/SKILL.md
@@ -13,10 +13,10 @@ name: git-maintain
 ## Context
 
 - Current branch: !`git branch --show-current`
-- Git status: !`git status --porcelain=v2 --branch 2>/dev/null`
+- Git status: !`git status --porcelain=v2 --branch`
 - Local branches: !`git branch -vv --format='%(refname:short) %(upstream:short) %(upstream:track)'`
-- Stash list: !`git stash list 2>/dev/null`
-- Repository size: !`du -sh .git 2>/dev/null`
+- Stash list: !`git stash list`
+- Repository size: !`du -sh .git`
 
 ## Parameters
 

--- a/git-plugin/skills/git-pr-feedback/SKILL.md
+++ b/git-plugin/skills/git-pr-feedback/SKILL.md
@@ -12,11 +12,11 @@ name: git-pr-feedback
 
 ## Context
 
-- Repo: !`gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null`
+- Repo: !`gh repo view --json nameWithOwner -q '.nameWithOwner'`
 - Current branch: !`git branch --show-current`
-- Git status: !`git status --porcelain=v2 --branch 2>/dev/null`
-- Staged changes: !`git diff --cached --numstat 2>/dev/null`
-- Unstaged changes: !`git diff --numstat 2>/dev/null`
+- Git status: !`git status --porcelain=v2 --branch`
+- Staged changes: !`git diff --cached --numstat`
+- Unstaged changes: !`git diff --numstat`
 - Recent commits: !`git log --format='%h %s' -n 5`
 
 ## Parameters

--- a/git-plugin/skills/git-worktree-agent-workflow/SKILL.md
+++ b/git-plugin/skills/git-worktree-agent-workflow/SKILL.md
@@ -35,10 +35,10 @@ Start every implementation in an isolated worktree. Each task gets its own direc
 
 ## Context
 
-- Current branch: !`git branch --show-current 2>/dev/null`
-- Worktrees: !`git worktree list --porcelain 2>/dev/null`
-- Uncommitted changes: !`git status --porcelain 2>/dev/null`
-- Default branch: !`git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null`
+- Current branch: !`git branch --show-current`
+- Worktrees: !`git worktree list --porcelain`
+- Uncommitted changes: !`git status --porcelain`
+- Default branch: !`git symbolic-ref --short refs/remotes/origin/HEAD`
 
 ## Execution
 

--- a/github-actions-plugin/skills/github-workflow-auto-fix/SKILL.md
+++ b/github-actions-plugin/skills/github-workflow-auto-fix/SKILL.md
@@ -27,9 +27,9 @@ Automated CI failure analysis and remediation using Claude Code Action.
 
 ## Context
 
-- Workflow exists: !`find .github/workflows -maxdepth 1 -name 'github-workflow-auto-fix.yml' 2>/dev/null`
-- Current workflows: !`find .github/workflows -maxdepth 1 -name '*.yml' -type f 2>/dev/null`
-- Claude secrets configured: !`gh secret list 2>/dev/null`
+- Workflow exists: !`find .github/workflows -maxdepth 1 -name 'github-workflow-auto-fix.yml'`
+- Current workflows: !`find .github/workflows -maxdepth 1 -name '*.yml' -type f`
+- Claude secrets configured: !`gh secret list`
 
 ## Parameters
 

--- a/github-actions-plugin/skills/workflow-dev/SKILL.md
+++ b/github-actions-plugin/skills/workflow-dev/SKILL.md
@@ -15,10 +15,10 @@ Automated development loop with issue creation, TDD, and CI monitoring.
 
 ## Context
 
-- Current branch: !`git branch --show-current 2>/dev/null`
-- Working tree: !`git status --porcelain 2>/dev/null`
-- Project type: !`find . -maxdepth 1 \( -name "package.json" -o -name "Cargo.toml" -o -name "pyproject.toml" -o -name "go.mod" -o -name "manage.py" \) -type f 2>/dev/null`
-- Open issues: !`gh issue list --state open --limit 5 --json number,title --jq '.' 2>/dev/null`
+- Current branch: !`git branch --show-current`
+- Working tree: !`git status --porcelain`
+- Project type: !`find . -maxdepth 1 \( -name "package.json" -o -name "Cargo.toml" -o -name "pyproject.toml" -o -name "go.mod" -o -name "manage.py" \) -type f`
+- Open issues: !`gh issue list --state open --limit 5 --json number,title --jq '.'`
 
 ## Parameters
 

--- a/health-plugin/skills/health-agentic-audit/SKILL.md
+++ b/health-plugin/skills/health-agentic-audit/SKILL.md
@@ -28,9 +28,9 @@ Standards reference: `.claude/rules/agentic-optimization.md` and `.claude/rules/
 ## Context
 
 - Plugin root: !`pwd`
-- Skill files: !`find . -name 'SKILL.md' -o -name 'skill.md' 2>/dev/null`
-- Skill files (all): !`find . \( -name 'SKILL.md' -o -name 'skill.md' \) 2>/dev/null`
-- Agent files: !`find . -path '*/agents/*.md' -not -name 'README.md' 2>/dev/null`
+- Skill files: !`find . -name 'SKILL.md' -o -name 'skill.md'`
+- Skill files (all): !`find . \( -name 'SKILL.md' -o -name 'skill.md' \)`
+- Agent files: !`find . -path '*/agents/*.md' -not -name 'README.md'`
 
 ## Parameters
 

--- a/health-plugin/skills/health-audit/SKILL.md
+++ b/health-plugin/skills/health-audit/SKILL.md
@@ -26,18 +26,18 @@ Audit the project's enabled plugins against the actual technology stack. Identif
 ## Context
 
 - Current project: !`pwd`
-- Project settings exists: !`find .claude -maxdepth 1 -name 'settings.json' 2>/dev/null`
-- Enabled plugins: !`jq -r '.enabledPlugins[]? // empty' .claude/settings.json 2>/dev/null`
-- Package.json exists: !`find . -maxdepth 1 -name 'package.json' 2>/dev/null`
-- Cargo.toml exists: !`find . -maxdepth 1 -name 'Cargo.toml' 2>/dev/null`
-- pyproject.toml exists: !`find . -maxdepth 1 -name 'pyproject.toml' 2>/dev/null`
-- requirements.txt exists: !`find . -maxdepth 1 -name 'requirements.txt' 2>/dev/null`
-- go.mod exists: !`find . -maxdepth 1 -name 'go.mod' 2>/dev/null`
-- Dockerfile exists: !`find . -maxdepth 1 -name 'Dockerfile' 2>/dev/null`
-- docker-compose exists: !`find . -maxdepth 1 \( -name 'docker-compose.yml' -o -name 'docker-compose.yaml' -o -name 'compose.yml' -o -name 'compose.yaml' \) 2>/dev/null`
-- GitHub workflows: !`find .github/workflows -maxdepth 1 -name '*.yml' 2>/dev/null -quit -print`
-- Terraform files: !`find . -maxdepth 2 -name '*.tf' 2>/dev/null -quit -print`
-- Kubernetes manifests: !`find . -maxdepth 3 \( -path '*/k8s/*' -o -path '*/kubernetes/*' \) -name '*.yaml' 2>/dev/null -quit -print`
+- Project settings exists: !`find .claude -maxdepth 1 -name 'settings.json'`
+- Enabled plugins: !`jq -r '.enabledPlugins[]? // empty' .claude/settings.json`
+- Package.json exists: !`find . -maxdepth 1 -name 'package.json'`
+- Cargo.toml exists: !`find . -maxdepth 1 -name 'Cargo.toml'`
+- pyproject.toml exists: !`find . -maxdepth 1 -name 'pyproject.toml'`
+- requirements.txt exists: !`find . -maxdepth 1 -name 'requirements.txt'`
+- go.mod exists: !`find . -maxdepth 1 -name 'go.mod'`
+- Dockerfile exists: !`find . -maxdepth 1 -name 'Dockerfile'`
+- docker-compose exists: !`find . -maxdepth 1 \( -name 'docker-compose.yml' -o -name 'docker-compose.yaml' -o -name 'compose.yml' -o -name 'compose.yaml' \)`
+- GitHub workflows: !`find .github/workflows -maxdepth 1 -name '*.yml' -quit -print`
+- Terraform files: !`find . -maxdepth 2 -name '*.tf' -quit -print`
+- Kubernetes manifests: !`find . -maxdepth 3 \( -path '*/k8s/*' -o -path '*/kubernetes/*' \) -name '*.yaml' -quit -print`
 
 ## Parameters
 

--- a/health-plugin/skills/health-check/SKILL.md
+++ b/health-plugin/skills/health-check/SKILL.md
@@ -27,10 +27,10 @@ Run a comprehensive diagnostic scan of your Claude Code environment. Identifies 
 
 - User home: !`echo $HOME`
 - Current project: !`pwd`
-- Plugin registry exists: !`find ~/.claude/plugins -maxdepth 1 -name 'installed_plugins.json' 2>/dev/null`
-- User settings exists: !`find ~/.claude -maxdepth 1 -name 'settings.json' 2>/dev/null`
-- Project settings exists: !`find .claude -maxdepth 1 -name 'settings.json' 2>/dev/null`
-- Local settings exists: !`find .claude -maxdepth 1 -name 'settings.local.json' 2>/dev/null`
+- Plugin registry exists: !`find ~/.claude/plugins -maxdepth 1 -name 'installed_plugins.json'`
+- User settings exists: !`find ~/.claude -maxdepth 1 -name 'settings.json'`
+- Project settings exists: !`find .claude -maxdepth 1 -name 'settings.json'`
+- Local settings exists: !`find .claude -maxdepth 1 -name 'settings.local.json'`
 
 ## Parameters
 

--- a/health-plugin/skills/health-plugins/SKILL.md
+++ b/health-plugin/skills/health-plugins/SKILL.md
@@ -26,9 +26,9 @@ Diagnose and fix issues with the Claude Code plugin registry. This command speci
 ## Context
 
 - Current project: !`pwd`
-- Plugin registry exists: !`find ~/.claude/plugins -maxdepth 1 -name 'installed_plugins.json' 2>/dev/null`
-- Project settings exists: !`find . -maxdepth 1 -name '.claude/settings.json' 2>/dev/null`
-- Project plugins dir: !`find . -maxdepth 1 -type d -name \'.claude-plugin\' 2>/dev/null`
+- Plugin registry exists: !`find ~/.claude/plugins -maxdepth 1 -name 'installed_plugins.json'`
+- Project settings exists: !`find . -maxdepth 1 -name '.claude/settings.json'`
+- Project plugins dir: !`find . -maxdepth 1 -type d -name \'.claude-plugin\'`
 
 ## Background: Issue #14202
 

--- a/home-assistant-plugin/skills/ha-validate/SKILL.md
+++ b/home-assistant-plugin/skills/ha-validate/SKILL.md
@@ -17,7 +17,7 @@ Validate Home Assistant configuration files for YAML syntax errors and common is
 ## Context
 
 - Config path: `{{ path or '.' }}`
-- YAML files: !`find {{ path or '.' }} -name "*.yaml" -type f 2>/dev/null`
+- YAML files: !`find {{ path or '.' }} -name "*.yaml" -type f`
 
 ## Validation Steps
 

--- a/hooks-plugin/skills/hooks-session-start-hook/SKILL.md
+++ b/hooks-plugin/skills/hooks-session-start-hook/SKILL.md
@@ -30,11 +30,11 @@ Generate a `SessionStart` hook that prepares your repository for Claude Code on 
 
 Detect project stack:
 
-- Lockfiles: !`find . -maxdepth 1 \( -name 'package-lock.json' -o -name 'yarn.lock' -o -name 'pnpm-lock.yaml' -o -name 'bun.lockb' -o -name 'poetry.lock' -o -name 'uv.lock' -o -name 'Cargo.lock' -o -name 'go.sum' -o -name 'Gemfile.lock' \) 2>/dev/null`
-- Project files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'requirements.txt' -o -name 'Cargo.toml' -o -name 'go.mod' -o -name 'Gemfile' -o -name 'pom.xml' \) -o -maxdepth 1 -name 'build.gradle*' 2>/dev/null`
-- Linter configs: !`find . -maxdepth 1 \( -name 'biome.json' -o -name 'biome.jsonc' -o -name '.eslintrc*' -o -name 'eslint.config.*' \) 2>/dev/null`
-- Existing settings: !`cat .claude/settings.json 2>/dev/null`
-- Existing hooks dir: !`find . -maxdepth 2 -type d -name 'scripts' 2>/dev/null`
+- Lockfiles: !`find . -maxdepth 1 \( -name 'package-lock.json' -o -name 'yarn.lock' -o -name 'pnpm-lock.yaml' -o -name 'bun.lockb' -o -name 'poetry.lock' -o -name 'uv.lock' -o -name 'Cargo.lock' -o -name 'go.sum' -o -name 'Gemfile.lock' \)`
+- Project files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'requirements.txt' -o -name 'Cargo.toml' -o -name 'go.mod' -o -name 'Gemfile' -o -name 'pom.xml' \) -o -maxdepth 1 -name 'build.gradle*'`
+- Linter configs: !`find . -maxdepth 1 \( -name 'biome.json' -o -name 'biome.jsonc' -o -name '.eslintrc*' -o -name 'eslint.config.*' \)`
+- Existing settings: !`cat .claude/settings.json`
+- Existing hooks dir: !`find . -maxdepth 2 -type d -name 'scripts'`
 
 ## Parameters
 

--- a/project-plugin/skills/project-distill/SKILL.md
+++ b/project-plugin/skills/project-distill/SKILL.md
@@ -43,12 +43,12 @@ Distill session insights into reusable project knowledge. Reviews what was done 
 
 The primary context source is the **current conversation history** — all messages, tool calls, and results from this session are available. Git history is supplemental and may be unavailable (e.g., in non-git directories or multi-repo workspaces).
 
-- Session diff: !`git log --stat --oneline --max-count=10 2>/dev/null`
-- Recent commits: !`git log --oneline --max-count=20 2>/dev/null`
-- Current branch: !`git branch --show-current 2>/dev/null`
-- Justfile: !`find . -maxdepth 1 \( -name 'justfile' -o -name 'Justfile' \) -print -quit 2>/dev/null`
-- Rules directory: !`find .claude/rules -name '*.md' -type f 2>/dev/null`
-- Changed files: !`git log --name-only --max-count=10 --format='' 2>/dev/null`
+- Session diff: !`git log --stat --oneline --max-count=10`
+- Recent commits: !`git log --oneline --max-count=20`
+- Current branch: !`git branch --show-current`
+- Justfile: !`find . -maxdepth 1 \( -name 'justfile' -o -name 'Justfile' \) -print -quit`
+- Rules directory: !`find .claude/rules -name '*.md' -type f`
+- Changed files: !`git log --name-only --max-count=10 --format=''`
 
 ## Parameters
 

--- a/project-plugin/skills/project-skill-scripts/SKILL.md
+++ b/project-plugin/skills/project-skill-scripts/SKILL.md
@@ -24,9 +24,9 @@ Analyze plugin skills to identify opportunities where supporting scripts would i
 
 ## Context
 
-- Plugin root: !`git rev-parse --show-toplevel 2>/dev/null`
-- Total plugins: !`find . -maxdepth 2 -name 'plugin.json' -type f 2>/dev/null`
-- Skills with scripts: !`find . -name 'scripts/*.sh' -type f 2>/dev/null`
+- Plugin root: !`git rev-parse --show-toplevel`
+- Total plugins: !`find . -maxdepth 2 -name 'plugin.json' -type f`
+- Skills with scripts: !`find . -name 'scripts/*.sh' -type f`
 
 ## Parameters
 

--- a/rust-plugin/skills/cargo-machete/SKILL.md
+++ b/rust-plugin/skills/cargo-machete/SKILL.md
@@ -26,11 +26,11 @@ Detect and remove unused dependencies in Rust projects using cargo-machete.
 
 ## Context
 
-- Cargo.toml: !`find . -maxdepth 1 -name \'Cargo.toml\' 2>/dev/null`
-- Workspace: !`grep -q '\[workspace\]' Cargo.toml 2>/dev/null`
-- cargo-machete installed: !`cargo machete --version 2>/dev/null`
-- Machete config: !`find . -maxdepth 1 -name \'.cargo-machete.toml\' 2>/dev/null`
-- Workspace members: !`grep -A 20 '^\[workspace\]' Cargo.toml 2>/dev/null`
+- Cargo.toml: !`find . -maxdepth 1 -name \'Cargo.toml\'`
+- Workspace: !`grep -q '\[workspace\]' Cargo.toml`
+- cargo-machete installed: !`cargo machete --version`
+- Machete config: !`find . -maxdepth 1 -name \'.cargo-machete.toml\'`
+- Workspace members: !`grep -A 20 '^\[workspace\]' Cargo.toml`
 
 ## Execution
 

--- a/scripts/lint-context-commands.sh
+++ b/scripts/lint-context-commands.sh
@@ -7,6 +7,7 @@
 # 2. Pipe operator blocked by shell protections
 # 3. ls commands that fail when files are missing (use find instead)
 # 4. Shell operators (&&, ||, ;) blocked by security protections
+# 5. Redirection operators (>, >>) blocked by security protections (includes 2>/dev/null)
 #
 # Exit codes:
 #   0 - no issues
@@ -67,6 +68,12 @@ check_pattern ERROR \
   '^- .*!`ls [^`]*`' \
   "replace ls with find; ls returns non-zero when files are missing"
 
+# Redirection operators (>, >>) including 2>/dev/null
+check_pattern ERROR \
+  "redirection-operator" \
+  '^- .*!`[^`]* [0-9]*>\/\?[^`]*`' \
+  "remove redirection; failed commands produce empty output which is handled gracefully"
+
 ##############################
 # WARNINGS - likely to break
 ##############################
@@ -75,13 +82,13 @@ check_pattern ERROR \
 check_pattern WARN \
   "shell-operator-and" \
   '^- .*!`[^`]* && [^`]*`' \
-  "remove && operator; for file checks use: find . -maxdepth 1 -name 'file' 2>/dev/null"
+  "remove && operator; for file checks use: find . -maxdepth 1 -name 'file'"
 
 # || operator in context commands
 check_pattern WARN \
   "shell-operator-or" \
   '^- .*!`[^`]* || [^`]*`' \
-  "remove || fallback; use 2>/dev/null and handle empty output in execution logic"
+  "remove || fallback; failed commands produce empty output which is handled gracefully"
 
 # Semicolons in context commands
 check_pattern WARN \

--- a/testing-plugin/skills/test-focus/SKILL.md
+++ b/testing-plugin/skills/test-focus/SKILL.md
@@ -11,12 +11,12 @@ name: test-focus
 
 ## Context
 
-- Project files: !`find . -maxdepth 1 \( -name 'pyproject.toml' -o -name 'package.json' -o -name 'Cargo.toml' -o -name 'go.mod' \) 2>/dev/null`
-- Playwright config: !`find . -maxdepth 1 -name 'playwright.config.*' 2>/dev/null`
-- Vitest config: !`find . -maxdepth 1 \( -name 'vitest.config.*' -o -name 'vite.config.*' \) 2>/dev/null`
-- Jest config: !`find . -maxdepth 1 -name 'jest.config.*' 2>/dev/null`
-- Pytest config: !`grep -l "pytest" pyproject.toml setup.cfg 2>/dev/null`
-- Package.json: !`head -20 package.json 2>/dev/null`
+- Project files: !`find . -maxdepth 1 \( -name 'pyproject.toml' -o -name 'package.json' -o -name 'Cargo.toml' -o -name 'go.mod' \)`
+- Playwright config: !`find . -maxdepth 1 -name 'playwright.config.*'`
+- Vitest config: !`find . -maxdepth 1 \( -name 'vitest.config.*' -o -name 'vite.config.*' \)`
+- Jest config: !`find . -maxdepth 1 -name 'jest.config.*'`
+- Pytest config: !`grep -l "pytest" pyproject.toml setup.cfg`
+- Package.json: !`head -20 package.json`
 
 ## Parameters
 

--- a/testing-plugin/skills/test-full/SKILL.md
+++ b/testing-plugin/skills/test-full/SKILL.md
@@ -11,9 +11,9 @@ name: test-full
 
 ## Context
 
-- Project files: !`find . -maxdepth 1 \( -name 'pyproject.toml' -o -name 'package.json' -o -name 'Cargo.toml' -o -name 'go.mod' \) 2>/dev/null`
-- Test directories: !`find . -type d \( -name "test*" -o -name "__tests__" \) 2>/dev/null`
-- E2E setup: !`find . -maxdepth 1 \( -name 'playwright.config.*' -o -name 'cypress.config.*' \) 2>/dev/null`
+- Project files: !`find . -maxdepth 1 \( -name 'pyproject.toml' -o -name 'package.json' -o -name 'Cargo.toml' -o -name 'go.mod' \)`
+- Test directories: !`find . -type d \( -name "test*" -o -name "__tests__" \)`
+- E2E setup: !`find . -maxdepth 1 \( -name 'playwright.config.*' -o -name 'cypress.config.*' \)`
 - CI environment: !`echo "CI=$CI GITHUB_ACTIONS=$GITHUB_ACTIONS"`
 
 ## Parameters

--- a/testing-plugin/skills/test-quick/SKILL.md
+++ b/testing-plugin/skills/test-quick/SKILL.md
@@ -11,9 +11,9 @@ name: test-quick
 
 ## Context
 
-- Project type: !`find . -maxdepth 1 \( -name 'pyproject.toml' -o -name 'package.json' -o -name 'Cargo.toml' -o -name 'go.mod' \) 2>/dev/null`
-- Test directories: !`find . -maxdepth 2 -type d \( -path '*/tests/unit' -o -path '*/test/unit' -o -path '*/__tests__/unit' \) 2>/dev/null`
-- Last test run: !`find .pytest_cache/v/cache -maxdepth 1 -name 'lastfailed' 2>/dev/null`
+- Project type: !`find . -maxdepth 1 \( -name 'pyproject.toml' -o -name 'package.json' -o -name 'Cargo.toml' -o -name 'go.mod' \)`
+- Test directories: !`find . -maxdepth 2 -type d \( -path '*/tests/unit' -o -path '*/test/unit' -o -path '*/__tests__/unit' \)`
+- Last test run: !`find .pytest_cache/v/cache -maxdepth 1 -name 'lastfailed'`
 
 ## Parameters
 

--- a/testing-plugin/skills/test-run/SKILL.md
+++ b/testing-plugin/skills/test-run/SKILL.md
@@ -11,10 +11,10 @@ name: test-run
 
 ## Context
 
-- Project indicators: !`find . -maxdepth 1 \( -name 'pyproject.toml' -o -name 'package.json' -o -name 'Cargo.toml' -o -name 'go.mod' \) 2>/dev/null`
-- Test directories: !`find . -maxdepth 1 -type d \( -name 'tests' -o -name 'test' -o -name '__tests__' -o -name 'spec' \) 2>/dev/null`
-- Package.json test script: !`grep -A2 '"test"' package.json 2>/dev/null`
-- Pytest config: !`grep -A5 '\[tool.pytest' pyproject.toml 2>/dev/null`
+- Project indicators: !`find . -maxdepth 1 \( -name 'pyproject.toml' -o -name 'package.json' -o -name 'Cargo.toml' -o -name 'go.mod' \)`
+- Test directories: !`find . -maxdepth 1 -type d \( -name 'tests' -o -name 'test' -o -name '__tests__' -o -name 'spec' \)`
+- Package.json test script: !`grep -A2 '"test"' package.json`
+- Pytest config: !`grep -A5 '\[tool.pytest' pyproject.toml`
 
 ## Parameters
 

--- a/workflow-orchestration-plugin/skills/workflow-checkpoint-refactor/SKILL.md
+++ b/workflow-orchestration-plugin/skills/workflow-checkpoint-refactor/SKILL.md
@@ -30,10 +30,10 @@ Multi-phase refactoring with persistent state that survives context limits and s
 
 ## Context
 
-- Repo root: !`git rev-parse --show-toplevel 2>/dev/null`
-- Plan file exists: !`find . -maxdepth 1 -name REFACTOR_PLAN.md 2>/dev/null`
-- Git status: !`git status --porcelain 2>/dev/null`
-- Recent commits: !`git log --oneline --max-count=5 2>/dev/null`
+- Repo root: !`git rev-parse --show-toplevel`
+- Plan file exists: !`find . -maxdepth 1 -name REFACTOR_PLAN.md`
+- Git status: !`git status --porcelain`
+- Recent commits: !`git log --oneline --max-count=5`
 
 ## Parameters
 

--- a/workflow-orchestration-plugin/skills/workflow-preflight/SKILL.md
+++ b/workflow-orchestration-plugin/skills/workflow-preflight/SKILL.md
@@ -29,11 +29,11 @@ Pre-work validation to prevent wasted effort from stale state, redundant work, o
 
 ## Context
 
-- Repo: !`gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null`
-- Current branch: !`git branch --show-current 2>/dev/null`
-- Remote tracking: !`git branch -vv --format='%(refname:short) %(upstream:short) %(upstream:track)' 2>/dev/null`
-- Uncommitted changes: !`git status --porcelain 2>/dev/null`
-- Stash count: !`git stash list 2>/dev/null`
+- Repo: !`gh repo view --json nameWithOwner --jq '.nameWithOwner'`
+- Current branch: !`git branch --show-current`
+- Remote tracking: !`git branch -vv --format='%(refname:short) %(upstream:short) %(upstream:track)'`
+- Uncommitted changes: !`git status --porcelain`
+- Stash count: !`git stash list`
 
 ## Execution
 


### PR DESCRIPTION
## Summary

- Remove `2>/dev/null` from context commands (`!` backtick syntax) across 88 skill files
- Add redirection operator (`>`, `>>`) check to `scripts/lint-context-commands.sh`
- Update `.claude/rules/agentic-permissions.md` to document the restriction
- Fix lint suggestion messages that incorrectly recommended `2>/dev/null`

## Root Cause

The `>` operator in `2>/dev/null` is blocked by Claude Code's shell operator protections in context command patterns, causing "Bash command failed" errors on skill invocation (e.g., `/project-distill --all`).

Commit 99769b5 removed `|| true` from project-plugin but left `2>/dev/null` which contains the equally-blocked `>` operator. This fix extends the cleanup to all 88 affected skill files.

## Test plan

- [x] `./scripts/lint-context-commands.sh` passes with 0 errors
- [x] Lint script catches `2>/dev/null` if reintroduced (verified with test file)
- [x] Lint script ignores `>` in non-context lines (e.g., `<command>` in code blocks)
- [ ] Invoke `/project-distill --all` — no more "Bash command failed" errors
- [ ] CI `lint-context-commands` workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)