### PR TITLE
feat(configure-plugin): add /configure:repo driver, marketplace enrollment, stack-aware permissions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,9 @@ repos:
         language: script
         files: '(SKILL|skill)\.md$'
         pass_filenames: false
+      - id: check-driver-freshness
+        name: check configure-repo driver freshness
+        entry: bash ./scripts/check-driver-freshness.sh
+        language: system
+        files: '(SKILL|skill)\.md$'
+        pass_filenames: false

--- a/configure-plugin/.claude-plugin/plugin.json
+++ b/configure-plugin/.claude-plugin/plugin.json
@@ -25,6 +25,10 @@
     "marketplace",
     "web-session",
     "session-start",
-    "remote"
+    "remote",
+    "onboarding",
+    "repo-setup",
+    "stack-aware",
+    "driver"
   ]
 }

--- a/configure-plugin/README.md
+++ b/configure-plugin/README.md
@@ -26,6 +26,7 @@ All commands support two modes:
 
 | Skill | Description |
 |-------|-------------|
+| `configure-repo` | **End-to-end driver** — onboard any repo to Claude Code with marketplace enrollment, permissions, SessionStart hook, and health validation |
 | `configure-all` | Run all infrastructure standards checks |
 | `configure-select` | Interactively select which components to configure |
 | `configure-status` | Show compliance status (read-only) |
@@ -126,6 +127,23 @@ Presents multi-select menus to choose which components to check/fix.
 /configure:pre-commit --fix
 /configure:dockerfile --fix
 ```
+
+### Onboard a Repo to Claude Code (end-to-end)
+
+```bash
+/configure:repo
+```
+
+The recommended starting point for any new repo. Runs the full onboarding workflow:
+1. Detects project stack
+2. Configures plugins, permissions, and marketplace enrollment in `.claude/settings.json`
+3. Creates `scripts/install_pkgs.sh` + `SessionStart` hook for web sessions
+4. Optionally offers tooling migrations (mypy→ty, black→ruff-format, etc.)
+5. Validates with `/health:check`
+6. Stages all files for commit
+
+The `extraKnownMarketplaces` enrollment in `.claude/settings.json` is critical for
+ephemeral web sessions (claude.ai/code) — without it, plugins are lost on every new session.
 
 ### Set Up Claude Code on the Web
 

--- a/configure-plugin/skills/configure-claude-plugins/SKILL.md
+++ b/configure-plugin/skills/configure-claude-plugins/SKILL.md
@@ -1,8 +1,8 @@
 ---
 created: 2026-01-23
-modified: 2026-02-10
-reviewed: 2026-01-30
-description: Configure .claude/settings.json and GitHub Actions workflows to use the laurigates/claude-plugins marketplace
+modified: 2026-04-14
+reviewed: 2026-04-14
+description: Configure .claude/settings.json (permissions, marketplace enrollment, enabledPlugins) and GitHub Actions workflows to use the laurigates/claude-plugins marketplace
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash(mkdir *), Bash(test *), Bash(ls *), Bash(git remote *), AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--plugins <plugin1,plugin2,...>]"
 argument-hint: "[--check-only] [--fix] [--plugins <plugin1,plugin2,...>]"
@@ -11,7 +11,7 @@ name: configure-claude-plugins
 
 # /configure:claude-plugins
 
-Configure a project to use the `laurigates/claude-plugins` Claude Code plugin marketplace. Sets up `.claude/settings.json` permissions and GitHub Actions workflows (`claude.yml`, `claude-code-review.yml`) with the marketplace pre-configured.
+Configure a project to use the `laurigates/claude-plugins` Claude Code plugin marketplace. Sets up `.claude/settings.json` with permissions, marketplace enrollment, and `enabledPlugins`; and GitHub Actions workflows (`claude.yml`, `claude-code-review.yml`) with the marketplace pre-configured.
 
 ## When to Use This Skill
 
@@ -25,11 +25,12 @@ Configure a project to use the `laurigates/claude-plugins` Claude Code plugin ma
 
 ## Context
 
-- Settings file exists: !`find . -maxdepth 1 -name \'.claude/settings.json\'`
+- Settings file exists: !`find . -maxdepth 3 -name 'settings.json' -path '*/.claude/*'`
 - Workflows: !`find .github/workflows -maxdepth 1 -name 'claude*.yml'`
 - Git remotes: !`git remote -v`
-- Project type indicators: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'Dockerfile' \)`
-- Existing workflows dir: !`find . -maxdepth 1 -type d -name \'.github/workflows\'`
+- Project type indicators: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' -o -name 'Dockerfile' -o -name 'justfile' -o -name 'Justfile' \)`
+- ESP/embedded indicators: !`find . -maxdepth 2 \( -name 'idf_component.yml' -o -name 'sdkconfig' -o -name 'CMakeLists.txt' \)`
+- ESPHome indicators: !`find . -maxdepth 2 -name '*.yaml' -path '*/esphome/*'`
 
 ## Parameters
 
@@ -45,46 +46,87 @@ Parse from command arguments:
 
 Execute this Claude plugins configuration workflow:
 
-### Step 1: Detect current state
+### Step 1: Detect current state and project stack
 
 1. Check for existing `.claude/settings.json`
 2. Check for existing `.github/workflows/claude.yml`
 3. Check for existing `.github/workflows/claude-code-review.yml`
 4. Detect project type (language, framework) from file indicators
 
-### Step 2: Configure .claude/settings.json
+### Step 2: Select plugins
 
-Create or merge into `.claude/settings.json` the following permissions structure:
+If `--plugins` is not specified, select recommended plugins based on detected project type:
+
+| Project Indicator | Recommended Plugins |
+|-------------------|---------------------|
+| `package.json` | `git-plugin`, `typescript-plugin`, `testing-plugin`, `code-quality-plugin` |
+| `pyproject.toml` / `setup.py` | `git-plugin`, `python-plugin`, `testing-plugin`, `code-quality-plugin` |
+| `Cargo.toml` | `git-plugin`, `rust-plugin`, `testing-plugin`, `code-quality-plugin` |
+| `Dockerfile` | Above + `container-plugin` |
+| `.github/workflows/` | Above + `github-actions-plugin` |
+| `idf_component.yml` / `sdkconfig` | `git-plugin`, `code-quality-plugin`, `testing-plugin`, `container-plugin` |
+| ESPHome yaml | `git-plugin`, `python-plugin`, `code-quality-plugin` |
+| Default (any) | `git-plugin`, `code-quality-plugin`, `testing-plugin`, `tools-plugin` |
+
+Always include: `configure-plugin`, `health-plugin`, `hooks-plugin`.
+
+### Step 3: Configure .claude/settings.json
+
+Create or merge into `.claude/settings.json`. The permissions baseline includes common entries plus stack-aware expansions. The stanza also enrolls the marketplace so web sessions retain plugin access.
+
+#### Stack-aware `permissions.allow` baseline
+
+Always include these common entries:
+
+```json
+"Bash(git:*)", "Bash(gh:*)", "Bash(pre-commit:*)", "Bash(gitleaks:*)", "Bash(python3:*)"
+```
+
+Add stack-specific entries based on detected project type:
+
+| Stack | Additional allow entries |
+|---|---|
+| Python (uv + ruff + ty) | `"Bash(uv:*)"`, `"Bash(uvx:*)"`, `"Bash(ruff:*)"`, `"Bash(ty:*)"`, `"Bash(pytest:*)"` |
+| Node / TypeScript | `"Bash(npm:*)"`, `"Bash(pnpm:*)"`, `"Bash(bun:*)"`, `"Bash(tsc:*)"`, `"Bash(eslint:*)"`, `"Bash(prettier:*)"`, `"Bash(vitest:*)"` |
+| Go | `"Bash(go:*)"`, `"Bash(gofmt:*)"`, `"Bash(golangci-lint:*)"` |
+| Rust | `"Bash(cargo:*)"`, `"Bash(rustc:*)"`, `"Bash(clippy:*)"`, `"Bash(rustfmt:*)"` |
+| ESP-IDF / embedded | `"Bash(idf.py:*)"`, `"Bash(esptool:*)"`, `"Bash(clang-format:*)"`, `"Bash(cppcheck:*)"`, `"Bash(docker:*)"`, `"Bash(docker compose:*)"`, `"Bash(just:*)"`, `"Bash(make:*)"` |
+| ESPHome | `"Bash(esphome:*)"`, `"Bash(uv:*)"`, `"Bash(uvx:*)"` |
+
+Use granular patterns only — do not add `Bash(bash *)` for CLI tools.
+
+#### Full settings.json stanza to merge
 
 ```json
 {
   "permissions": {
     "allow": [
-      "Bash(git status *)",
-      "Bash(git diff *)",
-      "Bash(git log *)",
-      "Bash(git branch *)",
-      "Bash(git add *)",
-      "Bash(git commit *)",
-      "Bash(git push *)",
-      "Bash(git remote *)",
-      "Bash(git checkout *)",
-      "Bash(git fetch *)",
-      "Bash(gh pr *)",
-      "Bash(gh run *)",
-      "Bash(gh issue *)",
-      "Bash(pre-commit *)",
-      "Bash(gitleaks *)",
-      "mcp__context7",
-      "mcp__sequential-thinking"
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(pre-commit:*)",
+      "Bash(gitleaks:*)",
+      "Bash(python3:*)"
+      // ... plus stack-specific entries from the table above
     ]
+  },
+  "extraKnownMarketplaces": {
+    "claude-plugins": {
+      "source": { "source": "github", "repo": "laurigates/claude-plugins" },
+      "autoUpdate": true
+    }
+  },
+  "enabledPlugins": {
+    "<selected-plugin-1>@claude-plugins": true,
+    "<selected-plugin-2>@claude-plugins": true
   }
 }
 ```
 
