### PR TITLE
feat: /code:error-swallowing skill for detecting syntactic error suppression

### DIFF
--- a/code-quality-plugin/.claude-plugin/plugin.json
+++ b/code-quality-plugin/.claude-plugin/plugin.json
@@ -24,6 +24,8 @@
     "duplication",
     "silent-degradation",
     "preconditions",
+    "error-handling",
+    "error-swallowing",
     "dead-code",
     "dependency-audit",
     "test-quality",

--- a/code-quality-plugin/README.md
+++ b/code-quality-plugin/README.md
@@ -18,6 +18,7 @@ This plugin provides comprehensive code quality tools including automated code r
 | `/code:dry-consolidation` | Find and extract duplicated code into shared, tested abstractions |
 | `/code:docs-quality` | Analyze documentation quality - PRDs, ADRs, PRPs, CLAUDE.md, and .claude/rules/ |
 | `/code:silent-degradation` | Detect silent degradation patterns where operations succeed with zero results |
+| `/code:error-swallowing` | Detect syntactic error swallowing (empty catch, `\|\| true`, `2>/dev/null`, floating promises, ignored Go/Rust errors) with context-aware surfacing recommendations |
 | `/code:dead-code` | Detect dead code, unused exports, unreachable branches, and orphaned files |
 | `/code:dep-audit` | Audit dependencies for security vulnerabilities, outdated packages, and license compliance |
 | `/code:test-quality` | Analyze test suite quality — detect test smells, empty assertions, flaky patterns |
@@ -141,6 +142,19 @@ Detects patterns where code silently degrades:
 ```
 
 Applies fixes: adds precondition checks, warning messages, and status indicators.
+
+### Error-Swallowing Scan
+
+```bash
+/code:error-swallowing src/ --severity high
+```
+
+Detects and classifies syntactic error suppression across shell, JS/TS,
+Python, Go, and Rust. Recommends a surfacing channel based on detected
+app context (CLI stderr, web toast + `console.error`, structured log,
+`Result` propagation) and applies a privacy redaction policy to any
+generated user-facing strings. Use `--emit-patch` to produce a
+reviewable diff without mutating files.
 
 ### Dead Code Detection
 

--- a/code-quality-plugin/skills/code-antipatterns/SKILL.md
+++ b/code-quality-plugin/skills/code-antipatterns/SKILL.md
@@ -1,9 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-02-03
-reviewed: 2025-12-16
+modified: 2026-04-14
+reviewed: 2026-04-14
 description: Analyze codebase for anti-patterns, code smells, and quality issues using ast-grep
-allowed-tools: Read, Bash(sg *), Bash(rg *), Glob, Grep, TodoWrite, Task
+allowed-tools: Read, Bash(sg *), Bash(rg *), Glob, Grep, TodoWrite, Task, SlashCommand
 args: "[PATH] [--focus <category>] [--severity <level>]"
 argument-hint: "[PATH] [--focus <category>] [--severity <level>]"
 name: code-antipatterns
@@ -25,12 +25,13 @@ Perform comprehensive anti-pattern analysis using ast-grep and parallel agent de
 Based on the detected languages, analyze for these categories:
 
 1. **JavaScript/TypeScript Anti-patterns**
-   - Callbacks, magic values, empty catch blocks, console.logs
+   - Callbacks, magic values, console.logs
    - var usage, deprecated patterns
+   - Error swallowing (empty catch, floating promises) → **delegate** to `/code:error-swallowing`
 
 2. **Async/Promise Patterns**
-   - Unhandled promises, nested callbacks, missing error handling
-   - Promise constructor anti-pattern
+   - Nested callbacks, Promise constructor anti-pattern
+   - Error-handling coverage (unhandled/floating promises) → **delegate** to `/code:error-swallowing`
 
 3. **Framework-Specific** (if detected)
    - **Vue 3**: Props mutation, reactivity issues, Options vs Composition API mixing
@@ -49,7 +50,19 @@ Based on the detected languages, analyze for these categories:
    - Event listeners without cleanup, setInterval leaks, inefficient patterns
 
 8. **Python Anti-patterns** (if detected)
-   - Mutable default arguments, bare except, global variables
+   - Mutable default arguments, global variables
+   - Bare except and suppression patterns → **delegate** to `/code:error-swallowing`
+
+### Delegated Category: Error Swallowing
+
+Do NOT re-implement empty-catch / bare-except / floating-promise detection
+here. Invoke `/code:error-swallowing` via the SlashCommand tool with the
+same `PATH` and severity filter, then fold its findings into the
+consolidated report under a dedicated **Error Swallowing** section.
+
+Rationale: a single source of truth prevents drift between severity
+models, app-context surfacing recommendations, and privacy redaction
+policies. See `code-quality-plugin/skills/code-error-swallowing/SKILL.md`.
 
 ### Execution Strategy
 
@@ -63,11 +76,12 @@ Detect project stack, identify file patterns, establish analysis scope
 
 ## Agent 2: JavaScript/TypeScript Analysis (code-analysis)
 - Use ast-grep for structural pattern matching
-- Focus on: empty catch, magic values, var usage, deprecated patterns
+- Focus on: magic values, var usage, deprecated patterns
+- Error swallowing handled separately via `/code:error-swallowing`
 
 ## Agent 3: Async/Promise Analysis (code-analysis)
-- Unhandled promises, nested callbacks, floating promises
-- Promise constructor anti-pattern
+- Nested callbacks, Promise constructor anti-pattern
+- Floating promises / unhandled rejections handled via `/code:error-swallowing`
 
 ## Agent 4: Framework-Specific Analysis (code-analysis)
 - Vue: props mutation, reactivity issues
@@ -87,9 +101,6 @@ Detect project stack, identify file patterns, establish analysis scope
 Use these patterns during analysis:
 
 ```bash
-# Empty catch blocks
-ast-grep -p 'try { $$$ } catch ($E) { }' --lang js
-
 # Magic numbers
 ast-grep -p 'if ($VAR > 100)' --lang js
 

