### PR TITLE
feat(taskwarrior-plugin): add agent identity claims via task-claim/task-release

### DIFF
--- a/.claude/rules/agent-coworker-detection.md
+++ b/.claude/rules/agent-coworker-detection.md
@@ -10,13 +10,14 @@ The root cause is missing coordination: each agent assumes it is the sole writer
 
 ## Detection Signals
 
-No single signal is reliable. Combine these three and treat any positive as "assume a coworker is present".
+No single signal is reliable. Combine these four and treat any positive as "assume a coworker is present".
 
 | Signal | Detects | Cost | Platform |
 |--------|---------|------|----------|
 | **Baseline drift** — snapshot `git status --porcelain` + `git stash list` at session start; diff at risky moments | Files that appeared after we started, regardless of who created them | Free | All |
 | **Session marker** — write `.git/.claude-session-<pid>` on start, delete on exit; scan siblings | Other agents that adopt the same convention | Free | All |
 | **Process scan** — find other `claude`/`node` processes whose `cwd` is the same repo | Ad-hoc agents that do not write markers | ~100ms | Linux/macOS differ |
+| **Taskwarrior `+ACTIVE` claims** — query `task project:<repo-basename> +ACTIVE export` for claims by other agent IDs | Coworkers that picked up coordination work via `/taskwarrior:task-claim`, even from a different process tree or host | ~50ms | Any host with `task` + `jq` |
 
 ### Baseline drift
 
@@ -56,6 +57,36 @@ done
 ```
 
 macOS uses `lsof -a -d cwd -c claude -c node -Fpn` since `/proc` is not available. The process-scan signal is a fallback — do not depend on it working in sandboxed environments (Claude Code on the web, restricted sandboxes) where process enumeration may be blocked.
+
+### Taskwarrior `+ACTIVE` claims
+
+When agents coordinate via `taskwarrior-plugin`, every claimed task is `task start`-ed (which sets the `+ACTIVE` virtual tag) and stamped with identity UDAs by `/taskwarrior:task-claim`:
+
+| UDA | Source on claim |
+|-----|-----------------|
+| `agent` | `claude-${CLAUDE_SESSION_ID:0:8}` |
+| `pid` | `$$` at claim time |
+| `host` | `hostname` |
+| `branch` | `git branch --show-current` |
+| `worktree` | `git rev-parse --show-toplevel` |
+
+Probe for active claims by other agents without contacting their processes:
+
+```bash
+project="$(basename "$(git rev-parse --show-toplevel)")"
+task project:"$project" +ACTIVE export \
+  | jq '.[] | {id, agent, pid, host, branch, worktree, start}'
+```
+
+The query is parallel-safe (`export` returns `[]` and exits 0 on no matches; see `.claude/rules/parallel-safe-queries.md`). Each row's `agent` is compared against `claude-${CLAUDE_SESSION_ID:0:8}` — matches are own claims and are reported as `OWN_CLAIM_*`; anything else counts toward `TW_CLAIM_COUNT` and raises the `coworker_detected` verdict.
+
+This signal is the only one that survives:
+
+- **Different hosts.** Taskwarrior stores can be synced via TaskChampion, so a claim on host A is visible to host B.
+- **Crashed Claude processes.** The claim outlives the process; staleness is reported separately by filtering on `start.before:now-Nh` (default 4h) without auto-stopping.
+- **Worktrees in the same project.** Taskwarrior records the project basename — not the worktree path — so two agents in sibling worktrees of the same repo still see each other's claims.
+
+The cross-link cuts both ways: when one agent claims via `/taskwarrior:task-claim`, the next agent's `/git:coworker-check` sees the claim before its destructive op even if that agent never invoked taskwarrior itself. The four-signal verdict is only as strong as the weakest signal that fires, so opting in to taskwarrior coordination strengthens the guard for every clone of the project.
 
 ## Response Rules
 

--- a/git-plugin/skills/git-coworker-check/SKILL.md
+++ b/git-plugin/skills/git-coworker-check/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "[--claim | --release | --check (default)]"
 allowed-tools: Bash(bash *), Bash(git status *), Bash(git stash *), Bash(git rev-parse *), Read, TodoWrite
 created: 2026-04-21
 modified: 2026-05-09
-reviewed: 2026-04-21
+reviewed: 2026-05-09
 ---
 
 # /git:coworker-check
@@ -75,16 +75,19 @@ No output is expected. Stop here.
 
 ### Step 3: Detect coworkers
 
-Look up the current session's baseline files (if `--claim` was run earlier this session). Then run detection:
+Look up the current session's baseline files (if `--claim` was run earlier this session). Then run detection. Pass `--self-agent claude-${CLAUDE_SESSION_ID:0:8}` so taskwarrior claims by this same session are reported as `OWN_CLAIM_*` rather than counted as coworkers:
 
 ```
 bash ${CLAUDE_SKILL_DIR}/scripts/detect-coworkers.sh \
   --project-dir "$(pwd)" \
