### PR TITLE
feat: cold-read-gate + workflow-verify-before-filing skills

### DIFF
--- a/agent-patterns-plugin/skills/cold-read-gate/SKILL.md
+++ b/agent-patterns-plugin/skills/cold-read-gate/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: cold-read-gate
+description: Gate outward-bound text (upstream issues, docs, PR bodies) through isolated haiku fresh-reader critique before publishing. Use when an artifact must survive a reader with zero project context.
+allowed-tools: Agent, Read, Write, Edit, TodoWrite
+model: opus
+created: 2026-06-11
+modified: 2026-06-11
+reviewed: 2026-06-11
+---
+
+# Cold-Read Gate
+
+Text written inside a long session inherits the session's context — codenames,
+version baselines, internal PR numbers, "the obvious fix" — and the author can
+no longer see which parts won't survive contact with a reader who has none of
+it. Before publishing an outward-bound artifact, **dispatch an isolated,
+cheap, context-free agent to read it cold and interrogate it**. What confuses
+the cold reader is what will cost you a round-trip question (or a silent
+deprioritization) from the real audience.
+
+The reader is deliberately **haiku, isolated, and shown only the artifact**.
+This is a measured exception to the "always Opus for subagents" rule: the
+subagent here is not doing delegated work — it *is* the measurement
+instrument. The test is "can a low-context reader act on this text alone?",
+and a stronger model (or one with session context) would answer a different,
+easier question. If haiku can act on it, a busy maintainer can.
+
+## When to Use This Skill
+
+| Use this skill when... | Skip when... |
+|---|---|
+| Filing issues/MRs on an upstream tracker (external maintainers) | Internal scratch notes, commit messages, chat replies |
+| Publishing docs a new team member will land on cold | The artifact is throwaway or has a captive expert audience |
+| PR descriptions for reviewers outside the work's context | The text is one paragraph — just reread it yourself |
+| Emails / announcements leaving the team | The same artifact already passed a gate and only typos changed |
+| Batch-producing N artifacts (one reader per artifact, parallel) | |
+
+## The Gate Protocol
+
+### Step 1: Artifact on disk
+
+The artifact must be a file. The reader gets a path, not pasted text — paste
+invites the orchestrator to "helpfully" add context, which defeats the test.
+
+### Step 2: Dispatch the cold reader
+
+One `Agent` per artifact, all in a single message when batching. Template:
+
+```
+subagent_type: general-purpose
+model: haiku
+prompt: |
+  You are <persona — see table>. You have NO context beyond the text itself.
+  Read ONLY this file (no other files, no repository exploration, no web):
+  <absolute path>
+
+  Produce:
+  1. QUESTIONS — anything unclear, ambiguous, undefined (jargon, acronyms,
+     unexplained references), or missing that you'd have to ask the author
+     before acting. Quote the exact phrase that confused you.
+  2. HESITATIONS — claims you can't verify from the text alone, confusing
+     structure, anything that would make you deprioritize it.
+  3. Verdict: clear-and-actionable as written, or needs-revision.
+
+  Ignore: <known artifacts of the test — see Step 3>.
+  Concise bullets. Your final message is the deliverable.
+```
+
+| Audience | Persona |
+|---|---|
+| Upstream bug report | "an open-source maintainer triaging a newly filed issue" |
+| Team documentation | "a new team member reading this doc with no project context" |
+| PR description | "a reviewer seeing this change for the first time" |
+
+### Step 3: Triage the critique — genuine gaps vs test artifacts
+
+The cold reader cannot know the publishing context, so some complaints are
+artifacts of the test, not defects. Triage before revising:
+
+| Genuine gap — fix it | Test artifact — ignore it |
+|---|---|
+| Bare file paths instead of clickable links pinned to a ref | "Which repo is this?" when the artifact is filed *on* that repo's tracker |
+| Unexplained acronym/jargon on first use | Complaints about metadata the publish step strips (HTML comments, frontmatter) |
+| Symptom asserted without the actual error output | Demands for repro environments beyond what quoted source code shows |
+| Three suggested fixes with no preference | Critique of pre-existing scope the current change didn't touch |
+| Internal references (PR #s, ticket IDs) leaking into external text | Requests to restructure a document section you didn't write |
+| Internal arithmetic that doesn't add up ("12 across two waves" — which 12?) | |
+
+### Step 4: Revise once, re-read only on failure
+
+Apply the genuine gaps with a revise pass (the orchestrator or a revise
+agent). Re-dispatch a fresh cold reader **only if the first verdict was
+needs-revision**; a "clear" verdict with minor notes doesn't need a second
+opinion. Do not loop more than twice — a third round means the artifact has a
+structural problem the gate can't fix.
+
+## Workflow-Script Integration
+
+Inside a `Workflow` script the gate is one schema-enforced stage per item:
+
+```javascript
+const cold = await agent(
+  `You are an upstream maintainer triaging a newly filed issue. NO context
+   beyond the text. Read ONLY ${draft.path}. QUESTIONS / HESITATIONS /
+   verdict. Ignore the top HTML comments (stripped before filing).`,
+  { label: `coldread:${item.id}`, phase: 'ColdRead', model: 'haiku',
+    schema: { type: 'object', properties: {
+      verdict: { type: 'string', enum: ['clear', 'needs-revision'] },
+      critique: { type: 'string' } },
+      required: ['verdict', 'critique'] } },
+)
+if (cold?.verdict === 'needs-revision') { /* revise agent, then one re-read */ }
+```
+
+## Evidence
+
+First production run (FVH infrastructure, 2026-06-11, 7 upstream issue
+drafts + 5 docs): the gate surfaced a timeline whose headline number didn't
+reconcile with its own breakdown, an undefined role name (`NOTARY`) at the
+moment of its dramatic payoff, a Spring Boot issue that never named Spring
+Boot, a fix section offering three options with no recommendation, and two
+drafts judged "not actionable as written" that were revised before filing.
+All 12 issues filed after the gate drew zero clarification round-trips.
+
+## Common Mistakes
+
+| Mistake | Correct approach |
+|---|---|
+| Using opus/sonnet as the reader "for better critique" | The weak reader is the point — it measures, not advises |
+| Pasting the artifact into the prompt | Give a path; pasted text tempts context smuggling |
+| Letting the reader explore the repo | "Read ONLY this file" — exploration restores the context the test removes |
+| Acting on every complaint | Triage first (Step 3); artifacts of the test produce busywork |
+| Looping until the reader is silent | One revise round; persistent confusion = structural problem |
+| Gating drafts but not the docs that reference them | Anything a cold audience lands on qualifies |
+
+## Related
+
+- [`verify-before-plan`](../verify-before-plan/SKILL.md) — verifies premises
+  before work; this skill verifies legibility after
+- `workflow-orchestration-plugin:workflow-verify-before-filing` — the filing
+  pipeline this gate slots into as the pre-publish stage
+- [`parallel-agent-dispatch`](../parallel-agent-dispatch/SKILL.md) — batching
+  N readers follows its single-message dispatch contract

--- a/agent-patterns-plugin/skills/cold-read-gate/SKILL.md
+++ b/agent-patterns-plugin/skills/cold-read-gate/SKILL.md
@@ -27,6 +27,9 @@ easier question. If haiku can act on it, a busy maintainer can.
 
 ## When to Use This Skill
 
+"Outward-bound" means any audience that lacks your session context — external
+maintainers *and* future teammates reading internal docs cold both qualify.
+
 | Use this skill when... | Skip when... |
 |---|---|
 | Filing issues/MRs on an upstream tracker (external maintainers) | Internal scratch notes, commit messages, chat replies |
@@ -60,9 +63,12 @@ prompt: |
      before acting. Quote the exact phrase that confused you.
   2. HESITATIONS — claims you can't verify from the text alone, confusing
      structure, anything that would make you deprioritize it.
-  3. Verdict: clear-and-actionable as written, or needs-revision.
+  3. Verdict: exactly one of `clear` | `needs-revision`.
 
-  Ignore: <known artifacts of the test — see Step 3>.
+  Ignore: <known artifacts of the test — see Step 3. Example:
+  "Ignore the HTML comments at the top (they are stripped by the filing
+  script before publishing) and do not ask which repository this is —
+  the issue is filed on the target project's own tracker.">
   Concise bullets. Your final message is the deliverable.
 ```
 
@@ -90,8 +96,8 @@ artifacts of the test, not defects. Triage before revising:
 
 Apply the genuine gaps with a revise pass (the orchestrator or a revise
 agent). Re-dispatch a fresh cold reader **only if the first verdict was
-needs-revision**; a "clear" verdict with minor notes doesn't need a second
-opinion. Do not loop more than twice — a third round means the artifact has a
+`needs-revision`**; a `clear` verdict with minor notes means apply the
+genuine ones and publish without a second opinion. Do not loop more than twice — a third round means the artifact has a
 structural problem the gate can't fix.
 
 ## Workflow-Script Integration

--- a/comfyui-plugin/skills/comfyui-node-scaffold/scaffold.py
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/scaffold.py
@@ -1181,8 +1181,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 """
 
-PUBLISH_YML = """\
-name: Publish to Comfy Registry
+# Raw string: the embedded changelog transform contains regex backslashes
+# (incl. \1 replacement refs) that a normal string literal would corrupt.
+PUBLISH_YML = r"""name: Publish to Comfy Registry
 
 on:
   workflow_dispatch:
@@ -1225,6 +1226,9 @@ jobs:
         # (fixed in Comfy-Org/registry-backend#168), so push the release-please
         # release notes there after publishing. The {versionId} path segment
         # must be the version's database UUID, not the semver string.
+        # The registry renders the changelog as PLAIN TEXT (line-clamp-2 card,
+        # bare <p> drawer; markdown shows raw and newlines collapse), so the
+        # release-please markdown is flattened to compact plain text first.
         # Best-effort: a failure here must not fail the publish itself.
         if: github.event_name == 'release' && github.event.release.body != ''
         env:
@@ -1237,16 +1241,53 @@ jobs:
           node_id=$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["name"])')
           publisher_id=$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["tool"]["comfy"]["PublisherId"])')
           version=$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')
+          changelog=$(python3 <<'PY'
+          import os, re
+
+          def clean(text):
+              text = re.sub(r"\(\[[0-9a-f]{6,40}\]\([^)]*\)\)", "", text)
+              text = re.sub(r"\[#([0-9]+)\]\([^)]*\)", r"#\1", text)
+              text = re.sub(r"\[([^\]]+)\]\([^)]*\)", r"\1", text)
+              text = text.replace("**", "")
+              return re.sub(r"\s+", " ", text).strip().rstrip(".")
+
+          sections, items, current = [], [], None
+
+          def flush():
+              if items:
+                  prefix = current + ": " if current else ""
+                  sections.append(prefix + "; ".join(items) + ".")
+
+          for raw in os.environ.get("RELEASE_BODY", "").splitlines():
+              line = raw.strip()
+              if not line:
+                  continue
+              if re.match(r"^#+\s*\[?[0-9]+\.[0-9]+\.[0-9]+", line):
+                  continue
+              m = re.match(r"^#+\s+(.*)", line)
+              if m:
+                  flush()
+                  items, current = [], clean(m.group(1))
+                  continue
+              m = re.match(r"^[*-]\s+(.*)", line)
+              cleaned = clean(m.group(1) if m else line)
+              if cleaned:
+                  items.append(cleaned)
+
+          flush()
+          print("\n".join(sections))
+          PY
+          )
+          if [ -z "$changelog" ]; then
+            echo "::warning::registry changelog: release notes empty after transform for ${node_id}@${version}; skipping"
+            exit 0
+          fi
           version_id=$(curl -sf "https://api.comfy.org/nodes/${node_id}/versions" | jq -r --arg v "$version" '.[] | select(.version == $v) | .id')
           if [ -z "$version_id" ] || [ "$version_id" = "null" ]; then
             echo "::warning::registry changelog: could not resolve UUID for ${node_id}@${version}; Updates section left empty"
             exit 0
           fi
-          if jq -n --arg c "$RELEASE_BODY" '{changelog: $c}' | curl -sf -X PUT \\
-              "https://api.comfy.org/publishers/${publisher_id}/nodes/${node_id}/versions/${version_id}" \\
-              -H "Authorization: Bearer ${REGISTRY_TOKEN}" \\
-              -H 'Content-Type: application/json' \\
-              --data-binary @- > /dev/null; then
+          if jq -n --arg c "$changelog" '{changelog: $c}' | curl -sf -X PUT "https://api.comfy.org/publishers/${publisher_id}/nodes/${node_id}/versions/${version_id}" -H "Authorization: Bearer ${REGISTRY_TOKEN}" -H 'Content-Type: application/json' --data-binary @- > /dev/null; then
             echo "registry changelog set for ${node_id}@${version} (${version_id})"
           else
             echo "::warning::registry changelog PUT failed for ${node_id}@${version}; Updates section left empty"

--- a/comfyui-plugin/skills/comfyui-node-scaffold/scaffold.py
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/scaffold.py
@@ -810,10 +810,12 @@ zoom during a gesture, intercept `wheel` (capture, `passive:false`,
 
 ## Releases
 
-Bump `version` in `pyproject.toml` and push to `main` → `publish.yml` runs
-`bun run build` then `Comfy-Org/publish-node-action` publishes to the Comfy
-Registry. Requires the `REGISTRY_ACCESS_TOKEN` repo secret. Use conventional
-commits; release-please maintains `CHANGELOG.md` and the version bump PR.
+Merge the release-please PR → the published GitHub release triggers
+`publish.yml`, which runs `bun run build`, publishes via
+`Comfy-Org/publish-node-action`, and pushes the release notes to the registry
+version changelog (the "Updates" section). Requires the
+`REGISTRY_ACCESS_TOKEN` repo secret. Use conventional commits; release-please
+maintains `CHANGELOG.md` and the version bump PR.
 """
 
 JUSTFILE = """\
@@ -1184,11 +1186,8 @@ name: Publish to Comfy Registry
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - pyproject.toml
+  release:
+    types: [published]
 
 jobs:
   publish-node:
@@ -1206,11 +1205,52 @@ jobs:
           bun install --frozen-lockfile
           bun run build
       - name: Publish Custom Node
-        uses: Comfy-Org/publish-node-action@v1
+        # Pinned to the main SHA that supports `skip_checkout`. The `@v1` and
+        # tagged releases predate that input: they run an unconditional
+        # actions/checkout that wipes the git-ignored web/dist built above, so
+        # the registry tarball ships an EMPTY web/dist and the extension never
+        # loads.
+        uses: Comfy-Org/publish-node-action@d2366e7abb6ab16f3bb03e3520ae25c8cf749bc9 # main: skip_checkout support
         with:
           # PAT issued at https://registry.comfy.org/, stored as the
           # REGISTRY_ACCESS_TOKEN repo secret.
           personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}
+          # Reuse the workspace the prior step already built (see pin comment).
+          skip_checkout: 'true'
+
+      - name: Set registry changelog from release notes
+        # `comfy node publish` cannot send a changelog (Comfy-Org/comfy-cli#467),
+        # so the registry's per-version "Updates" section stays empty. The
+        # registry does accept the publisher PAT on the version-update endpoint
+        # (fixed in Comfy-Org/registry-backend#168), so push the release-please
+        # release notes there after publishing. The {versionId} path segment
+        # must be the version's database UUID, not the semver string.
+        # Best-effort: a failure here must not fail the publish itself.
+        if: github.event_name == 'release' && github.event.release.body != ''
+        env:
+          REGISTRY_TOKEN: ${{ secrets.REGISTRY_ACCESS_TOKEN }}
+          # Passed via env (not inline interpolation) so markdown/quotes in the
+          # release notes cannot inject into the shell.
+          RELEASE_BODY: ${{ github.event.release.body }}
+        run: |
+          set -u
+          node_id=$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["name"])')
+          publisher_id=$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["tool"]["comfy"]["PublisherId"])')
+          version=$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')
+          version_id=$(curl -sf "https://api.comfy.org/nodes/${node_id}/versions" | jq -r --arg v "$version" '.[] | select(.version == $v) | .id')
+          if [ -z "$version_id" ] || [ "$version_id" = "null" ]; then
+            echo "::warning::registry changelog: could not resolve UUID for ${node_id}@${version}; Updates section left empty"
+            exit 0
+          fi
+          if jq -n --arg c "$RELEASE_BODY" '{changelog: $c}' | curl -sf -X PUT \\
+              "https://api.comfy.org/publishers/${publisher_id}/nodes/${node_id}/versions/${version_id}" \\
+              -H "Authorization: Bearer ${REGISTRY_TOKEN}" \\
+              -H 'Content-Type: application/json' \\
+              --data-binary @- > /dev/null; then
+            echo "registry changelog set for ${node_id}@${version} (${version_id})"
+          else
+            echo "::warning::registry changelog PUT failed for ${node_id}@${version}; Updates section left empty"
+          fi
 """
 
 RELEASE_PLEASE_YML = """\
@@ -1396,9 +1436,11 @@ RELEASE_CHECKLIST = """\
 
 - [ ] Land work via conventional commits on feature branches → PRs to `main`.
 - [ ] Merge the release-please PR (it bumps `version` + updates `CHANGELOG.md`).
-- [ ] The version bump on `main` triggers `publish.yml`, which runs
-      `bun install && bun run build` before `publish-node-action` so the built
-      `web/dist/` exists at publish time → Comfy Registry.
+- [ ] Publishing the GitHub release (release-please does this on merge)
+      triggers `publish.yml`, which runs `bun install && bun run build` before
+      `publish-node-action` so the built `web/dist/` exists at publish time →
+      Comfy Registry. A follow-up step sets the registry version changelog
+      ("Updates" section) from the release notes.
 - [ ] Verify the new version appears on registry.comfy.org.
 """
 

--- a/workflow-orchestration-plugin/skills/workflow-verify-before-filing/REFERENCE.md
+++ b/workflow-orchestration-plugin/skills/workflow-verify-before-filing/REFERENCE.md
@@ -1,0 +1,197 @@
+# workflow-verify-before-filing — Worked Example
+
+Complete operational scaffolding from the run that motivated the skill
+(FVH → SIMPL-Open on a GitLab instance, 2026-06-11: 17 candidates → 5 filed,
+12 dispositioned). Adapt names/hosts; the shapes are the deliverable.
+
+## Data flow
+
+```
+wave2-candidates.json ──► Workflow script (per candidate):
+                            parallel[ verify-agent, search-agent ]
+                            └─ gate ─► draft-agent ─► coldread(haiku) ─► revise
+                          ◄── result JSON: {id, disposition, draftPath, ...}
+result JSON ──► file-wave.sh (paced) ──► filed-urls.txt
+filed-urls.txt + dispositions ──► source-doc annotations, tracking-issue
+                                  comment, follow-up tasks
+```
+
+## Phase 1+2 — Workflow script skeleton
+
+Run with the `Workflow` tool. Candidates embedded or parsed from args
+(`const CANDIDATES = (typeof args === 'string') ? JSON.parse(args) : args` —
+args can arrive stringified).
+
+```javascript
+export const meta = {
+  name: 'verify-before-filing',
+  description: 'Verify candidates at upstream HEAD, dedup, draft + cold-read gate',
+  phases: [
+    { title: 'Verify' }, { title: 'Search' }, { title: 'Draft' },
+    { title: 'ColdRead', model: 'haiku' }, { title: 'Revise' },
+  ],
+}
+
+const DIR = '/abs/path/to/drafts'
+
+const GLAB = `Tooling (READ-ONLY — GET requests only, never create/edit/comment upstream):
+- GITLAB_HOST=<instance> glab api "projects/<id-or-urlencoded-path>" (.default_branch)
+- ... "projects/<id>/repository/files/<URL-ENCODED-PATH>/raw?ref=<ref>" (slashes as %2F)
+- ... "projects/<id>/repository/tags?per_page=20"
+- ... "groups/<urlencoded-group>/search?scope=issues&search=<term>"
+- ... "projects/<id>/packages?per_page=100&sort=desc" (chart/package versions)
+Known project IDs: <paste your map>. When a candidate says "locate project",
+resolve via groups/<g>/projects?include_subgroups=true&search=<name>.`
+
+const VERIFY_SCHEMA = { type: 'object', properties: {
+  verdict: { type: 'string', enum: ['still-present', 'partially-fixed',
+    'fixed-upstream', 'obsolete-version', 'claim-invalid', 'could-not-verify'] },
+  targetProject: { type: 'string' },
+  evidence: { type: 'string', description: 'quoted current content with paths + refs' },
+  checkedRefs: { type: 'string' }, notes: { type: 'string' } },
+  required: ['verdict', 'targetProject', 'evidence', 'checkedRefs', 'notes'] }
+
+const SEARCH_SCHEMA = { type: 'object', properties: {
+  duplicateFound: { type: 'string', enum: ['yes', 'possibly', 'no'] },
+  hits: { type: 'array', items: { type: 'object', properties: {
+    url: { type: 'string' }, title: { type: 'string' },
+    state: { type: 'string' }, relevance: { type: 'string' } },
+    required: ['url', 'title', 'state', 'relevance'] } },
+  wave1Overlap: { type: 'string', description: 'overlap with OUR prior reports incl. by-catches, or "none"' },
+  searchedTerms: { type: 'string' } },
+  required: ['duplicateFound', 'hits', 'wave1Overlap', 'searchedTerms'] }
+
+const PRIOR = `Our prior filed reports (fetch bodies via glab api
+"projects/<id>/issues/<iid>" and check overlap INCLUDING by-catch findings):
+- <project> issues <iids> (<one-line topic each>)`
+
+const results = await pipeline(CANDIDATES, async (item) => {
+  const [verify, search] = await parallel([
+    () => agent(
+      `You verify a candidate upstream bug. ${GLAB}\n\nBaseline: observed at
+"${item.observed_version}". Is the flaw STILL PRESENT at default-branch HEAD
+and the latest tag? Quote exact current content. Superseded line =>
+obsolete-version. Claim wrong on inspection => claim-invalid.\n\n## ${item.id}
+(${item.slug})\nTargets: ${item.targets.join(' ; ')}\n\n${item.claim}\n\nRaw
+data for a machine.`,
+      { label: `verify:${item.id}`, phase: 'Verify', schema: VERIFY_SCHEMA }),
+    () => agent(
+      `You check whether a bug was ALREADY reported. ${GLAB}\n\n${PRIOR}\n\n
+Search target project(s) + group-wide (issues+MRs, state=all, several
+phrasings incl. exact error strings), then judge overlap with our prior
+reports.\n\n## ${item.id}\nBug: ${item.claim}\n\nRaw data for a machine.`,
+      { label: `search:${item.id}`, phase: 'Search', schema: SEARCH_SCHEMA }),
+  ])
+  if (!verify || !search) return { id: item.id, disposition: 'agent-error' }
+
+  // Gate precedence: duplicate kills regardless of verdict; could-not-verify never files.
+  const passes = ['still-present', 'partially-fixed'].includes(verify.verdict)
+    && search.duplicateFound === 'no'
+  if (!passes) {
+    const why = search.duplicateFound !== 'no'
+      ? `duplicate: ${search.wave1Overlap}` : verify.verdict
+    log(`${item.id} gated out: ${why}`)
+    return { id: item.id, slug: item.slug, disposition: why, verify, search }
+  }
+
+  const draft = await agent(
+    `Draft an upstream issue per the house template (read 1-2 prior examples
+in ${DIR}). Target: ${verify.targetProject}. Claim: ${item.claim}\nVerified
+evidence (pin blob links to these refs):\n${verify.evidence}\nChecked:
+${verify.checkedRefs}\nNotes: ${verify.notes}\nMine real error output from
+PRs ${JSON.stringify(item.evidence_prs)} via gh pr view <n> --json body.
+Write to ${DIR}/${item.id}-${item.slug}.md.`,
+    { label: `draft:${item.id}`, phase: 'Draft',
+      schema: { type: 'object', properties: { path: { type: 'string' },
+        title: { type: 'string' }, targetProject: { type: 'string' } },
+        required: ['path', 'title', 'targetProject'] } })
+  if (!draft) return { id: item.id, disposition: 'draft-failed', verify, search }
+
+  // Cold-read gate (see agent-patterns-plugin:cold-read-gate)
+  let cold = await agent(
+    `You are an upstream maintainer triaging a newly filed issue. NO context
+beyond the text. Read ONLY ${draft.path}. QUESTIONS / HESITATIONS / verdict.
+Ignore the top HTML comments (stripped before filing); the issue is filed on
+the target project's own tracker.`,
+    { label: `coldread:${item.id}`, phase: 'ColdRead', model: 'haiku',
+      schema: { type: 'object', properties: {
+        verdict: { type: 'string', enum: ['clear', 'needs-revision'] },
+        critique: { type: 'string' } }, required: ['verdict', 'critique'] } })
+  if (cold?.verdict === 'needs-revision') {
+    await agent(
+      `Revise ${draft.path} in place per this critique. Apply only GENUINE
+gaps (links, jargon, evidence, single-fix); ignore test artifacts (HTML
+comments, implicit repo).\n\n${cold.critique}`,
+      { label: `revise:${item.id}`, phase: 'Revise',
+        schema: { type: 'object', properties: { summaryOfChanges:
+          { type: 'string' } }, required: ['summaryOfChanges'] } })
+    cold = await agent(/* one re-read, same coldread prompt */)
+  }
+  return { id: item.id, slug: item.slug, disposition: 'file',
+    draftPath: draft.path, title: draft.title,
+    targetProject: draft.targetProject, verify, search }
+})
+return results.filter(Boolean)
+```
+
+## Phase 3 — Paced filing script
+
+Generated from the result JSON's `disposition: 'file'` entries; run with
+Bash `run_in_background: true`.
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+export GITLAB_HOST=<instance>
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+declare -A TARGETS=(
+  [<draft-file>.md]="<group/project>"
+  # ... one line per gate-passing draft
+)
+
+for f in <draft files in order>; do
+  repo="${TARGETS[$f]}"
+  title="$(sed -n 's/^# //p;/^# /q' "$DIR/$f" | head -1)"   # first heading
+  body="$(sed '1d' "$DIR/$f" | grep -v '^<!--')"            # strip title + HTML comments
+  echo "==> $f -> $repo"
+  ok=""
+  for attempt in 1 2 3 4; do
+    if url="$(glab issue create -R "$repo" -t "$title" -d "$body" -y 2>&1 | tail -1)" \
+       && [[ "$url" == https://* ]]; then
+      echo "    filed: $url"; echo "$f -> $url" >> "$DIR/filed-urls.txt"; ok=1; break
+    fi
+    echo "    attempt $attempt failed, backing off 130s: $url"; sleep 130
+  done
+  [ -z "$ok" ] && echo "$f -> FAILED" >> "$DIR/filed-urls.txt"   # continue, don't abort
+  sleep 70
+done
+```
+
+Created GitLab issues may surface as `/-/work_items/<n>` URLs; the issues API
+addresses them by the same iid (`projects/<id>/issues/<iid>`). Cross-link
+related issues afterwards via
+`glab api -X POST "projects/<id>/issues/<iid>/notes" -f body="..."` (paced).
+
+## Phase 4 — Bookkeeping targets
+
+Generic shapes; adapt to the project's systems:
+
+- **Source docs**: append the disposition to each originating claim
+  (filed URL / "fixed upstream in vX" / "claim invalid: <what was true>"),
+  in the same repo, via a normal docs PR.
+- **Tracking issue**: post the disposition table as a comment on whatever
+  issue tracks "file these upstream"; close it when nothing known remains.
+- **Follow-up tasks**: fixed-upstream discoveries become tasks in the
+  project's task system (taskwarrior, GitHub issues, …): retire the fork,
+  advance the pin, delete the workaround.
+
+## Observed gotchas
+
+- `Workflow` args may arrive as a JSON **string** — parse defensively.
+- Verify agents must check both HEAD **and** the latest tag: HEAD-only
+  misses "fixed on main, broken in every release" and vice versa.
+- The search agent must fetch your prior reports' **full bodies** — by-catch
+  findings buried inside them are the duplicates you'll miss otherwise.
+- Expect framing corrections from verification (the bug is real but your
+  mechanism was wrong) — let the draft cite the *corrected* mechanism.

