### PR TITLE
perf: pR title generation from agent output

### DIFF
--- a/git-repo-agent/src/git_repo_agent/orchestrator.py
+++ b/git-repo-agent/src/git_repo_agent/orchestrator.py
@@ -1053,19 +1053,83 @@ def _extract_report_section(agent_output: str) -> str:
     return "\n".join(report_lines).strip()
 
 
+_WORKFLOW_REPORT_HEADINGS = {
+    "maintain": "Maintenance Report",
+    "onboard": "Onboarding Report",
+    "diagnose": "Diagnostics Report",
+}
+
+_FIXED_SECTION_MARKERS = ("fixed", "changes made", "applied", "changes")
+
+_PR_TITLE_MAX = 72
+
+
+def _extract_fixed_items(report: str) -> list[str]:
+    """Extract bullet items from a "fixed" / "changes made" section.
+
+    Looks under ``###``/``##`` sub-headings whose text contains one of
+    ``_FIXED_SECTION_MARKERS`` and returns the bullet text (without the
+    leading ``- ``). Placeholder lines like ``<list of auto-fixed items>``
+    from the prompt template are ignored.
+    """
+    if not report:
+        return []
+
+    items: list[str] = []
+    capturing = False
+    for raw in report.splitlines():
+        stripped = raw.strip()
+        if stripped.startswith("#"):
+            heading = stripped.lstrip("#").strip().lower()
+            capturing = any(marker in heading for marker in _FIXED_SECTION_MARKERS)
+            continue
+        if not capturing:
+            continue
+        if stripped.startswith(("- ", "* ")):
+            item = stripped[2:].strip()
+            if item and not (item.startswith("<") and item.endswith(">")):
+                items.append(item)
+    return items
+
+
+def _normalize_subject(text: str) -> str:
+    subject = text.strip().rstrip(".")
+    if subject and subject[0].isupper() and not subject[:2].isupper():
+        subject = subject[0].lower() + subject[1:]
+    if len(subject) > _PR_TITLE_MAX:
+        subject = subject[: _PR_TITLE_MAX - 3].rstrip() + "..."
+    return subject
+
+
+def _build_pr_title(workflow: str, fixed_items: list[str]) -> str:
+    """Build a conventional-commit PR title from fixed items when available."""
+    if len(fixed_items) == 1:
+        return f"chore: {_normalize_subject(fixed_items[0])}"
+    if fixed_items:
+        return f"chore: apply {len(fixed_items)} automated {workflow} fixes"
+    return f"chore: automated {workflow} run"
+
+
 def _build_pr_content(workflow: str, agent_output: str) -> tuple[str, str]:
     """Build PR title and body from workflow type and agent output.
+
+    The title summarises the actual changes when the agent's report lists
+    fixed items; otherwise it falls back to a generic scoped title. The
+    body heading is chosen per workflow so non-maintenance runs aren't
+    mislabelled as "Maintenance Report".
 
     Returns (title, body) tuple.
     """
     report = _extract_report_section(agent_output)
