### PR TITLE
feat(codebase-attributes-plugin): add SessionStart routing cue from health severity

### DIFF
--- a/codebase-attributes-plugin/.claude-plugin/plugin.json
+++ b/codebase-attributes-plugin/.claude-plugin/plugin.json
@@ -6,6 +6,7 @@
   "author": {
     "name": "Lauri Gates"
   },
+  "hooks": "./hooks.json",
   "keywords": [
     "attributes",
     "health",

--- a/codebase-attributes-plugin/README.md
+++ b/codebase-attributes-plugin/README.md
@@ -6,6 +6,10 @@ Structured codebase health attributes with severity-based agent routing.
 
 See [`docs/flow.md`](docs/flow.md) for a diagram of how the skills fit together.
 
+## SessionStart Cue
+
+When `.claude/attributes.json` exists in a repo, the plugin injects a one-line `additionalContext` cue at session startup/resume offering to run `/attributes:route` or `/attributes:dashboard`. The cue fires at most once per session and names the highest severity and category found. It never blocks — it is purely informational.
+
 ## Skills
 
 | Skill | Description |

--- a/codebase-attributes-plugin/hooks.json
+++ b/codebase-attributes-plugin/hooks.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "codebase-attributes-plugin hooks — SessionStart cue routes work by health severity",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/attributes-health-cue.sh",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/codebase-attributes-plugin/hooks/attributes-health-cue.sh
+++ b/codebase-attributes-plugin/hooks/attributes-health-cue.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# SessionStart hook — surfaces codebase-attributes health severity so work
+# routes through codebase-attributes-plugin:attributes-route / attributes-dashboard
+# when .claude/attributes.json is present in the repo. Injects additionalContext
+# (never blocks) and fires at most once per session_id.
+#
+# Fires only on source=startup|resume (silent on clear/compact — those are
+# mid-session continuations), at most once per session_id.
+set -uo pipefail
+
+input=$(cat)
+
+source_kind=$(jq -r '.source // empty' <<<"$input" 2>/dev/null || echo "")
+case "$source_kind" in
+    startup|resume) ;;
+    *) exit 0 ;;
+esac
+
+session_id=$(jq -r '.session_id // empty' <<<"$input" 2>/dev/null || echo "")
+cwd=$(jq -r '.cwd // empty' <<<"$input" 2>/dev/null || echo "")
+
+[ -z "$session_id" ] && exit 0
+[ -z "$cwd" ] && exit 0
+[ ! -d "$cwd" ] && exit 0
+
+# Resolve git repo root; fall back to cwd for non-git projects
+if git -C "$cwd" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    repo_root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || echo "$cwd")
+else
+    repo_root="$cwd"
+fi
+
+# Only fire when attributes data file exists — do not nag opt-out projects
+attrs_file="$repo_root/.claude/attributes.json"
+[ ! -f "$attrs_file" ] && exit 0
+
+# At most one cue per session
+# ATTRIBUTES_HEALTH_CUE_CACHE_DIR is a test seam — see test-attributes-health-cue.sh
+state_dir="${ATTRIBUTES_HEALTH_CUE_CACHE_DIR:-$HOME/.cache/attributes-health-cue}"
+mkdir -p "$state_dir"
+state_file="$state_dir/$session_id"
+[ -f "$state_file" ] && exit 0
+
+# Extract worst severity and category from the attributes JSON
+worst_severity=""
+worst_category=""
+if command -v jq >/dev/null 2>&1; then
+    # Severity order: critical > high > medium > low
+    for sev in critical high medium low; do
+        cat_match=$(jq -r --arg s "$sev" \
+            '[.attributes[]? | select(.severity == $s)] | first | .category // empty' \
+            "$attrs_file" 2>/dev/null || echo "")
+        if [ -n "$cat_match" ]; then
+            worst_severity="$sev"
+            worst_category="$cat_match"
+            break
+        fi
+    done
+fi
+
+touch "$state_file"
+
+if [ -n "$worst_severity" ] && [ -n "$worst_category" ]; then
+    context="Codebase health data found (.claude/attributes.json): highest severity is ${worst_severity} in ${worst_category}. If the user is starting work on this repo, offer to run codebase-attributes-plugin:attributes-route to auto-remediate by severity, or codebase-attributes-plugin:attributes-dashboard for a health overview. Offer once — do not run unprompted."
+else
+    context="Codebase health data found (.claude/attributes.json). If the user is starting work on this repo, offer to run codebase-attributes-plugin:attributes-route to auto-remediate issues, or codebase-attributes-plugin:attributes-dashboard for a health overview. Offer once — do not run unprompted."
+fi
+
+jq -nc --arg c "$context" \
+    '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $c}}'

