### PR TITLE
fix(repo): refresh stale plugin/skill counts in maps and guard them against drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Plugins
 
-A curated collection of 38 Claude Code plugins providing 300+ skills and 14 agents for development workflows.
+A curated collection of 41 Claude Code plugins providing 300+ skills and 21 agents for development workflows.
 
 ## Install the Marketplace
 
@@ -10,7 +10,7 @@ Install the full plugin collection as a marketplace:
 claude plugin install laurigates/claude-plugins
 ```
 
-This registers all 38 plugins. You can then enable individual plugins as needed.
+This registers all 41 plugins. You can then enable individual plugins as needed.
 
 ### Install Individual Plugins
 
@@ -60,8 +60,8 @@ Alternatively, use the `/configure:mcp` skill for interactive configuration.
 
 | Plugin | Skills | Description |
 |--------|--------|-------------|
-| **agent-patterns-plugin** | 16 | Multi-agent coordination and orchestration patterns |
-| **agents-plugin** | 1 + 10 agents | Task-focused agents for test, review, debug, docs, and CI workflows |
+| **agent-patterns-plugin** | 12 | Multi-agent coordination and orchestration patterns |
+| **agents-plugin** | 1 + 12 agents | Task-focused agents for test, review, debug, docs, and CI workflows |
 | **langchain-plugin** | 4 | LangChain JS/TS development - agents, chains, LangGraph, Deep Agents |
 | **prompt-engineering-plugin** | 1 | Prompt engineering for accurate, grounded responses - anti-hallucination workflow |
 
@@ -70,17 +70,18 @@ Alternatively, use the `/configure:mcp` skill for interactive configuration.
 | Plugin | Skills | Description |
 |--------|--------|-------------|
 | **api-plugin** | 2 | API integration and testing - REST endpoints, client generation |
-| **blueprint-plugin** | 30 | Blueprint Development methodology - PRD/PRP workflow with version tracking |
+| **blueprint-plugin** | 33 | Blueprint Development methodology - PRD/PRP workflow with version tracking |
+| **comfyui-plugin** | 2 | ComfyUI custom-node pack lifecycle - scaffold, seed repo, gitops adoption, registry publish |
 | **home-assistant-plugin** | 4 | Home Assistant configuration - automations, scripts, scenes, entities |
-| **obsidian-plugin** | 6 | Obsidian CLI operations - vault management, search, properties, tasks |
-| **project-plugin** | 6 | Project initialization, management, maintenance, and continuous development |
+| **obsidian-plugin** | 21 | Obsidian CLI operations - vault management, search, properties, tasks |
+| **project-plugin** | 7 | Project initialization, management, maintenance, and continuous development |
 
 ### Languages
 
 | Plugin | Skills | Description |
 |--------|--------|-------------|
 | **css-plugin** | 2 | CSS tooling - Lightning CSS transpilation, UnoCSS atomic utilities |
-| **python-plugin** | 17 | Python ecosystem - uv, ruff, pytest, basedpyright, packaging |
+| **python-plugin** | 16 | Python ecosystem - uv, ruff, pytest, basedpyright, packaging |
 | **rust-plugin** | 5 | Rust development - cargo, clippy, nextest, memory safety |
 | **typescript-plugin** | 17 | TypeScript development - Bun, Biome, ESLint, strict types |
 
@@ -88,17 +89,17 @@ Alternatively, use the `/configure:mcp` skill for interactive configuration.
 
 | Plugin | Skills | Description |
 |--------|--------|-------------|
-| **code-quality-plugin** | 13 | Code review, refactoring, linting, static analysis, debugging methodology |
+| **code-quality-plugin** | 14 | Code review, refactoring, linting, static analysis, debugging methodology |
 | **evaluate-plugin** | 4 + 3 agents | Skill evaluation and benchmarking - test effectiveness, grade results |
 | **codebase-attributes-plugin** | 3 | Structured codebase health attributes with severity-based agent routing |
 | **feedback-plugin** | 1 | Session feedback analysis - capture skill bugs and enhancements as issues |
-| **testing-plugin** | 15 | Test execution, TDD workflow, Vitest, Playwright, mutation testing |
+| **testing-plugin** | 16 | Test execution, TDD workflow, Vitest, Playwright, mutation testing |
 
 ### Version Control
 
 | Plugin | Skills | Description |
 |--------|--------|-------------|
-| **git-plugin** | 27 + 1 agent | Git workflows - commits, branches, PRs, worktrees, release-please |
+| **git-plugin** | 35 + 1 agent | Git workflows - commits, branches, PRs, worktrees, release-please |
 
 ### CI/CD
 
@@ -111,10 +112,10 @@ Alternatively, use the `/configure:mcp` skill for interactive configuration.
 
 | Plugin | Skills | Description |
 |--------|--------|-------------|
-| **configure-plugin** | 42 | Project infrastructure standards - pre-commit, CI/CD, Docker, testing |
+| **configure-plugin** | 46 | Project infrastructure standards - pre-commit, CI/CD, Docker, testing |
 | **container-plugin** | 9 + 1 agent | Container development - Docker, registry, Skaffold, OrbStack |
 | **kubernetes-plugin** | 8 + 1 agent | Kubernetes and Helm - deployments, charts, releases, ArgoCD |
-| **migration-patterns-plugin** | 2 | Safe database and system migration - dual write, shadow mode |
+| **migration-patterns-plugin** | 6 | Safe database and system migration - dual write, shadow mode |
 | **networking-plugin** | 6 | Network diagnostics, discovery, monitoring, HTTP load testing |
 | **terraform-plugin** | 6 + 1 agent | Terraform and Terraform Cloud - infrastructure as code |
 
@@ -138,11 +139,12 @@ Alternatively, use the `/configure:mcp` skill for interactive configuration.
 
 | Plugin | Skills | Description |
 |--------|--------|-------------|
-| **command-analytics-plugin** | 4 | Track command and skill usage analytics across projects |
-| **health-plugin** | 6 | Diagnose and fix Claude Code configuration issues |
-| **hooks-plugin** | 1 | Claude Code hooks for enforcing best practices |
+| **health-plugin** | 7 | Diagnose and fix Claude Code configuration issues |
+| **hooks-plugin** | 4 | Claude Code hooks for enforcing best practices |
+| **macos-plugin** | 4 | macOS dev tooling - kitty session persistence, LaunchServices health, incident postmortems |
+| **taskwarrior-plugin** | 6 | Taskwarrior coordination for multi-agent work - parallel-safe queries, urgency scoring |
 | **tools-plugin** | 14 | General utilities - fd, rg, jq, shell, ImageMagick, d2 |
-| **workflow-orchestration-plugin** | 2 | Workflow orchestration - preflight checks, checkpoint refactoring |
+| **workflow-orchestration-plugin** | 3 | Workflow orchestration - preflight checks, checkpoint refactoring |
 
 ### Game Development
 

--- a/docs/PLUGIN-MAP.md
+++ b/docs/PLUGIN-MAP.md
@@ -22,10 +22,10 @@ Install these first. They configure the environment other plugins rely on.
 
 | Plugin | Skills | Purpose |
 |--------|--------|---------|
-| health-plugin | 6 | Diagnose config issues, audit plugin selection |
-| hooks-plugin | 1 | Enforce best practices via lifecycle hooks |
-| configure-plugin | 43 | Infrastructure standards (CI, linting, testing, Docker, repo onboarding) |
-| agent-patterns-plugin | 17 | Agent orchestration, MCP management, delegation |
+| health-plugin | 7 | Diagnose config issues, audit plugin selection |
+| hooks-plugin | 4 | Enforce best practices via lifecycle hooks |
+| configure-plugin | 46 | Infrastructure standards (CI, linting, testing, Docker, repo onboarding) |
+| agent-patterns-plugin | 12 | Agent orchestration, MCP management, delegation |
 
 ### Tier 1 - Core Workflow
 
@@ -33,10 +33,10 @@ The development loop: plan, code, commit, ship.
 
 | Plugin | Skills | Purpose |
 |--------|--------|---------|
-| blueprint-plugin | 35 | PRD/ADR/PRP/TRP methodology, `/blueprint:execute` auto-pilot, monorepo portfolio tracking, story-audit/reconcile |
-| git-plugin | 32 + 1 agent | Commits, branches, PRs, issues, forks, worktrees, release-please |
-| project-plugin | 6 | Project init, modernization, maintenance |
-| agents-plugin | 1 + 10 agents | Task delegation to specialized agents |
+| blueprint-plugin | 33 | PRD/ADR/PRP/TRP methodology, `/blueprint:execute` auto-pilot, monorepo portfolio tracking, story-audit/reconcile |
+| git-plugin | 35 + 1 agent | Commits, branches, PRs, issues, forks, worktrees, release-please |
+| project-plugin | 7 | Project init, modernization, maintenance |
+| agents-plugin | 1 + 12 agents | Task delegation to specialized agents |
 
 ### Tier 2 - Quality Gates
 
@@ -45,7 +45,7 @@ Automated quality enforcement.
 | Plugin | Skills | Purpose |
 |--------|--------|---------|
 | testing-plugin | 16 | Test execution, TDD, Vitest, Playwright, Playwright CLI, mutation testing |
-| code-quality-plugin | 18 | Review, refactoring, linting, ast-grep, debugging, silent degradation, dead code, dep audit, test quality, complexity |
+| code-quality-plugin | 14 | Review, refactoring, linting, ast-grep, debugging, silent degradation, dead code, dep audit, test quality, complexity |
 | documentation-plugin | 5 | API docs, README generation, knowledge graphs |
 | evaluate-plugin | 4 + 3 agents | Skill evaluation, benchmarking, quality improvement |
 

--- a/scripts/check-docs-index.sh
+++ b/scripts/check-docs-index.sh
@@ -105,6 +105,81 @@ done <<< "$mkt_set"
 
 mkt_count="$(printf '%s\n' "$mkt_set" | grep -c . || true)"
 
+# --- Check 3: per-plugin skill/agent counts in README + PLUGIN-MAP -------------
+# Each plugin's skill count = number of skill.md files (case-insensitive) under
+# <plugin>/skills/; agent count = *.md files under <plugin>/agents/. The README
+# and PLUGIN-MAP tables state these as `| **name** | N |` or `| name | N + M
+# agent(s) |`. Zero-false-positive: only a table row whose FIRST cell is exactly
+# the plugin name (optionally bold) and whose count cell starts with an integer
+# is compared. Rows a doc omits (PLUGIN-MAP only covers the tier plugins) are
+# skipped, not flagged.
+readme_md="$proj_dir/README.md"
+
+skill_count() { find "$proj_dir/$1/skills" -iname 'skill.md' 2>/dev/null | grep -c . || true; }
+agent_count() { find "$proj_dir/$1/agents" -name '*.md' -type f 2>/dev/null | grep -c . || true; }
+
+# stated_rows <file> <plugin-name> -> emits "<lineno> <skills> <agents|-1>" per
+# matching first-cell row (agents=-1 when the cell states no agent count).
+stated_rows() {
+  awk -v name="$2" -F'|' '
+    NF < 3 { next }
+    {
+      cell = $2
+      gsub(/^[ \t]+|[ \t]+$/, "", cell)
+      gsub(/\*\*/, "", cell)
+      if (cell != name) next
+      cnt = $3
+      gsub(/^[ \t]+|[ \t]+$/, "", cnt)
+      if (!match(cnt, /^[0-9]+/)) next
+      sk = substr(cnt, 1, RLENGTH)
+      ag = -1
+      if (match(cnt, /\+[ ]*[0-9]+[ ]*agent/)) {
+        a = substr(cnt, RSTART, RLENGTH); gsub(/[^0-9]/, "", a); ag = a
+      }
+      print FNR, sk, ag
+    }
+  ' "$1"
+}
+
+total_skills=0
+total_agents=0
+while IFS= read -r p; do
+  [ -n "$p" ] || continue
+  cs="$(skill_count "$p")"
+  ca="$(agent_count "$p")"
+  total_skills=$((total_skills + cs))
+  total_agents=$((total_agents + ca))
+  for doc in "$readme_md" "$plugin_map"; do
+    [ -f "$doc" ] || continue
+    docname="$(basename "$doc")"
+    while read -r lineno st_sk st_ag; do
+      [ -n "$st_sk" ] || continue
+      if [ "$st_sk" -ne "$cs" ]; then
+        add_issue WARN doc_count_drift "$docname:$lineno states $p has $st_sk skills but $cs exist on disk"
+      fi
+      if [ "$st_ag" -ne -1 ] && [ "$st_ag" -ne "$ca" ]; then
+        add_issue WARN doc_count_drift "$docname:$lineno states $p has $st_ag agents but $ca exist on disk"
+      fi
+    done <<< "$(stated_rows "$doc" "$p")"
+  done
+done <<< "$disk_set"
+
+# Headline totals in README intro ("N Claude Code plugins ... and M agents").
+if [ -f "$readme_md" ]; then
+  hp="$(grep -oE '[0-9]+ Claude Code plugins' "$readme_md" | head -1 | grep -oE '^[0-9]+' || true)"
+  if [ -n "$hp" ] && [ "$hp" -ne "$mkt_count" ]; then
+    add_issue WARN doc_count_drift "README.md headline states $hp plugins but marketplace lists $mkt_count"
+  fi
+  ha="$(grep -oE 'and [0-9]+ agents' "$readme_md" | head -1 | grep -oE '[0-9]+' || true)"
+  if [ -n "$ha" ] && [ "$ha" -ne "$total_agents" ]; then
+    add_issue WARN doc_count_drift "README.md headline states $ha agents but $total_agents exist on disk"
+  fi
+  hsfloor="$(grep -oE '[0-9]+\+ skills' "$readme_md" | head -1 | grep -oE '^[0-9]+' || true)"
+  if [ -n "$hsfloor" ] && [ "$total_skills" -lt "$hsfloor" ]; then
+    add_issue WARN doc_count_drift "README.md headline claims ${hsfloor}+ skills but only $total_skills exist on disk"
+  fi
+fi
+
 # --- Status -------------------------------------------------------------------
 overall_status="OK"
 exit_severity=0
