### PR TITLE
fix(git-repo-agent): port two-phase onboard interaction (ADR-008)

### DIFF
--- a/git-repo-agent/docs/adr/008-onboard-two-phase-interaction.md
+++ b/git-repo-agent/docs/adr/008-onboard-two-phase-interaction.md
@@ -1,0 +1,173 @@
+# ADR-008: Two-Phase Interaction for the Onboard Workflow
+
+- **Status:** Accepted
+- **Date:** 2026-04-25
+- **Deciders:** @laurigates
+
+## Context
+
+The `git-repo-agent onboard` command runs the blueprint state-machine driver
+(ADR-006) followed by an LLM orchestrator under `ClaudeAgentOptions` (SDK
+subprocess transport). Until this ADR, the orchestrator prompt
+(`onboard.md`) instructed the model to "present the plan to the user via
+`AskUserQuestion`" before making changes.
+
+ADR-003 already established that `AskUserQuestion` does not work in SDK
+subprocess mode: the CLI's stdin/stdout carry the SDK JSON protocol, the
+tool has no terminal to render to, and the call fails silently. ADR-003
+ported the maintain workflow to a two-phase pattern (analysis →
+`console.input()` → execution) but onboard kept the single-session flow.
+
+### The failure
+
+In production, the symptom for onboard mirrored the original maintain
+bug:
+
+1. `BlueprintDriver` runs to completion and writes `docs/blueprint/`,
+   ADRs, rules, etc. into the worktree.
+2. Orchestrator phase prints tool calls culminating in two
+   `AskUserQuestion` calls.
+3. Session ends with `Onboarding complete.` and no commits.
+4. Pre-fix, `cleanup_worktree --force` then destroyed the blueprint
+   driver's uncommitted output.
+
+The data-loss part was mitigated by the `auto_commit_if_dirty()` /
+uncommitted-aware `worktree_has_changes()` work captured in
+`agent-cli-worktree-safety.md`. The interaction failure — the user
+never seeing the plan they were promised — remained.
+
+## Decision
+
+**Apply the ADR-003 two-phase pattern to `onboard`.** Reuse the
+`_stream_interactive` plumbing from maintain by parameterising the
+phase-2 prompt builder and the user-input label, so the same Python
+runner serves both workflows.
+
+### Implementation
+
+Three coordinated changes:
+
+**`orchestrator.py`** — generalise `_stream_interactive`:
+
+```python
+async def _stream_interactive(
+    prompt, options, completion_msg,
+    user_input_label,                    # caller-supplied prompt copy
+    build_phase2_prompt,                 # callable(text, selection, branch) -> str
+    worktree_branch=None,
+    none_message="No actions selected.",
+):
+    ...
+```
+
+`run_onboard` routes interactive (non-dry-run, non-non-interactive) runs
+through `_stream_interactive` with `_build_onboard_phase2_prompt`. The
+Phase 2 prompt embeds the planning-phase plan verbatim plus the user's
+selection. `_phase2_system_prompt` (already maintain-tested) appends the
+"Phase 2 Override (execution)" block to the system prompt to negate the
+"stop after presenting plan" anchor from `onboard.md`.
+
+`AskUserQuestion` is removed from the base `allowed_tools` list for
+onboard — it never works in subprocess mode for any onboard mode, so
+making accidental use fail loudly is preferable to silent no-op.
+
+**`onboard.md`** — Operating Modes section + Step 2 update:
+
+- New "Operating Modes" table mirroring maintain.md (planning,
+  execution, direct, dry-run).
+- Step 2 now produces a numbered plan (`1. [claude-md] …`, etc.) and
+  ends the response in interactive planning mode.
+- Step 4 now expects a fresh user prompt with the plan + selection
+  embedded, mirroring the maintain Step 4 contract.
+- `INTERACTIVE_MODE` env var documented.
+
+**`run_onboard`** — adds `INTERACTIVE_MODE` env var, removes
+`AskUserQuestion` from `allowed_tools`, branches to `_stream_interactive`
+when `non_interactive is None and not dry_run`.
+
+### User input contract
+
+The Phase 1 → user → Phase 2 selection grammar matches maintain:
+
+| Input | Meaning |
+|-------|---------|
+| `all` / `yes` / `y` | Apply every numbered step in the plan |
+| `1,3,5` (comma-separated digits) | Apply only those steps |
+| `none` / `no` / `n` / empty | Skip all execution; emit a brief "no changes" summary |
+
+## Alternatives Considered
+
+### 1. Add a callback for `AskUserQuestion`
+
+- **Rejected:** `claude-agent-sdk` 0.1.39 has no programmatic callback
+  for tool prompts. Re-evaluate if upstream adds one.
+
+### 2. Pre-collect via CLI flags (e.g. `--apply=1,3,5`)
+
+- **Rejected:** Users need to see the plan derived from the live
+  repository state before selecting. A flag-driven interface forces a
+  two-step CLI workflow for what the two-phase pattern handles
+  in-session.
+
+### 3. Always auto-execute and rely on PR review
+
+- **Rejected:** Onboarding can land high-impact changes (CI workflows,
+  pre-commit hooks, README). The auto-fix mode is appropriate for
+  scheduled non-interactive runs but not as the only behaviour for an
+  interactive command. Users want a plan-review checkpoint.
+
+### 4. Reuse a single `ClaudeSDKClient` across phases
+
+- **Rejected:** ADR-003 Revision 2026-04-12 documented why this fails
+  for maintain — the Phase 1 "stop after presenting" anchor in the
+  system prompt dominates the Phase 2 follow-up message, and the agent
+  wraps up with no tool calls. Two separate sessions with a Phase 2
+  Override block is the only pattern that has held in production.
+
+## Consequences
+
+### Positive
+
+- Users see the onboarding plan and can approve / reject / select before
+  changes land.
+- `AskUserQuestion` in `allowed_tools` no longer hides silent failures
+  for onboard.
+- One generalised `_stream_interactive` serves both onboard and maintain;
+  any future workflow that needs the same shape only writes a
+  `_build_<workflow>_phase2_prompt`.
+
+### Negative
+
+- Two `ClaudeSDKClient` sessions per interactive onboard run (two
+  `ResultMessage`s, two cost entries).
+- The agent must reliably output the numbered plan in the documented
+  format for the user prompt to make sense. Drift in `onboard.md` Step 2
+  can break Phase 2's plan parsing (mitigated: Phase 2 embeds the
+  Phase 1 text verbatim, so the agent rather than Python interprets the
+  plan).
+
+### Neutral
+
+- `INTERACTIVE_MODE` env var joins `DRY_RUN`, `SKIP_CI`, `SKIP_BLUEPRINT`
+  and `ONBOARD_BRANCH` as a workflow-mode signal.
+- Dry-run interactive runs continue to use single-phase
+  `_stream_messages` since they make no changes — there is nothing for
+  the user to approve.
+
+## Relationship to ADR-003
+
+ADR-003 introduced the two-phase pattern for maintain. ADR-008 extends
+it to onboard and refactors the helpers so the pattern is reusable
+without copy-paste. The "Phase 2 Override" override block, the
+two-separate-sessions decision, and the `_phase2_system_prompt` /
+`_build_*_phase2_prompt` split all originated in ADR-003.
+
+## Re-evaluation Triggers
+
+- If `claude-agent-sdk` adds a programmatic callback for
+  `AskUserQuestion`.
+- If a third workflow needs the same pattern — at that point promote
+  the per-workflow Phase 2 builder protocol into a `Protocol` /
+  dataclass instead of three loose callables.
+- If the onboarding plan format diverges so far from maintain's
+  numbered findings that the shared Phase 2 plumbing stops fitting.

