### PR TITLE
fix(hooks): bootstrap PATH for agent subshells

### DIFF
--- a/.claude/rules/sandbox-guidance.md
+++ b/.claude/rules/sandbox-guidance.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-03-03
-modified: 2026-03-03
-reviewed: 2026-03-03
+modified: 2026-04-25
+reviewed: 2026-04-25
 paths:
   - "**/skills/**"
   - "**/SKILL.md"
@@ -139,6 +139,28 @@ if [ -n "$CLAUDE_ENV_FILE" ]; then
   echo "NODE_ENV=development" >> "$CLAUDE_ENV_FILE"
 fi
 ```
+
+### PATH Bootstrap for Agent Subshells
+
+Agent subshells spawned by the harness do **not** source the user's interactive shell config (`~/.zshrc`, `~/.bash_profile`). They start with a `/usr/bin:/bin`-only PATH and report `command not found: head` / `command not found: jq` even though the parent CLI shell has both. The fix is a SessionStart hook that prepends Homebrew bin directories to PATH via `$CLAUDE_ENV_FILE`. Guard each candidate directory with `[ -d ]` so the same script is safe in remote sandboxes where `/opt/homebrew` may not exist.
+
+```bash
+# scripts/path-bootstrap.sh
+if [ -z "${CLAUDE_ENV_FILE:-}" ]; then exit 0; fi
+
+prepend=""
+for dir in /opt/homebrew/bin /opt/homebrew/sbin /usr/local/bin /usr/local/sbin; do
+  [ -d "$dir" ] || continue
+  case ":${PATH:-}:" in *":$dir:"*) continue ;; esac
+  prepend="${prepend:+$prepend:}$dir"
+done
+
+if [ -n "$prepend" ]; then
+  printf 'PATH=%s:%s\n' "$prepend" "${PATH:-/usr/bin:/bin}" >> "$CLAUDE_ENV_FILE"
+fi
+```
+
+Wire it into `.claude/settings.json` under `hooks.SessionStart` with an empty matcher so it runs on every session start (including resumes and `/clear`).
 
 ---
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -43,6 +43,20 @@
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/path-bootstrap.sh\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  },
   "enableAllProjectMcpServers": true,
   "enabledPlugins": {},
   "extraKnownMarketplaces": {}

--- a/scripts/path-bootstrap.sh
+++ b/scripts/path-bootstrap.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# scripts/path-bootstrap.sh
+#
+# SessionStart hook: prepend Homebrew bin directories to PATH so that agent
+# subshells inherit the same `head`, `jq`, `gh`, etc. that the parent
+# interactive shell sees. Without this, agents spawned via non-login shells
+# end up with a `/usr/bin:/bin`-only PATH and report `command not found:
+# head` / `command not found: jq` despite the parent having both.
+#
+# This script is idempotent and safe in remote sandboxes:
+#   - Only writes to $CLAUDE_ENV_FILE when the harness sets it.
+#   - Only adds directories that actually exist on this machine.
+#   - Does not duplicate entries that are already on PATH.
+#
+# Closes laurigates/claude-plugins#1111
+set -euo pipefail
+
+# No env file → nothing to persist; the harness ignores plain stdout writes
+# to PATH because each tool call is a fresh subshell.
+if [ -z "${CLAUDE_ENV_FILE:-}" ]; then
+  exit 0
+fi
+
+# Candidate directories, in priority order. /opt/homebrew is Apple Silicon;
+# /usr/local is Intel macOS / older installs / many Linux Homebrew layouts.
+candidates=(
+  /opt/homebrew/bin
+  /opt/homebrew/sbin
+  /usr/local/bin
+  /usr/local/sbin
+)
+
+prepend=""
+for dir in "${candidates[@]}"; do
+  # Skip dirs that don't exist on this machine (e.g. remote sandbox without
+  # Homebrew, or Intel-only host where /opt/homebrew is absent).
+  [ -d "$dir" ] || continue
+  # Skip dirs already on PATH to avoid duplication on session resume.
+  case ":${PATH:-}:" in
+    *":$dir:"*) continue ;;
+  esac
+  prepend="${prepend:+$prepend:}$dir"
+done
+
+if [ -n "$prepend" ]; then
+  printf 'PATH=%s:%s\n' "$prepend" "${PATH:-/usr/bin:/bin}" >> "$CLAUDE_ENV_FILE"
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Add `scripts/path-bootstrap.sh` and register it as a `SessionStart` hook in `.claude/settings.json` so agent subshells inherit Homebrew bin directories on `PATH`.
- Without this hook, agent subshells start with `/usr/bin:/bin` only and report `command not found: head` / `command not found: jq` even though the parent CLI shell has both via Homebrew.
- Document the pattern as a "PATH bootstrap" subsection in `.claude/rules/sandbox-guidance.md` right after the existing `CLAUDE_ENV_FILE` example.

## Why a dedicated script

`scripts/install_pkgs.sh` did not yet exist in this repo (only audit/lint scripts under `scripts/`), and there is no other SessionStart hook on this project. A dedicated script keeps the concern isolated and lets a future `install_pkgs.sh` be added later without untangling unrelated logic.

## Remote-sandbox safety

Each candidate directory (`/opt/homebrew/{bin,sbin}`, `/usr/local/{bin,sbin}`) is guarded with `[ -d "$dir" ]`, so the same script is a no-op on a remote sandbox where `/opt/homebrew` does not exist. The hook also no-ops when `$CLAUDE_ENV_FILE` is unset.

## Test plan

- [x] Smoke-tested locally with a stripped `PATH=/usr/bin:/bin` — script writes `PATH=/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin` to `$CLAUDE_ENV_FILE`.
- [x] Verified the no-`CLAUDE_ENV_FILE` case exits 0 silently.
- [x] Verified pre-commit hooks (shellcheck, gitleaks) pass.
- [ ] On merge: confirm a fresh agent session in this repo can run `head` and `jq` without `command not found`.

Closes #1111

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>