### PR TITLE
docs(git-plugin): mandate --body-file for gh issue/pr bodies

### DIFF
--- a/git-plugin/skills/git-api-pr/SKILL.md
+++ b/git-plugin/skills/git-api-pr/SKILL.md
@@ -6,8 +6,8 @@ allowed-tools: Bash(gh api *), Bash(gh pr *), Bash(gh repo *), Bash(base64 *), B
 argument-hint: <files...> --title "type(scope): description"
 disable-model-invocation: true
 created: 2026-02-15
-modified: 2026-02-16
-reviewed: 2026-02-15
+modified: 2026-04-29
+reviewed: 2026-04-29
 ---
 
 ## When to Use This Skill
@@ -151,14 +151,19 @@ If this fails with "Reference already exists", report the error and suggest usin
 
 ### Step 8: Create PR
 
+When `--body` is provided, write it to a tempfile with the `Write` tool and pass `--body-file`. This sidesteps shell quoting entirely so backticks and code fences in the body render correctly. See the **Body content** rule in `github-issue-writing` for the canonical guidance.
+
 ```bash
+# Write tool → "$TMP_BODY" (no shell escaping involved)
 gh pr create \
   --repo "$REPO" \
   --head "$BRANCH" \
   --base "$BASE_BRANCH" \
   --title "$TITLE" \
-  --body "${BODY:-"Created via API — no local git operations."}"
+  --body-file "$TMP_BODY"
 ```
+
+When `--body` is unset, fall back to the trivial-body form `--body "Created via API — no local git operations."`.
 
 Add `--draft` if the flag was provided.
 

--- a/git-plugin/skills/git-commit-push-pr/SKILL.md
+++ b/git-plugin/skills/git-commit-push-pr/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: git-commit-push-pr
 created: 2025-12-16
-modified: 2026-04-25
-reviewed: 2026-03-15
+modified: 2026-04-29
+reviewed: 2026-04-29
 allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git branch *), Bash(git remote *), Bash(gh pr *), Bash(gh label *), Bash(gh repo *), Bash(gh issue *), Bash(pre-commit *), Bash(find *), Read, Edit, Grep, Glob, TodoWrite, mcp__github__create_pull_request, mcp__github__list_issues, mcp__github__get_issue
 args: "[remote-branch] [--push] [--direct] [--pr] [--draft] [--issue <num>] [--no-commit] [--range <start>..<end>] [--skip-issue-detection]"
 argument-hint: [remote-branch] [--push] [--direct] [--pr] [--draft] [--issue <num>] [--no-commit] [--range <start>..<end>] [--skip-issue-detection]
@@ -159,10 +159,13 @@ Before creating the PR, scan commit messages, diff context, and any conversation
 
 For each post-merge action identified, create a GitHub issue — **not a PR checklist item**. PR descriptions are closed and buried once a PR merges; issues remain open until resolved.
 
+Write the follow-up body to a tempfile with the `Write` tool and pass it via `--body-file`. Inline `--body "..."` mangles backticks and multi-line content via shell escaping; see the **Body content** rule in `github-issue-writing`.
+
 ```bash
+# Write tool → /tmp/follow-up.md (markdown body, no shell escaping)
 gh issue create \
   --title "[Chore] DB: Run migration for new schema" \
-  --body "Follow-up to <PR-URL>.\n\nRun: rake db:migrate in production after deploy." \
+  --body-file /tmp/follow-up.md \
   --label "chore"
 # Note the returned issue number for the PR body
 ```
@@ -175,8 +178,10 @@ Use `mcp__github__create_pull_request` with:
 - `head`: The remote branch name (e.g., `feat/auth-oauth2`)
 - `base`: `main`
 - `title`: Derived from commit message
-- `body`: Include summary, issue link if --issue provided, and a **Follow-up Issues** section listing any issues created in 5a
+- `body`: Include summary, issue link if --issue provided, and a **Follow-up Issues** section listing any issues created in 5a. The MCP tool takes the body as a JSON string parameter — no shell escaping, so backticks and code fences pass through unchanged.
 - `draft`: true if --draft flag set
+
+If falling back to `gh pr create` instead of the MCP tool, write the body to a tempfile and pass `--body-file /tmp/pr-body.md` (see the **Body content** rule in `github-issue-writing`).
 
 PR body structure when follow-up issues exist:
 

--- a/git-plugin/skills/git-pr/skill.md
+++ b/git-plugin/skills/git-pr/skill.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-01-21
-modified: 2026-04-25
-reviewed: 2026-04-25
+modified: 2026-04-29
+reviewed: 2026-04-29
 name: git-pr
 description: |
   Create pull requests with proper descriptions, labels, and issue references. Handles
@@ -144,10 +144,19 @@ Keep a list of created issue numbers to link in the PR body.
 
 ### 4. Create PR
 
