### PR TITLE
feat(macos-plugin): add macOS-specific dev environment plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -399,6 +399,25 @@
       "category": "ai"
     },
     {
+      "name": "macos-plugin",
+      "source": "./macos-plugin",
+      "description": "macOS-specific dev environment tooling - kitty session persistence, LaunchServices health, incident postmortems for kernel panics, WindowServer hangs, and long-uptime drift",
+      "version": "1.0.0",
+      "keywords": [
+        "macos",
+        "darwin",
+        "kitty",
+        "session-persistence",
+        "launchservices",
+        "windowserver",
+        "kernel-panic",
+        "diagnostics",
+        "incident-postmortem",
+        "uptime"
+      ],
+      "category": "utilities"
+    },
+    {
       "name": "migration-patterns-plugin",
       "source": "./migration-patterns-plugin",
       "description": "Safe database and system migration patterns - dual write, shadow mode, strangler fig",

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -24,6 +24,7 @@
   "hooks-plugin": "1.16.9",
   "kubernetes-plugin": "1.7.2",
   "langchain-plugin": "1.5.2",
+  "macos-plugin": "1.0.0",
   "migration-patterns-plugin": "1.3.0",
   "networking-plugin": "1.3.2",
   "project-plugin": "1.14.0",

--- a/docs/PLUGIN-MAP.md
+++ b/docs/PLUGIN-MAP.md
@@ -1,6 +1,6 @@
 # Plugin Navigation Map
 
-Navigation guide for 38 plugins and 300+ skills. Start here.
+Navigation guide for 39 plugins and 300+ skills. Start here.
 
 ## Quick Start
 
@@ -184,6 +184,7 @@ Install based on your project's tech stack and domain.
 | api-plugin | Building or testing REST APIs |
 | langchain-plugin | Building AI agents with LangChain/LangGraph |
 | home-assistant-plugin | Home Assistant configuration management |
+| macos-plugin | macOS-specific operational tooling — kitty session persistence, LaunchServices health, incident postmortems |
 | blog-plugin | Writing project logs or technical posts |
 | communication-plugin | Formatting for Google Chat or ticket drafting |
 | css-plugin | Lightning CSS transpilation, UnoCSS atomic utility generation for style tooling |

--- a/macos-plugin/.claude-plugin/plugin.json
+++ b/macos-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "macos-plugin",
+  "version": "1.0.0",
+  "description": "macOS-specific dev environment tooling — kitty session persistence, LaunchServices health, incident postmortems for kernel panics, WindowServer hangs, and long-uptime drift",
+  "author": {
+    "name": "Lauri Gates",
+    "url": "https://github.com/laurigates"
+  },
+  "repository": "https://github.com/laurigates/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "macos",
+    "darwin",
+    "kitty",
+    "kitten",
+    "session-persistence",
+    "session-restore",
+    "launchctl",
+    "launchagent",
+    "launchservices",
+    "lsregister",
+    "windowserver",
+    "kernel-panic",
+    "watchdog",
+    "diagnosticreports",
+    "jetsam",
+    "incident-postmortem",
+    "uptime",
+    "kern-boottime"
+  ]
+}

