### PR TITLE
docs(git-plugin): note gh pr merge --auto worktree pitfall

### DIFF
--- a/git-plugin/skills/git-commit-push-pr/SKILL.md
+++ b/git-plugin/skills/git-commit-push-pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: git-commit-push-pr
 created: 2025-12-16
-modified: 2026-04-23
+modified: 2026-04-25
 reviewed: 2026-03-15
 allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git branch *), Bash(git remote *), Bash(gh pr *), Bash(gh label *), Bash(gh repo *), Bash(gh issue *), Bash(pre-commit *), Bash(find *), Read, Edit, Grep, Glob, TodoWrite, mcp__github__create_pull_request, mcp__github__list_issues, mcp__github__get_issue
 args: "[remote-branch] [--push] [--direct] [--pr] [--draft] [--issue <num>] [--no-commit] [--range <start>..<end>] [--skip-issue-detection]"
@@ -202,6 +202,16 @@ gh pr checks <pr-number> --watch --fail-fast
 **On success (exit 0)**:
 - Report: "All checks passed. PR #N is ready for merge."
 - Provide merge command: `gh pr merge <pr-number> --squash --delete-branch`
+
+> **Pitfall — `--delete-branch` from the PR's own working tree:** before running `gh pr merge <N> --squash --auto --delete-branch`, switch your working tree to `main` (or any branch other than the PR head). If your cwd or any worktree has the PR's branch checked out, the local-branch-delete step fails with `cannot delete branch 'X' used by worktree at Y` even though the server-side merge is queued correctly. The misleading error makes it look like the merge failed; confirm with `gh pr view <N> --json state`.
+>
+> Safer two-step pattern:
+>
+> ```bash
+> git switch main
+> git pull
+> gh pr merge <pr-number> --squash --auto --delete-branch
+> ```
 
 **On failure (exit 1)**:
 - Report which check(s) failed with details:


### PR DESCRIPTION
## Summary

`gh pr merge <N> --squash --auto --delete-branch` reports a misleading failure when the local working tree (or any worktree) has the PR's branch checked out — server-side merge is queued correctly, but the local branch-delete step fails with `cannot delete branch 'X' used by worktree at Y`. Users reasonably think the merge didn't happen and retry unnecessarily.

This adds a `> **Pitfall:**` callout in `git-plugin/skills/git-commit-push-pr/SKILL.md` near the existing `gh pr merge --delete-branch` guidance, plus the safer two-step pattern (`git switch main && git pull` first).

`git-commit-push-pr` is the most user-facing host: it directly hands the developer the merge command after PR creation. Three other skills mention `gh pr merge` (`git-triage`, `configure-plugin/ci-workflows`, `configure-plugin/configure-argocd-automerge`); the latter two run inside CI YAML where the pitfall doesn't apply, and `git-triage` is a candidate for a future docs sweep.

Closes #1093

## Test plan

- Manual: read the rendered SKILL — pitfall is visible near the gh pr merge guidance