### PR TITLE
chore: update Claude Code version tracking to 2.1.71

### DIFF
--- a/.claude-code-version-check.json
+++ b/.claude-code-version-check.json
@@ -1,8 +1,16 @@
 {
-  "lastCheckedVersion": "2.1.63",
-  "lastCheckedDate": "2026-03-02",
+  "lastCheckedVersion": "2.1.71",
+  "lastCheckedDate": "2026-03-09",
   "changelogUrl": "https://raw.githubusercontent.com/anthropics/claude-code/refs/heads/main/CHANGELOG.md",
   "reviewedChanges": [
+    {
+      "version": "2.1.71",
+      "date": "2026-03-09",
+      "relevantChanges": [],
+      "actionsRequired": [
+        "Review pending - see GitHub issue"
+      ]
+    },
     {
       "version": "2.1.63",
       "date": "2026-03-02",


### PR DESCRIPTION
Automated update of `.claude-code-version-check.json` to track Claude Code version 2.1.71.