### PR TITLE
feat(obsidian-plugin): cover full Obsidian CLI surface and add upstream-doc tracker

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -432,7 +432,7 @@
     {
       "name": "obsidian-plugin",
       "source": "./obsidian-plugin",
-      "description": "Obsidian CLI operations - vault management, search, properties, tasks, plugins, publish, and sync",
+      "description": "Obsidian CLI operations - vault files, search, properties, tasks, plugins/themes, publish/sync, bases, command palette, file history, dev tools, workspaces, multi-vault, templates, and bookmarks",
       "version": "1.3.1",
       "keywords": [
         "obsidian",
@@ -443,7 +443,13 @@
         "daily-notes",
         "properties",
         "publish",
-        "sync"
+        "sync",
+        "bases",
+        "command-palette",
+        "file-recovery",
+        "workspaces",
+        "templates",
+        "bookmarks"
       ],
       "category": "development"
     },

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -35,6 +35,7 @@ Claude: PR review
 PR: Auto-resolve conflicts
 PR: Enforce conventional commits
 Plugin: Lint skills
+Plugin: Obsidian CLI changelog review
 Plugin: PR checks
 Plugin: Scheduled audits
 Plugin: Skill splitter

--- a/.github/workflows/obsidian-cli-changelog.yml
+++ b/.github/workflows/obsidian-cli-changelog.yml
@@ -1,0 +1,248 @@
+name: "Plugin: Obsidian CLI changelog review"
+
+on:
+  schedule:
+    # Weekly on Tuesdays at 09:00 UTC (offset from the Claude Code review)
+    - cron: '0 9 * * 2'
+  workflow_dispatch:
+    inputs:
+      force_full_review:
+        description: 'Force review even when the doc hash is unchanged'
+        required: false
+        default: 'false'
+        type: boolean
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
+env:
+  CLI_DOC_URL: https://publish-01.obsidian.md/access/f786db9fac45774fa4f0d8112e232d67/Extending%20Obsidian/Obsidian%20CLI.md
+  RELEASES_URL: https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/desktop-releases.json
+  TRACKING_FILE: .obsidian-cli-version-check.json
+
+jobs:
+  check-cli-doc:
+    runs-on: ubuntu-latest
+    outputs:
+      has_updates: ${{ steps.compare.outputs.has_updates }}
+      latest_sha: ${{ steps.fetch.outputs.latest_sha }}
+      previous_sha: ${{ steps.read_tracked.outputs.previous_sha }}
+      latest_obsidian_version: ${{ steps.releases.outputs.latest_version }}
+      previous_obsidian_version: ${{ steps.read_tracked.outputs.previous_version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+
+      - name: Fetch Obsidian CLI doc
+        id: fetch
+        run: |
+          curl -sSLf "$CLI_DOC_URL" -o /tmp/obs-cli.md
+          SHA=$(sha256sum /tmp/obs-cli.md | awk '{print $1}')
+          if [ -z "$SHA" ]; then
+            echo "::error::Failed to hash Obsidian CLI doc"
+            exit 1
+          fi
+          echo "latest_sha=$SHA" >> $GITHUB_OUTPUT
+          echo "Fetched CLI doc, sha256=$SHA"
+
+      - name: Fetch latest Obsidian desktop version
+        id: releases
+        run: |
+          # Best-effort — the CLI doc hash drives change detection; this is informational metadata
+          VERSION=$(curl -sSLf "$RELEASES_URL" | jq -r '.latestVersion // empty')
+          if [ -z "$VERSION" ]; then
+            VERSION="unknown"
+          fi
+          echo "latest_version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Latest Obsidian desktop: $VERSION"
+
+      - name: Read tracked state
+        id: read_tracked
+        run: |
+          if [ -f "$TRACKING_FILE" ]; then
+            PREV_SHA=$(jq -r '.lastCheckedDocSha256 // ""' "$TRACKING_FILE")
+            PREV_VER=$(jq -r '.lastSeenObsidianVersion // "unknown"' "$TRACKING_FILE")
+          else
+            PREV_SHA=""
+            PREV_VER="unknown"
+          fi
+          echo "previous_sha=$PREV_SHA" >> $GITHUB_OUTPUT
+          echo "previous_version=$PREV_VER" >> $GITHUB_OUTPUT
+          echo "Tracked sha=$PREV_SHA version=$PREV_VER"
+
+      - name: Compare hashes
+        id: compare
+        run: |
+          LATEST="${{ steps.fetch.outputs.latest_sha }}"
+          TRACKED="${{ steps.read_tracked.outputs.previous_sha }}"
+          FORCE="${{ inputs.force_full_review }}"
+
+          if [ "$FORCE" = "true" ]; then
+            echo "Forced full review requested"
+            echo "has_updates=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          if [ "$LATEST" != "$TRACKED" ]; then
+            echo "CLI doc changed: $TRACKED -> $LATEST"
+            echo "has_updates=true" >> $GITHUB_OUTPUT
+          else
+            echo "No changes since $TRACKED"
+            echo "has_updates=false" >> $GITHUB_OUTPUT
+          fi
+
+  claude-review:
+    needs: check-cli-doc
+    if: needs.check-cli-doc.outputs.has_updates == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          fetch-depth: 0
+
+      - name: Review CLI doc changes and apply updates
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--model sonnet --max-turns 40"
+          prompt: |
+            You are reviewing changes to the Obsidian CLI documentation page.
+
+            - Doc URL (raw markdown): ${{ env.CLI_DOC_URL }}
+            - Doc URL (human): https://obsidian.md/help/cli
+            - Previous tracked SHA-256: ${{ needs.check-cli-doc.outputs.previous_sha }}
+            - Latest SHA-256: ${{ needs.check-cli-doc.outputs.latest_sha }}
+            - Previous Obsidian version: ${{ needs.check-cli-doc.outputs.previous_obsidian_version }}
+            - Latest Obsidian version: ${{ needs.check-cli-doc.outputs.latest_obsidian_version }}
+
+            ## Step 1: Fetch the current CLI doc
+
+            Use WebFetch (or `curl` via Bash) to retrieve the markdown source at
+            the doc URL above. The page lives behind an SPA — the raw markdown
+            URL is the canonical source.
+
+            Save it to `/tmp/obs-cli.md`. Read the full file.
+
+            ## Step 2: Diff against the existing skills
+
+            The obsidian-plugin lives at `obsidian-plugin/`. Each CLI-wrapping
+            skill is at `obsidian-plugin/skills/<name>/SKILL.md`:
+
+            | CLI area | Skill |
+            |----------|-------|
+            | Files, folders, daily, random, unique, wordcount, web, file/folder info, rename, --copy, version/reload/restart | `vault-files` |
+            | search, search:context, search:open, tags, tag, links, backlinks, unresolved, orphans, deadends, outline | `search-discovery` |
+            | properties, property:set/remove/read, aliases | `properties` |
+            | tasks, task | `tasks` |
+            | plugins, plugin:*, plugins:enabled, plugins:restrict, themes, theme:*, snippets, snippet:* | `plugins-themes` |
+            | publish:*, sync, sync:status, sync:deleted | `publish-sync` |
+            | bases, base:* | `bases` |
+            | commands, command, hotkeys, hotkey | `command-palette` |
+            | diff, history, history:*, sync:history, sync:read, sync:restore, sync:open | `file-history` |
+            | devtools, eval, dev:* | `dev-tools` |
+            | workspace, workspaces, workspace:*, tabs, tab:open, recents | `workspaces` |
+            | vault, vaults, vault:open, vault= prefix | `vault-management` |
+            | templates, template:read, template:insert | `templates` |
+            | bookmarks, bookmark | `bookmarks` |
+
+            For every command/flag/parameter in the new CLI doc, decide:
+
+            - **Already covered** — present in the matching skill, with current syntax. No change.
+            - **Drift** — covered but with outdated syntax, missing flags, or wrong examples. Fix in place.
+            - **New** — not yet documented. Add to the matching skill, or, for a wholly new command group, propose a new skill.
+            - **Removed upstream** — present in the skill but gone from the doc. Remove with a brief inline note.
+
+            For drift and additions, **edit the existing SKILL.md** rather than
+            creating a new file unless a new top-level command group emerged.
+
+            ## Step 3: Update the tracking file
+
+            Read `${{ env.TRACKING_FILE }}` and update it:
+
+            - `lastCheckedDocSha256`: `${{ needs.check-cli-doc.outputs.latest_sha }}`
+            - `lastCheckedDate`: today's date (YYYY-MM-DD)
+            - `lastSeenObsidianVersion`: `${{ needs.check-cli-doc.outputs.latest_obsidian_version }}`
+            - Prepend a new entry to `reviewedChanges` with:
+              - `date`
+              - `obsidianVersion`
+              - `docSha256`
+              - `summary` (one paragraph: what changed in the doc)
+              - `addedSkills` (paths) — only if a new skill was created
+              - `updatedSkills` (paths) — every skill you edited
+              - `followUpIssues` (numbers) — for anything you opened a separate issue for
+
+            ## Step 4: Bump skill `modified` and `reviewed` dates
+
+            For every SKILL.md you edited, set `modified` and `reviewed` to today's date.
+
+            ## Step 5: If a new top-level command group exists, create a new skill
+
+            Use the existing skill template (frontmatter + "When to Use" decision
+            table + sections + Agentic Optimizations table + Related Skills). See
+            `.claude/rules/skill-quality.md` for the required-sections checklist.
+            Keep SKILL.md under 500 lines.
+
+            Also update:
+            - `obsidian-plugin/README.md` (add to skills list)
+            - `obsidian-plugin/.claude-plugin/plugin.json` (keywords/description if scope changed)
+            - `.claude-plugin/marketplace.json` (description/keywords if scope changed)
+
+            ## Step 6: Branch, commit, PR
+
+            1. Create branch: `chore/obsidian-cli-review-${{ needs.check-cli-doc.outputs.latest_sha }}` (truncate to first 12 chars of the sha for the branch suffix).
+            2. Stage modified files: `${{ env.TRACKING_FILE }}` plus every SKILL.md / README / plugin.json / marketplace.json you touched.
+            3. Commit with a conventional message:
+               - For doc-drift fixes only: `docs(obsidian-plugin): sync CLI skills with upstream doc <sha-prefix>`
+               - For new skills: `feat(obsidian-plugin): cover new CLI commands from upstream doc <sha-prefix>`
+               - For removals: `refactor(obsidian-plugin): drop removed CLI commands from upstream doc <sha-prefix>`
+            4. Push: `git push -u origin <branch-name>`
+            5. Create a draft PR with a summary of what changed in the doc and which skills were touched. Title must follow conventional commit format and match the commit type.
+
+            ## Step 7: Open follow-up issues for non-trivial work
+
+            If the doc reveals work that doesn't belong in this PR (a new
+            command group needing a fresh skill design, a major refactor,
+            a breaking syntax change requiring a major version bump), open a
+            GitHub issue per follow-up via `gh issue create` with label
+            `obsidian-cli-review`.
+
+            ## Important rules
+
+            - Read `.claude/rules/conventional-commits.md` for commit format.
+            - Read `.claude/rules/skill-quality.md` and `.claude/rules/skill-development.md` before editing skills.
+            - Do NOT amend existing commits — create new commits.
+            - Be conservative: only modify a skill when the doc actually contradicts or extends it.
+            - Use `Bash(obsidian *)` permission patterns in any new skill's `allowed-tools`.
+          additional_permissions: |
+            Read
+            Write
+            Edit
+            Grep
+            Glob
+            TodoWrite
+            WebFetch
+            Bash(curl *)
+            Bash(sha256sum *)
+            Bash(jq *)
+            Bash(git status *)
+            Bash(git diff *)
+            Bash(git log *)
+            Bash(git show *)
+            Bash(git add *)
+            Bash(git commit *)
+            Bash(git push *)
+            Bash(git checkout *)
+            Bash(git branch *)
+            Bash(gh pr *)
+            Bash(gh issue *)
+          plugin_marketplaces: |
+            https://github.com/laurigates/claude-plugins.git
+          plugins: |
+            project-plugin@laurigates-claude-plugins
+            obsidian-plugin@laurigates-claude-plugins
+            configure-plugin@laurigates-claude-plugins

--- a/.obsidian-cli-version-check.json
+++ b/.obsidian-cli-version-check.json
@@ -1,0 +1,32 @@
+{
+  "_comment": "Tracks the Obsidian CLI documentation page so the obsidian-cli-changelog workflow can detect upstream changes and propose skill/README updates. See .github/workflows/obsidian-cli-changelog.yml.",
+  "docUrl": "https://publish-01.obsidian.md/access/f786db9fac45774fa4f0d8112e232d67/Extending%20Obsidian/Obsidian%20CLI.md",
+  "humanUrl": "https://obsidian.md/help/cli",
+  "lastCheckedDocSha256": "1544d5de218c9a84bb44666c6a19e35b6635532c0a853cd3721f2f6912207c75",
+  "lastCheckedDate": "2026-04-30",
+  "lastSeenObsidianVersion": "1.12.7",
+  "reviewedChanges": [
+    {
+      "date": "2026-04-30",
+      "obsidianVersion": "1.12.7",
+      "docSha256": "1544d5de218c9a84bb44666c6a19e35b6635532c0a853cd3721f2f6912207c75",
+      "summary": "Initial comprehensive coverage of the Obsidian CLI surface.",
+      "addedSkills": [
+        "bases",
+        "command-palette",
+        "file-history",
+        "dev-tools",
+        "workspaces",
+        "vault-management",
+        "templates",
+        "bookmarks"
+      ],
+      "updatedSkills": [
+        "vault-files",
+        "search-discovery",
+        "plugins-themes",
+        "publish-sync"
+      ]
+    }
+  ]
+}

--- a/obsidian-plugin/.claude-plugin/plugin.json
+++ b/obsidian-plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "obsidian-plugin",
   "version": "1.3.1",
-  "description": "Obsidian CLI operations - vault management, search, properties, tasks, plugins, publish, and sync",
+  "description": "Obsidian CLI operations - vault files, search, properties, tasks, plugins/themes, publish/sync, bases, command palette, file history, dev tools, workspaces, multi-vault, templates, and bookmarks",
   "keywords": [
     "obsidian",
     "vault",
@@ -13,6 +13,12 @@
     "properties",
     "frontmatter",
     "publish",
-    "sync"
+    "sync",
+    "bases",
+    "command-palette",
+    "file-recovery",
+    "workspaces",
+    "templates",
+    "bookmarks"
   ]
 }

