### PR TITLE
fix(vault-agent): pre-validate vault+git and refuse to clobber dirty worktree

### DIFF
--- a/vault-agent/src/vault_agent/main.py
+++ b/vault-agent/src/vault_agent/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import signal
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any, Callable, Optional
@@ -74,6 +75,56 @@ def main(
 # ---------------------------------------------------------------------------
 # Non-interactive plumbing
 # ---------------------------------------------------------------------------
+
+
+def _ensure_vault(vault: Path) -> None:
+    """Exit with a friendly message if ``vault`` does not look like an Obsidian vault.
+
+    Accepts either (a) an `.obsidian/` config directory, or (b) at least one
+    markdown file anywhere below the root. This catches the "pointed at the
+    wrong directory" case before the agent starts writing.
+    """
+    if (vault / ".obsidian").is_dir():
+        return
+    # Fallback: any markdown file. Cheap because rglob is lazy.
+    for _ in vault.rglob("*.md"):
+        return
+    console.print(
+        f"[red]Error:[/red] {vault} does not look like an Obsidian vault "
+        f"(no [bold].obsidian/[/bold] directory and no markdown files)."
+    )
+    raise typer.Exit(code=EXIT_CONFIG_ERROR)
+
+
+def _ensure_git_repo(vault: Path) -> None:
+    """Exit with a friendly message if ``vault`` is not a git work tree with at least one commit.
+
+    Only needed for write modes that create worktrees. Read-only commands
+    (analyze, health, report, mocs) skip this check.
+    """
+    inside = subprocess.run(
+        ["git", "rev-parse", "--is-inside-work-tree"],
+        cwd=vault, capture_output=True, text=True,
+    )
+    if inside.returncode != 0 or inside.stdout.strip() != "true":
+        console.print(
+            f"[red]Error:[/red] {vault} is not a git repository. "
+            f"Write modes need git for worktree isolation — run [bold]git init[/bold] "
+            f"and commit your vault first."
+        )
+        raise typer.Exit(code=EXIT_CONFIG_ERROR)
+
+    head = subprocess.run(
+        ["git", "rev-parse", "--verify", "HEAD"],
+        cwd=vault, capture_output=True, text=True,
+    )
+    if head.returncode != 0:
+        console.print(
+            f"[red]Error:[/red] {vault} has no commits yet. "
+            f"Worktree-based workflows need a base commit — run "
+            f"[bold]git add -A && git commit -m 'chore: initial vault commit'[/bold] first."
+        )
+        raise typer.Exit(code=EXIT_CONFIG_ERROR)
 
 
 def _build_ni_config(
@@ -312,6 +363,7 @@ def analyze(
     format: str = typer.Option("text", "--format", help="text | json | markdown"),
 ) -> None:
     """Run all read-only analyzers and emit a report. No LLM."""
+    _ensure_vault(vault)
     audit = run_audit(vault)
     if format == "json":
         typer.echo(render_json(audit))
@@ -326,6 +378,7 @@ def health(
     vault: Path = typer.Argument(..., exists=True, file_okay=False, dir_okay=True),
 ) -> None:
     """Compute the vault health score (0-100). No LLM."""
+    _ensure_vault(vault)
     audit = run_audit(vault)
     h = audit.health
     console.print(
@@ -341,6 +394,7 @@ def report(
     format: str = typer.Option("md", "--format", help="md | json"),
 ) -> None:
     """Emit a formatted report from the latest analysis."""
+    _ensure_vault(vault)
     audit = run_audit(vault)
     if format == "json":
         typer.echo(render_json(audit))
@@ -366,6 +420,9 @@ def lint(
     ),
 ) -> None:
     """Mechanical fixes: bare emoji tags, legacy id:, Templater leakage."""
+    _ensure_vault(vault)
+    if not dry_run:
+        _ensure_git_repo(vault)
     ni = _build_ni_config(
         non_interactive=non_interactive,
         apply=not dry_run,
@@ -405,6 +462,9 @@ def links(
     ),
 ) -> None:
     """Broken-wikilink repair and cross-namespace ambiguity resolution."""
+    _ensure_vault(vault)
+    if not dry_run:
+        _ensure_git_repo(vault)
     ni = _build_ni_config(
         non_interactive=non_interactive,
         apply=not dry_run,
@@ -444,6 +504,9 @@ def stubs(
     ),
 ) -> None:
     """Classify FVH/z stubs; fix broken_redirects; report stale_duplicates."""
+    _ensure_vault(vault)
+    if not dry_run:
+        _ensure_git_repo(vault)
     ni = _build_ni_config(
         non_interactive=non_interactive,
         apply=not dry_run,
@@ -473,6 +536,7 @@ def mocs(
     ),
 ) -> None:
     """MOC analysis: inventory, coverage, missing-MOC candidates."""
+    _ensure_vault(vault)
     _, report = run_mocs(vault)
     typer.echo(render_mocs_report(report))
 
@@ -500,6 +564,9 @@ def maintain(
     ),
 ) -> None:
     """Run multiple modes sequentially in a single worktree."""
+    _ensure_vault(vault)
+    if not dry_run:
+        _ensure_git_repo(vault)
     mode_list = [m.strip() for m in modes.split(",") if m.strip()]
     ni = _build_ni_config(
         non_interactive=non_interactive,

--- a/vault-agent/src/vault_agent/worktree.py
+++ b/vault-agent/src/vault_agent/worktree.py
@@ -114,14 +114,30 @@ def get_base_branch(vault_path: Path) -> str:
 def create_worktree(vault_path: Path, branch: str) -> WorktreeHandle:
     """Create an isolated worktree on ``branch`` branched off HEAD.
 
-    Removes any stale worktree at the same path and deletes any leftover
-    branch of the same name.
+    Removes any stale *clean* worktree at the same path and deletes any
+    leftover branch of the same name. Refuses to remove a pre-existing
+    worktree that has uncommitted or untracked changes, since branch names
+    are minute-timestamped and two runs within the same minute would
+    otherwise destroy the first's agent output.
     """
     worktree_path = vault_path / ".claude" / "worktrees" / branch.replace("/", "-")
     worktree_path.parent.mkdir(parents=True, exist_ok=True)
     base = get_base_branch(vault_path)
 
     if worktree_path.exists():
+        dirty = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+        )
+        if dirty.returncode == 0 and dirty.stdout.strip():
+            raise RuntimeError(
+                f"Refusing to overwrite worktree at {worktree_path}: it has "
+                f"uncommitted changes from a concurrent or prior run. Review "
+                f"with `git -C {worktree_path} status`, then commit or discard "
+                f"before re-running."
+            )
         subprocess.run(
             ["git", "worktree", "remove", "--force", str(worktree_path)],
             cwd=vault_path,

--- a/vault-agent/tests/test_main_cli.py
+++ b/vault-agent/tests/test_main_cli.py
@@ -196,3 +196,60 @@ class TestBadFlags:
             ],
         )
         assert result.exit_code == EXIT_CONFIG_ERROR
