### PR TITLE
feat(git-plugin): align git-pr-feedback with GitHub's documented PR-feedback workflow

### DIFF
--- a/git-plugin/skills/git-pr-feedback/REFERENCE.md
+++ b/git-plugin/skills/git-pr-feedback/REFERENCE.md
@@ -79,14 +79,14 @@ Leave the thread open when:
 
 ## Commit Message Format
 
-Group related fixes into logical commits:
+Group related fixes into logical commits — typically one commit per logical group of accepted suggestions, not one per individual suggestion:
 
 ```bash
 git add <files-for-fix-1>
 git commit -m "fix: address review feedback - <specific change>"
 ```
 
-For multi-fix commits:
+For multi-fix commits, list each change and append a `Co-authored-by:` trailer per unique suggester (see "Co-author Attribution" below):
 
 ```
 fix: address PR review feedback
@@ -94,7 +94,8 @@ fix: address PR review feedback
 - <Change 1 description>
 - <Change 2 description>
 
-Co-authored-by: <reviewer> (if they provided specific code)
+Co-authored-by: Octo Cat <octocat@users.noreply.github.com>
+Co-authored-by: Mona Lisa <mona@example.com>
 ```
 
 Run pre-commit hooks if configured:
@@ -103,6 +104,92 @@ Run pre-commit hooks if configured:
 pre-commit run --all-files
 git add -u  # Stage any formatter changes
 ```
+
+## Co-author Attribution
+
+When you apply a `\`\`\`suggestion` block — verbatim or as an adapted variant — the suggester should be credited as a commit co-author. GitHub's "Commit suggestion" UI does this automatically; when applying suggestions through file edits we have to add the trailer ourselves.
+
+**Trailer format** (one per unique suggester, blank line before the trailer block):
+
+```
+Co-authored-by: <Name> <email>
+```
+
+**Resolving the email**:
+
+| Source available in PR data | Use |
+|----------------------------|-----|
+| Comment author has `User.email` set publicly | `<author.name> <author.email>` |
+| Public email not set, but `databaseId` available | `<login> <id>+<login>@users.noreply.github.com` |
+| Only `login` available | `<login> <login>@users.noreply.github.com` (legacy form, still accepted by GitHub) |
+
+The `<id>+<login>@users.noreply.github.com` form is GitHub's privacy-preserving address; it always links the contribution to the account.
+
+**Rules**:
+
+- One `Co-authored-by:` trailer per **unique** suggester per commit. If two suggestions from the same reviewer land in the same commit, do not duplicate the trailer.
+- Adapted variants count: the suggester gave the seed even if the final code differs. Credit them.
+- Multi-author commits: list trailers in the order suggestions were authored on the PR.
+- Verify locally with `git log -1 --format='%(trailers:key=Co-authored-by)'` before pushing.
+
+## Re-request Review
+
+After pushing changes that address substantive feedback, ask the affected reviewers to re-review. This mirrors the **sync icon** in the GitHub Conversation tab.
+
+**When to re-request**:
+
+| Situation | Re-request? |
+|-----------|-------------|
+| Reviewer left `CHANGES_REQUESTED` and concerns are now addressed | Yes |
+| Reviewer left inline threads that were resolved this push | Yes |
+| Only nitpicks were declined | No (no new code to review) |
+| Only a question was answered (no code change) | No |
+| Reviewer is the PR author (self-review) | No |
+
+**Command**:
+
+```bash
+gh api -X POST \
+  /repos/<owner>/<repo>/pulls/<pr>/requested_reviewers \
+  -f 'reviewers[]=<login1>' \
+  -f 'reviewers[]=<login2>'
+```
+
+**Failure modes**:
+
+- HTTP 422 "Reviews may only be requested from collaborators" — the reviewer is an outside contributor who reviewed by being @-mentioned. Note in the summary and skip.
+- HTTP 422 "Review cannot be requested from pull request author" — filter the PR author out of the list before calling.
+
+## Out-of-Scope Feedback → Follow-up Issue
+
+When a reviewer raises a valid concern that is genuinely out of scope for the current PR, file a follow-up issue rather than expanding the PR's diff.
+
+**Decision**:
+
+| Comment shape | Action |
+|---------------|--------|
+| Bug or improvement clearly outside the PR's stated goal | File issue, defer in reply |
+| Refactor opportunity adjacent to changed code | File issue, defer (or implement if trivial and the user agrees) |
+| Concern that contradicts the PR's purpose | Discuss inline; do not file an issue until resolved |
+| Suggestion the user explicitly rejects | Decline inline; do not file an issue |
+
+**Issue body template**:
+
+```markdown
+Raised in <PR-URL>#discussion_r<comment-id> by @<reviewer>.
+
+> <quoted reviewer comment, prefixed with `> `>
+
+<one-line context: what file/area this concerns and why we're deferring>
+```
+
+**Reply on the original thread** (after issue is filed):
+
+```
+Deferred to #<issue> — <one-line reason>.
+```
+
+Then resolve the thread (the deferral itself is the resolution).
 
 ## Summary Report Template
 
