### PR TITLE
refactor(macos-plugin): extract macos-incident-postmortem procedure to scripts + regression test

### DIFF
--- a/macos-plugin/skills/macos-incident-postmortem/scripts/macos-incident-postmortem.sh
+++ b/macos-plugin/skills/macos-incident-postmortem/scripts/macos-incident-postmortem.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# macOS Incident Postmortem — deterministic signal gathering + reboot/hang classifier.
+#
+# Extracts the mechanical procedure of the macos-incident-postmortem skill
+# (issue #1557): reboot-vs-hang signal detection, DiagnosticReports timeline,
+# per-category report counts, CPU-event offender histogram, jetsam victim list,
+# and the fixed reboot/hang decision tree. The model still reads panic
+# backtraces, names suspect kexts, and writes the narrative — those are judgment,
+# not procedure, and stay with the agent.
+#
+# Every macOS-only system probe sits behind an injectable seam so this runs
+# offline on Linux CI against PLANTED fixture files:
+#   --reports-dir <path>   DiagnosticReports source (repeatable). Defaults to
+#                          /Library/Logs/DiagnosticReports and
+#                          ~/Library/Logs/DiagnosticReports.
+#   MACOS_PM_UNAME         override `uname -s` (default: real uname).
+#   MACOS_PM_LAST_REBOOT   command emitting `last reboot`-style lines.
+#   MACOS_PM_LAST_SHUTDOWN command emitting `last shutdown`-style lines.
+#   MACOS_PM_BOOTTIME      kern.boottime unix epoch (overrides sysctl probe).
+#   MACOS_PM_INCIDENT_EPOCH  unix epoch of the incident time T (optional; enables
+#                            the reboot-vs-hang classifier when boottime is known).
+#
+# Emits the structured KEY=value / STATUS= convention
+# (.claude/rules/structured-script-output.md).
+#
+# Usage:
+#   macos-incident-postmortem.sh [--home-dir <path>] [--project-dir <path>]
+#                                [--reports-dir <path> ...] [--verbose]
+set -uo pipefail
+
+home_dir=""
+project_dir=""
+verbose_mode=false
+reports_dirs=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --home-dir) home_dir="$2"; shift 2 ;;
+    --project-dir) project_dir="$2"; shift 2 ;;
+    --reports-dir) reports_dirs+=("$2"); shift 2 ;;
+    --verbose) verbose_mode=true; shift ;;
+    *) shift ;;
+  esac
+done
+
+: "${home_dir:=$HOME}"
+: "${project_dir:=$(pwd)}"
+
+# Default report sources when none injected.
+if [ "${#reports_dirs[@]}" -eq 0 ]; then
+  reports_dirs=(
+    "/Library/Logs/DiagnosticReports"
+    "${home_dir}/Library/Logs/DiagnosticReports"
+  )
+fi
+
+echo "=== MACOS INCIDENT POSTMORTEM ==="
+
+issue_count=0
+check_status="OK"
+issues_list=""
+
+add_issue() {
+  # $1 severity, $2 type, $3 message
+  issues_list="${issues_list}  - SEVERITY=$1 TYPE=$2 MSG=$3\n"
+  issue_count=$((issue_count + 1))
+  case "$1" in
+    ERROR) check_status="ERROR" ;;
+    WARN) [ "$check_status" = "OK" ] && check_status="WARN" ;;
+  esac
+}
+
+# --- Platform note (do not hard-fail offline; CI runs on Linux) -------------
+host_uname="${MACOS_PM_UNAME:-$(uname -s 2>/dev/null || echo unknown)}"
+echo "HOST_UNAME=${host_uname}"
+if [ "$host_uname" != "Darwin" ]; then
+  echo "PLATFORM=non-darwin"
+  add_issue WARN non_darwin "not running on Darwin; system probes inert, scanning injected report dirs only"
+fi
+
+# --- Resolve which report dirs actually exist ------------------------------
+present_dirs=()
+for d in "${reports_dirs[@]}"; do
+  if [ -d "$d" ]; then
+    present_dirs+=("$d")
+    [ "$verbose_mode" = true ] && echo "REPORTS_DIR_PRESENT=${d}"
+  else
+    [ "$verbose_mode" = true ] && echo "REPORTS_DIR_ABSENT=${d}"
+  fi
+done
+
+echo "REPORTS_DIRS_PRESENT=${#present_dirs[@]}"
+
+if [ "${#present_dirs[@]}" -eq 0 ]; then
+  # Degrade gracefully — a missing source is a known, non-fatal state.
+  echo "REPORT_COUNT=0"
+  add_issue WARN no_reports_dir "no DiagnosticReports directory found; cannot reconstruct timeline from report files"
+fi
+
+# --- Category counts + CPU histogram + jetsam list -------------------------
+# Walk each present dir once, classify by filename suffix.
+report_total=0
+panic_count=0
+hang_count=0
+spindump_count=0
+cpu_count=0
+wakeups_count=0
+diskwrites_count=0
+jetsam_count=0
+crash_count=0
+ips_count=0
+
+# CPU offender histogram: process -> count.
+declare -A cpu_offenders=()
+# Jetsam victim histogram from "name":"<proc>" lines in JetsamEvent files.
+declare -A jetsam_victims=()
+
+latest_panic=""
+latest_panic_epoch=0
+latest_hang=""
+latest_hang_epoch=0
+
+# Portable mtime epoch (BSD stat -f vs GNU stat -c).
+file_mtime_epoch() {
+  stat -f '%m' "$1" 2>/dev/null || stat -c '%Y' "$1" 2>/dev/null || echo 0
+}
+
+for d in "${present_dirs[@]}"; do
+  while IFS= read -r f; do
+    [ -f "$f" ] || continue
+    base="${f##*/}"
+    report_total=$((report_total + 1))
+    case "$base" in
+      *.panic)
+        panic_count=$((panic_count + 1))
+        e="$(file_mtime_epoch "$f")"
+        if [ "$e" -ge "$latest_panic_epoch" ]; then
+          latest_panic_epoch="$e"; latest_panic="$f"
+        fi
+        ;;
+      *.spindump.txt)
+        spindump_count=$((spindump_count + 1))
+        ;;
+      *.hang)
+        hang_count=$((hang_count + 1))
+        e="$(file_mtime_epoch "$f")"
+        if [ "$e" -ge "$latest_hang_epoch" ]; then
+          latest_hang_epoch="$e"; latest_hang="$f"
+        fi
+        ;;
+      *.cpu_resource.diag)
+        cpu_count=$((cpu_count + 1))
+        # Offender = leading token before the first '-' in the filename.
+        proc="${base%%-*}"
+        cpu_offenders["$proc"]=$(( ${cpu_offenders["$proc"]:-0} + 1 ))
+        ;;
+      *.wakeups_resource.diag)
+        wakeups_count=$((wakeups_count + 1))
+        ;;
+      *.diskwrites_resource.diag)
+        diskwrites_count=$((diskwrites_count + 1))
+        ;;
+      JetsamEvent-*)
+        jetsam_count=$((jetsam_count + 1))
+        # Collect victim process names from "name":"<proc>" occurrences.
+        while IFS= read -r victim; do
+          [ -n "$victim" ] || continue
+          jetsam_victims["$victim"]=$(( ${jetsam_victims["$victim"]:-0} + 1 ))
+        done < <(grep -hoE '"name"[[:space:]]*:[[:space:]]*"[^"]+"' "$f" 2>/dev/null \
+                   | sed -E 's/.*"name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')
+        ;;
+      *.crash)
+        crash_count=$((crash_count + 1))
+        ;;
+      *.ips)
+        ips_count=$((ips_count + 1))
+        ;;
+    esac
+  done < <(find "$d" -type f 2>/dev/null)
+done
+
+echo "REPORT_COUNT=${report_total}"
+echo "PANIC_COUNT=${panic_count}"
+echo "HANG_COUNT=${hang_count}"
+echo "SPINDUMP_COUNT=${spindump_count}"
+echo "CPU_RESOURCE_COUNT=${cpu_count}"
+echo "WAKEUPS_RESOURCE_COUNT=${wakeups_count}"
+echo "DISKWRITES_RESOURCE_COUNT=${diskwrites_count}"
+echo "JETSAM_COUNT=${jetsam_count}"
+echo "CRASH_COUNT=${crash_count}"
+echo "IPS_COUNT=${ips_count}"
+
+[ -n "$latest_panic" ] && echo "LATEST_PANIC=${latest_panic}"
+[ -n "$latest_hang" ] && echo "LATEST_HANG=${latest_hang}"
+
+# CPU offender histogram (descending by count). One row per offender.
+if [ "${#cpu_offenders[@]}" -gt 0 ]; then
+  echo "CPU_OFFENDERS:"
+  for proc in "${!cpu_offenders[@]}"; do
+    printf '%d\t%s\n' "${cpu_offenders[$proc]}" "$proc"
+  done | sort -rn | while IFS=$'\t' read -r cnt proc; do
+    echo "  - PROC=${proc} COUNT=${cnt}"
+  done
+fi
+
+# Jetsam victim histogram (descending by count).
+if [ "${#jetsam_victims[@]}" -gt 0 ]; then
+  echo "JETSAM_VICTIMS:"
+  for victim in "${!jetsam_victims[@]}"; do
+    printf '%d\t%s\n' "${jetsam_victims[$victim]}" "$victim"
+  done | sort -rn | while IFS=$'\t' read -r cnt victim; do
+    echo "  - PROC=${victim} COUNT=${cnt}"
+  done
+fi
+
+# --- Reboot-vs-hang signal detection ---------------------------------------
+# Boot time: injected epoch wins; else parse `sysctl -n kern.boottime`.
+boot_epoch=""
+if [ -n "${MACOS_PM_BOOTTIME:-}" ]; then
+  boot_epoch="$MACOS_PM_BOOTTIME"
+elif [ "$host_uname" = "Darwin" ] && command -v sysctl >/dev/null 2>&1; then
+  # sysctl emits e.g. "{ sec = 1714723200, usec = 0 } Tue Apr 22 ..."
+  boot_raw="$(sysctl -n kern.boottime 2>/dev/null || true)"
+  boot_epoch="$(printf '%s' "$boot_raw" | sed -nE 's/.*sec = ([0-9]+).*/\1/p')"
+fi
+[ -n "$boot_epoch" ] && echo "BOOT_EPOCH=${boot_epoch}"
+
+# Most-recent boot-history line, via injectable seam.
+last_reboot_line=""
+if [ -n "${MACOS_PM_LAST_REBOOT:-}" ]; then
+  last_reboot_line="$(eval "${MACOS_PM_LAST_REBOOT}" 2>/dev/null | grep -v '^$' | head -1)"
+elif [ "$host_uname" = "Darwin" ] && command -v last >/dev/null 2>&1; then
+  last_reboot_line="$(last reboot 2>/dev/null | grep -v '^$' | head -1)"
+fi
+[ -n "$last_reboot_line" ] && echo "LAST_REBOOT=${last_reboot_line}"
+
+last_shutdown_line=""
+if [ -n "${MACOS_PM_LAST_SHUTDOWN:-}" ]; then
+  last_shutdown_line="$(eval "${MACOS_PM_LAST_SHUTDOWN}" 2>/dev/null | grep -v '^$' | head -1)"
+elif [ "$host_uname" = "Darwin" ] && command -v last >/dev/null 2>&1; then
+  last_shutdown_line="$(last shutdown 2>/dev/null | grep -v '^$' | head -1)"
+fi
+[ -n "$last_shutdown_line" ] && echo "LAST_SHUTDOWN=${last_shutdown_line}"
+
+# --- Reboot/hang classifier (pure function over gathered signals) ----------
+# Only classify when we have both the incident time T and the boot epoch — the
+# two facts the decision tree turns on. Otherwise report UNKNOWN and let the
+# model gather more.
+classification="UNKNOWN"
+classification_reason="insufficient signals (need incident epoch + boot epoch)"
+
+incident_epoch="${MACOS_PM_INCIDENT_EPOCH:-}"
+[ -n "$incident_epoch" ] && echo "INCIDENT_EPOCH=${incident_epoch}"
+
+if [ -n "$incident_epoch" ] && [ -n "$boot_epoch" ]; then
+  if [ "$boot_epoch" -ge "$incident_epoch" ]; then
+    # Machine booted at or after the incident → a reboot happened around T.
+    if [ "$panic_count" -gt 0 ]; then
+      classification="REBOOT_PANIC"
+      classification_reason="boot at/after T and >=1 panic report present"
+    else
+      classification="REBOOT_CLEAN"
+      classification_reason="boot at/after T, no panic report (user-initiated or watchdog restart)"
+    fi
+  else
+    # Boot predates the incident → the kernel never reset; it was a hang.
+    if [ "$hang_count" -gt 0 ] || [ "$spindump_count" -gt 0 ]; then
+      classification="HANG_UI"
+      classification_reason="boot before T with hang/spindump report present (UI thread hang)"
+    elif [ "$cpu_count" -gt 0 ]; then
+      classification="HANG_CPU"
+      classification_reason="boot before T with cpu_resource report present (daemon CPU storm)"
+    elif [ "$jetsam_count" -gt 0 ]; then
+      classification="HANG_JETSAM"
+      classification_reason="boot before T with jetsam event present (memory-pressure kill)"
+    else
+      classification="HANG_OR_POWERCYCLE"
+      classification_reason="boot before T, no hang/cpu/jetsam report (power loss or hard power-cycle)"
+    fi
+  fi
+fi
+
+echo "CLASSIFICATION=${classification}"
+echo "CLASSIFICATION_REASON=${classification_reason}"
+
+# --- Trailer ----------------------------------------------------------------
+echo "STATUS=${check_status}"
+echo "ISSUE_COUNT=${issue_count}"
+if [ -n "$issues_list" ]; then
+  echo "ISSUES:"
+  echo -e "$issues_list" | sed '/^$/d'
+fi
+echo "=== END MACOS INCIDENT POSTMORTEM ==="
+
+# Exit 0 on OK/WARN, 1 on ERROR.
+[ "$check_status" = "ERROR" ] && exit 1
+exit 0