--- a/code-quality-plugin/skills/code-error-swallowing/REFERENCE-go.md
+++ b/code-quality-plugin/skills/code-error-swallowing/REFERENCE-go.md
@@ -1,0 +1,113 @@
+# Reference — Go Error Swallowing
+
+Go's error model makes error-swallowing especially easy to detect: any
+function returning `error` whose return is assigned to `_` or discarded is
+a candidate. Prefer the project's own `errcheck` / `staticcheck` (rules
+`SA4006`, `SA5001`) when configured.
+
+## Patterns
+
+| ID | Pattern | Default severity |
+|----|---------|------------------|
+| `go-ignore-underscore` | `_ = foo()` / `_, _ = foo()` where foo returns error | Medium |
+| `go-ignore-expr-stmt` | `foo()` (no assignment) where foo returns error | Medium |
+| `go-defer-close-unchecked` | `defer f.Close()` on a writer | Medium — write errors are dropped |
+| `go-log-continue` | `if err != nil { log.Print(err) }` in a loop with no return/break | Medium |
+| `go-panic-recover-empty` | `defer func() { recover() }()` | High |
+| `go-errors-is-swallow` | `if errors.Is(err, X) { /* empty */ }` | Medium |
+
+### Detection commands
+
+Prefer the project linter:
+
+```bash
+# If present
+errcheck ./...
+staticcheck -checks SA4006,SA5001 ./...
+```
+
+Fall back to ast-grep:
+
+```bash
+sg -p '_ = $EXPR($$$)' --lang go
+sg -p 'defer $F.Close()' --lang go
+```
+
+## Allowlist (classify as Low)
+
+| Pattern | Why |
+|---------|-----|
+| `defer f.Close()` on a **read-only** `os.Open` | Close errors on readers are benign |
+| `_ = w.WriteString(...)` where `w` is `os.Stderr` / `os.Stdout` | Terminal writes, acceptable |
+| `_ = os.Remove(tmpPath)` in a `defer` cleanup and the path is `os.CreateTemp` output | Cleanup-only, best-effort |
+| A `recover()` that logs + re-panics | Controlled propagation |
+
+## Severity promotion
+
+Promote to **High** when the ignored error comes from:
+
+- `db.Exec`, `tx.Commit`, `rows.Close` in a write path
+- `http.Client.Do`, `http.Post`, `http.Put` to non-idempotent endpoints
+- `os.WriteFile`, `io.Copy` into user-visible files
+- `crypto/*` operations
+- `exec.Cmd.Run` / `Start` for deploy/publish commands
+
+## Remediation templates
+
+### CLI tool
+
+```go
+// Before
+_ = cleanup()
+
+// After
+if err := cleanup(); err != nil {
+    fmt.Fprintf(os.Stderr, "warn: cleanup failed: %v\n", err) // TODO(error-swallowing): review wording
+    os.Exit(1)
+}
+```
+
+### Service / daemon
+
+```go
+// Before
+_ = tx.Commit()
+
+// After
+if err := tx.Commit(); err != nil {
+    logger.Error("tx.Commit failed", "err", err)
+    return fmt.Errorf("commit: %w", err)
+}
+```
+
+### Writer `defer Close`
+
+```go
+// Before
+defer f.Close()
+
+// After
+defer func() {
+    if cerr := f.Close(); cerr != nil && retErr == nil {
+        retErr = fmt.Errorf("close: %w", cerr)
+    }
+}()
+```
+
+Requires named return value `retErr error`.
+
+## Linter integration
+
+When the repository has `.golangci.yml`, check that these linters are
+enabled:
+
+```yaml
+linters:
+  enable:
+    - errcheck
+    - errorlint
+    - wrapcheck
+```
+
+If missing, recommend enabling — the skill should not replace real static
+analysis, only surface what linters would catch if configured.

--- a/code-quality-plugin/skills/code-error-swallowing/REFERENCE-js.md
+++ b/code-quality-plugin/skills/code-error-swallowing/REFERENCE-js.md
@@ -1,0 +1,125 @@
+# Reference — JavaScript / TypeScript Error Swallowing
+
+Detection rules for `.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`, `.cjs`. Use
+`sg` (ast-grep) for structural matching where possible; fall back to Grep
+for the heuristic ones.
+
+## Patterns
+
+| ID | ast-grep pattern | Default severity |
+|----|------------------|------------------|
+| `js-empty-catch` | `try { $$$ } catch ($E) {}` | Medium |
+| `js-catch-only-comment` | `try { $$$ } catch ($E) { /* $$ */ }` | Medium |
+| `js-promise-catch-empty` | `$EXPR.catch(() => {})` / `$EXPR.catch(() => null)` | Medium |
+| `js-promise-catch-ignore` | `$EXPR.catch(($E) => {})` | Medium |
+| `js-floating-promise` | Top-level `await`-less call returning a Promise with no `.then` / `.catch` | Medium |
+| `js-void-ignore` | `void $EXPR()` where `$EXPR` returns a Promise | Medium |
+| `js-try-log-swallow` | `catch ($E) { console.log($E) }` — logs, no rethrow | Low (if UI-layer) / Medium |
+| `js-swallow-rethrow` | `catch ($E) { logger.error($E); throw $E }` | **Low** (correct pattern) |
+| `js-error-boundary-silence` | React `componentDidCatch` with no logging or state update | High |
+
+### ast-grep commands
+
+```bash
+sg -p 'try { $$$ } catch ($E) {}' --lang ts
+sg -p 'try { $$$ } catch ($E) { }' --lang tsx
+sg -p '$EXPR.catch(() => {})' --lang ts
+sg -p '$EXPR.catch(($E) => {})' --lang ts
+sg -p 'void $EXPR($$$)' --lang ts
+```
+
+For floating promises the repo's own toolchain is authoritative — defer to
+`tsc --noImplicitAny` + `no-floating-promises` ESLint rule when configured;
+only report a finding when neither is present.
+
+## Allowlist (classify as Low)
+
+| Pattern | Why |
+|---------|-----|
+| `catch ($E) { /* intentionally ignored: <reason> */ }` | Explicit documented decision |
+| `catch` block that calls any `log*` / `console.error` / `Sentry.captureException` AND rethrows | Logs + rethrow is correct |
+| `.catch(() => defaultValue)` where `defaultValue` is a literal and the call site uses it | Fallback value, not suppression |
+| `catch` inside a `finally`-cleanup path, where the primary error is already propagating | Don't double-throw |
+
+## Severity promotion
+
+Promote to **High** if the swallowed expression matches any of:
+
+- `fetch(`, `axios.`, `client.`, `api.` calls whose result drives writes
+- `.save(` / `.insert(` / `.update(` / `.delete(` (ORM methods)
+- Any call inside a handler named `onSubmit`, `onSave`, `onPublish`,
+  `onDeploy`, `onPurchase`, `onPayment`
+- Auth / token refresh calls: `refreshToken`, `verifyToken`, `signIn`,
+  `signOut`
+
+## Remediation templates
+
+### Frontend empty catch → toast + console.error
+
+```typescript
+// Before
+try {
+  await saveProfile(data);
+} catch (e) {}
+
+// After
+try {
+  await saveProfile(data);
+} catch (e) {
+  console.error('saveProfile failed', e); // TODO(error-swallowing): review wording
+  toast.error('Could not save profile. Please try again.');
+}
+```
+
+### Backend empty catch → structured log + re-raise
+
+```typescript
+// Before
+try {
+  await db.insert(...);
+} catch (e) {}
+
+// After
+try {
+  await db.insert(...);
+} catch (e) {
+  logger.error({ err: e, op: 'db.insert' }, 'insert failed');
+  throw e; // let the request handler return 5xx
+}
+```
+
+### Library → propagate
+
+Libraries should almost never catch-and-discard. Delete the try/catch and
+let the caller decide.
+
+### `.catch(() => {})` → typed fallback
+
+```typescript
+// Before
+const user = await fetchUser(id).catch(() => {});
+
+// After
+const user = await fetchUser(id).catch((err) => {
+  console.error('fetchUser failed', err);
+  return null;           // explicit sentinel callers must handle
+});
+```
+
+## Framework-specific notes
+
+### React
+
+- `componentDidCatch` without logging is always **High** — it silences an
+  entire subtree.
+- `useEffect(() => { asyncFn(); }, [])` without a `.catch` is a floating
+  promise.
+
+### Node / Express
+
+- An error-handling middleware that calls `next()` instead of `next(err)`
+  after a `catch` is suppressing — flag as Medium.
+
+### Vue
+
+- `errorCaptured` returning `false` without logging = High.