-
-    # Build a descriptive title from the report if possible
-    pr_title = f"chore: {workflow} repository"
+    fixed_items = _extract_fixed_items(report)
+    pr_title = _build_pr_title(workflow, fixed_items)
+    heading = _WORKFLOW_REPORT_HEADINGS.get(
+        workflow, f"{workflow.capitalize()} Report"
+    )
 
     if report:
         pr_body = (
-            f"## Maintenance Report\n\n"
+            f"## {heading}\n\n"
             f"{report}\n\n"
             f"---\n\n"
             f"## Test plan\n\n"
@@ -1076,7 +1140,7 @@ def _build_pr_content(workflow: str, agent_output: str) -> tuple[str, str]:
     else:
         pr_body = (
             f"## Summary\n\n"
-            f"- Automated {workflow} via git-repo-agent\n\n"
+            f"- Automated {workflow} run via git-repo-agent\n\n"
             f"## Test plan\n\n"
             f"- [ ] Review changes in the diff\n"
             f"- [ ] Verify CI passes\n\n"

--- a/git-repo-agent/tests/test_orchestrator_display.py
+++ b/git-repo-agent/tests/test_orchestrator_display.py
@@ -3,7 +3,10 @@
 from git_repo_agent.orchestrator import (
     _build_phase2_prompt,
     _build_pr_content,
+    _build_pr_title,
+    _extract_fixed_items,
     _extract_report_section,
+    _normalize_subject,
     _phase2_system_prompt,
     _tool_detail,
 )
@@ -73,22 +76,110 @@ class TestExtractReportSection:
         assert _extract_report_section("just plain text\nno headings") == ""
 
 
+class TestExtractFixedItems:
+    def test_empty(self):
+        assert _extract_fixed_items("") == []
+
+    def test_no_fixed_section(self):
+        report = "## Maintenance Report\n\nHealth Score: 85/100"
+        assert _extract_fixed_items(report) == []
+
+    def test_extracts_issues_fixed_bullets(self):
+        report = (
+            "## Maintenance Report\n"
+            "### Issues Fixed\n"
+            "- Add install section to README.md\n"
+            "- Configure ESLint with default rules\n"
+            "### Remaining Issues\n"
+            "- Fix failing auth tests\n"
+        )
+        assert _extract_fixed_items(report) == [
+            "Add install section to README.md",
+            "Configure ESLint with default rules",
+        ]
+
+    def test_skips_placeholder_items(self):
+        report = "### Issues Fixed\n- <list of auto-fixed items>\n"
+        assert _extract_fixed_items(report) == []
+
+    def test_matches_changes_made_heading(self):
+        report = "### Changes Made\n- Update CLAUDE.md with project conventions\n"
+        assert _extract_fixed_items(report) == [
+            "Update CLAUDE.md with project conventions"
+        ]
+
+
+class TestNormalizeSubject:
+    def test_lowercases_first_char(self):
+        assert _normalize_subject("Add install section") == "add install section"
+
+    def test_preserves_acronyms(self):
+        assert _normalize_subject("CI workflow updated") == "CI workflow updated"
+
+    def test_strips_trailing_period(self):
+        assert _normalize_subject("add feature.") == "add feature"
+
+    def test_truncates_long_subjects(self):
+        long = "a" * 120
+        result = _normalize_subject(long)
+        assert len(result) <= 72
+        assert result.endswith("...")
+
+
+class TestBuildPrTitle:
+    def test_no_fixed_items_falls_back(self):
+        assert _build_pr_title("maintain", []) == "chore: automated maintain run"
+
+    def test_single_fixed_item_becomes_subject(self):
+        title = _build_pr_title("maintain", ["Add install section to README"])
+        assert title == "chore: add install section to README"
+
+    def test_multiple_fixed_items_summarised(self):
+        title = _build_pr_title("maintain", ["a", "b", "c"])
+        assert title == "chore: apply 3 automated maintain fixes"
+
+
 class TestBuildPrContent:
-    def test_with_report(self):
-        title, body = _build_pr_content("maintain", "## Health Score\n85/100")
-        assert title == "chore: maintain repository"
+    def test_descriptive_title_from_fixed_items(self):
+        output = (
+            "## Maintenance Report\n"
+            "### Issues Fixed\n"
+            "- Add install section to README.md\n"
+        )
+        title, body = _build_pr_content("maintain", output)
+        assert title == "chore: add install section to README.md"
         assert "## Maintenance Report" in body
-        assert "85/100" in body
+        assert "Add install section to README.md" in body
+
+    def test_onboard_uses_onboarding_heading(self):
+        output = "## Onboarding Report\nAll good"
+        _, body = _build_pr_content("onboard", output)
+        assert "## Onboarding Report" in body
+        assert "## Maintenance Report" not in body
+
+    def test_diagnose_uses_diagnostics_heading(self):
+        output = "## Diagnostics Report\nAll good"
+        _, body = _build_pr_content("diagnose", output)
+        assert "## Diagnostics Report" in body
+        assert "## Maintenance Report" not in body
 
     def test_without_report(self):
         title, body = _build_pr_content("onboard", "")
-        assert title == "chore: onboard repository"
+        assert title == "chore: automated onboard run"
         assert "## Summary" in body
         assert "Automated onboard" in body
 
     def test_fallback_for_no_headings(self):
         title, body = _build_pr_content("maintain", "no headings here")
+        assert title == "chore: automated maintain run"
         assert "## Summary" in body
+
+    def test_report_without_fixed_section_still_uses_report_body(self):
+        output = "## Health Score\n85/100"
+        title, body = _build_pr_content("maintain", output)
+        assert title == "chore: automated maintain run"
+        assert "## Maintenance Report" in body
+        assert "85/100" in body
 
 
 FINDINGS_FIXTURE = (


### PR DESCRIPTION
## Summary

Enhanced PR title generation to be more descriptive by extracting and summarizing actual changes from agent workflow output, rather than using generic titles. Also improved workflow-specific report heading handling.

## Key Changes

- **Extract fixed items from reports**: Added `_extract_fixed_items()` function to parse bullet-point lists from "Issues Fixed", "Changes Made", and similar sections in agent output, filtering out placeholder text
- **Normalize commit subjects**: Added `_normalize_subject()` function to format extracted items as proper commit subjects (lowercase first letter, strip trailing periods, truncate to 72 chars)
- **Intelligent title generation**: Added `_build_pr_title()` function that:
  - Uses the single fixed item as the subject when only one change is made
  - Summarizes multiple changes as "apply N automated {workflow} fixes"
  - Falls back to generic "automated {workflow} run" when no fixed items are found
- **Workflow-specific headings**: Introduced `_WORKFLOW_REPORT_HEADINGS` mapping to use appropriate report headings ("Maintenance Report", "Onboarding Report", "Diagnostics Report") based on workflow type instead of always using "Maintenance Report"
- **Updated PR body generation**: Modified `_build_pr_content()` to use the new title builder and dynamic headings

## Implementation Details

- Fixed items extraction uses configurable markers (`_FIXED_SECTION_MARKERS`) to identify relevant sections
- Placeholder items (text wrapped in angle brackets) are explicitly filtered out
- Subject normalization preserves acronyms (e.g., "CI workflow") while lowercasing regular first letters
- PR title length is constrained to 72 characters with ellipsis truncation for long subjects
- Comprehensive test coverage added for all new functions with edge cases (empty input, no fixed sections, multiple items, etc.)

https://claude.ai/code/session_013mctLiLUSk1NnCK2NdPpKw