### PR TITLE
fix(hooks-plugin): strip heredoc bodies & modernize branch-protection message

### DIFF
--- a/.claude/rules/handling-blocked-hooks.md
+++ b/.claude/rules/handling-blocked-hooks.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-01-01
-modified: 2026-03-07
-reviewed: 2026-03-07
+modified: 2026-04-17
+reviewed: 2026-04-17
 ---
 
 # Handling Blocked Hooks
@@ -81,7 +81,7 @@ the failed merge."
 
 The `branch-protection.sh` hook in `hooks-plugin` blocks writes on `main`/`master`. When it blocks you, the correct moves — in order — are:
 
-1. **Create a feature branch**: `git checkout -b feature/your-change`, then re-run the command.
+1. **Create a feature branch**: `git switch -c feature/your-change`, then re-run the command.
 2. **Explicit-refspec push** (for `git push` only): `git push origin main:feature/your-change` is allowed by the hook and is the right way to move local `main` commits onto a remote feature branch.
 3. **Delegate to the user** per the template above.
 

--- a/hooks-plugin/hooks/bash-antipatterns.sh
+++ b/hooks-plugin/hooks/bash-antipatterns.sh
@@ -15,6 +15,34 @@ if [ -z "$COMMAND" ]; then
     exit 0
 fi
 
