### PR TITLE
Fix branch-protection bypass: reject inline env-var prefixes

### DIFF
--- a/.claude/rules/handling-blocked-hooks.md
+++ b/.claude/rules/handling-blocked-hooks.md
@@ -77,6 +77,16 @@ the failed merge."
 | `rm -rf` | Cleaning build artifacts when other methods are insufficient |
 | Chained git commands | Complex atomic operations |
 
+## Branch Protection: Do Not Self-Serve the Bypass
+
+The `branch-protection.sh` hook in `hooks-plugin` blocks writes on `main`/`master`. When it blocks you, the correct moves — in order — are:
+
+1. **Create a feature branch**: `git checkout -b feature/your-change`, then re-run the command.
+2. **Explicit-refspec push** (for `git push` only): `git push origin main:feature/your-change` is allowed by the hook and is the right way to move local `main` commits onto a remote feature branch.
+3. **Delegate to the user** per the template above.
+
+Do **not** attempt to prefix commands with `CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1` as a self-serve override. The hook only honors that variable when the **human operator** has exported it in their shell environment — inline prefixes on an agent-emitted command are intentionally ignored. If the repo legitimately uses main-branch-dev (personal repo, dotfiles), ask the user to export the variable for their session rather than injecting it into the command.
+
 ## Key Points
 
 - Hooks protect against common mistakes - the suggested alternative is usually correct

