### PR TITLE
fix(blueprint-plugin): advertise v3.3.0 as upgrade target

### DIFF
--- a/.claude/rules/regression-testing.md
+++ b/.claude/rules/regression-testing.md
@@ -22,6 +22,7 @@ This ensures the CI catches the same class of problem in any future skill, not j
 | Skill body structure corruption (spurious headings, leaked frontmatter) | `scripts/plugin-compliance-check.sh` → `check_skill_body()` |
 | Frontmatter field missing or malformed | `scripts/plugin-compliance-check.sh` → `check_skill_frontmatter()` |
 | Skill size exceeding limit | `scripts/plugin-compliance-check.sh` → `check_skill_size()` |
+| Blueprint upgrade target drift (migrations added without updating `blueprint-upgrade`) | `scripts/check-blueprint-upgrade-target.sh` |
 
 ## Known Regressions (Documented Bugs)
 
@@ -36,6 +37,7 @@ This ensures the CI catches the same class of problem in any future skill, not j
 | `jq ... .claude/settings.json` fails when file missing | jq writes to stderr when target file doesn't exist; `2>/dev/null` is blocked in context commands | `lint-context-commands.sh` rule `jq-on-optional-settings` | PR #TBD |
 | `Bash(test *), Bash(jq *)` etc. causes ~20 approval prompts | Shell utility patterns in `allowed-tools` force inline bash that can't be allowlisted; each compound command needs individual approval | `plugin-compliance-check.sh` `check_bash_patterns()` | PR #TBD |
 | `blueprint-{generate,derive}-rules` writes hardcoded `.claude/rules/` and clobbers hand-authored rules | SKILL.md hardcoded the output directory; no `structure.generated_rules_path` field | `plugin-compliance-check.sh` `check_skill_body()` (blueprint rules-path check) | issue #1043 |
+| `/blueprint:upgrade` reports v3.2.0 as latest after v3.3 migration was added | `blueprint-upgrade/SKILL.md` hardcodes target version; PR #1026 added `migrations/v3.2-to-v3.3.md` without updating the upgrade skill | `check-blueprint-upgrade-target.sh` compares highest migration target to `blueprint-upgrade/SKILL.md` | PR #TBD |
 
 ## How to Add a Regression Check
 

--- a/.github/workflows/plugin-pr-checks.yml
+++ b/.github/workflows/plugin-pr-checks.yml
@@ -54,6 +54,10 @@ jobs:
           echo "$RESULT" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - name: Check blueprint-upgrade target version drift
+        if: contains(steps.changed.outputs.plugins, 'blueprint-plugin')
+        run: bash scripts/check-blueprint-upgrade-target.sh
+
       - name: Post compliance results
         if: steps.compliance.outputs.result
         env:

--- a/blueprint-plugin/skills/blueprint-migration/skill.md
+++ b/blueprint-plugin/skills/blueprint-migration/skill.md
@@ -4,8 +4,8 @@ description: Versioned migration procedures for upgrading blueprint structure be
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion, TodoWrite
 created: 2025-12-22
-modified: 2026-04-12
-reviewed: 2026-04-12
+modified: 2026-04-16
+reviewed: 2026-04-16
 ---
 
 # Blueprint Migration
@@ -40,6 +40,7 @@ Expert skill for migrating blueprint structures between format versions. This sk
 | 1.x.x | 2.0.0 | `migrations/v1.x-to-v2.0.md` |
 | 2.x.x | 3.0.0 | `migrations/v2.x-to-v3.0.md` |
 | 3.0.x | 3.1.0 | `migrations/v3.0-to-v3.1.md` |
+| 3.1.x | 3.2.0 | inline in `blueprint-upgrade` (step 3a) |
 | 3.2.x | 3.3.0 | `migrations/v3.2-to-v3.3.md` |
 
 ## Version Detection

