### PR TITLE
docs(git-plugin): document commit-loop pattern and front-load coworker-check

### DIFF
--- a/git-plugin/skills/git-commit-workflow/SKILL.md
+++ b/git-plugin/skills/git-commit-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-16
-modified: 2026-05-09
-reviewed: 2026-04-25
+modified: 2026-05-14
+reviewed: 2026-05-14
 name: git-commit-workflow
 description: "Conventional commit format, staging, and message conventions. Use when writing commit messages, staging files, grouping changes, or auto-detecting linked issues."
 user-invocable: false
@@ -22,6 +22,17 @@ allowed-tools: Bash, Read
 Expert guidance for commit message conventions, staging practices, and commit best practices using conventional commits and explicit staging workflows.
 
 For detailed examples, advanced patterns, and best practices, see [REFERENCE.md](REFERENCE.md).
+
+## Preconditions
+
+Before staging any files — especially for bulk-edit / commit-loop workflows that touch many subdirectories — verify the working tree is yours alone:
+
+| Check | Why | How |
+|-------|-----|-----|
+| Coworker check | Another Claude session in the same checkout may have already pre-staged files (`git commit -a` retry, abandoned staging) that your loop would sweep into the wrong commit. **Run this up front, not opportunistically.** | `SlashCommand` → `/git:coworker-check` |
+| Working tree scoped | Confirm `git status --porcelain` shows only your edits | `git status --porcelain` |
+
+If `/git:coworker-check` returns anything other than `clear`, stop and either move to a fresh worktree (`git worktree add ../<repo>-<task>`) or ask the user before proceeding. See `.claude/rules/agent-coworker-detection.md` for the four detection signals.
 
 ## Core Expertise
 