--- a/obsidian-plugin/README.md
+++ b/obsidian-plugin/README.md
@@ -99,12 +99,133 @@ Plugin lifecycle and theme management with developer tools.
 
 Obsidian Publish and Sync service management.
 
-**When to use**: User mentions publishing notes, Obsidian Publish workflows, or checking sync status.
+**When to use**: User mentions publishing notes, Obsidian Publish workflows, checking sync status, or recovering sync-deleted files.
 
 **Capabilities**:
-- List, add, and remove published notes
-- Check Obsidian Sync status
-- Batch publishing workflows
+- Publish site info, list/add/remove published notes, change set, open published page
+- Sync pause/resume, status & usage, sync-deleted file listing
+- Cross-links to `file-history` for per-file sync version restore
+
+---
+
+### Bases
+**File**: `skills/bases/SKILL.md`
+
+Query and create entries in Obsidian Bases — the database-over-notes feature.
+
+**When to use**: User mentions Obsidian Bases, `.base` files, querying notes as a database, base views, or structured note queries.
+
+**Capabilities**:
+- List `.base` files and their views
+- Query a view as JSON / CSV / TSV / Markdown / paths
+- Create new entries directly into a base view
+
+---
+
+### Command Palette
+**File**: `skills/command-palette/SKILL.md`
+
+Run any Obsidian command (built-in or plugin-registered) and inspect hotkeys.
+
+**When to use**: User wants to trigger a command they would normally pick from the command palette, enumerate plugin-registered commands, or look up a hotkey.
+
+**Capabilities**:
+- List, filter, and execute commands by ID
+- List and look up hotkey bindings
+- Discover plugin-registered commands
+
+---
+
+### File History
+**File**: `skills/file-history/SKILL.md`
+
+Diff and restore previous versions from File Recovery and Sync history. Critical safety net for agentic edits.
+
+**When to use**: User mentions undo, restoring a previous version, file recovery, version history, or comparing what changed.
+
+**Capabilities**:
+- `diff` across local + sync versions, with `from`/`to` and source filter
+- Local File Recovery list, read, and restore
+- Sync version list, read, restore, and deleted-files recovery
+
+---
+
+### Dev Tools
+**File**: `skills/dev-tools/SKILL.md`
+
+Developer commands for plugin and theme development — DevTools, Chrome DevTools Protocol, eval, captured console/error buffers, CSS and DOM inspection, mobile emulation, and screenshots.
+
+**When to use**: User is developing a plugin or theme, debugging the Obsidian app, or needs to introspect the running renderer state.
+
+**Capabilities**:
+- Toggle DevTools, attach/detach CDP debugger, run CDP methods
+- Run JavaScript via `eval`, inspect captured console / errors
+- Query CSS rules with source location and DOM elements
+- Mobile emulation toggle and screenshots
+
+---
+
+### Workspaces
+**File**: `skills/workspaces/SKILL.md`
+
+Inspect and manage the Obsidian editor workspace, tabs, recents, and saved layouts.
+
+**When to use**: User asks what's open in Obsidian, wants to switch to a saved layout, save the current layout, or open files into specific tabs/groups.
+
+**Capabilities**:
+- Workspace tree, open tabs, recently opened files
+- Save / load / delete named workspaces (Workspaces core plugin)
+- Open files or non-file views (graph, file explorer) into specific tab groups
+
+---
+
+### Vault Management
+**File**: `skills/vault-management/SKILL.md`
+
+Inspect the active vault, enumerate known vaults, and target commands at a specific vault.
+
+**When to use**: User asks about vault info (path, file count, size), works across multiple vaults, or wants to run a command against a non-active vault.
+
+**Capabilities**:
+- Active vault info (`name`, `path`, `files`, `folders`, `size`)
+- List known vaults with paths
+- Multi-vault `vault=<name>` global prefix
+
+---
+
+### Templates
+**File**: `skills/templates/SKILL.md`
+
+List, read, and insert templates from the core Templates plugin, with variable resolution.
+
+**When to use**: User mentions Obsidian templates, the Templates plugin, or template variable resolution (`{{date}}`, `{{time}}`, `{{title}}`).
+
+**Capabilities**:
+- List all templates and previews (raw or resolved)
+- Insert template into the active editor
+- Cross-link to `vault-files create … template=…` for new-note creation
+
+---
+
+### Bookmarks
+**File**: `skills/bookmarks/SKILL.md`
+
+List and add Obsidian bookmarks — files, folders, headings/blocks, saved searches, and external URLs.
+
+**When to use**: User mentions Obsidian bookmarks, starring/saving notes for quick access, or scripted bookmark creation.
+
+**Capabilities**:
+- List bookmarks with type metadata
+- Bookmark files, folders, headings (`subpath=#H`), blocks (`subpath=^id`), searches, and URLs
+- Bulk-bookmark patterns from base queries
+
+---
+
+## Keeping Skills Current
+
+A scheduled GitHub workflow (`.github/workflows/obsidian-cli-changelog.yml`) fetches the upstream Obsidian CLI documentation weekly, hashes its content, and — when the hash changes — opens a draft PR with proposed skill updates. State is tracked in `.obsidian-cli-version-check.json` at the repo root.
+
+Run on demand with: **Actions → Plugin: Obsidian CLI changelog review → Run workflow**.
 
 ---
 
@@ -147,7 +268,11 @@ claude plugins add --global /path/to/obsidian-plugin
 
 - Paths are vault-relative — use `folder/note.md`, not absolute paths
 - `create` omits `.md` (added automatically), `move` requires it
+- Flags are bare words (`overwrite`, `open`, `newtab`, `permanent`, `inline`, `total`); the universal `--copy` flag is the only `--`-prefixed one
+- `file=<name>` resolves like a wikilink; `path=<full/path.md>` is exact
+- Most commands default to the active file when no target is specified
 - Use `format=json` for machine-parseable output
+- Multi-vault: prefix `vault=<name>` before the command (see `vault-management`)
 - Obsidian must be running for all CLI commands
 
 ## Keywords

