### PR TITLE
feat(evaluate-plugin): add cross-model skill evaluation framework

### DIFF
--- a/.claude/rules/skill-evaluation.md
+++ b/.claude/rules/skill-evaluation.md
@@ -1,0 +1,91 @@
+# Skill Effectiveness Measurement
+
+How we know our skills actually work — and keep working as new Claude models
+ship. This rule is the methodology; the tooling lives in `evaluate-plugin`, and
+the full design is
+[`evaluate-plugin/docs/cross-model-evaluation.md`](../../evaluate-plugin/docs/cross-model-evaluation.md).
+
+`regression-testing.md` keeps a *fixed* bug from recurring. This rule measures
+whether a skill still *adds value* — a different question that the static
+compliance checks (structure, description length, size) can't answer.
+
+## The tiered cost model
+
+Measurement is tiered so only the top tier spends model tokens. Run the cheap
+tiers always; reserve the expensive tier for a small golden set.
+
+| Tier | Cost | Scope | Cadence | Tooling |
+|------|------|-------|---------|---------|
+| 0 — static | free | all skills | every PR | `scripts/plugin-compliance-check.sh`, the lints |
+| 1 — deterministic evals | ~free (no judge) | skills with an `evals.json` | CI on changed skill | `evaluate-plugin/scripts/grade_deterministic.py` |
+| 2 — cross-model matrix | budgeted | **golden set only**, opus/sonnet/haiku | monthly + on model release | `/evaluate:skill`, `render_matrix_report.py` |
+
+Tier 0 catches structural rot for free. Tier 2 is the only thing that costs
+tokens, and it is bounded to the canary set.
+
+## Principle 1 — grade deterministically, judge only the fuzzy
+
+Most expectations are machine-checkable (`starts with feat(`, `references #42`,
+`no trailing period`). Encode those as **typed checks** (`regex`, `substring`,
+`absent_regex`) so they grade for zero model tokens. Reserve the LLM judge for
+genuinely fuzzy expectations (tone, mood, "provides context"). On a typical eval
+set ~70% of assertions grade for free.
+
+A bare-string expectation defaults to `judge`, so this is opt-in and backward
+compatible. See the typed-check schema in
+[`evaluate-plugin/references/schemas.md`](../../evaluate-plugin/references/schemas.md).
+
+## Principle 2 — the signal is the with-skill − baseline *delta*, per model
+
+A bare pass rate means nothing; the delta against the model's own baseline
+(same prompt, no skill) does. Interpret it as a 2×2:
+
+| | baseline already high | baseline low |
+|---|---|---|
+| **with-skill high** | possibly **redundant** — the model already knows; candidate to slim or drop | **earns its keep** |
+| **with-skill low** | **fighting the model** — adds noise | **ineffective** — rewrite |
+
+Two derived signals:
+
+- **Portability** — a skill that scores ≥20 points higher on opus than haiku
+  leans on reasoning the cheap model lacks. Simplify the skill, or pin `model:`
+  in its frontmatter (never `haiku` — see `skill-development.md`).
+- **Drift on a new model** — store each matrix run; on a model release, re-run
+  the golden set and diff the delta column. A canary whose delta collapsed is
+  the trigger to audit: either the new model does it unaided (redundant) or does
+  it worse (needs adjusting).
+
+## Principle 3 — a golden set, not all 348 skills
+
+Cross-model runs target ~15–25 canary skills chosen to be representative,
+high-traffic, or high-risk — covering distinct patterns (CLI wrapper,
+multi-step orchestrator, `AskUserQuestion` skill, file generator,
+convention-enforcer). The canaries are the weathervane: when a new model
+degrades them, that's the cue to sweep the long tail. Everything else stays on
+Tier 0/1.
+
+## Principle 4 — reproducibility and cadence
+
+- **Pin model IDs** in the result file (`claude-opus-4-8`, `claude-sonnet-4-6`,
+  `claude-haiku-4-5`), single-turn prompts, version-controlled `evals.json`.
+- **Cache the baseline per model-version** — baseline only changes when the
+  model changes, so a skill edit re-runs only the with-skill side.
+- **Trigger on cadence, not per-PR** — monthly cron plus a manual run whenever a
+  new model ships. Tier 2 is too expensive for the per-PR path.
+
+## When to apply this
+
+| Situation | Tier to run |
+|-----------|-------------|
+| Authoring or editing a skill | Tier 0 (always) + Tier 1 if it has `evals.json` |
+| Adding a skill to the golden set | Write its `evals.json` with typed checks |
+| A new Claude model is released | Tier 2 sweep of the golden set; diff deltas vs last run |
+| A skill feels redundant or noisy | Tier 2 with `--baseline` to see if it beats the model alone |
+
+## Related
+
+- [`evaluate-plugin/docs/cross-model-evaluation.md`](../../evaluate-plugin/docs/cross-model-evaluation.md) — full design, run engine, token math
+- `evaluate-plugin` — the skills and scripts that implement this
+- `.claude/rules/regression-testing.md` — keeping a fixed bug fixed (the complement to effectiveness)
+- `.claude/rules/skill-quality.md` — the static-quality axis (Tier 0)
+- `.claude/rules/skill-development.md` — model-selection rules referenced by the portability signal

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ Claude Code plugin collection providing skills and agents for development workfl
 | `.claude/rules/agent-development.md` | Agent configuration, isolation, background execution, memory, and teams |
 | `.claude/rules/skill-fork-context.md` | When to set `context: fork` and `agent:` on skills |
 | `.claude/rules/regression-testing.md` | **Required**: add a script check for every skill bug fixed |
+| `.claude/rules/skill-evaluation.md` | How we measure skill *effectiveness*: tiered cost, deterministic-vs-judge grading, cross-model delta signal |
 | `.claude/rules/sandbox-guidance.md` | Sandbox constraints, `CLAUDE_CODE_REMOTE` detection, and remote/local skill patterns |
 | `.claude/rules/plugin-flow-diagrams.md` | When and how to add Mermaid flow diagrams |
 | `.claude/rules/agent-coworker-detection.md` | Detect other agents working in the same repo clone before destructive git ops |

