### PR TITLE
refactor(configure-plugin): extract security, formatting, ux-testing detection to scripts + regression tests

### DIFF
--- a/configure-plugin/skills/configure-formatting/SKILL.md
+++ b/configure-plugin/skills/configure-formatting/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-16
-modified: 2026-06-03
-reviewed: 2026-06-03
+modified: 2026-06-10
+reviewed: 2026-06-10
 description: "Biome formatter for JS/TS/JSON/CSS — the modern Prettier/ESLint replacement. Also Ruff (Python) and rustfmt. Use when setting up formatting, replacing Prettier, or wiring CI format checks."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--formatter <biome|ruff|rustfmt>]"
@@ -57,33 +57,28 @@ Parse from `$ARGUMENTS`:
 
 Execute this code formatting configuration workflow:
 
-### Step 1: Detect project languages and existing formatters
+### Step 1: Detect formatters and integration state
 
-Check for language indicators and formatter configurations:
+Run the detection script to scan the project for formatter config files,
+script/hook/CI presence, and a recommendation over the detected booleans:
 
-| Indicator | Language | Detected Formatter |
-|-----------|----------|-------------------|
-| `biome.json` with formatter | JavaScript/TypeScript | Biome |
-| `.prettierrc.*` | JavaScript/TypeScript | Prettier (legacy → migrate to Biome) |
-| `pyproject.toml` [tool.ruff.format] | Python | Ruff |
-| `pyproject.toml` [tool.black] | Python | Black (legacy) |
-| `rustfmt.toml` or `.rustfmt.toml` | Rust | rustfmt |
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/configure-formatting.sh" --home-dir "$HOME" --project-dir "$(pwd)"
+```
+
+Parse `STATUS=` and the `ISSUES:` block from the output. The `KEY=VALUE` lines
+report formatter detection (`BIOME`, `PRETTIER`, `RUFF_FORMAT`, `BLACK`,
+`RUSTFMT`, `EDITORCONFIG`), integration signals (`FORMAT_SCRIPT`,
+`PRE_COMMIT_FORMAT`, `CI_FORMAT`), and a `RECOMMENDATION` of `configured`
+(a modern formatter is set up), `migrate` (a legacy formatter wants migration to
+Biome/Ruff), or `setup` (no formatter detected).
 
 **Modern formatting preferences:**
-- **JavaScript/TypeScript**: Biome (replaces Prettier + ESLint). If Prettier is detected, offer migration to Biome — do not configure Prettier as the target formatter.
+- **JavaScript/TypeScript**: Biome (replaces Prettier + ESLint). On `RECOMMENDATION=migrate` with Prettier present, offer migration to Biome — do not configure Prettier as the target formatter.
 - **Python**: Ruff format (replaces Black)
 - **Rust**: rustfmt (standard)
 
-### Step 2: Analyze current formatter configuration
-
-For each detected formatter, check configuration completeness:
-1. Config file exists with required settings (indent, line width, quotes, etc.)
-2. Ignore patterns configured
-3. Format scripts defined in package.json / pyproject.toml
-4. Pre-commit hook configured
-5. CI/CD check configured
-
-### Step 3: Generate compliance report
+### Step 2: Generate compliance report
 
 Print a formatted compliance report:
 
@@ -105,7 +100,7 @@ Recommendations: [list specific fixes]
 
 If `--check-only`, stop here.
 
-### Step 4: Install and configure formatter (if --fix or user confirms)
+### Step 3: Install and configure formatter (if --fix or user confirms)
 
 Based on detected language and formatter preference, install and configure. Use configuration templates from [REFERENCE.md](REFERENCE.md).
 
@@ -114,11 +109,11 @@ Based on detected language and formatter preference, install and configure. Use 
 3. Add format scripts to package.json or Makefile/justfile
 4. Configure ignore patterns in the formatter config (e.g. `files.includes` in biome.json)
 
-### Step 5: Create EditorConfig integration
+### Step 4: Create EditorConfig integration
 
 Create or update `.editorconfig` with settings matching the formatter configuration.
 
-### Step 6: Handle migrations (if applicable)
+### Step 5: Handle migrations (if applicable)
 
 If legacy formatter detected (Prettier -> Biome, Black -> Ruff):
 1. Import existing configuration
@@ -129,19 +124,19 @@ If legacy formatter detected (Prettier -> Biome, Black -> Ruff):
 
 Use migration guides from [REFERENCE.md](REFERENCE.md).
 
-### Step 7: Configure pre-commit hooks
+### Step 6: Configure pre-commit hooks
 
 Add formatter to `.pre-commit-config.yaml` using the appropriate hook repository.
 
-### Step 8: Configure CI/CD integration
+### Step 7: Configure CI/CD integration
 
 Add format check step to GitHub Actions workflow.
 
-### Step 9: Configure editor integration
+### Step 8: Configure editor integration
 
 Create or update `.vscode/settings.json` with format-on-save and `.vscode/extensions.json` with formatter extension.
 
-### Step 10: Update standards tracking
+### Step 9: Update standards tracking
 
 Update `.project-standards.yaml`:
 
@@ -153,7 +148,7 @@ components:
   formatting_ci: true
 ```
 
-### Step 11: Print completion report
+### Step 10: Print completion report
 
 Print a summary of changes made, scripts added, and next steps (run format, verify CI, enable format-on-save).
 

