### PR TITLE
feat(agents-plugin): add checkpoint discipline to refactor/debug/docs

### DIFF
--- a/agents-plugin/agents/debug.md
+++ b/agents-plugin/agents/debug.md
@@ -3,11 +3,11 @@ name: debug
 model: opus
 color: "#FF7043"
 description: Diagnose and fix bugs. Finds root cause, implements fix, verifies solution. Handles errors, failures, and unexpected behavior.
-tools: Glob, Grep, LS, Read, Edit, Write, Bash(npm *), Bash(yarn *), Bash(bun *), Bash(pytest *), Bash(python *), Bash(node *), Bash(cargo *), Bash(go *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git show *), TaskOutput, TodoWrite
+tools: Glob, Grep, LS, Read, Edit, Write, Bash(npm *), Bash(yarn *), Bash(bun *), Bash(pytest *), Bash(python *), Bash(node *), Bash(cargo *), Bash(go *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git show *), Bash(git add *), Bash(git commit *), TaskOutput, TodoWrite
 maxTurns: 20
 created: 2025-12-27
-modified: 2026-05-07
-reviewed: 2026-04-22
+modified: 2026-05-26
+reviewed: 2026-05-26
 ---
 
 # Debug Agent
@@ -34,6 +34,22 @@ The harness blocks several common bash idioms — use the dedicated tool instead
 - **Input**: Bug description, error message, failing test, or unexpected behavior
 - **Output**: Fixed code, verification that issue is resolved
 - **Steps**: 5-15, completes the fix
