### PR TITLE
fix(git-repo-agent): detect and warn when agent commits land on parent main

### DIFF
--- a/git-repo-agent/src/git_repo_agent/orchestrator.py
+++ b/git-repo-agent/src/git_repo_agent/orchestrator.py
@@ -203,6 +203,56 @@ def _non_interactive_allowed_tools(base: list[str]) -> list[str]:
     return [t for t in base if t != "AskUserQuestion"]
 
 
+def _snapshot_parent_sha(repo_path: Path) -> str:
+    """Capture the current HEAD SHA of the parent repo for post-run integrity check."""
+    import subprocess as _sp
+    return _sp.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_path, capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+def _warn_if_parent_moved(
+    repo_path: Path,
+    sha_before: str,
+    base_branch: str,
+    worktree_branch: str,
+) -> bool:
+    """Return True if parent HEAD is unchanged; print a warning and return False if it moved.
+
+    When an agent escapes the worktree via `cd <repo_path> && git commit`, the
+    commit lands on the parent repo's default branch instead of the worktree
+    branch. This check detects that invariant violation so the user can recover.
+    Regression: issue #1260 — maintain commit landed on parent main.
+    """
+    import subprocess as _sp
+    result = _sp.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_path, capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        return True  # can't verify; don't block
+    current_sha = result.stdout.strip()
+    if current_sha == sha_before:
+        return True
+
+    console.print(
+        f"\n[bold red]Invariant violation:[/bold red] commit(s) landed on "
+        f"[cyan]{base_branch}[/cyan] instead of the worktree branch "
+        f"[cyan]{worktree_branch}[/cyan]. "
+        f"Parent branch moved from [dim]{sha_before[:8]}[/dim] to "
+        f"[dim]{current_sha[:8]}[/dim].\n\n"
+        f"To recover, run these commands manually:\n"
+        f"  # 1. See what landed on {base_branch}:\n"
+        f"  git -C {repo_path} log --oneline {sha_before}..HEAD\n"
+        f"  # 2. Cherry-pick each commit SHA into the worktree:\n"
+        f"  git cherry-pick <sha>   # run from inside the worktree\n"
+        f"  # 3. Reset {base_branch} back to its original tip:\n"
+        f"  git -C {repo_path} reset --hard {sha_before}\n"
+    )
+    return False
+
+
 def _prepare_non_interactive(
     repo_path: Path,
     ni: NonInteractiveConfig,
@@ -596,6 +646,10 @@ async def run_maintain(
         work_dir = worktree_path
         console.print(f"[dim]Working in: {worktree_path}[/dim]")
 
+    # Snapshot parent HEAD so we can detect if the agent escapes the worktree
+    # and accidentally commits to the parent branch (issue #1260).
+    parent_sha_before = _snapshot_parent_sha(repo_path) if makes_changes else ""
+
     cleanup_token = None
     if non_interactive is not None and worktree_path is not None:
         cleanup_token = _install_cleanup_handler(
@@ -680,6 +734,12 @@ async def run_maintain(
         }
 
         if worktree_path and makes_changes:
+            # Post-run integrity check: if the agent escaped the worktree via
+            # `cd <repo_path> && git commit`, commits land on the parent's
+            # default branch instead of the worktree branch. Warn early so the
+            # user can recover before cleanup destroys the evidence (issue #1260).
+            _warn_if_parent_moved(repo_path, parent_sha_before, base_branch, branch)
+
             if non_interactive is not None:
                 pr_result = await _auto_handle_pr(
                     repo_path, worktree_path, branch, base_branch,
@@ -996,7 +1056,13 @@ def _build_maintain_phase2_prompt(
         worktree_note = (
             f"\n\nYou are working in a git worktree on branch "
             f"'{worktree_branch}'. Commit your changes directly to this "
-            "branch. Do NOT create new branches or push."
+            "branch. Do NOT create new branches or push.\n\n"
+            "IMPORTANT: Never `cd` to a different directory in the same Bash "
+            "call as a `git commit`. A command like "
+            "`cd /other/path && git add ... && git commit` commits to whatever "
+            "branch is checked out at /other/path (the parent repo's main), "
+            "not to this worktree branch. All git operations must run from "
+            "the current working directory (the worktree root)."
         )
 
     return (
@@ -1047,7 +1113,13 @@ def _build_onboard_phase2_prompt(
         worktree_note = (
             f"\n\nYou are working in a git worktree on branch "
             f"'{worktree_branch}'. Commit your changes directly to this "
-            "branch. Do NOT create new branches or push."
+            "branch. Do NOT create new branches or push.\n\n"
+            "IMPORTANT: Never `cd` to a different directory in the same Bash "
+            "call as a `git commit`. A command like "
+            "`cd /other/path && git add ... && git commit` commits to whatever "
+            "branch is checked out at /other/path (the parent repo's main), "
+            "not to this worktree branch. All git operations must run from "
+            "the current working directory (the worktree root)."
         )
 
     return (
@@ -1271,7 +1343,12 @@ async def _prompt_pr_creation(
 ) -> None:
     """Check for changes in the worktree and offer to create a PR."""
     if not worktree_has_changes(worktree_path, base_branch):
-        console.print("[dim]No changes were made in the worktree.[/dim]")
+        console.print(
+            "[dim]No commits or uncommitted changes found in the worktree "
+            f"(branch: {base_branch}..{worktree_path.name}). "
+            "If you expected changes, check whether the parent branch moved — "
+            "a preceding warning would have been shown.[/dim]"
+        )
         cleanup_worktree(repo_path, worktree_path)
         return
 

--- a/git-repo-agent/src/git_repo_agent/prompts/maintain.md
+++ b/git-repo-agent/src/git_repo_agent/prompts/maintain.md
@@ -84,6 +84,8 @@ Execute fixes based on the operating mode:
 
 When making changes (interactive or auto-fix mode), you are working in a git worktree on a dedicated branch. Commit your changes directly to the current branch. Do NOT create new branches or push — the orchestrator manages the worktree and PR creation.
 
+**Never `cd` to a different directory in the same Bash call as a `git commit`.** All git operations must run from the current working directory (the worktree root). A command like `cd /some/path && git add ... && git commit` will commit to whatever branch is checked out at `/some/path` (the parent repo's `main`), not to the worktree branch. Use `git -C "/path"` if you need to reference another repo, but do not leave the worktree's working directory before committing.
+
 When committing dependency changes, always include lock files (uv.lock, package-lock.json, yarn.lock, pnpm-lock.yaml, bun.lockb, Cargo.lock, poetry.lock, go.sum) in the commit.
 
 ### What NOT to auto-fix

--- a/git-repo-agent/tests/test_orchestrator_display.py
+++ b/git-repo-agent/tests/test_orchestrator_display.py
@@ -250,6 +250,23 @@ class TestBuildMaintainPhase2Prompt:
         )
         assert "Do not ask the user any questions" in prompt
 
+    def test_warns_against_cd_before_commit(self):
+        """Regression: agent used `cd <repo> && git commit`, escaping the worktree
+        and landing commits on parent main instead of the worktree branch (issue #1260)."""
+        prompt = _build_maintain_phase2_prompt(
+            FINDINGS_FIXTURE, "all", "maintain/2026-05-07"
+        )
+        # Must warn against cd-escape antipattern.
+        assert "Never `cd`" in prompt or "IMPORTANT" in prompt
+        assert "cd" in prompt  # antipattern is named explicitly
+        assert "worktree root" in prompt or "working directory" in prompt
+
+    def test_none_selection_omits_cd_warning(self):
+        """No worktree note (and no cd warning) when the user selects none."""
+        prompt = _build_maintain_phase2_prompt(FINDINGS_FIXTURE, "none", None)
+        assert "IMPORTANT" not in prompt
+        assert "worktree root" not in prompt
+
 
 PLAN_FIXTURE = (
     "1. [claude-md] Generate CLAUDE.md with project description and lint commands\n"
@@ -329,6 +346,21 @@ class TestBuildOnboardPhase2Prompt:
             PLAN_FIXTURE, "all", "setup/onboard"
         )
         assert "Do not ask the user any questions" in prompt
+
+    def test_warns_against_cd_before_commit(self):
+        """Regression: same cd-escape antipattern applies to onboard (issue #1260)."""
+        prompt = _build_onboard_phase2_prompt(
+            PLAN_FIXTURE, "all", "setup/onboard"
+        )
+        assert "Never `cd`" in prompt or "IMPORTANT" in prompt
+        assert "cd" in prompt
+        assert "worktree root" in prompt or "working directory" in prompt
+
+    def test_none_selection_omits_cd_warning(self):
+        """No worktree note when the user selects none."""
+        prompt = _build_onboard_phase2_prompt(PLAN_FIXTURE, "none", None)
+        assert "IMPORTANT" not in prompt
+        assert "worktree root" not in prompt
 
 
 class TestPhase2SystemPrompt:

--- a/git-repo-agent/tests/test_worktree_changes.py
+++ b/git-repo-agent/tests/test_worktree_changes.py
@@ -4,6 +4,9 @@ Covers the data-loss bug where blueprint-driver phases wrote many files in
 the onboarding worktree but didn't commit them; the old
 ``worktree_has_changes`` only inspected commits, reported "no changes", and
 ``cleanup_worktree --force`` then discarded the agent's work.
+
+Also covers issue #1260: agent escaped worktree via `cd <repo> && git commit`,
+landing commits on the parent's default branch instead of the worktree branch.
 """
 
 from __future__ import annotations
@@ -14,6 +17,7 @@ from pathlib import Path
 
 import pytest
 
+from git_repo_agent.orchestrator import _snapshot_parent_sha, _warn_if_parent_moved
 from git_repo_agent.worktree import (
     auto_commit_if_dirty,
     worktree_has_changes,
@@ -29,14 +33,15 @@ needs_git = pytest.mark.skipif(not _git_available(), reason="git not installed")
 
 def _init_repo(path: Path) -> None:
     subprocess.run(["git", "init", "-b", "main", str(path)], check=True, capture_output=True)
-    subprocess.run(
-        ["git", "-C", str(path), "config", "user.email", "test@example.com"],
-        check=True, capture_output=True,
-    )
-    subprocess.run(
-        ["git", "-C", str(path), "config", "user.name", "Test"],
-        check=True, capture_output=True,
-    )
+    for key, value in [
+        ("user.email", "test@example.com"),
+        ("user.name", "Test"),
+        ("commit.gpgsign", "false"),  # override global signing in test environments
+    ]:
+        subprocess.run(
+            ["git", "-C", str(path), "config", key, value],
+            check=True, capture_output=True,
+        )
     (path / "README.md").write_text("init\n")
     subprocess.run(["git", "-C", str(path), "add", "-A"], check=True, capture_output=True)
     subprocess.run(
@@ -106,3 +111,70 @@ class TestAutoCommitIfDirty:
             check=True, capture_output=True, text=True,
         )
         assert status.stdout.strip() == ""
+
+
+@needs_git
+class TestParentBranchIntegrity:
+    """Regression tests for issue #1260: agent escaped worktree and committed
+    to parent main instead of the worktree branch.
+
+    The `_warn_if_parent_moved` guard detects the invariant violation and
+    warns the user before cleanup destroys the evidence.
+    """
+
+    def test_snapshot_returns_head_sha(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        sha = _snapshot_parent_sha(repo)
+        expected = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        assert sha == expected
+        assert len(sha) == 40
+
+    def test_warn_returns_true_when_parent_unchanged(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        sha = _snapshot_parent_sha(repo)
+        assert _warn_if_parent_moved(repo, sha, "main", "maintain/2026-05-07") is True
+
+    def test_warn_returns_false_when_parent_moved(self, tmp_path: Path):
+        """Regression: agent ran `cd <repo> && git commit`, moving parent HEAD."""
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        sha_before = _snapshot_parent_sha(repo)
+
+        # Simulate the agent escaping the worktree and committing to parent main.
+        (repo / "escaped.txt").write_text("written by agent outside worktree\n")
+        subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "oops: commit on wrong branch"],
+            check=True, capture_output=True,
+        )
+
+        assert _warn_if_parent_moved(repo, sha_before, "main", "maintain/2026-05-07") is False
+
+    def test_worktree_commit_does_not_affect_parent(self, tmp_path: Path):
+        """Regression: commits inside a git worktree must not move the parent HEAD."""
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        sha_before = _snapshot_parent_sha(repo)
+
+        # Create a real git worktree on a feature branch.
+        worktree = tmp_path / "worktree"
+        subprocess.run(
+            ["git", "-C", str(repo), "worktree", "add", "-b", "maintain/test", str(worktree)],
+            check=True, capture_output=True,
+        )
+
+        # Commit inside the worktree (the correct pattern).
+        (worktree / "fix.txt").write_text("fix applied in worktree\n")
+        subprocess.run(["git", "-C", str(worktree), "add", "-A"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(worktree), "commit", "-m", "fix: applied in worktree"],
+            check=True, capture_output=True,
+        )
+
+        # Parent HEAD must not have moved.
+        assert _warn_if_parent_moved(repo, sha_before, "main", "maintain/test") is True


### PR DESCRIPTION
## Summary

- Adds `_warn_if_parent_moved` + `_snapshot_parent_sha` helpers to detect when the agent escapes the worktree via `cd <repo> && git commit` and commits to the parent's default branch instead of the worktree branch (invariant violation from issue #1260)
- Strengthens Phase 2 prompts (`maintain` and `onboard`) with an explicit `IMPORTANT` warning naming the `cd`-before-commit antipattern
- Adds the same warning to `maintain.md`'s Git Worktree section so the agent sees it at system-prompt time
- Improves the misleading `"No changes were made in the worktree"` tail message to point users at the preceding invariant-violation warning

## Root cause (issue #1260)

The agent issued `cd <repo_path> && git add ... && git commit` in one Bash call. The `cd` escaped the worktree back to the parent checkout, so the commit landed on `main`. `worktree_has_changes` then returned False (worktree was clean), `_prompt_pr_creation` printed `"No changes were made in the worktree"`, and the PR prompt was silently skipped.

## Test plan

- [ ] `python -m pytest tests/test_worktree_changes.py::TestParentBranchIntegrity` — 4 new tests for snapshot/detection/worktree isolation
- [ ] `python -m pytest tests/test_orchestrator_display.py` — 4 new tests for anti-cd warning in Phase 2 prompts
- [ ] All 67 tests pass (`python -m pytest tests/test_worktree_changes.py tests/test_orchestrator_display.py`)

Closes #1260

https://claude.ai/code/session_01Mu2VGUyrujm6idhNtyoHrQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mu2VGUyrujm6idhNtyoHrQ)_