### PR TITLE
docs: trim oversized SKILL.md descriptions across 41 plugins

### DIFF
--- a/accessibility-plugin/skills/accessibility-implementation/SKILL.md
+++ b/accessibility-plugin/skills/accessibility-implementation/SKILL.md
@@ -1,9 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: accessibility-implementation
-description: WCAG 2.1/2.2 compliance implementation, ARIA patterns, keyboard navigation, focus management, and accessibility testing. Use when implementing accessible components, fixing accessibility issues, or when the user mentions WCAG, ARIA, screen readers, or keyboard navigation.
+description: WCAG 2.1/2.2 compliance, ARIA patterns, keyboard navigation, focus management, and accessibility testing. Use when implementing accessible components, fixing a11y issues, or when the user mentions WCAG, ARIA, screen readers, or keyboard nav.
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Edit, Write, Bash(npm *), Bash(npx *), Bash(axe *), BashOutput, TodoWrite, WebSearch, WebFetch
 ---

--- a/accessibility-plugin/skills/design-tokens/SKILL.md
+++ b/accessibility-plugin/skills/design-tokens/SKILL.md
@@ -1,9 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-02-14
+modified: 2026-05-09
 reviewed: 2025-12-16
 name: design-tokens
-description: CSS custom property architecture, theme systems, design token organization, and component library integration. Use when implementing design systems, theme switching, dark mode, or when the user mentions tokens, CSS variables, theming, or design system setup.
+description: CSS custom property architecture, theme systems, design token organization, and component library integration. Use when implementing design systems, theme switching, dark mode, or when the user mentions tokens, CSS variables, or theming.
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Edit, Write, Bash(npm *), Bash(npx *), TodoWrite
 ---

--- a/agent-patterns-plugin/skills/agent-teams/SKILL.md
+++ b/agent-patterns-plugin/skills/agent-teams/SKILL.md
@@ -1,16 +1,11 @@
 ---
 name: agent-teams
-description: |
-  Configure and orchestrate Claude Code agent teams (TeamCreate, SendMessage, TaskUpdate
-  workflow). Use when you need multiple agents working in parallel on a complex task,
-  want to coordinate background agents with messaging, or are setting up a lead/teammate
-  architecture with a shared task list. Teams are experimental — enable with
-  --enable-teams flag.
+description: Configure Claude Code agent teams (TeamCreate, SendMessage, TaskUpdate). Use when running multiple agents in parallel, coordinating with messaging, or setting up a lead/teammate architecture.
 user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 model: opus
 created: 2026-03-03
-modified: 2026-05-06
+modified: 2026-05-09
 reviewed: 2026-04-25
 ---
 

--- a/agent-patterns-plugin/skills/claude-hooks-configuration/SKILL.md
+++ b/agent-patterns-plugin/skills/claude-hooks-configuration/SKILL.md
@@ -1,14 +1,10 @@
 ---
 name: claude-hooks-configuration
-description: |
-  Set up Claude Code lifecycle hooks and event handlers in settings.json. Use when you
-  want to trigger a script on session start, run a hook before or after tool calls
-  (PreToolUse/PostToolUse), configure hook timeouts to prevent cancellation errors,
-  or debug hooks that aren't firing correctly.
+description: Set up Claude Code lifecycle hooks in settings.json. Use when triggering a script on session start, running PreToolUse/PostToolUse hooks, configuring timeouts, or debugging hooks.
 user-invocable: false
 allowed-tools: Bash(cat *), Bash(bash *), Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2025-12-27
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 ---
 

--- a/agent-patterns-plugin/skills/custom-agent-definitions/SKILL.md
+++ b/agent-patterns-plugin/skills/custom-agent-definitions/SKILL.md
@@ -1,14 +1,10 @@
 ---
 name: custom-agent-definitions
-description: |
-  Write and configure custom agent definitions in Claude Code's agents/ directory. Use
-  when you want to create a new agent .md file, define a specialized agent with its own
-  system prompt and tools, set up an agent with isolated context, or configure agent
-  capabilities and restrictions in your project's .claude/ configuration.
+description: Write and configure custom agent definitions in Claude Code's agents/ directory. Use when creating an agent .md file, defining a specialized agent, or configuring agent tools and capabilities.
 user-invocable: false
 allowed-tools: Bash(cat *), Read, Write, Edit, Glob, Grep, TodoWrite
 created: 2026-01-20
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 ---
 

--- a/agent-patterns-plugin/skills/exclusive-lock-dispatch/SKILL.md
+++ b/agent-patterns-plugin/skills/exclusive-lock-dispatch/SKILL.md
@@ -1,19 +1,11 @@
 ---
 name: exclusive-lock-dispatch
-description: |
-  Pre-dump-then-dispatch pattern for tools that hold an exclusive lock —
-  Ghidra projects, database migration locks, single-writer caches, git
-  indexes on shared checkouts, taskwarrior bulk modifications. Use when
-  planning a parallel fan-out and one or more candidate agents would need
-  a resource that cannot tolerate concurrent access, when a locked tool's
-  "retry" errors are showing up in agent returns, or when deciding whether
-  to serialise an agent or pre-compute its outputs. Complements
-  parallel-agent-dispatch §Wave Splits and workflow-wave-dispatch.
+description: Pre-dump-then-dispatch pattern for tools holding an exclusive lock (Ghidra, migrations, single-writer caches). Use when fanning out parallel agents that need a non-concurrent resource.
 user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 model: opus
 created: 2026-04-24
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-24
 ---
 

--- a/agent-patterns-plugin/skills/mcp-code-execution/SKILL.md
+++ b/agent-patterns-plugin/skills/mcp-code-execution/SKILL.md
@@ -1,14 +1,10 @@
 ---
 name: mcp-code-execution
-description: |
-  Design and scaffold the code execution pattern for MCP-based agent systems. Use when
-  building agents that interact with many MCP tools, when intermediate data is too large
-  for model context, when you need loops/conditionals across tool calls, or when PII must
-  stay out of the model context. Based on Anthropic's engineering guidance.
+description: Scaffold the code execution pattern for MCP-based agents. Use when agents call many MCP tools, intermediate data exceeds context, you need loops across tool calls, or PII must stay out of context.
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2026-02-08
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 ---
 

--- a/agent-patterns-plugin/skills/mcp-management/SKILL.md
+++ b/agent-patterns-plugin/skills/mcp-management/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-02-26
+modified: 2026-05-09
 reviewed: 2026-02-26
 name: mcp-management
-description: |
-  Install and configure Model Context Protocol (MCP) servers for Claude Code projects.
-  Use when you want to add or enable an MCP server, connect a tool or integration
-  (database, API, file system), update MCP settings in .mcp.json, manage OAuth-authenticated
-  remote MCP servers, enable/disable individual servers at runtime, or troubleshoot
-  MCP server connection issues.
+description: Install and configure MCP (Model Context Protocol) servers for Claude Code. Use when adding/enabling servers, updating .mcp.json, managing OAuth remote servers, or troubleshooting connections.
 user-invocable: false
 allowed-tools: Bash(jq *), Bash(find *), Read, Write, Edit, Grep, Glob, AskUserQuestion
 ---

--- a/agent-patterns-plugin/skills/meta-assimilate/SKILL.md
+++ b/agent-patterns-plugin/skills/meta-assimilate/SKILL.md
@@ -1,17 +1,12 @@
 ---
 created: 2025-12-16
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-25
 allowed-tools: Read, Write, Edit, MultiEdit, Glob, Grep, TodoWrite
 model: opus
 args: <project-path>
 argument-hint: <project-path>
-description: |
-  Analyze and assimilate project-specific Claude configurations into user-scoped agents and
-  commands. Use when you want to examine a project's .claude/{agents,commands} directory and
-  either copy, generalize, or merge useful agents and commands into your personal configuration,
-  when the user mentions assimilating or adopting another project's Claude setup, or when
-  looking to generalize a project-specific agent into a reusable one.
+description: Copy, generalize, or merge a project's .claude/{agents,commands} into user-scoped configuration. Use when assimilating another project's Claude setup or generalizing an agent.
 name: meta-assimilate
 ---
 

--- a/agent-patterns-plugin/skills/meta-audit/SKILL.md
+++ b/agent-patterns-plugin/skills/meta-audit/SKILL.md
@@ -4,12 +4,7 @@ modified: 2026-05-04
 reviewed: 2026-04-25
 allowed-tools: Glob, Read, TodoWrite
 model: opus
-description: |
-  Audit Claude subagent configurations for completeness, security, and best practices. Use when
-  the user wants to review .claude/agents/ for missing frontmatter fields, overprivileged tool
-  access, read-only agents with write permissions, inappropriate model choices, or inconsistent
-  naming; when checking agent configurations before committing; or when asked to validate
-  subagent security and privilege assignments.
+description: Audit Claude subagent configs for completeness, security, and best practices. Use when reviewing .claude/agents/ for missing frontmatter, overprivileged tools, or bad model choices.
 args: "[--verbose]"
 argument-hint: "[--verbose]"
 name: meta-audit

--- a/agent-patterns-plugin/skills/parallel-agent-dispatch/SKILL.md
+++ b/agent-patterns-plugin/skills/parallel-agent-dispatch/SKILL.md
@@ -1,20 +1,11 @@
 ---
 name: parallel-agent-dispatch
-description: |
-  Dispatch contract for any workflow that spawns more than one agent in parallel —
-  whether via the native TeamCreate / agent-teams flow or plain parallel Agent tool
-  fan-out. Covers the three recurring failure modes: worktree hygiene collisions,
-  unbounded agent scope leading to context overflow, and silent agent exits that
-  leave loose ends invisible to the orchestrator. Use when planning to spawn two
-  or more agents that run concurrently, when authoring a lead/orchestrator prompt
-  that will fan out work, or when recovering from a silent agent exit or worktree
-  collision. Complements agent-teams (TeamCreate mechanics) and
-  custom-agent-definitions (agent file structure).
+description: Dispatch contract for spawning multiple agents in parallel. Covers worktree collisions, scope overflow, and silent exits. Use when fanning out concurrent agents or authoring a lead prompt.
 user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 model: opus
 created: 2026-04-21
-modified: 2026-05-06
+modified: 2026-05-09
 reviewed: 2026-04-25
 ---
 

--- a/agent-patterns-plugin/skills/plugin-settings/SKILL.md
+++ b/agent-patterns-plugin/skills/plugin-settings/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: plugin-settings
-description: |
-  Configure per-project plugin settings using `.claude/plugin-name.local.md` files.
-  Use when building plugins that need user-configurable behavior, storing agent state
-  between sessions, or controlling hook activation per-project. Covers file structure,
-  YAML frontmatter parsing, gitignore setup, and common patterns like toggle-based
-  hooks and agent state management.
+description: Configure per-project plugin settings via .claude/plugin-name.local.md files. Use when building plugins with user-configurable behavior, storing agent state, or controlling hooks per-project.
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2026-03-06

--- a/agent-patterns-plugin/skills/wave-based-dispatch/SKILL.md
+++ b/agent-patterns-plugin/skills/wave-based-dispatch/SKILL.md
@@ -1,23 +1,11 @@
 ---
 name: wave-based-dispatch
-description: |
-  Sequential-wave counterpart to parallel-agent-dispatch for work-order chains
-  that cannot fan out at once — when one WO's output (a new file, type, or API)
-  is the next WO's input, when candidate agents share an exclusive lock (Ghidra
-  project, taskwarrior bulk modify, single-writer caches), or when the
-  orchestrator itself is the contention point because it edits the same shared
-  files between waves. Use when planning a multi-WO landing whose pieces
-  depend on each other, when deciding whether a research probe should be its
-  own wave before downstream WOs are written, or when a previous parallel
-  dispatch surfaced ordering or last-writer-wins problems. Complements
-  parallel-agent-dispatch (intra-wave contract), exclusive-lock-dispatch
-  (pre-dump mechanics), and workflow-orchestration-plugin:workflow-wave-dispatch
-  (the workflow-side scheduling view).
+description: Sequential-wave dispatch for WO chains that can't fan out — output of one WO feeds the next, shared locks, or shared files between waves. Use when planning dependent multi-WO landings.
 user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 model: opus
 created: 2026-04-25
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-25
 ---
 

--- a/agents-plugin/skills/agents-analyze/SKILL.md
+++ b/agents-plugin/skills/agents-analyze/SKILL.md
@@ -1,17 +1,11 @@
 ---
-description: |
-  Analyze all plugins for sub-agent opportunities by identifying skills with verbose output,
-  gaps in agent coverage, tool over-permissions, and model selection improvements. Use when
-  the user wants to audit the plugin collection for where sub-agents would improve workflows,
-  review haiku vs opus model selection across agents, check for tool over-permissions,
-  identify skills needing context isolation (builds, test runs, terraform plans), or map
-  delegation gaps; also use when focusing the analysis on a single plugin.
+description: Audit plugins for sub-agent opportunities — verbose-output skills, coverage gaps, tool over-permissions, and model selection. Use when reviewing where sub-agents would help or auditing haiku/opus choices.
 args: "[--focus <plugin-name>]"
 allowed-tools: Glob, Grep, Read, Bash(ls *), Bash(wc *), TodoWrite
 model: opus
 argument-hint: "analyze all plugins or --focus <plugin-name>"
 created: 2026-01-24
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: agents-analyze
 agent: general-purpose

--- a/api-plugin/skills/api-testing/SKILL.md
+++ b/api-plugin/skills/api-testing/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: api-testing
-description: |
-  HTTP API testing for TypeScript (Supertest) and Python (httpx, pytest). Covers
-  REST APIs, GraphQL, request/response validation, authentication, and error handling.
-  Use when user mentions API testing, Supertest, httpx, REST testing, endpoint testing,
-  HTTP response validation, or testing API routes.
+description: HTTP API testing for TypeScript (Supertest) and Python (httpx, pytest). Covers REST, GraphQL, request/response validation, auth, and error handling. Use when the user mentions API testing, Supertest, httpx, or HTTP response validation.
 user-invocable: false
 allowed-tools: Bash(curl *), Bash(http *), Bash(jq *), Read, Edit, Write, Grep, Glob, TodoWrite
 ---

--- a/api-plugin/skills/api-tests/SKILL.md
+++ b/api-plugin/skills/api-tests/SKILL.md
@@ -1,13 +1,8 @@
 ---
 created: 2025-12-16
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2025-12-16
-description: |
-  Check and configure API contract testing infrastructure with Pact, OpenAPI validation,
-  and schema testing (Zod/AJV). Use when the user wants to set up or audit API contract
-  tests, validate OpenAPI specification compliance, add breaking change detection to CI,
-  configure Pact consumer/provider workflows, or check the status of existing API testing
-  infrastructure.
+description: Configure API contract testing with Pact, OpenAPI validation, and Zod/AJV schemas. Use when setting up contract tests, validating OpenAPI compliance, or adding breaking-change CI checks.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash(curl *), Bash(http *), Bash(jq *), AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--type <pact|openapi|schema>]"
 argument-hint: "[--check-only] [--fix] [--type <pact|openapi|schema>]"

--- a/bevy-plugin/skills/bevy-ecs-patterns/SKILL.md
+++ b/bevy-plugin/skills/bevy-ecs-patterns/SKILL.md
@@ -1,9 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2025-12-16
+modified: 2026-05-09
 reviewed: 2025-12-16
 name: bevy-ecs-patterns
-description: Advanced Bevy ECS patterns including complex queries, system scheduling, change detection, entity relationships, and performance optimization. Use when working on advanced Bevy game architecture, optimizing ECS performance, or implementing complex game systems.
+description: "Advanced Bevy ECS patterns: complex queries, system scheduling, change detection, entity relationships, and performance tuning. Use when working on advanced Bevy game architecture, optimizing ECS, or implementing complex game systems."
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash(cargo *), Edit, Write, TodoWrite, WebFetch, WebSearch, BashOutput, KillShell
 ---

--- a/bevy-plugin/skills/bevy-game-engine/SKILL.md
+++ b/bevy-plugin/skills/bevy-game-engine/SKILL.md
@@ -1,9 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2025-12-16
+modified: 2026-05-09
 reviewed: 2025-12-16
 name: bevy-game-engine
-description: Bevy game engine development including ECS architecture, rendering, input handling, asset management, and game loop design. Use when building games with Bevy, working with entities/components/systems, or when the user mentions Bevy, game development in Rust, or 2D/3D games.
+description: "Bevy game engine: ECS architecture, rendering, input handling, asset management, and game loop design. Use when building games with Bevy, working with entities/components/systems, or when the user mentions Bevy, Rust gamedev, or 2D/3D games."
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash(cargo *), Edit, Write, TodoWrite, WebFetch, WebSearch, BashOutput, KillShell
 ---

--- a/blog-plugin/skills/blog-post-writing/skill.md
+++ b/blog-plugin/skills/blog-post-writing/skill.md
@@ -1,15 +1,10 @@
 ---
 name: blog-post-writing
-description: |
-  Consistent style guide for writing blog posts about projects and technical work. Supports
-  quick updates, detailed write-ups, retrospectives, tutorials, and deep dives with
-  low-friction entry and easy scanning. Use when the user is writing about work they've
-  done, documenting a project update, creating a devlog entry, or when they mention "write
-  up", "blog", "post", or "devlog".
+description: Style guide for blog posts about projects and technical work. Supports quick updates, write-ups, retrospectives, tutorials, and deep dives. Use when writing about work done, documenting a project update, or mentioning blog/post/devlog.
 user-invocable: false
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(hugo *), Bash(date *), TodoWrite
 created: 2026-01-10
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 ---
 

--- a/blog-plugin/skills/blog-post/SKILL.md
+++ b/blog-plugin/skills/blog-post/SKILL.md
@@ -1,16 +1,12 @@
 ---
 name: blog-post
-description: |
-  Create a blog post about your work with guided prompts and structured templates. Use when
-  the user wants to write a quick update, project update, retrospective, tutorial, or deep
-  dive about their work, when they mention "devlog", "write up", or "blog post", or when
-  they need git context auto-populated into a post to reduce blank-page anxiety.
+description: Create a blog post via guided prompts and structured templates with git context auto-populated. Use when writing a quick update, project update, retrospective, tutorial, deep dive, or devlog entry.
 args: "[type] [--project <name>] [--title <title>]"
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(hugo *), Bash(date *), TodoWrite, AskUserQuestion
 argument-hint: "quick-update | project-update | retrospective | tutorial | deep-dive"
 disable-model-invocation: true
 created: 2026-01-10
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2026-02-14
 ---
 

--- a/blueprint-plugin/skills/blueprint-adr-list/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-adr-list/SKILL.md
@@ -2,11 +2,7 @@
 created: 2026-01-29
 modified: 2026-05-04
 reviewed: 2026-04-25
-description: |
-  List all ADRs with title, status, date, and domain in a markdown table. Use when
-  the user wants to see all architecture decision records, generate an ADR index for
-  a README, audit ADR status, or asks to "list ADRs", "show architecture decisions",
-  or "view the ADR table".
+description: List all ADRs with title, status, date, and domain in a markdown table. Use when generating an ADR index for a README, auditing ADR status, or viewing all architecture decisions at once.
 allowed-tools: Bash, Glob
 model: sonnet
 name: blueprint-adr-list

--- a/blueprint-plugin/skills/blueprint-adr-validate/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-adr-validate/SKILL.md
@@ -2,11 +2,7 @@
 created: 2026-01-15
 modified: 2026-04-19
 reviewed: 2026-04-12
-description: |
-  Validate ADR relationships, detect orphaned references, and check domain consistency.
-  Use when the user asks to "validate ADRs", audits architecture decision records before
-  a release, checks for broken supersedes/extends links, investigates conflicting decisions
-  in the same domain, or wants to detect cycles in the supersession graph.
+description: Validate ADR relationships, detect orphaned references, and check domain consistency. Use when auditing ADRs before a release, finding broken supersedes/extends links, or detecting cycles in the supersession graph.
 args: "[--report-only]"
 argument-hint: "--report-only to validate without prompting for fixes"
 allowed-tools: Read, Bash, Glob, Grep, Edit, AskUserQuestion

--- a/blueprint-plugin/skills/blueprint-claude-md/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-claude-md/SKILL.md
@@ -1,12 +1,8 @@
 ---
 created: 2025-12-17
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2026-02-09
-description: |
-  Generate or update CLAUDE.md from project context and blueprint artifacts. Supports @import
-  syntax, CLAUDE.local.md, and auto memory delineation. Use when the user asks to "create
-  CLAUDE.md", "update CLAUDE.md", convert inline content to @import references, add
-  team-shared project instructions, or set up CLAUDE.local.md for personal preferences.
+description: Generate or update CLAUDE.md from project context and blueprint artifacts. Use when adding team-shared instructions, converting inline content to @imports, or setting up CLAUDE.local.md for personal preferences.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 name: blueprint-claude-md
 ---

--- a/blueprint-plugin/skills/blueprint-curate-docs/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-curate-docs/SKILL.md
@@ -1,9 +1,5 @@
 ---
-description: |
-  Curate library or project documentation for ai_docs to optimize AI context. Use when
-  the user wants to document a library's gotchas and patterns for PRP reuse, build a
-  project knowledge base under docs/blueprint/ai_docs/, capture project-specific
-  implementation patterns, or asks to "curate docs" for a library like redis or pydantic.
+description: Curate library or project documentation into ai_docs entries optimized for AI context. Use when documenting a library's gotchas and patterns for PRP reuse, or building a project knowledge base under docs/blueprint/ai_docs/.
 args: "[library-name|project:pattern-name]"
 argument-hint: "Library name (e.g., redis, pydantic) or project:pattern-name"
 allowed-tools: Read, Write, Glob, Bash, WebFetch, WebSearch, AskUserQuestion

--- a/blueprint-plugin/skills/blueprint-derive-adr/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-derive-adr/SKILL.md
@@ -1,13 +1,8 @@
 ---
 created: 2025-12-22
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-25
-description: |
-  Derive Architecture Decision Records from existing project structure, dependencies, and
-  documentation. Use when the user wants to onboard an existing project to blueprint by
-  documenting implicit architecture decisions, asks to "derive ADRs", "generate ADRs from
-  the codebase", or needs to capture framework, database, state-management, and testing
-  choices retroactively.
+description: Derive ADRs from project structure, dependencies, and docs. Use when onboarding an existing project by documenting implicit architecture decisions or capturing framework/database/testing choices retroactively.
 allowed-tools: Read, Write, Glob, Grep, Bash, AskUserQuestion, Task
 model: opus
 name: blueprint-derive-adr

--- a/blueprint-plugin/skills/blueprint-derive-plans/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-derive-plans/SKILL.md
@@ -1,13 +1,8 @@
 ---
 created: 2026-01-15
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-02-14
-description: |
-  Derive PRDs, ADRs, and PRPs from git history, codebase structure, and existing documentation.
-  Use when the user is onboarding an established project to blueprint, asks to "derive plans
-  from git history", extracts features from conventional commits, documents architecture
-  decisions retroactively, or wants to generate PRD/ADR/PRP docs from commit tags and release
-  boundaries.
+description: Derive PRDs, ADRs, and PRPs from git history, codebase, and existing docs. Use when onboarding an established project to blueprint, extracting features from conventional commits, or documenting architecture decisions retroactively.
 args: "[--quick] [--since DATE]"
 argument-hint: "--quick for fast scan, --since 2024-01-01 for date range"
 allowed-tools: Read, Write, Glob, Grep, Bash, AskUserQuestion, Task

--- a/blueprint-plugin/skills/blueprint-derive-prd/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-derive-prd/SKILL.md
@@ -1,12 +1,8 @@
 ---
 created: 2025-12-22
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-25
-description: |
-  Derive PRD from existing project documentation, README, and codebase analysis. Use when
-  the user asks to "derive a PRD", "generate a PRD from the README", onboards an existing
-  project to blueprint, or wants to extract problem statements, stakeholders, features, and
-  user personas from existing docs into a formal Product Requirements Document.
+description: Derive a PRD from existing project docs, README, and codebase. Use when onboarding an existing project to blueprint or extracting problem statements, stakeholders, features, and user personas into a formal PRD.
 allowed-tools: Read, Write, Glob, Grep, Bash, AskUserQuestion, Task
 model: opus
 name: blueprint-derive-prd

--- a/blueprint-plugin/skills/blueprint-derive-rules/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-derive-rules/SKILL.md
@@ -1,12 +1,8 @@
 ---
 created: 2026-01-30
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-02-14
-description: |
-  Derive Claude rules from git commit log decisions. Newer commits override older decisions
-  when conflicts exist. Use when the user asks to "derive rules from git history", wants to
-  extract implicit project decisions from refactor/fix/feat commits, codify coding standards
-  from commit patterns, or generate code-style, testing, and api-design rules retroactively.
+description: Derive Claude rules from git commit history (newer commits override older). Use when extracting implicit decisions from refactor/fix/feat commits or codifying code-style, testing, and api-design rules.
 args: "[--since DATE] [--scope SCOPE]"
 argument-hint: "--since 2024-01-01 for date range, --scope api for specific area"
 allowed-tools: Read, Write, Glob, Grep, Bash, AskUserQuestion, Task

--- a/blueprint-plugin/skills/blueprint-docs-currency/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-docs-currency/SKILL.md
@@ -1,16 +1,9 @@
 ---
 name: blueprint-docs-currency
-description: |
-  Advisory skill enforcing same-commit landing of code and its docs —
-  public APIs, file format specs, error enums, milestone status, and
-  ADR-worthy decisions must travel with their documentation. Also covers
-  research promotion from tmp/ into docs/ before tracker advancement.
-  Use when committing code that changes API, format specs, or milestone
-  status; when promoting research from scratch to docs; when landing an
-  ADR-worthy decision; or when a reviewer flags missing documentation.
+description: Enforce same-commit landing of code and its docs (public APIs, file formats, error enums, ADRs). Use when committing API/format/milestone changes, promoting tmp/ research to docs/, or landing an ADR-worthy decision.
 allowed-tools: Read, Grep, Glob, TodoWrite
 created: 2026-04-24
-modified: 2026-04-24
+modified: 2026-05-09
 reviewed: 2026-04-24
 ---
 

--- a/blueprint-plugin/skills/blueprint-docs-list/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-docs-list/SKILL.md
@@ -1,12 +1,8 @@
 ---
 created: 2026-02-06
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-25
-description: |
-  List blueprint documents (ADRs, PRDs, PRPs) with metadata extracted from frontmatter and
-  headers. Use when the user asks to "list blueprint docs", "show all PRDs/ADRs/PRPs", audit
-  document statuses, generate an index table for blueprint artifacts, or wants a quick
-  overview of all project documentation at once.
+description: List blueprint documents (ADRs, PRDs, PRPs) with metadata from frontmatter and headers. Use when listing blueprint docs, auditing statuses, or generating an index table for project documentation.
 args: "<type>"
 allowed-tools: Bash, Glob
 model: sonnet

--- a/blueprint-plugin/skills/blueprint-execute/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-execute/SKILL.md
@@ -1,12 +1,8 @@
 ---
 created: 2026-01-14
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
-description: |
-  Idempotent meta command that determines and executes the next logical blueprint action.
-  Use when the user asks "what's next?", "continue blueprint work", resumes a project after
-  pulling changes, wants smart detection of init/upgrade/derive/generate/execute steps, or
-  says things like "run blueprint" without specifying the exact command.
+description: Idempotent meta command that determines and executes the next logical blueprint action. Use when the user asks "what's next?", "continue blueprint work", or "run blueprint" without specifying init/upgrade/derive/generate/execute.
 allowed-tools: Read, Glob, Bash, AskUserQuestion, SlashCommand, Task
 name: blueprint-execute
 ---

--- a/blueprint-plugin/skills/blueprint-feature-tracker-status/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-feature-tracker-status/SKILL.md
@@ -1,12 +1,8 @@
 ---
 created: 2026-01-02
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-05-03
-description: |
-  Display feature tracker statistics and completion summary. Use when the user asks
-  "what's the feature completion status?", wants a progress bar showing phase progress,
-  checks PRD coverage, views blocked features, lists ready-to-start work, or asks to
-  "show feature tracker status".
+description: Display feature tracker statistics, phase progress, and completion summary. Use when checking feature completion status, viewing blocked features, or seeing ready-to-start work.
 allowed-tools: Read, Bash, AskUserQuestion
 model: sonnet
 name: blueprint-feature-tracker-status

--- a/blueprint-plugin/skills/blueprint-feature-tracker-sync/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-feature-tracker-sync/SKILL.md
@@ -1,14 +1,8 @@
 ---
 created: 2026-01-02
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-25
-description: |
-  Synchronize feature tracker with TODO.md, taskwarrior sidecars, and PRDs; manage tasks.
-  Use when the user asks to "sync feature tracker", reconcile discrepancies between
-  TODO.md checkboxes and tracker status, drain WO entries from a taskwarrior sidecar
-  (bpid/bpdoc UDAs) into tasks.completed with --drain-wave, recalculate completion
-  statistics, add/complete tasks in tasks.in_progress, or generate a markdown progress
-  summary with --summary.
+description: Sync feature tracker with TODO.md, taskwarrior sidecars (bpid/bpdoc UDAs), and PRDs. Use when reconciling TODO.md vs tracker, draining WO entries with --drain-wave, recalculating stats, or generating --summary.
 allowed-tools: Read, Write, Bash, Glob, AskUserQuestion
 model: sonnet
 name: blueprint-feature-tracker-sync

--- a/blueprint-plugin/skills/blueprint-generate-rules/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-generate-rules/SKILL.md
@@ -1,13 +1,8 @@
 ---
 created: 2025-12-16
-modified: 2026-05-03
+modified: 2026-05-09
 reviewed: 2026-05-03
-description: |
-  Generate project-specific rules from PRDs. Supports path-specific rules with paths
-  frontmatter and brace expansion. Use when the user asks to "generate rules from PRDs",
-  wants aggregated architecture/testing/implementation/quality standards rules auto-created
-  from docs/prds/, needs path-scoped rules for test files or specific directories, or is
-  automating rule creation from requirements.
+description: Generate project-specific rules from PRDs with path-scoped frontmatter. Use when auto-creating architecture/testing/implementation/quality rules from docs/prds/ or path-scoped rules for test files or specific directories.
 allowed-tools: Read, Write, Glob, Bash, AskUserQuestion
 name: blueprint-generate-rules
 ---

--- a/blueprint-plugin/skills/blueprint-init/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-init/SKILL.md
@@ -1,13 +1,8 @@
 ---
 created: 2025-12-16
-modified: 2026-05-03
+modified: 2026-05-09
 reviewed: 2026-05-03
-description: |
-  Initialize Blueprint Development structure in current project. Use when the user asks
-  to "init blueprint", "set up blueprint", bootstrap a new project with docs/blueprint/
-  manifest and PRD/ADR/PRP directories, enable feature tracking, migrate existing
-  documentation into blueprint-managed paths, or configure decision detection and task
-  scheduling for the first time.
+description: Initialize Blueprint Development structure in current project. Use when bootstrapping docs/blueprint/ with manifest, PRD/ADR/PRP directories, feature tracking, and decision detection for the first time.
 allowed-tools: Bash, Write, Read, AskUserQuestion, Glob
 name: blueprint-init
 ---

--- a/blueprint-plugin/skills/blueprint-migration/skill.md
+++ b/blueprint-plugin/skills/blueprint-migration/skill.md
@@ -1,14 +1,10 @@
 ---
 name: blueprint-migration
-description: |
-  Versioned migration procedures for upgrading blueprint structure between format versions.
-  Use when /blueprint:upgrade needs version-specific logic, when migrating a manifest between
-  format versions (v1.0→v1.1, v1.x→v2.0, v2.x→v3.0, v3.0→v3.1, v3.2→v3.3), or when content
-  hashing, safe file moves, and rollback are required during a blueprint format migration.
+description: Versioned migration procedures for blueprint format upgrades (v1.0->v1.1, v1.x->v2.0, v2.x->v3.0, v3.0->v3.1, v3.2->v3.3). Use when /blueprint:upgrade needs version-specific logic, content hashing, safe file moves, or rollback.
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion, TodoWrite
 created: 2025-12-22
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 ---
 

--- a/blueprint-plugin/skills/blueprint-promote/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-promote/SKILL.md
@@ -1,12 +1,8 @@
 ---
 created: 2025-12-22
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-05-04
-description: |
-  Move generated artifact to custom layer to preserve modifications. Use when the user
-  wants to "promote" a generated rule to keep manual edits, asks to preserve changes to
-  files in .claude/rules/, stops sync warnings for modified auto-generated content, or
-  says things like "acknowledge modifications" or "promote from proposed to custom".
+description: Move generated artifact to custom layer to preserve manual edits. Use when "promoting" a generated rule, preserving changes to .claude/rules/ files, or stopping sync warnings on modified auto-generated content.
 args: "[skill-name|command-name]"
 allowed-tools: Read, Write, Bash, AskUserQuestion
 argument-hint: "Name of the skill or command to promote"

--- a/blueprint-plugin/skills/blueprint-prp-create/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-prp-create/SKILL.md
@@ -1,16 +1,11 @@
 ---
-description: |
-  Create a PRP (Product Requirement Prompt) with systematic research, curated context, and
-  validation gates. Use when the user asks to "create a PRP", plans a feature implementation
-  packet for AI or subagent execution, wants comprehensive research with codebase patterns
-  and gotchas, or needs to build a self-contained spec with TDD requirements and confidence
-  scoring.
+description: Create a PRP (Product Requirement Prompt) with systematic research, curated context, and validation gates. Use when planning a feature implementation packet for AI/subagent execution with TDD requirements and confidence scoring.
 args: "[feature-name]"
 argument-hint: "Feature name for the PRP (e.g., auth-oauth2, api-rate-limiting)"
 allowed-tools: Read, Write, Glob, Bash, WebFetch, WebSearch, Task, AskUserQuestion
 model: opus
 created: 2025-12-16
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-02-14
 name: blueprint-prp-create
 ---

--- a/blueprint-plugin/skills/blueprint-prp-execute/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-prp-execute/SKILL.md
@@ -1,15 +1,11 @@
 ---
-description: |
-  Execute a PRP with validation loop, TDD workflow, and quality gates. Use when the user
-  asks to "execute a PRP", "implement the auth-oauth2 PRP", runs a planned feature from
-  docs/prps/ with red/green/refactor TDD cycles, wants automatic validation gates and
-  feature tracker sync, or needs to delegate a high-confidence PRP to subagents.
+description: Execute a PRP with validation loop, TDD workflow, and quality gates. Use when the user asks to "execute a PRP", running a planned feature from docs/prps/ with red/green/refactor cycles, or delegating a high-confidence PRP to subagents.
 args: "[prp-name]"
 argument-hint: "Name of PRP to execute (e.g., feature-auth-oauth2)"
 disable-model-invocation: true
 allowed-tools: Read, Write, Edit, Glob, Bash, Task, AskUserQuestion
 created: 2025-12-16
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2026-02-14
 name: blueprint-prp-execute
 ---

