### PR TITLE
feat(git-repo-agent): add `claude [feedback]` handoff to fix selection

### DIFF
--- a/git-repo-agent/src/git_repo_agent/orchestrator.py
+++ b/git-repo-agent/src/git_repo_agent/orchestrator.py
@@ -3,10 +3,13 @@
 import json
 import logging
 import signal
+import subprocess
 import sys
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from pathlib import Path
+from typing import Literal
 
 from claude_agent_sdk import (
     AssistantMessage,
@@ -540,19 +543,25 @@ async def run_onboard(
         prompt = " ".join(prompt_parts)
 
         if interactive:
-            agent_output = await _stream_interactive(
-                prompt,
-                options,
-                "Onboarding complete.",
-                user_input_label=(
-                    "[bold]Apply onboarding plan?[/bold] "
-                    "(comma-separated numbers, [green]all[/green], or "
-                    "[yellow]none[/yellow]): "
-                ),
-                build_phase2_prompt=_build_onboard_phase2_prompt,
-                worktree_branch=branch,
-                none_message="No onboarding actions selected.",
-            )
+            try:
+                agent_output = await _stream_interactive(
+                    prompt,
+                    options,
+                    "Onboarding complete.",
+                    user_input_label=(
+                        "[bold]Apply onboarding plan?[/bold] "
+                        "(comma-separated numbers, [green]all[/green], "
+                        "[yellow]none[/yellow], or [cyan]claude[/cyan] "
+                        "[optional feedback]): "
+                    ),
+                    build_phase2_prompt=_build_onboard_phase2_prompt,
+                    workflow="onboard",
+                    worktree_path=work_dir,
+                    worktree_branch=branch,
+                    none_message="No onboarding actions selected.",
+                )
+            except HandoffRequested:
+                return
         elif non_interactive is not None:
             agent_output = await _stream_messages_collecting(
                 prompt, options, "Onboarding complete.",
@@ -707,19 +716,25 @@ async def run_maintain(
         prompt = " ".join(prompt_parts)
 
         if interactive:
-            collected = await _stream_interactive(
-                prompt,
-                options,
-                "Maintenance complete.",
-                user_input_label=(
-                    "[bold]Select fixes to apply[/bold] "
-                    "(comma-separated numbers, [green]all[/green], or "
-                    "[yellow]none[/yellow]): "
-                ),
-                build_phase2_prompt=_build_maintain_phase2_prompt,
-                worktree_branch=branch,
-                none_message="No fixes selected.",
-            )
+            try:
+                collected = await _stream_interactive(
+                    prompt,
+                    options,
+                    "Maintenance complete.",
+                    user_input_label=(
+                        "[bold]Select fixes to apply[/bold] "
+                        "(comma-separated numbers, [green]all[/green], "
+                        "[yellow]none[/yellow], or [cyan]claude[/cyan] "
+                        "[optional feedback]): "
+                    ),
+                    build_phase2_prompt=_build_maintain_phase2_prompt,
+                    workflow="maintain",
+                    worktree_path=work_dir,
+                    worktree_branch=branch,
+                    none_message="No fixes selected.",
+                )
+            except HandoffRequested:
+                return
         else:
             collected = await _stream_messages_collecting(
                 prompt, options, "Maintenance complete.",
@@ -1020,6 +1035,141 @@ async def _stream_messages_collecting(
 
 
 _NONE_CHOICES = ("none", "n", "no", "")
+_HANDOFF_KEYWORDS = ("claude",)
+
+
+@dataclass(frozen=True)
+class UserChoice:
+    """Tagged selection-prompt result.
+
+    ``kind`` distinguishes the three branches the interlude can take:
+    ``"handoff"`` means the user wants to hand control to Claude Code in
+    the worktree; ``"none"`` means skip Phase 2 entirely; ``"select"``
+    means the LLM should parse ``raw`` as a selection list (numbers /
+    ``all`` / ``yes``).
+    """
+
+    kind: Literal["select", "none", "handoff"]
+    raw: str
+    feedback: str = ""
+
+
+def _parse_user_choice(raw: str) -> UserChoice:
+    """Parse the selection-prompt input into a tagged ``UserChoice``.
+
+    Recognises three kinds:
+
+    * ``"handoff"`` — first whitespace-delimited token is ``claude``
+      (case-insensitive). Anything after the first whitespace is treated
+      as free-text feedback for Claude Code.
+    * ``"none"`` — input matches ``_NONE_CHOICES`` after strip+lower.
+    * ``"select"`` — everything else; the LLM parses the actual numbers
+      in Phase 2.
+
+    The first-token check is deliberate: ``"1,2,claude"`` parses as
+    ``select`` (the leading ``1`` is not ``claude``); ``"claude"`` alone
+    is a clean handoff with empty feedback.
+    """
+    stripped = raw.strip()
+    tokens = stripped.split(maxsplit=1)
+    first = tokens[0].lower() if tokens else ""
+    if first in _HANDOFF_KEYWORDS:
+        feedback = tokens[1].strip() if len(tokens) > 1 else ""
+        return UserChoice(kind="handoff", raw=raw, feedback=feedback)
+    if stripped.lower() in _NONE_CHOICES:
+        return UserChoice(kind="none", raw=raw)
+    return UserChoice(kind="select", raw=raw)
+
+
+class HandoffRequested(Exception):
+    """Raised from ``_stream_interactive`` when the user hands off to Claude Code.
+
+    Callers in ``run_maintain`` / ``run_onboard`` catch this and return
+    cleanly, skipping the Phase 2 / push / PR pipeline. The worktree is
+    intentionally left intact for the Claude Code session to own.
+    """
+
+
+def _launch_claude_handoff(
+    *,
+    phase1_text: str,
+    feedback: str,
+    worktree_path: Path,
+    worktree_branch: str | None,
+    workflow: str,
+) -> None:
+    """Write a handoff file and launch interactive ``claude`` in the worktree.
+
+    The Phase 1 output and the user's free-text feedback are written to
+    ``<worktree>/.git/git-repo-agent-handoff.md`` (inside ``.git/`` so
+    it's never staged). A short initial prompt referencing that file via
+    ``@`` is passed to ``claude``, which is run with ``cwd`` set to the
+    worktree. The call blocks until the user exits Claude Code.
+
+    On ``FileNotFoundError`` (``claude`` not on PATH) we print a clear
+    message with the handoff file path so the user can run it manually.
+    """
+    handoff_path = worktree_path / ".git" / "git-repo-agent-handoff.md"
+    handoff_path.parent.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now(timezone.utc).isoformat()
+    branch_line = f"- Branch: `{worktree_branch}`\n" if worktree_branch else ""
+    feedback_section = (
+        f"\n## User feedback\n\n{feedback}\n" if feedback else ""
+    )
+
+    handoff_path.write_text(
+        f"# git-repo-agent handoff\n\n"
+        f"- Workflow: `{workflow}`\n"
+        f"{branch_line}"
+        f"- Timestamp: {timestamp}\n"
+        f"- Worktree: `{worktree_path}`\n\n"
+        f"The git-repo-agent orchestrator handed control to you because the "
+        f"suggestions below were not quite right and the user wants to drive "
+        f"from here. The worktree is yours — edit, commit, push, and open a "
+        f"PR as needed. Run `git worktree remove` when done.\n\n"
+        f"## Suggested actions\n\n"
+        f"{phase1_text}\n"
+        f"{feedback_section}\n"
+        f"---\n\n"
+        f"You are now inside the worktree at `{worktree_path}`. "
+        f"All git operations should run from here.\n",
+        encoding="utf-8",
+    )
+
+    initial_prompt = (
+        f"You are taking over a git-repo-agent `{workflow}` run. "
+        f"Read `@.git/git-repo-agent-handoff.md` for the suggestions list "
+        f"and the user's feedback, then help them complete the work in this "
+        f"worktree."
+    )
+
+    console.print(
+        "[bold cyan]Handing off to Claude Code in the worktree...[/bold cyan]"
+    )
+    console.print(f"[dim]Handoff context: {handoff_path}[/dim]")
+    console.print(f"[dim]Worktree: {worktree_path}[/dim]\n")
+
+    try:
+        subprocess.run(
+            ["claude", initial_prompt],
+            cwd=worktree_path,
+            check=False,
+        )
+    except FileNotFoundError:
+        console.print(
+            "[red]`claude` not found on PATH.[/red] "
+            f"The handoff context is at [cyan]{handoff_path}[/cyan]. "
+            f"Run `claude` from [cyan]{worktree_path}[/cyan] manually."
+        )
+        return
+
+    console.print()
+    console.print(
+        f"[bold green]Orchestrator exiting cleanly.[/bold green] "
+        f"The worktree is still at [cyan]{worktree_path}[/cyan] — "
+        f"commit, push, and open a PR from there when ready."
+    )
 
 
 def _build_maintain_phase2_prompt(
@@ -1160,6 +1310,8 @@ async def _stream_interactive(
     completion_msg: str,
     user_input_label: str,
     build_phase2_prompt: Callable[[str, str, str | None], str],
+    workflow: str,
+    worktree_path: Path,
     worktree_branch: str | None = None,
     none_message: str = "No actions selected.",
 ) -> str:
@@ -1179,6 +1331,10 @@ async def _stream_interactive(
     The caller supplies ``build_phase2_prompt`` so that the same plumbing
     serves both maintain (findings → fixes) and onboard (plan → setup).
 
+    When the user's selection is ``claude [feedback]``, ``HandoffRequested``
+    is raised so the caller can skip Phase 2 / push / PR; the worktree is
+    left intact for the Claude Code session that was just launched.
+
     Returns concatenated agent text output from both phases for
     post-processing (PR body, issue creation).
     """
@@ -1193,8 +1349,19 @@ async def _stream_interactive(
     # --- Interlude: prompt user ---
     console.print()
     user_input = console.input(user_input_label)
-    choice = user_input.strip().lower()
-    if choice in _NONE_CHOICES:
+    choice = _parse_user_choice(user_input)
+
+    if choice.kind == "handoff":
+        _launch_claude_handoff(
+            phase1_text=phase1_text,
+            feedback=choice.feedback,
+            worktree_path=worktree_path,
+            worktree_branch=worktree_branch,
+            workflow=workflow,
+        )
+        raise HandoffRequested
+
+    if choice.kind == "none":
         console.print(f"[yellow]{none_message}[/yellow]")
 
     # --- Phase 2: Execution (fresh session) ---

--- a/git-repo-agent/tests/test_handoff.py
+++ b/git-repo-agent/tests/test_handoff.py
@@ -1,0 +1,386 @@
+"""Tests for the Claude Code handoff verb in the selection prompt.
+
+See ``orchestrator.py::_parse_user_choice`` and ``_launch_claude_handoff``.
+The handoff path lets the user type ``claude [optional feedback]`` at the
+fix-selection prompt, which writes a context file inside the worktree
+``.git/`` and launches an interactive ``claude`` session there. Phase 2
+is intentionally skipped — the worktree is left intact for the Claude
+Code session to own.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from git_repo_agent import orchestrator
+from git_repo_agent.orchestrator import (
+    HandoffRequested,
+    _launch_claude_handoff,
+    _parse_user_choice,
+    _stream_interactive,
+)
+
+
+# ---------------------------------------------------------------------------
+# _parse_user_choice
+# ---------------------------------------------------------------------------
+
+
+class TestParseUserChoice:
+    def test_handoff_bare(self):
+        choice = _parse_user_choice("claude")
+        assert choice.kind == "handoff"
+        assert choice.feedback == ""
+
+    def test_handoff_with_feedback(self):
+        choice = _parse_user_choice("claude I want ty not pyright")
+        assert choice.kind == "handoff"
+        assert choice.feedback == "I want ty not pyright"
+
+    def test_handoff_case_insensitive_upper(self):
+        choice = _parse_user_choice("CLAUDE foo")
+        assert choice.kind == "handoff"
+        assert choice.feedback == "foo"
+
+    def test_handoff_case_insensitive_mixed_with_padding(self):
+        choice = _parse_user_choice("  Claude  foo bar  ")
+        assert choice.kind == "handoff"
+        assert choice.feedback == "foo bar"
+
+    def test_only_first_token_triggers_handoff(self):
+        # "1,2,claude" is a regular selection list — the leading token is
+        # "1,2,claude" (no whitespace split) but lower() != "claude" so
+        # it stays a select. Documents the boundary.
+        choice = _parse_user_choice("1,2,claude")
+        assert choice.kind == "select"
+
+    def test_select_numbers(self):
+        choice = _parse_user_choice("1,3,5")
+        assert choice.kind == "select"
+
+    def test_select_all(self):
+        # "all" is not a handoff keyword; LLM parses it in Phase 2.
+        choice = _parse_user_choice("all")
+        assert choice.kind == "select"
+
+    def test_select_yes(self):
+        choice = _parse_user_choice("yes")
+        assert choice.kind == "select"
+
+    def test_none_keyword(self):
+        assert _parse_user_choice("none").kind == "none"
+
+    def test_none_short(self):
+        assert _parse_user_choice("n").kind == "none"
+
+    def test_none_no(self):
+        assert _parse_user_choice("no").kind == "none"
+
+    def test_none_empty(self):
+        assert _parse_user_choice("").kind == "none"
+
+    def test_none_whitespace_only(self):
+        assert _parse_user_choice("   ").kind == "none"
+
+    def test_raw_preserved(self):
+        choice = _parse_user_choice("1,3,5")
+        assert choice.raw == "1,3,5"
+
+    def test_frozen(self):
+        choice = _parse_user_choice("claude")
+        with pytest.raises(Exception):
+            choice.feedback = "mutated"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# _launch_claude_handoff
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _SubprocessCall:
+    args: list[str]
+    cwd: Path | None
+    check: bool
+
+
+def _install_subprocess_mock(monkeypatch) -> list[_SubprocessCall]:
+    """Replace ``subprocess.run`` inside the orchestrator with a capturing stub."""
+    calls: list[_SubprocessCall] = []
+
+    def fake_run(args, cwd=None, check=False, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(_SubprocessCall(args=list(args), cwd=cwd, check=check))
+        return None
+
+    monkeypatch.setattr(orchestrator.subprocess, "run", fake_run)
+    return calls
+
+
+def _make_worktree(tmp_path: Path) -> Path:
+    worktree = tmp_path / "worktree"
+    (worktree / ".git").mkdir(parents=True)
+    return worktree
+
+
+class TestLaunchClaudeHandoff:
+    def test_writes_handoff_file_with_phase1_text(self, monkeypatch, tmp_path):
+        _install_subprocess_mock(monkeypatch)
+        worktree = _make_worktree(tmp_path)
+
+        _launch_claude_handoff(
+            phase1_text="1. fix README\n2. add tests",
+            feedback="",
+            worktree_path=worktree,
+            worktree_branch="maintain/2026-05-22",
+            workflow="maintain",
+        )
+
+        handoff = worktree / ".git" / "git-repo-agent-handoff.md"
+        assert handoff.exists()
+        content = handoff.read_text()
+        assert "1. fix README" in content
+        assert "2. add tests" in content
+        assert "maintain" in content
+        assert "maintain/2026-05-22" in content
+        assert "## Suggested actions" in content
+
+    def test_writes_feedback_section_when_present(self, monkeypatch, tmp_path):
+        _install_subprocess_mock(monkeypatch)
+        worktree = _make_worktree(tmp_path)
+
+        _launch_claude_handoff(
+            phase1_text="1. config pyright",
+            feedback="I want astral ty for type checking, not pyright",
+            worktree_path=worktree,
+            worktree_branch="maintain/x",
+            workflow="maintain",
+        )
+
+        content = (worktree / ".git" / "git-repo-agent-handoff.md").read_text()
+        assert "## User feedback" in content
+        assert "astral ty" in content
+
+    def test_omits_feedback_section_when_empty(self, monkeypatch, tmp_path):
+        _install_subprocess_mock(monkeypatch)
+        worktree = _make_worktree(tmp_path)
+
+        _launch_claude_handoff(
+            phase1_text="1. anything",
+            feedback="",
+            worktree_path=worktree,
+            worktree_branch=None,
+            workflow="onboard",
+        )
+
+        content = (worktree / ".git" / "git-repo-agent-handoff.md").read_text()
+        assert "## User feedback" not in content
+        assert "onboard" in content
+
+    def test_invokes_claude_in_worktree(self, monkeypatch, tmp_path):
+        calls = _install_subprocess_mock(monkeypatch)
+        worktree = _make_worktree(tmp_path)
+
+        _launch_claude_handoff(
+            phase1_text="1. fix",
+            feedback="say hi",
+            worktree_path=worktree,
+            worktree_branch="maintain/2026-05-22",
+            workflow="maintain",
+        )
+
+        assert len(calls) == 1
+        call = calls[0]
+        assert call.args[0] == "claude"
+        # Single positional prompt arg
+        assert len(call.args) == 2
+        assert "@.git/git-repo-agent-handoff.md" in call.args[1]
+        assert "maintain" in call.args[1]
+        assert call.cwd == worktree
+
+    def test_handles_missing_claude_binary(self, monkeypatch, tmp_path, capsys):
+        def fake_run(*args, **kwargs):  # type: ignore[no-untyped-def]
+            raise FileNotFoundError("claude")
+
+        monkeypatch.setattr(orchestrator.subprocess, "run", fake_run)
+        worktree = _make_worktree(tmp_path)
+
+        # Should not raise — graceful fallback message.
+        _launch_claude_handoff(
+            phase1_text="1. fix",
+            feedback="",
+            worktree_path=worktree,
+            worktree_branch=None,
+            workflow="maintain",
+        )
+
+        # Handoff file is still written so the user can use it manually.
+        assert (worktree / ".git" / "git-repo-agent-handoff.md").exists()
+
+    def test_creates_git_dir_if_missing(self, monkeypatch, tmp_path):
+        # If for some reason .git/ doesn't already exist, the helper still
+        # creates the parent directory rather than crashing.
+        _install_subprocess_mock(monkeypatch)
+        worktree = tmp_path / "fresh"
+        worktree.mkdir()
+
+        _launch_claude_handoff(
+            phase1_text="x",
+            feedback="",
+            worktree_path=worktree,
+            worktree_branch=None,
+            workflow="maintain",
+        )
+
+        assert (worktree / ".git" / "git-repo-agent-handoff.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# _stream_interactive — handoff branch
+# ---------------------------------------------------------------------------
+
+
+class _FakeSDKClient:
+    """Replaces ``ClaudeSDKClient`` so Phase 1 / Phase 2 streaming is mocked.
+
+    The Phase 2 client should never be opened on the handoff path.
+    """
+
+    instances: list["_FakeSDKClient"] = []
+
+    def __init__(self, options):
+        self.options = options
+        self.queries: list[str] = []
+        _FakeSDKClient.instances.append(self)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def query(self, prompt: str) -> None:
+        self.queries.append(prompt)
+
+    async def receive_response(self):
+        from claude_agent_sdk import AssistantMessage, TextBlock
+
+        yield AssistantMessage(
+            content=[TextBlock(text="1. fix this\n2. fix that")],
+            model="fake-model",
+        )
+
+
+class TestStreamInteractiveHandoff:
+    def test_handoff_raises_and_skips_phase2(self, monkeypatch, tmp_path):
+        _FakeSDKClient.instances = []
+        monkeypatch.setattr(
+            "git_repo_agent.orchestrator.ClaudeSDKClient", _FakeSDKClient,
+        )
+        # Mock console.input to return the handoff verb.
+        monkeypatch.setattr(
+            orchestrator.console, "input", lambda _label: "claude feedback here",
+        )
+        _install_subprocess_mock(monkeypatch)
+
+        worktree = _make_worktree(tmp_path)
+
+        def _build_phase2(_findings, _selection, _branch):
+            raise AssertionError("Phase 2 prompt builder must not be called")
+
+        with pytest.raises(HandoffRequested):
+            asyncio.run(
+                _stream_interactive(
+                    "Phase 1 prompt",
+                    options=_FakeOptions(),
+                    completion_msg="done",
+                    user_input_label="select: ",
+                    build_phase2_prompt=_build_phase2,
+                    workflow="maintain",
+                    worktree_path=worktree,
+                    worktree_branch="maintain/x",
+                )
+            )
+
+        # Exactly one ClaudeSDKClient was constructed (Phase 1 only).
+        assert len(_FakeSDKClient.instances) == 1
+
+        # Handoff file was written.
+        handoff = worktree / ".git" / "git-repo-agent-handoff.md"
+        assert handoff.exists()
+        content = handoff.read_text()
+        assert "feedback here" in content
+
+
+@dataclass
+class _FakeOptions:
+    """Minimal ClaudeAgentOptions stand-in for ``replace()`` compatibility."""
+
+    system_prompt: str | None = None
+    cwd: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# run_maintain — handoff skips push/PR pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestRunMaintainHandoff:
+    def test_handoff_path_skips_pr_creation(self, monkeypatch, tmp_path):
+        """Integration-style: simulate the handoff path through run_maintain
+        and assert the PR-creation prompt is never reached.
+        """
+        from git_repo_agent.orchestrator import run_maintain
+
+        # Stub out the heavyweight pre-compute step so the test doesn't run
+        # real git/repo analysis.
+        monkeypatch.setattr(
+            orchestrator,
+            "_pre_compute_context",
+            lambda _path: "## Pre-computed analysis (stub)",
+        )
+        monkeypatch.setattr(
+            orchestrator, "get_base_branch", lambda _path: "main",
+        )
+
+        # create_worktree returns a path we control; subsequent helpers
+        # must not be called on the handoff path.
+        worktree = _make_worktree(tmp_path)
+        monkeypatch.setattr(
+            orchestrator,
+            "create_worktree",
+            lambda _repo, _branch: worktree,
+        )
+        monkeypatch.setattr(
+            orchestrator, "_snapshot_parent_sha", lambda _path: "deadbeef",
+        )
+
+        # Track that the PR-creation prompt is never reached.
+        pr_called = []
+
+        async def _pr_called(*args, **kwargs):
+            pr_called.append(True)
+
+        monkeypatch.setattr(orchestrator, "_prompt_pr_creation", _pr_called)
+        monkeypatch.setattr(orchestrator, "_auto_handle_pr", _pr_called)
+
+        # Mock the SDK and console.input
+        _FakeSDKClient.instances = []
+        monkeypatch.setattr(
+            "git_repo_agent.orchestrator.ClaudeSDKClient", _FakeSDKClient,
+        )
+        monkeypatch.setattr(
+            orchestrator.console, "input", lambda _label: "claude",
+        )
+        _install_subprocess_mock(monkeypatch)
+
+        # run_maintain should return cleanly (no exception, no PR call).
+        asyncio.run(run_maintain(tmp_path, fix=False, report_only=False))
+
+        assert pr_called == [], "PR creation must not run on the handoff path"
+
+        # Phase 2 client must not have been opened (only Phase 1).
+        assert len(_FakeSDKClient.instances) == 1


### PR DESCRIPTION
## Summary

When the interactive `git-repo-agent maintain` / `onboard` selection prompt doesn't quite match what the user wants (e.g. the agent suggests `pyright` when the user wants `astral ty`), the only escape today is to abort, copy-paste the partial chat into a fresh Claude Code session, and restart with degraded context.

This adds a third selection verb — `claude [optional inline feedback]` — that hands control to an interactive Claude Code session in the worktree itself:

- Writes Phase 1 output + free-text feedback to `<worktree>/.git/git-repo-agent-handoff.md` (inside `.git/` so it's never staged)
- Launches `claude` with the worktree as `cwd` and an initial prompt that references the handoff file
- Skips Phase 2 entirely and exits the orchestrator cleanly — the user owns the worktree from there

## Design highlights

- **Trigger keyword:** `claude` as the first whitespace-delimited token (case-insensitive). `"1,2,claude"` still parses as a regular selection list.
- **Worktree preserved:** The orchestrator catches `HandoffRequested`, returns early, and leaves the worktree intact. No PR creation, no push, no auto-cleanup.
- **Missing-binary fallback:** If `claude` isn't on PATH, the handoff file is still written and the user is told where to find it.

## Test plan

- [x] 23 new regression tests in `tests/test_handoff.py` (parser, handoff helper, `_stream_interactive` handoff path, `run_maintain` skip-PR integration)
- [x] Full existing test suite still passes (291 tests total)
- [x] No new lint errors introduced (15 errors before and after — all pre-existing)
- [ ] Manual smoke: run `git-repo-agent maintain` against a test repo, type `claude I want astral ty` at the prompt, confirm Claude Code launches in the worktree with the handoff context pre-loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)