### PR TITLE
perf(hooks-plugin): dedup bash-antipatterns-teach hints per session

### DIFF
--- a/.claude/rules/hooks-reference.md
+++ b/.claude/rules/hooks-reference.md
@@ -483,6 +483,51 @@ Exit code 2 also declines. Return nothing to show dialog to user.
 
 ---
 
+## Transcript Replay Cost
+
+A second cost axis sits alongside the timeout budget: **anything a hook
+makes the model *see* lands in the transcript and is re-sent on every
+subsequent turn.** A one-line hint that fires on a high-frequency tool
+call isn't a one-time ~30-token cost — it's ~30 tokens × every remaining
+turn in the session. Hook authors should design for "never bloats the
+replayed transcript" as deliberately as "never reaches a diff."
+
+### Which output the model sees (and replays)
+
+| Output mechanism | Reaches the model? | Replays each turn? |
+|---|---|---|
+| Exit 0, write to a log file / disk only | No | No — **free** |
+| PreToolUse exit-2 stderr (block message) | Yes (as the tool result) | Yes |
+| PostToolUse `updatedToolOutput` | Yes (replaces the tool result) | Yes |
+| SessionStart `additionalContext` | Yes (prepended to first turn) | Yes |
+| `Stop` / `SubagentStop` `{"decision":"block","reason":...}` | **Yes** — the `reason` is shown so the model keeps working | Yes |
+| `Stop` exit 0 (allow) | No | No — **free** |
+
+A common misconception is that "`Stop` output never reaches the model."
+It does: a blocking `Stop` hook's `reason` is precisely what tells the
+model to continue, and the `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` safety net
+(2.1.143+) exists *because* the model re-reads that reason and keeps
+addressing it. What actually makes our `Stop` checks
+(`task-completeness.sh`, `git-stash-reminder.sh`) cheap is **frequency and
+conditionality**, not invisibility:
+
+- they fire at most once per stop attempt, not per tool call;
+- they stay silent (exit 0) unless there is a concrete finding; and
+- they are self-extinguishing — once the agent fixes the TODO / stray
+  debug line / stash, the next stop passes clean and the reason stops
+  replaying.
+
+### Design guidance
+
+| If the hook output is… | Do |
+|---|---|
+| Pure observability (logging, metrics) | Write to disk, exit 0 — never emit to the model (`event-logger.sh`) |
+| A correction the model needs once | Emit once, then **dedup per session** so repeats don't accumulate (`bash-antipatterns-teach.sh` keys a per-session seen-list under `${TMPDIR:-/tmp}/claude-bash-teach-seen/<session_id>`) |
+| A blocking gate | Keep the message short; fire only on a real finding; make it self-extinguishing so it stops replaying once resolved |
+| High-frequency per-call feedback | Reconsider — this is the most expensive shape; cap, dedup, or move the check to `Stop` |
+
+---
+
 ## PermissionRequest Hook Pattern
 
 `PermissionRequest` hooks fire when Claude requests permission for an operation (e.g., in default permission mode). They allow automated approval/denial without user interaction.

--- a/hooks-plugin/docs/teach-mode-experiment.md
+++ b/hooks-plugin/docs/teach-mode-experiment.md
@@ -132,7 +132,13 @@ Measure on sessions running the teach config:
 
 - Same-session repeat-block rate for `grep`/`rg`/`find -name`/`cat`/`head`/`tail`/`ls *.glob`
 - Per-session attempt rate (does the count fall as agents learn?)
-- Cost: tokens added per teach event (the corrective hint is ~30 tokens)
+- Cost: tokens added per *distinct* teach event. The corrective hint is
+  ~30 tokens, and `updatedToolOutput` persists in the transcript — so an
+  un-capped hint would replay ~30 tokens **per matching call for the rest
+  of the session**, not once. The session-scoped dedup (see Implementation
+  notes) caps this at one hint per pattern per session: at most ~150 tokens
+  of replayed banner for a whole session, regardless of how many times the
+  agent reaches for `grep`/`cat`/etc.
 
 Compare against the W20 baseline (21% repeat-block on `grep`/`rg`).
 
