### PR TITLE
feat(hooks-plugin): add no-calendar-estimates Stop hook (opt-in)

### DIFF
--- a/hooks-plugin/.claude-plugin/plugin.json
+++ b/hooks-plugin/.claude-plugin/plugin.json
@@ -133,6 +133,11 @@
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/task-completeness.sh",
             "timeout": 10000,
             "statusMessage": "Checking task completeness..."
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/no-calendar-estimates.sh",
+            "timeout": 5000
           }
         ]
       }

--- a/hooks-plugin/README.md
+++ b/hooks-plugin/README.md
@@ -159,6 +159,20 @@ Documentation files (`*.md`, `*.mdx`, `*.rst`, `*.txt`) and vendor/generated pat
 
 **Toggle:** `CLAUDE_HOOKS_DISABLE_TASK_COMPLETENESS=1`
 
+### no-calendar-estimates.sh
+
+A Stop hook that nudges the agent to restate work in tokens, context-window share, or effort tier (low/medium/high/max) rather than human calendar time (hours, days, weeks, months). AI work doesn't map to human time units; quoting calendar estimates is consistently misleading.
+
+| Aspect | Detail |
+|--------|--------|
+| Type | `command` (deterministic regex on the last assistant message) |
+| Default | **Disabled** (opt-in) |
+| Toggle | `CLAUDE_HOOKS_ENABLE_CALENDAR_ESTIMATES=1` |
+| Detection | Future-modal + estimation verb + number + time unit (`will/would/should/'ll … take/require/need … N minutes/hours/…`); explicit markers (`ETA`, `estimated`, `approximately`, `roughly`, `expect … N minutes/hours/…`) |
+| Skips | Past-tense observations (`took 2 hours`), frequency (`every 3 hours`), config values (`30-second timeout`), unit-less numbers |
+| Shape | One nudge per response — the `stop_hook_active` guard accepts the agent's revised response silently |
+| Reason | Carries positive guidance inline so the rule ships self-contained with the plugin (no `.claude/rules/` dependency in consuming repos) |
+
 ### test-verification.sh
 
 A **TaskCompleted** hook (previously a Stop hook) that runs an explicitly-fast test recipe when an Agent Teams task is marked complete. Three independent constraints make this hook conservative — every constraint is a silent no-op when unmet:
@@ -349,6 +363,7 @@ Every hook can be individually enabled or disabled via environment variables. Se
 | test-verification.sh | `CLAUDE_HOOKS_DISABLE_TEST_VERIFICATION=1` | Enabled |
 | event-logger.sh | `CLAUDE_HOOKS_ENABLE_EVENT_LOGGER=1` | **Disabled** (opt-in) |
 | bash-antipatterns-teach.sh | `CLAUDE_HOOKS_ENABLE_BASH_ANTIPATTERNS_TEACH=1` | **Disabled** (opt-in) |
+| no-calendar-estimates.sh | `CLAUDE_HOOKS_ENABLE_CALENDAR_ESTIMATES=1` | **Disabled** (opt-in) |
 
 Example — disable branch protection for a session:
 

