### PR TITLE
fix(hooks-plugin): scope git-commit heredoc reminder to actual git commit/tag

### DIFF
--- a/hooks-plugin/hooks/bash-antipatterns.sh
+++ b/hooks-plugin/hooks/bash-antipatterns.sh
@@ -105,9 +105,17 @@ fi
 
 # Check for commit message being written to temp file
 # Pattern: cat > /tmp/commit_msg.txt or similar, often with heredoc containing conventional commit
-if echo "$COMMAND" | grep -Eq 'cat\s*>\s*[^|]*commit' || \
-   echo "$COMMAND" | grep -Eq "(cat|echo|printf)\s*>\s*/tmp/.*<<.*EOF" && \
-   echo "$COMMAND" | grep -Eq '(feat|fix|docs|refactor|test|chore|perf|ci)(\(.+\))?[!:]'; then
+#
+# Gate on an actual `git commit` / `git tag` in the command. Otherwise a PR or
+# issue body written to a temp file and passed to `gh pr create --body-file` /
+# `gh issue edit --body-file` — the recommended multi-line-body pattern — falsely
+# triggered this git-commit-specific reminder, which is irrelevant to the blocked
+# command (issue #1584, #1587). The reminder only makes sense when the command
+# is in fact composing a git commit/tag message.
+if echo "$COMMAND" | grep -Eq 'git\s+(commit|tag)\b' && \
+   echo "$COMMAND" | grep -Eq '(feat|fix|docs|refactor|test|chore|perf|ci)(\(.+\))?[!:]' && \
+   { echo "$COMMAND" | grep -Eq 'cat\s*>\s*[^|]*commit' || \
+     echo "$COMMAND" | grep -Eq "(cat|echo|printf)\s*>\s*/tmp/.*<<.*EOF"; }; then
     block "REMINDER: Use HEREDOC directly in git commit:
 
 git commit -m \"\$(cat <<'EOF'
@@ -120,8 +128,14 @@ EOF
 )\""
 fi
 
-# Check for cat > file (writing files)
-if echo "$COMMAND" | grep -Eq 'cat\s*>\s*[^|]'; then
+# Check for cat > file (writing files).
+# Exempt heredoc writes (cat > file <<EOF ... EOF): writing a temp file via a
+# heredoc and feeding it to a later command (e.g. gh pr create --body-file) is
+# the recommended multi-line pattern (copy-paste-commands.md), and the hook's own
+# cat-read message above already states heredocs are allowed (issue #1584, #1587).
+# A plain `cat > file` with no heredoc is still blocked in favour of the Write tool.
+if echo "$COMMAND" | grep -Eq 'cat\s*>\s*[^|]' && \
+   ! echo "$COMMAND" | grep -Eq 'cat\s*>\s*\S.*<<'; then
     block "REMINDER: Use the Write tool instead of 'cat > file' to create files. The Write tool is the proper way to write file contents."
 fi
 

--- a/hooks-plugin/hooks/test-bash-antipatterns.sh
+++ b/hooks-plugin/hooks/test-bash-antipatterns.sh
@@ -193,6 +193,66 @@ assert_exit_complex \
     "plain git add && git commit (outside heredoc) is still blocked" 2 \
     "git add file.txt && git commit -m msg"
 
