### PR TITLE
docs: distill session learnings (npm publish gotchas + pilot-before-fanout)

### DIFF
--- a/agent-patterns-plugin/skills/wave-based-dispatch/SKILL.md
+++ b/agent-patterns-plugin/skills/wave-based-dispatch/SKILL.md
@@ -5,8 +5,8 @@ user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 model: opus
 created: 2026-04-25
-modified: 2026-05-09
-reviewed: 2026-04-25
+modified: 2026-06-06
+reviewed: 2026-06-06
 ---
 
 # Wave-Based Dispatch
@@ -71,6 +71,43 @@ Process:
 See `agent-patterns-plugin:exclusive-lock-dispatch` when the probe tool
 holds an exclusive lock — the pre-dump mechanics there are the right
 shape for the research wave's brief.
+
+## The Pilot-Before-Fan-Out Gate
+
+When the **same transformation** will be applied to N items (repos, files,
+packages, services), validate the whole recipe on **one representative
+pilot end-to-end — including the riskiest unknown — before fanning out**.
+Wave 1 is the pilot; wave 2 is the fan-out, and it *mirrors* the landed
+pilot rather than re-deriving the recipe N times in parallel.
+
+The reason is concrete: a parallel fan-out over an unvalidated recipe
+multiplies a single wrong assumption into N broken outputs, and you pay
+for all N before discovering the flaw. Proving it once converts the
+fan-out agents' job from "figure out how" to "replicate this exact,
+working example" — which is both cheaper and far more reliable.
+
+Process:
+
+1. **Wave 1 = the pilot.** Pick the *simplest representative* item. Do
+   the full transformation, and explicitly confirm the **load-bearing
+   unknown** — the one thing that, if it didn't work, would invalidate
+   the entire approach (a build externalization, an API contract, a
+   migration codemod's output).
+2. **Gate.** The pilot's own gates (build/test/lint) must pass **and**
+   the risky unknown must be confirmed before any fan-out brief is
+   written.
+3. **Wave 2 = the fan-out.** Each agent is told to mirror the landed
+   pilot — cite its path verbatim as the reference implementation — with
+   per-item detection only for the parts that genuinely vary.
+4. **If the pilot reveals the approach is wrong, re-plan.** Cheap,
+   because only one item was touched.
+
+Distinct from the Research-Before-WO Gate above: research produces a
+*spec / artefact* to scope an unknown ("what should we build?"); a pilot
+produces a *working reference implementation* of a repeatable change
+("we know what to build — is the recipe sound, and does the risky step
+actually work?"). Reach for research when the scope is unknown; reach for
+a pilot when the scope is known but the recipe is unproven.
 
 ## Six-Gate Verification Table Between Waves
 

--- a/typescript-plugin/skills/bun-publishing/skill.md
+++ b/typescript-plugin/skills/bun-publishing/skill.md
@@ -4,8 +4,8 @@ description: "Publish npm packages built with Bun: package.json config, CLI tool
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2025-12-21
-modified: 2026-05-09
-reviewed: 2025-12-21
+modified: 2026-06-06
+reviewed: 2026-06-06
 ---
 
 # Bun npm Publishing
@@ -390,3 +390,47 @@ npm pack --dry-run
 # Ensure chmod in build script
 chmod +x build/index.js
 ```
+
+**2FA publish (`EOTP`) is not automatable:**
+
+A non-interactive shell — a CI step, or an agent's Bash tool — cannot
+supply a one-time password. `npm publish` fails with:
+
+```
+npm error code EOTP
+npm error This operation requires a one-time password.
+```
+
+Two ways through:
+
+- **Human, interactive**: `npm publish --otp=<6-digit-code>` (the code
+  comes from the publisher's authenticator app, not from npm on demand).
+- **Automation token (CI / unattended)**: a Granular/Automation token
+  (npmjs.com → Access Tokens) **bypasses 2FA at publish time**. Put it in
+  `NODE_AUTH_TOKEN` / `NPM_TOKEN`. This is exactly why the release-please
+  workflow above publishes cleanly while a local `npm publish` prompts —
+  CI uses the token, the human uses the OTP.
+
+An agent that hits `EOTP` should hand the publish to the user or switch
+the repo to an automation token — it cannot mint or supply one itself
+(`npm token create` also requires a valid, OTP-satisfied session).
+
+**Fresh publish 404s for a few minutes (propagation lag):**
+
+Right after a first publish, *public / unauthenticated* reads can 404
+while the package is genuinely live — the access record updates instantly
+but the public metadata CDN lags. Don't conclude the publish failed.
+Confirm with authenticated, version-pinned checks:
+
+```bash
+npm access list packages              # shows it under your account immediately
+npm view @org/pkg@<version> _id       # version-pinned, authed — resolves once live
+npm pack @org/pkg@<version>           # actually fetches the tarball (definitive)
+```
+
+Signature of *propagation lag* (not a private/failed publish): a public
+404 **plus** `npm access list packages` shows the package **plus** an
+authed `npm pack @org/pkg@<version>` succeeds. (`npm config get
+//registry.npmjs.org/:_authToken` often returns empty even when logged
+in, so a hand-rolled `curl` with that "token" is an unauthenticated probe
+— use the `npm` CLI itself, which reads auth correctly, to test.)


### PR DESCRIPTION
Distilled from a session that built/published @laurigates/comfy-modal-kit and migrated 7 ComfyUI packs to TypeScript via a pilot-then-fanout workflow.

## Two skill updates (no version bump — docs only)

**typescript-plugin/bun-publishing** — Common Issues now covers two real npm-publish foot-guns:
- **2FA `EOTP` is not automatable** — a non-interactive shell (CI/agent) can't supply an OTP. Hand to a human (`--otp`) or use an automation token (bypasses 2FA). Clarifies *why* the CI workflow it documents works while a local publish prompts.
- **Post-publish propagation lag** — a fresh publish 404s on public/unauth reads for minutes while live; confirm with `npm access list packages` + version-pinned authed `npm view @pkg@ver _id` / `npm pack`.

**agent-patterns-plugin/wave-based-dispatch** — new **Pilot-Before-Fan-Out Gate** section, a sibling to the existing Research-Before-WO Gate. Validate the full recipe (incl. the load-bearing unknown) on one representative pilot, gate the fan-out on it, fan-out mirrors the pilot. Distinct intent from research (spec for an unknown) vs pilot (working reference impl of a repeatable change).

## Evidence
The session itself: 1 sampler-info pilot validated bun `/scripts/*` externalization + the whole TS recipe → a 6-pack fan-out (12 agents) mirrored it with zero red. The npm gotchas cost ~5 diagnostic round-trips during the modal-kit publish.

Compliance check: only pre-existing advisory WARNs (both skills already in the >250 band; no new ERRORs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)