### PR TITLE
feat: non-interactive mode for scheduled execution

### DIFF
--- a/git-repo-agent/README.md
+++ b/git-repo-agent/README.md
@@ -78,6 +78,78 @@ git-repo-agent diagnose /path/to/repo --sources argocd --app my-app --namespace 
 
 kubectl and argocd operations are **strictly read-only** — safety hooks block any mutating commands.
 
+### Scheduled / Non-Interactive Runs
+
+`onboard`, `maintain`, and `diagnose` all support a non-interactive mode
+designed for Claude Code desktop scheduled jobs, cron, and GitHub Actions.
+See `docs/adr/005-non-interactive-scheduled-execution.md` for the full
+contract.
+
+```bash
+# Daily maintenance with auto-PR, exits 3 if an earlier scheduled run is still
+# holding the lock, exit 2 on config error, exit 4 if a safety hook blocks an op.
+git-repo-agent maintain /repo \
+  --fix --non-interactive \
+  --auto-pr=on-changes --on-duplicate=skip \
+  --refresh-base --log-format=json
+
+# Report-only: creates de-duplicated GitHub issues, never commits.
+git-repo-agent maintain /repo \
+  --report-only --non-interactive \
+  --auto-issues=on-findings --log-format=json
+```
+
+**Key flags**
+
+| Flag | Values | Use |
+|------|--------|-----|
+| `--non-interactive` | — | Required when stdin is not a TTY |
+| `--auto-pr` | `always`, `never`, `on-changes` | Policy for PR creation |
+| `--auto-issues` | `always`, `never`, `on-findings` | Policy for issue creation |
+| `--on-duplicate` | `skip`, `append`, `new` | Behaviour if an open PR already exists for this workflow |
+| `--refresh-base` | flag | `git fetch` + ff the base before starting |
+| `--log-format` | `text`, `json`, `plain` | Output style (auto-selects `plain` when piped) |
+| `--max-cost-usd` | float | Warn if session cost exceeds this |
+
+**Exit codes**
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Unexpected runtime error |
+| 2 | Config error (missing flag, bad value, missing `gh` auth, non-TTY without `--non-interactive`) |
+| 3 | Locked — another run holds the advisory lock |
+| 4 | Blocked by a safety hook |
+
+**GitHub Actions snippet**
+
+```yaml
+name: Scheduled maintenance
+on:
+  schedule:
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+jobs:
+  maintain:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - run: uv tool install git+https://github.com/laurigates/claude-plugins#subdirectory=git-repo-agent
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          git-repo-agent maintain . \
+            --fix --non-interactive \
+            --auto-pr=on-changes --on-duplicate=skip \
+            --refresh-base --log-format=json
+```
+
+The two-phase interactive `maintain` (no `--fix`, no `--report-only`)
+requires a human and cannot be run non-interactively — the CLI exits
+with code 2 in that case.
+
 ### Quick Health Check
 
 Runs locally without LLM calls — direct Python scoring.
@@ -208,5 +280,5 @@ uv run --directory git-repo-agent git-repo-agent diagnose . --dry-run
 | Phase 1 | Done    | CLI, orchestrator, repo_analyze, blueprint subagent, onboard command                      |
 | Phase 2 | Done    | Configure/docs subagents, health_score, safety hooks, maintain command, skill compilation |
 | Phase 3 | Done    | Quality/security/test-runner subagents, report_generate, health command                   |
-| Phase 4 | Planned | Watch mode, trend tracking, GitHub Action template                                        |
+| Phase 4 | In progress | Non-interactive / scheduled execution (ADR-005); watch mode and trend tracking planned |
 | Phase 5 | Done    | Pipeline diagnostics (kubectl, ArgoCD, GitHub Actions, Sentry, Chrome DevTools)           |

--- a/git-repo-agent/docs/adr/005-non-interactive-scheduled-execution.md
+++ b/git-repo-agent/docs/adr/005-non-interactive-scheduled-execution.md
@@ -1,0 +1,131 @@
+# ADR-005: Non-Interactive / Scheduled Execution
+
+## Status
+
+Accepted (2026-04-14)
+
+## Context
+
+`git-repo-agent` was built for an interactive CLI: three places call
+`rich.console.input()` to ask the user about fix selection, PR creation,
+and issue creation. When the agent is invoked from a scheduled job —
+Claude Code desktop schedules, cron, GitHub Actions, etc. — stdin is
+not a TTY. The previous behaviour was to return an empty string and
+silently skip the prompt, so the scheduled run produced committed work
+in a worktree that nobody ever saw.
+
+We want a single, predictable non-interactive mode where the caller
+declares up front what the agent should do with every decision point,
+so scheduled runs are useful and safe.
+
+## Decision
+
+Add a `--non-interactive` flag plus a small policy vocabulary that
+every scheduled caller must supply. When the flag is set (or when
+stdin is not a TTY), the orchestrator skips every `console.input()`
+call and dispatches to the declared policy instead.
+
+### Flags (added to `onboard`, `maintain`, `diagnose`)
+
+| Flag | Values | Default | Purpose |
+|---|---|---|---|
+| `--non-interactive` | bool | false | Required if stdin is not a TTY |
+| `--auto-pr` | `always \| never \| on-changes` | `on-changes` | PR creation policy |
+| `--auto-issues` | `always \| never \| on-findings` | `on-findings` | Issue creation policy |
+| `--on-duplicate` | `skip \| append \| new` | `skip` | What to do if an open PR with the same workflow prefix exists |
+| `--refresh-base` | bool | false | `git fetch` + fast-forward the base before starting |
+| `--max-cost-usd` | float | — | Warn if the SDK session cost exceeds this |
+| `--log-format` | `text \| json \| plain` | `plain` when stdout ≠ TTY, else `text` | Output format |
+| `--notify` | `none \| pr-comment \| issue` | `none` | Reserved for future scheduler notifications |
+
+### TTY gating
+
+If stdin is not a TTY and `--non-interactive` is not passed, the CLI
+exits with code 2 and a message that tells the caller which flags to
+add. This prevents the silent-skip failure mode.
+
+### `maintain` is `--fix` or `--report-only` only
+
+The default interactive `maintain` uses a two-phase flow where Python
+prompts the user between agent phases (see ADR-003). That cannot be
+automated. Non-interactive `maintain` must pick a side: `--fix`
+applies auto-fixable findings and opens a PR; `--report-only`
+generates a report and opens GitHub issues.
+
+### `AskUserQuestion` is dropped from `allowed_tools`
+
+Per ADR-003 `AskUserQuestion` silently no-ops in SDK subprocess mode.
+In non-interactive runs we strip it from `allowed_tools` across
+`onboard`, `maintain`, and `diagnose` so subagents don't stall waiting
+for a prompt that will never appear.
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Success |
+| 1 | Unexpected runtime error |
+| 2 | Usage / config error (missing flag, bad value, missing `gh` auth, non-TTY without `--non-interactive`) |
+| 3 | Locked — another run holds the advisory lock |
+| 4 | Blocked by a safety hook |
+
+### Advisory lock
+
+A PID-tagged lock file is written to
+`./.claude/worktrees/.git-repo-agent.lock` at the start of a
+non-interactive run and released in `finally`. A stale lock (holder
+PID gone) is reclaimed automatically. Concurrent scheduled runs
+against the same repo therefore exit 3 instead of colliding.
+
+### Timestamped maintain branches
+
+Non-interactive `maintain` uses `maintain/YYYY-MM-DDTHH-MM` (UTC) so
+sub-daily schedules don't collide. Before pushing, `gh pr list` is
+queried for open PRs whose head branch starts with `maintain/`; if one
+exists and `--on-duplicate=skip`, the run exits cleanly without
+creating a duplicate PR.
+
+### Issue deduplication
+
+Report-only findings are matched against open issues by exact title
+before `gh issue create` is called. Repeat scheduled runs therefore
+don't fan out into duplicate issues.
+
+### SIGTERM cleanup
+
+A `SIGTERM`/`SIGINT` handler is installed for the lifetime of the
+agent session. If a scheduler kills the job mid-run, the worktree is
+removed and the lock is released before the handler re-raises the
+signal.
+
+### Structured summary line
+
+Every non-interactive run ends with a single-line summary. When
+`--log-format=json` the line is JSON (`{"status": "success", "pr":
+"...", "branch": "...", ...}`); otherwise it is a human-readable
+`key=value` line. Schedulers can scrape one or the other without
+parsing the whole run.
+
+## Consequences
+
+- Scheduled jobs become first-class: the agent refuses to run silently
+  broken, and the summary line gives schedulers something to alert on.
+- The interactive UX is unchanged — every change is gated on
+  `non_interactive is not None`.
+- Safety hooks still apply; they surface as exit code 4.
+- `diagnose --sources kubectl,argocd` still needs those CLIs; in the
+  Claude Code remote sandbox network allowlist they will gracefully
+  skip (the collector already handles missing CLIs).
+
+## Alternatives considered
+
+1. **Auto-detect non-TTY and silently switch modes.** Rejected:
+   scheduled jobs that get surprised by default policies fail in
+   non-obvious ways. Making the caller declare the policy up front is
+   worth the extra flag.
+2. **Emit results as comments on an existing issue.** Considered —
+   left as the `--notify` hook for a follow-up.
+3. **Use Claude Code's `Agent(background=true)` instead of the CLI
+   orchestrator.** Doesn't fit: the orchestrator owns the worktree
+   lifecycle, and the SDK's `ClaudeAgentOptions` does not expose
+   background execution (same constraint that drove ADR-004).