--- a/evaluate-plugin/README.md
+++ b/evaluate-plugin/README.md
@@ -92,3 +92,13 @@ Static compliance checks (`plugin-compliance-check.sh`) verify structure — thi
 |--------|---------|
 | `scripts/aggregate_benchmark.sh` | Aggregate benchmark results across a plugin's skills |
 | `scripts/eval_report.sh` | Generate formatted markdown report from benchmark data |
+| `scripts/grade_deterministic.py` | Grade machine-checkable (regex/substring) assertions with zero judge tokens; defers fuzzy ones to `eval-grader` |
+| `scripts/render_matrix_report.py` | Render the cross-model delta report from a `model-matrix.json` |
+
+## Cross-Model Evaluation
+
+Measuring skill effectiveness reproducibly across opus / sonnet / haiku — to
+catch when a skill needs adjusting after a new model ships — is designed in
+[`docs/cross-model-evaluation.md`](docs/cross-model-evaluation.md). The
+token-frugal grader and report format prototyped there run against
+`git-plugin/skills/git-commit/evals.json` today.

--- a/evaluate-plugin/agents/eval-grader.md
+++ b/evaluate-plugin/agents/eval-grader.md
@@ -56,7 +56,14 @@ The harness blocks several common bash idioms — use the dedicated tool instead
 
 ### Assertion Checking
 
-For each assertion in the eval case:
+Each item in `expectations` is either a plain string or a typed object
+`{assertion, check, ...}` (see `references/schemas.md`). Read the human text from
+the string itself, or from the object's `assertion` field. Items with a `check`
+other than `judge` are graded deterministically upstream by
+`scripts/grade_deterministic.py` — focus your judgment on the `judge`/string
+items and reconcile any deterministic results passed to you.
+
+For each assertion you grade:
 
 1. **Search the transcript and output** for evidence that the assertion is satisfied
 2. **Determine confidence**: `high` (clear evidence), `medium` (indirect evidence), `low` (ambiguous)

