### PR TITLE
feat(blueprint-plugin): add blueprint-docs-currency skill + claude-plugins docs-currency rule

### DIFF
--- a/.claude/rules/docs-currency.md
+++ b/.claude/rules/docs-currency.md
@@ -1,0 +1,100 @@
+---
+created: 2026-04-24
+modified: 2026-04-24
+reviewed: 2026-04-24
+---
+
+# Docs Currency
+
+Code and the docs that describe it land in the **same commit**. No deferred
+doc follow-ups, no "docs: update for X" three commits later, no notes to
+self in the PR description.
+
+## The Rule
+
+> When a change modifies a public API, format spec, error enum, or
+> milestone status, the same commit touches the corresponding `docs/`
+> file. When a decision was made, the same commit lands a new or updated
+> ADR.
+
+## Why
+
+Separate doc commits rot. The code change lands first, the work gets
+noisy, the doc commit slips. Grep-based re-investigation months later
+turns up the code without the context that explains *why* it exists.
+Conversely, a same-commit code + docs pair survives indefinitely — the
+prose is findable from the code and the code is findable from the prose.
+
+## Scope
+
+The rule applies when the change touches any of:
+
+- **Public API / schema** — function signatures, exported types,
+  generated schemas, protobuf, JSON-schema, OpenAPI
+- **File format specs** — binary/text format definitions, on-disk schemas
+- **Error enums / protocol codes** — user-visible error identifiers
+- **Milestone status / roadmap** — feature-tracker entries, `PLAN.md`,
+  `TODO.md`, release notes
+- **Decisions** — architectural choices that affect more than one module
+
+Ordinary implementation refactors, typo fixes, and internal helper churn
+do not require docs updates.
+
+## Research Promotion
+
+Findings produced by research — decompilation dumps, spec experiments,
+API probes, benchmark results — live in gitignored scratch
+(`tmp/research/…`). **Before** the feature that depends on those findings
+advances past "in progress" in the tracker, the findings move into
+`docs/` (and, if a decision was made, an ADR).
+
+Tracker-advancement gate:
+
+- [ ] Findings promoted to `docs/` at a canonical path
+- [ ] ADR filed if the research produced a decision
+- [ ] Tracker entry cites the new docs path in its evidence field
+
+If any box is unchecked, the tracker stays in "in progress."
+
+## Sidecars vs. authoritative docs
+
+| Layer | Audience | Content |
+|-------|----------|---------|
+| Sidecar (feature tracker, `TODO.md`) | Humans working in the repo | Priority, status, notes, evidence pointers |
+| Authoritative (`docs/`) | Anyone onboarding, debugging, or porting | Prose that survives without the author |
+
+Sidecars are fine; they are *not* documentation. If a reader needs the
+information to port, debug, or onboard, it belongs in `docs/`.
+
+## Pre-merge checklist
+
+Before merging a code change, ask:
+
+- [ ] Does this change the public API, file format, error enum, or
+      milestone status?
+- [ ] If yes, does the same commit touch the corresponding `docs/` file?
+- [ ] Was a decision made? If yes, is there a new or updated ADR?
+- [ ] Is `tmp/research/` empty (or intentionally scratch) for the change
+      being merged?
+
+Any unchecked box is a blocker. Fix in the same PR.
+
+## Why this lives here (claude-plugins)
+
+This file dogfoods the rule against claude-plugins itself. When a skill
+gains new behaviour, its README / skill-description / plugin README land
+in the same commit. The rule earned its own reusable skill
+(`blueprint-plugin:blueprint-docs-currency`) once it had survived a few
+weeks of practice here.
+
+## Related
+
+- `blueprint-plugin:blueprint-docs-currency` — reusable skill version of this rule
+- `blueprint-plugin:blueprint-curate-docs` — mechanics of promoting research to ai_docs
+- `blueprint-plugin:blueprint-sync` — detects stale generated content
+- `.claude/rules/conventional-commits.md` — commit-type scopes that co-evolve with doc edits
+
+> Evidence: research landed without a same-commit `docs/` update — the
+> spec had to be reconstructed in a follow-up PR. The inverse pattern
+> (same-commit code + spec) survived grep-based re-investigation months
+> later without loss.

--- a/blueprint-plugin/README.md
+++ b/blueprint-plugin/README.md
@@ -63,8 +63,9 @@ PRD (Product Requirements) → PRP (Product Requirement Prompt) → Work-Order �
 | `blueprint-upgrade` | Upgrade to latest blueprint format |
 | `blueprint-rules` | Manage modular rules |
 | `blueprint-claude-md` | Update CLAUDE.md from blueprint artifacts |