--- a/workflow-orchestration-plugin/skills/workflow-verify-before-filing/SKILL.md
+++ b/workflow-orchestration-plugin/skills/workflow-verify-before-filing/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: workflow-verify-before-filing
+description: Verify accumulated bug claims against upstream HEAD and dedup against trackers before filing issues - verify, draft, cold-read, paced filing, bookkeeping. Use when filing upstream reports from backlogs, audit docs, or git-history findings.
+allowed-tools: Agent, Read, Write, Edit, Bash(glab *), Bash(gh *), TodoWrite
+model: opus
+created: 2026-06-11
+modified: 2026-06-11
+reviewed: 2026-06-11
+---
+
+# Verify Before Filing
+
+A backlog of upstream bug candidates — audit docs, "file this later" notes,
+workaround commits — is a list of **hypotheses dated to when they were
+observed**, not a filing queue. Upstream moved since: versions shipped, files
+restructured, other deployers reported the same thing, and some of your own
+diagnoses were wrong. Filing the backlog as-is produces duplicate and
+already-fixed reports — exactly the noise that makes maintainers stop reading
+your issues. **Verify every claim at upstream HEAD, dedup against the
+trackers (including your own earlier reports), and only file what survives.**
+
+Measured base rate (FVH → SIMPL-Open, 2026-06-11): of 24 accumulated
+candidates, **only 12 were real-and-current** — 7 claims were invalid on
+inspection, 3 were already fixed upstream, 1 was obsolete, 1 duplicated our
+own earlier report's by-catch. Half the backlog would have been noise.
+
+## When to Use This Skill
+
+| Use this skill when... | Skip when... |
+|---|---|
+| Filing N accumulated candidates from docs/backlogs/git history | You just hit the bug minutes ago against current HEAD |
+| The observations are days-to-months old | Single trivially-checkable item — verify inline, then file |
+| Claims came from audit docs nobody re-checked | |
+| You've filed on this upstream before (self-dup risk) | |
+
+## The Pipeline
+
+### Phase 0 — Consolidate a candidate manifest
+
+One JSON/table entry per candidate: id, the **claim** (precise, falsifiable),
+target upstream project, version observed, source refs (your commits/PRs that
+hold real error output), and known-filed prior reports to dedup against.
+Merge all sources first — audit docs, strategy docs, and git sweeps usually
+overlap.
+
+### Phase 1 — Verify + dedup (two agents per candidate, parallel)
+
+**Verify agent** (read-only against upstream): fetch the implicated files at
+default-branch HEAD *and* the latest tag; quote the current content; return a
+verdict from a closed vocabulary:
+
+```
+still-present | partially-fixed | fixed-upstream | obsolete-version
+| claim-invalid | could-not-verify
+```
+
+plus `targetProject`, quoted `evidence`, `checkedRefs`, and `notes` (files
+moved, versions drifted, framing corrections). Hard rule: **agents are
+read-only upstream** — GET requests only; nothing writes until the filing
+phase.
+
+**Search agent**: tracker search (issues + MRs, all states, several
+phrasings including exact error strings) on the target project and group-wide
+— **plus fetch the full bodies of your own prior reports** and check overlap
+including their by-catch findings. Self-duplicates are the embarrassing kind.
+
+**Gate**: only `still-present`/`partially-fixed` with no duplicate proceeds.
+Everything else gets a recorded disposition — that record is a deliverable,
+not waste (see Phase 4).
+
+### Phase 2 — Draft to a house template
+
+Per surviving candidate: symptom-first title; evidence as clickable blob
+links **pinned to the verified refs** (not bare paths, not `main` if HEAD
+drifts); the *real* error signature mined from your own incident PRs/logs;
+**exactly one recommended fix** (alternatives get one trailing sentence);
+"happy to open the MR" only when trivial; a one-line context footer naming
+the deployment and verification date. Never leak internal PR numbers or repo
+paths into the body — use them only to mine evidence.
+
+Then gate every draft through
+`agent-patterns-plugin:cold-read-gate` (isolated haiku maintainer cold-read,
+one revise round).
+
+### Phase 3 — Paced filing
+
+Issue-creation endpoints rate-limit aggressively (observed: GitLab 429 after
+~1 create). File from a script with ≥70 s pacing and retry-with-backoff
+(~130 s × 4) on failure; append every created URL to a `filed-urls.txt`
+manifest; cross-link related new issues afterwards (also paced).
+`GITLAB_HOST=<instance> glab issue create -R <project> ...` for GitLab
+instances; `gh` for GitHub. Created GitLab issues may surface as
+`/-/work_items/` URLs.
+
+### Phase 4 — Bookkeeping (the dispositions are deliverables)
+
+- Annotate the **source docs** the candidates came from: filed URL,
+  fixed-upstream (version), duplicate-of, obsolete, or claim-retracted — the
+  audit trail keeps stale claims from being re-filed next quarter.
+- **Fixed-upstream discoveries usually imply local action**: a fork you can
+  retire, a pin you can advance, a workaround you can delete. Record each as
+  a follow-up task.
+- Post the disposition table to your tracking issue; close it if nothing
+  known remains unfiled.
+
+## Verdict Vocabulary Notes
+
+| Verdict | Meaning | Typical doc annotation |
+|---|---|---|
+| `still-present` | Reproduced at HEAD + latest tag | filed URL |
+| `partially-fixed` | Upstream fixed some instances; file the remainder, cite their own fix as the pattern | filed URL (narrowed) |
+| `fixed-upstream` | Shipped in a release — note which | version + local follow-up |
+| `obsolete-version` | The affected line is superseded/retired | superseded note |
+| `claim-invalid` | The original diagnosis was wrong | retraction + what was actually true |
+| `could-not-verify` | Evidence unreachable | human follow-up task |
+
+`claim-invalid` is not failure — it's the workflow catching your own docs
+drifting from reality. Correct the doc in the same pass.
+
+## Common Mistakes
+
+| Mistake | Correct approach |
+|---|---|
+| Filing the backlog as written ("the audit already verified it") | The audit verified it *then*; verify at HEAD *now* |
+| Dedup against the tracker but not your own issues | Your earlier reports' by-catch findings are duplicates too |
+| Quoting your old observed version in the issue | Quote HEAD/latest-tag content; cite the refs you checked |
+| Bulk-creating issues in a loop with no pacing | 429 after the first create; ≥70 s pacing + backoff |
+| Discarding gated-out candidates silently | Dispositions update docs, retire forks, close tracking issues |
+| Letting verify agents have write access upstream | Read-only until the dedicated, paced filing step |
+
+## Related
+
+- `agent-patterns-plugin:cold-read-gate` — the pre-publish legibility gate
+  (Phase 2)
+- `agent-patterns-plugin:verify-before-plan` — same epistemics one level up:
+  premises decay; check before acting on them
+- [`workflow-preflight`](../workflow-preflight/SKILL.md) — remote-state
+  verification before implementation work, the in-repo sibling
+- User rule `verify-upstream-before-patching` (where present) — the
+  single-item inline form of Phase 1

