### PR TITLE
docs(plugins): add flow diagrams for router and pipeline plugins

### DIFF
--- a/.claude/rules/plugin-flow-diagrams.md
+++ b/.claude/rules/plugin-flow-diagrams.md
@@ -1,0 +1,55 @@
+# Plugin Flow Diagrams
+
+Codifies when a plugin earns a Mermaid flow diagram, where it lives, and what conventions to follow.
+
+Canonical example: [`health-plugin/docs/flow.md`](../../health-plugin/docs/flow.md).
+
+## When to add a diagram
+
+Add `docs/flow.md` if **any** of the following apply:
+
+- **Router / delegation pattern** — one skill orchestrates others (e.g. `/health:check` → scope-specific sub-skills)
+- **Ordered pipeline** — skills have real sequencing (A → B → C), not just coexistence
+- **>15 skills** where visual grouping meaningfully clarifies scope
+- **Cross-skill integration** worth showing — shared artefacts, data handoffs, conditional branches
+
+## When NOT to add a diagram
+
+Skip if the plugin is a flat collection of independent tools. The README's Skills table **is** the diagram.
+
+Examples of flat bags (no diagram): `tools-plugin`, `python-plugin`, `rust-plugin`, `typescript-plugin`, `networking-plugin`, `obsidian-plugin`, `home-assistant-plugin`, `finops-plugin`, `testing-plugin`, `container-plugin`, `kubernetes-plugin`, `css-plugin`, `api-plugin`, `documentation-plugin`, `accessibility-plugin`, `migration-patterns-plugin`, `communication-plugin`, `prose-plugin`, `bevy-plugin`, `code-quality-plugin`, `langchain-plugin`, `github-actions-plugin`, `agent-patterns-plugin`, `component-patterns-plugin`, `blog-plugin`.
+
+A bad diagram (boxes without flow) is worse than no diagram.
+
+## Location and format
+
+- Path: `<plugin>/docs/flow.md`
+- Diagram type: Mermaid `flowchart TD`
+- Include a **Legend** table and a **scope → skill mapping** table beneath the diagram
+
+## Node colour conventions
+
+Use Mermaid `classDef` with these semantics:
+
+| Class | Fill | Meaning |
+|-------|------|---------|
+| `router` | Blue (`#4a9eff`) | Top-level orchestrating skill |
+| `check` | Green (`#8fbc8f`) | Read-only diagnostic / analysis |
+| `fix` | Orange (`#ffa500`) | Writes files / mutates state |
+| `prompt` | Purple (`#dda0dd`) | Interactive `AskUserQuestion` prompt |
+
+Copy the `classDef` block from `health-plugin/docs/flow.md` verbatim and assign only the classes that apply.
+
+## Linking from the README
+
+Add an **Overview** (or **Flow**) section near the top of the plugin README:
+
+```markdown
+## Flow
+
+See [`docs/flow.md`](docs/flow.md) for a diagram of how the skills fit together.
+```
+
+## Drift warning
+
+These diagrams are **not** CI-tested. Keep them coarse enough that adding or removing a single skill rarely invalidates the diagram — group fine-grained skills under a single node rather than drawing every skill individually. Prefer capturing *the pattern* over *every skill*.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ Claude Code plugin collection providing skills and agents for development workfl
 | `.claude/rules/skill-fork-context.md` | When to set `context: fork` and `agent:` on skills |
 | `.claude/rules/regression-testing.md` | **Required**: add a script check for every skill bug fixed |
 | `.claude/rules/sandbox-guidance.md` | Sandbox constraints, `CLAUDE_CODE_REMOTE` detection, and remote/local skill patterns |
+| `.claude/rules/plugin-flow-diagrams.md` | When and how to add Mermaid flow diagrams |
 
 ## Creating New Skills
 

--- a/agents-plugin/README.md
+++ b/agents-plugin/README.md
@@ -2,6 +2,10 @@
 
 Task-focused agents following 12-factor agent principles. Each agent completes a bounded task (3-20 steps) and can operate as a teammate (parallel, communicating) or subagent (focused, isolated).
 
+## Flow
+
+See [`docs/flow.md`](docs/flow.md) for a diagram of how `attribute-router` delegates to the domain agents.
+
 ## Agents
 
 | Agent | Model | Purpose | Team Role |

