### PR TITLE
refactor(evaluate-plugin): extract evaluate skill inline commands to standalone scripts

### DIFF
--- a/evaluate-plugin/scripts/inspect_eval.sh
+++ b/evaluate-plugin/scripts/inspect_eval.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Inspect a skill's eval setup: check for SKILL.md and evals.json,
+# count eval cases, and optionally pretty-print evals.json.
+#
+# Usage:
+#   inspect_eval.sh --plugin <plugin-name> --skill <skill-name> [--print-evals]
+#   inspect_eval.sh --plugin-dir <path>  # list all skills in plugin
+#
+# Output: KEY=value lines + optional JSON dump under === EVALS === header.
+
+set -uo pipefail
+
+plugin_name=""
+skill_name=""
+plugin_dir=""
+print_evals=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --plugin) plugin_name="$2"; shift 2 ;;
+    --skill) skill_name="$2"; shift 2 ;;
+    --plugin-dir) plugin_dir="$2"; shift 2 ;;
+    --print-evals) print_evals=true; shift ;;
+    *) shift ;;
+  esac
+done
+
+echo "=== INSPECT EVAL ==="
+
+# Mode 1: list all skills in a plugin
+if [ -n "$plugin_dir" ]; then
+  if [ ! -d "$plugin_dir/skills" ]; then
+    echo "SKILLS_DIR_EXISTS=false"
+    echo "STATUS=ERROR"
+    exit 1
+  fi
+  echo "SKILLS_DIR_EXISTS=true"
+
+  skill_count=$(find "$plugin_dir/skills" -maxdepth 3 -name "SKILL.md" | wc -l | tr -d ' ')
+  evals_count=$(find "$plugin_dir/skills" -maxdepth 3 -name "evals.json" | wc -l | tr -d ' ')
+
+  echo "SKILL_COUNT=$skill_count"
+  echo "EVALS_COUNT=$evals_count"
+
+  echo "=== SKILLS ==="
+  find "$plugin_dir/skills" -maxdepth 3 -name "SKILL.md" -print | sort
+  echo "=== EVALS ==="
+  find "$plugin_dir/skills" -maxdepth 3 -name "evals.json" -print | sort
+  exit 0
+fi
+
+# Mode 2: inspect one specific skill
+if [ -z "$plugin_name" ] || [ -z "$skill_name" ]; then
+  echo "ERROR: provide --plugin and --skill, or --plugin-dir" >&2
+  exit 1
+fi
+
+skill_md="$plugin_name/skills/$skill_name/SKILL.md"
+evals_json="$plugin_name/skills/$skill_name/evals.json"
+
+skill_md_exists=false
+evals_json_exists=false
+num_cases=0
+
+if [ -f "$skill_md" ]; then
+  skill_md_exists=true
+fi
+
+if [ -f "$evals_json" ]; then
+  evals_json_exists=true
+  num_cases=$(jq '.cases | length' "$evals_json" 2>/dev/null || echo 0)
+fi
+
+echo "SKILL_MD=$skill_md"
+echo "SKILL_MD_EXISTS=$skill_md_exists"
+echo "EVALS_JSON=$evals_json"
+echo "EVALS_JSON_EXISTS=$evals_json_exists"
+echo "NUM_CASES=$num_cases"
+
+if [ "$print_evals" = true ] && [ "$evals_json_exists" = true ]; then
+  echo "=== EVALS ==="
+  jq '.' "$evals_json"
+fi

--- a/evaluate-plugin/scripts/prepare_run.sh
+++ b/evaluate-plugin/scripts/prepare_run.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Prepare an eval run directory and write a run manifest.
+#
+# Creates:
+#   <skill-dir>/eval-results/runs/<eval-id>-run-<N>/
+# Writes:
+#   <skill-dir>/eval-results/runs/<eval-id>-run-<N>/manifest.json
+#
+# Usage:
+#   prepare_run.sh --skill-dir <path> --eval-id <id> --run <N> [--baseline]
+#
+# Output: KEY=value lines
+#   RUN_DIR=<absolute path>
+#   MANIFEST=<absolute path>
+#   STARTED_AT=<iso8601>
+
+set -uo pipefail
+
+skill_dir=""
+eval_id=""
+run_num=""
+baseline=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --skill-dir) skill_dir="$2"; shift 2 ;;
+    --eval-id) eval_id="$2"; shift 2 ;;
+    --run) run_num="$2"; shift 2 ;;
+    --baseline) baseline=true; shift ;;
+    *) shift ;;
+  esac
+done
+
+if [ -z "$skill_dir" ] || [ -z "$eval_id" ] || [ -z "$run_num" ]; then
+  echo "ERROR: --skill-dir, --eval-id, and --run are required" >&2
+  exit 1
+fi
+
+if [ ! -d "$skill_dir" ]; then
+  echo "ERROR: skill directory not found: $skill_dir" >&2
+  exit 1
+fi
+
+echo "=== PREPARE RUN ==="
+
+subdir="runs"
+if [ "$baseline" = true ]; then
+  subdir="baseline"
+fi
+
+run_dir="$skill_dir/eval-results/$subdir/${eval_id}-run-${run_num}"
+mkdir -p "$run_dir"
+
+started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+manifest="$run_dir/manifest.json"
+
+jq -n \
+  --arg eid "$eval_id" \
+  --argjson run "$run_num" \
+  --arg ts "$started_at" \
+  --argjson baseline "$baseline" \
+  '{eval_id: $eid, run: $run, started_at: $ts, baseline: $baseline}' \
+  > "$manifest"
+
+echo "RUN_DIR=$run_dir"
+echo "MANIFEST=$manifest"
+echo "STARTED_AT=$started_at"

