### PR TITLE
feat(session-plugin): chain taskwarrior state sync into session teardown

### DIFF
--- a/session-plugin/README.md
+++ b/session-plugin/README.md
@@ -15,7 +15,7 @@ Design background: [`docs/session-plugin-workflow.md`](../docs/session-plugin-wo
 |---|---|
 | `session-spinup` | Read-only session-start briefing: open taskwarrior tasks, git state (uncommitted / unpushed / open PRs), optional journal todos |
 | `session-wrap` | End-of-session capture of loose threads to taskwarrior, an optional journal, and GitHub follow-up issues |
-| `session-end` | Orchestrator: one survey, preview which of wrap / distill / feedback qualify, **single confirmation**, then sequence them |
+| `session-end` | Orchestrator: one survey, preview which of wrap / distill / feedback / taskwarrior-sync qualify, **single confirmation**, then sequence them |
 | `session-distill` | Distill session insights into `.claude/rules/`, skill improvements, and justfile recipes (moved from `project-plugin`) |
 
 `session-end` also references `feedback-plugin:feedback-session` by name
@@ -44,7 +44,7 @@ user-local by convention (`agent-patterns-plugin:plugin-settings`).
 | Hook | Event | Behavior |
 |---|---|---|
 | `session-spinup-nudge.sh` | SessionStart (startup/resume) | Injects a one-time context note when open threads exist (dirty tree, unpushed commits, open tasks for the cwd project). Informational only — never blocks |
-| `session-end-nudge.sh` | Stop | Offers `session-plugin:session-end` at most once per session when the user's own messages carry a wind-down phrase. Collapses the former separate wrap + distill nudges (design D4) |
+| `session-end-nudge.sh` | Stop | Offers `session-plugin:session-end` at most once per session when the user's own messages carry a wind-down phrase. Collapses the former separate wrap + distill nudges (design D4). When taskwarrior is on PATH and the project has open/active tasks, the offer also mentions a taskwarrior state-sync pass |
 
 The Stop nudge is deliberately conservative:
 
@@ -57,6 +57,8 @@ The Stop nudge is deliberately conservative:
   races a pending confirmation
 - requires something to capture into (taskwarrior on PATH, or a
   `.claude/rules/` / justfile surface)
+- the taskwarrior open-task query uses `export` (not `list`) so it exits 0
+  on empty and is safe in parallel batches (see `.claude/rules/parallel-safe-queries.md`)
 
 Pre-silence either nudge for a session:
 

--- a/session-plugin/hooks/session-end-nudge.sh
+++ b/session-plugin/hooks/session-end-nudge.sh
@@ -67,8 +67,18 @@ user_turns=${user_turns:-0}
 # test seam — point it at a nonexistent path to simulate "no taskwarrior".
 task_bin="${SESSION_NUDGE_TASK_BIN:-task}"
 has_surface=0
+has_open_tasks=0
 if command -v "$task_bin" >/dev/null 2>&1; then
     has_surface=1
+    # Read-only query for open/active tasks in the current project.
+    # Uses 'export' (not 'list') so it exits 0 on empty — parallel-safe.
+    if [ -n "$cwd" ]; then
+        repo_root_tw=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || echo "$cwd")
+        proj=$(basename "$repo_root_tw")
+        task_count=$("$task_bin" project:"$proj" '(status:pending or +ACTIVE)' export 2>/dev/null \
+            | jq 'length' 2>/dev/null || echo 0)
+        [ "${task_count:-0}" -gt 0 ] && has_open_tasks=1
+    fi
 elif [ -n "$cwd" ] && [ -d "$cwd" ]; then
     repo_root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || echo "$cwd")
     if [ -d "$repo_root/.claude/rules" ] \
@@ -88,6 +98,11 @@ fi
 # the agent produces one more response — an offer, never an execution.
 touch "$state_file"
 
