### PR TITLE
feat(evaluate-plugin): adopt RHO verify and best-of-N patterns

### DIFF
--- a/.claude/rules/skill-evaluation.md
+++ b/.claude/rules/skill-evaluation.md
@@ -78,6 +78,7 @@ Tier 0/1.
 | Situation | Tier to run |
 |-----------|-------------|
 | Authoring or editing a skill | Tier 0 (always) + Tier 1 if it has `evals.json` |
+| Improving a skill that has `evals.json` | Tier 1 best-of-N: `/evaluate:improve --apply --best-of 3` ranks candidate edits by re-running the deterministic evals and applies the winner |
 | Adding a skill to the golden set | Write its `evals.json` with typed checks |
 | A new Claude model is released | Tier 2 sweep of the golden set; diff deltas vs last run |
 | A skill feels redundant or noisy | Tier 2 with `--baseline` to see if it beats the model alone |

--- a/evaluate-plugin/README.md
+++ b/evaluate-plugin/README.md
@@ -64,7 +64,14 @@ Static compliance checks (`plugin-compliance-check.sh`) verify structure — thi
 ```
 /evaluate:improve git-plugin/git-commit
 /evaluate:improve git-plugin/git-commit --apply
+/evaluate:improve git-plugin/git-commit --apply --best-of 3
 ```
+
+With `--best-of N`, the skill drafts N alternative revisions instead of one,
+ranks them by re-running the skill's evals against each candidate (deterministic
+grading via `grade_deterministic.py`; `eval-comparator` blind pairwise as
+tie-break or as the fallback when no `evals.json` exists), and applies the
+winner. The ranking is recorded in `history.json`.
 
 ## Data Layout
 
@@ -75,6 +82,8 @@ Static compliance checks (`plugin-compliance-check.sh`) verify structure — thi
 └── eval-results/           # Gitignored: run outputs
     ├── benchmark.json
     ├── history.json
+    ├── candidates/         # --best-of candidate revisions
+    │   └── candidate-<i>.md
     └── runs/
         └── <eval-id>-<run-id>/
             ├── grading.json

--- a/evaluate-plugin/skills/evaluate-improve/SKILL.md
+++ b/evaluate-plugin/skills/evaluate-improve/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: evaluate-improve
 description: Suggest improvements to SKILL.md content, descriptions, or tool config from eval results. Use when raising pass rates, fixing triggering, or iterating on a skill after evaluation.
-args: <plugin/skill-name> [--apply] [--description-only]
-allowed-tools: Task, Read, Write, Edit, Glob, Grep, Bash(cat *), Bash(jq *), Bash(find *), Bash(diff *), AskUserQuestion, TodoWrite
-argument-hint: "git-plugin/git-commit [--apply]"
+args: <plugin/skill-name> [--apply] [--description-only] [--best-of N]
+allowed-tools: Task, Read, Write, Edit, Glob, Grep, Bash(bash *), Bash(python3 *), Bash(cat *), Bash(jq *), Bash(find *), Bash(diff *), AskUserQuestion, TodoWrite
+argument-hint: "git-plugin/git-commit [--apply] [--best-of 3]"
 created: 2026-03-04
-modified: 2026-05-09
+modified: 2026-06-11
 reviewed: 2026-03-04
 ---
 
@@ -31,6 +31,7 @@ Parse these from `$ARGUMENTS`:
 | `<plugin/skill-name>` | required | Path as `plugin-name/skill-name` |
 | `--apply` | false | Apply approved changes to SKILL.md |
 | `--description-only` | false | Focus on description improvements only |
+| `--best-of N` | 1 | Generate N candidate revisions and apply the eval-ranked winner (requires `--apply`) |
 
 ## Execution
 
