### PR TITLE
feat: make skills discoverable by Claude's auto-invocation

### DIFF
--- a/.claude/rules/regression-testing.md
+++ b/.claude/rules/regression-testing.md
@@ -21,6 +21,7 @@ This ensures the CI catches the same class of problem in any future skill, not j
 | Context command antipattern (API calls, shell operators) | `scripts/lint-context-commands.sh` |
 | Skill body structure corruption (spurious headings, leaked frontmatter) | `scripts/plugin-compliance-check.sh` → `check_skill_body()` |
 | Frontmatter field missing or malformed | `scripts/plugin-compliance-check.sh` → `check_skill_frontmatter()` |
+| Description fails auto-invocation matching (missing/empty, or no "Use when..." trigger) | `scripts/plugin-compliance-check.sh` → `check_skill_descriptions()` (delegates to `scripts/audit-skill-descriptions.py`) |
 | Skill size exceeding limit | `scripts/plugin-compliance-check.sh` → `check_skill_size()` |
 | Blueprint upgrade target drift (migrations added without updating `blueprint-upgrade`) | `scripts/check-blueprint-upgrade-target.sh` |
 
@@ -38,6 +39,7 @@ This ensures the CI catches the same class of problem in any future skill, not j
 | `Bash(test *), Bash(jq *)` etc. causes ~20 approval prompts | Shell utility patterns in `allowed-tools` force inline bash that can't be allowlisted; each compound command needs individual approval | `plugin-compliance-check.sh` `check_bash_patterns()` | PR #TBD |
 | `blueprint-{generate,derive}-rules` writes hardcoded `.claude/rules/` and clobbers hand-authored rules | SKILL.md hardcoded the output directory; no `structure.generated_rules_path` field | `plugin-compliance-check.sh` `check_skill_body()` (blueprint rules-path check) | issue #1043 |
 | `/blueprint:upgrade` reports v3.2.0 as latest after v3.3 migration was added | `blueprint-upgrade/SKILL.md` hardcodes target version; PR #1026 added `migrations/v3.2-to-v3.3.md` without updating the upgrade skill | `check-blueprint-upgrade-target.sh` compares highest migration target to `blueprint-upgrade/SKILL.md` | PR #TBD |
+| Skills with capability-list descriptions ("Check and configure X") never auto-invoke | Claude matches `description` against user intent; without "Use when..." and trigger phrases the matcher never fires. 133/325 skills were affected at baseline. | `plugin-compliance-check.sh` `check_skill_descriptions()` (warns on NO_TRIGGER for auto-invokable skills; errors on MISSING/EMPTY); `audit-skill-descriptions.py --strict` in pre-commit | PR #TBD |
 
 ## How to Add a Regression Check
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,9 @@ repos:
         language: system
         files: '(SKILL|skill)\.md$'
         pass_filenames: false
+      - id: audit-skill-descriptions
+        name: audit skill descriptions for auto-invocation
+        entry: python3 ./scripts/audit-skill-descriptions.py --strict
+        language: system
+        files: '(SKILL|skill)\.md$'
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         pass_filenames: false
       - id: audit-skill-descriptions
         name: audit skill descriptions for auto-invocation
-        entry: python3 ./scripts/audit-skill-descriptions.py --strict
+        entry: python3 ./scripts/audit-skill-descriptions.py --strict-all
         language: system
         files: '(SKILL|skill)\.md$'
         pass_filenames: false

--- a/agent-patterns-plugin/skills/meta-assimilate/SKILL.md
+++ b/agent-patterns-plugin/skills/meta-assimilate/SKILL.md
@@ -1,11 +1,16 @@
 ---
 created: 2025-12-16
-modified: 2025-12-16
+modified: 2026-04-19
 reviewed: 2025-12-16
 allowed-tools: Read, Write, Edit, MultiEdit, Glob, Grep, TodoWrite
 args: <project-path>
 argument-hint: <project-path>
-description: Analyze and assimilate project-specific Claude configurations
+description: |
+  Analyze and assimilate project-specific Claude configurations into user-scoped agents and
+  commands. Use when you want to examine a project's .claude/{agents,commands} directory and
+  either copy, generalize, or merge useful agents and commands into your personal configuration,
+  when the user mentions assimilating or adopting another project's Claude setup, or when
+  looking to generalize a project-specific agent into a reusable one.
 name: meta-assimilate
 ---
 

--- a/agent-patterns-plugin/skills/meta-audit/SKILL.md
+++ b/agent-patterns-plugin/skills/meta-audit/SKILL.md
@@ -1,9 +1,14 @@
 ---
 created: 2025-12-16
-modified: 2026-04-16
+modified: 2026-04-19
 reviewed: 2026-04-16
 allowed-tools: Glob, Read, TodoWrite
-description: Audit Claude subagent configurations for completeness, security, and best practices
+description: |
+  Audit Claude subagent configurations for completeness, security, and best practices. Use when
+  the user wants to review .claude/agents/ for missing frontmatter fields, overprivileged tool
+  access, read-only agents with write permissions, inappropriate model choices, or inconsistent
+  naming; when checking agent configurations before committing; or when asked to validate
+  subagent security and privilege assignments.
 args: "[--verbose]"
 argument-hint: "[--verbose]"
 name: meta-audit

--- a/agents-plugin/skills/agents-analyze/SKILL.md
+++ b/agents-plugin/skills/agents-analyze/SKILL.md
@@ -1,10 +1,16 @@
 ---
-description: Analyze all plugins for sub-agent opportunities. Identifies skills with verbose output, gaps in agent coverage, and model selection improvements.
+description: |
+  Analyze all plugins for sub-agent opportunities by identifying skills with verbose output,
+  gaps in agent coverage, tool over-permissions, and model selection improvements. Use when
+  the user wants to audit the plugin collection for where sub-agents would improve workflows,
+  review haiku vs opus model selection across agents, check for tool over-permissions,
+  identify skills needing context isolation (builds, test runs, terraform plans), or map
+  delegation gaps; also use when focusing the analysis on a single plugin.
 args: "[--focus <plugin-name>]"
 allowed-tools: Glob, Grep, Read, Bash(ls *), Bash(wc *), TodoWrite
 argument-hint: "analyze all plugins or --focus <plugin-name>"
 created: 2026-01-24
-modified: 2026-02-27
+modified: 2026-04-19
 reviewed: 2026-02-08
 name: agents-analyze
 agent: general-purpose

--- a/api-plugin/skills/api-tests/SKILL.md
+++ b/api-plugin/skills/api-tests/SKILL.md
@@ -1,8 +1,13 @@
 ---
 created: 2025-12-16
-modified: 2026-02-13
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure API contract testing with Pact, OpenAPI validation, and schema testing
+description: |
+  Check and configure API contract testing infrastructure with Pact, OpenAPI validation,
+  and schema testing (Zod/AJV). Use when the user wants to set up or audit API contract
+  tests, validate OpenAPI specification compliance, add breaking change detection to CI,
+  configure Pact consumer/provider workflows, or check the status of existing API testing
+  infrastructure.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash(curl *), Bash(http *), Bash(jq *), AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--type <pact|openapi|schema>]"
 argument-hint: "[--check-only] [--fix] [--type <pact|openapi|schema>]"

--- a/blog-plugin/skills/blog-post-writing/skill.md
+++ b/blog-plugin/skills/blog-post-writing/skill.md
@@ -1,13 +1,15 @@
 ---
 name: blog-post-writing
 description: |
-  Consistent style guide for writing blog posts about projects and technical work.
-  Supports quick updates, detailed write-ups, retrospectives, and tutorials.
-  Designed for low-friction entry and easy scanning.
+  Consistent style guide for writing blog posts about projects and technical work. Supports
+  quick updates, detailed write-ups, retrospectives, tutorials, and deep dives with
+  low-friction entry and easy scanning. Use when the user is writing about work they've
+  done, documenting a project update, creating a devlog entry, or when they mention "write
+  up", "blog", "post", or "devlog".
 user-invocable: false
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(hugo *), Bash(date *), TodoWrite
 created: 2026-01-10
-modified: 2026-01-10
+modified: 2026-04-19
 reviewed: 2026-01-10
 ---
 

--- a/blog-plugin/skills/blog-post/SKILL.md
+++ b/blog-plugin/skills/blog-post/SKILL.md
@@ -1,13 +1,16 @@
 ---
 name: blog-post
-description: Create a blog post about your work with guided prompts and templates
-description: Create a blog post about your work with guided prompts and templates
+description: |
+  Create a blog post about your work with guided prompts and structured templates. Use when
+  the user wants to write a quick update, project update, retrospective, tutorial, or deep
+  dive about their work, when they mention "devlog", "write up", or "blog post", or when
+  they need git context auto-populated into a post to reduce blank-page anxiety.
 args: "[type] [--project <name>] [--title <title>]"
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(hugo *), Bash(date *), TodoWrite, AskUserQuestion
 argument-hint: "quick-update | project-update | retrospective | tutorial | deep-dive"
 disable-model-invocation: true
 created: 2026-01-10
-modified: 2026-02-14
+modified: 2026-04-19
 reviewed: 2026-02-14
 ---
 

--- a/blueprint-plugin/skills/blueprint-adr-list/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-adr-list/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2026-01-29
-modified: 2026-02-06
+modified: 2026-04-19
 reviewed: 2026-02-06
-description: "List all ADRs with title, status, date, and domain in a markdown table"
+description: |
+  List all ADRs with title, status, date, and domain in a markdown table. Use when
+  the user wants to see all architecture decision records, generate an ADR index for
+  a README, audit ADR status, or asks to "list ADRs", "show architecture decisions",
+  or "view the ADR table".
 allowed-tools: Bash, Glob
 name: blueprint-adr-list
 ---

--- a/blueprint-plugin/skills/blueprint-adr-validate/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-adr-validate/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2026-01-15
-modified: 2026-04-12
+modified: 2026-04-19
 reviewed: 2026-04-12
-description: "Validate ADR relationships, detect orphaned references, and check domain consistency"
+description: |
+  Validate ADR relationships, detect orphaned references, and check domain consistency.
+  Use when the user asks to "validate ADRs", audits architecture decision records before
+  a release, checks for broken supersedes/extends links, investigates conflicting decisions
+  in the same domain, or wants to detect cycles in the supersession graph.
 args: "[--report-only]"
 argument-hint: "--report-only to validate without prompting for fixes"
 allowed-tools: Read, Bash, Glob, Grep, Edit, AskUserQuestion

--- a/blueprint-plugin/skills/blueprint-claude-md/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-claude-md/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2025-12-17
-modified: 2026-02-17
+modified: 2026-04-19
 reviewed: 2026-02-09
-description: "Generate or update CLAUDE.md from project context and blueprint artifacts. Supports @import syntax, CLAUDE.local.md, and auto memory delineation."
+description: |
+  Generate or update CLAUDE.md from project context and blueprint artifacts. Supports @import
+  syntax, CLAUDE.local.md, and auto memory delineation. Use when the user asks to "create
+  CLAUDE.md", "update CLAUDE.md", convert inline content to @import references, add
+  team-shared project instructions, or set up CLAUDE.local.md for personal preferences.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 name: blueprint-claude-md
 ---

--- a/blueprint-plugin/skills/blueprint-curate-docs/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-curate-docs/SKILL.md
@@ -1,10 +1,14 @@
 ---
-description: "Curate library or project documentation for ai_docs to optimize AI context"
+description: |
+  Curate library or project documentation for ai_docs to optimize AI context. Use when
+  the user wants to document a library's gotchas and patterns for PRP reuse, build a
+  project knowledge base under docs/blueprint/ai_docs/, capture project-specific
+  implementation patterns, or asks to "curate docs" for a library like redis or pydantic.
 args: "[library-name|project:pattern-name]"
 argument-hint: "Library name (e.g., redis, pydantic) or project:pattern-name"
 allowed-tools: Read, Write, Glob, Bash, WebFetch, WebSearch, AskUserQuestion
 created: 2025-12-16
-modified: 2026-03-10
+modified: 2026-04-19
 reviewed: 2026-02-14
 name: blueprint-curate-docs
 ---

--- a/blueprint-plugin/skills/blueprint-derive-adr/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-derive-adr/SKILL.md
@@ -1,8 +1,13 @@
 ---
 created: 2025-12-22
-modified: 2026-02-06
+modified: 2026-04-19
 reviewed: 2026-02-06
-description: "Derive Architecture Decision Records from existing project structure, dependencies, and documentation"
+description: |
+  Derive Architecture Decision Records from existing project structure, dependencies, and
+  documentation. Use when the user wants to onboard an existing project to blueprint by
+  documenting implicit architecture decisions, asks to "derive ADRs", "generate ADRs from
+  the codebase", or needs to capture framework, database, state-management, and testing
+  choices retroactively.
 allowed-tools: Read, Write, Glob, Grep, Bash, AskUserQuestion, Task
 name: blueprint-derive-adr
 ---

--- a/blueprint-plugin/skills/blueprint-derive-plans/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-derive-plans/SKILL.md
@@ -1,8 +1,13 @@
 ---
 created: 2026-01-15
-modified: 2026-03-01
+modified: 2026-04-19
 reviewed: 2026-02-14
-description: "Derive PRDs, ADRs, and PRPs from git history, codebase structure, and existing documentation"
+description: |
+  Derive PRDs, ADRs, and PRPs from git history, codebase structure, and existing documentation.
+  Use when the user is onboarding an established project to blueprint, asks to "derive plans
+  from git history", extracts features from conventional commits, documents architecture
+  decisions retroactively, or wants to generate PRD/ADR/PRP docs from commit tags and release
+  boundaries.
 args: "[--quick] [--since DATE]"
 argument-hint: "--quick for fast scan, --since 2024-01-01 for date range"
 allowed-tools: Read, Write, Glob, Grep, Bash, AskUserQuestion, Task

--- a/blueprint-plugin/skills/blueprint-derive-prd/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-derive-prd/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2025-12-22
-modified: 2026-02-17
+modified: 2026-04-19
 reviewed: 2025-12-22
-description: "Derive PRD from existing project documentation, README, and codebase analysis"
+description: |
+  Derive PRD from existing project documentation, README, and codebase analysis. Use when
+  the user asks to "derive a PRD", "generate a PRD from the README", onboards an existing
+  project to blueprint, or wants to extract problem statements, stakeholders, features, and
+  user personas from existing docs into a formal Product Requirements Document.
 allowed-tools: Read, Write, Glob, Grep, Bash, AskUserQuestion, Task
 name: blueprint-derive-prd
 ---

--- a/blueprint-plugin/skills/blueprint-derive-rules/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-derive-rules/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2026-01-30
-modified: 2026-04-16
+modified: 2026-04-19
 reviewed: 2026-02-14
-description: "Derive Claude rules from git commit log decisions. Newer commits override older decisions when conflicts exist."
+description: |
+  Derive Claude rules from git commit log decisions. Newer commits override older decisions
+  when conflicts exist. Use when the user asks to "derive rules from git history", wants to
+  extract implicit project decisions from refactor/fix/feat commits, codify coding standards
+  from commit patterns, or generate code-style, testing, and api-design rules retroactively.
 args: "[--since DATE] [--scope SCOPE]"
 argument-hint: "--since 2024-01-01 for date range, --scope api for specific area"
 allowed-tools: Read, Write, Glob, Grep, Bash, AskUserQuestion, Task

--- a/blueprint-plugin/skills/blueprint-docs-list/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-docs-list/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2026-02-06
-modified: 2026-02-06
+modified: 2026-04-19
 reviewed: 2026-02-06
-description: "List blueprint documents (ADRs, PRDs, PRPs) with metadata extracted from frontmatter and headers"
+description: |
+  List blueprint documents (ADRs, PRDs, PRPs) with metadata extracted from frontmatter and
+  headers. Use when the user asks to "list blueprint docs", "show all PRDs/ADRs/PRPs", audit
+  document statuses, generate an index table for blueprint artifacts, or wants a quick
+  overview of all project documentation at once.
 args: "<type>"
 allowed-tools: Bash, Glob
 argument-hint: "adrs | prds | prps | all"

--- a/blueprint-plugin/skills/blueprint-execute/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-execute/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2026-01-14
-modified: 2026-02-17
+modified: 2026-04-19
 reviewed: 2026-01-30
-description: "Idempotent meta command that determines and executes the next logical blueprint action"
+description: |
+  Idempotent meta command that determines and executes the next logical blueprint action.
+  Use when the user asks "what's next?", "continue blueprint work", resumes a project after
+  pulling changes, wants smart detection of init/upgrade/derive/generate/execute steps, or
+  says things like "run blueprint" without specifying the exact command.
 allowed-tools: Read, Glob, Bash, AskUserQuestion, SlashCommand, Task
 name: blueprint-execute
 ---

--- a/blueprint-plugin/skills/blueprint-feature-tracker-status/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-feature-tracker-status/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2026-01-02
-modified: 2026-04-12
+modified: 2026-04-19
 reviewed: 2026-04-12
-description: "Display feature tracker statistics and completion summary"
+description: |
+  Display feature tracker statistics and completion summary. Use when the user asks
+  "what's the feature completion status?", wants a progress bar showing phase progress,
+  checks PRD coverage, views blocked features, lists ready-to-start work, or asks to
+  "show feature tracker status".
 allowed-tools: Read, Bash, AskUserQuestion
 name: blueprint-feature-tracker-status
 ---

--- a/blueprint-plugin/skills/blueprint-feature-tracker-sync/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-feature-tracker-sync/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2026-01-02
-modified: 2026-04-12
+modified: 2026-04-19
 reviewed: 2026-04-12
-description: "Synchronize feature tracker with TODO.md and PRDs, manage tasks"
+description: |
+  Synchronize feature tracker with TODO.md and PRDs, manage tasks. Use when the user asks
+  to "sync feature tracker", reconcile discrepancies between TODO.md checkboxes and tracker
+  status, recalculate completion statistics, add/complete tasks in tasks.in_progress, or
+  generate a markdown progress summary with --summary.
 allowed-tools: Read, Write, Bash, Glob, AskUserQuestion
 name: blueprint-feature-tracker-sync
 ---

--- a/blueprint-plugin/skills/blueprint-generate-rules/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-generate-rules/SKILL.md
@@ -1,8 +1,13 @@
 ---
 created: 2025-12-16