--- a/code-quality-plugin/skills/code-error-swallowing/REFERENCE-python.md
+++ b/code-quality-plugin/skills/code-error-swallowing/REFERENCE-python.md
@@ -1,0 +1,121 @@
+# Reference — Python Error Swallowing
+
+Detection rules for `.py`. Use `sg --lang py` for structural matches.
+
+## Patterns
+
+| ID | ast-grep pattern | Default severity |
+|----|------------------|------------------|
+| `py-bare-except-pass` | `try:\n  $$$\nexcept:\n  pass` | High |
+| `py-broad-except-pass` | `except Exception: pass` / `except BaseException: pass` | High |
+| `py-typed-except-pass` | `except $TYPE: pass` (narrow type) | Medium |
+| `py-except-ellipsis` | `except $TYPE: ...` | Medium |
+| `py-except-only-log-debug` | `except $TYPE as $E:\n  logging.debug($$$)` with no raise | Medium |
+| `py-suppress-misuse` | `contextlib.suppress(Exception):` wrapping a required op | High |
+| `py-suppress-narrow` | `contextlib.suppress(FileNotFoundError):` on cache/optional path | Low |
+| `py-asyncio-ensure-future-floating` | `asyncio.ensure_future(coro)` with no task registered | Medium |
+| `py-try-return-none` | `except $T: return None` where caller doesn't check | Medium |
+
+### ast-grep commands
+
+```bash
+sg -p $'try:\n  $$$\nexcept:\n  pass' --lang py
+sg -p $'try:\n  $$$\nexcept Exception:\n  pass' --lang py
+sg -p $'with suppress($TYPE):\n  $$$' --lang py
+```
+
+## Allowlist (classify as Low)
+
+| Pattern | Why |
+|---------|-----|
+| `except (FileNotFoundError, PermissionError): pass` on optional cache | Intentional, narrow, harmless |
+| `except KeyboardInterrupt` that re-raises or sys.exit()s cleanly | Signal handling |
+| `except $T as e: logger.exception(...); raise` | Log + re-raise — correct |
+| Any `except` containing `raise` | Propagates, not suppresses |
+| `except` inside a `__del__` or `__exit__` finalizer | Python style requires suppression to avoid secondary exceptions |
+
+## Severity promotion
+
+Promote to **High** if the protected suite contains:
+
+- DB mutation: `session.commit`, `cursor.execute` with INSERT/UPDATE/DELETE
+- FS writes outside `/tmp`
+- Network writes: `requests.post`, `requests.put`, `requests.delete`,
+  `httpx.*` mutating methods
+- Crypto: `sign`, `decrypt`, `verify`, key loading
+- Config loading: `yaml.safe_load`, `json.load` on files the app depends on
+
+Demote a `py-bare-except-pass` to Medium only when the enclosing function is
+a `__del__`, `__exit__`, or an explicit `atexit` handler.
+
+## Remediation templates
+
+### CLI script
+
+```python
+# Before
+try:
+    do_thing()
+except:
+    pass
+
+# After
+try:
+    do_thing()
+except Exception as exc:  # noqa: BLE001 — surfaced below
+    print(f"warn: do_thing failed: {exc}", file=sys.stderr)  # TODO(error-swallowing): review wording
+    sys.exit(1)
+```
+
+### Backend service
+
+```python
+# Before
+try:
+    db.commit()
+except Exception:
+    pass
+
+# After
+try:
+    db.commit()
+except Exception:
+    logger.exception("db.commit failed")
+    raise
+```
+
+### Library
+
+```python
+# Before
+try:
+    result = parse(data)
+except ValueError:
+    return None
+
+# After — option A: propagate
+return parse(data)
+
+# After — option B: explicit Result-like return
+try:
+    return parse(data), None
+except ValueError as exc:
+    return None, exc
+```
+
+## Framework-specific notes
+
+### Django
+
+- `get_object_or_404` inside an `except Http404: pass` branch is **High**
+  when it hides a permissions/ownership check failure.
+
+### FastAPI
+
+- A route handler `except` that returns 200 with empty body instead of
+  raising `HTTPException` is **High**.
+
+### Celery
+
+- A task `except: pass` prevents retries and silences the worker — **High**
+  unless the task is explicitly `acks_late=False` with documented reason.

--- a/code-quality-plugin/skills/code-error-swallowing/REFERENCE-rust.md
+++ b/code-quality-plugin/skills/code-error-swallowing/REFERENCE-rust.md
@@ -1,0 +1,117 @@
+# Reference — Rust Error Swallowing
+
+Rust's `Result` and `#[must_use]` make the compiler a first line of defense.
+This skill's job is to find the *runtime* suppressions — the places where
+`.ok()`, `let _ =`, and friends discard errors deliberately. Prefer
+`cargo clippy` with the relevant lints enabled when available.
+
+## Patterns
+
+| ID | Pattern | Default severity |
+|----|---------|------------------|
+| `rs-let-underscore-result` | `let _ = <expr>;` where expr is `Result` | Medium |
+| `rs-ok-discard` | `<expr>.ok();` as a statement | Medium |
+| `rs-unwrap-or-default-on-err` | `<expr>.unwrap_or_default()` on an error that should be surfaced | Medium |
+| `rs-map-err-empty` | `.map_err(\|_\| ())` / `.map_err(\|_\| Default::default())` | Medium |
+| `rs-match-err-empty` | `match x { Ok(v) => v, Err(_) => Default::default() }` | Medium |
+| `rs-ignore-closure-result` | `.ok().or(None)` chain that forgets error | Medium |
+| `rs-io-result-drop` | `writeln!(f, "...").ok();` | Medium |
+
+### ast-grep commands
+
+```bash
+sg -p 'let _ = $EXPR;' --lang rust
+sg -p '$EXPR.ok();' --lang rust
+sg -p '$EXPR.map_err(|_| $$)' --lang rust
+```
+
+Better: run `cargo clippy -- -W clippy::let_underscore_must_use -W clippy::unused_io_amount`.
+
+## Allowlist (classify as Low)
+
+| Pattern | Why |
+|---------|-----|
+| `let _: () = <expr>;` — explicit unit binding to assert expression shape | Not a Result |
+| `let _ = tx.send(msg);` on a `mpsc::Sender` where receiver drop is expected | Channel close semantics |
+| `drop(<guard>)` or `let _ = <guard>;` on RAII guards (locks, spans) | Intentional lifetime extension |
+| `.unwrap_or_default()` on an `Option<String>` in display code | Option, not Result |
+| Inside a `Drop` impl | Panicking in Drop is worse than swallowing |
+
+## Severity promotion
+
+Promote to **High** when discarded Result comes from:
+
+- `std::fs::write`, `fs::remove_file` (non-temp), `OpenOptions::write`
+- Any `sqlx::*`, `diesel::*`, `sea_orm::*` mutating op
+- `reqwest::Client::post` / `put` / `delete`
+- Cryptographic ops: `signature::sign`, `decrypt_*`, key loading
+- `Command::status` / `output` for deploy/publish binaries
+
+## Remediation templates
+
+### Library — propagate with `?`
+
+```rust
+// Before
+let _ = do_thing();
+
+// After
+do_thing()?;
+```
+
+### Binary / CLI — log + exit
+
+```rust
+// Before
+let _ = cleanup();
+
+// After
+if let Err(err) = cleanup() {
+    eprintln!("warn: cleanup failed: {err}"); // TODO(error-swallowing): review wording
+    std::process::exit(1);
+}
+```
+
+### Fallback value with log
+
+```rust
+// Before
+let value = parse(s).unwrap_or_default();
+
+// After
+let value = parse(s).unwrap_or_else(|err| {
+    tracing::warn!(?err, "parse failed, using default");
+    Default::default()
+});
+```
+
+## Clippy lints to recommend
+
+When repository has `Cargo.toml` but missing these lints, recommend enabling:
+
+```toml
+[lints.clippy]
+let_underscore_must_use = "warn"
+unused_io_amount = "warn"
+unwrap_used = "warn"       # stricter; opt-in
+expect_used = "warn"       # stricter; opt-in
+```
+
+Also in the source:
+
+```rust
+#![warn(unused_must_use)]
+```
+
+## Framework-specific notes
+
+### Tokio
+
+- `tokio::spawn(async { ... })` returning a `JoinHandle` that's never
+  awaited nor given a handler is a floating task — **Medium** unless
+  explicitly annotated as fire-and-forget.
+
+### Axum / Actix
+
+- A handler `match` that returns `StatusCode::OK` on an `Err` arm is
+  **High**.

