### PR TITLE
docs(git-plugin): standardise When to Use tables

### DIFF
--- a/git-plugin/skills/gh-cli-agentic/skill.md
+++ b/git-plugin/skills/gh-cli-agentic/skill.md
@@ -9,11 +9,20 @@ description: |
 user-invocable: false
 allowed-tools: Bash(gh pr *), Bash(gh run *), Bash(gh issue *), Bash(gh repo *), Bash(gh workflow *), Bash(gh api *), Read
 created: 2025-01-16
-modified: 2026-04-19
-reviewed: 2026-03-19
+modified: 2026-04-25
+reviewed: 2026-04-25
 ---
 
 # GitHub CLI Agentic Patterns
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative when... |
+|---|---|
+| Querying PRs, issues, runs, or repo metadata with `gh` and need JSON output | Use `git-cli-agentic` for porcelain-mode local git queries (status, diff, log) |
+| Inspecting PR checks, mergeable status, or fetching failed CI logs | Use `gh-workflow-monitoring` to actively watch a run until it completes |
+| Resolving a github.com URL into an `gh api` call or working with sub-issues | Use `git-issue-hierarchy` for sub-issue add/remove/dependency-graph operations |
+| Looking up label, repo, or workflow metadata via `gh` JSON commands | Use `github-labels` to actually apply or create labels on issues/PRs |
 
 Optimized `gh` commands for AI agent consumption using JSON output and structured field selection.
 

--- a/git-plugin/skills/gh-workflow-monitoring/skill.md
+++ b/git-plugin/skills/gh-workflow-monitoring/skill.md
@@ -9,11 +9,20 @@ description: |
 user-invocable: false
 allowed-tools: Bash(gh run *), Bash(gh workflow *), Bash(gh pr *), Read
 created: 2025-01-16
-modified: 2026-04-19
-reviewed: 2025-01-16
+modified: 2026-04-25
+reviewed: 2026-04-25
 ---
 
 # GitHub Workflow Monitoring
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative when... |
+|---|---|
+| Watching a workflow run until it completes via blocking `gh run watch` | Use `gh-cli-agentic` for one-shot JSON queries of run/PR check state |
+| Waiting for CI after a push, or triggering a workflow and following progress | Use `git-fix-pr` to diagnose AND auto-correct failing checks on a PR |
+| Diagnosing a failed run with `gh run view --log-failed` | Use `git-pr-feedback` to address reviewer comments rather than CI failures |
+| Finding the latest in-progress run for a workflow | Use `gh-cli-agentic` to list completed runs by status filter |
 
 Watch and monitor GitHub Actions workflow runs using `gh run watch` - a blocking command that follows runs until completion without needing timeouts or polling.
 

--- a/git-plugin/skills/git-branch-pr-workflow/SKILL.md
+++ b/git-plugin/skills/git-branch-pr-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-16
-modified: 2026-03-04
-reviewed: 2026-03-04
+modified: 2026-04-25
+reviewed: 2026-04-25
 name: git-branch-pr-workflow
 description: |
   Branch management, pull request workflows, and GitHub integration. Main-branch
@@ -15,6 +15,15 @@ allowed-tools: Bash, Read, mcp__github__create_pull_request, mcp__github__list_p
 ---
 
 # Git Branch PR Workflow
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative when... |
+|---|---|
+| Designing the overall branch + PR workflow (main-branch dev, MCP integration) | Use `git-branch-naming` to pick or audit a single branch name |
+| Choosing between `git switch`, `git restore`, and feature-branch push patterns | Use `git-rebase-patterns` for linear-history cleanup and stacked PRs |
+| Creating PRs through GitHub MCP tools rather than `gh pr create` | Use `git-pr` to create PRs from a pushed branch via the `gh` CLI |
+| Coordinating commit -> push -> PR end-to-end | Use `git-commit-push-pr` for the consolidated commit+push+PR macro |
 
 Expert guidance for branch management, pull request workflows, and GitHub integration using modern Git commands and linear history practices.
 

--- a/git-plugin/skills/git-cli-agentic/skill.md
+++ b/git-plugin/skills/git-cli-agentic/skill.md
@@ -9,11 +9,20 @@ description: |
 user-invocable: false
 allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git branch *), Bash(git remote *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git restore *), Read
 created: 2025-01-16
