### PR TITLE
ci: add shared clear-autorelease-labels workflow caller

### DIFF
--- a/.github/workflows/clear-autorelease-labels.yml
+++ b/.github/workflows/clear-autorelease-labels.yml
@@ -1,0 +1,29 @@
+name: "Maintenance: clear autorelease labels"
+
+# Thin caller for the org reusable workflow. See
+# laurigates/.github/.github/workflows/reusable-clear-autorelease-labels.yml
+# for what this does and when to run it (manual escape hatch for a clogged
+# release-please pipeline).
+
+on:
+  workflow_dispatch:
+    inputs:
+      label:
+        description: "Label to strip from closed PRs"
+        default: "autorelease: pending"
+        required: false
+      dry_run:
+        description: "List matches without removing the label"
+        type: boolean
+        default: false
+
+jobs:
+  clear-labels:
+    uses: laurigates/.github/.github/workflows/reusable-clear-autorelease-labels.yml@main
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    with:
+      label: ${{ inputs.label }}
+      dry_run: ${{ inputs.dry_run }}


### PR DESCRIPTION
Adds a thin `workflow_dispatch` caller delegating to the org reusable workflow `laurigates/.github/.github/workflows/reusable-clear-autorelease-labels.yml@main`.

Manual escape hatch for a clogged release-please pipeline: strips a stale `autorelease: pending` label from closed PRs so release-please can move on after a failed release/tag step. Part of rolling this out to all `release_please = true` repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)