### PR TITLE
fix(blueprint-plugin): remove model field from skills and fix invocation syntax

### DIFF
--- a/.claude/rules/skill-development.md
+++ b/.claude/rules/skill-development.md
@@ -50,7 +50,6 @@ Skills live in `<plugin-name>/skills/<skill-name>/SKILL.md` (or `skill.md`).
 
 ```yaml
 ---
-model: <opus|sonnet|haiku>
 name: <Skill Name>        # Optional: uses directory name if omitted
 description: <1-2 sentence description of capability>
 allowed-tools: <Comma-separated list of tools>
@@ -118,19 +117,9 @@ Run helper: !`bash ${CLAUDE_SKILL_DIR}/scripts/helper.sh`
 
 ### Model Selection
 
-Choose the appropriate model based on task complexity:
+Skills inherit the user's active model by default. Do not set `model:` in skill frontmatter — this avoids forcing a specific model variant that may differ from the user's preferred model or require a tier they don't have access to.
 
-| Model | Use For |
-|-------|---------|
-| `opus` | Deep reasoning, architecture decisions, debugging methodology, security analysis, complex code review |
-| `sonnet` | Development workflows requiring judgment, code generation with analysis, framework expertise, multi-step pattern-based reasoning |
-| `haiku` | Simple CLI operations, formatting, configuration, status checks, standard mechanical workflows |
-
-**Guidelines:**
-- Default to `sonnet` for tasks requiring moderate reasoning or development expertise
-- Use `haiku` for straightforward, mechanical tasks (CLI tools, formatting, status checks)
-- Use `opus` only when the skill requires deep reasoning, security analysis, or complex decision-making
-- Consider: "Does this need deep reasoning (opus), moderate judgment (sonnet), or mechanical execution (haiku)?"
+> **Note**: The `model:` field is still supported in agent definitions (see `.claude/rules/agent-development.md`) where explicit model selection may be appropriate.
 
 ### Date Fields
 
@@ -215,7 +204,6 @@ Skills that accept arguments use the same frontmatter as other skills, with addi
 
 ```yaml
 ---
-model: <opus|sonnet|haiku>
 name: <skill-name>
 description: <What it does, with trigger phrases>
 args: <argument specification>

--- a/accessibility-plugin/skills/accessibility-implementation/SKILL.md
+++ b/accessibility-plugin/skills/accessibility-implementation/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2026-02-08

--- a/accessibility-plugin/skills/design-tokens/SKILL.md
+++ b/accessibility-plugin/skills/design-tokens/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16

