### PR TITLE
feat(git-plugin): add git-coworker-check skill and coworker-detection rule

### DIFF
--- a/.claude/rules/agent-coworker-detection.md
+++ b/.claude/rules/agent-coworker-detection.md
@@ -1,0 +1,104 @@
+# Agent Coworker Detection
+
+How an agent detects that another agent is already working in the same repository clone, and how it avoids destroying that coworker's in-flight changes.
+
+## The Problem
+
+When two agents run concurrently in the **same checkout** (rather than separate worktrees), they observe each other's uncommitted changes through `git status`. A naive agent sees files it did not touch, assumes the tree is dirty, and runs `git stash`, `git restore`, or `git checkout -- .` to "clean up". The coworker then finds its work has disappeared and may attempt its own recovery, compounding the loss.
+
+The root cause is missing coordination: each agent assumes it is the sole writer in the working tree.
+
+## Detection Signals
+
+No single signal is reliable. Combine these three and treat any positive as "assume a coworker is present".
+
+| Signal | Detects | Cost | Platform |
+|--------|---------|------|----------|
+| **Baseline drift** — snapshot `git status --porcelain` + `git stash list` at session start; diff at risky moments | Files that appeared after we started, regardless of who created them | Free | All |
+| **Session marker** — write `.git/.claude-session-<pid>` on start, delete on exit; scan siblings | Other agents that adopt the same convention | Free | All |
+| **Process scan** — find other `claude`/`node` processes whose `cwd` is the same repo | Ad-hoc agents that do not write markers | ~100ms | Linux/macOS differ |
+
+### Baseline drift
+
+At the start of each session / skill invocation, capture a baseline:
+
+```bash
+git status --porcelain=v2 --branch > .git/.claude-baseline-$$
+git stash list > .git/.claude-stash-baseline-$$
+```
+
+Before any destructive operation (`stash`, `restore`, `checkout -- .`, `reset --hard`), compare current state against the baseline. Entries present now but not in the baseline are **coworker changes**, not session changes — never stash or discard them.
+
+### Session marker file
+
+Marker path: `.git/.claude-session-<pid>` (kept inside `.git/` so it is never staged and is wiped by `git clean -x`).
+
+```bash
+marker=".git/.claude-session-$$"
+printf '%s\t%s\t%s\n' "$$" "$(date -Iseconds)" "$(hostname)" > "$marker"
+trap 'rm -f "$marker"' EXIT
+```
+
+Siblings: `ls .git/.claude-session-*` matching PIDs other than `$$`. For each, `kill -0 <pid> 2>/dev/null` confirms the process is still alive; stale markers from crashed sessions are safe to ignore.
+
+### Process scan
+
+Linux (cross-reference `/proc/*/cwd` symlinks against the repo root):
+
+```bash
+repo_root="$(git rev-parse --show-toplevel)"
+for pid_dir in /proc/[0-9]*; do
+  pid="${pid_dir##*/}"
+  [ "$pid" = "$$" ] && continue
+  cwd="$(readlink "$pid_dir/cwd" 2>/dev/null)" || continue
+  case "$cwd" in "$repo_root"|"$repo_root"/*) echo "$pid" ;; esac
+done
+```
+
+macOS uses `lsof -a -d cwd -c claude -c node -Fpn` since `/proc` is not available. The process-scan signal is a fallback — do not depend on it working in sandboxed environments (Claude Code on the web, restricted sandboxes) where process enumeration may be blocked.
+
+## Response Rules
+
+When any signal reports a coworker:
+
+1. **Do not stash, restore, or reset.** Leave the working tree alone.
+2. **Scope operations to your own files.** Use `git add <explicit paths>` — never `git add -A` or `git add .`.
+3. **Warn the user** with the list of other PIDs or changed files, and let them decide.
+4. **Prefer a worktree.** If starting a new session in a dirty clone with a live coworker, create `git worktree add ../<repo>-<task>` instead of working in-place.
+
+When no signal reports a coworker, still prefer explicit paths over bulk staging — the detection is best-effort, not a guarantee.
+
+## Integration Points
+
+| Where | How |
+|-------|-----|
+| `git-coworker-check` skill | User-invocable diagnostic — runs all three signals and reports |
+| `git-commit*` skills | Call the baseline-drift check before staging; fail loudly if drift is detected |
+| `git-maintain` skill | Never runs `git stash` or `git clean` without first running the coworker check |
+| SessionStart hook (optional) | Write the session marker; capture the baseline snapshot |
+| PreToolUse hook (optional) | Block `git stash`, `git checkout -- .`, `git reset --hard` when a coworker is detected |
+
+The skill is the primary surface; hooks are an enforcement layer that users can opt into via `hooks-plugin`.
+
+## Anti-Patterns
+
+| Don't | Do |
+|-------|-----|
+| `git stash` on "unexpected" changes | Compare against baseline first |
+| `git add -A` / `git add .` | Stage explicit paths you know you touched |
+| `git clean -fd` as cleanup | Never auto-clean in a shared checkout |
+| Trust `git status` as "my changes" | Treat it as "everyone's changes" until proven otherwise |
+| Block on the process scan alone | Treat it as a hint; the baseline + markers are authoritative |
+
+## Limitations
+
+- **Marker files** only help when both agents adopt the convention. An agent that skips writing a marker is invisible to marker-based detection.
+- **Process scans** fail silently in sandboxes without `/proc` or `lsof` — rely on baseline drift in those environments.
+- **Baseline drift** cannot tell "my earlier edit I forgot about" from "a coworker's edit". When in doubt, ask the user.
+- None of these signals handle concurrent writes to the **same file** — they only detect that a coworker exists, not that you are about to clobber its work.
+
+## Related Rules
+
+- `.claude/rules/handling-blocked-hooks.md` — how to respond when a PreToolUse coworker-check hook blocks a command
+- `.claude/rules/agent-development.md` — worktree isolation as the preferred answer to concurrency
+- `.claude/rules/sandbox-guidance.md` — `/proc` and `lsof` availability in the web sandbox

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-20
-modified: 2026-04-16
-reviewed: 2026-04-16
+modified: 2026-04-21
+reviewed: 2026-04-21
 ---
 
 # claude-plugins
