### PR TITLE
fix(hooks-plugin): exclude docs files and repair the TODO check in task-completeness

### DIFF
--- a/hooks-plugin/README.md
+++ b/hooks-plugin/README.md
@@ -144,29 +144,35 @@ A Stop hook that checks for obvious signs of incomplete work using deterministic
 
 | Check | Trigger |
 |-------|---------|
-| TODO/FIXME/HACK/XXX in uncommitted diff | Blocks with count and message |
-| Merge conflict markers (`<<<<`, `====`, `>>>>`) | Blocks with affected filenames |
-| Debugging artifacts (`console.log`, `debugger;`, `breakpoint()`, `pdb.set_trace`) | Blocks with count |
+| TODO/FIXME/HACK/XXX added in uncommitted diff | Blocks with count and message |
+| Merge conflict markers (`<<<<<<<`, `>>>>>>>`) in changed files | Blocks with affected filenames |
+| Debugging artifacts (`console.log`, `debugger;`, `breakpoint()`, `pdb.set_trace`) added in diff | Blocks with count |
 | `stop_hook_active=true` in input | Exits 0 immediately (prevents infinite loops) |
 | Non-git directory | Exits 0 silently |
 
+Documentation files (`*.md`, `*.mdx`, `*.rst`, `*.txt`) and vendor/generated paths (`node_modules`, `vendor`, `dist`, `build`, `*.min.*`) are excluded from all three checks — they routinely quote literal TODO/FIXME tokens, conflict markers, and `console.log` examples in prose.
+
 **Toggle:** `CLAUDE_HOOKS_DISABLE_TASK_COMPLETENESS=1`
+
+### test-verification.sh
+
+A Stop hook that auto-detects the project's test runner and runs tests when uncommitted changes touch source files. Skips silently when no source files changed, no recognised runner is found, or the diff is documentation-only.
+
+| Aspect | Detail |
+|--------|--------|
+| Type | `command` (deterministic — replaced the former `type: "agent"` variant for latency) |
+| Timeout | 60s framework / 45s hard internal (configurable via `CLAUDE_HOOKS_TEST_TIMEOUT`) |
+| Detected runners | `justfile` (prefers `test-quick` → `test-unit` → `test`), `Makefile` (same priority), Bun, npm, pytest (uv-aware), cargo, go |
+| Skip conditions | Only docs/config files changed, no test runner found, `stop_hook_active=true` |
+| Timeout behaviour | Approves with a warning instead of blocking (does not interrupt flow) |
+
+**Toggle:** `CLAUDE_HOOKS_DISABLE_TEST_VERIFICATION=1`
 
 > **Note on prompt-type Stop hooks**: When a `type: "prompt"` hook on `Stop` or `SubagentStop` returns `{"ok": false}`, Claude Code surfaces the full prompt text in the error message (e.g. `Stop hook error: [You are evaluating...]: reason`). This is a runtime behavior that cannot be configured away. Prefer `type: "command"` hooks with deterministic heuristics for Stop events to avoid this leakage. Only use `type: "prompt"` on Stop hooks when the check genuinely requires LLM judgment and cannot be deterministic.
 
 ## Prompt-Based and Agent-Based Hooks
 
 LLM-powered hooks that use judgment instead of deterministic rules.
-
-### Stop — Test Verification (agent)
-
-A `type: "agent"` hook that runs the project's test suite before allowing Claude to stop. Detects the test runner automatically (npm, pytest, cargo, go, make).
-
-| Aspect | Detail |
-|--------|--------|
-| Type | `agent` (multi-turn with tool access) |
-| Timeout | 120s |
-| Skip condition | No source files changed, or no test runner found |
 
 ### SubagentStop — Output Quality Gate (prompt)
 
@@ -325,6 +331,7 @@ Every hook can be individually enabled or disabled via environment variables. Se
 | auto-checkpoint.sh | `CLAUDE_HOOKS_DISABLE_AUTO_CHECKPOINT=1` | Enabled |
 | permission-auto-approve.sh | `CLAUDE_HOOKS_DISABLE_PERMISSION_AUTO=1` | Enabled |
 | task-completeness.sh | `CLAUDE_HOOKS_DISABLE_TASK_COMPLETENESS=1` | Enabled |