+
+
+class TestVaultAndGitValidation:
+    """Regression: commands must reject non-vault / non-git targets with a friendly message
+    rather than crashing deep in the pipeline with ``CalledProcessError``.
+    """
+
+    def test_analyze_rejects_non_vault_dir(self, tmp_path: Path) -> None:
+        empty = tmp_path / "not-a-vault"
+        empty.mkdir()
+        runner = CliRunner()
+        result = runner.invoke(app, ["analyze", str(empty)])
+        assert result.exit_code == EXIT_CONFIG_ERROR
+        # Rich may line-wrap; normalize whitespace before asserting.
+        flat = " ".join(result.stdout.split())
+        assert "does not look like an Obsidian vault" in flat
+
+    def test_analyze_accepts_dir_with_markdown(self, tmp_path: Path) -> None:
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        (vault_dir / "note.md").write_text("# hi\n")
+        runner = CliRunner()
+        result = runner.invoke(app, ["analyze", str(vault_dir)])
+        assert result.exit_code == EXIT_SUCCESS
+
+    def test_lint_fix_rejects_non_git_vault(self, tmp_path: Path) -> None:
+        """A markdown-only dir passes the vault check but fails the git check for --fix."""
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        (vault_dir / "note.md").write_text("# hi\n")
+        runner = CliRunner()
+        result = runner.invoke(app, ["lint", str(vault_dir), "--fix", "--non-interactive"])
+        assert result.exit_code == EXIT_CONFIG_ERROR
+        flat = " ".join(result.stdout.split())
+        assert "not a git repository" in flat
+
+    def test_lint_fix_rejects_empty_git_repo(self, tmp_path: Path) -> None:
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        (vault_dir / "note.md").write_text("# hi\n")
+        subprocess.run(["git", "init", "-q", "-b", "main"], cwd=vault_dir, check=True)
+        runner = CliRunner()
+        result = runner.invoke(app, ["lint", str(vault_dir), "--fix", "--non-interactive"])
+        assert result.exit_code == EXIT_CONFIG_ERROR
+        flat = " ".join(result.stdout.split())
+        assert "no commits yet" in flat
+
+    def test_lint_dry_run_does_not_require_git(self, tmp_path: Path) -> None:
+        """Read-only previews only need a vault — they never touch worktrees."""
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        (vault_dir / "note.md").write_text("# hi\n")
+        runner = CliRunner()
+        result = runner.invoke(
+            app, ["lint", str(vault_dir), "--dry-run", "--non-interactive"]
+        )
+        assert result.exit_code == EXIT_SUCCESS

