### PR TITLE
feat(project-plugin): add refocus skill for plan refresh

### DIFF
--- a/project-plugin/.claude-plugin/plugin.json
+++ b/project-plugin/.claude-plugin/plugin.json
@@ -18,7 +18,10 @@
     "maintenance",
     "distill",
     "insights",
-    "knowledge-capture"
+    "knowledge-capture",
+    "refocus",
+    "replan",
+    "context-management"
   ],
   "hooks": {
     "Stop": [

--- a/project-plugin/README.md
+++ b/project-plugin/README.md
@@ -128,6 +128,27 @@ Distill session insights into reusable knowledge: rules, skills, and justfile re
 
 **Auto-nudge:** A `Stop` hook (`hooks/project-distill-nudge.sh`) suggests `/project:distill --dry-run` at most once per session, only when (a) the session has ≥8 user turns, (b) the cwd's repo has either a `.claude/rules/` directory or a `justfile`, and (c) a recent user turn carries a wind-down phrase (`wrap up`, `done for today`, `gotta go`, etc.). The nudge is an offer only — the agent never runs `/project:distill` without explicit confirmation. To pre-silence it for a session, `touch ~/.cache/claude-project-distill-nudge/<session_id>` (the hook treats an existing marker as "already nudged"). To turn the hook off entirely, disable the plugin via `/plugin`.
 
+### `/project:refocus`
+Refresh the plan to focus on the task at hand when context has grown.
+
+**Features:**
+- Sorts the session into done / remaining / stale buckets
+- Extracts load-bearing decisions and active boundaries that would be lost on a context clear
+- Drafts a **self-contained** forward-only plan (restates files, decisions, and constraints — no back-references)
+- Surfaces it via `ExitPlanMode` so the approval dialog offers "clear context and continue in auto mode"
+- Prunes resolved tangents so the next stretch of work starts clean
+
+**Manual invocation:**
+- "refresh the plan"
+- "refocus on the task at hand"
+- "let's focus on what's left"
+- "trim the context and continue in auto mode"
+
+**Usage:**
+```bash
+/project:refocus
+```
+
 ### `changelog-review`
 Analyze Claude Code changelog for impacts on plugin development.
 

--- a/project-plugin/skills/project-refocus/SKILL.md
+++ b/project-plugin/skills/project-refocus/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: refocus
+description: "Refresh the plan to focus on the task at hand. Use when context grew, completed steps muddy it, or you want to clear context and continue in auto mode."
+args: ""
+argument-hint: "invoke mid-session when context is bloated and you want a tightened, self-contained plan"
+allowed-tools: Read, Grep, Glob, Bash(git status *), Bash(git log *), Bash(git diff *), TodoWrite, ExitPlanMode
+created: 2026-06-08
+modified: 2026-06-08
+reviewed: 2026-06-08
+---
+
+# /project:refocus
+
+Refresh the plan so it focuses only on the task that remains, then surface it for approval so the user can **clear context and continue in auto mode** from a clean slate.
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative when... |
+|------------------------|-----------------------------|
+| Context has grown and the completed early steps now muddy it | Resuming after a break with no live context to trim → `/project:continue` |
+| You want a tightened, forward-only plan before continuing | Capturing session learnings into rules/recipes → `/project:distill` |
+| You want to clear context and continue in auto mode without losing the thread | Entering an unfamiliar codebase needing orientation → `/project:discovery` |
+| The user says "refresh the plan", "refocus", "let's focus on what's left", "trim the context" | Picking the next blueprint action → `/blueprint:execute` |
+
+The output is deliberately **self-contained**: it must survive a context clear. Approving it from the `ExitPlanMode` dialog is where Claude Code offers "clear context and continue in auto mode."
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- Working tree: !`git status --porcelain=v2 --branch`
+- Recent commits: !`git log --format='%h %s' --max-count=8`
+- Active todos: review the current TodoWrite list (if any) for done-vs-remaining state
+
+## Execution
+
+Execute this plan-refresh workflow. Reason over the **live conversation**, not just git — git grounds what landed on disk; the conversation holds the decisions and the remaining intent.
+
+### Step 1: Take stock of the conversation
+
+Scan the session so far and sort everything into three buckets:
+
+1. **Done** — steps completed and verified (committed, tested, or confirmed working).
+2. **Remaining** — the task still at hand: what the user actually wants finished.
+3. **Stale** — exploration, abandoned approaches, and resolved tangents that now only add noise.
+
+Ground "Done" against `git log` / `git status` from Context so you don't trust a claim that never reached disk.
+
+### Step 2: Extract the load-bearing decisions
+
+From the Done and Remaining buckets, pull the facts the remaining work depends on — the things that would be **lost on a context clear**:
+
+- Concrete file paths and the functions/sections being changed.
+- Decisions already made (library chosen, approach agreed, constraint set by the user).
+- Stated boundaries still in force ("don't push until I review", "keep the old endpoint"). These do not survive compaction on their own — restate them explicitly (see `.claude/rules/auto-mode.md` on conversation-stated boundaries).
+- Open questions the user already answered, so they are not re-asked.
+
+### Step 3: Draft a self-contained forward plan
+
+Write a plan that reads as a **standalone brief** — assume the reader has none of the current context. Use no "as discussed above" / "the file we edited" references; name everything explicitly.
+
+```markdown
+## Objective
+<one sentence: the task at hand, restated plainly>
+
+## Already done (do not redo)
+- <completed step> → <commit / file proving it landed>
+
+## Constraints & decisions (carry forward)
+- <decision or boundary that the remaining work must honor>
+
+## Remaining steps
+1. <imperative step naming the exact file/path and what changes>
+2. ...
+
+## Verification
+- <how we confirm done: test command, behavior to observe>
+```
+
+Drop the Stale bucket entirely — that pruning is the point.
+
+### Step 4: Surface it via ExitPlanMode
+
+Call `ExitPlanMode` with the plan from Step 3 as its content. This presents the refreshed plan for approval and surfaces the continuation options — including **clear context and continue in auto mode**. Do not start executing the remaining steps before approval.
+
+If the session is not already in plan mode, present the plan as your response and offer to refocus from there; the self-contained plan text is the deliverable either way.
+
+### Step 5: Hand off to a cleared context
+
+When the user opts to clear context and continue in auto mode, the plan from Step 3 is all that survives — which is exactly why it was written standalone. After the clear, seed a fresh TodoWrite list from the "Remaining steps" and proceed.
+
+Under auto mode, keep the narrow `Bash(<command> *)` permissions this skill already declares — they carry over and skip the classifier round-trip (see `.claude/rules/auto-mode.md`).
+
+## Self-Contained Checklist
+
+Before calling `ExitPlanMode`, confirm the plan:
+
+- [ ] States the objective in one sentence with no back-references
+- [ ] Names every file/path explicitly (no "the file above")
+- [ ] Restates active user boundaries verbatim (they vanish on clear)
+- [ ] Lists what is already done so it is not redone
+- [ ] Ends with a concrete verification step
+- [ ] Contains nothing from the Stale bucket
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| What landed on disk | `git log --format='%h %s' --max-count=8` |
+| Uncommitted surface | `git status --porcelain=v2 --branch` |
+| Confirm a "done" claim | `git diff --stat` against the named files |
+| Seed remaining work | Rebuild TodoWrite from the plan's "Remaining steps" |


### PR DESCRIPTION
## What

Adds `/project:refocus` — a user-invocable skill that captures the *"refresh the plan to focus on the task at hand"* workflow.

You invoke it mid-session when context has grown and the earlier, already-completed steps only muddy it. The skill:

1. **Takes stock** of the live conversation, sorting it into `done` / `remaining` / `stale` buckets (grounding "done" against `git log`/`git status`).
2. **Extracts the load-bearing decisions** — file paths, chosen approaches, and active user boundaries that would be *lost on a context clear*.
3. **Drafts a self-contained, forward-only plan** that reads as a standalone brief (no "as discussed above" back-references), dropping the stale bucket entirely.
4. **Surfaces it via `ExitPlanMode`**, so the approval dialog offers **"clear context and continue in auto mode"** — and the cleared context retains only the standalone plan.

The core design principle: the refreshed plan must **survive a context clear**, so it doubles as a handoff brief.

## Placement

Lives in `project-plugin` beside `project-continue` (resume) and `project-distill` (end-of-session capture) as the mid-session *refocus* sibling. Skills aren't individually registered in `marketplace.json` / release-please, so only the plugin README and `plugin.json` keywords changed.

## Files

- `project-plugin/skills/project-refocus/SKILL.md` (new, 151-char description, within budget)
- `project-plugin/README.md` — skill entry + invocation phrases
- `project-plugin/.claude-plugin/plugin.json` — `refocus` / `replan` / `context-management` keywords

## Checks

- `audit-skill-descriptions.py --strict-length` ✅
- `lint-context-commands.sh` ✅ (fixed `-n` → `--max-count=` in the Context block)
- `plugin-compliance-check.sh project-plugin` ✅ (no warnings on the new skill)

https://claude.ai/code/session_01FfXqFvvfyPNjEm8xiVPMEa

---
_Generated by [Claude Code](https://claude.ai/code/session_01FfXqFvvfyPNjEm8xiVPMEa)_