### PR TITLE
fix(blueprint-plugin): canonicalize manifest.json filename across blueprint docs

### DIFF
--- a/blueprint-plugin/skills/blueprint-init/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-init/SKILL.md
@@ -186,7 +186,7 @@ Initialize Blueprint Development in this project.
    └── skills/                      # Custom skill overrides (optional)
    ```
 
-7. **Create `manifest.json`** (v3.3.0 schema):
+7. **Create `manifest.json`** (v3.3.0 schema — canonical filename is `docs/blueprint/manifest.json`, no dot prefix):
    ```json
    {
      "format_version": "3.3.0",

--- a/blueprint-plugin/skills/blueprint-migration/migrations/v3.0-to-v3.1.md
+++ b/blueprint-plugin/skills/blueprint-migration/migrations/v3.0-to-v3.1.md
@@ -15,19 +15,35 @@ Key changes:
 - Generated commands/skills from `/blueprint:generate-commands` → removed (deprecated)
 - `docs/blueprint/README.md` → updated to remove `work-overview.md` entry
 
+## Manifest Path
+
+All `jq` commands in this document use `$MANIFEST` to refer to the resolved manifest path.
+When running via `/blueprint:upgrade`, `$MANIFEST` is set in Step 2 of that skill.
+When running standalone, resolve it first:
+
+```bash
+if [[ -f "$MANIFEST" ]]; then
+  MANIFEST="$MANIFEST"
+elif [[ -f docs/blueprint/manifest.json ]]; then
+  MANIFEST=docs/blueprint/manifest.json
+else
+  echo "ERROR: no manifest found. Run /blueprint:init first."; exit 1
+fi
+```
+
 ## Pre-Migration Checks
 
 Before starting, verify:
 
 ```bash
-# 1. Manifest exists at v3.0 location
-test -f docs/blueprint/.manifest.json
+# 1. Manifest exists
+test -f "$MANIFEST"
 
 # 2. Read current version
-jq -r '.format_version // "1.0.0"' docs/blueprint/.manifest.json
+jq -r '.format_version // "1.0.0"' "$MANIFEST"
 
 # 3. Verify version is 3.0.x
-version=$(jq -r '.format_version // "1.0.0"' docs/blueprint/.manifest.json)
+version=$(jq -r '.format_version // "1.0.0"' "$MANIFEST")
 if [[ ! "$version" =~ ^3\.0 ]]; then
   echo "ERROR: Expected v3.0.x, found $version"
   exit 1
@@ -103,7 +119,7 @@ for path in \
 done
 
 # Check manifest for generated entries
-jq -r '.generated.commands // {} | keys[]' docs/blueprint/.manifest.json 2>/dev/null
+jq -r '.generated.commands // {} | keys[]' "$MANIFEST" 2>/dev/null
 ```
 
 **If deprecated entries found**, ask user:
@@ -132,8 +148,8 @@ rmdir .claude/commands/project 2>/dev/null
 rmdir .claude/commands 2>/dev/null
 
 # Remove entries from manifest
-jq 'del(.generated.commands)' docs/blueprint/.manifest.json > docs/blueprint/.manifest.json.tmp && \
-mv docs/blueprint/.manifest.json.tmp docs/blueprint/.manifest.json
+jq 'del(.generated.commands)' "$MANIFEST" > "$MANIFEST".tmp && \
+mv "$MANIFEST".tmp "$MANIFEST"
 ```
 
 ### Step 4: Update Blueprint README
@@ -170,8 +186,8 @@ jq '
       "Updated blueprint README"
     ]
   }]
-' docs/blueprint/.manifest.json > docs/blueprint/.manifest.json.tmp && \
-mv docs/blueprint/.manifest.json.tmp docs/blueprint/.manifest.json
+' "$MANIFEST" > "$MANIFEST".tmp && \
+mv "$MANIFEST".tmp "$MANIFEST"
 ```
 
 ## Post-Migration Verification
@@ -180,7 +196,7 @@ After migration, verify:
 
 ```bash
 # 1. Manifest exists with correct version
-jq -r '.format_version' docs/blueprint/.manifest.json
+jq -r '.format_version' "$MANIFEST"
 # Expected: 3.1.0
 
 # 2. work-overview.md removed
@@ -199,7 +215,7 @@ fi
 ! test -f .claude/commands/project-test-loop.md && echo "project-test-loop command removed: OK"
 
 # 5. Upgrade history recorded
-jq '.upgrade_history[-1]' docs/blueprint/.manifest.json
+jq '.upgrade_history[-1]' "$MANIFEST"
 ```
 
 ## Migration Summary Template
@@ -238,8 +254,8 @@ If migration fails or needs to be reverted:
 3. **Manual rollback**:
    ```bash
    # Restore manifest version
-   jq '.format_version = "3.0.0"' docs/blueprint/.manifest.json > docs/blueprint/.manifest.json.tmp && \
-   mv docs/blueprint/.manifest.json.tmp docs/blueprint/.manifest.json
+   jq '.format_version = "3.0.0"' "$MANIFEST" > "$MANIFEST".tmp && \
+   mv "$MANIFEST".tmp "$MANIFEST"
 
    # work-overview.md would need to be recreated manually if needed
    # Generated commands would need to be regenerated via /blueprint:generate-commands

--- a/blueprint-plugin/skills/blueprint-migration/migrations/v3.0-to-v3.1.md
+++ b/blueprint-plugin/skills/blueprint-migration/migrations/v3.0-to-v3.1.md
@@ -22,12 +22,14 @@ When running via `/blueprint:upgrade`, `$MANIFEST` is set in Step 2 of that skil
 When running standalone, resolve it first:
 
 ```bash
-if [[ -f "$MANIFEST" ]]; then
-  MANIFEST="$MANIFEST"
-elif [[ -f docs/blueprint/manifest.json ]]; then
-  MANIFEST=docs/blueprint/manifest.json
-else
-  echo "ERROR: no manifest found. Run /blueprint:init first."; exit 1
+if [[ -z "${MANIFEST:-}" ]]; then
+  if [[ -f docs/blueprint/manifest.json ]]; then
+    MANIFEST=docs/blueprint/manifest.json
+  elif [[ -f docs/blueprint/.manifest.json ]]; then
+    MANIFEST=docs/blueprint/.manifest.json
+  else
+    echo "ERROR: no manifest found. Run /blueprint:init first."; exit 1
+  fi
 fi
 ```
 

--- a/blueprint-plugin/skills/blueprint-migration/migrations/v3.2-to-v3.3.md
+++ b/blueprint-plugin/skills/blueprint-migration/migrations/v3.2-to-v3.3.md
@@ -24,14 +24,30 @@ Key additions:
 IDs remain scoped per workspace. Cross-workspace references use
 `<workspace-path>/ADR-NNN`, and a leading `/` means "the monorepo root".
 
+## Manifest Path
+
+All `jq` commands in this document use `$MANIFEST` to refer to the resolved manifest path.
+When running via `/blueprint:upgrade`, `$MANIFEST` is set in Step 2 of that skill.
+When running standalone, resolve it first:
+
+```bash
+if [[ -f docs/blueprint/.manifest.json ]]; then
+  MANIFEST=docs/blueprint/.manifest.json
+elif [[ -f "$MANIFEST" ]]; then
+  MANIFEST="$MANIFEST"
+else
+  echo "ERROR: no manifest found. Run /blueprint:init first."; exit 1
+fi
+```
+
 ## Pre-Migration Checks
 
 ```bash
 # 1. Manifest exists
-test -f docs/blueprint/manifest.json
+test -f "$MANIFEST"
 
 # 2. Version is 3.2.x
-version=$(jq -r '.format_version // "1.0.0"' docs/blueprint/manifest.json)
+version=$(jq -r '.format_version // "1.0.0"' "$MANIFEST")
 if [[ ! "$version" =~ ^3\.2 ]]; then
   echo "ERROR: Expected v3.2.x, found $version"
   exit 1
@@ -54,7 +70,7 @@ Determine the role this manifest will play:
 ancestor_root=""
 dir=$(cd .. && pwd)
 while [[ "$dir" != "/" && "$dir" != "$HOME" ]]; do
-  if [[ -f "$dir/docs/blueprint/manifest.json" ]]; then
+  if [[ -f "$dir/"$MANIFEST"" ]]; then
     ancestor_root="$dir"
     break
   fi
@@ -64,8 +80,8 @@ done
 # Look for descendant blueprints (indicates this is a root).
 descendant_count=$(find . -maxdepth 6 \
   -type d \( -name node_modules -o -name .git -o -name dist -o -name build \) -prune \
-  -o -type f -path '*/docs/blueprint/manifest.json' -print 2>/dev/null \
-  | grep -v '^./docs/blueprint/manifest.json$' \
+  -o -type f -path '*/"$MANIFEST"' -print 2>/dev/null \
+  | grep -v '^./"$MANIFEST"$' \
   | wc -l)
 ```
 
@@ -85,8 +101,8 @@ jq --arg rel "$root_rel" '
     "role": "child",
     "root_relative_path": $rel
   }
-' docs/blueprint/manifest.json > docs/blueprint/manifest.json.tmp && \
-mv docs/blueprint/manifest.json.tmp docs/blueprint/manifest.json
+' "$MANIFEST" > "$MANIFEST".tmp && \
+mv "$MANIFEST".tmp "$MANIFEST"
 ```
 
 **Root manifest**:
@@ -99,8 +115,8 @@ jq '
     "last_scanned_at": null,
     "children": []
   }
