### PR TITLE
feat(hooks-plugin): add SessionStart drift-nudge architecture

### DIFF
--- a/blueprint-plugin/hooks.json
+++ b/blueprint-plugin/hooks.json
@@ -2,6 +2,18 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Blueprint plugin validation hooks - see docs/hook-design-decisions.md",
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/blueprint-drift-probe.sh",
+            "timeout": 3000
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
     {
       "matcher": "Write(docs/prds/**)",

--- a/blueprint-plugin/hooks/blueprint-drift-probe.sh
+++ b/blueprint-plugin/hooks/blueprint-drift-probe.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# blueprint-drift-probe.sh — SessionStart probe for blueprint-plugin drift.
+#
+# Checks (when docs/blueprint/manifest.json is present):
+#   1. manifest.format_version vs the plugin's current format version (3.3.0)
+#   2. generated.rules[].content_hash vs current hash of the file on disk
+#   3. docs/blueprint/feature_tracker.json `last_updated` vs TODO.md mtime
+#
+# Emits findings to the shared drift-signal directory via drift-protocol.sh.
+# No-ops silently when manifest.json is absent.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Resolve protocol library. It ships from hooks-plugin. When this probe is
+# installed via the marketplace, both plugins live as siblings under
+# ~/.claude/plugins/<marketplace>/, so ../../hooks-plugin/hooks/lib resolves.
+PROTO_LIB="${SCRIPT_DIR}/../../hooks-plugin/hooks/lib/drift-protocol.sh"
+if [ ! -f "$PROTO_LIB" ]; then
+    # Best-effort fallback locations.
+    for candidate in \
+        "${CLAUDE_PLUGIN_ROOT:-}/../hooks-plugin/hooks/lib/drift-protocol.sh" \
+        "$HOME/.claude/plugins/hooks-plugin/hooks/lib/drift-protocol.sh"; do
+        if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+            PROTO_LIB="$candidate"
+            break
+        fi
+    done
+fi
+if [ ! -f "$PROTO_LIB" ]; then
+    exit 0
+fi
+# shellcheck source=../../hooks-plugin/hooks/lib/drift-protocol.sh
+# shellcheck disable=SC1091  # PROTO_LIB resolves at runtime via fallback chain
+. "$PROTO_LIB"
+
+drift_init "blueprint-plugin"
+drift_no_op_if_missing "docs/blueprint/manifest.json"
+
+CURRENT_FORMAT_VERSION="3.3.0"
+MANIFEST="${DRIFT_CWD}/docs/blueprint/manifest.json"
+
+# ---- check 1: format_version drift ----
+manifest_version=$(jq -r '.format_version // empty' "$MANIFEST" 2>/dev/null || echo "")
+if [ -n "$manifest_version" ] && [ "$manifest_version" != "$CURRENT_FORMAT_VERSION" ]; then
+    # Lexical compare is enough for "differs"; we don't try to order versions.
+    drift_add_finding warn \
+        format_version_drift \
+        "manifest format_version ${manifest_version} != plugin ${CURRENT_FORMAT_VERSION}" \
+        "/blueprint:upgrade"
+fi
+
+# ---- check 2: generated rule content_hash drift ----
+# generated.rules is an array of {path, content_hash, source_hash, ...}. If the
+# file on disk doesn't hash to content_hash anymore, someone hand-edited it.
+if command -v shasum >/dev/null 2>&1; then
+    drifted_count=0
+    while IFS=$'\t' read -r rule_path rule_hash; do
+        [ -z "$rule_path" ] && continue
+        [ -z "$rule_hash" ] && continue
+        full="${DRIFT_CWD}/${rule_path}"
+        [ -f "$full" ] || continue
+        current=$(shasum -a 256 "$full" 2>/dev/null | awk '{print $1}')
+        [ -z "$current" ] && continue
+        if [ "$current" != "$rule_hash" ]; then
+            drifted_count=$((drifted_count + 1))
+        fi
+    done < <(
+        jq -r '
+            (.generated.rules // [])[]
+            | select((.content_hash // "") != "")
+            | [.path, .content_hash]
+            | @tsv
+        ' "$MANIFEST" 2>/dev/null
+    )
+    if [ "$drifted_count" -gt 0 ]; then
+        drift_add_finding warn \
+            generated_rules_drift \
+            "${drifted_count} generated rule file(s) drifted from manifest hash" \
+            "/blueprint:sync"
+    fi
+fi
+
+# ---- check 3: feature_tracker last_updated vs TODO.md mtime ----
+TRACKER="${DRIFT_CWD}/docs/blueprint/feature_tracker.json"
+TODO="${DRIFT_CWD}/TODO.md"
+if [ -f "$TRACKER" ] && [ -f "$TODO" ]; then
+    tracker_iso=$(jq -r '.last_updated // empty' "$TRACKER" 2>/dev/null || echo "")
+    if [ -n "$tracker_iso" ]; then
+        # Convert tracker timestamp + TODO mtime to epoch seconds (portable).
+        tracker_epoch=""
+        if date -j -f "%Y-%m-%dT%H:%M:%SZ" "$tracker_iso" "+%s" >/dev/null 2>&1; then
+            tracker_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$tracker_iso" "+%s" 2>/dev/null)
+        elif date -j -f "%Y-%m-%d" "${tracker_iso%%T*}" "+%s" >/dev/null 2>&1; then
+            tracker_epoch=$(date -j -f "%Y-%m-%d" "${tracker_iso%%T*}" "+%s" 2>/dev/null)
+        elif date -d "$tracker_iso" "+%s" >/dev/null 2>&1; then
+            tracker_epoch=$(date -d "$tracker_iso" "+%s" 2>/dev/null)
+        fi
+        todo_epoch=$(stat -f %m "$TODO" 2>/dev/null || stat -c %Y "$TODO" 2>/dev/null || echo "")
+        if [ -n "$tracker_epoch" ] && [ -n "$todo_epoch" ] && [ "$todo_epoch" -gt "$tracker_epoch" ]; then
+            drift_add_finding warn \
+                feature_tracker_stale \
+                "TODO.md modified after feature_tracker last_updated (${tracker_iso})" \
+                "/blueprint:feature-tracker-sync"
+        fi
+    fi
+fi
+
+drift_emit
+exit 0

--- a/configure-plugin/.claude-plugin/plugin.json
+++ b/configure-plugin/.claude-plugin/plugin.json
@@ -8,6 +8,20 @@
   },
   "repository": "https://github.com/laurigates/claude-plugins",
   "license": "MIT",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/configure-drift-probe.sh",
+            "timeout": 3000
+          }
+        ]
+      }
+    ]
+  },
   "keywords": [
     "infrastructure",
     "standards",

--- a/configure-plugin/hooks/configure-drift-probe.sh
+++ b/configure-plugin/hooks/configure-drift-probe.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# configure-drift-probe.sh — SessionStart probe for configure-plugin drift.
+#
+# Checks (when .project-standards.yaml is present):
+#   1. last_configured > 90 days ago
+#   2. declared project_type vs detected stack (pyproject.toml / package.json /
+#      Cargo.toml / go.mod)
+#
+# Emits findings via the shared drift-protocol library. No-op when
+# .project-standards.yaml is absent.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PROTO_LIB="${SCRIPT_DIR}/../../hooks-plugin/hooks/lib/drift-protocol.sh"
+if [ ! -f "$PROTO_LIB" ]; then
+    for candidate in \
+        "${CLAUDE_PLUGIN_ROOT:-}/../hooks-plugin/hooks/lib/drift-protocol.sh" \
+        "$HOME/.claude/plugins/hooks-plugin/hooks/lib/drift-protocol.sh"; do
+        if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+            PROTO_LIB="$candidate"
+            break
+        fi
+    done
+fi
+if [ ! -f "$PROTO_LIB" ]; then
+    exit 0
+fi
+# shellcheck source=../../hooks-plugin/hooks/lib/drift-protocol.sh
+# shellcheck disable=SC1091  # PROTO_LIB resolves at runtime via fallback chain
+. "$PROTO_LIB"
+
+drift_init "configure-plugin"
+drift_no_op_if_missing ".project-standards.yaml"
+
+STANDARDS="${DRIFT_CWD}/.project-standards.yaml"
+
+# ---- check 1: last_configured > 90 days ----
+last_configured=$(
+    grep -m1 '^last_configured:' "$STANDARDS" 2>/dev/null \
+        | sed 's/^[^:]*:[[:space:]]*//' \
+        | tr -d '"' \
+        | tr -d "'" \
+        | tr -d '\r' \
+        || echo ""
+)
+if [ -n "$last_configured" ]; then
+    configured_epoch=""
+    # Accept YYYY-MM-DD or full ISO-8601.
+    if date -j -f "%Y-%m-%d" "${last_configured%%T*}" "+%s" >/dev/null 2>&1; then
+        configured_epoch=$(date -j -f "%Y-%m-%d" "${last_configured%%T*}" "+%s" 2>/dev/null)
+    elif date -d "$last_configured" "+%s" >/dev/null 2>&1; then
+        configured_epoch=$(date -d "$last_configured" "+%s" 2>/dev/null)
+    fi
+    if [ -n "$configured_epoch" ]; then
+        now_epoch=$(date +%s)
+        age_days=$(( (now_epoch - configured_epoch) / 86400 ))
+        if [ "$age_days" -gt 90 ]; then
+            drift_add_finding warn \
+                last_configured_stale \
+                ".project-standards.yaml last_configured ${age_days} days ago (>90)" \
+                "/configure:status"
+        fi
+    fi
+fi
+
+# ---- check 2: declared project_type vs detected stack ----
+declared_type=$(
+    grep -m1 '^project_type:' "$STANDARDS" 2>/dev/null \
+        | sed 's/^[^:]*:[[:space:]]*//' \
+        | tr -d '"' \
+        | tr -d "'" \
+        | tr -d '\r' \
+        || echo ""
+)
+if [ -n "$declared_type" ]; then
+    declared_lc=$(printf '%s' "$declared_type" | tr '[:upper:]' '[:lower:]')
+
+    detected=""
+    if [ -f "${DRIFT_CWD}/pyproject.toml" ] || [ -f "${DRIFT_CWD}/requirements.txt" ]; then
+        detected="python"
+    elif [ -f "${DRIFT_CWD}/package.json" ]; then
+        detected="node"
+    elif [ -f "${DRIFT_CWD}/Cargo.toml" ]; then
+        detected="rust"
+    elif [ -f "${DRIFT_CWD}/go.mod" ]; then
+        detected="go"
+    fi
+
+    if [ -n "$detected" ] && [ "$declared_lc" != "$detected" ]; then
+        # Avoid false positives for compound declarations like "python+node".
+        case "$declared_lc" in
+            *"$detected"*) ;;
+            *)
+                drift_add_finding warn \
+                    project_type_drift \
+                    "declared project_type='${declared_type}' but detected stack '${detected}'" \
+                    "/configure:status"
+                ;;
+        esac
+    fi
+fi
+
+drift_emit
+exit 0