--- a/git-repo-agent/src/git_repo_agent/main.py
+++ b/git-repo-agent/src/git_repo_agent/main.py
@@ -1,17 +1,98 @@
 """CLI entry point for git-repo-agent."""
 
 import asyncio
+import sys
 from pathlib import Path
 from typing import Optional
 
 import typer
 from rich.console import Console
 
+from .non_interactive import (
+    EXIT_CONFIG_ERROR,
+    EXIT_HOOK_BLOCKED,
+    EXIT_LOCKED,
+    EXIT_RUNTIME_ERROR,
+    EXIT_SUCCESS,
+    HookBlockedError,
+    LockedError,
+    NonInteractiveConfig,
+    NonInteractiveUsageError,
+)
+
 app = typer.Typer(
     name="git-repo-agent",
     help="Claude Agent SDK app for repo onboarding and maintenance.",
 )
 console = Console()
+
+
+def _build_ni_config(
+    *,
+    non_interactive: bool,
+    auto_pr: str,
+    auto_issues: str,
+    on_duplicate: str,
+    refresh_base: bool,
+    max_cost_usd: Optional[float],
+    log_format: Optional[str],
+    notify: str,
+) -> Optional[NonInteractiveConfig]:
+    """Validate non-interactive flags and return a config, or None if interactive."""
+    stdin_tty = sys.stdin.isatty()
+    stdout_tty = sys.stdout.isatty()
+
+    # Refuse silent breakage: if stdin isn't a TTY and the caller didn't opt in,
+    # exit loudly rather than letting console.input() eat an empty string.
+    if not stdin_tty and not non_interactive:
+        console.print(
+            "[red]Error:[/red] stdin is not a TTY. "
+            "Pass [bold]--non-interactive[/bold] to enable scheduled / headless "
+            "execution and declare how PR / issue decisions should be made "
+            "(e.g. --auto-pr=on-changes, --auto-issues=on-findings).",
+        )
+        raise typer.Exit(code=EXIT_CONFIG_ERROR)
+
+    if not non_interactive:
+        return None
+
+    # Default log format: plain when stdout isn't a TTY.
+    effective_log_format = log_format or ("text" if stdout_tty else "plain")
+
+    try:
+        return NonInteractiveConfig.build(
+            auto_pr=auto_pr,
+            auto_issues=auto_issues,
+            on_duplicate=on_duplicate,
+            refresh_base=refresh_base,
+            max_cost_usd=max_cost_usd,
+            log_format=effective_log_format,
+            notify=notify,
+        )
+    except NonInteractiveUsageError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(code=EXIT_CONFIG_ERROR)
+
+
+def _dispatch(coro) -> None:
+    """Run an async orchestrator coroutine and map exceptions to exit codes."""
+    try:
+        asyncio.run(coro)
+    except LockedError as exc:
+        console.print(f"[yellow]{exc}[/yellow]")
+        raise typer.Exit(code=EXIT_LOCKED)
+    except HookBlockedError as exc:
+        console.print(f"[red]Blocked by safety hook:[/red] {exc}", style="bold")
+        raise typer.Exit(code=EXIT_HOOK_BLOCKED)
+    except NonInteractiveUsageError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(code=EXIT_CONFIG_ERROR)
+    except typer.Exit:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive
+        console.print(f"[red]Unexpected error:[/red] {exc}")
+        raise typer.Exit(code=EXIT_RUNTIME_ERROR)
+    raise typer.Exit(code=EXIT_SUCCESS)
 
 
 @app.command()
@@ -40,22 +121,62 @@ def onboard(
         "--branch",
         help="Branch name for onboarding changes.",
     ),
+    non_interactive: bool = typer.Option(
+        False, "--non-interactive",
+        help="Run without prompting (required when stdin is not a TTY).",
+    ),
+    auto_pr: str = typer.Option(
+        "on-changes", "--auto-pr",
+        help="Non-interactive PR policy: always, never, on-changes.",
+    ),
+    auto_issues: str = typer.Option(
+        "never", "--auto-issues",
+        help="Non-interactive issue policy (unused by onboard): always, never, on-findings.",
+    ),
+    on_duplicate: str = typer.Option(
+        "skip", "--on-duplicate",
+        help="Policy if an open PR on the same branch prefix exists: skip, append, new.",
+    ),
+    refresh_base: bool = typer.Option(
+        False, "--refresh-base/--no-refresh-base",
+        help="git fetch + fast-forward the base branch before starting.",
+    ),
+    max_cost_usd: Optional[float] = typer.Option(
+        None, "--max-cost-usd",
+        help="Warn if session cost exceeds this amount.",
+    ),
+    log_format: Optional[str] = typer.Option(
+        None, "--log-format",
+        help="Output format: text, json, plain. Default: plain when not a TTY.",
+    ),
 ) -> None:
     """Onboard a repository with blueprint structure and standards."""
     repo_path = Path(repo).resolve()
     if not repo_path.is_dir():
         console.print(f"[red]Error:[/red] {repo_path} is not a directory")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=EXIT_CONFIG_ERROR)
+
+    ni = _build_ni_config(
+        non_interactive=non_interactive,
+        auto_pr=auto_pr,
+        auto_issues=auto_issues,
+        on_duplicate=on_duplicate,
+        refresh_base=refresh_base,
+        max_cost_usd=max_cost_usd,
+        log_format=log_format,
+        notify="none",
+    )
 
     from .orchestrator import run_onboard
 
