### PR TITLE
docs(project-plugin): document plan-mode flow in project-distill Step 4

### DIFF
--- a/feedback-plugin/skills/feedback-session/SKILL.md
+++ b/feedback-plugin/skills/feedback-session/SKILL.md
@@ -7,7 +7,7 @@ model: opus
 argument-hint: "--dry-run | --target-repo owner/repo | plugin-name"
 disable-model-invocation: true
 created: 2026-02-18
-modified: 2026-05-14
+modified: 2026-05-22
 reviewed: 2026-05-14
 ---
 
@@ -210,6 +210,8 @@ Let the user select which findings to file as issues (use multiSelect).
 If `--dry-run`, present findings and stop here.
 
 **Auto mode does not skip this step.** Filing a GitHub issue is not reversible via `git restore` — closing an issue leaves noise in the issue tracker and notifies subscribers. Always confirm the selection set before Step 5, regardless of mode. To skip the prompt entirely, the user can pass `--dry-run` and re-run after reviewing.
+
+**In plan mode**: neither `AskUserQuestion` nor the subsequent `gh issue create` call is permitted — the harness disallows non-readonly tool calls except writes to the active plan file. Write the categorized findings to the active plan file as a single coherent block (one section per finding with category, plugin/skill, description, evidence, and proposed title/body), then call `ExitPlanMode` to surface for user approval. Do not file issues directly. After the user approves the plan, fall back to the default flow: present the selection prompt via `AskUserQuestion` (Step 4) and create the approved issues (Step 5). The `--dry-run` flag remains the fastest way to preview findings without entering plan mode.
 
 ### Step 5: Create approved issues
 

--- a/project-plugin/skills/project-distill/SKILL.md
+++ b/project-plugin/skills/project-distill/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash(git diff *), Bash(git log *), Bash(git status *), Bash(just 
 argument-hint: "--rules | --skills | --recipes | --all | --dry-run"
 args: "[--rules] [--skills] [--recipes] [--all] [--dry-run]"
 created: 2026-02-11
-modified: 2026-05-09
+modified: 2026-05-22
 reviewed: 2026-02-26
 ---
 
@@ -78,6 +78,8 @@ If `--dry-run`: skip this step.
 **In auto mode**: apply proposals directly without per-category `AskUserQuestion`. All targets are reversible via `git restore` — rule files, skill files, and justfile recipes are tracked in git, so a wrong edit can be undone with one command. This matches auto mode's "prefer action over planning" directive. **Retain `AskUserQuestion` for destructive operations** (`[REDUNDANT]` proposals that remove a rule or recipe).
 
 **In manual / interactive mode**: use `AskUserQuestion` to confirm each category before applying. The user can multi-select which `[UPDATE]` / `[NEW]` proposals to accept.
+
+**In plan mode**: neither default applies — the harness disallows non-readonly tool calls (including `AskUserQuestion`-then-apply) except writes to the active plan file. Write the proposal set to the active plan file as a single coherent block (Context + per-category `[UPDATE]` / `[NEW]` / `[REDUNDANT]` sections + a brief verification section), then call `ExitPlanMode` to surface for user approval. Do not apply directly. After the user approves the plan, fall back to the auto-mode or manual-mode flow above depending on which is active.
 
 ### Step 5: Report summary
 


### PR DESCRIPTION
## Summary

- Add a plan-mode clause to Step 4 ("Apply changes") of `project-plugin/skills/project-distill/SKILL.md`, parallel to the existing auto-mode and manual/interactive-mode clauses. Documents the write-to-plan-file-then-`ExitPlanMode` pattern, with fallback to whichever underlying mode is active once approved.
- Mirror the same fix in `feedback-plugin/skills/feedback-session/SKILL.md` Step 4, which also uses `AskUserQuestion` (followed by `gh issue create`) without addressing plan mode. Same write-to-plan-file pattern applies — the `gh issue create` call is similarly blocked under plan mode.
- Bump `modified:` date on both skills.

Analogous to the auto-mode clause added in #1119; the plan-mode case is the next gap in the same pattern.

Closes #1347

## Test plan

- [ ] Re-read both Step 4 sections — auto/manual/plan clauses are parallel and the prose flows
- [ ] Confirm the plan-mode clause directs the reader to write to the active plan file and fall back to auto/manual once approved
- [ ] Pre-commit hooks pass (shellcheck, secrets, lint-context-commands, skill description audits) — verified locally on commit
