### PR TITLE
chore(ci): standardize workflow display names with Domain: Action scheme

### DIFF
--- a/.claude/rules/workflow-naming.md
+++ b/.claude/rules/workflow-naming.md
@@ -1,0 +1,73 @@
+# GitHub Actions Workflow Naming
+
+A `<Domain>: <Action> [<target>]` convention for the `name:` field of every GitHub Actions workflow this repo authors — and for the example snippets in any skill that scaffolds workflows.
+
+The motivation is the GitHub Actions sidebar: it sorts alphabetically by workflow display name, so a consistent prefix groups related workflows visually. The convention mirrors conventional-commit scope style: a Title Case domain noun, a colon, and a sentence-case action.
+
+## Rule
+
+Every workflow's `name:` follows:
+
+```
+<Domain>: <Action> [<target>]
+```
+
+- **Domain** — Title Case noun. Pick from the table below; add a new domain only when none fits.
+- **Colon + space** as separator.
+- **Action** — sentence case, short imperative or noun phrase. No trailing punctuation.
+- **Target** — kebab-case identifier (script, plugin, target name) when relevant.
+- **Quote the value** — colons must be quoted in YAML scalars: `name: "Plugin: Lint skills"`.
+
+A genuinely standalone workflow with no domain peers (e.g. `Renovate`) may go un-prefixed. Bias toward picking a domain — a one-off becomes a peer the moment a sibling workflow lands.
+
+## Domains in this repo
+
+| Domain | Used for |
+|--------|----------|
+| `Claude:` | Claude Code-driven workflows (PR reviews, @-mentions, scheduled reviews) |
+| `Plugin:` | Plugin infrastructure — PR checks, config validation, skill operations, scheduled audits |
+| `Release:` | release-please ecosystem — version bumps, changelog, release-PR doc audit, conflict repair |
+| `PR:` | Cross-cutting PR governance — conflict resolution, conventional-commit enforcement |
+| `Auto-fix:` | Autonomous CI failure remediation triggered by `workflow_run` |
+| _(none)_ | Standalones with no obvious domain peer (e.g. `Renovate`) |
+
+The canonical list of current names lives in `.github/workflows/README.md`. Update both that file and any affected `workflow_run.workflows` references when a `name:` changes.
+
+## Cross-workflow references
+
+When a workflow lists another workflow's display name (e.g. `on.workflow_run.workflows`), the listed string must match the target's `name:` exactly. Renaming a workflow is a same-PR job:
+
+1. Update the workflow's `name:` line.
+2. Grep for the old display name across `.github/workflows/` and update every reference.
+3. Update the sorted name list in `.github/workflows/README.md`.
+
+## Skills that scaffold workflows
+
+Any skill that emits a workflow YAML snippet must follow this convention in its examples. The affected skills today:
+
+| Skill | Where it generates `name:` |
+|-------|----------------------------|
+| `configure-plugin:ci-workflows` | Canonical workflow shapes (container build, tests, release, auto-fix) |
+| `configure-plugin:configure-workflows` | Interactive workflow scaffolder |
+| `configure-plugin:configure-reusable-workflows` | Reusable-workflow caller files |
+| `github-actions-plugin:claude-code-github-workflows` | Claude Code workflow design patterns |
+| `github-actions-plugin:github-workflow-auto-fix` | `Auto-fix: CI failures` template |
+| `github-actions-plugin:ci-autofix-reusable` | Reusable CI auto-fix workflow |
+| `agents-plugin/agents/ci.md` | CI agent's "Common Workflows" examples |
+
+When you add a new skill that scaffolds a workflow, register it here.
+
+## Example mapping
+
+| Before | After |
+|--------|-------|
+| `name: Plugin PR Checks` | `name: "Plugin: PR checks"` |
+| `name: Auto-fix Workflow Failures` | `name: "Auto-fix: CI failures"` |
+| `name: Release Please` | `name: "Release: release-please"` |
+| `name: Tests` | `name: "Test: Suite"` (or keep standalone if there is only one) |
+| `name: Build Container` | `name: "Container: Build"` |
+
+## Related
+
+- `.github/workflows/README.md` — current name list and per-domain rationale
+- `.claude/rules/conventional-commits.md` — analogous Domain-style scope rule for commits and PR titles

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,50 @@
+# GitHub Actions Workflows
+
+This directory contains GitHub Actions workflows for the claude-plugins repository.
+
+## Naming Convention
+
+All workflows use the `name:` pattern `<Domain>: <Action> [<target>]` so the Actions UI sidebar groups related workflows alphabetically.
+
+- **Domain** — Title Case noun. Matches the workflow's category, not necessarily its filename.
+- **Colon + space** as separator (mirrors conventional-commit scope style).
+- **Action** — sentence case, short imperative or noun phrase. No trailing punctuation.
+- **Target** — kebab-case identifier (script, plugin, target name) when relevant.
+- **Quotes required** — colons must be quoted in YAML scalars: `name: "Plugin: Lint skills"`.
+
+When adding a workflow, pick the existing domain that fits or extend the table below with a new one — don't introduce a one-off prefix.
+
+### Domains in use
+
+| Domain | Used for |
+|--------|----------|
+| `Claude:` | Claude Code-driven workflows (PR reviews, @-mentions, scheduled reviews) |
+| `Plugin:` | Plugin infrastructure — PR checks, config validation, skill operations, scheduled audits |
+| `Release:` | release-please ecosystem — version bumps, changelog, release-PR doc audit, conflict repair |
+| `PR:` | Cross-cutting PR governance — conflict resolution, conventional-commit enforcement |
+| `Auto-fix:` | Autonomous CI failure remediation triggered by `workflow_run` |
+| _(none)_ | One-off standalones with no obvious domain peer (e.g. `Renovate`) |
+
+### Sorted name list
+
+```
+Auto-fix: CI failures
+Claude: @mentions
+Claude: Changelog review
+Claude: PR review
+PR: Auto-resolve conflicts
+PR: Enforce conventional commits
+Plugin: Lint skills
+Plugin: PR checks
+Plugin: Scheduled audits
+Plugin: Skill splitter
+Plugin: Validate configs
+Release: Fix release-please conflicts
+Release: PR documentation audit
+Release: release-please
+Renovate
+```
+
+## Cross-workflow references
+
+When a workflow references another by display name (e.g. `on.workflow_run.workflows`), update the reference whenever the target's `name:` changes. The current cross-references live in `github-workflow-auto-fix.yml`.

