### PR TITLE
feat(git-repo-agent): parse project intent from idea string

### DIFF
--- a/git-repo-agent/src/git_repo_agent/intent.py
+++ b/git-repo-agent/src/git_repo_agent/intent.py
@@ -1,0 +1,172 @@
+"""Natural-language project idea → ``NewProjectSpec`` via a Claude SDK one-shot.
+
+Phase 1 of ``git-repo-agent new``. The command feeds the user's idea
+(e.g. ``"Telegram chat bot that replies to user messages"``) into a small
+single-turn ``ClaudeSDKClient`` session whose system prompt asks for a
+strict JSON response. The JSON is parsed and validated into a
+``NewProjectSpec`` the rest of the pipeline can trust.
+
+If the model is unreachable or the response is malformed, this module
+raises ``IntentParseError``. The ``new`` command hard-fails in that case
+rather than attempting a name-only fallback — the whole point of the
+one-shot command is to get a stack-appropriate scaffold, and a guessed
+scaffold is worse than no scaffold at all.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+from claude_agent_sdk import (
+    AssistantMessage,
+    ClaudeAgentOptions,
+    ClaudeSDKClient,
+    TextBlock,
+)
+
+from .creator import NewProjectSpec, slugify
+
+logger = logging.getLogger(__name__)
+
+_KNOWN_LANGUAGES: frozenset[str] = frozenset(
+    {"python", "typescript", "javascript", "rust", "go", "default"}
+)
+_KNOWN_INDICATORS: frozenset[str] = frozenset(
+    {
+        "python", "typescript", "javascript", "rust", "go",
+        "docker", "github-actions", "esp-idf", "esphome",
+    }
+)
+
+
+class IntentParseError(RuntimeError):
+    """Raised when the model returned nothing parseable or was unreachable."""
+
+
+_SYSTEM_PROMPT = """You classify short software-project ideas.
+
+Given an idea in one or two sentences, output ONLY a single JSON object
+describing the project. No prose, no markdown fences, no explanation.
+
+Fields:
+
+- name: concise human-readable title case (not a sentence). Max 40 chars.
+- description: one-sentence description for README + GitHub repo
+  description. Max 140 chars.
+- language: one of python, typescript, javascript, rust, go, default.
+  Pick the most likely primary language. Use "default" only if none fits.
+- stack_indicators: array of values from this exact set: python,
+  typescript, javascript, rust, go, docker, github-actions, esp-idf,
+  esphome. Always include the chosen language. Add docker only if
+  containerisation is clearly central. Add github-actions for any
+  project that will benefit from CI (default: yes, unless trivial).
+
+Respond with JSON only.
+"""
+
+
+async def parse_intent(idea: str) -> NewProjectSpec:
+    """Parse an idea string into a ``NewProjectSpec`` via the Claude API.
+
+    Raises ``IntentParseError`` on any failure (connection, timeout,
+    malformed JSON, missing required fields). The error message is meant
+    to be surfaced to the user as-is.
+    """
+    options = ClaudeAgentOptions(
+        system_prompt=_SYSTEM_PROMPT,
+        max_turns=1,
+        allowed_tools=[],
+    )
+    collected: list[str] = []
+    try:
+        async with ClaudeSDKClient(options) as client:
+            await client.query(
+                f"Project idea: {idea}\n\nRespond with the JSON object."
+            )
+            async for msg in client.receive_response():
+                if isinstance(msg, AssistantMessage):
+                    for block in msg.content:
+                        if isinstance(block, TextBlock):
+                            collected.append(block.text)
+    except Exception as exc:  # pragma: no cover — network paths
+        raise IntentParseError(
+            f"Could not reach Claude API to parse project intent: {exc}. "
+            "Re-run later or pass --name / --language explicitly."
+        ) from exc
+
+    return _parse_model_response(idea=idea, raw="".join(collected))
+
+
+def _parse_model_response(*, idea: str, raw: str) -> NewProjectSpec:
+    """Extract and validate the model's JSON response.
+
+    Factored out so tests can exercise the parser without spinning up
+    an SDK session.
+    """
+    text = raw.strip()
+    if not text:
+        raise IntentParseError("Model returned an empty response.")
+
+    # The model occasionally wraps JSON in code fences despite instructions.
+    # Strip a leading ```json / ``` and a trailing ```.
+    text = re.sub(r"^```(?:json)?\s*", "", text)
+    text = re.sub(r"\s*```\s*$", "", text)
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise IntentParseError(
+            f"Model response was not valid JSON: {exc}. "
+            f"Response (first 200 chars): {text[:200]!r}"
+        ) from exc
+
+    if not isinstance(data, dict):
+        raise IntentParseError(
+            f"Model response was {type(data).__name__}, expected object."
+        )
+
+    return _build_spec(idea=idea, data=data)
+
+
+def _build_spec(*, idea: str, data: dict[str, Any]) -> NewProjectSpec:
+    name_raw = data.get("name")
+    if not isinstance(name_raw, str) or not name_raw.strip():
+        raise IntentParseError("Model output missing or empty 'name' field.")
+    name = name_raw.strip()
+
+    description_raw = data.get("description") or idea
+    description = str(description_raw).strip()
+
+    language = str(data.get("language") or "default").strip().lower()
+    if language not in _KNOWN_LANGUAGES:
+        logger.debug("Unknown language %r from model; coercing to 'default'.", language)
+        language = "default"
+
+    raw_indicators = data.get("stack_indicators") or []
+    if not isinstance(raw_indicators, list):
+        raise IntentParseError(
+            f"'stack_indicators' must be a list, got {type(raw_indicators).__name__}."
+        )
+    indicators: list[str] = []
+    for item in raw_indicators:
+        norm = str(item).strip().lower()
+        if norm in _KNOWN_INDICATORS and norm not in indicators:
+            indicators.append(norm)
+    if language != "default" and language not in indicators:
+        indicators.insert(0, language)
+
+    return NewProjectSpec(
+        name=name,
+        slug=slugify(name),
+        description=description,
+        idea=idea,
+        language=language,
+        stack_indicators=tuple(indicators),
+        extra_plugins=(),
+    )
+
+
+__all__ = ["IntentParseError", "parse_intent"]

--- a/git-repo-agent/src/git_repo_agent/main.py
+++ b/git-repo-agent/src/git_repo_agent/main.py
@@ -136,16 +136,20 @@ def new(
         ...,
         help="Short description of what you want to build (1-2 sentences).",
     ),
-    name: str = typer.Option(
-        ...,
+    name: Optional[str] = typer.Option(
+        None,
         "--name",
-        help="Human-readable project name; also drives the directory / repo slug.",
+        help=(
+            "Human-readable project name; also drives the directory / repo slug. "
+            "Inferred from the idea when omitted."
+        ),
     ),
-    language: str = typer.Option(
-        "default",
+    language: Optional[str] = typer.Option(
+        None,
         "--language",
         help=(
-            "Primary language: python | typescript | javascript | rust | go | default."
+            "Primary language: python | typescript | javascript | rust | go | default. "
+            "Inferred from the idea when omitted."
         ),
     ),
     stack_indicators: Optional[str] = typer.Option(
@@ -194,10 +198,14 @@ def new(
 ) -> None:
     """Create a new repository from an idea: genesis + plugin enrollment + (optionally) gh repo create.
 