--- a/hooks-plugin/README.md
+++ b/hooks-plugin/README.md
@@ -96,7 +96,7 @@ A PreToolUse hook that blocks write operations on protected branches (main, mast
 | Staging (git add, rm, mv) | Blocked |
 | Reset | Blocked |
 
-**Toggle:** `CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1`
+**Toggle:** `export CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1` in your shell environment (e.g. in a personal repo, dotfiles, or main-branch-dev workflow). This is a **human-operator** opt-in — inline prefixes like `CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 git commit ...` on a Bash command are intentionally not honored, so that agents cannot self-serve the bypass. When blocked on a protected branch, an agent should follow `.claude/rules/handling-blocked-hooks.md` and delegate to the user instead.
 
 ### auto-checkpoint.sh
 

--- a/hooks-plugin/hooks/branch-protection.sh
+++ b/hooks-plugin/hooks/branch-protection.sh
@@ -2,13 +2,18 @@
 # PreToolUse hook — guards write operations on protected branches (main, master)
 #
 # Behavior:
-#   - Common operations (commit, push, add): denied with guidance for Claude
-#     to consider branching. Claude can override by prefixing the command with
-#     CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 after evaluating the context.
+#   - Common operations (commit, push, add): denied with guidance to switch to
+#     a feature branch, use an explicit-refspec push, or delegate to the user
+#     per .claude/rules/handling-blocked-hooks.md.
 #   - Destructive operations (reset, rebase): prompts user to approve via "ask"
 #   - Read-only operations: always allowed silently
 #
-# Toggle: set CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 to skip this hook entirely
+# Toggle: a human operator can export CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1
+# in their shell environment (e.g. in a personal repo / dotfiles / main-branch-
+# dev setup). The toggle is only honored when set in the process environment —
+# inline prefixes like `CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 git commit ...`
+# on the command line are intentionally NOT honored so that agents cannot
+# self-serve the bypass.
 #
 # Matches: Bash
 # Detects: git commit, git push, git rebase on main/master
@@ -16,7 +21,8 @@
 
 set -euo pipefail
 
-# Toggle off via environment variable
+# Human-operator escape hatch: only honored when set in the process environment
+# (not when prefixed inline on the command). See header comment for rationale.
 [ "${CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION:-}" = "1" ] && exit 0
 
 INPUT=$(cat)
@@ -28,13 +34,12 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 [ "$TOOL_NAME" != "Bash" ] && exit 0
 [ -z "$COMMAND" ] && exit 0
 
-# Allow inline override: CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 git ...
-if echo "$COMMAND" | grep -Eq '(^|\s)CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1\s+'; then
-  exit 0
-fi
-
-# Only check git commands
-echo "$COMMAND" | grep -Eq '^\s*git\s+' || exit 0
+# Only check git commands. Allow any number of leading `VAR=value` assignments
+# before the `git` invocation so that an attempt to inline-bypass via
+# `CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 git ...` is still treated as a git
+# command (and therefore subject to the protections below) rather than slipping
+# past this filter as "not a git command".
+echo "$COMMAND" | grep -Eq '^\s*([A-Za-z_][A-Za-z0-9_]*=\S*[[:space:]]+)*git[[:space:]]+' || exit 0
 
 # Deny with guidance — Claude sees the reason and decides to branch or override
 deny() {
@@ -82,7 +87,7 @@ case "$GIT_SUBCMD" in
     if [ "$GIT_SUBCMD" = "stash" ]; then
       if echo "$COMMAND" | grep -Eq 'stash\s+(pop|apply|drop|clear)'; then
         STASH_OP=$(echo "$COMMAND" | grep -oE '(pop|apply|drop|clear)')
-        deny "You're on '${CURRENT_BRANCH}'. Consider switching to a feature branch before 'git stash ${STASH_OP}'. If committing to ${CURRENT_BRANCH} is intentional, re-run with: CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 git stash ${STASH_OP}"
+        deny "You're on '${CURRENT_BRANCH}'. Switch to a feature branch before 'git stash ${STASH_OP}' (git checkout -b feature/your-change), or delegate this command to the user per .claude/rules/handling-blocked-hooks.md. If this repo uses main-branch-dev, ask the user to export CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 in their shell."
       fi
     fi
     exit 0
@@ -97,14 +102,14 @@ case "$GIT_SUBCMD" in
     ;;
   # Common write operations — deny with guidance for Claude
   commit|cherry-pick|revert)
-    deny "You're on '${CURRENT_BRANCH}'. If this repo uses PR workflows, create a feature branch: git checkout -b feature/your-change. If committing directly to ${CURRENT_BRANCH} is appropriate (e.g. personal repo, dotfiles), re-run with: CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 git ${GIT_SUBCMD} ..."
+    deny "You're on '${CURRENT_BRANCH}'. Create a feature branch first: git checkout -b feature/your-change, then re-run 'git ${GIT_SUBCMD}'. If committing directly to ${CURRENT_BRANCH} is genuinely required (e.g. personal repo, dotfiles, main-branch-dev), delegate to the user per .claude/rules/handling-blocked-hooks.md — ask them to run it, or to export CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 in their shell. Do not attempt to self-serve this bypass."
     ;;
   push)
     # Allow push to specific remote branch via explicit refspec
     if echo "$COMMAND" | grep -q ':'; then
       exit 0
     fi
-    deny "You're about to push directly to '${CURRENT_BRANCH}'. In collaborative repos, changes go through a PR on a feature branch. If pushing to ${CURRENT_BRANCH} is intentional, re-run with: CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 git push ..."
+    deny "You're about to push directly to '${CURRENT_BRANCH}'. In collaborative repos, changes go through a PR on a feature branch. To push local ${CURRENT_BRANCH} to a remote feature branch, use an explicit refspec (allowed): git push origin ${CURRENT_BRANCH}:feature/your-change. If pushing to ${CURRENT_BRANCH} is genuinely intentional, delegate to the user per .claude/rules/handling-blocked-hooks.md."
     ;;
   # Staging operations
   add|rm|mv|restore|checkout|switch)
@@ -117,7 +122,7 @@ case "$GIT_SUBCMD" in
       exit 0
     fi
     # Staging implies committing — deny with guidance
