### PR TITLE
fix(git-repo-agent): make maintain findings stack-aware

### DIFF
--- a/git-repo-agent/src/git_repo_agent/prompts/maintain.md
+++ b/git-repo-agent/src/git_repo_agent/prompts/maintain.md
@@ -18,6 +18,25 @@ Review the pre-computed `repo_analyze` and `health_score` results in your system
 - Technology stack and tooling
 - Overall health score with category breakdown
 - Specific findings per category
+- **`stack_profile`** — the project's actual installed tooling
+
+### Respect the existing stack (issue #1359)
+
+`health_score.stack_profile` tells you which tools are already
+installed. Treat it as authoritative when proposing fixes:
+
+| Existing tool | Don't recommend |
+|---|---|
+| `has_biome=true` | ESLint, Prettier, dprint — biome replaces all three |
+| `has_ruff_lint=true` and `has_ruff_format=true` | A separate formatter (black, autopep8) — ruff handles both |
+| `has_python_type_checker=true` | Switching to a different type checker family unless asked |
+| `ci_has_security_scanning=true` | Adding another security workflow (CodeQL, etc.) — list the existing tools as evidence |
+| `is_comfyui_pack=true` or `is_python_incidental=true` | Python library findings (type checking, py.typed, conftest.py, coverage) — the project has trivial Python by design |
+
+When the project uses **uv + ruff** (the Astral stack) and lacks a
+type checker, prefer recommending **`ty`** (Astral's beta type
+checker) over mypy or pyright. Don't mix tool families without a
+reason.
 
 ## Step 2: Triage Findings
 

--- a/git-repo-agent/src/git_repo_agent/tools/health_check.py
+++ b/git-repo-agent/src/git_repo_agent/tools/health_check.py
@@ -8,6 +8,8 @@ from typing import Any
 
 from claude_agent_sdk import tool
 
+from .stack_profile import StackProfile, profile_stack
+
 
 def _score_docs(repo: Path) -> tuple[int, list[str]]:
     """Score documentation health (0-20)."""
@@ -101,8 +103,16 @@ def _score_tests(repo: Path) -> tuple[int, list[str]]:
     return min(score, 20), findings
 
 
-def _score_security(repo: Path) -> tuple[int, list[str]]:
-    """Score security health (0-20)."""
+def _score_security(
+    repo: Path, profile: StackProfile | None = None,
+) -> tuple[int, list[str]]:
+    """Score security health (0-20).
+
+    Stack-aware (issue #1359): when CI already runs known security
+    tooling (gitleaks, trivy, codeql, etc.), credit the score and
+    omit the "no security scanning" finding even if the substring
+    heuristic below would have missed it.
+    """
     score = 0
     findings: list[str] = []
 
@@ -133,17 +143,22 @@ def _score_security(repo: Path) -> tuple[int, list[str]]:
 
     # Security-related CI checks
     workflows_dir = repo / ".github" / "workflows"
-    if workflows_dir.is_dir():
+    security_found = False
+    if profile is not None and profile.ci_has_security_scanning:
+        security_found = True
+        score += 4
+    elif workflows_dir.is_dir():
         for wf in workflows_dir.glob("*.yml"):
             try:
                 content = wf.read_text(encoding="utf-8", errors="replace").lower()
                 if any(kw in content for kw in ["security", "audit", "dependabot", "codeql", "snyk"]):
                     score += 4
+                    security_found = True
                     break
             except OSError:
                 pass
-        else:
-            findings.append("No security scanning in CI")
+    if not security_found and workflows_dir.is_dir():
+        findings.append("No security scanning in CI")
 
     # Dependabot
     if (repo / ".github" / "dependabot.yml").exists():
@@ -154,8 +169,26 @@ def _score_security(repo: Path) -> tuple[int, list[str]]:
     return min(score, 20), findings
 
 
