### PR TITLE
fix(kubernetes-plugin): allow chart-only helm subcommands without --kube-context

### DIFF
--- a/kubernetes-plugin/hooks/test-validate-kubectl-context.sh
+++ b/kubernetes-plugin/hooks/test-validate-kubectl-context.sh
@@ -100,6 +100,41 @@ assert_exit \
     "helm version (safe subcommand) is allowed" 0 \
     '{"tool_name":"Bash","tool_input":{"command":"helm version"}}'
 
+# Regression: `helm pull`/`fetch` and other chart-only subcommands were
+# missing from the safe list, blocking chart downloads from a repo even
+# though the commands never touch a cluster.
+assert_exit \
+    "helm pull --repo is allowed (downloads chart, no cluster)" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"helm pull --repo https://example.com/charts mychart --version 1.0.0"}}'
+
+assert_exit \
+    "helm fetch is allowed (alias for pull)" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"helm fetch mychart"}}'
+
+assert_exit \
+    "helm search repo is allowed" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"helm search repo --repo https://example.com/charts mychart"}}'
+
+assert_exit \
+    "helm lint is allowed (local chart analysis)" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"helm lint ./mychart"}}'
+
+assert_exit \
+    "helm dependency update is allowed (local chart deps)" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"helm dependency update ./mychart"}}'
+
+assert_exit \
+    "helm registry login is allowed (registry, not cluster)" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"helm registry login registry.example.com"}}'
+
+assert_exit \
+    "helm push is allowed (pushes to registry, not cluster)" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"helm push mychart-1.0.0.tgz oci://registry.example.com/charts"}}'
+
+assert_exit \
+    "helm verify is allowed (local provenance check)" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"helm verify mychart-1.0.0.tgz"}}'
+
 # ── Edge cases ───────────────────────────────────────────────────────────────
 echo ""
 echo "Edge cases:"

--- a/kubernetes-plugin/hooks/validate-kubectl-context.sh
+++ b/kubernetes-plugin/hooks/validate-kubectl-context.sh
@@ -111,7 +111,10 @@ fi
 if echo "$COMMAND_CLEAN" | grep -Eq '(^|\s|;|&&|\|)helm\s+'; then
 
     # Helm commands that don't need context
-    SAFE_HELM_SUBCOMMANDS="version|completion|env|repo|search|show|plugin|create|package|template"
+    # These operate on charts, repos, or registries — never on a cluster.
+    # Regression: `helm pull` (and its alias `helm fetch`) was missing, blocking
+    # chart downloads from a repo.
+    SAFE_HELM_SUBCOMMANDS="version|completion|env|repo|search|show|inspect|plugin|create|package|template|pull|fetch|lint|verify|dependency|registry|push"
 
     # Allow safe commands
     if echo "$COMMAND_CLEAN" | grep -Eq "helm\s+($SAFE_HELM_SUBCOMMANDS)"; then


### PR DESCRIPTION
## Summary

The `validate-kubectl-context.sh` hook was blocking `helm pull` (and several sibling commands) even though those commands never contact a Kubernetes cluster — they only download charts from a repository or operate on local chart files.

Reproduction:

```bash
helm pull --repo https://example.com/charts mychart --version 1.0.0
# Blocked: "HELM SAFETY: Missing --kube-context flag."
```

`helm pull --kube-context=anything pull ...` is nonsensical — there is no cluster involved. Users were forced to work around the hook for read-only chart operations.

## Fix

Expand `SAFE_HELM_SUBCOMMANDS` to cover the full set of helm subcommands that operate on charts, repos, or registries (never on a cluster):

| Subcommand | Operates on |
|------------|-------------|
| `pull` / `fetch` | Downloads chart from a repo |
| `lint` | Local chart analysis |
| `dependency` | Local chart dependencies |
| `verify` | Local provenance file |
| `registry` (login/logout) | OCI registry, not cluster |
| `push` | Pushes chart to a registry |
| `inspect` | Alias for `show` (already safe) |

## Regression tests

Adds eight assertions to `test-validate-kubectl-context.sh` — one per newly-safe subcommand. Full suite: 22 PASS / 0 FAIL.

## Test plan

- [x] `bash kubernetes-plugin/hooks/test-validate-kubectl-context.sh` — all 22 tests pass
- [x] Existing helm enforcement tests still pass (`helm install` without `--kube-context` is still blocked)
- [x] Existing kubectl enforcement tests unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_012yi9GRg9FT7n2vb9nqiWeK)_