--- a/agents-plugin/docs/flow.md
+++ b/agents-plugin/docs/flow.md
@@ -1,0 +1,60 @@
+# Agents Plugin Flow
+
+```mermaid
+flowchart TD
+    U[User / Workflow] -->|attribute data<br/>.claude/attributes.json| R[attribute-router<br/>load → filter → prioritize]
+
+    R --> PRI{severity<br/>weights<br/>crit=4 high=3<br/>med=2 low=1}
+
+    PRI -->|security<br/>critical/high| SEC[security-audit<br/>OWASP, CVEs]
+    PRI -->|deps<br/>any| DEP[dependency-audit<br/>CVE scan, licenses]
+    PRI -->|quality<br/>high+| REF[refactor<br/>SOLID, restructure]
+    PRI -->|quality<br/>medium| REV[review<br/>code review]
+    PRI -->|bugs<br/>any| DBG[debug<br/>diagnose, fix]
+    PRI -->|tests<br/>any| TST[test<br/>scaffold, run]
+    PRI -->|performance<br/>any| PRF[performance<br/>profile, bench]
+    PRI -->|docs<br/>any| DOC[docs<br/>fill gaps]
+    PRI -->|ci<br/>any| CI[ci<br/>pipelines]
+    PRI -->|research<br/>needed| RES[research<br/>docs, APIs]
+    PRI -->|bulk edits| SR[search-replace<br/>cross-file rename]
+
+    SEC & DEP & REV & PRF & DOC & RES --> SUM[Routing Summary<br/>addressed vs remaining]
+    REF & DBG & TST & CI & SR --> SUM
+
+    classDef router fill:#4a9eff,stroke:#1a6ecc,color:#fff
+    classDef check fill:#8fbc8f,stroke:#556b55,color:#000
+    classDef fix fill:#ffa500,stroke:#b37400,color:#000
+    classDef prompt fill:#dda0dd,stroke:#8b5a8b,color:#000
+
+    class R router
+    class SEC,DEP,REV,PRF,DOC,RES check
+    class REF,DBG,TST,CI,SR fix
+    class PRI prompt
+```
+
+## Legend
+
+| Node style | Meaning |
+|------------|---------|
+| Blue | Router agent (`attribute-router`) |
+| Green | Read-only analysis agent (audit, review, profile, research, docs) |
+| Orange | Write-capable agent (mutates code, tests, CI config) |
+| Purple | Severity / category decision point |
+
+## Category → Agent mapping
+
+| Attribute category | Severity threshold | Agent | Role |
+|--------------------|--------------------|-------|------|
+| `security` | critical / high | `security-audit` | Analysis |
+| `dependencies` | any | `dependency-audit` | Analysis |
+| `quality` | high+ | `refactor` | Write |
+| `quality` | medium | `review` | Analysis |
+| `bugs` | any | `debug` | Write |
+| `tests` | any | `test` | Write |
+| `performance` | any | `performance` | Analysis |
+| `docs` | any | `docs` | Analysis |
+| `ci` | any | `ci` | Write |
+| `research` | any | `research` | Analysis |
+| `bulk-edit` | any | `search-replace` | Write |
+
+Priority = sum of severity weights (critical=4, high=3, medium=2, low=1) across findings routed to each agent; higher totals run first.

--- a/blueprint-plugin/README.md
+++ b/blueprint-plugin/README.md
@@ -2,6 +2,10 @@
 
 Blueprint Development methodology for Claude Code - structured feature development with PRDs, PRPs, and work-orders.
 
+## Flow
+
+See [`docs/flow.md`](docs/flow.md) for a diagram of how the skills fit together.
+
 ## Overview
 
 This plugin provides a documentation-first development workflow:

