### PR TITLE
docs(rules): add auto-mode rule and cross-link permission references

### DIFF
--- a/.claude/rules/agentic-permissions.md
+++ b/.claude/rules/agentic-permissions.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-01-16
-modified: 2026-03-02
-reviewed: 2026-03-02
+modified: 2026-04-29
+reviewed: 2026-04-29
 paths:
   - "**/skills/**"
   - "**/SKILL.md"
@@ -10,7 +10,23 @@ paths:
 
 # Agentic Permissions
 
-Skills should use granular `allowed-tools` permissions to enable seamless, deterministic execution without interactive approval prompts.
+Skills should use granular `allowed-tools` permissions to enable seamless, deterministic execution without interactive approval prompts. The granular patterns in this rule are also the patterns that survive auto mode — see `.claude/rules/auto-mode.md`.
+
+## Permission Modes
+
+Claude Code now ships several permission modes. The relevant ones for skill authoring are:
+
+| Mode | What runs without asking | Skill-authoring impact |
+|------|--------------------------|------------------------|
+| `default` | Reads only | Granular `allowed-tools` is the only way to avoid prompts. |
+| `acceptEdits` | Reads, file edits, common filesystem commands (`mkdir`, `touch`, `mv`, `cp`, `sed`, etc.) | Bash skills still benefit from narrow `Bash(<command> *)` patterns. |
+| `auto` | Everything that survives a classifier review | Broad rules like `Bash(*)` and `Bash(python*)` are **dropped on entering auto mode**. Narrow rules like `Bash(git status *)` carry over and skip the classifier round-trip. |
+| `dontAsk` | Pre-approved tools only | Without granular `allow` rules, the skill cannot run. |
+| `bypassPermissions` | Everything except protected paths | No safety layer — granular permissions are unenforced but still document intent. |
+
+See `.claude/rules/auto-mode.md` for the full auto-mode model (decision order, dropped-rule list, conversation boundaries, subagent behaviour, deny-and-continue thresholds).
+
+**Bottom line for skill authors**: write narrow `Bash(<command> *)` patterns. They reduce prompts in `default`/`acceptEdits`, survive transition into `auto`, and are required by `dontAsk`.
 
 ## Permission Syntax
 
@@ -216,6 +232,8 @@ For projects using plugins with these patterns, recommend adding to `.claude/set
   }
 }
 ```
+
+These narrow rules carry over into auto mode and skip the classifier. Avoid broad patterns like `Bash(*)` or `Bash(python*)` — auto mode drops them at runtime, and they reduce safety in `default`/`acceptEdits`.
 
 ## Context Section Patterns
 