--- a/.github/workflows/auto-resolve-conflicts.yml
+++ b/.github/workflows/auto-resolve-conflicts.yml
@@ -1,4 +1,4 @@
-name: Auto-resolve PR Conflicts
+name: "PR: Auto-resolve conflicts"
 
 on:
   push:

--- a/.github/workflows/changelog-review.yml
+++ b/.github/workflows/changelog-review.yml
@@ -1,4 +1,4 @@
-name: Claude Code Changelog Review
+name: "Claude: Changelog review"
 
 on:
   schedule:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,9 +4,9 @@
 # The file is kept in-tree because configure-plugin/skills/configure-claude-plugins
 # dogfoods it as the canonical review workflow for downstream projects — removing
 # it would desync the plugin template from its reference repo.
-# Re-enable via Actions → Claude Code Review → Enable workflow if plugin-pr-checks
+# Re-enable via Actions → "Claude: PR review" → Enable workflow if plugin-pr-checks
 # is ever removed or repurposed.
-name: Claude Code Review
+name: "Claude: PR review"
 
 on:
   pull_request:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,4 +1,4 @@
-name: Claude Code
+name: "Claude: @mentions"
 
 on:
   issue_comment:

--- a/.github/workflows/enforce-conventional-commits.yml
+++ b/.github/workflows/enforce-conventional-commits.yml
@@ -1,4 +1,4 @@
-name: Enforce Conventional Commits
+name: "PR: Enforce conventional commits"
 
 on:
   pull_request:

--- a/.github/workflows/fix-release-conflicts.yml
+++ b/.github/workflows/fix-release-conflicts.yml
@@ -1,4 +1,4 @@
-name: Fix release-please conflicts
+name: "Release: Fix release-please conflicts"
 
 on:
   push:

--- a/.github/workflows/github-workflow-auto-fix.yml
+++ b/.github/workflows/github-workflow-auto-fix.yml
@@ -1,11 +1,11 @@
-name: Auto-fix Workflow Failures
+name: "Auto-fix: CI failures"
 
 on:
   workflow_run:
     workflows:
-      - "Plugin PR Checks"
-      - "Lint Context Commands"
-      - "Enforce Conventional Commits"
+      - "Plugin: PR checks"
+      - "Plugin: Lint skills"
+      - "PR: Enforce conventional commits"
     types: [completed]
 
 # Prevent concurrent auto-fix runs on the same branch

--- a/.github/workflows/lint-context-commands.yml
+++ b/.github/workflows/lint-context-commands.yml
@@ -1,4 +1,4 @@
-name: Lint Context Commands
+name: "Plugin: Lint skills"
 
 on:
   pull_request:

--- a/.github/workflows/plugin-pr-checks.yml
+++ b/.github/workflows/plugin-pr-checks.yml
@@ -1,4 +1,4 @@
-name: Plugin PR Checks
+name: "Plugin: PR checks"
 
 on:
   pull_request:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,4 +1,4 @@
-name: Release Please
+name: "Release: release-please"
 
 on:
   push:

--- a/.github/workflows/release-pr-doc-audit.yml
+++ b/.github/workflows/release-pr-doc-audit.yml
@@ -1,4 +1,4 @@
-name: Release PR Documentation Audit
+name: "Release: PR documentation audit"
 
 on:
   pull_request:

--- a/.github/workflows/scheduled-audits.yml
+++ b/.github/workflows/scheduled-audits.yml
@@ -1,4 +1,4 @@
-name: Scheduled Audits
+name: "Plugin: Scheduled audits"
 
 on:
   schedule:

--- a/.github/workflows/skill-splitter.yml
+++ b/.github/workflows/skill-splitter.yml
@@ -1,4 +1,4 @@
-name: Skill Splitter
+name: "Plugin: Skill splitter"
 
 on:
   pull_request:

--- a/.github/workflows/validate-plugin-configs.yml
+++ b/.github/workflows/validate-plugin-configs.yml
@@ -1,4 +1,4 @@
-name: Validate Plugin Configs
+name: "Plugin: Validate configs"
 
 on:
   pull_request:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ Claude Code plugin collection providing skills and agents for development workfl
 | `.claude/rules/sandbox-guidance.md` | Sandbox constraints, `CLAUDE_CODE_REMOTE` detection, and remote/local skill patterns |
 | `.claude/rules/plugin-flow-diagrams.md` | When and how to add Mermaid flow diagrams |
 | `.claude/rules/agent-coworker-detection.md` | Detect other agents working in the same repo clone before destructive git ops |
+| `.claude/rules/workflow-naming.md` | `<Domain>: <Action>` naming for `.github/workflows/*.yml` and skill-generated workflow examples |
 
 ## Creating New Skills
 

--- a/agents-plugin/agents/ci.md
+++ b/agents-plugin/agents/ci.md
@@ -6,8 +6,8 @@ description: Configure CI/CD pipelines. Creates and updates GitHub Actions workf
 tools: Glob, Grep, LS, Read, Edit, Write, Bash(gh pr *), Bash(gh run *), Bash(gh workflow *), Bash(npm *), Bash(yarn *), Bash(bun *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git branch *), TodoWrite
 maxTurns: 15
 created: 2025-12-27
-modified: 2026-03-09
-reviewed: 2026-03-09
+modified: 2026-04-29
+reviewed: 2026-04-29
 ---
 
 # CI Agent
@@ -28,11 +28,17 @@ Configure CI/CD pipelines. Creates GitHub Actions workflows and deployment autom
 4. **Validate** - Syntax check the configuration
 5. **Report** - List created/updated files
 
+## Display name convention
+
+Every workflow's `name:` follows `<Domain>: <Action> [<target>]` (quoted, since YAML treats `:` as a key separator). When generating workflows, mirror the example snippets below. See `.claude/rules/workflow-naming.md` for the canonical rule and active domains.
+
+When a workflow lists another by display name (`on.workflow_run.workflows`), the listed string must match the target's `name:` exactly — update both sides whenever a target's `name:` changes.
+
 ## Common Workflows
 
 ### Test on PR
 ```yaml
-name: Test
+name: "Test: Suite"
 on: [pull_request]
 jobs:
   test:
@@ -45,7 +51,7 @@ jobs:
 
 ### Deploy on Merge
 ```yaml