+| test-verification.sh | `CLAUDE_HOOKS_DISABLE_TEST_VERIFICATION=1` | Enabled |
 | event-logger.sh | `CLAUDE_HOOKS_ENABLE_EVENT_LOGGER=1` | **Disabled** (opt-in) |
 
 Example — disable branch protection for a session:

--- a/hooks-plugin/hooks/task-completeness.sh
+++ b/hooks-plugin/hooks/task-completeness.sh
@@ -28,42 +28,61 @@ if ! git -C "$CWD" rev-parse --git-dir >/dev/null 2>&1; then
     exit 0
 fi
 
-# Check 1: Look for TODO/FIXME markers in staged or unstaged changes
-# These indicate the author left intentional "finish this" markers
-# Get list of changed files and filter out commonly auto-generated/vendor paths
-# that are not meaningful to check (minified JS, node_modules, vendor/, etc.)
-CHANGED_FILES="$(git -C "$CWD" diff --name-only 2>/dev/null || true)"
-CHANGED_FILES="$CHANGED_FILES$(printf '\n%s' "$(git -C "$CWD" diff --cached --name-only 2>/dev/null || true)")"
-FILTERED_FILES="$(echo "$CHANGED_FILES" | while IFS= read -r file; do
-    [ -z "$file" ] && continue
-    # Skip common auto-generated and vendor paths
-    case "$file" in
-        *.min.js|*.min.css|*.min.map)
-            continue
-            ;;
-        */node_modules/*|*/.git/*|*/vendor/*|*/dist/*|*/build/*)
-            continue
-            ;;
-        */.obsidian/plugins/*)
-            continue
-            ;;
+# Returns 0 if the path should be excluded from completeness checks.
+# Documentation files (*.md, *.mdx, *.rst, *.txt) frequently quote literal
+# TODO/FIXME tokens, conflict markers, or console.log examples in prose
+# (this very plugin's docs do). Vendor / generated paths are excluded for
+# the same reason — they are not the author's working code.
+is_excluded() {
+    case "$1" in
+        *.md|*.mdx|*.rst|*.txt) return 0 ;;
+        *.min.js|*.min.css|*.min.map) return 0 ;;
+        */node_modules/*|*/.git/*|*/vendor/*|*/dist/*|*/build/*) return 0 ;;
+        */.obsidian/plugins/*) return 0 ;;
+        *) return 1 ;;
     esac
-    echo "$file"
-done)"
-DIFF_TODOS=$(echo "$FILTERED_FILES" | while IFS= read -r file; do
-    [ -z "$file" ] && continue
-    [ -f "$CWD/$file" ] || continue
-    grep -lE '^\+.*(TODO|FIXME|HACK|XXX)' "$CWD/$file" 2>/dev/null || true
-done | grep -c . 2>/dev/null || echo 0)
+}
 
-if [ "$DIFF_TODOS" -gt 0 ]; then
+# Build the list of changed files we actually care about (staged + unstaged,
+# de-duplicated, excluded paths filtered out, must currently exist on disk).
+RELEVANT_FILES=()
+while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    is_excluded "$file" && continue
+    [ -f "$CWD/$file" ] || continue
+    RELEVANT_FILES+=("$file")
+done < <(
+    {
+        git -C "$CWD" diff --name-only 2>/dev/null || true
+        git -C "$CWD" diff --name-only --cached 2>/dev/null || true
+    } | sort -u
+)
+
+# Nothing relevant changed → nothing to check.
+if [ "${#RELEVANT_FILES[@]}" -eq 0 ]; then
+    exit 0
+fi
+
+# Combined diff (staged + unstaged) restricted to the relevant files.
+# Re-used by Check 1 and Check 3.
+RELEVANT_DIFF=$(
+    {
+        git -C "$CWD" diff -- "${RELEVANT_FILES[@]}" 2>/dev/null || true
+        git -C "$CWD" diff --cached -- "${RELEVANT_FILES[@]}" 2>/dev/null || true
+    }
+)
+
+# Check 1: TODO/FIXME/HACK/XXX markers added in this diff.
+DIFF_TODOS=$(printf '%s\n' "$RELEVANT_DIFF" | grep -cE '^\+.*(TODO|FIXME|HACK|XXX)' || true)
+
+if [ "${DIFF_TODOS:-0}" -gt 0 ]; then
     # shellcheck disable=SC2016  # jq expression, not shell expansion
     jq -n --arg reason "Found ${DIFF_TODOS} TODO/FIXME/HACK/XXX marker(s) in uncommitted changes. Address or remove them before finishing." \
         '{"decision": "block", "reason": $reason}'
     exit 0
 fi
 
-# Check 2: Look for conflict markers in changed files
+# Check 2: conflict markers in relevant files.
 #
 # Real merge markers come paired (<<<<<<< … ======= … >>>>>>>), so any
 # conflict — fully unresolved or partially resolved — leaves at least
@@ -71,36 +90,25 @@ fi
 # many legitimate non-conflict uses (decorative dividers in fenced code
 # blocks, console-output examples, ASCII art) and were the dominant
 # false-positive signal, so they are intentionally excluded.
-CONFLICT_FILES=$(
-    {
-        git -C "$CWD" diff --name-only 2>/dev/null || true
-        git -C "$CWD" diff --name-only --cached 2>/dev/null || true
-    } | sort -u | while IFS= read -r file; do
-        [ -z "$file" ] && continue
-        [ -f "$CWD/$file" ] || continue
-        if grep -lE '^(<{7}|>{7})' "$CWD/$file" >/dev/null 2>&1; then
-            echo "$file"
-        fi
-    done
-)
+CONFLICT_FILES=()
+for file in "${RELEVANT_FILES[@]}"; do
+    if grep -lE '^(<{7}|>{7})' "$CWD/$file" >/dev/null 2>&1; then
+        CONFLICT_FILES+=("$file")
+    fi
+done
 
-if [ -n "$CONFLICT_FILES" ]; then
-    FILE_LIST=$(echo "$CONFLICT_FILES" | head -5 | tr '\n' ', ' | sed 's/,$//')
+if [ "${#CONFLICT_FILES[@]}" -gt 0 ]; then
+    FILE_LIST=$(printf '%s\n' "${CONFLICT_FILES[@]}" | head -5 | tr '\n' ', ' | sed 's/,$//')
     # shellcheck disable=SC2016  # jq expression, not shell expansion
     jq -n --arg reason "Unresolved merge conflict markers found in: ${FILE_LIST}" \
         '{"decision": "block", "reason": $reason}'
     exit 0
 fi
 
-# Check 3: Look for debugging artifacts in uncommitted changes
-DEBUG_COUNT=$(
-    {
-        git -C "$CWD" diff 2>/dev/null || true
-        git -C "$CWD" diff --cached 2>/dev/null || true
-    } | grep -cE '^\+.*(console\.log|debugger;|print\(.*DEBUG|breakpoint\(\)|pdb\.set_trace)' 2>/dev/null
-) || DEBUG_COUNT=0
+# Check 3: debugging artifacts added in this diff.
+DEBUG_COUNT=$(printf '%s\n' "$RELEVANT_DIFF" | grep -cE '^\+.*(console\.log|debugger;|print\(.*DEBUG|breakpoint\(\)|pdb\.set_trace)' || true)
 
-if [ "$DEBUG_COUNT" -gt 0 ]; then
+if [ "${DEBUG_COUNT:-0}" -gt 0 ]; then
     # shellcheck disable=SC2016  # jq expression, not shell expansion
     jq -n --arg reason "Found ${DEBUG_COUNT} debugging artifact(s) (console.log, debugger, breakpoint, etc.) in uncommitted changes. Clean up before finishing." \
         '{"decision": "block", "reason": $reason}'

--- a/hooks-plugin/hooks/test-task-completeness.sh
+++ b/hooks-plugin/hooks/test-task-completeness.sh
@@ -4,6 +4,11 @@
 # Verifies that the Stop hook detects incomplete work without leaking
 # the full prompt text in error output (issue #1009).
 #
+# The hook contract: block by emitting {"decision":"block","reason":"..."}
+# on stdout and exit 0 (per hooks-reference.md). Exit 0 with no output =
+# allow the stop. The legacy assertions that expected exit 2 were a bug
+# in the tests themselves, not the hook.
+#
 # Run: bash hooks-plugin/hooks/test-task-completeness.sh
 # Exit 0 = all tests pass, Exit 1 = failures
 set -euo pipefail
@@ -21,9 +26,18 @@ trap 'rm -rf "$TMPDIR" "$NON_GIT_DIR"' EXIT
 git -C "$TMPDIR" init -q
 git -C "$TMPDIR" config user.email "test@example.com"
 git -C "$TMPDIR" config user.name "Test"
+git -C "$TMPDIR" config commit.gpgsign false
+git -C "$TMPDIR" config gpg.format ""
 echo "initial" > "$TMPDIR/README.md"
 git -C "$TMPDIR" add README.md
 git -C "$TMPDIR" commit -q -m "initial"
+
+# Reset the test repo to a clean state between scenarios.
+reset_repo() {
+    git -C "$TMPDIR" restore --staged . 2>/dev/null || true
+    git -C "$TMPDIR" checkout -- . 2>/dev/null || true
+    git -C "$TMPDIR" clean -fdq 2>/dev/null || true
+}
 
 # Helper: run hook with a given CWD JSON and optional extra fields
 # Returns the exit code as stdout
@@ -44,7 +58,7 @@ run_hook() {
 run_hook_output() {
     local cwd="$1"
     local extra="${2:-}"
-    local json exit_code=0
+    local json
     if [ -n "$extra" ]; then
         json=$(printf '{"cwd":"%s",%s}' "$cwd" "$extra")
     else
@@ -101,131 +115,144 @@ assert_exit "stop_hook_active=true exits 0 (no blocking)" 0 "$exit_code"
 echo ""
 echo "clean working tree:"
 
+reset_repo
 exit_code=$(run_hook "$TMPDIR")
 assert_exit "clean tree exits 0" 0 "$exit_code"
-
-# ── TODO/FIXME markers in uncommitted changes ─────────────────────────────────
-# Regression: the old prompt hook leaked the full LLM prompt in error output
-# (issue #1009). The command hook must only emit {"decision":"block","reason":"..."}
-echo ""
-echo "TODO/FIXME/HACK/XXX detection:"
-
-echo "# TODO: finish this" >> "$TMPDIR/README.md"
-
-exit_code=$(run_hook "$TMPDIR")
-assert_exit "unstaged TODO exits 2 (blocked)" 2 "$exit_code"
-
 output=$(run_hook_output "$TMPDIR")
-assert_contains     "blocked output has 'decision' field"       '"decision"'        "$output"
-assert_contains     "blocked output has 'reason' field"         '"reason"'          "$output"
-assert_not_contains "output does not leak prompt text"          "You are evaluating" "$output"
-assert_not_contains "output does not leak stop_hook_active text" "stop_hook_active"  "$output"
+assert_not_contains "clean tree emits no block decision" '"decision"' "$output"
 
-git -C "$TMPDIR" checkout -- README.md  # restore clean state
+# ── TODO/FIXME markers in source-file diffs ──────────────────────────────────
+# Regression: the old prompt hook leaked the full LLM prompt in error output
+# (issue #1009). The command hook must only emit {"decision":"block","reason":"..."}.
+# Regression (this commit): a previous version grepped the file *content* for
+# `^\+...` lines instead of the diff output, so this check was a silent no-op.
+echo ""
+echo "TODO/FIXME/HACK/XXX detection in source files:"
 
-# Staged TODO
-echo "# FIXME: broken" >> "$TMPDIR/README.md"
+reset_repo
+echo "function foo() { /* TODO: implement */ }" > "$TMPDIR/app.js"
+git -C "$TMPDIR" add app.js
+output=$(run_hook_output "$TMPDIR")
+assert_contains     "staged TODO in app.js emits block decision"   '"decision": "block"' "$output"
+assert_contains     "staged TODO message references the count"     'TODO/FIXME/HACK/XXX' "$output"
+assert_not_contains "block output does not leak prompt text"       "You are evaluating"  "$output"
+assert_not_contains "block output does not leak stop_hook_active"  "stop_hook_active"    "$output"
+
+reset_repo
+echo "# FIXME: broken" > "$TMPDIR/app.py"
+git -C "$TMPDIR" add app.py
+output=$(run_hook_output "$TMPDIR")
+assert_contains "staged FIXME in app.py emits block decision" '"decision": "block"' "$output"
+
+# ── markdown / docs files are excluded ───────────────────────────────────────
+# Documentation files (this very plugin's README) routinely quote literal
+# TODO/FIXME tokens, conflict markers, and console.log examples in prose.
+# Treating those as unfinished work is the dominant false-positive class.
+echo ""
+echo "documentation files are excluded:"
+
+reset_repo
+echo "We have a TODO list to track outstanding work." >> "$TMPDIR/README.md"
 git -C "$TMPDIR" add README.md
