### PR TITLE
fix(skills): convert When to Use sections to required table format

### DIFF
--- a/agent-patterns-plugin/skills/parallel-agent-dispatch/SKILL.md
+++ b/agent-patterns-plugin/skills/parallel-agent-dispatch/SKILL.md
@@ -26,15 +26,12 @@ manual salvage from orphan branches.
 
 ## When to Use This Skill
 
-Activate whenever the orchestrator is about to spawn **>1 agent in parallel**:
-
-- Plain `Agent` tool fan-out (N concurrent invocations in one message)
-- `TeamCreate` + teammate spawn via `agent-teams`
-- Worktree-isolated parallel implementation across multiple repos or features
-- Parallel investigation / audit swarms
-
-Single-agent delegation does not need this contract — `agent-teams`'
-out-of-scope protocol is sufficient for one-off subagents.
+| Use this skill when... | Use `agent-teams` instead when... |
+|---|---|
+| Spawning >1 agent via plain `Agent` tool fan-out (N concurrent invocations) | Single-agent delegation or one-off subagent spawn |
+| Using `TeamCreate` + teammate spawn for coordinated parallel work | A simple background task with no parallel siblings |
+| Running worktree-isolated parallel implementation across repos/features | A read-only inline subagent that does not write to disk |
+| Coordinating parallel investigation or audit swarms | The work fits in the current session without forking |
 
 ## The Three Pillars
 

--- a/blueprint-plugin/skills/confidence-scoring/SKILL.md
+++ b/blueprint-plugin/skills/confidence-scoring/SKILL.md
@@ -14,12 +14,11 @@ This skill provides systematic evaluation of PRPs (Product Requirement Prompts) 
 
 ## When to Use This Skill
 
-Activate this skill when:
-- Creating a new PRP (`/prp:create`)
-- Generating a work-order (`/blueprint:work-order`)
-- Deciding whether to execute or refine a PRP
-- Evaluating whether a task is ready for subagent delegation
-- Reviewing PRPs/work-orders for quality
+| Use this skill when... | Use `blueprint-prp-create` instead when... |
+|---|---|
+| Scoring a draft PRP/work-order before execution or delegation | Authoring the PRP itself from research and context |
+| Deciding whether a work-order is ready for a subagent or needs refinement | Producing the work-order content (use `blueprint-work-order`) |
+| Reviewing existing PRPs/work-orders for context completeness and validation gates | Generating the PRD that the PRP derives from (use `blueprint-derive-prd`) |
 
 ## Scoring Dimensions
 

--- a/github-actions-plugin/skills/github-social-preview/skill.md
+++ b/github-actions-plugin/skills/github-social-preview/skill.md
@@ -219,17 +219,12 @@ magick social-preview.png -quality 85 preview.jpg
 
 ## When to Use This Skill
 
-**✓ Use for:**
-- Creating new repository social preview images
-- Refreshing outdated preview images
-- Generating project thumbnails for documentation
-- Creating Open Graph images for GitHub Pages
-
-**✗ Don't use for:**
-- General image generation (use nano-banana-pro directly)
-- Complex illustrations or detailed artwork
-- Images requiring pixel-perfect layouts
-- Animated GIF previews (use video editing tools)
+| Use this skill when... | Use other skills instead when... |
+|---|---|
+| Creating or refreshing a repository's social preview image | Generating arbitrary images from a text prompt — use `nano-banana-pro` directly |
+| Producing project thumbnails for documentation | Resizing or optimizing an existing image — use `imagemagick-conversion` |
+| Generating Open Graph images for GitHub Pages | Producing complex illustrations or pixel-perfect layouts (use a dedicated design tool) |
+| You want repo metadata (name, language, description) auto-fed into the prompt | Producing animated GIF previews (use video editing tools) |
 
 ## Related Skills
 

--- a/tools-plugin/skills/imagemagick-conversion/SKILL.md
+++ b/tools-plugin/skills/imagemagick-conversion/SKILL.md
@@ -297,19 +297,12 @@ magick test-image.jpg -resize 50% test-output.jpg
 
 ## When to Use This Skill
 
-**✓ Use this skill for:**
-- Format conversions between standard image types
-- Resizing operations (dimensions, percentages)
-- Quality adjustments and compression
-- Batch processing workflows
-- Generating thumbnails or previews
-- Basic transformations (rotate, crop, flip)
-
-**✗ Don't use this skill for:**
-- Advanced photo editing (use GIMP, Photoshop)
-- Complex filters or effects (consider dedicated tools)
-- Video processing (use FFmpeg)
-- Vector graphics (use Inkscape, Illustrator)
+| Use this skill when... | Use other skills instead when... |
+|---|---|
+| Converting an image between standard formats (PNG/JPG/WebP/AVIF/GIF/HEIC) | Producing a brand-new image from a text prompt — use `generate-image` |
+| Resizing, compressing, or adjusting quality of an existing image | Generating a repository social preview — use `github-actions-plugin:github-social-preview` |
+| Running batch processing or thumbnail generation across many files | Advanced photo editing or complex filters (use GIMP, Photoshop, or dedicated tools) |
+| Performing basic transformations (rotate, crop, flip) at scale | Video processing (use FFmpeg) or vector graphics (use Inkscape) |
 
 ## Integration with Workflows
 


### PR DESCRIPTION
## Summary

Track C lint enforcement (PR #1191) introduces a stricter compliance check that requires every `SKILL.md` to have both the `## When to Use This Skill` heading **and** a markdown table within 10 lines. Four pre-existing skills used bullet lists or `✓ / ✗` markers instead of the prescribed 2-column format — these need conversion before #1191 can land without breaking CI on main.

## Files

- `agent-patterns-plugin/skills/parallel-agent-dispatch/SKILL.md`
- `blueprint-plugin/skills/confidence-scoring/SKILL.md`
- `github-actions-plugin/skills/github-social-preview/skill.md`
- `tools-plugin/skills/imagemagick-conversion/SKILL.md`

Each violator now uses the 2-column `Use this skill when... | Use <real-sibling> instead when...` format with real sibling references, matching the rule in `.claude/rules/skill-quality.md` lines 27-38.

Refs #1156

## Test plan

- [x] All 4 files now have a table (`^|`) within 10 lines of `^## When to Use This Skill$`
- [x] No content removed — bullet items converted into table rows verbatim or with light editing for parallelism
- [x] Pre-commit hooks pass (gitleaks, lint-context-commands, configure-repo, audit-skill-descriptions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)