### PR TITLE
ci(plugin-pr-checks): pass multi-line outputs via env to avoid shell injection

### DIFF
--- a/.github/workflows/plugin-pr-checks.yml
+++ b/.github/workflows/plugin-pr-checks.yml
@@ -30,29 +30,42 @@ jobs:
         id: changed
         run: |
           FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*-plugin/**' '.claude-plugin/marketplace.json' '**/skills/**' | head -50)
-          echo "files<<EOF" >> $GITHUB_OUTPUT
-          echo "$FILES" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          {
+            echo "files<<EOF"
+            echo "$FILES"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
-          # Extract unique plugin directories affected
-          PLUGINS=$(echo "$FILES" | grep -oP '^[a-z][^/]*-plugin' | sort -u)
-          echo "plugins<<EOF" >> $GITHUB_OUTPUT
-          echo "$PLUGINS" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-          echo "plugin_count=$(echo "$PLUGINS" | grep -c '.' || true)" >> $GITHUB_OUTPUT
+          # Extract unique plugin directories affected.
+          # Emit as a single space-separated line so downstream steps can
+          # interpolate the value without bash splitting it across multiple
+          # commands (see issue #1385).
+          PLUGINS=$(echo "$FILES" | grep -oP '^[a-z][^/]*-plugin' | sort -u | tr '\n' ' ')
+          PLUGINS=${PLUGINS% }
+          PLUGIN_COUNT=$(echo "$PLUGINS" | wc -w | tr -d ' ')
+          echo "plugins=$PLUGINS" >> "$GITHUB_OUTPUT"
+          echo "plugin_count=$PLUGIN_COUNT" >> "$GITHUB_OUTPUT"
 
           # Check if skill files changed
           SKILL_FILES=$(echo "$FILES" | grep -c 'skills/' || true)
-          echo "skill_count=$SKILL_FILES" >> $GITHUB_OUTPUT
+          echo "skill_count=$SKILL_FILES" >> "$GITHUB_OUTPUT"
 
       - name: Run plugin compliance checks
         id: compliance
         if: steps.changed.outputs.plugin_count != '0'
+        env:
+          PLUGINS: ${{ steps.changed.outputs.plugins }}
         run: |
-          RESULT=$(bash scripts/plugin-compliance-check.sh ${{ steps.changed.outputs.plugins }}) || true
-          echo "result<<EOF" >> $GITHUB_OUTPUT
-          echo "$RESULT" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          # Pass plugins via env var (not template interpolation) so a
+          # multi-plugin value cannot break the shell command. Word-split
+          # is intentional: the script takes plugin names as separate args.
+          # shellcheck disable=SC2086
+          RESULT=$(bash scripts/plugin-compliance-check.sh $PLUGINS) || true
+          {
+            echo "result<<COMPLIANCE_EOF"
+            echo "$RESULT"
+            echo "COMPLIANCE_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Check blueprint-upgrade target version drift
         if: contains(steps.changed.outputs.plugins, 'blueprint-plugin')
@@ -62,9 +75,14 @@ jobs:
         if: steps.compliance.outputs.result
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Pass the multi-line comment body via env var so markdown
+          # special characters (backticks, quotes, parentheses) cannot
+          # corrupt the shell command and pollute the gh API call
+          # (see issue #1385: PR #1384 hit HTTP 401 on this step).
+          COMMENT_BODY: ${{ steps.compliance.outputs.result }}
         run: |
-          gh pr comment ${{ github.event.pull_request.number }} \
-            --body "${{ steps.compliance.outputs.result }}"
+          gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY"
 
       - name: Claude Skill Quality Review
         if: steps.changed.outputs.skill_count != '0'


### PR DESCRIPTION
## Summary

Fixes #1385.

Resolves two structural bugs in `.github/workflows/plugin-pr-checks.yml` where multi-line GitHub Actions outputs were template-interpolated raw into bash, breaking the compliance check for multi-plugin PRs and intermittently corrupting the comment-post step (the HTTP 401 from issue #1385).

## Bugs

1. **`plugins` output was multi-line.** When a PR touched 2+ plugins, the `${{ steps.changed.outputs.plugins }}` expansion in the next step broke the shell command in two:

   ```bash
   RESULT=$(bash scripts/plugin-compliance-check.sh agent-patterns-plugin
   agents-plugin
   hooks-plugin) || true
   ```

   Only `agent-patterns-plugin` was actually passed to the script; `agents-plugin` and `hooks-plugin` became their own commands (`command not found`). The bug is visible in run [26339830511](https://github.com/laurigates/claude-plugins/actions/runs/26339830511) — the comment body lists only one plugin row even though the PR touched three.

2. **`result` body was interpolated into `gh pr comment --body "..."`.** Multi-line markdown with backticks, quotes, parens, and emoji shouldn't be embedded directly into a shell command. The same run hit `HTTP 401: Bad credentials (https://api.github.com/graphql)` on this step despite the job's `GITHUB_TOKEN` correctly having `PullRequests: write` (visible in the run log's permissions block) — the most likely cause is that the malformed shell command poisoned the `gh` call rather than a real auth failure.

## Fix

For both values: pass via `env:` and reference as quoted shell variables. Emit `plugins` as a single space-separated line so the intentional word-splitting on the script invocation still works (with an explicit `shellcheck disable=SC2086`).

| Step | Before | After |
|------|--------|-------|
| `Run plugin compliance checks` | `bash ... ${{ steps.changed.outputs.plugins }}` (multi-line) | `bash ... $PLUGINS` (env, single-line) |
| `Post compliance results` | `gh pr comment N --body "${{ ... }}"` | `gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY"` |

The job-level `permissions:` block already grants `pull-requests: write`, so the original auth hypothesis in the issue (broken token scope) was a red herring — the real cause is the shell-interpolation antipattern.

## Test plan

- [x] `actionlint .github/workflows/plugin-pr-checks.yml` — clean
- [x] `shellcheck` of the new run blocks — only the expected SC2086 (intentional, disabled inline)
- [ ] Live workflow_dispatch / next PR — confirm both single-plugin and multi-plugin PRs comment correctly without `command not found` errors or 401 in the `Post compliance results` step

Closes #1385