-    This is the foundation (PR 1) of ``git-repo-agent new``: it performs
-    local genesis and writes ``.claude/settings.json`` with the right
-    marketplace + plugin list for the detected stack. Intent parsing and
-    blueprint-init scaffolding land in follow-up PRs.
+    When ``--name`` is omitted, the idea string is sent to Claude for intent
+    parsing — one short SDK call that returns a ``NewProjectSpec`` (name,
+    language, stack indicators). Any explicit flags (``--language``,
+    ``--description``, ``--stack-indicators``) layer on top as overrides.
+
+    If the Claude API is unreachable and ``--name`` was not provided, the
+    command exits with an error rather than falling back to a guessed
+    scaffold.
     """
     from pathlib import Path
 
@@ -208,8 +216,9 @@ def new(
         gh_repo_create,
         slugify,
     )
+    from .intent import IntentParseError, parse_intent
 
-    if language not in _VALID_LANGUAGES:
+    if language is not None and language not in _VALID_LANGUAGES:
         console.print(
             f"[red]Error:[/red] --language must be one of {list(_VALID_LANGUAGES)}, "
             f"got {language!r}"
@@ -227,28 +236,49 @@ def new(
         console.print(f"[red]Error:[/red] --parent-dir is not a directory: {parent}")
         raise typer.Exit(code=EXIT_CONFIG_ERROR)
 
-    try:
-        slug = slugify(name)
-    except ValueError as exc:
-        console.print(f"[red]Error:[/red] {exc}")
-        raise typer.Exit(code=EXIT_CONFIG_ERROR)
+    # Intent parsing: when --name is absent we treat this as the user
+    # asking us to infer the project shape from the idea string. Explicit
+    # flags below will still override.
+    spec: NewProjectSpec
+    if name is None:
+        console.print("[dim]Parsing project intent via Claude...[/dim]")
+        try:
+            spec = asyncio.run(parse_intent(idea))
+        except IntentParseError as exc:
+            console.print(f"[red]Error:[/red] {exc}")
+            raise typer.Exit(code=EXIT_RUNTIME_ERROR)
+    else:
+        try:
+            slug = slugify(name)
+        except ValueError as exc:
+            console.print(f"[red]Error:[/red] {exc}")
+            raise typer.Exit(code=EXIT_CONFIG_ERROR)
+        spec = NewProjectSpec(
+            name=name,
+            slug=slug,
+            description=description or idea,
+            idea=idea,
+            language=language or "default",
+            stack_indicators=(),
+            extra_plugins=(),
+        )
 
-    # Build the stack-indicator set. The language is itself an indicator
-    # when it isn't "default"; any extra indicators from --stack-indicators
-    # are merged on top (deduplicated, order-preserving).
-    indicators: list[str] = []
-    if language != "default":
-        indicators.append(language)
+    # Apply explicit overrides on top of the (possibly inferred) spec.
+    effective_language = (language or spec.language).lower()
+    effective_description = description or spec.description
+    indicators: list[str] = list(spec.stack_indicators)
+    if effective_language != "default" and effective_language not in indicators:
+        indicators.insert(0, effective_language)
     for extra in _parse_csv(stack_indicators):
         if extra not in indicators:
             indicators.append(extra)
 
     spec = NewProjectSpec(
-        name=name,
-        slug=slug,
-        description=description or idea,
+        name=spec.name,
+        slug=spec.slug,
+        description=effective_description,
         idea=idea,
-        language=language,
+        language=effective_language,
         stack_indicators=tuple(indicators),
         extra_plugins=_parse_csv(extra_plugins),
     )

--- a/git-repo-agent/tests/test_intent.py
+++ b/git-repo-agent/tests/test_intent.py
@@ -1,0 +1,210 @@
+"""Tests for the intent parser used by ``git-repo-agent new``.
+
+The pure JSON-parsing logic (``_parse_model_response`` / ``_build_spec``)
+is exercised directly. ``parse_intent`` itself is tested with a fake SDK
+client so the tests don't depend on network.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+
+import pytest
+
+from git_repo_agent.creator import NewProjectSpec
+from git_repo_agent.intent import (
+    IntentParseError,
+    _parse_model_response,
+    parse_intent,
+)
+
+
+# ---------------------------------------------------------------------------
+# _parse_model_response — JSON handling
+# ---------------------------------------------------------------------------
+
+
+def _valid_json(**over) -> str:
+    payload = {
+        "name": "Telegram Chat Bot",
+        "description": "Bot that replies to users on Telegram.",
+        "language": "python",
+        "stack_indicators": ["python", "github-actions"],
+    }
+    payload.update(over)
+    return json.dumps(payload)
+
+
+class TestParseModelResponse:
+    def test_happy_path(self):
+        spec = _parse_model_response(
+            idea="Telegram chat bot that replies to user messages",
+            raw=_valid_json(),
+        )
+        assert spec.name == "Telegram Chat Bot"
+        assert spec.slug == "telegram-chat-bot"
+        assert spec.language == "python"
+        assert spec.stack_indicators == ("python", "github-actions")
+        assert "Bot that replies to users" in spec.description
+
+    def test_strips_markdown_code_fence(self):
+        raw = "```json\n" + _valid_json() + "\n```"
+        spec = _parse_model_response(idea="foo", raw=raw)
+        assert spec.name == "Telegram Chat Bot"
+
+    def test_strips_plain_code_fence(self):
+        raw = "```\n" + _valid_json() + "\n```"
+        spec = _parse_model_response(idea="foo", raw=raw)
+        assert spec.language == "python"
+
+    def test_empty_response_raises(self):
+        with pytest.raises(IntentParseError, match="empty"):
+            _parse_model_response(idea="foo", raw="")
+
+    def test_invalid_json_raises(self):
+        with pytest.raises(IntentParseError, match="not valid JSON"):
+            _parse_model_response(idea="foo", raw="this is not json")
+
+    def test_non_object_raises(self):
+        with pytest.raises(IntentParseError, match="expected object"):
+            _parse_model_response(idea="foo", raw='["an", "array"]')
+
+    def test_missing_name_raises(self):
+        raw = json.dumps({"language": "python", "stack_indicators": ["python"]})
+        with pytest.raises(IntentParseError, match="name"):
+            _parse_model_response(idea="foo", raw=raw)
+
+    def test_empty_name_raises(self):
+        with pytest.raises(IntentParseError, match="name"):
+            _parse_model_response(idea="foo", raw=_valid_json(name="   "))
+
+    def test_description_defaults_to_idea_when_missing(self):
+        raw = json.dumps({
+            "name": "Foo",
+            "language": "python",
+            "stack_indicators": ["python"],
+        })
+        spec = _parse_model_response(idea="the original idea", raw=raw)
+        assert spec.description == "the original idea"
+
+    def test_unknown_language_coerced_to_default(self):
+        spec = _parse_model_response(
+            idea="foo",
+            raw=_valid_json(language="cobol", stack_indicators=[]),
+        )
+        assert spec.language == "default"
+
+    def test_language_inserted_into_indicators(self):
+        spec = _parse_model_response(
+            idea="foo",
+            raw=_valid_json(language="rust", stack_indicators=["github-actions"]),
+        )
+        # rust is prepended to the indicator list.
+        assert spec.stack_indicators[0] == "rust"
+        assert "github-actions" in spec.stack_indicators
+
+    def test_default_language_not_inserted(self):
+        spec = _parse_model_response(
+            idea="foo",
+            raw=_valid_json(language="default", stack_indicators=["github-actions"]),
+        )
+        assert "default" not in spec.stack_indicators
+        assert spec.stack_indicators == ("github-actions",)
+
+    def test_unknown_indicators_silently_dropped(self):
+        spec = _parse_model_response(
+            idea="foo",
+            raw=_valid_json(
+                language="python",
+                stack_indicators=["python", "quantum-computing", "github-actions"],
+            ),
+        )
+        assert spec.stack_indicators == ("python", "github-actions")
+
+    def test_stack_indicators_wrong_type_raises(self):
+        raw = json.dumps({
+            "name": "Foo",
+            "language": "python",
+            "stack_indicators": "python,github-actions",  # string, not list
+        })
+        with pytest.raises(IntentParseError, match="stack_indicators"):
+            _parse_model_response(idea="foo", raw=raw)
+
+
+# ---------------------------------------------------------------------------
+# parse_intent with a fake SDK client
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeTextBlock:
+    text: str
+
+
+@dataclass
+class _FakeAssistantMessage:
+    content: list
+
+
+class _FakeClient:
+    """Stand-in for ``ClaudeSDKClient`` used in ``parse_intent`` tests."""
+
+    def __init__(self, response_json: str):
+        self._response_json = response_json
+        self.queries: list[str] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def query(self, prompt: str) -> None:
+        self.queries.append(prompt)
+
+    async def receive_response(self):
+        # Reuse the real SDK's AssistantMessage/TextBlock classes so the
+        # isinstance() checks in parse_intent match.
+        from claude_agent_sdk import AssistantMessage, TextBlock
+
+        yield AssistantMessage(
+            content=[TextBlock(text=self._response_json)],
+            model="fake-model",
+        )
+
+
+def _make_fake_client_factory(response_json: str):
+    def factory(options):
+        return _FakeClient(response_json)
+    return factory
+
+
+class TestParseIntent:
+    def test_happy_path_with_fake_client(self, monkeypatch):
+        monkeypatch.setattr(
+            "git_repo_agent.intent.ClaudeSDKClient",
+            _make_fake_client_factory(_valid_json()),
+        )
+        spec = asyncio.run(parse_intent("Telegram chat bot"))
+        assert spec.name == "Telegram Chat Bot"
+        assert spec.slug == "telegram-chat-bot"
+        assert spec.language == "python"
+
+    def test_sdk_exception_raises_intent_parse_error(self, monkeypatch):
+        class _BoomClient:
+            def __init__(self, options):
+                pass
+
+            async def __aenter__(self):
+                raise RuntimeError("no network")
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        monkeypatch.setattr(
+            "git_repo_agent.intent.ClaudeSDKClient", _BoomClient,
+        )
+        with pytest.raises(IntentParseError, match="Could not reach Claude"):
+            asyncio.run(parse_intent("anything"))


### PR DESCRIPTION
## Summary

Replaces the auto-closed #1096 now that its base branch was deleted during the #1095 merge. Content is identical — a rebase onto main.

Layers intent parsing onto the \`new\` command. When \`--name\` is omitted, the idea string is sent to Claude in a single-turn SDK call whose system prompt demands a strict JSON response (name, description, language, stack_indicators). The response is validated and becomes the \`NewProjectSpec\` before genesis proceeds.

\`\`\`sh
git-repo-agent new \"Telegram chat bot that replies to user messages\"
# → infers name=\"Telegram Chat Bot\", language=python,
#   stack_indicators=[python, github-actions]
\`\`\`

Explicit flags always win. On SDK / network failure the command exits with \`EXIT_RUNTIME_ERROR\` rather than falling back to a guessed scaffold (per agreed behavior).

## Test plan

- [x] \`uv run pytest\` — 157 passed (16 new)
- [x] \`git-repo-agent new --help\` shows \`--name\`/\`--language\` as optional
- [ ] Real API smoke test covered by PR 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1096