### PR TITLE
fix(git-repo-agent): pre-validate repo state and preserve worktree changes on onboard

### DIFF
--- a/.claude/rules/agent-cli-worktree-safety.md
+++ b/.claude/rules/agent-cli-worktree-safety.md
@@ -1,0 +1,145 @@
+---
+paths:
+  - "git-repo-agent/**"
+  - "vault-agent/**"
+---
+
+# Agent-CLI Worktree Safety
+
+Data-loss prevention patterns for Python SDK agent CLIs (`git-repo-agent`, `vault-agent`, and any future sibling project built on `claude-agent-sdk` + Typer + git worktrees).
+
+## The Core Failure Mode
+
+These CLIs create a git worktree, invoke `ClaudeAgentOptions` to run an LLM orchestrator that writes files there, then clean up with `git worktree remove --force`. Three independent mistakes compound into silent data loss:
+
+1. **Driver phases write but don't commit** ("the outer orchestrator handles git state").
+2. **The outer orchestrator stalls** on `AskUserQuestion` (silently fails in SDK subprocess mode — see ADR-003) or otherwise ends without committing.
+3. **`worktree_has_changes` only checks commits** (`git log base..HEAD`), so it reports "no changes", and `cleanup_worktree` then force-removes the worktree.
+
+Net result: many files are written, the user sees "No changes were made", and the work is destroyed.
+
+## Required Invariants
+
+### 1. "Has changes" means commits OR dirty tree
+
+Any function used to decide whether a worktree is worth preserving **must** return true if the working tree is dirty, even when there are no commits beyond base:
+
+```python
+def worktree_has_changes(worktree_path, base_branch):
+    commits = subprocess.run(
+        ["git", "log", "--oneline", f"{base_branch}..HEAD"],
+        cwd=worktree_path, capture_output=True, text=True,
+    )
+    if commits.stdout.strip():
+        return True
+    dirty = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=worktree_path, capture_output=True, text=True,
+    )
+    return bool(dirty.stdout.strip())
+```
+
+A commits-only check is a data-loss bug. If uncommitted files matter for the next operation (push, PR, cleanup), they matter for the "has changes" check.
+
+### 2. Safety-net commit before any destructive cleanup
+
+If the agent phase was supposed to commit but didn't, capture the work anyway before moving on:
+
+```python
+def auto_commit_if_dirty(worktree_path, message):
+    status = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=worktree_path, capture_output=True, text=True, check=True,
+    )
+    if not status.stdout.strip():
+        return False
+    subprocess.run(["git", "add", "-A"], cwd=worktree_path, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", message],
+        cwd=worktree_path, check=True, capture_output=True, text=True,
+    )
+    return True
+```
+
+Call this from the post-run PR path (both interactive and non-interactive) with a clear message like `"chore({workflow}): commit remaining changes from agent run"` and print a warning so the user knows the safety net caught something.
+
+### 3. Pre-validate before git touches the path
+
+Typer's `exists=True, dir_okay=True` is not enough. Add explicit helpers and call them at the top of every command that will eventually run `git rev-parse`, `git worktree add`, or project-domain operations:
+
+```python
+def _ensure_git_repo(path):
+    inside = subprocess.run(
+        ["git", "rev-parse", "--is-inside-work-tree"],
+        cwd=path, capture_output=True, text=True,
+    )
+    if inside.returncode != 0 or inside.stdout.strip() != "true":
+        raise typer.Exit(code=EXIT_CONFIG_ERROR)
+    head = subprocess.run(
+        ["git", "rev-parse", "--verify", "HEAD"],
+        cwd=path, capture_output=True, text=True,
+    )
+    if head.returncode != 0:  # unborn HEAD — no commits yet
+        raise typer.Exit(code=EXIT_CONFIG_ERROR)
+```
+
+Add project-domain checks too (Obsidian vault → `.obsidian/` or any `*.md`; code repo → language marker). Print a friendly message; exit with `EXIT_CONFIG_ERROR`, not a traceback.
+
+**Unborn HEAD is its own failure class.** A fresh `git init` with no commits passes `--is-inside-work-tree` but fails every `rev-parse HEAD` and `worktree add -b <br> <path> HEAD` downstream. Always check both.
+
+### 4. Branch-name collisions are not free
+
+Timestamp-based branch names (`%Y-%m-%dT%H-%M`) collide when two runs start inside the same minute. If `create_worktree` force-removes a pre-existing worktree at the target path, the second run destroys the first's uncommitted agent output.
+
+Either:
+- Use second-granularity plus a short random suffix, or
+- Before removing a pre-existing worktree, probe `git status --porcelain` in it and **refuse** if dirty:
+
+```python
+if worktree_path.exists():
+    dirty = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=worktree_path, capture_output=True, text=True,
+    )
+    if dirty.returncode == 0 and dirty.stdout.strip():
+        raise RuntimeError(
+            f"Refusing to overwrite worktree at {worktree_path}: has "
+            f"uncommitted changes from a concurrent or prior run."
+        )
+```
+
+The advisory lock in `worktree.py::acquire_lock` only guards `--non-interactive` runs. Interactive and concurrent invocations need in-tree protection.
+
+## AskUserQuestion in SDK subprocess mode
+
+When `ClaudeAgentOptions` runs the CLI as an SDK subprocess, stdin/stdout carry the SDK JSON protocol. `AskUserQuestion` has no terminal to reach; the tool call fires, nothing renders, the model wraps up as if the user declined.
+
+- **Do not rely on `AskUserQuestion` for mid-pipeline interaction** in any onboard/maintain flow.
+- Use the two-phase interaction pattern (ADR-003): agent outputs findings and stops → Python collects input via `console.input()` → second `client.query()` executes the selection.
+- Remove `AskUserQuestion` from `allowed_tools` for paths that don't want silent failure.
+
+See [`git-repo-agent/docs/adr/003`](../../git-repo-agent/docs/) for the canonical write-up.
+
+## Required Tests
+
+Every agent CLI must have regression tests for:
+
+| Test | Verifies |
+|------|----------|
+| `test_worktree_has_changes_detects_untracked` | Dirty-tree detection covers the blueprint-driver-style "wrote files, never committed" case |
+| `test_auto_commit_if_dirty` | Safety-net commit captures uncommitted state and leaves the tree clean |
+| `test_create_worktree_refuses_to_overwrite_dirty` | Collision protection for same-minute runs |
+| `test_cli_rejects_non_git_target` | Friendly config error instead of `CalledProcessError` trace |
+| `test_cli_rejects_empty_git_repo` | Unborn-HEAD detection |
+| `test_cli_rejects_non_domain_target` (vault-agent: not a vault; git-repo-agent: N/A, domain is git) | Catches "pointed at the wrong directory" |
+
+Mirror the layouts in `git-repo-agent/tests/test_worktree_changes.py` and `vault-agent/tests/test_worktree.py::TestWorktreeCollisionSafety`.
+
+## Checklist When Adding a New Agent CLI
+
+- [ ] `_ensure_<domain>()` + `_ensure_git_repo()` called at the top of every write command
+- [ ] `worktree_has_changes` covers uncommitted + untracked state
+- [ ] `auto_commit_if_dirty` runs before any `cleanup_worktree(--force)` or push
+- [ ] `create_worktree` refuses to force-remove a dirty pre-existing worktree
+- [ ] Regression tests for each of the six rows above
+- [ ] Interactive flows use the ADR-003 two-phase pattern instead of mid-session `AskUserQuestion`

