### PR TITLE
docs(rules): add bash-tool-replacements and gh-json-fields rules (W20 friction)

### DIFF
--- a/.claude/rules/bash-tool-replacements.md
+++ b/.claude/rules/bash-tool-replacements.md
@@ -1,0 +1,71 @@
+# Bash → Tool Replacements
+
+Three search/list patterns in Bash are blocked by the `bash-antipatterns`
+hook because dedicated Claude Code tools cover the same ground faster,
+with structured output, and without paying the parallel-batch cost.
+
+The hook is already a soft-block (exit 2) — by the time you read this,
+you've probably already been blocked. Use this table to pick the right
+replacement.
+
+## The replacement table
+
+| Wrong (Bash) | Right (tool) | When the Bash form is genuinely fine |
+|---|---|---|
+| `find . -name '*.ts'` | `Glob(pattern="**/*.ts")` | Need `-maxdepth`, `-mindepth`, `-type d`, `-print0`, or `-mtime` — Glob can't do directory-discovery flags |
+| `find . -name '*.md' -type d` | `find . -name '*.md' -type d` | Already correct — `-type d` is the directory-discovery flag the hook explicitly allows |
+| `grep -rn 'foo' src/` | `Grep(pattern="foo", path="src", -r=true, -n=true)` | Piped into another command (`gh pr list \| rg 'foo'`), or you need `-q` for an exit-code boolean check |
+| `rg 'foo' --type ts` | `Grep(pattern="foo", glob="*.ts")` | Same exceptions as `grep` |
+| `cat /abs/path/file.md` | `Read(file_path="/abs/path/file.md")` | Piping a *here-doc* into a command — that's a `cat <<EOF` heredoc, not a file read |
+| `head -50 file.md` | `Read(file_path="/abs/path/file.md", limit=50)` | Inside a hook script where Bash is the only option |
+| `tail -50 file.md` | `Read(file_path=..., offset=<lines - 50>, limit=50)` | Same |
+| `ls -1 docs/` | `Glob(pattern="docs/*")` *or* `Bash("ls -1 docs/")` | `ls` is fine for directory listing — the hook only blocks `ls *.glob` patterns |
+
+The hook's allowed-exception logic for each:
+
+- **`find`** — passes through `-maxdepth`, `-mindepth`, `-type` (with a space after), `-print0`. Use these when Glob genuinely can't replace `find`.
+- **`grep` / `rg`** — passes through any pipeline (anything with `|`), and `-q` / `--quiet` (boolean exit-code checks like `grep -q pattern file && do_thing`).
+- **`cat` / `head` / `tail`** — passes through when the file path is `/dev/stdin`, `/dev/null`, or a here-doc target. The hook is checking for *file reads*, not stream handling.
+
+## Why this exists
+
+Three signals from the W20 friction analysis (2026-05-11):
+
+| Pattern | Events / sessions | Per-session rate | Same-session repeat-block rate |
+|---|---|---|---|
+| `find` vs `Glob` | 29 / 25 | 17% | 12% |
+| `grep` / `rg` vs `Grep` | 41 / 33 | 24% | **21%** |
+| `cat`/`head`/`tail` vs `Read` | 29 / 24 | 17% | low |
+
+The `grep` / `rg` 21% same-session repeat-block rate is the outlier:
+the hook is teaching less effectively for this pattern than for `find`
+or `git &&` (both at 8-12%). This rule fills the gap with the same
+explicit do/don't table style that worked for `find` in W16.
+
+## When to keep `find` / `grep` / `rg` in Bash
+
+The hook allows the Bash form in three scenarios:
+
+1. **Pipelines.** `gh pr list --json title --jq '.[].title' | rg 'feat'`
+   is fine — the `|` short-circuits the hook check.
+2. **Directory-discovery flags.** `find . -maxdepth 2 -type d` is the
+   right form. `Glob` doesn't expose directory-type filters.
+3. **Boolean exit-code checks.** `grep -q pattern file && do_thing`
+   is fine. The `Grep` tool returns content; it doesn't give you a
+   clean shell-conditional exit code.
+
+In all three cases the hook silently passes the command through. If
+you're getting blocked anyway, you're not in one of these cases —
+switch to the tool.
+
+## Related
+
+- `.claude/rules/friction/2026-W16-frictions.md` — original `find` →
+  `Glob` rule and its W16 baseline
+- `.claude/rules/friction/2026-W20-frictions.md` — measured impact
+  data and same-session repeat-block analysis
+- `.claude/rules/parallel-safe-queries.md` — why the Bash form is
+  doubly painful in parallel batches: it both fires the hook AND
+  exits non-zero on empty results, cancelling sibling tool calls
+- `hooks-plugin/hooks/bash-antipatterns.sh` — the hook that
+  implements all three blocks

