### PR TITLE
docs(configure-plugin): point pal MCP example at laurigates fork via uv tool

### DIFF
--- a/configure-plugin/skills/configure-mcp/REFERENCE.md
+++ b/configure-plugin/skills/configure-mcp/REFERENCE.md
@@ -7,12 +7,7 @@ Use these JSON configurations when adding servers to `.mcp.json`:
 ```json
 {
   "pal": {
-    "command": "uvx",
-    "args": [
-      "--from",
-      "git+https://github.com/BeehiveInnovations/pal-mcp-server.git",
-      "pal-mcp-server"
-    ]
+    "command": "pal-mcp-server"
   },
   "playwright": {
     "command": "bunx",
@@ -77,7 +72,7 @@ Use `${VAR_NAME}` references in `.mcp.json` — never hardcode tokens.
 - `github` - GitHub API integration (requires `GITHUB_TOKEN`)
 
 **Productivity:**
-- `pal` - PAL (Provider Abstraction Layer) - Multi-provider LLM integration (no env vars)
+- `pal` - PAL (Provider Abstraction Layer) - Multi-provider LLM integration (no env vars). Install once with `uv tool install git+https://github.com/laurigates/pal-mcp-server`; the `.mcp.json` entry then invokes the bare `pal-mcp-server` command instead of re-resolving the git source via `uvx` on every launch.
 
 **Infrastructure & Monitoring:**
 - `argocd-mcp` - ArgoCD GitOps deployment management (requires `ARGOCD_SERVER`, `ARGOCD_AUTH_TOKEN`)


### PR DESCRIPTION
## What
Update the `configure-mcp` skill's REFERENCE example for the `pal` server: switch from `uvx --from git+https://github.com/BeehiveInnovations/pal-mcp-server.git` to the bare installed `pal-mcp-server` command (laurigates fork), and document the `uv tool install` prerequisite in the server registry.

## Why
The `uvx --from git+...` form re-resolves the git source on every MCP launch, generating a process-spawn storm. Installing the fork once and invoking the bare command eliminates the per-launch git churn and picks up the fork's improvements. This brings the canonical example in line with the configuration now used across the dotfiles registry and project `.mcp.json` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)