+output=$(run_hook_output "$TMPDIR")
+assert_not_contains "TODO in README.md does NOT emit a block decision" '"decision"' "$output"
 
-exit_code=$(run_hook "$TMPDIR")
-assert_exit "staged FIXME exits 2 (blocked)" 2 "$exit_code"
+reset_repo
+cat > "$TMPDIR/notes.md" <<'NOTES'
+Conflict example for the runbook:
+<<<<<<< HEAD
+local
+=======
+remote
+>>>>>>> main
+NOTES
+git -C "$TMPDIR" add notes.md
+output=$(run_hook_output "$TMPDIR")
+assert_not_contains "conflict markers in *.md do NOT emit a block decision" '"decision"' "$output"
 
-git -C "$TMPDIR" restore --staged README.md 2>/dev/null || git -C "$TMPDIR" reset HEAD README.md 2>/dev/null || true
-git -C "$TMPDIR" checkout -- README.md
+reset_repo
+echo "Avoid leaving console.log statements in committed code." >> "$TMPDIR/README.md"
+git -C "$TMPDIR" add README.md
+output=$(run_hook_output "$TMPDIR")
+assert_not_contains "console.log in *.md does NOT emit a block decision" '"decision"' "$output"
+
+# Mixed: markdown should be skipped but the source-file change still blocks.
+reset_repo
+echo "We have a TODO list" >> "$TMPDIR/README.md"
+echo "function foo() { /* TODO: implement */ }" > "$TMPDIR/app.js"
+git -C "$TMPDIR" add README.md app.js
+output=$(run_hook_output "$TMPDIR")
+assert_contains "TODO in source still blocks when markdown TODO is also staged" '"decision": "block"' "$output"
 
 # ── merge conflict markers ────────────────────────────────────────────────────
 echo ""
 echo "merge conflict marker detection:"
 
