### PR TITLE
docs(git-repo-agent): update README and help text for new command

### DIFF
--- a/git-repo-agent/README.md
+++ b/git-repo-agent/README.md
@@ -1,10 +1,15 @@
 # git-repo-agent
 
-Claude Agent SDK application for automated repository onboarding and maintenance.
+Claude Agent SDK application for repository creation, onboarding, and maintenance.
 
 ## Overview
 
-git-repo-agent analyzes a repository's technology stack, initializes blueprint methodology structure, configures project standards, runs quality and security audits, and sets up documentation — all orchestrated by Claude through the Agent SDK.
+git-repo-agent covers the full repository lifecycle:
+
+- **Create** — `git-repo-agent new "<idea>"` parses the idea via Claude, scaffolds the repo, enrols the `laurigates/claude-plugins` marketplace, runs `blueprint-init`, and pushes to GitHub — all in one command. See [ADR-007](docs/adr/007-new-command-orchestrator.md).
+- **Onboard** — `git-repo-agent onboard <existing-repo>` analyses an existing repository's technology stack, initialises blueprint methodology structure, and configures project standards.
+- **Maintain** — `git-repo-agent maintain` runs quality, security, and documentation audits and optionally applies auto-fixes on a PR branch.
+- **Diagnose** — `git-repo-agent diagnose` correlates pipeline failures from CI, Kubernetes, and ArgoCD into a single GitHub issue.
 
 ## Installation
 
@@ -208,8 +213,12 @@ git-repo-agent health /path/to/repo
 git-repo-agent/
 ├── src/git_repo_agent/
 │   ├── main.py                # CLI entry point (Typer)
-│   ├── orchestrator.py        # Core agent orchestration
+│   ├── orchestrator.py        # Core agent orchestration (onboard / maintain / diagnose)
 │   ├── blueprint_driver.py    # Blueprint state machine (ADR-006)
+│   ├── intent.py              # `new`: idea → NewProjectSpec via Claude SDK (ADR-007)
+│   ├── creator.py             # `new`: local genesis (git init, templates, initial commit)
+│   ├── plugin_enroller.py     # `new`: marketplace + enabledPlugins in .claude/settings.json
+│   ├── templates/             # Per-language seed files (README, .gitignore, PRD)
 │   ├── agents/
 │   │   ├── configure.py       # Project standards (haiku)
 │   │   ├── diagnose.py        # Pipeline diagnostics (sonnet)
@@ -350,3 +359,4 @@ uv run --directory git-repo-agent git-repo-agent diagnose . --dry-run
 | Phase 3 | Done    | Quality/security/test-runner subagents, report_generate, health command                   |
 | Phase 4 | In progress | Non-interactive / scheduled execution (ADR-005); watch mode and trend tracking planned |
 | Phase 5 | Done    | Pipeline diagnostics (kubectl, ArgoCD, GitHub Actions, Sentry, Chrome DevTools)           |
+| Phase 6 | Done    | `new` command: intent parsing, local genesis, plugin enrollment, `blueprint-init` (ADR-007) |

--- a/git-repo-agent/pyproject.toml
+++ b/git-repo-agent/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "git-repo-agent"
 version = "1.0.0"
-description = "Claude Agent SDK app for repo onboarding and maintenance"
+description = "Claude Agent SDK app for repo creation, onboarding, and maintenance"
 readme = "README.md"
 authors = [
     { name = "Lauri Gates", email = "lauri.gates@forumvirium.fi" }

--- a/git-repo-agent/src/git_repo_agent/main.py
+++ b/git-repo-agent/src/git_repo_agent/main.py
@@ -22,7 +22,7 @@ from .non_interactive import (
 
 app = typer.Typer(
     name="git-repo-agent",
-    help="Claude Agent SDK app for repo onboarding and maintenance.",
+    help="Claude Agent SDK app for repo creation, onboarding, and maintenance.",
 )
 blueprint_app = typer.Typer(
     name="blueprint",


### PR DESCRIPTION
## Summary

Follow-up to the \`new\` command train (#1095, #1098, #1097).

The feature is live but several places still read \"repo onboarding and maintenance\" without mentioning creation:

| File | Fix |
|------|-----|
| \`README.md\` — Overview | Now lists Create / Onboard / Maintain / Diagnose with a one-liner each, pointing to ADR-007 for \`new\` |
| \`README.md\` — Architecture tree | Adds \`intent.py\`, \`creator.py\`, \`plugin_enroller.py\`, \`templates/\` |
| \`README.md\` — Implementation Phases | Adds Phase 6 (done): \`new\` command |
| \`pyproject.toml\` | \`description\` mentions creation |
| \`main.py\` | Typer \`help=\` mentions creation |

No functional changes. 162 tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)