+# ── heredoc-write-then-feed-CLI regression (issue #1584, #1587) ───────────────
+# Regression: `cat > /tmp/body.md <<EOF ... EOF; gh pr create --body-file ...`
+# was blocked with the git-commit heredoc reminder even though the command runs
+# no git commit at all — the commit-message-to-temp-file detector fired on any
+# heredoc-to-/tmp write containing conventional-commit-shaped text, and the
+# `cat > file` Write-tool block fired on the heredoc write itself. Writing a
+# body file via heredoc and passing it to `gh pr create --body-file` /
+# `gh issue edit --body-file` is the recommended multi-line pattern and must pass.
+echo ""
+echo "heredoc-write-then-feed-CLI is allowed; git-commit message file still nudged:"
+
+prbody_cmd=$(cat <<'OUTER'
+cat > /tmp/pr-body.md <<'EOF'
+## Summary
+
+fix(api): handle timeout edge case
+
+Closes #123
+EOF
+gh pr create --draft --title "fix: x" --body-file /tmp/pr-body.md -a laurigates
+OUTER
+)
+
+assert_exit_complex \
+    "cat > /tmp/body.md heredoc fed to gh pr create --body-file is allowed" 0 \
+    "$prbody_cmd"
+
+issuebody_cmd=$(cat <<'OUTER'
+cat > /tmp/issue-body.md <<'EOF'
+chore(scope): something
+
+docs note here.
+EOF
+gh issue edit 2001 --body-file /tmp/issue-body.md
+OUTER
+)
+
+assert_exit_complex \
+    "cat > /tmp/body.md heredoc fed to gh issue edit --body-file is allowed" 0 \
+    "$issuebody_cmd"
+
+# True positive preserved: a heredoc commit message to /tmp passed to git commit -F
+# still earns the reminder, because the command actually composes a git commit.
+gitcommit_cmd=$(cat <<'OUTER'
+cat > /tmp/commit_msg.txt <<'EOF'
+feat(auth): add OAuth2 support
+EOF
+git commit -F /tmp/commit_msg.txt
+OUTER
+)
+
+assert_exit_complex \
+    "heredoc commit message to /tmp fed to git commit -F is still blocked" 2 \
+    "$gitcommit_cmd"
+
+# Plain `cat > file` with no heredoc is still nudged toward the Write tool.
+assert_exit \
+    "plain cat > file (no heredoc) is still blocked" 2 \
+    "cat > /tmp/scratch.txt"
+
 # ── substitution-format block messages ──────────────────────────────────────
 # Regression: block messages were "REMINDER: Use the X tool instead of Y" —
 # advisory prose without a concrete substitution. W21 friction analysis showed


### PR DESCRIPTION
## What

Fixes a false positive in the `bash-antipatterns` PreToolUse hook (`hooks-plugin/hooks/bash-antipatterns.sh`) that blocked the recommended **write-a-body-file-then-feed-a-CLI** pattern:

```sh
cat > /tmp/pr-body.md <<'BODY'
...
BODY
gh pr create --body-file /tmp/pr-body.md
```

Two detectors fired on this legitimate, `git`-free command:

1. **Commit-message-to-temp-file detector** — surfaced the git-commit HEREDOC reminder for *any* heredoc-to-`/tmp` write containing conventional-commit-shaped text, even with no `git commit` present. The advice ("fold the heredoc into `git commit -m`") is irrelevant and misleading for `gh pr create --body-file`.
2. **`cat > file` Write-tool block** — fired on the heredoc write itself, even though heredoc writes feeding a later command are the recommended multi-line pattern (`copy-paste-commands.md`), and the hook's own cat-read message already states heredocs are allowed.

## Why

`--body-file` is the recommended way to pass multi-line bodies to `gh pr create` / `gh issue edit`. Blocking it pushes toward worse alternatives (giant inline `--body` strings) and costs a Write-tool round-trip each time. (This PR was itself blocked by the *installed* hook while being authored — a live reproduction.)

## How

- Gate the commit-message detector on an actual `git commit` / `git tag` in the command.
- Exempt heredoc writes (`cat > file <<EOF`) from the `cat > file` block.

Preserved true positives: a plain `cat > file` (no heredoc) and a real heredoc commit message fed to `git commit -F` are still nudged.

## Tests

Adds 4 regression tests to `test-bash-antipatterns.sh` (per `.claude/rules/regression-testing.md`):

| Case | Expected |
|------|----------|
| `cat > /tmp/body.md <<EOF … EOF; gh pr create --body-file` | allowed |
| `cat > /tmp/body.md <<EOF … EOF; gh issue edit --body-file` | allowed |
| heredoc commit message to `/tmp` fed to `git commit -F` | still blocked |
| plain `cat > file` (no heredoc) | still blocked |

Full suite: **40 passed, 0 failed**. `shellcheck` and `bash -n` clean.

## Scope note

This is the first issue in a small dependency cluster of `bash-antipatterns` false positives ([#1587](https://github.com/laurigates/claude-plugins/issues/1587), [#1591](https://github.com/laurigates/claude-plugins/issues/1591), [#1592](https://github.com/laurigates/claude-plugins/issues/1592)) plus a separate `secret-protection` issue ([#1580](https://github.com/laurigates/claude-plugins/issues/1580)). It fixes the foundational heredoc/`git commit` scoping that those issues' "bonus" reproductions share, but leaves their independent parts (quoted-string matching, `grep -l/-c` exemption, the deprecated-`TaskOutput` text, the `secret-protection` name gate) to focused follow-up PRs.

Closes #1584

🤖 Generated with [Claude Code](https://claude.com/claude-code)