--- a/git-repo-agent/src/git_repo_agent/main.py
+++ b/git-repo-agent/src/git_repo_agent/main.py
@@ -1,6 +1,7 @@
 """CLI entry point for git-repo-agent."""
 
 import asyncio
+import subprocess
 import sys
 from pathlib import Path
 from typing import Optional
@@ -76,6 +77,37 @@ def _build_ni_config(
         )
     except NonInteractiveUsageError as exc:
         console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(code=EXIT_CONFIG_ERROR)
+
+
+def _ensure_git_repo(repo_path: Path) -> None:
+    """Exit with a friendly message if ``repo_path`` is not a git work tree with at least one commit."""
+    inside = subprocess.run(
+        ["git", "rev-parse", "--is-inside-work-tree"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+    )
+    if inside.returncode != 0 or inside.stdout.strip() != "true":
+        console.print(
+            f"[red]Error:[/red] {repo_path} is not a git repository. "
+            f"Run [bold]git init[/bold] (or use [bold]git-repo-agent new[/bold]) first."
+        )
+        raise typer.Exit(code=EXIT_CONFIG_ERROR)
+
+    head = subprocess.run(
+        ["git", "rev-parse", "--verify", "HEAD"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+    )
+    if head.returncode != 0:
+        console.print(
+            f"[red]Error:[/red] {repo_path} has no commits yet. "
+            f"Worktree-based workflows need a base commit — run "
+            f"[bold]git commit --allow-empty -m 'chore: initial commit'[/bold] "
+            f"(or stage and commit your files) first."
+        )
         raise typer.Exit(code=EXIT_CONFIG_ERROR)
 
 
@@ -437,6 +469,7 @@ def onboard(
     if not repo_path.is_dir():
         console.print(f"[red]Error:[/red] {repo_path} is not a directory")
         raise typer.Exit(code=EXIT_CONFIG_ERROR)
+    _ensure_git_repo(repo_path)
 
     ni = _build_ni_config(
         non_interactive=non_interactive,
@@ -518,6 +551,7 @@ def maintain(
     if not repo_path.is_dir():
         console.print(f"[red]Error:[/red] {repo_path} is not a directory")
         raise typer.Exit(code=EXIT_CONFIG_ERROR)
+    _ensure_git_repo(repo_path)
 
     ni = _build_ni_config(
         non_interactive=non_interactive,
@@ -735,6 +769,7 @@ def route(
     if not repo_path.is_dir():
         console.print(f"[red]Error:[/red] {repo_path} is not a directory")
         raise typer.Exit(code=EXIT_CONFIG_ERROR)
+    _ensure_git_repo(repo_path)
 
     from .tools.attributes import (
         collect_attributes,

--- a/git-repo-agent/src/git_repo_agent/orchestrator.py
+++ b/git-repo-agent/src/git_repo_agent/orchestrator.py
@@ -95,6 +95,7 @@ from .tools.repo_analyzer import analyze_repo
 from .tools.report import generate_report
 from .worktree import (
     acquire_lock,
+    auto_commit_if_dirty,
     cleanup_worktree,
     create_github_issues,
     create_worktree,
@@ -256,6 +257,14 @@ async def _auto_handle_pr(
         result["pr_action"] = "no-changes"
         cleanup_worktree(repo_path, worktree_path)
         return result
+
+    if auto_commit_if_dirty(
+        worktree_path, f"chore({workflow}): commit remaining changes from agent run"
+    ):
+        console.print(
+            f"[yellow]Agent left uncommitted changes on {branch}; "
+            f"captured them as a safety-net commit.[/yellow]"
+        )
 
     if ni.auto_pr == "never":
         result["pr_action"] = "skipped-by-policy"
@@ -1163,6 +1172,14 @@ async def _prompt_pr_creation(
         console.print("[dim]No changes were made in the worktree.[/dim]")
         cleanup_worktree(repo_path, worktree_path)
         return
+
+    if auto_commit_if_dirty(
+        worktree_path, f"chore({workflow}): commit remaining changes from agent run"
+    ):
+        console.print(
+            f"[yellow]Agent left uncommitted changes on {branch}; "
+            f"captured them as a safety-net commit.[/yellow]"
+        )
 
     console.print()
     console.print(f"[bold]Changes committed on branch [cyan]{branch}[/cyan][/bold]")

--- a/git-repo-agent/src/git_repo_agent/prompts/compiler.py
+++ b/git-repo-agent/src/git_repo_agent/prompts/compiler.py
@@ -43,15 +43,15 @@ SUBAGENT_SKILLS: dict[str, list[str]] = {
         "blueprint-plugin/skills/blueprint-claude-md/SKILL.md",
         "blueprint-plugin/skills/blueprint-docs-list/SKILL.md",
         "blueprint-plugin/skills/blueprint-curate-docs/SKILL.md",
-        "code-quality-plugin/skills/docs-quality-check/SKILL.md",
+        "code-quality-plugin/skills/code-docs-quality/SKILL.md",
     ],
     "quality": [
         "code-quality-plugin/skills/code-review-checklist/SKILL.md",
         "code-quality-plugin/skills/code-antipatterns-analysis/SKILL.md",
-        "code-quality-plugin/skills/lint-check/SKILL.md",
+        "code-quality-plugin/skills/code-lint/SKILL.md",
         "code-quality-plugin/skills/dry-consolidation/SKILL.md",
         "code-quality-plugin/skills/code-silent-degradation/SKILL.md",
-        "code-quality-plugin/skills/linter-autofix/SKILL.md",
+        "code-quality-plugin/skills/code-lint-fix/SKILL.md",
     ],
     "security": [
         "git-plugin/skills/git-security-checks/SKILL.md",

--- a/git-repo-agent/src/git_repo_agent/worktree.py
+++ b/git-repo-agent/src/git_repo_agent/worktree.py
@@ -254,28 +254,58 @@ def create_worktree(repo_path: Path, branch: str) -> Path:
 
 
 def worktree_has_changes(worktree_path: Path, base_branch: str | None = None) -> bool:
-    """Check if the worktree has commits beyond the base branch.
+    """True if the worktree has commits beyond base OR any uncommitted/untracked changes.
 
-    Falls back to checking for any uncommitted changes if base_branch
-    detection fails.
+    Dirty-tree detection matters because subagents (e.g. the blueprint driver
+    phases) write files without committing, and force-removing the worktree
+    would otherwise discard that work. Callers that want to push must commit
+    any dirty state first — see ``auto_commit_if_dirty``.
     """
     if base_branch is None:
-        # Detect the base branch from the worktree's upstream
-        result = subprocess.run(
+        commits = subprocess.run(
             ["git", "log", "--oneline", "HEAD", "--not", "--remotes", "-1"],
             cwd=worktree_path,
             capture_output=True,
             text=True,
         )
-        return bool(result.stdout.strip())
+    else:
+        commits = subprocess.run(
+            ["git", "log", "--oneline", f"{base_branch}..HEAD"],
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+        )
+    if commits.stdout.strip():
+        return True
 
-    result = subprocess.run(
-        ["git", "log", "--oneline", f"{base_branch}..HEAD"],
+    dirty = subprocess.run(
+        ["git", "status", "--porcelain"],
         cwd=worktree_path,
         capture_output=True,
         text=True,
     )
-    return bool(result.stdout.strip())
+    return bool(dirty.stdout.strip())
+
+
+def auto_commit_if_dirty(worktree_path: Path, message: str) -> bool:
+    """Stage everything in the worktree and commit if the tree is dirty.
+
+    Safety net for workflows where the agent wrote files but didn't commit.
+    Returns True when a commit was created, False when the tree was already
+    clean. Raises ``subprocess.CalledProcessError`` on git failure.
+    """
+    status = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=worktree_path, capture_output=True, text=True, check=True,
+    )
+    if not status.stdout.strip():
+        return False
+    subprocess.run(["git", "add", "-A"], cwd=worktree_path, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", message],
+        cwd=worktree_path, check=True, capture_output=True, text=True,
+    )
+    return True
 
 
 def get_base_branch(repo_path: Path) -> str:

--- a/git-repo-agent/tests/test_worktree_changes.py
+++ b/git-repo-agent/tests/test_worktree_changes.py
@@ -1,0 +1,108 @@
+"""Regression tests for worktree change detection and safety-net commits.
+
+Covers the data-loss bug where blueprint-driver phases wrote many files in
+the onboarding worktree but didn't commit them; the old
+``worktree_has_changes`` only inspected commits, reported "no changes", and
+``cleanup_worktree --force`` then discarded the agent's work.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from git_repo_agent.worktree import (
+    auto_commit_if_dirty,
+    worktree_has_changes,
+)
+
+
+def _git_available() -> bool:
+    return shutil.which("git") is not None
+
+
+needs_git = pytest.mark.skipif(not _git_available(), reason="git not installed")
+
+
+def _init_repo(path: Path) -> None:
+    subprocess.run(["git", "init", "-b", "main", str(path)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(path), "config", "user.email", "test@example.com"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(path), "config", "user.name", "Test"],
+        check=True, capture_output=True,
+    )
+    (path / "README.md").write_text("init\n")
+    subprocess.run(["git", "-C", str(path), "add", "-A"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(path), "commit", "-m", "init"],
+        check=True, capture_output=True,
+    )
+
+
+@needs_git
+class TestWorktreeHasChanges:
+    def test_clean_tree_returns_false(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        assert worktree_has_changes(repo, "main") is False
+
+    def test_untracked_file_counts_as_changes(self, tmp_path: Path):
+        """Regression: blueprint driver writes untracked files. Old impl missed this."""
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        (repo / "new_file.md").write_text("content\n")
+        assert worktree_has_changes(repo, "main") is True
+
+    def test_modified_tracked_file_counts_as_changes(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        (repo / "README.md").write_text("modified\n")
+        assert worktree_has_changes(repo, "main") is True
+
+    def test_commit_beyond_base_counts_as_changes(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        subprocess.run(
+            ["git", "-C", str(repo), "checkout", "-b", "feature"],
+            check=True, capture_output=True,
+        )
+        (repo / "new_file.md").write_text("content\n")
+        subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "feat: add file"],
+            check=True, capture_output=True,
+        )
+        assert worktree_has_changes(repo, "main") is True
+
+
+@needs_git
+class TestAutoCommitIfDirty:
+    def test_clean_tree_returns_false(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        assert auto_commit_if_dirty(repo, "chore: noop") is False
+
+    def test_dirty_tree_gets_committed(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        (repo / "blueprint.json").write_text("{}\n")
+        (repo / "README.md").write_text("updated\n")
+
+        assert auto_commit_if_dirty(repo, "chore: safety-net") is True
+
+        log = subprocess.run(
+            ["git", "-C", str(repo), "log", "--oneline"],
+            check=True, capture_output=True, text=True,
+        )
+        assert "chore: safety-net" in log.stdout
+        status = subprocess.run(
+            ["git", "-C", str(repo), "status", "--porcelain"],
+            check=True, capture_output=True, text=True,
+        )
+        assert status.stdout.strip() == ""


### PR DESCRIPTION
## Summary

- Corrects three stale `code-quality-plugin` skill paths in `prompts/compiler.py` so subagent prompt loading no longer prints "not found, skipping" warnings.
- Adds `_ensure_git_repo()` in `main.py` (checks `--is-inside-work-tree` and `--verify HEAD`) and wires it into every command that creates a worktree, replacing the opaque `CalledProcessError (128)` trace with a friendly config-error exit.
- Teaches `worktree_has_changes` to inspect `git status --porcelain` in addition to commits, and introduces `auto_commit_if_dirty` as a safety net in both the interactive and non-interactive PR paths. Prevents the data-loss bug where the blueprint driver wrote files in the worktree but the LLM orchestrator ended without committing and `cleanup_worktree --force` then destroyed everything.
- Adds regression tests for dirty-tree detection and the safety-net commit.
- Adds `.claude/rules/agent-cli-worktree-safety.md` codifying the invariants discovered here for sibling agent CLIs. Path-scoped to `git-repo-agent/**` and `vault-agent/**`.

Refs #1120 (AskUserQuestion-in-SDK-subprocess — the underlying interaction failure that triggered the orchestrator to end without committing; mitigated here, proper fix in a follow-up).

## Test plan

- [x] `uv run pytest tests/ -q` inside `git-repo-agent/` — 168 pass (162 existing + 6 new)
- [x] `uv run git-repo-agent onboard /nonexistent-git` — exits 2 with friendly message
- [x] `uv run git-repo-agent onboard /tmp-empty-git` (fresh `git init`, no commits) — exits 2 with "no commits yet" hint
- [x] `SUBAGENT_SKILLS` compilation no longer prints "not found, skipping" warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)