-If `.claude/settings.json` already exists, MERGE the `permissions.allow` array without duplicating entries. Preserve any existing `hooks`, `env`, or other fields.
+Replace `<selected-plugin-N>` with the plugin names selected in Step 2.
 
-### Step 3: Configure .github/workflows/claude.yml
+If `.claude/settings.json` already exists, **MERGE** without duplicating entries. Preserve any existing `hooks`, `env`, or other fields.
+
+### Step 4: Configure .github/workflows/claude.yml
 
 Create `.github/workflows/claude.yml` with the Claude Code action configured to use the plugin marketplace:
 
@@ -130,7 +172,7 @@ jobs:
 
 Replace `PLUGINS_LIST` with the selected plugins in the format `plugin-name@laurigates-claude-plugins`, one per line.
 
-### Step 4: Configure .github/workflows/claude-code-review.yml
+### Step 5: Configure .github/workflows/claude-code-review.yml
 
 Create `.github/workflows/claude-code-review.yml` for automatic PR reviews:
 
@@ -173,19 +215,6 @@ jobs:
             testing-plugin@laurigates-claude-plugins
 ```
 
-### Step 5: Select plugins
-
-If `--plugins` is not specified, select recommended plugins based on detected project type:
-
-| Project Indicator | Recommended Plugins |
-|-------------------|---------------------|
-| `package.json` | `git-plugin`, `typescript-plugin`, `testing-plugin`, `code-quality-plugin` |
-| `pyproject.toml` / `setup.py` | `git-plugin`, `python-plugin`, `testing-plugin`, `code-quality-plugin` |
-| `Cargo.toml` | `git-plugin`, `rust-plugin`, `testing-plugin`, `code-quality-plugin` |
-| `Dockerfile` | Above + `container-plugin` |
-| `.github/workflows/` | Above + `github-actions-plugin` |
-| Default (any) | `git-plugin`, `code-quality-plugin`, `testing-plugin`, `tools-plugin` |
-
 ### Step 6: Report results
 
 Print a status report:
@@ -196,23 +225,24 @@ Claude Plugins Configuration Report
 Repository: <repo-name>
 
 .claude/settings.json:
-  Status:          <CREATED|UPDATED|EXISTS>
-  Permissions:     <N> allowed patterns configured
+  Status:              <CREATED|UPDATED|EXISTS>
+  Permissions:         <N> allowed patterns configured
+  Marketplace:         laurigates/claude-plugins (extraKnownMarketplaces)
+  Enabled plugins:     <list>
 
 .github/workflows/claude.yml:
-  Status:          <CREATED|UPDATED|EXISTS>
-  Marketplace:     laurigates/claude-plugins
-  Plugins:         <list>
+  Status:              <CREATED|UPDATED|EXISTS>
+  Marketplace:         laurigates/claude-plugins
+  Plugins:             <list>
 
 .github/workflows/claude-code-review.yml:
-  Status:          <CREATED|UPDATED|EXISTS>
-  Trigger:         PR opened/synchronize/reopened
-  Plugins:         <list>
+  Status:              <CREATED|UPDATED|EXISTS>
+  Trigger:             PR opened/synchronize/reopened
 
 Next Steps:
   1. Add CLAUDE_CODE_OAUTH_TOKEN to repository secrets
      Settings > Secrets and variables > Actions > New repository secret
-  2. Commit and push the new workflow files
+  2. Commit and push the new/updated files
   3. Test by mentioning @claude in a PR comment
 ```
 
@@ -223,8 +253,8 @@ Next Steps:
 | Quick status check | `/configure:claude-plugins --check-only` |
 | Auto-configure all | `/configure:claude-plugins --fix` |
 | Specific plugins only | `/configure:claude-plugins --fix --plugins git-plugin,testing-plugin` |
-| Verify settings exist | `test -f .claude/settings.json && echo "EXISTS"` |
-| List Claude workflows | `find .github/workflows -name 'claude*.yml' 2>/dev/null` |
+| Verify settings exist | `find .claude -maxdepth 1 -name 'settings.json'` |
+| List Claude workflows | `find .github/workflows -name 'claude*.yml'` |
 
 ## Flags
 
@@ -237,12 +267,13 @@ Next Steps:
 ## Important Notes
 
 - The `CLAUDE_CODE_OAUTH_TOKEN` secret must be added manually to the repository
-- If using AWS Bedrock or Google Vertex AI, adjust the authentication section accordingly
-- The plugin marketplace URL uses HTTPS Git format: `https://github.com/laurigates/claude-plugins.git`
-- Plugins are referenced as `<plugin-name>@laurigates-claude-plugins` (marketplace name from marketplace.json)
+- `extraKnownMarketplaces` in `.claude/settings.json` is the key to surviving ephemeral web sessions — without it, the marketplace is only enrolled via CI
+- `enabledPlugins` entries use `plugin-name@claude-plugins` format (marketplace key from the `extraKnownMarketplaces` stanza)
+- Plugins are referenced in workflows as `<plugin-name>@laurigates-claude-plugins` (marketplace `name` from marketplace.json)
 
 ## See Also
 
-- `/configure:workflows` - General GitHub Actions workflow configuration
+- `/configure:repo` - Full end-to-end driver (runs this skill + web-session + health check)
+- `/configure:web-session` - SessionStart hook for infrastructure tools
 - `/configure:all` - Run all compliance checks
 - `claude-security-settings` skill - Claude Code security settings