+
+## Checkpoint Discipline
+
+Investigations that span multiple files or take many tool uses can exhaust context mid-task (issue #1390). If you sense the response is getting long — many reads, complex edits, repeated test runs — commit work-in-progress before continuing:
+
+1. Stage what's done with explicit paths: `git add <path1> <path2>` (never `-A` or `.`)
+2. Commit as a separate Bash call: `git commit -m "wip: <description> — checkpoint"` (do not chain with `&&`)
+3. Continue with the next step
+
+A checkpoint commit makes the investigation recoverable if context exhausts. The orchestrator can rebase or squash checkpoints into the final commit. Checkpoint after each of:
+
+| Signal | Action |
+|--------|--------|
+| Root cause located, fix in progress | Checkpoint the reproduction / instrumentation before applying the fix |
+| Fix applied, tests pending | Checkpoint the fix before running the verification step |
+| Tool-use count approaching 20 | Checkpoint immediately |
 
 ## Workflow
 

--- a/agents-plugin/agents/docs.md
+++ b/agents-plugin/agents/docs.md
@@ -3,11 +3,11 @@ name: docs
 model: haiku
 color: "#4A90E2"
 description: Generate documentation from code. Creates README files, API references, and inline documentation based on code analysis.
-tools: Glob, Grep, LS, Read, Edit, Write, TodoWrite
+tools: Glob, Grep, LS, Read, Edit, Write, Bash(git status *), Bash(git diff *), Bash(git add *), Bash(git commit *), TodoWrite
 maxTurns: 15
 created: 2025-12-27
-modified: 2026-05-07
-reviewed: 2026-04-18
+modified: 2026-05-26
+reviewed: 2026-05-26
 ---
 
 # Docs Agent
@@ -34,6 +34,16 @@ The harness blocks several common bash idioms — use the dedicated tool instead
 - **Input**: Code to document, documentation type needed
 - **Output**: Written documentation files
 - **Steps**: 5-10, focused output
+
+## Checkpoint Discipline
+
+Doc generation across multiple modules can exhaust context (issue #1390). If you sense the response is getting long — many reads, large generated files, multi-module coverage — commit work-in-progress before continuing:
+
+1. Stage what's done with explicit paths: `git add <path1> <path2>` (never `-A` or `.`)
+2. Commit as a separate Bash call: `git commit -m "wip: <description> — checkpoint"` (do not chain with `&&`)
+3. Continue with the next module
+
+A checkpoint commit makes partial docs recoverable if context exhausts. The orchestrator can rebase or squash checkpoints into the final commit. Checkpoint after each module's docs land, not in the middle of generating a single file.
 
 ## Workflow
 

--- a/agents-plugin/agents/refactor.md
+++ b/agents-plugin/agents/refactor.md
@@ -3,11 +3,11 @@ name: refactor
 model: sonnet
 color: "#7B1FA2"
 description: Code refactoring specialist. Restructures code for improved readability, maintainability, and SOLID adherence while preserving behavior. Use when code needs structural improvement without changing functionality.
-tools: Glob, Grep, LS, Read, Edit, Write, Bash(npm test *), Bash(npm run *), Bash(yarn test *), Bash(bun test *), Bash(pytest *), Bash(vitest *), Bash(cargo test *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(find *), Bash(ls *), Bash(wc *), Bash(rg *), Bash(python3 scripts/audit-skill-descriptions.py *), TodoWrite
+tools: Glob, Grep, LS, Read, Edit, Write, Bash(npm test *), Bash(npm run *), Bash(yarn test *), Bash(bun test *), Bash(pytest *), Bash(vitest *), Bash(cargo test *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(find *), Bash(ls *), Bash(wc *), Bash(rg *), Bash(python3 scripts/audit-skill-descriptions.py *), TodoWrite
 maxTurns: 20
 created: 2026-01-24
-modified: 2026-05-14
-reviewed: 2026-05-14
+modified: 2026-05-26
+reviewed: 2026-05-26
 ---
 
 # Refactor Agent
@@ -35,6 +35,25 @@ The harness blocks several common bash idioms — use the dedicated tool instead
 - **Output**: Refactored code with explanation of changes
 - **Steps**: 5-15, focused transformations
 - **Constraint**: Never change external behavior
+
+## Checkpoint Discipline
+
+Multi-file refactors can exhaust context mid-task (issue #1390). If you sense the response is getting long — many tool uses, large reads, complex edits across more than one file — commit work-in-progress before continuing:
+
+1. Stage what's done with explicit paths: `git add <path1> <path2>` (never `-A` or `.`)
+2. Commit as a separate Bash call: `git commit -m "wip: <description> — checkpoint"` (do not chain with `&&`)
+3. Continue with the next step
+
+A checkpoint commit makes partial work auditable and recoverable if context exhausts. The orchestrator can rebase or squash checkpoints into the final commit; better to land a series of small commits than abort with a dirty worktree.
+
+When to checkpoint:
+
+| Signal | Action |
+|--------|--------|
+| Touched 3+ files | Checkpoint before the next file |
+| Completed a logical sub-step (e.g. cross-ref updates done, merge work next) | Checkpoint before starting the next sub-step |
+| Source-skill deleted as part of a merge | Checkpoint before editing the target skill |
+| Tool-use count approaching 20 | Checkpoint immediately |
 
 ## Workflow
 


### PR DESCRIPTION
## Summary

When the refactor / debug / docs subagents exhaust context mid-task (#1390), the worktree is left dirty with no commit and recovery costs the orchestrator either a SendMessage round-trip to ask the agent to "just commit" or a fight with branch-protection (#1389).

This PR adds a `## Checkpoint Discipline` section to each of those three agent definitions and grants them `Bash(git add *)` and `Bash(git commit *)` so the guidance is actionable. With checkpoint commits in place, partial work survives context exhaustion as a `wip:` commit the orchestrator can later rebase or squash.

Wording is adapted from the #1391 issue body with two reinforcements:

- Explicit paths only (`git add <path>` — no `-A` / `.`), aligning with each agent's existing `## Tool Selection` block.
- Separate Bash calls (no `&&` chaining), aligning with `.claude/rules/bash-tool-replacements.md`.

So the new permissions cannot be used to emit the bash idioms the hooks already block.

## Per-agent tuning

| Agent | Checkpoint signals tuned for |
|---|---|
| refactor | 3+ files touched, logical sub-step boundaries, source-skill deletion during merge, tool-use ≈20 |
| debug | Reproduction/instrumentation done, fix applied before verification, tool-use ≈20 |
| docs | Between modules — not mid-file |

## What this does NOT do

- Does **not** address #1390 directly (the underlying "Prompt is too long" failure). That requires an audit of each agent's own system-prompt size — out of scope here. This PR makes the failures less destructive, not less frequent.
- Does **not** change any agent's `maxTurns` (still 20 for refactor/debug, 15 for docs).
- Does **not** add a regression test. The change is behaviour guidance, not a bug fix to a SKILL.md, so `.claude/rules/regression-testing.md` ("every bug fix to a SKILL.md file") does not apply. The existing `scripts/check-agent-tool-selection.sh` continues to pass on all 21 agent files.

## Test plan

- [x] `bash scripts/check-agent-tool-selection.sh` passes
- [x] Pre-commit hooks pass (shellcheck, secret detection, lint-context, skill-description audit, taskwarrior tag lint, agent tool-selection)
- [ ] Next real refactor / debug / docs dispatch lands a `wip:` checkpoint commit before context exhaustion — verifiable in CI by watching `git log --grep='^wip:'` on agent-pushed branches

Closes #1391
Refs #1390, #1389

🤖 Generated with [Claude Code](https://claude.com/claude-code)