@@ -178,13 +184,41 @@ from command output. The 💡 prefix mirrors the existing reminder hook's
 voice without re-using the "REMINDER:" prefix (which signals
 exit-2-blocking to model and reader).
 
+### Session-scoped dedup (transcript replay cost)
+
+`updatedToolOutput` is not a one-shot message — it becomes the tool
+result in the transcript and is **re-sent to the model on every
+subsequent turn**, the same as any blocked-command stderr or injected
+context. An un-capped hint on a high-frequency command (`grep`, `cat`)
+therefore accumulates one replayed copy per matching call. The lesson is
+byte-identical each time, so every copy past the first is pure transcript
+bloat — the "never bloats the replayed transcript" axis, distinct from
+the "never reaches a diff" axis the PreToolUse blocks cover.
+
+The hook caps this with a per-session seen-list: each distinct hint
+(`read-cat`, `read-headtail`, `glob-find`, `grep`, `glob-ls`) is emitted
+at most once per session. The state file lives at
+`${TMPDIR:-/tmp}/claude-bash-teach-seen/<session_id>` (same sanitised-id
+convention as `git-stash-session-init.sh`) and is removed by
+`git-session-cleanup.sh` at `SessionEnd`. When `session_id` is absent the
+hook skips dedup and falls through to the old always-emit behaviour rather
+than guess a key — so the change is backward compatible and the existing
+no-session tests still pass.
+
+This caps the replayed banner at ~150 tokens for an entire session
+(five patterns × ~30 tokens) regardless of call count, while still
+delivering the correction the first time the agent reaches for each idiom.
+
 ### What we don't try in phase 1
 
 - **Stripping the soft-teach blocks from `bash-antipatterns.sh`.** That
   changes the default for every existing user. Phase 1 is opt-in.
 - **Tracking per-session lesson decay inside the hook.** Tempting
-  ("after 2 hints, switch to exit-2 blocking"), but adds state to a
-  stateless hook and is best left to the friction analyser.
+  ("after 2 hints, switch to exit-2 blocking"), but adds escalation state
+  to the hook and is best left to the friction analyser. Note this is a
+  different mechanism from the dedup above: dedup *suppresses* repeat hints
+  to save replay tokens; decay would *escalate* to a hard block. We do the
+  former, not the latter.
 - **Augmenting the security-critical blocks.** They stay exit-2.
   No data benefit, real security cost.
 - **Updating `.claude/rules/bash-tool-replacements.md`.** The rule
@@ -197,7 +231,7 @@ exit-2-blocking to model and reader).
 |---|---|
 | Agent treats the augmented output as adversarial and stops reading tool results | Phase 1 is opt-in; W21 metric catches this |
 | `updatedToolOutput` not yet on the user's Claude Code version (<2.1.121) | Document the version requirement; teach hook degrades to silent passthrough on older versions |
-| Hint adds tokens to every soft-teach call | Tracked in phase 2 metric; ~30 tokens/call is small vs the typical Bash result, but real |
+| Hint replays in the transcript on every matching call for the rest of the session | Session-scoped dedup emits each distinct hint at most once per session (see Implementation notes), capping replayed banner at ~150 tokens/session |
 | The five soft-teach patterns drift between the two hooks | Phase 3 consolidates into a shared matcher; phase 1 documents the duplication |
 
 ## Open questions for review

--- a/hooks-plugin/hooks/bash-antipatterns-teach.sh
+++ b/hooks-plugin/hooks/bash-antipatterns-teach.sh
@@ -45,8 +45,10 @@ if [ -z "$COMMAND" ]; then
 fi
 
 # Compose the hint based on which soft-teach pattern (if any) the command matched.
-# A command can match at most one hint - we pick the most specific.
+# A command can match at most one hint - we pick the most specific. hint_key is a
+# stable identifier for the matched pattern, used below for session-scoped dedup.
 hint=""
+hint_key=""
 
 # cat file (not in pipeline, not heredoc)
 if [ -z "$hint" ] && \