--- a/workflow-orchestration-plugin/skills/workflow-verify-before-filing/SKILL.md
+++ b/workflow-orchestration-plugin/skills/workflow-verify-before-filing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-verify-before-filing
-description: Verify accumulated bug claims against upstream HEAD and dedup against trackers before filing issues - verify, draft, cold-read, paced filing, bookkeeping. Use when filing upstream reports from backlogs, audit docs, or git-history findings.
+description: Verify accumulated bug claims at upstream HEAD and dedup against trackers before filing issues. Use when filing upstream reports from backlogs, audit docs, or git-history findings.
 allowed-tools: Agent, Read, Write, Edit, Bash(glab *), Bash(gh *), TodoWrite
 model: opus
 created: 2026-06-11

--- a/workflow-orchestration-plugin/skills/workflow-verify-before-filing/SKILL.md
+++ b/workflow-orchestration-plugin/skills/workflow-verify-before-filing/SKILL.md
@@ -10,6 +10,10 @@ reviewed: 2026-06-11
 
 # Verify Before Filing
 
+> Operational scaffolding — the complete Workflow script skeleton (agent
+> prompts, schemas, gate logic), the paced filing script, and the data flow —
+> lives in [REFERENCE.md](REFERENCE.md). This file is the decision layer.
+
 A backlog of upstream bug candidates — audit docs, "file this later" notes,
 workaround commits — is a list of **hypotheses dated to when they were
 observed**, not a filing queue. Upstream moved since: versions shipped, files
