### PR TITLE
fix(git-plugin): make check-pr-metadata-on-push retry-aware

### DIFF
--- a/git-plugin/hooks/check-pr-metadata-on-push.sh
+++ b/git-plugin/hooks/check-pr-metadata-on-push.sh
@@ -70,7 +70,7 @@ fi
 if [ -z "$PUSH_BRANCH" ]; then exit 0; fi
 
 # Check for an existing open PR on this branch
-PR_JSON=$(gh pr view "$PUSH_BRANCH" --repo "$(git -C "$CWD" remote get-url origin 2>/dev/null || true)" --json title,body,number,url 2>/dev/null || true)
+PR_JSON=$(gh pr view "$PUSH_BRANCH" --repo "$(git -C "$CWD" remote get-url origin 2>/dev/null || true)" --json title,body,number,url,updatedAt 2>/dev/null || true)
 
 # Guard: no open PR for this branch
 if [ -z "$PR_JSON" ] || [ "$PR_JSON" = "null" ]; then exit 0; fi
@@ -79,9 +79,41 @@ PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number // empty')
 PR_TITLE=$(echo "$PR_JSON" | jq -r '.title // empty')
 PR_BODY=$(echo "$PR_JSON" | jq -r '.body // empty')
 PR_URL=$(echo "$PR_JSON" | jq -r '.url // empty')
+PR_UPDATED_AT=$(echo "$PR_JSON" | jq -r '.updatedAt // empty')
 
 # Guard: couldn't parse PR data
 if [ -z "$PR_NUMBER" ] || [ -z "$PR_TITLE" ]; then exit 0; fi
+
+# Retry-aware bypass (issue #1041): if the PR was edited after the latest
+# local commit, metadata has demonstrably been reconciled for HEAD — let
+# the push proceed silently. The block only fires when there are commits
+# the PR has not been updated to reflect.
+HEAD_COMMIT_TIME=$(git -C "$CWD" log -1 --format=%cI HEAD 2>/dev/null || true)
+if [ -n "$PR_UPDATED_AT" ] && [ -n "$HEAD_COMMIT_TIME" ]; then
+    iso_to_epoch() {
+        # Convert ISO 8601 to epoch seconds. Handles both Z (UTC) and
+        # offset (e.g. +03:00) suffixes on BSD date (macOS) and GNU date.
+        local iso="$1"
+        if [[ "$iso" == *Z ]]; then
+            # UTC: parse with TZ=UTC so BSD date doesn't assume local time
+            TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "${iso%Z}" "+%s" 2>/dev/null && return 0
+        else
+            # Has explicit offset like +03:00; BSD date %z wants +0300
+            local tz_normalized
+            tz_normalized=$(printf '%s' "$iso" | sed -E 's/([+-][0-9]{2}):([0-9]{2})$/\1\2/')
+            date -j -f "%Y-%m-%dT%H:%M:%S%z" "$tz_normalized" "+%s" 2>/dev/null && return 0
+        fi
+        # GNU date (Linux) accepts ISO 8601 directly
+        date -d "$iso" "+%s" 2>/dev/null && return 0
+        return 1
+    }
+    PR_UPDATED_TS=$(iso_to_epoch "$PR_UPDATED_AT" || echo "")
+    HEAD_COMMIT_TS=$(iso_to_epoch "$HEAD_COMMIT_TIME" || echo "")
+    if [ -n "$PR_UPDATED_TS" ] && [ -n "$HEAD_COMMIT_TS" ] && \
+       [ "$PR_UPDATED_TS" -gt "$HEAD_COMMIT_TS" ]; then
+        exit 0
+    fi
+fi
 
 # Get recent commits on this branch (since divergence from default branch)
 RECENT_COMMITS=""

--- a/git-plugin/hooks/test-check-pr-metadata-on-push.sh
+++ b/git-plugin/hooks/test-check-pr-metadata-on-push.sh
@@ -140,6 +140,62 @@ assert_exit \
     "missing command field passes through" 0 \
     '{"tool_name":"Bash","tool_input":{},"cwd":"/tmp"}'
 
