### PR TITLE
feat(blueprint-plugin): add story-audit and story-reconcile skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,6 +230,7 @@ This repo runs `blueprint-plugin` against itself in a deliberately constrained m
 | Task | Status | Why |
 |------|--------|-----|
 | `adr-validate`, `sync-ids`, `feature-tracker-sync` | enabled | Read-leaning workflows that genuinely add value across 16 ADRs / 2 PRDs / 5 PRPs |
+| `story-audit`, `story-reconcile` | enabled | `story-audit` is read-only and writes only its own dated artifact under `docs/blueprint/audits/`. `story-reconcile` mutates PRDs only and confirms each edit interactively. |
 | `derive-prd`, `derive-plans`, `derive-rules`, `generate-rules`, `claude-md`, `curate-docs` | disabled | Would treat plugin source as project requirements or could overwrite the 18 hand-written rules / hand-curated `CLAUDE.md` |
 
 **Always run `/blueprint:sync-ids` with `--dry-run` first.** Each disabled task carries a `context.disabled_reason` in the manifest — read it before flipping any flag back on.

--- a/blueprint-plugin/.claude-plugin/plugin.json
+++ b/blueprint-plugin/.claude-plugin/plugin.json
@@ -47,6 +47,10 @@
     "test-gaps",
     "monorepo",
     "workspaces",
-    "portfolio-tracking"
+    "portfolio-tracking",
+    "story-audit",
+    "coverage-gap",
+    "drift-detection",
+    "prd-reconciliation"
   ]
 }

--- a/blueprint-plugin/README.md
+++ b/blueprint-plugin/README.md
@@ -46,6 +46,8 @@ PRD (Product Requirements) → PRP (Product Requirement Prompt) → Work-Order �
 | `prp-create` | Create a PRP with systematic research and validation gates |
 | `prp-execute` | Execute a PRP with validation loop, TDD workflow, and quality gates |
 | `prp-curate-docs` | Curate documentation for ai_docs to optimize AI context |
+| `blueprint-story-audit` | Read-only audit fusing capability map ↔ PRD stories ↔ tests into a tier-ranked gap report. Writes `docs/blueprint/audits/<date>-story-audit.md` |
+| `blueprint-story-reconcile` | PRD-only reconciliation pass against the latest story-audit. Adds `⚠️`/`❌`/`🆕` markers and a wholesale `## Known Drift` section; confirms each PRD interactively |
 
 ### Listing Skills
 

--- a/blueprint-plugin/docs/flow.md
+++ b/blueprint-plugin/docs/flow.md
@@ -30,6 +30,17 @@ flowchart TD
 
     RUN --> TRACK[feature-tracking<br/>blueprint-feature-tracker-sync<br/>blueprint-feature-tracker-status]
 
+    subgraph AUDIT["Story-audit loop (closes intent <-> reality gap)"]
+        direction TB
+        SA[blueprint-story-audit<br/>capability map x stories x tests<br/>writes docs/blueprint/audits/]
+        SR[blueprint-story-reconcile<br/>marks PRDs with drift status<br/>+ Known Drift section]
+    end
+
+    TRACK -.->|periodic| SA
+    SA -.->|drift report| SR
+    SR -.->|updated PRD| PRD
+    SA -.->|Tier-1 gap rows| WO
+
     subgraph META["Cross-cutting management"]
         direction TB
         SID[blueprint-sync-ids<br/>assign IDs,<br/>traceability registry]
@@ -65,8 +76,8 @@ flowchart TD
     classDef prompt fill:#dda0dd,stroke:#8b5a8b,color:#000
 
     class EX router