--- a/evaluate-plugin/.claude-plugin/plugin.json
+++ b/evaluate-plugin/.claude-plugin/plugin.json
@@ -9,6 +9,20 @@
   },
   "repository": "https://github.com/laurigates/claude-plugins",
   "license": "MIT",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/evaluate-drift-probe.sh",
+            "timeout": 3000
+          }
+        ]
+      }
+    ]
+  },
   "keywords": [
     "evaluation",
     "benchmarking",

--- a/evaluate-plugin/hooks/evaluate-drift-probe.sh
+++ b/evaluate-plugin/hooks/evaluate-drift-probe.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# evaluate-drift-probe.sh — SessionStart probe for evaluate-plugin drift.
+#
+# Detects eval-results that are older than the SKILL.md they evaluate.
+# Layout (per evaluate-plugin/skills/evaluate-skill/SKILL.md):
+#
+#   <plugin>/skills/<skill>/SKILL.md
+#   <plugin>/skills/<skill>/eval-results/*.json
+#
+# If the SKILL.md mtime is newer than every result file in eval-results/, the
+# stored results no longer reflect what the skill currently does.
+#
+# No-ops when no eval-results/ directory exists anywhere in $DRIFT_CWD.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PROTO_LIB="${SCRIPT_DIR}/../../hooks-plugin/hooks/lib/drift-protocol.sh"
+if [ ! -f "$PROTO_LIB" ]; then
+    for candidate in \
+        "${CLAUDE_PLUGIN_ROOT:-}/../hooks-plugin/hooks/lib/drift-protocol.sh" \
+        "$HOME/.claude/plugins/hooks-plugin/hooks/lib/drift-protocol.sh"; do
+        if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+            PROTO_LIB="$candidate"
+            break
+        fi
+    done
+fi
+if [ ! -f "$PROTO_LIB" ]; then
+    exit 0
+fi
+# shellcheck source=../../hooks-plugin/hooks/lib/drift-protocol.sh
+# shellcheck disable=SC1091  # PROTO_LIB resolves at runtime via fallback chain
+. "$PROTO_LIB"
+
+drift_init "evaluate-plugin"
+
+# Discover any eval-results/ directories under the project.
+# Bounded depth so the probe stays cheap on monorepos.
+mapfile -t result_dirs < <(
+    find "$DRIFT_CWD" -maxdepth 5 -type d -name 'eval-results' -not -path '*/node_modules/*' -not -path '*/.git/*' 2>/dev/null
+)
+
+if [ "${#result_dirs[@]}" -eq 0 ]; then
+    drift_emit
+    exit 0
+fi
+
+mtime_of() {
+    # Cross-platform mtime (epoch seconds). Empty on failure.
+    stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null || echo ""
+}
+
+stale_count=0
+for results_dir in "${result_dirs[@]}"; do
+    # Skill dir is one level up.
+    skill_dir=$(dirname "$results_dir")
+    skill_md="${skill_dir}/SKILL.md"
+    [ -f "$skill_md" ] || continue
+
+    skill_mtime=$(mtime_of "$skill_md")
+    [ -z "$skill_mtime" ] && continue
+
+    # Most-recent result file in this dir.
+    newest_result_mtime=0
+    while IFS= read -r result; do
+        [ -z "$result" ] && continue
+        rm_=$(mtime_of "$result")
+        [ -z "$rm_" ] && continue
+        if [ "$rm_" -gt "$newest_result_mtime" ]; then
+            newest_result_mtime="$rm_"
+        fi
+    done < <(find "$results_dir" -maxdepth 1 -type f -name '*.json' 2>/dev/null)
+
+    if [ "$newest_result_mtime" -eq 0 ]; then
+        continue
+    fi
+
+    if [ "$skill_mtime" -gt "$newest_result_mtime" ]; then
+        stale_count=$((stale_count + 1))
+    fi
+done
+
+if [ "$stale_count" -gt 0 ]; then
+    drift_add_finding info \
+        eval_results_stale \
+        "${stale_count} skill(s) edited after their last eval-results run" \
+        "/evaluate:report"
+fi
+
+drift_emit
+exit 0

--- a/health-plugin/.claude-plugin/plugin.json
+++ b/health-plugin/.claude-plugin/plugin.json
@@ -3,6 +3,20 @@
   "name": "health-plugin",
   "version": "1.10.1",
   "description": "Diagnose and fix Claude Code configuration issues including plugin registry, settings, hooks, MCP servers, SessionStart executability, pre-commit validity, permissions coverage, and marketplace enrollment",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/health-drift-probe.sh",
+            "timeout": 3000
+          }
+        ]
+      }
+    ]
+  },
   "keywords": [
     "health",
     "diagnostics",

--- a/health-plugin/hooks/health-drift-probe.sh
+++ b/health-plugin/hooks/health-drift-probe.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# health-drift-probe.sh — SessionStart probe for health-plugin drift.
+#
+# Detects mismatch between the user's enabled plugin set and the project's
+# detected stack. Example: kubernetes-plugin enabled in a repo with no YAML
+# manifests, python-plugin enabled in a repo with no Python files.
+#
+# Reads ~/.claude/settings.json (.enabledPlugins is a map of "plugin@source"
+# -> bool). No-ops when the file is absent or has no enabled plugins.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PROTO_LIB="${SCRIPT_DIR}/../../hooks-plugin/hooks/lib/drift-protocol.sh"
+if [ ! -f "$PROTO_LIB" ]; then
+    for candidate in \
+        "${CLAUDE_PLUGIN_ROOT:-}/../hooks-plugin/hooks/lib/drift-protocol.sh" \
+        "$HOME/.claude/plugins/hooks-plugin/hooks/lib/drift-protocol.sh"; do
+        if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+            PROTO_LIB="$candidate"
+            break
+        fi
+    done
+fi
+if [ ! -f "$PROTO_LIB" ]; then
+    exit 0
+fi
+# shellcheck source=../../hooks-plugin/hooks/lib/drift-protocol.sh
+# shellcheck disable=SC1091  # PROTO_LIB resolves at runtime via fallback chain
+. "$PROTO_LIB"
+
+drift_init "health-plugin"
+
+SETTINGS="${HOME}/.claude/settings.json"
+if [ ! -f "$SETTINGS" ]; then
+    drift_emit
+    exit 0
+fi
+
+# Enabled plugin names (strip "@source" suffix). True-only entries.
+enabled=$(
+    jq -r '
+        (.enabledPlugins // {})
+        | to_entries[]
+        | select(.value == true)
+        | .key
+        | sub("@.*"; "")
+    ' "$SETTINGS" 2>/dev/null || echo ""
+)
+if [ -z "$enabled" ]; then
+    drift_emit
+    exit 0
+fi
+
+# Stack-detection map: plugin → "true" if the stack is detected in $DRIFT_CWD.
+declare -A detected_stack=()
+
+if find "$DRIFT_CWD" -maxdepth 3 \( -name '*.py' -o -name 'pyproject.toml' -o -name 'requirements.txt' \) -print -quit 2>/dev/null | grep -q .; then
+    detected_stack[python-plugin]=true
+fi
+if find "$DRIFT_CWD" -maxdepth 3 \( -name 'package.json' -o -name '*.ts' -o -name '*.tsx' \) -print -quit 2>/dev/null | grep -q .; then
+    detected_stack[typescript-plugin]=true
+fi
+if find "$DRIFT_CWD" -maxdepth 3 \( -name 'Cargo.toml' -o -name '*.rs' \) -print -quit 2>/dev/null | grep -q .; then
+    detected_stack[rust-plugin]=true
+fi
+if find "$DRIFT_CWD" -maxdepth 3 -name 'go.mod' -print -quit 2>/dev/null | grep -q .; then
+    detected_stack[go-plugin]=true
+fi
+if find "$DRIFT_CWD" -maxdepth 4 \( -name 'Chart.yaml' -o -name 'kustomization.yaml' -o -name 'Tiltfile' -o -name 'skaffold.yaml' \) -print -quit 2>/dev/null | grep -q .; then
+    detected_stack[kubernetes-plugin]=true
+elif find "$DRIFT_CWD" -maxdepth 3 -path '*/k8s/*.yaml' -print -quit 2>/dev/null | grep -q .; then
+    detected_stack[kubernetes-plugin]=true
+fi
+if find "$DRIFT_CWD" -maxdepth 3 \( -name 'Dockerfile' -o -name 'docker-compose.yml' -o -name 'compose.yaml' -o -name 'compose.yml' \) -print -quit 2>/dev/null | grep -q .; then
+    detected_stack[container-plugin]=true
+fi
+if find "$DRIFT_CWD" -maxdepth 3 \( -name '*.tf' -o -name '*.tofu' \) -print -quit 2>/dev/null | grep -q .; then
+    detected_stack[terraform-plugin]=true
+fi
+
+# Plugins we audit. Anything outside this list is left alone — many plugins
+# (git, hooks, prose, ...) have no stack to detect against.
+auditable_plugins=(
+    python-plugin
+    typescript-plugin
+    rust-plugin
+    go-plugin
+    kubernetes-plugin
+    container-plugin
+    terraform-plugin
+)
+
+unused_count=0
+unused_list=""
+while IFS= read -r plugin; do
+    [ -z "$plugin" ] && continue
+    # Only flag if this plugin is in the auditable set.
+    is_auditable=false
+    for ap in "${auditable_plugins[@]}"; do
+        if [ "$ap" = "$plugin" ]; then
+            is_auditable=true
+            break
+        fi
+    done
+    [ "$is_auditable" = "true" ] || continue
+
+    if [ -z "${detected_stack[$plugin]:-}" ]; then
+        unused_count=$((unused_count + 1))
+        if [ -z "$unused_list" ]; then
+            unused_list="$plugin"
+        else
+            unused_list="${unused_list}, ${plugin}"
+        fi
+    fi
+done <<< "$enabled"
+
+if [ "$unused_count" -gt 0 ]; then
+    drift_add_finding info \
+        enabled_plugins_unused \
+        "${unused_count} enabled plugin(s) with no detected stack: ${unused_list}" \
+        "/health:audit"
+fi
+
+drift_emit
+exit 0

--- a/hooks-plugin/.claude-plugin/plugin.json
+++ b/hooks-plugin/.claude-plugin/plugin.json
@@ -40,6 +40,11 @@
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/git-stash-session-init.sh",
             "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/drift-aggregator.sh",
+            "timeout": 5000
           }
         ]
       }

