### PR TITLE
feat(repo): add top-level docs-index drift audit

### DIFF
--- a/.github/workflows/scheduled-audits.yml
+++ b/.github/workflows/scheduled-audits.yml
@@ -227,3 +227,39 @@ jobs:
             --title "Monthly Agentic Quality Audit: $MONTH" \
             --label "agentic-audit,maintenance" \
             --body-file /tmp/issue-body.md
+
+  docs-index:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Check for existing open issue
+        id: check_issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING=$(gh issue list --label "docs-index" --state open --json number --jq 'length')
+          echo "exists=$([ "$EXISTING" -gt 0 ] && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - name: Run docs-index drift check
+        if: steps.check_issue.outputs.exists == 'false'
+        id: docs
+        run: |
+          RESULT=$(bash scripts/check-docs-index.sh --issue-body)
+          echo "result<<EOF" >> $GITHUB_OUTPUT
+          echo "$RESULT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create docs-index drift issue
+        if: steps.check_issue.outputs.exists == 'false' && steps.docs.outputs.result
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_BODY: ${{ steps.docs.outputs.result }}
+        run: |
+          MONTH=$(date +%Y-%m)
+          printf '%s' "$ISSUE_BODY" > /tmp/issue-body.md
+          gh issue create \
+            --title "Top-level docs drift (Layer 1): $MONTH" \
+            --label "docs-index,maintenance" \
+            --body-file /tmp/issue-body.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,9 @@ Claude Code plugin collection providing skills and agents for development workfl
 | `.claude/rules/structured-script-output.md` | `=== HEADER ===` / `KEY=VALUE` / `STATUS=` convention for diagnostic shell scripts |
 | `.claude/rules/typer-cli-completion.md` | Bypass `shellingham` in Python/Typer CLIs by adding an explicit `completion <shell>` subcommand using Click's `get_completion_class` |
 | `.claude/rules/terminology.md` | Glossary of development terms with strong intent (scoping, review, parallelism, work state, code ops, requirements) — positive definitions with *Use when* disambiguation |
+| `.claude/rules/parallel-safe-queries.md` | Query commands that exit non-zero on empty results silently cancel sibling parallel tool calls — use the machine-readable variant (`--json`/`export` + `jq`) |
+| `.claude/rules/docs-currency.md` | Code and the docs describing it land in the **same commit** (stub → `blueprint:blueprint-docs-currency`) |
+| `.claude/rules/agent-cli-worktree-safety.md` | Data-loss-prevention conventions for the sibling Python/Typer CLI projects (`git-repo-agent`, `vault-agent`); path-scoped, not repo-wide |
 
 ## Creating New Skills
 