-name: Deploy
+name: "Deploy: Production"
 on:
   push:
     branches: [main]
@@ -67,6 +73,7 @@ jobs:
 | Parallel jobs | Matrix builds |
 | Minimal permissions | `permissions:` block |
 | Pin versions | `@v4` not `@latest` |
+| Display name convention | `name: "<Domain>: <Action>"` (quoted) |
 
 ## Language-Specific Patterns
 

--- a/configure-plugin/skills/ci-workflows/SKILL.md
+++ b/configure-plugin/skills/ci-workflows/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
-reviewed: 2026-04-25
+modified: 2026-04-29
+reviewed: 2026-04-29
 name: ci-workflows
 description: |
   GitHub Actions workflow standards. Use when configuring CI/CD workflows, checking
@@ -25,6 +25,10 @@ allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 
 Standard GitHub Actions workflows for CI/CD automation.
 
+## Display name convention
+
+Every workflow's `name:` follows `<Domain>: <Action> [<target>]` so the GitHub Actions sidebar groups related workflows alphabetically. Quote the value because YAML treats `:` inside an unquoted scalar as a key separator. See `.claude/rules/workflow-naming.md` for the canonical rule, the active domain list, and the cross-workflow rename procedure. Mirror the pattern in any workflow you scaffold here.
+
 ## Required Workflows
 
 ### 1. Container Build Workflow
@@ -34,7 +38,7 @@ Standard GitHub Actions workflows for CI/CD automation.
 Multi-platform container build with GHCR publishing:
 
 ```yaml
-name: Build Container
+name: "Container: Build"
 
 on:
   push:
@@ -114,7 +118,7 @@ See `release-please-standards` skill for details.
 Auto-merge PRs from ArgoCD Image Updater branches:
 
 ```yaml
-name: Auto-merge ArgoCD Image Updater branches
+name: "Image Updater: Auto-merge"
 
 on:
   push:
@@ -178,7 +182,7 @@ jobs:
 **File**: `.github/workflows/test.yml`
 
 ```yaml
-name: Tests
+name: "Test: Suite"
 
 on:
   push:
@@ -223,12 +227,13 @@ jobs:
 Automated CI failure analysis and remediation using Claude Code Action:
 
 ```yaml
-name: Claude Auto-fix CI Failures
+name: "Auto-fix: CI failures"
 
 on:
   workflow_run:
-    # Customize: list the CI workflow names to monitor
-    workflows: ["CI"]
+    # Customize: list the CI workflow display names to monitor.
+    # The strings here must match the target workflows' `name:` values exactly.
+    workflows: ["Test: Suite"]
     types: [completed]
   workflow_dispatch:
     inputs:

--- a/configure-plugin/skills/configure-reusable-workflows/SKILL.md
+++ b/configure-plugin/skills/configure-reusable-workflows/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-02-02
-modified: 2026-04-19
-reviewed: 2026-02-02
+modified: 2026-04-29
+reviewed: 2026-04-29
 description: |
   Install reusable GitHub Actions workflows for security, quality, and accessibility
   checks. Use when adding Claude-powered reusable workflows, installing pre-built workflow
@@ -101,14 +101,16 @@ If `--list` is set, print the Available Workflows tables above and stop.
 
 For each selected workflow, create a caller file in `.github/workflows/`.
 
-**Naming convention**: `claude-<category>-<name>.yml`
+**Filename convention**: `claude-<category>-<name>.yml`
 
 Example: `claude-security-secrets.yml`
+
+**Display name convention**: The workflow's `name:` follows `<Domain>: <Action> [<target>]` (quoted because YAML treats `:` as a key separator). For these reusable callers, `Claude:` is the right domain. See `.claude/rules/workflow-naming.md` for the canonical rule and active domains. Example: `name: "Claude: Security secrets"`.
 
 Use the caller workflow template:
 
 ```yaml
-name: Claude <Category> - <Name>
+name: "Claude: <Action> <target>"
 
 on:
   pull_request:

--- a/configure-plugin/skills/configure-workflows/SKILL.md
+++ b/configure-plugin/skills/configure-workflows/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-16
-modified: 2026-04-19
-reviewed: 2025-12-16
+modified: 2026-04-29
+reviewed: 2026-04-29
 description: |
   Check and configure GitHub Actions CI/CD workflows (container builds, tests, releases).
   Use when checking GitHub Actions workflows for compliance, setting up container build,
@@ -37,6 +37,8 @@ Check and configure GitHub Actions CI/CD workflows against project standards.
 - Release-please config: !`find . -maxdepth 1 -name \'release-please-config.json\'`
 
 **Skills referenced**: `ci-workflows`, `github-actions-auth-security`
