### PR TITLE
feat(project-plugin): document auto-mode policy for distill/feedback Step 4

### DIFF
--- a/feedback-plugin/skills/feedback-session/SKILL.md
+++ b/feedback-plugin/skills/feedback-session/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools: Bash(gh issue *), Bash(gh label *), Bash(gh search *), Bash(git s
 argument-hint: "--dry-run | --target-repo owner/repo | plugin-name"
 disable-model-invocation: true
 created: 2026-02-18
-modified: 2026-04-25
+modified: 2026-04-27
 reviewed: 2026-04-25
 ---
 
@@ -193,6 +193,8 @@ Format each finding as:
 Let the user select which findings to file as issues (use multiSelect).
 
 If `--dry-run`, present findings and stop here.
+
+**Auto mode does not skip this step.** Filing a GitHub issue is not reversible via `git restore` — closing an issue leaves noise in the issue tracker and notifies subscribers. Always confirm the selection set before Step 5, regardless of mode. To skip the prompt entirely, the user can pass `--dry-run` and re-run after reviewing.
 
 ### Step 5: Create approved issues
 

--- a/project-plugin/skills/project-distill/SKILL.md
+++ b/project-plugin/skills/project-distill/SKILL.md
@@ -14,7 +14,7 @@ allowed-tools: Bash(git diff *), Bash(git log *), Bash(git status *), Bash(just 
 argument-hint: "--rules | --skills | --recipes | --all | --dry-run"
 args: "[--rules] [--skills] [--recipes] [--all] [--dry-run]"
 created: 2026-02-11
-modified: 2026-04-25
+modified: 2026-04-27
 reviewed: 2026-02-26
 ---
 
@@ -82,7 +82,11 @@ Categorize as: `[UPDATE]`, `[SKIP]`, `[NEW]`, or `[REDUNDANT]` with file paths a
 
 ### Step 4: Apply changes
 
-If not `--dry-run`: use AskUserQuestion to confirm each category, then edit/create/remove.
+If `--dry-run`: skip this step.
+
+**In auto mode**: apply proposals directly without per-category `AskUserQuestion`. All targets are reversible via `git restore` — rule files, skill files, and justfile recipes are tracked in git, so a wrong edit can be undone with one command. This matches auto mode's "prefer action over planning" directive. **Retain `AskUserQuestion` for destructive operations** (`[REDUNDANT]` proposals that remove a rule or recipe).
+
+**In manual / interactive mode**: use `AskUserQuestion` to confirm each category before applying. The user can multi-select which `[UPDATE]` / `[NEW]` proposals to accept.
 
 ### Step 5: Report summary
 


### PR DESCRIPTION
## Summary

Resolves the auto-mode ambiguity flagged in #1119 for two related skills, with **opposite policies** that follow from the underlying reversibility of each skill's writes:

- **`/project:distill` Step 4** — In auto mode, apply `[UPDATE]` / `[NEW]` proposals directly without per-category `AskUserQuestion`. All targets (rule files, skill files, justfile recipes) are git-tracked, so `git restore` is the safety net. Confirmation is **retained** for destructive `[REDUNDANT]` proposals (removing a rule or recipe). Manual / interactive mode behaviour is unchanged.
- **`/feedback:session` Step 4** — Auto mode does **not** skip the confirmation. Filing a GitHub issue is not reversible via `git restore`, and closing the issue afterwards leaves noise in the tracker and notifies subscribers. Users wanting to batch the review can pass `--dry-run` and re-run.

The issue noted both skills shared the same silent ambiguity ("a fix here may be worth mirroring there"). Mirroring with the *same* policy would have been wrong — the right answer is to make each skill's policy explicit and have them differ where the destructiveness differs.

## Why this shape

The issue offers two acceptable directions ("skip in auto mode" vs "always confirm regardless of mode") and notes that *the silence* is the actual problem. For `/project:distill`, the user's recorded behaviour in the issue's evidence section was already to skip the prompt for reversible edits; this PR codifies that. For `/feedback:session`, the asymmetry in reversibility flips the answer.

No new flag is added — auto mode is a Claude Code mode, not a skill argument.

## Files changed

- `project-plugin/skills/project-distill/SKILL.md` — Step 4 split into auto / manual branches; `modified` bumped to 2026-04-27.
- `feedback-plugin/skills/feedback-session/SKILL.md` — explicit "auto mode does not skip" note added to Step 4; `modified` bumped to 2026-04-27.

## Test plan

- [x] `bash scripts/lint-context-commands.sh` — no new warnings on the touched files (the 2 pre-existing warnings live in `hooks-plugin` files that this PR does not touch).
- [x] `bash scripts/plugin-compliance-check.sh` — `project-plugin` and `feedback-plugin` rows are all green.
- [ ] Invoke `/project:distill --rules` in auto mode against a repo with a small `[UPDATE]` proposal — verify it applies without prompting.
- [ ] Invoke `/project:distill --rules` in manual mode — verify the per-category `AskUserQuestion` still fires.
- [ ] Invoke `/feedback:session` in auto mode — verify the Step 4 confirmation still fires (auto mode must **not** skip it for issue creation).

Closes #1119

https://claude.ai/code/session_01XzSDYWYdvt74VdG4xtDSew

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzSDYWYdvt74VdG4xtDSew)_