### PR TITLE
refactor(workflow-orchestration-plugin): extract workflow-preflight procedure to scripts + regression test

### DIFF
--- a/workflow-orchestration-plugin/skills/workflow-preflight/SKILL.md
+++ b/workflow-orchestration-plugin/skills/workflow-preflight/SKILL.md
@@ -2,11 +2,11 @@
 name: workflow-preflight
 description: Pre-work validation before implementation. Use when starting an issue or fix to verify remote state, check for existing PRs, and detect branch conflicts before coding.
 args: "[issue-number|branch-name]"
-allowed-tools: Bash(git fetch *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git branch *), Bash(git remote *), Bash(git stash *), Bash(gh pr *), Bash(gh issue *), Read, Grep, Glob, TodoWrite
+allowed-tools: Bash(bash *), Bash(git fetch *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git branch *), Bash(git remote *), Bash(git stash *), Bash(gh pr *), Bash(gh issue *), Read, Grep, Glob, TodoWrite
 argument-hint: optional issue number or branch name to check
 created: 2026-02-08
-modified: 2026-05-09
-reviewed: 2026-02-08
+modified: 2026-06-10
+reviewed: 2026-06-10
 ---
 
 # /workflow:preflight
@@ -32,73 +32,25 @@ Pre-work validation to prevent wasted effort from stale state, redundant work, o
 
 ## Execution
 
-### Step 1: Fetch Latest Remote State
+### Step 1: Run the deterministic preflight check
+
+Pass `--issue <n>` when an issue number was provided:
 
 ```bash
-git fetch origin --prune 2>/dev/null
+bash "${CLAUDE_SKILL_DIR}/scripts/workflow-preflight.sh" --home-dir "$HOME" --project-dir "$(pwd)"
 ```
 
-### Step 2: Check for Existing Work
+The script fetches the remote, computes ahead/behind counts, looks up an existing PR / issue / branch for the target, runs a `merge-tree` dry-run for conflicts, inspects uncommitted + stash state, and emits a `RECOMMENDATION=` from the fixed decision tree. Parse `STATUS=` and `ISSUES:` from the output, plus `RECOMMENDATION=`, `EXISTING_PR_STATE=`, `COMMITS_AHEAD=`/`COMMITS_BEHIND=`, `CONFLICTS_DETECTED=`, `UNCOMMITTED_CHANGES=`, and `STASH_COUNT=`.
 
-If an issue number was provided, check if it's already addressed:
+### Step 2: Decide on an existing open PR
 
-```bash
-# Check if issue exists and its state
-gh issue view $ISSUE --json number,title,state,labels 2>/dev/null
+The script reports `EXISTING_PR_STATE=MERGED|OPEN|NONE`:
 
-# Check for PRs that reference this issue
-gh pr list --search "fixes #$ISSUE OR closes #$ISSUE OR resolves #$ISSUE" --json number,title,state,headRefName 2>/dev/null
+- **`MERGED`**: the issue is already addressed — stop before duplicating.
+- **`OPEN`**: an existing PR already addresses this. Ask the user whether to continue on that branch or start fresh:
 
-# Check for branches that reference this issue
-git branch -a --list "*issue-$ISSUE*" --list "*fix/$ISSUE*" --list "*feat/$ISSUE*" 2>/dev/null
-```
-
-**If a merged PR exists**: Report that the issue is already addressed. Stop.
-**If an open PR exists**: Report the PR and ask if the user wants to continue on that branch or start fresh.
-
-### Step 3: Verify Branch State
-
-```bash
-# Check divergence from main/master
-git log --oneline origin/main..HEAD 2>/dev/null || git log --oneline origin/master..HEAD 2>/dev/null
-
-# Check if main has moved ahead
-git log --oneline HEAD..origin/main -5 2>/dev/null || git log --oneline HEAD..origin/master -5 2>/dev/null
-
-# Check for uncommitted changes
-git status --porcelain=v2 --branch 2>/dev/null
-```
-
-**Report**:
-- Commits ahead/behind remote
-- Uncommitted changes that might interfere
-- Whether a rebase is needed
-
-### Step 4: Check for Conflicts
-
-```bash
-# Dry-run merge to detect conflicts (without actually merging)
-git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main 2>/dev/null | head -20
-```
-
-### Step 5: Summary Report
-
-Output a structured summary:
-
-| Check | Status | Detail |
-|-------|--------|--------|
-| Remote state | fresh/stale | Last fetch time |
-| Existing PRs | none/open/merged | PR numbers if any |
-| Branch state | clean/dirty/diverged | Ahead/behind counts |
-| Conflicts | none/detected | Conflicting files |
-| Stash | empty/N items | Stash contents |
-
-**Recommendations**:
-- If behind remote: "Rebase recommended before starting work"
-- If existing PR found: "PR #N already addresses this - review before duplicating"
-- If dirty state: "Commit or stash changes before branching"
-- If conflicts detected: "Resolve conflicts with main before proceeding"
-- If clean: "Ready to proceed"
+  Use **AskUserQuestion** — "Continue on existing PR #N, or start fresh?" — before doing any work. This judgment call stays interactive; the script only surfaces the PR state.
+- **`NONE`**: proceed per the script's `RECOMMENDATION=`.
 
 ## Agentic Optimizations
 

