### PR TITLE
feat(comfyui-plugin): add comfyui-screenshot-pipeline skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -147,7 +147,7 @@
     {
       "name": "comfyui-plugin",
       "source": "./comfyui-plugin",
-      "description": "ComfyUI custom-node pack lifecycle - scaffold a pack, create + seed the repo, open the gitops adoption PR, publish to the Comfy Registry",
+      "description": "ComfyUI custom-node pack lifecycle - scaffold a pack, create + seed the repo, open the gitops adoption PR, publish to the Comfy Registry, and add README screenshots",
       "version": "1.1.0",
       "keywords": [
         "comfyui",
@@ -155,7 +155,9 @@
         "scaffold",
         "litegraph",
         "comfy-registry",
-        "gitops"
+        "gitops",
+        "screenshots",
+        "playwright"
       ],
       "category": "development"
     },

--- a/comfyui-plugin/.claude-plugin/plugin.json
+++ b/comfyui-plugin/.claude-plugin/plugin.json
@@ -2,13 +2,15 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "comfyui-plugin",
   "version": "1.1.0",
-  "description": "ComfyUI custom-node pack lifecycle - scaffold a pack, create + seed the repo, open the gitops adoption PR, publish to the Comfy Registry",
+  "description": "ComfyUI custom-node pack lifecycle - scaffold a pack, create + seed the repo, open the gitops adoption PR, publish to the Comfy Registry, and add README screenshots",
   "keywords": [
     "comfyui",
     "custom-node",
     "scaffold",
     "litegraph",
     "comfy-registry",
-    "gitops"
+    "gitops",
+    "screenshots",
+    "playwright"
   ]
 }

--- a/comfyui-plugin/README.md
+++ b/comfyui-plugin/README.md
@@ -6,11 +6,11 @@ on the Comfy Registry.
 
 ## Overview
 
-This plugin packages the two skills that build and ship ComfyUI node packs:
-scaffolding a CI-green repository, and orchestrating the full path from idea to
-a live-on-registry pipeline (repo creation, seeding, and the gitops adoption PR
+This plugin packages the three skills that build and ship ComfyUI node packs:
+scaffolding a CI-green repository, orchestrating the full path from idea to a
+live-on-registry pipeline (repo creation, seeding, and the gitops adoption PR
 that wires branch protection + release-please credentials + the registry token
-via Scalr).
+via Scalr), and adding a reproducible README-screenshot pipeline to a pack.
 
 ## Skills
 
@@ -43,6 +43,22 @@ the Scalr apply), then finishes the import-block-removal follow-up.
 
 **Use when** releasing or spinning up a new comfyui node pack with minimal manual
 steps.
+
+### comfyui-screenshot-pipeline
+
+Add a reproducible, containerized README-screenshot generator to an existing
+pack — the piece `comfyui-node-scaffold` intentionally defers:
+
+- Docker image pins the ComfyUI release + Playwright/Chromium revision, boots
+  ComfyUI headless on CPU, drives the pack's real frontend, writes a PNG to
+  `docs/`
+- A `just screenshots` recipe and a `capture.mjs` driver matched to the pack
+  archetype — `modal` (widget → HTML dialog), `gesture-affordance` (painted
+  canvas hint), or `gesture-overlay` (synthetic-touch transient overlay)
+- `--seed-models` for backend model packs whose grid would otherwise render empty
+
+**Use when** generating README screenshots for a comfyui pack, or wiring up the
+screenshot pipeline like `comfyui-gallery-loader`.
 
 ## When to Use This Plugin
 

