### PR TITLE
feat(configure-plugin): absorb pin-plugins exhaustive pinning mode into configure-claude-plugins

### DIFF
--- a/configure-plugin/skills/configure-claude-plugins/SKILL.md
+++ b/configure-plugin/skills/configure-claude-plugins/SKILL.md
@@ -1,8 +1,8 @@
 ---
 created: 2026-01-23
-modified: 2026-06-01
-reviewed: 2026-06-01
-description: "Claude plugins marketplace setup: .claude/settings.json, GitHub Actions, plugin sets. Use when onboarding to claude-plugins, setting up claude.yml, or pinning plugins."
+modified: 2026-06-10
+reviewed: 2026-06-10
+description: "Claude plugins marketplace setup: .claude/settings.json, GitHub Actions, plugin pinning. Use when onboarding to claude-plugins, setting up claude.yml, pinning plugins, or overriding global plugins."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash(mkdir *), Bash(test *), Bash(ls *), Bash(git remote *), Bash(gh api *), Bash(jq *), AskUserQuestion, TodoWrite
 args: "[--check-only] [--fix] [--exhaustive] [--plugins <plugin1,plugin2,...>] [--workflows] [--no-workflows]"
 argument-hint: "[--check-only] [--fix] [--exhaustive] [--plugins <plugin1,plugin2,...>] [--workflows] [--no-workflows]"
@@ -41,7 +41,7 @@ Parse from command arguments:
 | `--check-only` | Report current configuration status without changes |
 | `--fix` | Apply configuration automatically |
 | `--plugins` | Comma-separated list of plugins to install (default: all recommended) |
-| `--exhaustive` | Enumerate every marketplace plugin in `enabledPlugins` — recommended ones as `true`, the rest as `false`. Pins the project's plugin set against global toggles. |
+| `--exhaustive` | Enumerate every marketplace plugin in `enabledPlugins` as an explicit `true`/`false`, so the project fully overrides the user-global enable state. Derives each boolean from repo context (see the defaults table in Step 3), preserves any value the project already set, and shows a diff before writing. Also triggered by "pin plugins" / "override global plugins for this project". |
 | `--workflows` | Force-scaffold the `claude.yml` / `claude-code-review.yml` workflows even when no git remote is detected (default: scaffold only when a remote exists). |
 | `--no-workflows` | Skip workflow scaffolding even when a git remote is present. Useful for local-only or vendored projects. |
 
@@ -123,7 +123,27 @@ Use granular patterns only — do not add `Bash(bash *)` for CLI tools.
 
 #### Exhaustive enumeration (when `--exhaustive` is set)
 
-Build the full `enabledPlugins` map by reading every plugin name from the two relevant marketplaces, then writing each one with the appropriate boolean. The recommended set from Step 2 becomes `true`; everything else becomes `false`.
+Build the full `enabledPlugins` map by reading every plugin name from the two relevant marketplaces, then writing each one with an explicit `true`/`false`. Every marketplace plugin is named, so the project's map **fully overrides** the user-global enable state — a plugin the user toggled on globally is forced off here unless it is explicitly `true`. This skill only ever writes `<cwd>/.claude/settings.json`; it never modifies `~/.claude/settings.json` (user-global toggles stay as the user set them).
+
+**Deriving each plugin's boolean.** Start from the Step 2 recommended set (those become `true`), then refine from repo context using the signals below. A plugin a value already exists for in the project's current `enabledPlugins` **wins over the suggestion** — only fill in *missing* entries from this logic, so a deliberate prior choice is never silently flipped.
+
+| Signal in repo | Suggest enabling |
+|---|---|
+| `pyproject.toml`, `requirements.txt`, `*.py` | `python-plugin` |
+| `Cargo.toml`, `*.rs` | `rust-plugin` (and `bevy-plugin` if Bevy is in deps) |
+| `go.mod`, `*.go` | `go-plugin` (if present in the marketplace) |
+| `package.json`, `*.ts`, `*.tsx` | `typescript-plugin` |
+| `*.tf`, `terraform/` | `terraform-plugin` |
+| `Dockerfile`, `compose.yaml` | `container-plugin` |
+| `Chart.yaml`, `kustomization.yaml`, `k8s/` | `kubernetes-plugin` / `helm-plugin` |
+| `flake.nix`, `default.nix` | `nix-plugin` |
+| `langchain` in deps | `langchain-plugin` |
+| `home-assistant`/`hass` configs | `home-assistant-plugin` |
+| `.github/workflows/` | `github-actions-plugin` |
+| macOS host (`uname -s` = Darwin) | `macos-plugin` |
+| Markdown-heavy `docs/` or `blog/` | `documentation-plugin`, `blog-plugin` |
+
+Always-useful baseline (enable unless the user says otherwise): `agents-plugin`, `agent-patterns-plugin`, `blueprint-plugin`, `code-quality-plugin`, `communication-plugin`, `configure-plugin`, `git-plugin`, `health-plugin`, `prose-plugin`, `taskwarrior-plugin`, `testing-plugin`, `tools-plugin`, `workflow-orchestration-plugin`. Anything else not matched defaults to `false`.
 
 1. **Read the laurigates marketplace** in priority order:
    - If a local clone is present (e.g. inside this repo or a sibling checkout), parse `.claude-plugin/marketplace.json`:
@@ -166,7 +186,14 @@ Build the full `enabledPlugins` map by reading every plugin name from the two re
 }
 ```
 
-4. **Drop unknown global entries.** If the project's existing `enabledPlugins` (or a merged-in copy of the user's global file) contains plugin names that are not in either marketplace listing, surface them in the report and ask whether to keep them. They may belong to a third marketplace the user has enrolled.
+4. **Drop unknown global entries.** If the project's existing `enabledPlugins` (or a merged-in copy of the user's global file) contains plugin names that are not in either marketplace listing, surface them in the report and ask whether to keep them. They may belong to a third marketplace the user has enrolled. Do not delete them silently — stale entries are harmless and the user may have notes about them.
+
+5. **Show the diff before writing.** Exhaustive mode rewrites the whole `enabledPlugins` map, so present the proposal before committing it. Group it as:
+   - **Already correct** — count only, do not list each one.
+   - **Will add** — new key → `true`/`false`, with a one-line reason for each `true`.
+   - **Will change** — existing key → flipped value, with the reason.
+
+   Render compact (a small markdown table or a `+`/`-` list). **Highlight any currently-`true` entry the proposal would turn off** — that is where users most often disagree. Then confirm once (accept "yes"/"go"/"apply", or let the user veto specific plugins and re-render). Skip the prompt under `--check-only` (report the diff only) and under `--fix` when the user already opted into non-interactive application.
 
 #### Full settings.json stanza to merge
 
@@ -367,7 +394,7 @@ Next Steps:
 | `--check-only` | Report current status without making changes |
 | `--fix` | Apply all configuration automatically |
 | `--plugins` | Override automatic plugin selection |
-| `--exhaustive` | Enumerate every marketplace plugin (recommended ones `true`, the rest `false`). Pins the project's plugin set deterministically against global toggles. |
+| `--exhaustive` | Enumerate every marketplace plugin as an explicit `true`/`false` so the project fully overrides global toggles. Derives booleans from repo context, preserves existing project values, and diffs before writing. Triggered by "pin plugins" / "override global plugins for this project". |
 | `--workflows` | Force-scaffold the `claude.yml` / `claude-code-review.yml` workflows even when no git remote is detected. By default, workflow scaffolding is skipped on remote-less repos to avoid dormant files. |
 | `--no-workflows` | Skip workflow scaffolding even when a git remote is present. Useful for local-only or vendored projects where settings should be configured but Actions should not. |
 

--- a/configure-plugin/skills/configure-repo/SKILL.md
+++ b/configure-plugin/skills/configure-repo/SKILL.md
@@ -6,7 +6,7 @@ args: "[--check-only] [--skip-health] [--skip-migrations]"
 argument-hint: "[--check-only] [--skip-health] [--skip-migrations]"
 created: 2026-04-14
 modified: 2026-04-14
-reviewed: 2026-06-03
+reviewed: 2026-06-10
 ---
 
 # /configure:repo


### PR DESCRIPTION
## What

Extends `configure-claude-plugins` `--exhaustive` mode with the behavior of the standalone user-global `pin-plugins` skill: explicit true/false for every marketplace plugin so the project fully overrides global enable state, sensible-defaults-from-repo-context table (with an always-useful baseline), existing-project-values-win semantics, diff-before-write, and a hard "never touches `~/.claude`" guarantee. Adds the "override global plugins for this project" trigger phrasing to the description.

## Why

A skills audit found the standalone `pin-plugins` skill duplicated this skill's machinery (marketplace fetch via `gh api`, settings merge) against the same target file and same marketplace — the consolidation case the repo's own skill-consolidation rule warns about. Only the genuinely new behavior was ported; no machinery duplicated. The `configure-repo` driver's `reviewed:` date is bumped because the freshness hook requires it (the driver's `--fix` path is unaffected by this change).

Follow-up (tracked in the user's queue): delete the standalone user-global `pin-plugins` skill once this releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)