### PR TITLE
Add monorepo support (v3.3) with workspace discovery and portfolio tracking

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -95,7 +95,7 @@
     {
       "name": "blueprint-plugin",
       "source": "./blueprint-plugin",
-      "description": "Blueprint Development methodology - PRD/PRP workflow with version tracking, modular rules, and CLAUDE.md management",
+      "description": "Blueprint Development methodology - PRD/PRP workflow with version tracking, modular rules, CLAUDE.md management, and monorepo portfolio tracking",
       "version": "3.25.1",
       "keywords": [
         "blueprint",
@@ -104,7 +104,10 @@
         "requirements",
         "methodology",
         "version-tracking",
-        "modular-rules"
+        "modular-rules",
+        "monorepo",
+        "workspaces",
+        "portfolio-tracking"
       ],
       "category": "development"
     },

--- a/blueprint-plugin/.claude-plugin/plugin.json
+++ b/blueprint-plugin/.claude-plugin/plugin.json
@@ -43,6 +43,9 @@
     "adr-backlog",
     "test-regression-plan",
     "derive-tests",
-    "test-gaps"
+    "test-gaps",
+    "monorepo",
+    "workspaces",
+    "portfolio-tracking"
   ]
 }

--- a/blueprint-plugin/README.md
+++ b/blueprint-plugin/README.md
@@ -60,6 +60,7 @@ PRD (Product Requirements) → PRP (Product Requirement Prompt) → Work-Order �
 | `blueprint-rules` | Manage modular rules |
 | `blueprint-claude-md` | Update CLAUDE.md from blueprint artifacts |
 | `blueprint-sync-ids` | **NEW** - Assign IDs to all documents, build traceability registry |
+| `blueprint-workspace-scan` | **NEW (v3.3)** - Discover child blueprints in a monorepo and refresh the root's `workspaces.children` registry with cached feature-tracker stats |
 
 ### Feature Tracking Skills
 