-reason="The user is winding down the session. Briefly offer to run the session-plugin:session-end orchestrator — it surveys the session once, previews which end-of-session passes qualify (session-wrap loose-thread capture, session-distill durable learnings, /feedback:session plugin feedback) and runs only what the user confirms in a single prompt. Offer only — never run it without explicit user confirmation. If nothing follow-up-worthy surfaced this session, acknowledge the wind-down and end."
+task_cue=""
+if [ "$has_open_tasks" = 1 ]; then
+    task_cue=" Also mention a taskwarrior state-sync pass: check which tasks are still open or active (task project:<name> '(status:pending or +ACTIVE)' export | jq '.[]'), offer to mark done / update statuses / add follow-up tasks — use stable UUIDs from 'task +LATEST _get uuid' when referencing specific tasks."
+fi
+
+reason="The user is winding down the session. Briefly offer to run the session-plugin:session-end orchestrator — it surveys the session once, previews which end-of-session passes qualify (session-wrap loose-thread capture, session-distill durable learnings, /feedback:session plugin feedback) and runs only what the user confirms in a single prompt.${task_cue} Offer only — never run it without explicit user confirmation. If nothing follow-up-worthy surfaced this session, acknowledge the wind-down and end."
 
 jq -nc --arg r "$reason" '{decision: "block", reason: $r}'

--- a/session-plugin/hooks/test-session-end-nudge.sh
+++ b/session-plugin/hooks/test-session-end-nudge.sh
@@ -180,6 +180,68 @@ output=$(run_hook_output "sess-happy" "$REPO_WITH_RULES" "$TRANSCRIPT")
 assert_silent "second call in same session is silent" "$output"
 rm -f "$TRANSCRIPT"
 
+# ── taskwarrior state-sync cue ───────────────────────────────────────────────
+echo ""
+echo "taskwarrior state-sync cue (open tasks → sync cue in reason):"
+
+# run_hook_output always injects SESSION_NUDGE_TASK_BIN from the NO_TASK seam;
+# for taskwarrior-specific tests we call the hook directly so we can set our
+# own SESSION_NUDGE_TASK_BIN without interference.
+run_hook_with_task_bin() {
+    local task_bin="$1" session_id="$2" cwd="$3" transcript="$4"
+    local json
+    json=$(jq -nc --arg sid "$session_id" --arg cwd "$cwd" --arg tp "$transcript" \
+        '{session_id: $sid, cwd: $cwd, transcript_path: $tp}')
+    printf '%s' "$json" \
+        | HOME="$TEST_HOME" SESSION_NUDGE_TASK_BIN="$task_bin" \
+          bash "$HOOK" 2>/dev/null || true
+}
+
+# Create a mock task binary that returns a non-empty task list when queried.
+MOCK_TASK_DIR=$(mktemp -d)
+cat > "$MOCK_TASK_DIR/task" <<'MOCK'
+#!/bin/sh
+# Minimal task stub: 'export' returns one pending task; all other calls are no-ops.
+case "$*" in
+  *export*) printf '[{"id":1,"description":"open task","status":"pending","uuid":"00000000-0000-0000-0000-000000000001"}]\n' ;;
+  *) exit 0 ;;
+esac
+MOCK
+chmod +x "$MOCK_TASK_DIR/task"
+
+TRANSCRIPT=$(make_transcript 10 "im done for now")
+output=$(run_hook_with_task_bin "$MOCK_TASK_DIR/task" "sess-tw-tasks" "$REPO_WITH_RULES" "$TRANSCRIPT")
+assert_contains "open tasks → reason mentions taskwarrior sync cue" 'taskwarrior' "$output"
+assert_contains "open tasks → reason still references session-plugin:session-end" 'session-plugin:session-end' "$output"
+assert_contains "open tasks → reason still instructs offer-only" 'never run it without explicit user confirmation' "$output"
+assert_contains "open tasks → reason mentions stable UUID pattern" 'task +LATEST _get uuid' "$output"
+
+# When the task stub returns an empty list, the sync cue must NOT appear.
+MOCK_TASK_EMPTY_DIR=$(mktemp -d)
+cat > "$MOCK_TASK_EMPTY_DIR/task" <<'MOCK'
+#!/bin/sh
+# Task stub: returns empty list for all calls.
+case "$*" in
+  *export*) printf '[]\n' ;;
+  *) exit 0 ;;
+esac
+MOCK
+chmod +x "$MOCK_TASK_EMPTY_DIR/task"
+
+# Use a fresh session ID so the once-per-session marker doesn't suppress.
+output=$(run_hook_with_task_bin "$MOCK_TASK_EMPTY_DIR/task" "sess-tw-empty" "$REPO_WITH_RULES" "$TRANSCRIPT")
+# Hook must still fire (tasks stub means taskwarrior is "present" → has_surface=1)
+assert_contains "empty task list → hook still fires" '"decision":"block"' "$output"
+# But the taskwarrior sync cue text must not appear in the reason
+if echo "$output" | grep -q 'task +LATEST _get uuid'; then
+    printf "  FAIL: empty task list should NOT include UUID sync cue\n"; FAIL=$((FAIL + 1))
+else
+    printf "  PASS: empty task list does NOT include UUID sync cue\n"; PASS=$((PASS + 1))
+fi
+
+rm -rf "$MOCK_TASK_DIR" "$MOCK_TASK_EMPTY_DIR"
+rm -f "$TRANSCRIPT"
+
 echo ""
 echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
 [ "$FAIL" -gt 0 ] && exit 1