@@ -44,6 +44,7 @@ Claude Code plugin collection providing skills and agents for development workfl
 | `.claude/rules/regression-testing.md` | **Required**: add a script check for every skill bug fixed |
 | `.claude/rules/sandbox-guidance.md` | Sandbox constraints, `CLAUDE_CODE_REMOTE` detection, and remote/local skill patterns |
 | `.claude/rules/plugin-flow-diagrams.md` | When and how to add Mermaid flow diagrams |
+| `.claude/rules/agent-coworker-detection.md` | Detect other agents working in the same repo clone before destructive git ops |
 
 ## Creating New Skills
 

--- a/git-plugin/README.md
+++ b/git-plugin/README.md
@@ -26,6 +26,7 @@ See [`docs/flow.md`](docs/flow.md) for a diagram of how the skills fit together.
 | `/git:maintain` | Repository maintenance and cleanup (prune, gc, verify, branches, stash) |
 | `/git:derive-docs` | Analyze git history to derive undocumented rules, PRDs, ADRs, and PRPs |
 | `/git:upstream-pr` | Submit clean PRs to upstream repositories from fork work |
+| `/git:coworker-check` | Detect another agent working in the same repo clone before destructive git ops |
 
 ## Layered Skills (Composable Git Workflows)
 

--- a/git-plugin/skills/git-coworker-check/SKILL.md
+++ b/git-plugin/skills/git-coworker-check/SKILL.md
@@ -5,6 +5,7 @@ description: |
   running destructive git operations (stash, reset, checkout --). Use when
   starting a session in a non-worktree checkout, or before any "clean up the
   working tree" action that could wipe a coworker's in-flight changes.
+args: "[--check | --claim | --release]"
 argument-hint: [--claim | --release | --check (default)]
 allowed-tools: Bash(bash *), Bash(git status *), Bash(git stash *), Bash(git rev-parse *), Read, TodoWrite
 created: 2026-04-21

