### PR TITLE
feat(project-plugin): add Stop-hook nudge for /project:distill

### DIFF
--- a/project-plugin/.claude-plugin/plugin.json
+++ b/project-plugin/.claude-plugin/plugin.json
@@ -20,5 +20,18 @@
     "distill",
     "insights",
     "knowledge-capture"
-  ]
+  ],
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "args": ["bash", "${CLAUDE_PLUGIN_ROOT}/hooks/project-distill-nudge.sh"],
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/project-plugin/README.md
+++ b/project-plugin/README.md
@@ -172,6 +172,8 @@ Distill session insights into reusable knowledge: rules, skills, and justfile re
 /project:distill --dry-run      # Preview without changes
 ```
 
+**Auto-nudge:** A `Stop` hook (`hooks/project-distill-nudge.sh`) suggests `/project:distill --dry-run` at most once per session, only when (a) the session has ≥8 user turns, (b) the cwd's repo has either a `.claude/rules/` directory or a `justfile`, and (c) a recent user turn carries a wind-down phrase (`wrap up`, `done for today`, `gotta go`, etc.). The nudge is an offer only — the agent never runs `/project:distill` without explicit confirmation. To pre-silence it for a session, `touch ~/.cache/claude-project-distill-nudge/<session_id>` (the hook treats an existing marker as "already nudged"). To turn the hook off entirely, disable the plugin via `/plugin`.
+
 ### `changelog-review`
 Analyze Claude Code changelog for impacts on plugin development.
 

--- a/project-plugin/hooks/project-distill-nudge.sh
+++ b/project-plugin/hooks/project-distill-nudge.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Stop hook — nudges the agent to propose /project:distill when the user is
+# signaling end-of-session in a repo with a distillable surface
+# (`.claude/rules/` directory or a justfile).
+#
+# Fires at most once per session_id (state file). Conservative on three axes
+# (turn count, repo scope, wind-down phrasing) so it stays quiet on quick
+# lookups and on repos where there is nothing to distill into.
+
+set -euo pipefail
+
+input=$(cat)
+
+# Hard exits — never loop or run without the data we need
+stop_active=$(jq -r '.stop_hook_active // false' <<<"$input" 2>/dev/null || echo "false")
+[ "$stop_active" = "true" ] && exit 0
+
+session_id=$(jq -r '.session_id // empty' <<<"$input" 2>/dev/null || echo "")
+cwd=$(jq -r '.cwd // empty' <<<"$input" 2>/dev/null || echo "")
+transcript=$(jq -r '.transcript_path // empty' <<<"$input" 2>/dev/null || echo "")
+
+[ -z "$session_id" ] && exit 0
+[ -z "$transcript" ] && exit 0
+[ ! -f "$transcript" ] && exit 0
+
+# At most one nudge per session
+state_dir="${HOME}/.cache/claude-project-distill-nudge"
+mkdir -p "$state_dir"
+state_file="$state_dir/$session_id"
+[ -f "$state_file" ] && exit 0
+
+# Need substantial conversation — distill is heavier than wrap; raise the bar
+user_turns=$(grep -c '"role":"user"' "$transcript" 2>/dev/null || echo 0)
+[ "$user_turns" -lt 8 ] && exit 0
+
+# Scope filter: the cwd's repo must have something distillable. Resolve via
+# `git rev-parse --show-toplevel` so worktrees match against their parent
+# repo's surface. Fall back to cwd itself when not in a git repo.
+[ -z "$cwd" ] && exit 0
+[ ! -d "$cwd" ] && exit 0
+
+repo_root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || echo "$cwd")
+
+has_surface=0
+if [ -d "$repo_root/.claude/rules" ]; then
+    has_surface=1
+elif [ -f "$repo_root/justfile" ] || [ -f "$repo_root/Justfile" ]; then
+    has_surface=1
+fi
+
+[ "$has_surface" = 0 ] && exit 0
+
+# Wind-down signal in the last 3 user messages. Recent messages are at the
+# end of the transcript, so tail is enough.
+recent=$(grep '"role":"user"' "$transcript" 2>/dev/null | tail -3 || true)
+if ! echo "$recent" | grep -Eiq '\b(wrap up|wrap this|wrap the session|done for (today|now|the day)|calling it|good night|signing off|end of day|gotta go|heading out|i.?m done|thats it for|that.?s it for)\b'; then
+    exit 0
+fi
+
+# Mark and emit. `decision: block` injects the reason as continued context
+# so the agent will produce one more response — a /project:distill suggestion.
+touch "$state_file"
+
+reason="The user is wrapping up a session in a repo with a distillable surface (.claude/rules/ or a justfile). Before letting the session end, briefly offer to run /project:distill --dry-run so the user can preview captured learnings before applying. Cite the skill's 'Update Over Add' principle — favour updating existing rules/skills/recipes over creating new artifacts. Only nudge — never run /project:distill without explicit user confirmation."
+
+jq -nc --arg r "$reason" '{decision: "block", reason: $r}'

--- a/project-plugin/hooks/test-project-distill-nudge.sh
+++ b/project-plugin/hooks/test-project-distill-nudge.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# Regression tests for project-distill-nudge.sh
+#
+# Verifies that the Stop hook nudges /project:distill only when all three
+# filters pass (turn count >= 8, repo has distillable surface, recent user
+# turn carries a wind-down phrase) and stays silent otherwise.
+#
+# Semantic invariant (per .claude/rules/regression-testing.md): when the
+# hook fires, the emitted JSON must mention /project:distill literally so
+# downstream prose edits cannot silently break the nudge contract.
+#
+# Run: bash project-plugin/hooks/test-project-distill-nudge.sh
+# Exit 0 = all tests pass, Exit 1 = failures
+set -euo pipefail
+
+HOOK="$(dirname "$0")/project-distill-nudge.sh"
+PASS=0
+FAIL=0
+
+# Use a per-test state directory so this run cannot collide with a real
+# session's nudge marker. Override the HOME the hook sees.
+TEST_HOME=$(mktemp -d)
+REPO_WITH_RULES=$(mktemp -d)
+REPO_WITH_JUSTFILE=$(mktemp -d)
+REPO_PLAIN=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$REPO_WITH_RULES" "$REPO_WITH_JUSTFILE" "$REPO_PLAIN"' EXIT
+
+# REPO_WITH_RULES: has .claude/rules/, no justfile
+git -C "$REPO_WITH_RULES" init -q
+mkdir -p "$REPO_WITH_RULES/.claude/rules"
+echo "# rule" > "$REPO_WITH_RULES/.claude/rules/example.md"
+
+# REPO_WITH_JUSTFILE: has justfile, no .claude/rules/
+git -C "$REPO_WITH_JUSTFILE" init -q
+printf 'default:\n\t@echo ok\n' > "$REPO_WITH_JUSTFILE/justfile"
+
+# REPO_PLAIN: no distillable surface
+git -C "$REPO_PLAIN" init -q
+echo "# readme" > "$REPO_PLAIN/README.md"
+
+# Build a fake transcript file with N user messages and an optional final
+# user phrase. Each line is a minimal JSONL record carrying role=user.
+make_transcript() {
+    local turns="$1"
+    local final_phrase="${2:-}"
+    local path
+    path=$(mktemp)
+    local i=1
+    while [ "$i" -lt "$turns" ]; do
+        printf '{"role":"user","content":"step %d"}\n' "$i" >> "$path"
+        i=$((i + 1))
+    done
+    if [ -n "$final_phrase" ]; then
+        printf '{"role":"user","content":"%s"}\n' "$final_phrase" >> "$path"
+    else
+        printf '{"role":"user","content":"step %d"}\n' "$turns" >> "$path"
+    fi
+    echo "$path"
+}
+
+# Run the hook with a synthetic input JSON. Returns exit code via stdout.
+run_hook() {
+    local session_id="$1"
+    local cwd="$2"
+    local transcript="$3"
+    local extra="${4:-}"
+    local json exit_code=0
+    if [ -n "$extra" ]; then
+        json=$(jq -nc \
+            --arg sid "$session_id" \
+            --arg cwd "$cwd" \
+            --arg tp "$transcript" \
+            "{session_id: \$sid, cwd: \$cwd, transcript_path: \$tp, $extra}")
+    else
+        json=$(jq -nc \
+            --arg sid "$session_id" \
+            --arg cwd "$cwd" \
+            --arg tp "$transcript" \
+            '{session_id: $sid, cwd: $cwd, transcript_path: $tp}')
+    fi
+    printf '%s' "$json" | HOME="$TEST_HOME" bash "$HOOK" >/dev/null 2>&1 || exit_code=$?
+    echo "$exit_code"
+}
+
+run_hook_output() {
+    local session_id="$1"
+    local cwd="$2"
+    local transcript="$3"
+    local extra="${4:-}"
+    local json
+    if [ -n "$extra" ]; then
+        json=$(jq -nc \
+            --arg sid "$session_id" \
+            --arg cwd "$cwd" \
+            --arg tp "$transcript" \
+            "{session_id: \$sid, cwd: \$cwd, transcript_path: \$tp, $extra}")
+    else
+        json=$(jq -nc \
+            --arg sid "$session_id" \
+            --arg cwd "$cwd" \
+            --arg tp "$transcript" \
+            '{session_id: $sid, cwd: $cwd, transcript_path: $tp}')
+    fi
+    printf '%s' "$json" | HOME="$TEST_HOME" bash "$HOOK" 2>/dev/null || true
+}
+
+assert_exit() {
+    local desc="$1" expected="$2" actual="$3"
+    if [ "$actual" -eq "$expected" ]; then
+        printf "  PASS: %s\n" "$desc"
+        PASS=$((PASS + 1))
+    else
+        printf "  FAIL: %s (expected exit %d, got %d)\n" "$desc" "$expected" "$actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local desc="$1" pattern="$2" actual="$3"
+    if echo "$actual" | grep -q "$pattern"; then
+        printf "  PASS: %s\n" "$desc"
+        PASS=$((PASS + 1))
+    else
+        printf "  FAIL: %s (expected '%s' in: %s)\n" "$desc" "$pattern" "$actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_contains() {
+    local desc="$1" pattern="$2" actual="$3"
+    if echo "$actual" | grep -q "$pattern"; then
+        printf "  FAIL: %s (forbidden '%s' in: %s)\n" "$desc" "$pattern" "$actual"
+        FAIL=$((FAIL + 1))
+    else
+        printf "  PASS: %s\n" "$desc"
+        PASS=$((PASS + 1))
+    fi
+}
+
+echo "=== project-distill-nudge hook tests ==="
+
+# ── stop_hook_active guard ────────────────────────────────────────────────────
+echo ""
+echo "stop_hook_active guard:"
+TRANSCRIPT=$(make_transcript 10 "wrap up for the day")
+exit_code=$(run_hook "sess-loop" "$REPO_WITH_RULES" "$TRANSCRIPT" '"stop_hook_active":true')
+assert_exit "stop_hook_active=true exits 0 (no blocking)" 0 "$exit_code"
+rm -f "$TRANSCRIPT"
+
+# ── missing session_id / transcript guards ───────────────────────────────────
+echo ""
+echo "hard guards:"
+TRANSCRIPT=$(make_transcript 10 "wrap up for the day")
+exit_code=$(printf '{"cwd":"%s","transcript_path":"%s"}' "$REPO_WITH_RULES" "$TRANSCRIPT" \
+    | HOME="$TEST_HOME" bash "$HOOK" >/dev/null 2>&1; echo $?)
+assert_exit "missing session_id exits 0" 0 "$exit_code"
+
+exit_code=$(printf '{"session_id":"sess-no-tp","cwd":"%s"}' "$REPO_WITH_RULES" \
+    | HOME="$TEST_HOME" bash "$HOOK" >/dev/null 2>&1; echo $?)
+assert_exit "missing transcript_path exits 0" 0 "$exit_code"
+
+exit_code=$(printf '{"session_id":"sess-bad-tp","cwd":"%s","transcript_path":"/no/such/file"}' \
+    "$REPO_WITH_RULES" \
+    | HOME="$TEST_HOME" bash "$HOOK" >/dev/null 2>&1; echo $?)
+assert_exit "nonexistent transcript exits 0" 0 "$exit_code"
+rm -f "$TRANSCRIPT"
+
+# ── turn-count floor ─────────────────────────────────────────────────────────
+echo ""
+echo "turn-count floor (>=8):"
+TRANSCRIPT=$(make_transcript 5 "wrap up for the day")
+output=$(run_hook_output "sess-short" "$REPO_WITH_RULES" "$TRANSCRIPT")
+assert_not_contains "5 user turns does NOT emit a nudge" '"decision"' "$output"
+rm -f "$TRANSCRIPT"
+
+TRANSCRIPT=$(make_transcript 7 "wrap up for the day")
+output=$(run_hook_output "sess-just-under" "$REPO_WITH_RULES" "$TRANSCRIPT")
+assert_not_contains "7 user turns does NOT emit a nudge" '"decision"' "$output"
+rm -f "$TRANSCRIPT"
+
+# ── scope filter: repo with no distillable surface ───────────────────────────
+echo ""
+echo "scope filter:"
+TRANSCRIPT=$(make_transcript 10 "wrap up for the day")
+output=$(run_hook_output "sess-plain" "$REPO_PLAIN" "$TRANSCRIPT")
+assert_not_contains "repo without .claude/rules/ or justfile does NOT nudge" '"decision"' "$output"
+rm -f "$TRANSCRIPT"
+
+# ── wind-down phrase missing ─────────────────────────────────────────────────
+echo ""
+echo "wind-down phrase:"
+TRANSCRIPT=$(make_transcript 10 "what does this function do?")
+output=$(run_hook_output "sess-no-windown" "$REPO_WITH_RULES" "$TRANSCRIPT")
+assert_not_contains "no wind-down phrase does NOT nudge" '"decision"' "$output"
+rm -f "$TRANSCRIPT"
+
+# ── happy paths: all filters pass ────────────────────────────────────────────
+echo ""
+echo "happy paths (semantic invariant: /project:distill appears in reason):"
+
+TRANSCRIPT=$(make_transcript 10 "wrap up for the day")
+output=$(run_hook_output "sess-happy-rules" "$REPO_WITH_RULES" "$TRANSCRIPT")
+assert_contains "all filters pass with .claude/rules/ emits block" '"decision":"block"' "$output"
+assert_contains "block reason references /project:distill" '/project:distill' "$output"
+rm -f "$TRANSCRIPT"
+
+TRANSCRIPT=$(make_transcript 10 "im done for now")
+output=$(run_hook_output "sess-happy-just" "$REPO_WITH_JUSTFILE" "$TRANSCRIPT")
+assert_contains "all filters pass with justfile emits block" '"decision":"block"' "$output"
+assert_contains "block reason references /project:distill" '/project:distill' "$output"
+rm -f "$TRANSCRIPT"
+
+# ── once-per-session: state file ─────────────────────────────────────────────
+echo ""
+echo "once-per-session marker:"
+SESS_REPEAT="sess-repeat-$$"
+TRANSCRIPT=$(make_transcript 10 "wrap up for the day")
+# First call should nudge and create the marker
+output=$(run_hook_output "$SESS_REPEAT" "$REPO_WITH_RULES" "$TRANSCRIPT")
+assert_contains "first call in session emits block" '"decision":"block"' "$output"
+# Second call (same session_id) must NOT nudge
+output=$(run_hook_output "$SESS_REPEAT" "$REPO_WITH_RULES" "$TRANSCRIPT")
+assert_not_contains "second call in same session is silent" '"decision"' "$output"
+rm -f "$TRANSCRIPT"
+
+# ── summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/project-plugin/skills/project-distill/SKILL.md
+++ b/project-plugin/skills/project-distill/SKILL.md
@@ -23,6 +23,8 @@ Distill session insights into reusable project knowledge.
 | Want to update rules based on session experience | Need to check project infrastructure -> `/configure:status` |
 | Asked to "codify the workflow" or "analyze and promote session patterns to rules" | Need a one-off implementation, not a reusable rule -> implement directly |
 
+May also be auto-suggested at end-of-session when the cwd repo has `.claude/rules/` or a justfile and you signal wind-down — a Stop hook (`hooks/project-distill-nudge.sh`) injects a one-time offer to run `/project:distill --dry-run`.
+
 ## Core Principle: Update Over Add
 
 Before proposing any artifact, evaluate: Does it update an existing one? Does an existing one already cover this? Is this genuinely new and reusable? See [REFERENCE.md](REFERENCE.md) for detailed evaluation criteria.


### PR DESCRIPTION
## Summary

- Adds `project-plugin/hooks/project-distill-nudge.sh`, a deterministic Stop hook that offers `/project:distill --dry-run` at most once per session, only when (a) the session has >=8 user turns, (b) the cwd's repo has either `.claude/rules/` or a `justfile`, and (c) a recent user turn carries a wind-down phrase (`wrap up`, `done for today`, `gotta go`, ...).
- Registers the hook inline in `plugin.json` under `hooks.Stop` using the exec form, 10-second deadline.
- Ships `test-project-distill-nudge.sh` (14 cases) including a semantic-invariant assertion that the literal substring `/project:distill` appears in the injected reason -- per `.claude/rules/regression-testing.md`.
- README + SKILL.md get a short paragraph describing when the hook fires and how to silence it.

Modelled on `~/.claude/hooks/session-wrap-nudge.sh` (the FVH `/session-wrap` nudge), but scoped to ship inside the plugin so it reaches every marketplace user, not just the author. Pure-deterministic by design -- no Haiku eval; the filters are cheap, the nudge is just an offer the user can ignore, and the marker file + `stop_hook_active` guard prevent any loop.

## Why this earns its keep

`/project:distill` captures session learnings into `.claude/rules/`, skill bodies, and justfile recipes. The skill is genuinely useful but only when the user remembers to invoke it. Most sessions end without distillation, so reusable patterns are lost. The nudge converts "I should remember to do that" into "the agent just offered it, one beat to accept or decline."

## Test plan

- [x] `bash project-plugin/hooks/test-project-distill-nudge.sh` -- 14/14 pass (loop guard, hard guards, turn floor, scope filter, wind-down absence, two happy paths, once-per-session marker)
- [x] `shellcheck project-plugin/hooks/*.sh` -- clean
- [x] `bash scripts/lint-shell-scripts.sh` -- 0 errors / 0 warnings
- [x] `bash scripts/plugin-compliance-check.sh project-plugin` -- all checks green (one pre-existing line-count flag on the unrelated `changelog-review` skill)
- [x] `jq .` validation of `plugin.json` -- valid
- [x] Pre-commit ran on the commit (shellcheck, gitleaks, lint-context-commands, audit-skill-descriptions) -- all passed
- [ ] Smoke: in a repo with `.claude/rules/` and `justfile`, end a session with "wrapping up for the day" after >=8 turns; confirm the nudge fires exactly once
- [ ] Negative: in a repo with neither surface (e.g. `~/Documents`), confirm no nudge fires after the same wind-down

## Lifecycle bookkeeping

No additions/removals to the plugin set, so `marketplace.json`, `release-please-config.json`, `.release-please-manifest.json`, and `docs/PLUGIN-MAP.md` are intentionally untouched. The `feat(project-plugin)` scope triggers a minor version bump on `project-plugin` via release-please, which is correct for a new user-facing capability.

Co-authored with Claude (Opus 4.7 1M).

🤖 Generated with [Claude Code](https://claude.com/claude-code)