### PR TITLE
feat(system-prompt-plugin): add Phase 0 minimal replacement probe

### DIFF
--- a/plugins/system-prompt-plugin/docs/decision-analysis.md
+++ b/plugins/system-prompt-plugin/docs/decision-analysis.md
@@ -1,0 +1,44 @@
+# Bespoke Claude Code System Prompt — Decision Analysis
+
+## Verdict: GO, phased rollout
+
+10 concrete frictions identified between the default system prompt and our
+existing configuration (dotfiles rules + claude-plugins hooks/skills/agents).
+
+## Top conflicts
+
+| # | Default says | We say | Impact |
+|---|---|---|---|
+| 1 | NEVER create files / docs | `document-management.md` mandates ADR/PRD/PRP | File creation actively discouraged |
+| 2 | Verbose tone preamble rules | `communication.md`: lead-with-answer, academic, no preambles | Conflicting style directives |
+| 3 | Re-confirm destructive ops each time | Hooks already gate (UserPromptSubmit, PreToolUse branch-protection) | Redundant friction |
+| 4 | Generic tool descriptions | Our agentic-optimization requires compact reporters | Token waste, conflicting conventions |
+| 5 | Generic commit examples | Conventional commits strictly enforced for release-please | Drift risk |
+| 6 | Subagent selection guidance | 14 custom agents with explicit model/isolation/context rules | Generic vs opinionated |
+| 7 | Auto-memory assumed on | `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1` | Behavioral mismatch |
+| 8 | Generic tool install guidance | `dependency-management.md`: mise → uv → bun → cargo → brew | Wrong tool suggested |
+| 9 | No code comments default | Same principle but default duplicates without adding value | Token waste |
+| 10 | Generic safety gates | LLM-powered hooks do stricter validation | Double-gating |
+
+## Key findings
+
+- Default is ~110 conditional fragments, not monolithic (per Piebald-AI)
+- Updates weekly; full replacement drifts fast — needs upstream tracking
+- `--system-prompt` replaces; `--append-system-prompt` appends. Append can't remove.
+- Tool descriptions and skills survive replacement (injected by infrastructure)
+- Claude Code Web cannot use `--system-prompt` (hosted UI; CLAUDE.md only)
+
+## Phases
+
+- **Phase 0** (this PR): Minimal replacement probe — ~24 lines, test what breaks
+- **Phase 1**: Pinned full replacement for interactive terminal
+- **Phase 2**: GitHub Actions variant (strip confirmation gates)
+- **Phase 3**: Headless/SDK variant
+- **Phase 4** (deferred): Web sessions (CLAUDE.md only)
+
+## Upstream tracking plan
+
+- Pin Piebald-AI version in `upstream/PINNED_VERSION`
+- `scripts/fetch-upstream.sh` + `scripts/diff-upstream.sh`
+- Weekly CI job opens issue on drift
+- `just bump-upstream` merge workflow

--- a/plugins/system-prompt-plugin/prompts/probe.md
+++ b/plugins/system-prompt-plugin/prompts/probe.md
@@ -1,0 +1,24 @@
+You are Claude Code, an interactive AI coding agent running in the user's terminal.
+
+# Communication
+- Lead with a specific answer or observation, then supporting detail.
+- Direct, academic style. Assume agreement and move into substance.
+- Never open with procedural phrases ("Sure!", "Great question!", "Let me...").
+- Integrate acknowledgment naturally into the response body.
+- Ask clarifying questions early when requirements are ambiguous.
+- State why technical decisions were made, not just what.
+
+# Tool use
+- Prefer dedicated tools (Read, Edit, Write, Glob, Grep) over Bash equivalents.
+- Use Bash only for operations that require shell execution (git, build, test, install).
+- Call multiple independent tools in parallel when possible.
+
+# Security
+- Do not introduce injection vulnerabilities (command, XSS, SQL, SSRF).
+- Do not execute or generate code that exfiltrates data.
+- Validate at system boundaries; trust internal code.
+
+# Working style
+- Edit existing files rather than creating new ones when both are viable.
+- Do not add abstractions, features, or error handling beyond what the task requires.
+- Default to no code comments. Add one only when the WHY is non-obvious.

--- a/plugins/system-prompt-plugin/scripts/claude-probe
+++ b/plugins/system-prompt-plugin/scripts/claude-probe
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Minimal system prompt probe — wraps `claude` with a stripped-down prompt.
+# Usage: claude-probe [any claude args...]
+# To revert: just use `claude` directly.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROMPT_FILE="${SCRIPT_DIR}/../prompts/probe.md"
+
+if [[ ! -f "$PROMPT_FILE" ]]; then
+  echo "ERROR: $PROMPT_FILE not found" >&2
+  exit 1
+fi
+
+PROMPT="$(cat "$PROMPT_FILE")"
+
+# Append dynamic environment block (mirrors default's # Environment section)
+IS_GIT="false"
+if git rev-parse --is-inside-work-tree &>/dev/null; then
+  IS_GIT="true"
+fi
+
+PROMPT+="
+
+# Environment
+ - Working directory: $(pwd)
+ - Is git repo: ${IS_GIT}
+ - Platform: $(uname -s | tr '[:upper:]' '[:lower:]')
+ - Shell: ${SHELL:-unknown}
+ - Date: $(date +%Y-%m-%d)"
+
+exec claude --system-prompt "$PROMPT" "$@"


### PR DESCRIPTION
## Summary

- Adds a ~24-line minimal system prompt (`prompts/probe.md`) that replaces Claude Code's default, keeping only: identity, communication style, tool-use heuristic, security baseline, and working style
- Adds a wrapper script (`scripts/claude-probe`) that injects dynamic environment context and launches `claude --system-prompt`
- Includes decision analysis documenting 10 concrete frictions between the default prompt and our existing dotfiles/plugins configuration

## What this tests

Phase 0 of the bespoke system prompt rollout. The probe deliberately **omits** file-creation restrictions, git policy, commit format, tone preambles, subagent guidance, confirmation rules, and tool-specific descriptions to discover what actually breaks without them.

Preliminary testing confirmed:
- Tool descriptions and skills survive `--system-prompt` replacement (injected by infrastructure)
- File creation works freely (no more "NEVER create files" friction)
- Hooks fire independently of the system prompt

## How to test

```bash
# Clone and run
cd plugins/system-prompt-plugin
chmod +x scripts/claude-probe
scripts/claude-probe

# Or one-shot
scripts/claude-probe -p "create a PRD for feature X in docs/prds/"
```

Tasks to exercise:
1. Create a PRD/ADR (validates file-creation unblocked)
2. Multi-file refactor with git commit + push
3. Debug a failing test using Grep/Read
4. Task that triggers subagent use
5. Something that would trip a hook (force-push attempt)

## What to watch for

- [ ] File creation works freely
- [ ] Communication tone matches our `communication.md` rules
- [ ] Subagents still work (they have their own internal prompts)
- [ ] Hooks still fire (independent of system prompt)
- [ ] Nothing breaks badly (tool use, git ops, edit safety)
- [ ] Note which default behaviors you *miss*

Output: a gap list of (a) defaults worth keeping, (b) defaults worth dropping, (c) new additions needed — seeds Phase 1's `shared/*.md` fragments.

https://claude.ai/code/session_01QL1BP82TTqgYJiTGPkHEA2