+Write the PR body to a tempfile with the `Write` tool, then pass it via `--body-file`. This sidesteps shell quoting entirely — backticks, code fences, and shell metacharacters are preserved byte-for-byte. See the **Body content** rule in `github-issue-writing` for the canonical guidance and the threshold for when bare `--body "..."` is still acceptable.
+
 ```bash
+# 1) Write tool → /tmp/pr-body.md (no shell escaping involved)
+# 2) gh pr create --body-file
 gh pr create \
   --title "feat(scope): add feature" \
-  --body "$(cat <<'EOF'
+  --body-file /tmp/pr-body.md
+```
+
+Body content of `/tmp/pr-body.md`:
+
+```markdown
 ## Summary
 Brief description of what this PR does.
 
@@ -169,8 +178,6 @@ Why this change is needed.
 ## Related Issues
 Fixes #123
 Related: #456
-EOF
-)"
 ```
 
 ## PR Title Format
@@ -205,7 +212,7 @@ When on main, push to remote feature branch:
 git push origin main:feat/feature-name
 
 # Create PR with --head
-gh pr create --head feat/feature-name --base main --title "..." --body "..."
+gh pr create --head feat/feature-name --base main --title "..." --body-file /tmp/pr-body.md
 ```
 
 ## Pre-merge Checklist Guidelines
@@ -290,13 +297,13 @@ Status: Open
 
 | Action | Command |
 |--------|---------|
-| Create PR | `gh pr create --title "..." --body "..."` |
+| Create PR | `gh pr create --title "..." --body-file /tmp/pr-body.md` |
 | Draft PR | `gh pr create --draft` |
 | View PR | `gh pr view` |
-| Edit PR | `gh pr edit --title "..." --body "..."` |
+| Edit PR | `gh pr edit --title "..." --body-file /tmp/pr-body.md` |
 | List PRs | `gh pr list` |
 | Check status | `gh pr checks` |
-| Create follow-up issue | `gh issue create --title "[Chore] ..." --body "..."` |
+| Create follow-up issue | `gh issue create --title "[Chore] ..." --body-file /tmp/issue-body.md` |
 
 ## Agentic Optimizations
 
@@ -305,5 +312,5 @@ Status: Open
 | PR readiness | `gh pr view --json number,state 2>/dev/null` |
 | Commits | `git log origin/main..HEAD --format='%s'` |
 | Issue refs | `git log origin/main..HEAD --format='%B' \| grep -oE '#[0-9]+'` |
-| Create follow-up issue | `gh issue create --title "[Chore] ..." --body "Follow-up to PR #N..."` |
-| Create PR | `gh pr create --title "..." --body "..."` |
+| Create follow-up issue | `gh issue create --title "[Chore] ..." --body-file /tmp/follow-up.md` |
+| Create PR | `gh pr create --title "..." --body-file /tmp/pr-body.md` |

--- a/git-plugin/skills/github-issue-writing/skill.md
+++ b/git-plugin/skills/github-issue-writing/skill.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-01-30
-modified: 2026-04-25
-reviewed: 2026-04-25
+modified: 2026-04-29
+reviewed: 2026-04-29
 name: github-issue-writing
 description: |
   Create well-structured GitHub issues with clear titles, descriptions, and
@@ -95,24 +95,53 @@ GitHub supports first-class issue types. Use `--type` when creating issues:
 
 Note: Available types depend on repository/org configuration. Use `gh issue create --type "Bug"` to leverage them.
 
+## Body Content: Use `--body-file`
+
+For any non-trivial body — anything containing backticks, code fences, or multi-line content — use `--body-file <path>`, never `--body "<text>"`. This applies to **all** `gh` commands that accept a body: `gh issue create`, `gh issue edit`, `gh issue comment`, `gh pr create`, `gh pr edit`, `gh pr comment`.
+
+### When to use which
+
+| Body shape | Pattern |
+|---|---|
+| Trivially short, single line, no backticks | `--body "Short text"` is fine |
+| Contains backticks (inline code, code fences) | `--body-file /tmp/body.md` — required |
+| Multi-line | `--body-file /tmp/body.md` — required |
+| Contains shell metacharacters (`$`, `"`, `'`, `\`) | `--body-file /tmp/body.md` — required |
+
+### Why
+
+Shell-quoted `--body` strings escape backticks (`` ` `` becomes `` \` ``), breaking inline code spans and triple-backtick code fences in the rendered issue. Bash heredocs interact unpredictably with the agent's argument escaping. Writing the markdown to a file with the `Write` tool sidesteps shell quoting entirely — the file content is preserved byte-for-byte.
+
+### Pattern
+
+```
+1. Write tool → /tmp/issue-body.md   (markdown body, no shell escaping)
+2. gh issue create --title "..." --body-file /tmp/issue-body.md
+```
+
+The same `--body-file <path>` form is supported by every `gh` command that accepts a body.
+
 ## CLI Commands
 
 ```bash
-# Create issue
-gh issue create --title "[Bug] Auth: Login fails" --body "..."
+# Create issue with a body file (preferred for any non-trivial body)
+gh issue create --title "[Bug] Auth: Login fails" --body-file /tmp/issue-body.md
+
+# Trivially short body — inline --body is acceptable
+gh issue create --title "[Chore] Bump dep" --body "See renovate PR"
 
 # With labels
-gh issue create --title "..." --body "..." --label "bug" --label "priority: high"
+gh issue create --title "..." --body-file /tmp/body.md --label "bug" --label "priority: high"
 
 # With assignee
-gh issue create --title "..." --body "..." --assignee "@me"
+gh issue create --title "..." --body-file /tmp/body.md --assignee "@me"
 
 # With issue type
-gh issue create --title "..." --body "..." --type "Bug"
+gh issue create --title "..." --body-file /tmp/body.md --type "Bug"
 
 # As sub-issue of a parent
-gh issue create --title "..." --body "..." && \
-  gh api repos/{owner}/{repo}/issues/{parent}/sub_issues -f sub_issue_id={new_id}
+gh issue create --title "..." --body-file /tmp/body.md
+gh api repos/{owner}/{repo}/issues/{parent}/sub_issues -f sub_issue_id={new_id}
 
 # Search before creating
 gh issue list --search "login error" --state all
@@ -140,19 +169,20 @@ sidebar and on project boards.
 
 | Action | Command |
 |--------|---------|
-| Create | `gh issue create --title "..." --body "..."` |
-| Create with type | `gh issue create --title "..." --body "..." --type "Bug"` |
+| Create | `gh issue create --title "..." --body-file /tmp/body.md` |
+| Create with type | `gh issue create --title "..." --body-file /tmp/body.md --type "Bug"` |
 | Search | `gh issue list --search "keyword"` |
 | View | `gh issue view N` |
-| Edit | `gh issue edit N --title "..."` |
+| Edit body | `gh issue edit N --body-file /tmp/body.md` |
+| Comment | `gh issue comment N --body-file /tmp/comment.md` |
 | Labels | `gh label list` |
 
 ## Agentic Optimizations
 
 | Context | Command |
 |---------|---------|
-| Create issue | `gh issue create --title "..." --body "..."` |
-| Create with type | `gh issue create --title "..." --type "Bug" --body "..."` |
+| Create issue | `gh issue create --title "..." --body-file /tmp/body.md` |
+| Create with type | `gh issue create --title "..." --type "Bug" --body-file /tmp/body.md` |
 | List labels | `gh label list --json name` |
 | Search issues | `gh issue list --search "keyword" --state all --json number,title` |
 | View issue | `gh issue view N --json title,body,labels` |


### PR DESCRIPTION
Fixes #1199

## Summary

Inline `gh issue create --body "..."` and `gh pr create --body "..."` route the body through shell quoting, which escapes backticks (`` ` `` → `` \` ``) and breaks every inline code span and triple-backtick code fence in the rendered issue. The fix on the receiving end is always the same: rewrite the body to a file and re-issue with `--body-file`. This documents the rule across the PR-body skills so the agent picks the right form on the first try.

## Changes

| File | Change |
|---|---|
| `git-plugin/skills/github-issue-writing/skill.md` | Canonical **Body content: Use `--body-file`** section with the trivial-vs-non-trivial threshold; CLI / Quick Reference / Agentic Optimizations updated to use `--body-file` |
| `git-plugin/skills/git-pr/skill.md` | Step 4 rewritten as Write → tempfile → `--body-file`; Quick Reference / Agentic tables updated |
| `git-plugin/skills/git-api-pr/SKILL.md` | Step 8 uses `--body-file "$TMP_BODY"` when a body is provided; trivial default still uses inline `--body` |
| `git-plugin/skills/git-commit-push-pr/SKILL.md` | Step 5a follow-up `gh issue create` example uses `--body-file`; Step 5b notes that the MCP path is unaffected (JSON parameter, no shell) but the `gh pr create` fallback should still use `--body-file` |

## Why a single source of truth

The four PR-body skills used to repeat slightly different inline-body examples. Centralising the rule in `github-issue-writing` (and linking from the others) means future updates touch one place and the threshold for "trivial body — `--body` is fine" stays consistent.

## Test plan

- [x] `bash scripts/lint-context-commands.sh` passes
- [x] Pre-commit hooks pass (shellcheck, gitleaks, lint context commands, audit skill descriptions, configure-repo)
- [ ] Smoke-test: file a follow-up issue using the documented `--body-file` pattern and verify backticks render as code spans, not literal `` \` `` text
- [ ] Smoke-test: open a PR with a body containing a triple-backtick fenced code block and verify it renders as a fenced block

## Reference

Concrete evidence cited in the issue: ForumViriumHelsinki/infrastructure#1699 had every backtick in the issue body rendered as `` \` `` and required a manual `gh issue edit --body-file` round-trip to repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