--- a/session-plugin/skills/session-end/SKILL.md
+++ b/session-plugin/skills/session-end/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: session-end
-description: End-of-session orchestrator. Previews which of wrap/distill/feedback qualify, single confirm, then sequence. Use when winding down a session.
+description: End-of-session orchestrator. Previews which of wrap/distill/feedback/taskwarrior-sync qualify, single confirm, then sequence. Use when winding down a session.
 allowed-tools: Bash(task *), Bash(git *), Bash(gh *), Read, Skill, AskUserQuestion, TodoWrite
 created: 2026-06-10
-modified: 2026-06-10
-reviewed: 2026-06-10
+modified: 2026-06-13
+reviewed: 2026-06-13
 ---
 
 # session-end
@@ -19,6 +19,7 @@ over three capture skills that used to compete for the wind-down moment
 | Wrap | `session-plugin:session-wrap` | Loose threads → taskwarrior, optional journal, GitHub issues |
 | Distill | `session-plugin:session-distill` | Durable learnings → rules, skill updates, justfile recipes |
 | Feedback | `feedback-plugin:feedback-session` | Notable plugin/skill interactions → GitHub issues on claude-plugins |
+| Taskwarrior sync | (inline, no sub-skill) | Close done tasks, update statuses, add follow-ups; uses stable UUIDs |
 
 ## When to Use This Skill
 
@@ -59,6 +60,7 @@ failure mode.
 | Wrap | ≥1 genuine loose thread per session-wrap's LOG IT filter |
 | Distill | A durable, generalizable learning emerged AND the repo has a distillable surface (`.claude/rules/` or a justfile) |
 | Feedback | A plugin/skill behaved notably well or badly — bug, enhancement, or positive worth filing |
+| Taskwarrior sync | Taskwarrior is on PATH AND ≥1 pending/active task for the project (`task project:<name> '(status:pending or +ACTIVE)' export \| jq 'length'`) |
 
 If **nothing** qualifies, say so in one line and end — no preview, no
 question.
@@ -67,10 +69,10 @@ question.
 
 Present a single compact preview: each qualifying pass with a one-line
 reason and its concrete payload (the wrap items; the distill proposal
-sketch; the feedback finding). Then **one AskUserQuestion**
-(multiSelect) listing the qualifying passes as options, qualifying ones
-described with their reasons. The user picks any subset; "Other" covers
-adjustments.
+sketch; the feedback finding; the open taskwarrior items with their UUIDs).
+Then **one AskUserQuestion** (multiSelect) listing the qualifying passes
+as options, qualifying ones described with their reasons. The user picks
+any subset; "Other" covers adjustments.
 
 Never end the turn on a freeform "y/n" text question — ending the turn
 fires Stop hooks mid-confirmation (the race that motivated this
@@ -78,21 +80,27 @@ orchestrator). AskUserQuestion keeps the turn open.
 
 ### Step 4: Sequence the confirmed passes
 
