### PR TITLE
docs(skill-development): reframe model selection around effort, not just model

### DIFF
--- a/.claude/rules/skill-development.md
+++ b/.claude/rules/skill-development.md
@@ -148,10 +148,12 @@ Skills inherit the user's active model by default. Tag a skill with `model:` onl
 | Tag | Use for | Examples |
 |-----|---------|----------|
 | `model: opus` | Deep reasoning, multi-file orchestration, security review, architecture, long agentic chains | Skills that spawn many subagents, security audits, complex refactors, ADR/PRD synthesis |
-| `model: sonnet` | Mechanical / high-volume work where Opus's cost is unjustified | CLI tool wrappers (fd, rg, jq), formatters, status checks, single-file lookups |
+| `model: sonnet` | Mechanical / high-volume work that **Sonnet at low effort** can genuinely complete | CLI tool wrappers (fd, rg, jq), formatters, status checks, single-file lookups |
 | _(unset)_ | Everything in the middle | Default — inherits the user's active model |
 
-**Why both extremes?** A user defaulting to Opus saves cost when a mechanical skill self-selects Sonnet. A user defaulting to Sonnet (or Haiku) gets reliable results when a complex skill self-selects Opus.
+**Why both extremes?** A user defaulting to Opus saves cost when a *genuinely* mechanical skill self-selects Sonnet. A user defaulting to Sonnet (or Haiku) gets reliable results when a complex skill self-selects Opus.
+
+**Opus is often the cheaper default — `effort`, not `model`, is the main cost lever.** The per-token premium (Opus 4.8 output ≈ 1.7× Sonnet 4.6) is frequently outweighed by token *volume*: Opus at low effort tends to spend far fewer thinking + output tokens than Sonnet at high effort, so for reasoning-shaped work Opus-low can be both better *and* cheaper. The catch for this repo: that win rides on `effort`, which is a session/harness setting (e.g. Claude Code's default), **not** something a skill can express in frontmatter. So the practical translation is narrow — **don't reflexively reach for `model: sonnet`.** Tag it only when Sonnet at low effort genuinely suffices; when the task leans on reasoning, leave `model:` unset (or tag `opus`) and let the user's effort setting do the cost tuning. Treat the "Opus-low beats Sonnet-high" heuristic as workload-dependent, not dogma — confirm per-skill with the cross-model delta harness in [`.claude/rules/skill-evaluation.md`](skill-evaluation.md).
 
 **Hard constraints:**
 


### PR DESCRIPTION
## What

Revises `.claude/rules/skill-development.md` § Model Selection to fold in a recent finding:

> Opus 4.8 on low effort beats Sonnet 4.6 on med, high, or max, and for less cost. Unless the task can genuinely be done by Sonnet 4.6 on low, you're better off using Opus.

## Why

The previous guidance recommended `model: sonnet` for "mechanical / high-volume work where Opus's cost is unjustified." That framing under-counts how often Opus's cost *is* justified: the per-token premium (Opus 4.8 output ≈ 1.7× Sonnet 4.6) is frequently outweighed by **token volume** — Opus at low effort spends far fewer thinking + output tokens than Sonnet at high effort, so for reasoning-shaped work Opus-low can be both better and cheaper.

## The repo-specific nuance

The finding's leverage is **`effort`**, which is a session/harness setting — **not** something a skill can express in frontmatter. So the actionable translation for this repo's skills is narrow:

- Narrowed the `model: sonnet` row to "work **Sonnet at low effort** can genuinely complete."
- Added a note that `effort` (not `model`) is the real cost lever, and that it lives outside skill frontmatter — so the practical rule is "don't reflexively reach for `model: sonnet`."
- Pointed to the cross-model delta harness in `skill-evaluation.md` to verify the heuristic per-skill rather than treating it as dogma.

## Scope

Docs-only change to one rule file (`docs:` type — no version bump). No skill behavior changes; no `model:` frontmatter was added or removed on any skill.

https://claude.ai/code/session_01YJYjrM7T81arbqHFr4auUB

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJYjrM7T81arbqHFr4auUB)_