-modified: 2026-04-19
-reviewed: 2025-01-16
+modified: 2026-04-25
+reviewed: 2026-04-25
 ---
 
 # Git CLI Agentic Patterns
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative when... |
+|---|---|
+| Writing scriptable `git status/diff/log` calls in porcelain or `--format` mode | Use `gh-cli-agentic` for `gh` JSON queries against the GitHub API |
+| Needing `--porcelain=v2` status, `--numstat` diff counts, or custom `--format` log placeholders | Use `git-commit-workflow` for staging conventions and commit message structure |
+| Reading branch tracking info or main-branch-development push patterns | Use `git-branch-pr-workflow` for the broader branch + PR design choices |
+| Producing deterministic output for parsers and downstream tooling | Use `git-derive-docs` to mine commit history for rules/PRDs/ADRs/PRPs |
 
 Optimized git commands for AI agent consumption using porcelain output and stable formats.
 

--- a/git-plugin/skills/git-commit-trailers/SKILL.md
+++ b/git-plugin/skills/git-commit-trailers/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-03-05
-modified: 2026-03-05
-reviewed: 2026-03-05
+modified: 2026-04-25
+reviewed: 2026-04-25
 name: git-commit-trailers
 description: |
   Git commit trailer conventions and patterns. Use when composing commit messages
