### PR TITLE
fix(hooks-plugin): allow initial bootstrap push to main

### DIFF
--- a/hooks-plugin/README.md
+++ b/hooks-plugin/README.md
@@ -96,6 +96,7 @@ A PreToolUse hook that blocks write operations on protected branches (main, mast
 | Read-only git (status, diff, log, show) | Allowed |
 | Checkout/switch to another branch | Allowed |
 | Push with explicit refspec (`main:feature`) | Allowed |
+| Initial bootstrap push (single root commit) to main | Allowed (initializes an empty remote) |
 | Merge (local feature branch into main) | Allowed (reversible) |
 | Commit, rebase, push | Blocked with branch creation suggestion |
 | Staging (git add, rm, mv) | Blocked |

--- a/hooks-plugin/hooks/branch-protection.sh
+++ b/hooks-plugin/hooks/branch-protection.sh
@@ -17,7 +17,8 @@
 #
 # Matches: Bash
 # Detects: git commit, git push, git rebase on main/master
-# Allows: read-only git operations, git merge (local, reversible)
+# Allows: read-only git operations, git merge (local, reversible), and the
+#         initial bootstrap push (a single root commit) that initializes a repo
 
 set -euo pipefail
 
@@ -118,6 +119,20 @@ case "$GIT_SUBCMD" in
   push)
     # Allow push to specific remote branch via explicit refspec
     if echo "$COMMAND" | grep -q ':'; then
+      exit 0
+    fi
+    # Allow the very first push that bootstraps a repo. When the branch tip is
+    # the repo's only commit (a single root commit), there is no prior history
+    # to open a PR against — pushing it to main is how an empty remote gets
+    # initialized. The normal protection resumes as soon as a second commit
+    # exists. Branch detection respects `git -C <path>` for the same reason as
+    # CURRENT_BRANCH above (#1389).
+    if [ -n "$WORKING_DIR" ]; then
+      COMMIT_COUNT=$(git -C "$WORKING_DIR" rev-list --count HEAD 2>/dev/null || echo "")
+    else
+      COMMIT_COUNT=$(git rev-list --count HEAD 2>/dev/null || echo "")
+    fi
+    if [ "$COMMIT_COUNT" = "1" ]; then
       exit 0
     fi
     deny "You're about to push directly to '${CURRENT_BRANCH}'. In collaborative repos, changes go through a PR on a feature branch. To push local ${CURRENT_BRANCH} to a remote feature branch, use an explicit refspec (allowed): git push origin ${CURRENT_BRANCH}:feature/your-change. If pushing to ${CURRENT_BRANCH} is genuinely intentional, delegate to the user per .claude/rules/handling-blocked-hooks.md."

--- a/hooks-plugin/hooks/test-branch-protection.sh
+++ b/hooks-plugin/hooks/test-branch-protection.sh
@@ -12,6 +12,8 @@
 #   - `git push origin main:fix/foo` with explicit refspec is allowed.
 #   - Plain `git commit` / `git push` on main is denied.
 #   - `git -C <feature-worktree> commit` from a cwd on main is allowed (#1389).
+#   - The initial bootstrap push (single root commit) to main is allowed, and
+#     resumes denying once a second commit exists.
 set -euo pipefail
 
 HOOK="$(cd "$(dirname "$0")" && pwd)/branch-protection.sh"
@@ -26,7 +28,11 @@ TEST_REPO=$(mktemp -d)
 #   MASTER_WT  — on `master`, writes should still be denied (negative case)
 FEATURE_WT=$(mktemp -d)
 MASTER_WT=$(mktemp -d)
-trap 'rm -rf "$TEST_REPO" "$FEATURE_WT" "$MASTER_WT"' EXIT
+# INIT_REPO — a pristine repo with a single root commit on main, used to
+# assert the bootstrap-push exemption. Kept separate from TEST_REPO so the
+# baseline deny tests still run against a repo that has real history.
+INIT_REPO=$(mktemp -d)
+trap 'rm -rf "$TEST_REPO" "$FEATURE_WT" "$MASTER_WT" "$INIT_REPO"' EXIT
 
 git -C "$TEST_REPO" init -q -b main
 git -C "$TEST_REPO" config user.email "test@example.com"
