### PR TITLE
docs(taskwarrior-plugin): add task-tracking lifecycle doc with depends auto-unblock

### DIFF
--- a/taskwarrior-plugin/README.md
+++ b/taskwarrior-plugin/README.md
@@ -85,6 +85,10 @@ Override via `.claude/taskwarrior-plugin.local.md` (see `agent-patterns-plugin:p
 
 See [docs/flow.md](docs/flow.md) for a diagram of how the skills fit together.
 
+## Task Tracking Lifecycle
+
+See [docs/task-tracking.md](docs/task-tracking.md) for conventions on UDAs, tags, and the full task lifecycle — including the `depends:` + `task done` auto-unblock pattern that makes sequential WO chains self-managing.
+
 ## Related
 
 - `agent-patterns-plugin:parallel-agent-dispatch` — dispatch contract that `task-coordinate` feeds

--- a/taskwarrior-plugin/docs/task-tracking.md
+++ b/taskwarrior-plugin/docs/task-tracking.md
@@ -1,0 +1,122 @@
+# Task Tracking Pattern
+
+Conventions for using taskwarrior as a coordination layer for multi-agent and multi-WO blueprint work. These patterns apply across all `taskwarrior-plugin` skills.
+
+## UDAs (User-Defined Attributes)
+
+Declared in `~/.taskrc`. `task-add` installs them on first use (with confirmation).
+
+| UDA | Type | Purpose |
+|-----|------|---------|
+| `bpid` | string | Blueprint ID link (WO-NNN, PRP-NNN, FR-NNN) |
+| `bpdoc` | string | Repo-relative markdown path for the linked doc |
+| `bpms` | string | Milestone tag |
+| `ghid` | numeric | Linked GitHub issue number |
+| `ghpr` | numeric | Linked GitHub PR number |
+
+## Tags
+
+| Tag | Meaning |
+|-----|---------|
+| `+wo` | Work order (from blueprint-plugin) |
+| `+prp` | PRP implementation plan |
+| `+fr` | Feature request |
+| `+re` | Research task |
+| `+gh` | Linked to a GitHub issue or PR |
+| `+pr-ready` | Implementation done, open PR, waiting on merge |
+| `+needs-review` | Ready for review |
+| `+blocked-on-merge` | Waiting on another PR to merge |
+| `+blocked` | Blocked on external factor |
+
+## Lifecycle
+
+### 1. Pre-allocate blueprint IDs
+
+Before filing tasks, pre-allocate WO/PRP IDs in the manifest (e.g., WO-058/059/060). Task IDs assigned by taskwarrior at file-time may differ from blueprint IDs — the `bpid` UDA bridges them. Pre-allocating prevents ID drift and keeps the manifest and task queue in 1:1 correspondence.
+
+### 2. File tasks with `depends:` for sequential ordering
+
+For work orders that must land in sequence, set `depends:` on each downstream task pointing to its predecessor's taskwarrior ID (not its bpid — taskwarrior uses internal numeric IDs for dependency):
+
+```bash
+# File WO-058 first — no depends (it's first in the chain)
+task add "WO-058: implement sprite_blit_frame" bpid:WO-058 +wo project:myrepo
+# → taskwarrior assigns ID 51
+
+# WO-059 waits for WO-058
+task add "WO-059: add CLI subcommand" bpid:WO-059 +wo project:myrepo depends:51
+# → taskwarrior assigns ID 52
+
+# WO-060 waits for both
+task add "WO-060: document format spec" bpid:WO-060 +wo project:myrepo depends:51,52
+# → taskwarrior assigns ID 53
+```
+
+The `-BLOCKED` virtual attribute in `task-coordinate` and `task-status` automatically hides depends-blocked tasks from dispatch candidates — no manual filtering needed.
+
+### 3. ★ KEY: `depends:` + `task done` auto-unblocks the chain
+
+> **This is the single biggest productivity multiplier in multi-WO work.**
+
+When you close a task with `task done`, taskwarrior immediately unblocks every task that listed it in `depends:` and prints a confirmation:
+
+```
+$ task 51 done
+Completed task 51 'WO-058: implement sprite_blit_frame'.
+Unblocked 52 'WO-059: add CLI subcommand'.
+```
+
+No manual intervention. After `task done` on WO-058:
+
+- `task next` surfaces WO-059 as the top dispatch candidate
+- `task-coordinate` (`task ... -BLOCKED export | jq`) shows WO-059 as ready
+- A three-WO chain (058 → 059 → 060) manages itself: each `task done` fires the correct unblock automatically
+
+The agent only needs to call `task done` on the completed task; the queue re-sorts instantly.
+
+### 4. Annotate with the landing commit before closing
+
+Always annotate before calling `done` — if close fails (e.g., remaining unresolved depends), the annotation is still captured:
+
+```bash
+task "$TASKID" annotate "landed: $COMMIT_SHORT $COMMIT_SUBJECT"
+task "$TASKID" done
+```
+
+### 5. Report unblocked siblings after close
+
+After `task done`, query which tasks were unblocked (parallel-safe):
+
+```bash
+task depends:"$TASKID" export | jq '.[] | {id, description, urgency}'
+```
+
+Include these in the close-out report so the orchestrator knows the next ready task immediately.
+
+## Parallel-Safe Queries
+
+All taskwarrior queries use `export | jq` — never bare `list`, `next`, or similar commands — because these exit 1 on an empty result and cancel sibling Bash calls in parallel batches.
+
+| Use | Never use |
+|-----|-----------|
+| `task project:X status:pending export \| jq` | `task project:X status:pending list` |
+| `task status:pending -BLOCKED export \| jq` | `task next` |
+| `task depends:"$ID" export \| jq` | `task depends:"$ID" list` |
+| `task bpid:WO-012 export \| jq` | `task bpid:WO-012 list` |
+
+See `.claude/rules/parallel-safe-queries.md` for the full rule and rationale.
+
+## Urgency and `task next`
+
+The default urgency formula ranks tasks by project membership, tags, age, and dependencies. In most sessions no per-session priority tuning is needed — the parallel-safe equivalent (`task ... export | jq 'sort_by(-.urgency)'`) surfaces the right candidate.
+
+When urgency rankings feel wrong, the common culprits are missing `project:` tags (task falls outside the scoped filter) or stale `+blocked` tags that should have been removed after the external blocker resolved.
+
+## Related
+
+- `/taskwarrior:task-add` — file tasks with UDA linkage and `depends:` ordering
+- `/taskwarrior:task-done` — close + annotate + check unblocked siblings
+- `/taskwarrior:task-coordinate` — surface next unblocked candidates for a wave
+- `/taskwarrior:task-status` — full queue audit with drift detection
+- `.claude/rules/parallel-safe-queries.md` — the `export | jq` idiom (zero parallel-batch errors)
+- `blueprint-plugin:feature-tracking` — blueprint IDs that `bpid` links to

--- a/taskwarrior-plugin/skills/task-add/SKILL.md
+++ b/taskwarrior-plugin/skills/task-add/SKILL.md
@@ -11,7 +11,7 @@ args: "[description] [project:<name>] [--no-project]"
 allowed-tools: Bash(task *), Bash(git config *), Bash(git rev-parse *), Bash(gh auth *), Bash(gh issue *), Bash(gh api *), Read, TodoWrite
 argument-hint: short task description
 created: 2026-04-24
-modified: 2026-04-29
+modified: 2026-05-04
 reviewed: 2026-04-29
 ---
 
@@ -145,6 +145,22 @@ task add "$DESCRIPTION" \
 
 Run with only the fields that were provided; omit empty UDAs entirely rather than passing `uda:""`.
 
+#### Sequential WOs: use `depends:` for ordered chains
+
+For work orders that must land in sequence (e.g., WO-058 → 059 → 060),
+set `depends:` on each downstream task pointing to its predecessor's
+taskwarrior numeric ID. When the predecessor closes with `task done`,
+taskwarrior **automatically unblocks all dependents** — no manual
+intervention needed (see `docs/task-tracking.md § Lifecycle`):
+
+```bash
+# WO-059 waits for WO-058 (taskwarrior ID 51)
+task add "WO-059: ..." bpid:WO-059 +wo project:myrepo depends:51
+
+# WO-060 waits for both
+task add "WO-060: ..." bpid:WO-060 +wo project:myrepo depends:51,52
+```
+
 ### Step 6: Report
 
 Print:
@@ -187,7 +203,8 @@ Print:
 ## Related
 
 - `/taskwarrior:task-status` — see current queue
-- `/taskwarrior:task-done` — close an open task
+- `/taskwarrior:task-done` — close an open task (fires auto-unblock for `depends:` chains)
 - `/taskwarrior:task-coordinate` — next-agent candidates for a wave
 - `.claude/rules/parallel-safe-queries.md` — why `export | jq`, never `list`
 - `blueprint-plugin:feature-tracking` — FR/WO IDs that `bpid` points at
+- `taskwarrior-plugin/docs/task-tracking.md` — full lifecycle including `depends:` + auto-unblock pattern

--- a/taskwarrior-plugin/skills/task-done/SKILL.md
+++ b/taskwarrior-plugin/skills/task-done/SKILL.md
@@ -11,7 +11,7 @@ args: "<task-id> [commit-hash]"
 allowed-tools: Bash(task *), Bash(git config *), Bash(git log *), Bash(git rev-parse *), Bash(gh auth *), Bash(gh issue *), Bash(gh pr *), Read, Edit, TodoWrite
 argument-hint: task id (required), commit sha (optional — defaults to HEAD)
 created: 2026-04-24
-modified: 2026-04-29
+modified: 2026-05-04
 reviewed: 2026-04-29
 ---
 
@@ -134,8 +134,9 @@ Print:
 
 ## Related
 
-- `/taskwarrior:task-add` — file a task
+- `/taskwarrior:task-add` — file a task (use `depends:` for sequential WO chains)
 - `/taskwarrior:task-status` — see what's left
 - `blueprint-plugin:feature-tracking` — tracker format that `bpdoc` points at
 - `blueprint-plugin:blueprint-docs-currency` — companion discipline for the `bpdoc` update
 - `.claude/rules/parallel-safe-queries.md` — the `export | jq` idiom
+- `taskwarrior-plugin/docs/task-tracking.md` — full lifecycle: `depends:` + auto-unblock pattern


### PR DESCRIPTION
Creates `taskwarrior-plugin/docs/task-tracking.md` documenting the full coordination lifecycle — UDAs, tags, and the `depends:` + `task done` auto-unblock pattern prominently highlighted as the key productivity multiplier for sequential WO chains.

Updates task-add SKILL.md with `depends:` example and links both skill Related sections to the new doc.

Closes #1215

Generated with [Claude Code](https://claude.ai/code)