### PR TITLE
fix(agents-plugin): replace stale BashOutput tool reference with TaskOutput

### DIFF
--- a/agents-plugin/agents/debug.md
+++ b/agents-plugin/agents/debug.md
@@ -3,7 +3,7 @@ name: debug
 model: opus
 color: "#FF7043"
 description: Diagnose and fix bugs. Finds root cause, implements fix, verifies solution. Handles errors, failures, and unexpected behavior.
-tools: Glob, Grep, LS, Read, Edit, Write, Bash(npm *), Bash(yarn *), Bash(bun *), Bash(pytest *), Bash(python *), Bash(node *), Bash(cargo *), Bash(go *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git show *), BashOutput, TodoWrite
+tools: Glob, Grep, LS, Read, Edit, Write, Bash(npm *), Bash(yarn *), Bash(bun *), Bash(pytest *), Bash(python *), Bash(node *), Bash(cargo *), Bash(go *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git show *), TaskOutput, TodoWrite
 maxTurns: 20
 created: 2025-12-27
 modified: 2026-03-09

--- a/agents-plugin/agents/test.md
+++ b/agents-plugin/agents/test.md
@@ -3,7 +3,7 @@ name: test
 model: haiku
 color: "#4CAF50"
 description: Write and run tests. Analyzes code, writes appropriate tests, executes them, and reports results. Completes the full testing cycle.
-tools: Glob, Grep, LS, Read, Edit, Write, Bash(npm test *), Bash(npm run test *), Bash(yarn test *), Bash(bun test *), Bash(pytest *), Bash(vitest *), Bash(jest *), Bash(cargo test *), Bash(go test *), Bash(git status *), Bash(git diff *), Bash(git log *), BashOutput, TodoWrite
+tools: Glob, Grep, LS, Read, Edit, Write, Bash(npm test *), Bash(npm run test *), Bash(yarn test *), Bash(bun test *), Bash(pytest *), Bash(vitest *), Bash(jest *), Bash(cargo test *), Bash(go test *), Bash(git status *), Bash(git diff *), Bash(git log *), TaskOutput, TodoWrite
 maxTurns: 20
 created: 2025-12-27
 modified: 2026-04-18


### PR DESCRIPTION
## Summary

Replace `BashOutput` with `TaskOutput` in the `tools:` frontmatter of two agents.

- `agents-plugin/agents/test.md`
- `agents-plugin/agents/debug.md`

`BashOutput` is not a current Claude Code tool name; the background-task output tool is `TaskOutput`. Agents that listed `BashOutput` in their tool allowlist were calling a non-existent tool.

## Evidence

Surfaced by automated friction-learner analysis for week 2026-W16: 2 events of agents calling a non-existent `BashOutput` tool across 2 sessions.

## Scope

Minimal — only the tool-name rename. No other edits.

## Refs

- `/tmp/friction/clusters.json` (on the scheduler runner)
- Generated by friction-learner 2026-W16