-Run in this order, each via the Skill tool, passing along the Step 1
-survey so they don't re-do it:
+Run in this order, each via the Skill tool (or inline for taskwarrior
+sync), passing along the Step 1 survey so they don't re-do it:
 
-1. `session-plugin:session-wrap` — closes/annotates/adds tasks first so
-   later passes see the final queue state
-2. `session-plugin:session-distill` — apply mode per its own flow; the
+1. **Taskwarrior sync** (if confirmed) — run inline before Wrap so Wrap
+   sees the updated queue state. For each open/active task: ask the user
+   (via AskUserQuestion) whether to mark done, update, or leave. Address
+   tasks by stable UUID (`task +LATEST _get uuid` after creation;
+   `task <uuid> done` / `task <uuid> modify` for existing tasks). Never
+   use volatile numeric IDs — they shift when other tasks complete.
+2. `session-plugin:session-wrap` — closes/annotates/adds tasks so later
+   passes see the final queue state
+3. `session-plugin:session-distill` — apply mode per its own flow; the
    user already confirmed the pass, so skip a second blanket prompt but
    keep distill's per-category destructive-change prompts
-3. `feedback-plugin:feedback-session` — cross-plugin; if the feedback
+4. `feedback-plugin:feedback-session` — cross-plugin; if the feedback
    plugin isn't installed, note it and skip
 
 ### Step 5: Report
 
-One short block: what each executed pass wrote (tasks touched, files
-edited, issues filed) and which passes were skipped as not qualifying.
+One short block: what each executed pass wrote (tasks touched / closed,
+files edited, issues filed) and which passes were skipped as not qualifying.
 
 ## Seam: distill vs feedback
 
@@ -114,5 +122,7 @@ already in the transcript. Pre-silence:
 | Context | Command |
 |---|---|
 | Queue state (exit-0 on empty) | `task project:<name> '(status:pending or +ACTIVE)' export \| jq '.[]'` |
+| Stable UUID for latest task | `task +LATEST _get uuid` |
+| Mark task done by UUID | `task <uuid> done` |
 | Distillable surface check | `find . -maxdepth 2 -path '*/.claude/rules' -o -maxdepth 1 -name 'justfile' -o -maxdepth 1 -name 'Justfile'` |
 | Branch PRs | `gh pr list --head <branch> --json number,title,url,state --jq '.[]'` |


### PR DESCRIPTION
## Summary

- Extends `session-end-nudge.sh` (Stop hook) to run a read-only taskwarrior `export` query when taskwarrior is on PATH; when ≥1 open/active tasks exist for the project, the hook's wind-down offer conditionally includes a taskwarrior state-sync cue referencing stable UUIDs (`task +LATEST _get uuid`)
- Updates `session-end/SKILL.md` to add taskwarrior sync as a 4th qualifying pass in the orchestrator (Step 2 qualify + Step 4 sequence), with UUID guidance
- Adds 6 new regression tests in `test-session-end-nudge.sh` (open tasks → cue present with UUID pattern; empty task list → cue absent; all 14 pre-existing tests still green); introduces `run_hook_with_task_bin()` helper to bypass the `NO_TASK` seam cleanly

Closes #1614
Refs #1599

## Design constraints met

- No competing Stop hook added — extends the existing `session-end-nudge.sh`
- Hook is non-blocking, conditional (only when tasks exist), once-per-session deduped, terse
- Hook is offer-only: zero task mutations in the hook; skill layer (with AskUserQuestion) performs any change
- Taskwarrior query uses `export` (not `list`) → exits 0 on empty → parallel-safe (per `.claude/rules/parallel-safe-queries.md`)
- All existing semantic invariants preserved (`session-plugin:session-end` in reason; `never run it without explicit user confirmation` in reason)

## Test plan

- [x] `bash session-plugin/hooks/test-session-end-nudge.sh` → 20 passed, 0 failed
- [x] All 14 pre-existing tests green (no regression)
- [x] 6 new taskwarrior sync cue tests green
- [x] Only `session-plugin/` files touched (no marketplace/release-please edits)

https://claude.ai/code/session_01CviK9baM61wLFdLcCwuFcY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CviK9baM61wLFdLcCwuFcY)_