### PR TITLE
fix(ci): add id-token: write permission to scheduled-audits workflow

### DIFF
--- a/.github/workflows/scheduled-audits.yml
+++ b/.github/workflows/scheduled-audits.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   issues: write
+  id-token: write
 
 jobs:
   blueprint-health:


### PR DESCRIPTION
## Summary

`scheduled-audits.yml` invokes `anthropics/claude-code-action@v1` (in the `agentic-audit` job) but its top-level `permissions:` block grants only `contents: read` and `issues: write`. The action requires `id-token: write` for OIDC authentication and would fail at runtime with:

> Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?

Adds `id-token: write` to bring the workflow in line with the other seven workflows in this repo that invoke `claude-code-action` (`claude.yml`, `plugin-pr-checks.yml`, `release-pr-doc-audit.yml`, `obsidian-cli-changelog.yml`, `changelog-review.yml`, `skill-splitter.yml`, `github-workflow-auto-fix.yml`).

## Context

Filed against this repo while triaging the equivalent bug reported in `laurigates/dotfiles#181`; the same OIDC permission gap existed here.

## Test plan

- [ ] CI on this PR passes
- [ ] Next monthly run of `Plugin: Scheduled audits` (cron `0 9 1 * *`) completes the `agentic-audit` job without an OIDC error, or a manual `workflow_dispatch` of `Plugin: Scheduled audits` succeeds

Refs laurigates/dotfiles#181

---
_Generated by [Claude Code](https://claude.ai/code/session_014HYHUj4X7ArfDXYJTt2mvX)_