--- a/blueprint-plugin/skills/blueprint-rules/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-rules/SKILL.md
@@ -1,13 +1,8 @@
 ---
 created: 2025-12-17
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2026-02-09
-description: |
-  Manage modular rules in .claude/rules/ directory. Supports path-specific rules with glob
-  patterns, brace expansion, and user-level rules. Use when the user asks to "manage rules",
-  add a path-specific rule for certain file types, list project and user-level rules, sync
-  rules with CLAUDE.md, validate glob patterns in `paths` frontmatter, or create rules for
-  React, API, testing, or config files.
+description: Manage modular rules in .claude/rules/ with path-specific glob patterns and brace expansion. Use when adding/listing project or user-level rules, syncing with CLAUDE.md, or validating `paths` frontmatter globs.
 allowed-tools: Read, Write, Edit, Bash, Glob, AskUserQuestion
 name: blueprint-rules
 ---

--- a/blueprint-plugin/skills/blueprint-status/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-status/SKILL.md
@@ -1,13 +1,8 @@
 ---
 created: 2025-12-17
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-05-03
-description: |
-  Show blueprint version, configuration, and check for available upgrades. Use when the
-  user asks to "show blueprint status", checks the three-layer architecture breakdown,
-  audits traceability and orphan documents, views task registry health, looks for stale
-  or modified generated content, or wants to see PRD/ADR/PRP counts and feature tracker
-  progress.
+description: Show blueprint version, config, upgrade availability, PRD/ADR/PRP counts, and feature tracker progress. Use when auditing traceability, orphan docs, task registry health, or stale generated content.
 args: "[--report-only]"
 argument-hint: "--report-only to display status without interactive prompts"
 allowed-tools: Read, Bash, Glob, AskUserQuestion

--- a/blueprint-plugin/skills/blueprint-story-audit/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-story-audit/SKILL.md
@@ -1,13 +1,8 @@
 ---
 created: 2026-04-25
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-25
-description: |
-  Audit user stories against codebase capabilities and tests, producing a tier-ranked
-  coverage gap report. Use when the user asks to "audit stories", run a "story audit"
-  / "coverage audit" / "PRD reconciliation", surface PRD↔code drift, identify untested
-  critical paths, or find "implicit stories" that exist in code but never made it back
-  into the PRD. Read-only — writes a single audit artifact under docs/blueprint/audits/.
+description: Audit user stories against codebase and tests for tier-ranked coverage gaps. Use when running "story audit" / "PRD reconciliation", surfacing PRD<->code drift, or finding implicit stories. Read-only — writes one artifact under docs/blueprint/audits/.
 args: "[--scope <area>] [--prd <path>] [--no-write] [--report-only]"
 argument-hint: "--scope auth to limit; --prd docs/prds/PRD-001.md to override; --no-write skips artifact"
 allowed-tools: Read, Write, Glob, Grep, Bash, Task, AskUserQuestion

--- a/blueprint-plugin/skills/blueprint-story-reconcile/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-story-reconcile/SKILL.md
@@ -1,12 +1,8 @@
 ---
 created: 2026-04-25
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-25
-description: |
-  Reconcile PRD requirements with the drift report from a /blueprint:story-audit. Use
-  when the user wants to mark PRD entries as ✅ implemented / ⚠️ partial / ❌ missing
-  based on the latest audit, add a "Known Drift" section to a PRD, or promote a candidate
-  (code-only) story into the PRD. Mutates PRD files only — never touches source code.
+description: Reconcile PRD requirements with a /blueprint:story-audit drift report. Use when marking PRD entries implemented/partial/missing, adding a "Known Drift" section, or promoting a code-only story into the PRD. Mutates PRD files only.
 args: "[--audit <path>] [--prd <path>] [--apply-all] [--dry-run]"
 argument-hint: "--audit docs/blueprint/audits/2026-04-25-story-audit.md (defaults to latest)"
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion

--- a/blueprint-plugin/skills/blueprint-sync-ids/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-sync-ids/SKILL.md
@@ -1,12 +1,8 @@
 ---
 created: 2026-01-20
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-25
-description: |
-  Scan all blueprint documents and assign IDs to those missing them, update manifest registry.
-  Use when the user asks to "sync document IDs", assigns PRD-NNN / ADR-NNNN / PRP-NNN / WO-NNN
-  IDs to docs missing them, wants to build GitHub issue index for orphans, creates issues for
-  unlinked documents with --link-issues, or previews ID changes with --dry-run.
+description: Scan blueprint docs and assign missing PRD-NNN / ADR-NNNN / PRP-NNN / WO-NNN IDs, updating the manifest registry. Use when assigning IDs to docs missing them; --dry-run to preview, --link-issues to create GitHub issues for orphans.
 args: "[--dry-run] [--link-issues]"
 argument-hint: "--dry-run to preview changes, --link-issues to create GitHub issues for orphans"
 allowed-tools: Read, Write, Edit, Glob, Bash, AskUserQuestion

--- a/blueprint-plugin/skills/blueprint-sync/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-sync/SKILL.md
@@ -1,12 +1,8 @@
 ---
 created: 2025-12-22
-modified: 2026-05-03
+modified: 2026-05-09
 reviewed: 2026-05-03
-description: |
-  Check for stale generated content and offer regeneration or promotion. Use when the user
-  asks to "sync blueprint", detect manually modified generated rules, find stale content
-  when source PRDs have changed, review drift between .claude/rules/ and the manifest, or
-  reconcile edits via regenerate/promote/keep options.
+description: Check for stale generated content and offer regeneration or promotion. Use when syncing blueprint after PRD changes, detecting manually-modified generated rules, or reconciling drift between .claude/rules/ and the manifest.
 args: "[--dry-run]"
 argument-hint: "--dry-run to preview sync status without modifying files"
 allowed-tools: Read, Bash, Glob, AskUserQuestion

--- a/blueprint-plugin/skills/blueprint-upgrade/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-upgrade/SKILL.md
@@ -1,12 +1,8 @@
 ---
 created: 2025-12-17
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
-description: |
-  Upgrade blueprint structure to the latest format version. Use when the user asks to
-  "upgrade blueprint", migrates between format versions (v1.x→v2, v2→v3, v3.0→v3.1/3.2/3.3),
-  adds the task registry introduced in v3.2, enables monorepo workspaces in v3.3, or runs
-  batch upgrades across repos with --non-interactive / -y.
+description: Upgrade blueprint structure to the latest format version. Use when migrating between format versions (v1.x→v3.x), adding the v3.2 task registry, enabling v3.3 monorepo workspaces, or batch upgrading repos with --non-interactive.
 args: "[--non-interactive|-y]"
 argument-hint: "[--non-interactive|-y]"
 allowed-tools: Read, Write, Edit, Bash, Glob, AskUserQuestion

--- a/blueprint-plugin/skills/blueprint-work-order/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-work-order/SKILL.md
@@ -1,12 +1,8 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
-description: |
-  Create work-order with minimal context for isolated subagent execution, optionally linked
-  to GitHub issue. Use when the user asks to "create a work-order", breaks a PRP into
-  delegatable tasks for subagents, spawns a work-order from an existing PRP (--from-prp) or
-  GitHub issue (--from-issue), or needs a focused TDD task packet with clear success criteria.
+description: Create a work-order with minimal context for isolated subagent execution, optionally linked to a GitHub issue. Use when breaking a PRP into delegatable tasks (--from-prp) or spawning from an issue (--from-issue) with clear success criteria.
 args: "[--no-publish] [--from-issue N]"
 argument-hint: "--no-publish for local-only, --from-issue 123 to create from existing issue"
 disable-model-invocation: true

--- a/blueprint-plugin/skills/blueprint-workspace-scan/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-workspace-scan/SKILL.md
@@ -1,16 +1,11 @@
 ---
 name: blueprint-workspace-scan
-description: |
-  Discover child blueprint workspaces under a monorepo root and refresh the root
-  manifest's workspaces.children registry with cached feature-tracker stats.
-  Use when you add/remove a child blueprint, when `/blueprint:status` shows stale
-  portfolio data, or when migrating a root from v3.2 to v3.3. Requires
-  format_version >= 3.3.0.
+description: Discover child blueprint workspaces under a monorepo root and refresh the manifest's workspaces.children registry. Use when adding/removing a child blueprint, when /blueprint:status shows stale portfolio data, or migrating to v3.3.
 args: "[--max-depth N] [--dry-run]"
 argument-hint: "--dry-run to preview without writing; --max-depth sets search depth (default 4)"
 allowed-tools: Bash(bash *), Read, Glob
 created: 2026-04-12
-modified: 2026-04-12
+modified: 2026-05-09
 reviewed: 2026-04-12
 ---
 

--- a/blueprint-plugin/skills/document-detection/skill.md
+++ b/blueprint-plugin/skills/document-detection/skill.md
@@ -1,14 +1,9 @@
 ---
 created: 2026-01-09
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: document-detection
-description: |
-  Detect PRD/ADR/PRP opportunities in conversations and prompt for document creation. Use
-  when the user discusses feature requirements ("I want to build...", "users should be able
-  to..."), compares technology trade-offs ("should we use X or Y?"), plans implementation
-  scope ("let's implement the payment module"), or when conversations warrant capturing an
-  ADR, PRD, or PRP.
+description: Detect PRD/ADR/PRP opportunities in conversations and prompt for document creation. Use when the user discusses feature requirements, compares technology trade-offs, or plans implementation scope worth capturing.
 user-invocable: false
 allowed-tools: Read, Grep, Glob, Bash
 ---

--- a/blueprint-plugin/skills/document-linking/skill.md
+++ b/blueprint-plugin/skills/document-linking/skill.md
@@ -1,14 +1,9 @@
 ---
 created: 2026-01-20
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: document-linking
-description: |
-  Unified ID system for PRDs, ADRs, PRPs, and GitHub issues. Auto-generates IDs on document
-  access, maintains bidirectional links, and provides traceability across all artifacts. Use
-  when the user needs to link a PRD to a PRP, connect documents to GitHub issues, find
-  orphan docs/issues, auto-assign PRD-NNN / ADR-NNNN / PRP-NNN / WO-NNN IDs, or validate
-  broken cross-document references.
+description: Unified ID system for PRDs, ADRs, PRPs, and GitHub issues with bidirectional links. Use when linking PRD<->PRP, finding orphans, auto-assigning PRD-NNN / ADR-NNNN / PRP-NNN / WO-NNN IDs, or validating cross-doc references.
 user-invocable: false
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, TodoWrite
 ---

--- a/blueprint-plugin/skills/feature-tracking/SKILL.md
+++ b/blueprint-plugin/skills/feature-tracking/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2026-01-02
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: feature-tracking
-description: |
-  Track feature implementation status against requirements documents. Provides hierarchical
-  FR code tracking, phase management, task tracking, and sync with TODO.md. Use when the
-  user works with FR codes like FR1.2.1, manages phase-based development progress, links
-  features to PRDs via feature-tracker.json, or needs to recalculate completion statistics.
+description: Track feature implementation status against requirements with hierarchical FR codes (FR1.2.1), phase management, and TODO.md sync. Use when linking features to PRDs via feature-tracker.json or recalculating completion stats.
 user-invocable: false
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, TodoWrite
 ---

--- a/code-quality-plugin/skills/ast-grep-search/SKILL.md
+++ b/code-quality-plugin/skills/ast-grep-search/SKILL.md
@@ -1,9 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: ast-grep-search
-description: Find and replace code patterns structurally using ast-grep. Use when you need to match code by its AST structure (not just text), such as finding all functions with specific signatures, replacing API patterns across files, or detecting code anti-patterns that regex cannot reliably match.
+description: "Find and replace code patterns structurally with ast-grep. Use when matching code by AST structure (not text), finding functions with specific signatures, replacing API patterns across files, or detecting anti-patterns regex cannot match."
 user-invocable: false
 allowed-tools: Bash(sg *), Bash(ast-grep *), Read, Grep, Glob
 model: sonnet

--- a/code-quality-plugin/skills/code-antipatterns-analysis/SKILL.md
+++ b/code-quality-plugin/skills/code-antipatterns-analysis/SKILL.md
@@ -1,9 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: code-antipatterns-analysis
-description: Analyze codebases for anti-patterns, code smells, and quality issues using ast-grep structural pattern matching. Use when reviewing code quality, identifying technical debt, or performing comprehensive code analysis across JavaScript, TypeScript, Python, Vue, React, or other supported languages.
+description: "Analyze codebases for anti-patterns and code smells via ast-grep structural matching across JS, TS, Python, Vue, React. Use when reviewing code quality, identifying tech debt, or doing broad code analysis. Pairs with /code-antipatterns."
 user-invocable: false
 allowed-tools: Bash(sg *), Bash(rg *), Read, Grep, Glob, TodoWrite, Task
 model: opus

--- a/code-quality-plugin/skills/code-antipatterns/SKILL.md
+++ b/code-quality-plugin/skills/code-antipatterns/SKILL.md
@@ -1,13 +1,8 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
-description: |
-  Analyze a codebase for anti-patterns, code smells, and quality issues using
-  ast-grep. Use when the user asks to find code smells, detect anti-patterns,
-  scan for magic numbers or console.logs, check for var usage or excessive
-  `any` types, audit for security issues like eval/innerHTML, or identify
-  long functions and deep nesting.
+description: "Analyze a codebase for anti-patterns and code smells using ast-grep. Use when finding magic numbers, console.logs, var usage, excessive `any`, security issues like eval/innerHTML, long functions, or deep nesting."
 allowed-tools: Read, Bash(sg *), Bash(rg *), Glob, Grep, TodoWrite, Task, SlashCommand
 args: "[PATH] [--focus <category>] [--severity <level>]"
 argument-hint: "[PATH] [--focus <category>] [--severity <level>]"

--- a/code-quality-plugin/skills/code-dep-audit/SKILL.md
+++ b/code-quality-plugin/skills/code-dep-audit/SKILL.md
@@ -1,14 +1,11 @@
 ---
 name: code-dep-audit
-description: |
-  Audit dependencies for security vulnerabilities, outdated packages, and license compliance.
-  Use when checking supply chain security, preparing releases, or responding to CVE advisories.
-  Pairs with /configure:security for scanning infrastructure setup.
+description: "Audit dependencies for security vulnerabilities, outdated packages, and license compliance. Use when checking supply chain security, preparing releases, or responding to CVE advisories. Pairs with /configure:security for setup."
 args: "[--type <security|outdated|licenses|all>] [--fix]"
 argument-hint: --type security to check vulnerabilities, --type outdated for updates
 allowed-tools: Bash(npm audit *), Bash(npx *), Bash(pip-audit *), Bash(cargo audit *), Bash(pip *), Bash(uv *), Bash(cargo *), Read, Grep, Glob, TodoWrite
 created: 2026-04-10
-modified: 2026-04-10
+modified: 2026-05-09
 reviewed: 2026-04-10
 ---
 

--- a/code-quality-plugin/skills/code-docs-quality/SKILL.md
+++ b/code-quality-plugin/skills/code-docs-quality/SKILL.md
@@ -1,12 +1,8 @@
 ---
 created: 2026-01-08
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
-description: |
-  Analyze codebase documentation quality across PRDs, ADRs, PRPs, CLAUDE.md,
-  and .claude/rules/. Use when the user asks to audit or score documentation,
-  check for stale or missing ADRs/PRDs, validate frontmatter and structure of
-  rules, or review whether CLAUDE.md is up to date with recent code changes.
+description: "Analyze docs quality across PRDs, ADRs, PRPs, CLAUDE.md, .claude/rules/. Use when auditing or scoring documentation, checking for stale ADRs/PRDs, validating rule frontmatter/structure, or reviewing whether CLAUDE.md is up to date."
 allowed-tools: Read, Glob, Grep, Bash(markdownlint *), Bash(vale *), TodoWrite, Task
 args: "[PATH]"
 argument-hint: "[PATH]"

--- a/code-quality-plugin/skills/code-error-swallowing/SKILL.md
+++ b/code-quality-plugin/skills/code-error-swallowing/SKILL.md
@@ -1,19 +1,11 @@
 ---
 created: 2026-04-14
-modified: 2026-04-14
+modified: 2026-05-09
 reviewed: 2026-04-14
 allowed-tools: Bash(bash *), Bash(sg *), Read, Grep, Glob, TodoWrite
 args: "[PATH] [--lang <shell|js|py|go|rust|auto>] [--severity <low|med|high>] [--emit-patch]"
 argument-hint: "[PATH] [--lang LANG] [--severity LEVEL] [--emit-patch]"
-description: |
-  Scan for syntactic error swallowing — catch/except blocks that discard errors,
-  `|| true` and `2>/dev/null` idioms in shell, floating promises in JS/TS,
-  ignored Go error returns, and discarded Rust Results. Classifies each
-  finding by severity, recommends a context-appropriate surfacing channel
-  (CLI stderr, web toast, structured log, re-raise), and applies a privacy
-  redaction policy when generating suggested replacement text. Use when
-  failures "disappear", a CI job passes despite the real work failing, or a
-  user reports that a feature silently does nothing.
+description: "Scan for error swallowing — catch/except discarding errors, `|| true`, `2>/dev/null`, floating promises in JS/TS, ignored Go errors, discarded Rust Results. Use when failures \"disappear\" or CI passes despite failing work."
 name: code-error-swallowing
 ---
 

--- a/code-quality-plugin/skills/code-lint-fix/SKILL.md
+++ b/code-quality-plugin/skills/code-lint-fix/SKILL.md
@@ -1,15 +1,10 @@
 ---
 name: code-lint-fix
-description: |
-  Cross-language linter autofix commands and common fix patterns for biome,
-  ruff, clippy, shellcheck, and more. Use when the user wants to auto-fix
-  lint errors, sort imports, remove unused imports, quote shell variables,
-  apply prefer-const or clippy suggestions, or run a detect-and-fix pass
-  across a mixed-language project.
+description: "Cross-language linter autofix patterns for biome, ruff, clippy, shellcheck. Use when auto-fixing lint errors, sorting/removing imports, quoting shell vars, applying prefer-const/clippy suggestions, or detect-and-fix across mixed languages."
 allowed-tools: Bash(ruff *), Bash(eslint *), Bash(biome *), Bash(prettier *), Read, Edit, Grep
 model: sonnet
 created: 2025-12-27
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-25
 ---
 

--- a/code-quality-plugin/skills/code-lint/SKILL.md
+++ b/code-quality-plugin/skills/code-lint/SKILL.md
@@ -1,16 +1,12 @@
 ---
 created: 2025-12-16
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-25
 allowed-tools: Bash(ruff *), Bash(eslint *), Bash(rustfmt *), Bash(gofmt *), Bash(prettier *), Read, SlashCommand
 model: sonnet
 args: "[path] [--fix] [--format]"
 argument-hint: "[path] [--fix] [--format]"
-description: |
-  Universal linter that auto-detects and runs the appropriate linting tools
-  for the project's language. Use when the user asks to lint the code, run
-  ruff/eslint/clippy/gofmt, auto-fix lint errors with --fix, format code,
-  or run pre-commit checks across a polyglot repository.
+description: "Universal linter that auto-detects ruff/eslint/clippy/gofmt for the project language. Use when linting code, auto-fixing with --fix, formatting, or running pre-commit checks across a polyglot repo."
 name: code-lint
 ---
 

--- a/code-quality-plugin/skills/code-refactor/SKILL.md
+++ b/code-quality-plugin/skills/code-refactor/SKILL.md
@@ -1,16 +1,11 @@
 ---
 created: 2025-12-16
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2026-03-09
 allowed-tools: Task, TodoWrite
 args: <file-path|directory>
 argument-hint: <file-path|directory>
-description: |
-  Refactor code applying functional programming principles - pure functions,
-  immutability, and composition. Use when the user asks to refactor a file
-  or directory, extract pure functions, remove side effects, replace
-  imperative loops with map/filter/reduce, add early returns to deeply
-  nested code, or separate business logic from I/O.
+description: "Refactor code applying functional principles — pure functions, immutability, composition. Use when extracting pure functions, removing side effects, replacing imperative loops with map/filter/reduce, or separating logic from I/O."
 name: code-refactor
 ---
 

--- a/code-quality-plugin/skills/code-review-checklist/SKILL.md
+++ b/code-quality-plugin/skills/code-review-checklist/SKILL.md
@@ -1,16 +1,11 @@
 ---
 name: code-review-checklist
-description: |
-  Structured code review checklist covering security, correctness,
-  performance, quality, and consistency. Use when the user asks for a code
-  review, wants to check for hardcoded secrets or injection vulnerabilities,
-  verify error handling and edge cases, audit for N+1 queries or resource
-  leaks, or apply a priority-ordered review to a pull request.
+description: "Structured code review checklist for security, correctness, performance, quality, consistency. Use when reviewing PRs, checking hardcoded secrets/injection, verifying error handling and edge cases, or auditing for N+1 queries and resource leaks."
 user-invocable: false
 allowed-tools: Read, Grep, Glob
 model: opus
 created: 2025-12-27
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-25
 ---
 

--- a/code-quality-plugin/skills/code-review/SKILL.md
+++ b/code-quality-plugin/skills/code-review/SKILL.md
@@ -1,15 +1,10 @@
 ---
 created: 2025-12-16
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-25
 allowed-tools: Task, TodoWrite, Glob, Read
 model: opus
-description: |
-  Perform a comprehensive code review covering quality, security,
-  performance, architecture, and test coverage, with automated fixes where
-  safe. Use when the user asks to review code or a directory, audit for
-  vulnerabilities and OWASP issues, check SOLID adherence, look for
-  performance bottlenecks, or spot missing test cases.
+description: "Comprehensive code review covering quality, security, performance, architecture, and test coverage with safe automated fixes. Use when reviewing code, auditing OWASP issues, checking SOLID, or finding perf bottlenecks and missing tests."
 args: "[PATH]"
 argument-hint: "[PATH]"
 name: code-review

--- a/code-quality-plugin/skills/code-silent-degradation/SKILL.md
+++ b/code-quality-plugin/skills/code-silent-degradation/SKILL.md
@@ -1,17 +1,12 @@
 ---
 created: 2026-02-22
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-02-22
 allowed-tools: Bash(grep *), Read, Grep, Glob, Edit, Write, TodoWrite
 model: opus
 args: "[PATH] [--fix]"
 argument-hint: "[PATH] [--fix]"
-description: |
-  Detect silent degradation patterns where operations succeed with zero results
-  because preconditions are unmet. Use when features report "success" but produce
-  nothing, scan results show 0 items with no explanation, or UX shows green
-  success banners for empty outcomes. Finds missing precondition checks, silent
-  skips, and misleading success messages.
+description: "Detect silent degradation patterns where ops succeed with zero results because preconditions are unmet. Use when features report \"success\" but produce nothing, scans show 0 items unexplained, or UX shows green banners for empty outcomes."
 name: code-silent-degradation
 ---
 

--- a/code-quality-plugin/skills/code-test-quality/SKILL.md
+++ b/code-quality-plugin/skills/code-test-quality/SKILL.md
@@ -1,15 +1,11 @@
 ---
 name: code-test-quality
-description: |
-  Analyze test suite quality — detect test smells, empty assertions, flaky patterns,
-  coverage gaps, and missing edge cases. Use when test suite is unreliable, coverage
-  is misleading, or after major refactors. Pairs with /configure:tests and
-  /configure:coverage for framework setup.
+description: "Analyze test suite quality — test smells, empty assertions, flaky patterns, coverage gaps, missing edge cases. Use when test suite is unreliable, coverage is misleading, or after major refactors. Pairs with /configure:tests and /configure:coverage."
 args: "[PATH] [--focus <smells|coverage|flaky|all>]"
 argument-hint: path to test directory or specific test file
 allowed-tools: Bash(npx vitest *), Bash(npx jest *), Bash(pytest *), Bash(cargo test *), Read, Grep, Glob, TodoWrite
 created: 2026-04-10
-modified: 2026-04-10
+modified: 2026-05-09
 reviewed: 2026-04-10
 ---
 

--- a/code-quality-plugin/skills/debugging-methodology/SKILL.md
+++ b/code-quality-plugin/skills/debugging-methodology/SKILL.md
@@ -1,16 +1,11 @@
 ---
 name: debugging-methodology
-description: |
-  Systematic debugging methodology with tool recommendations for memory,
-  performance, and system-level issues. Use when the user asks to debug a
-  bug, diagnose a memory leak or performance problem, trace syscalls with
-  strace/eBPF, profile CPU usage with perf, reproduce a flaky test, or
-  reason about race conditions and null pointer errors.
+description: "Systematic debugging methodology with tool recommendations for memory, performance, system-level issues. Use when diagnosing memory leaks, tracing syscalls with strace/eBPF, profiling with perf, or reasoning about races."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 model: opus
 created: 2025-12-27
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-25
 ---
 

--- a/code-quality-plugin/skills/dry-consolidation/SKILL.md
+++ b/code-quality-plugin/skills/dry-consolidation/SKILL.md
@@ -1,16 +1,12 @@
 ---
 name: dry-consolidation
-description: |
-  Find and extract duplicated code into shared abstractions. Use when you see repeated
-  patterns across multiple files — identical utility functions, copy-pasted UI components,
-  duplicated hooks or state management, or repeated boilerplate blocks. Systematically
-  consolidates them into reusable utilities, components, hooks, and shared modules.
+description: "Find and extract duplicated code into shared abstractions. Use when seeing repeated patterns across files — identical utilities, copy-pasted UI components, duplicated hooks/state, or repeated boilerplate — and consolidating into reusable modules."
 args: "[PATH] [--scope <utilities|components|hooks|all>] [--dry-run]"
 allowed-tools: Read, Write, Edit, MultiEdit, Grep, Glob, Bash(npx tsc *), Bash(npm run *), Bash(npx *), Bash(bun *), Bash(pnpm *), Bash(yarn *), Bash(pytest *), Bash(cargo *), TodoWrite, Task
 model: opus
 argument-hint: path or directory to scan for duplication
 created: 2026-02-06
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-02-06
 agent: general-purpose
 ---

--- a/codebase-attributes-plugin/skills/attributes-dashboard/SKILL.md
+++ b/codebase-attributes-plugin/skills/attributes-dashboard/SKILL.md
@@ -1,16 +1,11 @@
 ---
 name: attributes-dashboard
-description: |
-  Compact text-based health dashboard showing scores, findings, and severity breakdown for
-  documentation, testing, security, code quality, and CI/CD. Use when the user wants a
-  quick visual health overview of the codebase, to review health before a session, to
-  compare category scores at a glance, or to see a compact terminal-style summary of
-  critical/high/medium/low findings with action suggestions.
+description: Compact text dashboard showing scores, findings, and severity for docs, testing, security, code quality, and CI/CD. Use when the user wants a quick health overview, to compare category scores, or a terminal-style summary with action suggestions.
 allowed-tools: Bash(test *), Read, Glob, Grep
 args: "[--format <type>]"
 argument-hint: ""
 created: 2026-03-15
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2026-03-15
 ---
 

--- a/codebase-attributes-plugin/skills/attributes-route/SKILL.md
+++ b/codebase-attributes-plugin/skills/attributes-route/SKILL.md
@@ -1,16 +1,11 @@
 ---
 name: attributes-route
-description: |
-  Route to specialized agents (security, test, refactor, review, docs, configure) based on
-  codebase health attributes, prioritized by severity weights. Use when the user has
-  attribute data and wants automated remediation, when batch-fixing multiple health findings,
-  when they want severity-based agent prioritization, or when mentioning "fix health
-  findings", "route to agents", or running after `/attributes:collect`.
+description: "Route to specialized agents (security, test, refactor, review, docs, configure) based on codebase health attributes, prioritized by severity. Use when the user has attribute data and wants automated remediation after `/attributes:collect`."
 allowed-tools: Read, Glob, Grep, Agent, TodoWrite
 args: "[--dry-run] [--focus <category>] [--min-severity <level>]"
 argument-hint: "--dry-run"
 created: 2026-03-15
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2026-03-15
 ---
 

--- a/communication-plugin/skills/google-chat-formatting/SKILL.md
+++ b/communication-plugin/skills/google-chat-formatting/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: google-chat-formatting
-description: Convert text to Google Chat compatible formatting (Markdown to Google Chat syntax). Use when formatting messages for Google Chat, converting Markdown documents for Google Chat, or when the user mentions Google Chat formatting.
+description: Convert Markdown text to Google Chat compatible formatting. Use when formatting messages for Google Chat or converting Markdown documents to Google Chat syntax.
 user-invocable: false
 allowed-tools: Read, Write, Edit, Bash
 ---

--- a/communication-plugin/skills/ticket-drafting-guidelines/SKILL.md
+++ b/communication-plugin/skills/ticket-drafting-guidelines/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: ticket-drafting-guidelines
-description: |
-  Structured guidelines for drafting GitHub issues and technical tickets.
-  Uses What/Why/How format with concise descriptions, markdown formatting,
-  and positive framing without estimates or bold claims.
-  Use when user mentions creating issues, drafting tickets, writing bug reports,
-  GitHub issue templates, or structuring technical tickets.
+description: Structured guidelines for drafting GitHub issues and technical tickets. Uses What/Why/How format with concise descriptions and positive framing without estimates. Use when creating issues, drafting tickets, or writing bug reports.
 user-invocable: false
 allowed-tools: Read, Grep, WebFetch
 ---

--- a/component-patterns-plugin/skills/components-version-badge/SKILL.md
+++ b/component-patterns-plugin/skills/components-version-badge/SKILL.md
@@ -1,14 +1,8 @@
 ---
 created: 2025-02-03
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
-description: |
-  Implement a framework-agnostic version badge component with a tooltip showing build info
-  (version, commit, branch, timestamp) and recent changelog entries. Use when the user
-  wants to add a version display to their app header or footer, surface build information
-  in the UI, expose recent changelog entries as a tooltip, or when they mention "version
-  badge", "build info display", or "commit SHA in UI". Supports Next.js, Nuxt, SvelteKit,
-  Vite+React, and plain React/Vue/Svelte.
+description: Framework-agnostic version badge with a tooltip showing build info (version, commit, branch, timestamp) and recent changelog. Use when adding version display to app header/footer. Supports Next.js, Nuxt, SvelteKit, Vite+React, plain React/Vue/Svelte.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--location <header|footer|custom>]"
 argument-hint: "[--check-only] [--location <header|footer|custom>]"

--- a/component-patterns-plugin/skills/version-badge-pattern/SKILL.md
+++ b/component-patterns-plugin/skills/version-badge-pattern/SKILL.md
@@ -1,14 +1,10 @@
 ---
 name: version-badge-pattern
-description: |
-  Implement a version badge UI component showing build version, git commit, and
-  recent changelog in a tooltip. Use when adding version visibility to applications
-  for support, debugging, and change awareness. Works with React, Vue, Svelte, and
-  plain JavaScript.
+description: Implement a version badge UI showing build version, git commit, and recent changelog in a tooltip. Use when adding version visibility for support, debugging, and change awareness. Works with React, Vue, Svelte, and plain JavaScript.
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2025-02-03
-modified: 2026-02-14
+modified: 2026-05-09
 reviewed: 2026-02-08
 ---
 

--- a/configure-plugin/skills/ci-workflows/SKILL.md
+++ b/configure-plugin/skills/ci-workflows/SKILL.md
@@ -3,10 +3,7 @@ created: 2025-12-16
 modified: 2026-04-29
 reviewed: 2026-04-29
 name: ci-workflows
-description: |
-  GitHub Actions workflow standards. Use when configuring CI/CD workflows, checking
-  workflow compliance, or when the user mentions GitHub Actions, container builds,
-  or CI/CD automation.
+description: GitHub Actions workflow standards. Use when configuring CI/CD workflows, checking workflow compliance, or working with container builds and CI/CD automation.
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 ---

--- a/configure-plugin/skills/claude-security-settings/SKILL.md
+++ b/configure-plugin/skills/claude-security-settings/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: claude-security-settings
-description: |
-  Configure Claude Code security settings including permission wildcards, shell
-  operator protections, and project-level access controls. Use when setting up
-  project permissions, configuring allowed tools, or securing Claude Code workflows.
+description: Configure Claude Code security settings — permission wildcards, shell operator protections, project-level access controls. Use when setting up project permissions or restricting allowed tools.
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, TodoWrite
 created: 2026-01-20

--- a/configure-plugin/skills/config-sync/SKILL.md
+++ b/configure-plugin/skills/config-sync/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: config-sync
-description: |
-  Extract, compare, and propagate tooling improvements across FVH repos.
-  Use when user says "sync workflows", "propagate config", "diff workflows",
-  "extract improvements", or "config sync".
+description: Extract, compare, and propagate tooling improvements across FVH repos. Use when syncing workflows, diffing configs across repos, or extracting improvements to apply elsewhere.
 allowed-tools: Bash(git *), Bash(gh *), Bash(fd *), Bash(rg *), Bash(diff *), Bash(sha256sum *), Bash(shasum *), Read, Grep, Glob, Edit, Write, TodoWrite, AskUserQuestion
 args: <mode> [options]
 argument-hint: "extract [repo]|diff <file-pattern>|apply <file-pattern> [--from repo] [--to repos|--all]"

--- a/configure-plugin/skills/configure-all/SKILL.md
+++ b/configure-plugin/skills/configure-all/SKILL.md
@@ -2,12 +2,7 @@
 created: 2025-12-16
 modified: 2026-04-19
 reviewed: 2025-12-16
-description: |
-  Run all infrastructure standards checks and configure compliance across a project.
-  Use when performing a comprehensive infrastructure audit, setting up a new project
-  against all standards, batch-fixing compliance issues with --fix, or validating
-  CI/CD compliance. Natural triggers: "check all standards", "audit project compliance",
-  "configure everything", "run all configure checks".
+description: Run all infrastructure standards checks and apply compliance fixes across a project. Use when performing a comprehensive audit, onboarding a new project against all standards, or batch-fixing with --fix.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, SlashCommand
 args: "[--check-only] [--fix] [--type <frontend|infrastructure|python>]"
 argument-hint: "[--check-only] [--fix] [--type <frontend|infrastructure|python>]"

--- a/configure-plugin/skills/configure-api-tests/SKILL.md
+++ b/configure-plugin/skills/configure-api-tests/SKILL.md
@@ -2,12 +2,7 @@
 created: 2025-12-16
 modified: 2026-04-19
 reviewed: 2025-12-16
-description: |
-  Check and configure API contract testing with Pact, OpenAPI validation, and schema testing.
-  Use when setting up Pact consumer/provider contract tests, configuring OpenAPI
-  request/response validation, adding JSON Schema or Zod schema testing, or detecting
-  breaking API changes in CI. Natural triggers: "set up contract testing", "add Pact",
-  "configure OpenAPI validation".
+description: Check and configure API contract testing with Pact, OpenAPI validation, and JSON Schema/Zod. Use when adding consumer/provider contract tests or detecting breaking API changes in CI.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--type <pact|openapi|schema>]"
 argument-hint: "[--check-only] [--fix] [--type <pact|openapi|schema>]"

--- a/configure-plugin/skills/configure-argocd-automerge/SKILL.md
+++ b/configure-plugin/skills/configure-argocd-automerge/SKILL.md
@@ -2,12 +2,7 @@
 created: 2026-02-03
 modified: 2026-04-19
 reviewed: 2026-02-03