--- a/workflow-orchestration-plugin/skills/workflow-preflight/scripts/tests/test-workflow-preflight.sh
+++ b/workflow-orchestration-plugin/skills/workflow-preflight/scripts/tests/test-workflow-preflight.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Regression test for workflow-preflight.sh (issue #1558).
+#
+# Semantic invariant under test: the deterministic recommendation decision tree
+# returns the correct RECOMMENDATION for each combination of booleans, computed
+# offline against a planted git repo + canned gh JSON via the fixture seam
+# (WORKFLOW_PREFLIGHT_FIXTURE + WORKFLOW_PREFLIGHT_NO_FETCH). No network, no gh.
+#
+# Cases:
+#   (a) existing OPEN PR + clean tree   -> "continue ... or start fresh"
+#   (b) merge conflicts detected        -> "Resolve conflicts"
+#   (c) uncommitted + stash present     -> "Commit or stash"
+#   (d) fresh branch, no PR, clean      -> "Ready to proceed"
+#
+# Exit 0 on success ("ALL TESTS PASSED"), non-zero on any failure.
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+preflight_script="${script_dir}/../workflow-preflight.sh"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+pass() { echo "PASS: $1"; }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq not installed; cannot run workflow-preflight tests"
+  exit 0
+fi
+
+[ -f "$preflight_script" ] || fail "workflow-preflight.sh not found at $preflight_script"
+
+home_dir="$(mktemp -d)"
+trap 'rm -rf "$home_dir"' EXIT
+
+# Build a planted git repo with origin/main, a feature branch one commit ahead,
+# and return its path. Isolated env so global git config can't interfere.
+make_repo() {
+  local root remote work
+  root="$(mktemp -d)"
+  remote="${root}/remote.git"
+  work="${root}/work"
+
+  git init --quiet --bare "$remote"
+
+  git init --quiet "$work"
+  git -C "$work" config user.email "test@example.com"
+  git -C "$work" config user.name "Test"
+  git -C "$work" config commit.gpgsign false
+  git -C "$work" checkout -q -b main
+  printf 'base\n' > "${work}/file.txt"
+  git -C "$work" add file.txt
+  git -C "$work" commit --quiet -m "base commit"
+  git -C "$work" remote add origin "$remote"
+  git -C "$work" push --quiet -u origin main
+
+  # Feature branch one commit ahead of main.
+  git -C "$work" checkout -q -b feature/issue-42
+  printf 'base\nfeature line\n' > "${work}/file.txt"
+  git -C "$work" add file.txt
+  git -C "$work" commit --quiet -m "feature work"
+
+  # Refresh remote-tracking refs without hitting the network at run time.
+  git -C "$work" fetch --quiet origin
+
+  echo "$root"
+}
+
+# ---------------------------------------------------------------------------
+# Case (a): existing OPEN PR + clean tree -> continue-or-start-fresh
+# ---------------------------------------------------------------------------
+root_a="$(make_repo)"
+work_a="${root_a}/work"
+fix_a="$(mktemp -d)"
+cat > "${fix_a}/issue.json" <<'JSON'
+{"number":42,"title":"Fix the thing","state":"OPEN","labels":[]}
+JSON
+cat > "${fix_a}/pr-search.json" <<'JSON'
+[{"number":99,"title":"fix: the thing","state":"OPEN","headRefName":"feature/issue-42"}]
+JSON
+
+out_a="$(WORKFLOW_PREFLIGHT_NO_FETCH=1 WORKFLOW_PREFLIGHT_FIXTURE="$fix_a" \
+  bash "$preflight_script" --home-dir "$home_dir" --project-dir "$work_a" --issue 42)"
+
+echo "$out_a" | grep -q "^EXISTING_PR_STATE=OPEN$" \
+  || fail "(a) expected EXISTING_PR_STATE=OPEN, got:\n$out_a"
+echo "$out_a" | grep -q "^RECOMMENDATION=Open PR #99 exists - continue on that branch or start fresh" \
+  || fail "(a) expected continue-or-start-fresh recommendation, got:\n$out_a"
+pass "(a) open PR + clean tree -> continue-or-start-fresh"
+rm -rf "$root_a" "$fix_a"
+
+# ---------------------------------------------------------------------------
+# Case (b): merge conflicts detected -> "Resolve conflicts"
+# ---------------------------------------------------------------------------
+root_b="$(make_repo)"
+work_b="${root_b}/work"
+# Diverge origin/main on the SAME line the feature branch changed, so a
+# merge-tree dry-run reports a real conflict.
+git -C "$work_b" checkout -q main
+printf 'base\nmain divergent line\n' > "${work_b}/file.txt"
+git -C "$work_b" add file.txt
+git -C "$work_b" commit --quiet -m "main diverges"
+git -C "$work_b" push --quiet origin main
+git -C "$work_b" fetch --quiet origin
+git -C "$work_b" checkout -q feature/issue-42
+
+out_b="$(WORKFLOW_PREFLIGHT_NO_FETCH=1 \
+  bash "$preflight_script" --home-dir "$home_dir" --project-dir "$work_b")"
+
+echo "$out_b" | grep -q "^CONFLICTS_DETECTED=true$" \
+  || fail "(b) expected CONFLICTS_DETECTED=true, got:\n$out_b"
+echo "$out_b" | grep -q "^RECOMMENDATION=Resolve conflicts with origin/main" \
+  || fail "(b) expected resolve-conflicts recommendation, got:\n$out_b"
+pass "(b) conflicts detected -> resolve-conflicts"
+rm -rf "$root_b"
+
+# ---------------------------------------------------------------------------
+# Case (c): uncommitted changes + stash present -> "Commit or stash"
+# ---------------------------------------------------------------------------
+root_c="$(make_repo)"
+work_c="${root_c}/work"
+# Create a stash, then leave an uncommitted change in the tree.
+printf 'base\nfeature line\nstashed change\n' > "${work_c}/file.txt"
+git -C "$work_c" stash --quiet
+printf 'base\nfeature line\nuncommitted change\n' > "${work_c}/file.txt"
+
+out_c="$(WORKFLOW_PREFLIGHT_NO_FETCH=1 \
+  bash "$preflight_script" --home-dir "$home_dir" --project-dir "$work_c")"
+
+echo "$out_c" | grep -q "^UNCOMMITTED_CHANGES=true$" \
+  || fail "(c) expected UNCOMMITTED_CHANGES=true, got:\n$out_c"
+echo "$out_c" | grep -qE "^STASH_COUNT=[1-9]" \
+  || fail "(c) expected STASH_COUNT>=1, got:\n$out_c"
+echo "$out_c" | grep -q "^RECOMMENDATION=Commit or stash uncommitted changes before branching$" \
+  || fail "(c) expected commit-or-stash recommendation, got:\n$out_c"
+pass "(c) uncommitted + stash present -> commit-or-stash"
+rm -rf "$root_c"
+
+# ---------------------------------------------------------------------------
+# Case (d): fresh branch, no PR, clean, up to date -> "Ready to proceed"
+# ---------------------------------------------------------------------------
+root_d="$(make_repo)"
+work_d="${root_d}/work"
+# Sit on main itself: clean, no divergence, no target issue.
+git -C "$work_d" checkout -q main
+
+out_d="$(WORKFLOW_PREFLIGHT_NO_FETCH=1 \
+  bash "$preflight_script" --home-dir "$home_dir" --project-dir "$work_d")"
+
+echo "$out_d" | grep -q "^EXISTING_PR_STATE=NONE$" \
+  || fail "(d) expected EXISTING_PR_STATE=NONE, got:\n$out_d"
+echo "$out_d" | grep -q "^UNCOMMITTED_CHANGES=false$" \
+  || fail "(d) expected clean tree, got:\n$out_d"
+echo "$out_d" | grep -q "^CONFLICTS_DETECTED=false$" \
+  || fail "(d) expected no conflicts, got:\n$out_d"
+echo "$out_d" | grep -q "^RECOMMENDATION=Ready to proceed$" \
+  || fail "(d) expected ready-to-proceed recommendation, got:\n$out_d"
+echo "$out_d" | grep -q "^STATUS=OK$" \
+  || fail "(d) expected STATUS=OK on a clean fresh tree, got:\n$out_d"
+pass "(d) fresh branch, no PR, clean -> ready-to-proceed"
+rm -rf "$root_d"
+
+echo "ALL TESTS PASSED"

--- a/workflow-orchestration-plugin/skills/workflow-preflight/scripts/workflow-preflight.sh
+++ b/workflow-orchestration-plugin/skills/workflow-preflight/scripts/workflow-preflight.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# Workflow Preflight
+# Deterministic pre-work validation: fetch remote, compute ahead/behind counts,
+# look up an existing PR / issue / branch for the target, detect merge conflicts
+# via merge-tree dry-run, inspect uncommitted + stash state, and apply the fixed
+# recommendation decision tree over those booleans.
+#
+# The judgment-bearing step ("Continue on existing PR or start fresh?" — an
+# AskUserQuestion handoff) stays in the skill; this script only emits the
+# deterministic state the skill needs to decide.
+#
+# Usage: bash workflow-preflight.sh --home-dir <path> --project-dir <path> \
+#          [--issue <number>]
+#
+# Fixture seam (offline testing): every network/gh probe is injectable so the
+# test suite runs against a planted git repo + canned gh JSON with no network.
+#   WORKFLOW_PREFLIGHT_NO_FETCH=1   skip `git fetch` (no network)
+#   WORKFLOW_PREFLIGHT_FIXTURE=DIR  read canned gh JSON from DIR instead of gh:
+#                                     DIR/issue.json     <- gh issue view ...
+#                                     DIR/pr-search.json <- gh pr list --search ...
+#                                   Absence of a file == empty result for that probe.
+
+set -uo pipefail
+
+home_dir=""
+project_dir=""
+preflight_issue=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --home-dir) home_dir="$2"; shift 2 ;;
+    --project-dir) project_dir="$2"; shift 2 ;;
+    --issue) preflight_issue="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+: "${home_dir:=$HOME}"
+: "${project_dir:=$(pwd)}"
+
+preflight_fixture="${WORKFLOW_PREFLIGHT_FIXTURE:-}"
+preflight_no_fetch="${WORKFLOW_PREFLIGHT_NO_FETCH:-}"
+
+echo "=== WORKFLOW PREFLIGHT ==="
+
+issue_count=0
+check_status="OK"
+issues_list=""
+
+add_issue() {
+  # $1 severity, $2 type, $3 message
+  issues_list="${issues_list}  - SEVERITY=${1} TYPE=${2} MSG=${3}\n"
+  issue_count=$((issue_count + 1))
+  if [ "$1" = "ERROR" ]; then
+    check_status="ERROR"
+  elif [ "$1" = "WARN" ] && [ "$check_status" = "OK" ]; then
+    check_status="WARN"
+  fi
+}
+
+# jq drives the gh JSON parsing; without it the existing-work lookup is unsafe.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "JQ_AVAILABLE=false"
+  echo "STATUS=ERROR"
+  echo "ISSUE_COUNT=1"
+  echo "ISSUES:"
+  echo "  - SEVERITY=ERROR TYPE=missing_tool MSG=jq is required but not installed"
+  echo "=== END WORKFLOW PREFLIGHT ==="
+  exit 1
+fi
+echo "JQ_AVAILABLE=true"
+
+# Resolve the git working tree from the project dir. Everything downstream runs
+# through `git -C "$project_dir"` so a moved cwd cannot leak operations.
+git_dir="$(git -C "$project_dir" rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$git_dir" ]; then
+  echo "GIT_REPO=false"
+  echo "STATUS=ERROR"
+  echo "ISSUE_COUNT=1"
+  echo "ISSUES:"
+  echo "  - SEVERITY=ERROR TYPE=not_a_repo MSG=${project_dir} is not inside a git repository"
+  echo "=== END WORKFLOW PREFLIGHT ==="
+  exit 1
+fi
+echo "GIT_REPO=true"
+git_cmd() { git -C "$git_dir" "$@"; }
+
+current_branch="$(git_cmd branch --show-current 2>/dev/null || true)"
+echo "CURRENT_BRANCH=${current_branch:-DETACHED}"
+
+# --- Step 1: Fetch latest remote state (injectable seam) ---------------------
+if [ -n "$preflight_no_fetch" ]; then
+  echo "FETCH=SKIPPED"
+else
+  if git_cmd fetch origin --prune >/dev/null 2>&1; then
+    echo "FETCH=OK"
+  else
+    echo "FETCH=FAILED"
+    add_issue WARN fetch_failed "git fetch origin failed; ahead/behind may be stale"
+  fi
+fi
+
+# --- Resolve the upstream base branch (main or master) -----------------------
+base_ref=""
+for candidate in origin/main origin/master; do
+  if git_cmd rev-parse --verify --quiet "$candidate" >/dev/null 2>&1; then
+    base_ref="$candidate"
+    break
+  fi
+done
+echo "BASE_REF=${base_ref:-NONE}"
+
+# --- Step 3: ahead/behind counts vs base ------------------------------------
+ahead=0
+behind=0
+if [ -n "$base_ref" ]; then
+  counts="$(git_cmd rev-list --left-right --count "${base_ref}...HEAD" 2>/dev/null || true)"
+  if [ -n "$counts" ]; then
+    behind="$(printf '%s\n' "$counts" | awk '{print $1}')"
+    ahead="$(printf '%s\n' "$counts" | awk '{print $2}')"
+  fi
+fi
+echo "COMMITS_AHEAD=${ahead:-0}"
+echo "COMMITS_BEHIND=${behind:-0}"
+if [ "${behind:-0}" -gt 0 ] 2>/dev/null; then
+  add_issue WARN behind_remote "HEAD is ${behind} commits behind ${base_ref}; rebase recommended"
+fi
+
+# --- Uncommitted + stash state ----------------------------------------------
+porcelain="$(git_cmd status --porcelain 2>/dev/null || true)"
+if [ -n "$porcelain" ]; then
+  uncommitted_count="$(printf '%s\n' "$porcelain" | grep -c .)"
+  echo "UNCOMMITTED_CHANGES=true"
+  echo "UNCOMMITTED_COUNT=${uncommitted_count}"
+  add_issue WARN dirty_tree "${uncommitted_count} uncommitted changes; commit or stash before branching"
+else
+  echo "UNCOMMITTED_CHANGES=false"
+  echo "UNCOMMITTED_COUNT=0"
+fi
+
+stash_list="$(git_cmd stash list 2>/dev/null || true)"
+if [ -n "$stash_list" ]; then
+  stash_count="$(printf '%s\n' "$stash_list" | grep -c .)"
+else
+  stash_count=0
+fi
+echo "STASH_COUNT=${stash_count}"
+
+# --- Step 4: merge-tree dry-run conflict detection --------------------------
+conflicts_detected=false
+if [ -n "$base_ref" ]; then
+  merge_base="$(git_cmd merge-base HEAD "$base_ref" 2>/dev/null || true)"
+  if [ -n "$merge_base" ]; then
+    merge_out="$(git_cmd merge-tree "$merge_base" HEAD "$base_ref" 2>/dev/null || true)"
+    # merge-tree (the trivial three-arg form) emits "changed in both" + "<<<<<<<"
+    # conflict markers when a path conflicts.
+    if printf '%s\n' "$merge_out" | grep -q '^<<<<<<<\|changed in both'; then
+      conflicts_detected=true
+    fi
+  fi
+fi
+echo "CONFLICTS_DETECTED=${conflicts_detected}"
+if [ "$conflicts_detected" = true ]; then
+  add_issue WARN conflicts "Merge conflicts with ${base_ref} detected; resolve before proceeding"
+fi
+
+# --- Step 2: existing-work lookup (issue + PR + branch) ---------------------
+existing_pr_state="NONE"
+existing_pr_number=""
+existing_pr_branch=""
+issue_state="NONE"
+matching_branches=""
+
+# gh probes go through the fixture seam: when WORKFLOW_PREFLIGHT_FIXTURE is set,
+# read canned JSON from files; otherwise call gh live.
+fixture_or_gh() {
+  # $1 = fixture filename, rest = gh argv
+  local fname="$1"; shift
+  if [ -n "$preflight_fixture" ]; then
+    if [ -f "${preflight_fixture}/${fname}" ]; then
+      cat "${preflight_fixture}/${fname}"
+    else
+      printf ''
+    fi
+    return 0
+  fi
+  command -v gh >/dev/null 2>&1 || { printf ''; return 0; }
+  gh "$@" 2>/dev/null || printf ''
+}
+
+if [ -n "$preflight_issue" ]; then
+  echo "TARGET_ISSUE=${preflight_issue}"
+
+  issue_json="$(fixture_or_gh issue.json issue view "$preflight_issue" --json number,title,state,labels)"
+  if [ -n "$issue_json" ]; then
+    issue_state="$(printf '%s' "$issue_json" | jq -r '.state // "NONE"' 2>/dev/null || echo NONE)"
+  fi
+  echo "ISSUE_STATE=${issue_state}"
+
+  pr_json="$(fixture_or_gh pr-search.json pr list --search "fixes #${preflight_issue} OR closes #${preflight_issue} OR resolves #${preflight_issue}" --json number,title,state,headRefName)"
+  if [ -n "$pr_json" ]; then
+    # First MERGED match wins; otherwise first OPEN match.
+    existing_pr_state="$(printf '%s' "$pr_json" | jq -r '
+      ([.[] | select(.state == "MERGED")] | first) as $m
+      | ([.[] | select(.state == "OPEN")] | first) as $o
+      | if $m then "MERGED" elif $o then "OPEN" else "NONE" end' 2>/dev/null || echo NONE)"
+    existing_pr_number="$(printf '%s' "$pr_json" | jq -r '
+      ([.[] | select(.state == "MERGED")] | first) as $m
+      | ([.[] | select(.state == "OPEN")] | first) as $o
+      | ($m // $o // {}) | .number // ""' 2>/dev/null || echo "")"
+    existing_pr_branch="$(printf '%s' "$pr_json" | jq -r '
+      ([.[] | select(.state == "MERGED")] | first) as $m
+      | ([.[] | select(.state == "OPEN")] | first) as $o
+      | ($m // $o // {}) | .headRefName // ""' 2>/dev/null || echo "")"
+  fi
+
+  matching_branches="$(git_cmd branch -a --list "*issue-${preflight_issue}*" --list "*fix/${preflight_issue}*" --list "*feat/${preflight_issue}*" 2>/dev/null | sed 's/^[* ] *//' | grep -c . || echo 0)"
+else
+  echo "TARGET_ISSUE=NONE"
+  echo "ISSUE_STATE=NONE"
+  matching_branches=0
+fi
+
+echo "EXISTING_PR_STATE=${existing_pr_state}"
+echo "EXISTING_PR_NUMBER=${existing_pr_number}"
+echo "EXISTING_PR_BRANCH=${existing_pr_branch}"
+echo "MATCHING_BRANCHES=${matching_branches}"
+
+if [ "$existing_pr_state" = "MERGED" ]; then
+  add_issue WARN already_addressed "Issue already addressed by merged PR #${existing_pr_number}; stop before duplicating"
+elif [ "$existing_pr_state" = "OPEN" ]; then
+  add_issue WARN existing_pr "Open PR #${existing_pr_number} (${existing_pr_branch}) already addresses this; review before duplicating"
+fi
+
+# --- Fixed recommendation decision tree over the booleans -------------------
+# Precedence: merged PR > conflicts > open PR > behind/dirty > clean.
+recommendation=""
+if [ "$existing_pr_state" = "MERGED" ]; then
+  recommendation="STOP: merged PR #${existing_pr_number} already addresses this issue"
+elif [ "$conflicts_detected" = true ]; then
+  recommendation="Resolve conflicts with ${base_ref} before proceeding"
+elif [ "$existing_pr_state" = "OPEN" ]; then
+  recommendation="Open PR #${existing_pr_number} exists - continue on that branch or start fresh (ask user)"
+elif [ "${behind:-0}" -gt 0 ] 2>/dev/null; then
+  recommendation="Rebase onto ${base_ref} before starting work (${behind} behind)"
+elif [ -n "$porcelain" ]; then
+  recommendation="Commit or stash uncommitted changes before branching"
+else
+  recommendation="Ready to proceed"
+fi
+echo "RECOMMENDATION=${recommendation}"
+
+echo "STATUS=${check_status}"
+echo "ISSUE_COUNT=${issue_count}"
+if [ -n "$issues_list" ]; then
+  echo "ISSUES:"
+  echo -e "$issues_list" | sed '/^$/d'
+fi
+echo "=== END WORKFLOW PREFLIGHT ==="
+
+[ "$check_status" = "ERROR" ] && exit 1
+exit 0


### PR DESCRIPTION
Closes #1558

Extracts the deterministic preflight procedure from `workflow-orchestration-plugin/skills/workflow-preflight` into a structured-output script per ADR-0016, keeping the interactive AskUserQuestion handoff in the skill.

- `scripts/workflow-preflight.sh` — `=== WORKFLOW PREFLIGHT ===` structured output: git fetch, ahead/behind counts, existing-PR/issue/branch lookup, merge-tree dry-run conflict detection, uncommitted+stash state, and the fixed `RECOMMENDATION=` decision tree. Every gh/network probe sits behind an injectable fixture seam (`WORKFLOW_PREFLIGHT_FIXTURE` + `WORKFLOW_PREFLIGHT_NO_FETCH`).
- `scripts/tests/test-workflow-preflight.sh` — offline regression test against a planted git repo + canned gh JSON, asserting the recommendation decision tree for existing-PR+clean, conflicts, uncommitted/stash, and fresh-branch-no-PR.
- `SKILL.md` — inline deterministic bash replaced with one script call; "Continue on existing PR or start fresh?" stays an interactive AskUserQuestion; behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)