--- a/agent-patterns-plugin/skills/agent-teams/SKILL.md
+++ b/agent-patterns-plugin/skills/agent-teams/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 name: agent-teams
 description: |
   Configure and orchestrate Claude Code agent teams (TeamCreate, SendMessage, TaskUpdate

--- a/agent-patterns-plugin/skills/claude-hooks-configuration/SKILL.md
+++ b/agent-patterns-plugin/skills/claude-hooks-configuration/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: claude-hooks-configuration
 description: |
   Set up Claude Code lifecycle hooks and event handlers in settings.json. Use when you

--- a/agent-patterns-plugin/skills/custom-agent-definitions/SKILL.md
+++ b/agent-patterns-plugin/skills/custom-agent-definitions/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 name: custom-agent-definitions
 description: |
   Write and configure custom agent definitions in Claude Code's agents/ directory. Use

--- a/agent-patterns-plugin/skills/mcp-code-execution/SKILL.md
+++ b/agent-patterns-plugin/skills/mcp-code-execution/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: mcp-code-execution
 description: |
   Design and scaffold the code execution pattern for MCP-based agent systems. Use when

--- a/agent-patterns-plugin/skills/mcp-management/SKILL.md
+++ b/agent-patterns-plugin/skills/mcp-management/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2026-02-26
 reviewed: 2026-02-26

--- a/agent-patterns-plugin/skills/meta-assimilate/SKILL.md
+++ b/agent-patterns-plugin/skills/meta-assimilate/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/agent-patterns-plugin/skills/meta-audit/SKILL.md
+++ b/agent-patterns-plugin/skills/meta-audit/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/agent-patterns-plugin/skills/plugin-settings/SKILL.md
+++ b/agent-patterns-plugin/skills/plugin-settings/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: plugin-settings
 description: |
   Configure per-project plugin settings using `.claude/plugin-name.local.md` files.

--- a/agents-plugin/skills/agents-analyze/SKILL.md
+++ b/agents-plugin/skills/agents-analyze/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 description: Analyze all plugins for sub-agent opportunities. Identifies skills with verbose output, gaps in agent coverage, and model selection improvements.
 args: "[--focus <plugin-name>]"
 allowed-tools: Glob, Grep, Read, Bash(ls *), Bash(wc *), TodoWrite

--- a/api-plugin/skills/api-testing/SKILL.md
+++ b/api-plugin/skills/api-testing/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2026-02-08

--- a/api-plugin/skills/api-tests/SKILL.md
+++ b/api-plugin/skills/api-tests/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2026-02-13
 reviewed: 2025-12-16

--- a/bevy-plugin/skills/bevy-ecs-patterns/skill.md
+++ b/bevy-plugin/skills/bevy-ecs-patterns/skill.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/bevy-plugin/skills/bevy-game-engine/skill.md
+++ b/bevy-plugin/skills/bevy-game-engine/skill.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/blog-plugin/skills/blog-post-writing/skill.md
+++ b/blog-plugin/skills/blog-post-writing/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: blog-post-writing
 description: |
   Consistent style guide for writing blog posts about projects and technical work.

--- a/blueprint-plugin/README.md
+++ b/blueprint-plugin/README.md
@@ -78,12 +78,12 @@ PRD (Product Requirements) → PRP (Product Requirement Prompt) → Work-Order �
 
 ## Workflow
 
-### Smart Mode: Using `/blueprint-execute`
+### Smart Mode: Using `/blueprint:execute`
 
 The easiest way to use Blueprint Development is with the **idempotent meta command**:
 
 ```bash
-/blueprint-execute
+/blueprint:execute
 ```
 
 This command:
@@ -110,16 +110,16 @@ The command automatically handles:
 **Example usage:**
 ```bash
 # First time in a project
-/blueprint-execute  # → Runs /blueprint-init
+/blueprint:execute  # → Runs /blueprint:init
 
 # After creating PRDs
-/blueprint-execute  # → Runs /blueprint-generate-rules
+/blueprint:execute  # → Runs /blueprint:generate-rules
 
 # When PRPs are ready
-/blueprint-execute  # → Prompts to execute PRPs
+/blueprint:execute  # → Prompts to execute PRPs
 
 # When everything is current
-/blueprint-execute  # → Shows status and options
+/blueprint:execute  # → Shows status and options
 ```
 
 ---
@@ -131,7 +131,7 @@ You can also run individual commands directly when you know exactly what you wan
 ### 1. Initialize Blueprint Development
 
 ```bash
-/blueprint-init
+/blueprint:init
 ```
 
 Creates the directory structure:
@@ -153,8 +153,8 @@ docs/
 For existing projects, derive documentation from codebase:
 
 ```bash
-/blueprint-derive-prd    # Derive PRD from README and docs
-/blueprint-derive-adr    # Derive ADRs from architecture analysis
+/blueprint:derive-prd    # Derive PRD from README and docs
+/blueprint:derive-adr    # Derive ADRs from architecture analysis
 ```
 
 These commands analyze existing documentation and code patterns, asking clarifying questions to fill gaps.
@@ -162,7 +162,7 @@ These commands analyze existing documentation and code patterns, asking clarifyi
 **For established projects with git history**, use the comprehensive derive command:
 
 ```bash
-/blueprint-derive-plans    # Derive PRDs, ADRs, and PRPs from git history
+/blueprint:derive-plans    # Derive PRDs, ADRs, and PRPs from git history
 ```
 
 This command:
@@ -175,7 +175,7 @@ This command:
 **For identifying untested bug fixes and generating a test backlog**:
 
 ```bash
-/blueprint-derive-tests    # Derive test regression plans from git history
+/blueprint:derive-tests    # Derive test regression plans from git history
 ```
 
 This command:
@@ -187,7 +187,7 @@ This command:
 **For deriving rules from significant commit decisions**:
 
 ```bash
-/blueprint-derive-rules    # Derive rules from git commit log decisions
+/blueprint:derive-rules    # Derive rules from git commit log decisions
 ```
 
 This command:
@@ -209,7 +209,7 @@ The `requirements-documentation` agent triggers proactively for new features.
 ### 4. Generate Project Skills
 
 ```bash
-/blueprint-generate-rules
+/blueprint:generate-rules
 ```
 
 Extracts patterns from PRDs and generates project-specific rules:
@@ -221,7 +221,7 @@ Extracts patterns from PRDs and generates project-specific rules:
 ### 5. Create Work-Orders
 
 ```bash
-/blueprint-work-order
+/blueprint:work-order
 ```
 
 Generates isolated task packages with minimal context for subagent execution.
@@ -251,8 +251,8 @@ All blueprint documents are connected through a unified ID system, enabling full
 ### Automatic ID Assignment
 
 IDs are automatically generated when:
-- Creating documents via `/blueprint-derive-prd`, `/blueprint-derive-adr`, `/blueprint-prp-create`
-- Running `/blueprint-sync-ids` to batch-assign IDs to existing documents
+- Creating documents via `/blueprint:derive-prd`, `/blueprint:derive-adr`, `/blueprint:prp-create`
+- Running `/blueprint:sync-ids` to batch-assign IDs to existing documents
 - Accessing documents without IDs (auto-assigned on first access)
 
 ### Cross-Linking
@@ -281,7 +281,7 @@ github-issues:
 
 ### Traceability Report
 
-Run `/blueprint-status` to see:
+Run `/blueprint:status` to see:
 - Documents with/without IDs
 - Documents linked to GitHub issues
 - Orphan documents (no issues)
@@ -291,9 +291,9 @@ Run `/blueprint-status` to see:
 ### Sync IDs
 
 ```bash
-/blueprint-sync-ids              # Assign IDs to all documents
-/blueprint-sync-ids --dry-run    # Preview changes
-/blueprint-sync-ids --link-issues # Also create GitHub issues for orphans
+/blueprint:sync-ids              # Assign IDs to all documents
+/blueprint:sync-ids --dry-run    # Preview changes
+/blueprint:sync-ids --link-issues # Also create GitHub issues for orphans
 ```
 
 ## Feature Tracking (Optional)
@@ -302,7 +302,7 @@ Track implementation progress against requirements documents using hierarchical 
 
 ### Enable During Init
 
-Feature tracking can be enabled during `/blueprint-init`. When enabled, it creates:
+Feature tracking can be enabled during `/blueprint:init`. When enabled, it creates:
 - `docs/blueprint/feature-tracker.json` - Main tracker file
 
 ### Feature Tracker Structure

--- a/blueprint-plugin/docs/blueprint-plugin-sequence.md
+++ b/blueprint-plugin/docs/blueprint-plugin-sequence.md
@@ -2,47 +2,47 @@
 
 This document provides Mermaid diagrams showing the Blueprint Plugin workflow from different perspectives.
 
-## 0. Smart Mode: /blueprint-execute Meta Command
+## 0. Smart Mode: /blueprint:execute Meta Command
 
 The idempotent meta command that analyzes repository state and determines the next action:
 
 ```mermaid
 graph TD
-    Start([Run /blueprint-execute]) --> CheckInit{Blueprint\ninitialized?}
+    Start([Run /blueprint:execute]) --> CheckInit{Blueprint\ninitialized?}
 
-    CheckInit -->|No| RunInit[Run /blueprint-init]
+    CheckInit -->|No| RunInit[Run /blueprint:init]
     RunInit --> Done([Exit])
 
     CheckInit -->|Yes| CheckUpgrade{Upgrade\navailable?}
 
-    CheckUpgrade -->|Yes v3.0.0| RunUpgrade[Run /blueprint-upgrade]
+    CheckUpgrade -->|Yes v3.0.0| RunUpgrade[Run /blueprint:upgrade]
     RunUpgrade --> Done
 
     CheckUpgrade -->|No| CheckStale{Generated\ncontent stale?}
 
     CheckStale -->|Yes PRDs changed| PromptRegen{User:\nRegenerate?}
-    PromptRegen -->|Yes| RunGenRules[Run /blueprint-generate-rules]
+    PromptRegen -->|Yes| RunGenRules[Run /blueprint:generate-rules]
     RunGenRules --> Done
     PromptRegen -->|Skip| CheckModified
 
     CheckStale -->|No| CheckModified{Generated\ncontent modified?}
 
     CheckModified -->|Yes user edited| PromptSync{User:\nReview/Promote?}
-    PromptSync -->|Review| RunSync[Run /blueprint-sync]
+    PromptSync -->|Review| RunSync[Run /blueprint:sync]
     RunSync --> Done
-    PromptSync -->|Promote| RunPromote[Run /blueprint-promote]
+    PromptSync -->|Promote| RunPromote[Run /blueprint:promote]
     RunPromote --> Done
     PromptSync -->|Skip| CheckPRDs
 
     CheckModified -->|No| CheckPRDs{PRDs exist\nno rules?}
 
-    CheckPRDs -->|Yes| RunGenRules2[Run /blueprint-generate-rules]
+    CheckPRDs -->|Yes| RunGenRules2[Run /blueprint:generate-rules]
     RunGenRules2 --> Done
 
     CheckPRDs -->|No| CheckPRPs{Ready\nPRPs found?}
 
     CheckPRPs -->|Yes| PromptPRP{User:\nSelect PRP}
-    PromptPRP --> RunPRPExec[Run /blueprint-prp-execute]
+    PromptPRP --> RunPRPExec[Run /blueprint:prp-execute]
     RunPRPExec --> Done
 
     CheckPRPs -->|No| CheckWO{Pending\nwork-orders?}
@@ -62,14 +62,14 @@ graph TD
 
     CheckOverview -->|No tasks| CheckTracker{Feature\ntracker exists?}
 
-    CheckTracker -->|Yes stale| RunTrackerSync[Run /blueprint-feature-tracker-sync]
+    CheckTracker -->|Yes stale| RunTrackerSync[Run /blueprint:feature-tracker-sync]
     RunTrackerSync --> ShowProgress
 
     CheckTracker -->|Yes current| ShowProgress{Show\nprogress}
     ShowProgress --> PromptNext{User:\nNext feature?}
     PromptNext --> WorkOnTask
 
-    CheckTracker -->|No| ShowStatus[Run /blueprint-status]
+    CheckTracker -->|No| ShowStatus[Run /blueprint:status]
     ShowStatus --> PromptOptions{User:\nWhat to do?}
     PromptOptions --> Done
 
@@ -95,16 +95,16 @@ graph TD
 **Common Use Cases:**
 ```bash
 # Morning start routine
-/blueprint-execute  # Figures out where you left off
+/blueprint:execute  # Figures out where you left off
 
 # After pulling changes
-/blueprint-execute  # Checks for stale content, upgrades
+/blueprint:execute  # Checks for stale content, upgrades
 
 # Periodic check-in
-/blueprint-execute  # Shows progress, suggests next work
+/blueprint:execute  # Shows progress, suggests next work
 
 # When stuck or unsure
-/blueprint-execute  # Always knows what to do next
+/blueprint:execute  # Always knows what to do next
 ```
 
 ---
@@ -115,19 +115,19 @@ The complete journey from initialization to implementation:
 
 ```mermaid
 graph TB
-    Start([Start New Project]) --> Init[/blueprint-init/]
+    Start([Start New Project]) --> Init[/blueprint:init/]
 
     Init --> InitArtifacts{Setup Type?}
-    InitArtifacts -->|Existing Project| GenPRD[/blueprint-prd/]
+    InitArtifacts -->|Existing Project| GenPRD[/blueprint:prd/]
     InitArtifacts -->|New Project| WritePRD[Write PRDs manually]
-    InitArtifacts -->|Architecture| GenADR[/blueprint-adr/]
+    InitArtifacts -->|Architecture| GenADR[/blueprint:adr/]
 
     GenPRD --> PRDs[(docs/prds/)]
     WritePRD --> PRDs
     GenADR --> ADRs[(docs/adrs/)]
 
-    PRDs --> GenRules[/blueprint-generate-rules/]
-    PRDs --> GenCmds[/blueprint-generate-commands/]
+    PRDs --> GenRules[/blueprint:generate-rules/]
+    PRDs --> GenCmds[/blueprint:generate-commands/]
 
     GenRules --> Rules[(4 Behavioral Rules)]
     GenCmds --> Commands[(Project Commands)]
@@ -135,8 +135,8 @@ graph TB
     Rules --> FeatureWork{Need to implement?}
     Commands --> FeatureWork
 
-    FeatureWork -->|Complex Feature| CreatePRP[/blueprint-prp-create/]
-    FeatureWork -->|Isolated Task| CreateWO[/blueprint-work-order/]
+    FeatureWork -->|Complex Feature| CreatePRP[/blueprint:prp-create/]
+    FeatureWork -->|Isolated Task| CreateWO[/blueprint:work-order/]
 
     CreatePRP --> ResearchPhase[Research Phase]
     ResearchPhase --> CurateAIDocs[Curate ai_docs]
@@ -150,7 +150,7 @@ graph TB
     PRP --> ConfidenceCheck{Confidence >= 7?}
     ConfidenceCheck -->|No| MoreResearch[More Research Needed]
     MoreResearch --> ResearchPhase
-    ConfidenceCheck -->|Yes| ExecutePRP[/blueprint-prp-execute/]
+    ConfidenceCheck -->|Yes| ExecutePRP[/blueprint:prp-execute/]
 
     CreateWO --> WorkOrder[(Work-Order)]
     WorkOrder --> OptionalGH{Create GitHub Issue?}
@@ -175,7 +175,7 @@ graph TB
     FixTests --> TDDCycle
 
     ValidationGates -->|All Pass| UpdateProgress[Update feature-tracker.json]
-    UpdateProgress --> TrackFeatures[/blueprint-feature-tracker-sync/]
+    UpdateProgress --> TrackFeatures[/blueprint:feature-tracker-sync/]
 
     TrackFeatures --> MoreWork{More work?}
     MoreWork -->|Yes| FeatureWork
@@ -200,7 +200,7 @@ Detailed view of PRP creation with research and confidence scoring:
 ```mermaid
 sequenceDiagram
     actor User
-    participant CMD as /blueprint-prp-create
+    participant CMD as /blueprint:prp-create
     participant Explore as Explore Agent
     participant WebSearch as Web/Docs
     participant Confidence as Confidence Skill
@@ -257,7 +257,7 @@ The RED → GREEN → REFACTOR workflow with validation gates:
 ```mermaid
 sequenceDiagram
     actor User
-    participant CMD as /blueprint-prp-execute
+    participant CMD as /blueprint:prp-execute
     participant PRP as PRP Document
     participant Tests as Test Suite
     participant Code as Implementation
@@ -319,7 +319,7 @@ How work-orders connect to GitHub for team visibility:
 ```mermaid
 graph LR
     subgraph "Work-Order Creation"
-        A[/blueprint-work-order/] --> B{Mode?}
+        A[/blueprint:work-order/] --> B{Mode?}
         B -->|Default| C[Analyze current state]
         B -->|--from-issue N| D[Fetch GitHub issue #N]
 
@@ -367,10 +367,10 @@ How conflict detection works when creating new ADRs:
 ```mermaid
 sequenceDiagram
     actor User
-    participant CMD as /blueprint-adr
+    participant CMD as /blueprint:adr
     participant Skill as adr-relationships
     participant ADRs as docs/adrs/
-    participant Validate as /blueprint-adr-validate
+    participant Validate as /blueprint:adr-validate
 
     User->>CMD: Create new ADR for state management
 
@@ -411,7 +411,7 @@ sequenceDiagram
     CMD->>User: ADR created with relationships
 
     Note over User,Validate: Later: Validation
-    User->>Validate: Run /blueprint-adr-validate
+    User->>Validate: Run /blueprint:adr-validate
     Validate->>ADRs: Scan all ADRs
     Validate->>Validate: Check reference integrity
     Validate->>Validate: Check domain conflicts
@@ -463,22 +463,22 @@ graph TD
     end
 
     subgraph Triggers
-        T1["User runs /blueprint-generate-rules"] --> BD
-        T2["User runs /blueprint-generate-commands"] --> BD
+        T1["User runs /blueprint:generate-rules"] --> BD
+        T2["User runs /blueprint:generate-commands"] --> BD
 
         T3["Creating PRP"] --> CS
         T4["Creating work-order"] --> CS
 
-        T5["Running /blueprint-feature-tracker-sync"] --> FT
-        T6["Running /blueprint-feature-tracker-status"] --> FT
+        T5["Running /blueprint:feature-tracker-sync"] --> FT
+        T6["Running /blueprint:feature-tracker-status"] --> FT
 
         T7["New feature discussed"] --> DD
         T8["Architecture decision made"] --> DD
 
         T9["Creating ADR in existing domain"] --> AR
-        T10["Running /blueprint-adr-validate"] --> AR
+        T10["Running /blueprint:adr-validate"] --> AR
 
-        T11["Running /blueprint-upgrade"] --> MG
+        T11["Running /blueprint:upgrade"] --> MG
     end
 
     subgraph Actions
@@ -521,11 +521,11 @@ How the plugin, generated, and custom layers interact:
 ```mermaid
 graph TB
     subgraph "Layer 1: Plugin (Auto-updated)"
-        P1["/blueprint-init"]
-        P2["/blueprint-prd"]
-        P3["/blueprint-prp-create"]
-        P4["/blueprint-prp-execute"]
-        P5["/blueprint-work-order"]
+        P1["/blueprint:init"]
+        P2["/blueprint:prd"]
+        P3["/blueprint:prp-create"]
+        P4["/blueprint:prp-execute"]
+        P5["/blueprint:work-order"]
         P6["Skills: blueprint-development,\nconfidence-scoring, etc."]
     end
 
@@ -540,8 +540,8 @@ graph TB
         C3[".claude/rules/\nManual project rules"]
     end
 
-    PRD[(docs/prds/)] --> Generate[/blueprint-generate-rules/]
-    PRD --> Generate2[/blueprint-generate-commands/]
+    PRD[(docs/prds/)] --> Generate[/blueprint:generate-rules/]
+    PRD --> Generate2[/blueprint:generate-commands/]
 
     Generate --> G1
     Generate2 --> G2

--- a/blueprint-plugin/skills/adr-relationships/skill.md
+++ b/blueprint-plugin/skills/adr-relationships/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: adr-relationships
 description: Domain analysis, conflict detection, and relationship validation for Architecture Decision Records. Use when creating or validating ADRs to ensure consistency.
 user-invocable: false

--- a/blueprint-plugin/skills/blueprint-adr-list/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-adr-list/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-01-29
 modified: 2026-02-06
 reviewed: 2026-02-06

--- a/blueprint-plugin/skills/blueprint-claude-md/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-claude-md/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-17
 modified: 2026-02-17
 reviewed: 2026-02-09
@@ -274,7 +273,7 @@ Use `@import` to reference existing documentation rather than duplicating conten
     Note: "Current Focus" and "Key Files" are managed by Claude's
     auto memory — no need to maintain these in CLAUDE.md.
 
-    Run `/blueprint-status` to see full configuration.
+    Run `/blueprint:status` to see full configuration.
     ```
 
 **CLAUDE.md Best Practices**:

--- a/blueprint-plugin/skills/blueprint-curate-docs/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-curate-docs/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 description: "Curate library or project documentation for ai_docs to optimize AI context"
 args: "[library-name|project:pattern-name]"
 argument-hint: "Library name (e.g., redis, pydantic) or project:pattern-name"

--- a/blueprint-plugin/skills/blueprint-derive-adr/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-derive-adr/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-22
 modified: 2026-02-06
 reviewed: 2026-02-06

--- a/blueprint-plugin/skills/blueprint-derive-plans/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-derive-plans/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2026-01-15
 modified: 2026-03-01
 reviewed: 2026-02-14

--- a/blueprint-plugin/skills/blueprint-derive-prd/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-derive-prd/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-22
 modified: 2026-02-17
 reviewed: 2025-12-22

--- a/blueprint-plugin/skills/blueprint-derive-rules/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-derive-rules/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2026-01-30
 modified: 2026-03-07
 reviewed: 2026-02-14

--- a/blueprint-plugin/skills/blueprint-derive-tests/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-derive-tests/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2026-02-22
 modified: 2026-03-01
 reviewed: 2026-02-22

--- a/blueprint-plugin/skills/blueprint-development/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-development/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2026-03-01
 reviewed: 2026-02-14

--- a/blueprint-plugin/skills/blueprint-docs-list/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-docs-list/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-02-06
 modified: 2026-02-06
 reviewed: 2026-02-06

--- a/blueprint-plugin/skills/blueprint-execute/REFERENCE.md
+++ b/blueprint-plugin/skills/blueprint-execute/REFERENCE.md
@@ -47,7 +47,7 @@ options:
 question: "You've modified generated content. What would you like to do?"
 options:
   - label: "Review changes"
-    description: "Run /blueprint-sync to see what changed"
+    description: "Run /blueprint:sync to see what changed"
   - label: "Promote to custom layer"
     description: "Move edited files to custom layer to prevent regeneration"
   - label: "Skip for now"
@@ -131,7 +131,7 @@ options:
   - label: "Create PRP for feature"
     description: "Create detailed implementation plan"
   - label: "View detailed status"
-    description: "Run /blueprint-feature-tracker-status"
+    description: "Run /blueprint:feature-tracker-status"
   - label: "Continue to other actions"
     description: "Skip feature work for now"
 ```
@@ -149,7 +149,7 @@ Output:
 Blueprint not initialized in this project.
 
 Initializing blueprint structure...
-[Runs /blueprint-init]
+[Runs /blueprint:init]
 ```
 
 ### Example 2: Has Ready PRPs
@@ -181,7 +181,7 @@ Blueprint Status: Up to date (v3.0.0)
 
 No pending PRPs, work-orders, or stale content detected.
 
-[Shows full status from /blueprint-status]
+[Shows full status from /blueprint:status]
 [Prompts: What would you like to do next?]
 ```
 

--- a/blueprint-plugin/skills/blueprint-execute/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-execute/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2026-01-14
 modified: 2026-02-17
 reviewed: 2026-01-30
@@ -45,7 +44,7 @@ Run through these checks in order, executing the first matching action:
 test -f docs/blueprint/manifest.json
 ```
 
-**If NOT initialized**: Run `/blueprint-init`, then **Exit**.
+**If NOT initialized**: Run `/blueprint:init`, then **Exit**.
 
 ### 2. Check for Upgrades
 
@@ -55,7 +54,7 @@ cat docs/blueprint/manifest.json | grep '"format_version"'
 
 **Current format version**: 3.0.0
 
-**If manifest version < 3.0.0**: Run `/blueprint-upgrade`, then **Exit**.
+**If manifest version < 3.0.0**: Run `/blueprint:upgrade`, then **Exit**.
 
 ### 2.5. Check Task Registry for Due Tasks
 
@@ -92,7 +91,7 @@ cat docs/blueprint/manifest.json | jq -r '.derived_rules.last_derived_at // empt
 
 Check each generated rule hash against manifest:
 
-**If stale** (PRDs changed since generation): Prompt to regenerate or skip. If regenerate, run `/blueprint-generate-rules`, then **Exit**.
+**If stale** (PRDs changed since generation): Prompt to regenerate or skip. If regenerate, run `/blueprint:generate-rules`, then **Exit**.
 
 **If modified** (user edited generated files): Prompt to review, promote to custom layer, or skip. Execute selected action, then **Exit**.
 
@@ -103,7 +102,7 @@ prd_count=$(find docs/prds -name "*.md" 2>/dev/null | wc -l)
 generated_count=$(cat docs/blueprint/manifest.json | jq '.generated.rules | length')
 ```
 
-**If PRDs exist but no generated rules**: Run `/blueprint-generate-rules`, then **Exit**.
+**If PRDs exist but no generated rules**: Run `/blueprint:generate-rules`, then **Exit**.
 
 ### 6. Check for Ready PRPs
 
@@ -113,7 +112,7 @@ find docs/prps -name "*.md" -type f 2>/dev/null
 
 **If multiple high-confidence PRPs (>= 2 with score >= 9)**: Prompt for parallel work-order creation or single PRP execution.
 
-**If single PRP or user selects one**: Run `/blueprint-prp-execute {selected-prp}`, then **Exit**.
+**If single PRP or user selects one**: Run `/blueprint:prp-execute {selected-prp}`, then **Exit**.
 
 ### 7. Check for Pending Work-Orders
 
@@ -151,7 +150,7 @@ test -f docs/blueprint/feature-tracker.json
 
 ### 10. No Clear Next Action - Show Status & Options
 
-Run `/blueprint-status` to display full blueprint status with available next actions.
+Run `/blueprint:status` to display full blueprint status with available next actions.
 
 ---
 
@@ -188,8 +187,8 @@ This meta command **delegates** to existing blueprint commands rather than repla
 | Smart next action | `/blueprint:execute` |
 | Morning start | `/blueprint:execute` (figures out where you left off) |
 | After pulling changes | `/blueprint:execute` (checks for stale content) |
-| Direct init | `/blueprint-init` (skip detection) |
-| Direct PRP execution | `/blueprint-prp-execute {name}` (skip detection) |
+| Direct init | `/blueprint:init` (skip detection) |
+| Direct PRP execution | `/blueprint:prp-execute {name}` (skip detection) |
 
 ---
 

--- a/blueprint-plugin/skills/blueprint-feature-tracker-status/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-feature-tracker-status/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2026-01-02
 modified: 2026-02-06
 reviewed: 2026-01-02
@@ -17,7 +16,7 @@ Display feature tracker statistics, phase progress, and completion summary.
    - If not found, report:
      ```
      Feature tracking not enabled in this project.
-     Run `/blueprint-init` and enable feature tracking to get started.
+     Run `/blueprint:init` and enable feature tracking to get started.
      ```
 
 2. **Load tracker data**:
@@ -92,7 +91,7 @@ Display feature tracker statistics, phase progress, and completion summary.
    - If `last_updated` is more than 7 days old, warn:
      ```
      Note: Tracker hasn't been synced in {N} days.
-     Run `/blueprint-feature-tracker-sync` to update.
+     Run `/blueprint:feature-tracker-sync` to update.
      ```
 
 7. **Prompt for next action** (use AskUserQuestion):
@@ -119,7 +118,7 @@ Display feature tracker statistics, phase progress, and completion summary.
    ```
 
    **Based on selection:**
-   - "Sync" → Run `/blueprint-feature-tracker-sync`
+   - "Sync" → Run `/blueprint:feature-tracker-sync`
    - "Start next" → Show next not_started feature details, suggest starting
    - "Continue" → Show in_progress features, suggest continuing
    - "View by status" → Ask which status, then list matching features
@@ -186,7 +185,7 @@ Ready to Start:
 - FR4.1: Basic Crafting (Phase 4)
 - FR4.2: Recipe System (Phase 4)
 
-Note: 14 features ready to start. Run `/blueprint-feature-tracker-sync` before beginning new work.
+Note: 14 features ready to start. Run `/blueprint:feature-tracker-sync` before beginning new work.
 ```
 
 **Quick Commands** (shown at end):

--- a/blueprint-plugin/skills/blueprint-feature-tracker-sync/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-feature-tracker-sync/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2026-01-02
 modified: 2026-02-17
 reviewed: 2026-02-04
@@ -80,7 +79,7 @@ test -f docs/blueprint/feature-tracker.json
 **If not found**, report:
 ```
 Feature tracking not enabled in this project.
-Run `/blueprint-init` and enable feature tracking to get started.
+Run `/blueprint:init` and enable feature tracking to get started.
 ```
 
 ### Step 2: Load current state
@@ -214,7 +213,7 @@ Use AskUserQuestion:
 question: "Sync complete. What would you like to do next?"
 options:
   - label: "View detailed status"
-    description: "Run /blueprint-feature-tracker-status for full breakdown"
+    description: "Run /blueprint:feature-tracker-status for full breakdown"
   - label: "Continue development"
     description: "Run /project:continue to work on next task"
   - label: "I'm done"

--- a/blueprint-plugin/skills/blueprint-generate-rules/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-generate-rules/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2026-02-17
 reviewed: 2026-02-09

--- a/blueprint-plugin/skills/blueprint-migration/skill.md
+++ b/blueprint-plugin/skills/blueprint-migration/skill.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 name: blueprint-migration
 description: Versioned migration procedures for upgrading blueprint structure between format versions
 user-invocable: false

--- a/blueprint-plugin/skills/blueprint-promote/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-promote/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-22
 modified: 2026-02-06
 reviewed: 2025-12-22

--- a/blueprint-plugin/skills/blueprint-prp-create/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-prp-create/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 description: "Create a PRP (Product Requirement Prompt) with systematic research, curated context, and validation gates"
 args: "[feature-name]"
 argument-hint: "Feature name for the PRP (e.g., auth-oauth2, api-rate-limiting)"

--- a/blueprint-plugin/skills/blueprint-prp-execute/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-prp-execute/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 description: "Execute a PRP with validation loop, TDD workflow, and quality gates"
 args: "[prp-name]"
 argument-hint: "Name of PRP to execute (e.g., feature-auth-oauth2)"

--- a/blueprint-plugin/skills/blueprint-rules/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-rules/SKILL.md
@@ -188,7 +188,7 @@ Project rules override user-level rules. Path-specific rules load conditionally 
     - Global: {count}
     - Scoped: {count}
 
-    Run `/blueprint-status` to see full configuration.
+    Run `/blueprint:status` to see full configuration.
     ```
 
 11. **Prompt for next action** (use AskUserQuestion):

--- a/blueprint-plugin/skills/blueprint-status/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-status/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-17
 modified: 2026-02-17
 reviewed: 2025-12-22

--- a/blueprint-plugin/skills/blueprint-sync-ids/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-sync-ids/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2026-01-20
 modified: 2026-02-17
 reviewed: 2026-01-20

--- a/blueprint-plugin/skills/blueprint-sync/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-sync/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-22
 modified: 2026-02-07
 reviewed: 2025-12-22

--- a/blueprint-plugin/skills/blueprint-work-order/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-work-order/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2026-02-06
 reviewed: 2025-12-26

--- a/blueprint-plugin/skills/confidence-scoring/SKILL.md
+++ b/blueprint-plugin/skills/confidence-scoring/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2026-02-06
 reviewed: 2025-12-16

--- a/blueprint-plugin/skills/document-detection/skill.md
+++ b/blueprint-plugin/skills/document-detection/skill.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2026-01-09
 modified: 2026-03-12
 reviewed: 2026-02-06

--- a/blueprint-plugin/skills/document-linking/skill.md
+++ b/blueprint-plugin/skills/document-linking/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-01-20
 modified: 2026-02-06
 reviewed: 2026-01-20

--- a/blueprint-plugin/skills/feature-tracking/SKILL.md
+++ b/blueprint-plugin/skills/feature-tracking/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-01-02
 modified: 2026-02-06
 reviewed: 2026-02-08
@@ -202,8 +201,8 @@ For each feature, verify:
 ## Commands
 
 Related blueprint commands:
-- `/blueprint-feature-tracker-status`: Display statistics and completion summary
-- `/blueprint-feature-tracker-sync`: Synchronize tracker with sync targets
+- `/blueprint:feature-tracker-status`: Display statistics and completion summary
+- `/blueprint:feature-tracker-sync`: Synchronize tracker with sync targets
 
 ## Example: Updating Feature Status
 
@@ -223,7 +222,7 @@ When completing a feature:
    }
    ```
 
-2. Run `/blueprint-feature-tracker-sync` to update:
+2. Run `/blueprint:feature-tracker-sync` to update:
    - Move task from `tasks.in_progress` to `tasks.completed`
    - TODO.md checkboxes
    - Statistics recalculation

--- a/code-quality-plugin/skills/ast-grep-search/SKILL.md
+++ b/code-quality-plugin/skills/ast-grep-search/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-01-24
 reviewed: 2026-01-24

--- a/code-quality-plugin/skills/code-antipatterns-analysis/SKILL.md
+++ b/code-quality-plugin/skills/code-antipatterns-analysis/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2026-02-27
 reviewed: 2025-12-16

--- a/code-quality-plugin/skills/code-antipatterns/SKILL.md
+++ b/code-quality-plugin/skills/code-antipatterns/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2026-02-03
 reviewed: 2025-12-16

--- a/code-quality-plugin/skills/code-refactor/SKILL.md
+++ b/code-quality-plugin/skills/code-refactor/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2026-03-09
 reviewed: 2026-03-09

--- a/code-quality-plugin/skills/code-review-checklist/SKILL.md
+++ b/code-quality-plugin/skills/code-review-checklist/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: code-review-checklist
 description: Structured code review approach covering security, quality, performance, and consistency.
 user-invocable: false

--- a/code-quality-plugin/skills/code-review/SKILL.md
+++ b/code-quality-plugin/skills/code-review/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 created: 2025-12-16
 modified: 2026-03-09
 reviewed: 2026-03-09

--- a/code-quality-plugin/skills/code-silent-degradation/SKILL.md
+++ b/code-quality-plugin/skills/code-silent-degradation/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2026-02-22
 modified: 2026-02-22
 reviewed: 2026-02-22

--- a/code-quality-plugin/skills/debugging-methodology/SKILL.md
+++ b/code-quality-plugin/skills/debugging-methodology/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: debugging-methodology
 description: Systematic debugging approach with tool recommendations for memory, performance, and system-level issues.
 user-invocable: false

--- a/code-quality-plugin/skills/docs-quality-check/SKILL.md
+++ b/code-quality-plugin/skills/docs-quality-check/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-01-08
 modified: 2026-03-01
 reviewed: 2026-01-08

--- a/code-quality-plugin/skills/dry-consolidation/SKILL.md
+++ b/code-quality-plugin/skills/dry-consolidation/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 name: dry-consolidation
 description: |
   Find and extract duplicated code into shared abstractions. Use when you see repeated

--- a/code-quality-plugin/skills/lint-check/SKILL.md
+++ b/code-quality-plugin/skills/lint-check/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-25
 reviewed: 2025-12-16

--- a/code-quality-plugin/skills/linter-autofix/SKILL.md
+++ b/code-quality-plugin/skills/linter-autofix/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: linter-autofix
 description: Cross-language linter autofix commands and common fix patterns for biome, ruff, clippy, shellcheck, and more.
 allowed-tools: Bash(ruff *), Bash(eslint *), Bash(biome *), Bash(prettier *), Read, Edit, Grep

--- a/codebase-attributes-plugin/skills/attributes-collect/SKILL.md
+++ b/codebase-attributes-plugin/skills/attributes-collect/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: attributes-collect
 description: Collect codebase health attributes as structured JSON. Use when you need a structured assessment of project health before routing to specialized agents.
 allowed-tools: Bash(test *), Bash(wc *), Read, Glob, Grep, TodoWrite

--- a/codebase-attributes-plugin/skills/attributes-dashboard/SKILL.md
+++ b/codebase-attributes-plugin/skills/attributes-dashboard/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: attributes-dashboard
 description: Compact text-based health dashboard showing scores, findings, and severity breakdown. Use for at-a-glance codebase health visibility.
 allowed-tools: Bash(test *), Read, Glob, Grep

--- a/codebase-attributes-plugin/skills/attributes-route/SKILL.md
+++ b/codebase-attributes-plugin/skills/attributes-route/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 name: attributes-route
 description: Route to specialized agents based on codebase health attributes. Use after /attributes:collect to automatically address findings by severity.
 allowed-tools: Read, Glob, Grep, Agent, TodoWrite

--- a/communication-plugin/skills/google-chat-formatting/skill.md
+++ b/communication-plugin/skills/google-chat-formatting/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16

--- a/communication-plugin/skills/ticket-drafting-guidelines/skill.md
+++ b/communication-plugin/skills/ticket-drafting-guidelines/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2026-02-08

--- a/component-patterns-plugin/skills/components-version-badge/SKILL.md
+++ b/component-patterns-plugin/skills/components-version-badge/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-02-03
 modified: 2026-02-10
 reviewed: 2025-02-03

--- a/component-patterns-plugin/skills/version-badge-pattern/SKILL.md
+++ b/component-patterns-plugin/skills/version-badge-pattern/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: version-badge-pattern
 description: |
   Implement a version badge UI component showing build version, git commit, and

--- a/configure-plugin/skills/ci-workflows/SKILL.md
+++ b/configure-plugin/skills/ci-workflows/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-03-04
 reviewed: 2025-12-16

--- a/configure-plugin/skills/claude-security-settings/SKILL.md
+++ b/configure-plugin/skills/claude-security-settings/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: claude-security-settings
 description: |
   Configure Claude Code security settings including permission wildcards, shell

--- a/configure-plugin/skills/config-sync/SKILL.md
+++ b/configure-plugin/skills/config-sync/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 name: config-sync
 description: |
   Extract, compare, and propagate tooling improvements across FVH repos.

--- a/configure-plugin/skills/configure-all/SKILL.md
+++ b/configure-plugin/skills/configure-all/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2026-02-10
 reviewed: 2025-12-16

--- a/configure-plugin/skills/configure-argocd-automerge/SKILL.md
+++ b/configure-plugin/skills/configure-argocd-automerge/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-02-03
 modified: 2026-02-13
 reviewed: 2026-02-03

--- a/configure-plugin/skills/configure-claude-plugins/SKILL.md
+++ b/configure-plugin/skills/configure-claude-plugins/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2026-01-23
 modified: 2026-02-10
 reviewed: 2026-01-30

--- a/configure-plugin/skills/configure-pre-commit/SKILL.md
+++ b/configure-plugin/skills/configure-pre-commit/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2026-02-10
 reviewed: 2025-12-16

--- a/configure-plugin/skills/configure-status/SKILL.md
+++ b/configure-plugin/skills/configure-status/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-10
 reviewed: 2025-12-16

--- a/configure-plugin/skills/configure-web-session/SKILL.md
+++ b/configure-plugin/skills/configure-web-session/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 name: configure-web-session
 description: |
   Set up a SessionStart hook so Claude Code on the web installs project-specific

--- a/configure-plugin/skills/configure-workflows/SKILL.md
+++ b/configure-plugin/skills/configure-workflows/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2026-03-04
 reviewed: 2025-12-16

--- a/configure-plugin/skills/go-feature-flag/SKILL.md
+++ b/configure-plugin/skills/go-feature-flag/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-25
 reviewed: 2025-12-16

--- a/configure-plugin/skills/openfeature/SKILL.md
+++ b/configure-plugin/skills/openfeature/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-06
 reviewed: 2025-12-16

--- a/configure-plugin/skills/pre-commit-standards/SKILL.md
+++ b/configure-plugin/skills/pre-commit-standards/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-06
 reviewed: 2025-12-16

--- a/configure-plugin/skills/readme-standards/SKILL.md
+++ b/configure-plugin/skills/readme-standards/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-17
 modified: 2026-02-06
 reviewed: 2025-12-17

--- a/configure-plugin/skills/release-please-standards/SKILL.md
+++ b/configure-plugin/skills/release-please-standards/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-06
 reviewed: 2025-12-16

--- a/configure-plugin/skills/skaffold-standards/SKILL.md
+++ b/configure-plugin/skills/skaffold-standards/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-06
 reviewed: 2025-12-16

--- a/container-plugin/skills/container-development/SKILL.md
+++ b/container-plugin/skills/container-development/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-01-19
 reviewed: 2026-01-19

--- a/container-plugin/skills/deploy-handoff/SKILL.md
+++ b/container-plugin/skills/deploy-handoff/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2026-02-10
 reviewed: 2025-12-16

--- a/container-plugin/skills/deploy-release/SKILL.md
+++ b/container-plugin/skills/deploy-release/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/container-plugin/skills/go-containers/SKILL.md
+++ b/container-plugin/skills/go-containers/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-01-15
 modified: 2026-01-15
 reviewed: 2026-01-15

--- a/container-plugin/skills/nodejs-containers/SKILL.md
+++ b/container-plugin/skills/nodejs-containers/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-01-15
 modified: 2026-02-14
 reviewed: 2026-01-15

--- a/container-plugin/skills/python-containers/SKILL.md
+++ b/container-plugin/skills/python-containers/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-01-15
 modified: 2026-02-14
 reviewed: 2026-01-15

--- a/container-plugin/skills/skaffold-filesync/skill.md
+++ b/container-plugin/skills/skaffold-filesync/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: skaffold-filesync
 description: |
   Fast iterative development with Skaffold file sync - copy changed files to running containers

--- a/container-plugin/skills/skaffold-orbstack/SKILL.md
+++ b/container-plugin/skills/skaffold-orbstack/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-06
 reviewed: 2025-12-16

--- a/container-plugin/skills/skaffold-testing/skill.md
+++ b/container-plugin/skills/skaffold-testing/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: skaffold-testing
 description: |
   Container image validation with Skaffold test and verify stages. Covers container-structure-tests

--- a/css-plugin/skills/lightning-css/SKILL.md
+++ b/css-plugin/skills/lightning-css/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: Lightning CSS
 description: |
   CSS transpilation, bundling, and minification using Lightning CSS (Rust-based).

--- a/css-plugin/skills/unocss/SKILL.md
+++ b/css-plugin/skills/unocss/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: UnoCSS
 description: |
   Atomic CSS engine for on-demand utility class generation using UnoCSS.

--- a/docs/adrs/0005-blueprint-development-methodology.md
+++ b/docs/adrs/0005-blueprint-development-methodology.md
@@ -38,10 +38,10 @@ PRD → PRP → Work Order
 
 | Component | Type | Purpose |
 |-----------|------|---------|
-| `/blueprint-init` | Command | Initialize blueprint structure in project |
-| `/blueprint-generate-commands` | Command | Create project-specific commands from PRD |
-| `/blueprint-generate-skills` | Command | Create project-specific skills from PRP |
-| `/blueprint-work-order` | Command | Generate work order from PRP |
+| `/blueprint:init` | Command | Initialize blueprint structure in project |
+| `/blueprint:generate-commands` | Command | Create project-specific commands from PRD |
+| `/blueprint:generate-skills` | Command | Create project-specific skills from PRP |
+| `/blueprint:work-order` | Command | Generate work order from PRP |
 | `/prp-create` | Command | Create new PRP from PRD |
 | `/prp-execute` | Command | Execute PRP with progress tracking |
 | `blueprint-development` | Skill | Methodology guidance and templates |

--- a/docs/adrs/0007-namespace-based-command-organization.md
+++ b/docs/adrs/0007-namespace-based-command-organization.md
@@ -56,7 +56,7 @@ commands/
 
 Some commands remain at root level for discoverability:
 
-- `/blueprint-init` - High-frequency entry point
+- `/blueprint:init` - High-frequency entry point
 - `/prp-create` - Direct access to PRP creation
 - `/handoffs` - Cross-cutting utility
 

--- a/docs/adrs/0008-semantic-versioning-with-manifest.md
+++ b/docs/adrs/0008-semantic-versioning-with-manifest.md
@@ -77,8 +77,8 @@ PATCH: Bug fixes, documentation updates
 
 | Command | Purpose |
 |---------|---------|
-| `/blueprint-status` | Display version, configuration, upgrade availability |
-| `/blueprint-upgrade` | Upgrade manifest to latest format |
+| `/blueprint:status` | Display version, configuration, upgrade availability |
+| `/blueprint:upgrade` | Upgrade manifest to latest format |
 
 ### Marketplace Sync
 
@@ -119,7 +119,7 @@ The `marketplace.json` reflects plugin versions:
 2. Update `plugin.json` version
 3. Update `marketplace.json` version
 4. Write migration notes if MAJOR change
-5. Update `/blueprint-upgrade` if manifest format changes
+5. Update `/blueprint:upgrade` if manifest format changes
 
 ### Breaking Changes (MAJOR)
 

--- a/documentation-plugin/skills/claude-blog-sources/SKILL.md
+++ b/documentation-plugin/skills/claude-blog-sources/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-27
 reviewed: 2026-02-09

--- a/documentation-plugin/skills/docs-decommission/SKILL.md
+++ b/documentation-plugin/skills/docs-decommission/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2026-02-08

--- a/documentation-plugin/skills/docs-generate/SKILL.md
+++ b/documentation-plugin/skills/docs-generate/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2026-03-09
 reviewed: 2026-03-09

--- a/documentation-plugin/skills/docs-latex/SKILL.md
+++ b/documentation-plugin/skills/docs-latex/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 name: docs-latex
 description: |
   Convert Markdown documents to professional LaTeX with TikZ visualizations and compile to PDF.

--- a/documentation-plugin/skills/docs-sync/SKILL.md
+++ b/documentation-plugin/skills/docs-sync/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 description: "Synchronize documentation with actual skills, commands, and agents in the codebase"
 args: "[--scope <type>] [--dry-run] [--verbose]"
 argument-hint: "--scope skills|commands|agents, --dry-run to preview, --verbose for details"

--- a/evaluate-plugin/skills/evaluate-improve/SKILL.md
+++ b/evaluate-plugin/skills/evaluate-improve/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: evaluate-improve
 description: |
   Analyze evaluation results and suggest concrete skill improvements. Use after

--- a/evaluate-plugin/skills/evaluate-plugin-batch/SKILL.md
+++ b/evaluate-plugin/skills/evaluate-plugin-batch/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: evaluate-plugin-batch
 description: |
   Batch evaluate all skills in a plugin. Runs /evaluate:skill for each skill

--- a/evaluate-plugin/skills/evaluate-report/SKILL.md
+++ b/evaluate-plugin/skills/evaluate-report/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: evaluate-report
 description: |
   View evaluation results and benchmark reports. Use when you want to see

--- a/evaluate-plugin/skills/evaluate-skill/SKILL.md
+++ b/evaluate-plugin/skills/evaluate-skill/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: evaluate-skill
 description: |
   Evaluate a skill's effectiveness by running test cases and grading results.

--- a/feedback-plugin/skills/feedback-session/SKILL.md
+++ b/feedback-plugin/skills/feedback-session/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: feedback-session
 description: |
   Analyze current session for skill feedback and create GitHub issues. Use when

--- a/finops-plugin/skills/finops-caches/SKILL.md
+++ b/finops-plugin/skills/finops-caches/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 description: Analyze cache usage - size, breakdown by prefix/branch, stale cache detection
 args: "[repo|org:orgname]"
 allowed-tools: Bash(gh api *), Bash(gh repo *), Bash(bash *), Read, TodoWrite

--- a/finops-plugin/skills/finops-compare/SKILL.md
+++ b/finops-plugin/skills/finops-compare/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 description: Compare FinOps metrics across multiple repositories in an organization
 args: "<org> [repo1 repo2 ...] [--limit N]"
 allowed-tools: Bash(gh api *), Bash(gh repo *), Bash(bash *), Read, TodoWrite

--- a/finops-plugin/skills/finops-overview/SKILL.md
+++ b/finops-plugin/skills/finops-overview/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 description: Quick FinOps summary - org billing and current repo workflow/cache stats
 args: "[org]"
 allowed-tools: Bash(gh api *), Bash(gh repo *), Bash(gh workflow *), Bash(bash *), Read, TodoWrite

--- a/finops-plugin/skills/finops-waste/SKILL.md
+++ b/finops-plugin/skills/finops-waste/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 description: Identify workflow waste patterns and suggest fixes - skipped runs, bot triggers, missing concurrency
 args: "[repo]"
 allowed-tools: Bash(gh api *), Bash(gh workflow *), Bash(gh repo *), Bash(bash *), Read, Grep, Glob, Edit, TodoWrite

--- a/finops-plugin/skills/finops-workflows/SKILL.md
+++ b/finops-plugin/skills/finops-workflows/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 description: Analyze workflow runs - frequency, duration, success rates, and efficiency
 args: "[repo] [--created RANGE]"
 allowed-tools: Bash(gh api *), Bash(gh workflow *), Bash(gh repo *), Bash(bash *), Read, TodoWrite

--- a/finops-plugin/skills/github-actions-cache-optimization/skill.md
+++ b/finops-plugin/skills/github-actions-cache-optimization/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: github-actions-cache-optimization
 description: |
   Analyze and optimize GitHub Actions cache usage. Use when investigating

--- a/finops-plugin/skills/github-actions-finops/skill.md
+++ b/finops-plugin/skills/github-actions-finops/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: github-actions-finops
 description: |
   Analyze GitHub Actions billing, workflow efficiency, and waste patterns.

--- a/git-plugin/skills/gh-cli-agentic/skill.md
+++ b/git-plugin/skills/gh-cli-agentic/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: gh-cli-agentic
 description: GitHub CLI commands optimized for AI agent workflows with JSON output and deterministic execution patterns.
 user-invocable: false

--- a/git-plugin/skills/gh-workflow-monitoring/skill.md
+++ b/git-plugin/skills/gh-workflow-monitoring/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: gh-workflow-monitoring
 description: Monitor GitHub Actions workflow runs using blocking watch commands instead of polling with timeouts.
 user-invocable: false

--- a/git-plugin/skills/git-api-pr/SKILL.md
+++ b/git-plugin/skills/git-api-pr/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: git-api-pr
 description: Create PRs via GitHub API without local git operations. Use when you want to submit file changes as a PR without committing locally — for quick fixes, typos, config updates, or when you want a clean workflow that bypasses local git state entirely.
 args: <file...> --title <title> [--base <branch>] [--branch <name>] [--body <text>] [--draft] [--delete]

--- a/git-plugin/skills/git-branch-naming/SKILL.md
+++ b/git-plugin/skills/git-branch-naming/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: git-branch-naming
 description: |
   Git branch naming conventions for consistent, traceable branches. Use when creating

--- a/git-plugin/skills/git-branch-pr-workflow/SKILL.md
+++ b/git-plugin/skills/git-branch-pr-workflow/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-03-04
 reviewed: 2026-03-04

--- a/git-plugin/skills/git-cli-agentic/skill.md
+++ b/git-plugin/skills/git-cli-agentic/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: git-cli-agentic
 description: Git commands optimized for AI agent workflows with porcelain output and deterministic execution patterns.
 user-invocable: false

--- a/git-plugin/skills/git-commit-push-pr/SKILL.md
+++ b/git-plugin/skills/git-commit-push-pr/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 name: git-commit-push-pr
 created: 2025-12-16
 modified: 2026-03-15

--- a/git-plugin/skills/git-commit-trailers/SKILL.md
+++ b/git-plugin/skills/git-commit-trailers/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-03-05
 modified: 2026-03-05
 reviewed: 2026-03-05

--- a/git-plugin/skills/git-commit-workflow/SKILL.md
+++ b/git-plugin/skills/git-commit-workflow/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2026-01-15

--- a/git-plugin/skills/git-commit/skill.md
+++ b/git-plugin/skills/git-commit/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-01-21
 modified: 2026-02-14
 reviewed: 2026-02-14

--- a/git-plugin/skills/git-conflicts/SKILL.md
+++ b/git-plugin/skills/git-conflicts/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 name: git-conflicts
 description: |
   Resolve merge conflicts. Use when a merge or rebase has conflicts, a PR

--- a/git-plugin/skills/git-derive-docs/SKILL.md
+++ b/git-plugin/skills/git-derive-docs/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2026-01-24
 modified: 2026-02-03
 reviewed: 2026-01-24

--- a/git-plugin/skills/git-fix-pr/SKILL.md
+++ b/git-plugin/skills/git-fix-pr/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2026-01-17
 reviewed: 2026-01-17

--- a/git-plugin/skills/git-fork-workflow/SKILL.md
+++ b/git-plugin/skills/git-fork-workflow/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2026-03-02
 modified: 2026-03-02
 reviewed: 2026-03-02

--- a/git-plugin/skills/git-issue-hierarchy/SKILL.md
+++ b/git-plugin/skills/git-issue-hierarchy/SKILL.md
@@ -11,7 +11,6 @@ args: "<parent-issue> [--add <N...>] [--remove <N...>] [--create \"title\"] [--s
 argument-hint: <parent-issue> [--add N] [--status] [--deps] [--block N]
 user-invocable: true
 allowed-tools: Bash(gh api *), Bash(gh issue *), Bash(git remote *), Read, Grep, Glob, TodoWrite
-model: sonnet
 ---
 
 ## Context

--- a/git-plugin/skills/git-issue-manage/SKILL.md
+++ b/git-plugin/skills/git-issue-manage/SKILL.md
@@ -12,7 +12,6 @@ args: "<operation> <issue-numbers...> [options]"
 argument-hint: <transfer|pin|lock|develop|bulk|fields> <issue-numbers...>
 user-invocable: true
 allowed-tools: Bash(gh issue *), Bash(gh api *), Bash(git switch *), Bash(git remote *), Read, Grep, Glob, TodoWrite, AskUserQuestion
-model: sonnet
 ---
 
 ## Context

--- a/git-plugin/skills/git-maintain/SKILL.md
+++ b/git-plugin/skills/git-maintain/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-01-16
 reviewed: 2026-01-16

--- a/git-plugin/skills/git-pr-feedback/SKILL.md
+++ b/git-plugin/skills/git-pr-feedback/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 created: 2026-01-30
 modified: 2026-03-24
 reviewed: 2026-02-26

--- a/git-plugin/skills/git-pr/skill.md
+++ b/git-plugin/skills/git-pr/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-01-21
 modified: 2026-03-04
 reviewed: 2026-03-04

--- a/git-plugin/skills/git-push/skill.md
+++ b/git-plugin/skills/git-push/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-01-21
 modified: 2026-02-18
 reviewed: 2026-01-23

--- a/git-plugin/skills/git-rebase-patterns/SKILL.md
+++ b/git-plugin/skills/git-rebase-patterns/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: git-rebase-patterns
 description: |
   Advanced git rebase patterns for linear history, stacked PRs, and clean commit management.

--- a/git-plugin/skills/git-repo-detection/SKILL.md
+++ b/git-plugin/skills/git-repo-detection/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/git-plugin/skills/git-resolve-conflicts/SKILL.md
+++ b/git-plugin/skills/git-resolve-conflicts/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: git-resolve-conflicts
 description: |
   Resolve merge conflicts in pull requests. Use when a PR has merge conflicts

--- a/git-plugin/skills/git-security-checks/SKILL.md
+++ b/git-plugin/skills/git-security-checks/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 created: 2025-12-16
 modified: 2026-02-16
 reviewed: 2026-02-16

--- a/git-plugin/skills/git-upstream-pr/SKILL.md
+++ b/git-plugin/skills/git-upstream-pr/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 name: git-upstream-pr
 description: |
   Submit clean PRs to upstream repositories from a fork. Use when you need to

--- a/git-plugin/skills/github-issue-autodetect/skill.md
+++ b/git-plugin/skills/github-issue-autodetect/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-01-15
 modified: 2026-01-15
 reviewed: 2026-01-15

--- a/git-plugin/skills/github-issue-writing/skill.md
+++ b/git-plugin/skills/github-issue-writing/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-01-30
 modified: 2026-03-19
 reviewed: 2026-03-19

--- a/git-plugin/skills/github-labels/SKILL.md
+++ b/git-plugin/skills/github-labels/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-04-01
 reviewed: 2026-04-01

--- a/git-plugin/skills/github-pr-title/skill.md
+++ b/git-plugin/skills/github-pr-title/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-01-30
 modified: 2026-03-04
 reviewed: 2026-03-04

--- a/git-plugin/skills/release-please-configuration/SKILL.md
+++ b/git-plugin/skills/release-please-configuration/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-28
 modified: 2025-12-28
 reviewed: 2025-12-28

--- a/git-plugin/skills/release-please-pr-workflow/skill.md
+++ b/git-plugin/skills/release-please-pr-workflow/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-01-09
 modified: 2026-01-09
 reviewed: 2026-01-09

--- a/git-plugin/skills/release-please-protection/SKILL.md
+++ b/git-plugin/skills/release-please-protection/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2026-02-06
 reviewed: 2025-12-16

--- a/git-repo-agent/src/git_repo_agent/prompts/generated/docs_skills.md
+++ b/git-repo-agent/src/git_repo_agent/prompts/generated/docs_skills.md
@@ -716,7 +716,7 @@ Use `@import` to reference existing documentation rather than duplicating conten
     Note: "Current Focus" and "Key Files" are managed by Claude's
     auto memory — no need to maintain these in CLAUDE.md.
 
-    Run `/blueprint-status` to see full configuration.
+    Run `/blueprint:status` to see full configuration.
     ```
 
 **CLAUDE.md Best Practices**:

--- a/github-actions-plugin/skills/ci-autofix-reusable/SKILL.md
+++ b/github-actions-plugin/skills/ci-autofix-reusable/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 name: ci-autofix-reusable
 description: |
   Generate a reusable GitHub Actions workflow for automated CI failure detection

--- a/github-actions-plugin/skills/claude-code-github-workflows/skill.md
+++ b/github-actions-plugin/skills/claude-code-github-workflows/skill.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/github-actions-plugin/skills/github-actions-auth-security/skill.md
+++ b/github-actions-plugin/skills/github-actions-auth-security/skill.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/github-actions-plugin/skills/github-actions-inspection/skill.md
+++ b/github-actions-plugin/skills/github-actions-inspection/skill.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16

--- a/github-actions-plugin/skills/github-actions-mcp-config/skill.md
+++ b/github-actions-plugin/skills/github-actions-mcp-config/skill.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/github-actions-plugin/skills/github-issue-search/skill.md
+++ b/github-actions-plugin/skills/github-issue-search/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16

--- a/github-actions-plugin/skills/github-social-preview/skill.md
+++ b/github-actions-plugin/skills/github-social-preview/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-06
 reviewed: 2025-12-16

--- a/github-actions-plugin/skills/github-workflow-auto-fix/SKILL.md
+++ b/github-actions-plugin/skills/github-workflow-auto-fix/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 name: github-workflow-auto-fix
 description: |
   Set up automated CI failure detection and fixing using Claude Code. Use when