-description: |
-  Configure GitHub Actions auto-merge workflow for ArgoCD Image Updater branches.
-  Use when setting up auto-merge for image-updater-** branches, creating the
-  argocd-automerge.yml workflow from scratch, verifying PAT and permissions for
-  auto-merge workflows, or updating an existing ArgoCD auto-merge workflow.
-  Natural triggers: "auto-merge ArgoCD PRs", "set up image-updater automerge".
+description: Configure GitHub Actions auto-merge for ArgoCD Image Updater branches. Use when setting up auto-merge for image-updater-** branches, creating argocd-automerge.yml, or verifying PAT permissions.
 allowed-tools: Glob, Grep, Read, Write, Edit, TodoWrite
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"

--- a/configure-plugin/skills/configure-cache-busting/SKILL.md
+++ b/configure-plugin/skills/configure-cache-busting/SKILL.md
@@ -2,12 +2,7 @@
 created: 2025-12-16
 modified: 2026-04-19
 reviewed: 2025-12-16
-description: |
-  Check and configure cache-busting strategies for Next.js and Vite projects.
-  Use when configuring content hashing for Next.js or Vite builds, setting up CDN
-  cache headers for Vercel or Cloudflare, adding build verification scripts for
-  hashed assets, or auditing static asset caching strategy. Natural triggers:
-  "configure cache busting", "set up CDN cache headers", "add content hashing".
+description: Check and configure cache-busting for Next.js and Vite projects. Use when adding content hashing, setting CDN cache headers (Vercel, Cloudflare), or auditing static asset caching.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--framework <nextjs|vite>] [--cdn <cloudflare|vercel|none>]"
 argument-hint: "[--check-only] [--fix] [--framework <nextjs|vite>] [--cdn <cloudflare|vercel|none>]"

--- a/configure-plugin/skills/configure-claude-plugins/SKILL.md
+++ b/configure-plugin/skills/configure-claude-plugins/SKILL.md
@@ -1,15 +1,8 @@
 ---
 created: 2026-01-23
-modified: 2026-05-06
+modified: 2026-05-09
 reviewed: 2026-05-06
-description: |
-  Configure .claude/settings.json (permissions, marketplace enrollment, enabledPlugins)
-  and GitHub Actions workflows to use the laurigates/claude-plugins marketplace.
-  Use when onboarding a new project to Claude Code plugins, setting up claude.yml
-  and claude-code-review.yml workflows, adding the laurigates/claude-plugins
-  marketplace to a repo, pinning a project's plugin set deterministically against
-  global drift, or merging plugin permissions into existing settings.
-  Natural triggers: "set up claude plugins", "add claude marketplace", "install claude.yml workflow", "pin plugins for this repo".
+description: Configure .claude/settings.json and GitHub Actions for the laurigates/claude-plugins marketplace. Use when onboarding to Claude Code plugins, setting up claude.yml, or pinning plugin sets.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash(mkdir *), Bash(test *), Bash(ls *), Bash(git remote *), Bash(gh api *), Bash(jq *), AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--exhaustive] [--plugins <plugin1,plugin2,...>]"
 argument-hint: "[--check-only] [--fix] [--exhaustive] [--plugins <plugin1,plugin2,...>]"

--- a/configure-plugin/skills/configure-container/SKILL.md
+++ b/configure-plugin/skills/configure-container/SKILL.md
@@ -2,12 +2,7 @@
 created: 2025-12-16
 modified: 2026-04-19
 reviewed: 2026-01-19
-description: |
-  Check and configure container infrastructure (builds, registry, scanning, devcontainer).
-  Use when auditing container infrastructure compliance, checking multi-stage builds and
-  non-root users, setting up container build workflows with GHCR and multi-platform support,
-  or adding Trivy/Grype scanning to CI pipelines. Natural triggers: "configure container
-  build", "add container scanning", "set up GHCR workflow".
+description: Check and configure container infrastructure — builds, GHCR registry, Trivy/Grype scanning, devcontainer. Use when setting up multi-platform GHCR workflows or adding container scanning to CI.
 allowed-tools: Glob, Grep, Read, Write, Edit, AskUserQuestion, TodoWrite, SlashCommand, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--component <dockerfile|workflow|registry|scanning|devcontainer>]"
 argument-hint: "[--check-only] [--fix] [--component <dockerfile|workflow|registry|scanning|devcontainer>]"

--- a/configure-plugin/skills/configure-coverage/SKILL.md
+++ b/configure-plugin/skills/configure-coverage/SKILL.md
@@ -2,12 +2,7 @@
 created: 2025-12-16
 modified: 2026-04-19
 reviewed: 2025-12-16
-description: |
-  Check and configure code coverage thresholds and reporting for test frameworks.
-  Use when setting up coverage thresholds for Vitest, Jest, pytest, or Rust, configuring
-  coverage reporters (text, JSON, HTML, lcov), adding Codecov or Coveralls integration,
-  or adjusting coverage threshold percentages. Natural triggers: "set up coverage",
-  "add codecov", "configure coverage threshold".
+description: Check and configure code coverage thresholds and reporters for Vitest, Jest, pytest, and Rust. Use when setting coverage thresholds, adding Codecov or Coveralls, or wiring lcov/HTML reports.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--threshold <percentage>]"
 argument-hint: "[--check-only] [--fix] [--threshold <percentage>]"

--- a/configure-plugin/skills/configure-dead-code/SKILL.md
+++ b/configure-plugin/skills/configure-dead-code/SKILL.md
@@ -2,12 +2,7 @@
 created: 2025-12-16
 modified: 2026-04-19
 reviewed: 2025-12-16
-description: |
-  Check and configure dead code detection tools (Knip, Vulture, cargo-machete, deadcode).
-  Use when setting up dead code detection for a new project, auditing whether Knip,
-  Vulture, or cargo-machete is configured correctly, migrating between dead code
-  detection tools, or adding dead code checks to CI/CD pipelines. Natural triggers:
-  "set up knip", "configure vulture", "detect unused code".
+description: Check and configure dead-code detection tools (Knip, Vulture, cargo-machete, deadcode). Use when setting up unused-code detection, migrating between tools, or adding dead-code checks to CI.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--tool <knip|vulture|deadcode|machete>]"
 argument-hint: "[--check-only] [--fix] [--tool <knip|vulture|deadcode|machete>]"

--- a/configure-plugin/skills/configure-dockerfile/SKILL.md
+++ b/configure-plugin/skills/configure-dockerfile/SKILL.md
@@ -2,12 +2,7 @@
 created: 2025-12-16
 modified: 2026-04-19
 reviewed: 2026-01-19
-description: |
-  Check and configure Dockerfile for project standards (minimal Alpine/slim, non-root,
-  multi-stage builds). Use when checking Dockerfile compliance with standards, creating
-  a Dockerfile from template, validating image size and security practices, setting up
-  minimal Alpine/slim-based images, or ensuring non-root user configuration. Natural
-  triggers: "create Dockerfile", "make Dockerfile non-root", "add multi-stage build".
+description: Check and configure Dockerfiles for minimal Alpine/slim base, non-root user, and multi-stage builds. Use when creating a Dockerfile, hardening for security, or auditing image size and layering.
 allowed-tools: Glob, Grep, Read, Write, Edit, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--type <frontend|python|go|rust>]"
 argument-hint: "[--check-only] [--fix] [--type <frontend|python|go|rust>]"

--- a/configure-plugin/skills/configure-docs/SKILL.md
+++ b/configure-plugin/skills/configure-docs/SKILL.md
@@ -2,12 +2,7 @@
 created: 2025-12-16
 modified: 2026-04-19
 reviewed: 2025-12-16
-description: |
-  Check and configure code documentation standards and generators (TSDoc, JSDoc,
-  pydoc, rustdoc). Use when setting up TSDoc/JSDoc/pydoc/rustdoc standards, configuring
-  a documentation generator (TypeDoc, MkDocs, Sphinx, rustdoc), auditing documentation
-  coverage, adding doc enforcement rules to CI, or migrating between documentation
-  conventions. Natural triggers: "set up docstrings", "configure typedoc", "add sphinx".
+description: Check and configure code documentation standards and generators (TSDoc, JSDoc, pydoc, rustdoc, TypeDoc, MkDocs, Sphinx). Use when setting up docstrings, configuring a docs generator, or enforcing doc coverage in CI.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--level <minimal|standard|strict>] [--type <typescript|javascript|python|rust>] [--generator <typedoc|sphinx|mkdocs|rustdoc>]"
 argument-hint: "[--check-only] [--fix] [--level <minimal|standard|strict>] [--type <typescript|javascript|python|rust>] [--generator <typedoc|sphinx|mkdocs|rustdoc>]"

--- a/configure-plugin/skills/configure-editor/SKILL.md
+++ b/configure-plugin/skills/configure-editor/SKILL.md
@@ -1,14 +1,8 @@
 ---
 created: 2025-12-16
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2025-12-16
-description: |
-  Check and configure EditorConfig and VS Code workspace settings for team consistency.
-  Use when setting up consistent editor configuration across a team, checking
-  EditorConfig or VS Code workspace compliance, configuring format-on-save for detected
-  languages, adding recommended VS Code extensions, or setting up debug configurations
-  and tasks. Natural triggers: "set up editorconfig", "configure vscode settings",
-  "add recommended extensions".
+description: Configure EditorConfig and VS Code workspace settings for team consistency. Use when setting up editor config, format-on-save, recommended extensions, or debug configurations.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"

--- a/configure-plugin/skills/configure-feature-flags/SKILL.md
+++ b/configure-plugin/skills/configure-feature-flags/SKILL.md
@@ -1,14 +1,8 @@
 ---
 created: 2025-12-16
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2025-12-16
-description: |
-  Check and configure feature flag infrastructure using OpenFeature with pluggable
-  providers. Use when adding feature flag infrastructure to a new project, setting up
-  the OpenFeature SDK with a provider (GOFF, flagd, LaunchDarkly), auditing existing
-  feature flag configuration, configuring relay proxy infrastructure, or adding
-  feature flag test helpers. Natural triggers: "set up feature flags", "add
-  openfeature", "configure launchdarkly".
+description: Configure feature flag infrastructure with OpenFeature and pluggable providers (GOFF, flagd, LaunchDarkly). Use when setting up the SDK, configuring a relay proxy, or adding flag test helpers.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--provider <goff|flagd|launchdarkly|split>]"
 argument-hint: "[--check-only] [--fix] [--provider <goff|flagd|launchdarkly|split>]"

--- a/configure-plugin/skills/configure-formatting/SKILL.md
+++ b/configure-plugin/skills/configure-formatting/SKILL.md
@@ -2,13 +2,7 @@
 created: 2025-12-16
 modified: 2026-04-19
 reviewed: 2025-12-16
-description: |
-  Check and configure code formatting tools (Biome, Prettier, Ruff format, rustfmt).
-  Use when setting up a formatter for a project, migrating from Prettier to Biome or
-  Black to Ruff, auditing formatter configuration for best practices, adding
-  format-on-save and CI format checks, or standardizing formatting across a monorepo.
-  Natural triggers: "set up formatting", "configure biome", "migrate to ruff format",
-  "add prettier".
+description: Check and configure code formatters (Biome, Prettier, Ruff format, rustfmt). Use when setting up formatting, migrating Prettier to Biome or Black to Ruff, adding format-on-save, or wiring CI format checks.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--formatter <biome|prettier|ruff|rustfmt>]"
 argument-hint: "[--check-only] [--fix] [--formatter <biome|prettier|ruff|rustfmt>]"

--- a/configure-plugin/skills/configure-github-pages/SKILL.md
+++ b/configure-plugin/skills/configure-github-pages/SKILL.md
@@ -2,12 +2,7 @@
 created: 2025-12-16
 modified: 2026-04-19
 reviewed: 2025-12-16
-description: |
-  Check and configure GitHub Pages deployment for documentation sites. Use when
-  setting up GitHub Pages deployment, creating or updating a GitHub Actions workflow
-  for Pages deployment, migrating from peaceiris/actions-gh-pages to the official
-  actions/deploy-pages, or auditing Pages workflow for outdated action versions.
-  Natural triggers: "deploy to github pages", "set up gh-pages", "configure pages workflow".
+description: Check and configure GitHub Pages deployment workflows for docs sites. Use when setting up Pages, migrating peaceiris/actions-gh-pages to actions/deploy-pages, or auditing Pages action versions.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--source <docs|site|custom>]"
 argument-hint: "[--check-only] [--fix] [--source <docs|site|custom>]"

--- a/configure-plugin/skills/configure-integration-tests/SKILL.md
+++ b/configure-plugin/skills/configure-integration-tests/SKILL.md
@@ -1,14 +1,8 @@
 ---
 created: 2025-12-16
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2025-12-16
-description: |
-  Check and configure integration testing for services, databases, and external
-  dependencies. Use when setting up integration testing with Supertest, pytest, or
-  Testcontainers, creating docker-compose.test.yml for local test service containers,
-  auditing integration test setup, adding integration test jobs to GitHub Actions,
-  or separating integration from unit tests. Natural triggers: "set up integration
-  tests", "add testcontainers", "configure supertest".
+description: Configure integration testing with Supertest, pytest, or Testcontainers. Use when setting up integration tests, creating docker-compose.test.yml, or separating integration from unit tests.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--framework <supertest|pytest|testcontainers>]"
 argument-hint: "[--check-only] [--fix] [--framework <supertest|pytest|testcontainers>]"

--- a/configure-plugin/skills/configure-justfile/SKILL.md
+++ b/configure-plugin/skills/configure-justfile/SKILL.md
@@ -2,12 +2,7 @@
 created: 2025-12-16
 modified: 2026-04-19
 reviewed: 2025-12-16
-description: |
-  Check and configure Justfile with standard recipes for project standards. Use when
-  setting up a new Justfile for a project, auditing an existing Justfile for missing
-  standard recipes, migrating from Makefile to Justfile, or ensuring Justfile follows
-  team conventions (groups, comments, settings). Natural triggers: "set up justfile",
-  "migrate makefile to justfile", "add just recipes".
+description: Check and configure Justfiles with standard recipes. Use when setting up a Justfile, auditing for missing recipes, or migrating from Makefile to Justfile.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"

--- a/configure-plugin/skills/configure-linting/SKILL.md
+++ b/configure-plugin/skills/configure-linting/SKILL.md
@@ -2,12 +2,7 @@
 created: 2025-12-16
 modified: 2026-04-19
 reviewed: 2025-12-16
-description: |
-  Check and configure modern linting tools (Biome, Ruff, Clippy) against best practices.
-  Use when setting up linting for a new project, migrating from ESLint/Prettier to Biome,
-  validating linter configuration, ensuring language-specific best practices, or
-  configuring pre-commit lint integration. Natural triggers: "set up linting",
-  "configure biome", "migrate to ruff", "add clippy".
+description: Check and configure modern linters (Biome, Ruff, Clippy). Use when setting up linting, migrating ESLint/Prettier to Biome, or wiring lint checks into pre-commit and CI.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--linter <biome|ruff|clippy>]"
 argument-hint: "[--check-only] [--fix] [--linter <biome|ruff|clippy>]"

--- a/configure-plugin/skills/configure-load-tests/SKILL.md
+++ b/configure-plugin/skills/configure-load-tests/SKILL.md
@@ -1,12 +1,8 @@
 ---
 created: 2025-12-16
-modified: 2026-04-29
+modified: 2026-05-09
 reviewed: 2026-04-29
-description: |
-  Check and configure load and performance testing with k6, Artillery, or Locust. Use when
-  setting up load testing infrastructure from scratch, auditing smoke/stress/spike/soak
-  coverage, adding CI/CD performance regression detection, migrating between load testing
-  frameworks, or when the user asks to configure k6, Artillery, or Locust.
+description: Configure load and performance testing with k6, Artillery, or Locust. Use when setting up load tests, auditing smoke/stress/spike/soak coverage, adding CI performance regression detection, or migrating between load testing frameworks.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--framework <k6|artillery|locust>]"
 argument-hint: "[--check-only] [--fix] [--framework <k6|artillery|locust>]"

--- a/configure-plugin/skills/configure-makefile/SKILL.md
+++ b/configure-plugin/skills/configure-makefile/SKILL.md
@@ -1,12 +1,8 @@
 ---
 created: 2025-12-16
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2025-12-16
-description: |
-  Check and configure Makefile with standard targets for project standards. Use when
-  setting up a new Makefile, auditing an existing Makefile for missing standard targets
-  (help, test, build, clean, lint), adding language-specific build/test/lint targets, or
-  when the user asks to create or standardize a Makefile.
+description: Configure Makefile with standard targets. Use when setting up a new Makefile, auditing for missing standard targets (help, test, build, clean, lint), or adding language-specific build/test/lint targets.
 allowed-tools: Glob, Grep, Read, Write, Edit, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"

--- a/configure-plugin/skills/configure-memory-profiling/SKILL.md
+++ b/configure-plugin/skills/configure-memory-profiling/SKILL.md
@@ -1,12 +1,8 @@
 ---
 created: 2025-12-16
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2025-12-16
-description: |
-  Check and configure memory profiling with pytest-memray for Python projects. Use when
-  setting up memory profiling from scratch, adding pytest-memray for CI memory regression
-  detection, configuring memory leak detection in test suites, setting memory thresholds
-  and allocation benchmarks, or when the user asks to profile Python memory usage.
+description: Configure memory profiling with pytest-memray for Python. Use when setting up memory profiling, adding CI memory regression detection, configuring leak detection in tests, or setting memory thresholds and allocation benchmarks.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--threshold <mb>] [--native]"
 argument-hint: "[--check-only] [--fix] [--threshold <mb>] [--native]"

--- a/configure-plugin/skills/configure-package-management/SKILL.md
+++ b/configure-plugin/skills/configure-package-management/SKILL.md
@@ -1,12 +1,8 @@
 ---
 created: 2025-12-16
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2025-12-16
-description: |
-  Check and configure modern package managers (uv for Python, bun for TypeScript). Use when
-  setting up a new project with uv or bun, migrating from legacy managers (pip, npm, yarn,
-  poetry, pipenv) to modern ones, auditing package manager configuration, or cleaning up
-  conflicting lock files from multiple managers.
+description: Configure modern package managers (uv for Python, bun for TypeScript). Use when setting up uv or bun, migrating from legacy managers (pip, npm, yarn, poetry, pipenv), or cleaning up conflicting lock files.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--manager <uv|bun|npm|cargo>]"
 argument-hint: "[--check-only] [--fix] [--manager <uv|bun|npm|cargo>]"

--- a/configure-plugin/skills/configure-pre-commit/SKILL.md
+++ b/configure-plugin/skills/configure-pre-commit/SKILL.md
@@ -1,12 +1,8 @@
 ---
 created: 2025-12-16
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2025-12-16
-description: |
-  Check and configure pre-commit hooks for project standards. Use when setting up or
-  validating pre-commit hooks, installing project-type-specific hooks (frontend,
-  infrastructure, python), migrating a project to the pre-commit framework, or updating
-  hook configurations for detected tools.
+description: Configure pre-commit hooks. Use when setting up or validating hooks, installing project-type-specific hooks (frontend, infrastructure, python), or migrating to the pre-commit framework.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--type <frontend|infrastructure|python>]"
 argument-hint: "[--check-only] [--fix] [--type <frontend|infrastructure|python>]"

--- a/configure-plugin/skills/configure-readme/SKILL.md
+++ b/configure-plugin/skills/configure-readme/SKILL.md
@@ -1,12 +1,8 @@
 ---
 created: 2025-12-17
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2026-02-08
-description: |
-  Check and configure README.md with logo, badges, features, tech stack, and project
-  structure. Use when creating a README for a new project, auditing an existing README for
-  missing sections, standardizing README format across projects, adding shields.io badges
-  or a project structure section, or when the user asks to generate or fix a README.
+description: Configure README.md with logo, badges, features, tech stack, and project structure. Use when creating a new README, auditing for missing sections, standardizing format across projects, or adding shields.io badges.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch
 args: "[--check-only] [--fix] [--style <minimal|standard|detailed>] [--badges <shields|custom>]"
 argument-hint: "[--check-only] [--fix] [--style <minimal|standard|detailed>] [--badges <shields|custom>]"

--- a/configure-plugin/skills/configure-release-please/SKILL.md
+++ b/configure-plugin/skills/configure-release-please/SKILL.md
@@ -1,12 +1,8 @@
 ---
 created: 2025-12-16
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2025-12-16
-description: |
-  Check and configure release-please workflow for project standards. Use when setting up
-  release-please for a new project, auditing an existing release-please configuration,
-  upgrading release-please-action, adding a new package to a monorepo release-please
-  config, or when the user asks to automate versioning and changelogs.
+description: Configure release-please workflows. Use when setting up release-please for a new project, auditing an existing config, upgrading release-please-action, or adding a new package to a monorepo release-please config.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"

--- a/configure-plugin/skills/configure-repo/SKILL.md
+++ b/configure-plugin/skills/configure-repo/SKILL.md
@@ -1,18 +1,12 @@
 ---
 name: configure-repo
-description: |
-  End-to-end repo config driver. Produces a working .claude/ directory
-  (settings.json with marketplace enrollment + permissions), a SessionStart
-  hook, and scripts/install_pkgs.sh — all staged for commit. Use when
-  onboarding any repo to Claude Code with the laurigates/claude-plugins
-  marketplace. Runs /configure:claude-plugins, /configure:web-session,
-  /health:check, and optionally prompts for migration offers (mypy→ty, etc.).
+description: End-to-end driver that produces a working .claude/ directory, SessionStart hook, and install_pkgs.sh, all staged for commit. Use when onboarding any repo to Claude Code with the laurigates/claude-plugins marketplace.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash(git add *), Bash(git status *), Bash(git diff *), Bash(find *), Bash(mkdir *), Bash(test *), AskUserQuestion, TodoWrite, SlashCommand
 args: "[--check-only] [--skip-health] [--skip-migrations]"
 argument-hint: "[--check-only] [--skip-health] [--skip-migrations]"
 created: 2026-04-14
 modified: 2026-04-14
-reviewed: 2026-05-06
+reviewed: 2026-05-09
 ---
 
 # /configure:repo

--- a/configure-plugin/skills/configure-reusable-workflows/SKILL.md
+++ b/configure-plugin/skills/configure-reusable-workflows/SKILL.md
@@ -2,12 +2,7 @@
 created: 2026-02-02
 modified: 2026-04-29
 reviewed: 2026-04-29
-description: |
-  Install reusable GitHub Actions workflows for security, quality, and accessibility
-  checks. Use when adding Claude-powered reusable workflows, installing pre-built workflow
-  callers from claude-plugins, automating OWASP/secret-scanning/code-smell detection in
-  CI, adding WCAG accessibility checks to PR pipelines, or bootstrapping a full suite of
-  Claude-powered CI checks.
+description: Install Claude-powered reusable GitHub Actions workflows for security, quality, and accessibility. Use when adding OWASP/secret/code-smell scans or WCAG checks to PR pipelines.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash(mkdir *), Bash(ls *), AskUserQuestion, TodoWrite
 args: "[--all] [--security] [--quality] [--a11y] [--list]"
 argument-hint: "[--all] [--security] [--quality] [--a11y] [--list]"

--- a/configure-plugin/skills/configure-security/SKILL.md
+++ b/configure-plugin/skills/configure-security/SKILL.md
@@ -1,12 +1,8 @@
 ---
 created: 2025-12-16
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2025-12-16
-description: |
-  Check and configure security scanning (dependency audits, SAST, secrets). Use when
-  setting up dependency auditing, SAST, or secret detection for a project, configuring
-  Dependabot, CodeQL, or TruffleHog in CI/CD, creating or updating a SECURITY.md policy,
-  or auditing which security tools are missing from a project.
+description: Configure security scanning — dependency audits, SAST, secrets. Use when setting up Dependabot, CodeQL, or TruffleHog in CI/CD, creating a SECURITY.md policy, or auditing missing security tools.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--type <dependencies|sast|secrets|all>]"
 argument-hint: "[--check-only] [--fix] [--type <dependencies|sast|secrets|all>]"

--- a/configure-plugin/skills/configure-select/SKILL.md
+++ b/configure-plugin/skills/configure-select/SKILL.md
@@ -1,12 +1,8 @@
 ---
 created: 2025-12-22
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2025-12-22
-description: |
-  Interactively select which infrastructure standards to configure. Use when the user
-  wants to set up selected components interactively, choose specific standards to
-  implement, customize configuration scope, or build infrastructure configuration
-  incrementally rather than running the full `/configure:all` pipeline.
+description: Interactively select which infrastructure standards to configure. Use when setting up selected components, customizing configuration scope, or building infrastructure incrementally rather than running the full `/configure:all` pipeline.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, SlashCommand
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"

--- a/configure-plugin/skills/configure-sentry/SKILL.md
+++ b/configure-plugin/skills/configure-sentry/SKILL.md
@@ -1,13 +1,8 @@
 ---
 created: 2025-12-16
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2025-12-16
-description: |
-  Check and configure Sentry error tracking for project standards. Use when setting up
-  Sentry for a new project, checking Sentry SDK installation and configuration compliance,
-  fixing hardcoded DSNs or missing env-var references, adding source map upload and
-  release tracking to CI/CD, or verifying Sentry config across frontend, Next.js, Node, or
-  Python projects.
+description: Check and configure Sentry error tracking. Use when installing the Sentry SDK, fixing hardcoded DSNs, or adding source map upload and release tracking for frontend, Next.js, Node, or Python.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--type <frontend|nextjs|python|node>]"
 argument-hint: "[--check-only] [--fix] [--type <frontend|nextjs|python|node>]"

--- a/configure-plugin/skills/configure-skaffold/SKILL.md
+++ b/configure-plugin/skills/configure-skaffold/SKILL.md
@@ -1,12 +1,8 @@
 ---
 created: 2025-12-16
-modified: 2026-04-29
+modified: 2026-05-09
 reviewed: 2026-04-29
-description: |
-  Check and configure Skaffold for project standards. Use when checking Skaffold
-  configuration compliance for a Kubernetes project, fixing port forwarding security
-  issues (0.0.0.0 binding), adding dotenvx hooks for secret generation, upgrading
-  Skaffold API version, or creating a standard skaffold.yaml from template.
+description: Configure Skaffold for Kubernetes projects. Use when fixing port forwarding security (0.0.0.0 binding), adding dotenvx hooks for secret generation, upgrading Skaffold API version, or creating skaffold.yaml from template.
 allowed-tools: Glob, Grep, Read, Write, Edit, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"

--- a/configure-plugin/skills/configure-status/SKILL.md
+++ b/configure-plugin/skills/configure-status/SKILL.md
@@ -1,12 +1,8 @@
 ---
 created: 2025-12-16
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2025-12-16
-description: |
-  Show infrastructure standards compliance status (read-only). Use when the user wants to
-  check overall compliance status, generate a compliance report, do a quick project
-  health check, validate CI/CD status, or review current configuration state without
-  making any changes.
+description: Show infrastructure standards compliance status (read-only). Use when checking overall compliance, generating a compliance report, doing a quick project health check, or reviewing current configuration without making changes.
 allowed-tools: Glob, Grep, Read, TodoWrite
 args: "[--verbose]"
 argument-hint: "[--verbose]"

--- a/configure-plugin/skills/configure-tests/SKILL.md
+++ b/configure-plugin/skills/configure-tests/SKILL.md
@@ -1,12 +1,8 @@
 ---
 created: 2025-12-16
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2025-12-16
-description: |
-  Check and configure testing frameworks and infrastructure. Use when setting up testing
-  infrastructure for a project, checking test framework configuration, migrating to
-  modern frameworks (Vitest, pytest, cargo-nextest), validating coverage configuration,
-  or when the user asks to configure Vitest, Jest, pytest, or nextest.
+description: Configure testing frameworks (Vitest, Jest, pytest, cargo-nextest). Use when setting up test infrastructure, migrating to a modern framework, or validating coverage configuration.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--framework <vitest|jest|pytest|nextest>]"
 argument-hint: "[--check-only] [--fix] [--framework <vitest|jest|pytest|nextest>]"

--- a/configure-plugin/skills/configure-ux-testing/SKILL.md
+++ b/configure-plugin/skills/configure-ux-testing/SKILL.md
@@ -1,13 +1,8 @@
 ---
 created: 2025-12-16
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2025-12-16
-description: |
-  Check and configure UX testing infrastructure (Playwright, accessibility, visual
-  regression). Use when setting up Playwright E2E testing, adding accessibility testing
-  with axe-core, configuring visual regression screenshot assertions, setting up
-  Playwright CLI or MCP for Claude browser automation, or creating CI/CD workflows for
-  E2E and accessibility tests.
+description: Configure UX testing — Playwright E2E, accessibility (axe-core), visual regression. Use when setting up E2E testing, configuring screenshot assertions, setting up Playwright CLI/MCP for browser automation, or adding E2E/a11y CI workflows.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--a11y] [--visual]"
 argument-hint: "[--check-only] [--fix] [--a11y] [--visual]"

--- a/configure-plugin/skills/configure-web-session/SKILL.md
+++ b/configure-plugin/skills/configure-web-session/SKILL.md
@@ -1,15 +1,11 @@
 ---
 name: configure-web-session
-description: |
-  Set up a SessionStart hook so Claude Code on the web installs project-specific
-  tools (helm, terraform, tflint, actionlint, gitleaks, just, etc.) at session
-  start. Use when pre-commit hooks, justfile recipes, or CI tools fail in remote
-  sessions because infrastructure tools are absent from the base image.
+description: Set up a SessionStart hook so Claude Code on the web installs project tools (helm, terraform, gitleaks, just). Use when pre-commit or CI tools fail in remote sessions due to missing binaries.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--tools <list>]"
 argument-hint: "[--check-only] [--fix] [--tools <list>]"
 created: 2026-02-25
-modified: 2026-02-25
+modified: 2026-05-09
 reviewed: 2026-02-25
 ---
 

--- a/configure-plugin/skills/configure-workflows/SKILL.md
+++ b/configure-plugin/skills/configure-workflows/SKILL.md
@@ -2,12 +2,7 @@
 created: 2025-12-16
 modified: 2026-04-29
 reviewed: 2026-04-29
-description: |
-  Check and configure GitHub Actions CI/CD workflows (container builds, tests, releases).
-  Use when checking GitHub Actions workflows for compliance, setting up container build,
-  test, or release-please workflows, updating outdated action versions (checkout,
-  build-push), adding multi-platform builds or GHA caching, or auditing which required
-  workflows are missing.
+description: Check and configure GitHub Actions CI/CD workflows for container builds, tests, and releases. Use when updating outdated action versions, adding multi-platform builds, or auditing required workflows.
 allowed-tools: Glob, Grep, Read, Write, Edit, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"

--- a/configure-plugin/skills/go-feature-flag/SKILL.md
+++ b/configure-plugin/skills/go-feature-flag/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: go-feature-flag
-description: |
-  GO Feature Flag (GOFF) self-hosted feature flag solution with OpenFeature
-  integration. Covers flag configuration, relay proxy, targeting rules, rollouts.
-  Use when user mentions GO Feature Flag, GOFF, gofeatureflag, self-hosted
-  feature flags, or flags.goff.yaml configuration.
+description: GO Feature Flag (GOFF) self-hosted feature flags with OpenFeature integration — config, relay proxy, targeting, rollouts. Use when working with GOFF or flags.goff.yaml.
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 ---

--- a/configure-plugin/skills/multi-repo-discipline/SKILL.md
+++ b/configure-plugin/skills/multi-repo-discipline/SKILL.md
@@ -1,17 +1,9 @@
 ---
 name: multi-repo-discipline
-description: |
-  Advisory rules for working in a multi-repository workspace — read-only
-  fixtures, upstream/downstream pairs, and authoritative repos that own
-  shared specs. Covers when cross-repo edits are allowed during agent
-  dispatch vs when commits in sibling repos require user confirmation.
-  Use when starting work in a parent directory that contains multiple
-  git repos, when dispatching agents that may touch sibling repos, when
-  updating a spec in an authoritative repo with downstream consumers,
-  or when a skill is about to edit a sibling's `CLAUDE.md` / `.claude/`.
+description: Advisory rules for multi-repo workspaces — read-only fixtures, upstream/downstream pairs, authoritative spec owners. Use when dispatching agents that may touch sibling repos or editing another repo's `.claude/`.
 allowed-tools: Bash(git rev-parse *), Bash(git status *), Bash(git branch *), Bash(git remote *), Bash(git log *), Read, Glob, Grep, TodoWrite
 created: 2026-04-24
-modified: 2026-04-24
+modified: 2026-05-09
 reviewed: 2026-04-24
 ---
 

--- a/configure-plugin/skills/openfeature/SKILL.md
+++ b/configure-plugin/skills/openfeature/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: openfeature
-description: |
-  OpenFeature vendor-agnostic feature flag SDK with standardized API across
-  languages. Covers SDK installation, flag evaluation, providers, and hooks.
-  Use when implementing feature flags, A/B testing, canary releases, or when
-  user mentions OpenFeature, feature toggles, or progressive rollouts.
+description: OpenFeature vendor-agnostic feature flag SDK — installation, flag evaluation, providers, hooks. Use when implementing feature flags, A/B testing, canary releases, or progressive rollouts.
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 ---

--- a/configure-plugin/skills/pre-commit-standards/SKILL.md
+++ b/configure-plugin/skills/pre-commit-standards/SKILL.md
@@ -3,10 +3,7 @@ created: 2025-12-16
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: pre-commit-standards
-description: |
-  Pre-commit hook standards and configuration. Use when configuring pre-commit hooks
-  in repositories, checking hook compliance, or when the user mentions pre-commit,
-  conventional commits, or hook configuration.
+description: Pre-commit hook standards and configuration. Use when configuring pre-commit hooks, checking hook compliance, or working with conventional commits.
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 ---

--- a/configure-plugin/skills/readme-standards/SKILL.md
+++ b/configure-plugin/skills/readme-standards/SKILL.md
@@ -3,9 +3,7 @@ created: 2025-12-17
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: readme-standards
-description: |
-  README.md templates and standards. Use when generating or improving README files,
-  checking README compliance, or when the user mentions README best practices or documentation.
+description: README.md templates and standards. Use when generating or improving README files, checking README compliance, or applying README best practices.
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 ---

--- a/configure-plugin/skills/release-please-standards/SKILL.md
+++ b/configure-plugin/skills/release-please-standards/SKILL.md
@@ -3,10 +3,7 @@ created: 2025-12-16
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: release-please-standards
-description: |
-  Release-please standards and configuration. Use when configuring release-please
-  workflows, checking release automation compliance, or when the user mentions
-  release-please, automated releases, or version management.
+description: Release-please standards and configuration. Use when configuring release-please workflows, checking release automation compliance, or working with automated releases and version bumps.
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 ---

--- a/configure-plugin/skills/skaffold-standards/SKILL.md
+++ b/configure-plugin/skills/skaffold-standards/SKILL.md
@@ -1,12 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: skaffold-standards
-description: |
-  Skaffold configuration standards for local Kubernetes development with OrbStack
-  and dotenvx. Use when configuring Skaffold, setting up local K8s development,
-  or when the user mentions Skaffold, local development, Kubernetes profiles, or dotenvx secrets.
+description: Skaffold standards for local Kubernetes development with OrbStack and dotenvx. Use when configuring Skaffold, setting up local K8s, Kubernetes profiles, or dotenvx secrets.
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 ---

