### PR TITLE
feat(opencode): add rulesync-based export pipeline for skills and subagents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ secrets.json
 
 # Blueprint work-orders (per-task scratch; may contain sensitive details)
 docs/blueprint/work-orders/
+
+# OpenCode export — reproducible build artifact (run `just export-opencode`)
+dist/

--- a/justfile
+++ b/justfile
@@ -95,3 +95,12 @@ pr-rebase-all:
             echo "FAILED"
         fi
     done
+
+####################
+# OpenCode export
+####################
+
+# Project skills + subagents to OpenCode format via rulesync (output: dist/opencode)
+[group: "opencode"]
+export-opencode *args:
+    ./scripts/export-opencode.sh {{args}}

--- a/scripts/export-opencode.sh
+++ b/scripts/export-opencode.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# export-opencode.sh — project this Claude Code plugin marketplace's skills and
+# subagents into OpenCode format via rulesync (https://github.com/dyoshikawa/rulesync).
+#
+# Source is read-only; output is fully reproducible. Skills convert near-losslessly;
+# subagents convert structurally (rulesync drops model/tools/maxTurns — see
+# docs/opencode-export.md). Hooks are intentionally NOT exported: Claude Code plugin
+# hooks reference ${CLAUDE_PLUGIN_ROOT} scripts that rulesync cannot resolve, and
+# OpenCode has no model-evaluation (prompt) hook. Hooks are hand-ported per-plugin.
+#
+# Source skills keep the compact comma-string `allowed-tools` form; this script
+# normalizes them to YAML lists in its disposable staging copy only (rulesync aborts
+# on the string form). The source tree is never modified.
+#
+# Usage: ./scripts/export-opencode.sh [OUTPUT_DIR]   (default: dist/opencode)
+set -euo pipefail
+
+export_script_dir="$(cd "$(dirname "$0")" && pwd)"
+export_repo_root="$(cd "$export_script_dir/.." && pwd)"
+export_out_dir="${1:-$export_repo_root/dist/opencode}"
+export_rulesync_version="${RULESYNC_VERSION:-8.28.1}"
+export_staging="$(mktemp -d)"
+trap 'rm -rf "$export_staging"' EXIT
+
+echo "=== OPENCODE EXPORT ==="
+echo "SOURCE=$export_repo_root"
+echo "OUTPUT=$export_out_dir"
+echo "RULESYNC=$export_rulesync_version"
+
+mkdir -p "$export_staging/.claude/skills" "$export_staging/.claude/agents"
+
+# 1. Flatten skills into the canonical consumer layout rulesync reads.
+#    Copy the whole skill directory so REFERENCE.md / scripts/ travel with SKILL.md.
+#    Skill directory names are globally unique across plugins (verified), so the flat
+#    namespace is collision-free.
+#    Canonicalize the skill filename to SKILL.md: 45 source skills are named skill.md
+#    (lowercase), which works on case-insensitive macOS but which rulesync matches
+#    case-sensitively — left as-is it copies them verbatim instead of converting. The
+#    temp-rename dance forces the stored case to SKILL.md on a case-insensitive FS too.
+export_skill_count=0
+for export_skill_md in "$export_repo_root"/*-plugin/skills/*/SKILL.md; do
+    [ -f "$export_skill_md" ] || continue
+    export_skill_dir="$(dirname "$export_skill_md")"
+    export_skill_dest="$export_staging/.claude/skills/$(basename "$export_skill_dir")"
+    cp -R "$export_skill_dir" "$export_skill_dest"
+    if [ -e "$export_skill_dest/skill.md" ]; then
+        mv "$export_skill_dest/skill.md" "$export_skill_dest/.skill-canon.tmp"
+        mv "$export_skill_dest/.skill-canon.tmp" "$export_skill_dest/SKILL.md"
+    fi
+    export_skill_count=$((export_skill_count + 1))
+done
+
+# 2. Flatten subagents.
+export_agent_count=0
+for export_agent_md in "$export_repo_root"/*-plugin/agents/*.md; do
+    [ -f "$export_agent_md" ] || continue
+    cp "$export_agent_md" "$export_staging/.claude/agents/"
+    export_agent_count=$((export_agent_count + 1))
+done
+
+echo "STAGED_SKILLS=$export_skill_count"
+echo "STAGED_AGENTS=$export_agent_count"
+
+# 3. Normalize allowed-tools to YAML lists in the staging copy. rulesync's claudecode
+#    importer hard-aborts on the comma-string form; YAML-list is valid Claude Code.
+#    Runs on the disposable staging tree only — source skills stay in the compact form.
+python3 "$export_script_dir/normalize-skill-allowed-tools.py" \
+    "$export_staging/.claude/skills"/*/SKILL.md >/dev/null
+
+# 4. Convert claudecode -> opencode.
+( cd "$export_staging" && bunx "rulesync@${export_rulesync_version}" convert \
+    --from claudecode --to opencode --features skills,subagents --silent )
+
+# 5. Publish the generated .opencode/ tree to the output directory.
+rm -rf "$export_out_dir"
+mkdir -p "$export_out_dir"
+cp -R "$export_staging/.opencode/." "$export_out_dir/"
+
+export_out_skills="$(find "$export_out_dir/skills" -name SKILL.md 2>/dev/null | wc -l | tr -d ' ')"
+export_out_agents="$(find "$export_out_dir/agents" -name '*.md' 2>/dev/null | wc -l | tr -d ' ')"
+echo "OUTPUT_SKILLS=$export_out_skills"
+echo "OUTPUT_AGENTS=$export_out_agents"
+
+if [ "$export_out_skills" -eq "$export_skill_count" ] && [ "$export_out_agents" -eq "$export_agent_count" ]; then
+    echo "STATUS=OK"
+else
+    echo "STATUS=WARN (staged/output counts differ — check rulesync output)"
+fi
+echo "=== END OPENCODE EXPORT ==="