--- a/evaluate-plugin/skills/evaluate-plugin-batch/SKILL.md
+++ b/evaluate-plugin/skills/evaluate-plugin-batch/SKILL.md
@@ -5,11 +5,11 @@ description: |
   that has eval cases, then produces a plugin-level report. Use when auditing
   an entire plugin's quality or before a release.
 args: <plugin-name> [--create-missing-evals] [--parallel N]
-allowed-tools: Task, Read, Write, Glob, Grep, Bash(cat *), Bash(jq *), Bash(find *), Bash(ls *), Bash(date *), Bash(mkdir *), SlashCommand, TodoWrite
+allowed-tools: Task, Read, Write, Glob, Grep, Bash(bash *), SlashCommand, TodoWrite
 argument-hint: "git-plugin [--create-missing-evals]"
 agent: general-purpose
 created: 2026-03-04
-modified: 2026-03-04
+modified: 2026-04-12
 reviewed: 2026-03-04
 ---
 
@@ -27,8 +27,7 @@ Batch evaluate all skills in a plugin. Runs `/evaluate:skill` for each skill, th
 
 ## Context
 
-- Plugin skills: !`find $1/skills -name "SKILL.md" -maxdepth 3`
-- Existing evals: !`find $1/skills -name "evals.json" -maxdepth 3`
+- Plugin inventory: !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/inspect_eval.sh --plugin-dir $1`
 
 ## Parameters
 
@@ -109,9 +108,8 @@ Rank skills by pass rate. Flag any below 50% as needing attention.
 
 | Context | Command |
 |---------|---------|
-| List plugin skills | `ls -d <plugin>/skills/*/SKILL.md` |
-| Check for evals | `find <plugin>/skills -name evals.json` |
-| Count skills | `ls -d <plugin>/skills/*/SKILL.md \| wc -l` |
+| Inventory plugin skills + evals | `bash evaluate-plugin/scripts/inspect_eval.sh --plugin-dir <plugin>` |
+| Inspect a single skill's evals | `bash evaluate-plugin/scripts/inspect_eval.sh --plugin <plugin> --skill <skill>` |
 | Aggregate results | `bash evaluate-plugin/scripts/aggregate_benchmark.sh <plugin>` |
 
 ## Quick Reference

--- a/evaluate-plugin/skills/evaluate-skill/SKILL.md
+++ b/evaluate-plugin/skills/evaluate-skill/SKILL.md
@@ -5,11 +5,11 @@ description: |
   Use when you want to test whether a skill produces correct guidance, validate
   skill improvements, or benchmark a skill before release.
 args: <plugin/skill-name> [--create-evals] [--runs N] [--baseline]
-allowed-tools: Task, Read, Write, Edit, Glob, Grep, Bash(cat *), Bash(jq *), Bash(wc *), Bash(ls *), Bash(find *), Bash(date *), Bash(mkdir *), TodoWrite
+allowed-tools: Task, Read, Write, Edit, Glob, Grep, Bash(bash *), TodoWrite
 argument-hint: "git-plugin/git-commit [--create-evals] [--runs 3] [--baseline]"
 agent: general-purpose
 created: 2026-03-04
-modified: 2026-03-04
+modified: 2026-04-12
 reviewed: 2026-03-04
 ---
 
@@ -28,8 +28,7 @@ Evaluate a skill's effectiveness by running behavioral test cases and grading th
 
 ## Context
 
-- Skill file: !`find $1/skills -name "SKILL.md" -maxdepth 3`
-- Eval cases: !`find $1/skills -name "evals.json" -maxdepth 3`
+- Skill files: !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/inspect_eval.sh --plugin-dir $1`
 
 ## Parameters
 
