### PR TITLE
fix: replace git remote get-url with git remote -v for verbose output

### DIFF
--- a/blog-plugin/skills/blog-post/SKILL.md
+++ b/blog-plugin/skills/blog-post/SKILL.md
@@ -26,7 +26,7 @@ Create a blog post about your work with minimal friction. Gathers context automa
 ## Context
 
 - Blog directory: !`find . -maxdepth 1 -type d \( -name blog -o -name posts -o -name _posts \) -print -quit`
-- Project name: !`git remote get-url origin`
+- Git remotes: !`git remote -v`
 - Recent commits: !`git rev-list --count --since="7 days ago" HEAD`
 - Current branch: !`git branch --show-current`
 

--- a/configure-plugin/skills/configure-claude-plugins/SKILL.md
+++ b/configure-plugin/skills/configure-claude-plugins/SKILL.md
@@ -27,7 +27,7 @@ Configure a project to use the `laurigates/claude-plugins` Claude Code plugin ma
 
 - Settings file exists: !`find . -maxdepth 1 -name \'.claude/settings.json\'`
 - Workflows: !`find .github/workflows -maxdepth 1 -name 'claude*.yml'`
-- Git remote: !`git remote get-url origin`
+- Git remotes: !`git remote -v`
 - Project type indicators: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'Dockerfile' \)`
 - Existing workflows dir: !`find . -maxdepth 1 -type d -name \'.github/workflows\'`
 

--- a/configure-plugin/skills/configure-readme/SKILL.md
+++ b/configure-plugin/skills/configure-readme/SKILL.md
@@ -25,7 +25,7 @@ name: configure-readme
 - Project name: !`basename $(pwd)`
 - README exists: !`find . -maxdepth 1 -name 'README.md'`
 - Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \)`
-- Git remote: !`git remote get-url origin`
+- Git remotes: !`git remote -v`
 - License file: !`find . -maxdepth 1 -name 'LICENSE*'`
 - Assets directory: !`find . -maxdepth 2 -type d \( -name 'assets' -o -name 'public' -o -name 'images' \)`
 - Logo files: !`find . -maxdepth 3 -type f \( -name 'logo*' -o -name 'icon*' \)`

--- a/container-plugin/skills/deploy-handoff/SKILL.md
+++ b/container-plugin/skills/deploy-handoff/SKILL.md
@@ -15,7 +15,7 @@ Generate professional handoff messages for deployed resources and services with 
 
 ## Context
 
-- Repository: !`git remote get-url origin`
+- Git remotes: !`git remote -v`
 - Branch: !`git branch --show-current`
 - Last commit: !`git log --oneline --max-count=1`
 - README: !`find . -maxdepth 1 -name \'README.md\'`

--- a/feedback-plugin/skills/feedback-session/SKILL.md
+++ b/feedback-plugin/skills/feedback-session/SKILL.md
@@ -30,7 +30,7 @@ Analyze the current session for skill feedback and create GitHub issues to track
 
 ## Context
 
-- Repository: !`git remote get-url origin`
+- Git remotes: !`git remote -v`
 - Open feedback issues: !`gh issue list --label session-feedback --state open --json number,title --jq '.[].title'`
 - Open positive issues: !`gh issue list --label positive-feedback --state open --json number,title --jq '.[].title'`
 

--- a/git-plugin/skills/git-commit-push-pr/SKILL.md
+++ b/git-plugin/skills/git-commit-push-pr/SKILL.md
@@ -18,7 +18,7 @@ description: Complete workflow from changes to PR - auto-detect related issues, 
 - Unstaged changes: !`git diff --numstat`
 - Staged changes: !`git diff --cached --numstat`
 - Recent commits: !`git log --format='%h %s' -n 10`
-- Remote: !`git remote get-url origin`
+- Git remotes: !`git remote -v`
 - Available labels: !`gh label list --json name --limit 50`
 - Open issues: !`gh issue list --state open --json number,title,labels --limit 30`
 


### PR DESCRIPTION
## Summary
Updated all skill context definitions across multiple plugins to use `git remote -v` instead of `git remote get-url origin`, providing more comprehensive git remote information.

## Key Changes
- **blog-plugin**: Updated blog-post skill to show all git remotes verbosely
- **configure-plugin**: Updated both configure-claude-plugins and configure-readme skills to use verbose remote listing
- **container-plugin**: Updated deploy-handoff skill context
- **feedback-plugin**: Updated feedback-session skill context
- **git-plugin**: Updated git-commit-push-pr skill context

## Implementation Details
The change replaces `git remote get-url origin` with `git remote -v` across 6 skill definition files. This provides:
- Display of all configured remotes (not just origin)
- Both fetch and push URLs for each remote
- More complete context for Claude when working with repositories that have multiple remotes

All context labels were also updated from singular ("Git remote", "Repository") to plural ("Git remotes") to accurately reflect the expanded output.

https://claude.ai/code/session_018DfhdtHQfvgFvyn9TAqUZx