@@ -132,9 +143,56 @@ git diff --cached  # Review actual changes
 git commit -m "feat(auth): add OAuth2 support"
 ```
 
-## Commit Message Formatting
+## Bulk-edit / per-plugin commit loops
 
-### HEREDOC Pattern (Required)
+When a single change touches many subdirectories (per-plugin, per-package, per-doc) and each needs its own scoped commit for release-please, write a one-shot script rather than chaining commands inline.
+
+### Why inline loops fail
+
+| Pattern | What blocks it |
+|---------|----------------|
+| `for d in a b c; do git add "$d/" && git commit -m "..."; done` | `bash-antipatterns.sh` blocks `git add ... && git commit ...` — chaining index-modifying git commands risks an `index.lock` race condition |
+| `git add -A`, `git add --all`, `git add .` | `bash-antipatterns.sh` blocks broad staging — sweeps in `.env`, large binaries, and **any coworker session's in-flight files** in a shared checkout (see `.claude/rules/agent-coworker-detection.md`) |
+| Repeating `git add <paths>; git commit -m "..."` as separate Bash tool calls per plugin | Works, but ~3 tool calls × N plugins becomes hundreds of round-trips for a 40-plugin sweep |
+
+### Canonical recipe
+
+Write the loop to `/tmp/commit-loop-<slug>.sh`, then run it in **one** Bash call. The hook treats the file as a script, not a chain — index-modifying commands are sequential within bash, not racing through separate tool invocations.
+
+```bash
+#!/bin/bash
+# /tmp/commit-loop-trim-descriptions.sh
+set -uo pipefail
+cd "$REPO_ROOT" || exit 1
+
+for p in plugin-a plugin-b plugin-c; do
+  # Skip plugins with nothing staged or modified inside them
+  [ -z "$(git status --porcelain "$p/")" ] && continue
+
+  git add "$p/skills/"            # explicit path, never -A or .
+  git commit -m "docs($p): trim skill descriptions for listing budget"
+done
+```
+
+Invoke once:
+
+```bash
+bash /tmp/commit-loop-trim-descriptions.sh
+```
+
+Each iteration runs pre-commit hooks and produces a clean per-plugin commit. Use `;` or newlines (not `&&`) between `git add` and `git commit` inside the script.
+
+### Failure recovery
+
+If the loop aborts mid-way (a pre-commit hook fails on plugin K of N), the commits for plugins 1..K-1 have **already landed** — they are not rolled back. Recovery rules:
+
+| Situation | Action |
+|-----------|--------|
+| Pre-commit hook caught a real issue in plugin K | Fix the issue, re-run the script — the `[ -z ... ] && continue` guard skips plugins with no remaining changes |
+| Script re-run picks up plugin K's leftover staged paths | Good — the unstaged-or-staged check via `git status --porcelain "$p/"` catches both |
+| You want to skip plugin K and continue | Edit the script to remove plugin K from the list, re-run |
+
+Do **not** re-stage paths that already committed cleanly; `git status` is the source of truth for what's left.
 
 **ALWAYS use HEREDOC directly in git commit.**
 

--- a/git-plugin/skills/git-coworker-check/SKILL.md
+++ b/git-plugin/skills/git-coworker-check/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: git-coworker-check
-description: "Detect coworker Claude agents before destructive git ops (stash, reset, checkout). Use when starting a session in a shared checkout or before working-tree cleanup."
+description: "Detect coworker Claude agents in a shared checkout. Use when starting a session in a shared clone, before destructive git ops (stash, reset, checkout), or before bulk-edit / commit-loop workflows."
 args: "[--check | --claim | --release]"
 argument-hint: "[--claim | --release | --check (default)]"
 allowed-tools: Bash(bash *), Bash(git status *), Bash(git stash *), Bash(git rev-parse *), Read, TodoWrite
 created: 2026-04-21
-modified: 2026-05-09
-reviewed: 2026-05-09
+modified: 2026-05-14
+reviewed: 2026-05-14
 ---
 
 # /git:coworker-check
@@ -21,9 +21,24 @@ destructive operations that could destroy its uncommitted changes.
 | Session starts in a clone that may already be in use | You control the session and can create `git worktree add ../<task>` |
 | About to run `git stash`, `git reset --hard`, `git checkout -- .` | You already know the working tree is yours alone |
 | `git status` shows files you don't remember touching | Baseline + markers are already confirming you are alone |
+| **Bulk-edit / commit-loop fan-out** about to start (per-plugin, per-package commits across many subdirectories) | Each iteration is already isolated in its own worktree |
 
 See `.claude/rules/agent-coworker-detection.md` for the full rationale and
 signal design.
+
+## Bulk-edit / commit-loop precondition
+
+Bulk-edit and commit-loop workflows (`git-commit-workflow` "Bulk-edit / per-plugin commit loops", per-package release-please loops, mass refactors) **MUST** run this check **up front, before staging any files** — not opportunistically partway through.
+
+**Why front-loaded, not opportunistic.** A real divergence scenario from the field: two Claude sessions converged on the same trim-descriptions task. Session A used `general-purpose` subagents in the main checkout; session B used worktrees + per-plugin commits. Session B landed 11 clean per-plugin commits and stopped. Session A's first commit then grabbed **all 30 remaining plugins** in a single mega-commit, because session A had previously hit a `git commit -a` failure that left everything pre-staged, and session B's loop never noticed because it ran `/git:coworker-check` *during* its work rather than *before*. The end result was correct, but the commit history said `docs(configure-plugin): ...` for changes spanning 30 plugins.
+
+The rule: **the orchestrator stops before fan-out if the playing field is contended.** Mid-loop checks let "the agent who happens to look first wins" — which is non-deterministic and produces misleading commit histories.
+
+| Verdict from up-front check | What to do |
+|-----------------------------|-----------|
+| `clear` | Proceed with the bulk-edit / commit loop |
+| `drift_detected` | Inspect the new files. If they are yours from earlier in the session, proceed with explicit paths. If unknown, stop and ask. |
+| `coworker_detected` | **Stop.** Recommend `git worktree add ../<repo>-<task>` for a fresh isolated checkout, or wait for the other session to finish. Do not start the loop. |
 
 ## Context
 
@@ -117,12 +132,15 @@ Print a short summary:
 
 ## Integration
 
-Other git-plugin skills should invoke this via SlashCommand before destructive operations:
+Other git-plugin skills should invoke this via SlashCommand before destructive operations or fan-out:
 
 ```markdown