@@ -54,6 +56,7 @@ if [ -z "$hint" ] && \
    ! echo "$COMMAND" | grep -Eq '<<|cat\s*>' && \
    ! echo "$COMMAND" | grep -q '|'; then
     hint="Use the Read tool instead of 'cat' to read files. Read returns line-numbered content and respects token budgets."
+    hint_key="read-cat"
 fi
 
 # head/tail file (not in pipeline)
@@ -61,6 +64,7 @@ if [ -z "$hint" ] && \
    echo "$COMMAND" | grep -Eq '^\s*(head|tail)\s+(-[0-9n]+\s+)?[^|]' && \
    ! echo "$COMMAND" | grep -q '|'; then
     hint="Use the Read tool with offset/limit parameters instead of 'head' or 'tail'. Example: Read with offset=100, limit=50."
+    hint_key="read-headtail"
 fi
 
 # find -name without directory-discovery flags
@@ -68,6 +72,7 @@ if [ -z "$hint" ] && \
    echo "$COMMAND" | grep -Eq '^\s*find\s+' && \
    ! echo "$COMMAND" | grep -Eq 'find\s+.*(-maxdepth|-mindepth|-type\s|-print0)'; then
     hint="Use the Glob tool for filename matching. Example: Glob(pattern=\"**/*.ts\") instead of 'find . -name \"*.ts\"'. Keep 'find' only when you need -maxdepth/-type d/-print0."
+    hint_key="glob-find"
 fi
 
 # grep/rg as standalone search (not piped, not -q)
@@ -76,17 +81,45 @@ if [ -z "$hint" ] && \
    ! echo "$COMMAND" | grep -q '|' && \
    ! echo "$COMMAND" | grep -Eq '(grep|rg)[^|]*\s(-[a-zA-Z]*q[a-zA-Z]*(\s|$)|--quiet(\s|$))'; then
     hint="Use the Grep tool for codebase searches. Example: Grep(pattern=\"foo\", path=\"src\", -n=true). Keep grep/rg for pipelines or boolean -q checks."
+    hint_key="grep"
 fi
 
 # ls with a glob
 if [ -z "$hint" ] && \
    echo "$COMMAND" | grep -Eq '^\s*ls\s+.*\*'; then
     hint="Use the Glob tool for pattern-based file listing - it returns paths sorted by modification time and handles large directories better."
+    hint_key="glob-ls"
 fi
 
 # No soft-teach pattern matched - leave tool output untouched.
 if [ -z "$hint" ]; then
     exit 0
+fi
+
+# Session-scoped dedup: emit each distinct hint at most once per session.
+#
+# updatedToolOutput is replayed on every subsequent turn (it persists in the
+# transcript like any tool result), so an un-capped hint on a high-frequency
+# command (grep, cat) accumulates one replayed copy per matching call for the
+# rest of the session. The lesson is identical each time, so the marginal copies
+# are pure transcript bloat. Teaching once per pattern caps the replay cost at
+# five hint banners for an entire session regardless of call count, while still
+# delivering the correction the first time the agent reaches for the idiom.
+#
+# State lives in a per-session file (sanitised session_id, same convention as
+# git-stash-session-init.sh) and is removed by git-session-cleanup.sh at
+# SessionEnd. When session_id is absent we skip dedup and fall through to the
+# old always-emit behaviour rather than guess at a key.
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' | tr -cd 'a-zA-Z0-9_-')
+if [ -n "$SESSION_ID" ]; then
+    SEEN_DIR="${TMPDIR:-/tmp}/claude-bash-teach-seen"
+    SEEN_FILE="${SEEN_DIR}/${SESSION_ID}"
+    if [ -f "$SEEN_FILE" ] && grep -qxF "$hint_key" "$SEEN_FILE" 2>/dev/null; then
+        # Already taught this lesson this session - leave tool output untouched.
+        exit 0
+    fi
+    mkdir -p "$SEEN_DIR" 2>/dev/null || true
+    echo "$hint_key" >> "$SEEN_FILE" 2>/dev/null || true
 fi
 
 # Build the augmented tool output: original response first, then the hint banner.