--- a/code-quality-plugin/skills/code-error-swallowing/REFERENCE-shell.md
+++ b/code-quality-plugin/skills/code-error-swallowing/REFERENCE-shell.md
@@ -1,0 +1,111 @@
+# Reference — Shell / Bash Error Swallowing
+
+Detection and classification rules for shell scripts (`*.sh`, `*.bash`,
+`Makefile` recipes). Paired scanner: `scripts/scan-shell.sh`.
+
+## Patterns
+
+| ID | Pattern | Raw risk |
+|----|---------|----------|
+| `sh-or-true` | `<cmd> \|\| true` / `<cmd> \|\| :` | Suppresses non-zero exit silently |
+| `sh-stderr-null` | `<cmd> 2>/dev/null` | Hides diagnostic output; may hide real failure |
+| `sh-both-null` | `<cmd> &>/dev/null` / `<cmd> >/dev/null 2>&1` | Hides stdout AND stderr |
+| `sh-set-plus-e` | `set +e` without a matching `set -e` | Disables fail-fast for the rest of the script |
+| `sh-trap-empty` | `trap '' ERR` / `trap - ERR` | Removes the error trap |
+| `sh-no-pipefail` | Script without `set -o pipefail` that uses pipes | Silently ignores mid-pipeline failures |
+| `sh-missing-check` | `command` at top level without `|| exit` on a High-severity op | No reaction to failure |
+| `sh-xtrace-suppression` | `{ cmd; } 2>/dev/null` wrapping xtrace output | Hides debugging stream |
+
+## Allowlist (classify as Low)
+
+These patterns are documented and intentional. See
+`.claude/rules/shell-scripting.md` §"Error Handling" (lines 135–162).
+
+| Pattern | Why allowed |
+|---------|-------------|
+| `grep -m1 '^field:' \| sed '...' \|\| true` | Frontmatter extraction; missing field is expected |
+| `grep -m1 '^field:' \| sed '...' \|\| echo ""` | Same; explicit empty default |
+| `rm -f <tmp>` without check | `-f` already suppresses missing-file error by design |
+| `mkdir -p <dir>` | `-p` already idempotent |
+| `command -v <tool> >/dev/null 2>&1` | Testing presence, output irrelevant |
+| `test -f <path> \|\| <default>` | Conditional guard, not suppression |
+| `2>/dev/null` inside a `find` predicate | Silences permission-denied on probes |
+
+Additionally, the scanner treats a line as Low when it is inside a function
+whose name starts with `extract_`, `probe_`, `has_`, `is_`, or `check_` —
+these are probe helpers where suppression is the idiom.
+
+## Severity assignment
+
+Start from the default severity per pattern below, then promote to **High**
+if the suppressed command matches the High operation regex; demote to
+**Low** if the allowlist matches.
+
+| Pattern | Default |
+|---------|---------|
+| `sh-or-true` | Medium |
+| `sh-stderr-null` | Medium |
+| `sh-both-null` | Medium |
+| `sh-set-plus-e` | Medium |
+| `sh-trap-empty` | Medium |
+| `sh-no-pipefail` | Low |
+| `sh-missing-check` | Medium |
+| `sh-xtrace-suppression` | High |
+
+### High-operation regex (any match promotes to High)
+
+```
+(npm publish|yarn publish|pnpm publish|cargo publish|gh release|
+ git push|git tag|docker push|helm upgrade|kubectl apply|
+ terraform apply|aws s3 cp|aws s3 sync|rclone copy|
+ psql.*INSERT|psql.*UPDATE|psql.*DELETE|psql.*DROP|
+ curl.*POST|curl.*PUT|curl.*DELETE|
+ rm -rf)
+```
+
+## Remediation templates
+
+### Replace `cmd || true` (CLI context)
+
+```bash
+# Before
+dangerous_cmd || true
+
+# After
+if ! dangerous_cmd; then
+  echo "warn: dangerous_cmd failed (continuing)" >&2
+fi
+```
+
+### Replace `cmd 2>/dev/null` (CLI context, High)
+
+```bash
+# Before
+dangerous_cmd 2>/dev/null
+
+# After — capture and surface
+err=$(dangerous_cmd 2>&1 >/dev/null) || {
+  echo "error: dangerous_cmd: ${err:0:200}" >&2
+  exit 1
+}
+```
+
+### Replace `set +e`
+
+Prefer a targeted `|| handler` on the single command that needs to tolerate
+failure, and keep `set -e` active elsewhere.
+
+## Scanner notes
+
+`scripts/scan-shell.sh` implements these rules. Its output format is
+pipe-delimited for machine parsing:
+
+```
+<severity>|<rule>|<file>:<line>|<content>|<recommended-surface>
+```
+
+Exit codes:
+
+- `0`: no Medium/High findings (Low tolerated)
+- `1`: Medium findings present
+- `2`: High findings present