@@ -113,10 +114,55 @@ Which improvements should I apply?
 [ ] Restructure flag reference
 ```
 
+If `--best-of N` with N > 1, follow Step 5a to pick the winning revision
+first, then continue with the apply flow below using the winner's content.
+
 For each approved suggestion:
 1. Read the current SKILL.md
 2. Apply the change using Edit
 3. Update the `modified` date in frontmatter
+
+### Step 5a: Generate and rank candidates (if --best-of N > 1)
+
+Instead of drafting the approved edits once, generate N alternative drafts and
+let evaluation pick the winner.
+
+1. **Generate candidates.** Write N complete candidate revisions of the
+   SKILL.md to `<plugin>/skills/<skill>/eval-results/candidates/candidate-<i>.md`
+   (the `eval-results/` tree is gitignored). Each candidate implements the
+   approved suggestions with a genuinely different strategy — different
+   instruction placement, phrasing, or example choice — not paraphrases of one
+   draft.
+
+2. **Rank with real grading when evals exist.** If the skill has `evals.json`:
+   - For each candidate, run one pass per eval case: spawn a Task subagent
+     (`subagent_type: general-purpose`) that receives the **candidate**
+     content as the skill context and executes the eval prompt (mirrors
+     `/evaluate:skill` Step 4; use `prepare_run.sh` for the run directories).
+   - Grade each transcript with
+     `python3 evaluate-plugin/scripts/grade_deterministic.py` — typed checks
+     grade for zero judge tokens; defer fuzzy assertions to the `eval-grader`
+     agent.
+   - Rank candidates by mean pass rate. Break ties with the `eval-comparator`
+     agent: blind pairwise comparison of the tied candidates' transcripts.
+
+3. **Fall back to blind self-preference when no evals exist.** Without
+   `evals.json` there are no prompts to roll out. Rank via the
+   `eval-comparator` agent — pairwise, candidates presented as Output A/B,
+   the analyzer's weakness list passed as the assertions. Flag this in the
+   report as a weaker signal and suggest re-running `/evaluate:skill` with
+   `--create-evals` first.
+
+4. **Apply the winner** through the Step 5 apply flow, and record the ranking
+   in the history entry (Step 5b below): a `candidates` array with each
+   candidate's id, pass rate (or comparison score), and a `selected` flag.
+
+Token cost is bounded at N × eval cases × 1 run plus grading; treat `--best-of`
+without a number as N=3. Prefer this mode for skills that have `evals.json` —
+deterministic ranking of real rollouts is the point; text-only self-preference
+is the fallback.
+
+### Step 5b: Record history
 
 After applying changes, update (or create) the history file at:
 ```
@@ -128,6 +174,7 @@ Add a new iteration entry recording:
 - Timestamp
 - Pass rate from current benchmark
 - Summary of changes made
+- Candidate ranking when `--best-of` was used: a `candidates` array of `{id, pass_rate, selected}` (use `comparison_score` instead of `pass_rate` for the no-evals fallback)
 
 ### Step 6: Suggest re-evaluation
 
@@ -152,3 +199,4 @@ Changes applied. Run `/evaluate:skill <plugin/skill-name>` to measure improvemen
 |------|-------------|
 | `--apply` | Apply approved changes to SKILL.md |
 | `--description-only` | Focus on description improvements only |
+| `--best-of N` | Generate N candidate revisions, rank by eval pass rate, apply winner |

--- a/feedback-plugin/README.md
+++ b/feedback-plugin/README.md
@@ -12,7 +12,7 @@ Session feedback analysis — capture per-session skill bugs as GitHub issues, a
 
 | Agent | Description |
 |-------|-------------|
-| `friction-learner` | Parse last week of transcripts, cluster interruptions/hook-blocks/rejections, propose rule/skill/hook fixes, open one PR per target repo |
+| `friction-learner` | Parse last week of transcripts, cluster interruptions/hook-blocks/rejections, propose rule/skill/hook fixes, reproduce-and-verify each fix where safe, open one PR per target repo |
 
 ### Friction learner
 