--- a/.claude/rules/gh-json-fields.md
+++ b/.claude/rules/gh-json-fields.md
@@ -1,0 +1,106 @@
+# `gh --json` Field Names
+
+The GitHub CLI's `--json` flag accepts a comma-separated list of field
+names. Invalid names exit 1 and dump the available field list — but
+that's a *runtime* failure, not a syntax check. Get the field name
+right the first time.
+
+## The `merged` mistake
+
+The single most-common mistake (6 of 10 `Unknown JSON field` errors in
+the W20 window, across 6 distinct sessions) is asking for a field
+called `merged`:
+
+```
+# Wrong — there is no `merged` field on the PR JSON object
+gh pr view 42 --json number,merged --jq '.merged'
+# → Exit 1: Unknown JSON field: "merged"
+```
+
+PR merge state lives on the `state` field (a string enum) or the
+`mergedAt` field (an ISO 8601 timestamp, or `null` when not merged).
+
+## PR state reference
+
+| Want to know | Correct field | Value when merged | Value when open | Value when closed-without-merge |
+|---|---|---|---|---|
+| State enum | `state` | `"MERGED"` | `"OPEN"` | `"CLOSED"` |
+| When merged (or null) | `mergedAt` | ISO 8601 string | `null` | `null` |
+| When closed (or null) | `closedAt` | ISO 8601 string | `null` | ISO 8601 string |
+| Merge commit SHA | `mergeCommit.oid` | full SHA | `null` | `null` |
+| Mergeable now? | `mergeable` | n/a | `MERGEABLE` / `CONFLICTING` / `UNKNOWN` | n/a |
+| Auto-merge enabled? | `autoMergeRequest` | n/a | object or `null` | n/a |
+
+Common idioms:
+
+```bash
+# Is the PR merged?
+gh pr view 42 --json state --jq '.state == "MERGED"'
+
+# When was it merged (or null)?
+gh pr view 42 --json mergedAt --jq '.mergedAt'
+
+# Find merged PRs in last month
+gh pr list --state merged --limit 100 --json number,title,mergedAt
+```
+
+## How to discover field names
+
+If you don't know the field name, **don't guess**. Two reliable ways
+to find it:
+
+1. **Run with one valid field, then read the error if any new field
+   is rejected.** The error message lists every available field:
+
+   ```bash
+   gh pr view 42 --json number,merged
+   # → Unknown JSON field: "merged"
+   # → Available fields: additions, assignees, author, autoMergeRequest,
+   #   baseRefName, baseRefOid, body, changedFiles, closed, closedAt, ...
+   ```
+
+   That list is authoritative. Pick the right field from it.
+
+2. **Use the help output:**
+
+   ```bash
+   gh pr view --help     # lists --json flag + field discovery hint
+   gh pr list --help
+   gh issue view --help
+   ```
+
+## Other commonly-mistaken field names
+
+| Want | You might try | Correct field |
+|---|---|---|
+| Is the issue closed? | `closed` (boolean) | `state` (`"OPEN"` / `"CLOSED"`) |
+| When was the issue closed? | `closed_at` (snake_case) | `closedAt` (camelCase) |
+| Is the repo archived? | `archived` on PR/issue object | Query repo separately: `gh repo view --json isArchived` |
+| Issue type | `issueType` | `issueType.name` (object, not string) |
+| Has Pages enabled? | `hasPages` on PR/issue | Query repo: `gh repo view --json hasPagesEnabled` |
+| Base repository | `baseRepository` on a PR | `baseRefRepositoryNameWithOwner` or query separately |
+
+These were all observed in the W20 window. The unifying theme: GitHub's
+GraphQL schema uses **camelCase**, not snake_case, and PR/issue
+objects don't carry every property of their parent repository.
+
+## Edge case: `--jq` on a null field
+
+`mergedAt` is `null` for unmerged PRs. Plain `--jq '.mergedAt'` prints
+`null` (literally the string `null`). For a boolean test:
+
+```bash
+# Right - explicit null check
+gh pr view 42 --json mergedAt --jq '.mergedAt != null'
+
+# Wrong - test "the string null"
+gh pr view 42 --json mergedAt --jq '.mergedAt | length > 0'
+```
+
+## Related
+
+- `.claude/rules/friction/2026-W20-frictions.md` — measured impact
+  (10 events across 10 distinct sessions in the W20 window)
+- `.claude/rules/github-metadata-hygiene.md` (parent
+  `laurigates/CLAUDE.md`) — when to query PR metadata at all
+- `gh pr help json-fields` — official field reference (when available)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,8 @@ Claude Code plugin collection providing skills and agents for development workfl
 | `.claude/rules/plugin-flow-diagrams.md` | When and how to add Mermaid flow diagrams |
 | `.claude/rules/agent-coworker-detection.md` | Detect other agents working in the same repo clone before destructive git ops |
 | `.claude/rules/workflow-naming.md` | `<Domain>: <Action>` naming for `.github/workflows/*.yml` and skill-generated workflow examples |
