### PR TITLE
feat(git-repo-agent): add blueprint-init phase to new command (+ ADR-007, README)

### DIFF
--- a/git-repo-agent/README.md
+++ b/git-repo-agent/README.md
@@ -18,6 +18,50 @@ pipx install ./git-repo-agent
 
 ## Usage
 
+### Create a New Repository
+
+Go from idea to interactive-ready repo in one shell command:
+
+```bash
+git-repo-agent new "Telegram chat bot that replies to user messages"
+```
+
+This performs, in order:
+
+1. **Intent parsing** — a single Claude SDK call reads the idea and infers
+   the project name, language, and stack indicators.
+2. **Local genesis** — `git init -b main`, seed README / `.gitignore` /
+   initial PRD, plus `.claude/settings.json` that already enrols the
+   `laurigates/claude-plugins` marketplace and enables stack-appropriate
+   plugins.
+3. **`blueprint-init`** — runs the blueprint initialisation phase so the
+   repo has a blueprint layout on day one. Skip with `--skip-blueprint`.
+4. **`gh repo create --push`** — publishes the repo. Skip with
+   `--no-remote`.
+
+By the time the command returns, `cd <repo> && claude` gives you a Claude
+Code session with the right plugins already enabled. See
+[ADR-007](docs/adr/007-new-command-orchestrator.md) for the design
+rationale.
+
+**Overrides for offline / scripted use:**
+
+```bash
+# Skip intent parsing entirely — provide everything explicitly
+git-repo-agent new "..." --name "Telegram Bot" --language python \
+  --stack-indicators github-actions
+
+# Preview without touching disk or the network
+git-repo-agent new "..." --dry-run
+
+# Local-only (no GitHub repo)
+git-repo-agent new "..." --no-remote
+```
+
+See `git-repo-agent new --help` for the full flag list. Use `onboard`
+(below) on existing repositories — `new` is only for bringing a project
+into existence.
+
 ### Onboard a Repository
 
 ```bash

--- a/git-repo-agent/docs/adr/007-new-command-orchestrator.md
+++ b/git-repo-agent/docs/adr/007-new-command-orchestrator.md
@@ -1,0 +1,144 @@
+# ADR-007: `git-repo-agent new` — Pre-Claude-Session Genesis Orchestrator
+
+- **Status:** Accepted
+- **Date:** 2026-04-19
+- **Deciders:** @laurigates
+
+## Context
+
+Before this decision, `git-repo-agent` operated only on existing repositories:
+`onboard`, `maintain`, `diagnose`, `route`. To start a new project the user
+had to manually run `mkdir`, `git init`, populate `.gitignore` / README /
+initial PRD, write `.claude/settings.json` (or rely on `claude` later running
+`/configure:claude-plugins`), then `gh repo create`, then finally `claude`.
+Every step was a chance for inconsistency and lost intent.
+
+The desired workflow is a single shell command:
+
+```sh
+git-repo-agent new "Telegram chat bot that replies to user messages"
+# → creates repo, scaffolds it, enrolls marketplace + stack-appropriate
+#   plugins, pushes to GitHub, and leaves the user one `cd` + `claude`
+#   away from an interactive-ready session.
+```
+
+The friction point that motivated this ADR: **by the time the user runs
+`claude`, the marketplace and plugin list must already be configured.**
+A workflow that requires running `claude` once just to execute
+`/configure:claude-plugins` and then reloading is strictly worse than no
+workflow.
+
+## Decision
+
+Add a top-level `new` command to `git-repo-agent` that orchestrates the
+full pre-Claude-session pipeline in a single process.
+
+### Pipeline
+
+| Phase | Module | Side effects | Failure mode |
+|-------|--------|--------------|--------------|
+| 1. Intent parsing | `intent.py` | SDK one-shot; no filesystem changes | Hard-fail (exit 1). No fallback. |
+| 2. Local genesis | `creator.py` | `mkdir`, `git init -b main`, templates, `.claude/settings.json`, initial commit | Hard-fail (exit 2). |
+| 3. Blueprint init | `blueprint_driver.py` (NEW_PHASES) | SDK session; creates `docs/blueprint/*`, second commit | Soft-fail — warn, continue. |
+| 4. GitHub push | `creator.gh_repo_create` | `gh repo create --source=. --push` | Hard-fail if `--no-remote` wasn't passed. |
+
+Each phase is optional via its own flag (`--name`/`--language` skip Phase 1;
+`--skip-blueprint` skips Phase 3; `--no-remote` skips Phase 4). `--dry-run`
+short-circuits all filesystem and network side effects after reporting the plan.
+
+### Plugin enrollment happens *before* any Claude Code session
+
+`.claude/settings.json` is written in Phase 2 (pure Python — no SDK). It
+includes:
+
+- `extraKnownMarketplaces.claude-plugins` → enrolls the
+  `laurigates/claude-plugins` marketplace so the first `claude` session
+  sees it.
+- `enabledPlugins` → stack-appropriate plugins from
+  `plugin_enroller.STACK_PLUGINS`.
+- `permissions.allow` → common baseline + stack-specific Bash patterns.
+
+The `STACK_PLUGINS` mapping mirrors the "Recommended Plugins" table in
+`configure-plugin/skills/configure-claude-plugins/SKILL.md`, with a drift
+test (`tests/test_plugin_enroller.py::TestSkillMdDrift`) that fails CI if
+either side is updated without the other.
+
+### Why `BlueprintDriver(NEW_PHASES)` instead of the full onboard pipeline
+
+The existing `ONBOARD_PHASES` runs `blueprint-init` followed by
+`derive-prd`, `derive-adr`, `derive-rules`, `derive-tests`, `sync-ids`,
+`adr-validate`, and `feature-tracker-sync`. All the derive-* phases mine
+existing source material (git history, docs, code) that a brand-new repo
+does not have. Running them on a fresh repo would at best produce empty
+artifacts and at worst hallucinate plausible-looking content.
+
+`NEW_PHASES` runs only `blueprint-init` — the one phase that is actually
+useful for a new repo. The seed PRD written in Phase 2
+(`docs/prds/0001-project-goal.md`) registers itself in the blueprint manifest
+during this phase.
+
+Users who want the full derive-* pipeline can run `git-repo-agent onboard`
+on the new repo later. That's intentionally not part of `new` because it
+requires the human to iterate on the seed PRD first.
+
+### Why genesis goes on `main` directly (no worktree)
+
+`run_onboard` uses a worktree on `setup/onboard` so changes stay isolated
+from the user's working state until a PR is merged. That model doesn't
+apply to a fresh repo: there is no prior state to protect, no base branch
+to fast-forward, no PR to open before the repo even has a remote. Genesis
+commits directly to `main`, and subsequent phases (blueprint-init) land as
+their own follow-up commits on the same branch.
+
+This is why `new` deliberately does **not** reuse `run_onboard` — the
+worktree machinery is unnecessary overhead for a fresh repo, and forcing
+`run_onboard` to branch on "is this a new repo" would muddle its contract.
+
+### Why intent parsing hard-fails on SDK unreachability
+
+The primary value of `new` over `mkdir && git init && ...` is
+stack-appropriate plugin enrollment. Without intent parsing the tool would
+either (a) require the user to provide `--name` + `--language` explicitly
+(which defeats the "single command" UX), or (b) produce a default scaffold
+with only the always-on plugins (which is strictly worse than letting the
+user try again later).
+
+The user can still bypass intent parsing by passing `--name` explicitly —
+that's the escape hatch for offline / air-gapped environments.
+
+## Consequences
+
+### Positive
+
+- **One command** from idea to interactive-ready repo.
+- **Plugin enrollment happens pre-session** — the user's first `claude`
+  invocation already sees the right marketplace and plugins.
+- **Each phase is independently testable**: the drift test covers plugin
+  selection, unit tests cover genesis, and the integration test (`cd
+  <repo> && claude`) covers the contract.
+- **Existing commands untouched.** `onboard`, `maintain`, `diagnose`,
+  `route` continue to operate on existing repos exactly as before.
+
+### Negative
+
+- Intent parsing adds a Claude API dependency to a shell command. Users
+  can opt out with `--name` / `--language`.
+- `new` is not idempotent — running it twice against the same `<parent>/<slug>`
+  fails with `FileExistsError`. That's by design; we don't want to
+  silently "resume" an interrupted genesis when the user can diagnose
+  and retry themselves.
+
+### Neutral
+
+- `NEW_PHASES` is a separate registry key under `PHASE_REGISTRIES["new"]`,
+  so the `blueprint` CLI subcommand could expose it later (`git-repo-agent
+  blueprint new <path>`) without extra wiring. No current plans to do so.
+
+## Related
+
+- **ADR-001** — pre-computed context pattern, reused in Phase 3.
+- **ADR-003** — `ClaudeSDKClient` multi-turn pattern, reused in Phase 1.
+- **ADR-006** — `BlueprintDriver` state machine, reused in Phase 3.
+- `configure-plugin/skills/configure-claude-plugins/SKILL.md` — the
+  source-of-truth plugin mapping that `plugin_enroller.STACK_PLUGINS`
+  mirrors.

--- a/git-repo-agent/src/git_repo_agent/blueprint_driver.py
+++ b/git-repo-agent/src/git_repo_agent/blueprint_driver.py
@@ -274,9 +274,30 @@ SCAN_PHASES: tuple[Phase, ...] = (
 )
 
 
+# `git-repo-agent new` runs only the init phase. A freshly created repo has
+# no source material for the derive-* phases to mine, so running them would
+# be noisy at best (ADR-007).
+NEW_PHASES: tuple[Phase, ...] = (
+    Phase(
+        name="init",
+        skill_relpath="blueprint-plugin/skills/blueprint-init/SKILL.md",
+        model="sonnet",
+        invocation=(
+            "Initialize the blueprint structure in this brand-new repository. "
+            "Create the standard layout (`docs/blueprint/` with `prds/`, "
+            "`adrs/`, `rules/`, `manifest.json`, `feature-tracker.md`) using "
+            "the latest format version. A seed PRD already exists at "
+            "`docs/prds/0001-project-goal.md` — register it in the manifest "
+            "rather than regenerating it. Do not ask the user questions."
+        ),
+    ),
+)
+
+
 # Named registries so the CLI can dispatch by mode name.
 PHASE_REGISTRIES: dict[str, tuple[Phase, ...]] = {
     "onboard": ONBOARD_PHASES,
+    "new": NEW_PHASES,
     "status": STATUS_PHASES,
     "upgrade": UPGRADE_PHASES,
     "sync": SYNC_PHASES,

--- a/git-repo-agent/src/git_repo_agent/main.py
+++ b/git-repo-agent/src/git_repo_agent/main.py
@@ -112,6 +112,30 @@ def _parse_csv(value: Optional[str]) -> tuple[str, ...]:
     return tuple(part.strip() for part in value.split(",") if part.strip())
 
 
+def _commit_if_dirty(repo_path: Path, message: str) -> bool:
+    """Stage everything in ``repo_path`` and commit if anything changed.
+
+    Returns ``True`` when a commit was created, ``False`` when the tree
+    was clean. Used by ``new`` to turn post-genesis phases
+    (``blueprint-init`` today; ``run_onboard`` in the future) into their
+    own follow-up commits instead of amending the genesis commit.
+    """
+    import subprocess
+
+    status = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=repo_path, capture_output=True, text=True, check=True,
+    )
+    if not status.stdout.strip():
+        return False
+    subprocess.run(["git", "add", "-A"], cwd=repo_path, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", message],
+        cwd=repo_path, check=True, capture_output=True, text=True,
+    )
+    return True
+
+
 def _print_new_plan(result, *, spec, remote_target: str | None) -> None:
     """Pretty-print the final summary after ``new`` completes (or dry-runs)."""
     console.print()
@@ -184,6 +208,11 @@ def new(
         False,
         "--no-remote",
         help="Skip `gh repo create`; keep the repo local-only.",
+    ),
+    skip_blueprint: bool = typer.Option(
+        False,
+        "--skip-blueprint",
+        help="Skip `blueprint-init` after genesis (faster, but the repo won't have the blueprint layout).",
     ),
     extra_plugins: Optional[str] = typer.Option(
         None,
@@ -291,6 +320,35 @@ def new(
     except FileNotFoundError as exc:
         console.print(f"[red]Error:[/red] {exc}")
         raise typer.Exit(code=EXIT_CONFIG_ERROR)
+
+    # After genesis: run blueprint-init so the repo has a blueprint layout
+    # on day one. We run only the `init` phase (see ADR-007) — the derive-*
+    # phases would have nothing to mine in a brand-new repo.
+    if not dry_run and not skip_blueprint:
+        from .blueprint_driver import (
+            BlueprintDriver,
+            DriverOptions,
+            NEW_PHASES,
+        )
+
+        console.print("[dim]Running blueprint-init...[/dim]")
+        driver = BlueprintDriver(
+            result.path,
+            DriverOptions(dry_run=False, non_interactive=True),
+        )
+        driver_result = asyncio.run(driver.run(NEW_PHASES))
+        if not driver_result.succeeded:
+            failed = [p.name for p in driver_result.phases if p.status == "error"]
+            console.print(
+                f"[yellow]blueprint-init had failures: {failed}. "
+                "Continuing — the repo is usable without it.[/yellow]"
+            )
+        # If blueprint-init wrote anything, capture it as a second commit so
+        # the genesis commit stays focused on scaffolding the user asked for.
+        _commit_if_dirty(
+            result.path,
+            message="chore: initialize blueprint layout",
+        )
 
     remote_target: str | None = None
     if not dry_run and not no_remote:

--- a/git-repo-agent/tests/test_blueprint_driver.py
+++ b/git-repo-agent/tests/test_blueprint_driver.py
@@ -171,6 +171,7 @@ class TestLifecycleRegistries:
     def test_registries_are_registered_under_expected_keys(self):
         assert set(PHASE_REGISTRIES) == {
             "onboard",
+            "new",
             "status",
             "upgrade",
             "sync",

--- a/git-repo-agent/tests/test_new_command.py
+++ b/git-repo-agent/tests/test_new_command.py
@@ -1,0 +1,129 @@
+"""End-to-end tests for the ``git-repo-agent new`` CLI command.
+
+These exercise the command through Typer's ``CliRunner`` so flag parsing,
+validation, and the spec-building pipeline are covered together. Tests
+either use ``--dry-run`` (no filesystem or network side effects) or
+point at ``tmp_path`` with ``--skip-blueprint --no-remote`` so the only
+side effect is a local repo that the tmpdir fixture cleans up.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from git_repo_agent.main import app
+
+
+runner = CliRunner()
+
+
+class TestNewDryRun:
+    def test_prints_plan_without_side_effects(self, tmp_path: Path):
+        result = runner.invoke(
+            app,
+            [
+                "new", "Just an idea",
+                "--name", "My Cool Project",
+                "--language", "python",
+                "--stack-indicators", "github-actions",
+                "--parent-dir", str(tmp_path),
+                "--no-remote",
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "DRY RUN" in result.output
+        assert "python-plugin" in result.output
+        assert "github-actions-plugin" in result.output
+        # No directory was actually created.
+        assert not (tmp_path / "my-cool-project").exists()
+
+    def test_unknown_language_rejected(self, tmp_path: Path):
+        result = runner.invoke(
+            app,
+            [
+                "new", "idea",
+                "--name", "x",
+                "--language", "cobol",
+                "--parent-dir", str(tmp_path),
+                "--no-remote", "--dry-run",
+            ],
+        )
+        assert result.exit_code == 2
+        assert "--language" in result.output
+
+    def test_unknown_visibility_rejected(self, tmp_path: Path):
+        result = runner.invoke(
+            app,
+            [
+                "new", "idea",
+                "--name", "x",
+                "--visibility", "secret",
+                "--parent-dir", str(tmp_path),
+                "--no-remote", "--dry-run",
+            ],
+        )
+        assert result.exit_code == 2
+        assert "--visibility" in result.output
+
+    def test_missing_parent_dir_rejected(self):
+        result = runner.invoke(
+            app,
+            [
+                "new", "idea",
+                "--name", "x", "--language", "python",
+                "--parent-dir", "/nonexistent/does/not/exist",
+                "--no-remote", "--dry-run",
+            ],
+        )
+        assert result.exit_code == 2
+        assert "parent-dir" in result.output.lower()
+
+
+class TestNewFullGenesis:
+    """Runs the real genesis pipeline, skipping blueprint-init + remote push.
+
+    Covers the PR 1 happy path end-to-end: CLI → creator → commit on main.
+    Blueprint-init would require spawning a real ClaudeSDKClient, so we
+    skip it here and cover that code path via unit tests separately.
+    """
+
+    def test_creates_local_repo_with_initial_commit(self, tmp_path: Path):
+        result = runner.invoke(
+            app,
+            [
+                "new", "A small CLI that does a thing",
+                "--name", "Small CLI",
+                "--language", "python",
+                "--stack-indicators", "github-actions",
+                "--parent-dir", str(tmp_path),
+                "--no-remote",
+                "--skip-blueprint",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+        repo = tmp_path / "small-cli"
+        assert (repo / ".git").is_dir()
+        assert (repo / "README.md").is_file()
+        assert (repo / "docs" / "prds" / "0001-project-goal.md").is_file()
+
+        settings = json.loads(
+            (repo / ".claude" / "settings.json").read_text(encoding="utf-8")
+        )
+        assert "claude-plugins" in settings["extraKnownMarketplaces"]
+        assert "python-plugin@claude-plugins" in settings["enabledPlugins"]
+        assert "github-actions-plugin@claude-plugins" in settings["enabledPlugins"]
+
+        # Single initial commit on main (blueprint-init was skipped).
+        log = subprocess.run(
+            ["git", "log", "--format=%s"],
+            cwd=repo, capture_output=True, text=True, check=True,
+        ).stdout.strip().splitlines()
+        assert len(log) == 1
+        assert log[0].startswith("chore: initialize")


### PR DESCRIPTION
## Summary

Stacks on #1096. Completes the \`git-repo-agent new\` pipeline.

After genesis, \`new\` now runs \`BlueprintDriver(NEW_PHASES)\` — a new phase tuple containing only the \`blueprint-init\` phase. A fresh repo has nothing for the derive-* phases to mine, so running the full onboard pipeline would be noisy at best.

## What lands here

| File | Change |
|------|--------|
| \`blueprint_driver.py\` | New \`NEW_PHASES\` tuple (init only); registered under \`PHASE_REGISTRIES[\"new\"]\` |
| \`main.py\` | \`--skip-blueprint\` flag; post-genesis \`BlueprintDriver\` run + optional second commit via \`_commit_if_dirty()\` |
| \`docs/adr/007-new-command-orchestrator.md\` | Design rationale: pipeline, failure modes, why not \`run_onboard\`, why hard-fail on SDK unreachability |
| \`README.md\` | Leads with \`new\` as headline workflow; \`onboard\` positioned as \"for existing repos\" |
| \`tests/test_new_command.py\` | 5 end-to-end CliRunner tests (dry-run + full genesis with \`--skip-blueprint\`) |
| \`tests/test_blueprint_driver.py\` | Updated registry-keys test to include \`\"new\"\` |

## Deliberately NOT in this PR

- **Full \`run_onboard()\` integration.** Onboard's worktree + PR flow assumes a pre-existing repo with a base branch to fast-forward. Wedging it into \`new\` would muddle its contract. Users who want the full scaffold can run \`git-repo-agent onboard\` on the freshly-created repo.
- **\`create\` / \`init\` aliases.** Still deferred from PR 1.

## Base

Based on \`feat/new-command-intent\` (PR #1096). After #1095 and #1096 merge, this rebases onto main.

## Test plan

- [x] \`uv run pytest\` — 162 passed (5 new)
- [x] \`git-repo-agent new ... --skip-blueprint --no-remote\` → one \"chore: initialize\" commit, no blueprint files (verified locally)
- [x] \`git-repo-agent new --help\` shows \`--skip-blueprint\`
- [ ] Live end-to-end (intent parse + blueprint-init + gh repo create) — intentionally manual; the tool's own README now serves as the test script

🤖 Generated with [Claude Code](https://claude.com/claude-code)