### PR TITLE
fix(health-plugin): strip CRLF from jq output for Windows compatibility

### DIFF
--- a/health-plugin/skills/health-check/scripts/check-plugins.sh
+++ b/health-plugin/skills/health-check/scripts/check-plugins.sh
@@ -73,8 +73,8 @@ fi
 
 echo "REGISTRY_VALID=true"
 
-# Count plugins
-plugin_count=$(jq '.plugins | length' "$registry_file" 2>/dev/null || echo "0")
+# Count plugins (tr -d '\r' to strip Windows CR from jq output)
+plugin_count=$(jq '.plugins | length' "$registry_file" 2>/dev/null | tr -d '\r' || echo "0")
 echo "PLUGIN_COUNT=${plugin_count}"
 
 # Count by scope
@@ -82,13 +82,15 @@ project_scoped=0
 global_scoped=0
 orphaned_count=0
 
-# Extract plugin entries with project paths
-plugin_keys=$(jq -r '.plugins | keys[]' "$registry_file" 2>/dev/null)
+# Extract plugin entries with project paths.
+# tr -d '\r' strips CR line endings that jq emits on Windows; without it,
+# every key but the last carries a trailing \r and breaks subsequent lookups.
+plugin_keys=$(jq -r '.plugins | keys[]' "$registry_file" 2>/dev/null | tr -d '\r')
 
 while IFS= read -r plugin_key; do
   [ -z "$plugin_key" ] && continue
 
-  plugin_path=$(jq -r ".plugins[\"${plugin_key}\"][0].projectPath // \"\"" "$registry_file" 2>/dev/null)
+  plugin_path=$(jq -r ".plugins[\"${plugin_key}\"][0].projectPath // \"\"" "$registry_file" 2>/dev/null | tr -d '\r')
 
   if [ -n "$plugin_path" ]; then
     project_scoped=$((project_scoped + 1))
@@ -117,11 +119,11 @@ echo "ORPHANED_ENTRIES=${orphaned_count}"
 
 # Check enabled plugins vs installed plugins
 if [ -f "$user_settings" ]; then
-  enabled_count=$(jq '.enabledPlugins // {} | length' "$user_settings" 2>/dev/null || echo "0")
+  enabled_count=$(jq '.enabledPlugins // {} | length' "$user_settings" 2>/dev/null | tr -d '\r' || echo "0")
   echo "ENABLED_IN_SETTINGS=${enabled_count}"
 
-  # Find enabled but not installed
-  enabled_keys=$(jq -r '.enabledPlugins // {} | keys[]' "$user_settings" 2>/dev/null)
+  # Find enabled but not installed (tr -d '\r' for Windows CRLF, see comment above)
+  enabled_keys=$(jq -r '.enabledPlugins // {} | keys[]' "$user_settings" 2>/dev/null | tr -d '\r')
   while IFS= read -r enabled_key; do
     [ -z "$enabled_key" ] && continue
     if ! jq -e ".plugins[\"${enabled_key}\"]" "$registry_file" >/dev/null 2>&1; then
@@ -131,12 +133,12 @@ if [ -f "$user_settings" ]; then
     fi
   done <<< "$enabled_keys"
 
-  # Find disabled plugins
-  disabled_count=$(jq '[.enabledPlugins // {} | to_entries[] | select(.value == false)] | length' "$user_settings" 2>/dev/null || echo "0")
+  # Find disabled plugins (tr -d '\r' so the numeric compare below works on Windows)
+  disabled_count=$(jq '[.enabledPlugins // {} | to_entries[] | select(.value == false)] | length' "$user_settings" 2>/dev/null | tr -d '\r' || echo "0")
   if [ "$disabled_count" -gt 0 ]; then
     echo "DISABLED_PLUGINS=${disabled_count}"
     if [ "$verbose_mode" = true ]; then
-      jq -r '.enabledPlugins // {} | to_entries[] | select(.value == false) | .key' "$user_settings" 2>/dev/null | while IFS= read -r disabled_name; do
+      jq -r '.enabledPlugins // {} | to_entries[] | select(.value == false) | .key' "$user_settings" 2>/dev/null | tr -d '\r' | while IFS= read -r disabled_name; do
         echo "  DISABLED: ${disabled_name}"
       done
     fi