@@ -140,6 +215,8 @@ else
   echo "RULES_ON_DISK=$rules_disk_count"
   echo "RULES_IN_TABLE=$rules_table_count"
   echo "MARKETPLACE_PLUGINS=$mkt_count"
+  echo "TOTAL_SKILLS=$total_skills"
+  echo "TOTAL_AGENTS=$total_agents"
   echo "STATUS=$overall_status"
   echo "ISSUE_COUNT=$issue_count"
   if [ "$issue_count" -gt 0 ]; then

--- a/scripts/tests/test-check-docs-index.sh
+++ b/scripts/tests/test-check-docs-index.sh
@@ -7,6 +7,8 @@
 #   B. an unindexed rule is flagged (WARN rule_not_indexed)
 #   C. a plugin present in marketplace.json but missing on disk is flagged
 #      (ERROR plugin_map_drift) and --strict exits non-zero
+#   D. a README table row stating the wrong skill count is flagged
+#      (WARN doc_count_drift); a correct row is NOT flagged (zero false positive)
 set -uo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -63,6 +65,25 @@ cat > "$fixture/.release-please-manifest.json" <<'EOF'
 EOF
 printf '# Map\nalpha-plugin, beta-plugin, gamma-plugin\n' > "$fixture/docs/PLUGIN-MAP.md"
 
