### PR TITLE
refactor(hooks-plugin)!: scope test-verification to TaskCompleted with HEAD and fast-recipe gates

### DIFF
--- a/hooks-plugin/.claude-plugin/plugin.json
+++ b/hooks-plugin/.claude-plugin/plugin.json
@@ -123,12 +123,6 @@
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/task-completeness.sh",
             "timeout": 10000,
             "statusMessage": "Checking task completeness..."
-          },
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/test-verification.sh",
-            "timeout": 60000,
-            "statusMessage": "Running test verification..."
           }
         ]
       }
@@ -148,6 +142,12 @@
     "TaskCompleted": [
       {
         "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/test-verification.sh",
+            "timeout": 60000,
+            "statusMessage": "Running fast tests..."
+          },
           {
             "type": "agent",
             "prompt": "You are verifying that a completed task meets quality standards before accepting it. Context: $ARGUMENTS\n\n1. Run git diff --stat to see what files were changed\n2. For each changed source file, search for TODO/FIXME/HACK comments that may indicate unfinished work\n3. Check that no debugging artifacts remain (stray console.log, print() statements, debugger keywords)\n4. If the task involved adding new functionality, check if test files exist nearby or were updated\n5. Verify the changes are consistent with the task description\n\nRespond with {\"ok\": true} if the implementation looks complete and clean, or {\"ok\": false, \"reason\": \"specific issues found\"} if problems remain.",

--- a/hooks-plugin/README.md
+++ b/hooks-plugin/README.md
@@ -34,7 +34,12 @@ A PreToolUse hook that intercepts Bash commands and blocks those that should use
 
 ### git-stash-session-init.sh
 
-A SessionStart hook that records the stash baseline for session-scoped tracking. Required by `git-stash-reminder.sh`.
+A SessionStart hook that writes two session-scoped baselines used by other hooks:
+
+| Baseline | Path | Used by |
+|----------|------|---------|
+| Pre-existing stash hashes | `/tmp/claude-stash-baselines/<session_id>` | `git-stash-reminder.sh` |
+| HEAD commit at session start | `/tmp/claude-test-baselines/<session_id>` | `test-verification.sh` |
 
 ### git-stash-reminder.sh
 
@@ -156,17 +161,27 @@ Documentation files (`*.md`, `*.mdx`, `*.rst`, `*.txt`) and vendor/generated pat
 
 ### test-verification.sh
 
-A Stop hook that auto-detects the project's test runner and runs tests when uncommitted changes touch source files. Skips silently when no source files changed, no recognised runner is found, or the diff is documentation-only.
+A **TaskCompleted** hook (previously a Stop hook) that runs an explicitly-fast test recipe when an Agent Teams task is marked complete. Three independent constraints make this hook conservative — every constraint is a silent no-op when unmet:
+
+| Layer | Constraint | Rationale |
+|-------|-----------|-----------|
+| Event | `TaskCompleted` only | Stops fire on every Claude response; TaskCompleted fires once per finished team task. The original Stop wiring re-ran tests during in-progress refactors. |
+| HEAD baseline | Skip when current HEAD matches the baseline written by `git-stash-session-init.sh` | No commits landed → nothing new to verify. Pre-existing failures at session start no longer block forever. |
+| Fast-recipe required | Only run if the project defines `test-quick`, `test-unit`, or `test-fast` in `justfile` / `Makefile` / `package.json` (`test:quick` / `test:unit` / `test:fast`) | Hour-long full-suite projects are now no-ops. The previous fallback to `just test` / `make test` / `npm test` / `pytest` / `cargo test` / `go test` is gone. |
 
 | Aspect | Detail |
 |--------|--------|
-| Type | `command` (deterministic — replaced the former `type: "agent"` variant for latency) |
+| Type | `command` (deterministic) |
 | Timeout | 60s framework / 45s hard internal (configurable via `CLAUDE_HOOKS_TEST_TIMEOUT`) |
-| Detected runners | `justfile` (prefers `test-quick` → `test-unit` → `test`), `Makefile` (same priority), Bun, npm, pytest (uv-aware), cargo, go |
-| Skip conditions | Only docs/config files changed, no test runner found, `stop_hook_active=true` |
-| Timeout behaviour | Approves with a warning instead of blocking (does not interrupt flow) |
+| Recipe priority | `test-quick` → `test-unit` → `test-fast` (first match wins) |
+| Runners | `just`, `make`, `bun run` (when `bun.lockb` / `bun.lock` is present), `npm run` |
+| Source-file gate | Skipped if only docs / config / build-recipe files changed (`*.md`, `*.json`, `justfile`, `Makefile`, `Dockerfile`, …) |
+| Failure | Block via `{"decision":"block","reason":"..."}` with the last 20 lines of test output |
+| Timeout | Approves with a warning instead of blocking — a "fast" recipe over 45s is itself a project-hygiene signal |
 
 **Toggle:** `CLAUDE_HOOKS_DISABLE_TEST_VERIFICATION=1`
+
+**Migrating from the old behaviour:** if you previously relied on `npm test` / `cargo test` running on every Stop, define a fast variant (`test:quick` / `test-quick`) that runs your unit tests only. Without one, the hook is intentionally silent.
 
 > **Note on prompt-type Stop hooks**: When a `type: "prompt"` hook on `Stop` or `SubagentStop` returns `{"ok": false}`, Claude Code surfaces the full prompt text in the error message (e.g. `Stop hook error: [You are evaluating...]: reason`). This is a runtime behavior that cannot be configured away. Prefer `type: "command"` hooks with deterministic heuristics for Stop events to avoid this leakage. Only use `type: "prompt"` on Stop hooks when the check genuinely requires LLM judgment and cannot be deterministic.
 
@@ -186,7 +201,7 @@ A `type: "prompt"` hook that evaluates subagent output completeness. Blocks vagu
 
 ### TaskCompleted — Implementation Verification (agent)
 
-A `type: "agent"` hook that verifies task implementation quality when a team task is marked complete. Checks for leftover TODOs, debug artifacts, and test coverage.
+A `type: "agent"` hook that verifies task implementation quality when a team task is marked complete. Runs alongside `test-verification.sh` (command-type) on the same event: the deterministic test run goes first, then the LLM-driven quality check fires only if tests pass.
 
 | Aspect | Detail |
 |--------|--------|

--- a/hooks-plugin/hooks/git-stash-session-init.sh
+++ b/hooks-plugin/hooks/git-stash-session-init.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
-# SessionStart hook - records current git stash hashes as a session baseline
-# Used by git-stash-reminder.sh to only flag stashes created during this session
+# SessionStart hook - records git baselines for session-scoped tracking
+#
+# Two baselines are written, both keyed by session_id:
+#   - stash baseline (used by git-stash-reminder.sh)
+#   - HEAD commit baseline (used by test-verification.sh to skip when no
+#     commits have landed since the session began)
+#
+# The script keeps its historical name for plugin.json compatibility even
+# though it now records more than stashes.
 set -euo pipefail
 
 # Read JSON input from stdin and extract fields
@@ -24,11 +31,17 @@ fi
 # Record current stash commit hashes as the session baseline
 # Uses %H (full commit hash) because stash indices (%gd) shift when stashes
 # are added or removed. Hashes are stable identifiers.
-BASELINE_DIR="/tmp/claude-stash-baselines"
-mkdir -p "$BASELINE_DIR"
-BASELINE_FILE="${BASELINE_DIR}/${SESSION_ID}"
+STASH_BASELINE_DIR="/tmp/claude-stash-baselines"
+mkdir -p "$STASH_BASELINE_DIR"
+STASH_BASELINE_FILE="${STASH_BASELINE_DIR}/${SESSION_ID}"
+git -C "$CWD" stash list --format='%H' 2>/dev/null > "$STASH_BASELINE_FILE" || true
 
-# Write all current stash hashes, one per line (empty file if no stashes)
-git -C "$CWD" stash list --format='%H' 2>/dev/null > "$BASELINE_FILE" || true
+# Record HEAD commit at session start. Used by test-verification.sh to skip
+# the test run when HEAD has not advanced (no commits landed → nothing new
+# to verify). Empty file if HEAD cannot be resolved (unborn branch, etc.).
+TEST_BASELINE_DIR="/tmp/claude-test-baselines"
+mkdir -p "$TEST_BASELINE_DIR"
+TEST_BASELINE_FILE="${TEST_BASELINE_DIR}/${SESSION_ID}"
+git -C "$CWD" rev-parse HEAD 2>/dev/null > "$TEST_BASELINE_FILE" || true
 
 exit 0

--- a/hooks-plugin/hooks/test-test-verification.sh
+++ b/hooks-plugin/hooks/test-test-verification.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# Regression tests for test-verification.sh
+#
+# Verifies the three layered constraints on the test-verification hook:
+#   Layer 1 - require an explicit fast recipe (no bare-`test` fallback)
+#   Layer 2 - skip when HEAD has not advanced since session start
+#   Layer 3 - is wired to TaskCompleted, not Stop (covered by plugin.json)
+#
+# The hook contract: emit {"decision":"block","reason":"..."} on stdout when
+# tests fail; emit {"decision":"approve","reason":"..."} on timeout; exit 0
+# silently in every other case (including all "skip" paths).
+#
+# Run: bash hooks-plugin/hooks/test-test-verification.sh
+# Exit 0 = all tests pass, Exit 1 = failures
+set -euo pipefail
+
+HOOK="$(dirname "$0")/test-verification.sh"
+PASS=0
+FAIL=0
+
+TMPDIR=$(mktemp -d)
+NON_GIT_DIR=$(mktemp -d)
+TEST_BASELINE_DIR="/tmp/claude-test-baselines"
+mkdir -p "$TEST_BASELINE_DIR"
+
+# Use a deterministic session ID per run so we can clean up our own baselines.
+SESSION_ID="task-verify-test-$$"
+BASELINE_FILE="${TEST_BASELINE_DIR}/${SESSION_ID}"
+
+trap 'rm -rf "$TMPDIR" "$NON_GIT_DIR" "$BASELINE_FILE"' EXIT
+
+# Initialize git repo
+git -C "$TMPDIR" init -q
+git -C "$TMPDIR" config user.email "test@example.com"
+git -C "$TMPDIR" config user.name "Test"
+git -C "$TMPDIR" config commit.gpgsign false
+git -C "$TMPDIR" config gpg.format ""
+echo "initial" > "$TMPDIR/README.md"
+git -C "$TMPDIR" add README.md
+git -C "$TMPDIR" commit -q -m "initial"
+
+# Helpers
+reset_repo() {
+    git -C "$TMPDIR" restore --staged . 2>/dev/null || true
+    git -C "$TMPDIR" checkout -- . 2>/dev/null || true
+    git -C "$TMPDIR" clean -fdq 2>/dev/null || true
+    rm -f "$TMPDIR/justfile" "$TMPDIR/Makefile" "$TMPDIR/package.json" "$TMPDIR/bun.lockb" "$TMPDIR/bun.lock"
+}
+
+set_baseline() {
+    git -C "$TMPDIR" rev-parse HEAD > "$BASELINE_FILE"
+}
+
+clear_baseline() {
+    rm -f "$BASELINE_FILE"
+}
+
+run_hook_output() {
+    local extra="${1:-}"
+    local json
+    if [ -n "$extra" ]; then
+        json=$(printf '{"cwd":"%s","session_id":"%s",%s}' "$TMPDIR" "$SESSION_ID" "$extra")
+    else
+        json=$(printf '{"cwd":"%s","session_id":"%s"}' "$TMPDIR" "$SESSION_ID")
+    fi
+    printf '%s' "$json" | bash "$HOOK" 2>/dev/null || true
+}
+
+run_hook_exit() {
+    local extra="${1:-}"
+    local json exit_code=0
+    if [ -n "$extra" ]; then
+        json=$(printf '{"cwd":"%s","session_id":"%s",%s}' "$TMPDIR" "$SESSION_ID" "$extra")
+    else
+        json=$(printf '{"cwd":"%s","session_id":"%s"}' "$TMPDIR" "$SESSION_ID")
+    fi
+    printf '%s' "$json" | bash "$HOOK" >/dev/null 2>&1 || exit_code=$?
+    echo "$exit_code"
+}
+
+assert_exit() {
+    local desc="$1" expected="$2" actual="$3"
+    if [ "$actual" -eq "$expected" ]; then
+        printf "  PASS: %s\n" "$desc"
+        PASS=$((PASS + 1))
+    else
+        printf "  FAIL: %s (expected exit %d, got %d)\n" "$desc" "$expected" "$actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local desc="$1" pattern="$2" actual="$3"
+    if echo "$actual" | grep -q "$pattern"; then
+        printf "  PASS: %s\n" "$desc"
+        PASS=$((PASS + 1))
+    else
+        printf "  FAIL: %s (expected pattern '%s', output was: %s)\n" "$desc" "$pattern" "$actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_contains() {
+    local desc="$1" pattern="$2" actual="$3"
+    if echo "$actual" | grep -q "$pattern"; then
+        printf "  FAIL: %s (found forbidden '%s' in: %s)\n" "$desc" "$pattern" "$actual"
+        FAIL=$((FAIL + 1))
+    else
+        printf "  PASS: %s\n" "$desc"
+        PASS=$((PASS + 1))
+    fi
+}
+
+echo "=== test-verification hook tests ==="
+
+# ── Guard tests ──────────────────────────────────────────────────────────────
+echo ""
+echo "guards:"
+
+reset_repo
+output=$(run_hook_output '"stop_hook_active":true')
+assert_not_contains "stop_hook_active=true emits no decision" '"decision"' "$output"
+
+exit_code=$(printf '{}' | bash "$HOOK" >/dev/null 2>&1; echo $?)
+assert_exit "missing cwd field exits 0" 0 "$exit_code"
+
+exit_code=$(printf '{"cwd":"%s","session_id":"x"}' "$NON_GIT_DIR" | bash "$HOOK" >/dev/null 2>&1; echo $?)
+assert_exit "non-git directory exits 0" 0 "$exit_code"
+
+# ── Layer 2: HEAD baseline ───────────────────────────────────────────────────
+# When the baseline matches HEAD, the hook must skip silently regardless of
+# what other state is present (changed files, fast recipe, anything).
+echo ""
+echo "Layer 2 — HEAD baseline:"
+
+reset_repo
+set_baseline  # baseline now equals current HEAD
+echo "function f() { return 1; }" > "$TMPDIR/app.js"
+git -C "$TMPDIR" add app.js
+# Even with a fast recipe defined, baseline match must short-circuit.
+cat > "$TMPDIR/justfile" <<'JF'
+test-quick:
+	exit 1
+JF
+output=$(run_hook_output)
+assert_not_contains "HEAD == baseline emits no decision" '"decision"' "$output"
+
+clear_baseline
+
+# ── Layer 1: fast recipe required ────────────────────────────────────────────
+echo ""
+echo "Layer 1 — fast recipe required:"
+
+# No fast recipe → silent no-op even with source changes.
+reset_repo
+echo "function f() { return 1; }" > "$TMPDIR/app.js"
+git -C "$TMPDIR" add app.js
+output=$(run_hook_output)
+assert_not_contains "no fast recipe → no decision" '"decision"' "$output"
+
+# Bare `test` recipe in justfile is NOT a fast recipe.
+reset_repo
+echo "function f() { return 1; }" > "$TMPDIR/app.js"
+git -C "$TMPDIR" add app.js
+cat > "$TMPDIR/justfile" <<'JF'
+test:
+	exit 1
+JF
+output=$(run_hook_output)
+assert_not_contains "bare 'just test' is NOT a fast recipe" '"decision"' "$output"
+
+# Bare `test` target in Makefile is NOT a fast recipe.
+reset_repo
+echo "function f() { return 1; }" > "$TMPDIR/app.js"
+git -C "$TMPDIR" add app.js
+cat > "$TMPDIR/Makefile" <<'MK'
+test:
+	exit 1
+MK
+output=$(run_hook_output)
+assert_not_contains "bare 'make test' is NOT a fast recipe" '"decision"' "$output"
+
+# Bare `test` script in package.json is NOT a fast recipe.
+reset_repo
+echo "function f() { return 1; }" > "$TMPDIR/app.js"
+git -C "$TMPDIR" add app.js
+cat > "$TMPDIR/package.json" <<'PJ'
+{"name":"x","scripts":{"test":"exit 1"}}
+PJ
+output=$(run_hook_output)
+assert_not_contains "bare 'npm test' is NOT a fast recipe" '"decision"' "$output"
+
+# ── Layer 1: explicit fast recipes are honoured ──────────────────────────────
+echo ""
+echo "Layer 1 — explicit fast recipes are honoured:"
+
+# justfile test-quick that fails should block.
+reset_repo
+echo "function f() { return 1; }" > "$TMPDIR/app.js"
+git -C "$TMPDIR" add app.js
+cat > "$TMPDIR/justfile" <<'JF'
+test-quick:
+	echo "FAIL"; exit 1
+JF
+output=$(run_hook_output)
+assert_contains "failing 'just test-quick' emits block decision" '"decision": "block"' "$output"
+assert_contains "block reason names the recipe"               'just test-quick'      "$output"
+
+# Makefile test-fast that passes should be silent.
+reset_repo
+echo "function f() { return 1; }" > "$TMPDIR/app.js"
+git -C "$TMPDIR" add app.js
+cat > "$TMPDIR/Makefile" <<'MK'
+test-fast:
+	@exit 0
+MK
+output=$(run_hook_output)
+assert_not_contains "passing 'make test-fast' emits no decision" '"decision"' "$output"
+
+# package.json test:quick failure should block (npm runner).
+reset_repo
+echo "function f() { return 1; }" > "$TMPDIR/app.js"
+git -C "$TMPDIR" add app.js
+cat > "$TMPDIR/package.json" <<'PJ'
+{"name":"x","scripts":{"test:quick":"exit 1"}}
+PJ
+output=$(run_hook_output)
+assert_contains "failing 'npm run test:quick' emits block decision" '"decision": "block"' "$output"
+assert_contains "block reason names the npm runner"                'npm run test:quick'  "$output"
+
+# package.json with bun.lockb present should use bun runner.
+reset_repo
+echo "function f() { return 1; }" > "$TMPDIR/app.js"
+git -C "$TMPDIR" add app.js
+cat > "$TMPDIR/package.json" <<'PJ'
+{"name":"x","scripts":{"test:fast":"exit 1"}}
+PJ
+echo "" > "$TMPDIR/bun.lock"
+output=$(run_hook_output)
+assert_contains "bun.lock + test:fast → bun run test:fast" 'bun run test:fast' "$output"
+
+# Priority: test-quick > test-unit > test-fast (justfile)
+reset_repo
+echo "function f() { return 1; }" > "$TMPDIR/app.js"
+git -C "$TMPDIR" add app.js
+cat > "$TMPDIR/justfile" <<'JF'
+test-quick:
+	@echo QUICK; exit 1
+test-unit:
+	@echo UNIT; exit 1
+JF
+output=$(run_hook_output)
+assert_contains "test-quick wins over test-unit" 'just test-quick' "$output"
+
+# ── Source-file gate ─────────────────────────────────────────────────────────
+echo ""
+echo "source-file gate:"
+
+# No file changes at all → silent.
+reset_repo
+cat > "$TMPDIR/justfile" <<'JF'
+test-quick:
+	@exit 1
+JF
+output=$(run_hook_output)
+assert_not_contains "no changed files → no decision" '"decision"' "$output"
+
+# Only docs changed → silent (even with a fast recipe and a failing one).
+reset_repo
+echo "more docs" >> "$TMPDIR/README.md"
+git -C "$TMPDIR" add README.md
+cat > "$TMPDIR/justfile" <<'JF'
+test-quick:
+	@exit 1
+JF
+output=$(run_hook_output)
+assert_not_contains "only docs changed → no decision" '"decision"' "$output"
+
+# ── Disable via environment variable ─────────────────────────────────────────
+echo ""
+echo "CLAUDE_HOOKS_DISABLE_TEST_VERIFICATION override:"
+
+reset_repo
+echo "function f() { return 1; }" > "$TMPDIR/app.js"
+git -C "$TMPDIR" add app.js
+cat > "$TMPDIR/justfile" <<'JF'
+test-quick:
+	@exit 1
+JF
+override_output=$(printf '{"cwd":"%s","session_id":"%s"}' "$TMPDIR" "$SESSION_ID" \
+    | CLAUDE_HOOKS_DISABLE_TEST_VERIFICATION=1 bash "$HOOK" 2>/dev/null) || true
+assert_not_contains "CLAUDE_HOOKS_DISABLE_TEST_VERIFICATION=1 emits no decision" '"decision"' "$override_output"
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/hooks-plugin/hooks/test-verification.sh
+++ b/hooks-plugin/hooks/test-verification.sh
@@ -1,10 +1,26 @@
 #!/usr/bin/env bash
-# Stop hook - runs tests if source files were modified during the session
-# Replaces the agent-based test verification hook with a deterministic script
-# to eliminate LLM latency on every stop event
+# TaskCompleted hook - runs an explicitly-fast test recipe when a team task
+# completes, but only if HEAD has advanced since the session began.
 #
-# Uses a hard timeout to prevent hanging when test suites are slow.
-# Prefers quick/unit test recipes over full suites for fast feedback.
+# Three layered constraints, each independently silent:
+#
+#   Layer 1 (fast-recipe required) - only runs when the project defines an
+#     explicit fast test recipe (just/make `test-quick` / `test-unit` /
+#     `test-fast`, or a `test:quick` / `test:unit` / `test:fast` script in
+#     package.json). The previous fallback to plain `just test` / `make test`
+#     / `npm test` / `pytest` / `cargo test` / `go test` is gone — projects
+#     with hour-long suites and no fast variant are now no-ops here.
+#
+#   Layer 2 (HEAD baseline) - skips when current HEAD matches the commit
+#     recorded by git-stash-session-init.sh at session start. No commits
+#     landed → nothing new to verify.
+#
+#   Layer 3 (event) - this hook is wired to TaskCompleted, not Stop, so it
+#     fires once per completed Agent Teams task instead of after every
+#     Claude response.
+#
+# A 45-second hard timeout via `timeout` keeps slow recipes from hanging the
+# event. Timeouts approve with a warning rather than block the task.
 set -euo pipefail
 
 # Hard timeout in seconds - prevents hanging on slow test suites
@@ -20,9 +36,11 @@ fi
 # Read JSON input from stdin and extract fields
 INPUT=$(cat)
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
 STOP_HOOK_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false')
 
-# Guard: stop_hook_active - prevent infinite loops
+# Guard: stop_hook_active - only meaningful when the hook is wired to Stop;
+# kept for safety in case a user re-attaches it there.
 if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
     exit 0
 fi
@@ -37,6 +55,20 @@ if ! git -C "$CWD" rev-parse --git-dir >/dev/null 2>&1; then
     exit 0
 fi
 
+# ── Layer 2: HEAD baseline ────────────────────────────────────────────────────
+# Skip when HEAD has not advanced since session start — no commits landed,
+# nothing new to verify. The baseline is written by git-stash-session-init.sh.
+SESSION_ID=$(echo "$SESSION_ID" | tr -cd 'a-zA-Z0-9_-')
+TEST_BASELINE_FILE="/tmp/claude-test-baselines/${SESSION_ID}"
+if [ -n "$SESSION_ID" ] && [ -f "$TEST_BASELINE_FILE" ]; then
+    BASELINE_HEAD=$(cat "$TEST_BASELINE_FILE" 2>/dev/null || true)
+    CURRENT_HEAD=$(git -C "$CWD" rev-parse HEAD 2>/dev/null || true)
+    if [ -n "$BASELINE_HEAD" ] && [ "$BASELINE_HEAD" = "$CURRENT_HEAD" ]; then
+        exit 0
+    fi
+fi
+
+# ── Source-file gate ─────────────────────────────────────────────────────────
 # Collect all changed files: staged, unstaged, and untracked
 CHANGED_FILES=$(
     {
@@ -51,69 +83,66 @@ if [ -z "$CHANGED_FILES" ]; then
     exit 0
 fi
 
-# Filter out non-source files (docs, config, metadata)
-SOURCE_FILES=$(echo "$CHANGED_FILES" | grep -vE '\.(md|json|yml|yaml|toml|lock|txt|cfg|ini|env|gitignore|prettierrc|eslintrc|editorconfig)$' | grep -v '^LICENSE' || true)
+# Filter out non-source files (docs, config, metadata, build recipes).
+# Extensionless config/build files (justfile, Makefile, Dockerfile, ...) are
+# matched by basename so an edit to the project's recipe file alone doesn't
+# trigger a test run.
+SOURCE_FILES=$(
+    echo "$CHANGED_FILES" \
+        | grep -vE '\.(md|json|yml|yaml|toml|lock|txt|cfg|ini|env|gitignore|prettierrc|eslintrc|editorconfig)$' \
+        | grep -vE '(^|/)(LICENSE|justfile|[Mm]akefile|GNUmakefile|Dockerfile|Containerfile|Vagrantfile|Procfile|Rakefile|Gemfile|Pipfile)$' \
+        || true
+)
 
 # Guard: no source files changed
 if [ -z "$SOURCE_FILES" ]; then
     exit 0
 fi
 
-# Detect test runner and build command
-# Priority: explicit build recipes (justfile/Makefile) first since they handle
-# venv/env setup correctly, then language-specific tool detection
+# ── Layer 1: fast-recipe detection ───────────────────────────────────────────
+# Only run when the project defines an explicit fast recipe. A bare `test`
+# recipe (full suite) does NOT qualify — projects with hour-long suites must
+# opt in by defining a fast variant.
 TEST_CMD=""
 
 if [ -f "$CWD/justfile" ]; then
-    # Prefer fast test recipes over full suite to avoid hanging on slow tests
-    if grep -q '^test-quick' "$CWD/justfile" 2>/dev/null; then
-        TEST_CMD="just test-quick"
-    elif grep -q '^test-unit' "$CWD/justfile" 2>/dev/null; then
-        TEST_CMD="just test-unit"
-    elif grep -q '^test' "$CWD/justfile" 2>/dev/null; then
-        TEST_CMD="just test"
-    fi
-elif [ -f "$CWD/Makefile" ]; then
-    if grep -q '^test-quick:' "$CWD/Makefile" 2>/dev/null; then
-        TEST_CMD="make test-quick"
-    elif grep -q '^test-unit:' "$CWD/Makefile" 2>/dev/null; then
-        TEST_CMD="make test-unit"
-    elif grep -q '^test:' "$CWD/Makefile" 2>/dev/null; then
-        TEST_CMD="make test"
-    fi
-elif [ -f "$CWD/bun.lockb" ] || [ -f "$CWD/bun.lock" ]; then
-    # Bun project - check for test script
-    if [ -f "$CWD/package.json" ] && jq -e '.scripts.test' "$CWD/package.json" >/dev/null 2>&1; then
-        TEST_CMD="bun run test -- --bail=1"
-    fi
-elif [ -f "$CWD/package.json" ] && jq -e '.scripts.test' "$CWD/package.json" >/dev/null 2>&1; then
-    TEST_CMD="npm test -- --bail=1"
-elif [ -f "$CWD/pytest.ini" ] || [ -f "$CWD/setup.cfg" ] && grep -q '\[tool:pytest\]' "$CWD/setup.cfg" 2>/dev/null; then
-    # Use uv run if uv.lock exists (project uses uv for dependency management)
-    if [ -f "$CWD/uv.lock" ]; then
-        TEST_CMD="uv run pytest -x --tb=short"
-    else
-        TEST_CMD="pytest -x --tb=short"
-    fi
-elif [ -f "$CWD/pyproject.toml" ] && grep -q '\[tool\.pytest' "$CWD/pyproject.toml" 2>/dev/null; then
-    if [ -f "$CWD/uv.lock" ]; then
-        TEST_CMD="uv run pytest -x --tb=short"
-    else
-        TEST_CMD="pytest -x --tb=short"
-    fi
-elif [ -f "$CWD/Cargo.toml" ]; then
-    TEST_CMD="cargo test"
-elif [ -f "$CWD/go.mod" ]; then
-    TEST_CMD="go test ./..."
+    for recipe in test-quick test-unit test-fast; do
+        if grep -qE "^${recipe}([[:space:]]|:|$)" "$CWD/justfile" 2>/dev/null; then
+            TEST_CMD="just $recipe"
+            break
+        fi
+    done
 fi
 
-# Guard: no test runner found
+if [ -z "$TEST_CMD" ] && [ -f "$CWD/Makefile" ]; then
+    for target in test-quick test-unit test-fast; do
+        if grep -qE "^${target}:" "$CWD/Makefile" 2>/dev/null; then
+            TEST_CMD="make $target"
+            break
+        fi
+    done
+fi
+
+if [ -z "$TEST_CMD" ] && [ -f "$CWD/package.json" ]; then
+    package_runner="npm run"
+    if [ -f "$CWD/bun.lockb" ] || [ -f "$CWD/bun.lock" ]; then
+        package_runner="bun run"
+    fi
+    for script_name in test:quick test:unit test:fast; do
+        if jq -e --arg s "$script_name" '.scripts[$s]' "$CWD/package.json" >/dev/null 2>&1; then
+            TEST_CMD="$package_runner $script_name"
+            break
+        fi
+    done
+fi
+
+# Guard: no fast recipe found - silent no-op (Layer 1 contract)
 if [ -z "$TEST_CMD" ]; then
     exit 0
 fi
 
-# Run tests with hard timeout to prevent hanging
-# Exit code 124 = timeout killed the process
+# ── Run the fast recipe ───────────────────────────────────────────────────────
+# Hard timeout to prevent hanging. Exit code 124 = timeout killed the process.
 TEST_OUTPUT=$(cd "$CWD" && timeout "$TEST_TIMEOUT" bash -c "$TEST_CMD" 2>&1) || TEST_EXIT=$?
 TEST_EXIT=${TEST_EXIT:-0}
 
@@ -122,9 +151,11 @@ if [ "$TEST_EXIT" -eq 0 ]; then
     exit 0
 fi
 
-# Timeout - don't block, just warn and let Claude continue
+# Timeout — don't block, just warn. A "fast" recipe that exceeds 45s is itself
+# a project-hygiene signal, not a reason to interrupt the task.
 if [ "$TEST_EXIT" -eq 124 ]; then
-    jq -n --arg reason "Test verification timed out after ${TEST_TIMEOUT}s (${TEST_CMD}). Tests may be slow — consider adding a fast test-unit or test-quick recipe." \
+    # shellcheck disable=SC2016  # jq expression, not shell expansion
+    jq -n --arg reason "Test verification timed out after ${TEST_TIMEOUT}s (${TEST_CMD}). The 'fast' recipe is no longer fast — consider trimming it." \
         '{"decision": "approve", "reason": $reason}'
     exit 0
 fi


### PR DESCRIPTION
## Summary

Stop-hook re-evaluation — round two. Picks up where #1229 left off and reshapes `test-verification.sh` along the three layered constraints discussed in the chat.

## What changed

**Layer 1 — fast recipe required.** Detection now only matches project-defined fast recipes:

| Where | Recipe |
|-------|--------|
| `justfile` | `test-quick` / `test-unit` / `test-fast` (first match wins) |
| `Makefile` | `test-quick` / `test-unit` / `test-fast` |
| `package.json` | `test:quick` / `test:unit` / `test:fast` (auto-selects `bun run` when `bun.lock`/`bun.lockb` is present, else `npm run`) |

The old fallbacks to `just test` / `make test` / `npm test` / `pytest -x` / `cargo test` / `go test ./...` are gone. Projects without a fast recipe are now no-ops here — fixes the hour-long-suite case explicitly.

**Layer 2 — HEAD baseline.** `git-stash-session-init.sh` now also writes `/tmp/claude-test-baselines/<session_id>` containing HEAD at session start. The hook short-circuits when current HEAD matches that baseline, so:
- An Agent Teams task that completes without a new commit doesn't re-run tests.
- Pre-existing failures from session-start commits no longer block forever.

**Layer 3 — event scope.** `plugin.json` moves the hook from `Stop` to `TaskCompleted`, alongside the existing implementation-quality agent hook. TaskCompleted only fires on Agent Teams task completion, so non-Teams users get the silent no-op behaviour they implicitly want.

## Side-effect fixes piggybacking on this

- **Source-file gate broadened.** Extensionless build/recipe filenames (`justfile`, `Makefile`, `Dockerfile`, `Vagrantfile`, `Procfile`, `Rakefile`, `Gemfile`, `Pipfile`) are now excluded. Editing your build recipe alone no longer triggers a test run.
- `git-stash-session-init.sh` keeps its name (it's referenced from `plugin.json`) but its comment block reflects the dual purpose.
- New regression suite at `hooks-plugin/hooks/test-test-verification.sh` covering all three layers, the source-file gate, and the disable toggle.

## Test plan

- [x] `bash hooks-plugin/hooks/test-test-verification.sh` → 18/18 pass
- [x] `bash hooks-plugin/hooks/test-task-completeness.sh` → 24/24 pass (no regressions)
- [x] `bash scripts/lint-shell-scripts.sh` → 0 errors, 0 warnings
- [x] `jq . hooks-plugin/.claude-plugin/plugin.json` validates

## ⚠️ BREAKING CHANGE

`test-verification.sh` has moved from `Stop` to `TaskCompleted` and now requires an explicit fast recipe. Projects without a `test-quick` / `test-unit` / `test-fast` recipe (or `test:quick` / `test:unit` / `test:fast` script in `package.json`) will no longer have tests auto-run. Define one to restore the previous behaviour.

Migration note is included in the README.

## Why a `!` (breaking change) and not a `feat`

`refactor!` because the externally-observable behaviour shifts in two ways: which event fires the hook, and which projects get auto-tested. Release-please will pick this up as a major bump on `hooks-plugin`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDUP1xhTZXLw9L2F1mxHnV)_