-    class DP,DA,DPL,DR,DT,LIST,VA,VP,CR check
-    class INIT,PRD,ADR,PRP,WO,RUN,TRACK,SID,SYNC,PROM,UPG fix
+    class DP,DA,DPL,DR,DT,LIST,VA,VP,CR,SA check
+    class INIT,PRD,ADR,PRP,WO,RUN,TRACK,SID,SYNC,PROM,UPG,SR fix
 ```
 
 ## Legend
@@ -98,3 +109,4 @@ Dotted arrows are optional side-paths and cross-cutting concerns.
 | Cross-cutting: listing/status | `blueprint-docs-list`, `blueprint-adr-list`, `blueprint-status` |
 | Cross-cutting: migration | `blueprint-upgrade`, `blueprint-migration`, `blueprint-workspace-scan` |
 | Validation | `validate-prp-frontmatter.sh`, `validate-adr-frontmatter.sh`, `check-prp-readiness.sh` |
+| Story-audit loop | `blueprint-story-audit` (read-only audit), `blueprint-story-reconcile` (PRD-only mutate) |

--- a/blueprint-plugin/skills/blueprint-story-audit/REFERENCE.md
+++ b/blueprint-plugin/skills/blueprint-story-audit/REFERENCE.md
@@ -1,0 +1,205 @@
+# /blueprint:story-audit Reference
+
+Detailed templates, heuristics, and edge-case behaviour for `/blueprint:story-audit`.
+
+## Audit Template
+
+The audit artifact is a single markdown file under `docs/blueprint/audits/<YYYY-MM-DD>-story-audit.md`. Use this skeleton verbatim — adjust counts, scope, and timestamps; do not invent additional sections.
+
+```markdown
+# Story Audit — <YYYY-MM-DD>
+
+**Scope**: <full repo | --scope <area>>
+**PRDs read**: <list of PRD paths>
+**Tier cutoff**: <which capability `kind` values were treated as "core">
+**Manifest run**: docs/blueprint/manifest.json#task_registry.story-audit
+
+## 1. Summary
+
+- Capabilities mapped: **<N>**
+- Explicit stories (from PRD): **<N>**
+- Candidate stories (code-only): **<N>**
+- Drift entries: **<N>** (✅ <a> / ⚠️ <b> / ❌ <c> / 🆕 <d>)
+- Stories with zero tests: **<N>**
+- Tier-1 gaps: **<N>**
+- Bugs surfaced by audit: **<N>**
+
+> Headline: <one sentence the team should walk away with>
+
+## 2. Capability Map
+
+### <Area>
+
+| Capability | Entry point | Kind | Notes |
+|------------|-------------|------|-------|
+| <name> | `<file:line>` | route\|cli\|event\|component\|cron\|worker | <edge cases or "—"> |
+
+(Repeat per area. Cap rows per area at ~15; collapse the long tail to `+ N more`.)
+
+## 3. Story Inventory
+
+### Explicit (from PRD)
+
+| ID | PRD | Story | Linked deps |
+|----|-----|-------|-------------|
+| FR-1.1 | PRD-001 | <verbatim> | <if PRD names dependencies> |
+
+### Candidate (code-only — awaiting promotion)
+
+| Capability | Entry point | Why this looks like a story |
+|------------|-------------|-----------------------------|
+| <name> | `<file:line>` | <route/event-handler/component evidence> |
+
+> Candidates are **not** PRD entries. Promote via `/blueprint:story-reconcile`.
+
+## 4. Drift Report
+
+| Status | PRD ref | Capability | Evidence |
+|--------|---------|------------|----------|
+| ✅ implemented | FR-1.1 | <name> | `<file:line>` |
+| ⚠️ partial | FR-1.2 | <name> | <what's missing> |
+| ❌ missing | FR-2.3 | <name> | "tesseract listed in package.json but never imported" |
+| 🆕 candidate | — | <name> | `<file:line>` (no matching PRD entry) |
+
+Group by status; sort within group by area.
+
+## 5. Coverage Matrix
+
+| Story | Linked tests | Test count | Skipped/todo | Confidence |
+|-------|--------------|------------|--------------|------------|
+| FR-1.1 | tests/auth/login.test.ts | 12 | 0 | ✓ |
+| FR-2.1 | (none) | 0 | 0 | ✗ |
+| FR-3.4 | tests/integration/checkout.test.ts | 4 | 1 | ~ |
+
+Confidence column legend: `✓` explicit story-id reference, `~` keyword/path overlap only, `✗` no match.
+
+## 6. Tiered Gap Analysis
+
+### Tier 1 — Critical untested
+
+> Core capabilities (state machines, auth, payment paths, event handlers) with **zero** matching tests.
+
+- [ ] FR-2.1: <story> — `<entry-point file:line>`
+- [ ] …
+
+### Tier 2 — Partial coverage
+
+> Core capabilities with only `~`-confidence matches (likely unit-only, no integration).
+
+- [ ] FR-3.4: <story> — `<entry-point>`
+
+### Tier 3 — Declared drift
+
+> ❌ PRD entries with no implementation.
+
+- [ ] FR-2.3: <story> — declared dependency: `tesseract` (never imported)
+
+### Tier 4 — Implicit candidates
+
+> 🆕 Code-only features awaiting story promotion.
+
+- [ ] <capability> — `<entry-point>`
+
+### Tier 5 — Healthy (reference)
+
+> Stories with `✅` + `✓` test confidence. Use these as the model for new tests.
+
+- FR-1.1, FR-1.2, …
+
+## 7. Bugs Surfaced by Audit
+
+(Omit this section entirely if no bugs were surfaced.)
+
+| Source | Evidence | Description |
+|--------|----------|-------------|
+| `tests/image/detect.test.ts:42` (test.todo) | "detector returns full frame for every input" | Image detector never actually segments — every call returns one region equal to the whole frame. |
+| `client/store.ts:88` (xit) | "ignores photos:detected event" | Store handler missing for three server-emitted events. |
+
+> File issues for any of these via `gh issue create` — the audit deliberately does **not** auto-file.
+```
+
+## Implicit-Story Heuristics by Stack
+
+When Agent 1 maps capabilities, use these patterns to decide whether a code construct is a candidate user story.
+
+### TypeScript / JavaScript
+
+| Construct | How to find it | Treat as story? |
+|-----------|---------------|-----------------|
+| Express/Fastify/Hono routes | `app.{get,post,put,patch,delete}(` | Yes — every route is a story candidate |
+| Next.js App Router | `app/**/page.tsx`, `app/**/route.ts` | Yes — pages are stories, route handlers are stories |
+| React components exported from `pages/` or `app/` | `export default function …Page` | Yes |
+| React components exported from `components/` | `export …` | Only if no parent page wraps them — internal components don't earn a story |
+| Socket.IO event handlers | `socket.on('<event>'` | Yes — each event name is a story |
+| BullMQ / Sidekiq workers | `new Worker(`, `Queue.add(` | Yes |
+| Cron entries | `cron.schedule(`, `node-cron` | Yes |
+| Middleware | `app.use(` | No — middleware isn't a story; surface as edge-case note on the route it guards |
+
+### Python
+
+| Construct | How to find it | Treat as story? |
+|-----------|---------------|-----------------|
+| FastAPI/Flask routes | `@app.{get,post,…}`, `@router.…` | Yes |
+| Django views | `class …View`, `def …(request, …)` in `views.py` | Yes |
+| Celery tasks | `@app.task`, `@celery.task` | Yes |
+| Click/Typer CLI commands | `@app.command()`, `@click.command()` | Yes |
+| Management commands | `BaseCommand` subclass | Yes |
+| Signal handlers | `@receiver(`, `connect(` | Sometimes — only when the signal is named in PRD vocabulary |
+
+### Go
+
+| Construct | How to find it | Treat as story? |
+|-----------|---------------|-----------------|
+| HTTP handlers | `http.HandleFunc`, `mux.Handle` | Yes |
+| gRPC services | `pb.Register…Server` | Yes — each method is a story |
+| Cobra CLI commands | `&cobra.Command{` | Yes |
+
+### Rust
+
+| Construct | How to find it | Treat as story? |
+|-----------|---------------|-----------------|
+| Axum/Actix routes | `Router::new().route(`, `web::resource(` | Yes |
+| Clap subcommands | `#[derive(Subcommand)]` | Yes |
+
+### Generic
+
+For any stack, also list:
+- **Public CLI entrypoints** declared in `package.json#bin`, `pyproject.toml#scripts`, `Cargo.toml#[[bin]]`, `go.mod` main packages
+- **Public API surface** declared in OpenAPI/protobuf/GraphQL schemas
+- **Top-level event types** declared in shared event schemas
+
+## Tier-Ranking Rationale
+
+The default tiering (1 = critical untested, 5 = healthy) is opinionated but tunable. Use these signals when deciding the cutoff between "core" and "non-core" capabilities:
+
+| Signal | "Core" weight |
+|--------|---------------|
+| Capability `kind` is `route` or `event-handler` | High |
+| Capability is named in a PRD with `priority: P0` / `must-have` | High |
+| Capability has more than one entry point (called from multiple places) | Medium |
+| Capability is a leaf component reachable from one parent only | Low |
+| Capability is a CLI subcommand reachable only via flag | Low |
+
+When in doubt, lean toward Tier 1. The cost of an over-eager tier-1 entry is a low-value test; the cost of a missed tier-1 entry is a real production bug.
+
+## Edge Cases
+
+| Situation | Behaviour |
+|-----------|-----------|
+| No PRD found | Emit Sections 1, 2, 3 (candidate-only), 5 (no story column), 6 (Tier 4 only). Note the missing input prominently. |
+| No tests found | Emit Sections 1–4 normally; Section 5 has every story at confidence `✗`; Tier 1 is the full core list. |
+| Multiple PRDs (monorepo / multi-feature) | Run Step 2 once per PRD; merge into one inventory; preserve PRD-id column. |
+| `--scope` matches no capabilities | Don't fail; emit an audit with empty Sections 2–6 and a note explaining the scope filter excluded everything. |
+| Audit file already exists for today | Append `-2`, `-3`, … to the filename. Never overwrite. |
+| Project uses no recognised test framework | Mark Section 5 entirely as `?`; note the missing convention. |
+
+## Why this artifact, not many
+
+ScanSift's pre-skill version produced a half-dozen sub-reports that each made sense individually but no one read in sequence. The forced single-artifact constraint — one file, top-to-bottom, every section — is what made it act-on-able. Resist the urge to split this into sub-files.
+
+## Related Skills
+
+- `/blueprint:story-reconcile` — promotes drift entries from this artifact back into the PRD (Phase 2)
+- `/blueprint:work-order` — packages a Tier-1 gap as an isolated subagent task (Phase 3)
+- `/blueprint:derive-tests` — git-history-based test backlog; complementary but operates on commits, not stories
+- `/blueprint:adr-validate` — orthogonal: validates ADR relationships, not story coverage

--- a/blueprint-plugin/skills/blueprint-story-audit/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-story-audit/SKILL.md
@@ -1,0 +1,209 @@
+---
+created: 2026-04-25
+modified: 2026-04-25
+reviewed: 2026-04-25
+description: |
+  Audit user stories against codebase capabilities and tests, producing a tier-ranked
+  coverage gap report. Use when the user asks to "audit stories", run a "story audit"
+  / "coverage audit" / "PRD reconciliation", surface PRD↔code drift, identify untested
+  critical paths, or find "implicit stories" that exist in code but never made it back
+  into the PRD. Read-only — writes a single audit artifact under docs/blueprint/audits/.
+args: "[--scope <area>] [--prd <path>] [--no-write] [--report-only]"
+argument-hint: "--scope auth to limit; --prd docs/prds/PRD-001.md to override; --no-write skips artifact"
+allowed-tools: Read, Write, Glob, Grep, Bash, Task, AskUserQuestion
+name: blueprint-story-audit
+---
+
+# /blueprint:story-audit
+
+Reconcile what the codebase actually does against what the PRD says it should do, then map every story to its tests and rank the gaps. Produces one durable artifact: `docs/blueprint/audits/<date>-story-audit.md`.
+
+**Usage**: `/blueprint:story-audit [--scope <area>] [--prd <path>] [--no-write] [--report-only]`
+
+## When to Use This Skill
+
+| Use this skill when... | Use alternative when... |
+|------------------------|-------------------------|
+| Auditing PRD↔code drift before a release or planning round | Drafting a brand-new PRD from scratch (`/blueprint:derive-prd`) |
+| Finding untested critical paths through the user-story lens | Mining commits for missing tests (`/blueprint:derive-tests`) |
+| Surfacing "implicit stories" — code-only features missing from PRD | Validating ADR relationships (`/blueprint:adr-validate`) |
+| Producing a single artifact the team can act on top-to-bottom | Listing existing blueprint docs (`/blueprint:docs-list`) |
+
+This skill is **read-only** apart from the audit artifact. PRD edits live in `/blueprint:story-reconcile`; agent dispatch for gap-fill work lives in `/blueprint:work-order`.
+
+## Context
+
+- Blueprint manifest: !`find docs/blueprint -maxdepth 1 -name 'manifest.json'`
+- PRD directory: !`find docs -maxdepth 1 -name 'prds' -type d`
+- PRD files: !`find docs/prds -maxdepth 1 -name '*.md'`
+- Audits directory: !`find docs/blueprint -maxdepth 1 -name 'audits' -type d`
+- Existing audits: !`find docs/blueprint/audits -maxdepth 1 -name '*.md'`
+- Test directories: !`find . -maxdepth 3 -type d \( -name tests -o -name __tests__ -o -name test -o -name spec \) -not -path '*/node_modules/*'`
+- Repo root: !`git rev-parse --show-toplevel`
+- Today: !`date -u +%Y-%m-%d`
+
+## Parameters
+
+Parse `$ARGUMENTS`:
+
+- `--scope <area>`: Limit discovery to a single capability area (e.g. `auth`, `image-detection`). Skips areas whose entry-point paths don't match the scope. Default: full repo.
+- `--prd <path>`: Override PRD auto-detection. Repeatable — pass multiple `--prd` flags for multi-PRD projects. Default: every `*.md` directly under `docs/prds/`.
+- `--no-write`: Print the audit to the conversation only; don't write to `docs/blueprint/audits/`.
+- `--report-only`: Skip the Step 8 "What next?" prompt. Useful when running this skill from another orchestrator.
+
+## Execution
+
+Execute this audit workflow. Each step is required unless its inputs are missing — in that case, note the missing input in the artifact and continue.
+
+### Step 1: Gather discovery inputs in parallel
+
+Spawn three Explore subagents via the Task tool **in parallel** (single message, three tool calls). Each agent returns a structured findings list with `file:line` evidence; do **not** ask any agent to write the audit itself.
+
+Agent 1 — **Capability map**:
+
+> Survey this codebase and list every user-facing capability. Group by area
+> (auth, billing, search, …). For each capability emit one row:
+> `<area> | <capability> | <entry-point file:line> | <kind>` where kind is
+> `route`, `cli`, `event-handler`, `component`, `cron`, or `worker`.
+> Flag dependencies that look declared-but-unused (imported library that
+> never has its main API called). Cap output at 200 rows; if a project is
+> larger, summarize tail areas as "+ N more in <area>". Read-only.
+
+Agent 2 — **Story extraction**:
+
+> Read every PRD under {PRD paths from --prd or auto-detected}. Emit one
+> row per stated user story or functional requirement:
+> `<PRD-id> | <story-id-or-section> | <verbatim user-visible behaviour>
+> | <linked deps if any>`. Also list any "Known Drift" or status-marked
+> entries verbatim. Don't infer — only extract. Read-only.
+
+Agent 3 — **Test inventory**:
+
+> List every test file under {test directories from Context}. For each
+> file emit: `<file> | <describe-or-suite> | <test-count> | <skipped-or-todo-count>`.
+> When a file has a top-level comment or describe block citing a story
+> ID (PRD-NNN, FR-N.N, story-name), include it. Read-only.
+
+Wait for all three to complete. If `--scope <area>` is set, filter Agent 1's rows to that area before moving on.
+
+### Step 2: Diff capabilities against stories
+
+Build the **drift report** by joining Agent 1's capability map against Agent 2's story inventory. For each capability:
+
+| Status | Meaning |
+|--------|---------|
+| ✅ implemented | Capability has a matching PRD story |
+| ⚠️ partial | PRD story exists but capability is missing significant sub-behaviour the story names |
+| ❌ missing | PRD story has no matching capability — feature declared but not built |
+| 🆕 candidate | Capability exists but no PRD story matches — implicit story |
+
+Match on substring overlap of capability name vs story title, then verify with a quick file-level read where ambiguous. **Do not promote candidates into the PRD here** — that is `/blueprint:story-reconcile`'s job.
+
+Also flag **declared-but-unused dependencies** from Agent 1's findings as `❌ missing` drift entries (e.g. "tesseract listed in package.json but never imported").
+
+### Step 3: Map stories to tests
+
+Build the **coverage matrix**: for every PRD story from Agent 2, find tests from Agent 3 that match by:
+
+1. Explicit story-id reference in test file/describe (highest confidence)
+2. File-path proximity (`auth/login.ts` → `auth/login.test.ts`)
+3. Keyword overlap in test description vs story title (lowest confidence, mark as `~`)
+
+Produce one row per story:
+
+```
+<story-id> | <linked tests> | <test-count> | <skipped/todo> | <confidence: ✓ / ~ / ✗>
+```
+
+Stories with **zero matched tests** become Tier-1 gap candidates.
+
+### Step 4: Tier-rank the gaps
+
+Apply this default ranking. Override per-row only if the user passed explicit guidance.
+
+| Tier | Combination | Examples |
+|------|-------------|----------|
+| 1 — **critical untested** | core capability × zero tests | state machines, auth, payment paths |
+| 2 — **partial coverage** | core capability × `~` confidence tests only | UI flows tested only at the unit level |
+| 3 — **declared drift** | `❌ missing` PRD story | OCR named in PRD, never implemented |
+| 4 — **implicit candidates** | `🆕 candidate` from Step 2 | code-only features awaiting story promotion |
+| 5 — **healthy** | `✅` with `✓` tests | reference for "what good looks like" |
+
+The tier cutoff between core and non-core is heuristic: Agent 1's `kind` field is the strongest signal (`route` and `event-handler` lean core; `component` leans non-core). Document the cutoff used at the top of the artifact so the user can override.
+
+### Step 5: Surface bugs the audit found
+
+If Agent 3 reported `test.todo` / `xit` / `skip` blocks with comments that read like bug reports (rather than "not yet implemented"), collect them into a **Bugs surfaced by audit** section with `file:line` + verbatim comment. Do **not** auto-file issues; the user decides.
+
+### Step 6: Compose the audit artifact
+
+Use the template at [REFERENCE.md#audit-template](REFERENCE.md#audit-template) and fill all six sections:
+
+1. **Summary** — counts and the headline number (e.g. "8 PRD requirements drift; 3 critical capability areas have zero tests")
+2. **Capability map** — Agent 1's output, grouped by area
+3. **Story inventory** — explicit (PRD) + candidate (code-only) lists
+4. **Drift report** — table with the four-status enum from Step 2
+5. **Coverage matrix** — story × tests with confidence column
+6. **Tiered gap analysis** — Tier 1 → 5 with one-line "why this matters" per tier
+7. **Bugs surfaced by audit** (only if Step 5 found any)
+
+Set the artifact path to `docs/blueprint/audits/<YYYY-MM-DD>-story-audit.md` using the `Today` value from Context. If a file with that name exists, append `-N` (e.g. `-2`).
+
+### Step 7: Write the artifact and update the manifest
+
+Skip this step if `--no-write` is set; print the artifact to the conversation instead.
+
+```bash
+mkdir -p docs/blueprint/audits
+# Write artifact via Write tool to the path computed in Step 6.
+```
+
+Update the task registry in `docs/blueprint/manifest.json`:
+
+```bash
+jq --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+   --arg result "${AUDIT_RESULT:-success}" \
+   --argjson stories "${STORY_COUNT:-0}" \
+   --argjson gaps "${TIER1_GAP_COUNT:-0}" \
+   '.task_registry["story-audit"].last_completed_at = $now |
+    .task_registry["story-audit"].last_result = $result |
+    .task_registry["story-audit"].stats.runs_total = ((.task_registry["story-audit"].stats.runs_total // 0) + 1) |
+    .task_registry["story-audit"].stats.items_processed = $stories |
+    .task_registry["story-audit"].stats.tier1_gaps = $gaps' \
+   docs/blueprint/manifest.json > docs/blueprint/manifest.json.tmp \
+   && mv docs/blueprint/manifest.json.tmp docs/blueprint/manifest.json
+```
+
+Where `AUDIT_RESULT` is `"success"`, `"{N} drift entries"`, or `"failed: {reason}"`.
+
+### Step 8: Offer next actions
+
+Skip this step if `--report-only` is set.
+
+Use AskUserQuestion to offer the three downstream paths the audit unlocks:
+
+- **Reconcile drift in the PRD** → run `/blueprint:story-reconcile` against this audit
+- **Dispatch a work-order for a Tier-1 gap** → run `/blueprint:work-order` per row
+- **I'll act on the artifact later** → exit; the artifact is the durable output
+
+Don't loop. The audit is the durable artifact; the user owns the next step.
+
+## Heuristics, templates, and edge cases
+
+For the implicit-story detection heuristics by stack (TypeScript/Python/Go), the audit-artifact template, the tier-ranking rationale, and how the skill behaves with no PRD or no tests, see [REFERENCE.md](REFERENCE.md).
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Count PRD files | `find docs/prds -maxdepth 1 -name '*.md'` |
+| Count test files (TS/JS) | `find . -type f \( -name '*.test.ts' -o -name '*.test.tsx' -o -name '*.spec.ts' \) -not -path '*/node_modules/*'` |
+| Count test files (Python) | `find . -type f -name 'test_*.py' -not -path '*/.venv/*'` |
+| Find skipped tests | `grep -rn -E "test\.(skip\|todo)\|xit\(\|@pytest.mark.skip" --include='*.test.*' --include='test_*.py'` |
+| Detect declared deps | `jq -r '.dependencies // {} \| keys[]' package.json` (or `grep '^[a-z].*=' pyproject.toml`) |
+| Check dep is imported | `grep -rln "from <pkg>\|import <pkg>\|require('<pkg>')" --include='*.ts' --include='*.py'` |
+| Audit filename | `echo "docs/blueprint/audits/$(date -u +%Y-%m-%d)-story-audit.md"` |
+
+---
+
+For the audit-artifact template, implicit-story heuristics by language, and tier-ranking rationale, see [REFERENCE.md](REFERENCE.md).

--- a/blueprint-plugin/skills/blueprint-story-reconcile/REFERENCE.md
+++ b/blueprint-plugin/skills/blueprint-story-reconcile/REFERENCE.md
@@ -1,0 +1,110 @@
+# /blueprint:story-reconcile Reference
+
+Detailed marker conventions, the canonical Known-Drift section format, and idempotency edge cases for `/blueprint:story-reconcile`.
+
+## Inline Status Markers
+
+The skill prepends one of these unicode markers to a requirement line. The marker is part of the line; the skill detects existing markers before inserting to stay idempotent.
+
+| Marker | Meaning | When applied |
+|--------|---------|--------------|
+| `✅ ` | implemented | **Never written by reconcile** — the audit reports `✅` informationally; reconcile leaves these lines alone |
+| `⚠️ ` | partial | Audit row status `⚠️ partial` |
+| `❌ ` | missing | Audit row status `❌ missing` |
+| `🆕 ` | candidate (promoted) | Audit row status `🆕 candidate` and the user accepted promotion in Step 5 |
+
+The marker goes **after** any leading list prefix (`- `, `* `, `1. `) and **before** the FR id:
+
+```diff
+- - FR-2.3 OCR support → server runs tesseract over uploads
++ - ❌ FR-2.3 OCR support → server runs tesseract over uploads (drift: dep declared but never imported)
+```
+
+## Known Drift Section — Canonical Format
+
+The section is **replaced wholesale** on every reconcile run. Match start with `^## Known Drift` and end at the next top-level `## ` heading or EOF.
+
+```markdown
+## Known Drift
+
+> Tracked by audit: `docs/blueprint/audits/<YYYY-MM-DD>-story-audit.md`
+> Last reconciled: <YYYY-MM-DD>
+
+| Status | Requirement | Evidence | Action |
+|--------|-------------|----------|--------|
+| ❌ | FR-2.3 OCR support | dep `tesseract` declared but never imported | open |
+| ⚠️ | FR-1.4 deskew on import | implemented but only for landscape orientation | WO-042 |
+| 🆕 | FR-3.7 image-detector tier-1 logging (promoted from audit 2026-04-25) | `server/detect.ts:88` | open |
+```
+
+Action column values:
+- `open` — no work-order linked yet
+- `WO-NNN` — linked work-order (looked up from `docs/blueprint/work-orders/` if a matching `implements: PRD-NNN` is found)
+- `wontfix` — only set by hand; reconcile does not write `wontfix`
+
+## Promoting Candidate Stories
+
+When the user accepts a `🆕` candidate in Step 5, append a new requirement to the end of the most-relevant FR section. Choose the section by:
+
+1. Match the candidate's area (from the audit's capability map) against existing FR section titles
+2. If no match, append to a new `## Drift Promotions` H2 at the end of the PRD (above any existing `## Known Drift`)
+
+The appended requirement uses this exact shape:
+
+```markdown
+- 🆕 FR-N.M (candidate, promoted from audit <YYYY-MM-DD>): <verbatim capability name>
+  Evidence: <entry-point file:line>
+  Status: not started
+```
+
+Choose `FR-N.M` by taking the highest existing FR index in the section and incrementing the trailing component. Never reuse a deleted index.
+
+## Idempotency Edge Cases
+
+| Scenario | Behaviour |
+|----------|-----------|
+| User re-runs reconcile with same audit | Inline markers already present → skip. Known Drift section already correct → no-op replace. Result: zero file mutations. |
+| User re-runs with a newer audit | Markers may flip (e.g. `❌ → ✅` because the gap was closed). The skill **removes** stale `❌`/`⚠️` markers when the new audit reports `✅` for the same FR. |
+| User edited the Known Drift table by hand | The wholesale replacement overwrites the user edits. Surface this in Step 5's diff so the user sees what they'd lose. |
+| Two audits exist for the same day (`-2` suffix) | `--audit` defaults pick the lexicographic last (`-2` > base name). Pass `--audit` explicitly to disambiguate. |
+| Audit references a PRD that no longer exists | Skip the row, report it in the summary as "PRD missing — drift not reconciled". |
+| Audit row's `prd_ref` is null but capability matches an existing FR | Use substring matching to locate the FR; if ambiguous (multiple matches), prompt the user to pick one. |
+
+## Marker-Removal Rules
+
+When a newer audit downgrades an entry's drift status to `✅`, reconcile **must** remove the stale marker rather than ignore it. Detection:
+
+```
+^(- |\* |[0-9]+\. )?(✅ |⚠️ |❌ |🆕 )(FR-[0-9.]+)
+```
+
+If `<FR>` appears as `✅` in the new audit but the line still carries `⚠️`/`❌`/`🆕`, strip the marker (and any "(drift: …)" trailing parenthetical) and leave the requirement clean.
+
+## What Counts as "PRD Drift" vs "Source Bug"
+
+The audit may surface entries that look like drift but are really code bugs (e.g. tesseract is imported but the OCR call is commented out). Reconcile treats both as `❌ missing` from the PRD's perspective — the line stays in the PRD as a roadmap entry. The bug filing happens through `gh issue create`, not through this skill.
+
+If the user wants to track the bug separately, the audit's "Bugs surfaced by audit" section is the place. Reconcile does not duplicate that into the PRD.
+
+## Commit Message Conventions
+
+Reconcile prints one of these shapes (see Step 8 in SKILL.md):
+
+```
+docs(prd-001): reconcile PRD with story-audit 2026-04-25
+
+Refs docs/blueprint/audits/2026-04-25-story-audit.md
+
+- Marked 8 drift entries (✅ 4 ⚠️ 2 ❌ 2)
+- Promoted 1 candidate story (FR-3.7)
+- Touched: docs/prds/PRD-001.md
+```
+
+The scope is the PRD id when one PRD is touched; omit the scope when multiple PRDs are touched. The PRP/work-order workflow's `feat()` / `fix()` scopes do not apply here — this is documentation only, hence `docs()`.
+
+## Related Skills
+
+- `/blueprint:story-audit` — produces the audit artifact this skill consumes
+- `/blueprint:work-order` — packages each `❌` entry as an isolated subagent task
+- `/blueprint:derive-prd` — used to bootstrap a PRD when no PRD covers a candidate story's area
+- `/blueprint:adr-validate` — orthogonal: ADR consistency, not story coverage

--- a/blueprint-plugin/skills/blueprint-story-reconcile/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-story-reconcile/SKILL.md
@@ -1,0 +1,220 @@
+---
+created: 2026-04-25
+modified: 2026-04-25
+reviewed: 2026-04-25
+description: |
+  Reconcile PRD requirements with the drift report from a /blueprint:story-audit. Use
+  when the user wants to mark PRD entries as ✅ implemented / ⚠️ partial / ❌ missing
+  based on the latest audit, add a "Known Drift" section to a PRD, or promote a candidate
+  (code-only) story into the PRD. Mutates PRD files only — never touches source code.
+args: "[--audit <path>] [--prd <path>] [--apply-all] [--dry-run]"
+argument-hint: "--audit docs/blueprint/audits/2026-04-25-story-audit.md (defaults to latest)"
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion
+name: blueprint-story-reconcile
+---
+
+# /blueprint:story-reconcile
+
+Apply the drift findings from `/blueprint:story-audit` back to the PRDs. Adds status markers, a `Known Drift` section, and (with consent) promotes candidate stories. Does **not** delete unimplemented requirements — they remain the roadmap.
+
+**Usage**: `/blueprint:story-reconcile [--audit <path>] [--prd <path>] [--apply-all] [--dry-run]`
+
+## When to Use This Skill
+
+| Use this skill when... | Use alternative when... |
+|------------------------|-------------------------|
+| Marking PRD requirements as implemented / partial / missing after an audit | Producing the audit itself (`/blueprint:story-audit`) |
+| Adding a "Known Drift" section to a PRD | Generating PRDs from scratch (`/blueprint:derive-prd`) |
+| Promoting a single candidate story into the PRD with user consent | Bulk-rewriting PRDs (this skill is deliberately conservative) |
+
+This skill **only edits PRDs**. Code changes belong to `/blueprint:work-order`. Audit re-runs belong to `/blueprint:story-audit`.
+
+## Context
+
+- Latest audit: !`find docs/blueprint/audits -maxdepth 1 -name '*-story-audit.md'`
+- PRD directory: !`find docs -maxdepth 1 -name 'prds' -type d`
+- PRD files: !`find docs/prds -maxdepth 1 -name '*.md'`
+- Manifest: !`find docs/blueprint -maxdepth 1 -name 'manifest.json'`
+- Branch: !`git branch --show-current`
+- Repo status: !`git status --porcelain=v2 --branch`
+
+## Parameters
+
+Parse `$ARGUMENTS`:
+
+- `--audit <path>`: Path to the audit artifact. Default: most-recent file matching `docs/blueprint/audits/*-story-audit.md` (sort lexically — date-stamped names sort correctly).
+- `--prd <path>`: Limit edits to a single PRD. Default: every PRD referenced by the audit's drift table.
+- `--apply-all`: Skip per-row prompts and apply every drift entry as an edit. Use only when the audit was reviewed elsewhere.
+- `--dry-run`: Show the planned edits as unified diffs without writing.
+
+## Execution
+
+Execute this PRD-reconciliation workflow.
+
+### Step 1: Locate the audit artifact
+
+1. If `--audit <path>` provided, read that file.
+2. Otherwise, list `docs/blueprint/audits/*-story-audit.md`, pick the lexicographically last one (date-stamped names sort correctly).
+3. If none found → abort with: "No audit artifact found. Run `/blueprint:story-audit` first."
+
+### Step 2: Parse the drift report
+
+Read the audit's **Drift Report** section (Section 4 in the canonical template). Extract every row into a structured list:
+
+```
+{ status: ✅|⚠️|❌|🆕, prd_ref: <id-or-null>, capability: <name>, evidence: <text> }
+```
+
+Skip `✅ implemented` rows — they're informational; reconcile only adds value for `⚠️`, `❌`, and `🆕`.
+
+If the audit also has a **Story Inventory → Candidate** section, merge those rows into the `🆕` group with their `entry-point` evidence.
+
+### Step 3: Group edits by PRD
+
+For each non-`✅` drift entry, determine the target PRD:
+
+| Status | Target PRD |
+|--------|-----------|
+| ⚠️ partial / ❌ missing | The PRD whose `prd_ref` matches the entry (e.g. `FR-2.3` → `docs/prds/PRD-002.md`) |
+| 🆕 candidate | Ask the user which PRD to promote into; if no PRD covers the area, suggest creating a stub via `/blueprint:derive-prd` |
+
+If `--prd <path>` is set, drop entries whose target PRD doesn't match.
+
+### Step 4: Plan edits per PRD
+
+For each target PRD, plan two kinds of edit:
+
+**A. Inline status markers** for `⚠️` and `❌` entries — locate the line containing the requirement (search by `prd_ref` or substring of `capability`) and prepend the marker to the requirement line:
+
+```
+- FR-2.3 OCR support → server runs tesseract over uploads
+```
+
+becomes
+
+```
+- ❌ FR-2.3 OCR support → server runs tesseract over uploads (drift: dep declared but never imported)
+```
+
+**B. A "Known Drift" appendix** at the bottom of the PRD, in this exact format (idempotent — replace the section if it already exists):
+
+```markdown
+## Known Drift
+
+> Tracked by audit: `docs/blueprint/audits/<YYYY-MM-DD>-story-audit.md`
+
+| Status | Requirement | Evidence | Action |
+|--------|-------------|----------|--------|
+| ❌ | FR-2.3 OCR support | dep `tesseract` declared but never imported | <work-order id or "open"> |
+| ⚠️ | FR-1.4 deskew on import | implemented but only for landscape orientation | open |
+```
+
+For `🆕` candidate entries (Step 3 mapped them to a PRD): append a new requirement row at the end of the relevant FR section, with explicit text:
+
+```
+- FR-N.M (candidate, promoted from audit <YYYY-MM-DD>): <verbatim capability name>
+  Evidence: <entry-point file:line>
+```
+
+Do **not** renumber existing FRs — append at the end.
+
+### Step 5: Confirm before writing
+
+Skip this step when `--apply-all` is set.
+
+For each PRD, show the planned edits as a unified diff and ask via AskUserQuestion:
+
+- **Apply all edits to this PRD** — proceed
+- **Apply some edits** — show each row individually for accept/skip
+- **Skip this PRD** — no edits land
+- **Cancel reconcile entirely** — exit with no changes
+
+If `--dry-run` is set, print the diffs and exit without prompting.
+
+### Step 6: Apply edits
+
+For each accepted edit, use the Edit tool to modify the PRD. Keep edits **idempotent**: re-running this skill against the same audit + same PRD must produce no further changes (the inline marker is already there; the Known Drift table already reflects the same rows).
+
+After all PRD edits land:
+
+```bash
+git status --porcelain=v2 docs/prds/
+```
+
+If any non-PRD file shows up as modified → abort and report. This skill must only touch PRDs.
+
+### Step 7: Update the manifest
+
+Update the task registry entry:
+
+```bash
+jq --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+   --arg result "${RECONCILE_RESULT:-success}" \
+   --argjson edits "${EDITS_APPLIED:-0}" \
+   --argjson prds "${PRDS_TOUCHED:-0}" \
+   '.task_registry["story-reconcile"].last_completed_at = $now |
+    .task_registry["story-reconcile"].last_result = $result |
+    .task_registry["story-reconcile"].stats.runs_total = ((.task_registry["story-reconcile"].stats.runs_total // 0) + 1) |
+    .task_registry["story-reconcile"].stats.items_processed = $edits |
+    .task_registry["story-reconcile"].stats.prds_touched = $prds' \
+   docs/blueprint/manifest.json > docs/blueprint/manifest.json.tmp \
+   && mv docs/blueprint/manifest.json.tmp docs/blueprint/manifest.json
+```
+
+### Step 8: Suggest the commit
+
+Print the suggested commit message but **do not commit automatically** — the user owns the commit boundary:
+
+```
+docs(<scope>): reconcile PRD with story-audit <YYYY-MM-DD>
+
+Refs docs/blueprint/audits/<YYYY-MM-DD>-story-audit.md
+
+- Marked <N> drift entries (✅ <a> ⚠️ <b> ❌ <c>)
+- Promoted <N> candidate stories
+- Touched: <list of PRD paths>
+```
+
+Choose `<scope>` as the PRD prefix shared by edits (e.g. `prd-001`) or omit if multiple PRDs were touched.
+
+### Step 9: Hand off the next action
+
+Use AskUserQuestion to surface the obvious follow-on:
+
+- **Open work-orders for ❌ entries** → invoke `/blueprint:work-order` per Tier-3 row
+- **Re-run the audit to confirm green** → invoke `/blueprint:story-audit`
+- **I'm done** → exit
+
+## What this skill deliberately does NOT do
+
+| Off-limits | Why |
+|------------|-----|
+| Edit source code | Code changes go through `/blueprint:work-order` so the change has a TDD packet behind it |
+| Delete unimplemented requirements | They are the roadmap. `❌` is a tracked status, not a delete signal. |
+| Auto-create GitHub issues for drift | Audit + reconcile are local artifacts; issue filing is an explicit user action |
+| Renumber FRs to "tidy up" | FR numbers are referenced from tests, commits, and other PRDs — renumbering is an unsafe, non-idempotent edit |
+| Commit changes | Commit boundaries are the user's decision; this skill prints the suggested message and stops |
+
+## Idempotency
+
+Re-running this skill against the same audit + same PRDs must be a no-op. The two mechanisms:
+
+1. Inline status markers (`⚠️ `, `❌ `, `🆕 `) are detected before insertion. If the requirement line already starts with the right marker, skip.
+2. The `## Known Drift` section is **replaced wholesale** by the new content, never appended.
+
+If a re-run produces changes, that is a bug — file it.
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Find latest audit | `find docs/blueprint/audits -maxdepth 1 -name '*-story-audit.md'` |
+| Show audit drift section | `awk '/^## 4\. Drift Report/,/^## 5\. /' <audit-path>` |
+| Detect existing Known Drift | `grep -c '^## Known Drift' docs/prds/*.md` |
+| Locate FR by id | `grep -n 'FR-2\.3' docs/prds/*.md` |
+| Count PRD files | `find docs/prds -maxdepth 1 -name '*.md'` |
+| Verify only-PRDs touched | `git status --porcelain=v2 docs/prds/` |
+
+---
+
+For drift-marker conventions, the full Known-Drift section format, and idempotency edge cases, see [REFERENCE.md](REFERENCE.md).

--- a/docs/blueprint/README.md
+++ b/docs/blueprint/README.md
@@ -21,6 +21,8 @@ See `manifest.json#task_registry` (each disabled task carries a `context.disable
 | `adr-validate` | ✓ | Detects orphans, broken `supersedes` chains, and missing domain tags across 16 ADRs |
 | `sync-ids` | ✓ | Reconciles document ID frontmatter; **always run with `--dry-run` first** |
 | `feature-tracker-sync` | ✓ | Read-leaning sync against `TODO.md` (no tracker enabled yet) |
+| `story-audit` | ✓ | Read-only audit: capability map ↔ PRD stories ↔ tests, tier-ranked. Writes one dated artifact under `docs/blueprint/audits/` |
+| `story-reconcile` | ✓ | Phase 2 of story-audit. Mutates PRDs only (idempotent inline markers + wholesale `## Known Drift` section); confirms each PRD before writing |
 | `derive-prd` | ✗ | Would invent PRDs from plugin-feature commits |
 | `derive-plans` | ✗ | Conflicts with hand-authored `docs/plans/` |
 | `derive-rules` | ✗ | Could overwrite the 18 hand-written rules |
@@ -37,6 +39,7 @@ docs/blueprint/
 ├── work-orders/         # Gitignored; per-task scratch
 │   ├── completed/
 │   └── archived/
+├── audits/              # Dated story-audit artifacts (one file per run)
 └── ai_docs/             # On-demand curated docs (curate-docs is disabled)
     ├── libraries/
     └── project/

--- a/docs/blueprint/manifest.json
+++ b/docs/blueprint/manifest.json
@@ -119,6 +119,28 @@
       "schedule": "on-demand",
       "stats": {},
       "context": {}
+    },
+    "story-audit": {
+      "enabled": true,
+      "auto_run": false,
+      "last_completed_at": null,
+      "last_result": null,
+      "schedule": "on-demand",
+      "stats": {},
+      "context": {
+        "rationale": "Read-only Phase 1: maps codebase capabilities, extracts PRD stories, and produces a single tier-ranked audit artifact under docs/blueprint/audits/. Fits the read-leaning green-list. Mutates only its own dated artifact."
+      }
+    },
+    "story-reconcile": {
+      "enabled": true,
+      "auto_run": false,
+      "last_completed_at": null,
+      "last_result": null,
+      "schedule": "on-demand",
+      "stats": {},
+      "context": {
+        "rationale": "Phase 2 of the story-audit workflow. Mutates PRD files only (never code), with idempotent inline markers and a wholesale-replaced Known Drift section. Confirms each PRD's edits via AskUserQuestion before writing."
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Two new blueprint skills that fuse capability mapping, PRD-story extraction, and test inventory into a single tier-ranked audit artifact, then reconcile the drift back into PRDs:

- **`/blueprint:story-audit`** — read-only. Spawns three parallel Explore subagents (capability map / story extraction / test inventory), joins their findings into a drift report (✅ / ⚠️ / ❌ / 🆕), builds a story × test coverage matrix, ranks gaps Tier 1–5, and writes one dated artifact under `docs/blueprint/audits/<YYYY-MM-DD>-story-audit.md`. Surfaces bugs hiding in `test.todo` / `xit` / `skip` blocks without auto-filing issues.
- **`/blueprint:story-reconcile`** — PRD-only mutator. Consumes the latest audit, applies **idempotent** inline drift markers and a wholesale-replaced `## Known Drift` section, optionally promotes 🆕 candidate stories with explicit user consent, and prints a suggested `docs()` commit message without committing automatically.

Phase-3 gap-fill dispatch deliberately reuses the existing `/blueprint:work-order` skill — no new orchestrator. The audit's Tier-1 rows are the work-order queue.

## Why these together

Story extraction alone is nothing new; drift detection alone is a doc-ops chore; coverage analysis alone produces a list nobody acts on. Fused through the user-story lens, they produce **one artifact** the team can read top-to-bottom and act on. Origin: a ScanSift session went 126 → 280 tests with 12 `test.todo` entries each documenting a real bug, plus 8 PRD requirements caught as silent drift (OCR, SQLite, deskew, pairing tolerance, archival paths, …).

## Files touched

- `blueprint-plugin/skills/blueprint-story-audit/{SKILL,REFERENCE}.md` (new)
- `blueprint-plugin/skills/blueprint-story-reconcile/{SKILL,REFERENCE}.md` (new)
- `blueprint-plugin/{README.md,docs/flow.md,.claude-plugin/plugin.json}` — Workflow Skills table, "Story-audit loop" subgraph, keywords
- `docs/blueprint/manifest.json` — `task_registry` entries for both, both `enabled: true, schedule: on-demand`
- `docs/blueprint/README.md`, top-level `CLAUDE.md` — green-list both tasks for this repo's dogfood with rationale

## Constrained-dogfood posture

`story-audit` is read-only and only writes its own dated artifact under `docs/blueprint/audits/`, so it fits the same green-list as `adr-validate` / `sync-ids` / `feature-tracker-sync`. `story-reconcile` mutates only PRD files (never code, never the manifest beyond its task-registry stats) and confirms each PRD's edits via `AskUserQuestion`, so it's safe to run against the repo's hand-authored PRDs.

## Test plan

- [ ] Run `/blueprint:story-audit --no-write` against this repo and verify the audit renders Sections 1–6 even with no formal PRD-story mappings yet
- [ ] Run `/blueprint:story-audit` for real and confirm the dated artifact lands under `docs/blueprint/audits/`, `manifest.json#task_registry.story-audit.stats` updates, and re-running the same day produces a `-2`-suffixed file
- [ ] Run `/blueprint:story-reconcile --dry-run` against the audit and verify the planned PRD diffs are sensible (no source-code edits, only `docs/prds/`)
- [ ] Run `/blueprint:story-reconcile` non-dry-run, then re-run — second run should be a no-op (idempotent markers + wholesale Known-Drift replacement)
- [ ] `bash scripts/lint-context-commands.sh blueprint-plugin/skills/blueprint-story-audit/ blueprint-plugin/skills/blueprint-story-reconcile/` (clean ✓)
- [ ] `bash scripts/plugin-compliance-check.sh blueprint-plugin` (passes all columns ✓)

## Open follow-ups (not in this PR)

- The dispatch primitive (worktree + cherry-pick + draft PR) lives inside `/blueprint:work-order`. Hardening that workflow for batch dispatch from a Tier-1 list is a separate change.
- Auto-filing GitHub issues from the audit's "Bugs surfaced by audit" section is deliberately out of scope — surface, don't auto-file.

https://claude.ai/code/session_01HjLFjiqBXgUAj9C9rho1vc

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjLFjiqBXgUAj9C9rho1vc)_