### PR TITLE
feat(health-plugin): add skill-audit

### DIFF
--- a/health-plugin/README.md
+++ b/health-plugin/README.md
@@ -13,6 +13,7 @@ Diagnose and fix Claude Code configuration issues including plugin registry, set
 | Skill | Description |
 |-------|-------------|
 | `/health:check` | **Single entry point.** Diagnose (and optionally fix) Claude Code environment, plugin registry, project-stack fit, and skill agentic-optimisation — routed by `--scope`. |
+| `/health:skill-audit` | Audit the plugin skill tree for skill-to-skill overlap, split-pressure inside a SKILL.md, and consolidation candidates. Writes four reports to `tmp/skill-audit/`. |
 | `plugin-registry` | Reference skill: Claude Code's plugin registry, scopes, and troubleshooting |
 | `settings-configuration` | Reference skill: settings file hierarchy, permission wildcards, and patterns |
 

--- a/health-plugin/docs/flow.md
+++ b/health-plugin/docs/flow.md
@@ -3,6 +3,7 @@
 ```mermaid
 flowchart TD
     U[User] -->|/health:check<br/>--scope --fix --dry-run| R["/health:check<br/>(router)"]
+    U -->|/health:skill-audit| SA[health-skill-audit<br/>skill-to-skill overlap<br/>split-pressure<br/>consolidation candidates]
 
     R --> ENV[Step 1: Environment checks]
     ENV --> CP[check-plugins.sh]
@@ -36,7 +37,7 @@ flowchart TD
     classDef prompt fill:#dda0dd,stroke:#8b5a8b,color:#000
 
     class R router
-    class CP,CS,CH,CM,REG,STK,AGT check
+    class CP,CS,CH,CM,REG,STK,AGT,SA check
     class FR,FS,FA fix
     class ASK prompt
 ```
@@ -58,3 +59,9 @@ flowchart TD
 | `stack` | `health-audit/` workflow | `health-audit/` `--fix` flow |
 | `agentic` | `health-agentic-audit/` workflow | `health-agentic-audit/` `--fix` flow |
 | `all` | All of the above + environment checks | `AskUserQuestion` to pick scopes |
+
+## Sibling skills (not scoped under `/health:check`)
+
+| Skill | Invocation | Purpose |
+|-------|------------|---------|
+| `health-skill-audit` | `/health:skill-audit [--plugin X] [--strict]` | Skill-to-skill overlap, split-pressure, and consolidation candidates (read-only; report-only; writes `tmp/skill-audit/`). |