--- a/.claude/rules/auto-mode.md
+++ b/.claude/rules/auto-mode.md
@@ -1,0 +1,170 @@
+---
+created: 2026-04-29
+modified: 2026-04-29
+reviewed: 2026-04-29
+paths:
+  - "**/skills/**"
+  - "**/SKILL.md"
+  - "**/.claude/settings.json"
+---
+
+# Auto Mode
+
+Auto mode lets Claude Code execute without permission prompts. A separate classifier model reviews each action before it runs, blocking anything that escalates beyond the user's request, targets unrecognized infrastructure, or appears driven by hostile content.
+
+Authoritative reference: [Choose a permission mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode). This rule summarises the parts that affect how plugin skills, settings, and hooks should be authored.
+
+## Availability
+
+Auto mode is conditional on every row of this table. If any row is unmet, auto mode is unavailable on the user's machine.
+
+| Requirement | Value |
+|-------------|-------|
+| Claude Code version | `v2.1.83` or later |
+| Plan | Max, Team, Enterprise, or API (not Pro) |
+| Model | Sonnet 4.6, Opus 4.6, Opus 4.7 (Team / Enterprise / API); Opus 4.7 only on Max |
+| Provider | Anthropic API (not Bedrock, Vertex, or Foundry) |
+| Admin | On Team / Enterprise, an admin must enable it in Claude Code admin settings |
+
+Admins can lock it off project-wide by setting `permissions.disableAutoMode: "disable"` in [managed settings](https://code.claude.com/docs/en/permissions#managed-settings).
+
+A "Auto mode unavailable" message means a requirement above is unmet — it is not a transient outage. A "cannot determine the safety of an action" message is a separate transient classifier outage.
+
+## How the Classifier Decides
+
+Each tool call walks a fixed decision order. The first matching step wins:
+
+1. Actions matching the user's `allow` or `deny` rules resolve immediately
+2. Read-only actions and file edits inside the working directory are auto-approved (except writes to [protected paths](https://code.claude.com/docs/en/permission-modes#protected-paths))
+3. Everything else goes to the classifier
+4. If the classifier blocks, Claude receives the reason and tries an alternative
+
+The classifier sees user messages, tool calls, and `CLAUDE.md` content. Tool results are stripped, so hostile content in a fetched page or read file cannot manipulate the classifier directly. A separate server-side probe scans incoming tool results for suspicious content before Claude reads them.
+
+## What the Classifier Blocks by Default
+
+| Blocked by default | Allowed by default |
+|--------------------|---------------------|
+| Downloading and executing code (`curl \| bash`) | Local file operations in the working directory |
+| Sending sensitive data to external endpoints | Installing dependencies declared in lockfiles or manifests |
+| Production deploys and migrations | Reading `.env` and sending credentials to the matching API |
+| Mass deletion on cloud storage | Read-only HTTP requests |
+| Granting IAM or repo permissions | Pushing to the branch the session started on or one Claude created |
+| Modifying shared infrastructure | |
+| Irreversibly destroying files that existed before the session | |
+| Force push, or pushing directly to `main` | |
+
+Sandbox network access requests are routed through the classifier rather than allowed by default. Run `claude auto-mode defaults` to see the live rule lists. Administrators can extend the trust set for specific repos, buckets, and services via the `autoMode.environment` setting — see [Configure auto mode](https://code.claude.com/docs/en/auto-mode-config).
+
+## What Happens to Allow Rules on Entering Auto Mode
+
+Auto mode **drops broad allow rules** that would otherwise grant arbitrary code execution. They are restored when leaving auto mode.
+
+| Pattern | Behaviour in auto mode |
+|---------|------------------------|
+| `Bash(*)`, `PowerShell(*)` | Dropped |
+| Wildcarded interpreters: `Bash(python*)`, `Bash(node*)`, etc. | Dropped |
+| Package-manager run wildcards (e.g. broad `Bash(npm *)` ish patterns granting arbitrary scripts) | Dropped |
+| `Agent` allow rules | Dropped |
+| **Narrow rules**: `Bash(npm test)`, `Bash(git status *)`, `Bash(gh pr *)` | **Carried over** — skip the classifier round-trip |
+
+**Implication for skill authors**: granular `Bash(<command> *)` patterns in skill `allowed-tools` and project `settings.json` are *more* valuable under auto mode, not less — they bypass the classifier and avoid latency. Broad `Bash(*)` is not a shortcut; it is dropped at runtime.
+
+## Conversation-Stated Boundaries
+
+The classifier treats boundaries the user states in the conversation as block signals. "Don't push", "wait until I review before deploying", and similar instructions block matching actions even when default rules would allow them. A boundary stays in force until the user lifts it in a later message; Claude's own judgement that the condition was met does not lift it.
+
+Boundaries are read from the transcript on each check, so context compaction can drop them. For a hard guarantee, use a [deny rule](https://code.claude.com/docs/en/permissions#permission-rule-syntax) instead of relying on a stated boundary.
+
+## Protected Paths
+
+Writes to protected paths are never auto-approved in any mode. Under auto mode they route to the classifier rather than being silently allowed.
+
+Protected directories: `.git`, `.vscode`, `.idea`, `.husky`, `.claude` (except `.claude/commands`, `.claude/agents`, `.claude/skills`, `.claude/worktrees`).
+
+Protected files: `.gitconfig`, `.gitmodules`, `.bashrc`, `.bash_profile`, `.zshrc`, `.zprofile`, `.profile`, `.ripgreprc`, `.mcp.json`, `.claude.json`.
+
+## Subagents Under Auto Mode
+
+The classifier checks subagent work at three points:
+
+1. **Spawn**: the delegated task description is evaluated; a dangerous-looking task is blocked at spawn time.
+2. **Each action**: every tool call goes through the classifier with the same rules as the parent session.
+3. **Return**: the subagent's full action history is reviewed; flagged concerns prepend a security warning to the subagent's results.
+
+Crucially, **`permissionMode` in subagent frontmatter is ignored** in auto mode. Skill authors should not rely on per-subagent permission overrides under auto mode; rely on `allowed-tools` for the subagent's tool boundary instead.
+
+## Deny-and-Continue Behaviour
+
+When the classifier blocks an action:
+
+1. The action is denied and a notification surfaces in `/permissions` under "Recently denied"
+2. The user can press `r` to retry it with a manual approval
+3. Claude receives the reason and tries an alternative
+
+If blocking happens **3 times in a row** or **20 times total** in a session, auto mode pauses and Claude Code resumes prompting. Approving the prompted action resumes auto mode. Any allowed action resets the consecutive counter; the total counter persists for the session and only resets when its own threshold triggers a fallback. These thresholds are not configurable.
+
+In `-p` (non-interactive) mode there is no user to prompt — repeated blocks abort the session.
+
+## Cost and Latency
+
+Each classifier check adds a round-trip and consumes tokens against the user's quota. Reads and working-directory edits skip the classifier, so the overhead lands mainly on shell commands and network operations. Narrow `allow` rules in `settings.json` and skill `allowed-tools` reduce that overhead by short-circuiting step 1 of the decision order.
+
+## Authoring Guidance for Plugin Skills
+
+| Skill area | Guidance under auto mode |
+|------------|--------------------------|
+| `allowed-tools` in frontmatter | Keep narrow `Bash(<command> *)` patterns. They carry over, skip the classifier round-trip, and remain the subagent tool boundary. Broad `Bash(*)` is dropped at runtime — do not rely on it. |
+| `:ask` suffix | Still useful for genuinely dangerous operations the user should always confirm regardless of mode. |
+| Hostile-content surface | Tool results are stripped from classifier input, but skill-emitted text the user reads is not. Continue to validate web fetches and untrusted file content as usual. |
+| Subagent skills | Do not rely on `permissionMode` in subagent frontmatter under auto mode — it is ignored. Lean on narrow `allowed-tools` and `allow`/`deny` rules. |
+| Stated boundaries | If a skill's prompts ask the user to set a boundary ("I won't push until you say so"), document that the boundary can be lost on context compaction; suggest a deny rule for hard guarantees. |
+| Project `settings.json` | Keep narrow `Bash(git *)`, `Bash(gh *)`, `Bash(fd *)`, etc. patterns. They are not redundant under auto mode. |
+
+## Project `settings.json` Recommendation
+
+Under auto mode, narrow allow rules still earn their keep:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(git status *)",
+      "Bash(git diff *)",
+      "Bash(gh pr *)",
+      "WebFetch(domain:your-docs-site.com)",
+      "mcp__your-mcp-server"
+    ]
+  }
+}
+```
+
+Avoid broad patterns such as `Bash(*)` — they are dropped on entering auto mode and provide no benefit while reducing safety in other modes.
+
+## PermissionRequest Hooks Under Auto Mode
+
+The auto-mode classifier handles approve/deny logic for most cases that previously needed a `PermissionRequest` hook. Hooks remain valuable for:
+
+- Deterministic, auditable rules where the classifier's probabilistic answer is unsuitable
+- Enterprise compliance requirements that need explicit deny lists
+- Project-specific policies beyond the default trust set
+- Cases where a 0% false-positive guarantee on a specific command matters
+
+`PermissionRequest` hooks coexist with auto mode. See [`hooks-plugin/skills/hooks-permission-request-hook`](../../hooks-plugin/skills/hooks-permission-request-hook/SKILL.md) for the generator and [`.claude/rules/hooks-reference.md`](hooks-reference.md) for hook event reference.
+
+## Mode Interaction Summary
+
+| Permission mode | Auto-approves | Notes |
+|-----------------|---------------|-------|
+| `default` | Reads only | Permission prompts for everything else |
+| `acceptEdits` | Reads, file edits, common filesystem commands | Edits scoped to working dir / `additionalDirectories` |
+| `plan` | Reads only; no source edits | Approve-from-plan can transition into `auto` |
+| `auto` | Everything that survives classifier review | Subject to availability matrix above |
+| `dontAsk` | Pre-approved tools only | Auto-denies anything that would prompt |
+| `bypassPermissions` | Everything (except protected paths) | No safety classifier; isolated environments only |
+
+## Related Rules
+
+- `.claude/rules/agentic-permissions.md` — granular permission syntax and standard sets
+- `.claude/rules/skill-development.md` — skill creation patterns and `allowed-tools` usage
+- `.claude/rules/hooks-reference.md` — hook event reference, including `PermissionRequest`

--- a/.claude/rules/skill-development.md
+++ b/.claude/rules/skill-development.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-20
-modified: 2026-03-09
-reviewed: 2026-03-09
+modified: 2026-04-29
+reviewed: 2026-04-29
 paths:
   - "**/skills/**"
   - "**/SKILL.md"
@@ -136,6 +136,15 @@ Skills inherit the user's active model by default. Do not set `model:` in skill 
 | CLI tool | `Bash, Read, Grep, Glob, TodoWrite` |
 | Development | `Bash, BashOutput, Read, Write, Edit, Grep, Glob, TodoWrite` |
 | Research | `Read, WebFetch, WebSearch, Grep, Glob` |
+
+### Permission Patterns
+
+When listing `Bash` in `allowed-tools`, prefer narrow `Bash(<command> *)` permission rules in the project's `.claude/settings.json` over broad wildcards:
+
+- Narrow rules survive the transition into auto mode and skip the auto-classifier round-trip on each call.
+- Broad rules (`Bash(*)`, `Bash(python*)`) are dropped at runtime when auto mode is active.
+
+See `.claude/rules/agentic-permissions.md` for canonical patterns and `.claude/rules/auto-mode.md` for the full auto-mode model.
 
 ## Content Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ Claude Code plugin collection providing skills and agents for development workfl
 | `.claude/rules/skill-naming.md` | Skill namespace conventions |
 | `.claude/rules/shell-scripting.md` | Safe shell patterns and frontmatter extraction |
 | `.claude/rules/agentic-permissions.md` | Granular tool permissions for skills |
+| `.claude/rules/auto-mode.md` | Auto mode availability, classifier rules, allow-rule fate, and authoring guidance |
 | `.claude/rules/skill-quality.md` | Skill size limits, required sections, and quality checklist |
 | `.claude/rules/skill-execution-structure.md` | Imperative execution patterns for user-invocable skills |
 | `.claude/rules/handling-blocked-hooks.md` | How to respond when hooks block commands |

--- a/hooks-plugin/skills/hooks-permission-request-hook/SKILL.md
+++ b/hooks-plugin/skills/hooks-permission-request-hook/SKILL.md
@@ -9,8 +9,8 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash, TodoWrite
 argument-hint: "--strict to deny unknown commands, --category git|test|lint|build|gh|deny"
 disable-model-invocation: true
 created: 2026-03-13
-modified: 2026-03-30
-reviewed: 2026-03-30
+modified: 2026-04-29
+reviewed: 2026-04-29
 ---
 
 # /hooks:permission-request-hook
@@ -25,6 +25,17 @@ Generate a `PermissionRequest` hook that auto-approves safe operations, auto-den
 | Replacing `--dangerouslySkipPermissions` with targeted rules | Need general hooks knowledge or debugging |
 | Setting up project-specific permission automation | Writing entirely custom hook logic from scratch |
 | You need a test harness to validate approve/deny behavior | Understanding hook lifecycle events |
+
+### Auto Mode vs `PermissionRequest` Hook
+
+Auto mode (Claude Code 2.1.83+) routes most approve/deny decisions through a classifier model. It overlaps with — but does not replace — a `PermissionRequest` hook. Choose this skill when you need any of:
+
+- **Deterministic, auditable rules** — the classifier's probabilistic answer is unsuitable for compliance contexts
+- **Project-specific deny lists** that go beyond the default trust set
+- **Hard 0% false-positive guarantees** for specific commands (the hook is exact, the classifier is not)
+- **Pre-approve narrow patterns** so they skip the classifier round-trip and avoid latency/token cost
+
+Hooks coexist with auto mode — they fire alongside the classifier. See `.claude/rules/auto-mode.md` for the full auto-mode model and how it interacts with allow rules and subagents.
 
 ## Context
 


### PR DESCRIPTION
## Summary

- Adds `.claude/rules/auto-mode.md` covering availability, classifier decision order, allow-rule fate on entering auto mode, conversation-stated boundaries, protected paths, subagent behaviour, deny-and-continue thresholds, and authoring guidance for plugin skills.
- Updates `agentic-permissions.md` with a Permission Modes table (correctly noting that broad `Bash(*)` patterns are dropped under auto mode while narrow `Bash(<command> *)` patterns carry over) and a cross-link to the new rule.
- Updates `skill-development.md` with a Permission Patterns note that prefers narrow Bash patterns and links to the new rule.
- Updates `hooks-permission-request-hook/SKILL.md` with an "Auto Mode vs `PermissionRequest` Hook" comparison so authors choose the right tool for deterministic deny lists vs probabilistic classifier decisions.
- Indexes `auto-mode.md` in the project `CLAUDE.md` rules table.

## Test plan

- [x] `bash scripts/plugin-compliance-check.sh` — all plugins green (only pre-existing `tools-plugin/generate-image` argument-hint warning).
- [x] `bash scripts/lint-context-commands.sh` — only pre-existing `jq-on-optional-settings` warnings unrelated to this change.
- [ ] Manual read-through to confirm cross-links resolve and Permission Modes table reflects current Claude Code behaviour.

https://claude.ai/code/session_01LQ9MyFfkWstvvZBuLuooTf

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQ9MyFfkWstvvZBuLuooTf)_