### PR TITLE
fix(plugin-pr-checks): regex incorrectly captures .claude-plugin as a plugin directory

### DIFF
--- a/.github/workflows/plugin-pr-checks.yml
+++ b/.github/workflows/plugin-pr-checks.yml
@@ -35,7 +35,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
           # Extract unique plugin directories affected
-          PLUGINS=$(echo "$FILES" | grep -oP '^[^/]+-plugin' | sort -u)
+          PLUGINS=$(echo "$FILES" | grep -oP '^[a-z][^/]*-plugin' | sort -u)
           echo "plugins<<EOF" >> $GITHUB_OUTPUT
           echo "$PLUGINS" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Fixes #782

## Changes
- Updated regex pattern in plugin-pr-checks.yml from `^[^/]+-plugin` to `^[a-z][^/]*-plugin`
- This prevents .claude-plugin (metadata directory) from being incorrectly matched as a plugin

## Why
The old pattern matched any character except `/`, including dots. This caused .claude-plugin/marketplace.json changes to trigger spurious compliance failures. The new pattern requires the first character to be lowercase, correctly filtering for actual plugin directories.