--- a/container-plugin/skills/container-development/SKILL.md
+++ b/container-plugin/skills/container-development/SKILL.md
@@ -1,15 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: container-development
-description: |
-  Container development with Docker, Dockerfiles, 12-factor principles, multi-stage
-  builds, and Skaffold workflows. Enforces MANDATORY non-root users, minimal Alpine/slim
-  base images, and security hardening. Covers containerization, orchestration, and secure
-  image construction.
-  Use when user mentions Docker, Dockerfile, containers, docker-compose, multi-stage
-  builds, container images, container security, or 12-factor app principles.
+description: Container development with Docker, Dockerfiles, 12-factor, multi-stage builds, and Skaffold. Enforces non-root users, minimal Alpine/slim images, and security hardening. Use when mentioning Docker, Dockerfile, docker-compose, or container security.
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash, Edit, Write, TodoWrite, WebSearch, WebFetch
 ---

--- a/container-plugin/skills/deploy-handoff/SKILL.md
+++ b/container-plugin/skills/deploy-handoff/SKILL.md
@@ -1,17 +1,12 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 allowed-tools: Read, Bash(git *), mcp__github__get_pull_request, mcp__github__list_issues, TodoWrite
 args: "[resource-name] [deployment-type]"
 argument-hint: "[resource-name] [deployment-type]"
 disable-model-invocation: true
-description: |
-  Generate professional deployment handoff documentation for a deployed service or resource,
-  including service overview, technical stack, access URLs, configuration, monitoring, and a
-  developer checklist. Use when the user is handing off a deployed service to another
-  developer, documenting deployment details for a ticket, creating client-facing deployment
-  summaries, or generating access information for a new team member.
+description: "Generate deployment handoff docs for a deployed service: overview, tech stack, access URLs, configuration, monitoring, and developer checklist. Use when handing off a service, documenting deployment, or generating client-facing summaries."
 name: deploy-handoff
 ---
 

--- a/container-plugin/skills/deploy-release/SKILL.md
+++ b/container-plugin/skills/deploy-release/SKILL.md
@@ -6,10 +6,7 @@ allowed-tools: Read, Write, Edit, Bash(git *), Bash(gh release *), Bash(gh pr *)
 args: <version> [--draft] [--prerelease]
 argument-hint: <version> [--draft] [--prerelease]
 disable-model-invocation: true
-description: |
-  Create and publish releases using release-please automation or manual GitHub releases.
-  Use when the user wants to cut a release, create a version tag, publish a GitHub release,
-  or set up release-please manifest configuration.
+description: Create and publish releases via release-please automation or manual GitHub releases. Use when cutting a release, tagging a version, or setting up release-please manifest config.
 name: deploy-release
 ---
 

--- a/container-plugin/skills/go-containers/SKILL.md
+++ b/container-plugin/skills/go-containers/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2026-01-15
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: go-containers
-description: |
-  Go-specific container optimization patterns including static binary compilation,
-  scratch/distroless base images, CGO handling, and systematic optimization journey
-  from 846MB to 2.5MB (99.7% reduction). Covers ldflags, trimpath, and build flag
-  optimizations specific to Go applications.
-  Use when working with Go containers, Dockerfiles for Go apps, or optimizing Go image sizes.
+description: "Go container optimization: static binary compilation, scratch/distroless base images, CGO handling, ldflags, trimpath. Documented journey from 846MB to 2.5MB (99.7% reduction). Use when working with Go containers or optimizing Go image sizes."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write, TodoWrite, WebSearch, WebFetch
 ---

--- a/container-plugin/skills/nodejs-containers/SKILL.md
+++ b/container-plugin/skills/nodejs-containers/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2026-01-15
-modified: 2026-02-14
+modified: 2026-05-09
 reviewed: 2026-01-15
 name: nodejs-containers
-description: |
-  Node.js-specific container optimization patterns including Alpine variants,
-  multi-stage builds, node_modules caching, production dependency separation,
-  and optimization from ~900MB to ~50-100MB. Covers npm/yarn/pnpm patterns,
-  BuildKit cache mounts, and non-root user configuration.
-  Use when working with Node.js containers, Dockerfiles for Node apps, or optimizing Node image sizes.
+description: "Node.js container optimization: Alpine variants, multi-stage builds, node_modules caching, prod dep separation, BuildKit cache mounts. Reduces ~900MB to ~50-100MB. Use when working with Node.js containers or optimizing Node image sizes."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write, TodoWrite, WebSearch, WebFetch
 ---

--- a/container-plugin/skills/python-containers/SKILL.md
+++ b/container-plugin/skills/python-containers/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2026-01-15
-modified: 2026-02-14
+modified: 2026-05-09
 reviewed: 2026-01-15
 name: python-containers
-description: |
-  Python-specific container optimization patterns including slim base images (NOT Alpine),
-  virtual environment handling, multi-stage builds with pip/poetry/uv, and optimization
-  from ~1GB to ~80-120MB. Covers musl libc issues, wheel building, and Python-specific
-  dependency management patterns.
-  Use when working with Python containers, Dockerfiles for Python apps, or optimizing Python image sizes.
+description: "Python container optimization: slim images (NOT Alpine), virtualenv, multi-stage builds with pip/poetry/uv, musl libc gotchas, wheel building. Reduces ~1GB to ~80-120MB. Use when working with Python containers or optimizing image sizes."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write, TodoWrite, WebSearch, WebFetch
 ---

--- a/container-plugin/skills/skaffold-filesync/skill.md
+++ b/container-plugin/skills/skaffold-filesync/skill.md
@@ -1,13 +1,10 @@
 ---
 name: skaffold-filesync
-description: |
-  Fast iterative development with Skaffold file sync - copy changed files to running containers
-  without rebuilding images. Use when optimizing the development loop, configuring sync rules,
-  or when the user mentions file sync, hot reload, live reload, or fast iteration.
+description: Fast iterative development with Skaffold file sync — copy changed files to running containers without rebuilding images. Use when optimizing the dev loop, configuring sync rules, or when the user mentions file sync, hot reload, or fast iteration.
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2026-01-21
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 ---
 

--- a/container-plugin/skills/skaffold-orbstack/SKILL.md
+++ b/container-plugin/skills/skaffold-orbstack/SKILL.md
@@ -1,12 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: skaffold-orbstack
-description: |
-  OrbStack-optimized Skaffold workflows for local Kubernetes development without port-forward.
-  Use when configuring Skaffold with OrbStack, accessing services via LoadBalancer or Ingress,
-  or when the user mentions OrbStack, k8s.orb.local, service access, or eliminating port-forward.
+description: OrbStack-optimized Skaffold workflows for local Kubernetes dev without port-forward. Use when configuring Skaffold with OrbStack, accessing services via LoadBalancer or Ingress, or mentioning OrbStack, k8s.orb.local, or eliminating port-forward.
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/container-plugin/skills/skaffold-testing/skill.md
+++ b/container-plugin/skills/skaffold-testing/skill.md
@@ -1,13 +1,10 @@
 ---
 name: skaffold-testing
-description: |
-  Container image validation with Skaffold test and verify stages. Covers container-structure-tests
-  for image hygiene, custom tests for security scanning, and post-deployment verification.
-  Use when configuring pre-deploy tests, security scans, or integration tests in Skaffold pipelines.
+description: Container image validation with Skaffold test/verify stages. Covers container-structure-tests, custom security scanning, and post-deployment verification. Use when configuring pre-deploy tests, security scans, or integration tests in Skaffold.
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2025-12-23
-modified: 2026-02-14
+modified: 2026-05-09
 reviewed: 2025-12-23
 ---
 

--- a/css-plugin/skills/lightning-css/SKILL.md
+++ b/css-plugin/skills/lightning-css/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: Lightning CSS
-description: |
-  CSS transpilation, bundling, and minification using Lightning CSS (Rust-based).
-  Use when configuring CSS processing in Vite, replacing PostCSS/autoprefixer,
-  setting up browser targets, enabling CSS modules, or optimizing CSS for production.
+description: CSS transpilation, bundling, and minification with Lightning CSS (Rust-based). Use when configuring CSS in Vite, replacing PostCSS/autoprefixer, setting browser targets, or enabling CSS modules.
 user-invocable: false
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob, TodoWrite
 created: 2026-02-13

--- a/css-plugin/skills/unocss/SKILL.md
+++ b/css-plugin/skills/unocss/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: UnoCSS
-description: |
-  Atomic CSS engine for on-demand utility class generation using UnoCSS.
-  Use when setting up utility-first CSS, configuring UnoCSS presets (wind3/wind4, icons,
-  typography), integrating with Vite/frameworks, or generating optimized atomic stylesheets.
+description: Atomic CSS engine for on-demand utility class generation with UnoCSS. Use when setting up utility-first CSS, configuring UnoCSS presets (wind3/wind4, icons, typography), or integrating with Vite.
 user-invocable: false
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob, TodoWrite
 created: 2026-02-13

--- a/documentation-plugin/skills/claude-blog-sources/SKILL.md
+++ b/documentation-plugin/skills/claude-blog-sources/SKILL.md
@@ -3,10 +3,7 @@ created: 2025-12-16
 modified: 2026-02-27
 reviewed: 2026-02-09
 name: claude-blog-sources
-description: |
-  Access Claude Blog and official Claude Code documentation for latest improvements, usage patterns,
-  and best practices. Use when researching Claude Code features, CLAUDE.md optimization, memory
-  management, or staying current with Claude capabilities.
+description: Fetch Claude Blog and official Claude Code docs for latest features and best practices. Use when researching Claude Code capabilities, CLAUDE.md optimization, memory hierarchy, or @import patterns.
 user-invocable: false
 allowed-tools: WebFetch, WebSearch, Task
 agent: general-purpose

--- a/documentation-plugin/skills/docs-decommission/SKILL.md
+++ b/documentation-plugin/skills/docs-decommission/SKILL.md
@@ -1,17 +1,12 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 allowed-tools: Read, Write, Edit, Bash(find *), Bash(ls *), Grep, TodoWrite
 args: <service-name>
 argument-hint: <service-name>
 disable-model-invocation: true
-description: |
-  Generate comprehensive service decommission documentation covering infrastructure resources,
-  data management, access/security, DNS/networking, dependencies, monitoring cleanup, and
-  financial/administrative checklists. Use when the user is decommissioning or retiring a
-  service, planning to shut down infrastructure, archiving a deployed resource, or wants a
-  DECOMMISSION-<service>.md checklist created at deployment time while context is fresh.
+description: Generate service decommission docs covering infrastructure, data, access, DNS, dependencies, monitoring cleanup, and financial checklists. Use when decommissioning a service or wanting a DECOMMISSION-<service>.md created at deploy time.
 name: docs-decommission
 ---
 

--- a/documentation-plugin/skills/docs-generate/SKILL.md
+++ b/documentation-plugin/skills/docs-generate/SKILL.md
@@ -1,16 +1,11 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 allowed-tools: Task, TodoWrite
 args: "[--api] [--readme] [--changelog]"
 argument-hint: "[--api] [--readme] [--changelog]"
-description: |
-  Generate or update project documentation from code annotations, docstrings, type signatures,
-  and git history. Use when the user wants to generate API reference docs, update the README
-  from code analysis, produce a CHANGELOG from conventional commits, or mentions "generate
-  docs", "update documentation", "API reference", or "regenerate changelog". Delegates to the
-  documentation agent for multi-language extraction.
+description: Generate or update project docs from code annotations, docstrings, type signatures, and git history. Use when the user wants API reference docs, README from code, a CHANGELOG from conventional commits, or to regenerate docs.
 name: docs-generate
 agent: general-purpose
 ---

--- a/documentation-plugin/skills/docs-latex/SKILL.md
+++ b/documentation-plugin/skills/docs-latex/SKILL.md
@@ -1,15 +1,12 @@
 ---
 name: docs-latex
-description: |
-  Convert Markdown documents to professional LaTeX with TikZ visualizations and compile to PDF.
-  Use when the user wants to create a presentation-quality PDF from a Markdown document, generate
-  a professional report with diagrams, or convert documentation to print-ready format.
+description: Convert Markdown documents to professional LaTeX with TikZ visualizations and compile to PDF. Use when the user wants a presentation-quality PDF from Markdown, a professional report with diagrams, or print-ready documentation.
 args: <file> [--no-compile] [--visualizations] [--report-type=roadmap|lifecycle|general]
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 argument-hint: path/to/document.md
 disable-model-invocation: true
 created: 2026-02-08
-modified: 2026-03-01
+modified: 2026-05-09
 reviewed: 2026-02-08
 ---
 

--- a/documentation-plugin/skills/docs-sync/SKILL.md
+++ b/documentation-plugin/skills/docs-sync/SKILL.md
@@ -1,16 +1,10 @@
 ---
-description: |
-  Synchronize documentation with the actual skills, commands, and agents present in the
-  codebase by fixing count mismatches, adding missing entries, and removing stale
-  references. Use when the user wants to sync skill/command/agent catalogs after adding or
-  removing items, fix wrong counts in README/CLAUDE.md, detect stale entries referencing
-  removed items, or when they mention "docs out of sync", "update skill catalog", or
-  "regenerate command reference".
+description: Synchronize docs with the actual skills, commands, and agents in the codebase by fixing count mismatches, adding missing entries, and removing stale references. Use when docs are out of sync, updating skill catalog, or regenerating command reference.
 args: "[--scope <type>] [--dry-run] [--verbose]"
 argument-hint: "--scope skills|commands|agents, --dry-run to preview, --verbose for details"
 allowed-tools: Bash, Grep, Glob, Read, Edit, Write, TodoWrite
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: docs-sync
 ---

--- a/evaluate-plugin/skills/evaluate-improve/SKILL.md
+++ b/evaluate-plugin/skills/evaluate-improve/SKILL.md
@@ -1,17 +1,11 @@
 ---
 name: evaluate-improve
-description: |
-  Analyze skill evaluation results and suggest concrete improvements to SKILL.md instructions,
-  descriptions, examples, error handling, tool configuration, or structure. Use after running
-  evaluations when the user wants actionable recommendations for raising pass rates,
-  improving skill descriptions so they trigger correctly, iterating on a skill after
-  benchmarking, or when they mention "improve this skill", "fix skill triggering", or
-  "what should I change based on the eval results".
+description: Analyze skill evaluation results and suggest concrete improvements to SKILL.md content, descriptions, examples, or tool config. Use when raising pass rates after evaluations, fixing triggering, or iterating on a skill.
 args: <plugin/skill-name> [--apply] [--description-only]
 allowed-tools: Task, Read, Write, Edit, Glob, Grep, Bash(cat *), Bash(jq *), Bash(find *), Bash(diff *), AskUserQuestion, TodoWrite
 argument-hint: "git-plugin/git-commit [--apply]"
 created: 2026-03-04
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2026-03-04
 ---
 

--- a/evaluate-plugin/skills/evaluate-plugin-batch/SKILL.md
+++ b/evaluate-plugin/skills/evaluate-plugin-batch/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: evaluate-plugin-batch
-description: |
-  Batch evaluate all skills in a plugin. Runs /evaluate:skill for each skill
-  that has eval cases, then produces a plugin-level report. Use when auditing
-  an entire plugin's quality or before a release.
+description: Batch evaluate every skill in a plugin and produce a plugin-level report. Use when auditing an entire plugin's quality or validating before a release.
 args: <plugin-name> [--create-missing-evals] [--parallel N]
 allowed-tools: Task, Read, Write, Glob, Grep, Bash(bash *), SlashCommand, TodoWrite
 argument-hint: "git-plugin [--create-missing-evals]"

--- a/evaluate-plugin/skills/evaluate-report/SKILL.md
+++ b/evaluate-plugin/skills/evaluate-report/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: evaluate-report
-description: |
-  View evaluation results and benchmark reports. Use when you want to see
-  past eval results, compare benchmark runs, or review quality trends for
-  a skill or plugin.
+description: View evaluation results and benchmark reports for a skill or plugin. Use when reviewing past eval results, comparing benchmark runs, or tracking quality trends.
 args: <plugin/skill-name | plugin-name> [--latest] [--history] [--compare]
 allowed-tools: Read, Glob, Grep, Bash(cat *), Bash(jq *), Bash(find *), Bash(ls *), TodoWrite
 argument-hint: "git-plugin/git-commit [--latest] | git-plugin [--history]"

--- a/evaluate-plugin/skills/evaluate-skill/SKILL.md
+++ b/evaluate-plugin/skills/evaluate-skill/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: evaluate-skill
-description: |
-  Evaluate a skill's effectiveness by running test cases and grading results.
-  Use when you want to test whether a skill produces correct guidance, validate
-  skill improvements, or benchmark a skill before release.
+description: Evaluate a skill's effectiveness by running test cases and grading results. Use when testing whether a skill produces correct guidance, validating improvements, or benchmarking before release.
 args: <plugin/skill-name> [--create-evals] [--runs N] [--baseline]
 allowed-tools: Task, Read, Write, Edit, Glob, Grep, Bash(bash *), TodoWrite
 argument-hint: "git-plugin/git-commit [--create-evals] [--runs 3] [--baseline]"

--- a/feedback-plugin/skills/feedback-session/SKILL.md
+++ b/feedback-plugin/skills/feedback-session/SKILL.md
@@ -1,18 +1,13 @@
 ---
 name: feedback-session
-description: |
-  Analyze current session for skill feedback and create GitHub issues. Use when
-  a skill gave wrong guidance, a command failed due to skill advice, you discovered
-  a better pattern, or a skill worked particularly well. Creates labeled issues
-  for tracking. Supports targeting a different repo (e.g. the plugin source repo)
-  with --target-repo.
+description: Analyze current session for skill feedback and create GitHub issues. Use when a skill gave wrong guidance, a command failed due to skill advice, you found a better pattern, or a skill worked well. Supports --target-repo for the plugin source repo.
 args: "[--dry-run] [--bugs-only] [--enhancements-only] [--positive-only] [--target-repo <owner/repo>] [plugin-name]"
 allowed-tools: Bash(gh issue *), Bash(gh label *), Bash(gh search *), Bash(git status *), Bash(git remote *), Read, Grep, Glob, AskUserQuestion, TodoWrite
 model: opus
 argument-hint: "--dry-run | --target-repo owner/repo | plugin-name"
 disable-model-invocation: true
 created: 2026-02-18
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-25
 ---
 

--- a/finops-plugin/skills/github-actions-cache-optimization/skill.md
+++ b/finops-plugin/skills/github-actions-cache-optimization/skill.md
@@ -1,9 +1,6 @@
 ---
 name: github-actions-cache-optimization
-description: |
-  Analyze and optimize GitHub Actions cache usage. Use when investigating
-  cache bloat, identifying stale caches, optimizing cache keys, or comparing
-  cache usage across repositories.
+description: Analyze and optimize GitHub Actions cache usage. Use when investigating cache bloat, identifying stale caches, optimizing cache keys, or comparing cache usage across repos.
 user-invocable: false
 allowed-tools: Bash(gh api *), Bash(gh repo *), Bash(gh cache *), Read, Grep, Glob, TodoWrite
 created: 2025-01-30

--- a/finops-plugin/skills/github-actions-finops/skill.md
+++ b/finops-plugin/skills/github-actions-finops/skill.md
@@ -1,10 +1,6 @@
 ---
 name: github-actions-finops
-description: |
-  Analyze GitHub Actions billing, workflow efficiency, and waste patterns.
-  Use when investigating CI/CD costs, identifying wasted runs, or optimizing
-  workflow triggers. Covers org-level billing, per-repo workflow analysis,
-  and waste pattern detection.
+description: Analyze GitHub Actions billing, workflow efficiency, and waste patterns at org or repo level. Use when investigating CI/CD costs, identifying wasted runs, or optimizing workflow triggers.
 user-invocable: false
 allowed-tools: Bash(gh api *), Bash(gh repo *), Bash(gh workflow *), Bash(gh run *), Read, Grep, Glob, TodoWrite
 created: 2025-01-30

--- a/git-plugin/skills/gh-cli-agentic/skill.md
+++ b/git-plugin/skills/gh-cli-agentic/skill.md
@@ -1,15 +1,10 @@
 ---
 name: gh-cli-agentic
-description: |
-  GitHub CLI commands optimized for AI agent workflows with JSON output and
-  deterministic execution patterns. Use when the user asks to query PRs,
-  issues, workflow runs, or repo metadata with gh, inspect PR checks or
-  mergeable status, fetch failed CI logs, work with sub-issues, or resolve
-  a github.com URL into an API call.
+description: gh CLI commands with JSON output for agent workflows. Use when querying PRs, issues, workflow runs, or repo metadata; inspecting PR checks; fetching failed CI logs; or resolving a github.com URL to an API call.
 user-invocable: false
 allowed-tools: Bash(gh pr *), Bash(gh run *), Bash(gh issue *), Bash(gh repo *), Bash(gh workflow *), Bash(gh api *), Read
 created: 2025-01-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 ---
 

--- a/git-plugin/skills/gh-workflow-monitoring/skill.md
+++ b/git-plugin/skills/gh-workflow-monitoring/skill.md
@@ -1,15 +1,10 @@
 ---
 name: gh-workflow-monitoring
-description: |
-  Monitor GitHub Actions workflow runs with blocking watch commands instead
-  of polling loops or timeouts. Use when the user wants to watch a workflow
-  run until it completes, wait for CI after a push, trigger a workflow and
-  follow its progress, diagnose a failed run with `gh run view --log-failed`,
-  or find the latest in-progress runs.
+description: Monitor GitHub Actions runs with blocking watch commands instead of polling loops. Use when waiting for CI after push, following a workflow to completion, or diagnosing failed runs with --log-failed.
 user-invocable: false
 allowed-tools: Bash(gh run *), Bash(gh workflow *), Bash(gh pr *), Read
 created: 2025-01-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 ---
 

--- a/git-plugin/skills/git-branch-naming/SKILL.md
+++ b/git-plugin/skills/git-branch-naming/SKILL.md
@@ -1,13 +1,10 @@
 ---
 name: git-branch-naming
-description: |
-  Git branch naming conventions for consistent, traceable branches. Use when creating
-  new branches, discussing branch naming standards, or setting up repository conventions.
-  Covers type prefixes (feat, fix, chore), issue linking, and kebab-case formatting.
+description: Git branch naming conventions — type prefixes (feat/fix/chore), issue linking, kebab-case. Use when creating branches or setting up repo conventions.
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 created: 2026-01-30
-modified: 2026-01-30
+modified: 2026-05-09
 reviewed: 2026-01-30
 ---
 

--- a/git-plugin/skills/git-branch-pr-workflow/SKILL.md
+++ b/git-plugin/skills/git-branch-pr-workflow/SKILL.md
@@ -1,15 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: git-branch-pr-workflow
-description: |
-  Branch management, pull request workflows, and GitHub integration. Main-branch
-  development pattern (push main to remote feature branches), modern Git commands
-  (switch, restore), and GitHub MCP tools. Use when user mentions creating branches,
-  opening PRs, git switch, git restore, feature branches, pull requests, or GitHub
-  PR workflows. For naming conventions see git-branch-naming, for rebase patterns
-  see git-rebase-patterns.
+description: Branch management and PR workflows — main-branch dev pattern, git switch/restore, GitHub MCP. Use when creating branches, opening PRs, or working with feature branches. For naming see git-branch-naming, for rebase see git-rebase-patterns.
 user-invocable: false
 allowed-tools: Bash, Read, mcp__github__create_pull_request, mcp__github__list_pull_requests, mcp__github__update_pull_request
 ---

--- a/git-plugin/skills/git-cli-agentic/skill.md
+++ b/git-plugin/skills/git-cli-agentic/skill.md
@@ -1,15 +1,10 @@
 ---
 name: git-cli-agentic
-description: |
-  Git commands optimized for AI agent workflows with porcelain output and
-  deterministic, machine-readable formats. Use when the user asks for
-  scriptable git status/diff/log commands, needs porcelain=v2 output,
-  --numstat-based diff counts, custom --format placeholders in git log,
-  branch tracking info, or main-branch-development push patterns.
+description: Git commands with porcelain and machine-readable output for agent workflows. Use when scripting status/diff/log, porcelain=v2, --numstat counts, custom --format placeholders, or branch tracking info.
 user-invocable: false
 allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git branch *), Bash(git remote *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git restore *), Read
 created: 2025-01-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 ---
 

--- a/git-plugin/skills/git-commit-push-pr/SKILL.md
+++ b/git-plugin/skills/git-commit-push-pr/SKILL.md
@@ -1,17 +1,13 @@
 ---
 name: git-commit-push-pr
 created: 2025-12-16
-modified: 2026-04-29
+modified: 2026-05-09
 reviewed: 2026-04-29
 allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git branch *), Bash(git remote *), Bash(gh pr *), Bash(gh label *), Bash(gh repo *), Bash(gh issue *), Bash(pre-commit *), Bash(find *), Read, Edit, Grep, Glob, TodoWrite, mcp__github__create_pull_request, mcp__github__list_issues, mcp__github__get_issue
 args: "[remote-branch] [--push] [--direct] [--pr] [--draft] [--issue <num>] [--no-commit] [--range <start>..<end>] [--skip-issue-detection]"
 argument-hint: "[remote-branch] [--push] [--direct] [--pr] [--draft] [--issue <num>] [--no-commit] [--range <start>..<end>] [--skip-issue-detection]"
 disable-model-invocation: true
-description: |
-  Complete workflow from changes to PR - auto-detect related issues, create logical commits
-  with proper issue linkage, push to remote feature branch, and create pull request.
-  Use when user says "create pr", "let's pr", "commit and pr", "push and create pr",
-  or wants to go from uncommitted changes to an open pull request in one step.
+description: End-to-end workflow from uncommitted changes to open PR — detects issues, creates logical commits, pushes, and opens the PR. Use when the user says "create pr", "commit and pr", or "push and pr".
 ---
 
 ## When to Use This Skill

--- a/git-plugin/skills/git-commit-trailers/SKILL.md
+++ b/git-plugin/skills/git-commit-trailers/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2026-03-05
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: git-commit-trailers
-description: |
-  Git commit trailer conventions and patterns. Use when composing commit messages
-  that need BREAKING CHANGE, Release-As, Co-authored-by, Signed-off-by, or other
-  trailer lines. Covers release-please trailers for version control, attribution
-  trailers, and git interpret-trailers for parsing and adding trailers programmatically.
+description: Git commit trailer conventions — BREAKING CHANGE, Release-As, Co-authored-by, Signed-off-by. Use when composing commit messages with trailers or parsing them via git interpret-trailers.
 user-invocable: false
 allowed-tools: Bash(git interpret-trailers *), Bash(git log *), Bash(git config *), Read, Grep, Glob
 ---

--- a/git-plugin/skills/git-commit-workflow/SKILL.md
+++ b/git-plugin/skills/git-commit-workflow/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: git-commit-workflow
-description: |
-  Commit message conventions, staging practices, and commit best practices.
-  Covers conventional commits, explicit staging workflow, logical change grouping,
-  humble fact-based communication style, and automatic issue detection.
-  Use when user mentions committing changes, writing commit messages, git add,
-  git commit, staging files, or conventional commit format.
+description: Commit message conventions, staging practices, and conventional commit format. Use when writing commit messages, staging files, grouping logical changes, or auto-detecting linked issues.
 user-invocable: false
 allowed-tools: Bash, Read
 ---

--- a/git-plugin/skills/git-commit/skill.md
+++ b/git-plugin/skills/git-commit/skill.md
@@ -1,13 +1,9 @@
 ---
 created: 2026-01-21
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: git-commit
-description: |
-  Create commits with conventional messages and issue references. Handles staging,
-  pre-commit hooks, and automatic issue detection. Use when user says "commit",
-  "commit locally", "save changes", "stage and commit", or similar. This skill
-  creates local commits only - see git-push for remote operations.
+description: Create commits with conventional messages and issue references. Use when user says "commit", "save changes", or "stage and commit". Local commits only — see git-push for remote.
 user-invocable: false
 allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git restore *), Bash(pre-commit *), Bash(gh issue *), Read, Grep, Glob, TodoWrite
 ---

--- a/git-plugin/skills/git-coworker-check/SKILL.md
+++ b/git-plugin/skills/git-coworker-check/SKILL.md
@@ -1,15 +1,11 @@
 ---
 name: git-coworker-check
-description: |
-  Detect whether another Claude agent is working in the same repo clone before
-  running destructive git operations (stash, reset, checkout --). Use when
-  starting a session in a non-worktree checkout, or before any "clean up the
-  working tree" action that could wipe a coworker's in-flight changes.
+description: Detect another Claude agent working in the same repo clone before destructive git ops (stash, reset, checkout --). Use when starting a session in a non-worktree checkout or before any working-tree cleanup that could wipe a coworker's changes.
 args: "[--check | --claim | --release]"
 argument-hint: "[--claim | --release | --check (default)]"
 allowed-tools: Bash(bash *), Bash(git status *), Bash(git stash *), Bash(git rev-parse *), Read, TodoWrite
 created: 2026-04-21
-modified: 2026-04-21
+modified: 2026-05-09
 reviewed: 2026-04-21
 ---
 

--- a/git-plugin/skills/git-derive-docs/SKILL.md
+++ b/git-plugin/skills/git-derive-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-01-24
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 allowed-tools: Bash(git log *), Bash(git shortlog *), Bash(git diff *), Bash(git branch *),
                Bash(git show *), Bash(git rev-list *), Bash(git diff-tree *),
@@ -8,12 +8,7 @@ allowed-tools: Bash(git log *), Bash(git shortlog *), Bash(git diff *), Bash(git
 args: "[--rules] [--prd] [--adr] [--prp] [--all] [--since=<date>] [--depth=<N>]"
 argument-hint: "[--rules] [--prd] [--adr] [--prp] [--all] [--since=<date>] [--depth=<N>]"
 disable-model-invocation: true
-description: |
-  Analyze git commit history to derive undocumented rules, PRDs, ADRs, and
-  PRPs. Use when the user asks to find documentation gaps, detect
-  architectural decisions that were never recorded, derive coding conventions
-  from commit patterns, or generate skeleton rules/PRDs/ADRs/PRPs from
-  existing git history.
+description: Derive undocumented rules, PRDs, ADRs, and PRPs from git commit history. Use when finding doc gaps, detecting unrecorded architectural decisions, deriving conventions from commit patterns, or generating skeleton docs.
 name: git-derive-docs
 ---
 

--- a/git-plugin/skills/git-fork-workflow/SKILL.md
+++ b/git-plugin/skills/git-fork-workflow/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2026-03-02
-modified: 2026-03-02
+modified: 2026-05-09
 reviewed: 2026-03-02
 name: git-fork-workflow
-description: |
-  Fork management and upstream synchronization. Use when working with forked
-  repositories, syncing fork with upstream, managing divergence between fork
-  and upstream, or preparing commits for upstream contribution. Covers remote
-  architecture, divergence detection, sync strategies, and cross-fork PRs.
-  For creating upstream PRs, see git-upstream-pr.
+description: Fork management and upstream synchronization. Use when working with forks, syncing with upstream, detecting divergence, or preparing commits for upstream contribution. For creating upstream PRs, see git-upstream-pr.
 allowed-tools: Bash(git remote *), Bash(git fetch *), Bash(git log *), Bash(git status *), Bash(git diff *), Bash(git rev-list *), Bash(gh repo *), Read, Grep, Glob
 ---
 

--- a/git-plugin/skills/git-issue-hierarchy/SKILL.md
+++ b/git-plugin/skills/git-issue-hierarchy/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2026-03-19
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: git-issue-hierarchy
-description: |
-  Manage sub-issues and native GitHub dependency relationships (blocked_by /
-  blocking) between issues. Use when breaking issues into sub-tasks, checking
-  sub-issue completion progress, marking one issue as blocked by another, or
-  viewing a dependency graph before starting work.
+description: Manage sub-issues and GitHub dependency relationships (blocked_by/blocking). Use when breaking issues into sub-tasks, checking sub-issue progress, marking one issue blocked by another, or viewing a dependency graph before starting work.
 args: "<parent-issue> [--add <N...>] [--remove <N...>] [--create \"title\"] [--status] [--deps] [--blocking] [--block <N>] [--blocked-by <N>] [--unblock <N>]"
 argument-hint: <parent-issue> [--add N] [--status] [--deps] [--blocked-by N]
 user-invocable: true

--- a/git-plugin/skills/git-issue/SKILL.md
+++ b/git-plugin/skills/git-issue/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-23
+modified: 2026-05-09
 reviewed: 2026-04-21
 allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git switch *), Bash(git pull *), Bash(git stash *), Bash(gh issue *), Bash(gh pr *), Bash(gh repo *), Bash(gh label *), Bash(gh api *), Bash(pre-commit *), Read, Edit, Write, Grep, Glob, TodoWrite, AskUserQuestion, Task, mcp__github__create_pull_request, mcp__github__issue_read, mcp__github__list_issues
-description: |
-  Process GitHub issues end-to-end with TDD, interactive selection, conflict
-  detection, and parallel work support. Use when the user asks to work on an
-  issue, fix issue #N, pick issues to tackle, batch-process several issues
-  in parallel, or spin up PRs from a prioritized issue list.
+description: Process GitHub issues end-to-end with TDD, interactive selection, conflict detection, and parallel work. Use when user asks to work on an issue, fix issue #N, pick issues to tackle, or batch-process several in parallel.
 args: "[issue-numbers...] [--auto] [--filter <label>] [--limit <n>] [--parallel]"
 argument-hint: "[issue-numbers...] [--auto] [--filter <label>] [--limit <n>] [--parallel]"
 disable-model-invocation: true

--- a/git-plugin/skills/git-maintain/SKILL.md
+++ b/git-plugin/skills/git-maintain/SKILL.md
@@ -1,16 +1,12 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 allowed-tools: Bash(git status *), Bash(git branch *), Bash(git stash *), Bash(git prune *), Bash(git gc *), Bash(git repack *), Bash(git fsck *), Bash(git rm *), Bash(du *), Read, Glob, TodoWrite
 args: "[--prune] [--gc] [--verify] [--branches] [--stash] [--all]"
 argument-hint: "[--prune] [--gc] [--verify] [--branches] [--stash] [--all]"
 disable-model-invocation: true
-description: |
-  Perform repository maintenance and cleanup - garbage collection, branch
-  pruning, stash cleanup, and integrity verification. Use when the user asks
-  to clean up the repo, run git gc, delete merged branches, prune old
-  stashes, verify repo integrity with git fsck, or shrink the .git directory.
+description: Repository maintenance and cleanup — gc, branch pruning, stash cleanup, integrity verification. Use when user asks to clean up the repo, run git gc, delete merged branches, prune stashes, run git fsck, or shrink .git.
 name: git-maintain
 ---
 

--- a/git-plugin/skills/git-pr-feedback/SKILL.md
+++ b/git-plugin/skills/git-pr-feedback/SKILL.md
@@ -1,17 +1,12 @@
 ---
 created: 2026-01-30