+# alpha-plugin: 2 skills (mixed SKILL.md / skill.md) + 1 agent; beta-plugin: 1 skill, 0 agents
+mkdir -p "$fixture/alpha-plugin/skills/s1" "$fixture/alpha-plugin/skills/s2" \
+  "$fixture/alpha-plugin/agents" "$fixture/beta-plugin/skills/s1"
+printf '# s\n' > "$fixture/alpha-plugin/skills/s1/SKILL.md"
+printf '# s\n' > "$fixture/alpha-plugin/skills/s2/skill.md"
+printf '# a\n' > "$fixture/alpha-plugin/agents/a1.md"
+printf '# s\n' > "$fixture/beta-plugin/skills/s1/skill.md"
+
+# README states a wrong count for alpha (5, actual 2), a correct one for beta (1),
+# and wrong headline totals (2 plugins / 21 agents; actual 3 / 1).
+cat > "$fixture/README.md" <<'EOF'
+A curated collection of 2 Claude Code plugins providing 300+ skills and 21 agents for development workflows.
+
+| Plugin | Skills | Description |
+|--------|--------|-------------|
+| **alpha-plugin** | 5 | wrong skill count |
+| **beta-plugin** | 1 | correct skill count |
+EOF
+
 echo "=== TEST B: unindexed rule flagged ==="
 fx_out="$(bash "$checker" --project-dir "$fixture")"
 assert "orphan.md should be flagged rule_not_indexed" "$(contains "$fx_out" "rule_not_indexed.*orphan.md")"
