### PR TITLE
feat(agent-patterns-plugin): refine parallel-agent-dispatch and add exclusive-lock-dispatch

### DIFF
--- a/agent-patterns-plugin/skills/exclusive-lock-dispatch/SKILL.md
+++ b/agent-patterns-plugin/skills/exclusive-lock-dispatch/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: exclusive-lock-dispatch
+description: |
+  Pre-dump-then-dispatch pattern for tools that hold an exclusive lock —
+  Ghidra projects, database migration locks, single-writer caches, git
+  indexes on shared checkouts, taskwarrior bulk modifications. Use when
+  planning a parallel fan-out and one or more candidate agents would need
+  a resource that cannot tolerate concurrent access, when a locked tool's
+  "retry" errors are showing up in agent returns, or when deciding whether
+  to serialise an agent or pre-compute its outputs. Complements
+  parallel-agent-dispatch §Wave Splits and workflow-wave-dispatch.
+user-invocable: false
+allowed-tools: Read, Glob, Grep, TodoWrite
+created: 2026-04-24
+modified: 2026-04-24
+reviewed: 2026-04-24
+---
+
+# Exclusive-Lock Dispatch
+
+The dispatch-time pattern for tools that hold an exclusive lock during
+execution. Running such a tool from multiple parallel agents is a guaranteed
+failure; running the same tool's *outputs* through many parallel agents is
+the right shape.
+
+## When to Use This Skill
+
+| Use this skill when… | Use `parallel-agent-dispatch` alone when… |
+|----------------------|-------------------------------------------|
+| Two or more candidate agents would invoke the same lock-holding tool | No candidate agent touches a locked resource |
+| A prior wave emitted lock-contention errors | Agents only read pre-computed artefacts |
+| You are debating "serialise the agent or pre-dump the artefacts?" | File scopes are disjoint and lock-free |
+| The tool in question is slow (decompilation, migration, compile) so re-running per agent would burn minutes | The lock holder is cheap enough to serialise without pre-dump |
+
+## Canonical Locked Resources
+
+| Tool / Resource | Lock Behaviour | Typical Symptom |
+|-----------------|---------------|-----------------|
+| Ghidra project (`.gpr`) | Single writer; second invocation fails | `Project is locked by another instance` |
+| Database migration lock | Single writer per database | Migration tool blocks or errors |
+| Git index on shared checkout (`.git/index.lock`) | Single writer per working tree | `index.lock` exists / cannot `git add` |
+| Taskwarrior bulk modify (`task modify`, `task done` ranges) | Effectively single-writer for the task store | Sporadic "task database is locked" or lost edits |
+| Single-writer build caches (ccache, cargo target/, Bazel action cache) | First writer serialises others | Spurious build failures or cache corruption |
+| Decompiler output caches | Re-analysis on every access | Minutes-per-agent rerun when artefacts could be shared |
+
+## The Anti-Pattern
+
+```
+Wave plan:
+  Agent A: ghidra -process BIN --script ExtractStrings.java
+  Agent B: ghidra -process BIN --script ExtractXrefs.java
+  Agent C: ghidra -process BIN --script ExtractStructs.java
+  Dispatched in parallel.
+```
+
+Second invocation refuses to open the project. The orchestrator receives
+two "failed" returns and, without this skill's discipline, dispatches
+*more* agents to "retry" — multiplying the lock contention.
+
+## The Pattern
+
+### Step 1 — One serialised run emits every artefact
+
+Run the locked tool exactly once (or once per distinct artefact kind),
+writing everything downstream agents will need into **gitignored scratch**.
+Keep the outputs under a stable path that the brief can reference:
+
+```
+tmp/decomp/strings.txt
+tmp/decomp/xrefs.json
+tmp/decomp/structs.json
+tmp/ghidra/analysis.log
+```
+
+The pre-dump agent runs alone in its wave. Its return contract includes
+the artefact paths as "produced" so downstream waves can cite them.
+
+### Step 2 — Downstream agents read, do not re-analyse
+
+Parallel agents in the next wave take the pre-computed artefacts as input
+and produce their implementation slabs from those. No lock-holder
+invocations, no re-analysis, no contention.
+
+Briefs must reference artefacts by path:
+
+> "Input artefacts: `tmp/decomp/strings.txt`, `tmp/decomp/xrefs.json`.
+> Treat as read-only. Do not re-run Ghidra."
+
+### Step 3 — Wave boundaries enforce exclusivity
+
+The orchestrator never places two lock-contenders in the same wave.
+`workflow-wave-dispatch` handles the scheduling; this skill is the
+pre-work that makes wide parallelism possible afterwards.
+
+## When to Pre-Dump vs Dispatch Directly
+
+| Situation | Decision |
+|-----------|----------|
+| N ≥ 2 candidate agents would each need a fresh analysis of the same source | **Pre-dump**: one serialised run, then fan out |
+| Exactly one agent needs the lock and no siblings do | **Dispatch directly**: the lone agent serialises itself |
+| Lock holder is fast (< 10s) and agents need fresh state | **Dispatch serially**: skip pre-dump, run agents one at a time |
+| Lock holder is slow and agents need only a stable snapshot | **Pre-dump**: amortises the cost across the fan-out |
+
+The pre-dump cost is paid once. Serialising N agents pays the lock cost
+N times and removes any parallelism benefit.
+
+## Ghidra Specifics
+
+Ghidra is the most common pre-dump target. The 12.x release changed
+scripting:
+
+| Concern | Current-as-of-2026 Answer |
+|---------|---------------------------|
+| Scripting language | `.java` post-scripts (Jython removed in 12.x) |
+| First-time vs re-run | `-import` on first run; `-process` once the binary is in the project |
+| Skip analyzers on re-run | `-noanalysis` |
+| Headless wrapper | `analyzeHeadless <project_dir> <project_name>` |
+| Output destination | Post-script writes to stdout or to a file under `tmp/` |
+
+A typical pre-dump recipe:
+
+```bash
+# First run: import and analyse once
+analyzeHeadless tmp/ghidra/ myproj -import path/to/bin \
+  -postScript ExtractEverything.java tmp/decomp/
+
+# Later runs: re-use analysis
+analyzeHeadless tmp/ghidra/ myproj -process bin -noanalysis \
+  -postScript RefreshStrings.java tmp/decomp/
+```
+
+For more-than-a-few-scripts workflows, extract the detailed recipe and
+script inventory to `REFERENCE.md` and cite it from here.
+
+## Taskwarrior Specifics
+
+The `~/.task/` store is single-writer in practice. Dispatching five
+agents to each `task modify` different filters produces sporadic
+"database is locked" errors and, worse, silently lost edits when one
+agent's write races another's.
+
+The rule is the same: one orchestrator-owned agent (or the orchestrator
+itself) performs the bulk mutation, derived tasks the parallel siblings
+need are emitted to gitignored scratch (`tmp/tasks.json`), and the
+parallel wave reads from scratch.
+
+## Quick Reference
+
+### Pre-Dispatch Checklist
+
+- [ ] Identified every locked resource across candidate agents
+- [ ] Confirmed which agents need lock access vs which just need artefacts
+- [ ] Decided pre-dump vs serial dispatch using the table above
+- [ ] Pre-dump artefacts targeted at a gitignored path under `tmp/`
+- [ ] Downstream briefs reference artefact paths, not the lock holder
+- [ ] Lock-holder agent runs alone in its wave
+
+### Common Mistakes
+
+| Mistake | Correct Approach |
+|---------|-----------------|
+| Dispatching N agents that each run the locked tool | Pre-dump once, fan out on artefacts |
+| Retrying the locked agent on failure | Diagnose the lock, then either serialise or pre-dump |
+| Committing `tmp/decomp/` or `tmp/ghidra/` | `.gitignore` the scratch directory |
+| Briefing "and run Ghidra again to double-check" | Once the artefacts exist, treat them as authoritative |
+
+## Related
+
+- `parallel-agent-dispatch` — overall dispatch contract; §Wave Splits cites this skill
+- `workflow-wave-dispatch` — wave scheduling between lock-holder and parallel waves
+- `.claude/rules/parallel-safe-queries.md` — commands that exit 1 on empty, a different form of parallel foot-gun
+
+> Evidence: six-wave renderer landing shipped with zero lock-contention
+> retries after adopting pre-dump for the decompiler and the task queue.
+> Before this discipline, ad-hoc parallel dispatches frequently consumed
+> an entire wave recovering from lock errors.