-modified: 2026-04-16
+modified: 2026-04-19
 reviewed: 2026-02-09
-description: "Generate project-specific rules from PRDs. Supports path-specific rules with paths frontmatter and brace expansion."
+description: |
+  Generate project-specific rules from PRDs. Supports path-specific rules with paths
+  frontmatter and brace expansion. Use when the user asks to "generate rules from PRDs",
+  wants aggregated architecture/testing/implementation/quality standards rules auto-created
+  from docs/prds/, needs path-scoped rules for test files or specific directories, or is
+  automating rule creation from requirements.
 allowed-tools: Read, Write, Glob, Bash, AskUserQuestion
 name: blueprint-generate-rules
 ---

--- a/blueprint-plugin/skills/blueprint-init/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-init/SKILL.md
@@ -1,8 +1,13 @@
 ---
 created: 2025-12-16
-modified: 2026-04-16
+modified: 2026-04-19
 reviewed: 2026-04-12
-description: "Initialize Blueprint Development structure in current project"
+description: |
+  Initialize Blueprint Development structure in current project. Use when the user asks
+  to "init blueprint", "set up blueprint", bootstrap a new project with docs/blueprint/
+  manifest and PRD/ADR/PRP directories, enable feature tracking, migrate existing
+  documentation into blueprint-managed paths, or configure decision detection and task
+  scheduling for the first time.
 allowed-tools: Bash, Write, Read, AskUserQuestion, Glob
 name: blueprint-init
 ---

--- a/blueprint-plugin/skills/blueprint-migration/skill.md
+++ b/blueprint-plugin/skills/blueprint-migration/skill.md
@@ -1,10 +1,14 @@
 ---
 name: blueprint-migration
-description: Versioned migration procedures for upgrading blueprint structure between format versions
+description: |
+  Versioned migration procedures for upgrading blueprint structure between format versions.
+  Use when /blueprint:upgrade needs version-specific logic, when migrating a manifest between
+  format versions (v1.0→v1.1, v1.x→v2.0, v2.x→v3.0, v3.0→v3.1, v3.2→v3.3), or when content
+  hashing, safe file moves, and rollback are required during a blueprint format migration.
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion, TodoWrite
 created: 2025-12-22
-modified: 2026-04-18
+modified: 2026-04-19
 reviewed: 2026-04-18
 ---
 

--- a/blueprint-plugin/skills/blueprint-promote/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-promote/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2025-12-22
-modified: 2026-02-06
+modified: 2026-04-19
 reviewed: 2025-12-22
-description: "Move generated artifact to custom layer to preserve modifications"
+description: |
+  Move generated artifact to custom layer to preserve modifications. Use when the user
+  wants to "promote" a generated rule to keep manual edits, asks to preserve changes to
+  files in .claude/rules/, stops sync warnings for modified auto-generated content, or
+  says things like "acknowledge modifications" or "promote from proposed to custom".
 args: "[skill-name|command-name]"
 allowed-tools: Read, Write, Bash, AskUserQuestion
 argument-hint: "Name of the skill or command to promote"

--- a/blueprint-plugin/skills/blueprint-prp-create/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-prp-create/SKILL.md
@@ -1,10 +1,15 @@
 ---
-description: "Create a PRP (Product Requirement Prompt) with systematic research, curated context, and validation gates"
+description: |
+  Create a PRP (Product Requirement Prompt) with systematic research, curated context, and
+  validation gates. Use when the user asks to "create a PRP", plans a feature implementation
+  packet for AI or subagent execution, wants comprehensive research with codebase patterns
+  and gotchas, or needs to build a self-contained spec with TDD requirements and confidence
+  scoring.
 args: "[feature-name]"
 argument-hint: "Feature name for the PRP (e.g., auth-oauth2, api-rate-limiting)"
 allowed-tools: Read, Write, Glob, Bash, WebFetch, WebSearch, Task, AskUserQuestion
 created: 2025-12-16
-modified: 2026-03-01
+modified: 2026-04-19
 reviewed: 2026-02-14
 name: blueprint-prp-create
 ---

--- a/blueprint-plugin/skills/blueprint-prp-execute/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-prp-execute/SKILL.md
@@ -1,11 +1,15 @@
 ---
-description: "Execute a PRP with validation loop, TDD workflow, and quality gates"
+description: |
+  Execute a PRP with validation loop, TDD workflow, and quality gates. Use when the user
+  asks to "execute a PRP", "implement the auth-oauth2 PRP", runs a planned feature from
+  docs/prps/ with red/green/refactor TDD cycles, wants automatic validation gates and
+  feature tracker sync, or needs to delegate a high-confidence PRP to subagents.
 args: "[prp-name]"
 argument-hint: "Name of PRP to execute (e.g., feature-auth-oauth2)"
 disable-model-invocation: true
 allowed-tools: Read, Write, Edit, Glob, Bash, Task, AskUserQuestion
 created: 2025-12-16
-modified: 2026-03-01
+modified: 2026-04-19
 reviewed: 2026-02-14
 name: blueprint-prp-execute
 ---

--- a/blueprint-plugin/skills/blueprint-rules/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-rules/SKILL.md
@@ -1,8 +1,13 @@
 ---
 created: 2025-12-17
-modified: 2026-02-09
+modified: 2026-04-19
 reviewed: 2026-02-09
-description: "Manage modular rules in .claude/rules/ directory. Supports path-specific rules with glob patterns, brace expansion, and user-level rules."
+description: |
+  Manage modular rules in .claude/rules/ directory. Supports path-specific rules with glob
+  patterns, brace expansion, and user-level rules. Use when the user asks to "manage rules",
+  add a path-specific rule for certain file types, list project and user-level rules, sync
+  rules with CLAUDE.md, validate glob patterns in `paths` frontmatter, or create rules for
+  React, API, testing, or config files.
 allowed-tools: Read, Write, Edit, Bash, Glob, AskUserQuestion
 name: blueprint-rules
 ---

--- a/blueprint-plugin/skills/blueprint-status/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-status/SKILL.md
@@ -1,8 +1,13 @@
 ---
 created: 2025-12-17
-modified: 2026-04-16
+modified: 2026-04-19
 reviewed: 2025-12-22
-description: "Show blueprint version, configuration, and check for available upgrades"
+description: |
+  Show blueprint version, configuration, and check for available upgrades. Use when the
+  user asks to "show blueprint status", checks the three-layer architecture breakdown,
+  audits traceability and orphan documents, views task registry health, looks for stale
+  or modified generated content, or wants to see PRD/ADR/PRP counts and feature tracker
+  progress.
 args: "[--report-only]"
 argument-hint: "--report-only to display status without interactive prompts"
 allowed-tools: Read, Bash, Glob, AskUserQuestion

--- a/blueprint-plugin/skills/blueprint-sync-ids/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-sync-ids/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2026-01-20
-modified: 2026-02-17
+modified: 2026-04-19
 reviewed: 2026-01-20
-description: "Scan all blueprint documents and assign IDs to those missing them, update manifest registry"
+description: |
+  Scan all blueprint documents and assign IDs to those missing them, update manifest registry.
+  Use when the user asks to "sync document IDs", assigns PRD-NNN / ADR-NNNN / PRP-NNN / WO-NNN
+  IDs to docs missing them, wants to build GitHub issue index for orphans, creates issues for
+  unlinked documents with --link-issues, or previews ID changes with --dry-run.
 args: "[--dry-run] [--link-issues]"
 argument-hint: "--dry-run to preview changes, --link-issues to create GitHub issues for orphans"
 allowed-tools: Read, Write, Edit, Glob, Bash, AskUserQuestion

--- a/blueprint-plugin/skills/blueprint-sync/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-sync/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2025-12-22
-modified: 2026-02-07
+modified: 2026-04-19
 reviewed: 2025-12-22
-description: "Check for stale generated content and offer regeneration or promotion"
+description: |
+  Check for stale generated content and offer regeneration or promotion. Use when the user
+  asks to "sync blueprint", detect manually modified generated rules, find stale content
+  when source PRDs have changed, review drift between .claude/rules/ and the manifest, or
+  reconcile edits via regenerate/promote/keep options.
 args: "[--dry-run]"
 argument-hint: "--dry-run to preview sync status without modifying files"
 allowed-tools: Read, Bash, Glob, AskUserQuestion

--- a/blueprint-plugin/skills/blueprint-upgrade/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-upgrade/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2025-12-17
-modified: 2026-04-18
+modified: 2026-04-19
 reviewed: 2026-04-18
-description: "Upgrade blueprint structure to the latest format version"
+description: |
+  Upgrade blueprint structure to the latest format version. Use when the user asks to
+  "upgrade blueprint", migrates between format versions (v1.x→v2, v2→v3, v3.0→v3.1/3.2/3.3),
+  adds the task registry introduced in v3.2, enables monorepo workspaces in v3.3, or runs
+  batch upgrades across repos with --non-interactive / -y.
 args: "[--non-interactive|-y]"
 argument-hint: "[--non-interactive|-y]"
 allowed-tools: Read, Write, Edit, Bash, Glob, AskUserQuestion

--- a/blueprint-plugin/skills/blueprint-work-order/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-work-order/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2025-12-16
-modified: 2026-02-06
+modified: 2026-04-19
 reviewed: 2025-12-26
-description: "Create work-order with minimal context for isolated subagent execution, optionally linked to GitHub issue"
+description: |
+  Create work-order with minimal context for isolated subagent execution, optionally linked
+  to GitHub issue. Use when the user asks to "create a work-order", breaks a PRP into
+  delegatable tasks for subagents, spawns a work-order from an existing PRP (--from-prp) or
+  GitHub issue (--from-issue), or needs a focused TDD task packet with clear success criteria.
 args: "[--no-publish] [--from-issue N]"
 argument-hint: "--no-publish for local-only, --from-issue 123 to create from existing issue"
 disable-model-invocation: true

--- a/blueprint-plugin/skills/document-detection/skill.md
+++ b/blueprint-plugin/skills/document-detection/skill.md
@@ -1,9 +1,14 @@
 ---
 created: 2026-01-09
-modified: 2026-03-12
+modified: 2026-04-19
 reviewed: 2026-02-06
 name: document-detection
-description: "Detect PRD/ADR/PRP opportunities in conversations and prompt for document creation. Activates when users discuss features, architecture decisions, or implementation planning."
+description: |
+  Detect PRD/ADR/PRP opportunities in conversations and prompt for document creation. Use
+  when the user discusses feature requirements ("I want to build...", "users should be able
+  to..."), compares technology trade-offs ("should we use X or Y?"), plans implementation
+  scope ("let's implement the payment module"), or when conversations warrant capturing an
+  ADR, PRD, or PRP.
 user-invocable: false
 allowed-tools: Read, Grep, Glob, Bash
 ---

--- a/blueprint-plugin/skills/document-linking/skill.md
+++ b/blueprint-plugin/skills/document-linking/skill.md
@@ -1,9 +1,14 @@
 ---
 created: 2026-01-20
-modified: 2026-02-06
+modified: 2026-04-19
 reviewed: 2026-01-20
 name: document-linking
-description: "Unified ID system for PRDs, ADRs, PRPs, and GitHub issues. Auto-generates IDs on document access, maintains bidirectional links, and provides traceability across all artifacts."
+description: |
+  Unified ID system for PRDs, ADRs, PRPs, and GitHub issues. Auto-generates IDs on document
+  access, maintains bidirectional links, and provides traceability across all artifacts. Use
+  when the user needs to link a PRD to a PRP, connect documents to GitHub issues, find
+  orphan docs/issues, auto-assign PRD-NNN / ADR-NNNN / PRP-NNN / WO-NNN IDs, or validate
+  broken cross-document references.
 user-invocable: false
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, TodoWrite
 ---

--- a/blueprint-plugin/skills/feature-tracking/SKILL.md
+++ b/blueprint-plugin/skills/feature-tracking/SKILL.md
@@ -1,9 +1,13 @@
 ---
 created: 2026-01-02
-modified: 2026-02-06
+modified: 2026-04-19
 reviewed: 2026-02-08
 name: feature-tracking
-description: "Track feature implementation status against requirements documents. Provides hierarchical FR code tracking, phase management, task tracking, and sync with TODO.md."
+description: |
+  Track feature implementation status against requirements documents. Provides hierarchical
+  FR code tracking, phase management, task tracking, and sync with TODO.md. Use when the
+  user works with FR codes like FR1.2.1, manages phase-based development progress, links
+  features to PRDs via feature-tracker.json, or needs to recalculate completion statistics.
 user-invocable: false
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, TodoWrite
 ---

--- a/code-quality-plugin/skills/code-antipatterns/SKILL.md
+++ b/code-quality-plugin/skills/code-antipatterns/SKILL.md
@@ -1,8 +1,13 @@
 ---
 created: 2025-12-16
-modified: 2026-04-14
+modified: 2026-04-19
 reviewed: 2026-04-14
-description: Analyze codebase for anti-patterns, code smells, and quality issues using ast-grep
+description: |
+  Analyze a codebase for anti-patterns, code smells, and quality issues using
+  ast-grep. Use when the user asks to find code smells, detect anti-patterns,
+  scan for magic numbers or console.logs, check for var usage or excessive
+  `any` types, audit for security issues like eval/innerHTML, or identify
+  long functions and deep nesting.
 allowed-tools: Read, Bash(sg *), Bash(rg *), Glob, Grep, TodoWrite, Task, SlashCommand
 args: "[PATH] [--focus <category>] [--severity <level>]"
 argument-hint: "[PATH] [--focus <category>] [--severity <level>]"

--- a/code-quality-plugin/skills/code-docs-quality/SKILL.md
+++ b/code-quality-plugin/skills/code-docs-quality/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2026-01-08
-modified: 2026-04-10
+modified: 2026-04-19
 reviewed: 2026-01-08
-description: "Analyze codebase documentation quality - PRDs, ADRs, PRPs, CLAUDE.md, and .claude/rules/"
+description: |
+  Analyze codebase documentation quality across PRDs, ADRs, PRPs, CLAUDE.md,
+  and .claude/rules/. Use when the user asks to audit or score documentation,
+  check for stale or missing ADRs/PRDs, validate frontmatter and structure of
+  rules, or review whether CLAUDE.md is up to date with recent code changes.
 allowed-tools: Read, Glob, Grep, Bash(markdownlint *), Bash(vale *), TodoWrite, Task
 args: "[PATH]"
 argument-hint: "[PATH]"

--- a/code-quality-plugin/skills/code-lint-fix/SKILL.md
+++ b/code-quality-plugin/skills/code-lint-fix/SKILL.md
@@ -1,9 +1,14 @@
 ---
 name: code-lint-fix
-description: Cross-language linter autofix commands and common fix patterns for biome, ruff, clippy, shellcheck, and more.
+description: |
+  Cross-language linter autofix commands and common fix patterns for biome,
+  ruff, clippy, shellcheck, and more. Use when the user wants to auto-fix
+  lint errors, sort imports, remove unused imports, quote shell variables,
+  apply prefer-const or clippy suggestions, or run a detect-and-fix pass
+  across a mixed-language project.
 allowed-tools: Bash(ruff *), Bash(eslint *), Bash(biome *), Bash(prettier *), Read, Edit, Grep
 created: 2025-12-27
-modified: 2026-04-10
+modified: 2026-04-19
 reviewed: 2026-02-08
 ---
 

--- a/code-quality-plugin/skills/code-lint/SKILL.md
+++ b/code-quality-plugin/skills/code-lint/SKILL.md
@@ -1,11 +1,15 @@
 ---
 created: 2025-12-16
-modified: 2026-04-10
+modified: 2026-04-19
 reviewed: 2025-12-16
 allowed-tools: Bash(ruff *), Bash(eslint *), Bash(rustfmt *), Bash(gofmt *), Bash(prettier *), Read, SlashCommand
 args: "[path] [--fix] [--format]"
 argument-hint: [path] [--fix] [--format]
-description: Universal linter that automatically detects and runs the appropriate linting tools
+description: |
+  Universal linter that auto-detects and runs the appropriate linting tools
+  for the project's language. Use when the user asks to lint the code, run
+  ruff/eslint/clippy/gofmt, auto-fix lint errors with --fix, format code,
+  or run pre-commit checks across a polyglot repository.
 name: code-lint
 ---
 

--- a/code-quality-plugin/skills/code-refactor/SKILL.md
+++ b/code-quality-plugin/skills/code-refactor/SKILL.md
@@ -1,11 +1,16 @@
 ---
 created: 2025-12-16
-modified: 2026-03-09
+modified: 2026-04-19
 reviewed: 2026-03-09
 allowed-tools: Task, TodoWrite
 args: <file-path|directory>
 argument-hint: <file-path|directory>
-description: Refactor code applying functional programming principles - pure functions, immutability, and composition. Use for file or directory-scope refactoring.
+description: |
+  Refactor code applying functional programming principles - pure functions,
+  immutability, and composition. Use when the user asks to refactor a file
+  or directory, extract pure functions, remove side effects, replace
+  imperative loops with map/filter/reduce, add early returns to deeply
+  nested code, or separate business logic from I/O.
 name: code-refactor
 ---
 

--- a/code-quality-plugin/skills/code-review-checklist/SKILL.md
+++ b/code-quality-plugin/skills/code-review-checklist/SKILL.md
@@ -1,10 +1,15 @@
 ---
 name: code-review-checklist
-description: Structured code review approach covering security, quality, performance, and consistency.
+description: |
+  Structured code review checklist covering security, correctness,
+  performance, quality, and consistency. Use when the user asks for a code
+  review, wants to check for hardcoded secrets or injection vulnerabilities,
+  verify error handling and edge cases, audit for N+1 queries or resource
+  leaks, or apply a priority-ordered review to a pull request.
 user-invocable: false
 allowed-tools: Read, Grep, Glob
 created: 2025-12-27
-modified: 2025-12-27
+modified: 2026-04-19
 reviewed: 2025-12-27
 ---
 

--- a/code-quality-plugin/skills/code-review/SKILL.md
+++ b/code-quality-plugin/skills/code-review/SKILL.md
@@ -1,9 +1,14 @@
 ---
 created: 2025-12-16
-modified: 2026-03-09
+modified: 2026-04-19
 reviewed: 2026-03-09
 allowed-tools: Task, TodoWrite, Glob, Read
-description: Perform comprehensive code review with automated fixes
+description: |
+  Perform a comprehensive code review covering quality, security,
+  performance, architecture, and test coverage, with automated fixes where
+  safe. Use when the user asks to review code or a directory, audit for
+  vulnerabilities and OWASP issues, check SOLID adherence, look for
+  performance bottlenecks, or spot missing test cases.
 args: "[PATH]"
 argument-hint: "[PATH]"
 name: code-review

--- a/code-quality-plugin/skills/debugging-methodology/SKILL.md
+++ b/code-quality-plugin/skills/debugging-methodology/SKILL.md
@@ -1,10 +1,15 @@
 ---
 name: debugging-methodology
-description: Systematic debugging approach with tool recommendations for memory, performance, and system-level issues.
+description: |
+  Systematic debugging methodology with tool recommendations for memory,
+  performance, and system-level issues. Use when the user asks to debug a
+  bug, diagnose a memory leak or performance problem, trace syscalls with
+  strace/eBPF, profile CPU usage with perf, reproduce a flaky test, or
+  reason about race conditions and null pointer errors.
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 created: 2025-12-27
-modified: 2025-12-27
+modified: 2026-04-19
 reviewed: 2025-12-27
 ---
 

--- a/codebase-attributes-plugin/skills/attributes-dashboard/SKILL.md
+++ b/codebase-attributes-plugin/skills/attributes-dashboard/SKILL.md
@@ -1,11 +1,16 @@
 ---
 name: attributes-dashboard
-description: Compact text-based health dashboard showing scores, findings, and severity breakdown. Use for at-a-glance codebase health visibility.
+description: |
+  Compact text-based health dashboard showing scores, findings, and severity breakdown for
+  documentation, testing, security, code quality, and CI/CD. Use when the user wants a
+  quick visual health overview of the codebase, to review health before a session, to
+  compare category scores at a glance, or to see a compact terminal-style summary of
+  critical/high/medium/low findings with action suggestions.
 allowed-tools: Bash(test *), Read, Glob, Grep
 args: "[--format <type>]"
 argument-hint: ""
 created: 2026-03-15
-modified: 2026-03-15
+modified: 2026-04-19
 reviewed: 2026-03-15
 ---
 

--- a/codebase-attributes-plugin/skills/attributes-route/SKILL.md
+++ b/codebase-attributes-plugin/skills/attributes-route/SKILL.md
@@ -1,11 +1,16 @@
 ---
 name: attributes-route
-description: Route to specialized agents based on codebase health attributes. Use after /attributes:collect to automatically address findings by severity.
+description: |
+  Route to specialized agents (security, test, refactor, review, docs, configure) based on
+  codebase health attributes, prioritized by severity weights. Use when the user has
+  attribute data and wants automated remediation, when batch-fixing multiple health findings,
+  when they want severity-based agent prioritization, or when mentioning "fix health
+  findings", "route to agents", or running after `/attributes:collect`.
 allowed-tools: Read, Glob, Grep, Agent, TodoWrite
 args: "[--dry-run] [--focus <category>] [--min-severity <level>]"
 argument-hint: "--dry-run"
 created: 2026-03-15
-modified: 2026-03-15
+modified: 2026-04-19
 reviewed: 2026-03-15
 ---
 

--- a/component-patterns-plugin/skills/components-version-badge/SKILL.md
+++ b/component-patterns-plugin/skills/components-version-badge/SKILL.md
@@ -1,8 +1,14 @@
 ---
 created: 2025-02-03
-modified: 2026-02-10
+modified: 2026-04-19
 reviewed: 2025-02-03
-description: Implement a version badge with tooltip showing build info and recent changelog - framework agnostic
+description: |
+  Implement a framework-agnostic version badge component with a tooltip showing build info
+  (version, commit, branch, timestamp) and recent changelog entries. Use when the user
+  wants to add a version display to their app header or footer, surface build information
+  in the UI, expose recent changelog entries as a tooltip, or when they mention "version
+  badge", "build info display", or "commit SHA in UI". Supports Next.js, Nuxt, SvelteKit,
+  Vite+React, and plain React/Vue/Svelte.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--location <header|footer|custom>]"
 argument-hint: "[--check-only] [--location <header|footer|custom>]"