@@ -358,6 +359,73 @@ jq '.. | objects | select(.status == "not_started") | .name' docs/blueprint/feat
 # Show PRD status
 jq '.prds | to_entries | .[] | "\(.key): \(.value.status)"' docs/blueprint/feature-tracker.json
 ```
+
+## Monorepo Support (v3.3)
+
+Blueprint 3.3 adds first-class monorepo support so a repo-root blueprint can act
+as a **portfolio index** over child workspaces (per-project blueprints in
+subdirectories).
+
+### Roles
+
+Each manifest declares a `workspaces.role`:
+
+| Role | Written by | Meaning |
+|------|------------|---------|
+| `root` | top-level manifest in a monorepo | Owns `workspaces.children[]` registry |
+| `child` | a blueprint under an ancestor root | Carries `root_relative_path` back to root |
+| *(absent)* | standalone project | No monorepo block; existing 3.2 behaviour |
+
+### Portfolio Feature Tracking
+
+Root `feature-tracker.json` can link portfolio FRs down to child FRs:
+
+```json
+"features": {
+  "FR1.1": {
+    "name": "Motion-reactive lighting",
+    "status": "partial",
+    "phase": "phase-1",
+    "implemented_by": [
+      { "workspace": "projects/esp32-lamp", "ref": "FR3.2" },
+      { "workspace": "projects/pir-bridge", "ref": "FR1" }
+    ]
+  }
+}
+```
+
+`/blueprint:feature-tracker-sync` at the root reads each child's tracker and
+**derives** the root status from the linked children (all complete → complete,
+any blocked → blocked, any in_progress/mixed → partial, all not_started →
+not_started).
+
+### Cross-Workspace References
+
+IDs remain per-workspace. Cross-workspace references use these forms:
+
+| Form | Meaning |
+|------|---------|
+| `ADR-NNN` | Local to the current workspace |
+| `projects/foo/ADR-NNN` | Sibling/child workspace (path relative to the root) |
+| `/ADR-NNN` | The monorepo root's ID space |
+
+`/blueprint:adr-validate` resolves these forms and flags unresolved ones as
+warnings.
+
+### Discovery
+
+`/blueprint:workspace-scan` walks the filesystem, finds every
+`docs/blueprint/manifest.json` under the root, and refreshes
+`workspaces.children` with cached rollup stats. It also runs automatically at
+the top of `/blueprint:status` and `/blueprint:feature-tracker-sync` when the
+active manifest has `workspaces.role == "root"`.
+
+### Migration
+
+Existing 3.2 projects migrate with `/blueprint:upgrade`. The v3.2→v3.3
+migration is **purely additive**: it only adds the `workspaces` block (or omits
+it for standalone projects) and bumps `format_version`. Nothing is moved,
+renamed, or deleted.
 
 ## Hooks
 

--- a/blueprint-plugin/schemas/feature-tracker.schema.json
+++ b/blueprint-plugin/schemas/feature-tracker.schema.json
@@ -66,6 +66,13 @@
     },
     "statistics": {
       "$ref": "#/definitions/statistics"
+    },
+    "workspaces": {
+      "type": "object",
+      "description": "Monorepo portfolio: cached rollup stats keyed by child workspace relative path. Populated by blueprint:feature-tracker-sync at root blueprints (format_version >= 3.3.0).",
+      "additionalProperties": {
+        "$ref": "#/definitions/workspaceStats"
+      }
     }
   },
   "definitions": {
@@ -201,6 +208,55 @@
             }
           },
           "additionalProperties": false
+        },
+        "implemented_by": {
+          "type": "array",
+          "description": "Monorepo portfolio: cross-workspace references to child-workspace FRs that implement this portfolio feature. When non-empty, status is derived by blueprint:feature-tracker-sync (format_version >= 3.3.0).",
+          "items": {
+            "$ref": "#/definitions/implementedByRef"
+          }
+        }
+      }
+    },
+    "implementedByRef": {
+      "type": "object",
+      "required": ["workspace", "ref"],
+      "properties": {
+        "workspace": {
+          "type": "string",
+          "description": "Relative path from the root blueprint to the child workspace (e.g., 'projects/esp32-lamp')"
+        },
+        "ref": {
+          "type": "string",
+          "description": "Feature code in the child workspace's feature-tracker.json (e.g., 'FR3.2')"
+        }
+      }
+    },
+    "workspaceStats": {
+      "type": "object",
+      "description": "Cached rollup statistics for a child workspace",
+      "properties": {
+        "total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "complete": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "completion_percentage": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "current_phase": {
+          "type": ["string", "null"],
+          "description": "Child workspace's currently active phase"
+        },
+        "last_synced_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of last sync from child feature-tracker"
         }
       }
     },

--- a/blueprint-plugin/skills/blueprint-adr-validate/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-adr-validate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-01-15
-modified: 2026-03-01
-reviewed: 2026-02-14
+modified: 2026-04-12
+reviewed: 2026-04-12
 description: "Validate ADR relationships, detect orphaned references, and check domain consistency"
 args: "[--report-only]"
 argument-hint: "--report-only to validate without prompting for fixes"
@@ -57,6 +57,17 @@ For each ADR, validate:
 3. **related references**: Verify all targets exist, warn if one-way links
 4. **self-references**: Flag if ADR references itself
 5. **circular chains**: Detect cycles in supersession graph
+6. **Cross-workspace references** (v3.3.0+, manifests with `workspaces.role`):
+   Recognise these reference forms in supersedes/extends/related fields:
+   - `ADR-NNN` — local to the current workspace (existing behaviour).
+   - `<workspace-path>/ADR-NNN` — points into a sibling/child workspace. Resolve
+     by reading `<workspace-path>/docs/adrs/` from the monorepo root. Warn if
+     the workspace is not listed in root `workspaces.children`.
+   - `/ADR-NNN` — points at the monorepo root's ADR set. Resolve using the
+     manifest's `workspaces.root_relative_path` (for child manifests) or the
+     current directory (for root manifests).
+   Unresolved cross-workspace refs are reported as warnings (not errors) so
+   they do not block validation during migration.
 
 See [REFERENCE.md](REFERENCE.md#validation-rules) for detailed checks.
 

--- a/blueprint-plugin/skills/blueprint-feature-tracker-status/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-feature-tracker-status/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-01-02
-modified: 2026-02-06
-reviewed: 2026-01-02
+modified: 2026-04-12
+reviewed: 2026-04-12
 description: "Display feature tracker statistics and completion summary"
 allowed-tools: Read, Bash, AskUserQuestion
 name: blueprint-feature-tracker-status
@@ -76,7 +76,28 @@ Display feature tracker statistics, phase progress, and completion summary.
    ===============
    {List first 10 not_started features by phase order}
    - {FR code}: {name} (Phase {N})
+
+   {If any feature has non-empty implemented_by (monorepo portfolio, v3.3.0+):}
+   Portfolio Features (linked to child workspaces):
+   ================================================
+   {For each portfolio feature with implemented_by:}
+   - {FR code}: {name} — derived status: {status}
+     Implemented by:
+     {For each link:}
+       - {link.workspace}/{link.ref} → {status from child feature-tracker}
+
+   {If top-level "workspaces" summary present:}
+   Workspace Rollups:
+   ==================
+   {For each workspace key:}
+   - {path}: {complete}/{total} ({completion_percentage}%) [last synced: {last_synced_at}]
    ```
+
+4a. **Resolve portfolio links** (v3.3.0+):
+   For each feature with non-empty `implemented_by`, open each referenced child
+   `<workspace>/docs/blueprint/feature-tracker.json` and look up the `ref` FR to
+   obtain its current status. Warn (do not fail) on missing workspaces or
+   refs; suggest `/blueprint:workspace-scan` + `/blueprint:feature-tracker-sync`.
 
 5. **Display visual progress bar**:
    Create ASCII progress bar:

--- a/blueprint-plugin/skills/blueprint-feature-tracker-sync/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-feature-tracker-sync/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-01-02
-modified: 2026-02-17
-reviewed: 2026-02-04
+modified: 2026-04-12
+reviewed: 2026-04-12
 description: "Synchronize feature tracker with TODO.md and PRDs, manage tasks"
 allowed-tools: Read, Write, Bash, Glob, AskUserQuestion
 name: blueprint-feature-tracker-sync
@@ -137,6 +137,48 @@ options:
   - `in_progress` if any feature in_progress
   - `partial` if some complete, some not
   - `not_started` if no features started
