### PR TITLE
docs: update Claude Opus model references to 4.7

### DIFF
--- a/.claude/rules/agent-development.md
+++ b/.claude/rules/agent-development.md
@@ -73,7 +73,7 @@ hooks:                 # Agent-scoped hooks (active only when agent is running)
 |-------|------|----------|-------------|
 | `name` | string | Yes | Agent identifier (kebab-case) |
 | `description` | string | Yes | Purpose and use cases for agent selection |
-| `model` | string | Yes | `opus`, `sonnet`, `haiku`, `inherit`, or full model ID (e.g., `claude-opus-4-5`) — full IDs fixed in 2.1.74 |
+| `model` | string | Yes | `opus`, `sonnet`, `haiku`, `inherit`, or full model ID (e.g., `claude-opus-4-7`) — full IDs fixed in 2.1.74 |
 | `tools` | comma-list | Yes | Tools the agent can use; use `Agent(name)` to restrict spawnable subagents |
 | `context` | string | No | `fork` for isolated context (default: shared) |
 | `isolation` | string | No | `worktree` to run agent in an isolated git worktree |

--- a/.claude/rules/skill-fork-context.md
+++ b/.claude/rules/skill-fork-context.md
@@ -11,11 +11,11 @@ When to set `context: fork` and `agent:` in skill frontmatter.
 
 ## Current Status: Do NOT Use `context: fork` in Plugin Skills
 
-**As of March 2026, `context: fork` has two blocking issues for plugin-based skills:**
+**As of April 2026, `context: fork` has two blocking issues for plugin-based skills:**
 
 1. **Broken for plugins** ([anthropics/claude-code#16803](https://github.com/anthropics/claude-code/issues/16803), OPEN) — `context: fork` is silently ignored for plugin-installed skills. It only works for skills in the user's `~/.claude/` folder.
 
-2. **Triggers rate limits with 1M context models** ([#27053](https://github.com/anthropics/claude-code/issues/27053), [#33154](https://github.com/anthropics/claude-code/issues/33154)) — Forking from an Opus 4.6 (1M) session spawns a second concurrent `[1m]` request, immediately hitting rate limits (`total_tokens: 0` rejection). This affects the default recommended model.
+2. **Triggers rate limits with 1M context models** ([#27053](https://github.com/anthropics/claude-code/issues/27053), [#33154](https://github.com/anthropics/claude-code/issues/33154)) — Forking from an Opus 4.7 (1M) session spawns a second concurrent `[1m]` request, immediately hitting rate limits (`total_tokens: 0` rejection). This affects the default recommended model.
 
 **Use `agent: general-purpose` without `context: fork`** to get subagent isolation without triggering these issues.
 

--- a/accessibility-plugin/README.md
+++ b/accessibility-plugin/README.md
@@ -66,7 +66,7 @@ Bridges the gap between service design decisions and production code.
 - Responsive implementation patterns
 - Performance-aware UX
 
-**Model:** Claude Opus 4.5
+**Model:** Claude Opus 4.7
 
 #### service-design
 Strategic UX architecture, service blueprints, and interaction design.
@@ -86,7 +86,7 @@ Strategic UX architecture, service blueprints, and interaction design.
 - Universal design principles
 - Omnichannel strategy
 
-**Model:** Claude Opus 4.5
+**Model:** Claude Opus 4.7
 
 ## Use Cases
 

--- a/agent-patterns-plugin/skills/custom-agent-definitions/SKILL.md
+++ b/agent-patterns-plugin/skills/custom-agent-definitions/SKILL.md
@@ -8,8 +8,8 @@ description: |
 user-invocable: false
 allowed-tools: Bash(cat *), Read, Write, Edit, Glob, Grep, TodoWrite
 created: 2026-01-20
-modified: 2026-03-09
-reviewed: 2026-03-09
+modified: 2026-04-16
+reviewed: 2026-04-16
 ---
 
 # Custom Agent Definitions
@@ -226,7 +226,7 @@ description: |
 |----------|-------|----------|
 | Simple/mechanical tasks | haiku | claude-haiku-4-5 |
 | Development workflows | sonnet | claude-sonnet-4-6 |
-| Deep reasoning/analysis | opus | claude-opus-4-6 |
+| Deep reasoning/analysis | opus | claude-opus-4-7 |
 
 ## Agent Configuration Fields Reference
 

--- a/agent-patterns-plugin/skills/meta-audit/SKILL.md
+++ b/agent-patterns-plugin/skills/meta-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-16
-modified: 2025-12-16
-reviewed: 2025-12-16
+modified: 2026-04-16
+reviewed: 2026-04-16
 allowed-tools: Glob, Read, TodoWrite
 description: Audit Claude subagent configurations for completeness, security, and best practices
 args: "[--verbose]"
@@ -27,7 +27,7 @@ name: meta-audit
 For each agent, verify required fields are present:
 
 - ✅ **name**: Agent identifier (must match filename)
-- ✅ **model**: Claude model to use (e.g., "claude-opus-4-5")
+- ✅ **model**: Claude model to use (e.g., "claude-opus-4-7")
 - ✅ **color**: Hex color code for UI (e.g., "#E53E3E")
 - ✅ **description**: Clear usage guidance with "Use proactively when..."
 - ✅ **tools**: Tool list or "All" for full access

--- a/api-plugin/README.md
+++ b/api-plugin/README.md
@@ -25,7 +25,7 @@ Specialized agent for exploring and integrating with REST APIs, especially when 
 - Generating OpenAPI specifications
 - Creating typed API clients
 
-**Model**: Claude Opus 4.5
+**Model**: Claude Opus 4.7
 
 **Workflow:**
 1. Probe for existing OpenAPI/Swagger specs

--- a/configure-plugin/skills/config-sync/SKILL.md
+++ b/configure-plugin/skills/config-sync/SKILL.md
@@ -8,8 +8,8 @@ allowed-tools: Bash(git *), Bash(gh *), Bash(fd *), Bash(rg *), Bash(diff *), Ba
 args: <mode> [options]
 argument-hint: "extract [repo]|diff <file-pattern>|apply <file-pattern> [--from repo] [--to repos|--all]"
 created: 2026-02-21
-modified: 2026-02-21
-reviewed: 2026-02-21
+modified: 2026-04-16
+reviewed: 2026-04-16
 ---
 
 # /configure:config-sync
@@ -303,7 +303,7 @@ git checkout -b config-sync/claude-yml
 git add <file>
 git commit -m "chore: sync claude.yml from canonical
 
-Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
 git push -u origin config-sync/claude-yml
 gh pr create --title "chore: sync claude.yml" --body "$(cat <<'EOF'
 ## Summary

--- a/git-plugin/skills/git-commit/skill.md
+++ b/git-plugin/skills/git-commit/skill.md
@@ -95,7 +95,7 @@ Optional body explaining the change.
 Fixes #123
 Refs #456
 
-Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
 EOF
 )"
 ```


### PR DESCRIPTION
Updates plugin docs, skill examples, and agent development rules to
reference the newly released Claude Opus 4.7 (claude-opus-4-7). Leaves
the .claude-code-version-check.json historical changelog intact since
it records past Claude Code releases.

Refs https://www.anthropic.com/news/claude-opus-4-7