### PR TITLE
fix(scripts): use user-writable install dir and pip --user

### DIFF
--- a/scripts/install_pkgs.sh
+++ b/scripts/install_pkgs.sh
@@ -9,14 +9,16 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
-INSTALL_DIR="/usr/local/bin"
+INSTALL_DIR="${HOME}/.local/bin"
+mkdir -p "$INSTALL_DIR"
+export PATH="$INSTALL_DIR:$PATH"
 
 has() { command -v "$1" >/dev/null 2>&1; }
 
 # --- pre-commit (via pip) ---
 if ! has pre-commit; then
   echo "[install_pkgs] Installing pre-commit..."
-  pip install --quiet pre-commit
+  pip install --user --quiet pre-commit
 else
   echo "[install_pkgs] pre-commit already installed, skipping."
 fi


### PR DESCRIPTION
Follow-up fix for the `scripts/install_pkgs.sh` introduced in the original `chore: configure SessionStart hook for web tooling` change (already merged).

## What changed

- `INSTALL_DIR` switched from `/usr/local/bin` → `${HOME}/.local/bin`
- Script now creates the directory and prepends it to `PATH` so the in-script `has()` checks find newly installed tools
- `pip install` now uses `--user` to handle PEP 668 externally-managed environments (Python 3.12+)

## Why

Writing to `/usr/local/bin` requires root, which is not guaranteed in remote Claude Code containers. Without `--user`, `pip install pre-commit` can fail outright on PEP 668 systems. Both issues were flagged by gemini-code-assist on the sibling PRs and have been validated by the analogous fix in `ForumViriumHelsinki/google-chat-agent#221` (commit `92eeae6`).

## Test plan

- [ ] Smoke-test locally: `CLAUDE_CODE_REMOTE=true bash scripts/install_pkgs.sh`
- [ ] Run again to verify idempotency
- [ ] Start a remote session on claude.ai/code and confirm tools land in `~/.local/bin`