--- a/scripts/normalize-skill-allowed-tools.py
+++ b/scripts/normalize-skill-allowed-tools.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Normalize SKILL.md `allowed-tools`/`disallowed-tools` frontmatter to YAML block lists.
+
+Claude Code accepts a space- or comma-separated string OR a YAML list for these
+fields (https://code.claude.com/docs/en/skills). This repo's house style is the
+compact comma-separated string form, but rulesync's claudecode importer requires
+the YAML list form and hard-aborts otherwise.
+
+`export-opencode.sh` runs this over its disposable staging copy so the source tree
+keeps the compact form (fewer tokens, passes the skill-size lint). It is written to
+be safe to run against the source too, should that policy ever change.
+
+Only the comma-separated string form is rewritten. Tool tokens themselves may
+contain spaces (e.g. `Bash(git status *)`), so the delimiter is the comma. Files
+already in block-list form are left untouched (idempotent).
+
+Usage:
+  normalize-skill-allowed-tools.py [--check] [PATH ...]
+
+  --check   Report files that WOULD change, exit 1 if any. No writes.
+  PATH      SKILL.md files or globs; defaults to */skills/*/SKILL.md under cwd.
+"""
+from __future__ import annotations
+
+import glob
+import re
+import sys
+from pathlib import Path
+
+FIELDS = ("allowed-tools", "disallowed-tools")
+FM_RE = re.compile(r"^(---\n)(.*?\n)(---\n)", re.DOTALL)
+
+
+def normalize_block(fm_body: str) -> tuple[str, bool]:
+    """Rewrite string-form FIELDS in a frontmatter body to YAML block lists."""
+    changed = False
+    out_lines: list[str] = []
+    for line in fm_body.splitlines(keepends=True):
+        m = re.match(r"^(allowed-tools|disallowed-tools):[ \t]*(.*?)[ \t]*\n$", line)
+        if not m:
+            out_lines.append(line)
+            continue
+        key, value = m.group(1), m.group(2)
+        # Empty value => already a YAML block list (items on following lines). Skip.
+        # Bracket value => already an inline array. Skip.
+        if value == "" or value.startswith("["):
+            out_lines.append(line)
+            continue
+        tools = [t.strip() for t in value.split(",") if t.strip()]
+        out_lines.append(f"{key}:\n")
+        out_lines.extend(f"  - {t}\n" for t in tools)
+        changed = True
+    return "".join(out_lines), changed
+
+
+def process(path: Path, check: bool) -> bool:
+    """Return True if the file changed (or would change in --check mode)."""
+    text = path.read_text(encoding="utf-8")
+    m = FM_RE.match(text)
+    if not m:
+        return False
+    new_body, changed = normalize_block(m.group(2))
+    if not changed:
+        return False
+    if not check:
+        new_text = m.group(1) + new_body + m.group(3) + text[m.end():]
+        path.write_text(new_text, encoding="utf-8")
+    return True
+
+
+def main(argv: list[str]) -> int:
+    check = "--check" in argv
+    args = [a for a in argv if a != "--check"]
+    if args:
+        files = [Path(p) for a in args for p in glob.glob(a, recursive=True)]
+    else:
+        files = [Path(p) for p in glob.glob("*-plugin/skills/*/SKILL.md")]
+    changed = [f for f in files if process(f, check)]
+    verb = "would change" if check else "changed"
+    print(f"{verb}: {len(changed)} / {len(files)} SKILL.md files")
+    for f in changed[:10]:
+        print(f"  {verb}: {f}")
+    if len(changed) > 10:
+        print(f"  ... and {len(changed) - 10} more")
+    if check and changed:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## What

Adds a reproducible pipeline that projects this Claude Code plugin marketplace's
**skills (×359)** and **subagents (×21)** into OpenCode format via
[rulesync](https://github.com/dyoshikawa/rulesync).

```
just export-opencode          # -> dist/opencode/{skills,agents}
```

## Why rulesync

OpenCode reads `name`+`description` skill frontmatter natively, so skill bodies
need no rewriting. rulesync converts into OpenCode's real layout
(`.opencode/skills/`, `.opencode/agents/`) and is actively maintained, so the
projection stays a thin build step rather than a bespoke translator.

## How it works

1. Flatten `<plugin>/skills/*` and `<plugin>/agents/*` into a disposable `.claude/`
   staging tree (skill dir-names are globally unique — verified — so the flat
   namespace is collision-free; whole dirs are copied so `REFERENCE.md`/`scripts/`
   travel along).
2. Normalize `allowed-tools` comma-strings → YAML lists **in staging only** —
   rulesync hard-aborts on the string form; YAML-list is valid Claude Code. Source
   keeps the compact form (fewer tokens, passes the skill-size lint).
3. Canonicalize lowercase `skill.md` → `SKILL.md` in staging (rulesync matches
   case-sensitively; see #1606).
4. `rulesync convert --from claudecode --to opencode --features skills,subagents`.
5. Publish to `dist/opencode` (gitignored — reproducible artifact).

## Fidelity

| Layer | Result |
|-------|--------|
| Skills (×359) | Near-lossless — `name`+`description`+body preserved |
| Subagents (×21) | Structural — rulesync conservatively drops `model`/`tools`/`maxTurns` |
| Hooks | **Out of scope** → #1605 (rulesync can't resolve `${CLAUDE_PLUGIN_ROOT}` scripts; OpenCode has no prompt-hook). Hand-port tracked separately. |

## Incidental finding

The build surfaced that **45 skills use a lowercase `skill.md` filename** and
silently fail to load on case-sensitive filesystems — tracked in #1606 (fixed in
PR #1608).

## Test plan

- [x] `just export-opencode` → 359 skills + 21 subagents, `STATUS=OK`, counts match
- [x] All 359 outputs cleanly converted (canonical `name`-first frontmatter)
- [x] Source tree unmodified by a run (staging-only normalization)
- [x] `shellcheck scripts/export-opencode.sh` clean
- [x] `just lint-compliance` unaffected (source untouched)

Refs #1605, #1606

🤖 Generated with [Claude Code](https://claude.com/claude-code)