--- a/configure-plugin/skills/configure-all/SKILL.md
+++ b/configure-plugin/skills/configure-all/SKILL.md
@@ -1,8 +1,13 @@
 ---
 created: 2025-12-16
-modified: 2026-02-10
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Run all infrastructure standards checks and configure compliance
+description: |
+  Run all infrastructure standards checks and configure compliance across a project.
+  Use when performing a comprehensive infrastructure audit, setting up a new project
+  against all standards, batch-fixing compliance issues with --fix, or validating
+  CI/CD compliance. Natural triggers: "check all standards", "audit project compliance",
+  "configure everything", "run all configure checks".
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, SlashCommand
 args: "[--check-only] [--fix] [--type <frontend|infrastructure|python>]"
 argument-hint: "[--check-only] [--fix] [--type <frontend|infrastructure|python>]"

--- a/configure-plugin/skills/configure-api-tests/SKILL.md
+++ b/configure-plugin/skills/configure-api-tests/SKILL.md
@@ -1,8 +1,13 @@
 ---
 created: 2025-12-16
-modified: 2026-02-11
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure API contract testing with Pact, OpenAPI validation, and schema testing
+description: |
+  Check and configure API contract testing with Pact, OpenAPI validation, and schema testing.
+  Use when setting up Pact consumer/provider contract tests, configuring OpenAPI
+  request/response validation, adding JSON Schema or Zod schema testing, or detecting
+  breaking API changes in CI. Natural triggers: "set up contract testing", "add Pact",
+  "configure OpenAPI validation".
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--type <pact|openapi|schema>]"
 argument-hint: "[--check-only] [--fix] [--type <pact|openapi|schema>]"

--- a/configure-plugin/skills/configure-argocd-automerge/SKILL.md
+++ b/configure-plugin/skills/configure-argocd-automerge/SKILL.md
@@ -1,8 +1,13 @@
 ---
 created: 2026-02-03
-modified: 2026-02-13
+modified: 2026-04-19
 reviewed: 2026-02-03
-description: Configure auto-merge workflow for ArgoCD Image Updater branches
+description: |
+  Configure GitHub Actions auto-merge workflow for ArgoCD Image Updater branches.
+  Use when setting up auto-merge for image-updater-** branches, creating the
+  argocd-automerge.yml workflow from scratch, verifying PAT and permissions for
+  auto-merge workflows, or updating an existing ArgoCD auto-merge workflow.
+  Natural triggers: "auto-merge ArgoCD PRs", "set up image-updater automerge".
 allowed-tools: Glob, Grep, Read, Write, Edit, TodoWrite
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"

--- a/configure-plugin/skills/configure-cache-busting/SKILL.md
+++ b/configure-plugin/skills/configure-cache-busting/SKILL.md
@@ -1,8 +1,13 @@
 ---
 created: 2025-12-16
-modified: 2026-02-11
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure cache-busting strategies for Next.js and Vite projects
+description: |
+  Check and configure cache-busting strategies for Next.js and Vite projects.
+  Use when configuring content hashing for Next.js or Vite builds, setting up CDN
+  cache headers for Vercel or Cloudflare, adding build verification scripts for
+  hashed assets, or auditing static asset caching strategy. Natural triggers:
+  "configure cache busting", "set up CDN cache headers", "add content hashing".
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--framework <nextjs|vite>] [--cdn <cloudflare|vercel|none>]"
 argument-hint: "[--check-only] [--fix] [--framework <nextjs|vite>] [--cdn <cloudflare|vercel|none>]"

--- a/configure-plugin/skills/configure-claude-plugins/SKILL.md
+++ b/configure-plugin/skills/configure-claude-plugins/SKILL.md
@@ -1,8 +1,14 @@
 ---
 created: 2026-01-23
-modified: 2026-04-14
+modified: 2026-04-19
 reviewed: 2026-04-14
-description: Configure .claude/settings.json (permissions, marketplace enrollment, enabledPlugins) and GitHub Actions workflows to use the laurigates/claude-plugins marketplace
+description: |
+  Configure .claude/settings.json (permissions, marketplace enrollment, enabledPlugins)
+  and GitHub Actions workflows to use the laurigates/claude-plugins marketplace.
+  Use when onboarding a new project to Claude Code plugins, setting up claude.yml
+  and claude-code-review.yml workflows, adding the laurigates/claude-plugins
+  marketplace to a repo, or merging plugin permissions into existing settings.
+  Natural triggers: "set up claude plugins", "add claude marketplace", "install claude.yml workflow".
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash(mkdir *), Bash(test *), Bash(ls *), Bash(git remote *), AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--plugins <plugin1,plugin2,...>]"
 argument-hint: "[--check-only] [--fix] [--plugins <plugin1,plugin2,...>]"

--- a/configure-plugin/skills/configure-container/SKILL.md
+++ b/configure-plugin/skills/configure-container/SKILL.md
@@ -1,8 +1,13 @@
 ---
 created: 2025-12-16
-modified: 2026-02-13
+modified: 2026-04-19
 reviewed: 2026-01-19
-description: Check and configure container infrastructure (builds, registry, scanning, devcontainer)
+description: |
+  Check and configure container infrastructure (builds, registry, scanning, devcontainer).
+  Use when auditing container infrastructure compliance, checking multi-stage builds and
+  non-root users, setting up container build workflows with GHCR and multi-platform support,
+  or adding Trivy/Grype scanning to CI pipelines. Natural triggers: "configure container
+  build", "add container scanning", "set up GHCR workflow".
 allowed-tools: Glob, Grep, Read, Write, Edit, AskUserQuestion, TodoWrite, SlashCommand, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--component <dockerfile|workflow|registry|scanning|devcontainer>]"
 argument-hint: "[--check-only] [--fix] [--component <dockerfile|workflow|registry|scanning|devcontainer>]"

--- a/configure-plugin/skills/configure-coverage/SKILL.md
+++ b/configure-plugin/skills/configure-coverage/SKILL.md
@@ -1,8 +1,13 @@
 ---
 created: 2025-12-16
-modified: 2026-02-11
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure code coverage thresholds and reporting
+description: |
+  Check and configure code coverage thresholds and reporting for test frameworks.
+  Use when setting up coverage thresholds for Vitest, Jest, pytest, or Rust, configuring
+  coverage reporters (text, JSON, HTML, lcov), adding Codecov or Coveralls integration,
+  or adjusting coverage threshold percentages. Natural triggers: "set up coverage",
+  "add codecov", "configure coverage threshold".
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--threshold <percentage>]"
 argument-hint: "[--check-only] [--fix] [--threshold <percentage>]"

--- a/configure-plugin/skills/configure-dead-code/SKILL.md
+++ b/configure-plugin/skills/configure-dead-code/SKILL.md
@@ -1,8 +1,13 @@
 ---
 created: 2025-12-16
-modified: 2026-02-11
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure dead code detection (Knip, Vulture, cargo-machete)
+description: |
+  Check and configure dead code detection tools (Knip, Vulture, cargo-machete, deadcode).
+  Use when setting up dead code detection for a new project, auditing whether Knip,
+  Vulture, or cargo-machete is configured correctly, migrating between dead code
+  detection tools, or adding dead code checks to CI/CD pipelines. Natural triggers:
+  "set up knip", "configure vulture", "detect unused code".
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--tool <knip|vulture|deadcode|machete>]"
 argument-hint: "[--check-only] [--fix] [--tool <knip|vulture|deadcode|machete>]"

--- a/configure-plugin/skills/configure-dockerfile/SKILL.md
+++ b/configure-plugin/skills/configure-dockerfile/SKILL.md
@@ -1,8 +1,13 @@
 ---
 created: 2025-12-16
-modified: 2026-02-10
+modified: 2026-04-19
 reviewed: 2026-01-19
-description: Check and configure Dockerfile for project standards (minimal Alpine/slim, non-root, multi-stage)
+description: |
+  Check and configure Dockerfile for project standards (minimal Alpine/slim, non-root,
+  multi-stage builds). Use when checking Dockerfile compliance with standards, creating
+  a Dockerfile from template, validating image size and security practices, setting up
+  minimal Alpine/slim-based images, or ensuring non-root user configuration. Natural
+  triggers: "create Dockerfile", "make Dockerfile non-root", "add multi-stage build".
 allowed-tools: Glob, Grep, Read, Write, Edit, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--type <frontend|python|go|rust>]"
 argument-hint: "[--check-only] [--fix] [--type <frontend|python|go|rust>]"

--- a/configure-plugin/skills/configure-docs/SKILL.md
+++ b/configure-plugin/skills/configure-docs/SKILL.md
@@ -1,8 +1,13 @@
 ---
 created: 2025-12-16
-modified: 2026-02-11
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure code documentation standards and generators (TSDoc, JSDoc, pydoc, rustdoc)
+description: |
+  Check and configure code documentation standards and generators (TSDoc, JSDoc,
+  pydoc, rustdoc). Use when setting up TSDoc/JSDoc/pydoc/rustdoc standards, configuring
+  a documentation generator (TypeDoc, MkDocs, Sphinx, rustdoc), auditing documentation
+  coverage, adding doc enforcement rules to CI, or migrating between documentation
+  conventions. Natural triggers: "set up docstrings", "configure typedoc", "add sphinx".
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--level <minimal|standard|strict>] [--type <typescript|javascript|python|rust>] [--generator <typedoc|sphinx|mkdocs|rustdoc>]"
 argument-hint: "[--check-only] [--fix] [--level <minimal|standard|strict>] [--type <typescript|javascript|python|rust>] [--generator <typedoc|sphinx|mkdocs|rustdoc>]"

--- a/configure-plugin/skills/configure-editor/SKILL.md
+++ b/configure-plugin/skills/configure-editor/SKILL.md
@@ -1,8 +1,14 @@
 ---
 created: 2025-12-16
-modified: 2026-02-10
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure EditorConfig and VS Code workspace settings
+description: |
+  Check and configure EditorConfig and VS Code workspace settings for team consistency.
+  Use when setting up consistent editor configuration across a team, checking
+  EditorConfig or VS Code workspace compliance, configuring format-on-save for detected
+  languages, adding recommended VS Code extensions, or setting up debug configurations
+  and tasks. Natural triggers: "set up editorconfig", "configure vscode settings",
+  "add recommended extensions".
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"

--- a/configure-plugin/skills/configure-feature-flags/SKILL.md
+++ b/configure-plugin/skills/configure-feature-flags/SKILL.md
@@ -1,8 +1,14 @@
 ---
 created: 2025-12-16
-modified: 2026-02-10
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure feature flag infrastructure (OpenFeature + providers)
+description: |
+  Check and configure feature flag infrastructure using OpenFeature with pluggable
+  providers. Use when adding feature flag infrastructure to a new project, setting up
+  the OpenFeature SDK with a provider (GOFF, flagd, LaunchDarkly), auditing existing
+  feature flag configuration, configuring relay proxy infrastructure, or adding
+  feature flag test helpers. Natural triggers: "set up feature flags", "add
+  openfeature", "configure launchdarkly".
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--provider <goff|flagd|launchdarkly|split>]"
 argument-hint: "[--check-only] [--fix] [--provider <goff|flagd|launchdarkly|split>]"

--- a/configure-plugin/skills/configure-formatting/SKILL.md
+++ b/configure-plugin/skills/configure-formatting/SKILL.md
@@ -1,8 +1,14 @@
 ---
 created: 2025-12-16
-modified: 2026-02-10
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure code formatting (Biome, Prettier, Ruff, rustfmt)
+description: |
+  Check and configure code formatting tools (Biome, Prettier, Ruff format, rustfmt).
+  Use when setting up a formatter for a project, migrating from Prettier to Biome or
+  Black to Ruff, auditing formatter configuration for best practices, adding
+  format-on-save and CI format checks, or standardizing formatting across a monorepo.
+  Natural triggers: "set up formatting", "configure biome", "migrate to ruff format",
+  "add prettier".
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--formatter <biome|prettier|ruff|rustfmt>]"
 argument-hint: "[--check-only] [--fix] [--formatter <biome|prettier|ruff|rustfmt>]"

--- a/configure-plugin/skills/configure-github-pages/SKILL.md
+++ b/configure-plugin/skills/configure-github-pages/SKILL.md
@@ -1,8 +1,13 @@
 ---
 created: 2025-12-16
-modified: 2026-02-11
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure GitHub Pages deployment
+description: |
+  Check and configure GitHub Pages deployment for documentation sites. Use when
+  setting up GitHub Pages deployment, creating or updating a GitHub Actions workflow
+  for Pages deployment, migrating from peaceiris/actions-gh-pages to the official
+  actions/deploy-pages, or auditing Pages workflow for outdated action versions.
+  Natural triggers: "deploy to github pages", "set up gh-pages", "configure pages workflow".
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--source <docs|site|custom>]"
 argument-hint: "[--check-only] [--fix] [--source <docs|site|custom>]"

--- a/configure-plugin/skills/configure-integration-tests/SKILL.md
+++ b/configure-plugin/skills/configure-integration-tests/SKILL.md
@@ -1,8 +1,14 @@
 ---
 created: 2025-12-16
-modified: 2026-02-11
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure integration testing for services, databases, and external dependencies
+description: |
+  Check and configure integration testing for services, databases, and external
+  dependencies. Use when setting up integration testing with Supertest, pytest, or
+  Testcontainers, creating docker-compose.test.yml for local test service containers,
+  auditing integration test setup, adding integration test jobs to GitHub Actions,
+  or separating integration from unit tests. Natural triggers: "set up integration
+  tests", "add testcontainers", "configure supertest".
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--framework <supertest|pytest|testcontainers>]"
 argument-hint: "[--check-only] [--fix] [--framework <supertest|pytest|testcontainers>]"

--- a/configure-plugin/skills/configure-justfile/SKILL.md
+++ b/configure-plugin/skills/configure-justfile/SKILL.md
@@ -1,8 +1,13 @@
 ---
 created: 2025-12-16