--- a/github-actions-plugin/skills/workflow-dev/SKILL.md
+++ b/github-actions-plugin/skills/workflow-dev/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2026-02-10
 reviewed: 2025-12-16

--- a/health-plugin/skills/health-agentic-audit/SKILL.md
+++ b/health-plugin/skills/health-agentic-audit/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2026-02-05
 modified: 2026-02-10
 reviewed: 2026-02-08

--- a/health-plugin/skills/health-audit/SKILL.md
+++ b/health-plugin/skills/health-audit/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2026-02-05
 modified: 2026-03-18
 reviewed: 2026-02-05

--- a/health-plugin/skills/health-check/SKILL.md
+++ b/health-plugin/skills/health-check/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-02-04
 modified: 2026-03-26
 reviewed: 2026-03-26

--- a/health-plugin/skills/health-plugins/SKILL.md
+++ b/health-plugin/skills/health-plugins/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2026-02-04
 modified: 2026-03-18
 reviewed: 2026-02-05

--- a/health-plugin/skills/plugin-registry/SKILL.md
+++ b/health-plugin/skills/plugin-registry/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: plugin-registry
 description: |
   Understanding Claude Code's plugin registry structure, installation scopes,

--- a/health-plugin/skills/settings-configuration/SKILL.md
+++ b/health-plugin/skills/settings-configuration/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: settings-configuration
 description: |
   Claude Code settings file hierarchy, permission wildcards, and configuration