-cat > "$TMPDIR/conflict.txt" <<'CONFLICT'
+reset_repo
+cat > "$TMPDIR/conflict.js" <<'CONFLICT'
 <<<<<<< HEAD
 local change
 =======
 remote change
 >>>>>>> main
 CONFLICT
-git -C "$TMPDIR" add conflict.txt
-
-exit_code=$(run_hook "$TMPDIR")
-assert_exit "staged conflict markers exits 2 (blocked)" 2 "$exit_code"
-
+git -C "$TMPDIR" add conflict.js
 output=$(run_hook_output "$TMPDIR")
-assert_contains     "conflict output has 'decision' field"      '"decision"'         "$output"
-assert_not_contains "conflict output does not leak prompt text" "Respond with ONLY"  "$output"
-
-git -C "$TMPDIR" restore --staged conflict.txt 2>/dev/null || git -C "$TMPDIR" reset HEAD conflict.txt 2>/dev/null || true
-rm -f "$TMPDIR/conflict.txt"
+assert_contains     "staged conflict markers emit block decision"  '"decision": "block"' "$output"
+assert_contains     "block message names the affected file"        'conflict.js'         "$output"
+assert_not_contains "conflict output does not leak prompt text"    "Respond with ONLY"   "$output"
 
 # Regression: standalone `=======` divider lines (decorative separators in
 # fenced code blocks, console-output examples, ASCII art) must NOT be flagged
 # as merge conflicts. Real conflicts always leave at least one of <<<<<<< or
 # >>>>>>> behind, even after a partial resolution.