--- a/comfyui-plugin/skills/comfyui-screenshot-pipeline/SKILL.md
+++ b/comfyui-plugin/skills/comfyui-screenshot-pipeline/SKILL.md
@@ -1,0 +1,141 @@
+---
+created: 2026-06-05
+modified: 2026-06-05
+reviewed: 2026-06-05
+name: comfyui-screenshot-pipeline
+description: >-
+  Containerized README-screenshot pipeline (Docker + Playwright) for ComfyUI
+  custom-node packs. Use when generating pack screenshots, adding `just
+  screenshots`, or capturing modal/gesture node UI.
+allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
+---
+
+# comfyui-screenshot-pipeline
+
+Add the containerized README-screenshot generator to a ComfyUI usability pack.
+It is the deferred piece from `comfyui-node-scaffold` (which intentionally does
+not emit it). The same pattern ships in `comfyui-gallery-loader`,
+`comfyui-sampler-info`, `comfyui-touch-numeric`, `comfyui-prompt-editor`,
+`comfyui-model-gallery`, `comfyui-touch-resize`, and `comfyui-touch-connect` —
+those are the living reference implementations.
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative when... |
+|---|---|
+| Adding a reproducible README-screenshot generator to an existing ComfyUI pack — Docker + Playwright driver, `just screenshots`, committed `docs/<out>.png` | Bootstrapping a brand-new pack repo → `comfyui-node-scaffold` (it intentionally defers the screenshot pipeline) |
+| Capturing the pack's real frontend deterministically (modal dialog, gesture affordance, or transient overlay) | Running the full idea→registry lifecycle → `comfy-node` |
+
+## Why containerized
+
+The shot must not depend on whatever models / theme / frontend a dev machine
+happens to have. A Docker image pins the ComfyUI release (hence the frontend
+bundle) and the Playwright/Chromium revision (the largest source of cross-host
+font-rendering drift), boots ComfyUI headless on CPU with no models, drives the
+pack's real public surface, and writes a PNG to a mounted `docs/`. Re-runs are
+deterministic.
+
+## Pick the archetype
+
+| Archetype | Use when the pack… | What the driver does |
+|-----------|--------------------|----------------------|
+| `modal` | opens an HTML dialog over a widget (the modal "vein": gallery-loader, sampler-info, touch-numeric, prompt-editor, model-gallery) | load a workflow with the target node, wait for the pack's patch flag on the widget, invoke `widget.onPointerDown`, wait for `.cmp-dialog`, screenshot it |
+| `gesture-affordance` | is a canvas gesture whose only static surface is a painted affordance (touch-resize's corner-hint bracket) | select a node directly (no `selectNode` → no Vue toolbox) so `onDrawForeground` paints, optionally inject an illustrative callout overlay, clip the canvas region around the node |
+| `gesture-overlay` | shows a transient overlay only during a live gesture that can't run headlessly (touch-connect's magnifier loupe) | force the canvas state (`connecting_links` etc.), dispatch a synthetic **touch** pointer the pack listens for, then screenshot the activated overlay element |
+
+For a backend model pack (model-gallery), add `--seed-models`: a fresh ComfyUI
+has empty model dirs, so the grid renders empty. The generator emits
+`seed_models.py` that drops zero-byte placeholder files (the `/list` endpoint
+enumerates names only, never reads contents) across a couple of subfolders.
+
+## How to run
+
+`add_screenshots.py` is stdlib-only. Run it from the pack repo root (or pass
+`--dir <pack>`). The script ships with this skill, so reference it via
+`${CLAUDE_SKILL_DIR}`:
+
+```sh
+# Modal pack (seed keypad over the `seed` widget)
+python3 ${CLAUDE_SKILL_DIR}/add_screenshots.py --name comfyui-touch-numeric --variant modal --node KSampler --widget seed --flag _touchNumericPatched --ready .tn-keypad --out seed.png
+
+# Backend model pack (seed placeholder models first)
+python3 ${CLAUDE_SKILL_DIR}/add_screenshots.py --name comfyui-model-gallery --variant modal --node CheckpointLoaderSimple --widget ckpt_name --flag _modelGalleryPatched --ready .mg-card --out picker.png --seed-models
+
+# Gesture pack — painted affordance
+python3 ${CLAUDE_SKILL_DIR}/add_screenshots.py --name comfyui-touch-resize --variant gesture-affordance --node KSampler --out hint.png
+
+# Gesture pack — forced overlay
+python3 ${CLAUDE_SKILL_DIR}/add_screenshots.py --name comfyui-touch-connect --variant gesture-overlay --out loupe.png
+```
+
+Flags: `--name` (pack dir name = the served URL segment, used as the Docker
+COPY target — must match the real dir), `--variant`, `--out` (PNG filename, also
+the `EXPECTED_OUTPUTS` the entrypoint asserts), `--node`/`--widget`/`--flag`/
+`--ready` (modal capture placeholders — the node type, the widget name the pack
+patches, the pack's per-widget patch-guard property, and an inner dialog
+selector that proves the body rendered), `--seed-models`, `--dir`, `--comfy-ref`
+(default `v0.22.0`), `--playwright` (default `1.49.1`). It refuses to overwrite
+an existing `screenshots/` unless `--force`.
+
+It writes `screenshots/{Dockerfile,Dockerfile.dockerignore,entrypoint.sh,package.json,capture.mjs,workflow.json,README.md}`
+(+ `seed_models.py` with `--seed-models`), and **appends** a `screenshots`
+recipe to the pack's `justfile` if one isn't already there.
+
+## After running: tailor, iterate, embed
+
+1. **Tailor `capture.mjs` + `workflow.json`.** The generic infra is done; the
+   capture is pack-specific. For `modal`, the placeholders are filled from your
+   flags but verify the widget name, patch flag, and the `--ready` inner
+   selector against the real pack JS. For the gesture variants, the emitted
+   driver is the touch-resize / touch-connect approach — adjust selectors,
+   forced state, and any injected overlay to your pack.
+
+2. **Iterate without rebuilding.** Build once, then mount the fast-changing
+   files into the cached image so each run is ~10–15s instead of a ~4-min
+   rebuild:
+
+   ```sh
+   docker build -f screenshots/Dockerfile -t <pack>-screenshots .
+   docker run --rm -v "$(pwd)/docs:/out" -v "$(pwd)/screenshots/capture.mjs:/opt/screenshots/capture.mjs" -v "$(pwd)/screenshots/workflow.json:/opt/screenshots/workflow.json" <pack>-screenshots
+   ```
+
+   For a gesture pack iterating on the extension itself, also mount the pack JS:
+   `-v "$(pwd)/web/js/<ext>.js:/opt/ComfyUI/custom_nodes/<pack>/web/js/<ext>.js"`.
+
+3. **Final run + embed.** `just screenshots` produces the committed `docs/<out>.png`.
+   Embed it as a README hero with an italic caption (see the reference packs).
+   Land it as a `docs(screenshots):` change (no release bump). If the work also
+   changes pack behavior (e.g. an affordance color), split that into its own
+   `fix(...)`/`feat(...)` commit so release-please attributes it correctly.
+
+## Gotchas (all encountered building the family)
+
+- **`biome` ignores `screenshots/`** in these packs, so CI's `biome check .`
+  won't lint `capture.mjs` — but keep it clean anyway (2-space indent, double
+  quotes) to match the family.
+- **`ruff` DOES lint `seed_models.py`** via `ruff check .` / `ruff format --check .`.
+  The generator's output is already ruff-clean and formatted.
+- **`entrypoint.sh` shellcheck**: the `for f in ${EXPECTED_OUTPUTS}` loop is
+  intentional word-splitting; the generator includes the `# shellcheck disable=SC2086`
+  directive so a pre-commit shellcheck hook doesn't fail.
+- **Dismiss the first-run dialog.** A fresh ComfyUI profile opens a PrimeVue
+  "Workflow Templates" dialog (`.p-dialog-mask`) over the canvas; the drivers
+  press Escape and remove the mask before shooting.
+- **`deviceScaleFactor: 2`** gives crisp 2× PNGs; the modal shell is `.cmp-dialog`.
+- **`widget.onPointerDown` may be the pack's own wrapper** that chains the
+  original first and only opens the modal if the original didn't consume the
+  event — invoking it with `{}` as the pointer works for the family's widgets.
+  If a modal won't open this way, fall back to the pack's Strategy-B button
+  (prompt-editor's `⤢`, gallery-loader's 📁) — see those capture scripts.
+- **Pin lockstep.** The Playwright version is pinned in BOTH the Dockerfile
+  `FROM` and `package.json`; bump together. `COMFYUI_REF` pins the frontend
+  bundle — bump deliberately (the modal/canvas render is sensitive to it).
+
+## The generic files (what's identical across packs)
+
+`entrypoint.sh` (boots ComfyUI on `--cpu :8188`, waits for `/system_stats`, runs
+the driver, asserts `$EXPECTED_OUTPUTS` exist), `Dockerfile.dockerignore`, and
+`package.json` (modulo the name) are the same everywhere. The Dockerfile differs
+only by pack name, `EXPECTED_OUTPUTS`, and the optional model-seeding block.
+`capture.mjs` + `workflow.json` are the only genuinely pack-specific files — and
+the reference packs are the canonical examples to crib from.