--- a/codebase-attributes-plugin/hooks/test-attributes-health-cue.sh
+++ b/codebase-attributes-plugin/hooks/test-attributes-health-cue.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Regression tests for attributes-health-cue.sh
+#
+# Verifies the SessionStart cue fires only on startup/resume when
+# .claude/attributes.json exists in the repo, injects additionalContext
+# (never a block), deduplicates per session, and stays silent otherwise.
+#
+# Semantic invariants:
+#   - When the cue fires, JSON must contain 'additionalContext'
+#   - When the cue fires, JSON must mention 'codebase-attributes-plugin:attributes-route'
+#   - Never emits a "decision" (never blocks)
+#   - Second call with same session_id is silent (dedup)
+#   - source=clear|compact is always silent
+#   - No .claude/attributes.json → always silent
+#   - Empty session_id → always silent
+#
+# Run: bash codebase-attributes-plugin/hooks/test-attributes-health-cue.sh
+set -euo pipefail
+
+HOOK="$(dirname "$0")/attributes-health-cue.sh"
+PASS=0
+FAIL=0
+
+# All temp directories use the test seam ATTRIBUTES_HEALTH_CUE_CACHE_DIR
+TEST_HOME=$(mktemp -d)
+CACHE_DIR=$(mktemp -d)
+
+# Repo with .claude/attributes.json containing a high-severity finding
+REPO_WITH_ATTRS=$(mktemp -d)
+# Repo without attributes data
+REPO_NO_ATTRS=$(mktemp -d)
+
+trap 'rm -rf "$TEST_HOME" "$CACHE_DIR" "$REPO_WITH_ATTRS" "$REPO_NO_ATTRS"' EXIT
+
+# Set up git repos
+for repo in "$REPO_WITH_ATTRS" "$REPO_NO_ATTRS"; do
+    git -C "$repo" init -q
+    git -C "$repo" -c user.email=t@t -c user.name=t -c commit.gpgsign=false -c gpg.format=none commit -q --allow-empty -m init
+done
+
+# Create .claude/attributes.json with a critical security finding
+mkdir -p "$REPO_WITH_ATTRS/.claude"
+cat > "$REPO_WITH_ATTRS/.claude/attributes.json" <<'EOF'
+{
+  "version": "1",
+  "repo": "/test/repo",
+  "timestamp": "2026-06-13T10:00:00Z",
+  "attributes": [
+    {
+      "id": "env-file-committed",
+      "category": "security",
+      "severity": "critical",
+      "description": ".env file committed",
+      "source": "attributes-collect",
+      "actions": [{"type": "agent", "target": "security-audit", "auto_fixable": true}]
+    },
+    {
+      "id": "missing-readme",
+      "category": "docs",
+      "severity": "high",
+      "description": "Missing README.md",
+      "source": "attributes-collect",
+      "actions": [{"type": "agent", "target": "docs", "auto_fixable": true}]
+    }
+  ],
+  "scores": {"overall": 45, "grade": "D", "max_score": 100}
+}
+EOF
+
+run_hook_output() {
+    local session_id="$1" cwd="$2" source_kind="$3"
+    jq -nc --arg sid "$session_id" --arg cwd "$cwd" --arg src "$source_kind" \
+        '{session_id: $sid, cwd: $cwd, source: $src}' \
+        | HOME="$TEST_HOME" ATTRIBUTES_HEALTH_CUE_CACHE_DIR="$CACHE_DIR" \
+          bash "$HOOK" 2>/dev/null || true
+}
+
+assert_contains() {
+    local desc="$1" pattern="$2" actual="$3"
+    if echo "$actual" | grep -q "$pattern"; then
+        printf "  PASS: %s\n" "$desc"; PASS=$((PASS + 1))
+    else
+        printf "  FAIL: %s (expected '%s' in: %s)\n" "$desc" "$pattern" "$actual"; FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_silent() {
+    local desc="$1" actual="$2"
+    if [ -n "$actual" ]; then
+        printf "  FAIL: %s (hook emitted: %s)\n" "$desc" "$actual"; FAIL=$((FAIL + 1))
+    else
+        printf "  PASS: %s\n" "$desc"; PASS=$((PASS + 1))
+    fi
+}
+
+echo "=== attributes-health-cue hook tests ==="
+
+# (c) source gate: clear and compact are silent
+echo ""
+echo "source gate:"
+output=$(run_hook_output "ahc-clear" "$REPO_WITH_ATTRS" "clear")
+assert_silent "source=clear is silent even with attrs data" "$output"
+output=$(run_hook_output "ahc-compact" "$REPO_WITH_ATTRS" "compact")
+assert_silent "source=compact is silent even with attrs data" "$output"
+
+# (b) silent when no attribute data file
+echo ""
+echo "no attribute data file:"
+output=$(run_hook_output "ahc-nodata" "$REPO_NO_ATTRS" "startup")
+assert_silent "repo without .claude/attributes.json is silent on startup" "$output"
+output=$(run_hook_output "ahc-nodata-resume" "$REPO_NO_ATTRS" "resume")
+assert_silent "repo without .claude/attributes.json is silent on resume" "$output"
+
+# (e) empty session_id → graceful no-op
+echo ""
+echo "empty session_id:"
+output=$(jq -nc --arg cwd "$REPO_WITH_ATTRS" --arg src "startup" \
+    '{session_id: "", cwd: $cwd, source: $src}' \
+    | HOME="$TEST_HOME" ATTRIBUTES_HEALTH_CUE_CACHE_DIR="$CACHE_DIR" \
+      bash "$HOOK" 2>/dev/null || true)
+assert_silent "empty session_id is a no-op" "$output"
+
+# (a) fires on startup with attrs data, output contains cue + additionalContext
+echo ""
+echo "fires on startup with attribute data:"
+output=$(run_hook_output "ahc-startup-1" "$REPO_WITH_ATTRS" "startup")
+assert_contains "startup emits additionalContext" '"additionalContext"' "$output"
+assert_contains "context mentions attributes-route" 'codebase-attributes-plugin:attributes-route' "$output"
+assert_contains "context mentions attributes-dashboard" 'codebase-attributes-plugin:attributes-dashboard' "$output"
+assert_contains "context mentions highest severity (critical)" 'critical' "$output"
+assert_contains "context mentions worst category (security)" 'security' "$output"
+if echo "$output" | grep -q '"decision"'; then
+    printf "  FAIL: cue must not emit a decision/block\n"; FAIL=$((FAIL + 1))
+else
+    printf "  PASS: cue does not block\n"; PASS=$((PASS + 1))
+fi
+
+# fires on resume too
+output=$(run_hook_output "ahc-resume-1" "$REPO_WITH_ATTRS" "resume")
+assert_contains "resume also emits additionalContext" '"additionalContext"' "$output"
+
+# (d) fire-once dedup: second call with same session_id is silent
+echo ""
+echo "once-per-session dedup:"
+output=$(run_hook_output "ahc-startup-1" "$REPO_WITH_ATTRS" "startup")
+assert_silent "second startup call with same session_id is silent" "$output"
+output=$(run_hook_output "ahc-resume-1" "$REPO_WITH_ATTRS" "resume")
+assert_silent "second resume call with same session_id is silent" "$output"
+
+# different session_id fires again
+output=$(run_hook_output "ahc-startup-2" "$REPO_WITH_ATTRS" "startup")
+assert_contains "different session_id fires fresh" '"additionalContext"' "$output"
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+[ "$FAIL" -gt 0 ] && exit 1
+exit 0


### PR DESCRIPTION
## Summary

- Adds `hooks/attributes-health-cue.sh` — a SessionStart hook that injects a terse `additionalContext` cue when `.claude/attributes.json` is present in the repo, naming the highest severity/category found and offering to run `codebase-attributes-plugin:attributes-route` or `attributes-dashboard`
- Adds `hooks.json` registering the hook under `SessionStart` (matcher `""`, `type: "command"`, timeout 15s)
- Updates `.claude-plugin/plugin.json` to reference `./hooks.json`
- Updates `README.md` with a SessionStart Cue section
- Adds `hooks/test-attributes-health-cue.sh` regression test (15 cases): source gate, no-data silence, empty `session_id`, `additionalContext` shape, no-decision/block, once-per-session dedup, cross-session re-fire

## ADR-0017 compliance

- **Conditional** — exits silently when `.claude/attributes.json` absent
- **Deduped** — at most once per session via `~/.cache/attributes-health-cue/<session_id>` (test seam: `ATTRIBUTES_HEALTH_CUE_CACHE_DIR`)
- **Terse** — single sentence with severity, category, and skill names
- **Non-blocking** — `additionalContext` only, never emits `decision`
- **Cheapest event** — SessionStart fires once per session

## Test plan

- [x] `bash codebase-attributes-plugin/hooks/test-attributes-health-cue.sh` — 15 passed, 0 failed
- [x] Only `codebase-attributes-plugin/` files staged; no marketplace/release-please edits

Closes #1613
Refs #1599

https://claude.ai/code/session_01CviK9baM61wLFdLcCwuFcY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CviK9baM61wLFdLcCwuFcY)_