--- a/agent-patterns-plugin/skills/parallel-agent-dispatch/SKILL.md
+++ b/agent-patterns-plugin/skills/parallel-agent-dispatch/SKILL.md
@@ -13,8 +13,8 @@ description: |
 user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 created: 2026-04-21
-modified: 2026-04-21
-reviewed: 2026-04-21
+modified: 2026-04-24
+reviewed: 2026-04-24
 ---
 
 # Parallel Agent Dispatch
@@ -72,6 +72,73 @@ These budgets are what prevents the "security audit agent hit context limits"
 and "prompt is too long" failure modes — without them, a well-intentioned
 agent exhausts its window on exploration and truncates its actual deliverable.
 
+#### Shared-File Exclusion List
+
+Even when each agent's declared file scope is disjoint, a second list of
+**orchestrator-only files** must be excluded from every agent's write-path.
+These are the files that many agents are tempted to touch because their work
+"relates to" them, and where last-writer-wins silently destroys earlier work.
+
+Adapt this template to the repository's stack:
+
+- Blueprint manifest (`docs/blueprint/manifest.json`) — ID registry, agents
+  risk clobbering each other's pre-allocated IDs
+- Per-project feature tracker (stats, phases, notes) — touched by every slab
+- Top-level plan / roadmap docs — agents cite these, they do not edit them
+- Build manifests (`CMakeLists.txt`, `pyproject.toml`, `package.json`,
+  `Cargo.toml`, `go.mod`) — added-dependency edits are cross-cutting
+- `justfile` / `Makefile` — new recipes land through the orchestrator so
+  conflicting recipe names surface at review time
+- Local task-queue stores (e.g. `~/.task/` for taskwarrior) — serialised
+  writes, never concurrent
+
+Every dispatched agent brief must call these out explicitly as **not in
+scope**, regardless of what the agent's declared write-paths say. The
+exclusion list belongs under a `### Orchestrator-only files` heading in
+the brief, not buried in prose.
+
+> Evidence: five-agent parallel dispatch, zero merge conflicts (2026-04-23).
+> Before this discipline, informal dispatches suffered silent manifest
+> clobbers (last-writer-wins) because each agent independently "also"
+> updated the manifest.
+
+#### Pre-Allocated Blueprint IDs
+
+The Worktree Preflight table mandates a **shared counter snapshot**. That
+snapshot must expand into **explicit per-agent ID assignment** in each
+brief — "Use WO-012 for this slice. Other agents claim WO-013 and WO-014."
+
+"Pick the next free ID" is a race condition under parallelism: two agents
+read the same counter, both allocate the same number, the second commit
+silently overwrites the first's manifest entry. Pre-allocation eliminates
+the race; the orchestrator, running alone, is the only writer.
+
+The same discipline applies to any shared monotonic identifier — ADR
+numbers, migration sequences, feature-request codes, PRP slugs. If agents
+need to reference them, the orchestrator assigns them up front.
+
+> Evidence: pre-allocation was added after observing a silent WO-number
+> collision in an early three-agent dispatch.
+
+#### Wave Splits for Exclusive Locks
+
+At dispatch time, check every candidate agent for resources with an
+**exclusive lock**:
+
+- Ghidra project lock (analyses fail on second concurrent invocation)
+- Git index on a shared checkout (two agents in the same cwd contend)
+- Database migration lock (single-writer)
+- Task-queue bulk modifications (taskwarrior `task modify`, `task done`
+  across many IDs)
+- Single-writer caches (build outputs, compiled decompilation)
+
+An agent that needs an exclusive lock **cannot share a wave** with another
+lock-contender. Either dispatch the lock-holder alone and parallelise the
+siblings afterwards, or pre-compute the locked tool's artefacts to
+gitignored scratch so all downstream agents read-only siblings.
+
+See `exclusive-lock-dispatch` for the full pattern.
+
 ### 3. Return Contract (mandatory structured summary)
 
 Every parallel agent must end its run with this schema as its final message,