+# Strip heredoc body content up front so detectors that scan the whole command
+# string don't false-positive on literal text inside a heredoc body. The main
+# offender is `gh pr create --body "$(cat <<'EOF' ... EOF)"` whose body may
+# contain example shell commands (e.g. "git add && git commit") that are just
+# documentation, not executable code.
+#
+# The awk program walks the command line-by-line. When it sees `<<DELIM` it
+# enters heredoc mode and suppresses subsequent lines until it sees a line
+# matching DELIM. The heredoc-opening line itself is still printed.
+COMMAND_SHELL_ONLY=$(echo "$COMMAND" | awk '
+    BEGIN { ih = 0 }
+    ih == 0 {
+        if (match($0, /<<-?[[:space:]]*[^[:space:]]*[A-Za-z_][A-Za-z_0-9]*/)) {
+            s = substr($0, RSTART)
+            gsub(/<<-?[[:space:]]*/, "", s)
+            gsub(/^[^A-Za-z_]+/, "", s)
+            gsub(/[^A-Za-z_0-9].*/, "", s)
+            if (s != "") { delim = s; ih = 1 }
+            print; next
+        }
+        print; next
+    }
+    ih == 1 {
+        t = $0; gsub(/^[[:space:]]+/, "", t); gsub(/[[:space:]]+$/, "", t)
+        if (t == delim) { ih = 0 }
+    }
+')
+
 # Function to output a blocking message (exit code 2 = blocking error)
 block() {
     echo "$1" >&2
@@ -52,6 +80,7 @@ fi
 # which would cause false positives when echo "text" is followed by an unrelated 2>/dev/null
 # Strip single-quoted strings first: content inside single quotes is literal bash text
 # (e.g., kubectl exec -- php -r 'echo "$c->id"') and cannot contain shell redirections.
+# shellcheck disable=SC2001  # bash pattern substitution can't do regex char class `[^']*`
 COMMAND_NO_SQUOTES=$(echo "$COMMAND" | sed "s/'[^']*'//g")
 if echo "$COMMAND_NO_SQUOTES" | grep -Eq '(^|\s)(echo|printf)\s+[^;&|]*>\s*[^&]' && \
    ! echo "$COMMAND_NO_SQUOTES" | grep -Eq '(echo|printf).*>>\s*/dev/null'; then
@@ -122,26 +151,8 @@ if echo "$COMMAND" | grep -Eq '(cat|tail|head).*(/tasks/|\.output)' || \
 fi
 
 # Check for excessive pipe chains (5+ pipes suggest over-complexity)
-# Strip heredoc body content first to avoid counting markdown table pipes
-# or other literal content as shell pipe operators
-COMMAND_SHELL_ONLY=$(echo "$COMMAND" | awk '
-    BEGIN { ih = 0 }
-    ih == 0 {
-        if (match($0, /<<-?[[:space:]]*[^[:space:]]*[A-Za-z_][A-Za-z_0-9]*/)) {
-            s = substr($0, RSTART)
-            gsub(/<<-?[[:space:]]*/, "", s)
-            gsub(/^[^A-Za-z_]+/, "", s)
-            gsub(/[^A-Za-z_0-9].*/, "", s)
-            if (s != "") { delim = s; ih = 1 }
-            print; next
-        }
-        print; next
-    }
-    ih == 1 {
-        t = $0; gsub(/^[[:space:]]+/, "", t); gsub(/[[:space:]]+$/, "", t)
-        if (t == delim) { ih = 0 }
-    }
-')
+# Uses COMMAND_SHELL_ONLY (heredoc body already stripped above) to avoid
+# counting markdown table pipes or other literal content as shell pipe operators.
 # Strip quoted strings and || operators before counting actual shell pipes
 # - Single-quoted strings contain regex alternation (grep -E '(a|b|c)')
 # - Double-quoted strings may contain literal pipe characters
@@ -184,9 +195,13 @@ fi
 # index.lock race conditions only occur when one command writes to the git index.
 # Index-modifying commands: add, commit, rm, mv, reset (not read-only commands like status/diff/log).
 # The fix is to run git commands as separate Bash calls, not chained.
+#
+# Uses COMMAND_SHELL_ONLY (heredoc body stripped) so that example shell
+# snippets inside `gh pr create --body "$(cat <<EOF ... EOF)"` do not trigger
+# a false positive when the body mentions `git add && git commit`.
 INDEX_MODIFYING='(add|commit|rm|mv|reset)'
-if echo "$COMMAND" | grep -Eq "git\\s+${INDEX_MODIFYING}\\b.*&&.*git\\s+\\S+" || \
-   echo "$COMMAND" | grep -Eq "git\\s+\\S+.*&&.*git\\s+${INDEX_MODIFYING}\\b"; then
+if echo "$COMMAND_SHELL_ONLY" | grep -Eq "git\\s+${INDEX_MODIFYING}\\b.*&&.*git\\s+\\S+" || \
+   echo "$COMMAND_SHELL_ONLY" | grep -Eq "git\\s+\\S+.*&&.*git\\s+${INDEX_MODIFYING}\\b"; then
     block "REMINDER: Chaining git commands with '&&' can cause index.lock race conditions.
 The lock file from an index-modifying command (add, commit, rm, mv, reset) may not be
 released before the next command tries to acquire it.

--- a/hooks-plugin/hooks/branch-protection.sh
+++ b/hooks-plugin/hooks/branch-protection.sh
@@ -87,7 +87,7 @@ case "$GIT_SUBCMD" in
     if [ "$GIT_SUBCMD" = "stash" ]; then
       if echo "$COMMAND" | grep -Eq 'stash\s+(pop|apply|drop|clear)'; then
         STASH_OP=$(echo "$COMMAND" | grep -oE '(pop|apply|drop|clear)')
-        deny "You're on '${CURRENT_BRANCH}'. Switch to a feature branch before 'git stash ${STASH_OP}' (git checkout -b feature/your-change), or delegate this command to the user per .claude/rules/handling-blocked-hooks.md. If this repo uses main-branch-dev, ask the user to export CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 in their shell."
+        deny "You're on '${CURRENT_BRANCH}'. Switch to a feature branch before 'git stash ${STASH_OP}' (git switch -c feature/your-change), or delegate this command to the user per .claude/rules/handling-blocked-hooks.md. If this repo uses main-branch-dev, ask the user to export CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 in their shell."
       fi
     fi
     exit 0
@@ -102,7 +102,7 @@ case "$GIT_SUBCMD" in
     ;;
   # Common write operations — deny with guidance for Claude
   commit|cherry-pick|revert)
-    deny "You're on '${CURRENT_BRANCH}'. Create a feature branch first: git checkout -b feature/your-change, then re-run 'git ${GIT_SUBCMD}'. If committing directly to ${CURRENT_BRANCH} is genuinely required (e.g. personal repo, dotfiles, main-branch-dev), delegate to the user per .claude/rules/handling-blocked-hooks.md — ask them to run it, or to export CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 in their shell. Do not attempt to self-serve this bypass."
+    deny "You're on '${CURRENT_BRANCH}'. Create a feature branch first: git switch -c feature/your-change, then re-run 'git ${GIT_SUBCMD}'. If committing directly to ${CURRENT_BRANCH} is genuinely required (e.g. personal repo, dotfiles, main-branch-dev), delegate to the user per .claude/rules/handling-blocked-hooks.md — ask them to run it, or to export CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 in their shell. Do not attempt to self-serve this bypass."
     ;;
   push)
     # Allow push to specific remote branch via explicit refspec
@@ -122,7 +122,7 @@ case "$GIT_SUBCMD" in
       exit 0
     fi
     # Staging implies committing — deny with guidance
-    deny "You're staging changes on '${CURRENT_BRANCH}'. Switch to a feature branch first: git checkout -b feature/your-change, then re-run 'git ${GIT_SUBCMD}'. If committing to ${CURRENT_BRANCH} is genuinely required, delegate to the user per .claude/rules/handling-blocked-hooks.md — do not self-serve the CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION bypass."
+    deny "You're staging changes on '${CURRENT_BRANCH}'. Switch to a feature branch first: git switch -c feature/your-change, then re-run 'git ${GIT_SUBCMD}'. If committing to ${CURRENT_BRANCH} is genuinely required, delegate to the user per .claude/rules/handling-blocked-hooks.md — do not self-serve the CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION bypass."
     ;;
 esac
 

--- a/hooks-plugin/hooks/test-bash-antipatterns.sh
+++ b/hooks-plugin/hooks/test-bash-antipatterns.sh
@@ -147,6 +147,52 @@ assert_exit \
     "echo in compound command before git 2>/dev/null is allowed" 0 \
     "cd /some/repo && git log --oneline -10 -- infra/ 2>/dev/null | head -20; echo '---'; git log --oneline 2>/dev/null | head -20"
 
+# ── heredoc body false-positive regression ───────────────────────────────────
+# Regression: `gh pr create --body "$(cat <<EOF ... EOF)"` bodies containing
+# example shell commands (e.g. "git add && git commit" shown as documentation
+# in a PR description) triggered the git-chain index.lock detector. The hook
+# must strip heredoc bodies before scanning for antipatterns.
+#
+# These cases have embedded quotes and newlines, so they use jq to build the
+# JSON payload safely (assert_exit's printf-based JSON cannot escape them).
+echo ""
+echo "heredoc body is ignored when scanning for antipatterns:"
+
+assert_exit_complex() {
+    local desc="$1" expected="$2" cmd="$3"
+    local json
+    json=$(jq -nc --arg cmd "$cmd" '{tool_name:"Bash",tool_input:{command:$cmd}}')
+    local exit_code=0
+    printf '%s' "$json" | bash "$HOOK" >/dev/null 2>&1 || exit_code=$?
+    if [ "$exit_code" -eq "$expected" ]; then
+        printf "  PASS: %s\n" "$desc"
+        PASS=$((PASS + 1))
+    else
+        printf "  FAIL: %s (expected exit %d, got %d)\n" "$desc" "$expected" "$exit_code"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+heredoc_body_cmd=$(cat <<'OUTER'
+gh pr create --title "fix: something" --body "$(cat <<'EOF'
+## Workflow
+
+Run git add && git commit to stage and commit.
+
+Then git push origin HEAD to publish.
+EOF
+)"
+OUTER
+)
+
+assert_exit_complex \
+    "gh pr create with heredoc body mentioning 'git add && git commit' is allowed" 0 \
+    "$heredoc_body_cmd"
+
+assert_exit_complex \
+    "plain git add && git commit (outside heredoc) is still blocked" 2 \
+    "git add file.txt && git commit -m msg"
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

Two small, independent fixes to `hooks-plugin`, both surfaced by the friction-learner agent in [2026-W16 findings](https://github.com/laurigates/claude-plugins/blob/main/feedback-plugin/docs/findings/2026-W16.md) (see PR #1068).

### 1. `bash-antipatterns.sh` — strip heredoc bodies before detection

The git-chain detector was matching documentation text inside PR descriptions written with `gh pr create --body "$(cat <<EOF ... EOF)"`. When the body mentioned chained git commands as user-facing instructions, the hook fired a false-positive reminder on the `gh pr create` call itself.

Fix: the script already strips heredoc bodies for pipe counting (`COMMAND_SHELL_ONLY`). Moved that computation to run up front and reused it for the git-chain detector. Added two regression tests: one for the false-positive case, one guarding the genuine-risk case (plain chained index-modifying git commands outside a heredoc still block).

Also: added `# shellcheck disable=SC2001` on a pre-existing `sed` line that shellcheck flagged once the file was re-linted (bash parameter substitution can't replicate the regex char class `[^']*` here).

### 2. `branch-protection.sh` + `handling-blocked-hooks.md` — prefer `git switch -c`

All block messages that told Claude "create a feature branch first" used the legacy `git checkout -b`. Replaced with `git switch -c` per modern Git (2.23+, 2019). Pure text change, no behavior change.

## Follow-ups (dotfiles)

The other two high-impact findings belong to the user's global rules, not this repo:

- [laurigates/dotfiles#178](https://github.com/laurigates/dotfiles/issues/178) — add rule against plan-mode for non-mutating prompts (~30 events/wk)
- [laurigates/dotfiles#179](https://github.com/laurigates/dotfiles/issues/179) — add rule to use plugin-qualified agent IDs

## Test plan

- [x] `bash hooks-plugin/hooks/test-bash-antipatterns.sh` — 25/25 pass (23 existing + 2 new)
- [x] `bash hooks-plugin/hooks/test-branch-protection.sh` — 12/12 pass
- [x] pre-commit (shellcheck + gitleaks) pass
- [ ] Re-measure in 2026-W17: git-chain and main-branch-stage clusters should shrink

Refs #1068