--- a/hooks-plugin/hooks/git-session-cleanup.sh
+++ b/hooks-plugin/hooks/git-session-cleanup.sh
@@ -11,6 +11,8 @@ SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
 SESSION_ID=$(echo "$SESSION_ID" | tr -cd 'a-zA-Z0-9_-')
 if [ -n "$SESSION_ID" ]; then
     rm -f "/tmp/claude-stash-baselines/${SESSION_ID}" 2>/dev/null || true
+    # bash-antipatterns-teach.sh dedup state (once-per-session hint tracking)
+    rm -f "${TMPDIR:-/tmp}/claude-bash-teach-seen/${SESSION_ID}" 2>/dev/null || true
 fi
 
 exit 0

--- a/hooks-plugin/hooks/test-bash-antipatterns-teach.sh
+++ b/hooks-plugin/hooks/test-bash-antipatterns-teach.sh
@@ -16,13 +16,21 @@ FAIL=0
 
 # Build a minimal PostToolUse input. tool_response is a stand-in for whatever
 # the harness actually produces; the hook just stringifies it.
+# Optional second arg sets session_id (enables the once-per-session dedup path).
 _payload() {
-    local cmd="$1"
-    jq -nc --arg cmd "$cmd" '{
+    local cmd="$1" session="${2:-}"
+    jq -nc --arg cmd "$cmd" --arg session "$session" '{
         tool_name: "Bash",
         tool_input: {command: $cmd},
         tool_response: "sample stdout output\n"
-    }'
+    } + (if $session == "" then {} else {session_id: $session} end)'
+}
+
+# Run the hook for a command under a given session id; echo non-empty stdout.
+_run_session() {
+    local cmd="$1" session="$2"
+    _payload "$cmd" "$session" \
+        | CLAUDE_HOOKS_ENABLE_BASH_ANTIPATTERNS_TEACH=1 bash "$HOOK" 2>/dev/null || true
 }
 
 # With the env var set, the hook should emit JSON whose
@@ -116,6 +124,62 @@ echo "env-var guard (disabled by default):"
 assert_disabled "cat README.md is silent when env var unset" "cat README.md"
 assert_disabled "grep -rn foo src/ is silent when env var unset" "grep -rn foo src/"
 assert_disabled "find . -name '*.ts' is silent when env var unset" "find . -name '*.ts'"
+
+echo ""
+echo "session-scoped dedup (each hint emits at most once per session):"
+# Use a unique session id so the seen-file starts clean for this test run.
+SID="test-dedup-$$-$RANDOM"
+SEEN_FILE="${TMPDIR:-/tmp}/claude-bash-teach-seen/${SID}"
+rm -f "$SEEN_FILE" 2>/dev/null || true
+
+# First grep under this session emits the hint.
+if [ -n "$(_run_session 'grep -rn foo src/' "$SID")" ]; then
+    printf "  PASS: %s\n" "first grep in session emits hint"
+    PASS=$((PASS + 1))
+else
+    printf "  FAIL: %s\n" "first grep in session should emit hint"
+    FAIL=$((FAIL + 1))
+fi
+
+# Second grep under the same session is silent (already taught).
+if [ -z "$(_run_session 'grep -rn bar lib/' "$SID")" ]; then
+    printf "  PASS: %s\n" "repeat grep in same session is silent"
+    PASS=$((PASS + 1))
+else
+    printf "  FAIL: %s\n" "repeat grep in same session should be silent"
+    FAIL=$((FAIL + 1))
+fi
+
+# A different pattern in the same session still emits (dedup is per-pattern).
+if [ -n "$(_run_session 'cat README.md' "$SID")" ]; then
+    printf "  PASS: %s\n" "different pattern in same session still emits"
+    PASS=$((PASS + 1))
+else
+    printf "  FAIL: %s\n" "different pattern in same session should emit"
+    FAIL=$((FAIL + 1))
+fi
+
+# Same pattern under a fresh session emits again (dedup is per-session).
+SID2="test-dedup-$$-$RANDOM-b"
+rm -f "${TMPDIR:-/tmp}/claude-bash-teach-seen/${SID2}" 2>/dev/null || true
+if [ -n "$(_run_session 'grep -rn foo src/' "$SID2")" ]; then
+    printf "  PASS: %s\n" "same pattern in a new session emits again"
+    PASS=$((PASS + 1))
+else
+    printf "  FAIL: %s\n" "same pattern in a new session should emit again"
+    FAIL=$((FAIL + 1))
+fi
+
+# Without a session_id, dedup is skipped: both calls emit (backward compatible).
+if [ -n "$(_run_session 'grep -rn foo src/' '')" ] && [ -n "$(_run_session 'grep -rn foo src/' '')" ]; then
+    printf "  PASS: %s\n" "no session_id falls through to always-emit"
+    PASS=$((PASS + 1))
+else
+    printf "  FAIL: %s\n" "no session_id should always emit"
+    FAIL=$((FAIL + 1))
+fi
+
+rm -f "$SEEN_FILE" "${TMPDIR:-/tmp}/claude-bash-teach-seen/${SID2}" 2>/dev/null || true
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Context

