### PR TITLE
chore(manifests): add $schema references for editor validation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
   "name": "laurigates-claude-plugins",
   "owner": {
     "name": "Lauri Gates"

--- a/accessibility-plugin/.claude-plugin/plugin.json
+++ b/accessibility-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "accessibility-plugin",
   "version": "2.3.2",
   "description": "Accessibility and UX implementation - WCAG, ARIA, design tokens",

--- a/agent-patterns-plugin/.claude-plugin/plugin.json
+++ b/agent-patterns-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "agent-patterns-plugin",
   "version": "2.15.0",
   "description": "Agent configuration utilities - project assimilation, config auditing, teammate definitions, MCP management, and hooks configuration",

--- a/agents-plugin/.claude-plugin/plugin.json
+++ b/agents-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "agents-plugin",
   "version": "1.9.1",
   "description": "Task-focused agents for test, review, debug, docs, CI, security, refactoring, research, performance, and search-replace — with teammate and subagent role guidance",

--- a/api-plugin/.claude-plugin/plugin.json
+++ b/api-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "api-plugin",
   "version": "1.6.0",
   "description": "API integration and testing - REST endpoints, client generation, contract testing",

--- a/bevy-plugin/.claude-plugin/plugin.json
+++ b/bevy-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "bevy-plugin",
   "version": "1.3.1",
   "description": "Bevy game engine development - ECS, rendering, game architecture",

--- a/blog-plugin/.claude-plugin/plugin.json
+++ b/blog-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "blog-plugin",
   "version": "1.3.0",
   "description": "Blog post creation - project logs, technical write-ups, personal documentation",

--- a/blueprint-plugin/.claude-plugin/plugin.json
+++ b/blueprint-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "blueprint-plugin",
   "version": "3.28.1",
   "description": "Blueprint Development methodology - structured feature development with PRD/PRP workflow, three-layer architecture (plugin/generated/custom), and documentation-first development",

--- a/code-quality-plugin/.claude-plugin/plugin.json
+++ b/code-quality-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-quality-plugin",
   "version": "1.13.0",
   "description": "Code review, refactoring, linting, anti-pattern detection, and static analysis",

--- a/codebase-attributes-plugin/.claude-plugin/plugin.json
+++ b/codebase-attributes-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "codebase-attributes-plugin",
   "version": "1.2.0",
   "description": "Structured codebase health attributes with severity-based agent routing",

--- a/communication-plugin/.claude-plugin/plugin.json
+++ b/communication-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "communication-plugin",
   "version": "1.2.1",
   "description": "External communication formatting - Google Chat, ticket drafting",

--- a/component-patterns-plugin/.claude-plugin/plugin.json
+++ b/component-patterns-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "component-patterns-plugin",
   "version": "1.4.0",
   "description": "Reusable UI component patterns for implementing common features across different frameworks and tech stacks",

--- a/configure-plugin/.claude-plugin/plugin.json
+++ b/configure-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "configure-plugin",
   "version": "1.19.0",
   "description": "Project infrastructure standards - comprehensive project configuration for pre-commit, CI/CD, Docker, testing, linting, formatting, and more",

--- a/container-plugin/.claude-plugin/plugin.json
+++ b/container-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "container-plugin",
   "version": "2.8.0",
   "description": "Container development and deployment - Docker, registry, Skaffold",

--- a/css-plugin/.claude-plugin/plugin.json
+++ b/css-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "css-plugin",
   "version": "1.2.1",
   "description": "CSS tooling - Lightning CSS transpilation/minification, UnoCSS atomic utility generation",

--- a/documentation-plugin/.claude-plugin/plugin.json
+++ b/documentation-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "documentation-plugin",
   "version": "1.8.0",
   "description": "Documentation generation - API docs, README, knowledge graphs, LaTeX PDF conversion",

--- a/evaluate-plugin/.claude-plugin/plugin.json
+++ b/evaluate-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "evaluate-plugin",
   "version": "1.4.0",
   "description": "Skill evaluation and benchmarking - test skill effectiveness with behavioral eval cases, grade results, and track quality improvements",

--- a/feedback-plugin/.claude-plugin/plugin.json
+++ b/feedback-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "feedback-plugin",
   "version": "1.3.2",
   "description": "Session feedback analysis - capture skill bugs as GitHub issues and learn from weekly friction across sessions",

--- a/finops-plugin/.claude-plugin/plugin.json
+++ b/finops-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "finops-plugin",
   "version": "1.3.2",
   "description": "GitHub Actions FinOps analysis - billing, cache usage, workflow efficiency, and waste identification",

--- a/git-plugin/.claude-plugin/plugin.json
+++ b/git-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "git-plugin",
   "hooks": "./hooks.json",
   "version": "2.34.1",

--- a/github-actions-plugin/.claude-plugin/plugin.json
+++ b/github-actions-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "github-actions-plugin",
   "version": "1.7.0",
   "description": "GitHub Actions CI/CD - workflows, authentication, inspection",

--- a/health-plugin/.claude-plugin/plugin.json
+++ b/health-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "health-plugin",
   "version": "1.8.0",
   "description": "Diagnose and fix Claude Code configuration issues including plugin registry, settings, hooks, MCP servers, SessionStart executability, pre-commit validity, permissions coverage, and marketplace enrollment",

--- a/home-assistant-plugin/.claude-plugin/plugin.json
+++ b/home-assistant-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "home-assistant-plugin",
   "version": "1.3.0",
   "description": "Home Assistant configuration management - YAML configuration, automations, scripts, scenes, and entity management for Home Assistant installations",

--- a/hooks-plugin/.claude-plugin/plugin.json
+++ b/hooks-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "hooks-plugin",
   "version": "1.16.6",
   "description": "Claude Code hooks for enforcing best practices and workflow automation",

--- a/kubernetes-plugin/.claude-plugin/plugin.json
+++ b/kubernetes-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "kubernetes-plugin",
   "version": "1.7.1",
   "description": "Kubernetes and Helm operations - deployments, charts, releases, diagnostics",

--- a/langchain-plugin/.claude-plugin/plugin.json
+++ b/langchain-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "langchain-plugin",
   "version": "1.5.1",
   "description": "LangChain JS/TS development - agents, chains, LangGraph workflows, and Deep Agents patterns",

--- a/migration-patterns-plugin/.claude-plugin/plugin.json
+++ b/migration-patterns-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "migration-patterns-plugin",
   "version": "1.3.0",
   "description": "Migration patterns - dual write, shadow mode, and automated tool migrations (mypy→ty, black→ruff-format, flake8→ruff, ESLint→Biome)",

--- a/networking-plugin/.claude-plugin/plugin.json
+++ b/networking-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "networking-plugin",
   "version": "1.3.1",
   "description": "Network diagnostics, reconnaissance, monitoring, and HTTP load testing - trippy, gping, ss, RustScan, nmap, bandwhich, sniffnet, oha",

--- a/obsidian-plugin/.claude-plugin/plugin.json
+++ b/obsidian-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "obsidian-plugin",
   "version": "1.3.0",
   "description": "Obsidian CLI operations - vault management, search, properties, tasks, plugins, publish, and sync",

--- a/project-plugin/.claude-plugin/plugin.json
+++ b/project-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "project-plugin",
   "version": "1.13.0",
   "description": "Project initialization and management - setup, modernization, and continuous development workflows",

--- a/prompt-engineering-plugin/.claude-plugin/plugin.json
+++ b/prompt-engineering-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "prompt-engineering-plugin",
   "version": "1.1.1",
   "description": "Prompt engineering techniques for accurate, grounded Claude responses — anti-hallucination workflow with citation-backed analysis",

--- a/prose-plugin/.claude-plugin/plugin.json
+++ b/prose-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "prose-plugin",
   "version": "1.3.1",
   "description": "Prose transformation and style control - synthesis, distillation, tone, voice, clarity, and consistency for written text",

--- a/python-plugin/.claude-plugin/plugin.json
+++ b/python-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "python-plugin",
   "version": "1.5.1",
   "description": "Python development ecosystem - uv, ruff, pytest, packaging, type checking",

--- a/rust-plugin/.claude-plugin/plugin.json
+++ b/rust-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "rust-plugin",
   "version": "1.3.1",
   "description": "Rust development - cargo, clippy, testing, memory safety",

--- a/terraform-plugin/.claude-plugin/plugin.json
+++ b/terraform-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "terraform-plugin",
   "version": "1.7.1",
   "description": "Terraform and Terraform Cloud - infrastructure as code",

--- a/testing-plugin/.claude-plugin/plugin.json
+++ b/testing-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "testing-plugin",
   "version": "3.13.0",
   "description": "Test execution, TDD workflow, testing strategies, and quality analysis",

--- a/tools-plugin/.claude-plugin/plugin.json
+++ b/tools-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tools-plugin",
   "version": "2.6.0",
   "description": "General utilities - fd, rg, jq, yq, nushell, shell, imagemagick, mermaid, d2",

--- a/typescript-plugin/.claude-plugin/plugin.json
+++ b/typescript-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "typescript-plugin",
   "version": "1.8.0",
   "description": "TypeScript development - strict types, ESLint, Biome, Bun runtime, debugging, Sentry monitoring, dead code detection",

--- a/workflow-orchestration-plugin/.claude-plugin/plugin.json
+++ b/workflow-orchestration-plugin/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "workflow-orchestration-plugin",
   "version": "1.4.3",
   "description": "Workflow orchestration patterns for parallel agents, CI pipelines, preflight checks, and checkpoint-based refactoring. Addresses common friction in multi-branch operations, permission restrictions, and context limits.",


### PR DESCRIPTION
## Summary

- Anthropic published marketplace and plugin-manifest JSON schemas to SchemaStore as part of the fix for [anthropics/claude-code#9686](https://github.com/anthropics/claude-code/issues/9686).
- Wire both schemas into every `.claude-plugin/plugin.json` (38 files) and the top-level `.claude-plugin/marketplace.json` so editors get autocomplete and validation when we touch plugin entries.
- Scope is `chore(manifests)` — intentionally outside release-please's package map, so no version bumps fire.

## Schemas referenced

| File | `$schema` |
|------|-----------|
| `.claude-plugin/marketplace.json` | `https://json.schemastore.org/claude-code-marketplace.json` |
| `<plugin>/.claude-plugin/plugin.json` | `https://json.schemastore.org/claude-code-plugin-manifest.json` |

Both URLs confirmed reachable (200 via SchemaStore redirect).

## Test plan

- [x] All 39 modified files still parse (`jq empty` clean)
- [x] Diff is exactly one inserted line per file — no reformatting, em-dashes preserved in the 4 plugin descriptions that use them
- [ ] Load `marketplace.json` in the editor and confirm the schema loads without error
- [ ] Load a sample `plugin.json` and confirm autocomplete/validation works
- [ ] Verify release-please does **not** pick up any of these files for a version bump (scope is unmapped by design)

Refs anthropics/claude-code#9686

https://claude.ai/code/session_01ABxpW9aqB8ZUTcDmVzi3wz

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABxpW9aqB8ZUTcDmVzi3wz)_