@@ -37,6 +37,14 @@ python3 feedback-plugin/scripts/friction_open_prs.py \
 ```
 
 Signatures currently recognized: `plan:entered-plan-mode`, `push:branch-has-open-pr`, `hook:pr-metadata`, `hook:branch-protection`, `hook:conventional-commit`, `hook:gitleaks`, `hook:pre-commit`, `error:<tool>:<class>`, `reject:<tool>`, `interrupt:user`.
+
+Before opening a PR, the agent reproduces each actionable failure and runs the
+proposed fix's prescribed substitution where it is safe and read-only (hook
+blocks are safe by construction — the blocked command never executes). Clusters
+that no longer reproduce are downgraded to watch items, and each PR body
+carries a `## Verification` table with one verdict per cluster
+(`REPRODUCED_FIX_VERIFIED` / `REPRODUCED_FIX_UNVERIFIED` / `NOT_REPRODUCED` /
+`NOT_REPRODUCIBLE`).
 
 ## Hooks
 

--- a/feedback-plugin/agents/friction-learner.md
+++ b/feedback-plugin/agents/friction-learner.md
@@ -4,8 +4,9 @@ description: |
   Analyze a week of Claude Code session transcripts to surface recurring friction
   (interruptions, hook blocks, tool-result errors, user rejections) and propose
   concrete rule, skill, or hook changes. Use when you want to convert lived