+  --self-agent claude-${CLAUDE_SESSION_ID:0:8} \
   --baseline-status .git/.claude-baseline-$$.status \
   --baseline-stash .git/.claude-baseline-$$.stash
 ```
 
-If no `--claim` was run, omit the `--baseline-*` flags — drift detection will return `unknown` but marker and process signals still work.
+If no `--claim` was run, omit the `--baseline-*` flags — drift detection will return `unknown` but marker, process, and taskwarrior signals still work.
+
+The taskwarrior signal is best-effort: when `task` or `jq` is not on `PATH`, the script reports `TW_SCAN_METHOD=unavailable` and the verdict falls back to the three git-side signals.
 
 ### Step 4: Interpret the verdict
 
@@ -93,8 +96,10 @@ Parse the `VERDICT=` line from the script's output:
 | Verdict | Meaning | Action |
 |---------|---------|--------|
 | `clear` | No coworker detected | Proceed; still prefer explicit `git add <paths>` over `git add -A` |
-| `drift_detected` | Files appeared since baseline but no other process/marker found | Inspect `NEW_STATUS_LINES` — may be coworker or may be a forgotten earlier edit. Ask the user before stashing. |
-| `coworker_detected` | Another agent/process is active in this clone | **Do not stash, restore, or reset.** Report the `MARKER_PID` / `PROC_PID` entries. Recommend the user switch to a worktree. |
+| `drift_detected` | Files appeared since baseline but no other process/marker/claim found | Inspect `NEW_STATUS_LINES` — may be coworker or may be a forgotten earlier edit. Ask the user before stashing. |
+| `coworker_detected` | Another agent/process/taskwarrior claim is active in this clone | **Do not stash, restore, or reset.** Report the `MARKER_PID` / `PROC_PID` / `TW_CLAIM_*` entries. Recommend the user switch to a worktree. |
+
+The four signals are independent — any one of `MARKER_COUNT > 0`, `PROC_COUNT > 0`, or `TW_CLAIM_COUNT > 0` raises `coworker_detected`. `OWN_CLAIM_*` lines are this session's own taskwarrior claims and do not contribute to the count.
 
 ### Step 5: Report findings
 
@@ -134,3 +139,5 @@ Hook-based enforcement (blocking `git stash` / `git reset --hard` when a coworke
 - `/git:maintain` — invokes this before any stash/clean operation
 - `/git:commit` — invokes this before staging when working in a shared checkout
 - `git-branch-pr-workflow` — recommends worktrees as the structural fix
+- `/taskwarrior:task-claim` — sister signal; writes the `+ACTIVE` claim that this skill now reads
+- `/taskwarrior:task-release` — drops the claim that contributes to `TW_CLAIM_COUNT`

--- a/git-plugin/skills/git-coworker-check/scripts/detect-coworkers.sh
+++ b/git-plugin/skills/git-coworker-check/scripts/detect-coworkers.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # Detect other Claude/agent processes working in the same repo clone.
 #
-# Combines three signals:
-#   1. Baseline drift  — optional snapshot from a prior session
-#   2. Session markers — .git/.claude-session-<pid> files written by coworkers
-#   3. Process scan    — other claude/node processes whose cwd is this repo
+# Combines four signals:
+#   1. Baseline drift     — optional snapshot from a prior session
+#   2. Session markers    — .git/.claude-session-<pid> files written by coworkers
+#   3. Process scan       — other claude/node processes whose cwd is this repo
+#   4. Taskwarrior claims — +ACTIVE tasks in this repo's project (best-effort)
 #
 # Output is a block of KEY=value lines plus === SECTION === headers so the
 # invoking skill can parse results without re-running git.
@@ -16,12 +17,14 @@ set -uo pipefail
 project_dir=""
 baseline_status=""
 baseline_stash=""
+self_agent=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --project-dir) project_dir="$2"; shift 2 ;;
     --baseline-status) baseline_status="$2"; shift 2 ;;
     --baseline-stash) baseline_stash="$2"; shift 2 ;;
+    --self-agent) self_agent="$2"; shift 2 ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
@@ -65,6 +68,7 @@ status_drift="unknown"
 stash_drift="unknown"
 marker_drift=0
 proc_drift=0
+tw_claim_drift=0
 
 # =========================================================================
 # Signal 1: baseline drift
@@ -183,11 +187,61 @@ fi
 echo "OTHER_PROC_COUNT=$proc_drift"
 
 # =========================================================================
+# Signal 4: taskwarrior +ACTIVE claims (best-effort)
+# =========================================================================
+echo "=== TASKWARRIOR_CLAIMS ==="
+
+if command -v task >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+  project="$(basename "$repo_root")"
+  claims_json="$(task project:"$project" +ACTIVE export 2>/dev/null)"
+  if [ -z "$claims_json" ]; then
+    claims_json="[]"
+  fi
+
+  if [ "$claims_json" != "[]" ]; then
+    while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      claim_agent="${line%%|*}"
+      rest="${line#*|}"
+      claim_id="${rest%%|*}"
+      rest="${rest#*|}"
+      claim_branch="${rest%%|*}"
+      rest="${rest#*|}"
+      claim_host="${rest%%|*}"
+      rest="${rest#*|}"
+      claim_pid="${rest%%|*}"
+      rest="${rest#*|}"
+      claim_start="$rest"
+
+      if [ -n "$self_agent" ] && [ "$claim_agent" = "$self_agent" ]; then
+        echo "OWN_CLAIM_TASK=$claim_id"
+        echo "OWN_CLAIM_AGENT=$claim_agent"
+        continue
+      fi
+
+      tw_claim_drift=$((tw_claim_drift + 1))
+      echo "TW_CLAIM_TASK=$claim_id"
+      echo "TW_CLAIM_AGENT=$claim_agent"
+      echo "TW_CLAIM_BRANCH=$claim_branch"
+      echo "TW_CLAIM_HOST=$claim_host"
+      echo "TW_CLAIM_PID=$claim_pid"
+      echo "TW_CLAIM_START=$claim_start"
+    done < <(printf '%s' "$claims_json" | jq -r '.[] | "\(.agent // "")|\(.id)|\(.branch // "")|\(.host // "")|\(.pid // "")|\(.start // "")"')
+  fi
+
+  echo "TW_PROJECT=$project"
+  echo "TW_CLAIM_COUNT=$tw_claim_drift"
+  echo "TW_SCAN_METHOD=task"
+else
+  echo "TW_SCAN_METHOD=unavailable"
+fi
+
+# =========================================================================
 # Summary verdict
 # =========================================================================
 echo "=== VERDICT ==="
 
-if [ "$marker_drift" -gt 0 ] || [ "$proc_drift" -gt 0 ]; then
+if [ "$marker_drift" -gt 0 ] || [ "$proc_drift" -gt 0 ] || [ "$tw_claim_drift" -gt 0 ]; then
   verdict="coworker_detected"
 elif [ "$status_drift" = "true" ] || [ "$stash_drift" = "true" ]; then
   verdict="drift_detected"
@@ -199,3 +253,4 @@ echo "STATUS_DRIFT=$status_drift"
 echo "STASH_DRIFT=$stash_drift"
 echo "MARKER_COUNT=$marker_drift"
 echo "PROC_COUNT=$proc_drift"
+echo "TW_CLAIM_COUNT=$tw_claim_drift"

--- a/taskwarrior-plugin/README.md
+++ b/taskwarrior-plugin/README.md
@@ -22,9 +22,30 @@ Both systems stay in sync via UDAs (`ghid`, `ghpr`) and tags (`+gh`, `+pr_ready`
 | Skill | Purpose |
 |-------|---------|
 | `/taskwarrior:task-add` | File a task with bpid / bpdoc / bpms fields; auto-tags `project:` from the current repo; offers GitHub issue linkage when a remote is detected |
-| `/taskwarrior:task-done` | Close a task, annotate with commit hash, drain the linked feature-tracker entry; offers to close the linked GitHub issue |
-| `/taskwarrior:task-status` | Read-only consolidated queue + drift report scoped to the current project; folds in `gh pr status` when GitHub is present |
-| `/taskwarrior:task-coordinate` | Surface the next N unblocked tasks (in the current project) sorted by urgency that do not contend on an exclusive lock — input for parallel / wave dispatch |
+| `/taskwarrior:task-claim` | Claim a pending task as in-flight: marks it `+ACTIVE` (`task start`), stamps identity UDAs (`agent` / `pid` / `host` / `branch` / `worktree`), and writes a `/git:coworker-check` session marker so destructive git ops in the clone are guarded |
+| `/taskwarrior:task-release` | Release an active claim without closing: stops the `+ACTIVE` clock, annotates the handoff state, drains `pid`, and drops the coworker-check marker. Pairs with `task-claim` for pause / handoff |
+| `/taskwarrior:task-done` | Close a task, annotate with commit hash, drain the linked feature-tracker entry; auto-stops the `+ACTIVE` claim and offers to close the linked GitHub issue |
+| `/taskwarrior:task-status` | Read-only consolidated queue + drift report scoped to the current project; surfaces in-flight claims and stale claims (>N hours); folds in `gh pr status` when GitHub is present |
+| `/taskwarrior:task-coordinate` | Surface the next N unblocked **and unclaimed** tasks (in the current project) sorted by urgency that do not contend on an exclusive lock — input for parallel / wave dispatch. Excludes `+ACTIVE` by default so dispatch waves never overlap with another agent's claim |
+
+### Identity / claim lifecycle
+
+```
+task-add  →  task-coordinate  →  task-claim  →  (work)  →  task-done
+                                       │                       │
+                                       ▼                       ▼
+                                 task-release  ──────────►  task-coordinate
+                                 (handoff)                  (re-dispatch)
+```
+
+`task-claim` and `task-release` are paired: claim picks the task up
+(sets `+ACTIVE`, stamps identity, writes a git session marker), release
+puts it back down (stops the clock, annotates state, drops the marker).
+`task-done` collapses both into a single close — it auto-stops the
+`+ACTIVE` claim and (with `--no-coworker-marker` opt-out) drops the
+matching git marker. The `+ACTIVE` claim is what `task-coordinate`,
+`task-status`, and `/git:coworker-check` all read to decide whether
+another agent is already working a task.
 
 ## Project scoping
 
@@ -38,6 +59,7 @@ git toplevel (or the cwd if no git repo is present).
 | `task-add` | Tags new task with `project:<repo>` | `project:<name>` arg | `--no-project` |
 | `task-status` | Filters report to `project:<repo>` | `--project=<name>` | `--all` |
 | `task-coordinate` | Filters dispatch candidates to `project:<repo>` | `--project=<name>` | `--all` (rare) |
+| `task-claim` / `task-release` | Operate on a single task ID — project filter inherited from the task | n/a | n/a |
 
 Tasks filed before this default existed have no `project:` set and will
 not match the auto-filter — pass `--all` once to find them, then
@@ -47,6 +69,8 @@ backfill with `task <ID> modify project:<name>`.
 
 Taskwarrior UDAs are declared in `~/.taskrc`. On first use, `task-add` prompts to install the set below if missing.
 
+**Linkage UDAs** (set by `task-add`, drained by `task-done`):
+
 | UDA | Type | Purpose |
 |-----|------|---------|
 | `bpid` | string | Blueprint ID link (WO-NNN, PRP-NNN, FR-NNN) |
@@ -54,6 +78,18 @@ Taskwarrior UDAs are declared in `~/.taskrc`. On first use, `task-add` prompts t
 | `bpms` | string | Milestone tag |
 | `ghid` | numeric | Linked GitHub issue number |
 | `ghpr` | numeric | Linked GitHub PR number |
+
+**Identity UDAs** (set by `task-claim`, drained by `task-release` / `task-done`):
+
+| UDA | Type | Purpose |
+|-----|------|---------|
+| `agent` | string | Claiming agent ID — `claude-${CLAUDE_SESSION_ID:0:8}` by default |
+| `pid` | numeric | Claiming process PID at claim time (cleared on release) |
+| `host` | string | Hostname where the claim was made |
+| `branch` | string | Git branch at claim time (omitted on detached HEAD) |
+| `worktree` | string | `git rev-parse --show-toplevel` at claim time |
+
+The identity UDAs power `task-coordinate`'s "In flight" / "Stale claims" sections, `task-status --mine`, and the taskwarrior signal in `/git:coworker-check`. See `.claude/rules/agent-coworker-detection.md` for how the four detection signals combine.
 
 ## Tag conventions
 
@@ -100,5 +136,7 @@ See [docs/task-tracking.md](docs/task-tracking.md) for conventions on UDAs, tags
 - `agent-patterns-plugin:parallel-agent-dispatch` — dispatch contract that `task-coordinate` feeds
 - `agent-patterns-plugin:exclusive-lock-dispatch` — taskwarrior's own store is single-writer; bulk modifies need exclusive-lock discipline
 - `workflow-orchestration-plugin:workflow-wave-dispatch` — wave scheduling that `task-coordinate` supports
+- `git-plugin:git-coworker-check` — sister signal: reads `+ACTIVE` claims as a fourth detection mechanism
+- `.claude/rules/agent-coworker-detection.md` — combined-signal rationale (drift + marker + process + taskwarrior)
 - `.claude/rules/parallel-safe-queries.md` — the `task export \| jq` idiom this plugin follows
 - `blueprint-plugin:feature-tracking` — blueprint IDs that `bpid` links to

--- a/taskwarrior-plugin/docs/flow.md
+++ b/taskwarrior-plugin/docs/flow.md
@@ -7,10 +7,13 @@ flowchart TD
     ADD[/taskwarrior:task-add/]:::fix
     STATUS[/taskwarrior:task-status/]:::check
     COORD[/taskwarrior:task-coordinate/]:::check
+    CLAIM[/taskwarrior:task-claim/]:::fix
+    RELEASE[/taskwarrior:task-release/]:::fix
     DONE[/taskwarrior:task-done/]:::fix
 
     GH{{GitHub remote?}}:::prompt
     STORE[(~/.task/)]
+    COWORKER[/git:coworker-check/]:::check
 
     ADD --> GH
     GH -->|yes| GHISSUE[link ghid / create issue]:::fix
@@ -20,11 +23,22 @@ flowchart TD
 
     STORE --> STATUS
     STORE --> COORD
-    COORD -->|next N unblocked| DISPATCH[parallel-agent-dispatch / workflow-wave-dispatch]:::router
+    COORD -->|next N unblocked + unclaimed| CLAIM
+    CLAIM -->|+ACTIVE + identity UDAs| STORE
+    CLAIM -->|writes session marker| COWORKER
 
-    STATUS -->|drift detected| DONE
-    DONE -->|annotate commit| STORE
+    STORE -->|+ACTIVE claims| COWORKER
+
+    CLAIM -->|pause / handoff| RELEASE
+    RELEASE -->|stop, drain pid, drop marker| STORE
+    RELEASE --> COORD
+
+    CLAIM -->|work landed| DONE
+    STATUS -->|drift / PR ready| DONE
+    DONE -->|annotate commit, auto-stop| STORE
     DONE -->|optional| CLOSEGH[gh issue close / gh pr comment]:::fix
+
+    COORD -->|wave of unclaimed| DISPATCH[parallel-agent-dispatch / workflow-wave-dispatch]:::router
 
     classDef router fill:#4a9eff,stroke:#222,color:#fff
     classDef check fill:#8fbc8f,stroke:#222,color:#000
@@ -46,6 +60,20 @@ flowchart TD
 | Skill | Scope |
 |-------|-------|
 | `task-add` | Create / link tasks |
-| `task-done` | Close / annotate tasks |
-| `task-status` | Read queue state |
-| `task-coordinate` | Query candidate agents for a dispatch wave |
+| `task-claim` | Claim a pending task (sets `+ACTIVE` + identity UDAs + session marker) |
+| `task-release` | Release an active claim without closing (handoff) |
+| `task-done` | Close / annotate tasks (auto-stops `+ACTIVE`) |
+| `task-status` | Read queue state, including in-flight + stale claims |
+| `task-coordinate` | Query unblocked + unclaimed candidates for a dispatch wave |
+
+## Claim lifecycle
+
+The `task-claim` / `task-release` / `task-done` triple is the identity
+layer that lets `task-coordinate` and `/git:coworker-check` reason about
+in-flight work:
+
+| Transition | Effect on store | Effect on `/git:coworker-check` |
+|-----------|------------------|-------------------------------|
+| `task-claim` | Task gains `+ACTIVE` + `agent` / `pid` / `host` / `branch` / `worktree` UDAs | Writes `.git/.claude-session-<pid>` and baseline snapshot |
+| `task-release` | `+ACTIVE` cleared, `pid` drained, annotation appended; `agent` / `host` / `branch` / `worktree` retained for handoff context (unless `--clear-identity`) | Drops the matching session marker (unless `--no-coworker-marker`) |
+| `task-done` | `+ACTIVE` auto-stopped, task closed, commit hash annotated | Drops the matching session marker (unless `--no-coworker-marker`) |

--- a/taskwarrior-plugin/skills/task-add/SKILL.md
+++ b/taskwarrior-plugin/skills/task-add/SKILL.md
@@ -72,9 +72,10 @@ Execute this workflow:
 
 ### Step 1: Ensure UDAs exist
 
-If `task _udas` output lacks `bpid`, `bpdoc`, `bpms`, `ghid`, or `ghpr`, offer to install them:
+If `task _udas` output lacks any of `bpid`, `bpdoc`, `bpms`, `ghid`, `ghpr` (linkage UDAs) or `agent`, `pid`, `host`, `branch`, `worktree` (identity UDAs populated by `/taskwarrior:task-claim`), offer to install them:
 
 ```bash