--- a/blueprint-plugin/docs/flow.md
+++ b/blueprint-plugin/docs/flow.md
@@ -1,0 +1,100 @@
+# Blueprint Plugin Flow
+
+```mermaid
+flowchart TD
+    U[User] -->|/blueprint:execute| EX["/blueprint:execute<br/>(router: detects repo state)"]
+
+    EX --> INIT[blueprint-init<br/>scaffold docs/blueprint/<br/>prds/ adrs/ prps/]
+
+    subgraph DERIVE["Derive from existing code (optional side-path)"]
+        direction TB
+        DP[blueprint-derive-prd]
+        DA[blueprint-derive-adr]
+        DPL[blueprint-derive-plans]
+        DR[blueprint-derive-rules]
+        DT[blueprint-derive-tests]
+    end
+
+    INIT -.->|brownfield| DERIVE
+
+    INIT --> PRD[Stage 1: PRD<br/>docs/prds/PRD-NNN]
+    DERIVE --> PRD
+
+    PRD --> ADR[Stage 2: ADR<br/>docs/adrs/ADR-NNNN<br/>blueprint-adr-validate<br/>adr-relationships]
+
+    ADR --> PRP[Stage 3: PRP<br/>blueprint-prp-create<br/>+ confidence-scoring<br/>+ blueprint-curate-docs]
+
+    PRP --> WO[blueprint-work-order<br/>isolated task package]
+
+    WO --> RUN[Stage 4: Execute<br/>blueprint-prp-execute<br/>TDD RED->GREEN->REFACTOR]
+
+    RUN --> TRACK[feature-tracking<br/>blueprint-feature-tracker-sync<br/>blueprint-feature-tracker-status]
+
+    subgraph META["Cross-cutting management"]
+        direction TB
+        SID[blueprint-sync-ids<br/>assign IDs,<br/>traceability registry]
+        SYNC[blueprint-sync<br/>blueprint-claude-md<br/>blueprint-generate-rules]
+        PROM[blueprint-promote<br/>child -> root rollup]
+        LIST[blueprint-docs-list<br/>blueprint-adr-list<br/>blueprint-status]
+        UPG[blueprint-upgrade<br/>blueprint-migration<br/>blueprint-workspace-scan]
+    end
+
+    PRD -.-> SID
+    ADR -.-> SID
+    PRP -.-> SID
+    SID -.-> SYNC
+    TRACK -.-> PROM
+
+    EX -.->|idempotent<br/>check state| LIST
+    EX -.->|format drift| UPG
+
+    subgraph VALID["Validation hooks (PreToolUse)"]
+        direction TB
+        VA[validate-adr-frontmatter.sh]
+        VP[validate-prp-frontmatter.sh]
+        CR[check-prp-readiness.sh<br/>confidence >= 7/10]
+    end
+
+    ADR -.->|on Write/Edit| VA
+    PRP -.->|on Write/Edit| VP
+    RUN -.->|on Skill invoke| CR
+
+    classDef router fill:#4a9eff,stroke:#1a6ecc,color:#fff
+    classDef check fill:#8fbc8f,stroke:#556b55,color:#000
+    classDef fix fill:#ffa500,stroke:#b37400,color:#000
+    classDef prompt fill:#dda0dd,stroke:#8b5a8b,color:#000
+
+    class EX router
+    class DP,DA,DPL,DR,DT,LIST,VA,VP,CR check
+    class INIT,PRD,ADR,PRP,WO,RUN,TRACK,SID,SYNC,PROM,UPG fix
+```
+
+## Legend
+
+| Node style | Meaning |
+|------------|---------|
+| Blue | Router skill (`/blueprint:execute`) |
+| Green | Read-only analysis / listing / validation |
+| Orange | Skills that create or mutate blueprint artefacts |
+| Purple | Interactive `AskUserQuestion` prompt (none currently) |
+
+Solid arrows are the main spine (PRD -> ADR -> PRP -> execute).
+Dotted arrows are optional side-paths and cross-cutting concerns.
+
+## Stage -> Skill mapping
+
+| Stage | Skills |
+|-------|--------|
+| Bootstrap | `blueprint-init`, `blueprint-execute` (router) |
+| Derive (brownfield) | `blueprint-derive-prd`, `blueprint-derive-adr`, `blueprint-derive-plans`, `blueprint-derive-rules`, `blueprint-derive-tests` |
+| PRD | `blueprint-development`, `document-detection`, `document-linking` |
+| ADR | `blueprint-adr-validate`, `blueprint-adr-list`, `adr-relationships` |
+| PRP | `blueprint-prp-create`, `blueprint-curate-docs`, `confidence-scoring` |
+| Execute | `blueprint-work-order`, `blueprint-prp-execute` |
+| Feature tracking | `feature-tracking`, `blueprint-feature-tracker-sync`, `blueprint-feature-tracker-status` |
+| Cross-cutting: IDs | `blueprint-sync-ids` |
+| Cross-cutting: sync | `blueprint-sync`, `blueprint-claude-md`, `blueprint-generate-rules`, `blueprint-rules` |
+| Cross-cutting: promote | `blueprint-promote` (child -> root monorepo rollup) |
+| Cross-cutting: listing/status | `blueprint-docs-list`, `blueprint-adr-list`, `blueprint-status` |
+| Cross-cutting: migration | `blueprint-upgrade`, `blueprint-migration`, `blueprint-workspace-scan` |
+| Validation | `validate-prp-frontmatter.sh`, `validate-adr-frontmatter.sh`, `check-prp-readiness.sh` |

--- a/codebase-attributes-plugin/README.md
+++ b/codebase-attributes-plugin/README.md
@@ -2,6 +2,10 @@
 
 Structured codebase health attributes with severity-based agent routing.
 
+## Flow
+
+See [`docs/flow.md`](docs/flow.md) for a diagram of how the skills fit together.
+
 ## Skills
 
 | Skill | Description |

