### PR TITLE
refactor(workflow-orchestration-plugin): dedupe wave-dispatch against agent-patterns

### DIFF
--- a/workflow-orchestration-plugin/skills/workflow-wave-dispatch/SKILL.md
+++ b/workflow-orchestration-plugin/skills/workflow-wave-dispatch/SKILL.md
@@ -4,29 +4,33 @@ description: Sequential-wave dispatch for multi-agent work with cross-task depen
 user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 created: 2026-04-24
-modified: 2026-04-24
-reviewed: 2026-04-24
+modified: 2026-05-29
+reviewed: 2026-05-29
 ---
 
 # Workflow Wave Dispatch
 
 Sequential waves, not parallel fan-out, when the work has real
-dependencies. Each wave runs to completion and passes a verification
-gate before the next wave is briefed.
+dependencies. This skill is the **workflow-side scheduling view**: which
+waves exist, what order they run in, and what to do when a gate fails.
+
+The **dispatch discipline** — the per-wave gate set, the research-before-WO
+gate, the ~10-line inline-fix threshold, the stable shared-file exclusion
+list, and Return Contract reuse — lives in
+`agent-patterns-plugin:wave-based-dispatch`. This skill does not restate it;
+it schedules around it.
 
 ## When to Use This Skill
 
-| Use wave-based dispatch when… | Use `parallel-agent-dispatch` alone when… |
-|-------------------------------|-------------------------------------------|
-| A later WO needs a file/type/API that an earlier WO defines | All WOs operate on disjoint file scopes with no shared definitions |
-| Research (decompile, spec probe, API experiment) gates downstream scope | Scope is fully known before dispatch |
-| Two candidates contend on an exclusive lock | No candidate touches a locked resource |
-| Shared-file edits would pile up if many agents ran in one batch | Orchestrator-only files are small, few, and well-understood |
-| Gate failure must block downstream work | Failure in one slab does not imply re-work in siblings |
+| Use this skill when… | Use the alternative when… |
+|----------------------|---------------------------|
+| Enumerating the waves and their ordering for a dependent landing | You need the per-wave gate set / dispatch discipline — use `agent-patterns-plugin:wave-based-dispatch` |
+| Deciding what to do when a wave's gate fails | Briefing the agents *inside* a wave — use `agent-patterns-plugin:parallel-agent-dispatch` |
+| Scheduling a research probe ahead of the implementation waves it unblocks | A tool holds an exclusive lock and the wave must pre-dump it — use `agent-patterns-plugin:exclusive-lock-dispatch` |
 
 `parallel-agent-dispatch` is the right call inside a wave. Waves are the
-layer above it — they answer "which agents run together" before
-`parallel-agent-dispatch` answers "how each agent is briefed."
+layer above it — they answer "which agents run together, in what order"
+before `parallel-agent-dispatch` answers "how each agent is briefed."
 
 ## Wave Structure
 
@@ -48,100 +52,17 @@ Wave N …
 
 Each wave is itself a `parallel-agent-dispatch` call. This skill covers
 wave **scheduling**: which waves exist, what gates between them, what to