-modified: 2026-05-06
+modified: 2026-05-09
 reviewed: 2026-05-06
 allowed-tools: Bash(gh pr checks *), Bash(gh pr view *), Bash(gh pr diff *), Bash(gh run view *), Bash(gh run list *), Bash(gh api *), Bash(gh repo view *), Bash(gh issue create *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git switch *), Bash(git pull *), Bash(git fetch *), Bash(pre-commit *), Bash(npm run *), Bash(uv run *), Bash(bash *), Read, Edit, Write, Grep, Glob, TodoWrite, Task, mcp__github__pull_request_read, mcp__github__add_reply_to_pull_request_comment, mcp__github__resolve_review_thread, mcp__github__pull_request_review_write, mcp__github__issue_write
 args: "[pr-number] [--commit] [--push] [--all] [--dry-run] [--limit N]"
 argument-hint: "[pr-number | --all] [--commit] [--push] [--dry-run] [--limit N]"
 disable-model-invocation: true
-description: |
-  Review PR workflow results and reviewer comments, then address substantive
-  feedback and suggestions. Use when the user asks to address PR review
-  comments, apply reviewer suggestions, reply to review threads, resolve
-  reviewer feedback after CHANGES_REQUESTED, or work through a list of
-  unresolved review threads on a pull request.
+description: Address PR review comments, apply reviewer suggestions, and resolve threads. Use when CHANGES_REQUESTED is set, when working through unresolved review threads, or when replying to reviewer feedback.
 name: git-pr-feedback
 agent: general-purpose
 ---

--- a/git-plugin/skills/git-pr/skill.md
+++ b/git-plugin/skills/git-pr/skill.md
@@ -1,13 +1,9 @@
 ---
 created: 2026-01-21
-modified: 2026-04-29
+modified: 2026-05-09
 reviewed: 2026-04-29
 name: git-pr
-description: |
-  Create pull requests with proper descriptions, labels, and issue references. Handles
-  draft mode, reviewers, and base branch selection. Use when user says "create PR",
-  "open pull request", "submit for review", or similar. This skill creates PRs from
-  pushed branches - see git-commit for commits and git-push for pushing.
+description: Create pull requests with descriptions, labels, and issue references. Use when user says "create PR", "open pull request", or "submit for review". Creates PRs from pushed branches — see git-commit for commits and git-push for pushing.
 user-invocable: false
 allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git branch *), Bash(git remote *), Bash(git push *), Bash(git fetch *), Bash(git rev-list *), Bash(gh pr *), Bash(gh issue *), Bash(gh repo *), Read, Grep, Glob, TodoWrite
 ---

--- a/git-plugin/skills/git-push/skill.md
+++ b/git-plugin/skills/git-push/skill.md
@@ -1,13 +1,9 @@
 ---
 created: 2026-01-21
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: git-push
-description: |
-  Push local commits to remote repositories. Handles branch tracking, upstream setup,
-  and safe push patterns. Use when user says "push", "push changes", "send to remote",
-  "update remote", or similar. This skill pushes existing commits - see git-commit for
-  creating commits and git-pr for pull request creation.
+description: Push local commits to remote — handles branch tracking, upstream setup, safe push patterns. Use when user says "push", "send to remote", or "update remote". Pushes existing commits — see git-commit for commits and git-pr for PR creation.
 user-invocable: false
 allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git push *), Bash(git branch *), Bash(git remote *), Bash(git rev-list *), Bash(git fetch *), Read, Grep, Glob, TodoWrite
 ---

--- a/git-plugin/skills/git-rebase-patterns/SKILL.md
+++ b/git-plugin/skills/git-rebase-patterns/SKILL.md
@@ -1,14 +1,10 @@
 ---
 name: git-rebase-patterns
-description: |
-  Advanced git rebase patterns for linear history, stacked PRs, and clean commit management.
-  Use when rebasing branches, cleaning up commit history, managing PR stacks, or converting
-  merge-heavy branches to linear history. Covers --reapply-cherry-picks, --update-refs, --onto,
-  and interactive rebase workflows.
+description: Advanced git rebase patterns for linear history, stacked PRs, and commit management. Use when rebasing branches, cleaning history, managing PR stacks, or converting merge-heavy branches. Covers --reapply-cherry-picks, --update-refs, --onto.
 user-invocable: false
 allowed-tools: Bash, Read
 created: 2026-01-30
-modified: 2026-01-30
+modified: 2026-05-09
 reviewed: 2026-01-30
 ---
 

--- a/git-plugin/skills/git-security-checks/SKILL.md
+++ b/git-plugin/skills/git-security-checks/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: git-security-checks
-description: |
-  Pre-commit security validation and secret detection. Runs gitleaks scan
-  and validates configuration, integrates with pre-commit hooks to prevent
-  credential leaks.
-  Use when user mentions scanning for secrets, gitleaks, secret detection,
-  credential scanning, pre-commit security, or .gitleaks.toml.
+description: Pre-commit security validation and secret detection via gitleaks. Use when user mentions scanning for secrets, gitleaks, secret/credential detection, pre-commit security, or .gitleaks.toml.
 user-invocable: false
 allowed-tools: Bash, Read
 ---

--- a/git-plugin/skills/git-triage/SKILL.md
+++ b/git-plugin/skills/git-triage/SKILL.md
@@ -1,18 +1,11 @@
 ---
 name: git-triage
-description: |
-  Triage open GitHub issues and PRs in one sweep. Scans the codebase and merged PRs for
-  evidence of issue completion, evaluates PR CI state, merge readiness, and review
-  decision, flags stale items, and cross-links issues to the PRs that resolve them.
-  Recommends actions by default; only closes or merges with explicit --auto-close or
-  --auto-merge flags. Use for periodic backlog grooming, pre-release cleanup, post-burst
-  queue reduction, or when the user asks to "triage issues", "triage PRs", "groom the
-  backlog", or "check what's open on this repo".
+description: Triage open GitHub issues and PRs in one sweep — cross-link, flag stale items, recommend actions. Use when grooming the backlog, doing pre-release cleanup, or when the user asks to "triage issues/PRs".
 args: "[--type issues|prs|both] [--batch N] [--repo owner/name] [--days-stale-issue N] [--days-stale-pr N] [--auto-close] [--auto-merge] [--oldest-first]"
 argument-hint: "--type both --batch 10 (defaults: days-stale-issue=90, days-stale-pr=30, current repo)"
 allowed-tools: Bash(gh issue *), Bash(gh pr *), Bash(gh api *), Bash(gh repo *), Bash(git log *), Bash(rg *), Read, Grep, Glob, AskUserQuestion, TodoWrite
 created: 2026-04-22
-modified: 2026-04-22
+modified: 2026-05-09
 reviewed: 2026-04-22
 ---
 

--- a/git-plugin/skills/git-upstream-pr/SKILL.md
+++ b/git-plugin/skills/git-upstream-pr/SKILL.md
@@ -1,16 +1,12 @@
 ---
 name: git-upstream-pr
-description: |
-  Submit clean PRs to upstream repositories from a fork. Use when you need to
-  contribute changes back to the original repo, cherry-pick fork commits for
-  upstream, or create cross-fork pull requests. Handles branch creation from
-  upstream/main, commit selection, squashing, and cross-fork PR creation.
+description: Submit clean PRs to upstream repos from a fork — branch from upstream/main, commit selection, squashing, cross-fork PR creation. Use when contributing changes back upstream, cherry-picking fork commits, or creating cross-fork pull requests.
 args: "[--commits sha1,sha2] [--branch name] [--upstream owner/repo] [--draft] [--dry-run]"
 allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git remote *), Bash(git fetch *), Bash(git switch *), Bash(git cherry-pick *), Bash(git reset *), Bash(git commit *), Bash(git push *), Bash(git stash *), Bash(git rev-list *), Bash(git rev-parse *), Bash(git branch *), Bash(gh pr *), Bash(gh repo *), Bash(gh auth *), AskUserQuestion, Read, Grep, Glob, TodoWrite
 argument-hint: --commits abc123,def456 or --branch feat/my-upstream-pr
 disable-model-invocation: true
 created: 2026-03-02
-modified: 2026-03-02
+modified: 2026-05-09
 reviewed: 2026-03-02
 ---
 

--- a/git-plugin/skills/github-issue-autodetect/skill.md
+++ b/git-plugin/skills/github-issue-autodetect/skill.md
@@ -1,13 +1,9 @@
 ---
 created: 2026-01-15
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: github-issue-autodetect
-description: |
-  Automatically detect GitHub issues that staged changes may fix or close.
-  Analyzes diffs, file paths, and issue metadata to suggest appropriate
-  closing keywords (Fixes, Closes, Resolves) for commit messages.
-  Use when committing changes to ensure proper issue linkage.
+description: Auto-detect GitHub issues that staged changes may fix or close. Analyzes diffs, paths, and issue metadata to suggest closing keywords (Fixes/Closes/Resolves) for commit messages. Use when committing to ensure proper issue linkage.
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob, mcp__github__list_issues, mcp__github__get_issue
 ---

--- a/git-plugin/skills/github-labels/SKILL.md
+++ b/git-plugin/skills/github-labels/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-01
+modified: 2026-05-09
 reviewed: 2026-04-01
 name: github-labels
-description: |
-  Discover and apply labels to GitHub PRs and issues using the gh CLI. Use when
-  you need to list available labels, add or remove labels on pull requests or issues,
-  or create new labels for a repository. Trigger phrases: "label this PR", "add
-  labels to issue", "what labels are available", "create a new label".
+description: Discover and apply labels to GitHub PRs and issues via gh CLI. Use when user says "label this PR", "add labels to issue", "what labels are available", or "create a new label".
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/git-plugin/skills/release-please-configuration/SKILL.md
+++ b/git-plugin/skills/release-please-configuration/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-28
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: release-please-configuration
-description: |
-  Configures release-please for monorepos and single-package repos. Handles
-  manifest files, component tagging, changelog sections, and extra-files setup.
-  Use when setting up automated releases, fixing release workflow issues, or
-  configuring version bump automation.
+description: Configure release-please for monorepos and single-package repos — manifests, component tagging, changelog sections, extra-files. Use when setting up automated releases, fixing release workflow issues, or configuring version bump automation.
 user-invocable: false
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, TodoWrite
 ---

--- a/git-plugin/skills/release-please-pr-workflow/skill.md
+++ b/git-plugin/skills/release-please-pr-workflow/skill.md
@@ -1,13 +1,9 @@
 ---
 created: 2026-01-09
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: release-please-pr-workflow
-description: |
-  Manages release-please PR merging workflow for monorepos. Handles batch merging,
-  conflict resolution through PR closure/recreation, and iterative processing until
-  all PRs are merged. Use when merging release PRs, handling PR conflicts, or
-  managing release automation in monorepos.
+description: Manage release-please PR merging for monorepos — batch merging, conflict resolution via PR closure/recreation, iterative processing. Use when merging release PRs, handling PR conflicts, or managing release automation in monorepos.
 user-invocable: false
 allowed-tools: Bash, Read, TodoWrite
 ---

--- a/git-plugin/skills/release-please-protection/SKILL.md
+++ b/git-plugin/skills/release-please-protection/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: release-please-protection
-description: |
-  Detects and prevents manual edits to release-please managed files (CHANGELOG.md,
-  version fields in package.json, pyproject.toml, Cargo.toml). Provides conventional
-  commit templates. Use when editing changelogs, version bumps, release files, or
-  when user mentions "release", "changelog", "version bump", or "conventional commits".
+description: Prevent manual edits to release-please managed files (CHANGELOG.md, version fields in package.json/pyproject.toml/Cargo.toml). Use when editing changelogs, bumping versions, or releasing.
 user-invocable: false
 allowed-tools: Read, Grep, Glob
 ---

--- a/github-actions-plugin/skills/ci-autofix-reusable/SKILL.md
+++ b/github-actions-plugin/skills/ci-autofix-reusable/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: ci-autofix-reusable
-description: |
-  Generate a reusable GitHub Actions workflow for automated CI failure detection
-  and fixing with Claude Code. Use when you want a workflow_call-based reusable
-  workflow that multiple repos or caller workflows can invoke with custom inputs.
+description: Generate a reusable GitHub Actions workflow for automated CI failure detection and fixing with Claude Code. Use when you want a workflow_call entry that multiple repos can invoke.
 allowed-tools: Bash(gh run *), Bash(gh pr *), Bash(gh issue *), Bash(git status *), Bash(git diff *), Bash(git log *), Read, Write, Edit, Grep, Glob, TodoWrite
 args: "[--setup] [--caller] [--workflows <names>] [--dry-run]"
 argument-hint: --setup to create reusable workflow, --caller to create caller workflow

--- a/github-actions-plugin/skills/github-actions-auth-security/skill.md
+++ b/github-actions-plugin/skills/github-actions-auth-security/skill.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: github-actions-auth-security
-description: GitHub Actions security and authentication for Claude Code including API keys, OIDC, AWS Bedrock, Google Vertex AI, secrets management, and permission scoping. Use when setting up authentication or discussing security for GitHub Actions workflows.
+description: Configure GitHub Actions auth and security for Claude Code — API keys, OIDC, AWS Bedrock, Vertex AI, secrets, and permission scoping. Use when setting up workflow authentication or security.
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, WebFetch
 ---

--- a/github-actions-plugin/skills/github-workflow-auto-fix/SKILL.md
+++ b/github-actions-plugin/skills/github-workflow-auto-fix/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: github-workflow-auto-fix
-description: |
-  Set up automated CI failure detection and fixing using Claude Code. Use when
-  you want to create a GitHub Actions workflow that automatically analyzes workflow
-  failures, applies fixes for common issues, and opens issues for complex problems.
+description: Set up automated CI failure detection and fixing with Claude Code. Use when you want a GitHub Actions workflow that analyzes failures, applies common fixes, and opens issues for the rest.
 allowed-tools: Bash(gh run *), Bash(gh pr *), Bash(gh issue *), Bash(git status *), Bash(git diff *), Bash(git log *), Read, Write, Edit, Grep, Glob, TodoWrite
 args: "[--setup] [--workflows <names>] [--dry-run]"
 argument-hint: --setup to create workflow, or --dry-run to preview

--- a/github-actions-plugin/skills/workflow-dev/SKILL.md
+++ b/github-actions-plugin/skills/workflow-dev/SKILL.md
@@ -1,18 +1,12 @@
 ---
 created: 2025-12-16
-modified: 2026-04-23
+modified: 2026-05-09
 reviewed: 2025-12-16
 allowed-tools: Read, Write, Edit, MultiEdit, Bash(git *), Bash(pytest *), Bash(npm test *), Bash(cargo test *), Bash(go test *), mcp__github__list_issues, mcp__github__create_issue, mcp__github__create_pull_request, mcp__github__get_issue, TodoWrite
 args: "[--max-cycles <n>] [--focus <bug|feature|test>]"
 argument-hint: "[--max-cycles <n>] [--focus <bug|feature|test>]"
 disable-model-invocation: true
-description: |
-  Automated development loop that runs tests, creates GitHub issues for failures, picks an
-  issue to work on, implements a TDD fix on a feature branch, opens a PR, and monitors CI
-  until green. Use when the user wants to run a continuous dev loop through open issues,
-  turn test failures into tracked issues, automate the issue-to-PR cycle, or when they
-  mention "work through the backlog", "autonomous dev loop", "TDD on open issues", or
-  "fix test failures and open PRs".
+description: "Automated dev loop: runs tests, files GitHub issues for failures, picks an issue, implements a TDD fix on a branch, opens a PR, and watches CI until green. Use when running a continuous dev loop through open issues, autonomous TDD, or fix-and-PR cycles."
 name: workflow-dev
 ---
 

--- a/health-plugin/skills/health-agentic-audit/SKILL.md
+++ b/health-plugin/skills/health-agentic-audit/SKILL.md
@@ -3,12 +3,7 @@ created: 2026-02-05
 modified: 2026-04-19
 reviewed: 2026-04-15
 user-invocable: false
-description: |
-  Audit plugin skills, commands, and agents for agentic output optimization compliance such
-  as missing Agentic Optimizations tables, bare CLI commands without compact/JSON flags, and
-  stale review dates. Use when the user wants to batch-check skill documentation quality,
-  find skills lacking compact output flags, enforce agentic optimization standards across
-  the repo, or identify skills with `modified` dates older than 90 days.
+description: Audit plugin skills, commands, and agents for agentic output compliance — missing optimization tables, bare CLI commands, stale review dates. Use when batch-checking skill documentation quality.
 allowed-tools: Bash(find *), Bash(head *), Read, Grep, Glob, TodoWrite
 args: "[--fix] [--verbose]"
 argument-hint: "[--fix] [--verbose]"

--- a/health-plugin/skills/health-audit/SKILL.md
+++ b/health-plugin/skills/health-audit/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2026-02-05
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2026-04-15
 user-invocable: false
-description: |
-  Audit the project's enabled plugins against the detected technology stack and recommend
-  which plugins to add or remove for relevance. Use when the user wants to review plugin
-  relevance for the current project, clean up unused plugins, discover missing plugins that
-  match the project's stack (Python, Node, Rust, Go, Terraform, Docker, Kubernetes), optimize
-  project-specific plugin configuration, or when onboarding to an existing project.
+description: Audit enabled plugins against the detected stack (Python, Node, Rust, Go, Terraform, Docker, Kubernetes) and recommend additions or removals. Use when cleaning up unused plugins, discovering stack-relevant ones, or onboarding a project.
 allowed-tools: Bash(test *), Bash(find *), Bash(jq *), Bash(claude plugin *), Read, Write, Edit, Glob, Grep, TodoWrite, AskUserQuestion
 args: "[--fix] [--dry-run] [--verbose]"
 argument-hint: "[--fix] [--dry-run] [--verbose]"

--- a/health-plugin/skills/health-check/SKILL.md
+++ b/health-plugin/skills/health-check/SKILL.md
@@ -1,14 +1,8 @@
 ---
 created: 2026-02-04
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2026-04-16
-description: |
-  Run a comprehensive diagnostic scan of Claude Code configuration — plugins, settings, hooks,
-  MCP servers, SessionStart executability, pre-commit validity, permissions coverage, and
-  marketplace enrollment — and optionally fix issues across registry, stack relevance, and
-  agentic optimisation scopes. Use when the user wants to troubleshoot Claude Code setup,
-  check plugin registry health, audit plugin fit for the project, or run a one-stop
-  diagnostic before starting work.
+description: One-stop diagnostic scan of Claude Code configuration — plugins, settings, hooks, MCP, SessionStart, permissions, marketplace — with optional fixes across registry/stack/agentic scopes. Use when troubleshooting Claude Code setup or before starting work.
 allowed-tools: Bash(bash *), Bash(pre-commit *), Read, Glob, Grep, TodoWrite, AskUserQuestion
 args: "[--scope=all|registry|stack|agentic] [--fix] [--dry-run] [--verbose]"
 argument-hint: "[--scope=all|registry|stack|agentic] [--fix] [--dry-run] [--verbose]"

--- a/health-plugin/skills/health-plugins/SKILL.md
+++ b/health-plugin/skills/health-plugins/SKILL.md
@@ -1,15 +1,9 @@
 ---
 created: 2026-02-04
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2026-04-15
 user-invocable: false
-description: |
-  Diagnose and fix Claude Code plugin registry corruption, orphaned entries, stale
-  enabledPlugins keys, and project-scope conflicts (issue #14202 where a plugin appears
-  "installed" in another project and blocks installation). Use when the user sees "plugin
-  already installed" errors across projects, needs to clean up orphaned projectPath
-  entries, wants to resolve registry-vs-settings drift, or when inspecting the registry
-  JSON directly.
+description: 'Diagnose and fix Claude Code plugin registry corruption — orphaned entries, stale enabledPlugins keys, cross-project scope conflicts (issue #14202). Use when seeing "plugin already installed" errors or registry-vs-settings drift.'
 allowed-tools: Bash(bash *), Read, Write, Edit, Glob, Grep, TodoWrite, AskUserQuestion
 args: "[--fix] [--dry-run] [--plugin <name>]"
 argument-hint: "[--fix] [--dry-run] [--plugin <name>]"

--- a/health-plugin/skills/health-skill-audit/SKILL.md
+++ b/health-plugin/skills/health-skill-audit/SKILL.md
@@ -1,14 +1,8 @@
 ---
 created: 2026-04-24
-modified: 2026-04-24
+modified: 2026-05-09
 reviewed: 2026-04-24
-description: |
-  Audit the plugin skill tree for skill-to-skill overlap, split-pressure inside
-  a single SKILL.md, and small sibling skills that could consolidate. Use when
-  the user asks to find overlapping skills, surface skills that should extract
-  a REFERENCE.md or scripts/ directory, locate clusters of confusingly similar
-  skills (e.g. configure-*-test* siblings, test-* fragmentation, *-development
-  variants), or run `/health:skill-audit`.
+description: Audit the plugin skill tree for skill-to-skill overlap, split-pressure inside one SKILL.md, and small siblings worth consolidating. Use when finding confusing clusters (configure-*-test*, test-*, *-development) or surfacing REFERENCE.md candidates.
 allowed-tools: Bash(python3 *), Read, TodoWrite
 args: "[--plugin <name>] [--strict]"
 argument-hint: "[--plugin <name>] [--strict]"

--- a/home-assistant-plugin/skills/ha-automations/SKILL.md
+++ b/home-assistant-plugin/skills/ha-automations/SKILL.md
@@ -3,10 +3,7 @@ created: 2025-02-01
 modified: 2026-02-14
 reviewed: 2026-02-08
 name: ha-automations
-description: |
-  Home Assistant automation creation and management. Use when creating automation rules,
-  working with triggers, conditions, actions, scripts, scenes, or blueprints.
-  Covers automation patterns, device triggers, and complex conditional logic.
+description: Home Assistant automation creation and management. Use when creating automation rules, working with triggers, conditions, actions, scripts, scenes, or blueprints.
 user-invocable: false
 allowed-tools: Read, Edit, Write, Grep, Glob, TodoWrite
 ---

--- a/home-assistant-plugin/skills/ha-configuration/SKILL.md
+++ b/home-assistant-plugin/skills/ha-configuration/SKILL.md
@@ -1,12 +1,9 @@
 ---
 created: 2025-02-01
-modified: 2025-02-01
+modified: 2026-05-09
 reviewed: 2025-02-01
 name: ha-configuration
-description: |
-  Home Assistant YAML configuration management. Use when editing configuration.yaml,
-  setting up integrations, configuring secrets, managing packages, or troubleshooting
-  Home Assistant configuration issues. Covers core configuration patterns and best practices.
+description: Home Assistant YAML configuration management. Use when editing configuration.yaml, setting up integrations, configuring secrets, managing packages, or troubleshooting HA configuration. Covers core configuration patterns and best practices.
 user-invocable: false
 allowed-tools: Read, Edit, Write, Grep, Glob, TodoWrite
 ---

--- a/home-assistant-plugin/skills/ha-entities/SKILL.md
+++ b/home-assistant-plugin/skills/ha-entities/SKILL.md
@@ -3,10 +3,7 @@ created: 2025-02-01
 modified: 2026-02-14
 reviewed: 2025-02-01
 name: ha-entities
-description: |
-  Home Assistant entity and domain management. Use when working with entity IDs,
-  device classes, customizations, template entities, groups, or understanding
-  entity naming conventions and domain-specific attributes.
+description: Home Assistant entity and domain management. Use when working with entity IDs, device classes, customizations, template entities, groups, or domain-specific attributes.
 user-invocable: false
 allowed-tools: Read, Edit, Write, Grep, Glob, TodoWrite
 ---

--- a/home-assistant-plugin/skills/ha-validate/SKILL.md
+++ b/home-assistant-plugin/skills/ha-validate/SKILL.md
@@ -1,16 +1,10 @@
 ---
-description: |
-  Validate Home Assistant YAML configuration files for syntax errors, undefined secret
-  references, and duplicate keys, with optional Docker/HA OS full-config checks. Use when
-  the user wants to validate Home Assistant configuration before reload, diagnose YAML
-  indentation or mapping errors, check for missing entries in secrets.yaml, detect
-  duplicate keys in configuration.yaml/automations.yaml/scripts.yaml, or run `hass --script
-  check_config` through a running container.
+description: Validate Home Assistant YAML for syntax errors, undefined secret references, and duplicate keys, with optional Docker/HA OS full-config checks. Use when validating HA config, diagnosing YAML errors, or running hass --script check_config.
 args: "[path]"
 allowed-tools: Bash(python3 *), Bash(docker exec *), Bash(ha *), Read, Grep, Glob
 argument-hint: "Optional path to config directory (defaults to current directory)"
 created: 2025-02-01
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: ha-validate
 ---

--- a/hooks-plugin/skills/hooks-configuration/SKILL.md
+++ b/hooks-plugin/skills/hooks-configuration/SKILL.md
@@ -1,16 +1,10 @@
 ---
 name: hooks-configuration
-description: |
-  Claude Code hooks configuration and development. Covers hook lifecycle events,
-  configuration patterns, input/output schemas, and common automation use cases.
-  Use when user mentions hooks, automation, PreToolUse, PostToolUse, SessionStart,
-  SubagentStart, PermissionRequest, WorktreeCreate, WorktreeRemove, TeammateIdle,
-  TaskCompleted, ConfigChange, or needs to enforce consistent behavior in Claude
-  Code workflows.
+description: Claude Code hooks configuration and development. Covers lifecycle events, configuration patterns, and input/output schemas. Use when the user mentions hooks, PreToolUse, PostToolUse, SessionStart, SubagentStart, PermissionRequest, or TaskCompleted.
 user-invocable: false
 allowed-tools: Bash(bash *), Bash(cat *), Read, Write, Edit, Glob, Grep, TodoWrite
 created: 2025-12-16
-modified: 2026-04-10
+modified: 2026-05-09
 reviewed: 2026-04-10
 ---
 

--- a/hooks-plugin/skills/hooks-permission-request-hook/SKILL.md
+++ b/hooks-plugin/skills/hooks-permission-request-hook/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: hooks-permission-request-hook
-description: |
-  Generate a PermissionRequest hook that auto-approves safe operations and auto-denies
-  dangerous ones. Use when you want a safer alternative to --dangerouslySkipPermissions
-  that builds compound auto-approval rules tailored to your project stack.
+description: Generate a PermissionRequest hook that auto-approves safe operations and auto-denies dangerous ones. Use when you need a safer alternative to --dangerouslySkipPermissions tailored to your project stack.
 args: "[--strict] [--category <name>...]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, TodoWrite
 argument-hint: "--strict to deny unknown commands, --category git|test|lint|build|gh|deny"

--- a/hooks-plugin/skills/hooks-session-end-issue-hook/SKILL.md
+++ b/hooks-plugin/skills/hooks-session-end-issue-hook/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: hooks-session-end-issue-hook
-description: |
-  Configure a Stop hook that surfaces unfinished todos before a session ends and suggests
-  creating GitHub issues for deferred work. Use when you want unfinished Claude Code session
-  tasks automatically flagged for GitHub issue creation at session end.
+description: Configure a Stop hook that surfaces unfinished todos at session end and suggests creating GitHub issues. Use when you want deferred work automatically flagged for issue creation.
 args: "[--no-verify]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, TodoWrite
 argument-hint: "--no-verify to skip gh auth verification"

--- a/hooks-plugin/skills/hooks-session-start-hook/SKILL.md
+++ b/hooks-plugin/skills/hooks-session-start-hook/SKILL.md
@@ -1,15 +1,12 @@
 ---
 name: hooks-session-start-hook
-description: |
-  Create a SessionStart hook for Claude Code on the web. Use when setting up a repository
-  for remote Claude Code sessions, ensuring dependencies install and tests/linters run
-  automatically on session start. Detects project type, package manager, test runner, and linter.
+description: Create a SessionStart hook for Claude Code on the web. Use when setting up a repo for remote sessions so dependencies install and tests/linters run automatically on session start. Detects project type, package manager, test runner, and linter.
 args: "[--remote-only] [--no-verify]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, TodoWrite
 argument-hint: "--remote-only to only run in web sessions, --no-verify to skip test verification"
 disable-model-invocation: true
 created: 2026-02-07
-modified: 2026-03-30
+modified: 2026-05-09
 reviewed: 2026-03-30
 ---
 

--- a/kubernetes-plugin/skills/helm-chart-development/SKILL.md
+++ b/kubernetes-plugin/skills/helm-chart-development/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: helm-chart-development
-description: |
-  Create, test, and package Helm charts for Kubernetes. Covers helm create, Chart.yaml,
-  values.yaml, template development, chart dependencies, packaging, and repository publishing.
-  Use when user mentions Helm charts, helm create, Chart.yaml, values.yaml, helm lint,
-  helm template, helm package, or Kubernetes packaging.
+description: Create, test, and package Helm charts. Covers helm create, Chart.yaml, values.yaml, template development, dependencies, packaging, and repository publishing. Use when the user mentions Helm charts, helm lint/template/package, or Kubernetes packaging.
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 ---

--- a/kubernetes-plugin/skills/helm-debugging/SKILL.md
+++ b/kubernetes-plugin/skills/helm-debugging/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: helm-debugging
-description: |
-  Debug and troubleshoot Helm deployment failures, template errors, and configuration
-  issues. Covers helm template, helm lint, dry-run, debugging YAML parse errors,
-  value type errors, and resource conflicts. Use when user mentions Helm errors,
-  debugging Helm, template rendering issues, or troubleshooting Helm deployments.
+description: Debug Helm deployment failures, template errors, and configuration issues. Covers helm template, helm lint, dry-run, YAML parse errors, value type errors, and resource conflicts. Use when the user mentions Helm errors or template rendering issues.
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/kubernetes-plugin/skills/helm-release-management/SKILL.md
+++ b/kubernetes-plugin/skills/helm-release-management/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: helm-release-management
-description: |
-  Manage Helm releases: install, upgrade, uninstall, list, and inspect releases.
-  Covers helm install, helm upgrade, helm list, helm status, release history.
-  Use when user mentions deploying Helm charts, upgrading releases, helm install,
-  helm upgrade, or managing Kubernetes deployments with Helm.
+description: "Manage Helm releases: install, upgrade, uninstall, list, and inspect. Covers helm install/upgrade/list/status and release history. Use when the user mentions deploying Helm charts, upgrading releases, or managing Kubernetes deployments with Helm."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/kubernetes-plugin/skills/helm-release-recovery/SKILL.md
+++ b/kubernetes-plugin/skills/helm-release-recovery/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: helm-release-recovery
-description: |
-  Recover from failed Helm deployments, rollback releases, fix stuck states
-  (pending-install, pending-upgrade). Covers helm rollback, release history,
-  atomic deployments. Use when user mentions rollback, failed Helm upgrade,
-  stuck release, or recovering from Helm deployment failures.
+description: Recover from failed Helm deployments, rollback releases, fix stuck states (pending-install, pending-upgrade). Covers helm rollback, release history, and atomic deployments. Use when the user mentions rollback, failed Helm upgrade, or stuck release.
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/kubernetes-plugin/skills/helm-values-management/SKILL.md
+++ b/kubernetes-plugin/skills/helm-values-management/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: helm-values-management
-description: |
-  Manage Helm values across environments with override precedence, multi-environment
-  configurations, and secret management. Covers values files, --set, --set-string,
-  values schema validation. Use when user mentions Helm values, environment-specific
-  configs, values.yaml, --set overrides, or Helm configuration.
+description: Manage Helm values across environments with override precedence, multi-env configs, and secret management. Covers values files, --set, --set-string, schema validation. Use when the user mentions Helm values, env-specific configs, or values.yaml.
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 ---

--- a/kubernetes-plugin/skills/kubectl-debugging/SKILL.md
+++ b/kubernetes-plugin/skills/kubectl-debugging/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: kubectl-debugging
-description: |
-  Debug Kubernetes pods, nodes, and workloads using kubectl debug. Covers ephemeral containers,
-  pod copying, node debugging, debug profiles, and interactive troubleshooting sessions.
-  Use when user mentions kubectl debug, debugging pods, ephemeral containers, node debugging,
-  or interactive troubleshooting in Kubernetes clusters.
+description: Debug Kubernetes pods, nodes, and workloads using kubectl debug. Covers ephemeral containers, pod copying, node debugging, debug profiles, and interactive sessions. Use when the user mentions kubectl debug, debugging pods, or ephemeral containers.
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash(kubectl *), Bash(stern *), Edit, Write, TodoWrite, WebFetch
 ---

--- a/kubernetes-plugin/skills/kubernetes-operations/SKILL.md
+++ b/kubernetes-plugin/skills/kubernetes-operations/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: kubernetes-operations
-description: |
-  Kubernetes operations including deployment, management, troubleshooting, kubectl mastery,
-  and cluster stability. Covers K8s workloads, networking, storage, and debugging pods.
-  Use when user mentions Kubernetes, K8s, kubectl, pods, deployments, services, ingress,
-  ConfigMaps, Secrets, or cluster operations.
+description: "Kubernetes operations: deployment, management, troubleshooting, kubectl mastery, cluster stability. Covers workloads, networking, storage, and pod debugging. Use when the user mentions K8s, kubectl, pods, deployments, services, or ingress."
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash(kubectl *), Bash(helm *), Bash(kustomize *), Edit, Write, TodoWrite, WebFetch
 ---

--- a/langchain-plugin/skills/deep-agents/skill.md
+++ b/langchain-plugin/skills/deep-agents/skill.md
@@ -1,14 +1,10 @@
 ---
 name: deep-agents
-description: |
-  Build hierarchical AI agents using the deep-agents TypeScript/npm package. Use when
-  you want to create an orchestrator agent that plans and executes multi-step tasks,
-  manages file system context, delegates subtasks to child agents, or maintains
-  persistent memory across runs with the Deep Agents library.
+description: Build hierarchical AI agents using the deep-agents TypeScript/npm package. Use when creating an orchestrator that plans multi-step tasks, manages file system context, delegates to child agents, or maintains persistent memory with Deep Agents.
 user-invocable: false
 allowed-tools: Bash(python *), Bash(uv *), BashOutput, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2026-01-08
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 ---
 

--- a/langchain-plugin/skills/langchain-development/skill.md
+++ b/langchain-plugin/skills/langchain-development/skill.md
@@ -1,9 +1,6 @@
 ---
 name: langchain-development
-description: |
-  LangChain JS/TS framework for building LLM-powered applications. Use when working
-  with chat models, prompt templates, LCEL chains, tool binding, or RAG pipelines
-  in a LangChain TypeScript project.
+description: LangChain JS/TS framework for building LLM-powered apps. Use when working with chat models, prompt templates, LCEL chains, tool binding, or RAG pipelines.
 user-invocable: false
 allowed-tools: Bash(python *), Bash(uv *), BashOutput, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2026-01-08

--- a/langchain-plugin/skills/langchain-init/SKILL.md
+++ b/langchain-plugin/skills/langchain-init/SKILL.md
@@ -1,8 +1,5 @@
 ---
