### PR TITLE
fix(kubernetes-plugin): strip quoted strings before kubectl/helm detection

### DIFF
--- a/kubernetes-plugin/hooks/test-validate-kubectl-context.sh
+++ b/kubernetes-plugin/hooks/test-validate-kubectl-context.sh
@@ -60,6 +60,63 @@ assert_exit \
     "helm in heredoc body" 0 \
     '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"$(cat <<'"'"'MSG'"'"'\nResolves helm --kube-context issue.\nMSG\n)\""}}'
 
+# ── Quoted-string false-positive regression tests ──────────────────────────
+# Regression (issue #1430): kubectl/helm mentioned inside a quoted grep
+# pattern, echo argument, awk regex, or find -name pattern was falsely
+# triggering this hook.
+echo ""
+echo "Quoted-string false-positive regression (#1430):"
+
+# grep with kubectl inside a double-quoted alternation pattern
+assert_exit \
+    "grep with kubectl in double-quoted pattern" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"grep -n \"pod-exec|pod-db|namespace|kubectl exec|skaffold\" justfile | head -40"}}'
+
+# grep with kubectl in a bare double-quoted pattern
+assert_exit \
+    "grep with bare kubectl pattern" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"grep -rn \"kubectl\" docs/"}}'
+
+# echo with kubectl in a double-quoted argument
+assert_exit \
+    "echo with kubectl in double-quoted arg" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"echo \"run kubectl get pods to list things\""}}'
+
+# awk with kubectl inside a single-quoted regex
+assert_exit \
+    "awk with kubectl in single-quoted regex" 0 \
+    "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"awk '/kubectl/ {print}' justfile\"}}"
+
+# find with kubectl in a quoted -name pattern
+assert_exit \
+    "find -name with kubectl in quoted pattern" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"find . -name \"kubectl*\" -type f"}}'
+
+# helm mentioned inside a quoted grep pattern
+assert_exit \
+    "grep with helm in double-quoted pattern" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"grep -n \"helm install\" justfile"}}'
+
+# Legitimate kubectl with quoted --context value (must still be allowed)
+assert_exit \
+    "kubectl with quoted --context value" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"kubectl --context=\"prod\" get pods"}}'
+
+# Legitimate kubectl with quoted argument after --context (must still be allowed)
+assert_exit \
+    "kubectl --context plus quoted positional arg" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"kubectl --context=staging get pods -l \"app=foo\""}}'
+
+# Pipe into kubectl (legitimate; must still be blocked without --context)
+assert_exit \
+    "pipe into kubectl without --context is blocked" 2 \
+    '{"tool_name":"Bash","tool_input":{"command":"cat manifest.yaml | kubectl apply -f -"}}'
+
+# Pipe into kubectl with --context (allowed)
+assert_exit \
+    "pipe into kubectl with --context is allowed" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"cat manifest.yaml | kubectl --context=staging apply -f -"}}'
+
 # ── kubectl enforcement tests ────────────────────────────────────────────────
 echo ""
 echo "kubectl enforcement:"

--- a/kubernetes-plugin/hooks/validate-kubectl-context.sh
+++ b/kubernetes-plugin/hooks/validate-kubectl-context.sh
@@ -70,8 +70,27 @@ strip_heredocs() {
     done
 }
 
-# Strip heredoc bodies before checking for kubectl/helm invocations
-COMMAND_CLEAN=$(printf '%s\n' "$COMMAND" | strip_heredocs)
+# Strip single- and double-quoted string contents so that kubectl/helm
+# mentioned inside a grep pattern, echo argument, awk regex, etc. does
+# not trigger validation. Only shell tokens outside quoted strings are
+# checked.
+#
+# Regression: `grep -n "kubectl exec|pod-db" justfile` falsely triggered
+# this hook because the substring "kubectl" inside the quoted grep
+# pattern matched the kubectl-detection regex. Legitimate kubectl
+# invocations like `kubectl --context="prod" get pods` are preserved
+# because the `kubectl` token sits outside the quoted string.
+#
+# Heuristic — escaped quotes (`"\""`) inside strings are not perfectly
+# handled, but the common case (grep patterns, echo/printf arguments,
+# awk regexes, find -name patterns) is covered.
+strip_quoted_strings() {
+    sed -E -e "s/'[^']*'//g" -e 's/"[^"]*"//g'
+}
+
+# Strip heredoc bodies, then quoted string contents, before checking
+# for kubectl/helm invocations.
+COMMAND_CLEAN=$(printf '%s\n' "$COMMAND" | strip_heredocs | strip_quoted_strings)
 
 # Commands that don't require --context (read-only info commands)
 # These are safe because they don't modify cluster state


### PR DESCRIPTION
## Summary

- Hook `kubernetes-plugin/hooks/validate-kubectl-context.sh` was matching the substring `kubectl` (and `helm`) anywhere in the command — including inside quoted grep patterns, echo strings, awk regexes, and `find -name` patterns — and falsely emitting *"KUBECTL SAFETY: Missing --context flag"*.
- Added a `strip_quoted_strings()` pass (mirroring the existing `strip_heredocs()` treatment) that removes single- and double-quoted string bodies before the kubectl/helm pattern checks.
- Legitimate kubectl invocations are preserved: `kubectl --context="prod" get pods` and `cat manifest.yaml | kubectl apply -f -` still trigger correctly because the `kubectl` token sits outside the quoted string.

## Repro before the fix

```
$ grep -n "pod-exec|pod-db|namespace|kubectl exec|skaffold" justfile
PreToolUse:Bash hook error: KUBECTL SAFETY: Missing --context flag.
```

After the fix this command exits 0 (allowed).

## Test plan

- [x] `bash kubernetes-plugin/hooks/test-validate-kubectl-context.sh` — 24/24 pass (14 pre-existing + 10 new regression cases for #1430)
- [x] Repro from issue body exits 0 against the patched hook
- [x] Legitimate `kubectl --context=…` invocations still allowed
- [x] `kubectl` without `--context` still blocked (including `cat manifest.yaml | kubectl apply` — pipe path)
- [x] `helm` quoted-string false-positive covered by symmetric test
- [x] `bash scripts/lint-shell-scripts.sh` — 0 errors, 0 warnings
- [x] Pre-commit hooks pass (shellcheck, detect-secrets)

## Notes

The fix is a heuristic: escaped quotes inside strings (`"foo \"kubectl\" bar"`) aren't perfectly handled, but the common cases the issue identifies (grep / echo / awk / find arguments) all pass.

Closes #1430