@@ -41,7 +45,22 @@ One JSON/table entry per candidate: id, the **claim** (precise, falsifiable),
 target upstream project, version observed, source refs (your commits/PRs that
 hold real error output), and known-filed prior reports to dedup against.
 Merge all sources first — audit docs, strategy docs, and git sweeps usually
-overlap.
+overlap. Shape:
+
+```json
+{
+  "id": "W2-13",
+  "slug": "notification-smtp-ec-defaults",
+  "claim": "Chart defaults SMTP to dev@simpl-europe.eu via ssl0.ovh.net (vendor dev infra) as live default values; should be placeholder/required.",
+  "targets": ["group/subgroup/notification-service"],
+  "observed_version": "2.1.1 (Apr 2026)",
+  "sources": ["audit-doc item 6"],
+  "evidence_prs": [1826]
+}
+```
+
+Keep prior-filed report URLs (with issue iids) in the same manifest so search
+agents can fetch their bodies.
 
 ### Phase 1 — Verify + dedup (two agents per candidate, parallel)
 
@@ -57,7 +76,29 @@ still-present | partially-fixed | fixed-upstream | obsolete-version
 plus `targetProject`, quoted `evidence`, `checkedRefs`, and `notes` (files
 moved, versions drifted, framing corrections). Hard rule: **agents are
 read-only upstream** — GET requests only; nothing writes until the filing
