### PR TITLE
ci(plugin-pr-checks): skip Claude Skill Quality Review when workflow file is modified

### DIFF
--- a/.github/workflows/plugin-pr-checks.yml
+++ b/.github/workflows/plugin-pr-checks.yml
@@ -50,6 +50,19 @@ jobs:
           SKILL_FILES=$(echo "$FILES" | grep -c 'skills/' || true)
           echo "skill_count=$SKILL_FILES" >> "$GITHUB_OUTPUT"
 
+          # Detect whether this PR modifies this workflow file itself.
+          # When it does, claude-code-action's OIDC token exchange is
+          # blocked by GitHub (the workflow must match the default branch
+          # to prevent privilege escalation), so the Claude Skill Quality
+          # Review step is skipped to avoid a benign-but-red failure
+          # (see issues #1472, #1495, #1508).
+          if git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
+            -- .github/workflows/plugin-pr-checks.yml | grep -q .; then
+            echo "workflow_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "workflow_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run plugin compliance checks
         id: compliance
         if: steps.changed.outputs.plugin_count != '0'
@@ -93,7 +106,10 @@ jobs:
           gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY"
 
       - name: Claude Skill Quality Review
-        if: steps.changed.outputs.skill_count != '0'
+        # Skip when this PR modifies plugin-pr-checks.yml: GitHub blocks the
+        # OIDC token exchange claude-code-action needs whenever the running
+        # workflow differs from the default branch (issues #1472, #1495, #1508).
+        if: steps.changed.outputs.skill_count != '0' && steps.changed.outputs.workflow_changed != 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/scripts/tests/test-plugin-pr-checks-workflow-gate.sh
+++ b/scripts/tests/test-plugin-pr-checks-workflow-gate.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Regression test for the Claude Skill Quality Review OIDC gate in
+# .github/workflows/plugin-pr-checks.yml (issues #1472, #1495, #1508).
+#
+# Root cause: when a PR modifies plugin-pr-checks.yml itself, GitHub blocks
+# the OIDC token exchange that claude-code-action relies on, so the
+# "Claude Skill Quality Review" step fails with a benign-but-red
+# "Workflow validation failed" error.
+#
+# Fix: the `changed` step emits a `workflow_changed` output, and the Claude
+# review step's `if:` skips when that output is true.
+#
+# This test guards both halves of the contract so a future edit can't silently
+# drop the gate and let the failure recur.
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+workflow="$repo_root/.github/workflows/plugin-pr-checks.yml"
+
+pass_count=0
+fail_count=0
+
+assert() {
+  # assert <description> <condition-result-string "true"/"false">
+  if [ "$2" = "true" ]; then
+    pass_count=$((pass_count + 1))
+  else
+    echo "FAIL: $1" >&2
+    fail_count=$((fail_count + 1))
+  fi
+}
+
+contains() { grep -qE "$1" "$workflow" && echo true || echo false; }
+contains_fixed() { grep -qF "$1" "$workflow" && echo true || echo false; }
+
+echo "=== TEST: workflow file exists ==="
+assert "plugin-pr-checks.yml is present" "$([ -f "$workflow" ] && echo true || echo false)"
+
+echo "=== TEST: changed step emits workflow_changed output ==="
+assert "changed step writes workflow_changed to GITHUB_OUTPUT" \
+  "$(contains 'workflow_changed=(true|false)')"
+
+echo "=== TEST: workflow_changed is computed from a diff of this workflow file ==="
+assert "diff targets plugin-pr-checks.yml" \
+  "$(contains 'plugin-pr-checks\.yml')"
+
+echo "=== TEST: Claude review step is gated on workflow_changed ==="
+assert "Claude review if-condition references workflow_changed" \
+  "$(contains_fixed "steps.changed.outputs.workflow_changed != 'true'")"
+
+echo
+echo "Passed: $pass_count  Failed: $fail_count"
+[ "$fail_count" -eq 0 ]


### PR DESCRIPTION
## What

The **Claude Skill Quality Review** step in `Plugin: PR checks` uses `anthropics/claude-code-action`, which depends on an OIDC token exchange. GitHub blocks that exchange whenever the running workflow file differs from the default branch (a privilege-escalation guard). As a result, **any PR that modifies `plugin-pr-checks.yml` itself** fails the step with a benign-but-red:

```
Workflow validation failed. The workflow file must exist and have identical content
to the version on the repository's default branch.
```

This is one root cause behind three separate CI-failure reports.

## How

- Add a `workflow_changed` output to the `changed` step — a `git diff` of `plugin-pr-checks.yml` against the base ref.
- Gate the Claude review step's `if:` to skip when `workflow_changed == 'true'`.
- The compliance checks (including new check steps) still run; only the OIDC-dependent review is skipped on self-modifying PRs.

A regression check (`scripts/tests/test-plugin-pr-checks-workflow-gate.sh`) guards both halves of the contract — the output emission and the if-condition gate — so a future edit can't silently drop the guard. It fails against `main` (gate absent) and passes with the fix. `actionlint` and YAML validation pass.

Closes #1508
Closes #1495
Closes #1472