### PR TITLE
docs(rules): extend gh-json-fields with CI check fields and W23 evidence

### DIFF
--- a/.claude/rules/gh-json-fields.md
+++ b/.claude/rules/gh-json-fields.md
@@ -8,8 +8,8 @@ right the first time.
 ## The `merged` mistake
 
 The single most-common mistake (6 of 10 `Unknown JSON field` errors in
-the W20 window, across 6 distinct sessions) is asking for a field
-called `merged`:
+the W20 window, and recurring at 4 sessions in W23, across 6+4 distinct
+sessions) is asking for a field called `merged`:
 
 ```
 # Wrong — there is no `merged` field on the PR JSON object
@@ -84,6 +84,39 @@ These were all observed in the W20 window. The unifying theme: GitHub's
 GraphQL schema uses **camelCase**, not snake_case, and PR/issue
 objects don't carry every property of their parent repository.
 
+## CI check fields (W23 additions)
+
+Asking a PR object directly about its CI checks does not work — there
+is no flat `conclusion`, `checksStatus`, or `checkRuns` field on the PR
+itself. Check status lives in **`statusCheckRollup`**, an array of one
+entry per check, each with its own `conclusion`, `name`, `startedAt`,
+`completedAt`, `detailsUrl`, etc.
+
+| Want to know | You might try | Correct field on PR |
+|---|---|---|
+| Are all checks passing? | `--json conclusion` | `--json statusCheckRollup --jq '[.statusCheckRollup[].conclusion] \| all(. == "SUCCESS")'` |
+| Are all checks complete? | `--json checksStatus` | `--json statusCheckRollup --jq '[.statusCheckRollup[].status] \| all(. == "COMPLETED")'` |
+| Which checks failed? | `--json conclusion,name` | `--json statusCheckRollup --jq '.statusCheckRollup[] \| select(.conclusion == "FAILURE") \| .name'` |
+| Conclusion of one specific check | (no flat field) | `--json statusCheckRollup --jq '.statusCheckRollup[] \| select(.name == "test") \| .conclusion'` |
+
+A single `statusCheckRollup[].conclusion` is one of: `SUCCESS`,
+`FAILURE`, `NEUTRAL`, `CANCELLED`, `SKIPPED`, `TIMED_OUT`,
+`ACTION_REQUIRED`, `STALE`, `STARTUP_FAILURE`, or `null` (still
+running). `status` is one of `QUEUED`, `IN_PROGRESS`, `COMPLETED`,
+`WAITING`, `PENDING`, `REQUESTED`.
+
+For the lighter "did CI pass" check that doesn't need per-check
+detail, `gh pr checks <number>` (without `--json`) returns a
+human-readable summary and exits non-zero on failure — sometimes that
+exit code is the only signal you actually need:
+
+```bash
+# Exit 0 iff all checks passed; exit 1 on any failure or pending
+if gh pr checks 42 --required; then
+  echo "all required checks passed"
+fi
+```
+
 ## Edge case: `--jq` on a null field
 
 `mergedAt` is `null` for unmerged PRs. Plain `--jq '.mergedAt'` prints
@@ -102,3 +135,7 @@ gh pr view 42 --json mergedAt --jq '.mergedAt | length > 0'
 - `.claude/rules/github-metadata-hygiene.md` (parent
   `laurigates/CLAUDE.md`) — when to query PR metadata at all
 - `gh pr help json-fields` — official field reference (when available)
+- W20 friction findings: original `merged` rule (10 events / 10
+  sessions). Held at near-zero for W21-W22, then 8 events / 8 sessions
+  in W23 (4× `merged`, 2× `conclusion`, 1× `checksStatus`, 1×
+  `issueType`) prompted this extension.


### PR DESCRIPTION
## Summary

W23 friction analysis (week ending 2026-06-01) surfaced 8 `Unknown JSON field` events across 8 distinct sessions — breaking the zero-hold the rule maintained through W21 and W22. Four of those events tried `--json merged` again (already documented), but four tried fields the rule did not cover:

| Field | Sessions | Correct lookup |
|---|---|---|
| `merged` on PR | 4 | `state == "MERGED"` or `mergedAt != null` (documented, recurring) |
| `conclusion` on PR | 2 | `statusCheckRollup[].conclusion` |
| `checksStatus` on PR | 1 | `statusCheckRollup[]` |
| `issueType` on issue | 1 | `issueType.name` (documented, but tried as flat field) |

The new "CI check fields" section adds `statusCheckRollup` recipes for the common questions (are all checks passing, which failed, conclusion of one specific check), the full conclusion / status value enums, and a pointer to `gh pr checks --required` for the lighter exit-code-only path.

This is a pure rule-text extension — no code change, no test infrastructure to touch (`regression-testing.md` requires a script check only for *bug fixes*).

## Evidence

Findings file: `~/.claude/rules/friction/2026-W23-frictions.md` (user-global, not in this repo)

Key drift:

| Period | Unknown-JSON-field events / sessions |
|---|---|
| W20 (original rule landed) | 10 / 10 |
| W21 | 0 / 0 (zero-hold) |
| W22 | 1 / 1 (zero-hold) |
| **W23** | **8 / 8** (broken) |

## Test plan

- [ ] Re-read the rule end-to-end to confirm the CI-check table renders cleanly and the recipes are correct against `gh pr view --help` output
- [ ] Verify the W24 friction pass (2026-06-08) shows the three new field-name mistakes (`conclusion`, `checksStatus`, `issueType` as flat) drop to zero
- [ ] `merged` recurrence rate trajectory will indicate whether project-local rule placement is insufficient (next-week decision: promote to user-global `~/.claude/rules/`)

## Decision context

PR opened by the `reduce-friction` scheduled task on behalf of `feedback-plugin:friction-learner`. Per the GitHub Metadata Hygiene rule, the PR author (`laurigates`) is not added as reviewer because GitHub rejects self-review with HTTP 422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)