### PR TITLE
feat(blueprint-plugin): size-aware artifact generation for tiny projects

### DIFF
--- a/git-repo-agent/src/git_repo_agent/blueprint_driver.py
+++ b/git-repo-agent/src/git_repo_agent/blueprint_driver.py
@@ -27,6 +27,7 @@ Related:
 from __future__ import annotations
 
 import json
+import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -43,6 +44,117 @@ from rich.console import Console
 from .prompts.compiler import get_compiled_skill
 
 _console = Console()
+
+
+# --------------------------------------------------------------------------
+# Project-size sniff (issue #1355)
+# --------------------------------------------------------------------------
+#
+# Heavy derive-* phases produce process documentation that dwarfs tiny
+# projects. A 5-line Python loader stub with one feat commit does not need
+# 8 ADRs and a TRP — those are reverse-engineered from already-existing
+# CLAUDE.md content and pad the repo with hundreds of lines of ceremony.
+#
+# A "tiny single-feat project" is detected by two cheap signals:
+#
+#   - `git log --grep '^fix' | wc -l` == 0 (no bug-fix commits)
+#   - `git log --pretty=oneline | wc -l` < `_TINY_COMMIT_THRESHOLD`
+#
+# When tiny, the derive-tests phase is a no-op by definition (no fixes
+# means no regressions to capture). When also single-feat (`feat` count
+# == 1), derive-adr / derive-prd / derive-rules / feature-tracker-sync
+# add little signal — the CLAUDE.md + README already describe the project
+# and reverse-engineering a multi-option ADR table from one feat commit is
+# noise.
+
+_TINY_COMMIT_THRESHOLD = 10
+# Phases that are skipped when the repo has zero `fix:` commits — these
+# pure regression-capture phases have nothing to mine on a clean history.
+_SKIP_PHASES_NO_FIXES: frozenset[str] = frozenset({"derive_tests"})
+
+# Phases skipped when the project is tiny AND has one or zero `feat:`
+# commits. These produce reverse-engineered process docs from already-
+# existing CLAUDE.md/README content for projects that don't need them.
+_SKIP_PHASES_TINY_SINGLE_FEAT: frozenset[str] = frozenset(
+    {"derive_adr", "derive_prd", "derive_rules", "feature_tracker_sync"}
+)
+
+
+def _git_commit_count(repo_path: Path, *grep_args: str) -> int | None:
+    """Count git commits matching ``grep_args``. ``None`` on git failure.
+
+    Used to sniff project size without paying the cost of full ``git log``
+    parsing. Returns ``None`` (not 0) on failure so the caller can treat
+    "unknown" as "don't gate" — never silently strip phases because of a
+    broken git invocation.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "log", "--pretty=oneline", *grep_args],
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    return sum(1 for line in result.stdout.splitlines() if line.strip())
+
+
+@dataclass(frozen=True)
+class ProjectSize:
+    """Result of the project-size sniff.
+
+    All counts are ``None`` when git failed (treat as "unknown — don't
+    gate"). When all three are populated, the booleans below reflect the
+    gating decisions for the issue #1355 heuristic.
+    """
+
+    total_commits: int | None
+    feat_commits: int | None
+    fix_commits: int | None
+
+    @property
+    def is_known(self) -> bool:
+        return (
+            self.total_commits is not None
+            and self.feat_commits is not None
+            and self.fix_commits is not None
+        )
+
+    @property
+    def has_no_fixes(self) -> bool:
+        """True when the repo has zero ``fix:`` commits (and we know it)."""
+        return self.is_known and self.fix_commits == 0
+
+    @property
+    def is_tiny_single_feat(self) -> bool:
+        """True for short-history single-feat projects (and we know it).
+
+        Tiny = fewer than ``_TINY_COMMIT_THRESHOLD`` commits total.
+        Single-feat = one or zero ``feat:`` commits.
+        """
+        return (
+            self.is_known
+            and self.total_commits < _TINY_COMMIT_THRESHOLD
+            and self.feat_commits is not None
+            and self.feat_commits <= 1
+        )
+
+
+def sniff_project_size(repo_path: Path) -> ProjectSize:
+    """Sniff a repo's git history to size the blueprint phase chain.
+
+    Returns a :class:`ProjectSize` with ``None`` fields if git is
+    unavailable or the repo has no commits yet — callers should treat
+    unknown as "don't gate" and run every phase.
+    """
+    total = _git_commit_count(repo_path)
+    feat = _git_commit_count(repo_path, "--grep=^feat", "-E")
+    fix = _git_commit_count(repo_path, "--grep=^fix", "-E")
+    return ProjectSize(total_commits=total, feat_commits=feat, fix_commits=fix)
 
 
 # --------------------------------------------------------------------------
@@ -446,12 +558,21 @@ def make_promote_phase(target: str) -> Phase:
 
 @dataclass
 class DriverOptions:
-    """Runtime flags for the blueprint driver."""
+    """Runtime flags for the blueprint driver.
+
+    ``size_aware`` enables the issue #1355 heuristic: derive-* phases
+    that would reverse-engineer process docs from already-existing
+    CLAUDE.md/README content are skipped when the repo is tiny and
+    has no bug-fix history to mine. Set to ``False`` to force the
+    full chain (useful for testing or when you really want the
+    docs).
+    """
 
     dry_run: bool = False
     skip: frozenset[str] = frozenset()  # phase names to skip by policy
     non_interactive: bool = False  # suppress AskUserQuestion tool
     max_turns_per_phase: int = 20
+    size_aware: bool = True
 
 
 @dataclass
@@ -485,6 +606,18 @@ class BlueprintDriver:
     def __init__(self, repo_path: Path, options: DriverOptions | None = None) -> None:
         self.repo_path = repo_path
         self.options = options or DriverOptions()
+        self._project_size: ProjectSize | None = None
+
+    @property
+    def project_size(self) -> ProjectSize:
+        """Lazily-sniffed project size used by ``_artifact_skip_reason``.
+
+        Cached on the driver so we run ``git log`` once per ``run()``
+        call rather than re-shelling per phase.
+        """
+        if self._project_size is None:
+            self._project_size = sniff_project_size(self.repo_path)
+        return self._project_size
 
     async def run(self, phases: tuple[Phase, ...] = ONBOARD_PHASES) -> DriverResult:
         result = DriverResult()
@@ -494,6 +627,14 @@ class BlueprintDriver:
         )
         if self.options.dry_run:
             _console.print("[yellow]DRY RUN — no filesystem writes[/yellow]")
+        if self.options.size_aware:
+            size = self.project_size
+            if size.is_known and (size.has_no_fixes or size.is_tiny_single_feat):
+                _console.print(
+                    f"[dim]Project sniff: total={size.total_commits} "
+                    f"feat={size.feat_commits} fix={size.fix_commits} — "
+                    f"size-aware gating active (issue #1355).[/dim]"
+                )
 
         for phase in phases:
             if self._should_skip(phase):
@@ -553,6 +694,24 @@ class BlueprintDriver:
         if phase.name == "workspace_scan":
             # Always run — the phase itself short-circuits if single-repo.
             return None
+
+        # Size-aware gating (issue #1355).
+        if self.options.size_aware:
+            size = self.project_size
+            if (
+                size.has_no_fixes
+                and phase.name in _SKIP_PHASES_NO_FIXES
+            ):
+                return "no fix: commits in history (size-aware)"
+            if (
+                size.is_tiny_single_feat
+                and phase.name in _SKIP_PHASES_TINY_SINGLE_FEAT
+            ):
+                return (
+                    f"tiny single-feat project "
+                    f"({size.total_commits} commits, "
+                    f"{size.feat_commits} feat) — size-aware"
+                )
 
         return None
 

--- a/git-repo-agent/tests/test_blueprint_driver.py
+++ b/git-repo-agent/tests/test_blueprint_driver.py
@@ -24,10 +24,12 @@ from git_repo_agent.blueprint_driver import (
     SYNC_PHASES,
     UPGRADE_PHASES,
     Phase,
+    ProjectSize,
     make_promote_phase,
     make_prp_create_phase,
     make_prp_execute_phase,
     make_work_order_phase,
+    sniff_project_size,
 )
 from git_repo_agent.prompts.compiler import (
     DROP_HEADINGS,
@@ -266,6 +268,189 @@ class TestSkipPolicy:
         driver = BlueprintDriver(tmp_path, DriverOptions())
         phase = next(p for p in ONBOARD_PHASES if p.name == "workspace_scan")
         assert driver._artifact_skip_reason(phase) is None
+
+
+class TestProjectSizeSniff:
+    """Regression tests for issue #1355.
+
+    Verify that the project-size sniff correctly identifies tiny
+    single-feat projects so the heavy derive-* phases skip them.
+    """
+
+    @staticmethod
+    def _init_repo(repo: Path) -> None:
+        import subprocess as _sp
+
+        _sp.run(["git", "init", "-q"], cwd=repo, check=True)
+        _sp.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repo, check=True,
+        )
+        _sp.run(
+            ["git", "config", "user.name", "Test"],
+            cwd=repo, check=True,
+        )
+
+    @staticmethod
+    def _commit(repo: Path, message: str) -> None:
+        import subprocess as _sp
+
+        # Touch a file then commit so each call creates a real commit.
+        marker = repo / "marker"
+        marker.write_text(message, encoding="utf-8")
+        _sp.run(["git", "add", "marker"], cwd=repo, check=True)
+        _sp.run(
+            ["git", "commit", "-q", "--allow-empty-message", "-m", message],
+            cwd=repo, check=True,
+        )
+
+    def test_unknown_when_not_a_git_repo(self, tmp_path: Path):
+        size = sniff_project_size(tmp_path)
+        assert not size.is_known
+        assert not size.has_no_fixes
+        assert not size.is_tiny_single_feat
+
+    def test_tiny_single_feat_detected(self, tmp_path: Path):
+        self._init_repo(tmp_path)
+        self._commit(tmp_path, "feat: ship everything in one go")
+        self._commit(tmp_path, "docs: add README")
+
+        size = sniff_project_size(tmp_path)
+        assert size.is_known
+        assert size.total_commits == 2
+        assert size.feat_commits == 1
+        assert size.fix_commits == 0
+        assert size.has_no_fixes
+        assert size.is_tiny_single_feat
+
+    def test_zero_feat_one_chore_still_tiny(self, tmp_path: Path):
+        self._init_repo(tmp_path)
+        self._commit(tmp_path, "chore: initial commit")
+
+        size = sniff_project_size(tmp_path)
+        assert size.feat_commits == 0
+        assert size.is_tiny_single_feat
+        assert size.has_no_fixes
+
+    def test_not_tiny_when_history_grows(self, tmp_path: Path):
+        self._init_repo(tmp_path)
+        for i in range(_TINY_BOUNDARY := 12):
+            self._commit(tmp_path, f"feat: thing {i}")
+
+        size = sniff_project_size(tmp_path)
+        assert size.total_commits == _TINY_BOUNDARY
+        assert not size.is_tiny_single_feat
+
+    def test_has_fixes_when_fix_commit_exists(self, tmp_path: Path):
+        self._init_repo(tmp_path)
+        self._commit(tmp_path, "feat: thing")
+        self._commit(tmp_path, "fix: handle null case")
+
+        size = sniff_project_size(tmp_path)
+        assert size.fix_commits == 1
+        assert not size.has_no_fixes
+
+
+class TestSizeAwareGating:
+    """Issue #1355: derive-* phases skip on tiny single-feat projects."""
+
+    def _init_with_commits(self, repo: Path, messages: list[str]) -> None:
+        import subprocess as _sp
+
+        _sp.run(["git", "init", "-q"], cwd=repo, check=True)
+        _sp.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repo, check=True,
+        )
+        _sp.run(
+            ["git", "config", "user.name", "Test"],
+            cwd=repo, check=True,
+        )
+        for msg in messages:
+            marker = repo / "marker"
+            marker.write_text(msg, encoding="utf-8")
+            _sp.run(["git", "add", "marker"], cwd=repo, check=True)
+            _sp.run(
+                ["git", "commit", "-q", "-m", msg],
+                cwd=repo, check=True,
+            )
+
+    def test_derive_tests_skipped_when_no_fix_commits(self, tmp_path: Path):
+        self._init_with_commits(tmp_path, ["feat: ship it"])
+        driver = BlueprintDriver(tmp_path, DriverOptions())
+        phase = next(p for p in ONBOARD_PHASES if p.name == "derive_tests")
+        reason = driver._artifact_skip_reason(phase)
+        assert reason is not None
+        assert "no fix" in reason.lower()
+
+    def test_derive_tests_runs_when_fix_commits_exist(self, tmp_path: Path):
+        self._init_with_commits(
+            tmp_path,
+            ["feat: thing", "fix: bug"],
+        )
+        driver = BlueprintDriver(tmp_path, DriverOptions())
+        phase = next(p for p in ONBOARD_PHASES if p.name == "derive_tests")
+        assert driver._artifact_skip_reason(phase) is None
+
+    def test_derive_adr_skipped_on_tiny_single_feat(self, tmp_path: Path):
+        self._init_with_commits(
+            tmp_path,
+            ["feat: ship it", "docs: readme"],
+        )
+        driver = BlueprintDriver(tmp_path, DriverOptions())
+        phase = next(p for p in ONBOARD_PHASES if p.name == "derive_adr")
+        reason = driver._artifact_skip_reason(phase)
+        assert reason is not None
+        assert "tiny" in reason.lower()
+
+    def test_derive_prd_skipped_on_tiny_single_feat(self, tmp_path: Path):
+        self._init_with_commits(tmp_path, ["feat: ship it"])
+        driver = BlueprintDriver(tmp_path, DriverOptions())
+        phase = next(p for p in ONBOARD_PHASES if p.name == "derive_prd")
+        assert driver._artifact_skip_reason(phase) is not None
+
+    def test_feature_tracker_sync_skipped_on_tiny_single_feat(self, tmp_path: Path):
+        self._init_with_commits(tmp_path, ["feat: ship it"])
+        driver = BlueprintDriver(tmp_path, DriverOptions())
+        phase = next(
+            p for p in ONBOARD_PHASES if p.name == "feature_tracker_sync"
+        )
+        assert driver._artifact_skip_reason(phase) is not None
+
+    def test_init_not_skipped_by_size_gating(self, tmp_path: Path):
+        """`init` is always-on — a tiny project still needs the layout."""
+        self._init_with_commits(tmp_path, ["feat: ship it"])
+        driver = BlueprintDriver(tmp_path, DriverOptions())
+        phase = next(p for p in ONBOARD_PHASES if p.name == "init")
+        # Reason is None because no manifest exists yet, not because gating
+        # let it through — but the size-aware code path must not flag init.
+        assert driver._artifact_skip_reason(phase) is None
+
+    def test_size_aware_disabled_runs_all_phases(self, tmp_path: Path):
+        """``size_aware=False`` bypasses the gating entirely."""
+        self._init_with_commits(tmp_path, ["feat: ship it"])
+        driver = BlueprintDriver(
+            tmp_path, DriverOptions(size_aware=False),
+        )
+        for phase_name in (
+            "derive_tests", "derive_adr", "derive_prd",
+            "derive_rules", "feature_tracker_sync",
+        ):
+            phase = next(p for p in ONBOARD_PHASES if p.name == phase_name)
+            assert driver._artifact_skip_reason(phase) is None, phase_name
+
+    def test_large_repo_runs_all_derive_phases(self, tmp_path: Path):
+        """A repo with substantial history runs the full chain."""
+        messages = [f"feat: feature {i}" for i in range(12)]
+        messages.append("fix: edge case")
+        self._init_with_commits(tmp_path, messages)
+        driver = BlueprintDriver(tmp_path, DriverOptions())
+        for phase_name in (
+            "derive_tests", "derive_adr", "derive_prd",
+            "derive_rules", "feature_tracker_sync",
+        ):
+            phase = next(p for p in ONBOARD_PHASES if p.name == phase_name)
+            assert driver._artifact_skip_reason(phase) is None, phase_name
 
 
 class TestStateHint:


### PR DESCRIPTION
## Summary

- `BlueprintDriver` now sniffs git history to size the phase chain and skips heavy derive-* phases on tiny single-feat projects (issue #1355).
- New `ProjectSize` dataclass with `has_no_fixes` / `is_tiny_single_feat` predicates drives the gating; the existing `_artifact_skip_reason` path now consults it.
- `derive_tests` skips when zero `fix:` commits exist; `derive_adr` / `derive_prd` / `derive_rules` / `feature_tracker_sync` skip on tiny single-feat projects (< 10 commits, ≤ 1 feat).
- Gating is on by default; set `DriverOptions(size_aware=False)` to force the full chain.

## Why this lives in `blueprint_driver.py` not `blueprint-plugin/`

The issue title flagged `feat(blueprint-plugin):` and the design discussion noted either layer could host the heuristic. The Python `BlueprintDriver` is the right home: it already owns the skip-policy mechanism (`_artifact_skip_reason`), the heuristic is purely about *whether* to invoke a phase (not the phase contents), and project-size sniffing belongs next to the orchestration logic that consumes it. The blueprint-plugin skills themselves remain untouched and reusable in non-driver contexts (e.g. `/blueprint:derive-adr` invoked manually).

## Test plan

- [x] Unit tests covering `sniff_project_size` over real git repos (16 new tests under `TestProjectSizeSniff` and `TestSizeAwareGating`)
- [x] Full git-repo-agent suite passes (304 tests, +13 from baseline)
- [ ] Smoke test on a tiny single-feat repo (e.g., `comfyui-sampler-info`): re-run `git-repo-agent onboard` and confirm derive-* phases skip
- [ ] Smoke test on a larger repo: confirm the full chain still runs

Closes #1355