--- a/git-plugin/skills/git-coworker-check/SKILL.md
+++ b/git-plugin/skills/git-coworker-check/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: git-coworker-check
+description: |
+  Detect whether another Claude agent is working in the same repo clone before
+  running destructive git operations (stash, reset, checkout --). Use when
+  starting a session in a non-worktree checkout, or before any "clean up the
+  working tree" action that could wipe a coworker's in-flight changes.
+argument-hint: [--claim | --release | --check (default)]
+allowed-tools: Bash(bash *), Bash(git status *), Bash(git stash *), Bash(git rev-parse *), Read, TodoWrite
+created: 2026-04-21
+modified: 2026-04-21
+reviewed: 2026-04-21
+---
+
+# /git:coworker-check
+
+Detect another agent working in the same repo clone and warn before
+destructive operations that could destroy its uncommitted changes.
+
+## When to Use This Skill
+
+| Use this skill when... | Use a worktree instead when... |
+|------------------------|-------------------------------|
+| Session starts in a clone that may already be in use | You control the session and can create `git worktree add ../<task>` |
+| About to run `git stash`, `git reset --hard`, `git checkout -- .` | You already know the working tree is yours alone |
+| `git status` shows files you don't remember touching | Baseline + markers are already confirming you are alone |
+
+See `.claude/rules/agent-coworker-detection.md` for the full rationale and
+signal design.
+
+## Context
+
+- Repo root: !`git rev-parse --show-toplevel`
+- Git dir: !`git rev-parse --git-dir`
+- Current status: !`git status --porcelain=v2 --branch`
+- Stash count: !`git stash list`
+- Existing markers: !`find . -path './.git/.claude-session-*' -maxdepth 3`
+
+## Parameters
+
+Parse `$ARGUMENTS` for the mode flag. Default is `--check`.
+
+| Flag | Action |
+|------|--------|
+| `--check` (default) | Run detection. Report verdict without writing anything. |
+| `--claim` | Write a session marker and baseline snapshot for this session. Run at session start. |
+| `--release` | Remove this session's marker and baseline files. Run on session exit. |
+
+## Execution
+
+Execute this detection workflow:
+
+### Step 1: Resolve mode
+
+Inspect `$ARGUMENTS`. If it contains `--claim`, go to Step 2a. If it contains `--release`, go to Step 2b. Otherwise (including empty), go to Step 3.
+
+### Step 2a: Claim (write marker + baseline)
+
+Run:
+
+```
+bash ${CLAUDE_SKILL_DIR}/scripts/claim-session.sh --project-dir "$(pwd)"
+```
+
+Report the three file paths printed. These are the marker and baseline files — do not commit or delete them. They live inside `.git/` and are not tracked.
+
+Stop here.
+
+### Step 2b: Release (remove marker + baseline)
+
+Run:
+
+```
+bash ${CLAUDE_SKILL_DIR}/scripts/release-session.sh --project-dir "$(pwd)"
+```
+
+No output is expected. Stop here.
+
+### Step 3: Detect coworkers
+
+Look up the current session's baseline files (if `--claim` was run earlier this session). Then run detection:
+
+```
+bash ${CLAUDE_SKILL_DIR}/scripts/detect-coworkers.sh \
+  --project-dir "$(pwd)" \
+  --baseline-status .git/.claude-baseline-$$.status \
+  --baseline-stash .git/.claude-baseline-$$.stash
+```
+
+If no `--claim` was run, omit the `--baseline-*` flags — drift detection will return `unknown` but marker and process signals still work.
+
+### Step 4: Interpret the verdict
+
+Parse the `VERDICT=` line from the script's output:
+
+| Verdict | Meaning | Action |
+|---------|---------|--------|
+| `clear` | No coworker detected | Proceed; still prefer explicit `git add <paths>` over `git add -A` |
+| `drift_detected` | Files appeared since baseline but no other process/marker found | Inspect `NEW_STATUS_LINES` — may be coworker or may be a forgotten earlier edit. Ask the user before stashing. |
+| `coworker_detected` | Another agent/process is active in this clone | **Do not stash, restore, or reset.** Report the `MARKER_PID` / `PROC_PID` entries. Recommend the user switch to a worktree. |
+
+### Step 5: Report findings
+
+Print a short summary:
+
+1. Verdict
+2. Count of markers + processes + drift entries
+3. If non-clear, the specific PIDs or changed files
+4. Recommended next action (worktree, ask user, proceed with explicit paths)
+
+## Post-actions
+
+- On `drift_detected` or `coworker_detected`: do not run `git stash`, `git reset --hard`, `git checkout -- .`, or `git clean` in this session. Stage only explicit paths.
+- Suggest the user run `git worktree add ../$(basename $(git rev-parse --show-toplevel))-<task>` for a clean isolated checkout.
+
+## Integration
+
+Other git-plugin skills should invoke this via SlashCommand before destructive operations:
+
+```markdown
+Before staging: Use SlashCommand to invoke `/git:coworker-check`.
+If the verdict is not `clear`, stop and ask the user how to proceed.
+```
+
+Hook-based enforcement (blocking `git stash` / `git reset --hard` when a coworker is detected) belongs in `hooks-plugin`, not here.
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Cheapest detection (no baseline) | `bash scripts/detect-coworkers.sh --project-dir "$(pwd)"` |
+| Full detection with drift | Add `--baseline-status` + `--baseline-stash` from a `--claim` run |
+| One-line verdict check | `... \| awk -F= '/^VERDICT=/ {print $2}'` |
+
+## Related Skills
+
+- `/git:maintain` — invokes this before any stash/clean operation
+- `/git:commit` — invokes this before staging when working in a shared checkout
+- `git-branch-pr-workflow` — recommends worktrees as the structural fix