@@ -104,6 +171,37 @@ regardless of success or failure:
 Include the schema verbatim in every dispatched agent's prompt under a heading
 like `### Return contract (mandatory)`. Do not paraphrase — agents follow
 concrete schemas more reliably than prose instructions.
+
+#### Verbatim patches, not prose
+
+The single largest productivity multiplier across multi-wave dispatches is
+filling **`Orchestrator action needed`** with **complete patches**, not
+prose descriptions of the edit.
+
+Agents should emit:
+
+- Complete CMake / build-manifest blocks with surrounding context, ready
+  for `Edit(old_string=…, new_string=…)`.
+- Full justfile / Makefile recipes including shebang and every parameter.
+- Literal prose paragraphs for docs updates — tracker evidence strings,
+  plan bullets, format-spec paragraphs — not "update the port plan with
+  findings about X."
+- Exact line numbers where the orchestrator must insert, when the target
+  is long.
+
+Prose descriptions like "add `src/foo.c` to `CMakeLists.txt`" force the
+orchestrator to re-derive the exact position. At five agents per wave,
+that derivation cost multiplies and is measurably slower **and** more
+error-prone than mechanical pasting.
+
+The orchestrator's role for `Orchestrator action needed` is `Edit(old=…,
+new=…)` — a mechanical operation, not prose synthesis. Brief agents
+accordingly.
+
+> Evidence: six-wave landing of a renderer module shipped in one day,
+> with `Orchestrator action needed` uniformly populated with verbatim
+> patches. Earlier prose-style return contracts required the orchestrator
+> to re-read source files on every merge.
 
 ## Why the Schema Matters
 


### PR DESCRIPTION
## Summary

Adds four sections to `parallel-agent-dispatch` drawn from real multi-agent sessions (five parallel agents with zero merge conflicts; a six-wave renderer landing completed in one day):

- **Shared-File Exclusion List** — orchestrator-only files (build manifests, blueprint manifests, top-level plans, task-queue stores) that every dispatched agent must treat as out-of-scope regardless of declared write paths. Stops silent manifest clobbers.
- **Verbatim-Patch Discipline** — `Orchestrator action needed` must carry complete patches (CMake blocks, justfile recipes, literal prose for docs) so the orchestrator's role is `Edit(old=…, new=…)`, not prose synthesis.
- **Pre-Allocated Blueprint IDs** — the shared-counter snapshot expands into explicit per-agent ID assignment; "pick the next free one" is a race condition under parallelism.
- **Wave Splits for Exclusive Locks** — dispatch-time check that lock contenders cannot share a wave.

Adds `exclusive-lock-dispatch` as the companion skill covering the pre-dump-then-dispatch pattern for Ghidra, migration locks, shared git index, taskwarrior bulk modify, and single-writer caches. Documents when to pre-dump vs serialise and includes Ghidra-specific notes.

## Test plan

- [x] `scripts/plugin-compliance-check.sh` — agent-patterns-plugin all green
- [x] `scripts/lint-context-commands.sh` — no new issues
- [x] SKILL.md sizes under 500 lines: `parallel-agent-dispatch` 281 lines, `exclusive-lock-dispatch` 176 lines
- [x] `rg -i 'skullcaps|ghidra-project|skull16'` — no leaked internal paths
- [ ] Reviewer to sanity-check the Return Contract schema is unchanged (only new Verbatim-Patch Discipline subsection added beside it)