@@ -89,21 +88,26 @@ Look for `<plugin-name>/skills/<skill-name>/evals.json`.
 
 For each eval case, for each run (up to `--runs N`):
 
-1. Create a results directory: `<plugin-name>/skills/<skill-name>/eval-results/runs/<eval-id>-run-<N>/`
-2. Record the start time.
-3. Spawn a Task subagent (`subagent_type: general-purpose`) that:
+1. Scaffold the run directory and record the start time by running:
+   ```
+   bash ${CLAUDE_PLUGIN_ROOT}/scripts/prepare_run.sh \
+     --skill-dir <plugin-name>/skills/<skill-name> \
+     --eval-id <eval-id> --run <N>
+   ```
+   Parse `RUN_DIR=`, `MANIFEST=`, and `STARTED_AT=` from output.
+2. Spawn a Task subagent (`subagent_type: general-purpose`) that:
    - Receives the skill content as context
    - Executes the eval prompt
    - Works in the repository as if it were a real user request
-4. Capture the subagent output.
-5. Record timing data (duration) and write to `timing.json`.
-6. Write the transcript to `transcript.md`.
+3. Capture the subagent output.
+4. Record timing data (duration) and write to `$RUN_DIR/timing.json`.
+5. Write the transcript to `$RUN_DIR/transcript.md`.
 
 ### Step 5: Run baseline (if --baseline)
 
-If `--baseline` is set, repeat Step 4 but **without** loading the skill content. This creates a comparison point to measure skill effectiveness.
+If `--baseline` is set, repeat Step 4 but **without** loading the skill content. Pass `--baseline` to `prepare_run.sh` so results are written into a parallel `baseline/` subdirectory. This creates a comparison point to measure skill effectiveness.
 
-Use the same eval prompts and record results in a parallel `baseline/` subdirectory.
+Use the same eval prompts and record results in the `baseline/` subdirectory.
 
 ### Step 6: Grade results
 
@@ -156,11 +160,9 @@ Print a summary table:
 
 | Context | Command |
 |---------|---------|
-| Check skill exists | `ls <plugin>/skills/<skill>/SKILL.md` |
-| Check evals exist | `ls <plugin>/skills/<skill>/evals.json` |
-| Read evals | `cat <plugin>/skills/<skill>/evals.json \| jq .` |
-| Create results dir | `mkdir -p <plugin>/skills/<skill>/eval-results/runs` |
-| Write JSON | `jq -n '<expression>' > file.json` |
+| Inspect skill eval setup | `bash evaluate-plugin/scripts/inspect_eval.sh --plugin <plugin> --skill <skill>` |
+| Print evals JSON | `bash evaluate-plugin/scripts/inspect_eval.sh --plugin <plugin> --skill <skill> --print-evals` |
+| Prepare a run directory | `bash evaluate-plugin/scripts/prepare_run.sh --skill-dir <plugin>/skills/<skill> --eval-id <id> --run <N>` |
 | Aggregate results | `bash evaluate-plugin/scripts/aggregate_benchmark.sh <plugin>` |
 
 ## Quick Reference


### PR DESCRIPTION
## Summary

Consolidate inline `cat` / `jq` / `wc` / `ls` / `find` / `date` / `mkdir` operations from `evaluate-skill` and `evaluate-plugin-batch` into plugin-level scripts under `evaluate-plugin/scripts/`, consistent with the existing `aggregate_benchmark.sh` / `eval_report.sh` placement. Both skills' `allowed-tools` narrow to `Bash(bash *)` so invocations no longer require per-command permission prompts.

## Changes

- New: `scripts/prepare_run.sh` — scaffolds `eval-results/runs/<id>-run-<N>/` (or `baseline/`), writes `manifest.json`, emits `RUN_DIR=` / `MANIFEST=` / `STARTED_AT=`.
- New: `scripts/inspect_eval.sh` — two modes: plugin-wide inventory and single-skill inspection with optional evals pretty-print.
- `evaluate-skill/SKILL.md`: `allowed-tools` → `Task, Read, Write, Edit, Glob, Grep, Bash(bash *), TodoWrite`.
- `evaluate-plugin-batch/SKILL.md`: `allowed-tools` → `Task, Read, Write, Glob, Grep, Bash(bash *), SlashCommand, TodoWrite`.
- Both skills' `modified` dates bumped.

## Verification

- `scripts/plugin-compliance-check.sh` Check 6 warnings for both skills removed; no new warnings introduced.
- Both scripts smoke-tested standalone.

Fixes #987