--- a/code-quality-plugin/skills/code-error-swallowing/REFERENCE-surfacing.md
+++ b/code-quality-plugin/skills/code-error-swallowing/REFERENCE-surfacing.md
@@ -1,0 +1,132 @@
+# Reference — Context-Aware Error Surfacing
+
+The right way to surface a previously-swallowed error depends on the host
+application. This file encodes the decision matrix and the privacy policy
+applied to every suggested replacement string.
+
+## Detecting app context
+
+Apply these signals in order; first match wins.
+
+| Order | Signal | Context |
+|-------|--------|---------|
+| 1 | `.github/workflows/*.yml` / top-level `Makefile` / `justfile` with `ci` target, AND the target file is under `scripts/`, `.github/`, `ci/` | **CI / build script** |
+| 2 | `Dockerfile` with `CMD` running a long-lived process, OR `*.service` file, OR `pyproject.toml` with `gunicorn`/`uvicorn`/`celery` entry points | **Daemon / service** |
+| 3 | `package.json` with `main`/`types` and no `bin` entry, OR `lib.rs`/`__init__.py` with no `__main__` | **Library** |
+| 4 | `index.html` at root, OR `package.json` with `react`/`vue`/`svelte`/`solid` dependency | **Web frontend** |
+| 5 | `package.json` with `express`/`fastify`/`hono`/`koa`, OR Django/Flask/FastAPI entry | **Web backend** |
+| 6 | `#!/usr/bin/env bash` on file, OR `bin/` directory, OR `package.json` with `bin` entry, OR `pyproject.toml` with `[project.scripts]` | **CLI / shell** |
+| 7 | Fallback | **Library** (propagate) |
+
+A single repository can contain multiple contexts (e.g., a CLI plus a web
+dashboard). Detect per-file: use signal 1–2 for files matching their
+globs, then fall through to signals 3–6 based on the file's directory's
+nearest `package.json` / `pyproject.toml` / `Cargo.toml`.
+
+## Surfacing matrix
+
+| App context | Recommended channel | Exit / status | User copy |
+|-------------|---------------------|---------------|-----------|
+| **CLI / shell** | `echo "<level>: <msg>" >&2` | Non-zero exit on High; continue on Medium | Short, actionable: `"error: could not fetch release; check network"` |
+| **Web frontend** | `console.error(detail, err)` + `toast.error(shortCopy)` / banner / tooltip | No HTTP status (client-side); no auto-retry | Short, action-oriented, no stack traces, no URLs |
+| **Web backend** | Structured log (`logger.error({err, op}, msg)`) with correlation ID + throw/return 5xx | HTTP 4xx/5xx per semantics | Opaque message + correlation ID: `"Request failed (id: abc123). Contact support."` |
+| **Daemon / service** | Structured log + metrics counter increment + optional retry | Internal state only | N/A (no direct user) |
+| **Library** | Propagate: `throw` / `return Err` / `raise` / `return error` | N/A | N/A — caller's concern |
+| **CI / build script** | `echo "::error file=<f>,line=<l>::<msg>"` (GitHub Actions) or stderr + non-zero exit | Non-zero exit always on High | For CI logs only — assume public readable |
+
+### Frontend split
+
+For web frontend findings, **always split** the surfacing into two calls:
+
+1. Developer channel: `console.error('<op> failed', err)` — verbose, full
+   `err` object, stack OK.
+2. User channel: a sanitized short-copy `toast`/`banner`/`tooltip`/
+   `inline-form-error`.
+
+The generated patch must include both, with the user-channel string run
+through the privacy redaction rules below.
+
+## Privacy redaction rules
+
+Apply these to every string that will appear in (a) the report, (b) the
+emitted patch, or (c) any log call's message argument (the object
+argument passed alongside may remain verbose):
+
+### Rule 1 — Redact env values by name pattern
+
+Replace the *value* of any env variable whose **name** matches:
+
+```
+*TOKEN*  *KEY*  *SECRET*  *PASSWORD*
+GH_*  GITHUB_*  ANTHROPIC_*  CLAUDE_*
+AWS_*  AZURE_*  GCP_*  GOOGLE_*
+OPENAI_*  HF_*
+```
+
+with `[REDACTED]`. Names are matched case-insensitively.
+
+### Rule 2 — Rewrite absolute home paths
+
+- `$HOME/…` → `~/…`
+- `/Users/<user>/…` → `~/…`
+- `/home/<user>/…` → `~/…`
+- `C:\Users\<user>\…` → `~\…`
+
+### Rule 3 — Truncate to 200 characters
+
+Message payloads longer than 200 chars are cut to 197 + `"..."`. This
+prevents a multi-kilobyte stack trace from being echoed into a
+user-facing toast.
+
+### Rule 4 — Prefer action-oriented copy
+
+Transform raw stderr forwarding into action-oriented copy:
+
+| Raw | Action-oriented |
+|-----|------------------|
+| `"ENOTFOUND api.example.com"` | `"Could not reach API. Check your network."` |
+| `"401 Unauthorized"` | `"Session expired. Please sign in again."` |
+| `"EACCES /var/foo"` | `"Permission denied writing <path>."` |
+| `"timeout of 5000ms exceeded"` | `"Request timed out. Try again."` |
+
+When the tool cannot safely translate, keep the raw message *only in the
+developer channel* and use a generic short copy for the user channel:
+`"Something went wrong. Please try again."`
+
+### Rule 5 — Never forward xtrace output
+
+If the swallowed stream was `set -x` output (shell), do NOT echo it to
+stderr after un-swallowing. Replace with a single high-level message.
+Detection: the stream being redirected away is the output of a block
+preceded by `set -x` with no intervening `set +x`.
+
+## Report / patch embedding
+
+Every generated user-facing string in a patch must be followed by this
+inline comment so the human reviewer can polish wording:
+
+```
+<inserted-string>  // TODO(error-swallowing): review wording
+```
+
+(Use the language's comment syntax: `#` in shell/Python, `//` in JS/TS/Go/
+Rust, `--` in SQL.)
+
+## Example end-to-end
+
+Scenario: `release.sh` has `npm publish 2>/dev/null || true`.
+
+- App context → **CI / build script** (file is `.github/workflows/`-adjacent).
+- Severity → **High** (`npm publish` matches the High-op regex).
+- Channel → `echo "::error::..."` + non-zero exit.
+- Redaction → strip any `NPM_TOKEN` value that might leak into the msg.
+
+Patch:
+
+```diff
+-npm publish 2>/dev/null || true
++if ! err=$(npm publish 2>&1 >/dev/null); then
++  echo "::error::npm publish failed: ${err:0:200}"  # TODO(error-swallowing): review wording
++  exit 1
++fi
+```