+
+**Display name convention**: Every generated or repaired workflow's `name:` follows `<Domain>: <Action> [<target>]` (quoted, since YAML treats `:` as a key separator). See `.claude/rules/workflow-naming.md` for the full rule and active domains.
 
 ## Parameters
 

--- a/github-actions-plugin/skills/ci-autofix-reusable/REFERENCE.md
+++ b/github-actions-plugin/skills/ci-autofix-reusable/REFERENCE.md
@@ -7,7 +7,7 @@ Full workflow YAML templates for the reusable CI auto-fix pattern.
 Create as `.github/workflows/reusable-ci-autofix.yml`:
 
 ```yaml
-name: Reusable CI Auto-Fix
+name: "Reusable: CI auto-fix"
 
 on:
   workflow_call:
@@ -347,17 +347,17 @@ jobs:
 
 ## Caller Workflow
 
-Create as `.github/workflows/auto-fix.yml`. Customize the `workflows:` list and input overrides for your project.
+Create as `.github/workflows/auto-fix.yml`. Customize the `workflows:` list and input overrides for your project. The strings under `workflows:` must match each target workflow's `name:` exactly.
 
 ```yaml
-name: Claude Auto-fix CI Failures
+name: "Auto-fix: CI failures"
 
 on:
   workflow_run:
     workflows:
-      # List your CI workflow names here:
-      - "CI"
-      - "Lint"
+      # List your CI workflow display names here (must match their `name:` exactly):
+      - "Test: Suite"
+      - "Lint: Suite"
     types: [completed]
 
   workflow_dispatch:
@@ -436,11 +436,12 @@ jobs:
 Example caller that overrides auto-fix criteria and verification commands for an ESP32/Python project:
 
 ```yaml
-name: Claude Auto-fix CI Failures
+name: "Auto-fix: CI failures"
 
 on:
   workflow_run:
-    workflows: ["Test Suite", "ESP32 Build Pipeline"]
+    # Match the target workflows' display names exactly.
+    workflows: ["Test: Suite", "ESP32: Build pipeline"]
     types: [completed]
 
   workflow_dispatch:

--- a/github-actions-plugin/skills/ci-autofix-reusable/SKILL.md
+++ b/github-actions-plugin/skills/ci-autofix-reusable/SKILL.md
@@ -9,8 +9,8 @@ args: "[--setup] [--caller] [--workflows <names>] [--dry-run]"
 argument-hint: --setup to create reusable workflow, --caller to create caller workflow
 disable-model-invocation: true
 created: 2026-03-07
-modified: 2026-03-07
-reviewed: 2026-03-07
+modified: 2026-04-29
+reviewed: 2026-04-29
 ---
 
 # Reusable CI Auto-Fix Workflow
@@ -79,9 +79,11 @@ Key customization points:
 If `--caller` or caller workflow is missing, create `.github/workflows/auto-fix.yml` using the template from [REFERENCE.md](REFERENCE.md) § Caller Workflow.
 
 Key customization points:
-1. Set the monitored workflow names in the `workflows:` list
+1. Set the monitored workflow names in the `workflows:` list — these are **display names** and must match each target workflow's `name:` exactly
 2. Configure `auto_fixable_criteria` override if the project has specific fixable patterns
 3. Configure `verification_commands` for the project's tools
+
+**Display name convention**: The caller workflow's `name:` follows `<Domain>: <Action>` (`Auto-fix: CI failures` is canonical for `workflow_run`-triggered remediation; the reusable definition itself uses `Reusable: CI auto-fix`). Quote values containing colons. See `.claude/rules/workflow-naming.md`.
 
 ### Step 5: Validate and report
 

--- a/github-actions-plugin/skills/claude-code-github-workflows/skill.md
+++ b/github-actions-plugin/skills/claude-code-github-workflows/skill.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
-reviewed: 2026-04-25
+modified: 2026-04-29
+reviewed: 2026-04-29
 name: claude-code-github-workflows
 description: Claude Code workflow design and automation patterns for PR reviews, issue triage, and CI/CD integration. Use when creating or modifying GitHub Actions workflows that integrate Claude Code.
 user-invocable: false
@@ -35,10 +35,16 @@ Expert knowledge for designing GitHub Actions workflows that integrate Claude Co
 - Workflow run triggers (CI failure handling)
 - Path-filtered reviews for specific directories
 
+## Display name convention
+
+Every workflow's `name:` follows `<Domain>: <Action> [<target>]` (quoted, since YAML treats `:` as a key separator). Use the `Claude:` domain for Claude Code-driven workflows; use `Auto-fix:` for `workflow_run`-triggered remediation. See `.claude/rules/workflow-naming.md` for the canonical rule and active domains. The example snippets below dogfood the convention.
+
+When a workflow's `on.workflow_run.workflows` lists another workflow's display name, the listed string must match the target workflow's `name:` exactly — update both sides in the same change.
+
 ## Essential Workflow Template
 
 ```yaml