--- a/obsidian-plugin/skills/bases/SKILL.md
+++ b/obsidian-plugin/skills/bases/SKILL.md
@@ -1,0 +1,125 @@
+---
+created: 2026-04-30
+modified: 2026-04-30
+reviewed: 2026-04-30
+name: bases
+description: |
+  Query and create entries in Obsidian Bases — the database-over-notes feature.
+  Covers listing base files, listing views, creating items in a base, and
+  running view queries with structured output (json/csv/tsv/md/paths).
+  Use when the user mentions Obsidian Bases, .base files, querying notes as
+  a database, base views, or structured note queries.
+user-invocable: false
+allowed-tools: Bash(obsidian *), Read, Grep, Glob
+---
+
+# Obsidian Bases
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative instead when... |
+|---|---|
+| Querying notes that share a Base view (status board, reading list, project tracker) | Doing a free-text search across the vault — use `search-discovery` |
+| Creating a new entry that should land in a specific Base view | Creating an arbitrary note — use `vault-files` |
+| Listing what `.base` files and views exist in the vault | Reading frontmatter on a single note — use `properties` |
+
+[Bases](https://help.obsidian.md/bases) turn note collections into queryable views with frontmatter-driven filters and columns. The CLI exposes those views as structured data — JSON for the agent, CSV/TSV for piping, markdown for rendering.
+
+## Prerequisites
+
+- Obsidian desktop v1.12.4+ with CLI enabled
+- Obsidian must be running
+- At least one `.base` file in the vault
+
+## List Bases and Views
+
+```bash
+# List all .base files in the vault
+obsidian bases
+
+# List the views defined in a base (default: active base)
+obsidian base:views file=Reading
+obsidian base:views path="Bases/Reading.base"
+```
+
+## Query a View
+
+`base:query` runs a view and returns rows. Default format is JSON, which is
+the right choice for agentic consumption.
+
+```bash
+# Query the active view of the active base
+obsidian base:query
+
+# Specific base + view, JSON for parsing
+obsidian base:query file=Reading view="To read" format=json
+
+# Markdown table for human consumption
+obsidian base:query file=Reading view="To read" format=md
+
+# Just the matching note paths (one per line, useful with xargs)
+obsidian base:query file=Projects view=Active format=paths
+
+# CSV for spreadsheet workflows
+obsidian base:query file=Tasks view=Open format=csv
+```
+
+The `format=paths` mode is the agentic-friendly equivalent of a vault search
+that already understands base filters — pipe the output into `obsidian read`
+or any file-level skill.
+
+## Create an Entry in a Base
+
+Create a new note that automatically lands in a base view (the base's filter
+must match the new note's frontmatter for it to actually appear):
+
+```bash
+# Add to the active base view
+obsidian base:create name="Untitled Book"
+
+# Specific base + view, with starting content
+obsidian base:create file=Reading view="To read" name="The Mythical Man-Month" content="# The Mythical Man-Month\n\n"
+
+# Open the new note in a new tab after creating
+obsidian base:create file=Reading view="To read" name="New entry" newtab open
+```
+
+## Common Patterns
+
+### "Find every active project and append a status update"
+
+```bash
+obsidian base:query file=Projects view=Active format=paths \
+  | while read -r path; do
+      obsidian append path="$path" content="\n## $(date +%F) update\n- "
+    done
+```
+
+### "Show me a markdown table of incomplete reading"
+
+```bash
+obsidian base:query file=Reading view="To read" format=md
+```
+
+### "Bulk-create entries from a CSV"
+
+Read each row, then call `base:create` per row with the desired `name=` and
+`content=`. Avoid embedding shell operators inside the CLI invocation —
+build values in shell variables first, then pass them.
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| List `.base` files | `obsidian bases` |
+| List views in a base | `obsidian base:views file=X` |
+| Query a view as JSON | `obsidian base:query file=X view=Y format=json` |
+| Get matching paths only | `obsidian base:query file=X view=Y format=paths` |
+| Markdown table for humans | `obsidian base:query file=X view=Y format=md` |
+| Create entry in a view | `obsidian base:create file=X view=Y name="…"` |
+
+## Related Skills
+
+- **vault-files** — Read/write notes returned by a base query
+- **properties** — Edit frontmatter that drives base filters
+- **search-discovery** — Free-text and tag search when no base exists

--- a/obsidian-plugin/skills/bookmarks/SKILL.md
+++ b/obsidian-plugin/skills/bookmarks/SKILL.md
@@ -1,0 +1,113 @@
+---
+created: 2026-04-30
+modified: 2026-04-30
+reviewed: 2026-04-30
+name: bookmarks
+description: |
+  List and add Obsidian bookmarks — files, folders, headings/blocks, saved
+  searches, and external URLs. Use when the user mentions Obsidian bookmarks,
+  starring/saving notes for quick access, or scripted bookmark creation.
+user-invocable: false
+allowed-tools: Bash(obsidian *), Read, Grep, Glob
+---
+
+# Obsidian Bookmarks
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative instead when... |
+|---|---|
+| Adding a file, folder, search query, or URL to the Bookmarks panel | Adding a generic frontmatter property — use `properties` |
+| Listing the user's existing bookmarks | Listing every file in the vault — use `vault-files` |
+| Bookmarking a heading or block within a file | Opening a file in a tab — use `workspaces` |
+
+The Bookmarks core plugin must be enabled. Bookmarks support five target
+types: files, folders, headings/blocks (via `subpath=`), saved searches, and
+external URLs.
+
+## Prerequisites
+
+- Obsidian desktop v1.12.4+ with CLI enabled
+- Obsidian must be running
+- Core **Bookmarks** plugin enabled
+
+## List Bookmarks
+
+```bash
+# All bookmarks (default tsv)
+obsidian bookmarks
+
+# Include bookmark types
+obsidian bookmarks verbose
+
+# Structured output
+obsidian bookmarks format=json
+
+# Just the count
+obsidian bookmarks total
+```
+
+## Add a Bookmark
+
+```bash
+# Bookmark a file
+obsidian bookmark file="Notes/Recipe.md"
+
+# Bookmark a folder
+obsidian bookmark folder="Projects/Active"
+
+# Bookmark a heading or block within a file
+obsidian bookmark file="Notes/Recipe.md" subpath="#Ingredients"
+obsidian bookmark file="Notes/Recipe.md" subpath="^block-id"
+
+# Bookmark a saved search query
+obsidian bookmark search="tag:#followup status::open"
+
+# Bookmark an external URL
+obsidian bookmark url="https://obsidian.md/help/cli" title="Obsidian CLI docs"
+
+# Custom title for any bookmark type
+obsidian bookmark file="Notes/Recipe.md" title="Tonight's recipe"
+```
+
+## Common Patterns
+
+### "Bookmark every file from a base view"
+
+```bash
+obsidian base:query file=Reading view="To read" format=paths \
+  | while read -r path; do
+      obsidian bookmark file="$path"
+    done
+```
+
+### "Promote a frequent search to a bookmark"
+
+```bash
+obsidian bookmark search="path:Daily tag:#followup" title="Outstanding follow-ups"
+```
+
+### "Snapshot the current bookmark set"
+
+```bash
+obsidian bookmarks format=json > bookmarks-$(date +%F).json
+```
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| List bookmarks (structured) | `obsidian bookmarks format=json` |
+| List bookmarks with types | `obsidian bookmarks verbose` |
+| Bookmark count | `obsidian bookmarks total` |
+| Bookmark a file | `obsidian bookmark file=X` |
+| Bookmark a heading | `obsidian bookmark file=X subpath="#H"` |
+| Bookmark a block | `obsidian bookmark file=X subpath="^id"` |
+| Bookmark a search | `obsidian bookmark search="QUERY"` |
+| Bookmark a URL | `obsidian bookmark url=https://… title=…` |
+
+## Related Skills
+
+- **vault-files** — Source files referenced by file/folder/subpath bookmarks
+- **search-discovery** — Construct the query strings used in search bookmarks
+- **bases** — `base:query format=paths` feeds nicely into bulk-bookmark loops

--- a/obsidian-plugin/skills/command-palette/SKILL.md
+++ b/obsidian-plugin/skills/command-palette/SKILL.md
@@ -1,0 +1,126 @@
+---
+created: 2026-04-30
+modified: 2026-04-30
+reviewed: 2026-04-30
+name: command-palette
+description: |
+  Run any Obsidian command (built-in or plugin-registered) from the CLI, list
+  available commands, and inspect or look up hotkeys. Use when the user wants
+  to trigger a command they would normally invoke from the command palette,
+  enumerate plugin-registered commands, or check which hotkey is bound to an
+  action.
+user-invocable: false
+allowed-tools: Bash(obsidian *), Read, Grep, Glob
+---
+
+# Obsidian Command Palette
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative instead when... |
+|---|---|
+| Triggering a command the user would normally pick from the command palette (`Ctrl/Cmd+P`) | Running JavaScript via the developer API — use `dev-tools` |
+| Discovering what commands a plugin registers | Enabling/disabling a plugin entirely — use `plugins-themes` |
+| Looking up which hotkey is bound to a command | Setting up a workspace — use `workspaces` |
+
+The command palette is Obsidian's universal action surface — every built-in
+operation and every command registered by a plugin appears here. The CLI
+exposes the same surface, which is the leverage point for automation: any
+plugin command becomes scriptable without writing JavaScript.
+
+## Prerequisites
+
+- Obsidian desktop v1.12.4+ with CLI enabled
+- Obsidian must be running
+
+## List Commands
+
+```bash
+# All available command IDs
+obsidian commands
+
+# Filter by ID prefix (e.g. only Templater commands)
+obsidian commands filter=templater
+
+# Filter to a built-in family
+obsidian commands filter=editor
+obsidian commands filter=workspace
+```
+
+Command IDs follow the `pluginid:action` convention — e.g.
+`editor:toggle-bold`, `workspace:split-vertical`, `dataview:dataview-rebuild-current-view`.
+
+## Execute a Command
+
+```bash
+# Run a built-in command
+obsidian command id=editor:toggle-bold
+
+# Run a plugin-registered command
+obsidian command id=templater-obsidian:insert-templater
+obsidian command id=dataview:dataview-rebuild-current-view
+
+# Open the command palette itself
+obsidian command id=command-palette:open
+```
+
+`command` always operates against the active editor / active file — there
+is no `file=` parameter. To run a command against a specific note, open
+the note first (`obsidian open file=Foo`), then run `command`.
+
+## Hotkeys
+
+```bash
+# All bound hotkeys
+obsidian hotkeys
+
+# Mark which entries are user-customised vs default
+obsidian hotkeys verbose
+
+# Count of bound hotkeys
+obsidian hotkeys total
+
+# Lookup the hotkey for one command
+obsidian hotkey id=editor:toggle-bold
+obsidian hotkey id=editor:toggle-bold verbose
+```
+
+## Common Patterns
+
+### "Run a Templater template against the current note"
+
+```bash
+obsidian open file="Notes/Today"
+obsidian command id=templater-obsidian:replace-in-file-templater
+```
+
+### "Find every Dataview command"
+
+```bash
+obsidian commands filter=dataview
+```
+
+### "Discover what hotkeys conflict with a new binding"
+
+```bash
+obsidian hotkeys format=json | jq '[.[] | select(.hotkey == "Ctrl+Shift+P")]'
+```
+
+(Requires the user's installed `jq`; the CLI itself does not pipe.)
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| List all commands | `obsidian commands` |
+| Filter commands by prefix | `obsidian commands filter=PREFIX` |
+| Run a command | `obsidian command id=PLUGIN:ACTION` |
+| List hotkeys (structured) | `obsidian hotkeys format=json` |
+| Lookup one hotkey | `obsidian hotkey id=PLUGIN:ACTION` |
+| Show user-customised hotkeys | `obsidian hotkeys verbose` |
+
+## Related Skills
+
+- **plugins-themes** — Enable the plugin before its commands become available
+- **workspaces** — Set up an editor state, then run a command against it
+- **dev-tools** — When a command doesn't exist for what you need

--- a/obsidian-plugin/skills/dev-tools/SKILL.md
+++ b/obsidian-plugin/skills/dev-tools/SKILL.md
@@ -1,0 +1,201 @@
+---
+created: 2026-04-30
+modified: 2026-04-30
+reviewed: 2026-04-30
+name: dev-tools
+description: |
+  Obsidian developer commands for plugin and theme development — DevTools,
+  Chrome DevTools Protocol, JavaScript eval, captured console/error buffers,
+  CSS and DOM inspection, mobile emulation, and screenshots. Use when the
+  user is developing a plugin or theme, debugging the Obsidian app, or
+  needs to introspect the running renderer state.
+user-invocable: false
+allowed-tools: Bash(obsidian *), Read, Grep, Glob
+---
+
+# Obsidian Developer Tools
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative instead when... |
+|---|---|
+| Developing or debugging a community plugin / theme | Enabling or disabling plugins as a user — use `plugins-themes` |
+| Running JavaScript against the live `app` API | Triggering an Obsidian command — use `command-palette` |
+| Inspecting CSS or DOM in the running app | Switching themes or snippets in normal use — use `plugins-themes` |
+| Capturing console errors during agent-run plugin tests | Reading note content — use `vault-files` |
+
+These commands are **for development and diagnostics**. They expose the same
+surface as the in-app DevTools window plus a captured buffer of console
+output and JavaScript errors that survives between calls — the leverage
+point for agentic plugin testing.
+
+## Prerequisites
+
+- Obsidian desktop v1.12.4+ with CLI enabled
+- Obsidian must be running
+- For `dev:debug` and `dev:cdp`: Chrome DevTools Protocol available
+  (Electron-based Obsidian — true on desktop)
+
+## DevTools Window
+
+```bash
+# Toggle the in-app DevTools panel
+obsidian devtools
+```
+
+## Eval JavaScript
+
+```bash
+# Read state from the live app
+obsidian eval code="app.vault.getFiles().length"
+obsidian eval code="app.workspace.getActiveFile()?.path"
+
+# Drive the app — anything you could type in the DevTools console
+obsidian eval code="app.commands.executeCommandById('editor:toggle-bold')"
+
+# Multi-statement: wrap in an IIFE
+obsidian eval code="(()=>{const f=app.vault.getFiles();return f.filter(x=>x.extension==='md').length})()"
+```
+
+`eval` returns the expression's value (or last statement's value in an IIFE)
+serialised to text. Use `JSON.stringify(...)` inside the expression for
+structured output you can parse downstream.
+
+## Captured Console & Errors
+
+The CLI maintains rolling buffers of `console.*` calls and JavaScript errors
+from the running app — invaluable for agent-driven plugin testing where the
+agent doesn't have the DevTools window open.
+
+```bash
+# Recent console messages (default limit 50)
+obsidian dev:console
+obsidian dev:console limit=200
+obsidian dev:console level=error
+obsidian dev:console level=warn
+
+# Clear the console buffer (e.g. before a test run)
+obsidian dev:console clear
+
+# Captured JS errors
+obsidian dev:errors
+obsidian dev:errors clear
+```
+
+Typical agent loop:
+
+```bash
+obsidian dev:errors clear
+obsidian dev:console clear
+obsidian plugin:reload id=my-plugin
+obsidian command id=my-plugin:run-test
+obsidian dev:errors        # any uncaught exceptions?
+obsidian dev:console level=error
+```
+
+## CSS Inspection
+
+```bash
+# All CSS rules matching a selector, with source location
+obsidian dev:css selector=".workspace-leaf"
+
+# Filter to one property
+obsidian dev:css selector=".workspace-leaf" prop=background-color
+```
+
+Useful for tracking down which snippet or theme is winning a cascade.
+
+## DOM Query
+
+```bash
+# First match — full outerHTML
+obsidian dev:dom selector=".nav-folder-title"
+
+# Inner HTML only
+obsidian dev:dom selector=".nav-folder-title" inner
+
+# Just the text content
+obsidian dev:dom selector=".nav-folder-title" text
+
+# All matches (not just the first)
+obsidian dev:dom selector=".nav-folder-title" all
+
+# Element count
+obsidian dev:dom selector=".nav-folder-title" total
+
+# Read an attribute or computed CSS prop
+obsidian dev:dom selector=".workspace-leaf.mod-active" attr=data-type
+obsidian dev:dom selector=".workspace-leaf.mod-active" css=display
+```
+
+## Chrome DevTools Protocol (CDP)
+
+```bash
+# Attach the CDP debugger
+obsidian dev:debug on
+obsidian dev:debug off
+
+# Run an arbitrary CDP method
+obsidian dev:cdp method=Page.captureScreenshot
+obsidian dev:cdp method=Runtime.evaluate params='{"expression":"location.href"}'
+```
+
+CDP is the right tool when `eval` is too coarse — anything you'd reach for
+in `chrome://inspect`.
+
+## Screenshots & Mobile Emulation
+
+```bash
+# Capture the running window
+obsidian dev:screenshot path=/tmp/state.png
+
+# Toggle mobile emulation (responsive testing without leaving desktop)
+obsidian dev:mobile on
+obsidian dev:mobile off
+```
+
+## Common Patterns
+
+### Plugin reload-test loop
+
+```bash
+obsidian dev:console clear
+obsidian dev:errors clear
+obsidian plugin:reload id=my-plugin
+obsidian command id=my-plugin:run-tests
+errors=$(obsidian dev:errors)
+[ -z "$errors" ] && echo "PASS" || { echo "FAIL"; echo "$errors"; }
+```
+
+### Theme regression screenshots
+
+```bash
+for theme in Default Minimal Things; do
+  obsidian theme:set name="$theme"
+  obsidian dev:screenshot path="/tmp/theme-$theme.png"
+done
+```
+
+### Probe the active workspace
+
+```bash
+obsidian eval code="JSON.stringify({file: app.workspace.getActiveFile()?.path, view: app.workspace.activeLeaf?.view?.getViewType()})"
+```
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Run JS, parseable output | `obsidian eval code="JSON.stringify(...)"` |
+| Errors since last check | `obsidian dev:errors` |
+| Reset error buffer | `obsidian dev:errors clear` |
+| Console (errors only) | `obsidian dev:console level=error` |
+| DOM element count | `obsidian dev:dom selector=X total` |
+| Screenshot for diff | `obsidian dev:screenshot path=/tmp/X.png` |
+| CSS source for property | `obsidian dev:css selector=X prop=Y` |
+
+## Related Skills
+
+- **plugins-themes** — Plugin/theme lifecycle (install/enable/reload/disable)
+- **command-palette** — Trigger commands the plugin registers
+- **workspaces** — Set up the editor state before running diagnostics

--- a/obsidian-plugin/skills/file-history/SKILL.md
+++ b/obsidian-plugin/skills/file-history/SKILL.md
@@ -1,0 +1,161 @@
+---
+created: 2026-04-30
+modified: 2026-04-30
+reviewed: 2026-04-30
+name: file-history
+description: |
+  Inspect, diff, and restore previous versions of notes from Obsidian's local
+  File Recovery store and from Obsidian Sync version history. Critical safety
+  net for agentic edits — lets you compare versions, recover overwritten
+  content, and audit changes. Use when the user mentions undo, restoring a
+  previous version, file recovery, version history, or comparing what changed.
+user-invocable: false
+allowed-tools: Bash(obsidian *), Read, Grep, Glob
+---
+
+# Obsidian File History & Recovery
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative instead when... |
+|---|---|
+| Recovering an overwritten or accidentally deleted note | Editing a current note — use `vault-files` |
+| Diffing what changed between two versions of a note | Searching the current vault state — use `search-discovery` |
+| Auditing the history of a single file before a destructive edit | Restoring a deleted file from disk-level backups — use OS tools |
+
+Obsidian keeps two parallel version stores:
+
+- **File Recovery** — local snapshots, configurable in Settings → File Recovery (`history:*`).
+- **Sync history** — server-side versions, available with Obsidian Sync (`sync:history`, `sync:read`, `sync:restore`).
+
+`diff` unifies both: by default it lists every available version (newest = 1)
+across both stores. `filter=local|sync` narrows the source.
+
+## Prerequisites
+
+- Obsidian desktop v1.12.4+ with CLI enabled
+- Obsidian must be running
+- File Recovery enabled (Settings → File Recovery) for local history
+- Active Obsidian Sync subscription for `sync:*` commands
+
+## Diff Versions
+
+```bash
+# List all available versions of the active file
+obsidian diff
+
+# List versions of a specific file
+obsidian diff file=Recipe
+
+# Compare the latest version (1) to current state
+obsidian diff file=Recipe from=1
+
+# Compare two specific versions (newest = 1)
+obsidian diff file=Recipe from=2 to=1
+
+# Restrict to one source
+obsidian diff file=Recipe filter=local
+obsidian diff file=Recipe filter=sync
+```
+
+## Local File Recovery
+
+```bash
+# History entries for a file
+obsidian history file=Recipe
+
+# Every file that has local history
+obsidian history:list
+
+# Read a specific version (default: version=1, newest)
+obsidian history:read file=Recipe version=3
+
+# Open the File Recovery view in the GUI
+obsidian history:open file=Recipe
+
+# Restore a previous version (overwrites current)
+obsidian history:restore file=Recipe version=3
+```
+
+## Sync Version History
+
+```bash
+# Sync versions for a file
+obsidian sync:history file=Recipe
+obsidian sync:history file=Recipe total
+
+# Read a specific sync version
+obsidian sync:read file=Recipe version=2
+
+# Restore a sync version (overwrites current)
+obsidian sync:restore file=Recipe version=2
+
+# Open the sync history view in the GUI
+obsidian sync:open file=Recipe
+
+# Files deleted via sync (recoverable)
+obsidian sync:deleted
+```
+
+## Common Patterns
+
+### "Show me what an agent changed since I last reviewed"
+
+```bash
+# Diff the most recent saved version against the current state
+obsidian diff file="Notes/Project" from=1
+```
+
+### "Restore yesterday's version after a bad edit"
+
+```bash
+# 1. List versions to identify the right one (newest = 1)
+obsidian history file=Daily/2026-04-29
+# 2. Read it to confirm
+obsidian history:read file=Daily/2026-04-29 version=2
+# 3. Restore
+obsidian history:restore file=Daily/2026-04-29 version=2
+```
+
+### "Audit history for every file an agent touched in this session"
+
+```bash
+# Given a list of changed paths in $changed_files
+while read -r path; do
+  echo "=== $path ==="
+  obsidian diff path="$path" filter=local
+done <<< "$changed_files"
+```
+
+### Pre-flight before destructive edits
+
+For agentic workflows that overwrite or delete notes, capture the version
+number first so a restore is one command away:
+
+```bash
+# Snapshot the current version
+obsidian history file="Notes/Important" | head -2
+# … perform edit …
+# If something breaks:
+obsidian history:restore file="Notes/Important" version=2
+```
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| List all versions of a file | `obsidian diff file=X` |
+| Diff latest version vs current | `obsidian diff file=X from=1` |
+| Diff two specific versions | `obsidian diff file=X from=2 to=1` |
+| Local-only versions | `obsidian diff file=X filter=local` |
+| Read a local version | `obsidian history:read file=X version=N` |
+| Restore a local version | `obsidian history:restore file=X version=N` |
+| Read a sync version | `obsidian sync:read file=X version=N` |
+| Restore a sync version | `obsidian sync:restore file=X version=N` |
+| Files deleted via sync | `obsidian sync:deleted` |
+
+## Related Skills
+
+- **vault-files** — Read or write the current state of a note
+- **publish-sync** — Sync service status (pause/resume) and published-file workflows
+- **vault-management** — Switch vaults before inspecting their history

--- a/obsidian-plugin/skills/plugins-themes/SKILL.md
+++ b/obsidian-plugin/skills/plugins-themes/SKILL.md
@@ -1,54 +1,80 @@
 ---
 created: 2026-03-04
-modified: 2026-04-25
-reviewed: 2026-04-25
+modified: 2026-04-30
+reviewed: 2026-04-30
 name: plugins-themes
 description: |
-  Obsidian plugin and theme management via the official CLI.
-  Covers listing, enabling, disabling, and reloading plugins,
-  theme switching, and developer tools (eval, screenshot).
-  Use when user mentions Obsidian plugins, themes, plugin development,
-  enabling/disabling plugins, or running JavaScript in Obsidian.
+  Lifecycle management for Obsidian community plugins, themes, and CSS
+  snippets via the official CLI — install, enable, disable, uninstall,
+  reload, switch theme, and toggle restricted (formerly "safe") mode.
+  Use when the user mentions installing/enabling/disabling Obsidian
+  plugins or themes, switching themes, or toggling CSS snippets. For
+  developer commands (eval, devtools, dev:*, screenshot) use `dev-tools`.
 user-invocable: false
-allowed-tools: Bash, Read, Grep, Glob
+allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---
 
-# Obsidian Plugin & Theme Management
+# Obsidian Plugins, Themes & Snippets
 
 ## When to Use This Skill
 
 | Use this skill when... | Use the alternative instead when... |
 |---|---|
-| Enabling, disabling, or reloading community plugins | Editing note content — use `vault-files` |
-| Switching the active theme or running developer-tool eval/screenshot | Reading or writing YAML frontmatter — use `properties` |
-| Diagnosing a plugin that fails to load in the running vault | Searching the vault for tags or backlinks — use `search-discovery` |
+| Installing, enabling, disabling, or reloading community plugins | Running JavaScript in the app or capturing screenshots — use `dev-tools` |
+| Switching the active theme or installing a new one | Triggering a plugin-registered command — use `command-palette` |
+| Toggling CSS snippets on/off | Editing snippet CSS source on disk — use `vault-files` |
+| Toggling Obsidian's restricted mode | Inspecting CSS rules with source location — use `dev-tools` |
 
-Manage community plugins, themes, and developer tools using the official Obsidian CLI.
+Lifecycle management for community plugins, themes, and CSS snippets. The
+**developer commands** (`eval`, `devtools`, `dev:*`, screenshots) live in
+the dedicated `dev-tools` skill.
 
 ## Prerequisites
 
 - Obsidian desktop v1.12.4+ with CLI enabled
 - Obsidian must be running
+- Restricted mode **off** (community plugins disabled while restricted mode is on)
 
-## When to Use
+## Plugins
 
-Use this skill automatically when:
-- User wants to list, enable, or disable Obsidian plugins
-- User needs to reload a plugin during development
-- User wants to switch or list themes
-- User needs to run JavaScript in the Obsidian runtime
-- User wants to take screenshots of the Obsidian app
-
-## Plugin Management
-
-### List Plugins
+### List
 
 ```bash
 # All installed plugins
 obsidian plugins
 
-# JSON output
+# Just community or just core
+obsidian plugins filter=community
+obsidian plugins filter=core
+
+# Include version numbers
+obsidian plugins versions
+
+# Structured output
 obsidian plugins format=json
+
+# Currently enabled
+obsidian plugins:enabled
+obsidian plugins:enabled filter=community versions
+```
+
+### Plugin Info
+
+```bash
+obsidian plugin id=dataview
+```
+
+### Install / Uninstall (community only)
+
+```bash
+# Install from the community catalogue
+obsidian plugin:install id=dataview
+
+# Install and enable in one shot
+obsidian plugin:install id=dataview enable
+
+# Remove
+obsidian plugin:uninstall id=dataview
 ```
 
 ### Enable / Disable
@@ -59,48 +85,88 @@ obsidian plugin:enable id=dataview
 
 # Disable a plugin
 obsidian plugin:disable id=dataview
+
+# Specify type if the same id exists in both core and community
+obsidian plugin:enable id=daily-notes filter=core
 ```
 
-### Reload (Development)
+### Reload (developer hot-reload)
 
 ```bash
-# Hot-reload a plugin during development
 obsidian plugin:reload id=my-plugin
 ```
 
-## Theme Management
+### Restricted Mode
 
-### List Themes
+Restricted mode disables all community plugins (formerly "Safe Mode"):
 
 ```bash
-# Available themes
+# Check / toggle
+obsidian plugins:restrict
+obsidian plugins:restrict on
+obsidian plugins:restrict off
+```
+
+## Themes
+
+```bash
+# All installed themes
 obsidian themes
-```
 
-### Switch Theme
+# Include version numbers
+obsidian themes versions
 
-```bash
-# Set active theme
+# Active theme info, or details for a specific theme
+obsidian theme
+obsidian theme name="Minimal"
+
+# Switch active theme (empty string = built-in default)
 obsidian theme:set name="Minimal"
+obsidian theme:set name=""
+
+# Install / uninstall community themes
+obsidian theme:install name="Things"
+obsidian theme:install name="Things" enable
+obsidian theme:uninstall name="Things"
 ```
 
-## Developer Tools
-
-### Eval (JavaScript Execution)
+## CSS Snippets
 
 ```bash
-# Execute JavaScript in Obsidian's runtime context
-obsidian eval code="app.vault.getFiles().length"
+# All snippets in the vault
+obsidian snippets
 
-# Access the full Obsidian API
-obsidian eval code="app.workspace.getActiveFile()?.path"
+# Currently enabled
+obsidian snippets:enabled
+
+# Toggle individual snippets by filename (without .css)
+obsidian snippet:enable name=callout-tweaks
+obsidian snippet:disable name=callout-tweaks
 ```
 
-### Screenshot
+## Common Patterns
+
+### "Install Dataview, enable it, and verify it loaded"
 
 ```bash
-# Capture Obsidian window
-obsidian dev:screenshot path=~/screenshot.png
+obsidian plugin:install id=dataview enable
+obsidian plugins:enabled filter=community | grep -q '^dataview$' && echo OK || echo FAIL
+```
+
+### "Snapshot the current plugin/theme state"
+
+```bash
+obsidian plugins format=json     > plugins-$(date +%F).json
+obsidian themes versions          > themes-$(date +%F).txt
+obsidian snippets:enabled         > snippets-enabled-$(date +%F).txt
+```
+
+### "Disable every community plugin temporarily"
+
+```bash
+obsidian plugins:restrict on
+# … work in restricted mode …
+obsidian plugins:restrict off
 ```
 
 ## Agentic Optimizations
@@ -108,14 +174,18 @@ obsidian dev:screenshot path=~/screenshot.png
 | Context | Command |
 |---------|---------|
 | List plugins (structured) | `obsidian plugins format=json` |
+| Enabled plugins only | `obsidian plugins:enabled` |
 | Enable plugin | `obsidian plugin:enable id=X` |
 | Disable plugin | `obsidian plugin:disable id=X` |
+| Install + enable | `obsidian plugin:install id=X enable` |
 | Reload during dev | `obsidian plugin:reload id=X` |
-| List themes | `obsidian themes` |
+| Toggle restricted mode | `obsidian plugins:restrict on\|off` |
 | Switch theme | `obsidian theme:set name="X"` |
-| Run JS in Obsidian | `obsidian eval code="expression"` |
+| Install theme + activate | `obsidian theme:install name="X" enable` |
+| Toggle CSS snippet | `obsidian snippet:enable\|disable name=X` |
 
 ## Related Skills
 
-- **vault-files** — Core file operations the plugins operate on
-- **publish-sync** — Publish and sync workflows
+- **dev-tools** — `eval`, `devtools`, `dev:*`, screenshots (developer surface)
+- **command-palette** — Trigger plugin-registered commands once enabled
+- **vault-files** — Read or edit snippet `.css` source under `.obsidian/snippets/`

--- a/obsidian-plugin/skills/publish-sync/SKILL.md
+++ b/obsidian-plugin/skills/publish-sync/SKILL.md
@@ -1,16 +1,17 @@
 ---
 created: 2026-03-04
-modified: 2026-04-25
-reviewed: 2026-04-25
+modified: 2026-04-30
+reviewed: 2026-04-30
 name: publish-sync
 description: |
-  Obsidian Publish and Sync management via the official CLI.
-  Covers listing published notes, adding/removing notes from Publish,
-  and checking Obsidian Sync status.
-  Use when user mentions Obsidian Publish, publishing notes,
-  Obsidian Sync, or sync status.
+  Obsidian Publish and Obsidian Sync management via the official CLI —
+  publish site info, list/add/remove published notes, publish change set,
+  open published page, sync pause/resume, sync status and usage, and
+  recovery of sync-deleted files. Use when the user mentions Obsidian
+  Publish, publishing notes, Obsidian Sync, sync status, or recovering
+  sync-deleted files.
 user-invocable: false
-allowed-tools: Bash, Read, Grep, Glob
+allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---
 
 # Obsidian Publish & Sync
@@ -19,93 +20,149 @@ allowed-tools: Bash, Read, Grep, Glob
 
 | Use this skill when... | Use the alternative instead when... |
 |---|---|
-| Listing, adding, or removing notes on Obsidian Publish | Creating or moving the underlying notes themselves — use `vault-files` |
-| Checking Obsidian Sync status for the active vault | Managing community plugins or themes — use `plugins-themes` |
-| Auditing which notes are currently public vs. private | Discovering orphaned or unresolved-link notes — use `search-discovery` |
+| Listing, adding, removing, or auditing the change set on Obsidian Publish | Creating or moving the underlying notes themselves — use `vault-files` |
+| Pausing/resuming Obsidian Sync or checking sync status & usage | Restoring a previous sync version of a file — use `file-history` |
+| Recovering a file that sync deleted | Recovering a file from local File Recovery — use `file-history` |
+| Auditing which notes are currently public vs private | Discovering orphaned or unresolved-link notes — use `search-discovery` |
 
-Manage Obsidian Publish and Obsidian Sync services using the official CLI.
+Manage Obsidian Publish and Obsidian Sync services from the CLI.
+**Sync version history** (per-file diff and restore) lives in `file-history`.
 
 ## Prerequisites
 
 - Obsidian desktop v1.12.4+ with CLI enabled
 - Obsidian must be running
-- Active Obsidian Publish and/or Sync subscription for respective commands
-
-## When to Use
-
-Use this skill automatically when:
-- User wants to list, add, or remove notes from Obsidian Publish
-- User needs to check Obsidian Sync status
-- User asks about publishing workflow or sync state
+- Active Obsidian Publish and/or Sync subscription for the respective commands
 
 ## Obsidian Publish
 
-### List Published Notes
+### Site Info
 
 ```bash
-# All currently published notes
+# Slug, URL, status of the connected Publish site
+obsidian publish:site
+```
+
+### List & Compare
+
+```bash
+# All currently published files
 obsidian publish:list
+obsidian publish:list total
 
-# JSON output
-obsidian publish:list format=json
+# What would change on next publish (new / changed / deleted)
+obsidian publish:status
+obsidian publish:status new
+obsidian publish:status changed
+obsidian publish:status deleted
+obsidian publish:status total
 ```
 
-### Add to Publish
+### Publish & Unpublish
 
 ```bash
-# Publish a note
+# Publish the active file
+obsidian publish:add
+
+# Publish a specific file
 obsidian publish:add file="Public Note"
-
-# Publish by path
 obsidian publish:add path="blog/post.md"
-```
 
-### Remove from Publish
+# Publish *all* changed files in one shot
+obsidian publish:add changed
 
-```bash
-# Unpublish a note
+# Unpublish
 obsidian publish:remove file="Draft Post"
+
+# Open the file's published page in the browser
+obsidian publish:open file="Public Note"
 ```
 
 ## Obsidian Sync
 
-### Check Status
+### Status & Pause/Resume
 
 ```bash
-# Current sync state
+# Sync state, last sync time, usage
 obsidian sync:status
+
+# Pause / resume sync
+obsidian sync off
+obsidian sync on
 ```
 
-## Publishing Workflow
-
-### Batch Publish
+### Files Deleted via Sync
 
 ```bash
-# Find all notes tagged for publish, then add them
-obsidian search query="[tag:publish]" format=json
-# Then publish each result
-obsidian publish:add file="Note Name"
+# Files removed via sync (recoverable)
+obsidian sync:deleted
+obsidian sync:deleted total
 ```
 
-### Publish Audit
+To restore one of those files, use `file-history`:
+`obsidian sync:restore file=X version=N`.
+
+### Per-file Sync Versions
+
+For listing, reading, or restoring a specific sync version of a file, use
+the **`file-history`** skill (`sync:history`, `sync:read`, `sync:restore`,
+`sync:open`).
+
+## Common Patterns
+
+### "Publish every note tagged #publish"
 
 ```bash
-# Compare published notes with tagged notes
-obsidian publish:list format=json
-obsidian tag tagname=publish
+# Find candidates
+obsidian search query="tag:#publish" format=json
+
+# Or rely on the change set after the user tags them
+obsidian publish:status new
+obsidian publish:add changed
+```
+
+### "Pre-publish dry run"
+
+```bash
+obsidian publish:status            # all changes
+obsidian publish:status new        # adds only
+obsidian publish:status deleted    # removes only
+```
+
+### "Snapshot the public surface"
+
+```bash
+obsidian publish:list > published-$(date +%F).txt
+obsidian publish:site
+```
+
+### "Recover a synced file the agent deleted"
+
+```bash
+obsidian sync:deleted
+# Identify the file, then restore via file-history:
+obsidian sync:restore file="Notes/Important" version=1
 ```
 
 ## Agentic Optimizations
 
 | Context | Command |
 |---------|---------|
-| List published (structured) | `obsidian publish:list format=json` |
-| Publish a note | `obsidian publish:add file="X"` |
-| Unpublish a note | `obsidian publish:remove file="X"` |
+| Site info | `obsidian publish:site` |
+| List published | `obsidian publish:list` |
+| What's changed since last publish | `obsidian publish:status` |
+| New files only | `obsidian publish:status new` |
+| Publish all changes | `obsidian publish:add changed` |
+| Publish one file | `obsidian publish:add file=X` |
+| Unpublish | `obsidian publish:remove file=X` |
 | Sync status | `obsidian sync:status` |
+| Pause sync | `obsidian sync off` |
+| Resume sync | `obsidian sync on` |
+| Sync-deleted files | `obsidian sync:deleted` |
 
 ## Related Skills
 
-- **vault-files** — Create and manage notes before publishing
-- **properties** — Set publish-related properties on notes
+- **vault-files** — Create or modify notes before publishing
+- **properties** — Set publish-related frontmatter on notes
 - **search-discovery** — Find notes tagged for publishing
+- **file-history** — Per-file sync history (`sync:history`, `sync:read`, `sync:restore`)

--- a/obsidian-plugin/skills/search-discovery/SKILL.md
+++ b/obsidian-plugin/skills/search-discovery/SKILL.md
@@ -1,16 +1,17 @@
 ---
 created: 2026-03-04
-modified: 2026-04-25
-reviewed: 2026-04-25
+modified: 2026-04-30
+reviewed: 2026-04-30
 name: search-discovery
 description: |
-  Obsidian vault search and discovery via the official CLI.
-  Covers full-text search, tag management, link traversal, backlinks,
-  orphan detection, and unresolved link discovery.
-  Use when user mentions searching notes, finding tags, exploring links,
-  backlinks, orphaned notes, or broken wikilinks.
+  Obsidian vault search and discovery via the official CLI — full-text and
+  grep-style context search, tag listing and lookup, outgoing/incoming link
+  traversal, outline navigation, orphan and dead-end detection, and broken
+  wikilink audits. Use when the user mentions searching notes, finding tags,
+  exploring links/backlinks, headings/outline, orphaned or dead-end notes,
+  or broken wikilinks.
 user-invocable: false
-allowed-tools: Bash, Read, Grep, Glob
+allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---
 
 # Obsidian Search & Discovery
@@ -19,141 +20,189 @@ allowed-tools: Bash, Read, Grep, Glob
 
 | Use this skill when... | Use the alternative instead when... |
 |---|---|
-| Running full-text search, tag queries, or backlink traversal against the running vault | Triaging orphaned notes for archival or MOC linking — use `vault-orphans` |
+| Running full-text or grep-style search, tag queries, or backlink traversal against the running vault | Triaging orphaned notes for archival or MOC linking — use `vault-orphans` |
 | Listing unresolved wikilinks Obsidian currently flags as broken | Repairing the broken wikilinks once located — use `vault-wikilinks` |
-| Enumerating notes matching a tag before a tag-rename pass | Performing the tag consolidation itself — use `vault-tags` |
+| Inspecting the heading outline of a single note | Reading the full note content — use `vault-files` |
+| Querying notes already organised by a Base view | — use `bases` |
 
-Full-text search, tag operations, and link graph traversal using the official Obsidian CLI.
+Search, navigate, and audit the vault link graph using the official Obsidian CLI.
 
 ## Prerequisites
 
 - Obsidian desktop v1.12.4+ with CLI enabled
 - Obsidian must be running
 
-## When to Use
-
-Use this skill automatically when:
-- User wants to search vault content or metadata
-- User asks about tags, tag counts, or tag management
-- User wants to explore note links or backlinks
-- User needs to find orphaned or unlinked notes
-- User asks about broken/unresolved wikilinks
-
 ## Search
 
-### Full-Text Search
+### Path-Only Search
+
+`search` returns matching file paths only.
 
 ```bash
 # Basic search
 obsidian search query="project roadmap"
 
-# JSON output for parsing
-obsidian search query="architecture" format=json
+# Limit and JSON output
+obsidian search query="meeting" limit=10 format=json
 
-# Limit results
-obsidian search query="meeting" limit=10
+# Restrict to a folder
+obsidian search query="status::active" path=Projects
 
-# Open results in Obsidian
+# Match count only
+obsidian search query="TODO" total
+
+# Case-sensitive
+obsidian search query="API" case
+```
+
+### Grep-Style Context Search
+
+`search:context` returns `path:line: text` lines — the agentic-friendly mode.
+
+```bash
+# Show matching lines with file/line context
+obsidian search:context query="TODO"
+
+# JSON-structured context
+obsidian search:context query="TODO" format=json
+
+# Restricted to a folder, case-sensitive
+obsidian search:context query="API" path=Projects case
+
+# Limit files searched
+obsidian search:context query="TODO" limit=20
+```
+
+`search:context` is the right default for agents — line numbers feed straight
+into `obsidian read` + line offsets, or into edit workflows.
+
+### Open Search View
+
+```bash
+# Pop the search panel pre-filled
 obsidian search:open query="review needed"
 ```
 
-### Property-Based Search
+### Obsidian Query Operators
+
+The `query=` value uses Obsidian's standard search syntax — `tag:`, `path:`,
+`file:`, `line:`, `[property:value]`, and so on:
 
 ```bash
-# Search by property value
-obsidian search query="[status:active]"
-
-# Search by tag
-obsidian search query="[tag:publish]"
-
-# Combined
-obsidian search query="[status:draft] [tag:blog]"
+obsidian search query="tag:#publish"
+obsidian search query="[status:active] tag:#blog"
+obsidian search:context query="path:Daily TODO"
 ```
 
 ## Tags
 
-### List Tags
-
 ```bash
-# All tags in vault
+# All tags
 obsidian tags
 
-# Tags sorted by frequency
-obsidian tags sort=count
+# Tags with counts (default sort=name)
+obsidian tags counts
 
-# Tags sorted by name
-obsidian tags sort=name
+# Sorted by frequency
+obsidian tags sort=count counts
+
+# JSON output
+obsidian tags format=json
+
+# Tags for the active file (or for file=/path=)
+obsidian tags active
+obsidian tags file=Recipe
+
+# Tag info (occurrence count + which files)
+obsidian tag name=pkm
+obsidian tag name=project/active total
+obsidian tag name=pkm verbose
 ```
 
-### Find Notes by Tag
+## Outline (Headings)
 
 ```bash
-# Notes with a specific tag
-obsidian tag tagname=pkm
+# Heading tree of the active file
+obsidian outline
 
-# Notes with nested tag
-obsidian tag tagname=project/active
-```
+# Specific file
+obsidian outline file=Recipe
 
-### Rename Tags
+# JSON for navigation
+obsidian outline file=Recipe format=json
 
-```bash
-# Bulk rename across vault (updates all notes)
-obsidian tags:rename old=meeting new=meetings
+# Markdown render
+obsidian outline file=Recipe format=md
+
+# Just the heading count
+obsidian outline file=Recipe total
 ```
 
 ## Links
 
-### Outgoing Links
-
 ```bash
-# Links from a note
+# Outgoing links from a note (default: active file)
 obsidian links file="Architecture Overview"
-```
+obsidian links file="Architecture Overview" total
 
-### Backlinks (Incoming Links)
-
-```bash
-# Notes that link to this note
+# Backlinks
 obsidian backlinks file="API Design"
-```
+obsidian backlinks file="API Design" counts
+obsidian backlinks file="API Design" format=json
 
-### Unresolved Links
-
-```bash
-# Broken wikilinks (targets don't exist)
+# Unresolved (broken) wikilinks across the vault
 obsidian unresolved
-```
+obsidian unresolved counts          # with link counts
+obsidian unresolved verbose         # include source files
+obsidian unresolved format=json
 
-### Orphaned Notes
-
-```bash
-# Notes with no incoming or outgoing links
+# Notes with no incoming links
 obsidian orphans
+
+# Notes with no outgoing links
+obsidian deadends
+
+# Counts only
+obsidian orphans total
+obsidian deadends total
 ```
+
+`orphans` (no incoming) and `deadends` (no outgoing) target different
+problems — combine them to find truly disconnected notes.
 
 ## Common Flags
 
 | Flag | Description |
 |------|-------------|
 | `format=json` | JSON output for machine parsing |
-| `format=csv` | CSV output |
-| `limit=N` | Limit result count |
-| `sort=count\|name\|date` | Sort order |
+| `format=tsv`, `format=csv` | Spreadsheet-friendly output |
+| `format=md` | Markdown rendering (outline, base:query) |
+| `limit=N` | Cap result count |
+| `path=<folder>` | Restrict search to a folder |
+| `case` | Case-sensitive search |
+| `total` | Return only the count |
+| `counts` | Include per-result counts |
+| `verbose` | Include source files / details |
 | `--copy` | Copy result to clipboard |
 
 ## Agentic Optimizations
 
 | Context | Command |
 |---------|---------|
-| Search (structured) | `obsidian search query="term" format=json` |
-| Tag frequency analysis | `obsidian tags sort=count` |
-| Find tagged notes | `obsidian tag tagname=X` |
-| Broken link audit | `obsidian unresolved` |
+| Grep-style search (default) | `obsidian search:context query="term"` |
+| Path-only search (structured) | `obsidian search query="term" format=json` |
+| Match count | `obsidian search query="term" total` |
+| Tag frequency analysis | `obsidian tags counts sort=count` |
+| Find tagged notes | `obsidian tag name=X verbose` |
+| Heading outline (json) | `obsidian outline file=X format=json` |
+| Broken link audit | `obsidian unresolved counts verbose` |
 | Orphan detection | `obsidian orphans` |
-| Link graph for note | `obsidian links file="X"` then `obsidian backlinks file="X"` |
+| Dead-end detection | `obsidian deadends` |
+| Link graph for note | `obsidian links file=X` + `obsidian backlinks file=X` |
 
 ## Related Skills
 
-- **vault-files** — Read, create, and manage notes
+- **vault-files** — Read content at a `path:line` returned by `search:context`
 - **properties** — Search and filter by frontmatter properties
+- **bases** — Pre-built queries via Base views
+- **bookmarks** — Promote a frequent search to a saved bookmark

--- a/obsidian-plugin/skills/templates/SKILL.md
+++ b/obsidian-plugin/skills/templates/SKILL.md
@@ -1,0 +1,125 @@
+---
+created: 2026-04-30
+modified: 2026-04-30
+reviewed: 2026-04-30
+name: templates
+description: |
+  List, read, and insert Obsidian templates from the core Templates plugin.
+  Covers template variable resolution ({{date}}, {{time}}, {{title}}) and the
+  difference between inserting into the active file vs creating a new file
+  from a template. Use when the user mentions Obsidian templates, the
+  Templates plugin, or template variable resolution.
+user-invocable: false
+allowed-tools: Bash(obsidian *), Read, Grep, Glob
+---
+
+# Obsidian Templates
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative instead when... |
+|---|---|
+| Listing or previewing the templates configured in the vault | Editing template content as a plain note — use `vault-files` |
+| Inserting a template into the currently open note | Creating a new note **from** a template — use `vault-files` `create … template=…` |
+| Reading the resolved (`{{date}}` → real date) form of a template | Working with Templater plugin scripts — use `command-palette` for `templater-obsidian:*` |
+
+This skill covers the **core Templates plugin**. The community Templater
+plugin uses a different command surface — invoke it via `command-palette`
+(`templater-obsidian:*`) instead.
+
+## Prerequisites
+
+- Obsidian desktop v1.12.4+ with CLI enabled
+- Obsidian must be running
+- Core **Templates** plugin enabled, with a templates folder configured
+
+## List Templates
+
+```bash
+# All templates
+obsidian templates
+
+# Just the count
+obsidian templates total
+```
+
+## Read a Template
+
+```bash
+# Raw template content (variables unresolved)
+obsidian template:read name="Meeting"
+
+# Resolve variables ({{date}}, {{time}}, {{title}})
+obsidian template:read name="Meeting" resolve
+
+# Provide a title for {{title}} resolution
+obsidian template:read name="Meeting" title="Standup 2026-04-30" resolve
+```
+
+## Insert a Template
+
+```bash
+# Insert into the active file at the cursor
+obsidian template:insert name="Meeting"
+```
+
+`template:insert` only works on the active editor. To create a new note
+from a template instead, reach for `vault-files`:
+
+```bash
+obsidian create name="Meeting 2026-04-30" template="Meeting"
+```
+
+## Common Patterns
+
+### "Preview what a template will produce before inserting"
+
+```bash
+obsidian template:read name="Daily" resolve
+```
+
+### "Bulk-create a week of daily notes from a template"
+
+```bash
+for offset in 0 1 2 3 4; do
+  date=$(date -v+${offset}d +%F)   # macOS; use date -d "+$offset days" +%F on Linux
+  obsidian create path="Daily/$date.md" template="Daily"
+done
+```
+
+### "Open today's daily template raw vs resolved (debugging)"
+
+```bash
+obsidian template:read name="Daily"           # raw, with {{date}}
+obsidian template:read name="Daily" resolve   # with today's date filled in
+```
+
+## Template Variables
+
+The core Templates plugin understands:
+
+| Variable | Resolves to |
+|----------|-------------|
+| `{{date}}` | Current date (format from Templates settings) |
+| `{{time}}` | Current time (format from Templates settings) |
+| `{{title}}` | The new note's title (or `title=` parameter) |
+
+Use the `resolve` flag to apply these — without it, `template:read` returns
+the raw source, which is what you want for editing the template itself.
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| List templates | `obsidian templates` |
+| Template count | `obsidian templates total` |
+| Raw template body | `obsidian template:read name=X` |
+| Resolved template body | `obsidian template:read name=X resolve` |
+| Insert into active file | `obsidian template:insert name=X` |
+| Create new note from template | `obsidian create name=X template=Y` (see `vault-files`) |
+
+## Related Skills
+
+- **vault-files** — Create new notes from templates (`create … template=…`)
+- **command-palette** — Invoke Templater (`templater-obsidian:*`) commands
+- **plugins-themes** — Enable / configure the Templates core plugin

--- a/obsidian-plugin/skills/vault-files/SKILL.md
+++ b/obsidian-plugin/skills/vault-files/SKILL.md
@@ -1,16 +1,17 @@
 ---
 created: 2026-03-04
-modified: 2026-04-25
-reviewed: 2026-04-25
+modified: 2026-04-30
+reviewed: 2026-04-30
 name: vault-files
 description: |
-  Obsidian vault file and folder operations via the official CLI.
-  Covers reading, creating, appending, prepending, moving, deleting notes,
-  listing files/folders, and daily note management.
-  Use when user mentions Obsidian notes, vault files, daily notes,
-  creating/editing notes, or managing vault content.
+  Obsidian vault file and folder operations via the official CLI — reading,
+  creating, appending, prepending, moving, renaming, deleting notes, file
+  info and word counts, listing files/folders, daily notes, random and
+  unique notes, and the web viewer. Use when the user mentions Obsidian
+  notes, vault files, daily notes, creating/editing/renaming notes, or
+  managing vault content.
 user-invocable: false
-allowed-tools: Bash, Read, Grep, Glob
+allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---
 
 # Obsidian Vault File Operations
@@ -19,9 +20,11 @@ allowed-tools: Bash, Read, Grep, Glob
 
 | Use this skill when... | Use the alternative instead when... |
 |---|---|
-| Reading, creating, appending, moving, or deleting notes through the running CLI | Doing offline bulk edits across many `.md` files — use `vault-frontmatter` or `vault-templates` |
+| Reading, creating, appending, moving, renaming, or deleting notes through the running CLI | Doing offline bulk edits across many `.md` files — use `vault-frontmatter` or `vault-templates` |
 | Opening or creating today's daily note | Curating MOC hub notes that organise existing content — use `vault-mocs` |
 | Managing folder layout while Obsidian is running | Renaming a note and rewriting all links to it — use `vault-wikilinks` |
+| Recovering a previous version after a bad edit | — use `file-history` |
+| Querying notes structured by a Base view | — use `bases` |
 
 Comprehensive guidance for managing files, folders, and daily notes in Obsidian vaults using the official Obsidian CLI.
 
@@ -31,26 +34,20 @@ Comprehensive guidance for managing files, folders, and daily notes in Obsidian 
 - CLI enabled in **Settings → General → Command line interface**
 - Obsidian must be running (CLI communicates with the running instance)
 
-## When to Use
-
-Use this skill automatically when:
-- User requests reading, creating, or editing Obsidian notes
-- User mentions listing files or folders in a vault
-- User wants to move or delete notes
-- User needs daily note operations (open, read, append, prepend)
-- User wants vault statistics or file counts
-
-## Path Conventions
+## Path & Flag Conventions
 
 - All paths are **vault-relative** — use `folder/note.md`, not absolute filesystem paths
-- `create` omits `.md` extension (added automatically)
-- `move` requires full target path including `.md` extension
+- `file=<name>` resolves like a wikilink (no extension needed); `path=<full/path.md>` is exact
+- Most commands default to the **active file** when neither `file=` nor `path=` is supplied
+- `create` omits `.md` from `name=` (added automatically); `move` requires `.md` in `to=`
 - Quote values containing spaces: `file="My Note Title"`
 - Newlines: `\n`, tabs: `\t`
+- **Flags are bare words** — `overwrite`, `open`, `newtab`, `permanent`, `inline`, `total`. The single exception is `--copy` (a universal output flag).
+- **Multi-vault**: prefix `vault=<name>` before the command — see `vault-management`
 
 ## Core File Operations
 
-### List Files
+### List Files & Folders
 
 ```bash
 # All files in vault
@@ -59,21 +56,36 @@ obsidian files
 # Files in specific folder
 obsidian files folder=Projects/Active
 
+# Filter by extension
+obsidian files ext=canvas
+
 # Total note count
 obsidian files total
 
-# JSON output for parsing
-obsidian files format=json
+# All folders, or a tree view
+obsidian folders
+obsidian folders format=tree
 ```
 
-### List Folders
+### File Info
 
 ```bash
-# All directories
-obsidian folders
+# Info on the active file (path/name/extension/size/created/modified)
+obsidian file
 
-# Tree view
-obsidian folders format=tree
+# Info on a specific file
+obsidian file file=Recipe
+obsidian file path="Notes/Recipe.md"
+
+# Folder info
+obsidian folder path="Projects"
+obsidian folder path="Projects" info=files
+obsidian folder path="Projects" info=size
+
+# Word and character counts
+obsidian wordcount file=Recipe
+obsidian wordcount file=Recipe words
+obsidian wordcount file=Recipe characters
 ```
 
 ### Read a Note
@@ -82,8 +94,14 @@ obsidian folders format=tree
 # Read by name (wikilink resolution)
 obsidian read file="Note Name"
 
-# Read by path
+# Read by exact path
 obsidian read path="Projects/spec.md"
+
+# Read the active file (no args)
+obsidian read
+
+# Copy result to clipboard
+obsidian read file="Note Name" --copy
 ```
 
 ### Create a Note
@@ -95,11 +113,11 @@ obsidian create name="New Note"
 # Create in folder with content
 obsidian create name="Projects/Feature Spec" content="# Feature Spec\n\nDescription here."
 
-# Create from template
-obsidian create name="Meeting Notes" template="Templates/Meeting"
+# Create from a template (see also: templates skill)
+obsidian create name="Meeting Notes" template="Meeting"
 
-# Overwrite existing
-obsidian create name="Draft" content="Fresh start" --overwrite
+# Overwrite existing, then open it
+obsidian create name="Draft" content="Fresh start" overwrite open
 ```
 
 ### Append / Prepend
@@ -108,29 +126,48 @@ obsidian create name="Draft" content="Fresh start" --overwrite
 # Add to end of note
 obsidian append file="Daily Log" content="\n## New Section\nContent here."
 
-# Add to beginning of note
+# Append without an extra newline
+obsidian append file="Daily Log" content="more text" inline
+
+# Add after frontmatter (prepend skips YAML)
 obsidian prepend file="Inbox" content="- [ ] New task\n"
 ```
 
-### Move a Note
+### Open a Note
 
 ```bash
-# Move to folder (requires .md extension on target)
+obsidian open file="Recipe"
+obsidian open path="Notes/Recipe.md" newtab
+```
+
+### Move / Rename
+
+```bash
+# Move to a folder (requires .md extension on target)
 obsidian move file="Draft" to=Archive/Draft.md
 
-# Rename in place
-obsidian move file="Old Name" to="New Name.md"
+# Move + rename in one shot
+obsidian move file="Old Name" to="Archive/New Name.md"
+
+# Rename in place — preserves extension automatically
+obsidian rename file="Old Name" name="New Name"
 ```
 
-### Delete a Note
+`move` and `rename` automatically update internal links if **Settings →
+Files & Links → Automatically update internal links** is enabled.
+
+### Delete
 
 ```bash
-# Move to Obsidian trash
+# Move to system / Obsidian trash
 obsidian delete file="Old Note"
 
-# Permanent deletion (irreversible)
-obsidian delete file="Old Note" --permanent
+# Permanent deletion (skips trash, irreversible)
+obsidian delete file="Old Note" permanent
 ```
+
+For undoing accidental deletes, see `file-history` (`history:restore`,
+`sync:restore`, `sync:deleted`).
 
 ## Daily Notes
 
@@ -138,46 +175,105 @@ obsidian delete file="Old Note" --permanent
 # Open today's daily note (creates if needed)
 obsidian daily
 
+# Get the expected daily note path (without creating)
+obsidian daily:path
+
 # Read today's content
 obsidian daily:read
 
-# Append to today's note
+# Append / prepend
 obsidian daily:append content="- Met with team about roadmap"
-
-# Prepend to today's note
 obsidian daily:prepend content="## Morning Goals\n- Review PRs"
 
-# Open specific date
-obsidian daily:open date=2026-02-15
+# Open in a split or new window
+obsidian daily paneType=split
+obsidian daily paneType=window
+```
+
+The CLI does not expose a `date=` parameter on `daily` itself; for past
+dates use `obsidian open path="Daily/2026-02-15.md"` (with the actual
+folder/format from your Daily Notes settings).
+
+## Random & Unique Notes
+
+```bash
+# Open a random note
+obsidian random
+
+# Limit randomness to a folder
+obsidian random folder=Inbox newtab
+
+# Read a random note (returns content + path)
+obsidian random:read folder=Inbox
+
+# Unique note creator (Zettelkasten-style)
+obsidian unique name="Idea" content="# Spark\n\n" open
+```
+
+## Web Viewer
+
+```bash
+# Open a URL in Obsidian's built-in web viewer
+obsidian web url="https://obsidian.md/help/cli"
+
+# In a new tab
+obsidian web url="https://obsidian.md/help/cli" newtab
+```
+
+Useful for keeping reference docs side-by-side with notes without leaving
+Obsidian.
+
+## App Maintenance
+
+```bash
+# Obsidian app version
+obsidian version
+
+# Reload the active window (cheap; preserves vault)
+obsidian reload
+
+# Full app restart (heavier; for plugin reloads, prefer plugin:reload)
+obsidian restart
 ```
 
 ## Common Flags
 
-| Flag | Description |
-|------|-------------|
+| Flag / Parameter | Description |
+|------------------|-------------|
 | `format=json` | JSON output for machine parsing |
-| `format=csv` | CSV output |
-| `format=tree` | Tree view for folders |
-| `--silent` | Suppress output |
-| `--overwrite` | Replace existing note on create |
-| `--permanent` | Irreversible delete (skip trash) |
-| `--copy` | Copy result to clipboard |
-| `limit=N` | Limit result count |
-| `sort=name\|date` | Sort order |
+| `format=csv`, `format=tsv` | Spreadsheet-friendly outputs |
+| `format=tree` | Tree view (folders, outline) |
+| `--copy` | **Universal**: copy command output to clipboard |
+| `overwrite` | Replace existing file on `create` |
+| `permanent` | Irreversible delete (skip trash) |
+| `inline` | Append/prepend without an added newline |
+| `open` | Open file after creating |
+| `newtab` | Open in a new tab instead of replacing the active leaf |
+| `total` | Return only the count for list commands |
+| `paneType=tab\|split\|window` | Choose where to open |
 
 ## Agentic Optimizations
 
 | Context | Command |
 |---------|---------|
 | List files (structured) | `obsidian files format=json` |
+| Filter by extension | `obsidian files ext=md` |
 | File count | `obsidian files total` |
-| Folder listing (structured) | `obsidian folders format=json` |
+| Folder tree | `obsidian folders format=tree` |
 | Read note content | `obsidian read file="Name"` |
+| Read & copy to clipboard | `obsidian read file="Name" --copy` |
 | Quick capture to daily | `obsidian daily:append content="text"` |
-| Batch file listing | `obsidian files folder=X format=json` |
+| Append without newline | `obsidian append file=X content=Y inline` |
+| Rename in place | `obsidian rename file=X name=Y` |
+| Word count only | `obsidian wordcount file=X words` |
+| Random note (read) | `obsidian random:read folder=X` |
 
 ## Related Skills
 
-- **search-discovery** — Find notes by content, tags, or links
+- **search-discovery** — Find notes by content, tags, links, or grep-style context
 - **properties** — Manage YAML frontmatter on notes
 - **tasks** — Task management across the vault
+- **bases** — Query notes via Base views
+- **templates** — List, preview, and insert templates
+- **file-history** — Restore previous versions or recover deletes
+- **vault-management** — Multi-vault `vault=` prefix and vault info

--- a/obsidian-plugin/skills/vault-management/SKILL.md
+++ b/obsidian-plugin/skills/vault-management/SKILL.md
@@ -1,0 +1,132 @@
+---
+created: 2026-04-30
+modified: 2026-04-30
+reviewed: 2026-04-30
+name: vault-management
+description: |
+  Inspect the active vault, enumerate known vaults, and target commands at a
+  specific vault using the global `vault=` prefix. Use when the user asks
+  about vault info (path, file count, size), works across multiple vaults,
+  or wants to run a command against a non-active vault.
+user-invocable: false
+allowed-tools: Bash(obsidian *), Read, Grep, Glob
+---
+
+# Obsidian Vault Management
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative instead when... |
+|---|---|
+| Listing every vault Obsidian knows about | Listing files inside the active vault — use `vault-files` |
+| Targeting a non-active vault for one command | Switching the active vault permanently — `vault:open` (TUI only) |
+| Reporting vault info (path, file count, size) for diagnostics | Reading a specific note — use `vault-files` |
+
+The CLI defaults to the **active vault** (the one currently focused in the
+Obsidian app), unless your terminal's working directory is itself inside a
+vault folder — in which case that vault wins. The `vault=` prefix overrides
+both, scoped to a single command invocation.
+
+## Prerequisites
+
+- Obsidian desktop v1.12.4+ with CLI enabled
+- Obsidian must be running
+
+## Vault Info
+
+```bash
+# Active vault overview
+obsidian vault
+
+# Specific fields only
+obsidian vault info=name
+obsidian vault info=path
+obsidian vault info=files
+obsidian vault info=folders
+obsidian vault info=size
+```
+
+## Enumerate Known Vaults
+
+```bash
+# All known vaults (name only)
+obsidian vaults
+
+# Include vault paths (verbose)
+obsidian vaults verbose
+
+# Just the count
+obsidian vaults total
+```
+
+## Target a Specific Vault
+
+`vault=` is a **global prefix** — it must come before the command, not as
+a normal parameter:
+
+```bash
+# Run against a specific vault by name
+obsidian vault=Notes daily
+obsidian vault="My Vault" search query="meeting"
+
+# By vault ID (from `obsidian vaults verbose` or settings)
+obsidian vault=abc123def files
+```
+
+In the TUI, `vault:open name=Notes` switches the active vault for the rest
+of the session. Outside the TUI, prefer the `vault=` prefix per command.
+
+## Working-Directory Default
+
+If the terminal is `cd`-ed into a vault folder, that vault is the default —
+no `vault=` needed:
+
+```bash
+cd ~/vaults/Work
+obsidian search query="status::active"   # runs against ~/vaults/Work
+```
+
+This is convenient for shell scripts that live alongside a specific vault.
+
+## Common Patterns
+
+### "Diagnostic snapshot of every vault"
+
+```bash
+obsidian vaults verbose | while read -r line; do
+  name=$(echo "$line" | awk '{print $1}')
+  echo "=== $name ==="
+  obsidian vault="$name" vault info=files
+  obsidian vault="$name" vault info=size
+done
+```
+
+### "Search across one vault while a different one is active"
+
+```bash
+obsidian vault=Personal search query="trip ideas" format=json
+```
+
+### "Confirm which vault a script will hit"
+
+```bash
+obsidian vault info=name
+obsidian vault info=path
+```
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Active vault summary | `obsidian vault` |
+| Active vault path only | `obsidian vault info=path` |
+| Active vault file count | `obsidian vault info=files` |
+| List vaults (verbose) | `obsidian vaults verbose` |
+| Vault count | `obsidian vaults total` |
+| Run command against a vault | `obsidian vault=NAME <command>` |
+
+## Related Skills
+
+- **vault-files** — File operations within the active or targeted vault
+- **publish-sync** — Per-vault Obsidian Sync configuration and status
+- **search-discovery** — Search inside a (possibly `vault=`-prefixed) vault

--- a/obsidian-plugin/skills/workspaces/SKILL.md
+++ b/obsidian-plugin/skills/workspaces/SKILL.md
@@ -1,0 +1,143 @@
+---
+created: 2026-04-30
+modified: 2026-04-30
+reviewed: 2026-04-30
+name: workspaces
+description: |
+  Inspect and manage the Obsidian editor workspace — open tabs, recent files,
+  saved Workspaces (the core plugin), and individual tab management. Use when
+  the user asks what's open in Obsidian, wants to switch to a saved layout,
+  save the current layout, or open files into specific tabs/groups.
+user-invocable: false
+allowed-tools: Bash(obsidian *), Read, Grep, Glob
+---
+
+# Obsidian Workspaces, Tabs & Recents
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative instead when... |
+|---|---|
+| Inspecting the current workspace tree, tabs, or recently opened files | Reading or writing note content — use `vault-files` |
+| Saving / loading layouts via the Workspaces core plugin | Switching between vaults — use `vault-management` |
+| Opening a file into a specific tab group | Triggering a generic UI command — use `command-palette` |
+
+The Workspaces core plugin must be enabled for `workspace:save` / `:load` /
+`:delete` and the `workspaces` list to return data. `tabs`, `tab:open`,
+`recents`, and the bare `workspace` tree command work without it.
+
+## Prerequisites
+
+- Obsidian desktop v1.12.4+ with CLI enabled
+- Obsidian must be running
+- For saved-layout commands: enable the **Workspaces** core plugin
+
+## Inspect the Current Workspace
+
+```bash
+# Tree of the active workspace (groups, splits, leaves)
+obsidian workspace
+
+# Include item IDs (needed for tab:open group=)
+obsidian workspace ids
+```
+
+## Tabs
+
+```bash
+# Open tabs in the active window
+obsidian tabs
+
+# Include tab IDs
+obsidian tabs ids
+
+# Open a file into a new tab (defaults to active group)
+obsidian tab:open file="Notes/Recipe"
+
+# Open into a specific group (use ids from `obsidian workspace ids` or `obsidian tabs ids`)
+obsidian tab:open group=<group-id> file="Notes/Recipe"
+
+# Open a non-file view (graph, file explorer, etc.)
+obsidian tab:open view=graph
+obsidian tab:open view=file-explorer
+```
+
+## Recent Files
+
+```bash
+# Recently opened files (tab history)
+obsidian recents
+
+# Just the count
+obsidian recents total
+```
+
+## Saved Workspaces (core plugin)
+
+```bash
+# All saved layouts
+obsidian workspaces
+obsidian workspaces total
+
+# Save the current layout
+obsidian workspace:save name="Writing"
+
+# Switch to a saved layout
+obsidian workspace:load name="Writing"
+
+# Delete a saved layout
+obsidian workspace:delete name="Writing"
+```
+
+## Common Patterns
+
+### "What is the user looking at right now?"
+
+```bash
+obsidian workspace
+obsidian tabs
+obsidian recents
+```
+
+### "Open these three notes side-by-side, then save the layout"
+
+```bash
+obsidian open file="Brief"
+obsidian command id=workspace:split-vertical
+obsidian tab:open file="Spec"
+obsidian command id=workspace:split-vertical
+obsidian tab:open file="Notes"
+obsidian workspace:save name="Triage"
+```
+
+### "Restore the writing layout for a focused session"
+
+```bash
+obsidian workspace:load name="Writing"
+```
+
+### "Open the graph view in a new tab"
+
+```bash
+obsidian tab:open view=graph
+```
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Workspace tree | `obsidian workspace` |
+| Workspace with IDs | `obsidian workspace ids` |
+| Open tabs | `obsidian tabs` |
+| Recently opened | `obsidian recents` |
+| Open file in new tab | `obsidian tab:open file=X` |
+| Open view (graph, etc.) | `obsidian tab:open view=Y` |
+| List saved layouts | `obsidian workspaces` |
+| Switch layout | `obsidian workspace:load name=X` |
+| Save layout | `obsidian workspace:save name=X` |
+
+## Related Skills
+
+- **vault-files** — Read or write the file you just opened
+- **command-palette** — `workspace:split-vertical`, `workspace:split-horizontal`, etc.
+- **vault-management** — Switch vaults before inspecting their workspace


### PR DESCRIPTION
## Summary

Brings `obsidian-plugin` into 1:1 coverage with the official Obsidian CLI documentation (https://obsidian.md/help/cli) and adds a scheduled workflow that watches the upstream doc for changes and proposes skill updates as draft PRs.

### New skills (8)

| Skill | CLI commands wrapped |
|-------|----------------------|
| `bases` | `bases`, `base:views`, `base:create`, `base:query` (json/csv/tsv/md/paths) |
| `command-palette` | `commands`, `command id=`, `hotkeys`, `hotkey` — runs any built-in or plugin-registered command |
| `file-history` | `diff`, `history`, `history:list/read/restore/open`, `sync:history/read/restore/open`, `sync:deleted` — restore-after-edit safety net |
| `dev-tools` | `devtools`, `eval`, `dev:debug/cdp/errors/console/css/dom/mobile/screenshot` — split out from `plugins-themes` |
| `workspaces` | `workspace`, `workspaces`, `workspace:save/load/delete`, `tabs`, `tab:open`, `recents` |
| `vault-management` | `vault`, `vaults`, `vault:open`, multi-vault `vault=<name>` global prefix |
| `templates` | `templates`, `template:read` (with `resolve`), `template:insert` |
| `bookmarks` | `bookmarks`, `bookmark` (file/folder/subpath/search/url) |

### Updated skills (4)

- **vault-files** — adds `file` info, `rename`, `random`/`random:read`, `unique`, `wordcount`, `web`, `version`/`reload`/`restart`, the universal `--copy` flag, and fixes the bare-flag vs `--flag` confusion (`overwrite`/`permanent` are bare; only `--copy` is `--`-prefixed).
- **search-discovery** — adds `search:context` (grep-style `path:line:text` — the agentic-friendly default), `outline`, and `deadends`.
- **plugins-themes** — slims developer commands out into `dev-tools`; adds `plugins:restrict`, `theme:install`/`uninstall`, and CSS `snippets`/`snippet:enable`/`disable`.
- **publish-sync** — adds `publish:site`, `publish:status` (new/changed/deleted), `publish:open`, `sync:deleted`, and cross-links to `file-history` for per-file sync version restore.

### Upstream-doc tracker

- `.obsidian-cli-version-check.json` — SHA-256 of the canonical CLI doc markdown plus the latest Obsidian desktop version (informational).
- `.github/workflows/obsidian-cli-changelog.yml` — runs weekly (Tuesdays 09:00 UTC), fetches `https://publish-01.obsidian.md/access/.../Obsidian%20CLI.md`, compares hashes, and on change spawns a Claude review pass that diffs the doc against existing skills and opens a draft PR with proposed updates. Modeled on the existing `changelog-review.yml` pattern.

Run on demand from **Actions → Plugin: Obsidian CLI changelog review → Run workflow**.

### Plugin lifecycle metadata

- `obsidian-plugin/.claude-plugin/plugin.json` — description + 6 new keywords
- `.claude-plugin/marketplace.json` — same description + keywords
- `obsidian-plugin/README.md` — 8 new skill entries + corrected conventions section
- `.github/workflows/README.md` — sorted-name list updated

## Test plan

- [ ] `python3 -c "import json; json.load(open('.claude-plugin/marketplace.json'))"` and the other JSON files parse cleanly ✅ (verified locally)
- [ ] All SKILL.md files under the 500-line limit ✅ (largest is `vault-files` at 279 lines)
- [ ] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/obsidian-cli-changelog.yml'))"` parses ✅
- [ ] CI: `Plugin: PR checks` and `Plugin: Lint skills` pass
- [ ] CI: `Plugin: Validate configs` passes (release-please config unchanged)
- [ ] Manual: trigger `Plugin: Obsidian CLI changelog review` via `workflow_dispatch` with `force_full_review=true` and confirm it opens a no-op review PR (or skips cleanly if no changes detected)
- [ ] Manual: invoke `bases`, `command-palette`, `file-history`, `dev-tools`, `workspaces`, `vault-management`, `templates`, `bookmarks` against a running Obsidian 1.12.7+ instance and confirm command syntax matches

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZCG5cLP1diwgLftRUfKax)_