-    asyncio.run(
+    _dispatch(
         run_onboard(
             repo_path=repo_path,
             dry_run=dry_run,
             skip_ci=skip_ci,
             skip_blueprint=skip_blueprint,
             branch=branch,
+            non_interactive=ni,
         )
     )
 
@@ -81,21 +202,70 @@ def maintain(
         "--focus",
         help="Comma-separated areas to focus on (docs,tests,security).",
     ),
+    non_interactive: bool = typer.Option(
+        False, "--non-interactive",
+        help="Run without prompting (required when stdin is not a TTY).",
+    ),
+    auto_pr: str = typer.Option(
+        "on-changes", "--auto-pr",
+        help="Non-interactive PR policy: always, never, on-changes.",
+    ),
+    auto_issues: str = typer.Option(
+        "on-findings", "--auto-issues",
+        help="Non-interactive issue policy (report-only): always, never, on-findings.",
+    ),
+    on_duplicate: str = typer.Option(
+        "skip", "--on-duplicate",
+        help="Policy if an open PR exists for the same workflow: skip, append, new.",
+    ),
+    refresh_base: bool = typer.Option(
+        False, "--refresh-base/--no-refresh-base",
+        help="git fetch + fast-forward the base branch before starting.",
+    ),
+    max_cost_usd: Optional[float] = typer.Option(
+        None, "--max-cost-usd",
+        help="Warn if session cost exceeds this amount.",
+    ),
+    log_format: Optional[str] = typer.Option(
+        None, "--log-format",
+        help="Output format: text, json, plain. Default: plain when not a TTY.",
+    ),
 ) -> None:
     """Run maintenance checks and optionally fix issues."""
     repo_path = Path(repo).resolve()
     if not repo_path.is_dir():
         console.print(f"[red]Error:[/red] {repo_path} is not a directory")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=EXIT_CONFIG_ERROR)
+
+    ni = _build_ni_config(
+        non_interactive=non_interactive,
+        auto_pr=auto_pr,
+        auto_issues=auto_issues,
+        on_duplicate=on_duplicate,
+        refresh_base=refresh_base,
+        max_cost_usd=max_cost_usd,
+        log_format=log_format,
+        notify="none",
+    )
+
+    # The two-phase interactive maintain flow cannot run without a human.
+    if ni is not None and not (fix or report_only):
+        console.print(
+            "[red]Error:[/red] non-interactive `maintain` requires either "
+            "[bold]--fix[/bold] or [bold]--report-only[/bold]. The default "
+            "interactive flow needs a human to select fixes."
+        )
+        raise typer.Exit(code=EXIT_CONFIG_ERROR)
 
     from .orchestrator import run_maintain
 
-    asyncio.run(
+    _dispatch(
         run_maintain(
             repo_path=repo_path,
             fix=fix,
             report_only=report_only,
             focus=focus,
+            non_interactive=ni,
         )
     )
 
@@ -131,16 +301,43 @@ def diagnose(
         "--app",
         help="ArgoCD application name.",
     ),
+    non_interactive: bool = typer.Option(
+        False, "--non-interactive",
+        help="Run without prompting (required when stdin is not a TTY).",
+    ),
+    auto_issues: str = typer.Option(
+        "on-findings", "--auto-issues",
+        help="Non-interactive issue policy: always, never, on-findings.",
+    ),
+    max_cost_usd: Optional[float] = typer.Option(
+        None, "--max-cost-usd",
+        help="Warn if session cost exceeds this amount.",
+    ),
+    log_format: Optional[str] = typer.Option(
+        None, "--log-format",
+        help="Output format: text, json, plain. Default: plain when not a TTY.",
+    ),
 ) -> None:
     """Diagnose pipeline failures and optionally create a GitHub issue."""
     repo_path = Path(repo).resolve()
     if not repo_path.is_dir():
         console.print(f"[red]Error:[/red] {repo_path} is not a directory")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=EXIT_CONFIG_ERROR)
+
+    ni = _build_ni_config(
+        non_interactive=non_interactive,
+        auto_pr="never",
+        auto_issues=auto_issues,
+        on_duplicate="skip",
+        refresh_base=False,
+        max_cost_usd=max_cost_usd,
+        log_format=log_format,
+        notify="none",
+    )
 
     from .orchestrator import run_diagnose
 
