### PR TITLE
fix(kubernetes-plugin): anchor kubectl/helm hook on command position

### DIFF
--- a/comfyui-plugin/skills/comfyui-node-scaffold/scaffold.py
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/scaffold.py
@@ -1181,8 +1181,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 """
 
-PUBLISH_YML = """\
-name: Publish to Comfy Registry
+# Raw string: the embedded changelog transform contains regex backslashes
+# (incl. \1 replacement refs) that a normal string literal would corrupt.
+PUBLISH_YML = r"""name: Publish to Comfy Registry
 
 on:
   workflow_dispatch:
@@ -1225,6 +1226,9 @@ jobs:
         # (fixed in Comfy-Org/registry-backend#168), so push the release-please
         # release notes there after publishing. The {versionId} path segment
         # must be the version's database UUID, not the semver string.
+        # The registry renders the changelog as PLAIN TEXT (line-clamp-2 card,
+        # bare <p> drawer; markdown shows raw and newlines collapse), so the
+        # release-please markdown is flattened to compact plain text first.
         # Best-effort: a failure here must not fail the publish itself.
         if: github.event_name == 'release' && github.event.release.body != ''
         env:
@@ -1237,16 +1241,53 @@ jobs:
           node_id=$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["name"])')
           publisher_id=$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["tool"]["comfy"]["PublisherId"])')
           version=$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')
+          changelog=$(python3 <<'PY'
+          import os, re
+
+          def clean(text):
+              text = re.sub(r"\(\[[0-9a-f]{6,40}\]\([^)]*\)\)", "", text)
+              text = re.sub(r"\[#([0-9]+)\]\([^)]*\)", r"#\1", text)
+              text = re.sub(r"\[([^\]]+)\]\([^)]*\)", r"\1", text)
+              text = text.replace("**", "")
+              return re.sub(r"\s+", " ", text).strip().rstrip(".")
+
+          sections, items, current = [], [], None
+
+          def flush():
+              if items:
+                  prefix = current + ": " if current else ""
+                  sections.append(prefix + "; ".join(items) + ".")
+
+          for raw in os.environ.get("RELEASE_BODY", "").splitlines():
+              line = raw.strip()
+              if not line:
+                  continue
+              if re.match(r"^#+\s*\[?[0-9]+\.[0-9]+\.[0-9]+", line):
+                  continue
+              m = re.match(r"^#+\s+(.*)", line)
+              if m:
+                  flush()
+                  items, current = [], clean(m.group(1))
+                  continue
+              m = re.match(r"^[*-]\s+(.*)", line)
+              cleaned = clean(m.group(1) if m else line)
+              if cleaned:
+                  items.append(cleaned)
+
+          flush()
+          print("\n".join(sections))
+          PY
+          )
+          if [ -z "$changelog" ]; then
+            echo "::warning::registry changelog: release notes empty after transform for ${node_id}@${version}; skipping"
+            exit 0
+          fi
           version_id=$(curl -sf "https://api.comfy.org/nodes/${node_id}/versions" | jq -r --arg v "$version" '.[] | select(.version == $v) | .id')
           if [ -z "$version_id" ] || [ "$version_id" = "null" ]; then
             echo "::warning::registry changelog: could not resolve UUID for ${node_id}@${version}; Updates section left empty"
             exit 0
           fi
-          if jq -n --arg c "$RELEASE_BODY" '{changelog: $c}' | curl -sf -X PUT \\
-              "https://api.comfy.org/publishers/${publisher_id}/nodes/${node_id}/versions/${version_id}" \\
-              -H "Authorization: Bearer ${REGISTRY_TOKEN}" \\
-              -H 'Content-Type: application/json' \\
-              --data-binary @- > /dev/null; then
+          if jq -n --arg c "$changelog" '{changelog: $c}' | curl -sf -X PUT "https://api.comfy.org/publishers/${publisher_id}/nodes/${node_id}/versions/${version_id}" -H "Authorization: Bearer ${REGISTRY_TOKEN}" -H 'Content-Type: application/json' --data-binary @- > /dev/null; then
             echo "registry changelog set for ${node_id}@${version} (${version_id})"
           else
             echo "::warning::registry changelog PUT failed for ${node_id}@${version}; Updates section left empty"

--- a/comfyui-plugin/skills/comfyui-node-scaffold/scaffold.py
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/scaffold.py
@@ -810,10 +810,12 @@ zoom during a gesture, intercept `wheel` (capture, `passive:false`,
 
 ## Releases
 
-Bump `version` in `pyproject.toml` and push to `main` → `publish.yml` runs
-`bun run build` then `Comfy-Org/publish-node-action` publishes to the Comfy
-Registry. Requires the `REGISTRY_ACCESS_TOKEN` repo secret. Use conventional
-commits; release-please maintains `CHANGELOG.md` and the version bump PR.
+Merge the release-please PR → the published GitHub release triggers
+`publish.yml`, which runs `bun run build`, publishes via
+`Comfy-Org/publish-node-action`, and pushes the release notes to the registry
+version changelog (the "Updates" section). Requires the
+`REGISTRY_ACCESS_TOKEN` repo secret. Use conventional commits; release-please
+maintains `CHANGELOG.md` and the version bump PR.
 """
 
 JUSTFILE = """\
@@ -1184,11 +1186,8 @@ name: Publish to Comfy Registry
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - pyproject.toml
+  release:
+    types: [published]
 
 jobs:
   publish-node:
@@ -1206,11 +1205,52 @@ jobs:
           bun install --frozen-lockfile
           bun run build
       - name: Publish Custom Node
-        uses: Comfy-Org/publish-node-action@v1
+        # Pinned to the main SHA that supports `skip_checkout`. The `@v1` and
+        # tagged releases predate that input: they run an unconditional
+        # actions/checkout that wipes the git-ignored web/dist built above, so
+        # the registry tarball ships an EMPTY web/dist and the extension never
+        # loads.
+        uses: Comfy-Org/publish-node-action@d2366e7abb6ab16f3bb03e3520ae25c8cf749bc9 # main: skip_checkout support
         with:
           # PAT issued at https://registry.comfy.org/, stored as the
           # REGISTRY_ACCESS_TOKEN repo secret.
           personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}
+          # Reuse the workspace the prior step already built (see pin comment).
+          skip_checkout: 'true'
+
+      - name: Set registry changelog from release notes
+        # `comfy node publish` cannot send a changelog (Comfy-Org/comfy-cli#467),
+        # so the registry's per-version "Updates" section stays empty. The
+        # registry does accept the publisher PAT on the version-update endpoint
+        # (fixed in Comfy-Org/registry-backend#168), so push the release-please
+        # release notes there after publishing. The {versionId} path segment
+        # must be the version's database UUID, not the semver string.
+        # Best-effort: a failure here must not fail the publish itself.
+        if: github.event_name == 'release' && github.event.release.body != ''
+        env:
+          REGISTRY_TOKEN: ${{ secrets.REGISTRY_ACCESS_TOKEN }}
+          # Passed via env (not inline interpolation) so markdown/quotes in the
+          # release notes cannot inject into the shell.
+          RELEASE_BODY: ${{ github.event.release.body }}
+        run: |
+          set -u
+          node_id=$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["name"])')
+          publisher_id=$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["tool"]["comfy"]["PublisherId"])')
+          version=$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')
+          version_id=$(curl -sf "https://api.comfy.org/nodes/${node_id}/versions" | jq -r --arg v "$version" '.[] | select(.version == $v) | .id')
+          if [ -z "$version_id" ] || [ "$version_id" = "null" ]; then
+            echo "::warning::registry changelog: could not resolve UUID for ${node_id}@${version}; Updates section left empty"
+            exit 0
+          fi
+          if jq -n --arg c "$RELEASE_BODY" '{changelog: $c}' | curl -sf -X PUT \\
+              "https://api.comfy.org/publishers/${publisher_id}/nodes/${node_id}/versions/${version_id}" \\
+              -H "Authorization: Bearer ${REGISTRY_TOKEN}" \\
+              -H 'Content-Type: application/json' \\
+              --data-binary @- > /dev/null; then
+            echo "registry changelog set for ${node_id}@${version} (${version_id})"
+          else
+            echo "::warning::registry changelog PUT failed for ${node_id}@${version}; Updates section left empty"
+          fi
 """
 
 RELEASE_PLEASE_YML = """\
@@ -1396,9 +1436,11 @@ RELEASE_CHECKLIST = """\
 
 - [ ] Land work via conventional commits on feature branches → PRs to `main`.
 - [ ] Merge the release-please PR (it bumps `version` + updates `CHANGELOG.md`).
