### PR TITLE
docs(blueprint-plugin): add behavioral-cue registry

### DIFF
--- a/blueprint-plugin/README.md
+++ b/blueprint-plugin/README.md
@@ -6,6 +6,8 @@ Blueprint Development methodology for Claude Code - structured feature developme
 
 See [`docs/flow.md`](docs/flow.md) for a diagram of how the skills fit together.
 
+See [`docs/behavioral-cue-registry.md`](docs/behavioral-cue-registry.md) for the registry of all behavioral-cue hooks (events, matchers, channels, dedup keys) mandated by ADR-0017.
+
 ## Overview
 
 This plugin provides a documentation-first development workflow:

--- a/blueprint-plugin/docs/behavioral-cue-registry.md
+++ b/blueprint-plugin/docs/behavioral-cue-registry.md
@@ -1,0 +1,48 @@
+# Behavioral Cue Registry
+
+Hand-maintained audit table of all hook-based behavioral cues in the
+repository, mandated by ADR-0017 (Risks table: "Registry doc lists all
+cues, events, dedup keys for audit"). Update this table whenever a new
+cue hook is added, modified, or removed.
+
+A future generator could produce this from `*/hooks.json` files by
+scanning for hooks whose scripts match `*-cue.sh` or `*-nudge.sh`; for
+now this file is hand-maintained.
+
+## Cue Registry
+
+| Hook script | Plugin | Event | Matcher | Channel | Dedup key | Trigger summary |
+|---|---|---|---|---|---|---|
+| `blueprint-plugin/hooks/blueprint-structural-cue.sh` | `blueprint-plugin` | `PostToolUse` | `Edit\|Write` | `updatedToolOutput` | `~/.cache/blueprint-structural-cue/<session_id>` | Manifest edit (`plugin.json`, `marketplace.json`), public-symbol/export line, TS `export interface/type`, exported Go/Rust types, route registration, or schema/IDL files (`*.proto`, `*.graphql`, `openapi*`) — widened by #1616. Excludes `docs/adrs/**` and `docs/prds/**`. Bypass: `BLUEPRINT_SKIP_HOOKS=1`. |
+| `codebase-attributes-plugin/hooks/attributes-health-cue.sh` | `codebase-attributes-plugin` | `SessionStart` | `""` (all) | `additionalContext` | `~/.cache/attributes-health-cue/<session_id>` | `.claude/attributes.json` present in project root. _(PR #1619, pending merge.)_ |
+| `session-plugin/hooks/session-end-nudge.sh` | `session-plugin` | `Stop` | _(none)_ | `decision:block` | `~/.cache/claude-session-end-nudge/<session_id>` | ≥6 genuine user turns + wind-down phrase in last 3 user messages + distillable surface (taskwarrior or `.claude/rules/`/justfile). Skips when session-wrap/end/distill skill already in transcript. Appends taskwarrior state-sync cue when open tasks exist (#1618). |
+| `code-quality-plugin/hooks/code-quality-preflight-cue.sh` | `code-quality-plugin` | `PostToolUse` | `Edit\|Write` | `decision:block` + `continueOnBlock` | `~/.cache/code-quality-preflight-cue/<session_id>` | Large or structurally significant edit. _(PR #1623, pending merge.)_ |
+| `session-plugin/hooks/session-spinup-nudge.sh` | `session-plugin` | `SessionStart` | `""` (`startup\|resume` only) | `additionalContext` | `~/.cache/claude-session-spinup-nudge/<session_id>` | Uncommitted changes, unpushed commits, or open taskwarrior tasks for the project at session start. Pre-ADR-0017; included for completeness. |
+| `hooks-plugin/hooks/bash-antipatterns-teach.sh` | `hooks-plugin` | `PostToolUse` | `Bash` | `updatedToolOutput` | `${TMPDIR}/claude-bash-teach-seen/<session_id>` | Soft-teach antipatterns: `cat file`→Read; `head`/`tail file`→Read with offset/limit; `find -name` without discovery flags→Glob; standalone `grep`/`rg`→Grep; `ls *glob*`→Glob. Opt-in: no-ops unless `CLAUDE_HOOKS_ENABLE_BASH_ANTIPATTERNS_TEACH=1`. Pre-ADR-0017; included for completeness. |
+
+## Collision Audit
+
+Two rows fire on `PostToolUse` with matcher `Edit|Write`:
+
+| Cue | Detection focus |
+|-----|----------------|
+| `blueprint-structural-cue.sh` | Manifests and public-symbol export lines |
+| `code-quality-preflight-cue.sh` _(#1623, pending)_ | Large or structurally significant edits |
+
+Both hooks may fire on the same edit event. Mitigations:
+
+- **Disjoint per-session dedup keys** — each hook maintains its own marker
+  file under a different cache path; firing one never suppresses the other.
+- **Idempotent fire-once markers** — each cue fires at most once per session
+  regardless of how many overlapping edits occur.
+- **Different channels** — `blueprint-structural-cue.sh` uses
+  `updatedToolOutput`; `code-quality-preflight-cue.sh` uses
+  `decision:block + continueOnBlock`. They do not interfere at the harness level.
+- **Cross-plugin hook order is not guaranteed** — the harness may run the two
+  hooks in any order; neither assumes the other has or has not fired.
+
+If both cues fire on the same edit, the model receives two independent signals
+in the same turn — acceptable but worth monitoring for cue fatigue. If overlap
+grows, consider merging the hooks or adding an explicit mutual-exclusion guard.
+Authors of future `Edit|Write` PostToolUse cues should document their detection
+logic here before merge.

--- a/docs/adrs/0017-hook-based-behavioral-cues-for-plugin-utilization.md
+++ b/docs/adrs/0017-hook-based-behavioral-cues-for-plugin-utilization.md
@@ -218,3 +218,4 @@ check blueprint context. This ADR specifies it; implementation is a follow-up PR
 - [ADR-0003: Auto-Discovery Component Pattern](0003-auto-discovery-component-pattern.md)
 - [ADR-0015: Adopt Agent Teams and Deprecate Manual Orchestration](0015-agent-teams-adoption.md)
 - [ADR-0016: Extract Deterministic Skill Procedure into Structured-Output Scripts](0016-deterministic-script-extraction-for-token-efficiency.md)
+- `blueprint-plugin/docs/behavioral-cue-registry.md` — registry of all cue hooks: events, matchers, channels, dedup keys


### PR DESCRIPTION
## Summary

- Creates `blueprint-plugin/docs/behavioral-cue-registry.md` — a 6-row table enumerating all behavioral-cue hooks in the repo with hook script, plugin, event, matcher, channel, dedup key, and trigger summary
- Adds a **Collision Audit** subsection flagging that `blueprint-structural-cue.sh` and `code-quality-preflight-cue.sh` (PR #1623, pending) both register `PostToolUse` `Edit|Write`, with mitigations documented
- Adds a reference line to the registry in ADR-0017's References section
- Links the registry from `blueprint-plugin/README.md`

Implements the registry mandated by ADR-0017 Risks table: "Registry doc lists all cues, events, dedup keys for audit."

## Cue hooks enumerated (6 rows)

| Hook | Event | Status |
|---|---|---|
| `blueprint-structural-cue.sh` | PostToolUse Edit\|Write | on main |
| `attributes-health-cue.sh` | SessionStart | PR #1619, pending |
| `session-end-nudge.sh` | Stop | on main |
| `code-quality-preflight-cue.sh` | PostToolUse Edit\|Write | PR #1623, pending |
| `session-spinup-nudge.sh` | SessionStart | on main (pre-ADR-0017) |
| `bash-antipatterns-teach.sh` | PostToolUse Bash | on main (pre-ADR-0017, opt-in) |

## Test plan

- [ ] Registry table renders correctly in GitHub markdown
- [ ] All hook script paths and dedup keys verified against source files before writing
- [ ] Collision audit covers the two overlapping PostToolUse Edit|Write cues
- [ ] ADR-0017 References section links resolve correctly
- [ ] README link to registry resolves correctly

https://claude.ai/code/session_01CviK9baM61wLFdLcCwuFcY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CviK9baM61wLFdLcCwuFcY)_