-phase.
+phase. State that rule verbatim in every agent prompt.
+
+Verify-agent prompt essentials (condensed):
+
+```
+You verify a candidate upstream bug against <forge>. READ-ONLY — GET only;
+never create/edit/comment upstream.
+Tooling: GITLAB_HOST=<instance> glab api "projects/<id>" (.default_branch),
+".../repository/files/<URL-ENCODED-PATH>/raw?ref=<ref>", ".../repository/tags",
+".../packages" for chart/package versions.
+Baseline: observed at <version, date>. Determine whether the flaw is STILL
+PRESENT at default-branch HEAD and the latest tag. Quote exact current
+content. Superseded version line => obsolete-version. Claim wrong on
+inspection => claim-invalid. Output is raw data for a machine (schema above).
+```
+
+Search-agent prompt adds: issue+MR search (state=all, several phrasings
+including exact error strings), group-wide search fallback, and "fetch the
+full bodies of our prior reports <list> and judge overlap including their
+by-catch findings".
+
+**Gate precedence**: any duplicate kills the filing regardless of verdict;
+`could-not-verify` never files (record a human follow-up task instead).
 
 **Search agent**: tracker search (issues + MRs, all states, several
 phrasings including exact error strings) on the target project and group-wide
@@ -70,24 +111,42 @@ not waste (see Phase 4).
 
 ### Phase 2 — Draft to a house template
 
