### PR TITLE
fix(git-plugin,blueprint-plugin): add label pre-check before --add-label calls

### DIFF
--- a/blueprint-plugin/skills/blueprint-work-order/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-work-order/SKILL.md
@@ -85,6 +85,10 @@ When `--from-issue N` is provided:
 4. **Update issue with link**:
    ```bash
    gh issue comment N --body "Work-order created: \`docs/blueprint/work-orders/NNN-task-name.md\`"
+   # Ensure the label exists before applying it
+   if ! gh label list --search "work-order" --json name | jq -e '.[] | select(.name=="work-order")' >/dev/null 2>&1; then
+     gh label create work-order --description "AI-assisted work order" --color "0E8A16"
+   fi
    gh issue edit N --add-label "work-order"
    ```
 

--- a/git-plugin/skills/git-issue-manage/SKILL.md
+++ b/git-plugin/skills/git-issue-manage/SKILL.md
@@ -138,8 +138,15 @@ Apply the same operation to multiple issues at once.
 
 **Bulk label:**
 ```bash
+# Pre-check: create any missing labels before applying
+for LABEL in $(echo "$LABELS" | tr ',' '\n'); do
+  if ! gh label list --search "$LABEL" --json name | jq -e ".[] | select(.name==\"$LABEL\")" >/dev/null 2>&1; then
+    echo "Label '$LABEL' not found — skipping (create it first with: gh label create \"$LABEL\")"
+    LABELS=$(echo "$LABELS" | sed "s/,$LABEL//;s/$LABEL,//;s/^$LABEL$//")
+  fi
+done
 for N in $ISSUE_NUMBERS; do
-  gh issue edit $N --add-label "$LABELS"
+  [ -n "$LABELS" ] && gh issue edit $N --add-label "$LABELS"
 done
 ```
 


### PR DESCRIPTION
## Summary

- **2 friction events, 2 sessions** (2026-W16): `could not add label: 'Label not found: docs'` / `could not add label: 'Label not found: chore'`
- Root cause: `gh issue edit --add-label X` fails HTTP 422 when label `X` does not exist in the repo
- Fix: add a label existence pre-check before every imperative `--add-label` call in skills

## Changes

- `blueprint-plugin/skills/blueprint-work-order/SKILL.md`: create-if-missing before applying `work-order` label
- `git-plugin/skills/git-issue-manage/SKILL.md`: skip-with-warning pattern for bulk label operations

Generated by friction-learner 2026-W16.