### PR TITLE
feat(configure-plugin): add C/C++ row to stack-aware permissions

### DIFF
--- a/configure-plugin/skills/configure-claude-plugins/SKILL.md
+++ b/configure-plugin/skills/configure-claude-plugins/SKILL.md
@@ -112,6 +112,7 @@ Add stack-specific entries based on detected project type:
 | Node / TypeScript | `"Bash(npm:*)"`, `"Bash(pnpm:*)"`, `"Bash(bun:*)"`, `"Bash(tsc:*)"`, `"Bash(eslint:*)"`, `"Bash(prettier:*)"`, `"Bash(vitest:*)"` |
 | Go | `"Bash(go:*)"`, `"Bash(gofmt:*)"`, `"Bash(golangci-lint:*)"` |
 | Rust | `"Bash(cargo:*)"`, `"Bash(rustc:*)"`, `"Bash(clippy:*)"`, `"Bash(rustfmt:*)"` |
+| C / C++ (CMake) | `"Bash(cmake:*)"`, `"Bash(ctest:*)"`, `"Bash(clang-format:*)"`, `"Bash(clang-tidy:*)"`, `"Bash(cppcheck:*)"`, `"Bash(make:*)"`, `"Bash(ninja:*)"` |
 | ESP-IDF / embedded | `"Bash(idf.py:*)"`, `"Bash(esptool:*)"`, `"Bash(clang-format:*)"`, `"Bash(cppcheck:*)"`, `"Bash(docker:*)"`, `"Bash(docker compose:*)"`, `"Bash(just:*)"`, `"Bash(make:*)"` |
 | ESPHome | `"Bash(esphome:*)"`, `"Bash(uv:*)"`, `"Bash(uvx:*)"` |
 


### PR DESCRIPTION
## Summary

Closes #1335

Adds a dedicated **C / C++ (CMake)** row to the "Stack-aware `permissions.allow` baseline" table in `/configure:claude-plugins`, alongside the existing Python / Node / Go / Rust / ESP-IDF / ESPHome rows.

The new row covers `cmake`, `ctest`, `clang-format`, `clang-tidy`, `cppcheck`, `make`, and `ninja` — the standard CMake-based desktop C/C++ toolchain. Just/justfile coverage is already handled by separate detection logic.

## Why

Native CMake-based projects (not ESP-IDF, not Dockerized) had to derive the allowlist by hand. The ESP-IDF row bundles `idf.py`, `esptool`, `docker`, and `docker compose`, which are irrelevant for desktop C and add unnecessary permission surface.

This pairs naturally with PR #1360 (just merged) which added the `CMakeLists.txt` row to the recommended-plugins table — the two tables now have consistent C/C++ coverage.

## Test plan

- [x] Verify the new row renders inline with surrounding rows
- [x] Confirm `clang-format` / `cppcheck` overlap with the ESP-IDF row is intentional (both stacks legitimately use them)
- [ ] Spot-check by re-running `/configure:claude-plugins` against a plain C/CMake project
