### PR TITLE
feat(code-quality-plugin): add PostToolUse pre-flight cue for structural edits

### DIFF
--- a/code-quality-plugin/.claude-plugin/plugin.json
+++ b/code-quality-plugin/.claude-plugin/plugin.json
@@ -32,5 +32,6 @@
     "test-quality",
     "complexity",
     "supply-chain"
-  ]
+  ],
+  "hooks": "./hooks.json"
 }

--- a/code-quality-plugin/README.md
+++ b/code-quality-plugin/README.md
@@ -226,6 +226,29 @@ Works well with:
 /plugin install code-quality-plugin@laurigates-claude-plugins
 ```
 
+## PostToolUse Pre-flight Cue
+
+The plugin ships a PostToolUse behavioral cue hook (ADR-0017) that fires **once per session** when an Edit or Write touches a file with structural signals. When it fires, it feeds back a short reminder to run `/code-quality:code-lint` (and `/evaluate:evaluate-skill` if a skill file changed) before continuing.
+
+### How it works
+
+- **Fires on**: Edit and Write tool completions
+- **Structural signals** (any one is enough to fire):
+  - The diff contains a public-symbol line: `export`, `export default`, `module.exports`, `pub`, `public`, `def`, `class`, `func`
+  - The edited file is a manifest: `plugin.json`, `marketplace.json`, `package.json`, `Cargo.toml`, `pyproject.toml`
+  - The payload (new_string + content) is >= 50 lines
+- **Silenced for**: `.md`/`.txt` files, `CHANGELOG.md`, test/spec files, lockfiles, docs under `docs/adrs/` or `docs/prds/`
+- **Once per session**: after firing, a marker file under `~/.cache/code-quality-preflight-cue/<session_id>` prevents re-firing in the same session
+- **ADR-0017 compliance**: uses `{"decision":"block","reason":"..."}` with `continueOnBlock: true` — the reason is fed back to the model and the turn continues
+
+### Bypass
+
+Set `CODE_QUALITY_SKIP_HOOKS=1` in your environment to disable the hook entirely for that session.
+
+### Test seam
+
+Override `CODE_QUALITY_PREFLIGHT_CUE_CACHE_DIR` to redirect marker storage (used by the regression tests under `hooks/test-code-quality-preflight-cue.sh`).
+
 ## License
 
 MIT

--- a/code-quality-plugin/hooks.json
+++ b/code-quality-plugin/hooks.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "code-quality-plugin PostToolUse pre-flight cue hook (ADR-0017 behavioral cue)",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/code-quality-preflight-cue.sh",
+            "continueOnBlock": true,
+            "timeout": 5000
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/code-quality-preflight-cue.sh",
+            "continueOnBlock": true,
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/code-quality-plugin/hooks/code-quality-preflight-cue.sh
+++ b/code-quality-plugin/hooks/code-quality-preflight-cue.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# code-quality-preflight-cue.sh — PostToolUse poka-yoke cue for structural edits.
+#
+# When an Edit/Write touches a file with structural signals (public-symbol lines,
+# key manifests, or large payloads), this emits a once-per-session cue suggesting
+# a code-quality pre-flight check. It is a behavioral cue (ADR-0017), not a gate:
+# continueOnBlock:true in hooks.json means the turn continues with the reason fed
+# back to the model.
+#
+# Mechanism: PostToolUse {"decision":"block","reason":"<cue>"} with continueOnBlock:true
+# so the model sees the cue and can act on it without the turn being terminated.
+# Dedup is per session (one cue per session) to bound transcript-replay cost.
+#
+# -e is intentionally omitted: a best-effort cue must never break a tool call.
+set -uo pipefail
+
+# Bypass (code-quality-plugin convention).
+if [ "${CODE_QUALITY_SKIP_HOOKS:-}" = "1" ]; then
+    exit 0
+fi
+
+cq_input=$(cat)
+
+cq_tool_name=$(printf '%s' "$cq_input" | jq -r '.tool_name // empty' 2>/dev/null || echo "")
+cq_file_path=$(printf '%s' "$cq_input" | jq -r '.tool_input.file_path // empty' 2>/dev/null || echo "")
+cq_new_string=$(printf '%s' "$cq_input" | jq -r '.tool_input.new_string // empty' 2>/dev/null || echo "")
+cq_content=$(printf '%s' "$cq_input" | jq -r '.tool_input.content // empty' 2>/dev/null || echo "")
+cq_session_id=$(printf '%s' "$cq_input" | jq -r '.session_id // empty' 2>/dev/null | tr -cd 'a-zA-Z0-9_-')
+
+# Only Edit/Write carry structural edits.
+case "$cq_tool_name" in
+    Edit|Write) ;;
+    *) exit 0 ;;
+esac
+
+[ -z "$cq_file_path" ] && exit 0
+
+# --- Exclusions: silence early, before detection ---
+cq_base_name="${cq_file_path##*/}"
+
+# .md and .txt files — always silent.
+case "$cq_file_path" in
+    *.md|*.txt) exit 0 ;;
+esac
+
+# CHANGELOG.md explicitly (belt-and-suspenders).
+[ "$cq_base_name" = "CHANGELOG.md" ] && exit 0
+
+# Test/spec files — path segment or basename pattern.
+case "$cq_file_path" in
+    */test/*|*/spec/*|*/__tests__/*) exit 0 ;;
+esac
+case "$cq_base_name" in
+    *_test.*|*.test.*|*.spec.*) exit 0 ;;
+esac
+
+# Lockfiles — always silent.
+case "$cq_base_name" in
+    package-lock.json|yarn.lock|pnpm-lock.yaml|bun.lockb|Cargo.lock|uv.lock|poetry.lock) exit 0 ;;
+esac
+
+# Docs/ADR/PRD paths — covered by blueprint hooks.
+case "$cq_file_path" in
+    docs/adrs/*|docs/prds/*|*/docs/adrs/*|*/docs/prds/*) exit 0 ;;
+esac
+
+# --- Detection: fire if ANY signal matches ---
+cq_payload="${cq_new_string}
+${cq_content}"
+cq_is_structural=0
+
+# Signal 1: key manifest basenames.
+case "$cq_base_name" in
+    plugin.json|marketplace.json|package.json|Cargo.toml|pyproject.toml) cq_is_structural=1 ;;
+esac
+
+# Signal 2: a public-symbol / export line in the edit payload.
+if [ "$cq_is_structural" -eq 0 ] && \
+    printf '%s' "$cq_payload" | grep -Eq '^[+-]?[[:space:]]*(export |export default|module\.exports|pub |public |def |class |func )'; then
+    cq_is_structural=1
+fi
+
+# Signal 3: large payload (>= 50 lines).
+if [ "$cq_is_structural" -eq 0 ]; then
+    cq_line_count=$(printf '%s' "$cq_payload" | wc -l)
+    if [ "$cq_line_count" -ge 50 ]; then
+        cq_is_structural=1
+    fi
+fi
+
+[ "$cq_is_structural" -eq 0 ] && exit 0
+
+# --- Dedup: one cue per session ---
+# CODE_QUALITY_PREFLIGHT_CUE_CACHE_DIR is the test seam.
+cq_cache_dir="${CODE_QUALITY_PREFLIGHT_CUE_CACHE_DIR:-${HOME}/.cache/code-quality-preflight-cue}"
+if [ -n "$cq_session_id" ]; then
+    cq_marker="${cq_cache_dir}/${cq_session_id}"
+    [ -f "$cq_marker" ] && exit 0
+    mkdir -p "$cq_cache_dir" 2>/dev/null || true
+    touch "$cq_marker" 2>/dev/null || true
+fi
+
+cq_cue="[code-quality] Large/structural edit detected. Run /code-quality:code-lint (and /evaluate:evaluate-skill if a skill changed) as a pre-flight before continuing."
+
+jq -n --arg reason "$cq_cue" '{"decision":"block","reason":$reason}'
+
+exit 0

--- a/code-quality-plugin/hooks/test-code-quality-preflight-cue.sh
+++ b/code-quality-plugin/hooks/test-code-quality-preflight-cue.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Regression tests for code-quality-preflight-cue.sh
+# Run: bash code-quality-plugin/hooks/test-code-quality-preflight-cue.sh
+set -uo pipefail
+
+CQ_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CQ_SCRIPT="${CQ_SCRIPT_DIR}/code-quality-preflight-cue.sh"
+CQ_PASS=0
+CQ_FAIL=0
+
+# Use a temp dir as the cache to isolate tests
+CQ_TEST_CACHE_DIR="$(mktemp -d)"
+trap 'rm -rf "$CQ_TEST_CACHE_DIR"' EXIT
+
+cq_pass() { echo "PASS: $1"; CQ_PASS=$((CQ_PASS + 1)); }
+cq_fail() { echo "FAIL: $1"; CQ_FAIL=$((CQ_FAIL + 1)); }
+
+cq_invoke() {
+  # Invoke the hook with a fresh session id (or passed one) and given JSON
+  local cq_json="$1"
+  CODE_QUALITY_PREFLIGHT_CUE_CACHE_DIR="$CQ_TEST_CACHE_DIR" \
+    bash "$CQ_SCRIPT" <<< "$cq_json"
+}
+
+cq_invoke_sid() {
+  local cq_json="$1"
+  local cq_sid="$2"
+  CODE_QUALITY_PREFLIGHT_CUE_CACHE_DIR="$CQ_TEST_CACHE_DIR" \
+    bash "$CQ_SCRIPT" <<< "$cq_json"
+}
+
+# Helper: build test payload JSON
+cq_payload() {
+  local cq_tool="$1"
+  local cq_file="$2"
+  local cq_new_string="${3:-}"
+  local cq_content="${4:-}"
+  local cq_sid="${5:-test-session-$(date +%s%N)}"
+  jq -n \
+    --arg tool_name "$cq_tool" \
+    --arg file_path "$cq_file" \
+    --arg new_string "$cq_new_string" \
+    --arg content "$cq_content" \
+    --arg session_id "$cq_sid" \
+    '{tool_name: $tool_name, tool_input: {file_path: $file_path, new_string: $new_string, content: $content}, session_id: $session_id}'
+}
+
+# --- (a) Public-symbol edit fires once, output contains cue text AND decision:block ---
+echo "--- Test (a): public-symbol edit fires ---"
+CQ_SID_A="test-sid-a-$(date +%s%N)"
+CQ_PAYLOAD_A="$(cq_payload Edit /some/src/app.ts 'export function doThing() { return 1; }' '' "$CQ_SID_A")"
+CQ_OUT_A="$(CODE_QUALITY_PREFLIGHT_CUE_CACHE_DIR="$CQ_TEST_CACHE_DIR" bash "$CQ_SCRIPT" <<< "$CQ_PAYLOAD_A")"
+if echo "$CQ_OUT_A" | jq -e '.decision == "block"' > /dev/null 2>&1; then
+  cq_pass "(a) decision:block present"
+else
+  cq_fail "(a) decision:block missing; got: $CQ_OUT_A"
+fi
+if echo "$CQ_OUT_A" | jq -e '.reason' | grep -q "code-quality"; then
+  cq_pass "(a) reason contains [code-quality]"
+else
+  cq_fail "(a) reason missing [code-quality]; got: $CQ_OUT_A"
+fi
+
+# --- (b) Manifest filename fires ---
+echo "--- Test (b): manifest filename (plugin.json) fires ---"
+CQ_SID_B="test-sid-b-$(date +%s%N)"
+CQ_PAYLOAD_B="$(cq_payload Edit /repo/myplugin/.claude-plugin/plugin.json 'trivial change' '' "$CQ_SID_B")"
+CQ_OUT_B="$(CODE_QUALITY_PREFLIGHT_CUE_CACHE_DIR="$CQ_TEST_CACHE_DIR" bash "$CQ_SCRIPT" <<< "$CQ_PAYLOAD_B")"
+if echo "$CQ_OUT_B" | jq -e '.decision == "block"' > /dev/null 2>&1; then
+  cq_pass "(b) plugin.json edit fires"
+else
+  cq_fail "(b) plugin.json edit did not fire; got: $CQ_OUT_B"
+fi
+
+# --- (c) >=50 lines fires, <50 lines trivial edit is silent ---
+echo "--- Test (c): 50-line payload fires ---"
+CQ_SID_C1="test-sid-c1-$(date +%s%N)"
+# Generate 50 lines of content (no public symbols, not a manifest)
+CQ_50LINES="$(printf 'line\n%.0s' {1..50})"
+CQ_PAYLOAD_C1="$(cq_payload Edit /repo/src/helpers.rb '' "$CQ_50LINES" "$CQ_SID_C1")"
+CQ_OUT_C1="$(CODE_QUALITY_PREFLIGHT_CUE_CACHE_DIR="$CQ_TEST_CACHE_DIR" bash "$CQ_SCRIPT" <<< "$CQ_PAYLOAD_C1")"
+if echo "$CQ_OUT_C1" | jq -e '.decision == "block"' > /dev/null 2>&1; then
+  cq_pass "(c) 50-line payload fires"
+else
+  cq_fail "(c) 50-line payload did not fire; got: $CQ_OUT_C1"
+fi
+
+echo "--- Test (c): <50 lines trivial edit is silent ---"
+CQ_SID_C2="test-sid-c2-$(date +%s%N)"
+CQ_SMALL="$(printf 'line\n%.0s' {1..10})"
+CQ_PAYLOAD_C2="$(cq_payload Edit /repo/src/helpers.rb '' "$CQ_SMALL" "$CQ_SID_C2")"
+CQ_OUT_C2="$(CODE_QUALITY_PREFLIGHT_CUE_CACHE_DIR="$CQ_TEST_CACHE_DIR" bash "$CQ_SCRIPT" <<< "$CQ_PAYLOAD_C2")"
+if [ -z "$CQ_OUT_C2" ]; then
+  cq_pass "(c) trivial small edit is silent"
+else
+  cq_fail "(c) trivial small edit should be silent; got: $CQ_OUT_C2"
+fi
+
+# --- (d) .md / test-file / lockfile edits are silent ---
+echo "--- Test (d): .md file is silent ---"
+CQ_SID_D1="test-sid-d1-$(date +%s%N)"
+CQ_PAYLOAD_D1="$(cq_payload Edit /repo/README.md 'export function big() {}' '' "$CQ_SID_D1")"
+CQ_OUT_D1="$(CODE_QUALITY_PREFLIGHT_CUE_CACHE_DIR="$CQ_TEST_CACHE_DIR" bash "$CQ_SCRIPT" <<< "$CQ_PAYLOAD_D1")"
+if [ -z "$CQ_OUT_D1" ]; then
+  cq_pass "(d) .md edit is silent"
+else
+  cq_fail "(d) .md edit should be silent; got: $CQ_OUT_D1"
+fi
+
+echo "--- Test (d): test file is silent ---"
+CQ_SID_D2="test-sid-d2-$(date +%s%N)"
+CQ_PAYLOAD_D2="$(cq_payload Edit /repo/src/app.test.ts 'export function doThing() { return 1; }' '' "$CQ_SID_D2")"
+CQ_OUT_D2="$(CODE_QUALITY_PREFLIGHT_CUE_CACHE_DIR="$CQ_TEST_CACHE_DIR" bash "$CQ_SCRIPT" <<< "$CQ_PAYLOAD_D2")"
+if [ -z "$CQ_OUT_D2" ]; then
+  cq_pass "(d) test file edit is silent"
+else
+  cq_fail "(d) test file edit should be silent; got: $CQ_OUT_D2"
+fi
+
+echo "--- Test (d): lockfile is silent ---"
+CQ_SID_D3="test-sid-d3-$(date +%s%N)"
+CQ_PAYLOAD_D3="$(cq_payload Edit /repo/package-lock.json 'export function doThing() { return 1; }' '' "$CQ_SID_D3")"
+CQ_OUT_D3="$(CODE_QUALITY_PREFLIGHT_CUE_CACHE_DIR="$CQ_TEST_CACHE_DIR" bash "$CQ_SCRIPT" <<< "$CQ_PAYLOAD_D3")"
+if [ -z "$CQ_OUT_D3" ]; then
+  cq_pass "(d) lockfile edit is silent"
+else
+  cq_fail "(d) lockfile edit should be silent; got: $CQ_OUT_D3"
+fi
+
+# --- (e) fire-once dedup: second structural edit with marker present is silent ---
+echo "--- Test (e): fire-once dedup ---"
+CQ_SID_E="test-sid-e-fixed"
+CQ_PAYLOAD_E="$(cq_payload Edit /repo/src/app.ts 'export function doThing() { return 1; }' '' "$CQ_SID_E")"
+# First call should fire
+CQ_OUT_E1="$(CODE_QUALITY_PREFLIGHT_CUE_CACHE_DIR="$CQ_TEST_CACHE_DIR" bash "$CQ_SCRIPT" <<< "$CQ_PAYLOAD_E")"
+# Second call with same session id should be silent
+CQ_OUT_E2="$(CODE_QUALITY_PREFLIGHT_CUE_CACHE_DIR="$CQ_TEST_CACHE_DIR" bash "$CQ_SCRIPT" <<< "$CQ_PAYLOAD_E")"
+if echo "$CQ_OUT_E1" | jq -e '.decision == "block"' > /dev/null 2>&1; then
+  cq_pass "(e) first call fires"
+else
+  cq_fail "(e) first call did not fire; got: $CQ_OUT_E1"
+fi
+if [ -z "$CQ_OUT_E2" ]; then
+  cq_pass "(e) second call is silent (dedup)"
+else
+  cq_fail "(e) second call should be silent; got: $CQ_OUT_E2"
+fi
+
+# --- (f) empty session_id does not crash and still emits ---
+echo "--- Test (f): empty session_id does not crash ---"
+CQ_PAYLOAD_F="$(jq -n --arg tool_name Edit --arg file_path /repo/src/app.ts --arg new_string 'export function doThing() { return 1; }' \
+  '{tool_name: $tool_name, tool_input: {file_path: $file_path, new_string: $new_string}}')"
+CQ_EXIT_F=0
+CQ_OUT_F="$(CODE_QUALITY_PREFLIGHT_CUE_CACHE_DIR="$CQ_TEST_CACHE_DIR" bash "$CQ_SCRIPT" <<< "$CQ_PAYLOAD_F")" || CQ_EXIT_F=$?
+if [ "$CQ_EXIT_F" -eq 0 ]; then
+  cq_pass "(f) empty session_id exits 0"
+else
+  cq_fail "(f) empty session_id crashed with exit $CQ_EXIT_F"
+fi
+if echo "$CQ_OUT_F" | jq -e '.decision == "block"' > /dev/null 2>&1; then
+  cq_pass "(f) empty session_id still emits cue"
+else
+  cq_fail "(f) empty session_id should still emit; got: $CQ_OUT_F"
+fi
+
+# --- (g) JSON field name 'decision' is pinned ---
+echo "--- Test (g): decision field name is pinned ---"
+CQ_SID_G="test-sid-g-$(date +%s%N)"
+CQ_PAYLOAD_G="$(cq_payload Edit /repo/src/app.ts 'export function doThing() { return 1; }' '' "$CQ_SID_G")"
+CQ_OUT_G="$(CODE_QUALITY_PREFLIGHT_CUE_CACHE_DIR="$CQ_TEST_CACHE_DIR" bash "$CQ_SCRIPT" <<< "$CQ_PAYLOAD_G")"
+if echo "$CQ_OUT_G" | jq -e 'has("decision")' > /dev/null 2>&1; then
+  cq_pass "(g) 'decision' field is present"
+else
+  cq_fail "(g) 'decision' field missing; got: $CQ_OUT_G"
+fi
+if echo "$CQ_OUT_G" | jq -e 'has("reason")' > /dev/null 2>&1; then
+  cq_pass "(g) 'reason' field is present"
+else
+  cq_fail "(g) 'reason' field missing; got: $CQ_OUT_G"
+fi
+
+# --- (h) CODE_QUALITY_SKIP_HOOKS=1 is a no-op ---
+echo "--- Test (h): CODE_QUALITY_SKIP_HOOKS=1 silences all ---"
+CQ_SID_H="test-sid-h-$(date +%s%N)"
+CQ_PAYLOAD_H="$(cq_payload Edit /repo/src/app.ts 'export function doThing() { return 1; }' '' "$CQ_SID_H")"
+CQ_OUT_H="$(CODE_QUALITY_PREFLIGHT_CUE_CACHE_DIR="$CQ_TEST_CACHE_DIR" CODE_QUALITY_SKIP_HOOKS=1 bash "$CQ_SCRIPT" <<< "$CQ_PAYLOAD_H")"
+if [ -z "$CQ_OUT_H" ]; then
+  cq_pass "(h) CODE_QUALITY_SKIP_HOOKS=1 silences hook"
+else
+  cq_fail "(h) CODE_QUALITY_SKIP_HOOKS=1 should silence; got: $CQ_OUT_H"
+fi
+
+# --- Summary ---
+echo ""
+echo "=== RESULTS ==="
+echo "PASS: $CQ_PASS"
+echo "FAIL: $CQ_FAIL"
+if [ "$CQ_FAIL" -eq 0 ]; then
+  echo "STATUS=OK"
+  exit 0
+else
+  echo "STATUS=ERROR"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Adds `code-quality-plugin/hooks/code-quality-preflight-cue.sh` — PostToolUse hook that fires once per session when Edit/Write touches a file with structural signals (public-symbol lines, manifest filenames, or payloads >=50 lines)
- Registers the hook in `code-quality-plugin/hooks.json` with `continueOnBlock: true` so the cue feeds back to the model without aborting the turn
- Wires `"hooks": "./hooks.json"` into `code-quality-plugin/.claude-plugin/plugin.json`
- Documents the behaviour in a new "PostToolUse Pre-flight Cue" section in the plugin README

## ADR-0017 Compliance

- **Conditional**: silenced for `.md`/`.txt`, `CHANGELOG.md`, test/spec files, lockfiles, `docs/adrs|prds` paths
- **Deduped once per session**: marker under `~/.cache/code-quality-preflight-cue/<session_id>`
- **Terse**: cue text <=25 words
- **Cheapest channel**: `{"decision":"block","reason":"..."}` with `continueOnBlock: true` per ADR-0017 §4

## Test plan

- [ ] `bash code-quality-plugin/hooks/test-code-quality-preflight-cue.sh` passes 15/15 assertions (a-h from spec)
- [ ] `bash scripts/lint-shell-scripts.sh code-quality-plugin/hooks/code-quality-preflight-cue.sh` reports 0 errors
- [ ] `CODE_QUALITY_SKIP_HOOKS=1` silences all output
- [ ] `CODE_QUALITY_PREFLIGHT_CUE_CACHE_DIR=/tmp/test` redirects marker storage

Closes #1612
Refs #1599

https://claude.ai/code/session_01CviK9baM61wLFdLcCwuFcY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CviK9baM61wLFdLcCwuFcY)_