-def _score_quality(repo: Path) -> tuple[int, list[str]]:
-    """Score code quality health (0-20)."""
+def _score_quality(
+    repo: Path, profile: StackProfile | None = None,
+) -> tuple[int, list[str]]:
+    """Score code quality health (0-20).
+
+    Stack-aware (issue #1359):
+
+      - When ``biome.json`` is present, both the linter and formatter
+        slots are credited (biome replaces both ESLint and Prettier).
+      - When ruff is configured, both linter and formatter are credited
+        (ruff's ``format`` subcommand works whenever ``[tool.ruff]`` is
+        present, even without ``[tool.ruff.format]``).
+      - The "No type checking" finding is suppressed for
+        Python-incidental projects (e.g. ComfyUI custom-node packs
+        with a 5-line ``__init__.py``) because there is nothing to
+        type-check.
+      - For Astral-aligned projects (uv + ruff) without a type
+        checker, the finding wording prefers Astral's ``ty`` over
+        mypy/pyright to match the project's tool family.
+    """
     score = 0
     findings: list[str] = []
 
@@ -180,7 +213,7 @@ def _score_quality(repo: Path) -> tuple[int, list[str]]:
         if score == 0:
             findings.append("No linter configured")
 
-    # Formatter config
+    # Formatter config — biome and ruff each cover the formatter slot.
     formatter_configs = [
         "biome.json", "biome.jsonc",
         ".prettierrc", ".prettierrc.json", ".prettierrc.yaml", ".prettierrc.yml",
@@ -194,7 +227,10 @@ def _score_quality(repo: Path) -> tuple[int, list[str]]:
         score += 5
     else:
         formatter_found = False
-        if (repo / "pyproject.toml").exists():
+        if profile is not None and profile.has_ruff_format:
+            score += 5
+            formatter_found = True
+        elif (repo / "pyproject.toml").exists():
             try:
                 content = (repo / "pyproject.toml").read_text(encoding="utf-8")
                 if "tool.ruff" in content or "tool.black" in content:
@@ -205,7 +241,7 @@ def _score_quality(repo: Path) -> tuple[int, list[str]]:
         if not formatter_found:
             findings.append("No formatter configured")
 
-    # Type checking
+    # Type checking — suppress finding for Python-incidental projects.
     type_configs = [
         "tsconfig.json",
         "pyrightconfig.json", "basedpyright",
@@ -215,8 +251,11 @@ def _score_quality(repo: Path) -> tuple[int, list[str]]:
         score += 5
     else:
         typechecker_found = False
+        if profile is not None and profile.has_python_type_checker:
+            score += 5
+            typechecker_found = True
         # Check pyproject.toml
-        if (repo / "pyproject.toml").exists():
+        if not typechecker_found and (repo / "pyproject.toml").exists():
             try:
                 content = (repo / "pyproject.toml").read_text(encoding="utf-8")
                 if any(t in content for t in ["tool.pyright", "tool.basedpyright", "tool.mypy", "tool.ty"]):
@@ -245,7 +284,25 @@ def _score_quality(repo: Path) -> tuple[int, list[str]]:
                 except OSError:
                     pass
         if not typechecker_found:
-            findings.append("No type checking configured")
+            # Stack-aware suppression: don't recommend type checking for
+            # projects that have essentially no Python to check.
+            if profile is not None and (
+                profile.is_comfyui_pack or profile.is_python_incidental
+            ):
+                # No finding emitted — but also no score credit.
+                pass
+            else:
+                # Stack-aware wording: for uv+ruff (Astral) projects,
+                # default the recommendation to ``ty``. Otherwise leave
+                # the generic message so a JS/TS project doesn't see a
+                # Python-specific suggestion.
+                if profile is not None and profile.uses_uv and profile.has_ruff_lint:
+                    findings.append(
+                        "No type checking configured (recommend `ty` — "
+                        "Astral's type checker, matches the uv+ruff stack)"
+                    )
+                else:
+                    findings.append("No type checking configured")
 
     # Editor config
     if (repo / ".editorconfig").exists():
@@ -315,8 +372,20 @@ def _grade(overall_score: int) -> str:
 
 
 def compute_health_score(repo_path: Path) -> dict[str, Any]:
-    """Compute repository health score with category breakdown."""
-    categories = {
+    """Compute repository health score with category breakdown.
+
+    Computes a :class:`StackProfile` once and passes it to scorers that
+    use it to skip findings that don't apply to the project's actual
+    stack (issue #1359). The profile is also surfaced under the
+    ``stack_profile`` key in the result so downstream consumers (and
+    the agent prompt) can see what was detected.
+    """
+    profile = profile_stack(repo_path)
+
+    # The profile-aware scorers accept an optional second argument; the
+    # plain ones ignore it. Pass the profile uniformly so future scorers
+    # can opt in without changing the dispatch.
+    profile_aware_scorers: dict[str, Any] = {
         "docs": _score_docs,
         "tests": _score_tests,
         "security": _score_security,
@@ -327,8 +396,15 @@ def compute_health_score(repo_path: Path) -> dict[str, Any]:
     category_scores: dict[str, int] = {}
     all_findings: dict[str, list[str]] = {}
 
-    for cat_name, scorer in categories.items():
-        cat_score, cat_findings = scorer(repo_path)
+    for cat_name, scorer in profile_aware_scorers.items():
+        # Use a parameter probe so we only forward the profile to
+        # scorers that accept it. Cheaper than introspection: every
+        # scorer here is called with profile as keyword arg when its
+        # signature supports it.
+        try:
+            cat_score, cat_findings = scorer(repo_path, profile=profile)  # type: ignore[call-arg]
+        except TypeError:
+            cat_score, cat_findings = scorer(repo_path)
         category_scores[cat_name] = cat_score
         if cat_findings:
             all_findings[cat_name] = cat_findings
@@ -341,6 +417,22 @@ def compute_health_score(repo_path: Path) -> dict[str, Any]:
         "category_scores": category_scores,
         "findings": all_findings,
         "max_score": 100,
+        "stack_profile": {
+            "has_biome": profile.has_biome,
+            "has_eslint": profile.has_eslint,
+            "has_prettier": profile.has_prettier,
+            "has_tsconfig": profile.has_tsconfig,
+            "has_ruff_lint": profile.has_ruff_lint,
+            "has_ruff_format": profile.has_ruff_format,
+            "has_python_type_checker": profile.has_python_type_checker,
+            "python_type_checker_kind": profile.python_type_checker_kind,
+            "uses_uv": profile.uses_uv,
+            "ci_has_security_scanning": profile.ci_has_security_scanning,
+            "ci_security_tools": list(profile.ci_security_tools),
+            "is_comfyui_pack": profile.is_comfyui_pack,
+            "is_python_incidental": profile.is_python_incidental,
+            "python_loc_outside_tests": profile.python_loc_outside_tests,
+        },
     }
 
 

--- a/git-repo-agent/src/git_repo_agent/tools/stack_profile.py
+++ b/git-repo-agent/src/git_repo_agent/tools/stack_profile.py
@@ -1,0 +1,260 @@
+"""Project stack profile — what tools are already installed, what shape is the code.
+
+Used by ``health_check.py`` to skip findings that don't apply to the
+project's actual stack — e.g. don't recommend ESLint when ``biome.json``
+exists, don't recommend a Python type checker when the project has no
+Python code beyond a 5-line stub, don't recommend CodeQL when CI already
+runs security tooling.
+
+Issue #1359.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+# Patterns that indicate the file is a "trivial" Python loader/stub.
+# ComfyUI custom-node packs ship a few-line ``__init__.py`` whose only
+# job is to expose a ``WEB_DIRECTORY`` constant; auditing it as if it
+# were a Python library is noise.
+_COMFYUI_PACK_MARKERS = re.compile(
+    r"^\s*WEB_DIRECTORY\s*=", re.MULTILINE,
+)
+
+# Heuristic threshold: when total non-test Python LOC is below this,
+# treat the project as "Python-incidental" and suppress Python quality
+# findings (type checker, coverage, py.typed, conftest.py).
+_PYTHON_INCIDENTAL_LOC_THRESHOLD = 50
+
+
+@dataclass(frozen=True)
+class StackProfile:
+    """Summary of what tooling is already installed and the project shape.
+
+    Used by health-score functions to skip findings that would propose
+    tools conflicting with what's already in place, or findings against
+    aspects of the project that don't apply.
+
+    All booleans default to ``False`` (conservative — don't suppress
+    findings when we can't measure). Callers should treat each field as
+    "we definitely know this is true" rather than "we know one way or
+    the other".
+    """
+
+    # JS/TS quality stack
+    has_biome: bool = False
+    has_eslint: bool = False
+    has_prettier: bool = False
+    has_tsconfig: bool = False
+
+    # Python quality stack
+    has_ruff_lint: bool = False
+    has_ruff_format: bool = False
+    has_python_type_checker: bool = False  # mypy, pyright, basedpyright, ty
+    python_type_checker_kind: str = ""  # "mypy" | "pyright" | "basedpyright" | "ty" | ""
+    uses_uv: bool = False
+
+    # CI security stack
+    ci_has_security_scanning: bool = False  # gitleaks, trivy, semgrep, codeql, snyk, etc.
+    ci_security_tools: tuple[str, ...] = field(default_factory=tuple)
+
+    # Project shape
+    is_comfyui_pack: bool = False
+    is_python_incidental: bool = False  # < ~50 LOC of Python outside tests
+    python_loc_outside_tests: int = 0
+
+
+def _read_text(path: Path) -> str:
+    """Read a file as text, returning '' on any failure."""
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def _detect_js_stack(repo: Path) -> dict[str, bool]:
+    """Detect installed JS/TS tooling configs at the repo root."""
+    has_biome = (repo / "biome.json").exists() or (repo / "biome.jsonc").exists()
+    has_eslint = any(
+        (repo / name).exists() for name in (
+            ".eslintrc", ".eslintrc.json", ".eslintrc.js", ".eslintrc.cjs",
+            "eslint.config.js", "eslint.config.mjs", "eslint.config.cjs",
+        )
+    )
+    has_prettier = any(
+        (repo / name).exists() for name in (
+            ".prettierrc", ".prettierrc.json", ".prettierrc.yaml",
+            ".prettierrc.yml", "prettier.config.js", "prettier.config.mjs",
+            "prettier.config.cjs",
+        )
+    )
+    has_tsconfig = (repo / "tsconfig.json").exists()
+    return {
+        "has_biome": has_biome,
+        "has_eslint": has_eslint,
+        "has_prettier": has_prettier,
+        "has_tsconfig": has_tsconfig,
+    }
+
+
+def _detect_python_stack(repo: Path) -> dict[str, object]:
+    """Detect installed Python tooling — ruff/mypy/pyright/ty/uv."""
+    pyproject_text = _read_text(repo / "pyproject.toml")
+    precommit_text = _read_text(repo / ".pre-commit-config.yaml")
+    setupcfg_text = _read_text(repo / "setup.cfg")
+
+    has_ruff_lint = (
+        "[tool.ruff" in pyproject_text
+        or (repo / "ruff.toml").exists()
+        or (repo / ".ruff.toml").exists()
+    )
+    has_ruff_format = "[tool.ruff.format]" in pyproject_text or has_ruff_lint
+    # ruff's `format` subcommand works without a [tool.ruff.format] table
+    # — having ruff configured is enough to count as a formatter.
+
+    uses_uv = (repo / "uv.lock").exists() or "uv_build" in pyproject_text
+
+    # Type checker (the first found wins; the ordering reflects 2026
+    # ecosystem reality: a uv+ruff project is most likely to add ty,
+    # then basedpyright, then pyright, then mypy).
+    type_checker_kind = ""
+    if "[tool.ty" in pyproject_text:
+        type_checker_kind = "ty"
+    elif "[tool.basedpyright" in pyproject_text or (repo / "basedpyright").exists():
+        type_checker_kind = "basedpyright"
+    elif "[tool.pyright" in pyproject_text or (repo / "pyrightconfig.json").exists():
+        type_checker_kind = "pyright"
+    elif (
+        "[tool.mypy" in pyproject_text
+        or (repo / "mypy.ini").exists()
+        or (repo / ".mypy.ini").exists()
+        or "[mypy" in setupcfg_text
+    ):
+        type_checker_kind = "mypy"
+    elif "pyright" in precommit_text or "mypy" in precommit_text or "ty" in precommit_text:
+        # Fall back to pre-commit declarations; can't distinguish
+        # confidently without parsing, so report a generic marker.
+        type_checker_kind = "precommit"
+
+    return {
+        "has_ruff_lint": has_ruff_lint,
+        "has_ruff_format": has_ruff_format,
+        "uses_uv": uses_uv,
+        "has_python_type_checker": bool(type_checker_kind),
+        "python_type_checker_kind": type_checker_kind,
+    }
+
+
+def _detect_ci_security(repo: Path) -> dict[str, object]:
+    """Scan ``.github/workflows/*.yml`` for known security tools."""
+    workflows = repo / ".github" / "workflows"
+    if not workflows.is_dir():
+        return {"ci_has_security_scanning": False, "ci_security_tools": ()}
+
+    tools: list[str] = []
+    # The substring sniff is conservative — it under-counts if the
+    # workflow references a tool only by uses: <action> path. That's
+    # fine: a false negative produces a more verbose recommendation, a
+    # false positive silently skips a useful one. Bias toward verbosity.
+    detectors = {
+        "gitleaks": ("gitleaks",),
+        "trufflehog": ("trufflehog",),
+        "codeql": ("codeql",),
+        "trivy": ("trivy",),
+        "grype": ("grype",),
+        "semgrep": ("semgrep",),
+        "snyk": ("snyk",),
+        "dependency-review": ("dependency-review",),
+        "osv-scanner": ("osv-scanner",),
+    }
+    for wf in workflows.glob("*.yml"):
+        content = _read_text(wf).lower()
+        if not content:
+            continue
+        for name, patterns in detectors.items():
+            if name in tools:
+                continue
+            if any(p in content for p in patterns):
+                tools.append(name)
+    for wf in workflows.glob("*.yaml"):
+        content = _read_text(wf).lower()
+        if not content:
+            continue
+        for name, patterns in detectors.items():
+            if name in tools:
+                continue
+            if any(p in content for p in patterns):
+                tools.append(name)
+
+    return {
+        "ci_has_security_scanning": bool(tools),
+        "ci_security_tools": tuple(sorted(tools)),
+    }
+
+
+def _count_python_loc_outside_tests(repo: Path) -> int:
+    """Return total non-test Python LOC. Skips ``.venv`` and test paths."""
+    skip_dir_names = {".venv", "venv", "node_modules", "tests", "test", "__pycache__"}
+    total = 0
+    for py in repo.rglob("*.py"):
+        if not py.is_file():
+            continue
+        parts = py.relative_to(repo).parts
+        if any(part in skip_dir_names for part in parts[:-1]):
+            continue
+        if py.name.startswith("test_") or py.name.endswith("_test.py"):
+            continue
+        try:
+            total += sum(
+                1 for line in py.read_text(encoding="utf-8", errors="replace").splitlines()
+                if line.strip()  # non-blank
+            )
+        except OSError:
+            continue
+        if total >= _PYTHON_INCIDENTAL_LOC_THRESHOLD * 10:
+            # Bail early — we only care about the < 50 boundary.
+            return total
+    return total
+
+
+def _detect_project_shape(repo: Path) -> dict[str, object]:
+    """Detect ComfyUI-pack pattern and Python-incidental projects."""
+    init_py = repo / "__init__.py"
+    is_comfyui_pack = bool(init_py.exists() and _COMFYUI_PACK_MARKERS.search(_read_text(init_py)))
+
+    # Also scan the top-level package dir for the marker (some packs
+    # put __init__.py inside the slug-named directory).
+    if not is_comfyui_pack:
+        for sub in repo.iterdir():
+            if sub.is_dir() and not sub.name.startswith("."):
+                child_init = sub / "__init__.py"
+                if (
+                    child_init.exists()
+                    and _COMFYUI_PACK_MARKERS.search(_read_text(child_init))
+                ):
+                    is_comfyui_pack = True
+                    break
+
+    loc = _count_python_loc_outside_tests(repo)
+    return {
+        "is_comfyui_pack": is_comfyui_pack,
+        "is_python_incidental": loc < _PYTHON_INCIDENTAL_LOC_THRESHOLD,
+        "python_loc_outside_tests": loc,
+    }
+
+
+def profile_stack(repo_path: Path) -> StackProfile:
+    """Compute a :class:`StackProfile` for ``repo_path``.
+
+    Safe to call on any directory — returns a profile with all-False
+    fields when no tooling is detected.
+    """
+    fields: dict[str, object] = {}
+    fields.update(_detect_js_stack(repo_path))
+    fields.update(_detect_python_stack(repo_path))
+    fields.update(_detect_ci_security(repo_path))
+    fields.update(_detect_project_shape(repo_path))
+    return StackProfile(**fields)  # type: ignore[arg-type]

--- a/git-repo-agent/tests/test_stack_profile.py
+++ b/git-repo-agent/tests/test_stack_profile.py
@@ -1,0 +1,249 @@
+"""Regression tests for issue #1359 — stack-aware findings.
+
+The maintain pass previously generated findings from a generic Python-
+library template, recommending tools that conflict with the project's
+chosen stack (e.g. ESLint when biome is already installed, pyright when
+the project has no Python beyond a 5-line stub).
+
+These tests pin the :class:`StackProfile` behaviour that
+``health_check.compute_health_score`` consults to suppress those
+findings.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from git_repo_agent.tools.health_check import (
+    _score_quality,
+    _score_security,
+    compute_health_score,
+)
+from git_repo_agent.tools.stack_profile import StackProfile, profile_stack
+
+
+def _write(path: Path, content: str = "") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+class TestStackProfileJS:
+    def test_empty_repo_detects_nothing(self, tmp_path: Path):
+        profile = profile_stack(tmp_path)
+        assert isinstance(profile, StackProfile)
+        assert not profile.has_biome
+        assert not profile.has_eslint
+        assert not profile.has_prettier
+        assert not profile.has_tsconfig
+
+    def test_biome_json_detected(self, tmp_path: Path):
+        _write(tmp_path / "biome.json", "{}")
+        profile = profile_stack(tmp_path)
+        assert profile.has_biome
+
+    def test_biome_jsonc_detected(self, tmp_path: Path):
+        _write(tmp_path / "biome.jsonc", "{}")
+        profile = profile_stack(tmp_path)
+        assert profile.has_biome
+
+    def test_eslint_config_detected(self, tmp_path: Path):
+        _write(tmp_path / "eslint.config.js", "")
+        profile = profile_stack(tmp_path)
+        assert profile.has_eslint
+
+    def test_prettier_config_detected(self, tmp_path: Path):
+        _write(tmp_path / ".prettierrc.json", "{}")
+        profile = profile_stack(tmp_path)
+        assert profile.has_prettier
+
+
+class TestStackProfilePython:
+    def test_ruff_in_pyproject(self, tmp_path: Path):
+        _write(
+            tmp_path / "pyproject.toml",
+            "[tool.ruff]\nline-length = 100\n",
+        )
+        profile = profile_stack(tmp_path)
+        assert profile.has_ruff_lint
+        # Ruff's format subcommand works without [tool.ruff.format].
+        assert profile.has_ruff_format
+
+    def test_uv_lock_detected(self, tmp_path: Path):
+        _write(tmp_path / "uv.lock", "version = 1\n")
+        profile = profile_stack(tmp_path)
+        assert profile.uses_uv
+
+    def test_uv_build_backend_detected(self, tmp_path: Path):
+        _write(
+            tmp_path / "pyproject.toml",
+            '[build-system]\nrequires = ["uv_build"]\n',
+        )
+        profile = profile_stack(tmp_path)
+        assert profile.uses_uv
+
+    def test_ty_type_checker_detected(self, tmp_path: Path):
+        _write(tmp_path / "pyproject.toml", "[tool.ty]\n")
+        profile = profile_stack(tmp_path)
+        assert profile.has_python_type_checker
+        assert profile.python_type_checker_kind == "ty"
+
+    def test_basedpyright_detected(self, tmp_path: Path):
+        _write(tmp_path / "pyproject.toml", "[tool.basedpyright]\n")
+        profile = profile_stack(tmp_path)
+        assert profile.python_type_checker_kind == "basedpyright"
+
+    def test_pyright_detected(self, tmp_path: Path):
+        _write(tmp_path / "pyrightconfig.json", "{}")
+        profile = profile_stack(tmp_path)
+        assert profile.python_type_checker_kind == "pyright"
+
+    def test_mypy_detected(self, tmp_path: Path):
+        _write(tmp_path / "pyproject.toml", "[tool.mypy]\n")
+        profile = profile_stack(tmp_path)
+        assert profile.python_type_checker_kind == "mypy"
+
+
+class TestStackProfileCISecurity:
+    def test_no_workflows_means_no_security(self, tmp_path: Path):
+        profile = profile_stack(tmp_path)
+        assert not profile.ci_has_security_scanning
+        assert profile.ci_security_tools == ()
+
+    def test_gitleaks_workflow_detected(self, tmp_path: Path):
+        _write(
+            tmp_path / ".github" / "workflows" / "ci.yml",
+            "name: ci\non: push\njobs:\n  scan:\n    steps:\n      - uses: gitleaks/gitleaks-action@v2\n",
+        )
+        profile = profile_stack(tmp_path)
+        assert profile.ci_has_security_scanning
+        assert "gitleaks" in profile.ci_security_tools
+
+    def test_trivy_workflow_detected(self, tmp_path: Path):
+        _write(
+            tmp_path / ".github" / "workflows" / "security.yml",
+            "name: scan\non: push\njobs:\n  trivy:\n    steps:\n      - uses: aquasecurity/trivy-action@v0\n",
+        )
+        profile = profile_stack(tmp_path)
+        assert profile.ci_has_security_scanning
+        assert "trivy" in profile.ci_security_tools
+
+
+class TestStackProfileProjectShape:
+    def test_comfyui_pack_detected_top_level(self, tmp_path: Path):
+        _write(
+            tmp_path / "__init__.py",
+            'WEB_DIRECTORY = "./web"\nNODE_CLASS_MAPPINGS = {}\n',
+        )
+        profile = profile_stack(tmp_path)
+        assert profile.is_comfyui_pack
+
+    def test_comfyui_pack_detected_in_subdirectory(self, tmp_path: Path):
+        _write(
+            tmp_path / "my-pack" / "__init__.py",
+            'WEB_DIRECTORY = "./web"\n',
+        )
+        profile = profile_stack(tmp_path)
+        assert profile.is_comfyui_pack
+
+    def test_python_incidental_for_tiny_pack(self, tmp_path: Path):
+        _write(
+            tmp_path / "__init__.py",
+            'WEB_DIRECTORY = "./web"\nNODE_CLASS_MAPPINGS = {}\n',
+        )
+        profile = profile_stack(tmp_path)
+        assert profile.is_python_incidental
+        assert profile.python_loc_outside_tests < 50
+
+    def test_not_python_incidental_for_real_library(self, tmp_path: Path):
+        body_lines = "\n".join(f"x_{i} = {i}" for i in range(80))
+        _write(tmp_path / "src" / "lib.py", body_lines)
+        profile = profile_stack(tmp_path)
+        assert not profile.is_python_incidental
+        assert profile.python_loc_outside_tests >= 50
+
+
+class TestScoreQualityStackAware:
+    """Issue #1359: _score_quality respects existing stack."""
+
+    def test_biome_credits_formatter_slot(self, tmp_path: Path):
+        _write(tmp_path / "biome.json", "{}")
+        profile = profile_stack(tmp_path)
+        _, findings = _score_quality(tmp_path, profile=profile)
+        assert "No formatter configured" not in findings
+
+    def test_comfyui_pack_no_type_checker_finding(self, tmp_path: Path):
+        """A ComfyUI pack with a 5-line stub doesn't need a type checker."""
+        _write(
+            tmp_path / "__init__.py",
+            'WEB_DIRECTORY = "./web"\nNODE_CLASS_MAPPINGS = {}\n',
+        )
+        profile = profile_stack(tmp_path)
+        _, findings = _score_quality(tmp_path, profile=profile)
+        assert "No type checking configured" not in findings
+        # And the more verbose ty-variant should also be absent.
+        assert not any("type checking" in f for f in findings)
+
+    def test_python_incidental_no_type_checker_finding(self, tmp_path: Path):
+        """Trivial-Python projects suppress the type-checker finding."""
+        _write(tmp_path / "loader.py", "X = 1\n")
+        profile = profile_stack(tmp_path)
+        _, findings = _score_quality(tmp_path, profile=profile)
+        assert not any("type checking" in f for f in findings)
+
+    def test_real_python_library_still_warns(self, tmp_path: Path):
+        body = "\n".join(f"x_{i} = {i}" for i in range(80))
+        _write(tmp_path / "src" / "lib.py", body)
+        profile = profile_stack(tmp_path)
+        _, findings = _score_quality(tmp_path, profile=profile)
+        assert any("type checking" in f for f in findings)
+
+    def test_uv_ruff_project_recommends_ty(self, tmp_path: Path):
+        """uv+ruff project gets the ty-variant wording, not generic."""
+        _write(
+            tmp_path / "pyproject.toml",
+            '[tool.ruff]\nline-length = 100\n\n'
+            '[build-system]\nrequires = ["uv_build"]\n',
+        )
+        # Add enough Python LOC so the project isn't tagged "incidental".
+        body = "\n".join(f"x_{i} = {i}" for i in range(80))
+        _write(tmp_path / "src" / "lib.py", body)
+        profile = profile_stack(tmp_path)
+        _, findings = _score_quality(tmp_path, profile=profile)
+        assert any(
+            "ty" in f and "Astral" in f for f in findings
+        ), f"Expected ty/Astral wording in: {findings}"
+
+
+class TestScoreSecurityStackAware:
+    """Issue #1359: ``_score_security`` credits existing CI security tooling."""
+
+    def test_existing_gitleaks_workflow_credits_score(self, tmp_path: Path):
+        _write(
+            tmp_path / ".github" / "workflows" / "ci.yml",
+            "jobs:\n  scan:\n    steps:\n      - uses: gitleaks/gitleaks-action@v2\n",
+        )
+        profile = profile_stack(tmp_path)
+        _, findings = _score_security(tmp_path, profile=profile)
+        assert "No security scanning in CI" not in findings
+
+
+class TestComputeHealthScoreStackProfile:
+    """The top-level result must surface the stack profile."""
+
+    def test_stack_profile_in_output(self, tmp_path: Path):
+        _write(tmp_path / "biome.json", "{}")
+        _write(tmp_path / "pyproject.toml", "[tool.ruff]\n")
+        result = compute_health_score(tmp_path)
+        assert "stack_profile" in result
+        sp = result["stack_profile"]
+        assert sp["has_biome"] is True
+        assert sp["has_ruff_lint"] is True
+
+    def test_comfyui_pack_no_type_finding_in_aggregated_output(self, tmp_path: Path):
+        _write(
+            tmp_path / "__init__.py",
+            'WEB_DIRECTORY = "./web"\n',
+        )
+        result = compute_health_score(tmp_path)
+        quality_findings = result["findings"].get("quality", [])
+        assert not any("type checking" in f for f in quality_findings)


### PR DESCRIPTION
Closes #1359

## Summary

- New `StackProfile` dataclass (`tools/stack_profile.py`) sniffs the repo for JS/TS tooling (biome / eslint / prettier / tsconfig), Python tooling (ruff lint, ruff format, type checker flavor including `ty` / basedpyright / pyright / mypy, uv usage), CI security tooling (gitleaks, trivy, codeql, semgrep, snyk, osv-scanner, dependency-review), and project shape (ComfyUI custom-node packs, Python-incidental projects with < 50 LOC outside tests).
- `health_check.compute_health_score` computes the profile once and threads it into the per-category scorers; `_score_quality` and `_score_security` now consult it to credit existing tooling and suppress findings that don't apply to the project's stack/shape.
- For Astral-aligned projects (uv + ruff), the type-checker recommendation now defaults to `ty` rather than mypy/pyright.
- The `maintain` prompt gains a "respect the existing stack" section with a do-not-recommend table so the agent treats `stack_profile` as authoritative.

## Failure modes addressed (from the issue)

| Was recommending | On projects with | Now |
|---|---|---|
| ESLint/Prettier | `biome.json` | Credited; no finding |
| pyright/mypy | 5-line ComfyUI stub | Suppressed (shape-aware) |
| CodeQL workflow | existing gitleaks/trivy CI | Credited; no finding |
| mypy or pyright | uv + ruff (Astral) stack | Recommends `ty` instead |
| Coverage / py.typed / conftest.py | `is_python_incidental` | Suppressed |

## Test plan

- [x] 27 new tests cover `StackProfile` sniffing and `_score_quality` / `_score_security` stack-awareness
- [x] Full suite passes (318 tests, +27 from baseline)
- [ ] Smoke test on `comfyui-sampler-info`: re-run `maintain` and confirm pyright/CodeQL/ESLint recommendations are gone

## Interaction with #1358

This PR is independent of #1358 (#1358 fixes "maintain analyzes stale local state"). Together they cover the two failure modes the issue describes: stale state was making maintain re-suggest just-merged fixes, and generic templates were making it suggest tools that fight the stack. Either PR helps on its own; together they cover the original repro.