--- a/vault-agent/tests/test_worktree.py
+++ b/vault-agent/tests/test_worktree.py
@@ -105,3 +105,35 @@ class TestWorktreeLifecycle:
         assert "merge" in text
 
         cleanup_worktree(handle)
+
+
+class TestWorktreeCollisionSafety:
+    """Regression: two runs in the same minute produce the same branch name.
+
+    The old ``create_worktree`` force-removed any pre-existing worktree at
+    the target path. If the first run had uncommitted agent output there,
+    the second run would silently destroy it.
+    """
+
+    def test_refuses_to_overwrite_dirty_worktree(self, tmp_path: Path) -> None:
+        _init_repo(tmp_path)
+        branch = timestamped_branch()
+        handle = create_worktree(tmp_path, branch)
+
+        # Simulate agent output that wasn't committed yet.
+        (handle.worktree_path / "agent-output.md").write_text("valuable work\n")
+
+        with pytest.raises(RuntimeError, match="uncommitted changes"):
+            create_worktree(tmp_path, branch)
+
+        # Original work is preserved.
+        assert (handle.worktree_path / "agent-output.md").exists()
+
+    def test_overwrites_clean_worktree(self, tmp_path: Path) -> None:
+        _init_repo(tmp_path)
+        branch = timestamped_branch()
+        create_worktree(tmp_path, branch)
+
+        # Second call on a clean worktree is fine.
+        handle2 = create_worktree(tmp_path, branch)
+        assert handle2.worktree_path.exists()


### PR DESCRIPTION
## Summary

Applies the same hardening pattern we added to `git-repo-agent` (#1121) to its sibling `vault-agent`, whose README explicitly calls it "Modeled on git-repo-agent". A cross-check identified two of the same class of bugs (the stale-skill-paths bug was absent).

- Adds `_ensure_vault()` (looks for `.obsidian/` or any `*.md`) and `_ensure_git_repo()` (work tree + verified HEAD) helpers in `main.py`; wires them into every command. Read-only commands only need the vault check; write commands with `--fix` get both. Replaces the opaque `CalledProcessError (128)` deep in the worktree pipeline with a friendly config-error exit.
- Teaches `create_worktree` to probe `git status --porcelain` of a pre-existing worktree before force-removing it. Same-minute branch-name collisions no longer destroy the prior run's uncommitted agent output; callers get a `RuntimeError` with a recovery hint.
- New regression tests: `TestVaultAndGitValidation` in `test_main_cli.py` (non-vault, non-git, empty-repo, dry-run-without-git) and `TestWorktreeCollisionSafety` in `test_worktree.py` (dirty refusal + clean overwrite).

Refs #1120, related to #1121.

## Test plan

- [x] `uv run pytest tests/ -q` inside `vault-agent/` — 160 pass (153 existing + 7 new)
- [x] `uv run vault-agent analyze /tmp/empty-dir` — exits 2 with "does not look like an Obsidian vault"
- [x] `uv run vault-agent analyze /path/with/md-files` — succeeds (no git required for read-only)
- [x] Regression tests cover both the friendly-error path and the collision-refusal path

🤖 Generated with [Claude Code](https://claude.com/claude-code)