+| `.claude/rules/bash-tool-replacements.md` | `find`/`grep`/`rg`/`cat`/`head`/`tail` → dedicated tools; when the Bash form is genuinely fine |
+| `.claude/rules/gh-json-fields.md` | Correct `gh --json` field names (PR `state`/`mergedAt`, not `merged`); how to discover field lists |
 
 ## Creating New Skills
 


### PR DESCRIPTION
## Summary

Two new project rules driven by the W20 friction analysis (2026-05-11, 7-day window, 242 transcripts, 169 sessions, 771 events). Source data: `~/.claude/rules/friction/2026-W20-frictions.md`.

- **`bash-tool-replacements.md`** — consolidates the `find`→`Glob`, `grep`/`rg`→`Grep`, `cat`/`head`/`tail`→`Read` replacement table. The `grep`/`rg` pattern is a new dominant signature this week (41 events / 33 sessions, 24% per-session rate) with a **21% same-session repeat-block rate**, substantially above the 8-12% seen for `git &&` or `find` blocks. The hook is teaching less effectively for this pattern — likely because the reminder lacks the concrete do/don't examples that worked for `find` in W16. The new rule mirrors that table style.
- **`gh-json-fields.md`** — addresses the `gh pr view --json merged` error (6 events / 6 distinct sessions in W20, broadly distributed). The `merged` field does not exist on the GitHub CLI's PR JSON object; the correct fields are `state` (enum: `OPEN`/`CLOSED`/`MERGED`) or `mergedAt` (ISO 8601 timestamp, `null` when not merged). Includes a reference table of common `gh --json` field mistakes (camelCase vs snake_case, scoping mistakes like asking for repo-level fields on a PR object) and a field-discovery procedure.

Both files are also registered in the project `CLAUDE.md` rules table.

## W19 watch-list verdicts

The W19 report (`~/.claude/rules/friction/2026-W19-frictions.md`) defined four triggers for this pass. Outcomes:

1. **Per-session `git &&` / `find` rates after high-activity sessions roll out** — both stayed flat (23% / 17% on 169 sessions, vs 26% / 15% on 110 sessions in W19). Confirms a steady-state population prior, not workload mix. But same-session repeat-block rates remain low (8% / 12%), so the hook is doing its job for these two. **No action**, exactly as W19 anticipated.
2. **PR-metadata push concentration** — W19's loud sessions (`930d527f`, `agent-a628`, `agent-a63810d5`) have all closed. W20's PR-metadata events (15) are broadly distributed across 7 new sessions, top-1 only 20% of volume. **No action.**
3. **Edit-before-Read concentration** — still concentrated (43% in `agent-a243`), but in a *different* session than W19's `e069f314`. Volatile single-session pattern. **No action.**
4. **New dominant `hook_block` signature** — secret-protection blocks (5/9), all distinct sessions, hook working correctly. **No action.**

## Test plan

- [ ] Read `bash-tool-replacements.md` end-to-end and confirm the table examples are correct
- [ ] Confirm the `gh-json-fields.md` reference table matches `gh pr view --help` field list on current `gh` version
- [ ] Sanity-check that `bash-tool-replacements.md` does not contradict any existing rule (specifically `parallel-safe-queries.md` and the W16 friction findings)
- [ ] After merge, watch the W21 (2026-05-18) friction pass for the `grep`/`rg` same-session repeat-block rate — target is <15% (down from 21%)
- [ ] Watch the W21 pass for `gh --json` unknown-field volume — target is zero or near-zero

## Related

- `~/.claude/rules/friction/2026-W20-frictions.md` — full findings with measured impact, drift table, and W21 watch list
- `~/.claude/rules/friction/2026-W19-frictions.md` — previous week's findings and watch list this PR responds to
- `~/.claude/rules/friction/2026-W16-frictions.md` — original `find`→`Glob` rule that this PR's `grep`→`Grep` row mirrors

🤖 Generated with [Claude Code](https://claude.com/claude-code)