-' docs/blueprint/manifest.json > docs/blueprint/manifest.json.tmp && \
-mv docs/blueprint/manifest.json.tmp docs/blueprint/manifest.json
+' "$MANIFEST" > "$MANIFEST".tmp && \
+mv "$MANIFEST".tmp "$MANIFEST"
 ```
 
 ### Step 3: Bump `format_version` and record upgrade history
@@ -119,8 +135,8 @@ jq '
       "Optional: implemented_by portfolio links in feature-tracker.json"
     ]
   }])
-' docs/blueprint/manifest.json > docs/blueprint/manifest.json.tmp && \
-mv docs/blueprint/manifest.json.tmp docs/blueprint/manifest.json
+' "$MANIFEST" > "$MANIFEST".tmp && \
+mv "$MANIFEST".tmp "$MANIFEST"
 ```
 
 ### Step 4: Populate `workspaces.children` (root only)
@@ -154,23 +170,23 @@ about and runs `/blueprint:feature-tracker-sync` at the root to derive statuses.
 
 ```bash
 # 1. format_version is 3.3.0
-jq -r '.format_version' docs/blueprint/manifest.json
+jq -r '.format_version' "$MANIFEST"
 # Expected: 3.3.0
 
 # 2. workspaces.role is set (root/child) or absent (standalone) as expected
-jq -r '.workspaces.role // "(standalone)"' docs/blueprint/manifest.json
+jq -r '.workspaces.role // "(standalone)"' "$MANIFEST"
 
 # 3. Root: children populated
-jq '.workspaces.children | length' docs/blueprint/manifest.json
+jq '.workspaces.children | length' "$MANIFEST"
 
 # 4. Child: root_relative_path resolves
-rel=$(jq -r '.workspaces.root_relative_path // empty' docs/blueprint/manifest.json)
+rel=$(jq -r '.workspaces.root_relative_path // empty' "$MANIFEST")
 if [[ -n "$rel" ]]; then
-  test -f "$rel/docs/blueprint/manifest.json" && echo "root link resolves: OK"
+  test -f "$rel/"$MANIFEST"" && echo "root link resolves: OK"
 fi
 
 # 5. Upgrade history recorded
-jq '.upgrade_history[-1]' docs/blueprint/manifest.json
+jq '.upgrade_history[-1]' "$MANIFEST"
 ```
 
 ## Migration Summary Template