-modified: 2026-02-11
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure Justfile with standard recipes for project standards
+description: |
+  Check and configure Justfile with standard recipes for project standards. Use when
+  setting up a new Justfile for a project, auditing an existing Justfile for missing
+  standard recipes, migrating from Makefile to Justfile, or ensuring Justfile follows
+  team conventions (groups, comments, settings). Natural triggers: "set up justfile",
+  "migrate makefile to justfile", "add just recipes".
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"

--- a/configure-plugin/skills/configure-linting/SKILL.md
+++ b/configure-plugin/skills/configure-linting/SKILL.md
@@ -1,8 +1,13 @@
 ---
 created: 2025-12-16
-modified: 2026-02-10
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure linting tools (Biome, Ruff, Clippy)
+description: |
+  Check and configure modern linting tools (Biome, Ruff, Clippy) against best practices.
+  Use when setting up linting for a new project, migrating from ESLint/Prettier to Biome,
+  validating linter configuration, ensuring language-specific best practices, or
+  configuring pre-commit lint integration. Natural triggers: "set up linting",
+  "configure biome", "migrate to ruff", "add clippy".
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--linter <biome|ruff|clippy>]"
 argument-hint: "[--check-only] [--fix] [--linter <biome|ruff|clippy>]"

--- a/configure-plugin/skills/configure-load-tests/SKILL.md
+++ b/configure-plugin/skills/configure-load-tests/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2025-12-16
-modified: 2026-02-10
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure load and performance testing with k6, Artillery, or Locust
+description: |
+  Check and configure load and performance testing with k6, Artillery, or Locust. Use when
+  setting up load testing infrastructure from scratch, auditing smoke/stress/spike/soak
+  coverage, adding CI/CD performance regression detection, migrating between load testing
+  frameworks, or when the user asks to configure k6, Artillery, or Locust.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--framework <k6|artillery|locust>]"
 argument-hint: "[--check-only] [--fix] [--framework <k6|artillery|locust>]"

--- a/configure-plugin/skills/configure-makefile/SKILL.md
+++ b/configure-plugin/skills/configure-makefile/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2025-12-16
-modified: 2026-02-10
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure Makefile with standard targets for project standards
+description: |
+  Check and configure Makefile with standard targets for project standards. Use when
+  setting up a new Makefile, auditing an existing Makefile for missing standard targets
+  (help, test, build, clean, lint), adding language-specific build/test/lint targets, or
+  when the user asks to create or standardize a Makefile.
 allowed-tools: Glob, Grep, Read, Write, Edit, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"

--- a/configure-plugin/skills/configure-memory-profiling/SKILL.md
+++ b/configure-plugin/skills/configure-memory-profiling/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2025-12-16
-modified: 2026-02-10
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure memory profiling with pytest-memray for Python projects
+description: |
+  Check and configure memory profiling with pytest-memray for Python projects. Use when
+  setting up memory profiling from scratch, adding pytest-memray for CI memory regression
+  detection, configuring memory leak detection in test suites, setting memory thresholds
+  and allocation benchmarks, or when the user asks to profile Python memory usage.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--threshold <mb>] [--native]"
 argument-hint: "[--check-only] [--fix] [--threshold <mb>] [--native]"

--- a/configure-plugin/skills/configure-package-management/SKILL.md
+++ b/configure-plugin/skills/configure-package-management/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2025-12-16
-modified: 2026-02-11
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure modern package managers (uv for Python, bun for TypeScript)
+description: |
+  Check and configure modern package managers (uv for Python, bun for TypeScript). Use when
+  setting up a new project with uv or bun, migrating from legacy managers (pip, npm, yarn,
+  poetry, pipenv) to modern ones, auditing package manager configuration, or cleaning up
+  conflicting lock files from multiple managers.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--manager <uv|bun|npm|cargo>]"
 argument-hint: "[--check-only] [--fix] [--manager <uv|bun|npm|cargo>]"

--- a/configure-plugin/skills/configure-pre-commit/SKILL.md
+++ b/configure-plugin/skills/configure-pre-commit/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2025-12-16
-modified: 2026-02-10
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure pre-commit hooks for project standards
+description: |
+  Check and configure pre-commit hooks for project standards. Use when setting up or
+  validating pre-commit hooks, installing project-type-specific hooks (frontend,
+  infrastructure, python), migrating a project to the pre-commit framework, or updating
+  hook configurations for detected tools.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--type <frontend|infrastructure|python>]"
 argument-hint: "[--check-only] [--fix] [--type <frontend|infrastructure|python>]"

--- a/configure-plugin/skills/configure-readme/SKILL.md
+++ b/configure-plugin/skills/configure-readme/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2025-12-17
-modified: 2026-02-11
+modified: 2026-04-19
 reviewed: 2026-02-08
-description: Check and configure README.md with logo, badges, features, tech stack, and project structure
+description: |
+  Check and configure README.md with logo, badges, features, tech stack, and project
+  structure. Use when creating a README for a new project, auditing an existing README for
+  missing sections, standardizing README format across projects, adding shields.io badges
+  or a project structure section, or when the user asks to generate or fix a README.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch
 args: "[--check-only] [--fix] [--style <minimal|standard|detailed>] [--badges <shields|custom>]"
 argument-hint: "[--check-only] [--fix] [--style <minimal|standard|detailed>] [--badges <shields|custom>]"

--- a/configure-plugin/skills/configure-release-please/SKILL.md
+++ b/configure-plugin/skills/configure-release-please/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2025-12-16
-modified: 2026-02-11
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure release-please workflow for project standards
+description: |
+  Check and configure release-please workflow for project standards. Use when setting up
+  release-please for a new project, auditing an existing release-please configuration,
+  upgrading release-please-action, adding a new package to a monorepo release-please
+  config, or when the user asks to automate versioning and changelogs.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"

--- a/configure-plugin/skills/configure-reusable-workflows/SKILL.md
+++ b/configure-plugin/skills/configure-reusable-workflows/SKILL.md
@@ -1,8 +1,13 @@
 ---
 created: 2026-02-02
-modified: 2026-02-11
+modified: 2026-04-19
 reviewed: 2026-02-02
-description: Install reusable GitHub Actions workflows for security, quality, and accessibility checks
+description: |
+  Install reusable GitHub Actions workflows for security, quality, and accessibility
+  checks. Use when adding Claude-powered reusable workflows, installing pre-built workflow
+  callers from claude-plugins, automating OWASP/secret-scanning/code-smell detection in
+  CI, adding WCAG accessibility checks to PR pipelines, or bootstrapping a full suite of
+  Claude-powered CI checks.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash(mkdir *), Bash(ls *), AskUserQuestion, TodoWrite
 args: "[--all] [--security] [--quality] [--a11y] [--list]"
 argument-hint: "[--all] [--security] [--quality] [--a11y] [--list]"

--- a/configure-plugin/skills/configure-security/SKILL.md
+++ b/configure-plugin/skills/configure-security/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2025-12-16
-modified: 2026-02-11
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure security scanning (dependency audits, SAST, secrets)
+description: |
+  Check and configure security scanning (dependency audits, SAST, secrets). Use when
+  setting up dependency auditing, SAST, or secret detection for a project, configuring
+  Dependabot, CodeQL, or TruffleHog in CI/CD, creating or updating a SECURITY.md policy,
+  or auditing which security tools are missing from a project.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--type <dependencies|sast|secrets|all>]"
 argument-hint: "[--check-only] [--fix] [--type <dependencies|sast|secrets|all>]"

--- a/configure-plugin/skills/configure-select/SKILL.md
+++ b/configure-plugin/skills/configure-select/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2025-12-22
-modified: 2026-02-10
+modified: 2026-04-19
 reviewed: 2025-12-22
-description: Interactively select which infrastructure standards to configure
+description: |
+  Interactively select which infrastructure standards to configure. Use when the user
+  wants to set up selected components interactively, choose specific standards to
+  implement, customize configuration scope, or build infrastructure configuration
+  incrementally rather than running the full `/configure:all` pipeline.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, SlashCommand
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"

--- a/configure-plugin/skills/configure-sentry/SKILL.md
+++ b/configure-plugin/skills/configure-sentry/SKILL.md
@@ -1,8 +1,13 @@
 ---
 created: 2025-12-16
-modified: 2026-03-27
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure Sentry error tracking for project standards
+description: |
+  Check and configure Sentry error tracking for project standards. Use when setting up
+  Sentry for a new project, checking Sentry SDK installation and configuration compliance,
+  fixing hardcoded DSNs or missing env-var references, adding source map upload and
+  release tracking to CI/CD, or verifying Sentry config across frontend, Next.js, Node, or
+  Python projects.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--type <frontend|nextjs|python|node>]"
 argument-hint: "[--check-only] [--fix] [--type <frontend|nextjs|python|node>]"

--- a/configure-plugin/skills/configure-skaffold/SKILL.md
+++ b/configure-plugin/skills/configure-skaffold/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2025-12-16
-modified: 2026-03-01
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure Skaffold for project standards
+description: |
+  Check and configure Skaffold for project standards. Use when checking Skaffold
+  configuration compliance for a Kubernetes project, fixing port forwarding security
+  issues (0.0.0.0 binding), adding dotenvx hooks for secret generation, upgrading
+  Skaffold API version, or creating a standard skaffold.yaml from template.
 allowed-tools: Glob, Grep, Read, Write, Edit, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"

--- a/configure-plugin/skills/configure-status/SKILL.md
+++ b/configure-plugin/skills/configure-status/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2025-12-16
-modified: 2026-02-10
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Show infrastructure standards compliance status (read-only)
+description: |
+  Show infrastructure standards compliance status (read-only). Use when the user wants to
+  check overall compliance status, generate a compliance report, do a quick project
+  health check, validate CI/CD status, or review current configuration state without
+  making any changes.
 allowed-tools: Glob, Grep, Read, TodoWrite
 args: "[--verbose]"
 argument-hint: "[--verbose]"

--- a/configure-plugin/skills/configure-tests/SKILL.md
+++ b/configure-plugin/skills/configure-tests/SKILL.md
@@ -1,8 +1,12 @@
 ---
 created: 2025-12-16
-modified: 2026-03-01
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure testing frameworks and infrastructure
+description: |
+  Check and configure testing frameworks and infrastructure. Use when setting up testing
+  infrastructure for a project, checking test framework configuration, migrating to
+  modern frameworks (Vitest, pytest, cargo-nextest), validating coverage configuration,
+  or when the user asks to configure Vitest, Jest, pytest, or nextest.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--framework <vitest|jest|pytest|nextest>]"
 argument-hint: "[--check-only] [--fix] [--framework <vitest|jest|pytest|nextest>]"

--- a/configure-plugin/skills/configure-ux-testing/SKILL.md
+++ b/configure-plugin/skills/configure-ux-testing/SKILL.md
@@ -1,8 +1,13 @@
 ---
 created: 2025-12-16
-modified: 2026-03-19
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure UX testing infrastructure (Playwright, accessibility, visual regression)
+description: |
+  Check and configure UX testing infrastructure (Playwright, accessibility, visual
+  regression). Use when setting up Playwright E2E testing, adding accessibility testing
+  with axe-core, configuring visual regression screenshot assertions, setting up
+  Playwright CLI or MCP for Claude browser automation, or creating CI/CD workflows for
+  E2E and accessibility tests.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--a11y] [--visual]"
 argument-hint: "[--check-only] [--fix] [--a11y] [--visual]"

--- a/configure-plugin/skills/configure-workflows/SKILL.md
+++ b/configure-plugin/skills/configure-workflows/SKILL.md
@@ -1,8 +1,13 @@
 ---
 created: 2025-12-16
-modified: 2026-03-04
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure GitHub Actions CI/CD workflows (container builds, tests, releases)
+description: |
+  Check and configure GitHub Actions CI/CD workflows (container builds, tests, releases).
+  Use when checking GitHub Actions workflows for compliance, setting up container build,
+  test, or release-please workflows, updating outdated action versions (checkout,
+  build-push), adding multi-platform builds or GHA caching, or auditing which required
+  workflows are missing.
 allowed-tools: Glob, Grep, Read, Write, Edit, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"

--- a/container-plugin/skills/deploy-handoff/SKILL.md
+++ b/container-plugin/skills/deploy-handoff/SKILL.md
@@ -1,12 +1,17 @@
 ---
 created: 2025-12-16
-modified: 2026-04-10
+modified: 2026-04-19
 reviewed: 2026-04-10
 allowed-tools: Read, Bash(git *), mcp__github__get_pull_request, mcp__github__list_issues, TodoWrite
 args: [resource-name] [deployment-type]
 argument-hint: [resource-name] [deployment-type]
 disable-model-invocation: true
-description: Generate deployment handoff documentation
+description: |
+  Generate professional deployment handoff documentation for a deployed service or resource,
+  including service overview, technical stack, access URLs, configuration, monitoring, and a
+  developer checklist. Use when the user is handing off a deployed service to another
+  developer, documenting deployment details for a ticket, creating client-facing deployment
+  summaries, or generating access information for a new team member.
 name: deploy-handoff
 ---
 

--- a/documentation-plugin/skills/docs-decommission/SKILL.md
+++ b/documentation-plugin/skills/docs-decommission/SKILL.md
@@ -1,12 +1,17 @@
 ---
 created: 2025-12-16
-modified: 2025-12-16
+modified: 2026-04-19
 reviewed: 2026-02-08
 allowed-tools: Read, Write, Edit, Bash(find *), Bash(ls *), Grep, TodoWrite
 args: <service-name>
 argument-hint: <service-name>
 disable-model-invocation: true
-description: Generate comprehensive service decommission documentation
+description: |
+  Generate comprehensive service decommission documentation covering infrastructure resources,
+  data management, access/security, DNS/networking, dependencies, monitoring cleanup, and
+  financial/administrative checklists. Use when the user is decommissioning or retiring a
+  service, planning to shut down infrastructure, archiving a deployed resource, or wants a
+  DECOMMISSION-<service>.md checklist created at deployment time while context is fresh.
 name: docs-decommission
 ---
 

--- a/documentation-plugin/skills/docs-generate/SKILL.md
+++ b/documentation-plugin/skills/docs-generate/SKILL.md
@@ -1,11 +1,16 @@
 ---
 created: 2025-12-16
-modified: 2026-03-09
+modified: 2026-04-19
 reviewed: 2026-03-09
 allowed-tools: Task, TodoWrite
 args: [--api] [--readme] [--changelog]
 argument-hint: [--api] [--readme] [--changelog]
-description: Update project documentation from code annotations
+description: |
+  Generate or update project documentation from code annotations, docstrings, type signatures,
+  and git history. Use when the user wants to generate API reference docs, update the README
+  from code analysis, produce a CHANGELOG from conventional commits, or mentions "generate
+  docs", "update documentation", "API reference", or "regenerate changelog". Delegates to the
+  documentation agent for multi-language extraction.
 name: docs-generate
 agent: general-purpose
 ---

--- a/documentation-plugin/skills/docs-sync/SKILL.md
+++ b/documentation-plugin/skills/docs-sync/SKILL.md
@@ -1,10 +1,16 @@
 ---
-description: "Synchronize documentation with actual skills, commands, and agents in the codebase"
+description: |
+  Synchronize documentation with the actual skills, commands, and agents present in the
+  codebase by fixing count mismatches, adding missing entries, and removing stale
+  references. Use when the user wants to sync skill/command/agent catalogs after adding or
+  removing items, fix wrong counts in README/CLAUDE.md, detect stale entries referencing
+  removed items, or when they mention "docs out of sync", "update skill catalog", or
+  "regenerate command reference".
 args: "[--scope <type>] [--dry-run] [--verbose]"
 argument-hint: "--scope skills|commands|agents, --dry-run to preview, --verbose for details"
 allowed-tools: Bash, Grep, Glob, Read, Edit, Write, TodoWrite
 created: 2025-12-16
-modified: 2026-02-11
+modified: 2026-04-19
 reviewed: 2025-12-16
 name: docs-sync
 ---

--- a/evaluate-plugin/skills/evaluate-improve/SKILL.md
+++ b/evaluate-plugin/skills/evaluate-improve/SKILL.md
@@ -1,14 +1,17 @@
 ---
 name: evaluate-improve
 description: |
-  Analyze evaluation results and suggest concrete skill improvements. Use after
-  running evaluations to get actionable recommendations for improving skill
-  quality, descriptions, or instructions.
+  Analyze skill evaluation results and suggest concrete improvements to SKILL.md instructions,
+  descriptions, examples, error handling, tool configuration, or structure. Use after running
+  evaluations when the user wants actionable recommendations for raising pass rates,
+  improving skill descriptions so they trigger correctly, iterating on a skill after
+  benchmarking, or when they mention "improve this skill", "fix skill triggering", or
+  "what should I change based on the eval results".
 args: <plugin/skill-name> [--apply] [--description-only]
 allowed-tools: Task, Read, Write, Edit, Glob, Grep, Bash(cat *), Bash(jq *), Bash(find *), Bash(diff *), AskUserQuestion, TodoWrite
 argument-hint: "git-plugin/git-commit [--apply]"
 created: 2026-03-04
-modified: 2026-03-04
+modified: 2026-04-19
 reviewed: 2026-03-04
 ---
 

--- a/git-plugin/skills/gh-cli-agentic/skill.md
+++ b/git-plugin/skills/gh-cli-agentic/skill.md
@@ -1,10 +1,15 @@
 ---
 name: gh-cli-agentic
-description: GitHub CLI commands optimized for AI agent workflows with JSON output and deterministic execution patterns.
+description: |
+  GitHub CLI commands optimized for AI agent workflows with JSON output and
+  deterministic execution patterns. Use when the user asks to query PRs,
+  issues, workflow runs, or repo metadata with gh, inspect PR checks or
+  mergeable status, fetch failed CI logs, work with sub-issues, or resolve
+  a github.com URL into an API call.
 user-invocable: false
 allowed-tools: Bash(gh pr *), Bash(gh run *), Bash(gh issue *), Bash(gh repo *), Bash(gh workflow *), Bash(gh api *), Read
 created: 2025-01-16
-modified: 2026-03-19
+modified: 2026-04-19
 reviewed: 2026-03-19
 ---
 