--- a/git-repo-agent/src/git_repo_agent/orchestrator.py
+++ b/git-repo-agent/src/git_repo_agent/orchestrator.py
@@ -4,6 +4,7 @@ import json
 import logging
 import signal
 import sys
+from collections.abc import Callable
 from datetime import date, datetime, timezone
 from pathlib import Path
 
@@ -380,6 +381,11 @@ async def run_onboard(
             )
         )
 
+    # Interactive onboard uses the two-phase pattern (ADR-008): plan in
+    # Phase 1, Python prompts the user, execute in Phase 2. Dry-run and
+    # non-interactive runs use single-phase streaming.
+    interactive = non_interactive is None and not dry_run
+
     try:
         # Phase 0: run the blueprint state machine before handing off to the
         # LLM orchestrator. See ADR-006. Each phase is a single compiled
@@ -415,12 +421,13 @@ async def run_onboard(
             + repo_context
         )
 
+        # AskUserQuestion no-ops in SDK subprocess mode (ADR-003/008); the
+        # interactive onboard path uses the two-phase pattern via
+        # _stream_interactive instead. Removing it from allowed_tools makes
+        # accidental use fail loudly rather than silently.
         allowed_tools = [
-            "Read", "Write", "Edit", "Bash", "Glob", "Grep", "Task",
-            "AskUserQuestion", "TodoWrite",
+            "Read", "Write", "Edit", "Bash", "Glob", "Grep", "Task", "TodoWrite",
         ]
