### PR TITLE
docs(git-plugin,github-actions-plugin): add When to Use tables to 3 skills

### DIFF
--- a/git-plugin/skills/git-commit-push-pr/SKILL.md
+++ b/git-plugin/skills/git-commit-push-pr/SKILL.md
@@ -14,6 +14,14 @@ description: |
   or wants to go from uncommitted changes to an open pull request in one step.
 ---
 
+## When to Use This Skill
+
+| Use this skill when... | Use X instead when... |
+|------------------------|----------------------|
+| Going from uncommitted changes to an open PR in one step | Creating commits only with no push or PR (`/git:commit`) |
+| Auto-detecting issues, committing, pushing, and opening a PR together | Pushing existing commits to a remote without opening a PR (`/git:push`) |
+| Running the full commit-push-PR pipeline non-interactively | Opening a PR from already-pushed commits (`/git:pr-create`) |
+
 ## Context
 
 - Pre-commit config: !`find . -maxdepth 1 -name ".pre-commit-config.yaml"`

--- a/git-plugin/skills/git-issue/SKILL.md
+++ b/git-plugin/skills/git-issue/SKILL.md
@@ -14,6 +14,14 @@ disable-model-invocation: true
 name: git-issue
 ---
 
+## When to Use This Skill
+
+| Use this skill when... | Use X instead when... |
+|------------------------|----------------------|
+| Implementing a fix for one or more open issues with TDD and PR creation | Performing administrative ops (transfer, pin, lock, bulk edit) on issues (`/git:issue-manage`) |
+| Picking issues from the backlog to work on, optionally in parallel | Periodically grooming open issues and PRs to close stale or completed ones (`/git:triage`) |
+| Going from an issue number to a merged-ready PR end-to-end | Hierarchical sub-issue planning and tracking (`/git:issue-hierarchy`) |
+
 ## Context
 
 - Git remotes: !`git remote -v`

--- a/github-actions-plugin/skills/workflow-dev/SKILL.md
+++ b/github-actions-plugin/skills/workflow-dev/SKILL.md
@@ -20,6 +20,14 @@ name: workflow-dev
 
 Automated development loop with issue creation, TDD, and CI monitoring.
 
+## When to Use This Skill
+
+| Use this skill when... | Use X instead when... |
+|------------------------|----------------------|
+| Running a continuous loop that turns test failures into issues, then resolves them | Inspecting an existing workflow run or debugging CI failures (`/workflow:github-actions-inspection`) |
+| Automating the full issue → branch → PR → green-CI cycle through the backlog | Generating a reusable auto-fix workflow file for multiple repos (`/workflow:ci-autofix-reusable`) |
+| Wanting Claude to pick the next issue and drive it through TDD without user input | Searching upstream OSS issues for known errors or workarounds (`/workflow:github-issue-search`) |
+
 ## Context
 
 - Current branch: !`git branch --show-current`


### PR DESCRIPTION
## Summary

Adds the required "When to Use This Skill" decision table to three SKILL.md files that were flagged by PR review as missing it. The table is a quality requirement defined in `.claude/rules/skill-quality.md`.

Skills updated:
- `git-plugin/skills/git-commit-push-pr/SKILL.md` — contrasted with `/git:commit`, `/git:push`, `/git:pr-create`
- `git-plugin/skills/git-issue/SKILL.md` — contrasted with `/git:issue-manage`, `/git:triage`, `/git:issue-hierarchy`
- `github-actions-plugin/skills/workflow-dev/SKILL.md` — contrasted with `/workflow:github-actions-inspection`, `/workflow:ci-autofix-reusable`, `/workflow:github-issue-search`

Each "Use X instead when..." row references a real sibling skill verified to exist in the same plugin (no placeholders). Tables are placed immediately after the title/intro, before the first content section, per the rule.

Closes #1125
Refs #1123

## Test plan

- [x] Pre-commit hooks pass (shellcheck, gitleaks, lint-context-commands, configure-repo freshness, audit-skill-descriptions)
- [x] All three "Use X instead when..." references point to real sibling skills (verified via `ls`)
- [x] Tables placed immediately after title/frontmatter and before first `##` content section
- [x] No other SKILL.md files modified (scope limited to the three flagged in #1125)
- [ ] CI checks pass on this PR