@@ -199,9 +215,9 @@ Next steps:
 Because v3.3 is purely additive, rollback is straightforward:
 
 ```bash
-jq 'del(.workspaces) | .format_version = "3.2.0"' docs/blueprint/manifest.json \
-  > docs/blueprint/manifest.json.tmp && \
-mv docs/blueprint/manifest.json.tmp docs/blueprint/manifest.json
+jq 'del(.workspaces) | .format_version = "3.2.0"' "$MANIFEST" \
+  > "$MANIFEST".tmp && \
+mv "$MANIFEST".tmp "$MANIFEST"
 
 # Optionally remove the top-level workspaces summary from feature-tracker.json:
 if [[ -f docs/blueprint/feature-tracker.json ]]; then

--- a/blueprint-plugin/skills/blueprint-migration/migrations/v3.2-to-v3.3.md
+++ b/blueprint-plugin/skills/blueprint-migration/migrations/v3.2-to-v3.3.md
@@ -31,12 +31,14 @@ When running via `/blueprint:upgrade`, `$MANIFEST` is set in Step 2 of that skil
 When running standalone, resolve it first:
 
 ```bash
-if [[ -f docs/blueprint/.manifest.json ]]; then
-  MANIFEST=docs/blueprint/.manifest.json
-elif [[ -f "$MANIFEST" ]]; then
-  MANIFEST="$MANIFEST"
-else
-  echo "ERROR: no manifest found. Run /blueprint:init first."; exit 1
+if [[ -z "${MANIFEST:-}" ]]; then
+  if [[ -f docs/blueprint/manifest.json ]]; then
+    MANIFEST=docs/blueprint/manifest.json
+  elif [[ -f docs/blueprint/.manifest.json ]]; then
+    MANIFEST=docs/blueprint/.manifest.json
+  else
+    echo "ERROR: no manifest found. Run /blueprint:init first."; exit 1
+  fi
 fi
 ```
 

--- a/blueprint-plugin/skills/blueprint-migration/skill.md
+++ b/blueprint-plugin/skills/blueprint-migration/skill.md
@@ -4,8 +4,8 @@ description: Versioned migration procedures for upgrading blueprint structure be
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion, TodoWrite
 created: 2025-12-22
-modified: 2026-04-16
-reviewed: 2026-04-16
+modified: 2026-04-18
+reviewed: 2026-04-18
 ---
 
 # Blueprint Migration
@@ -14,11 +14,16 @@ Expert skill for migrating blueprint structures between format versions. This sk
 
 ## Core Expertise
 
-- Reading and parsing `.claude/blueprints/.manifest.json` for current version
+- Reading and parsing the blueprint manifest (`docs/blueprint/manifest.json` in v3.0+, or legacy `.claude/blueprints/.manifest.json` in v1.x/v2.x) for current version
 - Determining appropriate migration path based on version comparison
 - Executing versioned migration steps with user confirmation
 - Content hashing for detecting manual modifications
 - Safe file moves with rollback capability
+
+## Canonical Manifest Filename
+
+- **v3.0+**: `docs/blueprint/manifest.json` (canonical, no dot prefix — produced by `/blueprint:init`). Some repos carry a legacy `docs/blueprint/.manifest.json` from earlier v3.0 migrations; upgrade tooling tolerates both via the `$MANIFEST` variable resolved in `/blueprint:upgrade` Step 2.
+- **v1.x/v2.x (historical)**: `.claude/blueprints/.manifest.json` — references to this path in v1/v2 migration documents are historical and must not be renamed.
 
 ## Migration Workflow
 
@@ -46,15 +51,20 @@ Expert skill for migrating blueprint structures between format versions. This sk
 ## Version Detection
 
 ```bash