--- a/codebase-attributes-plugin/docs/flow.md
+++ b/codebase-attributes-plugin/docs/flow.md
@@ -1,0 +1,66 @@
+# Codebase Attributes Plugin Flow
+
+```mermaid
+flowchart TD
+    SRC[Source code<br/>README, tests, CI,<br/>lockfiles, SCA config]
+    SRC -->|scan file:line signals| COL["/attributes:collect<br/>(collector)"]
+
+    COL -->|emit structured JSON| STORE[(Attribute data store<br/>id • category • severity<br/>description • source • actions)]
+
+    STORE --> ROUTE["/attributes:route<br/>(router)"]
+    ROUTE --> SEV{severity<br/>+ category}
+
+    SEV -->|critical / high<br/>category=security| SEC[security-audit agent]
+    SEV -->|high / medium<br/>category=tests| TST[test agent]
+    SEV -->|medium / low<br/>category=docs| DOC[documentation agent]
+    SEV -->|medium<br/>category=quality| QUAL[code-review agent]
+    SEV -->|info / low<br/>category=ci| CI[cicd agent]
+
+    STORE --> DASH["/attributes:dashboard<br/>(visualizer)<br/>render severity counts,<br/>top findings, remediation hints"]
+
+    SEC & TST & DOC & QUAL & CI -->|remediation actions| OUT[Fixes / PRs / issues]
+    DASH --> TERM[Terminal-style<br/>health overview]
+
+    classDef router fill:#4a9eff,stroke:#1a6ecc,color:#fff
+    classDef check fill:#8fbc8f,stroke:#556b55,color:#000
+    classDef fix fill:#ffa500,stroke:#b37400,color:#000
+    classDef store fill:#e8e8e8,stroke:#666,color:#000
+    classDef prompt fill:#dda0dd,stroke:#8b5a8b,color:#000
+
+    class COL,DASH check
+    class ROUTE router
+    class STORE store
+    class SEC,TST,DOC,QUAL,CI fix
+    class SEV prompt
+```
+
+## Legend
+
+| Node style | Meaning |
+|------------|---------|
+| Blue | Router skill (`/attributes:route`) |
+| Green | Read-only collector / visualizer skill |
+| Orange | Downstream agent that may mutate code |
+| Grey | Shared attribute data store (JSON) |
+| Purple | Routing decision (severity + category) |
+
+## Stage → Skill mapping
+
+| Stage | Skill / Agent | Input | Output |
+|-------|---------------|-------|--------|
+| Collect | `/attributes:collect` | Source tree (README, tests, CI, lockfiles, linter config) | Attribute JSON: `{id, category, severity, description, source, actions}` keyed by `file:line` |
+| Store | (in-memory / file artefact) | Collector output | Normalised attribute list consumed by router + dashboard |
+| Route | `/attributes:route` | Attribute JSON | Agent delegations keyed by `(category, severity)` |
+| Act | `security-audit`, `test`, `documentation`, `code-review`, `cicd` agents | Routed attributes + remediation `actions` | Fixes, PRs, issues |
+| Visualize | `/attributes:dashboard` | Attribute JSON | Terminal health dashboard grouped by category and severity |
+
+## Data contract
+
+Attributes flowing between stages carry:
+
+- **Location** — `file:line` (plus optional column) so downstream agents can jump straight to the offending site
+- **Category** — `docs` · `tests` · `security` · `quality` · `ci`
+- **Severity** — `critical` · `high` · `medium` · `low` · `info` (drives routing priority and dashboard colouring)
+- **Actions** — array of `{agent, command, rationale}` entries; the router uses `agent` as its dispatch key
+
+Integration: the `git-repo-agent` Python tool emits the same JSON schema, so it can substitute for `/attributes:collect` without changing downstream stages.

--- a/configure-plugin/README.md
+++ b/configure-plugin/README.md
@@ -2,6 +2,10 @@
 
 Infrastructure standards enforcement for Claude Code projects.
 
+## Flow
+
+See [`docs/flow.md`](docs/flow.md) for a diagram of how the skills fit together.
+
 ## Overview
 
 This plugin provides comprehensive project configuration commands that check and enforce infrastructure standards across multiple domains: CI/CD, testing, code quality, containers, and more.