-cat > "$TMPDIR/dividers.md" <<'DIVIDERS'
-Expected output:
-```
-==================================================
-Setup Validation
-==================================================
-All checks passed
-```
+reset_repo
+cat > "$TMPDIR/dividers.sh" <<'DIVIDERS'
+#!/bin/bash
+echo "=================================================="
+echo "Setup Validation"
+echo "=================================================="
+echo "All checks passed"
 DIVIDERS
-git -C "$TMPDIR" add dividers.md
-
+git -C "$TMPDIR" add dividers.sh
 output=$(run_hook_output "$TMPDIR")
 assert_not_contains "standalone === dividers do NOT emit a block decision" '"decision"' "$output"
 
-git -C "$TMPDIR" restore --staged dividers.md 2>/dev/null || git -C "$TMPDIR" reset HEAD dividers.md 2>/dev/null || true
-rm -f "$TMPDIR/dividers.md"
-
-# Regression: an orphan <<<<<<< marker (left behind after a partial conflict
-# resolution that removed ======= and >>>>>>>) must still be flagged.
-cat > "$TMPDIR/orphan-open.txt" <<'ORPHAN_OPEN'
+# Regression: orphan markers (left after a partial conflict resolution) must
+# still be flagged.
+reset_repo
+cat > "$TMPDIR/orphan-open.js" <<'ORPHAN_OPEN'
 <<<<<<< HEAD
 local change
 ORPHAN_OPEN
