### PR TITLE
fix(hooks-plugin): exclude root-level vendor paths and long banner runs from task-completeness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # Git worktrees created by agent workflows
 /worktrees/
+.claude/worktrees/
+
+# Claude Code runtime state
+.claude/scheduled_tasks.lock
 
 # Python
 __pycache__/

--- a/hooks-plugin/hooks/task-completeness.sh
+++ b/hooks-plugin/hooks/task-completeness.sh
@@ -34,11 +34,19 @@ fi
 # (this very plugin's docs do). Vendor / generated paths are excluded for
 # the same reason — they are not the author's working code.
 is_excluded() {
+    # Each vendor/generated pattern is written twice — root-level (foo/*)
+    # and nested (*/foo/*) — because `git diff --name-only` returns paths
+    # relative to repo root, so a top-level `node_modules/` would not
+    # match `*/node_modules/*`.
     case "$1" in
         *.md|*.mdx|*.rst|*.txt) return 0 ;;
         *.min.js|*.min.css|*.min.map) return 0 ;;
-        */node_modules/*|*/.git/*|*/vendor/*|*/dist/*|*/build/*) return 0 ;;
-        */.obsidian/plugins/*) return 0 ;;
+        node_modules/*|*/node_modules/*) return 0 ;;
+        .git/*|*/.git/*) return 0 ;;
+        vendor/*|*/vendor/*) return 0 ;;
+        dist/*|*/dist/*) return 0 ;;
+        build/*|*/build/*) return 0 ;;
+        .obsidian/plugins/*|*/.obsidian/plugins/*) return 0 ;;
         *) return 1 ;;
     esac
 }
@@ -86,13 +94,16 @@ fi
 #
 # Real merge markers come paired (<<<<<<< … ======= … >>>>>>>), so any
 # conflict — fully unresolved or partially resolved — leaves at least
-# one of <<<<<<< or >>>>>>> behind. Standalone `=======` lines have too
+# one of <<<<<<< or >>>>>>> behind. Match exactly 7 marker characters
+# followed by a non-marker character or end-of-line — not 7+ — so long
+# decorative banners (e.g. 42-char `>` runs used as log delimiters in
+# minified code) are not flagged. Standalone `=======` lines have too
 # many legitimate non-conflict uses (decorative dividers in fenced code
 # blocks, console-output examples, ASCII art) and were the dominant
 # false-positive signal, so they are intentionally excluded.
 CONFLICT_FILES=()
 for file in "${RELEVANT_FILES[@]}"; do
-    if grep -lE '^(<{7}|>{7})' "$CWD/$file" >/dev/null 2>&1; then
+    if grep -lE '^<{7}([^<]|$)|^>{7}([^>]|$)' "$CWD/$file" >/dev/null 2>&1; then
         CONFLICT_FILES+=("$file")
     fi
 done

--- a/hooks-plugin/hooks/test-task-completeness.sh
+++ b/hooks-plugin/hooks/test-task-completeness.sh
@@ -238,6 +238,47 @@ git -C "$TMPDIR" add orphan-close.js
 output=$(run_hook_output "$TMPDIR")
 assert_contains "orphan >>>>>>> marker still emits a block decision" '"decision"' "$output"
 
+# Regression: long decorative banners of `<` or `>` (>7 consecutive chars)
+# must NOT be flagged. They appear in vendored minified code — e.g. the
+# Obsidian Tasks plugin's main.js uses a 42-char `>` / `<` banner inside
+# a template literal in formatQueryForLogging() as a log delimiter.
+reset_repo
+cat > "$TMPDIR/banner.js" <<'BANNER'
+return `
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+${this.source}
+<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+`
+BANNER
+git -C "$TMPDIR" add banner.js
+output=$(run_hook_output "$TMPDIR")
+assert_not_contains "long >7 banner does NOT emit a block decision" '"decision"' "$output"
+
+# Regression: top-level vendored directories (e.g. `.obsidian/plugins/`
+# at the repo root) must be excluded. `git diff --name-only` returns
+# repo-root-relative paths, so a `*/foo/*` pattern that requires a
+# leading slash never matches a top-level path.
+reset_repo
+mkdir -p "$TMPDIR/.obsidian/plugins/some-plugin"
+cat > "$TMPDIR/.obsidian/plugins/some-plugin/main.js" <<'PLUGIN_CONFLICT'
+<<<<<<< HEAD
+local
+=======
+remote
+>>>>>>> main
+PLUGIN_CONFLICT
+git -C "$TMPDIR" add .obsidian/plugins/some-plugin/main.js
+output=$(run_hook_output "$TMPDIR")
+assert_not_contains "top-level .obsidian/plugins/ is excluded" '"decision"' "$output"
+
+# Same gap class for the other vendor patterns — top-level node_modules/.
+reset_repo
+mkdir -p "$TMPDIR/node_modules/pkg"
+echo "console.log('vendored');" > "$TMPDIR/node_modules/pkg/index.js"
+git -C "$TMPDIR" add node_modules/pkg/index.js
+output=$(run_hook_output "$TMPDIR")
+assert_not_contains "top-level node_modules/ is excluded from debug check" '"decision"' "$output"
+
 # ── debugging artifacts ───────────────────────────────────────────────────────
 echo ""
 echo "debugging artifact detection:"


### PR DESCRIPTION
## Summary

Fixes two false-positive sources in the `task-completeness` PostToolUse hook that surfaced from real-world repos:

- **Long decorative banner runs** (`>>>>>>>...` / `<<<<<<<...` longer than 7 chars) inside vendored minified code were flagged as merge conflict markers. The Obsidian Tasks plugin's `main.js` uses a 42-char banner inside a template literal as a log delimiter. The regex now matches exactly 7 marker chars followed by a non-marker (or EOL) — orphan 7-char markers still block.
- **Top-level vendored directories** (e.g. `.obsidian/plugins/`, `node_modules/`) were not excluded because `git diff --name-only` returns repo-root-relative paths, and the existing `*/foo/*` patterns require a leading segment. Added a root-level alternate to every vendor pattern.

## Test plan

- [x] `bash hooks-plugin/hooks/test-task-completeness.sh` — 27/27 pass
- [x] New regression tests cover all three gaps:
  - long `>7` banner does NOT emit a block decision
  - top-level `.obsidian/plugins/` is excluded
  - top-level `node_modules/` is excluded
- [x] Existing tests for orphan `<<<<<<<` / `>>>>>>>` markers and standalone `===` dividers still pass — coverage of the original behaviour preserved