### PR TITLE
feat(blueprint-plugin): add structural-change cue PostToolUse hook

### DIFF
--- a/blueprint-plugin/README.md
+++ b/blueprint-plugin/README.md
@@ -441,6 +441,14 @@ renamed, or deleted.
 
 The PRP content quality agent hook runs alongside the structural command hook. The command hook validates structure (confidence >= 7/10, required sections, file references). The agent hook evaluates content quality (specificity of requirements, testability of acceptance criteria, edge case coverage).
 
+### Behavioral Cues (command)
+
+| Hook | Event | Target | Purpose |
+|------|-------|--------|---------|
+| `blueprint-structural-cue.sh` | PostToolUse | `Write` / `Edit` | Once-per-session cue to check blueprint context after an architecture-affecting edit |
+
+Implements the first worked example from [ADR-0017](../docs/adrs/0017-hook-based-behavioral-cues-for-plugin-utilization.md). When an `Edit`/`Write` touches a plugin/marketplace manifest or adds a public-API (`export`/`pub`) line, the hook appends a one-line cue to the tool result suggesting `/blueprint:derive-plans` or `/blueprint:adr-validate`. It is a non-blocking cue, not a gate: it never blocks an edit, and to bound transcript-replay cost it fires **at most once per session** (keyed on `~/.cache/blueprint-structural-cue/<session_id>`). Edits under `docs/adrs/**` and `docs/prds/**` are excluded — the validation hooks above already cover those. Active by default; set `BLUEPRINT_SKIP_HOOKS=1` to disable. Regression test: `hooks/spec/blueprint_structural_cue_spec.sh` (run with `shellspec hooks/spec/`).
+
 ## Installation
 
 ```bash

--- a/blueprint-plugin/hooks.json
+++ b/blueprint-plugin/hooks.json
@@ -172,6 +172,26 @@
           "timeout": 5000
         }
       ]
+    },
+    {
+      "matcher": "Write",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/blueprint-structural-cue.sh",
+          "timeout": 5000
+        }
+      ]
+    },
+    {
+      "matcher": "Edit",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/blueprint-structural-cue.sh",
+          "timeout": 5000
+        }
+      ]
     }
   ],
   "PreCompact": [

--- a/blueprint-plugin/hooks/blueprint-structural-cue.sh
+++ b/blueprint-plugin/hooks/blueprint-structural-cue.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# blueprint-structural-cue.sh — PostToolUse cue for architecture-affecting edits.
+#
+# When an Edit/Write touches a plugin/marketplace manifest or adds a public-API
+# (export) line, this appends a one-line, once-per-session cue to the tool result
+# suggesting a blueprint check. It is a behavioral cue (ADR-0017), not a gate:
+# it never blocks an edit and degrades to silence on any error.
+#
+# Mechanism: PostToolUse hookSpecificOutput.updatedToolOutput replaces the tool
+# result, so the original tool_response is preserved and the cue is appended.
+# Dedup is per session (one cue per session) to bound transcript-replay cost.
+#
+# -e is intentionally omitted: a best-effort cue must never break a tool call.
+set -uo pipefail
+
+# Bypass (shared blueprint-plugin convention).
+if [ "${BLUEPRINT_SKIP_HOOKS:-}" = "1" ]; then
+    exit 0
+fi
+
+INPUT=$(cat)
+
+tool_name=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || echo "")
+file_path=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null || echo "")
+new_string=$(printf '%s' "$INPUT" | jq -r '.tool_input.new_string // empty' 2>/dev/null || echo "")
+content=$(printf '%s' "$INPUT" | jq -r '.tool_input.content // empty' 2>/dev/null || echo "")
+original=$(printf '%s' "$INPUT" | jq -r '.tool_response | if type == "string" then . else tostring end // empty' 2>/dev/null || echo "")
+session_id=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null | tr -cd 'a-zA-Z0-9_-')
+
+# Only Edit/Write carry structural edits.
+case "$tool_name" in
+    Edit|Write) ;;
+    *) exit 0 ;;
+esac
+
+[ -z "$file_path" ] && exit 0
+
+# --- Detection: narrow, start small (ADR-0017 roadmap widens later) ---
+base_name="${file_path##*/}"
+payload="${new_string}
+${content}"
+is_structural=0
+
+# Signal 1: plugin/marketplace manifest.
+case "$file_path" in
+    *.claude-plugin/marketplace.json) is_structural=1 ;;
+esac
+if [ "$base_name" = "plugin.json" ]; then
+    is_structural=1
+fi
+
+# Signal 2: a public-API / export line in the edit payload.
+if [ "$is_structural" -eq 0 ] && \
+    printf '%s' "$payload" | grep -Eq '(export |export default|module\.exports|^[+[:space:]]*pub |def __all__)'; then
+    is_structural=1
+fi
+
+# Deliberately exclude docs/adrs|prds — validate-*-frontmatter.sh +
+# auto-sync-id-registry.sh already cover those; a cue there is redundant.
+case "$file_path" in
+    docs/adrs/*|docs/prds/*|*/docs/adrs/*|*/docs/prds/*) is_structural=0 ;;
+esac
+
+[ "$is_structural" -eq 0 ] && exit 0
+
+# --- Dedup: one cue per session ---
+# BLUEPRINT_STRUCTURAL_CUE_CACHE_DIR is the test seam.
+cache_dir="${BLUEPRINT_STRUCTURAL_CUE_CACHE_DIR:-${HOME}/.cache/blueprint-structural-cue}"
+if [ -n "$session_id" ]; then
+    marker="${cache_dir}/${session_id}"
+    [ -f "$marker" ] && exit 0
+    mkdir -p "$cache_dir" 2>/dev/null || true
+    touch "$marker" 2>/dev/null || true
+fi
+
+cue="Structural change detected (manifest / public API). Consider /blueprint:derive-plans or /blueprint:adr-validate to keep PRDs/ADRs current."
+
+augmented="${original}
+
+[blueprint] ${cue}"
+
+jq -n --arg out "$augmented" '{
+    hookSpecificOutput: {
+        hookEventName: "PostToolUse",
+        updatedToolOutput: $out
+    }
+}'
+
+exit 0

--- a/blueprint-plugin/hooks/spec/blueprint_structural_cue_spec.sh
+++ b/blueprint-plugin/hooks/spec/blueprint_structural_cue_spec.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# ShellSpec tests for blueprint-structural-cue.sh (ADR-0017 behavioral cue).
+
+Describe "blueprint-structural-cue.sh"
+  HOOK_SCRIPT="$SHELLSPEC_PROJECT_ROOT/blueprint-structural-cue.sh"
+
+  setup() {
+    CACHE_DIR=$(mktemp -d)
+    export BLUEPRINT_STRUCTURAL_CUE_CACHE_DIR="$CACHE_DIR"
+  }
+
+  cleanup() {
+    rm -rf "$CACHE_DIR"
+    unset BLUEPRINT_STRUCTURAL_CUE_CACHE_DIR
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  Describe "structural edits fire a cue"
+    It "fires on a plugin.json manifest edit"
+      input='{"tool_name":"Edit","session_id":"s1","tool_input":{"file_path":"foo-plugin/.claude-plugin/plugin.json","new_string":"x"},"tool_response":"File edited successfully"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should include "derive-plans"
+      The output should include "updatedToolOutput"
+    End
+
+    It "fires on a marketplace.json edit"
+      input='{"tool_name":"Edit","session_id":"s2","tool_input":{"file_path":".claude-plugin/marketplace.json","new_string":"x"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should include "adr-validate"
+    End
+
+    It "fires on an export-line write"
+      input='{"tool_name":"Write","session_id":"s3","tool_input":{"file_path":"src/index.ts","content":"export function foo() {}"},"tool_response":"written"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should include "Structural change detected"
+    End
+
+    It "preserves the original tool_response in the output"
+      input='{"tool_name":"Write","session_id":"s4","tool_input":{"file_path":"lib.rs","content":"pub fn bar() {}"},"tool_response":"ORIGINAL-OUTPUT-XYZ"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should include "ORIGINAL-OUTPUT-XYZ"
+    End
+  End
+
+  Describe "non-structural edits stay silent"
+    It "is silent on a trivial README edit"
+      input='{"tool_name":"Edit","session_id":"s5","tool_input":{"file_path":"README.md","new_string":"fixed a typo"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should equal ""
+    End
+
+    It "excludes docs/adrs paths (covered by other blueprint hooks)"
+      input='{"tool_name":"Edit","session_id":"s6","tool_input":{"file_path":"docs/adrs/0001-x.md","new_string":"export note"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should equal ""
+    End
+
+    It "ignores non-Edit/Write tools"
+      input='{"tool_name":"Bash","session_id":"s7","tool_input":{"command":"export FOO=1"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should equal ""
+    End
+  End
+
+  Describe "dedup and bypass"
+    It "fires only once per session"
+      input='{"tool_name":"Edit","session_id":"dup","tool_input":{"file_path":"a/plugin.json","new_string":"x"},"tool_response":"ok"}'
+      # First call sets the per-session marker.
+      echo "$input" | bash "$HOOK_SCRIPT" >/dev/null 2>&1
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should equal ""
+    End
+
+    It "skips when BLUEPRINT_SKIP_HOOKS=1"
+      export BLUEPRINT_SKIP_HOOKS=1
+      input='{"tool_name":"Edit","session_id":"s8","tool_input":{"file_path":"a/plugin.json","new_string":"x"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should equal ""
+    End
+  End
+
+  Describe "graceful edge cases"
+    It "emits without a session_id and does not crash"
+      input='{"tool_name":"Write","tool_input":{"file_path":"lib.rs","content":"pub fn bar() {}"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should include "Structural change detected"
+    End
+  End
+End


### PR DESCRIPTION
## Summary

Implements the first worked example from **ADR-0017** (merged in #1610): a `blueprint-plugin` PostToolUse hook that nudges the model toward blueprint context after architecture-affecting edits. Part of #1599.

A **non-blocking behavioral cue**, not a gate — it never blocks an edit and degrades to silence on any error.

## How it works

- **Trigger:** `Edit`/`Write` whose `file_path` is a `plugin.json` / `.claude-plugin/marketplace.json` manifest, **or** whose payload adds a public-API line (`export`, `export default`, `module.exports`, `pub `, `def __all__`).
- **Excluded:** `docs/adrs/**` and `docs/prds/**` — already covered by the existing `validate-*-frontmatter.sh` + `auto-sync-id-registry.sh` hooks, so a cue there would be redundant.
- **Output:** appends a one-line cue to the tool result via `hookSpecificOutput.updatedToolOutput`, **preserving** the original `tool_response` (the channel *replaces* output, so this is required). `additionalContext` is not valid for PostToolUse.
- **Cost control:** fires **at most once per session**, keyed on `~/.cache/blueprint-structural-cue/<session_id>`, to bound transcript-replay cost (the ADR's token-budget contract).
- **Enablement:** active by default; `BLUEPRINT_SKIP_HOOKS=1` disables it (the plugin's existing bypass convention).

Cue text: *"Structural change detected (manifest / public API). Consider /blueprint:derive-plans or /blueprint:adr-validate to keep PRDs/ADRs current."*

## Files

- **add** `blueprint-plugin/hooks/blueprint-structural-cue.sh` — the hook (`set -uo pipefail`; modeled on `hooks-plugin/hooks/bash-antipatterns-teach.sh`).
- **add** `blueprint-plugin/hooks/spec/blueprint_structural_cue_spec.sh` — shellspec regression coverage.
- **edit** `blueprint-plugin/hooks.json` — wire `Write` + `Edit` PostToolUse entries.
- **edit** `blueprint-plugin/README.md` — "Behavioral Cues" subsection under Hooks.

No `plugin.json` / `marketplace.json` / version edits — release-please bumps on the `feat(blueprint-plugin):` commit.

## Verification

- 8-case bash smoke test (manifest fires, fire-once silent, export fires + preserves original output, trivial silent, excluded-ADR silent, bypass silent, no-session_id graceful, non-Edit/Write silent) — all green.
- `scripts/lint-shell-scripts.sh`: 0 errors / 0 warnings. pre-commit `shellcheck` + secret scan pass. `hooks.json` parses.
- ⚠️ shellspec isn't installed in the sandbox (and isn't run in CI), so the `*_spec.sh` was authored to mirror the existing passing `check_prp_readiness_spec.sh` DSL and validated behaviorally via the bash smoke test rather than executed. Run locally with `shellspec hooks/spec/` from `blueprint-plugin/`.

## Out of scope (ADR-0017 roadmap)

- The cue-registry doc (deferred until a 2nd cue exists).
- The other three mechanisms (poka-yoke pre-write gate, codebase-health routing cue, session-teardown task chaining).
- Widening detection beyond manifests + export lines.

Refs #1599

https://claude.ai/code/session_01CviK9baM61wLFdLcCwuFcY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CviK9baM61wLFdLcCwuFcY)_