-Per surviving candidate: symptom-first title; evidence as clickable blob
-links **pinned to the verified refs** (not bare paths, not `main` if HEAD
-drifts); the *real* error signature mined from your own incident PRs/logs;
-**exactly one recommended fix** (alternatives get one trailing sentence);
-"happy to open the MR" only when trivial; a one-line context footer naming
-the deployment and verification date. Never leak internal PR numbers or repo
-paths into the body — use them only to mine evidence.
+Per surviving candidate, one markdown file per issue:
 
-Then gate every draft through
-`agent-patterns-plugin:cold-read-gate` (isolated haiku maintainer cold-read,
-one revise round).
+```markdown
+# <symptom-first title — becomes the issue title>
+<!-- target: <project path>  (stripped by the filing script) -->
+
+## Summary
+<claim, with evidence as blob links PINNED to the verified refs
+(https://<forge>/<path>/-/blob/<ref>/<file>#L<n>) — not bare paths,
+not `main` if HEAD drifts>
+
+<real error signature mined from your own incident PRs/logs>
+
+## Suggested fix
+<EXACTLY ONE recommended fix; alternatives get one trailing sentence;
+"happy to open the MR" only when trivial>
+
+---
+Observed while <one-line deployment context>; verified against <refs> on <date>.
+```
+
+Never leak internal PR numbers or repo paths into the body — use them only to
+mine evidence. Then gate every draft through
+`agent-patterns-plugin:cold-read-gate` (isolated haiku maintainer cold-read;
+one revise round, re-gate only if the verdict was `needs-revision`).
 
 ### Phase 3 — Paced filing
 
