### PR TITLE
feat(macos-plugin): add endpoint-security-cpu skill

### DIFF
--- a/macos-plugin/.claude-plugin/plugin.json
+++ b/macos-plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "macos-plugin",
   "version": "1.1.2",
-  "description": "macOS-specific dev environment tooling — kitty session persistence, LaunchServices health, incident postmortems for kernel panics, WindowServer hangs, and long-uptime drift",
+  "description": "macOS-specific dev environment tooling — kitty session persistence, LaunchServices health, incident postmortems for kernel panics and WindowServer hangs, EndpointSecurity/EDR CPU diagnosis, and long-uptime drift",
   "author": {
     "name": "Lauri Gates",
     "url": "https://github.com/laurigates"
@@ -27,6 +27,15 @@
     "jetsam",
     "incident-postmortem",
     "uptime",
-    "kern-boottime"
+    "kern-boottime",
+    "endpoint-security",
+    "eslogger",
+    "powermetrics",
+    "kandji",
+    "xprotect",
+    "edr",
+    "exec-storm",
+    "battery-drain",
+    "systemextensionsctl"
   ]
 }

--- a/macos-plugin/README.md
+++ b/macos-plugin/README.md
@@ -11,6 +11,7 @@ All skills are **Darwin-only** — they detect non-macOS systems and refuse to a
 | [kitty-session-persistence](skills/kitty-session-persistence/skill.md) | Snapshot and restore kitty terminal sessions across crashes and reboots via `kitten @ ls` and a LaunchAgent |
 | [launchservices-health](skills/launchservices-health/skill.md) | Quantify the LaunchServices DB, `launchservicesd` RSS/uptime, and surface the safe rebuild command |
 | [macos-incident-postmortem](skills/macos-incident-postmortem/skill.md) | Reconstruct what happened from `/Library/Logs/DiagnosticReports/`, `kern.boottime`, and shell history after a hang or panic |
+| [endpoint-security-cpu](skills/endpoint-security-cpu/skill.md) | Diagnose an EndpointSecurity/EDR extension (Kandji ESF, XProtect) hot from a process-spawn storm; trace the source with `powermetrics` + `eslogger` |
 
 ## When to Use
 
@@ -20,6 +21,8 @@ All skills are **Darwin-only** — they detect non-macOS systems and refuse to a
 | `launchservicesd` is pegged at high CPU; LS DB feels bloated | `launchservices-health` |
 | GUI froze and you're not sure if the machine actually rebooted | `macos-incident-postmortem` |
 | Investigating recent kernel panics, watchdog timeouts, jetsam events | `macos-incident-postmortem` |
+| A security extension (Kandji ESF, XProtect, an EDR) is pegged at high CPU; battery drains | `endpoint-security-cpu` |
+| `syspolicyd`/`trustd`/`tccd`/`auditd` are all elevated together — an exec storm | `endpoint-security-cpu` |
 | Auditing whether the machine is "due for a reboot" after weeks of uptime | `macos-incident-postmortem` + `launchservices-health` |
 
 ## Scope

