### PR TITLE
fix(hooks-plugin): drop standalone === from conflict-marker regex

### DIFF
--- a/hooks-plugin/hooks/task-completeness.sh
+++ b/hooks-plugin/hooks/task-completeness.sh
@@ -45,6 +45,13 @@ if [ "$DIFF_TODOS" -gt 0 ]; then
 fi
 
 # Check 2: Look for conflict markers in changed files
+#
+# Real merge markers come paired (<<<<<<< … ======= … >>>>>>>), so any
+# conflict — fully unresolved or partially resolved — leaves at least
+# one of <<<<<<< or >>>>>>> behind. Standalone `=======` lines have too
+# many legitimate non-conflict uses (decorative dividers in fenced code
+# blocks, console-output examples, ASCII art) and were the dominant
+# false-positive signal, so they are intentionally excluded.
 CONFLICT_FILES=$(
     {
         git -C "$CWD" diff --name-only 2>/dev/null || true
@@ -52,7 +59,7 @@ CONFLICT_FILES=$(
     } | sort -u | while IFS= read -r file; do
         [ -z "$file" ] && continue
         [ -f "$CWD/$file" ] || continue
-        if grep -lE '^(<{7}|={7}|>{7})' "$CWD/$file" >/dev/null 2>&1; then
+        if grep -lE '^(<{7}|>{7})' "$CWD/$file" >/dev/null 2>&1; then
             echo "$file"
         fi
     done

--- a/hooks-plugin/hooks/test-task-completeness.sh
+++ b/hooks-plugin/hooks/test-task-completeness.sh
@@ -156,6 +156,55 @@ assert_not_contains "conflict output does not leak prompt text" "Respond with ON
 git -C "$TMPDIR" restore --staged conflict.txt 2>/dev/null || git -C "$TMPDIR" reset HEAD conflict.txt 2>/dev/null || true
 rm -f "$TMPDIR/conflict.txt"
 
+# Regression: standalone `=======` divider lines (decorative separators in
+# fenced code blocks, console-output examples, ASCII art) must NOT be flagged
+# as merge conflicts. Real conflicts always leave at least one of <<<<<<< or
+# >>>>>>> behind, even after a partial resolution.
+cat > "$TMPDIR/dividers.md" <<'DIVIDERS'
+Expected output:
+```
+==================================================
+Setup Validation
+==================================================
+All checks passed
+```
+DIVIDERS
+git -C "$TMPDIR" add dividers.md
+
+output=$(run_hook_output "$TMPDIR")
+assert_not_contains "standalone === dividers do NOT emit a block decision" '"decision"' "$output"
+
+git -C "$TMPDIR" restore --staged dividers.md 2>/dev/null || git -C "$TMPDIR" reset HEAD dividers.md 2>/dev/null || true
+rm -f "$TMPDIR/dividers.md"
+
+# Regression: an orphan <<<<<<< marker (left behind after a partial conflict
+# resolution that removed ======= and >>>>>>>) must still be flagged.
+cat > "$TMPDIR/orphan-open.txt" <<'ORPHAN_OPEN'
+<<<<<<< HEAD
+local change
+ORPHAN_OPEN
+git -C "$TMPDIR" add orphan-open.txt
+
+output=$(run_hook_output "$TMPDIR")
+assert_contains "orphan <<<<<<< marker still emits a block decision" '"decision"' "$output"
+
+git -C "$TMPDIR" restore --staged orphan-open.txt 2>/dev/null || git -C "$TMPDIR" reset HEAD orphan-open.txt 2>/dev/null || true
+rm -f "$TMPDIR/orphan-open.txt"
+
+# Regression: an orphan >>>>>>> marker (left behind after a partial conflict
+# resolution that removed <<<<<<< and =======) must still be flagged.
+cat > "$TMPDIR/orphan-close.txt" <<'ORPHAN_CLOSE'
+remote change
+>>>>>>> main
+ORPHAN_CLOSE
+git -C "$TMPDIR" add orphan-close.txt
+
+output=$(run_hook_output "$TMPDIR")
+assert_contains "orphan >>>>>>> marker still emits a block decision" '"decision"' "$output"
+
+git -C "$TMPDIR" restore --staged orphan-close.txt 2>/dev/null || git -C "$TMPDIR" reset HEAD orphan-close.txt 2>/dev/null || true
+rm -f "$TMPDIR/orphan-close.txt"
+
 # ── debugging artifacts ───────────────────────────────────────────────────────
 echo ""
 echo "debugging artifact detection:"


### PR DESCRIPTION
## Summary

The task-completeness Stop hook (`hooks-plugin/hooks/task-completeness.sh:55`) was matching any line starting with seven or more `<`, `=`, or `>` characters as a merge conflict marker. Standalone `=======` dividers — common in fenced code blocks showing console output, ASCII separators, and Markdown examples — triggered the hook with `Unresolved merge conflict markers found in: …` even though no merge had ever happened.

Real merge conflicts always pair an opener with a closer, so dropping the standalone `=======` rule is safe:

- Fully unresolved conflicts retain `<<<<<<<` **and** `>>>>>>>`
- Partially resolved conflicts retain at least one of the two (orphan opener or orphan closer)

Decorative `=======` lines have too many legitimate non-conflict uses to remain a reliable signal.

## Concrete trigger

While initializing Blueprint structure in another repo, six work-order markdown files containing setup-validator sample output were migrated via `git mv`. Three of them tripped the hook with content like:

```
==================================================
Setup Validation
==================================================
```

The files contained no `<<<<<<<` or `>>>>>>>` — only the `===` dividers — and Stop fired with `level: suggestion, preventedContinuation: false`. So the hook didn't actually block, but it surfaced a confusing false-positive notice as a user message every time work was about to wrap.

## Change

`hooks-plugin/hooks/task-completeness.sh`:

```diff
- if grep -lE '^(<{7}|={7}|>{7})' "$CWD/$file" >/dev/null 2>&1; then
+ if grep -lE '^(<{7}|>{7})' "$CWD/$file" >/dev/null 2>&1; then
```

Plus a doc comment explaining the rationale.

## Tests

`hooks-plugin/hooks/test-task-completeness.sh` — three new regression tests using the same JSON-output assertion pattern as the existing conflict-marker test (`assert_contains '"decision"' "$output"`):

| Case | Input | Expected |
|---|---|---|
| Standalone `===` dividers | Markdown code block with `===` separator lines | **No** block decision emitted |
| Orphan `<<<<<<<` | File with `<<<<<<< HEAD` but no `>>>>>>>` (partial resolution remnant) | Block decision emitted |
| Orphan `>>>>>>>` | File with `>>>>>>> main` but no `<<<<<<<` (partial resolution remnant) | Block decision emitted |

Local run after the change:

```
merge conflict marker detection:
  PASS: conflict output has 'decision' field
  PASS: conflict output does not leak prompt text
  PASS: standalone === dividers do NOT emit a block decision
  PASS: orphan <<<<<<< marker still emits a block decision
  PASS: orphan >>>>>>> marker still emits a block decision
…
Results: 14 passed, 5 failed
```

The 5 failures are **pre-existing on `main`** — they assert `exit_code == 2` but the hook implementation uses JSON-output blocking via `exit 0` + `{"decision":"block"}`. Verified by running the suite on clean `main` before this change: same 5 failures. Worth a follow-up PR to convert those assertions to the working `assert_contains '"decision"'` pattern.

## Test plan

- [x] Bash regression suite passes for the three new cases
- [x] Existing triplet conflict test still asserts `'"decision"'` in output (no regression)
- [x] No change to TODO/FIXME, debugger, edge-case, or env-override paths
- [ ] Reviewer eyeballs the comment block to confirm the partial-resolution argument matches their mental model

🤖 Generated with [Claude Code](https://claude.com/claude-code)