--- a/comfyui-plugin/skills/comfyui-screenshot-pipeline/add_screenshots.py
+++ b/comfyui-plugin/skills/comfyui-screenshot-pipeline/add_screenshots.py
@@ -1,0 +1,998 @@
+#!/usr/bin/env python3
+"""Add the containerized README screenshot pipeline to a ComfyUI custom-node pack.
+
+Emits a screenshots/ directory (Docker + Playwright) that boots a pinned ComfyUI
+headless, drives the pack's real frontend, and writes a PNG to a mounted docs/.
+The generic infra (entrypoint, dockerignore, package.json, Dockerfile) is
+identical to the comfyui-gallery-loader / comfyui-sampler-info family; capture.mjs
+and workflow.json are emitted as an archetype-matched skeleton to tailor.
+
+Stdlib-only. See SKILL.md for the full workflow (archetypes, the runtime-mount
+iteration loop, pins, and gotchas).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import stat
+import sys
+
+# --------------------------------------------------------------------------- #
+# Generic files — identical across packs (modulo the @@TOKENS@@)
+# --------------------------------------------------------------------------- #
+
+DOCKERIGNORE = """# Keep the Docker build context lean. The pack source + screenshots/
+# directory are all the build needs.
+.git/
+.github/
+.venv/
+.pytest_cache/
+.ruff_cache/
+node_modules/
+docs/
+tests/
+uv.lock
+*.egg-info/
+__pycache__/
+.DS_Store
+.vscode/
+.idea/
+.claude/
+TODO.local.md
+NOTES.local.md
+"""
+
+ENTRYPOINT = """#!/usr/bin/env bash
+#
+# Launch ComfyUI headless, wait for it to be ready, then run the
+# Playwright capture script. Exits non-zero if any expected screenshot is
+# missing afterwards so a failed run surfaces in the build output.
+#
+# EXPECTED_OUTPUTS is a space-separated list of filenames (relative to
+# OUT_DIR) the capture must produce. Set it via ENV in the Dockerfile.
+
+set -euo pipefail
+
+PORT="${COMFYUI_PORT:-8188}"
+OUT_DIR="${OUT_DIR:-/out}"
+COMFY_DIR="${COMFY_DIR:-/opt/ComfyUI}"
+CAPTURE="${CAPTURE_SCRIPT:-/opt/screenshots/capture.mjs}"
+EXPECTED_OUTPUTS="${EXPECTED_OUTPUTS:-picker.png}"
+READY_URL="http://127.0.0.1:${PORT}/system_stats"
+READY_TIMEOUT="${READY_TIMEOUT:-120}"
+
+mkdir -p "${OUT_DIR}"
+
+cd "${COMFY_DIR}"
+python main.py \\
+    --cpu \\
+    --listen 0.0.0.0 \\
+    --port "${PORT}" \\
+    --disable-auto-launch \\
+    >/tmp/comfyui.log 2>&1 &
+COMFY_PID=$!
+
+cleanup() {
+    if kill -0 "${COMFY_PID}" 2>/dev/null; then
+        kill "${COMFY_PID}" 2>/dev/null || true
+        wait "${COMFY_PID}" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+echo "Waiting for ComfyUI to come up on ${READY_URL} (timeout: ${READY_TIMEOUT}s)..."
+deadline=$(( $(date +%s) + READY_TIMEOUT ))
+until curl -fs "${READY_URL}" >/dev/null 2>&1; do
+    if ! kill -0 "${COMFY_PID}" 2>/dev/null; then
+        echo "ComfyUI exited before becoming ready. Log tail:" >&2
+        tail -n 200 /tmp/comfyui.log >&2 || true
+        exit 1
+    fi
+    if [ "$(date +%s)" -ge "${deadline}" ]; then
+        echo "ComfyUI did not become ready within ${READY_TIMEOUT}s. Log tail:" >&2
+        tail -n 200 /tmp/comfyui.log >&2 || true
+        exit 1
+    fi
+    sleep 1
+done
+echo "ComfyUI is ready."
+
+node "${CAPTURE}"
+status=$?
+
+# Word-splitting on EXPECTED_OUTPUTS is intentional - it's a space-separated list.
+# shellcheck disable=SC2086
+for f in ${EXPECTED_OUTPUTS}; do
+    if [ ! -s "${OUT_DIR}/${f}" ]; then
+        echo "Missing or empty ${OUT_DIR}/${f} after capture." >&2
+        exit 1
+    fi
+done
+
+echo "Captured: ${EXPECTED_OUTPUTS} (in ${OUT_DIR})."
+exit "${status}"
+"""
+
+PACKAGE_JSON = """{
+  "name": "@@PACK@@-screenshots",
+  "private": true,
+  "type": "module",
+  "description": "Playwright driver for generating README screenshots of @@PACK@@.",
+  "dependencies": {
+    "playwright": "@@PW@@"
+  }
+}
+"""
+
+DOCKERFILE = """# syntax=docker/dockerfile:1.7
+#
+# Single-stage build for the README screenshot generator. Base image: the
+# official Playwright image (Node 22 + Chromium pre-installed). On top we
+# install Python + clone a pinned ComfyUI release + CPU-only torch + ComfyUI's
+# requirements. The entrypoint boots ComfyUI headless on :8188, waits for
+# /system_stats, then runs the Playwright driver which writes /out/@@OUT@@.
+
+# Pin to a real ComfyUI release. Bumping is deliberate - the render is sensitive
+# to the frontend bundle that ships with this release. @@COMFY_REF@@ ships
+# comfyui-frontend-package==1.43.18, clearing the pack's >=1.40 floor.
+ARG COMFYUI_REF=@@COMFY_REF@@
+
+# Pinning the Playwright image version pins the Chromium revision too, the
+# single largest source of cross-host font-rendering drift. Keep in sync with
+# the playwright version in package.json.
+FROM mcr.microsoft.com/playwright:v@@PW@@-noble
+
+ARG COMFYUI_REF
+
+ENV DEBIAN_FRONTEND=noninteractive \\
+    PIP_NO_CACHE_DIR=1 \\
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \\
+    PIP_BREAK_SYSTEM_PACKAGES=1 \\
+    EXPECTED_OUTPUTS="@@OUT@@"
+
+RUN apt-get update \\
+    && apt-get install -y --no-install-recommends \\
+        python3 python3-pip python3-venv git ca-certificates \\
+    && rm -rf /var/lib/apt/lists/* \\
+    && ln -sf /usr/bin/python3 /usr/local/bin/python
+
+WORKDIR /opt
+RUN git clone --depth 1 --branch "${COMFYUI_REF}" \\
+    https://github.com/comfyanonymous/ComfyUI.git /opt/ComfyUI
+
+WORKDIR /opt/ComfyUI
+
+# CPU-only torch keeps the image lean and avoids CUDA driver dependencies.
+RUN pip install --index-url https://download.pytorch.org/whl/cpu \\
+        torch torchvision torchaudio \\
+    && pip install -r requirements.txt
+@@SEED_BLOCK@@
+WORKDIR /opt/screenshots
+COPY screenshots/package.json /opt/screenshots/package.json
+# Chromium is pre-installed in the Playwright base image, so we only need the
+# npm dependency for the driver script itself.
+RUN npm install --omit=dev
+
+# The pack lives under custom_nodes/ with the canonical directory name. This
+# name is the served URL prefix (/extensions/@@PACK@@/), so don't rename it.
+COPY . /opt/ComfyUI/custom_nodes/@@PACK@@
+
+COPY screenshots/capture.mjs /opt/screenshots/capture.mjs
+COPY screenshots/workflow.json /opt/screenshots/workflow.json
+COPY screenshots/entrypoint.sh /opt/screenshots/entrypoint.sh
+RUN chmod +x /opt/screenshots/entrypoint.sh
+
+WORKDIR /opt/ComfyUI
+
+VOLUME ["/out"]
+
+ENTRYPOINT ["/opt/screenshots/entrypoint.sh"]
+"""
+
+SEED_BLOCK = """
+# Seed placeholder model files so the gallery grid is populated. The /list
+# endpoint enumerates names only (never reads contents), so zero-byte files with
+# believable names are enough. Done here so the layer is cached.
+COPY screenshots/seed_models.py /opt/screenshots/seed_models.py
+RUN python /opt/screenshots/seed_models.py
+"""
+
+SEED_MODELS = '''"""Seed placeholder model files so the gallery grid is not empty.
+
+The picker grid lists real files via folder_paths.get_filename_list - a fresh
+ComfyUI clone has empty model dirs. The /list endpoint enumerates names only (it
+never reads contents), so zero-byte placeholders with believable names + a couple
+of subfolders are enough to populate the grid and exercise the subfolder chips.
+Run at Docker build time, before ComfyUI starts.
+"""
+
+from __future__ import annotations
+
+import os
+
+COMFY_DIR = os.environ.get("COMFY_DIR", "/opt/ComfyUI")
+MODELS_DIR = os.path.join(COMFY_DIR, "models")
+
+# category -> relative names (forward-slash subfolders allowed). Illustrative
+# only; nothing is loaded. Edit to match the categories your pack lists.
+SEED: dict[str, list[str]] = {
+    "checkpoints": [
+        "sd_xl_base_1.0.safetensors",
+        "sd_xl_refiner_1.0.safetensors",
+        "v1-5-pruned-emaonly.safetensors",
+        "flux/flux1-dev.safetensors",
+        "flux/flux1-schnell.safetensors",
+        "sd35/sd3.5_large.safetensors",
+    ],
+    "loras": [
+        "detail_tweaker_xl.safetensors",
+        "add_detail.safetensors",
+        "flux/realism_lora.safetensors",
+        "style/ghibli_style.safetensors",
+    ],
+}
+
+
+def main() -> None:
+    for category, names in SEED.items():
+        for name in names:
+            path = os.path.join(MODELS_DIR, category, name)
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "wb"):
+                pass
+            print(f"seeded {category}/{name}")
+
+
+if __name__ == "__main__":
+    main()
+'''
+
+# --------------------------------------------------------------------------- #
+# workflow.json templates (single-node, or a connected pair for gesture-overlay)
+# --------------------------------------------------------------------------- #
+
+WF_KSAMPLER = """{
+  "last_node_id": 1,
+  "last_link_id": 0,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "KSampler",
+      "pos": [360, 180],
+      "size": [320, 262],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [
+        { "name": "model", "type": "MODEL", "link": null },
+        { "name": "positive", "type": "CONDITIONING", "link": null },
+        { "name": "negative", "type": "CONDITIONING", "link": null },
+        { "name": "latent_image", "type": "LATENT", "link": null }
+      ],
+      "outputs": [
+        { "name": "LATENT", "type": "LATENT", "links": null, "shape": 3 }
+      ],
+      "properties": { "Node name for S&R": "KSampler" },
+      "widgets_values": [156680208700286, "randomize", 20, 8, "dpmpp_2m", "karras", 1]
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "config": {},
+  "extra": {},
+  "version": 0.4
+}
+"""
+
+WF_CHECKPOINT = """{
+  "last_node_id": 1,
+  "last_link_id": 0,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "CheckpointLoaderSimple",
+      "pos": [360, 200],
+      "size": [340, 100],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        { "name": "MODEL", "type": "MODEL", "links": null, "shape": 3 },
+        { "name": "CLIP", "type": "CLIP", "links": null, "shape": 3 },
+        { "name": "VAE", "type": "VAE", "links": null, "shape": 3 }
+      ],
+      "properties": { "Node name for S&R": "CheckpointLoaderSimple" },
+      "widgets_values": ["sd_xl_base_1.0.safetensors"]
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "config": {},
+  "extra": {},
+  "version": 0.4
+}
+"""
+
+WF_CLIPTEXT = """{
+  "last_node_id": 1,
+  "last_link_id": 0,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "CLIPTextEncode",
+      "pos": [360, 180],
+      "size": [400, 200],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [ { "name": "clip", "type": "CLIP", "link": null } ],
+      "outputs": [ { "name": "CONDITIONING", "type": "CONDITIONING", "links": null, "shape": 3 } ],
+      "properties": { "Node name for S&R": "CLIPTextEncode" },
+      "widgets_values": ["cinematic portrait of an arctic fox in a snowstorm, (rim lighting:1.2), shallow depth of field, 85mm, masterpiece"]
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "config": {},
+  "extra": {},
+  "version": 0.4
+}
+"""
+
+WF_GENERIC = """{
+  "last_node_id": 1,
+  "last_link_id": 0,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "@@NODE@@",
+      "pos": [360, 180],
+      "size": [320, 220],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": { "Node name for S&R": "@@NODE@@" },
+      "widgets_values": []
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "config": {},
+  "extra": {},
+  "version": 0.4
+}
+"""
+
+WF_CONNECTED_PAIR = """{
+  "last_node_id": 2,
+  "last_link_id": 1,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "EmptyLatentImage",
+      "pos": [80, 200],
+      "size": [270, 106],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [ { "name": "LATENT", "type": "LATENT", "links": [1], "slot_index": 0, "shape": 3 } ],
+      "properties": { "Node name for S&R": "EmptyLatentImage" },
+      "widgets_values": [512, 512, 1]
+    },
+    {
+      "id": 2,
+      "type": "VAEDecode",
+      "pos": [470, 220],
+      "size": [210, 46],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        { "name": "samples", "type": "LATENT", "link": 1 },
+        { "name": "vae", "type": "VAE", "link": null }
+      ],
+      "outputs": [ { "name": "IMAGE", "type": "IMAGE", "links": null, "slot_index": 0, "shape": 3 } ],
+      "properties": { "Node name for S&R": "VAEDecode" },
+      "widgets_values": []
+    }
+  ],
+  "links": [ [1, 1, 0, 2, 0, "LATENT"] ],
+  "groups": [],
+  "config": {},
+  "extra": {},
+  "version": 0.4
+}
+"""
+
+# --------------------------------------------------------------------------- #
+# capture.mjs templates, one per archetype
+# --------------------------------------------------------------------------- #
+
+CAPTURE_MODAL = """// Playwright driver for the README screenshot (MODAL archetype).
+//
+// Loads a workflow with the target node, invokes the pack's patched
+// widget.onPointerDown to open the HTML modal, and screenshots the dialog.
+// Direct widget invocation is intentional: clicking the canvas at computed
+// coords is fragile; widget.onPointerDown is the exact surface the pack hooks.
+//
+// TODO: verify these against the real pack JS:
+//   WIDGET ("@@WIDGET@@")  - the widget name the pack patches
+//   FLAG   ("@@FLAG@@")    - the pack's per-widget patch-guard property
+//   READY  ("@@READY@@")   - an inner dialog element proving the body rendered
+// If the modal won't open this way, fall back to the pack's Strategy-B button
+// (see comfyui-prompt-editor / comfyui-gallery-loader capture.mjs).
+
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const WORKFLOW_PATH = resolve(HERE, "workflow.json");
+const OUT_DIR = process.env.OUT_DIR || "/out";
+const BASE_URL = process.env.COMFYUI_URL || "http://127.0.0.1:8188/";
+// Optional: type into the modal search to show the fuzzy-match state. Empty
+// (default) leaves the full view. Only used if the dialog has a .cmp-search.
+const PICKER_QUERY = process.env.PICKER_QUERY || "";
+const WIDGET = "@@WIDGET@@";
+const FLAG = "@@FLAG@@";
+const READY = "@@READY@@";
+
+async function dismissStartupDialog(page) {
+  await page.keyboard.press("Escape");
+  await page.waitForTimeout(150);
+  await page.evaluate(() => {
+    for (const el of document.querySelectorAll(".p-dialog-mask")) el.remove();
+  });
+}
+
+async function main() {
+  const workflow = JSON.parse(await readFile(WORKFLOW_PATH, "utf8"));
+  const browser = await chromium.launch({ args: ["--font-render-hinting=none"] });
+  const context = await browser.newContext({
+    viewport: { width: 1280, height: 800 },
+    deviceScaleFactor: 2,
+  });
+  const page = await context.newPage();
+  page.on("console", (msg) => {
+    const t = msg.type();
+    if (t === "error" || t === "warning") console.log(`[page:${t}] ${msg.text()}`);
+  });
+
+  console.log(`Navigating to ${BASE_URL}...`);
+  await page.goto(BASE_URL, { waitUntil: "networkidle" });
+  await page.waitForFunction(
+    () => window.app && window.app.graph && Array.isArray(window.app.graph._nodes),
+    null,
+    { timeout: 30_000 },
+  );
+
+  console.log("Loading workflow...");
+  await page.evaluate((wf) => window.app.loadGraphData(wf, true), workflow);
+  await page.waitForFunction(() => window.app.graph._nodes.length >= 1, null, {
+    timeout: 10_000,
+  });
+  await dismissStartupDialog(page);
+
+  // Wait until the pack has patched the target widget.
+  await page.waitForFunction(
+    ({ widget, flag }) =>
+      window.app.graph._nodes.some((n) =>
+        (n.widgets || []).some((w) => w.name === widget && w[flag] === true),
+      ),
+    { widget: WIDGET, flag: FLAG },
+    { timeout: 15_000 },
+  );
+
+  await page.evaluate(() => {
+    window.app.canvas?.setDirty?.(true, true);
+    window.app.canvas?.draw?.(true, true);
+  });
+
+  console.log(`Opening modal via ${WIDGET}.onPointerDown...`);
+  await page.evaluate(
+    ({ widget }) => {
+      const node = window.app.graph._nodes.find((n) =>
+        (n.widgets || []).some((w) => w.name === widget),
+      );
+      const w = node.widgets.find((x) => x.name === widget);
+      w.onPointerDown({}, node, window.app.canvas);
+    },
+    { widget: WIDGET },
+  );
+
+  const dialog = page.locator(".cmp-dialog");
+  await dialog.waitFor({ state: "visible", timeout: 10_000 });
+  await page.waitForFunction((sel) => document.querySelector(`.cmp-dialog ${sel}`), READY, {
+    timeout: 10_000,
+  });
+
+  if (PICKER_QUERY) {
+    const search = dialog.locator(".cmp-search");
+    await search.waitFor({ state: "visible", timeout: 5_000 });
+    await search.fill(PICKER_QUERY);
+    await page.waitForTimeout(300);
+  }
+  await page.waitForTimeout(300);
+
+  console.log(`Capturing ${OUT_DIR}/@@OUT@@...`);
+  await dialog.screenshot({ path: `${OUT_DIR}/@@OUT@@` });
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error("capture failed:", err);
+  process.exit(1);
+});
+"""
+
+CAPTURE_AFFORDANCE = """// Playwright driver for the README screenshot (GESTURE-AFFORDANCE archetype).
+//
+// Canvas-gesture pack - no modal. Selects a node directly (no canvas.selectNode
+// -> no Vue selection toolbox) so the pack's onDrawForeground affordance paints,
+// optionally injects an illustrative gesture callout, and clips the canvas around
+// the node. Modeled on comfyui-touch-resize.
+//
+// TODO: this template injects a two-finger PINCH callout (fingertips + diverging
+// arrow). If your gesture is different (drag, long-press), adjust or remove the
+// injectCallout() overlay. The injected glyph is a documentation annotation -
+// the pack draws only its real affordance.
+
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const WORKFLOW_PATH = resolve(HERE, "workflow.json");
+const OUT_DIR = process.env.OUT_DIR || "/out";
+const BASE_URL = process.env.COMFYUI_URL || "http://127.0.0.1:8188/";
+const ACCENT = "#ffb02e"; // keep in sync with the pack's affordance colour
+
+async function dismissStartupDialog(page) {
+  await page.keyboard.press("Escape");
+  await page.waitForTimeout(150);
+  await page.evaluate(() => {
+    for (const el of document.querySelectorAll(".p-dialog-mask")) el.remove();
+  });
+}
+
+async function main() {
+  const workflow = JSON.parse(await readFile(WORKFLOW_PATH, "utf8"));
+  const browser = await chromium.launch({ args: ["--font-render-hinting=none"] });
+  const context = await browser.newContext({
+    viewport: { width: 1280, height: 800 },
+    deviceScaleFactor: 2,
+  });
+  const page = await context.newPage();
+  page.on("console", (msg) => {
+    const t = msg.type();
+    if (t === "error" || t === "warning") console.log(`[page:${t}] ${msg.text()}`);
+  });
+
+  console.log(`Navigating to ${BASE_URL}...`);
+  await page.goto(BASE_URL, { waitUntil: "networkidle" });
+  await page.waitForFunction(
+    () => window.app && window.app.graph && Array.isArray(window.app.graph._nodes),
+    null,
+    { timeout: 30_000 },
+  );
+
+  console.log("Loading workflow...");
+  await page.evaluate((wf) => window.app.loadGraphData(wf, true), workflow);
+  await page.waitForFunction(() => window.app.graph._nodes.length >= 1, null, {
+    timeout: 10_000,
+  });
+  await dismissStartupDialog(page);
+
+  console.log("Positioning + selecting the node...");
+  const rect = await page.evaluate(() => {
+    const node = window.app.graph._nodes[0];
+    const canvas = window.app.canvas;
+    const ds = canvas.ds;
+    ds.scale = 1;
+    ds.offset[0] = 240 - node.pos[0];
+    ds.offset[1] = 190 - node.pos[1];
+    // Select directly (no selectNode -> no Vue selection toolbox).
+    node.selected = true;
+    canvas.selected_nodes = { [node.id]: node };
+    canvas.setDirty(true, true);
+    canvas.draw(true, true);
+    return {
+      bx: (node.pos[0] + ds.offset[0]) * ds.scale,
+      by: (node.pos[1] + ds.offset[1]) * ds.scale,
+      bw: node.size[0] * ds.scale,
+      bh: node.size[1] * ds.scale,
+    };
+  });
+
+  // Inject a two-finger pinch callout over the node body (documentation overlay).
+  await page.evaluate(
+    ({ bx, by, bw, bh, accent }) => {
+      const cx = bw / 2;
+      const cy = bh / 2;
+      const L = Math.min(bw, bh) * 0.26;
+      const u = Math.SQRT1_2;
+      const ax = cx - u * L;
+      const ay = cy - u * L;
+      const bxp = cx + u * L;
+      const byp = cy + u * L;
+      const f1x = cx - u * (L - 22);
+      const f1y = cy - u * (L - 22);
+      const f2x = cx + u * (L - 22);
+      const f2y = cy + u * (L - 22);
+      const svg = `
+        <svg width="${bw}" height="${bh}" viewBox="0 0 ${bw} ${bh}"
+             xmlns="http://www.w3.org/2000/svg" style="position:absolute;inset:0;">
+          <defs>
+            <marker id="tr-ah" markerUnits="userSpaceOnUse" markerWidth="18"
+                    markerHeight="18" refX="12" refY="9" orient="auto-start-reverse">
+              <path d="M0,0 L16,9 L0,18 Z" fill="${accent}"/>
+            </marker>
+          </defs>
+          <line x1="${ax}" y1="${ay}" x2="${bxp}" y2="${byp}"
+                stroke="rgba(0,0,0,0.5)" stroke-width="9" stroke-linecap="round"/>
+          <line x1="${ax}" y1="${ay}" x2="${bxp}" y2="${byp}"
+                stroke="${accent}" stroke-width="5" stroke-linecap="round"
+                marker-start="url(#tr-ah)" marker-end="url(#tr-ah)"/>
+          <circle cx="${f1x}" cy="${f1y}" r="15" fill="rgba(255,255,255,0.95)"
+                  stroke="${accent}" stroke-width="2.5"/>
+          <circle cx="${f2x}" cy="${f2y}" r="15" fill="rgba(255,255,255,0.95)"
+                  stroke="${accent}" stroke-width="2.5"/>
+        </svg>`;
+      const overlay = document.createElement("div");
+      overlay.style.cssText = [
+        "position:fixed",
+        `left:${bx}px`,
+        `top:${by}px`,
+        `width:${bw}px`,
+        `height:${bh}px`,
+        "pointer-events:none",
+        "z-index:10000",
+      ].join(";");
+      overlay.innerHTML = svg;
+      document.body.appendChild(overlay);
+    },
+    { bx: rect.bx, by: rect.by, bw: rect.bw, bh: rect.bh, accent: ACCENT },
+  );
+
+  await page.waitForTimeout(300);
+  const TITLE = 30;
+  const PAD = 60;
+  const clip = {
+    x: Math.max(0, rect.bx - PAD),
+    y: Math.max(0, rect.by - TITLE - PAD),
+    width: rect.bw + PAD * 2,
+    height: rect.bh + TITLE + PAD * 2,
+  };
+  console.log(`Capturing ${OUT_DIR}/@@OUT@@...`);
+  await page.screenshot({ path: `${OUT_DIR}/@@OUT@@`, clip });
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error("capture failed:", err);
+  process.exit(1);
+});
+"""
+
+CAPTURE_OVERLAY = """// Playwright driver for the README screenshot (GESTURE-OVERLAY archetype).
+//
+// Canvas-gesture pack whose overlay only appears during a live gesture that
+// can't run headlessly (e.g. touch-connect's magnifier loupe during a connection
+// drag). Synthesizes that state through the pack's real public surface: forces
+// the canvas drag state, dispatches a synthetic TOUCH pointer the pack listens
+// for, then screenshots the activated overlay element. Modeled on
+// comfyui-touch-connect.
+//
+// TODO: adapt the forced state + the overlay locator to your pack:
+//   - what canvas state activates the overlay (here: connecting_links)
+//   - how the pack detects the gesture (here: a window touch pointerdown)
+//   - how to find the overlay element (here: a fixed circular <canvas>)
+
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const WORKFLOW_PATH = resolve(HERE, "workflow.json");
+const OUT_DIR = process.env.OUT_DIR || "/out";
+const BASE_URL = process.env.COMFYUI_URL || "http://127.0.0.1:8188/";
+const FINGER_X = 560;
+const FINGER_Y = 380;
+const SCALE = 1.4;
+
+async function dismissStartupDialog(page) {
+  await page.keyboard.press("Escape");
+  await page.waitForTimeout(150);
+  await page.evaluate(() => {
+    for (const el of document.querySelectorAll(".p-dialog-mask")) el.remove();
+  });
+}
+
+async function main() {
+  const workflow = JSON.parse(await readFile(WORKFLOW_PATH, "utf8"));
+  const browser = await chromium.launch({ args: ["--font-render-hinting=none"] });
+  const context = await browser.newContext({
+    viewport: { width: 1280, height: 800 },
+    deviceScaleFactor: 2,
+    hasTouch: true,
+  });
+  const page = await context.newPage();
+  page.on("console", (msg) => {
+    const t = msg.type();
+    if (t === "error" || t === "warning") console.log(`[page:${t}] ${msg.text()}`);
+  });
+
+  console.log(`Navigating to ${BASE_URL}...`);
+  await page.goto(BASE_URL, { waitUntil: "networkidle" });
+  await page.waitForFunction(
+    () => window.app && window.app.graph && Array.isArray(window.app.graph._nodes),
+    null,
+    { timeout: 30_000 },
+  );
+
+  console.log("Loading workflow...");
+  await page.evaluate((wf) => window.app.loadGraphData(wf, true), workflow);
+  await page.waitForFunction(() => window.app.graph._nodes.length >= 1, null, {
+    timeout: 10_000,
+  });
+  await dismissStartupDialog(page);
+
+  console.log("Positioning view + forcing the gesture state...");
+  await page.evaluate(
+    ({ fingerX, fingerY, scale }) => {
+      const graph = window.app.graph;
+      const canvas = window.app.canvas;
+      const ds = canvas.ds;
+      ds.scale = scale;
+      const node1 = graph._nodes[0];
+      const node2 = graph._nodes[graph._nodes.length - 1];
+      const gx = node2.pos[0];
+      const gy = node2.pos[1] + 18;
+      ds.offset[0] = fingerX / scale - gx;
+      ds.offset[1] = fingerY / scale - gy;
+      // Force the LiteGraph connection-drag state (modern + legacy fields).
+      const out = node1.outputs && node1.outputs[0];
+      if (out) {
+        canvas.connecting_links = [
+          { node: node1, slot: 0, output: out, type: out.type },
+        ];
+        canvas.connecting_node = node1;
+        canvas.connecting_output = out;
+      }
+      canvas.setDirty(true, true);
+      canvas.draw(true, true);
+    },
+    { fingerX: FINGER_X, fingerY: FINGER_Y, scale: SCALE },
+  );
+
+  console.log("Dispatching synthetic touch pointer...");
+  await page.evaluate(
+    ({ x, y }) => {
+      const fire = (type) =>
+        window.dispatchEvent(
+          new PointerEvent(type, {
+            pointerType: "touch",
+            clientX: x,
+            clientY: y,
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+      fire("pointerdown");
+      fire("pointermove");
+    },
+    { x: FINGER_X, y: FINGER_Y },
+  );
+
+  console.log("Waiting for the overlay to activate...");
+  await page.waitForFunction(
+    () => {
+      const c = [...document.querySelectorAll("canvas")].find(
+        (el) => el.style?.position === "fixed" && el.style?.borderRadius === "50%",
+      );
+      if (!c || c.style.display === "none") return false;
+      c.id = "overlay-shot";
+      return true;
+    },
+    null,
+    { timeout: 8_000 },
+  );
+  await page.waitForTimeout(500);
+
+  console.log(`Capturing ${OUT_DIR}/@@OUT@@...`);
+  await page.locator("#overlay-shot").screenshot({ path: `${OUT_DIR}/@@OUT@@` });
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error("capture failed:", err);
+  process.exit(1);
+});
+"""
+
+README_TMPL = """# README screenshot pipeline
+
+Containerized [Playwright](https://playwright.dev) + ComfyUI generator that
+regenerates the README screenshot (`docs/@@OUT@@`) reproducibly, so the shot
+doesn't depend on whatever models/theme/frontend a particular dev machine has.
+
+## Run
+
+From the repo root:
+
+```sh
+just screenshots
+```
+
+First build is ~4 min (clones ComfyUI, installs CPU torch + ComfyUI deps, pulls
+the npm driver dep on top of the pre-baked Chromium). Cached rebuilds are ~30s.
+The PNG lands at `docs/@@OUT@@`.
+
+## Iterating without a rebuild
+
+`capture.mjs` + `workflow.json` are COPY'd late, so editing them rebuilds in
+~30s. To iterate even faster, mount them into the cached image:
+
+```sh
+docker build -f screenshots/Dockerfile -t @@PACK@@-screenshots .
+docker run --rm -v "$(pwd)/docs:/out" -v "$(pwd)/screenshots/capture.mjs:/opt/screenshots/capture.mjs" -v "$(pwd)/screenshots/workflow.json:/opt/screenshots/workflow.json" @@PACK@@-screenshots
+```
+
+## Pins (bump deliberately)
+
+- **`ARG COMFYUI_REF`** (`Dockerfile`) - the ComfyUI release pins the frontend
+  bundle the render depends on.
+- **Playwright version** - pinned in BOTH `Dockerfile` (`FROM ...playwright:v@@PW@@-noble`)
+  and `package.json`. Keep them in lockstep; bump together.
+
+## Don't hand-edit `docs/@@OUT@@`
+
+It's generated. To change it, edit `capture.mjs` / `workflow.json` and re-run
+`just screenshots`.
+"""
+
+JUST_RECIPE = """
+##########
+# Documentation artifacts
+##########
+
+# Regenerate docs/@@OUT@@ via the containerized screenshot generator.
+[group: "docs"]
+screenshots:
+    docker build -f screenshots/Dockerfile -t @@PACK@@-screenshots .
+    docker run --rm -v "$(pwd)/docs:/out" @@PACK@@-screenshots
+"""
+
+
+# --------------------------------------------------------------------------- #
+# Generation
+# --------------------------------------------------------------------------- #
+
+
+def render(tmpl: str, repl: dict[str, str]) -> str:
+    out = tmpl
+    for key, val in repl.items():
+        out = out.replace(f"@@{key}@@", val)
+    return out
+
+
+def write(path: str, content: str, *, executable: bool = False) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(content)
+    if executable:
+        mode = os.stat(path).st_mode
+        os.chmod(path, mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    print(f"  wrote {path}")
+
+
+def pick_workflow(variant: str, node: str) -> str:
+    if variant == "gesture-overlay":
+        return WF_CONNECTED_PAIR
+    return {
+        "KSampler": WF_KSAMPLER,
+        "CheckpointLoaderSimple": WF_CHECKPOINT,
+        "CLIPTextEncode": WF_CLIPTEXT,
+    }.get(node, WF_GENERIC)
+
+
+def pick_capture(variant: str) -> str:
+    return {
+        "modal": CAPTURE_MODAL,
+        "gesture-affordance": CAPTURE_AFFORDANCE,
+        "gesture-overlay": CAPTURE_OVERLAY,
+    }[variant]
+
+
+def append_just_recipe(pack_dir: str, repl: dict[str, str]) -> None:
+    justfile = os.path.join(pack_dir, "justfile")
+    recipe = render(JUST_RECIPE, repl)
+    if not os.path.exists(justfile):
+        print(f"  note: no justfile at {justfile}; skipping recipe (add it by hand)")
+        return
+    with open(justfile, encoding="utf-8") as fh:
+        existing = fh.read()
+    if "screenshots:" in existing:
+        print(f"  note: {justfile} already has a `screenshots` recipe; not appending")
+        return
+    with open(justfile, "a", encoding="utf-8") as fh:
+        if not existing.endswith("\n"):
+            fh.write("\n")
+        fh.write(recipe)
+    print(f"  appended `screenshots` recipe to {justfile}")
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--name", required=True, help="pack dir name = served URL segment, e.g. comfyui-touch-numeric")
+    p.add_argument(
+        "--variant",
+        choices=["modal", "gesture-affordance", "gesture-overlay"],
+        default="modal",
+    )
+    p.add_argument("--out", default="picker.png", help="output PNG filename (also EXPECTED_OUTPUTS)")
+    p.add_argument("--node", default="KSampler", help="node type for workflow.json (modal/affordance)")
+    p.add_argument("--widget", default="seed", help="widget name the pack patches (modal)")
+    p.add_argument("--flag", default="_examplePatched", help="pack's per-widget patch-guard property (modal)")
+    p.add_argument("--ready", default=".cmp-body", help="inner dialog selector proving the body rendered (modal)")
+    p.add_argument("--seed-models", action="store_true", help="emit seed_models.py + Dockerfile seeding (backend model packs)")
+    p.add_argument("--comfy-ref", default="v0.22.0", help="ComfyUI release to pin")
+    p.add_argument("--playwright", default="1.49.1", help="Playwright version (Dockerfile FROM + package.json)")
+    p.add_argument("--dir", default=".", help="pack repo root (default: cwd)")
+    p.add_argument("--force", action="store_true", help="overwrite an existing screenshots/ dir")
+    args = p.parse_args()
+
+    pack_dir = os.path.abspath(args.dir)
+    if not os.path.isdir(pack_dir):
+        print(f"error: --dir {pack_dir} is not a directory", file=sys.stderr)
+        return 1
+    ss_dir = os.path.join(pack_dir, "screenshots")
+    if os.path.isdir(ss_dir) and not args.force:
+        print(f"error: {ss_dir} already exists (use --force to overwrite)", file=sys.stderr)
+        return 1
+
+    repl = {
+        "PACK": args.name,
+        "OUT": args.out,
+        "COMFY_REF": args.comfy_ref,
+        "PW": args.playwright,
+        "NODE": args.node,
+        "WIDGET": args.widget,
+        "FLAG": args.flag,
+        "READY": args.ready,
+        "SEED_BLOCK": SEED_BLOCK if args.seed_models else "",
+    }
+
+    print(f"Generating screenshots/ for {args.name} (variant={args.variant})")
+    write(os.path.join(ss_dir, "Dockerfile.dockerignore"), DOCKERIGNORE)
+    write(os.path.join(ss_dir, "entrypoint.sh"), ENTRYPOINT, executable=True)
+    write(os.path.join(ss_dir, "package.json"), render(PACKAGE_JSON, repl))
+    write(os.path.join(ss_dir, "Dockerfile"), render(DOCKERFILE, repl))
+    write(os.path.join(ss_dir, "workflow.json"), render(pick_workflow(args.variant, args.node), repl))
+    write(os.path.join(ss_dir, "capture.mjs"), render(pick_capture(args.variant), repl))
+    write(os.path.join(ss_dir, "README.md"), render(README_TMPL, repl))
+    if args.seed_models:
+        write(os.path.join(ss_dir, "seed_models.py"), SEED_MODELS)
+    append_just_recipe(pack_dir, repl)
+
+    print("\nNext steps:")
+    print(f"  1. Tailor screenshots/capture.mjs + workflow.json to {args.name}.")
+    if args.variant == "modal":
+        print(f"     Verify --widget ({args.widget}), --flag ({args.flag}), --ready ({args.ready}) against the pack JS.")
+    print("  2. Iterate fast (mount capture.mjs/workflow.json into the cached image - see screenshots/README.md).")
+    print("  3. just screenshots  -> docs/" + args.out + ", then embed it in the README.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Promotes the **last of the three comfyui project skills** from the laurigates portfolio (`.claude/skills/`, untracked) into `comfyui-plugin` as its canonical, versioned home.

[#1502](https://github.com/laurigates/claude-plugins/pull/1502) promoted `comfy-node` and `comfyui-node-scaffold`; this PR completes the set with `comfyui-screenshot-pipeline` — the containerized README-screenshot generator that `comfyui-node-scaffold` intentionally defers. Resolves the deferred-decision task to make all three skills version-controlled and distributable via the marketplace.

## What's here

New skill `comfyui-plugin/skills/comfyui-screenshot-pipeline/`:

- **SKILL.md** — adds a Docker + Playwright pipeline (pins the ComfyUI release + Chromium revision, boots ComfyUI headless on CPU, drives the pack's real frontend, writes a PNG to `docs/`), a `just screenshots` recipe, and a `capture.mjs` driver matched to the pack archetype — `modal` (widget → HTML dialog), `gesture-affordance` (painted canvas hint), or `gesture-overlay` (synthetic-touch transient overlay). `--seed-models` handles backend model packs whose grid would otherwise render empty.
- **add_screenshots.py** — the stdlib-only generator (998 lines), copied verbatim from the working portfolio skill; `py_compile`-clean.

## Conformance to repo gates

- SKILL.md frontmatter: `allowed-tools`, `created`/`modified`/`reviewed`
- Description trimmed to 194 chars (≤200 ceiling)
- Added the `## When to Use This Skill` decision table
- Script examples reference `${CLAUDE_SKILL_DIR}` (the documented bundled-script form, correct after the local copies are deleted)
- Registered the new capability across `marketplace.json` + `plugin.json` (keywords `screenshots`, `playwright`; description note)

## Verification

- `scripts/plugin-compliance-check.sh comfyui-plugin` — ✅ (new skill ✅ on every axis; the only ⚠️ is the pre-existing 302-line advisory on `comfy-node`, carried from #1502)
- `scripts/audit-skill-descriptions.py --strict-length` — exit 0
- `scripts/check-docs-index.sh` — `STATUS=OK`, `ISSUE_COUNT=0`
- All pre-commit hooks pass on the commit
- `add_screenshots.py` compiles

## Follow-up

After merge + `comfyui-plugin` enabled in the relevant project settings, the duplicate local skill dir `repos/laurigates/.claude/skills/comfyui-screenshot-pipeline` can be removed (tracked alongside the existing cleanup task for `comfy-node` / `comfyui-node-scaffold`).

Refs #1502

🤖 Generated with [Claude Code](https://claude.com/claude-code)