### PR TITLE
chore: remove MCP setup recipes duplicated from portfolio justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -11,45 +11,6 @@ default:
     @just --list
 
 ####################
-# Claude Code Setup
-####################
-
-# Add Sentry MCP server to project
-[group: "claude"]
-mcp-sentry:
-    claude mcp add-json -s project sentry '{"type": "http", "url": "https://mcp.sentry.dev/mcp"}'
-
-# Add GitHub MCP server to project
-[group: "claude"]
-mcp-github:
-    claude mcp add-json -s project github '{"command": "github-mcp-server", "args": ["stdio"], "env": {"GITHUB_TOKEN": "$GITHUB_TOKEN"}}'
-
-# Add Context7 MCP server (documentation lookup)
-[group: "claude"]
-mcp-context7:
-    claude mcp add-json -s project context7 '{"command": "bunx", "args": ["-y", "@upstash/context7-mcp"]}'
-
-# Add Playwright MCP server (browser automation)
-[group: "claude"]
-mcp-playwright:
-    claude mcp add-json -s project playwright '{"command": "bunx", "args": ["-y", "@playwright/mcp@latest"]}'
-
-# Add Sequential Thinking MCP server (multi-step reasoning)
-[group: "claude"]
-mcp-sequential-thinking:
-    claude mcp add-json -s project sequential-thinking '{"command": "bunx", "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]}'
-
-# Add Chrome DevTools MCP server
-[group: "claude"]
-mcp-chrome-devtools:
-    claude mcp add-json -s project chrome-devtools '{"command": "bunx", "args": ["chrome-devtools-mcp@latest"]}'
-
-# Set up Claude Code Language Server Protocol
-[group: "claude"]
-cclsp:
-    bunx cclsp@latest setup
-
-####################
 # Linting
 ####################
 
@@ -90,10 +51,6 @@ lint-all: lint-context-commands lint-compliance lint-health lint-infra lint-task
 [group: "test"]
 test-skill-scripts:
     ./scripts/run-skill-script-tests.sh
-
-# Add all MCP servers and set up cclsp
-[group: "claude"]
-claude-setup: mcp-sentry mcp-github mcp-context7 mcp-playwright mcp-sequential-thinking mcp-chrome-devtools cclsp
 
 ####################
 # Git Repo Agent


### PR DESCRIPTION
## What

Removes the eight MCP/Claude setup recipes (`mcp-sentry`, `mcp-github`, `mcp-context7`, `mcp-playwright`, `mcp-sequential-thinking`, `mcp-chrome-devtools`, `cclsp`, `claude-setup`) and the now-empty "Claude Code Setup" group from the repo-root justfile.

## Why

These were drifted, less-complete duplicates of the canonical copies in the user's portfolio-root justfile (`~/repos/justfile`), which carries the fuller definitions (explicit `"type":"stdio"`, env plumbing). Two homes for the same recipes had already diverged (`mcp-github` command and token name differed). A portfolio-wide justfile/rules consolidation audit picked the portfolio root as the single home; the laurigates parent justfile now registers this repo as a `mod`, so these recipes remain reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)