--- a/git-plugin/skills/gh-workflow-monitoring/skill.md
+++ b/git-plugin/skills/gh-workflow-monitoring/skill.md
@@ -1,10 +1,15 @@
 ---
 name: gh-workflow-monitoring
-description: Monitor GitHub Actions workflow runs using blocking watch commands instead of polling with timeouts.
+description: |
+  Monitor GitHub Actions workflow runs with blocking watch commands instead
+  of polling loops or timeouts. Use when the user wants to watch a workflow
+  run until it completes, wait for CI after a push, trigger a workflow and
+  follow its progress, diagnose a failed run with `gh run view --log-failed`,
+  or find the latest in-progress runs.
 user-invocable: false
 allowed-tools: Bash(gh run *), Bash(gh workflow *), Bash(gh pr *), Read
 created: 2025-01-16
-modified: 2025-01-16
+modified: 2026-04-19
 reviewed: 2025-01-16
 ---
 

--- a/git-plugin/skills/git-cli-agentic/skill.md
+++ b/git-plugin/skills/git-cli-agentic/skill.md
@@ -1,10 +1,15 @@
 ---
 name: git-cli-agentic
-description: Git commands optimized for AI agent workflows with porcelain output and deterministic execution patterns.
+description: |
+  Git commands optimized for AI agent workflows with porcelain output and
+  deterministic, machine-readable formats. Use when the user asks for
+  scriptable git status/diff/log commands, needs porcelain=v2 output,
+  --numstat-based diff counts, custom --format placeholders in git log,
+  branch tracking info, or main-branch-development push patterns.
 user-invocable: false
 allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git branch *), Bash(git remote *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git restore *), Read
 created: 2025-01-16
-modified: 2026-01-31
+modified: 2026-04-19
 reviewed: 2025-01-16
 ---
 

--- a/git-plugin/skills/git-derive-docs/SKILL.md
+++ b/git-plugin/skills/git-derive-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-01-24
-modified: 2026-02-03
+modified: 2026-04-19
 reviewed: 2026-01-24
 allowed-tools: Bash(git log *), Bash(git shortlog *), Bash(git diff *), Bash(git branch *),
                Bash(git show *), Bash(git rev-list *), Bash(git diff-tree *),
@@ -8,7 +8,12 @@ allowed-tools: Bash(git log *), Bash(git shortlog *), Bash(git diff *), Bash(git
 args: "[--rules] [--prd] [--adr] [--prp] [--all] [--since=<date>] [--depth=<N>]"
 argument-hint: [--rules] [--prd] [--adr] [--prp] [--all] [--since=<date>] [--depth=<N>]
 disable-model-invocation: true
-description: Analyze git history to derive undocumented rules, PRDs, ADRs, and PRPs
+description: |
+  Analyze git commit history to derive undocumented rules, PRDs, ADRs, and
+  PRPs. Use when the user asks to find documentation gaps, detect
+  architectural decisions that were never recorded, derive coding conventions
+  from commit patterns, or generate skeleton rules/PRDs/ADRs/PRPs from
+  existing git history.
 name: git-derive-docs
 ---
 

--- a/git-plugin/skills/git-fix-pr/SKILL.md
+++ b/git-plugin/skills/git-fix-pr/SKILL.md
@@ -1,12 +1,16 @@
 ---
 created: 2025-12-16
-modified: 2026-01-17
+modified: 2026-04-19
 reviewed: 2026-01-17
 allowed-tools: Bash(gh pr checks *), Bash(gh pr view *), Bash(gh run view *), Bash(gh run list *), Bash(gh repo view *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(pre-commit *), Bash(npm run *), Bash(uv run *), Read, Edit, Grep, Glob, TodoWrite, mcp__github__pull_request_read
 args: "[pr-number] [--auto-fix] [--push]"
 argument-hint: [pr-number] [--auto-fix] [--push]
 disable-model-invocation: true
-description: Analyze and fix failing PR checks
+description: |
+  Analyze and fix failing PR checks. Use when the user asks to fix the PR,
+  resolve failing CI checks, diagnose red GitHub Actions runs, auto-fix
+  lint/type/test failures on a pull request, or reproduce CI errors locally
+  before pushing corrections.
 name: git-fix-pr
 ---
 

--- a/git-plugin/skills/git-issue/SKILL.md
+++ b/git-plugin/skills/git-issue/SKILL.md
@@ -1,9 +1,13 @@
 ---
 created: 2025-12-16
-modified: 2026-03-09
+modified: 2026-04-19
 reviewed: 2026-03-09
 allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git switch *), Bash(git pull *), Bash(git stash *), Bash(gh issue *), Bash(gh pr *), Bash(gh repo *), Bash(gh label *), Bash(pre-commit *), Read, Edit, Write, Grep, Glob, TodoWrite, AskUserQuestion, Task, mcp__github__create_pull_request, mcp__github__issue_read, mcp__github__list_issues
-description: Process GitHub issues with interactive selection, conflict detection, and parallel work support
+description: |
+  Process GitHub issues end-to-end with TDD, interactive selection, conflict
+  detection, and parallel work support. Use when the user asks to work on an
+  issue, fix issue #N, pick issues to tackle, batch-process several issues
+  in parallel, or spin up PRs from a prioritized issue list.
 args: "[issue-numbers...] [--auto] [--filter <label>] [--limit <n>] [--parallel]"
 argument-hint: [issue-numbers...] [--auto] [--filter <label>] [--limit <n>] [--parallel]
 disable-model-invocation: true

--- a/git-plugin/skills/git-maintain/SKILL.md
+++ b/git-plugin/skills/git-maintain/SKILL.md
@@ -1,12 +1,16 @@
 ---
 created: 2025-12-16
-modified: 2026-01-16
+modified: 2026-04-19
 reviewed: 2026-01-16
 allowed-tools: Bash(git status *), Bash(git branch *), Bash(git stash *), Bash(git prune *), Bash(git gc *), Bash(git repack *), Bash(git fsck *), Bash(git rm *), Bash(du *), Read, Glob, TodoWrite
 args: "[--prune] [--gc] [--verify] [--branches] [--stash] [--all]"
 argument-hint: [--prune] [--gc] [--verify] [--branches] [--stash] [--all]
 disable-model-invocation: true
-description: Perform repository maintenance and cleanup
+description: |
+  Perform repository maintenance and cleanup - garbage collection, branch
+  pruning, stash cleanup, and integrity verification. Use when the user asks
+  to clean up the repo, run git gc, delete merged branches, prune old
+  stashes, verify repo integrity with git fsck, or shrink the .git directory.
 name: git-maintain
 ---
 

--- a/git-plugin/skills/git-pr-feedback/SKILL.md
+++ b/git-plugin/skills/git-pr-feedback/SKILL.md
@@ -1,12 +1,17 @@
 ---
 created: 2026-01-30
-modified: 2026-04-17
+modified: 2026-04-19
 reviewed: 2026-02-26
 allowed-tools: Bash(gh pr checks *), Bash(gh pr view *), Bash(gh pr diff *), Bash(gh run view *), Bash(gh run list *), Bash(gh api *), Bash(gh repo view *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git switch *), Bash(git pull *), Bash(pre-commit *), Bash(npm run *), Bash(uv run *), Bash(bash *), Read, Edit, Write, Grep, Glob, TodoWrite, Task, mcp__github__pull_request_read, mcp__github__add_reply_to_pull_request_comment, mcp__github__resolve_review_thread, mcp__github__pull_request_review_write
 args: "[pr-number] [--commit] [--push]"
 argument-hint: [pr-number] [--commit] [--push]
 disable-model-invocation: true
-description: Review PR workflow results and comments, then address substantive feedback and suggestions from reviewers
+description: |
+  Review PR workflow results and reviewer comments, then address substantive
+  feedback and suggestions. Use when the user asks to address PR review
+  comments, apply reviewer suggestions, reply to review threads, resolve
+  reviewer feedback after CHANGES_REQUESTED, or work through a list of
+  unresolved review threads on a pull request.
 name: git-pr-feedback
 agent: general-purpose
 ---

--- a/github-actions-plugin/skills/workflow-dev/SKILL.md
+++ b/github-actions-plugin/skills/workflow-dev/SKILL.md
@@ -1,12 +1,18 @@
 ---
 created: 2025-12-16
-modified: 2026-02-10
+modified: 2026-04-19
 reviewed: 2025-12-16
 allowed-tools: Read, Write, Edit, MultiEdit, Bash(git *), Bash(pytest *), Bash(npm test *), Bash(cargo test *), Bash(go test *), mcp__github__list_issues, mcp__github__create_issue, mcp__github__create_pull_request, mcp__github__get_issue, TodoWrite
 args: [--max-cycles <n>] [--focus <bug|feature|test>]
 argument-hint: [--max-cycles <n>] [--focus <bug|feature|test>]
 disable-model-invocation: true
-description: Automated development loop with issue creation and TDD
+description: |
+  Automated development loop that runs tests, creates GitHub issues for failures, picks an
+  issue to work on, implements a TDD fix on a feature branch, opens a PR, and monitors CI
+  until green. Use when the user wants to run a continuous dev loop through open issues,
+  turn test failures into tracked issues, automate the issue-to-PR cycle, or when they
+  mention "work through the backlog", "autonomous dev loop", "TDD on open issues", or
+  "fix test failures and open PRs".
 name: workflow-dev
 ---
 

--- a/health-plugin/skills/health-agentic-audit/SKILL.md
+++ b/health-plugin/skills/health-agentic-audit/SKILL.md
@@ -1,9 +1,14 @@
 ---
 created: 2026-02-05
-modified: 2026-04-15
+modified: 2026-04-19
 reviewed: 2026-04-15
 user-invocable: false
-description: Audit skills and agents for agentic output optimization (missing compact/JSON flags, missing Agentic Optimizations tables)
+description: |
+  Audit plugin skills, commands, and agents for agentic output optimization compliance such
+  as missing Agentic Optimizations tables, bare CLI commands without compact/JSON flags, and
+  stale review dates. Use when the user wants to batch-check skill documentation quality,
+  find skills lacking compact output flags, enforce agentic optimization standards across
+  the repo, or identify skills with `modified` dates older than 90 days.
 allowed-tools: Bash(find *), Bash(head *), Read, Grep, Glob, TodoWrite
 args: "[--fix] [--verbose]"
 argument-hint: "[--fix] [--verbose]"

--- a/health-plugin/skills/health-audit/SKILL.md
+++ b/health-plugin/skills/health-audit/SKILL.md
@@ -1,9 +1,14 @@
 ---
 created: 2026-02-05
-modified: 2026-04-15
+modified: 2026-04-19
 reviewed: 2026-04-15
 user-invocable: false
-description: Audit enabled plugins against project tech stack and recommend additions/removals for relevance
+description: |
+  Audit the project's enabled plugins against the detected technology stack and recommend
+  which plugins to add or remove for relevance. Use when the user wants to review plugin
+  relevance for the current project, clean up unused plugins, discover missing plugins that
+  match the project's stack (Python, Node, Rust, Go, Terraform, Docker, Kubernetes), optimize
+  project-specific plugin configuration, or when onboarding to an existing project.
 allowed-tools: Bash(test *), Bash(find *), Bash(jq *), Bash(claude plugin *), Read, Write, Edit, Glob, Grep, TodoWrite, AskUserQuestion
 args: "[--fix] [--dry-run] [--verbose]"
 argument-hint: "[--fix] [--dry-run] [--verbose]"

--- a/health-plugin/skills/health-check/SKILL.md
+++ b/health-plugin/skills/health-check/SKILL.md
@@ -1,8 +1,14 @@
 ---
 created: 2026-02-04
-modified: 2026-04-16
+modified: 2026-04-19
 reviewed: 2026-04-16
-description: Run a comprehensive diagnostic scan of Claude Code configuration (plugins, settings, hooks, MCP servers, SessionStart executability, pre-commit validity, permissions coverage, marketplace enrollment) and optionally fix detected issues across registry, stack relevance, and agentic optimisation scopes
+description: |
+  Run a comprehensive diagnostic scan of Claude Code configuration — plugins, settings, hooks,
+  MCP servers, SessionStart executability, pre-commit validity, permissions coverage, and
+  marketplace enrollment — and optionally fix issues across registry, stack relevance, and
+  agentic optimisation scopes. Use when the user wants to troubleshoot Claude Code setup,
+  check plugin registry health, audit plugin fit for the project, or run a one-stop
+  diagnostic before starting work.
 allowed-tools: Bash(bash *), Bash(pre-commit *), Read, Glob, Grep, TodoWrite, AskUserQuestion
 args: "[--scope=all|registry|stack|agentic] [--fix] [--dry-run] [--verbose]"
 argument-hint: "[--scope=all|registry|stack|agentic] [--fix] [--dry-run] [--verbose]"

--- a/health-plugin/skills/health-plugins/SKILL.md
+++ b/health-plugin/skills/health-plugins/SKILL.md
@@ -1,9 +1,15 @@
 ---
 created: 2026-02-04
-modified: 2026-04-15
+modified: 2026-04-19
 reviewed: 2026-04-15
 user-invocable: false
-description: Diagnose and fix plugin registry issues including orphaned entries and project-scope conflicts (addresses Claude Code issue #14202)
+description: |
+  Diagnose and fix Claude Code plugin registry corruption, orphaned entries, stale
+  enabledPlugins keys, and project-scope conflicts (issue #14202 where a plugin appears
+  "installed" in another project and blocks installation). Use when the user sees "plugin
+  already installed" errors across projects, needs to clean up orphaned projectPath
+  entries, wants to resolve registry-vs-settings drift, or when inspecting the registry
+  JSON directly.
 allowed-tools: Bash(bash *), Read, Write, Edit, Glob, Grep, TodoWrite, AskUserQuestion
 args: "[--fix] [--dry-run] [--plugin <name>]"
 argument-hint: "[--fix] [--dry-run] [--plugin <name>]"

--- a/home-assistant-plugin/skills/ha-validate/SKILL.md
+++ b/home-assistant-plugin/skills/ha-validate/SKILL.md
@@ -1,10 +1,16 @@
 ---
-description: Validate Home Assistant YAML configuration files for syntax and structure errors
+description: |
+  Validate Home Assistant YAML configuration files for syntax errors, undefined secret
+  references, and duplicate keys, with optional Docker/HA OS full-config checks. Use when
+  the user wants to validate Home Assistant configuration before reload, diagnose YAML
+  indentation or mapping errors, check for missing entries in secrets.yaml, detect
+  duplicate keys in configuration.yaml/automations.yaml/scripts.yaml, or run `hass --script
+  check_config` through a running container.
 args: "[path]"
 allowed-tools: Bash(python3 *), Bash(docker exec *), Bash(ha *), Read, Grep, Glob
 argument-hint: "Optional path to config directory (defaults to current directory)"
 created: 2025-02-01
-modified: 2026-02-03
+modified: 2026-04-19
 reviewed: 2025-02-01
 name: ha-validate
 ---

--- a/obsidian-plugin/skills/vault-frontmatter/SKILL.md
+++ b/obsidian-plugin/skills/vault-frontmatter/SKILL.md
@@ -1,13 +1,14 @@
 ---
 created: 2026-04-17
-modified: 2026-04-17
+modified: 2026-04-19
 reviewed: 2026-04-17
 name: vault-frontmatter
 description: |
-  Offline maintenance of YAML frontmatter in Obsidian notes. Covers
-  detecting and fixing missing frontmatter, legacy `id:` fields, null
-  tag values, unrendered Templater markers, and corrupt emoji bytes.
-  Works directly on markdown files without a running Obsidian instance.
+  Offline maintenance of YAML frontmatter in Obsidian notes. Use when the
+  user asks to strip legacy `id:` fields, add missing frontmatter blocks,
+  remove null tag values, clean up unrendered Templater markers like
+  `{{title}}` or `<% tp.file.cursor() %>`, fix bare emoji placeholder tags,
+  or add `context: fvh` to FVH notes in bulk.
 user-invocable: false
 allowed-tools: Read, Edit, Write, Grep, Glob
 ---

--- a/obsidian-plugin/skills/vault-mocs/SKILL.md
+++ b/obsidian-plugin/skills/vault-mocs/SKILL.md
@@ -1,13 +1,13 @@
 ---
 created: 2026-04-17
-modified: 2026-04-17
+modified: 2026-04-19
 reviewed: 2026-04-17
 name: vault-mocs
 description: |
-  Map-of-Content (MOC) curation for Obsidian vaults. Covers MOC
-  conventions (`📝/moc` tag, section structure), coverage analysis
-  (which notes are orphaned from a MOC), and when to create a new MOC
-  vs. extend an existing one.
+  Map-of-Content (MOC) curation for Obsidian vaults. Use when the user asks
+  to create a new MOC for a tag category, extend an existing MOC with
+  orphaned notes, fix legacy `🗺️` MOC tags to `📝/moc`, analyze MOC
+  coverage for a category, or reorganize hand-curated hub notes.
 user-invocable: false
 allowed-tools: Read, Edit, Write, Grep, Glob
 ---

--- a/obsidian-plugin/skills/vault-orphans/SKILL.md
+++ b/obsidian-plugin/skills/vault-orphans/SKILL.md
@@ -1,13 +1,14 @@
 ---
 created: 2026-04-17
-modified: 2026-04-17
+modified: 2026-04-19
 reviewed: 2026-04-17
 name: vault-orphans
 description: |
-  Triage orphaned notes (zero incoming, zero outgoing wikilinks) in
-  an Obsidian vault. Distinguishes expected orphans (inbox, daily
-  notes) from meaningful orphans and suggests linkage targets
-  (MOCs, related notes).
+  Triage orphaned notes (zero incoming, zero outgoing wikilinks) in an
+  Obsidian vault. Use when the user asks to find orphan notes, link
+  disconnected notes into a MOC, distinguish expected orphans (inbox,
+  daily notes) from meaningful ones, suggest archival for stale orphans,
+  or reconnect isolated Zettelkasten notes to the knowledge graph.
 user-invocable: false
 allowed-tools: Read, Edit, Grep, Glob
 ---

--- a/obsidian-plugin/skills/vault-stubs/SKILL.md
+++ b/obsidian-plugin/skills/vault-stubs/SKILL.md
@@ -1,13 +1,14 @@
 ---
 created: 2026-04-17
-modified: 2026-04-17
+modified: 2026-04-19
 reviewed: 2026-04-17
 name: vault-stubs
 description: |
-  FVH/z/ redirect-stub classification and consolidation. Determines
-  whether a file in the work namespace is a proper redirect, a stale
-  duplicate of a canonical Zettelkasten note, or legitimately
-  FVH-original content. Applies the right rewrite in each case.
+  FVH/z/ redirect-stub classification and consolidation for LakuVault. Use
+  when the user asks to clean up FVH/z redirect stubs, convert stale
+  duplicates into canonical redirects, merge unique FVH content back into
+  Zettelkasten, promote an FVH-only note into the main vault, or fix
+  broken/oversized stubs.
 user-invocable: false
 allowed-tools: Read, Edit, Write, Grep, Glob
 ---

--- a/obsidian-plugin/skills/vault-tags/SKILL.md
+++ b/obsidian-plugin/skills/vault-tags/SKILL.md
@@ -1,13 +1,14 @@
 ---
 created: 2026-04-17
-modified: 2026-04-17
+modified: 2026-04-19
 reviewed: 2026-04-17
 name: vault-tags
 description: |
-  Emoji-prefixed tag taxonomy for Obsidian vaults. Defines canonical
-  categories, how to consolidate near-duplicate tags (`🔍/security` vs
-  `🔒/security`, `games` vs `gaming`), and when to collapse bare
-  placeholders. Works offline on .md files.
+  Emoji-prefixed tag taxonomy for Obsidian vaults. Use when the user asks
+  to consolidate duplicate or drifted tags (e.g. `🔒/security` vs
+  `🔍/security`, `gaming` vs `🎮/games`), collapse bare emoji placeholder
+  tags like `📝` or `🌱`, convert flat tags to emoji-prefixed form, or
+  reduce over-tagged notes down to the 2-3 canonical tags.
 user-invocable: false
 allowed-tools: Read, Edit, Grep, Glob
 ---

--- a/obsidian-plugin/skills/vault-templates/SKILL.md
+++ b/obsidian-plugin/skills/vault-templates/SKILL.md
@@ -1,13 +1,14 @@
 ---
 created: 2026-04-17
-modified: 2026-04-17
+modified: 2026-04-19
 reviewed: 2026-04-17
 name: vault-templates
 description: |
-  Obsidian Templater conventions and drift repair. Detects unrendered
-  template markers (`<% tp.file.cursor() %>`, `{{title}}`, `{{date}}`)
-  and applies the correct rendering to fix notes that were committed
-  before Templater finished running.
+  Obsidian Templater conventions and drift repair. Use when the user asks
+  to fix unrendered Templater markers like `<% tp.file.cursor() %>`,
+  replace `{{title}}` or `{{date}}` placeholders in daily notes, clean up
+  notes committed before Templater finished running, or audit daily-note
+  structure drift against the canonical template.
 user-invocable: false
 allowed-tools: Read, Edit, Write, Grep, Glob
 ---

--- a/obsidian-plugin/skills/vault-wikilinks/SKILL.md
+++ b/obsidian-plugin/skills/vault-wikilinks/SKILL.md
@@ -1,14 +1,14 @@
 ---
 created: 2026-04-17
-modified: 2026-04-17
+modified: 2026-04-19
 reviewed: 2026-04-17
 name: vault-wikilinks
 description: |
-  Detect and repair broken wikilinks in an Obsidian vault. Covers the
-  `[[Target]]`, `[[Target|Alias]]`, and `[[Target#Section]]` syntax,
-  basename resolution, cross-namespace ambiguity (e.g. Docker note
-  existing in both `Zettelkasten/` and `FVH/z/`), and the path-qualified
-  `[[Kanban/X]]` anti-pattern.
+  Detect and repair broken wikilinks in an Obsidian vault. Use when the
+  user asks to fix broken `[[Target]]` links, rewrite a renamed note's
+  references across the vault, resolve cross-namespace ambiguity between
+  Zettelkasten and FVH/z notes, unqualify `[[Kanban/X]]` path-qualified
+  links, or clean up wikilinks after renaming notes.
 user-invocable: false
 allowed-tools: Read, Edit, Grep, Glob
 ---

--- a/project-plugin/skills/project-continue/SKILL.md
+++ b/project-plugin/skills/project-continue/SKILL.md
@@ -1,10 +1,14 @@
 ---
-description: "Analyze project state and continue development where left off"
+description: |
+  Analyze project state and continue development where left off. Use when
+  the user asks to resume work, pick up where we left off, figure out what
+  to do next, identify the next task from PRDs and feature tracker, or
+  continue a TDD workflow after a break.
 args: "[--task <id>] [--skip-status]"
 argument-hint: "--task to resume specific task, --skip-status to skip state analysis"
 allowed-tools: Read, Bash, Grep, Glob, Edit, Write
 created: 2025-12-16
-modified: 2026-02-03
+modified: 2026-04-19
 reviewed: 2025-12-17
 name: project-continue
 ---

--- a/project-plugin/skills/project-distill/SKILL.md
+++ b/project-plugin/skills/project-distill/SKILL.md
@@ -1,14 +1,17 @@
 ---
 name: project-distill
 description: |
-  Distill session insights into reusable knowledge: Claude rules, skill improvements,
-  and justfile recipes. Use at the end of a session to capture learnings, update existing
-  artifacts, and avoid reinventing solutions. Prioritizes updating over adding.
+  Distill session insights into reusable knowledge: Claude rules, skill
+  improvements, and justfile recipes. Use when the user asks to capture
+  session learnings at end of day, extract patterns worth reusing, update
+  existing rules based on session experience, propose new justfile recipes
+  from commands we ran, or turn pain points into durable artifacts.
+  Prioritizes updating over adding.
 allowed-tools: Bash(git diff *), Bash(git log *), Bash(git status *), Bash(just *), Read, Grep, Glob, Edit, Write, AskUserQuestion, TodoWrite
 argument-hint: "--rules | --skills | --recipes | --all | --dry-run"
 args: "[--rules] [--skills] [--recipes] [--all] [--dry-run]"
 created: 2026-02-11
-modified: 2026-03-24
+modified: 2026-04-19
 reviewed: 2026-02-26
 ---
 

--- a/project-plugin/skills/project-init/SKILL.md
+++ b/project-plugin/skills/project-init/SKILL.md
@@ -1,12 +1,17 @@
 ---
 created: 2025-12-16
-modified: 2025-12-16
+modified: 2026-04-19
 reviewed: 2025-12-16
 allowed-tools: Write, Bash(mkdir *), Bash(git init *), Bash(gh repo create *), Bash(pwd *), Bash(git config *), Bash(which *), SlashCommand, TodoWrite
 args: <project-name> [project-type] [--github] [--private]
 argument-hint: <project-name> [project-type] [--github] [--private]
 disable-model-invocation: true
-description: Base project initialization that other commands can extend for language-specific setup
+description: |
+  Initialize a new project with a universal base structure (src/tests/docs,
+  git, README, LICENSE, .gitignore, .editorconfig, pre-commit, CI workflow,
+  Makefile). Use when the user asks to start a new project, scaffold a
+  new repo, create project skeleton, or bootstrap a Python/Node/Rust/Go
+  codebase - optionally creating a matching GitHub repository.
 name: project-init
 ---
 

--- a/project-plugin/skills/project-skill-scripts/SKILL.md
+++ b/project-plugin/skills/project-skill-scripts/SKILL.md
@@ -1,11 +1,18 @@
 ---
 name: project-skill-scripts
-description: Analyze plugin skills to identify opportunities where supporting scripts would improve performance (fewer tokens, faster execution, consistent results), then optionally create those scripts.
+description: |
+  Analyze plugin skills to identify opportunities where supporting scripts
+  would improve performance (fewer tokens, faster execution, consistent
+  results), then optionally create those scripts. Use when the user asks
+  to audit skills for script opportunities, measure script coverage across
+  the plugin portfolio, bulk-create supporting scripts for high-scoring
+  candidates, or extract repeated bash blocks from a SKILL.md into a
+  reusable script.
 args: "[--analyze] [--create <plugin/skill>] [--all]"
 allowed-tools: Bash(chmod *), Bash(mkdir *), Read, Write, Edit, Glob, Grep, TodoWrite
 argument-hint: "--analyze | --create git-plugin/git-commit-workflow | --all"
 created: 2026-01-24
-modified: 2026-02-14
+modified: 2026-04-19
 reviewed: 2026-02-14
 ---
 

--- a/project-plugin/skills/project-test-loop/SKILL.md
+++ b/project-plugin/skills/project-test-loop/SKILL.md
@@ -1,10 +1,15 @@
 ---
-description: "Run test → fix → refactor loop with TDD workflow"
+description: |
+  Run an automated test - fix - refactor TDD cycle until tests pass and
+  no refactoring opportunities remain. Use when the user asks to loop on
+  failing tests, iterate on a test pattern, run a TDD cycle, fix failing
+  tests and then refactor, or drive implementation via RED/GREEN/REFACTOR
+  until everything is green.
 args: "[test-pattern] [--max-cycles <N>]"
 argument-hint: "Test pattern to focus on, --max-cycles to limit iterations"
 allowed-tools: Read, Edit, Bash
 created: 2025-12-16
-modified: 2026-02-03
+modified: 2026-04-19
 reviewed: 2025-12-17
 name: project-test-loop
 ---

--- a/scripts/audit-skill-descriptions.py
+++ b/scripts/audit-skill-descriptions.py
@@ -147,6 +147,9 @@ def skill_slug(skill_path: Path) -> str:
     return skill_path.parent.name
 
 
+_DISABLE_RE = re.compile(r"^disable-model-invocation:\s*true\b", re.MULTILINE)
+
+
 def audit(root: Path) -> list[dict]:
     results = []
     for path in find_skills(root):
@@ -162,13 +165,21 @@ def audit(root: Path) -> list[dict]:
                         "path": str(path.relative_to(REPO_ROOT)),
                         "category": "MISSING",
                         "description": "",
+                        "auto_invokable": True,
                         "reason": "unparseable frontmatter",
                     }
                 )
                 continue
             reason = "frontmatter YAML parse error (regex fallback)"
