### PR TITLE
refactor: tighten skill descriptions across all plugins for listing budget

### DIFF
--- a/.claude/rules/skill-quality.md
+++ b/.claude/rules/skill-quality.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-03-02
-modified: 2026-05-03
-reviewed: 2026-05-03
+modified: 2026-05-13
+reviewed: 2026-05-13
 paths:
   - "**/skills/**"
   - "**/SKILL.md"
@@ -83,13 +83,12 @@ Descriptions must match real user intents. They are loaded into Claude's context
 description: AST-based code search using ast-grep for structural pattern matching
 ```
 
-**Intent-matching** (effective):
+**Intent-matching, length-aware** (effective):
 ```yaml
-description: |
-  Find and replace code patterns structurally using ast-grep. Use when you need
-  to match code by its AST structure, such as finding all functions with specific
-  signatures, replacing API patterns across files, or detecting code anti-patterns.
+description: ast-grep structural code search/rewrite. Use when matching code by AST, refactoring signatures across files, or detecting anti-patterns.
 ```
+
+The example above is **140 chars**. Front-loads the tool name and the matching verbs (`structural code search/rewrite`, `matching code by AST`, `refactoring signatures`, `detecting anti-patterns`) so trigger keywords survive truncation.
 
 ### Description Checklist
 - [ ] Describes what the user can accomplish (not just the tool name)
@@ -97,6 +96,47 @@ description: |
 - [ ] Mentions common trigger phrases users would say
 - [ ] Distinguishes from related skills
 - [ ] Is a string type (non-string values cause a crash)
+- [ ] Length within target band (see below)
+- [ ] Trigger keywords appear in the first ~120 chars
+
+## Description Length and the Listing Budget
+
+Every enabled skill's `name` + `description` is concatenated into a single block that Claude Code injects into the system prompt at session start. That block is capped by two settings introduced in Claude Code 2.1.129:
+
+| Setting | Default | What it caps |
+|---------|---------|--------------|
+| `skillListingBudgetFraction` | `0.01` (1%) | Total skill-metadata share of the context window |
+| `skillListingMaxDescChars` | `1536` | Per-skill description truncation point |
+
+On a 200K-token context that's ~2,000 tokens for **all** skill metadata combined; on a 1M-token context, ~10,000 tokens. Each listed skill costs ~35 tokens of XML wrapper *plus* `(name + description) / 4` tokens. Once the budget is blown, Claude strips descriptions from the overflow skills — they appear by name only, and `description`-based skill-selection silently degrades.
+
+### Target band
+
+| Length | Verdict |
+|--------|---------|
+| ≤ 150 chars | Ideal — leaves headroom and survives any per-skill truncation |
+| 151 – 200 chars | OK — within budget for typical plugin loadouts |
+| 201 – 300 chars | WARN — eats budget faster than it earns invocation accuracy |
+| > 300 chars | ERROR — almost always rewordable; rewrite before merge |
+| > 1536 chars | Truncated at runtime by `skillListingMaxDescChars` |
+
+The previous "intent-matching" guidance produced 220-char medians across this repo. **Target ~120–150 chars** with trigger keywords front-loaded.
+
+### Front-loading trigger keywords
+
+`skillListingMaxDescChars` truncates from the **end**, so put the words Claude needs for selection at the **start**. Order:
+
+1. **Tool / verb / domain** (first 30 chars) — `gh workflow auto-fix`, `OAuth2 token refresh`, `kubectl rollout diagnosis`
+2. **"Use when..." trigger phrases** (next ~60 chars) — concrete user intents, comma-separated
+3. **Disambiguation from sibling skills** (last ~30 chars) — only if needed
+
+| Anti-pattern | Better |
+|---|---|
+| `Comprehensive guide to ast-grep including installation, usage, common patterns, and integration with editor tooling for structural code search and refactoring across large codebases.` (180 chars, keywords late) | `ast-grep structural code search/rewrite. Use when refactoring signatures across files, finding AST patterns, detecting anti-patterns.` (135 chars, keywords first) |
+
+### Why this matters for plugin authors
+
+A plugin with 35 skills × 220 chars consumes ~3,100 tokens on its own — already over a default 200K-context budget before the user enables any other plugin. Tightening to 130 chars cuts that to ~1,950 tokens, leaving headroom for the user's other plugins. See [`skill-listing-budget`](https://claudefa.st/blog/guide/mechanics/skill-listing-budget) for the upstream rationale.
 
 ### `disable-model-invocation` Field
 
@@ -143,6 +183,7 @@ When reviewing skill/command changes:
 - [ ] Has "When to Use" decision table
 - [ ] Has "Agentic Optimizations" table (for CLI/tool skills)
 - [ ] Description matches user intents (not just tool jargon)
+- [ ] Description ≤ 150 chars with trigger keywords in the first ~120 chars (see "Description Length and the Listing Budget")
 - [ ] Model selection follows extremes-only rule (`opus` for deep reasoning, `sonnet` for mechanical tasks, unset otherwise; never `haiku`)
 - [ ] Reference material extracted to REFERENCE.md if needed
 - [ ] Supporting files referenced with markdown links

--- a/accessibility-plugin/skills/accessibility-implementation/SKILL.md
+++ b/accessibility-plugin/skills/accessibility-implementation/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: accessibility-implementation
-description: WCAG 2.1/2.2 compliance, ARIA patterns, keyboard navigation, focus management, and accessibility testing. Use when implementing accessible components, fixing a11y issues, or when the user mentions WCAG, ARIA, screen readers, or keyboard nav.
+description: "WCAG 2.1/2.2 compliance, ARIA patterns, keyboard nav, focus management, a11y testing. Use when implementing accessible components or user mentions WCAG/ARIA/screen readers."
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Edit, Write, Bash(npm *), Bash(npx *), Bash(axe *), BashOutput, TodoWrite, WebSearch, WebFetch
 ---

--- a/accessibility-plugin/skills/design-tokens/SKILL.md
+++ b/accessibility-plugin/skills/design-tokens/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
 name: design-tokens
-description: CSS custom property architecture, theme systems, design token organization, and component library integration. Use when implementing design systems, theme switching, dark mode, or when the user mentions tokens, CSS variables, or theming.
+description: "Design tokens and CSS custom properties: theme systems, dark mode, component libraries. Use when implementing design systems or user mentions tokens, CSS variables, or theming."
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Edit, Write, Bash(npm *), Bash(npx *), TodoWrite
 ---

--- a/agent-patterns-plugin/skills/agent-teams/SKILL.md
+++ b/agent-patterns-plugin/skills/agent-teams/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-teams
-description: Configure Claude Code agent teams (TeamCreate, SendMessage, TaskUpdate). Use when running multiple agents in parallel, coordinating with messaging, or setting up a lead/teammate architecture.
+description: Configure Claude Code agent teams (TeamCreate, SendMessage, TaskUpdate). Use when running parallel agents, coordinating with messaging, or setting up a lead/teammate architecture.
 user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 model: opus

--- a/agent-patterns-plugin/skills/custom-agent-definitions/SKILL.md
+++ b/agent-patterns-plugin/skills/custom-agent-definitions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: custom-agent-definitions
-description: Write and configure custom agent definitions in Claude Code's agents/ directory. Use when creating an agent .md file, defining a specialized agent, or configuring agent tools and capabilities.
+description: Write and configure custom agent definitions in Claude Code agents/ directory. Use when creating an agent .md file, defining a specialized agent, or configuring agent tools.
 user-invocable: false
 allowed-tools: Bash(cat *), Read, Write, Edit, Glob, Grep, TodoWrite
 created: 2026-01-20

--- a/agent-patterns-plugin/skills/exclusive-lock-dispatch/SKILL.md
+++ b/agent-patterns-plugin/skills/exclusive-lock-dispatch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exclusive-lock-dispatch
-description: Pre-dump-then-dispatch pattern for tools holding an exclusive lock (Ghidra, migrations, single-writer caches). Use when fanning out parallel agents that need a non-concurrent resource.
+description: Pre-dump-then-dispatch for tools holding an exclusive lock (Ghidra, migrations, single-writer caches). Use when fanning out parallel agents needing a non-concurrent resource.
 user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 model: opus

--- a/agent-patterns-plugin/skills/mcp-code-execution/SKILL.md
+++ b/agent-patterns-plugin/skills/mcp-code-execution/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-code-execution
-description: Scaffold the code execution pattern for MCP-based agents. Use when agents call many MCP tools, intermediate data exceeds context, you need loops across tool calls, or PII must stay out of context.
+description: Scaffold the code execution pattern for MCP-based agents. Use when agents call many MCP tools, intermediate data exceeds context, you need loops, or PII must stay out of context.
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2026-02-08

--- a/agent-patterns-plugin/skills/mcp-management/SKILL.md
+++ b/agent-patterns-plugin/skills/mcp-management/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-02-26
 name: mcp-management
-description: Install and configure MCP (Model Context Protocol) servers for Claude Code. Use when adding/enabling servers, updating .mcp.json, managing OAuth remote servers, or troubleshooting connections.
+description: Install and configure MCP servers for Claude Code. Use when adding/enabling servers, updating .mcp.json, managing OAuth remote servers, or troubleshooting connections.
 user-invocable: false
 allowed-tools: Bash(jq *), Bash(find *), Read, Write, Edit, Grep, Glob, AskUserQuestion
 ---

--- a/agent-patterns-plugin/skills/meta-audit/SKILL.md
+++ b/agent-patterns-plugin/skills/meta-audit/SKILL.md
@@ -4,7 +4,7 @@ modified: 2026-05-04
 reviewed: 2026-04-25
 allowed-tools: Glob, Read, TodoWrite
 model: opus
-description: Audit Claude subagent configs for completeness, security, and best practices. Use when reviewing .claude/agents/ for missing frontmatter, overprivileged tools, or bad model choices.
+description: Audit Claude subagent configs for completeness, security, and best practices. Use when reviewing agents/ for missing frontmatter, overprivileged tools, or bad model choices.
 args: "[--verbose]"
 argument-hint: "[--verbose]"
 name: meta-audit

--- a/agent-patterns-plugin/skills/meta-promote/SKILL.md
+++ b/agent-patterns-plugin/skills/meta-promote/SKILL.md
@@ -4,7 +4,7 @@ modified: 2026-05-09
 reviewed: 2026-05-09
 allowed-tools: Glob, Read, Edit, Write, Bash(git status *), Bash(git diff *), Bash(git mv *), Bash(diff *), Bash(rm *), AskUserQuestion, TodoWrite
 model: opus
-description: Evaluate whether rules, skills, commands, or agents at one .claude scope should be promoted to a higher scope (parent or user-global), and execute approved promotions safely. Use when reorganizing nested .claude/ directories, when sibling repos hold near-duplicate rules, or when a portfolio root has overlapping configuration with its children.
+description: Promote rules, skills, or agents from project scope to parent or user-global scope. Use when reorganizing .claude/ directories or when sibling repos hold near-duplicate rules.
 args: "[scope-path]"
 argument-hint: "[scope-path]"
 name: meta-promote

--- a/agent-patterns-plugin/skills/parallel-agent-dispatch/SKILL.md
+++ b/agent-patterns-plugin/skills/parallel-agent-dispatch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: parallel-agent-dispatch
-description: Dispatch contract for spawning multiple agents in parallel. Covers worktree collisions, scope overflow, and silent exits. Use when fanning out concurrent agents or authoring a lead prompt.
+description: Dispatch contract for spawning parallel agents covering worktree collisions, scope overflow, and silent exits. Use when fanning out concurrent agents or authoring a lead prompt.
 user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 model: opus

--- a/agent-patterns-plugin/skills/plugin-settings/SKILL.md
+++ b/agent-patterns-plugin/skills/plugin-settings/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plugin-settings
-description: Configure per-project plugin settings via .claude/plugin-name.local.md files. Use when building plugins with user-configurable behavior, storing agent state, or controlling hooks per-project.
+description: Configure per-project plugin settings via .claude/plugin-name.local.md files. Use when building plugins with user-configurable behavior, storing agent state, or controlling hooks.
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2026-03-06

--- a/agent-patterns-plugin/skills/wave-based-dispatch/SKILL.md
+++ b/agent-patterns-plugin/skills/wave-based-dispatch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wave-based-dispatch
-description: Sequential-wave dispatch for WO chains that can't fan out — output of one WO feeds the next, shared locks, or shared files between waves. Use when planning dependent multi-WO landings.
+description: Sequential-wave dispatch for WO chains where output of one feeds the next, shared locks, or shared files prevent fan-out. Use when planning dependent multi-WO landings.
 user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 model: opus

--- a/agents-plugin/skills/agents-analyze/SKILL.md
+++ b/agents-plugin/skills/agents-analyze/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Audit plugins for sub-agent opportunities — verbose-output skills, coverage gaps, tool over-permissions, and model selection. Use when reviewing where sub-agents would help or auditing haiku/opus choices.
+description: Audit plugins for sub-agent opportunities — verbose skills, coverage gaps, over-permissions, and model selection. Use when reviewing where sub-agents would help or auditing model choices.
 args: "[--focus <plugin-name>]"
 allowed-tools: Glob, Grep, Read, Bash(ls *), Bash(wc *), TodoWrite
 model: opus

--- a/agents-plugin/skills/agents-analyze/SKILL.md
+++ b/agents-plugin/skills/agents-analyze/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Audit plugins for sub-agent opportunities — verbose skills, coverage gaps, over-permissions, and model selection. Use when reviewing where sub-agents would help or auditing model choices.
+description: Audit plugins for sub-agent opportunities — verbose skills, coverage gaps, over-permissions. Use when reviewing where sub-agents would help or auditing model (haiku/opus) choices.
 args: "[--focus <plugin-name>]"
 allowed-tools: Glob, Grep, Read, Bash(ls *), Bash(wc *), TodoWrite
 model: opus

--- a/api-plugin/skills/api-testing/SKILL.md
+++ b/api-plugin/skills/api-testing/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: api-testing
-description: HTTP API testing for TypeScript (Supertest) and Python (httpx, pytest). Covers REST, GraphQL, request/response validation, auth, and error handling. Use when the user mentions API testing, Supertest, httpx, or HTTP response validation.
+description: HTTP API testing with Supertest (TS) and httpx/pytest (Python). Use when the user mentions API testing, Supertest, httpx, REST/GraphQL validation, or HTTP response errors.
 user-invocable: false
 allowed-tools: Bash(curl *), Bash(http *), Bash(jq *), Read, Edit, Write, Grep, Glob, TodoWrite
 ---

--- a/api-plugin/skills/api-tests/SKILL.md
+++ b/api-plugin/skills/api-tests/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
-description: Configure API contract testing with Pact, OpenAPI validation, and Zod/AJV schemas. Use when setting up contract tests, validating OpenAPI compliance, or adding breaking-change CI checks.
+description: API contract testing with Pact, OpenAPI validation, and Zod/AJV schemas. Use when setting up contract tests, validating OpenAPI compliance, or adding breaking-change CI checks.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash(curl *), Bash(http *), Bash(jq *), AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--type <pact|openapi|schema>]"
 argument-hint: "[--check-only] [--fix] [--type <pact|openapi|schema>]"

--- a/bevy-plugin/skills/bevy-ecs-patterns/SKILL.md
+++ b/bevy-plugin/skills/bevy-ecs-patterns/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
 name: bevy-ecs-patterns
-description: "Advanced Bevy ECS patterns: complex queries, system scheduling, change detection, entity relationships, and performance tuning. Use when working on advanced Bevy game architecture, optimizing ECS, or implementing complex game systems."
+description: "Advanced Bevy ECS: complex queries, system scheduling, change detection, and performance tuning. Use when optimizing Bevy architecture or implementing complex game systems."
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash(cargo *), Edit, Write, TodoWrite, WebFetch, WebSearch, BashOutput, KillShell
 ---

--- a/bevy-plugin/skills/bevy-game-engine/SKILL.md
+++ b/bevy-plugin/skills/bevy-game-engine/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
 name: bevy-game-engine
-description: "Bevy game engine: ECS, rendering, input, asset management, and game loops. Use when building games with Bevy, working with entities/components/systems, or mentioning Rust gamedev or 2D/3D games."
+description: "Bevy game engine: ECS, rendering, input, and asset management. Use when building Bevy games, working with entities/components/systems, or mentioning Rust gamedev or 2D/3D games."
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash(cargo *), Edit, Write, TodoWrite, WebFetch, WebSearch, BashOutput, KillShell
 ---

--- a/bevy-plugin/skills/bevy-game-engine/SKILL.md
+++ b/bevy-plugin/skills/bevy-game-engine/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
 name: bevy-game-engine
-description: "Bevy game engine: ECS architecture, rendering, input handling, asset management, and game loop design. Use when building games with Bevy, working with entities/components/systems, or when the user mentions Bevy, Rust gamedev, or 2D/3D games."
+description: "Bevy game engine: ECS, rendering, input, asset management, and game loops. Use when building games with Bevy, working with entities/components/systems, or mentioning Rust gamedev or 2D/3D games."
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash(cargo *), Edit, Write, TodoWrite, WebFetch, WebSearch, BashOutput, KillShell
 ---

--- a/blog-plugin/skills/blog-post-writing/skill.md
+++ b/blog-plugin/skills/blog-post-writing/skill.md
@@ -1,6 +1,6 @@
 ---
 name: blog-post-writing
-description: Style guide for blog posts about projects and technical work. Supports quick updates, write-ups, retrospectives, tutorials, and deep dives. Use when writing about work done, documenting a project update, or mentioning blog/post/devlog.
+description: Style guide for technical blog posts — updates, retrospectives, tutorials, deep dives. Use when writing about work done, documenting a project update, or mentioning blog/post/devlog.
 user-invocable: false
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(hugo *), Bash(date *), TodoWrite
 created: 2026-01-10

--- a/blog-plugin/skills/blog-post-writing/skill.md
+++ b/blog-plugin/skills/blog-post-writing/skill.md
@@ -1,6 +1,6 @@
 ---
 name: blog-post-writing
-description: Style guide for technical blog posts — updates, retrospectives, tutorials, deep dives. Use when writing about work done, documenting a project update, or mentioning blog/post/devlog.
+description: Style guide for technical blog posts — updates, retrospectives, tutorials, deep dives. Use when writing about work done, documenting a project, or mentioning blog/post/devlog.
 user-invocable: false
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(hugo *), Bash(date *), TodoWrite
 created: 2026-01-10

--- a/blog-plugin/skills/blog-post/SKILL.md
+++ b/blog-plugin/skills/blog-post/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: blog-post
-description: Create a blog post via guided prompts and structured templates with git context auto-populated. Use when writing a quick update, project update, retrospective, tutorial, deep dive, or devlog entry.
+description: Create a blog post via guided prompts with git context auto-populated. Use when writing a quick update, retrospective, tutorial, deep dive, or devlog entry.
 args: "[type] [--project <name>] [--title <title>]"
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(hugo *), Bash(date *), TodoWrite, AskUserQuestion
 argument-hint: "quick-update | project-update | retrospective | tutorial | deep-dive"

--- a/blueprint-plugin/skills/blueprint-adr-list/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-adr-list/SKILL.md
@@ -2,7 +2,7 @@
 created: 2026-01-29
 modified: 2026-05-04
 reviewed: 2026-04-25
-description: List all ADRs with title, status, date, and domain in a markdown table. Use when generating an ADR index for a README, auditing ADR status, or viewing all architecture decisions at once.
+description: List ADRs as a markdown table with title, status, date, domain. Use when generating an ADR index, auditing ADR status, or reviewing all architecture decisions.
 allowed-tools: Bash, Glob
 model: sonnet
 name: blueprint-adr-list

--- a/blueprint-plugin/skills/blueprint-adr-validate/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-adr-validate/SKILL.md
@@ -2,7 +2,7 @@
 created: 2026-01-15
 modified: 2026-04-19
 reviewed: 2026-04-12
-description: Validate ADR relationships, detect orphaned references, and check domain consistency. Use when auditing ADRs before a release, finding broken supersedes/extends links, or detecting cycles in the supersession graph.
+description: Validate ADR relationships and domain consistency. Use when auditing ADRs before release, finding broken supersedes/extends links, or detecting cycles.
 args: "[--report-only]"
 argument-hint: "--report-only to validate without prompting for fixes"
 allowed-tools: Read, Bash, Glob, Grep, Edit, AskUserQuestion

--- a/blueprint-plugin/skills/blueprint-claude-md/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-claude-md/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-17
 modified: 2026-05-09
 reviewed: 2026-02-09
-description: Generate or update CLAUDE.md from project context and blueprint artifacts. Use when adding team-shared instructions, converting inline content to @imports, or setting up CLAUDE.local.md for personal preferences.
+description: Generate or update CLAUDE.md from blueprint artifacts. Use when adding team instructions, converting inline content to @imports, or setting up CLAUDE.local.md.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 name: blueprint-claude-md
 ---

--- a/blueprint-plugin/skills/blueprint-curate-docs/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-curate-docs/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Curate library or project documentation into ai_docs entries optimized for AI context. Use when documenting a library's gotchas and patterns for PRP reuse, or building a project knowledge base under docs/blueprint/ai_docs/.
+description: Curate docs into ai_docs entries for AI context. Use when documenting library gotchas for PRP reuse or building a knowledge base under docs/blueprint/ai_docs/.
 args: "[library-name|project:pattern-name]"
 argument-hint: "Library name (e.g., redis, pydantic) or project:pattern-name"
 allowed-tools: Read, Write, Glob, Bash, WebFetch, WebSearch, AskUserQuestion

--- a/blueprint-plugin/skills/blueprint-derive-adr/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-derive-adr/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-22
 modified: 2026-05-09
 reviewed: 2026-04-25
-description: Derive ADRs from project structure, dependencies, and docs. Use when onboarding an existing project by documenting implicit architecture decisions or capturing framework/database/testing choices retroactively.
+description: Derive ADRs from project structure, deps, and docs. Use when onboarding a project to capture implicit architecture, framework, or database decisions retroactively.
 allowed-tools: Read, Write, Glob, Grep, Bash, AskUserQuestion, Task
 model: opus
 name: blueprint-derive-adr

--- a/blueprint-plugin/skills/blueprint-derive-plans/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-derive-plans/SKILL.md
@@ -2,7 +2,7 @@
 created: 2026-01-15
 modified: 2026-05-09
 reviewed: 2026-02-14
-description: Derive PRDs, ADRs, and PRPs from git history, codebase, and existing docs. Use when onboarding an established project to blueprint, extracting features from conventional commits, or documenting architecture decisions retroactively.
+description: Derive PRDs, ADRs, PRPs from git history and codebase. Use when onboarding a project to blueprint or extracting features from conventional commits retroactively.
 args: "[--quick] [--since DATE]"
 argument-hint: "--quick for fast scan, --since 2024-01-01 for date range"
 allowed-tools: Read, Write, Glob, Grep, Bash, AskUserQuestion, Task

--- a/blueprint-plugin/skills/blueprint-derive-prd/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-derive-prd/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-22
 modified: 2026-05-09
 reviewed: 2026-04-25
-description: Derive a PRD from existing project docs, README, and codebase. Use when onboarding an existing project to blueprint or extracting problem statements, stakeholders, features, and user personas into a formal PRD.
+description: Derive a PRD from existing docs, README, and codebase. Use when onboarding a project to blueprint or extracting stakeholders, features, and personas into a PRD.
 allowed-tools: Read, Write, Glob, Grep, Bash, AskUserQuestion, Task
 model: opus
 name: blueprint-derive-prd

--- a/blueprint-plugin/skills/blueprint-derive-rules/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-derive-rules/SKILL.md
@@ -2,7 +2,7 @@
 created: 2026-01-30
 modified: 2026-05-09
 reviewed: 2026-02-14
-description: Derive Claude rules from git commit history (newer commits override older). Use when extracting implicit decisions from refactor/fix/feat commits or codifying code-style, testing, and api-design rules.
+description: Derive Claude rules from git commit history. Use when extracting implicit decisions from commits or codifying code-style, testing, and API-design rules.
 args: "[--since DATE] [--scope SCOPE]"
 argument-hint: "--since 2024-01-01 for date range, --scope api for specific area"
 allowed-tools: Read, Write, Glob, Grep, Bash, AskUserQuestion, Task

--- a/blueprint-plugin/skills/blueprint-derive-tests/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-derive-tests/SKILL.md
@@ -2,7 +2,7 @@
 created: 2026-02-22
 modified: 2026-05-04
 reviewed: 2026-02-22
-description: "Derive test regression plans from git history by identifying fix and feature commits lacking corresponding tests. Use when you need to find untested bug fixes, coverage gaps, or generate a test backlog from commit analysis."
+description: Derive test regression plans from git history by finding commits lacking tests. Use when finding untested bug fixes, coverage gaps, or generating a test backlog.
 args: "[--since DATE] [--quick] [--scope AREA]"
 argument-hint: "--since 2024-06-01 for date range, --quick for last 50, --scope auth for specific area"
 allowed-tools: Read, Write, Glob, Grep, Bash, AskUserQuestion, Task

--- a/blueprint-plugin/skills/blueprint-development/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-development/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-03-01
 reviewed: 2026-02-14
 name: blueprint-development
-description: "Generate project-specific rules and commands from PRDs for Blueprint Development methodology. Use when generating behavioral rules for architecture patterns, testing strategies, implementation guides, or quality standards from requirements documents."
+description: Generate project-specific rules from PRDs for Blueprint Development. Use when generating architecture, testing, or quality rules from requirements documents.
 user-invocable: false
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, TodoWrite
 ---

--- a/blueprint-plugin/skills/blueprint-docs-currency/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-docs-currency/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: blueprint-docs-currency
-description: Enforce same-commit landing of code and its docs (public APIs, file formats, error enums, ADRs). Use when committing API/format/milestone changes, promoting tmp/ research to docs/, or landing an ADR-worthy decision.
+description: Enforce same-commit landing of code and docs (APIs, formats, ADRs). Use when committing API/format changes, promoting research to docs/, or landing an ADR decision.
 allowed-tools: Read, Grep, Glob, TodoWrite
 created: 2026-04-24
 modified: 2026-05-09

--- a/blueprint-plugin/skills/blueprint-docs-list/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-docs-list/SKILL.md
@@ -2,7 +2,7 @@
 created: 2026-02-06
 modified: 2026-05-09
 reviewed: 2026-04-25
-description: List blueprint documents (ADRs, PRDs, PRPs) with metadata from frontmatter and headers. Use when listing blueprint docs, auditing statuses, or generating an index table for project documentation.
+description: List blueprint documents (ADRs, PRDs, PRPs) with frontmatter metadata. Use when listing docs, auditing statuses, or generating an index for project documentation.
 args: "<type>"
 allowed-tools: Bash, Glob
 model: sonnet

--- a/blueprint-plugin/skills/blueprint-execute/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-execute/SKILL.md
@@ -2,7 +2,7 @@
 created: 2026-01-14
 modified: 2026-05-09
 reviewed: 2026-04-25
-description: Idempotent meta command that determines and executes the next logical blueprint action. Use when the user asks "what's next?", "continue blueprint work", or "run blueprint" without specifying init/upgrade/derive/generate/execute.
+description: "Blueprint meta command: determine and execute the next logical action. Use when asked 'what's next?', 'continue blueprint', or 'run blueprint' without a subcommand."
 allowed-tools: Read, Glob, Bash, AskUserQuestion, SlashCommand, Task
 name: blueprint-execute
 ---

--- a/blueprint-plugin/skills/blueprint-feature-tracker-status/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-feature-tracker-status/SKILL.md
@@ -2,7 +2,7 @@
 created: 2026-01-02
 modified: 2026-05-09
 reviewed: 2026-05-03
-description: Display feature tracker statistics, phase progress, and completion summary. Use when checking feature completion status, viewing blocked features, or seeing ready-to-start work.
+description: Display feature tracker stats, phase progress, and completion summary. Use when checking feature status, viewing blocked features, or seeing ready-to-start work.
 allowed-tools: Read, Bash, AskUserQuestion
 model: sonnet
 name: blueprint-feature-tracker-status

--- a/blueprint-plugin/skills/blueprint-feature-tracker-sync/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-feature-tracker-sync/SKILL.md
@@ -2,7 +2,7 @@
 created: 2026-01-02
 modified: 2026-05-09
 reviewed: 2026-05-09
-description: Sync feature tracker with TODO.md, taskwarrior sidecars (bpid/bpdoc UDAs), and PRDs. Use when reconciling TODO.md vs tracker, draining WO entries with --drain-wave, recalculating stats, or generating --summary.
+description: Sync feature tracker with TODO.md, taskwarrior sidecars, and PRDs. Use when reconciling TODO.md vs tracker, draining WO entries, or recalculating stats.
 allowed-tools: Read, Write, Bash, Glob, AskUserQuestion
 model: sonnet
 name: blueprint-feature-tracker-sync

--- a/blueprint-plugin/skills/blueprint-generate-rules/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-generate-rules/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-05-03
-description: Generate project-specific rules from PRDs with path-scoped frontmatter. Use when auto-creating architecture/testing/implementation/quality rules from docs/prds/ or path-scoped rules for test files or specific directories.
+description: Generate project-specific rules from PRDs with path-scoped frontmatter. Use when auto-creating architecture, testing, or quality rules from docs/prds/.
 allowed-tools: Read, Write, Glob, Bash, AskUserQuestion
 name: blueprint-generate-rules
 ---

--- a/blueprint-plugin/skills/blueprint-init/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-init/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-05-03
-description: Initialize Blueprint Development structure in current project. Use when bootstrapping docs/blueprint/ with manifest, PRD/ADR/PRP directories, feature tracking, and decision detection for the first time.
+description: Initialize Blueprint Development structure. Use when bootstrapping docs/blueprint/ with manifest, PRD/ADR/PRP directories, and feature tracking for the first time.
 allowed-tools: Bash, Write, Read, AskUserQuestion, Glob
 name: blueprint-init
 ---

--- a/blueprint-plugin/skills/blueprint-migration/skill.md
+++ b/blueprint-plugin/skills/blueprint-migration/skill.md
@@ -1,6 +1,6 @@
 ---
 name: blueprint-migration
-description: Versioned migration procedures for blueprint format upgrades (v1.0->v1.1, v1.x->v2.0, v2.x->v3.0, v3.0->v3.1, v3.2->v3.3). Use when /blueprint:upgrade needs version-specific logic, content hashing, safe file moves, or rollback.
+description: Versioned migration procedures for blueprint format upgrades (v1.x to v3.3). Use when blueprint-upgrade needs version-specific logic, content hashing, or rollback.
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion, TodoWrite
 created: 2025-12-22

--- a/blueprint-plugin/skills/blueprint-promote/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-promote/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-22
 modified: 2026-05-09
 reviewed: 2026-05-04
-description: Move generated artifact to custom layer to preserve manual edits. Use when "promoting" a generated rule, preserving changes to .claude/rules/ files, or stopping sync warnings on modified auto-generated content.
+description: "Move generated artifact to custom layer to preserve manual edits. Use when promoting a generated rule, preserving .claude/rules/ changes, or stopping sync warnings."
 args: "[skill-name|command-name]"
 allowed-tools: Read, Write, Bash, AskUserQuestion
 argument-hint: "Name of the skill or command to promote"

--- a/blueprint-plugin/skills/blueprint-prp-create/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-prp-create/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Create a PRP (Product Requirement Prompt) with systematic research, curated context, and validation gates. Use when planning a feature implementation packet for AI/subagent execution with TDD requirements and confidence scoring.
+description: Create a PRP (Product Requirement Prompt) with research, context, and validation gates. Use when planning a feature packet for subagent execution with TDD and confidence scoring.
 args: "[feature-name]"
 argument-hint: "Feature name for the PRP (e.g., auth-oauth2, api-rate-limiting)"
 allowed-tools: Read, Write, Glob, Bash, WebFetch, WebSearch, Task, AskUserQuestion

--- a/blueprint-plugin/skills/blueprint-prp-execute/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-prp-execute/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Execute a PRP with validation loop, TDD workflow, and quality gates. Use when the user asks to "execute a PRP", running a planned feature from docs/prps/ with red/green/refactor cycles, or delegating a high-confidence PRP to subagents.
+description: Execute a PRP with validation loop, TDD, and quality gates. Use when asked to execute a PRP, run a planned feature from docs/prps/, or delegate a PRP to subagents.
 args: "[prp-name]"
 argument-hint: "Name of PRP to execute (e.g., feature-auth-oauth2)"
 disable-model-invocation: true

--- a/blueprint-plugin/skills/blueprint-rules/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-rules/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-17
 modified: 2026-05-09
 reviewed: 2026-02-09
-description: Manage modular rules in .claude/rules/ with path-specific glob patterns and brace expansion. Use when adding/listing project or user-level rules, syncing with CLAUDE.md, or validating `paths` frontmatter globs.
+description: "Manage modular rules in .claude/rules/ with path-specific globs. Use when adding or listing rules, syncing with CLAUDE.md, or validating path frontmatter."
 allowed-tools: Read, Write, Edit, Bash, Glob, AskUserQuestion
 name: blueprint-rules
 ---

--- a/blueprint-plugin/skills/blueprint-status/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-status/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-17
 modified: 2026-05-09
 reviewed: 2026-05-03
-description: Show blueprint version, config, upgrade availability, PRD/ADR/PRP counts, and feature tracker progress. Use when auditing traceability, orphan docs, task registry health, or stale generated content.
+description: Show blueprint version, config, PRD/ADR/PRP counts, and feature tracker progress. Use when auditing traceability, orphan docs, or stale generated content.
 args: "[--report-only]"
 argument-hint: "--report-only to display status without interactive prompts"
 allowed-tools: Read, Bash, Glob, AskUserQuestion

--- a/blueprint-plugin/skills/blueprint-story-audit/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-story-audit/SKILL.md
@@ -2,7 +2,7 @@
 created: 2026-04-25
 modified: 2026-05-09
 reviewed: 2026-04-25
-description: Audit user stories against codebase and tests for tier-ranked coverage gaps. Use when running "story audit" / "PRD reconciliation", surfacing PRD<->code drift, or finding implicit stories. Read-only — writes one artifact under docs/blueprint/audits/.
+description: Audit user stories against codebase and tests for tier-ranked coverage gaps. Use when running story audit, PRD reconciliation, or surfacing PRD-code drift.
 args: "[--scope <area>] [--prd <path>] [--no-write] [--report-only]"
 argument-hint: "--scope auth to limit; --prd docs/prds/PRD-001.md to override; --no-write skips artifact"
 allowed-tools: Read, Write, Glob, Grep, Bash, Task, AskUserQuestion

--- a/blueprint-plugin/skills/blueprint-story-reconcile/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-story-reconcile/SKILL.md
@@ -2,7 +2,7 @@
 created: 2026-04-25
 modified: 2026-05-09
 reviewed: 2026-04-25
-description: Reconcile PRD requirements with a /blueprint:story-audit drift report. Use when marking PRD entries implemented/partial/missing, adding a "Known Drift" section, or promoting a code-only story into the PRD. Mutates PRD files only.
+description: Reconcile PRD requirements with a story-audit drift report. Use when marking PRD entries implemented/partial/missing, or promoting code-only stories into the PRD.
 args: "[--audit <path>] [--prd <path>] [--apply-all] [--dry-run]"
 argument-hint: "--audit docs/blueprint/audits/2026-04-25-story-audit.md (defaults to latest)"
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion

--- a/blueprint-plugin/skills/blueprint-sync-ids/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-sync-ids/SKILL.md
@@ -2,7 +2,7 @@
 created: 2026-01-20
 modified: 2026-05-09
 reviewed: 2026-04-25
-description: Scan blueprint docs and assign missing PRD-NNN / ADR-NNNN / PRP-NNN / WO-NNN IDs, updating the manifest registry. Use when assigning IDs to docs missing them; --dry-run to preview, --link-issues to create GitHub issues for orphans.
+description: Scan blueprint docs and assign missing PRD/ADR/PRP/WO IDs. Use when assigning IDs to docs; --dry-run to preview, --link-issues to create GitHub issues for orphans.
 args: "[--dry-run] [--link-issues]"
 argument-hint: "--dry-run to preview changes, --link-issues to create GitHub issues for orphans"
 allowed-tools: Read, Write, Edit, Glob, Bash, AskUserQuestion

--- a/blueprint-plugin/skills/blueprint-sync/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-sync/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-22
 modified: 2026-05-09
 reviewed: 2026-05-03
-description: Check for stale generated content and offer regeneration or promotion. Use when syncing blueprint after PRD changes, detecting manually-modified generated rules, or reconciling drift between .claude/rules/ and the manifest.
+description: "Check for stale generated content and offer regeneration or promotion. Use when syncing blueprint after PRD changes, or reconciling .claude/rules/ drift."
 args: "[--dry-run]"
 argument-hint: "--dry-run to preview sync status without modifying files"
 allowed-tools: Read, Bash, Glob, AskUserQuestion

--- a/blueprint-plugin/skills/blueprint-upgrade/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-upgrade/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-17
 modified: 2026-05-09
 reviewed: 2026-05-09
-description: Upgrade blueprint structure to the latest format version. Use when migrating between format versions (v1.x→v3.x), adding the v3.2 task registry, enabling v3.3 monorepo workspaces, or batch upgrading repos with --non-interactive.
+description: Upgrade blueprint structure to the latest format version. Use when migrating between format versions, enabling monorepo workspaces, or batch upgrading repos.
 args: "[--non-interactive|-y]"
 argument-hint: "[--non-interactive|-y]"
 allowed-tools: Read, Write, Edit, Bash, Glob, AskUserQuestion

--- a/blueprint-plugin/skills/blueprint-work-order/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-work-order/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
-description: Create a work-order with minimal context for isolated subagent execution, optionally linked to a GitHub issue. Use when breaking a PRP into delegatable tasks (--from-prp) or spawning from an issue (--from-issue) with clear success criteria.
+description: Create a work-order for isolated subagent execution, optionally linked to a GitHub issue. Use when breaking a PRP into delegatable tasks or spawning from an issue.
 args: "[--no-publish] [--from-issue N]"
 argument-hint: "--no-publish for local-only, --from-issue 123 to create from existing issue"
 disable-model-invocation: true

--- a/blueprint-plugin/skills/blueprint-workspace-scan/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-workspace-scan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: blueprint-workspace-scan
-description: Discover child blueprint workspaces under a monorepo root and refresh the manifest's workspaces.children registry. Use when adding/removing a child blueprint, when /blueprint:status shows stale portfolio data, or migrating to v3.3.
+description: Discover child blueprint workspaces and refresh the manifest. Use when adding/removing a child blueprint or when status shows stale portfolio data.
 args: "[--max-depth N] [--dry-run]"
 argument-hint: "--dry-run to preview without writing; --max-depth sets search depth (default 4)"
 allowed-tools: Bash(bash *), Read, Glob

--- a/blueprint-plugin/skills/document-detection/skill.md
+++ b/blueprint-plugin/skills/document-detection/skill.md
@@ -3,7 +3,7 @@ created: 2026-01-09
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: document-detection
-description: Detect PRD/ADR/PRP opportunities in conversations and prompt for document creation. Use when the user discusses feature requirements, compares technology trade-offs, or plans implementation scope worth capturing.
+description: Detect PRD/ADR/PRP opportunities in conversations and prompt for document creation. Use when the user discusses feature requirements, tech trade-offs, or implementation plans.
 user-invocable: false
 allowed-tools: Read, Grep, Glob, Bash
 ---

--- a/blueprint-plugin/skills/document-linking/skill.md
+++ b/blueprint-plugin/skills/document-linking/skill.md
@@ -3,7 +3,7 @@ created: 2026-01-20
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: document-linking
-description: Unified ID system for PRDs, ADRs, PRPs, and GitHub issues with bidirectional links. Use when linking PRD<->PRP, finding orphans, auto-assigning PRD-NNN / ADR-NNNN / PRP-NNN / WO-NNN IDs, or validating cross-doc references.
+description: Unified ID system for PRDs, ADRs, PRPs, and GitHub issues with bidirectional links. Use when linking docs, finding orphans, auto-assigning IDs, or validating cross-doc references.
 user-invocable: false
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, TodoWrite
 ---

--- a/blueprint-plugin/skills/feature-tracking/SKILL.md
+++ b/blueprint-plugin/skills/feature-tracking/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-01-02
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: feature-tracking
-description: Track feature implementation status against requirements with hierarchical FR codes (FR1.2.1), phase management, and TODO.md sync. Use when linking features to PRDs via feature-tracker.json or recalculating completion stats.
+description: Track feature implementation against requirements with hierarchical FR codes and TODO.md sync. Use when linking features to PRDs or recalculating completion stats.
 user-invocable: false
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, TodoWrite
 ---

--- a/code-quality-plugin/skills/ast-grep-search/SKILL.md
+++ b/code-quality-plugin/skills/ast-grep-search/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: ast-grep-search
-description: "Find and replace code patterns structurally with ast-grep. Use when matching code by AST structure (not text), finding functions with specific signatures, replacing API patterns across files, or detecting anti-patterns regex cannot match."
+description: Find and replace code patterns structurally with ast-grep. Use when matching code by AST structure, finding functions with specific signatures, or detecting anti-patterns regex cannot match.
 user-invocable: false
 allowed-tools: Bash(sg *), Bash(ast-grep *), Read, Grep, Glob
 model: sonnet

--- a/code-quality-plugin/skills/code-antipatterns-analysis/SKILL.md
+++ b/code-quality-plugin/skills/code-antipatterns-analysis/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: code-antipatterns-analysis
-description: "Analyze codebases for anti-patterns and code smells via ast-grep structural matching across JS, TS, Python, Vue, React. Use when reviewing code quality, identifying tech debt, or doing broad code analysis. Pairs with /code-antipatterns."
+description: Analyze codebases for anti-patterns via ast-grep structural matching across JS, TS, Python, Vue, React. Use when reviewing code quality, identifying tech debt, or doing broad code analysis.
 user-invocable: false
 allowed-tools: Bash(sg *), Bash(rg *), Read, Grep, Glob, TodoWrite, Task
 model: opus

--- a/code-quality-plugin/skills/code-antipatterns/SKILL.md
+++ b/code-quality-plugin/skills/code-antipatterns/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
-description: "Analyze a codebase for anti-patterns and code smells using ast-grep. Use when finding magic numbers, console.logs, var usage, excessive `any`, security issues like eval/innerHTML, long functions, or deep nesting."
+description: Analyze a codebase for anti-patterns using ast-grep. Use when finding magic numbers, console.logs, var usage, excessive any, eval/innerHTML security issues, or deep nesting.
 allowed-tools: Read, Bash(sg *), Bash(rg *), Glob, Grep, TodoWrite, Task, SlashCommand
 args: "[PATH] [--focus <category>] [--severity <level>]"
 argument-hint: "[PATH] [--focus <category>] [--severity <level>]"

--- a/code-quality-plugin/skills/code-complexity/SKILL.md
+++ b/code-quality-plugin/skills/code-complexity/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: code-complexity
-description: |
-  Analyze code complexity metrics — cyclomatic complexity, cognitive complexity,
-  function length, and file-level coupling. Use when identifying refactoring
-  targets, tracking codebase health over time, or reviewing large changes.
+description: Analyze code complexity metrics (cyclomatic, cognitive, function length, coupling). Use when identifying refactoring targets, tracking codebase health, or reviewing large changes.
 args: "[PATH] [--threshold <number>] [--format <summary|detailed|json>]"
 argument-hint: path or directory to analyze for complexity
 allowed-tools: Bash(npx *), Bash(radon *), Bash(cargo *), Read, Grep, Glob, TodoWrite

--- a/code-quality-plugin/skills/code-dead-code/SKILL.md
+++ b/code-quality-plugin/skills/code-dead-code/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: code-dead-code
-description: |
-  Detect dead code, unused exports, unreachable branches, and orphaned files.
-  Use when reducing maintenance burden, cleaning up after refactors, or auditing
-  codebase health. Pairs with /configure:dead-code for tool setup.
+description: Detect dead code, unused exports, unreachable branches, and orphaned files. Use when reducing maintenance burden, cleaning up after refactors, or auditing codebase health.
 args: "[PATH] [--tool <knip|vulture|machete>] [--fix]"
 argument-hint: path or directory to scan for dead code
 allowed-tools: Bash(npx knip *), Bash(vulture *), Bash(cargo machete *), Bash(npx ts-prune *), Read, Grep, Glob, TodoWrite

--- a/code-quality-plugin/skills/code-dep-audit/SKILL.md
+++ b/code-quality-plugin/skills/code-dep-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-dep-audit
-description: "Audit dependencies for security vulnerabilities, outdated packages, and license compliance. Use when checking supply chain security, preparing releases, or responding to CVE advisories. Pairs with /configure:security for setup."
+description: Audit dependencies for security vulnerabilities, outdated packages, and license compliance. Use when checking supply chain security, preparing releases, or responding to CVEs.
 args: "[--type <security|outdated|licenses|all>] [--fix]"
 argument-hint: --type security to check vulnerabilities, --type outdated for updates
 allowed-tools: Bash(npm audit *), Bash(npx *), Bash(pip-audit *), Bash(cargo audit *), Bash(pip *), Bash(uv *), Bash(cargo *), Read, Grep, Glob, TodoWrite

--- a/code-quality-plugin/skills/code-docs-quality/SKILL.md
+++ b/code-quality-plugin/skills/code-docs-quality/SKILL.md
@@ -2,7 +2,7 @@
 created: 2026-01-08
 modified: 2026-05-09
 reviewed: 2026-04-25
-description: "Analyze docs quality across PRDs, ADRs, PRPs, CLAUDE.md, .claude/rules/. Use when auditing or scoring documentation, checking for stale ADRs/PRDs, validating rule frontmatter/structure, or reviewing whether CLAUDE.md is up to date."
+description: "Analyze docs quality across PRDs, ADRs, PRPs, CLAUDE.md, .claude/rules/. Use when auditing documentation, checking for stale ADRs/PRDs, or validating rule frontmatter structure."
 allowed-tools: Read, Glob, Grep, Bash(markdownlint *), Bash(vale *), TodoWrite, Task
 args: "[PATH]"
 argument-hint: "[PATH]"

--- a/code-quality-plugin/skills/code-error-swallowing/SKILL.md
+++ b/code-quality-plugin/skills/code-error-swallowing/SKILL.md
@@ -5,7 +5,7 @@ reviewed: 2026-04-14
 allowed-tools: Bash(bash *), Bash(sg *), Read, Grep, Glob, TodoWrite
 args: "[PATH] [--lang <shell|js|py|go|rust|auto>] [--severity <low|med|high>] [--emit-patch]"
 argument-hint: "[PATH] [--lang LANG] [--severity LEVEL] [--emit-patch]"
-description: "Scan for error swallowing — catch/except discarding errors, `|| true`, `2>/dev/null`, floating promises in JS/TS, ignored Go errors, discarded Rust Results. Use when failures \"disappear\" or CI passes despite failing work."
+description: "Scan for error swallowing: catch/except discarding errors, || true, 2>/dev/null, floating promises, ignored Go errors, discarded Rust Results. Use when failures disappear or CI passes despite failing work."
 name: code-error-swallowing
 ---
 

--- a/code-quality-plugin/skills/code-lint-fix/SKILL.md
+++ b/code-quality-plugin/skills/code-lint-fix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-lint-fix
-description: "Cross-language linter autofix patterns for biome, ruff, clippy, shellcheck. Use when auto-fixing lint errors, sorting/removing imports, quoting shell vars, applying prefer-const/clippy suggestions, or detect-and-fix across mixed languages."
+description: Autofix lint errors with biome, ruff, clippy, shellcheck. Use when fixing imports, quoting shell vars, applying clippy fixes, or running detect-and-fix across mixed-language repos.
 allowed-tools: Bash(ruff *), Bash(eslint *), Bash(biome *), Bash(prettier *), Read, Edit, Grep
 model: sonnet
 created: 2025-12-27

--- a/code-quality-plugin/skills/code-lint/SKILL.md
+++ b/code-quality-plugin/skills/code-lint/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash(ruff *), Bash(eslint *), Bash(rustfmt *), Bash(gofmt *), Bas
 model: sonnet
 args: "[path] [--fix] [--format]"
 argument-hint: "[path] [--fix] [--format]"
-description: "Universal linter that auto-detects ruff/eslint/clippy/gofmt for the project language. Use when linting code, auto-fixing with --fix, formatting, or running pre-commit checks across a polyglot repo."
+description: Universal linter that auto-detects ruff/eslint/clippy/gofmt for the project language. Use when linting code, auto-fixing, formatting, or running pre-commit checks.
 name: code-lint
 ---
 

--- a/code-quality-plugin/skills/code-refactor/SKILL.md
+++ b/code-quality-plugin/skills/code-refactor/SKILL.md
@@ -5,7 +5,7 @@ reviewed: 2026-03-09
 allowed-tools: Task, TodoWrite
 args: <file-path|directory>
 argument-hint: <file-path|directory>
-description: "Refactor code applying functional principles — pure functions, immutability, composition. Use when extracting pure functions, removing side effects, replacing imperative loops with map/filter/reduce, or separating logic from I/O."
+description: Refactor toward pure functions, immutability, composition. Use when extracting pure functions, removing side effects, replacing loops with map/filter/reduce, or separating I/O.
 name: code-refactor
 ---
 

--- a/code-quality-plugin/skills/code-review-checklist/SKILL.md
+++ b/code-quality-plugin/skills/code-review-checklist/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review-checklist
-description: "Structured code review checklist for security, correctness, performance, quality, consistency. Use when reviewing PRs, checking hardcoded secrets/injection, verifying error handling and edge cases, or auditing for N+1 queries and resource leaks."
+description: Checklist for security, correctness, and performance review. Use when reviewing PRs, checking for secrets/injection, verifying error handling, or auditing N+1 queries.
 user-invocable: false
 allowed-tools: Read, Grep, Glob
 model: opus

--- a/code-quality-plugin/skills/code-review/SKILL.md
+++ b/code-quality-plugin/skills/code-review/SKILL.md
@@ -4,7 +4,7 @@ modified: 2026-05-09
 reviewed: 2026-04-25
 allowed-tools: Task, TodoWrite, Glob, Read
 model: opus
-description: "Comprehensive code review covering quality, security, performance, architecture, and test coverage with safe automated fixes. Use when reviewing code, auditing OWASP issues, checking SOLID, or finding perf bottlenecks and missing tests."
+description: Code review for quality, security, performance, and architecture. Use when reviewing code, auditing OWASP, checking SOLID, or finding perf bottlenecks and test gaps.
 args: "[PATH]"
 argument-hint: "[PATH]"
 name: code-review

--- a/code-quality-plugin/skills/code-silent-degradation/SKILL.md
+++ b/code-quality-plugin/skills/code-silent-degradation/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash(grep *), Read, Grep, Glob, Edit, Write, TodoWrite
 model: opus
 args: "[PATH] [--fix]"
 argument-hint: "[PATH] [--fix]"
-description: "Detect silent degradation patterns where ops succeed with zero results because preconditions are unmet. Use when features report \"success\" but produce nothing, scans show 0 items unexplained, or UX shows green banners for empty outcomes."
+description: Detect silent degradation where ops succeed with zero results. Use when features report success but produce nothing, scans return 0 items, or UI shows success for empty outcomes.
 name: code-silent-degradation
 ---
 

--- a/code-quality-plugin/skills/code-test-quality/SKILL.md
+++ b/code-quality-plugin/skills/code-test-quality/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-test-quality
-description: "Analyze test suite quality — test smells, empty assertions, flaky patterns, coverage gaps, missing edge cases. Use when test suite is unreliable, coverage is misleading, or after major refactors. Pairs with /configure:tests and /configure:coverage."
+description: "Analyze test quality: smells, empty assertions, flaky patterns, coverage gaps. Use when tests are unreliable, coverage is misleading, or after major refactors."
 args: "[PATH] [--focus <smells|coverage|flaky|all>]"
 argument-hint: path to test directory or specific test file
 allowed-tools: Bash(npx vitest *), Bash(npx jest *), Bash(pytest *), Bash(cargo test *), Read, Grep, Glob, TodoWrite

--- a/code-quality-plugin/skills/debugging-methodology/SKILL.md
+++ b/code-quality-plugin/skills/debugging-methodology/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debugging-methodology
-description: "Systematic debugging methodology with tool recommendations for memory, performance, system-level issues. Use when diagnosing memory leaks, tracing syscalls with strace/eBPF, profiling with perf, or reasoning about races."
+description: Systematic debugging for memory, performance, and system-level issues. Use when diagnosing memory leaks, tracing syscalls with strace/eBPF, profiling, or reasoning about races.
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 model: opus

--- a/code-quality-plugin/skills/dry-consolidation/SKILL.md
+++ b/code-quality-plugin/skills/dry-consolidation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dry-consolidation
-description: "Find and extract duplicated code into shared abstractions. Use when seeing repeated patterns across files — identical utilities, copy-pasted UI components, duplicated hooks/state, or repeated boilerplate — and consolidating into reusable modules."
+description: Find and extract duplicated code into shared abstractions. Use when seeing repeated utilities, copy-pasted components, duplicated hooks, or boilerplate repeated across files.
 args: "[PATH] [--scope <utilities|components|hooks|all>] [--dry-run]"
 allowed-tools: Read, Write, Edit, MultiEdit, Grep, Glob, Bash(npx tsc *), Bash(npm run *), Bash(npx *), Bash(bun *), Bash(pnpm *), Bash(yarn *), Bash(pytest *), Bash(cargo *), TodoWrite, Task
 model: opus

--- a/codebase-attributes-plugin/skills/attributes-collect/SKILL.md
+++ b/codebase-attributes-plugin/skills/attributes-collect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: attributes-collect
-description: Collect codebase health attributes as structured JSON. Use when you need a structured assessment of project health before routing to specialized agents.
+description: Collect codebase health attributes as structured JSON. Use when assessing project health before routing to specialized agents via attributes-route.
 allowed-tools: Bash(test *), Bash(wc *), Read, Glob, Grep, TodoWrite
 args: "[--output <path>] [--categories <list>]"
 argument-hint: "[--output .claude/attributes.json]"

--- a/codebase-attributes-plugin/skills/attributes-dashboard/SKILL.md
+++ b/codebase-attributes-plugin/skills/attributes-dashboard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: attributes-dashboard
-description: Compact text dashboard showing scores, findings, and severity for docs, testing, security, code quality, and CI/CD. Use when the user wants a quick health overview, to compare category scores, or a terminal-style summary with action suggestions.
+description: Codebase health dashboard with scores and severity for docs, testing, security, and CI/CD. Use when wanting a quick health overview or terminal-style summary with action suggestions.
 allowed-tools: Bash(test *), Read, Glob, Grep
 args: "[--format <type>]"
 argument-hint: ""

--- a/codebase-attributes-plugin/skills/attributes-dashboard/SKILL.md
+++ b/codebase-attributes-plugin/skills/attributes-dashboard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: attributes-dashboard
-description: Codebase health dashboard with scores and severity for docs, testing, security, and CI/CD. Use when wanting a quick health overview or terminal-style summary with action suggestions.
+description: Codebase health dashboard with scores and severity for docs, testing, security, and CI/CD. Use when wanting a health overview or terminal-style summary with action suggestions.
 allowed-tools: Bash(test *), Read, Glob, Grep
 args: "[--format <type>]"
 argument-hint: ""

--- a/codebase-attributes-plugin/skills/attributes-route/SKILL.md
+++ b/codebase-attributes-plugin/skills/attributes-route/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: attributes-route
-description: "Route to specialized agents (security, test, refactor, review, docs, configure) based on codebase health attributes, prioritized by severity. Use when the user has attribute data and wants automated remediation after `/attributes:collect`."
+description: "Route to specialized agents (security, test, refactor, docs) based on codebase health attributes by severity. Use when the user has attribute data and wants automated remediation."
 allowed-tools: Read, Glob, Grep, Agent, TodoWrite
 args: "[--dry-run] [--focus <category>] [--min-severity <level>]"
 argument-hint: "--dry-run"

--- a/communication-plugin/skills/google-chat-formatting/SKILL.md
+++ b/communication-plugin/skills/google-chat-formatting/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: google-chat-formatting
-description: Convert Markdown text to Google Chat compatible formatting. Use when formatting messages for Google Chat or converting Markdown documents to Google Chat syntax.
+description: Convert Markdown to Google Chat formatting. Use when formatting messages for Google Chat or converting Markdown documents to Google Chat syntax.
 user-invocable: false
 allowed-tools: Read, Write, Edit, Bash
 ---

--- a/communication-plugin/skills/ticket-drafting-guidelines/SKILL.md
+++ b/communication-plugin/skills/ticket-drafting-guidelines/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: ticket-drafting-guidelines
-description: Structured guidelines for drafting GitHub issues and technical tickets. Uses What/Why/How format with concise descriptions and positive framing without estimates. Use when creating issues, drafting tickets, or writing bug reports.
+description: Guidelines for drafting GitHub issues using What/Why/How format. Use when creating issues, drafting tickets, or writing bug reports with concise and positive framing.
 user-invocable: false
 allowed-tools: Read, Grep, WebFetch
 ---

--- a/component-patterns-plugin/skills/components-version-badge/SKILL.md
+++ b/component-patterns-plugin/skills/components-version-badge/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-02-03
 modified: 2026-05-09
 reviewed: 2026-04-25
-description: Framework-agnostic version badge with a tooltip showing build info (version, commit, branch, timestamp) and recent changelog. Use when adding version display to app header/footer. Supports Next.js, Nuxt, SvelteKit, Vite+React, plain React/Vue/Svelte.
+description: Version badge with build-info tooltip (version, commit, changelog). Use when adding version display to app header/footer. Supports Next.js, Nuxt, SvelteKit, Vite+React, React/Vue/Svelte.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--location <header|footer|custom>]"
 argument-hint: "[--check-only] [--location <header|footer|custom>]"

--- a/component-patterns-plugin/skills/components-version-badge/SKILL.md
+++ b/component-patterns-plugin/skills/components-version-badge/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-02-03
 modified: 2026-05-09
 reviewed: 2026-04-25
-description: Version badge with build-info tooltip (version, commit, changelog). Use when adding version display to app header/footer. Supports Next.js, Nuxt, SvelteKit, Vite+React, React/Vue/Svelte.
+description: Version badge with build-info tooltip (version, commit, changelog). Use when adding version display to app header/footer for Next.js, Nuxt, SvelteKit, Vite, React, Vue, or Svelte.
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--location <header|footer|custom>]"
 argument-hint: "[--check-only] [--location <header|footer|custom>]"

--- a/component-patterns-plugin/skills/version-badge-pattern/SKILL.md
+++ b/component-patterns-plugin/skills/version-badge-pattern/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: version-badge-pattern
-description: Version badge UI pattern showing build version, git commit, and changelog in a tooltip. Use when adding version visibility for support or debugging. Works with React, Vue, Svelte, and JS.
+description: Version badge UI showing build version, git commit, and changelog in a tooltip. Use when adding version visibility for support or debugging. Works with React, Vue, Svelte, and JS.
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2025-02-03

--- a/component-patterns-plugin/skills/version-badge-pattern/SKILL.md
+++ b/component-patterns-plugin/skills/version-badge-pattern/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: version-badge-pattern
-description: Implement a version badge UI showing build version, git commit, and recent changelog in a tooltip. Use when adding version visibility for support, debugging, and change awareness. Works with React, Vue, Svelte, and plain JavaScript.
+description: Version badge UI pattern showing build version, git commit, and changelog in a tooltip. Use when adding version visibility for support or debugging. Works with React, Vue, Svelte, and JS.
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2025-02-03

--- a/configure-plugin/skills/ci-workflows/SKILL.md
+++ b/configure-plugin/skills/ci-workflows/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-04-29
 reviewed: 2026-04-29
 name: ci-workflows
-description: GitHub Actions workflow standards. Use when configuring CI/CD workflows, checking workflow compliance, or working with container builds and CI/CD automation.
+description: "GitHub Actions workflow standards. Use when checking CI/CD compliance, referencing canonical workflow shapes, or another skill needs workflow structure guidance."
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 ---

--- a/configure-plugin/skills/claude-security-settings/SKILL.md
+++ b/configure-plugin/skills/claude-security-settings/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: claude-security-settings
-description: Configure Claude Code security settings — permission wildcards, shell operator protections, project-level access controls. Use when setting up project permissions or restricting allowed tools.
+description: "Claude Code security settings: permission wildcards, shell operator protections, project-level allowlists. Use when auditing or hardening .claude/settings.json permissions."
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, TodoWrite
 created: 2026-01-20

--- a/configure-plugin/skills/config-sync/SKILL.md
+++ b/configure-plugin/skills/config-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: config-sync
-description: Extract, compare, and propagate tooling improvements across FVH repos. Use when syncing workflows, diffing configs across repos, or extracting improvements to apply elsewhere.
+description: "Config sync across FVH repos: extract, diff, propagate tooling improvements. Use when syncing workflows or configs across multiple repos."
 allowed-tools: Bash(git *), Bash(gh *), Bash(fd *), Bash(rg *), Bash(diff *), Bash(sha256sum *), Bash(shasum *), Read, Grep, Glob, Edit, Write, TodoWrite, AskUserQuestion
 args: <mode> [options]
 argument-hint: "extract [repo]|diff <file-pattern>|apply <file-pattern> [--from repo] [--to repos|--all]"

--- a/configure-plugin/skills/configure-all/SKILL.md
+++ b/configure-plugin/skills/configure-all/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-04-19
 reviewed: 2025-12-16
-description: Run all infrastructure standards checks and apply compliance fixes across a project. Use when performing a comprehensive audit, onboarding a new project against all standards, or batch-fixing with --fix.
+description: "Run all infrastructure standards checks and fixes. Use when onboarding a new project, doing a full compliance audit, or batch-fixing with --fix."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, SlashCommand
 args: "[--check-only] [--fix] [--type <frontend|infrastructure|python>]"
 argument-hint: "[--check-only] [--fix] [--type <frontend|infrastructure|python>]"

--- a/configure-plugin/skills/configure-api-tests/SKILL.md
+++ b/configure-plugin/skills/configure-api-tests/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure API contract testing with Pact, OpenAPI validation, and JSON Schema/Zod. Use when adding consumer/provider contract tests or detecting breaking API changes in CI.
+description: "API contract testing: Pact, OpenAPI validation, JSON Schema/Zod. Use when adding consumer/provider contract tests or detecting breaking API changes in CI."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--type <pact|openapi|schema>]"
 argument-hint: "[--check-only] [--fix] [--type <pact|openapi|schema>]"

--- a/configure-plugin/skills/configure-argocd-automerge/SKILL.md
+++ b/configure-plugin/skills/configure-argocd-automerge/SKILL.md
@@ -2,7 +2,7 @@
 created: 2026-02-03
 modified: 2026-04-19
 reviewed: 2026-02-03
-description: Configure GitHub Actions auto-merge for ArgoCD Image Updater branches. Use when setting up auto-merge for image-updater-** branches, creating argocd-automerge.yml, or verifying PAT permissions.
+description: "ArgoCD auto-merge: configure GitHub Actions for image-updater-** branches. Use when setting up argocd-automerge.yml or verifying PAT permissions."
 allowed-tools: Glob, Grep, Read, Write, Edit, TodoWrite
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"

--- a/configure-plugin/skills/configure-cache-busting/SKILL.md
+++ b/configure-plugin/skills/configure-cache-busting/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure cache-busting for Next.js and Vite projects. Use when adding content hashing, setting CDN cache headers (Vercel, Cloudflare), or auditing static asset caching.
+description: "Cache-busting for Next.js and Vite: content hashing, CDN cache headers. Use when adding Vercel/Cloudflare cache headers or auditing static asset caching."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--framework <nextjs|vite>] [--cdn <cloudflare|vercel|none>]"
 argument-hint: "[--check-only] [--fix] [--framework <nextjs|vite>] [--cdn <cloudflare|vercel|none>]"

--- a/configure-plugin/skills/configure-claude-plugins/SKILL.md
+++ b/configure-plugin/skills/configure-claude-plugins/SKILL.md
@@ -2,7 +2,7 @@
 created: 2026-01-23
 modified: 2026-05-09
 reviewed: 2026-05-06
-description: Configure .claude/settings.json and GitHub Actions for the laurigates/claude-plugins marketplace. Use when onboarding to Claude Code plugins, setting up claude.yml, or pinning plugin sets.
+description: "Claude plugins marketplace setup: .claude/settings.json, GitHub Actions, plugin sets. Use when onboarding to claude-plugins, setting up claude.yml, or pinning plugins."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash(mkdir *), Bash(test *), Bash(ls *), Bash(git remote *), Bash(gh api *), Bash(jq *), AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--exhaustive] [--plugins <plugin1,plugin2,...>]"
 argument-hint: "[--check-only] [--fix] [--exhaustive] [--plugins <plugin1,plugin2,...>]"

--- a/configure-plugin/skills/configure-container/SKILL.md
+++ b/configure-plugin/skills/configure-container/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-04-19
 reviewed: 2026-01-19
-description: Check and configure container infrastructure — builds, GHCR registry, Trivy/Grype scanning, devcontainer. Use when setting up multi-platform GHCR workflows or adding container scanning to CI.
+description: "Container infrastructure: GHCR builds, Trivy/Grype scanning, devcontainer. Use when setting up multi-platform GHCR workflows or adding container scanning to CI."
 allowed-tools: Glob, Grep, Read, Write, Edit, AskUserQuestion, TodoWrite, SlashCommand, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--component <dockerfile|workflow|registry|scanning|devcontainer>]"
 argument-hint: "[--check-only] [--fix] [--component <dockerfile|workflow|registry|scanning|devcontainer>]"

--- a/configure-plugin/skills/configure-coverage/SKILL.md
+++ b/configure-plugin/skills/configure-coverage/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure code coverage thresholds and reporters for Vitest, Jest, pytest, and Rust. Use when setting coverage thresholds, adding Codecov or Coveralls, or wiring lcov/HTML reports.
+description: "Code coverage: thresholds and reporters for Vitest, Jest, pytest, Rust. Use when setting thresholds, adding Codecov/Coveralls, or wiring lcov/HTML reports."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--threshold <percentage>]"
 argument-hint: "[--check-only] [--fix] [--threshold <percentage>]"

--- a/configure-plugin/skills/configure-dead-code/SKILL.md
+++ b/configure-plugin/skills/configure-dead-code/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure dead-code detection tools (Knip, Vulture, cargo-machete, deadcode). Use when setting up unused-code detection, migrating between tools, or adding dead-code checks to CI.
+description: "Dead-code detection: Knip, Vulture, cargo-machete, deadcode. Use when setting up unused-code scanning, migrating tools, or adding dead-code CI checks."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--tool <knip|vulture|deadcode|machete>]"
 argument-hint: "[--check-only] [--fix] [--tool <knip|vulture|deadcode|machete>]"

--- a/configure-plugin/skills/configure-dockerfile/SKILL.md
+++ b/configure-plugin/skills/configure-dockerfile/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-04-19
 reviewed: 2026-01-19
-description: Check and configure Dockerfiles for minimal Alpine/slim base, non-root user, and multi-stage builds. Use when creating a Dockerfile, hardening for security, or auditing image size and layering.
+description: "Dockerfile standards: Alpine/slim base, non-root user, multi-stage builds. Use when creating a Dockerfile, hardening security, or auditing image size."
 allowed-tools: Glob, Grep, Read, Write, Edit, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--type <frontend|python|go|rust>]"
 argument-hint: "[--check-only] [--fix] [--type <frontend|python|go|rust>]"

--- a/configure-plugin/skills/configure-docs/SKILL.md
+++ b/configure-plugin/skills/configure-docs/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure code documentation standards and generators (TSDoc, JSDoc, pydoc, rustdoc, TypeDoc, MkDocs, Sphinx). Use when setting up docstrings, configuring a docs generator, or enforcing doc coverage in CI.
+description: "Code docs: TSDoc, JSDoc, pydoc, rustdoc, TypeDoc, MkDocs, Sphinx. Use when setting up docstrings, configuring a docs generator, or enforcing doc coverage in CI."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--level <minimal|standard|strict>] [--type <typescript|javascript|python|rust>] [--generator <typedoc|sphinx|mkdocs|rustdoc>]"
 argument-hint: "[--check-only] [--fix] [--level <minimal|standard|strict>] [--type <typescript|javascript|python|rust>] [--generator <typedoc|sphinx|mkdocs|rustdoc>]"

--- a/configure-plugin/skills/configure-editor/SKILL.md
+++ b/configure-plugin/skills/configure-editor/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
-description: Configure EditorConfig and VS Code workspace settings for team consistency. Use when setting up editor config, format-on-save, recommended extensions, or debug configurations.
+description: "EditorConfig and VS Code workspace settings for team consistency. Use when setting up format-on-save, recommended extensions, or debug configurations."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"

--- a/configure-plugin/skills/configure-feature-flags/SKILL.md
+++ b/configure-plugin/skills/configure-feature-flags/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
-description: Configure feature flag infrastructure with OpenFeature and pluggable providers (GOFF, flagd, LaunchDarkly). Use when setting up the SDK, configuring a relay proxy, or adding flag test helpers.
+description: "Feature flags with OpenFeature and providers (GOFF, flagd, LaunchDarkly). Use when setting up the SDK, configuring a relay proxy, or adding flag test helpers."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--provider <goff|flagd|launchdarkly|split>]"
 argument-hint: "[--check-only] [--fix] [--provider <goff|flagd|launchdarkly|split>]"

--- a/configure-plugin/skills/configure-formatting/SKILL.md
+++ b/configure-plugin/skills/configure-formatting/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure code formatters (Biome, Prettier, Ruff format, rustfmt). Use when setting up formatting, migrating Prettier to Biome or Black to Ruff, adding format-on-save, or wiring CI format checks.
+description: "Code formatters: Biome, Prettier, Ruff, rustfmt. Use when setting up formatting, migrating Prettier to Biome, or wiring CI format checks."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--formatter <biome|prettier|ruff|rustfmt>]"
 argument-hint: "[--check-only] [--fix] [--formatter <biome|prettier|ruff|rustfmt>]"

--- a/configure-plugin/skills/configure-github-pages/SKILL.md
+++ b/configure-plugin/skills/configure-github-pages/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure GitHub Pages deployment workflows for docs sites. Use when setting up Pages, migrating peaceiris/actions-gh-pages to actions/deploy-pages, or auditing Pages action versions.
+description: "GitHub Pages deployment workflows for docs sites. Use when setting up Pages, migrating to actions/deploy-pages, or auditing Pages action versions."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--source <docs|site|custom>]"
 argument-hint: "[--check-only] [--fix] [--source <docs|site|custom>]"

--- a/configure-plugin/skills/configure-integration-tests/SKILL.md
+++ b/configure-plugin/skills/configure-integration-tests/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
-description: Configure integration testing with Supertest, pytest, or Testcontainers. Use when setting up integration tests, creating docker-compose.test.yml, or separating integration from unit tests.
+description: "Integration testing: Supertest, pytest, Testcontainers. Use when setting up integration tests, creating docker-compose.test.yml, or separating from unit tests."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--framework <supertest|pytest|testcontainers>]"
 argument-hint: "[--check-only] [--fix] [--framework <supertest|pytest|testcontainers>]"

--- a/configure-plugin/skills/configure-linting/SKILL.md
+++ b/configure-plugin/skills/configure-linting/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-04-19
 reviewed: 2025-12-16
-description: Check and configure modern linters (Biome, Ruff, Clippy). Use when setting up linting, migrating ESLint/Prettier to Biome, or wiring lint checks into pre-commit and CI.
+description: "Modern linters: Biome, Ruff, Clippy. Use when setting up linting, migrating ESLint/Prettier to Biome, or wiring lint into pre-commit and CI."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--linter <biome|ruff|clippy>]"
 argument-hint: "[--check-only] [--fix] [--linter <biome|ruff|clippy>]"

--- a/configure-plugin/skills/configure-load-tests/SKILL.md
+++ b/configure-plugin/skills/configure-load-tests/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-29
-description: Configure load and performance testing with k6, Artillery, or Locust. Use when setting up load tests, auditing smoke/stress/spike/soak coverage, adding CI performance regression detection, or migrating between load testing frameworks.
+description: "Load testing: k6, Artillery, Locust. Use when setting up load tests, auditing smoke/stress/spike/soak coverage, or adding CI performance regression detection."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--framework <k6|artillery|locust>]"
 argument-hint: "[--check-only] [--fix] [--framework <k6|artillery|locust>]"

--- a/configure-plugin/skills/configure-makefile/SKILL.md
+++ b/configure-plugin/skills/configure-makefile/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
-description: Configure Makefile with standard targets. Use when setting up a new Makefile, auditing for missing standard targets (help, test, build, clean, lint), or adding language-specific build/test/lint targets.
+description: "Makefile with standard targets (help, test, build, clean, lint). Use when setting up a Makefile, auditing missing targets, or adding language-specific targets."
 allowed-tools: Glob, Grep, Read, Write, Edit, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"

--- a/configure-plugin/skills/configure-memory-profiling/SKILL.md
+++ b/configure-plugin/skills/configure-memory-profiling/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
-description: Configure memory profiling with pytest-memray for Python. Use when setting up memory profiling, adding CI memory regression detection, configuring leak detection in tests, or setting memory thresholds and allocation benchmarks.
+description: "Memory profiling with pytest-memray for Python. Use when setting up memory profiling, adding CI memory regression detection, or setting memory thresholds."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--threshold <mb>] [--native]"
 argument-hint: "[--check-only] [--fix] [--threshold <mb>] [--native]"

--- a/configure-plugin/skills/configure-package-management/SKILL.md
+++ b/configure-plugin/skills/configure-package-management/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
-description: Configure modern package managers (uv for Python, bun for TypeScript). Use when setting up uv or bun, migrating from legacy managers (pip, npm, yarn, poetry, pipenv), or cleaning up conflicting lock files.
+description: "Package managers: uv (Python), bun (TypeScript). Use when setting up uv or bun, migrating from pip/npm/yarn/poetry/pipenv, or resolving lockfile conflicts."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--manager <uv|bun|npm|cargo>]"
 argument-hint: "[--check-only] [--fix] [--manager <uv|bun|npm|cargo>]"

--- a/configure-plugin/skills/configure-pre-commit/SKILL.md
+++ b/configure-plugin/skills/configure-pre-commit/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
-description: Configure pre-commit hooks. Use when setting up or validating hooks, installing project-type-specific hooks (frontend, infrastructure, python), or migrating to the pre-commit framework.
+description: "pre-commit hooks setup and validation. Use when installing hooks, configuring frontend/infrastructure/python project types, or migrating to pre-commit."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--type <frontend|infrastructure|python>]"
 argument-hint: "[--check-only] [--fix] [--type <frontend|infrastructure|python>]"

--- a/configure-plugin/skills/configure-readme/SKILL.md
+++ b/configure-plugin/skills/configure-readme/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-17
 modified: 2026-05-09
 reviewed: 2026-02-08
-description: Configure README.md with logo, badges, features, tech stack, and project structure. Use when creating a new README, auditing for missing sections, standardizing format across projects, or adding shields.io badges.
+description: "README.md with logo, badges, features, tech stack sections. Use when creating a README, auditing missing sections, or adding shields.io badges."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch
 args: "[--check-only] [--fix] [--style <minimal|standard|detailed>] [--badges <shields|custom>]"
 argument-hint: "[--check-only] [--fix] [--style <minimal|standard|detailed>] [--badges <shields|custom>]"

--- a/configure-plugin/skills/configure-release-please/SKILL.md
+++ b/configure-plugin/skills/configure-release-please/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
-description: Configure release-please workflows. Use when setting up release-please for a new project, auditing an existing config, upgrading release-please-action, or adding a new package to a monorepo release-please config.
+description: "release-please workflow setup and auditing. Use when configuring release-please, upgrading release-please-action, or adding a package to a monorepo config."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"

--- a/configure-plugin/skills/configure-repo/SKILL.md
+++ b/configure-plugin/skills/configure-repo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: configure-repo
-description: End-to-end driver that produces a working .claude/ directory, SessionStart hook, and install_pkgs.sh, all staged for commit. Use when onboarding any repo to Claude Code with the laurigates/claude-plugins marketplace.
+description: "Repo onboarding driver: .claude/ directory, SessionStart hook, install_pkgs.sh. Use when onboarding any repo to Claude Code with the claude-plugins marketplace."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash(git add *), Bash(git status *), Bash(git diff *), Bash(find *), Bash(mkdir *), Bash(test *), AskUserQuestion, TodoWrite, SlashCommand
 args: "[--check-only] [--skip-health] [--skip-migrations]"
 argument-hint: "[--check-only] [--skip-health] [--skip-migrations]"

--- a/configure-plugin/skills/configure-reusable-workflows/SKILL.md
+++ b/configure-plugin/skills/configure-reusable-workflows/SKILL.md
@@ -2,7 +2,7 @@
 created: 2026-02-02
 modified: 2026-04-29
 reviewed: 2026-04-29
-description: Install Claude-powered reusable GitHub Actions workflows for security, quality, and accessibility. Use when adding OWASP/secret/code-smell scans or WCAG checks to PR pipelines.
+description: "Reusable GitHub Actions workflows for security, quality, accessibility. Use when adding OWASP/secret/code-smell scans or WCAG checks to PR pipelines."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash(mkdir *), Bash(ls *), AskUserQuestion, TodoWrite
 args: "[--all] [--security] [--quality] [--a11y] [--list]"
 argument-hint: "[--all] [--security] [--quality] [--a11y] [--list]"

--- a/configure-plugin/skills/configure-security/SKILL.md
+++ b/configure-plugin/skills/configure-security/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
-description: Configure security scanning — dependency audits, SAST, secrets. Use when setting up Dependabot, CodeQL, or TruffleHog in CI/CD, creating a SECURITY.md policy, or auditing missing security tools.
+description: "Security scanning: dependency audits, SAST, secrets detection. Use when setting up Dependabot, CodeQL, or TruffleHog in CI, or creating a SECURITY.md policy."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--type <dependencies|sast|secrets|all>]"
 argument-hint: "[--check-only] [--fix] [--type <dependencies|sast|secrets|all>]"

--- a/configure-plugin/skills/configure-select/SKILL.md
+++ b/configure-plugin/skills/configure-select/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-22
 modified: 2026-05-09
 reviewed: 2025-12-22
-description: Interactively select which infrastructure standards to configure. Use when setting up selected components, customizing configuration scope, or building infrastructure incrementally rather than running the full `/configure:all` pipeline.
+description: "Interactive selector for infrastructure standards. Use when setting up specific components or building infrastructure incrementally instead of running /configure:all."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, SlashCommand
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"

--- a/configure-plugin/skills/configure-sentry/SKILL.md
+++ b/configure-plugin/skills/configure-sentry/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
-description: Check and configure Sentry error tracking. Use when installing the Sentry SDK, fixing hardcoded DSNs, or adding source map upload and release tracking for frontend, Next.js, Node, or Python.
+description: "Sentry error tracking setup. Use when installing the Sentry SDK, fixing hardcoded DSNs, or adding source map upload for frontend, Next.js, Node, or Python."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--type <frontend|nextjs|python|node>]"
 argument-hint: "[--check-only] [--fix] [--type <frontend|nextjs|python|node>]"

--- a/configure-plugin/skills/configure-skaffold/SKILL.md
+++ b/configure-plugin/skills/configure-skaffold/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-29
-description: Configure Skaffold for Kubernetes projects. Use when fixing port forwarding security (0.0.0.0 binding), adding dotenvx hooks for secret generation, upgrading Skaffold API version, or creating skaffold.yaml from template.
+description: "Skaffold for Kubernetes: port forwarding, dotenvx hooks, API version. Use when fixing 0.0.0.0 binding, adding secret generation hooks, or creating skaffold.yaml."
 allowed-tools: Glob, Grep, Read, Write, Edit, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"

--- a/configure-plugin/skills/configure-status/SKILL.md
+++ b/configure-plugin/skills/configure-status/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
-description: Show infrastructure standards compliance status (read-only). Use when checking overall compliance, generating a compliance report, doing a quick project health check, or reviewing current configuration without making changes.
+description: "Infrastructure compliance status (read-only). Use when checking overall compliance, generating a report, or reviewing project health without making changes."
 allowed-tools: Glob, Grep, Read, TodoWrite
 args: "[--verbose]"
 argument-hint: "[--verbose]"

--- a/configure-plugin/skills/configure-tests/SKILL.md
+++ b/configure-plugin/skills/configure-tests/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
-description: Configure testing frameworks (Vitest, Jest, pytest, cargo-nextest). Use when setting up test infrastructure, migrating to a modern framework, or validating coverage configuration.
+description: "Test frameworks: Vitest, Jest, pytest, cargo-nextest. Use when setting up test infrastructure, migrating to a modern framework, or validating coverage config."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--framework <vitest|jest|pytest|nextest>]"
 argument-hint: "[--check-only] [--fix] [--framework <vitest|jest|pytest|nextest>]"

--- a/configure-plugin/skills/configure-ux-testing/SKILL.md
+++ b/configure-plugin/skills/configure-ux-testing/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
-description: Configure UX testing — Playwright E2E, accessibility (axe-core), visual regression. Use when setting up E2E testing, configuring screenshot assertions, setting up Playwright CLI/MCP for browser automation, or adding E2E/a11y CI workflows.
+description: "UX testing: Playwright E2E, axe-core a11y, visual regression. Use when setting up E2E testing, screenshot assertions, browser automation, or a11y CI workflows."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--a11y] [--visual]"
 argument-hint: "[--check-only] [--fix] [--a11y] [--visual]"

--- a/configure-plugin/skills/configure-web-session/SKILL.md
+++ b/configure-plugin/skills/configure-web-session/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: configure-web-session
-description: Set up a SessionStart hook so Claude Code on the web installs project tools (helm, terraform, gitleaks, just). Use when pre-commit or CI tools fail in remote sessions due to missing binaries.
+description: "SessionStart hook for Claude Code web sessions to install tools (helm, terraform, gitleaks, just). Use when CI tools fail in remote sessions due to missing binaries."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--tools <list>]"
 argument-hint: "[--check-only] [--fix] [--tools <list>]"

--- a/configure-plugin/skills/configure-workflows/SKILL.md
+++ b/configure-plugin/skills/configure-workflows/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-04-29
 reviewed: 2026-04-29
-description: Check and configure GitHub Actions CI/CD workflows for container builds, tests, and releases. Use when updating outdated action versions, adding multi-platform builds, or auditing required workflows.
+description: "GitHub Actions CI/CD workflows for container builds, tests, releases. Use when updating outdated action versions, adding multi-platform builds, or auditing workflows."
 allowed-tools: Glob, Grep, Read, Write, Edit, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"

--- a/configure-plugin/skills/multi-repo-discipline/SKILL.md
+++ b/configure-plugin/skills/multi-repo-discipline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: multi-repo-discipline
-description: Advisory rules for multi-repo workspaces — read-only fixtures, upstream/downstream pairs, authoritative spec owners. Use when dispatching agents that may touch sibling repos or editing another repo's `.claude/`.
+description: "Multi-repo workspace rules: read-only fixtures, upstream/downstream pairs. Use when dispatching agents across sibling repos or editing another repo's .claude/."
 allowed-tools: Bash(git rev-parse *), Bash(git status *), Bash(git branch *), Bash(git remote *), Bash(git log *), Read, Glob, Grep, TodoWrite
 created: 2026-04-24
 modified: 2026-05-09

--- a/configure-plugin/skills/openfeature/SKILL.md
+++ b/configure-plugin/skills/openfeature/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: openfeature
-description: OpenFeature vendor-agnostic feature flag SDK — installation, flag evaluation, providers, hooks. Use when implementing feature flags, A/B testing, canary releases, or progressive rollouts.
+description: "OpenFeature vendor-agnostic feature flag SDK: installation, evaluation, providers. Use when implementing feature flags, A/B testing, or progressive rollouts."
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 ---

--- a/configure-plugin/skills/release-please-standards/SKILL.md
+++ b/configure-plugin/skills/release-please-standards/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: release-please-standards
-description: Release-please standards and configuration. Use when configuring release-please workflows, checking release automation compliance, or working with automated releases and version bumps.
+description: "release-please standards and configuration reference. Use when configuring release workflows, checking automation compliance, or working with version bumps."
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 ---

--- a/configure-plugin/skills/skaffold-standards/SKILL.md
+++ b/configure-plugin/skills/skaffold-standards/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: skaffold-standards
-description: Skaffold standards for local Kubernetes development with OrbStack and dotenvx. Use when configuring Skaffold, setting up local K8s, Kubernetes profiles, or dotenvx secrets.
+description: "Skaffold standards with OrbStack and dotenvx for local K8s. Use when configuring Skaffold, setting up K8s profiles, or managing dotenvx secrets."
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 ---

--- a/container-plugin/skills/container-development/SKILL.md
+++ b/container-plugin/skills/container-development/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: container-development
-description: Container development with Docker, Dockerfiles, 12-factor, multi-stage builds, and Skaffold. Enforces non-root users, minimal Alpine/slim images, and security hardening. Use when mentioning Docker, Dockerfile, docker-compose, or container security.
+description: "Container development — Docker, multi-stage builds, Skaffold, non-root users, Alpine/slim images, security hardening. Use when working with Docker, Dockerfiles, docker-compose, or container security."
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash, Edit, Write, TodoWrite, WebSearch, WebFetch
 ---

--- a/container-plugin/skills/deploy-handoff/SKILL.md
+++ b/container-plugin/skills/deploy-handoff/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Read, Bash(git *), mcp__github__get_pull_request, mcp__github__li
 args: "[resource-name] [deployment-type]"
 argument-hint: "[resource-name] [deployment-type]"
 disable-model-invocation: true
-description: "Generate deployment handoff docs for a deployed service: overview, tech stack, access URLs, configuration, monitoring, and developer checklist. Use when handing off a service, documenting deployment, or generating client-facing summaries."
+description: "Generate deployment handoff docs — tech stack, access URLs, config, monitoring, dev checklist. Use when handing off a service, documenting deployments, or creating client-facing summaries."
 name: deploy-handoff
 ---
 

--- a/container-plugin/skills/deploy-release/SKILL.md
+++ b/container-plugin/skills/deploy-release/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Read, Write, Edit, Bash(git *), Bash(gh release *), Bash(gh pr *)
 args: <version> [--draft] [--prerelease]
 argument-hint: <version> [--draft] [--prerelease]
 disable-model-invocation: true
-description: Create and publish releases via release-please automation or manual GitHub releases. Use when cutting a release, tagging a version, or setting up release-please manifest config.
+description: "Create and publish releases via release-please or manual GitHub releases. Use when cutting a release, tagging a version, or setting up release-please config."
 name: deploy-release
 ---
 

--- a/container-plugin/skills/go-containers/SKILL.md
+++ b/container-plugin/skills/go-containers/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-01-15
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: go-containers
-description: "Go container optimization: static binary compilation, scratch/distroless base images, CGO handling, ldflags, trimpath. Documented journey from 846MB to 2.5MB (99.7% reduction). Use when working with Go containers or optimizing Go image sizes."
+description: "Go container optimization — scratch/distroless images, static binaries, CGO, ldflags, trimpath (846MB to 2.5MB). Use when working with Go containers or optimizing Go image sizes."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write, TodoWrite, WebSearch, WebFetch
 ---

--- a/container-plugin/skills/nodejs-containers/SKILL.md
+++ b/container-plugin/skills/nodejs-containers/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-01-15
 modified: 2026-05-09
 reviewed: 2026-01-15
 name: nodejs-containers
-description: "Node.js container optimization: Alpine variants, multi-stage builds, node_modules caching, prod dep separation, BuildKit cache mounts. Reduces ~900MB to ~50-100MB. Use when working with Node.js containers or optimizing Node image sizes."
+description: "Node.js container optimization — Alpine, multi-stage builds, node_modules caching, BuildKit mounts (900MB to ~100MB). Use when working with Node.js containers or optimizing image sizes."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write, TodoWrite, WebSearch, WebFetch
 ---

--- a/container-plugin/skills/python-containers/SKILL.md
+++ b/container-plugin/skills/python-containers/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-01-15
 modified: 2026-05-09
 reviewed: 2026-01-15
 name: python-containers
-description: "Python container optimization: slim images (NOT Alpine), virtualenv, multi-stage builds with pip/poetry/uv, musl libc gotchas, wheel building. Reduces ~1GB to ~80-120MB. Use when working with Python containers or optimizing image sizes."
+description: "Python container optimization — slim images (not Alpine), virtualenv, multi-stage, pip/poetry/uv, musl gotchas (1GB to ~120MB). Use when working with Python containers or optimizing image sizes."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write, TodoWrite, WebSearch, WebFetch
 ---

--- a/container-plugin/skills/skaffold-filesync/skill.md
+++ b/container-plugin/skills/skaffold-filesync/skill.md
@@ -1,6 +1,6 @@
 ---
 name: skaffold-filesync
-description: Fast iterative development with Skaffold file sync — copy changed files to running containers without rebuilding images. Use when optimizing the dev loop, configuring sync rules, or when the user mentions file sync, hot reload, or fast iteration.
+description: "Skaffold file sync — copy changed files to containers without rebuilding. Use when optimizing the dev loop, configuring sync rules, or the user mentions hot reload or fast iteration."
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2026-01-21

--- a/container-plugin/skills/skaffold-orbstack/SKILL.md
+++ b/container-plugin/skills/skaffold-orbstack/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: skaffold-orbstack
-description: OrbStack-optimized Skaffold workflows for local Kubernetes dev without port-forward. Use when configuring Skaffold with OrbStack, accessing services via LoadBalancer or Ingress, or mentioning OrbStack, k8s.orb.local, or eliminating port-forward.
+description: "OrbStack-optimized Skaffold for local Kubernetes dev without port-forward. Use when configuring Skaffold with OrbStack, k8s.orb.local, LoadBalancer, or eliminating port-forward."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/container-plugin/skills/skaffold-testing/skill.md
+++ b/container-plugin/skills/skaffold-testing/skill.md
@@ -1,6 +1,6 @@
 ---
 name: skaffold-testing
-description: Container image validation with Skaffold test/verify stages. Covers container-structure-tests, custom security scanning, and post-deployment verification. Use when configuring pre-deploy tests, security scans, or integration tests in Skaffold.
+description: "Container image validation with Skaffold test/verify stages — container-structure-tests, security scans. Use when configuring pre-deploy tests or integration tests in Skaffold."
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2025-12-23

--- a/css-plugin/skills/lightning-css/SKILL.md
+++ b/css-plugin/skills/lightning-css/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Lightning CSS
-description: Lightning CSS transpilation, bundling, and minification (Rust-based). Use when configuring CSS in Vite, replacing PostCSS/autoprefixer, setting browser targets, or enabling CSS modules.
+description: Lightning CSS transpilation, bundling, and minification. Use when configuring CSS in Vite, replacing PostCSS/autoprefixer, setting browser targets, or enabling CSS modules.
 user-invocable: false
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob, TodoWrite
 created: 2026-02-13

--- a/css-plugin/skills/lightning-css/SKILL.md
+++ b/css-plugin/skills/lightning-css/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Lightning CSS
-description: CSS transpilation, bundling, and minification with Lightning CSS (Rust-based). Use when configuring CSS in Vite, replacing PostCSS/autoprefixer, setting browser targets, or enabling CSS modules.
+description: Lightning CSS transpilation, bundling, and minification (Rust-based). Use when configuring CSS in Vite, replacing PostCSS/autoprefixer, setting browser targets, or enabling CSS modules.
 user-invocable: false
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob, TodoWrite
 created: 2026-02-13

--- a/css-plugin/skills/unocss/SKILL.md
+++ b/css-plugin/skills/unocss/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: UnoCSS
-description: Atomic CSS engine for on-demand utility class generation with UnoCSS. Use when setting up utility-first CSS, configuring UnoCSS presets (wind3/wind4, icons, typography), or integrating with Vite.
+description: UnoCSS atomic CSS engine for on-demand utility class generation. Use when setting up utility-first CSS, configuring presets (wind3/wind4, icons, typography), or integrating with Vite.
 user-invocable: false
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob, TodoWrite
 created: 2026-02-13

--- a/css-plugin/skills/unocss/SKILL.md
+++ b/css-plugin/skills/unocss/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: UnoCSS
-description: UnoCSS atomic CSS engine for on-demand utility class generation. Use when setting up utility-first CSS, configuring presets (wind3/wind4, icons, typography), or integrating with Vite.
+description: UnoCSS atomic CSS engine for on-demand utility classes. Use when setting up utility-first CSS, configuring presets (wind3/wind4, icons, typography), or integrating with Vite.
 user-invocable: false
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob, TodoWrite
 created: 2026-02-13

--- a/documentation-plugin/skills/claude-blog-sources/SKILL.md
+++ b/documentation-plugin/skills/claude-blog-sources/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-02-27
 reviewed: 2026-02-09
 name: claude-blog-sources
-description: Fetch Claude Blog and official Claude Code docs for latest features and best practices. Use when researching Claude Code capabilities, CLAUDE.md optimization, memory hierarchy, or @import patterns.
+description: Fetch Claude Blog and official Claude Code docs. Use when researching Claude Code capabilities, CLAUDE.md optimization, memory hierarchy, or @import patterns.
 user-invocable: false
 allowed-tools: WebFetch, WebSearch, Task
 agent: general-purpose

--- a/documentation-plugin/skills/docs-decommission/SKILL.md
+++ b/documentation-plugin/skills/docs-decommission/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Read, Write, Edit, Bash(find *), Bash(ls *), Grep, TodoWrite
 args: <service-name>
 argument-hint: <service-name>
 disable-model-invocation: true
-description: Generate service decommission docs covering infrastructure, data, access, DNS, dependencies, monitoring cleanup, and financial checklists. Use when decommissioning a service or wanting a DECOMMISSION-<service>.md created at deploy time.
+description: "Generate DECOMMISSION-<service>.md covering infra, data, access, DNS, dependencies, monitoring, and financial checklists. Use when decommissioning a service."
 name: docs-decommission
 ---
 

--- a/documentation-plugin/skills/docs-generate/SKILL.md
+++ b/documentation-plugin/skills/docs-generate/SKILL.md
@@ -5,7 +5,7 @@ reviewed: 2026-04-25
 allowed-tools: Task, TodoWrite
 args: "[--api] [--readme] [--changelog]"
 argument-hint: "[--api] [--readme] [--changelog]"
-description: Generate or update project docs from code annotations, docstrings, type signatures, and git history. Use when the user wants API reference docs, README from code, a CHANGELOG from conventional commits, or to regenerate docs.
+description: Generate or update docs from code annotations, docstrings, and git history. Use when wanting API reference, README from code, or CHANGELOG from conventional commits.
 name: docs-generate
 agent: general-purpose
 ---

--- a/documentation-plugin/skills/docs-latex/SKILL.md
+++ b/documentation-plugin/skills/docs-latex/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-latex
-description: Convert Markdown documents to professional LaTeX with TikZ visualizations and compile to PDF. Use when the user wants a presentation-quality PDF from Markdown, a professional report with diagrams, or print-ready documentation.
+description: Convert Markdown to LaTeX with TikZ visualizations and compile to PDF. Use when wanting a presentation-quality PDF, a professional report with diagrams, or print-ready documentation.
 args: <file> [--no-compile] [--visualizations] [--report-type=roadmap|lifecycle|general]
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 argument-hint: path/to/document.md

--- a/documentation-plugin/skills/docs-latex/SKILL.md
+++ b/documentation-plugin/skills/docs-latex/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-latex
-description: Convert Markdown to LaTeX with TikZ visualizations and compile to PDF. Use when wanting a presentation-quality PDF, a professional report with diagrams, or print-ready documentation.
+description: Convert Markdown to LaTeX with TikZ and compile to PDF. Use when wanting a presentation-quality PDF, a professional report with diagrams, or print-ready documentation.
 args: <file> [--no-compile] [--visualizations] [--report-type=roadmap|lifecycle|general]
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 argument-hint: path/to/document.md

--- a/documentation-plugin/skills/docs-sync/SKILL.md
+++ b/documentation-plugin/skills/docs-sync/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Sync docs with actual skills, commands, and agents by fixing mismatches and stale entries. Use when docs are out of sync, updating the skill catalog, or regenerating command reference.
+description: Sync docs with actual skills, commands, and agents. Use when docs are out of sync, updating the skill catalog, or regenerating command reference to fix mismatches.
 args: "[--scope <type>] [--dry-run] [--verbose]"
 argument-hint: "--scope skills|commands|agents, --dry-run to preview, --verbose for details"
 allowed-tools: Bash, Grep, Glob, Read, Edit, Write, TodoWrite

--- a/documentation-plugin/skills/docs-sync/SKILL.md
+++ b/documentation-plugin/skills/docs-sync/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Synchronize docs with the actual skills, commands, and agents in the codebase by fixing count mismatches, adding missing entries, and removing stale references. Use when docs are out of sync, updating skill catalog, or regenerating command reference.
+description: Sync docs with actual skills, commands, and agents by fixing mismatches and stale entries. Use when docs are out of sync, updating the skill catalog, or regenerating command reference.
 args: "[--scope <type>] [--dry-run] [--verbose]"
 argument-hint: "--scope skills|commands|agents, --dry-run to preview, --verbose for details"
 allowed-tools: Bash, Grep, Glob, Read, Edit, Write, TodoWrite

--- a/evaluate-plugin/skills/evaluate-improve/SKILL.md
+++ b/evaluate-plugin/skills/evaluate-improve/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: evaluate-improve
-description: Analyze skill evaluation results and suggest concrete improvements to SKILL.md content, descriptions, examples, or tool config. Use when raising pass rates after evaluations, fixing triggering, or iterating on a skill.
+description: Suggest improvements to SKILL.md content, descriptions, or tool config from eval results. Use when raising pass rates, fixing triggering, or iterating on a skill after evaluation.
 args: <plugin/skill-name> [--apply] [--description-only]
 allowed-tools: Task, Read, Write, Edit, Glob, Grep, Bash(cat *), Bash(jq *), Bash(find *), Bash(diff *), AskUserQuestion, TodoWrite
 argument-hint: "git-plugin/git-commit [--apply]"

--- a/evaluate-plugin/skills/evaluate-skill/SKILL.md
+++ b/evaluate-plugin/skills/evaluate-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: evaluate-skill
-description: Evaluate a skill's effectiveness by running test cases and grading results. Use when testing whether a skill produces correct guidance, validating improvements, or benchmarking before release.
+description: Evaluate a skill by running test cases and grading results. Use when testing whether a skill produces correct guidance, validating improvements, or benchmarking before release.
 args: <plugin/skill-name> [--create-evals] [--runs N] [--baseline]
 allowed-tools: Task, Read, Write, Edit, Glob, Grep, Bash(bash *), TodoWrite
 argument-hint: "git-plugin/git-commit [--create-evals] [--runs 3] [--baseline]"

--- a/feedback-plugin/skills/feedback-session/SKILL.md
+++ b/feedback-plugin/skills/feedback-session/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: feedback-session
-description: Analyze current session for skill feedback and create GitHub issues. Use when a skill gave wrong guidance, a command failed due to skill advice, you found a better pattern, or a skill worked well. Supports --target-repo for the plugin source repo.
+description: Analyze session for skill feedback and create GitHub issues. Use when a skill gave wrong guidance, a command failed, you found a better pattern, or a skill worked well.
 args: "[--dry-run] [--bugs-only] [--enhancements-only] [--positive-only] [--target-repo <owner/repo>] [plugin-name]"
 allowed-tools: Bash(gh issue *), Bash(gh label *), Bash(gh search *), Bash(git status *), Bash(git remote *), Read, Grep, Glob, AskUserQuestion, TodoWrite
 model: opus

--- a/finops-plugin/skills/finops-caches/SKILL.md
+++ b/finops-plugin/skills/finops-caches/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Analyze cache usage - size, breakdown by prefix/branch, stale cache detection. Use when investigating GitHub Actions cache bloat, finding stale caches, or auditing cache key strategies.
+description: "GitHub Actions cache analysis — size, prefix/branch breakdown, stale detection. Use when investigating cache bloat, stale caches, or auditing cache key strategies."
 args: "[repo|org:orgname]"
 allowed-tools: Bash(gh api *), Bash(gh repo *), Bash(bash *), Read, TodoWrite
 argument-hint: Repo (owner/name), org:orgname for org-wide, or empty for current repo

--- a/finops-plugin/skills/finops-compare/SKILL.md
+++ b/finops-plugin/skills/finops-compare/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Compare FinOps metrics across multiple repositories in an organization. Use when benchmarking repos against each other, identifying worst-performing repos, or doing org-wide CI cost analysis.
+description: "FinOps metrics comparison across repos in an org. Use when benchmarking repos, identifying worst-performing ones, or doing org-wide CI cost analysis."
 args: "<org> [repo1 repo2 ...] [--limit N]"
 allowed-tools: Bash(gh api *), Bash(gh repo *), Bash(bash *), Read, TodoWrite
 argument-hint: Org name required, optional repo list, --limit for auto-discovery

--- a/finops-plugin/skills/finops-overview/SKILL.md
+++ b/finops-plugin/skills/finops-overview/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Quick FinOps summary - org billing and current repo workflow/cache stats. Use when you want a high-level snapshot of CI spending, cache usage, and workflow health before diving deeper.
+description: "FinOps snapshot — org billing, workflow stats, cache usage. Use when you want a high-level view of CI spending or workflow health before diving deeper."
 args: "[org]"
 allowed-tools: Bash(gh api *), Bash(gh repo *), Bash(gh workflow *), Bash(bash *), Read, TodoWrite
 argument-hint: Optional org name (defaults to current repo's org)

--- a/finops-plugin/skills/finops-waste/SKILL.md
+++ b/finops-plugin/skills/finops-waste/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Identify workflow waste patterns and suggest fixes - skipped runs, bot triggers, missing concurrency. Use when CI costs are high, workflows run too often, or you need to optimize GitHub Actions efficiency.
+description: "Identify GitHub Actions waste — skipped runs, bot triggers, missing concurrency — and suggest fixes. Use when CI costs are high or workflows run too often."
 args: "[repo]"
 allowed-tools: Bash(gh api *), Bash(gh workflow *), Bash(gh repo *), Bash(bash *), Read, Grep, Glob, Edit, TodoWrite
 argument-hint: Optional repo (owner/name format, defaults to current repo)

--- a/finops-plugin/skills/finops-workflows/SKILL.md
+++ b/finops-plugin/skills/finops-workflows/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Analyze workflow runs - frequency, duration, success rates, and efficiency. Use when investigating slow CI, high failure rates, or understanding workflow run patterns over time.
+description: "Analyze workflow runs — frequency, duration, success rates, efficiency. Use when investigating slow CI, high failure rates, or run patterns over time."
 args: "[repo] [--created RANGE]"
 allowed-tools: Bash(gh api *), Bash(gh workflow *), Bash(gh repo *), Bash(bash *), Read, TodoWrite
 argument-hint: Optional repo (owner/name format, defaults to current repo). Use --created for date range. Use org mode for org-wide analysis.

--- a/finops-plugin/skills/github-actions-cache-optimization/skill.md
+++ b/finops-plugin/skills/github-actions-cache-optimization/skill.md
@@ -1,6 +1,6 @@
 ---
 name: github-actions-cache-optimization
-description: Analyze and optimize GitHub Actions cache usage. Use when investigating cache bloat, identifying stale caches, optimizing cache keys, or comparing cache usage across repos.
+description: "GitHub Actions cache analysis and optimization. Use when investigating cache bloat, finding stale caches, optimizing keys, or comparing cache usage across repos."
 user-invocable: false
 allowed-tools: Bash(gh api *), Bash(gh repo *), Bash(gh cache *), Read, Grep, Glob, TodoWrite
 created: 2025-01-30

--- a/finops-plugin/skills/github-actions-finops/skill.md
+++ b/finops-plugin/skills/github-actions-finops/skill.md
@@ -1,6 +1,6 @@
 ---
 name: github-actions-finops
-description: Analyze GitHub Actions billing, workflow efficiency, and waste patterns at org or repo level. Use when investigating CI/CD costs, identifying wasted runs, or optimizing workflow triggers.
+description: "GitHub Actions billing, workflow efficiency, and waste analysis at org or repo level. Use when investigating CI/CD costs, wasted runs, or optimizing triggers."
 user-invocable: false
 allowed-tools: Bash(gh api *), Bash(gh repo *), Bash(gh workflow *), Bash(gh run *), Read, Grep, Glob, TodoWrite
 created: 2025-01-30

--- a/git-plugin/skills/git-api-pr/SKILL.md
+++ b/git-plugin/skills/git-api-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-api-pr
-description: Create PRs via GitHub API without local git operations. Use when you want to submit file changes as a PR without committing locally — for quick fixes, typos, config updates, or when you want a clean workflow that bypasses local git state entirely.
+description: "GitHub API PR creation without local git. Use when submitting file changes as a PR without local commits — quick fixes, typos, config updates, or bypassing local git state."
 args: "<file...> --title <title> [--base <branch>] [--branch <name>] [--body <text>] [--draft] [--delete]"
 allowed-tools: Bash(gh api *), Bash(gh pr *), Bash(gh repo *), Bash(base64 *), Bash(git remote *), Bash(mktemp *), Read, TodoWrite
 argument-hint: '<files...> --title "type(scope): description"'

--- a/git-plugin/skills/git-branch-pr-workflow/SKILL.md
+++ b/git-plugin/skills/git-branch-pr-workflow/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-05-09
 name: git-branch-pr-workflow
-description: Branch management and PR workflows — main-branch dev pattern, git switch/restore, GitHub MCP. Use when creating branches, opening PRs, or working with feature branches. For naming see git-branch-naming, for rebase see git-rebase-patterns.
+description: "Branch management and PR workflows — git switch/restore, GitHub MCP. Use when creating branches, opening PRs, or working with feature branches."
 user-invocable: false
 allowed-tools: Bash, Read, mcp__github__create_pull_request, mcp__github__list_pull_requests, mcp__github__update_pull_request
 ---

--- a/git-plugin/skills/git-commit-push-pr/SKILL.md
+++ b/git-plugin/skills/git-commit-push-pr/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git a
 args: "[remote-branch] [--push] [--direct] [--pr] [--draft] [--issue <num>] [--no-commit] [--range <start>..<end>] [--skip-issue-detection]"
 argument-hint: "[remote-branch] [--push] [--direct] [--pr] [--draft] [--issue <num>] [--no-commit] [--range <start>..<end>] [--skip-issue-detection]"
 disable-model-invocation: true
-description: End-to-end workflow from uncommitted changes to open PR — detects issues, creates logical commits, pushes, and opens the PR. Use when the user says "create pr", "commit and pr", or "push and pr".
+description: "End-to-end commit-to-PR workflow. Use when the user says \"create pr\", \"commit and pr\", \"push and pr\", or wants to go from uncommitted changes to an open PR."
 ---
 
 ## When to Use This Skill

--- a/git-plugin/skills/git-commit-trailers/SKILL.md
+++ b/git-plugin/skills/git-commit-trailers/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-03-05
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: git-commit-trailers
-description: Git commit trailer conventions — BREAKING CHANGE, Release-As, Co-authored-by, Signed-off-by. Use when composing commit messages with trailers or parsing them via git interpret-trailers.
+description: "Git commit trailer conventions — BREAKING CHANGE, Co-authored-by, Signed-off-by. Use when composing messages with trailers or parsing via git interpret-trailers."
 user-invocable: false
 allowed-tools: Bash(git interpret-trailers *), Bash(git log *), Bash(git config *), Read, Grep, Glob
 ---

--- a/git-plugin/skills/git-commit-workflow/SKILL.md
+++ b/git-plugin/skills/git-commit-workflow/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: git-commit-workflow
-description: Commit message conventions, staging practices, and conventional commit format. Use when writing commit messages, staging files, grouping logical changes, or auto-detecting linked issues.
+description: "Conventional commit format, staging, and message conventions. Use when writing commit messages, staging files, grouping changes, or auto-detecting linked issues."
 user-invocable: false
 allowed-tools: Bash, Read
 ---

--- a/git-plugin/skills/git-conflicts/SKILL.md
+++ b/git-plugin/skills/git-conflicts/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: git-conflicts
-description: |
-  Resolve merge conflicts. Use when a merge or rebase has conflicts, a PR
-  can't merge, "fix conflicts" appears, or you need to reconcile diverged
-  branches. Handles file-by-file resolution with modern git tooling.
+description: "Resolve merge conflicts file-by-file. Use when a merge/rebase has conflicts, a PR can't merge, \"fix conflicts\" is requested, or branches have diverged."
 allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git show *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git merge *), Bash(git checkout *), Bash(git rebase *), Bash(git restore *), Bash(git config *), Bash(git rerere *), Bash(gh pr *), Read, Edit, Grep, Glob, TodoWrite
 args: "[file-or-pr] [--ours] [--theirs] [--push]"
 argument-hint: file path, PR number, --ours, --theirs, or --push

--- a/git-plugin/skills/git-coworker-check/SKILL.md
+++ b/git-plugin/skills/git-coworker-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-coworker-check
-description: Detect another Claude agent working in the same repo clone before destructive git ops (stash, reset, checkout --). Use when starting a session in a non-worktree checkout or before any working-tree cleanup that could wipe a coworker's changes.
+description: "Detect coworker Claude agents before destructive git ops (stash, reset, checkout). Use when starting a session in a shared checkout or before working-tree cleanup."
 args: "[--check | --claim | --release]"
 argument-hint: "[--claim | --release | --check (default)]"
 allowed-tools: Bash(bash *), Bash(git status *), Bash(git stash *), Bash(git rev-parse *), Read, TodoWrite

--- a/git-plugin/skills/git-derive-docs/SKILL.md
+++ b/git-plugin/skills/git-derive-docs/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(git log *), Bash(git shortlog *), Bash(git diff *), Bash(git
 args: "[--rules] [--prd] [--adr] [--prp] [--all] [--since=<date>] [--depth=<N>]"
 argument-hint: "[--rules] [--prd] [--adr] [--prp] [--all] [--since=<date>] [--depth=<N>]"
 disable-model-invocation: true
-description: Derive undocumented rules, PRDs, ADRs, and PRPs from git commit history. Use when finding doc gaps, detecting unrecorded architectural decisions, deriving conventions from commit patterns, or generating skeleton docs.
+description: "Derive ADRs, rules, PRDs from git commit history. Use when finding doc gaps, detecting unrecorded decisions, deriving conventions from commits, or generating skeleton docs."
 name: git-derive-docs
 ---
 

--- a/git-plugin/skills/git-fix-pr/SKILL.md
+++ b/git-plugin/skills/git-fix-pr/SKILL.md
@@ -6,11 +6,7 @@ allowed-tools: Bash(gh pr checks *), Bash(gh pr view *), Bash(gh run view *), Ba
 args: "[pr-number] [--auto-fix] [--push]"
 argument-hint: "[pr-number] [--auto-fix] [--push]"
 disable-model-invocation: true
-description: |
-  Analyze and fix failing PR checks. Use when the user asks to fix the PR,
-  resolve failing CI checks, diagnose red GitHub Actions runs, auto-fix
-  lint/type/test failures on a pull request, or reproduce CI errors locally
-  before pushing corrections.
+description: "Analyze and fix failing PR checks. Use when asked to fix a PR, resolve red CI checks, auto-fix lint/test failures, or reproduce CI errors locally before pushing."
 name: git-fix-pr
 ---
 

--- a/git-plugin/skills/git-fork-workflow/SKILL.md
+++ b/git-plugin/skills/git-fork-workflow/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-03-02
 modified: 2026-05-09
 reviewed: 2026-03-02
 name: git-fork-workflow
-description: Fork management and upstream synchronization. Use when working with forks, syncing with upstream, detecting divergence, or preparing commits for upstream contribution. For creating upstream PRs, see git-upstream-pr.
+description: "Fork management and upstream sync. Use when working with forks, syncing with upstream, detecting divergence, or preparing commits for contribution."
 allowed-tools: Bash(git remote *), Bash(git fetch *), Bash(git log *), Bash(git status *), Bash(git diff *), Bash(git rev-list *), Bash(gh repo *), Read, Grep, Glob
 ---
 

--- a/git-plugin/skills/git-issue-hierarchy/SKILL.md
+++ b/git-plugin/skills/git-issue-hierarchy/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-03-19
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: git-issue-hierarchy
-description: Manage sub-issues and GitHub dependency relationships (blocked_by/blocking). Use when breaking issues into sub-tasks, checking sub-issue progress, marking one issue blocked by another, or viewing a dependency graph before starting work.
+description: "Manage GitHub sub-issues and dependencies (blocked_by/blocking). Use when breaking issues into sub-tasks, checking progress, or viewing a dependency graph."
 args: "<parent-issue> [--add <N...>] [--remove <N...>] [--create \"title\"] [--status] [--deps] [--blocking] [--block <N>] [--blocked-by <N>] [--unblock <N>]"
 argument-hint: <parent-issue> [--add N] [--status] [--deps] [--blocked-by N]
 user-invocable: true

--- a/git-plugin/skills/git-issue-manage/SKILL.md
+++ b/git-plugin/skills/git-issue-manage/SKILL.md
@@ -3,11 +3,7 @@ created: 2026-03-19
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: git-issue-manage
-description: |
-  Administrative operations on GitHub issues. Use when transferring issues
-  between repos, pinning important issues, locking resolved discussions,
-  creating development branches from issues, performing bulk operations,
-  or managing custom issue fields.
+description: "GitHub issue admin operations. Use when transferring issues, pinning, locking discussions, creating dev branches from issues, bulk ops, or managing custom fields."
 args: "<operation> <issue-numbers...> [options]"
 argument-hint: <transfer|pin|lock|develop|bulk|fields> <issue-numbers...>
 user-invocable: true

--- a/git-plugin/skills/git-issue/SKILL.md
+++ b/git-plugin/skills/git-issue/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-21
 allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git switch *), Bash(git pull *), Bash(git stash *), Bash(gh issue *), Bash(gh pr *), Bash(gh repo *), Bash(gh label *), Bash(gh api *), Bash(pre-commit *), Read, Edit, Write, Grep, Glob, TodoWrite, AskUserQuestion, Task, mcp__github__create_pull_request, mcp__github__issue_read, mcp__github__list_issues
-description: Process GitHub issues end-to-end with TDD, interactive selection, conflict detection, and parallel work. Use when user asks to work on an issue, fix issue #N, pick issues to tackle, or batch-process several in parallel.
+description: "Process GitHub issues end-to-end with TDD and parallel work. Use when asked to work on an issue, fix issue #N, pick issues to tackle, or batch-process several."
 args: "[issue-numbers...] [--auto] [--filter <label>] [--limit <n>] [--parallel]"
 argument-hint: "[issue-numbers...] [--auto] [--filter <label>] [--limit <n>] [--parallel]"
 disable-model-invocation: true

--- a/git-plugin/skills/git-maintain/SKILL.md
+++ b/git-plugin/skills/git-maintain/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash(git status *), Bash(git branch *), Bash(git stash *), Bash(g
 args: "[--prune] [--gc] [--verify] [--branches] [--stash] [--all]"
 argument-hint: "[--prune] [--gc] [--verify] [--branches] [--stash] [--all]"
 disable-model-invocation: true
-description: Repository maintenance and cleanup — gc, branch pruning, stash cleanup, integrity verification. Use when user asks to clean up the repo, run git gc, delete merged branches, prune stashes, run git fsck, or shrink .git.
+description: "Repo maintenance — gc, branch pruning, stash cleanup, fsck. Use when asked to clean up the repo, run git gc, delete merged branches, prune stashes, or shrink .git."
 name: git-maintain
 ---
 

--- a/git-plugin/skills/git-pr-feedback/SKILL.md
+++ b/git-plugin/skills/git-pr-feedback/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash(gh pr checks *), Bash(gh pr view *), Bash(gh pr diff *), Bas
 args: "[pr-number] [--commit] [--push] [--all] [--dry-run] [--limit N]"
 argument-hint: "[pr-number | --all] [--commit] [--push] [--dry-run] [--limit N]"
 disable-model-invocation: true
-description: Address PR review comments, apply reviewer suggestions, and resolve threads. Use when CHANGES_REQUESTED is set, when working through unresolved review threads, or when replying to reviewer feedback.
+description: "Address PR review comments and resolve threads. Use when CHANGES_REQUESTED is set, working through unresolved review threads, or replying to reviewer feedback."
 name: git-pr-feedback
 agent: general-purpose
 ---

--- a/git-plugin/skills/git-rebase-patterns/SKILL.md
+++ b/git-plugin/skills/git-rebase-patterns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-rebase-patterns
-description: Advanced git rebase patterns for linear history, stacked PRs, and commit management. Use when rebasing branches, cleaning history, managing PR stacks, or converting merge-heavy branches. Covers --reapply-cherry-picks, --update-refs, --onto.
+description: "Advanced git rebase — linear history, stacked PRs, --update-refs, --onto. Use when rebasing branches, cleaning history, managing PR stacks, or fixing merge-heavy branches."
 user-invocable: false
 allowed-tools: Bash, Read
 created: 2026-01-30

--- a/git-plugin/skills/git-repo-detection/SKILL.md
+++ b/git-plugin/skills/git-repo-detection/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: git-repo-detection
-description: Detect GitHub repository name and owner from git remotes. Use when needing repo identifier for GitHub CLI, API calls, or when working with multiple repositories. Automatically extracts owner/repo format.
+description: "Detect GitHub repo owner/name from git remotes. Use when needing the owner/repo identifier for GitHub CLI or API calls, especially across multiple repos."
 user-invocable: false
 allowed-tools: Bash, Read, Grep
 ---

--- a/git-plugin/skills/git-resolve-conflicts/SKILL.md
+++ b/git-plugin/skills/git-resolve-conflicts/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: git-resolve-conflicts
-description: |
-  Resolve merge conflicts in pull requests. Use when a PR has merge conflicts
-  with its base branch, when rebasing produces conflicts, or when automated
-  merges fail due to conflicting changes.
+description: "Resolve PR merge conflicts. Use when a PR has conflicts with its base branch, rebasing produces conflicts, or automated merges fail."
 allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git show *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git merge *), Bash(git checkout *), Bash(git rebase *), Bash(gh pr *), Read, Edit, Grep, Glob, TodoWrite
 args: "[pr-number] [--push]"
 argument-hint: PR number to resolve conflicts for

--- a/git-plugin/skills/git-security-checks/SKILL.md
+++ b/git-plugin/skills/git-security-checks/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: git-security-checks
-description: Pre-commit security validation and secret detection via gitleaks. Use when user mentions scanning for secrets, gitleaks, secret/credential detection, pre-commit security, or .gitleaks.toml.
+description: "Pre-commit security validation and secret detection via gitleaks. Use when scanning for secrets, setting up gitleaks, or configuring .gitleaks.toml pre-commit security."
 user-invocable: false
 allowed-tools: Bash, Read
 ---

--- a/git-plugin/skills/git-triage/SKILL.md
+++ b/git-plugin/skills/git-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-triage
-description: Triage open GitHub issues and PRs in one sweep — cross-link, flag stale items, recommend actions. Use when grooming the backlog, doing pre-release cleanup, or when the user asks to "triage issues/PRs".
+description: "Triage GitHub issues and PRs — cross-link, flag stale items, recommend actions. Use when grooming the backlog, pre-release cleanup, or asked to triage issues/PRs."
 args: "[--type issues|prs|both] [--batch N] [--repo owner/name] [--days-stale-issue N] [--days-stale-pr N] [--auto-close] [--auto-merge] [--oldest-first]"
 argument-hint: "--type both --batch 10 (defaults: days-stale-issue=90, days-stale-pr=30, current repo)"
 allowed-tools: Bash(gh issue *), Bash(gh pr *), Bash(gh api *), Bash(gh repo *), Bash(git log *), Bash(rg *), Read, Grep, Glob, AskUserQuestion, TodoWrite

--- a/git-plugin/skills/git-upstream-pr/SKILL.md
+++ b/git-plugin/skills/git-upstream-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-upstream-pr
-description: Submit clean PRs to upstream repos from a fork — branch from upstream/main, commit selection, squashing, cross-fork PR creation. Use when contributing changes back upstream, cherry-picking fork commits, or creating cross-fork pull requests.
+description: "Submit PRs to upstream repos from a fork — commit selection, squashing, cross-fork creation. Use when contributing changes upstream or cherry-picking fork commits."
 args: "[--commits sha1,sha2] [--branch name] [--upstream owner/repo] [--draft] [--dry-run]"
 allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git remote *), Bash(git fetch *), Bash(git switch *), Bash(git cherry-pick *), Bash(git reset *), Bash(git commit *), Bash(git push *), Bash(git stash *), Bash(git rev-list *), Bash(git rev-parse *), Bash(git branch *), Bash(gh pr *), Bash(gh repo *), Bash(gh auth *), AskUserQuestion, Read, Grep, Glob, TodoWrite
 argument-hint: --commits abc123,def456 or --branch feat/my-upstream-pr

--- a/git-plugin/skills/github-labels/SKILL.md
+++ b/git-plugin/skills/github-labels/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-01
 name: github-labels
-description: Discover and apply labels to GitHub PRs and issues via gh CLI. Use when user says "label this PR", "add labels to issue", "what labels are available", or "create a new label".
+description: "Discover and apply GitHub labels via gh CLI. Use when asked to label a PR/issue, list available labels, or create new labels for a repository."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/git-plugin/skills/release-please-configuration/SKILL.md
+++ b/git-plugin/skills/release-please-configuration/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-28
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: release-please-configuration
-description: Configure release-please for monorepos and single-package repos — manifests, component tagging, changelog sections, extra-files. Use when setting up automated releases, fixing release workflow issues, or configuring version bump automation.
+description: "Configure release-please — manifests, component tagging, changelog sections. Use when setting up automated releases, fixing release workflow issues, or configuring version bumps."
 user-invocable: false
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, TodoWrite
 ---

--- a/git-plugin/skills/release-please-protection/SKILL.md
+++ b/git-plugin/skills/release-please-protection/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: release-please-protection
-description: Prevent manual edits to release-please managed files (CHANGELOG.md, version fields in package.json/pyproject.toml/Cargo.toml). Use when editing changelogs, bumping versions, or releasing.
+description: "Block manual edits to release-please files (CHANGELOG, version fields). Use when editing changelogs, bumping versions, or releasing to avoid conflicting with automation."
 user-invocable: false
 allowed-tools: Read, Grep, Glob
 ---

--- a/github-actions-plugin/skills/ci-autofix-reusable/SKILL.md
+++ b/github-actions-plugin/skills/ci-autofix-reusable/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ci-autofix-reusable
-description: Generate a reusable GitHub Actions workflow for automated CI failure detection and fixing with Claude Code. Use when you want a workflow_call entry that multiple repos can invoke.
+description: "Generate a reusable GitHub Actions workflow for automated CI fixing with Claude Code. Use when creating a workflow_call entry multiple repos can invoke."
 allowed-tools: Bash(gh run *), Bash(gh pr *), Bash(gh issue *), Bash(git status *), Bash(git diff *), Bash(git log *), Read, Write, Edit, Grep, Glob, TodoWrite
 args: "[--setup] [--caller] [--workflows <names>] [--dry-run]"
 argument-hint: --setup to create reusable workflow, --caller to create caller workflow

--- a/github-actions-plugin/skills/claude-code-github-workflows/skill.md
+++ b/github-actions-plugin/skills/claude-code-github-workflows/skill.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-04-29
 reviewed: 2026-04-29
 name: claude-code-github-workflows
-description: Claude Code workflow design and automation patterns for PR reviews, issue triage, and CI/CD integration. Use when creating or modifying GitHub Actions workflows that integrate Claude Code.
+description: "Claude Code GitHub Actions workflow patterns — PR reviews, issue triage, CI/CD integration. Use when creating or modifying workflows that integrate Claude Code."
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, WebFetch, mcp__github
 ---

--- a/github-actions-plugin/skills/github-actions-auth-security/skill.md
+++ b/github-actions-plugin/skills/github-actions-auth-security/skill.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: github-actions-auth-security
-description: Configure GitHub Actions auth and security for Claude Code — API keys, OIDC, AWS Bedrock, Vertex AI, secrets, and permission scoping. Use when setting up workflow authentication or security.
+description: "GitHub Actions auth and security for Claude Code — OIDC, AWS Bedrock, Vertex AI, secrets, permission scoping. Use when setting up workflow authentication or security."
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, WebFetch
 ---

--- a/github-actions-plugin/skills/github-actions-inspection/skill.md
+++ b/github-actions-plugin/skills/github-actions-inspection/skill.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: github-actions-inspection
-description: Inspect GitHub Actions workflow runs, check status, analyze logs, debug failures, and identify root causes. Use when investigating CI/CD failures, checking workflow status, or debugging GitHub Actions issues.
+description: "Inspect GitHub Actions runs, analyze logs, debug failures. Use when investigating CI/CD failures, checking workflow status, or debugging GitHub Actions issues."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob, mcp__github
 ---

--- a/github-actions-plugin/skills/github-actions-mcp-config/skill.md
+++ b/github-actions-plugin/skills/github-actions-mcp-config/skill.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: github-actions-mcp-config
-description: MCP server configuration for GitHub Actions including tool permissions, environment variables, and multi-server setups. Use when configuring MCP servers in GitHub Actions workflows.
+description: "MCP server config for GitHub Actions — tool permissions, env vars, multi-server setups. Use when configuring MCP servers in GitHub Actions workflows."
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, WebFetch
 ---

--- a/github-actions-plugin/skills/github-issue-search/skill.md
+++ b/github-actions-plugin/skills/github-issue-search/skill.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: github-issue-search
-description: Search GitHub issues for solutions, workarounds, and discussions for open source problems. Use when encountering errors with OSS libraries or finding upstream bug workarounds.
+description: "Search GitHub issues for solutions and workarounds. Use when encountering errors with OSS libraries, finding upstream bug workarounds, or researching known issues."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/github-actions-plugin/skills/github-social-preview/skill.md
+++ b/github-actions-plugin/skills/github-social-preview/skill.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-02-06
 reviewed: 2025-12-16
 name: github-social-preview
-description: Generate 1280x640 PNG social preview images for GitHub repositories using nano-banana-pro. Use when user mentions social preview, Open Graph image, or needs repository images for social media sharing.
+description: "Generate 1280x640 PNG social preview images for GitHub repos using nano-banana-pro. Use when asked for social preview, Open Graph image, or repo images for social media."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/github-actions-plugin/skills/github-workflow-auto-fix/SKILL.md
+++ b/github-actions-plugin/skills/github-workflow-auto-fix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-workflow-auto-fix
-description: Set up automated CI failure detection and fixing with Claude Code. Use when you want a GitHub Actions workflow that analyzes failures, applies common fixes, and opens issues for the rest.
+description: "Set up automated CI fixing with Claude Code. Use when adding a GitHub Actions workflow that analyzes failures, applies common fixes, and files issues for the rest."
 allowed-tools: Bash(gh run *), Bash(gh pr *), Bash(gh issue *), Bash(git status *), Bash(git diff *), Bash(git log *), Read, Write, Edit, Grep, Glob, TodoWrite
 args: "[--setup] [--workflows <names>] [--dry-run]"
 argument-hint: --setup to create workflow, or --dry-run to preview

--- a/github-actions-plugin/skills/workflow-dev/SKILL.md
+++ b/github-actions-plugin/skills/workflow-dev/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Read, Write, Edit, MultiEdit, Bash(git *), Bash(pytest *), Bash(n
 args: "[--max-cycles <n>] [--focus <bug|feature|test>]"
 argument-hint: "[--max-cycles <n>] [--focus <bug|feature|test>]"
 disable-model-invocation: true
-description: "Automated dev loop: runs tests, files GitHub issues for failures, picks an issue, implements a TDD fix on a branch, opens a PR, and watches CI until green. Use when running a continuous dev loop through open issues, autonomous TDD, or fix-and-PR cycles."
+description: "Automated dev loop — run tests, file issues for failures, TDD fix on branch, open PR, watch CI. Use when running a continuous dev loop, autonomous TDD, or fix-and-PR cycles."
 name: workflow-dev
 ---
 

--- a/health-plugin/skills/health-agentic-audit/SKILL.md
+++ b/health-plugin/skills/health-agentic-audit/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-02-05
 modified: 2026-04-19
 reviewed: 2026-04-15
 user-invocable: false
-description: Audit plugin skills, commands, and agents for agentic output compliance — missing optimization tables, bare CLI commands, stale review dates. Use when batch-checking skill documentation quality.
+description: "Audit skills, commands, and agents for agentic output compliance — optimization tables, bare CLI commands. Use when batch-checking skill documentation quality."
 allowed-tools: Bash(find *), Bash(head *), Read, Grep, Glob, TodoWrite
 args: "[--fix] [--verbose]"
 argument-hint: "[--fix] [--verbose]"

--- a/health-plugin/skills/health-audit/SKILL.md
+++ b/health-plugin/skills/health-audit/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-02-05
 modified: 2026-05-09
 reviewed: 2026-04-15
 user-invocable: false
-description: Audit enabled plugins against the detected stack (Python, Node, Rust, Go, Terraform, Docker, Kubernetes) and recommend additions or removals. Use when cleaning up unused plugins, discovering stack-relevant ones, or onboarding a project.
+description: "Plugin audit against detected stack (Python, Node, Rust, Go, Terraform, Docker, K8s). Use when cleaning up unused plugins or discovering stack-relevant ones for a project."
 allowed-tools: Bash(test *), Bash(find *), Bash(jq *), Bash(claude plugin *), Read, Write, Edit, Glob, Grep, TodoWrite, AskUserQuestion
 args: "[--fix] [--dry-run] [--verbose]"
 argument-hint: "[--fix] [--dry-run] [--verbose]"

--- a/health-plugin/skills/health-check/SKILL.md
+++ b/health-plugin/skills/health-check/SKILL.md
@@ -2,7 +2,7 @@
 created: 2026-02-04
 modified: 2026-05-09
 reviewed: 2026-04-16
-description: One-stop diagnostic scan of Claude Code configuration — plugins, settings, hooks, MCP, SessionStart, permissions, marketplace — with optional fixes across registry/stack/agentic scopes. Use when troubleshooting Claude Code setup or before starting work.
+description: "Claude Code health check — scans plugins, settings, hooks, MCP, permissions, marketplace with optional fixes. Use when checking project health or troubleshooting setup."
 allowed-tools: Bash(bash *), Bash(pre-commit *), Read, Glob, Grep, TodoWrite, AskUserQuestion
 args: "[--scope=all|registry|stack|agentic] [--fix] [--dry-run] [--verbose]"
 argument-hint: "[--scope=all|registry|stack|agentic] [--fix] [--dry-run] [--verbose]"

--- a/health-plugin/skills/health-plugins/SKILL.md
+++ b/health-plugin/skills/health-plugins/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-02-04
 modified: 2026-05-09
 reviewed: 2026-04-15
 user-invocable: false
-description: 'Diagnose and fix Claude Code plugin registry corruption — orphaned entries, stale enabledPlugins keys, cross-project scope conflicts (issue #14202). Use when seeing "plugin already installed" errors or registry-vs-settings drift.'
+description: "Diagnose and fix Claude Code plugin registry corruption — orphaned entries, stale keys, scope conflicts. Use when seeing plugin-already-installed errors or registry drift."
 allowed-tools: Bash(bash *), Read, Write, Edit, Glob, Grep, TodoWrite, AskUserQuestion
 args: "[--fix] [--dry-run] [--plugin <name>]"
 argument-hint: "[--fix] [--dry-run] [--plugin <name>]"

--- a/health-plugin/skills/health-skill-audit/SKILL.md
+++ b/health-plugin/skills/health-skill-audit/SKILL.md
@@ -2,7 +2,7 @@
 created: 2026-04-24
 modified: 2026-05-09
 reviewed: 2026-04-24
-description: Audit the plugin skill tree for skill-to-skill overlap, split-pressure inside one SKILL.md, and small siblings worth consolidating. Use when finding confusing clusters (configure-*-test*, test-*, *-development) or surfacing REFERENCE.md candidates.
+description: "Audit skill tree for overlap, split-pressure, and consolidation candidates. Use when finding confusing skill clusters or surfacing REFERENCE.md extraction candidates."
 allowed-tools: Bash(python3 *), Read, TodoWrite
 args: "[--plugin <name>] [--strict]"
 argument-hint: "[--plugin <name>] [--strict]"

--- a/health-plugin/skills/plugin-registry/SKILL.md
+++ b/health-plugin/skills/plugin-registry/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: plugin-registry
-description: |
-  Understanding Claude Code's plugin registry structure, installation scopes,
-  and common issues. Use when troubleshooting plugin installation problems,
-  understanding why plugins show as installed incorrectly, or manually fixing
-  registry entries.
+description: "Claude Code plugin registry structure, installation scopes, and common issues. Use when troubleshooting plugin installation problems or manually fixing registry entries."
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, TodoWrite
 created: 2026-02-04

--- a/health-plugin/skills/settings-configuration/SKILL.md
+++ b/health-plugin/skills/settings-configuration/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: settings-configuration
-description: |
-  Claude Code settings file hierarchy, permission wildcards, and configuration
-  patterns. Use when setting up project permissions, debugging settings issues,
-  or understanding why certain tools are allowed or blocked.
+description: "Claude Code settings hierarchy, permission wildcards, and configuration patterns. Use when setting up permissions, debugging settings issues, or understanding allowed tools."
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, TodoWrite
 created: 2026-02-04

--- a/home-assistant-plugin/skills/ha-automations/SKILL.md
+++ b/home-assistant-plugin/skills/ha-automations/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-02-01
 modified: 2026-02-14
 reviewed: 2026-02-08
 name: ha-automations
-description: Home Assistant automation creation and management. Use when creating automation rules, working with triggers, conditions, actions, scripts, scenes, or blueprints.
+description: Home Assistant automation creation and management. Use when working with HA triggers, conditions, actions, scripts, scenes, or blueprints.
 user-invocable: false
 allowed-tools: Read, Edit, Write, Grep, Glob, TodoWrite
 ---

--- a/home-assistant-plugin/skills/ha-configuration/SKILL.md
+++ b/home-assistant-plugin/skills/ha-configuration/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-02-01
 modified: 2026-05-09
 reviewed: 2025-02-01
 name: ha-configuration
-description: Home Assistant YAML configuration management. Use when editing configuration.yaml, setting up integrations, configuring secrets, managing packages, or troubleshooting HA configuration. Covers core configuration patterns and best practices.
+description: Home Assistant YAML configuration management. Use when editing configuration.yaml, setting up integrations, configuring secrets, or troubleshooting HA configuration.
 user-invocable: false
 allowed-tools: Read, Edit, Write, Grep, Glob, TodoWrite
 ---

--- a/home-assistant-plugin/skills/ha-entities/SKILL.md
+++ b/home-assistant-plugin/skills/ha-entities/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-02-01
 modified: 2026-02-14
 reviewed: 2025-02-01
 name: ha-entities
-description: Home Assistant entity and domain management. Use when working with entity IDs, device classes, customizations, template entities, groups, or domain-specific attributes.
+description: Home Assistant entity and domain management. Use when working with entity IDs, device classes, template entities, groups, or domain-specific attribute customizations.
 user-invocable: false
 allowed-tools: Read, Edit, Write, Grep, Glob, TodoWrite
 ---

--- a/home-assistant-plugin/skills/ha-validate/SKILL.md
+++ b/home-assistant-plugin/skills/ha-validate/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Validate Home Assistant YAML for syntax errors, undefined secret references, and duplicate keys, with optional Docker/HA OS full-config checks. Use when validating HA config, diagnosing YAML errors, or running hass --script check_config.
+description: Validate Home Assistant YAML for syntax errors, undefined secrets, and duplicate keys. Use when validating HA config, diagnosing YAML errors, or running hass check_config.
 args: "[path]"
 allowed-tools: Bash(python3 *), Bash(docker exec *), Bash(ha *), Read, Grep, Glob
 argument-hint: "Optional path to config directory (defaults to current directory)"

--- a/hooks-plugin/skills/hooks-configuration/SKILL.md
+++ b/hooks-plugin/skills/hooks-configuration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hooks-configuration
-description: Claude Code hooks configuration and development. Covers lifecycle events, configuration patterns, and input/output schemas. Use when the user mentions hooks, PreToolUse, PostToolUse, SessionStart, SubagentStart, PermissionRequest, or TaskCompleted.
+description: Claude Code hooks configuration and development. Use when the user mentions hooks, PreToolUse, PostToolUse, SessionStart, SubagentStart, PermissionRequest, or TaskCompleted.
 user-invocable: false
 allowed-tools: Bash(bash *), Bash(cat *), Read, Write, Edit, Glob, Grep, TodoWrite
 created: 2025-12-16

--- a/hooks-plugin/skills/hooks-permission-request-hook/SKILL.md
+++ b/hooks-plugin/skills/hooks-permission-request-hook/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hooks-permission-request-hook
-description: Generate a PermissionRequest hook that auto-approves safe operations and auto-denies dangerous ones. Use when you need a safer alternative to --dangerouslySkipPermissions tailored to your project stack.
+description: Generate a PermissionRequest hook with auto-approve/deny rules. Use when needing a safer alternative to --dangerouslySkipPermissions tailored to your project stack.
 args: "[--strict] [--category <name>...]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, TodoWrite
 argument-hint: "--strict to deny unknown commands, --category git|test|lint|build|gh|deny"

--- a/hooks-plugin/skills/hooks-session-end-issue-hook/SKILL.md
+++ b/hooks-plugin/skills/hooks-session-end-issue-hook/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hooks-session-end-issue-hook
-description: Configure a Stop hook that surfaces unfinished todos at session end and suggests creating GitHub issues. Use when you want deferred work automatically flagged for issue creation.
+description: Configure a Stop hook that surfaces unfinished todos at session end. Use when you want deferred work automatically flagged for GitHub issue creation.
 args: "[--no-verify]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, TodoWrite
 argument-hint: "--no-verify to skip gh auth verification"

--- a/hooks-plugin/skills/hooks-session-start-hook/SKILL.md
+++ b/hooks-plugin/skills/hooks-session-start-hook/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hooks-session-start-hook
-description: Create a SessionStart hook for Claude Code on the web. Use when setting up a repo for remote sessions so dependencies install and tests/linters run automatically on session start. Detects project type, package manager, test runner, and linter.
+description: Create a SessionStart hook for Claude Code on the web. Use when setting up a repo so dependencies install and tests/linters run automatically on remote session start.
 args: "[--remote-only] [--no-verify]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, TodoWrite
 argument-hint: "--remote-only to only run in web sessions, --no-verify to skip test verification"

--- a/kubernetes-plugin/skills/argocd-login/SKILL.md
+++ b/kubernetes-plugin/skills/argocd-login/SKILL.md
@@ -3,10 +3,7 @@ created: 2025-12-16
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: argocd-login
-description: |
-  ArgoCD CLI authentication with SSO. Provides argocd login command, gRPC-Web
-  configuration, and post-login operations. Use when user mentions ArgoCD login,
-  argocd authentication, SSO auth, or accessing ArgoCD applications and clusters.
+description: "ArgoCD CLI auth with SSO and gRPC-Web. Use when the user mentions ArgoCD login, argocd authentication, SSO auth, or accessing ArgoCD applications and clusters."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/kubernetes-plugin/skills/helm-chart-development/SKILL.md
+++ b/kubernetes-plugin/skills/helm-chart-development/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: helm-chart-development
-description: Create, test, and package Helm charts. Covers helm create, Chart.yaml, values.yaml, template development, dependencies, packaging, and repository publishing. Use when the user mentions Helm charts, helm lint/template/package, or Kubernetes packaging.
+description: "Create, test, and package Helm charts — Chart.yaml, templates, dependencies, repo publishing. Use when the user mentions Helm charts, helm lint/template/package, or Kubernetes packaging."
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 ---

--- a/kubernetes-plugin/skills/helm-debugging/SKILL.md
+++ b/kubernetes-plugin/skills/helm-debugging/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: helm-debugging
-description: Debug Helm deployment failures, template errors, and configuration issues. Covers helm template, helm lint, dry-run, YAML parse errors, value type errors, and resource conflicts. Use when the user mentions Helm errors or template rendering issues.
+description: "Debug Helm failures — template errors, dry-run, YAML parse errors, value type errors, resource conflicts. Use when the user mentions Helm errors or template rendering issues."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/kubernetes-plugin/skills/helm-release-management/SKILL.md
+++ b/kubernetes-plugin/skills/helm-release-management/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: helm-release-management
-description: "Manage Helm releases: install, upgrade, uninstall, list, and inspect. Covers helm install/upgrade/list/status and release history. Use when the user mentions deploying Helm charts, upgrading releases, or managing Kubernetes deployments with Helm."
+description: "Manage Helm releases — install, upgrade, uninstall, list, inspect, history. Use when the user mentions deploying Helm charts, upgrading releases, or managing Kubernetes deployments."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/kubernetes-plugin/skills/helm-release-recovery/SKILL.md
+++ b/kubernetes-plugin/skills/helm-release-recovery/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: helm-release-recovery
-description: Recover from failed Helm deployments, rollback releases, fix stuck states (pending-install, pending-upgrade). Covers helm rollback, release history, and atomic deployments. Use when the user mentions rollback, failed Helm upgrade, or stuck release.
+description: "Recover from failed Helm deployments — rollback, fix stuck states (pending-install/upgrade), atomic deployments. Use when the user mentions rollback, failed Helm upgrade, or stuck releases."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/kubernetes-plugin/skills/helm-values-management/SKILL.md
+++ b/kubernetes-plugin/skills/helm-values-management/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: helm-values-management
-description: Manage Helm values across environments with override precedence, multi-env configs, and secret management. Covers values files, --set, --set-string, schema validation. Use when the user mentions Helm values, env-specific configs, or values.yaml.
+description: "Manage Helm values — override precedence, multi-env configs, --set, schema validation, secrets. Use when the user mentions Helm values, env-specific configs, or values.yaml."
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 ---

--- a/kubernetes-plugin/skills/kubectl-debugging/SKILL.md
+++ b/kubernetes-plugin/skills/kubectl-debugging/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: kubectl-debugging
-description: Debug Kubernetes pods, nodes, and workloads using kubectl debug. Covers ephemeral containers, pod copying, node debugging, debug profiles, and interactive sessions. Use when the user mentions kubectl debug, debugging pods, or ephemeral containers.
+description: "Debug K8s pods/nodes with kubectl debug — ephemeral containers, pod copying, debug profiles, interactive sessions. Use when the user mentions kubectl debug or debugging pods."
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash(kubectl *), Bash(stern *), Edit, Write, TodoWrite, WebFetch
 ---

--- a/kubernetes-plugin/skills/kubernetes-operations/SKILL.md
+++ b/kubernetes-plugin/skills/kubernetes-operations/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: kubernetes-operations
-description: "Kubernetes operations: deployment, management, troubleshooting, kubectl mastery, cluster stability. Covers workloads, networking, storage, and pod debugging. Use when the user mentions K8s, kubectl, pods, deployments, services, or ingress."
+description: "Kubernetes operations — deployment, management, troubleshooting, kubectl mastery. Use when the user mentions K8s, kubectl, pods, deployments, services, ingress, or cluster stability."
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash(kubectl *), Bash(helm *), Bash(kustomize *), Edit, Write, TodoWrite, WebFetch
 ---

--- a/langchain-plugin/skills/deep-agents/skill.md
+++ b/langchain-plugin/skills/deep-agents/skill.md
@@ -1,6 +1,6 @@
 ---
 name: deep-agents
-description: Build hierarchical AI agents using the deep-agents TypeScript/npm package. Use when creating an orchestrator that plans multi-step tasks, manages file system context, delegates to child agents, or maintains persistent memory with Deep Agents.
+description: Build hierarchical AI agents with the deep-agents npm package. Use when creating orchestrators that plan multi-step tasks, delegate to child agents, or maintain persistent memory.
 user-invocable: false
 allowed-tools: Bash(python *), Bash(uv *), BashOutput, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2026-01-08

--- a/langchain-plugin/skills/langchain-init/SKILL.md
+++ b/langchain-plugin/skills/langchain-init/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Initialize a new LangChain TypeScript project with recommended config. Use when starting a new LLM-powered app, scaffolding an AI agent project, or setting up LangChain from scratch.
+description: Initialize a new LangChain TypeScript project. Use when starting an LLM-powered app, scaffolding an AI agent project, or setting up LangChain from scratch.
 args: "[project-name]"
 allowed-tools: Bash(uv *), Bash(pip *), Bash(python *), Read, Write, Edit
 argument-hint: my-agent-project

--- a/langchain-plugin/skills/langgraph-agents/skill.md
+++ b/langchain-plugin/skills/langgraph-agents/skill.md
@@ -1,6 +1,6 @@
 ---
 name: langgraph-agents
-description: Build stateful AI agents using LangGraph's graph-based workflow framework. Use when creating state-machine agents with checkpoints, defining behavior as graphs, adding human-in-the-loop, streaming execution, or composing subgraphs.
+description: LangGraph stateful AI agents with graph-based workflows. Use when creating state-machine agents with checkpoints, human-in-the-loop, streaming execution, or subgraph composition.
 user-invocable: false
 allowed-tools: Bash(python *), Bash(uv *), BashOutput, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2026-01-08

--- a/macos-plugin/skills/kitty-session-persistence/skill.md
+++ b/macos-plugin/skills/kitty-session-persistence/skill.md
@@ -1,6 +1,6 @@
 ---
 name: kitty-session-persistence
-description: "Snapshot and restore kitty terminal sessions across crashes, reboots, and GUI hangs on macOS. Use when surviving WindowServer hangs without losing tabs, configuring periodic snapshots, or restoring after a force-reboot."
+description: Snapshot and restore kitty terminal sessions on macOS. Use when surviving WindowServer hangs without losing tabs, configuring snapshots, or restoring after a force-reboot.
 user-invocable: false
 allowed-tools: Bash(kitty *), Bash(kitten *), Bash(launchctl *), Bash(uname *), Bash(plutil *), Bash(test *), Read, Write, Edit, Grep, Glob
 created: 2026-05-03

--- a/macos-plugin/skills/launchservices-health/skill.md
+++ b/macos-plugin/skills/launchservices-health/skill.md
@@ -1,6 +1,6 @@
 ---
 name: launchservices-health
-description: Diagnose macOS LaunchServices DB bloat and launchservicesd CPU issues. Use when launchservicesd is pegged at high CPU, the LS database feels bloated after long uptime, or you suspect LaunchServices is blocking WindowServer with XPC stalls.
+description: Diagnose macOS LaunchServices DB bloat and launchservicesd CPU spikes. Use when launchservicesd is pegged at high CPU, the LS DB feels bloated, or WindowServer XPC stalls are suspected.
 user-invocable: false
 allowed-tools: Bash(uname *), Bash(ps *), Bash(pgrep *), Bash(uptime *), Bash(awk *), Bash(grep *), Bash(wc *), Bash(ls *), Bash(stat *), Bash(mktemp *), Bash(rm *), Read, Write, Edit, Grep, Glob
 created: 2026-05-03

--- a/macos-plugin/skills/launchservices-health/skill.md
+++ b/macos-plugin/skills/launchservices-health/skill.md
@@ -1,6 +1,6 @@
 ---
 name: launchservices-health
-description: Diagnose macOS LaunchServices DB bloat and launchservicesd CPU spikes. Use when launchservicesd is pegged at high CPU, the LS DB feels bloated, or WindowServer XPC stalls are suspected.
+description: Diagnose macOS LaunchServices DB bloat and launchservicesd CPU spikes. Use when launchservicesd is pegged at high CPU or WindowServer XPC stalls are suspected.
 user-invocable: false
 allowed-tools: Bash(uname *), Bash(ps *), Bash(pgrep *), Bash(uptime *), Bash(awk *), Bash(grep *), Bash(wc *), Bash(ls *), Bash(stat *), Bash(mktemp *), Bash(rm *), Read, Write, Edit, Grep, Glob
 created: 2026-05-03

--- a/macos-plugin/skills/macos-incident-postmortem/skill.md
+++ b/macos-plugin/skills/macos-incident-postmortem/skill.md
@@ -1,6 +1,6 @@
 ---
 name: macos-incident-postmortem
-description: Reconstruct macOS GUI freeze, kernel panic, or unexplained reboot from DiagnosticReports and shell history. Use when investigating hangs, panics, watchdog timeouts, jetsam, or thermal throttling.
+description: Reconstruct macOS freeze, panic, or reboot from DiagnosticReports and shell history. Use when investigating hangs, panics, watchdog timeouts, jetsam, or thermal throttling.
 user-invocable: false
 allowed-tools: Bash(uname *), Bash(sysctl *), Bash(uptime *), Bash(last *), Bash(ls *), Bash(find *), Bash(stat *), Bash(awk *), Bash(grep *), Bash(wc *), Bash(date *), Bash(log *), Bash(pmset *), Read, Grep, Glob, TodoWrite
 created: 2026-05-03

--- a/macos-plugin/skills/macos-incident-postmortem/skill.md
+++ b/macos-plugin/skills/macos-incident-postmortem/skill.md
@@ -1,6 +1,6 @@
 ---
 name: macos-incident-postmortem
-description: "Reconstruct macOS GUI freeze, kernel panic, or unexplained reboot by parsing /Library/Logs/DiagnosticReports/, kern.boottime, and shell history. Use when investigating a GUI hang, ambiguous reboot, panics, watchdog timeouts, jetsam, or thermal throttling."
+description: Reconstruct macOS GUI freeze, kernel panic, or unexplained reboot from DiagnosticReports and shell history. Use when investigating hangs, panics, watchdog timeouts, jetsam, or thermal throttling.
 user-invocable: false
 allowed-tools: Bash(uname *), Bash(sysctl *), Bash(uptime *), Bash(last *), Bash(ls *), Bash(find *), Bash(stat *), Bash(awk *), Bash(grep *), Bash(wc *), Bash(date *), Bash(log *), Bash(pmset *), Read, Grep, Glob, TodoWrite
 created: 2026-05-03

--- a/migration-patterns-plugin/skills/black-to-ruff-format/SKILL.md
+++ b/migration-patterns-plugin/skills/black-to-ruff-format/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: black-to-ruff-format
-description: Migrate a Python project from black to ruff format. Use when .pre-commit-config.yaml contains psf/black, or [tool.black] config exists in pyproject.toml. Replaces the black hook with ruff-format, migrates config, and removes black from dependencies.
+description: "Migrate Python formatting from black to ruff-format. Use when psf/black is in .pre-commit-config.yaml or [tool.black] exists in pyproject.toml."
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(find *), Bash(test *), Bash(pre-commit *), Bash(uvx *), AskUserQuestion, TodoWrite
 model: sonnet
 args: "[--check-only] [--fix]"

--- a/migration-patterns-plugin/skills/dual-write/SKILL.md
+++ b/migration-patterns-plugin/skills/dual-write/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dual-write
-description: Dual write (double write) migration pattern for safely transitioning between data stores. Use when planning database migrations, switching storage backends, migrating to new schemas, or reviewing code that writes to multiple systems simultaneously.
+description: Dual-write migration pattern for safe data store transitions. Use when planning DB migrations, switching storage backends, or reviewing code that writes to multiple systems simultaneously.
 user-invocable: false
 allowed-tools: Read, Grep, Glob, Edit, Write, Bash, TodoWrite
 created: 2026-02-18

--- a/migration-patterns-plugin/skills/dual-write/SKILL.md
+++ b/migration-patterns-plugin/skills/dual-write/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dual-write
-description: Dual-write migration pattern for safe data store transitions. Use when planning DB migrations, switching storage backends, or reviewing code that writes to multiple systems simultaneously.
+description: Dual-write pattern for safe data store transitions. Use when planning DB migrations, switching storage backends, or reviewing code writing to multiple systems simultaneously.
 user-invocable: false
 allowed-tools: Read, Grep, Glob, Edit, Write, Bash, TodoWrite
 created: 2026-02-18

--- a/migration-patterns-plugin/skills/eslint-to-biome/SKILL.md
+++ b/migration-patterns-plugin/skills/eslint-to-biome/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: eslint-to-biome
-description: Migrate a JavaScript/TypeScript project from ESLint to Biome. Use when .eslintrc* or eslint.config.* exists and no biome.json is present. Replaces ESLint and Prettier configs/hooks with Biome, preserving rule equivalents (Rust linter+formatter).
+description: "Migrate JS/TS linting from ESLint+Prettier to Biome. Use when .eslintrc* or eslint.config.* exists and no biome.json is present."
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(find *), Bash(test *), Bash(npx *), Bash(bun *), AskUserQuestion, TodoWrite
 model: sonnet
 args: "[--check-only] [--fix]"

--- a/migration-patterns-plugin/skills/flake8-to-ruff/SKILL.md
+++ b/migration-patterns-plugin/skills/flake8-to-ruff/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flake8-to-ruff
-description: Migrate a Python project from flake8 and/or isort to ruff linting. Use when .pre-commit-config.yaml has pycqa/flake8 or PyCQA/isort, or [tool.flake8]/[tool.isort] config exists. Replaces both with one ruff hook and removes the old tools.
+description: "Migrate Python linting from flake8/isort to ruff. Use when pycqa/flake8 or PyCQA/isort is in .pre-commit-config.yaml or [tool.flake8]/[tool.isort] config exists."
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(find *), Bash(test *), Bash(pre-commit *), Bash(uvx *), AskUserQuestion, TodoWrite
 model: sonnet
 args: "[--check-only] [--fix]"

--- a/migration-patterns-plugin/skills/mypy-to-ty/SKILL.md
+++ b/migration-patterns-plugin/skills/mypy-to-ty/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mypy-to-ty
-description: Migrate a Python project from mypy to ty (Astral's type checker). Use when .pre-commit-config.yaml has mirrors-mypy or [tool.mypy] config exists. Swaps the hook to local uvx ty check, converts [tool.mypy] to [tool.ty], and removes mypy.ini.
+description: "Migrate Python type checking from mypy to ty (Astral). Use when mirrors-mypy is in .pre-commit-config.yaml or [tool.mypy] config exists."
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(find *), Bash(test *), Bash(pre-commit *), Bash(uvx *), AskUserQuestion, TodoWrite
 model: sonnet
 args: "[--check-only] [--fix]"

--- a/migration-patterns-plugin/skills/shadow-mode/SKILL.md
+++ b/migration-patterns-plugin/skills/shadow-mode/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shadow-mode
-description: Shadow mode / dark-launch pattern for validating new systems under production load. Use when testing replacement services, comparing behavior, or planning traffic mirroring for migrations.
+description: Shadow mode / dark-launch for validating new systems under production load. Use when testing replacement services, comparing behavior, or planning traffic mirroring for migrations.
 user-invocable: false
 allowed-tools: Read, Grep, Glob, Edit, Write, Bash, TodoWrite
 created: 2026-02-18

--- a/migration-patterns-plugin/skills/shadow-mode/SKILL.md
+++ b/migration-patterns-plugin/skills/shadow-mode/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shadow-mode
-description: Shadow mode (shadow traffic, dark launching) for validating new systems under production load. Use when testing replacement services, validating new deployments, comparing system behavior, or planning traffic mirroring for migration validation.
+description: Shadow mode / dark-launch pattern for validating new systems under production load. Use when testing replacement services, comparing behavior, or planning traffic mirroring for migrations.
 user-invocable: false
 allowed-tools: Read, Grep, Glob, Edit, Write, Bash, TodoWrite
 created: 2026-02-18

--- a/networking-plugin/skills/dns-tools/skill.md
+++ b/networking-plugin/skills/dns-tools/skill.md
@@ -1,6 +1,6 @@
 ---
 name: dns-tools
-description: Resolve DNS records, check propagation, and debug name resolution. Use when you need to look up A/AAAA/MX/TXT records, verify DNS changes across resolvers, or query via encrypted DNS (DoT/DoH).
+description: DNS resolution and propagation debugging. Use when looking up A/AAAA/MX/TXT records, verifying DNS changes across resolvers, or querying via DoT/DoH.
 user-invocable: false
 allowed-tools: Bash(dig *), Bash(nslookup *), Bash(host *), Bash(whois *), Read, Grep, Glob, TodoWrite
 created: 2026-01-01

--- a/networking-plugin/skills/http-load-testing/skill.md
+++ b/networking-plugin/skills/http-load-testing/skill.md
@@ -3,7 +3,7 @@ created: 2026-01-01
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: http-load-testing
-description: Stress test HTTP endpoints with oha. Use when measuring latency percentiles, finding a server's breaking point under load, or validating SLA targets with coordinated-omission correction.
+description: HTTP load testing with oha. Use when measuring latency percentiles, finding a server's breaking point, or validating SLA targets under coordinated-omission correction.
 user-invocable: false
 allowed-tools: Bash(hey *), Bash(ab *), Bash(wrk *), Bash(curl *), Read, Grep, Glob, TodoWrite
 ---

--- a/networking-plugin/skills/layer2-discovery/skill.md
+++ b/networking-plugin/skills/layer2-discovery/skill.md
@@ -3,7 +3,7 @@ created: 2026-01-01
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: layer2-discovery
-description: Discover devices and map physical topology on the local network segment. Use when finding which switch port a server is on, enumerating hosts via ARP, or identifying unknown devices by MAC vendor.
+description: Layer 2 device discovery and topology mapping. Use when finding switch port assignments, enumerating hosts via ARP, or identifying unknown devices by MAC vendor.
 user-invocable: false
 allowed-tools: Bash(arp *), Bash(ip *), Bash(bridge *), Bash(ethtool *), Read, Write, Edit, Grep, Glob
 ---

--- a/networking-plugin/skills/network-diagnostics/skill.md
+++ b/networking-plugin/skills/network-diagnostics/skill.md
@@ -3,7 +3,7 @@ created: 2026-01-01
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: network-diagnostics
-description: Troubleshoot network connectivity, latency, and path issues. Use when you need to trace the route to a host, compare ping latency across endpoints, or inspect local socket/port usage.
+description: Network connectivity and latency diagnostics. Use when tracing routes, comparing ping latency across endpoints, or inspecting local socket/port usage.
 user-invocable: false
 allowed-tools: Bash(ping *), Bash(traceroute *), Bash(mtr *), Bash(netstat *), Bash(ss *), Bash(ip *), Read, Grep, Glob, TodoWrite
 ---

--- a/networking-plugin/skills/network-discovery/skill.md
+++ b/networking-plugin/skills/network-discovery/skill.md
@@ -1,6 +1,6 @@
 ---
 name: network-discovery
-description: Find live hosts and open ports on a network. Use when you need to scan all TCP ports on a target, enumerate hosts on a subnet, or identify running services and their versions.
+description: Network host and port discovery with nmap. Use when scanning TCP ports, enumerating hosts on a subnet, or identifying running services and versions.
 user-invocable: false
 allowed-tools: Bash(nmap *), Bash(ping *), Bash(arp *), Bash(ip *), Read, Grep, Glob, TodoWrite
 created: 2026-01-01

--- a/networking-plugin/skills/network-monitoring/skill.md
+++ b/networking-plugin/skills/network-monitoring/skill.md
@@ -3,7 +3,7 @@ created: 2026-01-01
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: network-monitoring
-description: Monitor real-time network traffic and per-process bandwidth with bandwhich and Sniffnet. Use when finding which app is consuming bandwidth, inspecting active connections, or capturing traffic samples.
+description: Real-time network traffic and per-process bandwidth monitoring. Use when finding which app consumes bandwidth, inspecting active connections, or capturing traffic samples.
 user-invocable: false
 allowed-tools: Bash(iftop *), Bash(nethogs *), Bash(tcpdump *), Bash(ss *), Bash(netstat *), Read, Grep, Glob, TodoWrite
 ---

--- a/obsidian-plugin/skills/bases/SKILL.md
+++ b/obsidian-plugin/skills/bases/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-04-30
 modified: 2026-05-09
 reviewed: 2026-04-30
 name: bases
-description: Query and create entries in Obsidian Bases — the database-over-notes feature. Covers listing base files and views, creating items, and view queries with structured output (json/csv/tsv/md/paths). Use when the user mentions Bases or .base files.
+description: "Obsidian Bases (database-over-notes): list base files/views, create items, run view queries with json/csv/tsv/md output. Use when user mentions Bases or .base files."
 user-invocable: false
 allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---

--- a/obsidian-plugin/skills/bookmarks/SKILL.md
+++ b/obsidian-plugin/skills/bookmarks/SKILL.md
@@ -3,10 +3,7 @@ created: 2026-04-30
 modified: 2026-04-30
 reviewed: 2026-04-30
 name: bookmarks
-description: |
-  List and add Obsidian bookmarks — files, folders, headings/blocks, saved
-  searches, and external URLs. Use when the user mentions Obsidian bookmarks,
-  starring/saving notes for quick access, or scripted bookmark creation.
+description: "Obsidian bookmarks: list and add file/folder/heading/saved-search/URL bookmarks. Use when starring or saving notes for quick access."
 user-invocable: false
 allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---

--- a/obsidian-plugin/skills/command-palette/SKILL.md
+++ b/obsidian-plugin/skills/command-palette/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-04-30
 modified: 2026-05-09
 reviewed: 2026-04-30
 name: command-palette
-description: Run any Obsidian command (built-in or plugin-registered) from the CLI, list available commands, and inspect or look up hotkeys. Use when the user wants to trigger a command, enumerate commands, or check which hotkey is bound to an action.
+description: "Run, list, and inspect Obsidian commands and hotkeys from the CLI. Use when triggering a command, enumerating commands, or checking hotkey bindings."
 user-invocable: false
 allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---

--- a/obsidian-plugin/skills/dev-tools/SKILL.md
+++ b/obsidian-plugin/skills/dev-tools/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-04-30
 modified: 2026-05-09
 reviewed: 2026-04-30
 name: dev-tools
-description: Obsidian developer commands for plugin/theme dev — DevTools, CDP, JavaScript eval, console/error buffers, CSS/DOM inspection, mobile emulation, screenshots. Use when developing a plugin/theme, debugging the app, or introspecting the renderer.
+description: "Obsidian plugin/theme dev: DevTools, CDP, JS eval, console/error buffers, CSS/DOM inspection, mobile emulation, screenshots. Use when debugging the app."
 user-invocable: false
 allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---

--- a/obsidian-plugin/skills/file-history/SKILL.md
+++ b/obsidian-plugin/skills/file-history/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-04-30
 modified: 2026-05-09
 reviewed: 2026-04-30
 name: file-history
-description: Inspect, diff, and restore previous note versions from Obsidian's local File Recovery store and Sync history. Critical safety net for agentic edits. Use when the user mentions undo, restoring a previous version, file recovery, or version history.
+description: "Obsidian File Recovery and Sync history: inspect, diff, restore previous note versions. Use when undoing edits, restoring versions, or recovering files."
 user-invocable: false
 allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---

--- a/obsidian-plugin/skills/plugins-themes/SKILL.md
+++ b/obsidian-plugin/skills/plugins-themes/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-03-04
 modified: 2026-05-09
 reviewed: 2026-04-30
 name: plugins-themes
-description: Lifecycle management for Obsidian community plugins, themes, and CSS snippets via the official CLI — install, enable, disable, uninstall, reload, switch theme, toggle restricted mode. Use when installing/enabling Obsidian plugins or themes.
+description: "Obsidian community plugins/themes/CSS snippets management. Use when installing, enabling, switching theme, or toggling restricted mode."
 user-invocable: false
 allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---

--- a/obsidian-plugin/skills/properties/SKILL.md
+++ b/obsidian-plugin/skills/properties/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-03-04
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: properties
-description: Obsidian YAML frontmatter property management via the official CLI. Covers reading, setting, and removing properties on notes. Use when the user mentions frontmatter, properties, metadata, YAML, or note attributes like status, tags, dates, aliases.
+description: "Obsidian YAML frontmatter properties: read, set, remove on notes. Use when user mentions frontmatter, metadata, tags, aliases, status, or dates."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/obsidian-plugin/skills/publish-sync/SKILL.md
+++ b/obsidian-plugin/skills/publish-sync/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-03-04
 modified: 2026-05-09
 reviewed: 2026-04-30
 name: publish-sync
-description: Obsidian Publish and Sync via the official CLI — publish info, list/add/remove published notes, change set, sync pause/resume, status, and recovery of sync-deleted files. Use when mentioning Publish, Sync, or recovering deleted files.
+description: "Obsidian Publish and Sync operations. Use when publishing notes, managing change sets, pausing/resuming sync, or recovering sync-deleted files."
 user-invocable: false
 allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---

--- a/obsidian-plugin/skills/search-discovery/SKILL.md
+++ b/obsidian-plugin/skills/search-discovery/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-03-04
 modified: 2026-05-09
 reviewed: 2026-04-30
 name: search-discovery
-description: Obsidian vault search and discovery via the official CLI — full-text/grep search, tag listing, link traversal, outline, orphan/dead-end detection, and broken wikilink audits. Use when searching notes, exploring backlinks, or auditing wikilinks.
+description: "Obsidian vault search: full-text/grep, tag listing, link traversal, outline, orphan/dead-end detection, broken wikilink audit. Use when exploring backlinks."
 user-invocable: false
 allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---

--- a/obsidian-plugin/skills/tasks/SKILL.md
+++ b/obsidian-plugin/skills/tasks/SKILL.md
@@ -3,11 +3,7 @@ created: 2026-03-04
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: tasks
-description: |
-  Obsidian task management via the official CLI.
-  Covers listing open tasks, creating tasks, and marking tasks complete.
-  Use when user mentions Obsidian tasks, todos, checklists,
-  or completing/creating tasks in their vault.
+description: "Obsidian tasks via CLI: list open tasks, create tasks, mark complete. Use when user mentions Obsidian tasks, todos, checklists, or completion."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/obsidian-plugin/skills/templates/SKILL.md
+++ b/obsidian-plugin/skills/templates/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-04-30
 modified: 2026-05-09
 reviewed: 2026-04-30
 name: templates
-description: List, read, and insert Obsidian templates from the core Templates plugin. Covers template variable resolution ({{date}}, {{time}}, {{title}}) and inserting into the active file vs creating a new file. Use when the user mentions Obsidian templates.
+description: "Obsidian Templates plugin: list, read, insert templates with {{date}}/{{time}}/{{title}} variables. Use when inserting or applying a template."
 user-invocable: false
 allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---

--- a/obsidian-plugin/skills/vault-files/SKILL.md
+++ b/obsidian-plugin/skills/vault-files/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-03-04
 modified: 2026-05-09
 reviewed: 2026-04-30
 name: vault-files
-description: Obsidian vault file/folder operations via the official CLI — read, create, append, prepend, move, rename, delete notes, file info, listing, daily/random/unique notes, web viewer. Use when mentioning vault files, daily notes, or managing content.
+description: "Obsidian vault file ops via CLI: read, create, append, move, rename, delete, listings, daily/random notes. Use when managing vault files."
 user-invocable: false
 allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---

--- a/obsidian-plugin/skills/vault-frontmatter/SKILL.md
+++ b/obsidian-plugin/skills/vault-frontmatter/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-04-17
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: vault-frontmatter
-description: "Offline maintenance of YAML frontmatter in Obsidian notes. Use when the user asks to strip legacy `id:` fields, add missing frontmatter, remove null tag values, clean up unrendered Templater markers, or fix bare emoji placeholder tags in bulk."
+description: "Offline YAML frontmatter maintenance for Obsidian notes. Use when stripping legacy `id:`, cleaning Templater markers, or fixing bare emoji tags."
 user-invocable: false
 allowed-tools: Read, Edit, Write, Grep, Glob
 ---

--- a/obsidian-plugin/skills/vault-management/SKILL.md
+++ b/obsidian-plugin/skills/vault-management/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-04-30
 modified: 2026-05-09
 reviewed: 2026-04-30
 name: vault-management
-description: Inspect the active vault, enumerate known vaults, and target commands at a specific vault using the global `vault=` prefix. Use when the user asks about vault info (path, file count, size), works across vaults, or runs against a non-active vault.
+description: "Obsidian vault inspection and cross-vault routing via `vault=` prefix. Use when checking vault info (path, size, file count) or targeting a non-active vault."
 user-invocable: false
 allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---

--- a/obsidian-plugin/skills/vault-mocs/SKILL.md
+++ b/obsidian-plugin/skills/vault-mocs/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-04-17
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: vault-mocs
-description: Map-of-Content (MOC) curation for Obsidian vaults. Use when the user asks to create a MOC for a tag category, extend an existing MOC with orphans, fix legacy MOC tags to `📝/moc`, analyze MOC coverage, or reorganize hand-curated hub notes.
+description: "Map-of-Content (MOC) curation for Obsidian vaults. Use when creating a MOC for a tag, extending with orphans, fixing legacy MOC tags, or analyzing coverage."
 user-invocable: false
 allowed-tools: Read, Edit, Write, Grep, Glob
 ---

--- a/obsidian-plugin/skills/vault-orphans/SKILL.md
+++ b/obsidian-plugin/skills/vault-orphans/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-04-17
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: vault-orphans
-description: Triage orphaned notes (zero in/out wikilinks) in an Obsidian vault. Use when the user asks to find orphans, link disconnected notes into a MOC, distinguish expected orphans (inbox, daily) from meaningful ones, or reconnect Zettelkasten notes.
+description: "Triage orphaned notes (zero in/out wikilinks) in an Obsidian vault. Use when finding orphans, linking them into a MOC, or reconnecting Zettelkasten notes."
 user-invocable: false
 allowed-tools: Read, Edit, Grep, Glob
 ---

--- a/obsidian-plugin/skills/vault-stubs/SKILL.md
+++ b/obsidian-plugin/skills/vault-stubs/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-04-17
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: vault-stubs
-description: FVH/z/ redirect-stub classification and consolidation for LakuVault. Use when the user asks to clean up FVH/z stubs, convert stale duplicates to canonical redirects, merge unique FVH content into Zettelkasten, or fix broken stubs.
+description: "LakuVault FVH/z redirect-stub classification. Use when cleaning stubs, converting duplicates to redirects, or merging content into Zettelkasten."
 user-invocable: false
 allowed-tools: Read, Edit, Write, Grep, Glob
 ---

--- a/obsidian-plugin/skills/vault-tags/SKILL.md
+++ b/obsidian-plugin/skills/vault-tags/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-04-17
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: vault-tags
-description: Emoji-prefixed tag taxonomy for Obsidian vaults. Use when the user asks to consolidate duplicate or drifted tags (`🔒/security` vs `🔍/security`), collapse bare emoji placeholder tags, convert flat tags to emoji-prefixed, or reduce over-tagging.
+description: "Emoji-prefixed tag taxonomy for Obsidian vaults. Use when consolidating drifted tags, collapsing bare emoji placeholders, or reducing over-tagging."
 user-invocable: false
 allowed-tools: Read, Edit, Grep, Glob
 ---

--- a/obsidian-plugin/skills/vault-templates/SKILL.md
+++ b/obsidian-plugin/skills/vault-templates/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-04-17
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: vault-templates
-description: Obsidian Templater conventions and drift repair. Use when the user asks to fix unrendered Templater markers like `<% tp.file.cursor() %>`, replace `{{title}}`/`{{date}}` placeholders, or audit daily-note structure drift.
+description: "Obsidian Templater drift repair. Use when fixing unrendered `<% tp.file.cursor() %>` markers or replacing `{{title}}`/`{{date}}` placeholders."
 user-invocable: false
 allowed-tools: Read, Edit, Write, Grep, Glob
 ---

--- a/obsidian-plugin/skills/vault-wikilinks/SKILL.md
+++ b/obsidian-plugin/skills/vault-wikilinks/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-04-17
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: vault-wikilinks
-description: Detect and repair broken wikilinks in an Obsidian vault. Use when the user asks to fix broken `[[Target]]` links, rewrite a renamed note's references, resolve ambiguity between Zettelkasten and FVH/z, or unqualify path-qualified links.
+description: "Broken Obsidian wikilink detection and repair. Use when fixing `[[Target]]` links, rewriting renamed-note refs, or resolving Zettelkasten/FVH paths."
 user-invocable: false
 allowed-tools: Read, Edit, Grep, Glob
 ---

--- a/obsidian-plugin/skills/workspaces/SKILL.md
+++ b/obsidian-plugin/skills/workspaces/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-04-30
 modified: 2026-05-09
 reviewed: 2026-04-30
 name: workspaces
-description: Inspect and manage the Obsidian editor workspace — open tabs, recent files, saved Workspaces, tab management. Use when the user asks what's open, wants to switch to a saved layout, save the current layout, or open files into specific tabs.
+description: "Obsidian editor workspace: list open tabs, recent files, saved Workspaces. Use when checking what's open, switching layouts, or opening files into tabs."
 user-invocable: false
 allowed-tools: Bash(obsidian *), Read, Grep, Glob
 ---

--- a/project-plugin/skills/changelog-review/SKILL.md
+++ b/project-plugin/skills/changelog-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: changelog-review
-description: Analyze Claude Code changelog for plugin-impact changes. Use when checking new features, breaking changes, or improvement opportunities for plugins from Claude Code updates.
+description: Claude Code changelog analysis for plugin impact. Use when checking new features, breaking changes, or upgrade opportunities from a Claude Code release.
 user-invocable: false
 allowed-tools: Bash(git log *), Bash(git diff *), Read, Write, Edit, Glob, Grep, WebFetch, TodoWrite
 created: 2026-01-14

--- a/project-plugin/skills/project-continue/SKILL.md
+++ b/project-plugin/skills/project-continue/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Analyze project state and continue development where left off. Use when the user asks to resume work, pick up where we left off, figure out what to do next, identify the next task from PRDs and feature tracker, or continue TDD after a break.
+description: Resume development from current project state. Use when the user asks to continue work, pick up where we left off, find the next task, or resume a TDD cycle after a break.
 args: "[--task <id>] [--skip-status]"
 argument-hint: "--task to resume specific task, --skip-status to skip state analysis"
 allowed-tools: Read, Bash, Grep, Glob, Edit, Write

--- a/project-plugin/skills/project-discovery/SKILL.md
+++ b/project-plugin/skills/project-discovery/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-05-09
 name: project-discovery
-description: Systematic project orientation for unfamiliar codebases. Auto-activates on project uncertainty. Analyzes git state, project type, and dev tooling (build, test, lint, CI/CD). Use when entering new projects or working on shaky assumptions.
+description: Project orientation for unfamiliar codebases. Use when entering a new project, exploring unknown repos, or working on shaky assumptions about build, test, lint, or CI setup.
 user-invocable: false
 allowed-tools: Bash(ls *), Bash(find *), Bash(wc *), Read, Grep, Glob, TodoWrite
 ---

--- a/project-plugin/skills/project-distill/SKILL.md
+++ b/project-plugin/skills/project-distill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-distill
-description: Distill session insights into reusable knowledge — Claude rules, skill improvements, justfile recipes. Use when capturing session learnings, extracting reusable patterns, updating rules from experience, or codifying workflow into `.claude/rules`.
+description: "Distill session insights into rules, skill improvements, and justfile recipes. Use when capturing learnings, extracting reusable patterns, or codifying workflow into .claude/rules."
 allowed-tools: Bash(git diff *), Bash(git log *), Bash(git status *), Bash(just *), Read, Grep, Glob, Edit, Write, AskUserQuestion, TodoWrite
 argument-hint: "--rules | --skills | --recipes | --all | --dry-run"
 args: "[--rules] [--skills] [--recipes] [--all] [--dry-run]"

--- a/project-plugin/skills/project-init/SKILL.md
+++ b/project-plugin/skills/project-init/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Write, Bash(mkdir *), Bash(git init *), Bash(gh repo create *), B
 args: <project-name> [project-type] [--github] [--private]
 argument-hint: <project-name> [project-type] [--github] [--private]
 disable-model-invocation: true
-description: Initialize a new project with universal base structure (src/tests/docs, git, README, LICENSE, .gitignore, .editorconfig, pre-commit, CI, Makefile). Use when the user asks to start a new project, scaffold a repo, or bootstrap Python/Node/Rust/Go.
+description: Scaffold a new project with base structure (git, README, LICENSE, CI, pre-commit). Use when starting a new project, initializing a repo, or bootstrapping Python/Node/Rust/Go.
 name: project-init
 ---
 

--- a/project-plugin/skills/project-skill-scripts/SKILL.md
+++ b/project-plugin/skills/project-skill-scripts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-skill-scripts
-description: Analyze plugin skills to find where supporting scripts would improve performance (fewer tokens, faster, more consistent), then optionally create them. Use when auditing skills for script opportunities or extracting bash blocks from SKILL.md.
+description: Find and create supporting scripts for plugin skills. Use when auditing skills for script opportunities, improving token efficiency, or extracting bash blocks from SKILL.md.
 args: "[--analyze] [--create <plugin/skill>] [--all]"
 allowed-tools: Bash(chmod *), Bash(mkdir *), Read, Write, Edit, Glob, Grep, TodoWrite
 argument-hint: "--analyze | --create git-plugin/git-commit-workflow | --all"

--- a/project-plugin/skills/project-test-loop/SKILL.md
+++ b/project-plugin/skills/project-test-loop/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Run an automated test-fix-refactor TDD cycle until tests pass and no refactoring opportunities remain. Use when the user asks to loop on failing tests, run a TDD cycle, or drive implementation via RED/GREEN/REFACTOR until green.
+description: Automated TDD test-fix-refactor cycle until tests pass. Use when looping on failing tests, running a TDD cycle, or driving RED/GREEN/REFACTOR until green.
 args: "[test-pattern] [--max-cycles <N>]"
 argument-hint: "Test pattern to focus on, --max-cycles to limit iterations"
 allowed-tools: Read, Edit, Bash

--- a/prompt-engineering-plugin/skills/prompt-engineering-ground-response/SKILL.md
+++ b/prompt-engineering-plugin/skills/prompt-engineering-ground-response/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ground-response
-description: Produce citation-backed responses from source documents with direct quotes and verified claims. Use when analyzing long docs, answering codebase or spec questions, or when response accuracy is critical.
+description: Citation-backed responses with direct quotes from source documents. Use when analyzing long docs, answering codebase/spec questions, or when response accuracy is critical.
 args: <question or task> [--source <file-or-path>]
 allowed-tools: Read, Grep, Glob, TodoWrite
 argument-hint: <question about a document or codebase>

--- a/prose-plugin/skills/prose-distill/SKILL.md
+++ b/prose-plugin/skills/prose-distill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prose-distill
-description: Distill verbose text to its concentrated essence — precis, condensation, verbal economy. Use when asked to condense, tighten, shorten, reduce verbosity, or omit needless words while preserving substance.
+description: "Prose distill: condense verbose text to its essence. Use when asked to condense, tighten, shorten, reduce verbosity, or omit needless words while preserving substance."
 args: "[text or file path]"
 allowed-tools: Read, Edit, Write, Grep, Glob, TodoWrite
 argument-hint: <text to distill> or <path to file>

--- a/prose-plugin/skills/prose-synthesize/SKILL.md
+++ b/prose-plugin/skills/prose-synthesize/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prose-synthesize
-description: Synthesize unstructured thinking into a structured, actionable plan with goals and priorities. Use when given stream-of-consciousness notes, brain dumps, or scattered thoughts that need organizing.
+description: "Prose synthesize: turn unstructured notes into a structured, actionable plan. Use when given brain dumps, stream-of-consciousness, or scattered thoughts needing order."
 args: "[prose to synthesize]"
 allowed-tools: Read, Edit, Write, Grep, Glob, TodoWrite
 argument-hint: <unstructured thoughts or file path>

--- a/python-plugin/skills/basedpyright-type-checking/SKILL.md
+++ b/python-plugin/skills/basedpyright-type-checking/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
 name: basedpyright-type-checking
-description: "Basedpyright static type checker config, installation, and usage. Use when implementing type checking, configuring LSP, comparing type checkers, or setting up strict type validation. Triggers: basedpyright, pyright, type checking, mypy alternative."
+description: Basedpyright static type checker for Python. Use when setting up type checking, configuring LSP, or comparing type checkers (basedpyright, pyright, mypy alternative).
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/python-plugin/skills/pytest-advanced/SKILL.md
+++ b/python-plugin/skills/pytest-advanced/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-01-24
 name: pytest-advanced
-description: "Advanced pytest patterns: fixtures, markers, parametrization, parallel execution. Use when implementing test infrastructure, organizing test suites, writing fixtures, or running with coverage. Covers pytest-cov, pytest-asyncio, pytest-xdist."
+description: "Advanced pytest: fixtures, markers, parametrization, parallel execution. Use when implementing test infrastructure, writing fixtures, or running with coverage."
 user-invocable: false
 allowed-tools: Bash(pytest *), Bash(python *), Bash(uv run *), Read, Grep, Glob
 ---

--- a/python-plugin/skills/python-code-quality/SKILL.md
+++ b/python-plugin/skills/python-code-quality/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: python-code-quality
-description: Python code quality with ruff (linting & formatting) and ty (type checking). Covers pyproject.toml configuration, pre-commit hooks, and type hints. Use when the user mentions ruff, ty, linting, formatting, type checking, or Python code style.
+description: Python code quality with ruff and ty. Use when the user mentions ruff, ty, linting, formatting, type checking, or Python code style.
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/python-plugin/skills/python-development/SKILL.md
+++ b/python-plugin/skills/python-development/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: python-development
-description: Core Python development concepts, idioms, and language features (3.10+). Covers type hints, async/await, and Pythonic patterns. For scripts see uv-run; for project setup see uv-project-management. Use when mentioning Python, type hints, or async.
+description: Core Python development idioms and language features (3.10+). Use when mentioning Python, type hints, or async. For scripts see uv-run; for project setup see uv-project-management.
 user-invocable: false
 allowed-tools: Glob, Grep, Read, WebFetch, TodoWrite, WebSearch, BashOutput, KillShell, Edit, Write, NotebookEdit, Bash
 ---

--- a/python-plugin/skills/python-packaging/SKILL.md
+++ b/python-plugin/skills/python-packaging/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: python-packaging
-description: Build and publish Python packages with uv and modern build tools. Covers uv build, uv publish, pyproject.toml, versioning, entry points, and PyPI publishing. Use when the user mentions building packages, publishing to PyPI, or wheel/sdist creation.
+description: Build and publish Python packages with uv. Use when the user mentions building packages, publishing to PyPI, wheel/sdist creation, or entry points.
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/python-plugin/skills/python-testing/SKILL.md
+++ b/python-plugin/skills/python-testing/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: python-testing
-description: Python testing with pytest, coverage, fixtures, parametrization, and mocking. Covers test organization, conftest.py, markers, async testing, and TDD. Use when the user mentions pytest, unit tests, coverage, fixtures, mocking, or writing Python tests.
+description: Python testing with pytest, coverage, fixtures, and mocking. Use when the user mentions pytest, unit tests, coverage, fixtures, mocking, or writing Python tests.
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/python-plugin/skills/ruff-formatting/SKILL.md
+++ b/python-plugin/skills/ruff-formatting/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16
 name: ruff-formatting
-description: Python code formatting with ruff format. Fast, Black-compatible formatting for consistent code style. Use when formatting Python files, enforcing style, or checking format compliance.
+description: Python code formatting with ruff format. Fast, Black-compatible formatter. Use when formatting Python files, enforcing style, or checking format compliance.
 user-invocable: false
 allowed-tools: Bash(ruff *), Bash(python *), Bash(uv *), Read, Edit, Write, Grep, Glob
 ---

--- a/python-plugin/skills/ruff-integration/SKILL.md
+++ b/python-plugin/skills/ruff-integration/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-01-24
 name: ruff-integration
-description: "Integrate ruff into dev workflows: editor setup, pre-commit hooks, and CI/CD. Use when configuring ruff in VS Code, setting up pre-commit, or adding ruff to GitHub Actions. For ruff rules see ruff-linting; for formatting see ruff-formatting."
+description: "Integrate ruff into dev workflows: editor, pre-commit, CI/CD. Use when configuring ruff in VS Code, setting up pre-commit, or adding ruff to GitHub Actions."
 user-invocable: false
 allowed-tools: Bash(ruff *), Bash(python *), Bash(uv *), Read, Edit, Write, Grep, Glob
 ---

--- a/python-plugin/skills/ruff-linting/SKILL.md
+++ b/python-plugin/skills/ruff-linting/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: ruff-linting
-description: Python code quality with ruff linter. Fast linting, rule selection, auto-fixing, and configuration. Use when checking Python code quality, enforcing standards, or finding bugs.
+description: Python linting with ruff. Fast linting, rule selection, auto-fixing, and config. Use when checking Python code quality, enforcing standards, or finding bugs.
 user-invocable: false
 allowed-tools: Bash(ruff *), Bash(python *), Bash(uv *), Read, Edit, Write, Grep, Glob
 ---

--- a/python-plugin/skills/ty-type-checking/SKILL.md
+++ b/python-plugin/skills/ty-type-checking/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-01-29
 modified: 2026-05-09
 reviewed: 2026-01-29
 name: ty-type-checking
-description: "Python type checking with ty, Astral's extremely fast type checker (10-100x faster than mypy/Pyright). Use when checking Python types, configuring rules, or setting up type checking. Triggers: ty, type checking, mypy alternative, pyright alternative."
+description: "ty: Astral's extremely fast Python type checker (mypy/Pyright alternative). Use when checking Python types or setting up type checking. Triggers: ty, mypy alternative."
 user-invocable: false
 allowed-tools: Bash(ty *), Bash(python *), Bash(uv *), Read, Edit, Write, Grep, Glob, TodoWrite
 ---

--- a/python-plugin/skills/uv-advanced-dependencies/SKILL.md
+++ b/python-plugin/skills/uv-advanced-dependencies/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: uv-advanced-dependencies
-description: "Advanced dependency scenarios in uv projects: Git deps, path deps, editable installs, dependency groups, extras, constraints, and custom indexes. Use when the user mentions git+https deps, local path deps, editable installs, or private indexes."
+description: "Advanced uv dependencies: Git deps, path deps, editable installs, groups, extras, custom indexes. Use when the user mentions git+https deps, editable installs, or private indexes."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/python-plugin/skills/uv-project-management/SKILL.md
+++ b/python-plugin/skills/uv-project-management/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: uv-project-management
-description: Python project setup, dependencies, and lockfiles with uv. Covers uv init, uv add, uv remove, uv lock, uv sync, and pyproject.toml. Use when the user mentions uv, creating Python projects, managing deps, lockfiles, or pyproject.toml.
+description: Python project setup, deps, and lockfiles with uv. Use when the user mentions uv, creating Python projects, managing dependencies, lockfiles, or pyproject.toml.
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/python-plugin/skills/uv-python-versions/SKILL.md
+++ b/python-plugin/skills/uv-python-versions/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: uv-python-versions
-description: Install and manage Python interpreter versions with uv. Covers uv python install/list/pin and .python-version pinning. Use when the user mentions installing or switching Python versions, .python-version, uv python, or managing CPython/PyPy.
+description: Install and manage Python interpreter versions with uv. Use when the user mentions installing Python versions, .python-version, uv python, or managing CPython/PyPy.
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/python-plugin/skills/uv-run/SKILL.md
+++ b/python-plugin/skills/uv-run/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: uv-run
-description: Run Python scripts with uv including inline dependencies (PEP 723), temporary deps (--with), and ephemeral tool execution. Use when running scripts, needing one-off dependencies, or creating executable Python scripts. No venv activation required.
+description: Run Python scripts with uv (PEP 723 inline deps, --with for one-off deps). Use when running scripts without venv activation or needing one-off dependencies.
 user-invocable: false
 allowed-tools: Glob, Grep, Read, WebFetch, TodoWrite, WebSearch, BashOutput, KillShell, Edit, Write, NotebookEdit, Bash
 ---

--- a/python-plugin/skills/uv-tool-management/SKILL.md
+++ b/python-plugin/skills/uv-tool-management/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: uv-tool-management
-description: Install and manage global Python CLI tools with uv (pipx alternative). Covers uv tool install, uvx for ephemeral execution, tool isolation, and updates. Use when the user mentions uv tool, uvx, installing CLI tools globally, or pipx replacement.
+description: Install and manage global Python CLI tools with uv (pipx alternative). Use when the user mentions uv tool, uvx, installing CLI tools globally, or pipx replacement.
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/python-plugin/skills/uv-workspaces/SKILL.md
+++ b/python-plugin/skills/uv-workspaces/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-02-12
 name: uv-workspaces
-description: Manage monorepo and multi-package Python projects with uv workspaces. Covers workspace config, virtual workspaces, member deps, shared lockfiles, source inheritance, and building. Use when the user mentions uv workspaces or Python monorepo.
+description: Manage multi-package Python projects with uv workspaces. Use when the user mentions uv workspaces, Python monorepo, shared lockfiles, or member dependencies.
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/python-plugin/skills/vulture-dead-code/SKILL.md
+++ b/python-plugin/skills/vulture-dead-code/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
 name: vulture-dead-code
-description: "Vulture and deadcode tools for detecting unused Python code (functions, classes, variables, imports). Use when cleaning up codebases, removing unused code, or enforcing hygiene in CI. Triggers: vulture, deadcode, dead code detection, unused code."
+description: Vulture and deadcode tools for detecting unused Python code (functions, classes, imports). Use when cleaning up codebases or removing dead code. Triggers vulture, deadcode.
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/rust-plugin/skills/cargo-llvm-cov/SKILL.md
+++ b/rust-plugin/skills/cargo-llvm-cov/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: cargo-llvm-cov
-description: "Code coverage for Rust using LLVM instrumentation, multiple output formats, and CI integration. Use when measuring coverage, generating reports, enforcing thresholds, or integrating codecov/coveralls. Triggers: coverage, llvm-cov, codecov."
+description: "cargo-llvm-cov: Rust code coverage with LLVM instrumentation. Use when measuring coverage, enforcing thresholds, generating reports, or integrating codecov/coveralls."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/rust-plugin/skills/cargo-machete/SKILL.md
+++ b/rust-plugin/skills/cargo-machete/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
 name: cargo-machete
-description: "Detect unused dependencies in Rust projects for cleaner Cargo.toml and faster builds. Use when auditing deps, optimizing build times, cleaning up Cargo.toml, or detecting bloat. Triggers: unused dependencies, cargo-machete, cargo-udeps."
+description: "cargo-machete: detect unused Rust dependencies. Use when auditing Cargo.toml, optimizing build times, or cleaning up dependency bloat."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/rust-plugin/skills/cargo-nextest/SKILL.md
+++ b/rust-plugin/skills/cargo-nextest/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: cargo-nextest
-description: "Next-gen test runner for Rust with parallel execution, advanced filtering, and CI integration. Use when running tests, configuring execution, setting up CI, or optimizing performance. Triggers: nextest, test runner, parallel tests, flaky tests."
+description: "cargo-nextest: fast Rust test runner with parallel execution and advanced filtering. Use when running tests, setting up CI, or diagnosing flaky/slow tests."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/rust-plugin/skills/clippy-advanced/SKILL.md
+++ b/rust-plugin/skills/clippy-advanced/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
 name: clippy-advanced
-description: "Advanced Clippy configuration for Rust linting with custom rules, categories, and IDE integration. Use when configuring lint rules, enforcing standards, setting up CI linting, or customizing clippy. Triggers: clippy, clippy.toml, pedantic, nursery."
+description: "Advanced Clippy configuration for Rust — custom rules, pedantic/nursery lints, clippy.toml, IDE and CI integration. Use when configuring or enforcing lint standards."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/rust-plugin/skills/rust-development/SKILL.md
+++ b/rust-plugin/skills/rust-development/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: rust-development
-description: Modern Rust development with cargo, rustc, clippy, rustfmt, async, and memory-safe systems programming. Covers ownership, fearless concurrency, and the modern ecosystem (Tokio, Serde). Use when mentioning Rust, cargo, ownership, lifetimes, or async.
+description: Rust development — cargo, clippy, rustfmt, async, Tokio, Serde, memory safety. Use when mentioning Rust, cargo, ownership, lifetimes, fearless concurrency, or async programming.
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash, Edit, Write, TodoWrite, WebFetch, WebSearch, BashOutput, KillShell
 ---

--- a/taskwarrior-plugin/skills/task-add/SKILL.md
+++ b/taskwarrior-plugin/skills/task-add/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-add
-description: File a new taskwarrior task with blueprint linkage (bpid/bpdoc/bpms) and optional GitHub issue linkage. Use when adding multi-agent coordination tasks, linking a blueprint WO, or mirroring a GitHub issue locally.
+description: Add a taskwarrior task with blueprint (bpid/bpdoc) and optional GitHub issue linkage. Use when adding coordination tasks, linking a blueprint WO, or mirroring a GitHub issue locally.
 args: "[description] [project:<name>] [--no-project]"
 allowed-tools: Bash(task *), Bash(git config *), Bash(git rev-parse *), Bash(gh auth *), Bash(gh issue *), Bash(gh api *), Read, TodoWrite
 argument-hint: short task description

--- a/taskwarrior-plugin/skills/task-add/SKILL.md
+++ b/taskwarrior-plugin/skills/task-add/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-add
-description: Add a taskwarrior task with blueprint (bpid/bpdoc) and optional GitHub issue linkage. Use when adding coordination tasks, linking a blueprint WO, or mirroring a GitHub issue locally.
+description: Add a taskwarrior task with blueprint linkage and optional GitHub issue. Use when adding coordination tasks, linking a blueprint WO, or mirroring a GitHub issue locally.
 args: "[description] [project:<name>] [--no-project]"
 allowed-tools: Bash(task *), Bash(git config *), Bash(git rev-parse *), Bash(gh auth *), Bash(gh issue *), Bash(gh api *), Read, TodoWrite
 argument-hint: short task description

--- a/taskwarrior-plugin/skills/task-claim/SKILL.md
+++ b/taskwarrior-plugin/skills/task-claim/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-claim
-description: Claim a taskwarrior task as in-flight by this agent. Marks the task `+ACTIVE` (`task start`), populates identity UDAs (agent / pid / host / branch / worktree), and writes a `git-coworker-check` session marker so other agents can see the work is taken. Use when picking up a task from `/taskwarrior:task-coordinate` output before starting implementation.
+description: Claim a taskwarrior task as in-flight (+ACTIVE), populate identity UDAs, and write a coworker marker. Use when picking up a task from task-coordinate output before starting implementation.
 args: "<task-id> [--no-coworker-marker] [--force]"
 allowed-tools: Bash(task *), Bash(git rev-parse *), Bash(git branch *), Bash(git config *), Bash(hostname *), Bash(jq *), Bash(bash *), Read, TodoWrite
 argument-hint: task id (required)

--- a/taskwarrior-plugin/skills/task-claim/SKILL.md
+++ b/taskwarrior-plugin/skills/task-claim/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-claim
-description: Claim a taskwarrior task as in-flight (+ACTIVE), populate identity UDAs, and write a coworker marker. Use when picking up a task from task-coordinate output before starting implementation.
+description: Claim a taskwarrior task as in-flight (+ACTIVE) and write a coworker marker. Use when picking up a task from task-coordinate output before starting implementation.
 args: "<task-id> [--no-coworker-marker] [--force]"
 allowed-tools: Bash(task *), Bash(git rev-parse *), Bash(git branch *), Bash(git config *), Bash(hostname *), Bash(jq *), Bash(bash *), Read, TodoWrite
 argument-hint: task id (required)

--- a/taskwarrior-plugin/skills/task-coordinate/SKILL.md
+++ b/taskwarrior-plugin/skills/task-coordinate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-coordinate
-description: Surface the next N unblocked taskwarrior tasks sorted by urgency, skipping lock-contending tasks. Use when planning a parallel-agent-dispatch wave or deciding which tasks share a dispatch slot.
+description: Surface next N unblocked taskwarrior tasks by urgency, skipping lock-contending tasks. Use when planning a parallel-agent wave or choosing tasks for a dispatch slot.
 args: "[--n=N] [--lock=<resource>] [--wave] [--project=<name>] [--all]"
 allowed-tools: Bash(task *), Bash(git rev-parse *), Bash(jq *), Read, TodoWrite
 argument-hint: optional count (default 3) and lock filter

--- a/taskwarrior-plugin/skills/task-done/SKILL.md
+++ b/taskwarrior-plugin/skills/task-done/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-done
-description: Close a taskwarrior task, annotate it with the landing commit, drain the linked feature-tracker entry, and optionally close linked GitHub issues/PRs. Use when finishing a coordination task or marking a WO complete.
+description: Close a taskwarrior task with landing commit annotation and optional GitHub issue/PR close. Use when finishing a coordination task or marking a work order complete.
 args: "<task-id> [commit-hash]"
 allowed-tools: Bash(task *), Bash(git config *), Bash(git log *), Bash(git rev-parse *), Bash(gh auth *), Bash(gh issue *), Bash(gh pr *), Read, Edit, TodoWrite
 argument-hint: task id (required), commit sha (optional — defaults to HEAD)

--- a/taskwarrior-plugin/skills/task-release/SKILL.md
+++ b/taskwarrior-plugin/skills/task-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-release
-description: Release a taskwarrior task without closing it. Stops the `+ACTIVE` clock, annotates the current state for the next agent to read, and clears the `pid` UDA (keeps `agent` / `branch` / `worktree` for handoff context). Use when pausing mid-task, handing off to another agent, or aborting cleanly when the work is not actually done.
+description: Release a taskwarrior task without closing it — stops +ACTIVE clock and annotates state for handoff. Use when pausing mid-task, handing off to another agent, or aborting cleanly.
 args: "<task-id> [<state-message>] [--clear-identity] [--no-coworker-marker]"
 allowed-tools: Bash(task *), Bash(git rev-parse *), Bash(git branch *), Bash(jq *), Bash(bash *), Read, TodoWrite
 argument-hint: task id (required) and optional state message

--- a/taskwarrior-plugin/skills/task-status/SKILL.md
+++ b/taskwarrior-plugin/skills/task-status/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-status
-description: Read-only taskwarrior queue report covering pending, blocked, ready tasks plus drift between the queue and linked PRs/trackers. Use when auditing queue health, orienting before a wave, or for standup summaries.
+description: Read-only taskwarrior queue report — pending, blocked, ready tasks plus drift vs linked PRs/trackers. Use when auditing queue health, orienting before a wave, or for standup summaries.
 args: "[--mine] [--blocked] [--stale=N] [--project=<name>] [--all]"
 allowed-tools: Bash(task *), Bash(git config *), Bash(git rev-parse *), Bash(gh auth *), Bash(gh pr *), Bash(jq *), Read, TodoWrite
 argument-hint: optional filters

--- a/taskwarrior-plugin/skills/task-status/SKILL.md
+++ b/taskwarrior-plugin/skills/task-status/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-status
-description: Read-only taskwarrior queue report — pending, blocked, ready tasks plus drift vs linked PRs/trackers. Use when auditing queue health, orienting before a wave, or for standup summaries.
+description: Read-only taskwarrior queue report — pending, blocked, ready tasks and drift vs linked PRs. Use when auditing queue health, orienting before a wave, or for standup summaries.
 args: "[--mine] [--blocked] [--stale=N] [--project=<name>] [--all]"
 allowed-tools: Bash(task *), Bash(git config *), Bash(git rev-parse *), Bash(gh auth *), Bash(gh pr *), Bash(jq *), Read, TodoWrite
 argument-hint: optional filters

--- a/terraform-plugin/skills/infrastructure-terraform/SKILL.md
+++ b/terraform-plugin/skills/infrastructure-terraform/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: infrastructure-terraform
-description: "Infrastructure as Code with Terraform: HCL, state management, modular design, plan-apply workflows. Covers cloud and on-prem provisioning, remote backends, and modules. Use when the user mentions Terraform, HCL, terraform plan/apply, tfstate, or IaC."
+description: "Terraform IaC: HCL, state management, modules, plan-apply workflows. Use when the user mentions Terraform, HCL, terraform plan/apply, tfstate, or IaC provisioning."
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash, Edit, Write, TodoWrite
 ---

--- a/terraform-plugin/skills/tfc-list-runs/SKILL.md
+++ b/terraform-plugin/skills/tfc-list-runs/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: tfc-list-runs
-description: List Terraform Cloud runs for a workspace, filtering by status, operation, or date. Use when reviewing run history, finding failed runs, or auditing infra changes. Requires TFE_TOKEN.
+description: "List Terraform Cloud workspace runs filtered by status or date. Use when reviewing run history, finding failed runs, or auditing infra changes. Requires TFE_TOKEN."
 user-invocable: false
 allowed-tools: Bash, Read
 ---

--- a/terraform-plugin/skills/tfc-plan-json/SKILL.md
+++ b/terraform-plugin/skills/tfc-plan-json/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: tfc-plan-json
-description: Download and analyze structured plan JSON from Terraform Cloud runs. Use when diffing resource changes, inspecting replacement reasons, or feeding plan data downstream. Requires TFE_TOKEN.
+description: "TFC plan JSON download and analysis. Use when diffing resource changes, inspecting replacements, or feeding plan data downstream. Requires TFE_TOKEN."
 user-invocable: false
 allowed-tools: Bash, Read
 ---

--- a/terraform-plugin/skills/tfc-run-logs/SKILL.md
+++ b/terraform-plugin/skills/tfc-run-logs/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: tfc-run-logs
-description: Retrieve plan and apply logs from Terraform Cloud runs. Use when examining TFC run output, debugging failed plans/applies, or reviewing infrastructure changes. Requires TFE_TOKEN environment variable.
+description: "Retrieve plan and apply logs from Terraform Cloud runs. Use when debugging failed plans/applies or reviewing TFC run output. Requires TFE_TOKEN."
 user-invocable: false
 allowed-tools: Bash, Read
 ---

--- a/terraform-plugin/skills/tfc-run-status/SKILL.md
+++ b/terraform-plugin/skills/tfc-run-status/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: tfc-run-status
-description: Quick status check for a Terraform Cloud run with resource counts, timestamps, and actions. Use when polling a run, checking pass/fail, or seeing if it can be applied or canceled. Requires TFE_TOKEN.
+description: "Terraform Cloud run status with resource counts and actions. Use when polling a run, checking pass/fail, or seeing if it can be applied or canceled. Requires TFE_TOKEN."
 user-invocable: false
 allowed-tools: Bash, Read
 ---

--- a/terraform-plugin/skills/tfc-workspace-runs/SKILL.md
+++ b/terraform-plugin/skills/tfc-workspace-runs/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: tfc-workspace-runs
-description: Convenience wrapper for listing Terraform Cloud runs in Forum Virium Helsinki workspaces (github, sentry, gcp, onelogin, twingate). Requires TFE_TOKEN. Use when mentioning TFC runs, Terraform Cloud workspace, or checking TFC status.
+description: "List TFC runs across known workspaces (github, sentry, gcp, onelogin, twingate). Use when checking TFC status or listing runs by workspace. Requires TFE_TOKEN."
 user-invocable: false
 allowed-tools: Bash, Read
 ---

--- a/testing-plugin/skills/hypothesis-testing/SKILL.md
+++ b/testing-plugin/skills/hypothesis-testing/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: hypothesis-testing
-description: "Property-based testing with Hypothesis for Python. Use when testing code with many possible inputs, verifying invariants, testing serialization round-trips, or finding edge cases that example-based tests miss."
+description: "Property-based testing with Hypothesis (Python). Use when testing with many inputs, verifying invariants, testing round-trips, or finding edge cases example tests miss."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/testing-plugin/skills/mutation-testing/SKILL.md
+++ b/testing-plugin/skills/mutation-testing/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
 name: mutation-testing
-description: "Validate test effectiveness with mutation testing using Stryker (TS/JS) and mutmut (Python). Use when finding weak tests that pass despite mutated code, or improving test quality through mutation analysis."
+description: "Mutation testing with Stryker (TS/JS) and mutmut (Python). Use when finding weak tests that pass on mutated code, or improving test quality through mutation analysis."
 user-invocable: false
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob, TodoWrite
 ---

--- a/testing-plugin/skills/playwright-cli/SKILL.md
+++ b/testing-plugin/skills/playwright-cli/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-03-19
 modified: 2026-03-19
 reviewed: 2026-03-19
 name: playwright-cli
-description: Automate browsers from the shell with Playwright CLI — navigate, screenshot, fill forms, click. Use when automating browser tasks from the shell; preferred over Playwright MCP (4-10x more token-efficient).
+description: "Playwright CLI browser automation — navigate, screenshot, fill forms, click. Use when automating browser tasks from the shell; 4-10x more token-efficient than Playwright MCP."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob, TodoWrite
 ---

--- a/testing-plugin/skills/playwright-testing/SKILL.md
+++ b/testing-plugin/skills/playwright-testing/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
 name: playwright-testing
-description: "Playwright E2E testing for web apps with cross-browser (Chromium, Firefox, WebKit), visual regression, API testing, and mobile emulation. Use when writing E2E tests or setting up automated UI testing."
+description: "Playwright E2E testing — cross-browser, visual regression, API testing, mobile emulation. Use when writing E2E tests or setting up automated UI testing for web apps."
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash, Edit, Write, TodoWrite, WebFetch, WebSearch, BashOutput, KillShell
 ---

--- a/testing-plugin/skills/property-based-testing/SKILL.md
+++ b/testing-plugin/skills/property-based-testing/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
 name: property-based-testing
-description: "Property-based testing with fast-check (TS/JS) and Hypothesis (Python). Use when generating test data, finding edge cases automatically, testing mathematical properties, or writing QuickCheck-style tests."
+description: "Property-based testing with fast-check (TS/JS) and Hypothesis (Python). Use when generating test data, finding edge cases, testing properties, or writing QuickCheck-style tests."
 user-invocable: false
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob, TodoWrite
 ---

--- a/testing-plugin/skills/test-analyze/SKILL.md
+++ b/testing-plugin/skills/test-analyze/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Analyze test results and create a fix plan with subagent delegation. Use when triaging failing tests, analyzing JUnit XML or test-results dirs, planning fixes for accessibility/security findings, or categorizing flaky/perf/E2E failures."
+description: "Analyze test results and create a fix plan with subagents. Use when triaging failing tests, analyzing JUnit XML, planning fixes for accessibility/security, or categorizing flaky/E2E failures."
 args: "<results-path> [--type <test-type>] [--focus <area>]"
 argument-hint: "Path to test results (e.g., ./test-results/), optional --type and --focus filters"
 allowed-tools: Task, Read, Glob, Grep, TodoWrite

--- a/testing-plugin/skills/test-consult/SKILL.md
+++ b/testing-plugin/skills/test-consult/SKILL.md
@@ -5,7 +5,7 @@ reviewed: 2026-04-25
 allowed-tools: Task, Read, Glob, Grep
 args: "<topic> [--context <path>]"
 argument-hint: "<topic> [--context <path>]"
-description: "Consult the test-architecture agent for testing strategy decisions. Use when asking about coverage gaps, test pyramid balance, framework selection, flaky-test remediation, or \"how should we test X?\" questions."
+description: "Consult the test-architecture agent for strategy decisions. Use when asking about coverage gaps, test pyramid, framework selection, flaky-test remediation, or how to test X."
 name: test-consult
 ---
 

--- a/testing-plugin/skills/test-focus/SKILL.md
+++ b/testing-plugin/skills/test-focus/SKILL.md
@@ -5,7 +5,7 @@ reviewed: 2026-04-25
 allowed-tools: Bash, Read, Grep, Glob, TodoWrite
 args: "<file-path> [--serial] [--debug]"
 argument-hint: "<file-path> [--serial] [--debug]"
-description: "Run a single test file in fail-fast mode for rapid TDD across Playwright, Vitest, Jest, pytest, cargo, or go test. Use when rerunning one test file, iterating on a failing spec, headed/debug mode, or serial WebGL/database tests."
+description: "Run one test file fail-fast for rapid TDD — Playwright, Vitest, Jest, pytest, cargo, go test. Use when iterating on a failing spec, headed/debug mode, or serial WebGL tests."
 name: test-focus
 ---
 

--- a/testing-plugin/skills/test-full/SKILL.md
+++ b/testing-plugin/skills/test-full/SKILL.md
@@ -5,7 +5,7 @@ reviewed: 2026-04-25
 allowed-tools: Task, TodoWrite
 args: "[--coverage] [--parallel] [--report]"
 argument-hint: "[--coverage] [--parallel] [--report]"
-description: "Run the complete test suite in pyramid order — unit, then integration, then E2E. Use when running all tests before a PR, with coverage, generating HTML reports, or pre-commit verification across all test tiers."
+description: "Run complete test suite in pyramid order — unit, integration, E2E. Use when running all tests before a PR, generating coverage reports, or doing pre-commit verification."
 name: test-full
 agent: general-purpose
 ---

--- a/testing-plugin/skills/test-quality-analysis/SKILL.md
+++ b/testing-plugin/skills/test-quality-analysis/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-02-14
 reviewed: 2025-12-16
 name: test-quality-analysis
-description: Detect test smells, overmocking, flaky tests, and coverage issues. Analyze test effectiveness, maintainability, and reliability. Use when reviewing tests or improving test quality.
+description: "Detect test smells, overmocking, flaky tests, and coverage issues. Use when reviewing tests, improving test quality, or analyzing test effectiveness and reliability."
 user-invocable: false
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob, TodoWrite
 ---

--- a/testing-plugin/skills/test-quick/SKILL.md
+++ b/testing-plugin/skills/test-quick/SKILL.md
@@ -5,7 +5,7 @@ reviewed: 2026-04-25
 allowed-tools: Task, TodoWrite
 args: "[path] [--watch] [--affected]"
 argument-hint: "[path] [--watch] [--affected]"
-description: "Run fast unit tests only, skipping slow/integration/E2E tiers. Use when checking unit tests after a change, running affected tests since last commit, watch mode for TDD, or sub-30s feedback while iterating."
+description: "Run fast unit tests only, skip slow/integration/E2E. Use when checking units after a change, running affected tests since last commit, watch mode TDD, or sub-30s feedback."
 name: test-quick
 ---
 

--- a/testing-plugin/skills/test-report/SKILL.md
+++ b/testing-plugin/skills/test-report/SKILL.md
@@ -5,7 +5,7 @@ reviewed: 2026-04-25
 allowed-tools: Read, Glob, Bash(git *)
 args: "[--history] [--coverage] [--flaky]"
 argument-hint: "[--history] [--coverage] [--flaky]"
-description: "Show test status from cached pytest/vitest/jest/playwright/go/cargo results without re-running. Use when checking current test health, standup status, coverage summary or history, or identifying flaky tests from recent runs."
+description: "Show cached test status without re-running. Use when checking test health, standup status, coverage summary, history, or identifying flaky tests from recent runs."
 name: test-report
 ---
 

--- a/testing-plugin/skills/test-run/SKILL.md
+++ b/testing-plugin/skills/test-run/SKILL.md
@@ -5,7 +5,7 @@ reviewed: 2026-04-25
 allowed-tools: Task, TodoWrite
 args: "[test-pattern] [--coverage] [--watch]"
 argument-hint: "[test-pattern] [--coverage] [--watch]"
-description: "Universal test runner that auto-detects pytest, vitest, jest, cargo test, or go test. Use when running tests, testing a specific file or pattern, running with coverage, watch-mode dev loops, or running tests without specifying a framework."
+description: "Universal test runner auto-detecting pytest, vitest, jest, cargo, go test. Use when running tests, targeting a file/pattern, running with coverage, or watch-mode dev loops."
 name: test-run
 ---
 

--- a/testing-plugin/skills/test-setup/SKILL.md
+++ b/testing-plugin/skills/test-setup/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 allowed-tools: Read, Write, Edit, MultiEdit, Bash(pip install *), Bash(npm install *), Bash(pre-commit *), Bash(pytest *), Bash(npm test *), Bash(git *), TodoWrite, SlashCommand
-description: "Configure testing infrastructure with CI/CD integration. Use when setting up testing, scaffolding unit/integration/E2E directories, adding pre-commit hooks, GitHub Actions test workflows, Codecov reporting, or coverage badges."
+description: "Configure testing infrastructure with CI/CD. Use when setting up tests, scaffolding test dirs, adding pre-commit hooks, GitHub Actions workflows, Codecov, or coverage badges."
 args: "[--coverage] [--ci <github|gitlab|circleci>]"
 argument-hint: "[--coverage] [--ci <github|gitlab|circleci>]"
 name: test-setup

--- a/testing-plugin/skills/test-tier-selection/SKILL.md
+++ b/testing-plugin/skills/test-tier-selection/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-04-25
 reviewed: 2026-04-25
 name: test-tier-selection
-description: Automatic selection of appropriate test tiers based on change scope. Guides unit tests for small changes, full suite for larger changes. Use when running tests, discussing testing strategy, or after code modifications.
+description: "Auto-select test tiers based on change scope — unit for small, full suite for large. Use when running tests, discussing testing strategy, or after code modifications."
 user-invocable: false
 allowed-tools: Bash, Read, Glob, Grep
 ---

--- a/testing-plugin/skills/vitest-testing/SKILL.md
+++ b/testing-plugin/skills/vitest-testing/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
 name: vitest-testing
-description: "Vitest test runner for JavaScript and TypeScript — Vite-native, ESM, watch/UI mode, coverage, mocking, snapshots. Use when setting up tests for Vite projects, migrating from Jest, or needing fast test execution."
+description: "Vitest test runner — Vite-native, ESM, watch/UI mode, coverage, mocking, snapshots. Use when setting up tests for Vite projects, migrating from Jest, or needing fast execution."
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash, Edit, Write, TodoWrite, WebFetch, WebSearch, BashOutput, KillShell
 ---

--- a/tools-plugin/skills/binary-analysis/SKILL.md
+++ b/tools-plugin/skills/binary-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: binary-analysis
-description: Reverse engineer binaries with strings, binwalk, hexdump, xxd, file, objdump. Use when identifying unknown files, extracting strings, hunting credentials, or entropy analysis.
+description: "Binary analysis: strings, binwalk, hexdump, xxd, file, objdump. Use when identifying unknown files, extracting strings, hunting credentials, or entropy analysis."
 user-invocable: false
 allowed-tools: Bash(file *), Bash(xxd *), Bash(hexdump *), Bash(strings *), Bash(objdump *), Bash(readelf *), Bash(nm *), Read, Grep, Glob
 created: 2025-12-27

--- a/tools-plugin/skills/cli-smoke-recipes/SKILL.md
+++ b/tools-plugin/skills/cli-smoke-recipes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cli-smoke-recipes
-description: Expose pure-function modules (decoders, parsers, formatters) via CLI subcommands plus a bulk-smoke justfile recipe. Use when designing data-transform modules or authoring smoke recipes.
+description: "CLI smoke recipes: expose pure-function modules via subcommands with a bulk-smoke justfile recipe. Use when designing data-transform modules or authoring smoke tests."
 allowed-tools: Read, Grep, Glob, TodoWrite
 model: sonnet
 created: 2026-04-24

--- a/tools-plugin/skills/deps-install/SKILL.md
+++ b/tools-plugin/skills/deps-install/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash(uv *), Bash(npm *), Bash(bun *), Bash(cargo *), Bash(go *), 
 model: sonnet
 args: "[package-names] [--dev] [--global]"
 argument-hint: "[package-names] [--dev] [--global]"
-description: Auto-detect the project's package manager (uv, bun, npm, yarn, pnpm, cargo, go) and run the right install. Use when installing deps, adding dev/global packages, or syncing lockfiles.
+description: "Deps install: auto-detect package manager (uv, bun, npm, yarn, pnpm, cargo, go) and run the right install. Use when installing deps or syncing lockfiles."
 name: deps-install
 ---
 

--- a/tools-plugin/skills/fd-file-finding/SKILL.md
+++ b/tools-plugin/skills/fd-file-finding/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-04
 reviewed: 2026-04-25
 name: fd-file-finding
-description: Fast file finding using fd command-line tool with smart defaults, gitignore awareness, and parallel execution. Use when searching for files by name, extension, or pattern across directories.
+description: "fd fast file finding: smart defaults, gitignore-aware, parallel. Use when searching for files by name, extension, or pattern across directories."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 model: sonnet

--- a/tools-plugin/skills/generate-image/SKILL.md
+++ b/tools-plugin/skills/generate-image/SKILL.md
@@ -2,7 +2,7 @@
 created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
-description: Generate images via Google's Nano Banana Pro (Gemini 3 Pro Image) with configurable aspect ratio, resolution, and reference images. Use when creating artwork, product photos, or mockups.
+description: "Image generation via Gemini 3 Pro Image: aspect ratio, resolution, reference images. Use when creating artwork, product photos, or mockups with AI."
 allowed-tools: Bash, Read, WebFetch
 model: sonnet
 args: <prompt> [--aspect <ratio>] [--resolution <size>] [--reference <path>]

--- a/tools-plugin/skills/imagemagick-conversion/SKILL.md
+++ b/tools-plugin/skills/imagemagick-conversion/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
 name: imagemagick-conversion
-description: Convert and manipulate images with ImageMagick — format conversion, resizing, batch processing, quality. Use when converting, resizing, batch-processing, or generating thumbnails.
+description: "ImageMagick image manipulation: format conversion, resizing, batch processing, quality. Use when converting, resizing, batch-processing, or generating thumbnails."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 model: sonnet

--- a/tools-plugin/skills/jq-json-processing/SKILL.md
+++ b/tools-plugin/skills/jq-json-processing/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-04
 reviewed: 2026-04-25
 name: jq-json-processing
-description: JSON querying, filtering, and transformation with jq command-line tool. Use when working with JSON data, parsing JSON files, filtering JSON arrays/objects, or transforming JSON structures.
+description: "jq JSON processing: query, filter, transform JSON. Use when parsing JSON files, filtering arrays/objects, transforming structures, or extracting fields from JSON."
 user-invocable: false
 allowed-tools: Bash(jq *), Bash(cat *), Read, Write, Edit, Grep, Glob
 model: sonnet

--- a/tools-plugin/skills/rg-code-search/SKILL.md
+++ b/tools-plugin/skills/rg-code-search/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-04
 reviewed: 2026-04-25
 name: rg-code-search
-description: Fast code search using ripgrep (rg) with smart defaults, regex patterns, and file filtering. Use when searching for text patterns, code snippets, or performing multi-file code analysis.
+description: "ripgrep (rg) fast code search: smart defaults, regex, file filtering. Use when searching for text patterns, code snippets, or doing multi-file analysis."
 user-invocable: false
 allowed-tools: Bash(rg *), Read, Grep, Glob
 model: sonnet

--- a/tools-plugin/skills/shell-expert/SKILL.md
+++ b/tools-plugin/skills/shell-expert/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: shell-expert
-description: "Shell scripting expertise — bash, zsh, POSIX, CLI tools, automation, cross-platform best practices. Use when writing shell scripts, pipes, command-line automation, or portable shell code."
+description: "Shell scripting: bash, zsh, POSIX, CLI tools, cross-platform automation. Use when writing shell scripts, pipes, command-line automation, or portable shell code."
 user-invocable: false
 allowed-tools: Bash, BashOutput, KillShell, Grep, Glob, Read, Write, Edit, TodoWrite
 ---

--- a/tools-plugin/skills/yq-yaml-processing/SKILL.md
+++ b/tools-plugin/skills/yq-yaml-processing/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-04
 reviewed: 2025-12-16
 name: yq-yaml-processing
-description: Query, filter, and transform YAML with yq. Use when parsing YAML files or configs, modifying Kubernetes manifests or GitHub Actions workflows, or transforming YAML structures.
+description: "yq YAML processing: query, filter, transform YAML. Use when parsing configs, modifying Kubernetes manifests or GitHub Actions workflows, or transforming YAML."
 user-invocable: false
 allowed-tools: Bash(yq *), Read, Write, Edit, Grep, Glob
 model: sonnet

--- a/typescript-plugin/skills/biome-tooling/SKILL.md
+++ b/typescript-plugin/skills/biome-tooling/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
 name: biome-tooling
-description: Biome all-in-one formatter and linter for JavaScript, TypeScript, JSX, TSX, JSON, and CSS. Zero-config, 15-20x faster than ESLint/Prettier. Use when working with modern JS/TS projects, setting up formatting/linting, or migrating from ESLint+Prettier.
+description: "Biome all-in-one JS/TS formatter and linter, 15-20x faster than ESLint/Prettier. Use when setting up formatting/linting or migrating from ESLint+Prettier."
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash, Edit, Write, TodoWrite, WebFetch, WebSearch, BashOutput, KillShell
 ---

--- a/typescript-plugin/skills/bun-add/SKILL.md
+++ b/typescript-plugin/skills/bun-add/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Add a package dependency with Bun. Use when the user wants to install a single package, add a dev dependency (`bun add --dev typescript`), pin an exact version, or target a workspace. Triggers: 'add express', 'install lodash', 'pin react exact'."
+description: "Bun add: install a package, add dev dependency, pin exact version, or target a workspace. Use when the user wants to add/install a specific package with bun."
 args: <package> [--dev] [--exact]
 allowed-tools: Bash, Read
 argument-hint: package-name [--dev] [--exact]

--- a/typescript-plugin/skills/bun-build/SKILL.md
+++ b/typescript-plugin/skills/bun-build/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Bundle or compile JavaScript/TypeScript with Bun. Use when the user wants a production bundle, to compile to a standalone executable with `bun build --compile`, or to build for a target (browser, bun, node). Triggers: 'bundle', 'compile to binary'."
+description: "Bun build: bundle or compile JS/TS to production bundle or standalone binary. Use when the user wants to bundle, compile, or build for browser/bun/node target."
 args: <entry> [--compile] [--minify]
 allowed-tools: Bash, Read
 argument-hint: ./src/index.ts [--compile] [--minify]

--- a/typescript-plugin/skills/bun-debug/SKILL.md
+++ b/typescript-plugin/skills/bun-debug/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Launch a script with Bun's debugger via `--inspect`. Use when the user wants to interactively debug a TS/JS file, break at the first line, wait for a debugger to attach, or debug tests via `bun --inspect-brk test`. Triggers: 'debug this'."
+description: "Bun debugger via --inspect. Use when the user wants to debug a TS/JS file interactively, break at first line, wait for attach, or debug tests with --inspect-brk."
 args: <file> [--brk] [--wait] [--port=<port>]
 allowed-tools: Bash, BashOutput, Read
 argument-hint: <script.ts> [--brk] [--wait] [--port=9229]

--- a/typescript-plugin/skills/bun-install/SKILL.md
+++ b/typescript-plugin/skills/bun-install/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Install all dependencies from package.json using Bun. Use when bootstrapping a fresh checkout with `bun install`, running a reproducible CI install with `--frozen-lockfile`, or preparing a production deploy with `--production`.
+description: "Bun install: install all deps from package.json. Use when bootstrapping a checkout, running a reproducible CI install (--frozen-lockfile), or deploying (--production)."
 args: "[--frozen-lockfile] [--production]"
 argument-hint: "--frozen-lockfile for CI, --production for deployment"
 allowed-tools: Bash, Read

--- a/typescript-plugin/skills/bun-lockfile-update/SKILL.md
+++ b/typescript-plugin/skills/bun-lockfile-update/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: bun-lockfile-update
-description: Update Bun lockfiles (bun.lockb) with proper dependency management. Covers bun update, bun install, lockfile regeneration, and security audits. Use when the user mentions bun lockfile, bun update, bun.lockb, or resolving lockfile conflicts.
+description: "Bun lockfile update (bun.lockb): bun update, regeneration, security audits. Use when updating dependencies, resolving lockfile conflicts, or regenerating bun.lockb."
 allowed-tools: Bash, Read, Grep, Glob
 ---
 

--- a/typescript-plugin/skills/bun-outdated/SKILL.md
+++ b/typescript-plugin/skills/bun-outdated/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Check which dependencies have newer versions using `bun outdated`. Use when auditing freshness, spotting major updates before upgrading, deciding between `bun update` and `bun update --latest`, or reviewing a single package.
+description: "Bun outdated: check which deps have newer versions. Use when auditing freshness, spotting major updates, or deciding between bun update and bun update --latest."
 args: "[package]"
 argument-hint: "Optional package name to check specific dependency"
 allowed-tools: Bash, Read

--- a/typescript-plugin/skills/bun-publish/SKILL.md
+++ b/typescript-plugin/skills/bun-publish/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Publish a package to npm after building with Bun. Use when the user wants to release to npm, preview with `--dry-run`, publish a scoped package with `--access public`, or enable `--provenance` signing. Triggers: 'publish to npm'."
+description: "Bun publish to npm. Use when the user wants to release to npm, preview with --dry-run, publish a scoped package with --access public, or enable --provenance signing."
 args: "[--dry-run] [--access <level>] [--provenance]"
 allowed-tools: Bash, Read
 argument-hint: "[--dry-run] [--access public]"

--- a/typescript-plugin/skills/bun-test/SKILL.md
+++ b/typescript-plugin/skills/bun-test/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Run tests using Bun's built-in test runner with compact, agent-friendly output. Use when running bun tests, targeting a file or pattern, collecting coverage with `--coverage`, enabling watch mode, or emitting JUnit XML for CI.
+description: "Bun test runner with compact agent-friendly output. Use when running bun tests, targeting a pattern, collecting --coverage, watching, or emitting JUnit XML for CI."
 args: "[pattern] [--coverage] [--bail] [--watch]"
 allowed-tools: Bash, BashOutput, Read
 argument-hint: "[test-pattern] [--coverage] [--bail] [--watch]"

--- a/typescript-plugin/skills/knip-dead-code/SKILL.md
+++ b/typescript-plugin/skills/knip-dead-code/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
 name: knip-dead-code
-description: Knip finds unused files, dependencies, exports, and types in JS/TS projects. Plugin system for frameworks (React, Next.js, Vite), test runners (Vitest, Jest), build tools. Use when cleaning up codebases or enforcing dep hygiene in CI.
+description: "Knip dead-code detector for JS/TS: unused files, deps, exports, types. Use when cleaning up codebases, finding dead exports, or enforcing dependency hygiene in CI."
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash, Edit, Write, TodoWrite, WebFetch, WebSearch, BashOutput, KillShell
 ---

--- a/typescript-plugin/skills/nodejs-development/SKILL.md
+++ b/typescript-plugin/skills/nodejs-development/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
 name: nodejs-development
-description: Modern Node.js development with Bun, Vite, Vue 3, Pinia, and TypeScript. Covers JS/TS projects, high-performance tooling, and modern frameworks. Use when the user mentions Node.js, Bun, Vite, Vue, Pinia, npm, or pnpm.
+description: "Node.js development with Bun, Vite, Vue 3, Pinia, TypeScript. Use when the user mentions Node.js, Bun, Vite, Vue, Pinia, npm, pnpm, or modern JS/TS frameworks."
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash, Edit, Write, TodoWrite, WebFetch, WebSearch, BashOutput, KillShell, NotebookEdit
 ---

--- a/typescript-plugin/skills/typescript-strict/SKILL.md
+++ b/typescript-plugin/skills/typescript-strict/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2025-12-16
 name: typescript-strict
-description: TypeScript strict mode configuration for 2025. Recommended tsconfig.json, strict flags, moduleResolution (Bundler vs NodeNext), verbatimModuleSyntax, noUncheckedIndexedAccess. Use when setting up TypeScript or migrating to stricter type safety.
+description: "TypeScript strict mode: tsconfig.json, strict flags, Bundler/NodeNext moduleResolution, verbatimModuleSyntax. Use when setting up TS or migrating to stricter type safety."
 user-invocable: false
 allowed-tools: Glob, Grep, Read, Bash, Edit, Write, TodoWrite, WebFetch, WebSearch, BashOutput, KillShell
 ---

--- a/upstream-pr-plugin/skills/upstream-pr/SKILL.md
+++ b/upstream-pr-plugin/skills/upstream-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: upstream-pr
-description: Submit a single commit from a heavily-diverged fork to upstream as a clean PR. Handles eligibility (patch-id matching), cherry-pick with re-derive fallback for dense conflicts, message scrubbing, and regression checks. Use when direct rebase fails.
+description: Submit a diverged-fork commit to upstream as a clean PR via cherry-pick with re-derive fallback, message scrubbing, and regression checks. Use when direct rebase fails.
 args: "<sha> [--topic <slug>]"
 allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git show *), Bash(git remote *), Bash(git fetch *), Bash(git switch *), Bash(git checkout *), Bash(git cherry-pick *), Bash(git reset *), Bash(git commit *), Bash(git push *), Bash(git stash *), Bash(git rev-list *), Bash(git rev-parse *), Bash(git branch *), Bash(git cat-file *), Bash(git patch-id *), Bash(gh pr *), Bash(gh repo *), Bash(bash *), Bash(uv *), Bash(pytest *), Bash(ruff *), Bash(python3 *), Read, Edit, Write, Grep, Glob, TodoWrite
 argument-hint: "<sha-to-send-upstream>"

--- a/workflow-orchestration-plugin/skills/workflow-checkpoint-refactor/SKILL.md
+++ b/workflow-orchestration-plugin/skills/workflow-checkpoint-refactor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-checkpoint-refactor
-description: Multi-phase refactoring with persistent checkpoint files that survive context limits. Use when refactoring spans 10+ files, needs phased rollout, or risks running out of context — supports "continue the refactor" across sessions.
+description: Multi-phase refactoring with checkpoint files that survive context limits. Use when refactoring spans 10+ files, needs phased rollout, or risks running out of context mid-session.
 args: "[--init|--continue|--status|--phase=N]"
 allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(npm run *), Bash(npx *), Bash(uv run *), Bash(cargo *), Read, Write, Edit, Grep, Glob, Task, TodoWrite
 argument-hint: "--init to create plan, --continue to resume, --status to check progress"

--- a/workflow-orchestration-plugin/skills/workflow-preflight/SKILL.md
+++ b/workflow-orchestration-plugin/skills/workflow-preflight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-preflight
-description: Pre-work validation before implementation. Use when starting an issue or fix to verify remote state, check for existing PRs, detect branch conflicts, and avoid stale or merged work.
+description: Pre-work validation before implementation. Use when starting an issue or fix to verify remote state, check for existing PRs, and detect branch conflicts before coding.
 args: "[issue-number|branch-name]"
 allowed-tools: Bash(git fetch *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git branch *), Bash(git remote *), Bash(git stash *), Bash(gh pr *), Bash(gh issue *), Read, Grep, Glob, TodoWrite
 argument-hint: optional issue number or branch name to check

--- a/workflow-orchestration-plugin/skills/workflow-preflight/SKILL.md
+++ b/workflow-orchestration-plugin/skills/workflow-preflight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-preflight
-description: Pre-work validation before implementation. Use when starting on an issue, feature, or fix to verify remote state, check for existing PRs, detect branch conflicts, and avoid wasted effort on already-merged fixes or stale branches.
+description: Pre-work validation before implementation. Use when starting an issue or fix to verify remote state, check for existing PRs, detect branch conflicts, and avoid stale or merged work.
 args: "[issue-number|branch-name]"
 allowed-tools: Bash(git fetch *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git branch *), Bash(git remote *), Bash(git stash *), Bash(gh pr *), Bash(gh issue *), Read, Grep, Glob, TodoWrite
 argument-hint: optional issue number or branch name to check

--- a/workflow-orchestration-plugin/skills/workflow-wave-dispatch/SKILL.md
+++ b/workflow-orchestration-plugin/skills/workflow-wave-dispatch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-wave-dispatch
-description: Sequential-wave dispatch contract for multi-agent work with cross-task dependencies or shared locks. Use when planning multi-step implementations, recovering from parallel-dispatch ordering issues, or scheduling waves around verification gates.
+description: Sequential-wave dispatch for multi-agent work with cross-task dependencies or shared locks. Use when planning multi-step work, recovering from parallel-dispatch ordering issues, or gating waves on verification.
 user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 created: 2026-04-24

--- a/workflow-orchestration-plugin/skills/workflow-wave-dispatch/SKILL.md
+++ b/workflow-orchestration-plugin/skills/workflow-wave-dispatch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-wave-dispatch
-description: Sequential-wave dispatch for multi-agent work with cross-task dependencies. Use when planning multi-step work, fixing parallel-dispatch ordering issues, or gating waves on verification.
+description: Sequential-wave dispatch for multi-agent work with cross-task dependencies. Use when planning multi-step work, fixing parallel-dispatch order, or gating waves on verification.
 user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 created: 2026-04-24

--- a/workflow-orchestration-plugin/skills/workflow-wave-dispatch/SKILL.md
+++ b/workflow-orchestration-plugin/skills/workflow-wave-dispatch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-wave-dispatch
-description: Sequential-wave dispatch for multi-agent work with cross-task dependencies or shared locks. Use when planning multi-step work, recovering from parallel-dispatch ordering issues, or gating waves on verification.
+description: Sequential-wave dispatch for multi-agent work with cross-task dependencies. Use when planning multi-step work, fixing parallel-dispatch ordering issues, or gating waves on verification.
 user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 created: 2026-04-24


### PR DESCRIPTION
## Summary

Considers [claudefa.st: Skill Listing Budget](https://claudefa.st/blog/guide/mechanics/skill-listing-budget) against this collection, codifies a length target in `.claude/rules/skill-quality.md`, and applies a full-repo tightening pass: obsidian-plugin first as a pilot, then the remaining 39 plugins in parallel via 4 worktree-isolated Sonnet agents.

## What the blog post says (relevant numbers)

| Setting (Claude Code 2.1.129+) | Default | Caps |
|---|---|---|
| `skillListingBudgetFraction` | `0.01` | Total skill metadata, as a fraction of the context window |
| `skillListingMaxDescChars` | `1536` | Per-skill description, truncated from the end |

On a 200K context that's ~2,000 tokens for **all** skill listings combined; ~10K on a 1M context. Each listed skill costs ~35 tokens of XML wrapper + `(name + description) / 4` tokens. Once the budget is blown, descriptions are stripped from overflow skills — auto-invocation matching silently degrades.

## What this PR does

### 1. Codify the length target in `.claude/rules/skill-quality.md`

- New "Description Length and the Listing Budget" section with the budget settings, a target band (ideal ≤150, OK ≤200, WARN ≤300, ERROR >300), and a front-loading playbook (tool/verb → trigger phrases → disambiguator).
- Rewrote the existing intent-matching example from 220-char block scalar to a 140-char single line so authors aren't pulled in two directions.
- Added a description-length check to the PR review checklist.

### 2. Full-repo tightening pass (40 plugins, 356 skills)

Sequence:
1. **obsidian-plugin pilot** (21 skills, by hand) — proved the approach works without losing the audit's `Use when...` trigger phrase.
2. **4 parallel Sonnet agents with worktree isolation**, each owning a balanced ~80-skill group, producing one commit per plugin so release-please can attribute changelog entries correctly.

Full-repo impact (vs `merge-base origin/main`):

| Metric | Before | After | Δ |
|---|---|---|---|
| Total chars (name+desc) | 81,932 | 64,744 | **−21.0%** |
| Approx listing tokens | 32,873 | 28,646 | **−4,227 (−12.9%)** |
| Median description length | 220 chars | 163 chars | **−26%** |
| Max description length | 345 chars | 249 chars | |
| Descriptions ≤ 150 chars (ideal) | 6 | 56 | 9.3× |
| Descriptions ≤ 180 chars (acceptable) | 46 | 329 | 7.2× |
| Descriptions > 180 chars | 308 | 27 | **−91%** |
| `--strict-all` audit | OK | OK | trigger phrases preserved on all 356 |

### Budget headroom interpretation

The marketplace as a whole still exceeds a single user's default budget — 356 skills × ~80 tokens/listing is irreducibly ~28K tokens, vs ~2K (200K × 1%) or ~10K (1M × 1%). That's expected: this repo is a *plugin catalog*, not a typical user's enabled set. The right structural fix is **per-project plugin enable/disable orchestration** (see Follow-ups below). The −21% tightening here is the cosmetic pass that buys headroom *within* each plugin so users who enable a few plugins stay under budget.

### Per-plugin examples

| Plugin (before → after median chars) | Skills |
|---|---|
| `obsidian-plugin` (242 → 150) | 21 |
| `configure-plugin` (191 → ~145) | 46 |
| `blueprint-plugin` (221 → ~170) | 35 |
| `git-plugin` (211 → ~150) | 35 |
| `python-plugin` (244 → ~170) | 17 |
| `typescript-plugin` (238 → ~165) | 17 |
| `code-quality-plugin` (231 → ~170) | 17 |
| `testing-plugin` (210 → ~150) | 16 |

### 27 remaining over-180 stragglers

Mostly in the 181–249 band, all retain `Use when...` triggers. Acceptable per the rule's `WARN` band (201–300); a follow-up cleanup pass can take them down further if the project wants stricter enforcement.

## Why a docs+pilot+parallel approach

- The rule + pilot lands the design *before* the bulk pass — anyone reviewing the parallel agents' work has a written spec to check against.
- Per-plugin commits keep release-please changelog attribution clean (each plugin gets a `Code Refactoring` entry; no version bumps since `refactor` doesn't trigger them).
- Sonnet agents (not Opus [1m]) sidestep the documented concurrent-subagent rate-limit hazard with 1M-context models.

## Merge-style note

This PR has **53 per-plugin commits** so release-please can attribute changelogs to each affected plugin. **Use a merge commit (not squash) to preserve attribution.** Squash-merge would collapse everything under the PR's `refactor:` (no scope), losing per-plugin changelog entries.

## Follow-ups (not in this PR)

- **Project-context skill enable/disable orchestration**: extend `configure-plugin` (or split it) so users don't toggle each skill manually via `/skills`. This is the structural fix; tightening is the cosmetic one.
- **Optional**: add a length check to `scripts/audit-skill-descriptions.py` as a regression gate (warn at >200, error at >300), mirroring the table in the new rule section.
- **Tail cleanup**: 27 skills remain in 181–249 chars; a focused pass could pull them under 180.

## Test plan

- [x] `python3 scripts/audit-skill-descriptions.py --strict-all` — exit 0 (zero `MISSING` / `EMPTY` / `NO_TRIGGER` across all 356 skills)
- [x] `bash scripts/plugin-compliance-check.sh` — exit 0 (no new errors; pre-existing size warnings unchanged)
- [x] `yaml.safe_load()` round-trip on every modified SKILL.md — all parse cleanly (double-quoted form used for descriptions containing `:`)
- [x] Token-impact measurement reproduced via `git show <merge-base>:<path>` vs current
- [ ] Reviewer check: do the rewritten descriptions still feel discoverable for their intended triggers?
- [ ] Spot-check: pick 3–4 skills you use often and confirm the trigger phrase still matches how you'd naturally ask for them.

Refs https://claudefa.st/blog/guide/mechanics/skill-listing-budget