@@ -78,6 +99,16 @@ assert "--strict should exit 1 on ERROR drift" "$([ "$strict_rc" -eq 1 ] && echo
 clean_rc=0
 bash "$checker" --project-dir "$repo_root" --strict >/dev/null || clean_rc=$?
 assert "--strict should exit 0 on clean repo" "$([ "$clean_rc" -eq 0 ] && echo true || echo false)"
+
+echo "=== TEST D: per-plugin count drift flagged, correct row not flagged ==="
+assert "alpha-plugin wrong skill count should be flagged doc_count_drift" \
+  "$(contains "$fx_out" "doc_count_drift.*alpha-plugin has 5 skills but 2")"
+assert "beta-plugin correct count should NOT be flagged" \
+  "$([ "$(contains "$fx_out" "doc_count_drift.*beta-plugin")" = "false" ] && echo true || echo false)"
+assert "README headline plugin-count drift should be flagged" \
+  "$(contains "$fx_out" "doc_count_drift.*headline states 2 plugins")"
+assert "README headline agent-count drift should be flagged" \
+  "$(contains "$fx_out" "doc_count_drift.*headline states 21 agents")"
 
 echo ""
 echo "=== SUMMARY ==="


### PR DESCRIPTION
## What

Refreshes the stale plugin/skill counts in the two top-level navigation maps (`README.md`, `docs/PLUGIN-MAP.md`) and extends `scripts/check-docs-index.sh` so this class of drift is caught automatically going forward.