--- a/code-quality-plugin/skills/code-error-swallowing/SKILL.md
+++ b/code-quality-plugin/skills/code-error-swallowing/SKILL.md
@@ -1,0 +1,171 @@
+---
+created: 2026-04-14
+modified: 2026-04-14
+reviewed: 2026-04-14
+allowed-tools: Bash(bash *), Bash(sg *), Read, Grep, Glob, TodoWrite
+args: "[PATH] [--lang <shell|js|py|go|rust|auto>] [--severity <low|med|high>] [--emit-patch]"
+argument-hint: "[PATH] [--lang LANG] [--severity LEVEL] [--emit-patch]"
+description: |
+  Scan for syntactic error swallowing — catch/except blocks that discard errors,
+  `|| true` and `2>/dev/null` idioms in shell, floating promises in JS/TS,
+  ignored Go error returns, and discarded Rust Results. Classifies each
+  finding by severity, recommends a context-appropriate surfacing channel
+  (CLI stderr, web toast, structured log, re-raise), and applies a privacy
+  redaction policy when generating suggested replacement text. Use when
+  failures "disappear", a CI job passes despite the real work failing, or a
+  user reports that a feature silently does nothing.
+name: code-error-swallowing
+---
+
+# Error-Swallowing Scanner
+
+Detect syntactic patterns that suppress errors without surfacing them to a log,
+user channel, or caller. Unlike `/code:silent-degradation` — which targets
+*logical* silent failures (success on empty results) — this skill targets the
+*syntactic* act of discarding an error signal.
+
+## When to Use This Skill
+
+| Use this skill when... | Use another skill instead when... |
+|------------------------|-----------------------------------|
+| Scripts report success but real work failed | `/code:silent-degradation` — operation "succeeds" with zero results |
+| `|| true`, `2>/dev/null`, empty `catch {}`, `except: pass` suspected | `/code:antipatterns` — you want a broad multi-category scan |
+| Floating promises or ignored Go/Rust errors | `/code:review` — you want prose code review |
+| You need severity classification for error suppression | `/code:lint` — a linter already flags the issue |
+| You want a context-aware surfacing recommendation | `/code:dead-code` — you suspect code never runs |
+
+## Context
+
+- Scan path: `$ARGUMENTS` (defaults to current directory)
+- Language signals: !`find . -maxdepth 2 \( -name '*.sh' -o -name '*.bash' -o -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.jsx' -o -name '*.py' -o -name '*.go' -o -name '*.rs' \) -type f -not -path './node_modules/*' -not -path './.git/*'`
+- App-type signals (frontend): !`find . -maxdepth 2 \( -name 'index.html' -o -name 'vite.config.*' -o -name 'next.config.*' \) -type f`
+- App-type signals (CLI): !`find . -maxdepth 2 \( -name 'bin' -type d -o -name 'Makefile' -o -name 'justfile' \)`
+- App-type signals (service): !`find . -maxdepth 2 \( -name 'Dockerfile' -o -name '*.service' -o -name 'pyproject.toml' \) -type f`
+- Workflows: !`find .github/workflows -maxdepth 1 -name '*.yml' -type f`
+
+## Parameters
+
+Parse from `$ARGUMENTS`:
+
+- `PATH`: directory or file to scan (defaults to `.`)
+- `--lang <shell|js|py|go|rust|auto>`: restrict to one language (default `auto`)
+- `--severity <low|med|high>`: minimum severity to report (default `med`)
+- `--emit-patch`: generate a unified-diff patch on stdout instead of a report.
+  No in-place mutation. The user applies with `git apply`.
+
+## Execution
+
+Execute this error-swallowing scan:
+
+### Step 1: Detect languages and app context
+
+From the context commands above, determine which language matchers to run.
+For the app-context matrix (signals → surfacing channel), load
+[REFERENCE-surfacing.md](REFERENCE-surfacing.md).
+
+### Step 2: Run language-specific matchers
+
+Load only the REFERENCE files for languages actually present in the path:
+
+| Language | File | Tool |
+|----------|------|------|
+| Shell / bash | [REFERENCE-shell.md](REFERENCE-shell.md) | `bash ${CLAUDE_SKILL_DIR}/scripts/scan-shell.sh <path>` |
+| JavaScript / TypeScript | [REFERENCE-js.md](REFERENCE-js.md) | `sg` ast-grep with language-specific patterns |
+| Python | [REFERENCE-python.md](REFERENCE-python.md) | `sg` with `--lang py` |
+| Go | [REFERENCE-go.md](REFERENCE-go.md) | Prefer repo's `errcheck` if configured, else `sg --lang go` |
+| Rust | [REFERENCE-rust.md](REFERENCE-rust.md) | `sg --lang rust` + `clippy::let_underscore_must_use` hints |
+
+For each matcher, capture: `file:line`, matched snippet, surrounding function
+name if discoverable.
+
+### Step 3: Classify severity
+
+For every raw finding, assign **Low / Medium / High** using this matrix:
+
+| Severity | Criteria | Examples |
+|----------|----------|----------|
+| **Low** | Matches a documented allowlist entry *or* catch block has a log call + rethrow. | Frontmatter extraction `|| true` (see `.claude/rules/shell-scripting.md` lines 135–162); `except FileNotFoundError: pass` around an optional cache. |
+| **Medium** | Error suppressed with no log, no fallback value, no surfacing, on a recoverable operation. | `catch (e) {}` around a UI-layer fetch; `|| true` after `make lint`. |
+| **High** | Suppression around a required operation: data writes, auth, secret handling, config loading, release builds, push/deploy. | `npm publish 2>/dev/null || true`; `except: pass` around a DB commit; `_ = os.Remove(tmpPath)` on a path the caller assumed was cleaned. |
+
+Apply the per-language allowlist rules from each `REFERENCE-*.md` before
+assigning Low.
+
+### Step 4: Recommend a surfacing channel
+
+For each Medium/High finding, consult `REFERENCE-surfacing.md` to pick the
+channel appropriate to the detected app context. Do **not** recommend a
+uniform "log and rethrow" — the right channel differs:
+
+| App context | Recommended channel |
+|-------------|---------------------|
+| CLI / shell | `echo "warn: ..." >&2` + non-zero exit on High |
+| Web frontend | `console.error` + user-facing toast/banner with sanitized copy |
+| Web backend / daemon | Structured log (error ID) + generic 5xx + opaque user message |
+| Library | Re-raise / return `Result` / propagate — do not surface to user |
+| CI / build script | `echo "::error::..."` (GitHub) or stderr + non-zero exit |
+
+### Step 5: Apply privacy redaction
+
+Every suggested replacement text (in the report *and* in `--emit-patch`
+output) MUST be passed through the redaction rules in
+`REFERENCE-surfacing.md` §Privacy. Summary:
+
+1. Redact env values by name pattern (`*TOKEN*`, `*KEY*`, `*SECRET*`,
+   `*PASSWORD*`, `GH_*`, `ANTHROPIC_*`, `AWS_*`) → `[REDACTED]`.
+2. Rewrite absolute home paths (`$HOME`, `/Users/…`, `/home/…`) → `~`.
+3. Truncate message payloads at 200 characters.
+4. Prefer action-oriented copy over raw stderr forwarding.
+5. Never forward `set -x` / xtrace output.
+
+For web frontend, split: verbose detail → `console.error`; short sanitized
+copy → UI channel.
+
+### Step 6: Report findings
+
+Print:
+
+```
+Error-Swallowing Scan: <path>
+Detected app context: <cli|frontend|backend|library|daemon|ci>
+
+| Severity | File:Line       | Pattern                 | Recommended surfacing            |
+|----------|-----------------|-------------------------|----------------------------------|
+| High     | release.sh:42   | `npm publish ... \|\| true` | stderr + exit 1                  |
+| Medium   | api/fetch.ts:17 | empty catch             | console.error + toast (sanitized)|
+| Low      | build.sh:8      | frontmatter `\|\| true` | allowlisted — no change          |
+
+Totals: high=N, medium=N, low=N (across M files)
+```
+
+Group by severity descending; omit Low findings unless `--severity low`.
+
+### Step 7: Emit patch (if --emit-patch)
+
+Generate a unified diff (printed to stdout, not written to files) that:
+
+1. Covers only Medium/High findings.
+2. Applies the surfacing channel appropriate to the detected app context.
+3. Runs every inserted string through the Step 5 redaction rules.
+4. Includes a `# TODO(error-swallowing): review wording` comment next to
+   each generated user-facing message so the human can polish copy.
+
+Do not modify files in place. Remind the user: `git apply <patchfile>`.
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Default scan of repo | `/code:error-swallowing .` |
+| Shell only, high severity | `/code:error-swallowing . --lang shell --severity high` |
+| JS/TS in a subdir | `/code:error-swallowing src/ --lang js` |
+| Produce review-ready patch | `/code:error-swallowing src/ --emit-patch > /tmp/fix.patch` |
+
+## See Also
+
+- `/code:silent-degradation` — logical silent failures (zero-result success)
+- `/code:antipatterns` — delegates to this skill for the error-swallowing
+  category
+- `.claude/rules/shell-scripting.md` — canonical allowlist for shell
+  `|| true` / `2>/dev/null` usage
+- `REFERENCE-surfacing.md` — app-context → channel matrix and privacy rules

