### PR TITLE
refactor(configure-plugin): standardize configure-formatting on Biome, drop Prettier

### DIFF
--- a/configure-plugin/skills/configure-formatting/REFERENCE.md
+++ b/configure-plugin/skills/configure-formatting/REFERENCE.md
@@ -2,7 +2,7 @@
 
 Configuration templates, migration guides, and pre-commit configurations for code formatters.
 
-## Biome Configuration (Recommended for JS/TS)
+## Biome Configuration (JS/TS/JSON/CSS — the Prettier + ESLint replacement)
 
 ### Install
 
@@ -63,61 +63,6 @@ bun add --dev @biomejs/biome
     "format": "biome format --write .",
     "format:check": "biome format .",
     "lint:format": "biome check --write ."
-  }
-}
-```
-
-## Prettier Configuration (Alternative for JS/TS)
-
-### Install
-
-```bash
-npm install --save-dev prettier
-# or
-bun add --dev prettier
-```
-
-### `.prettierrc.json`
-
-```json
-{
-  "printWidth": 100,
-  "tabWidth": 2,
-  "useTabs": false,
-  "semi": true,
-  "singleQuote": true,
-  "quoteProps": "as-needed",
-  "jsxSingleQuote": false,
-  "trailingComma": "all",
-  "bracketSpacing": true,
-  "bracketSameLine": false,
-  "arrowParens": "always",
-  "endOfLine": "lf",
-  "embeddedLanguageFormatting": "auto"
-}
-```
-
-### `.prettierignore`
-
-```
-node_modules
-dist
-build
-.next
-coverage
-*.min.js
-*.min.css
-package-lock.json
-pnpm-lock.yaml
-```
-
-### package.json Scripts
-
-```json
-{
-  "scripts": {
-    "format": "prettier --write .",
-    "format:check": "prettier --check ."
   }
 }
 ```
@@ -295,21 +240,10 @@ uv remove black
 ```yaml
 repos:
   - repo: https://github.com/biomejs/pre-commit
-    rev: v0.4.0
+    rev: v2.4.16
     hooks:
       - id: biome-check
-        additional_dependencies: ["@biomejs/biome@1.9.4"]
-```
-
-### Prettier
-
-```yaml
-repos:
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
-    hooks:
-      - id: prettier
-        types_or: [javascript, jsx, ts, tsx, json, yaml, markdown]
+        additional_dependencies: ["@biomejs/biome@2.4.16"]
 ```
 
 ### Ruff Format
@@ -317,7 +251,7 @@ repos:
 ```yaml
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.4
+    rev: v0.15.15
     hooks:
       - id: ruff-format
 ```
@@ -339,13 +273,6 @@ repos:
 ```yaml
 - name: Check formatting
   run: npx @biomejs/biome format .
-```
-
-### GitHub Actions - Prettier
-
-```yaml
-- name: Check formatting
-  run: npm run format:check
 ```
 
 ### GitHub Actions - Ruff

--- a/configure-plugin/skills/configure-formatting/SKILL.md
+++ b/configure-plugin/skills/configure-formatting/SKILL.md
@@ -1,11 +1,11 @@
 ---
 created: 2025-12-16
-modified: 2026-04-19
-reviewed: 2025-12-16
-description: "Code formatters: Biome, Prettier, Ruff, rustfmt. Use when setting up formatting, migrating Prettier to Biome, or wiring CI format checks."
+modified: 2026-06-03
+reviewed: 2026-06-03
+description: "Biome formatter for JS/TS/JSON/CSS — the modern Prettier/ESLint replacement. Also Ruff (Python) and rustfmt. Use when setting up formatting, replacing Prettier, or wiring CI format checks."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
-args: "[--check-only] [--fix] [--formatter <biome|prettier|ruff|rustfmt>]"
-argument-hint: "[--check-only] [--fix] [--formatter <biome|prettier|ruff|rustfmt>]"
+args: "[--check-only] [--fix] [--formatter <biome|ruff|rustfmt>]"
+argument-hint: "[--check-only] [--fix] [--formatter <biome|ruff|rustfmt>]"
 name: configure-formatting
 ---
 
@@ -17,8 +17,8 @@ Check and configure code formatting tools against modern best practices.
 
 | Use this skill when... | Use another approach when... |
 |------------------------|------------------------------|
-| Setting up Biome, Prettier, Ruff format, or rustfmt for a project | Running an existing formatter (`biome format`, `ruff format`) |
-| Migrating from Prettier to Biome or Black to Ruff | Fixing individual formatting issues in specific files |
+| Setting up Biome, Ruff format, or rustfmt for a project | Running an existing formatter (`biome format`, `ruff format`) |
+| Migrating from Prettier or ESLint to Biome, or Black to Ruff | Fixing individual formatting issues in specific files |
 | Auditing formatter configuration for completeness and best practices | Configuring linting rules (`/configure:linting` instead) |
 | Adding format-on-save and CI format checks | Setting up pre-commit hooks only (`/configure:pre-commit` instead) |
 | Standardizing formatting settings across a monorepo | Editing `.editorconfig` or `.vscode/settings.json` manually |
@@ -43,16 +43,15 @@ Parse from `$ARGUMENTS`:
 
 - `--check-only`: Report compliance status without modifications
 - `--fix`: Apply all fixes automatically without prompting
-- `--formatter <formatter>`: Override formatter detection (biome, prettier, ruff, rustfmt)
+- `--formatter <formatter>`: Override formatter detection (biome, ruff, rustfmt)
 
 ## Version Checking
 
 **CRITICAL**: Before flagging outdated formatters, verify latest releases using WebSearch or WebFetch:
 
 1. **Biome**: Check [biomejs.dev](https://biomejs.dev/) or [GitHub releases](https://github.com/biomejs/biome/releases)
-2. **Prettier**: Check [prettier.io](https://prettier.io/) or [npm](https://www.npmjs.com/package/prettier)
-3. **Ruff**: Check [docs.astral.sh/ruff](https://docs.astral.sh/ruff/) or [GitHub releases](https://github.com/astral-sh/ruff/releases)
-4. **rustfmt**: Bundled with Rust toolchain - check [Rust releases](https://releases.rs/)
+2. **Ruff**: Check [docs.astral.sh/ruff](https://docs.astral.sh/ruff/) or [GitHub releases](https://github.com/astral-sh/ruff/releases)
+3. **rustfmt**: Bundled with Rust toolchain - check [Rust releases](https://releases.rs/)
 
 ## Execution
 
@@ -65,13 +64,13 @@ Check for language indicators and formatter configurations:
 | Indicator | Language | Detected Formatter |
 |-----------|----------|-------------------|
 | `biome.json` with formatter | JavaScript/TypeScript | Biome |
-| `.prettierrc.*` | JavaScript/TypeScript | Prettier |
+| `.prettierrc.*` | JavaScript/TypeScript | Prettier (legacy → migrate to Biome) |
 | `pyproject.toml` [tool.ruff.format] | Python | Ruff |
 | `pyproject.toml` [tool.black] | Python | Black (legacy) |
 | `rustfmt.toml` or `.rustfmt.toml` | Rust | rustfmt |
 
 **Modern formatting preferences:**
-- **JavaScript/TypeScript**: Biome (preferred) or Prettier
+- **JavaScript/TypeScript**: Biome (replaces Prettier + ESLint). If Prettier is detected, offer migration to Biome — do not configure Prettier as the target formatter.
 - **Python**: Ruff format (replaces Black)
 - **Rust**: rustfmt (standard)
 
@@ -111,9 +110,9 @@ If `--check-only`, stop here.
 Based on detected language and formatter preference, install and configure. Use configuration templates from [REFERENCE.md](REFERENCE.md).
 
 1. Install formatter package
-2. Create configuration file (biome.json, .prettierrc.json, pyproject.toml section, rustfmt.toml)
+2. Create configuration file (biome.json, pyproject.toml section, rustfmt.toml)
 3. Add format scripts to package.json or Makefile/justfile
-4. Create ignore file if needed (.prettierignore)
+4. Configure ignore patterns in the formatter config (e.g. `files.includes` in biome.json)
 
 ### Step 5: Create EditorConfig integration
 
@@ -149,7 +148,7 @@ Update `.project-standards.yaml`:
 ```yaml
 components:
   formatting: "2025.1"