--- a/macos-plugin/README.md
+++ b/macos-plugin/README.md
@@ -1,0 +1,44 @@
+# macos-plugin
+
+macOS-specific operational tooling for the dev-environment concerns that don't fit cleanly into cross-platform plugins: recovering from GUI freezes, diagnosing macOS-specific instability, and long-uptime hygiene.
+
+All skills are **Darwin-only** — they detect non-macOS systems and refuse to act.
+
+## Skills
+
+| Skill | Description |
+|-------|-------------|
+| [kitty-session-persistence](skills/kitty-session-persistence/skill.md) | Snapshot and restore kitty terminal sessions across crashes and reboots via `kitten @ ls` and a LaunchAgent |
+| [launchservices-health](skills/launchservices-health/skill.md) | Quantify the LaunchServices DB, `launchservicesd` RSS/uptime, and surface the safe rebuild command |
+| [macos-incident-postmortem](skills/macos-incident-postmortem/skill.md) | Reconstruct what happened from `/Library/Logs/DiagnosticReports/`, `kern.boottime`, and shell history after a hang or panic |
+
+## When to Use
+
+| Scenario | Skill |
+|----------|-------|
+| Terminal sessions vanished after a hard reboot or kitty crash | `kitty-session-persistence` |
+| `launchservicesd` is pegged at high CPU; LS DB feels bloated | `launchservices-health` |
+| GUI froze and you're not sure if the machine actually rebooted | `macos-incident-postmortem` |
+| Investigating recent kernel panics, watchdog timeouts, jetsam events | `macos-incident-postmortem` |
+| Auditing whether the machine is "due for a reboot" after weeks of uptime | `macos-incident-postmortem` + `launchservices-health` |
+
+## Scope
+
+- **macOS-only** — every skill checks `uname -s` and refuses on non-Darwin systems.
+- **Runtime diagnostics, not initial setup** — overlaps with `configure-plugin` are intentional gaps; that plugin is for project setup, this is for recovery and observability.
+- **OS health, not Claude Code health** — `health-plugin` covers Claude Code config; this covers the host operating system.
+
+## Origin
+
+Created in response to a real 2026-04-22 incident: a 33-day uptime plus repeated `wineserver` crashes pushed `launchservicesd` to sustained 85% CPU, blocking WindowServer's main thread on a LaunchServices XPC call. The GUI froze, kitty was killed, all open Claude Code sessions terminated mid-write. Recovery required reconstructing what was open from `~/.claude/projects/*/*.jsonl` mtimes and ad-hoc `lsregister -dump` analysis. The skills here turn that ad-hoc recovery into repeatable workflows.
+
+See [issue #1108](https://github.com/laurigates/claude-plugins/issues/1108) for the original proposal.
+
+## Future Skills
+
+These are deliberately out of scope for the initial release; track in follow-up issues if needed:
+
+- `pmset-analysis` — sleep/wake assertion attribution
+- `mdworker-diagnostics` — Spotlight indexing health
+- `homebrew-services-audit` — long-running brew services hygiene
+- `mac-kernel-extension-status` — `kmutil` / `systemextensionsctl` summaries

--- a/macos-plugin/skills/kitty-session-persistence/skill.md
+++ b/macos-plugin/skills/kitty-session-persistence/skill.md
@@ -1,0 +1,274 @@
+---
+name: kitty-session-persistence
+description: Snapshot and restore kitty terminal sessions across crashes, reboots, and GUI hangs on macOS. Use when you want to survive WindowServer hangs without losing open tabs, configure a periodic kitty session snapshot, or restore a snapshot after a force-reboot.
+user-invocable: false
+allowed-tools: Bash(kitty *), Bash(kitten *), Bash(launchctl *), Bash(uname *), Bash(plutil *), Bash(test *), Read, Write, Edit, Grep, Glob
+created: 2026-05-03
+modified: 2026-05-03
+reviewed: 2026-05-03
+---
+
+# Kitty Session Persistence (macOS)
+
+## When to Use This Skill
+
+| Use this skill when... | Use something else when... |
+|------------------------|----------------------------|
+| Terminal sessions need to survive WindowServer hangs and force-reboots | The user's terminal is iTerm2 / Terminal.app / Ghostty / Wezterm — kitty-specific |
+| Configuring kitty's `listen_on` socket and a snapshot LaunchAgent | Cross-platform terminal config — this is macOS LaunchAgents |
+| Restoring a previous session after a crash | One-off "open these tabs" — `kitty @ launch` directly is enough |
+| Auditing whether snapshot capture is still running | General system diagnostics — see `macos-incident-postmortem` |
+
+## Platform Guard
+
+This skill is **macOS-only**. All commands assume Darwin and `launchctl`-managed LaunchAgents. Refuse to act if `uname -s` is not `Darwin`.
+
+```bash
+test "$(uname -s)" = "Darwin" || { echo "macos-plugin: not Darwin, refusing"; exit 1; }
+```
+
+## Core Expertise
+
+Kitty exposes a remote control protocol via a Unix socket. With `listen_on` configured, `kitten @ ls` returns a JSON description of every OS window, tab, and window inside kitty — enough to reconstruct the layout from scratch.
+
+The pattern this skill installs:
+
+1. **Always-listen socket** — `listen_on unix:/tmp/kitty-$USER` in `kitty.conf` so the snapshot script can always reach the running instance.
+2. **Snapshot script** — captures `kitten @ ls` output to a timestamped JSON file under `~/.local/state/kitty-sessions/`, with a `latest.json` symlink.
+3. **LaunchAgent** — runs the snapshot script every 5 minutes (default) so the worst-case loss is one window of work.
+4. **Restore command** — reads `latest.json` and re-launches tabs with the recorded `cwd` and command.
+
+### Architectural notes
+
+- Kitty's remote control requires `allow_remote_control yes` in `kitty.conf` **or** `--allow-remote-control yes` at launch.
+- The socket path must match between `listen_on` and the `kitten @ --to` flag the snapshot script uses.
+- LaunchAgent `StandardOutPath` and `StandardErrorPath` are essential — failing snapshots are otherwise silent.
+- Use `RunAtLoad: false` and rely on `StartInterval` so a kitty restart doesn't spawn a backlog of immediate snapshots.
+
+## Setup
+
+### 1. Configure kitty
+
+Add to `~/.config/kitty/kitty.conf`:
+
+```conf
+allow_remote_control yes
+listen_on unix:/tmp/kitty-{kitty_pid}
+```
+
+Using `{kitty_pid}` makes each kitty instance addressable on its own socket. For the persistent-socket pattern this skill needs, use the user-stable form instead:
+
+```conf
+allow_remote_control yes
+listen_on unix:/tmp/kitty-USER
+```
+
+Replace `USER` with the actual username. The snapshot LaunchAgent points at this exact path.
+
+Reload kitty after editing:
+
+```bash
+kitty @ --to unix:/tmp/kitty-USER load-config
+```
+
+### 2. Install the snapshot script
+
+Create `~/.local/bin/kitty-snapshot` (mode 0755):
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+
+[ "$(uname -s)" = "Darwin" ] || exit 0
+
+SOCKET="unix:/tmp/kitty-${USER}"
+STATE_DIR="${HOME}/.local/state/kitty-sessions"
+mkdir -p "$STATE_DIR"
+
+ts="$(date -u +%Y%m%dT%H%M%SZ)"
+out="${STATE_DIR}/${ts}.json"
+
+if ! kitten @ --to "$SOCKET" ls >"$out" 2>>"${STATE_DIR}/snapshot.err"; then
+  rm -f "$out"
+  exit 0   # kitty not running — silent success
+fi
+
+ln -sfn "$out" "${STATE_DIR}/latest.json"
+
+# Keep ~7 days of 5-min snapshots = 2016 files; cap at 4032 (14 days)
+ls -1t "$STATE_DIR"/*.json 2>/dev/null | tail -n +4033 | xargs -r rm -f
+```
+
+The `exit 0` on `kitten @ ls` failure is intentional — the LaunchAgent fires every 5 minutes regardless of whether kitty is running.
+
+### 3. Install the LaunchAgent
+
+Write `~/Library/LaunchAgents/com.<reverse-dns>.kitty-snapshot.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.example.kitty-snapshot</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/USER/.local/bin/kitty-snapshot</string>
+  </array>
+  <key>StartInterval</key>
+  <integer>300</integer>
+  <key>RunAtLoad</key>
+  <false/>
+  <key>StandardOutPath</key>
+  <string>/Users/USER/.local/state/kitty-sessions/launchd.out</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/USER/.local/state/kitty-sessions/launchd.err</string>
+</dict>
+</plist>
+```
+
+Replace `com.example` with a stable reverse-DNS prefix and `USER` with the literal username (LaunchAgents do not expand `$HOME`).
+
+Validate, load, and verify:
+
+```bash
+plutil -lint ~/Library/LaunchAgents/com.example.kitty-snapshot.plist
+launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.example.kitty-snapshot.plist
+launchctl print "gui/$(id -u)/com.example.kitty-snapshot" | grep -E 'state|last exit'
+```
+
+`bootstrap` replaces the deprecated `launchctl load`; on macOS 11+ prefer it.
+
+### 4. Confirm capture is working
+
+After ~5 minutes:
+
+```bash
+ls -lt ~/.local/state/kitty-sessions/*.json | head -3
+```
+
+There should be JSON files newer than the LaunchAgent install time. The newest file's content should match what kitty has open right now.
+
+## Restore
+
+Read `latest.json` and re-launch each window/tab. A minimal restore script:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+[ "$(uname -s)" = "Darwin" ] || exit 1
+
+LATEST="${HOME}/.local/state/kitty-sessions/latest.json"
+SOCKET="unix:/tmp/kitty-${USER}"
+
+[ -L "$LATEST" ] || { echo "no snapshot found"; exit 1; }
+
+jq -c '.[] | .tabs[] | .windows[] | {cwd, foreground_processes}' "$LATEST" |
+while IFS= read -r win; do
+  cwd=$(printf '%s' "$win" | jq -r '.cwd')
+  cmd=$(printf '%s' "$win" | jq -r '.foreground_processes[0].cmdline | join(" ")')
+  kitten @ --to "$SOCKET" launch --type=tab --cwd="$cwd" "$cmd"
+done
+```
+
+The shape of `kitten @ ls` output is `[{tabs:[{windows:[{cwd, foreground_processes:[{cmdline}]}]}]}]`. Adjust the `jq` query if a future kitty release changes it.
+
+## Common Patterns
+
+### Audit recent snapshots
+
+```bash
+ls -1t ~/.local/state/kitty-sessions/*.json | head -10
+jq '. | length, [.[].tabs | length] | add' ~/.local/state/kitty-sessions/latest.json
+# → window count, tab count
+```
+
+### Confirm LaunchAgent is healthy
+
+```bash
+launchctl print "gui/$(id -u)/com.example.kitty-snapshot" | \
+  grep -E 'state|last exit|on demand'
+```
+
+`state = running` (briefly, every 5 minutes) and `last exit code = 0` indicate health. Persistent non-zero exit means something is broken — check `launchd.err`.
+
+### Disable / unload temporarily
+
+```bash
+launchctl bootout "gui/$(id -u)/com.example.kitty-snapshot"
+```
+
+`bootout` is the modern equivalent of `launchctl unload`.
+
+### Snapshot interval tuning
+
+| Interval | When to use |
+|----------|-------------|
+| 60s (`StartInterval=60`) | Heavy editing days — minimum loss-on-crash |
+| 300s (default) | Balanced — typical workflow |
+| 900s (15 min) | Stable, low-edit days — less noise in `ls -lt` |
+
+Reload after editing the plist:
+
+```bash
+launchctl bootout "gui/$(id -u)/com.example.kitty-snapshot"
+launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.example.kitty-snapshot.plist
+```
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Snapshot count last hour | `find ~/.local/state/kitty-sessions -name '*.json' -newermt '1 hour ago' \| wc -l` |
+| Most recent snapshot age | `stat -f '%Sm %N' ~/.local/state/kitty-sessions/latest.json` |
+| Validate a plist | `plutil -lint ~/Library/LaunchAgents/com.example.kitty-snapshot.plist` |
+| Last exit code | `launchctl print "gui/$(id -u)/com.example.kitty-snapshot" \| awk '/last exit code/{print $NF}'` |
+| Live socket reachable | `kitten @ --to unix:/tmp/kitty-$USER ls \| jq '. \| length'` |
+
+## Quick Reference
+
+### LaunchAgent commands (macOS 11+)
+
+| Operation | Command |
+|-----------|---------|
+| Load (modern) | `launchctl bootstrap "gui/$(id -u)" <plist>` |
+| Unload (modern) | `launchctl bootout "gui/$(id -u)/<label>"` |
+| Inspect | `launchctl print "gui/$(id -u)/<label>"` |
+| Run now | `launchctl kickstart -k "gui/$(id -u)/<label>"` |
+| List user agents | `launchctl print-disabled "gui/$(id -u)"` |
+
+### Kitty remote control
+
+| Operation | Command |
+|-----------|---------|
+| List sessions | `kitten @ --to <socket> ls` |
+| Launch tab | `kitten @ --to <socket> launch --type=tab --cwd=<path> <cmd>` |
+| Reload config | `kitten @ --to <socket> load-config` |
+| Send text | `kitten @ --to <socket> send-text --match "title:foo" "ls\n"` |
+
+### Snapshot file structure
+
+```
+~/.local/state/kitty-sessions/
+├── 20260503T120000Z.json
+├── 20260503T120500Z.json
+├── ...
+├── latest.json -> 20260503T143000Z.json
+├── snapshot.err
+├── launchd.out
+└── launchd.err
+```
+
+## Error Handling
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `kitten @ ls` fails with "remote control not allowed" | `allow_remote_control no` in `kitty.conf` | Set to `yes`, reload config |
+| LaunchAgent loads but `last exit code = 78` | Script not executable | `chmod +x ~/.local/bin/kitty-snapshot` |
+| LaunchAgent loads but never fires | `StartInterval` missing or zero | Set to a positive integer (seconds) |
+| All snapshots empty `[]` | No kitty windows running, or wrong socket path | Check `listen_on` path matches `--to` |
+| `bootstrap` fails with "already loaded" | Old `load` form still active | `launchctl bootout` first, then bootstrap |
+| Restore opens windows with wrong shell | `cmdline[0]` is the shell, not the user command | Use `cwd` only and let the user re-run |

--- a/macos-plugin/skills/launchservices-health/skill.md
+++ b/macos-plugin/skills/launchservices-health/skill.md
@@ -1,0 +1,268 @@
+---
+name: launchservices-health
+description: Diagnose macOS LaunchServices DB bloat and launchservicesd CPU issues. Use when launchservicesd is pegged at high CPU, the LS database feels bloated after long uptime, or you suspect LaunchServices is blocking WindowServer with XPC stalls.
+user-invocable: false
+allowed-tools: Bash(uname *), Bash(ps *), Bash(pgrep *), Bash(uptime *), Bash(awk *), Bash(grep *), Bash(wc *), Bash(ls *), Bash(stat *), Bash(mktemp *), Bash(rm *), Read, Write, Edit, Grep, Glob
+created: 2026-05-03
+modified: 2026-05-03
+reviewed: 2026-05-03
+---
+
+# LaunchServices Health (macOS)
+
+## When to Use This Skill
+
+| Use this skill when... | Use something else when... |
+|------------------------|----------------------------|
+| `launchservicesd` is at sustained high CPU | General process forensics — use `ps`/`top` directly |
+| GUI feels sluggish after weeks of uptime | The machine actually hung — see `macos-incident-postmortem` |
+| Quantifying LS DB bloat (size, bundle count, claim count) | Checking app launch failures — use `system_profiler SPApplicationsDataType` |
+| Deciding whether `lsregister` rebuild is warranted | First-time install setup — use `configure-plugin` |
+
+## Platform Guard
+
+This skill is **macOS-only**. The `lsregister` binary, `launchservicesd` daemon, and the LaunchServices database are Darwin-specific. Refuse to act if `uname -s` is not `Darwin`.
+
+```bash
+test "$(uname -s)" = "Darwin" || { echo "macos-plugin: not Darwin, refusing"; exit 1; }
+```
+
+## Core Expertise
+
+LaunchServices is the macOS subsystem that maps documents and URL schemes to applications. State is held by `launchservicesd` and persisted to a binary database. Two failure modes matter:
+
+1. **DB bloat** — over months of uptime and app churn (Homebrew updates, Xcode reinstalls, Wine/CrossOver bottle creation, Electron app upgrades), the DB accumulates stale bundle records and duplicate claims. The bigger the DB, the slower `lsregister -dump` runs and the more memory `launchservicesd` holds.
+2. **Daemon wedge** — `launchservicesd` can spin at high CPU when a misbehaving process repeatedly registers/unregisters bundles. WindowServer makes synchronous XPC calls into `launchservicesd` for icon and document-handler lookups; a wedged daemon manifests as a frozen GUI.
+
+The diagnostic answer is always: **measure first, rebuild only if warranted**. Rebuild (`lsregister -kill -r ...`) takes minutes, makes every app's "open with" disappear briefly, and rebuilds the DB from scratch — only do it when the metrics justify it.
+
+### Where the bits live
+
+| Path | Purpose |
+|------|---------|
+| `/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister` | The `lsregister` CLI — not on `$PATH`, must be invoked by absolute path |
+| `~/Library/Application Support/com.apple.PersistentURLTranslator/` | Per-user persisted state |
+| `/var/folders/*/0/com.apple.LaunchServices*` | LS cache directories (varies by macOS version) |
+
+## Quick Snapshot
+
+The reference script `ls-stats` produces a one-page health snapshot. Install at `~/.local/bin/ls-stats` (mode 0755):
+
+```bash
+#!/usr/bin/env bash
+# ls-stats: macOS LaunchServices DB + launchservicesd health snapshot
+set -euo pipefail
+
+[ "$(uname -s)" = "Darwin" ] || { echo "not Darwin" >&2; exit 1; }
+
+LSREG=/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister
+PID=$(pgrep -x launchservicesd) || { echo "launchservicesd not running" >&2; exit 1; }
+
+DUMP=$(mktemp); trap 'rm -f "$DUMP"' EXIT
+"$LSREG" -dump >"$DUMP" 2>/dev/null
+
+echo "=== launchservicesd ==="
+ps -o pid,rss,etime,command -p "$PID" | sed 's/^/  /'
+
+echo
+echo "=== LaunchServices DB ==="
+wc -c <"$DUMP" | awk '{printf "  size:    %d bytes (%.1f MB)\n", $1, $1/1048576}'
+printf "  bundles: %d\n" "$(grep -c '^bundle id:' "$DUMP")"
+printf "  claims:  %d\n" "$(grep -c '^claim '    "$DUMP")"
+printf "  records: %d\n" "$(grep -c '^----'      "$DUMP")"
+
+echo
+printf "=== Diagnostic reports ===\n  launchservicesd CPU events: %d\n" \
+  "$(ls /Library/Logs/DiagnosticReports/ 2>/dev/null | grep -c launchservicesd)"
+
+echo
+echo "=== Uptime ==="
+uptime | awk '{print "  " $0}'
+```
+
+The script prints four blocks: daemon process state (RSS, etime), DB size and counts, recent CPU diagnostic-report count, and current uptime. All numbers are absolute — interpret them against the baseline thresholds below.
+
+## Interpreting the Snapshot
+
+### launchservicesd RSS
+
+| RSS (KB) | Meaning |
+|----------|---------|
+| < 50 000 (~50 MB) | Healthy |
+| 50 000 – 150 000 | Normal for active use |
+| 150 000 – 400 000 | Bloated; consider rebuild |
+| > 400 000 (~400 MB) | Pathological; rebuild warranted |
+
+### Daemon `etime` (elapsed time since launch)
+
+`launchservicesd` is launched once per boot and lives until reboot. `etime` close to `uptime` is normal. `etime` significantly less than `uptime` means the daemon was relaunched mid-session — usually after a crash; check Diagnostic Reports.
+
+### DB size
+
+| Size | Meaning |
+|------|---------|
+| < 5 MB | Normal |
+| 5 – 20 MB | Healthy heavy-app workstation |
+| 20 – 50 MB | Bloated; rebuild improves things |
+| > 50 MB | Pathological |
+
+### Bundle / claim / record counts
+
+There is no absolute threshold — these matter relative to the **expected** number of installed apps. Useful sanity check:
+
+```bash
+ls /Applications /Applications/Utilities ~/Applications 2>/dev/null | wc -l
+```
+
+If `bundle id:` count is 5x or more above the visible-`.app` count, the DB has stale records.
+
+### Diagnostic-report CPU events
+
+`/Library/Logs/DiagnosticReports/launchservicesd-*.cpu_resource.diag` files indicate the daemon hit a CPU threshold (typically 80% sustained for 90s). Each file is one event. Recent volume:
+
+```bash
+find /Library/Logs/DiagnosticReports -name 'launchservicesd*.cpu_resource.diag' -mtime -7 | wc -l
+```
+
+| Count (last 7 days) | Meaning |
+|---------------------|---------|
+| 0 | Normal |
+| 1 – 3 | Notable; monitor |
+| 4+ | Pattern; likely a misbehaving registrar — investigate |
+
+## Rebuild Procedure
+
+Rebuild **only** when the snapshot shows multiple red flags. The rebuild takes 1–10 minutes depending on app count.
+
+```bash
+# Rebuild the LaunchServices database
+/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister \
+  -kill -r -domain local -domain system -domain user
+```
+
+What the flags do:
+
+| Flag | Effect |
+|------|--------|
+| `-kill` | Reset the existing database first |
+| `-r` | Recursively scan for bundles to register |
+| `-domain local` | `/Applications` |
+| `-domain system` | `/System/Applications`, `/System/Library` |
+| `-domain user` | `~/Applications`, `~/Library/Application Support` |
+
+Side effects:
+
+- "Open With" submenus regenerate (a few seconds of "no apps available")
+- Default-app preferences are preserved (stored separately)
+- The Dock badge and icon caches are NOT affected
+- A new `launchservicesd` process is spawned; PID changes
+
+### After rebuild
+
+Re-run `ls-stats` to confirm RSS, DB size, and counts dropped.
+
+## Common Patterns
+
+### Snapshot before/after a rebuild
+
+```bash
+ls-stats > /tmp/ls-before.txt
+"$LSREG" -kill -r -domain local -domain system -domain user
+ls-stats > /tmp/ls-after.txt
+diff -u /tmp/ls-before.txt /tmp/ls-after.txt
+```
+
+### Track DB growth across boots
+
+Append a snapshot to a logbook on each session:
+
+```bash
+{ date -Iseconds; ls-stats; echo "---"; } >> ~/.local/state/launchservices.log
+```
+
+Plot or grep over time to see whether DB size is monotonically growing.
+
+### Identify the registrar driving CPU
+
+When `launchservicesd` is hot and you suspect a specific app:
+
+```bash
+log stream --predicate 'process == "launchservicesd"' --style syslog | head -200
+```
+
+Look for repeated `bundle id` or `path` strings — that's the offender.
+
+### Check for bottle-creation amplification
+
+Wine/CrossOver bottle creation registers hundreds of `.exe`-as-bundle entries. Count them:
+
+```bash
+"$LSREG" -dump 2>/dev/null | grep -c -i 'wineprefix\|bottle'
+```
+
+A 4-digit answer is the smoking gun.
+
+## Justfile Recipe
+
+```just
+[doc('Quantify LaunchServices DB and launchservicesd state (macOS)')]
+[macos]
+ls-stats:
+    @~/.local/bin/ls-stats
+```
+
+The `[macos]` attribute (just 1.34+) skips the recipe on non-Darwin. On older just versions, drop the attribute and let the script's `uname -s` check do the gating.
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| One-line size | `$LSREG -dump 2>/dev/null \| wc -c \| awk '{printf "%.1f MB\n", $1/1048576}'` |
+| RSS only | `ps -o rss= -p "$(pgrep -x launchservicesd)"` |
+| Bundle count | `$LSREG -dump 2>/dev/null \| grep -c '^bundle id:'` |
+| Recent CPU events | `find /Library/Logs/DiagnosticReports -name 'launchservicesd*.cpu_resource.diag' -mtime -7 \| wc -l` |
+| Daemon uptime vs system uptime | `ps -o etime= -p "$(pgrep -x launchservicesd)"; uptime` |
+
+## Quick Reference
+
+### Key paths
+
+| Path | Purpose |
+|------|---------|
+| `/System/.../Support/lsregister` | The CLI |
+| `/Library/Logs/DiagnosticReports/` | CPU and crash diag files |
+| `~/Library/Application Support/com.apple.PersistentURLTranslator/` | Per-user state |
+
+### Useful flags
+
+| Flag | Description |
+|------|-------------|
+| `-dump` | Print the entire DB to stdout |
+| `-kill -r -domain ...` | Rebuild |
+| `-h` | List all flags (undocumented elsewhere) |
+| `-f <bundle>` | Force-register a single bundle |
+| `-u <bundle>` | Unregister a bundle |
+
+### Indicator thresholds (rough)
+
+| Metric | Healthy | Bloated | Rebuild |
+|--------|---------|---------|---------|
+| DB size | < 5 MB | 20–50 MB | > 50 MB |
+| Daemon RSS | < 50 MB | 150–400 MB | > 400 MB |
+| Bundle count vs visible apps | 1–2x | 3–5x | > 5x |
+| CPU diag events / 7 days | 0 | 1–3 | 4+ |
+
+## Error Handling
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `lsregister: command not found` | Not on `$PATH` by design | Use the full `/System/.../Support/lsregister` path |
+| `lsregister -dump` exits non-zero with stderr | Permissions or DB corruption | Capture stderr separately; rebuild may resolve it |
+| `pgrep -x launchservicesd` returns nothing | Daemon crashed and not yet relaunched | Check Diagnostic Reports; force a relaunch with `lsregister -kill -r ...` |
+| Rebuild appears to hang | Indexing many app bundles is genuinely slow | Wait — typical 1–10 min depending on app count |
+| Sudden RSS jump after Homebrew upgrade | Many bundles re-registered at once | Expected; will settle within minutes |
+
+## Related Skills
+
+- `macos-incident-postmortem` — when LaunchServices CPU caused a GUI hang, parse Diagnostic Reports there
+- `kitty-session-persistence` — recover terminal sessions lost when WindowServer wedged on an LS XPC call

--- a/macos-plugin/skills/macos-incident-postmortem/skill.md
+++ b/macos-plugin/skills/macos-incident-postmortem/skill.md
@@ -1,0 +1,322 @@
+---
+name: macos-incident-postmortem
+description: Reconstruct what happened after a macOS GUI freeze, kernel panic, or unexplained reboot by parsing /Library/Logs/DiagnosticReports/, kern.boottime, and shell history. Use when the GUI hung, you can't tell whether the machine actually rebooted, or you're investigating recent panics, watchdog timeouts, jetsam events, or thermal throttling.
+user-invocable: false
+allowed-tools: Bash(uname *), Bash(sysctl *), Bash(uptime *), Bash(last *), Bash(ls *), Bash(find *), Bash(stat *), Bash(awk *), Bash(grep *), Bash(wc *), Bash(date *), Bash(log *), Bash(pmset *), Read, Grep, Glob, TodoWrite
+created: 2026-05-03
+modified: 2026-05-03
+reviewed: 2026-05-03
+---
+
+# macOS Incident Postmortem
+
+## When to Use This Skill
+
+| Use this skill when... | Use something else when... |
+|------------------------|----------------------------|
+| GUI froze and you're not sure if the machine rebooted | Live-debugging a hung process — use `sample` / `spindump` |
+| Investigating recent kernel panics or watchdog timeouts | Application crashes — open the per-app `.crash` / `.ips` directly |
+| Cross-referencing "what was I doing at time T?" against logs | Active CPU diagnosis — see `launchservices-health` |
+| Auditing whether the system is "due for a reboot" | Pre-incident hardening — wrong skill, this is forensics |
+
+## Platform Guard
+
+This skill is **macOS-only**. `/Library/Logs/DiagnosticReports/`, `kern.boottime`, `pmset -g log`, and the `log` command are Darwin-specific. Refuse to act if `uname -s` is not `Darwin`.
+
+```bash
+test "$(uname -s)" = "Darwin" || { echo "macos-plugin: not Darwin, refusing"; exit 1; }
+```
+
+## Core Expertise
+
+A macOS "incident" can mean any of:
+
+- A kernel panic (system reset by the kernel)
+- A WindowServer userspace watchdog timeout (the GUI froze and the user power-cycled)
+- A LaunchServices / coreaudiod / mds-stores XPC stall (one daemon dragged the GUI down)
+- A jetsam memory-pressure event (the kernel killed apps to reclaim RAM)
+- A thermal throttle (CPU clamped to base frequency for minutes)
+- A user-initiated force-reboot after a hang (no panic; just lost state)
+
+The first job in a postmortem is **distinguishing between actual reboots and GUI hangs**. The 2026-04-22 incident that motivated this plugin *looked* like a crash to the user but `last reboot` showed no reboot — the kernel was fine, only the GUI stack hung.
+
+The second job is **timeline reconstruction**: cross-reference Diagnostic Reports, `kern.boottime`, `last reboot`, `last shutdown`, and shell history to answer "what happened around time T?".
+
+## Did the Machine Actually Reboot?
+
+Three signals, evaluated together:
+
+```bash
+# Current boot time as a unix timestamp
+sysctl -n kern.boottime
+# → { sec = 1714723200, usec = 0 } Tue Apr 22 ...
+
+# Boot history (most recent first)
+last reboot | head -5
+
+# Shutdown history
+last shutdown | head -5
+```
+
+Decision rules:
+
+| Pattern | Interpretation |
+|---------|----------------|
+| `last reboot` shows a new entry near time T | True reboot — kernel was reset |
+| `last reboot` unchanged, `kern.boottime` matches the older boot | GUI hang — machine did not reboot |
+| `last shutdown` shows an "abrupt" entry near time T | Power loss or hard hold-down — kernel did not write a clean shutdown |
+| `last shutdown` shows a clean entry, then `last reboot` | User-initiated shutdown/restart |
+
+`last reboot` reads `/var/log/wtmp.X` rotated logs. On modern macOS, also check the unified log:
+
+```bash
+log show --predicate 'eventType == "stateEvent" AND (event == "boot" OR event == "shutdown")' \
+  --last 7d --style syslog
+```
+
+## Diagnostic Report Categories
+
+`/Library/Logs/DiagnosticReports/` collects everything macOS thinks is worth keeping. The filename pattern identifies the category:
+
+| Pattern | Category | Severity |
+|---------|----------|----------|
+| `*.panic` | Kernel panic | Critical |
+| `*.ips` (process-specific) | Userspace crash report (Apple's modern format) | Per-process |
+| `*.crash` | Legacy userspace crash | Per-process |
+| `*.cpu_resource.diag` | Process exceeded CPU threshold (typ. 80% / 90s) | Hot daemon |
+| `*.wakeups_resource.diag` | Process woke the system too often | Power drain |
+| `*.diskwrites_resource.diag` | Process wrote too much to disk | I/O drain |
+| `*.hang` | UI thread hang detection | GUI freeze |
+| `*.spindump.txt` | Spindump capture from a hang | GUI freeze |
+| `JetsamEvent-*.ips` | Kernel killed processes for memory pressure | RAM exhaustion |
+
+Note: Apple migrated most categories to the `.ips` extension circa Monterey. Older systems and some categories still produce legacy extensions. Match by suffix, not by exact filename.
+
+## Timeline Reconstruction
+
+### Step 1: List recent events
+
+```bash
+find /Library/Logs/DiagnosticReports -type f -mtime -2 \
+  -exec stat -f '%Sm  %N' -t '%Y-%m-%d %H:%M:%S' {} \; \
+  | sort
+```
+
+This produces a chronological list of every diagnostic report from the last 48 hours. Filter further by category if needed:
+
+```bash
+find /Library/Logs/DiagnosticReports -type f -mtime -2 \
+  \( -name '*.panic' -o -name '*.hang' -o -name 'JetsamEvent-*' \) \
+  -exec stat -f '%Sm  %N' -t '%Y-%m-%d %H:%M:%S' {} \; | sort
+```
+
+### Step 2: Cross-reference with boot history
+
+```bash
+last reboot | head -5
+last shutdown | head -5
+sysctl -n kern.boottime
+```
+
+Mark the incident time T. Determine: was T before or after the most recent boot? If after, the machine never rebooted — it was a hang.
+
+### Step 3: Inspect the unified log around T
+
+```bash
+# Adjust the time window to bracket T
+log show --start "2026-04-22 08:15:00" --end "2026-04-22 08:25:00" \
+  --predicate 'subsystem == "com.apple.WindowServer" OR process == "launchservicesd" OR process == "coreaudiod"' \
+  --style syslog \
+  | head -500
+```
+
+Common signatures to grep for:
+
+| Signature | Meaning |
+|-----------|---------|
+| `WindowServer:` watchdog | UI froze long enough to trip the watchdog |
+| `posix_spawn` failures | Fork/exec storm — usually shell loops or runaway scripts |
+| `Jetsam Killing` | Kernel killing processes for memory |
+| `_dispatch_*_timeout` | Daemon stuck on a synchronous IPC call |
+| `Thermal pressure` | CPU thermal-throttled |
+
+### Step 4: Inspect the panic / hang report
+
+```bash
+# Most recent panic
+ls -1t /Library/Logs/DiagnosticReports/*.panic 2>/dev/null | head -1
+
+# Most recent hang
+ls -1t /Library/Logs/DiagnosticReports/*.hang* 2>/dev/null | head -1
+```
+
+Read the file. Key fields in a panic report:
+
+| Field | Meaning |
+|-------|---------|
+| `panic(cpu N caller ...)` | The instruction that panicked; first line says why |
+| `Backtrace (CPU N)` | Call stack at the time of panic |
+| `Mac OS version`, `Kernel version` | OS state |
+| `System uptime in nanoseconds` | Uptime at the moment of panic |
+| `last loaded kext` / `loaded kexts` | Likely third-party suspect |
+
+Hang reports are spindump-style: one column per thread of the hung process (typically WindowServer or the offender daemon), with stack traces at sample intervals.
+
+### Step 5: Correlate with shell activity
+
+```bash
+# Most recent zsh history entries (assumes default zsh)
+fc -l -t '%Y-%m-%d %H:%M:%S' -100
+
+# Or directly:
+tail -50 ~/.zsh_history
+```
+
+The zsh `EXTENDED_HISTORY` format `: <epoch>:<elapsed>;<cmd>` lets you grep for commands run within the incident window.
+
+### Step 6: Synthesize
+
+Write a one-paragraph timeline including:
+
+- Type of incident (panic / hang / jetsam / power-cycle)
+- Time T and time-since-boot at T
+- Top suspects (loaded kexts, busy daemons, low-memory processes)
+- What recovery looked like (clean reboot / hard power-cycle / GUI returned on its own)
+
+## Common Patterns
+
+### "Was that a reboot or a hang?" one-liner
+
+```bash
+last reboot | awk 'NR<=3' && \
+  echo "kern.boottime: $(sysctl -n kern.boottime)" && \
+  echo "uptime: $(uptime)"
+```
+
+If the most recent `last reboot` line is older than the incident, the machine never rebooted — it was a userspace hang.
+
+### Count diag reports by category, last 7 days
+
+```bash
+find /Library/Logs/DiagnosticReports -type f -mtime -7 -name '*.panic' | wc -l
+find /Library/Logs/DiagnosticReports -type f -mtime -7 -name '*.hang*' | wc -l
+find /Library/Logs/DiagnosticReports -type f -mtime -7 -name '*.cpu_resource.diag' | wc -l
+find /Library/Logs/DiagnosticReports -type f -mtime -7 -name 'JetsamEvent-*' | wc -l
+```
+
+A sudden rise in any category is a leading indicator before a major hang or panic.
+
+### Find the dominant CPU-event offender
+
+```bash
+ls /Library/Logs/DiagnosticReports/*.cpu_resource.diag 2>/dev/null \
+  | awk -F/ '{print $NF}' \
+  | awk -F- '{print $1}' \
+  | sort | uniq -c | sort -rn
+```
+
+The first column is event count; the second is the offender process name.
+
+### Jetsam victim list
+
+```bash
+grep -lE 'killed' /Library/Logs/DiagnosticReports/JetsamEvent-*.ips 2>/dev/null \
+  | xargs -r grep -hE '"name":' \
+  | sort | uniq -c | sort -rn | head -20
+```
+
+Apps that show up here repeatedly are running near their memory budget.
+
+### Correlate with sleep/wake history
+
+```bash
+pmset -g log | grep -E 'Sleep|Wake|DarkWake' | tail -50
+```
+
+A spurt of `DarkWake` entries followed by a hang report often means a peripheral or sleep-assertion-holder is the trigger.
+
+## Skip List (Common False Suspects)
+
+| Suspect | Why it's usually NOT the cause |
+|---------|--------------------------------|
+| `mds`, `mds_stores` (Spotlight) | Heavy I/O is normal after large file changes; rarely panics |
+| `cloudd` | High network use is normal during iCloud sync |
+| `bird` (CloudKit) | Same as `cloudd` |
+| `Time Machine` | Throttles itself; almost never the proximate cause |
+| `kernel_task` at 100% | This is thermal management *running*, not a bug |
+
+If one of these is the only thing visible in your timeline, look harder — the real cause is usually a daemon that *blocked on* one of these, not the daemon itself.
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Last 5 boots | `last reboot \| head -5` |
+| Last 5 shutdowns | `last shutdown \| head -5` |
+| Did we reboot since T? | `last reboot \| awk '$0 ~ /YYYY-MM-DD/'` |
+| Recent diag reports (48h) | `find /Library/Logs/DiagnosticReports -type f -mtime -2 -exec stat -f '%Sm  %N' -t '%F %T' {} \;` |
+| Last panic file | `ls -1t /Library/Logs/DiagnosticReports/*.panic 2>/dev/null \| head -1` |
+| First panic line | `head -1 "$(ls -1t /Library/Logs/DiagnosticReports/*.panic \| head -1)"` |
+| WindowServer log slice | `log show --predicate 'subsystem == "com.apple.WindowServer"' --last 1h --style syslog \| head -200` |
+| CPU offender histogram | `ls /Library/Logs/DiagnosticReports/*.cpu_resource.diag \| awk -F/ '{print $NF}' \| awk -F- '{print $1}' \| sort \| uniq -c \| sort -rn` |
+
+## Quick Reference
+
+### Key paths
+
+| Path | Contents |
+|------|----------|
+| `/Library/Logs/DiagnosticReports/` | All system-wide reports |
+| `~/Library/Logs/DiagnosticReports/` | Per-user reports (rare; mostly legacy) |
+| `/var/log/wtmp.X` | Reboot / shutdown record (read via `last`) |
+| `/var/log/asl/` | ASL legacy logs (mostly unused in 2026) |
+| `/var/db/diagnostics/` | Unified log binary database |
+
+### Useful `log show` predicates
+
+| Predicate | Use |
+|-----------|-----|
+| `subsystem == "com.apple.WindowServer"` | GUI hangs |
+| `process == "launchservicesd"` | LS XPC stalls |
+| `process == "coreaudiod"` | Audio daemon issues |
+| `eventType == "stateEvent"` | Boot/shutdown/sleep |
+| `eventMessage CONTAINS[c] "hang"` | Hang detection events |
+| `category == "ttsd"` | Speech synthesis stalls |
+
+### Time selectors
+
+| Selector | Example |
+|----------|---------|
+| `--last <duration>` | `--last 1h`, `--last 1d` |
+| `--start <ts> --end <ts>` | `--start "2026-04-22 08:00:00"` |
+| `--info` / `--debug` | Include lower-priority entries |
+| `--style syslog` | Compact, grep-friendly |
+
+## Decision Flow
+
+```
+Did `last reboot` advance near time T?
+├─ YES → Kernel-level event
+│   ├─ *.panic file present? → Panic; read backtrace
+│   └─ No panic file → Clean restart (user-initiated or watchdog)
+└─ NO → Userspace event
+    ├─ *.hang or *.spindump.txt near T? → UI thread hang
+    ├─ *.cpu_resource.diag spike near T? → Daemon CPU storm
+    ├─ JetsamEvent-* near T? → Memory-pressure kill
+    └─ None of the above → Power loss or hard power-cycle
+```
+
+## Error Handling
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `find: ...DiagnosticReports: Permission denied` | Some user-level reports require sudo | Stick to system-wide; don't sudo unless necessary |
+| `last reboot` empty | `wtmp` rotated past the incident | Use `log show --predicate 'event == "boot"'` instead |
+| `log show` very slow / huge output | Default predicate is too broad | Narrow with `--predicate` and tighter time range |
+| Reports only go back a few days | Apple rotates the diag dir aggressively | Check `~/Library/Logs/DiagnosticReports/` for backups; some events only persist as `log show` entries |
+| Filenames with `.ips` not `.crash` | Modern macOS format change | Treat both as equivalent; same parser tools work |
+
+## Related Skills
+
+- `launchservices-health` — when the timeline points at `launchservicesd`, dig deeper there
+- `kitty-session-persistence` — recover terminal state lost during the incident

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -827,6 +827,39 @@
         }
       ]
     },
+    "macos-plugin": {
+      "component": "macos-plugin",
+      "release-type": "simple",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        }
+      ],
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance"
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactoring"
+        },
+        {
+          "type": "docs",
+          "section": "Documentation"
+        }
+      ]
+    },
     "migration-patterns-plugin": {
       "component": "migration-patterns-plugin",
       "release-type": "simple",


### PR DESCRIPTION
## Summary

Introduces `macos-plugin` with three Darwin-only skills for operational concerns that don't fit into cross-platform plugins:

- **`kitty-session-persistence`** — snapshot/restore kitty terminal sessions across crashes via `kitten @ ls` + a 5-minute LaunchAgent.
- **`launchservices-health`** — quantify the LaunchServices DB (size, bundle/claim/record counts), `launchservicesd` RSS/uptime, and recent CPU diag events; surface the safe rebuild command with thresholds.
- **`macos-incident-postmortem`** — reconstruct timelines after a GUI freeze or panic from `/Library/Logs/DiagnosticReports/`, `kern.boottime`, `last reboot`, `pmset -g log`, and the unified log.

## Motivation

Real 2026-04-22 incident: 33-day uptime + repeated `wineserver` crashes drove `launchservicesd` to sustained 85% CPU, blocking WindowServer on an LS XPC call. The GUI froze, kitty was killed, all open Claude Code sessions terminated mid-write. Recovery required ad-hoc `lsregister` analysis and reconstructing kitty state from `~/.claude/projects/*/*.jsonl` mtimes — exactly the kind of repeatable operations that belong in a plugin.

## Scope

Per the issue's guardrails:

- **macOS-only** — every skill guards on `uname -s == Darwin` and refuses to act on non-Darwin systems.
- **Runtime diagnostics, not initial setup** — no overlap with `configure-plugin`.
- **OS health, not Claude Code health** — no overlap with `health-plugin`.

The 4 "possible future skills" mentioned in the issue (`pmset-analysis`, `mdworker-diagnostics`, `homebrew-services-audit`, `mac-kernel-extension-status`) are deliberately deferred — `README.md` notes they should become follow-up issues if needed.

The "monorepo vs standalone repo" open question is resolved as **monorepo** to match the established pattern.

## Plugin lifecycle bookkeeping

Updated as a single coherent unit:

- `macos-plugin/.claude-plugin/plugin.json` — manifest
- `macos-plugin/README.md` — plugin docs
- `.claude-plugin/marketplace.json` — entry inserted between `langchain-plugin` and `migration-patterns-plugin`
- `release-please-config.json` — package config
- `.release-please-manifest.json` — version `1.0.0`
- `docs/PLUGIN-MAP.md` — count bumped 38 → 39, conditional-plugin row added

## Test plan

- [x] `jq empty` validates all touched JSON files
- [x] `bash scripts/plugin-compliance-check.sh macos-plugin` — all 9 columns ✅
- [x] `python3 scripts/sync-plugin-configs.py` — "All plugin configurations are in sync"
- [x] `python3 scripts/audit-skill-descriptions.py --plugin macos-plugin --all` — all 3 skills `[OK]`
- [x] `bash scripts/lint-context-commands.sh` — no warnings on macos-plugin
- [x] All three skills under the 500-line limit (274 / 268 / 322)
- [x] Pre-commit hooks pass (shellcheck, secrets, lint-context, driver-freshness, description audit)
- [ ] Validate the kitty/LaunchAgent setup against a real workstation — left for manual verification post-merge

Closes #1108
