### PR TITLE
feat(upstream-pr-plugin): add heavy-divergence fork-to-upstream PR plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -598,6 +598,23 @@
       "category": "language"
     },
     {
+      "name": "upstream-pr-plugin",
+      "source": "./upstream-pr-plugin",
+      "description": "Heavy-divergence fork-to-upstream PR workflow — eligibility checks via patch-id, cherry-pick with re-derive fallback, commit-message scrubbing, and pre-flight regression verification",
+      "version": "1.0.0",
+      "keywords": [
+        "fork",
+        "upstream",
+        "pull-request",
+        "cherry-pick",
+        "patch-id",
+        "re-derive",
+        "scrub",
+        "regression"
+      ],
+      "category": "development"
+    },
+    {
       "name": "workflow-orchestration-plugin",
       "source": "./workflow-orchestration-plugin",
       "description": "Workflow orchestration - parallel agents, CI pipelines, preflight checks, checkpoint refactoring",

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -37,5 +37,6 @@
   "typescript-plugin": "1.8.1",
   "workflow-orchestration-plugin": "1.5.0",
   "obsidian-plugin": "1.3.1",
-  "prompt-engineering-plugin": "1.1.1"
+  "prompt-engineering-plugin": "1.1.1",
+  "upstream-pr-plugin": "1.0.0"
 }

--- a/docs/PLUGIN-MAP.md
+++ b/docs/PLUGIN-MAP.md
@@ -1,6 +1,6 @@
 # Plugin Navigation Map
 
-Navigation guide for 37 plugins and 300+ skills. Start here.
+Navigation guide for 38 plugins and 300+ skills. Start here.
 
 ## Quick Start
 
@@ -198,6 +198,7 @@ Install based on your project's tech stack and domain.
 | prompt-engineering-plugin | Anti-hallucination workflow — grounded, citation-backed analysis from source documents |
 | prose-plugin | Prose style control — distillation, tone, voice, clarity, consistency |
 | obsidian-plugin | Obsidian CLI vault management — files, search, properties, tasks, publish, sync |
+| upstream-pr-plugin | Heavy-divergence fork-to-upstream PR workflow — patch-id eligibility, re-derive fallback, scrub, regression check |
 
 ## Key Entry Points
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1190,6 +1190,39 @@
         }
       ]
     },
+    "upstream-pr-plugin": {
+      "component": "upstream-pr-plugin",
+      "release-type": "simple",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        }
+      ],
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance"
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactoring"
+        },
+        {
+          "type": "docs",
+          "section": "Documentation"
+        }
+      ]
+    },
     "workflow-orchestration-plugin": {
       "component": "workflow-orchestration-plugin",
       "release-type": "simple",

--- a/upstream-pr-plugin/.claude-plugin/plugin.json
+++ b/upstream-pr-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin.json",
+  "name": "upstream-pr-plugin",
+  "version": "1.0.0",
+  "description": "Heavy-divergence fork-to-upstream PR workflow — eligibility checks via patch-id, cherry-pick with re-derive fallback, commit-message scrubbing, and pre-flight regression verification",
+  "author": {
+    "name": "Lauri Gates"
+  },
+  "repository": "https://github.com/laurigates/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "fork",
+    "upstream",
+    "pull-request",
+    "cherry-pick",
+    "patch-id",
+    "re-derive",
+    "scrub",
+    "regression"
+  ]
+}

