### PR TITLE
fix(git-plugin): clarify check-pr-metadata-on-push bypass message

### DIFF
--- a/git-plugin/hooks/check-pr-metadata-on-push.sh
+++ b/git-plugin/hooks/check-pr-metadata-on-push.sh
@@ -175,5 +175,11 @@ Before pushing, verify:
 2. PR description/summary reflects what the commits actually do
 3. Issue references (Closes/Fixes/Resolves #N) are still correct
 
-If the PR metadata is already accurate, re-run the push command.
-If updates are needed, update the PR title/description first, then push."
+Timestamps (why a bare re-run won't bypass this check):
+  Latest commit authored: ${HEAD_AUTHOR_TIME:-(unknown)}
+  PR last updated:        ${PR_UPDATED_AT:-(unknown)}
+
+To bypass: edit the PR title or body so it reflects the new commit, THEN push.
+Editing the PR bumps its updatedAt past your commit's author time, which the
+hook reads as 'metadata reconciled' and lets the push through on the next attempt.
+Re-running the push without editing the PR fires the same block again."


### PR DESCRIPTION
## Summary

- The block message previously said "If the PR metadata is already accurate, re-run the push command" — implying a bare re-run bypasses the hook. It does not.
- The retry-aware bypass (lines 135-138) only exits 0 when PR_UPDATED_TS > HEAD_AUTHOR_TS. A re-run with no PR-side change fires the same block again.
- Rewrites the closing section to explain that bypassing requires **editing** the PR title or body after the new commit, and adds a timestamp display so the user can see at a glance why a bare re-run won't help.

## Changes

`git-plugin/hooks/check-pr-metadata-on-push.sh` — rewrite block message lines 178-185:
- Surface HEAD_AUTHOR_TIME and PR_UPDATED_AT so the user sees the timestamps being compared
- Replace the misleading "re-run the push command" instruction with a clear explanation of the updatedAt > authorTime bypass mechanism

## Test plan

- [ ] Push to a branch with an existing PR — verify the block message now shows both timestamps and the correct bypass instruction
- [ ] Edit the PR title/body after the push attempt, then push again — verify the bypass fires as before
- [ ] Confirm no change in bypass logic (only message text changed)

Closes #1431

🤖 Generated with [Claude Code](https://claude.com/claude-code)