--- a/health-plugin/skills/health-skill-audit/REFERENCE.md
+++ b/health-plugin/skills/health-skill-audit/REFERENCE.md
@@ -1,0 +1,203 @@
+# health-skill-audit — Reference
+
+Detailed rubric, threshold rationale, and JSON schema for `/health:skill-audit`.
+
+## Scope
+
+This audit owns **skill-to-skill relationships** — overlap, split-pressure,
+and consolidation. Adjacent audits own their own concerns and must be run
+first:
+
+| Audit | Owns |
+|-------|------|
+| `scripts/plugin-compliance-check.sh` | Frontmatter fields, 500-line hard limit, body corruption |
+| `scripts/audit-skill-descriptions.py` | Description presence and "Use when…" trigger phrases |
+| `/health:check --scope=agentic` | CLI-flag compactness inside individual skills |
+| **`/health:skill-audit`** | **Overlap clusters, split-pressure evidence, consolidation** |
+
+## Heuristics
+
+### Overlap clusters
+
+Emit a cluster whenever ≥3 skills share a meaningful name component. Three
+cluster bases are computed — deliberately redundant so a single skill may
+appear in multiple clusters (this is a triage signal, not a disjoint
+partition):
+
+| Basis | Key format | Rule |
+|-------|------------|------|
+| `plugin-prefix` | `<plugin>:<component>-*` | Within one plugin, ≥3 skills sharing their distinctive first name component (first component that is not the plugin's own stem, e.g. `api` for `configure-api-tests` inside `configure-plugin`). |
+| `suffix` | `*-<component>*` | Globally, ≥3 skills sharing their last name component (after light stemming: `-s`, `-es`, `-ing` folded), spanning ≥2 plugins. |
+| `shared-token` | `*<token>*` | Globally, ≥4 skills sharing any other name component (stemmed), spanning ≥2 plugins, where the token is not any member's plugin stem. |
+
+**Pair scoring within a cluster** uses Jaccard similarity on description
+trigger tokens (stop-words removed). Pairs flagged when:
+
+- Similarity ≥ **0.60**, or
+- Descriptions have an **identical first sentence**.
+
+Pair flagging is a secondary signal — the **cluster itself** is the finding.
+A cluster with zero flagged pairs still means ≥3 skills share a name token
+and merits a disposition (merge / rename / rewrite / leave).
+
+**Ambiguity markers.** Inside a cluster, a skill whose description tokens
+are fully covered by a sibling's (set subset) is flagged as dominated —
+there is no distinguishing token against its sibling. This mirrors the
+global trigger-phrase check from `audit-skill-descriptions.py`, rescoped
+to the cluster.
+
+### Split candidates
+
+Each finding is `warn` or `error` tier. `error`-tier exits non-zero; `warn`
+exits non-zero only under `--strict`.
+
+| Rule | Severity | Suppressed when |
+|------|----------|-----------------|
+| SKILL.md > **400** lines | `warn` | sibling `REFERENCE.md` exists |
+| SKILL.md > **500** lines | `error` | sibling `REFERENCE.md` exists |
+| Contiguous table block > **80** rows | `warn` | sibling `REFERENCE.md` exists |
+| Aggregate fenced-code lines > **100** | `warn` | sibling `scripts/` exists and is non-empty |
+| ≥ **5** `example` headings totalling > **120** lines | `warn` | sibling `examples/` exists and is non-empty |
+
+The thresholds are conservative. An oversized skill with a sibling file
+already split out is surfaced only if there is a *different* kind of
+pressure (e.g. 450 lines + 300 fenced-code lines despite an existing
+`REFERENCE.md` → still flagged for `scripts/` extraction).
+
+### Consolidation candidates
+
+A pair is flagged when all four hold:
+
+1. Both skills belong to the same plugin
+2. Both SKILL.md files are under **100** lines
+3. They share the same first name component (after dropping the plugin stem)
+4. Jaccard similarity on trigger tokens ≥ **0.70**
+
+Merges are always editorial — the pair is a candidate, not a prescription.
+
+### Stop-word and token model
+
+Tokens are extracted from `description` using the lowercase regex
+``[a-z][a-z0-9-]+``. A conservative stop-word list (copied below) drops
+filler verbs, auxiliaries, and pronouns that would otherwise inflate
+Jaccard scores. Tokens shorter than three characters are dropped.
+
+```
+a an and or the of to for with in on at by from as is are be use used using
+when user users asks want wants ask asking need needs requires requirement
+this that these those it its skill use-when such skills command commands
+mentions mention provides provide provided can will would should may might
+also etc via into over up all any each every some other another same more
+less less-than greater-than between before after during while if then else
+new existing your their my our they them he she his her its we i you
+support supports supporting across against including include included
+make makes made do does doing done have has had get gets got set sets
+configure configured configuring run running runs based uses using
+check checks checking
+```
+
+## What the analyzer deliberately does not do
+
+- Does **not** re-check frontmatter / size / review-date / body corruption — that is the domain of `scripts/plugin-compliance-check.sh`.
+- Does **not** re-check the global "Use when…" trigger phrase — that is the domain of `scripts/audit-skill-descriptions.py`.
+- Does **not** re-check CLI-flag compactness — that is the domain of `/health:check --scope=agentic`.
+- Does **not** auto-fix anything. Every finding is surfaced for human editorial judgement.
+
+## `report.json` schema
+
+```jsonc
+{
+  "skills": [
+    {
+      "plugin": "configure-plugin",
+      "skill": "configure-tests",
+      "path": "configure-plugin/skills/configure-tests/SKILL.md",
+      "lines": 184,
+      "fenced_lines": 42,
+      "table_lines": 28,
+      "largest_table": 12,
+      "example_blocks": 0,
+      "example_lines": 0,
+      "has_reference": false,
+      "has_scripts": false,
+      "has_examples_dir": false,
+      "description": "Check and configure testing frameworks..."
+    }
+  ],
+  "overlap_clusters": [
+    {
+      "cluster": "*-test*",
+      "basis": "suffix",
+      "members": ["configure-plugin/skills/configure-tests/SKILL.md", "..."],
+      "pairs": [
+        {
+          "a": "configure-plugin/skills/configure-tests/SKILL.md",
+          "b": "configure-plugin/skills/configure-api-tests/SKILL.md",
+          "similarity": 0.42,
+          "identical_first_sentence": false
+        }
+      ],
+      "ambiguous": [
+        {
+          "skill": "configure-plugin/skills/configure-tests/SKILL.md",
+          "dominated_by": "configure-plugin/skills/configure-api-tests/SKILL.md"
+        }
+      ]
+    }
+  ],
+  "split_candidates": [
+    {
+      "skill": "blueprint-plugin/skills/blueprint-upgrade/SKILL.md",
+      "lines": 523,
+      "reason": "523 lines and no sibling REFERENCE.md",
+      "severity": "error"
+    }
+  ],
+  "consolidation_candidates": [
+    {
+      "plugin": "example-plugin",
+      "prefix": "foo",
+      "skills": ["example-plugin/skills/foo-a/SKILL.md", "example-plugin/skills/foo-b/SKILL.md"],
+      "similarity": 0.78,
+      "combined_lines": 132,
+      "rationale": "Both under 100 lines, same prefix 'foo', Jaccard 0.78"
+    }
+  ],
+  "thresholds": {
+    "warn_lines": 400,
+    "error_lines": 500,
+    "table_block_warn": 80,
+    "fenced_code_warn": 100,
+    "example_block_count": 5,
+    "example_block_lines": 120,
+    "overlap_similarity": 0.6,
+    "consolidation_similarity": 0.7,
+    "consolidation_max_lines": 100
+  }
+}
+```
+
+## Exit codes
+
+| Condition | Exit code |
+|-----------|-----------|
+| Default (any finding, report-only) | `0` |
+| `--strict` with any `warn` or `error` split candidate | `1` |
+
+The default is report-only so the audit can land alongside a baseline that
+still contains real findings. Wire `--strict` into CI once the baseline is
+clean. Overlap clusters and consolidation candidates never change the exit
+code — they are editorial surfacing only.
+
+## Output paths
+
+All artefacts are written to `tmp/skill-audit/` relative to the repo root.
+The directory is created if missing. The script overwrites existing
+artefacts on each run (the JSON is the source of truth).
+
+## Related
+
+- `.claude/rules/skill-quality.md` — size limits and required sections
+- `.claude/rules/skill-naming.md` — namespace conventions that drive cluster names
+- `.claude/rules/skill-development.md` — granularity decision that drives consolidation
+- `.claude/rules/regression-testing.md` — add a fixture when acting on a finding

--- a/health-plugin/skills/health-skill-audit/SKILL.md
+++ b/health-plugin/skills/health-skill-audit/SKILL.md
@@ -1,0 +1,146 @@
+---
+created: 2026-04-24
+modified: 2026-04-24
+reviewed: 2026-04-24
+description: |
+  Audit the plugin skill tree for skill-to-skill overlap, split-pressure inside
+  a single SKILL.md, and small sibling skills that could consolidate. Use when
+  the user asks to find overlapping skills, surface skills that should extract
+  a REFERENCE.md or scripts/ directory, locate clusters of confusingly similar
+  skills (e.g. configure-*-test* siblings, test-* fragmentation, *-development
+  variants), or run `/health:skill-audit`.
+allowed-tools: Bash(python3 *), Read, TodoWrite
+args: "[--plugin <name>] [--strict]"
+argument-hint: "[--plugin <name>] [--strict]"
+name: health-skill-audit
+---
+
+# /health:skill-audit
+
+Produce triageable evidence for **skill-to-skill** quality: overlap clusters, split-pressure inside a skill body, and consolidation candidates. The analyzer reports only — every recommendation is editorial.
+
+Complements the other skill audits — this skill assumes frontmatter hygiene is already green.
+
+## When to Use This Skill
+
+| Use this skill when... | Use another approach when... |
+|------------------------|------------------------------|
+| Finding overlapping skills ambiguous to an invoking agent | Frontmatter / size / body corruption (use `scripts/plugin-compliance-check.sh`) |
+| Scoring split-pressure in an oversized skill body | Missing "Use when…" triggers (use `scripts/audit-skill-descriptions.py`) |
+| Locating name-prefix or name-suffix clusters | CLI-flag compactness (use `/health:check --scope=agentic`) |
+| Surfacing small sibling skills that could merge | Plugin ↔ stack relevance (use `/health:check --scope=stack`) |
+
+## Context
+
+- Analyzer: !`find scripts -maxdepth 1 -name audit-skill-structure.py -type f`
+- Prior output: !`find tmp/skill-audit -maxdepth 1 -type f`
+- Compliance pre-check: !`find scripts -maxdepth 1 -name plugin-compliance-check.sh -type f`
+- Description pre-check: !`find scripts -maxdepth 1 -name audit-skill-descriptions.py -type f`
+
+## Parameters
+
+Parse these from `$ARGUMENTS`:
+
+| Parameter | Description |
+|-----------|-------------|
+| `--plugin <name>` | Restrict scan to a single plugin directory (e.g. `configure-plugin`) |
+| `--strict` | Exit non-zero on `warn`-tier findings in addition to `error`-tier |
+
+## Execution
+
+Execute this skill-structure audit:
+
+### Step 1: Confirm prerequisites are green
+
+These audits own orthogonal concerns. Run them first and resolve their findings before triaging this skill's output:
+
+1. `scripts/plugin-compliance-check.sh` — frontmatter, size budget, body corruption
+2. `python3 scripts/audit-skill-descriptions.py --strict` — `description` fields have trigger phrases
+
+If either reports errors, pause and ask the user whether to continue — a messy frontmatter baseline makes the overlap heuristics noisier.
+
+### Step 2: Run the analyzer
+
+```bash
+python3 scripts/audit-skill-structure.py $ARGUMENTS
+```
+
+This writes five artefacts into `tmp/skill-audit/`:
+
+| File | Contents |
+|------|----------|
+| `report.json` | Canonical machine-readable output (source of truth) |
+| `summary.md` | Top-N by severity, intended for triage |
+| `overlap-clusters.md` | Side-by-side description comparison per cluster |
+| `split-candidates.md` | Per-skill evidence (lines, tables, fenced code, examples) |
+| `consolidation-candidates.md` | Conservative merge suggestions |
+
+The schema for `report.json` and the rationale for every threshold live in [REFERENCE.md](REFERENCE.md).
+
+### Step 3: Triage `summary.md` first
+
+Open `tmp/skill-audit/summary.md`. It lists:
+
+1. Top error-tier split candidates (SKILL.md bodies that exceed the hard line limit without a `REFERENCE.md`)
+2. Largest overlap clusters (by number of flagged pairs)
+3. Pointers to the three detail reports
+
+### Step 4: For each overlap cluster, decide the disposition
+
+For each cluster in `tmp/skill-audit/overlap-clusters.md`, pick one:
+
+| Disposition | When it fits |
+|-------------|--------------|
+| Merge | Two small skills describing the same intent → fold into one |
+| Rename | Clear distinct intent but colliding names → disambiguate the slug |
+| Rewrite descriptions | Intent is distinct but descriptions collide → sharpen trigger phrases |
+| Leave | Cluster is a family by design (e.g. `python-plugin` ecosystem skills) — no change |
+
+Do **not** auto-act. Each disposition lands in its own PR per the `CLAUDE.md` guidance.
+
+### Step 5: For each split candidate, decide the disposition
+
+For each row in `tmp/skill-audit/split-candidates.md`, pick one:
+
+| Disposition | When it fits |
+|-------------|--------------|
+| Extract to `REFERENCE.md` | Warn/error-tier size or contiguous table block |
+| Extract to `scripts/` | Fenced-code aggregate exceeds threshold |
+| Extract to `examples/` | Multiple lengthy example blocks |
+| Leave | Content is genuinely part of the skill's core instruction |
+
+The report's `reason` column carries the quantitative evidence — cite it when opening the split PR.
+
+### Step 6: For each consolidation candidate, decide the disposition
+
+Consolidation suggestions are conservative — both skills must be small, share a plugin, share a name prefix, and have high description similarity. Still, *merge* is editorial:
+
+1. Read both SKILL.md files
+2. Confirm the intents really are duplicative (not complementary)
+3. Choose the merge target name and fold the smaller skill into it
+
+File a GitHub issue per consolidation decision rather than bundling them.
+
+## Post-actions
+
+- `report.json` is the source of truth for any follow-up PRs — cite the relevant JSON entries in PR descriptions
+- Each cluster or split candidate acted upon lands as its own PR
+- Add a regression fixture under `tmp/fixtures/` if a fix should be prevented from recurring (see `.claude/rules/regression-testing.md`)
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Full scan | `python3 scripts/audit-skill-structure.py` |
+| Single-plugin scan | `python3 scripts/audit-skill-structure.py --plugin configure-plugin` |
+| CI-gating run | `python3 scripts/audit-skill-structure.py --strict` |
+| Top splits only | `jq '.split_candidates \| sort_by(-.lines) \| .[:10]' tmp/skill-audit/report.json` |
+| Top clusters only | `jq '.overlap_clusters \| sort_by(-(.pairs \| length)) \| .[:10]' tmp/skill-audit/report.json` |
+
+## See Also
+
+- `.claude/rules/skill-quality.md` — size limits and required sections
+- `scripts/plugin-compliance-check.sh` — frontmatter and body corruption owner
+- `scripts/audit-skill-descriptions.py` — trigger-phrase coverage owner
+- `/health:check --scope=agentic` — CLI-flag compactness audit
+- [REFERENCE.md](REFERENCE.md) — heuristic rubric, thresholds, and JSON schema

--- a/scripts/audit-skill-structure.py
+++ b/scripts/audit-skill-structure.py
@@ -1,0 +1,816 @@
+#!/usr/bin/env python3
+"""
+Audit SKILL.md files for overlap, split-pressure, and consolidation candidates.
+
+Complements existing audits — `plugin-compliance-check.sh` owns frontmatter,
+size, and body corruption; `audit-skill-descriptions.py` owns trigger-phrase
+presence; `/health:agentic-audit` owns CLI-flag compactness. This audit fills
+the remaining gap: **skill-to-skill** relationships.
+
+Outputs four artefacts under ``tmp/skill-audit/``:
+
+  report.json                   canonical machine-readable output
+  summary.md                    top-N by severity, intended for triage
+  overlap-clusters.md           side-by-side description comparison per cluster
+  split-candidates.md           quantitative evidence per oversized skill
+  consolidation-candidates.md   conservative merge suggestions
+
+Usage:
+    python scripts/audit-skill-structure.py
+    python scripts/audit-skill-structure.py --plugin configure-plugin
+    python scripts/audit-skill-structure.py --strict
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+OUTPUT_DIR = REPO_ROOT / "tmp" / "skill-audit"
+
+# --- Heuristic thresholds (documented in REFERENCE.md) ----------------------
+
+WARN_LINES = 400
+ERROR_LINES = 500
+TABLE_BLOCK_WARN = 80
+FENCED_CODE_WARN = 100
+EXAMPLE_BLOCK_COUNT = 5
+EXAMPLE_BLOCK_LINES = 120
+OVERLAP_SIMILARITY = 0.60
+CONSOLIDATION_SIMILARITY = 0.70
+CONSOLIDATION_MAX_LINES = 100
+
+STOPWORDS = frozenset(
+    """
+    a an and or the of to for with in on at by from as is are be use used using
+    when user users asks want wants ask asking need needs requires requirement
+    this that these those it its skill use-when such skills command commands
+    mentions mention provides provide provided can will would should may might
+    also etc via into over up all any each every some other another same more
+    less less-than greater-than between before after during while if then else
+    new existing your their my our they them he she his her its we i you
+    support supports supporting across against including include included
+    make makes made do does doing done have has had get gets got set sets
+    configure configured configuring run running runs based uses using
+    check checks checking
+    """.split()
+)
+
+# --- Data classes -----------------------------------------------------------
+
+
+@dataclass
+class Skill:
+    plugin: str
+    skill: str
+    path: Path
+    rel_path: str
+    lines: int
+    fenced_lines: int
+    table_lines: int
+    example_blocks: int
+    example_lines: int
+    largest_table: int
+    has_reference: bool
+    has_scripts: bool
+    has_examples_dir: bool
+    description: str
+    trigger_tokens: frozenset[str]
+
+
+@dataclass
+class SplitFinding:
+    skill: Skill
+    reason: str
+    severity: str  # "warn" | "error"
+
+
+@dataclass
+class Cluster:
+    key: str
+    basis: str  # "prefix" | "suffix"
+    skills: list[Skill] = field(default_factory=list)
+    pairs: list[dict] = field(default_factory=list)
+
+
+# --- Frontmatter extraction (stdlib-only) -----------------------------------
+
+_FM_FIELD_RE = re.compile(
+    r"^(?P<key>[\w-]+):\s*(?P<value>.*?)(?=^[\w-]+:\s|^---\s*$|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def _strip_block_scalar(value: str) -> str:
+    value = value.rstrip()
+    if not value:
+        return ""
+    if value.lstrip().startswith(("|", ">")):
+        lines = value.splitlines()[1:]
+        return " ".join(line.strip() for line in lines if line.strip())
+    if (value.startswith('"') and value.endswith('"')) or (
+        value.startswith("'") and value.endswith("'")
+    ):
+        return value[1:-1]
+    return " ".join(line.strip() for line in value.splitlines() if line.strip())
+
+
+def extract_description(text: str) -> str:
+    if not text.startswith("---"):
+        return ""
+    parts = text.split("\n---", 1)
+    if len(parts) < 2:
+        return ""
+    fm_text = parts[0].lstrip("-").lstrip("\n")
+    for m in _FM_FIELD_RE.finditer(fm_text):
+        if m.group("key") == "description":
+            return _strip_block_scalar(m.group("value"))
+    return ""
+
+
+# --- Body analysis ----------------------------------------------------------
+
+_FENCE_RE = re.compile(r"^```")
+_TABLE_ROW_RE = re.compile(r"^\s*\|")
+_EXAMPLE_HEADING_RE = re.compile(r"^#{2,4}\s+.*example", re.IGNORECASE)
+
+
+def analyze_body(text: str) -> dict:
+    """Scan the markdown body for fenced code, table blocks, and example sections."""
+    body = text
+    if text.startswith("---"):
+        parts = text.split("\n---", 2)
+        if len(parts) >= 3:
+            body = parts[2]
+
+    lines = body.splitlines()
+    fenced_lines = 0
+    table_lines = 0
+    largest_table = 0
+    current_table = 0
+    in_fence = False
+    example_blocks = 0
+    example_lines = 0
+    in_example = False
+    example_heading_level = 0
+
+    for line in lines:
+        if _FENCE_RE.match(line):
+            in_fence = not in_fence
+            fenced_lines += 1  # count the fence line
+            continue
+        if in_fence:
+            fenced_lines += 1
+            if in_example:
+                example_lines += 1
+            continue
+
+        if _TABLE_ROW_RE.match(line):
+            table_lines += 1
+            current_table += 1
+            largest_table = max(largest_table, current_table)
+        else:
+            current_table = 0
+
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            heading_hashes = len(stripped) - len(stripped.lstrip("#"))
+            if _EXAMPLE_HEADING_RE.match(stripped):
+                if in_example:
+                    # nested example heading — keep counting under the outer
+                    pass
+                else:
+                    in_example = True
+                    example_heading_level = heading_hashes
+                    example_blocks += 1
+            elif in_example and heading_hashes <= example_heading_level:
+                in_example = False
+                example_heading_level = 0
+
+        if in_example:
+            example_lines += 1
+
+    return {
+        "fenced_lines": fenced_lines,
+        "table_lines": table_lines,
+        "largest_table": largest_table,
+        "example_blocks": example_blocks,
+        "example_lines": example_lines,
+        "total_lines": len(lines),
+    }
+
+
+# --- Skill discovery --------------------------------------------------------
+
+
+def find_skills(root: Path, plugin_filter: str | None) -> list[Path]:
+    skills: list[Path] = []
+    for plugin_dir in sorted(root.glob("*-plugin")):
+        if not plugin_dir.is_dir():
+            continue
+        if plugin_filter and plugin_dir.name != plugin_filter:
+            continue
+        skills_dir = plugin_dir / "skills"
+        if not skills_dir.is_dir():
+            continue
+        for skill_md in sorted(skills_dir.rglob("SKILL.md")):
+            skills.append(skill_md)
+        for skill_md in sorted(skills_dir.rglob("skill.md")):
+            if skill_md.parent not in {s.parent for s in skills}:
+                skills.append(skill_md)
+    return skills
+
+
+def load_skill(path: Path, root: Path) -> Skill:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    body = analyze_body(text)
+    description = extract_description(text)
+    trigger_tokens = tokenize(description)
+    parent = path.parent
+    rel_path = str(path.relative_to(root))
+    plugin = path.relative_to(root).parts[0]
+    scripts_dir = parent / "scripts"
+    examples_dir = parent / "examples"
+    return Skill(
+        plugin=plugin,
+        skill=parent.name,
+        path=path,
+        rel_path=rel_path,
+        lines=len(text.splitlines()),
+        fenced_lines=body["fenced_lines"],
+        table_lines=body["table_lines"],
+        example_blocks=body["example_blocks"],
+        example_lines=body["example_lines"],
+        largest_table=body["largest_table"],
+        has_reference=(parent / "REFERENCE.md").is_file(),
+        has_scripts=scripts_dir.is_dir() and any(scripts_dir.iterdir()),
+        has_examples_dir=examples_dir.is_dir() and any(examples_dir.iterdir()),
+        description=description,
+        trigger_tokens=trigger_tokens,
+    )
+
+
+# --- Tokenization & similarity ---------------------------------------------
+
+_TOKEN_RE = re.compile(r"[a-z][a-z0-9-]+")
+
+
+def tokenize(text: str) -> frozenset[str]:
+    if not text:
+        return frozenset()
+    tokens = _TOKEN_RE.findall(text.lower())
+    return frozenset(t for t in tokens if t not in STOPWORDS and len(t) > 2)
+
+
+def jaccard(a: frozenset[str], b: frozenset[str]) -> float:
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+# --- Cluster detection ------------------------------------------------------
+
+
+def prefix_of(slug: str) -> str:
+    parts = slug.split("-")
+    return parts[0] if parts else slug
+
+
+def suffix_of(slug: str) -> str:
+    parts = slug.split("-")
+    return parts[-1] if parts else slug
+
+
+def stem(word: str) -> str:
+    """Fold ``-s``/``-es``/``-ing`` so tests/testing/test collapse to 'test'."""
+    if len(word) > 5 and word.endswith("ing"):
+        return word[:-3]
+    if len(word) > 4 and word.endswith("es"):
+        return word[:-2]
+    if len(word) > 3 and word.endswith("s") and not word.endswith("ss"):
+        return word[:-1]
+    return word
+
+
+def plugin_stem(plugin: str) -> str:
+    """Plugin name stem: 'configure-plugin' → 'configure'."""
+    return plugin.removesuffix("-plugin")
+
+
+def distinctive_prefix(skill: Skill) -> str:
+    """First name component that isn't the plugin's own stem."""
+    parts = skill.skill.split("-")
+    stem = plugin_stem(skill.plugin)
+    for p in parts:
+        if p != stem:
+            return p
+    return parts[0] if parts else skill.skill
+
+
+def score_pairs(members: list[Skill]) -> list[dict]:
+    """Pairwise scoring within a cluster. Returns only pairs >= threshold."""
+    pairs: list[dict] = []
+    for i, a in enumerate(members):
+        for b in members[i + 1 :]:
+            sim = jaccard(a.trigger_tokens, b.trigger_tokens)
+            first_a = (a.description.split(".")[0] or "").strip().lower()
+            first_b = (b.description.split(".")[0] or "").strip().lower()
+            identical_first = bool(first_a) and first_a == first_b
+            if sim >= OVERLAP_SIMILARITY or identical_first:
+                pairs.append(
+                    {
+                        "a": a.rel_path,
+                        "b": b.rel_path,
+                        "similarity": round(sim, 3),
+                        "identical_first_sentence": identical_first,
+                    }
+                )
+    return pairs
+
+
+def build_clusters(skills: list[Skill]) -> list[Cluster]:
+    """Emit clusters when ≥3 skills share a meaningful name component.
+
+    Three cluster bases — deliberately redundant so a single skill may appear
+    in multiple clusters (triage signal, not disjoint partition):
+
+    - ``plugin-prefix`` — within one plugin, skills sharing their distinctive
+      first name component (first component that is not the plugin stem).
+    - ``suffix`` — globally, skills sharing their last name component,
+      provided ≥2 plugins are represented.
+    - ``shared-token`` — globally, skills sharing any other name component
+      that occurs in ≥4 skills across ≥2 plugins.
+    """
+    clusters: list[Cluster] = []
+
+    # Per-plugin distinctive-prefix clusters
+    by_pp: dict[tuple[str, str], list[Skill]] = {}
+    for s in skills:
+        by_pp.setdefault((s.plugin, distinctive_prefix(s)), []).append(s)
+    for (plugin, key), members in sorted(by_pp.items()):
+        if len(members) < 3:
+            continue
+        clusters.append(
+            Cluster(
+                key=f"{plugin}:{key}-*",
+                basis="plugin-prefix",
+                skills=members,
+                pairs=score_pairs(members),
+            )
+        )
+
+    seen_member_sets: set[frozenset[str]] = {
+        frozenset(s.rel_path for s in c.skills) for c in clusters
+    }
+
+    # Global suffix clusters (spanning ≥2 plugins, with s/ing stemming)
+    by_suffix: dict[str, list[Skill]] = {}
+    for s in skills:
+        by_suffix.setdefault(stem(suffix_of(s.skill)), []).append(s)
+    for key, members in sorted(by_suffix.items()):
+        if len(members) < 3:
+            continue
+        if len({s.plugin for s in members}) < 2:
+            continue
+        member_set = frozenset(s.rel_path for s in members)
+        if member_set in seen_member_sets:
+            continue
+        seen_member_sets.add(member_set)
+        clusters.append(
+            Cluster(
+                key=f"*-{key}*",
+                basis="suffix",
+                skills=members,
+                pairs=score_pairs(members),
+            )
+        )
+
+    # Global shared-token clusters (other name components, stemmed)
+    token_index: dict[str, list[Skill]] = {}
+    for s in skills:
+        for part in {stem(p) for p in s.skill.split("-")}:
+            token_index.setdefault(part, []).append(s)
+    for token, members in sorted(token_index.items()):
+        if len(members) < 4:
+            continue
+        if len({s.plugin for s in members}) < 2:
+            continue
+        # Skip tokens already covered by a prefix/suffix cluster
+        member_set = frozenset(s.rel_path for s in members)
+        if member_set in seen_member_sets:
+            continue
+        # Skip tokens equal to any plugin stem (e.g. 'configure', 'blueprint')
+        if any(token == plugin_stem(s.plugin) for s in members):
+            continue
+        seen_member_sets.add(member_set)
+        clusters.append(
+            Cluster(
+                key=f"*{token}*",
+                basis="shared-token",
+                skills=members,
+                pairs=score_pairs(members),
+            )
+        )
+
+    return clusters
+
+
+def ambiguous_within_cluster(cluster: Cluster) -> list[dict]:
+    """Skills whose tokens are fully covered by a sibling's — no distinguisher."""
+    findings = []
+    for skill in cluster.skills:
+        for sibling in cluster.skills:
+            if sibling is skill:
+                continue
+            if skill.trigger_tokens and skill.trigger_tokens <= sibling.trigger_tokens:
+                findings.append(
+                    {
+                        "skill": skill.rel_path,
+                        "dominated_by": sibling.rel_path,
+                    }
+                )
+                break
+    return findings
+
+
+# --- Split-candidate detection ---------------------------------------------
+
+
+def split_candidates(skill: Skill) -> list[SplitFinding]:
+    findings: list[SplitFinding] = []
+    if skill.lines > ERROR_LINES and not skill.has_reference:
+        findings.append(
+            SplitFinding(
+                skill,
+                f"{skill.lines} lines and no sibling REFERENCE.md",
+                "error",
+            )
+        )
+    elif skill.lines > WARN_LINES and not skill.has_reference:
+        findings.append(
+            SplitFinding(
+                skill,
+                f"{skill.lines} lines and no sibling REFERENCE.md",
+                "warn",
+            )
+        )
+    if skill.largest_table > TABLE_BLOCK_WARN and not skill.has_reference:
+        findings.append(
+            SplitFinding(
+                skill,
+                f"contiguous table block of {skill.largest_table} lines "
+                "→ extract to REFERENCE.md",
+                "warn",
+            )
+        )
+    if skill.fenced_lines > FENCED_CODE_WARN and not skill.has_scripts:
+        findings.append(
+            SplitFinding(
+                skill,
+                f"{skill.fenced_lines} fenced-code lines "
+                "→ consider scripts/ directory",
+                "warn",
+            )
+        )
+    if (
+        skill.example_blocks >= EXAMPLE_BLOCK_COUNT
+        and skill.example_lines > EXAMPLE_BLOCK_LINES
+        and not skill.has_examples_dir
+    ):
+        findings.append(
+            SplitFinding(
+                skill,
+                f"{skill.example_blocks} example blocks totalling "
+                f"{skill.example_lines} lines → consider examples/ directory",
+                "warn",
+            )
+        )
+    return findings
+
+
+# --- Consolidation-candidate detection -------------------------------------
+
+
+def consolidation_candidates(skills: list[Skill]) -> list[dict]:
+    out = []
+    by_plugin_prefix: dict[tuple[str, str], list[Skill]] = {}
+    for s in skills:
+        by_plugin_prefix.setdefault((s.plugin, prefix_of(s.skill)), []).append(s)
+    for (plugin, prefix), group in by_plugin_prefix.items():
+        small = [s for s in group if s.lines < CONSOLIDATION_MAX_LINES]
+        if len(small) < 2:
+            continue
+        for i, a in enumerate(small):
+            for b in small[i + 1 :]:
+                sim = jaccard(a.trigger_tokens, b.trigger_tokens)
+                if sim >= CONSOLIDATION_SIMILARITY:
+                    out.append(
+                        {
+                            "plugin": plugin,
+                            "prefix": prefix,
+                            "skills": [a.rel_path, b.rel_path],
+                            "similarity": round(sim, 3),
+                            "combined_lines": a.lines + b.lines,
+                            "rationale": (
+                                f"Both under {CONSOLIDATION_MAX_LINES} lines, "
+                                f"same prefix '{prefix}', Jaccard {sim:.2f}"
+                            ),
+                        }
+                    )
+    return out
+
+
+# --- Report rendering -------------------------------------------------------
+
+
+def render_summary(
+    skills: list[Skill],
+    splits: list[SplitFinding],
+    clusters: list[Cluster],
+    consolidations: list[dict],
+) -> str:
+    errors = [f for f in splits if f.severity == "error"]
+    warns = [f for f in splits if f.severity == "warn"]
+    lines = [
+        "# Skill Audit Summary",
+        "",
+        f"Scanned **{len(skills)}** skills across "
+        f"**{len({s.plugin for s in skills})}** plugins.",
+        "",
+        "## Counts",
+        "",
+        "| Category | Count |",
+        "|----------|-------|",
+        f"| Split candidates (error) | {len(errors)} |",
+        f"| Split candidates (warn) | {len(warns)} |",
+        f"| Overlap clusters | {len(clusters)} |",
+        f"| Overlap pairs | {sum(len(c.pairs) for c in clusters)} |",
+        f"| Consolidation candidates | {len(consolidations)} |",
+        "",
+        "## Top split candidates (error tier)",
+        "",
+    ]
+    if errors:
+        lines.append("| Skill | Lines | Reason |")
+        lines.append("|-------|------:|--------|")
+        for f in sorted(errors, key=lambda f: -f.skill.lines)[:20]:
+            lines.append(
+                f"| `{f.skill.rel_path}` | {f.skill.lines} | {f.reason} |"
+            )
+    else:
+        lines.append("_None._")
+    lines += ["", "## Largest overlap clusters", ""]
+    if clusters:
+        lines.append("| Cluster | Basis | Members | Pairs flagged |")
+        lines.append("|---------|-------|--------:|--------------:|")
+        for c in sorted(clusters, key=lambda c: (-len(c.pairs), -len(c.skills)))[:10]:
+            lines.append(
+                f"| `{c.key}` | {c.basis} | {len(c.skills)} | {len(c.pairs)} |"
+            )
+    else:
+        lines.append("_None._")
+    lines += [
+        "",
+        "## Output files",
+        "",
+        "- `report.json` — canonical machine-readable output",
+        "- `overlap-clusters.md` — per-cluster detail",
+        "- `split-candidates.md` — per-skill detail",
+        "- `consolidation-candidates.md` — merge suggestions",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def render_overlap_clusters(clusters: list[Cluster]) -> str:
+    out = ["# Overlap Clusters", ""]
+    if not clusters:
+        out.append("_No clusters flagged._")
+        return "\n".join(out)
+    out.append(
+        "Clusters are groups of skills sharing a name prefix or suffix where "
+        "at least one pair has Jaccard token similarity ≥ "
+        f"{OVERLAP_SIMILARITY:.2f} or an identical first-sentence description."
+    )
+    out.append("")
+    for cluster in sorted(clusters, key=lambda c: (-len(c.pairs), c.key)):
+        out.append(f"## `{cluster.key}` ({cluster.basis})")
+        out.append("")
+        out.append("| Skill | Description (first ~120 chars) |")
+        out.append("|-------|--------------------------------|")
+        for s in sorted(cluster.skills, key=lambda s: s.skill):
+            preview = " ".join(s.description.split())
+            if len(preview) > 120:
+                preview = preview[:117] + "..."
+            preview = preview.replace("|", "\\|")
+            out.append(f"| `{s.rel_path}` | {preview} |")
+        out.append("")
+        out.append("**Flagged pairs:**")
+        out.append("")
+        out.append("| A | B | Similarity | Identical first sentence |")
+        out.append("|---|---|-----------:|:------------------------:|")
+        for pair in sorted(cluster.pairs, key=lambda p: -p["similarity"]):
+            out.append(
+                f"| `{pair['a']}` | `{pair['b']}` | {pair['similarity']} "
+                f"| {'yes' if pair['identical_first_sentence'] else 'no'} |"
+            )
+        ambiguous = ambiguous_within_cluster(cluster)
+        if ambiguous:
+            out.append("")
+            out.append("**Ambiguity markers** (description tokens dominated by a sibling):")
+            out.append("")
+            for a in ambiguous:
+                out.append(f"- `{a['skill']}` dominated by `{a['dominated_by']}`")
+        out.append("")
+    return "\n".join(out)
+
+
+def render_split_candidates(splits: list[SplitFinding]) -> str:
+    out = ["# Split Candidates", ""]
+    if not splits:
+        out.append("_None._")
+        return "\n".join(out)
+    out.append(
+        f"Thresholds: `warn` at {WARN_LINES} lines, `error` at {ERROR_LINES} "
+        f"lines (when no REFERENCE.md exists). Tables > {TABLE_BLOCK_WARN} "
+        f"contiguous rows, fenced-code > {FENCED_CODE_WARN} lines, and example "
+        "clusters are surfaced as supporting evidence."
+    )
+    out.append("")
+    out.append("| Severity | Skill | Lines | Tables | Fenced | Examples | Reason |")
+    out.append("|----------|-------|------:|-------:|-------:|---------:|--------|")
+    for f in sorted(splits, key=lambda f: (f.severity != "error", -f.skill.lines)):
+        s = f.skill
+        out.append(
+            f"| {f.severity} | `{s.rel_path}` | {s.lines} | "
+            f"{s.largest_table} | {s.fenced_lines} | {s.example_blocks} "
+            f"| {f.reason} |"
+        )
+    return "\n".join(out)
+
+
+def render_consolidations(consolidations: list[dict]) -> str:
+    out = ["# Consolidation Candidates", ""]
+    if not consolidations:
+        out.append("_None._")
+        return "\n".join(out)
+    out.append(
+        "Pairs where both skills are small, share a name prefix inside the "
+        "same plugin, and have high description similarity. Merging is "
+        "editorial — these are surfaced for human review only."
+    )
+    out.append("")
+    out.append("| Plugin | Prefix | Skills | Similarity | Combined lines |")
+    out.append("|--------|--------|--------|-----------:|---------------:|")
+    for c in sorted(consolidations, key=lambda c: -c["similarity"]):
+        skills_cell = "<br>".join(f"`{s}`" for s in c["skills"])
+        out.append(
+            f"| {c['plugin']} | {c['prefix']} | {skills_cell} "
+            f"| {c['similarity']} | {c['combined_lines']} |"
+        )
+    return "\n".join(out)
+
+
+# --- JSON emission ----------------------------------------------------------
+
+
+def build_json(
+    skills: list[Skill],
+    splits: list[SplitFinding],
+    clusters: list[Cluster],
+    consolidations: list[dict],
+) -> dict:
+    return {
+        "skills": [
+            {
+                "plugin": s.plugin,
+                "skill": s.skill,
+                "path": s.rel_path,
+                "lines": s.lines,
+                "fenced_lines": s.fenced_lines,
+                "table_lines": s.table_lines,
+                "largest_table": s.largest_table,
+                "example_blocks": s.example_blocks,
+                "example_lines": s.example_lines,
+                "has_reference": s.has_reference,
+                "has_scripts": s.has_scripts,
+                "has_examples_dir": s.has_examples_dir,
+                "description": s.description,
+            }
+            for s in skills
+        ],
+        "overlap_clusters": [
+            {
+                "cluster": c.key,
+                "basis": c.basis,
+                "members": [s.rel_path for s in c.skills],
+                "pairs": c.pairs,
+                "ambiguous": ambiguous_within_cluster(c),
+            }
+            for c in clusters
+        ],
+        "split_candidates": [
+            {
+                "skill": f.skill.rel_path,
+                "lines": f.skill.lines,
+                "reason": f.reason,
+                "severity": f.severity,
+            }
+            for f in splits
+        ],
+        "consolidation_candidates": consolidations,
+        "thresholds": {
+            "warn_lines": WARN_LINES,
+            "error_lines": ERROR_LINES,
+            "table_block_warn": TABLE_BLOCK_WARN,
+            "fenced_code_warn": FENCED_CODE_WARN,
+            "example_block_count": EXAMPLE_BLOCK_COUNT,
+            "example_block_lines": EXAMPLE_BLOCK_LINES,
+            "overlap_similarity": OVERLAP_SIMILARITY,
+            "consolidation_similarity": CONSOLIDATION_SIMILARITY,
+            "consolidation_max_lines": CONSOLIDATION_MAX_LINES,
+        },
+    }
+
+
+# --- Main -------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--plugin",
+        help="Restrict analysis to a single plugin (e.g. configure-plugin)",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero on any finding (warn or error). Default exit is 0.",
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=REPO_ROOT,
+        help=argparse.SUPPRESS,
+    )
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    skill_paths = find_skills(root, args.plugin)
+    skills = [load_skill(p, root) for p in skill_paths]
+
+    splits = [f for s in skills for f in split_candidates(s)]
+    clusters = build_clusters(skills)
+    consolidations = consolidation_candidates(skills)
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    (OUTPUT_DIR / "report.json").write_text(
+        json.dumps(
+            build_json(skills, splits, clusters, consolidations),
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (OUTPUT_DIR / "summary.md").write_text(
+        render_summary(skills, splits, clusters, consolidations) + "\n",
+        encoding="utf-8",
+    )
+    (OUTPUT_DIR / "overlap-clusters.md").write_text(
+        render_overlap_clusters(clusters) + "\n",
+        encoding="utf-8",
+    )
+    (OUTPUT_DIR / "split-candidates.md").write_text(
+        render_split_candidates(splits) + "\n",
+        encoding="utf-8",
+    )
+    (OUTPUT_DIR / "consolidation-candidates.md").write_text(
+        render_consolidations(consolidations) + "\n",
+        encoding="utf-8",
+    )
+
+    errors = [f for f in splits if f.severity == "error"]
+    warns = [f for f in splits if f.severity == "warn"]
+
+    print(
+        f"Scanned {len(skills)} skills. "
+        f"Split: {len(errors)} error / {len(warns)} warn. "
+        f"Clusters: {len(clusters)}. "
+        f"Consolidations: {len(consolidations)}.",
+        file=sys.stderr,
+    )
+    print(f"Reports written to {OUTPUT_DIR.relative_to(REPO_ROOT)}/", file=sys.stderr)
+
+    if args.strict and (errors or warns):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Introduces `/health:skill-audit` — a read-only, report-only audit that surfaces **skill-to-skill** quality signals that the existing audits don't cover:

- **Overlap clusters** — groups of ≥3 skills sharing a name component (e.g. the 5 `configure-*-test*` siblings, `testing-plugin`'s 10 `test-*` skills, the 8 `*-development` variants across 7 plugins)
- **Split pressure** — per-skill evidence for oversized bodies (>400/>500 lines), contiguous tables (>80 rows), fenced-code aggregate (>100 lines), and example-heavy sections
- **Consolidation candidates** — small (<100 line) sibling pairs in the same plugin with Jaccard ≥ 0.70 on description tokens

Complements the existing audits — each remains the owner of its concern:

| Audit | Owns |
|-------|------|
| `scripts/plugin-compliance-check.sh` | Frontmatter, size budget, body corruption |
| `scripts/audit-skill-descriptions.py` | "Use when…" trigger presence |
| `/health:check --scope=agentic` | CLI-flag compactness |
| **`/health:skill-audit`** (new) | **Skill-to-skill overlap, split pressure, consolidation** |

## What lands in this PR

- `scripts/audit-skill-structure.py` — stdlib-only analyzer (no yaml dep)
- `health-plugin/skills/health-skill-audit/SKILL.md` + `REFERENCE.md`
- `health-plugin/README.md` + `docs/flow.md` — same-commit doc updates per `.claude/rules/docs-currency.md`

No `marketplace.json` / `release-please-config.json` edits — those apply only when adding a plugin, not a skill within an existing one.

## Exit-code model

Default exits **0** (report-only) so the audit can land on a baseline that still contains real findings. `--strict` exits 1 on any warn or error — wire that into CI once the baseline is clean.

## Baseline findings

On `main` (338 skills, 39 plugins) the audit surfaces:

- **2 error-tier** split candidates: `blueprint-upgrade` (523 lines, no `REFERENCE.md`) and `project-discovery` (518 lines, no `REFERENCE.md`)
- **125 warn-tier** split candidates
- **76 overlap clusters**, including all three known targets:
  - `*-test*` (17 members, covers all 5 `configure-*-test*` targets)
  - `testing-plugin:test-*` (10 members)
  - `*-development*` (8 members)

Each cluster / split candidate the human decides to act on lands as its own follow-up PR per `CLAUDE.md` guidance.

## Test plan

- [x] `python3 scripts/audit-skill-structure.py` writes five artefacts to `tmp/skill-audit/` and exits 0
- [x] `python3 scripts/audit-skill-structure.py --strict` exits 1 (baseline has 2 error-tier splits)
- [x] `report.json` validates (`python3 -m json.tool`)
- [x] `overlap-clusters.md` surfaces all three target clusters (verified)
- [x] Size-tier split suppressed on skills with sibling `REFERENCE.md` (e.g. `d2-diagrams` 446 lines — only fenced-code check fires, not size)
- [x] Regression fixture at `tmp/fixtures/fixture-plugin/skills/oversized-skill/SKILL.md` (525 lines) fires as error-tier when run with `--root tmp/fixtures`
- [x] New skill dogfoods cleanly — passes `plugin-compliance-check.sh`, `audit-skill-descriptions.py --strict`, `lint-context-commands.sh`, `ruff check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)