+            # Still look for disable-model-invocation via regex
+            try:
+                fm_text = path.read_text(encoding="utf-8").split("\n---", 1)[0]
+            except OSError:
+                fm_text = ""
+            auto_invokable = not _DISABLE_RE.search(fm_text)
         else:
             desc = fm.get("description")
+            auto_invokable = not (fm.get("disable-model-invocation") is True)
         category = classify(desc)
         preview = ""
         if isinstance(desc, str):
@@ -182,6 +193,7 @@ def audit(root: Path) -> list[dict]:
                 "path": str(path.relative_to(REPO_ROOT)),
                 "category": category,
                 "description": preview,
+                "auto_invokable": auto_invokable,
                 "reason": reason,
             }
         )
@@ -195,6 +207,9 @@ def print_summary(results: list[dict]) -> None:
     for r in results:
         per_plugin[r["plugin"]][r["category"]] += 1
 
+    auto_bad = sum(1 for r in results if r["category"] != "OK" and r["auto_invokable"])
+    explicit_only_bad = sum(1 for r in results if r["category"] != "OK" and not r["auto_invokable"])
+
     print(f"Audited {total} skills across {len(per_plugin)} plugins")
     print()
     print("Overall:")
@@ -204,6 +219,8 @@ def print_summary(results: list[dict]) -> None:
         print(f"  {cat:<11} {n:>4}  ({pct:5.1f}%)")
     bad = total - overall.get("OK", 0)
     print(f"  {'NEEDS FIX':<11} {bad:>4}  ({(bad / total * 100) if total else 0:5.1f}%)")
+    print(f"    auto-invokable: {auto_bad:>3}  (priority)")
+    print(f"    explicit-only:  {explicit_only_bad:>3}  (disable-model-invocation: true)")
     print()
 
     # Per-plugin breakdown, sorted by worst-offender count
@@ -241,9 +258,19 @@ def main() -> int:
     parser.add_argument("--plugin", help="Filter output to one plugin")
     parser.add_argument("--json", action="store_true", help="Emit JSON")
     parser.add_argument(
+        "--auto-invokable",
+        action="store_true",
+        help="Filter to skills that Claude can auto-invoke (omit those with disable-model-invocation: true)",
+    )
+    parser.add_argument(
         "--strict",
         action="store_true",
-        help="Exit non-zero if any skill is not OK (for CI use)",
+        help="Exit non-zero if any skill has a MISSING or EMPTY description (pre-commit gate)",
+    )
+    parser.add_argument(
+        "--strict-all",
+        action="store_true",
+        help="Exit non-zero if any auto-invokable skill is not OK (stricter CI gate; fails on NO_TRIGGER)",
     )
     args = parser.parse_args()
 
@@ -254,6 +281,8 @@ def main() -> int:
         filtered = [r for r in filtered if r["category"] == args.category]
     if args.plugin:
         filtered = [r for r in filtered if r["plugin"] == args.plugin]
+    if args.auto_invokable:
+        filtered = [r for r in filtered if r["auto_invokable"]]
 
     if args.json:
         json.dump(filtered, sys.stdout, indent=2)
@@ -263,9 +292,20 @@ def main() -> int:
     else:
         print_summary(results)
 
+    if args.strict_all:
+        bad = [r for r in results if r["category"] != "OK" and r["auto_invokable"]]
+        if bad:
+            print(f"\n{len(bad)} auto-invokable skills need description fixes", file=sys.stderr)
+            return 1
+        return 0
     if args.strict:
-        bad = [r for r in results if r["category"] != "OK"]
-        return 1 if bad else 0
+        bad = [r for r in results if r["category"] in ("MISSING", "EMPTY")]
+        if bad:
+            print(f"\n{len(bad)} skills have MISSING or EMPTY description:", file=sys.stderr)
+            for r in bad:
+                print(f"  {r['path']} ({r['category']})", file=sys.stderr)
+            return 1
+        return 0
     return 0
 
 