--- a/configure-plugin/docs/flow.md
+++ b/configure-plugin/docs/flow.md
@@ -1,0 +1,72 @@
+# Configure Plugin Flow
+
+```mermaid
+flowchart TD
+    U[User] -->|/configure:all<br/>--check-only --fix| R["/configure:all<br/>(router)"]
+    U -->|/configure:status| STATUS[configure-status<br/>read-only compliance report]
+    U -->|/configure:select| SELECT[configure-select<br/>AskUserQuestion<br/>pick domains]
+
+    R --> MODE{--fix or<br/>--check-only?}
+    SELECT --> MODE
+
+    MODE --> CI[CI / Workflows<br/>• configure-workflows<br/>• configure-reusable-workflows<br/>• configure-release-please<br/>• configure-argocd-automerge<br/>• configure-github-pages<br/>• configure-claude-plugins]
+
+    MODE --> CONT[Containers & Deploy<br/>• configure-dockerfile<br/>• configure-container<br/>• configure-skaffold]
+
+    MODE --> TEST[Testing<br/>• configure-tests<br/>• configure-coverage<br/>• configure-api-tests<br/>• configure-integration-tests<br/>• configure-load-tests<br/>• configure-memory-profiling<br/>• configure-ux-testing]
+
+    MODE --> QUAL[Lint / Format / Dead code<br/>• configure-linting<br/>• configure-formatting<br/>• configure-dead-code<br/>• configure-pre-commit]
+
+    MODE --> SEC[Security<br/>• configure-security<br/>• claude-security-settings]
+
+    MODE --> DOCS[Docs<br/>• configure-docs<br/>• configure-readme]
+
+    MODE --> FF[Feature flags<br/>• configure-feature-flags<br/>• openfeature<br/>• go-feature-flag]
+
+    MODE --> PKG[Package management<br/>• configure-package-management<br/>• configure-cache-busting]
+
+    MODE --> EDIT[Editor / Dev env<br/>• configure-editor<br/>• configure-mcp<br/>• configure-makefile<br/>• configure-justfile<br/>• configure-web-session<br/>• configure-sentry]
+
+    CI & CONT & TEST & QUAL & SEC & DOCS & FF & PKG & EDIT --> RPT[Consolidated report<br/>per-domain compliance]
+
+    RPT --> FIXQ{--fix?}
+    FIXQ -->|no| DONE[Done]
+    FIXQ -->|yes| APPLY[Each domain skill<br/>writes config files]
+    APPLY --> DONE
+
+    SYNC[config-sync<br/>cross-repo propagation] -.->|reference<br/>implementation| MODE
+
+    classDef router fill:#4a9eff,stroke:#1a6ecc,color:#fff
+    classDef check fill:#8fbc8f,stroke:#556b55,color:#000
+    classDef fix fill:#ffa500,stroke:#b37400,color:#000
+    classDef prompt fill:#dda0dd,stroke:#8b5a8b,color:#000
+
+    class R router
+    class STATUS,CI,CONT,TEST,QUAL,SEC,DOCS,FF,PKG,EDIT,SYNC check
+    class APPLY fix
+    class SELECT prompt
+```
+
+## Legend
+
+| Node style | Meaning |
+|------------|---------|
+| Blue | Router skill (`/configure:all`) |
+| Green | Read-only audit / domain group (`--check-only`) |
+| Orange | Fix application (`--fix` writes config files) |
+| Purple | Interactive `AskUserQuestion` prompt |
+
+## Domain → Skill mapping
+
+| Domain | Skills |
+|--------|--------|
+| CI / Workflows | `configure-workflows`, `configure-reusable-workflows`, `configure-release-please`, `configure-argocd-automerge`, `configure-github-pages`, `configure-claude-plugins`, `ci-workflows`, `release-please-standards` |
+| Containers & Deploy | `configure-dockerfile`, `configure-container`, `configure-skaffold`, `skaffold-standards` |
+| Testing | `configure-tests`, `configure-coverage`, `configure-api-tests`, `configure-integration-tests`, `configure-load-tests`, `configure-memory-profiling`, `configure-ux-testing` |
+| Lint / Format / Dead code | `configure-linting`, `configure-formatting`, `configure-dead-code`, `configure-pre-commit`, `pre-commit-standards` |
+| Security | `configure-security`, `claude-security-settings` |
+| Docs | `configure-docs`, `configure-readme`, `readme-standards` |
+| Feature flags | `configure-feature-flags`, `openfeature`, `go-feature-flag` |
+| Package management | `configure-package-management`, `configure-cache-busting` |
+| Editor / Dev env | `configure-editor`, `configure-mcp`, `configure-makefile`, `configure-justfile`, `configure-web-session`, `configure-sentry` |
+| Orchestration | `configure-all` (router), `configure-select` (interactive), `configure-status` (read-only), `config-sync` (cross-repo) |

--- a/evaluate-plugin/README.md
+++ b/evaluate-plugin/README.md
@@ -2,6 +2,10 @@
 
 Skill evaluation and benchmarking plugin. Tests skill effectiveness through behavioral eval cases, grades results against assertions, and tracks quality improvements over time.
 
+## Flow
+
+See [`docs/flow.md`](docs/flow.md) for a diagram of how the skills and agents fit together.
+
 ## What It Does
 
 Static compliance checks (`plugin-compliance-check.sh`) verify structure — this plugin tests **behavior**: does a skill actually produce correct results when invoked?