--- a/macos-plugin/skills/macos-incident-postmortem/scripts/tests/test-macos-incident-postmortem.sh
+++ b/macos-plugin/skills/macos-incident-postmortem/scripts/tests/test-macos-incident-postmortem.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Regression test for macos-incident-postmortem.sh (issue #1557).
+#
+# Runs entirely offline on Linux CI against PLANTED fixture report files via the
+# injectable seams (--reports-dir + MACOS_PM_* env vars) — never against the
+# real macOS system. Asserts the SEMANTIC invariants:
+#   - A planted reboot scenario (boot at/after T) classifies as a reboot, with
+#     correct per-category report counts and CPU/jetsam histograms.
+#   - A planted hang scenario (boot before T, hang report present) classifies as
+#     a UI hang.
+#   - A missing/empty reports dir degrades gracefully (STATUS without crashing).
+# Exit 0 on success ("ALL TESTS PASSED"); non-zero on any failure.
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+pm_script="${script_dir}/../macos-incident-postmortem.sh"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+pass() {
+  echo "PASS: $1"
+}
+
+# Hard deps: find, sed, grep, sort. Skip cleanly if missing (CI determinism).
+for dep in find sed grep sort; do
+  if ! command -v "$dep" >/dev/null 2>&1; then
+    echo "SKIP: $dep not installed; cannot run macos-incident-postmortem tests"
+    exit 0
+  fi
+done
+
+[ -f "$pm_script" ] || fail "macos-incident-postmortem.sh not found at $pm_script"
+
+fixture_root="$(mktemp -d)"
+trap 'rm -rf "$fixture_root"' EXIT
+
+# -----------------------------------------------------------------------------
+# Case 1: REBOOT scenario — boot AT/AFTER T, a panic + CPU + jetsam present.
+# Decision tree: boot_epoch >= incident_epoch AND panic_count > 0 → REBOOT_PANIC.
+# -----------------------------------------------------------------------------
+reboot_dir="${fixture_root}/reboot"
+mkdir -p "$reboot_dir"
+# A panic report.
+printf 'panic(cpu 0 caller 0xdead): fake panic for fixture\nBacktrace (CPU 0):\n' \
+  > "${reboot_dir}/Kernel-2026-04-22-081500.panic"
+# Two CPU-resource diags for the same offender, one for another.
+printf '{}' > "${reboot_dir}/hungdaemon-2026-04-22-081000.cpu_resource.diag"
+printf '{}' > "${reboot_dir}/hungdaemon2-2026-04-22-081100.cpu_resource.diag"
+# Note: offender token is everything before the first '-'.
+printf '{}' > "${reboot_dir}/coreaudiod-2026-04-22-081200.cpu_resource.diag"
+# A jetsam event naming two victim processes.
+printf '{ "killed": 1, "name":"Safari" }\n{ "name":"Mail" }\n' \
+  > "${reboot_dir}/JetsamEvent-2026-04-22-081300.ips"
+# A legacy crash + a modern ips, to exercise both counters.
+printf 'legacy crash\n' > "${reboot_dir}/SomeApp-2026-04-22.crash"
+
+incident_epoch=1714723200          # the incident time T
+boot_after=$((incident_epoch + 60)) # booted 60s after T → reboot
+
+out1="$(MACOS_PM_UNAME=Linux \
+        MACOS_PM_BOOTTIME="$boot_after" \
+        MACOS_PM_INCIDENT_EPOCH="$incident_epoch" \
+        MACOS_PM_LAST_REBOOT='printf "reboot ~ Tue Apr 22 08:16\n"' \
+        bash "$pm_script" --home-dir "$fixture_root" --reports-dir "$reboot_dir")"
+rc1=$?
+
+[ "$rc1" -eq 0 ] || fail "reboot case should exit 0 (WARN on non-darwin), got rc=$rc1:\n$out1"
+echo "$out1" | grep -q "^CLASSIFICATION=REBOOT_PANIC$" \
+  || fail "expected CLASSIFICATION=REBOOT_PANIC, got:\n$out1"
+echo "$out1" | grep -q "^PANIC_COUNT=1$" \
+  || fail "expected PANIC_COUNT=1, got:\n$out1"
+echo "$out1" | grep -q "^CPU_RESOURCE_COUNT=3$" \
+  || fail "expected CPU_RESOURCE_COUNT=3, got:\n$out1"
+echo "$out1" | grep -q "^JETSAM_COUNT=1$" \
+  || fail "expected JETSAM_COUNT=1, got:\n$out1"
+echo "$out1" | grep -q "^CRASH_COUNT=1$" \
+  || fail "expected CRASH_COUNT=1, got:\n$out1"
+echo "$out1" | grep -q "^STATUS=" \
+  || fail "expected a STATUS= line, got:\n$out1"
+# CPU offender histogram: the top offender 'hungdaemon2'/'hungdaemon' each have 1
+# — assert the histogram block exists and lists a known offender.
+echo "$out1" | grep -q "^CPU_OFFENDERS:$" \
+  || fail "expected CPU_OFFENDERS histogram block, got:\n$out1"
+echo "$out1" | grep -q "PROC=coreaudiod COUNT=1" \
+  || fail "expected coreaudiod offender row, got:\n$out1"
+# Jetsam victims histogram lists Safari and Mail.
+echo "$out1" | grep -q "^JETSAM_VICTIMS:$" \
+  || fail "expected JETSAM_VICTIMS histogram block, got:\n$out1"
+echo "$out1" | grep -q "PROC=Safari COUNT=1" \
+  || fail "expected Safari jetsam victim row, got:\n$out1"
+pass "planted reboot fixture classifies REBOOT_PANIC with correct counts/histograms"
+
+# -----------------------------------------------------------------------------
+# Case 2: HANG scenario — boot BEFORE T, a .hang report present, no panic.
+# Decision tree: boot_epoch < incident_epoch AND hang_count > 0 → HANG_UI.
+# -----------------------------------------------------------------------------
+hang_dir="${fixture_root}/hang"
+mkdir -p "$hang_dir"
+printf 'WindowServer hang detected\n' > "${hang_dir}/WindowServer-2026-04-22-081500.hang"
+printf 'spindump capture\n' > "${hang_dir}/WindowServer-2026-04-22-081500.spindump.txt"
+
+boot_before=$((incident_epoch - 3600)) # booted 1h before T → no reboot
+
+out2="$(MACOS_PM_UNAME=Linux \
+        MACOS_PM_BOOTTIME="$boot_before" \
+        MACOS_PM_INCIDENT_EPOCH="$incident_epoch" \
+        bash "$pm_script" --home-dir "$fixture_root" --reports-dir "$hang_dir")"
+rc2=$?
+
+[ "$rc2" -eq 0 ] || fail "hang case should exit 0, got rc=$rc2:\n$out2"
+echo "$out2" | grep -q "^CLASSIFICATION=HANG_UI$" \
+  || fail "expected CLASSIFICATION=HANG_UI, got:\n$out2"
+echo "$out2" | grep -q "^HANG_COUNT=1$" \
+  || fail "expected HANG_COUNT=1, got:\n$out2"
+echo "$out2" | grep -q "^SPINDUMP_COUNT=1$" \
+  || fail "expected SPINDUMP_COUNT=1, got:\n$out2"
+echo "$out2" | grep -q "^PANIC_COUNT=0$" \
+  || fail "expected PANIC_COUNT=0 in hang case, got:\n$out2"
+pass "planted hang fixture classifies HANG_UI with correct counts"
+
+# -----------------------------------------------------------------------------
+# Case 3: missing reports dir → graceful degradation (STATUS, no crash).
+# -----------------------------------------------------------------------------
+missing_dir="${fixture_root}/does-not-exist"
+
+out3="$(MACOS_PM_UNAME=Linux \
+        bash "$pm_script" --home-dir "$fixture_root" --reports-dir "$missing_dir")"
+rc3=$?
+
+[ "$rc3" -eq 0 ] || fail "missing-dir case should exit 0 (WARN, not ERROR), got rc=$rc3:\n$out3"
+echo "$out3" | grep -q "^REPORTS_DIRS_PRESENT=0$" \
+  || fail "expected REPORTS_DIRS_PRESENT=0 for missing dir, got:\n$out3"
+echo "$out3" | grep -q "^REPORT_COUNT=0$" \
+  || fail "expected REPORT_COUNT=0 for missing dir, got:\n$out3"
+echo "$out3" | grep -q "^STATUS=WARN$" \
+  || fail "expected STATUS=WARN for missing reports dir, got:\n$out3"
+echo "$out3" | grep -q "TYPE=no_reports_dir" \
+  || fail "expected a no_reports_dir issue row, got:\n$out3"
+echo "$out3" | grep -q "=== END MACOS INCIDENT POSTMORTEM ===" \
+  || fail "expected closing section delimiter, got:\n$out3"
+pass "missing reports dir degrades gracefully with STATUS=WARN, no crash"
+
+# -----------------------------------------------------------------------------
+# Case 4: insufficient signals (no incident epoch) → UNKNOWN, not a guess.
+# -----------------------------------------------------------------------------
+out4="$(MACOS_PM_UNAME=Linux \
+        MACOS_PM_BOOTTIME="$boot_before" \
+        bash "$pm_script" --home-dir "$fixture_root" --reports-dir "$hang_dir")"
+rc4=$?
+
+[ "$rc4" -eq 0 ] || fail "no-incident-epoch case should exit 0, got rc=$rc4:\n$out4"
+echo "$out4" | grep -q "^CLASSIFICATION=UNKNOWN$" \
+  || fail "expected CLASSIFICATION=UNKNOWN without incident epoch, got:\n$out4"
+pass "without incident epoch the classifier reports UNKNOWN rather than guessing"
+
+echo "ALL TESTS PASSED"

--- a/macos-plugin/skills/macos-incident-postmortem/skill.md
+++ b/macos-plugin/skills/macos-incident-postmortem/skill.md
@@ -2,10 +2,10 @@
 name: macos-incident-postmortem
 description: Reconstruct macOS freeze, panic, or reboot from DiagnosticReports and shell history. Use when investigating hangs, panics, watchdog timeouts, jetsam, or thermal throttling.
 user-invocable: false
-allowed-tools: Bash(uname *), Bash(sysctl *), Bash(uptime *), Bash(last *), Bash(ls *), Bash(find *), Bash(stat *), Bash(awk *), Bash(grep *), Bash(wc *), Bash(date *), Bash(log *), Bash(pmset *), Read, Grep, Glob, TodoWrite
+allowed-tools: Bash(bash *), Bash(uname *), Bash(sysctl *), Bash(uptime *), Bash(last *), Bash(log *), Bash(pmset *), Read, Grep, Glob, TodoWrite
 created: 2026-05-03
-modified: 2026-05-09
-reviewed: 2026-05-03
+modified: 2026-06-10
+reviewed: 2026-06-10
 ---
 
 # macOS Incident Postmortem
@@ -42,41 +42,44 @@ The first job in a postmortem is **distinguishing between actual reboots and GUI
 
 The second job is **timeline reconstruction**: cross-reference Diagnostic Reports, `kern.boottime`, `last reboot`, `last shutdown`, and shell history to answer "what happened around time T?".
 
-## Did the Machine Actually Reboot?
+## Gather the deterministic signals
 
-Three signals, evaluated together:
+Run the bundled script to gather every mechanical signal in one pass —
+reboot-vs-hang detection, per-category DiagnosticReports counts, the CPU-event
+offender histogram, the jetsam victim list, and the fixed reboot/hang
+classifier:
 
 ```bash
-# Current boot time as a unix timestamp
-sysctl -n kern.boottime
-# → { sec = 1714723200, usec = 0 } Tue Apr 22 ...
-
-# Boot history (most recent first)
-last reboot | head -5
-
-# Shutdown history
-last shutdown | head -5
+bash "${CLAUDE_SKILL_DIR}/scripts/macos-incident-postmortem.sh" --home-dir "$HOME"
 ```
 
-Decision rules:
+Parse `STATUS=` and `ISSUES:` from the output. The script emits
+`CLASSIFICATION=` (REBOOT_PANIC / REBOOT_CLEAN / HANG_UI / HANG_CPU /
+HANG_JETSAM / HANG_OR_POWERCYCLE / UNKNOWN) with a `CLASSIFICATION_REASON=`,
+plus `PANIC_COUNT=` / `HANG_COUNT=` / `JETSAM_COUNT=` / `CPU_RESOURCE_COUNT=`
+etc., `LATEST_PANIC=` / `LATEST_HANG=` paths, and `CPU_OFFENDERS:` /
+`JETSAM_VICTIMS:` histograms.
+
+Pass the incident time T as an epoch to enable the classifier
+(`MACOS_PM_INCIDENT_EPOCH=<epoch> bash …`), or supply an alternate report
+source with `--reports-dir <path>`. With no incident time the classifier
+reports `UNKNOWN` rather than guessing — feed it T once you know it.
+
+The reboot/hang decision tree the script encodes:
 
 | Pattern | Interpretation |
 |---------|----------------|
-| `last reboot` shows a new entry near time T | True reboot — kernel was reset |
-| `last reboot` unchanged, `kern.boottime` matches the older boot | GUI hang — machine did not reboot |
-| `last shutdown` shows an "abrupt" entry near time T | Power loss or hard hold-down — kernel did not write a clean shutdown |
-| `last shutdown` shows a clean entry, then `last reboot` | User-initiated shutdown/restart |
+| Boot at/after T with a `.panic` report | True reboot from a kernel panic |
+| Boot at/after T, no panic | Clean restart (user-initiated or watchdog) |
+| Boot before T with a `.hang`/`.spindump.txt` | GUI hang — machine did not reboot |
+| Boot before T with a `.cpu_resource.diag` | Daemon CPU storm |
+| Boot before T with a `JetsamEvent-*` | Memory-pressure kill |
+| Boot before T, none of the above | Power loss or hard power-cycle |
 
-`last reboot` reads `/var/log/wtmp.X` rotated logs. On modern macOS, also check the unified log:
+### Diagnostic report category reference
 
-```bash
-log show --predicate 'eventType == "stateEvent" AND (event == "boot" OR event == "shutdown")' \
-  --last 7d --style syslog
-```
-
-## Diagnostic Report Categories
-
-`/Library/Logs/DiagnosticReports/` collects everything macOS thinks is worth keeping. The filename pattern identifies the category:
+`/Library/Logs/DiagnosticReports/` collects everything macOS thinks is worth
+keeping; the script classifies each by filename suffix:
 
 | Pattern | Category | Severity |
 |---------|----------|----------|
@@ -90,37 +93,25 @@ log show --predicate 'eventType == "stateEvent" AND (event == "boot" OR event ==
 | `*.spindump.txt` | Spindump capture from a hang | GUI freeze |
 | `JetsamEvent-*.ips` | Kernel killed processes for memory pressure | RAM exhaustion |
 
-Note: Apple migrated most categories to the `.ips` extension circa Monterey. Older systems and some categories still produce legacy extensions. Match by suffix, not by exact filename.
+Note: Apple migrated most categories to the `.ips` extension circa Monterey.
+Older systems and some categories still produce legacy extensions. The script
+matches by suffix, not by exact filename.
 
-## Timeline Reconstruction
-
-### Step 1: List recent events
-
-```bash
-find /Library/Logs/DiagnosticReports -type f -mtime -2 \
-  -exec stat -f '%Sm  %N' -t '%Y-%m-%d %H:%M:%S' {} \; \
-  | sort
-```
-
-This produces a chronological list of every diagnostic report from the last 48 hours. Filter further by category if needed:
+`last reboot` reads `/var/log/wtmp.X` rotated logs. On modern macOS, also check
+the unified log when `wtmp` has rotated past the incident:
 
 ```bash
-find /Library/Logs/DiagnosticReports -type f -mtime -2 \
-  \( -name '*.panic' -o -name '*.hang' -o -name 'JetsamEvent-*' \) \
-  -exec stat -f '%Sm  %N' -t '%Y-%m-%d %H:%M:%S' {} \; | sort
+log show --predicate 'eventType == "stateEvent" AND (event == "boot" OR event == "shutdown")' \
+  --last 7d --style syslog
 ```
 
-### Step 2: Cross-reference with boot history
+## Timeline Reconstruction (judgment)
 
-```bash
-last reboot | head -5
-last shutdown | head -5
-sysctl -n kern.boottime
-```
+With the deterministic classification and counts in hand, the remaining steps
+are the agent's job: read the panic backtrace, name suspect kexts, correlate
+with logs and shell activity, and write the narrative.
 
-Mark the incident time T. Determine: was T before or after the most recent boot? If after, the machine never rebooted — it was a hang.
-
-### Step 3: Inspect the unified log around T
+### Step 1: Inspect the unified log around T
 
 ```bash
 # Adjust the time window to bracket T
@@ -140,17 +131,10 @@ Common signatures to grep for:
 | `_dispatch_*_timeout` | Daemon stuck on a synchronous IPC call |
 | `Thermal pressure` | CPU thermal-throttled |
 
-### Step 4: Inspect the panic / hang report
+### Step 2: Inspect the panic / hang report
 
-```bash
-# Most recent panic
-ls -1t /Library/Logs/DiagnosticReports/*.panic 2>/dev/null | head -1
-
-# Most recent hang
-ls -1t /Library/Logs/DiagnosticReports/*.hang* 2>/dev/null | head -1
-```
-
-Read the file. Key fields in a panic report:
+The script's `LATEST_PANIC=` / `LATEST_HANG=` lines give you the file to read.
+Key fields in a panic report:
 
 | Field | Meaning |
 |-------|---------|
@@ -162,7 +146,7 @@ Read the file. Key fields in a panic report:
 
 Hang reports are spindump-style: one column per thread of the hung process (typically WindowServer or the offender daemon), with stack traces at sample intervals.
 
-### Step 5: Correlate with shell activity
+### Step 3: Correlate with shell activity
 
 ```bash
 # Most recent zsh history entries (assumes default zsh)
@@ -174,7 +158,7 @@ tail -50 ~/.zsh_history
 
 The zsh `EXTENDED_HISTORY` format `: <epoch>:<elapsed>;<cmd>` lets you grep for commands run within the incident window.
 
-### Step 6: Synthesize
+### Step 4: Synthesize
 
 Write a one-paragraph timeline including:
 
@@ -185,47 +169,14 @@ Write a one-paragraph timeline including:
 
 ## Common Patterns
 
-### "Was that a reboot or a hang?" one-liner
-
-```bash
-last reboot | awk 'NR<=3' && \
-  echo "kern.boottime: $(sysctl -n kern.boottime)" && \
-  echo "uptime: $(uptime)"
-```
-
-If the most recent `last reboot` line is older than the incident, the machine never rebooted — it was a userspace hang.
-
-### Count diag reports by category, last 7 days
-
-```bash
-find /Library/Logs/DiagnosticReports -type f -mtime -7 -name '*.panic' | wc -l
-find /Library/Logs/DiagnosticReports -type f -mtime -7 -name '*.hang*' | wc -l
-find /Library/Logs/DiagnosticReports -type f -mtime -7 -name '*.cpu_resource.diag' | wc -l
-find /Library/Logs/DiagnosticReports -type f -mtime -7 -name 'JetsamEvent-*' | wc -l
-```
-
-A sudden rise in any category is a leading indicator before a major hang or panic.
-
-### Find the dominant CPU-event offender
-
-```bash
-ls /Library/Logs/DiagnosticReports/*.cpu_resource.diag 2>/dev/null \
-  | awk -F/ '{print $NF}' \
-  | awk -F- '{print $1}' \
-  | sort | uniq -c | sort -rn
-```
-
-The first column is event count; the second is the offender process name.
-
-### Jetsam victim list
-
-```bash
-grep -lE 'killed' /Library/Logs/DiagnosticReports/JetsamEvent-*.ips 2>/dev/null \
-  | xargs -r grep -hE '"name":' \
-  | sort | uniq -c | sort -rn | head -20
-```
-
-Apps that show up here repeatedly are running near their memory budget.
+The reboot-vs-hang one-liner, per-category report counts, the CPU-event
+offender histogram, and the jetsam victim list are all produced in one pass by
+the bundled script (`scripts/macos-incident-postmortem.sh` — see "Gather the
+deterministic signals" above). Read `CLASSIFICATION=`, the `*_COUNT=` keys,
+`CPU_OFFENDERS:`, and `JETSAM_VICTIMS:` from its output rather than re-running
+the equivalent shell pipelines. A sudden rise in any category count is a
+leading indicator before a major hang or panic; offenders/victims that recur
+are running near their CPU/memory budget.
 
 ### Correlate with sleep/wake history
 
@@ -251,14 +202,11 @@ If one of these is the only thing visible in your timeline, look harder — the 
 
 | Context | Command |
 |---------|---------|
+| All deterministic signals + classifier | `bash "${CLAUDE_SKILL_DIR}/scripts/macos-incident-postmortem.sh" --home-dir "$HOME"` |
+| Classify against a known T | `MACOS_PM_INCIDENT_EPOCH=<epoch> bash "${CLAUDE_SKILL_DIR}/scripts/macos-incident-postmortem.sh"` |
 | Last 5 boots | `last reboot \| head -5` |
 | Last 5 shutdowns | `last shutdown \| head -5` |
-| Did we reboot since T? | `last reboot \| awk '$0 ~ /YYYY-MM-DD/'` |
-| Recent diag reports (48h) | `find /Library/Logs/DiagnosticReports -type f -mtime -2 -exec stat -f '%Sm  %N' -t '%F %T' {} \;` |
-| Last panic file | `ls -1t /Library/Logs/DiagnosticReports/*.panic 2>/dev/null \| head -1` |
-| First panic line | `head -1 "$(ls -1t /Library/Logs/DiagnosticReports/*.panic \| head -1)"` |
 | WindowServer log slice | `log show --predicate 'subsystem == "com.apple.WindowServer"' --last 1h --style syslog \| head -200` |
-| CPU offender histogram | `ls /Library/Logs/DiagnosticReports/*.cpu_resource.diag \| awk -F/ '{print $NF}' \| awk -F- '{print $1}' \| sort \| uniq -c \| sort -rn` |
 
 ## Quick Reference
 


### PR DESCRIPTION
Closes #1557

Extracts the deterministic procedure from the `macos-incident-postmortem` skill into a structured-output helper script plus a colocated offline regression test, per ADR-0016. Reading panic backtraces, naming suspect kexts, and narrative assembly stay with the model.

- `scripts/macos-incident-postmortem.sh` — gathers reboot-vs-hang signals, per-category DiagnosticReports counts, the CPU-event offender histogram, and the jetsam victim list, then runs the fixed reboot/hang classifier; every macOS probe sits behind an injectable seam (`--reports-dir`, `MACOS_PM_*`) and emits the `=== … ===` / `STATUS=` / `ISSUE_COUNT=` convention.
- `scripts/tests/test-macos-incident-postmortem.sh` — runs offline on Linux against planted fixture reports: asserts a planted reboot classifies REBOOT_PANIC with correct counts/histograms, a planted hang classifies HANG_UI, a missing reports dir degrades gracefully (STATUS=WARN, no crash), and no incident epoch yields UNKNOWN rather than a guess.
- `skill.md` — replaces the inline deterministic bash with a single script call (`Parse STATUS= and ISSUES:`), keeps the When-to-Use and Agentic-Optimizations tables and the judgment prose, bumps `modified:`/`reviewed:` to 2026-06-10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)