-# Read manifest version - check both v3.0 and legacy locations
-if [[ -f docs/blueprint/.manifest.json ]]; then
-  cat docs/blueprint/.manifest.json | jq -r '.format_version'
+# Resolve manifest path — canonical first, then tolerated variants
+if [[ -f docs/blueprint/manifest.json ]]; then
+  MANIFEST=docs/blueprint/manifest.json
+elif [[ -f docs/blueprint/.manifest.json ]]; then
+  MANIFEST=docs/blueprint/.manifest.json
 elif [[ -f .claude/blueprints/.manifest.json ]]; then
-  cat .claude/blueprints/.manifest.json | jq -r '.format_version'
+  MANIFEST=.claude/blueprints/.manifest.json
 fi
 
-# Detect v1.0 (no format_version field)
-if ! jq -e '.format_version' .claude/blueprints/.manifest.json > /dev/null 2>&1; then
+jq -r '.format_version // "1.0.0"' "$MANIFEST"
+
+# Detect v1.0 (no format_version field — legacy v1.x/v2.x location only)
+if [[ -f .claude/blueprints/.manifest.json ]] && \
+   ! jq -e '.format_version' .claude/blueprints/.manifest.json > /dev/null 2>&1; then
   echo "v1.0.0"
 fi
 ```
@@ -67,8 +77,8 @@ For detecting modifications to generated content:
 # Generate SHA256 hash of file content
 sha256sum path/to/file | cut -d' ' -f1
 
-# Compare with stored hash in manifest
-jq -r '.generated.skills["skill-name"].content_hash' .claude/blueprints/.manifest.json
+# Compare with stored hash in manifest (use $MANIFEST from Version Detection above)
+jq -r '.generated.skills["skill-name"].content_hash' "$MANIFEST"
 ```
 
 ## Migration Execution Pattern
