### PR TITLE
fix(project-plugin): use shell command form for Stop hook

### DIFF
--- a/project-plugin/.claude-plugin/plugin.json
+++ b/project-plugin/.claude-plugin/plugin.json
@@ -27,10 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "args": [
-              "bash",
-              "${CLAUDE_PLUGIN_ROOT}/hooks/project-distill-nudge.sh"
-            ],
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/project-distill-nudge.sh",
             "timeout": 10
           }
         ]


### PR DESCRIPTION
## Summary

- The `project-plugin` manifest used the `args` (exec form) field for its Stop hook, but the marketplace JSON schema (`json.schemastore.org/claude-code-plugin-manifest.json`) doesn't accept it yet
- Result: `Plugin project-plugin has an invalid manifest file ... Validation errors: hooks: Invalid input`
- Swap to the `command` (shell form) string used by every other plugin with embedded hooks (`configure-plugin`, `evaluate-plugin`, `feedback-plugin`, `health-plugin`, `hooks-plugin`, `kubernetes-plugin`, `taskwarrior-plugin`)

The `args` form is documented in `.claude/rules/hooks-reference.md` as valid for Claude Code 2.1.139+, but the marketplace's manifest validator schema lags. The shell form is universally supported.

## Test plan

- [x] `jq .` parses the updated manifest
- [x] Hook shape matches sibling plugins (e.g. `hooks-plugin/.claude-plugin/plugin.json` Stop entries)
- [ ] After merge + marketplace refresh: `claude plugin details project-plugin` no longer reports the validation error