--- a/scripts/audit-skill-descriptions.py
+++ b/scripts/audit-skill-descriptions.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""
+Audit SKILL.md descriptions for auto-invocation quality.
+
+Claude auto-invokes a skill based on its `description` frontmatter field. A good
+description includes a "Use when..." trigger clause so Claude can match it to
+user intent. This script classifies every skill in the repo into:
+
+  MISSING     — no description field
+  EMPTY       — description is empty / null / whitespace
+  NO_TRIGGER  — description present but lacks a "Use when..." trigger clause
+  OK          — description includes a trigger clause
+
+See .claude/rules/skill-quality.md for the Description Quality checklist.
+
+Usage:
+    python scripts/audit-skill-descriptions.py                       # Summary
+    python scripts/audit-skill-descriptions.py --list                # Show every offender
+    python scripts/audit-skill-descriptions.py --category EMPTY      # Filter
+    python scripts/audit-skill-descriptions.py --plugin git-plugin   # Filter
+    python scripts/audit-skill-descriptions.py --json                # Machine-readable
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Trigger phrases that signal an intent-matching description.
+# See .claude/rules/skill-quality.md for the canonical pattern.
+TRIGGER_PATTERNS = [
+    r"\buse when\b",
+    r"\buse this (?:skill|command) when\b",
+    r"\bwhen the user\b",
+    r"\bwhen (?:you|a user) (?:need|want|ask|request|mention)",
+    r"\binvoke (?:this|when)\b",
+    r"\btrigger(?:s|ed)? (?:on|when|by)\b",
+]
+TRIGGER_RE = re.compile("|".join(TRIGGER_PATTERNS), re.IGNORECASE)
+
+CATEGORIES = ("MISSING", "EMPTY", "NO_TRIGGER", "OK")
+
+
+def find_skills(root: Path) -> list[Path]:
+    """Return all SKILL.md / skill.md files under *-plugin directories."""
+    skills: list[Path] = []
+    for plugin_dir in sorted(root.glob("*-plugin")):
+        if not plugin_dir.is_dir():
+            continue
+        skills_dir = plugin_dir / "skills"
+        if not skills_dir.is_dir():
+            continue
+        for skill_md in sorted(skills_dir.rglob("SKILL.md")):
+            skills.append(skill_md)
+        for skill_md in sorted(skills_dir.rglob("skill.md")):
+            if skill_md not in skills:
+                skills.append(skill_md)
+    return skills
+
+
+_DESC_RE = re.compile(
+    r"^description:\s*(?P<value>.*?)(?=^\w[\w-]*:\s|^---\s*$|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def _regex_description(fm_text: str) -> str | None:
+    """Best-effort extraction of description when YAML parsing fails.
+
+    Handles single-line strings, quoted strings, and multi-line block scalars
+    (`|` and `>`). Returns None if no `description:` key is present.
+    """
+    m = _DESC_RE.search(fm_text)
+    if not m:
+        return None
+    value = m.group("value").rstrip()
+    if not value:
+        return ""
+    # Block scalar: `|` or `>` followed by indented lines
+    if value.lstrip().startswith(("|", ">")):
+        lines = value.splitlines()[1:]
+        return " ".join(line.strip() for line in lines if line.strip())
+    # Quoted string
+    if (value.startswith('"') and value.endswith('"')) or (
+        value.startswith("'") and value.endswith("'")
+    ):
+        return value[1:-1]
+    # Plain multi-line (YAML folds these) — join
+    return " ".join(line.strip() for line in value.splitlines() if line.strip())
+
+
+def extract_frontmatter(path: Path) -> tuple[dict | None, str | None]:
+    """Parse the YAML frontmatter block.
+
+    Returns `(data, fallback_description)`. `data` is the parsed dict, or None
+    on parse failure. `fallback_description` is a regex-extracted description
+    used when YAML parsing fails but the field is still recoverable.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None, None
+    if not text.startswith("---"):
+        return None, None
+    parts = text.split("\n---", 1)
+    if len(parts) < 2:
+        return None, None
+    fm_text = parts[0].lstrip("-").lstrip("\n")
+    try:
+        data = yaml.safe_load(fm_text)
+    except yaml.YAMLError:
+        return None, _regex_description(fm_text)
+    if not isinstance(data, dict):
+        return None, _regex_description(fm_text)
+    return data, None
+
+
+def classify(description) -> str:
+    """Classify a description value into one of the CATEGORIES."""
+    if description is None:
+        return "MISSING"
+    if not isinstance(description, str):
+        # Non-string descriptions crash the skill loader; treat as empty.
+        return "EMPTY"
+    stripped = description.strip()
+    if not stripped:
+        return "EMPTY"
+    if TRIGGER_RE.search(stripped):
+        return "OK"
+    return "NO_TRIGGER"
+
+
+def plugin_of(skill_path: Path) -> str:
+    rel = skill_path.relative_to(REPO_ROOT)
+    return rel.parts[0]
+
+
+def skill_slug(skill_path: Path) -> str:
+    return skill_path.parent.name
+
+
+def audit(root: Path) -> list[dict]:
+    results = []
+    for path in find_skills(root):
+        fm, fallback = extract_frontmatter(path)
+        reason = ""
+        if fm is None:
+            desc = fallback
+            if fallback is None:
+                results.append(
+                    {
+                        "plugin": plugin_of(path),
+                        "skill": skill_slug(path),
+                        "path": str(path.relative_to(REPO_ROOT)),
+                        "category": "MISSING",
+                        "description": "",
+                        "reason": "unparseable frontmatter",
+                    }
+                )
+                continue
+            reason = "frontmatter YAML parse error (regex fallback)"
+        else:
+            desc = fm.get("description")
+        category = classify(desc)
+        preview = ""
+        if isinstance(desc, str):
+            preview = " ".join(desc.split())
+            if len(preview) > 120:
+                preview = preview[:117] + "..."
+        results.append(
+            {
+                "plugin": plugin_of(path),
+                "skill": skill_slug(path),
+                "path": str(path.relative_to(REPO_ROOT)),
+                "category": category,
+                "description": preview,
+                "reason": reason,
+            }
+        )
+    return results
+
+
+def print_summary(results: list[dict]) -> None:
+    total = len(results)
+    overall = Counter(r["category"] for r in results)
+    per_plugin: dict[str, Counter] = defaultdict(Counter)
+    for r in results:
+        per_plugin[r["plugin"]][r["category"]] += 1
+
+    print(f"Audited {total} skills across {len(per_plugin)} plugins")
+    print()
+    print("Overall:")
+    for cat in CATEGORIES:
+        n = overall.get(cat, 0)
+        pct = (n / total * 100) if total else 0.0
+        print(f"  {cat:<11} {n:>4}  ({pct:5.1f}%)")
+    bad = total - overall.get("OK", 0)
+    print(f"  {'NEEDS FIX':<11} {bad:>4}  ({(bad / total * 100) if total else 0:5.1f}%)")
+    print()
+
+    # Per-plugin breakdown, sorted by worst-offender count
+    print(f"{'Plugin':<32} {'OK':>5} {'NO_TRIG':>8} {'EMPTY':>7} {'MISSING':>8} {'TOTAL':>6}")
+    print("-" * 72)
+    rows = sorted(
+        per_plugin.items(),
+        key=lambda kv: (-(kv[1].get("EMPTY", 0) + kv[1].get("NO_TRIGGER", 0) + kv[1].get("MISSING", 0)), kv[0]),
+    )
+    for plugin, counts in rows:
+        tot = sum(counts.values())
+        print(
+            f"{plugin:<32} {counts.get('OK', 0):>5} "
+            f"{counts.get('NO_TRIGGER', 0):>8} "
+            f"{counts.get('EMPTY', 0):>7} "
+            f"{counts.get('MISSING', 0):>8} "
+            f"{tot:>6}"
+        )
+
+
+def print_list(results: list[dict], show_ok: bool) -> None:
+    for r in results:
+        if not show_ok and r["category"] == "OK":
+            continue
+        desc = r["description"] or "(none)"
+        print(f"[{r['category']:<10}] {r['path']}")
+        print(f"             {desc}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--list", action="store_true", help="List every offender (non-OK skills)")
+    parser.add_argument("--all", action="store_true", help="With --list, include OK skills too")
+    parser.add_argument("--category", choices=CATEGORIES, help="Filter output to one category")
+    parser.add_argument("--plugin", help="Filter output to one plugin")
+    parser.add_argument("--json", action="store_true", help="Emit JSON")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero if any skill is not OK (for CI use)",
+    )
+    args = parser.parse_args()
+
+    results = audit(REPO_ROOT)
+
+    filtered = results
+    if args.category:
+        filtered = [r for r in filtered if r["category"] == args.category]
+    if args.plugin:
+        filtered = [r for r in filtered if r["plugin"] == args.plugin]
+
+    if args.json:
+        json.dump(filtered, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    elif args.list or args.category or args.plugin:
+        print_list(filtered, show_ok=args.all)
+    else:
+        print_summary(results)
+
+    if args.strict:
+        bad = [r for r in results if r["category"] != "OK"]
+        return 1 if bad else 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/plugin-compliance-check.sh
+++ b/scripts/plugin-compliance-check.sh
@@ -36,6 +36,7 @@ results_body=()
 results_marketplace=()
 results_release=()
 results_bash=()
+results_desc=()
 results_overall=()
 
 # Helper: extract YAML frontmatter field
@@ -392,6 +393,59 @@ check_bash_patterns() {
   return 0
 }
 
+# Check 7: Skill description quality for auto-invocation
+# Regression: skills whose description lacks a "Use when..." trigger clause are
+# not matched by Claude's auto-invocation heuristic, so they rarely fire without
+# explicit user instruction. See .claude/rules/skill-quality.md "Description
+# Quality" checklist. Delegates to scripts/audit-skill-descriptions.py which
+# handles multi-line YAML block scalars correctly.
+check_skill_descriptions() {
+  local plugin="$1"
+  local skills_dir="${plugin}/skills"
+
+  if [ ! -d "$skills_dir" ]; then
+    return 0
+  fi
+
+  local audit_script="scripts/audit-skill-descriptions.py"
+  if [ ! -f "$audit_script" ] || ! command -v python3 >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local audit_json
+  if ! audit_json=$(python3 "$audit_script" --plugin "$plugin" --json 2>/dev/null); then
+    return 0
+  fi
+
+  local has_errors=false
+  local has_warnings=false
+
+  while IFS=$'\t' read -r category skill_path auto; do
+    [ -z "$category" ] && continue
+    local skill_slug
+    skill_slug=$(basename "$(dirname "$skill_path")")
+    case "$category" in
+      MISSING|EMPTY)
+        issues+=("❌ ${plugin}/${skill_slug}: description is ${category} — Claude cannot auto-invoke this skill")
+        has_errors=true
+        ;;
+      NO_TRIGGER)
+        if [ "$auto" = "true" ]; then
+          recommendations+=("⚠️ ${plugin}/${skill_slug}: description lacks a \"Use when...\" trigger clause — Claude may not auto-invoke this skill (see .claude/rules/skill-quality.md)")
+          has_warnings=true
+        fi
+        ;;
+    esac
+  done < <(echo "$audit_json" | jq -r '.[] | select(.category != "OK") | [.category, .path, (.auto_invokable | tostring)] | @tsv')
+
+  if $has_errors; then
+    return 2
+  elif $has_warnings; then
+    return 1
+  fi
+  return 0
+}
+
 # Main check loop
 for i in "${!PLUGINS[@]}"; do
   plugin="${PLUGINS[$i]}"
@@ -404,6 +458,7 @@ for i in "${!PLUGINS[@]}"; do
     results_marketplace+=("❌")
     results_release+=("❌")
     results_bash+=("❌")
+    results_desc+=("❌")
     results_overall+=("❌")
     overall_failed=true
     continue
@@ -416,6 +471,7 @@ for i in "${!PLUGINS[@]}"; do
   marketplace_status=0; check_marketplace "$plugin" || marketplace_status=$?
   release_status=0; check_release_config "$plugin" || release_status=$?
   bash_status=0; check_bash_patterns "$plugin" || bash_status=$?
+  desc_status=0; check_skill_descriptions "$plugin" || desc_status=$?
 
   results_json+=("$(to_symbol $json_status)")
   results_frontmatter+=("$(to_symbol $frontmatter_status)")
@@ -423,10 +479,11 @@ for i in "${!PLUGINS[@]}"; do
   results_marketplace+=("$(to_symbol $marketplace_status)")
   results_release+=("$(to_symbol $release_status)")
   results_bash+=("$(to_symbol $bash_status)")
+  results_desc+=("$(to_symbol $desc_status)")
 
   # Overall: ❌ if any ❌, ⚠️ if any ⚠️, ✅ if all ✅
   plugin_overall="✅"
-  for status in $json_status $frontmatter_status $body_status $marketplace_status $release_status $bash_status; do
+  for status in $json_status $frontmatter_status $body_status $marketplace_status $release_status $bash_status $desc_status; do
     if [ "$status" -ge 2 ]; then
       plugin_overall="❌"
       overall_failed=true
@@ -441,11 +498,11 @@ done
 # Output report
 echo "## Plugin Compliance Review"
 echo ""
-echo "| Plugin | plugin.json | Frontmatter | Body | Marketplace | Release Config | Bash Patterns | Overall |"
-echo "|--------|-------------|-------------|------|-------------|----------------|---------------|---------|"
+echo "| Plugin | plugin.json | Frontmatter | Body | Marketplace | Release Config | Bash Patterns | Descriptions | Overall |"
+echo "|--------|-------------|-------------|------|-------------|----------------|---------------|--------------|---------|"
 
 for i in "${!PLUGINS[@]}"; do
-  echo "| ${PLUGINS[$i]} | ${results_json[$i]} | ${results_frontmatter[$i]} | ${results_body[$i]} | ${results_marketplace[$i]} | ${results_release[$i]} | ${results_bash[$i]} | ${results_overall[$i]} |"
+  echo "| ${PLUGINS[$i]} | ${results_json[$i]} | ${results_frontmatter[$i]} | ${results_body[$i]} | ${results_marketplace[$i]} | ${results_release[$i]} | ${results_bash[$i]} | ${results_desc[$i]} | ${results_overall[$i]} |"
 done
 
 echo ""

--- a/testing-plugin/skills/test-analyze/SKILL.md
+++ b/testing-plugin/skills/test-analyze/SKILL.md
@@ -1,10 +1,15 @@
 ---
-description: Analyze test results and create systematic fix plan with subagent delegation
+description: |
+  Analyze test results and create a systematic fix plan with subagent
+  delegation. Use when the user asks to triage failing tests, analyze a
+  test-results directory or JUnit XML, plan fixes for accessibility or
+  security scan findings, categorize flaky/performance/E2E failures, or
+  delegate fixes to specialized agents.
 args: "<results-path> [--type <test-type>] [--focus <area>]"
 argument-hint: "Path to test results (e.g., ./test-results/), optional --type and --focus filters"
 allowed-tools: Task, Read, Glob, Grep, TodoWrite
 created: 2025-12-16
-modified: 2026-02-27
+modified: 2026-04-19
 reviewed: 2025-12-16
 name: test-analyze
 agent: general-purpose

--- a/testing-plugin/skills/test-consult/SKILL.md
+++ b/testing-plugin/skills/test-consult/SKILL.md
@@ -1,11 +1,15 @@
 ---
 created: 2025-12-16
-modified: 2025-12-16
+modified: 2026-04-19
 reviewed: 2025-12-16
 allowed-tools: Task, Read, Glob, Grep
 args: "<topic> [--context <path>]"
 argument-hint: "<topic> [--context <path>]"
-description: Consult test-architecture agent for testing strategy and design
+description: |
+  Consult the test-architecture agent for testing strategy and design
+  decisions. Use when the user asks for advice on test coverage gaps, test
+  pyramid balance, framework selection, flaky-test remediation, designing
+  tests for a new feature, or any strategic "how should we test X?" question.
 name: test-consult
 ---
 

--- a/testing-plugin/skills/test-focus/SKILL.md
+++ b/testing-plugin/skills/test-focus/SKILL.md
@@ -1,11 +1,16 @@
 ---
 created: 2026-01-19
-modified: 2026-03-01
+modified: 2026-04-19
 reviewed: 2026-02-08
 allowed-tools: Bash, Read, Grep, Glob, TodoWrite
 args: "<file-path> [--serial] [--debug]"
 argument-hint: "<file-path> [--serial] [--debug]"
-description: Run single test file with fail-fast mode for rapid iteration
+description: |
+  Run a single test file in fail-fast mode for rapid TDD iteration across
+  Playwright, Vitest, Jest, pytest, cargo, or go test. Use when the user
+  asks to rerun one test file, iterate quickly on a failing spec, stop at
+  the first failure, run a test in headed/debug mode, or force serial
+  execution for WebGL or database tests.
 name: test-focus
 ---
 

--- a/testing-plugin/skills/test-full/SKILL.md
+++ b/testing-plugin/skills/test-full/SKILL.md
@@ -1,11 +1,16 @@
 ---
 created: 2025-12-16
-modified: 2026-03-09
+modified: 2026-04-19
 reviewed: 2026-03-09
 allowed-tools: Task, TodoWrite
 args: "[--coverage] [--parallel] [--report]"
 argument-hint: "[--coverage] [--parallel] [--report]"
-description: Complete test suite including integration and E2E tests
+description: |
+  Run the complete test suite in pyramid order - unit, then integration,
+  then E2E. Use when the user asks to run all tests before a PR, run the
+  full test suite with coverage, execute integration and E2E together,
+  generate an HTML test report, or run pre-commit verification across all
+  test tiers.
 name: test-full
 agent: general-purpose
 ---

--- a/testing-plugin/skills/test-quick/SKILL.md
+++ b/testing-plugin/skills/test-quick/SKILL.md
@@ -1,11 +1,15 @@
 ---
 created: 2025-12-16
-modified: 2026-03-09
+modified: 2026-04-19
 reviewed: 2026-03-09
 allowed-tools: Task, TodoWrite
 args: "[path] [--watch] [--affected]"
 argument-hint: "[path] [--watch] [--affected]"
-description: Fast unit tests only (skip slow/integration/E2E)
+description: |
+  Run fast unit tests only, skipping slow/integration/E2E tiers. Use when
+  the user asks to run quick tests, check unit tests after a change, run
+  only affected tests since the last commit, enable watch mode for TDD,
+  or get sub-30-second feedback while iterating.
 name: test-quick
 ---
 

--- a/testing-plugin/skills/test-report/SKILL.md
+++ b/testing-plugin/skills/test-report/SKILL.md
@@ -1,11 +1,16 @@
 ---
 created: 2025-12-16
-modified: 2025-12-16
+modified: 2026-04-19
 reviewed: 2025-12-16
 allowed-tools: Read, Glob, Bash(git *)
 args: "[--history] [--coverage] [--flaky]"
 argument-hint: "[--history] [--coverage] [--flaky]"
-description: Show test status from last run (without re-executing)
+description: |
+  Show test status from the last run without re-executing tests, reading
+  cached results from pytest/vitest/jest/playwright/go/cargo caches. Use
+  when the user asks for current test health, wants a quick status check
+  for standup, needs to see coverage summary or history trend, or wants to
+  identify flaky tests from recent runs.
 name: test-report
 ---
 

--- a/testing-plugin/skills/test-run/SKILL.md
+++ b/testing-plugin/skills/test-run/SKILL.md
@@ -1,11 +1,16 @@
 ---
 created: 2025-12-16
-modified: 2026-03-09
+modified: 2026-04-19
 reviewed: 2026-03-09
 allowed-tools: Task, TodoWrite
 args: [test-pattern] [--coverage] [--watch]
 argument-hint: [test-pattern] [--coverage] [--watch]
-description: Universal test runner that automatically detects and runs the appropriate testing framework
+description: |
+  Universal test runner that auto-detects and runs the appropriate testing
+  framework (pytest, vitest, jest, cargo test, go test). Use when the user
+  asks to run the tests, test a specific file or pattern, run tests with
+  coverage, start a watch-mode dev loop, or run tests without specifying
+  the framework.
 name: test-run
 ---
 

--- a/testing-plugin/skills/test-setup/SKILL.md
+++ b/testing-plugin/skills/test-setup/SKILL.md
@@ -1,9 +1,14 @@
 ---
 created: 2025-12-16
-modified: 2025-12-16
+modified: 2026-04-19
 reviewed: 2025-12-16
 allowed-tools: Read, Write, Edit, MultiEdit, Bash(pip install *), Bash(npm install *), Bash(pre-commit *), Bash(pytest *), Bash(npm test *), Bash(git *), TodoWrite, SlashCommand
-description: Configure comprehensive testing infrastructure with CI/CD integration
+description: |
+  Configure comprehensive testing infrastructure with CI/CD integration.
+  Use when the user asks to set up testing, scaffold unit/integration/E2E
+  test directories, add pre-commit hooks, create GitHub Actions test
+  workflows, wire up Codecov coverage reporting, or add test and coverage
+  badges to the README.
 args: [--coverage] [--ci <github|gitlab|circleci>]
 argument-hint: [--coverage] [--ci <github|gitlab|circleci>]
 name: test-setup

--- a/tools-plugin/skills/binary-analysis/SKILL.md
+++ b/tools-plugin/skills/binary-analysis/SKILL.md
@@ -1,10 +1,16 @@
 ---
 name: binary-analysis
-description: Reverse engineering and binary exploration using strings, binwalk, hexdump, and related tools.
+description: |
+  Reverse engineering and binary exploration using strings, binwalk, hexdump, xxd, file, and
+  objdump. Use when the user needs to identify unknown file types, extract printable strings
+  from compiled binaries or firmware, analyze firmware images for embedded files, inspect
+  raw hex data, hunt for hardcoded credentials or URLs inside binaries, run entropy analysis
+  to find compressed/encrypted regions, or when they mention "reverse engineer", "firmware
+  analysis", "strings dump", "binwalk", or "hexdump this binary".
 user-invocable: false
 allowed-tools: Bash(file *), Bash(xxd *), Bash(hexdump *), Bash(strings *), Bash(objdump *), Bash(readelf *), Bash(nm *), Read, Grep, Glob
 created: 2025-12-27
-modified: 2025-12-27
+modified: 2026-04-19
 reviewed: 2025-12-27
 ---
 

--- a/tools-plugin/skills/deps-install/SKILL.md
+++ b/tools-plugin/skills/deps-install/SKILL.md
@@ -1,11 +1,17 @@
 ---
 created: 2025-12-16
-modified: 2025-12-16
+modified: 2026-04-19
 reviewed: 2025-12-16
 allowed-tools: Bash(uv *), Bash(npm *), Bash(bun *), Bash(cargo *), Bash(go *), Bash(brew *), Read, Write
 args: [package-names] [--dev] [--global]
 argument-hint: [package-names] [--dev] [--global]
-description: Universal dependency installer that automatically detects and uses the appropriate package manager
+description: |
+  Universal dependency installer that auto-detects the project's package manager (uv, bun,
+  npm, yarn, pnpm, cargo, go) and runs the correct install command for dev, global, or
+  project-local installs. Use when the user wants to install dependencies without worrying
+  which package manager the project uses, add a package as a dev dependency, install
+  globally, sync the lockfile, or when they mention "install dependencies", "add package",
+  or "run the right package manager here".
 name: deps-install
 ---
 

--- a/tools-plugin/skills/generate-image/SKILL.md
+++ b/tools-plugin/skills/generate-image/SKILL.md
@@ -1,8 +1,13 @@
 ---
 created: 2025-12-16
-modified: 2026-02-06
+modified: 2026-04-19
 reviewed: 2025-12-16
-description: Generate images using Nano Banana Pro (Gemini 3 Pro Image)
+description: |
+  Generate images from a text prompt using Google's Nano Banana Pro (Gemini 3 Pro Image)
+  with configurable aspect ratio, resolution (1K/2K/4K), and up to 5 reference images. Use
+  when the user wants to generate an image, produce artwork for a blog post, create a
+  product photo, mock up a portrait or cinematic scene, or when they mention "generate an
+  image", "make a picture", "Nano Banana", or "Gemini image".
 allowed-tools: Bash, Read, WebFetch
 args: <prompt> [--aspect <ratio>] [--resolution <size>] [--reference <path>]
 disable-model-invocation: true

--- a/tools-plugin/skills/mermaid-diagrams/skill.md
+++ b/tools-plugin/skills/mermaid-diagrams/skill.md
@@ -1,10 +1,16 @@
 ---
 name: mermaid-diagrams
-description: Generate diagrams from text using Mermaid CLI (mmdc) - flowcharts, sequence diagrams, ERDs, class diagrams, state machines, and more.
+description: |
+  Generate diagrams from text using the Mermaid CLI (mmdc) — flowcharts, sequence diagrams,
+  ERDs, class diagrams, state machines, Gantt charts, pie charts, and git graphs — with
+  output as SVG, PNG, or PDF. Use when the user wants to render a Mermaid diagram, convert
+  .mmd text to an image, embed diagrams in GitHub Markdown, create an architecture or API
+  flow diagram, or when they mention "mermaid", "flowchart", "sequence diagram", or
+  "render this diagram".
 user-invocable: false
 allowed-tools: Bash, Read, Write, Grep, Glob, TodoWrite
 created: 2025-12-26
-modified: 2025-12-26
+modified: 2026-04-19
 reviewed: 2025-12-26
 ---
 

--- a/tools-plugin/skills/nushell-data-processing/skill.md
+++ b/tools-plugin/skills/nushell-data-processing/skill.md
@@ -1,9 +1,15 @@
 ---
 created: 2025-12-25
-modified: 2025-12-25
+modified: 2026-04-19
 reviewed: 2025-12-25
 name: nushell-data-processing
-description: Structured data processing with nushell - native table handling, multi-format parsing (JSON, YAML, TOML, CSV), and pipeline operations. Preferred over jq/yq for complex transformations.
+description: |
+  Structured data processing with nushell — native tables, multi-format parsing (JSON, YAML,
+  TOML, CSV, XML), pipelines, aggregations, and group-by operations. Preferred over jq/yq
+  for complex multi-step transforms. Use when the user wants to run multi-step data
+  transformations, process multiple formats together, aggregate or group records, perform
+  cross-file data operations, visually explore data as tables, or when they mention
+  "nushell", "nu pipeline", or ask for transforms that would be awkward in jq.
 user-invocable: false
 allowed-tools: Bash(nu *), Read, Write, Edit, Grep, Glob
 ---

--- a/typescript-plugin/skills/bun-add/SKILL.md
+++ b/typescript-plugin/skills/bun-add/SKILL.md
@@ -1,10 +1,14 @@
 ---
-description: Add package dependency with Bun
+description: |
+  Add a package dependency with Bun. Use when the user wants to install a single
+  package quickly, add a dev dependency (e.g. `bun add --dev typescript`), pin an
+  exact version without a semver range, or target a specific workspace. Triggers:
+  "add express", "install lodash", "bun add a dev dep", "pin react exact".
 args: <package> [--dev] [--exact]
 allowed-tools: Bash, Read
 argument-hint: package-name [--dev] [--exact]
 created: 2025-12-20
-modified: 2025-12-20
+modified: 2026-04-19
 reviewed: 2025-12-20
 name: bun-add
 ---

--- a/typescript-plugin/skills/bun-build/SKILL.md
+++ b/typescript-plugin/skills/bun-build/SKILL.md
@@ -1,10 +1,15 @@
 ---
-description: Bundle or compile with Bun
+description: |
+  Bundle or compile JavaScript/TypeScript with Bun. Use when the user wants a
+  quick production bundle of an entry point, to compile to a standalone
+  executable with `bun build --compile`, or to build for a specific target
+  (browser, bun, node). Triggers: "bundle src/index.ts", "compile to binary",
+  "build for node target", "make a standalone executable".
 args: <entry> [--compile] [--minify]
 allowed-tools: Bash, Read
 argument-hint: ./src/index.ts [--compile] [--minify]
 created: 2025-12-20
-modified: 2025-12-20
+modified: 2026-04-19
 reviewed: 2025-12-20
 name: bun-build
 ---

--- a/typescript-plugin/skills/bun-debug/SKILL.md
+++ b/typescript-plugin/skills/bun-debug/SKILL.md
@@ -1,10 +1,15 @@
 ---
-description: Debug TypeScript/JavaScript with Bun inspector
+description: |
+  Launch a script with Bun's debugger enabled via `--inspect`. Use when the user
+  wants to interactively debug a TypeScript/JavaScript file, break at the first
+  line of a fast-exiting script, wait for a debugger to attach before running,
+  or debug tests via `bun --inspect-brk test`. Triggers: "debug this script",
+  "attach debugger", "open debug.bun.sh", "break on start".
 args: <file> [--brk] [--wait] [--port=<port>]
 allowed-tools: Bash, BashOutput, Read
 argument-hint: <script.ts> [--brk] [--wait] [--port=9229]
 created: 2026-01-22
-modified: 2026-01-22
+modified: 2026-04-19
 reviewed: 2026-01-22
 name: bun-debug
 ---

--- a/typescript-plugin/skills/bun-development/skill.md
+++ b/typescript-plugin/skills/bun-development/skill.md
@@ -1,10 +1,17 @@
 ---
 name: bun-development
-description: Bun runtime for running scripts, testing, building, and project initialization - optimized flags for fast feedback and minimal output.
+description: |
+  Bun runtime workflows for running scripts, testing, building, and
+  initializing projects with agent-optimized flags. Use when the user wants to
+  run a TypeScript file with `bun run` or `bunx`, use watch/hot reload during
+  development, configure `bun test` in detail, bundle or compile to a
+  standalone executable, or scaffold a new Bun project. Triggers: "run this
+  with bun", "bun watch dev", "configure bun test", "compile to exe",
+  "bun init a react app".
 user-invocable: false
 allowed-tools: Bash, BashOutput, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2025-12-20
-modified: 2025-12-20
+modified: 2026-04-19
 reviewed: 2025-12-20
 ---
 

--- a/typescript-plugin/skills/bun-install/SKILL.md
+++ b/typescript-plugin/skills/bun-install/SKILL.md
@@ -1,10 +1,15 @@
 ---
-description: Install dependencies with Bun package manager
+description: |
+  Install all dependencies from package.json using Bun. Use when the user wants
+  to bootstrap a fresh checkout with `bun install`, run a reproducible CI
+  install with `--frozen-lockfile`, or prepare a production deployment with
+  `--production` (no devDependencies). Triggers: "install deps", "bun install",
+  "restore node_modules", "CI install", "production install".
 args: "[--frozen-lockfile] [--production]"
 argument-hint: "--frozen-lockfile for CI, --production for deployment"
 allowed-tools: Bash, Read
 created: 2025-12-20
-modified: 2026-02-03
+modified: 2026-04-19
 reviewed: 2025-12-20
 name: bun-install
 ---

--- a/typescript-plugin/skills/bun-outdated/SKILL.md
+++ b/typescript-plugin/skills/bun-outdated/SKILL.md
@@ -1,10 +1,15 @@
 ---
-description: Check for outdated dependencies
+description: |
+  Check which project dependencies have newer versions available using `bun
+  outdated`. Use when the user wants to audit dependency freshness, spot major
+  version updates before upgrading, decide between `bun update` (in-range) and
+  `bun update --latest`, or review a single package. Triggers: "check outdated",
+  "what can be upgraded", "show newer versions", "review dependency updates".
 args: "[package]"
 argument-hint: "Optional package name to check specific dependency"
 allowed-tools: Bash, Read
 created: 2025-12-20
-modified: 2026-02-03
+modified: 2026-04-19
 reviewed: 2025-12-20
 name: bun-outdated
 ---

--- a/typescript-plugin/skills/bun-package-manager/skill.md
+++ b/typescript-plugin/skills/bun-package-manager/skill.md
@@ -1,10 +1,17 @@
 ---
 name: bun-package-manager
-description: Fast JavaScript package management with Bun - install, add, remove, update dependencies with optimized CLI flags for agentic workflows.
+description: |
+  Fast JavaScript package management with Bun - install, add, remove, and
+  update dependencies. Use when the user wants to install all project
+  dependencies, add or remove packages, run `bun update` or `bun outdated`,
+  manage workspace dependencies across a monorepo, produce a reproducible CI
+  install with `--frozen-lockfile`, or debug lockfile conflicts. Triggers:
+  "install dependencies", "update packages", "check outdated", "add to
+  workspace", "frozen lockfile for CI".
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob, TodoWrite
 created: 2025-12-20
-modified: 2025-12-20
+modified: 2026-04-19
 reviewed: 2025-12-20
 ---
 

--- a/typescript-plugin/skills/bun-publish/SKILL.md
+++ b/typescript-plugin/skills/bun-publish/SKILL.md
@@ -1,11 +1,16 @@
 ---
-description: Publish package to npm with Bun build
+description: |
+  Publish a package to the npm registry after building with Bun. Use when the
+  user wants to release to npm, preview a publish with `--dry-run`, publish a
+  scoped package with `--access public`, or enable supply chain `--provenance`
+  signing. Triggers: "publish to npm", "release this package", "npm publish
+  dry run", "publish scoped package with provenance".
 args: [--dry-run] [--access <level>] [--provenance]
 allowed-tools: Bash, Read
 argument-hint: [--dry-run] [--access public]
 disable-model-invocation: true
 created: 2025-12-21
-modified: 2025-12-21
+modified: 2026-04-19
 reviewed: 2025-12-21
 name: bun-publish
 ---

--- a/typescript-plugin/skills/bun-publishing/skill.md
+++ b/typescript-plugin/skills/bun-publishing/skill.md
@@ -1,10 +1,17 @@
 ---
 name: bun-publishing
-description: Publish packages to npm with Bun - package.json configuration, CLI packaging, provenance signing, and release automation.
+description: |
+  Publish npm packages built with Bun, including package.json configuration,
+  CLI tool packaging, provenance signing, and release automation. Use when the
+  user wants to set up `publishConfig`/`files`/`bin` for npm, package a CLI
+  tool with an executable entry, enable `npm publish --provenance`, validate
+  tarball contents with `npm pack --dry-run`, or wire up release-please for
+  automated versioning. Triggers: "publish to npm", "set up release-please",
+  "configure package.json for publishing", "add provenance signing".
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2025-12-21
-modified: 2025-12-21
+modified: 2026-04-19
 reviewed: 2025-12-21
 ---
 

--- a/typescript-plugin/skills/bun-test/SKILL.md
+++ b/typescript-plugin/skills/bun-test/SKILL.md
@@ -1,10 +1,15 @@
 ---
-description: Run tests with Bun test runner
+description: |
+  Run tests using Bun's built-in test runner with compact, agent-friendly
+  output. Use when the user wants to run bun tests, target a specific file or
+  name pattern, collect coverage with `--coverage`, enable watch mode during
+  development, or emit JUnit XML for CI. Triggers: "run bun tests", "test this
+  file", "run tests with coverage", "watch tests", "CI test output".
 args: [pattern] [--coverage] [--bail] [--watch]
 allowed-tools: Bash, BashOutput, Read
 argument-hint: [test-pattern] [--coverage] [--bail] [--watch]
 created: 2025-12-20
-modified: 2025-12-20
+modified: 2026-04-19
 reviewed: 2025-12-20
 name: bun-test
 ---

--- a/typescript-plugin/skills/typescript-debugging/skill.md
+++ b/typescript-plugin/skills/typescript-debugging/skill.md
@@ -1,10 +1,18 @@
 ---
 name: typescript-debugging
-description: Modern TypeScript/JavaScript debugging with Bun - inspector flags, web debugger, VSCode integration, memory profiling, and heap analysis.
+description: |
+  Modern TypeScript/JavaScript debugging with the Bun runtime - inspector
+  flags, the debug.bun.sh web debugger, VSCode `launch.json` integration,
+  memory profiling, and heap analysis. Use when the user wants to set up
+  interactive debugging, investigate a memory leak with heap snapshots, CPU
+  profile with `--cpu-prof`, debug network requests via
+  `BUN_CONFIG_VERBOSE_FETCH`, or configure sourcemaps so stack traces show
+  original TypeScript. Triggers: "debug this", "find the memory leak",
+  "profile CPU", "set up launch.json for bun".
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2026-01-22
-modified: 2026-01-22
+modified: 2026-04-19
 reviewed: 2026-01-22
 ---
 

--- a/typescript-plugin/skills/typescript-sentry/skill.md
+++ b/typescript-plugin/skills/typescript-sentry/skill.md
@@ -1,10 +1,18 @@
 ---
 name: typescript-sentry
-description: Error monitoring and performance tracking with Sentry SDK - error capture, breadcrumbs, performance spans, cron monitoring, source maps, structured logging, profiling, and enrichment helpers for Bun/Node.js/Next.js.
+description: |
+  Error monitoring and performance tracking with the Sentry SDK for
+  Bun/Node.js/Next.js - error capture, breadcrumbs, performance spans, cron
+  monitoring, source maps, structured logging, profiling, and enrichment
+  helpers. Use when the user wants to add Sentry to a project, instrument
+  performance spans or cron check-ins with `withMonitor`, upload source maps
+  so traces show TypeScript, filter events via `beforeSend`, or configure
+  session replay/profiling. Triggers: "add Sentry", "capture this error",
+  "monitor this cron job", "upload sourcemaps to Sentry".
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2026-01-22
-modified: 2026-03-27
+modified: 2026-04-19
 reviewed: 2026-01-22
 ---
 


### PR DESCRIPTION
## Summary

Most skills in this repo had descriptions that described WHAT the skill did but not WHEN to use it. Claude picks a skill for auto-invocation by matching the `description` field against user intent, so descriptions without a "Use when..." trigger clause almost never fire without an explicit `/plugin:skill` invocation. At baseline, **133 of 325 skills (41%)** were silently invisible to auto-invocation.

This PR addresses the problem in three layers:

1. **Audit tool** — `scripts/audit-skill-descriptions.py` classifies every `SKILL.md` into `MISSING` / `EMPTY` / `NO_TRIGGER` / `OK`, with per-plugin breakdown, filters, JSON output, and `--strict` / `--strict-all` modes. Uses PyYAML with a regex fallback for files whose frontmatter has unquoted brackets in `argument-hint`.

2. **Rewrites** — every offending skill description now carries a "Use when..." clause with concrete scenarios mined from the skill's existing body (usually its `## When to Use This Skill` table) plus natural trigger phrases a user would actually say. Bodies are unchanged; only `description:` and `modified:` were touched.

3. **CI enforcement** — `plugin-compliance-check.sh` now reports a `Descriptions` column on PRs, and the pre-commit hook runs `audit-skill-descriptions.py --strict-all` so no new auto-invokable skill can land without a trigger clause. The `.claude/rules/regression-testing.md` rule is updated with the new routing and known-regression entry.

## Result

**325/325 skills OK (100%)** across 38 plugins, up from 192/325 (59%) at baseline. 0 MISSING, 0 EMPTY, 0 NO_TRIGGER.

| Plugin | Before → After |
|--------|---------------|
| configure-plugin | 12/45 → 45/45 |
| blueprint-plugin | 5/32 → 32/32 |
| typescript-plugin | 5/17 → 17/17 |
| code-quality-plugin | 9/17 → 17/17 |
| git-plugin | 25/33 → 33/33 |
| testing-plugin | 8/16 → 16/16 |
| obsidian-plugin | 6/13 → 13/13 |
| …and 31 other plugins | all now 100% |

## Test plan

- [x] `python3 scripts/audit-skill-descriptions.py` → 325/325 OK
- [x] `python3 scripts/audit-skill-descriptions.py --strict-all` → exit 0
- [x] `bash scripts/plugin-compliance-check.sh <plugin>` → new `Descriptions` column shows ✅ for every plugin in the compliance bot's PR comments
- [ ] `pre-commit run audit-skill-descriptions --all-files` locally (pass)
- [ ] Manual spot-check: load a rewritten skill (e.g. `/configure:linting`) and verify Claude auto-invokes it from a natural prompt like "set up linting for this project"

## Rule alignment

- `.claude/rules/skill-quality.md` — canonical Description Quality pattern (source of truth)
- `.claude/rules/regression-testing.md` — updated routing + known-regression row
- `.claude/rules/skill-development.md` — referenced for the user-invocable skill schema

https://claude.ai/code/session_018HdzLSJuS2cLHWwqoR4gk8