--- a/hooks-plugin/hooks/drift-aggregator.sh
+++ b/hooks-plugin/hooks/drift-aggregator.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# drift-aggregator.sh — SessionStart hook that consolidates per-plugin drift
+# findings into a single additionalContext nudge.
+#
+# Per-plugin probes (blueprint-drift-probe.sh, configure-drift-probe.sh, ...)
+# write to ${CLAUDE_DRIFT_SIGNALS_DIR:-/tmp/claude-drift-signals}/<sid>/<plugin>.json
+# during the same SessionStart event. This aggregator reads every file in that
+# directory, sorts findings by severity (error > warn > info) then plugin name,
+# caps at 5 lines, and emits a single hookSpecificOutput.additionalContext block
+# back to Claude.
+#
+# Opt-out: CLAUDE_HOOKS_DISABLE_DRIFT_NUDGE=1 → silent exit.
+#
+# Loop prevention: SessionStart fires once per session, not per turn — no
+# stop_hook_active guard needed.
+
+set -uo pipefail
+
+# Opt-out
+if [ "${CLAUDE_HOOKS_DISABLE_DRIFT_NUDGE:-0}" = "1" ]; then
+    exit 0
+fi
+
+# Require jq — without it we cannot parse signals or emit valid JSON.
+if ! command -v jq >/dev/null 2>&1; then
+    exit 0
+fi
+
+INPUT=$(cat)
+SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
+if [ -z "$SESSION_ID" ]; then
+    exit 0
+fi
+
+# Sanitize (same rules as drift-protocol.sh).
+SESSION_ID=$(printf '%s' "$SESSION_ID" | tr -cd 'a-zA-Z0-9_-')
+if [ -z "$SESSION_ID" ]; then
+    exit 0
+fi
+
+SIGNAL_BASE="${CLAUDE_DRIFT_SIGNALS_DIR:-/tmp/claude-drift-signals}"
+SIGNAL_DIR="${SIGNAL_BASE}/${SESSION_ID}"
+
+# No signals at all = nothing to report. This is the no-drift path.
+if [ ! -d "$SIGNAL_DIR" ]; then
+    exit 0
+fi
+
+# Concatenate all valid signal files into a single findings stream.
+# Each signal contributes its `findings[]` plus its `plugin` field so we can
+# render the plugin name on the nudge line.
+#
+# Defensive jq: `.findings // [] | .[]` skips malformed files (missing key,
+# wrong type) instead of erroring out. The `try ... catch empty` in the outer
+# stream filter skips files whose top-level JSON is unparseable.
+VALID_SIGNALS=()
+for sig in "$SIGNAL_DIR"/*.json; do
+    [ -f "$sig" ] || continue
+    if jq empty "$sig" >/dev/null 2>&1; then
+        VALID_SIGNALS+=("$sig")
+    fi
+done
+
+if [ "${#VALID_SIGNALS[@]}" -eq 0 ]; then
+    exit 0
+fi
+
+ALL_FINDINGS=$(
+    jq -s '
+        [
+          .[] as $sig
+          | ($sig.findings // [])[]
+          | . + {plugin: ($sig.plugin // "unknown")}
+        ]
+    ' "${VALID_SIGNALS[@]}" 2>/dev/null || echo "[]"
+)
+
+if [ -z "$ALL_FINDINGS" ] || [ "$ALL_FINDINGS" = "[]" ] || [ "$ALL_FINDINGS" = "null" ]; then
+    exit 0
+fi
+
+# Sort findings: error > warn > info, then plugin name asc, then kind asc.
+# jq lacks descending sort by string, so map severity to numeric rank.
+SORTED_FINDINGS=$(
+    printf '%s' "$ALL_FINDINGS" | jq -c '
+        map(
+          . + {
+            _rank: (
+              if .severity == "error" then 0
+              elif .severity == "warn" then 1
+              elif .severity == "info" then 2
+              else 3
+              end
+            )
+          }
+        )
+        | sort_by([._rank, .plugin, .kind])
+        | map(del(._rank))
+    ' 2>/dev/null || echo "$ALL_FINDINGS"
+)
+
+TOTAL=$(printf '%s' "$SORTED_FINDINGS" | jq 'length' 2>/dev/null || echo 0)
+if [ "$TOTAL" -eq 0 ] 2>/dev/null; then
+    exit 0
+fi
+
+MAX_LINES=5
+if [ "$TOTAL" -le "$MAX_LINES" ]; then
+    DISPLAY_COUNT="$TOTAL"
+    OVERFLOW=0
+else
+    DISPLAY_COUNT="$MAX_LINES"
+    OVERFLOW=$((TOTAL - MAX_LINES))
+fi
+
+# Render each displayed finding as one line:
+#   [SEVERITY] plugin-name: summary → /skill
+LINES=$(
+    printf '%s' "$SORTED_FINDINGS" | jq -r \
+        --argjson n "$DISPLAY_COUNT" '
+        .[:$n] | .[] |
+        "  [\(.severity | ascii_upcase)] \(.plugin): \(.summary) → \(.remediation_skill // "(no remediation skill)")"
+    ' 2>/dev/null || echo ""
+)
+
+if [ -z "$LINES" ]; then
+    exit 0
+fi
+
+FOOTER=""
+if [ "$OVERFLOW" -gt 0 ]; then
+    FOOTER=$(printf '\n  +%d more — run /health:check for the full list' "$OVERFLOW")
+fi
+
+CONTEXT=$(printf 'Drift detected since last session:\n%s%s\n\nOffer these to the user as appropriate.' "$LINES" "$FOOTER")
+
+# Emit the SessionStart additionalContext envelope.
+jq -n --arg ctx "$CONTEXT" '{
+  hookSpecificOutput: {
+    hookEventName: "SessionStart",
+    additionalContext: $ctx
+  }
+}'
+
+exit 0

--- a/hooks-plugin/hooks/lib/drift-protocol.sh
+++ b/hooks-plugin/hooks/lib/drift-protocol.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# drift-protocol.sh — shared helpers for drift-nudge probes.
+#
+# Source this from a SessionStart probe to write a per-plugin signal file under
+# ${CLAUDE_DRIFT_SIGNALS_DIR:-/tmp/claude-drift-signals}/<sanitized-session-id>/.
+#
+# The aggregator (hooks-plugin/hooks/drift-aggregator.sh) reads every JSON file
+# in that directory and emits one consolidated SessionStart additionalContext
+# nudge per session.
+#
+# Schema (per file):
+#   {
+#     "plugin": "<plugin-name>",
+#     "checked_at": "<ISO-8601 UTC>",
+#     "findings": [
+#       {
+#         "severity": "info|warn|error",
+#         "kind": "<short snake_case identifier>",
+#         "summary": "<one-line human readable>",
+#         "remediation_skill": "/<plugin>:<skill>"
+#       },
+#       ...
+#     ]
+#   }
+#
+# Always write the file (empty findings = "checked, no drift"). The aggregator
+# tells "didn't run" from "ran clean" by file presence.
+#
+# Sourcing pattern:
+#
+#   #!/usr/bin/env bash
+#   set -uo pipefail
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   # shellcheck source=../../hooks-plugin/hooks/lib/drift-protocol.sh
+#   . "${SCRIPT_DIR}/../../hooks-plugin/hooks/lib/drift-protocol.sh"
+#   drift_init "blueprint-plugin"   # parses stdin, sets DRIFT_SID / DRIFT_CWD, prepares signal dir
+#   drift_no_op_if_missing "docs/blueprint/manifest.json"
+#   drift_add_finding warn format_version_drift "manifest 3.2 < plugin 3.3" "/blueprint:upgrade"
+#   drift_emit
+
+# This file is sourced — we deliberately omit `set -e` so a non-zero command
+# inside a helper does not exit the calling probe. `set -uo pipefail` is safe
+# because every variable is initialized below and probes already enable both.
+set -uo pipefail
+
+# ---------- internals ----------
+
+# DRIFT_SID, DRIFT_CWD, DRIFT_PLUGIN, DRIFT_SIGNAL_DIR, DRIFT_SIGNAL_FILE
+# DRIFT_FINDINGS — JSON-array string built up by drift_add_finding.
+DRIFT_FINDINGS="[]"
+DRIFT_PLUGIN=""
+DRIFT_SID=""
+DRIFT_CWD=""
+DRIFT_SIGNAL_DIR=""
+DRIFT_SIGNAL_FILE=""
+
+# drift_signal_dir — returns the per-session signal directory path on stdout.
+# Honors $CLAUDE_DRIFT_SIGNALS_DIR override, sanitizes the session id, mkdir -p.
+drift_signal_dir() {
+    local sid="$1"
+    local base="${CLAUDE_DRIFT_SIGNALS_DIR:-/tmp/claude-drift-signals}"
+    # Sanitize: keep only alnum, hyphen, underscore. Prevents path traversal.
+    local clean
+    clean=$(printf '%s' "$sid" | tr -cd 'a-zA-Z0-9_-')
+    if [ -z "$clean" ]; then
+        clean="unknown"
+    fi
+    printf '%s/%s' "$base" "$clean"
+}
+
+# drift_init <plugin-name>
+#   Reads JSON hook input from stdin, populates DRIFT_* globals, ensures the
+#   signal directory exists. Exits 0 (silently) if session_id or cwd is missing,
+#   or if jq is unavailable.
+drift_init() {
+    DRIFT_PLUGIN="${1:-}"
+    if [ -z "$DRIFT_PLUGIN" ]; then
+        exit 0
+    fi
+
+    if ! command -v jq >/dev/null 2>&1; then
+        exit 0
+    fi
+
+    local input
+    input=$(cat)
+    DRIFT_SID=$(printf '%s' "$input" | jq -r '.session_id // empty' 2>/dev/null || true)
+    DRIFT_CWD=$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null || true)
+
+    if [ -z "$DRIFT_SID" ]; then
+        exit 0
+    fi
+
+    DRIFT_SIGNAL_DIR=$(drift_signal_dir "$DRIFT_SID")
+    DRIFT_SIGNAL_FILE="${DRIFT_SIGNAL_DIR}/${DRIFT_PLUGIN}.json"
+    mkdir -p "$DRIFT_SIGNAL_DIR" 2>/dev/null || exit 0
+}
+
+# drift_no_op_if_missing <path>
+#   Exit 0 (after writing an empty signal file) if the given path does not exist.
+#   Path is resolved relative to DRIFT_CWD when not absolute.
+drift_no_op_if_missing() {
+    local target="$1"
+    case "$target" in
+        /*) ;;
+        *)
+            if [ -n "$DRIFT_CWD" ]; then
+                target="${DRIFT_CWD}/${target}"
+            fi
+            ;;
+    esac
+    if [ ! -e "$target" ]; then
+        drift_emit
+        exit 0
+    fi
+}
+
+# drift_no_op_if_command_missing <command>
+#   Exit 0 (with empty signal) if a required CLI is unavailable.
+drift_no_op_if_command_missing() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        drift_emit
+        exit 0
+    fi
+}
+
+# drift_add_finding <severity> <kind> <summary> <remediation_skill>
+#   Append a finding to DRIFT_FINDINGS. Severity must be info|warn|error.
+drift_add_finding() {
+    local severity="$1"
+    local kind="$2"
+    local summary="$3"
+    local skill="$4"
+
+    case "$severity" in
+        info|warn|error) ;;
+        *) severity="info" ;;
+    esac
+
+    DRIFT_FINDINGS=$(
+        printf '%s' "$DRIFT_FINDINGS" | jq -c \
+            --arg sev "$severity" \
+            --arg kind "$kind" \
+            --arg summary "$summary" \
+            --arg skill "$skill" \
+            '. + [{severity: $sev, kind: $kind, summary: $summary, remediation_skill: $skill}]' \
+            2>/dev/null
+    ) || DRIFT_FINDINGS="[]"
+}
+
+# drift_emit — writes the signal file atomically and returns 0. Safe to call
+# multiple times; only the last DRIFT_FINDINGS state survives.
+drift_emit() {
+    if [ -z "$DRIFT_SIGNAL_FILE" ]; then
+        return 0
+    fi
+
+    local checked_at
+    checked_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")
+
+    local payload
+    payload=$(
+        jq -n -c \
+            --arg plugin "$DRIFT_PLUGIN" \
+            --arg checked_at "$checked_at" \
+            --argjson findings "$DRIFT_FINDINGS" \
+            '{plugin: $plugin, checked_at: $checked_at, findings: $findings}' \
+            2>/dev/null
+    ) || return 0
+
+    # Atomic write: temp file in same dir, then mv.
+    local tmp="${DRIFT_SIGNAL_FILE}.tmp.$$"
+    printf '%s\n' "$payload" > "$tmp" 2>/dev/null || return 0
+    mv -f "$tmp" "$DRIFT_SIGNAL_FILE" 2>/dev/null || rm -f "$tmp"
+}

--- a/taskwarrior-plugin/.claude-plugin/plugin.json
+++ b/taskwarrior-plugin/.claude-plugin/plugin.json
@@ -3,6 +3,20 @@
   "name": "taskwarrior-plugin",
   "version": "1.3.2",
   "description": "Coordination layer for multi-agent work using taskwarrior - parallel-safe queries, urgency scoring, and optional GitHub linkage via ghid/ghpr UDAs",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/taskwarrior-drift-probe.sh",
+            "timeout": 3000
+          }
+        ]
+      }
+    ]
+  },
   "keywords": [
     "taskwarrior",
     "coordination",

--- a/taskwarrior-plugin/hooks/taskwarrior-drift-probe.sh
+++ b/taskwarrior-plugin/hooks/taskwarrior-drift-probe.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# taskwarrior-drift-probe.sh — SessionStart probe for taskwarrior-plugin drift.
+#
+# The plugin's task-add skill references custom UDAs (bpid, bpdoc, bpms, ghid,
+# ghpr, agent, pid, host, branch, worktree). If those UDAs are not declared in
+# ~/.taskrc, `task add` silently drops the field. This probe surfaces that gap
+# at session start so the user can install the UDAs via `/taskwarrior:task-add`
+# (which offers the install).
+#
+# No-ops when ~/.taskrc is absent OR the task binary is missing.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PROTO_LIB="${SCRIPT_DIR}/../../hooks-plugin/hooks/lib/drift-protocol.sh"
+if [ ! -f "$PROTO_LIB" ]; then
+    for candidate in \
+        "${CLAUDE_PLUGIN_ROOT:-}/../hooks-plugin/hooks/lib/drift-protocol.sh" \
+        "$HOME/.claude/plugins/hooks-plugin/hooks/lib/drift-protocol.sh"; do
+        if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+            PROTO_LIB="$candidate"
+            break
+        fi
+    done
+fi
+if [ ! -f "$PROTO_LIB" ]; then
+    exit 0
+fi
+# shellcheck source=../../hooks-plugin/hooks/lib/drift-protocol.sh
+# shellcheck disable=SC1091  # PROTO_LIB resolves at runtime via fallback chain
+. "$PROTO_LIB"
+
+drift_init "taskwarrior-plugin"
+
+# No-op if user doesn't use taskwarrior.
+TASKRC="${HOME}/.taskrc"
+if [ ! -f "$TASKRC" ]; then
+    drift_emit
+    exit 0
+fi
+if ! command -v task >/dev/null 2>&1; then
+    drift_emit
+    exit 0
+fi
+
+# UDAs the plugin's task-add skill emits.
+required_udas=(bpid bpdoc bpms ghid ghpr agent pid host branch worktree)
+
+missing=()
+for uda in "${required_udas[@]}"; do
+    # Match either inline taskrc form (uda.<name>.type=...) or include-based.
+    # `task _udas` is the authoritative list; fall back to grep on taskrc.
+    if task _udas 2>/dev/null | grep -qx "$uda"; then
+        continue
+    fi
+    if grep -qE "^uda\.${uda}\.type" "$TASKRC" 2>/dev/null; then
+        continue
+    fi
+    missing+=("$uda")
+done
+
+if [ "${#missing[@]}" -gt 0 ]; then
+    list=$(IFS=, ; printf '%s' "${missing[*]}")
+    drift_add_finding warn \
+        udas_missing \
+        "${#missing[@]} UDA(s) missing from ~/.taskrc: ${list}" \
+        "/taskwarrior:task-add"
+fi
+
+drift_emit
+exit 0


### PR DESCRIPTION
## Summary

Auto-detect repo-state drift across five plugins at SessionStart and surface a single consolidated `additionalContext` nudge — instead of forcing the user to remember to run `/blueprint:status`, `/configure:status`, `/health:check`, etc.

Plan: https://github.com/laurigates/claude-plugins/blob/main/docs/(local-only) — implements the "Drift-Nudge Hook Architecture" plan approved in conversation.

### Architecture

- **Per-plugin probes** write structured findings to `${CLAUDE_DRIFT_SIGNALS_DIR:-/tmp/claude-drift-signals}/<sid>/<plugin>.json` via a shared protocol library (`drift_init`, `drift_no_op_if_missing`, `drift_add_finding`, `drift_emit`). Each probe no-ops silently when its state file is absent, so users who don't use a plugin never see noise.
- **`drift-aggregator.sh`** in `hooks-plugin` reads the signal dir, validates each file (defensively skips malformed JSON), sorts findings `error > warn > info` then plugin then kind, caps at 5 lines with a `+N more` footer, and emits one `hookSpecificOutput.additionalContext`.
- **Opt-out**: `CLAUDE_HOOKS_DISABLE_DRIFT_NUDGE=1` → silent exit.
- **Loop prevention** is implicit — SessionStart fires once per session.

### Probes shipped

| Plugin | Checks |
|---|---|
| blueprint | `manifest.format_version` vs `3.3.0`, `generated.rules[].content_hash` drift, `feature_tracker.last_updated` vs `TODO.md` mtime |
| configure | `.project-standards.yaml` `last_configured > 90 days`, declared `project_type` vs detected stack |
| health | `enabledPlugins` vs detected stack (python/typescript/rust/go/k8s/container/terraform) |
| evaluate | `eval-results/` mtimes vs sibling `SKILL.md` mtimes |
| taskwarrior | Required UDAs (`bpid`, `bpdoc`, `bpms`, `ghid`, `ghpr`, `agent`, `pid`, `host`, `branch`, `worktree`) missing from `~/.taskrc` |

### Files

**New** (7)
- `hooks-plugin/hooks/lib/drift-protocol.sh` — sourced helpers
- `hooks-plugin/hooks/drift-aggregator.sh` — SessionStart aggregator
- `blueprint-plugin/hooks/blueprint-drift-probe.sh`
- `configure-plugin/hooks/configure-drift-probe.sh`
- `health-plugin/hooks/health-drift-probe.sh`
- `evaluate-plugin/hooks/evaluate-drift-probe.sh`
- `taskwarrior-plugin/hooks/taskwarrior-drift-probe.sh`

**Edited** (6)
- `hooks-plugin/.claude-plugin/plugin.json` — append aggregator to `SessionStart` array
- `blueprint-plugin/hooks.json` — add `SessionStart` probe entry
- `configure-plugin/.claude-plugin/plugin.json` — add inline `hooks.SessionStart`
- `health-plugin/.claude-plugin/plugin.json` — same
- `evaluate-plugin/.claude-plugin/plugin.json` — same
- `taskwarrior-plugin/.claude-plugin/plugin.json` — same

## Test plan

- [x] `scripts/lint-shell-scripts.sh` → 0 errors, 0 warnings
- [x] shellcheck pre-commit hook passes
- [x] All 6 modified JSON manifests parse with `jq empty`
- [x] **Fresh checkout + empty `$HOME`** → all 5 probes emit empty findings, aggregator emits nothing
- [x] **Single-plugin drift** (force `format_version: 3.1.0` in manifest) → one WARN line
- [x] **Multi-plugin drift** (manifest drift + stale standards + wrong project_type) → 3 findings, sorted, 3 lines
- [x] **Overflow** (8 findings) → 5 lines + `+3 more — run /health:check for the full list` footer
- [x] **Opt-out** `CLAUDE_HOOKS_DISABLE_DRIFT_NUDGE=1` → aggregator silent regardless of drift
- [x] **Malformed signal JSON** in dir → aggregator skips it, valid signals still rendered

## Notes for reviewers

- The aggregator is wired into `hooks-plugin/.claude-plugin/plugin.json` `SessionStart` so it runs as part of the existing array (after `git-stash-session-init.sh`).
- Probe ordering across plugins is not guaranteed by Claude Code — accepted as a minor imperfection. If the aggregator runs before some probes, those signals miss the current session's nudge. Acceptable because drift doesn't change rapidly and the probe sets are deliberately read-only/cheap.
- Out-of-scope drift surfaces (documentation-plugin, git-plugin / release-please, agent-patterns-plugin, testing-plugin) are documented in the plan for awareness; revisit if signal emerges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)