-name: Claude Code
+name: "Claude: @mentions"
 
 on:
   issue_comment:
@@ -76,7 +82,7 @@ jobs:
 
 ### Comprehensive PR Review
 ```yaml
-name: Claude PR Review
+name: "Claude: PR review"
 
 on:
   pull_request:
@@ -106,11 +112,12 @@ jobs:
 
 ### CI Failure Auto-Fix
 ```yaml
-name: Auto-Fix CI Failures
+name: "Auto-fix: CI failures"
 
 on:
   workflow_run:
-    workflows: ["CI"]
+    # The string here must match the target workflow's `name:` exactly.
+    workflows: ["Test: Suite"]
     types: [completed]
 
 jobs:
@@ -136,7 +143,7 @@ jobs:
 
 ### Issue Triage and Labeling
 ```yaml
-name: Issue Triage
+name: "Claude: Issue triage"
 
 on:
   issues:
@@ -161,7 +168,7 @@ jobs:
 
 ### Path-Filtered PR Review
 ```yaml
-name: Review Backend Changes
+name: "Claude: Review backend changes"
 
 on:
   pull_request:
@@ -190,7 +197,7 @@ jobs:
 
 ### Custom Trigger Phrase
 ```yaml
-name: Claude Custom Trigger
+name: "Claude: Custom trigger"
 
 on:
   issue_comment:
@@ -214,7 +221,7 @@ jobs:
 
 ### External Contributor Handling
 ```yaml
-name: Review External Contributions
+name: "Claude: Review external contributions"
 
 on:
   pull_request_target:

--- a/github-actions-plugin/skills/github-workflow-auto-fix/SKILL.md
+++ b/github-actions-plugin/skills/github-workflow-auto-fix/SKILL.md
@@ -9,8 +9,8 @@ args: "[--setup] [--workflows <names>] [--dry-run]"
 argument-hint: --setup to create workflow, or --dry-run to preview
 disable-model-invocation: true
 created: 2026-02-18
-modified: 2026-02-19
-reviewed: 2026-02-18
+modified: 2026-04-29
+reviewed: 2026-04-29
 ---
 
 # GitHub Workflow Auto-Fix
@@ -66,17 +66,19 @@ If `--workflows` provided, use those. Otherwise, auto-detect suitable workflows:
 
 ### Step 3: Generate workflow file
 
