### PR TITLE
fix: resolve actionable open issues (#1424, #1425, #1463)

### DIFF
--- a/agent-patterns-plugin/skills/parallel-agent-dispatch/REFERENCE.md
+++ b/agent-patterns-plugin/skills/parallel-agent-dispatch/REFERENCE.md
@@ -176,14 +176,28 @@ than waiting for it to fail on its own. The key affordance is that
 change survives the kill — so the orchestrator can recover the work
 instead of re-implementing from scratch.
 
-**When to kill early.** An agent that is hook-thrashing emits a visible
-signature well before it gives up: a Bash-heavy tool mix with very few
-Edits and a rising rate of `is_error: true` results (typically
-`PreToolUse` hook blocks). Killing at that point and salvaging the
-worktree is cheaper than letting it run another 80–200 tool calls to a
-silent failure. (The leading-indicator heuristic itself is tracked
-separately in issue
-[#1424](https://github.com/laurigates/claude-plugins/issues/1424).)
+**When to kill early.** A hook-thrashing agent emits a quantifiable
+signature well before it gives up. Use these thresholds to intervene
+programmatically — don't wait for the silent failure 80–200 tool calls
+later:
+
+| Signal | Thrashing threshold | Meaning |
+|--------|--------------------|---------| 
+| **Bash:Edit ratio** | ≥ 9:1 (≥ ~90% Bash calls relative to Edit calls) | Agent is retrying blocked commands instead of making file progress |
+| **`is_error: true` rate on Bash calls** | Rising (≥ 3 consecutive `PreToolUse` blocks, or ≥ 30% of recent Bash calls) | Hook is repeatedly denying the same class of command |
+| **Combined signal** | Both thresholds met simultaneously | Strong indicator — kill and salvage now |
+
+The ratio threshold alone is not sufficient (a read-heavy research
+phase is legitimately Bash-heavy). The rising `is_error` rate on Bash
+calls is the key discriminator: it shows the agent is blocked, not just
+exploring. When both thresholds fire together, the agent is
+hook-thrashing and `TaskStop` is the right call.
+
+Killing at that point and salvaging the worktree is cheaper than
+waiting. Cross-reference the concurrency-cap and wave-splitting guidance
+in `SKILL.md § Concurrent rate-limit risk` — a Bash:Edit ratio spike
+during a rate-limit storm can mimic hook-thrashing; check `is_error`
+content for `Rate limited` vs `hook` keywords before killing.
 
 **Recovery checklist** — from the parent, after `TaskStop`:
 

--- a/agent-patterns-plugin/skills/parallel-agent-dispatch/SKILL.md
+++ b/agent-patterns-plugin/skills/parallel-agent-dispatch/SKILL.md
@@ -5,8 +5,8 @@ user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 model: opus
 created: 2026-04-21
-modified: 2026-06-01
-reviewed: 2026-06-01
+modified: 2026-06-04
+reviewed: 2026-06-04
 ---
 
 # Parallel Agent Dispatch
@@ -354,10 +354,13 @@ for symptoms, the four-step salvage routine, and prevention briefs.
 `TaskStop` does **not** discard the agent's work — its worktree stays on
 disk with every uncommitted change intact. This makes `TaskStop` a
 **recovery affordance**, not a last resort: when an agent is stuck or
-thrashing (e.g. repeatedly hitting a `PreToolUse` hook with a rising
-`is_error` rate and few Edits), killing it early and salvaging the
-worktree beats waiting for it to give up silently 80–200 tool calls
-later.
+thrashing — Bash:Edit ratio ≥ 9:1 **and** a rising `is_error` rate on
+those Bash calls, typically `PreToolUse` hook blocks — killing it early
+and salvaging the worktree beats waiting for it to give up silently
+80–200 tool calls later. See
+[REFERENCE.md → When to kill early](REFERENCE.md#killed-agent-worktree-recovery-taskstop)
+for the full quantitative thresholds and the rate-limit vs hook-block
+discriminator.
 
 After `TaskStop`, decide **salvage vs restart** from the worktree state:
 

--- a/feedback-plugin/skills/feedback-session/SKILL.md
+++ b/feedback-plugin/skills/feedback-session/SKILL.md
@@ -7,8 +7,8 @@ model: opus
 argument-hint: "--dry-run | --target-repo owner/repo | plugin-name"
 disable-model-invocation: true
 created: 2026-02-18
-modified: 2026-05-22
-reviewed: 2026-05-14
+modified: 2026-06-04
+reviewed: 2026-06-04
 ---
 
 # /feedback:session
@@ -32,7 +32,7 @@ Analyze the current session for skill feedback and create GitHub issues to track
 
 **Default target repo**: By default, this skill files issues against the repository in the current working directory. If you are giving feedback about a plugin skill itself rather than the application code in the session, use `--target-repo <owner/repo>` to point at the plugin source repo.
 
-**No-remote auto-suggest**: When the cwd has no git remote and `--target-repo` is not provided, this skill scans the session for plugin-skill references (e.g. `blueprint-plugin:blueprint-init`) and auto-suggests the dominant `<owner>/<repo>` from the plugin cache as the default — typically `laurigates/claude-plugins` for marketplace users. The user can accept the suggestion or override with a different `owner/repo`. See Step 1a.
+**Dominant-source mismatch**: When the cwd has a git remote but the session's tool calls were dominated by a *different* plugin/source repo, this skill detects the mismatch and asks you to confirm which repo to file against — the cwd repo or the plugin source. See Step 1a for the full four-combination decision table.
 
 ## Context
 
@@ -42,8 +42,9 @@ stderr when invoked outside a git repository — and stderr from a Context
 backtick aborts the skill before its body runs. `2>/dev/null` and `||` are
 also blocked in Context commands (see `.claude/rules/agentic-permissions.md`),
 so there is no fallback form that survives the no-git case. Step 1a's
-dominant-source auto-suggest fallback is the canonical handler for the
-no-remote scenario.
+dominant-source scan runs for both the cwd-with-remote and the no-remote
+cases, and surfaces a mismatch-confirmation prompt when the session's plugin
+activity points to a different repo than the cwd remote.
 
 Open feedback issues are fetched during Step 3 (deduplication), scoped to the
 resolved `$TARGET_REPO`. They are not pre-fetched in context because
@@ -74,28 +75,60 @@ Execute this session feedback workflow:
 
 **1a. Determine target repo**
 
+Use this four-combination decision table to resolve `$TARGET_REPO`:
+
+| `--target-repo` set? | cwd has remote? | Dominant source found? | Action |
+|----------------------|-----------------|------------------------|--------|
+| Yes | any | any | Use `--target-repo` value. Done. |
+| No | No | Yes (≥70%, ≥3 refs) | Prompt: accept dominant source or enter free-text. |
+| No | No | No | Prompt: free-text entry or abort. |
+| No | Yes | Agrees with cwd remote | Use cwd remote silently. |
+| No | Yes | Differs from cwd remote | Prompt: offer dominant source AND cwd remote as named choices. |
+
+Execute the steps below to implement this table.
+
+**Step A: Check for explicit `--target-repo` / `-R`.**
+
 If `--target-repo` or `-R` was passed in `$ARGUMENTS`, set `$TARGET_REPO` to that value and append `-R $TARGET_REPO` to every `gh` command in the remaining steps. Skip the rest of this sub-step.
 
-Otherwise, infer the repo from the cwd: `gh repo view --json nameWithOwner -q '.nameWithOwner'`. If this succeeds, use the returned `owner/repo` as the implicit target (no `-R` flag needed since `gh` defaults to cwd) and continue to Step 1b.
+**Step B: Run the dominant-source scan (always).**
 
-If `gh repo view` fails (typically with `no git remotes found` in a repo without a remote), execute this fallback in order:
+Walk the conversation transcript and tool-call history collecting every reference of the form `<plugin>:<skill>` (skill invocations like `/blueprint:init`, agent IDs like `agents-plugin:security-audit`, and plugin names mentioned in skill bodies). For each match, look up the owning `<owner>/<repo>` by enumerating directories under `~/.claude/plugins/cache/<owner>/<repo>/` and matching `<plugin>` against the cached plugin manifests. Tally references per `<owner>/<repo>`.
 
-1. **Scan the session for plugin-skill references.** Walk the conversation transcript and tool-call history collecting every reference of the form `<plugin>:<skill>` (skill invocations like `/blueprint:init`, agent IDs like `agents-plugin:security-audit`, and plugin names mentioned in skill bodies). For each match, look up the owning `<owner>/<repo>` by enumerating directories under `~/.claude/plugins/cache/<owner>/<repo>/` and matching `<plugin>` against the cached plugin manifests. Tally references per `<owner>/<repo>`.
+Compute the share per entry. If the top entry accounts for **more than ~70%** of total references **and** there are at least 3 references in total, treat it as dominant: record `$SUGGESTED_REPO` and `$N`.
 
-2. **Detect a dominant source.** Compute the share of references attributable to each `<owner>/<repo>`. If the top entry accounts for **more than ~70%** of total references **and** there are at least 3 references in total, treat it as dominant. Record the dominant `$SUGGESTED_REPO`, the reference count `$N`, and proceed to step 3. Otherwise, jump to step 4.
+**Step C: Attempt cwd remote detection.**
 
-3. **Prompt with the suggestion as the default.** Use AskUserQuestion to ask:
+Run `gh repo view --json nameWithOwner -q '.nameWithOwner'`. If it succeeds, record the result as `$CWD_REPO`.
 
-   > **No git remote found.** Suggested target: `$SUGGESTED_REPO` (derived from $N plugin skills referenced this session). Accept, or enter a different `owner/repo`?
+**Step D: Branch on the combination.**
 
-   Provide options:
-   1. **Accept `$SUGGESTED_REPO`** — set `$TARGET_REPO` to the suggestion and append `-R $TARGET_REPO` to every `gh` command in the remaining steps.
-   2. **Enter a different `owner/repo`** — open a free-text follow-up; validate the input matches `^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$` and set `$TARGET_REPO` accordingly.
-   3. **Abort** — exit the skill.
+- **No `$CWD_REPO` and no dominant source** — Use AskUserQuestion to ask the user to enter an `owner/repo` free-text. Validate against `^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`, set `$TARGET_REPO`, and continue to Step 1b. If the user declines, exit the skill.
 
-   Continue to Step 1b once `$TARGET_REPO` is set.
+- **No `$CWD_REPO` and dominant source found** — Use AskUserQuestion to ask:
 
-4. **Fall back to free-text prompt (no dominant source detected).** Use AskUserQuestion to ask the user to enter an `owner/repo`. Validate the input matches `^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`, set `$TARGET_REPO`, and continue to Step 1b. If the user declines to provide a target, exit the skill.
+  > **No git remote found.** Suggested target: `$SUGGESTED_REPO` (derived from $N plugin skills referenced this session). Accept, or enter a different `owner/repo`?
+
+  Options:
+  1. **Accept `$SUGGESTED_REPO`** — set `$TARGET_REPO` to the suggestion and append `-R $TARGET_REPO` to every remaining `gh` command.
+  2. **Enter a different `owner/repo`** — free-text follow-up; validate and set `$TARGET_REPO`.
+  3. **Abort** — exit the skill.
+
+  Continue to Step 1b once `$TARGET_REPO` is set.
+
+- **`$CWD_REPO` present, no dominant source OR dominant source == `$CWD_REPO`** — use `$CWD_REPO` silently as the implicit target (`gh` defaults to cwd; no `-R` needed). Continue to Step 1b.
+
+- **`$CWD_REPO` present AND dominant source differs from `$CWD_REPO`** — the session's plugin activity pointed mostly at a different repo than the cwd remote. Use AskUserQuestion to ask:
+
+  > **Mismatch detected.** The session's tool calls were dominated by **`$SUGGESTED_REPO`** ($N references), but the current directory's git remote points to **`$CWD_REPO`**. Which repo should receive the feedback?
+
+  Options:
+  1. **`$SUGGESTED_REPO`** (plugin/skill source — dominant this session) — set `$TARGET_REPO` to `$SUGGESTED_REPO` and append `-R $TARGET_REPO` to all remaining `gh` commands.
+  2. **`$CWD_REPO`** (cwd git remote — the application repo) — use `$CWD_REPO` silently (no `-R` needed).
+  3. **Enter a different `owner/repo`** — free-text follow-up; validate and set `$TARGET_REPO`.
+  4. **Abort** — exit the skill.
+
+  Continue to Step 1b once the choice is resolved.
 
 #### Dominant-source detection: parameters and tiering
 
@@ -106,8 +139,9 @@ The thresholds and prompt order above are deliberate. Keep them aligned when edi
 | Dominance threshold | **> 70%** of total references | Lower thresholds risk wrong defaults on mixed sessions; higher would suppress correct suggestions on small ones |
 | Minimum sample size | **≥ 3** references | Two references can both come from one stray skill mention; three is the smallest sample that survives one outlier |
 | Prompt tiering | suggestion → free-text → abort | The user can correct a wrong guess in one keystroke without redoing the scan, and `Abort` is always one selection away |
+| Mismatch prompt | named choices (dominant / cwd / free-text / abort) | Both repos are plausible; naming them saves the user a copy-paste and makes the choice explicit |
 
-Evidence: issue #1207 (positive feedback) reported the first end-to-end exercise of this fallback in a no-remote cwd. The 3/3 100%-dominant case auto-suggested `laurigates/claude-plugins`, the user accepted on the first prompt, and the free-text tier never fired — confirming the "Recommended" affordance lands the suggestion cleanly when the heuristic is well-tuned.
+Evidence: issue #1207 (positive feedback) reported the first end-to-end exercise of this fallback in a no-remote cwd. The 3/3 100%-dominant case auto-suggested `laurigates/claude-plugins`, the user accepted on the first prompt, and the free-text tier never fired — confirming the "Recommended" affordance lands the suggestion cleanly when the heuristic is well-tuned. Issue #1425 extended the dominant-source scan to the cwd-with-remote branch so the mismatch is surfaced rather than silently dropped.
 
 > **Bonus / future work**: when `$SUGGESTED_REPO` is also cloned at `~/.claude/plugins/cache/<owner>/<repo>/<version>/`, that path could be used by Step 1b's `labels.tf`/`labels.yaml` Glob detection instead of cwd, so IaC-managed labels are detected correctly even when the skill runs outside the plugin checkout. This Step 1b plumbing is intentionally out of scope for this PR — track as a separate issue. For now, Step 1b continues to scan the cwd.
 

--- a/scripts/check-agent-failure-contract.sh
+++ b/scripts/check-agent-failure-contract.sh
@@ -62,13 +62,26 @@ require_marker "$dispatch_skill" "#1422" "the issue reference"
 # custom-agent-definitions carries the cross-reference best practice.
 require_marker "$agentdef_skill" "#1422" "the issue reference / cross-link"
 
+# Regression #1424: REFERENCE.md must carry the QUANTITATIVE hook-thrashing
+# heuristic so an orchestrator can intervene programmatically.  A bulk edit
+# that "tightens" the prose may silently remove the threshold numbers, leaving
+# only qualitative guidance and restoring the deferral to "issue #1424".
+# Check for the specific numeric threshold strings that make the heuristic
+# actionable (9:1 ratio and the 30% / 3-consecutive-blocks is_error rate).
+reference_md="agent-patterns-plugin/skills/parallel-agent-dispatch/REFERENCE.md"
+require_marker "$reference_md" "9:1" "Bash:Edit ratio threshold (issue #1424)"
+require_marker "$reference_md" "is_error" "is_error rate signal (issue #1424)"
+require_marker "$reference_md" "30%" "30% is_error-rate threshold (issue #1424)"
+
 if [ "$errors" -ne 0 ]; then
   echo
-  echo "The loud-failure contract (issue #1422) must remain in the dispatch skills."
-  echo "See .claude/rules/regression-testing.md and the 'Loud-failure contract'"
-  echo "section in $dispatch_skill."
+  echo "The loud-failure contract (issue #1422) and the hook-thrashing heuristic"
+  echo "(issue #1424) must remain in the dispatch skills / REFERENCE.md."
+  echo "See .claude/rules/regression-testing.md and:"
+  echo "  - 'Loud-failure contract' section in $dispatch_skill"
+  echo "  - 'Killed-agent worktree recovery' section in $reference_md"
   exit 1
 fi
 
-echo "OK: loud-failure contract present in both agent-patterns dispatch skills"
+echo "OK: loud-failure contract and hook-thrashing heuristic present in agent-patterns dispatch skills"
 exit 0

--- a/scripts/plugin-compliance-check.sh
+++ b/scripts/plugin-compliance-check.sh
@@ -313,6 +313,27 @@ check_skill_body() {
         has_errors=true
       fi
     fi
+
+    # Regression: feedback-session Step 1a silently filed against the cwd git
+    # remote even when the session's tool calls were dominated by a different
+    # plugin/source repo (issue #1425). The semantic invariant is that the
+    # dominant-source scan runs for BOTH the cwd-with-remote and the no-remote
+    # cases, and that a mismatch between the dominant source and the cwd remote
+    # surfaces a confirmation prompt rather than silently using the cwd repo.
+    # Two literal strings anchor the fix:
+    #   "Mismatch detected" — the mismatch-confirmation prompt heading
+    #   "SUGGESTED_REPO" in the cwd-remote-present branch — proves the dominant
+    #     source is compared against the cwd remote, not only used as fallback
+    if [ "$skill_name" = "feedback-session" ]; then
+      if ! grep -q "Mismatch detected" "$skill_file"; then
+        issues+=("❌ ${plugin}/${skill_name}: SKILL.md must include 'Mismatch detected' mismatch-confirmation prompt in Step 1a (issue #1425)")
+        has_errors=true
+      fi
+      if ! grep -q "dominant source differs from" "$skill_file"; then
+        issues+=("❌ ${plugin}/${skill_name}: SKILL.md must include the cwd-remote-vs-dominant-source branch ('dominant source differs from') in Step 1a decision table (issue #1425)")
+        has_errors=true
+      fi
+    fi
   done < <(find "$skills_dir" -type f \( -iname "SKILL.md" -o -iname "skill.md" \) -print0 2>/dev/null)
 
   if $has_errors; then

--- a/workflow-orchestration-plugin/skills/workflow-wave-dispatch/SKILL.md
+++ b/workflow-orchestration-plugin/skills/workflow-wave-dispatch/SKILL.md
@@ -4,8 +4,8 @@ description: Sequential-wave dispatch for multi-agent work with cross-task depen
 user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 created: 2026-04-24
-modified: 2026-05-29
-reviewed: 2026-05-29
+modified: 2026-06-04
+reviewed: 2026-06-04
 ---
 
 # Workflow Wave Dispatch
@@ -69,6 +69,38 @@ do when a gate fails. The gate *set* itself is the six-gate table in
   waves.
 - Inside a single wave, fan out to the widest safe parallelism that
   `parallel-agent-dispatch` allows.
+
+## Schema-Constrained Agents Under Rate-Limit Storms
+
+Schema-constrained `agent()` calls — agents bound to a `StructuredOutput`
+schema — are **fragile under rate-limit storms** (issue
+[#1463](https://github.com/laurigates/claude-plugins/issues/1463)). A
+rate-limit hit that occurs *before* the agent emits its `StructuredOutput`
+is reported as a hard parse failure: the caller receives no partial output
+and the agent's work is unrecoverable from the schema path, even when
+substantial work was done inside the agent's context window.
+
+**Why this matters at the wave layer.** A wide wave of schema-bound agents
+(e.g. 8–10 concurrent structured-output extractors) creates a rate-limit
+storm risk. If the storm wipes half the wave, the gate fails and the
+orchestrator has no partial results to salvage — unlike a plain `agent()`
+call where the worktree holds the work.
+
+**Blast-radius containment** — apply at wave-scheduling time:
+
+| Heuristic | Guidance |
+|-----------|----------|
+| Wave size | Cap schema-bound waves at **≤ 5 concurrent agents** (same cap as `parallel-agent-dispatch` for Opus 4.7 parents) |
+| Stagger | Add **~30 s between launches** in the same wave to spread the token-request window |
+| Wave splits | If the fan-out genuinely needs >5 schema-bound calls, dispatch in sequential sub-waves of ≤ 5 — gate each sub-wave before launching the next |
+| Retry shape | On a rate-limit partial failure, recovery-dispatch only the failed agents (not the whole wave) — the successful siblings' outputs are valid |
+
+For concurrency caps, wave-splitting mechanics, and the recovery-dispatch
+routine for rate-limited agents, see
+`agent-patterns-plugin:parallel-agent-dispatch` § Concurrent rate-limit
+risk and
+[REFERENCE.md → Concurrent rate-limit recovery](../../agent-patterns-plugin/skills/parallel-agent-dispatch/REFERENCE.md).
+Do not duplicate that guidance here.
 
 ## Gate Failure: Roll Back, Don't Paper Over
 


### PR DESCRIPTION
## Summary

Worked through the open-issue backlog as a workflow: triaged 28 open issues, verified each candidate against the **current** tree (most were already resolved by recently-merged PRs #1496/#1498/#1471/#1465), and dispatched small sonnet teams on the three that were genuinely still actionable. Per the repo's `regression-testing.md` rule, every fix lands with a regression guard, and each team grepped for sibling instances of the same root cause.

## Changes (3 commits, one per issue)

### `fix(feedback-plugin)` — Closes #1425
**Root cause:** `feedback-session` Step 1a only ran the dominant-source scan in the *no-remote* branch. When the cwd had a remote pointing to an unrelated application repo, the skill silently filed feedback against it even when the session was dominated by plugin-skill activity.
**Fix:** Restructured Step 1a into four sequential steps (A: `--target-repo` → B: dominant-source scan *always* → C: cwd remote detect → D: branch on combination) with a four-combination decision table. New mismatch branch surfaces an `AskUserQuestion` offering both repos as named choices.
**Guard:** `plugin-compliance-check.sh` asserts the `"Mismatch detected"` prompt and the cwd-remote-vs-dominant-source branch survive future edits.
**Siblings checked:** `git-issue-hierarchy`, `git-upstream-pr` use `gh repo view` but neither shares the blind spot (no alternative filing destination).

### `docs(agent-patterns-plugin)` — Closes #1424
**Root cause:** The hook-thrashing kill-early signal was documented only qualitatively, with a deferral line pointing at this issue.
**Fix:** Quantified the heuristic — Bash:Edit ratio ≥ 9:1 **combined with** a rising `is_error` rate (≥ 3 consecutive `PreToolUse` blocks, or ≥ 30% of recent Bash calls) — plus a rate-limit-storm-vs-hook-block discriminator so a concurrency spike isn't mistaken for thrashing.
**Guard:** `check-agent-failure-contract.sh` now asserts the numeric thresholds (`9:1`, `is_error`, `30%`) remain in REFERENCE.md.

### `docs(workflow-orchestration-plugin)` — Closes #1463
**Root cause:** No guidance existed on schema-constrained `agent()` calls failing hard under rate-limit storms (no recoverable partial output when the limit lands before `StructuredOutput`).
**Fix:** Added blast-radius containment guidance at the wave-scheduling layer (≤ 5 concurrent schema-bound agents, ~30s stagger, sequential sub-waves, recovery-dispatch only the failed agents), cross-referencing `parallel-agent-dispatch` rather than duplicating it.

## Verification findings — issues that need no code (candidates for closing)

| Issue | State | Resolved by |
|-------|-------|-------------|
| #1420, #1481 | already fixed | PR #1498 |
| #1482, #1483, #1492, #1489 | already fixed | PR #1496 |
| #1490, #1491 | already fixed | PRs #1471, #1465 |
| #1472 / #1495 | documented as expected GitHub OIDC platform behavior (auto-resolves on merge) | `.github/workflows/README.md` |

**#1439 / #1440** reference a `/session-spinup` skill that does not exist in this repo (it lives in the user's personal config), so they are not actionable here.

## Test plan
- [x] `scripts/check-agent-failure-contract.sh` passes (exit 0)
- [x] `scripts/plugin-compliance-check.sh` — no new errors (only a pre-existing soft size warning)
- [x] `bash -n` clean on both edited scripts
- [x] Regression anchors present in the edited SKILL.md files

https://claude.ai/code/session_01TAPDQb2kTkHXxbkchUVacF

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAPDQb2kTkHXxbkchUVacF)_