### PR TITLE
fix(git-repo-agent): remove dangling derive-plans reference

### DIFF
--- a/git-repo-agent/README.md
+++ b/git-repo-agent/README.md
@@ -278,7 +278,7 @@ CLI surface (`git-repo-agent blueprint <subcommand>`):
 | `sync` | `blueprint-sync` | Detect stale generated content |
 | `scan` | `workspace-scan` → `feature-tracker-sync` → `feature-tracker-status` | Refresh monorepo rollups |
 | `adr-list` | `blueprint-adr-list` | List ADRs as markdown table |
-| `derive-plans` | `blueprint-derive-plans` | Derive PRDs/ADRs/PRPs from git |
+| `derive-plans` | `blueprint-derive-plans` | Derive PRDs/ADRs/PRPs from git (disabled for the claude-plugins repo itself — see [`CLAUDE.md`](../CLAUDE.md) "Blueprint constrained dogfooding") |
 | `generate-rules` | `blueprint-generate-rules` | Auto-generate project rules |
 | `promote <target>` | `blueprint-promote` | Preserve custom edits |
 | `prp-create <feature>` | `blueprint-prp-create` | Create a PRP for a feature |


### PR DESCRIPTION
## Summary

- Annotates the `derive-plans` row in the `git-repo-agent` blueprint CLI surface table to indicate the subcommand is intentionally disabled when run against the `claude-plugins` repo itself (per `CLAUDE.md` "Blueprint constrained dogfooding").
- Resolves the `Unknown skill: blueprint-plugin:derive-plans` hook errors traced to repeated invocations of an undocumented-as-disabled workflow.

## Rationale

The Wave 3 triage (issue #1112) found three references to `derive-plans` in the repo:

1. `git-repo-agent/README.md:281` — the only **dangling** one (no disabled marker), this PR's target.
2. `CLAUDE.md:233` — already correctly marked as disabled (untouched).
3. `git-repo-agent/docs/adr/006-blueprint-state-machine-driver.md:139` — historical ADR, immutable record (untouched).

Decision: **mark as disabled** rather than remove. The table documents `git-repo-agent`'s full blueprint CLI surface — the CLI subcommand and underlying skill both still exist for upstream consumers. Removing the row would create a gap in CLI documentation; annotating it preserves coverage while signaling the dogfooding constraint.

## Test plan

- [ ] Verify the row renders correctly in GitHub's markdown preview
- [ ] Confirm the link to `../CLAUDE.md` resolves
- [ ] Spot-check that no other `derive-plans` references in the repo were inadvertently touched

Closes #1112