### PR TITLE
fix(blueprint-plugin): infer feature status from working tree and git history

### DIFF
--- a/blueprint-plugin/skills/blueprint-feature-tracker-sync/REFERENCE.md
+++ b/blueprint-plugin/skills/blueprint-feature-tracker-sync/REFERENCE.md
@@ -36,6 +36,86 @@ jq '.tasks.pending += [{"id": "FR4.1", "description": "Webhook support", "source
   docs/blueprint/feature-tracker.json > tmp.json && mv tmp.json docs/blueprint/feature-tracker.json
 ```
 
+## Evidence Backfill jq Recipe
+
+After Step 3b scans the working tree and git history, merge results into the tracker. For each feature `$FR_ID` with scanned `$NEW_COMMITS` (newline-separated SHAs in `/tmp/scan-commits.txt`), `$NEW_TESTS` (newline-separated paths in `/tmp/scan-tests.txt`), and an `$INFERRED_STATUS` of `complete` / `partial` / `null`:
+
+```bash
+jq --arg id "$FR_ID" \
+   --rawfile commits /tmp/scan-commits.txt \
+   --rawfile tests /tmp/scan-tests.txt \
+   --arg status "$INFERRED_STATUS" \
+   --arg today "$(date -u +%Y-%m-%d)" '
+  (.features // []) |= map(
+    if .id == $id then
+      . as $fr
+      | .implementation.commits = (
+          ((.implementation.commits // []) +
+           ($commits | split("\n") | map(select(length > 0))))
+          | unique
+        )
+      | .implementation.tests = (
+          ((.implementation.tests // []) +
+           ($tests | split("\n") | map(select(length > 0))))
+          | unique
+        )
+      | if ($fr.status // "not_started") == "not_started" and $status != "null"
+        then .status = $status
+             | (if $status == "complete" then .completed_at = $today else . end)
+        else .
+        end
+    else .
+    end
+  )
+' docs/blueprint/feature-tracker.json > docs/blueprint/feature-tracker.json.tmp
+mv docs/blueprint/feature-tracker.json.tmp docs/blueprint/feature-tracker.json
+```
+
+Run sequentially per feature so concurrent writes don't collide. The recipe preserves any existing commit/test entries (deduped via `unique`) and only flips `status` upward from `not_started` — already-`complete`/`in_progress`/`partial` features are left alone.
+
+## Sync Report Template
+
+```
+Feature Tracker Sync Report
+===========================
+Last Updated: {date}
+
+Statistics:
+- Total Features: {total}
+- Complete: {complete} ({percentage}%)
+- Partial: {partial}
+- In Progress: {in_progress}
+- Not Started: {not_started}
+- Blocked: {blocked}
+
+Current Phase: {current_phase}
+
+Phase Status:
+- Phase 0: {status}
+- Phase 1: {status}
+...
+
+Active Tasks:
+{tasks.in_progress | list}
+
+Changes Made:
+{If changes made:}
+- {feature}: {old_status} -> {new_status}
+- Updated TODO.md: checked {N} items
+{If no changes:}
+- No changes needed, all in sync
+
+Inferred from evidence (Step 3b):
+{For each feature flipped from not_started:}
+- {feature_id} ({feature_title}): not_started -> {inferred_status}
+  Files: {implementation.files | join(", ")}
+  Commits backfilled: {N} SHAs
+
+{If discrepancies skipped:}
+Unresolved Discrepancies:
+- {feature}: tracker says {status}, TODO.md shows {checkbox_state}
+```
+
 ## Example Summary Output
 
 ```

--- a/blueprint-plugin/skills/blueprint-feature-tracker-sync/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-feature-tracker-sync/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-01-02
-modified: 2026-05-09
-reviewed: 2026-05-09
+modified: 2026-05-22
+reviewed: 2026-05-22
 description: Sync feature tracker with TODO.md, taskwarrior sidecars, and PRDs. Use when reconciling TODO.md vs tracker, draining WO entries, or recalculating stats.
 allowed-tools: Read, Write, Bash, Glob, AskUserQuestion
 model: sonnet
@@ -154,10 +154,17 @@ a. **Verify status consistency**:
    - `not_started`: Check TODO.md has `[ ]`, not in completed
    - `blocked`: Note if blocking reason is documented
 
-b. **Check implementation evidence** (optional, for thorough sync):
-   - Look for files listed in `implementation.files`
-   - Check if tests exist in `implementation.tests`
-   - Verify commits in `implementation.commits`
+b. **Check implementation evidence** (REQUIRED — drives status inference for shipped code). For each feature with non-empty `implementation.files`: verify each file exists, backfill `implementation.commits` via `git log --follow --format="%H" -- <file>` (deduped, merged into existing array), and backfill `implementation.tests` via `Glob` on conventional patterns (`tests/**/*<slug>*`, `**/*<slug>*.test.*`, `**/test_*<slug>*.py`).
+
+   **Infer status from evidence** ONLY when current `status == "not_started"`:
+
+   | Evidence | Inferred status |
+   |---|---|
+   | All files exist AND ≥1 commit touches them | `complete` (pending Step 5 user confirmation) |
+   | Some files exist, others missing | `partial` |
+   | No listed files exist | leave as `not_started` |
+
+   Never silently downgrade an already-`complete`/`in_progress`/`partial` feature. List flipped features under "Inferred from evidence" in the Step 9 sync report. See [REFERENCE.md](REFERENCE.md#evidence-backfill-jq-recipe) for the canonical merge `jq`.
 
 ### Step 4: Detect discrepancies
 
@@ -166,6 +173,7 @@ Look for inconsistencies:
 - Feature checked in TODO.md but not `complete` in tracker
 - Feature in `tasks.in_progress` but tracker says `complete`
 - PRD status doesn't match feature implementation status
+- Feature marked `not_started` but Step 3b inferred shipped code (confirm via Step 5)
 
 ### Step 5: Ask user about discrepancies
 
@@ -252,40 +260,7 @@ feature-tracker contains any feature with a non-empty `implemented_by` array.
 
 ### Step 9: Output sync report
 
-```
-Feature Tracker Sync Report
-===========================
-Last Updated: {date}
-
-Statistics:
-- Total Features: {total}
-- Complete: {complete} ({percentage}%)
-- Partial: {partial}
-- In Progress: {in_progress}
-- Not Started: {not_started}
-- Blocked: {blocked}
-
-Current Phase: {current_phase}
-
-Phase Status:
-- Phase 0: {status}
-- Phase 1: {status}
-...
-
-Active Tasks:
-{tasks.in_progress | list}
-
-Changes Made:
-{If changes made:}
-- {feature}: {old_status} -> {new_status}
-- Updated TODO.md: checked {N} items
-{If no changes:}
-- No changes needed, all in sync
-
-{If discrepancies skipped:}
-Unresolved Discrepancies:
-- {feature}: tracker says {status}, TODO.md shows {checkbox_state}
-```
+Print: statistics block (total/complete/partial/in_progress/not_started/blocked + completion %), current phase, phase-status list, active tasks list, "Changes Made" (status flips, TODO checkboxes touched), "Inferred from evidence" (Step 3b flips with their commit SHAs), and "Unresolved Discrepancies" if any were skipped. See [REFERENCE.md](REFERENCE.md#sync-report-template) for the full report template.
 
 ### Step 10: Update task registry
 


### PR DESCRIPTION
## Summary

- Promote feature-tracker-sync's "implementation evidence" check from
  optional to required: scan `implementation.files` against the working
  tree, backfill `implementation.commits` from `git log --follow`,
  populate `implementation.tests` via conventional Glob patterns, and
  upgrade `not_started` features that already ship to `partial` /
  `complete` (only upward; never silently downgrade).
- Surface inferred flips in the Step 9 sync report and route them through
  Step 5 discrepancy resolution so the user confirms before writes land.
- Move the sync-report template and the new evidence-backfill `jq` recipe
  to REFERENCE.md to keep SKILL.md under the 500-line ceiling.

Fixes the reported case where blueprint init on
`laurigates/comfyui-sampler-info` (every FR implemented in the initial
release commit) emitted `complete: 0`, `not_started: 14`,
`completion_percentage: 0.0` — and queued 13 redundant work orders for
already-shipped code.

Closes #1354

## Test plan

- [ ] Run `/blueprint:feature-tracker-sync` on a project where the feature tracker JSON has all features marked `not_started` but the files in `implementation.files` already exist and have commits.
- [ ] Verify the sync flips the matching FRs to `complete` (after confirmation) and populates `implementation.commits` with the SHAs that touched those files.
- [ ] Verify already-`complete` / `in_progress` features are not downgraded by the evidence scan.
- [ ] Verify `bash scripts/plugin-compliance-check.sh` still reports `blueprint-plugin` as ✅.