@@ -156,7 +158,7 @@ if [ "$fix_mode" = true ] && [ "$orphaned_count" -gt 0 ]; then
   jq_filter='.plugins'
   while IFS= read -r plugin_key; do
     [ -z "$plugin_key" ] && continue
-    plugin_path=$(jq -r ".plugins[\"${plugin_key}\"][0].projectPath // \"\"" "$registry_file" 2>/dev/null)
+    plugin_path=$(jq -r ".plugins[\"${plugin_key}\"][0].projectPath // \"\"" "$registry_file" 2>/dev/null | tr -d '\r')
     if [ -n "$plugin_path" ] && [ ! -d "$plugin_path" ]; then
       jq_filter="${jq_filter} | del(.\"${plugin_key}\")"
       echo "FIX_REMOVED=${plugin_key}"

--- a/health-plugin/skills/health-plugins/scripts/check-registry.sh
+++ b/health-plugin/skills/health-plugins/scripts/check-registry.sh
@@ -70,7 +70,7 @@ fi
 
 echo "REGISTRY_VALID=true"
 
-plugin_count=$(jq '.plugins | length' "$registry_file" 2>/dev/null || echo "0")
+plugin_count=$(jq '.plugins | length' "$registry_file" 2>/dev/null | tr -d '\r' || echo "0")
 echo "PLUGIN_COUNT=${plugin_count}"
 
 issue_count=0
@@ -81,17 +81,19 @@ global_scoped=0
 orphaned_count=0
 other_project_count=0
 
+# tr -d '\r' strips CR line endings that jq emits on Windows; without it,
+# every key but the last carries a trailing \r and breaks subsequent lookups.
 if [ -n "$target_plugin" ]; then
-  plugin_keys=$(jq -r --arg k "$target_plugin" '.plugins | keys[] | select(. == $k or startswith($k + "@"))' "$registry_file" 2>/dev/null)
+  plugin_keys=$(jq -r --arg k "$target_plugin" '.plugins | keys[] | select(. == $k or startswith($k + "@"))' "$registry_file" 2>/dev/null | tr -d '\r')
 else
-  plugin_keys=$(jq -r '.plugins | keys[]' "$registry_file" 2>/dev/null)
+  plugin_keys=$(jq -r '.plugins | keys[]' "$registry_file" 2>/dev/null | tr -d '\r')
 fi
 
 echo "=== PLUGINS ==="
 while IFS= read -r plugin_key; do
   [ -z "$plugin_key" ] && continue
 
-  plugin_path=$(jq -r --arg k "$plugin_key" '.plugins[$k][0].projectPath // ""' "$registry_file" 2>/dev/null)
+  plugin_path=$(jq -r --arg k "$plugin_key" '.plugins[$k][0].projectPath // ""' "$registry_file" 2>/dev/null | tr -d '\r')
   plugin_source=$(jq -r --arg k "$plugin_key" '.plugins[$k][0].source // "unknown"' "$registry_file" 2>/dev/null)
   plugin_scope=$(jq -r --arg k "$plugin_key" '.plugins[$k][0].scope // "user"' "$registry_file" 2>/dev/null)
   plugin_version=$(jq -r --arg k "$plugin_key" '.plugins[$k][0].version // "unknown"' "$registry_file" 2>/dev/null)
@@ -124,7 +126,7 @@ echo "OTHER_PROJECT_ENTRIES=${other_project_count}"
 
 stale_enabled_count=0
 if [ -f "$user_settings" ]; then
-  enabled_count=$(jq '.enabledPlugins // {} | length' "$user_settings" 2>/dev/null || echo "0")
+  enabled_count=$(jq '.enabledPlugins // {} | length' "$user_settings" 2>/dev/null | tr -d '\r' || echo "0")
   echo "ENABLED_IN_SETTINGS=${enabled_count}"
 
   # Collect marketplace plugin names (if any marketplaces are configured).
@@ -133,13 +135,14 @@ if [ -f "$user_settings" ]; then
   if [ -d "$marketplaces_dir" ]; then
     while IFS= read -r mp_file; do
       [ -z "$mp_file" ] && continue