-        if non_interactive is not None:
-            allowed_tools = _non_interactive_allowed_tools(allowed_tools)
 
         # Build orchestrator options
         options = ClaudeAgentOptions(
@@ -444,6 +451,7 @@ async def run_onboard(
                 "SKIP_CI": str(skip_ci),
                 "SKIP_BLUEPRINT": str(blueprint_already_done),
                 "ONBOARD_BRANCH": branch,
+                "INTERACTIVE_MODE": str(interactive),
             },
             stderr=lambda line: console.print(f"[dim red]STDERR: {line}[/dim red]"),
         )
@@ -451,10 +459,23 @@ async def run_onboard(
         # Build the prompt — agent should commit but NOT create branches
         prompt_parts = [
             f"Onboard the repository at {work_dir}.",
-            "Repository analysis and health score are in your system prompt. Plan and execute the onboarding workflow.",
+            "Repository analysis and health score are in your system prompt.",
             f"You are working in a git worktree on branch '{branch}'.",
             "Commit your changes directly to this branch. Do NOT create new branches.",
         ]
+        if interactive:
+            prompt_parts.append(
+                "INTERACTIVE_MODE is True. Plan the onboarding by following "
+                "Steps 1 and 2: present a numbered plan of actions and end "
+                "your response. Do NOT execute changes in this phase. The "
+                "orchestrator will collect the user's selection and start a "
+                "new session for execution."
+            )
+        else:
+            prompt_parts.append(
+                "Plan and execute the onboarding workflow without stopping "
+                "for plan review."
+            )
         if dry_run:
             prompt_parts.append("DRY RUN — report what you would do without making changes.")
         if skip_ci:
@@ -468,11 +489,26 @@ async def run_onboard(
 
         prompt = " ".join(prompt_parts)
 
-        if non_interactive is not None:
+        if interactive:
+            agent_output = await _stream_interactive(
+                prompt,
+                options,
+                "Onboarding complete.",
+                user_input_label=(
+                    "[bold]Apply onboarding plan?[/bold] "
+                    "(comma-separated numbers, [green]all[/green], or "
+                    "[yellow]none[/yellow]): "
+                ),
+                build_phase2_prompt=_build_onboard_phase2_prompt,
+                worktree_branch=branch,
+                none_message="No onboarding actions selected.",
+            )
+        elif non_interactive is not None:
             agent_output = await _stream_messages_collecting(
                 prompt, options, "Onboarding complete.",
             )
         else:
+            # Dry-run interactive: agent reports without making changes.
             await _stream_messages(prompt, options, "Onboarding complete.")
             agent_output = ""
 
@@ -618,8 +654,17 @@ async def run_maintain(
 
         if interactive:
             collected = await _stream_interactive(
-                prompt, options, "Maintenance complete.",
+                prompt,
+                options,
+                "Maintenance complete.",
+                user_input_label=(
+                    "[bold]Select fixes to apply[/bold] "
+                    "(comma-separated numbers, [green]all[/green], or "
+                    "[yellow]none[/yellow]): "
+                ),
+                build_phase2_prompt=_build_maintain_phase2_prompt,
                 worktree_branch=branch,
+                none_message="No fixes selected.",
             )
         else:
             collected = await _stream_messages_collecting(
@@ -914,12 +959,15 @@ async def _stream_messages_collecting(
     return "\n".join(collected)
 
 
-def _build_phase2_prompt(
+_NONE_CHOICES = ("none", "n", "no", "")
+
+
+def _build_maintain_phase2_prompt(
     findings_text: str,
     user_selection: str,
     worktree_branch: str | None,
 ) -> str:
-    """Build the Phase 2 execution prompt.
+    """Build the Phase 2 execution prompt for the maintain workflow.
 
     Phase 2 is a fresh session, so we re-embed the findings list from
     Phase 1 and give explicit instructions to execute the selected fixes
@@ -928,7 +976,7 @@ def _build_phase2_prompt(
     agent to proceed with tool calls.
     """
     choice = user_selection.strip().lower()
-    if choice in ("none", "n", ""):
+    if choice in _NONE_CHOICES:
         selection_instruction = (
             "The user chose not to apply any fixes. "
             "Skip Step 4. Proceed directly to Step 5 (record health "
@@ -944,7 +992,7 @@ def _build_phase2_prompt(
         )
 
     worktree_note = ""
-    if worktree_branch and choice not in ("none", "n", ""):
+    if worktree_branch and choice not in _NONE_CHOICES:
         worktree_note = (
             f"\n\nYou are working in a git worktree on branch "
             f"'{worktree_branch}'. Commit your changes directly to this "
@@ -962,6 +1010,57 @@ def _build_phase2_prompt(
         f"{worktree_note}\n\n"
         "Do not ask the user any questions — they have already selected "
         "their fixes. Execute now."
+    )
+
+
+def _build_onboard_phase2_prompt(
+    plan_text: str,
+    user_selection: str,
+    worktree_branch: str | None,
+) -> str:
+    """Build the Phase 2 execution prompt for the onboard workflow.
+
+    Phase 2 is a fresh session, so we re-embed the plan from Phase 1 and
+    give explicit instructions to execute the selected onboarding steps
+    and commit to the worktree branch. The prompt does NOT inherit the
+    Phase 1 "stop after presenting plan" directive — it tells the agent
+    to proceed with tool calls.
+    """
+    choice = user_selection.strip().lower()
+    if choice in _NONE_CHOICES:
+        selection_instruction = (
+            "The user chose not to apply any onboarding actions. "
+            "Skip the configuration and documentation steps. Output a brief "
+            "summary noting that no changes were applied, then end."
+        )
+    else:
+        selection_instruction = (
+            f"The user approved the plan with selection: **{user_selection}** "
+            "(reference the numbered plan below; `all` or `yes` means apply "
+            "every step). Execute exactly those steps from the plan by "
+            "making real tool calls (Edit, Write, Bash, etc.), then commit "
+            "your changes and generate the onboarding report (Step 6)."
+        )
+
+    worktree_note = ""
+    if worktree_branch and choice not in _NONE_CHOICES:
+        worktree_note = (
+            f"\n\nYou are working in a git worktree on branch "
+            f"'{worktree_branch}'. Commit your changes directly to this "
+            "branch. Do NOT create new branches or push."
+        )
+
+    return (
+        "This is the execution phase of the onboard workflow. "
+        "An earlier planning phase produced the following numbered plan. "
+        "Your job is to act on it, not to re-plan.\n\n"
+        "## Plan from planning phase\n\n"
+        f"{plan_text}\n\n"
+        "## Your task\n\n"
+        f"{selection_instruction}"
+        f"{worktree_note}\n\n"
+        "Do not ask the user any questions — they have already approved "
+        "their selection. Execute now."
     )
 
 
@@ -987,25 +1086,31 @@ async def _stream_interactive(
     prompt: str,
     options: ClaudeAgentOptions,
     completion_msg: str,
+    user_input_label: str,
+    build_phase2_prompt: Callable[[str, str, str | None], str],
     worktree_branch: str | None = None,
+    none_message: str = "No actions selected.",
 ) -> str:
-    """Run a two-phase interactive maintain workflow.
+    """Run a two-phase interactive workflow (maintain or onboard).
 
-    Phase 1: Agent analyzes and presents numbered findings, then stops.
-    Interlude: Python prompts the user for their selections via rich.
-    Phase 2: A fresh agent session receives the Phase 1 findings plus the
-    user's selections, and executes the fixes.
+    Phase 1: Agent analyzes/plans and presents output, then stops.
+    Interlude: Python prompts the user for their selection via rich.
+    Phase 2: A fresh agent session receives the Phase 1 output plus the
+    user's selection and executes the chosen actions.
 
     Two separate ClaudeSDKClient sessions are used (rather than
     ``client.query()`` back-to-back on one client). Multi-turn on the same
-    client proved unreliable: the Phase 1 "stop after findings" anchor
-    from ``maintain.md`` caused Phase 2 to wrap up with no tool calls.
-    See ADR-003 (Revision 2026-04).
+    client proved unreliable: the Phase 1 "stop after presenting" anchor
+    in the workflow markdown caused Phase 2 to wrap up with no tool calls.
+    See ADR-003 (Revision 2026-04) and ADR-008.
+
+    The caller supplies ``build_phase2_prompt`` so that the same plumbing
+    serves both maintain (findings → fixes) and onboard (plan → setup).
 
     Returns concatenated agent text output from both phases for
     post-processing (PR body, issue creation).
     """
-    # --- Phase 1: Analysis ---
+    # --- Phase 1: Analysis/planning ---
     phase1_collected: list[str] = []
     async with ClaudeSDKClient(options) as client:
         await client.query(prompt)
@@ -1015,16 +1120,13 @@ async def _stream_interactive(
 
     # --- Interlude: prompt user ---
     console.print()
-    user_input = console.input(
-        "[bold]Select fixes to apply[/bold] "
-        "(comma-separated numbers, [green]all[/green], or [yellow]none[/yellow]): "
-    )
+    user_input = console.input(user_input_label)
     choice = user_input.strip().lower()
-    if choice in ("none", "n", ""):
-        console.print("[yellow]No fixes selected.[/yellow]")
+    if choice in _NONE_CHOICES:
+        console.print(f"[yellow]{none_message}[/yellow]")
 
     # --- Phase 2: Execution (fresh session) ---
-    phase2_prompt = _build_phase2_prompt(phase1_text, user_input, worktree_branch)
+    phase2_prompt = build_phase2_prompt(phase1_text, user_input, worktree_branch)
     phase2_options = replace(
         options,
         system_prompt=_phase2_system_prompt(options.system_prompt or ""),

--- a/git-repo-agent/src/git_repo_agent/prompts/onboard.md
+++ b/git-repo-agent/src/git_repo_agent/prompts/onboard.md
@@ -2,6 +2,23 @@
 
 Execute this 6-step onboarding workflow for the target repository.
 
+## Operating Modes
+
+The workflow has two phases driven by the orchestrator. Mode is signalled
+by the `INTERACTIVE_MODE` environment variable and the wording of the
+user prompt you receive:
+
+| Mode | Condition | Behavior |
+|------|-----------|----------|
+| **Interactive — planning phase** | `INTERACTIVE_MODE` = "True" AND no Phase 2 Override section in your system prompt | Steps 1–2: present a numbered plan and end your response. The orchestrator prompts the user, then opens a new session for execution. |
+| **Interactive — execution phase** | `INTERACTIVE_MODE` = "True" AND your system prompt includes a "Phase 2 Override (execution)" section | Receive the embedded plan + user selections in your user prompt; execute Steps 4–6. Do NOT re-plan. |
+| **Direct execution** | `INTERACTIVE_MODE` = "False" AND `DRY_RUN` = "False" | Run Steps 1–6 in a single session without stopping for plan review. |
+| **Dry run** | `DRY_RUN` = "True" | Report what would be done; make no changes. |
+
+`AskUserQuestion` is not in your tool list — it does not work in SDK
+subprocess mode (ADR-003/008). Do not attempt to call it; the orchestrator
+manages user interaction in Python.
+
 ## Step 1: Review Repository Analysis
 
 Review the pre-computed `repo_analyze` and `health_score` results in your system prompt.
@@ -33,10 +50,35 @@ Based on the analysis, determine what's needed:
 | CI/CD | `ci_system == "none"` | Create GitHub Actions workflows |
 | Pre-commit | `has_pre_commit == false` | Set up pre-commit hooks |
 
-Present the plan to the user via AskUserQuestion. Include:
-- What exists and will be preserved
-- What will be added
-- Estimated scope of changes
+Present the plan as a numbered list of actionable steps. For each step include:
+
+- **Number** (sequential, starting at 1)
+- **Component** in brackets: `[claude-md]`, `[readme]`, `[linter]`, `[formatter]`, `[tests]`, `[ci]`, `[pre-commit]`
+- **Description** of what will be added or configured
+
+Example output format:
+
+```
+1. [claude-md] Generate CLAUDE.md with project description, tech stack, and lint/test commands
+2. [readme] Generate README.md with quick-start guide
+3. [linter] Configure Ruff with default rules
+4. [formatter] Configure Ruff format
+5. [pre-commit] Set up pre-commit hooks for ruff and gitleaks
+```
+
+After the numbered plan, list what already exists and will be preserved
+(existing docs, configurations, CI workflows).
+
+**In the planning phase only: end your response after presenting the
+numbered plan.** Do NOT use `AskUserQuestion` (it is not in your tool
+list). The orchestrator will collect the user's selection in Python and
+start a new session for the execution phase with the plan and the
+selection embedded in its user prompt. This "stop after presenting plan"
+instruction does NOT apply when you see a "Phase 2 Override (execution)"
+section in your system prompt.
+
+In **direct execution mode** (`INTERACTIVE_MODE` = "False"), skip the
+planning stop and proceed directly to Step 4.
 
 ## Step 3: Blueprint Already Initialized
 
@@ -47,6 +89,14 @@ anomaly — the driver failed and should be investigated — but continue
 with remaining steps. Do not invoke any blueprint-related subagent.
 
 ## Step 4: Configure Standards
+
+In the **interactive execution phase** you will receive a **fresh user
+prompt** from the orchestrator containing (a) the full numbered plan
+from the planning phase and (b) the user's selection (e.g., `1,3,5`,
+`all`, or `none`). Treat the embedded plan as authoritative. Apply
+exactly the steps corresponding to the user's selection by making real
+tool calls (Edit, Write, Bash). Do NOT re-plan; do NOT present the plan
+again; do NOT ask the user anything.
 
 For each missing tool, configure it based on the detected language:
 
@@ -91,3 +141,4 @@ If in dry-run mode:
 - `SKIP_CI` — if "True", skip CI/CD setup
 - `SKIP_BLUEPRINT` — if "True", skip blueprint initialization
 - `ONBOARD_BRANCH` — branch name for changes (default: "setup/onboard")
+- `INTERACTIVE_MODE` — if "True", stop after Step 2 (planning); the orchestrator restarts a fresh session with user selections for Steps 4–6

--- a/git-repo-agent/tests/test_orchestrator_display.py
+++ b/git-repo-agent/tests/test_orchestrator_display.py
@@ -1,7 +1,8 @@
 """Tests for orchestrator display and PR content helpers."""
 
 from git_repo_agent.orchestrator import (
-    _build_phase2_prompt,
+    _build_maintain_phase2_prompt,
+    _build_onboard_phase2_prompt,
     _build_pr_content,
     _build_pr_title,
     _extract_fixed_items,
@@ -189,7 +190,7 @@ FINDINGS_FIXTURE = (
 )
 
 
-class TestBuildPhase2Prompt:
+class TestBuildMaintainPhase2Prompt:
     """Regression tests for the interactive-maintain Phase 2 bug.
 
     See ADR-003 Revision 2026-04-12 — Phase 2 used to silently skip tool
@@ -199,15 +200,21 @@ class TestBuildPhase2Prompt:
     """
 
     def test_embeds_findings_verbatim(self):
-        prompt = _build_phase2_prompt(FINDINGS_FIXTURE, "all", "maintain/2026-04-12")
+        prompt = _build_maintain_phase2_prompt(
+            FINDINGS_FIXTURE, "all", "maintain/2026-04-12"
+        )
         assert FINDINGS_FIXTURE in prompt
 
     def test_embeds_user_selection(self):
-        prompt = _build_phase2_prompt(FINDINGS_FIXTURE, "1,3", "maintain/2026-04-12")
+        prompt = _build_maintain_phase2_prompt(
+            FINDINGS_FIXTURE, "1,3", "maintain/2026-04-12"
+        )
         assert "1,3" in prompt
 
     def test_all_selection_instructs_execution(self):
-        prompt = _build_phase2_prompt(FINDINGS_FIXTURE, "all", "maintain/2026-04-12")
+        prompt = _build_maintain_phase2_prompt(
+            FINDINGS_FIXTURE, "all", "maintain/2026-04-12"
+        )
         # Agent must be told to make tool calls, not re-analyze or stop.
         assert "Apply exactly those fixes" in prompt
         assert "tool calls" in prompt
@@ -215,14 +222,14 @@ class TestBuildPhase2Prompt:
         assert "Do NOT create new branches" in prompt
 
     def test_none_selection_skips_fixes(self):
-        prompt = _build_phase2_prompt(FINDINGS_FIXTURE, "none", None)
+        prompt = _build_maintain_phase2_prompt(FINDINGS_FIXTURE, "none", None)
         assert "not to apply any fixes" in prompt
         assert "Skip Step 4" in prompt
         # No worktree note when nothing will be committed.
         assert "Do NOT create new branches" not in prompt
 
     def test_empty_selection_treated_as_none(self):
-        prompt = _build_phase2_prompt(FINDINGS_FIXTURE, "", None)
+        prompt = _build_maintain_phase2_prompt(FINDINGS_FIXTURE, "", None)
         assert "not to apply any fixes" in prompt
 
     def test_does_not_inherit_phase1_stop_anchor(self):
@@ -230,13 +237,97 @@ class TestBuildPhase2Prompt:
         # after presenting the numbered findings list". Phase 2 must not
         # repeat that instruction, or the agent will wrap up without
         # making any tool calls (the original bug).
-        prompt = _build_phase2_prompt(FINDINGS_FIXTURE, "all", "maintain/2026-04-12")
+        prompt = _build_maintain_phase2_prompt(
+            FINDINGS_FIXTURE, "all", "maintain/2026-04-12"
+        )
         assert "end your response after presenting" not in prompt.lower()
         # Explicit anti-instruction should be present instead.
         assert "Execute now" in prompt
 
     def test_all_forbids_asking_questions(self):
-        prompt = _build_phase2_prompt(FINDINGS_FIXTURE, "all", "maintain/2026-04-12")
+        prompt = _build_maintain_phase2_prompt(
+            FINDINGS_FIXTURE, "all", "maintain/2026-04-12"
+        )
+        assert "Do not ask the user any questions" in prompt
+
+
+PLAN_FIXTURE = (
+    "1. [claude-md] Generate CLAUDE.md with project description and lint commands\n"
+    "2. [readme] Generate README.md with quick-start guide\n"
+    "3. [linter] Configure Ruff with default rules\n"
+    "4. [pre-commit] Set up pre-commit hooks for ruff and gitleaks"
+)
+
+
+class TestBuildOnboardPhase2Prompt:
+    """Regression tests for issue #1120 — onboard ended silently when
+    `AskUserQuestion` no-ops in SDK subprocess mode. Phase 2 now embeds
+    the planning-phase plan and the user's selection in a fresh session.
+    See ADR-008.
+    """
+
+    def test_embeds_plan_verbatim(self):
+        prompt = _build_onboard_phase2_prompt(
+            PLAN_FIXTURE, "all", "setup/onboard"
+        )
+        assert PLAN_FIXTURE in prompt
+
+    def test_embeds_user_selection(self):
+        prompt = _build_onboard_phase2_prompt(
+            PLAN_FIXTURE, "1,3", "setup/onboard"
+        )
+        assert "1,3" in prompt
+
+    def test_all_selection_instructs_execution(self):
+        prompt = _build_onboard_phase2_prompt(
+            PLAN_FIXTURE, "all", "setup/onboard"
+        )
+        # Agent must be told to make tool calls, not re-plan or stop.
+        assert "Execute exactly those steps" in prompt
+        assert "tool calls" in prompt
+        assert "setup/onboard" in prompt
+        assert "Do NOT create new branches" in prompt
+
+    def test_yes_treated_as_apply(self):
+        prompt = _build_onboard_phase2_prompt(
+            PLAN_FIXTURE, "yes", "setup/onboard"
+        )
+        # "yes" is a non-none choice so it should route into the execute
+        # branch (worktree note included, no skip directive).
+        assert "Execute exactly those steps" in prompt
+        assert "Do NOT create new branches" in prompt
+
+    def test_none_selection_skips_actions(self):
+        prompt = _build_onboard_phase2_prompt(PLAN_FIXTURE, "none", None)
+        assert "not to apply any onboarding actions" in prompt
+        assert "no changes were applied" in prompt
+        # No worktree note when nothing will be committed.
+        assert "Do NOT create new branches" not in prompt
+
+    def test_empty_selection_treated_as_none(self):
+        prompt = _build_onboard_phase2_prompt(PLAN_FIXTURE, "", None)
+        assert "not to apply any onboarding actions" in prompt
+
+    def test_no_keyword_treated_as_none(self):
+        prompt = _build_onboard_phase2_prompt(PLAN_FIXTURE, "no", None)
+        assert "not to apply any onboarding actions" in prompt
+
+    def test_does_not_inherit_phase1_stop_anchor(self):
+        # The Phase 1 system prompt tells the agent to "end your response
+        # after presenting the numbered plan". Phase 2 must not repeat
+        # that, or the agent will wrap up without tool calls (issue
+        # #1120's original failure mode for onboard).
+        prompt = _build_onboard_phase2_prompt(
+            PLAN_FIXTURE, "all", "setup/onboard"
+        )
+        assert "end your response after presenting" not in prompt.lower()
+        # Explicit anti-instruction should be present instead.
+        assert "Execute now" in prompt
+
+    def test_all_forbids_asking_questions(self):
+        prompt = _build_onboard_phase2_prompt(
+            PLAN_FIXTURE, "all", "setup/onboard"
+        )
         assert "Do not ask the user any questions" in prompt
 
 


### PR DESCRIPTION
## Summary

- Onboard's interactive path called `AskUserQuestion` to present its plan, but that no-ops in SDK subprocess mode (the same bug ADR-003 fixed for maintain) — the orchestrator wrapped up without committing.
- Apply the maintain two-phase pattern to onboard by parameterising `_stream_interactive` and adding `_build_onboard_phase2_prompt`. Phase 1 presents a numbered plan and stops; Python collects the user's selection via `console.input()`; Phase 2 opens a fresh session with the plan + selection embedded and a "Phase 2 Override (execution)" block on the system prompt.
- Remove `AskUserQuestion` from onboard's `allowed_tools` entirely so accidental use fails loudly instead of silently.

## Files

- `git-repo-agent/src/git_repo_agent/orchestrator.py` — generalised `_stream_interactive`, renamed `_build_phase2_prompt` → `_build_maintain_phase2_prompt`, added `_build_onboard_phase2_prompt`, routed interactive `run_onboard` through `_stream_interactive`, added `INTERACTIVE_MODE` env var
- `git-repo-agent/src/git_repo_agent/prompts/onboard.md` — Operating Modes section; Step 2 now outputs a numbered plan and stops in interactive mode; Step 4 expects a fresh user prompt with the plan + selection embedded
- `git-repo-agent/docs/adr/008-onboard-two-phase-interaction.md` — new ADR documenting the onboard variant of the pattern
- `git-repo-agent/tests/test_orchestrator_display.py` — 9 new onboard phase-2 regression tests (plan embedding, all/none/empty/no/yes synonyms, no Phase 1 stop anchor, worktree note conditional); renamed maintain phase-2 tests

Closes #1120

## Test plan

- [x] `pytest` — all 177 git-repo-agent tests pass locally
- [x] `ruff check tests/test_orchestrator_display.py` clean
- [x] `ruff check src/git_repo_agent/orchestrator.py` — same 15 pre-existing E402/F401 errors as on main; no new lint introduced
- [ ] CI green
- [ ] Manual smoke: `git-repo-agent onboard <fresh-repo>` shows the numbered plan, prompts at the terminal, and commits after the user picks `all`