-  formatting_tool: "[biome|prettier|ruff|rustfmt]"
+  formatting_tool: "[biome|ruff|rustfmt]"
   formatting_pre_commit: true
   formatting_ci: true
 ```
@@ -167,7 +166,6 @@ For detailed configuration templates, migration guides, and pre-commit configura
 | Quick compliance check | `/configure:formatting --check-only` |
 | Auto-fix all issues | `/configure:formatting --fix` |
 | Check Biome formatting | `biome format --check --reporter=github` |
-| Check Prettier formatting | `npx prettier --check . 2>&1 | tail -5` |
 | Check Ruff formatting | `ruff format --check --output-format=github` |
 | Check rustfmt formatting | `cargo fmt --check 2>&1 | head -20` |
 
@@ -177,7 +175,7 @@ For detailed configuration templates, migration guides, and pre-commit configura
 |------|-------------|
 | `--check-only` | Report status without offering fixes |
 | `--fix` | Apply all fixes automatically without prompting |
-| `--formatter <formatter>` | Override formatter detection (biome, prettier, ruff, rustfmt) |
+| `--formatter <formatter>` | Override formatter detection (biome, ruff, rustfmt) |
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Standardizes the `configure-formatting` skill on **Biome** and removes Prettier as a setup option. Split out of #1476 (which deferred a "what to do about the archived `pre-commit/mirrors-prettier` mirror" follow-up) so the changelog records it as a `refactor`, not a version-pin refresh.

## Why

A survey of the `laurigates` + `ForumViriumHelsinki` portfolios:

| Formatter (in pre-commit) | Projects | Notes |
|---|---|---|
| **Biome** | 13 | The de-facto JS/TS formatter — `scansift` labels it "FVH Standards v2025.1 - Frontend (Biome)" |
| **Prettier** (`pre-commit/mirrors-prettier`, **archived**) | 3 | All not-yet-migrated frontends; one (`R4C-Cesium-Viewer`) runs **both** mid-migration |
| dprint / mdformat / yamlfmt | 0 | Unused |

Biome also fully supersedes Prettier for code formatting (JS/TS/JSX/TSX/JSON/JSONC/CSS/GraphQL/HTML, per [Biome's language support](https://biomejs.dev/internals/language-support/)). It still can't format Markdown (unsupported) or YAML (in progress) — but no project here formats those anyway, so there's nothing to cover.

## What changed

**`REFERENCE.md`**
- Remove the Prettier config block, the Prettier pre-commit hook (was the archived `pre-commit/mirrors-prettier@v4.0.0-alpha.8`), and the Prettier CI step.
- Keep the **"Prettier → Biome" migration guide**; reframe the Biome heading as "the Prettier + ESLint replacement".

**`SKILL.md`**
- Drop `prettier` from `--formatter` / args / flags / standards-tool enum and the version-check + agentic tables.
- Keep Prettier **detection** so an existing Prettier setup is recognised and routed to a Biome migration ("do not configure Prettier as the target formatter").
- Reword the `description` so the skill still fires on "prettier" intent but answers with Biome.
- Refresh `modified`/`reviewed` to 2026-06-03.

Net **−95 / +20** lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
