### PR TITLE
chore: enable all in-repo plugins and guard against enablement drift

### DIFF
--- a/.claude/rules/regression-testing.md
+++ b/.claude/rules/regression-testing.md
@@ -64,6 +64,7 @@ The audit script in this repo is the canonical example — it pairs a human repo
 | Skill body or `allowed-tools` references an MCP tool name that the server doesn't actually expose | `scripts/lint-mcp-tool-references.sh` — extend the `denylist=()` array with the unavailable tool name and the suggested fix |
 | Skill body documents an install/import for a package name that doesn't exist on its registry (npm/PyPI/crates/RubyGems/Go) — a dependency-confusion hazard | `scripts/lint-package-references.sh` — extend the `denylist=()` array with the `(ecosystem, wrong-name, fix)` triple |
 | Skill markdown ships a version pin (`uses:`/`FROM`/`image:`/`rev:`) in a shape Renovate's customManagers can't see, so it silently rots | `scripts/check-version-pin-coverage.sh` — extend the managed-form predicates **and** the matching `renovate.json` customManager together (see `.claude/rules/version-pinning.md`) |
+| `.claude/settings.json` `enabledPlugins` drifts from the plugins published in `.claude-plugin/marketplace.json` (a plugin is added to the marketplace but never enabled, or a removed plugin is left enabled) | `scripts/check-enabled-plugins-drift.sh --strict` (+ `scripts/tests/test-check-enabled-plugins-drift.sh`); wired into `.pre-commit-config.yaml` and the `Plugin: Enablement drift` workflow |
 
 ## Known Regressions (Documented Bugs)
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -64,6 +64,55 @@
     ]
   },
   "enableAllProjectMcpServers": true,
-  "enabledPlugins": {},
-  "extraKnownMarketplaces": {}
+  "enabledPlugins": {
+    "accessibility-plugin@laurigates-claude-plugins": true,
+    "agent-patterns-plugin@laurigates-claude-plugins": true,
+    "agents-plugin@laurigates-claude-plugins": true,
+    "api-plugin@laurigates-claude-plugins": true,
+    "bevy-plugin@laurigates-claude-plugins": true,
+    "blog-plugin@laurigates-claude-plugins": true,
+    "blueprint-plugin@laurigates-claude-plugins": true,
+    "code-quality-plugin@laurigates-claude-plugins": true,
+    "codebase-attributes-plugin@laurigates-claude-plugins": true,
+    "comfyui-plugin@laurigates-claude-plugins": true,
+    "communication-plugin@laurigates-claude-plugins": true,
+    "component-patterns-plugin@laurigates-claude-plugins": true,
+    "configure-plugin@laurigates-claude-plugins": true,
+    "container-plugin@laurigates-claude-plugins": true,
+    "css-plugin@laurigates-claude-plugins": true,
+    "documentation-plugin@laurigates-claude-plugins": true,
+    "evaluate-plugin@laurigates-claude-plugins": true,
+    "feedback-plugin@laurigates-claude-plugins": true,
+    "finops-plugin@laurigates-claude-plugins": true,
+    "git-plugin@laurigates-claude-plugins": true,
+    "github-actions-plugin@laurigates-claude-plugins": true,
+    "health-plugin@laurigates-claude-plugins": true,
+    "home-assistant-plugin@laurigates-claude-plugins": true,
+    "hooks-plugin@laurigates-claude-plugins": true,
+    "kubernetes-plugin@laurigates-claude-plugins": true,
+    "langchain-plugin@laurigates-claude-plugins": true,
+    "macos-plugin@laurigates-claude-plugins": true,
+    "migration-patterns-plugin@laurigates-claude-plugins": true,
+    "networking-plugin@laurigates-claude-plugins": true,
+    "obsidian-plugin@laurigates-claude-plugins": true,
+    "project-plugin@laurigates-claude-plugins": true,
+    "prompt-engineering-plugin@laurigates-claude-plugins": true,
+    "prose-plugin@laurigates-claude-plugins": true,
+    "python-plugin@laurigates-claude-plugins": true,
+    "rust-plugin@laurigates-claude-plugins": true,
+    "taskwarrior-plugin@laurigates-claude-plugins": true,
+    "terraform-plugin@laurigates-claude-plugins": true,
+    "testing-plugin@laurigates-claude-plugins": true,
+    "tools-plugin@laurigates-claude-plugins": true,
+    "typescript-plugin@laurigates-claude-plugins": true,
+    "workflow-orchestration-plugin@laurigates-claude-plugins": true
+  },
+  "extraKnownMarketplaces": {
+    "laurigates-claude-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "laurigates/claude-plugins"
+      }
+    }
+  }
 }

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -34,6 +34,7 @@ Claude: Changelog review
 Claude: PR review
 PR: Auto-resolve conflicts
 PR: Enforce conventional commits
