### PR TITLE
feat(taskwarrior-plugin): add coordination layer for multi-agent work

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -527,6 +527,22 @@
       "category": "language"
     },
     {
+      "name": "taskwarrior-plugin",
+      "source": "./taskwarrior-plugin",
+      "description": "Coordination layer for multi-agent work using taskwarrior - parallel-safe queries, urgency scoring, and optional GitHub linkage via ghid/ghpr UDAs",
+      "version": "1.0.0",
+      "keywords": [
+        "taskwarrior",
+        "coordination",
+        "multi-agent",
+        "queue",
+        "local-first",
+        "urgency",
+        "github-integration"
+      ],
+      "category": "automation"
+    },
+    {
       "name": "terraform-plugin",
       "source": "./terraform-plugin",
       "description": "Terraform and Terraform Cloud - infrastructure as code",

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -30,6 +30,7 @@
   "prose-plugin": "1.3.1",
   "python-plugin": "1.5.1",
   "rust-plugin": "1.3.1",
+  "taskwarrior-plugin": "1.0.0",
   "terraform-plugin": "1.7.1",
   "testing-plugin": "3.13.0",
   "tools-plugin": "2.6.0",

--- a/docs/PLUGIN-MAP.md
+++ b/docs/PLUGIN-MAP.md
@@ -192,6 +192,7 @@ Install based on your project's tech stack and domain.
 | evaluate-plugin | Behavioral skill evaluation, benchmarking, and quality improvement |
 | feedback-plugin | Capturing session skill feedback as GitHub issues |
 | tools-plugin | fd, rg, jq, shell, ImageMagick, d2 utilities |
+| taskwarrior-plugin | Multi-agent coordination via taskwarrior — parallel-safe queries, urgency scoring, optional GitHub issue/PR linkage |
 | workflow-orchestration-plugin | Parallel agent orchestration, CI pipelines, preflight checks, checkpoint refactoring |
 | migration-patterns-plugin | Safe database and system migration patterns — dual write, shadow mode, strangler fig; automated tooling migrations (mypy→ty, black→ruff-format, flake8→ruff, ESLint→Biome) |
 | prompt-engineering-plugin | Anti-hallucination workflow — grounded, citation-backed analysis from source documents |

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1025,6 +1025,39 @@
         }
       ]
     },
+    "taskwarrior-plugin": {
+      "component": "taskwarrior-plugin",
+      "release-type": "simple",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        }
+      ],
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance"
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactoring"
+        },
+        {
+          "type": "docs",
+          "section": "Documentation"
+        }
+      ]
+    },
     "terraform-plugin": {
       "component": "terraform-plugin",
       "release-type": "simple",

--- a/taskwarrior-plugin/.claude-plugin/plugin.json
+++ b/taskwarrior-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "taskwarrior-plugin",
+  "version": "1.0.0",
+  "description": "Coordination layer for multi-agent work using taskwarrior - parallel-safe queries, urgency scoring, and optional GitHub linkage via ghid/ghpr UDAs",
+  "keywords": [
+    "taskwarrior",
+    "coordination",
+    "multi-agent",
+    "queue",
+    "local-first",
+    "urgency",
+    "github-integration"
+  ]
+}