@@ -94,7 +104,7 @@ If migration fails:
 
 | Operation | Command |
 |-----------|---------|
-| Check version | `jq -r '.format_version' .claude/blueprints/.manifest.json` |
+| Check version | `jq -r '.format_version' "$MANIFEST"` (resolve `$MANIFEST` first; see Version Detection) |
 | Hash file | `sha256sum file \| cut -d' ' -f1` |
 | Safe move | `cp -r source target && rm -rf source` |
 | Check empty dir | `[ -z "$(ls -A dir)" ]` |

--- a/blueprint-plugin/skills/blueprint-upgrade/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-upgrade/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-17
-modified: 2026-04-17
-reviewed: 2026-04-17
+modified: 2026-04-18
+reviewed: 2026-04-18
 description: "Upgrade blueprint structure to the latest format version"
 args: "[--non-interactive|-y]"
 argument-hint: "[--non-interactive|-y]"
@@ -43,20 +43,31 @@ If a migration step would require any prompt not listed above, **abort the upgra
 **Steps**:
 
 1. **Check current state**:
-   - Read `docs/blueprint/.manifest.json` (v3.0 location) or `.claude/blueprints/.manifest.json` (v1.x/v2.x location)
-   - If not found in either location, suggest running `/blueprint:init` instead
+   - Resolve manifest path — check all known locations (in order):
+     1. `docs/blueprint/.manifest.json` (v3.0+ dot-prefixed)
+     2. `docs/blueprint/manifest.json` (v3.1+ without dot prefix)
+     3. `.claude/blueprints/.manifest.json` (v1.x/v2.x location)
+   - Store the resolved path as `$MANIFEST`; if not found in any location, suggest running `/blueprint:init` instead
    - Extract current `format_version` (default to "1.0.0" if field missing)
 
 2. **Determine upgrade path**:
    ```bash
-   # Read current version - check both old and new locations
+   # Resolve manifest path once — use $MANIFEST in all subsequent jq commands
    if [[ -f docs/blueprint/.manifest.json ]]; then
-     current=$(jq -r '.format_version // "3.0.0"' docs/blueprint/.manifest.json)
+     MANIFEST=docs/blueprint/.manifest.json
+   elif [[ -f docs/blueprint/manifest.json ]]; then
+     MANIFEST=docs/blueprint/manifest.json
    elif [[ -f .claude/blueprints/.manifest.json ]]; then
-     current=$(jq -r '.format_version // "1.0.0"' .claude/blueprints/.manifest.json)
+     MANIFEST=.claude/blueprints/.manifest.json
+   else
+     echo "ERROR: no blueprint manifest found. Run /blueprint:init first."
+     exit 1
    fi
+   current=$(jq -r '.format_version // "1.0.0"' "$MANIFEST")
    target="3.3.0"
    ```