--- a/evaluate-plugin/docs/flow.md
+++ b/evaluate-plugin/docs/flow.md
@@ -1,0 +1,58 @@
+# Evaluate Plugin Flow
+
+```mermaid
+flowchart TD
+    U[User] -->|/evaluate:skill<br/>plugin/skill| ES["/evaluate:skill<br/>(single-skill pipeline)"]
+    U -->|/evaluate:plugin<br/>plugin-name| EB["/evaluate:plugin<br/>(batch router)"]
+
+    %% Single-skill pipeline
+    ES --> RUN[Run eval cases<br/>against SKILL.md<br/>capture transcripts]
+    RUN --> GRADE[eval-grader agent<br/>score vs. assertions<br/>cite evidence]
+    GRADE --> CMP{--baseline?}
+    CMP -->|yes| COMP[eval-comparator agent<br/>blind with-skill vs.<br/>baseline comparison]
+    CMP -->|no| BENCH
+    COMP --> BENCH[Write benchmark.json<br/>history.json<br/>grading.json]
+
+    BENCH --> IMP[/evaluate:improve<br/>plugin/skill/]
+    IMP --> ANA[eval-analyzer agent<br/>diagnose failure patterns<br/>propose SKILL.md edits]
+    ANA --> APPLY{--apply?}
+    APPLY -->|yes| EDIT[Apply edits to<br/>SKILL.md]
+    APPLY -->|no| SUGG[Print suggestions]
+    EDIT --> RPT
+    SUGG --> RPT
+
+    RPT[/evaluate:report<br/>render benchmark/<br/>history as markdown/]
+    RPT --> DONE[Done]
+
+    %% Batch side-branch
+    EB --> DISC[Discover skills/*/evals.json]
+    DISC --> FAN{{fan out per skill}}
+    FAN --> ES
+    ES -.batch aggregate.-> AGG[aggregate_benchmark.sh<br/>merge per-skill results]
+    AGG --> RPT
+
+    classDef router fill:#4a9eff,stroke:#1a6ecc,color:#fff
+    classDef check fill:#8fbc8f,stroke:#556b55,color:#000
+    classDef fix fill:#ffa500,stroke:#b37400,color:#000
+
+    class ES,EB,FAN router
+    class RUN,GRADE,COMP,BENCH,ANA,RPT,AGG,DISC check
+    class EDIT,IMP,APPLY fix
+```
+
+## Legend
+
+| Node style | Meaning |
+|------------|---------|
+| Blue | Router / orchestrator skill (`/evaluate:skill`, `/evaluate:plugin`) |
+| Green | Read-only run, grading, analysis, or reporting step |
+| Orange | Mutating step (applies edits to `SKILL.md`) |
+
+## Stage → Skill/Agent mapping
+
+| Stage | Skill | Agent |
+|-------|-------|-------|
+| Evaluate | `/evaluate:skill` (`evaluate-skill/`) | `eval-grader` (grade), `eval-comparator` (blind with-skill vs. baseline) |
+| Improve | `/evaluate:improve` (`evaluate-improve/`) | `eval-analyzer` (diagnose + propose edits) |
+| Report | `/evaluate:report` (`evaluate-report/`) | — |
+| Batch | `/evaluate:plugin` (`evaluate-plugin-batch/`) | fans out to `/evaluate:skill` per skill, then `aggregate_benchmark.sh` merges results into a single report |

--- a/git-plugin/README.md
+++ b/git-plugin/README.md
@@ -6,6 +6,10 @@ Git workflows, commits, branches, PRs, and repository management for Claude Code
 
 This plugin provides comprehensive Git workflow automation including conventional commits, branch management, pull request handling, and issue processing.
 
+## Flow
+
+See [`docs/flow.md`](docs/flow.md) for a diagram of how the skills fit together.
+
 ## Skills
 
 | Skill | Description |