--- a/home-assistant-plugin/skills/ha-automations/SKILL.md
+++ b/home-assistant-plugin/skills/ha-automations/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-02-01
 modified: 2026-02-14
 reviewed: 2026-02-08

--- a/home-assistant-plugin/skills/ha-configuration/SKILL.md
+++ b/home-assistant-plugin/skills/ha-configuration/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-02-01
 modified: 2025-02-01
 reviewed: 2025-02-01

--- a/home-assistant-plugin/skills/ha-entities/SKILL.md
+++ b/home-assistant-plugin/skills/ha-entities/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-02-01
 modified: 2026-02-14
 reviewed: 2025-02-01

--- a/home-assistant-plugin/skills/ha-validate/SKILL.md
+++ b/home-assistant-plugin/skills/ha-validate/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 description: Validate Home Assistant YAML configuration files for syntax and structure errors
 args: "[path]"
 allowed-tools: Bash(python3 *), Bash(docker exec *), Bash(ha *), Read, Grep, Glob

--- a/hooks-plugin/skills/hooks-configuration/SKILL.md
+++ b/hooks-plugin/skills/hooks-configuration/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: hooks-configuration
 description: |
   Claude Code hooks configuration and development. Covers hook lifecycle events,

--- a/hooks-plugin/skills/hooks-permission-request-hook/SKILL.md
+++ b/hooks-plugin/skills/hooks-permission-request-hook/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: hooks-permission-request-hook
 description: |
   Generate a PermissionRequest hook that auto-approves safe operations and auto-denies