--- a/scripts/check-docs-index.sh
+++ b/scripts/check-docs-index.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Audit top-level documentation maps for mechanical drift (Layer 1 of #1460).
+#
+# Two zero-false-positive checks:
+#   1. RULES INDEX  — every .claude/rules/*.md appears in the CLAUDE.md Rules
+#      table, and every table entry exists on disk (bidirectional).
+#   2. PLUGIN MAPS  — the plugin set agrees across marketplace.json,
+#      release-please-config.json, .release-please-manifest.json, the *-plugin
+#      directories on disk, and docs/PLUGIN-MAP.md.
+#
+# Emits the structured KEY=value / STATUS= convention
+# (.claude/rules/structured-script-output.md) so scheduled-audits can roll it up.
+#
+# Usage:
+#   check-docs-index.sh [--project-dir <path>] [--issue-body] [--strict]
+#
+#   --project-dir   Repo root to audit (default: git toplevel, else cwd)
+#   --issue-body    Emit a markdown issue body (empty when clean) instead of the
+#                   structured section — for the scheduled-audits workflow
+#   --strict        Exit 1 when drift is found (default: always exit 0)
+set -uo pipefail
+
+proj_dir=""
+emit_issue_body=false
+strict=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --project-dir) proj_dir="$2"; shift 2 ;;
+    --issue-body) emit_issue_body=true; shift ;;
+    --strict) strict=true; shift ;;
+    *) shift ;;
+  esac
+done
+
+if [ -z "$proj_dir" ]; then
+  proj_dir="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+fi
+
+claude_md="$proj_dir/CLAUDE.md"
+rules_dir="$proj_dir/.claude/rules"
+marketplace="$proj_dir/.claude-plugin/marketplace.json"
+rp_config="$proj_dir/release-please-config.json"
+rp_manifest="$proj_dir/.release-please-manifest.json"
+plugin_map="$proj_dir/docs/PLUGIN-MAP.md"
+
+issue_count=0
+declare -a issues=()
+
+add_issue() {
+  # add_issue <severity> <type> <message>
+  issues+=("  - SEVERITY=$1 TYPE=$2 MSG=$3")
+  issue_count=$((issue_count + 1))
+}
+
+# --- Check 1: rules index vs disk ---------------------------------------------
+rules_on_disk="$(find "$rules_dir" -maxdepth 1 -name '*.md' -type f 2>/dev/null \
+  | sed "s#$rules_dir/##" | sort)"
+rules_in_table="$(grep -oE '\.claude/rules/[a-z0-9-]+\.md' "$claude_md" 2>/dev/null \
+  | sed 's#.claude/rules/##' | sort -u)"
+
+missing_from_table="$(comm -23 <(printf '%s\n' "$rules_on_disk") <(printf '%s\n' "$rules_in_table"))"
+missing_from_disk="$(comm -13 <(printf '%s\n' "$rules_on_disk") <(printf '%s\n' "$rules_in_table"))"
+
+while IFS= read -r rule; do
+  [ -n "$rule" ] && add_issue WARN rule_not_indexed "$rule exists but is absent from the CLAUDE.md Rules table"
+done <<< "$missing_from_table"
+
+while IFS= read -r rule; do
+  [ -n "$rule" ] && add_issue ERROR rule_table_dangling "CLAUDE.md Rules table lists $rule but no such file exists"
+done <<< "$missing_from_disk"
+
+rules_disk_count="$(printf '%s\n' "$rules_on_disk" | grep -c . || true)"
+rules_table_count="$(printf '%s\n' "$rules_in_table" | grep -c . || true)"
+
+# --- Check 2: plugin maps agree -----------------------------------------------
+mkt_set="$(jq -r '.plugins[].name' "$marketplace" 2>/dev/null | sort)"
+rp_set="$(jq -r '.packages | keys[]' "$rp_config" 2>/dev/null | grep -v '^\.$' | sort)"
+manifest_set="$(jq -r 'keys[]' "$rp_manifest" 2>/dev/null | grep -v '^\.$' | sort)"
+disk_set="$(find "$proj_dir" -maxdepth 1 -type d -name '*-plugin' -not -name '.claude-plugin' 2>/dev/null \
+  | sed "s#$proj_dir/##" | sort)"
+
+compare_sets() {
+  # compare_sets <label-a> <set-a> <label-b> <set-b>
+  local only_a only_b
+  only_a="$(comm -23 <(printf '%s\n' "$2") <(printf '%s\n' "$4"))"
+  only_b="$(comm -13 <(printf '%s\n' "$2") <(printf '%s\n' "$4"))"
+  while IFS= read -r p; do
+    [ -n "$p" ] && add_issue ERROR plugin_map_drift "$p in $1 but missing from $3"
+  done <<< "$only_a"
+  while IFS= read -r p; do
+    [ -n "$p" ] && add_issue ERROR plugin_map_drift "$p in $3 but missing from $1"
+  done <<< "$only_b"
+}
+
+compare_sets "marketplace.json" "$mkt_set" "release-please-config.json" "$rp_set"
+compare_sets "marketplace.json" "$mkt_set" ".release-please-manifest.json" "$manifest_set"
+compare_sets "marketplace.json" "$mkt_set" "plugin dirs on disk" "$disk_set"
+
+# PLUGIN-MAP.md is prose, so check presence (substring) rather than exact set.
+while IFS= read -r p; do
+  [ -n "$p" ] || continue
+  grep -q "$p" "$plugin_map" 2>/dev/null || add_issue WARN plugin_map_missing "$p not mentioned in docs/PLUGIN-MAP.md"
+done <<< "$mkt_set"
+
+mkt_count="$(printf '%s\n' "$mkt_set" | grep -c . || true)"
+
+# --- Status -------------------------------------------------------------------
+overall_status="OK"
+exit_severity=0
+for line in "${issues[@]}"; do
+  case "$line" in
+    *SEVERITY=ERROR*) overall_status="ERROR"; exit_severity=1 ;;
+  esac
+done
+if [ "$overall_status" = "OK" ] && [ "$issue_count" -gt 0 ]; then
+  overall_status="WARN"
+fi
+
+# --- Output -------------------------------------------------------------------
+if [ "$emit_issue_body" = true ]; then
+  if [ "$issue_count" -gt 0 ]; then
+    echo "## Top-level documentation drift (Layer 1)"
+    echo ""
+    echo "\`scripts/check-docs-index.sh\` found $issue_count mechanical drift issue(s)."
+    echo ""
+    echo "| Severity | Type | Detail |"
+    echo "|----------|------|--------|"
+    for line in "${issues[@]}"; do
+      sev="$(printf '%s' "$line" | sed -n 's/.*SEVERITY=\([A-Z]*\).*/\1/p')"
+      typ="$(printf '%s' "$line" | sed -n 's/.*TYPE=\([a-z_]*\).*/\1/p')"
+      msg="$(printf '%s' "$line" | sed -n 's/.*MSG=//p')"
+      echo "| $sev | \`$typ\` | $msg |"
+    done
+    echo ""
+    echo "See \`.claude/rules\` and the Plugin Lifecycle section of CLAUDE.md. Tracked under the recurring Layer 1 audit (#1460)."
+  fi
+else
+  echo "=== DOCS INDEX AUDIT ==="
+  echo "RULES_ON_DISK=$rules_disk_count"
+  echo "RULES_IN_TABLE=$rules_table_count"
+  echo "MARKETPLACE_PLUGINS=$mkt_count"
+  echo "STATUS=$overall_status"
+  echo "ISSUE_COUNT=$issue_count"
+  if [ "$issue_count" -gt 0 ]; then
+    echo "ISSUES:"
+    printf '%s\n' "${issues[@]}"
+  fi
+  echo "=== END DOCS INDEX AUDIT ==="
+fi
+
+if [ "$strict" = true ]; then
+  exit "$exit_severity"
+fi
+exit 0

