### PR TITLE
feat: fallback PR selector for git-pr-feedback skill

### DIFF
--- a/git-plugin/skills/git-pr-feedback/SKILL.md
+++ b/git-plugin/skills/git-pr-feedback/SKILL.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-01-30
-modified: 2026-04-16
+modified: 2026-04-17
 reviewed: 2026-02-26
 allowed-tools: Bash(gh pr checks *), Bash(gh pr view *), Bash(gh pr diff *), Bash(gh run view *), Bash(gh run list *), Bash(gh api *), Bash(gh repo view *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git switch *), Bash(git pull *), Bash(pre-commit *), Bash(npm run *), Bash(uv run *), Bash(bash *), Read, Edit, Write, Grep, Glob, TodoWrite, Task, mcp__github__pull_request_read, mcp__github__add_reply_to_pull_request_comment, mcp__github__resolve_review_thread, mcp__github__pull_request_review_write
 args: "[pr-number] [--commit] [--push]"
@@ -23,7 +23,7 @@ Parse these parameters from the command (all optional):
 
 | Parameter | Description |
 |-----------|-------------|
-| `$1` | PR number (if not provided, detect from current branch) |
+| `$1` | PR number (if omitted, use PR of current branch; if no such PR, list actionable PRs) |
 | `--commit` | Create commit(s) after addressing feedback |
 | `--push` | Push changes after committing (implies --commit) |
 
@@ -45,19 +45,32 @@ For feedback categorization, decision trees, commit format, and report templates
 
 ### Step 1: Determine PR and Gather All Data
 
-1. **Get PR number** from argument or detect from current branch:
-   ```bash
-   gh pr view --json number -q '.number'
-   ```
+1. **Parse owner/repo** from the git remote URL.
 
-2. **Switch to PR branch** if not already on it:
+2. **Resolve the PR number** in this order:
+   1. If `$1` was provided, use it.
+   2. Otherwise, try the PR for the current branch:
+      ```bash
+      gh pr view --json number -q '.number'
+      ```
+   3. If step 2 fails (no PR for the branch) **or** the command is on a detached/default branch, fall back to listing actionable PRs:
+      ```bash
+      bash ${CLAUDE_SKILL_DIR}/scripts/list-actionable-prs.sh <owner> <repo>
+      ```
+      The script emits a JSON array of open, non-draft PRs that have unresolved review threads, failing/errored CI, or `CHANGES_REQUESTED`. Handle the result as follows:
+
+      | Result | Action |
+      |--------|--------|
+      | Empty array | Report "No PRs need attention." and stop. |
+      | One entry | Use that PR number and continue. |
+      | Multiple entries | Print a compact table (number, author, CI, unresolved, reviewDecision, title) ordered as returned, then stop and instruct the user to re-run `/git:pr-feedback <number>`. Do **not** guess which PR they meant. |
+
+3. **Switch to PR branch** if not already on it:
    ```bash
    gh pr view $PR --json headRefName -q '.headRefName'
    git switch <branch-name>
    git pull origin <branch-name>
    ```
