### PR TITLE
feat(feedback-plugin): add friction-learner agent for weekly session analysis

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -243,13 +243,14 @@
     {
       "name": "feedback-plugin",
       "source": "./feedback-plugin",
-      "description": "Session feedback analysis - capture skill bugs, enhancements, and positive patterns as GitHub issues",
+      "description": "Session feedback analysis - capture skill bugs as GitHub issues and learn from weekly friction across sessions",
       "version": "1.2.1",
       "keywords": [
         "feedback",
         "session-analysis",
         "skill-quality",
-        "github-issues"
+        "github-issues",
+        "friction-learner"
       ],
       "category": "quality"
     },

--- a/feedback-plugin/.claude-plugin/plugin.json
+++ b/feedback-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "feedback-plugin",
   "version": "1.2.1",
-  "description": "Session feedback analysis - capture skill bugs, enhancements, and positive patterns as GitHub issues",
+  "description": "Session feedback analysis - capture skill bugs as GitHub issues and learn from weekly friction across sessions",
   "author": {
     "name": "Lauri Gates",
     "url": "https://github.com/laurigates"
@@ -13,6 +13,7 @@
     "session-analysis",
     "skill-quality",
     "github-issues",
-    "continuous-improvement"
+    "continuous-improvement",
+    "friction-learner"
   ]
 }

--- a/feedback-plugin/README.md
+++ b/feedback-plugin/README.md
@@ -1,12 +1,39 @@
 # feedback-plugin
 
-Session feedback analysis - capture skill bugs, enhancements, and positive patterns as GitHub issues.
+Session feedback analysis — capture per-session skill bugs as GitHub issues, and learn recurring friction across a week of sessions via the `friction-learner` agent.
 
 ## Skills
 
 | Skill | Description |
 |-------|-------------|
 | `/feedback:session` | Analyze session for skill feedback and create GitHub issues |
+
+## Agents
+
+| Agent | Description |
+|-------|-------------|
+| `friction-learner` | Parse last week of transcripts, cluster interruptions/hook-blocks/rejections, propose rule/skill/hook fixes, open one PR per target repo |
+
+### Friction learner
+
+Spawn via the Agent tool or wire to a weekly cron:
+
+```
+Agent({
+  subagent_type: "friction-learner",
+  prompt: "Analyze the last 7 days of sessions. Target repo: laurigates/claude-plugins. Open a PR with proposed rule edits.",
+})
+```
+
+Dry-run the pipeline manually:
+
+```bash
+python3 feedback-plugin/scripts/friction_parse.py --since 7d --out /tmp/frictions.jsonl
+python3 feedback-plugin/scripts/friction_cluster.py --in /tmp/frictions.jsonl --min-count 3 \
+  --render-pr-body /tmp/pr-body.md --out /tmp/clusters.json
+```
+
+Signatures currently recognized: `plan:entered-plan-mode`, `push:branch-has-open-pr`, `hook:pr-metadata`, `hook:branch-protection`, `hook:conventional-commit`, `hook:gitleaks`, `hook:pre-commit`, `error:<tool>:<class>`, `reject:<tool>`, `interrupt:user`.
 
 ## Usage
 

