### PR TITLE
docs(taskwarrior-plugin): document bulk-close patterns in task-done

### DIFF
--- a/taskwarrior-plugin/skills/task-done/SKILL.md
+++ b/taskwarrior-plugin/skills/task-done/SKILL.md
@@ -5,8 +5,8 @@ args: "<task-id> [commit-hash]"
 allowed-tools: Bash(task *), Bash(git config *), Bash(git log *), Bash(git rev-parse *), Bash(gh auth *), Bash(gh issue *), Bash(gh pr *), Read, Edit, TodoWrite
 argument-hint: task id (required), commit sha (optional — defaults to HEAD)
 created: 2026-04-24
-modified: 2026-05-09
-reviewed: 2026-05-09
+modified: 2026-05-22
+reviewed: 2026-05-22
 ---
 
 # /taskwarrior:task-done
@@ -20,6 +20,7 @@ Close a task with full coordination hygiene: annotate with the landing commit, d
 | Closing a task whose work has landed in a commit | Filing a brand-new task — use `task-add` |
 | Draining a linked blueprint tracker entry to `done` | Reading current queue state without mutating it — use `task-status` |
 | Closing a `ghid`-linked GitHub issue or commenting on a `ghpr` PR | Picking the next dispatch candidate from the queue — use `task-coordinate` |
+| Closing many tasks in one pass (queue cleanup, triage sweep) | See **Bulk-close patterns** below — the naive `for id in 1 2 3; do task $id done; done` loop silently closes the wrong tasks |
 
 ## Context
 
@@ -163,6 +164,73 @@ Print:
 | Check unblocked siblings | `task depends:ID export \| jq '.[]'` |
 | GitHub close | `gh issue close N --comment "msg"` |
 | PR comment | `gh pr comment N --body "msg"` |
+
+## Bulk-close patterns
+
+Closing many tasks in one pass has two silent foot-guns. The obvious shape — `for id in 1 2 3; do task $id done; done` — reports success while doing the wrong thing.
+
+### Foot-gun 1: numeric IDs renumber after every `task done`
+
+Numeric IDs are a display index over **pending** tasks. The moment one closes, every higher ID shifts down by one. A loop over numeric IDs closes the original first task, then keeps targeting wrong tasks as IDs slide underneath the iterator. No error surfaces.
+
+**Fix: use UUIDs** (immutable). The same applies to any iterated state-changing op — `annotate`, `modify`, `delete`.
+
+```sh
+# WRONG — IDs shift mid-loop
+for id in 35 36 37 38 39; do task "$id" done; done
+
+# Correct — capture immutable UUIDs first
+UUIDS=$(task status:pending project:myrepo export | jq -r '.[].uuid')
+for u in $UUIDS; do task "$u" done </dev/null; done    # stdin redirect — see below
+```
+
+### Foot-gun 2: `task done` consumes loop stdin
+
+`task done` reads from stdin (for confirmation prompts). In a shell `for` loop, the loop's input is *also* stdin — so `task done` eats subsequent iterations and the loop exits early, usually after one or two passes, with no error.
+
+Symptom: a loop over 15 UUIDs reports "processed 15" but only 1 task closed.
+
+```sh
+# Fix A — redirect stdin per inner command
+for u in $UUIDS; do
+  task "$u" rc.confirmation=no done </dev/null
+done
+
+# Fix B — xargs (preferred; each invocation runs in its own subshell with no
+# stdin link to the source loop)
+echo "$UUIDS" | xargs -I {} sh -c 'task rc.confirmation=no {} done'
+```
+
+### Always pass `rc.confirmation=no` for batch closes
+
+Without it, taskwarrior may prompt "this task is blocked by N other tasks, complete anyway? (yes/no)" per task, hanging the loop. `rc.confirmation=no` makes batch closes deterministic.
+
+### Annotate before `done`, not after
+
+Once `completed`, a task's `id` becomes 0 and `task <id>` no longer addresses it — only the UUID does. Annotate first to keep the UUID-or-ID workflow uniform.
+
+### Finding tasks for the bulk close
+
+Use `export | jq` (never `list` — it exits 1 on empty filters and cancels parallel siblings; see `.claude/rules/parallel-safe-queries.md`):
+
+```sh
+task status:pending project:myrepo +pr_ready export | jq -r '.[].uuid'
+
+# Tasks with no project (CLI filter quirk — empty value as first filter
+# errors; sidestep through jq)
+task status:pending export | jq -r '.[] | select(.project == null) | .uuid'
+
+# Substring matches on description (for markers that aren't real tags)
+task status:pending export \
+  | jq -r '.[] | select(.description | test("\\[triage\\]")) | .uuid'
+```
+
+### Canonical pattern
+
+```sh
+UUIDS=$(task status:pending project:myrepo +pr_ready export | jq -r '.[].uuid')
+echo "$UUIDS" | xargs -I {} sh -c 'task rc.confirmation=no {} done'
+```
 
 ## Related
 


### PR DESCRIPTION
Closes #1352

## Summary

- Add a "Bulk-close patterns" section to `task-done/SKILL.md` documenting the two silent foot-guns when closing many tasks in one pass: (1) numeric IDs renumber after every `task done`, and (2) `task done` consumes loop stdin.
- Extend the "When to Use" table with a pointer to the new section.
- Canonical one-liner: `task ... export | jq -r .uuid | xargs -I {} sh -c 'task rc.confirmation=no {} done'`.

## Placement decision

Inline section in `task-done/SKILL.md` rather than a new `task-bulk-close` skill because:

1. **Point of need** — readers reaching for `/taskwarrior:task-done` are exactly the population that benefits from seeing this.
2. **No metadata churn** — avoids `plugin.json` / `marketplace.json` / `release-please-config.json` / `.release-please-manifest.json` updates.
3. **Size budget** — final body lands at 245 lines, below the 251-line WARN threshold in `.claude/rules/skill-quality.md`.

## Test plan

- [x] Run `bash scripts/lint-context-commands.sh` — exits 0.
- [x] Run `bash scripts/lint-taskwarrior-tags.sh` — exits 0 (the description-substring example uses `[triage]` rather than `+upstream-issue` to avoid the hyphenated-tag lint, which would otherwise fire because the lint can't distinguish "broken-tag example" from "broken-tag usage").
- [x] Pre-commit hooks pass.
- [ ] Render `task-done` SKILL.md in a Markdown previewer — confirm the new section reads cleanly and code blocks are properly fenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)