### PR TITLE
feat(git-plugin): reply, resolve, and accept suggestions in PR feedback

### DIFF
--- a/git-plugin/skills/git-pr-feedback/REFERENCE.md
+++ b/git-plugin/skills/git-pr-feedback/REFERENCE.md
@@ -14,18 +14,68 @@
 ## Decision Tree: Handling Different Feedback Types
 
 ```
-Is it a "Request Changes" review?
-├─ Yes → Must address all blocking concerns
-└─ No → Is it an inline code comment?
-         ├─ Yes → Does it suggest a specific fix?
-         │        ├─ Yes → Implement the suggestion (or better alternative)
-         │        └─ No → Analyze and determine best fix
-         └─ No → Is it a general comment/question?
-                  ├─ Yes → Note for PR reply
-                  └─ No → Is it a resolved/outdated comment?
-                           ├─ Yes → Skip
-                           └─ No → Evaluate importance
+Is the thread isResolved or isOutdated?
+├─ Yes → Skip
+└─ No → Is it a "Request Changes" review?
+         ├─ Yes → Must address all blocking concerns before resolving any thread
+         └─ No → Is it an inline code comment?
+                  ├─ Yes → Does the body contain a ```suggestion block?
+                  │        ├─ Yes, fix is correct → Accept the suggestion verbatim
+                  │        ├─ Yes, fix needs adjustment → Apply a variant; explain in reply
+                  │        └─ No → Analyze and implement best fix
+                  └─ No → Is it a general comment/question?
+                           ├─ Question → Reply inline; resolve only after answering
+                           └─ Statement → Evaluate importance; reply if action taken
 ```
+
+## Accepting Suggestions
+
+GitHub review comments can embed a code-block proposal that replaces the lines the comment is anchored to:
+
+````
+```suggestion
+new line of code here
+another new line
+```
+````
+
+**To accept**: Replace the targeted lines (`comment.line` through `comment.originalLine` if multi-line) in `comment.path` with the exact contents between the suggestion fences. Use `Edit` with the original lines (visible in `comment.diffHunk`) as `old_string` and the suggestion body as `new_string`.
+
+**Rules**:
+- Preserve indentation **as written in the suggestion block** — GitHub renders the block with absolute indentation.
+- A suggestion may span multiple lines; replace the entire range, not just the anchor line.
+- If the suggestion conflicts with another reviewer's request or with intent established elsewhere in the PR, apply a variant and explain in the reply.
+- After applying, include the file in the next commit so the reply can reference the resolving SHA.
+
+## Reply Templates
+
+Keep replies concise. Use these templates with `mcp__github__add_reply_to_pull_request_comment` (the `commentId` is the top-level `databaseId` of the thread, an integer).
+
+| Situation | Template |
+|-----------|----------|
+| Suggestion accepted as-is | `Accepted in <sha>.` |
+| Suggestion adapted | `Applied a variant in <sha>: <one-line reason>.` |
+| Code change made (no suggestion) | `Fixed in <sha> — <one-line summary>.` |
+| Question answered | `<direct answer>. <optional code/file reference>.` |
+| Deferred to follow-up | `Deferred to #<issue> — <reason>.` |
+| Declined nitpick | `Leaving as-is: <reason>. Happy to revisit if you feel strongly.` |
+| Partial fix | `Partially addressed in <sha>: <what was done>. <what remains>.` |
+
+## Resolution Criteria
+
+Resolve a thread with `mcp__github__resolve_review_thread` (threadId is the `PRRT_…` GraphQL node ID) when **all** of these hold:
+
+- [ ] The reviewer's concern is fully addressed by a pushed commit, OR a question has been answered, OR a nitpick was explicitly declined with reasoning.
+- [ ] No follow-up question to the reviewer is pending in your reply.
+- [ ] The reviewer has not asked for the thread to remain open.
+- [ ] You authored or own-pushed the change (or the user explicitly approved resolving on a PR you don't own).
+
+Leave the thread open when:
+
+- [ ] Your reply asks the reviewer something.
+- [ ] The fix is partial or deferred.
+- [ ] You disagree without making a change — let the reviewer decide.
+- [ ] No commit has been pushed yet (resolution should reference a SHA).
 
 ## Commit Message Format
 
@@ -65,19 +115,24 @@ git add -u  # Stage any formatter changes
 
 ### Feedback Addressed
 
-| Category | Count | Status |
-|----------|-------|--------|
-| Blocking | N | ✅ Resolved |
-| Substantive | N | ✅ Resolved |
-| Suggestions | N | ✅/⏭️ Addressed/Deferred |
-| Questions | N | 💬 Need response |
+| Category | Count | Code Change | Replied | Resolved |
+|----------|-------|-------------|---------|----------|
+| Blocking | N | ✅ N | ✅ N | ✅ N |
+| Substantive | N | ✅ N | ✅ N | ✅ N |
+| Suggestions accepted | N | ✅ N | ✅ N | ✅ N |
+| Suggestions adapted | N | ✅ N | ✅ N | ✅ N |
+| Questions | N | — | 💬 N | ⏸ N |
+| Nitpicks declined | N | — | ✅ N | ✅ N |
 
 ### Changes Made
-- <File 1>: <description of change>
-- <File 2>: <description of change>
+- <File 1>: <description of change> (commit <sha>)
+- <File 2>: <description of change> (commit <sha>)
+
+### Threads Left Open
+- <thread URL>: <why it's still open>
 
 ### Next Steps
-- [ ] Reply to clarification questions on PR
 - [ ] Re-request review from <reviewer>
 - [ ] Monitor CI for new run
+- [ ] Follow up on <deferred item>
 ```

--- a/git-plugin/skills/git-pr-feedback/SKILL.md
+++ b/git-plugin/skills/git-pr-feedback/SKILL.md
@@ -1,8 +1,8 @@
 ---
 created: 2026-01-30
-modified: 2026-03-24
+modified: 2026-04-16
 reviewed: 2026-02-26
-allowed-tools: Bash(gh pr checks *), Bash(gh pr view *), Bash(gh pr diff *), Bash(gh run view *), Bash(gh run list *), Bash(gh api *), Bash(gh repo view *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git switch *), Bash(git pull *), Bash(pre-commit *), Bash(npm run *), Bash(uv run *), Bash(bash *), Read, Edit, Write, Grep, Glob, TodoWrite, Task, mcp__github__pull_request_read
+allowed-tools: Bash(gh pr checks *), Bash(gh pr view *), Bash(gh pr diff *), Bash(gh run view *), Bash(gh run list *), Bash(gh api *), Bash(gh repo view *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git switch *), Bash(git pull *), Bash(pre-commit *), Bash(npm run *), Bash(uv run *), Bash(bash *), Read, Edit, Write, Grep, Glob, TodoWrite, Task, mcp__github__pull_request_read, mcp__github__add_reply_to_pull_request_comment, mcp__github__resolve_review_thread, mcp__github__pull_request_review_write
 args: "[pr-number] [--commit] [--push]"
 argument-hint: [pr-number] [--commit] [--push]
 disable-model-invocation: true
@@ -83,21 +83,27 @@ If the GraphQL query fails with a rate limit error, wait 60 seconds and retry on
 
 Categorize all comments from the GraphQL response (see [REFERENCE.md](REFERENCE.md) for category definitions):
 
-1. Categorize each comment as Blocking, Substantive, Suggestion, Question, Nitpick, or Resolved
-2. For each actionable comment, note file, line, scope, and dependencies
-3. Create a todo list using TodoWrite with all actionable items
+1. Skip any thread where `isResolved: true` or `isOutdated: true` — already handled.
+2. Categorize each remaining comment as Blocking, Substantive, Suggestion, Question, or Nitpick.
+3. For each actionable comment, capture: thread `id`, top-level comment `databaseId`, file, line, scope, and whether the body contains a ` ```suggestion ` block.
+4. Create a todo list using TodoWrite with one item per actionable thread, including the thread `id` and `databaseId` so Steps 3–5 can reply and resolve.
 
 ---
 
 ### Step 3: Address Feedback
 
-Work through actionable items systematically:
+Work through actionable items systematically. For each thread, decide using the table below — see [REFERENCE.md](REFERENCE.md) for the full decision tree.
 
-**Code review comments:** Read relevant code, understand context, implement fix, verify no breakage.
+| Comment shape | Action |
+|---------------|--------|
+| Contains a ` ```suggestion ` block, fix is correct | **Accept the suggestion**: apply the suggestion's exact replacement to the file (see [REFERENCE.md](REFERENCE.md) "Accepting Suggestions") |
+| Contains a ` ```suggestion ` block, fix needs adjustment | Implement an improved variant; explain the deviation in the reply |
+| Inline code comment without suggestion | Read context, implement fix, verify no regressions |
+| Question / clarification | Skip code change; draft an inline reply for Step 4 |
+| Blocking review (`REQUEST_CHANGES`) | Address every concern before resolving any thread |
+| Failed CI check | Identify failure type (lint/type/test/build), fix locally, run to verify |
 
-**Failed CI checks:** Identify failure type (lint/type/test/build), fix locally, run to verify.
-
-**Questions/clarifications:** Note for PR reply; consider adding code comments for future readers.
+Mark each todo `in_progress` while working it and `completed` once the file change (if any) lands locally. Do **not** resolve threads yet — replies and resolution happen after the commit so reviewers see the linked SHA.
 
 ---
 
@@ -113,19 +119,45 @@ Run pre-commit hooks if configured, then stage any formatter changes.
 git push origin HEAD
 ```
 
-### Step 6: Summary Report
+### Step 6: Reply and Resolve Threads
 
-Provide a summary table of feedback addressed, changes made, and next steps. See [REFERENCE.md](REFERENCE.md) for report template.
+For every actionable thread tracked in Step 2, post a reply and resolve when appropriate. Owner/repo/PR are the same values used in Step 1.
+
+1. **Reply** with `mcp__github__add_reply_to_pull_request_comment` using the top-level comment's `databaseId` (a number, not the GraphQL node ID). Keep replies short — see [REFERENCE.md](REFERENCE.md) "Reply Templates".
+   - Code change made → reference the commit SHA: `Fixed in <sha> by <one-line summary>.`
+   - Suggestion accepted verbatim → `Accepted suggestion in <sha>.`
+   - Suggestion adapted → explain the deviation: `Applied a variant in <sha>: <reason>.`
+   - Deferred / out of scope → state why and link a follow-up issue if one exists.
+   - Question → answer it directly.
+
+2. **Resolve** with `mcp__github__resolve_review_thread` using the thread `id` (a `PRRT_…` GraphQL node ID) when **all** of the following hold:
+   - The reviewer's concern is fully addressed by the pushed commit, OR the reviewer asked a question that has been answered, OR the comment is a nitpick you've explicitly declined with reasoning.
+   - The thread is not part of an unsubmitted `REQUEST_CHANGES` review where other concerns remain open.
+   - You authored or own-pushed the resolving change (do not resolve threads on PRs you don't own without explicit user approval).
+
+3. **Do NOT resolve** when:
+   - The reply asks the reviewer a follow-up question.
+   - The fix is partial or deferred to another PR.
+   - The reviewer explicitly asked to keep the thread open.
+   - You merely disagree without making a change — leave it for the reviewer.
+
+If `--commit`/`--push` was not passed, still post replies for questions, but skip resolution (no resolving SHA exists yet) — note pending replies in the Step 7 summary instead.
+
+### Step 7: Summary Report
+
+Provide a summary table of feedback addressed, replies posted, threads resolved, and next steps. See [REFERENCE.md](REFERENCE.md) for the report template.
 
 ---
 
 ## Agentic Optimizations
 
-| Context | Command |
-|---------|---------|
+| Context | Command / Tool |
+|---------|----------------|
 | All PR data (single query) | `bash ${CLAUDE_SKILL_DIR}/scripts/fetch-pr-data.sh <owner> <repo> <pr>` |
 | Failed check logs | `gh run view $ID --log-failed` |
 | Quick check status (fallback) | `gh pr checks $PR --json name,state,conclusion` |
+| Reply to a review comment | `mcp__github__add_reply_to_pull_request_comment` (commentId = `databaseId`) |
+| Resolve a review thread | `mcp__github__resolve_review_thread` (threadId = `PRRT_…` node ID) |
 
 ## See Also
 

--- a/git-plugin/skills/git-pr-feedback/scripts/fetch-pr-data.sh
+++ b/git-plugin/skills/git-pr-feedback/scripts/fetch-pr-data.sh
@@ -47,13 +47,21 @@ query($owner: String!, $repo: String!, $pr: Int!) {
       }
       reviewThreads(first: 100) {
         nodes {
+          id
           isResolved
+          isOutdated
+          isCollapsed
           comments(first: 20) {
             nodes {
+              id
+              databaseId
               path
               line
+              originalLine
+              diffHunk
               body
               author { login }
+              url
             }
           }
         }


### PR DESCRIPTION
Extend git-pr-feedback so the agent finishes the round-trip on each
review thread:

- Fetch thread node IDs, comment databaseIds, diffHunks, and
  isOutdated/isCollapsed flags via the existing GraphQL query
- Add explicit Step 6 "Reply and Resolve Threads" using
  mcp__github__add_reply_to_pull_request_comment and
  mcp__github__resolve_review_thread
- Detect ```suggestion``` blocks and document the "accept" pattern
  (apply the exact replacement, reference the resolving SHA in reply)
- Add reply templates, resolution criteria, and an updated summary
  table covering replies posted and threads resolved

Skip already-resolved or outdated threads up front to avoid
re-processing.