+
+### Step 6a: Resolve portfolio links (v3.3.0+, root blueprints only)
+
+Run only when the manifest at the root has `workspaces.role == "root"` AND the
+feature-tracker contains any feature with a non-empty `implemented_by` array.
+
+1. For each feature with `implemented_by`:
+   - For every `{workspace, ref}` entry, read
+     `<workspace>/docs/blueprint/feature-tracker.json` and look up `ref`.
+   - Collect the child statuses. If any entry cannot be resolved (missing file
+     or missing ref), record a warning and treat that entry as `not_started`
+     for the rollup.
+   - Derive the root feature's `status` using this rule:
+
+     | Child statuses observed | Derived status |
+     |-------------------------|----------------|
+     | All resolved entries `complete` | `complete` |
+     | Any `blocked` | `blocked` |
+     | Any `in_progress`, or a mix of `complete`/`not_started` | `partial` |
+     | All `not_started` | `not_started` |
+
+   - Overwrite the feature's `status` with the derived value. Do NOT touch
+     `implementation` on portfolio features; status alone is recomputed.
+
+2. Rebuild the top-level `workspaces` summary by reading each child's
+   `statistics` block:
+
+   ```json
+   "workspaces": {
+     "projects/esp32-lamp": {
+       "total": 14, "complete": 6, "completion_percentage": 42.9,
+       "current_phase": "phase-1", "last_synced_at": "<now>"
+     }
+   }
+   ```
+
+3. Recompute root `statistics` after the derived statuses are applied so the
+   portfolio-level totals reflect the child-driven states.
+
+4. Emit warnings in the sync report (Step 9) for unresolved `implemented_by`
+   entries, and suggest `/blueprint:workspace-scan` when a referenced
+   workspace is not present in the root manifest's `workspaces.children`.
 
 ### Step 7: Update feature-tracker.json
 

--- a/blueprint-plugin/skills/blueprint-init/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-init/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-16
-modified: 2026-02-20
-reviewed: 2026-01-17
+modified: 2026-04-12
+reviewed: 2026-04-12
 description: "Initialize Blueprint Development structure in current project"
 allowed-tools: Bash, Write, Read, AskUserQuestion, Glob
 name: blueprint-init
@@ -22,6 +22,27 @@ Initialize Blueprint Development in this project.
        - "Reinitialize (will reset manifest)" → continue with step 2
        - "Cancel" → exit
      ```
+
+1a. **Detect monorepo context** (format_version 3.3.0+):
+   - Walk upward from the current directory looking for an ancestor
+     `docs/blueprint/manifest.json` (stop at the repo root or `$HOME`).
+   - If an ancestor root manifest exists, this init is creating a **child**
+     workspace. Capture the relative path from the child back to the root.
+   - Additionally scan descendants (max depth 4, skipping `node_modules`,
+     `.git`, `dist`, `build`, `target`, `.venv`) for existing
+     `docs/blueprint/manifest.json`. If any are found, this init is creating a
+     **root** that will own existing children.
+   - Otherwise this is a **standalone** blueprint (no `workspaces` block written).
+
+   ```
+   Use AskUserQuestion (only when ancestor root detected):
+   question: "Found a parent blueprint at {parent_path}. Register this as a child workspace?"
+   options:
+     - label: "Yes - register as child"
+       description: "Writes workspaces.role=child + root_relative_path; root picks it up on next /blueprint:workspace-scan"
+     - label: "No - treat as standalone"
+       description: "No workspaces block written; this project is independent"
+   ```
 
 2. **Ask about feature tracking** (use AskUserQuestion):
    ```