-Issue-creation endpoints rate-limit aggressively (observed: GitLab 429 after
-~1 create). File from a script with ≥70 s pacing and retry-with-backoff
-(~130 s × 4) on failure; append every created URL to a `filed-urls.txt`
-manifest; cross-link related new issues afterwards (also paced).
+Issue-creation endpoints rate-limit aggressively (observed: a GitLab
+instance returning 429 after a single create; treat the numbers below as a
+starting point, not a spec). File from a script with ≥70 s pacing between
+creates and, on failure, up to 4 retries with ~130 s backoff each; append
+every created URL to a `filed-urls.txt` manifest, and record `FAILED` lines
+for anything that exhausts retries — continue past failures and report them
+at the end rather than aborting the batch. Cross-link related new issues
+afterwards (also paced).
 `GITLAB_HOST=<instance> glab issue create -R <project> ...` for GitLab
 instances; `gh` for GitHub. Created GitLab issues may surface as
 `/-/work_items/` URLs.


### PR DESCRIPTION
## What

Two new skills distilled from the 2026-06-11 SIMPL-Open upstream filing session:

**`agent-patterns-plugin:cold-read-gate`** — gate outward-bound text (upstream issues, docs, PR bodies) through an isolated **haiku** fresh-reader critique before publishing. The reader is deliberately weak, isolated, and shown only the artifact: it *measures* whether a zero-context audience can act on the text. Covers the QUESTIONS/HESITATIONS/verdict prompt, the genuine-gap vs test-artifact triage table, the one-revise-round loop, and Workflow-script schema integration.

**`workflow-orchestration-plugin:workflow-verify-before-filing`** — the filing pipeline around it: candidate manifest → verify every claim at upstream HEAD + latest tag → dedup against trackers *and your own prior reports* → gate → house-template drafting → cold-read gate → paced rate-limit-aware filing → disposition bookkeeping back into the source docs.

## Why

Measured base rates from the motivating session:
- Of **24 accumulated upstream candidates, only 12 were real-and-current** (7 claims invalid on inspection, 3 already fixed upstream, 1 obsolete, 1 duplicate of our own earlier report's by-catch) — verification prevented 12 noise filings.
- The cold-read gate caught real defects across 12 drafts + 5 docs (unreconciled headline numbers, undefined role names, missing stack identification, three-option fix sections); the filed issues drew zero clarification round-trips.

Companion change (separate repo): the dotfiles' `agent-and-tool-selection.md` always-Opus rule now carries a sanctioned-exception section for cold-read haiku readers, so future sessions don't "fix" them to Opus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)