-    deny "You're staging changes on '${CURRENT_BRANCH}'. If this repo uses PR workflows, switch to a feature branch: git checkout -b feature/your-change. If committing to ${CURRENT_BRANCH} is intentional, re-run with: CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 git ${GIT_SUBCMD} ..."
+    deny "You're staging changes on '${CURRENT_BRANCH}'. Switch to a feature branch first: git checkout -b feature/your-change, then re-run 'git ${GIT_SUBCMD}'. If committing to ${CURRENT_BRANCH} is genuinely required, delegate to the user per .claude/rules/handling-blocked-hooks.md — do not self-serve the CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION bypass."
     ;;
 esac
 

--- a/hooks-plugin/hooks/test-branch-protection.sh
+++ b/hooks-plugin/hooks/test-branch-protection.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Regression tests for branch-protection.sh
+#
+# Run: bash hooks-plugin/hooks/test-branch-protection.sh
+# Exit 0 = all tests pass, Exit 1 = failures
+#
+# Covers:
+#   - Inline `CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 git ...` prefix is NOT
+#     honored (regression: subagents previously self-served this bypass).
+#   - Process-environment `CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1` IS still
+#     honored (human-operator escape hatch).
+#   - `git push origin main:fix/foo` with explicit refspec is allowed.
+#   - Plain `git commit` / `git push` on main is denied.
+set -euo pipefail
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/branch-protection.sh"
+PASS=0
+FAIL=0
+
+# Create a throwaway git repo on `main` so the hook's branch detection has
+# something to find. Cleaned up on exit.
+TEST_REPO=$(mktemp -d)
+trap 'rm -rf "$TEST_REPO"' EXIT
+
+git -C "$TEST_REPO" init -q -b main
+git -C "$TEST_REPO" config user.email "test@example.com"
+git -C "$TEST_REPO" config user.name "test"
+git -C "$TEST_REPO" config commit.gpgsign false
+git -C "$TEST_REPO" config tag.gpgsign false
+git -C "$TEST_REPO" commit -q --allow-empty -m "init"
+
+# run_hook <command-string> [env-var-assignment...]
+# Returns the hook's stdout (the JSON decision body, or empty for silent allow).
+run_hook() {
+  local cmd_str="$1"
+  shift
+  local input
+  input=$(jq -nc --arg cmd "$cmd_str" '{tool_name:"Bash",tool_input:{command:$cmd}}')
+  (
+    cd "$TEST_REPO"
+    # Apply any extra env-var assignments passed as remaining args.
+    for assign in "$@"; do
+      export "$assign"
+    done
+    printf '%s' "$input" | bash "$HOOK"
+  )
+}
+
+assert_deny() {
+  local desc="$1" cmd_str="$2"
+  shift 2
+  local out
+  out=$(run_hook "$cmd_str" "$@")
+  if echo "$out" | grep -q '"permissionDecision":"deny"'; then
+    printf "  PASS: %s\n" "$desc"
+    PASS=$((PASS + 1))
+  else
+    printf "  FAIL: %s\n        expected deny, got: %s\n" "$desc" "${out:-<empty>}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_allow() {
+  local desc="$1" cmd_str="$2"
+  shift 2
+  local out
+  out=$(run_hook "$cmd_str" "$@")
+  # Allow = either silent (empty) or any non-deny JSON. The hook only emits
+  # JSON for deny/ask, so a non-empty non-deny output would also be unexpected.
+  if [ -z "$out" ]; then
+    printf "  PASS: %s\n" "$desc"
+    PASS=$((PASS + 1))
+  else
+    printf "  FAIL: %s\n        expected silent allow, got: %s\n" "$desc" "$out"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== branch-protection hook tests ==="
+
+# ── inline-bypass regression ────────────────────────────────────────────────
+# Regression: subagents bypassed this hook by prefixing their commands with
+# CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1, committing to main. The hook used
+# to honor this inline form. It must now be ignored so that agents cannot
+# self-serve the bypass.
+echo ""
+echo "inline bypass regression (CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 prefix on the command must NOT bypass):"
+
+assert_deny \
+  "inline-prefixed git commit on main is denied" \
+  "CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 git commit -m foo"
+
+assert_deny \
+  "inline-prefixed git add on main is denied" \
+  "CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 git add ."
+
+assert_deny \
+  "inline-prefixed git push on main (no refspec) is denied" \
+  "CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 git push"
+
+# ── plain block behavior ────────────────────────────────────────────────────
+echo ""
+echo "baseline blocks (writes on main are denied):"
+
+assert_deny \
+  "plain git commit on main is denied" \
+  "git commit -m foo"
+
+assert_deny \
+  "plain git push on main (no refspec) is denied" \
+  "git push"
+
+assert_deny \
+  "plain git add on main is denied" \
+  "git add file.txt"
+
+# ── refspec-push allow (already-existing behavior, guarded against regression)
+echo ""
+echo "explicit-refspec push (the recommended way to move local main onto a remote feature branch):"
+
+assert_allow \
+  "git push origin main:fix/foo is allowed" \
+  "git push origin main:fix/foo"
+
+assert_allow \
+  "git push origin HEAD:feature/bar is allowed" \
+  "git push origin HEAD:feature/bar"
+
+# ── human-operator env-var escape hatch ─────────────────────────────────────
+# When the variable is exported in the *process environment* (not inline on
+# the command), the hook short-circuits at the top. This is the legitimate
+# main-branch-dev / dotfiles workflow.
+echo ""
+echo "process-environment escape hatch (human-operator opt-in must still work):"
+
+assert_allow \
+  "git commit allowed when CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 is in the env" \
+  "git commit -m foo" \
+  "CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1"
+
+assert_allow \
+  "git push allowed when CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 is in the env" \
+  "git push" \
+  "CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1"
+
+# ── read-only operations remain silently allowed ────────────────────────────
+echo ""
+echo "read-only git operations remain allowed:"
+
+assert_allow \
+  "git status on main is allowed" \
+  "git status"
+
+assert_allow \
+  "git log on main is allowed" \
+  "git log --oneline"
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

Closes a security regression in the `branch-protection.sh` hook where agents could bypass write protections on `main`/`master` by prefixing commands with `CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1`. The hook now only honors this variable when set in the process environment (human-operator escape hatch), not when injected inline on the command line.

## Key Changes

- **branch-protection.sh**: Modified the git command detection regex to match commands with leading `VAR=value` assignments, ensuring inline bypass attempts are still caught and blocked by the hook's protections
- **branch-protection.sh**: Updated all deny messages to remove suggestions for agents to self-serve the bypass via inline prefix; now directs users to delegate to the human operator per `.claude/rules/handling-blocked-hooks.md`
- **handling-blocked-hooks.md**: Added new "Branch Protection: Do Not Self-Serve the Bypass" section documenting the correct escalation path (feature branch → explicit-refspec push → delegate to user)
- **README.md**: Clarified that the toggle is a human-operator opt-in via shell export, not an inline command prefix
- **test-branch-protection.sh**: Added comprehensive regression test suite covering:
  - Inline bypass attempts are denied
  - Plain write operations on main are denied
  - Explicit-refspec pushes are allowed
  - Process-environment variable still works as escape hatch
  - Read-only operations remain allowed

## Implementation Details

The key fix changes the git command detection from:
```bash
echo "$COMMAND" | grep -Eq '^\s*git\s+'
```

To:
```bash
echo "$COMMAND" | grep -Eq '^\s*([A-Za-z_][A-Za-z0-9_]*=\S*[[:space:]]+)*git[[:space:]]+'
```

This allows the regex to match (and therefore block) commands like `CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 git commit ...` instead of treating them as non-git commands that slip past the filter. The early environment-variable check at the top of the script still allows legitimate human-operator usage.

https://claude.ai/code/session_016MAufgHTYanm9CY4WxupN4