--- a/hooks-plugin/skills/hooks-session-end-issue-hook/SKILL.md
+++ b/hooks-plugin/skills/hooks-session-end-issue-hook/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: hooks-session-end-issue-hook
 description: |
   Configure a Stop hook that surfaces unfinished todos before a session ends and suggests

--- a/hooks-plugin/skills/hooks-session-start-hook/SKILL.md
+++ b/hooks-plugin/skills/hooks-session-start-hook/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: hooks-session-start-hook
 description: |
   Create a SessionStart hook for Claude Code on the web. Use when setting up a repository

--- a/kubernetes-plugin/skills/argocd-login/SKILL.md
+++ b/kubernetes-plugin/skills/argocd-login/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-06
 reviewed: 2025-12-16

--- a/kubernetes-plugin/skills/helm-chart-development/SKILL.md
+++ b/kubernetes-plugin/skills/helm-chart-development/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16

--- a/kubernetes-plugin/skills/helm-debugging/SKILL.md
+++ b/kubernetes-plugin/skills/helm-debugging/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16

--- a/kubernetes-plugin/skills/helm-release-management/SKILL.md
+++ b/kubernetes-plugin/skills/helm-release-management/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16

--- a/kubernetes-plugin/skills/helm-release-recovery/SKILL.md
+++ b/kubernetes-plugin/skills/helm-release-recovery/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16

