### PR TITLE
fix(agents-plugin): replace stale BashOutput tool reference with TaskOutput

### DIFF
--- a/agents-plugin/agents/debug.md
+++ b/agents-plugin/agents/debug.md
@@ -3,11 +3,11 @@ name: debug
 model: opus
 color: "#FF7043"
 description: Diagnose and fix bugs. Finds root cause, implements fix, verifies solution. Handles errors, failures, and unexpected behavior.
-tools: Glob, Grep, LS, Read, Edit, Write, Bash(npm *), Bash(yarn *), Bash(bun *), Bash(pytest *), Bash(python *), Bash(node *), Bash(cargo *), Bash(go *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git show *), BashOutput, TodoWrite
+tools: Glob, Grep, LS, Read, Edit, Write, Bash(npm *), Bash(yarn *), Bash(bun *), Bash(pytest *), Bash(python *), Bash(node *), Bash(cargo *), Bash(go *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git show *), TaskOutput, TodoWrite
 maxTurns: 20
 created: 2025-12-27
-modified: 2026-03-09
-reviewed: 2026-03-09
+modified: 2026-04-22
+reviewed: 2026-04-22
 ---
 
 # Debug Agent

--- a/agents-plugin/agents/test.md
+++ b/agents-plugin/agents/test.md
@@ -3,11 +3,11 @@ name: test
 model: haiku
 color: "#4CAF50"
 description: Write and run tests. Analyzes code, writes appropriate tests, executes them, and reports results. Completes the full testing cycle.
-tools: Glob, Grep, LS, Read, Edit, Write, Bash(npm test *), Bash(npm run test *), Bash(yarn test *), Bash(bun test *), Bash(pytest *), Bash(vitest *), Bash(jest *), Bash(cargo test *), Bash(go test *), Bash(git status *), Bash(git diff *), Bash(git log *), BashOutput, TodoWrite
+tools: Glob, Grep, LS, Read, Edit, Write, Bash(npm test *), Bash(npm run test *), Bash(yarn test *), Bash(bun test *), Bash(pytest *), Bash(vitest *), Bash(jest *), Bash(cargo test *), Bash(go test *), Bash(git status *), Bash(git diff *), Bash(git log *), TaskOutput, TodoWrite
 maxTurns: 20
 created: 2025-12-27
-modified: 2026-04-18
-reviewed: 2026-04-18
+modified: 2026-04-22
+reviewed: 2026-04-22
 ---
 
 # Test Agent


### PR DESCRIPTION
## Summary

The `BashOutput` tool was renamed to `TaskOutput` in a recent Claude Code release (documented in `.claude/rules/agent-development.md` and `.claude/rules/hooks-reference.md` — no mention of BashOutput remains). Agent definitions still listing `BashOutput` reference a tool that no longer exists, which reduces their effective capabilities when they need to inspect background task output.

Rename `BashOutput` → `TaskOutput` in the two agent definitions that still had the stale reference, and bump their `modified:` / `reviewed:` dates.

## Changes

- `agents-plugin/agents/debug.md` — `BashOutput` → `TaskOutput` in `tools:`, dates bumped to 2026-04-22
- `agents-plugin/agents/test.md` — `BashOutput` → `TaskOutput` in `tools:`, dates bumped to 2026-04-22

Diff: 6 insertions, 6 deletions.

## Provenance

Surfaced by the `friction-learner` 2026-W16 analysis — it found 2 events where agents tried to call the non-existent `BashOutput` tool and failed. The edits were staged in an earlier session but never committed; this PR finishes that work.

## Test plan

- [x] Staged diff is exactly the one-word rename + date bumps
- [x] Pre-commit hooks pass (no files matched the shell/lint/description checks since these are agent frontmatter edits)
- [ ] Spawn the `debug` agent and confirm it can use `TaskOutput` to read background task output
- [ ] Spawn the `test` agent and confirm the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)