-      mp_plugins=$(jq -r '.plugins[]?.name // empty' "$mp_file" 2>/dev/null)
+      # tr -d '\r' so the names match cleanly under grep -Fxq on Windows
+      mp_plugins=$(jq -r '.plugins[]?.name // empty' "$mp_file" 2>/dev/null | tr -d '\r')
       marketplace_names="${marketplace_names}
 ${mp_plugins}"
     done < <(find "$marketplaces_dir" -maxdepth 3 -name '*.json' -type f 2>/dev/null)
   fi
 
-  enabled_keys=$(jq -r '.enabledPlugins // {} | keys[]' "$user_settings" 2>/dev/null)
+  enabled_keys=$(jq -r '.enabledPlugins // {} | keys[]' "$user_settings" 2>/dev/null | tr -d '\r')
   while IFS= read -r enabled_key; do
     [ -z "$enabled_key" ] && continue
 

--- a/health-plugin/skills/health-plugins/scripts/test-fix-registry.sh
+++ b/health-plugin/skills/health-plugins/scripts/test-fix-registry.sh
@@ -129,5 +129,84 @@ if ! grep -q '^RESTART_REQUIRED=true$' <<<"$output"; then
 fi
 pass "RESTART_REQUIRED=true emitted in dry-run"
 
+# -----------------------------------------------------------------------------
+# Guard 3: Windows CRLF regression for check-plugins.sh and check-registry.sh
+# (issue #1330) — simulate jq emitting CRLF line endings and verify the scripts
+# do NOT flag every-key-but-the-last as enabled_not_installed / stale.
+# -----------------------------------------------------------------------------
+crlf_dir="${tmp_dir}/crlf"
+mkdir -p "$crlf_dir/.claude/plugins"
+
+cat > "${crlf_dir}/.claude/plugins/installed_plugins.json" <<'JSON'
+{
+  "version": 2,
+  "plugins": {
+    "alpha-plugin@test-mp": [{"scope": "user", "version": "1.0.0"}],
+    "beta-plugin@test-mp": [{"scope": "user", "version": "1.0.0"}],
+    "gamma-plugin@test-mp": [{"scope": "user", "version": "1.0.0"}]
+  }
+}
+JSON
+
+cat > "${crlf_dir}/.claude/settings.json" <<'JSON'
+{
+  "enabledPlugins": {
+    "alpha-plugin@test-mp": true,
+    "beta-plugin@test-mp": true,
+    "gamma-plugin@test-mp": true
+  }
+}
+JSON
+
+# Wrap jq with a stub that appends \r to every output line, emulating Windows.
+jq_stub_dir="${tmp_dir}/jq-crlf-stub"
+mkdir -p "$jq_stub_dir"
+real_jq="$(command -v jq)"
+cat > "${jq_stub_dir}/jq" <<EOF
+#!/usr/bin/env bash
+# Test stub: forwards to real jq but rewrites LF -> CRLF on stdout
+# to reproduce Windows behaviour.
+"${real_jq}" "\$@" | sed 's/\$/\r/'
+EOF
+chmod +x "${jq_stub_dir}/jq"
+
+check_plugins="${script_dir}/../../health-check/scripts/check-plugins.sh"
+
+crlf_output=$(PATH="${jq_stub_dir}:$PATH" bash "$check_plugins" \
+  --home-dir "$crlf_dir" --project-dir "$crlf_dir")
+
+# With the fix, none of the three enabled plugins should be flagged.
+if grep -q 'TYPE=enabled_not_installed' <<<"$crlf_output"; then
+  echo "--- check-plugins.sh CRLF output ---" >&2
+  echo "$crlf_output" >&2
+  echo "------------------------------------" >&2
+  fail "check-plugins.sh produced enabled_not_installed false positives under CRLF jq output (issue #1330 regression)"
+fi
+if ! grep -q '^STATUS=OK$' <<<"$crlf_output"; then
+  echo "--- check-plugins.sh CRLF output ---" >&2
+  echo "$crlf_output" >&2
+  echo "------------------------------------" >&2
+  fail "check-plugins.sh did not report STATUS=OK under CRLF jq output (issue #1330 regression)"
+fi
+pass "check-plugins.sh survives CRLF jq output"
+
+check_registry="${script_dir}/check-registry.sh"
+crlf_reg_output=$(PATH="${jq_stub_dir}:$PATH" bash "$check_registry" \
+  --home-dir "$crlf_dir" --project-dir "$crlf_dir")
+
+if grep -qE 'TYPE=(enabled_not_installed|stale_enabled)' <<<"$crlf_reg_output"; then
+  echo "--- check-registry.sh CRLF output ---" >&2
+  echo "$crlf_reg_output" >&2
+  echo "-------------------------------------" >&2
+  fail "check-registry.sh produced stale/enabled-not-installed false positives under CRLF jq output (issue #1330 regression)"
+fi
+if ! grep -q '^STATUS=OK$' <<<"$crlf_reg_output"; then
+  echo "--- check-registry.sh CRLF output ---" >&2
+  echo "$crlf_reg_output" >&2
+  echo "-------------------------------------" >&2
+  fail "check-registry.sh did not report STATUS=OK under CRLF jq output (issue #1330 regression)"
+fi
+pass "check-registry.sh survives CRLF jq output"
+
 echo "ALL CHECKS PASSED"
 exit 0


