### PR TITLE
Fix Phase 2 tool execution in interactive maintain workflow

### DIFF
--- a/git-repo-agent/docs/adr/003-switch-to-claude-sdk-client-for-interactive-workflows.md
+++ b/git-repo-agent/docs/adr/003-switch-to-claude-sdk-client-for-interactive-workflows.md
@@ -147,6 +147,48 @@ all interactive CLI tools) do not work in SDK subprocess mode because the CLI ca
 access the terminal. The solution follows the same principle — move interaction out of the
 agent and into the Python orchestrator.
 
+## Revision 2026-04-12: Two separate sessions, not one multi-turn session
+
+The single-client two-phase pattern regressed. Observed symptom: after the user
+selected fixes at the Python prompt, Phase 2 ran but made no tool calls — the
+agent emitted a brief terminal response and `ResultMessage`, leaving the
+worktree empty. Cost: $3.11 for an analysis-only run that looked successful.
+
+Root cause: the Phase 1 system prompt (`maintain.md` Step 3) anchored the
+agent on "end your response after presenting findings". When Phase 2's
+follow-up `client.query()` arrived on the same `ClaudeSDKClient`, the model's
+prior turn dominated — it summarized and stopped again instead of executing.
+Embedded findings still lived in the conversation history, but the "stop"
+instruction from the system prompt overrode the follow-up user message in
+practice.
+
+The fix is to use **two separate `ClaudeSDKClient` sessions**:
+
+1. Phase 1 runs to `ResultMessage` and the client is torn down. The collected
+   assistant text (findings list) is saved in Python.
+2. Python prompts the user for selections via `rich.console.input()`.
+3. Phase 2 opens a **new** client whose system prompt includes a
+   "Phase 2 Override (execution)" section that negates the "stop" directive,
+   and whose user prompt embeds the Phase 1 findings list verbatim plus the
+   user's selections. The agent starts cold with unambiguous instructions to
+   execute tool calls.
+
+Implementation lives in `orchestrator.py`:
+- `_build_phase2_prompt(findings_text, user_selection, branch)` — builds the
+  user prompt.
+- `_phase2_system_prompt(base)` — appends the override block to the system
+  prompt.
+- `_stream_interactive()` — two `async with ClaudeSDKClient(...)` blocks
+  instead of one multi-turn block.
+
+Also silenced a spurious `Task exception was never retrieved:
+ProcessError(exit code -15)` warning: the subprocess transport's `close()`
+terminates the CLI with SIGTERM after a 5s grace period, and the read
+generator's final `_process.wait()` raises `ProcessError` into an
+async-generator finalizer that no one awaits. The orchestrator now monkey-
+patches `_read_messages_impl` to swallow `exit_code == -15` specifically
+(other exit codes still propagate).
+
 ## Re-evaluation Triggers
 
 - If `claude-agent-sdk` adds a callback mechanism for `AskUserQuestion` (allowing the SDK

--- a/git-repo-agent/src/git_repo_agent/orchestrator.py
+++ b/git-repo-agent/src/git_repo_agent/orchestrator.py
@@ -9,11 +9,13 @@ from claude_agent_sdk import (
     AssistantMessage,
     ClaudeAgentOptions,
     ClaudeSDKClient,
+    ProcessError,
     ResultMessage,
     SystemMessage,
     TextBlock,
     ToolUseBlock,
 )
+from dataclasses import replace
 from rich.console import Console
 
 logger = logging.getLogger(__name__)
@@ -42,6 +44,32 @@ def _resilient_parse_message(data):
 
 _msg_parser.parse_message = _resilient_parse_message
 _sdk_client.parse_message = _resilient_parse_message
+
+# Patch the subprocess transport so SIGTERM-on-close (exit code -15) does not
+# produce a spurious "Task exception was never retrieved" warning when the
+# CLI subprocess doesn't exit gracefully within the SDK's 5s grace period.
+# The ProcessError is raised from the transport's read generator during
+# shutdown and often lands in a GC'd async-generator finalizer with no one
+# awaiting it. SIGTERM at close() is expected — the orchestrator has already
+# received the ResultMessage by then.
+import claude_agent_sdk._internal.transport.subprocess_cli as _sdk_subprocess  # noqa: E402
+
+_original_read_messages_impl = _sdk_subprocess.SubprocessCLITransport._read_messages_impl
+
+
+async def _quiet_read_messages_impl(self):  # type: ignore[no-untyped-def]
+    try:
+        async for data in _original_read_messages_impl(self):
+            yield data
+    except Exception as exc:
+        exit_code = getattr(exc, "exit_code", None)
+        if exit_code == -15:
+            logger.debug("Suppressing SIGTERM-on-close ProcessError: %s", exc)
+            return
+        raise
+
+
+_sdk_subprocess.SubprocessCLITransport._read_messages_impl = _quiet_read_messages_impl
 
 from .agents.blueprint import definition as blueprint_definition
 from .agents.configure import definition as configure_definition
@@ -557,66 +585,129 @@ async def _stream_messages_collecting(
     return "\n".join(collected)
 
 
+def _build_phase2_prompt(
+    findings_text: str,
+    user_selection: str,
+    worktree_branch: str | None,
+) -> str:
+    """Build the Phase 2 execution prompt.
+
+    Phase 2 is a fresh session, so we re-embed the findings list from
+    Phase 1 and give explicit instructions to execute the selected fixes
+    and commit to the worktree branch. Crucially this prompt does NOT
+    inherit the Phase 1 "stop after findings" directive — it tells the
+    agent to proceed with tool calls.
+    """
+    choice = user_selection.strip().lower()
+    if choice in ("none", "n", ""):
+        selection_instruction = (
+            "The user chose not to apply any fixes. "
+            "Skip Step 4. Proceed directly to Step 5 (record health "
+            "history) and Step 6 (generate report)."
+        )
+    else:
+        selection_instruction = (
+            f"The user selected fixes: **{user_selection}** "
+            "(reference the numbered list below). Apply exactly those fixes "
+            "from your findings list by making real tool calls (Edit, Write, "
+            "Bash, etc.), then run Step 5 (record health history) and "
+            "Step 6 (generate report)."
+        )
+
+    worktree_note = ""
+    if worktree_branch and choice not in ("none", "n", ""):
+        worktree_note = (
+            f"\n\nYou are working in a git worktree on branch "
+            f"'{worktree_branch}'. Commit your changes directly to this "
+            "branch. Do NOT create new branches or push."
+        )
+
+    return (
+        "This is the execution phase of the maintain workflow. "
+        "An earlier analysis phase produced the following numbered findings "
+        "list. Your job is to act on it, not to re-analyze.\n\n"
+        "## Findings from analysis phase\n\n"
+        f"{findings_text}\n\n"
+        "## Your task\n\n"
+        f"{selection_instruction}"
+        f"{worktree_note}\n\n"
+        "Do not ask the user any questions — they have already selected "
+        "their fixes. Execute now."
+    )
+
+
+def _phase2_system_prompt(base_system_prompt: str) -> str:
+    """Augment the system prompt for Phase 2 (execution).
+
+    Phase 1's system prompt (from maintain.md) instructs the agent to stop
+    after presenting findings. Phase 2 must override that so the agent
+    makes tool calls instead of wrapping up.
+    """
+    override = (
+        "\n\n## Phase 2 Override (execution)\n\n"
+        "You are in the EXECUTION phase. Ignore any instructions in the "
+        "workflow prompt that tell you to end your response after presenting "
+        "findings — those apply only to the analysis phase. In this phase "
+        "you MUST make tool calls to apply the selected fixes, commit them, "
+        "record the health snapshot, and output the maintenance report."
+    )
+    return base_system_prompt + override
+
+
 async def _stream_interactive(
     prompt: str,
     options: ClaudeAgentOptions,
     completion_msg: str,
     worktree_branch: str | None = None,
 ) -> str:
-    """Run a two-phase interactive session using ClaudeSDKClient.
+    """Run a two-phase interactive maintain workflow.
 
     Phase 1: Agent analyzes and presents numbered findings, then stops.
     Interlude: Python prompts the user for their selections via rich.
-    Phase 2: Agent executes the selected fixes and generates a report.
+    Phase 2: A fresh agent session receives the Phase 1 findings plus the
+    user's selections, and executes the fixes.
 
-    This replaces AskUserQuestion which does not work in SDK subprocess
-    mode. See ADR-003.
+    Two separate ClaudeSDKClient sessions are used (rather than
+    ``client.query()`` back-to-back on one client). Multi-turn on the same
+    client proved unreliable: the Phase 1 "stop after findings" anchor
+    from ``maintain.md`` caused Phase 2 to wrap up with no tool calls.
+    See ADR-003 (Revision 2026-04).
 
-    Returns concatenated agent text output for post-processing.
+    Returns concatenated agent text output from both phases for
+    post-processing (PR body, issue creation).
     """
-    collected: list[str] = []
+    # --- Phase 1: Analysis ---
+    phase1_collected: list[str] = []
     async with ClaudeSDKClient(options) as client:
-        # Phase 1: Analysis — agent presents findings and stops
         await client.query(prompt)
-
         async for message in client.receive_response():
-            _display_message(message, collected=collected)
+            _display_message(message, collected=phase1_collected)
+    phase1_text = "\n".join(phase1_collected)
 
-        # Prompt user for selections
-        console.print()
-        user_input = console.input(
-            "[bold]Select fixes to apply[/bold] "
-            "(comma-separated numbers, [green]all[/green], or [yellow]none[/yellow]): "
-        )
+    # --- Interlude: prompt user ---
+    console.print()
+    user_input = console.input(
+        "[bold]Select fixes to apply[/bold] "
+        "(comma-separated numbers, [green]all[/green], or [yellow]none[/yellow]): "
+    )
+    choice = user_input.strip().lower()
+    if choice in ("none", "n", ""):
+        console.print("[yellow]No fixes selected.[/yellow]")
 
-        choice = user_input.strip().lower()
-        if choice in ("none", "n", ""):
-            console.print("[yellow]No fixes selected.[/yellow]")
-            followup = (
-                "The user chose not to apply any fixes. "
-                "Skip Step 4. Proceed to Step 5 (record health history) "
-                "and Step 6 (generate report)."
-            )
-        else:
-            worktree_note = ""
-            if worktree_branch:
-                worktree_note = (
-                    f" You are working in a git worktree on branch '{worktree_branch}'. "
-                    "Commit your changes directly to this branch. Do NOT create new branches."
-                )
-            followup = (
-                f"The user selected: {user_input}. "
-                "Execute the selected fixes (Step 4), then record health "
-                f"history (Step 5) and generate the maintenance report (Step 6).{worktree_note}"
-            )
+    # --- Phase 2: Execution (fresh session) ---
+    phase2_prompt = _build_phase2_prompt(phase1_text, user_input, worktree_branch)
+    phase2_options = replace(
+        options,
+        system_prompt=_phase2_system_prompt(options.system_prompt or ""),
+    )
 
-        # Phase 2: Execution
-        await client.query(followup)
-
+    phase2_collected: list[str] = []
+    async with ClaudeSDKClient(phase2_options) as client:
+        await client.query(phase2_prompt)
         async for message in client.receive_response():
-            _display_message(message, completion_msg, collected)
+            _display_message(message, completion_msg, phase2_collected)
 
-    return "\n".join(collected)
+    return phase1_text + "\n" + "\n".join(phase2_collected)
 
 
 def _extract_report_section(agent_output: str) -> str:

--- a/git-repo-agent/src/git_repo_agent/prompts/maintain.md
+++ b/git-repo-agent/src/git_repo_agent/prompts/maintain.md
@@ -53,7 +53,7 @@ Example output format:
 
 Mark items that should NOT be auto-fixed (test failures, security vulnerabilities, architecture decisions) as "report-only".
 
-**End your response after presenting the numbered findings list.** Do NOT use `AskUserQuestion`. The orchestrator will prompt the user for their selections and send a follow-up message with their choices.
+**In the analysis phase only: end your response after presenting the numbered findings list.** Do NOT use `AskUserQuestion`. The orchestrator will prompt the user for their selections in Python and then start a new session for the execution phase with the findings list and selections embedded in its user prompt. This "stop after findings" instruction does NOT apply when you see a "Phase 2 Override (execution)" section in your system prompt.
 
 In **auto-fix mode**, skip this step and proceed directly to Step 4.
 
@@ -63,7 +63,7 @@ In **report-only mode**, present the full findings list with ALL items marked as
 
 Execute fixes based on the operating mode:
 
-- **Interactive mode**: You will receive a follow-up message from the orchestrator containing the user's selections (e.g., "1,3,5" or "all"). Apply exactly the fixes corresponding to those numbers from your Step 3 findings list.
+- **Interactive mode**: In the execution phase you will receive a **fresh user prompt** from the orchestrator containing (a) the full numbered findings list from the analysis phase and (b) the user's selections (e.g., "1,3,5" or "all"). This is a new session — treat the embedded findings list as authoritative. Apply exactly the fixes corresponding to the user's selections by making real tool calls (Edit, Write, Bash). Do NOT re-run the analysis; do NOT present findings again; do NOT ask the user anything.
 - **Auto-fix mode**: Apply all conservative auto-fixes
 
 ### Auto-fix scope (conservative)

--- a/git-repo-agent/tests/test_orchestrator_display.py
+++ b/git-repo-agent/tests/test_orchestrator_display.py
@@ -1,6 +1,12 @@
 """Tests for orchestrator display and PR content helpers."""
 
-from git_repo_agent.orchestrator import _tool_detail, _extract_report_section, _build_pr_content
+from git_repo_agent.orchestrator import (
+    _build_phase2_prompt,
+    _build_pr_content,
+    _extract_report_section,
+    _phase2_system_prompt,
+    _tool_detail,
+)
 
 
 class TestToolDetail:
@@ -83,3 +89,73 @@ class TestBuildPrContent:
     def test_fallback_for_no_headings(self):
         title, body = _build_pr_content("maintain", "no headings here")
         assert "## Summary" in body
+
+
+FINDINGS_FIXTURE = (
+    "1. [docs] README missing install section — auto-fixable\n"
+    "2. [security] Dependency CVE-2025-0001 — report-only\n"
+    "3. [quality] ESLint not configured — auto-fixable"
+)
+
+
+class TestBuildPhase2Prompt:
+    """Regression tests for the interactive-maintain Phase 2 bug.
+
+    See ADR-003 Revision 2026-04-12 — Phase 2 used to silently skip tool
+    calls because it inherited the Phase 1 "stop after findings" anchor.
+    The fix passes a fresh, self-contained prompt that embeds findings +
+    user selection and instructs the agent to execute.
+    """
+
+    def test_embeds_findings_verbatim(self):
+        prompt = _build_phase2_prompt(FINDINGS_FIXTURE, "all", "maintain/2026-04-12")
+        assert FINDINGS_FIXTURE in prompt
+
+    def test_embeds_user_selection(self):
+        prompt = _build_phase2_prompt(FINDINGS_FIXTURE, "1,3", "maintain/2026-04-12")
+        assert "1,3" in prompt
+
+    def test_all_selection_instructs_execution(self):
+        prompt = _build_phase2_prompt(FINDINGS_FIXTURE, "all", "maintain/2026-04-12")
+        # Agent must be told to make tool calls, not re-analyze or stop.
+        assert "Apply exactly those fixes" in prompt
+        assert "tool calls" in prompt
+        assert "maintain/2026-04-12" in prompt
+        assert "Do NOT create new branches" in prompt
+
+    def test_none_selection_skips_fixes(self):
+        prompt = _build_phase2_prompt(FINDINGS_FIXTURE, "none", None)
+        assert "not to apply any fixes" in prompt
+        assert "Skip Step 4" in prompt
+        # No worktree note when nothing will be committed.
+        assert "Do NOT create new branches" not in prompt
+
+    def test_empty_selection_treated_as_none(self):
+        prompt = _build_phase2_prompt(FINDINGS_FIXTURE, "", None)
+        assert "not to apply any fixes" in prompt
+
+    def test_does_not_inherit_phase1_stop_anchor(self):
+        # The Phase 1 system prompt tells the agent to "end your response
+        # after presenting the numbered findings list". Phase 2 must not
+        # repeat that instruction, or the agent will wrap up without
+        # making any tool calls (the original bug).
+        prompt = _build_phase2_prompt(FINDINGS_FIXTURE, "all", "maintain/2026-04-12")
+        assert "end your response after presenting" not in prompt.lower()
+        # Explicit anti-instruction should be present instead.
+        assert "Execute now" in prompt
+
+    def test_all_forbids_asking_questions(self):
+        prompt = _build_phase2_prompt(FINDINGS_FIXTURE, "all", "maintain/2026-04-12")
+        assert "Do not ask the user any questions" in prompt
+
+
+class TestPhase2SystemPrompt:
+    def test_appends_override_section(self):
+        result = _phase2_system_prompt("# Original system prompt\n\nStop after findings.")
+        assert "# Original system prompt" in result
+        assert "Phase 2 Override" in result
+        assert "make tool calls" in result.lower()
+
+    def test_handles_empty_base(self):
+        result = _phase2_system_prompt("")
+        assert "Phase 2 Override" in result


### PR DESCRIPTION
## Summary

Fixes a critical bug in the interactive maintain workflow where Phase 2 (execution) was silently skipping tool calls after the user selected fixes. The agent would analyze findings in Phase 1, the user would select fixes, but Phase 2 would wrap up without executing anything.

## Root Cause

The Phase 1 system prompt from `maintain.md` anchored the agent on "end your response after presenting findings". When Phase 2's follow-up ran on the same `ClaudeSDKClient` session, the model's prior turn and system prompt instruction dominated — it would summarize and stop again instead of executing the selected fixes.

## Solution

Refactored `_stream_interactive()` to use **two separate `ClaudeSDKClient` sessions** instead of one multi-turn session:

- **Phase 1**: Agent analyzes and presents findings, then the client is torn down. Findings are collected in Python.
- **Interlude**: Python prompts user for selections via `rich.console.input()`.
- **Phase 2**: A fresh client session with:
  - A new system prompt that includes a "Phase 2 Override (execution)" section negating the "stop" directive
  - A self-contained user prompt that embeds Phase 1 findings verbatim plus the user's selections
  - Explicit instructions to execute tool calls without re-analyzing

## Key Changes

- Added `_build_phase2_prompt()` to construct the Phase 2 user prompt with findings + selections
- Added `_phase2_system_prompt()` to augment the system prompt with execution-phase override
- Refactored `_stream_interactive()` to use two separate `ClaudeSDKClient` contexts
- Updated `maintain.md` to clarify the "stop after findings" instruction applies only to the analysis phase
- Added comprehensive regression tests in `test_orchestrator_display.py`
- Documented the fix in ADR-003 Revision 2026-04-12

## Additional Fix

Silenced a spurious `Task exception was never retrieved: ProcessError(exit code -15)` warning by monkey-patching the subprocess transport's `_read_messages_impl` to swallow SIGTERM-on-close errors (exit code -15), which are expected during graceful shutdown.

https://claude.ai/code/session_01SMzA3S3eAKWtLqUvcXEiG8