-| `blueprint-sync-ids` | **NEW** - Assign IDs to all documents, build traceability registry |
-| `blueprint-workspace-scan` | **NEW (v3.3)** - Discover child blueprints in a monorepo and refresh the root's `workspaces.children` registry with cached feature-tracker stats |
+| `blueprint-sync-ids` | Assign IDs to all documents, build traceability registry |
+| `blueprint-workspace-scan` | Discover child blueprints in a monorepo and refresh the root's `workspaces.children` registry with cached feature-tracker stats |
+| `blueprint-docs-currency` | Advisory discipline for same-commit landing of code and its docs (API, format specs, error enums, milestone status, ADRs); research-promotion workflow from `tmp/` to `docs/` |
 
 ### Feature Tracking Skills
 

--- a/blueprint-plugin/skills/blueprint-docs-currency/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-docs-currency/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: blueprint-docs-currency
+description: |
+  Advisory skill enforcing same-commit landing of code and its docs —
+  public APIs, file format specs, error enums, milestone status, and
+  ADR-worthy decisions must travel with their documentation. Also covers
+  research promotion from tmp/ into docs/ before tracker advancement.
+  Use when committing code that changes API, format specs, or milestone
+  status; when promoting research from scratch to docs; when landing an
+  ADR-worthy decision; or when a reviewer flags missing documentation.
+allowed-tools: Read, Grep, Glob, TodoWrite
+created: 2026-04-24
+modified: 2026-04-24
+reviewed: 2026-04-24
+---
+
+# Blueprint Docs Currency
+
+Same-commit discipline for code and documentation. This skill is the
+reusable version of claude-plugins' `.claude/rules/docs-currency.md`,
+refined for blueprint-driven projects.
+
+## When to Use This Skill
+
+| Use this skill when… | Skip when… |
+|---------------------|------------|
+| Committing code that changes a public API, format spec, or error enum | Refactoring internal helpers with no external surface change |
+| Promoting research findings from `tmp/` to `docs/` | Scratch work that will not ship |
+| Landing an architectural decision | Implementation detail with no branching trade-off |
+| Advancing a tracker entry past "in progress" | Small task completion that does not cross a phase gate |
+| A reviewer flags missing documentation | Typo fixes or whitespace changes |
+
+## The Rule
+
+> Code + its docs land in the same commit. Research promotes to `docs/`
+> before the feature advances past "in progress." ADR-worthy decisions
+> land with a new or updated ADR in the same commit.
+
+## Same-commit scope
+
+| Change kind | Doc target |
+|-------------|-----------|
+| Public API / exported type | Inline docstring + reference doc under `docs/api/` (or tool-appropriate) |
+| File-format spec | `docs/format-spec/<name>.md` (hand-written prose, not generated) |
+| Error enum / protocol code | `docs/errors/<name>.md` or the protocol reference |
+| Milestone / phase status | Feature-tracker entry + `docs/PLAN.md` if the phase advanced |
+| Architectural decision | New ADR under `docs/adrs/NNNN-<title>.md` |
+| New CLI flag or subcommand | README + relevant `docs/cli/` page |
+
+Forward-reference `blueprint-plugin:blueprint-curate-docs` for how to
+produce the prose that goes into `docs/ai_docs/` when the code change
+surfaces an AI-context gotcha worth capturing.
+
+## Research promotion workflow
+
+Research findings arrive in `tmp/` (gitignored). Before the dependent
+feature advances past "in progress" in the blueprint feature tracker:
+
+1. Move the findings into `docs/` at a canonical path (e.g.
+   `docs/research/<topic>.md`, or directly into `docs/format-spec/<name>.md`
+   if the research *is* the spec).
+2. If the research produced a decision, file an ADR. ADRs without a
+   decision record are a code smell — revert to research notes.
+3. Update the feature-tracker entry with the `docs/` path in its
+   evidence field (`blueprint-plugin:feature-tracking` handles the
+   mechanical edit).
+4. Only then flip the tracker status from `in_progress` to `done`.
+
+See `blueprint-plugin:blueprint-curate-docs` for the prose-production
+mechanics; see `blueprint-plugin:blueprint-sync` for the drift detection
+that catches stale generated content drifting from source PRDs.
+
+## Sidecars are not documentation
+
+| Layer | Lives at | Authoritative? |
+|-------|----------|----------------|
+| `TODO.md`, feature tracker JSON | Repo root or `docs/blueprint/` | No — sidecar |
+| `docs/PLAN.md`, `docs/roadmap.md` | `docs/` | Yes |
+| `docs/format-spec/`, `docs/api/` | `docs/` | Yes |
+| ADRs in `docs/adrs/` | `docs/adrs/` | Yes |
+| `tmp/research/…` | gitignored | No — scratch |
+
+Sidecars record priority, status, and notes for humans. If a reader
+needs the information to port, debug, or onboard, it belongs in `docs/`,
+not the sidecar.
+
+## Pre-commit checklist
+
+Before `git commit`, ask:
+
+- [ ] Does this change the public API, file format, error enum, or milestone status?
+- [ ] Same commit touches the corresponding `docs/` file?
+- [ ] Decision made → new / updated ADR in the same commit?
+- [ ] `tmp/research/` either empty or intentionally scratch for this change?
+- [ ] Feature tracker entry's evidence field cites the new `docs/` path?
+
+If any box is unchecked, the commit is not ready. Pattern-match on what
+the code changed, then fix the doc gap in place.
+
+## Pre-merge checklist
+
+Before a PR's final review:
+
+- [ ] `git log main..HEAD` — each commit that touches a scoped surface
+      has a same-commit doc edit
+- [ ] `find tmp -type f` — empty, or the contents are scratch that
+      should not ship
+- [ ] No `docs: follow-up` commits planned for after merge
+
+Deferred doc follow-ups are the failure mode this skill exists to
+prevent. "I'll write the spec after the code is in" is the signal to
+stop and write the spec now.
+
+## Quick Reference
+
+| Signal | Action |
+|--------|--------|
+| Adding a new exported function | Same commit: update the reference doc |
+| Changing a binary format header | Same commit: update `docs/format-spec/<name>.md` |
+| Adding an error code | Same commit: update error enum docs |
+| Choosing library A over library B | Same commit: file an ADR |
+| Promoting `tmp/research/foo.md` → feature | Move to `docs/` first, advance tracker second |
+
+## Related
+
+- `.claude/rules/docs-currency.md` — claude-plugins' dogfood version of this rule
+- `blueprint-plugin:blueprint-curate-docs` — mechanics of producing ai_docs prose
+- `blueprint-plugin:blueprint-sync` — drift detection for generated docs
+- `blueprint-plugin:feature-tracking` — tracker entry mechanics
+- `.claude/rules/conventional-commits.md` — commit types that co-evolve with docs
+
+> Evidence: research landed without a same-commit `docs/` update — the
+> spec had to be reconstructed in a follow-up PR. The inverse pattern
+> (same-commit code + spec) survived grep-based re-investigation months
+> later without loss.