--- a/kubernetes-plugin/skills/helm-values-management/SKILL.md
+++ b/kubernetes-plugin/skills/helm-values-management/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16

--- a/kubernetes-plugin/skills/kubectl-debugging/SKILL.md
+++ b/kubernetes-plugin/skills/kubectl-debugging/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/kubernetes-plugin/skills/kubernetes-operations/SKILL.md
+++ b/kubernetes-plugin/skills/kubernetes-operations/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2026-02-05
 reviewed: 2025-12-16

--- a/langchain-plugin/skills/deep-agents/skill.md
+++ b/langchain-plugin/skills/deep-agents/skill.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 name: deep-agents
 description: |
   Build hierarchical AI agents using the deep-agents TypeScript/npm package. Use when

--- a/langchain-plugin/skills/langchain-development/skill.md
+++ b/langchain-plugin/skills/langchain-development/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: langchain-development
 description: LangChain JS/TS framework for building LLM-powered applications - models, chains, tools, and RAG patterns.
 user-invocable: false

--- a/langchain-plugin/skills/langchain-init/SKILL.md
+++ b/langchain-plugin/skills/langchain-init/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 description: Initialize a new LangChain TypeScript project with recommended configuration
 args: [project-name]
 allowed-tools: Bash(uv *), Bash(pip *), Bash(python *), Read, Write, Edit

--- a/langchain-plugin/skills/langgraph-agents/skill.md
+++ b/langchain-plugin/skills/langgraph-agents/skill.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 name: langgraph-agents
 description: |
   Build stateful AI agents in Python using LangGraph's graph-based workflow framework.

--- a/migration-patterns-plugin/skills/dual-write/SKILL.md
+++ b/migration-patterns-plugin/skills/dual-write/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: dual-write
 description: |
   Dual write (double write) migration pattern for safely transitioning between data stores.

--- a/migration-patterns-plugin/skills/shadow-mode/SKILL.md
+++ b/migration-patterns-plugin/skills/shadow-mode/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: shadow-mode
 description: |
   Shadow mode (shadow traffic, dark launching) pattern for validating new systems under

--- a/networking-plugin/skills/dns-tools/skill.md
+++ b/networking-plugin/skills/dns-tools/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: dns-tools
 description: Modern DNS query tools with focus on dog for readable, colorized output and modern protocol support (DoT/DoH).
 user-invocable: false

--- a/networking-plugin/skills/http-load-testing/skill.md
+++ b/networking-plugin/skills/http-load-testing/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-01-01
 modified: 2026-01-01
 reviewed: 2026-01-01

--- a/networking-plugin/skills/layer2-discovery/skill.md
+++ b/networking-plugin/skills/layer2-discovery/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-01-01
 modified: 2026-01-01
 reviewed: 2026-01-01

--- a/networking-plugin/skills/network-diagnostics/skill.md
+++ b/networking-plugin/skills/network-diagnostics/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-01-01
 modified: 2026-01-01
 reviewed: 2026-01-01

--- a/networking-plugin/skills/network-discovery/skill.md
+++ b/networking-plugin/skills/network-discovery/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: network-discovery
 description: Host and port discovery using RustScan for fast TCP scanning, arp-scan-rs for local network enumeration, and nmap for deep service analysis.
 user-invocable: false

--- a/networking-plugin/skills/network-monitoring/skill.md
+++ b/networking-plugin/skills/network-monitoring/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-01-01
 modified: 2026-01-01
 reviewed: 2026-01-01

--- a/obsidian-plugin/skills/plugins-themes/SKILL.md
+++ b/obsidian-plugin/skills/plugins-themes/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-03-04
 modified: 2026-03-04
 reviewed: 2026-03-04

--- a/obsidian-plugin/skills/properties/SKILL.md
+++ b/obsidian-plugin/skills/properties/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-03-04
 modified: 2026-03-04
 reviewed: 2026-03-04

--- a/obsidian-plugin/skills/publish-sync/SKILL.md
+++ b/obsidian-plugin/skills/publish-sync/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-03-04
 modified: 2026-03-04
 reviewed: 2026-03-04

--- a/obsidian-plugin/skills/search-discovery/SKILL.md
+++ b/obsidian-plugin/skills/search-discovery/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-03-04
 modified: 2026-03-04
 reviewed: 2026-03-04

--- a/obsidian-plugin/skills/tasks/SKILL.md
+++ b/obsidian-plugin/skills/tasks/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-03-04
 modified: 2026-03-04
 reviewed: 2026-03-04

--- a/obsidian-plugin/skills/vault-files/SKILL.md
+++ b/obsidian-plugin/skills/vault-files/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-03-04
 modified: 2026-03-04
 reviewed: 2026-03-04

--- a/project-plugin/README.md
+++ b/project-plugin/README.md
@@ -84,7 +84,7 @@ Analyze project state and continue development where you left off.
 /project:continue
 ```
 
-**Note:** Generic template that should be customized per project using `/blueprint-generate-commands`. Project-specific version is generated to `.claude/skills/project-continue/SKILL.md`.
+**Note:** Generic template that should be customized per project using `/blueprint:generate-commands`. Project-specific version is generated to `.claude/skills/project-continue/SKILL.md`.
 
 ### `/project:test-loop`
 Run automated TDD cycle: test → fix → refactor.
@@ -101,7 +101,7 @@ Run automated TDD cycle: test → fix → refactor.
 /project:test-loop
 ```
 
-**Note:** Generic template that should be customized per project using `/blueprint-generate-commands`. Project-specific version is generated to `.claude/skills/project-test-loop/SKILL.md`.
+**Note:** Generic template that should be customized per project using `/blueprint:generate-commands`. Project-specific version is generated to `.claude/skills/project-test-loop/SKILL.md`.
 
 ### `/changelog:review`
 Review Claude Code changelog for changes impacting plugin development.
@@ -251,8 +251,8 @@ Follow strict RED → GREEN → REFACTOR workflow:
 ## Integration
 
 ### With Blueprint Plugin
-- `/blueprint-generate-commands` - Creates project-specific versions of generic commands
-- `/blueprint-work-order` - Create work orders before starting features
+- `/blueprint:generate-commands` - Creates project-specific versions of generic commands
+- `/blueprint:work-order` - Create work orders before starting features
 
 ### With Git Plugin
 - `/git:smartcommit` - Conventional commits integration

--- a/project-plugin/skills/changelog-review/SKILL.md
+++ b/project-plugin/skills/changelog-review/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: changelog-review
 description: |
   Analyze Claude Code changelog for changes that impact plugin development.

--- a/project-plugin/skills/project-continue/SKILL.md
+++ b/project-plugin/skills/project-continue/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 description: "Analyze project state and continue development where left off"
 args: "[--task <id>] [--skip-status]"
 argument-hint: "--task to resume specific task, --skip-status to skip state analysis"
@@ -105,7 +104,7 @@ Continue project development by analyzing current state and resuming work.
 **Handling Common Scenarios**:
 
 **Scenario: Starting new feature**:
-1. Create work-order first with `/blueprint-work-order`
+1. Create work-order first with `/blueprint:work-order`
 2. Then continue with this command
 
 **Scenario: Blocked by dependency**:

--- a/project-plugin/skills/project-discovery/SKILL.md
+++ b/project-plugin/skills/project-discovery/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2026-02-10
 reviewed: 2026-02-08

--- a/project-plugin/skills/project-distill/SKILL.md
+++ b/project-plugin/skills/project-distill/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: project-distill
 description: |
   Distill session insights into reusable knowledge: Claude rules, skill improvements,

--- a/project-plugin/skills/project-init/SKILL.md
+++ b/project-plugin/skills/project-init/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/project-plugin/skills/project-skill-scripts/SKILL.md
+++ b/project-plugin/skills/project-skill-scripts/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 name: project-skill-scripts
 description: Analyze plugin skills to identify opportunities where supporting scripts would improve performance (fewer tokens, faster execution, consistent results), then optionally create those scripts.
 args: "[--analyze] [--create <plugin/skill>] [--all]"

--- a/project-plugin/skills/project-test-loop/SKILL.md
+++ b/project-plugin/skills/project-test-loop/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 description: "Run test → fix → refactor loop with TDD workflow"
 args: "[test-pattern] [--max-cycles <N>]"
 argument-hint: "Test pattern to focus on, --max-cycles to limit iterations"

--- a/prompt-engineering-plugin/skills/prompt-engineering-ground-response/SKILL.md
+++ b/prompt-engineering-plugin/skills/prompt-engineering-ground-response/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: ground-response
 description: |
   Produce grounded, citation-backed responses from source documents. Use when analyzing

--- a/prose-plugin/skills/prose-distill/SKILL.md
+++ b/prose-plugin/skills/prose-distill/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 name: prose-distill
 description: |
   Distill verbose text to its concentrated essence. Compress without losing meaning —

--- a/prose-plugin/skills/prose-synthesize/SKILL.md
+++ b/prose-plugin/skills/prose-synthesize/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 name: prose-synthesize
 description: |
   Synthesize unstructured thinking into a structured, actionable plan. Use when user provides

--- a/python-plugin/skills/basedpyright-type-checking/SKILL.md
+++ b/python-plugin/skills/basedpyright-type-checking/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16

--- a/python-plugin/skills/pytest-advanced/SKILL.md
+++ b/python-plugin/skills/pytest-advanced/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-01-24
 reviewed: 2026-01-24

--- a/python-plugin/skills/python-code-quality/SKILL.md
+++ b/python-plugin/skills/python-code-quality/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-25
 reviewed: 2025-12-16

--- a/python-plugin/skills/python-development/SKILL.md
+++ b/python-plugin/skills/python-development/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/python-plugin/skills/python-packaging/SKILL.md
+++ b/python-plugin/skills/python-packaging/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-06
 reviewed: 2025-12-16

--- a/python-plugin/skills/python-testing/SKILL.md
+++ b/python-plugin/skills/python-testing/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-06
 reviewed: 2025-12-16

--- a/python-plugin/skills/ruff-formatting/SKILL.md
+++ b/python-plugin/skills/ruff-formatting/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16

--- a/python-plugin/skills/ruff-integration/SKILL.md
+++ b/python-plugin/skills/ruff-integration/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-01-24
 reviewed: 2026-01-24

--- a/python-plugin/skills/ruff-linting/SKILL.md
+++ b/python-plugin/skills/ruff-linting/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/python-plugin/skills/ty-type-checking/SKILL.md
+++ b/python-plugin/skills/ty-type-checking/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-01-29
 modified: 2026-01-29
 reviewed: 2026-01-29

--- a/python-plugin/skills/uv-advanced-dependencies/SKILL.md
+++ b/python-plugin/skills/uv-advanced-dependencies/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-06
 reviewed: 2025-12-16

--- a/python-plugin/skills/uv-project-management/SKILL.md
+++ b/python-plugin/skills/uv-project-management/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-06
 reviewed: 2025-12-16

--- a/python-plugin/skills/uv-python-versions/SKILL.md
+++ b/python-plugin/skills/uv-python-versions/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-06
 reviewed: 2025-12-16