-git -C "$TMPDIR" add orphan-open.txt
-
+git -C "$TMPDIR" add orphan-open.js
 output=$(run_hook_output "$TMPDIR")
 assert_contains "orphan <<<<<<< marker still emits a block decision" '"decision"' "$output"
 
-git -C "$TMPDIR" restore --staged orphan-open.txt 2>/dev/null || git -C "$TMPDIR" reset HEAD orphan-open.txt 2>/dev/null || true
-rm -f "$TMPDIR/orphan-open.txt"
-
-# Regression: an orphan >>>>>>> marker (left behind after a partial conflict
-# resolution that removed <<<<<<< and =======) must still be flagged.
-cat > "$TMPDIR/orphan-close.txt" <<'ORPHAN_CLOSE'
+reset_repo
+cat > "$TMPDIR/orphan-close.js" <<'ORPHAN_CLOSE'
 remote change
 >>>>>>> main
 ORPHAN_CLOSE
-git -C "$TMPDIR" add orphan-close.txt
-
+git -C "$TMPDIR" add orphan-close.js
 output=$(run_hook_output "$TMPDIR")
 assert_contains "orphan >>>>>>> marker still emits a block decision" '"decision"' "$output"
-
-git -C "$TMPDIR" restore --staged orphan-close.txt 2>/dev/null || git -C "$TMPDIR" reset HEAD orphan-close.txt 2>/dev/null || true
-rm -f "$TMPDIR/orphan-close.txt"
 
 # ── debugging artifacts ───────────────────────────────────────────────────────
 echo ""
 echo "debugging artifact detection:"
 
-echo "console.log('debug', x);" >> "$TMPDIR/app.js"
+reset_repo
+echo "console.log('debug', x);" > "$TMPDIR/app.js"
 git -C "$TMPDIR" add app.js
+output=$(run_hook_output "$TMPDIR")
+assert_contains "staged console.log emits block decision" '"decision": "block"' "$output"
 
-exit_code=$(run_hook "$TMPDIR")
-assert_exit "staged console.log exits 2 (blocked)" 2 "$exit_code"
-
-git -C "$TMPDIR" restore --staged app.js 2>/dev/null || git -C "$TMPDIR" reset HEAD app.js 2>/dev/null || true
-rm -f "$TMPDIR/app.js"
-
-echo "debugger;" >> "$TMPDIR/app.js"
+reset_repo
+echo "debugger;" > "$TMPDIR/app.js"
 git -C "$TMPDIR" add app.js
-
-exit_code=$(run_hook "$TMPDIR")
-assert_exit "staged 'debugger;' exits 2 (blocked)" 2 "$exit_code"
-
-git -C "$TMPDIR" restore --staged app.js 2>/dev/null || git -C "$TMPDIR" reset HEAD app.js 2>/dev/null || true
-rm -f "$TMPDIR/app.js"
+output=$(run_hook_output "$TMPDIR")
+assert_contains "staged 'debugger;' emits block decision" '"decision": "block"' "$output"
 
 # ── edge cases ────────────────────────────────────────────────────────────────
 echo ""
@@ -242,11 +269,13 @@ assert_exit "missing cwd field exits 0" 0 "$empty_exit"
 echo ""
 echo "CLAUDE_HOOKS_DISABLE_TASK_COMPLETENESS override:"
 