--- a/evaluate-plugin/docs/cross-model-evaluation.md
+++ b/evaluate-plugin/docs/cross-model-evaluation.md
@@ -1,0 +1,154 @@
+# Cross-Model Skill Evaluation
+
+How we measure skill effectiveness reproducibly, across models (opus / sonnet /
+haiku), without burning tokens — so we notice when a skill needs adjusting,
+especially when a new Claude model ships.
+
+This is a design + prototype. The prototype lands the token-frugality lever (the
+deterministic grader) and the report format against the one existing eval set
+(`git-plugin/skills/git-commit/evals.json`). Populating a golden set and the
+`/evaluate:matrix` orchestration skill are follow-ups.
+
+## The problem
+
+`evaluate-plugin` already grades a single skill's behaviour against assertions
+with a `--baseline` delta. Three things were missing for the question "are our
+skills still effective, and which model are they effective on?":
+
+1. **No cross-model dimension** — runs use whatever model is active.
+2. **Token cost** — every assertion routes through an Opus `eval-grader`
+   subagent, N runs each. Fine for one skill; ruinous as a regular signal
+   across 348 skills.
+3. **No reproducibility / cadence contract** — nothing pins model IDs or says
+   "re-run this fixed set when a model drops and diff against last time."
+
+## Design principles
+
+### 1. Tier the cost; only the top tier spends real tokens
+
+| Tier | Cost | Scope | Cadence |
+|------|------|-------|---------|
+| 0 — static | free | all 348 skills | every PR (`plugin-compliance-check.sh`, lints) |
+| 1 — deterministic evals | ~free (no judge) | skills with `evals.json`, single active model | CI on changed skill |
+| 2 — cross-model matrix | budgeted | **golden set only**, opus/sonnet/haiku | monthly + on model release |
+
+Tier 0 catches structural rot for free. Tier 2 is the only thing that costs
+tokens, and it is bounded to the golden set.
+
+### 2. Split assertions into deterministic vs judged — the biggest lever
+
+Most skill-output expectations are machine-checkable. From the git-commit set:
+"starts with `feat(`", "does not end with a period", "references `#42`",
+"both `#100` and `#101`" are regex/substring checks that cost **zero** model
+tokens. Only genuinely fuzzy ones ("uses imperative mood", "body provides
+context") need an LLM judge.
+
+`scripts/grade_deterministic.py` grades the typed checks and reports the fuzzy
+ones as `DEFERRED`, so the judge agent only ever runs on those. On the
+git-commit set this is ~70% of assertions graded for free.
+
+Expectations stay backward compatible: a bare string is treated as `judge`
+(existing behaviour); a typed object opts into deterministic grading.
+
+```json
+{ "assertion": "Commit message starts with feat(", "check": "regex",
+  "pattern": "^feat\\(", "scope": "subject" }
+```
+
+Check types: `regex`, `substring`, `substring_all`, `absent_regex`, `judge`.
+Optional `scope` (`full` | `subject` | `body`) and regex `flags`. Full schema
+in [`references/schemas.md`](../references/schemas.md).
+
+### 3. The signal is the with-skill − baseline *delta*, per model, over time
+
+A bare pass rate means nothing; the delta against the model's own baseline does.
+The cross-model interpretation is a 2×2:
+
+| | baseline already high | baseline low |
+|---|---|---|
+| **with-skill high** | possibly **redundant** — model already knows; candidate to slim | **earns its keep** |
+| **with-skill low** | **fighting the model** — adds noise | **ineffective** — rewrite |
+
+`render_matrix_report.py` computes the verdict per model from these thresholds
+and flags **portability**: a skill that scores ≥20 points higher on opus than
+haiku leans on reasoning the cheap model lacks — simplify it or pin `model:`.
+
+This is what "noticing a new model needs adjusting" reduces to: store each
+matrix run, and on a new model release re-run the golden set and diff the delta
+column (`Δ vs prev`). A canary whose delta collapsed gets flagged — either the
+model now does it unaided (redundant) or now does it worse (needs adjusting).
+
+### 4. Reproducibility = pin everything, run on a trigger not per-PR
+
+- Pinned model IDs (`claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5`),
+  recorded in `model-matrix.json metadata.models`.
+- Single-turn prompts, version-controlled fixtures (`evals.json`).
+- **Baseline cached per model-version** — baseline only changes when the model
+  changes, so a skill edit re-runs only the with-skill side.
+- Trigger: monthly cron + manual "new model dropped" run.
+
+> Note: testing a skill *on* haiku here is unrelated to the repo ban on
+> `model: haiku` in skill frontmatter. We evaluate the skill across models; we
+> still don't author skills that pin themselves to haiku.
+
+## Run engine: in-session subagents
+
+Cross-model runs reuse the existing `Task`-subagent approach, parameterized by
+model (the `Agent`/`Task` `model` field selects opus / sonnet / haiku). This
+keeps real tool execution (Bash/Edit) so skills that produce artifacts — not
+just text — are evaluated faithfully. The orchestrating `/evaluate:matrix` skill
+(follow-up) loops models × evals × {with_skill, cached_baseline}, captures each
+transcript, runs `grade_deterministic.py` first, and only dispatches the
+`eval-grader` agent for the `DEFERRED` assertions.
+
+Mind `.claude/rules/skill-fork-context.md`: do **not** add `context: fork`, and
+serialize subagent dispatch to avoid the `[1m]` concurrent-rate-limit trap.
+
+## Golden set criteria
+
+Don't test all 348 skills × 3 models. Pick ~15–25 canaries that are
+representative, high-traffic, or high-risk, covering distinct patterns:
+
+| Dimension to cover | Example canary |
+|--------------------|----------------|
+| CLI-wrapper skill (mechanical) | `tools-plugin` rg/jq/fd skill |
+| Multi-step orchestrator | a `blueprint` or `git` workflow skill |
+| `AskUserQuestion` interactive skill | a `configure-plugin` skill |
+| Generator (produces files) | a scaffolder skill |
+| Convention-enforcing (text output) | `git-plugin/git-commit` ← prototype anchor |
+
+When a new model degrades the canaries, that's the trigger to audit the long
+tail. The other ~320 skills stay on Tier 0/1.
+
+## Token math for a full Tier-2 sweep
+
+≈ 20 skills × ~4 evals × 3 models × 2 configs (with-skill + cached baseline)
+≈ 480 single-turn runs. At a few k tokens each → low single-digit millions per
+monthly sweep. With ~70% of assertions graded deterministically, the judge
+agent fires on a fraction of that. Cheap enough to automate; expensive enough to
+be worth not eyeballing.
+
+## Prototype status
+
+| Piece | Status |
+|-------|--------|
+| Typed-check schema on `expectations` | done — `git-commit/evals.json` migrated, back-compatible |
+| `scripts/grade_deterministic.py` | done — regex/substring/absent, scope, JSON + KEY=value out |
+| `scripts/render_matrix_report.py` | done — delta table, verdicts, portability flag |
+| `scripts/tests/test_grade_deterministic.sh` | done — 14 assertions, wired for CI |
+| `model-matrix.json` schema | done — documented; example fixture renders |
+| `/evaluate:matrix` orchestration skill | follow-up |
+| Golden set definition (`golden-set.json`) | follow-up |
+| Cron / model-release trigger | follow-up |
+
+## Related
+
+- [`references/schemas.md`](../references/schemas.md) — evals.json (typed
+  checks) and model-matrix.json schemas
+- [`skills/evaluate-skill/SKILL.md`](../skills/evaluate-skill/SKILL.md) —
+  single-skill / single-model evaluation this extends
+- `.claude/rules/skill-fork-context.md` — why subagents are serialized and
+  `context: fork` is avoided
+- `.claude/rules/regression-testing.md` — every check ships a test
+- `.claude/rules/structured-script-output.md` — the `=== SECTION ===` /
+  `STATUS=` grader output convention

--- a/evaluate-plugin/docs/cross-model-evaluation.md
+++ b/evaluate-plugin/docs/cross-model-evaluation.md
@@ -143,6 +143,8 @@ be worth not eyeballing.
 
 ## Related
 
+- `.claude/rules/skill-evaluation.md` — the top-level methodology this design
+  implements (tiered cost, delta signal, golden set, cadence)
 - [`references/schemas.md`](../references/schemas.md) — evals.json (typed
   checks) and model-matrix.json schemas
 - [`skills/evaluate-skill/SKILL.md`](../skills/evaluate-skill/SKILL.md) —

--- a/evaluate-plugin/references/schemas.md
+++ b/evaluate-plugin/references/schemas.md
@@ -52,6 +52,39 @@ Defines test cases for a skill. Lives alongside the SKILL.md it tests. **Version
 | Good | "Output includes issue reference #42" |
 | Good | "Created file contains at least 3 test cases" |
 
+### Typed Checks (deterministic grading)
+
+Each item in `expectations` is **either** a plain string (graded by the LLM
+`eval-grader` — the `judge` path) **or** a typed object that
+`scripts/grade_deterministic.py` grades with zero model tokens. Mixing both in
+one `expectations` array is supported and backward compatible.
+
+```json
+{
+  "assertion": "string — human-readable assertion (also shown to the judge)",
+  "check": "regex | substring | substring_all | absent_regex | judge",
+  "pattern": "string — regex (for regex / absent_regex)",
+  "value": "string — substring to find (for substring)",
+  "values": ["string — all must be present (for substring_all)"],
+  "scope": "full | subject | body  — default full",
+  "flags": "string — any of imsx, regex flags (for regex / absent_regex)"
+}
+```
+
+| `check` | Passes when | Required field |
+|---------|-------------|----------------|
+| `regex` | `pattern` matches within `scope` | `pattern` |
+| `substring` | `value` appears within `scope` | `value` |
+| `substring_all` | every entry in `values` appears within `scope` | `values` |
+| `absent_regex` | `pattern` does **not** match within `scope` | `pattern` |
+| `judge` | deferred to the LLM grader (default for bare strings) | — |
+
+`scope`: `subject` = first non-empty line, `body` = text after the first blank
+line, `full` = whole output. Prefer typed checks for anything mechanically
+verifiable; reserve `judge` for genuinely fuzzy expectations (tone, mood,
+"provides context"). See
+[`docs/cross-model-evaluation.md`](../docs/cross-model-evaluation.md).
+
 ## grading.json — Grading Output
 
 Produced by the `eval-grader` agent for each eval run. **Gitignored.**
@@ -226,6 +259,49 @@ Tracks skill improvements over evaluation cycles. **Gitignored.**
   ]
 }
 ```
+
+## model-matrix.json — Cross-Model Results
+
+Records with-skill and baseline pass rates for one skill across pinned models.
+Consumed by `scripts/render_matrix_report.py`. **Gitignored** (the rendered
+report and stored history are the durable artifacts). See
+[`docs/cross-model-evaluation.md`](../docs/cross-model-evaluation.md).
+
+```json
+{
+  "metadata": {
+    "skill_path": "string",
+    "generated_at": "string — ISO-8601",
+    "previous_run": "string | null — ISO-8601 of the last sweep, for Δ vs prev",
+    "models": [
+      { "alias": "string — opus | sonnet | haiku", "model_id": "string — pinned id, e.g. claude-opus-4-8" }
+    ]
+  },
+  "evals": [
+    {
+      "eval_id": "string",
+      "by_model": {
+        "<alias>": { "with_skill": "number 0.0-1.0", "baseline": "number 0.0-1.0" }
+      }
+    }
+  ],
+  "summary": {
+    "by_model": {
+      "<alias>": {
+        "with_skill": "number — mean pass rate across evals",
+        "baseline": "number — mean baseline pass rate",
+        "delta": "number — with_skill - baseline",
+        "prev_delta": "number | null — delta from previous_run, drives the ▲/▼ marker"
+      }
+    }
+  }
+}
+```
+
+The renderer derives per-model verdicts (`earns its keep`, `possibly redundant`,
+`fighting the model`, `ineffective`, `marginal`) from `with_skill`/`baseline`,
+and raises a portability flag when the opus−haiku with-skill spread is ≥20
+points.
 
 ## plugin-benchmark.json — Plugin-Level Aggregation
 

--- a/evaluate-plugin/scripts/grade_deterministic.py
+++ b/evaluate-plugin/scripts/grade_deterministic.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Deterministic grader for skill eval expectations.
+
+Grades the machine-checkable expectations in an evals.json eval case against a
+captured skill output, WITHOUT spending LLM judge tokens. Expectations whose
+``check`` type is ``judge`` (or plain-string expectations, which default to
+``judge``) are reported as DEFERRED so the LLM grader only ever runs on the
+genuinely fuzzy assertions.
+
+This is the core token-frugality lever of the cross-model evaluation framework:
+on the git-commit eval set ~70% of expectations are regex/substring checks that
+cost zero model tokens to grade.
+
+Expectation forms accepted in evals.json (``expectations`` may mix both):
+
+  "Commit message starts with feat("          # string -> check: judge
+
+  {                                            # object -> typed check
+    "assertion": "Commit message starts with feat(",
+    "check": "regex",
+    "pattern": "^feat\\(",
+    "scope": "subject"
+  }
+
+Check types:
+  regex          pattern matches (re.search) within scope
+  substring      value is present within scope
+  substring_all  every entry in values[] is present within scope
+  absent_regex   pattern does NOT match within scope
+  judge          deferred to the LLM grader (default for bare strings)
+
+Optional fields on a typed check:
+  scope   full | subject | body   (default: full)
+  flags   any of "imsx"           (regex flags; applied to regex/absent_regex)
+
+Usage:
+  grade_deterministic.py --evals <evals.json> --eval-id <id> \
+    --output <file|-> [--json] [--strict]
+
+Output: structured KEY=value section by default; full JSON with --json.
+Exit code: 0 normally; with --strict, 1 when a deterministic check fails.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def _scope_text(text: str, scope: str) -> str:
+    """Return the slice of ``text`` named by ``scope``."""
+    if scope == "subject":
+        for line in text.splitlines():
+            if line.strip():
+                return line
+        return ""
+    if scope == "body":
+        parts = text.split("\n\n", 1)
+        return parts[1] if len(parts) == 2 else ""
+    return text
+
+
+def _compile_flags(flags: str) -> int:
+    table = {"i": re.IGNORECASE, "m": re.MULTILINE, "s": re.DOTALL, "x": re.VERBOSE}
+    value = 0
+    for ch in flags or "":
+        if ch not in table:
+            raise ValueError(f"unknown regex flag: {ch!r}")
+        value |= table[ch]
+    return value
+
+
+def grade_expectation(exp, output: str) -> dict:
+    """Grade one expectation. Returns a result dict with a ``deferred`` flag."""
+    # Bare string -> deferred to the LLM judge.
+    if isinstance(exp, str):
+        return {"assertion": exp, "check": "judge", "deferred": True}
+
+    assertion = exp.get("assertion", "")
+    check = exp.get("check", "judge")
+    scope = exp.get("scope", "full")
+    text = _scope_text(output, scope)
+
+    if check == "judge":
+        return {"assertion": assertion, "check": "judge", "deferred": True}
+
+    try:
+        if check == "regex":
+            flags = _compile_flags(exp.get("flags", ""))
+            ok = re.search(exp["pattern"], text, flags) is not None
+            evidence = f"/{exp['pattern']}/ {'matched' if ok else 'no match'} in {scope}"
+        elif check == "absent_regex":
+            flags = _compile_flags(exp.get("flags", ""))
+            ok = re.search(exp["pattern"], text, flags) is None
+            evidence = f"/{exp['pattern']}/ {'absent (ok)' if ok else 'present (fail)'} in {scope}"
+        elif check == "substring":
+            ok = exp["value"] in text
+            evidence = f"{exp['value']!r} {'found' if ok else 'missing'} in {scope}"
+        elif check == "substring_all":
+            missing = [v for v in exp["values"] if v not in text]
+            ok = not missing
+            evidence = "all present" if ok else f"missing {missing!r} in {scope}"
+        else:
+            return {
+                "assertion": assertion,
+                "check": check,
+                "deferred": True,
+                "evidence": f"unknown check type {check!r} -> deferred",
+            }
+    except KeyError as err:
+        return {
+            "assertion": assertion,
+            "check": check,
+            "passed": False,
+            "deferred": False,
+            "evidence": f"malformed check, missing field {err}",
+        }
+
+    return {
+        "assertion": assertion,
+        "check": check,
+        "passed": ok,
+        "deferred": False,
+        "evidence": evidence,
+    }
+
+
+def grade_eval_case(eval_case: dict, output: str) -> dict:
+    results = [grade_expectation(e, output) for e in eval_case.get("expectations", [])]
+    deterministic = [r for r in results if not r.get("deferred")]
+    deferred = [r for r in results if r.get("deferred")]
+    passed = sum(1 for r in deterministic if r.get("passed"))
+    failed = len(deterministic) - passed
+    return {
+        "eval_id": eval_case.get("id", ""),
+        "deterministic": deterministic,
+        "deferred": deferred,
+        "summary": {
+            "deterministic_total": len(deterministic),
+            "deterministic_passed": passed,
+            "deterministic_failed": failed,
+            "judge_pending": len(deferred),
+        },
+    }
+
+
+def render_structured(graded: dict) -> tuple[str, int]:
+    """Render the KEY=value section. Returns (text, exit_status_severity)."""
+    s = graded["summary"]
+    if s["deterministic_failed"] > 0:
+        status, severity = "ERROR", 1
+    elif s["judge_pending"] > 0:
+        status, severity = "WARN", 0
+    else:
+        status, severity = "OK", 0
+
+    lines = ["=== DETERMINISTIC GRADING ==="]
+    lines.append(f"EVAL_ID={graded['eval_id']}")
+    lines.append(f"DETERMINISTIC_TOTAL={s['deterministic_total']}")
+    lines.append(f"DETERMINISTIC_PASSED={s['deterministic_passed']}")
+    lines.append(f"DETERMINISTIC_FAILED={s['deterministic_failed']}")
+    lines.append(f"JUDGE_PENDING={s['judge_pending']}")
+    lines.append(f"STATUS={status}")
+    lines.append(f"ISSUE_COUNT={s['deterministic_failed']}")
+    lines.append("RESULTS:")
+    for r in graded["deterministic"]:
+        verdict = "PASS" if r.get("passed") else "FAIL"
+        lines.append(f"  - CHECK={r['check']} RESULT={verdict} ASSERTION={r['assertion']!r}")
+    for r in graded["deferred"]:
+        lines.append(f"  - CHECK={r['check']} RESULT=DEFERRED ASSERTION={r['assertion']!r}")
+    lines.append("=== END DETERMINISTIC GRADING ===")
+    return "\n".join(lines), severity
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Deterministic skill-eval grader")
+    parser.add_argument("--evals", required=True, help="Path to evals.json")
+    parser.add_argument("--eval-id", required=True, help="Eval case id to grade")
+    parser.add_argument("--output", required=True, help="Skill output file, or - for stdin")
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of KEY=value")
+    parser.add_argument("--strict", action="store_true", help="Exit 1 when a deterministic check fails")
+    args = parser.parse_args(argv)
+
+    evals = json.loads(Path(args.evals).read_text())
+    eval_case = next((e for e in evals.get("evals", []) if e.get("id") == args.eval_id), None)
+    if eval_case is None:
+        print(f"ERROR: eval id {args.eval_id!r} not found in {args.evals}", file=sys.stderr)
+        return 2
+
+    output = sys.stdin.read() if args.output == "-" else Path(args.output).read_text()
+    graded = grade_eval_case(eval_case, output)
+
+    if args.json:
+        print(json.dumps(graded, indent=2))
+        severity = 1 if graded["summary"]["deterministic_failed"] > 0 else 0
+    else:
+        text, severity = render_structured(graded)
+        print(text)
+
+    return severity if args.strict else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/evaluate-plugin/scripts/render_matrix_report.py
+++ b/evaluate-plugin/scripts/render_matrix_report.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Render a markdown report from a model-matrix.json result file.
+
+The matrix file records with-skill and baseline pass rates for one skill across
+several pinned models (opus / sonnet / haiku). This renderer turns it into the
+delta table that is the actual signal: does the skill beat the model's baseline,
+does that hold on cheaper models, and did the picture move since the last run.
+
+See ``evaluate-plugin/references/schemas.md`` (model-matrix.json) for the input
+schema, and ``evaluate-plugin/docs/cross-model-evaluation.md`` for how the
+verdicts are interpreted.
+
+Usage:
+  render_matrix_report.py <model-matrix.json> [--out <file.md>]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Verdict thresholds (delta = with_skill - baseline). See the design doc's 2x2.
+EARNS_KEEP_DELTA = 0.15   # with-skill clearly beats baseline
+REDUNDANT_BASELINE = 0.85  # baseline already strong; skill may be redundant
+FIGHTING_DELTA = -0.05    # with-skill underperforms baseline
+
+
+def _pct(x) -> str:
+    return "—" if x is None else f"{round(x * 100)}%"
+
+
+def _delta_cell(delta, prev_delta) -> str:
+    if delta is None:
+        return "—"
+    cell = f"{'+' if delta >= 0 else ''}{round(delta * 100)}%"
+    if prev_delta is not None:
+        move = round((delta - prev_delta) * 100)
+        if move > 0:
+            cell += f" ▲{move}"
+        elif move < 0:
+            cell += f" ▼{abs(move)}"
+        else:
+            cell += " ="
+    return cell
+
+
+def _verdict(with_skill, baseline) -> str:
+    if with_skill is None or baseline is None:
+        return "n/a"
+    delta = with_skill - baseline
+    if delta <= FIGHTING_DELTA:
+        return "⚠ fighting the model" if baseline >= 0.5 else "⚠ ineffective"
+    if baseline >= REDUNDANT_BASELINE and delta < EARNS_KEEP_DELTA:
+        return "possibly redundant"
+    if delta >= EARNS_KEEP_DELTA:
+        return "earns its keep"
+    return "marginal"
+
+
+def render(matrix: dict) -> str:
+    meta = matrix.get("metadata", {})
+    models = meta.get("models", [])
+    aliases = [m["alias"] for m in models]
+    by_model = matrix.get("summary", {}).get("by_model", {})
+
+    out = []
+    out.append(f"# Cross-model evaluation: {meta.get('skill_path', '?')}")
+    out.append("")
+    out.append(f"_Generated: {meta.get('generated_at', '?')}_  ")
+    prev = meta.get("previous_run")
+    out.append(f"_Previous run: {prev or 'none — first sweep'}_")
+    out.append("")
+    id_line = ", ".join(f"`{m['alias']}`=`{m['model_id']}`" for m in models)
+    out.append(f"Pinned models: {id_line}")
+    out.append("")
+
+    # Summary delta table.
+    out.append("## Summary (mean pass rate across all evals)")
+    out.append("")
+    out.append("| Model | With skill | Baseline | Delta (Δ vs prev) | Verdict |")
+    out.append("|-------|-----------|----------|-------------------|---------|")
+    for alias in aliases:
+        row = by_model.get(alias, {})
+        ws, bl = row.get("with_skill"), row.get("baseline")
+        out.append(
+            f"| {alias} | {_pct(ws)} | {_pct(bl)} | "
+            f"{_delta_cell(row.get('delta'), row.get('prev_delta'))} | {_verdict(ws, bl)} |"
+        )
+    out.append("")
+
+    # Per-eval breakdown (with-skill rates per model).
+    evals = matrix.get("evals", [])
+    if evals:
+        out.append("## Per-eval breakdown (with-skill pass rate)")
+        out.append("")
+        out.append("| Eval | " + " | ".join(aliases) + " |")
+        out.append("|------|" + "|".join(["------"] * len(aliases)) + "|")
+        for ev in evals:
+            cells = []
+            for alias in aliases:
+                cell = ev.get("by_model", {}).get(alias, {})
+                cells.append(_pct(cell.get("with_skill")))
+            out.append(f"| {ev.get('eval_id', '?')} | " + " | ".join(cells) + " |")
+        out.append("")
+
+    # Portability flag: opus vs haiku with-skill spread.
+    opus = by_model.get("opus", {}).get("with_skill")
+    haiku = by_model.get("haiku", {}).get("with_skill")
+    if opus is not None and haiku is not None and (opus - haiku) >= 0.2:
+        out.append(
+            f"> **Portability flag:** opus with-skill ({_pct(opus)}) exceeds haiku "
+            f"({_pct(haiku)}) by ≥20 points — the skill leans on reasoning the cheaper "
+            f"model lacks. Consider simplifying the skill or pinning `model:` in frontmatter."
+        )
+        out.append("")
+
+    return "\n".join(out)
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Render cross-model eval report")
+    parser.add_argument("matrix", help="Path to model-matrix.json")
+    parser.add_argument("--out", help="Write markdown to this file instead of stdout")
+    args = parser.parse_args(argv)
+
+    matrix = json.loads(Path(args.matrix).read_text())
+    report = render(matrix)
+
+    if args.out:
+        Path(args.out).write_text(report + "\n")
+        print(f"Wrote {args.out}")
+    else:
+        print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/evaluate-plugin/scripts/tests/fixtures/example-model-matrix.json
+++ b/evaluate-plugin/scripts/tests/fixtures/example-model-matrix.json
@@ -1,0 +1,38 @@
+{
+  "_note": "ILLUSTRATIVE EXAMPLE DATA — not the result of a real run. Demonstrates the model-matrix.json shape consumed by render_matrix_report.py. Numbers are hand-authored to exercise every verdict branch.",
+  "metadata": {
+    "skill_path": "git-plugin/skills/git-commit/SKILL.md",
+    "generated_at": "2026-05-30T00:00:00Z",
+    "previous_run": "2026-04-30T00:00:00Z",
+    "models": [
+      { "alias": "opus", "model_id": "claude-opus-4-8" },
+      { "alias": "sonnet", "model_id": "claude-sonnet-4-6" },
+      { "alias": "haiku", "model_id": "claude-haiku-4-5" }
+    ]
+  },
+  "evals": [
+    {
+      "eval_id": "gc-001",
+      "by_model": {
+        "opus": { "with_skill": 1.0, "baseline": 0.6 },
+        "sonnet": { "with_skill": 1.0, "baseline": 0.6 },
+        "haiku": { "with_skill": 0.8, "baseline": 0.4 }
+      }
+    },
+    {
+      "eval_id": "gc-002",
+      "by_model": {
+        "opus": { "with_skill": 1.0, "baseline": 0.5 },
+        "sonnet": { "with_skill": 0.9, "baseline": 0.5 },
+        "haiku": { "with_skill": 0.6, "baseline": 0.3 }
+      }
+    }
+  ],
+  "summary": {
+    "by_model": {
+      "opus": { "with_skill": 1.0, "baseline": 0.55, "delta": 0.45, "prev_delta": 0.4 },
+      "sonnet": { "with_skill": 0.95, "baseline": 0.55, "delta": 0.4, "prev_delta": 0.42 },
+      "haiku": { "with_skill": 0.7, "baseline": 0.35, "delta": 0.35, "prev_delta": 0.2 }
+    }
+  }
+}

--- a/evaluate-plugin/scripts/tests/fixtures/gc-001-bad.txt
+++ b/evaluate-plugin/scripts/tests/fixtures/gc-001-bad.txt
@@ -1,0 +1,1 @@
+Feature: Added OAuth Login.

--- a/evaluate-plugin/scripts/tests/fixtures/gc-001-good.txt
+++ b/evaluate-plugin/scripts/tests/fixtures/gc-001-good.txt
@@ -1,0 +1,4 @@
+feat(auth): add OAuth login support
+
+Implements the OAuth2 authorization code flow for the auth module so
+enterprise users can sign in with a federated identity provider.

--- a/evaluate-plugin/scripts/tests/test_grade_deterministic.sh
+++ b/evaluate-plugin/scripts/tests/test_grade_deterministic.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Regression test for grade_deterministic.py and render_matrix_report.py.
+#
+# Per .claude/rules/regression-testing.md, the deterministic grader (the
+# token-frugality lever of the cross-model framework) ships with a test that
+# proves: (a) machine-checkable assertions pass on good output, (b) they fail
+# on bad output, (c) judge-typed assertions are deferred not graded, and
+# (d) the matrix renderer produces the delta table.
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+scripts_dir="$(dirname "$script_dir")"
+fixtures="$script_dir/fixtures"
+evals="$scripts_dir/../../git-plugin/skills/git-commit/evals.json"
+grader="$scripts_dir/grade_deterministic.py"
+renderer="$scripts_dir/render_matrix_report.py"
+
+fail_count=0
+pass_count=0
+
+check() {
+  # check <description> <expected> <actual>
+  if [ "$2" = "$3" ]; then
+    pass_count=$((pass_count + 1))
+  else
+    echo "FAIL: $1 (expected '$2', got '$3')" >&2
+    fail_count=$((fail_count + 1))
+  fi
+}
+
+field() {
+  # field <output> <KEY>  -> prints the value after KEY=
+  printf '%s\n' "$1" | grep -m1 "^$2=" | cut -d= -f2
+}
+
+echo "=== TEST: deterministic grading (gc-001) ==="
+
+# Good output: all 4 deterministic checks pass, 1 judge deferred.
+good_out="$(python3 "$grader" --evals "$evals" --eval-id gc-001 --output "$fixtures/gc-001-good.txt")"
+check "good: deterministic total" "4" "$(field "$good_out" DETERMINISTIC_TOTAL)"
+check "good: deterministic passed" "4" "$(field "$good_out" DETERMINISTIC_PASSED)"
+check "good: deterministic failed" "0" "$(field "$good_out" DETERMINISTIC_FAILED)"
+check "good: judge pending" "1" "$(field "$good_out" JUDGE_PENDING)"
+check "good: status" "WARN" "$(field "$good_out" STATUS)"
+
+# Bad output: all 4 deterministic checks fail.
+bad_out="$(python3 "$grader" --evals "$evals" --eval-id gc-001 --output "$fixtures/gc-001-bad.txt")"
+check "bad: deterministic passed" "0" "$(field "$bad_out" DETERMINISTIC_PASSED)"
+check "bad: deterministic failed" "4" "$(field "$bad_out" DETERMINISTIC_FAILED)"
+check "bad: status" "ERROR" "$(field "$bad_out" STATUS)"
+
+# --strict exits non-zero when a deterministic check fails.
+python3 "$grader" --evals "$evals" --eval-id gc-001 --output "$fixtures/gc-001-bad.txt" --strict >/dev/null
+check "bad: --strict exit code" "1" "$?"
+python3 "$grader" --evals "$evals" --eval-id gc-001 --output "$fixtures/gc-001-good.txt" --strict >/dev/null
+check "good: --strict exit code" "0" "$?"
+
+echo "=== TEST: stdin + JSON mode ==="
+json_out="$(cat "$fixtures/gc-001-good.txt" | python3 "$grader" --evals "$evals" --eval-id gc-001 --output - --json)"
+check "json: passed count" "4" "$(printf '%s' "$json_out" | python3 -c 'import json,sys; print(json.load(sys.stdin)["summary"]["deterministic_passed"])')"
+
+echo "=== TEST: matrix report rendering ==="
+report="$(python3 "$renderer" "$fixtures/example-model-matrix.json")"
+printf '%s\n' "$report" | grep -q "earns its keep" \
+  && pass_count=$((pass_count + 1)) \
+  || { echo "FAIL: report missing 'earns its keep' verdict" >&2; fail_count=$((fail_count + 1)); }
+printf '%s\n' "$report" | grep -q "claude-opus-4-8" \
+  && pass_count=$((pass_count + 1)) \
+  || { echo "FAIL: report missing pinned model id" >&2; fail_count=$((fail_count + 1)); }
+printf '%s\n' "$report" | grep -q "Portability flag" \
+  && pass_count=$((pass_count + 1)) \
+  || { echo "FAIL: report missing portability flag (opus-haiku spread = 30pts)" >&2; fail_count=$((fail_count + 1)); }
+
+echo ""
+echo "=== SUMMARY ==="
+echo "PASSED=$pass_count"
+echo "FAILED=$fail_count"
+if [ "$fail_count" -gt 0 ]; then
+  echo "STATUS=FAIL"
+  exit 1
+fi
+echo "STATUS=OK"

--- a/git-plugin/skills/git-commit/evals.json
+++ b/git-plugin/skills/git-commit/evals.json
@@ -7,11 +7,11 @@
       "description": "Basic conventional commit with scope for a new feature",
       "prompt": "I just added a new OAuth login feature to the auth module. Please commit my staged changes.",
       "expectations": [
-        "Commit message starts with feat(",
-        "Commit message includes a scope related to auth or oauth",
+        { "assertion": "Commit message starts with feat(", "check": "regex", "pattern": "^feat\\(", "scope": "subject" },
+        { "assertion": "Commit message includes a scope related to auth or oauth", "check": "regex", "pattern": "^[a-z]+\\((auth|oauth|login)", "flags": "i", "scope": "subject" },
         "Subject line uses imperative mood",
-        "Subject line does not end with a period",
-        "Subject begins with lowercase after the colon"
+        { "assertion": "Subject line does not end with a period", "check": "regex", "pattern": "[^.]$", "scope": "subject" },
+        { "assertion": "Subject begins with lowercase after the colon", "check": "regex", "pattern": ":\\s+[a-z]", "scope": "subject" }
       ],
       "tags": ["conventional-commits", "feat", "basic"]
     },
@@ -20,9 +20,9 @@
       "description": "Bug fix commit with issue reference",
       "prompt": "I fixed the null pointer crash in the API serializer. This fixes issue #42. Please commit.",
       "expectations": [
-        "Commit message starts with fix(",
-        "Commit message references #42 in the body or footer",
-        "Uses Fixes or Closes keyword for the issue reference",
+        { "assertion": "Commit message starts with fix(", "check": "regex", "pattern": "^fix\\(", "scope": "subject" },
+        { "assertion": "Commit message references #42 in the body or footer", "check": "substring", "value": "#42" },
+        { "assertion": "Uses Fixes or Closes keyword for the issue reference", "check": "regex", "pattern": "(Fixes|Closes)\\s+#42", "flags": "i" },
         "Subject describes the fix, not just 'fix bug'"
       ],
       "tags": ["conventional-commits", "fix", "issue-ref"]
@@ -32,9 +32,9 @@
       "description": "Breaking change commit",
       "prompt": "I removed the deprecated /v1/users endpoint. This is a breaking change. Please commit.",
       "expectations": [
-        "Commit message includes ! before the colon OR includes BREAKING CHANGE in footer",
+        { "assertion": "Commit message includes ! before the colon OR includes BREAKING CHANGE in footer", "check": "regex", "pattern": "(^[a-z]+(\\([^)]*\\))?!:|BREAKING CHANGE)", "flags": "m" },
         "Commit message explains what was removed",
-        "Commit type is feat or fix or refactor"
+        { "assertion": "Commit type is feat or fix or refactor", "check": "regex", "pattern": "^(feat|fix|refactor)", "scope": "subject" }
       ],
       "tags": ["conventional-commits", "breaking-change"]
     },
@@ -43,9 +43,9 @@
       "description": "Documentation-only change",
       "prompt": "I updated the README with new installation instructions. Please commit.",
       "expectations": [
-        "Commit message starts with docs(",
-        "Subject mentions README or documentation or installation",
-        "Does not use feat or fix type"
+        { "assertion": "Commit message starts with docs(", "check": "regex", "pattern": "^docs\\(", "scope": "subject" },
+        { "assertion": "Subject mentions README or documentation or installation", "check": "regex", "pattern": "(README|documentation|install)", "flags": "i", "scope": "subject" },
+        { "assertion": "Does not use feat or fix type", "check": "absent_regex", "pattern": "^(feat|fix)\\(", "scope": "subject" }
       ],
       "tags": ["conventional-commits", "docs"]
     },
@@ -54,9 +54,9 @@
       "description": "Multi-issue commit with body",
       "prompt": "I refactored the database connection pooling to use async/await. This closes #100 and is related to #101. Please commit with a detailed message.",
       "expectations": [
-        "Commit message starts with refactor(",
-        "Commit message references both #100 and #101",
-        "Commit has a body (not just a subject line)",
+        { "assertion": "Commit message starts with refactor(", "check": "regex", "pattern": "^refactor\\(", "scope": "subject" },
+        { "assertion": "Commit message references both #100 and #101", "check": "substring_all", "values": ["#100", "#101"] },
+        { "assertion": "Commit has a body (not just a subject line)", "check": "regex", "pattern": "\\S\\n\\n\\S", "flags": "s" },
         "Body provides context about what changed"
       ],
       "tags": ["conventional-commits", "refactor", "multi-issue", "body"]


### PR DESCRIPTION
## What & why

A pragmatic, reproducible way to measure skill effectiveness across models (opus / sonnet / haiku) — cheap enough to run on a cadence, with enough signal to flag when a skill needs adjusting after a new Claude model ships.

This is a **design + prototype** (first slice). It extends the existing `evaluate-plugin` rather than introducing a new plugin.

## The gap it closes

`evaluate-plugin` already grades a single skill against assertions with a `--baseline` delta. Missing for "are our skills still effective, and on which model?":

1. **No cross-model dimension** — runs used whatever model was active.
2. **Token cost** — every assertion routed through an Opus `eval-grader` subagent; ruinous as a fleet-wide regular signal.
3. **No reproducibility/cadence contract** — nothing pinned model IDs or diffed against the last run.

## Key idea: split assertions into deterministic vs judged

Most expectations are machine-checkable (`starts with feat(`, `references #42`, `no trailing period`). Those grade for **zero model tokens**. Only fuzzy ones (`imperative mood`, `provides context`) need the LLM judge. On the git-commit set this is ~70% graded for free.

## What's in this PR

| Piece | |
|-------|--|
| `scripts/grade_deterministic.py` | regex / substring / substring_all / absent_regex checks with `scope` + `flags`; KEY=value + JSON output; `--strict` exit code for CI |
| `scripts/render_matrix_report.py` | with-skill vs baseline delta table per model, redundant/earns-keep/fighting verdicts, opus↔haiku portability flag, Δ-vs-previous-run markers |
| `references/schemas.md` | typed-check schema on `expectations` + new `model-matrix.json` schema |
| `git-plugin/skills/git-commit/evals.json` | migrated to typed checks — **backward compatible** (bare strings still grade as `judge`) |
| `agents/eval-grader.md` | handles string-or-object expectations; defers typed checks to the deterministic grader |
| `scripts/tests/test_grade_deterministic.sh` | 14-assertion regression test (per `.claude/rules/regression-testing.md`) |
| `docs/cross-model-evaluation.md` | tiered cost model, golden-set criteria, in-session-subagent run engine, token math, cadence |

## Design decisions (chosen with the user)

- **Run engine:** in-session subagents (the `Agent`/`Task` `model` field selects opus/sonnet/haiku), keeping real tool execution. No `context: fork`; subagent dispatch serialized to avoid the `[1m]` rate-limit trap (`.claude/rules/skill-fork-context.md`).
- **First slice:** design doc + prototype against the one existing `evals.json` (git-commit).

## Verification

```
$ bash evaluate-plugin/scripts/tests/test_grade_deterministic.sh
PASSED=14  FAILED=0  STATUS=OK
```

Plugin compliance check passes for `evaluate-plugin`; both new JSON files validate.

## Follow-ups (not in this PR)

- `/evaluate:matrix` orchestration skill (loops models × evals × {with_skill, cached_baseline})
- `golden-set.json` (~15–25 canary skills)
- cron + model-release trigger

https://claude.ai/code/session_01WbpDSdJ94s5Kvutw8ueZQR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbpDSdJ94s5Kvutw8ueZQR)_