@@ -128,11 +215,20 @@ git add -u  # Stage any formatter changes
 - <File 1>: <description of change> (commit <sha>)
 - <File 2>: <description of change> (commit <sha>)
 
+### Co-authored Commits
+- <sha>: Co-authored-by <suggester1>, <suggester2>
+
+### Follow-up Issues Filed
+- #<n>: <title> (deferred from <thread URL>)
+
+### Re-requested Reviewers
+- @<login1> (CHANGES_REQUESTED → addressed)
+- @<login2> (resolved threads on this push)
+
 ### Threads Left Open
 - <thread URL>: <why it's still open>
 
 ### Next Steps
-- [ ] Re-request review from <reviewer>
 - [ ] Monitor CI for new run
-- [ ] Follow up on <deferred item>
+- [ ] Track follow-up issue #<n>
 ```

--- a/git-plugin/skills/git-pr-feedback/SKILL.md
+++ b/git-plugin/skills/git-pr-feedback/SKILL.md
@@ -1,8 +1,8 @@
 ---
 created: 2026-01-30
-modified: 2026-04-19
-reviewed: 2026-02-26
-allowed-tools: Bash(gh pr checks *), Bash(gh pr view *), Bash(gh pr diff *), Bash(gh run view *), Bash(gh run list *), Bash(gh api *), Bash(gh repo view *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git switch *), Bash(git pull *), Bash(pre-commit *), Bash(npm run *), Bash(uv run *), Bash(bash *), Read, Edit, Write, Grep, Glob, TodoWrite, Task, mcp__github__pull_request_read, mcp__github__add_reply_to_pull_request_comment, mcp__github__resolve_review_thread, mcp__github__pull_request_review_write
+modified: 2026-05-05
+reviewed: 2026-05-05
+allowed-tools: Bash(gh pr checks *), Bash(gh pr view *), Bash(gh pr diff *), Bash(gh run view *), Bash(gh run list *), Bash(gh api *), Bash(gh repo view *), Bash(gh issue create *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git switch *), Bash(git pull *), Bash(pre-commit *), Bash(npm run *), Bash(uv run *), Bash(bash *), Read, Edit, Write, Grep, Glob, TodoWrite, Task, mcp__github__pull_request_read, mcp__github__add_reply_to_pull_request_comment, mcp__github__resolve_review_thread, mcp__github__pull_request_review_write, mcp__github__issue_write
 args: "[pr-number] [--commit] [--push]"
 argument-hint: [pr-number] [--commit] [--push]
 disable-model-invocation: true
@@ -114,20 +114,33 @@ Work through actionable items systematically. For each thread, decide using the 
 
 | Comment shape | Action |
 |---------------|--------|
-| Contains a ` ```suggestion ` block, fix is correct | **Accept the suggestion**: apply the suggestion's exact replacement to the file (see [REFERENCE.md](REFERENCE.md) "Accepting Suggestions") |
-| Contains a ` ```suggestion ` block, fix needs adjustment | Implement an improved variant; explain the deviation in the reply |
+| Contains a ` ```suggestion ` block, fix is correct | **Accept the suggestion**: apply the suggestion's exact replacement to the file (see [REFERENCE.md](REFERENCE.md) "Accepting Suggestions"). Record the comment author's `login` and `name`/`email` for co-author attribution in Step 4. |
+| Contains a ` ```suggestion ` block, fix needs adjustment | Implement an improved variant; explain the deviation in the reply. Record the suggester for co-author attribution. |
 | Inline code comment without suggestion | Read context, implement fix, verify no regressions |
 | Question / clarification | Skip code change; draft an inline reply for Step 4 |
 | Blocking review (`REQUEST_CHANGES`) | Address every concern before resolving any thread |
 | Failed CI check | Identify failure type (lint/type/test/build), fix locally, run to verify |
+| Out-of-scope feedback | Do not implement in this PR. Open a follow-up issue (see Step 3a) and reference its number in the reply. |
 
 Mark each todo `in_progress` while working it and `completed` once the file change (if any) lands locally. Do **not** resolve threads yet — replies and resolution happen after the commit so reviewers see the linked SHA.
+
+### Step 3a: File follow-up issues for out-of-scope feedback
+
+For any thread categorised as out-of-scope (or where the user opts to defer rather than implement now):
+
+1. Draft a one-line title and short body that quotes the reviewer comment and links the PR thread URL.
+2. Use `mcp__github__issue_write` (action `create`) or `gh issue create -R <owner>/<repo> --title "<title>" --body "<body>"` to file the issue.
+3. Capture the returned issue number — Step 6's reply uses it (`Deferred to #<n> — <reason>.`).
+
+Skip this step if the user has explicitly said not to file follow-ups. When ambiguous, ask via `AskUserQuestion` before creating an issue.
 
 ---
 
 ### Step 4: Commit Changes (if --commit or --push)
 