+Plugin: Enablement drift
 Plugin: Lint skills
 Plugin: Obsidian CLI changelog review
 Plugin: PR checks

--- a/.github/workflows/plugin-enablement-drift.yml
+++ b/.github/workflows/plugin-enablement-drift.yml
@@ -1,0 +1,44 @@
+name: "Plugin: Enablement drift"
+
+# Keeps .claude/settings.json `enabledPlugins` in lockstep with the plugins
+# published in .claude-plugin/marketplace.json, so the repo always dogfoods its
+# full plugin set. Triggers whenever either file changes — adding a plugin to
+# the marketplace without enabling it (or leaving a removed plugin enabled)
+# fails the check.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - '.claude-plugin/marketplace.json'
+      - '.claude/settings.json'
+      - 'scripts/check-enabled-plugins-drift.sh'
+      - 'scripts/tests/test-check-enabled-plugins-drift.sh'
+      - '.github/workflows/plugin-enablement-drift.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.claude-plugin/marketplace.json'
+      - '.claude/settings.json'
+
+concurrency:
+  group: plugin-enablement-drift-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Self-test the drift guard
+        run: bash scripts/tests/test-check-enabled-plugins-drift.sh
+
+      - name: Check plugin enablement drift
+        run: |
+          bash scripts/check-enabled-plugins-drift.sh
+          bash scripts/check-enabled-plugins-drift.sh --strict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,3 +69,9 @@ repos:
         language: system
         files: '/skills/.*\.md$'
         pass_filenames: false
+      - id: check-enabled-plugins-drift
+        name: enabledPlugins matches the marketplace (plugin-enablement-drift)
+        entry: bash ./scripts/check-enabled-plugins-drift.sh --strict
+        language: system
+        files: '^(\.claude-plugin/marketplace\.json|\.claude/settings\.json)$'
+        pass_filenames: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,7 @@ When creating, modifying, or deleting a plugin, update these files:
 | `release-please-config.json` | Root | Add/remove plugin package config |
 | `.release-please-manifest.json` | Root | Add/remove plugin version entry |
 | `PLUGIN-MAP.md` | `docs/PLUGIN-MAP.md` | Add/remove plugin from navigation map |
+| `settings.json` | `.claude/settings.json` | Add/remove the plugin in `enabledPlugins` (`<plugin>@laurigates-claude-plugins`) — enforced by the `Plugin: Enablement drift` check |
 
 ### Creating a New Plugin
 
@@ -182,6 +183,11 @@ When creating, modifying, or deleting a plugin, update these files:
    ```json
    "new-plugin": "1.0.0"
    ```
+7. Enable it in `.claude/settings.json` so the repo dogfoods it:
+   ```json
+   "enabledPlugins": { "new-plugin@laurigates-claude-plugins": true }
+   ```
+   The `Plugin: Enablement drift` check (`scripts/check-enabled-plugins-drift.sh`) fails CI if a marketplace plugin is left disabled.
 
 ### Deleting a Plugin
 
@@ -189,6 +195,7 @@ When creating, modifying, or deleting a plugin, update these files:
 2. Remove entry from `.claude-plugin/marketplace.json`
 3. Remove package from `release-please-config.json`
 4. Remove version from `.release-please-manifest.json`
+5. Remove the `<plugin>@laurigates-claude-plugins` key from `.claude/settings.json` `enabledPlugins`
 
 ## Git Workflow
 