-do when a gate fails.
-
-## Research-Before-WO Gate
-
-If the scope of a later work-order depends on information only a tool run
-can produce — decompilation output, a live API's actual behaviour, the
-real structure of a binary format, a spec experiment — run the research
-as its **own wave first**.
-
-- Research wave writes findings to gitignored scratch (`tmp/research/…`,
-  `tmp/decomp/…`).
-- Implementation wave is briefed **after** research returns, citing the
-  artefacts that now exist.
-- Do **not** bundle "decompile X, then implement Y" into one brief — the
-  implementation brief is stale before the research lands, and the agent
-  will either waste its window re-deriving the research or ship against
-  incorrect assumptions.
-
-Briefs for the implementation wave reference artefact paths:
-
-> "Inputs: `tmp/research/format-spec.md`, `tmp/decomp/strings.txt`. Do not
-> re-run the decompiler. If the artefacts are insufficient, return a
-> `partial` status with the missing question in `Orchestrator action
-> needed`."
-
-See `agent-patterns-plugin:exclusive-lock-dispatch` for the pre-dump
-mechanics when the research tool holds an exclusive lock.
-
-## Verification Gates Between Waves
-
-Every wave ends with a gate. No brief for wave N+1 is written before
-wave N's gate passes. Typical gates, in rough order of cost:
-
-| Gate | Signal |
-|------|--------|
-| Clean tree | `git status --porcelain` empty |
-| Build green | Project's compile / typecheck recipe succeeds |
-| Tests green | Project's test recipe succeeds |
-| Smoke recipes | Bulk-smoke recipes (see `tools-plugin:cli-smoke-recipes`) pass |
-| Task-queue state | Pending tasks for the wave drain to `done` |
-| Tracker drain | Feature tracker entries touched by the wave advance from `in progress` to `done` |
-| Docs currency | Same-commit docs updates present for any API / format / spec change |
-
-A gate failure **rolls back to "fix in place, retry the gate"** — never
-to "dispatch wave N+1 and paper over the failure." If the wave as a whole
-is un-recoverable, revert it and re-brief.
-
-## Inline Fix vs Re-Dispatch
-
-When a wave returns with small issues, the orchestrator has a choice:
-
-| Situation | Decision |
-|-----------|----------|
-| ~10 lines of fix, orchestrator has the symbolic context in its head | Fix inline |
-| Fix spans multiple files or needs the same exploration the agent did | File a follow-up WO, dispatch in the next wave |
-| Fix is mechanical (rename, move, format) | Fix inline |
-| Fix requires judgement about a design trade-off | Follow-up WO — judgement is cheaper to revisit than re-inject |
-
-The threshold is approximate. The deciding question is "will the
-orchestrator spend less time fixing in place than re-writing a brief and
-re-loading the agent's context?" Below ~10 lines, usually yes.
-
-## Return Contract Reuse
-
-Do **not** redefine the Return Contract per wave. Every agent in every
-wave uses the schema from
-`agent-patterns-plugin:parallel-agent-dispatch` §Return Contract verbatim.
-Redefining it per wave drifts the schema and breaks the orchestrator's
-parse step.
-
-Reference in the brief:
-
-> "Return contract: follow
-> `agent-patterns-plugin:parallel-agent-dispatch` §Return Contract
-> verbatim. Do not paraphrase."
-
-## Stable Exclusion List Across Waves
-
-The shared-file exclusion list (see
-`parallel-agent-dispatch` §Shared-File Exclusion List) is **cited once in
-the first wave's brief** and referenced by name in every subsequent
-wave's brief. Re-deriving the list per wave drifts it and produces
-silent manifest clobbers on the Nth wave.
-
-Example wave-N brief fragment:
-
-> "Orchestrator-only files: as in the wave-1 brief. No changes."
+do when a gate fails. The gate *set* itself is the six-gate table in
+`agent-patterns-plugin:wave-based-dispatch` § Six-Gate Verification Table.
 
 ## Scheduling Heuristics
 
 - Put the **lock-holder** (Ghidra, migration, bulk taskwarrior) alone in
-  its wave. See `exclusive-lock-dispatch`.
+  its wave. See `agent-patterns-plugin:exclusive-lock-dispatch`.
 - Put the **research wave** before any implementation wave that depends