+
+   **Important**: Store the resolved `$MANIFEST` path. Use it in every `jq` invocation throughout this skill and in all delegated migration steps. This avoids silent failures when the filename differs from what a command hard-codes.
 
    **Version compatibility matrix**:
    | From Version | To Version | Migration Document |
@@ -82,7 +93,7 @@ If a migration step would require any prompt not listed above, **abort the upgra
    ls .claude/commands/project/continue.md 2>/dev/null
 
    # Check manifest for generated entries
-   jq -r '.generated.commands // {} | keys[]' docs/blueprint/.manifest.json 2>/dev/null
+   jq -r '.generated.commands // {} | keys[]' "$MANIFEST" 2>/dev/null
    ```
 
    **If deprecated entries found**:
@@ -112,7 +123,7 @@ If a migration step would require any prompt not listed above, **abort the upgra
 
    a. **Check if task_registry already exists**:
       ```bash
-      jq -e '.task_registry' docs/blueprint/manifest.json 2>/dev/null
+      jq -e '.task_registry' "$MANIFEST" 2>/dev/null
       ```
 
       If exists, skip to next step.
@@ -134,7 +145,7 @@ If a migration step would require any prompt not listed above, **abort the upgra
       ```
 
    c. **Add task_registry to manifest**:
-      Use `jq` to add the `task_registry` section to manifest.json with all tasks defaulting to:
+      Use `jq` to add the `task_registry` section to `"$MANIFEST"` with all tasks defaulting to:
       - `enabled: true` (except `curate-docs` which defaults to `false`)
       - `auto_run`: based on user choice (safe read-only tasks: `adr-validate`, `feature-tracker-sync`, `sync-ids`)
       - `last_completed_at: null`
@@ -151,8 +162,8 @@ If a migration step would require any prompt not listed above, **abort the upgra
 
    Delegate to `skills/blueprint-migration/migrations/v3.2-to-v3.3.md`. Summary of what it does:
 
-   a. Classify the blueprint as `root`, `child`, or `standalone` by walking ancestors and descendants for other `docs/blueprint/manifest.json` files.
-   b. Add a `workspaces` block to `docs/blueprint/manifest.json` (omitted for standalone).
+   a. Classify the blueprint as `root`, `child`, or `standalone` by walking ancestors and descendants for other blueprint manifest files.
+   b. Add a `workspaces` block to `$MANIFEST` (omitted for standalone).
    c. Bump `format_version` to `3.3.0` and append an entry to `upgrade_history`.
    d. For root blueprints, run `/blueprint:workspace-scan` to populate `workspaces.children`.
    e. (Optional) Initialise the root `feature-tracker.json` `workspaces` summary for portfolio FR tracking.
@@ -486,6 +497,19 @@ If a migration step would require any prompt not listed above, **abort the upgra
    - "Regenerate rules" → Run `/blueprint:generate-rules`
    - "Update CLAUDE.md" → Run `/blueprint:claude-md`
    - "Commit changes" → Run `/git:commit` with migration message