+# Linkage UDAs
 task config uda.bpid.type string
 task config uda.bpid.label "Blueprint ID"
 task config uda.bpdoc.type string
@@ -85,9 +86,21 @@ task config uda.ghid.type numeric
 task config uda.ghid.label "GH Issue"
 task config uda.ghpr.type numeric
 task config uda.ghpr.label "GH PR"
+
+# Identity UDAs (populated by task-claim, drained by task-release / task-done)
+task config uda.agent.type string
+task config uda.agent.label "Agent ID"
+task config uda.pid.type numeric
+task config uda.pid.label "Agent PID"
+task config uda.host.type string
+task config uda.host.label "Host"
+task config uda.branch.type string
+task config uda.branch.label "Git branch"
+task config uda.worktree.type string
+task config uda.worktree.label "Worktree path"
 ```
 
-Install only with user confirmation on first run per host.
+Install only with user confirmation on first run per host. Identity UDAs are not set by `task-add` itself — `/taskwarrior:task-claim` stamps them when an agent picks the task up.
 
 ### Step 2: Detect GitHub mode
 
@@ -174,7 +187,7 @@ Print:
 - bpid → bpdoc → bpms chain
 - ghid/ghpr if linked
 - Tags applied
-- Suggested next step (`/taskwarrior:task-status` or `/taskwarrior:task-coordinate`)
+- Suggested next step (`/taskwarrior:task-status`, `/taskwarrior:task-coordinate`, or `/taskwarrior:task-claim` if the user is about to start)
 
 ## Agentic Optimizations
 
@@ -207,6 +220,7 @@ Print:
 ## Related
 
 - `/taskwarrior:task-status` — see current queue
+- `/taskwarrior:task-claim` — claim a task and stamp identity UDAs
 - `/taskwarrior:task-done` — close an open task (fires auto-unblock for `depends:` chains)
 - `/taskwarrior:task-coordinate` — next-agent candidates for a wave
 - `.claude/rules/parallel-safe-queries.md` — why `export | jq`, never `list`

--- a/taskwarrior-plugin/skills/task-claim/SKILL.md
+++ b/taskwarrior-plugin/skills/task-claim/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: task-claim
+description: Claim a taskwarrior task as in-flight by this agent. Marks the task `+ACTIVE` (`task start`), populates identity UDAs (agent / pid / host / branch / worktree), and writes a `git-coworker-check` session marker so other agents can see the work is taken. Use when picking up a task from `/taskwarrior:task-coordinate` output before starting implementation.
+args: "<task-id> [--no-coworker-marker] [--force]"
+allowed-tools: Bash(task *), Bash(git rev-parse *), Bash(git branch *), Bash(git config *), Bash(hostname *), Bash(jq *), Bash(bash *), Read, TodoWrite
+argument-hint: task id (required)
+created: 2026-05-09
+modified: 2026-05-09
+reviewed: 2026-05-09
+---
+
+# /taskwarrior:task-claim
+
+Take ownership of a pending task. Stamps the task with this agent's identity and marks it `+ACTIVE` so concurrent agents see it is in flight and `/taskwarrior:task-coordinate` skips it on the next wave.
+
+## When to Use This Skill
+
+| Use this skill when... | Use a sibling skill instead when... |
+|---|---|
+| Starting work on a task surfaced by `/taskwarrior:task-coordinate` | Filing a brand-new task — use `/taskwarrior:task-add` |
+| Resuming a task after a context break (re-stamps `started` time) | Pausing for handoff without closing — use `/taskwarrior:task-release` |
+| Forcing a stale claim onto yourself with `--force` | The task is done and ready to land — use `/taskwarrior:task-done` |
+
+## Context
+
+- Task CLI available: !`task --version`
+- Git toplevel: !`git rev-parse --show-toplevel`
+- Current branch: !`git branch --show-current`
+- Hostname: !`hostname`
+- Existing UDAs: !`task _udas`
+
+## Parameters
+
+Parse `$ARGUMENTS`:
+
+- `$0` — task ID (required).
+- `--no-coworker-marker` — skip the `/git:coworker-check --claim` step (use when the repo is intentionally shared and another agent will claim its own scope).
+- `--force` — claim even when the task is already `+ACTIVE` (the previous claim is overwritten with an annotation noting the takeover).
+
+## Execution
+
+Execute this claim workflow:
+
+### Step 1: Ensure identity UDAs exist
+
+If `task _udas` output lacks `agent`, `pid`, `host`, `branch`, or `worktree`, install them on first run per host:
+
+```bash
+task config uda.agent.type string
+task config uda.agent.label "Agent ID"
+task config uda.pid.type numeric
+task config uda.pid.label "Agent PID"
+task config uda.host.type string
+task config uda.host.label "Host"
+task config uda.branch.type string
+task config uda.branch.label "Git branch"
+task config uda.worktree.type string
+task config uda.worktree.label "Worktree path"
+```
+
+Confirm with the user before installing — UDA declarations live in `~/.taskrc` and persist across sessions.
+
+### Step 2: Load the task and check active state
+
+```bash
+task "$TASKID" export | jq '.[0] | {id, description, status, start, agent, pid, host, branch, worktree}'
+```
+
+Use `export | jq` — never `task <id> info` or `task <id> list` (both exit 1 on empty / closed tasks and cancel parallel siblings; see `.claude/rules/parallel-safe-queries.md`).
+
+Read the JSON. Decide:
+
+| Condition | Action |
+|---|---|
+| `status` is not `pending` | Abort. Tasks must be pending to claim. |
+| `start` is set and `--force` not passed | Abort. Report current `agent` / `pid` / `host` / `branch` so the user can either `--force` or pick another task. |
+| `start` is set and `--force` passed | Annotate with takeover notice (Step 6) and proceed. |
+| `start` is unset | Proceed cleanly. |
+
+### Step 3: Coworker-check claim (default on)
+
+Unless `--no-coworker-marker` was passed, write the session marker so destructive git ops in this clone (stash, reset, checkout --) trigger the cross-agent guard:
+
+```
+Use SlashCommand to invoke `/git:coworker-check --claim`.
+```
+
+The git-side marker (`<git-dir>/.claude-session-<pid>`) and the taskwarrior `+ACTIVE` claim are independent signals. Together they reinforce: a stash hook can read either one, and either is enough to pause a destructive op.
+
+If the SlashCommand tool is unavailable in the current session, fall back to running the script directly:
+
+```bash
+bash "$(git rev-parse --show-toplevel)/git-plugin/skills/git-coworker-check/scripts/claim-session.sh" --project-dir "$(pwd)"
+```
+
+### Step 4: Resolve identity values
+
+Capture once and reuse across the next two steps:
+
+| Value | Source |
+|---|---|
+| `AGENT` | `claude-${CLAUDE_SESSION_ID:0:8}` (short, stable for the session) |
+| `PID` | `$$` (the bash subshell PID — sufficient to cross-link with the git marker since both are taken at the same moment) |
+| `HOST` | `hostname` |
+| `BRANCH` | `git branch --show-current` (may be empty on a detached HEAD — leave the UDA unset rather than writing the literal "HEAD") |
+| `WORKTREE` | `git rev-parse --show-toplevel` |
+
+### Step 5: Start the task and stamp identity
+
+Two calls — start first so `+ACTIVE` is set even if the modify step fails:
+
+```bash
+task "$TASKID" start
+task "$TASKID" modify \
+  agent:"$AGENT" \
+  pid:"$PID" \
+  host:"$HOST" \
+  branch:"$BRANCH" \
+  worktree:"$WORKTREE"
+```
+
+Omit `branch:` when `BRANCH` is empty (detached HEAD). Quote every value — `worktree:` paths frequently contain spaces.
+
+### Step 6: Annotate the claim
+
+```bash
+task "$TASKID" annotate "claimed by $AGENT (pid $PID) on $BRANCH from $HOST:$WORKTREE"
+```
+
+When `--force` is used over an existing claim, annotate the takeover separately first so the previous owner's identity is preserved in the audit trail:
+
+```bash
+task "$TASKID" annotate "force-claim by $AGENT — previous: agent=$PREV_AGENT pid=$PREV_PID host=$PREV_HOST"
+```
+
+### Step 7: Report
+
+Print:
+
+- Task ID, description, urgency
+- Identity stamp: `agent` / `pid` / `host` / `branch` / `worktree`
+- Coworker-check status: claim written / skipped
+- Suggested next step:
+  - implementation work
+  - `/taskwarrior:task-release <id>` to hand off without closing
+  - `/taskwarrior:task-done <id>` once the work has landed
+
+## Agentic Optimizations
+
+| Context | Command |
+|---|---|
+| Active filter (parallel-safe) | `task +ACTIVE export \| jq '.[] \| {id, agent, branch, host}'` |
+| Single-field DOM read | `task _get "$TASKID".agent` (exit 0 even when unset) |
+| Cross-project active scan | `task status:pending +ACTIVE export \| jq` |
+| Stale-claim probe | `task +ACTIVE start.before:now-4h export \| jq` |
+| Skip empty-result failures | Always `export \| jq`, never `task active list` |
+
+## Quick Reference
+
+| Field | Type | Source on claim |
+|---|---|---|
+| `agent` | string | `claude-${CLAUDE_SESSION_ID:0:8}` |
+| `pid` | numeric | `$$` at claim time |
+| `host` | string | `hostname` |
+| `branch` | string | `git branch --show-current` (omit on detached HEAD) |
+| `worktree` | string | `git rev-parse --show-toplevel` |
+| `start` (built-in) | date | Set automatically by `task start`; cleared by `task stop` |
+
+| Tag (virtual) | Set by | Cleared by |
+|---|---|---|
+| `+ACTIVE` | `task start` | `task stop` / `task done` |
+
+## Related
+
+- `/taskwarrior:task-coordinate` — surfaces unblocked candidates to claim
+- `/taskwarrior:task-release` — release without closing (handoff)
+- `/taskwarrior:task-done` — close after landing (auto-releases the claim)
+- `/git:coworker-check` — sister signal: process-scan + session marker
+- `.claude/rules/agent-coworker-detection.md` — combined-signal rationale
+- `.claude/rules/parallel-safe-queries.md` — `export | jq` idiom

--- a/taskwarrior-plugin/skills/task-coordinate/SKILL.md
+++ b/taskwarrior-plugin/skills/task-coordinate/SKILL.md
@@ -5,8 +5,8 @@ args: "[--n=N] [--lock=<resource>] [--wave] [--project=<name>] [--all]"
 allowed-tools: Bash(task *), Bash(git rev-parse *), Bash(jq *), Read, TodoWrite
 argument-hint: optional count (default 3) and lock filter
 created: 2026-04-24
-modified: 2026-05-06
-reviewed: 2026-05-06
+modified: 2026-05-09
+reviewed: 2026-05-09
 ---
 
 # /taskwarrior:task-coordinate
@@ -36,6 +36,8 @@ Parse `$ARGUMENTS`:
 - `--wave` — format output as a wave brief (orchestrator-ready)
 - `--project=<name>` — override the auto-detected project filter
 - `--all` — opt out of project filtering (cross-project wave; rare — usually wrong for dispatch)
+- `--include-active` — include `+ACTIVE` (already-claimed) tasks in candidate ranking. Default behaviour excludes them so a wave is never dispatched onto work another agent has already started via `/taskwarrior:task-claim`.
+- `--stale-after=N` — threshold (hours) for flagging a `+ACTIVE` claim as stale in the report. Default 4. Stale claims are reported only — never auto-stopped.
 
 ### Project resolution
 
@@ -55,16 +57,43 @@ Execute this workflow:
 ### Step 1: Load unblocked pending tasks
 
 Substitute the literal project name into the filter (no `$()` command
-substitution — shell-operator protections will reject it):
+substitution — shell-operator protections will reject it). Default
+behaviour excludes both `+BLOCKED` (depends-blocked) and `+ACTIVE`
+(already claimed via `/taskwarrior:task-claim`):
 
 ```bash