-  session pain into durable rules — typically on a weekly cadence. Opens one PR
-  per target repo summarizing evidence and proposed edits.
+  session pain into durable rules — typically on a weekly cadence. Reproduces
+  each failure and verifies the prescribed fix where safe before opening one PR
+  per target repo summarizing evidence, verdicts, and proposed edits.
 model: opus
 color: "#E53E3E"
 tools: Bash(python3 *), Bash(jq *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git branch *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(gh pr *), Bash(find *), Read, Write, Edit, Glob, Grep, TodoWrite
@@ -13,7 +14,7 @@ context: fork
 maxTurns: 40
 memory: user
 created: 2026-04-16
-modified: 2026-05-07
+modified: 2026-06-11
 reviewed: 2026-04-28
 ---
 
@@ -43,8 +44,8 @@ The harness blocks several common bash idioms — use the dedicated tool instead
 ## Scope
 
 - **Input**: A time window (default: last 7 days) and a list of target rulesync repos
-- **Output**: One PR per repo with a proposed-rules diff and an evidence summary
-- **Steps**: 6-15 (parse → classify → cluster → propose → render → PR)
+- **Output**: One PR per repo with a proposed-rules diff, an evidence summary, and per-cluster verification verdicts
+- **Steps**: 8-20 (parse → classify → cluster → propose → verify → render → PR)
 - **Value**: Converts recurring session pain into durable guardrails without manual log-reading
 
 ## When to Use
@@ -126,13 +127,62 @@ The same gate applies to any new cluster signature whose underlying cause
 cannot be determined from the cluster shape alone — when in doubt, surface
 samples rather than prescribe.
 
-### Step 4: Render proposed diffs per target repo
+### Step 4: Reproduce and verify (actionable clusters only)
+
+Transcript evidence proves the friction *was* live; it does not prove the
+friction is *still* live, nor that the proposed fix works. Before rendering,
+run a reproduce → verify pass per actionable cluster. Skip `classify-required`
+clusters — they carry no prescribed fix to verify.
+
+**Reproduce** — confirm the failure still fires:
+
+| Cluster kind | Reproduction | Safety |
+|---|---|---|
+| Hook block | Re-issue one representative command shape from the evidence | Safe by construction — a PreToolUse exit-2 block means the command never executes |
+| Tool error on a read-only command (e.g. a `gh pr view --json` field error) | Re-run the failing command | Read-only |
+| Tool error on a mutating command, push failures | Skip — rely on transcript evidence | Mark `NOT_REPRODUCIBLE` |
+
+A cluster that no longer reproduces (hook updated mid-week, CLI fixed, rule
+already landed) is **stale**: downgrade it to a watch item rather than
+proposing a fix for a failure that no longer exists.
+
+**Verify the fix** — confirm the proposal's prescribed substitution works:
+
+1. Extract the exact substitution the draft rule prescribes (the corrected
+   flag, the allowed command form, the replacement tool call).
+2. If it is a read-only command (or a hook-checked git form), run it: it must
+   exit 0 and pass the hook. If the substitution *also* fails, the proposal is
+   wrong — fix the proposal before rendering, or downgrade to watch.
+3. If the fix landed as a regression-check script (see
+   `.claude/rules/regression-testing.md`), running that script **is** the
+   verification.
+4. Verify mutating substitutions by inspection only — record `FIX_UNVERIFIED`.
+
+Only run reproductions and verifications whose command shape matches your tool
+allowlist (`python3`, `jq`, `git status/diff/log/branch`, `gh pr`, `find`).
+Anything else is `NOT_REPRODUCIBLE` — never request broader permissions for
+verification.
+
+Record one verdict per cluster:
+
+| Verdict | Meaning | Effect |
+|---|---|---|
+| `REPRODUCED_FIX_VERIFIED` | Failure re-fired; substitution ran clean | Strongest proposal — render as-is |
+| `REPRODUCED_FIX_UNVERIFIED` | Failure re-fired; fix verified by inspection only | Render; note in PR body |
+| `NOT_REPRODUCED` | Failure no longer fires | Downgrade to watch item |
+| `NOT_REPRODUCIBLE` | Unsafe or outside allowlist to re-run | Render on transcript evidence alone |
+
+### Step 5: Render proposed diffs per target repo
 
 Cluster output (`/tmp/clusters.json`) already carries one `path` + `body` per
 actionable cluster, produced by `friction_cluster.py`. Evidence blocks are
 redacted at parse time.
 
-### Step 5: Open one PR per repo
+Append a `## Verification` section to the PR body (`/tmp/pr-body.md`): one row
+per cluster with its signature, verdict, and the reproduction/verification
+command that was run (redacted per the Guardrails).
+
+### Step 6: Open one PR per repo
 
 Delegate to the shipped helper, which clones each target repo, writes the
 proposals, branches, commits, pushes, and opens a draft PR:
@@ -151,20 +201,20 @@ updates the existing PR instead of opening a new one. It also enforces the
 quiet-window guardrail (`--min-total-events`, default 5) and always creates
 drafts — PRs are never auto-merged.
 
-### Step 6: Report summary to main session
+### Step 7: Report summary to main session
 
-Print a table: cluster → count → deliverable → PR URL.
+Print a table: cluster → count → verdict → deliverable → PR URL.
 
 ## Output Format
 
 ```
 ## Friction Report: 2026-W15 (last 7 days)
 
-| Cluster | Count | Deliverable | PR |
-|---|---|---|---|
-| plan-mode-on-qa | 5 | rule edit | #123 |
-| push-to-branch-with-open-pr | 4 | hook + rule | #124 |
-| gh-api-in-context | 3 | skill patch | #125 |
+| Cluster | Count | Verdict | Deliverable | PR |
+|---|---|---|---|---|
+| plan-mode-on-qa | 5 | classify-required | needs human classification | #123 |
+| push-to-branch-with-open-pr | 4 | NOT_REPRODUCIBLE | hook + rule | #124 |
+| gh-api-in-context | 3 | REPRODUCED_FIX_VERIFIED | skill patch | #125 |
 
 Sessions analyzed: 14
 Friction events: 42
@@ -174,6 +224,7 @@ Clusters found: 7 (3 actionable)
 ## Guardrails
 
 - **Never auto-merge**. The agent only opens the PR; a human reviews evidence.
+- **Verification is read-only**. Never execute a mutating command to reproduce or verify a fix; hook-block reproductions rely on the hook's exit-2 preventing execution. Stay within the tool allowlist — outside it, record `NOT_REPRODUCIBLE`.
 - **Redact**. Strip absolute paths from `$HOME` downwards, and any token-looking strings matching `[A-Za-z0-9_-]{32,}`, before embedding evidence in PR bodies.
 - **Quiet windows**. If fewer than 5 friction events total, print the report to stdout and do NOT open a PR.
 - **Min-count gate**. Default `--min-count 3`. Clusters below the threshold are listed as "watch" items only.


### PR DESCRIPTION
## What

Adopts two mechanisms from **Retrospective Harness Optimization** ([arXiv:2606.05922](https://arxiv.org/abs/2606.05922), "Evolving Agents in the Dark") that our existing self-improvement pipeline lacked. The paper improves agent harnesses from unlabeled past trajectories via (1) re-executing failing tasks before generating fixes and (2) generating multiple candidate harness edits and ranking them.

### 1. `feedback-plugin`: reproduce-and-verify loop in `friction-learner`

The friction pipeline previously went straight from static transcript evidence to a proposed rule — nothing confirmed the failure was still live or that the fix worked before the PR opened. The agent now:

- **Reproduces** each actionable failure where safe: hook blocks are safe by construction (PreToolUse exit-2 means the command never executes); read-only tool errors are re-run; mutating commands are skipped (`NOT_REPRODUCIBLE`).
- **Verifies the fix** by running the proposed rule's prescribed substitution (read-only / hook-checked forms only); a regression-check script, where one exists, *is* the verification.
- **Downgrades stale clusters** that no longer reproduce to watch items.
- **Reports verdicts** (`REPRODUCED_FIX_VERIFIED` / `REPRODUCED_FIX_UNVERIFIED` / `NOT_REPRODUCED` / `NOT_REPRODUCIBLE`) in a `## Verification` table in each friction PR body.

Verification stays strictly within the agent's existing tool allowlist — no new tool grants, never mutating.

### 2. `evaluate-plugin`: `--best-of N` candidate ranking in `/evaluate:improve`

The improve skill previously drafted a single edit per approved suggestion. With `--best-of N` it now generates N genuinely different candidate revisions and applies the eval-ranked winner:

- **With `evals.json`**: each candidate is rolled out against the eval cases and graded with `grade_deterministic.py` (typed checks = zero judge tokens); `eval-comparator` blind pairwise breaks ties.
- **Without `evals.json`**: falls back to the paper's pairwise self-preference via `eval-comparator`, explicitly flagged as a weaker signal.
- Rankings land in `history.json`; candidates live under the gitignored `eval-results/candidates/`.

This deliberately *strengthens* the paper's method: real grading ranks candidates whenever assertions exist, with self-preference only as fallback. The human gates (AskUserQuestion approval, draft-only friction PRs) are kept — the paper's fully-unsupervised deployment step is intentionally not adopted.

## Files

- `feedback-plugin/agents/friction-learner.md` — new Step 4 (reproduce/verify), verdict table, guardrail
- `feedback-plugin/README.md` — verification behaviour documented
- `evaluate-plugin/skills/evaluate-improve/SKILL.md` — `--best-of N` flag, Steps 5a/5b
- `evaluate-plugin/README.md` — usage example, data layout
- `.claude/rules/skill-evaluation.md` — best-of-N row in the "When to apply this" table

## Verification

- `scripts/plugin-compliance-check.sh evaluate-plugin feedback-plugin` — ✅ (pre-existing size WARN on untouched `feedback-session`)
- `scripts/check-agent-tool-selection.sh` — ✅ all 21 agents

https://claude.ai/code/session_01L5KyoTheNQ37V3yecLiwj5

---
_Generated by [Claude Code](https://claude.ai/code/session_01L5KyoTheNQ37V3yecLiwj5)_