@@ -34,6 +40,18 @@ git -C "$TEST_REPO" config user.name "test"
 git -C "$TEST_REPO" config commit.gpgsign false
 git -C "$TEST_REPO" config tag.gpgsign false
 git -C "$TEST_REPO" commit -q --allow-empty -m "init"
+# A second commit so TEST_REPO has real history — the baseline deny tests
+# must not be confused with the single-commit bootstrap exemption. Worktrees
+# below branch from this two-commit tip.
+git -C "$TEST_REPO" commit -q --allow-empty -m "second"
+
+# INIT_REPO has exactly one commit on main — the bootstrap case.
+git -C "$INIT_REPO" init -q -b main
+git -C "$INIT_REPO" config user.email "test@example.com"
+git -C "$INIT_REPO" config user.name "test"
+git -C "$INIT_REPO" config commit.gpgsign false
+git -C "$INIT_REPO" config tag.gpgsign false
+git -C "$INIT_REPO" commit -q --allow-empty -m "init"
 
 # Add linked worktrees. The TEST_REPO stays on `main`; tests then invoke
 # `git -C "$FEATURE_WT" ...` from inside TEST_REPO and the hook must read
@@ -143,6 +161,22 @@ assert_allow \
 assert_allow \
   "git push origin HEAD:feature/bar is allowed" \
   "git push origin HEAD:feature/bar"
+
+# ── bootstrap push (initial commit initializes the repo) ─────────────────────
+# Pushing the very first commit to main is how an empty GitHub repo gets
+# initialized. When the branch tip is the repo's only commit there is no PR-able
+# history, so a plain `git push` is allowed. Protection resumes once a second
+# commit exists (covered by the baseline deny on TEST_REPO, which has history).
+echo ""
+echo "bootstrap push (single root commit on main is allowed to initialize the repo):"
+
+assert_allow \
+  "git -C <single-commit-repo> push to main is allowed" \
+  "git -C $INIT_REPO push"
+
+assert_allow \
+  "git -C <single-commit-repo> push -u origin main is allowed" \
+  "git -C $INIT_REPO push -u origin main"
 
 # ── human-operator env-var escape hatch ─────────────────────────────────────
 # When the variable is exported in the *process environment* (not inline on


### PR DESCRIPTION
## Summary

The `branch-protection.sh` hook denied every direct push to `main`/`master` unless an explicit refspec (`main:feature`) was supplied. That blocks the legitimate **first push that initializes an empty remote** — GitHub requires an initial commit on the default branch, and at that point there's no prior history to open a PR against.

This relaxes the push guard to allow a plain `git push` when the branch tip is the repo's **only commit** (a single root commit). Normal protection resumes the moment a second commit exists.

## How it's detected

`git rev-list --count HEAD == 1` — deterministic, offline, and respects `git -C <path>` for parity with the existing `CURRENT_BRANCH` resolution (#1389). A single commit is necessarily a root commit, so there is no PR-able history; once history exists, the guard denies as before.

## Tests

`hooks-plugin/hooks/test-branch-protection.sh` (19 passing):
- New `INIT_REPO` single-commit fixture asserts the bootstrap-push exemption (plain `push` and `push -u origin main`).
- `TEST_REPO` now carries **two** commits so the existing baseline deny tests exercise a repo with real history (and aren't accidentally satisfied by the new exemption).
- The `master`-worktree deny case still passes, proving the exemption is scoped to the single-commit shape, not a blanket bypass.

Per `.claude/rules/regression-testing.md`, the behavior change ships with its test in the same commit. README behavior table updated alongside the code.

https://claude.ai/code/session_01GxRE5tYhSTZbfHZvNoTPNV

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxRE5tYhSTZbfHZvNoTPNV)_