--- a/upstream-pr-plugin/README.md
+++ b/upstream-pr-plugin/README.md
@@ -1,0 +1,59 @@
+# upstream-pr-plugin
+
+Heavy-divergence fork-to-upstream PR workflow for Claude Code.
+
+When a fork has substantially diverged from upstream, direct rebase is not viable. This plugin codifies the patterns that make a clean upstream PR possible anyway: **eligibility checks** via patch-id matching, **cherry-pick with re-derive fallback** when conflicts get dense, **commit-message scrubbing** to strip fork-local context, and **pre-flight regression verification** against the upstream baseline.
+
+## When to use this plugin vs `git-plugin:git-upstream-pr`
+
+| `upstream-pr-plugin` (this plugin) | `git-plugin:git-upstream-pr` |
+|------------------------------------|------------------------------|
+| Heavy fork divergence | Low fork divergence |
+| Patch-id eligibility check (catches re-applied content) | Skips patch-id check |
+| Re-derive fallback when cherry-pick fails | Cherry-pick + abort |
+| Commit-message scrubbing | No scrubbing |
+| Pre-flight regression check vs upstream | No regression check |
+
+Both plugins coexist intentionally. Use the simpler `git-upstream-pr` first; if the cherry-pick flounders or you discover the change has already been applied upstream under a different SHA, switch to `upstream-pr`.
+
+## Skills
+
+| Skill | Description |
+|-------|-------------|
+| `/upstream-pr:upstream-pr` | Submit a single fork commit upstream as a clean PR |
+
+## Configuration
+
+Per-project configuration lives at `.claude/upstream-pr.local.md`:
+
+```markdown
+---
+upstream_remote: upstream
+upstream_repo: owner/repo
+branch_prefix: pr-upstream/
+linter_cmd: uv run ruff check
+test_cmd: uv run pytest -q
+pr_body_template_path: docs/UPSTREAM_PR_TEMPLATE.md
+---
+```
+
+All fields are optional — sensible defaults are derived from `git remote get-url upstream`. Add `.claude/*.local.md` to `.gitignore`.
+
+## Workflow
+
+```
+git log --oneline                                  # pick the SHA to send upstream
+bash skills/upstream-pr/scripts/check-eligibility.sh <sha>
+bash skills/upstream-pr/scripts/prepare-branch.sh <topic> <sha>
+# resolve conflicts, or abort + re-derive
+bash skills/upstream-pr/scripts/scrub-commit.sh --check
+bash skills/upstream-pr/scripts/scrub-commit.sh    # if --check failed
+git push origin <branch>
+gh pr create --repo <upstream_repo> --base main --head <fork-owner>:<branch> ...
+```
+
+See [skills/upstream-pr/SKILL.md](skills/upstream-pr/SKILL.md) for the full workflow.
+
+## Origin
+
+Generalized from the in-repo skill at [`laurigates/kicad-mcp:.claude/skills/upstream-pr/`](https://github.com/laurigates/kicad-mcp/blob/main/.claude/skills/upstream-pr/SKILL.md), which was driven by a series of upstream PRs to `lamaalrajih/kicad-mcp` ([#53](https://github.com/lamaalrajih/kicad-mcp/pull/53), [#54](https://github.com/lamaalrajih/kicad-mcp/pull/54), [#55](https://github.com/lamaalrajih/kicad-mcp/pull/55)). See [issue #1201](https://github.com/laurigates/claude-plugins/issues/1201) for the proposal that motivated this plugin.

--- a/upstream-pr-plugin/skills/upstream-pr/SKILL.md
+++ b/upstream-pr-plugin/skills/upstream-pr/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: upstream-pr
+description: |
+  Submit a single commit from a heavily-diverged fork back to upstream as a
+  clean PR. Handles eligibility checks (patch-id matching against upstream),
+  cherry-pick with re-derive fallback when conflicts are too dense, commit-
+  message scrubbing of fork-local context, and pre-flight regression
+  verification against the upstream baseline. Use when the fork has
+  substantially diverged from upstream and direct rebase is not viable, or
+  when the user asks to "send X upstream", "backport to upstream", or
+  "open an upstream PR".
+args: "<sha> [--topic <slug>]"
+allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git show *), Bash(git remote *), Bash(git fetch *), Bash(git switch *), Bash(git checkout *), Bash(git cherry-pick *), Bash(git reset *), Bash(git commit *), Bash(git push *), Bash(git stash *), Bash(git rev-list *), Bash(git rev-parse *), Bash(git branch *), Bash(git cat-file *), Bash(git patch-id *), Bash(gh pr *), Bash(gh repo *), Bash(bash *), Bash(uv *), Bash(pytest *), Bash(ruff *), Bash(python3 *), Read, Edit, Write, Grep, Glob, TodoWrite
+argument-hint: "<sha-to-send-upstream>"
+created: 2026-04-29
+modified: 2026-04-29
+reviewed: 2026-04-29
+---
+
+# /upstream-pr
+
+Submit a single commit from a heavily-diverged fork back to upstream as a clean, regression-free PR.
+
+## When to Use This Skill
+
+| Use this skill when... | Use `/git:upstream-pr` instead when... |
+|------------------------|----------------------------------------|
+| Fork has substantially diverged from upstream | Fork and upstream are roughly aligned |
+| Cherry-pick may produce many conflicts on shared modules | Single commit applies cleanly |
+| You need patch-id matching for already-applied content | You want a quick cherry-pick + cross-fork PR |
+| The change touches files that may be fork-only | All touched files exist upstream |
+| The PR needs commit-message scrubbing (fork issue refs, Claude trailers) | Commit messages are already upstream-clean |
+| Pre-flight regression check against upstream baseline matters | The change is trivial enough to skip pre-flight |
+
+## Configuration
+
+Per-project configuration lives at `.claude/upstream-pr.local.md` (gitignored). All fields are optional; sensible defaults apply.
+
+```markdown
+---
+upstream_remote: upstream
+upstream_repo: owner/repo
+branch_prefix: pr-upstream/
+linter_cmd: uv run ruff check
+test_cmd: uv run pytest -q
+pr_body_template_path: docs/UPSTREAM_PR_TEMPLATE.md
+---
+
+# Notes
+
+Free-form notes — fork drift hotspots, files to never touch upstream, etc.
+```
+
+| Field | Default | Used by |
+|-------|---------|---------|
+| `upstream_remote` | `upstream` | All scripts |
+| `upstream_repo` | Parsed from `git remote get-url <upstream_remote>` | `gh pr create --repo` |
+| `branch_prefix` | `pr-upstream/` | Branch name in `prepare-branch.sh` |
+| `linter_cmd` | (empty — pre-flight skipped) | Pre-flight stash-roundtrip |
+| `test_cmd` | (empty — pre-flight skipped) | Pre-flight stash-roundtrip |
+| `pr_body_template_path` | (empty — built-in template) | PR body |
+
+Add `.claude/*.local.md` to `.gitignore`.
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- Working tree: !`git status --porcelain=v2 --branch`
+- Remotes: !`git remote -v`
+- Config file: !`find .claude -maxdepth 1 -name 'upstream-pr.local.md'`
+
+## Parameters
+
+Parse from `$ARGUMENTS`:
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `<sha>` | Yes | Commit SHA on the fork to send upstream |
+| `--topic <slug>` | No | Topic slug for branch name; auto-derived from commit subject if omitted |
+
+## Execution
+
+Execute this upstream-PR workflow:
+
+### Step 1: Check eligibility
+
+Run the eligibility check before touching any branch:
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/check-eligibility.sh" <sha>
+```
+
+Exit codes drive next steps:
+
+| Exit | Meaning | Action |
+|------|---------|--------|
+| `0` | Every touched file exists upstream and content is novel | Proceed to Step 2 |
+| `1` | At least one fork-only file | Stop. Tell the user the change isn't standalone-PR-able; predecessor feature must land first |
+| `3` | Content already applied upstream under a different SHA | Stop. Report the matching upstream commit; nothing to PR |
+
+The patch-id check (`git patch-id --stable`) catches re-applied content from maintainer re-merges or squashes — even when the SHA differs.
+
+### Step 2: Prepare the branch
+
+Derive a topic slug from the commit subject if `--topic` was not provided. Then:
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/prepare-branch.sh" <topic-slug> <sha>
+```
+
+The script:
+
+1. Verifies a clean working tree
+2. Re-runs the eligibility check
+3. Fetches the upstream remote
+4. Creates `<branch_prefix><topic-slug>` from `<upstream_remote>/main` (or `/master`)
+5. Cherry-picks `<sha>`
+6. Reports any conflict files
+
+### Step 3: Resolve conflicts (if any)
+
+When the cherry-pick produces conflicts, **preserve upstream's surrounding shape**, not the fork's. The goal is the smallest readable diff against upstream — a maintainer must see the change make sense in upstream's current code, not in the fork's.
+
+#### When to abort and re-derive
+
+If the cherry-pick produces dozens of conflict blocks across multiple files (typical when upstream and fork have drifted heavily on shared modules), abort and re-derive instead of fighting hunks:
+
+```bash
+git cherry-pick --abort
+git checkout -b <branch> <upstream_remote>/main
+# Re-apply the change against upstream's actual current files.
+```
+
+Re-derive is the right call when:
+
+- The original commit is a **mechanical, re-applicable transform** (e.g. `print()` → logging, deprecation rename, lint-rule auto-fixes) — the rules transfer cleanly even if line numbers don't.
+- Upstream's version of the file has **additional lines the fork removed** — re-derive lets you cover them with the same heuristic rather than rationalizing missing hunks.
+- The cherry-pick conflict count exceeds roughly **20 blocks across >2 files**.
+
+Heuristic: extract the original commit's `before → after` map (e.g. `git show <sha> | grep -E '^[-+].*pattern'`) and use it as the rulebook when re-applying against upstream. The PR body should disclose the re-derive (see template below).
+
+### Step 4: Pre-flight regression check
+
+For refactor / cleanup PRs, verify lint and test parity against the **pristine upstream baseline**, not against the fork. This catches stray formatter touches, accidental import reordering, and indentation drift from Edit-tool replacements.
+
+If `linter_cmd` and `test_cmd` are configured, run a stash roundtrip:
+
+```bash
+# Baseline (pristine upstream):
+git stash push -- <changed-files>
+<linter_cmd> <changed-files> 2>&1 | tail -1   # error count
+<test_cmd> 2>&1 | tail -1                     # pass count
+git stash pop
+
+# After (with your changes): run the same two commands and compare.
+```
+
+Both numbers must match (or improve). Quote both in the PR body's "Testing Performed" section.
+
+For Python files, also run `python3 -c "import ast; ast.parse(open(F).read())"` on every edited file — catches indentation breaks that ruff might miss on already-warning-laden upstream code.
+
+### Step 5: Scrub the commit message
+
+Run the scrub helper:
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/scrub-commit.sh" --check
+```
+
+If violations are reported, run without `--check` to amend interactively:
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/scrub-commit.sh"
+```
+
+The scrub rules:
+
+- **Strip local issue references** — `Closes #74`, `Addresses #19`, etc. point at the fork's tracker, not upstream's.
+- **Strip Claude trailers** — `Co-authored-by: Claude ...`, `Generated with [Claude Code]`. Upstream doesn't follow that convention.
+- **Soften fork-specific tooling** — if the body cites a tool upstream doesn't run (`bandit B607`, `ty`, `vulture`), describe the underlying problem instead.
+- **Keep the conventional-commit prefix** — `fix(security):`, `feat(parser):`, etc.
+
+The amend wraps `git commit --amend` with `PRE_COMMIT_ALLOW_NO_CONFIG=1` because upstream may have no `.pre-commit-config.yaml` and a locally-installed pre-commit hook would otherwise refuse the commit.
+
+### Step 6: Verify diff hygiene
+
+Before pushing, verify with:
+
+```bash
+git diff <upstream_remote>/main..HEAD
+```
+
+Every hunk should be defensible to a maintainer who has never seen the fork.
+
+- Don't bundle formatter cleanups with the fix. Keep upstream's existing import order even if the fork's linter would reformat. Upstream may have unusual indentation (e.g. 21-space rather than 20-space blocks) — preserve it; Edit-tool replacements that change leading whitespace by even one character will break the parse.
+- One commit per PR. If the cherry-pick produced multiple commits, squash before pushing.
+
+### Step 7: Push and open the PR
+
+```bash
+git push origin <branch>
+
+gh pr create --repo <upstream_repo> --base main \
+  --head <fork-owner>:<branch> \
+  --title "<conventional-commit subject>" \
+  --body "<see body template below>"
+```
+
+If `pr_body_template_path` is configured, use that template; otherwise use the built-in template:
+
+```markdown
+## Description
+
+<one or two paragraphs explaining the problem and the fix from the
+maintainer's perspective — not from the fork's perspective>
+
+## Related Issue(s)
+
+None.  <or upstream issue numbers only>
+
+## Type of Change
+
+- [x] Bug fix (non-breaking change that fixes an issue)
+
+## Testing Performed
+
+- [x] `<linter_cmd> <changed-files>` — N issues (matches upstream baseline)
+- [x] `<test_cmd>` — M passed (matches upstream baseline)
+
+## Notes
+
+Originally authored on a downstream fork; the branch was cut from
+`<upstream_repo>:main` and a single commit cherry-picked onto it so
+it applies cleanly.
+
+<If re-derived: "The fork's version of this change collided heavily with
+upstream's current code; the diff was re-derived against upstream's files
+using the original commit's transformation rules.">
+```
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Eligibility check | `bash check-eligibility.sh <sha>` (exit 0/1/3) |
+| Prepare branch | `bash prepare-branch.sh <topic> <sha>` |
+| Scrub check (CI mode) | `bash scrub-commit.sh --check` |
+| Diff against upstream | `git diff <upstream_remote>/main..HEAD --stat` |
+| Cross-fork PR | `gh pr create --repo <upstream_repo> --head <fork-owner>:<branch>` |
+| Patch-id of HEAD | `git show HEAD \| git patch-id --stable` |
+
+## Related Skills
+
+- [git-plugin: git-upstream-pr](../../../git-plugin/skills/git-upstream-pr/SKILL.md) — simpler cherry-pick path for low-divergence forks
+- [git-plugin: git-fork-workflow](../../../git-plugin/skills/git-fork-workflow/SKILL.md) — fork management and upstream sync
+- [git-plugin: git-conflicts](../../../git-plugin/skills/git-conflicts/SKILL.md) — conflict resolution patterns

