### PR TITLE
feat(comfyui-plugin): scaffold TypeScript + bun build packs (consume comfy-modal-kit)

### DIFF
--- a/comfyui-plugin/README.md
+++ b/comfyui-plugin/README.md
@@ -16,20 +16,32 @@ via Scalr), and adding a reproducible README-screenshot pipeline to a pack.
 
 ### comfyui-node-scaffold
 
-Scaffold a new ComfyUI custom-node repository ready for implementation:
+Scaffold a new ComfyUI custom-node repository ready for implementation, in the
+**TypeScript + bun build** architecture (source in `src/`, built to `web/dist/`):
 
-- `pyproject.toml` with Comfy Registry metadata
-- CI + release-please + publish GitHub Actions
-- ruff / biome / pre-commit config
-- vitest + pytest harness
-- `__init__.py`, `CLAUDE.md`, and a JS extension skeleton
+- `pyproject.toml` with Comfy Registry metadata (`[tool.comfy] includes =
+  ["web/dist"]` force-ships the built output)
+- CI + release-please + publish GitHub Actions (CI runs `tsc` + `bun build`;
+  `publish.yml` builds before publishing)
+- strict `tsconfig.json` + ruff / biome / knip / pre-commit config
+- vitest (imports the `.ts` source) + pytest harness
+- `src/index.ts` + `src/comfyui-shims.d.ts`, `__init__.py`
+  (`WEB_DIRECTORY = "./web/dist"`), `CLAUDE.md`, and a migration ADR
 - Three variants: `frontend` (per-widget modal), `backend` (adds a node +
   aiohttp endpoints), `gesture` (canvas pointer layer — pinch/drag)