-- [ ] The version bump on `main` triggers `publish.yml`, which runs
-      `bun install && bun run build` before `publish-node-action` so the built
-      `web/dist/` exists at publish time → Comfy Registry.
+- [ ] Publishing the GitHub release (release-please does this on merge)
+      triggers `publish.yml`, which runs `bun install && bun run build` before
+      `publish-node-action` so the built `web/dist/` exists at publish time →
+      Comfy Registry. A follow-up step sets the registry version changelog
+      ("Updates" section) from the release notes.
 - [ ] Verify the new version appears on registry.comfy.org.
 """
 

--- a/kubernetes-plugin/hooks/test-validate-kubectl-context.sh
+++ b/kubernetes-plugin/hooks/test-validate-kubectl-context.sh
@@ -117,6 +117,54 @@ assert_exit \
     "pipe into kubectl with --context is allowed" 0 \
     '{"tool_name":"Bash","tool_input":{"command":"cat manifest.yaml | kubectl --context=staging apply -f -"}}'
 
+# ── Prose-substring false-positive regression tests ────────────────────────
+# Regression (issue #1544): the detection anchor allowed ANY whitespace before
+# the tool name, so a bare mention of "helm"/"kubectl" in prose that leaked past
+# heredoc/quote stripping (e.g. a commit message with an escaped quote) was
+# blocked as if it were a real invocation. Detection now anchors on command
+# position (start, after a separator, or after env/sudo prefixes), so mid-prose
+# mentions are allowed while genuine invocations are still enforced.
+echo ""
+echo "Prose-substring false-positive regression (#1544):"
+
+# helm mentioned mid-sentence in an unquoted command (prose, not an invocation)
+assert_exit \
+    "helm mid-prose after a non-command word is allowed" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"echo please install helm soon"}}'
+
+# kubectl mentioned mid-sentence in an unquoted command
+assert_exit \
+    "kubectl mid-prose after a non-command word is allowed" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"echo run kubectl later to inspect pods"}}'
+
+# Commit message whose escaped quote defeats naive quote-stripping, leaking the
+# word "helm" into the cleaned command — must NOT be treated as an invocation
+assert_exit \
+    "helm in commit message with escaped quote is allowed" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"rename the \\\"fix\\\" fork to a helm hook name\""}}'
+
+# Same shape for kubectl
+assert_exit \
+    "kubectl in commit message with escaped quote is allowed" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"document the \\\"new\\\" kubectl context flow\""}}'
+
+# Protection preserved: sudo/env-prefixed invocations are still real invocations
+assert_exit \
+    "sudo helm install without --kube-context is still blocked" 2 \
+    '{"tool_name":"Bash","tool_input":{"command":"sudo helm install myapp ./chart"}}'
+
+assert_exit \
+    "env-prefixed kubectl without --context is still blocked" 2 \
+    '{"tool_name":"Bash","tool_input":{"command":"KUBECONFIG=/tmp/kc kubectl get pods"}}'
+
+assert_exit \
+    "sudo helm with --kube-context is allowed" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"sudo helm --kube-context=prod install myapp ./chart"}}'
+
+assert_exit \
+    "env-prefixed kubectl with --context is allowed" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"KUBECONFIG=/tmp/kc kubectl --context=prod get pods"}}'
+
 # ── kubectl enforcement tests ────────────────────────────────────────────────
 echo ""
 echo "kubectl enforcement:"

--- a/kubernetes-plugin/hooks/validate-kubectl-context.sh
+++ b/kubernetes-plugin/hooks/validate-kubectl-context.sh
@@ -92,12 +92,32 @@ strip_quoted_strings() {
 # for kubectl/helm invocations.
 COMMAND_CLEAN=$(printf '%s\n' "$COMMAND" | strip_heredocs | strip_quoted_strings)
 
+# Detect whether a tool name appears as an actual command invocation in
+# COMMAND_CLEAN, rather than as a bare substring inside prose. A command
+# position is:
+#   - the start of the command (or any line of it), or
+#   - immediately after a shell command separator: ; & | (  — which also
+#     covers &&, ||, and $( ), or
+#   - after a run of leading command-prefix tokens: env assignments
+#     (NAME=value) or sudo/time/env/command/exec/nice/nohup.
+#
+# Regression (issue #1544): the previous anchor allowed ANY whitespace
+# (`\s`) before the tool name, so a bare mention in prose that leaked past
+# heredoc/quote stripping — e.g. "a helm hook" in a `git commit -m "..."`
+# message containing an escaped quote — was treated as a `helm` invocation
+# and blocked. Anchoring on command position eliminates that false-positive
+# while still catching env-prefixed and sudo-prefixed invocations.
+is_invocation() {
+    printf '%s\n' "$COMMAND_CLEAN" | grep -Eq \
+        "(^|[;&|(])[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+|(sudo|time|env|command|exec|nice|nohup)[[:space:]]+)*$1[[:space:]]"
+}
+
 # Commands that don't require --context (read-only info commands)
 # These are safe because they don't modify cluster state
 SAFE_KUBECTL_SUBCOMMANDS="config|version|api-resources|api-versions|explain|completion"
 
 # Check if this is a kubectl command
-if echo "$COMMAND_CLEAN" | grep -Eq '(^|\s|;|&&|\|)kubectl\s+'; then
+if is_invocation kubectl; then
 
     # Allow safe commands that don't need context
     if echo "$COMMAND_CLEAN" | grep -Eq "kubectl\s+($SAFE_KUBECTL_SUBCOMMANDS)"; then
@@ -127,7 +147,7 @@ Using explicit --context prevents accidental operations on production or other c
 fi
 
 # Check if this is a helm command
-if echo "$COMMAND_CLEAN" | grep -Eq '(^|\s|;|&&|\|)helm\s+'; then
+if is_invocation helm; then
 
     # Helm commands that don't need context
     # These operate on charts, repos, or registries — never on a cluster.


### PR DESCRIPTION
## What

The `validate-kubectl-context.sh` PreToolUse hook detected `kubectl`/`helm` with an anchor that accepted **any whitespace** before the tool name (`(^|\s|;|&&|\|)helm\s+`). A bare mention of "helm"/"kubectl" anywhere in a command — including prose that leaked past the existing heredoc/quote stripping — was treated as a real invocation and blocked.

## Why (#1544)

A `git commit -m "...a Helm hook..."` was blocked twice with `HELM SAFETY: Missing --kube-context flag` even though it was a `git commit`, not a `helm` command. The existing `strip_quoted_strings` is documented as not handling escaped quotes (`\"`); when a commit message contains one, the trailing prose leaks into the cleaned command, and the loose `\s` anchor then matches the word `helm`/`kubectl` mid-sentence.

Confirmed repro on `main` (both blocked, exit 2):

```
echo please install helm soon
echo run kubectl later to inspect pods
```

## How

Replace the two detection conditionals with an `is_invocation` helper that anchors on an actual **command position**:

- start of the command (or any line of it), or
- immediately after a shell separator `; & | (` (which also covers `&&`, `||`, `$(`), or
- after a run of leading command-prefix tokens: env assignments (`NAME=value`) or `sudo`/`time`/`env`/`command`/`exec`/`nice`/`nohup`.

Mid-prose mentions are no longer matched, while genuine env-prefixed (`KUBECONFIG=… kubectl …`) and `sudo helm …` invocations stay enforced. This is strictly broader protection than the bare separator-anchor suggested in the issue.

## Tests

Added 8 regression tests (`#1544` section in `test-validate-kubectl-context.sh`):

- helm/kubectl mid-prose → allowed
- helm/kubectl in a commit message with an escaped quote → allowed
- `sudo helm install` / `KUBECONFIG=… kubectl get` without a context flag → still blocked
- the same with `--kube-context` / `--context` → allowed

Suite: **32 → 40 passing**. `shellcheck` and `scripts/lint-shell-scripts.sh` both clean.

Closes #1544

🤖 Generated with [Claude Code](https://claude.com/claude-code)