--- a/feedback-plugin/agents/friction-learner.md
+++ b/feedback-plugin/agents/friction-learner.md
@@ -1,0 +1,155 @@
+---
+name: friction-learner
+description: |
+  Analyze a week of Claude Code session transcripts to surface recurring friction
+  (interruptions, hook blocks, tool-result errors, user rejections) and propose
+  concrete rule, skill, or hook changes. Use when you want to convert lived
+  session pain into durable rules — typically on a weekly cadence. Opens one PR
+  per target repo summarizing evidence and proposed edits.
+model: opus
+color: "#E53E3E"
+tools: Bash(python3 *), Bash(jq *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git branch *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(gh pr *), Bash(find *), Read, Write, Edit, Glob, Grep, TodoWrite
+context: fork
+maxTurns: 40
+memory: user
+created: 2026-04-16
+modified: 2026-04-16
+reviewed: 2026-04-16
+---
+
+# Friction Learner Agent
+
+Parse recent Claude Code session transcripts, cluster recurring frictions, and
+open a single evidence-backed PR per target repo with proposed rules/skills/hook
+adjustments.
+
+## Scope
+
+- **Input**: A time window (default: last 7 days) and a list of target rulesync repos
+- **Output**: One PR per repo with a proposed-rules diff and an evidence summary
+- **Steps**: 6-15 (parse → classify → cluster → propose → render → PR)
+- **Value**: Converts recurring session pain into durable guardrails without manual log-reading
+
+## When to Use
+
+| Use this agent when… | Use alternative when… |
+|---|---|
+| End of week, want durable fixes | Single session feedback → `/feedback:session` |
+| Multiple sessions show same friction | One-off guidance bug → edit the SKILL directly |
+| Want cross-repo rule updates | Project-internal retrospective → `/health:check` |
+
+## Transcript Source
+
+Transcripts live in `~/.claude/projects/<slug>/<session-id>.jsonl`. Each line is
+a JSON record. Friction signals come from these record shapes:
+
+| Signal | Where it appears |
+|---|---|
+| User interrupt | `type: user`, content starts with `[Request interrupted by user` |
+| User rejection of tool | `toolUseResult.is_error: true` with `content: "The user doesn't want…"` |
+| Hook block (PreToolUse exit 2) | `toolUseResult` containing `hookEventName: PreToolUse` and `exit_code: 2` — or content matching `blocked by a hook`/`exit code 2` |
+| Tool error | `toolUseResult.is_error: true` with command output |
+| Plan-mode entry | assistant `tool_use` with `name: ExitPlanMode` |
+| Push-to-PR-branch failure | `git push` tool_result mentioning `open pull request` or `protected branch` |
+
+## Workflow
+
+### Step 1: Enumerate transcripts in window
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/friction_parse.py" \
+  --since 7d \
+  --out /tmp/frictions.jsonl
+```
+
+The parser emits one friction event per line:
+
+```json
+{"session": "…", "ts": "…", "kind": "hook_block|tool_error|user_reject|user_interrupt|plan_mode|push_to_pr_branch", "signature": "…", "tool": "…", "evidence": "…"}
+```
+
+### Step 2: Cluster by signature
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/friction_cluster.py" \
+  --in /tmp/frictions.jsonl \
+  --min-count 3 \
+  --out /tmp/clusters.json
+```
+
+Signature keys normalize tool + canonical substring so `git push origin foo` and
+`git push origin bar` collapse to `push:branch-has-open-pr` when the error body
+matches that regex.
+
+### Step 3: Propose a fix per cluster
+
+For each cluster with ≥3 occurrences, map to a concrete deliverable:
+
+| Cluster kind | Deliverable |
+|---|---|
+| Hook block seen ≥3× | Rule edit (`CLAUDE.md` or `.claude/rules/*.md`) documenting the block + fix |
+| Tool error with a known flag-fix | Skill SKILL.md edit adding the correct flag |
+| User rejection of plan mode on Q&A | Rule edit: "don't enter plan mode for conceptual Q&A" |
+| Push-to-PR-branch repeats | Hook adjustment: pre-push check for open PR on target branch |
+
+### Step 4: Render proposed diffs per target repo
+
+The target is the repo containing the rules — usually `rulesync`. Per repo:
+
+1. Clone (or reuse worktree) of the target repo
+2. Write proposed rule file(s) to `rules/claude/friction/YYYY-WW-frictions.md`
+3. Include an **Evidence** section with session IDs + timestamps (redact paths if needed)
+
+### Step 5: Open one PR per repo
+
+Use a stable branch name: `friction/YYYY-WW-<repo>`. Title:
+
+```
+docs(rules): add friction-learner findings for week YYYY-WW
+```
+
+PR body contains the cluster summary table and evidence snippets.
+
+### Step 6: Report summary to main session
+
+Print a table: cluster → count → deliverable → PR URL.
+
+## Output Format
+
+```
+## Friction Report: 2026-W15 (last 7 days)
+
+| Cluster | Count | Deliverable | PR |
+|---|---|---|---|
+| plan-mode-on-qa | 5 | rule edit | #123 |
+| push-to-branch-with-open-pr | 4 | hook + rule | #124 |
+| gh-api-in-context | 3 | skill patch | #125 |
+
+Sessions analyzed: 14
+Friction events: 42
+Clusters found: 7 (3 actionable)
+```
+
+## Guardrails
+
+- **Never auto-merge**. The agent only opens the PR; a human reviews evidence.
+- **Redact**. Strip absolute paths from `$HOME` downwards, and any token-looking strings matching `[A-Za-z0-9_-]{32,}`, before embedding evidence in PR bodies.
+- **Quiet windows**. If fewer than 5 friction events total, print the report to stdout and do NOT open a PR.
+- **Min-count gate**. Default `--min-count 3`. Clusters below the threshold are listed as "watch" items only.
+- **Scope per user instruction**. If the user named target repos, only open PRs there. If they did not, default to the current repo's upstream and print a warning.
+
+## Team Configuration
+
+**Recommended role**: Teammate (preferred) or Subagent
+
+| Mode | When to Use |
+|---|---|
+| Teammate | Weekly cron-style run alongside other automation |
+| Subagent | Manual invocation from main session, return findings for review |
+
+## What This Agent Does NOT Do
+
+- Auto-merge PRs
+- Modify settings.json hooks (proposes them; user applies)
+- Send webhook notifications
+- Rewrite existing rules (only adds a new dated rule file; humans consolidate later)

--- a/feedback-plugin/scripts/friction_cluster.py
+++ b/feedback-plugin/scripts/friction_cluster.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Cluster friction events and propose concrete fixes.
+
+Input:  JSONL of events from friction_parse.py (stdin or --in)
+Output: JSON clusters with proposed deliverable + rendered rule body
+
+Usage:
+    friction_cluster.py --in frictions.jsonl --min-count 3 --out clusters.json
+    friction_cluster.py --in frictions.jsonl --min-count 3 --render-pr-body out.md
+
+Deliverable mapping:
+    hook:*          -> rule edit documenting the block + the correct workflow
+    push:*          -> hook adjustment (pre-push PR check) + rule
+    plan:*          -> rule edit: "don't enter plan mode for conceptual Q&A"
+    error:Bash:*    -> skill patch (quick reference flag or note)
+    reject:*        -> rule edit documenting what the user declined
+    interrupt:*     -> summary only (usually not actionable)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+DELIVERABLES = {
+    "plan:entered-plan-mode": {
+        "kind": "rule",
+        "path": "rules/claude/friction/plan-mode-on-qa.md",
+        "title": "Avoid plan mode for conceptual Q&A",
+        "body": """# Avoid plan mode for conceptual Q&A
+
+When the user asks a **question** (starts with "how", "what", "why", "can", "does")
+and does not request a change to files, **do not** call `ExitPlanMode`. Answer
+the question directly.
+
+## Heuristics
+
+| Signal | Action |
+|---|---|
+| Request contains "explain", "how does", "what is", "compare" | Answer inline, no plan mode |
+| Request asks to modify, add, remove, rename, fix | Plan mode is acceptable |
+| User says "just tell me" / "no plan needed" | Never enter plan mode |
+
+## Evidence
+
+__EVIDENCE__
+""",
+    },
+    "push:branch-has-open-pr": {
+        "kind": "rule+hook",
+        "path": "rules/claude/friction/push-to-pr-branch.md",
+        "title": "Check for existing open PR before pushing to a shared branch",
+        "body": """# Check for existing open PR before pushing to a shared branch
+
+Pushing to a branch that already has an **open PR** can surprise reviewers and
+retrigger CI. Before `git push`, verify whether the target branch has an open PR
+and confirm the push is intended.
+
+## Required pre-push check
+
+```bash
+target_branch=$(git rev-parse --abbrev-ref HEAD)
+open_pr=$(gh pr list --head "$target_branch" --state open --json number --jq '.[0].number // empty')
+if [ -n "$open_pr" ]; then
+  echo "Branch '$target_branch' has open PR #$open_pr — confirm before pushing" >&2
+fi
+```
+
+## Suggested hook
+
+Add to `.claude/settings.json` under `hooks.PreToolUse`:
+
+```json
+{
+  "matcher": "Bash",
+  "hooks": [{
+    "type": "command",
+    "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/check-open-pr.sh"
+  }]
+}
+```
+
+The hook exits with code 2 when the push targets a branch with an open PR and
+the commit message doesn't include `[force-push-ok]`.
+
+## Evidence
+
+__EVIDENCE__
+""",
+    },
+}
+
+
+def load_events(path: str) -> list[dict]:
+    stream = sys.stdin if path == "-" else open(path, "r", encoding="utf-8")
+    try:
+        out = []
+        for line in stream:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+        return out
+    finally:
+        if stream is not sys.stdin:
+            stream.close()
+
+
+def cluster(events: list[dict]) -> dict[str, list[dict]]:
+    buckets: dict[str, list[dict]] = defaultdict(list)
+    for ev in events:
+        buckets[ev.get("signature", "unknown")].append(ev)
+    return buckets
+
+
+def propose(signature: str, hits: list[dict]) -> dict:
+    spec = DELIVERABLES.get(signature)
+    if spec is None:
+        if signature.startswith("hook:"):
+            spec = {
+                "kind": "rule",
+                "path": f"rules/claude/friction/{signature.replace(':', '-')}.md",
+                "title": f"Workaround for {signature}",
+                "body": f"# Workaround for {signature}\n\nObserved __COUNT__ times.\n\n__EVIDENCE__\n",
+            }
+        elif signature.startswith("error:"):
+            spec = {
+                "kind": "skill-patch",
+                "path": f"notes/{signature.replace(':', '-')}.md",
+                "title": f"Tool-error pattern: {signature}",
+                "body": f"# {signature}\n\nObserved __COUNT__ times. Add the correct flag/pattern to the relevant skill Quick Reference table.\n\n__EVIDENCE__\n",
+            }
+        else:
+            spec = {
+                "kind": "watch",
+                "path": "",
+                "title": f"Watch: {signature}",
+                "body": "",
+            }
+    evidence_block = "\n".join(
+        f"- `{h.get('session','?')[:8]}` at {h.get('ts','?')}: {h.get('evidence','')[:200].strip()}"
+        for h in hits[:5]
+    )
+    rendered_body = (
+        spec["body"].replace("__COUNT__", str(len(hits))).replace("__EVIDENCE__", evidence_block)
+        if spec["body"] else ""
+    )
+    return {
+        "signature": signature,
+        "count": len(hits),
+        "kind": spec["kind"],
+        "path": spec["path"],
+        "title": spec["title"],
+        "body": rendered_body,
+        "samples": [
+            {"session": h.get("session"), "ts": h.get("ts"), "tool": h.get("tool"), "evidence": h.get("evidence")}
+            for h in hits[:3]
+        ],
+    }
+
+
+def render_pr_body(proposals: list[dict], total_events: int, total_sessions: int, window: str) -> str:
+    week = datetime.now(tz=timezone.utc).strftime("%G-W%V")
+    lines = [
+        f"## Friction Report: {week}",
+        "",
+        f"- Window: {window}",
+        f"- Sessions analyzed: {total_sessions}",
+        f"- Friction events: {total_events}",
+        f"- Actionable clusters: {sum(1 for p in proposals if p['kind'] != 'watch')}",
+        "",
+        "| Cluster | Count | Deliverable | Path |",
+        "|---|---|---|---|",
+    ]
+    for p in sorted(proposals, key=lambda x: -x["count"]):
+        lines.append(f"| `{p['signature']}` | {p['count']} | {p['kind']} | `{p['path'] or '—'}` |")
+    lines += ["", "## Proposed changes", ""]
+    for p in proposals:
+        if p["kind"] == "watch" or not p["body"]:
+            continue
+        lines += [f"### {p['title']}", f"**File**: `{p['path']}`", "", "```markdown", p["body"].rstrip(), "```", ""]
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="infile", default="-")
+    ap.add_argument("--min-count", type=int, default=3)
+    ap.add_argument("--out", default="-")
+    ap.add_argument("--render-pr-body", default="", help="Also write a PR body markdown to this path")
+    ap.add_argument("--window", default="7d")
+    args = ap.parse_args()
+
+    events = load_events(args.infile)
+    buckets = cluster(events)
+    proposals_all = [propose(sig, hits) for sig, hits in buckets.items()]
+    actionable = [p for p in proposals_all if p["count"] >= args.min_count]
+
+    sessions = {e.get("session") for e in events}
+
+    result = {
+        "window": args.window,
+        "total_events": len(events),
+        "total_sessions": len(sessions),
+        "min_count": args.min_count,
+        "actionable": actionable,
+        "watch": [p for p in proposals_all if p["count"] < args.min_count],
+    }
+
+    out = sys.stdout if args.out == "-" else open(args.out, "w", encoding="utf-8")
+    try:
+        json.dump(result, out, indent=2, ensure_ascii=False)
+        out.write("\n")
+    finally:
+        if out is not sys.stdout:
+            out.close()
+
+    if args.render_pr_body:
+        body = render_pr_body(actionable, len(events), len(sessions), args.window)
+        Path(args.render_pr_body).write_text(body, encoding="utf-8")
+        sys.stderr.write(f"wrote PR body to {args.render_pr_body}\n")
+
+    sys.stderr.write(
+        f"events={len(events)} sessions={len(sessions)} clusters={len(buckets)} actionable={len(actionable)}\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/feedback-plugin/scripts/friction_parse.py
+++ b/feedback-plugin/scripts/friction_parse.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Parse Claude Code session transcripts into normalized friction events.
+
+Reads JSONL files under ~/.claude/projects/*/ (or paths given on argv) and emits
+one friction event per line on stdout (or to --out). A friction event looks like:
+
+    {"session": "...", "ts": "...", "kind": "hook_block", "signature": "...",
+     "tool": "Bash", "evidence": "first 400 chars of the offending content"}
+
+Kinds:
+  hook_block         PreToolUse exit-2 or explicit "blocked by a hook" in content
+  tool_error         tool_use_result with is_error: true that is not a hook block
+  user_reject        is_error with content matching "user (doesn't|does not) want"
+  user_interrupt     user message starts with "[Request interrupted"
+  plan_mode          assistant tool_use name == "ExitPlanMode"
+  push_to_pr_branch  git push result mentioning an existing open PR / protected branch
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable, Iterator
+
+HOME = Path(os.path.expanduser("~"))
+DEFAULT_ROOT = HOME / ".claude" / "projects"
+
+HOOK_BLOCK_RE = re.compile(r"(blocked by (?:a |the )?hook|exit(?:ed)? (?:with )?(?:code )?2|PreToolUse.*blocked)", re.I)
+USER_REJECT_RE = re.compile(r"user (?:doesn'?t|does not|did not|refused to|declined)", re.I)
+PUSH_PR_RE = re.compile(r"(open pull request|protected branch|pr .*already open|has an open PR|refusing to push)", re.I)
+INTERRUPT_RE = re.compile(r"^\[Request interrupted")
+SECRET_RE = re.compile(r"\b[A-Za-z0-9_\-]{32,}\b")
+
+
+def redact(text: str) -> str:
+    """Strip $HOME paths and token-looking strings."""
+    if not text:
+        return text
+    text = text.replace(str(HOME), "$HOME")
+    text = SECRET_RE.sub(lambda m: m.group(0)[:6] + "…" if len(m.group(0)) > 40 else m.group(0), text)
+    return text
+
+
+def first_text(content) -> str:
+    """Extract first text content from a message.content (string or list)."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        for item in content:
+            if isinstance(item, dict):
+                if item.get("type") == "text" and "text" in item:
+                    return item["text"]
+                if item.get("type") == "tool_result":
+                    inner = item.get("content")
+                    if isinstance(inner, str):
+                        return inner
+                    if isinstance(inner, list):
+                        for sub in inner:
+                            if isinstance(sub, dict) and sub.get("type") == "text":
+                                return sub.get("text", "")
+    return ""
+
+
+def canonical_signature(kind: str, tool: str, evidence: str) -> str:
+    """Collapse similar-looking evidence into a stable cluster key."""
+    ev = evidence.lower()
+    if kind == "hook_block":
+        for needle, sig in [
+            ("branch-protection", "hook:branch-protection"),
+            ("pr metadata", "hook:pr-metadata"),
+            ("conventional commit", "hook:conventional-commit"),
+            ("gitleaks", "hook:gitleaks"),
+            ("pre-commit", "hook:pre-commit"),
+        ]:
+            if needle in ev:
+                return sig
+        return "hook:unclassified"
+    if kind == "push_to_pr_branch":
+        return "push:branch-has-open-pr"
+    if kind == "plan_mode":
+        return "plan:entered-plan-mode"
+    if kind == "user_reject":
+        return f"reject:{tool.lower()}"
+    if kind == "user_interrupt":
+        return "interrupt:user"
+    if kind == "tool_error":
+        m = re.search(r"\b(ENOENT|EACCES|not found|permission denied|timeout|connection refused)\b", ev, re.I)
+        if m:
+            return f"error:{tool.lower()}:{m.group(1).lower().replace(' ', '-')}"
+        return f"error:{tool.lower()}"
+    return f"{kind}:{tool.lower()}"
+
+
+def iter_transcripts(roots: list[Path], since: datetime | None) -> Iterator[Path]:
+    for root in roots:
+        if not root.exists():
+            continue
+        for path in sorted(root.rglob("*.jsonl")):
+            try:
+                mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+            except OSError:
+                continue
+            if since and mtime < since:
+                continue
+            yield path
+
+
+def parse_since(spec: str) -> datetime | None:
+    if not spec:
+        return None
+    if spec.endswith("d"):
+        return datetime.now(tz=timezone.utc) - timedelta(days=int(spec[:-1]))
+    if spec.endswith("h"):
+        return datetime.now(tz=timezone.utc) - timedelta(hours=int(spec[:-1]))
+    return datetime.fromisoformat(spec.replace("Z", "+00:00"))
+
+
+def extract_frictions(path: Path) -> Iterator[dict]:
+    session = path.stem
+    with path.open("r", encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            rtype = rec.get("type")
+            ts = rec.get("timestamp", "")
+
+            # User interrupt markers (sit in user messages)
+            if rtype == "user":
+                msg = rec.get("message", {})
+                content = msg.get("content")
+                text = first_text(content)
+                if text and INTERRUPT_RE.match(text):
+                    yield {
+                        "session": session, "ts": ts, "kind": "user_interrupt",
+                        "tool": "-", "signature": "interrupt:user",
+                        "evidence": redact(text[:400]),
+                    }
+                    continue
+                # Tool results embedded in user messages carry is_error
+                tur = rec.get("toolUseResult") or {}
+                if not isinstance(tur, dict):
+                    tur = {"content": tur}
+                is_error = tur.get("is_error") or (isinstance(content, list) and any(
+                    isinstance(i, dict) and i.get("type") == "tool_result" and i.get("is_error")
+                    for i in content
+                ))
+                if is_error:
+                    tool = rec.get("toolUseName") or tur.get("toolName") or "?"
+                    body = text or json.dumps(tur)[:400]
+                    if HOOK_BLOCK_RE.search(body):
+                        kind = "hook_block"
+                    elif USER_REJECT_RE.search(body):
+                        kind = "user_reject"
+                    elif tool == "Bash" and "git push" in body.lower() and PUSH_PR_RE.search(body):
+                        kind = "push_to_pr_branch"
+                    else:
+                        kind = "tool_error"
+                    yield {
+                        "session": session, "ts": ts, "kind": kind,
+                        "tool": tool,
+                        "signature": canonical_signature(kind, tool, body),
+                        "evidence": redact(body[:400]),
+                    }
+
+            elif rtype == "assistant":
+                msg = rec.get("message", {})
+                for item in msg.get("content", []) or []:
+                    if isinstance(item, dict) and item.get("type") == "tool_use":
+                        if item.get("name") == "ExitPlanMode":
+                            plan = ""
+                            inp = item.get("input") or {}
+                            if isinstance(inp, dict):
+                                plan = inp.get("plan", "")
+                            yield {
+                                "session": session, "ts": ts, "kind": "plan_mode",
+                                "tool": "ExitPlanMode",
+                                "signature": canonical_signature("plan_mode", "ExitPlanMode", plan),
+                                "evidence": redact(str(plan)[:400]),
+                            }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--since", default="7d", help="Time window (e.g. 7d, 24h, ISO timestamp)")
+    ap.add_argument("--root", action="append", default=[],
+                    help="Transcript root (repeatable). Defaults to ~/.claude/projects")
+    ap.add_argument("--out", default="-", help="Output path; '-' for stdout")
+    args = ap.parse_args()
+
+    roots = [Path(r) for r in args.root] or [DEFAULT_ROOT]
+    since = parse_since(args.since)
+    out = sys.stdout if args.out == "-" else open(args.out, "w", encoding="utf-8")
+
+    total_files = 0
+    total_events = 0
+    try:
+        for path in iter_transcripts(roots, since):
+            total_files += 1
+            for ev in extract_frictions(path):
+                out.write(json.dumps(ev, ensure_ascii=False) + "\n")
+                total_events += 1
+    finally:
+        if out is not sys.stdout:
+            out.close()
+
+    sys.stderr.write(f"parsed {total_files} transcript(s), emitted {total_events} friction event(s)\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds a new agent that parses Claude Code session transcripts under
~/.claude/projects/, classifies friction events (interruptions, hook blocks,
tool errors, user rejections, plan-mode entries, push-to-PR-branch attempts),
clusters them by canonical signature, and proposes rule/skill/hook edits for
clusters above a configurable min-count threshold.

The agent delivers one PR per target repo with:
- A cluster summary table (signature, count, deliverable, path)
- Proposed rule file bodies with redacted evidence snippets
- Concrete hook config snippets where applicable

Two canonical deliverables ship with built-in templates:
- plan:entered-plan-mode -> rule edit "don't enter plan mode for Q&A"
- push:branch-has-open-pr -> pre-push open-PR hook + rule edit

Components:
- feedback-plugin/agents/friction-learner.md (agent definition)
- feedback-plugin/scripts/friction_parse.py (transcript -> events)
- feedback-plugin/scripts/friction_cluster.py (events -> proposals/PR body)

Metadata: marketplace.json description + keyword, plugin.json keyword.
README updated with an Agents section and manual dry-run instructions.

Refs claude/friction-learner-agent-l5FYg