### PR TITLE
docs(git-plugin): add coworker-check success example from #1277

### DIFF
--- a/git-plugin/skills/git-coworker-check/SKILL.md
+++ b/git-plugin/skills/git-coworker-check/SKILL.md
@@ -40,6 +40,12 @@ The rule: **the orchestrator stops before fan-out if the playing field is conten
 | `drift_detected` | Inspect the new files. If they are yours from earlier in the session, proceed with explicit paths. If unknown, stop and ask. |
 | `coworker_detected` | **Stop.** Recommend `git worktree add ../<repo>-<task>` for a fresh isolated checkout, or wait for the other session to finish. Do not start the loop. |
 
+### Worked example: detection enables defensive restoration (#1277)
+
+A second positive scenario from the field — the "stop and inspect" rather than "stop and abort" branch. A description-trimming refactor agent ran in a checkout that already had ~7 active `claude` processes touching the same files. The `coworker_detected` verdict fired off the **process-scan signal** alone (the `ps`-based fallback, well before any taskwarrior coordination existed for this batch). Per the verdict-to-action table above, the agent did not stash or reset; it scoped its pass to the remaining 17 files and inspected the coworker's already-landed edits before writing.
+
+That inspection caught a real regression: in `git-fork-workflow`, the coworker had cut the description from 358 → 240 chars and dropped the sibling cross-reference `For creating upstream PRs, see git-upstream-pr`. The agent re-added the line on its own pass. Eight other skills had a stale `modified:` date for the same reason and were stamped forward. No work was lost; a silent cross-reference regression became an explicit recovery. `Evidence: issue #1277.`
+
 ## Context
 
 - Repo root: !`git rev-parse --show-toplevel`


### PR DESCRIPTION
## Summary

Adds a worked-example subsection to `git-plugin/skills/git-coworker-check/SKILL.md` that complements PR #1316's negative case (commit-loop divergence from #1276) with a concrete prevention case from #1277:

- A `claude` process-scan signal alone fired `coworker_detected` in a checkout with ~7 active sibling sessions.
- Per the verdict-to-action table from #1316, the agent did not stash/reset; it scoped its pass to the remaining files and inspected what the coworker had landed.
- Inspection caught a stripped sibling cross-reference in `git-fork-workflow` (358 → 240 chars) and the agent restored "For creating upstream PRs, see git-upstream-pr".

The example sits directly under the existing "Bulk-edit / commit-loop precondition" section so the negative (#1276 / PR #1316) and positive (#1277) cases are colocated. Bumps `modified:` and `reviewed:` to today's date (already at 2026-05-14 from #1316). SKILL.md is now 168 lines, well under the 500-line ceiling.

Closes #1277

## Test plan

- [ ] `pre-commit run --files git-plugin/skills/git-coworker-check/SKILL.md` passes (note: the known `check-driver-freshness` hook may flag pre-existing failures unrelated to this change)
- [ ] `wc -l git-plugin/skills/git-coworker-check/SKILL.md` reports ≤ 250
- [ ] PR title follows conventional commit format (`docs(git-plugin): …`)

https://claude.ai/code/session_016vKMVRDNSkeFrZbGWhdC8q

---
_Generated by [Claude Code](https://claude.ai/code/session_016vKMVRDNSkeFrZbGWhdC8q)_