--- a/scripts/check-enabled-plugins-drift.sh
+++ b/scripts/check-enabled-plugins-drift.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Guard against drift between the repo's plugin marketplace and the set of
+# plugins enabled in project settings (.claude/settings.json).
+#
+# The repo dogfoods its own plugins: every plugin published in
+# .claude-plugin/marketplace.json should be enabled in the committed project
+# settings so contributors load the full set. This script keeps the two in
+# lockstep with three zero-false-positive checks:
+#
+#   1. MARKETPLACE REGISTERED — extraKnownMarketplaces contains the marketplace
+#      name declared in marketplace.json, so the enabled keys resolve to a
+#      source.
+#   2. ALL ENABLED — every plugin in marketplace.json is enabled in
+#      enabledPlugins as "<plugin>@<marketplace>" (value not false).
+#   3. NO DANGLING — every enabledPlugins key for this marketplace maps to a
+#      real plugin still listed in marketplace.json.
+#
+# Emits the structured KEY=value / STATUS= convention
+# (.claude/rules/structured-script-output.md) so scheduled-audits can roll it
+# up, and a markdown issue body for the audit workflow.
+#
+# Usage:
+#   check-enabled-plugins-drift.sh [--project-dir <path>] [--issue-body] [--strict]
+#
+#   --project-dir   Repo root to audit (default: git toplevel, else cwd)
+#   --issue-body    Emit a markdown issue body (empty when clean) instead of the
+#                   structured section
+#   --strict        Exit 1 when drift is found (default: always exit 0)
+set -uo pipefail
+
+proj_dir=""
+emit_issue_body=false
+strict=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --project-dir) proj_dir="$2"; shift 2 ;;
+    --issue-body) emit_issue_body=true; shift ;;
+    --strict) strict=true; shift ;;
+    *) shift ;;
+  esac
+done
+
+if [ -z "$proj_dir" ]; then
+  proj_dir="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+fi
+
+marketplace="$proj_dir/.claude-plugin/marketplace.json"
+settings="$proj_dir/.claude/settings.json"
+
+issue_count=0
+declare -a issues=()
+
+add_issue() {
+  # add_issue <severity> <type> <message>
+  issues+=("  - SEVERITY=$1 TYPE=$2 MSG=$3")
+  issue_count=$((issue_count + 1))
+}
+
+jq_available=true
+command -v jq >/dev/null 2>&1 || jq_available=false
+
+mkt_name=""
+mkt_count=0
+enabled_count=0
+registered="false"
+
+if [ "$jq_available" = false ]; then
+  add_issue ERROR missing_jq "jq is required to audit plugin enablement but is not installed"
+elif [ ! -f "$marketplace" ]; then
+  add_issue ERROR missing_marketplace "marketplace.json not found at $marketplace"
+elif [ ! -f "$settings" ]; then
+  add_issue ERROR missing_settings ".claude/settings.json not found at $settings"
+else
+  mkt_name="$(jq -r '.name // empty' "$marketplace")"
+  if [ -z "$mkt_name" ]; then
+    add_issue ERROR marketplace_unnamed "marketplace.json has no top-level .name"
+  else
+    # Plugin names published by the marketplace.
+    mapfile -t mkt_plugins < <(jq -r '.plugins[].name' "$marketplace" | sort)
+    mkt_count=${#mkt_plugins[@]}
+
+    # Enabled plugin keys for THIS marketplace (value not false), suffix stripped.
+    mapfile -t enabled_plugins < <(
+      jq -r --arg n "$mkt_name" '
+        (.enabledPlugins // {})
+        | to_entries[]
+        | select(.value != false)
+        | .key
+        | select(endswith("@" + $n))
+        | sub("@" + $n + "$"; "")
+      ' "$settings" | sort
+    )
+    enabled_count=${#enabled_plugins[@]}
+
+    # Check 1: marketplace registered as a source.
+    if jq -e --arg n "$mkt_name" '(.extraKnownMarketplaces // {}) | has($n)' "$settings" >/dev/null; then
+      registered="true"
+    else
+      add_issue ERROR marketplace_not_registered \
+        "extraKnownMarketplaces is missing the '$mkt_name' source — enabled '@$mkt_name' plugins cannot resolve"
+    fi
+
+    # Build a lookup set of enabled plugins for membership tests.
+    declare -A enabled_set=()
+    for p in "${enabled_plugins[@]}"; do
+      [ -n "$p" ] && enabled_set["$p"]=1
+    done
+    declare -A mkt_set=()
+    for p in "${mkt_plugins[@]}"; do
+      [ -n "$p" ] && mkt_set["$p"]=1
+    done
+
+    # Check 2: every marketplace plugin is enabled.
+    for p in "${mkt_plugins[@]}"; do
+      [ -n "$p" ] || continue
+      if [ -z "${enabled_set[$p]:-}" ]; then
+        add_issue ERROR plugin_not_enabled \
+          "$p is published in marketplace.json but not enabled as '$p@$mkt_name' in .claude/settings.json"
+      fi
+    done
+
+    # Check 3: every enabled plugin maps to a real marketplace plugin.
+    for p in "${enabled_plugins[@]}"; do
+      [ -n "$p" ] || continue
+      if [ -z "${mkt_set[$p]:-}" ]; then
+        add_issue ERROR enabled_plugin_dangling \
+          "$p@$mkt_name is enabled in .claude/settings.json but no longer listed in marketplace.json"
+      fi
+    done
+  fi
+fi
+
+# --- Status -------------------------------------------------------------------
+overall_status="OK"
+exit_severity=0
+for line in "${issues[@]}"; do
+  case "$line" in
+    *SEVERITY=ERROR*) overall_status="ERROR"; exit_severity=1 ;;
+  esac
+done
+if [ "$overall_status" = "OK" ] && [ "$issue_count" -gt 0 ]; then
+  overall_status="WARN"
+fi
+
+# --- Output -------------------------------------------------------------------
+if [ "$emit_issue_body" = true ]; then
+  if [ "$issue_count" -gt 0 ]; then
+    echo "## Plugin enablement drift"
+    echo ""
+    echo "\`scripts/check-enabled-plugins-drift.sh\` found $issue_count issue(s) between"
+    echo "\`.claude-plugin/marketplace.json\` and \`.claude/settings.json\`."
+    echo ""
+    echo "| Severity | Type | Detail |"
+    echo "|----------|------|--------|"
+    for line in "${issues[@]}"; do
+      sev="$(printf '%s' "$line" | sed -n 's/.*SEVERITY=\([A-Z]*\).*/\1/p')"
+      typ="$(printf '%s' "$line" | sed -n 's/.*TYPE=\([a-z_]*\).*/\1/p')"
+      msg="$(printf '%s' "$line" | sed -n 's/.*MSG=//p')"
+      echo "| $sev | \`$typ\` | $msg |"
+    done
+    echo ""
+    echo "Regenerate the enabled set from the marketplace:"
+    echo '```bash'
+    echo "ep=\$(jq -c '[.plugins[].name | . + \"@$mkt_name\"] | map({(.):true}) | add' .claude-plugin/marketplace.json)"
+    echo "jq --argjson ep \"\$ep\" '.enabledPlugins = \$ep' .claude/settings.json > tmp && mv tmp .claude/settings.json"
+    echo '```'
+  fi
+else
+  echo "=== PLUGIN ENABLEMENT DRIFT ==="
+  echo "JQ_AVAILABLE=$jq_available"
+  echo "MARKETPLACE_NAME=$mkt_name"
+  echo "MARKETPLACE_REGISTERED=$registered"
+  echo "MARKETPLACE_PLUGINS=$mkt_count"
+  echo "ENABLED_PLUGINS=$enabled_count"
+  echo "STATUS=$overall_status"
+  echo "ISSUE_COUNT=$issue_count"
+  if [ "$issue_count" -gt 0 ]; then
+    echo "ISSUES:"
+    printf '%s\n' "${issues[@]}"
+  fi
+  echo "=== END PLUGIN ENABLEMENT DRIFT ==="
+fi
+
+if [ "$strict" = true ]; then
+  exit "$exit_severity"
+fi
+exit 0

--- a/scripts/tests/test-check-enabled-plugins-drift.sh
+++ b/scripts/tests/test-check-enabled-plugins-drift.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Regression test for scripts/check-enabled-plugins-drift.sh
+#
+# Per .claude/rules/regression-testing.md: the drift guard ships with a test
+# proving it (a) passes when settings match the marketplace, and (b) flags each
+# drift class — plugin not enabled, enabled plugin dangling, marketplace not
+# registered. Uses temp-dir fixtures so it never touches the real repo state.
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "$0")/.." && pwd)"
+check="$script_dir/check-enabled-plugins-drift.sh"
+
+pass=0
+fail=0
+
+ok() { echo "PASS: $1"; pass=$((pass + 1)); }
+ko() { echo "FAIL: $1"; fail=$((fail + 1)); }
+
+# assert_has <desc> <text> <needle>  — text contains needle
+assert_has() {
+  if printf '%s' "$2" | grep -q -- "$3"; then ok "$1"; else ko "$1"; fi
+}
+
+# assert_lacks <desc> <text>  — text is empty
+assert_empty() {
+  if [ -z "$2" ]; then ok "$1"; else ko "$1"; fi
+}
+
+# assert_strict_ok <desc> <dir>  — --strict exits 0
+assert_strict_ok() {
+  if bash "$check" --project-dir "$2" --strict >/dev/null 2>&1; then ok "$1"; else ko "$1"; fi
+}
+
+# assert_strict_fails <desc> <dir>  — --strict exits non-zero
+assert_strict_fails() {
+  if bash "$check" --project-dir "$2" --strict >/dev/null 2>&1; then ko "$1"; else ok "$1"; fi
+}
+
+# Build a fixture project dir. Args: <out-dir> <marketplace-json> <settings-json>
+make_fixture() {
+  mkdir -p "$1/.claude-plugin" "$1/.claude"
+  printf '%s' "$2" > "$1/.claude-plugin/marketplace.json"
+  printf '%s' "$3" > "$1/.claude/settings.json"
+}
+
+MKT='{"name":"test-mkt","plugins":[{"name":"alpha-plugin","source":"./alpha-plugin"},{"name":"beta-plugin","source":"./beta-plugin"}]}'
+
+tmp_root="$(mktemp -d)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+# --- TEST A: fully in sync ----------------------------------------------------
+a="$tmp_root/a"
+make_fixture "$a" "$MKT" \
+  '{"extraKnownMarketplaces":{"test-mkt":{"source":{"source":"github","repo":"o/r"}}},"enabledPlugins":{"alpha-plugin@test-mkt":true,"beta-plugin@test-mkt":true}}'
+out_a="$(bash "$check" --project-dir "$a")"
+assert_has "in-sync settings report STATUS=OK" "$out_a" "STATUS=OK"
+assert_has "in-sync settings report ISSUE_COUNT=0" "$out_a" "ISSUE_COUNT=0"
+assert_strict_ok "in-sync settings pass --strict (exit 0)" "$a"
+
+# --- TEST B: a marketplace plugin is not enabled ------------------------------
+b="$tmp_root/b"
+make_fixture "$b" "$MKT" \
+  '{"extraKnownMarketplaces":{"test-mkt":{"source":{"source":"github","repo":"o/r"}}},"enabledPlugins":{"alpha-plugin@test-mkt":true}}'
+out_b="$(bash "$check" --project-dir "$b")"
+assert_has "unenabled marketplace plugin flagged plugin_not_enabled" "$out_b" "TYPE=plugin_not_enabled"
+assert_has "missing enablement yields STATUS=ERROR" "$out_b" "STATUS=ERROR"
+assert_strict_fails "missing enablement fails --strict (exit 1)" "$b"
+
+# --- TEST C: an enabled plugin no longer in the marketplace -------------------
+c="$tmp_root/c"
+make_fixture "$c" "$MKT" \
+  '{"extraKnownMarketplaces":{"test-mkt":{"source":{"source":"github","repo":"o/r"}}},"enabledPlugins":{"alpha-plugin@test-mkt":true,"beta-plugin@test-mkt":true,"ghost-plugin@test-mkt":true}}'
+out_c="$(bash "$check" --project-dir "$c")"
+assert_has "enabled plugin absent from marketplace flagged enabled_plugin_dangling" "$out_c" "TYPE=enabled_plugin_dangling"
+
+# --- TEST D: marketplace not registered ---------------------------------------
+d="$tmp_root/d"
+make_fixture "$d" "$MKT" \
+  '{"enabledPlugins":{"alpha-plugin@test-mkt":true,"beta-plugin@test-mkt":true}}'
+out_d="$(bash "$check" --project-dir "$d")"
+assert_has "unregistered marketplace flagged marketplace_not_registered" "$out_d" "TYPE=marketplace_not_registered"
+assert_has "unregistered marketplace reports MARKETPLACE_REGISTERED=false" "$out_d" "MARKETPLACE_REGISTERED=false"
+
+# --- TEST E: a plugin set to false counts as not enabled ----------------------
+e="$tmp_root/e"
+make_fixture "$e" "$MKT" \
+  '{"extraKnownMarketplaces":{"test-mkt":{"source":{"source":"github","repo":"o/r"}}},"enabledPlugins":{"alpha-plugin@test-mkt":true,"beta-plugin@test-mkt":false}}'
+out_e="$(bash "$check" --project-dir "$e")"
+assert_has "plugin explicitly set to false flagged plugin_not_enabled" "$out_e" "TYPE=plugin_not_enabled"
+
+# --- TEST F: --issue-body empty when clean, populated on drift ----------------
+body_clean="$(bash "$check" --project-dir "$a" --issue-body)"
+assert_empty "--issue-body empty when in sync" "$body_clean"
+body_drift="$(bash "$check" --project-dir "$b" --issue-body)"
+assert_has "--issue-body populated on drift" "$body_drift" "Plugin enablement drift"
+
+echo ""
+echo "RESULTS: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What

Two changes that make the repo dogfood its own plugins — and keep doing so:

1. **Enable all 41 in-repo plugins** in the committed project `.claude/settings.json`:
   - Register the repo's own marketplace `laurigates-claude-plugins` (GitHub source) in `extraKnownMarketplaces`.
   - Populate `enabledPlugins` with `"<plugin>@laurigates-claude-plugins": true` for every plugin in `.claude-plugin/marketplace.json`.
   - The `enabledPlugins` block was generated directly from `marketplace.json`, so coverage is 1:1 (zero drift at authoring time).

2. **A drift guard so the two never separate again** — `scripts/check-enabled-plugins-drift.sh`, which fails when:
   - a plugin is published in `marketplace.json` but not enabled (`plugin_not_enabled`),
   - an enabled `@laurigates-claude-plugins` key no longer maps to a marketplace plugin (`enabled_plugin_dangling`), or
   - the marketplace isn't registered in `extraKnownMarketplaces` (`marketplace_not_registered`).

   It emits the repo's structured `=== SECTION ===` / `STATUS=` / `ISSUE_COUNT=` convention and supports `--strict` (gate) and `--issue-body` (audit).

## Where the guard runs

| Surface | Trigger |
|---------|---------|
| **`Plugin: Enablement drift` workflow** (new) | PR/push changes to `marketplace.json` or `.claude/settings.json` |
| **pre-commit** (`.pre-commit-config.yaml`) | local commits touching those two files |
| **Self-test in CI** | the workflow runs `test-check-enabled-plugins-drift.sh` before the guard |

## Tests & docs

- `scripts/tests/test-check-enabled-plugins-drift.sh` — 6 cases (in-sync passes; each drift class is flagged; `false` counts as disabled; `--issue-body` empty-when-clean). All pass; shellcheck clean.
- Documented in the `.claude/rules/regression-testing.md` check catalog and the **CLAUDE.md Plugin Lifecycle** checklist (create/delete a plugin now includes the `enabledPlugins` step), plus registered in the workflows README sorted-name list.

## Notes

- `enabledPlugins` is read at session start, so the plugins go live on the next Claude Code session/reload, not mid-session.
- Conventional types (`chore`/`ci`) and no plugin scope → release-please bumps nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015wtqvJ6gwGwYQxHrs7kcJ6)_