@@ -144,14 +165,14 @@ Initialize Blueprint Development in this project.
    └── skills/                      # Custom skill overrides (optional)
    ```
 
-7. **Create `manifest.json`** (v3.2.0 schema):
+7. **Create `manifest.json`** (v3.3.0 schema):
    ```json
    {
-     "format_version": "3.2.0",
+     "format_version": "3.3.0",
      "created_at": "[ISO timestamp]",
      "updated_at": "[ISO timestamp]",
      "created_by": {
-       "blueprint_plugin": "3.2.0"
+       "blueprint_plugin": "3.3.0"
      },
      "project": {
        "name": "[detected from package.json/pyproject.toml or directory name]",
@@ -270,6 +291,29 @@ Initialize Blueprint Development in this project.
    Note: Include `feature_tracker` section only if feature tracking is enabled.
    Note: As of v3.2.0, progress tracking is consolidated into feature-tracker.json (work-overview.md removed).
 
+   **Monorepo `workspaces` block (v3.3.0+)**, appended to the manifest based on the
+   detection from Step 1a:
+
+   - **Child** (ancestor blueprint found and user opted in):
+     ```json
+     "workspaces": {
+       "role": "child",
+       "root_relative_path": "[relative path from this dir to the root]"
+     }
+     ```
+   - **Root** (descendant blueprints found):
+     ```json
+     "workspaces": {
+       "role": "root",
+       "discovery_strategy": "auto-cache",
+       "last_scanned_at": null,
+       "children": []
+     }
+     ```
+     After writing the manifest, run `/blueprint:workspace-scan` once to
+     populate `children[]`.
+   - **Standalone**: omit the `workspaces` block entirely.
+
 8. **Create initial rules**:
    - `development.md`: TDD workflow, commit conventions
    - `testing.md`: Test requirements, coverage expectations
@@ -282,7 +326,7 @@ Initialize Blueprint Development in this project.
 
 10. **Report**:
    ```
-   Blueprint Development initialized! (v3.2.0)
+   Blueprint Development initialized! (v3.3.0)
 
    Blueprint structure created:
    - docs/blueprint/manifest.json

--- a/blueprint-plugin/skills/blueprint-migration/migrations/v3.2-to-v3.3.md
+++ b/blueprint-plugin/skills/blueprint-migration/migrations/v3.2-to-v3.3.md
@@ -1,0 +1,216 @@
+# Migration: v3.2 → v3.3
+
+This document describes the migration from blueprint format version 3.2 to 3.3.
+
+## Overview
+
+Version 3.3 adds **first-class monorepo support**. All changes are purely
+additive — nothing is moved, renamed, or deleted. Standalone (single-project)
+blueprints keep working unchanged; they simply omit the new `workspaces` block.
+
+Key additions:
+
+- `manifest.json` gains a `workspaces` object:
+  - `role: "root" | "child"` (omitted for standalone projects)
+  - Root: `discovery_strategy`, `last_scanned_at`, `children[]` (populated by
+    `/blueprint:workspace-scan`)
+  - Child: `root_relative_path` pointing back to the root
+- `feature-tracker.json` (root only) gains two optional additions:
+  - Per-feature `implemented_by: [{workspace, ref}, ...]` on portfolio FRs
+  - Top-level `workspaces: {"<path>": {total, complete, ...}}` cached rollup
+- New skill `/blueprint:workspace-scan` discovers child blueprints and
+  refreshes cached stats.
+
+IDs remain scoped per workspace. Cross-workspace references use
+`<workspace-path>/ADR-NNN`, and a leading `/` means "the monorepo root".
+
+## Pre-Migration Checks
+
+```bash
+# 1. Manifest exists
+test -f docs/blueprint/manifest.json
+
+# 2. Version is 3.2.x
+version=$(jq -r '.format_version // "1.0.0"' docs/blueprint/manifest.json)
+if [[ ! "$version" =~ ^3\.2 ]]; then
+  echo "ERROR: Expected v3.2.x, found $version"
+  exit 1
+fi
+
+# 3. Working tree clean
+git status --porcelain
+```
+
+**Confirmation**: "Current version is v{version}. Proceed with migration to v3.3.0?"
+
+## Migration Steps
+
+### Step 1: Classify this blueprint
+
+Determine the role this manifest will play:
+
+```bash
+# Look for an ancestor blueprint root (indicates this is a child).
+ancestor_root=""
+dir=$(cd .. && pwd)
+while [[ "$dir" != "/" && "$dir" != "$HOME" ]]; do
+  if [[ -f "$dir/docs/blueprint/manifest.json" ]]; then
+    ancestor_root="$dir"
+    break
+  fi
+  dir=$(dirname "$dir")
+done
+
+# Look for descendant blueprints (indicates this is a root).
+descendant_count=$(find . -maxdepth 6 \
+  -type d \( -name node_modules -o -name .git -o -name dist -o -name build \) -prune \
+  -o -type f -path '*/docs/blueprint/manifest.json' -print 2>/dev/null \
+  | grep -v '^./docs/blueprint/manifest.json$' \
+  | wc -l)
+```
+
+- If `ancestor_root` is set → **child** role (ask user to confirm).
+- Else if `descendant_count > 0` → **root** role.
+- Otherwise → **standalone**: skip Step 2, proceed to Step 3 with no
+  `workspaces` block.
+
+### Step 2: Add the `workspaces` block
+
+**Child manifest**:
+
+```bash
+root_rel=$(python3 -c "import os,sys; print(os.path.relpath(sys.argv[1], sys.argv[2]))" "$ancestor_root" "$(pwd)")
+jq --arg rel "$root_rel" '
+  .workspaces = {
+    "role": "child",
+    "root_relative_path": $rel
+  }
+' docs/blueprint/manifest.json > docs/blueprint/manifest.json.tmp && \
+mv docs/blueprint/manifest.json.tmp docs/blueprint/manifest.json
+```
+
+**Root manifest**:
+
+```bash
+jq '
+  .workspaces = {
+    "role": "root",
+    "discovery_strategy": "auto-cache",
+    "last_scanned_at": null,
+    "children": []
+  }
+' docs/blueprint/manifest.json > docs/blueprint/manifest.json.tmp && \
+mv docs/blueprint/manifest.json.tmp docs/blueprint/manifest.json
+```
+
+### Step 3: Bump `format_version` and record upgrade history
+
+```bash
+jq '
+  .format_version = "3.3.0" |
+  .updated_at = (now | strftime("%Y-%m-%dT%H:%M:%SZ")) |
+  .upgrade_history = ((.upgrade_history // []) + [{
+    "from": "3.2.0",
+    "to": "3.3.0",
+    "date": (now | strftime("%Y-%m-%dT%H:%M:%SZ")),
+    "changes": [
+      "Added workspaces block for monorepo support",
+      "Enabled cross-workspace cross-references (`<path>/ADR-NNN`, `/ADR-NNN`)",
+      "Optional: implemented_by portfolio links in feature-tracker.json"
+    ]
+  }])
+' docs/blueprint/manifest.json > docs/blueprint/manifest.json.tmp && \
+mv docs/blueprint/manifest.json.tmp docs/blueprint/manifest.json
+```
+
+### Step 4: Populate `workspaces.children` (root only)
+
+Run the workspace scan to discover child blueprints and cache their stats:
+
+```
+/blueprint:workspace-scan
+```
+
+This is idempotent — children that have not yet migrated to 3.3 are still
+listed; their `manifest_format_version` will show `3.2.0` until they migrate.
+
+### Step 5: (Optional) Opt into portfolio feature tracking
+
+Only when the user wants to track portfolio-level FRs that span workspaces:
+
+```bash
+# Add an empty top-level workspaces summary to the root feature-tracker.
+if [[ -f docs/blueprint/feature-tracker.json ]]; then
+  jq '.workspaces = (.workspaces // {})' docs/blueprint/feature-tracker.json \
+    > docs/blueprint/feature-tracker.json.tmp && \
+  mv docs/blueprint/feature-tracker.json.tmp docs/blueprint/feature-tracker.json
+fi
+```
+
+The user then hand-adds `implemented_by` arrays to the portfolio FRs they care
+about and runs `/blueprint:feature-tracker-sync` at the root to derive statuses.
+
+## Post-Migration Verification
+
+```bash
+# 1. format_version is 3.3.0
+jq -r '.format_version' docs/blueprint/manifest.json
+# Expected: 3.3.0
+
+# 2. workspaces.role is set (root/child) or absent (standalone) as expected
+jq -r '.workspaces.role // "(standalone)"' docs/blueprint/manifest.json
+
+# 3. Root: children populated
+jq '.workspaces.children | length' docs/blueprint/manifest.json
+
+# 4. Child: root_relative_path resolves
+rel=$(jq -r '.workspaces.root_relative_path // empty' docs/blueprint/manifest.json)
+if [[ -n "$rel" ]]; then
+  test -f "$rel/docs/blueprint/manifest.json" && echo "root link resolves: OK"
+fi
+
+# 5. Upgrade history recorded
+jq '.upgrade_history[-1]' docs/blueprint/manifest.json
+```
+
+## Migration Summary Template
+
+```
+Blueprint Migration Complete (v3.2 → v3.3)
+
+Monorepo support enabled:
+- Role: {root|child|standalone}
+- Children discovered: {N} (root only)
+- Cross-workspace references now resolvable in ADR validation
+
+Manifest updated:
+- format_version: 3.3.0
+- upgrade_history entry added
+
+Next steps:
+1. Run /blueprint:status to view the new portfolio section (root only)
+2. (Optional) Add implemented_by links to portfolio FRs, then run
+   /blueprint:feature-tracker-sync
+3. Commit the migration
+```
+
+## Rollback
+
+Because v3.3 is purely additive, rollback is straightforward:
+
+```bash
+jq 'del(.workspaces) | .format_version = "3.2.0"' docs/blueprint/manifest.json \
+  > docs/blueprint/manifest.json.tmp && \
+mv docs/blueprint/manifest.json.tmp docs/blueprint/manifest.json
+
+# Optionally remove the top-level workspaces summary from feature-tracker.json:
+if [[ -f docs/blueprint/feature-tracker.json ]]; then
+  jq 'del(.workspaces)' docs/blueprint/feature-tracker.json \
+    > docs/blueprint/feature-tracker.json.tmp && \
+  mv docs/blueprint/feature-tracker.json.tmp docs/blueprint/feature-tracker.json
+fi
+```
+
+`implemented_by` entries, if added, remain valid JSON under v3.2 schema
+validation (schemas did not forbid unknown keys on feature objects) but will
+be treated as plain data until re-upgraded.

--- a/blueprint-plugin/skills/blueprint-migration/skill.md
+++ b/blueprint-plugin/skills/blueprint-migration/skill.md
@@ -4,8 +4,8 @@ description: Versioned migration procedures for upgrading blueprint structure be
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion, TodoWrite
 created: 2025-12-22
-modified: 2026-01-09
-reviewed: 2026-01-09
+modified: 2026-04-12
+reviewed: 2026-04-12
 ---
 
 # Blueprint Migration
@@ -24,7 +24,7 @@ Expert skill for migrating blueprint structures between format versions. This sk
 
 ```
 1. Read current manifest version
-2. Compare with target version (latest: 3.1.0)
+2. Compare with target version (latest: 3.3.0)
 3. Load migration document for version range
 4. Execute migration steps sequentially
 5. Confirm each destructive operation
@@ -40,6 +40,7 @@ Expert skill for migrating blueprint structures between format versions. This sk
 | 1.x.x | 2.0.0 | `migrations/v1.x-to-v2.0.md` |
 | 2.x.x | 3.0.0 | `migrations/v2.x-to-v3.0.md` |
 | 3.0.x | 3.1.0 | `migrations/v3.0-to-v3.1.md` |
+| 3.2.x | 3.3.0 | `migrations/v3.2-to-v3.3.md` |
 
 ## Version Detection
 

--- a/blueprint-plugin/skills/blueprint-status/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-status/SKILL.md
@@ -55,8 +55,15 @@ Display the current blueprint configuration status with three-layer architecture
 
 3. **Check for upgrade availability**:
    - Compare `format_version` in manifest with current plugin version
-   - Current format version: **3.0.0**
+   - Current format version: **3.3.0**
    - If manifest version < current → upgrade available
+
+3a. **Monorepo portfolio refresh (v3.3.0+)**:
+   - If `workspaces.role == "root"`, invoke `/blueprint:workspace-scan` to
+     refresh `workspaces.children` and cached stats before rendering. Skip if
+     scanned within the last hour (`last_scanned_at`).
+   - If `workspaces.role == "child"`, resolve `workspaces.root_relative_path`
+     and mention the parent in the status report but do NOT trigger a scan.
 
 4. **Check generated content status**:
    - For each generated rule in manifest:
@@ -113,6 +120,16 @@ Display the current blueprint configuration status with three-layer architecture
    - Progress: {statistics.complete}/{statistics.total_features} ({statistics.completion_percentage}%)
    - Last Sync: {last_updated}
    - Phases: {count in_progress} active, {count complete} complete
+
+   {If workspaces.role == "root":}
+   Monorepo Portfolio ({workspaces.children|length} workspaces, scanned {last_scanned_at}):
+   | Workspace | Format | Progress | Phase |
+   |-----------|--------|----------|-------|
+   {for each child:}
+   | {child.path} | v{child.manifest_format_version} | {child.cached_stats.complete}/{child.cached_stats.total} ({child.cached_stats.completion_percentage}%) | {child.cached_stats.current_phase or "—"} |
+
+   {If workspaces.role == "child":}
+   Workspace: child of blueprint at {workspaces.root_relative_path}
 
    {If task_registry exists:}
    Task Health:

--- a/blueprint-plugin/skills/blueprint-workspace-scan/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-workspace-scan/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: blueprint-workspace-scan
+description: |
+  Discover child blueprint workspaces under a monorepo root and refresh the root
+  manifest's workspaces.children registry with cached feature-tracker stats.
+  Use when you add/remove a child blueprint, when `/blueprint:status` shows stale
+  portfolio data, or when migrating a root from v3.2 to v3.3. Requires
+  format_version >= 3.3.0.
+args: "[--max-depth N] [--dry-run]"
+argument-hint: "--dry-run to preview without writing; --max-depth sets search depth (default 4)"
+allowed-tools: Bash(bash *), Read, Glob
+created: 2026-04-12
+modified: 2026-04-12
+reviewed: 2026-04-12
+---
+
+# /blueprint:workspace-scan
+
+Refresh the monorepo root blueprint's `workspaces.children` registry by walking
+the filesystem for child `docs/blueprint/manifest.json` files, reading their
+`feature-tracker.json` when present, and writing cached rollup stats back to the
+root manifest.
+
+## When to Use This Skill
+
+| Use this skill when... | Use `/blueprint:status` instead when... |
+|------------------------|-----------------------------------------|
+| Adding or removing a child blueprint | Just inspecting overall blueprint state |
+| Root `workspaces.children` looks stale | You do not run a monorepo |
+| Migrating to `format_version` 3.3.0 | You only want per-project details |
+
+## Context
+
+- Root manifest: !`find docs/blueprint -maxdepth 1 -name manifest.json`
+- Candidate child manifests: !`find . -maxdepth 6 -type d \( -name node_modules -o -name .git -o -name dist -o -name build \) -prune -o -type f -path '*/docs/blueprint/manifest.json' -print`
+- Current scan time: !`date -u +%Y-%m-%dT%H:%M:%SZ`
+
+## Parameters
+
+Parse these from `$ARGUMENTS`:
+
+- `--dry-run`: Preview discovered children and the JSON that would be written — make no changes.
+- `--max-depth N`: Maximum directory depth to search (default 4). Increase for deeply nested monorepos.
+
+## Execution
+
+Execute this workspace scan:
+
+### Step 1: Verify a root manifest exists
+
+If `docs/blueprint/manifest.json` is missing, stop and report that the current
+directory is not a blueprint root. Suggest `/blueprint:init` for new projects.
+
+### Step 2: Run the scan script
+
+Invoke the bundled script; it walks the tree, writes the updated manifest, and
+emits a structured summary:
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/workspace-scan.sh" \
+  --project-dir "$(pwd)" \
+  --max-depth 4 $ARGUMENTS
+```
+
+The script:
+
+1. Refuses to run on a manifest whose `workspaces.role == "child"`.
+2. Skips `node_modules`, `.git`, `dist`, `build`, `target`, `.venv`.
+3. Writes `workspaces.role=root`, `discovery_strategy=auto-cache`,
+   `last_scanned_at`, and a refreshed `children[]` array with `cached_stats`.
+4. Leaves existing feature-tracker data untouched.
+
+### Step 3: Report findings
+
+Summarize the script output for the user:
+
+- Number of children discovered.
+- Any children whose `manifest_format_version` is below `3.3.0` (suggest running
+  `/blueprint:upgrade` inside them if the user wants a fully v3.3 portfolio).
+- Any children without a `feature-tracker.json` (cached stats will be `null`).
+
+### Step 4: Next steps
+
+Recommend running `/blueprint:feature-tracker-sync` at the root afterwards to
+recompute derived statuses for any portfolio FRs that use `implemented_by`.
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Preview changes | `/blueprint:workspace-scan --dry-run` |
+| Deeper monorepo | `/blueprint:workspace-scan --max-depth 6` |
+| Refresh all | `/blueprint:workspace-scan` followed by `/blueprint:feature-tracker-sync` |
+
+## Quick Reference
+
+| Key | Meaning |
+|-----|---------|
+| `workspaces.role` | `root` on the top manifest, `child` on per-project manifests |
+| `workspaces.children[].path` | Path relative to the root (e.g., `projects/esp32-lamp`) |
+| `workspaces.children[].cached_stats` | Rolled-up `{total, complete, completion_percentage, current_phase}` from the child's feature-tracker |
+
+## Post-actions
+
+- If any child was removed from the registry (e.g., deleted on disk), the
+  script replaces `children[]` wholesale — verify expected workspaces still
+  appear.
+- Commit the updated manifest with a conventional commit:
+  `chore(blueprint-plugin): refresh workspaces registry`.

--- a/blueprint-plugin/skills/blueprint-workspace-scan/scripts/workspace-scan.sh
+++ b/blueprint-plugin/skills/blueprint-workspace-scan/scripts/workspace-scan.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+#
+# workspace-scan.sh — Discover child blueprint workspaces under a root and
+# refresh the root manifest's workspaces.children registry + cached stats.
+#
+# Usage:
+#   workspace-scan.sh --project-dir <path> [--max-depth N] [--dry-run]
+#
+# Output:
+#   Structured KEY=value pairs with === SECTION === headers.
+#
+# Exit codes:
+#   0 on success, 1 on invocation/filesystem error, 2 if no root manifest found.
+
+set -uo pipefail
+
+project_dir=""
+max_depth=4
+dry_run=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project-dir) project_dir="$2"; shift 2 ;;
+    --max-depth)   max_depth="$2";   shift 2 ;;
+    --dry-run)     dry_run=1;        shift   ;;
+    *) echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$project_dir" ]]; then
+  echo "Usage: workspace-scan.sh --project-dir <path> [--max-depth N] [--dry-run]" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required but not installed" >&2
+  exit 1
+fi
+
+root_manifest="$project_dir/docs/blueprint/manifest.json"
+if [[ ! -f "$root_manifest" ]]; then
+  echo "=== ERROR ==="
+  echo "ROOT_MANIFEST_MISSING=$root_manifest"
+  exit 2
+fi
+
+# Verify this manifest is a root (or has no workspaces.role yet — treat as candidate root)
+scan_role=$(jq -r '.workspaces.role // "unset"' "$root_manifest")
+if [[ "$scan_role" == "child" ]]; then
+  echo "=== ERROR ==="
+  echo "NOT_A_ROOT=true"
+  echo "ROLE=$scan_role"
+  echo "HINT=Run this from the repository root that owns this workspace, or update workspaces.role."
+  exit 1
+fi
+
+timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+tmp_children=$(mktemp)
+trap 'rm -f "$tmp_children"' EXIT
+
+# Discover child manifests — skip the root itself.
+# Respect .gitignore by filtering out common vendor dirs; the `-prune` pattern
+# avoids descending into them entirely.
+root_abs=$(cd "$project_dir" && pwd)
+
+echo "=== DISCOVERED ==="
+echo "ROOT=$root_abs"
+echo "MAX_DEPTH=$max_depth"
+echo "SCANNED_AT=$timestamp"
+
+children_json='[]'
+count=0
+
+while IFS= read -r -d '' child_manifest; do
+  # Skip the root manifest itself.
+  child_abs=$(cd "$(dirname "$child_manifest")" && pwd)/manifest.json
+  if [[ "$child_abs" == "$root_abs/docs/blueprint/manifest.json" ]]; then
+    continue
+  fi
+
+  # Workspace path = dirname of "docs/blueprint/manifest.json" relative to root.
+  ws_dir=$(dirname "$(dirname "$(dirname "$child_manifest")")")
+  ws_rel=$(realpath --relative-to="$root_abs" "$ws_dir" 2>/dev/null || python3 -c "import os,sys; print(os.path.relpath(sys.argv[1], sys.argv[2]))" "$ws_dir" "$root_abs")
+
+  child_fmt=$(jq -r '.format_version // "unknown"' "$child_manifest")
+  child_project=$(jq -r '.project.name // ""' "$child_manifest")
+
+  # Feature tracker cached stats (if present)
+  child_ft="$ws_dir/docs/blueprint/feature-tracker.json"
+  if [[ -f "$child_ft" ]]; then
+    stats=$(jq -c '{
+      total: (.statistics.total_features // 0),
+      complete: (.statistics.complete // 0),
+      completion_percentage: (.statistics.completion_percentage // 0),
+      current_phase: (.current_phase // null),
+      last_synced_at: "'"$timestamp"'"
+    }' "$child_ft" 2>/dev/null || echo 'null')
+    has_ft=true
+  else
+    stats='null'
+    has_ft=false
+  fi
+
+  entry=$(jq -n \
+    --arg path "$ws_rel" \
+    --arg project "$child_project" \
+    --arg fmt "$child_fmt" \
+    --argjson has_ft "$has_ft" \
+    --argjson stats "$stats" \
+    --arg ts "$timestamp" \
+    '{
+      path: $path,
+      project_name: $project,
+      manifest_format_version: $fmt,
+      has_feature_tracker: $has_ft,
+      last_synced_at: $ts,
+      cached_stats: $stats
+    }')
+
+  children_json=$(jq -c ". + [$entry]" <<< "$children_json")
+  count=$((count + 1))
+  echo "CHILD=$ws_rel fmt=$child_fmt ft=$has_ft"
+
+done < <(find "$root_abs" -maxdepth $((max_depth + 3)) \
+  -type d \( -name node_modules -o -name .git -o -name dist -o -name build -o -name target -o -name .venv \) -prune \
+  -o -type f -name manifest.json -path '*/docs/blueprint/manifest.json' -print0)
+
+echo "=== SUMMARY ==="
+echo "CHILDREN_COUNT=$count"
+
+if [[ "$dry_run" -eq 1 ]]; then
+  echo "DRY_RUN=true"
+  echo "=== CHILDREN_JSON ==="
+  echo "$children_json" | jq .
+  exit 0
+fi
+
+# Write back to root manifest: set workspaces.role=root (if unset), update children + scan time.
+updated=$(jq \
+  --argjson children "$children_json" \
+  --arg ts "$timestamp" \
+  '
+    .workspaces = (.workspaces // {}) |
+    .workspaces.role = (.workspaces.role // "root") |
+    .workspaces.discovery_strategy = (.workspaces.discovery_strategy // "auto-cache") |
+    .workspaces.last_scanned_at = $ts |
+    .workspaces.children = $children |
+    .updated_at = $ts
+  ' "$root_manifest")
+
+echo "$updated" > "$root_manifest"
+echo "WROTE=$root_manifest"
+exit 0

--- a/docs/PLUGIN-MAP.md
+++ b/docs/PLUGIN-MAP.md
@@ -33,7 +33,7 @@ The development loop: plan, code, commit, ship.
 
 | Plugin | Skills | Purpose |
 |--------|--------|---------|
-| blueprint-plugin | 31 | PRD/ADR/PRP/TRP methodology, `/blueprint:execute` auto-pilot |
+| blueprint-plugin | 32 | PRD/ADR/PRP/TRP methodology, `/blueprint:execute` auto-pilot, monorepo portfolio tracking |
 | git-plugin | 32 + 1 agent | Commits, branches, PRs, issues, forks, worktrees, release-please |
 | project-plugin | 6 | Project init, modernization, maintenance |
 | agents-plugin | 1 + 10 agents | Task delegation to specialized agents |


### PR DESCRIPTION
## Summary

This PR introduces first-class monorepo support to Blueprint format v3.3, enabling a root blueprint to act as a portfolio index over child workspaces while maintaining backward compatibility with existing v3.2 standalone projects.

## Key Changes

### New Migration Guide
- **`migrations/v3.2-to-v3.3.md`**: Comprehensive migration documentation covering:
  - Classification of blueprints as root/child/standalone
  - Step-by-step migration with bash examples
  - Post-migration verification and rollback procedures
  - Portfolio feature tracking opt-in

### New Workspace Discovery Skill
- **`blueprint-workspace-scan/`**: New skill to discover child blueprints and refresh the root manifest's registry
  - `scripts/workspace-scan.sh`: Bash script that walks the filesystem, finds all `docs/blueprint/manifest.json` files, reads cached stats from child `feature-tracker.json`, and updates the root manifest's `workspaces.children` array
  - `SKILL.md`: Documentation with usage patterns, parameters (`--dry-run`, `--max-depth`), and integration points

### Schema Updates
- **`feature-tracker.schema.json`**: Extended to support:
  - `implemented_by[]` array on portfolio features linking to child workspace FRs
  - `workspaceStats` definition for cached rollup statistics (total, complete, completion_percentage, current_phase, last_synced_at)
  - Top-level `workspaces` object for portfolio-level rollup summaries

### Manifest Structure (v3.3.0)
- **Root blueprints**: `workspaces.role = "root"` with `discovery_strategy`, `last_scanned_at`, and `children[]` registry
- **Child blueprints**: `workspaces.role = "child"` with `root_relative_path` back to the root
- **Standalone projects**: No `workspaces` block (backward compatible with v3.2)

### Updated Skills
- **`blueprint-init`**: Enhanced to detect monorepo context (ancestor/descendant blueprints) and conditionally write `workspaces` block
- **`blueprint-feature-tracker-sync`**: Added Step 6a to resolve portfolio feature links, derive statuses from child FRs, and rebuild workspace rollup summaries
- **`blueprint-feature-tracker-status`**: Added portfolio feature display and workspace rollup reporting
- **`blueprint-status`**: Added monorepo portfolio refresh (auto-scan if root, resolve parent if child)
- **`blueprint-adr-validate`**: Extended to recognize cross-workspace reference forms (`<path>/ADR-NNN`, `/ADR-NNN`)

### Documentation
- **`README.md`**: Added monorepo support section explaining roles, portfolio feature tracking, cross-workspace references, and discovery workflow
- **`plugin.json`**: Added tags for monorepo, workspaces, and portfolio-tracking
- **`PLUGIN-MAP.md`**: Updated skill count (31 → 32)

## Implementation Details

- **Backward compatible**: v3.2 projects work unchanged; `workspaces` block is optional
- **Additive only**: No fields moved, renamed, or deleted; rollback is straightforward
- **ID scoping**: IDs remain per-workspace; cross-workspace refs use relative paths or `/` prefix for root
- **Lazy discovery**: `workspace-scan` is idempotent and can be run on-demand or auto-triggered by status/sync skills
- **Cached stats**: Child feature-tracker stats are cached in root manifest to avoid repeated reads; sync refreshes them
- **Derived statuses**: Portfolio FR statuses are computed from linked child FRs (all complete → complete, any blocked → blocked, mixed → partial)

https://claude.ai/code/session_01NLcf8ZN8sc1HMdh6boN3Q3