-
-3. **Parse owner/repo** from the git remote URL.
 
 4. **Fetch ALL PR data** using the bundled script (single GraphQL query):
    ```bash
@@ -154,6 +167,7 @@ Provide a summary table of feedback addressed, replies posted, threads resolved,
 | Context | Command / Tool |
 |---------|----------------|
 | All PR data (single query) | `bash ${CLAUDE_SKILL_DIR}/scripts/fetch-pr-data.sh <owner> <repo> <pr>` |
+| Actionable PRs (fallback selector) | `bash ${CLAUDE_SKILL_DIR}/scripts/list-actionable-prs.sh <owner> <repo>` |
 | Failed check logs | `gh run view $ID --log-failed` |
 | Quick check status (fallback) | `gh pr checks $PR --json name,state,conclusion` |
 | Reply to a review comment | `mcp__github__add_reply_to_pull_request_comment` (commentId = `databaseId`) |

--- a/git-plugin/skills/git-pr-feedback/scripts/list-actionable-prs.sh
+++ b/git-plugin/skills/git-pr-feedback/scripts/list-actionable-prs.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# List open PRs that have actionable feedback:
+#   - Unresolved (non-outdated) review threads
+#   - Failing or errored CI workflows
+#   - Reviewer requested changes
+#
+# Emits a JSON array sorted by most-recently-updated.
+#
+# Usage: list-actionable-prs.sh <owner> <repo>
+set -euo pipefail
+
+OWNER="${1:?Usage: list-actionable-prs.sh <owner> <repo>}"
+REPO="${2:?Usage: list-actionable-prs.sh <owner> <repo>}"
+
+# shellcheck disable=SC2016
+gh api graphql -f query='
+query($owner: String!, $repo: String!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequests(states: OPEN, first: 50, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      nodes {
+        number
+        title
+        url
+        isDraft
+        author { login }
+        headRefName
+        reviewDecision
+        updatedAt
+        commits(last: 1) {
+          nodes {
+            commit {
+              statusCheckRollup { state }
+            }
+          }
+        }
+        reviewThreads(first: 50) {
+          nodes {
+            isResolved
+            isOutdated
+          }
+        }
+      }
+    }
+  }
+}' -F owner="$OWNER" -F repo="$REPO" | jq '[
+  .data.repository.pullRequests.nodes[]
+  | . as $pr
+  | ($pr.reviewThreads.nodes | map(select(.isResolved == false and .isOutdated == false)) | length) as $unresolved
+  | ($pr.commits.nodes[0].commit.statusCheckRollup.state // "PENDING") as $ci
+  | (($ci == "FAILURE") or ($ci == "ERROR")) as $ciFailing
+  | ($pr.reviewDecision == "CHANGES_REQUESTED") as $changesRequested
+  | select(($ciFailing or ($unresolved > 0) or $changesRequested) and (($pr.isDraft // false) | not))
+  | {
+      number: $pr.number,
+      title: $pr.title,
+      url: $pr.url,
+      author: $pr.author.login,
+      head: $pr.headRefName,
+      ci: $ci,
+      unresolved: $unresolved,
+      reviewDecision: ($pr.reviewDecision // "NONE"),
+      updatedAt: $pr.updatedAt
+    }
+]'


### PR DESCRIPTION
## Summary
Enhanced the `git-pr-feedback` skill to intelligently handle cases where no PR number is provided and the current branch has no associated PR. Instead of failing, the skill now falls back to listing actionable PRs that need attention, allowing users to select one.

## Key Changes
- **New script**: `list-actionable-prs.sh` - Queries GitHub for open, non-draft PRs with actionable feedback (unresolved review threads, failing/errored CI, or requested changes), returning results as a sorted JSON array
- **Updated workflow**: Modified Step 1 of the skill to implement a three-tier PR resolution strategy:
  1. Use PR number from `$1` argument if provided
  2. Detect PR from current branch if available
  3. Fall back to listing actionable PRs if detection fails
- **Smart result handling**: When multiple actionable PRs are found, display a compact table and prompt user to re-run with a specific PR number (no guessing)
- **Documentation**: Updated SKILL.md with new parameter behavior and added reference to the fallback script

## Implementation Details
- The `list-actionable-prs.sh` script uses a single GraphQL query to efficiently fetch PR data, filtering for:
  - Non-resolved, non-outdated review threads
  - Failing or errored CI status
  - `CHANGES_REQUESTED` review decision
- Results are sorted by most-recently-updated (descending) for prioritization
- The script validates required arguments and uses `jq` for JSON filtering and transformation
- Gracefully handles missing CI status (defaults to "PENDING")

https://claude.ai/code/session_01LzEXgx6voiB22uiHiSwQr2