-Group related fixes into logical commits. See [REFERENCE.md](REFERENCE.md) for commit message format.
+Group related fixes into logical commits — one commit per logical group of accepted suggestions, not one per suggestion. See [REFERENCE.md](REFERENCE.md) for commit message format.
+
+For any commit that contains an **accepted (or adapted) suggestion**, append a `Co-authored-by:` trailer for each unique suggester. This mirrors GitHub's "Commit suggestion" / "Add suggestion to batch" behaviour, which credits the suggester as co-author. See [REFERENCE.md](REFERENCE.md) "Co-author Attribution" for how to construct the trailer line and resolve the suggester's email.
 
 Run pre-commit hooks if configured, then stage any formatter changes.
 
@@ -137,6 +150,26 @@ Run pre-commit hooks if configured, then stage any formatter changes.
 git push origin HEAD
 ```
 
+### Step 5a: Re-request Review (if --push)
+
+After a successful push that addresses substantive feedback, re-request review from any reviewer whose threads were resolved or who left a `CHANGES_REQUESTED` review. Skip this step when only nitpicks or questions were addressed.
+
+Determine reviewers to re-request from the GraphQL response captured in Step 1:
+
+- `latestReviews` entries with `state == "CHANGES_REQUESTED"`
+- Authors of any review thread you resolved in Step 6
+
+Then call:
+
+```bash
+gh api -X POST \
+  /repos/<owner>/<repo>/pulls/<pr>/requested_reviewers \
+  -f 'reviewers[]=<login1>' \
+  -f 'reviewers[]=<login2>'
+```
+
+If `gh api` returns 422 ("Reviews may only be requested from collaborators"), the reviewer cannot be re-requested via the API — note it in the Step 7 summary and continue.
+
 ### Step 6: Reply and Resolve Threads
 
 For every actionable thread tracked in Step 2, post a reply and resolve when appropriate. Owner/repo/PR are the same values used in Step 1.
@@ -145,7 +178,7 @@ For every actionable thread tracked in Step 2, post a reply and resolve when app
    - Code change made → reference the commit SHA: `Fixed in <sha> by <one-line summary>.`
    - Suggestion accepted verbatim → `Accepted suggestion in <sha>.`
    - Suggestion adapted → explain the deviation: `Applied a variant in <sha>: <reason>.`
-   - Deferred / out of scope → state why and link a follow-up issue if one exists.
+   - Deferred / out of scope → reference the follow-up issue filed in Step 3a: `Deferred to #<issue> — <reason>.`
    - Question → answer it directly.
 
 2. **Resolve** with `mcp__github__resolve_review_thread` using the thread `id` (a `PRRT_…` GraphQL node ID) when **all** of the following hold:
@@ -177,6 +210,8 @@ Provide a summary table of feedback addressed, replies posted, threads resolved,
 | Quick check status (fallback) | `gh pr checks $PR --json name,state,conclusion` |
 | Reply to a review comment | `mcp__github__add_reply_to_pull_request_comment` (commentId = `databaseId`) |
 | Resolve a review thread | `mcp__github__resolve_review_thread` (threadId = `PRRT_…` node ID) |
+| Re-request review after push | `gh api -X POST /repos/<owner>/<repo>/pulls/<pr>/requested_reviewers -f 'reviewers[]=<login>'` |
+| File follow-up issue for deferred feedback | `mcp__github__issue_write` (action `create`) or `gh issue create -R <owner>/<repo> --title <t> --body <b>` |
 
 ## See Also
 


### PR DESCRIPTION
## Summary

Aligns `git-pr-feedback` with the affordances documented at [Incorporating feedback in your pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/incorporating-feedback-in-your-pull-request). Three concrete additions:

- **Co-authoring on accepted suggestions** — applying a `` ```suggestion `` block via file edits loses GitHub's automatic `Co-authored-by:` attribution that "Commit suggestion" / "Add suggestion to batch" performs. Step 4 now records suggesters and appends per-unique-suggester `Co-authored-by:` trailers; REFERENCE.md adds a "Co-author Attribution" section covering email resolution (public email → `<id>+<login>@users.noreply.github.com` → legacy `<login>@users.noreply.github.com`).
- **Re-request review after push (Step 5a)** — mirrors the doc's "sync icon" affordance via `gh api -X POST /repos/{o}/{r}/pulls/{n}/requested_reviewers`. Scoped to reviewers with `CHANGES_REQUESTED` state or threads resolved on this push; documents 422 failure modes (outside collaborators, PR author).
- **Follow-up issue for out-of-scope feedback (Step 3a)** — replaces "link a follow-up issue if one exists" with explicit issue creation via `mcp__github__issue_write` / `gh issue create`. The reply template `Deferred to #<issue> — <reason>.` references the new issue number directly.

Also tightens the commit-grouping wording to "one commit per logical group of accepted suggestions, not one per individual suggestion" — matches the batched-suggestion pattern from the doc.

## Files changed

- `git-plugin/skills/git-pr-feedback/SKILL.md` — new Step 3a and Step 5a, suggester-tracking note in Step 3, expanded `allowed-tools` (`Bash(gh issue create *)`, `mcp__github__issue_write`), bumped `modified`/`reviewed`.
- `git-plugin/skills/git-pr-feedback/REFERENCE.md` — "Co-author Attribution", "Re-request Review", "Out-of-Scope Feedback → Follow-up Issue" sections; summary report template gains "Co-authored Commits", "Follow-up Issues Filed", "Re-requested Reviewers" rows.

## Test plan

- [ ] Lint clean: `bash scripts/lint-context-commands.sh git-plugin/skills/git-pr-feedback` (no new warnings)
- [ ] SKILL.md under 500 lines: 220 lines after changes
- [ ] Manually walk a real PR with a `` ```suggestion `` thread and verify the trailer is constructed correctly
- [ ] Verify `gh api ... /requested_reviewers` works against a PR with a `CHANGES_REQUESTED` review

https://claude.ai/code/session_01Rot7REwrtqKqQjTQVNMY7Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rot7REwrtqKqQjTQVNMY7Y)_