@@ -13,6 +13,15 @@ allowed-tools: Bash(git interpret-trailers *), Bash(git log *), Bash(git config 
 ---
 
 # Git Commit Trailers
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative when... |
+|---|---|
+| Adding `BREAKING CHANGE:`, `Release-As:`, `Co-authored-by:`, or `Signed-off-by:` trailers | Use `git-commit-workflow` for the type/scope/subject portion of the message |
+| Driving release-please version bumps via trailer metadata | Use `release-please-configuration` to set up the manifest and changelog rules |
+| Parsing or programmatically adding trailers via `git interpret-trailers` | Use `github-issue-autodetect` to insert `Fixes #N` / `Closes #N` references |
+| Auditing existing commits for missing or malformed trailer keys | Use `git-commit-push-pr` for the end-to-end commit-to-PR macro |
 
 Structured key-value metadata at the end of commit messages. Trailers drive release-please automation, attribution, and issue linking.
 

--- a/git-plugin/skills/git-commit-workflow/SKILL.md
+++ b/git-plugin/skills/git-commit-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-16
-modified: 2026-02-14
-reviewed: 2026-01-15
+modified: 2026-04-25
+reviewed: 2026-04-25
 name: git-commit-workflow
 description: |
   Commit message conventions, staging practices, and commit best practices.
@@ -14,6 +14,15 @@ allowed-tools: Bash, Read
 ---
 
 # Git Commit Workflow
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative when... |
+|---|---|
+| Designing the conventional-commit message and staging conventions for a repo | Use `git-commit` to actually create a commit (handles pre-commit hooks, issue detection) |
+| Reviewing how to group changes logically into focused commits | Use `git-commit-trailers` for `BREAKING CHANGE` / `Co-authored-by` trailer rules |
+| Discussing humble, fact-based commit communication style | Use `github-issue-autodetect` to add `Fixes #N` / `Closes #N` links to messages |
+| Authoring `feat(scope): subject` rules for your codebase | Use `github-pr-title` to apply the same conventional format to PR titles |
 
 Expert guidance for commit message conventions, staging practices, and commit best practices using conventional commits and explicit staging workflows.
 

--- a/git-plugin/skills/git-commit/skill.md
+++ b/git-plugin/skills/git-commit/skill.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-01-21
-modified: 2026-02-14
-reviewed: 2026-02-14
+modified: 2026-04-25
+reviewed: 2026-04-25
 name: git-commit
 description: |
   Create commits with conventional messages and issue references. Handles staging,
@@ -13,6 +13,15 @@ allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git a
 ---
 
 # Git Commit
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative when... |
+|---|---|
+| Creating a local commit with conventional message and pre-commit hooks | Use `git-push` afterwards to send the commit to remote |
+| Auto-detecting related GitHub issues and inserting `Fixes #N` references | Use `github-issue-autodetect` to study the detection patterns themselves |
+| Staging and committing without pushing or opening a PR | Use `git-commit-push-pr` to chain commit + push + PR creation in one step |
+| Applying repo conventions (humble tone, logical grouping) to a single commit | Use `git-commit-workflow` for the broader staging + message convention guidance |
 
 Create local commits with proper conventional messages and issue references.
 

--- a/git-plugin/skills/git-derive-docs/SKILL.md
+++ b/git-plugin/skills/git-derive-docs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-01-24
-modified: 2026-04-19
-reviewed: 2026-01-24
+modified: 2026-04-25
+reviewed: 2026-04-25
 allowed-tools: Bash(git log *), Bash(git shortlog *), Bash(git diff *), Bash(git branch *),
                Bash(git show *), Bash(git rev-list *), Bash(git diff-tree *),
                Bash(git status *), Read, Grep, Glob, Edit, Write, TodoWrite
@@ -16,6 +16,15 @@ description: |
   existing git history.
 name: git-derive-docs
 ---
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative when... |
+|---|---|
+| Mining git history for undocumented rules, PRDs, ADRs, or PRPs | Use `git-cli-agentic` for one-shot porcelain queries against the history |
+| Generating skeleton documentation from commit-message patterns | Use `git-commit-workflow` to set conventions BEFORE the history accrues |
+| Detecting architectural decisions or feature work that was never recorded | Use `github-issue-writing` to file fresh issues from the gaps you find |
+| Auditing whether `.claude/rules/` and `docs/{prds,adrs,prps}/` reflect actual practice | Use `git-triage` to triage the open issues and PRs surfaced during the audit |
 
 ## Context
 

--- a/git-plugin/skills/git-fix-pr/SKILL.md
+++ b/git-plugin/skills/git-fix-pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-16
-modified: 2026-04-19
-reviewed: 2026-01-17
+modified: 2026-04-25
+reviewed: 2026-04-25
 allowed-tools: Bash(gh pr checks *), Bash(gh pr view *), Bash(gh run view *), Bash(gh run list *), Bash(gh repo view *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(pre-commit *), Bash(npm run *), Bash(uv run *), Read, Edit, Grep, Glob, TodoWrite, mcp__github__pull_request_read
 args: "[pr-number] [--auto-fix] [--push]"
 argument-hint: [pr-number] [--auto-fix] [--push]
@@ -13,6 +13,15 @@ description: |
   before pushing corrections.
 name: git-fix-pr
 ---
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative when... |
+|---|---|
+| Fixing failing CI checks on an existing PR (lint, type, test) | Use `git-pr-feedback` to address reviewer comments rather than CI failures |
+| Reproducing red GitHub Actions runs locally before pushing corrections | Use `gh-workflow-monitoring` to passively watch a run rather than fix it |
+| Auto-applying lint/format/type fixes and pushing them to the PR branch | Use `git-resolve-conflicts` when the failure is a merge conflict, not a check |
+| Diagnosing why a pull request is red after a push | Use `git-triage` to sweep many PRs at once instead of fixing one |
 
 ## Context
 

--- a/git-plugin/skills/git-issue-hierarchy/SKILL.md
+++ b/git-plugin/skills/git-issue-hierarchy/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-03-19
-modified: 2026-04-21
-reviewed: 2026-04-21
+modified: 2026-04-25
+reviewed: 2026-04-25
 name: git-issue-hierarchy
 description: |
   Manage sub-issues and native GitHub dependency relationships (blocked_by /
@@ -13,6 +13,15 @@ argument-hint: <parent-issue> [--add N] [--status] [--deps] [--blocked-by N]
 user-invocable: true
 allowed-tools: Bash(gh api *), Bash(gh issue *), Bash(git remote *), Read, Grep, Glob, TodoWrite
 ---
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative when... |
+|---|---|
+| Adding/removing native GitHub sub-issues to a parent issue | Use `git-issue-manage` for transfer, pin, lock, develop-branch operations |
+| Marking issue A as `blocked_by` issue B (or unblocking) | Use `github-issue-writing` to create well-structured issue bodies in the first place |
+| Viewing a parent issue's sub-issue completion progress and dependency graph | Use `git-issue` to actually start working on issues end-to-end |
+| Checking the dependency graph before starting work on a multi-issue feature | Use `gh-cli-agentic` for raw `gh issue --json` queries without hierarchy logic |
 
 ## Context
 

--- a/git-plugin/skills/git-issue-manage/SKILL.md
+++ b/git-plugin/skills/git-issue-manage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-03-19
-modified: 2026-04-23
-reviewed: 2026-03-19
+modified: 2026-04-25
+reviewed: 2026-04-25
 name: git-issue-manage
 description: |
   Administrative operations on GitHub issues. Use when transferring issues
@@ -13,6 +13,15 @@ argument-hint: <transfer|pin|lock|develop|bulk|fields> <issue-numbers...>
 user-invocable: true
 allowed-tools: Bash(gh issue *), Bash(gh api *), Bash(git switch *), Bash(git remote *), Read, Grep, Glob, TodoWrite, AskUserQuestion
 ---
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative when... |
+|---|---|
+| Transferring, pinning, locking, or bulk-editing GitHub issues | Use `github-issue-writing` to compose a single issue body well |
+| Creating a development branch from an issue (`gh issue develop`) | Use `git-branch-pr-workflow` for general branch + PR design |
+| Updating custom issue fields (priority, severity, custom selects) in bulk | Use `github-labels` for label-only operations on issues and PRs |
+| Performing bulk operations across many issue numbers in one command | Use `git-triage` to evaluate issues and PRs by completion evidence and CI state |
 
 ## Context
 

--- a/git-plugin/skills/git-maintain/SKILL.md
+++ b/git-plugin/skills/git-maintain/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-16
-modified: 2026-04-19
-reviewed: 2026-01-16
+modified: 2026-04-25
+reviewed: 2026-04-25
 allowed-tools: Bash(git status *), Bash(git branch *), Bash(git stash *), Bash(git prune *), Bash(git gc *), Bash(git repack *), Bash(git fsck *), Bash(git rm *), Bash(du *), Read, Glob, TodoWrite
 args: "[--prune] [--gc] [--verify] [--branches] [--stash] [--all]"
 argument-hint: [--prune] [--gc] [--verify] [--branches] [--stash] [--all]
@@ -13,6 +13,15 @@ description: |
   stashes, verify repo integrity with git fsck, or shrink the .git directory.
 name: git-maintain
 ---
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative when... |
+|---|---|
+| Running `git gc`, repacking objects, or shrinking the `.git` directory | Use `git-coworker-check` first if other agents may be writing to the same checkout |
+| Pruning merged local branches and old stashes | Use `git-cli-agentic` for read-only branch/stash queries without mutating state |
+| Verifying repo integrity with `git fsck` | Use `git-security-checks` for secret scanning rather than object integrity |
+| Cleaning up a checkout before a long-lived feature branch goes stale | Use `git-rebase-patterns` to clean up commit history rather than the object store |
 
 ## Context
 

--- a/git-plugin/skills/git-pr/skill.md
+++ b/git-plugin/skills/git-pr/skill.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-01-21
-modified: 2026-03-04
-reviewed: 2026-03-04
+modified: 2026-04-25
+reviewed: 2026-04-25
 name: git-pr
 description: |
   Create pull requests with proper descriptions, labels, and issue references. Handles
@@ -16,13 +16,14 @@ allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git b
 
 Create pull requests with comprehensive descriptions and proper issue linkage.
 
-## When to Use
+## When to Use This Skill
 
-| Use this skill when... | Use X instead when... |
-|------------------------|----------------------|
-| Creating a new PR | Just crafting a title (`github-pr-title`) |
-| Full PR workflow | Just pushing (`git-push`) |
-| Submit for review | Just committing (`git-commit`) |
+| Use this skill when... | Use the alternative when... |
+|---|---|
+| Opening a PR from a pushed branch with description, labels, and issue refs | Use `github-pr-title` if you only need to author or fix the conventional title |
+| Selecting a base branch, draft mode, or reviewers as part of PR creation | Use `git-push` first if the branch has not been pushed to remote yet |
+| Going from a pushed branch to an open pull request | Use `git-commit` first if there are uncommitted changes locally |
+| Inserting `Fixes #N` / `Closes #N` issue references into the PR body | Use `git-commit-push-pr` for the consolidated commit + push + PR macro |
 
 ## PR Description Format
 

--- a/git-plugin/skills/git-push/skill.md
+++ b/git-plugin/skills/git-push/skill.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-01-21
-modified: 2026-02-18
-reviewed: 2026-01-23
+modified: 2026-04-25
+reviewed: 2026-04-25
 name: git-push
 description: |
   Push local commits to remote repositories. Handles branch tracking, upstream setup,
@@ -13,6 +13,15 @@ allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git p
 ---
 
 # Git Push
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative when... |
+|---|---|
+| Pushing existing local commits to a remote with branch tracking and upstream setup | Use `git-commit` first when there are uncommitted changes to push |
+| Sending changes to remote without opening a PR yet | Use `git-pr` afterwards to open a pull request from the pushed branch |
+| Migrating commits from local main to a remote feature branch via explicit refspec | Use `git-branch-pr-workflow` to design the broader main-branch-dev pattern |
+| Updating a remote branch with new commits after a rebase or amend | Use `git-commit-push-pr` for the consolidated commit + push + PR macro |
 
 Push local commits to remote repositories with proper branch tracking.
 

--- a/git-plugin/skills/git-repo-detection/SKILL.md
+++ b/git-plugin/skills/git-repo-detection/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-16
-modified: 2025-12-16
-reviewed: 2025-12-16
+modified: 2026-04-25
+reviewed: 2026-04-25
 name: git-repo-detection
 description: Detect GitHub repository name and owner from git remotes. Use when needing repo identifier for GitHub CLI, API calls, or when working with multiple repositories. Automatically extracts owner/repo format.
 user-invocable: false
@@ -9,6 +9,15 @@ allowed-tools: Bash, Read, Grep
 ---
 
 # Git Repository Detection
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative when... |
+|---|---|
+| Extracting `owner/repo` from a git remote (HTTPS or SSH URL) for `gh` calls | Use `gh-cli-agentic` once you already have the `owner/repo` identifier |
+| Handling GitHub Enterprise host URLs alongside github.com | Use `git-fork-workflow` when the question is fork vs upstream identification |
+| Resolving the repo identifier to pass with `gh -R` to avoid remote-required errors | Use `git-cli-agentic` for raw `git remote -v` parsing if you need URL details |
+| Detecting which repo a script is running inside before issuing API calls | Use `git-coworker-check` to detect concurrent agents in the same checkout |
 
 Expert knowledge for detecting and extracting GitHub repository information from git remotes, including repository name, owner, and full identifiers.
 

--- a/git-plugin/skills/git-security-checks/SKILL.md
+++ b/git-plugin/skills/git-security-checks/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-16
-modified: 2026-02-16
-reviewed: 2026-02-16
+modified: 2026-04-25
+reviewed: 2026-04-25
 name: git-security-checks
 description: |
   Pre-commit security validation and secret detection. Runs gitleaks scan
@@ -14,6 +14,15 @@ allowed-tools: Bash, Read
 ---
 
 # Git Security Checks
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative when... |
+|---|---|
+| Running `gitleaks` to scan for secrets before committing | Use `git-commit-workflow` for general staging and commit-message conventions |
+| Configuring `.gitleaks.toml` allowlists and pre-commit integration | Use `git-maintain` for `git fsck` integrity checks rather than secret scanning |
+| Validating that no credentials leak into a PR | Use `git-fix-pr` when CI gitleaks scans fail and you need to fix them on branch |
+| Setting up pre-commit hooks for credential scanning | Use `release-please-protection` to detect manual edits to release-managed files |
 
 Expert guidance for pre-commit security validation and secret detection using gitleaks and pre-commit hooks.
 

--- a/git-plugin/skills/github-issue-autodetect/skill.md
+++ b/git-plugin/skills/github-issue-autodetect/skill.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-01-15
-modified: 2026-04-21
-reviewed: 2026-04-21
+modified: 2026-04-25
+reviewed: 2026-04-25
 name: github-issue-autodetect
 description: |
   Automatically detect GitHub issues that staged changes may fix or close.
@@ -13,6 +13,15 @@ allowed-tools: Bash, Read, Grep, Glob, mcp__github__list_issues, mcp__github__ge
 ---
 
 # GitHub Issue Auto-Detection
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative when... |
+|---|---|
+| Suggesting `Fixes #N` / `Closes #N` keywords from staged-diff content | Use `git-commit-workflow` for the broader commit message style |
+| Matching diff hunks against open issues by file path or label | Use `github-issue-writing` to author or restructure the issue body itself |
+| Inferring proper issue linkage before composing a commit message | Use `git-issue-hierarchy` for parent/child sub-issue and dependency links |
+| Adding closing keywords mechanically based on issue metadata | Use `git-commit-trailers` for trailer-style metadata (Co-authored-by, Release-As) |
 
 Expert guidance for automatically detecting GitHub issues that staged changes may fix or close, ensuring proper issue linkage in commit messages.
 

--- a/git-plugin/skills/github-issue-writing/skill.md
+++ b/git-plugin/skills/github-issue-writing/skill.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-01-30
-modified: 2026-04-21
-reviewed: 2026-04-21
+modified: 2026-04-25
+reviewed: 2026-04-25
 name: github-issue-writing
 description: |
   Create well-structured GitHub issues with clear titles, descriptions, and
@@ -15,13 +15,14 @@ allowed-tools: Bash(gh issue *), Bash(gh label *), Bash(gh repo *), Read, Grep, 
 
 Create well-structured, actionable GitHub issues.
 
-## When to Use
+## When to Use This Skill
 
-| Use this skill when... | Use X instead when... |
-|------------------------|----------------------|
-| Creating new issues | Processing existing issues (`git:issue`) |
-| Writing bug reports | Auto-detecting issues (`github-issue-autodetect`) |
-| Filing feature requests | Creating PRs (`git-pr`) |
+| Use this skill when... | Use the alternative when... |
+|---|---|
+| Filing a new bug, feature, or chore issue with clear title and acceptance criteria | Use `git-issue` to start working on existing issues end-to-end |
+| Structuring an issue body with reproduction steps, scope, and definition of done | Use `github-issue-autodetect` to link existing issues from staged diffs |
+| Choosing the `[Type] Component: Description` title format | Use `github-pr-title` to author the conventional title for the PR that fixes it |
+| Designing a feature-request issue before implementation begins | Use `git-issue-manage` for transfer/pin/lock/develop-branch admin operations |
 
 ## Issue Title Format
 

--- a/git-plugin/skills/github-pr-title/skill.md
+++ b/git-plugin/skills/github-pr-title/skill.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-01-30
-modified: 2026-03-04
-reviewed: 2026-03-04
+modified: 2026-04-25
+reviewed: 2026-04-25
 name: github-pr-title
 description: |
   Craft PR titles using conventional commits format. Use when creating PRs or
@@ -17,13 +17,14 @@ Craft clear PR titles using conventional commits format.
 
 **CRITICAL:** PR titles must follow conventional commit format. This drives release-please version automation and ensures consistent git history when using squash-and-merge.
 
-## When to Use
+## When to Use This Skill
 
-| Use this skill when... | Use X instead when... |
-|------------------------|----------------------|
-| Creating a PR title | Full PR workflow (`git-pr`) |
-| Reviewing title format | Issue titles (`github-issue-writing`) |
-| Updating existing PR title | Fixing committed messages (see `git-commit`) |
+| Use this skill when... | Use the alternative when... |
+|---|---|
+| Authoring a `type(scope): subject` PR title that drives release-please automation | Use `git-pr` for the full PR creation workflow (body, labels, reviewers) |
+| Renaming an existing PR title to fix release-please version-bump detection | Use `git-commit-workflow` to set the same conventions on commit messages |
+| Selecting the right `feat`, `fix`, `perf`, `refactor`, `chore` type for a PR | Use `github-issue-writing` for issue titles (different `[Type] Component:` format) |
+| Validating PR title format before merge to maintain clean git history | Use `git-commit` to fix already-committed message formats locally |
 
 ## Format
 

--- a/git-plugin/skills/release-please-configuration/SKILL.md
+++ b/git-plugin/skills/release-please-configuration/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-28
-modified: 2025-12-28
-reviewed: 2025-12-28
+modified: 2026-04-25
+reviewed: 2026-04-25
 name: release-please-configuration
 description: |
   Configures release-please for monorepos and single-package repos. Handles
@@ -13,6 +13,15 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob, TodoWrite
 ---
 
 # Release-Please Configuration
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative when... |
+|---|---|
+| Setting up `release-please-config.json` and `.release-please-manifest.json` | Use `release-please-pr-workflow` to actually merge release-please PRs |
+| Configuring component tagging, changelog sections, or `extra-files` for a package | Use `release-please-protection` to detect manual edits to managed files |
+| Adding a new package to a monorepo's release-please config | Use `git-commit-trailers` for `Release-As:` trailer-based version overrides |
+| Fixing release-please workflow issues (missing component, no version bump) | Use `git-commit-workflow` to ensure commits use the conventional types release-please reads |
 
 Expert knowledge for configuring Google's release-please for automated releases.
 

--- a/git-plugin/skills/release-please-pr-workflow/skill.md
+++ b/git-plugin/skills/release-please-pr-workflow/skill.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-01-09
-modified: 2026-01-09
-reviewed: 2026-01-09
+modified: 2026-04-25
+reviewed: 2026-04-25
 name: release-please-pr-workflow
 description: |
   Manages release-please PR merging workflow for monorepos. Handles batch merging,
@@ -13,6 +13,15 @@ allowed-tools: Bash, Read, TodoWrite
 ---
 
 # Release-Please PR Workflow
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative when... |
+|---|---|
+| Iteratively merging multiple release-please PRs in a monorepo | Use `release-please-configuration` to fix the upstream config that produced them |
+| Resolving conflicts between sibling release PRs by closure/recreation | Use `git-resolve-conflicts` for ordinary feature-PR merge conflicts |
+| Coordinating sequential merges when `separate-pull-requests: true` | Use `git-fix-pr` if individual release PRs have failing CI checks |
+| Reducing the open release PR queue after a burst of releasable commits | Use `release-please-protection` to detect manual edits to changelog/version files |
 
 Expert knowledge for managing release-please PRs in monorepos, including batch merging, conflict handling, and iterative processing.
 

--- a/git-plugin/skills/release-please-protection/SKILL.md
+++ b/git-plugin/skills/release-please-protection/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-16
-modified: 2026-02-06
-reviewed: 2025-12-16
+modified: 2026-04-25
+reviewed: 2026-04-25
 name: release-please-protection
 description: |
   Detects and prevents manual edits to release-please managed files (CHANGELOG.md,
@@ -13,6 +13,15 @@ allowed-tools: Read, Grep, Glob
 ---
 
 # Release-Please Protection
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative when... |
+|---|---|
+| Detecting manual edits to `CHANGELOG.md`, `package.json` version fields, etc. | Use `release-please-configuration` to set up the manifest in the first place |
+| Warning before a manual changelog or version bump conflicts with release-please | Use `release-please-pr-workflow` once release PRs already exist and need merging |
+| Suggesting conventional-commit alternatives instead of editing managed files | Use `git-commit-trailers` for `Release-As:` / `BREAKING CHANGE:` overrides |
+| Protecting release-managed files during refactors and bulk edits | Use `git-security-checks` for credential leaks rather than version-file mutations |
 
 Automatically detects and prevents manual edits to release-please managed files across all projects.
 


### PR DESCRIPTION
## Summary

Adds the canonical \`## When to Use This Skill\` decision table to every git-plugin skill that was missing it (22 skills). Each table contrasts the skill against 3-4 real sibling skills in the plugin so Claude can pick the right one at load time rather than scanning the whole skill body.

Format follows \`.claude/rules/skill-quality.md\` lines 27-38.

## Skills updated (22)

\`gh-cli-agentic\`, \`gh-workflow-monitoring\`, \`git-branch-pr-workflow\`, \`git-cli-agentic\`, \`git-commit\`, \`git-commit-trailers\`, \`git-commit-workflow\`, \`git-derive-docs\`, \`git-fix-pr\`, \`git-issue-hierarchy\`, \`git-issue-manage\`, \`git-maintain\`, \`git-pr\`, \`git-push\`, \`git-repo-detection\`, \`git-security-checks\`, \`github-issue-autodetect\`, \`github-issue-writing\`, \`github-pr-title\`, \`release-please-configuration\`, \`release-please-pr-workflow\`, \`release-please-protection\`.

\`git-pr\`, \`github-issue-writing\`, and \`github-pr-title\` had thin \`## When to Use\` tables already; those were rewritten under the canonical heading with sibling-specific rows.

\`modified\` and \`reviewed\` dates bumped to 2026-04-25.

## Test plan

- [x] \`find git-plugin/skills \( -name SKILL.md -o -name skill.md \) -exec grep -L '^## When to Use This Skill' {} \;\` returns empty
- [x] Pre-commit hooks pass (shellcheck, gitleaks, lint-context-commands, audit-skill-descriptions)
- [x] Each table's right column references real sibling skill names from \`git-plugin/skills/\`
- [ ] Reviewer spot-checks that contrast rows actually distinguish the skills

Refs #1156