### PR TITLE
docs(repo): remove dangling friction-file references

### DIFF
--- a/.claude/rules/bash-tool-replacements.md
+++ b/.claude/rules/bash-tool-replacements.md
@@ -60,10 +60,6 @@ switch to the tool.
 
 ## Related
 
-- `.claude/rules/friction/2026-W16-frictions.md` — original `find` →
-  `Glob` rule and its W16 baseline
-- `.claude/rules/friction/2026-W20-frictions.md` — measured impact
-  data and same-session repeat-block analysis
 - `.claude/rules/parallel-safe-queries.md` — why the Bash form is
   doubly painful in parallel batches: it both fires the hook AND
   exits non-zero on empty results, cancelling sibling tool calls

--- a/.claude/rules/gh-json-fields.md
+++ b/.claude/rules/gh-json-fields.md
@@ -99,8 +99,6 @@ gh pr view 42 --json mergedAt --jq '.mergedAt | length > 0'
 
 ## Related
 
-- `.claude/rules/friction/2026-W20-frictions.md` — measured impact
-  (10 events across 10 distinct sessions in the W20 window)
 - `.claude/rules/github-metadata-hygiene.md` (parent
   `laurigates/CLAUDE.md`) — when to query PR metadata at all
 - `gh pr help json-fields` — official field reference (when available)

--- a/.claude/rules/parallel-safe-queries.md
+++ b/.claude/rules/parallel-safe-queries.md
@@ -59,8 +59,5 @@ earns dedicated reference from more than a handful of skills.
 
 ## Related
 
-- `.claude/rules/friction/2026-W16-frictions.md` — cancelled-parallel-call
-  friction pattern; the same class of failure manifests when `find` is
-  used instead of Glob
 - `agent-patterns-plugin:parallel-agent-dispatch` — the broader
   orchestrator contract that this rule slots into

--- a/hooks-plugin/docs/teach-mode-experiment.md
+++ b/hooks-plugin/docs/teach-mode-experiment.md
@@ -7,8 +7,8 @@ PreToolUse `bash-antipatterns.sh` blocks are unchanged.
 
 ## Motivation
 
-The 2026-W20 friction analysis (`.claude/rules/friction/2026-W20-frictions.md`)
-showed `grep`/`rg` vs the `Grep` tool sitting at a **21% same-session
+The 2026-W20 friction analysis showed `grep`/`rg` vs the `Grep` tool
+sitting at a **21% same-session
 repeat-block rate** — about 2× the rate for established `bash-antipatterns`
 blocks like `git &&` chains (8%) or `find` vs `Glob` (12%).
 
@@ -147,8 +147,8 @@ noise and stop reading tool output).
   default `hooks.json`, strip the soft-teach blocks from
   `bash-antipatterns.sh` (keep the security-critical ones), document
   the new shape in `.claude/rules/bash-tool-replacements.md`.
-- **If not met**: revert. Document why in
-  `.claude/rules/friction/2026-W2X-frictions.md` and re-investigate.
+- **If not met**: revert. Document why in the W2X friction analysis
+  and re-investigate.
 
 ## Implementation notes
 
@@ -224,6 +224,5 @@ exit-2-blocking to model and reader).
 ## Related
 
 - `.claude/rules/hooks-reference.md` — `PostToolUse` / `updatedToolOutput` reference
-- `.claude/rules/friction/2026-W20-frictions.md` — motivating data
 - `.claude/rules/bash-tool-replacements.md` — current rule prose (no edits in phase 1)
 - `hooks-plugin/hooks/bash-antipatterns.sh` — existing PreToolUse hook

--- a/hooks-plugin/hooks/bash-antipatterns-teach.sh
+++ b/hooks-plugin/hooks/bash-antipatterns-teach.sh
@@ -10,7 +10,7 @@
 #
 # Why PostToolUse + updatedToolOutput instead of PreToolUse + exit 2?
 #
-# 2026-W20 friction analysis (.claude/rules/friction/2026-W20-frictions.md):
+# 2026-W20 friction analysis:
 # - grep/rg vs Grep tool: 41 events / 33 sessions / 24% per-session rate / 21%
 #   same-session repeat-block rate
 # - find vs Glob: 29 events / 25 sessions / 17% per-session / 12% repeat-block


### PR DESCRIPTION
## Summary

The `.claude/rules/friction/2026-W*-frictions.md` files are personal friction-analysis artifacts that live under `~/.claude`, **not** in this repo. Several files carried repo-relative links to them (`./.claude/rules/friction/...`), which are broken — the path resolves to nothing inside the checkout.

This PR removes those dangling repo-relative references while preserving the descriptive context and data around them.

## Changes

- **`.claude/rules/parallel-safe-queries.md`** — drop the `## Related` bullet pointing at `friction/2026-W16-frictions.md`
- **`.claude/rules/gh-json-fields.md`** — drop the `## Related` bullet pointing at `friction/2026-W20-frictions.md`
- **`.claude/rules/bash-tool-replacements.md`** — drop two `## Related` bullets pointing at `friction/2026-W16` and `2026-W20`
- **`hooks-plugin/docs/teach-mode-experiment.md`** — strip the broken inline path from the Motivation/Phase-3 prose and remove the `## Related` bullet, keeping the W20 data and narrative
- **`hooks-plugin/hooks/bash-antipatterns-teach.sh`** — strip the broken path from the rationale comment

## Left intentionally untouched

References that use the **home path** `~/.claude/rules/friction/...` (in `.claude/rules/regression-testing.md` and `feedback-plugin/scripts/`) are correct by convention — they point at personal artifacts under `$HOME`, not at repo files.

## Verification

```
grep -rn '\.claude/rules/friction/' . | grep -v ~/.claude   →  no matches
```

https://claude.ai/code/session_01WbpDSdJ94s5Kvutw8ueZQR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbpDSdJ94s5Kvutw8ueZQR)_