-If `--setup` or workflow is missing, create `.github/workflows/github-workflow-auto-fix.yml`:
+If `--setup` or workflow is missing, create `.github/workflows/github-workflow-auto-fix.yml`.
+
+The workflow's display name follows `<Domain>: <Action>` (`Auto-fix:` is the canonical domain for `workflow_run`-triggered remediation; quote the value because YAML treats `:` as a key separator). The strings under `workflows:` must match the **display names** of the target workflows exactly — update both sides whenever a target's `name:` changes. See `.claude/rules/workflow-naming.md`.
 
 ```yaml
-name: Auto-fix Workflow Failures
+name: "Auto-fix: CI failures"
 
 on:
   workflow_run:
     workflows:
-      # List monitored workflows here
-      - "CI"
-      - "Lint"
+      # List monitored workflows by display name (must match their `name:` exactly)
+      - "Test: Suite"
+      - "Plugin: Lint skills"
     types: [completed]
 
 concurrency:


### PR DESCRIPTION
## Summary

Apply a consistent `<Domain>: <Action> [<target>]` naming pattern to the `name:` field of all 15 workflows in `.github/workflows/` so the GitHub Actions sidebar groups related workflows alphabetically (`Claude:`, `Plugin:`, `Release:`, `PR:`, `Auto-fix:` cluster together). Inspired by [ForumViriumHelsinki/infrastructure#1728](https://github.com/ForumViriumHelsinki/infrastructure/pull/1728), then extended so the workflow-authoring skills in this repo teach the convention to downstream users.

### What changed

**Workflows (`8c3a6248`):**
- 14 workflow `name:` values rewritten to the new scheme; `Renovate` kept as a standalone (no domain peer).
- `github-workflow-auto-fix.yml`: cross-reference list under `on.workflow_run.workflows` updated to match the renamed targets — those strings are display names and must match the targets' `name:` exactly.
- `.github/workflows/README.md`: new file documenting the rule, the active domain table, and the sorted name list.
- `.claude/rules/workflow-naming.md`: new project rule that any workflow-authoring skill cites.
- `CLAUDE.md`: rules table entry for the new rule.

**Skills (`308a0916`):**
- `configure-plugin:ci-workflows` — 4 example names rewritten (`Container: Build`, `Image Updater: Auto-merge`, `Test: Suite`, `Auto-fix: CI failures`); new "Display name convention" section.
- `configure-plugin:configure-workflows` — convention pointer added.
- `configure-plugin:configure-reusable-workflows` — caller-template `name:` value retemplated to `Claude: <Action> <target>`.
- `github-actions-plugin:claude-code-github-workflows` — 7 example names rewritten (`Claude: @mentions`, `Claude: PR review`, `Auto-fix: CI failures`, `Claude: Issue triage`, etc.); section flags the `on.workflow_run.workflows` exact-match requirement.
- `github-actions-plugin:github-workflow-auto-fix` — `Auto-fix: CI failures` in the generated template.
- `github-actions-plugin:ci-autofix-reusable` — REFERENCE.md templates use `Reusable: CI auto-fix` and `Auto-fix: CI failures`; SKILL.md flags the `workflow_run.workflows` exact-match requirement.
- `agents-plugin/agents/ci.md` — `Test: Suite` / `Deploy: Production` examples; "Display name convention" entry in Best Practices.

### Domains in use

`Claude:` (3), `Plugin:` (5), `Release:` (3), `PR:` (2), `Auto-fix:` (1), plus standalone `Renovate`.

### Sorted name list (post-change)

```
Auto-fix: CI failures
Claude: @mentions
Claude: Changelog review
Claude: PR review
PR: Auto-resolve conflicts
PR: Enforce conventional commits
Plugin: Lint skills
Plugin: PR checks
Plugin: Scheduled audits
Plugin: Skill splitter
Plugin: Validate configs
Release: Fix release-please conflicts
Release: PR documentation audit
Release: release-please
Renovate
```

## Test plan

- [x] `actionlint .github/workflows/*.yml` — exit 0 (remaining shellcheck/expression warnings are pre-existing and unrelated to the rename)
- [x] Each workflow has exactly one `^name:` line
- [x] `pre-commit` ran clean against the renamed workflows + new docs
- [x] No stale workflow-name references outside `.github/workflows/` (rg sweep)
- [ ] After merge: confirm the Actions sidebar groups by domain prefix as expected
- [ ] After merge: confirm any teammate-bookmarked Actions URLs filtering on the old workflow name still resolve (GitHub's filter is a substring match)

## Tradeoff

Anyone with a bookmarked Actions URL filtering on the old display name (e.g. `Plugin PR Checks`) will need to update the filter. GitHub's Actions UI filter is a substring match, so partial matches like `pygeoapi` continue to work for the FVH-style cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)