--- a/taskwarrior-plugin/README.md
+++ b/taskwarrior-plugin/README.md
@@ -1,0 +1,77 @@
+# taskwarrior-plugin
+
+Coordination layer for multi-agent work using [taskwarrior](https://taskwarrior.org/), the local-first command-line task manager. Complements GitHub for repositories with a remote; operates standalone for repositories without.
+
+## Why taskwarrior next to GitHub
+
+GitHub issues are the system of record for work the team should see. Taskwarrior is the coordination layer for work an agent (or the orchestrator) needs to query without rate limits, urgency-sort, or see in the five seconds before a wave dispatch.
+
+| Capability | GitHub issues | Taskwarrior |
+|-----------|---------------|-------------|
+| Parallel-safe `export`/JSON reads | Rate-limited | Local, unlimited |
+| Offline operation | No | Yes |
+| Urgency scoring | No (manual labels) | Native, tunable |
+| Custom fields (UDAs) | Labels only | Typed UDAs (numeric, string, date) |
+| Cost to read 50 items | 50 API calls or rate limit | Single `task export \| jq` |
+| Discovery surface | GitHub UI | Agent-queryable shell |
+
+Both systems stay in sync via UDAs (`ghid`, `ghpr`) and tags (`+gh`, `+pr-ready`, `+blocked-on-merge`). This plugin's skills detect GitHub remotes automatically and offer the linkage; repositories without a remote operate in local-only mode.
+
+## Skills
+
+| Skill | Purpose |
+|-------|---------|
+| `/taskwarrior:task-add` | File a task with bpid / bpdoc / bpms fields; offers GitHub issue linkage when a remote is detected |
+| `/taskwarrior:task-done` | Close a task, annotate with commit hash, drain the linked feature-tracker entry; offers to close the linked GitHub issue |
+| `/taskwarrior:task-status` | Read-only consolidated queue + drift report; folds in `gh pr status` when GitHub is present |
+| `/taskwarrior:task-coordinate` | Surface the next N unblocked tasks sorted by urgency that do not contend on an exclusive lock — input for parallel / wave dispatch |
+
+## User-Defined Attributes (UDAs)
+
+Taskwarrior UDAs are declared in `~/.taskrc`. On first use, `task-add` prompts to install the set below if missing.
+
+| UDA | Type | Purpose |
+|-----|------|---------|
+| `bpid` | string | Blueprint ID link (WO-NNN, PRP-NNN, FR-NNN) |
+| `bpdoc` | string | Repo-relative markdown path |
+| `bpms` | string | Milestone tag |
+| `ghid` | numeric | Linked GitHub issue number |
+| `ghpr` | numeric | Linked GitHub PR number |
+
+## Tag conventions
+
+| Tag | Meaning |
+|-----|---------|
+| `+wo` | Work order (from blueprint-plugin) |
+| `+prp` | PRP implementation plan |
+| `+fr` | Feature request |
+| `+re` | Research task |
+| `+gh` | Linked to a GitHub issue or PR |
+| `+pr-ready` | Implementation done, open PR, waiting on merge |
+| `+needs-review` | Ready for review |
+| `+blocked-on-merge` | Waiting on another PR to merge |
+| `+blocked` | Blocked on external factor |
+
+## GitHub-mode detection
+
+On first invocation the plugin probes:
+
+1. `git config --get remote.origin.url` — remote present?
+2. `gh auth status` — `gh` authenticated?
+
+Both pass → GitHub mode: `ghid` / `ghpr` fields are offered, PR status is folded into reports.
+Either fails → local-only mode: taskwarrior operates standalone, GitHub-specific prompts are skipped.
+
+Override via `.claude/taskwarrior-plugin.local.md` (see `agent-patterns-plugin:plugin-settings`).
+
+## Flow
+
+See [docs/flow.md](docs/flow.md) for a diagram of how the skills fit together.
+
+## Related
+
+- `agent-patterns-plugin:parallel-agent-dispatch` — dispatch contract that `task-coordinate` feeds
+- `agent-patterns-plugin:exclusive-lock-dispatch` — taskwarrior's own store is single-writer; bulk modifies need exclusive-lock discipline
+- `workflow-orchestration-plugin:workflow-wave-dispatch` — wave scheduling that `task-coordinate` supports
+- `.claude/rules/parallel-safe-queries.md` — the `task export \| jq` idiom this plugin follows
+- `blueprint-plugin:feature-tracking` — blueprint IDs that `bpid` links to

--- a/taskwarrior-plugin/docs/flow.md
+++ b/taskwarrior-plugin/docs/flow.md
@@ -1,0 +1,51 @@
+# taskwarrior-plugin Flow
+
+How the skills fit together as a coordination layer for multi-agent work.
+
+```mermaid
+flowchart TD
+    ADD[/taskwarrior:task-add/]:::fix
+    STATUS[/taskwarrior:task-status/]:::check
+    COORD[/taskwarrior:task-coordinate/]:::check
+    DONE[/taskwarrior:task-done/]:::fix
+
+    GH{{GitHub remote?}}:::prompt
+    STORE[(~/.task/)]
+
+    ADD --> GH
+    GH -->|yes| GHISSUE[link ghid / create issue]:::fix
+    GH -->|no| LOCAL[local-only task]:::fix
+    GHISSUE --> STORE
+    LOCAL --> STORE
+
+    STORE --> STATUS
+    STORE --> COORD
+    COORD -->|next N unblocked| DISPATCH[parallel-agent-dispatch / workflow-wave-dispatch]:::router
+
+    STATUS -->|drift detected| DONE
+    DONE -->|annotate commit| STORE
+    DONE -->|optional| CLOSEGH[gh issue close / gh pr comment]:::fix
+
+    classDef router fill:#4a9eff,stroke:#222,color:#fff
+    classDef check fill:#8fbc8f,stroke:#222,color:#000
+    classDef fix fill:#ffa500,stroke:#222,color:#000
+    classDef prompt fill:#dda0dd,stroke:#222,color:#000
+```
+
+## Legend
+
+| Class | Fill | Meaning |
+|-------|------|---------|
+| router | Blue | Orchestrating skill (external — the parallel / wave dispatch that consumes coordinate output) |
+| check | Green | Read-only diagnostic / query |
+| fix | Orange | Mutates the task store or GitHub |
+| prompt | Purple | Decision point |
+
+## Scope map
+
+| Skill | Scope |
+|-------|-------|
+| `task-add` | Create / link tasks |
+| `task-done` | Close / annotate tasks |
+| `task-status` | Read queue state |
+| `task-coordinate` | Query candidate agents for a dispatch wave |

--- a/taskwarrior-plugin/skills/task-add/SKILL.md
+++ b/taskwarrior-plugin/skills/task-add/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: task-add
+description: |
+  File a new taskwarrior task with blueprint linkage (bpid/bpdoc/bpms) and,
+  when a GitHub remote is present, optional issue linkage via ghid. Checks
+  for duplicates by bpid, offers to pre-fill from an existing GitHub issue,
+  or offers to create a new issue. Use when adding a coordination task for
+  multi-agent work, linking a blueprint WO to an actionable queue entry,
+  or mirroring a GitHub issue into the local task queue.
+args: "[description]"
+allowed-tools: Bash(task *), Bash(git config *), Bash(git rev-parse *), Bash(gh auth *), Bash(gh issue *), Bash(gh api *), Read, TodoWrite
+argument-hint: short task description
+created: 2026-04-24
+modified: 2026-04-24
+reviewed: 2026-04-24
+---
+
+# /taskwarrior:task-add
+
+File a coordination task. When a GitHub remote is present, offer optional linkage so GitHub stays the system of record and taskwarrior stays the parallel-safe query layer.
+
+## Context
+
+- Task CLI available: !`command -v task`
+- Git remote: !`git config --get remote.origin.url`
+- GH auth: !`gh auth status`
+- Existing UDAs: !`task _udas`
+- Duplicate check preamble: !`task _projects`
+
+## Parameters
+
+Parse `$ARGUMENTS`:
+
+- Freeform short description (required).
+- Optional inline `bpid:WO-012` / `bpdoc:docs/wo/012.md` / `bpms:M6` / `ghid:145` / `ghpr:99` fields.
+- Optional tags: `+wo`, `+prp`, `+fr`, `+re`, `+gh`, `+pr-ready`, `+needs-review`, `+blocked-on-merge`, `+blocked`.
+
+## Execution
+
+Execute this workflow:
+
+### Step 1: Ensure UDAs exist
+
+If `task _udas` output lacks `bpid`, `bpdoc`, `bpms`, `ghid`, or `ghpr`, offer to install them:
+
+```bash
+task config uda.bpid.type string
+task config uda.bpid.label "Blueprint ID"
+task config uda.bpdoc.type string
+task config uda.bpdoc.label "Blueprint doc"
+task config uda.bpms.type string
+task config uda.bpms.label "Milestone"
+task config uda.ghid.type numeric
+task config uda.ghid.label "GH Issue"
+task config uda.ghpr.type numeric
+task config uda.ghpr.label "GH PR"
+```
+
+Install only with user confirmation on first run per host.
+
+### Step 2: Detect GitHub mode
+
+GitHub mode is active when all of:
+
+1. `git config --get remote.origin.url` is non-empty
+2. `gh auth status` exits 0
+
+If either fails, skip GitHub-related branches in later steps.
+
+### Step 3: Duplicate check by bpid
+
+If `bpid:` was given, run parallel-safe:
+
+```bash
+task bpid:"$BPID" export | jq '.[] | {id, description, status}'
+```
+
+Never use `task bpid:"$BPID" list` — it exits 1 on empty result and cancels sibling tool calls in parallel batches (see `.claude/rules/parallel-safe-queries.md`).
+
+If a matching open task exists, report the ID and ask whether to update instead of re-add.
+
+### Step 4: Optionally pre-fill from a GitHub issue
+
+When GitHub mode is active and either `ghid:` is set or the description looks like an issue reference:
+
+```bash
+gh issue view "$GHID" --json number,title,body,labels,state
+```
+
+Offer to copy title into description, map labels to tags, and capture the issue number into the `ghid` UDA.
+
+If the user wants a new issue created, use:
+
+```bash
+gh issue create --title "$TITLE" --body "$BODY"
+```
+
+…then capture the returned issue number into `ghid`. Skip this branch entirely in local-only mode.
+
+### Step 5: Create the task
+
+Compose the taskwarrior add command from the collected inputs. Quote every field; tags use the `+tag` form:
+
+```bash
+task add "$DESCRIPTION" \
+  bpid:"$BPID" \
+  bpdoc:"$BPDOC" \
+  bpms:"$BPMS" \
+  ghid:"$GHID" \
+  ghpr:"$GHPR" \
+  +wo +gh
+```
+
+Run with only the fields that were provided; omit empty UDAs entirely rather than passing `uda:""`.
+
+### Step 6: Report
+
+Print:
+
+- New task ID
+- bpid → bpdoc → bpms chain
+- ghid/ghpr if linked
+- Tags applied
+- Suggested next step (`/taskwarrior:task-status` or `/taskwarrior:task-coordinate`)
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Duplicate check by bpid | `task bpid:WO-012 export \| jq '.[] \| {id, status}'` |
+| Pre-fill from issue | `gh issue view 145 --json number,title,body,labels` |
+| Next unblocked | `task status:pending -BLOCKED export \| jq '.[:3]'` |
+| Skip empty filter exit | Always use `export \| jq`, never `list` |
+
+## Quick Reference
+
+| Flag / field | Purpose |
+|--------------|---------|
+| `bpid:` | Blueprint ID link |
+| `bpdoc:` | Blueprint doc path |
+| `bpms:` | Milestone |
+| `ghid:` | GitHub issue number |
+| `ghpr:` | GitHub PR number |
+| `+wo` | Work order |
+| `+prp` | PRP |
+| `+fr` | Feature request |
+| `+re` | Research |
+| `+gh` | Linked to GitHub |
+| `+pr-ready` | Open PR waiting |
+| `+blocked-on-merge` | Waiting on another PR |
+
+## Related
+
+- `/taskwarrior:task-status` — see current queue
+- `/taskwarrior:task-done` — close an open task
+- `/taskwarrior:task-coordinate` — next-agent candidates for a wave
+- `.claude/rules/parallel-safe-queries.md` — why `export | jq`, never `list`
+- `blueprint-plugin:feature-tracking` — FR/WO IDs that `bpid` points at

--- a/taskwarrior-plugin/skills/task-coordinate/SKILL.md
+++ b/taskwarrior-plugin/skills/task-coordinate/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: task-coordinate
+description: |
+  Surface the next N unblocked taskwarrior tasks sorted by urgency,
+  filtered to skip any that contend on the same exclusive lock (Ghidra
+  project, git index, migration, bulk task store). Produces a
+  candidate-agent list for a parallel or wave dispatch. Use when
+  planning a parallel-agent-dispatch wave, when deciding which tasks
+  share a dispatch slot, or when deciding whether to pre-dump a locked
+  resource before fanning out.
+args: "[--n=N] [--lock=<resource>] [--wave]"
+allowed-tools: Bash(task *), Bash(jq *), Read, TodoWrite
+argument-hint: optional count (default 3) and lock filter
+created: 2026-04-24
+modified: 2026-04-24
+reviewed: 2026-04-24
+---
+
+# /taskwarrior:task-coordinate
+
+Next-candidate-agent surfacing for parallel / wave dispatch. Pairs with `agent-patterns-plugin:parallel-agent-dispatch` and `workflow-orchestration-plugin:workflow-wave-dispatch`.
+
+## Context
+
+- Task CLI available: !`command -v task`
+- Pending with urgency: !`task status:pending -BLOCKED export`
+- Pending blocked: !`task +BLOCKED export`
+
+## Parameters
+
+Parse `$ARGUMENTS`:
+
+- `--n=N` — number of candidates to surface (default 3)
+- `--lock=<resource>` — exclude candidates that need the named lock (e.g. `ghidra`, `migration`, `task-bulk`)
+- `--wave` — format output as a wave brief (orchestrator-ready)
+
+## Execution
+
+Execute this workflow:
+
+### Step 1: Load unblocked pending tasks
+
+```bash
+task status:pending -BLOCKED export \
+  | jq 'sort_by(-.urgency) | .[] | {id, description, urgency, tags, bpid, depends}'
+```
+
+Already filters out `depends:`-blocked tasks via the `-BLOCKED` virtual
+attribute. Never use `task next` — exits 1 on empty.
+
+### Step 2: Detect lock contenders
+
+Classify each task by the locks implied by its tags or `bpid`:
+
+| Tag / ID prefix | Implied lock |
+|-----------------|--------------|
+| `+re` on decomp work, `tmp/decomp/` in description | `ghidra` |
+| `+migration`, bpid starts with `MIG-` | `migration` |
+| `+bulk-task` | `task-bulk` (taskwarrior itself — single-writer) |
+| Matching `bpdoc` in shared manifest | `manifest` |
+
+Drop any candidate that matches the `--lock=` filter. Two tasks that
+would contend on the same lock cannot share a wave — keep the one with
+higher urgency, defer the other to the next wave.
+
+### Step 3: Rank and cap
+
+Keep the top N by urgency. If ties, prefer:
+
+1. Tasks with a pre-existing `bpdoc` (scope is already written down)
+2. Tasks without exclusive-lock contention
+3. Tasks with earlier `entry` (older first)
+
+### Step 4: Emit candidates
+
+Default format (compact):
+
+```
+1. #7   WO-012   Implement foo decoder                u:14.2
+2. #11  WO-013   Add foo CLI subcommand               u:12.8
+3. #15  WO-014   Document foo format spec             u:11.1
+```
+
+With `--wave`, emit a wave brief:
+
+```
+## Wave N candidates (3 agents, no lock contention)
+
+| # | Task | Scope | Exclusion |
+|---|------|-------|-----------|
+| A | WO-012 (task #7)  | src/codec/foo.c, tests/foo.c | orchestrator-only: CMakeLists.txt |
+| B | WO-013 (task #11) | cli/commands/foo.c           | orchestrator-only: CMakeLists.txt |
+| C | WO-014 (task #15) | docs/format-spec/foo.md      | orchestrator-only: docs/blueprint/manifest.json |
+
+Pre-allocated IDs: WO-012, WO-013, WO-014 (see parallel-agent-dispatch §Pre-Allocated Blueprint IDs).
+```
+
+### Step 5: Note deferred lock-contenders
+
+If the rank step dropped any lock-contending candidates, report them as
+deferred-to-next-wave with the lock name — the orchestrator decides
+whether to pre-dump via `exclusive-lock-dispatch` or serialise.
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Unblocked sorted by urgency | `task status:pending -BLOCKED export \| jq 'sort_by(-.urgency)'` |
+| Same-lock siblings | Filter on `tags` / bpid prefix locally, not via `task` filter |
+| Wave brief | `--wave` flag emits table with exclusion column |
+| Skip failing-filter variants | Never `task next`, always `export \| jq` |
+
+## Quick Reference
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--n=3` | 3 | How many candidates |
+| `--lock=ghidra` | unset | Drop ghidra-contending tasks |
+| `--wave` | off | Emit wave brief format |
+
+## Related
+
+- `agent-patterns-plugin:parallel-agent-dispatch` — the dispatch contract these candidates feed
+- `agent-patterns-plugin:exclusive-lock-dispatch` — when to pre-dump instead of serialise
+- `workflow-orchestration-plugin:workflow-wave-dispatch` — wave scheduling that consumes the brief
+- `.claude/rules/parallel-safe-queries.md` — `export | jq` idiom
+- `/taskwarrior:task-status` — full queue audit

--- a/taskwarrior-plugin/skills/task-done/SKILL.md
+++ b/taskwarrior-plugin/skills/task-done/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: task-done
+description: |
+  Close a taskwarrior task, annotate it with the landing commit hash, drain
+  the linked blueprint feature-tracker entry, and — when GitHub linkage is
+  present — offer to close the linked issue or comment on the linked PR.
+  Use when finishing a coordination task, marking a WO as complete, closing
+  out research after findings are promoted to docs, or closing a GitHub
+  issue linked via ghid.
+args: "<task-id> [commit-hash]"
+allowed-tools: Bash(task *), Bash(git config *), Bash(git log *), Bash(git rev-parse *), Bash(gh auth *), Bash(gh issue *), Bash(gh pr *), Read, Edit, TodoWrite
+argument-hint: task id (required), commit sha (optional — defaults to HEAD)
+created: 2026-04-24
+modified: 2026-04-24
+reviewed: 2026-04-24
+---
+
+# /taskwarrior:task-done
+
+Close a task with full coordination hygiene: annotate with the landing commit, drain the tracker entry, optionally close the GitHub issue.
+
+## Context
+
+- Task CLI available: !`command -v task`
+- Git remote: !`git config --get remote.origin.url`
+- GH auth: !`gh auth status`
+- HEAD commit: !`git rev-parse --short HEAD`
+- Current branch: !`git branch --show-current`
+
+## Parameters
+
+Parse `$ARGUMENTS`:
+
+- `$0` — task ID (required)
+- `$1` — commit hash (optional; defaults to `HEAD`)
+- `--no-gh` — skip GitHub close/comment even when remote is present
+- `--no-tracker` — skip blueprint tracker drain
+
+## Execution
+
+Execute this workflow:
+
+### Step 1: Load the task
+
+```bash
+task "$TASKID" export | jq '.[0]'
+```
+
+Never use `task $TASKID info` or `task $TASKID list` — both can exit 1 and
+cancel parallel siblings. `export | jq` returns valid JSON even when the
+task is already closed (treat empty as "no such open task" and abort).
+
+Capture: `bpid`, `bpdoc`, `ghid`, `ghpr`, `tags`, `description`.
+
+### Step 2: Resolve commit hash
+
+If `$1` is unset, read `git rev-parse --short HEAD`. Confirm the HEAD commit
+actually touches work this task covers before annotating — a stale HEAD is
+a common footgun.
+
+### Step 3: Annotate and close
+
+```bash
+task "$TASKID" annotate "landed: $COMMIT_SHORT $COMMIT_SUBJECT"
+task "$TASKID" done
+```
+
+Annotation first, then done — if close fails (e.g. dependencies), the
+annotation is still captured.
+
+### Step 4: Drain the blueprint tracker
+
+If `bpdoc` is set and points to a valid path, read the file and advance
+its status marker in place. Typical patterns by tracker format:
+
+- Feature-tracker JSON: `status: in_progress` → `status: done`, append
+  evidence entry citing the commit
+- Work-order markdown: check off the relevant bullet, add landed-in line
+- PRP: flip the "Implementation" status field
+
+Use `Edit` with a narrow `old_string` / `new_string` pair — do not rewrite
+the file. When `bpdoc` references a shared tracker (manifest.json, global
+feature-tracker), fall back to reporting "manual tracker update required"
+rather than concurrent-write the shared file.
+
+### Step 5: Close linked GitHub items (optional)
+
+When GitHub mode is active and `--no-gh` was not passed:
+
+- `ghid` set → offer `gh issue close "$GHID" --comment "Closed by $COMMIT_SHORT (branch $BRANCH)"`
+- `ghpr` set → offer `gh pr comment "$GHPR" --body "Linked task closed: $COMMIT_SHORT"`
+
+Always confirm before mutating GitHub state — the user may want to close
+the issue as part of the PR merge rather than ahead of time.
+
+### Step 6: Report
+
+Print:
+
+- Task closed: id + description + new status
+- Commit annotated: `$COMMIT_SHORT`
+- Tracker drained: path + diff summary, or "skipped"
+- GitHub: "issue #N closed" / "PR #N commented" / "skipped"
+- Unblocked siblings: any tasks whose `depends:` pointed at this one now
+  free to start (query via `task depends:$TASKID export | jq`)
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Load task | `task "$TASKID" export \| jq '.[0]'` |
+| Annotate + close | Two separate calls (hook-friendly) |
+| Blocked children | `task depends:"$TASKID" export \| jq '.[]'` |
+| Skip empty-result failures | Always `export \| jq` |
+
+## Quick Reference
+
+| Step | Command |
+|------|---------|
+| Load | `task ID export \| jq` |
+| Annotate | `task ID annotate "msg"` |
+| Close | `task ID done` |
+| Check unblocked siblings | `task depends:ID export \| jq '.[]'` |
+| GitHub close | `gh issue close N --comment "msg"` |
+| PR comment | `gh pr comment N --body "msg"` |
+
+## Related
+
+- `/taskwarrior:task-add` — file a task
+- `/taskwarrior:task-status` — see what's left
+- `blueprint-plugin:feature-tracking` — tracker format that `bpdoc` points at
+- `blueprint-plugin:blueprint-docs-currency` — companion discipline for the `bpdoc` update
+- `.claude/rules/parallel-safe-queries.md` — the `export | jq` idiom

--- a/taskwarrior-plugin/skills/task-status/SKILL.md
+++ b/taskwarrior-plugin/skills/task-status/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: task-status
+description: |
+  Read-only consolidated taskwarrior queue report — pending, blocked,
+  ready, and drift detection between the queue and linked trackers / PRs.
+  When a GitHub remote is present, folds in gh pr status so "PR #99 green,
+  task #7 still pending" surfaces in one view. Use when auditing queue
+  health, orienting before a wave dispatch, spotting tasks that lost
+  their linked issue or PR, or producing a standup summary.
+args: "[--mine] [--blocked] [--stale=N]"
+allowed-tools: Bash(task *), Bash(git config *), Bash(gh auth *), Bash(gh pr *), Bash(jq *), Read, TodoWrite
+argument-hint: optional filters
+created: 2026-04-24
+modified: 2026-04-24
+reviewed: 2026-04-24
+---
+
+# /taskwarrior:task-status
+
+Read-only status report on the coordination queue. Strictly uses `export | jq` — never `list` — so parallel Bash batches from downstream skills stay safe.
+
+## Context
+
+- Task CLI available: !`command -v task`
+- Pending count (export/jq): !`task status:pending export`
+- Git remote: !`git config --get remote.origin.url`
+- GH auth: !`gh auth status`
+
+## Parameters
+
+Parse `$ARGUMENTS`:
+
+- `--mine` — limit to tasks where `assigned:` matches current user / agent
+- `--blocked` — only tasks with `+blocked` / `+blocked-on-merge` or active `depends:`
+- `--stale=N` — highlight tasks modified > N days ago
+- No flags — full report
+
+## Execution
+
+Execute this workflow:
+
+### Step 1: Snapshot the queue
+
+Pull full state as JSON in a single call. `task export` emits `[]` on an
+empty store — valid and exit 0.
+
+```bash
+task status:pending export | jq '.[] | {id, description, urgency, tags, bpid, bpdoc, ghid, ghpr, modified, depends}'
+```
+
+For completeness also pull recently-completed:
+
+```bash
+task status:completed end.after:now-7d export | jq '.[] | {id, description, bpid, ghid, end}'
+```
+
+### Step 2: Sort and group
+
+By urgency descending, then by milestone (`bpms`), then by blueprint kind
+(`+wo` / `+prp` / `+fr` / `+re`). Use jq to partition:
+
+```bash
+task status:pending export \
+  | jq 'group_by(.bpms) | map({milestone: .[0].bpms, tasks: sort_by(-.urgency)})'
+```
+
+### Step 3: Drift detection
+
+For each task with `bpdoc`: check the file exists and is readable. Flag
+missing or unreadable `bpdoc` as drift.
+
+For each task with `ghid` in GitHub mode:
+
+```bash
+gh issue view "$GHID" --json number,state | jq
+```
+
+Flag:
+
+- Task open, issue closed — `drift: stale-open`
+- Task `+pr-ready` but PR not in `OPEN` — `drift: pr-state-mismatch`
+
+### Step 4: PR status fold-in (GitHub mode)
+
+```bash
+gh pr status --json number,title,state,statusCheckRollup | jq
+```
+
+Join by `ghpr` UDA. Annotate each matched task with its PR's check
+rollup (`SUCCESS` / `FAILURE` / `PENDING`). Tasks tagged `+pr-ready`
+with a green PR are the highest-value drain candidates.
+
+### Step 5: Render
+
+Output these sections, in order:
+
+1. **Summary**: pending count, ready count (unblocked), blocked count, stale count
+2. **By milestone**: table of pending tasks per `bpms`
+3. **Ready for dispatch**: top 5 by urgency with no `depends:` and no `+blocked*` tags
+4. **Blocked**: tasks waiting on dependencies or external factors
+5. **PR-ready** (GitHub mode): tasks with green PRs ready to close
+6. **Drift**: tasks with stale links (issue closed, missing bpdoc, etc.)
+
+Each row cites the command to act on it (`/taskwarrior:task-done 7`).
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Full queue JSON | `task status:pending export \| jq` |
+| Ready-for-dispatch | `task status:pending -BLOCKED export \| jq 'sort_by(-.urgency) \| .[:5]'` |
+| PR status | `gh pr status --json number,state,statusCheckRollup` |
+| Drift check | `gh issue view "$GHID" --json state` |
+| Never use | `task list`, `task next`, `task report` — exit 1 on empty |
+
+## Quick Reference
+
+| Filter | Expands to |
+|--------|-----------|
+| `status:pending` | Open tasks |
+| `-BLOCKED` | Exclude `depends:`-blocked |
+| `urgency.above:5` | High-urgency only |
+| `modified.before:now-30d` | Stale |
+| `bpms:M6` | Single milestone |
+
+## Related
+
+- `/taskwarrior:task-coordinate` — next-N candidates for dispatch
+- `/taskwarrior:task-add` — file something surfaced by drift detection
+- `/taskwarrior:task-done` — close PR-ready tasks
+- `.claude/rules/parallel-safe-queries.md` — `export | jq` idiom


### PR DESCRIPTION
## Summary

Introduces **taskwarrior-plugin** as a coordination layer that complements GitHub for multi-agent work. GitHub stays the system of record when present; taskwarrior adds the local, unlimited, agent-queryable surface with urgency scoring and typed UDAs that GitHub labels cannot model.

### Why next to GitHub

| Capability | GitHub issues | Taskwarrior |
|-----------|---------------|-------------|
| Parallel-safe reads | Rate-limited | Local, unlimited |
| Offline operation | No | Yes |
| Urgency scoring | Manual labels | Native |
| Typed custom fields | Labels only | UDAs (string/numeric/date) |
| Cost to read 50 items | 50 API calls | Single `task export \| jq` |

### Skills

- `/taskwarrior:task-add` — file a task with `bpid`/`bpdoc`/`bpms`; offers GitHub issue linkage when detected; duplicate check by `bpid`
- `/taskwarrior:task-done` — close, annotate with commit hash, drain the blueprint feature-tracker entry; optionally close linked GitHub issue / comment PR
- `/taskwarrior:task-status` — read-only queue + drift report; folds in `gh pr status` when GitHub is present; uses `export | jq` exclusively
- `/taskwarrior:task-coordinate` — next-N unblocked tasks sorted by urgency with exclusive-lock filtering; feeds `parallel-agent-dispatch` and `workflow-wave-dispatch`

### GitHub-mode detection

Plugin auto-detects via `gh auth status` + `git config --get remote.origin.url`. Both pass → GitHub mode; either fails → local-only mode. No user flag required.

### UDAs

| UDA | Type | Purpose |
|-----|------|---------|
| `bpid` | string | Blueprint ID link (WO-NNN / PRP-NNN / FR-NNN) |
| `bpdoc` | string | Repo-relative markdown path |
| `bpms` | string | Milestone tag |
| `ghid` | numeric | Linked GitHub issue number |
| `ghpr` | numeric | Linked GitHub PR number |

## Registrations

- `.claude-plugin/marketplace.json` — added (category `automation`)
- `release-please-config.json` — added
- `.release-please-manifest.json` — v1.0.0
- `docs/PLUGIN-MAP.md` — added to conditional plugins

## Test plan

- [x] `scripts/plugin-compliance-check.sh` — taskwarrior-plugin all green (descriptions include "Use when…" triggers)
- [x] `scripts/lint-context-commands.sh` — no issues in the four skills
- [x] `jq .` validates `plugin.json`, `marketplace.json`, `release-please-config.json`, `.release-please-manifest.json`
- [x] All skills use `task ... export | jq`, never `task list` / `task next` / `task report` (cites `.claude/rules/parallel-safe-queries.md` from #1133)
- [ ] Functional smoke (reviewer, requires `task` CLI installed):
  - [ ] `task --version` ≥ 3.x
  - [ ] `/taskwarrior:task-status` shows meaningful empty-queue report in a claude-plugins session
  - [ ] `/taskwarrior:task-add` in a repo with GitHub remote offers `ghid` linkage; skips in a remote-less repo

## Related

- Depends on #1131 (refined `parallel-agent-dispatch` that the coordinate skill cites)
- Depends on #1132 (`workflow-wave-dispatch` that the coordinate skill cites)
- Depends on #1133 (`parallel-safe-queries` rule that every skill references)

Can merge in any order — references are documentation cross-links, not code dependencies.