--- a/blueprint-plugin/skills/blueprint-upgrade/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-upgrade/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-17
-modified: 2026-02-17
-reviewed: 2026-01-09
+modified: 2026-04-16
+reviewed: 2026-04-16
 description: "Upgrade blueprint structure to the latest format version"
 allowed-tools: Read, Write, Edit, Bash, Glob, AskUserQuestion
 name: blueprint-upgrade
@@ -9,7 +9,7 @@ name: blueprint-upgrade
 
 Upgrade the blueprint structure to the latest format version.
 
-**Current Format Version**: 3.2.0
+**Current Format Version**: 3.3.0
 
 This command delegates version-specific migration logic to the `blueprint-migration` skill.
 
@@ -28,7 +28,7 @@ This command delegates version-specific migration logic to the `blueprint-migrat
    elif [[ -f .claude/blueprints/.manifest.json ]]; then
      current=$(jq -r '.format_version // "1.0.0"' .claude/blueprints/.manifest.json)
    fi
-   target="3.2.0"
+   target="3.3.0"
    ```
 
    **Version compatibility matrix**:
@@ -38,8 +38,9 @@ This command delegates version-specific migration logic to the `blueprint-migrat
    | 1.x.x        | 2.0.0      | `migrations/v1.x-to-v2.0.md` |
    | 2.x.x        | 3.0.0      | `migrations/v2.x-to-v3.0.md` |
    | 3.0.x        | 3.1.0      | `migrations/v3.0-to-v3.1.md` |
-   | 3.1.x        | 3.2.0      | `migrations/v3.1-to-v3.2.md` |
-   | 3.2.0        | 3.2.0      | Already up to date |
+   | 3.1.x        | 3.2.0      | inline (step 3a) |
+   | 3.2.x        | 3.3.0      | `migrations/v3.2-to-v3.3.md` |
+   | 3.3.0        | 3.3.0      | Already up to date |
 
 3. **Check for deprecated generated commands**:
 
@@ -112,12 +113,26 @@ This command delegates version-specific migration logic to the `blueprint-migrat
 
    d. **Bump format_version to 3.2.0**
 
+---
+
+3b. **v3.2 → v3.3 migration: Monorepo support**:
+
+   Delegate to `skills/blueprint-migration/migrations/v3.2-to-v3.3.md`. Summary of what it does:
+
+   a. Classify the blueprint as `root`, `child`, or `standalone` by walking ancestors and descendants for other `docs/blueprint/manifest.json` files.
+   b. Add a `workspaces` block to `docs/blueprint/manifest.json` (omitted for standalone).
+   c. Bump `format_version` to `3.3.0` and append an entry to `upgrade_history`.
+   d. For root blueprints, run `/blueprint:workspace-scan` to populate `workspaces.children`.
+   e. (Optional) Initialise the root `feature-tracker.json` `workspaces` summary for portfolio FR tracking.
+
+   All changes are purely additive — standalone projects get no new top-level keys beyond `format_version` and `upgrade_history`.
+
 4. **Display upgrade plan**:
    ```
    Blueprint Upgrade
 
    Current version: v{current}
-   Target version: v3.0.0
+   Target version: v3.3.0
 
    Major changes in v3.0:
    - Blueprint state moves from .claude/blueprints/ to docs/blueprint/
@@ -131,6 +146,13 @@ This command delegates version-specific migration logic to the `blueprint-migrat
    - Enable/disable individual tasks
    - Incremental operations with context persistence
 
+   Major changes in v3.3:
+   - First-class monorepo support: root/child/standalone roles
+   - `workspaces` block in manifest.json (additive; standalone projects omit it)
+   - New /blueprint:workspace-scan skill for discovering child blueprints
+   - Cross-workspace references (`<path>/ADR-NNN`, `/ADR-NNN`)
+   - Optional portfolio feature tracking via implemented_by links
+
    (For v2.0 changes when upgrading from v1.x:)
    - PRDs, ADRs, PRPs move to docs/ (project documentation)
    - Custom overrides in .claude/skills/