-description: |
-  Initialize a new LangChain TypeScript project with recommended configuration.
-  Use when starting a new LLM-powered application, scaffolding an AI agent project,
-  or setting up LangChain with TypeScript from scratch.
+description: Initialize a new LangChain TypeScript project with recommended config. Use when starting a new LLM-powered app, scaffolding an AI agent project, or setting up LangChain from scratch.
 args: "[project-name]"
 allowed-tools: Bash(uv *), Bash(pip *), Bash(python *), Read, Write, Edit
 argument-hint: my-agent-project

--- a/langchain-plugin/skills/langgraph-agents/skill.md
+++ b/langchain-plugin/skills/langgraph-agents/skill.md
@@ -1,14 +1,10 @@
 ---
 name: langgraph-agents
-description: |
-  Build stateful AI agents using LangGraph's graph-based workflow framework. Use when
-  creating state machine agents with checkpoints, defining agent behavior as graphs of
-  nodes and edges, adding human-in-the-loop approval steps, streaming agent execution,
-  or composing multiple agents as subgraphs in a LangGraph application.
+description: Build stateful AI agents using LangGraph's graph-based workflow framework. Use when creating state-machine agents with checkpoints, defining behavior as graphs, adding human-in-the-loop, streaming execution, or composing subgraphs.
 user-invocable: false
 allowed-tools: Bash(python *), Bash(uv *), BashOutput, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2026-01-08
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 ---
 

--- a/macos-plugin/skills/kitty-session-persistence/skill.md
+++ b/macos-plugin/skills/kitty-session-persistence/skill.md
@@ -1,10 +1,10 @@
 ---
 name: kitty-session-persistence
-description: Snapshot and restore kitty terminal sessions across crashes, reboots, and GUI hangs on macOS. Use when you want to survive WindowServer hangs without losing open tabs, configure a periodic kitty session snapshot, or restore a snapshot after a force-reboot.
+description: "Snapshot and restore kitty terminal sessions across crashes, reboots, and GUI hangs on macOS. Use when surviving WindowServer hangs without losing tabs, configuring periodic snapshots, or restoring after a force-reboot."
 user-invocable: false
 allowed-tools: Bash(kitty *), Bash(kitten *), Bash(launchctl *), Bash(uname *), Bash(plutil *), Bash(test *), Read, Write, Edit, Grep, Glob
 created: 2026-05-03
-modified: 2026-05-03
+modified: 2026-05-09
 reviewed: 2026-05-03
 ---
 

--- a/macos-plugin/skills/macos-incident-postmortem/skill.md
+++ b/macos-plugin/skills/macos-incident-postmortem/skill.md
@@ -1,10 +1,10 @@
 ---
 name: macos-incident-postmortem
-description: Reconstruct what happened after a macOS GUI freeze, kernel panic, or unexplained reboot by parsing /Library/Logs/DiagnosticReports/, kern.boottime, and shell history. Use when the GUI hung, you can't tell whether the machine actually rebooted, or you're investigating recent panics, watchdog timeouts, jetsam events, or thermal throttling.
+description: "Reconstruct macOS GUI freeze, kernel panic, or unexplained reboot by parsing /Library/Logs/DiagnosticReports/, kern.boottime, and shell history. Use when investigating a GUI hang, ambiguous reboot, panics, watchdog timeouts, jetsam, or thermal throttling."
 user-invocable: false
 allowed-tools: Bash(uname *), Bash(sysctl *), Bash(uptime *), Bash(last *), Bash(ls *), Bash(find *), Bash(stat *), Bash(awk *), Bash(grep *), Bash(wc *), Bash(date *), Bash(log *), Bash(pmset *), Read, Grep, Glob, TodoWrite
 created: 2026-05-03
-modified: 2026-05-03
+modified: 2026-05-09
 reviewed: 2026-05-03
 ---
 

--- a/migration-patterns-plugin/skills/black-to-ruff-format/SKILL.md
+++ b/migration-patterns-plugin/skills/black-to-ruff-format/SKILL.md
@@ -1,16 +1,12 @@
 ---
 name: black-to-ruff-format
