### PR TITLE
refactor: stub .claude/rules/docs-currency.md to defer to blueprint-docs-currency skill

### DIFF
--- a/.claude/rules/docs-currency.md
+++ b/.claude/rules/docs-currency.md
@@ -1,100 +1,41 @@
 ---
 created: 2026-04-24
-modified: 2026-04-24
-reviewed: 2026-04-24
+modified: 2026-05-23
+reviewed: 2026-05-23
 ---
 
 # Docs Currency
 
-Code and the docs that describe it land in the **same commit**. No deferred
-doc follow-ups, no "docs: update for X" three commits later, no notes to
-self in the PR description.
+> **Moved to plugin skill.** The canonical content lives in
+> [`blueprint-plugin/skills/blueprint-docs-currency/SKILL.md`](../../blueprint-plugin/skills/blueprint-docs-currency/SKILL.md).
+> This stub is kept for backward compatibility with existing
+> `.claude/rules/docs-currency.md` references (currently:
+> `configure-plugin/skills/multi-repo-discipline`,
+> `tools-plugin/skills/cli-smoke-recipes`, and the skill's own back-link).
 
-## The Rule
+The rule: code and the docs that describe it land in the **same commit**.
+No deferred doc follow-ups, no "docs: update for X" three commits later.
 
-> When a change modifies a public API, format spec, error enum, or
-> milestone status, the same commit touches the corresponding `docs/`
-> file. When a decision was made, the same commit lands a new or updated
-> ADR.
+For the same-commit scope, research-promotion workflow, pre-commit and
+pre-merge checklists, and sidecars-vs-authoritative-docs distinction,
+invoke the skill directly:
 
-## Why
+```
+/blueprint:blueprint-docs-currency
+```
 
-Separate doc commits rot. The code change lands first, the work gets
-noisy, the doc commit slips. Grep-based re-investigation months later
-turns up the code without the context that explains *why* it exists.
-Conversely, a same-commit code + docs pair survives indefinitely — the
-prose is findable from the code and the code is findable from the prose.
+## Why this dogfooding stub remains
 
-## Scope
-
-The rule applies when the change touches any of:
-
-- **Public API / schema** — function signatures, exported types,
-  generated schemas, protobuf, JSON-schema, OpenAPI
-- **File format specs** — binary/text format definitions, on-disk schemas
-- **Error enums / protocol codes** — user-visible error identifiers
-- **Milestone status / roadmap** — feature-tracker entries, `PLAN.md`,
-  `TODO.md`, release notes
-- **Decisions** — architectural choices that affect more than one module
-
-Ordinary implementation refactors, typo fixes, and internal helper churn
-do not require docs updates.
-
-## Research Promotion
-
-Findings produced by research — decompilation dumps, spec experiments,
-API probes, benchmark results — live in gitignored scratch
-(`tmp/research/…`). **Before** the feature that depends on those findings
-advances past "in progress" in the tracker, the findings move into
-`docs/` (and, if a decision was made, an ADR).
-
-Tracker-advancement gate:
-
-- [ ] Findings promoted to `docs/` at a canonical path
-- [ ] ADR filed if the research produced a decision
-- [ ] Tracker entry cites the new docs path in its evidence field
-
-If any box is unchecked, the tracker stays in "in progress."
-
-## Sidecars vs. authoritative docs
-
-| Layer | Audience | Content |
-|-------|----------|---------|
-| Sidecar (feature tracker, `TODO.md`) | Humans working in the repo | Priority, status, notes, evidence pointers |
-| Authoritative (`docs/`) | Anyone onboarding, debugging, or porting | Prose that survives without the author |
-
-Sidecars are fine; they are *not* documentation. If a reader needs the
-information to port, debug, or onboard, it belongs in `docs/`.
-
-## Pre-merge checklist
-
-Before merging a code change, ask:
-
-- [ ] Does this change the public API, file format, error enum, or
-      milestone status?
-- [ ] If yes, does the same commit touch the corresponding `docs/` file?
-- [ ] Was a decision made? If yes, is there a new or updated ADR?
-- [ ] Is `tmp/research/` empty (or intentionally scratch) for the change
-      being merged?
-
-Any unchecked box is a blocker. Fix in the same PR.
-
-## Why this lives here (claude-plugins)
-
-This file dogfoods the rule against claude-plugins itself. When a skill
+This file dogfoods the rule against claude-plugins itself — when a skill
 gains new behaviour, its README / skill-description / plugin README land
-in the same commit. The rule earned its own reusable skill
-(`blueprint-plugin:blueprint-docs-currency`) once it had survived a few
-weeks of practice here.
+in the same commit as the code. The narrative ("the rule earned its own
+reusable skill once it had survived a few weeks of practice here") is
+preserved so references from sibling skills resolve to a meaningful
+pointer rather than a 404.
 
 ## Related
 
-- `blueprint-plugin:blueprint-docs-currency` — reusable skill version of this rule
+- `blueprint-plugin:blueprint-docs-currency` — the reusable skill (canonical content)
 - `blueprint-plugin:blueprint-curate-docs` — mechanics of promoting research to ai_docs
 - `blueprint-plugin:blueprint-sync` — detects stale generated content
 - `.claude/rules/conventional-commits.md` — commit-type scopes that co-evolve with doc edits
-
-> Evidence: research landed without a same-commit `docs/` update — the
-> spec had to be reconstructed in a follow-up PR. The inverse pattern
-> (same-commit code + spec) survived grep-based re-investigation months
-> later without loss.


### PR DESCRIPTION
## Summary

Investigated Tier 5 of the consolidation analysis: which `.claude/rules/*.md` files are now redundant with published plugin skills.

- **`docs-currency.md`**: stubbed (41 → ~10 lines). The `blueprint-plugin:blueprint-docs-currency` skill explicitly identifies itself as "the reusable version" of this rule; substantive content is mirrored there. Three importers (`multi-repo-discipline`, `cli-smoke-recipes`, `blueprint-docs-currency`) preserved by leaving a stub pointer.
- **`agent-coworker-detection.md`**: left as-is. Investigation inverted the premise: the rule is actually the canonical design reference (5-signal design with platform-specific code snippets), and the `git-coworker-check` skill explicitly defers to it. 11 importers cite it as "the full rationale and signal design." Demoting it to a pointer would have broken authoritative cross-references.

Part of the Wave 1B consolidation pass.

## Test plan

- [ ] `docs-currency.md` stub still points readers at the canonical skill
- [ ] The three importers still resolve their cross-references
- [ ] `agent-coworker-detection.md` cross-references from 11 sites still work