@@ -139,7 +161,7 @@ This command delegates version-specific migration logic to the `blueprint-migrat
 
 5. **Confirm with user** (use AskUserQuestion):
    ```
-   question: "Ready to upgrade blueprint from v{current} to v3.2.0?"
+   question: "Ready to upgrade blueprint from v{current} to v3.3.0?"
    options:
      - "Yes, upgrade now" → proceed
      - "Show detailed migration steps" → display migration document
@@ -151,6 +173,9 @@ This command delegates version-specific migration logic to the `blueprint-migrat
    - Read the appropriate migration document from `blueprint-migration` skill
    - For v1.x → v2.0: Load `migrations/v1.x-to-v2.0.md`
    - For v2.x → v3.0: Load `migrations/v2.x-to-v3.0.md`
+   - For v3.0 → v3.1: Load `migrations/v3.0-to-v3.1.md`
+   - For v3.1 → v3.2: Execute inline step 3a above
+   - For v3.2 → v3.3: Load `migrations/v3.2-to-v3.3.md` (see step 3b summary)
    - Execute each step with user confirmation for destructive operations
 
 7. **v1.x → v2.0 migration overview** (from migration document):

--- a/scripts/check-blueprint-upgrade-target.sh
+++ b/scripts/check-blueprint-upgrade-target.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check-blueprint-upgrade-target.sh
+#
+# Regression check: ensure blueprint-upgrade/SKILL.md advertises the latest
+# format version implied by the migration documents in
+# blueprint-plugin/skills/blueprint-migration/migrations/.
+#
+# Bug fixed: PR #1026 added monorepo support via migrations/v3.2-to-v3.3.md,
+# but blueprint-upgrade/SKILL.md still said v3.2.0 was the latest. Users
+# running /blueprint:upgrade were told they were up to date when they
+# were not.
+#
+# This script fails (exit 1) if:
+#   - The highest migration target version is not set as
+#     `**Current Format Version**: X.Y.Z` in blueprint-upgrade/SKILL.md
+#   - That version is missing from the `target="X.Y.Z"` assignment
+#   - That version is not present in the Version compatibility matrix
+#
+# Usage: bash scripts/check-blueprint-upgrade-target.sh
+
+cd "$(dirname "$0")/.." || exit 1
+
+migrations_dir="blueprint-plugin/skills/blueprint-migration/migrations"
+upgrade_skill="blueprint-plugin/skills/blueprint-upgrade/SKILL.md"
+
+if [ ! -d "$migrations_dir" ]; then
+  echo "ERROR: migrations directory not found: $migrations_dir" >&2
+  exit 2
+fi
+
+if [ ! -f "$upgrade_skill" ]; then
+  echo "ERROR: upgrade skill not found: $upgrade_skill" >&2
+  exit 2
+fi
+
+# Extract target versions from migration filenames (vA.B-to-vX.Y.md or vA.x-to-vX.Y.md).
+# We only care about the right-hand "to" version.
+#
+# sort -V gives correct semver-ish ordering for X.Y.Z strings.
+latest_target=$(
+  find "$migrations_dir" -maxdepth 1 -type f -name 'v*-to-v*.md' -print \
+    | sed -E 's|.*-to-v([0-9]+\.[0-9]+)(\.md)$|\1.0|; s|.*-to-v([0-9]+\.[0-9]+\.[0-9]+)\.md$|\1|' \
+    | sort -V \
+    | tail -n1
+)
+
+if [ -z "$latest_target" ]; then
+  echo "ERROR: could not infer latest target version from $migrations_dir" >&2
+  exit 2
+fi
+
+# Normalize to X.Y.Z (migration filenames sometimes drop the patch).
+if ! [[ "$latest_target" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  latest_target="${latest_target}.0"
+fi
+
+failures=0
+
+check_pattern() {
+  local label="$1"
+  local pattern="$2"
+  if ! grep -qE "$pattern" "$upgrade_skill"; then
+    echo "FAIL: $label"
+    echo "  Expected pattern: $pattern"
+    echo "  File: $upgrade_skill"
+    failures=$((failures + 1))
+  fi
+}
+
+# 1. Current Format Version line must match the latest migration target.
+check_pattern \
+  "Current Format Version header advertises v${latest_target}" \
+  "^\*\*Current Format Version\*\*: ${latest_target}$"
+
+# 2. The target= shell assignment inside step 2 must match.
+check_pattern \
+  "target=\"${latest_target}\" assignment present in step 2" \
+  "target=\"${latest_target}\""
+
+# 3. The version compatibility matrix must include the latest version.
+check_pattern \
+  "Compatibility matrix includes row for v${latest_target}" \
+  "\| *${latest_target} *\| *${latest_target} *\| *Already up to date"
+
+if [ "$failures" -eq 0 ]; then
+  echo "OK: blueprint-upgrade/SKILL.md is in sync with migrations (latest: v${latest_target})"
+  exit 0
+fi
+
+cat <<EOF >&2
+
+Detected $failures drift(s) between migrations/ and blueprint-upgrade/SKILL.md.
+Latest migration target: v${latest_target}
+
+Fix by updating these locations in $upgrade_skill:
+  - Header:     **Current Format Version**: ${latest_target}
+  - Step 2:     target="${latest_target}"
+  - Matrix:     | ${latest_target} | ${latest_target} | Already up to date |
+  - Add a delegation step pointing at the corresponding migration document.
+
+See .claude/rules/regression-testing.md for the prevention rationale.
+EOF
+
+exit 1


### PR DESCRIPTION
## Summary

- `/blueprint:upgrade` reported v3.2.0 as the latest version even though [#1026](https://github.com/laurigates/claude-plugins/pull/1026) added `migrations/v3.2-to-v3.3.md`. Three hardcoded mentions in `blueprint-upgrade/SKILL.md` were never updated.
- Fix the upgrade skill (header, `target=`, compatibility matrix) and add an inline Step 3b that delegates v3.2 → v3.3 work to the existing migration document.
- Prevent recurrence with `scripts/check-blueprint-upgrade-target.sh`, wired into `plugin-pr-checks.yml` so any future migration doc triggers the drift check automatically.

## What changed

| File | Change |
|------|--------|
| `blueprint-plugin/skills/blueprint-upgrade/SKILL.md` | Retarget to v3.3.0; add Step 3b; fix stale v3.1→v3.2 matrix row; bump review dates |
| `blueprint-plugin/skills/blueprint-migration/skill.md` | Add missing v3.1.x → v3.2.0 row to the Available Migrations table |
| `scripts/check-blueprint-upgrade-target.sh` | New: infers latest target from migration filenames and asserts the three hardcoded mentions match |
| `.github/workflows/plugin-pr-checks.yml` | Run the new check when `blueprint-plugin` is among changed plugins |
| `.claude/rules/regression-testing.md` | Document the regression and check |

## How the prevention works

The migration directory is the source of truth: add `migrations/vA.B-to-vX.Y.md` and the script infers the new target from the filename. If `blueprint-upgrade/SKILL.md` does not advertise that version as current + target + `Already up to date` row, the PR check fails with an exact diff instruction.

Verified the script flags the pre-fix `SKILL.md` on all three patterns.

## Test plan

- [x] `bash scripts/check-blueprint-upgrade-target.sh` passes on the fixed skill
- [x] Simulated the pre-fix state and confirmed all three assertions fail
- [x] `bash scripts/lint-shell-scripts.sh scripts/check-blueprint-upgrade-target.sh` clean
- [x] Pre-commit hooks (shellcheck, gitleaks, lint-context-commands) pass
- [ ] CI `plugin-pr-checks` job runs the new step and passes on this PR

Refs #1026