--- a/hooks-plugin/hooks/no-calendar-estimates.sh
+++ b/hooks-plugin/hooks/no-calendar-estimates.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Stop hook — soft suggestion that the agent restate work in tokens / effort
+# tier rather than human calendar time. AI work doesn't map to hours, days,
+# weeks, or months; quoting calendar estimates is consistently misleading.
+#
+# Shape: one nudge per response. Fires {"decision":"block","reason":"..."} on
+# first detection; the agent revises; the stop_hook_active guard accepts the
+# revised response silently. The reason text carries the positive guidance
+# inline so it ships self-contained with the plugin — consumers don't need a
+# separate .claude/rules/ file.
+#
+# Opt-in: set CLAUDE_HOOKS_ENABLE_CALENDAR_ESTIMATES=1 to enable.
+set -uo pipefail
+
+# Opt-in guard — disabled by default
+if [ "${CLAUDE_HOOKS_ENABLE_CALENDAR_ESTIMATES:-0}" != "1" ]; then
+    exit 0
+fi
+
+INPUT=$(cat)
+STOP_HOOK_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false')
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty')
+
+# One nudge per response: after the agent revises, stop_hook_active=true and
+# the second pass accepts silently. Prevents loops.
+if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
+    exit 0
+fi
+
+if [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ]; then
+    exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    exit 0
+fi
+
+# Extract the last assistant message's text content from the JSONL transcript.
+LAST_RESPONSE=$(jq -Rs '
+    split("\n")
+    | map(select(length > 0))
+    | map(try fromjson catch null)
+    | map(select(. != null))
+    | map(select(.message.role == "assistant"))
+    | last
+    | if . == null then "" else
+        (.message.content
+         | if type == "string" then .
+           else map(select(.type == "text") | .text) | join("\n")
+         end)
+      end
+' "$TRANSCRIPT_PATH" 2>/dev/null || echo "")
+
+if [ -z "$LAST_RESPONSE" ]; then
+    exit 0
+fi
+
+# Calendar-time estimation regexes. Two carefully-scoped patterns:
+#
+#   PATTERN_FUTURE — future-tense modal + estimation verb + number + time unit.
+#     Catches: "this'll take 3 hours", "would take roughly 5 minutes",
+#              "should require 2 weeks", "will need about 30 minutes".
+#     Skips:   "took 2 minutes" (past tense), "every 3 hours" (frequency),
+#              "modified 2 days ago" (observation), "30s timeout" (config).
+#
+#   PATTERN_MARKER — explicit estimation marker + number + time unit.
+#     Catches: "ETA: 30 minutes", "estimated 2 days", "approximately 5 hours",
+#              "expect this in 2 weeks".
+#     Skips:   "about 30 minutes ago" (we drop "about" — too ambiguous past/future).
+#
+# Time-unit floor is "minute" — seconds are usually config (timeouts, sleeps,
+# retries) rather than effort estimates.
+#
+# Regex uses [^.!?]* (unbounded, but sentence-terminator-anchored) rather than
+# bounded {0,N} repetition. GNU grep's NFA implementation can hit catastrophic
+# backtracking on long bounded patterns with multiple groups; the unbounded
+# form stays linear and naturally stops at sentence boundaries.
+PATTERN_FUTURE="(will|would|should|could|may|might|'ll|going to|gonna)[^.!?]*(take|takes|taking|require|requires|need|needs)[^.!?]*([0-9]+|a few|several|many|couple)[^.!?]*(minute|hour|day|week|month|year)s?"
+PATTERN_MARKER="(ETA|estimate|estimated|estimating|expect|expects|expected|approximately|roughly|around)[^.!?]*([0-9]+|a few|several|many|couple)[^.!?]*(minute|hour|day|week|month|year)s?"
+
+if echo "$LAST_RESPONSE" | grep -qiE "$PATTERN_FUTURE|$PATTERN_MARKER"; then
+    REASON="Avoid quoting AI work in calendar time (hours, days, weeks, months). The honest units for agent work are: tokens consumed, context-window share remaining, effort tier (low / medium / high / max), tool-call count, or files / lines to touch. Restate the estimate in one of those units."
+    # shellcheck disable=SC2016  # jq expression, not shell expansion
+    jq -n --arg reason "$REASON" '{"decision": "block", "reason": $reason}'
+    exit 0
+fi
+
+exit 0

--- a/hooks-plugin/hooks/test-no-calendar-estimates.sh
+++ b/hooks-plugin/hooks/test-no-calendar-estimates.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Regression tests for no-calendar-estimates.sh
+#
+# Verifies that the Stop hook:
+#  - Stays silent when CLAUDE_HOOKS_ENABLE_CALENDAR_ESTIMATES is unset (opt-in).
+#  - Stays silent on stop_hook_active=true (one-nudge guard).
+#  - Blocks with the positive-guidance reason when the last assistant response
+#    contains future-tense calendar estimates.
+#  - Allows past-tense observations, frequency descriptions, and config values
+#    that mention time units.
+#
+# Run: bash hooks-plugin/hooks/test-no-calendar-estimates.sh
+# Exit 0 = all tests pass, Exit 1 = failures
+set -uo pipefail
+
+HOOK="$(dirname "$0")/no-calendar-estimates.sh"
+PASS=0
+FAIL=0
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Build a JSONL transcript containing one assistant message with the given text.
+# jq -c emits one compact line per object (JSONL format the hook expects).
+make_transcript() {
+    local text="$1"
+    local path="$2"
+    jq -nc --arg text "$text" '{
+        message: { role: "assistant", content: [{ type: "text", text: $text }] }
+    }' > "$path"
+}
+
+# Run the hook with a synthesized transcript and return its stdout.
+run_hook_output() {
+    local transcript="$1"
+    local stop_active="${2:-false}"
+    printf '{"transcript_path":"%s","stop_hook_active":%s}' "$transcript" "$stop_active" \
+        | CLAUDE_HOOKS_ENABLE_CALENDAR_ESTIMATES=1 bash "$HOOK" 2>/dev/null || true
+}
+
+# Run the hook without the opt-in env var set.
+run_hook_optout() {
+    local transcript="$1"
+    printf '{"transcript_path":"%s"}' "$transcript" \
+        | bash "$HOOK" 2>/dev/null || true
+}
+
+assert_blocks() {
+    local desc="$1" text="$2"
+    local t="$TMPDIR/transcript-$RANDOM.jsonl"
+    make_transcript "$text" "$t"
+    local out
+    out=$(run_hook_output "$t")
+    if echo "$out" | grep -q '"decision": "block"'; then
+        printf "  PASS: %s\n" "$desc"
+        PASS=$((PASS + 1))
+    else
+        printf "  FAIL: %s (expected block, got: %s)\n" "$desc" "$out"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_allows() {
+    local desc="$1" text="$2"
+    local t="$TMPDIR/transcript-$RANDOM.jsonl"
+    make_transcript "$text" "$t"
+    local out
+    out=$(run_hook_output "$t")
+    if [ -z "$out" ]; then
+        printf "  PASS: %s\n" "$desc"
+        PASS=$((PASS + 1))
+    else
+        printf "  FAIL: %s (expected silent allow, got: %s)\n" "$desc" "$out"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "=== no-calendar-estimates hook tests ==="
+
+# ── opt-in guard ──────────────────────────────────────────────────────────────
+echo ""
+echo "opt-in guard:"
+t="$TMPDIR/transcript-optout.jsonl"
+make_transcript "This will take 3 hours to finish." "$t"
+out=$(run_hook_optout "$t")
+if [ -z "$out" ]; then
+    printf "  PASS: %s\n" "hook is silent when CLAUDE_HOOKS_ENABLE_CALENDAR_ESTIMATES is unset"
+    PASS=$((PASS + 1))
+else
+    printf "  FAIL: hook fired without opt-in (output: %s)\n" "$out"
+    FAIL=$((FAIL + 1))
+fi
+
+# ── stop_hook_active guard ────────────────────────────────────────────────────
+echo ""
+echo "stop_hook_active guard:"
+t="$TMPDIR/transcript-active.jsonl"
+make_transcript "This will take 3 hours to finish." "$t"
+out=$(run_hook_output "$t" "true")
+if [ -z "$out" ]; then
+    printf "  PASS: %s\n" "stop_hook_active=true exits 0 (no re-blocking on revised response)"
+    PASS=$((PASS + 1))
+else
+    printf "  FAIL: stop_hook_active=true still blocked (output: %s)\n" "$out"
+    FAIL=$((FAIL + 1))
+fi
+
+# ── future-tense calendar estimates SHOULD block ──────────────────────────────
+echo ""
+echo "future-tense calendar estimates block:"
+assert_blocks "this'll take 3 hours"                "This'll take 3 hours to wire up."
+assert_blocks "should take about 2 weeks"           "The migration should take about 2 weeks."
+assert_blocks "would take roughly 5 minutes"        "Refactoring this would take roughly 5 minutes."
+assert_blocks "will need 30 minutes"                "We'll need 30 minutes to refactor the loader."
+assert_blocks "going to require 2 days"             "This is going to require 2 days of work."
+assert_blocks "could take a few weeks"              "Migrating could take a few weeks if we hit edge cases."
+
+# ── explicit estimate markers SHOULD block ────────────────────────────────────
+echo ""
+echo "explicit estimate markers block:"
+assert_blocks "ETA: 30 minutes"                     "ETA: 30 minutes for the rollout."
+assert_blocks "estimated 2 days"                    "I've estimated 2 days for this refactor."
+assert_blocks "approximately 5 hours"               "Approximately 5 hours of engineering effort."
+assert_blocks "expect this in 2 weeks"              "Expect this work in 2 weeks if priorities hold."
+assert_blocks "roughly 4 hours"                     "Roughly 4 hours to finish the migration."
+
+# ── past-tense and observational mentions SHOULD pass ─────────────────────────
+echo ""
+echo "past-tense and observational mentions pass:"
+assert_allows "past-tense took"                     "The migration took 2 hours to finish."
+assert_allows "modified N days ago"                 "The file was modified 2 days ago."
+assert_allows "frequency (every N hours)"           "The cron job runs every 3 hours."
+assert_allows "config timeout in seconds"           "The API timeout is 30 seconds."
+assert_allows "ran for N minutes"                   "The build ran for 5 minutes before failing."
+
+# ── unrelated content SHOULD pass ─────────────────────────────────────────────
+echo ""
+echo "unrelated content passes:"
+assert_allows "no time mentions at all"             "I've refactored the loader and updated the tests."
+assert_allows "number without time unit"            "There are 47 files in the dist directory."
+assert_allows "time unit without number"            "I'll add a few comments to the loader."
+
+# ── reason text carries positive guidance ─────────────────────────────────────
+echo ""
+echo "block reason carries positive guidance:"
+t="$TMPDIR/transcript-reason.jsonl"
+make_transcript "Would take about 3 hours" "$t"
+out=$(run_hook_output "$t")
+for token in "tokens" "context-window" "effort tier" "tool-call count"; do
+    if echo "$out" | grep -q "$token"; then
+        printf "  PASS: reason mentions '%s'\n" "$token"
+        PASS=$((PASS + 1))
+    else
+        printf "  FAIL: reason missing '%s' (output: %s)\n" "$token" "$out"
+        FAIL=$((FAIL + 1))
+    fi
+done
+
+# ── summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "─────────────────────────────────────"
+printf "Results: %d passed, %d failed\n" "$PASS" "$FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

A soft-suggestion Stop hook that nudges the agent to restate work in **tokens**, **context-window share**, or **effort tier** (low/medium/high/max) rather than human calendar time (hours, days, weeks, months). AI work doesn't map to human time units; quoting calendar estimates is consistently misleading.

## Shape

One nudge per response:

1. Hook detects calendar-time framing in the agent's last response.
2. Emits `{"decision":"block","reason":"..."}` with positive guidance inline.
3. Agent revises.
4. Second Stop fires with `stop_hook_active=true` — hook accepts silently.

The reason text carries the positive guidance inline so the rule ships **self-contained with the plugin** — consumer repos don't need a separate `.claude/rules/effort-estimation.md` file. Any repo that enables `hooks-plugin` and sets the opt-in env var gets both the enforcement and the teaching.

## Detection

| Catches | Skips |
|---|---|
| `this'll take 3 hours` | `the migration took 2 hours` (past tense) |
| `should take about 2 weeks` | `the cron runs every 3 hours` (frequency) |
| `would require 30 minutes` | `the API timeout is 30 seconds` (config) |
| `ETA: 30 minutes` | `modified 2 days ago` (observation) |
| `estimated 2 days`, `approximately 5 hours` | unit-less numbers, numberless time units |

Two scoped regexes:
- **PATTERN_FUTURE** — future-modal + estimation verb + number + time unit
- **PATTERN_MARKER** — explicit estimation marker (ETA, estimated, approximately, roughly, expect) + number + time unit

Time-unit floor is "minute" — seconds are usually config (timeouts, sleeps, retries) rather than effort estimates.

## Regex implementation note

The regex uses unbounded `[^.!?]*` (sentence-terminator-anchored) rather than bounded `{0,N}` repetition. GNU grep's NFA implementation hits catastrophic backtracking on long bounded patterns with multiple groups; the unbounded form stays linear and naturally stops at sentence boundaries. Discovered while writing the test suite — every block test failed silently with the bounded form because grep was being killed mid-evaluation.

## Opt-in

Disabled by default. Enable with `CLAUDE_HOOKS_ENABLE_CALENDAR_ESTIMATES=1`. The pet peeve is opinionated, so it follows the `event-logger.sh` / `bash-antipatterns-teach.sh` convention rather than the default-on `task-completeness.sh` convention.

## Files

- `hooks-plugin/hooks/no-calendar-estimates.sh` — the hook
- `hooks-plugin/hooks/test-no-calendar-estimates.sh` — 25-test regression suite
- `hooks-plugin/.claude-plugin/plugin.json` — wired into Stop chain with 5s timeout
- `hooks-plugin/README.md` — hook documentation and toggle row

## Test plan

- [x] `bash hooks-plugin/hooks/test-no-calendar-estimates.sh` — 25/25 pass
- [x] `bash hooks-plugin/hooks/test-task-completeness.sh` — 27/27 pass (no sibling regression)
- [x] `bash hooks-plugin/hooks/test-bash-antipatterns.sh` — 25/25 pass (no sibling regression)
- [x] `bash scripts/lint-shell-scripts.sh hooks-plugin/hooks/no-calendar-estimates.sh hooks-plugin/hooks/test-no-calendar-estimates.sh` — 0 errors, 0 warnings
- [x] `jq empty hooks-plugin/.claude-plugin/plugin.json` validates

## Discussion thread

Came out of a thread evaluating Reddit-sourced hook suggestions. After deciding most of the suggestions were either already implemented or actively undesirable, this one matched a real pet peeve (the OP of the source post had the same hook idea) and had a clean implementation path.

Decision path traced:
1. Hard block → too coercive, regex tuning becomes urgent
2. Soft suggestion via `additionalContext` → Stop hooks don't support that field
3. Soft suggestion via `{"decision":"block"}` + `stop_hook_active` guard → one nudge then accept; same shape as `task-completeness.sh`
4. Pair with a positive `.claude/rules/` file → doesn't propagate to consumer repos
5. Embed positive guidance in the hook's `reason` text → self-contained, ships with the plugin ✅


---
_Generated by [Claude Code](https://claude.ai/code/session_0146yBvj69hBCXvRpkK3MHgi)_