--- a/configure-plugin/skills/configure-formatting/scripts/configure-formatting.sh
+++ b/configure-plugin/skills/configure-formatting/scripts/configure-formatting.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Detect code-formatting posture for a project.
+# Scans --project-dir for formatter config-file signals (biome.json /
+# .prettierrc / pyproject [tool.ruff.format] / [tool.black] / rustfmt.toml),
+# script/hook/CI presence, and emits a recommendation over the detected
+# booleans. Generative steps (writing configs) stay with the model.
+# Usage: bash configure-formatting.sh --home-dir <path> --project-dir <path>
+
+set -uo pipefail
+
+home_dir=""
+project_dir=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --home-dir) home_dir="$2"; shift 2 ;;
+    --project-dir) project_dir="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+: "${home_dir:=$HOME}"
+: "${project_dir:=$(pwd)}"
+
+echo "=== CONFIGURE FORMATTING ==="
+
+fmt_issue_count=0
+fmt_status="OK"
+fmt_issues_list=""
+
+add_issue() {
+  fmt_issues_list="${fmt_issues_list}  - SEVERITY=$1 TYPE=$2 MSG=$3\n"
+  fmt_issue_count=$((fmt_issue_count + 1))
+  if [ "$1" = "ERROR" ]; then
+    fmt_status="ERROR"
+  elif [ "$1" = "WARN" ] && [ "$fmt_status" = "OK" ]; then
+    fmt_status="WARN"
+  fi
+}
+
+exists_file() { [ -f "$1" ] && echo "true" || echo "false"; }
+
+# -----------------------------------------------------------------------------
+# Language indicators
+# -----------------------------------------------------------------------------
+pkg_json=$(exists_file "${project_dir}/package.json")
+pyproject=$(exists_file "${project_dir}/pyproject.toml")
+cargo=$(exists_file "${project_dir}/Cargo.toml")
+echo "PACKAGE_JSON=${pkg_json}"
+echo "PYPROJECT=${pyproject}"
+echo "CARGO=${cargo}"
+
+# -----------------------------------------------------------------------------
+# Formatter config-file detection
+# -----------------------------------------------------------------------------
+biome=$(exists_file "${project_dir}/biome.json")
+if [ "$biome" = "false" ] && [ -f "${project_dir}/biome.jsonc" ]; then
+  biome="true"
+fi
+echo "BIOME=${biome}"
+
+prettier=false
+for f in "${project_dir}"/.prettierrc "${project_dir}"/.prettierrc.* \
+         "${project_dir}"/prettier.config.*; do
+  [ -f "$f" ] && { prettier=true; break; }
+done
+echo "PRETTIER=${prettier}"
+
+ruff_format=false
+if [ "$pyproject" = "true" ] && grep -q "tool.ruff.format" "${project_dir}/pyproject.toml" 2>/dev/null; then
+  ruff_format=true
+fi
+echo "RUFF_FORMAT=${ruff_format}"
+
+black=false
+if [ "$pyproject" = "true" ] && grep -q "tool.black" "${project_dir}/pyproject.toml" 2>/dev/null; then
+  black=true
+fi
+echo "BLACK=${black}"
+
+rustfmt=false
+if [ -f "${project_dir}/rustfmt.toml" ] || [ -f "${project_dir}/.rustfmt.toml" ]; then
+  rustfmt=true
+fi
+echo "RUSTFMT=${rustfmt}"
+
+editorconfig=$(exists_file "${project_dir}/.editorconfig")
+echo "EDITORCONFIG=${editorconfig}"
+
+# -----------------------------------------------------------------------------
+# Script / hook / CI presence scans
+# -----------------------------------------------------------------------------
+format_script=false
+if [ "$pkg_json" = "true" ] && grep -q '"format"' "${project_dir}/package.json" 2>/dev/null; then
+  format_script=true
+fi
+echo "FORMAT_SCRIPT=${format_script}"
+
+precommit_config=$(exists_file "${project_dir}/.pre-commit-config.yaml")
+echo "PRE_COMMIT_CONFIG=${precommit_config}"
+
+precommit_format=false
+if [ "$precommit_config" = "true" ]; then
+  if grep -qE "biome|ruff|rustfmt|prettier|black" "${project_dir}/.pre-commit-config.yaml" 2>/dev/null; then
+    precommit_format=true
+  fi
+fi
+echo "PRE_COMMIT_FORMAT=${precommit_format}"
+
+ci_format=false
+workflows_dir="${project_dir}/.github/workflows"
+if [ -d "$workflows_dir" ]; then
+  for wf in "$workflows_dir"/*.yml "$workflows_dir"/*.yaml; do
+    [ -f "$wf" ] || continue
+    if grep -qE "biome format|ruff format|cargo fmt|prettier" "$wf" 2>/dev/null; then
+      ci_format=true
+      break
+    fi
+  done
+fi
+echo "CI_FORMAT=${ci_format}"
+
+# -----------------------------------------------------------------------------
+# Recommendation over detected booleans
+# -----------------------------------------------------------------------------
+# A modern formatter is one of biome / ruff-format / rustfmt.
+modern_formatter=false
+[ "$biome" = "true" ] && modern_formatter=true
+[ "$ruff_format" = "true" ] && modern_formatter=true
+[ "$rustfmt" = "true" ] && modern_formatter=true
+
+recommendation="setup"
+if [ "$modern_formatter" = "true" ]; then
+  recommendation="configured"
+fi
+# Legacy formatters present without a modern one → migrate.
+if [ "$modern_formatter" = "false" ] && { [ "$prettier" = "true" ] || [ "$black" = "true" ]; }; then
+  recommendation="migrate"
+fi
+echo "RECOMMENDATION=${recommendation}"
+
+case "$recommendation" in
+  setup)
+    add_issue "WARN" "no_formatter" "no formatter config detected — recommend Biome/Ruff/rustfmt setup"
+    ;;
+  migrate)
+    [ "$prettier" = "true" ] && add_issue "WARN" "legacy_prettier" "Prettier detected — recommend migrating to Biome"
+    [ "$black" = "true" ] && add_issue "WARN" "legacy_black" "Black detected — recommend migrating to Ruff format"
+    ;;
+esac
+
+echo "STATUS=${fmt_status}"
+echo "ISSUE_COUNT=${fmt_issue_count}"
+if [ -n "$fmt_issues_list" ]; then
+  echo "ISSUES:"
+  echo -e "$fmt_issues_list" | sed '/^$/d'
+fi
+echo "=== END CONFIGURE FORMATTING ==="
+
+[ "$fmt_status" = "ERROR" ] && exit 1
+exit 0

--- a/configure-plugin/skills/configure-formatting/scripts/tests/test-configure-formatting.sh
+++ b/configure-plugin/skills/configure-formatting/scripts/tests/test-configure-formatting.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Regression test for configure-formatting.sh detection.
+# A planted fixture with biome.json must be detected and recommend "configured";
+# a bare fixture must recommend "setup". A legacy (prettier-only) fixture must
+# recommend "migrate".
+# Exit 0 on success, non-zero on failure.
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+check_script="${script_dir}/../configure-formatting.sh"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+pass() { echo "PASS: $1"; }
+
+[ -f "$check_script" ] || fail "configure-formatting.sh not found at $check_script"
+
+# -----------------------------------------------------------------------------
+# Case 1: biome.json present → detected, RECOMMENDATION=configured, STATUS=OK
+# -----------------------------------------------------------------------------
+biome_proj="$(mktemp -d)"
+trap 'rm -rf "$biome_proj"' EXIT
+printf '{}' > "${biome_proj}/package.json"
+printf '{"formatter":{"enabled":true}}' > "${biome_proj}/biome.json"
+
+out1="$(bash "$check_script" --home-dir "$HOME" --project-dir "$biome_proj")"
+echo "$out1" | grep -q "^BIOME=true$" || fail "expected BIOME=true:\n$out1"
+echo "$out1" | grep -q "^RECOMMENDATION=configured$" || fail "expected RECOMMENDATION=configured:\n$out1"
+echo "$out1" | grep -q "^STATUS=OK$" || fail "expected STATUS=OK with biome configured:\n$out1"
+pass "biome.json detected and recommends configured"
+rm -rf "$biome_proj"
+
+# -----------------------------------------------------------------------------
+# Case 2: bare project → RECOMMENDATION=setup, STATUS=WARN
+# -----------------------------------------------------------------------------
+bare="$(mktemp -d)"
+out2="$(bash "$check_script" --home-dir "$HOME" --project-dir "$bare")"
+echo "$out2" | grep -q "^BIOME=false$" || fail "expected BIOME=false:\n$out2"
+echo "$out2" | grep -q "^RECOMMENDATION=setup$" || fail "expected RECOMMENDATION=setup for bare project:\n$out2"
+echo "$out2" | grep -q "^STATUS=WARN$" || fail "expected STATUS=WARN for bare project:\n$out2"
+pass "bare project recommends setup"
+rm -rf "$bare"
+
+# -----------------------------------------------------------------------------
+# Case 3: legacy prettier only → RECOMMENDATION=migrate
+# -----------------------------------------------------------------------------
+legacy="$(mktemp -d)"
+printf '{}' > "${legacy}/package.json"
+printf '{}' > "${legacy}/.prettierrc"
+out3="$(bash "$check_script" --home-dir "$HOME" --project-dir "$legacy")"
+echo "$out3" | grep -q "^PRETTIER=true$" || fail "expected PRETTIER=true:\n$out3"
+echo "$out3" | grep -q "^RECOMMENDATION=migrate$" || fail "expected RECOMMENDATION=migrate for prettier-only:\n$out3"
+pass "legacy prettier-only project recommends migrate"
+rm -rf "$legacy"
+
+echo "ALL TESTS PASSED"

--- a/configure-plugin/skills/configure-security/SKILL.md
+++ b/configure-plugin/skills/configure-security/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-16
-modified: 2026-05-09
-reviewed: 2025-12-16
+modified: 2026-06-10
+reviewed: 2026-06-10
 description: "Security scanning: dependency audits, SAST, secrets detection. Use when setting up Dependabot, CodeQL, or TruffleHog in CI, or creating a SECURITY.md policy."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--type <dependencies|sast|secrets|all>]"
@@ -62,42 +62,22 @@ Verify latest versions before configuring:
 
 Use WebSearch or WebFetch to verify current versions.
 
-### Step 2: Detect project languages and tools
+### Step 2: Detect project languages and security posture
 
-Identify project languages and existing security tools:
+Run the detection script to scan the project for language signals and the
+three security layers (dependency auditing / SAST / secret detection) plus a
+SECURITY.md policy:
 
-| Indicator | Language/Tool | Security Tools |
-|-----------|---------------|----------------|
-| `package.json` | JavaScript/TypeScript | npm audit, Snyk |
-| `pyproject.toml` | Python | pip-audit, safety, bandit |
-| `Cargo.toml` | Rust | cargo-audit, cargo-deny |
-| `.gitleaks.toml` | gitleaks | Secret scanning |
-| `.github/workflows/` | GitHub Actions | CodeQL, Dependabot |
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/configure-security.sh" --home-dir "$HOME" --project-dir "$(pwd)"
+```
 
-### Step 3: Analyze current security state
+Parse `STATUS=` and the `ISSUES:` block from the output. The `KEY=VALUE` lines
+report language detection (`LANG_JS`, `LANG_PYTHON`, `LANG_RUST`, `LANG_GO`) and
+the presence matrix (`DEPENDABOT`, `CODEQL`, `GITLEAKS_CONFIG`, `SECURITY_POLICY`,
+`TRUFFLEHOG`, `DEPENDENCY_REVIEW`, `SECURITY_LAYERS_PRESENT`).
 
-Check existing security configuration across three areas:
-
-**Dependency Auditing:**
-- Package manager audit configured
-- Audit scripts in package.json/Makefile
-- Dependabot enabled
-- Dependency review action in CI
-- Auto-merge for minor updates configured
-
-**SAST Scanning:**
-- CodeQL workflow exists
-- Semgrep configured
-- Bandit configured (Python)
-- SAST in CI pipeline
-
-**Secret Detection:**
-- Gitleaks configured with `.gitleaks.toml`
-- Pre-commit hook configured
-- Git history scanned
-- TruffleHog configured (optional complement)
-
-### Step 4: Generate compliance report
+### Step 3: Generate compliance report
 
 Print a formatted compliance report showing status for each security component across dependency auditing, SAST scanning, secret detection, and security policies.
 
@@ -105,7 +85,7 @@ If `--check-only` is set, stop here.
 
 For the compliance report format, see [REFERENCE.md](REFERENCE.md).
 
-### Step 5: Configure dependency auditing (if --fix or user confirms)
+### Step 4: Configure dependency auditing (if --fix or user confirms)
 
 Based on detected language:
 
@@ -124,7 +104,7 @@ Based on detected language:
 
 For complete configuration templates, see [REFERENCE.md](REFERENCE.md).
 
-### Step 6: Configure SAST scanning (if --fix or user confirms)
+### Step 5: Configure SAST scanning (if --fix or user confirms)
 
 1. Create CodeQL workflow `.github/workflows/codeql.yml` with detected languages
 2. For Python projects, install and configure Bandit
@@ -132,7 +112,7 @@ For complete configuration templates, see [REFERENCE.md](REFERENCE.md).
 
 For CodeQL workflow and Bandit configuration templates, see [REFERENCE.md](REFERENCE.md).
 
-### Step 7: Configure secret detection (if --fix or user confirms)
+### Step 6: Configure secret detection (if --fix or user confirms)
 
 1. Install gitleaks: `brew install gitleaks` (or `go install github.com/gitleaks/gitleaks/v8@latest`)
 2. Create `.gitleaks.toml` with project-specific allowlists
@@ -142,7 +122,7 @@ For CodeQL workflow and Bandit configuration templates, see [REFERENCE.md](REFER
 
 For gitleaks, TruffleHog, and CI workflow configuration templates, see [REFERENCE.md](REFERENCE.md).
 
-### Step 8: Create security policy
+### Step 7: Create security policy
 
 Create `SECURITY.md` with:
 - Supported versions table
@@ -153,7 +133,7 @@ Create `SECURITY.md` with:
 
 For the SECURITY.md template, see [REFERENCE.md](REFERENCE.md).
 
-### Step 9: Configure CI/CD integration
+### Step 8: Configure CI/CD integration
 
 Create comprehensive security workflow `.github/workflows/security.yml` with jobs for:
 - Dependency audit
@@ -164,7 +144,7 @@ Schedule weekly scans in addition to push/PR triggers.
 
 For the CI security workflow template, see [REFERENCE.md](REFERENCE.md).
 
-### Step 10: Update standards tracking
+### Step 9: Update standards tracking
 
 Update `.project-standards.yaml`:
 
@@ -178,7 +158,7 @@ components:
   security_dependabot: true
 ```
 
-### Step 11: Report configuration results
+### Step 10: Report configuration results
 
 Print a summary of all changes made across dependency auditing, SAST scanning, secret detection, security policy, and CI/CD integration. Include next steps for reviewing Dependabot PRs, CodeQL findings, and enabling private vulnerability reporting.
 

--- a/configure-plugin/skills/configure-security/scripts/configure-security.sh
+++ b/configure-plugin/skills/configure-security/scripts/configure-security.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Detect security-scanning posture for a project.
+# Scans --project-dir for language/tool signals and the three security layers
+# (dependency auditing / SAST / secret detection) plus a SECURITY.md policy,
+# emitting a structured presence matrix. Generative steps (writing workflows /
+# SECURITY.md) stay with the model.
+# Usage: bash configure-security.sh --home-dir <path> --project-dir <path>
+
+set -uo pipefail
+
+home_dir=""
+project_dir=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --home-dir) home_dir="$2"; shift 2 ;;
+    --project-dir) project_dir="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+: "${home_dir:=$HOME}"
+: "${project_dir:=$(pwd)}"
+
+echo "=== CONFIGURE SECURITY ==="
+
+sec_issue_count=0
+sec_status="OK"
+sec_issues_list=""
+
+add_issue() {
+  # severity type message
+  sec_issues_list="${sec_issues_list}  - SEVERITY=$1 TYPE=$2 MSG=$3\n"
+  sec_issue_count=$((sec_issue_count + 1))
+  if [ "$1" = "ERROR" ]; then
+    sec_status="ERROR"
+  elif [ "$1" = "WARN" ] && [ "$sec_status" = "OK" ]; then
+    sec_status="WARN"
+  fi
+}
+
+exists_file() { [ -f "$1" ] && echo "true" || echo "false"; }
+
+# -----------------------------------------------------------------------------
+# Language / package-manager detection (package-file globs)
+# -----------------------------------------------------------------------------
+lang_js=$(exists_file "${project_dir}/package.json")
+lang_python=$(exists_file "${project_dir}/pyproject.toml")
+lang_rust=$(exists_file "${project_dir}/Cargo.toml")
+lang_go=$(exists_file "${project_dir}/go.mod")
+
+echo "LANG_JS=${lang_js}"
+echo "LANG_PYTHON=${lang_python}"
+echo "LANG_RUST=${lang_rust}"
+echo "LANG_GO=${lang_go}"
+
+detected_langs=0
+for v in "$lang_js" "$lang_python" "$lang_rust" "$lang_go"; do
+  [ "$v" = "true" ] && detected_langs=$((detected_langs + 1))
+done
+echo "DETECTED_LANGUAGES=${detected_langs}"
+
+# -----------------------------------------------------------------------------
+# Layer 1: dependency auditing — Dependabot
+# -----------------------------------------------------------------------------
+dependabot=false
+if [ -f "${project_dir}/.github/dependabot.yml" ] || [ -f "${project_dir}/.github/dependabot.yaml" ]; then
+  dependabot=true
+fi
+echo "DEPENDABOT=${dependabot}"
+
+# -----------------------------------------------------------------------------
+# Layer 2: SAST — CodeQL (workflow file under .github/workflows)
+# -----------------------------------------------------------------------------
+codeql=false
+workflows_dir="${project_dir}/.github/workflows"
+if [ -d "$workflows_dir" ]; then
+  for wf in "$workflows_dir"/codeql*.yml "$workflows_dir"/codeql*.yaml; do
+    [ -f "$wf" ] && { codeql=true; break; }
+  done
+  # Also catch a CodeQL action referenced inside any workflow file.
+  if [ "$codeql" = false ]; then
+    for wf in "$workflows_dir"/*.yml "$workflows_dir"/*.yaml; do
+      [ -f "$wf" ] || continue
+      if grep -q "github/codeql-action" "$wf" 2>/dev/null; then
+        codeql=true
+        break
+      fi
+    done
+  fi
+fi
+echo "CODEQL=${codeql}"
+
+# -----------------------------------------------------------------------------
+# Layer 3: secret detection — gitleaks config + pre-commit hook reference
+# -----------------------------------------------------------------------------
+gitleaks_config=$(exists_file "${project_dir}/.gitleaks.toml")
+echo "GITLEAKS_CONFIG=${gitleaks_config}"
+
+precommit_config=$(exists_file "${project_dir}/.pre-commit-config.yaml")
+echo "PRE_COMMIT_CONFIG=${precommit_config}"
+
+precommit_gitleaks=false
+if [ "$precommit_config" = "true" ]; then
+  if grep -q "gitleaks" "${project_dir}/.pre-commit-config.yaml" 2>/dev/null; then
+    precommit_gitleaks=true
+  fi
+fi
+echo "PRE_COMMIT_GITLEAKS=${precommit_gitleaks}"
+
+# -----------------------------------------------------------------------------
+# Security policy
+# -----------------------------------------------------------------------------
+security_policy=$(exists_file "${project_dir}/SECURITY.md")
+if [ "$security_policy" = "false" ] && [ -f "${project_dir}/.github/SECURITY.md" ]; then
+  security_policy="true"
+fi
+echo "SECURITY_POLICY=${security_policy}"
+
+# -----------------------------------------------------------------------------
+# Workflow action-name grep: which security workflow actions are referenced
+# -----------------------------------------------------------------------------
+trufflehog=false
+dep_review=false
+if [ -d "$workflows_dir" ]; then
+  for wf in "$workflows_dir"/*.yml "$workflows_dir"/*.yaml; do
+    [ -f "$wf" ] || continue
+    grep -q "trufflehog" "$wf" 2>/dev/null && trufflehog=true
+    grep -q "dependency-review-action" "$wf" 2>/dev/null && dep_review=true
+  done
+fi
+echo "TRUFFLEHOG=${trufflehog}"
+echo "DEPENDENCY_REVIEW=${dep_review}"
+
+# -----------------------------------------------------------------------------
+# Presence-matrix rollup
+# -----------------------------------------------------------------------------
+present_layers=0
+[ "$dependabot" = "true" ] && present_layers=$((present_layers + 1))
+[ "$codeql" = "true" ] && present_layers=$((present_layers + 1))
+[ "$gitleaks_config" = "true" ] && present_layers=$((present_layers + 1))
+echo "SECURITY_LAYERS_PRESENT=${present_layers}"
+
+# Advisory issues — informational, drive STATUS to WARN.
+[ "$dependabot" = "false" ] && add_issue "WARN" "missing_dependabot" "no Dependabot config (.github/dependabot.yml)"
+[ "$codeql" = "false" ] && add_issue "WARN" "missing_sast" "no CodeQL workflow or codeql-action reference"
+[ "$gitleaks_config" = "false" ] && add_issue "WARN" "missing_secret_detection" "no .gitleaks.toml secret-scanning config"
+[ "$security_policy" = "false" ] && add_issue "WARN" "missing_security_policy" "no SECURITY.md policy"
+
+echo "STATUS=${sec_status}"
+echo "ISSUE_COUNT=${sec_issue_count}"
+if [ -n "$sec_issues_list" ]; then
+  echo "ISSUES:"
+  echo -e "$sec_issues_list" | sed '/^$/d'
+fi
+echo "=== END CONFIGURE SECURITY ==="
+
+[ "$sec_status" = "ERROR" ] && exit 1
+exit 0

--- a/configure-plugin/skills/configure-security/scripts/tests/test-configure-security.sh
+++ b/configure-plugin/skills/configure-security/scripts/tests/test-configure-security.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Regression test for configure-security.sh detection.
+# A planted fixture WITH Dependabot + CodeQL + gitleaks + SECURITY.md must report
+# all four present; a bare fixture must report them missing with STATUS=WARN.
+# Exit 0 on success, non-zero on failure.
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+check_script="${script_dir}/../configure-security.sh"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+pass() { echo "PASS: $1"; }
+
+[ -f "$check_script" ] || fail "configure-security.sh not found at $check_script"
+
+# -----------------------------------------------------------------------------
+# Case 1: fully-configured project → all layers present, STATUS=OK
+# -----------------------------------------------------------------------------
+full="$(mktemp -d)"
+trap 'rm -rf "$full"' EXIT
+mkdir -p "${full}/.github/workflows"
+printf '{}' > "${full}/package.json"
+printf 'version: 2\nupdates: []\n' > "${full}/.github/dependabot.yml"
+printf 'name: CodeQL\njobs:\n  analyze:\n    steps:\n      - uses: github/codeql-action/analyze@v3\n' \
+  > "${full}/.github/workflows/codeql.yml"
+printf '[allowlist]\n' > "${full}/.gitleaks.toml"
+printf 'repos:\n  - repo: https://github.com/gitleaks/gitleaks\n' > "${full}/.pre-commit-config.yaml"
+printf '# Security Policy\n' > "${full}/SECURITY.md"
+
+out1="$(bash "$check_script" --home-dir "$HOME" --project-dir "$full")"
+echo "$out1" | grep -q "^DEPENDABOT=true$" || fail "expected DEPENDABOT=true:\n$out1"
+echo "$out1" | grep -q "^CODEQL=true$" || fail "expected CODEQL=true:\n$out1"
+echo "$out1" | grep -q "^GITLEAKS_CONFIG=true$" || fail "expected GITLEAKS_CONFIG=true:\n$out1"
+echo "$out1" | grep -q "^SECURITY_POLICY=true$" || fail "expected SECURITY_POLICY=true:\n$out1"
+echo "$out1" | grep -q "^PRE_COMMIT_GITLEAKS=true$" || fail "expected PRE_COMMIT_GITLEAKS=true:\n$out1"
+echo "$out1" | grep -q "^SECURITY_LAYERS_PRESENT=3$" || fail "expected SECURITY_LAYERS_PRESENT=3:\n$out1"
+echo "$out1" | grep -q "^STATUS=OK$" || fail "expected STATUS=OK for fully-configured project:\n$out1"
+echo "$out1" | grep -q "^LANG_JS=true$" || fail "expected LANG_JS=true:\n$out1"
+pass "fully-configured project reports all security layers present and STATUS=OK"
+rm -rf "$full"
+
+# -----------------------------------------------------------------------------
+# Case 2: bare project → all missing, STATUS=WARN
+# -----------------------------------------------------------------------------
+bare="$(mktemp -d)"
+out2="$(bash "$check_script" --home-dir "$HOME" --project-dir "$bare")"
+echo "$out2" | grep -q "^DEPENDABOT=false$" || fail "expected DEPENDABOT=false:\n$out2"
+echo "$out2" | grep -q "^CODEQL=false$" || fail "expected CODEQL=false:\n$out2"
+echo "$out2" | grep -q "^GITLEAKS_CONFIG=false$" || fail "expected GITLEAKS_CONFIG=false:\n$out2"
+echo "$out2" | grep -q "^SECURITY_POLICY=false$" || fail "expected SECURITY_POLICY=false:\n$out2"
+echo "$out2" | grep -q "^SECURITY_LAYERS_PRESENT=0$" || fail "expected SECURITY_LAYERS_PRESENT=0:\n$out2"
+echo "$out2" | grep -q "^STATUS=WARN$" || fail "expected STATUS=WARN for bare project:\n$out2"
+echo "$out2" | grep -q "^ISSUE_COUNT=4$" || fail "expected ISSUE_COUNT=4 for bare project:\n$out2"
+pass "bare project reports all security layers missing and STATUS=WARN"
+rm -rf "$bare"
+
+echo "ALL TESTS PASSED"

--- a/configure-plugin/skills/configure-ux-testing/SKILL.md
+++ b/configure-plugin/skills/configure-ux-testing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-16
-modified: 2026-05-09
-reviewed: 2025-12-16
+modified: 2026-06-10
+reviewed: 2026-06-10
 description: "UX testing: Playwright E2E, axe-core a11y, visual regression. Use when setting up E2E testing, screenshot assertions, browser automation, or a11y CI workflows."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--a11y] [--visual]"
@@ -67,48 +67,20 @@ Use WebSearch or WebFetch to verify current versions.
 
 ### Step 2: Detect existing UX testing infrastructure
 
-Check for each component:
+Run the detection script to scan the project for Playwright / axe-core signals
+(package.json deps + config globs), the e2e dir / `__snapshots__` / e2e workflow,
+and the playwright MCP-server entry:
 
-| Indicator | Component | Status |
-|-----------|-----------|--------|
-| `playwright.config.*` | Playwright | Installed |
-| `@axe-core/playwright` in package.json | Accessibility testing | Configured |
-| `@playwright/test` in package.json | Playwright Test | Installed |
-| `tests/e2e/` or `e2e/` directory | E2E tests | Present |
-| `*.spec.ts` files with toHaveScreenshot | Visual regression | Configured |
-| `@playwright/cli` globally or in package.json | Playwright CLI | Installed |
-| `.mcp.json` with playwright server | Playwright MCP | Configured |
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/configure-ux-testing.sh" --home-dir "$HOME" --project-dir "$(pwd)"
+```
 
-### Step 3: Analyze current testing state
+Parse `STATUS=` and the `ISSUES:` block from the output. The `KEY=VALUE` lines
+report `PLAYWRIGHT_CONFIG`, `PLAYWRIGHT_DEP`, `AXE_CORE_DEP`, `E2E_DIR`,
+`VISUAL_SNAPSHOTS`, `E2E_WORKFLOW`, `PLAYWRIGHT_MCP`, and the rollup
+`PLAYWRIGHT_DETECTED` / `UX_SIGNALS_PRESENT`.
 
-Check for complete UX testing setup across four areas:
-
-**Playwright Core:**
-- `@playwright/test` installed
-- `playwright.config.ts` exists
-- Browser projects configured (Chromium, Firefox, WebKit)
-- Mobile viewports configured (optional)
-- WebServer configuration for local dev
-- Trace/screenshot/video on failure
-
-**Accessibility Testing:**
-- `@axe-core/playwright` installed
-- Accessibility tests created
-- WCAG level configured (A, AA, AAA)
-- Custom rules/exceptions documented
-
-**Visual Regression:**
-- Screenshot assertions configured
-- Snapshot directory configured
-- Update workflow documented
-- CI snapshot handling configured
-
-**Browser Automation:**
-- Playwright CLI installed (preferred for agents with shell access)
-- Playwright MCP server in `.mcp.json` (fallback for sandboxed environments)
-- Browser automation available to Claude
-
-### Step 4: Generate compliance report
+### Step 3: Generate compliance report
 
 Print a formatted compliance report showing status for Playwright core, accessibility testing, visual regression, and MCP integration.
 
@@ -116,7 +88,7 @@ If `--check-only` is set, stop here.
 
 For the compliance report format, see [REFERENCE.md](REFERENCE.md).
 
-### Step 5: Install dependencies (if --fix or user confirms)
+### Step 4: Install dependencies (if --fix or user confirms)
 
 ```bash
 # Core Playwright
@@ -129,7 +101,7 @@ bun add --dev @axe-core/playwright
 bunx playwright install
 ```
 
-### Step 6: Create Playwright configuration
+### Step 5: Create Playwright configuration
 
 Create `playwright.config.ts` with:
 - Desktop browser projects (Chromium, Firefox, WebKit)
@@ -141,7 +113,7 @@ Create `playwright.config.ts` with:
 
 For the complete `playwright.config.ts` template, see [REFERENCE.md](REFERENCE.md).
 
-### Step 7: Create accessibility test helper
+### Step 6: Create accessibility test helper
 
 Create `tests/e2e/helpers/a11y.ts` with:
 - `expectNoA11yViolations(page, options)` - Assert no WCAG violations
@@ -152,7 +124,7 @@ Create `tests/e2e/helpers/a11y.ts` with:
 
 For the complete a11y helper code, see [REFERENCE.md](REFERENCE.md).
 
-### Step 8: Create example test files
+### Step 7: Create example test files
 
 Create example tests:
 
@@ -161,7 +133,7 @@ Create example tests:
 
 For complete example test files, see [REFERENCE.md](REFERENCE.md).
 
-### Step 9: Add npm scripts
+### Step 8: Add npm scripts
 
 Update `package.json` with test scripts:
 
@@ -181,7 +153,7 @@ Update `package.json` with test scripts:
 }
 ```
 
-### Step 10: Configure browser automation (optional)
+### Step 9: Configure browser automation (optional)
 
 Choose the appropriate browser automation approach based on the agent's environment:
 
@@ -214,7 +186,7 @@ Use MCP when running in environments without shell access (Claude Desktop, brows
 }
 ```
 
-### Step 11: Create CI/CD workflow
+### Step 10: Create CI/CD workflow
 
 Create `.github/workflows/e2e.yml` with parallel jobs for:
 - E2E tests (all browsers)
@@ -223,7 +195,7 @@ Create `.github/workflows/e2e.yml` with parallel jobs for:
 
 For the complete CI workflow template, see [REFERENCE.md](REFERENCE.md).
 
-### Step 12: Update standards tracking
+### Step 11: Update standards tracking
 
 Update `.project-standards.yaml`:
 
@@ -238,7 +210,7 @@ components:
   ux_testing_mcp: false
 ```
 
-### Step 13: Report configuration results
+### Step 12: Report configuration results
 
 Print a summary of configuration applied, scripts added, and CI/CD setup. Include next steps for starting the dev server, running tests, updating snapshots, and opening the interactive UI.
 

--- a/configure-plugin/skills/configure-ux-testing/scripts/configure-ux-testing.sh
+++ b/configure-plugin/skills/configure-ux-testing/scripts/configure-ux-testing.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Detect UX-testing posture for a project.
+# Scans --project-dir for Playwright / axe-core signals (package.json deps +
+# config globs), e2e/__snapshots__/e2e-workflow presence, and the playwright
+# MCP-server entry in .mcp.json. Generative config-writing stays with the model.
+# Usage: bash configure-ux-testing.sh --home-dir <path> --project-dir <path>
+#
+# Offline seam: the MCP lookup reads ${MCP_CONFIG_PATH:-<project>/.mcp.json}.
+# Tests point MCP_CONFIG_PATH at a planted fixture so the check stays offline.
+
+set -uo pipefail
+
+home_dir=""
+project_dir=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --home-dir) home_dir="$2"; shift 2 ;;
+    --project-dir) project_dir="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+: "${home_dir:=$HOME}"
+: "${project_dir:=$(pwd)}"
+
+echo "=== CONFIGURE UX TESTING ==="
+
+ux_issue_count=0
+ux_status="OK"
+ux_issues_list=""
+
+add_issue() {
+  ux_issues_list="${ux_issues_list}  - SEVERITY=$1 TYPE=$2 MSG=$3\n"
+  ux_issue_count=$((ux_issue_count + 1))
+  if [ "$1" = "ERROR" ]; then
+    ux_status="ERROR"
+  elif [ "$1" = "WARN" ] && [ "$ux_status" = "OK" ]; then
+    ux_status="WARN"
+  fi
+}
+
+exists_file() { [ -f "$1" ] && echo "true" || echo "false"; }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "JQ_AVAILABLE=false"
+  echo "STATUS=ERROR"
+  echo "ISSUE_COUNT=1"
+  echo "ISSUES:"
+  echo "  - SEVERITY=ERROR TYPE=missing_tool MSG=jq is required but not installed"
+  echo "=== END CONFIGURE UX TESTING ==="
+  exit 1
+fi
+echo "JQ_AVAILABLE=true"
+
+# -----------------------------------------------------------------------------
+# Package manager
+# -----------------------------------------------------------------------------
+pkg_json=$(exists_file "${project_dir}/package.json")
+echo "PACKAGE_JSON=${pkg_json}"
+[ -f "${project_dir}/bun.lockb" ] && echo "BUN_LOCKFILE=true" || echo "BUN_LOCKFILE=false"
+
+# -----------------------------------------------------------------------------
+# Playwright config glob
+# -----------------------------------------------------------------------------
+playwright_config=false
+for f in "${project_dir}"/playwright.config.*; do
+  [ -f "$f" ] && { playwright_config=true; break; }
+done
+echo "PLAYWRIGHT_CONFIG=${playwright_config}"
+
+# -----------------------------------------------------------------------------
+# Playwright / axe-core deps in package.json (jq lookup, tolerant of missing)
+# -----------------------------------------------------------------------------
+dep_present() {
+  # $1 = dependency name; checks dependencies + devDependencies
+  local dep="$1"
+  if [ "$pkg_json" != "true" ]; then
+    echo "false"
+    return
+  fi
+  if jq -e --arg d "$dep" \
+      '((.dependencies // {}) + (.devDependencies // {})) | has($d)' \
+      "${project_dir}/package.json" >/dev/null 2>&1; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
+playwright_dep=$(dep_present "@playwright/test")
+axe_dep=$(dep_present "@axe-core/playwright")
+echo "PLAYWRIGHT_DEP=${playwright_dep}"
+echo "AXE_CORE_DEP=${axe_dep}"
+
+# -----------------------------------------------------------------------------
+# e2e directory + __snapshots__ + e2e workflow detection
+# -----------------------------------------------------------------------------
+e2e_dir=false
+for d in "${project_dir}/e2e" "${project_dir}/tests/e2e"; do
+  [ -d "$d" ] && { e2e_dir=true; break; }
+done
+echo "E2E_DIR=${e2e_dir}"
+
+snapshots=false
+# __snapshots__ can live a few levels deep under tests/
+while IFS= read -r snap; do
+  [ -n "$snap" ] && { snapshots=true; break; }
+done < <(find "$project_dir" -maxdepth 5 -type d -name '__snapshots__' 2>/dev/null)
+echo "VISUAL_SNAPSHOTS=${snapshots}"
+
+e2e_workflow=false
+workflows_dir="${project_dir}/.github/workflows"
+if [ -d "$workflows_dir" ]; then
+  for wf in "$workflows_dir"/e2e*.yml "$workflows_dir"/e2e*.yaml; do
+    [ -f "$wf" ] && { e2e_workflow=true; break; }
+  done
+fi
+echo "E2E_WORKFLOW=${e2e_workflow}"
+
+# -----------------------------------------------------------------------------
+# Playwright MCP-server lookup (offline seam via MCP_CONFIG_PATH)
+# -----------------------------------------------------------------------------
+mcp_config_path="${MCP_CONFIG_PATH:-${project_dir}/.mcp.json}"
+playwright_mcp=false
+if [ -f "$mcp_config_path" ]; then
+  if jq -e '.mcpServers.playwright // empty' "$mcp_config_path" >/dev/null 2>&1; then
+    playwright_mcp=true
+  fi
+fi
+echo "PLAYWRIGHT_MCP=${playwright_mcp}"
+
+# -----------------------------------------------------------------------------
+# Presence-matrix rollup
+# -----------------------------------------------------------------------------
+ux_present=0
+[ "$playwright_config" = "true" ] && ux_present=$((ux_present + 1))
+[ "$playwright_dep" = "true" ] && ux_present=$((ux_present + 1))
+[ "$axe_dep" = "true" ] && ux_present=$((ux_present + 1))
+[ "$e2e_dir" = "true" ] && ux_present=$((ux_present + 1))
+echo "UX_SIGNALS_PRESENT=${ux_present}"
+
+playwright_detected=false
+if [ "$playwright_config" = "true" ] || [ "$playwright_dep" = "true" ]; then
+  playwright_detected=true
+fi
+echo "PLAYWRIGHT_DETECTED=${playwright_detected}"
+
+[ "$playwright_detected" = "false" ] && add_issue "WARN" "no_playwright" "no Playwright config or @playwright/test dependency detected"
+[ "$axe_dep" = "false" ] && add_issue "WARN" "no_a11y" "no @axe-core/playwright dependency — accessibility testing not configured"
+
+echo "STATUS=${ux_status}"
+echo "ISSUE_COUNT=${ux_issue_count}"
+if [ -n "$ux_issues_list" ]; then
+  echo "ISSUES:"
+  echo -e "$ux_issues_list" | sed '/^$/d'
+fi
+echo "=== END CONFIGURE UX TESTING ==="
+
+[ "$ux_status" = "ERROR" ] && exit 1
+exit 0

--- a/configure-plugin/skills/configure-ux-testing/scripts/tests/test-configure-ux-testing.sh
+++ b/configure-plugin/skills/configure-ux-testing/scripts/tests/test-configure-ux-testing.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Regression test for configure-ux-testing.sh detection.
+# A planted fixture with a playwright config + e2e dir (+ axe dep + playwright
+# MCP via the offline seam) must be detected; a bare fixture must not.
+# SKIP (exit 0) if jq is absent.
+# Exit 0 on success, non-zero on failure.
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+check_script="${script_dir}/../configure-ux-testing.sh"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+pass() { echo "PASS: $1"; }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq not installed; cannot run configure-ux-testing tests"
+  exit 0
+fi
+
+[ -f "$check_script" ] || fail "configure-ux-testing.sh not found at $check_script"
+
+# -----------------------------------------------------------------------------
+# Case 1: configured project → playwright detected, e2e dir present, MCP present
+# -----------------------------------------------------------------------------
+full="$(mktemp -d)"
+trap 'rm -rf "$full"' EXIT
+mkdir -p "${full}/tests/e2e/__snapshots__" "${full}/.github/workflows"
+cat > "${full}/package.json" <<'JSON'
+{
+  "devDependencies": {
+    "@playwright/test": "^1.40.0",
+    "@axe-core/playwright": "^4.8.0"
+  }
+}
+JSON
+printf 'export default {};\n' > "${full}/playwright.config.ts"
+printf 'name: e2e\n' > "${full}/.github/workflows/e2e.yml"
+cat > "${full}/.mcp.json" <<'JSON'
+{ "mcpServers": { "playwright": { "command": "bunx", "args": ["-y", "@playwright/mcp@latest"] } } }
+JSON
+
+out1="$(MCP_CONFIG_PATH="${full}/.mcp.json" bash "$check_script" --home-dir "$HOME" --project-dir "$full")"
+echo "$out1" | grep -q "^PLAYWRIGHT_CONFIG=true$" || fail "expected PLAYWRIGHT_CONFIG=true:\n$out1"
+echo "$out1" | grep -q "^PLAYWRIGHT_DEP=true$" || fail "expected PLAYWRIGHT_DEP=true:\n$out1"
+echo "$out1" | grep -q "^AXE_CORE_DEP=true$" || fail "expected AXE_CORE_DEP=true:\n$out1"
+echo "$out1" | grep -q "^E2E_DIR=true$" || fail "expected E2E_DIR=true:\n$out1"
+echo "$out1" | grep -q "^VISUAL_SNAPSHOTS=true$" || fail "expected VISUAL_SNAPSHOTS=true:\n$out1"
+echo "$out1" | grep -q "^E2E_WORKFLOW=true$" || fail "expected E2E_WORKFLOW=true:\n$out1"
+echo "$out1" | grep -q "^PLAYWRIGHT_MCP=true$" || fail "expected PLAYWRIGHT_MCP=true:\n$out1"
+echo "$out1" | grep -q "^PLAYWRIGHT_DETECTED=true$" || fail "expected PLAYWRIGHT_DETECTED=true:\n$out1"
+echo "$out1" | grep -q "^STATUS=OK$" || fail "expected STATUS=OK for configured project:\n$out1"
+pass "configured project detects playwright config, deps, e2e dir, snapshots, workflow, and MCP"
+rm -rf "$full"
+
+# -----------------------------------------------------------------------------
+# Case 2: bare project → nothing detected, STATUS=WARN
+# -----------------------------------------------------------------------------
+bare="$(mktemp -d)"
+out2="$(MCP_CONFIG_PATH="${bare}/.mcp.json" bash "$check_script" --home-dir "$HOME" --project-dir "$bare")"
+echo "$out2" | grep -q "^PLAYWRIGHT_CONFIG=false$" || fail "expected PLAYWRIGHT_CONFIG=false:\n$out2"
+echo "$out2" | grep -q "^PLAYWRIGHT_DEP=false$" || fail "expected PLAYWRIGHT_DEP=false:\n$out2"
+echo "$out2" | grep -q "^E2E_DIR=false$" || fail "expected E2E_DIR=false:\n$out2"
+echo "$out2" | grep -q "^PLAYWRIGHT_MCP=false$" || fail "expected PLAYWRIGHT_MCP=false:\n$out2"
+echo "$out2" | grep -q "^PLAYWRIGHT_DETECTED=false$" || fail "expected PLAYWRIGHT_DETECTED=false:\n$out2"
+echo "$out2" | grep -q "^STATUS=WARN$" || fail "expected STATUS=WARN for bare project:\n$out2"
+pass "bare project detects no UX testing infrastructure and reports STATUS=WARN"
+rm -rf "$bare"
+
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
Extracts the deterministic detection procedure from three `configure-plugin` skills into structured-output helper scripts (ADR-0016), each with a colocated regression test and a thinned SKILL.md detection step. Generative steps (writing workflows / configs / SECURITY.md) stay with the model.

Closes #1554

Scripts added:
- `configure-plugin/skills/configure-security/scripts/configure-security.sh` — language/tool detection + 3-layer presence scan (Dependabot / CodeQL / gitleaks / pre-commit / SECURITY.md) + workflow action-name grep + presence-matrix rollup.
- `configure-plugin/skills/configure-formatting/scripts/configure-formatting.sh` — formatter config-file detection (biome/.prettierrc/pyproject/rustfmt) + script/hook/CI presence scans + recommendation over detected booleans.
- `configure-plugin/skills/configure-ux-testing/scripts/configure-ux-testing.sh` — Playwright/axe-core detection (package.json + config globs) + e2e dir / __snapshots__ / e2e workflow detection + playwright MCP lookup (jq, behind an offline `MCP_CONFIG_PATH` seam).

Each script follows the `health-plugin` `check-*.sh` shape (`set -uo pipefail`, `--home-dir`/`--project-dir`, `=== SECTION ===` wrap, `STATUS=`/`ISSUE_COUNT=`/`ISSUES:` trailer). Each has a colocated `scripts/tests/test-*.sh` asserting the semantic invariant against planted `mktemp -d` fixtures (offline). All three tests pass; `lint-shell-scripts.sh`, `plugin-compliance-check.sh configure-plugin`, and `check-version-pin-coverage.sh --strict` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)