Acting on external review feedback praising the hooks setup but flagging a real cost axis we hadn't fully accounted for: **anything a hook makes the model *see* is replayed in the transcript on every subsequent turn.** The reviewer specifically called out `bash-antipatterns-teach.sh` — its `updatedToolOutput` hint replays per matching call — and suggested capping or deduping.

This PR adopts the valid core insight and corrects one factual misunderstanding in the same feedback.

## What changed

**1. Session-scoped dedup in `bash-antipatterns-teach.sh`**

The teach hint persists in the transcript like any tool result, so an un-capped hint on a high-frequency command (`grep`, `cat`) accumulated one replayed copy per matching call — identical lesson each time, pure bloat past the first. Each distinct hint (`read-cat`, `read-headtail`, `glob-find`, `grep`, `glob-ls`) now emits at most **once per session** via a sanitised-session-id seen-list under `${TMPDIR:-/tmp}/claude-bash-teach-seen/`, mirroring `git-stash-session-init.sh`. Caps replayed banner at ~150 tokens/session regardless of call count.

- `git-session-cleanup.sh` removes the seen-list at `SessionEnd`.
- When `session_id` is absent, the hook falls through to the old always-emit behaviour — backward compatible, existing no-session tests still pass.

**2. Codified the transcript-replay-cost axis** in `.claude/rules/hooks-reference.md` (new "Transcript Replay Cost" section), including a corrected note on `Stop` semantics — see below.

**3. Updated `teach-mode-experiment.md`** cost accounting and risk table to reflect replay cost (not one-time ~30 tokens) and the dedup mitigation.

## Refuting the misunderstanding

The feedback states *"Stop output never reaches the model."* That is not accurate. A blocking `Stop` hook's `reason` **is** shown to the model — that is precisely how it nudges the agent to keep working, and `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` (2.1.143+) exists *because* the model re-reads that reason. What makes our `Stop` checks (`task-completeness.sh`, `git-stash-reminder.sh`) cheap is **frequency + conditionality + self-extinction**, not invisibility:
- fire at most once per stop attempt, not per tool call;
- silent (exit 0) unless there is a concrete finding;
- self-extinguishing — once the agent fixes the finding, the next stop passes clean.

The practical upshot matters: "move chatty checks to Stop because Stop is free" would mislead — a verbose Stop hook that blocks on every stop is both costly and can burn the 8-block cap.

## Testing

- `test-bash-antipatterns-teach.sh`: **22 passed** (5 new dedup-path tests: first-emit / repeat-silent / different-pattern-still-emits / new-session-re-emits / no-session-fallthrough)
- `test-bash-antipatterns.sh`: 36 passed · `test-task-completeness.sh`: 27 passed
- `scripts/lint-shell-scripts.sh`: 0 errors, 0 warnings

https://claude.ai/code/session_01P2FJF1euBcG4w5apvve9n9

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2FJF1euBcG4w5apvve9n9)_