+# ── Retry-aware bypass: PR updated after HEAD commit ──────────────────────
+# Regression test for issue #1041: the hook must NOT block when the PR
+# metadata was edited after the latest local commit, because the agent
+# (or human) has demonstrably already reconciled metadata for HEAD.
+echo ""
+echo "retry-aware bypass (PR updatedAt vs HEAD commit time):"
+
+# Mock gh CLI: writes canned PR JSON from $MOCK_PR_JSON
+MOCK_BIN=$(mktemp -d)
+cat >"$MOCK_BIN/gh" <<'MOCK_EOF'
+#!/usr/bin/env bash
+# Mock: only handles `gh pr view ...` for these tests.
+if [ "${1:-}" = "pr" ] && [ "${2:-}" = "view" ]; then
+    if [ -n "${MOCK_PR_JSON:-}" ]; then
+        printf '%s' "$MOCK_PR_JSON"
+    fi
+    exit 0
+fi
+exit 0
+MOCK_EOF
+chmod +x "$MOCK_BIN/gh"
+
+# Cross-platform ISO 8601 timestamp helpers (BSD vs GNU date)
+iso_offset() {
+    local offset_sec="$1"
+    if date -u -v"${offset_sec}S" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null; then
+        return 0
+    fi
+    date -u -d "${offset_sec} seconds" "+%Y-%m-%dT%H:%M:%SZ"
+}
+
+PR_FUTURE=$(iso_offset "+3600")  # 1h ahead of HEAD commit
+PR_PAST=$(iso_offset   "-3600")  # 1h behind HEAD commit
+
+# Make `git push origin feature` resolve to a PR via the mock
+PUSH_JSON=$(make_json "git push origin feature")
+
+# Test: PR updated AFTER HEAD commit → hook exits 0 (skip block)
+MOCK_PR_JSON=$(jq -n --arg t "$PR_FUTURE" \
+    '{number:42,title:"feat: x",body:"body",url:"https://example/42",updatedAt:$t}')
+PATH="$MOCK_BIN:$PATH" MOCK_PR_JSON="$MOCK_PR_JSON" \
+    assert_exit "PR updated after HEAD commit allows push (retry-aware)" 0 "$PUSH_JSON"
+
+# Test: PR updated BEFORE HEAD commit → hook still blocks (exit 2)
+MOCK_PR_JSON=$(jq -n --arg t "$PR_PAST" \
+    '{number:42,title:"feat: x",body:"body",url:"https://example/42",updatedAt:$t}')
+PATH="$MOCK_BIN:$PATH" MOCK_PR_JSON="$MOCK_PR_JSON" \
+    assert_exit "PR not updated since HEAD commit still blocks" 2 "$PUSH_JSON"
+
+# Test: missing updatedAt → fall back to legacy block behaviour
+MOCK_PR_JSON='{"number":42,"title":"feat: x","body":"body","url":"https://example/42"}'
+PATH="$MOCK_BIN:$PATH" MOCK_PR_JSON="$MOCK_PR_JSON" \
+    assert_exit "missing updatedAt falls back to blocking" 2 "$PUSH_JSON"
+
+rm -rf "$MOCK_BIN"
+
 # ── Summary ────────────────────────────────────────────────────────────────
 echo ""
 echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"


### PR DESCRIPTION
## Summary

The `git-plugin/hooks/check-pr-metadata-on-push.sh` hook unconditionally blocked **every** `git push` when an open PR existed, because it had no state tracking and always exited 2 once a PR was found. The "re-run to bypass" guidance was misleading — re-running triggered the identical block, halting agentic workflows on any branch with an open PR (#1041).

## Fix (Option 2 from the issue)

- Query the PR's `updatedAt` timestamp alongside title/body.
- Compare it to the HEAD commit time (`git log -1 --format=%cI`).
- If `updatedAt > HEAD commit time`, the PR was edited after the latest local commit → agent has demonstrably reconciled metadata for HEAD → exit 0 silently.
- Otherwise, fall through to the existing block (commits the PR has not been updated to reflect).

This preserves the hook's enforcement teeth: it still blocks when the PR genuinely needs a metadata update.

## Test plan

- [x] All 15 pre-existing guard-clause tests still pass
- [x] New: PR `updatedAt` after HEAD commit → exit 0 (bypass)
- [x] New: PR `updatedAt` before HEAD commit → exit 2 (block preserved)
- [x] New: PR JSON without `updatedAt` field → exit 2 (graceful fallback)
- [x] Cross-platform timestamp parsing (BSD on macOS, GNU on Linux)
- [x] `bash scripts/lint-shell-scripts.sh` clean
- [x] pre-commit (shellcheck + gitleaks) clean

Tests use a stubbed `gh` binary placed on `PATH` so the gh-CLI path is exercised without needing a real GitHub PR.

Fixes #1041