This is **Layer 2 (content currency)** work from #1460. The existing Layer 1 audit verified the rules index and the plugin *set*, but nothing validated the *counts* the maps advertise — so they had quietly drifted.

## Drift found (all objective, verified against disk)

- **README headline**: said "38 plugins … 14 agents"; actual **41 plugins, 21 agents** (skills "300+" stays accurate — 351).
- **README plugin set**: listed the removed `command-analytics-plugin` and omitted three live plugins — `comfyui-plugin`, `macos-plugin`, `taskwarrior-plugin`. README now lists all 41.
- **Per-plugin skill counts**: ~15 stale across the two maps, which also disagreed with each other, e.g.

  | plugin | README was | PLUGIN-MAP was | actual |
  |---|---|---|---|
  | git-plugin | 27 | 32 | **35** |
  | agent-patterns | 16 | 17 | **12** |
  | configure | 42 | 43 | **46** |
  | obsidian | 6 | — | **21** |
  | blueprint | 30 | 35 | **33** |
  | code-quality | 13 | 18 | **14** |

  (full set corrected in both files)

## Guard added (so it can't silently recur)

`check-docs-index.sh` gains **Check 3**: for every plugin on disk it compares the skill/agent counts stated in README and PLUGIN-MAP tables, plus the README headline plugin/agent totals, against the files on disk. Counting is case-insensitive (`skill.md`/`SKILL.md`). Zero-false-positive: only a table row whose first cell is exactly a plugin name and whose count cell starts with an integer is compared; rows a map omits (PLUGIN-MAP only covers the tier plugins) are skipped. New `TOTAL_SKILLS` / `TOTAL_AGENTS` keys are emitted.

This audit is already wired into `scheduled-audits.yml` (weekly) — the goal #1460 named as "make Layer 1 recurring".

The guard immediately earned its keep: it flagged my own off-by-one on `comfyui-plugin` (this PR branches off `main`, which doesn't yet include the comfyui-screenshot-pipeline skill from #1521, so the count is 2 here).

## Tests

`scripts/tests/test-check-docs-index.sh` gains **TEST D**: a wrong count is flagged (`doc_count_drift`) and a correct count is not (zero-false-positive guard). All 11 assertions pass; `shellcheck` clean; repo shell lint clean.

## Out of scope (follow-ups)

`command-analytics-plugin` is also referenced in historical/generated docs that are *not* the live navigation maps and are deliberately left for separate handling:
- `docs/adrs/0015-agent-teams-adoption.md`, `docs/prps/agent-teams-migration.md` — point-in-time records, shouldn't be rewritten.
- `docs/diagrams/plugin-relationships.d2` / `.svg` — generated; the diagram also carries the same stale counts and needs a `d2` re-render.
- `docs/migration-commands-to-skills.md` — #1460 already names this an archival candidate.

These, plus the judgment-based remainder of Layer 2, stay tracked under #1460.

Refs #1460

🤖 Generated with [Claude Code](https://claude.com/claude-code)