--- a/git-plugin/skills/git-coworker-check/scripts/claim-session.sh
+++ b/git-plugin/skills/git-coworker-check/scripts/claim-session.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Write a session marker and capture a baseline snapshot so this session can
+# later distinguish its own changes from a coworker's.
+#
+# Marker path: <git-dir>/.claude-session-<pid>
+# Baseline:    <git-dir>/.claude-baseline-<pid>.status
+#              <git-dir>/.claude-baseline-<pid>.stash
+#
+# The caller is responsible for deleting these on exit (or trusting the
+# `kill -0` stale-marker sweep in detect-coworkers.sh).
+
+set -uo pipefail
+
+project_dir=""
+pid_override=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --project-dir) project_dir="$2"; shift 2 ;;
+    --pid) pid_override="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "$project_dir" ]; then
+  project_dir="$(pwd)"
+fi
+
+cd "$project_dir" || exit 1
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "NOT_A_REPO=true"
+  exit 0
+fi
+
+git_dir="$(git rev-parse --git-dir)"
+pid="${pid_override:-$$}"
+
+marker="$git_dir/.claude-session-$pid"
+baseline_status="$git_dir/.claude-baseline-$pid.status"
+baseline_stash="$git_dir/.claude-baseline-$pid.stash"
+
+printf 'pid=%s\nstarted=%s\nhost=%s\ncwd=%s\n' \
+  "$pid" "$(date -Iseconds)" "$(hostname)" "$project_dir" > "$marker"
+
+git status --porcelain=v2 --branch > "$baseline_status" 2>/dev/null || true
+git stash list > "$baseline_stash" 2>/dev/null || true
+
+echo "MARKER=$marker"
+echo "BASELINE_STATUS=$baseline_status"
+echo "BASELINE_STASH=$baseline_stash"

