### PR TITLE
fix(hooks-plugin): add regression test and document prompt-leaking limitation

### DIFF
--- a/hooks-plugin/README.md
+++ b/hooks-plugin/README.md
@@ -138,19 +138,25 @@ A PermissionRequest hook that auto-approves safe operations and auto-denies dang
 
 **Toggle:** `CLAUDE_HOOKS_DISABLE_PERMISSION_AUTO=1`
 
+### task-completeness.sh
+
+A Stop hook that checks for obvious signs of incomplete work using deterministic heuristics. Replaces the former `type: "prompt"` task-completeness hook to avoid leaking the full LLM prompt in error output (see [#1009](https://github.com/laurigates/claude-plugins/issues/1009)).
+
+| Check | Trigger |
+|-------|---------|
+| TODO/FIXME/HACK/XXX in uncommitted diff | Blocks with count and message |
+| Merge conflict markers (`<<<<`, `====`, `>>>>`) | Blocks with affected filenames |
+| Debugging artifacts (`console.log`, `debugger;`, `breakpoint()`, `pdb.set_trace`) | Blocks with count |
+| `stop_hook_active=true` in input | Exits 0 immediately (prevents infinite loops) |
+| Non-git directory | Exits 0 silently |
+
+**Toggle:** `CLAUDE_HOOKS_DISABLE_TASK_COMPLETENESS=1`
+
+> **Note on prompt-type Stop hooks**: When a `type: "prompt"` hook on `Stop` or `SubagentStop` returns `{"ok": false}`, Claude Code surfaces the full prompt text in the error message (e.g. `Stop hook error: [You are evaluating...]: reason`). This is a runtime behavior that cannot be configured away. Prefer `type: "command"` hooks with deterministic heuristics for Stop events to avoid this leakage. Only use `type: "prompt"` on Stop hooks when the check genuinely requires LLM judgment and cannot be deterministic.
+
 ## Prompt-Based and Agent-Based Hooks
 
 LLM-powered hooks that use judgment instead of deterministic rules.
-
-### Stop — Task Completeness Gate (prompt)
-
-A `type: "prompt"` hook that evaluates whether Claude completed all user-requested tasks before stopping. Prevents Claude from finishing prematurely with incomplete work.
-
-| Aspect | Detail |
-|--------|--------|
-| Type | `prompt` (single-turn LLM call) |
-| Timeout | 30s |
-| Loop prevention | Checks `stop_hook_active` to avoid infinite loops |
 
 ### Stop — Test Verification (agent)
 
@@ -318,6 +324,7 @@ Every hook can be individually enabled or disabled via environment variables. Se
 | branch-protection.sh | `CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1` | Enabled |
 | auto-checkpoint.sh | `CLAUDE_HOOKS_DISABLE_AUTO_CHECKPOINT=1` | Enabled |
 | permission-auto-approve.sh | `CLAUDE_HOOKS_DISABLE_PERMISSION_AUTO=1` | Enabled |
+| task-completeness.sh | `CLAUDE_HOOKS_DISABLE_TASK_COMPLETENESS=1` | Enabled |
 | event-logger.sh | `CLAUDE_HOOKS_ENABLE_EVENT_LOGGER=1` | **Disabled** (opt-in) |
 
 Example — disable branch protection for a session:

--- a/hooks-plugin/hooks/test-task-completeness.sh
+++ b/hooks-plugin/hooks/test-task-completeness.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# Regression tests for task-completeness.sh
+#
+# Verifies that the Stop hook detects incomplete work without leaking
+# the full prompt text in error output (issue #1009).
+#
+# Run: bash hooks-plugin/hooks/test-task-completeness.sh
+# Exit 0 = all tests pass, Exit 1 = failures
+set -euo pipefail
+
+HOOK="$(dirname "$0")/task-completeness.sh"
+PASS=0
+FAIL=0
+
+# Create temporary directories for testing
+TMPDIR=$(mktemp -d)
+NON_GIT_DIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR" "$NON_GIT_DIR"' EXIT
+
+# Initialize git repo for tests
+git -C "$TMPDIR" init -q
+git -C "$TMPDIR" config user.email "test@example.com"
+git -C "$TMPDIR" config user.name "Test"
+echo "initial" > "$TMPDIR/README.md"
+git -C "$TMPDIR" add README.md
+git -C "$TMPDIR" commit -q -m "initial"
+
+# Helper: run hook with a given CWD JSON and optional extra fields
+# Returns the exit code as stdout
+run_hook() {
+    local cwd="$1"
+    local extra="${2:-}"
+    local json exit_code=0
+    if [ -n "$extra" ]; then
+        json=$(printf '{"cwd":"%s",%s}' "$cwd" "$extra")
+    else
+        json=$(printf '{"cwd":"%s"}' "$cwd")
+    fi
+    printf '%s' "$json" | bash "$HOOK" >/dev/null 2>&1 || exit_code=$?
+    echo "$exit_code"
+}
+
+# Helper: run hook and capture stdout (the JSON output)
+run_hook_output() {
+    local cwd="$1"
+    local extra="${2:-}"
+    local json exit_code=0
+    if [ -n "$extra" ]; then
+        json=$(printf '{"cwd":"%s",%s}' "$cwd" "$extra")
+    else
+        json=$(printf '{"cwd":"%s"}' "$cwd")
+    fi
+    printf '%s' "$json" | bash "$HOOK" 2>/dev/null || true
+}
+
+assert_exit() {
+    local desc="$1" expected="$2" actual="$3"
+    if [ "$actual" -eq "$expected" ]; then
+        printf "  PASS: %s\n" "$desc"
+        PASS=$((PASS + 1))
+    else
+        printf "  FAIL: %s (expected exit %d, got %d)\n" "$desc" "$expected" "$actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local desc="$1" pattern="$2" actual="$3"
+    if echo "$actual" | grep -q "$pattern"; then
+        printf "  PASS: %s\n" "$desc"
+        PASS=$((PASS + 1))
+    else
+        printf "  FAIL: %s (expected pattern '%s', output was: %s)\n" "$desc" "$pattern" "$actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_contains() {
+    local desc="$1" pattern="$2" actual="$3"
+    if echo "$actual" | grep -q "$pattern"; then
+        printf "  FAIL: %s (found forbidden '%s' in: %s)\n" "$desc" "$pattern" "$actual"
+        FAIL=$((FAIL + 1))
+    else
+        printf "  PASS: %s\n" "$desc"
+        PASS=$((PASS + 1))
+    fi
+}
+
+echo "=== task-completeness hook tests ==="
+
+# ── stop_hook_active guard ────────────────────────────────────────────────────
+# Regression: must pass immediately when stop_hook_active=true to prevent
+# infinite loops where the hook blocks and Claude tries again.
+echo ""
+echo "stop_hook_active guard:"
+
+exit_code=$(run_hook "$TMPDIR" '"stop_hook_active":true')
+assert_exit "stop_hook_active=true exits 0 (no blocking)" 0 "$exit_code"
+
+# ── clean working tree ────────────────────────────────────────────────────────
+echo ""
+echo "clean working tree:"
+
+exit_code=$(run_hook "$TMPDIR")
+assert_exit "clean tree exits 0" 0 "$exit_code"
+
+# ── TODO/FIXME markers in uncommitted changes ─────────────────────────────────
+# Regression: the old prompt hook leaked the full LLM prompt in error output
+# (issue #1009). The command hook must only emit {"decision":"block","reason":"..."}
+echo ""
+echo "TODO/FIXME/HACK/XXX detection:"
+
+echo "# TODO: finish this" >> "$TMPDIR/README.md"
+
+exit_code=$(run_hook "$TMPDIR")
+assert_exit "unstaged TODO exits 2 (blocked)" 2 "$exit_code"
+
+output=$(run_hook_output "$TMPDIR")
+assert_contains     "blocked output has 'decision' field"       '"decision"'        "$output"
+assert_contains     "blocked output has 'reason' field"         '"reason"'          "$output"
+assert_not_contains "output does not leak prompt text"          "You are evaluating" "$output"
+assert_not_contains "output does not leak stop_hook_active text" "stop_hook_active"  "$output"
+
+git -C "$TMPDIR" checkout -- README.md  # restore clean state
+
+# Staged TODO
+echo "# FIXME: broken" >> "$TMPDIR/README.md"
+git -C "$TMPDIR" add README.md
+
+exit_code=$(run_hook "$TMPDIR")
+assert_exit "staged FIXME exits 2 (blocked)" 2 "$exit_code"
+
+git -C "$TMPDIR" restore --staged README.md 2>/dev/null || git -C "$TMPDIR" reset HEAD README.md 2>/dev/null || true
+git -C "$TMPDIR" checkout -- README.md
+
+# ── merge conflict markers ────────────────────────────────────────────────────
+echo ""
+echo "merge conflict marker detection:"
+
+cat > "$TMPDIR/conflict.txt" <<'CONFLICT'
+<<<<<<< HEAD
+local change
+=======
+remote change
+>>>>>>> main
+CONFLICT
+git -C "$TMPDIR" add conflict.txt
+
+exit_code=$(run_hook "$TMPDIR")
+assert_exit "staged conflict markers exits 2 (blocked)" 2 "$exit_code"
+
+output=$(run_hook_output "$TMPDIR")
+assert_contains     "conflict output has 'decision' field"      '"decision"'         "$output"
+assert_not_contains "conflict output does not leak prompt text" "Respond with ONLY"  "$output"
+
+git -C "$TMPDIR" restore --staged conflict.txt 2>/dev/null || git -C "$TMPDIR" reset HEAD conflict.txt 2>/dev/null || true
+rm -f "$TMPDIR/conflict.txt"
+
+# ── debugging artifacts ───────────────────────────────────────────────────────
+echo ""
+echo "debugging artifact detection:"
+
+echo "console.log('debug', x);" >> "$TMPDIR/app.js"
+git -C "$TMPDIR" add app.js
+
+exit_code=$(run_hook "$TMPDIR")
+assert_exit "staged console.log exits 2 (blocked)" 2 "$exit_code"
+
+git -C "$TMPDIR" restore --staged app.js 2>/dev/null || git -C "$TMPDIR" reset HEAD app.js 2>/dev/null || true
+rm -f "$TMPDIR/app.js"
+
+echo "debugger;" >> "$TMPDIR/app.js"
+git -C "$TMPDIR" add app.js
+
+exit_code=$(run_hook "$TMPDIR")
+assert_exit "staged 'debugger;' exits 2 (blocked)" 2 "$exit_code"
+
+git -C "$TMPDIR" restore --staged app.js 2>/dev/null || git -C "$TMPDIR" reset HEAD app.js 2>/dev/null || true
+rm -f "$TMPDIR/app.js"
+
+# ── edge cases ────────────────────────────────────────────────────────────────
+echo ""
+echo "edge cases:"
+
+exit_code=$(run_hook "$NON_GIT_DIR")
+assert_exit "non-git directory exits 0" 0 "$exit_code"
+
+empty_exit=0
+printf '{}' | bash "$HOOK" >/dev/null 2>&1 || empty_exit=$?
+assert_exit "missing cwd field exits 0" 0 "$empty_exit"
+
+# ── disable via environment variable ─────────────────────────────────────────
+echo ""
+echo "CLAUDE_HOOKS_DISABLE_TASK_COMPLETENESS override:"
+
+echo "# TODO: should be ignored" >> "$TMPDIR/README.md"
+override_exit=0
+printf '{"cwd":"%s"}' "$TMPDIR" | CLAUDE_HOOKS_DISABLE_TASK_COMPLETENESS=1 bash "$HOOK" >/dev/null 2>&1 || override_exit=$?
+assert_exit "CLAUDE_HOOKS_DISABLE_TASK_COMPLETENESS=1 skips checks" 0 "$override_exit"
+git -C "$TMPDIR" checkout -- README.md
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
Adds a regression test for task-completeness.sh and updates the README to document the prompt-leaking limitation of prompt-type Stop hooks.

Follows up on PR #1010 which fixed the core issue — these are the remaining gaps: no regression test, outdated README, and no warning about the limitation for future hook authors.

Fixes #1009

Generated with [Claude Code](https://claude.ai/code)