--- a/python-plugin/skills/uv-run/SKILL.md
+++ b/python-plugin/skills/uv-run/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/python-plugin/skills/uv-tool-management/SKILL.md
+++ b/python-plugin/skills/uv-tool-management/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-06
 reviewed: 2025-12-16

--- a/python-plugin/skills/uv-workspaces/SKILL.md
+++ b/python-plugin/skills/uv-workspaces/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-12
 reviewed: 2026-02-12

--- a/python-plugin/skills/vulture-dead-code/SKILL.md
+++ b/python-plugin/skills/vulture-dead-code/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16

--- a/rust-plugin/skills/cargo-llvm-cov/SKILL.md
+++ b/rust-plugin/skills/cargo-llvm-cov/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-06
 reviewed: 2025-12-16

--- a/rust-plugin/skills/cargo-machete/SKILL.md
+++ b/rust-plugin/skills/cargo-machete/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-11
 reviewed: 2025-12-16

--- a/rust-plugin/skills/cargo-nextest/SKILL.md
+++ b/rust-plugin/skills/cargo-nextest/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-06
 reviewed: 2025-12-16

--- a/rust-plugin/skills/clippy-advanced/SKILL.md
+++ b/rust-plugin/skills/clippy-advanced/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16

--- a/rust-plugin/skills/rust-development/SKILL.md
+++ b/rust-plugin/skills/rust-development/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/terraform-plugin/skills/infrastructure-terraform/SKILL.md
+++ b/terraform-plugin/skills/infrastructure-terraform/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2026-01-20
 reviewed: 2025-12-16

--- a/terraform-plugin/skills/tfc-list-runs/SKILL.md
+++ b/terraform-plugin/skills/tfc-list-runs/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/terraform-plugin/skills/tfc-plan-json/SKILL.md
+++ b/terraform-plugin/skills/tfc-plan-json/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/terraform-plugin/skills/tfc-run-logs/SKILL.md
+++ b/terraform-plugin/skills/tfc-run-logs/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2026-02-08

--- a/terraform-plugin/skills/tfc-run-status/SKILL.md
+++ b/terraform-plugin/skills/tfc-run-status/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/terraform-plugin/skills/tfc-workspace-runs/SKILL.md
+++ b/terraform-plugin/skills/tfc-workspace-runs/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/testing-plugin/skills/hypothesis-testing/SKILL.md
+++ b/testing-plugin/skills/hypothesis-testing/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-01-24
 reviewed: 2026-01-24

--- a/testing-plugin/skills/mutation-testing/SKILL.md
+++ b/testing-plugin/skills/mutation-testing/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16

--- a/testing-plugin/skills/playwright-cli/SKILL.md
+++ b/testing-plugin/skills/playwright-cli/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-03-19
 modified: 2026-03-19
 reviewed: 2026-03-19

--- a/testing-plugin/skills/playwright-testing/SKILL.md
+++ b/testing-plugin/skills/playwright-testing/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16

--- a/testing-plugin/skills/property-based-testing/SKILL.md
+++ b/testing-plugin/skills/property-based-testing/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16

--- a/testing-plugin/skills/test-analyze/SKILL.md
+++ b/testing-plugin/skills/test-analyze/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 description: Analyze test results and create systematic fix plan with subagent delegation
 args: "<results-path> [--type <test-type>] [--focus <area>]"
 argument-hint: "Path to test results (e.g., ./test-results/), optional --type and --focus filters"

--- a/testing-plugin/skills/test-consult/SKILL.md
+++ b/testing-plugin/skills/test-consult/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/testing-plugin/skills/test-focus/SKILL.md
+++ b/testing-plugin/skills/test-focus/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2026-01-19
 modified: 2026-03-01
 reviewed: 2026-02-08

--- a/testing-plugin/skills/test-full/SKILL.md
+++ b/testing-plugin/skills/test-full/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-03-09
 reviewed: 2026-03-09

--- a/testing-plugin/skills/test-quality-analysis/SKILL.md
+++ b/testing-plugin/skills/test-quality-analysis/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16

--- a/testing-plugin/skills/test-quick/SKILL.md
+++ b/testing-plugin/skills/test-quick/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-03-09
 reviewed: 2026-03-09

--- a/testing-plugin/skills/test-report/SKILL.md
+++ b/testing-plugin/skills/test-report/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/testing-plugin/skills/test-run/SKILL.md
+++ b/testing-plugin/skills/test-run/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-03-09
 reviewed: 2026-03-09

--- a/testing-plugin/skills/test-setup/SKILL.md
+++ b/testing-plugin/skills/test-setup/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/testing-plugin/skills/test-tier-selection/SKILL.md
+++ b/testing-plugin/skills/test-tier-selection/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/testing-plugin/skills/vitest-testing/SKILL.md
+++ b/testing-plugin/skills/vitest-testing/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16

--- a/tools-plugin/skills/binary-analysis/SKILL.md
+++ b/tools-plugin/skills/binary-analysis/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: binary-analysis
 description: Reverse engineering and binary exploration using strings, binwalk, hexdump, and related tools.
 user-invocable: false

--- a/tools-plugin/skills/d2-diagrams/skill.md
+++ b/tools-plugin/skills/d2-diagrams/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: d2-diagrams
 description: |
   Generate diagrams from declarative text using D2 - modern text-to-diagram language with

--- a/tools-plugin/skills/deps-install/SKILL.md
+++ b/tools-plugin/skills/deps-install/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/tools-plugin/skills/fd-file-finding/SKILL.md
+++ b/tools-plugin/skills/fd-file-finding/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-01-21
 reviewed: 2025-12-16

--- a/tools-plugin/skills/generate-image/SKILL.md
+++ b/tools-plugin/skills/generate-image/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-06
 reviewed: 2025-12-16

--- a/tools-plugin/skills/imagemagick-conversion/SKILL.md
+++ b/tools-plugin/skills/imagemagick-conversion/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-06
 reviewed: 2025-12-16

--- a/tools-plugin/skills/jq-json-processing/SKILL.md
+++ b/tools-plugin/skills/jq-json-processing/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/tools-plugin/skills/justfile-expert/SKILL.md
+++ b/tools-plugin/skills/justfile-expert/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-06
 reviewed: 2026-02-06

--- a/tools-plugin/skills/mermaid-diagrams/skill.md
+++ b/tools-plugin/skills/mermaid-diagrams/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: mermaid-diagrams
 description: Generate diagrams from text using Mermaid CLI (mmdc) - flowcharts, sequence diagrams, ERDs, class diagrams, state machines, and more.
 user-invocable: false

--- a/tools-plugin/skills/nushell-data-processing/skill.md
+++ b/tools-plugin/skills/nushell-data-processing/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-25
 modified: 2025-12-25
 reviewed: 2025-12-25

--- a/tools-plugin/skills/rg-code-search/SKILL.md
+++ b/tools-plugin/skills/rg-code-search/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-01-21
 reviewed: 2025-12-16

--- a/tools-plugin/skills/shell-expert/SKILL.md
+++ b/tools-plugin/skills/shell-expert/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2026-02-08

--- a/tools-plugin/skills/yq-yaml-processing/SKILL.md
+++ b/tools-plugin/skills/yq-yaml-processing/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16

--- a/typescript-plugin/skills/biome-tooling/SKILL.md
+++ b/typescript-plugin/skills/biome-tooling/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16

--- a/typescript-plugin/skills/bun-add/SKILL.md
+++ b/typescript-plugin/skills/bun-add/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 description: Add package dependency with Bun
 args: <package> [--dev] [--exact]
 allowed-tools: Bash, Read

--- a/typescript-plugin/skills/bun-build/SKILL.md
+++ b/typescript-plugin/skills/bun-build/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 description: Bundle or compile with Bun
 args: <entry> [--compile] [--minify]
 allowed-tools: Bash, Read

--- a/typescript-plugin/skills/bun-development/skill.md
+++ b/typescript-plugin/skills/bun-development/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: bun-development
 description: Bun runtime for running scripts, testing, building, and project initialization - optimized flags for fast feedback and minimal output.
 user-invocable: false

--- a/typescript-plugin/skills/bun-install/SKILL.md
+++ b/typescript-plugin/skills/bun-install/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 description: Install dependencies with Bun package manager
 args: "[--frozen-lockfile] [--production]"
 argument-hint: "--frozen-lockfile for CI, --production for deployment"

--- a/typescript-plugin/skills/bun-lockfile-update/SKILL.md
+++ b/typescript-plugin/skills/bun-lockfile-update/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-06
 reviewed: 2025-12-16

--- a/typescript-plugin/skills/bun-outdated/SKILL.md
+++ b/typescript-plugin/skills/bun-outdated/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 description: Check for outdated dependencies
 args: "[package]"
 argument-hint: "Optional package name to check specific dependency"

--- a/typescript-plugin/skills/bun-package-manager/skill.md
+++ b/typescript-plugin/skills/bun-package-manager/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: bun-package-manager
 description: Fast JavaScript package management with Bun - install, add, remove, update dependencies with optimized CLI flags for agentic workflows.
 user-invocable: false

--- a/typescript-plugin/skills/bun-publish/SKILL.md
+++ b/typescript-plugin/skills/bun-publish/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 description: Publish package to npm with Bun build
 args: [--dry-run] [--access <level>] [--provenance]
 allowed-tools: Bash, Read

--- a/typescript-plugin/skills/bun-publishing/skill.md
+++ b/typescript-plugin/skills/bun-publishing/skill.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: bun-publishing
 description: Publish packages to npm with Bun - package.json configuration, CLI packaging, provenance signing, and release automation.
 user-invocable: false

--- a/typescript-plugin/skills/bun-test/SKILL.md
+++ b/typescript-plugin/skills/bun-test/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 description: Run tests with Bun test runner
 args: [pattern] [--coverage] [--bail] [--watch]
 allowed-tools: Bash, BashOutput, Read

--- a/typescript-plugin/skills/knip-dead-code/SKILL.md
+++ b/typescript-plugin/skills/knip-dead-code/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16

--- a/typescript-plugin/skills/nodejs-development/SKILL.md
+++ b/typescript-plugin/skills/nodejs-development/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2025-12-16
 reviewed: 2025-12-16

--- a/typescript-plugin/skills/typescript-strict/SKILL.md
+++ b/typescript-plugin/skills/typescript-strict/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16

--- a/workflow-orchestration-plugin/skills/workflow-checkpoint-refactor/SKILL.md
+++ b/workflow-orchestration-plugin/skills/workflow-checkpoint-refactor/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: sonnet
 name: workflow-checkpoint-refactor
 description: |
   Multi-phase refactoring with persistent checkpoint files that survive context

--- a/workflow-orchestration-plugin/skills/workflow-preflight/SKILL.md
+++ b/workflow-orchestration-plugin/skills/workflow-preflight/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: haiku
 name: workflow-preflight
 description: |
   Pre-work validation before starting implementation. Use when beginning work


### PR DESCRIPTION
Remove `model:` frontmatter from all skill files so skills inherit the
user's active model. Update blueprint command references from dash syntax
(`/blueprint-init`) to colon namespace syntax (`/blueprint:init`) across
all documentation, skills, and sequence diagrams.

https://claude.ai/code/session_012HLt1bFJbR1wSMBAWiN2MY