--- a/macos-plugin/skills/endpoint-security-cpu/SKILL.md
+++ b/macos-plugin/skills/endpoint-security-cpu/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: endpoint-security-cpu
+description: macOS EndpointSecurity/EDR high CPU & battery drain. Use when Kandji ESF / XProtect pegs a core; trace the exec storm via powermetrics + eslogger.
+user-invocable: false
+allowed-tools: Bash(uname *), Bash(ps *), Bash(pgrep *), Bash(uptime *), Bash(systemextensionsctl list*), Bash(sudo powermetrics *), Bash(sudo eslogger *), Bash(sudo killall *), Read, Grep, Glob
+created: 2026-06-03
+modified: 2026-06-03
+reviewed: 2026-06-03
+---
+
+# EndpointSecurity / EDR CPU (macOS)
+
+## When to Use This Skill
+
+| Use this skill when... | Use something else when... |
+|------------------------|----------------------------|
+| A security extension (Kandji ESF, XProtect, an EDR) sits at sustained high CPU | `launchservicesd` is the hot process — use `launchservices-health` |
+| Battery drains fast and `powermetrics` blames the security stack | The machine actually hung or panicked — use `macos-incident-postmortem` |
+| `syspolicyd`/`trustd`/`tccd`/`auditd` are *all* elevated together | One ordinary app is hot — use `ps`/`top` directly |
+| You suspect a process-spawn (exec) storm is taxing the system | Auditing kernel-extension *inventory* — `systemextensionsctl list` alone |
+
+## Platform Guard
+
+**macOS-only.** EndpointSecurity, `eslogger` (macOS 13+), `powermetrics`, and `systemextensionsctl` are Darwin-specific.
+
+```bash
+test "$(uname -s)" = "Darwin" || { echo "macos-plugin: not Darwin, refusing"; exit 1; }
+```
+
+## Core Insight: the EDR is usually a symptom, not the disease
+
+An EndpointSecurity (ES) client — Kandji's ESF extension, XProtect's behavioral service, a corporate EDR — subscribes to the kernel's `exec`/`open`/`rename` event stream. Its CPU is **proportional to the system-wide rate of those events**. When something spawns hundreds of short-lived processes per second, *every* behavioral/security monitor must inspect each one, so they light up **together**:
+
+```
+XprotectService      behavioral malware scan, per exec
+syspolicyd           Gatekeeper code-signing assessment, per binary
+io.kandji…ESF        corporate EDR, per exec/open
+trustd / tccd        cert eval / privacy, per access
+auditd               audit record, per event
+kernel_task          servicing the syscall + interrupt load
+```
+
+That column lighting up at once is the signature: **one exec storm, taxing the whole stack.** Restarting the EDR clears its queue for a few seconds, then the storm refills it. The fix is upstream — find and stop whatever is spawning the processes.
+
+A hot ES extension with **near-zero wakeups** confirms this: it is draining a real inbound event queue in user space, not timer-spinning. High CPU *with* a high wakeup count and a quiet `eslogger` points instead at an internally wedged extension — the one case where restarting it (below) actually helps.
+
+## Diagnose
+
+Both probes need root. If `sudo` isn't cached, hand them to the user with the `!` prefix.
+
+**1. Per-process energy + wakeups — who is taxed, and is it spawn churn?**
+
+```bash
+sudo powermetrics --samplers tasks --show-process-energy -n 1 | head -45
+```
+
+Read three things:
+- **`DEAD_TASKS`** high (CPU + deadlines + wakeups) = a storm of processes that spawned and exited *within the sample* — the exec churn made visible.
+- The **security-stack cluster** (XprotectService, syspolicyd, the ESF extension, trustd, tccd, auditd) all elevated together = the one-storm-taxes-all signature.
+- The **Wakeups** column. Energy Impact *understates* VMs and wakeup-heavy tasks; a process with a huge wakeup count (e.g. a container VM) keeps the CPU package out of deep idle — the real battery cost on an otherwise "low energy" line.
+
+**2. The EndpointSecurity firehose — name the generator.**
+
+`eslogger` subscribes to the *same* stream the EDR consumes, and reports the initiating process. Rank the offenders over a short sample:
+
+```bash
+sudo eslogger exec 2>/dev/null | head -400 | jq -r '.process.executable.path' | sort | uniq -c | sort -rn | head -15
+```
+
+Whatever path dominates is the storm's source. If the stream scrolls instantly to 400 lines, the event rate itself is the problem. If it only trickles while the ESF stays hot, the extension is wedged internally — restart it.
+
+## Common exec-storm generators
+
+Recurring sources, with the upstream fix that removes the load (not the symptom):
+
+| Generator (fingerprint in `eslogger`) | Fix |
+|---|---|
+| `uvx --from git+https://…` MCP / tools re-resolving the git source on every launch | Install once (`uv tool install git+…`) and invoke the bare command |
+| `brew` invoked in a loop (`portable-ruby` + Homebrew `bash` + `git`) — often a menubar "outdated" poller or per-invocation auto-update | `export HOMEBREW_NO_AUTO_UPDATE=1`; throttle/remove the caller |
+| Many concurrent dev/AI sessions spawning short-lived `git`/`node`/`bun`/`gh` | Collapse duplicate sessions; dedupe per-session helper servers |
+| A status tool shelling out on a tight timer | Lengthen its interval or cache its result |
+
+## No-reboot levers
+
+macOS rewards not rebooting — both the EDR and the inventory are inspectable and (mostly) restartable live.
+
+- **Restart a wedged ES extension** (only if `eslogger` trickled while it stayed hot): `sudo killall -9 <ESF-process-name>`. `sysextd` relaunches the `[activated enabled]` extension within seconds. No reboot, no logout.
+- **Inventory + stale-version backlog:** `systemextensionsctl list`. Over long uptime, each EDR update leaves the prior version as `[terminated waiting to uninstall on reboot]`. Those are **terminated — zero CPU** — pure disk/registry cruft that only a reboot clears, and **never** the performance problem. Don't reboot *for them*.
+- **Managed Macs:** Kandji/JAMF EDR extensions can't be removed on a managed device. If the extension stays hot after the generators are gone *and* a reboot, escalate to IT — a persistently-hot EDR is a known agent failure mode they fix centrally.
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| ESF extension CPU now | `ps -Ao pcpu,comm \| grep -i ESF-Extension` |
+| Storm source (top initiators) | `sudo eslogger exec 2>/dev/null \| head -400 \| jq -r '.process.executable.path' \| sort \| uniq -c \| sort -rn \| head` |
+| Security-stack energy snapshot | `sudo powermetrics --samplers tasks --show-process-energy -n 1 \| head -45` |
+| Stale sysext versions (reboot-gated cruft) | `systemextensionsctl list \| grep -c 'waiting to uninstall'` |
+| Restart wedged ESF (sysextd relaunches) | `sudo killall -9 <esf-process-name>` |
+
+## Quick Reference
+
+| Tool | Role | Root? |
+|------|------|-------|
+| `powermetrics --samplers tasks` | Per-process energy, wakeups, `DEAD_TASKS` churn | yes |
+| `eslogger exec open rename` | The ES event stream the EDR consumes; names the initiator | yes (macOS 13+) |
+| `systemextensionsctl list` | Extension inventory + reboot-gated stale versions | no |
+| `ps -Ao pcpu,comm` | Instantaneous CPU per process | no |
+
+## Related Skills
+
+- `launchservices-health` — when `launchservicesd` (not an ES extension) is the hot process
+- `macos-incident-postmortem` — when the load caused an actual hang/panic; reconstruct from DiagnosticReports


### PR DESCRIPTION
## What
A new macOS skill, `endpoint-security-cpu`, for diagnosing an EndpointSecurity/EDR extension (Kandji ESF, XProtect) pegged at high CPU.

## Why
The non-obvious insight, learned the hard way: a hot security extension is usually a **symptom**. It subscribes to the kernel's exec/open event stream, so a process-spawn storm makes it — and `syspolicyd`, `trustd`, `tccd`, `auditd`, XProtect — all light up **together**. Restarting the EDR clears its queue for seconds; the fix is upstream. The skill captures the `powermetrics` + `eslogger` flow to name the generator (commonly `uvx --from git+…` tools re-resolving per launch, brew autoupdate loops, or many concurrent dev sessions) and the macOS no-reboot levers.

## Distinct from existing skills
- `launchservices-health` — `launchservicesd` / LS-DB, not an ES extension
- `macos-incident-postmortem` — panics/reboots from DiagnosticReports

## Files
- `macos-plugin/skills/endpoint-security-cpu/SKILL.md` (new)
- `macos-plugin/README.md` — skills + when-to-use tables
- `macos-plugin/.claude-plugin/plugin.json` — keywords + description

🤖 Generated with [Claude Code](https://claude.com/claude-code)