--- a/code-quality-plugin/skills/code-error-swallowing/fixtures/sample.sh
+++ b/code-quality-plugin/skills/code-error-swallowing/fixtures/sample.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Regression fixture for /code:error-swallowing scan-shell.sh.
+# Each line is annotated with its expected (severity, rule).
+
+set -euo pipefail
+
+# --- Low: allowlisted frontmatter extraction idiom ----------------------------
+extract_status() {
+  # Expected: Low | sh-or-true  (allowlisted: function name prefix "extract_")
+  head -50 "$1" | grep -m1 "^status:" | sed 's/^[^:]*:[[:space:]]*//' || true
+}
+
+# Expected: Low | sh-stderr-null  (allowlisted content regex: `command -v`)
+command -v jq >/dev/null 2>&1
+
+# --- Medium: generic suppression on recoverable op ---------------------------
+# Expected: Medium | sh-or-true
+make lint || true
+
+# Expected: Medium | sh-stderr-null
+ls /tmp/maybe-missing 2>/dev/null
+
+# Expected: Medium | sh-set-plus-e
+set +e
+
+# --- High: suppression around a destructive/required op ----------------------
+# Expected: High | sh-or-true  (promoted by `npm publish`)
+npm publish --tag latest || true
+
+# Expected: High | sh-both-null  (promoted by `git push`)
+git push origin main >/dev/null 2>&1
+
+# Expected: High | sh-or-true  (promoted by `rm -rf`)
+rm -rf /var/app/state || true

