### PR TITLE
feat(taskwarrior-plugin): scope queries to current project by default

### DIFF
--- a/taskwarrior-plugin/README.md
+++ b/taskwarrior-plugin/README.md
@@ -21,10 +21,27 @@ Both systems stay in sync via UDAs (`ghid`, `ghpr`) and tags (`+gh`, `+pr-ready`
 
 | Skill | Purpose |
 |-------|---------|
-| `/taskwarrior:task-add` | File a task with bpid / bpdoc / bpms fields; offers GitHub issue linkage when a remote is detected |
+| `/taskwarrior:task-add` | File a task with bpid / bpdoc / bpms fields; auto-tags `project:` from the current repo; offers GitHub issue linkage when a remote is detected |
 | `/taskwarrior:task-done` | Close a task, annotate with commit hash, drain the linked feature-tracker entry; offers to close the linked GitHub issue |
-| `/taskwarrior:task-status` | Read-only consolidated queue + drift report; folds in `gh pr status` when GitHub is present |
-| `/taskwarrior:task-coordinate` | Surface the next N unblocked tasks sorted by urgency that do not contend on an exclusive lock — input for parallel / wave dispatch |
+| `/taskwarrior:task-status` | Read-only consolidated queue + drift report scoped to the current project; folds in `gh pr status` when GitHub is present |
+| `/taskwarrior:task-coordinate` | Surface the next N unblocked tasks (in the current project) sorted by urgency that do not contend on an exclusive lock — input for parallel / wave dispatch |
+
+## Project scoping
+
+`task-add`, `task-status`, and `task-coordinate` all default to the
+**current repo's project** so an agent in repo A is not distracted by
+tasks from repos B and C. The project identifier is the basename of the
+git toplevel (or the cwd if no git repo is present).
+
+| Skill | Default scope | Override | Opt out |
+|-------|---------------|----------|---------|
+| `task-add` | Tags new task with `project:<repo>` | `project:<name>` arg | `--no-project` |
+| `task-status` | Filters report to `project:<repo>` | `--project=<name>` | `--all` |
+| `task-coordinate` | Filters dispatch candidates to `project:<repo>` | `--project=<name>` | `--all` (rare) |
+
+Tasks filed before this default existed have no `project:` set and will
+not match the auto-filter — pass `--all` once to find them, then
+backfill with `task <ID> modify project:<name>`.
 
 ## User-Defined Attributes (UDAs)
 

--- a/taskwarrior-plugin/skills/task-add/SKILL.md
+++ b/taskwarrior-plugin/skills/task-add/SKILL.md
@@ -7,12 +7,12 @@ description: |
   or offers to create a new issue. Use when adding a coordination task for
   multi-agent work, linking a blueprint WO to an actionable queue entry,
   or mirroring a GitHub issue into the local task queue.
-args: "[description]"
+args: "[description] [project:<name>] [--no-project]"
 allowed-tools: Bash(task *), Bash(git config *), Bash(git rev-parse *), Bash(gh auth *), Bash(gh issue *), Bash(gh api *), Read, TodoWrite
 argument-hint: short task description
 created: 2026-04-24
-modified: 2026-04-24
-reviewed: 2026-04-24
+modified: 2026-04-25
+reviewed: 2026-04-25
 ---
 
 # /taskwarrior:task-add
@@ -22,18 +22,37 @@ File a coordination task. When a GitHub remote is present, offer optional linkag
 ## Context
 
 - Task CLI available: !`command -v task`
+- Git toplevel: !`git rev-parse --show-toplevel`
 - Git remote: !`git config --get remote.origin.url`
 - GH auth: !`gh auth status`
 - Existing UDAs: !`task _udas`
-- Duplicate check preamble: !`task _projects`
+- Known projects: !`task _projects`
 
 ## Parameters
 
 Parse `$ARGUMENTS`:
 
 - Freeform short description (required).
+- Optional inline `project:<name>` to override the auto-detected project.
+- Optional `--no-project` to file the task without any project (cross-cutting work).
 - Optional inline `bpid:WO-012` / `bpdoc:docs/wo/012.md` / `bpms:M6` / `ghid:145` / `ghpr:99` fields.
 - Optional tags: `+wo`, `+prp`, `+fr`, `+re`, `+gh`, `+pr-ready`, `+needs-review`, `+blocked-on-merge`, `+blocked`.
+
+### Project resolution
+
+By default every task is filed under the current repo's project so
+`/taskwarrior:task-status` and `/taskwarrior:task-coordinate` only see
+tasks relevant to where the agent is working. Resolve the project in
+this order:
+
+1. Explicit `project:<name>` in `$ARGUMENTS`.
+2. `--no-project` → file with no project (rare; cross-cutting work).
+3. Basename of the path reported as `Git toplevel` in Context.
+4. If no git repo, basename of cwd.
+
+Cross-check the resolved name against `Known projects` and reuse the
+exact spelling when it matches (case-insensitive) — taskwarrior treats
+`MyRepo` and `myrepo` as different projects.
 
 ## Execution
 
@@ -69,10 +88,12 @@ If either fails, skip GitHub-related branches in later steps.
 
 ### Step 3: Duplicate check by bpid
 
-If `bpid:` was given, run parallel-safe:
+If `bpid:` was given, run parallel-safe and constrain to the resolved
+project so a matching `bpid` in another repo's queue is not surfaced as
+a false-positive duplicate:
 
 ```bash
-task bpid:"$BPID" export | jq '.[] | {id, description, status}'
+task project:myrepo bpid:"$BPID" export | jq '.[] | {id, description, status}'
 ```
 
 Never use `task bpid:"$BPID" list` — it exits 1 on empty result and cancels sibling tool calls in parallel batches (see `.claude/rules/parallel-safe-queries.md`).
@@ -99,10 +120,13 @@ gh issue create --title "$TITLE" --body "$BODY"
 
 ### Step 5: Create the task
 
-Compose the taskwarrior add command from the collected inputs. Quote every field; tags use the `+tag` form:
+Compose the taskwarrior add command from the collected inputs. Always
+include `project:` (the resolved project from Parameters) unless the
+user passed `--no-project`. Quote every field; tags use the `+tag` form:
 
 ```bash
 task add "$DESCRIPTION" \
+  project:myrepo \
   bpid:"$BPID" \
   bpdoc:"$BPDOC" \
   bpms:"$BPMS" \
@@ -118,6 +142,7 @@ Run with only the fields that were provided; omit empty UDAs entirely rather tha
 Print:
 
 - New task ID
+- Project (auto-detected / overridden / `--no-project`)
 - bpid → bpdoc → bpms chain
 - ghid/ghpr if linked
 - Tags applied
@@ -136,6 +161,8 @@ Print:
 
 | Flag / field | Purpose |
 |--------------|---------|
+| `project:` | Project (defaults to repo basename) |
+| `--no-project` | File without a project (cross-cutting) |
 | `bpid:` | Blueprint ID link |
 | `bpdoc:` | Blueprint doc path |
 | `bpms:` | Milestone |

--- a/taskwarrior-plugin/skills/task-coordinate/SKILL.md
+++ b/taskwarrior-plugin/skills/task-coordinate/SKILL.md
@@ -8,12 +8,12 @@ description: |
   planning a parallel-agent-dispatch wave, when deciding which tasks
   share a dispatch slot, or when deciding whether to pre-dump a locked
   resource before fanning out.
-args: "[--n=N] [--lock=<resource>] [--wave]"
-allowed-tools: Bash(task *), Bash(jq *), Read, TodoWrite
+args: "[--n=N] [--lock=<resource>] [--wave] [--project=<name>] [--all]"
+allowed-tools: Bash(task *), Bash(git rev-parse *), Bash(jq *), Read, TodoWrite
 argument-hint: optional count (default 3) and lock filter
 created: 2026-04-24
-modified: 2026-04-24
-reviewed: 2026-04-24
+modified: 2026-04-25
+reviewed: 2026-04-25
 ---
 
 # /taskwarrior:task-coordinate
@@ -23,8 +23,8 @@ Next-candidate-agent surfacing for parallel / wave dispatch. Pairs with `agent-p
 ## Context
 
 - Task CLI available: !`command -v task`
-- Pending with urgency: !`task status:pending -BLOCKED export`
-- Pending blocked: !`task +BLOCKED export`
+- Git toplevel: !`git rev-parse --show-toplevel`
+- Known projects: !`task _projects`
 
 ## Parameters
 
@@ -33,6 +33,19 @@ Parse `$ARGUMENTS`:
 - `--n=N` — number of candidates to surface (default 3)
 - `--lock=<resource>` — exclude candidates that need the named lock (e.g. `ghidra`, `migration`, `task-bulk`)
 - `--wave` — format output as a wave brief (orchestrator-ready)
+- `--project=<name>` — override the auto-detected project filter
+- `--all` — opt out of project filtering (cross-project wave; rare — usually wrong for dispatch)
+
+### Project resolution
+
+Default behaviour is project-scoped. A wave dispatch almost always wants
+candidates from a single repo, so cross-project candidates are filtered
+out by default. Resolve `$PROJECT` in this order:
+
+1. `--project=<name>` if provided.
+2. `--all` → no project filter (cross-project wave).
+3. Basename of the path reported as `Git toplevel` in Context.
+4. If no git repo, basename of cwd.
 
 ## Execution
 
@@ -40,13 +53,17 @@ Execute this workflow:
 
 ### Step 1: Load unblocked pending tasks
 
+Substitute the literal project name into the filter (no `$()` command
+substitution — shell-operator protections will reject it):
+
 ```bash
-task status:pending -BLOCKED export \
+task project:myrepo status:pending -BLOCKED export \
   | jq 'sort_by(-.urgency) | .[] | {id, description, urgency, tags, bpid, depends}'
 ```
 
 Already filters out `depends:`-blocked tasks via the `-BLOCKED` virtual
-attribute. Never use `task next` — exits 1 on empty.
+attribute. Never use `task next` — exits 1 on empty. With `--all`, drop
+the `project:` clause.
 
 ### Step 2: Detect lock contenders
 
@@ -72,6 +89,13 @@ Keep the top N by urgency. If ties, prefer:
 3. Tasks with earlier `entry` (older first)
 
 ### Step 4: Emit candidates
+
+Lead the output with the resolved project scope so the orchestrator
+knows the wave is single-repo (default) or cross-project (`--all`):
+
+```
+Project: myrepo (auto-detected from git toplevel)
+```
 
 Default format (compact):
 
@@ -105,7 +129,8 @@ whether to pre-dump via `exclusive-lock-dispatch` or serialise.
 
 | Context | Command |
 |---------|---------|
-| Unblocked sorted by urgency | `task status:pending -BLOCKED export \| jq 'sort_by(-.urgency)'` |
+| Project unblocked by urgency | `task project:myrepo status:pending -BLOCKED export \| jq 'sort_by(-.urgency)'` |
+| Cross-project (`--all`) | `task status:pending -BLOCKED export \| jq 'sort_by(-.urgency)'` |
 | Same-lock siblings | Filter on `tags` / bpid prefix locally, not via `task` filter |
 | Wave brief | `--wave` flag emits table with exclusion column |
 | Skip failing-filter variants | Never `task next`, always `export \| jq` |
@@ -117,6 +142,8 @@ whether to pre-dump via `exclusive-lock-dispatch` or serialise.
 | `--n=3` | 3 | How many candidates |
 | `--lock=ghidra` | unset | Drop ghidra-contending tasks |
 | `--wave` | off | Emit wave brief format |
+| `--project=<name>` | repo basename | Override the project filter |
+| `--all` | off | Disable project filter (cross-project wave) |
 
 ## Related
 

--- a/taskwarrior-plugin/skills/task-status/SKILL.md
+++ b/taskwarrior-plugin/skills/task-status/SKILL.md
@@ -7,12 +7,12 @@ description: |
   task #7 still pending" surfaces in one view. Use when auditing queue
   health, orienting before a wave dispatch, spotting tasks that lost
   their linked issue or PR, or producing a standup summary.
-args: "[--mine] [--blocked] [--stale=N]"
-allowed-tools: Bash(task *), Bash(git config *), Bash(gh auth *), Bash(gh pr *), Bash(jq *), Read, TodoWrite
+args: "[--mine] [--blocked] [--stale=N] [--project=<name>] [--all]"
+allowed-tools: Bash(task *), Bash(git config *), Bash(git rev-parse *), Bash(gh auth *), Bash(gh pr *), Bash(jq *), Read, TodoWrite
 argument-hint: optional filters
 created: 2026-04-24
-modified: 2026-04-24
-reviewed: 2026-04-24
+modified: 2026-04-25
+reviewed: 2026-04-25
 ---
 
 # /taskwarrior:task-status
@@ -22,9 +22,10 @@ Read-only status report on the coordination queue. Strictly uses `export | jq` �
 ## Context
 
 - Task CLI available: !`command -v task`
-- Pending count (export/jq): !`task status:pending export`
+- Git toplevel: !`git rev-parse --show-toplevel`
 - Git remote: !`git config --get remote.origin.url`
 - GH auth: !`gh auth status`
+- Known projects: !`task _projects`
 
 ## Parameters
 
@@ -33,7 +34,25 @@ Parse `$ARGUMENTS`:
 - `--mine` — limit to tasks where `assigned:` matches current user / agent
 - `--blocked` — only tasks with `+blocked` / `+blocked-on-merge` or active `depends:`
 - `--stale=N` — highlight tasks modified > N days ago
-- No flags — full report
+- `--project=<name>` — override the auto-detected project filter
+- `--all` — opt out of project filtering and report across every project
+- No flags — full report **scoped to the current project**
+
+### Project resolution
+
+Default behaviour is project-scoped — surfacing tasks from other repos as
+"queue noise" is the most common waste of agent context. Resolve the
+project identifier in this order:
+
+1. `--project=<name>` if provided.
+2. `--all` → no project filter.
+3. Basename of the path reported as `Git toplevel` in Context.
+4. If no git repo, basename of the cwd.
+
+Cross-check the resolved name against `Known projects`. If it is not in
+the list, note it (likely a fresh project or no tasks filed yet) but
+still apply the filter — `task export` returns `[]` cleanly when the
+project has no matching tasks.
 
 ## Execution
 
@@ -41,17 +60,20 @@ Execute this workflow:
 
 ### Step 1: Snapshot the queue
 
-Pull full state as JSON in a single call. `task export` emits `[]` on an
-empty store — valid and exit 0.
+Pull full state as JSON in a single call, scoped to the resolved project
+(omit `project:$PROJECT` only when `--all` is set). `task export` emits
+`[]` on an empty store — valid and exit 0. Substitute the literal
+project name into the filter — do **not** use `$()` command substitution
+in the inline command (shell-operator protections will reject it).
 
 ```bash
-task status:pending export | jq '.[] | {id, description, urgency, tags, bpid, bpdoc, ghid, ghpr, modified, depends}'
+task project:myrepo status:pending export | jq '.[] | {id, description, urgency, tags, bpid, bpdoc, ghid, ghpr, modified, depends}'
 ```
 
-For completeness also pull recently-completed:
+For completeness also pull recently-completed in the same project:
 
 ```bash
-task status:completed end.after:now-7d export | jq '.[] | {id, description, bpid, ghid, end}'
+task project:myrepo status:completed end.after:now-7d export | jq '.[] | {id, description, bpid, ghid, end}'
 ```
 
 ### Step 2: Sort and group
@@ -60,7 +82,7 @@ By urgency descending, then by milestone (`bpms`), then by blueprint kind
 (`+wo` / `+prp` / `+fr` / `+re`). Use jq to partition:
 
 ```bash
-task status:pending export \
+task project:myrepo status:pending export \
   | jq 'group_by(.bpms) | map({milestone: .[0].bpms, tasks: sort_by(-.urgency)})'
 ```
 
@@ -92,6 +114,14 @@ with a green PR are the highest-value drain candidates.
 
 ### Step 5: Render
 
+Lead the report with the resolved project scope so the reader knows
+whether they're seeing a single-project view or `--all`:
+
+```
+Project: myrepo (auto-detected from git toplevel)
+Pass --all for cross-project view, --project=<name> to override.
+```
+
 Output these sections, in order:
 
 1. **Summary**: pending count, ready count (unblocked), blocked count, stale count
@@ -107,8 +137,9 @@ Each row cites the command to act on it (`/taskwarrior:task-done 7`).
 
 | Context | Command |
 |---------|---------|
-| Full queue JSON | `task status:pending export \| jq` |
-| Ready-for-dispatch | `task status:pending -BLOCKED export \| jq 'sort_by(-.urgency) \| .[:5]'` |
+| Project queue JSON | `task project:myrepo status:pending export \| jq` |
+| Cross-project queue (`--all`) | `task status:pending export \| jq` |
+| Ready-for-dispatch | `task project:myrepo status:pending -BLOCKED export \| jq 'sort_by(-.urgency) \| .[:5]'` |
 | PR status | `gh pr status --json number,state,statusCheckRollup` |
 | Drift check | `gh issue view "$GHID" --json state` |
 | Never use | `task list`, `task next`, `task report` — exit 1 on empty |
@@ -117,6 +148,7 @@ Each row cites the command to act on it (`/taskwarrior:task-done 7`).
 
 | Filter | Expands to |
 |--------|-----------|
+| `project:<name>` | Single project (default scope) |
 | `status:pending` | Open tasks |
 | `-BLOCKED` | Exclude `depends:`-blocked |
 | `urgency.above:5` | High-urgency only |


### PR DESCRIPTION
## Summary

- `task-status`, `task-coordinate`, and `task-add` now default to scoping their `task export` queries to the **current repo's project** (basename of the git toplevel, with `cwd` as fallback) so an agent in repo A is not distracted by queue noise from repos B and C.
- New `--project=<name>` override and `--all` opt-out on both read skills; new `project:<name>` arg and `--no-project` opt-out on `task-add`.
- `task-add` now stamps every new task with `project:` by default — going forward, the project filter on the read skills will match. Pre-existing tasks without a project need a one-time `--all` view + `task <id> modify project:<name>` backfill (called out in the README).

### Why

The previous defaults pulled the full pending queue across every repo on the host. For agent contexts that's pure noise: a task-coordinate run in repo A would surface candidates from repo B that the dispatcher has no business touching, and the resulting list ate context window budget for nothing. Scoping by project is the obvious filter — taskwarrior already supports `project:` natively and `task export` returns `[]` cleanly when the filter matches nothing, so parallel-safe semantics are preserved.

### Implementation notes

- Project name is computed by the model from the `Git toplevel` value in the `## Context` block (basename), then **inlined as a literal** in the `task export` command. We avoid `$(basename "$(git rev-parse ...)")` in the inline bash because `$()` is on the shell-operator protection list and would force interactive permission prompts.
- `--all` is documented as the escape hatch on `task-status` (cross-project audit) and as "rare — usually wrong" on `task-coordinate` (cross-project waves are almost always a mistake).
- `task-done` is unchanged — it loads tasks by id, so project scoping is irrelevant. The "unblocked siblings" report at the end still surfaces cross-project dependents intentionally.

## Test plan

- [ ] `/taskwarrior:task-add "thing"` in repo A files the task with `project:A` and reports the project in the summary
- [ ] `/taskwarrior:task-status` in repo A only shows tasks with `project:A`
- [ ] `/taskwarrior:task-status --all` shows tasks across every project
- [ ] `/taskwarrior:task-status --project=B` shows tasks from repo B while running from repo A
- [ ] `/taskwarrior:task-coordinate` only ranks candidates from the current project
- [ ] `/taskwarrior:task-add "thing" --no-project` files the task without a project
- [ ] `bash scripts/plugin-compliance-check.sh taskwarrior-plugin` passes
- [ ] `bash scripts/lint-context-commands.sh taskwarrior-plugin` produces no taskwarrior warnings

https://claude.ai/code/session_01RZb6T82wMAUfdmLCWcZv3N

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZb6T82wMAUfdmLCWcZv3N)_