--- a/git-plugin/docs/flow.md
+++ b/git-plugin/docs/flow.md
@@ -1,0 +1,64 @@
+# Git Plugin Flow
+
+```mermaid
+flowchart TD
+    U[User] -->|/git:commit<br/>--push --pr| START[Start]
+
+    START --> DETECT[git-repo-detection<br/>git-cli-agentic<br/>gh-cli-agentic]
+    DETECT --> BRANCH[Stage 1: Branch<br/>git-branch-naming<br/>git-branch-pr-workflow]
+    BRANCH --> SEC[Stage 2: Security checks<br/>git-security-checks<br/>pre-commit / gitleaks]
+    SEC --> COMMIT[Stage 3: Commit<br/>git-commit<br/>git-commit-workflow<br/>git-commit-trailers]
+    COMMIT --> PUSH[Stage 4: Push<br/>git-push]
+    PUSH --> PR[Stage 5: Pull Request<br/>git-pr / git-api-pr<br/>github-pr-title<br/>github-labels]
+    PR --> MON[Stage 6: Monitor<br/>gh-workflow-monitoring<br/>git-fix-pr<br/>git-pr-feedback]
+    MON --> CONF{conflicts?}
+    CONF -->|yes| RES[git-conflicts<br/>git-resolve-conflicts]
+    CONF -->|no| DONE[Merged]
+    RES --> PUSH
+
+    %% Issues side branch
+    COMMIT -.-> ISS[Issues side branch<br/>git-issue<br/>git-issue-manage<br/>git-issue-hierarchy<br/>github-issue-writing<br/>github-issue-autodetect]
+    ISS -.-> BRANCH
+
+    %% Release-please side branch
+    PR -.-> RP[release-please side branch<br/>release-please-configuration<br/>release-please-protection<br/>release-please-pr-workflow]
+    RP -.-> DONE
+
+    %% Rebase / fork side branch
+    BRANCH -.-> RBF[Rebase & fork patterns<br/>git-rebase-patterns<br/>git-fork-workflow<br/>git-upstream-pr<br/>git-maintain<br/>git-derive-docs]
+    RBF -.-> PUSH
+
+    classDef router fill:#4a9eff,stroke:#1a6ecc,color:#fff
+    classDef check fill:#8fbc8f,stroke:#556b55,color:#000
+    classDef fix fill:#ffa500,stroke:#b37400,color:#000
+    classDef prompt fill:#dda0dd,stroke:#8b5a8b,color:#000
+
+    class DETECT,SEC,MON check
+    class BRANCH,COMMIT,PUSH,PR,RES,RP,ISS,RBF fix
+    class CONF prompt
+```
+
+## Legend
+
+| Node style | Meaning |
+|------------|---------|
+| Green | Read-only diagnostic / detection (repo detection, security scan, workflow monitoring) |
+| Orange | Writes state (branch create, commit, push, PR, release-please, issue ops) |
+| Purple | Decision / interactive prompt |
+| Dashed edge | Side branch — invoked situationally, not every run |
+
+## Stage → Skill mapping
+
+| Stage | Skills |
+|-------|--------|
+| Detect | `git-repo-detection`, `git-cli-agentic`, `gh-cli-agentic` |
+| Branch | `git-branch-naming`, `git-branch-pr-workflow` |
+| Security | `git-security-checks` |
+| Commit | `git-commit`, `git-commit-workflow`, `git-commit-trailers` |
+| Push | `git-push` |
+| Pull Request | `git-pr`, `git-api-pr`, `github-pr-title`, `github-labels` |
+| Monitor | `gh-workflow-monitoring`, `git-fix-pr`, `git-pr-feedback` |
+| Conflicts | `git-conflicts`, `git-resolve-conflicts` |
+| Issues (side) | `git-issue`, `git-issue-manage`, `git-issue-hierarchy`, `github-issue-writing`, `github-issue-autodetect` |
+| Release-please (side) | `release-please-configuration`, `release-please-protection`, `release-please-pr-workflow` |
+| Rebase / fork (side) | `git-rebase-patterns`, `git-fork-workflow`, `git-upstream-pr`, `git-maintain`, `git-derive-docs` |

--- a/workflow-orchestration-plugin/README.md
+++ b/workflow-orchestration-plugin/README.md
@@ -2,6 +2,10 @@
 
 Workflow orchestration patterns for parallel agents, CI pipelines, preflight checks, and checkpoint-based refactoring. Addresses common friction in multi-branch operations, permission restrictions, and context limits.
 
+## Flow
+
+See [`docs/flow.md`](docs/flow.md) for a diagram of the preflight → checkpoint → refactor pipeline.
+
 ## Skills
 
 | Skill | Command | Description |