--- a/upstream-pr-plugin/skills/upstream-pr/scripts/check-eligibility.sh
+++ b/upstream-pr-plugin/skills/upstream-pr/scripts/check-eligibility.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Check whether a commit can be cleanly cherry-picked to upstream.
+#
+# Usage: check-eligibility.sh <sha>
+#
+# A commit is "eligible" if its content is novel (not already applied
+# upstream under a different SHA) AND every file it touches already
+# exists on the upstream branch. If the commit creates a fork-only file
+# (or modifies one), the change cannot land standalone — its predecessor
+# feature must be PR'd upstream first.
+#
+# Patch-id matching catches the case where upstream has re-applied our
+# change with a different SHA (e.g. via a maintainer re-merge or
+# squash). `git patch-id --stable` produces a content hash robust
+# against rebases, cherry-picks, and trivial whitespace differences.
+#
+# Configuration (via .claude/upstream-pr.local.md or env vars):
+#   UPSTREAM_REMOTE    remote name (default: "upstream")
+#
+# Exit codes:
+#   0  every touched file exists upstream and content is novel
+#   1  at least one fork-only file
+#   2  invalid arguments / git error
+#   3  content already applied upstream under a different SHA
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$script_dir/lib/load-config.sh"
+load_upstream_pr_config
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: $0 <sha>" >&2
+    exit 2
+fi
+
+sha="$1"
+upstream_ref="${UPSTREAM_REMOTE}/main"
+
+if ! git rev-parse --verify --quiet "${sha}^{commit}" >/dev/null; then
+    echo "error: '$sha' is not a valid commit" >&2
+    exit 2
+fi
+
+if ! git rev-parse --verify --quiet "$upstream_ref" >/dev/null; then
+    # Try master as a fallback
+    if git rev-parse --verify --quiet "${UPSTREAM_REMOTE}/master" >/dev/null; then
+        upstream_ref="${UPSTREAM_REMOTE}/master"
+    else
+        echo "error: $upstream_ref not found. Run 'git fetch $UPSTREAM_REMOTE' first." >&2
+        exit 2
+    fi
+fi
+
+echo "Commit:   $(git log -1 --format='%h %s' "$sha")"
+echo "Upstream: $upstream_ref"
+echo
+
+# --- Patch-id pre-check ---------------------------------------------------
+#
+# If the commit's content already exists on the upstream branch under any
+# SHA, there is nothing to PR. Compute patch-id for the target and compare
+# against patch-ids of all non-merge commits on the upstream branch.
+
+target_patch=$(git show "$sha" | git patch-id --stable | awk '{print $1}')
+
+if [[ -n "$target_patch" ]]; then
+    # `awk ... exit` closes the pipe early on a match, which would
+    # SIGPIPE-kill the upstream patch-id producer and surface as 141
+    # under `set -o pipefail`. Disable pipefail just for this block.
+    set +o pipefail
+    match=$(
+        git log --no-merges --format=%H "$upstream_ref" \
+        | while read -r u; do
+            printf '%s %s\n' "$(git show "$u" | git patch-id --stable | awk '{print $1}')" "$u"
+          done \
+        | awk -v t="$target_patch" '$1 == t { print $2; exit }'
+    )
+    set -o pipefail
+
+    if [[ -n "$match" ]]; then
+        match_subject=$(git log -1 --format='%s' "$match")
+        echo "ALREADY APPLIED — content matches upstream commit $(git rev-parse --short "$match")"
+        echo "  (\"$match_subject\")"
+        echo
+        echo "Nothing to PR; this change is already on $upstream_ref with a different SHA."
+        exit 3
+    fi
+fi
+
+# --- File-existence check -------------------------------------------------
+
+mapfile -t touched < <(git show --name-only --format= "$sha" | sed '/^$/d')
+
+if [[ ${#touched[@]} -eq 0 ]]; then
+    echo "error: commit touches no files" >&2
+    exit 2
+fi
+
+missing=()
+for path in "${touched[@]}"; do
+    if git cat-file -e "$upstream_ref:$path" 2>/dev/null; then
+        printf '  + %s\n' "$path"
+    else
+        printf '  - %s (fork-only)\n' "$path"
+        missing+=("$path")
+    fi
+done
+
+echo
+if [[ ${#missing[@]} -eq 0 ]]; then
+    echo "ELIGIBLE — all ${#touched[@]} file(s) exist on $upstream_ref."
+    exit 0
+fi
+
+echo "NOT ELIGIBLE — ${#missing[@]} of ${#touched[@]} file(s) are fork-only:"
+for path in "${missing[@]}"; do
+    printf '  - %s\n' "$path"
+done
+echo
+echo "The predecessor feature must be PR'd upstream before this commit can land."
+exit 1

--- a/upstream-pr-plugin/skills/upstream-pr/scripts/lib/load-config.sh
+++ b/upstream-pr-plugin/skills/upstream-pr/scripts/lib/load-config.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+set -uo pipefail
+
+# Load configuration for the upstream-pr skill.
+#
+# Configuration is read in this order (later overrides earlier):
+#   1. Auto-detected defaults
+#        - upstream_remote: "upstream"
+#        - upstream_repo:   parsed from `git remote get-url <upstream_remote>`
+#        - branch_prefix:   "pr-upstream/"
+#   2. Frontmatter in .claude/upstream-pr.local.md (project-local)
+#   3. Environment variables: UPSTREAM_REMOTE, UPSTREAM_REPO, BRANCH_PREFIX,
+#                             LINTER_CMD, TEST_CMD, PR_BODY_TEMPLATE_PATH
+#
+# Sources expose these variables to the caller:
+#   UPSTREAM_REMOTE, UPSTREAM_REPO, BRANCH_PREFIX,
+#   LINTER_CMD (may be empty), TEST_CMD (may be empty),
+#   PR_BODY_TEMPLATE_PATH (may be empty)
+#
+# Intended usage:
+#   source "$(dirname "${BASH_SOURCE[0]}")/lib/load-config.sh"
+#   load_upstream_pr_config
+
+# shellcheck disable=SC2034  # variables are exported for callers
+
+extract_field() {
+    local file="$1" field="$2"
+    [[ -f "$file" ]] || return 0
+    head -50 "$file" | grep -m1 "^${field}:" | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r'
+}
+
+derive_repo_from_remote_url() {
+    local url="$1"
+    # github.com:owner/repo[.git] or https://github.com/owner/repo[.git]
+    sed -E 's#.*github\.com[:/]##; s#\.git$##' <<<"$url"
+}
+
+load_upstream_pr_config() {
+    local config_file=".claude/upstream-pr.local.md"
+
+    UPSTREAM_REMOTE="${UPSTREAM_REMOTE:-$(extract_field "$config_file" upstream_remote)}"
+    UPSTREAM_REMOTE="${UPSTREAM_REMOTE:-upstream}"
+
+    UPSTREAM_REPO="${UPSTREAM_REPO:-$(extract_field "$config_file" upstream_repo)}"
+    if [[ -z "$UPSTREAM_REPO" ]]; then
+        local url
+        url=$(git remote get-url "$UPSTREAM_REMOTE" 2>/dev/null || true)
+        if [[ -n "$url" ]]; then
+            UPSTREAM_REPO=$(derive_repo_from_remote_url "$url")
+        fi
+    fi
+
+    BRANCH_PREFIX="${BRANCH_PREFIX:-$(extract_field "$config_file" branch_prefix)}"
+    BRANCH_PREFIX="${BRANCH_PREFIX:-pr-upstream/}"
+
+    LINTER_CMD="${LINTER_CMD:-$(extract_field "$config_file" linter_cmd)}"
+    TEST_CMD="${TEST_CMD:-$(extract_field "$config_file" test_cmd)}"
+    PR_BODY_TEMPLATE_PATH="${PR_BODY_TEMPLATE_PATH:-$(extract_field "$config_file" pr_body_template_path)}"
+
+    export UPSTREAM_REMOTE UPSTREAM_REPO BRANCH_PREFIX
+    export LINTER_CMD TEST_CMD PR_BODY_TEMPLATE_PATH
+}

--- a/upstream-pr-plugin/skills/upstream-pr/scripts/prepare-branch.sh
+++ b/upstream-pr-plugin/skills/upstream-pr/scripts/prepare-branch.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Cut a branch from the upstream main branch and cherry-pick a commit onto it.
+#
+# Usage: prepare-branch.sh <topic-slug> <sha>
+#
+# Creates branch `<branch_prefix><topic-slug>` from `<upstream_remote>/main`
+# (or `/master` as fallback), attempts to cherry-pick <sha>, and reports
+# any conflicts that need manual resolution.
+#
+# Configuration (via .claude/upstream-pr.local.md or env vars):
+#   UPSTREAM_REMOTE    remote name (default: "upstream")
+#   UPSTREAM_REPO      target repo (auto-detected from remote URL)
+#   BRANCH_PREFIX      branch name prefix (default: "pr-upstream/")
+#
+# Exit codes:
+#   0  branch created and cherry-pick succeeded cleanly
+#   1  cherry-pick produced conflicts (branch exists, ready for manual resolution)
+#   2  invalid arguments, ineligible commit, or git precondition failure
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$script_dir/lib/load-config.sh"
+load_upstream_pr_config
+
+if [[ $# -ne 2 ]]; then
+    echo "usage: $0 <topic-slug> <sha>" >&2
+    exit 2
+fi
+
+topic="$1"
+sha="$2"
+branch="${BRANCH_PREFIX}${topic}"
+
+# --- Preconditions ---------------------------------------------------------
+
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "error: working tree has uncommitted changes; commit or stash first" >&2
+    exit 2
+fi
+
+if git rev-parse --verify --quiet "refs/heads/$branch" >/dev/null; then
+    echo "error: branch '$branch' already exists" >&2
+    echo "delete it with: git branch -D $branch" >&2
+    exit 2
+fi
+
+# --- Eligibility -----------------------------------------------------------
+
+echo "==> Checking eligibility..."
+elig_rc=0
+"$script_dir/check-eligibility.sh" "$sha" || elig_rc=$?
+case "$elig_rc" in
+    0) ;;
+    3)
+        echo
+        echo "Aborting — commit already applied upstream, nothing to PR." >&2
+        exit 2
+        ;;
+    *)
+        echo
+        echo "Aborting — commit is not standalone-PR-able to upstream." >&2
+        exit 2
+        ;;
+esac
+
+# --- Branch + cherry-pick --------------------------------------------------
+
+echo
+echo "==> Fetching $UPSTREAM_REMOTE..."
+git fetch "$UPSTREAM_REMOTE"
+
+# Resolve the upstream main reference (main or master).
+upstream_ref="${UPSTREAM_REMOTE}/main"
+if ! git rev-parse --verify --quiet "$upstream_ref" >/dev/null; then
+    upstream_ref="${UPSTREAM_REMOTE}/master"
+fi
+
+echo
+echo "==> Creating branch '$branch' from $upstream_ref..."
+git checkout -b "$branch" "$upstream_ref"
+
+echo
+echo "==> Cherry-picking $sha..."
+if git cherry-pick "$sha"; then
+    echo
+    echo "SUCCESS — cherry-pick clean."
+    echo
+    echo "Next steps:"
+    echo "  1. Review:  git diff $upstream_ref..HEAD"
+    echo "  2. Scrub commit message:"
+    echo "     bash $script_dir/scrub-commit.sh"
+    echo "  3. Push:    git push origin $branch"
+    if [[ -n "${UPSTREAM_REPO:-}" ]]; then
+        local_owner=$(git remote get-url origin | sed -E 's#.*github\.com[:/]##; s#\.git$##; s#/.*##')
+        echo "  4. Open PR: gh pr create --repo $UPSTREAM_REPO --base ${upstream_ref##*/} \\"
+        echo "                --head ${local_owner}:$branch ..."
+    else
+        echo "  4. Open PR: gh pr create --repo <upstream-owner/repo> --base ${upstream_ref##*/} \\"
+        echo "                --head <fork-owner>:$branch ..."
+    fi
+    exit 0
+fi
+
+echo
+echo "CONFLICTS — resolve manually, then run 'git cherry-pick --continue'."
+echo
+echo "Conflicted files:"
+git diff --name-only --diff-filter=U | sed 's/^/  - /'
+echo
+echo "Reminder: preserve upstream's surrounding shape, not ours."
+echo
+echo "If conflicts span >2 files with >20 blocks, abort and re-derive instead:"
+echo "  git cherry-pick --abort"
+echo "  git checkout -b $branch $upstream_ref"
+echo "  # Re-apply the change against upstream's actual current files."
+exit 1

--- a/upstream-pr-plugin/skills/upstream-pr/scripts/scrub-commit.sh
+++ b/upstream-pr-plugin/skills/upstream-pr/scripts/scrub-commit.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Scrub fork-local context from the most recent commit message before
+# pushing to upstream.
+#
+# Usage: scrub-commit.sh [--check]
+#
+# Without --check: opens the commit message in $EDITOR for an interactive
+# amend. Pre-fills the message with a scrub checklist appended as
+# stripped-comments so the human can edit while seeing the rules.
+#
+# With --check: reports which scrub rules the current HEAD commit message
+# violates without rewriting anything. Exit 1 if any violations found.
+#
+# The scrub rules:
+#   - Strip local issue references: "Closes #N", "Fixes #N", "Refs #N",
+#     "Addresses #N" (these point at the fork's tracker, not upstream's)
+#   - Strip Claude trailers: "Co-authored-by: Claude...",
+#     "Generated with Claude Code", "Co-Authored-By: Claude..."
+#   - Flag (but don't auto-strip) fork-specific tooling references:
+#     bandit, ty, vulture, mypy custom config — these may not apply
+#     upstream
+#   - Keep the conventional-commit prefix (fix:, feat:, etc.)
+#
+# Pre-commit hooks: upstream may have no .pre-commit-config.yaml. The
+# amend uses PRE_COMMIT_ALLOW_NO_CONFIG=1 to avoid the locally-installed
+# pre-commit hook refusing the commit.
+
+set -euo pipefail
+
+mode="amend"
+if [[ "${1:-}" == "--check" ]]; then
+    mode="check"
+fi
+
+# --- Detect violations -----------------------------------------------------
+
+msg=$(git log -1 --format='%B')
+
+issue_refs=$(grep -nE '^[[:space:]]*(Closes|Fixes|Refs|Addresses)[[:space:]]*:?[[:space:]]*#[0-9]+' <<<"$msg" || true)
+claude_trailers=$(grep -niE 'Claude (Code|Opus|Sonnet|Haiku)|Co-[Aa]uthored-[Bb]y:[[:space:]]*Claude|Generated with \[?Claude' <<<"$msg" || true)
+fork_tooling=$(grep -niE '\b(bandit|vulture|ty)\b' <<<"$msg" || true)
+
+indent_lines() {
+    awk '{print "    "$0}' <<<"$1"
+}
+
+violations=0
+[[ -n "$issue_refs" ]] && violations=$((violations + 1))
+[[ -n "$claude_trailers" ]] && violations=$((violations + 1))
+
+if [[ "$mode" == "check" ]]; then
+    if [[ "$violations" -eq 0 && -z "$fork_tooling" ]]; then
+        echo "OK — no scrub violations found."
+        exit 0
+    fi
+
+    echo "Scrub violations found in HEAD commit message:"
+    echo
+    if [[ -n "$issue_refs" ]]; then
+        echo "  Local issue references (point at fork tracker, strip before upstream PR):"
+        indent_lines "$issue_refs"
+        echo
+    fi
+    if [[ -n "$claude_trailers" ]]; then
+        echo "  Claude trailers (upstream doesn't follow this convention):"
+        indent_lines "$claude_trailers"
+        echo
+    fi
+    if [[ -n "$fork_tooling" ]]; then
+        echo "  Fork-specific tooling references (verify upstream runs these):"
+        indent_lines "$fork_tooling"
+        echo "    (advisory — describe the underlying problem if upstream doesn't run the tool)"
+        echo
+    fi
+    echo "Run 'bash $(basename "$0")' (without --check) to amend interactively."
+    exit 1
+fi
+
+# --- Interactive amend -----------------------------------------------------
+
+cat <<'EOF'
+==> Scrub checklist for upstream PR commit message:
+    1. Strip local issue refs (Closes #N, Fixes #N, Refs #N) — they point
+       at the fork's tracker, not upstream's.
+    2. Strip Claude trailers (Co-authored-by: Claude..., Generated with
+       Claude Code) — upstream doesn't follow that convention.
+    3. Soften fork-specific tooling — if the body cites a tool upstream
+       doesn't run (bandit, ty, vulture), describe the underlying
+       problem instead.
+    4. Keep the conventional-commit prefix (fix:, feat:, etc.).
+EOF
+echo
+
+if [[ -n "$issue_refs$claude_trailers$fork_tooling" ]]; then
+    echo "Detected items to consider:"
+    [[ -n "$issue_refs" ]]      && { echo "  Issue refs:";        indent_lines "$issue_refs"; }
+    [[ -n "$claude_trailers" ]] && { echo "  Claude trailers:";   indent_lines "$claude_trailers"; }
+    [[ -n "$fork_tooling" ]]    && { echo "  Fork tooling (advisory):"; indent_lines "$fork_tooling"; }
+    echo
+fi
+
+echo "Opening editor for amend..."
+PRE_COMMIT_ALLOW_NO_CONFIG=1 git -c core.commentChar='|' commit --amend


### PR DESCRIPTION
## Summary

Generalizes the in-repo `upstream-pr` skill from [`laurigates/kicad-mcp`](https://github.com/laurigates/kicad-mcp/blob/main/.claude/skills/upstream-pr/SKILL.md) into a reusable plugin. Project-agnostic via `.claude/upstream-pr.local.md` (or env overrides): upstream remote, upstream repo, branch prefix, and optional `linter_cmd` / `test_cmd` for the pre-flight regression check.

This plugin is the **heavy-divergence** counterpart to `git-plugin:git-upstream-pr`. The two coexist intentionally — `git-upstream-pr` handles the simpler cherry-pick + cross-fork PR path; `upstream-pr-plugin` adds the workflow that becomes necessary once a fork has substantially diverged.

## What's added

- **Plugin scaffold** — `upstream-pr-plugin/` with `plugin.json`, `README.md`, marketplace entry, release-please config, manifest version, and `docs/PLUGIN-MAP.md` registration.
- **Skill** (`/upstream-pr:upstream-pr`) — full workflow doc with When-to-Use, Configuration, Context, Parameters, and 7-step Execution.
- **`scripts/check-eligibility.sh`** — patch-id matching (catches re-applied content upstream under a different SHA, exit 3) plus per-file existence check (exit 1 for fork-only files).
- **`scripts/prepare-branch.sh`** — clean-tree precondition, eligibility re-check, fetch, branch from upstream/main (with master fallback), cherry-pick, conflict report, re-derive guidance when conflicts are dense.
- **`scripts/scrub-commit.sh`** — `--check` mode (CI-friendly, exits 1 on violations) plus interactive amend; detects fork-local issue refs (`Closes #N`, `Refs #N`), Claude trailers (`Co-Authored-By: Claude`, `Generated with [Claude Code]`), and advisory fork-only tooling references (bandit/ty/vulture).
- **`scripts/lib/load-config.sh`** — frontmatter loader with env override → `.claude/upstream-pr.local.md` → auto-detection from `git remote get-url`.

## Configuration

Per-project, gitignored:

```yaml
---
upstream_remote: upstream
upstream_repo: owner/repo
branch_prefix: pr-upstream/
linter_cmd: uv run ruff check
test_cmd: uv run pytest -q
pr_body_template_path: docs/UPSTREAM_PR_TEMPLATE.md
---
```

All fields optional; defaults are derived from `git remote get-url upstream`.

## Verification

- `bash scripts/plugin-compliance-check.sh upstream-pr-plugin` — all 8 columns ✅
- `bash scripts/lint-shell-scripts.sh upstream-pr-plugin` — 0 errors, 0 warnings
- `python3 scripts/audit-skill-descriptions.py --plugin upstream-pr-plugin --strict` — exit 0
- `pre-commit run --files <new files>` — all hooks pass
- Smoke-tested in `~/repos/laurigates/kicad-mcp`:
  - `load-config.sh` auto-detects `UPSTREAM_REPO=lamaalrajih/kicad-mcp` from the existing `upstream` remote ✅
  - `check-eligibility.sh` correctly reports invalid SHA (exit 2) and ELIGIBLE for HEAD ✅
- Synthetic test of `scrub-commit.sh --check`:
  - Dirty commit (Closes #74 + Claude trailer) → exit 1 with itemized report ✅
  - Clean commit → exit 0 with `OK — no scrub violations found.` ✅

## Test plan

- [ ] CI: plugin compliance / shell-lint / context-lint pass
- [ ] Manual: install via marketplace and run `/upstream-pr:upstream-pr <sha>` against the kicad-mcp fork to repro PR #53–#55 paths
- [ ] Follow-up: kicad-mcp repo can drop its in-repo `.claude/skills/upstream-pr/` after the plugin is live (per the issue author's note)

Closes #1201

🤖 Generated with [Claude Code](https://claude.com/claude-code)