+
+The `frontend`/`backend` (modal) variants consume the shared
+[`@laurigates/comfy-modal-kit`](https://www.npmjs.com/package/@laurigates/comfy-modal-kit)
+primitives via an `import` (inlined by `bun build`) — they no longer copy
+`modal-shell.js` / `modal-fuzzy.js` in. The `gesture` variant has no kit
+dependency.
 
 The generated `CLAUDE.md` teaches the pack to **verify the LiteGraph/canvas API
 against the frontend sourcemap** (the `api-*.js.map` chunk) before coding against
 the minified frontend — names are renamed in the bundle, so `instanceof` and
-guessed property names are unreliable.
+guessed property names are unreliable. Static types from
+`@comfyorg/comfyui-frontend-types` cover the seam `ComfyApp`; the un-exported
+internals are modelled with local structural interfaces.
 
 **Use when** bootstrapping / init-ing a new ComfyUI node pack repo.
 

--- a/comfyui-plugin/skills/comfyui-node-scaffold/SKILL.md
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/SKILL.md
@@ -1,11 +1,11 @@
 ---
 created: 2026-06-04
-modified: 2026-06-04
-reviewed: 2026-06-04
+modified: 2026-06-06
+reviewed: 2026-06-06
 name: comfyui-node-scaffold
 description: >-
-  Scaffold a new ComfyUI custom-node repo (pyproject, CI, release-please,
-  vitest+pytest, JS extension skeleton) in the picker/gesture vein. Use when
+  Scaffold a new ComfyUI custom-node repo (TypeScript + bun build, CI,
+  release-please, vitest+pytest) consuming @laurigates/comfy-modal-kit. Use when
   bootstrapping or init-ing a comfyui node pack.
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 ---
@@ -13,95 +13,117 @@ allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 # comfyui-node-scaffold
 
 Bootstrap a new ComfyUI custom-node pack that matches the established
-mobile-first architecture of `comfyui-gallery-loader` and
-`comfyui-sampler-info`, leaving only the actual node logic to implement.
+mobile-first **TypeScript + bun build** architecture of `comfyui-gallery-loader`,
+`comfyui-sampler-info`, and `comfyui-touch-numeric`, leaving only the actual
+node logic to implement.
 
 ## When to Use This Skill
 
 | Use this skill when... | Use the alternative when... |
 |---|---|
-| Starting a new ComfyUI usability pack repo — CI-green tooling, Comfy Registry publish, and the widget-intercept/gesture skeleton before writing pack logic | You want the full pipeline (repo created + seeded + gitops-adopted) → `comfy-node` |
+| Starting a new ComfyUI usability pack repo — CI-green TS toolchain, Comfy Registry publish, and the widget-intercept/gesture skeleton before writing pack logic | You want the full pipeline (repo created + seeded + gitops-adopted) → `comfy-node` |
 | Spinning up a `project:comfyui-nodes` backlog idea (touch-numeric, prompt-editor, model-gallery…) | Adding a node to an *existing* pack — this creates a **new** repo |
 
-## The pattern it scaffolds ("the vein")
+## The architecture it scaffolds
 
-A frontend JS extension that intercepts `widget.onPointerDown` (modern Vue
+**TypeScript source in `src/` (entry `src/index.ts`), built to `web/dist/` via
+`bun build`** — typed authoring against `@comfyorg/comfyui-frontend-types`,
+browser-ESM output, the `/scripts/app.js` runtime import left unbundled. This
+supersedes the old vanilla-JS (`web/js/*.js` + copied modal primitives)
+template. The generated pack starts with an ADR (`docs/blueprint/adrs/0001-…`)
+recording the decision, mirroring sampler-info's ADR-0010.
+
+- **Type gate**: `bun run typecheck` → `tsc --noEmit` (never emits).
+- **Emit**: `bun build ./src/index.ts --target browser --format esm --outdir
+  web/dist --external '/scripts/*'`. If the pack ships a static data corpus,
+  append `&& cp -R web/data web/dist/data`.
+- **Serve**: `__init__.py` sets `WEB_DIRECTORY = "./web/dist"`; ComfyUI serves
+  that tree at `/extensions/<name>/`.
+- **Distribute**: `web/dist/` is git-ignored; `[tool.comfy] includes =
+  ["web/dist"]` force-ships it, and `publish.yml` runs `bun run build` first.
+- **The `/scripts/app.js` type shim**: a `paths` mapping in `tsconfig.json`
+  points the rooted import at `src/comfyui-shims.d.ts` (TypeScript will not
+  match an ambient `declare module` against a `/…` specifier). The emitted
+  import string stays `/scripts/app.js` and `--external '/scripts/*'` keeps it
+  unbundled.
+
+## The vein
+
+A frontend extension that intercepts `widget.onPointerDown` (modern Vue
 frontend, `comfyui-frontend-package >= 1.40`) and opens a touch-friendly HTML
 modal in place of a clunky native LiteGraph control. Widgets are matched **by
 name** (generic across node packs); the enhancement is **additive** (graceful
-fallback, never breaks serialized workflows); the modal is **touch-first**
-(16px inputs, big tap targets, momentum scroll). Reuses `modal-shell.js`
-(`openModalShell` / `closeModalShell`) and `modal-fuzzy.js` (`fuzzyScore` /
-`fuzzyRank` / `highlightMatches`).
+fallback, never breaks serialized workflows); the modal is **touch-first** (16px
+inputs, big tap targets, momentum scroll). The modal primitives come from
+`@laurigates/comfy-modal-kit` (`openModalShell` / `fuzzyRank` /
+`highlightMatches`) — **imported, not copied** — and `bun build` inlines them.
 
 ## Three variants
 
-| Variant | Use when | Shape |
-|---------|----------|-------|
-| `frontend` (default) | No Python needed — pure widget UX (seed/numeric keypad, prompt editor, tooltips, enum recipes). | Empty `NODE_CLASS_MAPPINGS`; everything in `web/js/`. Widget-intercept modal vein. Like sampler-info. |
-| `backend` | Needs to read disk / serve thumbnails / add a node (model thumbnails, file listings). | Adds `<module>.py` with a node + aiohttp endpoints (ComfyUI-bundled libs only) and an extension-whitelist gate. Like gallery-loader. |
-| `gesture` | The UX is a **canvas interaction**, not a widget — pinch/drag/long-press on nodes or groups (resize, move, region-box). | Empty `NODE_CLASS_MAPPINGS`; a canvas pointer layer in `web/js/`. No modal primitives copied. Exported pure geometry helpers + unit tests. |
+| Variant | Use when | Shape | Modal kit |
+|---------|----------|-------|-----------|
+| `frontend` (default) | No Python needed — pure widget UX (seed/numeric keypad, prompt editor, tooltips, enum recipes). | Empty `NODE_CLASS_MAPPINGS`; widget-intercept modal in `src/index.ts`. Like sampler-info / touch-numeric. | **imports** the kit |
+| `backend` | Needs to read disk / serve thumbnails / add a node (model thumbnails, file listings). | Adds `<module>.py` (node + aiohttp endpoints, ComfyUI-bundled libs only) + a `tests/conftest.py` that stubs aiohttp/server so pytest is green. Like gallery-loader. | **imports** the kit |
+| `gesture` | The UX is a **canvas interaction**, not a widget — pinch/drag/long-press on nodes or groups (resize, move, region-box). | Empty `NODE_CLASS_MAPPINGS`; a canvas pointer layer in `src/index.ts` with exported pure geometry helpers. Like touch-resize. | **no kit** |
 
-**Decision rule:** pick `frontend` for a per-widget modal; pick `gesture` when
-the interaction is on the canvas/node frame itself (no widget to hook); pick
-`backend` only when the feature genuinely needs the server to read files or
-serve data. A non-bundled Python dependency is never allowed — if you reach for
-one, it belongs in a separate companion pack.
+**Decision rule:** `frontend` for a per-widget modal; `gesture` when the
+interaction is on the canvas/node frame itself (no widget to hook); `backend`
+only when the feature genuinely needs the server to read files or serve data. A
+non-bundled Python dependency is never allowed — if you reach for one, it
+belongs in a separate companion pack.
 
 The `gesture` variant intercepts the **canvas pointer stream** (capture-phase
 `pointerdown`/`move`/`up` on `app.canvas.canvas`), hit-tests against selected
 nodes/groups in screen space (via `ds.scale`/`ds.offset`), and acts only when
-the gesture lands on a selected target — suppressing the native canvas
-pan/zoom for that gesture. It is a no-op when `app.canvas` is absent, so the
-native control always survives. Pure math (distance, hit-test, scale-clamp)
-lives in exported, unit-tested helpers; DOM/canvas wiring stays below them.
+the gesture lands on a selected target. It is a no-op when `app.canvas` is
+absent, so the native control always survives. Pure math (distance, hit-test,
+scale-clamp) lives in exported, unit-tested helpers; DOM/canvas wiring stays
+below them. It has **no** `@laurigates/comfy-modal-kit` dependency.
 
 ## How to run
 
-`scaffold.py` is stdlib-only. From the workspace root (`repos/laurigates/`, so
-the new repo lands as a sibling of the reference packs and the modal primitives
-copy cleanly):
+`scaffold.py` is stdlib-only. Run from the workspace root (`repos/laurigates/`)
+so the new repo lands as a sibling of the reference packs.
 
 Frontend-only pack:
 
 ```sh
-python3 .claude/skills/comfyui-node-scaffold/scaffold.py --name comfyui-touch-numeric --display "Touch Numeric" --desc "Touch-friendly keypad + slider modal for seed and INT/FLOAT widgets." --variant frontend --widgets seed,noise_seed,cfg,steps,denoise
+python3 ${CLAUDE_SKILL_DIR}/scaffold.py --name comfyui-touch-numeric --display "Touch Numeric" --desc "Touch-friendly keypad + slider modal for seed and INT/FLOAT widgets." --variant frontend --widgets seed,noise_seed,cfg,steps,denoise
 ```
 
 Pack with a Python backend:
 
 ```sh
-python3 .claude/skills/comfyui-node-scaffold/scaffold.py --name comfyui-model-gallery --display "Model Gallery" --desc "Touch-first card-grid picker for the folder-backed model combos." --variant backend --widgets lora_name,ckpt_name,vae_name,control_net_name
+python3 ${CLAUDE_SKILL_DIR}/scaffold.py --name comfyui-model-gallery --display "Model Gallery" --desc "Touch-first card-grid picker for the folder-backed model combos." --variant backend --widgets lora_name,ckpt_name,vae_name,control_net_name
 ```
 
-Canvas-gesture pack (resize/move/region — no widget, no modal):
+Canvas-gesture pack (resize/move/region — no widget, no modal, no kit):
 
 ```sh
-python3 .claude/skills/comfyui-node-scaffold/scaffold.py --name comfyui-touch-resize --display "Touch Resize" --desc "Selection-gated pinch-to-resize for ComfyUI nodes and groups on touch devices." --variant gesture
+python3 ${CLAUDE_SKILL_DIR}/scaffold.py --name comfyui-touch-resize --display "Touch Resize" --desc "Selection-gated pinch-to-resize for ComfyUI nodes and groups on touch devices." --variant gesture
 ```
 
 Flags: `--name` (repo + served URL segment), `--display` (Comfy DisplayName),
-`--desc`, `--variant {frontend,backend,gesture}`, `--widgets` (CSV → the JS
+`--desc`, `--variant {frontend,backend,gesture}`, `--widgets` (CSV → the TS
 stub's `TARGET_WIDGETS`; modal variants only), `--publisher` (default
-`laurigates`), `--dir` (parent dir, default cwd), `--modal-source` (pack to copy
-`modal-shell.js`/`modal-fuzzy.js` from; default `<parent>/comfyui-gallery-loader`;
-`none` to skip — the `gesture` variant defaults to `none`).
+`laurigates`), `--dir` (parent dir, default cwd).
 
 It refuses to overwrite an existing directory.
 
 ## What you get
 
-A repo where `just check` (ruff + biome + pytest + vitest) passes from the first
-commit, with: `pyproject.toml` (`[tool.comfy]` metadata, ruff config, dev deps),
-`.github/workflows/` (`ci.yml`, `publish.yml`, `release-please.yml`),
-`dependabot.yml`, `biome.json`, `.pre-commit-config.yaml`,
+A repo where `just check` (typecheck + build + lint + test) passes from the
+first commit: `pyproject.toml` (`[tool.comfy]` metadata with `includes =
+["web/dist"]`, ruff config, dev deps), `.github/workflows/` (`ci.yml`,
+`publish.yml`, `release-please.yml`), `dependabot.yml`, strict `tsconfig.json`,
+`biome.json`, `knip.json`, `.pre-commit-config.yaml`,
 `release-please-config.json` + manifest, `vitest.config.js`, `package.json`
-(dev-only), `tests/` (a green pytest + vitest smoke test), `__init__.py`, a
-`CLAUDE.md` seeded with the pattern + hard rules, `README`, `LICENSE`,
-`RELEASE-CHECKLIST.md`, the `web/js/<short>.js` extension skeleton with the
-`onPointerDown` interception already wired, and copies of `modal-shell.js` +
-`modal-fuzzy.js`. The `backend` variant additionally gets `<module>.py` (node +
-endpoint + whitelist gate).
+(bun scripts; modal variants add `@laurigates/comfy-modal-kit`), `tests/` (a
+green pytest + vitest smoke test), `src/index.ts` + `src/comfyui-shims.d.ts`,
+`__init__.py` (`WEB_DIRECTORY = "./web/dist"`), `CLAUDE.md`, the migration ADR,
+`README`, `LICENSE`, and `RELEASE-CHECKLIST.md`. The `backend` variant
+additionally gets `<module>.py` (node + endpoint + whitelist gate) and
+`tests/conftest.py` (stubs aiohttp/server).
 
 ## After scaffolding
 
@@ -111,7 +133,7 @@ The generator prints the exact next steps. In order:
 cd comfyui-<name>
 git init -b main
 uv sync --group dev
-npm install --no-audit --no-fund
+bun install
 pre-commit install
 just check
 ```
@@ -122,55 +144,68 @@ a feature branch first would leave `main` missing on origin and force a rename
 
 Then implement, and wire up infra:
 
-1. **Implement the modal** in `web/js/<short>.js` — tune `TARGET_WIDGETS` and
-   replace the `openPicker` stub with the real modal body (use `fuzzyRank` for
-   search, `openModalShell` for the dialog). For the `backend` variant, fill in
-   `<module>.py`'s node + endpoints; widen `ALLOWED_EXTENSIONS` explicitly for
-   any new file type read off disk.
+1. **Implement the modal** in `src/index.ts` — tune `TARGET_WIDGETS` and replace
+   the `openPicker` stub with the real modal body (`import { fuzzyRank } from
+   "@laurigates/comfy-modal-kit"` for search, `openModalShell` for the dialog).
+   For the `backend` variant, fill in `<module>.py`'s node + endpoints; widen
+   `ALLOWED_EXTENSIONS` explicitly for any new file type read off disk. For the
+   `gesture` variant, tune the pinch layer
+   (`selectedNodes`/`nodeScreenRect`/`scaledSize`).
 2. **Add the repo to `gitops/repositories.tf`** with `comfy_registry = true`
-   (and `release_please = true`) — repos are managed via OpenTofu/Scalr, *not*
-   the GitHub UI (see `laurigates/CLAUDE.md` and `gitops/CLAUDE.md`). On apply,
-   gitops pushes both the release-please App credentials **and** the
-   `REGISTRY_ACCESS_TOKEN` secret (from the Scalr `comfy_registry_token` var).
-   No per-repo secret creation is needed.
+   (and `release_please = true`). On apply, gitops pushes both the release-please
+   App credentials **and** the `REGISTRY_ACCESS_TOKEN` secret. No per-repo secret
+   creation is needed.
 
 **Or skip steps 1–2 entirely:** run the **`/comfy-node`** orchestrator, which
-chains scaffold → `gh repo create` → seed `main` → the gitops PR (entry +
-transient `import` block), stopping at the single human gate (merge the gitops
-PR → Scalr applies).
+chains scaffold → `gh repo create` → seed `main` → the gitops PR.
 
 ## Hard rules baked into the output
 
-- **Pack directory name is part of the served URL** (`/extensions/<name>/js/…`).
-  Don't rename the dir without syncing `EXT_NAME` in the JS.
+- **TypeScript source, bun build.** Author in `src/`; build to `web/dist/`.
+  `tsc --noEmit` checks, `bun build` emits — decoupled. Never hand-edit
+  `web/dist/` (it is generated and git-ignored).
+- **Modal primitives come from `@laurigates/comfy-modal-kit`** (modal variants)
+  — import them; never copy `modal-shell.js`/`modal-fuzzy.js` into the pack.
+  `bun build` inlines the imported code. The gesture variant has no kit.
+- **Pack directory name is part of the served URL** (`/extensions/<name>/index.js`).
 - **No non-bundled Python deps.** `dependencies` is `comfyui-frontend-package`
   only; the backend variant may use ComfyUI-bundled `aiohttp` / `folder_paths` /
   `server` and nothing else.
 - **Additive, never clobbering;** always fall back to the native control.
 - **Never hand-edit `CHANGELOG.md` or the `version` field** — release-please
-  owns them (conventional commits drive the bump).
+  owns them.
 - **Arbitrary-path endpoints gate on an extension whitelist** (backend variant).
 - **`openModalShell` has NO `body` option.** It returns a controller
   (`{ bodyEl, close, setBusy, setStatus, ... }`) whose `bodyEl` starts empty;
   fill it *after* opening (`const m = openModalShell({title}); m.bodyEl.appendChild(el)`).
   Passing `body:` is silently ignored and the dialog renders empty — a bug that
-  **passes green unit tests** because modal builders are DOM-uncovered (it shipped
-  once; the scaffold stub now does it right). Same for `closeModalShell()` vs the
-  controller's `.close()`.
+  **passes green unit tests** because modal builders are DOM-uncovered. The stub
+  does it right.
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Scaffold a frontend pack | `python3 ${CLAUDE_SKILL_DIR}/scaffold.py --name comfyui-X --display "X" --desc "…" --variant frontend --widgets a,b` |
+| Scaffold a gesture pack | `python3 ${CLAUDE_SKILL_DIR}/scaffold.py --name comfyui-X --display "X" --desc "…" --variant gesture` |
+| Verify a generated pack | `cd comfyui-X && bun install && just check` |
 
 ## Notes & deferrals
 
-- The screenshot pipeline (`screenshots/` Docker + Playwright) and the
-  `docs/blueprint/` PRD/ADR set are **not** generated — they are heavy and
-  pack-specific. Add them later (copy `screenshots/` from a reference pack and
-  re-point the Dockerfile COPY target / served URL prefix to the new pack name).
+- The screenshot pipeline (`screenshots/` Docker + Playwright) and the full
+  `docs/blueprint/` PRD/ADR set (beyond the single migration ADR) are **not**
+  generated — they are heavy and pack-specific. Add them later (the
+  `comfyui-screenshot-pipeline` skill wires the screenshots).
 - Action/tool versions in the generated workflows mirror the reference packs as
-  of scaffolding; Dependabot/Renovate will bump them.
-- The JS stub imports only `openModalShell`; add `fuzzyRank` / `highlightMatches`
-  from `./modal-fuzzy.js` when the real modal's search lands.
+  of scaffolding; Dependabot/Renovate will bump them. The biome pin is
+  single-sourced in `scaffold.py`'s `BIOME_VERSION` constant so biome.json,
+  pre-commit, CI, and the justfile never drift (a guard in
+  `scripts/plugin-compliance-check.sh` enforces this).
+- The TS stub imports only `openModalShell`; add `fuzzyRank` /
+  `highlightMatches` from `@laurigates/comfy-modal-kit` when the real modal's
+  search lands.
 - **Add at least one jsdom DOM-attach test for each modal builder** (assert the
-  expected element exists in `modal.bodyEl` after `openX()`). The generated pytest
-  + vitest gate covers pure helpers only; modal DOM is otherwise left to the manual
-  browser smoke matrix — which is exactly the gap that let an empty-modal bug ship
-  green. A single `expect(modal.bodyEl.querySelector(...)).toBeTruthy()` would have
-  caught it. (`vitest --environment jsdom`.)
+  expected element exists in `modal.bodyEl` after `openX()`). The generated
+  pytest + vitest gate covers pure helpers only; modal DOM is otherwise left to
+  the manual browser smoke matrix — which is exactly the gap that let an
+  empty-modal bug ship green. (`vitest --environment jsdom`.)

--- a/comfyui-plugin/skills/comfyui-node-scaffold/scaffold.py
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/scaffold.py
@@ -1,19 +1,25 @@
 #!/usr/bin/env python3
-"""Scaffold a new ComfyUI custom-node repo in the gallery-loader / sampler-info vein.
+"""Scaffold a new ComfyUI custom-node repo (TypeScript + bun build) in the
+gallery-loader / sampler-info / touch-numeric vein.
 
-Generates a CI-green, ready-to-implement pack: pyproject.toml, CI +
-release-please + publish workflows, ruff/biome/pre-commit config, a
-vitest + pytest harness, __init__.py, CLAUDE.md, a JS extension skeleton
-that already wires the widget.onPointerDown → modal interception, and
-(for the backend variant) an aiohttp node + endpoint skeleton with the
-extension-whitelist security gate. Optionally copies the proven
-modal-shell.js + modal-fuzzy.js primitives from a reference pack.
+Generates a CI-green, ready-to-implement pack with TypeScript source in `src/`
+(entry `src/index.ts`) built to `web/dist/` via `bun build`: pyproject.toml,
+CI + release-please + publish workflows, ruff/biome/pre-commit config, a
+strict tsconfig + knip + vitest harness, __init__.py (WEB_DIRECTORY pointing at
+the built `web/dist`), CLAUDE.md, an ADR recording the TS+bun decision, and the
+extension skeleton. The frontend/backend (modal) variants consume the shared
+`@laurigates/comfy-modal-kit` primitives via an `import` (NOT copied-in files);
+the gesture variant is a self-contained canvas pointer layer with no kit
+dependency.
+
+This supersedes the previous vanilla-JS (`web/js/*.js` + copied
+modal-shell.js/modal-fuzzy.js) template — see the generated ADR.
 
 Stdlib only. Run with `python3 scaffold.py` or `uv run scaffold.py`.
 
 Examples
 --------
-Frontend-only pack (sampler-info shape):
+Frontend-only pack (sampler-info / touch-numeric shape — consumes the kit):
     python3 scaffold.py \
         --name comfyui-touch-numeric \
         --display "Touch Numeric" \
@@ -21,7 +27,7 @@ Frontend-only pack (sampler-info shape):
         --variant frontend \
         --widgets seed,noise_seed,cfg,steps,denoise
 
-Pack with a small Python backend (gallery-loader shape):
+Pack with a small Python backend (gallery-loader shape — consumes the kit):
     python3 scaffold.py \
         --name comfyui-model-gallery \
         --display "Model Gallery" \
@@ -29,7 +35,7 @@ Pack with a small Python backend (gallery-loader shape):
         --variant backend \
         --widgets lora_name,ckpt_name,vae_name,control_net_name
 
-Canvas-gesture pack (no widget, no modal — a canvas pointer layer):
+Canvas-gesture pack (touch-resize shape — no widget, no modal, no kit):
     python3 scaffold.py \
         --name comfyui-touch-resize \
         --display "Touch Resize" \
@@ -41,12 +47,26 @@ from __future__ import annotations
 
 import argparse
 import datetime
-import shutil
 import sys
 from pathlib import Path
 
 AUTHOR_DEFAULT = "Lauri Gates"
 PUBLISHER_DEFAULT = "laurigates"
+
+# The shared modal-kit consumed by the modal (frontend/backend) variants. The
+# gesture variant does NOT depend on it. Bump in lockstep with the kit's
+# published major/minor when its exported API changes.
+MODAL_KIT_PKG = "@laurigates/comfy-modal-kit"
+MODAL_KIT_VERSION = "^0.2.0"
+
+# Pinned tool versions — kept in ONE place so the biome pin can never drift
+# between biome.json, the pre-commit hook, CI, and the justfile. The previous
+# template pinned an old 1.x biome in the pre-commit hook while biome.json/CI
+# were on 2.x, and the pre-commit hook surfaced that mismatch as a config-parse
+# failure. The regression check in scripts/plugin-compliance-check.sh asserts
+# every generated biome pin stays on this single version.
+BIOME_VERSION = "2.4.15"
+COMFY_FRONTEND_TYPES_VERSION = "^1.43.0"
 
 
 # --------------------------------------------------------------------------- #
@@ -55,14 +75,15 @@ PUBLISHER_DEFAULT = "laurigates"
 def derive(name: str) -> dict[str, str]:
     """Derive the family of names a pack needs from its repo name."""
     if not name.startswith("comfyui-"):
-        print(f"warning: pack name '{name}' does not start with 'comfyui-'", file=sys.stderr)
+        print(
+            f"warning: pack name '{name}' does not start with 'comfyui-'",
+            file=sys.stderr,
+        )
     short = name.removeprefix("comfyui-")  # e.g. touch-numeric
     return {
         "NAME": name,  # comfyui-touch-numeric  (repo + served URL segment)
         "SHORT": short,  # touch-numeric
-        "EXT_FILE": short,  # web/js/touch-numeric.js
         "PY_MODULE": short.replace("-", "_"),  # touch_numeric  (backend .py)
-        "EXT_CONST": short.upper().replace("-", "_"),  # TOUCH_NUMERIC
         "EXT_CONST_CAMEL": _camel(short),  # touchNumeric  (JS guard-flag prefix)
     }
 
@@ -74,7 +95,7 @@ def _camel(short: str) -> str:
 
 
 # --------------------------------------------------------------------------- #
-# Templates — @@TOKEN@@ placeholders (avoids brace conflicts with JSON/JS)
+# Templates — @@TOKEN@@ placeholders (avoids brace conflicts with JSON/JS/TS)
 # --------------------------------------------------------------------------- #
 def subst(text: str, ctx: dict[str, str]) -> str:
     for key, val in ctx.items():
@@ -82,7 +103,7 @@ def subst(text: str, ctx: dict[str, str]) -> str:
     return text
 
 
-PYPROJECT = '''\
+PYPROJECT = """\
 [project]
 name = "@@NAME@@"
 description = "@@DESC@@"
@@ -133,16 +154,21 @@ pythonpath = ["."]
 PublisherId = "@@PUBLISHER@@"
 DisplayName = "@@DISPLAY@@"
 Icon = ""
-'''
+# The built frontend (web/dist/) is git-ignored — emitted by `bun run build`.
+# publish-node-action honors [tool.comfy] includes to force-add otherwise-
+# ignored paths into the published tarball. See ADR-0001.
+includes = ["web/dist"]
+"""
 
 INIT_FRONTEND = '''\
 """@@DISPLAY@@ for ComfyUI.
 
-Frontend-only pack: no Python nodes. The whole extension lives in
-web/js/@@EXT_FILE@@.js and is loaded via WEB_DIRECTORY below.
+Frontend-only pack: no Python nodes. The TypeScript source in `src/` is
+compiled to ESM via `bun build` and emitted to `web/dist/`, which ComfyUI
+serves as the extension root via WEB_DIRECTORY below. See ADR-0001.
 """
 
-WEB_DIRECTORY = "./web"
+WEB_DIRECTORY = "./web/dist"
 
 NODE_CLASS_MAPPINGS = {}
 NODE_DISPLAY_NAME_MAPPINGS = {}
@@ -153,8 +179,9 @@ __all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS", "WEB_DIRECTORY"]
 INIT_BACKEND = '''\
 """@@DISPLAY@@ for ComfyUI.
 
-See @@PY_MODULE@@.py for the backend (node + HTTP endpoints) and
-web/js/@@EXT_FILE@@.js for the frontend extension.
+See @@PY_MODULE@@.py for the backend (node + HTTP endpoints). The frontend
+TypeScript source in `src/` is compiled to ESM via `bun build` and emitted to
+`web/dist/`, which ComfyUI serves via WEB_DIRECTORY below. See ADR-0001.
 """
 
 try:
@@ -165,7 +192,7 @@ except ImportError:
     # absolute (the pack root is on sys.path via pyproject pythonpath).
     from @@PY_MODULE@@ import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
 
-WEB_DIRECTORY = "./web"
+WEB_DIRECTORY = "./web/dist"
 
 __all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS", "WEB_DIRECTORY"]
 '''
@@ -219,14 +246,19 @@ NODE_CLASS_MAPPINGS = {"@@DISPLAY_NOSPACE@@": @@DISPLAY_NOSPACE@@}
 NODE_DISPLAY_NAME_MAPPINGS = {"@@DISPLAY_NOSPACE@@": "@@DISPLAY@@"}
 '''
 
-EXT_JS = '''\
+# --------------------------------------------------------------------------- #
+# TypeScript source — modal (frontend/backend) variant
+# --------------------------------------------------------------------------- #
+INDEX_TS_MODAL = """\
 // @@DISPLAY@@ — ComfyUI frontend extension.
 //
-// Served at /extensions/@@NAME@@/js/@@EXT_FILE@@.js — the pack directory
-// name IS this URL segment. Do not rename the pack dir without syncing
+// TypeScript source in `src/`, built to ESM via `bun build` and emitted to
+// `web/dist/` (served at /extensions/@@NAME@@/index.js — the pack directory
+// name IS the URL segment). Do not rename the pack dir without syncing
 // EXT_NAME below (used for log prefixes and any /@@PY_MODULE@@/ fetches).
+// See ADR-0001.
 //
-// Pattern (shared with gallery-loader / sampler-info):
+// Pattern (shared with gallery-loader / sampler-info / touch-numeric):
 //   registerExtension -> enhance each node (on create AND on graph load) ->
 //   wrap widget.onPointerDown on widgets matched BY NAME -> open an HTML
 //   modal instead of the native LiteGraph control. Additive + mobile-first;
@@ -234,20 +266,56 @@ EXT_JS = '''\
 //   Requires the modern Vue frontend's onPointerDown hook
 //   (comfyui-frontend-package >= 1.40).
 //
-// To add fuzzy search to the modal, import from ./modal-fuzzy.js:
-//   import { fuzzyRank, highlightMatches } from "./modal-fuzzy.js";
+// The shared modal primitives come from @@MODAL_KIT_PKG@@. They are NOT copied
+// into this pack — `bun build` INLINES the imported code into web/dist. To add
+// fuzzy search to the modal, import the matcher from the same package:
+//   import { fuzzyRank, highlightMatches } from "@@MODAL_KIT_PKG@@";
 //   fuzzyRank(query, [primaryField, ...otherFields]) -> { score, primaryMatches } | null
-
-import { app } from "../../../scripts/app.js";
-import { openModalShell } from "./modal-shell.js";
+import { openModalShell } from "@@MODAL_KIT_PKG@@";
+// ComfyUI serves its frontend API at runtime from `/scripts/app.js`. The
+// emitted import string stays `/scripts/app.js` (bun's `--external '/scripts/*'`
+// keeps it unbundled); the type is supplied via a `paths` mapping in
+// tsconfig.json that points the import at `src/comfyui-shims.d.ts`. See ADR-0001.
+import { app } from "/scripts/app.js";
 
 const EXT_NAME = "@@NAME@@";
 
 // Widgets this pack enhances, detected by NAME (generic across node packs).
 // TODO: tune this set for the pack.
-const TARGET_WIDGETS = new Set([@@WIDGET_SET@@]);
+const TARGET_WIDGETS = new Set<string>([@@WIDGET_SET@@]);
 
-function openPicker(widget, node) {
+// ============================================================
+// Types — the narrow LiteGraph surface this pack reaches into
+// ============================================================
+//
+// `@comfyorg/comfyui-frontend-types` exports `ComfyApp` (the type of the
+// imported `app`) but NOT `LGraphNode` / the widget interfaces — they are
+// declared internally and not re-exported. Model the small surface this pack
+// touches with local structural interfaces instead (narrow blast radius).
+
+// A widget plus the custom props this pack hangs off it. `onPointerDown` and
+// the private guard flag are this pack's intercept seam, not part of the
+// public widget surface.
+interface PatchedWidget {
+  name: string;
+  onPointerDown?: (pointer: unknown, node: PatchedNode, canvas: unknown) => boolean | undefined;
+  _@@EXT_CONST_CAMEL@@Patched?: boolean;
+}
+
+// Minimal structural type for the LiteGraph node this pack operates on. Named
+// to avoid colliding with the package's own un-exported `LGraphNode` at the
+// registerExtension lifecycle-hook seam — the hooks receive the package node,
+// which we cast to this structural shape.
+interface PatchedNode {
+  type?: string;
+  widgets?: PatchedWidget[];
+}
+
+// ============================================================
+// Modal
+// ============================================================
+
+function openPicker(widget: PatchedWidget, node: PatchedNode | null): void {
   // CONTRACT: openModalShell has NO `body` option — it returns a controller
   // ({ bodyEl, close, setBusy, setStatus, ... }) with an EMPTY bodyEl that you
   // fill AFTER opening. Passing `body:` is silently ignored and the dialog
@@ -255,7 +323,6 @@ function openPicker(widget, node) {
   // check catches it). Always: open, then modal.bodyEl.appendChild(...).
   const modal = openModalShell({
     title: widget.name,
-    // search: (query) => { ... fuzzyRank over options, re-render rows ... },
     onClose: () => {},
   });
 
@@ -266,16 +333,26 @@ function openPicker(widget, node) {
   modal.bodyEl.appendChild(body);
 }
 
-function enhanceNode(node) {
+// ============================================================
+// Wiring
+// ============================================================
+
+function enhanceNode(node: PatchedNode): void {
   for (const w of node?.widgets ?? []) {
     if (!TARGET_WIDGETS.has(w.name)) continue;
     if (w._@@EXT_CONST_CAMEL@@Patched) continue; // guard against double-patching
     w._@@EXT_CONST_CAMEL@@Patched = true;
 
     // Strategy A: wrap onPointerDown. Chain to the original first; only open
-    // our modal if the original didn't consume the event.
+    // our modal if the original didn't consume the event. Fall back to the
+    // native control on error (additive — never break the widget).
     const origDown = w.onPointerDown;
-    w.onPointerDown = function (pointer, ownerNode, canvas) {
+    w.onPointerDown = function (
+      this: PatchedWidget,
+      pointer: unknown,
+      ownerNode: PatchedNode,
+      canvas: unknown,
+    ): boolean | undefined {
       try {
         if (typeof origDown === "function") {
           const consumed = origDown.call(this, pointer, ownerNode, canvas);
@@ -288,32 +365,48 @@ function enhanceNode(node) {
         return false; // fall back to native on error
       }
     };
-
-    // Strategy B safety net: if a future frontend drops the onPointerDown
-    // hook, an explicit button widget keeps the modal reachable. Uncomment
-    // if this pack depends on the modal always being openable:
-    // node.addWidget("button", `\\u{1F50D} ${w.name}`, null, () => openPicker(w, node));
   }
 }
 
 app.registerExtension({
   name: "comfy.@@SHORT@@",
-  // Handle freshly created nodes AND nodes restored from a saved graph.
+  // Handle freshly created nodes AND nodes restored from a saved graph. The
+  // lifecycle-hook node params are the package's own `LGraphNode`; cast each to
+  // the structural `PatchedNode` this pack operates on.
   async nodeCreated(node) {
-    enhanceNode(node);
+    try {
+      enhanceNode(node as unknown as PatchedNode);
+    } catch (e) {
+      console.warn(`[${EXT_NAME}] nodeCreated enhance failed`, e);
+    }
   },
   async loadedGraphNode(node) {
-    enhanceNode(node);
+    try {
+      enhanceNode(node as unknown as PatchedNode);
+    } catch (e) {
+      console.warn(`[${EXT_NAME}] loadedGraphNode enhance failed`, e);
+    }
   },
 });
-'''
 
-GESTURE_JS = '''\
+// Re-export the pure helpers a real implementation adds here, so the Vitest
+// suite (tests/js) can import them directly from the .ts source. The seed
+// example is a placeholder — replace with this pack's own helpers.
+export function clampToTargets(name: string): boolean {
+  return TARGET_WIDGETS.has(name);
+}
+"""
+
+# --------------------------------------------------------------------------- #
+# TypeScript source — gesture variant (no modal-kit dependency)
+# --------------------------------------------------------------------------- #
+INDEX_TS_GESTURE = """\
 // @@DISPLAY@@ — ComfyUI frontend extension (canvas-gesture pack).
 //
-// Served at /extensions/@@NAME@@/js/@@EXT_FILE@@.js — the pack directory
-// name IS this URL segment. Do not rename the pack dir without syncing
-// EXT_NAME below.
+// TypeScript source in `src/`, built to ESM via `bun build` and emitted to
+// `web/dist/` (served at /extensions/@@NAME@@/index.js — the pack directory
+// name IS the URL segment). Do not rename the pack dir without syncing
+// EXT_NAME below. See ADR-0001.
 //
 // Pattern ("the gesture vein"): instead of intercepting a single widget,
 // this pack adds a CANVAS-LEVEL pointer layer. A two-finger pinch whose
@@ -323,35 +416,75 @@ GESTURE_JS = '''\
 // absent it does nothing and native corner-handle resize still works.
 // Resize only writes node.size (already serialized) so no workflow breaks.
 //
-// Pure geometry helpers are exported and unit-tested (tests/js); the
-// DOM/canvas wiring below is exercised in the manual browser matrix.
-
-import { app } from "../../../scripts/app.js";
+// This variant has NO @@MODAL_KIT_PKG@@ dependency — there is no widget to
+// hook and no modal to open. Pure geometry helpers are exported and
+// unit-tested (tests/js); the DOM/canvas wiring below is exercised in the
+// manual browser matrix.
+//
+// ComfyUI serves its frontend API at runtime from `/scripts/app.js`. The
+// emitted import string stays `/scripts/app.js` (bun's `--external '/scripts/*'`
+// keeps it unbundled); the type is supplied via a `paths` mapping in
+// tsconfig.json that points the import at `src/comfyui-shims.d.ts`. See ADR-0001.
+import { app } from "/scripts/app.js";
 
 const EXT_NAME = "@@NAME@@";
 
 // LiteGraph maps a canvas point p to screen space as (p + ds.offset) * ds.scale.
-const DEFAULT_TITLE_HEIGHT = 30; // LiteGraph.NODE_TITLE_HEIGHT default.
+// LiteGraph.NODE_TITLE_HEIGHT = 30 (confirm against the frontend sourcemap).
+const DEFAULT_TITLE_HEIGHT = 30;
 
-// --- Pure helpers (unit-tested) ----------------------------------------- //
+// ============================================================
+// Types
+// ============================================================
+
+/** A screen-space rectangle. */
+interface Rect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/** A 2-tuple of [x, y] / [w, h] used throughout the geometry. */
+type Vec2 = [number, number];
+
+/** The narrow node surface this pack reaches into. */
+interface GestureNode {
+  pos: Vec2;
+  size: Vec2;
+  computeSize?: () => Vec2;
+  onResize?: (size: Vec2) => void;
+}
+
+// ============================================================
+// Pure helpers (unit-tested in tests/js)
+// ============================================================
 
 /** Euclidean distance between two {x, y} pointers. */
-export function pinchDistance(a, b) {
+export function pinchDistance(a: { x: number; y: number }, b: { x: number; y: number }): number {
   return Math.hypot(a.x - b.x, a.y - b.y);
 }
 
 /** Midpoint between two {x, y} pointers. */
-export function centroid(a, b) {
+export function centroid(
+  a: { x: number; y: number },
+  b: { x: number; y: number },
+): { x: number; y: number } {
   return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
 }
 
 /** Is screen point (x, y) inside rect {x, y, w, h}? */
-export function pointInRect(x, y, rect) {
+export function pointInRect(x: number, y: number, rect: Rect): boolean {
   return x >= rect.x && y >= rect.y && x <= rect.x + rect.w && y <= rect.y + rect.h;
 }
 
 /** Node bounding rect (incl. title bar) in screen space. */
-export function nodeScreenRect(node, scale, offset, titleHeight = DEFAULT_TITLE_HEIGHT) {
+export function nodeScreenRect(
+  node: GestureNode,
+  scale: number,
+  offset: Vec2,
+  titleHeight = DEFAULT_TITLE_HEIGHT,
+): Rect {
   const x = (node.pos[0] + offset[0]) * scale;
   const yBody = (node.pos[1] + offset[1]) * scale;
   return {
@@ -366,48 +499,71 @@ export function nodeScreenRect(node, scale, offset, titleHeight = DEFAULT_TITLE_
  * New [w, h] after a uniform pinch scale, clamped to a minimum.
  * ratio = currentPinchDistance / startPinchDistance; minSize = [minW, minH].
  */
-export function scaledSize(startSize, ratio, minSize = [0, 0]) {
+export function scaledSize(startSize: Vec2, ratio: number, minSize: Vec2 = [0, 0]): Vec2 {
   return [Math.max(minSize[0], startSize[0] * ratio), Math.max(minSize[1], startSize[1] * ratio)];
 }
 
 /** Selected nodes as an array, defensively across LiteGraph variants. */
-export function selectedNodes(canvas) {
-  if (!canvas) return [];
-  const sel = canvas.selected_nodes;
+export function selectedNodes(canvas: unknown): GestureNode[] {
+  if (!canvas || typeof canvas !== "object") return [];
+  const c = canvas as {
+    selected_nodes?: Record<string, GestureNode>;
+    selectedItems?: Set<unknown>;
+  };
+  const sel = c.selected_nodes;
   if (sel && typeof sel === "object") return Object.values(sel);
-  if (canvas.selectedItems instanceof Set) {
-    return [...canvas.selectedItems].filter((it) => it?.size && it?.pos);
+  if (c.selectedItems instanceof Set) {
+    return [...c.selectedItems].filter(
+      (it): it is GestureNode => !!it && typeof it === "object" && "size" in it && "pos" in it,
+    );
   }
   return [];
 }
 
-// --- Wiring (DOM + canvas; browser-matrix tested) ----------------------- //
+// ============================================================
+// Wiring (DOM + canvas; browser-matrix tested)
+// ============================================================
 
-function installGestureLayer() {
-  const canvas = app.canvas;
+interface PinchLock {
+  node: GestureNode;
+  startDist: number;
+  startSize: Vec2;
+  minSize: Vec2;
+}
+
+function installGestureLayer(): void {
+  const canvas = (
+    app as {
+      canvas?: {
+        canvas?: HTMLCanvasElement;
+        ds?: { scale?: number; offset?: Vec2 };
+        setDirty?: (a: boolean, b: boolean) => void;
+      };
+    }
+  ).canvas;
   const el = canvas?.canvas; // the actual <canvas> element
-  if (!el) {
+  if (!el || !canvas) {
     console.warn(`[${EXT_NAME}] no canvas element — gesture layer not installed`);
     return;
   }
 
-  const pointers = new Map(); // pointerId -> { x, y } in canvas-element-local space
-  let lock = null; // { node, startDist, startSize, minSize }
+  const pointers = new Map<number, { x: number; y: number }>();
+  let lock: PinchLock | null = null;
 
-  const localPoint = (e) => {
+  const localPoint = (e: PointerEvent): { x: number; y: number } => {
     const r = el.getBoundingClientRect();
     return { x: e.clientX - r.left, y: e.clientY - r.top };
   };
 
-  function tryStartPinch() {
+  function tryStartPinch(): void {
     if (pointers.size !== 2 || lock) return;
-    const [p1, p2] = [...pointers.values()];
+    const [p1, p2] = [...pointers.values()] as [{ x: number; y: number }, { x: number; y: number }];
     const c = centroid(p1, p2);
-    const scale = canvas.ds?.scale ?? 1;
-    const offset = canvas.ds?.offset ?? [0, 0];
+    const scale = canvas?.ds?.scale ?? 1;
+    const offset = canvas?.ds?.offset ?? ([0, 0] as Vec2);
     for (const node of selectedNodes(canvas)) {
       if (pointInRect(c.x, c.y, nodeScreenRect(node, scale, offset))) {
-        const minSize = typeof node.computeSize === "function" ? node.computeSize() : [0, 0];
+        const minSize: Vec2 = typeof node.computeSize === "function" ? node.computeSize() : [0, 0];
         lock = {
           node,
           startDist: pinchDistance(p1, p2) || 1,
@@ -435,19 +591,22 @@ function installGestureLayer() {
       if (!pointers.has(e.pointerId)) return;
       pointers.set(e.pointerId, localPoint(e));
       if (!lock || pointers.size < 2) return;
-      const [p1, p2] = [...pointers.values()];
+      const [p1, p2] = [...pointers.values()] as [
+        { x: number; y: number },
+        { x: number; y: number },
+      ];
       const ratio = pinchDistance(p1, p2) / lock.startDist;
       const [w, h] = scaledSize(lock.startSize, ratio, lock.minSize);
       lock.node.size[0] = w;
       lock.node.size[1] = h;
       lock.node.onResize?.(lock.node.size);
-      canvas.setDirty(true, true);
+      canvas?.setDirty?.(true, true);
       e.stopImmediatePropagation();
     },
     true,
   );
 
-  const endPointer = (e) => {
+  const endPointer = (e: PointerEvent): void => {
     pointers.delete(e.pointerId);
     if (pointers.size < 2) lock = null;
   };
@@ -469,9 +628,57 @@ app.registerExtension({
     //   independent W/H instead of uniform scale (behind a config flag).
   },
 });
-'''
+"""
 
-README = '''\
+COMFYUI_SHIMS = """\
+// ComfyUI serves its frontend API at runtime from `/scripts/app.js`. The
+// `@comfyorg/comfyui-frontend-types` package only types the bare-package
+// symbols, not that served-path module. TypeScript will not match an ambient
+// `declare module` against a rooted (`/…`) path specifier, so instead a
+// `paths` mapping in tsconfig.json points the `/scripts/app.js` import at this
+// declaration file. The emitted import string stays `/scripts/app.js` (bun's
+// `--external '/scripts/*'` keeps it unbundled, resolved at runtime against
+// ComfyUI's served module).
+import type { ComfyApp } from "@comfyorg/comfyui-frontend-types";
+
+export declare const app: ComfyApp;
+"""
+
+TSCONFIG = """\
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "paths": {
+      "/scripts/app.js": ["./src/comfyui-shims.d.ts"]
+    },
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "allowJs": false,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "skipLibCheck": true,
+    "types": ["@comfyorg/comfyui-frontend-types"]
+  },
+  "include": ["src"]
+}
+"""
+
+KNIP_JSON = """\
+{
+  "$schema": "https://unpkg.com/knip@5/schema.json",
+  "entry": ["src/index.ts"],
+  "project": ["src/**/*.ts"]
+}
+"""
+
+README = """\
 # @@NAME@@
 
 @@DESC@@
@@ -486,25 +693,29 @@ README = '''\
 ```sh
 cd <ComfyUI>/custom_nodes
 git clone https://github.com/@@PUBLISHER@@/@@NAME@@
+cd @@NAME@@
+bun install
+bun run build      # emit web/dist/ (served by ComfyUI)
 ```
 
 Restart ComfyUI; hard-refresh the browser tab (Ctrl+Shift+R / Cmd+Shift+R).
 
 ## What it does
 
-TODO — describe the widgets it enhances and the modal it opens.
+TODO — describe @@WHAT_DESC@@.
 
 ## Compatibility
 
 @@COMPAT_BULLET@@
-- Frontend changes (JS/CSS) take effect on browser hard-refresh — no restart.
+- Frontend changes take effect after `bun run build` + a browser hard-refresh —
+  no ComfyUI restart.
 
 ## License
 
 MIT — see `LICENSE`.
-'''
+"""
 
-CLAUDE_MD = '''\
+CLAUDE_MD = """\
 # CLAUDE.md
 
 @@CLAUDE_INTRO@@
@@ -517,47 +728,63 @@ CLAUDE_MD = '''\
 
 | Path | Purpose |
 |------|---------|
+| `src/index.ts` | @@EXT_ROW_DESC@@ |
+| `src/comfyui-shims.d.ts` | Types the `/scripts/app.js` runtime import (via the `paths` mapping in `tsconfig.json`). |
 | `__init__.py` | Loader stub. @@INIT_DESC@@ |
-@@BACKEND_LAYOUT_ROW@@| `web/js/@@EXT_FILE@@.js` | @@EXT_ROW_DESC@@ |
-@@MODAL_LAYOUT_ROWS@@| `pyproject.toml` | Comfy Registry metadata. `PublisherId` + `version` are the fields you touch. |
-| `.github/workflows/` | `ci.yml` (ruff/biome/pytest/vitest/gitleaks), `publish.yml` (auto-publish on version bump), `release-please.yml`. |
-| `tests/` | pytest backend suite. `tests/js/` Vitest suite for pure JS helpers. |
-| `justfile` | `lint`, `format`, `test`, `check` recipes — the local CI gate. |
+@@BACKEND_LAYOUT_ROW@@| `web/dist/` | **Generated** by `bun run build` (git-ignored). ComfyUI serves it at `/extensions/@@NAME@@/`. |
+| `pyproject.toml` | Comfy Registry metadata. `PublisherId` + `version` are the fields you touch; `[tool.comfy] includes = ["web/dist"]` force-ships the built output. |
+| `tsconfig.json` / `biome.json` / `knip.json` | Strict TS config, Biome lint/format, knip dead-code. |
+| `.github/workflows/` | `ci.yml` (tsc+build/biome/vitest/ruff/pytest/gitleaks), `publish.yml` (builds then publishes on version bump), `release-please.yml`. |
+| `tests/js/` | Vitest suite importing the `.ts` source directly.@@PYTEST_LAYOUT_NOTE@@ |
+| `justfile` | `build`, `lint`, `format`, `test`, `check` recipes — the local CI gate. |
 
 ## Hard rules
 
-- **Pack directory name is part of the URL.** `web/js/@@EXT_FILE@@.js` is
-  served at `/extensions/@@NAME@@/js/@@EXT_FILE@@.js`. Renaming the pack dir
-  breaks every fetch. If unavoidable, sync `EXT_NAME` in the JS.
+- **Pack directory name is part of the URL.** `web/dist/index.js` is served at
+  `/extensions/@@NAME@@/index.js`. Renaming the pack dir breaks every fetch. If
+  unavoidable, sync `EXT_NAME` in the source.
+- **TypeScript source, bun build.** Author in `src/` (entry `src/index.ts`),
+  build to `web/dist/` via `bun build ./src/index.ts --target browser --format
+  esm --outdir web/dist --external '/scripts/*'`. `tsc --noEmit` is the type
+  gate; `bun build` is the emit — they are decoupled. The `/scripts/app.js`
+  import is left **unbundled** (resolved at runtime against ComfyUI's served
+  module). See ADR-0001.
 - **@@DEP_RULE@@**
+- **@@KIT_RULE@@**
 - **Additive only.** Never clobber an existing tooltip/control; fall back to
   the native widget when there's no match. Never fabricate data.
 - @@HOOK_RULE@@
+- **Never hand-edit `CHANGELOG.md` or the `version` field** — release-please
+  owns them (conventional commits drive the bump).
 
 ## Dev workflow
 
 ```sh
 uv sync --group dev          # ruff, pytest, pre-commit
-npm install --no-audit --no-fund   # Vitest (dev-only; nothing ships from node_modules)
+bun install                  # TypeScript, Biome, Vitest, knip, @@KIT_DEV_NOTE@@
 pre-commit install
-just check                   # lint + test — the local CI gate
+just check                   # typecheck + build + lint + test — the local CI gate
 ```
 
-Iterating on JS/CSS/JSON needs **no ComfyUI restart** — hard-refresh the tab.
-@@RESTART_NOTE@@
+Iterating on the frontend needs a **`bun run build`** (the served file is
+`web/dist/index.js`, not the source) plus a browser hard-refresh — no ComfyUI
+restart.@@RESTART_NOTE@@
 
 ### Endpoint reachability check
 
 ```sh
-curl -s -o /dev/null -w "%{http_code}\\n" http://127.0.0.1:8188/extensions/@@NAME@@/js/@@EXT_FILE@@.js
+curl -s -o /dev/null -w "%{http_code}\\n" http://127.0.0.1:8188/extensions/@@NAME@@/index.js
 ```
 
 ## Verify the frontend API against the sourcemap
 
 The ComfyUI frontend (`comfyui-frontend-package`) ships **minified** — property
 and method names are renamed in the bundle, so reading the running app's objects
-by guessed names (or trusting old tutorials) is unreliable. Before coding against
-a LiteGraph / canvas API, verify its real shape against the bundled sourcemap.
+by guessed names (or trusting old tutorials) is unreliable. The TypeScript types
+from `@comfyorg/comfyui-frontend-types` cover `ComfyApp` but **not** the internal
+`LGraphNode` / `LGraphCanvas` / widget interfaces (un-exported). Model the small
+surface you touch with local structural interfaces, and verify the real shape
+against the bundled sourcemap before coding against a LiteGraph / canvas API.
 
 LiteGraph is bundled in the **`api-*.js.map`** chunk under
 `.venv/lib/python*/site-packages/comfyui_frontend_package/static/assets/`. The
@@ -569,22 +796,11 @@ cd .venv/lib/python*/site-packages/comfyui_frontend_package/static/assets
 grep -l 'LGraphGroup' *.js.map        # find the chunk
 ```
 
-```sh
-python3 - <<'PY'
-import json
-m = json.load(open("api-<hash>.js.map"))
-for name, src in zip(m["sources"], m["sourcesContent"] or []):
-    if src and "class LGraphGroup" in src:
-        i = src.index("class LGraphGroup"); print(name); print(src[i:i+2000]); break
-PY
-```
-
 Facts worth confirming this way (recheck on a `comfyui-frontend-package` bump):
 `LiteGraph.NODE_TITLE_HEIGHT` (30); `canvas.selectedItems` is a
 `Set<Positionable>` holding nodes + groups + reroutes; `canvas.selected_nodes` is
-a node-only dictionary; `LGraphGroup.size` self-clamps to 140×80 and has
-`recomputeInsideNodes()`; canvas zoom is **wheel-driven**
-(`processMouseWheel → ds.changeScale`).
+a node-only dictionary; canvas zoom is **wheel-driven**
+(`processMouseWheel -> ds.changeScale`).
 
 Two gotchas that follow: discriminate selected items by **shape, not
 `instanceof`** (the class is renamed under minification); and to suppress native
@@ -594,13 +810,13 @@ zoom during a gesture, intercept `wheel` (capture, `passive:false`,
 
 ## Releases
 
-Bump `version` in `pyproject.toml` and push to `main` →
-`Comfy-Org/publish-node-action` publishes to the Comfy Registry. Requires
-the `REGISTRY_ACCESS_TOKEN` repo secret. Use conventional commits;
-release-please maintains `CHANGELOG.md` and the version bump PR.
-'''
+Bump `version` in `pyproject.toml` and push to `main` → `publish.yml` runs
+`bun run build` then `Comfy-Org/publish-node-action` publishes to the Comfy
+Registry. Requires the `REGISTRY_ACCESS_TOKEN` repo secret. Use conventional
+commits; release-please maintains `CHANGELOG.md` and the version bump PR.
+"""
 
-JUSTFILE = '''\
+JUSTFILE = """\
 # @@NAME@@ — task runner. Run `just` (or `just --list`) for recipes.
 
 set positional-arguments
@@ -613,33 +829,43 @@ default:
 # Quality
 ##########
 
-# Lint Python + JS/JSON (no changes).
+# Build the frontend bundle to web/dist/ (bun build).
+[group: "quality"]
+build:
+    bun run build
+
+# Typecheck the TypeScript source (tsc --noEmit; bun emits, tsc only checks).
+[group: "quality"]
+typecheck:
+    bun run typecheck
+
+# Lint Python + TS/JSON (no changes).
 [group: "quality"]
 lint:
     uv run ruff check .
-    npx @biomejs/biome check .
+    bunx @biomejs/biome@@@BIOME_VERSION@@ check
 
-# Auto-format Python + JS/JSON.
+# Auto-format Python + TS/JSON.
 [group: "quality"]
 format:
     uv run ruff format .
     uv run ruff check --fix .
-    npx @biomejs/biome check --write .
+    bunx @biomejs/biome@@@BIOME_VERSION@@ check --write
 
-# Run the full test suite (pytest + Vitest) — the local CI gate.
+# Run the full test suite (pytest + Vitest).
 [group: "quality"]
 test:
     uv run pytest -v
-    npm test
+    bun run test
 
-# Lint + test in one shot.
+# Typecheck + build + lint + test in one shot — the local CI gate.
 [group: "quality"]
-check: lint test
-'''
+check: typecheck build lint test
+"""
 
-BIOME_JSON = '''\
+BIOME_JSON = """\
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/@@BIOME_VERSION@@/schema.json",
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,
@@ -660,36 +886,47 @@ BIOME_JSON = '''\
   },
   "files": {
     "includes": [
-      "**/web/**/*.js",
-      "**/web/**/*.json",
+      "src/**/*.ts",
+      "**/web/data/**/*.json",
       "**/tests/js/**/*.js",
       "vitest.config.js",
       "package.json",
+      "knip.json",
+      "tsconfig.json",
       "!**/node_modules",
+      "!**/web/dist",
       "!**/dist",
       "!**/coverage"
     ]
   }
 }
-'''
+"""
 
-PACKAGE_JSON = '''\
+PACKAGE_JSON = """\
 {
-  "name": "@@NAME@@-dev",
+  "name": "@@NAME@@",
   "private": true,
   "type": "module",
-  "description": "Dev-only test harness for @@NAME@@. Nothing here ships to users.",
+  "description": "@@DESC@@ TypeScript source in src/, built to web/dist/ via bun build.@@KIT_PKG_NOTE@@ See ADR-0001.",
   "scripts": {
+    "build": "bun build ./src/index.ts --target browser --format esm --outdir web/dist --external '/scripts/*'",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
-  },
+    "test:watch": "vitest",
+    "lint": "biome check",
+    "knip": "knip"
+  },@@DEPENDENCIES_BLOCK@@
   "devDependencies": {
-    "vitest": "^4.1.7"
+    "typescript": "^5.7.0",
+    "@comfyorg/comfyui-frontend-types": "@@COMFY_FRONTEND_TYPES_VERSION@@",
+    "@biomejs/biome": "^@@BIOME_VERSION@@",
+    "vitest": "^4.1.7",
+    "knip": "^5.0.0"
   }
 }
-'''
+"""
 
-VITEST_CONFIG = '''\
+VITEST_CONFIG = """\
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
@@ -703,47 +940,55 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      "../../../scripts/app.js": resolve(__dirname, "tests/js/__mocks__/app.js"),
+      // ComfyUI's served-path runtime import. The TS source imports the
+      // absolute `/scripts/app.js` form; vitest aliases it to the mock so
+      // the pure functions can be imported (and the module side-effect —
+      // app.registerExtension — runs against the stub).
+      "/scripts/app.js": resolve(__dirname, "tests/js/__mocks__/app.js"),
     },
   },
 });
-'''
+"""
 
-APP_MOCK = '''\
+APP_MOCK = """\
 // Minimal stub of ComfyUI's scripts/app.js for the Vitest harness.
-// Picker-module tests import `app` without a real frontend.
+// Extension-module tests import `app` without a real frontend.
 export const app = {
   registerExtension() {},
   graph: { _nodes: [] },
 };
-'''
+"""
 
-JS_TEST = '''\
+JS_TEST_MODAL = """\
 import { describe, expect, it } from "vitest";
-import { fuzzyRank } from "../../web/js/modal-fuzzy.js";
+// Vitest transpiles TypeScript, so the test imports the `.ts` source directly
+// (no build step). Importing the module also confirms the registerExtension
+// wiring loads cleanly against tests/js/__mocks__/app.js.
+import { clampToTargets } from "../../src/index.ts";
 
-// Smoke test so `npm test` is green from the first commit. Exercises the
-// copied fuzzy matcher; replace with real tests of this pack's pure helpers
-// as they land. fuzzyRank(query, [primary, ...rest]) -> {score, primaryMatches} | null.
+// Smoke test so `bun run test` is green from the first commit. Exercises the
+// placeholder pure helper; replace with real tests of this pack's helpers as
+// they land. Add at least one jsdom DOM-attach test per modal builder (assert
+// the expected element exists in modal.bodyEl after openX()) — the gate below
+// covers pure helpers only, which is exactly the gap that let an empty-modal
+// bug ship green. Use `vitest --environment jsdom` for those.
 describe("@@NAME@@ harness", () => {
-  it("scores a subsequence match and returns null for a non-match", () => {
-    const hit = fuzzyRank("eul", ["euler"]);
-    expect(hit).not.toBeNull();
-    expect(hit.score).toBeGreaterThan(0);
-
-    const miss = fuzzyRank("zzz", ["euler"]);
-    expect(miss).toBeNull();
+  it("recognises a target widget name and rejects a non-target", () => {
+    expect(clampToTargets("@@FIRST_WIDGET@@")).toBe(@@FIRST_WIDGET_EXPECT@@);
+    expect(clampToTargets("definitely-not-a-target-widget")).toBe(false);
   });
 });
-'''
+"""
 
-GESTURE_JS_TEST = '''\
+JS_TEST_GESTURE = """\
 import { describe, expect, it } from "vitest";
-import { pinchDistance, pointInRect, scaledSize } from "../../web/js/@@EXT_FILE@@.js";
+// Vitest transpiles TypeScript, so the test imports the `.ts` source directly
+// (no build step). Importing the module also confirms the registerExtension
+// wiring loads cleanly against tests/js/__mocks__/app.js.
+import { pinchDistance, pointInRect, scaledSize } from "../../src/index.ts";
 
-// Smoke tests so `npm test` is green from the first commit. Exercise the pure
-// gesture helpers; importing the module also confirms the registerExtension
-// wiring loads cleanly. Add a jsdom test for installGestureLayer's pointer
+// Smoke tests so `bun run test` is green from the first commit. Exercise the
+// pure gesture helpers. Add a jsdom test for installGestureLayer's pointer
 // handling as the real resize logic lands.
 describe("@@NAME@@ gesture helpers", () => {
   it("measures pinch distance", () => {
@@ -761,7 +1006,7 @@ describe("@@NAME@@ gesture helpers", () => {
     expect(scaledSize([200, 100], 0.1, [120, 60])).toEqual([120, 60]);
   });
 });
-'''
+"""
 
 TEST_INIT = '''\
 """Smoke tests for the loader stub so CI is green from the first commit."""
@@ -770,7 +1015,7 @@ import @@PY_MODULE_OR_INIT@@ as pack
 
 
 def test_web_directory_exported():
-    assert pack.WEB_DIRECTORY == "./web"
+    assert pack.WEB_DIRECTORY == "./web/dist"
 
 
 def test_node_mappings_exported():
@@ -778,7 +1023,69 @@ def test_node_mappings_exported():
     assert isinstance(pack.NODE_DISPLAY_NAME_MAPPINGS, dict)
 '''
 
-CI_YML = '''\
+# Backend variant only: the backend module does `from aiohttp import web` and
+# `from server import PromptServer` — ComfyUI-bundled libs the dev group does
+# NOT ship. This conftest stubs them (the gallery-loader pattern) so __init__.py
+# imports cleanly under pytest. Widen the stub set as the real backend grows
+# (numpy/torch/PIL/folder_paths/node_helpers are the usual additions).
+BACKEND_CONFTEST = '''\
+"""Stub ComfyUI-bundled imports so @@PY_MODULE@@.py can be imported in a vanilla
+Python environment for unit tests. The dev group ships none of these — they only
+exist inside a ComfyUI install — so the module-level imports would otherwise
+fail collection.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+
+class _StubModule(ModuleType):
+    def __getattr__(self, attr: str):
+        if attr.startswith("__"):
+            raise AttributeError(attr)
+        m = MagicMock()
+        setattr(self, attr, m)
+        return m
+
+
+def _ensure_stub(name: str) -> ModuleType:
+    if name in sys.modules and not isinstance(sys.modules[name], _StubModule):
+        return sys.modules[name]
+    m = _StubModule(name)
+    sys.modules[name] = m
+    return m
+
+
+# aiohttp — the backend does `from aiohttp import web`.
+_aiohttp = _ensure_stub("aiohttp")
+_aiohttp.web = _ensure_stub("aiohttp.web")
+
+# ComfyUI core `server` — the backend does `from server import PromptServer`.
+_server = _ensure_stub("server")
+
+
+class _NoopRoutes:
+    """Decorator-shaped no-op for @PromptServer.instance.routes.get(path)."""
+
+    def get(self, path):
+        def deco(fn):
+            return fn
+
+        return deco
+
+    def post(self, path):
+        return self.get(path)
+
+
+# PromptServer.instance.routes is read at module load; supply a real object so
+# the @decorator calls in @@PY_MODULE@@.py return their wrapped function.
+_server.PromptServer = SimpleNamespace(instance=SimpleNamespace(routes=_NoopRoutes()))
+'''
+
+CI_YML = """\
 name: CI
 
 on:
@@ -806,16 +1113,32 @@ jobs:
         run: uvx ruff format --check .
 
   lint-js:
-    name: Lint & format (JavaScript)
+    name: Lint & format (TypeScript/JSON)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
         with:
-          version: 2.4.15
+          # Pin to the schema version declared in biome.json. Bump in lockstep
+          # with a config migration via `biome migrate` when upgrading.
+          version: @@BIOME_VERSION@@
       - name: Biome check
         run: biome check .
+
+  typecheck-build:
+    name: Typecheck & build (TypeScript)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Typecheck
+        run: bun run typecheck
+      - name: Build
+        run: bun run build
 
   test:
     name: Tests (Python)
@@ -834,14 +1157,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-      - name: Install dev dependencies
-        run: npm install --no-audit --no-fund
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
       - name: Run Vitest
-        run: npm test
+        run: bun run test
 
   security:
     name: Security scanning
@@ -849,14 +1170,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          # gitleaks scans <prev>^..<head>; the parent commit must be present
+          # locally, so a shallow clone fails with "stderr is not empty".
           fetch-depth: 0
       - name: Gitleaks secret scan
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-'''
+"""
 
-PUBLISH_YML = '''\
+PUBLISH_YML = """\
 name: Publish to Comfy Registry
 
 on:
@@ -876,15 +1199,21 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v6
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+      - name: Install dependencies and build frontend
+        run: |
+          bun install --frozen-lockfile
+          bun run build
       - name: Publish Custom Node
         uses: Comfy-Org/publish-node-action@v1
         with:
           # PAT issued at https://registry.comfy.org/, stored as the
           # REGISTRY_ACCESS_TOKEN repo secret.
           personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}
-'''
+"""
 
-RELEASE_PLEASE_YML = '''\
+RELEASE_PLEASE_YML = """\
 name: "Release: release-please"
 
 on:
@@ -915,9 +1244,9 @@ jobs:
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
-'''
+"""
 
-DEPENDABOT_YML = '''\
+DEPENDABOT_YML = """\
 version: 2
 updates:
   - package-ecosystem: "github-actions"
@@ -928,9 +1257,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-'''
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+"""
 
-RP_CONFIG = '''\
+RP_CONFIG = """\
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "packages": {
@@ -952,11 +1285,11 @@ RP_CONFIG = '''\
   ],
   "separate-pull-requests": false
 }
-'''
+"""
 
 RP_MANIFEST = '{\n  ".": "0.1.0"\n}\n'
 
-PRE_COMMIT = '''\
+PRE_COMMIT = """\
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.12
@@ -969,7 +1302,9 @@ repos:
     rev: v0.6.1
     hooks:
       - id: biome-check
-        additional_dependencies: ["@biomejs/biome@1.9.4"]
+        # Match the biome.json schema (2.4.x) and CI's setup-biome pin so the
+        # pre-commit hook understands the 2.x config (e.g. files.includes).
+        additional_dependencies: ["@biomejs/biome@@@BIOME_VERSION@@"]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -984,9 +1319,9 @@ repos:
     rev: v8.24.3
     hooks:
       - id: gitleaks
-'''
+"""
 
-GITIGNORE = '''\
+GITIGNORE = """\
 __pycache__/
 *.py[cod]
 *$py.class
@@ -998,6 +1333,10 @@ __pycache__/
 .ruff_cache/
 node_modules/
 coverage/
+
+# Built frontend output — emitted by `bun run build`, force-shipped to the
+# Comfy Registry via [tool.comfy] includes in pyproject.toml.
+web/dist/
 
 # Editor
 .vscode/
@@ -1012,11 +1351,11 @@ Thumbs.db
 # Local notes / scratch
 TODO.local.md
 NOTES.local.md
-'''
+"""
 
-GITATTRIBUTES = "* text=auto eol=lf\n*.png binary\n*.jpg binary\n*.webp binary\nuv.lock linguist-generated=true\npackage-lock.json linguist-generated=true\n"
+GITATTRIBUTES = "* text=auto eol=lf\n*.png binary\n*.jpg binary\n*.webp binary\nuv.lock linguist-generated=true\nbun.lock linguist-generated=true\n"
 
-LICENSE = '''\
+LICENSE = """\
 MIT License
 
 Copyright (c) @@YEAR@@ @@AUTHOR@@
@@ -1038,9 +1377,9 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-'''
+"""
 
-RELEASE_CHECKLIST = '''\
+RELEASE_CHECKLIST = """\
 # Release checklist
 
 ## One-time setup
@@ -1057,17 +1396,110 @@ RELEASE_CHECKLIST = '''\
 
 - [ ] Land work via conventional commits on feature branches → PRs to `main`.
 - [ ] Merge the release-please PR (it bumps `version` + updates `CHANGELOG.md`).
-- [ ] The version bump on `main` triggers `publish.yml` → Comfy Registry.
+- [ ] The version bump on `main` triggers `publish.yml`, which runs
+      `bun install && bun run build` before `publish-node-action` so the built
+      `web/dist/` exists at publish time → Comfy Registry.
 - [ ] Verify the new version appears on registry.comfy.org.
-'''
+"""
+
+ADR_0001 = """\
+---
+id: ADR-0001
+date: @@DATE@@
+status: Accepted
+deciders: @@AUTHOR@@
+domain: build-tooling
+github-issues: []
+---
+
+# ADR-0001: TypeScript source + bun build (browser ESM)
+
+## Context
+
+This pack reaches deep into the **minified** ComfyUI frontend's LiteGraph
+widget/node/canvas objects (`widget.onPointerDown`, `node.widgets`,
+`app.canvas`, `ds.scale`/`ds.offset`). Those accesses are exactly where a
+frontend-version bump silently breaks the pack. A vanilla-JS single file has no
+static type checking at that seam — the largest source of silent breakage is
+uncaught until runtime.
+
+## Decision
+
+Author the frontend in **TypeScript** under `src/` (entry `src/index.ts`) and
+build to `web/dist/` with **`bun build`**:
+
+```sh
+bun build ./src/index.ts --target browser --format esm --outdir web/dist --external '/scripts/*'
+```
+
+- **Type gate**: `bun run typecheck` → `tsc --noEmit` against
+  `@comfyorg/comfyui-frontend-types`. `tsc` never emits; `bun build` never
+  type-checks — the two are decoupled and each stays fast and single-purpose.
+- **Emit**: `bun build` produces browser-clean ESM with the `/scripts/app.js`
+  runtime import left **unbundled** (`--external '/scripts/*'`), resolved at
+  runtime against ComfyUI's served module. If the pack ships a static data
+  corpus, append `&& cp -R web/data web/dist/data` to the build script.
+- **Serve**: `__init__.py` sets `WEB_DIRECTORY = "./web/dist"`. ComfyUI serves
+  that tree at `/extensions/@@NAME@@/`, so the built JS is at
+  `/extensions/@@NAME@@/index.js`.
+- **Distribution**: `web/dist/` is git-ignored (generated). The Comfy Registry
+  tarball includes it via `[tool.comfy] includes = ["web/dist"]`, and
+  `publish.yml` runs `bun run build` before `publish-node-action`.
+
+@@ADR_KIT_SECTION@@## Type-seam notes (for future maintainers)
+
+- `@comfyorg/comfyui-frontend-types` exports `ComfyApp` at the module root but
+  **not** `LGraphNode` / `LGraphCanvas` / the widget interfaces (declared
+  internally, un-exported). Model the small surface this pack touches with local
+  structural interfaces rather than importing un-exportable types.
+- TypeScript will not match an ambient `declare module` against a rooted
+  (`/scripts/app.js`) path specifier. A `paths` mapping in `tsconfig.json` points
+  that import at `src/comfyui-shims.d.ts` for type resolution; the emitted import
+  string stays `/scripts/app.js` and `--external '/scripts/*'` keeps it unbundled.
+
+## Consequences
+
+- **Positive**: static type checking at the version-sensitive frontend seam;
+  output is still plain browser ESM served as a static file (no runtime bundler,
+  no framework); `knip` + `tsc` + Vitest + Biome give a complete local gate
+  chain; Vitest imports the `.ts` source directly (no build dependency in tests).
+- **Negative**: the edit → refresh loop now requires a `bun run build` step; a
+  build artifact must exist before the registry publish (CI wires this); one more
+  dev-dependency set (`typescript`, `@comfyorg/comfyui-frontend-types`, `knip`)
+  and a `tsconfig.json` to maintain.
+
+## Supersedes
+
+This replaces the earlier vanilla-JS approach (a single `web/js/<short>.js` with
+copied-in `modal-shell.js` / `modal-fuzzy.js`). The modal primitives are now
+consumed from `@@MODAL_KIT_PKG@@` and `bun build` inlines them.
+"""
+
+ADR_KIT_SECTION_MODAL = """\
+## Shared modal kit (not copied)
+
+The modal-shell + fuzzy-matcher primitives come from `@@MODAL_KIT_PKG@@`
+(a dependency), imported in `src/index.ts`. They are **not** vendored into the
+pack — `bun build` inlines the imported code into `web/dist`. This single-sources
+the primitives that were previously copied byte-identically across packs.
+
+"""
 
 
 # --------------------------------------------------------------------------- #
 # Generation
 # --------------------------------------------------------------------------- #
-def build_file_map(ctx: dict[str, str], variant: str, widgets: list[str]) -> dict[str, str]:
+def build_file_map(
+    ctx: dict[str, str], variant: str, widgets: list[str]
+) -> dict[str, str]:
     backend = variant == "backend"
     gesture = variant == "gesture"
+    modal = not gesture  # frontend or backend → consumes the kit
+
+    # Shared pinned versions injected into every templated config.
+    ctx["BIOME_VERSION"] = BIOME_VERSION
+    ctx["COMFY_FRONTEND_TYPES_VERSION"] = COMFY_FRONTEND_TYPES_VERSION
+    ctx["MODAL_KIT_PKG"] = MODAL_KIT_PKG
 
     # Variant-conditional pyproject bits.
     ctx["BACKEND_DEP_NOTE"] = (
@@ -1075,41 +1507,70 @@ def build_file_map(ctx: dict[str, str], variant: str, widgets: list[str]) -> dic
         if backend
         else "Frontend-only pack — no runtime Python deps."
     )
+    # importlib import-mode keeps pytest from importing the pack-root
+    # __init__.py as a discovered package (its relative import would fail).
+    # Backend-only — frontend/gesture import the stub cleanly with the default.
     ctx["PYTEST_ADDOPTS"] = (
-        '# importlib mode avoids pytest treating the pack-root __init__.py\n'
-        '# (with its relative import) as a discovered package.\n'
+        "# importlib mode avoids pytest treating the pack-root __init__.py\n"
+        "# (with its relative import) as a discovered package.\n"
         'addopts = "--import-mode=importlib"\n'
         if backend
         else ""
     )
     ctx["WIDGET_SET"] = ", ".join(f'"{w}"' for w in widgets)
+    # First widget drives the modal smoke test's positive assertion.
+    first_widget = widgets[0] if widgets else ""
+    ctx["FIRST_WIDGET"] = first_widget
+    ctx["FIRST_WIDGET_EXPECT"] = "true" if first_widget else "false"
+
+    # package.json: only the modal variants add the kit as a runtime dependency.
+    if modal:
+        ctx["DEPENDENCIES_BLOCK"] = (
+            '\n  "dependencies": {\n'
+            f'    "{MODAL_KIT_PKG}": "{MODAL_KIT_VERSION}"\n'
+            "  },"
+        )
+        ctx["KIT_PKG_NOTE"] = (
+            f" The {MODAL_KIT_PKG} primitives are inlined by bun build."
+        )
+    else:
+        ctx["DEPENDENCIES_BLOCK"] = ""
+        ctx["KIT_PKG_NOTE"] = ""
 
     # CLAUDE.md conditional fragments.
     if backend:
         ctx["CLAUDE_INTRO"] = (
             f"ComfyUI custom-node pack with a thin Python backend (a node + HTTP "
-            f"endpoints in `{ctx['PY_MODULE']}.py`) and a JS frontend extension."
+            f"endpoints in `{ctx['PY_MODULE']}.py`) and a TypeScript frontend "
+            f"extension built to `web/dist/` via bun. See ADR-0001."
         )
     elif gesture:
         ctx["CLAUDE_INTRO"] = (
             "Frontend-only ComfyUI custom-node pack in the canvas-gesture vein. "
-            "`__init__.py` is a loader stub; the whole extension lives in `web/js/`."
+            "`__init__.py` is a loader stub; the whole extension is TypeScript in "
+            "`src/`, built to `web/dist/` via bun. See ADR-0001."
         )
     else:
         ctx["CLAUDE_INTRO"] = (
             "Frontend-only ComfyUI custom-node pack. `__init__.py` is a loader "
-            "stub; the whole extension lives in `web/js/`."
+            "stub; the whole extension is TypeScript in `src/`, built to "
+            "`web/dist/` via bun. See ADR-0001."
         )
     ctx["INIT_DESC"] = (
-        "Imports node mappings from the backend module; exports `WEB_DIRECTORY`."
+        'Imports node mappings from the backend module; exports `WEB_DIRECTORY = "./web/dist"`.'
         if backend
-        else "Empty `NODE_CLASS_MAPPINGS`; exports `WEB_DIRECTORY = \"./web\"`."
+        else 'Empty `NODE_CLASS_MAPPINGS`; exports `WEB_DIRECTORY = "./web/dist"`.'
     )
     ctx["BACKEND_LAYOUT_ROW"] = (
         f"| `{ctx['PY_MODULE']}.py` | Node + HTTP endpoints. Bundled libs only; "
         f"arbitrary-path endpoints gate on an extension whitelist. |\n"
         if backend
         else ""
+    )
+    ctx["PYTEST_LAYOUT_NOTE"] = (
+        " `tests/test_init.py` is the pytest backend suite."
+        if backend
+        else " `tests/test_init.py` is a pytest loader-stub smoke test."
     )
     ctx["DEP_RULE"] = (
         "No new Python dependencies. Backend uses ComfyUI-bundled libs only "
@@ -1119,33 +1580,53 @@ def build_file_map(ctx: dict[str, str], variant: str, widgets: list[str]) -> dic
         else "No Python dependencies. The pack is frontend-only; a feature "
         "genuinely needing Python belongs in a separate companion pack."
     )
+    ctx["KIT_RULE"] = (
+        f"**Modal primitives come from `{MODAL_KIT_PKG}`** — import them, do NOT "
+        "copy `modal-shell.js`/`modal-fuzzy.js` into the pack. `bun build` inlines "
+        "the imported code into `web/dist`."
+        if modal
+        else "**No modal kit.** This gesture pack has no widget to hook and no "
+        "modal; it adds a canvas pointer layer with self-contained pure helpers."
+    )
+    ctx["KIT_DEV_NOTE"] = (
+        f"{MODAL_KIT_PKG} (inlined at build)"
+        if modal
+        else "(no modal kit — gesture pack)"
+    )
     ctx["RESTART_NOTE"] = (
-        f"Changes to `{ctx['PY_MODULE']}.py` (backend) DO require a ComfyUI restart."
+        f" Changes to `{ctx['PY_MODULE']}.py` (backend) DO require a ComfyUI restart."
         if backend
         else ""
     )
-    ctx["PY_MODULE_OR_INIT"] = ctx["PY_MODULE"] if backend else "__init__"
+    # The smoke test imports `__init__` for both: it defines WEB_DIRECTORY and
+    # re-exports the node mappings. The backend conftest stubs aiohttp/server so
+    # `__init__`'s import of the backend module resolves under pytest.
+    ctx["PY_MODULE_OR_INIT"] = "__init__"
     ctx["DISPLAY_NOSPACE"] = ctx["DISPLAY"].replace(" ", "")
 
-    # Vein-conditional fragments: the modal vein (frontend/backend) intercepts a
-    # widget and opens an HTML modal; the gesture vein adds a canvas pointer layer.
+    # ADR conditional: the modal variants document the shared-kit decision.
+    ctx["ADR_KIT_SECTION"] = subst(ADR_KIT_SECTION_MODAL, ctx) if modal else ""
+
+    # Vein-conditional fragments.
     if gesture:
         ctx["DEP_FLOOR_NOTE"] = "Floor tied to the modern Vue canvas/pointer model."
+        ctx["WHAT_DESC"] = "the canvas gesture it adds and which targets it acts on"
         ctx["VEIN"] = (
             "A mobile-first ComfyUI usability pack in the *gesture* vein: instead "
-            "of intercepting a single widget, a frontend JS extension adds a "
+            "of intercepting a single widget, a frontend extension adds a "
             "CANVAS-LEVEL pointer layer. A two-finger pinch whose centroid lands "
             "inside a **selected** node (single tap selects it) resizes that node "
             "and suppresses the native canvas zoom for the gesture's duration. The "
             "enhancement is **additive** (no-op fallback if `app.canvas` or the "
             "pointer model is absent — native corner-handle resize still works), "
             "**touch-first**, and never breaks serialized workflows (it only writes "
-            "`node.size`, which is already serialized). Pure geometry helpers live "
-            "at the top of the extension and are unit-tested; DOM/canvas wiring "
-            "stays below them."
+            "`node.size`, which is already serialized). Pure geometry helpers are "
+            "exported from `src/index.ts` and unit-tested; DOM/canvas wiring stays "
+            "below them."
         )
-        ctx["EXT_ROW_DESC"] = "The extension: canvas pointer layer + pure geometry helpers."
-        ctx["MODAL_LAYOUT_ROWS"] = ""
+        ctx["EXT_ROW_DESC"] = (
+            "The extension: canvas pointer layer + exported pure geometry helpers."
+        )
         ctx["HOOK_RULE"] = (
             "**Canvas pointer model is version-sensitive.** The pinch layer reads "
             "`app.canvas` / `ds.scale` / `ds.offset` and the pointer-event stream. "
@@ -1162,27 +1643,26 @@ def build_file_map(ctx: dict[str, str], variant: str, widgets: list[str]) -> dic
         )
     else:
         ctx["DEP_FLOOR_NOTE"] = "Floor tied to widget.onPointerDown availability."
+        ctx["WHAT_DESC"] = "the widgets it enhances and the modal it opens"
         ctx["VEIN"] = (
-            "A mobile-first ComfyUI usability pack: a frontend JS extension that "
+            "A mobile-first ComfyUI usability pack: a frontend extension that "
             "intercepts a widget interaction (`widget.onPointerDown`, modern Vue "
             "frontend) and opens a touch-friendly HTML modal in place of a clunky "
             "native LiteGraph control. Widgets are matched **by name** (generic "
             "across node packs), the enhancement is **additive** (graceful fallback "
             "to the native control, never breaks serialized workflows), and the "
             "modal is **touch-first** (16px inputs to avoid iOS zoom, big tap "
-            "targets, momentum scroll). Reuses `modal-shell.js` (`openModalShell` / "
-            "`closeModalShell`) and `modal-fuzzy.js` (`fuzzyScore` / `fuzzyRank` / "
-            "`highlightMatches`)."
+            f"targets, momentum scroll). The modal primitives come from "
+            f"`{MODAL_KIT_PKG}` (`openModalShell` / `fuzzyRank` / `highlightMatches`), "
+            "imported and inlined by `bun build` — not copied into the pack."
         )
-        ctx["EXT_ROW_DESC"] = "The extension: widget interception + modal."
-        ctx["MODAL_LAYOUT_ROWS"] = (
-            "| `web/js/modal-shell.js` | Reusable modal dialog (copied from gallery-loader). |\n"
-            "| `web/js/modal-fuzzy.js` | fzf-lite fuzzy matcher (copied from gallery-loader). |\n"
+        ctx["EXT_ROW_DESC"] = (
+            "The extension: widget interception + modal (consumes the modal kit)."
         )
         ctx["HOOK_RULE"] = (
             "**Frontend hook is version-sensitive.** The modal opens via "
-            "`widget.onPointerDown`. Keep an explicit button-widget fallback "
-            "(Strategy B) if you depend on the modal being reachable."
+            "`widget.onPointerDown`. Keep an explicit button-widget fallback if "
+            "you depend on the modal being reachable."
         )
         ctx["FAMILY_BLURB"] = (
             "> touch-friendly HTML modals that replace clunky native LiteGraph\n"
@@ -1201,6 +1681,8 @@ def build_file_map(ctx: dict[str, str], variant: str, widgets: list[str]) -> dic
         "RELEASE-CHECKLIST.md": RELEASE_CHECKLIST,
         "justfile": JUSTFILE,
         "biome.json": BIOME_JSON,
+        "knip.json": KNIP_JSON,
+        "tsconfig.json": TSCONFIG,
         "package.json": PACKAGE_JSON,
         "vitest.config.js": VITEST_CONFIG,
         ".pre-commit-config.yaml": PRE_COMMIT,
@@ -1212,14 +1694,18 @@ def build_file_map(ctx: dict[str, str], variant: str, widgets: list[str]) -> dic
         ".github/workflows/publish.yml": PUBLISH_YML,
         ".github/workflows/release-please.yml": RELEASE_PLEASE_YML,
         ".github/dependabot.yml": DEPENDABOT_YML,
-        f"web/js/{ctx['EXT_FILE']}.js": GESTURE_JS if gesture else EXT_JS,
+        "docs/blueprint/adrs/0001-adopt-typescript-bun-build.md": ADR_0001,
+        "src/index.ts": INDEX_TS_GESTURE if gesture else INDEX_TS_MODAL,
+        "src/comfyui-shims.d.ts": COMFYUI_SHIMS,
         "tests/test_init.py": TEST_INIT,
         "tests/js/__mocks__/app.js": APP_MOCK,
-        f"tests/js/{ctx['EXT_FILE']}.test.js": GESTURE_JS_TEST if gesture else JS_TEST,
+        "tests/js/index.test.js": JS_TEST_GESTURE if gesture else JS_TEST_MODAL,
     }
     if backend:
         files["__init__.py"] = INIT_BACKEND
         files[f"{ctx['PY_MODULE']}.py"] = BACKEND_PY
+        # Stub aiohttp/server so the backend imports cleanly under pytest.
+        files["tests/conftest.py"] = BACKEND_CONFTEST
     else:
         files["__init__.py"] = INIT_FRONTEND
 
@@ -1227,26 +1713,32 @@ def build_file_map(ctx: dict[str, str], variant: str, widgets: list[str]) -> dic
 
 
 def main() -> int:
-    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    p.add_argument("--name", required=True, help="pack/repo name, e.g. comfyui-touch-numeric")
-    p.add_argument("--display", required=True, help='Comfy DisplayName, e.g. "Touch Numeric"')
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument(
+        "--name", required=True, help="pack/repo name, e.g. comfyui-touch-numeric"
+    )
+    p.add_argument(
+        "--display", required=True, help='Comfy DisplayName, e.g. "Touch Numeric"'
+    )
     p.add_argument("--desc", required=True, help="one-line description")
-    p.add_argument("--variant", choices=["frontend", "backend", "gesture"], default="frontend")
-    p.add_argument("--widgets", default="", help="CSV of target widget names for the JS stub (modal variants only)")
+    p.add_argument(
+        "--variant", choices=["frontend", "backend", "gesture"], default="frontend"
+    )
+    p.add_argument(
+        "--widgets",
+        default="",
+        help="CSV of target widget names for the TS stub (modal variants only)",
+    )
     p.add_argument("--publisher", default=PUBLISHER_DEFAULT)
     p.add_argument("--author", default=AUTHOR_DEFAULT)
-    p.add_argument("--dir", default=".", help="parent directory to create the pack in (default: cwd)")
     p.add_argument(
-        "--modal-source",
-        default="",
-        help="pack dir to copy modal-shell.js + modal-fuzzy.js from "
-        "(default: <parent>/comfyui-gallery-loader). Pass 'none' to skip.",
+        "--dir",
+        default=".",
+        help="parent directory to create the pack in (default: cwd)",
     )
     args = p.parse_args()
-
-    # The gesture variant imports no modal primitives — skip the copy by default.
-    if args.variant == "gesture" and not args.modal_source:
-        args.modal_source = "none"
 
     ctx = derive(args.name)
     ctx.update(
@@ -1255,13 +1747,16 @@ def main() -> int:
         PUBLISHER=args.publisher,
         AUTHOR=args.author,
         YEAR=str(datetime.date.today().year),
+        DATE=datetime.date.today().isoformat(),
     )
     widgets = [w.strip() for w in args.widgets.split(",") if w.strip()]
 
     parent = Path(args.dir).resolve()
     target = parent / args.name
     if target.exists():
-        print(f"error: {target} already exists — refusing to overwrite", file=sys.stderr)
+        print(
+            f"error: {target} already exists — refusing to overwrite", file=sys.stderr
+        )
         return 1
 
     file_map = build_file_map(ctx, args.variant, widgets)
@@ -1270,43 +1765,30 @@ def main() -> int:
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_text(content)
 
-    # Copy the proven modal primitives so the JS stub's imports resolve.
-    copied = []
-    if args.modal_source.lower() != "none":
-        src_dir = Path(args.modal_source).resolve() if args.modal_source else parent / "comfyui-gallery-loader"
-        for fname in ("modal-shell.js", "modal-fuzzy.js"):
-            src = src_dir / "web" / "js" / fname
-            if src.is_file():
-                shutil.copy2(src, target / "web" / "js" / fname)
-                copied.append(fname)
-        if not copied:
-            print(
-                f"note: no modal primitives copied (looked in {src_dir}/web/js). "
-                f"The JS stub imports ./modal-shell.js and ./modal-fuzzy.js — "
-                f"copy them in, or adjust the imports.",
-                file=sys.stderr,
-            )
-
-    n = len(file_map) + len(copied)
+    n = len(file_map)
     print(f"\nScaffolded {args.name} ({args.variant}) — {n} files in {target}")
-    if copied:
-        print(f"  copied modal primitives: {', '.join(copied)}")
     print(
         "\nNext steps:\n"
         f"  cd {target}\n"
         "  git init -b main                       # seed main directly (no branch juggling)\n"
         "  uv sync --group dev\n"
-        "  npm install --no-audit --no-fund\n"
-        "  pre-commit install\n"
-        "  just check                              # lint + test should pass green\n"
+        "  bun install                            # TypeScript, Biome, Vitest, knip"
+        + (", comfy-modal-kit\n" if args.variant != "gesture" else "\n")
+        + "  pre-commit install\n"
+        "  just check                              # typecheck + build + lint + test should pass green\n"
         "\nThen:\n"
         + (
-            f"  - tune the pinch layer in web/js/{ctx['EXT_FILE']}.js "
+            "  - tune the pinch layer in src/index.ts "
             "(selectedNodes/nodeScreenRect/scaledSize; groups + affordance TODOs)\n"
             if args.variant == "gesture"
-            else f"  - implement the modal in web/js/{ctx['EXT_FILE']}.js (TARGET_WIDGETS + openPicker)\n"
+            else "  - implement the modal in src/index.ts (TARGET_WIDGETS + openPicker; "
+            "import fuzzyRank from @laurigates/comfy-modal-kit for search)\n"
         )
-        + (f"  - implement the node/endpoints in {ctx['PY_MODULE']}.py\n" if args.variant == "backend" else "")
+        + (
+            f"  - implement the node/endpoints in {ctx['PY_MODULE']}.py\n"
+            if args.variant == "backend"
+            else ""
+        )
         + "  - add the repo to gitops/repositories.tf with comfy_registry = true\n"
         "    (do NOT create via the GitHub UI; gitops auto-pushes REGISTRY_ACCESS_TOKEN)\n"
         "  - or run the /comfy-node orchestrator, which does the gitops wiring for you\n"

--- a/scripts/plugin-compliance-check.sh
+++ b/scripts/plugin-compliance-check.sh
@@ -331,6 +331,62 @@ check_skill_body() {
       fi
     fi
 
+    # Regression: comfyui-node-scaffold must emit a TypeScript + bun-build pack
+    # consuming @laurigates/comfy-modal-kit (NOT a vanilla-JS pack with copied-in
+    # modal primitives), and its biome pin must be consistent across biome.json,
+    # the pre-commit hook, and CI. The previous template pinned
+    # @biomejs/biome@1.9.4 in pre-commit while biome.json/CI were on 2.x — a
+    # silent mismatch the pre-commit hook surfaced as a config-parse failure.
+    # The templates live in the sibling scaffold.py (not the SKILL.md body), so
+    # this check reads that generator. Semantic invariants:
+    #   1. emits TypeScript (src/index.ts), not web/js/*.js vanilla
+    #   2. consumes the shared kit via import (no copied modal-shell/-fuzzy)
+    #   3. every biome pin is the same version (no 1.9.4 drift)
+    if [ "$skill_name" = "comfyui-node-scaffold" ]; then
+      local scaffold_py
+      scaffold_py="$(dirname "$skill_file")/scaffold.py"
+      if [ ! -f "$scaffold_py" ]; then
+        issues+=("❌ ${plugin}/${skill_name}: scaffold.py missing next to SKILL.md")
+        has_errors=true
+      else
+        # 1. TypeScript, not vanilla JS.
+        if ! grep -q '"src/index.ts":' "$scaffold_py"; then
+          issues+=("❌ ${plugin}/${skill_name}: scaffold.py must emit TypeScript 'src/index.ts' (TS+bun template, not vanilla web/js/*.js)")
+          has_errors=true
+        fi
+        if grep -q '"web/js/' "$scaffold_py"; then
+          issues+=("❌ ${plugin}/${skill_name}: scaffold.py must not emit vanilla 'web/js/*.js' — the TS source lives in src/ and builds to web/dist/")
+          has_errors=true
+        fi
+        # 2. Consume the shared kit; never copy the primitives in.
+        if ! grep -q 'comfy-modal-kit' "$scaffold_py"; then
+          issues+=("❌ ${plugin}/${skill_name}: scaffold.py modal variants must consume @laurigates/comfy-modal-kit (the dependency + import)")
+          has_errors=true
+        fi
+        if grep -Eq 'shutil\.copy|modal-shell\.js"|modal-fuzzy\.js"' "$scaffold_py"; then
+          issues+=("❌ ${plugin}/${skill_name}: scaffold.py must not copy modal-shell.js/modal-fuzzy.js into the pack — consume the kit instead")
+          has_errors=true
+        fi
+        # 3. biome pin consistency: every generated biome pin must flow from the
+        #    single @@BIOME_VERSION@@ token, never a hard-coded version. No stale
+        #    1.x literal pin (the original bug), and a single-source constant.
+        if grep -Eq '@biomejs/biome@1\.[0-9]' "$scaffold_py"; then
+          issues+=("❌ ${plugin}/${skill_name}: scaffold.py pins a stale 1.x @biomejs/biome — must use @@BIOME_VERSION@@ (2.x)")
+          has_errors=true
+        fi
+        if ! grep -q '^BIOME_VERSION = ' "$scaffold_py"; then
+          issues+=("❌ ${plugin}/${skill_name}: scaffold.py must single-source the biome pin in a BIOME_VERSION constant")
+          has_errors=true
+        fi
+        # Any hard-coded biome version pin in a template (a literal X.Y.Z next to
+        # 'biome', rather than the @@BIOME_VERSION@@ token) can drift — reject it.
+        if grep -Eq 'biome[^@]*@[0-9]+\.[0-9]+\.[0-9]+|biome/schemas/[0-9]+\.[0-9]+\.[0-9]+' "$scaffold_py"; then
+          issues+=("❌ ${plugin}/${skill_name}: scaffold.py hard-codes a biome version in a template — use the @@BIOME_VERSION@@ token so all pins stay in lockstep")
+          has_errors=true
+        fi
+      fi
+    fi
+
     # Regression: feedback-session Step 1a silently filed against the cwd git
     # remote even when the session's tool calls were dominated by a different
     # plugin/source repo (issue #1425). The semantic invariant is that the


### PR DESCRIPTION
## What

Rewrites the `comfyui-node-scaffold` skill so it generates a **TypeScript + bun build** pack template instead of the vanilla-JS template. This codifies the architecture validated across 7 packs (`comfyui-gallery-loader`, `comfyui-sampler-info`, `comfyui-touch-numeric`, `comfyui-touch-resize`, …).

**Supersedes the vanilla-JS template** (`web/js/*.js` + copied-in `modal-shell.js`/`modal-fuzzy.js`) and **fixes the biome `@1.9.4` pre-commit pin** that mismatched biome.json/CI 2.x.

## What the updated scaffold emits

- **TypeScript source under `src/`** (entry `src/index.ts`) + `src/comfyui-shims.d.ts`, with the tsconfig `paths` mapping for the `/scripts/app.js` runtime import (not an ambient `declare module`).
- **bun build** to `web/dist/` (`--target browser --format esm --external '/scripts/*'`); `WEB_DIRECTORY="./web/dist"`; `[tool.comfy] includes=["web/dist"]`; `web/dist` git-ignored. The ADR notes the `&& cp -R web/data web/dist/data` append for corpus packs.
- **Shared kit, not copied primitives:** the `frontend`/`backend` (modal) variants add `@laurigates/comfy-modal-kit` as a dependency and `import` from it; `bun build` inlines it. The **gesture** variant adds no kit.
- **Configs:** strict `tsconfig.json` (noEmit), `knip.json`, `vitest.config.js` (aliases `/scripts/app.js`), `biome.json`, and all biome pins single-sourced at **2.4.15** (pre-commit, biome.json, CI, justfile).
- **CI** (`ci.yml`): tsc+build (bun), biome 2.4.15, vitest, ruff+pytest, gitleaks. **`publish.yml`** runs `bun install && bun run build` BEFORE the publish action.
- **ADR** `docs/blueprint/adrs/0001-adopt-typescript-bun-build.md` recording the decision (mirrors sampler-info's ADR-0010; the kit section is included for modal variants only).
- **Backend** variant additionally gets `tests/conftest.py` stubbing aiohttp/server so pytest is green without a ComfyUI runtime.

## Variant differences

| | frontend | backend | gesture |
|---|---|---|---|
| `src/index.ts` | widget-intercept modal | (same) + `<module>.py` node/endpoints | canvas pointer layer + pure helpers |
| `@laurigates/comfy-modal-kit` | dependency + import | dependency + import | **none** |
| Python test | imports `__init__` | `conftest.py` stubs aiohttp/server | imports `__init__` |
| ADR kit section | yes | yes | no |

## Regression check

Added to `scripts/plugin-compliance-check.sh` `check_skill_body()`, scoped to `comfyui-node-scaffold` (reads the sibling `scaffold.py`). It is a **semantic** gate asserting the generator:
1. emits TypeScript `src/index.ts`, not vanilla `web/js/*.js`;
2. consumes `@laurigates/comfy-modal-kit` and never copies the primitives in (`shutil.copy` / `modal-shell.js"` / `modal-fuzzy.js"`);
3. keeps every biome pin on one version — no stale `@biomejs/biome@1.x`, a single-source `BIOME_VERSION` constant, no hard-coded version in any template.

Verified the gate **fires** on each injected bug and **passes** on the fixed generator.

## Verification

All three variants pass the full gate from the first scaffold:

```
tsc=OK build=OK biome=OK knip=OK vitest=OK ruff=OK pytest=OK   (×3 variants)
```

`scripts/plugin-compliance-check.sh comfyui-plugin` → Body ✅ (only pre-existing `comfy-node` size ⚠️ remains). `lint-context-commands.sh`, `lint-shell-scripts.sh`, and all pre-commit hooks pass. Docs (SKILL.md + plugin README) updated in the same commit; frontmatter `modified`/`reviewed` bumped to 2026-06-06.

🤖 Generated with [Claude Code](https://claude.com/claude-code)