### PR TITLE
docs(agent-patterns-plugin): document killed-agent worktree recovery

### DIFF
--- a/agent-patterns-plugin/skills/parallel-agent-dispatch/REFERENCE.md
+++ b/agent-patterns-plugin/skills/parallel-agent-dispatch/REFERENCE.md
@@ -167,6 +167,55 @@ hangs, emit your Return Contract with `status: failed`,
 `worktree: dirty: <files>`, and `Orchestrator action needed: pre-commit
 hook X failed, fix and commit on my behalf."*
 
+## Killed-agent worktree recovery (TaskStop)
+
+Distinct from the silent commit-stall above: here the orchestrator
+**deliberately kills** a stuck or thrashing agent with `TaskStop` rather
+than waiting for it to fail on its own. The key affordance is that
+`TaskStop` preserves the agent's worktree on disk — every uncommitted
+change survives the kill — so the orchestrator can recover the work
+instead of re-implementing from scratch.
+
+**When to kill early.** An agent that is hook-thrashing emits a visible
+signature well before it gives up: a Bash-heavy tool mix with very few
+Edits and a rising rate of `is_error: true` results (typically
+`PreToolUse` hook blocks). Killing at that point and salvaging the
+worktree is cheaper than letting it run another 80–200 tool calls to a
+silent failure. (The leading-indicator heuristic itself is tracked
+separately in issue
+[#1424](https://github.com/laurigates/claude-plugins/issues/1424).)
+
+**Recovery checklist** — from the parent, after `TaskStop`:
+
+1. `cd .claude/worktrees/agent-<id>/`
+2. `git status` — see the uncommitted changes the agent left.
+3. `git diff origin/main --stat` — measure the scope of what landed.
+4. `git log --oneline -5` — check whether the agent committed anything
+   before it was killed.
+5. Decide **salvage vs restart**:
+   - **Salvage** (substantive diff): finish the work in the parent
+     session — complete any half-written files, fix tests that depend
+     on the agent's changes, run the quality gates, then commit and push
+     preserving the agent's intended branch, and open the PR.
+   - **Restart** (empty/trivial diff, or the design was wrong):
+     `git worktree remove .claude/worktrees/agent-<id>` to clear the
+     abandoned worktree before re-dispatching from scratch.
+
+This pattern pays off most for refactors with heavy design-time work:
+the agent's exploration and partial implementation are recoverable even
+when the agent itself fails to land them.
+
+> **Evidence.** During Wave B of a multi-wave refactor on
+> `pal-mcp-server`, a dispatched agent thrashed on `bash-antipatterns.sh`
+> (180 tool calls, 120 error signals, no PR pushed). Killing it via
+> `TaskStop` left its worktree intact with the bulk of the refactor
+> done (−791 lines net across five provider files, plus a
+> partially-written contract test). Salvaging in the parent session —
+> finishing the contract test, repairing three tests that depended on the
+> old API, running the gates, committing, pushing, opening the PR — took
+> ~30 min versus an estimated ~90 min for a fresh agent (which would have
+> re-discovered the refactor design before reimplementing).
+
 ## Concurrent rate-limit risk — recovery-dispatch routine
 
 When a subagent returns with the rate-limit signature (`API Error: Server

--- a/agent-patterns-plugin/skills/parallel-agent-dispatch/SKILL.md
+++ b/agent-patterns-plugin/skills/parallel-agent-dispatch/SKILL.md
@@ -5,8 +5,8 @@ user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 model: opus
 created: 2026-04-21
-modified: 2026-05-19
-reviewed: 2026-05-19
+modified: 2026-05-31
+reviewed: 2026-05-31
 ---
 
 # Parallel Agent Dispatch
@@ -312,6 +312,30 @@ The dominant cause of silent stalls is a **pre-commit hook blocking
 parked, no Return Contract fires. See
 [REFERENCE.md → Agent stalled at commit / push](REFERENCE.md#agent-stalled-at-commit--push--salvage-routine)
 for symptoms, the four-step salvage routine, and prevention briefs.
+
+## Killing a Thrashing Agent Preserves Its Worktree
+
+`TaskStop` does **not** discard the agent's work — its worktree stays on
+disk with every uncommitted change intact. This makes `TaskStop` a
+**recovery affordance**, not a last resort: when an agent is stuck or
+thrashing (e.g. repeatedly hitting a `PreToolUse` hook with a rising
+`is_error` rate and few Edits), killing it early and salvaging the
+worktree beats waiting for it to give up silently 80–200 tool calls
+later.
+
+After `TaskStop`, decide **salvage vs restart** from the worktree state:
+
+| Worktree state | Decision |
+|----------------|----------|
+| Substantive diff vs `origin/main` (the agent did the hard part) | **Salvage** — finish in the parent session, commit, push, open the PR |
+| Empty / trivial diff, or the design itself was wrong | **Restart** — `git worktree remove <path>` first, then re-dispatch |
+
+Quick triage inside the worktree: `git status`, `git diff origin/main
+--stat`, `git log --oneline -5`. The agent's exploration and partial
+implementation are not wasted even when the agent itself failed — which
+matters most for refactors with heavy design-time work. See
+[REFERENCE.md → Killed-agent worktree recovery](REFERENCE.md#killed-agent-worktree-recovery-taskstop)
+for the full recovery checklist and evidence.
 
 ## Concurrent rate-limit risk
 


### PR DESCRIPTION
## What

Documents the **killed-agent worktree recovery** affordance in
`agent-patterns-plugin:parallel-agent-dispatch`. `TaskStop` preserves a
dispatched agent's worktree on disk with all uncommitted work intact, so
an orchestrator can salvage a thrashing agent's work instead of
re-implementing from scratch.

Closes #1427.

## Why

The skill already covered the **silent commit-stall** salvage case (an
agent that parks on a pre-commit hook and never returns). It never
documented the **deliberate-kill** case: when the orchestrator actively
`TaskStop`s a stuck or hook-thrashing agent. The reporter hit this live
on `pal-mcp-server` — killing a thrashing agent and salvaging its
worktree took ~30 min versus an estimated ~90 min for a fresh agent that
would have re-discovered the refactor design before reimplementing.

This is the root of the agent-dispatch failure/recovery cluster: it
documents the worktree-preservation fact that the **kill + recover**
intervention in #1424 (tool-use-ratio thrashing heuristic) relies on, so
landing it first unblocks #1424.

## Changes

| File | Change |
|------|--------|
| `SKILL.md` | New section "Killing a Thrashing Agent Preserves Its Worktree" — salvage-vs-restart decision table, quick triage commands, REFERENCE link |
| `REFERENCE.md` | New section "Killed-agent worktree recovery (TaskStop)" — when-to-kill-early signal, full recovery checklist, and the pal-mcp-server evidence |

Frontmatter `modified` / `reviewed` bumped to 2026-05-31.

## Scope notes

- Documentation-only (positive-feedback), so no behavior change and no
  regression-script addition (the regression-testing rule targets bug
  fixes that alter skill behavior).
- SKILL.md is 396 lines, within the 500-line ceiling. REFERENCE.md has
  no size limit.
- All pre-commit hooks pass (skill-description audits, context-command
  lint, MCP-tool-reference lint, secret scan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)