--- a/scripts/tests/test-check-docs-index.sh
+++ b/scripts/tests/test-check-docs-index.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Regression test for scripts/check-docs-index.sh (Layer 1 docs-drift audit, #1460).
+#
+# Guards three things:
+#   A. the real repo stays clean — every new rule must be added to the CLAUDE.md
+#      Rules table (this is the recurring invariant the audit enforces)
+#   B. an unindexed rule is flagged (WARN rule_not_indexed)
+#   C. a plugin present in marketplace.json but missing on disk is flagged
+#      (ERROR plugin_map_drift) and --strict exits non-zero
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+checker="$repo_root/scripts/check-docs-index.sh"
+
+pass_count=0
+fail_count=0
+
+assert() {
+  # assert <description> <condition-result-string "true"/"false">
+  if [ "$2" = "true" ]; then
+    pass_count=$((pass_count + 1))
+  else
+    echo "FAIL: $1" >&2
+    fail_count=$((fail_count + 1))
+  fi
+}
+
+field() { printf '%s\n' "$1" | grep -m1 "^$2=" | cut -d= -f2; }
+contains() { printf '%s' "$1" | grep -q "$2" && echo true || echo false; }
+
+echo "=== TEST A: real repo is clean ==="
+real_out="$(bash "$checker" --project-dir "$repo_root")"
+assert "real repo STATUS should be OK" "$([ "$(field "$real_out" STATUS)" = "OK" ] && echo true || echo false)"
+assert "real repo ISSUE_COUNT should be 0" "$([ "$(field "$real_out" ISSUE_COUNT)" = "0" ] && echo true || echo false)"
+
+# --- Build a synthetic fixture repo with deliberate drift ---------------------
+fixture="$(mktemp -d)"
+trap 'rm -rf "$fixture"' EXIT
+mkdir -p "$fixture/.claude/rules" "$fixture/.claude-plugin" "$fixture/docs" \
+  "$fixture/alpha-plugin" "$fixture/beta-plugin"
+
+printf '# Indexed rule\n' > "$fixture/.claude/rules/indexed.md"
+printf '# Orphan rule (intentionally not in the table)\n' > "$fixture/.claude/rules/orphan.md"
+
+cat > "$fixture/CLAUDE.md" <<'EOF'
+# Rules
+| Rule | Purpose |
+|------|---------|
+| `.claude/rules/indexed.md` | listed |
+EOF
+
+# marketplace has a ghost plugin (gamma) that has no dir on disk
+cat > "$fixture/.claude-plugin/marketplace.json" <<'EOF'
+{ "name": "m", "plugins": [
+  {"name": "alpha-plugin"}, {"name": "beta-plugin"}, {"name": "gamma-plugin"} ] }
+EOF
+cat > "$fixture/release-please-config.json" <<'EOF'
+{ "packages": { "alpha-plugin": {}, "beta-plugin": {}, "gamma-plugin": {} } }
+EOF
+cat > "$fixture/.release-please-manifest.json" <<'EOF'
+{ "alpha-plugin": "1.0.0", "beta-plugin": "1.0.0", "gamma-plugin": "1.0.0" }
+EOF
+printf '# Map\nalpha-plugin, beta-plugin, gamma-plugin\n' > "$fixture/docs/PLUGIN-MAP.md"
+
+echo "=== TEST B: unindexed rule flagged ==="
+fx_out="$(bash "$checker" --project-dir "$fixture")"
+assert "orphan.md should be flagged rule_not_indexed" "$(contains "$fx_out" "rule_not_indexed.*orphan.md")"
+
+echo "=== TEST C: ghost plugin flagged + --strict exit code ==="
+assert "gamma-plugin should be flagged plugin_map_drift" "$(contains "$fx_out" "plugin_map_drift.*gamma-plugin")"
+assert "fixture STATUS should be ERROR" "$([ "$(field "$fx_out" STATUS)" = "ERROR" ] && echo true || echo false)"
+
+strict_rc=0
+bash "$checker" --project-dir "$fixture" --strict >/dev/null || strict_rc=$?
+assert "--strict should exit 1 on ERROR drift" "$([ "$strict_rc" -eq 1 ] && echo true || echo false)"
+
+clean_rc=0
+bash "$checker" --project-dir "$repo_root" --strict >/dev/null || clean_rc=$?
+assert "--strict should exit 0 on clean repo" "$([ "$clean_rc" -eq 0 ] && echo true || echo false)"
+
+echo ""
+echo "=== SUMMARY ==="
+echo "PASSED=$pass_count"
+echo "FAILED=$fail_count"
+if [ "$fail_count" -gt 0 ]; then echo "STATUS=FAIL"; exit 1; fi
+echo "STATUS=OK"


### PR DESCRIPTION
## What

Layer 1 of #1460 — close the top-level documentation index drift and make it recurring so it can't silently re-accumulate.

## Findings from the sweep

I audited all the Layer 1 (mechanical) dimensions:

| Check | Result |
|-------|--------|
| Plugin maps (marketplace ↔ release-please-config ↔ manifest ↔ disk ↔ PLUGIN-MAP.md) | ✅ already consistent (40/40/40/40) |
| Dead markdown links in rules | ✅ none (the apparent hits were illustrative `[REFERENCE.md](REFERENCE.md)` author-pattern examples) |
| **CLAUDE.md Rules table vs `.claude/rules/*.md`** | ❌ **3 rules on disk missing from the table** |

The only real gap was the index: 31 rule files, 28 table rows.

## Changes

1. **Add the 3 missing rows** to the CLAUDE.md Rules table, each with a judged purpose description:
   - `parallel-safe-queries.md` — active, broadly-cited rule
   - `docs-currency.md` — noted as a stub → `blueprint:blueprint-docs-currency`
   - `agent-cli-worktree-safety.md` — noted as path-scoped to the sibling `git-repo-agent`/`vault-agent` projects

2. **`scripts/check-docs-index.sh`** — repeatable check encoding both zero-false-positive audits (Rules-table-vs-disk bidirectional + plugin-map consistency). Structured `STATUS=`/`ISSUE_COUNT=` output per `.claude/rules/structured-script-output.md`; `--issue-body` and `--strict` modes.

3. **`scripts/tests/test-check-docs-index.sh`** — 7 assertions: real repo stays clean (the recurring invariant — new rules must be indexed), unindexed rule flagged, ghost plugin flagged, `--strict` exit codes.

4. **Wire into `scheduled-audits.yml`** — a monthly `docs-index` job that opens a `docs-index,maintenance` issue *only when drift is found*.

This mirrors how `plugin-compliance-check.sh` audits *skills*; nothing previously audited the *top-level maps* that tie them together.

## Verification

```
$ bash scripts/check-docs-index.sh        # after the fix
STATUS=OK  ISSUE_COUNT=0  (RULES 31/31, 40 plugins)

$ bash scripts/tests/test-check-docs-index.sh
PASSED=7  FAILED=0  STATUS=OK
```
shellcheck + pre-commit clean.

## Deliberately out of scope (Layer 2 follow-up)

The `friction/` cross-references in several rules point at files that live in the maintainer's personal `~/.claude/rules/friction/`, not this repo (one cite even uses the `~/` prefix). Whether to normalize those paths is a content/provenance judgment call — left for the Layer 2 read-through tracked in #1460.

Refs #1460

https://claude.ai/code/session_01WbpDSdJ94s5Kvutw8ueZQR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbpDSdJ94s5Kvutw8ueZQR)_