### PR TITLE
chore(configure-plugin): bump configure-repo reviewed: date

### DIFF
--- a/configure-plugin/skills/configure-repo/SKILL.md
+++ b/configure-plugin/skills/configure-repo/SKILL.md
@@ -12,7 +12,7 @@ args: "[--check-only] [--skip-health] [--skip-migrations]"
 argument-hint: "[--check-only] [--skip-health] [--skip-migrations]"
 created: 2026-04-14
 modified: 2026-04-14
-reviewed: 2026-04-16
+reviewed: 2026-04-21
 ---
 
 # /configure:repo


### PR DESCRIPTION
## Summary

Unblocks the `check-driver-freshness` pre-commit hook by reviewing the two dependency SKILL.md changes that landed after configure-repo's last review (2026-04-16) and bumping `reviewed:` to 2026-04-21.

## Review of dependency changes

| Dependency | Commit | Modified | Impact on driver |
|------------|--------|----------|------------------|
| `configure-claude-plugins/SKILL.md` | #1090 | 2026-04-19 | Description-only rewrite adding "Use when..." trigger clause — no behavioural change |
| `health-check/SKILL.md` | #1090 | 2026-04-19 | Same — description-only rewrite |
| `health-check/SKILL.md` (earlier) | #1038 | 2026-04-16 | Router refactor; that PR already bumped `configure-repo` `reviewed:` and confirmed `/health:check` remains behaviour-compatible at Step 5's invocation point |

Confirmed driver steps still work unchanged:
- **Step 2** `/configure:claude-plugins --fix` — invocation signature unchanged.
- **Step 5** `/health:check` — remains the single entry point after the router refactor; the driver's "parse output, report failures, continue" flow composes cleanly with the new `--scope` / `--fix` surface without needing to adopt them.

No driver content edits required — this is a review-only bump per the hook's documented workflow ("Update the driver skill, bump its 'reviewed:' date, and document any behaviour changes from the updated dependency").

## Why a separate PR

Spun out of #1101 where this failure was encountered as a pre-existing blocker unrelated to that PR's content. Keeping concerns separate (per the two-PR default for distinct changes).

## Test plan

- [x] `bash scripts/check-driver-freshness.sh` → `OK: Driver is fresh.`
- [x] Full pre-commit suite passes (shellcheck, secrets, lint-context, driver-freshness, audit-skill-descriptions) without `SKIP=`
- [ ] Visual review of the bumped date against the referenced dependency commits (#1090, #1038)

🤖 Generated with [Claude Code](https://claude.com/claude-code)