--- a/configure-plugin/skills/configure-repo/SKILL.md
+++ b/configure-plugin/skills/configure-repo/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: configure-repo
+description: |
+  End-to-end repo config driver. Produces a working .claude/ directory
+  (settings.json with marketplace enrollment + permissions), a SessionStart
+  hook, and scripts/install_pkgs.sh — all staged for commit. Use when
+  onboarding any repo to Claude Code with the laurigates/claude-plugins
+  marketplace. Runs /configure:claude-plugins, /configure:web-session,
+  /health:check, and optionally prompts for migration offers (mypy→ty, etc.).
+allowed-tools: Glob, Grep, Read, Write, Edit, Bash(git add *), Bash(git status *), Bash(git diff *), Bash(find *), Bash(mkdir *), Bash(test *), AskUserQuestion, TodoWrite, SlashCommand
+args: "[--check-only] [--skip-health] [--skip-migrations]"
+argument-hint: "[--check-only] [--skip-health] [--skip-migrations]"
+created: 2026-04-14
+modified: 2026-04-14
+reviewed: 2026-04-14
+---
+
+# /configure:repo
+
+End-to-end driver that brings any repo's Claude Code configuration to a healthy baseline in one command. Produces committed-ready files: `.claude/settings.json` (permissions + marketplace enrollment), a `SessionStart` hook, and `scripts/install_pkgs.sh`.
+
+## When to Use This Skill
+
+| Use this skill when... | Use another approach when... |
+|------------------------|------------------------------|
+| Onboarding a new repo to Claude Code from scratch | Changing a single setting — use `/configure:claude-plugins` or `/configure:web-session` directly |
+| Updating an existing repo to the latest baseline config | Diagnosing a specific hook or plugin issue — use `/health:check` directly |
+| Checking what would change before committing | Running a health-only audit — use `/health:check` |
+| Setting up a repo for ephemeral web sessions (claude.ai/code) | Managing plugins on an already-configured repo |
+
+## Context
+
+Detect current state and project stack:
+
+- Existing settings: !`find .claude -maxdepth 1 -name 'settings.json' -type f`
+- Install script: !`find . -name 'install_pkgs.sh' -path '*/scripts/*'`
+- Workflows: !`find .github/workflows -maxdepth 1 -name 'claude*.yml'`
+- Project files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' -o -name 'justfile' -o -name 'Justfile' \)`
+- ESP indicators: !`find . -maxdepth 2 \( -name 'idf_component.yml' -o -name 'sdkconfig' \)`
+- Pre-commit config: !`find . -maxdepth 1 -name '.pre-commit-config.yaml'`
+- Git remote: !`git remote -v`
+
+## Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `--check-only` | Report what would change without modifying any files |
+| `--skip-health` | Skip the final `/health:check` validation step |
+| `--skip-migrations` | Skip migration detection (don't offer mypy→ty etc.) |
+
+## Execution
+
+Execute this end-to-end repository configuration workflow:
+
+### Step 1: Detect project stack
+
+Identify the stack from the context above. Produce a brief summary:
+
+```
+Stack detected:
+  Language:   Python (uv + ruff) | Node/TypeScript | Rust | Go | ESP-IDF | ESPHome | ...
+  Tools:      pre-commit, just, docker, ...
+  Migrations: mypy→ty candidate | black→ruff-format candidate | flake8→ruff candidate | ESLint→Biome candidate
+```
+
+If `--check-only`, annotate all subsequent steps as "(would do)" rather than doing them.
+
+### Step 2: Configure plugins, permissions, and marketplace enrollment
+
+Invoke `/configure:claude-plugins --fix` using the SlashCommand tool.
+
+This step:
+- Selects recommended plugins based on detected stack
+- Writes `permissions.allow` (common + stack-aware) to `.claude/settings.json`
+- Writes `extraKnownMarketplaces` + `enabledPlugins` to `.claude/settings.json` (critical for web sessions)
+- Creates/updates `.github/workflows/claude.yml` and `claude-code-review.yml`
+
+### Step 3: Configure SessionStart hook and install script
+
+Invoke `/configure:web-session --fix` using the SlashCommand tool.
+
+This step generates `scripts/install_pkgs.sh` with idempotent tool installs gated on `CLAUDE_CODE_REMOTE=true`, and wires the `SessionStart` hook in `.claude/settings.json`.
+
+If the project uses language-level deps (Python, Node, Rust, Go), also invoke `/hooks:session-start-hook --remote-only` using the SlashCommand tool to add dependency installation to the hook script.
+
+### Step 4: Offer migrations (unless --skip-migrations)
+
+Detect these migratable patterns and ask whether to run each migration via `AskUserQuestion`:
+
+| Pattern detected | Migration to offer | Skill to invoke |
+|------------------|--------------------|-----------------|
+| `.pre-commit-config.yaml` contains `mirrors-mypy` or `[tool.mypy]` in pyproject.toml | mypy → ty | `/migration-patterns:mypy-to-ty` |
+| `.pre-commit-config.yaml` contains `psf/black` | black → ruff-format | `/migration-patterns:black-to-ruff-format` |
+| `.pre-commit-config.yaml` contains `pycqa/flake8` or `PyCQA/isort` | flake8/isort → ruff | `/migration-patterns:flake8-to-ruff` |
+| `.eslintrc*` or `eslint.config.*` present, no `biome.json` | ESLint → Biome | `/migration-patterns:eslint-to-biome` |
+
+For each detected pattern, ask: "Found [pattern] — offer to migrate? (y/n)". Only run the migration skill if the user confirms.
+
+Migrations are **not** part of the happy path. If the user declines all migrations, continue to Step 5.
+
+### Step 5: Validate with health check (unless --skip-health)
+
+Invoke `/health:check` using the SlashCommand tool.
+
+Parse the health check output. If any checks fail:
+- Report the specific failures
+- Suggest how to fix them
+- Continue (do not abort — the config files are still staged)
+
+### Step 6: Stage files and report
+
+Run `git status` to list all created/modified files. Stage the relevant files:
+
+```bash
+git add .claude/settings.json
+git add scripts/install_pkgs.sh        # if created
+git add .github/workflows/claude.yml   # if created
+git add .github/workflows/claude-code-review.yml  # if created
+```
+
+Print a summary:
+
+```
+configure-repo complete
+=======================
+Repository: <repo-name>
+
+Files staged:
+  .claude/settings.json             [CREATED | UPDATED]
+  scripts/install_pkgs.sh           [CREATED | UPDATED | SKIPPED]
+  .github/workflows/claude.yml      [CREATED | UPDATED | SKIPPED]
+  .github/workflows/claude-code-review.yml  [CREATED | UPDATED | SKIPPED]
+
+Marketplace enrollment:
+  .claude/settings.json → extraKnownMarketplaces.claude-plugins  ✓
+  .github/workflows/claude.yml → plugin_marketplaces             ✓
+
+Health check: PASS | WARN (<N> warnings) | FAIL (<N> failures)
+
+Next steps:
+  1. Review the staged diff: git diff --cached
+  2. Commit: git commit -m "chore(claude): configure repo for Claude Code"
+  3. Add CLAUDE_CODE_OAUTH_TOKEN to repository secrets
+  4. Push and test: mention @claude in a PR comment
+```
+
+If `--check-only` was set, prefix the summary with "DRY RUN — no files modified".
+
+## Important Notes
+
+- This skill is a thin orchestrator — it contains no business logic. All logic lives in its dependencies.
+- Never auto-commit; always stage and let the user review with `git diff --cached`.
+- `AskUserQuestion` is required for migration offers — this skill must not run on `haiku` model.
+- `extraKnownMarketplaces` in `.claude/settings.json` is the key to surviving ephemeral web sessions.
+- The SessionStart hook uses `CLAUDE_CODE_REMOTE` guard so it is a no-op in local sessions.
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Full setup with health check | `/configure:repo` |
+| Dry-run, no file changes | `/configure:repo --check-only` |
+| Setup without migration prompts | `/configure:repo --skip-migrations` |
+| Quick setup, skip health | `/configure:repo --skip-health --skip-migrations` |
+| Stage and review | `git diff --cached` |
+
+## Dependencies (driver freshness)
+
+This skill orchestrates these dependencies. If any dependency's `modified:` date is newer than this skill's `reviewed:` date, run `scripts/check-driver-freshness.sh` and update this skill accordingly.
+
+| Dependency | File |
+|------------|------|
+| `/configure:claude-plugins` | `configure-plugin/skills/configure-claude-plugins/SKILL.md` |
+| `/configure:web-session` | `configure-plugin/skills/configure-web-session/SKILL.md` |
+| `/hooks:session-start-hook` | `hooks-plugin/skills/hooks-session-start-hook/SKILL.md` |
+| `/health:check` | `health-plugin/skills/health-check/SKILL.md` |
+| `/migration-patterns:mypy-to-ty` | `migration-patterns-plugin/skills/mypy-to-ty/SKILL.md` |
+| `/migration-patterns:black-to-ruff-format` | `migration-patterns-plugin/skills/black-to-ruff-format/SKILL.md` |
+| `/migration-patterns:flake8-to-ruff` | `migration-patterns-plugin/skills/flake8-to-ruff/SKILL.md` |
+| `/migration-patterns:eslint-to-biome` | `migration-patterns-plugin/skills/eslint-to-biome/SKILL.md` |
+
+## See Also
+
+- `/configure:claude-plugins` — Configure plugins, permissions, and marketplace enrollment
+- `/configure:web-session` — SessionStart hook for infrastructure tools
+- `/health:check` — Claude Code configuration health check
+- `scripts/check-driver-freshness.sh` — Detect when this driver is out of sync with its dependencies

--- a/docs/PLUGIN-MAP.md
+++ b/docs/PLUGIN-MAP.md
@@ -24,7 +24,7 @@ Install these first. They configure the environment other plugins rely on.
 |--------|--------|---------|
 | health-plugin | 6 | Diagnose config issues, audit plugin selection |
 | hooks-plugin | 1 | Enforce best practices via lifecycle hooks |
-| configure-plugin | 42 | Infrastructure standards (CI, linting, testing, Docker) |
+| configure-plugin | 43 | Infrastructure standards (CI, linting, testing, Docker, repo onboarding) |
 | agent-patterns-plugin | 16 | Agent orchestration, MCP management, delegation |
 
 ### Tier 1 - Core Workflow
@@ -193,7 +193,7 @@ Install based on your project's tech stack and domain.
 | feedback-plugin | Capturing session skill feedback as GitHub issues |
 | tools-plugin | fd, rg, jq, shell, ImageMagick, d2 utilities |
 | workflow-orchestration-plugin | Parallel agent orchestration, CI pipelines, preflight checks, checkpoint refactoring |
-| migration-patterns-plugin | Safe database and system migration patterns — dual write, shadow mode, strangler fig |
+| migration-patterns-plugin | Safe database and system migration patterns — dual write, shadow mode, strangler fig; automated tooling migrations (mypy→ty, black→ruff-format, flake8→ruff, ESLint→Biome) |
 | prompt-engineering-plugin | Anti-hallucination workflow — grounded, citation-backed analysis from source documents |
 | prose-plugin | Prose style control — distillation, tone, voice, clarity, consistency |
 | obsidian-plugin | Obsidian CLI vault management — files, search, properties, tasks, publish, sync |

--- a/health-plugin/.claude-plugin/plugin.json
+++ b/health-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "health-plugin",
   "version": "1.5.3",
-  "description": "Diagnose and fix Claude Code configuration issues including plugin registry, settings, hooks, and MCP servers",
+  "description": "Diagnose and fix Claude Code configuration issues including plugin registry, settings, hooks, MCP servers, SessionStart executability, pre-commit validity, permissions coverage, and marketplace enrollment",
   "keywords": [
     "health",
     "diagnostics",
@@ -14,6 +14,10 @@
     "agentic",
     "optimization",
     "fix",
-    "repair"
+    "repair",
+    "marketplace",
+    "permissions",
+    "session-start",
+    "pre-commit"
   ]
 }

--- a/health-plugin/skills/health-check/SKILL.md
+++ b/health-plugin/skills/health-check/SKILL.md
@@ -1,8 +1,8 @@
 ---
 created: 2026-02-04
-modified: 2026-03-26
-reviewed: 2026-03-26
-description: Run a comprehensive diagnostic scan of Claude Code configuration including plugins, settings, hooks, and MCP servers
+modified: 2026-04-14
+reviewed: 2026-04-14
+description: Run a comprehensive diagnostic scan of Claude Code configuration including plugins, settings, hooks, MCP servers, SessionStart executability, pre-commit validity, permissions coverage, and marketplace enrollment
 allowed-tools: Bash(bash *), Read, Glob, Grep, TodoWrite
 args: "[--fix] [--verbose]"
 argument-hint: "[--fix] [--verbose]"
@@ -73,9 +73,102 @@ bash "${CLAUDE_SKILL_DIR}/scripts/check-mcp.sh" --home-dir "$HOME" --project-dir
 
 Parse the `STATUS=` and `ISSUES:` lines from output.
 
-### Step 5: Generate the diagnostic report
+### Step 5: SessionStart smoke test
 