--- a/workflow-orchestration-plugin/docs/flow.md
+++ b/workflow-orchestration-plugin/docs/flow.md
@@ -1,0 +1,79 @@
+# Workflow Orchestration Plugin Flow
+
+Pipeline: **preflight → checkpoint → refactor**. Validate remote state before committing to work, then execute large refactors through persistent, resumable phases.
+
+```mermaid
+flowchart TD
+    U[User] -->|/workflow:preflight<br/>issue# or branch| PF["/workflow:preflight<br/>(gate)"]
+
+    PF --> FETCH[Step 1: git fetch --prune<br/>sync remote state]
+    FETCH --> EXIST[Step 2: Check existing work<br/>gh pr list / gh issue view]
+    EXIST --> EXGATE{existing PR?}
+    EXGATE -->|merged| STOP[Stop:<br/>already addressed]
+    EXGATE -->|open| ASKPR[AskUserQuestion<br/>continue on branch<br/>or start fresh?]
+    EXGATE -->|none| BRANCH[Step 3: Verify branch<br/>ahead/behind, dirty tree]
+    ASKPR --> BRANCH
+    BRANCH --> CONF[Step 4: Conflict probe<br/>git merge-tree dry-run]
+    CONF --> SUM[Step 5: Summary report<br/>+ recommendations]
+
+    SUM --> READY{state clean<br/>& refactor scope?}
+    READY -->|small change| DIRECT[Direct edit<br/>out of scope]
+    READY -->|10+ files,<br/>multi-phase| CR["/workflow:checkpoint-refactor<br/>(pipeline)"]
+
+    CR --> MODE{mode flag}
+    MODE -->|--init| INIT[Step 1: Analyze scope<br/>Write REFACTOR_PLAN.md<br/>record base commit]
+    MODE -->|--status| STAT[Step 3: Parse plan<br/>print phase table]
+    MODE -->|--continue| RESUME[Step 2: Find next<br/>pending phase]
+    MODE -->|--phase=N| PICK[Select phase N]
+
+    INIT --> EXEC[Step 4: Execute phase<br/>read files, apply edits]
+    RESUME --> EXEC
+    PICK --> EXEC
+
+    EXEC --> BIG{phase has<br/>7+ files?}
+    BIG -->|yes| SUB[Step 5: Task sub-agent<br/>delegated edits]
+    BIG -->|no| VAL[Validate: tsc / test /<br/>cargo check]
+    SUB --> VAL
+
+    VAL --> OK{validation}
+    OK -->|pass| DONE_PH[Mark phase done<br/>git commit refactor phase N<br/>update plan]
+    OK -->|fail| REV[Mark needs-review<br/>WIP commit with<br/>error details]
+
+    DONE_PH --> MORE{more phases?}
+    MORE -->|yes| SUG[Suggest --continue<br/>or auto-proceed]
+    MORE -->|no| FIN[Refactor complete]
+    REV --> SUG
+
+    classDef router fill:#4a9eff,stroke:#1a6ecc,color:#fff
+    classDef check fill:#8fbc8f,stroke:#556b55,color:#000
+    classDef fix fill:#ffa500,stroke:#b37400,color:#000
+    classDef prompt fill:#dda0dd,stroke:#8b5a8b,color:#000
+
+    class PF,CR router
+    class FETCH,EXIST,BRANCH,CONF,SUM,STAT,RESUME,PICK,VAL check
+    class INIT,EXEC,SUB,DONE_PH,REV fix
+    class ASKPR prompt
+```
+
+## Legend
+
+| Node style | Meaning |
+|------------|---------|
+| Blue | Router / pipeline-stage skill (`/workflow:preflight`, `/workflow:checkpoint-refactor`) |
+| Green | Read-only diagnostic / validation step |
+| Orange | Mutating step (writes plan file, commits, edits code) |
+| Purple | Interactive `AskUserQuestion` prompt |
+
+## Stage to Skill mapping
+
+| Stage | Skill | Produces | Gates |
+|-------|-------|----------|-------|
+| Preflight | `workflow-preflight/` | Summary report: remote freshness, existing PRs, branch divergence, conflicts | Whether to proceed at all (blocks on merged PRs, dirty tree, detected conflicts) |
+| Checkpoint (init) | `workflow-checkpoint-refactor/` `--init` | `REFACTOR_PLAN.md` with phased file groups, acceptance criteria, base commit | Entry point for refactors spanning 10+ files |
+| Refactor (execute) | `workflow-checkpoint-refactor/` `--continue` / `--phase=N` | Per-phase commits (`refactor phase N: ...`), plan status updates, optional `needs-review` markers | Survives context limits — each phase reads/writes the plan file so sessions resume cleanly |
+
+## Pipeline rationale
+
+- **Preflight is a gate, not a step** — it produces no code change, only a go/no-go signal. Skipping it is the common cause of wasted refactor effort (duplicate PRs, rebase surprises mid-phase).
+- **Checkpoint is the orchestrator** — `--init` defines the contract (`REFACTOR_PLAN.md`), subsequent invocations consume and mutate it.
+- **Refactor phases are the atoms** — each phase is an independently committable, validatable unit. Failure marks `needs-review` rather than blocking the pipeline.


### PR DESCRIPTION
## Summary

- Adds `.claude/rules/plugin-flow-diagrams.md` codifying **when** a plugin earns a Mermaid flow diagram (router/delegation, ordered pipeline, >15 skills, cross-skill integration) and when to skip (flat independent-tool collections).
- Rolls out `docs/flow.md` for seven qualifying plugins and links each from its README.
- `health-plugin/docs/flow.md` remains the canonical example referenced by the rule.

### Plugins gaining a flow diagram

| Plugin | Pattern |
|---|---|
| `blueprint-plugin` | Pipeline: PRD → ADR → PRP → execute, with derive/promote/sync side-paths |
| `configure-plugin` | Router: `configure-all` → domain groups |
| `git-plugin` | Pipeline: branch → commit → push → PR, with release-please side-branch |
| `workflow-orchestration-plugin` | Pipeline: preflight → checkpoint → refactor |
| `agents-plugin` | Router: attribute-router → domain agents |
| `codebase-attributes-plugin` | Pipeline: collect → route → dashboard |
| `evaluate-plugin` | Pipeline: evaluate → improve → report (plus batch variant) |

Flat "bag of tools" plugins (tools, python, rust, typescript, networking, testing, container, kubernetes, etc.) are explicitly listed as non-qualifying in the rule — their Skills table already **is** the diagram.

Using `docs` commit type so release-please produces no version bump.

## Test plan

- [ ] Each `docs/flow.md` renders on GitHub with Mermaid
- [ ] Each linked plugin README shows a working `## Flow` section
- [ ] Rule file lists both "when to add" criteria and "skip" rationale
- [ ] `CLAUDE.md` Rules table row points at the new rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)