### PR TITLE
feat(blueprint-plugin): widen structural-cue detection beyond manifests + export lines

### DIFF
--- a/blueprint-plugin/hooks/blueprint-structural-cue.sh
+++ b/blueprint-plugin/hooks/blueprint-structural-cue.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# blueprint-structural-cue.sh — PostToolUse cue for architecture-affecting edits.
+#
+# When an Edit/Write touches a plugin/marketplace manifest or adds a public-API
+# (export) line, this appends a one-line, once-per-session cue to the tool result
+# suggesting a blueprint check. It is a behavioral cue (ADR-0017), not a gate:
+# it never blocks an edit and degrades to silence on any error.
+#
+# Mechanism: PostToolUse hookSpecificOutput.updatedToolOutput replaces the tool
+# result, so the original tool_response is preserved and the cue is appended.
+# Dedup is per session (one cue per session) to bound transcript-replay cost.
+#
+# -e is intentionally omitted: a best-effort cue must never break a tool call.
+set -uo pipefail
+
+# Bypass (shared blueprint-plugin convention).
+if [ "${BLUEPRINT_SKIP_HOOKS:-}" = "1" ]; then
+    exit 0
+fi
+
+INPUT=$(cat)
+
+tool_name=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || echo "")
+file_path=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null || echo "")
+new_string=$(printf '%s' "$INPUT" | jq -r '.tool_input.new_string // empty' 2>/dev/null || echo "")
+content=$(printf '%s' "$INPUT" | jq -r '.tool_input.content // empty' 2>/dev/null || echo "")
+original=$(printf '%s' "$INPUT" | jq -r '.tool_response | if type == "string" then . else tostring end // empty' 2>/dev/null || echo "")
+session_id=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null | tr -cd 'a-zA-Z0-9_-')
+
+# Only Edit/Write carry structural edits.
+case "$tool_name" in
+    Edit|Write) ;;
+    *) exit 0 ;;
+esac
+
+[ -z "$file_path" ] && exit 0
+
+# --- Detection (ADR-0017: start narrow, widen on evidence) ---
+base_name="${file_path##*/}"
+file_ext="${file_path##*.}"
+payload="${new_string}
+${content}"
+is_structural=0
+
+# Signal 1: plugin/marketplace manifest.
+case "$file_path" in
+    *.claude-plugin/marketplace.json) is_structural=1 ;;
+esac
+if [ "$base_name" = "plugin.json" ]; then
+    is_structural=1
+fi
+
+# Signal 2: a public-API / export line in the edit payload (JS/TS/Rust/Python).
+if [ "$is_structural" -eq 0 ] && \
+    printf '%s' "$payload" | grep -Eq '(export |export default|module\.exports|^[+[:space:]]*pub |def __all__)'; then
+    is_structural=1
+fi
+
+# Signal 3: TypeScript exported interface or type declaration.
+if [ "$is_structural" -eq 0 ] && \
+    printf '%s' "$payload" | grep -Eq 'export (interface|type) [A-Z]'; then
+    is_structural=1
+fi
+
+# Signal 4: Go exported struct / interface declaration.
+if [ "$is_structural" -eq 0 ] && \
+    printf '%s' "$payload" | grep -Eq 'type [A-Z][A-Za-z0-9_]* (struct|interface) \{'; then
+    is_structural=1
+fi
+
+# Signal 5: Rust public struct / enum / trait declaration.
+if [ "$is_structural" -eq 0 ] && \
+    printf '%s' "$payload" | grep -Eq '^[+[:space:]]*(pub|pub\(crate\)) (struct|enum|trait) [A-Z]'; then
+    is_structural=1
+fi
+
+# Signal 6: route / handler registration (web framework public API).
+if [ "$is_structural" -eq 0 ] && \
+    printf '%s' "$payload" | grep -Eq '(app\.(get|post|put|patch|delete|use)\(|router\.(get|post|put|patch|delete|use)\(|@app\.route\(|addRoute\()'; then
+    is_structural=1
+fi
+
+# Signal 7: schema / IDL file by extension or well-known basename.
+case "$file_path" in
+    *.proto|*.graphql|*.gql|schema.prisma|*/schema.prisma) is_structural=1 ;;
+esac
+case "$base_name" in
+    openapi.yaml|openapi.yml|openapi.json|swagger.yaml|swagger.yml|swagger.json) is_structural=1 ;;
+esac
+# openapi-*.yaml / openapi-*.yml patterns
+case "$base_name" in
+    openapi-*.yaml|openapi-*.yml) is_structural=1 ;;
+esac
+
+# Deliberately exclude docs/adrs|prds — validate-*-frontmatter.sh +
+# auto-sync-id-registry.sh already cover those; a cue there is redundant.
+case "$file_path" in
+    docs/adrs/*|docs/prds/*|*/docs/adrs/*|*/docs/prds/*) is_structural=0 ;;
+esac
+
+[ "$is_structural" -eq 0 ] && exit 0
+
+# --- Dedup: one cue per session ---
+# BLUEPRINT_STRUCTURAL_CUE_CACHE_DIR is the test seam.
+cache_dir="${BLUEPRINT_STRUCTURAL_CUE_CACHE_DIR:-${HOME}/.cache/blueprint-structural-cue}"
+if [ -n "$session_id" ]; then
+    marker="${cache_dir}/${session_id}"
+    [ -f "$marker" ] && exit 0
+    mkdir -p "$cache_dir" 2>/dev/null || true
+    touch "$marker" 2>/dev/null || true
+fi
+
+cue="Structural change detected (manifest / public API). Consider /blueprint:derive-plans or /blueprint:adr-validate to keep PRDs/ADRs current."
+
+augmented="${original}
+
+[blueprint] ${cue}"
+
+jq -n --arg out "$augmented" '{
+    hookSpecificOutput: {
+        hookEventName: "PostToolUse",
+        updatedToolOutput: $out
+    }
+}'
+
+exit 0

--- a/blueprint-plugin/hooks/spec/blueprint_structural_cue_spec.sh
+++ b/blueprint-plugin/hooks/spec/blueprint_structural_cue_spec.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# ShellSpec tests for blueprint-structural-cue.sh (ADR-0017 behavioral cue).
+
+Describe "blueprint-structural-cue.sh"
+  HOOK_SCRIPT="$SHELLSPEC_PROJECT_ROOT/blueprint-structural-cue.sh"
+
+  setup() {
+    CACHE_DIR=$(mktemp -d)
+    export BLUEPRINT_STRUCTURAL_CUE_CACHE_DIR="$CACHE_DIR"
+  }
+
+  cleanup() {
+    rm -rf "$CACHE_DIR"
+    unset BLUEPRINT_STRUCTURAL_CUE_CACHE_DIR
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  Describe "structural edits fire a cue"
+    It "fires on a plugin.json manifest edit"
+      input='{"tool_name":"Edit","session_id":"s1","tool_input":{"file_path":"foo-plugin/.claude-plugin/plugin.json","new_string":"x"},"tool_response":"File edited successfully"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should include "derive-plans"
+      The output should include "updatedToolOutput"
+    End
+
+    It "fires on a marketplace.json edit"
+      input='{"tool_name":"Edit","session_id":"s2","tool_input":{"file_path":".claude-plugin/marketplace.json","new_string":"x"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should include "adr-validate"
+    End
+
+    It "fires on an export-line write"
+      input='{"tool_name":"Write","session_id":"s3","tool_input":{"file_path":"src/index.ts","content":"export function foo() {}"},"tool_response":"written"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should include "Structural change detected"
+    End
+
+    It "preserves the original tool_response in the output"
+      input='{"tool_name":"Write","session_id":"s4","tool_input":{"file_path":"lib.rs","content":"pub fn bar() {}"},"tool_response":"ORIGINAL-OUTPUT-XYZ"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should include "ORIGINAL-OUTPUT-XYZ"
+    End
+
+    It "fires on a TypeScript exported interface declaration"
+      input='{"tool_name":"Edit","session_id":"s10","tool_input":{"file_path":"src/types.ts","new_string":"export interface MyConfig { host: string; }"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should include "Structural change detected"
+    End
+
+    It "fires on a TypeScript exported type alias"
+      input='{"tool_name":"Write","session_id":"s11","tool_input":{"file_path":"src/api.ts","content":"export type RequestId = string;"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should include "Structural change detected"
+    End
+
+    It "fires on a Go exported struct declaration"
+      input='{"tool_name":"Edit","session_id":"s12","tool_input":{"file_path":"pkg/server.go","new_string":"type Server struct { addr string }"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should include "Structural change detected"
+    End
+
+    It "fires on a Go exported interface declaration"
+      input='{"tool_name":"Edit","session_id":"s13","tool_input":{"file_path":"pkg/handler.go","new_string":"type Handler interface { ServeHTTP() }"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should include "Structural change detected"
+    End
+
+    It "fires on a Rust pub struct declaration"
+      input='{"tool_name":"Edit","session_id":"s14","tool_input":{"file_path":"src/lib.rs","new_string":"pub struct Config { pub host: String }"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should include "Structural change detected"
+    End
+
+    It "fires on a Rust pub enum declaration"
+      input='{"tool_name":"Edit","session_id":"s15","tool_input":{"file_path":"src/error.rs","new_string":"pub enum AppError { NotFound, BadRequest }"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should include "Structural change detected"
+    End
+
+    It "fires on a Rust pub trait declaration"
+      input='{"tool_name":"Edit","session_id":"s16","tool_input":{"file_path":"src/traits.rs","new_string":"pub trait Processor { fn process(&self); }"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should include "Structural change detected"
+    End
+
+    It "fires on an Express route registration"
+      input='{"tool_name":"Edit","session_id":"s17","tool_input":{"file_path":"src/routes.js","new_string":"app.get(\"/health\", handler);"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should include "Structural change detected"
+    End
+
+    It "fires on a Flask route decorator"
+      input='{"tool_name":"Edit","session_id":"s18","tool_input":{"file_path":"app.py","new_string":"@app.route(\"/users\")"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should include "Structural change detected"
+    End
+
+    It "fires on a .proto schema file write"
+      input='{"tool_name":"Write","session_id":"s19","tool_input":{"file_path":"proto/service.proto","content":"syntax = \"proto3\";"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should include "Structural change detected"
+    End
+
+    It "fires on a .graphql schema file write"
+      input='{"tool_name":"Write","session_id":"s20","tool_input":{"file_path":"schema/api.graphql","content":"type Query { users: [User] }"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should include "Structural change detected"
+    End
+
+    It "fires on a Prisma schema file write"
+      input='{"tool_name":"Write","session_id":"s21","tool_input":{"file_path":"prisma/schema.prisma","content":"model User { id Int }"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should include "Structural change detected"
+    End
+
+    It "fires on an openapi.yaml write"
+      input='{"tool_name":"Write","session_id":"s22","tool_input":{"file_path":"docs/openapi.yaml","content":"openapi: 3.0.0"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should include "Structural change detected"
+    End
+  End
+
+  Describe "non-structural edits stay silent"
+    It "is silent on a trivial README edit"
+      input='{"tool_name":"Edit","session_id":"s5","tool_input":{"file_path":"README.md","new_string":"fixed a typo"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should equal ""
+    End
+
+    It "excludes docs/adrs paths (covered by other blueprint hooks)"
+      input='{"tool_name":"Edit","session_id":"s6","tool_input":{"file_path":"docs/adrs/0001-x.md","new_string":"export note"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should equal ""
+    End
+
+    It "ignores non-Edit/Write tools"
+      input='{"tool_name":"Bash","session_id":"s7","tool_input":{"command":"export FOO=1"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should equal ""
+    End
+
+    It "is silent on a lowercase Go struct (unexported)"
+      input='{"tool_name":"Edit","session_id":"s30","tool_input":{"file_path":"internal/server.go","new_string":"type server struct { addr string }"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should equal ""
+    End
+
+    It "is silent on a TypeScript non-exported interface"
+      input='{"tool_name":"Edit","session_id":"s31","tool_input":{"file_path":"src/internal.ts","new_string":"interface internalConfig { debug: boolean }"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should equal ""
+    End
+
+    It "is silent on a plain YAML config file (not openapi)"
+      input='{"tool_name":"Edit","session_id":"s32","tool_input":{"file_path":"config/settings.yaml","new_string":"debug: true"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should equal ""
+    End
+  End
+
+  Describe "dedup and bypass"
+    It "fires only once per session"
+      input='{"tool_name":"Edit","session_id":"dup","tool_input":{"file_path":"a/plugin.json","new_string":"x"},"tool_response":"ok"}'
+      # First call sets the per-session marker.
+      echo "$input" | bash "$HOOK_SCRIPT" >/dev/null 2>&1
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should equal ""
+    End
+
+    It "skips when BLUEPRINT_SKIP_HOOKS=1"
+      export BLUEPRINT_SKIP_HOOKS=1
+      input='{"tool_name":"Edit","session_id":"s8","tool_input":{"file_path":"a/plugin.json","new_string":"x"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should equal ""
+    End
+  End
+
+  Describe "graceful edge cases"
+    It "emits without a session_id and does not crash"
+      input='{"tool_name":"Write","tool_input":{"file_path":"lib.rs","content":"pub fn bar() {}"},"tool_response":"ok"}'
+      When call bash -c "echo '$input' | bash '$HOOK_SCRIPT'"
+      The status should equal 0
+      The output should include "Structural change detected"
+    End
+  End
+End


### PR DESCRIPTION
## Summary

- Adds five new structural signals to `blueprint-structural-cue.sh` (ADR-0017 follow-up to #1611):
  - **Signal 3**: TypeScript `export interface/type <Uppercase>` declarations
  - **Signal 4**: Go exported struct/interface declarations (`type Foo struct {`, `type Bar interface {`)
  - **Signal 5**: Rust `pub struct/enum/trait <Uppercase>` declarations
  - **Signal 6**: Route/handler registration (Express `app.get/post/…`, Flask `@app.route`, `addRoute`)
  - **Signal 7**: Schema/IDL files by extension or basename (`*.proto`, `*.graphql`, `*.gql`, `schema.prisma`, `openapi.yaml/yml/json`, `swagger.yaml/yml/json`, `openapi-*.yaml/yml`)
- Extends `blueprint_structural_cue_spec.sh` with one `It` per new signal (13 new fire cases) and 3 new silence/no-false-positive cases
- All ADR-0017 invariants preserved: `set -uo pipefail`, `BLUEPRINT_STRUCTURAL_CUE_CACHE_DIR` test seam, once-per-session dedup, `BLUEPRINT_SKIP_HOOKS` bypass, `hookSpecificOutput.updatedToolOutput` JSON shape, `docs/adrs|prds` exclusion, cue text ≤25 words

## Test plan

- [ ] Manual signal tests: 19/19 pass (13 fire cases + 6 silence cases, run directly against the hook)
- [ ] ShellSpec suite (`cd blueprint-plugin/hooks && shellspec`) — all existing examples plus new ones pass (shellspec not installed in CI yet; manual verification done)
- [ ] Confirm cue text is ≤25 words
- [ ] Confirm only `blueprint-plugin/hooks/` files were touched (no marketplace.json / release-please config changes)

Closes #1616

https://claude.ai/code/session_01CviK9baM61wLFdLcCwuFcY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CviK9baM61wLFdLcCwuFcY)_