### PR TITLE
docs(skills): stop escaping backticks/$ inside quoted heredoc examples

### DIFF
--- a/configure-plugin/skills/config-sync/SKILL.md
+++ b/configure-plugin/skills/config-sync/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash(git *), Bash(gh *), Bash(fd *), Bash(rg *), Bash(diff *), Ba
 args: <mode> [options]
 argument-hint: "extract [repo]|diff <file-pattern>|apply <file-pattern> [--from repo] [--to repos|--all]"
 created: 2026-02-21
-modified: 2026-04-16
+modified: 2026-05-30
 reviewed: 2026-04-16
 ---
 
@@ -313,6 +313,15 @@ gh pr create --title "chore: sync claude.yml" --body "$(cat <<'EOF'
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 EOF
 )"
+```
+
+**Inside a quoted heredoc (`<<'EOF'`), backticks, `$`, and `\` are already literal — never backslash-escape them.** A stray `\`` lands in the rendered PR body and needs a follow-up `gh pr edit` to fix. To skip the `$(cat ...)` subshell entirely, feed the body straight to `gh` over stdin:
+
+```bash
+gh pr create --title "chore: sync claude.yml" --body-file - <<'EOF'
+## Summary
+- Synced `.github/workflows/claude.yml` to match canonical version
+EOF
 ```
 
 Report results:

--- a/git-plugin/skills/git-cli-agentic/skill.md
+++ b/git-plugin/skills/git-cli-agentic/skill.md
@@ -4,7 +4,7 @@ description: Git commands with porcelain and machine-readable output for agent w
 user-invocable: false
 allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git branch *), Bash(git remote *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git restore *), Read
 created: 2025-01-16
-modified: 2026-05-09
+modified: 2026-05-30
 reviewed: 2026-04-25
 ---
 
@@ -256,10 +256,13 @@ git restore path/to/file
 git commit -m "message"
 
 # With body (heredoc)
+# Inside <<'EOF' (quoted delimiter), backticks, $, and \ are already
+# literal — never backslash-escape them, or the backslash survives into
+# the commit message.
 git commit -m "$(cat <<'EOF'
 Subject line
 
-Body paragraph.
+Body paragraph with `code` and $vars written verbatim.
 
 Co-Authored-By: Name <email>
 EOF

--- a/git-plugin/skills/git-commit/skill.md
+++ b/git-plugin/skills/git-commit/skill.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-01-21
-modified: 2026-05-09
+modified: 2026-05-30
 reviewed: 2026-04-25
 name: git-commit
 description: Create commits with conventional messages and issue references. Use when user says "commit", "save changes", or "stage and commit". Local commits only — see git-push for remote.
@@ -104,6 +104,8 @@ Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
 EOF
 )"
 ```
+
+**Inside a quoted heredoc (`<<'EOF'`), backticks, `$`, and `\` are already literal — never backslash-escape them.** A reflexive `\`` produces a literal backslash in the commit message that survives into `git log` and needs an `--amend` to clean up.
 
 For trailer conventions (Co-authored-by, Signed-off-by, BREAKING CHANGE, Release-As), see **git-commit-trailers** skill.
 

--- a/git-plugin/skills/git-pr/skill.md
+++ b/git-plugin/skills/git-pr/skill.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-01-21
-modified: 2026-05-09
+modified: 2026-05-30
 reviewed: 2026-04-29
 name: git-pr
 description: Create pull requests with descriptions, labels, and issue references. Use when user says "create PR", "open pull request", or "submit for review". Creates PRs from pushed branches — see git-commit for commits and git-push for pushing.
@@ -156,6 +156,17 @@ gh pr create \
   --title "feat(scope): add feature" \
   --body-file /tmp/pr-body.md
 ```
+
+For a short body you can skip the tempfile and stream it over stdin with `--body-file -` and a **quoted** heredoc:
+
+```bash
+gh pr create --title "feat(scope): add feature" --body-file - <<'EOF'
+## Summary
+Use `code`, ${vars}, and $shell syntax freely — they render verbatim.
+EOF
+```
+
+**Inside `<<'EOF'` (quoted delimiter), backticks, `$`, and `\` are already literal — never backslash-escape them.** A reflexive `\`` survives into the rendered PR description and needs a follow-up `gh pr edit --body-file` to clean up. (The `Write` tool → `--body-file` path above sidesteps the question entirely and stays the default for non-trivial bodies.)
 
 Body content of `/tmp/pr-body.md`:
 


### PR DESCRIPTION
## Summary

Closes #1428.

Several skills document the canonical multi-line `git commit -m` / `gh pr create --body` pattern using a **quoted** heredoc:

```bash
git commit -m "$(cat <<'EOF'
## Summary
Use `code` and ${vars} here.
EOF
)"
```

A quoted delimiter (`<<'EOF'`) already suppresses all shell expansion — backticks, `$`, and `\` pass through literally, so **no escaping is needed**. In practice agents reflexively backslash-escape backticks inside the body, producing a literal `` \` `` in the rendered commit message / PR description that then needs a follow-up `gh pr edit --body-file` (observed on `ForumViriumHelsinki/theme-management#1077`).

This adds a concise inline note next to each heredoc example, plus the subshell-free `--body-file -` alternative for `gh pr create`.

## Changes

| Skill | Change |
|-------|--------|
| `git-plugin/git-pr` | "don't escape inside quoted heredoc" note + `--body-file -` over-stdin example |
| `git-plugin/git-commit` | "don't escape" note next to the existing heredoc example |
| `git-plugin/git-cli-agentic` | "don't escape" comment inside the heredoc example |
| `configure-plugin/config-sync` | "don't escape" note + `--body-file -` alternative |

## Acceptance criteria (from #1428)

- [x] `git-pr` skill: explicit "don't escape inside quoted heredoc" note + `--body-file -` example
- [x] `git-commit` / `git-cli-agentic` skills: "don't escape" note added next to existing heredoc example
- [x] `config-sync` skill: same treatment

## Notes

- **No regression script added.** This is additive prose guidance (a `skill-quality` enhancement), not a behavior-bug fix to a SKILL.md that the `regression-testing.md` rule targets. The `bash-antipatterns` hook already strips heredoc bodies before its detectors run (`hooks-plugin/hooks/bash-antipatterns.sh:18-27`), and #1428 explicitly scoped a lint hook out ("the volume isn't there yet").
- `git-commit` keeps the `$(cat <<'EOF'…EOF)` form (the issue notes `git commit` doesn't accept `-F -` cleanly with a heredoc across shells); only the "don't escape" note is added there.
- All four `modified:` dates bumped to 2026-05-30. Pre-commit (skill-description audits, context-command lint, MCP-reference lint) passes; `plugin-compliance-check.sh` shows no new ERRORs.

## Dependency-sequencing context

This scheduled run surveyed the 27 open issues (none had associated PRs). #1428 was selected as the first resolvable, self-contained issue: it has explicit acceptance criteria, zero hook/behavior risk, and no dependency on other open issues. Issues that were *not* picked and why:

- **#1411** (extend substitution-format hook messages) — RESEARCH, gated on the W23 friction pass (2026-06-01); deciding data isn't in yet.
- **#1416** (`ls`→Glob reminder asymmetry) — its bare-`ls` evidence no longer matches the current `*`-requiring regex, and its live `ls *.glob` concern overlaps #1411's deliberately-deferred tracked work.
- **#1439 / #1440** (session-spinup) — target a user-scoped skill (`~/.claude/skills/session-spinup`), not files in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