-    asyncio.run(
+    _dispatch(
         run_diagnose(
             repo_path=repo_path,
             sources=sources,
@@ -148,6 +345,7 @@ def diagnose(
             dry_run=dry_run,
             namespace=namespace,
             app_name=app_name,
+            non_interactive=ni,
         )
     )
 
@@ -163,7 +361,7 @@ def health(
     repo_path = Path(repo).resolve()
     if not repo_path.is_dir():
         console.print(f"[red]Error:[/red] {repo_path} is not a directory")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=EXIT_CONFIG_ERROR)
 
     from .orchestrator import run_health
 
@@ -191,7 +389,7 @@ def attributes(
     repo_path = Path(repo).resolve()
     if not repo_path.is_dir():
         console.print(f"[red]Error:[/red] {repo_path} is not a directory")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=EXIT_CONFIG_ERROR)
 
     from .tools.attributes import (
         collect_attributes,
@@ -245,7 +443,7 @@ def route(
     repo_path = Path(repo).resolve()
     if not repo_path.is_dir():
         console.print(f"[red]Error:[/red] {repo_path} is not a directory")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=EXIT_CONFIG_ERROR)
 
     from .tools.attributes import (
         collect_attributes,

--- a/git-repo-agent/src/git_repo_agent/non_interactive.py
+++ b/git-repo-agent/src/git_repo_agent/non_interactive.py
@@ -1,0 +1,94 @@
+"""Non-interactive run configuration and exit-code contract.
+
+See ``docs/adr/005-non-interactive-scheduled-execution.md`` for the full
+contract. The key idea is that a caller running git-repo-agent from a
+scheduled job (Claude Code desktop schedules, cron, GitHub Actions, …)
+declares up front what the agent should do with every decision point —
+we never silently skip a prompt.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+# Exit codes. See ADR-005.
+EXIT_SUCCESS = 0
+EXIT_RUNTIME_ERROR = 1
+EXIT_CONFIG_ERROR = 2
+EXIT_LOCKED = 3
+EXIT_HOOK_BLOCKED = 4
+
+
+class NonInteractiveUsageError(ValueError):
+    """Raised when non-interactive flags are inconsistent or unsupported."""
+
+
+class LockedError(RuntimeError):
+    """Raised when another git-repo-agent run holds the repo lock."""
+
+
+class HookBlockedError(RuntimeError):
+    """Raised when a safety hook blocked a critical operation."""
+
+
+AutoPr = Literal["always", "never", "on-changes"]
+AutoIssues = Literal["always", "never", "on-findings"]
+OnDuplicate = Literal["skip", "append", "new"]
+LogFormat = Literal["text", "json", "plain"]
+Notify = Literal["none", "pr-comment", "issue"]
+
+_AUTO_PR_VALUES = {"always", "never", "on-changes"}
+_AUTO_ISSUES_VALUES = {"always", "never", "on-findings"}
+_ON_DUP_VALUES = {"skip", "append", "new"}
+_LOG_FMT_VALUES = {"text", "json", "plain"}
+_NOTIFY_VALUES = {"none", "pr-comment", "issue"}
+
+
+@dataclass(frozen=True)
+class NonInteractiveConfig:
+    """Validated policy for a non-interactive run."""
+
+    auto_pr: AutoPr
+    auto_issues: AutoIssues
+    on_duplicate: OnDuplicate
+    refresh_base: bool
+    max_cost_usd: float | None
+    log_format: LogFormat
+    notify: Notify
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        auto_pr: str,
+        auto_issues: str,
+        on_duplicate: str,
+        refresh_base: bool,
+        max_cost_usd: float | None,
+        log_format: str,
+        notify: str,
+    ) -> "NonInteractiveConfig":
+        _check(auto_pr, _AUTO_PR_VALUES, "--auto-pr")
+        _check(auto_issues, _AUTO_ISSUES_VALUES, "--auto-issues")
+        _check(on_duplicate, _ON_DUP_VALUES, "--on-duplicate")
+        _check(log_format, _LOG_FMT_VALUES, "--log-format")
+        _check(notify, _NOTIFY_VALUES, "--notify")
+        if max_cost_usd is not None and max_cost_usd <= 0:
+            raise NonInteractiveUsageError("--max-cost-usd must be positive")
+        return cls(
+            auto_pr=auto_pr,  # type: ignore[arg-type]
+            auto_issues=auto_issues,  # type: ignore[arg-type]
+            on_duplicate=on_duplicate,  # type: ignore[arg-type]
+            refresh_base=refresh_base,
+            max_cost_usd=max_cost_usd,
+            log_format=log_format,  # type: ignore[arg-type]
+            notify=notify,  # type: ignore[arg-type]
+        )
+
+
+def _check(value: str, allowed: set[str], flag: str) -> None:
+    if value not in allowed:
+        raise NonInteractiveUsageError(
+            f"{flag} must be one of {sorted(allowed)}, got {value!r}"
+        )

--- a/git-repo-agent/src/git_repo_agent/orchestrator.py
+++ b/git-repo-agent/src/git_repo_agent/orchestrator.py
@@ -2,7 +2,9 @@
 
 import json
 import logging
-from datetime import date
+import signal
+import sys
+from datetime import date, datetime, timezone
 from pathlib import Path
 
 from claude_agent_sdk import (
@@ -72,6 +74,10 @@ async def _quiet_read_messages_impl(self):  # type: ignore[no-untyped-def]
 _sdk_subprocess.SubprocessCLITransport._read_messages_impl = _quiet_read_messages_impl
 
 from .agents.blueprint import definition as blueprint_definition
+from .non_interactive import (
+    LockedError,
+    NonInteractiveConfig,
+)
 from .agents.configure import definition as configure_definition
 from .agents.diagnose import definition as diagnose_definition
 from .agents.docs import definition as docs_definition
@@ -88,12 +94,19 @@ from .tools.pipeline_collector import collect_pipeline_diagnostics
 from .tools.repo_analyzer import analyze_repo
 from .tools.report import generate_report
 from .worktree import (
+    acquire_lock,
     cleanup_worktree,
     create_github_issues,
     create_worktree,
+    find_existing_issue,
+    find_existing_pr,
     get_base_branch,
+    gh_auth_ok,
     parse_report_only_findings,
     push_and_create_pr,
+    refresh_base as refresh_base_branch,
+    release_lock,
+    timestamped_branch,
     worktree_has_changes,
 )
 
@@ -135,12 +148,194 @@ def _pre_compute_context(repo_path: Path) -> str:
     )
 
 
+def _summary_line(
+    payload: dict,
+    log_format: str | None,
+) -> None:
+    """Emit a final machine-scrapeable summary line.
+
+    JSON is printed unconditionally when log_format=='json'. For other
+    formats a one-line key=value summary is printed so a scheduler can
+    still grep for it.
+    """
+    if log_format == "json":
+        sys.stdout.write(json.dumps(payload, default=str) + "\n")
+        sys.stdout.flush()
+        return
+    parts = [f"{k}={v}" for k, v in payload.items() if v not in (None, "", [])]
+    console.print("[bold]git-repo-agent result[/bold] " + " ".join(parts))
+
+
+def _install_cleanup_handler(cleanup):
+    """Install SIGTERM/SIGINT handlers that invoke ``cleanup`` then re-exit.
+
+    Returns a token that the caller should pass to ``_restore_handlers``
+    to revert. We don't use contextlib because the orchestrator needs the
+    handler to survive until after the final PR/issue work.
+    """
+    prev_term = signal.getsignal(signal.SIGTERM)
+    prev_int = signal.getsignal(signal.SIGINT)
+
+    def _handler(signum, _frame):
+        try:
+            cleanup()
+        finally:
+            signal.signal(signum, signal.SIG_DFL)
+            # Re-raise with the default handler (propagates exit code).
+            import os
+            os.kill(os.getpid(), signum)
+
+    signal.signal(signal.SIGTERM, _handler)
+    signal.signal(signal.SIGINT, _handler)
+    return (prev_term, prev_int)
+
+
+def _restore_handlers(token) -> None:
+    prev_term, prev_int = token
+    signal.signal(signal.SIGTERM, prev_term)
+    signal.signal(signal.SIGINT, prev_int)
+
+
+def _non_interactive_allowed_tools(base: list[str]) -> list[str]:
+    """Remove AskUserQuestion — it no-ops in SDK subprocess mode (ADR-003)."""
+    return [t for t in base if t != "AskUserQuestion"]
+
+
+def _prepare_non_interactive(
+    repo_path: Path,
+    ni: NonInteractiveConfig,
+    base_branch: str,
+) -> Path:
+    """Validate auth, acquire the repo lock, optionally refresh the base.
+
+    Returns the lock path to release later. Caller must handle
+    ``LockedError`` and ``NonInteractiveUsageError``.
+    """
+    from .non_interactive import NonInteractiveUsageError
+
+    needs_gh = ni.auto_pr != "never" or ni.auto_issues != "never"
+    if needs_gh and not gh_auth_ok(repo_path):
+        raise NonInteractiveUsageError(
+            "gh CLI is not authenticated but --auto-pr / --auto-issues need it. "
+            "Run `gh auth login` or set GH_TOKEN, or pass "
+            "--auto-pr=never / --auto-issues=never."
+        )
+
+    lock_path = acquire_lock(repo_path)
+    if lock_path is None:
+        raise LockedError(
+            f"Another git-repo-agent run holds the lock at "
+            f"{repo_path / '.claude' / 'worktrees' / '.git-repo-agent.lock'}"
+        )
+
+    if ni.refresh_base:
+        if refresh_base_branch(repo_path, base_branch):
+            console.print(f"[dim]Refreshed base branch {base_branch}[/dim]")
+        else:
+            console.print(
+                f"[yellow]Warning:[/yellow] could not refresh base {base_branch}; "
+                "continuing on local HEAD."
+            )
+
+    return lock_path
+
+
+async def _auto_handle_pr(
+    repo_path: Path,
+    worktree_path: Path,
+    branch: str,
+    base_branch: str,
+    workflow: str,
+    agent_output: str,
+    ni: NonInteractiveConfig,
+) -> dict:
+    """Non-interactive PR handling. Returns a dict for the summary line."""
+    result: dict = {"branch": branch, "pr": None, "pr_action": "none"}
+
+    if not worktree_has_changes(worktree_path, base_branch):
+        result["pr_action"] = "no-changes"
+        cleanup_worktree(repo_path, worktree_path)
+        return result
+
+    if ni.auto_pr == "never":
+        result["pr_action"] = "skipped-by-policy"
+        console.print(
+            f"[dim]Changes committed on {branch}; --auto-pr=never so no PR created.[/dim]"
+        )
+        return result
+
+    # Duplicate detection: same workflow prefix, same base.
+    existing = find_existing_pr(repo_path, workflow, base_branch)
+    if existing:
+        if ni.on_duplicate == "skip":
+            result["pr_action"] = "duplicate-skip"
+            result["pr"] = existing
+            console.print(
+                f"[yellow]Open PR already exists for workflow '{workflow}': "
+                f"{existing}. Skipping.[/yellow]"
+            )
+            cleanup_worktree(repo_path, worktree_path)
+            return result
+        # "append" / "new" both fall through to creating a new PR on the
+        # timestamped branch; "append" semantics are left for a future pass.
+
+    pr_title, pr_body = _build_pr_content(workflow, agent_output)
+    console.print(f"[dim]Pushing {branch} and creating PR...[/dim]")
+    pr_url = push_and_create_pr(worktree_path, branch, base_branch, pr_title, pr_body)
+    if pr_url:
+        result["pr"] = pr_url
+        result["pr_action"] = "created"
+        console.print(f"[bold green]PR created:[/bold green] {pr_url}")
+        cleanup_worktree(repo_path, worktree_path)
+    else:
+        result["pr_action"] = "push-failed"
+        console.print(
+            f"[red]Failed to push / create PR. Worktree preserved at {worktree_path}[/red]"
+        )
+    return result
+
+
+async def _auto_handle_issues(
+    repo_path: Path,
+    agent_output: str,
+    ni: NonInteractiveConfig,
+) -> dict:
+    """Non-interactive issue handling for report-only runs."""
+    result: dict = {"issues_created": [], "issues_skipped_duplicate": 0}
+
+    if ni.auto_issues == "never":
+        return result
+
+    findings = parse_report_only_findings(agent_output)
+    if not findings and ni.auto_issues == "on-findings":
+        return result
+
+    # Dedupe by exact title.
+    to_create = []
+    for f in findings:
+        if find_existing_issue(repo_path, f["title"]):
+            result["issues_skipped_duplicate"] += 1
+        else:
+            to_create.append(f)
+
+    if not to_create:
+        return result
+
+    console.print(f"[dim]Creating {len(to_create)} GitHub issue(s)...[/dim]")
+    urls = create_github_issues(repo_path, to_create)
+    for url in urls:
+        console.print(f"  [green]Created:[/green] {url}")
+    result["issues_created"] = urls
+    return result
+
+
 async def run_onboard(
     repo_path: Path,
     dry_run: bool = False,
     skip_ci: bool = False,
     skip_blueprint: bool = False,
     branch: str = "setup/onboard",
+    non_interactive: NonInteractiveConfig | None = None,
 ) -> None:
     """Run the onboarding workflow for a repository."""
     console.print(f"[bold]Git Repo Agent[/bold] — Onboarding [cyan]{repo_path}[/cyan]")
@@ -152,8 +347,12 @@ async def run_onboard(
     console.print("[dim]Analyzing repository...[/dim]")
     repo_context = _pre_compute_context(repo_path)
 
-    # Create worktree for isolated work (see ADR-004)
     base_branch = get_base_branch(repo_path)
+    lock_path: Path | None = None
+    if non_interactive is not None:
+        lock_path = _prepare_non_interactive(repo_path, non_interactive, base_branch)
+
+    # Create worktree for isolated work (see ADR-004)
     worktree_path = None
     work_dir = repo_path
 
@@ -163,74 +362,107 @@ async def run_onboard(
         work_dir = worktree_path
         console.print(f"[dim]Working in: {worktree_path}[/dim]")
 
-    # Build system prompt with embedded analysis
-    system_prompt = (
-        _load_prompt("orchestrator")
-        + "\n\n"
-        + _load_prompt("onboard")
-        + "\n\n"
-        + repo_context
-    )
-
-    # Build orchestrator options
-    options = ClaudeAgentOptions(
-        system_prompt=system_prompt,
-        cwd=str(work_dir),
-        max_turns=50,
-        allowed_tools=[
-            "Read",
-            "Write",
-            "Edit",
-            "Bash",
-            "Glob",
-            "Grep",
-            "Task",
-            "AskUserQuestion",
-            "TodoWrite",
-        ],
-        permission_mode="acceptEdits",
-        agents={
-            "blueprint": blueprint_definition,
-            "configure": configure_definition,
-            "docs": docs_definition,
-            "quality": quality_definition,
-            "security": security_definition,
-            "test_runner": test_runner_definition,
-        },
-        env={
-            "CLAUDECODE": "",
-            "DRY_RUN": str(dry_run),
-            "SKIP_CI": str(skip_ci),
-            "SKIP_BLUEPRINT": str(skip_blueprint),
-            "ONBOARD_BRANCH": branch,
-        },
-        stderr=lambda line: console.print(f"[dim red]STDERR: {line}[/dim red]"),
-    )
-
-    # Build the prompt — agent should commit but NOT create branches (worktree handles that)
-    prompt_parts = [
-        f"Onboard the repository at {work_dir}.",
-        "Repository analysis and health score are in your system prompt. Plan and execute the onboarding workflow.",
-        f"You are working in a git worktree on branch '{branch}'.",
-        "Commit your changes directly to this branch. Do NOT create new branches.",
-    ]
-    if dry_run:
-        prompt_parts.append("DRY RUN — report what you would do without making changes.")
-    if skip_ci:
-        prompt_parts.append("Skip CI/CD setup.")
-    if skip_blueprint:
-        prompt_parts.append("Skip blueprint initialization.")
-
-    prompt = " ".join(prompt_parts)
-
-    # Stream and display messages
-    await _stream_messages(prompt, options, "Onboarding complete.")
-
-    # Post-workflow: offer to create PR if worktree has changes
-    if worktree_path and not dry_run:
-        await _prompt_pr_creation(
-            repo_path, worktree_path, branch, base_branch, "onboard"
+    cleanup_token = None
+    if non_interactive is not None and worktree_path is not None:
+        cleanup_token = _install_cleanup_handler(
+            lambda: (
+                cleanup_worktree(repo_path, worktree_path),
+                release_lock(lock_path),
+            )
         )
+
+    try:
+        # Build system prompt with embedded analysis
+        system_prompt = (
+            _load_prompt("orchestrator")
+            + "\n\n"
+            + _load_prompt("onboard")
+            + "\n\n"
+            + repo_context
+        )
+
+        allowed_tools = [
+            "Read", "Write", "Edit", "Bash", "Glob", "Grep", "Task",
+            "AskUserQuestion", "TodoWrite",
+        ]
+        if non_interactive is not None:
+            allowed_tools = _non_interactive_allowed_tools(allowed_tools)
+
+        # Build orchestrator options
+        options = ClaudeAgentOptions(
+            system_prompt=system_prompt,
+            cwd=str(work_dir),
+            max_turns=50,
+            allowed_tools=allowed_tools,
+            permission_mode="acceptEdits",
+            agents={
+                "blueprint": blueprint_definition,
+                "configure": configure_definition,
+                "docs": docs_definition,
+                "quality": quality_definition,
+                "security": security_definition,
+                "test_runner": test_runner_definition,
+            },
+            env={
+                "CLAUDECODE": "",
+                "DRY_RUN": str(dry_run),
+                "SKIP_CI": str(skip_ci),
+                "SKIP_BLUEPRINT": str(skip_blueprint),
+                "ONBOARD_BRANCH": branch,
+            },
+            stderr=lambda line: console.print(f"[dim red]STDERR: {line}[/dim red]"),
+        )
+
+        # Build the prompt — agent should commit but NOT create branches
+        prompt_parts = [
+            f"Onboard the repository at {work_dir}.",
+            "Repository analysis and health score are in your system prompt. Plan and execute the onboarding workflow.",
+            f"You are working in a git worktree on branch '{branch}'.",
+            "Commit your changes directly to this branch. Do NOT create new branches.",
+        ]
+        if dry_run:
+            prompt_parts.append("DRY RUN — report what you would do without making changes.")
+        if skip_ci:
+            prompt_parts.append("Skip CI/CD setup.")
+        if skip_blueprint:
+            prompt_parts.append("Skip blueprint initialization.")
+
+        prompt = " ".join(prompt_parts)
+
+        if non_interactive is not None:
+            agent_output = await _stream_messages_collecting(
+                prompt, options, "Onboarding complete.",
+            )
+        else:
+            await _stream_messages(prompt, options, "Onboarding complete.")
+            agent_output = ""
+
+        # Post-workflow: PR creation
+        summary: dict = {
+            "status": "success",
+            "workflow": "onboard",
+            "branch": branch,
+            "dry_run": dry_run,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        if worktree_path and not dry_run:
+            if non_interactive is not None:
+                pr_result = await _auto_handle_pr(
+                    repo_path, worktree_path, branch, base_branch,
+                    "setup/onboard", agent_output, non_interactive,
+                )
+                summary.update(pr_result)
+            else:
+                await _prompt_pr_creation(
+                    repo_path, worktree_path, branch, base_branch, "onboard",
+                )
+
+        if non_interactive is not None:
+            _summary_line(summary, non_interactive.log_format)
+    finally:
+        if cleanup_token is not None:
+            _restore_handlers(cleanup_token)
+        release_lock(lock_path)
 
 
 async def run_maintain(
@@ -238,6 +470,7 @@ async def run_maintain(
     fix: bool = False,
     report_only: bool = False,
     focus: str | None = None,
+    non_interactive: NonInteractiveConfig | None = None,
 ) -> None:
     """Run the maintenance workflow for a repository."""
     console.print(f"[bold]Git Repo Agent[/bold] — Maintaining [cyan]{repo_path}[/cyan]")
@@ -264,14 +497,23 @@ async def run_maintain(
 
     # Interactive mode does not use AskUserQuestion — the orchestrator
     # handles user prompting in Python between two agent phases. See ADR-003.
-    interactive = not fix and not report_only
+    interactive = not fix and not report_only and non_interactive is None
     makes_changes = not report_only
 
-    # Create worktree for isolated work when changes will be made (see ADR-004)
     base_branch = get_base_branch(repo_path)
+    lock_path: Path | None = None
+    if non_interactive is not None:
+        lock_path = _prepare_non_interactive(repo_path, non_interactive, base_branch)
+
+    # Create worktree for isolated work when changes will be made (see ADR-004).
+    # Non-interactive runs use a UTC-timestamped branch so repeated scheduled
+    # invocations on the same day don't collide.
     worktree_path = None
     work_dir = repo_path
-    branch = f"maintain/{date.today().isoformat()}"
+    if non_interactive is not None:
+        branch = timestamped_branch("maintain")
+    else:
+        branch = f"maintain/{date.today().isoformat()}"
 
     if makes_changes:
         console.print(f"[dim]Creating worktree on branch {branch}...[/dim]")
@@ -279,83 +521,107 @@ async def run_maintain(
         work_dir = worktree_path
         console.print(f"[dim]Working in: {worktree_path}[/dim]")
 
-    # Build orchestrator options
-    allowed_tools = [
-        "Read",
-        "Write",
-        "Edit",
-        "Bash",
-        "Glob",
-        "Grep",
-        "Task",
-        "TodoWrite",
-    ]
-    if not interactive:
-        allowed_tools.append("AskUserQuestion")
-
-    options = ClaudeAgentOptions(
-        system_prompt=system_prompt,
-        cwd=str(work_dir),
-        max_turns=50,
-        allowed_tools=allowed_tools,
-        permission_mode="acceptEdits",
-        agents={
-            "blueprint": blueprint_definition,
-            "configure": configure_definition,
-            "docs": docs_definition,
-            "quality": quality_definition,
-            "security": security_definition,
-            "test_runner": test_runner_definition,
-        },
-        env={
-            "CLAUDECODE": "",
-            "FIX_MODE": str(fix),
-            "REPORT_ONLY": str(report_only),
-            "FOCUS_AREAS": focus or "",
-        },
-    )
-
-    # Build the prompt
-    prompt_parts = [
-        f"Run maintenance checks on the repository at {work_dir}.",
-        "Repository analysis and health score are in your system prompt. Execute the maintenance workflow.",
-    ]
-    if report_only:
-        prompt_parts.append("REPORT ONLY — do not make any changes, just generate a report.")
-    elif fix:
-        prompt_parts.append("FIX MODE — apply safe auto-fixes for issues found.")
-        prompt_parts.append(
-            f"You are working in a git worktree on branch '{branch}'. "
-            "Commit your changes directly to this branch. Do NOT create new branches."
-        )
-    if focus:
-        prompt_parts.append(f"Focus on these categories: {focus}")
-
-    prompt = " ".join(prompt_parts)
-
-    if interactive:
-        collected = await _stream_interactive(
-            prompt, options, "Maintenance complete.",
-            worktree_branch=branch,
-        )
-    elif report_only:
-        collected = await _stream_messages_collecting(
-            prompt, options, "Maintenance complete.",
-        )
-    else:
-        await _stream_messages(prompt, options, "Maintenance complete.")
-        collected = ""
-
-    # Post-workflow: offer to create PR if worktree has changes
-    if worktree_path and makes_changes:
-        await _prompt_pr_creation(
-            repo_path, worktree_path, branch, base_branch, "maintain",
-            agent_output=collected,
+    cleanup_token = None
+    if non_interactive is not None and worktree_path is not None:
+        cleanup_token = _install_cleanup_handler(
+            lambda: (
+                cleanup_worktree(repo_path, worktree_path),
+                release_lock(lock_path),
+            )
         )
 
-    # Post-workflow: offer to create GitHub issues for report-only findings
-    if report_only and collected:
-        await _prompt_issue_creation(repo_path, collected)
+    try:
+        allowed_tools = [
+            "Read", "Write", "Edit", "Bash", "Glob", "Grep", "Task", "TodoWrite",
+        ]
+        if not interactive and non_interactive is None:
+            allowed_tools.append("AskUserQuestion")
+
+        options = ClaudeAgentOptions(
+            system_prompt=system_prompt,
+            cwd=str(work_dir),
+            max_turns=50,
+            allowed_tools=allowed_tools,
+            permission_mode="acceptEdits",
+            agents={
+                "blueprint": blueprint_definition,
+                "configure": configure_definition,
+                "docs": docs_definition,
+                "quality": quality_definition,
+                "security": security_definition,
+                "test_runner": test_runner_definition,
+            },
+            env={
+                "CLAUDECODE": "",
+                "FIX_MODE": str(fix),
+                "REPORT_ONLY": str(report_only),
+                "FOCUS_AREAS": focus or "",
+            },
+        )
+
+        prompt_parts = [
+            f"Run maintenance checks on the repository at {work_dir}.",
+            "Repository analysis and health score are in your system prompt. Execute the maintenance workflow.",
+        ]
+        if report_only:
+            prompt_parts.append("REPORT ONLY — do not make any changes, just generate a report.")
+        elif fix:
+            prompt_parts.append("FIX MODE — apply safe auto-fixes for issues found.")
+            prompt_parts.append(
+                f"You are working in a git worktree on branch '{branch}'. "
+                "Commit your changes directly to this branch. Do NOT create new branches."
+            )
+        if focus:
+            prompt_parts.append(f"Focus on these categories: {focus}")
+
+        prompt = " ".join(prompt_parts)
+
+        if interactive:
+            collected = await _stream_interactive(
+                prompt, options, "Maintenance complete.",
+                worktree_branch=branch,
+            )
+        else:
+            collected = await _stream_messages_collecting(
+                prompt, options, "Maintenance complete.",
+            )
+
+        summary: dict = {
+            "status": "success",
+            "workflow": "maintain",
+            "mode": "fix" if fix else ("report-only" if report_only else "interactive"),
+            "branch": branch if makes_changes else None,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+
+        if worktree_path and makes_changes:
+            if non_interactive is not None:
+                pr_result = await _auto_handle_pr(
+                    repo_path, worktree_path, branch, base_branch,
+                    "maintain", collected, non_interactive,
+                )
+                summary.update(pr_result)
+            else:
+                await _prompt_pr_creation(
+                    repo_path, worktree_path, branch, base_branch, "maintain",
+                    agent_output=collected,
+                )
+
+        if report_only and collected:
+            if non_interactive is not None:
+                issue_result = await _auto_handle_issues(
+                    repo_path, collected, non_interactive,
+                )
+                summary.update(issue_result)
+            else:
+                await _prompt_issue_creation(repo_path, collected)
+
+        if non_interactive is not None:
+            _summary_line(summary, non_interactive.log_format)
+    finally:
+        if cleanup_token is not None:
+            _restore_handlers(cleanup_token)
+        release_lock(lock_path)
 
 
 async def run_diagnose(
@@ -365,6 +631,7 @@ async def run_diagnose(
     dry_run: bool = False,
     namespace: str | None = None,
     app_name: str | None = None,
+    non_interactive: NonInteractiveConfig | None = None,
 ) -> None:
     """Run the pipeline diagnostics workflow for a repository."""
     console.print(f"[bold]Git Repo Agent[/bold] — Diagnosing [cyan]{repo_path}[/cyan]")
@@ -429,6 +696,13 @@ async def run_diagnose(
         "mcp__github__list_issues",
         "mcp__github__search_issues",
     ]
+    if non_interactive is not None:
+        allowed_tools = _non_interactive_allowed_tools(allowed_tools)
+
+    lock_path: Path | None = None
+    if non_interactive is not None:
+        base_branch = get_base_branch(repo_path)
+        lock_path = _prepare_non_interactive(repo_path, non_interactive, base_branch)
 
     options = ClaudeAgentOptions(
         system_prompt=system_prompt,
@@ -465,7 +739,22 @@ async def run_diagnose(
 
     prompt = " ".join(prompt_parts)
 
-    await _stream_messages(prompt, options, "Diagnostics complete.")
+    try:
+        await _stream_messages(prompt, options, "Diagnostics complete.")
+
+        if non_interactive is not None:
+            _summary_line(
+                {
+                    "status": "success",
+                    "workflow": "diagnose",
+                    "dry_run": dry_run,
+                    "sources": sources,
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                },
+                non_interactive.log_format,
+            )
+    finally:
+        release_lock(lock_path)
 
 
 def run_health(repo_path: Path) -> None:

--- a/git-repo-agent/src/git_repo_agent/worktree.py
+++ b/git-repo-agent/src/git_repo_agent/worktree.py
@@ -1,11 +1,204 @@
 """Git worktree management for isolated agent work."""
 
+import errno
+import json
 import logging
+import os
 import re
 import subprocess
+from datetime import datetime, timezone
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+def timestamped_branch(prefix: str) -> str:
+    """Return a UTC-timestamped branch name under ``prefix``.
+
+    Used by non-interactive runs so repeated scheduled invocations do not
+    collide on e.g. ``maintain/2026-04-14``.
+    """
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M")
+    return f"{prefix}/{stamp}"
+
+
+_LOCK_RELATIVE = Path(".claude") / "worktrees" / ".git-repo-agent.lock"
+
+
+def acquire_lock(repo_path: Path) -> Path | None:
+    """Acquire an advisory lock for a non-interactive run.
+
+    Writes PID + ISO-8601 start time to ``.claude/worktrees/.git-repo-agent.lock``
+    via ``O_CREAT | O_EXCL``. Returns the lock path on success, ``None`` if
+    a live lock is already held. Stale locks (holder process gone) are
+    reclaimed automatically.
+    """
+    lock_path = repo_path / _LOCK_RELATIVE
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+    payload = json.dumps(
+        {"pid": os.getpid(), "started_at": datetime.now(timezone.utc).isoformat()}
+    ).encode()
+
+    try:
+        fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+    except FileExistsError:
+        # Check liveness of the existing holder.
+        try:
+            existing = json.loads(lock_path.read_text(encoding="utf-8"))
+            pid = int(existing.get("pid", 0))
+        except (ValueError, OSError):
+            pid = 0
+        if pid > 0 and _pid_alive(pid):
+            return None
+        # Stale — remove and retry once.
+        try:
+            lock_path.unlink()
+        except FileNotFoundError:
+            pass
+        try:
+            fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        except FileExistsError:
+            return None
+
+    with os.fdopen(fd, "wb") as f:
+        f.write(payload)
+    return lock_path
+
+
+def release_lock(lock_path: Path | None) -> None:
+    """Remove the advisory lock file. Safe to call with ``None``."""
+    if lock_path is None:
+        return
+    try:
+        lock_path.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        logger.warning("Failed to release lock %s: %s", lock_path, exc)
+
+
+def _pid_alive(pid: int) -> bool:
+    """True if ``pid`` is a live process we can see."""
+    try:
+        os.kill(pid, 0)
+    except OSError as exc:
+        return exc.errno == errno.EPERM
+    return True
+
+
+def refresh_base(repo_path: Path, base_branch: str) -> bool:
+    """Fetch the remote and fast-forward the local base branch.
+
+    Returns True on success, False on any failure (network, no remote,
+    non-fast-forward, etc.). Non-fatal: scheduled runs should log and
+    continue on stale base if the fetch fails.
+    """
+    fetch = subprocess.run(
+        ["git", "fetch", "origin", base_branch],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+    )
+    if fetch.returncode != 0:
+        logger.warning("git fetch origin %s failed: %s", base_branch, fetch.stderr.strip())
+        return False
+    # Only fast-forward if the local branch is checked out and behind.
+    current = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if current != base_branch:
+        return True  # fetch is enough; worktree base will come from origin/<base>
+    ff = subprocess.run(
+        ["git", "merge", "--ff-only", f"origin/{base_branch}"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+    )
+    if ff.returncode != 0:
+        logger.warning("Non-fast-forward refresh of %s: %s", base_branch, ff.stderr.strip())
+        return False
+    return True
+
+
+def find_existing_pr(
+    repo_path: Path,
+    branch_prefix: str,
+    base_branch: str,
+) -> str | None:
+    """Return the URL of an open PR whose head branch starts with ``branch_prefix``.
+
+    Used by non-interactive runs to dedupe scheduled PRs. Returns None if
+    ``gh`` is unavailable, auth fails, or no match is found.
+    """
+    result = subprocess.run(
+        [
+            "gh", "pr", "list",
+            "--state", "open",
+            "--base", base_branch,
+            "--json", "url,headRefName",
+            "--limit", "100",
+        ],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        logger.debug("gh pr list failed: %s", result.stderr.strip())
+        return None
+    try:
+        prs = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        return None
+    for pr in prs:
+        head = pr.get("headRefName", "")
+        if head == branch_prefix or head.startswith(f"{branch_prefix}/"):
+            return pr.get("url")
+    return None
+
+
+def find_existing_issue(repo_path: Path, title: str) -> str | None:
+    """Return the URL of an open issue with an exact matching title.
+
+    Used to dedupe report-only findings across scheduled runs.
+    """
+    result = subprocess.run(
+        [
+            "gh", "issue", "list",
+            "--state", "open",
+            "--search", f'in:title "{title}"',
+            "--json", "url,title",
+            "--limit", "50",
+        ],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        logger.debug("gh issue list failed: %s", result.stderr.strip())
+        return None
+    try:
+        issues = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        return None
+    for issue in issues:
+        if issue.get("title") == title:
+            return issue.get("url")
+    return None
+
+
+def gh_auth_ok(repo_path: Path) -> bool:
+    """Check that ``gh`` is authenticated. Fast fail for scheduled runs."""
+    result = subprocess.run(
+        ["gh", "auth", "status"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
 
 
 def create_worktree(repo_path: Path, branch: str) -> Path:

--- a/git-repo-agent/tests/test_non_interactive.py
+++ b/git-repo-agent/tests/test_non_interactive.py
@@ -1,0 +1,118 @@
+"""Tests for NonInteractiveConfig, lock acquisition, and branch naming."""
+
+from pathlib import Path
+
+import pytest
+
+from git_repo_agent.non_interactive import (
+    EXIT_CONFIG_ERROR,
+    EXIT_HOOK_BLOCKED,
+    EXIT_LOCKED,
+    EXIT_RUNTIME_ERROR,
+    EXIT_SUCCESS,
+    NonInteractiveConfig,
+    NonInteractiveUsageError,
+)
+from git_repo_agent.worktree import (
+    acquire_lock,
+    release_lock,
+    timestamped_branch,
+)
+
+
+class TestExitCodes:
+    def test_contract(self):
+        # ADR-005 contract: these are part of the public API.
+        assert (EXIT_SUCCESS, EXIT_RUNTIME_ERROR, EXIT_CONFIG_ERROR,
+                EXIT_LOCKED, EXIT_HOOK_BLOCKED) == (0, 1, 2, 3, 4)
+
+
+class TestNonInteractiveConfig:
+    def _build(self, **over):
+        defaults = dict(
+            auto_pr="on-changes",
+            auto_issues="on-findings",
+            on_duplicate="skip",
+            refresh_base=False,
+            max_cost_usd=None,
+            log_format="plain",
+            notify="none",
+        )
+        defaults.update(over)
+        return NonInteractiveConfig.build(**defaults)
+
+    def test_happy_path(self):
+        cfg = self._build()
+        assert cfg.auto_pr == "on-changes"
+        assert cfg.log_format == "plain"
+
+    def test_invalid_auto_pr(self):
+        with pytest.raises(NonInteractiveUsageError, match="--auto-pr"):
+            self._build(auto_pr="maybe")
+
+    def test_invalid_auto_issues(self):
+        with pytest.raises(NonInteractiveUsageError, match="--auto-issues"):
+            self._build(auto_issues="whenever")
+
+    def test_invalid_log_format(self):
+        with pytest.raises(NonInteractiveUsageError, match="--log-format"):
+            self._build(log_format="yaml")
+
+    def test_invalid_on_duplicate(self):
+        with pytest.raises(NonInteractiveUsageError, match="--on-duplicate"):
+            self._build(on_duplicate="replace")
+
+    def test_negative_cost(self):
+        with pytest.raises(NonInteractiveUsageError, match="positive"):
+            self._build(max_cost_usd=-1.0)
+
+    def test_frozen(self):
+        cfg = self._build()
+        with pytest.raises(Exception):
+            cfg.auto_pr = "always"  # type: ignore[misc]
+
+
+class TestLock:
+    def test_acquire_and_release(self, tmp_path: Path):
+        lock = acquire_lock(tmp_path)
+        assert lock is not None
+        assert lock.exists()
+        release_lock(lock)
+        assert not lock.exists()
+
+    def test_double_acquire_fails(self, tmp_path: Path):
+        lock1 = acquire_lock(tmp_path)
+        assert lock1 is not None
+        try:
+            lock2 = acquire_lock(tmp_path)
+            assert lock2 is None  # live holder present
+        finally:
+            release_lock(lock1)
+
+    def test_stale_lock_reclaimed(self, tmp_path: Path):
+        # Create a stale lock pointing at a PID unlikely to exist.
+        lock_dir = tmp_path / ".claude" / "worktrees"
+        lock_dir.mkdir(parents=True)
+        lock_path = lock_dir / ".git-repo-agent.lock"
+        # PID 2^31-1 virtually never exists.
+        lock_path.write_text('{"pid": 2147483646, "started_at": "stale"}')
+        acquired = acquire_lock(tmp_path)
+        assert acquired is not None
+        release_lock(acquired)
+
+    def test_release_none_is_safe(self):
+        release_lock(None)  # should not raise
+
+
+class TestTimestampedBranch:
+    def test_format(self):
+        b = timestamped_branch("maintain")
+        assert b.startswith("maintain/")
+        # YYYY-MM-DDTHH-MM -> 16 chars
+        suffix = b[len("maintain/"):]
+        assert len(suffix) == 16
+        assert suffix[4] == "-" and suffix[7] == "-" and suffix[10] == "T"
+
+    def test_uniqueness_prefix(self):
+        assert timestamped_branch("maintain").startswith("maintain/")
+        assert timestamped_branch("setup").startswith("setup/")


### PR DESCRIPTION
## Summary

Adds comprehensive non-interactive / scheduled execution support to `git-repo-agent`, enabling safe automation via cron, GitHub Actions, Claude Code desktop schedules, and other schedulers. When stdin is not a TTY, the CLI now requires explicit `--non-interactive` flag with policy declarations for every decision point, preventing silent failures.

## Key Changes

**New non-interactive configuration module** (`non_interactive.py`)
- `NonInteractiveConfig` dataclass with validated policies for PR creation, issue creation, duplicate handling, and logging
- Exit code contract (0=success, 1=runtime error, 2=config error, 3=locked, 4=hook blocked)
- Exception types: `LockedError`, `HookBlockedError`, `NonInteractiveUsageError`

**CLI enhancements** (`main.py`)
- Added `--non-interactive`, `--auto-pr`, `--auto-issues`, `--on-duplicate`, `--refresh-base`, `--max-cost-usd`, `--log-format` flags to `onboard`, `maintain`, and `diagnose` commands
- TTY detection: exits with code 2 if stdin is not a TTY and `--non-interactive` is not passed
- `_build_ni_config()` validates all non-interactive flags and returns `None` for interactive runs
- `_dispatch()` wrapper maps exceptions to exit codes and runs async orchestrator coroutines

**Orchestrator workflow changes** (`orchestrator.py`)
- `_summary_line()` emits machine-scrapeable final summary (JSON or key=value format)
- `_install_cleanup_handler()` / `_restore_handlers()` install SIGTERM/SIGINT handlers that clean up worktrees and release locks before re-raising
- `_non_interactive_allowed_tools()` removes `AskUserQuestion` from allowed tools (no-ops in SDK subprocess mode per ADR-003)
- `_prepare_non_interactive()` validates `gh` auth, acquires advisory lock, optionally refreshes base branch
- `_auto_handle_pr()` implements non-interactive PR creation with duplicate detection and policy enforcement
- `_auto_handle_issues()` implements non-interactive issue creation for report-only runs with deduplication
- Both `run_onboard()` and `run_maintain()` updated to accept `NonInteractiveConfig`, use timestamped branches, install cleanup handlers, and emit summary lines

**Worktree management enhancements** (`worktree.py`)
- `timestamped_branch()` generates UTC-timestamped branch names (e.g., `maintain/2026-04-14T05-30`) for sub-daily scheduled runs
- `acquire_lock()` / `release_lock()` implement PID-tagged advisory locking with automatic stale lock reclamation
- `refresh_base()` performs `git fetch` + fast-forward of base branch
- `find_existing_pr()` queries `gh pr list` to detect open PRs with matching workflow prefix
- `find_existing_issue()` queries `gh issue list` to detect open issues by exact title
- `gh_auth_ok()` validates `gh` CLI authentication

**Documentation**
- ADR-005 documents the non-interactive execution contract, policies, exit codes, and safety mechanisms
- README updated with scheduled execution examples and GitHub Actions snippet

## Notable Implementation Details

- **Advisory locking**: Prevents concurrent scheduled runs from colliding; stale locks (holder PID gone) are automatically reclaimed
- **Duplicate detection**: PRs matched by branch prefix + base; issues matched by exact title
- **Cleanup on signal**: SIGTERM/SIGINT handlers ensure worktrees are removed and locks released even if scheduler kills the job mid-run
- **Conditional tool removal**: `AskUserQuestion` stripped from `allowed_tools` in non-interactive mode to prevent subagent stalls
- **Two-phase maintain constraint**: Non-interactive `maintain` requires either `--fix` or `--report-only` (default interactive flow cannot be automated)
- **Structured output**: Final summary line is JSON when `--log-format=json`, otherwise human-readable `key=value` for scheduler scraping

https://claude.ai/code/session_01Wxit8S5m8crDSqmYu5FciV