### PR TITLE
docs(project-plugin): broaden project-distill triggers for codify-workflow

### DIFF
--- a/project-plugin/skills/project-distill/SKILL.md
+++ b/project-plugin/skills/project-distill/SKILL.md
@@ -5,13 +5,16 @@ description: |
   improvements, and justfile recipes. Use when the user asks to capture
   session learnings at end of day, extract patterns worth reusing, update
   existing rules based on session experience, propose new justfile recipes
-  from commands we ran, or turn pain points into durable artifacts.
-  Prioritizes updating over adding.
+  from commands we ran, or turn pain points into durable artifacts. Also
+  use when the user asks to "codify the workflow" into `.claude/rules`,
+  "analyze session patterns and promote to rules", "write a new rule
+  from these session patterns", or "extract durable knowledge from a
+  productive session". Prioritizes updating over adding.
 allowed-tools: Bash(git diff *), Bash(git log *), Bash(git status *), Bash(just *), Read, Grep, Glob, Edit, Write, AskUserQuestion, TodoWrite
 argument-hint: "--rules | --skills | --recipes | --all | --dry-run"
 args: "[--rules] [--skills] [--recipes] [--all] [--dry-run]"
 created: 2026-02-11
-modified: 2026-04-19
+modified: 2026-04-25
 reviewed: 2026-02-26
 ---
 
@@ -27,6 +30,7 @@ Distill session insights into reusable project knowledge.
 | Discovered a pattern worth reusing | Need to analyze git history for docs gaps -> `/git:log-documentation` |
 | Found a CLI workflow worth saving as a recipe | Need to configure a justfile from scratch -> `/configure:justfile` |
 | Want to update rules based on session experience | Need to check project infrastructure -> `/configure:status` |
+| Asked to "codify the workflow" or "analyze and promote session patterns to rules" | Need a one-off implementation, not a reusable rule -> implement directly |
 
 ## Core Principle: Update Over Add
 


### PR DESCRIPTION
## Summary

- Broadens `project-distill` discoverability so it surfaces for mid-session "codify the workflow" requests, not only end-of-day "distill" phrasing.
- Adds four new trigger phrases to the frontmatter `description` covering codify / analyze-and-promote / write-a-new-rule / extract-durable-knowledge intents.
- Adds a "When to Use This Skill" row keyed off "codify the workflow" / "analyze and promote session patterns to rules" with the contrasting case "Need a one-off implementation, not a reusable rule -> implement directly".
- Bumps `modified` to 2026-04-25; leaves `reviewed` unchanged (no doc-currency review performed).

This is a discoverability fix — no behavior change inside the skill body. Issue #1130 reports a session where the user said "Let's analyze and codify the best parts of the workflow this session" and Claude went straight to dispatching sub-agents instead of invoking `/project:distill`. The skill already produces the right artefacts (rules + skill updates + recipes); it just wasn't matching the trigger phrasing.

## Test plan

- [ ] Frontmatter is valid YAML (pre-commit hooks pass — confirmed at commit time)
- [ ] `audit-skill-descriptions.py` still passes (confirmed in pre-commit)
- [ ] Manual smoke check: phrase "codify this session's workflow into a rule" auto-invokes `/project:distill` instead of falling through to ad-hoc rule writing

Closes #1130