### PR TITLE
ci(plugin): run skill-local regression tests in CI

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -23,6 +23,7 @@ When adding a workflow, pick the existing domain that fits or extend the table b
 | `Release:` | release-please ecosystem — version bumps, changelog, release-PR doc audit, conflict repair |
 | `PR:` | Cross-cutting PR governance — conflict resolution, conventional-commit enforcement |
 | `Auto-fix:` | Autonomous CI failure remediation triggered by `workflow_run` |
+| `Test:` | Repo test suites — skill-local regression tests |
 | _(none)_ | One-off standalones with no obvious domain peer (e.g. `Renovate`) |
 
 ### Sorted name list
@@ -45,6 +46,7 @@ Release: Fix release-please conflicts
 Release: PR documentation audit
 Release: release-please
 Renovate
+Test: Skill scripts
 ```
 
 ## Cross-workflow references

--- a/.github/workflows/test-skill-scripts.yml
+++ b/.github/workflows/test-skill-scripts.yml
@@ -1,0 +1,38 @@
+name: "Test: Skill scripts"
+
+# Runs the skill-local regression tests that ship next to a skill's extracted
+# scripts (**/skills/**/scripts/tests/test-*.sh). Mirrors the per-path-trigger
+# shape of plugin-enablement-drift.yml so it fires only when skill scripts (or
+# the runner itself) change — independent of plugin-pr-checks.yml, which gates
+# the SKILL.md / compliance surface.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - '**/skills/**/scripts/**'
+      - 'scripts/run-skill-script-tests.sh'
+      - 'justfile'
+      - '.github/workflows/test-skill-scripts.yml'
+  push:
+    branches: [main]
+    paths:
+      - '**/skills/**/scripts/**'
+      - 'scripts/run-skill-script-tests.sh'
+
+concurrency:
+  group: test-skill-scripts-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Run skill-local regression tests
+        run: bash scripts/run-skill-script-tests.sh

--- a/justfile
+++ b/justfile
@@ -82,6 +82,15 @@ lint-taskwarrior-tags:
 [group: "lint"]
 lint-all: lint-context-commands lint-compliance lint-health lint-infra lint-taskwarrior-tags
 
+####################
+# Testing
+####################
+
+# Run every skill-local regression test (**/skills/**/scripts/tests/test-*.sh)
+[group: "test"]
+test-skill-scripts:
+    ./scripts/run-skill-script-tests.sh
+
 # Add all MCP servers and set up cclsp
 [group: "claude"]
 claude-setup: mcp-sentry mcp-github mcp-context7 mcp-playwright mcp-sequential-thinking mcp-chrome-devtools cclsp

--- a/scripts/run-skill-script-tests.sh
+++ b/scripts/run-skill-script-tests.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Run every skill-local regression test in the repo.
+#
+# Discovers and runs `*/skills/*/scripts/tests/test-*.sh`, the colocated tests
+# that ship next to a skill's extracted scripts (canonical reference:
+# health-plugin/skills/health-check/scripts/tests/test-check-settings.sh). Used
+# by the `just test-skill-scripts` recipe and the `Test: Skill scripts` CI
+# workflow so local and CI run the identical discovery (local↔CI parity).
+#
+# A test may SKIP (exit 0 with a SKIP line) when a dependency is absent; only a
+# non-zero exit counts as a failure. Exits 0 when no tests are found (greenfield)
+# so the runner is safe to wire in before any test exists.
+#
+# Usage: bash scripts/run-skill-script-tests.sh [--root <dir>]
+
+set -uo pipefail
+
+root_dir="."
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --root) root_dir="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+echo "=== SKILL SCRIPT TESTS ==="
+
+failed=0
+total=0
+failed_list=""
+
+# Prune `.claude/worktrees/` (sibling agent clones of the whole repo, #1492) so
+# we don't run the same test many times over from worktree copies.
+while IFS= read -r -d '' test_file; do
+  total=$((total + 1))
+  log_file="$(mktemp)"
+  if bash "$test_file" >"$log_file" 2>&1; then
+    echo "PASS=${test_file}"
+  else
+    echo "FAIL=${test_file}"
+    sed 's/^/  | /' "$log_file"
+    failed=$((failed + 1))
+    failed_list="${failed_list}  - ${test_file}\n"
+  fi
+  rm -f "$log_file"
+done < <(find "$root_dir" \
+  -path '*/.claude/worktrees/*' -prune -o \
+  -path '*/skills/*/scripts/tests/test-*.sh' -type f -print0 | sort -z)
+
+echo "TOTAL=${total}"
+echo "FAILED=${failed}"
+if [ "$failed" -eq 0 ]; then
+  echo "STATUS=OK"
+else
+  echo "STATUS=ERROR"
+  echo "ISSUES:"
+  printf '%b' "$failed_list"
+fi
+echo "=== END SKILL SCRIPT TESTS ==="
+
+[ "$failed" -eq 0 ]


### PR DESCRIPTION
## What

Wires a CI runner for the colocated skill-local regression tests
(`*/skills/*/scripts/tests/test-*.sh`) that ship next to a skill's
extracted `scripts/`.

- **`scripts/run-skill-script-tests.sh`** — discovers and runs every
  skill-local test. Prunes `.claude/worktrees/` agent-clone copies
  (#1492), exits 0 on zero tests (greenfield-safe), treats only a
  non-zero exit as failure (SKIP-on-missing-dep is fine), and emits the
  `STATUS=`/`ISSUES:` structured-output convention.
- **`just test-skill-scripts`** — local recipe calling the same script,
  for local↔CI parity.
- **`Test: Skill scripts`** workflow — per-path trigger on
  `**/skills/**/scripts/**`, mirroring `plugin-enablement-drift.yml`, so
  it fires independently of `plugin-pr-checks.yml`.

## Why

This is the **prerequisite (Step 0)** for the ADR-0016 deterministic
script-extraction sweep (#1552–#1558). Each of those 7 PRs adds a new
skill-local regression test; without this runner, no workflow would
execute them, so an extraction could land green while its test never
gated CI.

It already discovers and gates the two existing skill-local tests
(`health-check/.../test-check-settings.sh`,
`git-pr-feedback/.../test-list-actionable-prs.sh`).

Refs ADR-0016 (deterministic script extraction for token efficiency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)