### PR TITLE
fix(git-repo-agent): refresh base branch before maintain analyzes

### DIFF
--- a/git-repo-agent/src/git_repo_agent/orchestrator.py
+++ b/git-repo-agent/src/git_repo_agent/orchestrator.py
@@ -108,6 +108,7 @@ from .worktree import (
     get_base_branch,
     gh_auth_ok,
     parse_report_only_findings,
+    probe_base_freshness,
     push_and_create_pr,
     refresh_base as refresh_base_branch,
     release_lock,
@@ -650,8 +651,39 @@ async def run_maintain(
         branch = f"maintain/{date.today().isoformat()}"
 
     if makes_changes:
-        console.print(f"[dim]Creating worktree on branch {branch}...[/dim]")
-        worktree_path = create_worktree(repo_path, branch)
+        # Freshness check (issue #1358). Maintain runs back-to-back with
+        # onboard PRs will see a local main that hasn't been pulled,
+        # then re-suggest every fix the just-merged PR landed. Always
+        # fetch origin/<base> before branching the worktree off it, so
+        # the analysis starts from the actual remote head.
+        freshness = probe_base_freshness(repo_path, base_branch)
+        worktree_base = base_branch
+        if freshness.has_remote and freshness.fetched:
+            worktree_base = f"origin/{base_branch}"
+            if freshness.behind > 0:
+                console.print(
+                    f"[yellow]Local {base_branch} is {freshness.behind} "
+                    f"commit(s) behind origin/{base_branch}. Branching "
+                    f"worktree off origin/{base_branch} so analysis "
+                    f"sees freshly-merged changes (issue #1358).[/yellow]"
+                )
+            else:
+                console.print(
+                    f"[dim]Fetched origin/{base_branch} — local base is up to date.[/dim]"
+                )
+        elif freshness.has_remote and not freshness.fetched:
+            console.print(
+                f"[yellow]Could not fetch origin/{base_branch}; "
+                f"analysis will run against possibly-stale local "
+                f"{base_branch}. (issue #1358)[/yellow]"
+            )
+        # else: no origin remote — local-only repo, nothing to refresh.
+
+        console.print(
+            f"[dim]Creating worktree on branch {branch} "
+            f"(base: {worktree_base})...[/dim]"
+        )
+        worktree_path = create_worktree(repo_path, branch, base_ref=worktree_base)
         work_dir = worktree_path
         console.print(f"[dim]Working in: {worktree_path}[/dim]")
 

--- a/git-repo-agent/src/git_repo_agent/worktree.py
+++ b/git-repo-agent/src/git_repo_agent/worktree.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import subprocess
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -124,6 +125,85 @@ def refresh_base(repo_path: Path, base_branch: str) -> bool:
     return True
 
 
+@dataclass(frozen=True)
+class BaseFreshness:
+    """Result of a base-branch freshness probe (issue #1358).
+
+    ``fetched`` is True when ``git fetch`` succeeded (so we know
+    ``origin/<base>`` reflects the remote). ``behind`` is the number of
+    commits local ``<base>`` is behind ``origin/<base>`` after the
+    fetch. ``has_remote`` is False for purely local repos (no origin),
+    in which case staleness isn't measurable.
+    """
+
+    fetched: bool
+    has_remote: bool
+    behind: int
+    base_branch: str
+
+
+def _has_origin(repo_path: Path) -> bool:
+    """True if the repo has an ``origin`` remote configured."""
+    result = subprocess.run(
+        ["git", "remote", "get-url", "origin"],
+        cwd=repo_path, capture_output=True, text=True,
+    )
+    return result.returncode == 0
+
+
+def _count_behind(repo_path: Path, local_ref: str, remote_ref: str) -> int:
+    """Count commits ``local_ref`` is behind ``remote_ref`` (``rev-list --count``).
+
+    Returns 0 when either ref is missing or git fails — callers should
+    treat that as "not measurably behind".
+    """
+    result = subprocess.run(
+        ["git", "rev-list", "--count", f"{local_ref}..{remote_ref}"],
+        cwd=repo_path, capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        return 0
+    try:
+        return int(result.stdout.strip() or "0")
+    except ValueError:
+        return 0
+
+
+def probe_base_freshness(repo_path: Path, base_branch: str) -> BaseFreshness:
+    """Fetch origin/<base> and report how far local <base> is behind.
+
+    Used by the maintain workflow to detect the failure mode in issue
+    #1358: maintain runs immediately after an onboard PR merges, sees
+    the local main that hasn't been pulled, and re-suggests every fix
+    the just-merged PR landed.
+
+    Always attempts to fetch (does not depend on ``--refresh-base``).
+    Failures are non-fatal — the caller decides whether to abort.
+    """
+    if not _has_origin(repo_path):
+        return BaseFreshness(
+            fetched=False, has_remote=False, behind=0, base_branch=base_branch,
+        )
+    fetch = subprocess.run(
+        ["git", "fetch", "origin", base_branch],
+        cwd=repo_path, capture_output=True, text=True,
+    )
+    if fetch.returncode != 0:
+        logger.warning(
+            "git fetch origin %s failed: %s",
+            base_branch, fetch.stderr.strip(),
+        )
+        return BaseFreshness(
+            fetched=False, has_remote=True, behind=0, base_branch=base_branch,
+        )
+    behind = _count_behind(
+        repo_path, base_branch, f"origin/{base_branch}",
+    )
+    return BaseFreshness(
+        fetched=True, has_remote=True, behind=behind, base_branch=base_branch,
+    )
+
+
 def find_existing_pr(
     repo_path: Path,
     branch_prefix: str,
@@ -201,12 +281,20 @@ def gh_auth_ok(repo_path: Path) -> bool:
     return result.returncode == 0
 
 
-def create_worktree(repo_path: Path, branch: str) -> Path:
+def create_worktree(
+    repo_path: Path,
+    branch: str,
+    base_ref: str | None = None,
+) -> Path:
     """Create a git worktree for isolated agent work.
 
     Args:
         repo_path: Path to the main repository.
         branch: Branch name to create in the worktree.
+        base_ref: Explicit base ref to branch from (e.g. ``origin/main``).
+            When ``None``, uses the current ``HEAD`` of ``repo_path``.
+            Use this to avoid the issue #1358 failure mode where the
+            local base branch is behind ``origin``.
 
     Returns:
         Path to the new worktree directory.
@@ -214,14 +302,15 @@ def create_worktree(repo_path: Path, branch: str) -> Path:
     worktree_path = repo_path / ".claude" / "worktrees" / branch.replace("/", "-")
     worktree_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Get current branch to use as base
-    base = subprocess.run(
-        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-        cwd=repo_path,
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout.strip()
+    if base_ref is None:
+        # Get current branch to use as base (legacy behavior).
+        base_ref = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
 
     # Remove stale worktree if it exists
     if worktree_path.exists():
@@ -242,14 +331,17 @@ def create_worktree(repo_path: Path, branch: str) -> Path:
 
     # Create worktree with new branch
     subprocess.run(
-        ["git", "worktree", "add", "-b", branch, str(worktree_path), base],
+        ["git", "worktree", "add", "-b", branch, str(worktree_path), base_ref],
         cwd=repo_path,
         capture_output=True,
         text=True,
         check=True,
     )
 
-    logger.info("Created worktree at %s on branch %s (base: %s)", worktree_path, branch, base)
+    logger.info(
+        "Created worktree at %s on branch %s (base: %s)",
+        worktree_path, branch, base_ref,
+    )
     return worktree_path
 
 

--- a/git-repo-agent/tests/test_handoff.py
+++ b/git-repo-agent/tests/test_handoff.py
@@ -352,10 +352,21 @@ class TestRunMaintainHandoff:
         monkeypatch.setattr(
             orchestrator,
             "create_worktree",
-            lambda _repo, _branch: worktree,
+            lambda _repo, _branch, base_ref=None: worktree,
         )
         monkeypatch.setattr(
             orchestrator, "_snapshot_parent_sha", lambda _path: "deadbeef",
+        )
+
+        # The freshness probe shells out to git; stub it for this unit test.
+        from git_repo_agent.worktree import BaseFreshness
+
+        monkeypatch.setattr(
+            orchestrator,
+            "probe_base_freshness",
+            lambda _repo, _base: BaseFreshness(
+                fetched=False, has_remote=False, behind=0, base_branch=_base,
+            ),
         )
 
         # Track that the PR-creation prompt is never reached.

--- a/git-repo-agent/tests/test_maintain_freshness.py
+++ b/git-repo-agent/tests/test_maintain_freshness.py
@@ -1,0 +1,237 @@
+"""Regression tests for issue #1358 — maintain pass operates on stale state.
+
+When ``git-repo-agent maintain`` runs back-to-back with ``git-repo-agent
+onboard`` (i.e. immediately after the onboard PR squash-merges), the
+maintain pass analyzes the **pre-merge local working copy** and
+re-suggests every fix the onboard PR just landed.
+
+The fix is :func:`probe_base_freshness` plus an explicit ``base_ref``
+parameter on :func:`create_worktree`: maintain now fetches origin and
+branches off ``origin/<base>`` so the analysis reflects whatever has
+just been merged remotely.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from git_repo_agent.worktree import (
+    BaseFreshness,
+    create_worktree,
+    probe_base_freshness,
+)
+
+
+def _git_available() -> bool:
+    return shutil.which("git") is not None
+
+
+needs_git = pytest.mark.skipif(not _git_available(), reason="git not installed")
+
+
+def _init_repo(path: Path) -> None:
+    """Initialize a fresh repo with one commit on ``main``."""
+    subprocess.run(
+        ["git", "init", "-b", "main", str(path)],
+        check=True, capture_output=True,
+    )
+    for key, value in [
+        ("user.email", "test@example.com"),
+        ("user.name", "Test"),
+        ("commit.gpgsign", "false"),
+    ]:
+        subprocess.run(
+            ["git", "-C", str(path), "config", key, value],
+            check=True, capture_output=True,
+        )
+    (path / "README.md").write_text("init\n")
+    subprocess.run(
+        ["git", "-C", str(path), "add", "-A"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(path), "commit", "-m", "init"],
+        check=True, capture_output=True,
+    )
+
+
+def _make_remote_with_extra_commits(
+    tmp_path: Path, extra_commits: int = 0
+) -> tuple[Path, Path]:
+    """Create a bare ``remote`` and a ``local`` clone that may be behind.
+
+    ``extra_commits`` is the number of commits added to the remote
+    *after* the local clones it. ``> 0`` simulates the issue #1358 case
+    where the onboard PR squash-merged on the remote while the local
+    main hasn't been pulled.
+
+    Returns ``(local_path, remote_path)``.
+    """
+    remote = tmp_path / "remote.git"
+    upstream = tmp_path / "upstream"
+    local = tmp_path / "local"
+
+    # Build the upstream working copy, then push to a bare remote.
+    _init_repo(upstream)
+    subprocess.run(
+        ["git", "init", "--bare", str(remote)],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(upstream), "remote", "add", "origin", str(remote)],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(upstream), "push", "-u", "origin", "main"],
+        check=True, capture_output=True,
+    )
+
+    # Clone the local working copy.
+    subprocess.run(
+        ["git", "clone", str(remote), str(local)],
+        check=True, capture_output=True,
+    )
+    # Match the test repo identity in the local clone.
+    for key, value in [
+        ("user.email", "test@example.com"),
+        ("user.name", "Test"),
+        ("commit.gpgsign", "false"),
+    ]:
+        subprocess.run(
+            ["git", "-C", str(local), "config", key, value],
+            check=True, capture_output=True,
+        )
+
+    # Now move the remote forward by N commits via the upstream working copy.
+    for i in range(extra_commits):
+        (upstream / f"file_{i}.txt").write_text(f"merged after clone {i}\n")
+        subprocess.run(
+            ["git", "-C", str(upstream), "add", "-A"],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            [
+                "git", "-C", str(upstream), "commit",
+                "-m", f"feat: post-clone change {i}",
+            ],
+            check=True, capture_output=True,
+        )
+    if extra_commits:
+        subprocess.run(
+            ["git", "-C", str(upstream), "push", "origin", "main"],
+            check=True, capture_output=True,
+        )
+
+    return local, remote
+
+
+@needs_git
+class TestProbeBaseFreshness:
+    """Cover the three states of remote/fetch state."""
+
+    def test_no_origin_remote_returns_local_only(self, tmp_path: Path):
+        """Local-only repos have nothing to refresh — has_remote is False."""
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+
+        result = probe_base_freshness(repo, "main")
+        assert isinstance(result, BaseFreshness)
+        assert result.has_remote is False
+        assert result.fetched is False
+        assert result.behind == 0
+        assert result.base_branch == "main"
+
+    def test_clean_clone_reports_zero_behind(self, tmp_path: Path):
+        """Right after `git clone`, local main matches origin/main."""
+        local, _ = _make_remote_with_extra_commits(tmp_path, extra_commits=0)
+
+        result = probe_base_freshness(local, "main")
+        assert result.has_remote is True
+        assert result.fetched is True
+        assert result.behind == 0
+
+    def test_stale_clone_reports_positive_behind(self, tmp_path: Path):
+        """Issue #1358 repro: remote moved forward but local hasn't pulled."""
+        local, _ = _make_remote_with_extra_commits(tmp_path, extra_commits=3)
+
+        result = probe_base_freshness(local, "main")
+        assert result.has_remote is True
+        assert result.fetched is True
+        assert result.behind == 3, (
+            "Expected 3 commits behind origin/main — the remote moved "
+            "forward by 3 commits while the local clone was untouched."
+        )
+
+    def test_probe_does_not_modify_local_main(self, tmp_path: Path):
+        """Probe must fetch but NOT auto-merge. Caller decides."""
+        local, _ = _make_remote_with_extra_commits(tmp_path, extra_commits=2)
+
+        head_before = subprocess.run(
+            ["git", "-C", str(local), "rev-parse", "HEAD"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+
+        probe_base_freshness(local, "main")
+
+        head_after = subprocess.run(
+            ["git", "-C", str(local), "rev-parse", "HEAD"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        assert head_before == head_after
+
+
+@needs_git
+class TestCreateWorktreeWithBaseRef:
+    """``create_worktree`` accepts an explicit base ref (issue #1358)."""
+
+    def test_default_base_uses_current_head(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        head = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+
+        wt = create_worktree(repo, "feature/test")
+        wt_head = subprocess.run(
+            ["git", "-C", str(wt), "rev-parse", "HEAD"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        assert wt_head == head
+
+    def test_explicit_base_ref_used(self, tmp_path: Path):
+        """Pinning base_ref forces the worktree to branch off that ref.
+
+        Regression: issue #1358. Maintain must branch off origin/<base>,
+        not local <base>, so a just-merged onboard PR is reflected even
+        when the local main hasn't been pulled.
+        """
+        local, _ = _make_remote_with_extra_commits(tmp_path, extra_commits=2)
+
+        local_head = subprocess.run(
+            ["git", "-C", str(local), "rev-parse", "main"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        # Force the fetch via the probe helper, so origin/main is in the
+        # local clone's ref database when create_worktree runs.
+        probe_base_freshness(local, "main")
+        origin_head = subprocess.run(
+            ["git", "-C", str(local), "rev-parse", "origin/main"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        assert local_head != origin_head, (
+            "Test setup invariant: local main must differ from origin/main"
+        )
+
+        wt = create_worktree(local, "maintain/test", base_ref="origin/main")
+        wt_head = subprocess.run(
+            ["git", "-C", str(wt), "rev-parse", "HEAD"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        assert wt_head == origin_head, (
+            "Worktree must be branched off origin/main, not local main"
+        )


### PR DESCRIPTION
Closes #1358

## Summary

- Before creating its analysis worktree, `run_maintain` now unconditionally fetches `origin/<base>` and branches the worktree off `origin/<base>` rather than local HEAD. The analysis sees freshly-merged changes regardless of whether local main has been pulled.
- New `probe_base_freshness()` helper in `worktree.py` returns a `BaseFreshness` dataclass capturing fetch success and behind commit count; warns the user when local is N commits behind origin.
- `create_worktree()` gains an optional `base_ref` parameter (default: legacy current-HEAD behavior) so `onboard` is unaffected.
- Failures are warnings, not aborts — local-only repos and offline runs still work.

## What this does NOT do

The issue listed three proposed fixes; this PR lands the most impactful one (mandatory fetch + branch off `origin/<base>`). The other two (suggestion 2: cross-reference recently-merged PRs; suggestion 3: refuse to create CONFLICTING PRs) are separate concerns and can land later.

## Test plan

- [x] 6 new unit tests cover the three freshness states (no remote / clean clone / stale clone) and the new `base_ref` parameter on `create_worktree`
- [x] Updated one existing handoff-path test to stub the new probe (kept all 297 tests green)
- [ ] Smoke test: run onboard → squash-merge → run maintain immediately; confirm maintain branches off origin head, not stale local