### PR TITLE
feat(health-plugin): refactor /health:check into scope-routed diagnostic command

### DIFF
--- a/configure-plugin/skills/configure-repo/SKILL.md
+++ b/configure-plugin/skills/configure-repo/SKILL.md
@@ -12,7 +12,7 @@ args: "[--check-only] [--skip-health] [--skip-migrations]"
 argument-hint: "[--check-only] [--skip-health] [--skip-migrations]"
 created: 2026-04-14
 modified: 2026-04-14
-reviewed: 2026-04-14
+reviewed: 2026-04-16
 ---
 
 # /configure:repo

--- a/docs/PLUGIN-MAP.md
+++ b/docs/PLUGIN-MAP.md
@@ -6,7 +6,7 @@ Navigation guide for 37 plugins and 300+ skills. Start here.
 
 | Intent | Commands | What happens |
 |--------|----------|--------------|
-| Diagnose setup | `/health:check` then `/health:audit` | Scans config, recommends plugins for your stack |
+| Diagnose setup | `/health:check` | Scans config and (by default) recommends plugins for your stack |
 | New project | `/project:init` then `/blueprint:init` | Scaffolds project, creates PRD |
 | Resume work | `/blueprint:execute` | Analyzes repo state, picks next action, runs it |
 
@@ -204,8 +204,7 @@ Commands organized by workflow phase.
 
 | Phase | Command | Purpose |
 |-------|---------|---------|
-| **Diagnose** | `/health:check` | Scan Claude Code configuration |
-| **Diagnose** | `/health:audit` | Recommend plugins for your stack |
+| **Diagnose** | `/health:check` | Scan Claude Code configuration (use `--scope=registry\|stack\|agentic` to narrow) |
 | **Diagnose** | `/attributes:collect` | Collect structured health attributes |
 | **Diagnose** | `/attributes:dashboard` | Compact health dashboard |
 | **Diagnose** | `/attributes:route` | Route to agents by attribute severity |

--- a/health-plugin/README.md
+++ b/health-plugin/README.md
@@ -12,12 +12,20 @@ Diagnose and fix Claude Code configuration issues including plugin registry, set
 
 | Skill | Description |
 |-------|-------------|