-Using the structured output from Steps 1-4, print a diagnostic report following the template in [REFERENCE.md](REFERENCE.md). Include status indicators (OK/WARN/ERROR), issue counts, and recommended actions. If `--fix` was used and fixes were applied, include a summary of changes made.
+Check whether `scripts/install_pkgs.sh` (or any script registered in the `SessionStart` hook in `.claude/settings.json`) is executable and exits cleanly in both remote and local contexts.
+
+1. Locate the `SessionStart` hook command from `.claude/settings.json` (look for the `command` field).
+2. If a script is found, run:
+   ```bash
+   CLAUDE_CODE_REMOTE=true bash <script-path>
+   ```
+   Capture exit code. Expected: 0.
+3. Run again to verify idempotency:
+   ```bash
+   CLAUDE_CODE_REMOTE=true bash <script-path>
+   ```
+   Expected: 0 (second run must also succeed).
+4. Run with remote guard off:
+   ```bash
+   CLAUDE_CODE_REMOTE=false bash <script-path>
+   ```
+   Expected: 0 (script must exit cleanly when not in remote mode — typically a no-op).
+5. Report results:
+   - OK: All three exit 0
+   - WARN: Script exists but is not registered in settings.json hook
+   - ERROR: Script exits non-zero, or script referenced in hook does not exist
+
+### Step 6: Pre-commit config validator
+
+If `.pre-commit-config.yaml` exists:
+
+```bash
+pre-commit validate-config .pre-commit-config.yaml
+```
+
+Report:
+- OK: exits 0 (config is valid)
+- WARN: `pre-commit` not installed — skip check, suggest `pip install pre-commit`
+- ERROR: exits non-zero — show validation error
+
+### Step 7: Permissions coverage check
+
+Compare tools referenced in project files against `permissions.allow` in `.claude/settings.json`.
+
+1. Read `permissions.allow` from `.claude/settings.json`. Extract the command prefix from each `Bash(<prefix>:*)` entry.
+2. Scan these files for tool invocations:
+   - `justfile` / `Justfile` — commands on recipe lines
+   - `Makefile` — shell commands on recipe lines
+   - `.pre-commit-config.yaml` — `entry:` fields
+3. For each tool found in project files:
+   - Flag as **MISSING** if no matching `Bash(<tool>:*)` entry exists in `permissions.allow`
+4. For each `Bash(<tool>:*)` entry in `permissions.allow`:
+   - Flag as **UNUSED** if the tool is not found in any project file (informational, not an error)
+
+Report a table:
+
+```
+Permissions Coverage
+====================
+MISSING (in project files, not in allow list):
+  just      (found in Makefile — add "Bash(just:*)")
+  docker    (found in justfile — add "Bash(docker:*)")
+
+UNUSED (in allow list, not found in project files):
+  Bash(gofmt:*)   (informational)
+```
+
+Scoring:
+- OK: No missing permissions
+- WARN: 1–3 missing permissions
+- ERROR: 4+ missing permissions
+
+### Step 8: Marketplace enrollment check
+
+1. Read `.claude/settings.json`.
+2. Check that `extraKnownMarketplaces.claude-plugins` exists with `source.repo = "laurigates/claude-plugins"`.
+3. Check that `enabledPlugins` contains at least one `@claude-plugins` entry.
+4. Report:
+   - OK: Both checks pass
+   - WARN: `enabledPlugins` is empty or missing (marketplace enrolled but no plugins enabled)
+   - ERROR: `extraKnownMarketplaces` is missing (run `/configure:claude-plugins --fix` to add it)
+
+### Step 9: Generate the diagnostic report
+
+Using the structured output from Steps 1-8, print a diagnostic report following the template in [REFERENCE.md](REFERENCE.md). Include status indicators (OK/WARN/ERROR), issue counts, and recommended actions. If `--fix` was used and fixes were applied, include a summary of changes made.
+
+Include rows for the new checks in the summary table:
+
+| Check | Status | Issues |
+|-------|--------|--------|
+| Plugin registry | OK/WARN/ERROR | ... |
+| Settings files | OK/WARN/ERROR | ... |
+| Hooks configuration | OK/WARN/ERROR | ... |
+| MCP servers | OK/WARN/ERROR | ... |
+| SessionStart smoke test | OK/WARN/ERROR | ... |
+| Pre-commit config | OK/WARN/ERROR/SKIP | ... |
+| Permissions coverage | OK/WARN/ERROR | ... |
+| Marketplace enrollment | OK/WARN/ERROR | ... |
 
 ## Agentic Optimizations
 
@@ -84,9 +177,12 @@ Using the structured output from Steps 1-4, print a diagnostic report following 
 | Quick health check | `/health:check` |
 | Health check with auto-fix | `/health:check --fix` |
 | Detailed diagnostics | `/health:check --verbose` |
-| Check plugin registry exists | `test -f ~/.claude/plugins/installed_plugins.json && echo "exists" \|\| echo "missing"` |
-| Validate settings JSON | `jq empty .claude/settings.json 2>&1` |
-| List MCP servers | `jq -r '.mcpServers \| keys[]' .mcp.json 2>/dev/null` |
+| Check plugin registry exists | `find ~/.claude/plugins -name 'installed_plugins.json'` |
+| Validate settings JSON | `find .claude -maxdepth 1 -name 'settings.json'` |
+| Smoke-test install script | `CLAUDE_CODE_REMOTE=true bash scripts/install_pkgs.sh` |
+| Verify idempotency | `CLAUDE_CODE_REMOTE=true bash scripts/install_pkgs.sh` (run twice) |
+| Validate pre-commit config | `pre-commit validate-config .pre-commit-config.yaml` |
+| Check marketplace enrollment | `find .claude -maxdepth 1 -name 'settings.json'` then grep for `extraKnownMarketplaces` |
 
 ## Known Issues Database
 

--- a/migration-patterns-plugin/.claude-plugin/plugin.json
+++ b/migration-patterns-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "migration-patterns-plugin",
   "version": "1.2.1",
-  "description": "Safe database and system migration patterns - dual write, shadow mode, strangler fig",
+  "description": "Migration patterns - dual write, shadow mode, and automated tool migrations (mypy→ty, black→ruff-format, flake8→ruff, ESLint→Biome)",
   "keywords": [
     "migration",
     "dual-write",
@@ -10,6 +10,15 @@
     "dark-launching",
     "strangler-fig",
     "database-migration",
-    "zero-downtime"
+    "zero-downtime",
+    "mypy",
+    "ty",
+    "ruff",
+    "black",
+    "flake8",
+    "isort",
+    "eslint",
+    "biome",
+    "tooling-migration"
   ]
 }

--- a/migration-patterns-plugin/README.md
+++ b/migration-patterns-plugin/README.md
@@ -1,15 +1,26 @@
 # migration-patterns-plugin
 
-Safe database and system migration patterns for zero-downtime transitions.
+Migration patterns for safe, zero-downtime transitions — both data migrations and tooling migrations.
 
 ## Skills
 
-| Skill | Model | Description |
-|-------|-------|-------------|
-| dual-write | opus | Dual write (double write) pattern for keeping two data stores in sync during migration |
-| shadow-mode | opus | Shadow mode (dark launching) pattern for validating new systems under production traffic |
+### Data Migration Patterns
 
