### PR TITLE
docs(workflows): document OIDC validation failure on workflow-modifying PRs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -49,3 +49,13 @@ Renovate
 ## Cross-workflow references
 
 When a workflow references another by display name (e.g. `on.workflow_run.workflows`), update the reference whenever the target's `name:` changes. The current cross-references live in `github-workflow-auto-fix.yml`.
+
+## Known limitations
+
+### OIDC token validation failure on workflow-modifying PRs
+
+Any PR that modifies files in `.github/workflows/` will see a `401 Unauthorized – Workflow validation failed` error in the **Claude Skill Quality Review** step of the **Plugin: PR checks** workflow. This is a GitHub Actions platform limitation: OIDC token exchange validates that the workflow file content is identical to the version on the default branch. PRs modifying workflows fail this check because the executing workflow file differs from `main`.
+
+This failure is not a code issue and requires no action — it resolves automatically when the PR merges to the default branch. The workflow then re-runs successfully on the merged commit.
+
+See [#1204](https://github.com/laurigates/claude-plugins/issues/1204) for details.


### PR DESCRIPTION
## Summary

Adds a **Known limitations** section to `.github/workflows/README.md` documenting the GitHub OIDC token-exchange behavior that causes the **Claude Skill Quality Review** step (in **Plugin: PR checks**) to fail on any PR that modifies `.github/workflows/*.yml`.

This is a server-side GitHub security check — OIDC token exchange validates the executing workflow file content against the default branch. Workflow-modifying PRs fail the check because the executing file differs from `main`. The failure resolves automatically when the PR merges.

## Test plan

- [x] README diff is docs-only (no workflow YAML touched, so this PR will not itself trigger the documented failure)
- [x] Renders correctly as GitHub Markdown
- [x] Cites issue #1204 for traceability

Closes #1204