-echo "# TODO: should be ignored" >> "$TMPDIR/README.md"
+reset_repo
+echo "function f() { /* TODO: should be ignored */ }" > "$TMPDIR/app.js"
+git -C "$TMPDIR" add app.js
 override_exit=0
-printf '{"cwd":"%s"}' "$TMPDIR" | CLAUDE_HOOKS_DISABLE_TASK_COMPLETENESS=1 bash "$HOOK" >/dev/null 2>&1 || override_exit=$?
-assert_exit "CLAUDE_HOOKS_DISABLE_TASK_COMPLETENESS=1 skips checks" 0 "$override_exit"
-git -C "$TMPDIR" checkout -- README.md
+override_output=$(printf '{"cwd":"%s"}' "$TMPDIR" | CLAUDE_HOOKS_DISABLE_TASK_COMPLETENESS=1 bash "$HOOK" 2>/dev/null) || override_exit=$?
+assert_exit       "CLAUDE_HOOKS_DISABLE_TASK_COMPLETENESS=1 exits 0" 0 "$override_exit"
+assert_not_contains "CLAUDE_HOOKS_DISABLE_TASK_COMPLETENESS=1 emits no decision" '"decision"' "$override_output"
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

Stop-hook re-evaluation, first batch — items (a) and (c) from the conversation. Item (b) (test-verification reshape) is intentionally **not** in this PR.

## What changed

**`task-completeness.sh` — repair two latent bugs and exclude docs files**

- The TODO/FIXME/HACK/XXX check was a silent no-op since the 2026-04-25 rewrite. It grepped each changed file's *content* for lines starting with `+` instead of the diff output, so it never matched real source code.
- The count arithmetic produced `"0\n0"` on empty input (`grep -c . || echo 0` doubling the fallback), which raised "integer expression expected" errors and masked the broken check.
- Rewrote the hook around a single relevant-file list and a shared `git diff` block that all three checks consume, so the TODO and debug-artifact checks actually inspect added lines.
- Excluded documentation files (`*.md`, `*.mdx`, `*.rst`, `*.txt`) from every check. This plugin's own docs quote literal TODO tokens, conflict markers, and `console.log` examples in prose; that was the dominant false-positive class on docs-heavy repos.

**`test-task-completeness.sh` — match the actual contract and add regressions**

- The legacy assertions expected exit 2 on block; the hook actually emits `{"decision":"block",...}` on stdout with exit 0 (per `hooks-reference.md`). The mismatch had been silent because the test script wasn't wired into CI.
- Switched all blocking assertions to inspect the JSON output.
- Added regressions for: docs-file exclusion (`*.md` TODO, `*.md` conflict marker, `*.md` console.log), the previously-broken TODO-in-source detection, and a mixed case where a docs TODO and a source TODO land in the same diff.
- Disabled commit signing inside the suite so it runs in sandboxed environments.

**`hooks-plugin/README.md` — sync with current implementations**

- Replaced the stale "Stop — Test Verification (agent), 120s" section with the actual `command`-type hook (60s framework / 45s hard internal, runner detection list including the justfile/Makefile fast-recipe priority, timeout-approve behaviour, `CLAUDE_HOOKS_DISABLE_TEST_VERIFICATION` toggle).
- Documented the new docs-file exclusions on `task-completeness.sh`.
- Added the `CLAUDE_HOOKS_DISABLE_TEST_VERIFICATION` toggle row.

## Test plan

- [x] `bash hooks-plugin/hooks/test-task-completeness.sh` → 24/24 pass
- [x] `bash scripts/lint-shell-scripts.sh` → 0 errors, 0 warnings
- [x] Manual smoke test: TODO in `app.js` blocks; TODO in `README.md` does not; conflict markers in `.js` block; conflict markers in `.md` do not; `console.log` in `.js` blocks; `console.log` in `.md` does not.

## Not in this PR

The Stop-hook review also flagged `test-verification.sh` (option (b) in the discussion). That hook has separate concerns — pre-existing test failures blocking every Stop, the 45s hard timeout vs hour-long suites, and whether to demote it to `TaskCompleted`. Deferring to a follow-up so this fix can land cleanly.

Refs #1009

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDUP1xhTZXLw9L2F1mxHnV)_