-task project:myrepo status:pending -BLOCKED export \
+task project:myrepo status:pending -BLOCKED -ACTIVE export \
   | jq 'sort_by(-.urgency) | .[] | {id, description, urgency, tags, bpid, depends}'
 ```
 
-Already filters out `depends:`-blocked tasks via the `-BLOCKED` virtual
-attribute. Never use `task next` — exits 1 on empty. With `--all`, drop
-the `project:` clause.
+With `--include-active`, drop the `-ACTIVE` clause so already-claimed
+tasks compete for ranking. With `--all`, drop the `project:` clause.
+Never use `task next` — exits 1 on empty.
+
+### Step 1b: Snapshot in-flight claims
+
+In parallel with Step 1 (these are independent reads), collect the set
+of currently-claimed tasks for the report:
+
+```bash
+task project:myrepo status:pending +ACTIVE export \
+  | jq '.[] | {id, description, agent, pid, host, branch, worktree, start, urgency}'
+```
+
+Empty array is exit-0 from `task export` — safe in parallel batches.
+
+### Step 1c: Detect stale claims
+
+Filter the in-flight set for claims older than `--stale-after` hours:
+
+```bash
+task project:myrepo +ACTIVE start.before:now-4h export \
+  | jq '.[] | {id, agent, host, branch, start}'
+```
+
+Stale claims are surfaced in the report only; `task-coordinate` never
+calls `task stop` on its own. The orchestrator (or the original claimer)
+decides whether to release.
 
 ### Step 2: Detect lock contenders
 
@@ -126,12 +155,38 @@ If the rank step dropped any lock-contending candidates, report them as
 deferred-to-next-wave with the lock name — the orchestrator decides
 whether to pre-dump via `exclusive-lock-dispatch` or serialise.
 
+### Step 6: Append in-flight + stale-claim sections
+
+Always emit two trailing sections so the orchestrator sees the full
+state of the project queue, not just the dispatchable subset:
+
+```
+## In flight (claimed)
+
+| Task | Agent | Branch | Host | Started |
+|------|-------|--------|------|---------|
+| #4 (WO-008) | claude-a1b2c3d4 | feature/parser | host-1 | 2h ago |
+| #9 (WO-011) | claude-9f8e7d6c | feature/api    | host-2 | 30m ago |
+
+## Stale claims (>4h)
+
+| Task | Agent | Started | Action |
+|------|-------|---------|--------|
+| #2 (WO-005) | claude-44556677 | 6h ago | Investigate; release with `/taskwarrior:task-release 2` if abandoned |
+```
+
+Empty sections render as "(none)". Never auto-stop a stale claim —
+report only, per the v1 design.
+
 ## Agentic Optimizations
 
 | Context | Command |
 |---------|---------|
-| Project unblocked by urgency | `task project:myrepo status:pending -BLOCKED export \| jq 'sort_by(-.urgency)'` |
-| Cross-project (`--all`) | `task status:pending -BLOCKED export \| jq 'sort_by(-.urgency)'` |
+| Project unclaimed + unblocked | `task project:myrepo status:pending -BLOCKED -ACTIVE export \| jq 'sort_by(-.urgency)'` |
+| Include claimed (rare) | drop `-ACTIVE` clause |
+| In-flight snapshot | `task project:myrepo +ACTIVE export \| jq '.[] \| {id, agent, branch, start}'` |
+| Stale claims | `task project:myrepo +ACTIVE start.before:now-4h export \| jq` |
+| Cross-project (`--all`) | `task status:pending -BLOCKED -ACTIVE export \| jq 'sort_by(-.urgency)'` |
 | Same-lock siblings | Filter on `tags` / bpid prefix locally, not via `task` filter |
 | Wave brief | `--wave` flag emits table with exclusion column |
 | Skip failing-filter variants | Never `task next`, always `export \| jq` |
@@ -145,11 +200,15 @@ whether to pre-dump via `exclusive-lock-dispatch` or serialise.
 | `--wave` | off | Emit wave brief format |
 | `--project=<name>` | repo basename | Override the project filter |
 | `--all` | off | Disable project filter (cross-project wave) |
+| `--include-active` | off | Include `+ACTIVE` (claimed) tasks in candidate ranking |
+| `--stale-after=N` | 4 | Hours before a `+ACTIVE` claim is flagged stale in the report |
 
 ## Related
 
+- `/taskwarrior:task-claim` — the skill agents call after picking a candidate (sets `+ACTIVE`, which this skill respects)
+- `/taskwarrior:task-release` — release a stale claim surfaced by this skill
+- `/taskwarrior:task-status` — full queue audit
 - `agent-patterns-plugin:parallel-agent-dispatch` — the dispatch contract these candidates feed
 - `agent-patterns-plugin:exclusive-lock-dispatch` — when to pre-dump instead of serialise
 - `workflow-orchestration-plugin:workflow-wave-dispatch` — wave scheduling that consumes the brief
 - `.claude/rules/parallel-safe-queries.md` — `export | jq` idiom
-- `/taskwarrior:task-status` — full queue audit

--- a/taskwarrior-plugin/skills/task-done/SKILL.md
+++ b/taskwarrior-plugin/skills/task-done/SKILL.md
@@ -5,8 +5,8 @@ args: "<task-id> [commit-hash]"
 allowed-tools: Bash(task *), Bash(git config *), Bash(git log *), Bash(git rev-parse *), Bash(gh auth *), Bash(gh issue *), Bash(gh pr *), Read, Edit, TodoWrite
 argument-hint: task id (required), commit sha (optional — defaults to HEAD)
 created: 2026-04-24
-modified: 2026-05-04
-reviewed: 2026-04-29
+modified: 2026-05-09
+reviewed: 2026-05-09
 ---
 
 # /taskwarrior:task-done
@@ -37,6 +37,8 @@ Parse `$ARGUMENTS`:
 - `$1` — commit hash (optional; defaults to `HEAD`)
 - `--no-gh` — skip GitHub close/comment even when remote is present
 - `--no-tracker` — skip blueprint tracker drain
+- `--drain-identity` — also clear `agent` / `pid` / `host` / `branch` / `worktree` UDAs after closing (default keeps them as audit trail)
+- `--no-coworker-marker` — skip the `/git:coworker-check --release` step
 
 ## Execution
 
@@ -52,7 +54,9 @@ Never use `task $TASKID info` or `task $TASKID list` — both can exit 1 and
 cancel parallel siblings. `export | jq` returns valid JSON even when the
 task is already closed (treat empty as "no such open task" and abort).
 
-Capture: `bpid`, `bpdoc`, `ghid`, `ghpr`, `tags`, `description`.
+Capture: `bpid`, `bpdoc`, `ghid`, `ghpr`, `tags`, `description`, plus
+identity UDAs `agent`, `pid`, `host`, `branch`, `worktree`, and `start`
+(if the task was claimed via `/taskwarrior:task-claim`).
 
 ### Step 2: Resolve commit hash
 
@@ -69,6 +73,27 @@ task "$TASKID" done
 
 Annotation first, then done — if close fails (e.g. dependencies), the
 annotation is still captured.
+
+Taskwarrior auto-stops a `+ACTIVE` task on `done`, so an explicit
+`task stop` is not needed. The task transition removes `+ACTIVE` and
+records the duration. If you want to drain the identity UDAs (so the
+closed task does not retain the stamp), do so separately after the
+close — see Step 4b below.
+
+### Step 4b: Drain identity UDAs (optional)
+
+After the task is closed, optionally clear the identity stamp left by
+the original claim:
+
+```bash
+task "$TASKID" modify agent: pid: host: branch: worktree:
+```
+
+Default behaviour is to **leave** these set on closed tasks — the audit
+trail of "who claimed and landed this" is useful in `task-status`
+recently-completed reports. Drain them only when the user explicitly
+asks (e.g. compliance / privacy hygiene), or when handing the queue
+file off to another team.
 
 ### Step 4: Drain the blueprint tracker
 
@@ -94,6 +119,19 @@ When GitHub mode is active and `--no-gh` was not passed:
 
 Always confirm before mutating GitHub state — the user may want to close
 the issue as part of the PR merge rather than ahead of time.
+
+### Step 5b: Drop the coworker-check marker
+
+If the task was `+ACTIVE` (claimed via `/taskwarrior:task-claim`), the
+matching git-side session marker should be released so destructive ops
+in this clone are no longer guarded:
+
+```
+Use SlashCommand to invoke `/git:coworker-check --release`.
+```
+
+Skip when the user has more work in flight on this branch — releasing
+the marker lifts the cross-agent guard.
 
 ### Step 6: Report
 
@@ -129,7 +167,10 @@ Print:
 ## Related
 
 - `/taskwarrior:task-add` — file a task (use `depends:` for sequential WO chains)
+- `/taskwarrior:task-claim` — claim a task before working on it (this skill closes a claimed task)
+- `/taskwarrior:task-release` — release a claim without closing (handoff)
 - `/taskwarrior:task-status` — see what's left
+- `/git:coworker-check` — the matching session marker that `--no-coworker-marker` controls
 - `blueprint-plugin:feature-tracking` — tracker format that `bpdoc` points at
 - `blueprint-plugin:blueprint-docs-currency` — companion discipline for the `bpdoc` update
 - `.claude/rules/parallel-safe-queries.md` — the `export | jq` idiom

--- a/taskwarrior-plugin/skills/task-release/SKILL.md
+++ b/taskwarrior-plugin/skills/task-release/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: task-release
+description: Release a taskwarrior task without closing it. Stops the `+ACTIVE` clock, annotates the current state for the next agent to read, and clears the `pid` UDA (keeps `agent` / `branch` / `worktree` for handoff context). Use when pausing mid-task, handing off to another agent, or aborting cleanly when the work is not actually done.
+args: "<task-id> [<state-message>] [--clear-identity] [--no-coworker-marker]"
+allowed-tools: Bash(task *), Bash(git rev-parse *), Bash(git branch *), Bash(jq *), Bash(bash *), Read, TodoWrite
+argument-hint: task id (required) and optional state message
+created: 2026-05-09
+modified: 2026-05-09
+reviewed: 2026-05-09
+---
+
+# /taskwarrior:task-release
+
+Release an active claim without closing the task. Pairs with `/taskwarrior:task-claim`: claim picks the task up, release puts it back down.
+
+## When to Use This Skill
+
+| Use this skill when... | Use a sibling skill instead when... |
+|---|---|
+| Pausing a task mid-flight (lunch break, context switch, end of session) | The work has landed in a commit — use `/taskwarrior:task-done` |
+| Handing off to another agent — leaving an annotation describing where you stopped | Starting work on a fresh task — use `/taskwarrior:task-claim` |
+| Aborting a started task because scope was wrong | Filing a brand-new task to capture the work — use `/taskwarrior:task-add` |
+
+## Context
+
+- Task CLI available: !`task --version`
+- Git toplevel: !`git rev-parse --show-toplevel`
+- Current branch: !`git branch --show-current`
+
+## Parameters
+
+Parse `$ARGUMENTS`:
+
+- `$0` — task ID (required).
+- Remaining positional words — concatenate as the freeform state message for the handoff annotation. If empty, prompt for one before annotating (an empty handoff annotation defeats the purpose).
+- `--clear-identity` — clear `agent` / `host` / `branch` / `worktree` UDAs in addition to `pid`. Use when the next agent should not inherit any context (e.g. cross-host handoff). Default behaviour preserves these so the queue still shows who last touched the task.
+- `--no-coworker-marker` — skip the `/git:coworker-check --release` step. By default, releasing the task also drops the git-side session marker so destructive ops in this clone are no longer guarded.
+
+## Execution
+
+Execute this release workflow:
+
+### Step 1: Load the task
+
+```bash
+task "$TASKID" export | jq '.[0] | {id, description, status, start, agent, pid, host, branch, worktree, annotations}'
+```
+
+Use `export | jq` — never `info` / `list`. Decide:
+
+| Condition | Action |
+|---|---|
+| `status` is not `pending` | Abort. Released tasks must be pending; if it is already closed, the release is a no-op. |
+| `start` is unset (not `+ACTIVE`) | Warn but proceed — annotation + UDA drain still useful as a "I looked at this" signal. |
+| `start` is set | Standard path. Continue. |
+
+### Step 2: Resolve state message
+
+If the user did not pass a message, ask them for one with a single `AskUserQuestion`. The annotation is the handoff payload — without it the next agent has only timestamps. Keep the prompt focused: "Where did you stop? (one sentence)".
+
+### Step 3: Annotate the handoff
+
+Annotate **before** stopping — if the stop fails (e.g. concurrent modify), the annotation is still captured:
+
+```bash
+task "$TASKID" annotate "released by $AGENT — state: $MESSAGE"
+```
+
+`$AGENT` is read from the task's existing `agent` UDA (the claim stamped it); fall back to `claude-${CLAUDE_SESSION_ID:0:8}` if unset.
+
+### Step 4: Stop the active state
+
+```bash
+task "$TASKID" stop
+```
+
+This clears the built-in `start` attribute and removes the `+ACTIVE` virtual tag. The task is back in the dispatch pool for `/taskwarrior:task-coordinate`.
+
+### Step 5: Drain identity UDAs
+
+Always clear `pid` (the process is going away):
+
+```bash
+task "$TASKID" modify pid:
+```
+
+When `--clear-identity` is passed, also clear the rest:
+
+```bash
+task "$TASKID" modify agent: host: branch: worktree:
+```
+
+The empty-value `field:` syntax removes a UDA in taskwarrior. Default behaviour keeps `agent` / `host` / `branch` / `worktree` so `task-status` "Recently touched" can attribute the work.
+
+### Step 6: Drop the coworker-check marker
+
+Unless `--no-coworker-marker` was passed:
+
+```
+Use SlashCommand to invoke `/git:coworker-check --release`.
+```
+
+Fallback if SlashCommand is unavailable:
+
+```bash
+bash "$(git rev-parse --show-toplevel)/git-plugin/skills/git-coworker-check/scripts/release-session.sh" --project-dir "$(pwd)"
+```
+
+### Step 7: Report
+
+Print:
+
+- Task ID, description, current status (still pending)
+- Time spent active (from `start` timestamp to now — read before stopping)
+- Annotation appended
+- Identity drain: `pid` only / full drain
+- Coworker-check status: marker released / skipped
+- Suggested next step:
+  - `/taskwarrior:task-coordinate` to dispatch the now-unclaimed work onto the next wave
+  - `/taskwarrior:task-claim <id>` to re-claim later
+
+## Agentic Optimizations
+
+| Context | Command |
+|---|---|
+| Read existing claim before release | `task _get "$TASKID".agent` (single-field, exit 0 even when unset) |
+| Time-spent computation | `task "$TASKID" export \| jq '.[0].start'` then compute against `now` |
+| Bulk release of stale claims | Pair with `task +ACTIVE start.before:now-4h export \| jq '.[].id'` |
+| Skip empty-result failures | Always `export \| jq`, never `task active list` |
+
+## Quick Reference
+
+| Step | Command |
+|---|---|
+| Annotate | `task ID annotate "released by AGENT — state: MSG"` |
+| Stop active | `task ID stop` |
+| Clear pid | `task ID modify pid:` |
+| Full identity drain | `task ID modify agent: host: branch: worktree: pid:` |
+| Drop git marker | `/git:coworker-check --release` |
+
+## Related
+
+- `/taskwarrior:task-claim` — pair: pick up an unclaimed task
+- `/taskwarrior:task-done` — close after landing (also auto-stops + drains identity)
+- `/taskwarrior:task-coordinate` — finds the next dispatch candidate
+- `/git:coworker-check` — sister marker that this skill drops on `--release`
+- `.claude/rules/agent-coworker-detection.md` — combined-signal rationale

--- a/taskwarrior-plugin/skills/task-status/SKILL.md
+++ b/taskwarrior-plugin/skills/task-status/SKILL.md
@@ -5,8 +5,8 @@ args: "[--mine] [--blocked] [--stale=N] [--project=<name>] [--all]"
 allowed-tools: Bash(task *), Bash(git config *), Bash(git rev-parse *), Bash(gh auth *), Bash(gh pr *), Bash(jq *), Read, TodoWrite
 argument-hint: optional filters
 created: 2026-04-24
-modified: 2026-05-06
-reviewed: 2026-05-06
+modified: 2026-05-09
+reviewed: 2026-05-09
 ---
 
 # /taskwarrior:task-status
@@ -33,9 +33,11 @@ Read-only status report on the coordination queue. Strictly uses `export | jq` �
 
 Parse `$ARGUMENTS`:
 
-- `--mine` — limit to tasks where `assigned:` matches current user / agent
+- `--mine` — limit to tasks where the `agent` UDA matches `claude-${CLAUDE_SESSION_ID:0:8}` (the value `/taskwarrior:task-claim` writes). Useful for "what am I currently holding?" reports.
 - `--blocked` — only tasks with `+blocked` / `+blocked_on_merge` or active `depends:`
+- `--active` — only `+ACTIVE` tasks (claimed and in flight)
 - `--stale=N` — highlight tasks modified > N days ago
+- `--stale-claim-after=N` — threshold (hours) for flagging a `+ACTIVE` claim as stale in the "Stale claims" section. Default 4. Reports only — never auto-stops.
 - `--project=<name>` — override the auto-detected project filter
 - `--all` — opt out of project filtering and report across every project
 - No flags — full report **scoped to the current project**
@@ -69,7 +71,7 @@ project name into the filter — do **not** use `$()` command substitution
 in the inline command (shell-operator protections will reject it).
 
 ```bash