-description: |
-  Migrate a Python project from black to ruff format (ruff's formatter).
-  Use when .pre-commit-config.yaml contains psf/black, or when [tool.black]
-  config exists in pyproject.toml. Replaces the black pre-commit hook with
-  ruff-format, migrates config, and removes black from dependencies.
+description: Migrate a Python project from black to ruff format. Use when .pre-commit-config.yaml contains psf/black, or [tool.black] config exists in pyproject.toml. Replaces the black hook with ruff-format, migrates config, and removes black from dependencies.
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(find *), Bash(test *), Bash(pre-commit *), Bash(uvx *), AskUserQuestion, TodoWrite
 model: sonnet
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"
 created: 2026-04-14
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-14
 ---
 

--- a/migration-patterns-plugin/skills/dual-write/SKILL.md
+++ b/migration-patterns-plugin/skills/dual-write/SKILL.md
@@ -1,13 +1,10 @@
 ---
 name: dual-write
-description: |
-  Dual write (double write) migration pattern for safely transitioning between data stores.
-  Use when planning or implementing database migrations, switching storage backends, migrating
-  to new schemas, or reviewing code that writes to multiple systems simultaneously.
+description: Dual write (double write) migration pattern for safely transitioning between data stores. Use when planning database migrations, switching storage backends, migrating to new schemas, or reviewing code that writes to multiple systems simultaneously.
 user-invocable: false
 allowed-tools: Read, Grep, Glob, Edit, Write, Bash, TodoWrite
 created: 2026-02-18
-modified: 2026-02-18
+modified: 2026-05-09
 reviewed: 2026-02-18
 ---
 

--- a/migration-patterns-plugin/skills/eslint-to-biome/SKILL.md
+++ b/migration-patterns-plugin/skills/eslint-to-biome/SKILL.md
@@ -1,16 +1,12 @@
 ---
 name: eslint-to-biome
-description: |
-  Migrate a JavaScript/TypeScript project from ESLint to Biome. Use when
-  .eslintrc* or eslint.config.* exists and no biome.json is present. Replaces
-  ESLint and Prettier configs/hooks with Biome, preserving rule equivalents.
-  Biome is a fast, zero-config-needed Rust linter+formatter that replaces both.
+description: Migrate a JavaScript/TypeScript project from ESLint to Biome. Use when .eslintrc* or eslint.config.* exists and no biome.json is present. Replaces ESLint and Prettier configs/hooks with Biome, preserving rule equivalents (Rust linter+formatter).
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(find *), Bash(test *), Bash(npx *), Bash(bun *), AskUserQuestion, TodoWrite
 model: sonnet
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"
 created: 2026-04-14
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-14
 ---
 

--- a/migration-patterns-plugin/skills/flake8-to-ruff/SKILL.md
+++ b/migration-patterns-plugin/skills/flake8-to-ruff/SKILL.md
@@ -1,17 +1,12 @@
 ---
 name: flake8-to-ruff
-description: |
-  Migrate a Python project from flake8 and/or isort to ruff linting.
-  Use when .pre-commit-config.yaml contains pycqa/flake8 or PyCQA/isort
-  hooks, or when [tool.flake8] or [tool.isort] config exists. Replaces both
-  hooks with a single ruff hook, migrates rule selections, and removes the
-  old tools from dependencies.
+description: Migrate a Python project from flake8 and/or isort to ruff linting. Use when .pre-commit-config.yaml has pycqa/flake8 or PyCQA/isort, or [tool.flake8]/[tool.isort] config exists. Replaces both with one ruff hook and removes the old tools.
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(find *), Bash(test *), Bash(pre-commit *), Bash(uvx *), AskUserQuestion, TodoWrite
 model: sonnet
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"
 created: 2026-04-14
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-14
 ---
 

--- a/migration-patterns-plugin/skills/mypy-to-ty/SKILL.md
+++ b/migration-patterns-plugin/skills/mypy-to-ty/SKILL.md
@@ -1,17 +1,12 @@
 ---
 name: mypy-to-ty
-description: |
-  Migrate a Python project from mypy to ty (Astral's type checker). Use when
-  .pre-commit-config.yaml contains mirrors-mypy, or when [tool.mypy] config
-  exists in pyproject.toml, and you want to switch to the faster ty checker.
-  Swaps the pre-commit hook to a local repo running uvx ty check, converts
-  [tool.mypy] to [tool.ty], and removes mypy.ini.
+description: Migrate a Python project from mypy to ty (Astral's type checker). Use when .pre-commit-config.yaml has mirrors-mypy or [tool.mypy] config exists. Swaps the hook to local uvx ty check, converts [tool.mypy] to [tool.ty], and removes mypy.ini.
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(find *), Bash(test *), Bash(pre-commit *), Bash(uvx *), AskUserQuestion, TodoWrite
 model: sonnet
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"
 created: 2026-04-14
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-14
 ---
 

--- a/migration-patterns-plugin/skills/shadow-mode/SKILL.md
+++ b/migration-patterns-plugin/skills/shadow-mode/SKILL.md
@@ -1,13 +1,10 @@
 ---
 name: shadow-mode
-description: |
-  Shadow mode (shadow traffic, dark launching) pattern for validating new systems under
-  production load. Use when testing replacement services, validating new deployments,
-  comparing system behavior, or planning traffic mirroring for migration validation.
+description: Shadow mode (shadow traffic, dark launching) for validating new systems under production load. Use when testing replacement services, validating new deployments, comparing system behavior, or planning traffic mirroring for migration validation.
 user-invocable: false
 allowed-tools: Read, Grep, Glob, Edit, Write, Bash, TodoWrite
 created: 2026-02-18
-modified: 2026-02-18
+modified: 2026-05-09
 reviewed: 2026-02-18
 ---
 

--- a/networking-plugin/skills/http-load-testing/skill.md
+++ b/networking-plugin/skills/http-load-testing/skill.md
@@ -3,7 +3,7 @@ created: 2026-01-01
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: http-load-testing
-description: Stress test and benchmark HTTP endpoints. Use when you need to measure request latency percentiles, find a server's breaking point under load, or validate SLA targets with proper coordinated-omission correction.
+description: Stress test HTTP endpoints with oha. Use when measuring latency percentiles, finding a server's breaking point under load, or validating SLA targets with coordinated-omission correction.
 user-invocable: false
 allowed-tools: Bash(hey *), Bash(ab *), Bash(wrk *), Bash(curl *), Read, Grep, Glob, TodoWrite
 ---

--- a/networking-plugin/skills/layer2-discovery/skill.md
+++ b/networking-plugin/skills/layer2-discovery/skill.md
@@ -3,7 +3,7 @@ created: 2026-01-01
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: layer2-discovery
-description: Discover devices and map physical topology on the local network segment. Use when you need to find which switch port a server is connected to, enumerate hosts via ARP without IP routing, or identify unknown devices by MAC vendor.
+description: Discover devices and map physical topology on the local network segment. Use when finding which switch port a server is on, enumerating hosts via ARP, or identifying unknown devices by MAC vendor.
 user-invocable: false
 allowed-tools: Bash(arp *), Bash(ip *), Bash(bridge *), Bash(ethtool *), Read, Write, Edit, Grep, Glob
 ---

--- a/networking-plugin/skills/network-monitoring/skill.md
+++ b/networking-plugin/skills/network-monitoring/skill.md
@@ -3,7 +3,7 @@ created: 2026-01-01
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: network-monitoring
-description: Monitor real-time network traffic and bandwidth usage per process. Use when you need to find which application is consuming bandwidth, inspect active connections, or capture a sample of traffic for analysis.
+description: Monitor real-time network traffic and per-process bandwidth with bandwhich and Sniffnet. Use when finding which app is consuming bandwidth, inspecting active connections, or capturing traffic samples.
 user-invocable: false
 allowed-tools: Bash(iftop *), Bash(nethogs *), Bash(tcpdump *), Bash(ss *), Bash(netstat *), Read, Grep, Glob, TodoWrite
 ---

--- a/obsidian-plugin/skills/bases/SKILL.md
+++ b/obsidian-plugin/skills/bases/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2026-04-30
-modified: 2026-04-30
+modified: 2026-05-09
 reviewed: 2026-04-30
 name: bases
-description: |
-  Query and create entries in Obsidian Bases — the database-over-notes feature.
-  Covers listing base files, listing views, creating items in a base, and
-  running view queries with structured output (json/csv/tsv/md/paths).
-  Use when the user mentions Obsidian Bases, .base files, querying notes as
-  a database, base views, or structured note queries.
+description: Query and create entries in Obsidian Bases — the database-over-notes feature. Covers listing base files and views, creating items, and view queries with structured output (json/csv/tsv/md/paths). Use when the user mentions Bases or .base files.
 user-invocable: false
 allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---

--- a/obsidian-plugin/skills/command-palette/SKILL.md
+++ b/obsidian-plugin/skills/command-palette/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2026-04-30
-modified: 2026-04-30
+modified: 2026-05-09
 reviewed: 2026-04-30
 name: command-palette
-description: |
-  Run any Obsidian command (built-in or plugin-registered) from the CLI, list
-  available commands, and inspect or look up hotkeys. Use when the user wants
-  to trigger a command they would normally invoke from the command palette,
-  enumerate plugin-registered commands, or check which hotkey is bound to an
-  action.
+description: Run any Obsidian command (built-in or plugin-registered) from the CLI, list available commands, and inspect or look up hotkeys. Use when the user wants to trigger a command, enumerate commands, or check which hotkey is bound to an action.
 user-invocable: false
 allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---

--- a/obsidian-plugin/skills/dev-tools/SKILL.md
+++ b/obsidian-plugin/skills/dev-tools/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2026-04-30
-modified: 2026-04-30
+modified: 2026-05-09
 reviewed: 2026-04-30
 name: dev-tools
-description: |
-  Obsidian developer commands for plugin and theme development — DevTools,
-  Chrome DevTools Protocol, JavaScript eval, captured console/error buffers,
-  CSS and DOM inspection, mobile emulation, and screenshots. Use when the
-  user is developing a plugin or theme, debugging the Obsidian app, or
-  needs to introspect the running renderer state.
+description: Obsidian developer commands for plugin/theme dev — DevTools, CDP, JavaScript eval, console/error buffers, CSS/DOM inspection, mobile emulation, screenshots. Use when developing a plugin/theme, debugging the app, or introspecting the renderer.
 user-invocable: false
 allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---

--- a/obsidian-plugin/skills/file-history/SKILL.md
+++ b/obsidian-plugin/skills/file-history/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2026-04-30
-modified: 2026-04-30
+modified: 2026-05-09
 reviewed: 2026-04-30
 name: file-history
-description: |
-  Inspect, diff, and restore previous versions of notes from Obsidian's local
-  File Recovery store and from Obsidian Sync version history. Critical safety
-  net for agentic edits — lets you compare versions, recover overwritten
-  content, and audit changes. Use when the user mentions undo, restoring a
-  previous version, file recovery, version history, or comparing what changed.
+description: Inspect, diff, and restore previous note versions from Obsidian's local File Recovery store and Sync history. Critical safety net for agentic edits. Use when the user mentions undo, restoring a previous version, file recovery, or version history.
 user-invocable: false
 allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---

--- a/obsidian-plugin/skills/plugins-themes/SKILL.md
+++ b/obsidian-plugin/skills/plugins-themes/SKILL.md
@@ -1,15 +1,9 @@
 ---
 created: 2026-03-04
-modified: 2026-04-30
+modified: 2026-05-09
 reviewed: 2026-04-30
 name: plugins-themes
-description: |
-  Lifecycle management for Obsidian community plugins, themes, and CSS
-  snippets via the official CLI — install, enable, disable, uninstall,
-  reload, switch theme, and toggle restricted (formerly "safe") mode.
-  Use when the user mentions installing/enabling/disabling Obsidian
-  plugins or themes, switching themes, or toggling CSS snippets. For
-  developer commands (eval, devtools, dev:*, screenshot) use `dev-tools`.
+description: Lifecycle management for Obsidian community plugins, themes, and CSS snippets via the official CLI — install, enable, disable, uninstall, reload, switch theme, toggle restricted mode. Use when installing/enabling Obsidian plugins or themes.
 user-invocable: false
 allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---

--- a/obsidian-plugin/skills/properties/SKILL.md
+++ b/obsidian-plugin/skills/properties/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2026-03-04
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: properties
-description: |
-  Obsidian YAML frontmatter property management via the official CLI.
-  Covers reading, setting, and removing properties/metadata on notes.
-  Use when user mentions frontmatter, properties, metadata, YAML,
-  or note attributes like status, tags, dates, aliases.
+description: Obsidian YAML frontmatter property management via the official CLI. Covers reading, setting, and removing properties on notes. Use when the user mentions frontmatter, properties, metadata, YAML, or note attributes like status, tags, dates, aliases.
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/obsidian-plugin/skills/publish-sync/SKILL.md
+++ b/obsidian-plugin/skills/publish-sync/SKILL.md
@@ -1,15 +1,9 @@
 ---
 created: 2026-03-04
-modified: 2026-04-30
+modified: 2026-05-09
 reviewed: 2026-04-30
 name: publish-sync
-description: |
-  Obsidian Publish and Obsidian Sync management via the official CLI —
-  publish site info, list/add/remove published notes, publish change set,
-  open published page, sync pause/resume, sync status and usage, and
-  recovery of sync-deleted files. Use when the user mentions Obsidian
-  Publish, publishing notes, Obsidian Sync, sync status, or recovering
-  sync-deleted files.
+description: Obsidian Publish and Sync via the official CLI — publish info, list/add/remove published notes, change set, sync pause/resume, status, and recovery of sync-deleted files. Use when mentioning Publish, Sync, or recovering deleted files.
 user-invocable: false
 allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---

--- a/obsidian-plugin/skills/search-discovery/SKILL.md
+++ b/obsidian-plugin/skills/search-discovery/SKILL.md
@@ -1,15 +1,9 @@
 ---
 created: 2026-03-04
-modified: 2026-04-30
+modified: 2026-05-09
 reviewed: 2026-04-30
 name: search-discovery
-description: |
-  Obsidian vault search and discovery via the official CLI — full-text and
-  grep-style context search, tag listing and lookup, outgoing/incoming link
-  traversal, outline navigation, orphan and dead-end detection, and broken
-  wikilink audits. Use when the user mentions searching notes, finding tags,
-  exploring links/backlinks, headings/outline, orphaned or dead-end notes,
-  or broken wikilinks.
+description: Obsidian vault search and discovery via the official CLI — full-text/grep search, tag listing, link traversal, outline, orphan/dead-end detection, and broken wikilink audits. Use when searching notes, exploring backlinks, or auditing wikilinks.
 user-invocable: false
 allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---

--- a/obsidian-plugin/skills/templates/SKILL.md
+++ b/obsidian-plugin/skills/templates/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2026-04-30
-modified: 2026-04-30
+modified: 2026-05-09
 reviewed: 2026-04-30
 name: templates
-description: |
-  List, read, and insert Obsidian templates from the core Templates plugin.
-  Covers template variable resolution ({{date}}, {{time}}, {{title}}) and the
-  difference between inserting into the active file vs creating a new file
-  from a template. Use when the user mentions Obsidian templates, the
-  Templates plugin, or template variable resolution.
+description: List, read, and insert Obsidian templates from the core Templates plugin. Covers template variable resolution ({{date}}, {{time}}, {{title}}) and inserting into the active file vs creating a new file. Use when the user mentions Obsidian templates.
 user-invocable: false
 allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---

--- a/obsidian-plugin/skills/vault-files/SKILL.md
+++ b/obsidian-plugin/skills/vault-files/SKILL.md
@@ -1,15 +1,9 @@
 ---
 created: 2026-03-04
-modified: 2026-04-30
+modified: 2026-05-09
 reviewed: 2026-04-30
 name: vault-files
-description: |
-  Obsidian vault file and folder operations via the official CLI — reading,
-  creating, appending, prepending, moving, renaming, deleting notes, file
-  info and word counts, listing files/folders, daily notes, random and
-  unique notes, and the web viewer. Use when the user mentions Obsidian
-  notes, vault files, daily notes, creating/editing/renaming notes, or
-  managing vault content.
+description: Obsidian vault file/folder operations via the official CLI — read, create, append, prepend, move, rename, delete notes, file info, listing, daily/random/unique notes, web viewer. Use when mentioning vault files, daily notes, or managing content.
 user-invocable: false
 allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---

--- a/obsidian-plugin/skills/vault-frontmatter/SKILL.md
+++ b/obsidian-plugin/skills/vault-frontmatter/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2026-04-17
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: vault-frontmatter
-description: |
-  Offline maintenance of YAML frontmatter in Obsidian notes. Use when the
-  user asks to strip legacy `id:` fields, add missing frontmatter blocks,
-  remove null tag values, clean up unrendered Templater markers like
-  `{{title}}` or `<% tp.file.cursor() %>`, fix bare emoji placeholder tags,
-  or add `context: fvh` to FVH notes in bulk.
+description: "Offline maintenance of YAML frontmatter in Obsidian notes. Use when the user asks to strip legacy `id:` fields, add missing frontmatter, remove null tag values, clean up unrendered Templater markers, or fix bare emoji placeholder tags in bulk."
 user-invocable: false
 allowed-tools: Read, Edit, Write, Grep, Glob
 ---

--- a/obsidian-plugin/skills/vault-management/SKILL.md
+++ b/obsidian-plugin/skills/vault-management/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2026-04-30
-modified: 2026-04-30
+modified: 2026-05-09
 reviewed: 2026-04-30
 name: vault-management
-description: |
-  Inspect the active vault, enumerate known vaults, and target commands at a
-  specific vault using the global `vault=` prefix. Use when the user asks
-  about vault info (path, file count, size), works across multiple vaults,
-  or wants to run a command against a non-active vault.
+description: Inspect the active vault, enumerate known vaults, and target commands at a specific vault using the global `vault=` prefix. Use when the user asks about vault info (path, file count, size), works across vaults, or runs against a non-active vault.
 user-invocable: false
 allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---

--- a/obsidian-plugin/skills/vault-mocs/SKILL.md
+++ b/obsidian-plugin/skills/vault-mocs/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2026-04-17
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: vault-mocs
-description: |
-  Map-of-Content (MOC) curation for Obsidian vaults. Use when the user asks
-  to create a new MOC for a tag category, extend an existing MOC with
-  orphaned notes, fix legacy `🗺️` MOC tags to `📝/moc`, analyze MOC
-  coverage for a category, or reorganize hand-curated hub notes.
+description: Map-of-Content (MOC) curation for Obsidian vaults. Use when the user asks to create a MOC for a tag category, extend an existing MOC with orphans, fix legacy MOC tags to `📝/moc`, analyze MOC coverage, or reorganize hand-curated hub notes.
 user-invocable: false
 allowed-tools: Read, Edit, Write, Grep, Glob
 ---

--- a/obsidian-plugin/skills/vault-orphans/SKILL.md
+++ b/obsidian-plugin/skills/vault-orphans/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2026-04-17
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: vault-orphans
-description: |
-  Triage orphaned notes (zero incoming, zero outgoing wikilinks) in an
-  Obsidian vault. Use when the user asks to find orphan notes, link
-  disconnected notes into a MOC, distinguish expected orphans (inbox,
-  daily notes) from meaningful ones, suggest archival for stale orphans,
-  or reconnect isolated Zettelkasten notes to the knowledge graph.
+description: Triage orphaned notes (zero in/out wikilinks) in an Obsidian vault. Use when the user asks to find orphans, link disconnected notes into a MOC, distinguish expected orphans (inbox, daily) from meaningful ones, or reconnect Zettelkasten notes.
 user-invocable: false
 allowed-tools: Read, Edit, Grep, Glob
 ---

--- a/obsidian-plugin/skills/vault-stubs/SKILL.md
+++ b/obsidian-plugin/skills/vault-stubs/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2026-04-17
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: vault-stubs
-description: |
-  FVH/z/ redirect-stub classification and consolidation for LakuVault. Use
-  when the user asks to clean up FVH/z redirect stubs, convert stale
-  duplicates into canonical redirects, merge unique FVH content back into
-  Zettelkasten, promote an FVH-only note into the main vault, or fix
-  broken/oversized stubs.
+description: FVH/z/ redirect-stub classification and consolidation for LakuVault. Use when the user asks to clean up FVH/z stubs, convert stale duplicates to canonical redirects, merge unique FVH content into Zettelkasten, or fix broken stubs.
 user-invocable: false
 allowed-tools: Read, Edit, Write, Grep, Glob
 ---

--- a/obsidian-plugin/skills/vault-tags/SKILL.md
+++ b/obsidian-plugin/skills/vault-tags/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2026-04-17
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: vault-tags
-description: |
-  Emoji-prefixed tag taxonomy for Obsidian vaults. Use when the user asks
-  to consolidate duplicate or drifted tags (e.g. `🔒/security` vs
-  `🔍/security`, `gaming` vs `🎮/games`), collapse bare emoji placeholder
-  tags like `📝` or `🌱`, convert flat tags to emoji-prefixed form, or
-  reduce over-tagged notes down to the 2-3 canonical tags.
+description: Emoji-prefixed tag taxonomy for Obsidian vaults. Use when the user asks to consolidate duplicate or drifted tags (`🔒/security` vs `🔍/security`), collapse bare emoji placeholder tags, convert flat tags to emoji-prefixed, or reduce over-tagging.
 user-invocable: false
 allowed-tools: Read, Edit, Grep, Glob
 ---

--- a/obsidian-plugin/skills/vault-templates/SKILL.md
+++ b/obsidian-plugin/skills/vault-templates/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2026-04-17
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: vault-templates
-description: |
-  Obsidian Templater conventions and drift repair. Use when the user asks
-  to fix unrendered Templater markers like `<% tp.file.cursor() %>`,
-  replace `{{title}}` or `{{date}}` placeholders in daily notes, clean up
-  notes committed before Templater finished running, or audit daily-note
-  structure drift against the canonical template.
+description: Obsidian Templater conventions and drift repair. Use when the user asks to fix unrendered Templater markers like `<% tp.file.cursor() %>`, replace `{{title}}`/`{{date}}` placeholders, or audit daily-note structure drift.
 user-invocable: false
 allowed-tools: Read, Edit, Write, Grep, Glob
 ---

--- a/obsidian-plugin/skills/vault-wikilinks/SKILL.md
+++ b/obsidian-plugin/skills/vault-wikilinks/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2026-04-17
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: vault-wikilinks
-description: |
-  Detect and repair broken wikilinks in an Obsidian vault. Use when the
-  user asks to fix broken `[[Target]]` links, rewrite a renamed note's
-  references across the vault, resolve cross-namespace ambiguity between
-  Zettelkasten and FVH/z notes, unqualify `[[Kanban/X]]` path-qualified
-  links, or clean up wikilinks after renaming notes.
+description: Detect and repair broken wikilinks in an Obsidian vault. Use when the user asks to fix broken `[[Target]]` links, rewrite a renamed note's references, resolve ambiguity between Zettelkasten and FVH/z, or unqualify path-qualified links.
 user-invocable: false
 allowed-tools: Read, Edit, Grep, Glob
 ---

--- a/obsidian-plugin/skills/workspaces/SKILL.md
+++ b/obsidian-plugin/skills/workspaces/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2026-04-30
-modified: 2026-04-30
+modified: 2026-05-09
 reviewed: 2026-04-30
 name: workspaces
-description: |
-  Inspect and manage the Obsidian editor workspace — open tabs, recent files,
-  saved Workspaces (the core plugin), and individual tab management. Use when
-  the user asks what's open in Obsidian, wants to switch to a saved layout,
-  save the current layout, or open files into specific tabs/groups.
+description: Inspect and manage the Obsidian editor workspace — open tabs, recent files, saved Workspaces, tab management. Use when the user asks what's open, wants to switch to a saved layout, save the current layout, or open files into specific tabs.
 user-invocable: false
 allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---

--- a/project-plugin/skills/changelog-review/SKILL.md
+++ b/project-plugin/skills/changelog-review/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: changelog-review
-description: |
-  Analyze Claude Code changelog for changes that impact plugin development.
-  Use when checking for new features, breaking changes, or opportunities to
-  improve plugins based on Claude Code updates.
+description: Analyze Claude Code changelog for plugin-impact changes. Use when checking new features, breaking changes, or improvement opportunities for plugins from Claude Code updates.
 user-invocable: false
 allowed-tools: Bash(git log *), Bash(git diff *), Read, Write, Edit, Glob, Grep, WebFetch, TodoWrite
 created: 2026-01-14

--- a/project-plugin/skills/project-continue/SKILL.md
+++ b/project-plugin/skills/project-continue/SKILL.md
@@ -1,14 +1,10 @@
 ---
-description: |
-  Analyze project state and continue development where left off. Use when
-  the user asks to resume work, pick up where we left off, figure out what
-  to do next, identify the next task from PRDs and feature tracker, or
-  continue a TDD workflow after a break.
+description: Analyze project state and continue development where left off. Use when the user asks to resume work, pick up where we left off, figure out what to do next, identify the next task from PRDs and feature tracker, or continue TDD after a break.
 args: "[--task <id>] [--skip-status]"
 argument-hint: "--task to resume specific task, --skip-status to skip state analysis"
 allowed-tools: Read, Bash, Grep, Glob, Edit, Write
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: project-continue
 ---

--- a/project-plugin/skills/project-discovery/SKILL.md
+++ b/project-plugin/skills/project-discovery/SKILL.md
@@ -1,9 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: project-discovery
-description: Systematic project orientation for unfamiliar codebases. Automatically activates when Claude detects uncertainty about project state, structure, or tooling. Analyzes git state (branch, changes, commits), project type (language, framework, structure), and development tooling (build, test, lint, CI/CD). Provides structured summary with risk flags and recommendations. Use when entering new projects or when working on shaky assumptions.
+description: Systematic project orientation for unfamiliar codebases. Auto-activates on project uncertainty. Analyzes git state, project type, and dev tooling (build, test, lint, CI/CD). Use when entering new projects or working on shaky assumptions.
 user-invocable: false
 allowed-tools: Bash(ls *), Bash(find *), Bash(wc *), Read, Grep, Glob, TodoWrite
 ---

--- a/project-plugin/skills/project-distill/SKILL.md
+++ b/project-plugin/skills/project-distill/SKILL.md
@@ -1,20 +1,11 @@
 ---
 name: project-distill
-description: |
-  Distill session insights into reusable knowledge: Claude rules, skill
-  improvements, and justfile recipes. Use when the user asks to capture
-  session learnings at end of day, extract patterns worth reusing, update
-  existing rules based on session experience, propose new justfile recipes
-  from commands we ran, or turn pain points into durable artifacts. Also
-  use when the user asks to "codify the workflow" into `.claude/rules`,
-  "analyze session patterns and promote to rules", "write a new rule
-  from these session patterns", or "extract durable knowledge from a
-  productive session". Prioritizes updating over adding.
+description: Distill session insights into reusable knowledge — Claude rules, skill improvements, justfile recipes. Use when capturing session learnings, extracting reusable patterns, updating rules from experience, or codifying workflow into `.claude/rules`.
 allowed-tools: Bash(git diff *), Bash(git log *), Bash(git status *), Bash(just *), Read, Grep, Glob, Edit, Write, AskUserQuestion, TodoWrite
 argument-hint: "--rules | --skills | --recipes | --all | --dry-run"
 args: "[--rules] [--skills] [--recipes] [--all] [--dry-run]"
 created: 2026-02-11
-modified: 2026-04-27
+modified: 2026-05-09
 reviewed: 2026-02-26
 ---
 

--- a/project-plugin/skills/project-init/SKILL.md
+++ b/project-plugin/skills/project-init/SKILL.md
@@ -1,17 +1,12 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 allowed-tools: Write, Bash(mkdir *), Bash(git init *), Bash(gh repo create *), Bash(pwd *), Bash(git config *), Bash(which *), SlashCommand, TodoWrite
 args: <project-name> [project-type] [--github] [--private]
 argument-hint: <project-name> [project-type] [--github] [--private]
 disable-model-invocation: true
-description: |
-  Initialize a new project with a universal base structure (src/tests/docs,
-  git, README, LICENSE, .gitignore, .editorconfig, pre-commit, CI workflow,
-  Makefile). Use when the user asks to start a new project, scaffold a
-  new repo, create project skeleton, or bootstrap a Python/Node/Rust/Go
-  codebase - optionally creating a matching GitHub repository.
+description: Initialize a new project with universal base structure (src/tests/docs, git, README, LICENSE, .gitignore, .editorconfig, pre-commit, CI, Makefile). Use when the user asks to start a new project, scaffold a repo, or bootstrap Python/Node/Rust/Go.
 name: project-init
 ---
 

--- a/project-plugin/skills/project-skill-scripts/SKILL.md
+++ b/project-plugin/skills/project-skill-scripts/SKILL.md
@@ -1,18 +1,11 @@
 ---
 name: project-skill-scripts
-description: |
-  Analyze plugin skills to identify opportunities where supporting scripts
-  would improve performance (fewer tokens, faster execution, consistent
-  results), then optionally create those scripts. Use when the user asks
-  to audit skills for script opportunities, measure script coverage across
-  the plugin portfolio, bulk-create supporting scripts for high-scoring
-  candidates, or extract repeated bash blocks from a SKILL.md into a
-  reusable script.
+description: Analyze plugin skills to find where supporting scripts would improve performance (fewer tokens, faster, more consistent), then optionally create them. Use when auditing skills for script opportunities or extracting bash blocks from SKILL.md.
 args: "[--analyze] [--create <plugin/skill>] [--all]"
 allowed-tools: Bash(chmod *), Bash(mkdir *), Read, Write, Edit, Glob, Grep, TodoWrite
 argument-hint: "--analyze | --create git-plugin/git-commit-workflow | --all"
 created: 2026-01-24
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2026-02-14
 ---
 

--- a/project-plugin/skills/project-test-loop/SKILL.md
+++ b/project-plugin/skills/project-test-loop/SKILL.md
@@ -1,15 +1,10 @@
 ---
-description: |
-  Run an automated test - fix - refactor TDD cycle until tests pass and
-  no refactoring opportunities remain. Use when the user asks to loop on
-  failing tests, iterate on a test pattern, run a TDD cycle, fix failing
-  tests and then refactor, or drive implementation via RED/GREEN/REFACTOR
-  until everything is green.
+description: Run an automated test-fix-refactor TDD cycle until tests pass and no refactoring opportunities remain. Use when the user asks to loop on failing tests, run a TDD cycle, or drive implementation via RED/GREEN/REFACTOR until green.
 args: "[test-pattern] [--max-cycles <N>]"
 argument-hint: "Test pattern to focus on, --max-cycles to limit iterations"
 allowed-tools: Read, Edit, Bash
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: project-test-loop
 ---

--- a/prompt-engineering-plugin/skills/prompt-engineering-ground-response/SKILL.md
+++ b/prompt-engineering-plugin/skills/prompt-engineering-ground-response/SKILL.md
@@ -1,17 +1,11 @@
 ---
 name: ground-response
-description: |
-  Produce grounded, citation-backed responses from source documents. Use when analyzing
-  long documents, answering questions about codebases or specs, or whenever response
-  accuracy is critical. Applies three anti-hallucination techniques: permits uncertainty,
-  extracts direct quotes, and verifies all claims against source material. Trigger phrases:
-  "ground this", "cite sources", "no hallucination", "verify claims", "quote the source",
-  "fact-check this against the doc", "reduce hallucination".
+description: Produce citation-backed responses from source documents with direct quotes and verified claims. Use when analyzing long docs, answering codebase or spec questions, or when response accuracy is critical.
 args: <question or task> [--source <file-or-path>]
 allowed-tools: Read, Grep, Glob, TodoWrite
 argument-hint: <question about a document or codebase>
 created: 2026-03-22
-modified: 2026-03-22
+modified: 2026-05-09
 reviewed: 2026-03-22
 ---
 

--- a/prose-plugin/skills/prose-distill/SKILL.md
+++ b/prose-plugin/skills/prose-distill/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: prose-distill
-description: |
-  Distill verbose text to its concentrated essence. Compress without losing meaning —
-  precis, condensation, verbal economy. Use when user says "distill", "condense",
-  "tighten", "make concise", "make this more concise", "shorten this", "too wordy",
-  "reduce verbosity", "compress this text", "trim the fat", "omit needless words",
-  or asks to reduce text length while preserving substance.
+description: Distill verbose text to its concentrated essence — precis, condensation, verbal economy. Use when asked to condense, tighten, shorten, reduce verbosity, or omit needless words while preserving substance.
 args: "[text or file path]"
 allowed-tools: Read, Edit, Write, Grep, Glob, TodoWrite
 argument-hint: <text to distill> or <path to file>

--- a/prose-plugin/skills/prose-synthesize/SKILL.md
+++ b/prose-plugin/skills/prose-synthesize/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: prose-synthesize
-description: |
-  Synthesize unstructured thinking into a structured, actionable plan. Use when user provides
-  stream-of-consciousness thoughts, scattered notes, or a brain dump and needs them organized
-  into a coherent plan with goals, actions, and priorities. Trigger phrases: "synthesize",
-  "organize my thoughts", "turn this into a plan", "make sense of this", "structure this",
-  "formalize these notes", "what should I do with all this".
+description: Synthesize unstructured thinking into a structured, actionable plan with goals and priorities. Use when given stream-of-consciousness notes, brain dumps, or scattered thoughts that need organizing.
 args: "[prose to synthesize]"
 allowed-tools: Read, Edit, Write, Grep, Glob, TodoWrite
 argument-hint: <unstructured thoughts or file path>

--- a/python-plugin/skills/basedpyright-type-checking/SKILL.md
+++ b/python-plugin/skills/basedpyright-type-checking/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-02-14
+modified: 2026-05-09
 reviewed: 2025-12-16
 name: basedpyright-type-checking
-description: |
-  Basedpyright static type checker configuration, installation, and usage patterns.
-  Use when implementing type checking, configuring LSP, comparing type checkers,
-  or setting up strict type validation in Python projects.
-  Triggered by: basedpyright, pyright, type checking, LSP, mypy alternative, static analysis.
+description: "Basedpyright static type checker config, installation, and usage. Use when implementing type checking, configuring LSP, comparing type checkers, or setting up strict type validation. Triggers: basedpyright, pyright, type checking, mypy alternative."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/python-plugin/skills/pytest-advanced/SKILL.md
+++ b/python-plugin/skills/pytest-advanced/SKILL.md
@@ -1,12 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-01-24
+modified: 2026-05-09
 reviewed: 2026-01-24
 name: pytest-advanced
-description: |
-  Advanced pytest patterns including fixtures, markers, parametrization, and parallel execution.
-  Use when implementing test infrastructure, organizing test suites, writing fixtures,
-  or running tests with coverage. Covers pytest-cov, pytest-asyncio, pytest-xdist, pytest-mock.
+description: "Advanced pytest patterns: fixtures, markers, parametrization, parallel execution. Use when implementing test infrastructure, organizing test suites, writing fixtures, or running with coverage. Covers pytest-cov, pytest-asyncio, pytest-xdist."
 user-invocable: false
 allowed-tools: Bash(pytest *), Bash(python *), Bash(uv run *), Read, Grep, Glob
 ---

--- a/python-plugin/skills/python-code-quality/SKILL.md
+++ b/python-plugin/skills/python-code-quality/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: python-code-quality
-description: |
-  Python code quality with ruff (linting & formatting) and ty (type checking).
-  Covers pyproject.toml configuration, pre-commit hooks, and type hints.
-  Use when user mentions ruff, ty, linting, formatting, type checking,
-  code style, or Python code quality.
+description: Python code quality with ruff (linting & formatting) and ty (type checking). Covers pyproject.toml configuration, pre-commit hooks, and type hints. Use when the user mentions ruff, ty, linting, formatting, type checking, or Python code style.
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/python-plugin/skills/python-development/SKILL.md
+++ b/python-plugin/skills/python-development/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: python-development
-description: |
-  Core Python development concepts, idioms, best practices, and language features.
-  Covers Python 3.10+ features, type hints, async/await, and Pythonic patterns.
-  For running scripts, see uv-run. For project setup, see uv-project-management.
-  Use when user mentions Python, type hints, async Python, decorators, context managers,
-  or writing Pythonic code.
+description: Core Python development concepts, idioms, and language features (3.10+). Covers type hints, async/await, and Pythonic patterns. For scripts see uv-run; for project setup see uv-project-management. Use when mentioning Python, type hints, or async.
 user-invocable: false
 allowed-tools: Glob, Grep, Read, WebFetch, TodoWrite, WebSearch, BashOutput, KillShell, Edit, Write, NotebookEdit, Bash
 ---

--- a/python-plugin/skills/python-packaging/SKILL.md
+++ b/python-plugin/skills/python-packaging/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: python-packaging
-description: |
-  Build and publish Python packages with uv and modern build tools. Covers uv build,
-  uv publish, pyproject.toml, versioning, entry points, and PyPI publishing.
-  Use when user mentions building packages, publishing to PyPI, uv build, uv publish,
-  package distribution, or Python wheel/sdist creation.
+description: Build and publish Python packages with uv and modern build tools. Covers uv build, uv publish, pyproject.toml, versioning, entry points, and PyPI publishing. Use when the user mentions building packages, publishing to PyPI, or wheel/sdist creation.
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/python-plugin/skills/python-testing/SKILL.md
+++ b/python-plugin/skills/python-testing/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: python-testing
-description: |
-  Python testing with pytest, coverage, fixtures, parametrization, and mocking.
-  Covers test organization, conftest.py, markers, async testing, and TDD workflows.
-  Use when user mentions pytest, unit tests, test coverage, fixtures, mocking,
-  or writing Python tests.
+description: Python testing with pytest, coverage, fixtures, parametrization, and mocking. Covers test organization, conftest.py, markers, async testing, and TDD. Use when the user mentions pytest, unit tests, coverage, fixtures, mocking, or writing Python tests.
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/python-plugin/skills/ruff-integration/SKILL.md
+++ b/python-plugin/skills/ruff-integration/SKILL.md
@@ -1,12 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-01-24
+modified: 2026-05-09
 reviewed: 2026-01-24
 name: ruff-integration
-description: |
-  Integrate ruff into development workflows: editor setup, pre-commit hooks, and CI/CD pipelines.
-  Use when configuring ruff in VS Code, setting up pre-commit hooks, or adding ruff to GitHub Actions.
-  For ruff rules/linting config see ruff-linting skill; for formatting see ruff-formatting skill.
+description: "Integrate ruff into dev workflows: editor setup, pre-commit hooks, and CI/CD. Use when configuring ruff in VS Code, setting up pre-commit, or adding ruff to GitHub Actions. For ruff rules see ruff-linting; for formatting see ruff-formatting."
 user-invocable: false
 allowed-tools: Bash(ruff *), Bash(python *), Bash(uv *), Read, Edit, Write, Grep, Glob
 ---

--- a/python-plugin/skills/ty-type-checking/SKILL.md
+++ b/python-plugin/skills/ty-type-checking/SKILL.md
@@ -1,12 +1,9 @@
 ---
 created: 2026-01-29
-modified: 2026-01-29
+modified: 2026-05-09
 reviewed: 2026-01-29
 name: ty-type-checking
-description: |
-  Python type checking with ty, Astral's extremely fast type checker (10-100x faster than mypy/Pyright).
-  Use when checking Python types, configuring type checking rules, or setting up type checking in projects.
-  Triggered by: ty, type checking, type errors, static analysis, mypy alternative, pyright alternative.
+description: "Python type checking with ty, Astral's extremely fast type checker (10-100x faster than mypy/Pyright). Use when checking Python types, configuring rules, or setting up type checking. Triggers: ty, type checking, mypy alternative, pyright alternative."
 user-invocable: false
 allowed-tools: Bash(ty *), Bash(python *), Bash(uv *), Read, Edit, Write, Grep, Glob, TodoWrite
 ---

--- a/python-plugin/skills/uv-advanced-dependencies/SKILL.md
+++ b/python-plugin/skills/uv-advanced-dependencies/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: uv-advanced-dependencies
-description: |
-  Advanced dependency scenarios in uv projects: Git dependencies, path dependencies,
-  editable installs, dependency groups, extras, constraints, and custom indexes.
-  Use when user mentions git+https dependencies, local path dependencies, editable
-  installs, dependency groups, or private package indexes.
+description: "Advanced dependency scenarios in uv projects: Git deps, path deps, editable installs, dependency groups, extras, constraints, and custom indexes. Use when the user mentions git+https deps, local path deps, editable installs, or private indexes."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/python-plugin/skills/uv-project-management/SKILL.md
+++ b/python-plugin/skills/uv-project-management/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: uv-project-management
-description: |
-  Python project setup, dependencies, and lockfiles with uv package manager. Covers
-  uv init, uv add, uv remove, uv lock, uv sync, and pyproject.toml configuration.
-  Use when user mentions uv, creating Python projects, managing dependencies,
-  lockfiles, pyproject.toml, or Python packaging with uv.
+description: Python project setup, dependencies, and lockfiles with uv. Covers uv init, uv add, uv remove, uv lock, uv sync, and pyproject.toml. Use when the user mentions uv, creating Python projects, managing deps, lockfiles, or pyproject.toml.
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/python-plugin/skills/uv-python-versions/SKILL.md
+++ b/python-plugin/skills/uv-python-versions/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: uv-python-versions
-description: |
-  Install and manage Python interpreter versions with uv. Covers uv python install,
-  uv python list, uv python pin, version pinning with .python-version file.
-  Use when user mentions installing Python versions, switching Python versions,
-  .python-version, uv python, or managing CPython/PyPy interpreters.
+description: Install and manage Python interpreter versions with uv. Covers uv python install/list/pin and .python-version pinning. Use when the user mentions installing or switching Python versions, .python-version, uv python, or managing CPython/PyPy.
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/python-plugin/skills/uv-run/SKILL.md
+++ b/python-plugin/skills/uv-run/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: uv-run
-description: |
-  Run Python scripts with uv including inline dependencies (PEP 723),
-  temporary dependencies (--with), and ephemeral tool execution.
-  Use when running scripts, needing one-off dependencies, or creating
-  executable Python scripts. No venv activation required.
+description: Run Python scripts with uv including inline dependencies (PEP 723), temporary deps (--with), and ephemeral tool execution. Use when running scripts, needing one-off dependencies, or creating executable Python scripts. No venv activation required.
 user-invocable: false
 allowed-tools: Glob, Grep, Read, WebFetch, TodoWrite, WebSearch, BashOutput, KillShell, Edit, Write, NotebookEdit, Bash
 ---

--- a/python-plugin/skills/uv-tool-management/SKILL.md
+++ b/python-plugin/skills/uv-tool-management/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: uv-tool-management
-description: |
-  Install and manage global Python CLI tools with uv (pipx alternative). Covers
-  uv tool install, uvx for ephemeral execution, tool isolation, and updates.
-  Use when user mentions uv tool, uvx, installing CLI tools globally, pipx
-  replacement, or running Python tools without installation.
+description: Install and manage global Python CLI tools with uv (pipx alternative). Covers uv tool install, uvx for ephemeral execution, tool isolation, and updates. Use when the user mentions uv tool, uvx, installing CLI tools globally, or pipx replacement.
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/python-plugin/skills/uv-workspaces/SKILL.md
+++ b/python-plugin/skills/uv-workspaces/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-02-12
+modified: 2026-05-09
 reviewed: 2026-02-12
 name: uv-workspaces
-description: |
-  Manage monorepo and multi-package Python projects with uv workspaces. Covers
-  workspace configuration, virtual workspaces, member dependencies, shared lockfiles,
-  source inheritance, and building. Use when user mentions uv workspaces, Python
-  monorepo, multi-package projects, workspace members, or shared dependencies across
-  packages.
+description: Manage monorepo and multi-package Python projects with uv workspaces. Covers workspace config, virtual workspaces, member deps, shared lockfiles, source inheritance, and building. Use when the user mentions uv workspaces or Python monorepo.
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/python-plugin/skills/vulture-dead-code/SKILL.md
+++ b/python-plugin/skills/vulture-dead-code/SKILL.md
@@ -1,12 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-02-14
+modified: 2026-05-09
 reviewed: 2025-12-16
 name: vulture-dead-code
-description: |
-  Vulture and deadcode tools for detecting unused Python code (functions, classes, variables, imports).
-  Use when cleaning up codebases, removing unused code, or enforcing code hygiene in CI.
-  Triggered by: vulture, deadcode, dead code detection, unused code, code cleanup, remove unused.
+description: "Vulture and deadcode tools for detecting unused Python code (functions, classes, variables, imports). Use when cleaning up codebases, removing unused code, or enforcing hygiene in CI. Triggers: vulture, deadcode, dead code detection, unused code."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/rust-plugin/skills/cargo-llvm-cov/SKILL.md
+++ b/rust-plugin/skills/cargo-llvm-cov/SKILL.md
@@ -1,12 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: cargo-llvm-cov
-description: |
-  Code coverage for Rust using LLVM instrumentation with support for multiple output formats and CI integration.
-  Use when measuring test coverage, generating coverage reports, enforcing coverage thresholds, or integrating with codecov/coveralls.
-  Trigger terms: coverage, llvm-cov, code coverage, test coverage, coverage report, codecov, coveralls, branch coverage.
+description: "Code coverage for Rust using LLVM instrumentation, multiple output formats, and CI integration. Use when measuring coverage, generating reports, enforcing thresholds, or integrating codecov/coveralls. Triggers: coverage, llvm-cov, codecov."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/rust-plugin/skills/cargo-machete/SKILL.md
+++ b/rust-plugin/skills/cargo-machete/SKILL.md
@@ -1,12 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-02-11
+modified: 2026-05-09
 reviewed: 2025-12-16
 name: cargo-machete
-description: |
-  Detect unused dependencies in Rust projects for cleaner Cargo.toml files and faster builds.
-  Use when auditing dependencies, optimizing build times, cleaning up Cargo.toml, or detecting bloat.
-  Trigger terms: unused dependencies, cargo-machete, dependency audit, dependency cleanup, bloat detection, cargo-udeps.
+description: "Detect unused dependencies in Rust projects for cleaner Cargo.toml and faster builds. Use when auditing deps, optimizing build times, cleaning up Cargo.toml, or detecting bloat. Triggers: unused dependencies, cargo-machete, cargo-udeps."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/rust-plugin/skills/cargo-nextest/SKILL.md
+++ b/rust-plugin/skills/cargo-nextest/SKILL.md
@@ -1,12 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: cargo-nextest
-description: |
-  Next-generation test runner for Rust with parallel execution, advanced filtering, and CI integration.
-  Use when running tests, configuring test execution, setting up CI pipelines, or optimizing test performance.
-  Trigger terms: nextest, test runner, parallel tests, test filtering, test performance, flaky tests, CI testing.
+description: "Next-gen test runner for Rust with parallel execution, advanced filtering, and CI integration. Use when running tests, configuring execution, setting up CI, or optimizing performance. Triggers: nextest, test runner, parallel tests, flaky tests."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/rust-plugin/skills/clippy-advanced/SKILL.md
+++ b/rust-plugin/skills/clippy-advanced/SKILL.md
@@ -1,12 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-02-14
+modified: 2026-05-09
 reviewed: 2025-12-16
 name: clippy-advanced
-description: |
-  Advanced Clippy configuration for comprehensive Rust linting with custom rules, categories, and IDE integration.
-  Use when configuring linting rules, enforcing code standards, setting up CI linting, or customizing clippy behavior.
-  Trigger terms: clippy, linting, code quality, clippy.toml, pedantic, nursery, restriction, lint configuration, code standards.
+description: "Advanced Clippy configuration for Rust linting with custom rules, categories, and IDE integration. Use when configuring lint rules, enforcing standards, setting up CI linting, or customizing clippy. Triggers: clippy, clippy.toml, pedantic, nursery."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/rust-plugin/skills/rust-development/SKILL.md
+++ b/rust-plugin/skills/rust-development/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: rust-development
-description: |
-  Modern Rust development with cargo, rustc, clippy, rustfmt, async programming, and
-  memory-safe systems programming. Covers ownership patterns, fearless concurrency,
-  and the modern Rust ecosystem including Tokio, Serde, and popular crates.
-  Use when user mentions Rust, cargo, rustc, clippy, rustfmt, ownership, borrowing,
-  lifetimes, async Rust, or Rust crates.
+description: Modern Rust development with cargo, rustc, clippy, rustfmt, async, and memory-safe systems programming. Covers ownership, fearless concurrency, and the modern ecosystem (Tokio, Serde). Use when mentioning Rust, cargo, ownership, lifetimes, or async.
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash, Edit, Write, TodoWrite, WebFetch, WebSearch, BashOutput, KillShell
 ---

--- a/taskwarrior-plugin/skills/task-add/SKILL.md
+++ b/taskwarrior-plugin/skills/task-add/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: task-add
-description: |
-  File a new taskwarrior task with blueprint linkage (bpid/bpdoc/bpms) and,
-  when a GitHub remote is present, optional issue linkage via ghid. Checks
-  for duplicates by bpid, offers to pre-fill from an existing GitHub issue,
-  or offers to create a new issue. Use when adding a coordination task for
-  multi-agent work, linking a blueprint WO to an actionable queue entry,
-  or mirroring a GitHub issue into the local task queue.
+description: File a new taskwarrior task with blueprint linkage (bpid/bpdoc/bpms) and optional GitHub issue linkage. Use when adding multi-agent coordination tasks, linking a blueprint WO, or mirroring a GitHub issue locally.
 args: "[description] [project:<name>] [--no-project]"
 allowed-tools: Bash(task *), Bash(git config *), Bash(git rev-parse *), Bash(gh auth *), Bash(gh issue *), Bash(gh api *), Read, TodoWrite
 argument-hint: short task description

--- a/taskwarrior-plugin/skills/task-coordinate/SKILL.md
+++ b/taskwarrior-plugin/skills/task-coordinate/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: task-coordinate
-description: |
-  Surface the next N unblocked taskwarrior tasks sorted by urgency,
-  filtered to skip any that contend on the same exclusive lock (Ghidra
-  project, git index, migration, bulk task store). Produces a
-  candidate-agent list for a parallel or wave dispatch. Use when
-  planning a parallel-agent-dispatch wave, when deciding which tasks
-  share a dispatch slot, or when deciding whether to pre-dump a locked
-  resource before fanning out.
+description: Surface the next N unblocked taskwarrior tasks sorted by urgency, skipping lock-contending tasks. Use when planning a parallel-agent-dispatch wave or deciding which tasks share a dispatch slot.
 args: "[--n=N] [--lock=<resource>] [--wave] [--project=<name>] [--all]"
 allowed-tools: Bash(task *), Bash(git rev-parse *), Bash(jq *), Read, TodoWrite
 argument-hint: optional count (default 3) and lock filter

--- a/taskwarrior-plugin/skills/task-done/SKILL.md
+++ b/taskwarrior-plugin/skills/task-done/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: task-done
-description: |
-  Close a taskwarrior task, annotate it with the landing commit hash, drain
-  the linked blueprint feature-tracker entry, and — when GitHub linkage is
-  present — offer to close the linked issue or comment on the linked PR.
-  Use when finishing a coordination task, marking a WO as complete, closing
-  out research after findings are promoted to docs, or closing a GitHub
-  issue linked via ghid.
+description: Close a taskwarrior task, annotate it with the landing commit, drain the linked feature-tracker entry, and optionally close linked GitHub issues/PRs. Use when finishing a coordination task or marking a WO complete.
 args: "<task-id> [commit-hash]"
 allowed-tools: Bash(task *), Bash(git config *), Bash(git log *), Bash(git rev-parse *), Bash(gh auth *), Bash(gh issue *), Bash(gh pr *), Read, Edit, TodoWrite
 argument-hint: task id (required), commit sha (optional — defaults to HEAD)

--- a/taskwarrior-plugin/skills/task-status/SKILL.md
+++ b/taskwarrior-plugin/skills/task-status/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: task-status
-description: |
-  Read-only consolidated taskwarrior queue report — pending, blocked,
-  ready, and drift detection between the queue and linked trackers / PRs.
-  When a GitHub remote is present, folds in gh pr status so "PR #99 green,
-  task #7 still pending" surfaces in one view. Use when auditing queue
-  health, orienting before a wave dispatch, spotting tasks that lost
-  their linked issue or PR, or producing a standup summary.
+description: Read-only taskwarrior queue report covering pending, blocked, ready tasks plus drift between the queue and linked PRs/trackers. Use when auditing queue health, orienting before a wave, or for standup summaries.
 args: "[--mine] [--blocked] [--stale=N] [--project=<name>] [--all]"
 allowed-tools: Bash(task *), Bash(git config *), Bash(git rev-parse *), Bash(gh auth *), Bash(gh pr *), Bash(jq *), Read, TodoWrite
 argument-hint: optional filters

--- a/terraform-plugin/skills/infrastructure-terraform/SKILL.md
+++ b/terraform-plugin/skills/infrastructure-terraform/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: infrastructure-terraform
-description: |
-  Infrastructure as Code with Terraform including HCL configuration, state management,
-  modular design, and plan-apply workflows. Covers cloud and on-prem resource provisioning,
-  remote backends, and Terraform modules.
-  Use when user mentions Terraform, HCL, terraform plan, terraform apply, tfstate,
-  infrastructure as code, or IaC provisioning.
+description: "Infrastructure as Code with Terraform: HCL, state management, modular design, plan-apply workflows. Covers cloud and on-prem provisioning, remote backends, and modules. Use when the user mentions Terraform, HCL, terraform plan/apply, tfstate, or IaC."
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash, Edit, Write, TodoWrite
 ---

--- a/terraform-plugin/skills/tfc-list-runs/SKILL.md
+++ b/terraform-plugin/skills/tfc-list-runs/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: tfc-list-runs
-description: List Terraform Cloud runs for a workspace with filtering by status, operation type, and date. Use when reviewing run history, finding failed runs, or auditing infrastructure changes. Requires TFE_TOKEN environment variable.
+description: List Terraform Cloud runs for a workspace, filtering by status, operation, or date. Use when reviewing run history, finding failed runs, or auditing infra changes. Requires TFE_TOKEN.
 user-invocable: false
 allowed-tools: Bash, Read
 ---

--- a/terraform-plugin/skills/tfc-plan-json/SKILL.md
+++ b/terraform-plugin/skills/tfc-plan-json/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: tfc-plan-json
-description: Download and analyze structured Terraform plan JSON output from Terraform Cloud. Use when analyzing resource changes, diffing infrastructure, or programmatically inspecting plan details. Requires TFE_TOKEN environment variable.
+description: Download and analyze structured plan JSON from Terraform Cloud runs. Use when diffing resource changes, inspecting replacement reasons, or feeding plan data downstream. Requires TFE_TOKEN.
 user-invocable: false
 allowed-tools: Bash, Read
 ---

--- a/terraform-plugin/skills/tfc-run-status/SKILL.md
+++ b/terraform-plugin/skills/tfc-run-status/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: tfc-run-status
-description: Quick status check for Terraform Cloud runs showing status, resource changes, timestamps, and available actions. Use when monitoring run progress or checking if a run can be applied/canceled. Requires TFE_TOKEN environment variable.
+description: Quick status check for a Terraform Cloud run with resource counts, timestamps, and actions. Use when polling a run, checking pass/fail, or seeing if it can be applied or canceled. Requires TFE_TOKEN.
 user-invocable: false
 allowed-tools: Bash, Read
 ---

--- a/terraform-plugin/skills/tfc-workspace-runs/SKILL.md
+++ b/terraform-plugin/skills/tfc-workspace-runs/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: tfc-workspace-runs
-description: |
-  Convenience wrapper for listing Terraform Cloud runs in Forum Virium Helsinki
-  workspaces (github, sentry, gcp, onelogin, twingate). Requires TFE_TOKEN.
-  Use when user mentions TFC runs, Terraform Cloud workspace, listing TFC runs,
-  infrastructure run history, or checking Terraform Cloud status.
+description: Convenience wrapper for listing Terraform Cloud runs in Forum Virium Helsinki workspaces (github, sentry, gcp, onelogin, twingate). Requires TFE_TOKEN. Use when mentioning TFC runs, Terraform Cloud workspace, or checking TFC status.
 user-invocable: false
 allowed-tools: Bash, Read
 ---

--- a/testing-plugin/skills/hypothesis-testing/SKILL.md
+++ b/testing-plugin/skills/hypothesis-testing/SKILL.md
@@ -1,12 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: hypothesis-testing
-description: |
-  Property-based testing with Hypothesis for discovering edge cases and validating invariants.
-  Use when testing code with many possible inputs, verifying mathematical properties,
-  testing serialization round-trips, or finding edge cases that example-based tests miss.
+description: "Property-based testing with Hypothesis for Python. Use when testing code with many possible inputs, verifying invariants, testing serialization round-trips, or finding edge cases that example-based tests miss."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/testing-plugin/skills/mutation-testing/SKILL.md
+++ b/testing-plugin/skills/mutation-testing/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-02-14
+modified: 2026-05-09
 reviewed: 2025-12-16
 name: mutation-testing
-description: |
-  Validate test effectiveness with mutation testing using Stryker (TypeScript/JavaScript)
-  and mutmut (Python). Find weak tests that pass despite code mutations.
-  Use when user mentions mutation testing, Stryker, mutmut, test effectiveness,
-  finding weak tests, or improving test quality through mutation analysis.
+description: "Validate test effectiveness with mutation testing using Stryker (TS/JS) and mutmut (Python). Use when finding weak tests that pass despite mutated code, or improving test quality through mutation analysis."
 user-invocable: false
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob, TodoWrite
 ---

--- a/testing-plugin/skills/playwright-cli/SKILL.md
+++ b/testing-plugin/skills/playwright-cli/SKILL.md
@@ -3,10 +3,7 @@ created: 2026-03-19
 modified: 2026-03-19
 reviewed: 2026-03-19
 name: playwright-cli
-description: |
-  Playwright CLI browser automation for AI agents. Navigate pages, take screenshots,
-  fill forms, click elements from the command line. Use when automating browser tasks
-  with shell access. Prefer over Playwright MCP (4-10x more token-efficient).
+description: Automate browsers from the shell with Playwright CLI — navigate, screenshot, fill forms, click. Use when automating browser tasks from the shell; preferred over Playwright MCP (4-10x more token-efficient).
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob, TodoWrite
 ---

--- a/testing-plugin/skills/playwright-testing/SKILL.md
+++ b/testing-plugin/skills/playwright-testing/SKILL.md
@@ -1,12 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-02-14
+modified: 2026-05-09
 reviewed: 2025-12-16
 name: playwright-testing
-description: |
-  Playwright end-to-end testing for web applications. Cross-browser testing (Chromium, Firefox, WebKit),
-  visual regression, API testing, mobile emulation. Use when writing E2E tests, testing across browsers,
-  or setting up automated UI testing workflows.
+description: "Playwright E2E testing for web apps with cross-browser (Chromium, Firefox, WebKit), visual regression, API testing, and mobile emulation. Use when writing E2E tests or setting up automated UI testing."
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash, Edit, Write, TodoWrite, WebFetch, WebSearch, BashOutput, KillShell
 ---

--- a/testing-plugin/skills/property-based-testing/SKILL.md
+++ b/testing-plugin/skills/property-based-testing/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-02-14
+modified: 2026-05-09
 reviewed: 2025-12-16
 name: property-based-testing
-description: |
-  Property-based testing with fast-check (TypeScript/JavaScript) and Hypothesis (Python).
-  Generate test cases automatically, find edge cases, and test mathematical properties.
-  Use when user mentions property-based testing, fast-check, Hypothesis, generating
-  test data, QuickCheck-style testing, or finding edge cases automatically.
+description: "Property-based testing with fast-check (TS/JS) and Hypothesis (Python). Use when generating test data, finding edge cases automatically, testing mathematical properties, or writing QuickCheck-style tests."
 user-invocable: false
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob, TodoWrite
 ---

--- a/testing-plugin/skills/test-analyze/SKILL.md
+++ b/testing-plugin/skills/test-analyze/SKILL.md
@@ -1,15 +1,10 @@
 ---
-description: |
-  Analyze test results and create a systematic fix plan with subagent
-  delegation. Use when the user asks to triage failing tests, analyze a
-  test-results directory or JUnit XML, plan fixes for accessibility or
-  security scan findings, categorize flaky/performance/E2E failures, or
-  delegate fixes to specialized agents.
+description: "Analyze test results and create a fix plan with subagent delegation. Use when triaging failing tests, analyzing JUnit XML or test-results dirs, planning fixes for accessibility/security findings, or categorizing flaky/perf/E2E failures."
 args: "<results-path> [--type <test-type>] [--focus <area>]"
 argument-hint: "Path to test results (e.g., ./test-results/), optional --type and --focus filters"
 allowed-tools: Task, Read, Glob, Grep, TodoWrite
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: test-analyze
 agent: general-purpose

--- a/testing-plugin/skills/test-consult/SKILL.md
+++ b/testing-plugin/skills/test-consult/SKILL.md
@@ -1,15 +1,11 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 allowed-tools: Task, Read, Glob, Grep
 args: "<topic> [--context <path>]"
 argument-hint: "<topic> [--context <path>]"
-description: |
-  Consult the test-architecture agent for testing strategy and design
-  decisions. Use when the user asks for advice on test coverage gaps, test
-  pyramid balance, framework selection, flaky-test remediation, designing
-  tests for a new feature, or any strategic "how should we test X?" question.
+description: "Consult the test-architecture agent for testing strategy decisions. Use when asking about coverage gaps, test pyramid balance, framework selection, flaky-test remediation, or \"how should we test X?\" questions."
 name: test-consult
 ---
 

--- a/testing-plugin/skills/test-focus/SKILL.md
+++ b/testing-plugin/skills/test-focus/SKILL.md
@@ -1,16 +1,11 @@
 ---
 created: 2026-01-19
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 allowed-tools: Bash, Read, Grep, Glob, TodoWrite
 args: "<file-path> [--serial] [--debug]"
 argument-hint: "<file-path> [--serial] [--debug]"
-description: |
-  Run a single test file in fail-fast mode for rapid TDD iteration across
-  Playwright, Vitest, Jest, pytest, cargo, or go test. Use when the user
-  asks to rerun one test file, iterate quickly on a failing spec, stop at
-  the first failure, run a test in headed/debug mode, or force serial
-  execution for WebGL or database tests.
+description: "Run a single test file in fail-fast mode for rapid TDD across Playwright, Vitest, Jest, pytest, cargo, or go test. Use when rerunning one test file, iterating on a failing spec, headed/debug mode, or serial WebGL/database tests."
 name: test-focus
 ---
 

--- a/testing-plugin/skills/test-full/SKILL.md
+++ b/testing-plugin/skills/test-full/SKILL.md
@@ -1,16 +1,11 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 allowed-tools: Task, TodoWrite
 args: "[--coverage] [--parallel] [--report]"
 argument-hint: "[--coverage] [--parallel] [--report]"
-description: |
-  Run the complete test suite in pyramid order - unit, then integration,
-  then E2E. Use when the user asks to run all tests before a PR, run the
-  full test suite with coverage, execute integration and E2E together,
-  generate an HTML test report, or run pre-commit verification across all
-  test tiers.
+description: "Run the complete test suite in pyramid order — unit, then integration, then E2E. Use when running all tests before a PR, with coverage, generating HTML reports, or pre-commit verification across all test tiers."
 name: test-full
 agent: general-purpose
 ---

--- a/testing-plugin/skills/test-quick/SKILL.md
+++ b/testing-plugin/skills/test-quick/SKILL.md
@@ -1,15 +1,11 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 allowed-tools: Task, TodoWrite
 args: "[path] [--watch] [--affected]"
 argument-hint: "[path] [--watch] [--affected]"
-description: |
-  Run fast unit tests only, skipping slow/integration/E2E tiers. Use when
-  the user asks to run quick tests, check unit tests after a change, run
-  only affected tests since the last commit, enable watch mode for TDD,
-  or get sub-30-second feedback while iterating.
+description: "Run fast unit tests only, skipping slow/integration/E2E tiers. Use when checking unit tests after a change, running affected tests since last commit, watch mode for TDD, or sub-30s feedback while iterating."
 name: test-quick
 ---
 

--- a/testing-plugin/skills/test-report/SKILL.md
+++ b/testing-plugin/skills/test-report/SKILL.md
@@ -1,16 +1,11 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 allowed-tools: Read, Glob, Bash(git *)
 args: "[--history] [--coverage] [--flaky]"
 argument-hint: "[--history] [--coverage] [--flaky]"
-description: |
-  Show test status from the last run without re-executing tests, reading
-  cached results from pytest/vitest/jest/playwright/go/cargo caches. Use
-  when the user asks for current test health, wants a quick status check
-  for standup, needs to see coverage summary or history trend, or wants to
-  identify flaky tests from recent runs.
+description: "Show test status from cached pytest/vitest/jest/playwright/go/cargo results without re-running. Use when checking current test health, standup status, coverage summary or history, or identifying flaky tests from recent runs."
 name: test-report
 ---
 

--- a/testing-plugin/skills/test-run/SKILL.md
+++ b/testing-plugin/skills/test-run/SKILL.md
@@ -1,16 +1,11 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 allowed-tools: Task, TodoWrite
 args: "[test-pattern] [--coverage] [--watch]"
 argument-hint: "[test-pattern] [--coverage] [--watch]"
-description: |
-  Universal test runner that auto-detects and runs the appropriate testing
-  framework (pytest, vitest, jest, cargo test, go test). Use when the user
-  asks to run the tests, test a specific file or pattern, run tests with
-  coverage, start a watch-mode dev loop, or run tests without specifying
-  the framework.
+description: "Universal test runner that auto-detects pytest, vitest, jest, cargo test, or go test. Use when running tests, testing a specific file or pattern, running with coverage, watch-mode dev loops, or running tests without specifying a framework."
 name: test-run
 ---
 

--- a/testing-plugin/skills/test-setup/SKILL.md
+++ b/testing-plugin/skills/test-setup/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 allowed-tools: Read, Write, Edit, MultiEdit, Bash(pip install *), Bash(npm install *), Bash(pre-commit *), Bash(pytest *), Bash(npm test *), Bash(git *), TodoWrite, SlashCommand
-description: |
-  Configure comprehensive testing infrastructure with CI/CD integration.
-  Use when the user asks to set up testing, scaffold unit/integration/E2E
-  test directories, add pre-commit hooks, create GitHub Actions test
-  workflows, wire up Codecov coverage reporting, or add test and coverage
-  badges to the README.
+description: "Configure testing infrastructure with CI/CD integration. Use when setting up testing, scaffolding unit/integration/E2E directories, adding pre-commit hooks, GitHub Actions test workflows, Codecov reporting, or coverage badges."
 args: "[--coverage] [--ci <github|gitlab|circleci>]"
 argument-hint: "[--coverage] [--ci <github|gitlab|circleci>]"
 name: test-setup

--- a/testing-plugin/skills/vitest-testing/SKILL.md
+++ b/testing-plugin/skills/vitest-testing/SKILL.md
@@ -1,12 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-02-14
+modified: 2026-05-09
 reviewed: 2025-12-16
 name: vitest-testing
-description: |
-  Vitest test runner for JavaScript and TypeScript. Fast, modern alternative to Jest.
-  Vite-native, ESM support, watch mode, UI mode, coverage, mocking, snapshot testing.
-  Use when setting up tests for Vite projects, migrating from Jest, or needing fast test execution.
+description: "Vitest test runner for JavaScript and TypeScript — Vite-native, ESM, watch/UI mode, coverage, mocking, snapshots. Use when setting up tests for Vite projects, migrating from Jest, or needing fast test execution."
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash, Edit, Write, TodoWrite, WebFetch, WebSearch, BashOutput, KillShell
 ---

--- a/tools-plugin/skills/binary-analysis/SKILL.md
+++ b/tools-plugin/skills/binary-analysis/SKILL.md
@@ -1,16 +1,10 @@
 ---
 name: binary-analysis
-description: |
-  Reverse engineering and binary exploration using strings, binwalk, hexdump, xxd, file, and
-  objdump. Use when the user needs to identify unknown file types, extract printable strings
-  from compiled binaries or firmware, analyze firmware images for embedded files, inspect
-  raw hex data, hunt for hardcoded credentials or URLs inside binaries, run entropy analysis
-  to find compressed/encrypted regions, or when they mention "reverse engineer", "firmware
-  analysis", "strings dump", "binwalk", or "hexdump this binary".
+description: Reverse engineer binaries with strings, binwalk, hexdump, xxd, file, objdump. Use when identifying unknown files, extracting strings, hunting credentials, or entropy analysis.
 user-invocable: false
 allowed-tools: Bash(file *), Bash(xxd *), Bash(hexdump *), Bash(strings *), Bash(objdump *), Bash(readelf *), Bash(nm *), Read, Grep, Glob
 created: 2025-12-27
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 ---
 

--- a/tools-plugin/skills/cli-smoke-recipes/SKILL.md
+++ b/tools-plugin/skills/cli-smoke-recipes/SKILL.md
@@ -1,18 +1,10 @@
 ---
 name: cli-smoke-recipes
-description: |
-  Advisory pattern for exposing pure-function modules via CLI subcommands
-  and a bulk-smoke justfile recipe. Applies to decoders, codecs, parsers,
-  validators, formatters, compilers, transpilers — any module with an
-  input-to-output contract. Use when designing a new module that
-  transforms data, when adding CLI access to an existing library, when
-  authoring smoke recipes that iterate every shipped input, or when
-  deciding whether a feature can advance past "in progress" without its
-  CLI surface.
+description: Expose pure-function modules (decoders, parsers, formatters) via CLI subcommands plus a bulk-smoke justfile recipe. Use when designing data-transform modules or authoring smoke recipes.
 allowed-tools: Read, Grep, Glob, TodoWrite
 model: sonnet
 created: 2026-04-24
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-24
 ---
 

--- a/tools-plugin/skills/d2-diagrams/skill.md
+++ b/tools-plugin/skills/d2-diagrams/skill.md
@@ -1,14 +1,11 @@
 ---
 name: d2-diagrams
-description: |
-  Generate diagrams from declarative text using D2 - modern text-to-diagram language with
-  automatic layouts, themes, and advanced styling. Use when creating architecture diagrams,
-  flowcharts, decision trees, workflow diagrams, sequence flows, or ERDs from text definitions.
+description: Generate diagrams from text using D2 with automatic layouts and themes. Use when creating architecture diagrams, flowcharts, decision trees, sequence flows, or ERDs.
 user-invocable: false
 allowed-tools: Bash(d2 *), Read, Write, Grep, Glob, TodoWrite
 model: sonnet
 created: 2025-12-26
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-02-06
 ---
 

--- a/tools-plugin/skills/deps-install/SKILL.md
+++ b/tools-plugin/skills/deps-install/SKILL.md
@@ -1,18 +1,12 @@
 ---
 created: 2025-12-16
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-25
 allowed-tools: Bash(uv *), Bash(npm *), Bash(bun *), Bash(cargo *), Bash(go *), Bash(brew *), Read, Write
 model: sonnet
 args: "[package-names] [--dev] [--global]"
 argument-hint: "[package-names] [--dev] [--global]"
-description: |
-  Universal dependency installer that auto-detects the project's package manager (uv, bun,
-  npm, yarn, pnpm, cargo, go) and runs the correct install command for dev, global, or
-  project-local installs. Use when the user wants to install dependencies without worrying
-  which package manager the project uses, add a package as a dev dependency, install
-  globally, sync the lockfile, or when they mention "install dependencies", "add package",
-  or "run the right package manager here".
+description: Auto-detect the project's package manager (uv, bun, npm, yarn, pnpm, cargo, go) and run the right install. Use when installing deps, adding dev/global packages, or syncing lockfiles.
 name: deps-install
 ---
 

--- a/tools-plugin/skills/generate-image/SKILL.md
+++ b/tools-plugin/skills/generate-image/SKILL.md
@@ -1,13 +1,8 @@
 ---
 created: 2025-12-16
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-25
-description: |
-  Generate images from a text prompt using Google's Nano Banana Pro (Gemini 3 Pro Image)
-  with configurable aspect ratio, resolution (1K/2K/4K), and up to 5 reference images. Use
-  when the user wants to generate an image, produce artwork for a blog post, create a
-  product photo, mock up a portrait or cinematic scene, or when they mention "generate an
-  image", "make a picture", "Nano Banana", or "Gemini image".
+description: Generate images via Google's Nano Banana Pro (Gemini 3 Pro Image) with configurable aspect ratio, resolution, and reference images. Use when creating artwork, product photos, or mockups.
 allowed-tools: Bash, Read, WebFetch
 model: sonnet
 args: <prompt> [--aspect <ratio>] [--resolution <size>] [--reference <path>]

--- a/tools-plugin/skills/imagemagick-conversion/SKILL.md
+++ b/tools-plugin/skills/imagemagick-conversion/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2025-12-16
 name: imagemagick-conversion
-description: |
-  Convert and manipulate images with ImageMagick. Covers format conversion,
-  resizing, batch processing, quality adjustment, and image transformations.
-  Use when user mentions image conversion, resizing images, ImageMagick,
-  magick command, batch image processing, or thumbnail generation.
+description: Convert and manipulate images with ImageMagick — format conversion, resizing, batch processing, quality. Use when converting, resizing, batch-processing, or generating thumbnails.
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 model: sonnet

--- a/tools-plugin/skills/justfile-expert/SKILL.md
+++ b/tools-plugin/skills/justfile-expert/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-02-06
 name: justfile-expert
-description: |
-  Just command runner expertise, Justfile syntax, recipe development, and cross-platform
-  task automation. Covers recipe patterns, parameters, modules, settings, shebang recipes
-  for multi-language scripts, and workflow integration. Use when user mentions just,
-  justfile, recipes, command runner, task automation, project commands, or needs help
-  writing executable project documentation.
+description: Just command runner expertise — Justfile syntax, recipes, parameters, modules, shebang recipes. Use when authoring justfiles, project commands, or task automation.
 user-invocable: false
 allowed-tools: Bash, BashOutput, Grep, Glob, Read, Write, Edit, TodoWrite
 model: sonnet

--- a/tools-plugin/skills/mermaid-diagrams/skill.md
+++ b/tools-plugin/skills/mermaid-diagrams/skill.md
@@ -1,17 +1,11 @@
 ---
 name: mermaid-diagrams
-description: |
-  Generate diagrams from text using the Mermaid CLI (mmdc) — flowcharts, sequence diagrams,
-  ERDs, class diagrams, state machines, Gantt charts, pie charts, and git graphs — with
-  output as SVG, PNG, or PDF. Use when the user wants to render a Mermaid diagram, convert
-  .mmd text to an image, embed diagrams in GitHub Markdown, create an architecture or API
-  flow diagram, or when they mention "mermaid", "flowchart", "sequence diagram", or
-  "render this diagram".
+description: Render Mermaid diagrams (mmdc) to SVG/PNG/PDF — flowcharts, sequence, ERDs, class, state, Gantt, pie, gitGraph. Use when rendering .mmd or embedding diagrams in GitHub Markdown.
 user-invocable: false
 allowed-tools: Bash, Read, Write, Grep, Glob, TodoWrite
 model: sonnet
 created: 2025-12-26
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-25
 ---
 

--- a/tools-plugin/skills/nushell-data-processing/skill.md
+++ b/tools-plugin/skills/nushell-data-processing/skill.md
@@ -1,15 +1,9 @@
 ---
 created: 2025-12-25
-modified: 2026-05-04
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: nushell-data-processing
-description: |
-  Structured data processing with nushell — native tables, multi-format parsing (JSON, YAML,
-  TOML, CSV, XML), pipelines, aggregations, and group-by operations. Preferred over jq/yq
-  for complex multi-step transforms. Use when the user wants to run multi-step data
-  transformations, process multiple formats together, aggregate or group records, perform
-  cross-file data operations, visually explore data as tables, or when they mention
-  "nushell", "nu pipeline", or ask for transforms that would be awkward in jq.
+description: Structured data processing with nushell — native tables, multi-format parsing (JSON/YAML/TOML/CSV/XML), pipelines, group-by. Use when running multi-step cross-format transforms awkward in jq.
 user-invocable: false
 allowed-tools: Bash(nu *), Read, Write, Edit, Grep, Glob
 model: sonnet

--- a/tools-plugin/skills/shell-expert/SKILL.md
+++ b/tools-plugin/skills/shell-expert/SKILL.md
@@ -1,14 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: shell-expert
-description: |
-  Shell scripting expertise, command-line tools, automation, and cross-platform
-  scripting best practices. Covers shell script development, CLI tool usage,
-  and system automation with bash, zsh, and POSIX shell.
-  Use when user mentions shell scripts, bash, zsh, CLI commands, pipes, command-line
-  automation, or writing portable shell code.
+description: "Shell scripting expertise — bash, zsh, POSIX, CLI tools, automation, cross-platform best practices. Use when writing shell scripts, pipes, command-line automation, or portable shell code."
 user-invocable: false
 allowed-tools: Bash, BashOutput, KillShell, Grep, Glob, Read, Write, Edit, TodoWrite
 ---

--- a/tools-plugin/skills/yq-yaml-processing/SKILL.md
+++ b/tools-plugin/skills/yq-yaml-processing/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-04
 reviewed: 2025-12-16
 name: yq-yaml-processing
-description: YAML querying, filtering, and transformation with yq command-line tool. Use when working with YAML files, parsing YAML configuration, modifying Kubernetes manifests, GitHub Actions workflows, or transforming YAML structures.
+description: Query, filter, and transform YAML with yq. Use when parsing YAML files or configs, modifying Kubernetes manifests or GitHub Actions workflows, or transforming YAML structures.
 user-invocable: false
 allowed-tools: Bash(yq *), Read, Write, Edit, Grep, Glob
 model: sonnet

--- a/typescript-plugin/skills/biome-tooling/SKILL.md
+++ b/typescript-plugin/skills/biome-tooling/SKILL.md
@@ -1,12 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-02-14
+modified: 2026-05-09
 reviewed: 2025-12-16
 name: biome-tooling
-description: |
-  Biome all-in-one formatter and linter for JavaScript, TypeScript, JSX, TSX, JSON, and CSS.
-  Zero-config setup, 15-20x faster than ESLint/Prettier. Use when working with modern JavaScript/TypeScript
-  projects, setting up formatting/linting, or migrating from ESLint+Prettier to a faster alternative.
+description: Biome all-in-one formatter and linter for JavaScript, TypeScript, JSX, TSX, JSON, and CSS. Zero-config, 15-20x faster than ESLint/Prettier. Use when working with modern JS/TS projects, setting up formatting/linting, or migrating from ESLint+Prettier.
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash, Edit, Write, TodoWrite, WebFetch, WebSearch, BashOutput, KillShell
 ---

--- a/typescript-plugin/skills/bun-add/SKILL.md
+++ b/typescript-plugin/skills/bun-add/SKILL.md
@@ -1,14 +1,10 @@
 ---
-description: |
-  Add a package dependency with Bun. Use when the user wants to install a single
-  package quickly, add a dev dependency (e.g. `bun add --dev typescript`), pin an
-  exact version without a semver range, or target a specific workspace. Triggers:
-  "add express", "install lodash", "bun add a dev dep", "pin react exact".
+description: "Add a package dependency with Bun. Use when the user wants to install a single package, add a dev dependency (`bun add --dev typescript`), pin an exact version, or target a workspace. Triggers: 'add express', 'install lodash', 'pin react exact'."
 args: <package> [--dev] [--exact]
 allowed-tools: Bash, Read
 argument-hint: package-name [--dev] [--exact]
 created: 2025-12-20
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2025-12-20
 name: bun-add
 ---

--- a/typescript-plugin/skills/bun-build/SKILL.md
+++ b/typescript-plugin/skills/bun-build/SKILL.md
@@ -1,15 +1,10 @@
 ---
-description: |
-  Bundle or compile JavaScript/TypeScript with Bun. Use when the user wants a
-  quick production bundle of an entry point, to compile to a standalone
-  executable with `bun build --compile`, or to build for a specific target
-  (browser, bun, node). Triggers: "bundle src/index.ts", "compile to binary",
-  "build for node target", "make a standalone executable".
+description: "Bundle or compile JavaScript/TypeScript with Bun. Use when the user wants a production bundle, to compile to a standalone executable with `bun build --compile`, or to build for a target (browser, bun, node). Triggers: 'bundle', 'compile to binary'."
 args: <entry> [--compile] [--minify]
 allowed-tools: Bash, Read
 argument-hint: ./src/index.ts [--compile] [--minify]
 created: 2025-12-20
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2025-12-20
 name: bun-build
 ---

--- a/typescript-plugin/skills/bun-debug/SKILL.md
+++ b/typescript-plugin/skills/bun-debug/SKILL.md
@@ -1,15 +1,10 @@
 ---
-description: |
-  Launch a script with Bun's debugger enabled via `--inspect`. Use when the user
-  wants to interactively debug a TypeScript/JavaScript file, break at the first
-  line of a fast-exiting script, wait for a debugger to attach before running,
-  or debug tests via `bun --inspect-brk test`. Triggers: "debug this script",
-  "attach debugger", "open debug.bun.sh", "break on start".
+description: "Launch a script with Bun's debugger via `--inspect`. Use when the user wants to interactively debug a TS/JS file, break at the first line, wait for a debugger to attach, or debug tests via `bun --inspect-brk test`. Triggers: 'debug this'."
 args: <file> [--brk] [--wait] [--port=<port>]
 allowed-tools: Bash, BashOutput, Read
 argument-hint: <script.ts> [--brk] [--wait] [--port=9229]
 created: 2026-01-22
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: bun-debug
 ---

--- a/typescript-plugin/skills/bun-development/skill.md
+++ b/typescript-plugin/skills/bun-development/skill.md
@@ -1,17 +1,10 @@
 ---
 name: bun-development
-description: |
-  Bun runtime workflows for running scripts, testing, building, and
-  initializing projects with agent-optimized flags. Use when the user wants to
-  run a TypeScript file with `bun run` or `bunx`, use watch/hot reload during
-  development, configure `bun test` in detail, bundle or compile to a
-  standalone executable, or scaffold a new Bun project. Triggers: "run this
-  with bun", "bun watch dev", "configure bun test", "compile to exe",
-  "bun init a react app".
+description: Bun runtime workflows for running scripts, testing, building, and initializing projects with agent-optimized flags. Use when running a TS file, watch/hot reload, configuring `bun test`, bundling/compiling, or scaffolding a Bun project.
 user-invocable: false
 allowed-tools: Bash, BashOutput, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2025-12-20
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2025-12-20
 ---
 

--- a/typescript-plugin/skills/bun-install/SKILL.md
+++ b/typescript-plugin/skills/bun-install/SKILL.md
@@ -1,15 +1,10 @@
 ---
-description: |
-  Install all dependencies from package.json using Bun. Use when the user wants
-  to bootstrap a fresh checkout with `bun install`, run a reproducible CI
-  install with `--frozen-lockfile`, or prepare a production deployment with
-  `--production` (no devDependencies). Triggers: "install deps", "bun install",
-  "restore node_modules", "CI install", "production install".
+description: Install all dependencies from package.json using Bun. Use when bootstrapping a fresh checkout with `bun install`, running a reproducible CI install with `--frozen-lockfile`, or preparing a production deploy with `--production`.
 args: "[--frozen-lockfile] [--production]"
 argument-hint: "--frozen-lockfile for CI, --production for deployment"
 allowed-tools: Bash, Read
 created: 2025-12-20
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: bun-install
 ---

--- a/typescript-plugin/skills/bun-lockfile-update/SKILL.md
+++ b/typescript-plugin/skills/bun-lockfile-update/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: bun-lockfile-update
-description: |
-  Update Bun lockfiles (bun.lockb) with proper dependency management. Covers
-  bun update, bun install, lockfile regeneration, and security audits.
-  Use when user mentions bun lockfile, bun update, bun.lockb, updating Bun
-  dependencies, or resolving Bun lockfile conflicts.
+description: Update Bun lockfiles (bun.lockb) with proper dependency management. Covers bun update, bun install, lockfile regeneration, and security audits. Use when the user mentions bun lockfile, bun update, bun.lockb, or resolving lockfile conflicts.
 allowed-tools: Bash, Read, Grep, Glob
 ---
 

--- a/typescript-plugin/skills/bun-outdated/SKILL.md
+++ b/typescript-plugin/skills/bun-outdated/SKILL.md
@@ -1,15 +1,10 @@
 ---
-description: |
-  Check which project dependencies have newer versions available using `bun
-  outdated`. Use when the user wants to audit dependency freshness, spot major
-  version updates before upgrading, decide between `bun update` (in-range) and
-  `bun update --latest`, or review a single package. Triggers: "check outdated",
-  "what can be upgraded", "show newer versions", "review dependency updates".
+description: Check which dependencies have newer versions using `bun outdated`. Use when auditing freshness, spotting major updates before upgrading, deciding between `bun update` and `bun update --latest`, or reviewing a single package.
 args: "[package]"
 argument-hint: "Optional package name to check specific dependency"
 allowed-tools: Bash, Read
 created: 2025-12-20
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: bun-outdated
 ---

--- a/typescript-plugin/skills/bun-package-manager/skill.md
+++ b/typescript-plugin/skills/bun-package-manager/skill.md
@@ -1,17 +1,10 @@
 ---
 name: bun-package-manager
-description: |
-  Fast JavaScript package management with Bun - install, add, remove, and
-  update dependencies. Use when the user wants to install all project
-  dependencies, add or remove packages, run `bun update` or `bun outdated`,
-  manage workspace dependencies across a monorepo, produce a reproducible CI
-  install with `--frozen-lockfile`, or debug lockfile conflicts. Triggers:
-  "install dependencies", "update packages", "check outdated", "add to
-  workspace", "frozen lockfile for CI".
+description: Fast JavaScript package management with Bun — install, add, remove, update. Use when installing all deps, adding/removing packages, running `bun update`/`outdated`, managing workspaces, doing a `--frozen-lockfile` CI install, or debugging conflicts.
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob, TodoWrite
 created: 2025-12-20
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2025-12-20
 ---
 

--- a/typescript-plugin/skills/bun-publish/SKILL.md
+++ b/typescript-plugin/skills/bun-publish/SKILL.md
@@ -1,16 +1,11 @@
 ---
-description: |
-  Publish a package to the npm registry after building with Bun. Use when the
-  user wants to release to npm, preview a publish with `--dry-run`, publish a
-  scoped package with `--access public`, or enable supply chain `--provenance`
-  signing. Triggers: "publish to npm", "release this package", "npm publish
-  dry run", "publish scoped package with provenance".
+description: "Publish a package to npm after building with Bun. Use when the user wants to release to npm, preview with `--dry-run`, publish a scoped package with `--access public`, or enable `--provenance` signing. Triggers: 'publish to npm'."
 args: "[--dry-run] [--access <level>] [--provenance]"
 allowed-tools: Bash, Read
 argument-hint: "[--dry-run] [--access public]"
 disable-model-invocation: true
 created: 2025-12-21
-modified: 2026-04-25
+modified: 2026-05-09
 reviewed: 2026-04-25
 name: bun-publish
 ---

--- a/typescript-plugin/skills/bun-publishing/skill.md
+++ b/typescript-plugin/skills/bun-publishing/skill.md
@@ -1,17 +1,10 @@
 ---
 name: bun-publishing
-description: |
-  Publish npm packages built with Bun, including package.json configuration,
-  CLI tool packaging, provenance signing, and release automation. Use when the
-  user wants to set up `publishConfig`/`files`/`bin` for npm, package a CLI
-  tool with an executable entry, enable `npm publish --provenance`, validate
-  tarball contents with `npm pack --dry-run`, or wire up release-please for
-  automated versioning. Triggers: "publish to npm", "set up release-please",
-  "configure package.json for publishing", "add provenance signing".
+description: "Publish npm packages built with Bun: package.json config, CLI tool packaging, provenance signing, release automation. Use when setting up `publishConfig`/`files`/`bin`, packaging a CLI, enabling `--provenance`, or wiring release-please."
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2025-12-21
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2025-12-21
 ---
 

--- a/typescript-plugin/skills/bun-test/SKILL.md
+++ b/typescript-plugin/skills/bun-test/SKILL.md
@@ -1,15 +1,10 @@
 ---
-description: |
-  Run tests using Bun's built-in test runner with compact, agent-friendly
-  output. Use when the user wants to run bun tests, target a specific file or
-  name pattern, collect coverage with `--coverage`, enable watch mode during
-  development, or emit JUnit XML for CI. Triggers: "run bun tests", "test this
-  file", "run tests with coverage", "watch tests", "CI test output".
+description: Run tests using Bun's built-in test runner with compact, agent-friendly output. Use when running bun tests, targeting a file or pattern, collecting coverage with `--coverage`, enabling watch mode, or emitting JUnit XML for CI.
 args: "[pattern] [--coverage] [--bail] [--watch]"
 allowed-tools: Bash, BashOutput, Read
 argument-hint: "[test-pattern] [--coverage] [--bail] [--watch]"
 created: 2025-12-20
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2025-12-20
 name: bun-test
 ---

--- a/typescript-plugin/skills/knip-dead-code/SKILL.md
+++ b/typescript-plugin/skills/knip-dead-code/SKILL.md
@@ -1,12 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-02-14
+modified: 2026-05-09
 reviewed: 2025-12-16
 name: knip-dead-code
-description: |
-  Knip finds unused files, dependencies, exports, and types in JavaScript/TypeScript projects.
-  Plugin system for frameworks (React, Next.js, Vite), test runners (Vitest, Jest), and build tools.
-  Use when cleaning up codebases, optimizing bundle size, or enforcing strict dependency hygiene in CI.
+description: Knip finds unused files, dependencies, exports, and types in JS/TS projects. Plugin system for frameworks (React, Next.js, Vite), test runners (Vitest, Jest), build tools. Use when cleaning up codebases or enforcing dep hygiene in CI.
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash, Edit, Write, TodoWrite, WebFetch, WebSearch, BashOutput, KillShell
 ---

--- a/typescript-plugin/skills/nodejs-development/SKILL.md
+++ b/typescript-plugin/skills/nodejs-development/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2025-12-16
+modified: 2026-05-09
 reviewed: 2025-12-16
 name: nodejs-development
-description: |
-  Modern Node.js development with Bun, Vite, Vue 3, Pinia, and TypeScript. Covers
-  JavaScript/TypeScript projects, high-performance tooling, and modern frameworks.
-  Use when user mentions Node.js, Bun, Vite, Vue, Pinia, npm, pnpm, JavaScript runtime,
-  or building frontend/backend JS applications.
+description: Modern Node.js development with Bun, Vite, Vue 3, Pinia, and TypeScript. Covers JS/TS projects, high-performance tooling, and modern frameworks. Use when the user mentions Node.js, Bun, Vite, Vue, Pinia, npm, or pnpm.
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash, Edit, Write, TodoWrite, WebFetch, WebSearch, BashOutput, KillShell, NotebookEdit
 ---

--- a/typescript-plugin/skills/typescript-debugging/skill.md
+++ b/typescript-plugin/skills/typescript-debugging/skill.md
@@ -1,18 +1,10 @@
 ---
 name: typescript-debugging
-description: |
-  Modern TypeScript/JavaScript debugging with the Bun runtime - inspector
-  flags, the debug.bun.sh web debugger, VSCode `launch.json` integration,
-  memory profiling, and heap analysis. Use when the user wants to set up
-  interactive debugging, investigate a memory leak with heap snapshots, CPU
-  profile with `--cpu-prof`, debug network requests via
-  `BUN_CONFIG_VERBOSE_FETCH`, or configure sourcemaps so stack traces show
-  original TypeScript. Triggers: "debug this", "find the memory leak",
-  "profile CPU", "set up launch.json for bun".
+description: Modern TypeScript/JavaScript debugging with Bun — inspector flags, debug.bun.sh, VSCode launch.json, memory profiling, heap analysis. Use when setting up interactive debugging, investigating leaks, CPU profiling with `--cpu-prof`, or sourcemaps.
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2026-01-22
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2026-01-22
 ---
 

--- a/typescript-plugin/skills/typescript-sentry/skill.md
+++ b/typescript-plugin/skills/typescript-sentry/skill.md
@@ -1,18 +1,10 @@
 ---
 name: typescript-sentry
-description: |
-  Error monitoring and performance tracking with the Sentry SDK for
-  Bun/Node.js/Next.js - error capture, breadcrumbs, performance spans, cron
-  monitoring, source maps, structured logging, profiling, and enrichment
-  helpers. Use when the user wants to add Sentry to a project, instrument
-  performance spans or cron check-ins with `withMonitor`, upload source maps
-  so traces show TypeScript, filter events via `beforeSend`, or configure
-  session replay/profiling. Triggers: "add Sentry", "capture this error",
-  "monitor this cron job", "upload sourcemaps to Sentry".
+description: Error monitoring and performance with Sentry SDK for Bun/Node.js/Next.js — error capture, breadcrumbs, spans, cron monitoring, source maps, structured logging, profiling. Use when adding Sentry, instrumenting cron, or uploading sourcemaps.
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2026-01-22
-modified: 2026-04-19
+modified: 2026-05-09
 reviewed: 2026-01-22
 ---
 

--- a/typescript-plugin/skills/typescript-strict/SKILL.md
+++ b/typescript-plugin/skills/typescript-strict/SKILL.md
@@ -1,13 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-02-14
+modified: 2026-05-09
 reviewed: 2025-12-16
 name: typescript-strict
-description: |
-  TypeScript strict mode configuration for 2025. Recommended tsconfig.json settings,
-  strict flags explained, moduleResolution strategies (Bundler vs NodeNext),
-  verbatimModuleSyntax, noUncheckedIndexedAccess. Use when setting up TypeScript projects
-  or migrating to stricter type safety.
+description: TypeScript strict mode configuration for 2025. Recommended tsconfig.json, strict flags, moduleResolution (Bundler vs NodeNext), verbatimModuleSyntax, noUncheckedIndexedAccess. Use when setting up TypeScript or migrating to stricter type safety.
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash, Edit, Write, TodoWrite, WebFetch, WebSearch, BashOutput, KillShell
 ---

--- a/upstream-pr-plugin/skills/upstream-pr/SKILL.md
+++ b/upstream-pr-plugin/skills/upstream-pr/SKILL.md
@@ -1,19 +1,11 @@
 ---
 name: upstream-pr
-description: |
-  Submit a single commit from a heavily-diverged fork back to upstream as a
-  clean PR. Handles eligibility checks (patch-id matching against upstream),
-  cherry-pick with re-derive fallback when conflicts are too dense, commit-
-  message scrubbing of fork-local context, and pre-flight regression
-  verification against the upstream baseline. Use when the fork has
-  substantially diverged from upstream and direct rebase is not viable, or
-  when the user asks to "send X upstream", "backport to upstream", or
-  "open an upstream PR".
+description: Submit a single commit from a heavily-diverged fork to upstream as a clean PR. Handles eligibility (patch-id matching), cherry-pick with re-derive fallback for dense conflicts, message scrubbing, and regression checks. Use when direct rebase fails.
 args: "<sha> [--topic <slug>]"
 allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git show *), Bash(git remote *), Bash(git fetch *), Bash(git switch *), Bash(git checkout *), Bash(git cherry-pick *), Bash(git reset *), Bash(git commit *), Bash(git push *), Bash(git stash *), Bash(git rev-list *), Bash(git rev-parse *), Bash(git branch *), Bash(git cat-file *), Bash(git patch-id *), Bash(gh pr *), Bash(gh repo *), Bash(bash *), Bash(uv *), Bash(pytest *), Bash(ruff *), Bash(python3 *), Read, Edit, Write, Grep, Glob, TodoWrite
 argument-hint: "<sha-to-send-upstream>"
 created: 2026-04-29
-modified: 2026-04-29
+modified: 2026-05-09
 reviewed: 2026-04-29
 ---
 

--- a/workflow-orchestration-plugin/skills/workflow-checkpoint-refactor/SKILL.md
+++ b/workflow-orchestration-plugin/skills/workflow-checkpoint-refactor/SKILL.md
@@ -1,15 +1,11 @@
 ---
 name: workflow-checkpoint-refactor
-description: |
-  Multi-phase refactoring with persistent checkpoint files that survive context
-  limits. Use when refactoring spans 10+ files, requires multiple phases, or
-  risks hitting conversation context limits. Each phase reads/writes a plan file,
-  enabling resume from any point. Supports "continue the refactor" across sessions.
+description: Multi-phase refactoring with persistent checkpoint files that survive context limits. Use when refactoring spans 10+ files, needs phased rollout, or risks running out of context — supports "continue the refactor" across sessions.
 args: "[--init|--continue|--status|--phase=N]"
 allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(npm run *), Bash(npx *), Bash(uv run *), Bash(cargo *), Read, Write, Edit, Grep, Glob, Task, TodoWrite
 argument-hint: "--init to create plan, --continue to resume, --status to check progress"
 created: 2026-02-08
-modified: 2026-02-14
+modified: 2026-05-09
 reviewed: 2026-02-14
 ---
 

--- a/workflow-orchestration-plugin/skills/workflow-preflight/SKILL.md
+++ b/workflow-orchestration-plugin/skills/workflow-preflight/SKILL.md
@@ -1,15 +1,11 @@
 ---
 name: workflow-preflight
-description: |
-  Pre-work validation before starting implementation. Use when beginning work
-  on an issue, feature, or fix to verify remote state, check for existing PRs,
-  detect branch conflicts, and prevent redundant work. Catches problems that
-  cause wasted effort: already-merged fixes, stale branches, unclean diffs.
+description: Pre-work validation before implementation. Use when starting on an issue, feature, or fix to verify remote state, check for existing PRs, detect branch conflicts, and avoid wasted effort on already-merged fixes or stale branches.
 args: "[issue-number|branch-name]"
 allowed-tools: Bash(git fetch *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git branch *), Bash(git remote *), Bash(git stash *), Bash(gh pr *), Bash(gh issue *), Read, Grep, Glob, TodoWrite
 argument-hint: optional issue number or branch name to check
 created: 2026-02-08
-modified: 2026-02-08
+modified: 2026-05-09
 reviewed: 2026-02-08
 ---
 

--- a/workflow-orchestration-plugin/skills/workflow-wave-dispatch/SKILL.md
+++ b/workflow-orchestration-plugin/skills/workflow-wave-dispatch/SKILL.md
@@ -1,14 +1,6 @@
 ---
 name: workflow-wave-dispatch
-description: |
-  Sequential-wave dispatch contract for multi-agent work where tasks have
-  internal dependencies — when a later work-order needs a file, type, or
-  API defined by an earlier one; when a research question gates downstream
-  scope; or when lock-contenders force serialisation. Companion to
-  parallel-agent-dispatch (which assumes disjoint scopes). Use when
-  planning a multi-step implementation, when a previous parallel dispatch
-  hit ordering problems, or when deciding whether to re-dispatch a wave
-  after a verification gate fails.
+description: Sequential-wave dispatch contract for multi-agent work with cross-task dependencies or shared locks. Use when planning multi-step implementations, recovering from parallel-dispatch ordering issues, or scheduling waves around verification gates.
 user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 created: 2026-04-24


### PR DESCRIPTION
## Summary

- Compresses oversized `description:` frontmatter fields across 706 SKILL.md files in 41 plugins to fit Claude Code's `skillListingBudgetFraction` (~120-180 char target, ≤250 hard cap).
- Net effect: **-1,349 lines** across **310 files** (-71% description bytes on the worst offenders).
- Collapses multi-line block scalars (`description: |`) to inline form for cheaper parsing.
- Trims marketing prose, redundant restatements of SKILL.md bodies, and trigger lists that duplicated action verbs already in the description.
- Bumps `configure-repo` driver `reviewed:` date to acknowledge dependent skill updates (no behaviour change in the driver).

Why: a recent doctor diagnostic flagged that the skill listing was consuming **~22k tokens (~9.9% of context)** vs the **2% (~4k) `skillListingBudgetFraction` budget**, dropping ~193 skill descriptions from autoload. The biggest offenders averaged 446 chars per description.

Style guide applied (per [Anthropic agent-skills examples](https://github.com/anthropics/skills)):

- One-sentence shape: `<verb-led action>. Use when <trigger>.`
- Includes a "Use when…" trigger clause (enforced by `audit-skill-descriptions.py --strict-all`).
- No marketing copy, no body restatements, no exhaustive tool lists.

## Per-plugin scope

41 commits, one per plugin, so release-please can version each plugin independently.

## Test plan

- [x] `python3 scripts/audit-skill-descriptions.py --strict-all` exits 0 (706/706 OK)
- [x] `pre-commit run --all-files` green (shellcheck, gitleaks, lint-context-commands, check-driver-freshness, audit-skill-descriptions, lint-taskwarrior-tags, agent-tool-selection)
- [ ] Verify CI plugin-pr-checks pass
- [ ] Verify enforce-conventional-commits passes (each commit uses `docs(<plugin>): trim skill descriptions`)
- [ ] Spot-check a few rewritten descriptions render correctly in the skill picker after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)