-| `/health:agentic-audit` | Audit skills, commands, and agents for agentic output optimization |
-| `/health:audit` | Audit enabled plugins against project tech stack and recommend additions/removals |
-| `/health:check` | Comprehensive diagnostic scan of Claude Code environment |
-| `/health:plugins` | Diagnose and fix plugin registry issues (addresses [#14202](https://github.com/anthropics/claude-code/issues/14202)) |
-| `plugin-registry` | Understanding Claude Code's plugin registry, scopes, and troubleshooting |
-| `settings-configuration` | Settings file hierarchy, permission wildcards, and patterns |
+| `/health:check` | **Single entry point.** Diagnose (and optionally fix) Claude Code environment, plugin registry, project-stack fit, and skill agentic-optimisation — routed by `--scope`. |
+| `plugin-registry` | Reference skill: Claude Code's plugin registry, scopes, and troubleshooting |
+| `settings-configuration` | Reference skill: settings file hierarchy, permission wildcards, and patterns |
+
+### Internal scopes (routed by `/health:check --scope=...`)
+
+| Scope | Covers | Internal skill |
+|-------|--------|----------------|
+| `registry` | Orphaned `projectPath` entries, stale `enabledPlugins` keys (addresses [#14202](https://github.com/anthropics/claude-code/issues/14202)) | `health-plugins` |
+| `stack` | Enabled plugins vs project tech stack | `health-audit` |
+| `agentic` | Skill/command/agent agentic-optimisation compliance | `health-agentic-audit` |
+| `all` | All of the above (default) | — |
+
+These internal skills are auto-discoverable but not user-invocable — use `/health:check` instead.
 
 ## Scripts
 
@@ -33,10 +41,10 @@ This is a known issue ([#14202](https://github.com/anthropics/claude-code/issues
 
 ```bash
 # Diagnose the issue
-/health:plugins
+/health:check --scope=registry
 
 # Fix automatically
-/health:plugins --fix
+/health:check --scope=registry --fix
 ```
 
 ### Full Environment Health Check
@@ -55,13 +63,13 @@ Ensure only relevant plugins are enabled for your project:
 
 ```bash
 # See what plugins are relevant to this project
-/health:audit
+/health:check --scope=stack
 
 # Preview changes without applying
-/health:audit --dry-run
+/health:check --scope=stack --fix --dry-run
 
 # Apply recommended changes
-/health:audit --fix
+/health:check --scope=stack --fix
 ```
 
 This analyzes your project's tech stack (package.json, Cargo.toml, Dockerfile, etc.) and recommends:
@@ -114,8 +122,8 @@ Your settings, MCP servers, and tips history are preserved.
 
 | Symptom | Likely Cause | Command |
 |---------|--------------|---------|
-| Plugin not working | Wrong projectPath in registry | `/health:plugins --fix` |
-| Irrelevant plugins enabled | No relevance audit done | `/health:audit --fix` |
+| Plugin not working | Wrong projectPath in registry | `/health:check --scope=registry --fix` |
+| Irrelevant plugins enabled | No relevance audit done | `/health:check --scope=stack --fix` |
 | Permission denied | Missing allow pattern | Check settings-configuration skill |
 | Settings ignored | Invalid JSON | `/health:check` |
 | Large ~/.claude.json | Orphaned projects/caches | `prune-claude-config.py` |

--- a/health-plugin/docs/flow.md
+++ b/health-plugin/docs/flow.md
@@ -1,0 +1,60 @@
+# Health Plugin Flow
+
+```mermaid
+flowchart TD
+    U[User] -->|/health:check<br/>--scope --fix --dry-run| R["/health:check<br/>(router)"]
+
+    R --> ENV[Step 1: Environment checks]
+    ENV --> CP[check-plugins.sh]
+    ENV --> CS[check-settings.sh]
+    ENV --> CH[check-hooks.sh]
+    ENV --> CM[check-mcp.sh]
+
+    R --> SCOPE{scope?}
+    SCOPE -->|registry<br/>or all| REG[check-registry.sh<br/>• orphaned projectPath<br/>• stale enabledPlugins<br/>• marketplace drift]
+    SCOPE -->|stack<br/>or all| STK[health-audit<br/>enabled plugins vs.<br/>project tech stack]
+    SCOPE -->|agentic<br/>or all| AGT[health-agentic-audit<br/>skill optimisation<br/>compliance]
+
+    CP & CS & CH & CM & REG & STK & AGT --> RPT[Step 3: Consolidated report<br/>grouped by scope]
+
+    RPT --> FIX{--fix?}
+    FIX -->|no| DONE[Done]
+    FIX -->|yes, multi-scope| ASK[AskUserQuestion<br/>pick scopes to fix]
+    FIX -->|yes, single scope| DELEGATE
+    ASK --> DELEGATE{selected scope}
+
+    DELEGATE -->|registry| FR[fix-registry.sh<br/>backup settings.json<br/>prune orphans<br/>jq del enabledPlugins<br/>RESTART_REQUIRED=true]
+    DELEGATE -->|stack| FS[health-audit --fix<br/>disable irrelevant<br/>install missing]
+    DELEGATE -->|agentic| FA[health-agentic-audit --fix<br/>add optimisation tables<br/>update reviewed dates]
+
+    FR & FS & FA --> VER[Step 5: Verify<br/>re-run checks]
+    VER --> DONE
+
+    classDef router fill:#4a9eff,stroke:#1a6ecc,color:#fff
+    classDef check fill:#8fbc8f,stroke:#556b55,color:#000
+    classDef fix fill:#ffa500,stroke:#b37400,color:#000
+    classDef prompt fill:#dda0dd,stroke:#8b5a8b,color:#000
+
+    class R router
+    class CP,CS,CH,CM,REG,STK,AGT check
+    class FR,FS,FA fix
+    class ASK prompt
+```
+
+## Legend
+
+| Node style | Meaning |
+|------------|---------|
+| Blue | Router skill (`/health:check`) |
+| Green | Read-only diagnostic script |
+| Orange | Fix script (writes files, backs up first) |
+| Purple | Interactive `AskUserQuestion` prompt |
+
+## Scope → Skill mapping
+
+| `--scope` | Check | Fix |
+|-----------|-------|-----|
+| `registry` | `health-plugins/scripts/check-registry.sh` | `health-plugins/scripts/fix-registry.sh` |
+| `stack` | `health-audit/` workflow | `health-audit/` `--fix` flow |
+| `agentic` | `health-agentic-audit/` workflow | `health-agentic-audit/` `--fix` flow |
+| `all` | All of the above + environment checks | `AskUserQuestion` to pick scopes |

--- a/health-plugin/skills/health-agentic-audit/SKILL.md
+++ b/health-plugin/skills/health-agentic-audit/SKILL.md
@@ -1,7 +1,8 @@
 ---
 created: 2026-02-05
-modified: 2026-02-10
-reviewed: 2026-02-08
+modified: 2026-04-15
+reviewed: 2026-04-15
+user-invocable: false
 description: Audit skills and agents for agentic output optimization (missing compact/JSON flags, missing Agentic Optimizations tables)
 allowed-tools: Bash(find *), Bash(head *), Read, Grep, Glob, TodoWrite
 args: "[--fix] [--verbose]"

--- a/health-plugin/skills/health-audit/SKILL.md
+++ b/health-plugin/skills/health-audit/SKILL.md
@@ -1,7 +1,8 @@
 ---
 created: 2026-02-05
-modified: 2026-03-18
-reviewed: 2026-02-05
+modified: 2026-04-15
+reviewed: 2026-04-15
+user-invocable: false
 description: Audit enabled plugins against project tech stack and recommend additions/removals for relevance
 allowed-tools: Bash(test *), Bash(find *), Bash(jq *), Bash(claude plugin *), Read, Write, Edit, Glob, Grep, TodoWrite, AskUserQuestion
 args: "[--fix] [--dry-run] [--verbose]"

--- a/health-plugin/skills/health-check/SKILL.md
+++ b/health-plugin/skills/health-check/SKILL.md
@@ -1,79 +1,74 @@
 ---
 created: 2026-02-04
-modified: 2026-04-14
-reviewed: 2026-04-14
-description: Run a comprehensive diagnostic scan of Claude Code configuration including plugins, settings, hooks, MCP servers, SessionStart executability, pre-commit validity, permissions coverage, and marketplace enrollment
-allowed-tools: Bash(bash *), Read, Glob, Grep, TodoWrite
-args: "[--fix] [--verbose]"
-argument-hint: "[--fix] [--verbose]"
+modified: 2026-04-16
+reviewed: 2026-04-16
+description: Run a comprehensive diagnostic scan of Claude Code configuration (plugins, settings, hooks, MCP servers, SessionStart executability, pre-commit validity, permissions coverage, marketplace enrollment) and optionally fix detected issues across registry, stack relevance, and agentic optimisation scopes
+allowed-tools: Bash(bash *), Bash(pre-commit *), Read, Glob, Grep, TodoWrite, AskUserQuestion
+args: "[--scope=all|registry|stack|agentic] [--fix] [--dry-run] [--verbose]"
+argument-hint: "[--scope=all|registry|stack|agentic] [--fix] [--dry-run] [--verbose]"
 name: health-check
 ---
 
 # /health:check
 
-Run a comprehensive diagnostic scan of your Claude Code environment. Identifies issues with plugin registry, settings files, hooks configuration, and MCP servers.
+Single entry point for Claude Code health diagnostics. Runs environment checks (plugin registry, settings, hooks, MCP servers, SessionStart executability, pre-commit validity, permissions coverage, marketplace enrollment) plus optional deeper audits, and routes `--fix` to the appropriate internal workflow.
 
 ## When to Use This Skill
 
 | Use this skill when... | Use another approach when... |
 |------------------------|------------------------------|
-| Running comprehensive Claude Code diagnostics | Checking specific component only (use `/health:plugins`, `/health:settings`) |
-| Troubleshooting general Claude Code issues | Plugin registry issues only (use `/health:plugins --fix`) |
-| Validating environment configuration | Auditing plugins for project fit (use `/health:audit`) |
-| Identifying misconfigured settings or hooks | Just viewing settings (use Read tool on settings.json) |
-| Quick health check before starting work | Need agentic optimization audit (use `/health:agentic-audit`) |
+| Running Claude Code diagnostics | Viewing raw settings (use Read on settings.json) |
+| Troubleshooting plugin registry issues | Inspecting marketplace metadata manually |
+| Auditing plugins for project fit | Installing a specific plugin (use `/plugin install`) |
+| Checking skill agentic-optimisation quality | Editing a single known skill |
+| One-stop `--fix` across registry/stack/agentic | Precise surgical edits to a single file |
 
 ## Context
 
-- User home: !`echo $HOME`
 - Current project: !`pwd`
 - Project settings exists: !`find .claude -maxdepth 1 -name 'settings.json'`
 - Local settings exists: !`find .claude -maxdepth 1 -name 'settings.local.json'`
 
 ## Parameters
 
+Parse these from `$ARGUMENTS`:
+
 | Parameter | Description |
 |-----------|-------------|
-| `--fix` | Attempt to automatically fix identified issues |
-| `--verbose` | Show detailed diagnostic information |
+| `--scope=<all\|registry\|stack\|agentic>` | Which audits to run. Default `all`. |
+| `--fix` | Apply fixes to findings (prompts for confirmation). |
+| `--dry-run` | Preview fixes without modifying files. |
+| `--verbose` | Include detailed diagnostics. |
+
+**Scope semantics:**
+
+| Scope | Covers |
+|-------|--------|
+| `registry` | Plugin registry health (orphaned `projectPath`, stale `enabledPlugins`, registry-vs-settings drift) |
+| `stack` | Enabled plugins vs detected project tech stack |
+| `agentic` | Skill/command/agent agentic-optimisation compliance |
+| `all` | Environment checks + all three audits |
 
 ## Execution
 
-Execute this comprehensive health check by running the diagnostic scripts. Pass `--verbose` and `--fix` flags through from `$ARGUMENTS` when specified.
+Execute this diagnostic router. Default scope is `all` when `--scope` is not provided.
 
-### Step 1: Check plugin registry
+### Step 1: Run environment checks (always)
 
-```bash
-bash "${CLAUDE_SKILL_DIR}/scripts/check-plugins.sh" --home-dir "$HOME" --project-dir "$(pwd)" [--fix] [--verbose]
-```
+Environment checks run regardless of `--scope`. They cover the baseline health of the Claude Code installation and the current project's `.claude/` directory.
 
-Parse the `STATUS=` and `ISSUES:` lines from output.
-
-### Step 2: Validate settings files
+#### 1a. Core environment scripts
 
 ```bash
-bash "${CLAUDE_SKILL_DIR}/scripts/check-settings.sh" --home-dir "$HOME" --project-dir "$(pwd)" [--verbose]
+bash "${CLAUDE_SKILL_DIR}/scripts/check-plugins.sh" --home-dir "$HOME" --project-dir "$(pwd)"
+bash "${CLAUDE_SKILL_DIR}/scripts/check-settings.sh" --home-dir "$HOME" --project-dir "$(pwd)"
+bash "${CLAUDE_SKILL_DIR}/scripts/check-hooks.sh" --home-dir "$HOME" --project-dir "$(pwd)"
+bash "${CLAUDE_SKILL_DIR}/scripts/check-mcp.sh" --home-dir "$HOME" --project-dir "$(pwd)"
 ```
 
-Parse the `STATUS=` and `ISSUES:` lines from output.
+Parse `STATUS=` and `ISSUES:` from each. Pass `--verbose` when set on `$ARGUMENTS`.
 
-### Step 3: Check hooks configuration
-
-```bash
-bash "${CLAUDE_SKILL_DIR}/scripts/check-hooks.sh" --home-dir "$HOME" --project-dir "$(pwd)" [--verbose]
-```
-
-Parse the `STATUS=` and `ISSUES:` lines from output.
-
-### Step 4: Check MCP server configuration
-
-```bash
-bash "${CLAUDE_SKILL_DIR}/scripts/check-mcp.sh" --home-dir "$HOME" --project-dir "$(pwd)" [--verbose]
-```
-
-Parse the `STATUS=` and `ISSUES:` lines from output.
-
-### Step 5: SessionStart smoke test
+#### 1b. SessionStart smoke test
 
 Check whether `scripts/install_pkgs.sh` (or any script registered in the `SessionStart` hook in `.claude/settings.json`) is executable and exits cleanly in both remote and local contexts.
 
@@ -83,22 +78,18 @@ Check whether `scripts/install_pkgs.sh` (or any script registered in the `Sessio
    CLAUDE_CODE_REMOTE=true bash <script-path>
    ```
    Capture exit code. Expected: 0.
-3. Run again to verify idempotency:
-   ```bash
-   CLAUDE_CODE_REMOTE=true bash <script-path>
-   ```
-   Expected: 0 (second run must also succeed).
+3. Run again to verify idempotency — expected: 0.
 4. Run with remote guard off:
    ```bash
    CLAUDE_CODE_REMOTE=false bash <script-path>
    ```
-   Expected: 0 (script must exit cleanly when not in remote mode — typically a no-op).
-5. Report results:
+   Expected: 0 (typically a no-op).
+5. Report:
    - OK: All three exit 0
    - WARN: Script exists but is not registered in settings.json hook
    - ERROR: Script exits non-zero, or script referenced in hook does not exist
 
-### Step 6: Pre-commit config validator
+#### 1c. Pre-commit config validator
 
 If `.pre-commit-config.yaml` exists:
 
@@ -111,7 +102,7 @@ Report:
 - WARN: `pre-commit` not installed — skip check, suggest `pip install pre-commit`
 - ERROR: exits non-zero — show validation error
 
-### Step 7: Permissions coverage check
+#### 1d. Permissions coverage check
 
 Compare tools referenced in project files against `permissions.allow` in `.claude/settings.json`.
 
@@ -125,25 +116,12 @@ Compare tools referenced in project files against `permissions.allow` in `.claud
 4. For each `Bash(<tool>:*)` entry in `permissions.allow`:
    - Flag as **UNUSED** if the tool is not found in any project file (informational, not an error)
 
-Report a table:
-
-```
-Permissions Coverage
-====================
-MISSING (in project files, not in allow list):
-  just      (found in Makefile — add "Bash(just:*)")
-  docker    (found in justfile — add "Bash(docker:*)")
-
-UNUSED (in allow list, not found in project files):
-  Bash(gofmt:*)   (informational)
-```
-
 Scoring:
 - OK: No missing permissions
 - WARN: 1–3 missing permissions
 - ERROR: 4+ missing permissions
 
-### Step 8: Marketplace enrollment check
+#### 1e. Marketplace enrollment check
 
 1. Read `.claude/settings.json`.
 2. Check that `extraKnownMarketplaces.claude-plugins` exists with `source.repo = "laurigates/claude-plugins"`.
@@ -153,11 +131,31 @@ Scoring:
    - WARN: `enabledPlugins` is empty or missing (marketplace enrolled but no plugins enabled)
    - ERROR: `extraKnownMarketplaces` is missing (run `/configure:claude-plugins --fix` to add it)
 
-### Step 9: Generate the diagnostic report
+### Step 2: Run scope-specific audits
 
-Using the structured output from Steps 1-8, print a diagnostic report following the template in [REFERENCE.md](REFERENCE.md). Include status indicators (OK/WARN/ERROR), issue counts, and recommended actions. If `--fix` was used and fixes were applied, include a summary of changes made.
+For `--scope=registry` or `all`:
 
-Include rows for the new checks in the summary table:
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/skills/health-plugins/scripts/check-registry.sh" \
+  --home-dir "$HOME" --project-dir "$(pwd)"
+```
+
+Parse `STATUS=`, `PLUGIN_COUNT=`, `ORPHANED_ENTRIES=`, `STALE_ENABLED_ENTRIES=`, and `ISSUES:`.
+
+For `--scope=stack` or `all`: follow the tech-stack audit steps from the internal `health-audit` skill (see `${CLAUDE_PLUGIN_ROOT}/skills/health-audit/SKILL.md` and its `REFERENCE.md`).
+
+For `--scope=agentic` or `all`: follow the skill-quality audit steps from the internal `health-agentic-audit` skill (see `${CLAUDE_PLUGIN_ROOT}/skills/health-agentic-audit/SKILL.md` and its `REFERENCE.md`).
+
+### Step 3: Report findings
+
+Print a consolidated report grouped by scope:
+
+1. **Environment** — plugins/settings/hooks/MCP status + counts, SessionStart smoke test, pre-commit validity, permissions coverage, marketplace enrollment
+2. **Registry** — orphaned projectPath entries, stale enabledPlugins keys, registry-vs-settings drift
+3. **Stack** — detected stack + relevant/irrelevant/missing plugin recommendations
+4. **Agentic** — skills missing optimisation tables, bare CLI commands, stale reviews
+
+Use `STATUS=` indicators (OK/WARN/ERROR) and issue counts per scope. Include a summary table:
 
 | Check | Status | Issues |
 |-------|--------|--------|
@@ -169,42 +167,55 @@ Include rows for the new checks in the summary table:
 | Pre-commit config | OK/WARN/ERROR/SKIP | ... |
 | Permissions coverage | OK/WARN/ERROR | ... |
 | Marketplace enrollment | OK/WARN/ERROR | ... |
+| Registry audit | OK/WARN/ERROR | ... |
+| Stack audit | OK/WARN/ERROR | ... |
+| Agentic audit | OK/WARN/ERROR | ... |
+
+See [REFERENCE.md](REFERENCE.md) for the full report template.
+
+### Step 4: Apply fixes (if `--fix`)
+
+If `--fix` is set:
+
+1. If `--scope=all` AND findings exist in multiple scopes, use `AskUserQuestion` to let the user pick which scopes to fix (multi-select: `registry`, `stack`, `agentic`).
+2. For each selected scope, delegate:
+
+   | Scope | Delegate to |
+   |-------|-------------|
+   | `registry` | `bash "${CLAUDE_PLUGIN_ROOT}/skills/health-plugins/scripts/fix-registry.sh" --home-dir "$HOME" --project-dir "$(pwd)"` (pass `--dry-run` when set) |
+   | `stack` | Follow the `--fix` flow in `${CLAUDE_PLUGIN_ROOT}/skills/health-audit/SKILL.md` (Step 6) |
+   | `agentic` | Follow the `--fix` flow in `${CLAUDE_PLUGIN_ROOT}/skills/health-agentic-audit/SKILL.md` (Step 6) |
+
+3. Parse each script's output (`STATUS=`, `REMOVED_COUNT=`, `MESSAGE=`, `RESTART_REQUIRED=`) and report what changed.
+4. If any fix reports `RESTART_REQUIRED=true`, remind the user to restart Claude Code.
+
+### Step 5: Verify
+
+Re-run the relevant checks and confirm issue counts have dropped.
 
 ## Agentic Optimizations
 
 | Context | Command |
 |---------|---------|
-| Quick health check | `/health:check` |
-| Health check with auto-fix | `/health:check --fix` |
+| Full scan | `/health:check` |
+| Registry only | `/health:check --scope=registry` |
+| Stack relevance only | `/health:check --scope=stack` |
+| Agentic audit only | `/health:check --scope=agentic` |
+| Fix everything (interactive) | `/health:check --fix` |
+| Dry-run preview of fixes | `/health:check --fix --dry-run` |
 | Detailed diagnostics | `/health:check --verbose` |
 | Check plugin registry exists | `find ~/.claude/plugins -name 'installed_plugins.json'` |
 | Validate settings JSON | `find .claude -maxdepth 1 -name 'settings.json'` |
 | Smoke-test install script | `CLAUDE_CODE_REMOTE=true bash scripts/install_pkgs.sh` |
-| Verify idempotency | `CLAUDE_CODE_REMOTE=true bash scripts/install_pkgs.sh` (run twice) |
 | Validate pre-commit config | `pre-commit validate-config .pre-commit-config.yaml` |
 | Check marketplace enrollment | `find .claude -maxdepth 1 -name 'settings.json'` then grep for `extraKnownMarketplaces` |
 
-## Known Issues Database
+## Known Issues
 
-Reference these known Claude Code issues when diagnosing:
-
-| Issue | Symptoms | Solution |
-|-------|----------|----------|
-| #14202 | Plugin shows "installed" but not active in project | Run `/health:plugins --fix` |
-| Orphaned projectPath | Plugin was installed for deleted project | Run `/health:plugins --fix` |
-| Invalid JSON | Settings file won't load | Validate and fix JSON syntax |
-| Hook timeout | Commands hang or fail silently | Check hook timeout settings |
-
-## Flags
-
-| Flag | Description |
-|------|-------------|
-| `--fix` | Attempt automatic fixes for identified issues |
-| `--verbose` | Include detailed diagnostic output |
-
-## See Also
-
-- `/health:plugins` - Detailed plugin registry diagnostics
-- `/health:settings` - Settings file validation
-- `/health:hooks` - Hooks configuration check
-- `/health:mcp` - MCP server diagnostics
+| Issue | Symptom | Fix path |
+|-------|---------|----------|
+| [#14202](https://github.com/anthropics/claude-code/issues/14202) | Plugin shows "installed" but not active | `/health:check --scope=registry --fix` |
+| Stale `enabledPlugins` key in settings.json | Plugin appears enabled but no registry/marketplace entry | `/health:check --scope=registry --fix` |
+| Orphaned `projectPath` | Plugin installed for deleted project | `/health:check --scope=registry --fix` |
+| Invalid settings JSON | Settings file won't load | `/health:check` |
+| Missing marketplace enrollment | `@claude-plugins` skills unavailable in web sessions | `/configure:claude-plugins --fix` |

--- a/health-plugin/skills/health-plugins/SKILL.md
+++ b/health-plugin/skills/health-plugins/SKILL.md
@@ -1,7 +1,8 @@
 ---
 created: 2026-02-04
-modified: 2026-04-12
-reviewed: 2026-02-05
+modified: 2026-04-15
+reviewed: 2026-04-15
+user-invocable: false
 description: Diagnose and fix plugin registry issues including orphaned entries and project-scope conflicts (addresses Claude Code issue #14202)
 allowed-tools: Bash(bash *), Read, Write, Edit, Glob, Grep, TodoWrite, AskUserQuestion
 args: "[--fix] [--dry-run] [--plugin <name>]"

--- a/health-plugin/skills/health-plugins/scripts/check-registry.sh
+++ b/health-plugin/skills/health-plugins/scripts/check-registry.sh
@@ -122,20 +122,53 @@ echo "GLOBAL_SCOPED=${global_scoped}"
 echo "ORPHANED_ENTRIES=${orphaned_count}"
 echo "OTHER_PROJECT_ENTRIES=${other_project_count}"
 
+stale_enabled_count=0
 if [ -f "$user_settings" ]; then
   enabled_count=$(jq '.enabledPlugins // {} | length' "$user_settings" 2>/dev/null || echo "0")
   echo "ENABLED_IN_SETTINGS=${enabled_count}"
 
+  # Collect marketplace plugin names (if any marketplaces are configured).
+  marketplace_names=""
+  marketplaces_dir="${home_dir}/.claude/plugins/marketplaces"
+  if [ -d "$marketplaces_dir" ]; then
+    while IFS= read -r mp_file; do
+      [ -z "$mp_file" ] && continue
+      mp_plugins=$(jq -r '.plugins[]?.name // empty' "$mp_file" 2>/dev/null)
+      marketplace_names="${marketplace_names}
+${mp_plugins}"
+    done < <(find "$marketplaces_dir" -maxdepth 3 -name '*.json' -type f 2>/dev/null)
+  fi
+
   enabled_keys=$(jq -r '.enabledPlugins // {} | keys[]' "$user_settings" 2>/dev/null)
   while IFS= read -r enabled_key; do
     [ -z "$enabled_key" ] && continue
-    if ! jq -e --arg k "$enabled_key" '.plugins[$k]' "$registry_file" >/dev/null 2>&1; then
+
+    # enabledPlugins keys are of the form "<plugin>@<marketplace>"; the registry
+    # is keyed the same way but older Claude Code versions left stale entries
+    # behind when the plugin or marketplace was removed.
+    plugin_name="${enabled_key%@*}"
+
+    # Present in registry?
+    if jq -e --arg k "$enabled_key" '.plugins[$k]' "$registry_file" >/dev/null 2>&1; then
+      continue
+    fi
+
+    # Present in any known marketplace?
+    if [ -n "$marketplace_names" ] && printf '%s\n' "$marketplace_names" | grep -Fxq "$plugin_name"; then
       issues_list="${issues_list}  - SEVERITY=WARN TYPE=enabled_not_installed PLUGIN=${enabled_key}\n"
       issue_count=$((issue_count + 1))
       [ "$check_status" = "OK" ] && check_status="WARN"
+      continue
     fi
+
+    # Neither installed nor in any marketplace -- fully stale.
+    stale_enabled_count=$((stale_enabled_count + 1))
+    issues_list="${issues_list}  - SEVERITY=WARN TYPE=stale_enabled PLUGIN=${enabled_key} FIX=remove_enabled_key\n"
+    issue_count=$((issue_count + 1))
+    [ "$check_status" = "OK" ] && check_status="WARN"
   done <<< "$enabled_keys"
 fi
+echo "STALE_ENABLED_ENTRIES=${stale_enabled_count}"
 
 echo "STATUS=${check_status}"
 echo "ISSUE_COUNT=${issue_count}"

--- a/health-plugin/skills/health-plugins/scripts/fix-registry.sh
+++ b/health-plugin/skills/health-plugins/scripts/fix-registry.sh
@@ -25,12 +25,19 @@ done
 : "${home_dir:=$HOME}"
 : "${project_dir:=$(pwd)}"
 
+# Allow tests/tools to point the script at alternative file paths without
+# having to construct a full fake $HOME. When these env vars are set they
+# override the defaults derived from --home-dir.
+registry_file="${FIX_REGISTRY_FILE:-${home_dir}/.claude/plugins/installed_plugins.json}"
+settings_file="${FIX_SETTINGS_FILE:-${home_dir}/.claude/settings.json}"
+marketplaces_dir="${FIX_MARKETPLACES_DIR:-${home_dir}/.claude/plugins/marketplaces}"
+backup_dir="$(dirname "$registry_file")"
+
 echo "=== PLUGIN REGISTRY FIX ==="
 echo "HOME_DIR=${home_dir}"
 echo "DRY_RUN=${dry_run}"
-
-registry_file="${home_dir}/.claude/plugins/installed_plugins.json"
-backup_dir="${home_dir}/.claude/plugins"
+echo "REGISTRY_FILE=${registry_file}"
+echo "SETTINGS_FILE=${settings_file}"
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "STATUS=ERROR"
@@ -72,7 +79,40 @@ done <<< "$plugin_keys"
 
 echo "ORPHANED_COUNT=${#orphaned_keys[@]}"
 
-if [ "${#orphaned_keys[@]}" -eq 0 ]; then
+# Identify stale enabledPlugins entries: keys in settings.json whose plugin
+# name is not installed AND not in any configured marketplace.
+stale_enabled_keys=()
+if [ -f "$settings_file" ] && jq empty "$settings_file" >/dev/null 2>&1; then
+  marketplace_names=""
+  if [ -d "$marketplaces_dir" ]; then
+    while IFS= read -r mp_file; do
+      [ -z "$mp_file" ] && continue
+      mp_plugins=$(jq -r '.plugins[]?.name // empty' "$mp_file" 2>/dev/null)
+      marketplace_names="${marketplace_names}
+${mp_plugins}"
+    done < <(find "$marketplaces_dir" -maxdepth 3 -name '*.json' -type f 2>/dev/null)
+  fi
+
+  enabled_keys_raw=$(jq -r '.enabledPlugins // {} | keys[]' "$settings_file" 2>/dev/null)
+  while IFS= read -r enabled_key; do
+    [ -z "$enabled_key" ] && continue
+    plugin_name="${enabled_key%@*}"
+    # Keep if installed in registry.
+    if jq -e --arg k "$enabled_key" '.plugins[$k]' "$registry_file" >/dev/null 2>&1; then
+      continue
+    fi
+    # Keep if present in any known marketplace (still installable).
+    if [ -n "$marketplace_names" ] && printf '%s\n' "$marketplace_names" | grep -Fxq "$plugin_name"; then
+      continue
+    fi
+    stale_enabled_keys+=("$enabled_key")
+    echo "STALE_ENABLED: key=${enabled_key}"
+  done <<< "$enabled_keys_raw"
+fi
+
+echo "STALE_ENABLED_COUNT=${#stale_enabled_keys[@]}"
+
+if [ "${#orphaned_keys[@]}" -eq 0 ] && [ "${#stale_enabled_keys[@]}" -eq 0 ]; then
   echo "STATUS=OK"
   echo "MESSAGE=No orphaned entries to fix"
   echo "=== END PLUGIN REGISTRY FIX ==="
@@ -82,52 +122,110 @@ fi
 if [ "$dry_run" = true ]; then
   echo "STATUS=DRY_RUN"
   echo "WOULD_REMOVE=${#orphaned_keys[@]}"
+  echo "WOULD_REMOVE_ENABLED=${#stale_enabled_keys[@]}"
+  if [ "${#stale_enabled_keys[@]}" -gt 0 ]; then
+    echo "MESSAGE=Would remove ${#stale_enabled_keys[@]} stale enabledPlugins entries"
+    echo "RESTART_REQUIRED=true"
+  fi
   echo "=== END PLUGIN REGISTRY FIX ==="
   exit 0
 fi
 
-# Create backup
 mkdir -p "$backup_dir"
-backup_file="${registry_file}.backup.$(date -u +%Y%m%dT%H%M%SZ)"
-if ! cp "$registry_file" "$backup_file"; then
-  echo "STATUS=ERROR"
-  echo "ERROR=Failed to create backup"
-  echo "=== END PLUGIN REGISTRY FIX ==="
-  exit 1
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+backup_file=""
+settings_backup_file=""
+restart_required=false
+
+# Stage 1: Remove orphaned entries from installed_plugins.json
+if [ "${#orphaned_keys[@]}" -gt 0 ]; then
+  backup_file="${registry_file}.backup.${timestamp}"
+  if ! cp "$registry_file" "$backup_file"; then
+    echo "STATUS=ERROR"
+    echo "ERROR=Failed to create registry backup"
+    echo "=== END PLUGIN REGISTRY FIX ==="
+    exit 1
+  fi
+  echo "BACKUP_CREATED=${backup_file}"
+
+  jq_filter='.'
+  for plugin_key in "${orphaned_keys[@]}"; do
+    jq_filter="${jq_filter} | del(.plugins[\"${plugin_key}\"])"
+  done
+
+  tmp_file="${registry_file}.tmp.$$"
+  if ! jq "$jq_filter" "$registry_file" > "$tmp_file"; then
+    echo "STATUS=ERROR"
+    echo "ERROR=jq transformation failed"
+    rm -f "$tmp_file"
+    echo "=== END PLUGIN REGISTRY FIX ==="
+    exit 1
+  fi
+
+  if ! jq empty "$tmp_file" >/dev/null 2>&1; then
+    echo "STATUS=ERROR"
+    echo "ERROR=Resulting registry JSON is invalid; no changes applied"
+    rm -f "$tmp_file"
+    echo "=== END PLUGIN REGISTRY FIX ==="
+    exit 1
+  fi
+
+  mv "$tmp_file" "$registry_file"
+
+  for plugin_key in "${orphaned_keys[@]}"; do
+    echo "REMOVED=${plugin_key}"
+  done
+  restart_required=true
 fi
-echo "BACKUP_CREATED=${backup_file}"
 
-# Build jq filter to delete orphaned keys
-jq_filter='.'
-for plugin_key in "${orphaned_keys[@]}"; do
-  jq_filter="${jq_filter} | del(.plugins[\"${plugin_key}\"])"
-done
+# Stage 2: Remove stale enabledPlugins entries from settings.json
+if [ "${#stale_enabled_keys[@]}" -gt 0 ] && [ -f "$settings_file" ]; then
+  settings_backup_file="${settings_file}.backup.${timestamp}"
+  if ! cp "$settings_file" "$settings_backup_file"; then
+    echo "STATUS=ERROR"
+    echo "ERROR=Failed to create settings backup"
+    echo "=== END PLUGIN REGISTRY FIX ==="
+    exit 1
+  fi
+  echo "SETTINGS_BACKUP_CREATED=${settings_backup_file}"
 
-tmp_file="${registry_file}.tmp.$$"
-if ! jq "$jq_filter" "$registry_file" > "$tmp_file"; then
-  echo "STATUS=ERROR"
-  echo "ERROR=jq transformation failed"
-  rm -f "$tmp_file"
-  echo "=== END PLUGIN REGISTRY FIX ==="
-  exit 1
+  settings_filter='.'
+  for enabled_key in "${stale_enabled_keys[@]}"; do
+    settings_filter="${settings_filter} | del(.enabledPlugins[\"${enabled_key}\"])"
+  done
+
+  settings_tmp="${settings_file}.tmp.$$"
+  if ! jq "$settings_filter" "$settings_file" > "$settings_tmp"; then
+    echo "STATUS=ERROR"
+    echo "ERROR=jq transformation of settings.json failed"
+    rm -f "$settings_tmp"
+    echo "=== END PLUGIN REGISTRY FIX ==="
+    exit 1
+  fi
+
+  if ! jq empty "$settings_tmp" >/dev/null 2>&1; then
+    echo "STATUS=ERROR"
+    echo "ERROR=Resulting settings JSON is invalid; no changes applied"
+    rm -f "$settings_tmp"
+    echo "=== END PLUGIN REGISTRY FIX ==="
+    exit 1
+  fi
+
+  mv "$settings_tmp" "$settings_file"
+
+  for enabled_key in "${stale_enabled_keys[@]}"; do
+    echo "REMOVED_ENABLED=${enabled_key}"
+  done
+  echo "MESSAGE=Removed ${#stale_enabled_keys[@]} stale enabledPlugins entries"
+  restart_required=true
 fi
-
-# Validate result
-if ! jq empty "$tmp_file" >/dev/null 2>&1; then
-  echo "STATUS=ERROR"
-  echo "ERROR=Resulting JSON is invalid; no changes applied"
-  rm -f "$tmp_file"
-  echo "=== END PLUGIN REGISTRY FIX ==="
-  exit 1
-fi
-
-mv "$tmp_file" "$registry_file"
-
-for plugin_key in "${orphaned_keys[@]}"; do
-  echo "REMOVED=${plugin_key}"
-done
 
 echo "STATUS=FIXED"
 echo "REMOVED_COUNT=${#orphaned_keys[@]}"
-echo "BACKUP_PATH=${backup_file}"
+echo "REMOVED_ENABLED_COUNT=${#stale_enabled_keys[@]}"
+[ -n "$backup_file" ] && echo "BACKUP_PATH=${backup_file}"
+[ -n "$settings_backup_file" ] && echo "SETTINGS_BACKUP_PATH=${settings_backup_file}"
+if [ "$restart_required" = true ]; then
+  echo "RESTART_REQUIRED=true"
+fi
 echo "=== END PLUGIN REGISTRY FIX ==="

--- a/health-plugin/skills/health-plugins/scripts/test-fix-registry.sh
+++ b/health-plugin/skills/health-plugins/scripts/test-fix-registry.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Regression test for fix-registry.sh stale enabledPlugins handling.
+# Also guards health-check SKILL.md against the `!\`` context-command antipattern.
+# Exit 0 on success, non-zero on failure.
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fix_script="${script_dir}/fix-registry.sh"
+health_check_skill="${script_dir}/../../health-check/SKILL.md"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+pass() {
+  echo "PASS: $1"
+}
+
+# -----------------------------------------------------------------------------
+# Guard 1: health-check SKILL.md must not use the `!\`` context-command antipattern
+# -----------------------------------------------------------------------------
+if grep -n '!`' "$health_check_skill" | grep -E '!`(echo|printf|eval)' >/dev/null; then
+  fail "health-check/SKILL.md contains !\`echo|printf|eval backtick antipattern"
+fi
+pass "health-check/SKILL.md free of forbidden !\`echo backtick"
+
+# -----------------------------------------------------------------------------
+# Guard 2: fix-registry.sh cleans stale enabledPlugins in --dry-run
+# -----------------------------------------------------------------------------
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq not installed; cannot run fix-registry dry-run test"
+  exit 0
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+registry_file="${tmp_dir}/installed_plugins.json"
+settings_file="${tmp_dir}/settings.json"
+marketplaces_dir="${tmp_dir}/marketplaces"
+mkdir -p "$marketplaces_dir/test-mp"
+
+# Registry contains only 'good-plugin'.
+cat > "$registry_file" <<'JSON'
+{
+  "version": 2,
+  "plugins": {
+    "good-plugin@test-mp": [
+      {"scope": "user", "version": "1.0.0", "installPath": "/tmp/good"}
+    ]
+  }
+}
+JSON
+
+# Marketplace lists 'good-plugin' and 'installable-plugin' (enabled but not installed).
+cat > "${marketplaces_dir}/test-mp/marketplace.json" <<'JSON'
+{
+  "name": "test-mp",
+  "plugins": [
+    {"name": "good-plugin"},
+    {"name": "installable-plugin"}
+  ]
+}
+JSON
+
+# settings.json has: good (valid), installable (enabled_not_installed), stale (fully gone).
+cat > "$settings_file" <<'JSON'
+{
+  "enabledPlugins": {
+    "good-plugin@test-mp": true,
+    "installable-plugin@test-mp": true,
+    "stale-plugin@dead-mp": true
+  }
+}
+JSON
+
+output=$(
+  FIX_REGISTRY_FILE="$registry_file" \
+  FIX_SETTINGS_FILE="$settings_file" \
+  FIX_MARKETPLACES_DIR="$marketplaces_dir" \
+  bash "$fix_script" --home-dir "$tmp_dir" --project-dir "$tmp_dir" --dry-run
+)
+
+echo "--- fix-registry.sh --dry-run output ---"
+echo "$output"
+echo "----------------------------------------"
+
+# Stale key must be reported.
+if ! grep -q 'STALE_ENABLED: key=stale-plugin@dead-mp' <<<"$output"; then
+  fail "stale-plugin@dead-mp not reported as stale"
+fi
+pass "stale-plugin@dead-mp reported"
+
+# Good keys must NOT be reported as stale.
+if grep -q 'STALE_ENABLED: key=good-plugin@test-mp' <<<"$output"; then
+  fail "good-plugin@test-mp incorrectly flagged as stale"
+fi
+if grep -q 'STALE_ENABLED: key=installable-plugin@test-mp' <<<"$output"; then
+  fail "installable-plugin@test-mp incorrectly flagged as stale (should be kept)"
+fi
+pass "valid keys preserved"
+
+# STALE_ENABLED_COUNT must be exactly 1.
+if ! grep -q '^STALE_ENABLED_COUNT=1$' <<<"$output"; then
+  fail "expected STALE_ENABLED_COUNT=1"
+fi
+pass "STALE_ENABLED_COUNT=1"
+
+# Dry-run must not modify settings.json.
+if ! diff -q <(jq -S . "$settings_file") <(cat <<'JSON' | jq -S .
+{
+  "enabledPlugins": {
+    "good-plugin@test-mp": true,
+    "installable-plugin@test-mp": true,
+    "stale-plugin@dead-mp": true
+  }
+}
+JSON
+) >/dev/null; then
+  fail "--dry-run modified settings.json"
+fi
+pass "--dry-run preserved settings.json"
+
+# RESTART_REQUIRED should be emitted on dry-run when stale keys would be removed.
+if ! grep -q '^RESTART_REQUIRED=true$' <<<"$output"; then
+  fail "expected RESTART_REQUIRED=true in dry-run output"
+fi
+pass "RESTART_REQUIRED=true emitted in dry-run"
+
+echo "ALL CHECKS PASSED"
+exit 0


### PR DESCRIPTION
## Summary

Consolidates `/health:check`, `/health:audit`, `/health:agentic-audit`, and `/health:plugins` behind a single user-invocable entry point routed by `--scope={registry,stack,agentic,all}`.

**Before:** four top-level commands with overlapping purpose; users had to remember which to run.
**After:** one entry point (`/health:check`); internal skills marked `user-invocable: false`; `--scope` narrows the audit, `--fix` delegates per-scope with multi-select prompt when findings span scopes.

### Command surface

| Before | After |
|--------|-------|
| `/health:check` | `/health:check` (env + all audits) |
| `/health:audit` | `/health:check --scope=stack` |
| `/health:agentic-audit` | `/health:check --scope=agentic` |
| `/health:plugins` | `/health:check --scope=registry` |
| — | `/health:check --fix --dry-run` (new) |

### What's in this PR

- `health-plugin/skills/health-check/SKILL.md` — router refactor with 5-step execution (env checks → scope audits → report → fix → verify). Preserves upstream extensions from laurigates/claude-plugins#1036 (SessionStart smoke test, pre-commit validator, permissions coverage, marketplace enrollment) folded into Step 1.
- `health-plugin/skills/{health-audit,health-agentic-audit,health-plugins}/SKILL.md` — marked `user-invocable: false`; still auto-discoverable as internal workflows.
- `health-plugin/skills/health-plugins/scripts/{check,fix}-registry.sh` — extended to handle stale `enabledPlugins` entries alongside orphaned `projectPath`; new `test-fix-registry.sh` regression harness.
- `health-plugin/README.md` — rewrites Skills table to show `/health:check` as the single entry point, with an "Internal scopes" subtable.
- `health-plugin/docs/flow.md` — **fixes latent broken reference from laurigates/claude-plugins#1034**: the rule `.claude/rules/plugin-flow-diagrams.md` points at this file as the canonical example, but the file was never committed. This PR lands it.
- `docs/PLUGIN-MAP.md` — updated to reflect consolidated command surface.
- `configure-plugin/skills/configure-repo/SKILL.md` — `reviewed:` bumped (driver-freshness hook dependency); `/health:check` invocation remains behaviour-compatible.

### Design decisions

1. **Merged upstream extensions rather than rebasing.** PR laurigates/claude-plugins#1036 added SessionStart/pre-commit/permissions/marketplace checks to the pre-router SKILL. I folded those inline into Step 1 rather than extracting them to scripts — keeping scope creep out. Follow-up issue suggested below.
2. **`user-invocable: false` over deletion.** The three audit skills still contain the detailed logic; only their top-level invocation disappears. Internal `/health:check` dispatch references them via `${CLAUDE_PLUGIN_ROOT}/skills/<name>/SKILL.md`.
3. **Multi-scope `--fix` uses `AskUserQuestion`**, so the user picks which scopes to fix when findings span multiple. Single-scope runs skip the prompt.

## Test plan

- [ ] `/health:check` runs all environment checks + all three audits
- [ ] `/health:check --scope=registry` runs env checks + registry audit only
- [ ] `/health:check --scope=agentic` runs env checks + agentic audit only
- [ ] `/health:check --fix` with findings in 2+ scopes → `AskUserQuestion` appears with multi-select
- [ ] `/health:check --fix --dry-run` previews without writes
- [ ] `/health:audit`, `/health:agentic-audit`, `/health:plugins` no longer appear in `/plugin` picker (user-invocable: false)
- [ ] `bash health-plugin/skills/health-plugins/scripts/test-fix-registry.sh` passes
- [ ] `health-plugin/docs/flow.md` renders on GitHub with Mermaid
- [ ] `/configure:repo` still completes successfully (driver-dependency check)

## Follow-ups (not blockers)

- [ ] Extract Step 1 inline checks (SessionStart smoke, pre-commit, permissions, marketplace) into dedicated scripts under `health-check/scripts/` for consistency with the existing script-based env checks — tracking issue to file after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)