-task project:myrepo status:pending export | jq '.[] | {id, description, urgency, tags, bpid, bpdoc, ghid, ghpr, modified, depends}'
+task project:myrepo status:pending export | jq '.[] | {id, description, urgency, tags, bpid, bpdoc, ghid, ghpr, agent, pid, host, branch, worktree, start, modified, depends}'
 ```
 
 For completeness also pull recently-completed in the same project:
@@ -77,6 +79,17 @@ For completeness also pull recently-completed in the same project:
 ```bash
 task project:myrepo status:completed end.after:now-7d export | jq '.[] | {id, description, bpid, ghid, end}'
 ```
+
+In parallel, pull the in-flight set so the "In flight" and "Stale
+claims" sections in Step 5 have data to render:
+
+```bash
+task project:myrepo +ACTIVE export | jq '.[] | {id, description, agent, pid, host, branch, worktree, start, urgency}'
+task project:myrepo +ACTIVE start.before:now-4h export | jq '.[] | {id, agent, host, branch, start}'
+```
+
+These three reads are independent and parallel-safe — `export` returns
+exit 0 on empty.
 
 ### Step 2: Sort and group
 
@@ -126,14 +139,17 @@ Pass --all for cross-project view, --project=<name> to override.
 
 Output these sections, in order:
 
-1. **Summary**: pending count, ready count (unblocked), blocked count, stale count
-2. **By milestone**: table of pending tasks per `bpms`
-3. **Ready for dispatch**: top 5 by urgency with no `depends:` and no `+blocked*` tags
-4. **Blocked**: tasks waiting on dependencies or external factors
-5. **PR-ready** (GitHub mode): tasks with green PRs ready to close
-6. **Drift**: tasks with stale links (issue closed, missing bpdoc, etc.)
+1. **Summary**: pending count, in-flight count, ready count (unblocked + unclaimed), blocked count, stale count, stale-claim count
+2. **In flight**: `+ACTIVE` tasks with `agent` / `branch` / `host` / `worktree` and time since `start`. Sorted by `start` ascending (oldest first). Section header notes `--mine` / `--all` scope.
+3. **Stale claims** (>4h or `--stale-claim-after`): subset of "In flight" with `start.before:now-Nh`. Recommend `/taskwarrior:task-release <id>` per row — the report never auto-stops.
+4. **Ready for dispatch**: top 5 by urgency with no `depends:`, no `+blocked*` tags, and not `+ACTIVE`. These are what `/taskwarrior:task-coordinate` would emit.
+5. **By milestone**: table of pending tasks per `bpms`
+6. **Blocked**: tasks waiting on dependencies or external factors
+7. **PR-ready** (GitHub mode): tasks with green PRs ready to close
+8. **Drift**: tasks with stale links (issue closed, missing bpdoc, etc.)
 
-Each row cites the command to act on it (`/taskwarrior:task-done 7`).
+Each row cites the command to act on it (`/taskwarrior:task-done 7`,
+`/taskwarrior:task-release 4`, `/taskwarrior:task-claim 11`).
 
 ## Agentic Optimizations
 
@@ -141,7 +157,10 @@ Each row cites the command to act on it (`/taskwarrior:task-done 7`).
 |---------|---------|
 | Project queue JSON | `task project:myrepo status:pending export \| jq` |
 | Cross-project queue (`--all`) | `task status:pending export \| jq` |
-| Ready-for-dispatch | `task project:myrepo status:pending -BLOCKED export \| jq 'sort_by(-.urgency) \| .[:5]'` |
+| Ready-for-dispatch (excludes claimed) | `task project:myrepo status:pending -BLOCKED -ACTIVE export \| jq 'sort_by(-.urgency) \| .[:5]'` |
+| In flight | `task project:myrepo +ACTIVE export \| jq '.[] \| {id, agent, branch, host, start}'` |
+| Stale claims (>4h) | `task project:myrepo +ACTIVE start.before:now-4h export \| jq` |
+| Mine (claimed by this agent) | `task project:myrepo +ACTIVE agent:claude-${CLAUDE_SESSION_ID:0:8} export \| jq` |
 | PR status | `gh pr status --json number,state,statusCheckRollup` |
 | Drift check | `gh issue view "$GHID" --json state` |
 | Never use | `task list`, `task next`, `task report` — exit 1 on empty |
@@ -153,6 +172,9 @@ Each row cites the command to act on it (`/taskwarrior:task-done 7`).
 | `project:<name>` | Single project (default scope) |
 | `status:pending` | Open tasks |
 | `-BLOCKED` | Exclude `depends:`-blocked |
+| `+ACTIVE` / `-ACTIVE` | Tasks with `task start` time set / not set |
+| `start.before:now-4h` | Stale claims |
+| `agent:claude-<sid>` | Mine (UDA-based) |
 | `urgency.above:5` | High-urgency only |
 | `modified.before:now-30d` | Stale |
 | `bpms:M6` | Single milestone |
@@ -160,6 +182,8 @@ Each row cites the command to act on it (`/taskwarrior:task-done 7`).
 ## Related
 
 - `/taskwarrior:task-coordinate` — next-N candidates for dispatch
+- `/taskwarrior:task-claim` — pick up a "Ready" candidate from this report
+- `/taskwarrior:task-release` — release a "Stale claim" surfaced by this report
 - `/taskwarrior:task-add` — file something surfaced by drift detection
 - `/taskwarrior:task-done` — close PR-ready tasks
 - `.claude/rules/parallel-safe-queries.md` — `export | jq` idiom


### PR DESCRIPTION
## Summary

Adds an agent-identity claim lifecycle to taskwarrior-plugin so concurrent agents can coordinate on the local queue without stepping on each other's work, and wires `+ACTIVE` claims into `git-coworker-check` as a fourth detection signal.

## Commits in this PR

| Commit | Scope | Notes |
|--------|-------|-------|
| `feat(taskwarrior-plugin): add task-claim and task-release for agent identity coordination` | taskwarrior-plugin | Two new skills + identity-aware updates to `task-add`, `task-coordinate`, `task-done`, `task-status`; README and flow diagram updated. |
| `feat(git-plugin): read taskwarrior +ACTIVE claims as a fourth coworker signal` | git-plugin | `detect-coworkers.sh` queries `task project:<repo> +ACTIVE export` (best-effort — falls back gracefully when `task`/`jq` are absent). Self-claims are reported as `OWN_CLAIM_*`. |
| `docs: document taskwarrior claim signal in agent-coworker-detection rule` | rules | Adds the prose subsection that the four-signal table in `.claude/rules/agent-coworker-detection.md` was missing. |

## What changed

### New skills

- `/taskwarrior:task-claim <id>` — `task start` (sets `+ACTIVE`), stamps identity UDAs (`agent` / `pid` / `host` / `branch` / `worktree`), and writes a matching `/git:coworker-check` session marker.
- `/taskwarrior:task-release <id> [<state-message>]` — stops the active clock, annotates the handoff, drains `pid` (keeps the rest for audit unless `--clear-identity`), and drops the coworker-check marker.

### Updated skills

- **`task-add`** — now installs identity UDAs alongside linkage UDAs on first run.
- **`task-coordinate`** — excludes `+ACTIVE` from candidates by default (`--include-active` to opt in); appends in-flight + stale-claim sections to the brief; `--stale-after=N` (default 4h) flags claims to investigate but never auto-stops.
- **`task-done`** — auto-stops `+ACTIVE` on close (taskwarrior built-in); adds `--drain-identity` and `--no-coworker-marker` opt-outs.
- **`task-status`** — adds in-flight + stale-claim sections, `--active` filter, `--stale-claim-after=N`, and rebinds `--mine` to the `agent` UDA.
- **`git-coworker-check`** — reads taskwarrior claims as a fourth signal; `TW_SCAN_METHOD=unavailable` when `task`/`jq` are absent; verdict raises `coworker_detected` on any non-zero `MARKER_COUNT` / `PROC_COUNT` / `TW_CLAIM_COUNT`.

### Why a fourth signal

The three git-side signals (baseline drift, session marker, process scan) only see local in-process coworkers. The taskwarrior signal also catches:

- Coworkers on other hosts (when `~/.task` is synced via TaskChampion)
- Crashed Claude processes whose claim outlived them
- Sibling-worktree agents in the same project

## Test plan

- [ ] In a repo with `task` installed: `/taskwarrior:task-add "test"`, then `/taskwarrior:task-claim <id>` — verify `task <id> export` shows `+ACTIVE`, identity UDAs populated, and `.git/.claude-session-<pid>` written.
- [ ] In the same session: `/git:coworker-check` reports `OWN_CLAIM_TASK=<id>` (not counted as coworker), `VERDICT=clear`.
- [ ] In a sibling shell: `/git:coworker-check` reports `TW_CLAIM_COUNT >= 1`, `VERDICT=coworker_detected`.
- [ ] `/taskwarrior:task-release <id> "stopped at step 2"` clears `+ACTIVE`, drains `pid`, drops marker; subsequent `/git:coworker-check` returns `clear`.
- [ ] `/taskwarrior:task-coordinate` excludes the claimed task from dispatch candidates by default; `--include-active` includes it.
- [ ] `/taskwarrior:task-done <id>` on a `+ACTIVE` task auto-stops, annotates the commit, and drops the marker.
- [ ] On a host without `task`/`jq`: `detect-coworkers.sh` reports `TW_SCAN_METHOD=unavailable`; verdict falls back to the three git-side signals without erroring.
- [ ] `lint-context-commands.sh` passes for both new skills (no `command -v`, no shell operators, no `git config --get` in context).


---
_Generated by [Claude Code](https://claude.ai/code/session_016ihSyy1J1PU4qW5qrWQLpM)_