--- a/code-quality-plugin/skills/code-error-swallowing/scripts/scan-shell.sh
+++ b/code-quality-plugin/skills/code-error-swallowing/scripts/scan-shell.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# scan-shell.sh — shell/bash error-swallowing scanner for
+# /code:error-swallowing. Paired rules: REFERENCE-shell.md
+#
+# Output format (pipe-delimited, stable for machine parsing):
+#   <severity>|<rule>|<file>:<line>|<snippet>
+#
+# Exit codes:
+#   0 - no Medium/High findings
+#   1 - Medium findings present, no High
+#   2 - High findings present
+#
+# Usage:
+#   scan-shell.sh <path> [--min-severity low|med|high]
+#   scan-shell.sh --self-test
+set -uo pipefail
+
+# Defensive: allow this script to be invoked outside a shell that sets -e,
+# so that grep-miss exit codes don't terminate the whole scan.
+
+scan_path=""
+min_sev="med"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --min-severity) min_sev="$2"; shift 2 ;;
+    --self-test)
+      # Re-exec against the bundled fixture
+      fixture_dir="$(dirname "$0")/../fixtures"
+      if [[ ! -d "$fixture_dir" ]]; then
+        echo "self-test: fixture dir missing: $fixture_dir" >&2
+        exit 3
+      fi
+      exec bash "$0" "$fixture_dir" --min-severity low
+      ;;
+    --) shift; break ;;
+    -*) shift ;;
+    *) scan_path="$1"; shift ;;
+  esac
+done
+scan_path="${scan_path:-.}"
+
+if [[ ! -e "$scan_path" ]]; then
+  echo "scan-shell.sh: path not found: $scan_path" >&2
+  exit 3
+fi
+
+# High-operation promotion regex. Any line containing one of these promotes
+# a Medium finding to High.
+high_op_regex='(npm publish|yarn publish|pnpm publish|cargo publish|gh release|git push|git tag|docker push|helm upgrade|kubectl apply|terraform apply|aws s3 (cp|sync)|rclone copy|psql.*(INSERT|UPDATE|DELETE|DROP)|curl.*(-X *POST|-X *PUT|-X *DELETE|--request POST|--request PUT|--request DELETE)|rm -rf)'
+
+# Low-allowlist: line content patterns that downgrade to Low regardless of
+# default severity. These mirror REFERENCE-shell.md "Allowlist".
+allowlist_regex='(head -[0-9]+ "?\$[a-zA-Z_]+"? *\| *grep -m1 "\^[a-zA-Z_]+:"|command -v [a-zA-Z0-9_./-]+ *>/dev/null|rm -f [^|;&]+$|mkdir -p |2>/dev/null\s*\|\|\s*true)'
+
+# Allowlisted function-name prefixes (if the enclosing function name begins
+# with one of these, treat the line as Low).
+allowlist_fn_prefix_regex='^(extract|probe|has|is|check)_'
+
+# Collect shell files. Accept a single file too.
+declare -a files
+if [[ -f "$scan_path" ]]; then
+  files=("$scan_path")
+else
+  while IFS= read -r -d '' f; do
+    files+=("$f")
+  done < <(
+    find "$scan_path" -type f \
+      \( -name '*.sh' -o -name '*.bash' \) \
+      -not -path '*/node_modules/*' \
+      -not -path '*/.git/*' \
+      -not -path '*/vendor/*' \
+      -print0 2>/dev/null
+  )
+fi
+
+if [[ ${#files[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+high_count=0
+med_count=0
+low_count=0
+
+sev_rank() {
+  case "$1" in
+    High) echo 3 ;;
+    Medium) echo 2 ;;
+    Low) echo 1 ;;
+    *) echo 0 ;;
+  esac
+}
+min_rank=$(case "$min_sev" in
+  high) echo 3 ;;
+  med|medium) echo 2 ;;
+  low) echo 1 ;;
+  *) echo 2 ;;
+esac)
+
+# Track enclosing function name per-file using a simple forward scan.
+# Used to demote lines inside probe_*/extract_*/... to Low.
+
+scan_file() {
+  local file="$1"
+  local lineno=0
+  local fn_name=""
+  while IFS= read -r line; do
+    lineno=$((lineno + 1))
+
+    # Update fn_name when we see a function opener.
+    # Patterns: `funcname() {` or `function funcname {`.
+    # Reset on a closing `}` at column 0 — naive but sufficient for the
+    # conventions in this codebase.
+    if [[ "$line" =~ ^[[:space:]]*([a-zA-Z_][a-zA-Z0-9_]*)\(\)[[:space:]]*\{ ]]; then
+      fn_name="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ ^[[:space:]]*function[[:space:]]+([a-zA-Z_][a-zA-Z0-9_]*) ]]; then
+      fn_name="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ ^\}[[:space:]]*$ ]]; then
+      fn_name=""
+    fi
+
+    # Skip comments/blank lines
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+    [[ -z "${line// }" ]] && continue
+
+    local rule="" sev=""
+
+    # sh-or-true: `cmd || true` or `cmd || :` (but NOT `|| echo ""` and
+    # not `|| <cmd-that-actually-handles>` — we treat "handles" as anything
+    # besides `true` / `:`).
+    if [[ "$line" =~ \|\|[[:space:]]+(true|:)([[:space:]]|$) ]]; then
+      rule="sh-or-true"; sev="Medium"
+    # sh-both-null: `>/dev/null 2>&1` or `&>/dev/null`
+    elif [[ "$line" =~ \>/dev/null[[:space:]]+2\>\&1 ]] || [[ "$line" =~ \&\>/dev/null ]]; then
+      rule="sh-both-null"; sev="Medium"
+    # sh-stderr-null: `2>/dev/null`
+    elif [[ "$line" =~ 2\>/dev/null ]]; then
+      rule="sh-stderr-null"; sev="Medium"
+    # sh-set-plus-e
+    elif [[ "$line" =~ ^[[:space:]]*set[[:space:]]+\+e([[:space:]]|$) ]]; then
+      rule="sh-set-plus-e"; sev="Medium"
+    # sh-trap-empty: trap '' ERR or trap - ERR
+    elif [[ "$line" =~ ^[[:space:]]*trap[[:space:]]+(\'\'|-)[[:space:]]+ERR ]]; then
+      rule="sh-trap-empty"; sev="Medium"
+    else
+      continue
+    fi
+
+    # Allowlist → Low
+    if [[ "$line" =~ $allowlist_regex ]]; then
+      sev="Low"
+    elif [[ -n "$fn_name" && "$fn_name" =~ $allowlist_fn_prefix_regex ]]; then
+      sev="Low"
+    # Promote to High on dangerous operations
+    elif [[ "$line" =~ $high_op_regex ]]; then
+      sev="High"
+    fi
+
+    # Filter by min severity
+    local rank
+    rank=$(sev_rank "$sev")
+    if [[ "$rank" -lt "$min_rank" ]]; then
+      continue
+    fi
+
+    # Trim snippet
+    local snippet="${line#"${line%%[![:space:]]*}"}"
+    snippet="${snippet//|/\\|}"
+    if [[ ${#snippet} -gt 160 ]]; then
+      snippet="${snippet:0:157}..."
+    fi
+
+    printf '%s|%s|%s:%d|%s\n' "$sev" "$rule" "$file" "$lineno" "$snippet"
+
+    case "$sev" in
+      High) high_count=$((high_count + 1)) ;;
+      Medium) med_count=$((med_count + 1)) ;;
+      Low) low_count=$((low_count + 1)) ;;
+    esac
+  done < "$file"
+}
+
+for f in "${files[@]}"; do
+  scan_file "$f"
+done
+
+# Summary on stderr so stdout stays pipe-friendly
+printf '\n' >&2
+printf 'scan-shell summary: high=%d medium=%d low=%d files=%d\n' \
+  "$high_count" "$med_count" "$low_count" "${#files[@]}" >&2
+
+if [[ "$high_count" -gt 0 ]]; then
+  exit 2
+elif [[ "$med_count" -gt 0 ]]; then
+  exit 1
+else
+  exit 0
+fi

--- a/code-quality-plugin/skills/code-error-swallowing/scripts/test-fixture.sh
+++ b/code-quality-plugin/skills/code-error-swallowing/scripts/test-fixture.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Regression test for scan-shell.sh.
+# Runs the scanner against fixtures/sample.sh and asserts exact counts
+# per severity. Any drift in classification rules — allowlist matching,
+# high-op promotion, function-scope tracking — will cause this to fail.
+#
+# Exit code 0 on success, non-zero with a diff on failure.
+set -uo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+scanner="$here/scan-shell.sh"
+fixture="$here/../fixtures/sample.sh"
+
+if [[ ! -x "$scanner" ]]; then
+  echo "FAIL: scanner not executable: $scanner" >&2
+  exit 1
+fi
+if [[ ! -f "$fixture" ]]; then
+  echo "FAIL: fixture missing: $fixture" >&2
+  exit 1
+fi
+
+# Run with --min-severity low so all severities appear in output.
+# Capture stdout (findings) and exit code; stderr (summary) is discarded.
+output=$(bash "$scanner" "$fixture" --min-severity low 2>/dev/null)
+exit_code=$?
+
+high=$(printf '%s\n' "$output" | grep -c '^High|' || true)
+med=$(printf '%s\n'  "$output" | grep -c '^Medium|' || true)
+low=$(printf '%s\n'  "$output" | grep -c '^Low|' || true)
+
+# Expected from fixtures/sample.sh annotations:
+#   Low=2, Medium=3, High=3
+#   exit code 2 (High findings present)
+expected_high=3
+expected_med=3
+expected_low=2
+expected_exit=2
+
+failed=0
+if [[ "$high" -ne "$expected_high" ]]; then
+  printf 'FAIL: High count: got %d, expected %d\n' "$high" "$expected_high" >&2
+  failed=1
+fi
+if [[ "$med" -ne "$expected_med" ]]; then
+  printf 'FAIL: Medium count: got %d, expected %d\n' "$med" "$expected_med" >&2
+  failed=1
+fi
+if [[ "$low" -ne "$expected_low" ]]; then
+  printf 'FAIL: Low count: got %d, expected %d\n' "$low" "$expected_low" >&2
+  failed=1
+fi
+if [[ "$exit_code" -ne "$expected_exit" ]]; then
+  printf 'FAIL: exit code: got %d, expected %d\n' "$exit_code" "$expected_exit" >&2
+  failed=1
+fi
+
+if [[ "$failed" -ne 0 ]]; then
+  echo "" >&2
+  echo "Scanner output was:" >&2
+  printf '%s\n' "$output" >&2
+  exit 1
+fi
+
+echo "OK: scan-shell.sh fixture (High=$high Medium=$med Low=$low, exit=$exit_code)"


### PR DESCRIPTION
## Summary

Introduces a new `/code:error-swallowing` skill that detects syntactic patterns where errors are suppressed without proper surfacing—including shell `|| true` and `2>/dev/null` idioms, empty catch blocks in JavaScript/TypeScript, bare `except: pass` in Python, ignored error returns in Go, and discarded Results in Rust.

## Key Changes

- **New skill: `/code:error-swallowing`** with multi-language support
  - Shell/Bash scanner (`scripts/scan-shell.sh`) with regex-based pattern detection
  - Language-specific reference guides for JavaScript/TypeScript, Python, Go, and Rust
  - Context-aware severity classification (Low/Medium/High) with promotion rules for dangerous operations
  - Privacy redaction policy for suggested replacements (env vars, home paths, truncation)
  - App-context detection matrix (CLI, web frontend, web backend, daemon, library, CI) to recommend appropriate error surfacing channels

- **Shell scanner implementation** (`scripts/scan-shell.sh`)
  - Detects 5 core patterns: `|| true`, `2>/dev/null`, `&>/dev/null`, `set +e`, `trap '' ERR`
  - Allowlist support for documented safe idioms (frontmatter extraction, `command -v` probes, `rm -f`, `mkdir -p`)
  - Function-scope tracking to demote probe helpers (`extract_*`, `has_*`, `check_*`) to Low
  - High-operation regex promotion for destructive/required operations (npm publish, git push, rm -rf, kubectl apply, etc.)
  - Pipe-delimited output format for machine parsing; exit codes: 0 (no findings), 1 (Medium), 2 (High)

- **Reference documentation** for each language
  - `REFERENCE-shell.md`: Shell patterns, allowlist, remediation templates
  - `REFERENCE-js.md`: ast-grep patterns for empty catch, floating promises, error boundaries
  - `REFERENCE-python.md`: Bare except, broad except, contextlib.suppress patterns
  - `REFERENCE-go.md`: Underscore assignment, errcheck integration, defer Close handling
  - `REFERENCE-rust.md`: let underscore, .ok() discard, unwrap_or_default patterns
  - `REFERENCE-surfacing.md`: Context-aware surfacing matrix (CLI stderr, web toast, structured log, re-raise) and privacy redaction rules

- **Test fixture** (`fixtures/sample.sh`) with regression assertions
  - Validates scanner classification: Low (2), Medium (3), High (3) findings
  - Covers allowlist matching, function-scope demotion, and high-op promotion

- **Integration updates**
  - Updated `/code:antipatterns` to delegate error-swallowing patterns (empty catch, floating promises) to the new skill
  - Added skill to plugin registry with `error-handling` and `error-swallowing` tags

## Notable Implementation Details

- **Severity model**: Starts from pattern-specific defaults, then applies allowlist demotion and high-operation promotion in a single pass
- **Privacy-first**: All suggested replacement text redacts env values by name pattern, rewrites home paths, truncates payloads, and prefers action-oriented copy over raw stderr
- **App-context aware**: Recommends different surfacing channels (echo to stderr for CLI, toast for frontend, structured log for backend, re-raise for libraries) based on detected application type
- **Machine-parseable output**: Pipe-delimited format (`severity|rule|file:line|snippet`) enables downstream tooling and CI integration

https://claude.ai/code/session_01VnN21KnSd9vLNKEBnZMa9T