### PR DESCRIPTION
## Summary

Fixes #1330 — on Windows, `jq` emits CRLF line endings, and bash's `while IFS= read -r ... <<< "$keys"` captures the trailing `\r` on every line but the last. The next `jq` lookup then searches for `github@claude-plugins-official\r`, returns null, and the script emits `TYPE=enabled_not_installed` warnings for 31 of 32 correctly-installed plugins.

## Approach

Pipe each affected `jq` invocation through `tr -d '\r'`. Considered four alternatives — wrapping `jq` as a shell function, stripping `\r` in each `read` loop, a `jq_lines` helper, and the per-site `tr` — and went with the per-site `tr` (the issue's suggestion). It's the canonical bash idiom for cross-platform CRLF handling, has no exit-code interaction with `jq -e` under `pipefail`, and reviewers recognize the intent at a glance.

**Scope is broader than the four lines listed in #1330.** I audited every `jq` call in both scripts and fixed each one whose output flows into either:

- a multi-line `while read` loop (the original bug),
- a single-value test like `[ -d "$plugin_path" ]` (would treat `path\r` as a missing directory on Windows),
- a `grep -Fxq` exact-line match (`mp_plugins` → marketplace name lookup), or
- a numeric comparison like `[ "$disabled_count" -gt 0 ]` (would fail with `integer expression expected: 0\r`).

| File | Fixed sites |
|---|---|
| `health-plugin/skills/health-check/scripts/check-plugins.sh` | L77 (`plugin_count`), L86 (`plugin_keys`), L91 (`plugin_path` inline), L122 (`enabled_count`), L126 (`enabled_keys`), L137 (`disabled_count`), L141 (`disabled_name` pipe), L159 (`plugin_path` in fix loop) |
| `health-plugin/skills/health-plugins/scripts/check-registry.sh` | L73 (`plugin_count`), L86–88 (both `plugin_keys` branches), L94 (`plugin_path`), L127 (`enabled_count`), L137 (`mp_plugins` for grep), L143 (`enabled_keys`) |

## Regression test

Per `.claude/rules/regression-testing.md` (semantic gate preferred over syntactic), added a CRLF guard to `test-fix-registry.sh` that:

1. Builds a synthetic registry + settings with three enabled plugins.
2. Stubs `jq` with a wrapper script that pipes real-jq output through `sed 's/$/\r/'`, emulating Windows.
3. Runs `check-plugins.sh` and `check-registry.sh` against the stubbed `PATH`.
4. Asserts `STATUS=OK` and absence of `TYPE=enabled_not_installed` / `TYPE=stale_enabled` lines.

Without the fix, both assertions fire and the test fails — confirmed locally before applying the source-side `tr -d '\r'` calls.

## Test plan

- [x] `bash health-plugin/skills/health-plugins/scripts/test-fix-registry.sh` passes locally (all 8 guards green, including the new CRLF guard).
- [x] Both scripts still run cleanly under normal LF input (smoke-tested against the sandbox's empty registry — early-out path produces `STATUS=WARN missing_registry` as before).
- [ ] Reviewer with a Windows machine confirms `/health:check` no longer flags the 31 false-positive `enabled_not_installed` warnings.

---
_Generated by [Claude Code](https://claude.ai/code/session_018ucHL53LLC1moffCovazKR)_