+
+**Post-migration assertion**:
+After any version bump, verify `format_version` actually changed to the target. This catches silent failures where `jq` operated on the wrong path and exited 0 with empty output:
+
+```bash
+actual=$(jq -r '.format_version' "$MANIFEST")
+if [[ "$actual" != "$target" ]]; then
+  echo "ERROR: Migration failed — format_version is '$actual', expected '$target'"
+  echo "Check that $MANIFEST was written correctly and rerun the migration step."
+  exit 1
+fi
+echo "Migration verified: format_version = $actual in $MANIFEST"
+```
 
 **Rollback**:
 If upgrade fails:


### PR DESCRIPTION
## Summary

Fixes two related user-reported issues about the blueprint manifest filename confusion between `docs/blueprint/manifest.json` (no dot) and `docs/blueprint/.manifest.json` (dot-prefixed):

- **#1055 (bug)** — skill docs disagreed on the canonical filename, causing v3.2 → v3.3 `jq` commands to silently no-op against `.manifest.json` repos.
- **#1056 (enhancement)** — `blueprint-upgrade` now resolves the manifest path once into `$MANIFEST` and substitutes it into all downstream migration commands.

## Changes

**Commit 1** (cherry-picked from a prior unlanded branch, `feat(blueprint-plugin): auto-detect manifest path in blueprint-upgrade`):

- `blueprint-upgrade/SKILL.md`: Step 2 resolves `$MANIFEST` across the three known locations (`docs/blueprint/.manifest.json`, `docs/blueprint/manifest.json`, `.claude/blueprints/.manifest.json`); every downstream `jq` call uses `"$MANIFEST"`.
- `migrations/v3.0-to-v3.1.md`, `migrations/v3.2-to-v3.3.md`: replaced hardcoded paths with `"$MANIFEST"`; added a standalone-invocation resolution preamble.
- Post-migration assertion that `format_version` actually changed to target (catches silent jq failures).

**Commit 2** (this branch, `fix(blueprint-plugin): canonicalize manifest.json filename across migration docs`):

- Declared `docs/blueprint/manifest.json` canonical (no dot — matches what `/blueprint:init` currently produces and what ~30 downstream skills reference).
- Fixed a bug in the prior commit's standalone `$MANIFEST` resolution blocks — `if [[ -f "$MANIFEST" ]]` against an unset variable was wrong; replaced with `-z "${MANIFEST:-}"` guard that checks canonical first.
- Updated `blueprint-migration/skill.md` core docs and Version Detection snippet to use `$MANIFEST` and document the canonical/historical split.
- Added a comment in `blueprint-init/SKILL.md` Step 7 clarifying `manifest.json` (no dot) is canonical.

Historical references in v1.0-to-v1.1, v1.x-to-v2.0, and v2.x-to-v3.0 migration docs keep their `.claude/blueprints/.manifest.json` paths because those were the real filenames at those versions.

Closes #1055
Closes #1056

## Test plan

- [ ] `/blueprint:upgrade` against a repo with `docs/blueprint/manifest.json` resolves to that path
- [ ] `/blueprint:upgrade` against a repo with legacy `docs/blueprint/.manifest.json` resolves to that path
- [ ] `/blueprint:upgrade` against a repo with legacy `.claude/blueprints/.manifest.json` resolves to that path
- [ ] v3.2 → v3.3 migration run standalone (outside `/blueprint:upgrade`) resolves `$MANIFEST` correctly
- [ ] Post-migration assertion fires when `format_version` fails to advance
- [ ] No residual hardcoded `docs/blueprint/.manifest.json` or `docs/blueprint/manifest.json` in files touched by this PR (current-state references only; historical refs preserved)

https://claude.ai/code/session_01YPLPgbxvX1PKyoVHgTurdd