### PR TITLE
ci(workflows): mirror skill-description audit into CI and document disabled review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,3 +1,11 @@
+# This workflow is intentionally DISABLED in the GitHub Actions UI.
+# Rationale: plugin-pr-checks.yml already runs a Claude skill-quality review
+# scoped to the files that changed. Running both duplicates cost and comments.
+# The file is kept in-tree because configure-plugin/skills/configure-claude-plugins
+# dogfoods it as the canonical review workflow for downstream projects — removing
+# it would desync the plugin template from its reference repo.
+# Re-enable via Actions → Claude Code Review → Enable workflow if plugin-pr-checks
+# is ever removed or repurposed.
 name: Claude Code Review
 
 on:

--- a/.github/workflows/lint-context-commands.yml
+++ b/.github/workflows/lint-context-commands.yml
@@ -6,6 +6,7 @@ on:
       - '**/skills/**/SKILL.md'
       - '**/skills/**/skill.md'
       - 'scripts/lint-context-commands.sh'
+      - 'scripts/audit-skill-descriptions.py'
   push:
     branches:
       - main
@@ -13,6 +14,7 @@ on:
       - '**/skills/**/SKILL.md'
       - '**/skills/**/skill.md'
       - 'scripts/lint-context-commands.sh'
+      - 'scripts/audit-skill-descriptions.py'
 
 permissions:
   contents: read
@@ -25,3 +27,9 @@ jobs:
 
       - name: Lint context commands
         run: ./scripts/lint-context-commands.sh
+
+      - name: Install Python deps for skill-description audit
+        run: pip install --quiet pyyaml
+
+      - name: Audit skill descriptions for auto-invocation
+        run: python3 scripts/audit-skill-descriptions.py --strict-all


### PR DESCRIPTION
## Summary

Audit of the 15 workflows in `.github/workflows/`. All currently pass; two gaps worth fixing.

### Workflow status (recent runs)

| # | File | Trigger | Intent | Recent runs |
|---|------|---------|--------|-------------|
| 1 | `auto-resolve-conflicts.yml` | push main, dispatch | Claude haiku auto-merges conflicting PRs; closes stale bot PRs | ✅ 10/10 |
| 2 | `release-pr-doc-audit.yml` | PR (release-please--* only) | CHANGELOG/version/skill-freshness audit on release PRs | ✅ |
| 3 | `changelog-review.yml` | weekly cron, dispatch | Upstream Claude Code changelog → rules update PR | ✅ 10/10 |
| 4 | `plugin-pr-checks.yml` | PR on plugins/marketplace | `plugin-compliance-check.sh` + Claude skill-quality review | ✅ 10/10 |
| 5 | `claude.yml` | `@claude` mentions | Claude responds to mentions | ✅ (1s fast-skip when no mention) |
| 6 | `lint-context-commands.yml` | PR/push on SKILL.md | `lint-context-commands.sh` | ✅ 10/10 |
| 7 | `scheduled-audits.yml` | monthly cron | blueprint-health / infra-compliance / agentic-audit issues | ✅ (added 2026-04-12; 2 runs so far) |
| 8 | `claude-code-review.yml` | PR | Reusable Claude PR review | **Manually disabled** in UI |
| 9 | `github-workflow-auto-fix.yml` | `workflow_run` on 3 workflows | Claude sonnet auto-fixes CI failures | ✅ (1s fast-skips while upstream is green) |
| 10 | `validate-plugin-configs.yml` | PR/push on plugin configs | `sync-plugin-configs.py` + auto-fix commit | ✅ 10/10 |
| 11 | `skill-splitter.yml` | PR on SKILL.md | Claude extracts oversized SKILL.md into REFERENCE.md | ✅ 10/10 |
| 12 | `release-please.yml` | push main | release-please + auto-merge + marketplace sync | ✅ 10/10 |
| 13 | `fix-release-conflicts.yml` | push main, 2×/hr cron | Reusable: resolve release-please conflicts | ✅ 10/10 |
| 14 | `renovate.yml` | 2h cron | Reusable: dependency updates | ✅ 10/10 |
| 15 | `enforce-conventional-commits.yml` | PR | Reusable: PR title + commit format | ✅ 10/10 |

### Changes in this PR

1. **`lint-context-commands.yml`** — add `audit-skill-descriptions.py --strict-all` as a CI step.
   - Pre-commit already runs it, but Claude-agent branches (`claude/*`) bypass pre-commit, so description regressions (missing `Use when...` triggers, empty descriptions) reach `main` unblocked.
   - Same triggers (SKILL.md changes), minimal cost (`ubuntu-slim`, adds `pip install pyyaml`).
   - Verified passing against current repo state.

2. **`claude-code-review.yml`** — add a header comment explaining the manual-disable.
   - Rationale: `plugin-pr-checks.yml` already runs a file-scoped Claude skill-quality review. Enabling both would duplicate cost and comments.
   - File stays on disk because `configure-plugin/skills/configure-claude-plugins` dogfoods it as the canonical review workflow for downstream projects — deleting it would desync the template.

### Not fixed (flagged for follow-up)

- **`check-driver-freshness.sh` not in CI** — same gap as above (pre-commit only). Currently **fails locally** (exit 1) because `configure-repo/SKILL.md` was reviewed 2026-04-16 but `configure-claude-plugins/SKILL.md` and `health-check/SKILL.md` were modified 2026-04-19. Wiring it into CI would block every skill PR until someone does an actual review pass on `configure-repo` and bumps its `reviewed:` date. Needs a human decision; opening as separate work.

## Test plan

- [ ] `Lint Context Commands` passes on this PR (both `lint-context-commands.sh` and `audit-skill-descriptions.py --strict-all`)
- [ ] No other workflow status changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)