### PR DESCRIPTION
## Summary

Adds same-commit discipline for code and its docs in two placements:

- `.claude/rules/docs-currency.md` — dogfood rule for claude-plugins itself (~80 lines)
- `blueprint-plugin/skills/blueprint-docs-currency/SKILL.md` — auto-invocable skill for downstream blueprint users

### The rule

When a change modifies a public API, file format spec, error enum, or milestone status, the same commit touches the corresponding `docs/` file. When a decision was made, the same commit lands a new or updated ADR.

### What's covered

- **Same-commit scope**: public API, file-format specs, error enums, milestone status, architectural decisions, new CLI flags
- **Research promotion**: findings in `tmp/research/` must move into `docs/` before the feature advances past "in progress" in the blueprint feature tracker
- **Sidecars vs. authoritative docs**: `TODO.md` / feature tracker JSON are sidecars (priority, status, notes); `docs/` is authoritative
- **Pre-commit / pre-merge checklists**

### Why two placements

The rule dogfoods against claude-plugins (the short form lives in `.claude/rules/`), and the fully-fledged skill is the reusable-for-blueprint-users version. The skill forward-references `blueprint-curate-docs` (mechanics) and `blueprint-sync` (drift detection) — it adds the *timing rule* they do not currently enforce.

## Test plan

- [x] `scripts/plugin-compliance-check.sh` — blueprint-plugin all green (description has "Use when…" triggers)
- [x] `scripts/lint-context-commands.sh` — read-only advisory skill, no context commands
- [x] SKILL.md under 500 lines (135)
- [x] Cross-references resolve: `blueprint-curate-docs`, `blueprint-sync`, `feature-tracking`
- [x] `blueprint-plugin/README.md` updated with the new skill in the Management Skills table
- [ ] Reviewer to confirm the short claude-plugins rule and the fleshed-out blueprint skill stay in sync if the rule evolves

## Evidence

Research landed without a same-commit `docs/` update — the spec had to be reconstructed in a follow-up PR. The inverse pattern (same-commit code + spec) survived grep-based re-investigation months later without loss.