### PR TITLE
feat(git-repo-agent): add new command foundation (genesis + plugin enrollment)

### DIFF
--- a/git-repo-agent/src/git_repo_agent/creator.py
+++ b/git-repo-agent/src/git_repo_agent/creator.py
@@ -1,0 +1,287 @@
+"""Local genesis for ``git-repo-agent new`` (Phase 2 of the plan).
+
+Pure Python — no SDK. Given a ``NewProjectSpec`` this module:
+
+1. Creates the target directory
+2. Runs ``git init -b main``
+3. Renders seed templates (README, .gitignore, initial PRD)
+4. Writes ``.claude/settings.json`` via ``plugin_enroller``
+5. Stages everything and creates a single initial commit on ``main``
+
+Phase 4 (``gh repo create`` + push) is handled separately by the ``new``
+command so dry-run and ``--no-remote`` can short-circuit before touching
+GitHub.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+
+from .plugin_enroller import (
+    select_permissions,
+    select_plugins,
+    write_settings_json,
+)
+
+_TEMPLATES_DIR = Path(__file__).parent / "templates"
+
+# Languages that have a dedicated gitignore fragment. Any other value falls
+# back to the default fragment only.
+_KNOWN_LANGUAGES: frozenset[str] = frozenset(
+    {"python", "typescript", "javascript", "rust", "go"}
+)
+
+
+@dataclass(frozen=True)
+class NewProjectSpec:
+    """Parsed intent for a new project.
+
+    In PR 1 this is populated from explicit CLI flags. PR 2 adds an
+    ``intent.py`` parser that derives it from a natural-language idea.
+    """
+
+    name: str                        # human-readable display name
+    slug: str                        # directory / repo name (kebab-case)
+    description: str                 # 1-line summary for README + gh repo create
+    idea: str                        # original idea string
+    language: str                    # "python" | "typescript" | ... | "default"
+    stack_indicators: tuple[str, ...]  # e.g. ("python", "github-actions")
+    extra_plugins: tuple[str, ...] = ()
+
+
+@dataclass
+class GenesisResult:
+    path: Path
+    plugins: list[str]
+    permissions: list[str]
+    commit_sha: str | None
+    dry_run: bool
+    files_written: list[Path] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Name / slug utilities
+# ---------------------------------------------------------------------------
+
+_SLUG_STRIP = re.compile(r"[^a-z0-9-]+")
+_SLUG_SQUEEZE = re.compile(r"-+")
+
+
+def slugify(text: str) -> str:
+    """Return a kebab-case slug safe for use as a directory and gh repo name.
+
+    Lowercases, replaces whitespace / underscores with dashes, and strips
+    any remaining non-``[a-z0-9-]`` characters. Collapses repeated dashes
+    and trims leading / trailing dashes.
+
+    >>> slugify("Telegram Chat Bot")
+    'telegram-chat-bot'
+    >>> slugify("My_App v2!")
+    'my-app-v2'
+    """
+    if not text:
+        raise ValueError("slugify() requires a non-empty string")
+    lowered = text.strip().lower()
+    # Replace whitespace and underscores with dashes before stripping.
+    lowered = re.sub(r"[\s_]+", "-", lowered)
+    slug = _SLUG_STRIP.sub("", lowered)
+    slug = _SLUG_SQUEEZE.sub("-", slug).strip("-")
+    if not slug:
+        raise ValueError(f"could not derive a slug from {text!r}")
+    return slug
+
+
+# ---------------------------------------------------------------------------
+# Template rendering
+# ---------------------------------------------------------------------------
+
+
+def _load_template(name: str) -> str:
+    return (_TEMPLATES_DIR / name).read_text(encoding="utf-8")
+
+
+def _render_template(name: str, /, **vars: str) -> str:
+    """Render a ``templates/<name>`` file with ``str.format`` substitutions."""
+    return _load_template(name).format(**vars)
+
+
+def _render_gitignore(language: str) -> str:
+    """Compose a .gitignore from the language fragment + default block."""
+    parts: list[str] = []
+    if language in _KNOWN_LANGUAGES:
+        parts.append(_load_template(f"gitignore-{language}.tmpl").rstrip() + "\n")
+    parts.append(_load_template("gitignore-default.tmpl").rstrip() + "\n")
+    return "\n".join(parts)
+
+
+def _render_readme(spec: NewProjectSpec) -> str:
+    return _render_template(
+        "README.md.tmpl",
+        name=spec.name,
+        description=spec.description,
+    )
+
+
+def _render_prd(spec: NewProjectSpec, *, today: date | None = None) -> str:
+    today = today or date.today()
+    indicators = ", ".join(spec.stack_indicators) or "(none)"
+    return _render_template(
+        "prd-0001.md.tmpl",
+        name=spec.name,
+        idea=spec.idea,
+        description=spec.description,
+        language=spec.language,
+        stack_indicators=indicators,
+        initial_date=today.isoformat(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Genesis
+# ---------------------------------------------------------------------------
+
+
+def _run_git(args: list[str], *, cwd: Path) -> subprocess.CompletedProcess:
+    """Run a git subcommand, capturing output, raising on non-zero exit.
+
+    Helper so subprocess calls in tests can be mocked in one place.
+    """
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def create_repo(
+    *,
+    spec: NewProjectSpec,
+    parent_dir: Path,
+    dry_run: bool = False,
+    commit_message: str | None = None,
+) -> GenesisResult:
+    """Run the local-genesis pipeline.
+
+    Side effects (unless ``dry_run=True``):
+
+    - Creates ``<parent_dir>/<spec.slug>/``
+    - ``git init -b main`` inside it
+    - Writes README, .gitignore, docs/prds/0001-project-goal.md,
+      .claude/settings.json
+    - Stages all tracked files and creates a single initial commit on main
+    """
+    if not parent_dir.is_dir():
+        raise FileNotFoundError(f"parent directory does not exist: {parent_dir}")
+
+    target = parent_dir / spec.slug
+    plugins = select_plugins(spec.stack_indicators, extra_plugins=spec.extra_plugins)
+    permissions = select_permissions(spec.stack_indicators)
+
+    if dry_run:
+        return GenesisResult(
+            path=target,
+            plugins=plugins,
+            permissions=permissions,
+            commit_sha=None,
+            dry_run=True,
+        )
+
+    if target.exists():
+        raise FileExistsError(f"target directory already exists: {target}")
+
+    target.mkdir(parents=True)
+    _run_git(["init", "-b", "main"], cwd=target)
+
+    files_written: list[Path] = []
+    files_written.append(_write(target / "README.md", _render_readme(spec)))
+    files_written.append(_write(target / ".gitignore", _render_gitignore(spec.language)))
+    prd_path = target / "docs" / "prds" / "0001-project-goal.md"
+    files_written.append(_write(prd_path, _render_prd(spec)))
+    files_written.append(
+        write_settings_json(target, plugins, permissions)
+    )
+
+    _run_git(["add", "-A"], cwd=target)
+    message = commit_message or f"chore: initialize {spec.slug}"
+    _run_git(["commit", "-m", message], cwd=target)
+    sha = _run_git(["rev-parse", "HEAD"], cwd=target).stdout.strip()
+
+    return GenesisResult(
+        path=target,
+        plugins=plugins,
+        permissions=permissions,
+        commit_sha=sha,
+        dry_run=False,
+        files_written=files_written,
+    )
+
+
+def _write(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Remote push (Phase 4)
+# ---------------------------------------------------------------------------
+
+
+def gh_repo_create(
+    *,
+    repo_path: Path,
+    owner: str | None,
+    slug: str,
+    description: str,
+    visibility: str = "private",
+) -> str:
+    """Run ``gh repo create ... --source=. --push``.
+
+    Returns the created repo's URL on stdout. Raises ``CalledProcessError``
+    if ``gh`` is not authenticated or the repo name is already taken.
+    """
+    target = f"{owner}/{slug}" if owner else slug
+    result = subprocess.run(
+        [
+            "gh", "repo", "create", target,
+            "--source", str(repo_path),
+            "--push",
+            f"--{visibility}",
+            "--description", description,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    # gh prints the HTTPS URL on stdout; may contain trailing whitespace.
+    return result.stdout.strip()
+
+
+def gh_current_user(default: str | None = None) -> str | None:
+    """Return the authenticated gh user login, or ``default`` if unauth'd."""
+    try:
+        result = subprocess.run(
+            ["gh", "api", "user", "--jq", ".login"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return default
+    return result.stdout.strip() or default
+
+
+__all__ = [
+    "GenesisResult",
+    "NewProjectSpec",
+    "create_repo",
+    "gh_current_user",
+    "gh_repo_create",
+    "slugify",
+]

--- a/git-repo-agent/src/git_repo_agent/main.py
+++ b/git-repo-agent/src/git_repo_agent/main.py
@@ -155,7 +155,7 @@ def onboard(
         help="Output format: text, json, plain. Default: plain when not a TTY.",
     ),
 ) -> None:
-    """Onboard a repository with blueprint structure and standards."""
+    """Bootstrap a repository: scaffold blueprint files, CI workflows, and standards, then commit on a setup branch and (per --auto-pr) open a PR."""
     repo_path = Path(repo).resolve()
     if not repo_path.is_dir():
         console.print(f"[red]Error:[/red] {repo_path} is not a directory")
@@ -236,7 +236,7 @@ def maintain(
         help="Output format: text, json, plain. Default: plain when not a TTY.",
     ),
 ) -> None:
-    """Run maintenance checks and optionally fix issues."""
+    """Scan the repo for maintenance issues (docs, tests, security, etc.). With --fix, applies fixes on a branch and (per --auto-pr) opens a PR; with --report-only, writes findings without code changes."""
     repo_path = Path(repo).resolve()
     if not repo_path.is_dir():
         console.print(f"[red]Error:[/red] {repo_path} is not a directory")
@@ -323,7 +323,7 @@ def diagnose(
         help="Output format: text, json, plain. Default: plain when not a TTY.",
     ),
 ) -> None:
-    """Diagnose pipeline failures and optionally create a GitHub issue."""
+    """Collect diagnostics from CI/CD, Kubernetes, ArgoCD, and package sources for recent failures; with --create-issue (and per --auto-issues), opens a GitHub issue aggregating the findings."""
     repo_path = Path(repo).resolve()
     if not repo_path.is_dir():
         console.print(f"[red]Error:[/red] {repo_path} is not a directory")
@@ -431,7 +431,7 @@ def route(
     dry_run: bool = typer.Option(
         False,
         "--dry-run",
-        help="Show routing plan without executing.",
+        help="Print the routing plan and exit without running maintain --fix.",
     ),
     focus: Optional[str] = typer.Option(
         None,
@@ -444,7 +444,16 @@ def route(
         help="Minimum severity threshold: critical, high, medium, low.",
     ),
 ) -> None:
-    """Route to agents based on attribute analysis."""
+    """Analyze repo health attributes and run maintenance fixes on the highest-priority issues.
+
+    Collects structured health attributes, ranks them by severity (respecting
+    --min-severity and --focus), prints the routing plan, and then runs
+    `maintain --fix` scoped to those priorities. Use --dry-run to only print
+    the plan without modifying the repository.
+
+    Side effects (unless --dry-run): may modify files, create a branch, commit,
+    and — per --auto-pr policy inherited by maintain — open a pull request.
+    """
     repo_path = Path(repo).resolve()
     if not repo_path.is_dir():
         console.print(f"[red]Error:[/red] {repo_path} is not a directory")

--- a/git-repo-agent/src/git_repo_agent/main.py
+++ b/git-repo-agent/src/git_repo_agent/main.py
@@ -100,6 +100,195 @@ def _dispatch(coro) -> None:
     raise typer.Exit(code=EXIT_SUCCESS)
 
 
+_VALID_LANGUAGES: tuple[str, ...] = (
+    "python", "typescript", "javascript", "rust", "go", "default",
+)
+_VALID_VISIBILITIES: tuple[str, ...] = ("private", "public")
+
+
+def _parse_csv(value: Optional[str]) -> tuple[str, ...]:
+    if not value:
+        return ()
+    return tuple(part.strip() for part in value.split(",") if part.strip())
+
+
+def _print_new_plan(result, *, spec, remote_target: str | None) -> None:
+    """Pretty-print the final summary after ``new`` completes (or dry-runs)."""
+    console.print()
+    console.print(f"[bold]Repo created:[/bold] {remote_target or '(local only)'}")
+    console.print(f"[bold]Local path:[/bold]   {result.path}")
+    console.print(f"[bold]Marketplace:[/bold]  laurigates/claude-plugins")
+    plugin_lines = ", ".join(result.plugins)
+    console.print(f"[bold]Plugins:[/bold]      {plugin_lines}")
+    if spec.stack_indicators:
+        console.print(
+            f"[bold]Indicators:[/bold]   {', '.join(spec.stack_indicators)}"
+        )
+    if result.dry_run:
+        console.print("[yellow]DRY RUN — no filesystem changes were made[/yellow]")
+    else:
+        console.print(f"[dim]Next:         cd {result.path} && claude[/dim]")
+
+
+@app.command()
+def new(
+    idea: str = typer.Argument(
+        ...,
+        help="Short description of what you want to build (1-2 sentences).",
+    ),
+    name: str = typer.Option(
+        ...,
+        "--name",
+        help="Human-readable project name; also drives the directory / repo slug.",
+    ),
+    language: str = typer.Option(
+        "default",
+        "--language",
+        help=(
+            "Primary language: python | typescript | javascript | rust | go | default."
+        ),
+    ),
+    stack_indicators: Optional[str] = typer.Option(
+        None,
+        "--stack-indicators",
+        help=(
+            "Comma-separated extra stack indicators (e.g. 'docker,github-actions'). "
+            "Merged with --language to pick plugins."
+        ),
+    ),
+    description: Optional[str] = typer.Option(
+        None,
+        "--description",
+        help="Short description (defaults to the idea argument).",
+    ),
+    owner: Optional[str] = typer.Option(
+        None,
+        "--owner",
+        help="GitHub owner for `gh repo create` (defaults to current gh user).",
+    ),
+    visibility: str = typer.Option(
+        "private",
+        "--visibility",
+        help="GitHub visibility: private or public.",
+    ),
+    parent_dir: str = typer.Option(
+        ".",
+        "--parent-dir",
+        help="Directory in which to create the new repo (default: current dir).",
+    ),
+    no_remote: bool = typer.Option(
+        False,
+        "--no-remote",
+        help="Skip `gh repo create`; keep the repo local-only.",
+    ),
+    extra_plugins: Optional[str] = typer.Option(
+        None,
+        "--extra-plugins",
+        help="Comma-separated plugins to enable beyond stack-recommended defaults.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Print the plan and exit without creating any files.",
+    ),
+) -> None:
+    """Create a new repository from an idea: genesis + plugin enrollment + (optionally) gh repo create.
+
+    This is the foundation (PR 1) of ``git-repo-agent new``: it performs
+    local genesis and writes ``.claude/settings.json`` with the right
+    marketplace + plugin list for the detected stack. Intent parsing and
+    blueprint-init scaffolding land in follow-up PRs.
+    """
+    from pathlib import Path
+
+    from .creator import (
+        NewProjectSpec,
+        create_repo,
+        gh_current_user,
+        gh_repo_create,
+        slugify,
+    )
+
+    if language not in _VALID_LANGUAGES:
+        console.print(
+            f"[red]Error:[/red] --language must be one of {list(_VALID_LANGUAGES)}, "
+            f"got {language!r}"
+        )
+        raise typer.Exit(code=EXIT_CONFIG_ERROR)
+    if visibility not in _VALID_VISIBILITIES:
+        console.print(
+            f"[red]Error:[/red] --visibility must be one of "
+            f"{list(_VALID_VISIBILITIES)}, got {visibility!r}"
+        )
+        raise typer.Exit(code=EXIT_CONFIG_ERROR)
+
+    parent = Path(parent_dir).resolve()
+    if not parent.is_dir():
+        console.print(f"[red]Error:[/red] --parent-dir is not a directory: {parent}")
+        raise typer.Exit(code=EXIT_CONFIG_ERROR)
+
+    try:
+        slug = slugify(name)
+    except ValueError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(code=EXIT_CONFIG_ERROR)
+
+    # Build the stack-indicator set. The language is itself an indicator
+    # when it isn't "default"; any extra indicators from --stack-indicators
+    # are merged on top (deduplicated, order-preserving).
+    indicators: list[str] = []
+    if language != "default":
+        indicators.append(language)
+    for extra in _parse_csv(stack_indicators):
+        if extra not in indicators:
+            indicators.append(extra)
+
+    spec = NewProjectSpec(
+        name=name,
+        slug=slug,
+        description=description or idea,
+        idea=idea,
+        language=language,
+        stack_indicators=tuple(indicators),
+        extra_plugins=_parse_csv(extra_plugins),
+    )
+
+    try:
+        result = create_repo(spec=spec, parent_dir=parent, dry_run=dry_run)
+    except FileExistsError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(code=EXIT_CONFIG_ERROR)
+    except FileNotFoundError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(code=EXIT_CONFIG_ERROR)
+
+    remote_target: str | None = None
+    if not dry_run and not no_remote:
+        repo_owner = owner or gh_current_user()
+        if not repo_owner:
+            console.print(
+                "[yellow]Warning:[/yellow] could not determine gh user for "
+                "`gh repo create`. Pass --owner or --no-remote. Skipping remote."
+            )
+        else:
+            try:
+                remote_target = gh_repo_create(
+                    repo_path=result.path,
+                    owner=repo_owner,
+                    slug=spec.slug,
+                    description=spec.description,
+                    visibility=visibility,
+                )
+            except Exception as exc:  # subprocess.CalledProcessError / FileNotFoundError
+                console.print(
+                    f"[red]Failed to create GitHub repo:[/red] {exc}. "
+                    f"Local repo preserved at {result.path}."
+                )
+                raise typer.Exit(code=EXIT_RUNTIME_ERROR)
+
+    _print_new_plan(result, spec=spec, remote_target=remote_target)
+
+
 @app.command()
 def onboard(
     repo: str = typer.Argument(

--- a/git-repo-agent/src/git_repo_agent/plugin_enroller.py
+++ b/git-repo-agent/src/git_repo_agent/plugin_enroller.py
@@ -1,0 +1,254 @@
+"""Plugin-enrollment logic for ``git-repo-agent new``.
+
+Writes ``.claude/settings.json`` with:
+
+- ``extraKnownMarketplaces.claude-plugins`` — enrolls the laurigates/claude-plugins
+  marketplace so the repo's first Claude Code session already sees it
+- ``enabledPlugins`` — stack-appropriate plugins pre-enabled
+- ``permissions.allow`` — common baseline + stack-specific Bash patterns
+
+The stack-indicator → plugin mapping is the source of truth for non-interactive
+(pre-Claude-session) plugin selection. It mirrors
+``configure-plugin/skills/configure-claude-plugins/SKILL.md`` — see the drift
+test in ``tests/test_plugin_enroller.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Mapping, MutableMapping
+
+
+MARKETPLACE_KEY = "claude-plugins"
+MARKETPLACE_REPO = "laurigates/claude-plugins"
+
+
+# Always enabled regardless of detected stack. Extends SKILL.md's
+# "configure-plugin, health-plugin, hooks-plugin" baseline with two more
+# plugins that `new` repos consistently benefit from:
+#   - blueprint-plugin: the repo gets a PRD on day one
+#   - tools-plugin: covers jq/rg/fd which the agent uses during onboarding
+ALWAYS_ON_PLUGINS: tuple[str, ...] = (
+    "configure-plugin",
+    "health-plugin",
+    "hooks-plugin",
+    "blueprint-plugin",
+    "tools-plugin",
+)
+
+# Per stack-indicator additions. Keep in sync with the "Recommended Plugins"
+# table in configure-plugin/skills/configure-claude-plugins/SKILL.md (Step 2).
+STACK_PLUGINS: Mapping[str, tuple[str, ...]] = {
+    "python": (
+        "python-plugin",
+        "testing-plugin",
+        "code-quality-plugin",
+        "git-plugin",
+    ),
+    "typescript": (
+        "typescript-plugin",
+        "testing-plugin",
+        "code-quality-plugin",
+        "git-plugin",
+    ),
+    "javascript": (
+        "typescript-plugin",
+        "testing-plugin",
+        "code-quality-plugin",
+        "git-plugin",
+    ),
+    "rust": (
+        "rust-plugin",
+        "testing-plugin",
+        "code-quality-plugin",
+        "git-plugin",
+    ),
+    "docker": ("container-plugin",),
+    "github-actions": ("github-actions-plugin",),
+    "esp-idf": (
+        "code-quality-plugin",
+        "testing-plugin",
+        "container-plugin",
+        "git-plugin",
+    ),
+    "esphome": (
+        "python-plugin",
+        "code-quality-plugin",
+        "git-plugin",
+    ),
+}
+
+
+# Always-present Bash patterns in permissions.allow.
+_COMMON_PERMISSIONS: tuple[str, ...] = (
+    "Bash(git:*)",
+    "Bash(gh:*)",
+    "Bash(pre-commit:*)",
+    "Bash(gitleaks:*)",
+    "Bash(python3:*)",
+)
+
+# Stack-specific permissions, keyed by stack indicator. Mirrors the
+# "Stack-aware permissions.allow baseline" table in SKILL.md.
+_STACK_PERMISSIONS: Mapping[str, tuple[str, ...]] = {
+    "python": (
+        "Bash(uv:*)",
+        "Bash(uvx:*)",
+        "Bash(ruff:*)",
+        "Bash(ty:*)",
+        "Bash(pytest:*)",
+    ),
+    "typescript": (
+        "Bash(npm:*)",
+        "Bash(pnpm:*)",
+        "Bash(bun:*)",
+        "Bash(tsc:*)",
+        "Bash(eslint:*)",
+        "Bash(prettier:*)",
+        "Bash(vitest:*)",
+    ),
+    "javascript": (
+        "Bash(npm:*)",
+        "Bash(pnpm:*)",
+        "Bash(bun:*)",
+        "Bash(eslint:*)",
+        "Bash(prettier:*)",
+        "Bash(vitest:*)",
+    ),
+    "go": (
+        "Bash(go:*)",
+        "Bash(gofmt:*)",
+        "Bash(golangci-lint:*)",
+    ),
+    "rust": (
+        "Bash(cargo:*)",
+        "Bash(rustc:*)",
+        "Bash(clippy:*)",
+        "Bash(rustfmt:*)",
+    ),
+    "docker": (
+        "Bash(docker:*)",
+        "Bash(docker compose:*)",
+    ),
+    "esp-idf": (
+        "Bash(idf.py:*)",
+        "Bash(esptool:*)",
+        "Bash(clang-format:*)",
+        "Bash(cppcheck:*)",
+        "Bash(docker:*)",
+        "Bash(docker compose:*)",
+        "Bash(just:*)",
+        "Bash(make:*)",
+    ),
+    "esphome": (
+        "Bash(esphome:*)",
+        "Bash(uv:*)",
+        "Bash(uvx:*)",
+    ),
+}
+
+
+def select_plugins(
+    stack_indicators: Iterable[str],
+    *,
+    extra_plugins: Iterable[str] = (),
+) -> list[str]:
+    """Compute the enabled-plugin set for a given stack.
+
+    Combines ``ALWAYS_ON_PLUGINS`` with per-indicator additions from
+    ``STACK_PLUGINS`` and any user-supplied ``extra_plugins``, then returns
+    a sorted deduplicated list.
+
+    Unknown stack indicators are silently ignored (callers are expected to
+    validate input separately if they want to warn).
+    """
+    chosen: set[str] = set(ALWAYS_ON_PLUGINS)
+    for indicator in stack_indicators:
+        chosen.update(STACK_PLUGINS.get(indicator, ()))
+    chosen.update(extra_plugins)
+    return sorted(chosen)
+
+
+def select_permissions(stack_indicators: Iterable[str]) -> list[str]:
+    """Compute the permissions.allow list for a given stack.
+
+    Combines the common baseline with per-indicator entries; deduplicated,
+    preserving common-entries-first order.
+    """
+    ordered: list[str] = list(_COMMON_PERMISSIONS)
+    seen: set[str] = set(ordered)
+    for indicator in stack_indicators:
+        for entry in _STACK_PERMISSIONS.get(indicator, ()):
+            if entry not in seen:
+                ordered.append(entry)
+                seen.add(entry)
+    return ordered
+
+
+def build_settings_json(
+    plugins: Iterable[str],
+    permissions: Iterable[str],
+    *,
+    existing: Mapping | None = None,
+) -> dict:
+    """Build the ``.claude/settings.json`` contents.
+
+    If ``existing`` is supplied (a previously parsed settings.json), non-
+    conflicting fields are preserved: ``hooks``, ``env``, and any top-level
+    keys we don't own. For the keys we do manage (``permissions.allow``,
+    ``extraKnownMarketplaces``, ``enabledPlugins``) we merge rather than
+    replace, so a re-run never drops entries the caller added by hand.
+    """
+    out: dict = dict(existing) if existing else {}
+
+    # --- permissions ---------------------------------------------------
+    perms = dict(out.get("permissions") or {})
+    allow = list(perms.get("allow") or [])
+    for entry in permissions:
+        if entry not in allow:
+            allow.append(entry)
+    perms["allow"] = allow
+    out["permissions"] = perms
+
+    # --- extraKnownMarketplaces ---------------------------------------
+    marketplaces = dict(out.get("extraKnownMarketplaces") or {})
+    marketplaces.setdefault(
+        MARKETPLACE_KEY,
+        {
+            "source": {"source": "github", "repo": MARKETPLACE_REPO},
+            "autoUpdate": True,
+        },
+    )
+    out["extraKnownMarketplaces"] = marketplaces
+
+    # --- enabledPlugins -----------------------------------------------
+    enabled: MutableMapping[str, bool] = dict(out.get("enabledPlugins") or {})
+    for plugin in plugins:
+        enabled[f"{plugin}@{MARKETPLACE_KEY}"] = True
+    out["enabledPlugins"] = dict(sorted(enabled.items()))
+
+    return out
+
+
+def write_settings_json(
+    target_dir: Path,
+    plugins: Iterable[str],
+    permissions: Iterable[str],
+) -> Path:
+    """Write (or merge) ``<target_dir>/.claude/settings.json``.
+
+    Returns the path of the written file.
+    """
+    import json
+
+    settings_dir = target_dir / ".claude"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    settings_path = settings_dir / "settings.json"
+
+    existing = None
+    if settings_path.exists():
+        existing = json.loads(settings_path.read_text(encoding="utf-8"))
+
+    data = build_settings_json(plugins, permissions, existing=existing)
+    settings_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return settings_path

--- a/git-repo-agent/src/git_repo_agent/templates/README.md.tmpl
+++ b/git-repo-agent/src/git_repo_agent/templates/README.md.tmpl
@@ -1,0 +1,20 @@
+# {name}
+
+{description}
+
+## Project Goal
+
+See [docs/prds/0001-project-goal.md](docs/prds/0001-project-goal.md) for the
+initial product requirements.
+
+## Getting Started
+
+This repo was bootstrapped by `git-repo-agent new`. Launch a Claude Code session
+from the repo root:
+
+```sh
+claude
+```
+
+The marketplace and plugin list are already configured in
+`.claude/settings.json`, so the session comes up ready for the intended stack.

--- a/git-repo-agent/src/git_repo_agent/templates/gitignore-default.tmpl
+++ b/git-repo-agent/src/git_repo_agent/templates/gitignore-default.tmpl
@@ -1,0 +1,18 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# Editors
+.vscode/
+.idea/
+*.swp
+*~
+
+# Environments
+.env
+.env.local
+.env.*.local
+
+# Claude Code
+.claude/scheduled_tasks.lock
+.claude/worktrees/

--- a/git-repo-agent/src/git_repo_agent/templates/gitignore-go.tmpl
+++ b/git-repo-agent/src/git_repo_agent/templates/gitignore-go.tmpl
@@ -1,0 +1,19 @@
+# Go binaries
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test + coverage
+*.test
+*.out
+coverage.out
+coverage.html
+
+# Vendored deps
+vendor/
+
+# Go workspace
+go.work
+go.work.sum

--- a/git-repo-agent/src/git_repo_agent/templates/gitignore-python.tmpl
+++ b/git-repo-agent/src/git_repo_agent/templates/gitignore-python.tmpl
@@ -1,0 +1,18 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+build/
+dist/
+wheels/
+
+# uv / venv
+.venv/
+venv/
+
+# Type checkers / linters caches
+.mypy_cache/
+.ruff_cache/
+.pytest_cache/
+.ty_cache/

--- a/git-repo-agent/src/git_repo_agent/templates/gitignore-rust.tmpl
+++ b/git-repo-agent/src/git_repo_agent/templates/gitignore-rust.tmpl
@@ -1,0 +1,6 @@
+# Rust
+/target/
+**/*.rs.bk
+
+# If this is a library crate, remove the next line; for binaries keep it committed.
+# Cargo.lock

--- a/git-repo-agent/src/git_repo_agent/templates/gitignore-typescript.tmpl
+++ b/git-repo-agent/src/git_repo_agent/templates/gitignore-typescript.tmpl
@@ -1,0 +1,16 @@
+# Node / TypeScript
+node_modules/
+dist/
+build/
+out/
+.next/
+.turbo/
+
+# Build artifacts
+*.tsbuildinfo
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*

--- a/git-repo-agent/src/git_repo_agent/templates/prd-0001.md.tmpl
+++ b/git-repo-agent/src/git_repo_agent/templates/prd-0001.md.tmpl
@@ -1,0 +1,32 @@
+---
+id: PRD-0001
+status: draft
+created: {initial_date}
+---
+
+# {name} — Project Goal
+
+## Idea
+
+{idea}
+
+## Description
+
+{description}
+
+## Inferred Stack
+
+- Primary language: {language}
+- Stack indicators: {stack_indicators}
+
+## In Scope
+
+- _Populate this section as the project takes shape._
+
+## Out of Scope
+
+- _Populate this section as the project takes shape._
+
+## Open Questions
+
+- _Populate this section as the project takes shape._

--- a/git-repo-agent/tests/test_creator.py
+++ b/git-repo-agent/tests/test_creator.py
@@ -1,0 +1,156 @@
+"""Tests for the local-genesis logic used by ``git-repo-agent new``."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from git_repo_agent.creator import (
+    NewProjectSpec,
+    create_repo,
+    slugify,
+)
+
+
+def _git_available() -> bool:
+    return shutil.which("git") is not None
+
+
+needs_git = pytest.mark.skipif(not _git_available(), reason="git not installed")
+
+
+# ---------------------------------------------------------------------------
+# slugify
+# ---------------------------------------------------------------------------
+
+
+class TestSlugify:
+    def test_basic_conversion(self):
+        assert slugify("Telegram Chat Bot") == "telegram-chat-bot"
+
+    def test_snake_case_becomes_kebab(self):
+        assert slugify("my_cool_project") == "my-cool-project"
+
+    def test_strips_special_chars(self):
+        assert slugify("Hello, World! v2") == "hello-world-v2"
+
+    def test_collapses_dashes(self):
+        assert slugify("a---b  c") == "a-b-c"
+
+    def test_rejects_empty(self):
+        with pytest.raises(ValueError):
+            slugify("")
+
+    def test_rejects_only_specials(self):
+        with pytest.raises(ValueError):
+            slugify("!!!")
+
+
+# ---------------------------------------------------------------------------
+# create_repo — dry run
+# ---------------------------------------------------------------------------
+
+
+def _spec(**over) -> NewProjectSpec:
+    defaults = dict(
+        name="Telegram Chat Bot",
+        slug="telegram-chat-bot",
+        description="Bot that replies to users",
+        idea="Telegram chat bot that replies to user messages",
+        language="python",
+        stack_indicators=("python",),
+        extra_plugins=(),
+    )
+    defaults.update(over)
+    return NewProjectSpec(**defaults)
+
+
+class TestCreateRepoDryRun:
+    def test_dry_run_makes_no_changes(self, tmp_path: Path):
+        result = create_repo(spec=_spec(), parent_dir=tmp_path, dry_run=True)
+        assert result.dry_run is True
+        assert result.commit_sha is None
+        assert result.path == tmp_path / "telegram-chat-bot"
+        assert not result.path.exists()
+        assert "python-plugin" in result.plugins
+        assert "Bash(uv:*)" in result.permissions
+
+    def test_dry_run_with_missing_parent_dir(self, tmp_path: Path):
+        bogus = tmp_path / "does" / "not" / "exist"
+        with pytest.raises(FileNotFoundError):
+            create_repo(spec=_spec(), parent_dir=bogus, dry_run=True)
+
+
+# ---------------------------------------------------------------------------
+# create_repo — full genesis (requires git on PATH)
+# ---------------------------------------------------------------------------
+
+
+@needs_git
+class TestCreateRepoFullGenesis:
+    def test_creates_directory_and_initial_commit(self, tmp_path: Path):
+        result = create_repo(spec=_spec(), parent_dir=tmp_path)
+
+        assert result.path.is_dir()
+        assert (result.path / ".git").is_dir()
+        assert (result.path / "README.md").is_file()
+        assert (result.path / ".gitignore").is_file()
+        assert (result.path / "docs" / "prds" / "0001-project-goal.md").is_file()
+        assert (result.path / ".claude" / "settings.json").is_file()
+
+        assert result.commit_sha is not None
+        assert len(result.commit_sha) == 40
+
+        # Initial commit is on main with expected scope.
+        branch = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=result.path, capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        assert branch == "main"
+
+        log = subprocess.run(
+            ["git", "log", "--format=%s", "-n", "1"],
+            cwd=result.path, capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        assert log.startswith("chore: initialize")
+
+    def test_settings_json_has_marketplace_and_plugins(self, tmp_path: Path):
+        result = create_repo(spec=_spec(), parent_dir=tmp_path)
+        settings = json.loads(
+            (result.path / ".claude" / "settings.json").read_text(encoding="utf-8")
+        )
+        assert "claude-plugins" in settings["extraKnownMarketplaces"]
+        assert (
+            settings["extraKnownMarketplaces"]["claude-plugins"]["source"]["repo"]
+            == "laurigates/claude-plugins"
+        )
+        assert "python-plugin@claude-plugins" in settings["enabledPlugins"]
+        # Always-on baseline survives.
+        assert "configure-plugin@claude-plugins" in settings["enabledPlugins"]
+
+    def test_prd_contains_idea_text(self, tmp_path: Path):
+        result = create_repo(spec=_spec(), parent_dir=tmp_path)
+        prd = (result.path / "docs" / "prds" / "0001-project-goal.md").read_text(
+            encoding="utf-8"
+        )
+        assert "Telegram chat bot that replies to user messages" in prd
+        assert "Primary language: python" in prd
+
+    def test_refuses_to_overwrite_existing_target(self, tmp_path: Path):
+        # Pre-create the target so the second create_repo call must refuse.
+        (tmp_path / "telegram-chat-bot").mkdir()
+        with pytest.raises(FileExistsError):
+            create_repo(spec=_spec(), parent_dir=tmp_path)
+
+    def test_default_language_uses_only_default_gitignore(self, tmp_path: Path):
+        spec = _spec(language="default", stack_indicators=())
+        result = create_repo(spec=spec, parent_dir=tmp_path)
+        gi = (result.path / ".gitignore").read_text(encoding="utf-8")
+        # Default fragment is always present.
+        assert ".DS_Store" in gi
+        # Python fragment is not.
+        assert "__pycache__" not in gi

--- a/git-repo-agent/tests/test_plugin_enroller.py
+++ b/git-repo-agent/tests/test_plugin_enroller.py
@@ -1,0 +1,282 @@
+"""Tests for the plugin-enrollment logic used by ``git-repo-agent new``.
+
+Includes a drift test that parses the ``configure-claude-plugins`` SKILL.md
+table and asserts the Python-side mapping (``STACK_PLUGINS``) matches it
+row-for-row. Update either the Python mapping or SKILL.md whenever one
+changes — they must stay in lockstep.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from git_repo_agent.plugin_enroller import (
+    ALWAYS_ON_PLUGINS,
+    MARKETPLACE_KEY,
+    STACK_PLUGINS,
+    build_settings_json,
+    select_permissions,
+    select_plugins,
+    write_settings_json,
+)
+
+
+# ---------------------------------------------------------------------------
+# select_plugins / select_permissions
+# ---------------------------------------------------------------------------
+
+
+class TestSelectPlugins:
+    def test_no_indicators_returns_always_on(self):
+        result = select_plugins([])
+        assert set(result) == set(ALWAYS_ON_PLUGINS)
+
+    def test_python_adds_stack_plugins(self):
+        result = set(select_plugins(["python"]))
+        assert set(ALWAYS_ON_PLUGINS).issubset(result)
+        assert {"python-plugin", "testing-plugin", "code-quality-plugin", "git-plugin"}.issubset(result)
+
+    def test_multiple_indicators_merge(self):
+        result = set(select_plugins(["python", "docker", "github-actions"]))
+        assert {"python-plugin", "container-plugin", "github-actions-plugin"}.issubset(result)
+
+    def test_extra_plugins_merged_and_deduped(self):
+        result = select_plugins(
+            ["python"],
+            extra_plugins=["python-plugin", "my-custom-plugin"],
+        )
+        # No duplicates even though python-plugin is already selected via the stack.
+        assert result.count("python-plugin") == 1
+        assert "my-custom-plugin" in result
+
+    def test_unknown_indicator_ignored(self):
+        # Unknown indicators don't raise — callers own validation.
+        result = select_plugins(["not-a-real-stack"])
+        assert set(result) == set(ALWAYS_ON_PLUGINS)
+
+    def test_result_is_sorted(self):
+        result = select_plugins(["python", "docker"])
+        assert result == sorted(result)
+
+
+class TestSelectPermissions:
+    def test_common_entries_always_present(self):
+        result = select_permissions([])
+        assert "Bash(git:*)" in result
+        assert "Bash(gh:*)" in result
+        assert "Bash(pre-commit:*)" in result
+
+    def test_python_stack_permissions(self):
+        result = select_permissions(["python"])
+        assert "Bash(uv:*)" in result
+        assert "Bash(ruff:*)" in result
+        assert "Bash(pytest:*)" in result
+
+    def test_typescript_stack_permissions(self):
+        result = select_permissions(["typescript"])
+        assert "Bash(npm:*)" in result
+        assert "Bash(vitest:*)" in result
+
+    def test_permissions_deduplicated(self):
+        # esphome includes uv / uvx; python does too — combined, each should appear once.
+        result = select_permissions(["python", "esphome"])
+        assert result.count("Bash(uv:*)") == 1
+
+
+# ---------------------------------------------------------------------------
+# build_settings_json / write_settings_json
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSettingsJson:
+    def test_fresh_settings(self):
+        plugins = ["python-plugin", "git-plugin"]
+        perms = ["Bash(git:*)", "Bash(uv:*)"]
+        data = build_settings_json(plugins, perms)
+
+        assert data["permissions"]["allow"] == perms
+        assert MARKETPLACE_KEY in data["extraKnownMarketplaces"]
+        assert data["extraKnownMarketplaces"][MARKETPLACE_KEY]["source"] == {
+            "source": "github",
+            "repo": "laurigates/claude-plugins",
+        }
+        assert data["enabledPlugins"] == {
+            "git-plugin@claude-plugins": True,
+            "python-plugin@claude-plugins": True,
+        }
+
+    def test_merges_with_existing(self):
+        existing = {
+            "permissions": {"allow": ["Bash(git:*)", "Bash(custom:*)"]},
+            "enabledPlugins": {"existing-plugin@claude-plugins": True},
+            "hooks": {"SessionStart": []},  # preserved untouched
+            "env": {"MY_VAR": "1"},
+        }
+        data = build_settings_json(
+            plugins=["python-plugin"],
+            permissions=["Bash(git:*)", "Bash(uv:*)"],
+            existing=existing,
+        )
+        # Custom permissions are preserved.
+        assert "Bash(custom:*)" in data["permissions"]["allow"]
+        # New permission is added.
+        assert "Bash(uv:*)" in data["permissions"]["allow"]
+        # No duplicates.
+        assert data["permissions"]["allow"].count("Bash(git:*)") == 1
+        # Previously enabled plugins are preserved.
+        assert data["enabledPlugins"]["existing-plugin@claude-plugins"] is True
+        assert data["enabledPlugins"]["python-plugin@claude-plugins"] is True
+        # Non-managed keys pass through.
+        assert data["hooks"] == {"SessionStart": []}
+        assert data["env"] == {"MY_VAR": "1"}
+
+    def test_preserves_existing_marketplace_entry(self):
+        existing = {
+            "extraKnownMarketplaces": {
+                MARKETPLACE_KEY: {
+                    "source": {"source": "github", "repo": "laurigates/claude-plugins"},
+                    "autoUpdate": False,  # user turned it off
+                }
+            },
+        }
+        data = build_settings_json([], [], existing=existing)
+        # We do not overwrite autoUpdate when the marketplace entry is already present.
+        assert data["extraKnownMarketplaces"][MARKETPLACE_KEY]["autoUpdate"] is False
+
+
+class TestWriteSettingsJson:
+    def test_creates_claude_dir_and_file(self, tmp_path: Path):
+        path = write_settings_json(
+            tmp_path,
+            plugins=["python-plugin"],
+            permissions=["Bash(git:*)"],
+        )
+        assert path == tmp_path / ".claude" / "settings.json"
+        assert path.is_file()
+
+        import json as _json
+        data = _json.loads(path.read_text(encoding="utf-8"))
+        assert data["enabledPlugins"]["python-plugin@claude-plugins"] is True
+
+    def test_merges_when_called_twice(self, tmp_path: Path):
+        # First run: python stack.
+        write_settings_json(tmp_path, ["python-plugin"], ["Bash(git:*)"])
+        # Second run: add a docker indicator's plugin + permission.
+        path = write_settings_json(
+            tmp_path, ["container-plugin"], ["Bash(docker:*)"],
+        )
+        import json as _json
+        data = _json.loads(path.read_text(encoding="utf-8"))
+        # Both plugins should survive.
+        assert "python-plugin@claude-plugins" in data["enabledPlugins"]
+        assert "container-plugin@claude-plugins" in data["enabledPlugins"]
+        # Both permissions should survive.
+        assert "Bash(git:*)" in data["permissions"]["allow"]
+        assert "Bash(docker:*)" in data["permissions"]["allow"]
+
+
+# ---------------------------------------------------------------------------
+# Drift test against configure-claude-plugins/SKILL.md
+# ---------------------------------------------------------------------------
+
+_SKILL_MD_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "configure-plugin"
+    / "skills"
+    / "configure-claude-plugins"
+    / "SKILL.md"
+)
+
+# Maps SKILL.md "Project Indicator" column (lowercased) to the Python-side
+# stack-indicator name in STACK_PLUGINS. ``Default (any)`` is intentionally
+# omitted — the Python code treats the always-on baseline separately.
+_SKILL_INDICATOR_TO_STACK = {
+    "package.json": "typescript",
+    "pyproject.toml / setup.py": "python",
+    "cargo.toml": "rust",
+    "dockerfile": "docker",
+    ".github/workflows/": "github-actions",
+    "idf_component.yml / sdkconfig": "esp-idf",
+    "esphome yaml": "esphome",
+}
+
+
+def _parse_plugins_cell(cell: str) -> set[str]:
+    """Extract ``*-plugin`` names from a markdown table cell.
+
+    Strips ``Above +`` prefix so rows expressed as deltas (Dockerfile,
+    .github/workflows/) compare correctly against the Python table, which
+    stores those same deltas.
+    """
+    cell = cell.replace("Above +", "").strip()
+    return set(re.findall(r"`([a-z0-9-]+-plugin)`", cell))
+
+
+def _parse_skill_table(skill_md: str) -> dict[str, set[str]]:
+    """Return ``{indicator_label_lowercase: {plugin, ...}}`` from SKILL.md.
+
+    Parses the "Project Indicator | Recommended Plugins" table under
+    Step 2. Stops at the first non-table line.
+    """
+    rows: dict[str, set[str]] = {}
+    in_table = False
+    for line in skill_md.splitlines():
+        if "Project Indicator" in line and "Recommended Plugins" in line:
+            in_table = True
+            continue
+        if not in_table:
+            continue
+        if line.startswith("|---") or line.startswith("| ---"):
+            continue
+        if not line.startswith("|"):
+            break
+        parts = [p.strip() for p in line.split("|")[1:-1]]
+        if len(parts) != 2:
+            continue
+        # SKILL.md renders each indicator in its own backticks, e.g.
+        # "`pyproject.toml` / `setup.py`". Strip all backticks and normalise
+        # internal whitespace before lowercasing.
+        indicator = re.sub(r"\s+", " ", parts[0].replace("`", "")).strip().lower()
+        rows[indicator] = _parse_plugins_cell(parts[1])
+    return rows
+
+
+class TestSkillMdDrift:
+    """Fails if the Python stack→plugins mapping drifts from SKILL.md.
+
+    SKILL.md is the user-facing source of truth for plugin selection; this
+    test catches cases where one side is updated and the other is not.
+    """
+
+    @pytest.fixture(scope="class")
+    def skill_rows(self) -> dict[str, set[str]]:
+        assert _SKILL_MD_PATH.is_file(), (
+            f"Expected SKILL.md at {_SKILL_MD_PATH}; monorepo layout changed?"
+        )
+        return _parse_skill_table(_SKILL_MD_PATH.read_text(encoding="utf-8"))
+
+    def test_every_mapped_indicator_parses(self, skill_rows):
+        for indicator in _SKILL_INDICATOR_TO_STACK:
+            assert indicator in skill_rows, (
+                f"SKILL.md table no longer contains row {indicator!r}. "
+                f"Update _SKILL_INDICATOR_TO_STACK in tests."
+            )
+
+    def test_stack_plugins_match_skill_md(self, skill_rows):
+        mismatches: list[str] = []
+        for skill_indicator, stack_name in _SKILL_INDICATOR_TO_STACK.items():
+            skill_plugins = skill_rows[skill_indicator]
+            python_plugins = set(STACK_PLUGINS[stack_name])
+            if skill_plugins != python_plugins:
+                mismatches.append(
+                    f"  {skill_indicator!r} ({stack_name}): "
+                    f"SKILL.md={sorted(skill_plugins)}, "
+                    f"Python={sorted(python_plugins)}"
+                )
+        assert not mismatches, (
+            "Drift between configure-claude-plugins SKILL.md and "
+            "plugin_enroller.STACK_PLUGINS:\n" + "\n".join(mismatches)
+        )


### PR DESCRIPTION
## Summary

First of three PRs implementing \`git-repo-agent new \"<idea>\"\` — one command from idea to interactive-ready repo (see plan in conversation).

This PR is the foundation: it lets you run

\`\`\`sh
git-repo-agent new \"Telegram chat bot that replies to user messages\" \\
  --name \"Telegram Chat Bot\" --language python --stack-indicators github-actions
\`\`\`

and get a freshly-\`git init\`'d directory with README, .gitignore, an initial PRD, and a \`.claude/settings.json\` that already enrolls the \`laurigates/claude-plugins\` marketplace and enables the right plugins for the stack. Optional \`gh repo create --push\` at the end (opt-out with \`--no-remote\`).

## What lands here

| Area | Files |
|------|-------|
| Plugin enrollment (pure Python) | \`plugin_enroller.py\` — stack→plugins mapping + settings.json merge |
| Local genesis | \`creator.py\` — \`git init\`, templates, initial commit |
| Seed templates | \`templates/README.md.tmpl\`, \`prd-0001.md.tmpl\`, \`gitignore-*.tmpl\` |
| CLI | \`main.py\` \`new\` command |
| Tests | \`test_plugin_enroller.py\` (incl. SKILL.md drift test), \`test_creator.py\` |

The drift test parses the markdown table in \`configure-plugin/skills/configure-claude-plugins/SKILL.md\` with a small regex-based parser and asserts the Python-side \`STACK_PLUGINS\` matches row-for-row. If either side drifts, CI fails.

## Deliberately NOT in this PR

- **Intent parsing** (PR 2): for now \`--name\` and \`--language\` must be explicit. PR 2 adds a small Claude SDK one-shot call that derives them from the idea string; if the model is unreachable the command hard-fails rather than falling back (per user preference).
- **Blueprint-init + LLM onboard scaffolding** (PR 3): the plan has the new repo get its blueprint structure on day one. PR 3 wires \`BlueprintDriver\` (init phase only) + \`run_onboard()\` on top of the genesis commit, plus ADR-007.
- **\`create\` / \`init\` aliases**: Typer doesn't support command aliases natively; deferred until the final shape is settled.

## Test plan

- [x] Unit tests: \`uv run pytest\` — 141 passed
- [x] Drift test against SKILL.md passes
- [x] Smoke test: \`git-repo-agent new \"...\" --name ... --language python --parent-dir /tmp/... --no-remote\` → directory with expected files, initial commit on main, valid settings.json
- [x] Dry-run: prints plan without touching fs
- [ ] Real \`gh repo create\` path not verified in CI (requires gh auth); covered by PR 3 dogfood step

🤖 Generated with [Claude Code](https://claude.com/claude-code)