-Before staging: Use SlashCommand to invoke `/git:coworker-check`.
+Before staging (or before starting a per-plugin commit loop):
+Use SlashCommand to invoke `/git:coworker-check`.
 If the verdict is not `clear`, stop and ask the user how to proceed.
 ```
+
+Bulk-edit / commit-loop skills (`git-commit-workflow`, per-plugin release-please loops, mass refactors) must invoke this **before staging any files** — see the "Bulk-edit / commit-loop precondition" section above for why an opportunistic mid-loop check is insufficient.
 
 Hook-based enforcement (blocking `git stash` / `git reset --hard` when a coworker is detected) belongs in `hooks-plugin`, not here.
 
@@ -138,6 +156,7 @@ Hook-based enforcement (blocking `git stash` / `git reset --hard` when a coworke
 
 - `/git:maintain` — invokes this before any stash/clean operation
 - `/git:commit` — invokes this before staging when working in a shared checkout
+- `git-commit-workflow` — invokes this as a precondition for bulk-edit / per-plugin commit loops
 - `git-branch-pr-workflow` — recommends worktrees as the structural fix
 - `/taskwarrior:task-claim` — sister signal; writes the `+ACTIVE` claim that this skill now reads
 - `/taskwarrior:task-release` — drops the claim that contributes to `TW_CLAIM_COUNT`


### PR DESCRIPTION
## Summary

Two cross-linked skill edits in `git-plugin`, no behaviour change.

- **`git-commit-workflow/SKILL.md`** — adds a **Preconditions** section pointing to `/git:coworker-check` before any staging, and a **Bulk-edit / per-plugin commit loops** section that:
  - Explains *why* inline `git add ... && git commit ...` is blocked (the `bash-antipatterns.sh` hook flags `git X && git Y` for index.lock race risk).
  - Explains *why* `git add -A` / `git add --all` / `git add .` are blocked (broad-staging hook; also sweeps coworker changes in a shared checkout — cross-links `.claude/rules/agent-coworker-detection.md`).
  - Gives the canonical `/tmp/commit-loop-<slug>.sh` recipe with a ~10-line inline template and a failure-recovery table.
- **`git-coworker-check/SKILL.md`** — expanded description and "When to Use" row for bulk-edit / commit-loop fan-out, plus a new **Bulk-edit / commit-loop precondition** section with the divergence scenario from #1276 (308-file omnibus commit caused by a mid-loop check) and a verdict-to-action table.

Cross-references between the two skills (Related Skills, Integration) updated. `modified:` and `reviewed:` dates bumped to 2026-05-14.

Closes #1275
Closes #1276

## Test plan

- [x] `bash scripts/plugin-compliance-check.sh git-plugin` — `git-commit-workflow` and `git-coworker-check` pass description, frontmatter, body, when-to-use, and bash-patterns checks. Only the existing size WARN on `git-commit-workflow` (263 lines, in the 251–500 advisory band) — shared by most sibling git-plugin skills.
- [x] `pre-commit run --files git-plugin/skills/git-commit-workflow/SKILL.md git-plugin/skills/git-coworker-check/SKILL.md` — lint-context-commands, audit-skill-descriptions, secrets-scan all pass on the changed files.
- [ ] Reviewer spot-check: the `/tmp/commit-loop-<slug>.sh` template should match what the bash-antipatterns hook actually allows (script body bypasses the `git X && git Y` chain check because it runs as a single bash invocation).
- [ ] Reviewer spot-check: the divergence scenario in `git-coworker-check` accurately reproduces the #1276 evidence.

## Notes

- Pre-existing pre-commit failure unrelated to this PR: `check-driver-freshness` flags `configure-plugin/skills/configure-repo/SKILL.md` against `hooks-plugin/skills/hooks-session-start-hook/SKILL.md` (modified 2026-05-11, driver reviewed 2026-05-09). Not introduced here; should be tracked separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_016vKMVRDNSkeFrZbGWhdC8q)_