-## Patterns Covered
+| Skill | Description |
+|-------|-------------|
+| `dual-write` | Dual write (double write) pattern for keeping two data stores in sync during migration |
+| `shadow-mode` | Shadow mode (dark launching) pattern for validating new systems under production traffic |
+
+### Automated Tooling Migrations
+
+| Skill | Invocation | Description |
+|-------|-----------|-------------|
+| `mypy-to-ty` | `/migration-patterns:mypy-to-ty` | Migrate from mypy to ty (Astral's type checker) |
+| `black-to-ruff-format` | `/migration-patterns:black-to-ruff-format` | Migrate from black to ruff's formatter |
+| `flake8-to-ruff` | `/migration-patterns:flake8-to-ruff` | Migrate from flake8/isort to ruff linting |
+| `eslint-to-biome` | `/migration-patterns:eslint-to-biome` | Migrate from ESLint/Prettier to Biome |
+
+## Data Migration Patterns
 
 ### Dual Write
 
@@ -29,6 +40,39 @@ These patterns are complementary tactics within the Strangler Fig migration stra
 - Shadow mode validates read behavior
 - Dual write keeps both systems in sync
 - Together they enable safe, gradual migration with rollback at every phase
+
+## Tooling Migration Skills
+
+These skills automate common Python and TypeScript tooling migrations. Each migration:
+- Audits the current state
+- Updates `.pre-commit-config.yaml`
+- Migrates configuration in `pyproject.toml` / `biome.json`
+- Removes old dependencies
+- Verifies the migration with a dry run
+
+All four skills are invoked by `/configure:repo` via `AskUserQuestion` when the corresponding migration pattern is detected — they are not run automatically.
+
+### mypy → ty
+
+Replaces the `mirrors-mypy` pre-commit hook with a `repo: local` hook running `uvx ty check`. Converts `[tool.mypy]` config to `[tool.ty]`.
+
+**Note:** `astral-sh/ty-pre-commit` does not yet exist; `repo: local` with `entry: uvx ty check` is the correct pattern.
+
+### black → ruff-format
+
+Replaces `psf/black` pre-commit hook with `ruff-format`. Migrates `[tool.black]` config to `[tool.ruff.format]`. Drop-in compatible output.
+
+### flake8/isort → ruff
+
+Replaces `pycqa/flake8` and `PyCQA/isort` hooks with a single `ruff` hook. Migrates rule configuration and import-sort settings.
+
+### ESLint → Biome
+
+Replaces `.eslintrc*` and Prettier configs with `biome.json`. Updates pre-commit hooks and `package.json` scripts. Flags plugins without Biome equivalents (e.g., `eslint-plugin-jsx-a11y`) for manual review.
+
+## Integration with /configure:repo
+
+The end-to-end driver `/configure:repo` detects migratable patterns and offers each migration via `AskUserQuestion`. Users choose which migrations to apply.
 
 ## Installation
 

--- a/migration-patterns-plugin/skills/black-to-ruff-format/SKILL.md
+++ b/migration-patterns-plugin/skills/black-to-ruff-format/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: black-to-ruff-format
+description: |
+  Migrate a Python project from black to ruff format (ruff's formatter).
+  Use when .pre-commit-config.yaml contains psf/black, or when [tool.black]
+  config exists in pyproject.toml. Replaces the black pre-commit hook with
+  ruff-format, migrates config, and removes black from dependencies.
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash(find *), Bash(test *), Bash(pre-commit *), Bash(uvx *), AskUserQuestion, TodoWrite
+args: "[--check-only] [--fix]"
+argument-hint: "[--check-only] [--fix]"
+created: 2026-04-14
+modified: 2026-04-14
+reviewed: 2026-04-14
+---
+
+# /migration-patterns:black-to-ruff-format
+
+Migrate from [black](https://github.com/psf/black) to [ruff format](https://docs.astral.sh/ruff/formatter/) — Ruff's drop-in Black-compatible formatter written in Rust (~35x faster). Replaces the `psf/black` pre-commit hook, migrates `[tool.black]` configuration, and removes black from dev dependencies.
+
+## When to Use This Skill
+
+| Use this skill when... | Keep black when... |
+|------------------------|-------------------|
+| `.pre-commit-config.yaml` contains `psf/black` | Team has strong preference for black's exact output |
+| `[tool.black]` exists in pyproject.toml | CI uses `black --check` specifically by name |
+| Repo already uses ruff for linting | Project uses black's API in build scripts |
+| Wanting to consolidate formatting under ruff | |
+
+## Context
+
+- Pre-commit config: !`find . -maxdepth 1 -name '.pre-commit-config.yaml'`
+- pyproject.toml: !`find . -maxdepth 1 -name 'pyproject.toml'`
+- ruff already present: !`find . -maxdepth 1 -name 'ruff.toml'`
+
+## Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `--check-only` | Report what would change without modifying files |
+| `--fix` | Apply migration automatically |
+
+## Execution
+
+Execute this black-to-ruff-format migration:
+
+### Step 1: Audit current black configuration
+
+1. Read `.pre-commit-config.yaml` and locate `psf/black` entries.
+2. Read `pyproject.toml` and extract the `[tool.black]` section.
+3. Report findings:
+   ```
+   black → ruff-format migration audit
+   =====================================
+   pre-commit hook:  psf/black found at rev <rev>
+   pyproject.toml:   [tool.black] section found (line-length=<N>, target-version=<X>)
+   ruff already:     EXISTS / NOT PRESENT
+   ```
+   If `--check-only`, stop here.
+
+### Step 2: Update .pre-commit-config.yaml
+
+Remove the `psf/black` repo block. If `ruff-pre-commit` is already present, add the `ruff-format` hook ID. Otherwise add the full ruff-pre-commit repo block with both `ruff` and `ruff-format` hooks:
+
+```yaml
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.9.1  # use latest stable ruff version
+  hooks:
+    - id: ruff
+      args: [--fix]
+    - id: ruff-format
+```
+
+If `ruff-pre-commit` already exists but only has the `ruff` linter hook, add the `ruff-format` hook ID under the same repo block.
+
+### Step 3: Migrate [tool.black] → [tool.ruff.format] in pyproject.toml
+
+Convert black configuration to ruff format config:
+
+| black key | ruff equivalent | Notes |
+|-----------|----------------|-------|
+| `line-length` | `[tool.ruff] line-length` | Shared with linter |
+| `target-version` | `[tool.ruff] target-version` | Shared with linter |
+| `skip-string-normalization` | `[tool.ruff.format] quote-style = "preserve"` | |
+| `skip-magic-trailing-comma` | `[tool.ruff.format] skip-magic-trailing-comma = true` | |
+| `preview` | `[tool.ruff.format] preview = true` | |
+
+Remove the `[tool.black]` section. Merge settings into `[tool.ruff]` and `[tool.ruff.format]` sections (create if absent, merge if existing).
+
+### Step 4: Remove black from dependencies
+
+Remove `black` from dev/lint dependencies:
+
+```bash
+# With uv
+uvx --from uv uv remove --dev black 2>/dev/null || true
+```
+
+If not using uv, note it for manual removal.
+
+### Step 5: Verify migration
+
+Run the new hook to confirm it works:
+
+```bash
+pre-commit run ruff-format --all-files
+```
+
+If it exits 0, the migration is complete. If it produces diffs, this is expected on first run (ruff format may reformat some files differently from black). Commit the reformatted files as part of the migration.
+
+### Step 6: Report
+
+Print a summary of changes:
+
+```
+black → ruff-format migration complete
+=======================================
+.pre-commit-config.yaml   UPDATED (removed psf/black, added ruff-format hook)
+pyproject.toml            UPDATED ([tool.black] → [tool.ruff.format])
+
+Note: ruff-format is Black-compatible (same defaults), but may reformat a small
+number of files. Review the diff and include these reformatted files in the
+migration commit.
+
+Files to stage:
+  git add .pre-commit-config.yaml pyproject.toml
+  git add <any reformatted .py files>
+```
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Audit only | `/migration-patterns:black-to-ruff-format --check-only` |
+| Apply migration | `/migration-patterns:black-to-ruff-format --fix` |
+| Verify after migration | `pre-commit run ruff-format --all-files` |
+| Check format directly | `uvx ruff format --check .` |
+
+## Quick Reference
+
+| Item | Value |
+|------|-------|
+| ruff format docs | https://docs.astral.sh/ruff/formatter/ |
+| Black compatibility | ruff format is designed as a Black drop-in with ~99.9% compatible output |
+| Config section | `[tool.ruff.format]` in pyproject.toml |
+| Pre-commit hook | `ruff-format` in `astral-sh/ruff-pre-commit` |
+
+## See Also
+
+- `/migration-patterns:flake8-to-ruff` — Migrate flake8/isort linting to ruff
+- `/migration-patterns:mypy-to-ty` — Migrate mypy to ty
+- `/configure:repo` — End-to-end repo config driver

--- a/migration-patterns-plugin/skills/eslint-to-biome/SKILL.md
+++ b/migration-patterns-plugin/skills/eslint-to-biome/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: eslint-to-biome
+description: |
+  Migrate a JavaScript/TypeScript project from ESLint to Biome. Use when
+  .eslintrc* or eslint.config.* exists and no biome.json is present. Replaces
+  ESLint and Prettier configs/hooks with Biome, preserving rule equivalents.
+  Biome is a fast, zero-config-needed Rust linter+formatter that replaces both.
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash(find *), Bash(test *), Bash(npx *), Bash(bun *), AskUserQuestion, TodoWrite
+args: "[--check-only] [--fix]"
+argument-hint: "[--check-only] [--fix]"
+created: 2026-04-14
+modified: 2026-04-14
+reviewed: 2026-04-14
+---
+
+# /migration-patterns:eslint-to-biome
+
+Migrate from [ESLint](https://eslint.org/) (and optionally [Prettier](https://prettier.io/)) to [Biome](https://biomejs.dev/) — a fast, unified linter and formatter for JavaScript/TypeScript written in Rust. Migrates configuration, updates pre-commit hooks, and removes old dependencies.
+
+## When to Use This Skill
+
+| Use this skill when... | Keep ESLint when... |
+|------------------------|---------------------|
+| `biome.json` does not exist yet | You rely on an ESLint plugin with no Biome equivalent (e.g., `eslint-plugin-react-hooks`, `eslint-plugin-jsx-a11y`) |
+| `.eslintrc*` or `eslint.config.*` exists | CI requires ESLint's exit codes specifically |
+| You also want to replace Prettier with Biome formatter | Team has invested in custom ESLint rules |
+| Using TypeScript and want a single tool | |
+
+> **Important:** Biome covers ~90% of common ESLint rules but not all plugins. Audit `eslint-plugin-*` dependencies before migrating. The most common unsupported plugins are accessibility (jsx-a11y) and framework hooks (react-hooks). You may need to keep ESLint alongside Biome for these.
+
+## Context
+
+- ESLint configs: !`find . -maxdepth 2 \( -name '.eslintrc' -o -name '.eslintrc.js' -o -name '.eslintrc.cjs' -o -name '.eslintrc.json' -o -name '.eslintrc.yaml' -o -name '.eslintrc.yml' -o -name 'eslint.config.js' -o -name 'eslint.config.mjs' -o -name 'eslint.config.ts' \)`
+- Prettier configs: !`find . -maxdepth 2 \( -name '.prettierrc' -o -name '.prettierrc.js' -o -name '.prettierrc.json' -o -name 'prettier.config.js' \)`
+- Biome config: !`find . -maxdepth 2 -name 'biome.json'`
+- package.json: !`find . -maxdepth 1 -name 'package.json'`
+- Pre-commit config: !`find . -maxdepth 1 -name '.pre-commit-config.yaml'`
+
+## Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `--check-only` | Report what would change without modifying files |
+| `--fix` | Apply migration automatically |
+
+## Execution
+
+Execute this ESLint-to-Biome migration:
+
+### Step 1: Audit current ESLint/Prettier configuration
+
+1. Read all ESLint config files found in context.
+2. Read Prettier config files if present.
+3. Check package.json for `eslint*` and `prettier*` dependencies.
+4. Report findings:
+   ```
+   ESLint → Biome migration audit
+   ================================
+   ESLint config:    .eslintrc.json (N rules, plugins: [...])
+   Prettier config:  .prettierrc (printWidth=N, singleQuote=true)
+   ESLint plugins:   eslint-plugin-import, @typescript-eslint, ...
+   Biome support:    ✓ eslint-plugin-import → Biome handles this
+                     ⚠ eslint-plugin-jsx-a11y → No Biome equivalent (keep ESLint for this)
+   biome.json:       NOT PRESENT
+   ```
+   If `--check-only`, stop here.
+
+### Step 2: Check plugin compatibility
+
+For each `eslint-plugin-*` found, determine Biome coverage:
+
+| ESLint plugin | Biome equivalent |
+|---------------|-----------------|
+| `@typescript-eslint` | Biome has TypeScript-aware rules (`nursery/use*`, `suspicious/`, `correctness/`) |
+| `eslint-plugin-import` | Biome `correctness/noUndeclaredDependencies`, `correctness/noUnusedImports` |
+| `eslint-plugin-unicorn` | Biome has partial coverage via `style/` rules |
+| `eslint-plugin-jsx-a11y` | **Not covered by Biome** — keep ESLint for accessibility |
+| `eslint-plugin-react-hooks` | **Not covered by Biome** — keep ESLint for hooks rules |
+| `eslint-plugin-security` | Partial coverage in Biome `security/` rules |
+
+If unsupported plugins are found, ask the user whether to proceed with a partial migration (keep ESLint only for those plugins). If the user declines, abort.
+
+### Step 3: Create biome.json
+
+Generate `biome.json` preserving equivalent rules from the existing ESLint and Prettier configurations:
+
+```json
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.0/schema.json",
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 80
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "trailingCommas": "all",
+      "semicolons": "always"
+    }
+  }
+}
+```
+
+Adjust these defaults to match the Prettier config found in Step 1:
+- `lineWidth` → from `printWidth`
+- `quoteStyle` → from `singleQuote: true` → `"single"`
+- `trailingCommas` → from `trailingComma: "es5"` → `"es5"`
+- `semicolons` → from `semi: false` → `"asNeeded"`
+- `indentStyle` → from `useTabs: true` → `"tab"`
+
+### Step 4: Update package.json
+
+1. Remove ESLint and Prettier dev dependencies (if doing full migration):
+   ```
+   "devDependencies": {
+     remove: eslint, @typescript-eslint/parser, @typescript-eslint/eslint-plugin,
+             eslint-plugin-import, prettier, eslint-config-prettier, eslint-plugin-prettier
+     keep: eslint-plugin-jsx-a11y, eslint-plugin-react-hooks (if partial migration)
+   }
+   ```
+2. Add Biome:
+   ```json
+   "@biomejs/biome": "^1.9.0"
+   ```
+3. Update scripts in package.json:
+   ```json
+   {
+     "scripts": {
+       "lint": "biome check .",
+       "lint:fix": "biome check --write .",
+       "format": "biome format --write ."
+     }
+   }
+   ```
+
+### Step 5: Update .pre-commit-config.yaml (if present)
+
+Remove any ESLint/Prettier pre-commit hooks. Add Biome:
+
+```yaml
+- repo: https://github.com/biomejs/pre-commit
+  rev: v0.6.0  # use latest
+  hooks:
+    - id: biome-check
+      additional_dependencies: ["@biomejs/biome@1.9.0"]
+```
+
+### Step 6: Delete old config files
+
+Remove ESLint and Prettier config files (unless keeping ESLint for unsupported plugins — in that case, keep `.eslintrc` but note Biome replaces most rules):
+- `.eslintrc*` → delete (if full migration)
+- `eslint.config.*` → delete (if full migration)
+- `.prettierrc*` → delete
+- `.eslintignore` → convert relevant patterns to `biome.json` `ignore` section
+
+### Step 7: Verify migration
+
+Run Biome to confirm it works:
+
+```bash
+npx @biomejs/biome check .
+# or with bun:
+bunx @biomejs/biome check .
+```
+
+Address any errors that weren't caught by ESLint (Biome may surface additional issues). Errors on first run are expected — fix them or add to `biome.json` ignore rules.
+
+### Step 8: Report
+
+Print a summary:
+
+```
+ESLint → Biome migration complete
+===================================
+biome.json                CREATED
+package.json              UPDATED (added @biomejs/biome, removed eslint/prettier)
+.eslintrc.json            DELETED / KEPT (partial migration)
+.prettierrc               DELETED
+.pre-commit-config.yaml   UPDATED (added biome-check hook)
+
+Partial migration note (if applicable):
+  Kept eslint-plugin-jsx-a11y and eslint-plugin-react-hooks — these plugins
+  have no Biome equivalent. ESLint is still needed for these rules.
+
+Files to stage:
+  git add biome.json package.json .pre-commit-config.yaml
+  git add <deleted config files>
+```
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Audit only | `/migration-patterns:eslint-to-biome --check-only` |
+| Apply migration | `/migration-patterns:eslint-to-biome --fix` |
+| Check with Biome | `npx @biomejs/biome check .` |
+| Format with Biome | `npx @biomejs/biome format --write .` |
+
+## Quick Reference
+
+| Item | Value |
+|------|-------|
+| Biome docs | https://biomejs.dev/ |
+| ESLint migration guide | https://biomejs.dev/guides/migrate-eslint-prettier/ |
+| Config schema | `https://biomejs.dev/schemas/1.9.0/schema.json` |
+| Pre-commit hook | `biomejs/pre-commit` |
+
+## See Also
+
+- `/migration-patterns:black-to-ruff-format` — Python formatter migration (analogous pattern)
+- `/configure:repo` — End-to-end repo config driver

--- a/migration-patterns-plugin/skills/flake8-to-ruff/SKILL.md
+++ b/migration-patterns-plugin/skills/flake8-to-ruff/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: flake8-to-ruff
+description: |
+  Migrate a Python project from flake8 and/or isort to ruff linting.
+  Use when .pre-commit-config.yaml contains pycqa/flake8 or PyCQA/isort
+  hooks, or when [tool.flake8] or [tool.isort] config exists. Replaces both
+  hooks with a single ruff hook, migrates rule selections, and removes the
+  old tools from dependencies.
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash(find *), Bash(test *), Bash(pre-commit *), Bash(uvx *), AskUserQuestion, TodoWrite
+args: "[--check-only] [--fix]"
+argument-hint: "[--check-only] [--fix]"
+created: 2026-04-14
+modified: 2026-04-14
+reviewed: 2026-04-14
+---
+
+# /migration-patterns:flake8-to-ruff
+
+Migrate from [flake8](https://flake8.pycqa.org/) and/or [isort](https://pycqa.github.io/isort/) to [ruff](https://docs.astral.sh/ruff/) — consolidating linting and import sorting into a single, fast Rust-based tool. Replaces pre-commit hooks, migrates rule configuration, and removes old dependencies.
+
+## When to Use This Skill
+
+| Use this skill when... | Keep flake8/isort when... |
+|------------------------|--------------------------|
+| `.pre-commit-config.yaml` contains `pycqa/flake8` or `PyCQA/isort` | You rely on a flake8 plugin with no ruff equivalent |
+| `[tool.flake8]` or `[tool.isort]` config exists | Team uses flake8 API in custom scripts |
+| Looking to consolidate linting tooling | CI requires specific flake8 exit codes |
+| Using ruff format and wanting a unified tool | |
+
+## Context
+
+- Pre-commit config: !`find . -maxdepth 1 -name '.pre-commit-config.yaml'`
+- pyproject.toml: !`find . -maxdepth 1 -name 'pyproject.toml'`
+- setup.cfg: !`find . -maxdepth 1 -name 'setup.cfg'`
+- .flake8: !`find . -maxdepth 1 -name '.flake8'`
+- ruff already present: !`find . -maxdepth 1 -name 'ruff.toml'`
+
+## Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `--check-only` | Report what would change without modifying files |
+| `--fix` | Apply migration automatically |
+
+## Execution
+
+Execute this flake8/isort-to-ruff migration:
+
+### Step 1: Audit current configuration
+
+1. Read `.pre-commit-config.yaml` and locate `pycqa/flake8`, `PyCQA/isort`, and `pycqa/pep8-naming` entries.
+2. Read all config sources: `pyproject.toml` (`[tool.flake8]`, `[tool.isort]`), `setup.cfg` (`[flake8]`, `[isort]`), `.flake8`.
+3. Report findings:
+   ```
+   flake8/isort → ruff migration audit
+   =====================================
+   pre-commit hooks:  pycqa/flake8 v<rev>, PyCQA/isort v<rev>
+   flake8 config:     [tool.flake8] max-line-length=<N>, extend-ignore=[E501,W503], per-file-ignores=<...>
+   isort config:      [tool.isort] profile=black, known-first-party=[...]
+   ruff already:      EXISTS / NOT PRESENT
+   ```
+   If `--check-only`, stop here.
+
+### Step 2: Build ruff rule selection
+
+Map flake8 plugins and ignore rules to ruff equivalents:
+
+| flake8 config | ruff equivalent |
+|---------------|----------------|
+| `max-line-length = N` | `[tool.ruff] line-length = N` |
+| `extend-ignore = E501` | `[tool.ruff.lint] ignore = ["E501"]` |
+| `per-file-ignores = path:E501` | `[tool.ruff.lint.per-file-ignores] "path" = ["E501"]` |
+| `pep8-naming` plugin | add `"N"` to `select` |
+| `flake8-bugbear` plugin | add `"B"` to `select` |
+| `flake8-annotations` plugin | add `"ANN"` to `select` |
+
+For isort config:
+
+| isort config | ruff equivalent |
+|--------------|----------------|
+| `profile = black` | `[tool.ruff.lint.isort] force-single-line = false` |
+| `known-first-party = [...]` | `[tool.ruff.lint.isort] known-first-party = [...]` |
+| `multi-line-output = 3` | Handled by ruff's Black-compatible default |
+| `force-sort-within-sections` | `[tool.ruff.lint.isort] force-sort-within-sections = true` |
+
+Baseline ruff rule selection (add to existing if present):
+
+```toml
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "N", "B"]
+# E/W = pycodestyle, F = pyflakes, I = isort, N = pep8-naming, B = bugbear
+```
+
+Preserve any existing ignores from flake8 config.
+
+### Step 3: Update .pre-commit-config.yaml
+
+Remove `pycqa/flake8`, `PyCQA/isort`, and any flake8 plugin repos. Add or extend the ruff pre-commit block:
+
+```yaml
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.9.1  # use latest stable ruff version
+  hooks:
+    - id: ruff
+      args: [--fix]
+    - id: ruff-format  # include if also migrating from black
+```
+
+### Step 4: Update pyproject.toml
+
+1. Remove `[tool.flake8]` and `[tool.isort]` sections.
+2. Add/merge `[tool.ruff]`, `[tool.ruff.lint]`, and `[tool.ruff.lint.isort]` sections with converted config.
+3. Remove `flake8*` and `isort` from dev/lint dependencies:
+   ```bash
+   uvx --from uv uv remove --dev flake8 isort 2>/dev/null || true
+   ```
+
+### Step 5: Remove other config files
+
+If standalone config files exist, delete them:
+- `.flake8` → delete (config is now in `pyproject.toml`)
+- `setup.cfg` `[flake8]`/`[isort]` sections → remove those sections
+
+### Step 6: Verify migration
+
+Run the new hook to confirm it works:
+
+```bash
+pre-commit run ruff --all-files
+```
+
+Note any new lint errors introduced by ruff's stricter defaults. Decide whether to:
+- Fix them immediately
+- Add temporary ignore rules in `[tool.ruff.lint] ignore`
+- Accept them as a follow-up
+
+### Step 7: Report
+
+Print a summary:
+
+```
+flake8/isort → ruff migration complete
+========================================
+.pre-commit-config.yaml   UPDATED (removed flake8/isort hooks, added ruff hook)
+pyproject.toml            UPDATED ([tool.flake8]+[tool.isort] → [tool.ruff.lint])
+.flake8                   DELETED / NOT FOUND
+setup.cfg                 UPDATED (removed [flake8]/[isort] sections) / NOT FOUND
+
+Note: Ruff may surface new lint errors not caught by flake8. Review with:
+  uvx ruff check . --select E,W,F,I,N,B
+
+Files to stage:
+  git add .pre-commit-config.yaml pyproject.toml .flake8 setup.cfg
+```
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Audit only | `/migration-patterns:flake8-to-ruff --check-only` |
+| Apply migration | `/migration-patterns:flake8-to-ruff --fix` |
+| Verify after migration | `pre-commit run ruff --all-files` |
+| Check with specific rules | `uvx ruff check . --select E,W,F,I` |
+
+## Quick Reference
+
+| Item | Value |
+|------|-------|
+| ruff rule docs | https://docs.astral.sh/ruff/rules/ |
+| isort equivalent | select `"I"` in ruff |
+| pep8-naming equivalent | select `"N"` in ruff |
+| Config section | `[tool.ruff.lint]` and `[tool.ruff.lint.isort]` |
+
+## See Also
+
+- `/migration-patterns:black-to-ruff-format` — Migrate black to ruff format
+- `/migration-patterns:mypy-to-ty` — Migrate mypy to ty
+- `/configure:repo` — End-to-end repo config driver

--- a/migration-patterns-plugin/skills/mypy-to-ty/SKILL.md
+++ b/migration-patterns-plugin/skills/mypy-to-ty/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: mypy-to-ty
+description: |
+  Migrate a Python project from mypy to ty (Astral's type checker). Use when
+  .pre-commit-config.yaml contains mirrors-mypy, or when [tool.mypy] config
+  exists in pyproject.toml, and you want to switch to the faster ty checker.
+  Swaps the pre-commit hook to a local repo running uvx ty check, converts
+  [tool.mypy] to [tool.ty], and removes mypy.ini.
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash(find *), Bash(test *), Bash(pre-commit *), Bash(uvx *), AskUserQuestion, TodoWrite
+args: "[--check-only] [--fix]"
+argument-hint: "[--check-only] [--fix]"
+created: 2026-04-14
+modified: 2026-04-14
+reviewed: 2026-04-14
+---
+
+# /migration-patterns:mypy-to-ty
+
+Migrate from mypy to [ty](https://github.com/astral-sh/ty) — Astral's new fast Python type checker. Replaces the `mirrors-mypy` pre-commit hook with a local `repo: local` hook using `uvx ty check`, migrates config from `[tool.mypy]` to `[tool.ty]`, and removes `mypy.ini`.
+
+## When to Use This Skill
+
+| Use this skill when... | Keep mypy when... |
+|------------------------|-------------------|
+| `.pre-commit-config.yaml` contains `mirrors-mypy` | ty does not yet support a specific mypy plugin you rely on |
+| `[tool.mypy]` section exists in `pyproject.toml` | CI pipeline depends on mypy-specific exit codes or plugins |
+| You want faster type checking (ty is written in Rust) | Project uses mypy daemon (`dmypy`) for incremental checks |
+| Repo uses uv and the astral stack already | Team prefers mypy's error message format |
+
+## Context
+
+- Pre-commit config: !`find . -maxdepth 1 -name '.pre-commit-config.yaml'`
+- pyproject.toml: !`find . -maxdepth 1 -name 'pyproject.toml'`
+- mypy.ini: !`find . -maxdepth 1 -name 'mypy.ini'`
+- uv available: !`find . -maxdepth 1 -name 'uv.lock'`
+
+## Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `--check-only` | Report what would change without modifying files |
+| `--fix` | Apply migration automatically |
+
+## Execution
+
+Execute this mypy-to-ty migration:
+
+### Step 1: Audit current mypy configuration
+
+1. Read `.pre-commit-config.yaml` and locate any `mirrors-mypy` or `mypy` entries.
+2. Read `pyproject.toml` and extract the `[tool.mypy]` section.
+3. Check for `mypy.ini`.
+4. Report findings:
+   ```
+   mypy → ty migration audit
+   ==========================
+   pre-commit hook:   mirrors-mypy found at rev <rev>
+   pyproject.toml:    [tool.mypy] section found (N lines)
+   mypy.ini:          FOUND / NOT FOUND
+   uv.lock:           EXISTS (uv available) / MISSING
+   ```
+   If `--check-only`, stop here.
+
+### Step 2: Update .pre-commit-config.yaml
+
+Remove the `mirrors-mypy` repo block. Add a `repo: local` hook for ty:
+
+```yaml
+- repo: local
+  hooks:
+    - id: ty
+      name: ty type check
+      entry: uvx ty check
+      language: system
+      types: [python]
+      pass_filenames: false
+```
+
+**Note:** `astral-sh/ty-pre-commit` does not yet exist as a hosted pre-commit repo. The `repo: local` pattern with `uvx ty check` is the correct approach until an official mirror is published.
+
+If an `entry: mypy` hook in a non-mirrors-mypy repo exists, replace it similarly.
+
+### Step 3: Migrate [tool.mypy] → [tool.ty] in pyproject.toml
+
+Read the `[tool.mypy]` section and convert each key to the ty equivalent:
+
+| mypy key | ty equivalent | Notes |
+|----------|--------------|-------|
+| `python_version` | `python-version` | Rename only |
+| `strict` | `strict` | Same |
+| `warn_return_any` | `warn-return-any` | Kebab-case |
+| `disallow_untyped_defs` | `disallow-untyped-defs` | Kebab-case |
+| `ignore_missing_imports` | Not needed | ty resolves stubs natively |
+| `exclude` | `exclude` | Same |
+| Per-module `[[tool.mypy.overrides]]` | Drop or convert manually | Note for manual review |
+
+Remove the `[tool.mypy]` section (and any `[[tool.mypy.overrides]]` sections). Add `[tool.ty]` with converted keys. Annotate any options that need manual review.
+
+### Step 4: Remove mypy.ini
+
+If `mypy.ini` exists, delete it. Its content should already be in `[tool.ty]` after Step 3.
+
+### Step 5: Remove mypy from dependencies
+
+If `mypy` appears in `pyproject.toml` dev/lint dependencies, remove it:
+
+```bash
+# With uv
+uvx --from uv uv remove --dev mypy 2>/dev/null || true
+```
+
+If not using uv, note it for manual removal.
+
+### Step 6: Verify migration
+
+Run the new hook to confirm it works:
+
+```bash
+pre-commit run ty --all-files
+```
+
+If it exits 0, the migration is complete. If it exits non-zero:
+- Summarize ty errors
+- Suggest addressing them before committing
+
+### Step 7: Report
+
+Print a summary of all changes made and list files to commit:
+
+```
+mypy → ty migration complete
+=============================
+.pre-commit-config.yaml   UPDATED (removed mirrors-mypy, added local ty hook)
+pyproject.toml            UPDATED ([tool.mypy] → [tool.ty])
+mypy.ini                  DELETED / NOT FOUND
+
+Manual review needed:
+  - [[tool.mypy.overrides]] sections were dropped — verify ty handles them
+  - Check ty docs for any unsupported mypy options
+
+Files to stage:
+  git add .pre-commit-config.yaml pyproject.toml
+```
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Audit only | `/migration-patterns:mypy-to-ty --check-only` |
+| Apply migration | `/migration-patterns:mypy-to-ty --fix` |
+| Verify after migration | `pre-commit run ty --all-files` |
+| Test ty directly | `uvx ty check .` |
+
+## Quick Reference
+
+| Item | Value |
+|------|-------|
+| ty docs | https://github.com/astral-sh/ty |
+| Pre-commit hook type | `repo: local`, `entry: uvx ty check` |
+| Config section | `[tool.ty]` in pyproject.toml |
+| Key difference | ty uses kebab-case keys; mypy uses underscore |
+
+## See Also
+
+- `/migration-patterns:black-to-ruff-format` — Migrate from black to ruff format
+- `/migration-patterns:flake8-to-ruff` — Migrate flake8/isort to ruff
+- `/configure:repo` — End-to-end repo config driver

--- a/scripts/check-driver-freshness.sh
+++ b/scripts/check-driver-freshness.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# check-driver-freshness.sh
+# Verify that the /configure:repo driver skill is not out of sync with its dependencies.
+#
+# Checks:
+#   1. For each dependency SKILL.md, compare its `modified:` date to the driver's `reviewed:` date.
+#      Exits non-zero if any dependency is newer than the driver's last review.
+#   2. Exits non-zero if the driver's `reviewed:` date is older than 90 days (staleness check).
+#
+# Usage:
+#   ./scripts/check-driver-freshness.sh [--driver <path>] [--max-age-days <N>]
+#
+# Exit codes:
+#   0 - Driver is fresh
+#   1 - Driver is stale (dependency newer than reviewed: date, or reviewed: >N days old)
+
+set -uo pipefail
+
+# Change to repository root
+cd "$(dirname "$0")/.." || exit 1
+
+# Defaults
+DRIVER_PATH="configure-plugin/skills/configure-repo/SKILL.md"
+MAX_AGE_DAYS=90
+VERBOSE=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --driver)
+      DRIVER_PATH="$2"
+      shift 2
+      ;;
+    --max-age-days)
+      MAX_AGE_DAYS="$2"
+      shift 2
+      ;;
+    --verbose|-v)
+      VERBOSE=true
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      echo "Usage: $0 [--driver <path>] [--max-age-days <N>] [--verbose]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+extract_date_field() {
+  local skill_file="$1"
+  local field_name="$2"
+  head -20 "$skill_file" | grep -m1 "^${field_name}:" | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r '
+}
+
+# Cross-platform date → epoch seconds
+date_to_epoch() {
+  local date_str="$1"
+  if date -j -f "%Y-%m-%d" "$date_str" "+%s" >/dev/null 2>&1; then
+    date -j -f "%Y-%m-%d" "$date_str" "+%s"
+  elif date -d "$date_str" "+%s" >/dev/null 2>&1; then
+    date -d "$date_str" "+%s"
+  else
+    echo "0"
+  fi
+}
+
+today_epoch() {
+  if date -j "+%s" >/dev/null 2>&1; then
+    date -j "+%s"
+  else
+    date "+%s"
+  fi
+}
+
+log() {
+  echo "$@"
+}
+
+verbose() {
+  if $VERBOSE; then
+    echo "  $*"
+  fi
+}
+
+# ── Validate driver exists ───────────────────────────────────────────────────
+
+if [ ! -f "$DRIVER_PATH" ]; then
+  echo "ERROR: Driver skill not found: $DRIVER_PATH" >&2
+  exit 1
+fi
+
+# ── Extract driver reviewed: date ─────────────────────────────────────────────
+
+driver_reviewed=$(extract_date_field "$DRIVER_PATH" "reviewed")
+
+if [ -z "$driver_reviewed" ]; then
+  echo "ERROR: Driver skill has no 'reviewed:' date in frontmatter: $DRIVER_PATH" >&2
+  exit 1
+fi
+
+verbose "Driver: $DRIVER_PATH"
+verbose "Driver reviewed: $driver_reviewed"
+
+driver_epoch=$(date_to_epoch "$driver_reviewed")
+
+if [ "$driver_epoch" = "0" ]; then
+  echo "ERROR: Could not parse driver reviewed date: $driver_reviewed" >&2
+  exit 1
+fi
+
+# ── Parse dependency skill paths from driver ──────────────────────────────────
+
+# Extract paths from the Dependencies table in the SKILL.md
+# Looks for lines like: | `/configure:claude-plugins` | `configure-plugin/skills/configure-claude-plugins/SKILL.md` |
+dependency_paths=()
+while IFS= read -r dep_path; do
+  if [ -n "$dep_path" ] && [ -f "$dep_path" ]; then
+    dependency_paths+=("$dep_path")
+  elif [ -n "$dep_path" ]; then
+    verbose "WARNING: Dependency not found: $dep_path"
+  fi
+done < <(grep -oE '[a-z][a-z0-9-]+/skills/[a-z0-9-]+/SKILL\.md' "$DRIVER_PATH" | sort -u)
+
+# ── Check each dependency ────────────────────────────────────────────────────
+
+failed=false
+stale_deps=()
+
+for dep_file in "${dependency_paths[@]}"; do
+  dep_modified=$(extract_date_field "$dep_file" "modified")
+
+  if [ -z "$dep_modified" ]; then
+    verbose "SKIP: $dep_file has no 'modified:' date"
+    continue
+  fi
+
+  dep_epoch=$(date_to_epoch "$dep_modified")
+
+  if [ "$dep_epoch" = "0" ]; then
+    verbose "SKIP: Could not parse modified date '$dep_modified' for $dep_file"
+    continue
+  fi
+
+  verbose "Checking: $dep_file  modified=$dep_modified  driver-reviewed=$driver_reviewed"
+
+  if [ "$dep_epoch" -gt "$driver_epoch" ]; then
+    stale_deps+=("$dep_file (modified: $dep_modified, driver reviewed: $driver_reviewed)")
+    failed=true
+  fi
+done
+
+# ── Check driver age (>MAX_AGE_DAYS) ──────────────────────────────────────────
+
+now_epoch=$(today_epoch)
+age_seconds=$(( now_epoch - driver_epoch ))
+age_days=$(( age_seconds / 86400 ))
+
+verbose "Driver age: ${age_days} days (max: ${MAX_AGE_DAYS})"
+
+driver_age_stale=false
+if [ "$age_days" -gt "$MAX_AGE_DAYS" ]; then
+  driver_age_stale=true
+  failed=true
+fi
+
+# ── Report ───────────────────────────────────────────────────────────────────
+
+log ""
+log "Driver Freshness Check"
+log "======================"
+log "Driver:    $DRIVER_PATH"
+log "Reviewed:  $driver_reviewed  (${age_days} days ago)"
+log "Max age:   ${MAX_AGE_DAYS} days"
+log ""
+
+if [ ${#stale_deps[@]} -gt 0 ]; then
+  log "FAIL: ${#stale_deps[@]} dependency(ies) newer than driver's reviewed: date:"
+  for dep in "${stale_deps[@]}"; do
+    log "  - $dep"
+  done
+  log ""
+  log "Update the driver skill, bump its 'reviewed:' date, and document any"
+  log "behaviour changes from the updated dependency."
+fi
+
+if $driver_age_stale; then
+  log "FAIL: Driver reviewed: date is ${age_days} days old (>${MAX_AGE_DAYS} days)."
+  log "  Even if no dependencies changed, the driver should be re-reviewed"
+  log "  quarterly to catch upstream claude-code behaviour changes."
+fi
+
+if ! $failed; then
+  log "OK: Driver is fresh."
+  log "  All ${#dependency_paths[@]} dependencies are older than or equal to the driver's reviewed: date."
+  log "  Driver age: ${age_days} days (within ${MAX_AGE_DAYS}-day threshold)."
+fi
+
+log ""
+
+$failed && exit 1 || exit 0


### PR DESCRIPTION
Closes #1021

## Summary

- Gap 1: `configure-claude-plugins` now writes `extraKnownMarketplaces` + `enabledPlugins` to `.claude/settings.json` (critical for ephemeral web sessions)
- Gap 2: New `configure-repo/SKILL.md` — end-to-end driver `/configure:repo` orchestrating all config steps
- Gap 3: Stack-aware `permissions.allow` templates for Python, Node, Go, Rust, ESP-IDF, ESPHome
- Gap 4: `health:check` extended with SessionStart smoke test, pre-commit validator, permissions coverage, marketplace enrollment check
- Gap 5: Four tooling migration skills (mypy→ty, black→ruff-format, flake8→ruff, ESLint→Biome) in migration-patterns-plugin
- Gap 6: `scripts/check-driver-freshness.sh` + pre-commit hook to detect driver drift

## Test plan

- [ ] Run `/configure:repo --check-only` on a fresh repo and verify the dry-run output
- [ ] Run `/configure:repo --fix` on an ESP32 repo and verify `.claude/settings.json` contains `extraKnownMarketplaces`
- [ ] Run `bash scripts/check-driver-freshness.sh` and confirm it exits 0
- [ ] Run `/health:check` and verify new Steps 5-8 are executed
- [ ] Run `/migration-patterns:mypy-to-ty --check-only` on a repo with mirrors-mypy

Generated with [Claude Code](https://claude.ai/code)