-  on its artefacts.
+  on its artefacts (the research-before-WO gate in
+  `agent-patterns-plugin:wave-based-dispatch` explains why the downstream
+  WO's *size* collapses once the probe lands).
 - Put **foundation** (new types, new APIs, new files that others will
   import) in the earliest implementation wave.
 - Put **extensions** (new call sites, new tests, new docs) in later
@@ -149,30 +70,58 @@ Example wave-N brief fragment:
 - Inside a single wave, fan out to the widest safe parallelism that
   `parallel-agent-dispatch` allows.
 
+## Gate Failure: Roll Back, Don't Paper Over
+
+Every wave ends with a gate (the six-gate set lives in
+`agent-patterns-plugin:wave-based-dispatch`). No brief for wave N+1 is
+written before wave N's gate passes.
+
+A gate failure **rolls back to "fix in place, retry the gate"** — never
+to "dispatch wave N+1 and paper over the failure." If the wave as a whole
+is un-recoverable, revert it and re-brief.
+
+Whether a returned issue is fixed inline or filed as a follow-up WO for
+the next wave is the ~10-line inline-fix threshold — see
+`agent-patterns-plugin:wave-based-dispatch` § The ~10-Line Inline-Fix
+Threshold.
+
+## Shared Mechanics (owned by `wave-based-dispatch`)
+
+These are defined once in `agent-patterns-plugin:wave-based-dispatch` and
+referenced — never restated — when scheduling waves:
+
+| Mechanic | Where |
+|----------|-------|
+| Per-wave gate set | § Six-Gate Verification Table |
+| Research-before-WO gate | § The Research-Before-WO Gate |
+| Inline-fix vs follow-up WO | § The ~10-Line Inline-Fix Threshold |
+| Stable shared-file exclusion list across waves | § Stable Shared-File Exclusion List |
+| Return Contract reuse | `parallel-agent-dispatch` § Return Contract |
+
 ## Quick Reference
 
-### Orchestrator Checklist
+### Orchestrator Checklist (scheduling)
 
 - [ ] Waves enumerated with explicit dependencies identified
 - [ ] Research wave scheduled first if any scope depends on tool output
-- [ ] Gate defined for every wave boundary
-- [ ] Shared-file exclusion list cited in wave-1 brief, referenced later
-- [ ] Return Contract referenced from `parallel-agent-dispatch`, never redefined
-- [ ] Inline-fix threshold decided at wave-end, not mid-wave
+- [ ] Lock-holder isolated in its own wave
+- [ ] Foundation scheduled before extensions
+- [ ] A gate defined for every wave boundary (set per `wave-based-dispatch`)
 - [ ] No brief for wave N+1 written until wave N's gate passes
+- [ ] Gate failure → fix in place and retry, never dispatch-over
 
-### Common Mistakes
+### Common Scheduling Mistakes
 
 | Mistake | Correct Approach |
 |---------|-----------------|
-| Bundling "decompile X, then implement Y" in one brief | Split into research wave + implementation wave |
-| Dispatching wave N+1 after a gate failure to "patch over it" | Fix in place, retry the gate |
-| Redefining the Return Contract per wave | Reference `parallel-agent-dispatch` §Return Contract verbatim |
-| Re-deriving the exclusion list per wave | Cite once in wave 1, reference by name in later waves |
-| Treating every small issue as a follow-up WO | Inline fixes under ~10 lines when the orchestrator has context |
+| Bundling "decompile X, then implement Y" in one wave | Split into a research wave + an implementation wave |
+| Dispatching wave N+1 after a gate failure to "patch over it" | Fix in place, retry the gate; revert and re-brief if unrecoverable |
+| Scheduling extensions before the foundation they import | Foundation in the earliest implementation wave, extensions later |
+| Running the lock-holder concurrently with its consumers | Lock-holder alone in its wave; downstream reads pre-dumped artefacts |
 
 ## Related
 
+- `agent-patterns-plugin:wave-based-dispatch` — the dispatch discipline and the shared between-wave gate set this skill schedules around
 - `agent-patterns-plugin:parallel-agent-dispatch` — intra-wave dispatch contract
 - `agent-patterns-plugin:exclusive-lock-dispatch` — pre-dump pattern for lock-contending waves
 - `agent-patterns-plugin:agent-teams` — TeamCreate mechanics that waves sit on top of


### PR DESCRIPTION
## Summary

Wave 2 Tier 3 dedupe (Refs #121). `workflow-orchestration-plugin:workflow-wave-dispatch` and `agent-patterns-plugin:wave-based-dispatch` duplicated the shared between-wave mechanics: the research-before-WO gate, the verification-gate set, the ~10-line inline-fix threshold, the stable shared-file exclusion list, and Return Contract reuse.

## Why skill-name dedupe, not a shared REFERENCE.md

The task annotation suggested a shared `REFERENCE.md`, but the two skills live in **different plugins**. A `REFERENCE.md` is referenced by relative file path, which doesn't resolve from the other plugin when only one is installed. The skills already cross-reference each other by `plugin:skill` name — the pattern that *does* survive independent install — so I deduped that way (confirmed with the user).

## Changes

- **`agent-patterns-plugin:wave-based-dispatch`** stays the canonical owner of the shared dispatch discipline — **unchanged**.
- **`workflow-orchestration-plugin:workflow-wave-dispatch`** slimmed to its distinct workflow-side scheduling view (wave-structure diagram, scheduling heuristics, gate-failure rollback) plus a **Shared Mechanics** pointer table into `wave-based-dispatch`. The duplicated prose/tables (research gate, six-gate table, inline-fix table, exclusion-list prose, return-contract prose) are removed in favour of section pointers. **185 → 134 lines.**

## Test plan

- [x] `python3 scripts/audit-skill-descriptions.py --strict-length` — exit 0
- [x] `bash scripts/plugin-compliance-check.sh workflow-orchestration-plugin` — all ✅ (including Size)
- [x] Pre-commit pipeline green
- [x] Description unchanged → README / flow references unaffected

Refs #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)