--- a/git-plugin/skills/git-coworker-check/scripts/detect-coworkers.sh
+++ b/git-plugin/skills/git-coworker-check/scripts/detect-coworkers.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# Detect other Claude/agent processes working in the same repo clone.
+#
+# Combines three signals:
+#   1. Baseline drift  — optional snapshot from a prior session
+#   2. Session markers — .git/.claude-session-<pid> files written by coworkers
+#   3. Process scan    — other claude/node processes whose cwd is this repo
+#
+# Output is a block of KEY=value lines plus === SECTION === headers so the
+# invoking skill can parse results without re-running git.
+#
+# Exit code: 0 always (diagnostic; the skill decides how to react).
+
+set -uo pipefail
+
+project_dir=""
+baseline_status=""
+baseline_stash=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --project-dir) project_dir="$2"; shift 2 ;;
+    --baseline-status) baseline_status="$2"; shift 2 ;;
+    --baseline-stash) baseline_stash="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "$project_dir" ]; then
+  project_dir="$(pwd)"
+fi
+
+cd "$project_dir" || exit 0
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "NOT_A_REPO=true"
+  exit 0
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+git_dir="$(git rev-parse --git-dir)"
+self_pid="$$"
+
+# Build an exclusion set of ancestor PIDs — the Claude process that invoked
+# this script is not a "coworker". Read PPid from /proc/<pid>/status.
+ancestors=" $self_pid "
+if [ -d /proc ]; then
+  cur="$self_pid"
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    status_file="/proc/$cur/status"
+    [ -r "$status_file" ] || break
+    ppid="$(awk '/^PPid:/ {print $2; exit}' "$status_file")"
+    case "$ppid" in ''|0|1) break ;; esac
+    ancestors="$ancestors$ppid "
+    cur="$ppid"
+  done
+fi
+
+echo "REPO_ROOT=$repo_root"
+echo "SELF_PID=$self_pid"
+echo "HOSTNAME=$(hostname)"
+echo "TIMESTAMP=$(date -Iseconds)"
+
+status_drift="unknown"
+stash_drift="unknown"
+marker_drift=0
+proc_drift=0
+
+# =========================================================================
+# Signal 1: baseline drift
+# =========================================================================
+echo "=== BASELINE_DRIFT ==="
+
+current_status="$(git status --porcelain=v2 --branch 2>/dev/null || true)"
+current_stash="$(git stash list 2>/dev/null || true)"
+
+if [ -n "$baseline_status" ] && [ -f "$baseline_status" ]; then
+  new_status_lines="$(diff <(cat "$baseline_status") <(printf '%s' "$current_status") | awk '/^> / {sub(/^> /,""); print}')"
+  if [ -n "$new_status_lines" ]; then
+    status_drift="true"
+    echo "DRIFT_FILES=true"
+    echo "=== NEW_STATUS_LINES ==="
+    printf '%s\n' "$new_status_lines"
+    echo "=== END_NEW_STATUS_LINES ==="
+  else
+    status_drift="false"
+    echo "DRIFT_FILES=false"
+  fi
+else
+  echo "DRIFT_FILES=unknown"
+  echo "DRIFT_FILES_REASON=no baseline snapshot provided"
+fi
+
+if [ -n "$baseline_stash" ] && [ -f "$baseline_stash" ]; then
+  new_stash_lines="$(diff <(cat "$baseline_stash") <(printf '%s' "$current_stash") | awk '/^> / {sub(/^> /,""); print}')"
+  if [ -n "$new_stash_lines" ]; then
+    stash_drift="true"
+    echo "DRIFT_STASH=true"
+    echo "=== NEW_STASH_LINES ==="
+    printf '%s\n' "$new_stash_lines"
+    echo "=== END_NEW_STASH_LINES ==="
+  else
+    stash_drift="false"
+    echo "DRIFT_STASH=false"
+  fi
+else
+  echo "DRIFT_STASH=unknown"
+fi
+
+# =========================================================================
+# Signal 2: session markers
+# =========================================================================
+echo "=== SESSION_MARKERS ==="
+
+for marker in "$git_dir"/.claude-session-*; do
+  [ -e "$marker" ] || continue
+  marker_pid="${marker##*.claude-session-}"
+  case "$marker_pid" in *[!0-9]*) continue ;; esac
+  if [ "$marker_pid" = "$self_pid" ]; then
+    continue
+  fi
+  if kill -0 "$marker_pid" 2>/dev/null; then
+    marker_drift=$((marker_drift + 1))
+    echo "MARKER_PID=$marker_pid"
+    echo "MARKER_FILE=$marker"
+    echo "MARKER_CONTENTS=$(tr '\n' '|' < "$marker")"
+  else
+    echo "STALE_MARKER=$marker"
+  fi
+done
+echo "OTHER_MARKER_COUNT=$marker_drift"
+
+# =========================================================================
+# Signal 3: process scan (best-effort)
+# =========================================================================
+echo "=== PROCESS_SCAN ==="
+
+if [ -d /proc ]; then
+  for pid_dir in /proc/[0-9]*; do
+    pid="${pid_dir##*/}"
+    case "$ancestors" in *" $pid "*) continue ;; esac
+    cwd="$(readlink "$pid_dir/cwd" 2>/dev/null)" || continue
+    case "$cwd" in
+      "$repo_root"|"$repo_root"/*)
+        comm="$(cat "$pid_dir/comm" 2>/dev/null | tr -d '\n' | head -c 80)"
+        case "$comm" in
+          claude|node|Claude|"claude code"|claude-code)
+            proc_drift=$((proc_drift + 1))
+            echo "PROC_PID=$pid"
+            echo "PROC_COMM=$comm"
+            echo "PROC_CWD=$cwd"
+            ;;
+        esac
+        ;;
+    esac
+  done
+  echo "PROC_SCAN_METHOD=proc"
+  echo "ANCESTORS_EXCLUDED=$ancestors"
+elif command -v lsof >/dev/null 2>&1; then
+  lsof_out="$(lsof -a -d cwd -c claude -c node -Fpn 2>/dev/null || true)"
+  pid=""
+  while IFS= read -r line; do
+    case "$line" in
+      p*) pid="${line#p}" ;;
+      n*)
+        path="${line#n}"
+        case "$path" in
+          "$repo_root"|"$repo_root"/*)
+            if [ -n "$pid" ] && [ "$pid" != "$self_pid" ]; then
+              proc_drift=$((proc_drift + 1))
+              echo "PROC_PID=$pid"
+              echo "PROC_CWD=$path"
+            fi
+            ;;
+        esac
+        ;;
+    esac
+  done <<< "$lsof_out"
+  echo "PROC_SCAN_METHOD=lsof"
+else
+  echo "PROC_SCAN_METHOD=unavailable"
+fi
+echo "OTHER_PROC_COUNT=$proc_drift"
+
+# =========================================================================
+# Summary verdict
+# =========================================================================
+echo "=== VERDICT ==="
+
+if [ "$marker_drift" -gt 0 ] || [ "$proc_drift" -gt 0 ]; then
+  verdict="coworker_detected"
+elif [ "$status_drift" = "true" ] || [ "$stash_drift" = "true" ]; then
+  verdict="drift_detected"
+else
+  verdict="clear"
+fi
+echo "VERDICT=$verdict"
+echo "STATUS_DRIFT=$status_drift"
+echo "STASH_DRIFT=$stash_drift"
+echo "MARKER_COUNT=$marker_drift"
+echo "PROC_COUNT=$proc_drift"

--- a/git-plugin/skills/git-coworker-check/scripts/release-session.sh
+++ b/git-plugin/skills/git-coworker-check/scripts/release-session.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Remove session marker and baseline files for the given PID (default: $$).
+
+set -uo pipefail
+
+project_dir=""
+pid_override=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --project-dir) project_dir="$2"; shift 2 ;;
+    --pid) pid_override="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "$project_dir" ]; then
+  project_dir="$(pwd)"
+fi
+
+cd "$project_dir" || exit 0
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  exit 0
+fi
+
+git_dir="$(git rev-parse --git-dir)"
+pid="${pid_override:-$$}"
+
+rm -f \
+  "$git_dir/.claude-session-$pid" \
+  "$git_dir/.claude-baseline-$pid.status" \
+  "$git_dir/.claude-baseline-$pid.stash"


### PR DESCRIPTION
## Summary

Adds detection for concurrent agents working in the same repo clone, so destructive git operations (`stash`, `reset --hard`, `checkout -- .`) don't wipe a coworker's in-flight changes. Motivated by a recurring failure mode: two agents sharing a checkout, one stashes "unexpected" files that are actually the other's work.

- **New rule** `.claude/rules/agent-coworker-detection.md` — three detection signals (baseline drift, session markers, process scan), response rules, anti-patterns, limitations.
- **New skill** `/git:coworker-check` with `--check` / `--claim` / `--release` modes. Scripts exclude the invoking Claude's ancestor chain so the check doesn't false-positive on itself.
- **Metadata** — registered the rule in `CLAUDE.md` and the skill in `git-plugin/README.md`.

### Detection signals

| Signal | Source | Cost |
|--------|--------|------|
| Baseline drift | Snapshot `git status` + `git stash list` at `--claim`; diff at `--check` | Free |
| Session marker | `.git/.claude-session-<pid>` written on claim, `kill -0` to ignore stale | Free |
| Process scan | `/proc/<pid>/cwd` on Linux, `lsof -Fpn` on macOS, excluding ancestors | ~100ms |

Verdict: `clear`, `drift_detected`, or `coworker_detected`. The skill tells the caller what to do for each.

## Scope not included

Intentionally left out of this draft — happy to follow up:

- Wiring the check into `git-commit` / `git-maintain` before destructive ops.
- A PreToolUse hook in `hooks-plugin` that blocks `git stash` / `git reset --hard` when a coworker is detected.
- A flow-diagram node in `git-plugin/docs/flow.md`.

## Test plan

- [x] `claim-session.sh` writes marker + baseline files inside `.git/`
- [x] `detect-coworkers.sh` reports `VERDICT=clear` when alone and excludes ancestor Claude processes
- [x] `detect-coworkers.sh` reports drift when files change between claim and check
- [x] `release-session.sh` removes marker + baseline files
- [ ] Run from a second checkout with a real coworker and confirm `VERDICT=coworker_detected`
- [ ] Confirm `lsof` path works on macOS (only the `/proc` path was exercised locally)

https://claude.ai/code/session_01Gfa3P3PsZeUcM72CvEwsZD