### PR TITLE
refactor: model field from skill compliance checks

### DIFF
--- a/scripts/blueprint-health-check.sh
+++ b/scripts/blueprint-health-check.sh
@@ -111,7 +111,6 @@ while IFS= read -r -d '' plugin_dir; do
     skill_name_field=$(extract_field "$skill_file" "name")
     skill_desc=$(extract_field "$skill_file" "description")
     skill_allowed_tools=$(extract_field "$skill_file" "allowed-tools")
-    skill_model=$(extract_field "$skill_file" "model")
     skill_created=$(extract_field "$skill_file" "created")
     skill_modified=$(extract_field "$skill_file" "modified")
     skill_reviewed=$(extract_field "$skill_file" "reviewed")
@@ -123,8 +122,9 @@ while IFS= read -r -d '' plugin_dir; do
     [ -z "$skill_allowed_tools" ] && missing_required+="allowed-tools, "
 
     # Check recommended fields
+    # Note: `model` is intentionally not checked. Skills should inherit the
+    # user's active model by default — see .claude/rules/skill-development.md.
     missing_recommended=""
-    [ -z "$skill_model" ] && missing_recommended+="model, "
     [ -z "$skill_created" ] && missing_recommended+="created, "
     [ -z "$skill_modified" ] && missing_recommended+="modified, "
     [ -z "$skill_reviewed" ] && missing_recommended+="reviewed, "

--- a/scripts/plugin-compliance-check.sh
+++ b/scripts/plugin-compliance-check.sh
@@ -148,12 +148,10 @@ check_skill_frontmatter() {
     fm_reviewed=$(extract_field "$skill_file" "reviewed")
 
     local missing_recommended=()
-    # Skills using AskUserQuestion must omit model: haiku (or omit model entirely).
-    # Omitting model is the documented correct approach for interactive skills, so
-    # do not flag missing model as a recommendation for them.
-    local uses_ask_user_question=false
-    echo "$fm_allowed_tools" | grep -q "AskUserQuestion" && uses_ask_user_question=true
-    [ -z "$fm_model" ] && ! $uses_ask_user_question && missing_recommended+=("model")
+    # Note: `model` is intentionally not checked here. Skills should inherit the
+    # user's active model by default — see .claude/rules/skill-development.md
+    # ("Model Selection"). The only model-related check is the regression below
+    # that rejects `model: haiku` alongside AskUserQuestion.
     [ -z "$fm_created" ] && missing_recommended+=("created")
     [ -z "$fm_modified" ] && missing_recommended+=("modified")
     [ -z "$fm_reviewed" ] && missing_recommended+=("reviewed")


### PR DESCRIPTION
## Summary
Updated skill compliance checks to no longer require or recommend the `model` field in skill frontmatter. Skills should inherit the user's active model by default rather than specifying a model explicitly.

## Changes
- **plugin-compliance-check.sh**: Removed the logic that flagged missing `model` as a recommended field. Replaced the conditional check with a clarifying comment explaining that model selection is intentionally not enforced, with skills inheriting the user's active model by default.
- **blueprint-health-check.sh**: Removed extraction and validation of the `skill_model` field from the health check. Added a matching explanatory comment about intentional model field omission.

## Implementation Details
- Both scripts previously checked for missing `model` fields and flagged them as recommended metadata
- The changes align with the documented skill development guidelines (`.claude/rules/skill-development.md`)
- The special handling for `AskUserQuestion` tools (which previously exempted them from the model check) is no longer needed
- Skills will now consistently inherit the user's configured model rather than having individual model specifications

https://claude.ai/code/session_01UJqjbdgY6yHSDqS2RX7W2J