### PR TITLE
feat(evaluate-plugin): weak-model skill validation — legibility + matrix gates + fixtures

### DIFF
--- a/.claude/rules/skill-evaluation.md
+++ b/.claude/rules/skill-evaluation.md
@@ -18,7 +18,7 @@ tiers always; reserve the expensive tier for a small golden set.
 |------|------|-------|---------|---------|
 | 0 — static | free | all skills | every PR | `scripts/plugin-compliance-check.sh`, the lints |
 | 1 — deterministic evals | ~free (no judge) | skills with an `evals.json` | CI on changed skill | `evaluate-plugin/scripts/grade_deterministic.py` |
-| 2 — cross-model matrix | budgeted | **golden set only**, opus/sonnet/haiku | monthly + on model release | `/evaluate:skill`, `render_matrix_report.py` |
+| 2 — cross-model matrix | budgeted | **golden set only**, opus/sonnet/haiku | monthly + on model release | `/evaluate:matrix`, `render_matrix_report.py` |
 
 Tier 0 catches structural rot for free. Tier 2 is the only thing that costs
 tokens, and it is bounded to the canary set.

--- a/evaluate-plugin/README.md
+++ b/evaluate-plugin/README.md
@@ -27,6 +27,7 @@ Static compliance checks (`plugin-compliance-check.sh`) verify structure — thi
 | `/evaluate:report` | View evaluation results and benchmark reports |
 | `/evaluate:improve` | Suggest improvements based on eval results |
 | `/evaluate:legibility` | Cold-read a SKILL.md with a zero-context agent reader to check its intent is legible (comprehension gate) |
+| `/evaluate:matrix` | Run a skill's evals across pinned models with real execution and grade the artifact (executability gate) |
 
 ## Agents
 
@@ -103,12 +104,16 @@ winner. The ranking is recorded in `history.json`.
 | `scripts/aggregate_benchmark.sh` | Aggregate benchmark results across a plugin's skills |
 | `scripts/eval_report.sh` | Generate formatted markdown report from benchmark data |
 | `scripts/grade_deterministic.py` | Grade machine-checkable (regex/substring) assertions with zero judge tokens; defers fuzzy ones to `eval-grader` |
-| `scripts/render_matrix_report.py` | Render the cross-model delta report from a `model-matrix.json` |
+| `scripts/render_matrix_report.py` | Render the cross-model delta report from a `model-matrix.json` (delta verdict, portability flag, `executable_on_haiku` executability flag) |
 
 ## Cross-Model Evaluation
 
 Measuring skill effectiveness reproducibly across opus / sonnet / haiku — to
 catch when a skill needs adjusting after a new model ships — is designed in
-[`docs/cross-model-evaluation.md`](docs/cross-model-evaluation.md). The
-token-frugal grader and report format prototyped there run against
-`git-plugin/skills/git-commit/evals.json` today.
+[`docs/cross-model-evaluation.md`](docs/cross-model-evaluation.md) and driven by
+**`/evaluate:matrix`** (the executability gate). The token-frugal grader and
+report format run against `git-plugin/skills/git-commit/evals.json` today.
+
+The two weak-model gates are complementary: `/evaluate:legibility` reads a
+SKILL.md cold (comprehension), while `/evaluate:matrix` runs it on a weak model
+with real tool execution and grades the artifact (executability).

--- a/evaluate-plugin/README.md
+++ b/evaluate-plugin/README.md
@@ -26,6 +26,7 @@ Static compliance checks (`plugin-compliance-check.sh`) verify structure — thi
 | `/evaluate:plugin` | Batch evaluate all skills in a plugin |
 | `/evaluate:report` | View evaluation results and benchmark reports |
 | `/evaluate:improve` | Suggest improvements based on eval results |
+| `/evaluate:legibility` | Cold-read a SKILL.md with a zero-context agent reader to check its intent is legible (comprehension gate) |
 
 ## Agents
 

--- a/evaluate-plugin/README.md
+++ b/evaluate-plugin/README.md
@@ -105,6 +105,7 @@ winner. The ranking is recorded in `history.json`.
 | `scripts/eval_report.sh` | Generate formatted markdown report from benchmark data |
 | `scripts/grade_deterministic.py` | Grade machine-checkable (regex/substring) assertions with zero judge tokens; defers fuzzy ones to `eval-grader` |
 | `scripts/render_matrix_report.py` | Render the cross-model delta report from a `model-matrix.json` (delta verdict, portability flag, `executable_on_haiku` executability flag) |
+| `scripts/apply_fixture.sh` | Apply/tear down an eval's opt-in `fixture` block in an isolated temp workdir so context-needing skills can honestly execute |
 
 ## Cross-Model Evaluation
 

--- a/evaluate-plugin/docs/cross-model-evaluation.md
+++ b/evaluate-plugin/docs/cross-model-evaluation.md
@@ -138,7 +138,8 @@ be worth not eyeballing.
 | `scripts/tests/test_grade_deterministic.sh` | done — 14 assertions, wired for CI |
 | `model-matrix.json` schema | done — documented; example fixture renders |
 | `/evaluate:matrix` orchestration skill | done — runs the matrix, grades deterministic-first, renders the executability flag |
-| Golden set definition (`golden-set.json`) | follow-up |
+| Golden set definition (`golden-set.json`) | done — 16 canaries across 6 patterns |
+| Fixture / scaffolding layer (`evals[].fixture`, `apply_fixture.sh`) | done — opt-in, isolated temp workdir, golden-set scope |
 | Cron / model-release trigger | follow-up |
 
 ## Related

--- a/evaluate-plugin/docs/cross-model-evaluation.md
+++ b/evaluate-plugin/docs/cross-model-evaluation.md
@@ -137,7 +137,7 @@ be worth not eyeballing.
 | `scripts/render_matrix_report.py` | done — delta table, verdicts, portability flag |
 | `scripts/tests/test_grade_deterministic.sh` | done — 14 assertions, wired for CI |
 | `model-matrix.json` schema | done — documented; example fixture renders |
-| `/evaluate:matrix` orchestration skill | follow-up |
+| `/evaluate:matrix` orchestration skill | done — runs the matrix, grades deterministic-first, renders the executability flag |
 | Golden set definition (`golden-set.json`) | follow-up |
 | Cron / model-release trigger | follow-up |
 

--- a/evaluate-plugin/golden-set.json
+++ b/evaluate-plugin/golden-set.json
@@ -1,0 +1,29 @@
+{
+  "_note": "The cross-model (Tier-2) canary set. ~15-25 representative, high-traffic, or high-risk skills covering distinct patterns. /evaluate:matrix runs the full sweep against these; the long tail stays on Tier 0/1. See .claude/rules/skill-evaluation.md (Principle 3) and docs/cross-model-evaluation.md. Only golden-set skills should carry fixture blocks (references/schemas.md).",
+  "patterns": [
+    "cli-wrapper",
+    "multi-step-orchestrator",
+    "ask-user-question",
+    "file-generator",
+    "convention-enforcer",
+    "weak-model-gate"
+  ],
+  "canaries": [
+    { "skill": "tools-plugin/rg-code-search", "pattern": "cli-wrapper" },
+    { "skill": "tools-plugin/jq-json-processing", "pattern": "cli-wrapper" },
+    { "skill": "tools-plugin/fd-file-finding", "pattern": "cli-wrapper" },
+    { "skill": "git-plugin/git-cli-agentic", "pattern": "cli-wrapper" },
+    { "skill": "blueprint-plugin/blueprint-execute", "pattern": "multi-step-orchestrator" },
+    { "skill": "blueprint-plugin/blueprint-prp-create", "pattern": "multi-step-orchestrator" },
+    { "skill": "agent-patterns-plugin/parallel-agent-dispatch", "pattern": "multi-step-orchestrator" },
+    { "skill": "session-plugin/session-wrap", "pattern": "ask-user-question" },
+    { "skill": "session-plugin/session-end", "pattern": "ask-user-question" },
+    { "skill": "configure-plugin/configure-readme", "pattern": "file-generator" },
+    { "skill": "documentation-plugin/docs-generate", "pattern": "file-generator" },
+    { "skill": "git-plugin/git-commit", "pattern": "convention-enforcer" },
+    { "skill": "git-plugin/github-pr-title", "pattern": "convention-enforcer" },
+    { "skill": "code-quality-plugin/code-review", "pattern": "convention-enforcer" },
+    { "skill": "evaluate-plugin/evaluate-legibility", "pattern": "weak-model-gate" },
+    { "skill": "evaluate-plugin/evaluate-matrix", "pattern": "weak-model-gate" }
+  ]
+}

--- a/evaluate-plugin/references/schemas.md
+++ b/evaluate-plugin/references/schemas.md
@@ -21,6 +21,12 @@ Defines test cases for a skill. Lives alongside the SKILL.md it tests. **Version
       "context_files": [
         "string — optional files to make available during evaluation"
       ],
+      "fixture": {
+        "dir": "string — optional fixture template dir (relative to the evals.json) copied into the temp workdir",
+        "setup": ["string — shell commands run in the temp workdir after the copy"],
+        "teardown": ["string — optional commands run before the temp dir is discarded"],
+        "workdir": "string — optional; where the eval subagent runs (default: the temp dir)"
+      },
       "tags": [
         "string — categorization tags for filtering"
       ]
@@ -40,7 +46,49 @@ Defines test cases for a skill. Lives alongside the SKILL.md it tests. **Version
 | `evals[].prompt` | Yes | The simulated user request |
 | `evals[].expectations` | Yes | List of assertion strings (grader checks these) |
 | `evals[].context_files` | No | Files to include in evaluation context |
+| `evals[].fixture` | No | Opt-in execution scaffold (see below). Evals without it run unchanged |
 | `evals[].tags` | No | Tags for filtering (e.g., `basic`, `edge-case`) |
+
+### Fixtures (opt-in execution scaffold)
+
+A context-needing skill cannot honestly execute in eval without a real
+workdir — without one it fails on a weak model purely for lack of fixtures, a
+false negative that poisons the executability gate (`/evaluate:matrix`). The
+optional `fixture` block gives such an eval an isolated, throwaway workdir.
+
+`fixture` is **additive and back-compatible**: evals without it run exactly as
+today, and `grade_deterministic.py` is unaffected (it reads only
+`expectations`). `scripts/apply_fixture.sh` applies it — `mktemp -d` a workdir
+**outside the repo**, copy `dir`, run `setup`, emit `WORKDIR=`; teardown runs
+`teardown` then `rm -rf`s the dir (refusing any path outside the temp root,
+since `setup` is arbitrary shell — see `.claude/rules/sandbox-guidance.md`).
+Fixture templates live beside `evals.json`. Scope `fixture` blocks to the
+golden-set canaries (`golden-set.json`).
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `fixture.dir` | No | Template dir (relative to `evals.json`) copied into the workdir |
+| `fixture.setup` | No | Shell commands run in the workdir after the copy |
+| `fixture.teardown` | No | Commands run before the workdir is discarded (dir removed by default) |
+| `fixture.workdir` | No | Where the eval subagent runs (default: the temp dir) |
+
+Worked example — `git-commit`'s gc-001 in a real staged repo:
+
+```json
+{
+  "id": "gc-001",
+  "prompt": "I just added a new OAuth login feature to the auth module. Please commit my staged changes.",
+  "fixture": {
+    "setup": ["git init -q", "printf 'oauth code' > auth.py", "git add auth.py"]
+  },
+  "expectations": [
+    { "assertion": "Commit message starts with feat(", "check": "regex", "pattern": "^feat\\(", "scope": "subject" }
+  ]
+}
+```
+
+The subagent runs `git-commit` in the staged-repo `WORKDIR`; the produced
+commit message is graded exactly as before.
 
 ### Writing Good Assertions
 

--- a/evaluate-plugin/scripts/apply_fixture.sh
+++ b/evaluate-plugin/scripts/apply_fixture.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Apply (or tear down) an eval's optional `fixture` block in an isolated temp
+# workdir, so a context-needing skill can honestly execute during evaluation.
+#
+# Without an honest execution context, context-needing skills fail on a weak
+# model purely for lack of fixtures — a false negative that poisons the Slice-2
+# executability gate. This script gives each such eval a real, throwaway workdir.
+#
+# The `fixture` block is additive and opt-in (see references/schemas.md). Evals
+# without it run exactly as before; grade_deterministic.py is unaffected (it
+# reads only `expectations`).
+#
+# Safety (the setup commands are arbitrary shell from evals.json): the workdir
+# is always a fresh `mktemp -d` OUTSIDE the repo (honoring the worktree
+# write-allowlist, .claude/rules/sandbox-guidance.md); teardown refuses any path
+# not under the temp root. The blast radius is one disposable directory.
+#
+# Usage:
+#   apply_fixture.sh --fixture '<json>'  [--repo-root <path>]   # apply
+#   apply_fixture.sh --fixture '@file'   [--repo-root <path>]   # apply (from file)
+#   apply_fixture.sh --teardown <workdir> [--fixture '<json>']  # teardown
+#
+# Apply output (KEY=value, see .claude/rules/structured-script-output.md):
+#   === APPLY FIXTURE ===
+#   FIXTURE_APPLIED=true|false
+#   WORKDIR=<absolute temp path>        (only when FIXTURE_APPLIED=true)
+#   DIR_COPIED=true|false
+#   SETUP_COUNT=<int>
+#   STATUS=OK|ERROR
+#   === END APPLY FIXTURE ===
+
+set -uo pipefail
+
+mode="apply"
+fixture_arg=""
+repo_root="$(pwd)"
+teardown_dir=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --fixture) fixture_arg="$2"; shift 2 ;;
+    --repo-root) repo_root="$2"; shift 2 ;;
+    --teardown) mode="teardown"; teardown_dir="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+# Resolve --fixture into JSON text. Empty / "null" / "{}" all mean "no fixture".
+fixture_json="${fixture_arg}"
+case "$fixture_arg" in
+  @*) fixture_json="$(cat "${fixture_arg#@}" 2>/dev/null)" ;;
+esac
+[ -z "$fixture_json" ] && fixture_json="null"
+
+# Temp root: honor $TMPDIR but never the repo. mktemp -d lands here.
+# Normalize the trailing slash ($TMPDIR is slash-terminated on macOS) so the
+# teardown prefix guard matches the WORKDIR mktemp produced.
+tmp_root="${TMPDIR:-/tmp}"
+tmp_root="${tmp_root%/}"
+
+# ---------------------------------------------------------------------------
+# Teardown mode
+# ---------------------------------------------------------------------------
+if [ "$mode" = "teardown" ]; then
+  echo "=== TEARDOWN FIXTURE ==="
+  if [ -z "$teardown_dir" ]; then
+    echo "STATUS=ERROR"
+    echo "ERROR=--teardown requires a workdir path"
+    echo "=== END TEARDOWN FIXTURE ==="
+    exit 1
+  fi
+  # Refuse to remove anything outside the temp root — the setup commands are
+  # untrusted, so this guard is the backstop against a poisoned WORKDIR value.
+  abs_teardown="$teardown_dir"
+  case "$abs_teardown" in
+    "$tmp_root"/*) : ;;
+    /tmp/*|/var/folders/*) : ;;  # macOS mktemp lives under /var/folders
+    *)
+      echo "STATUS=ERROR"
+      echo "ERROR=refusing to tear down a path outside the temp root: ${teardown_dir}"
+      echo "=== END TEARDOWN FIXTURE ==="
+      exit 1
+      ;;
+  esac
+  # Run optional teardown commands first, then discard the dir.
+  if [ -d "$abs_teardown" ]; then
+    while IFS= read -r cmd; do
+      [ -z "$cmd" ] && continue
+      ( cd "$abs_teardown" && bash -c "$cmd" ) >/dev/null 2>&1
+    done < <(printf '%s' "$fixture_json" | jq -r '.teardown[]?' 2>/dev/null)
+    rm -rf "$abs_teardown"
+  fi
+  echo "TEARDOWN_DONE=true"
+  echo "STATUS=OK"
+  echo "=== END TEARDOWN FIXTURE ==="
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Apply mode
+# ---------------------------------------------------------------------------
+echo "=== APPLY FIXTURE ==="
+
+has_dir="$(printf '%s' "$fixture_json" | jq -r '(.dir // "") | tostring' 2>/dev/null)"
+setup_count="$(printf '%s' "$fixture_json" | jq -r '(.setup // []) | length' 2>/dev/null)"
+[ -z "$setup_count" ] && setup_count=0
+
+# No-op when the eval carries no fixture (back-compat): the eval runs in the
+# repo exactly as today.
+if [ "$fixture_json" = "null" ] || { [ -z "$has_dir" ] && [ "$setup_count" = "0" ]; }; then
+  echo "FIXTURE_APPLIED=false"
+  echo "DIR_COPIED=false"
+  echo "SETUP_COUNT=0"
+  echo "STATUS=OK"
+  echo "=== END APPLY FIXTURE ==="
+  exit 0
+fi
+
+workdir="$(mktemp -d "${tmp_root%/}/eval-fixture.XXXXXX")"
+if [ -z "$workdir" ] || [ ! -d "$workdir" ]; then
+  echo "FIXTURE_APPLIED=false"
+  echo "STATUS=ERROR"
+  echo "ERROR=mktemp -d failed"
+  echo "=== END APPLY FIXTURE ==="
+  exit 1
+fi
+
+dir_copied=false
+if [ -n "$has_dir" ]; then
+  src="${repo_root%/}/${has_dir}"
+  if [ ! -d "$src" ]; then
+    rm -rf "$workdir"
+    echo "FIXTURE_APPLIED=false"
+    echo "STATUS=ERROR"
+    echo "ERROR=fixture.dir not found: ${src}"
+    echo "=== END APPLY FIXTURE ==="
+    exit 1
+  fi
+  # Copy template contents (including dotfiles) into the workdir.
+  cp -R "$src"/. "$workdir"/ 2>/dev/null
+  dir_copied=true
+fi
+
+# Run setup commands sequentially in the workdir. Fail loudly on first error.
+setup_failed=false
+while IFS= read -r cmd; do
+  [ -z "$cmd" ] && continue
+  if ! ( cd "$workdir" && bash -c "$cmd" ) >/dev/null 2>&1; then
+    setup_failed=true
+    failed_cmd="$cmd"
+    break
+  fi
+done < <(printf '%s' "$fixture_json" | jq -r '.setup[]?' 2>/dev/null)
+
+if [ "$setup_failed" = true ]; then
+  rm -rf "$workdir"
+  echo "FIXTURE_APPLIED=false"
+  echo "DIR_COPIED=${dir_copied}"
+  echo "SETUP_COUNT=${setup_count}"
+  echo "STATUS=ERROR"
+  echo "ERROR=setup command failed: ${failed_cmd}"
+  echo "=== END APPLY FIXTURE ==="
+  exit 1
+fi
+
+echo "FIXTURE_APPLIED=true"
+echo "WORKDIR=${workdir}"
+echo "DIR_COPIED=${dir_copied}"
+echo "SETUP_COUNT=${setup_count}"
+echo "STATUS=OK"
+echo "=== END APPLY FIXTURE ==="

--- a/evaluate-plugin/scripts/render_matrix_report.py
+++ b/evaluate-plugin/scripts/render_matrix_report.py
@@ -25,6 +25,14 @@ EARNS_KEEP_DELTA = 0.15   # with-skill clearly beats baseline
 REDUNDANT_BASELINE = 0.85  # baseline already strong; skill may be redundant
 FIGHTING_DELTA = -0.05    # with-skill underperforms baseline
 
+# Executability floor (absolute with-skill pass rate, not a delta). The
+# executability gate asks "can a weak model actually DO the task" — distinct
+# from the delta verdict (does the skill beat the baseline) and the portability
+# flag (opus−haiku spread). When haiku's absolute with-skill rate sits below
+# this floor while opus clears it, the skill is effectively not executable on
+# haiku. See evaluate-matrix/SKILL.md and docs/cross-model-evaluation.md.
+HAIKU_EXEC_FLOOR = 0.5
+
 
 def _pct(x) -> str:
     return "—" if x is None else f"{round(x * 100)}%"
@@ -112,6 +120,26 @@ def render(matrix: dict) -> str:
             f"> **Portability flag:** opus with-skill ({_pct(opus)}) exceeds haiku "
             f"({_pct(haiku)}) by ≥20 points — the skill leans on reasoning the cheaper "
             f"model lacks. Consider simplifying the skill or pinning `model:` in frontmatter."
+        )
+        out.append("")
+
+    # Executability flag (Slice 2): absolute haiku capability, not spread. When
+    # haiku's with-skill rate is below the floor while opus clears it, a weak
+    # model cannot actually *do* the task even with the skill loaded. Additive
+    # and backward compatible — emits nothing when haiku is at/above the floor
+    # (or either model is missing).
+    if (
+        opus is not None
+        and haiku is not None
+        and haiku < HAIKU_EXEC_FLOOR <= opus
+    ):
+        out.append(
+            f"> **Executability flag:** `executable_on_haiku=false` — haiku with-skill "
+            f"pass rate ({_pct(haiku)}) is below the {round(HAIKU_EXEC_FLOOR * 100)}% "
+            f"floor while opus reaches {_pct(opus)}. A weak model cannot carry out the "
+            f"task even with the skill loaded; this poisons the executability gate until "
+            f"the skill is simplified or the eval gains an honest execution context "
+            f"(see Slice 3 fixtures)."
         )
         out.append("")
 

--- a/evaluate-plugin/scripts/tests/fixtures/low-haiku-model-matrix.json
+++ b/evaluate-plugin/scripts/tests/fixtures/low-haiku-model-matrix.json
@@ -1,0 +1,27 @@
+{
+  "_note": "ILLUSTRATIVE EXAMPLE DATA — not a real run. Haiku with-skill sits below the 0.5 executability floor while opus clears it, so render_matrix_report.py must emit the `executable_on_haiku=false` callout. Distinct from example-model-matrix.json, where haiku (0.7) is above the floor and the callout is absent.",
+  "metadata": {
+    "skill_path": "some-plugin/skills/context-heavy-skill/SKILL.md",
+    "generated_at": "2026-06-13T00:00:00Z",
+    "previous_run": null,
+    "models": [
+      { "alias": "opus", "model_id": "claude-opus-4-8" },
+      { "alias": "haiku", "model_id": "claude-haiku-4-5" }
+    ]
+  },
+  "evals": [
+    {
+      "eval_id": "ch-001",
+      "by_model": {
+        "opus": { "with_skill": 0.9, "baseline": 0.5 },
+        "haiku": { "with_skill": 0.3, "baseline": 0.1 }
+      }
+    }
+  ],
+  "summary": {
+    "by_model": {
+      "opus": { "with_skill": 0.9, "baseline": 0.5, "delta": 0.4, "prev_delta": null },
+      "haiku": { "with_skill": 0.3, "baseline": 0.1, "delta": 0.2, "prev_delta": null }
+    }
+  }
+}

--- a/evaluate-plugin/scripts/tests/test-emit-legibility-prompt.sh
+++ b/evaluate-plugin/scripts/tests/test-emit-legibility-prompt.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Regression test for emit-legibility-prompt.sh (Slice 1: legibility gate).
+#
+# Per .claude/rules/regression-testing.md, the prompt-emitter ships with a test
+# proving: (a) a valid plugin/skill resolves to an absolute SKILL.md path and
+# emits the cold-reader prompt with the verdict tokens, (b) a malformed argument
+# is rejected with STATUS=ERROR, (c) a missing SKILL.md is rejected with
+# STATUS=ERROR, and (d) the emitted prompt carries the QUESTIONS/HESITATIONS
+# headings and the clear|needs-revision verdict that Step-3 triage consumes.
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+emitter="$(dirname "$script_dir")/../skills/evaluate-legibility/scripts/emit-legibility-prompt.sh"
+
+fail_count=0
+pass_count=0
+
+check() {
+  # check <description> <expected> <actual>
+  if [ "$2" = "$3" ]; then
+    pass_count=$((pass_count + 1))
+  else
+    echo "FAIL: $1 (expected '$2', got '$3')" >&2
+    fail_count=$((fail_count + 1))
+  fi
+}
+
+contains() {
+  # contains <description> <haystack> <needle>
+  if printf '%s' "$2" | grep -qF -- "$3"; then
+    pass_count=$((pass_count + 1))
+  else
+    echo "FAIL: $1 (output missing '$3')" >&2
+    fail_count=$((fail_count + 1))
+  fi
+}
+
+field() {
+  printf '%s\n' "$1" | grep -m1 "^$2=" | cut -d= -f2
+}
+
+# Build a throwaway repo with one well-formed skill.
+tmp_root="$(mktemp -d)"
+trap 'rm -rf "$tmp_root"' EXIT
+mkdir -p "$tmp_root/demo-plugin/skills/demo-skill"
+cat > "$tmp_root/demo-plugin/skills/demo-skill/SKILL.md" <<'EOF'
+---
+name: demo-skill
+description: Demo. Use when testing the legibility emitter.
+---
+
+# /demo:demo-skill
+
+## Execution
+
+Run the thing.
+EOF
+
+echo "=== TEST: valid plugin/skill resolves and emits prompt ==="
+good_out="$("$emitter" --plugin-skill demo-plugin/demo-skill --repo-root "$tmp_root")"
+check "good: status" "OK" "$(field "$good_out" STATUS)"
+check "good: issue count" "0" "$(field "$good_out" ISSUE_COUNT)"
+check "good: plugin" "demo-plugin" "$(field "$good_out" PLUGIN)"
+check "good: skill" "demo-skill" "$(field "$good_out" SKILL)"
+# SKILL_PATH must be absolute.
+skill_path="$(field "$good_out" SKILL_PATH)"
+case "$skill_path" in
+  /*) pass_count=$((pass_count + 1)) ;;
+  *) echo "FAIL: SKILL_PATH not absolute ('$skill_path')" >&2; fail_count=$((fail_count + 1)) ;;
+esac
+# Prompt block carries the cold-reader schema tokens.
+contains "good: prompt has QUESTIONS" "$good_out" "QUESTIONS"
+contains "good: prompt has HESITATIONS" "$good_out" "HESITATIONS"
+# shellcheck disable=SC2016  # literal backticks are the needle, not command substitution
+contains "good: prompt has clear|needs-revision verdict" "$good_out" '`clear` | `needs-revision`'
+contains "good: prompt asks WHEN to invoke" "$good_out" "WHEN to invoke"
+contains "good: prompt asks FIRST concrete action" "$good_out" "FIRST concrete action"
+contains "good: emits PROMPT block delimiters" "$good_out" "=== PROMPT ==="
+
+echo "=== TEST: malformed argument is rejected ==="
+bad_arg_out="$("$emitter" --plugin-skill no-slash-here --repo-root "$tmp_root")"
+check "bad-arg: status" "ERROR" "$(field "$bad_arg_out" STATUS)"
+"$emitter" --plugin-skill no-slash-here --repo-root "$tmp_root" >/dev/null
+check "bad-arg: exit code" "1" "$?"
+
+echo "=== TEST: missing argument is rejected ==="
+missing_arg_out="$("$emitter" --repo-root "$tmp_root")"
+check "missing-arg: status" "ERROR" "$(field "$missing_arg_out" STATUS)"
+
+echo "=== TEST: missing SKILL.md is rejected ==="
+missing_out="$("$emitter" --plugin-skill demo-plugin/nonexistent --repo-root "$tmp_root")"
+check "missing-skill: status" "ERROR" "$(field "$missing_out" STATUS)"
+"$emitter" --plugin-skill demo-plugin/nonexistent --repo-root "$tmp_root" >/dev/null
+check "missing-skill: exit code" "1" "$?"
+
+echo ""
+echo "=== SUMMARY ==="
+echo "PASSED=$pass_count"
+echo "FAILED=$fail_count"
+if [ "$fail_count" -gt 0 ]; then
+  echo "STATUS=FAIL"
+  exit 1
+fi
+echo "STATUS=OK"

--- a/evaluate-plugin/scripts/tests/test_apply_fixture.sh
+++ b/evaluate-plugin/scripts/tests/test_apply_fixture.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Regression test for apply_fixture.sh (Slice 3: fixture/scaffolding layer).
+#
+# Per .claude/rules/regression-testing.md, the fixture run-engine ships with a
+# test proving: (a) a setup-only fixture yields an isolated $WORKDIR with the
+# expected state, (b) the workdir is a fresh temp dir OUTSIDE the repo, (c) an
+# eval with NO fixture is a no-op (back-compat — FIXTURE_APPLIED=false, no
+# WORKDIR), (d) teardown removes the dir, and (e) teardown refuses a path
+# outside the temp root (the untrusted-setup blast-radius guard).
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+apply="$(dirname "$script_dir")/apply_fixture.sh"
+repo_root="$(cd "$(dirname "$script_dir")/../.." && pwd)"
+
+fail_count=0
+pass_count=0
+
+check() {
+  if [ "$2" = "$3" ]; then
+    pass_count=$((pass_count + 1))
+  else
+    echo "FAIL: $1 (expected '$2', got '$3')" >&2
+    fail_count=$((fail_count + 1))
+  fi
+}
+
+field() {
+  printf '%s\n' "$1" | grep -m1 "^$2=" | cut -d= -f2
+}
+
+echo "=== TEST: setup-only fixture yields isolated staged-repo workdir ==="
+# Mirrors the Slice-3 minimal increment: git init + a staged file, no dir copy.
+setup_fixture='{"setup":["git init -q","printf hello > f.txt","git add f.txt"]}'
+apply_out="$("$apply" --fixture "$setup_fixture" --repo-root "$repo_root")"
+check "apply: status" "OK" "$(field "$apply_out" STATUS)"
+check "apply: applied" "true" "$(field "$apply_out" FIXTURE_APPLIED)"
+check "apply: dir not copied" "false" "$(field "$apply_out" DIR_COPIED)"
+check "apply: setup count" "3" "$(field "$apply_out" SETUP_COUNT)"
+
+workdir="$(field "$apply_out" WORKDIR)"
+# (b) workdir is absolute and OUTSIDE the repo.
+case "$workdir" in
+  /*) pass_count=$((pass_count + 1)) ;;
+  *) echo "FAIL: WORKDIR not absolute ('$workdir')" >&2; fail_count=$((fail_count + 1)) ;;
+esac
+case "$workdir" in
+  "$repo_root"/*) echo "FAIL: WORKDIR is inside the repo ('$workdir')" >&2; fail_count=$((fail_count + 1)) ;;
+  *) pass_count=$((pass_count + 1)) ;;
+esac
+# (a) the setup actually ran: a git repo with f.txt staged.
+if [ -d "$workdir/.git" ]; then pass_count=$((pass_count + 1)); else echo "FAIL: workdir has no .git" >&2; fail_count=$((fail_count + 1)); fi
+staged="$(cd "$workdir" && git diff --cached --name-only 2>/dev/null)"
+check "apply: f.txt is staged" "f.txt" "$staged"
+
+echo "=== TEST: no-fixture eval is a no-op (back-compat) ==="
+noop_out="$("$apply" --repo-root "$repo_root")"
+check "noop: applied" "false" "$(field "$noop_out" FIXTURE_APPLIED)"
+check "noop: status" "OK" "$(field "$noop_out" STATUS)"
+# No WORKDIR line at all.
+if printf '%s\n' "$noop_out" | grep -q "^WORKDIR="; then
+  echo "FAIL: no-fixture run emitted a WORKDIR" >&2; fail_count=$((fail_count + 1))
+else
+  pass_count=$((pass_count + 1))
+fi
+# Explicit empty-object fixture is also a no-op.
+empty_out="$("$apply" --fixture '{}' --repo-root "$repo_root")"
+check "empty: applied" "false" "$(field "$empty_out" FIXTURE_APPLIED)"
+
+echo "=== TEST: teardown removes the workdir ==="
+teardown_out="$("$apply" --teardown "$workdir")"
+check "teardown: status" "OK" "$(field "$teardown_out" STATUS)"
+check "teardown: done" "true" "$(field "$teardown_out" TEARDOWN_DONE)"
+if [ -d "$workdir" ]; then
+  echo "FAIL: workdir still exists after teardown ('$workdir')" >&2; fail_count=$((fail_count + 1))
+  rm -rf "$workdir"
+else
+  pass_count=$((pass_count + 1))
+fi
+
+echo "=== TEST: teardown refuses a path outside the temp root ==="
+guard_dir="$(mktemp -d)"
+mkdir -p "$repo_root/.git-fixture-probe-DO-NOT-REMOVE" 2>/dev/null || true
+unsafe="$repo_root/.git-fixture-probe-DO-NOT-REMOVE"
+guard_out="$("$apply" --teardown "$unsafe")"
+check "guard: refuses outside temp" "ERROR" "$(field "$guard_out" STATUS)"
+if [ -d "$unsafe" ]; then pass_count=$((pass_count + 1)); else echo "FAIL: guard removed an in-repo path!" >&2; fail_count=$((fail_count + 1)); fi
+rmdir "$unsafe" 2>/dev/null || rm -rf "$unsafe"
+rm -rf "$guard_dir"
+
+echo ""
+echo "=== SUMMARY ==="
+echo "PASSED=$pass_count"
+echo "FAILED=$fail_count"
+if [ "$fail_count" -gt 0 ]; then
+  echo "STATUS=FAIL"
+  exit 1
+fi
+echo "STATUS=OK"

--- a/evaluate-plugin/scripts/tests/test_grade_deterministic.sh
+++ b/evaluate-plugin/scripts/tests/test_grade_deterministic.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+# Test assertions use the `cmd && pass++ || fail` idiom deliberately (pass++ is
+# arithmetic that always exits 0 here, so the || branch only runs on real
+# failure) and pipe fixtures through cat for readability. Suppress the style
+# nags rather than rewrite every assertion.
+# shellcheck disable=SC2015,SC2002
+#
 # Regression test for grade_deterministic.py and render_matrix_report.py.
 #
 # Per .claude/rules/regression-testing.md, the deterministic grader (the
@@ -70,6 +76,20 @@ printf '%s\n' "$report" | grep -q "claude-opus-4-8" \
 printf '%s\n' "$report" | grep -q "Portability flag" \
   && pass_count=$((pass_count + 1)) \
   || { echo "FAIL: report missing portability flag (opus-haiku spread = 30pts)" >&2; fail_count=$((fail_count + 1)); }
+
+# Executability flag (Slice 2): absent when haiku (0.7) is above the 0.5 floor.
+printf '%s\n' "$report" | grep -q "executable_on_haiku=false" \
+  && { echo "FAIL: example report should NOT fire executability flag (haiku 0.7 >= floor)" >&2; fail_count=$((fail_count + 1)); } \
+  || pass_count=$((pass_count + 1))
+
+echo "=== TEST: executability callout fires when haiku < floor < opus ==="
+low_report="$(python3 "$renderer" "$fixtures/low-haiku-model-matrix.json")"
+printf '%s\n' "$low_report" | grep -q "executable_on_haiku=false" \
+  && pass_count=$((pass_count + 1)) \
+  || { echo "FAIL: low-haiku report missing executability flag (haiku 0.3 < 0.5 <= opus 0.9)" >&2; fail_count=$((fail_count + 1)); }
+printf '%s\n' "$low_report" | grep -q "Executability flag" \
+  && pass_count=$((pass_count + 1)) \
+  || { echo "FAIL: low-haiku report missing 'Executability flag' heading" >&2; fail_count=$((fail_count + 1)); }
 
 echo ""
 echo "=== SUMMARY ==="

--- a/evaluate-plugin/skills/evaluate-legibility/SKILL.md
+++ b/evaluate-plugin/skills/evaluate-legibility/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: evaluate-legibility
+description: Cold-read a SKILL.md with a zero-context agent reader to check its intent is legible. Use when validating whether a skill says clearly when to invoke it and how to start.
+args: <plugin/skill-name>
+allowed-tools: Task, Read, Glob, Bash(bash *), TodoWrite
+argument-hint: "git-plugin/git-commit"
+model: opus
+agent: general-purpose
+created: 2026-06-13
+modified: 2026-06-13
+reviewed: 2026-06-13
+---
+
+# /evaluate:legibility
+
+Dispatch an isolated, zero-context **agent reader** at a single `SKILL.md` and
+ask it the only two questions that matter for reuse: *from this file alone, can
+you tell WHEN to invoke the skill, and can you carry out its FIRST concrete
+action?* What confuses a cold agent reader is what will silently degrade
+auto-invocation and first-step execution for every future agent that loads the
+skill.
+
+This is the **comprehension** gate — read and critique, never execute. It
+reuses the dispatch contract of `agent-patterns-plugin:cold-read-gate` (isolated
+haiku reader, `QUESTIONS` / `HESITATIONS` / `verdict` schema, triage before
+acting). The difference: the reader here is an *agent* loading a skill, not a
+human triaging an outward artifact — so the persona and the triage table are
+skill-doc-specific. See that skill for the dispatch rationale; this skill does
+not restate it.
+
+The verdict is **advisory, not a CI gate**: haiku is non-deterministic, so a
+`needs-revision` is a prompt to look, never a merge block.
+
+## When to Use This Skill
+
+| Use this skill when... | Use alternative when... |
+|------------------------|------------------------|
+| Checking a SKILL.md reads clearly to a fresh agent | Testing whether the skill *executes* correctly -> `/evaluate:matrix` |
+| Triaging why a skill never auto-invokes | Need structural/lint validation -> `scripts/plugin-compliance-check.sh` |
+| Reviewing a newly-authored or just-edited skill | Gating outward issues/docs for a human reader -> `agent-patterns-plugin:cold-read-gate` |
+| Want a cheap, no-execution legibility read | Benchmarking effectiveness vs a baseline -> `/evaluate:skill` |
+
+## Context
+
+- Legibility prompt: !`bash ${CLAUDE_SKILL_DIR}/scripts/emit-legibility-prompt.sh --plugin-skill $1 --repo-root "$(pwd)"`
+
+## Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `<plugin/skill-name>` | required | Target skill as `plugin-name/skill-name` |
+
+## Execution
+
+Execute this legibility gate:
+
+### Step 1: Resolve the prompt
+
+The Context block above ran `emit-legibility-prompt.sh`, which resolved the
+target `SKILL.md` absolute path and emitted the cold-reader dispatch prompt
+between `=== PROMPT ===` and `=== END PROMPT ===`.
+
+If `STATUS=ERROR`, report the `ERROR=` line and stop (bad argument or missing
+SKILL.md). Otherwise read `SKILL_PATH=` and the `=== PROMPT ===` block.
+
+### Step 2: Dispatch the cold reader
+
+Spawn one `Task` subagent to read the skill cold:
+
+```
+Task subagent_type: general-purpose
+model: haiku
+prompt: <the text between === PROMPT === and === END PROMPT ===>
+```
+
+The reader is deliberately **haiku, isolated, and shown only the file path** —
+it is the measurement instrument, not a delegate (the sanctioned exception in
+`.claude/rules/agent-and-tool-selection.md`). Do not add context, do not let it
+explore the repo. Capture its final message: `QUESTIONS`, `HESITATIONS`, and a
+`verdict` of `clear` or `needs-revision`.
+
+### Step 3: Triage — genuine gaps vs test artifacts
+
+The cold reader cannot know the invocation context, so some complaints are
+artifacts of reading a skill in isolation. Triage before recommending changes:
+
+| Genuine gap — fix it | Test artifact — ignore it |
+|---|---|
+| No "When to Use" table; reader can't tell when to invoke | "What is plugin X?" when X is named in the frontmatter |
+| `description` has no "Use when…" trigger phrase | REFERENCE.md content absent (loaded on demand by design) |
+| First execution step names a script/term the file never defines | Harness vars (`$ARGUMENTS`, `${CLAUDE_SKILL_DIR}`) unrecognized |
+| Skill narrates ("this skill handles X") instead of an imperative step | Full tool list absent from the body (it's in `allowed-tools`) |
+| Acronym/jargon used before it is introduced | Demands for context a real invocation supplies |
+
+### Step 4: Report
+
+Print the verdict, the genuine-gap `QUESTIONS` (each with the quoted phrase that
+blocked the reader), and a one-line recommendation per gap. State explicitly
+that the verdict is advisory. Do **not** edit the skill — surfacing the gaps is
+the deliverable; fixing them is a separate, human-confirmed step.
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Resolve path + emit prompt | `bash evaluate-plugin/skills/evaluate-legibility/scripts/emit-legibility-prompt.sh --plugin-skill <plugin/skill>` |
+| Run the script test | `bash evaluate-plugin/scripts/tests/test-emit-legibility-prompt.sh` |
+
+## Quick Reference
+
+| Field | Meaning |
+|-------|---------|
+| `verdict: clear` | Reader could answer both (a) when and (b) first action |
+| `verdict: needs-revision` | A genuine gap blocked (a) or (b) — advisory, not a block |
+| `QUESTIONS` | Blocking confusions, each with a quoted phrase |
+| `HESITATIONS` | Non-blocking uncertainties |
+
+## Related
+
+- `agent-patterns-plugin:cold-read-gate` — the dispatch contract this reuses (outward artifacts, human reader)
+- `/evaluate:matrix` — the executability gate (run on haiku, grade the artifact)
+- `/evaluate:skill` — effectiveness vs a baseline (with-skill − baseline delta)
+- `.claude/rules/skill-evaluation.md` — the tiered measurement methodology

--- a/evaluate-plugin/skills/evaluate-legibility/scripts/emit-legibility-prompt.sh
+++ b/evaluate-plugin/skills/evaluate-legibility/scripts/emit-legibility-prompt.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Resolve a skill's SKILL.md and emit the cold-reader dispatch prompt for the
+# legibility gate (Slice 1 of weak-model skill validation).
+#
+# The body of evaluate-legibility/SKILL.md stays declarative: it invokes this
+# script to get the haiku dispatch prompt, then hands the PROMPT block to a
+# Task subagent. Keeping the prompt assembly here collapses the skill's
+# permission surface to `Bash(bash *)` (see .claude/rules/agentic-permissions.md).
+#
+# Reuses the cold-read-gate dispatch contract by name reference — see
+# agent-patterns-plugin:cold-read-gate. The reader persona and output schema
+# (QUESTIONS / HESITATIONS / verdict) mirror that skill; this script targets a
+# SKILL.md and an *agent* reader rather than an outward artifact and a human.
+#
+# Usage:
+#   emit-legibility-prompt.sh --plugin-skill <plugin/skill> [--repo-root <path>]
+#
+# Output: structured KEY=value (see .claude/rules/structured-script-output.md)
+#   === LEGIBILITY PROMPT ===
+#   SKILL_PATH=<absolute path>
+#   PLUGIN=<plugin>
+#   SKILL=<skill>
+#   STATUS=OK|ERROR
+#   ISSUE_COUNT=<int>
+#   === PROMPT ===
+#   <the dispatch prompt text>
+#   === END PROMPT ===
+#   === END LEGIBILITY PROMPT ===
+
+set -uo pipefail
+
+plugin_skill=""
+repo_root="$(pwd)"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --plugin-skill) plugin_skill="$2"; shift 2 ;;
+    --repo-root) repo_root="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+echo "=== LEGIBILITY PROMPT ==="
+
+if [ -z "$plugin_skill" ]; then
+  echo "STATUS=ERROR"
+  echo "ISSUE_COUNT=1"
+  echo "ERROR=--plugin-skill <plugin/skill> is required"
+  echo "=== END LEGIBILITY PROMPT ==="
+  exit 1
+fi
+
+# Split plugin/skill on the first slash. Accept exactly one slash.
+plugin_name="${plugin_skill%%/*}"
+skill_name="${plugin_skill#*/}"
+
+if [ -z "$plugin_name" ] || [ -z "$skill_name" ] || [ "$plugin_name" = "$plugin_skill" ]; then
+  echo "STATUS=ERROR"
+  echo "ISSUE_COUNT=1"
+  echo "ERROR=argument must be in the form <plugin>/<skill> (got: ${plugin_skill})"
+  echo "=== END LEGIBILITY PROMPT ==="
+  exit 1
+fi
+
+# Resolve the SKILL.md path. Accept either SKILL.md or skill.md.
+skill_dir="${repo_root}/${plugin_name}/skills/${skill_name}"
+skill_path=""
+for candidate in "${skill_dir}/SKILL.md" "${skill_dir}/skill.md"; do
+  if [ -f "$candidate" ]; then
+    skill_path="$candidate"
+    break
+  fi
+done
+
+if [ -z "$skill_path" ]; then
+  echo "PLUGIN=${plugin_name}"
+  echo "SKILL=${skill_name}"
+  echo "STATUS=ERROR"
+  echo "ISSUE_COUNT=1"
+  echo "ERROR=SKILL.md not found under ${skill_dir}"
+  echo "=== END LEGIBILITY PROMPT ==="
+  exit 1
+fi
+
+# Absolutise the path (the cold reader gets a path, not pasted text).
+case "$skill_path" in
+  /*) abs_path="$skill_path" ;;
+  *)  abs_path="$(cd "$(dirname "$skill_path")" && pwd)/$(basename "$skill_path")" ;;
+esac
+
+echo "SKILL_PATH=${abs_path}"
+echo "PLUGIN=${plugin_name}"
+echo "SKILL=${skill_name}"
+echo "STATUS=OK"
+echo "ISSUE_COUNT=0"
+echo "=== PROMPT ==="
+cat <<PROMPT
+You are an agent that just loaded this SKILL.md file with ZERO prior knowledge
+of the "${plugin_name}" plugin or its repository. You have NO context beyond the
+text itself. Read ONLY this file (no other files, no repository exploration, no
+web):
+${abs_path}
+
+From this file ALONE, answer two questions:
+  (a) Could you tell WHEN to invoke this skill?
+  (b) Could you carry out its FIRST concrete action?
+
+Produce:
+1. QUESTIONS — anything that left you unable to answer (a) or (b): undefined
+   terms, a first execution step that names a script/file/concept the file never
+   introduces, narration where you expected an instruction, a description with no
+   "Use when…" trigger. Quote the exact phrase that blocked you.
+2. HESITATIONS — anything that made you unsure rather than blocked: ambiguous
+   ordering, a step you could guess at but not confirm, structure that obscured
+   the entry point.
+3. Verdict: exactly one of \`clear\` | \`needs-revision\`.
+
+Ignore (these are artifacts of reading a skill in isolation, not defects):
+- "What is the ${plugin_name} plugin?" — its identity is in the frontmatter and
+  the surrounding plugin, which a real invocation supplies.
+- A referenced REFERENCE.md you were told not to open — it is loaded on demand
+  by design.
+- Unrecognized harness variables (\$ARGUMENTS, \${CLAUDE_SKILL_DIR},
+  \${CLAUDE_PLUGIN_ROOT}, \${CLAUDE_SESSION_ID}) — the harness substitutes them.
+- The full tool list not appearing in the body — it lives in \`allowed-tools\`.
+
+Concise bullets. Your final message is the deliverable.
+PROMPT
+echo "=== END PROMPT ==="
+echo "=== END LEGIBILITY PROMPT ==="

--- a/evaluate-plugin/skills/evaluate-matrix/SKILL.md
+++ b/evaluate-plugin/skills/evaluate-matrix/SKILL.md
@@ -76,6 +76,15 @@ combination:
      --skill-dir <plugin-name>/skills/<skill-name> \
      --eval-id <eval-id> --run <N>
    ```
+   If the eval carries a `fixture` block, apply it for an honest execution
+   context — without one a context-needing skill fails on haiku purely for lack
+   of fixtures, a false negative that poisons this gate:
+   ```
+   bash ${CLAUDE_PLUGIN_ROOT}/scripts/apply_fixture.sh \
+     --fixture '<eval.fixture JSON>' --repo-root "$(pwd)"
+   ```
+   Parse `WORKDIR=`; the subagent operates there. Tear it down after the
+   transcript is copied out (`--teardown "$WORKDIR"`).
 2. Dispatch **one `Task` subagent with the `model` field set to the loop
    model** (full `Bash`/`Edit` — it does real tool execution, not just reading):
    ```

--- a/evaluate-plugin/skills/evaluate-matrix/SKILL.md
+++ b/evaluate-plugin/skills/evaluate-matrix/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: evaluate-matrix
+description: Cross-model skill evals with real execution and grading — the executability gate. Use when checking whether a weak model can actually do a skill, not just comprehend it.
+args: <plugin/skill-name> [--models opus,haiku] [--with-skill-only] [--runs N]
+allowed-tools: Task, Read, Write, Edit, Glob, Bash(bash *), Bash(python3 *), TodoWrite
+argument-hint: "git-plugin/git-commit --models opus,haiku --with-skill-only"
+model: opus
+agent: general-purpose
+created: 2026-06-13
+modified: 2026-06-13
+reviewed: 2026-06-13
+---
+
+# /evaluate:matrix
+
+The **executability** gate. Where `/evaluate:legibility` asks "can a fresh
+agent *comprehend* this skill," this skill asks "can a *weak model* actually
+*do* it" — run the skill's evals on haiku (and opus/sonnet) with real tool
+execution, grade the produced artifact, and surface the per-skill verdict
+`executable_on_haiku`. A skill that opus passes and haiku fails leans on
+reasoning the cheap model lacks.
+
+This builds the orchestration the cross-model design
+([`docs/cross-model-evaluation.md`](../../docs/cross-model-evaluation.md))
+calls a follow-up. It reuses, without duplicating: `prepare_run.sh`,
+`grade_deterministic.py` (zero-token first pass), the `eval-grader` agent
+(deferred fuzzy checks only), `model-matrix.json`, and `render_matrix_report.py`.
+
+## When to Use This Skill
+
+| Use this skill when... | Use alternative when... |
+|------------------------|------------------------|
+| Checking whether a weak model can *execute* a skill | Checking whether the SKILL.md *reads* clearly -> `/evaluate:legibility` |
+| Running the Tier-2 cross-model sweep on a golden-set skill | Single-skill, single-model effectiveness -> `/evaluate:skill` |
+| Diagnosing a skill that opus passes but haiku fails | Structural/lint validation -> `scripts/plugin-compliance-check.sh` |
+| Re-checking canaries after a new model ships | Improving a skill from results -> `/evaluate:improve` |
+
+## Context
+
+- Skill eval setup: !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/inspect_eval.sh --plugin-dir $1`
+
+## Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `<plugin/skill-name>` | required | Target skill as `plugin-name/skill-name` |
+| `--models <list>` | `opus,haiku` | Comma-separated pinned aliases to run |
+| `--with-skill-only` | false | Skip the cached baseline side (with-skill runs only) |
+| `--runs N` | 1 | Runs per (model × eval × config) |
+
+Pinned model ids: `opus`=`claude-opus-4-8`, `sonnet`=`claude-sonnet-4-6`,
+`haiku`=`claude-haiku-4-5`. Record the exact ids in `model-matrix.json` for
+reproducibility (`.claude/rules/skill-evaluation.md`).
+
+## Execution
+
+Execute this cross-model matrix:
+
+### Step 1: Resolve skill and evals
+
+Read `<plugin-name>/skills/<skill-name>/evals.json`. If absent, report that
+the matrix needs eval cases (point at `/evaluate:skill --create-evals`) and
+stop. Validate it against the evals.json schema
+([`references/schemas.md`](../../references/schemas.md)).
+
+### Step 2: Run the matrix (serialized)
+
+Loop over (model ∈ `--models`) × eval × config ∈ {`with_skill`,
+`cached_baseline`} — skip `cached_baseline` if `--with-skill-only`, and reuse a
+baseline cached for the same model-version rather than re-running it. For each
+combination:
+
+1. Scaffold the run dir:
+   ```
+   bash ${CLAUDE_PLUGIN_ROOT}/scripts/prepare_run.sh \
+     --skill-dir <plugin-name>/skills/<skill-name> \
+     --eval-id <eval-id> --run <N>
+   ```
+2. Dispatch **one `Task` subagent with the `model` field set to the loop
+   model** (full `Bash`/`Edit` — it does real tool execution, not just reading):
+   ```
+   Task subagent_type: general-purpose
+   model: <loop model alias>
+   prompt: <eval prompt; with_skill runs also receive the SKILL.md content>
+   ```
+   **Serialize** the dispatches — one at a time, never a parallel batch.
+   `[1m]` models hit cascading rate limits with concurrent subagents
+   (`.claude/rules/skill-fork-context.md`).
+3. Write the subagent's produced artifact to `$RUN_DIR/transcript.md`.
+
+### Step 3: Grade — deterministic first, judge only on deferral
+
+For each run, grade the produced output:
+
+1. Run the zero-token deterministic grader first:
+   ```
+   python3 ${CLAUDE_PLUGIN_ROOT}/scripts/grade_deterministic.py \
+     --evals <evals.json> --eval-id <eval-id> --output $RUN_DIR/transcript.md --json
+   ```
+2. Only if it reports `JUDGE_PENDING > 0`, dispatch the `eval-grader` agent for
+   the deferred fuzzy expectations:
+   ```
+   Task subagent_type: eval-grader
+   Prompt: Grade ONLY the deferred (judge) expectations for <eval-id> ...
+   ```
+   Most expectations grade deterministically — the judge fires on a fraction.
+
+### Step 4: Aggregate to model-matrix.json
+
+Combine per-run pass rates into `<skill-dir>/eval-results/model-matrix.json`
+following the schema. Compute, per model alias, the mean `with_skill` and
+`baseline`, the `delta`, and `prev_delta` from any stored prior run.
+
+### Step 5: Render the report
+
+```
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/render_matrix_report.py \
+  <skill-dir>/eval-results/model-matrix.json
+```
+
+The renderer emits the delta table, per-model verdicts, the **portability
+flag** (opus−haiku spread ≥20 pts), and the **executability flag**
+(`executable_on_haiku=false` when haiku's absolute with-skill rate is below the
+0.5 floor while opus clears it). Print the report and call out whether the
+executability flag fired.
+
+## Minimal Provable Increment
+
+Run the matrix for **`git-plugin/git-commit` only** (it already has typed-check
+evals), `--models opus,haiku --with-skill-only`: grade deterministically,
+render, and confirm the executability callout lights up or stays dark
+correctly. This exercises every reused piece end-to-end before scaling to the
+golden set.
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Inspect eval setup | `bash evaluate-plugin/scripts/inspect_eval.sh --plugin-dir <plugin>/skills/<skill>` |
+| Prepare a run dir | `bash evaluate-plugin/scripts/prepare_run.sh --skill-dir <dir> --eval-id <id> --run <N>` |
+| Deterministic grade | `python3 evaluate-plugin/scripts/grade_deterministic.py --evals <f> --eval-id <id> --output <out> --json` |
+| Render the matrix | `python3 evaluate-plugin/scripts/render_matrix_report.py <dir>/eval-results/model-matrix.json` |
+
+## Quick Reference
+
+| Flag | Meaning |
+|------|---------|
+| `--models opus,haiku` | Which pinned aliases to run (default opus,haiku) |
+| `--with-skill-only` | Skip the cached baseline side |
+| `--runs N` | Runs per (model × eval × config) |
+
+## Related
+
+- `/evaluate:legibility` — the comprehension gate (cold-read, no execution)
+- `/evaluate:skill` — single-model effectiveness with a baseline
+- [`docs/cross-model-evaluation.md`](../../docs/cross-model-evaluation.md) — the design this implements
+- `.claude/rules/skill-evaluation.md` — tiered methodology, golden set, cadence
+- `.claude/rules/skill-fork-context.md` — why subagent dispatch is serialized

--- a/evaluate-plugin/skills/evaluate-skill/SKILL.md
+++ b/evaluate-plugin/skills/evaluate-skill/SKILL.md
@@ -62,7 +62,7 @@ If structural issues are found, report them and stop. Behavioral evaluation on a
 
 Look for `<plugin-name>/skills/<skill-name>/evals.json`.
 
-**If the file exists**: read and validate it against the evals.json schema (see `evaluate-plugin/references/schemas.md`).
+**If the file exists**: read and validate it against the evals.json schema (see `evaluate-plugin/references/schemas.md`). Accept the optional, back-compatible `evals[].fixture` block (`dir` / `setup` / `teardown` / `workdir`) — an eval without it is unchanged; an eval with it needs an isolated execution context (Step 4).
 
 **If the file does not exist AND `--create-evals` is set**: Analyze the SKILL.md and generate eval cases:
 
@@ -92,13 +92,22 @@ For each eval case, for each run (up to `--runs N`):
      --eval-id <eval-id> --run <N>
    ```
    Parse `RUN_DIR=`, `MANIFEST=`, and `STARTED_AT=` from output.
-2. Spawn a Task subagent (`subagent_type: general-purpose`) that:
+2. If the eval carries a `fixture` block, apply it to get an isolated workdir:
+   ```
+   bash ${CLAUDE_PLUGIN_ROOT}/scripts/apply_fixture.sh \
+     --fixture '<eval.fixture JSON>' --repo-root "$(pwd)"
+   ```
+   Parse `WORKDIR=` (the subagent then operates there). Skip this for evals
+   without a `fixture` — they run in the repo as before.
+3. Spawn a Task subagent (`subagent_type: general-purpose`) that:
    - Receives the skill content as context
    - Executes the eval prompt
-   - Works in the repository as if it were a real user request
-3. Capture the subagent output.
-4. Record timing data (duration) and write to `$RUN_DIR/timing.json`.
-5. Write the transcript to `$RUN_DIR/transcript.md`.
+   - Works in `$WORKDIR` if a fixture was applied, else in the repository
+4. Capture the subagent output.
+5. Record timing data (duration) and write to `$RUN_DIR/timing.json`.
+6. Write the transcript to `$RUN_DIR/transcript.md`.
+7. If a fixture was applied, tear it down after the transcript is copied out:
+   `bash ${CLAUDE_PLUGIN_ROOT}/scripts/apply_fixture.sh --teardown "$WORKDIR" --fixture '<eval.fixture JSON>'`.
 
 ### Step 5: Run baseline (if --baseline)
 

--- a/scripts/plugin-compliance-check.sh
+++ b/scripts/plugin-compliance-check.sh
@@ -314,6 +314,21 @@ check_skill_body() {
       fi
     fi
 
+    # Regression: evaluate-legibility's Step-3 triage and the cold-reader prompt
+    # depend on the verdict vocabulary (`clear` / `needs-revision`) and the
+    # QUESTIONS / HESITATIONS critique headings reused from cold-read-gate. A
+    # bulk edit that "tightens" the prose and drops those literal tokens would
+    # silently sever the gate from its consumer (Slice 2 triage reads them).
+    # Guards the semantic invariant, scoped to this skill only.
+    if [ "$skill_name" = "evaluate-legibility" ]; then
+      for token in "clear" "needs-revision" "QUESTIONS" "HESITATIONS"; do
+        if ! grep -q "$token" "$skill_file"; then
+          issues+=("❌ ${plugin}/${skill_name}: SKILL.md must retain the cold-reader token '${token}' (verdict/critique schema reused from cold-read-gate)")
+          has_errors=true
+        fi
+      done
+    fi
+
     # Regression: project-continue read deprecated blueprint v1/v2 state paths
     # `.claude/blueprints/prds/` and `.claude/blueprints/work-orders/`, so it
     # never found PRDs or work-orders in a current-format (v3.x) blueprint repo


### PR DESCRIPTION
## What

Extends `evaluate-plugin` with a sequenced **three-slice** weak-model skill validation capability — turning the `cold-read-gate` instrument on our own skills. Two distinct gates plus the missing scaffolding layer, each shipped as a minimal provable increment.

| Slice | Skill / artifact | Gate |
|-------|------------------|------|
| 1 | `/evaluate:legibility` | **comprehension** — cold-read a SKILL.md, never execute |
| 2 | `/evaluate:matrix` | **executability** — run on a weak model with real tool execution, grade the artifact |
| 3 | `evals[].fixture` + `apply_fixture.sh` | **scaffolding** — honest execution context so context-needing skills don't false-negative |

All three slices add skills/scripts/schema *inside the already-published* `evaluate-plugin`, so per `skill-consolidation.md` §3 there are **no** `marketplace.json` / release-config / `enabledPlugins` / `PLUGIN-MAP.md` edits — only the plugin's own README/docs.

## Slice 1 — `/evaluate:legibility` (comprehension gate)

A **new** skill (not a `cold-read-gate` generalization — that lives in another plugin and targets a human audience). Reuses `agent-patterns-plugin:cold-read-gate`'s dispatch contract **by name reference**: isolated haiku reader, `QUESTIONS`/`HESITATIONS`/`verdict` schema, triage-before-acting. The reader is an *agent* loading a skill, so the persona and triage table are skill-doc-specific. Verdict is **advisory, never a CI hard-gate** (haiku non-determinism).

- `emit-legibility-prompt.sh` resolves the SKILL.md abs path and emits the dispatch prompt as structured `KEY=value`, collapsing the skill's permissions to `Bash(bash *)`.
- Scoped `plugin-compliance-check.sh` semantic gate asserts the verdict/critique tokens survive bulk edits (Slice-2 triage consumes them).
- **Proven:** `git-commit` → `clear`, a deliberately thin skill → `needs-revision` with genuine gaps (no Use-when trigger, undefined terms, no first action), correctly ignoring test artifacts.

## Slice 2 — `/evaluate:matrix` (executability gate)

Builds the orchestration the cross-model design called a follow-up. Loops (model × eval × {with_skill, cached_baseline}) → `Task` subagent **with the `model` field set to the loop model** (serialized for `[1m]` rate limits) → `grade_deterministic.py` first (zero tokens), `eval-grader` only on `JUDGE_PENDING` → aggregate → render. Reuses `prepare_run.sh`, the grader, the matrix schema, and the renderer.

- `render_matrix_report.py` gains the `executable_on_haiku=false` callout — distinct from the delta verdict and the portability flag — when haiku's absolute with-skill rate is below the 0.5 floor while opus clears it. Additive, backward compatible.
- **Proven end-to-end** on `git-commit` gc-001 (opus+haiku, with-skill): opus 4/4 deterministic, haiku 1/4 → flag fires (haiku 25% < 50% floor < opus 100%).

## Slice 3 — fixture scaffolding (the real engineering)

Without an honest execution context, context-needing skills fail on a weak model purely for lack of fixtures — a false negative that poisons the Slice-2 gate. Adds an **additive, opt-in** `evals[].fixture` block (`dir`/`setup`/`teardown`/`workdir`).

- `apply_fixture.sh`: `mktemp -d` an isolated workdir **outside the repo**, copy `dir`, run `setup`, emit `WORKDIR=`; teardown runs `teardown` then `rm -rf`, **refusing any path outside the temp root** (the untrusted-`setup` blast-radius guard).
- `golden-set.json`: 16 canaries across 6 patterns; fixture blocks are golden-set scoped.
- Evals without `fixture` run exactly as today; `grade_deterministic.py` is untouched.
- **Proven:** `git-commit` gc-001 runs through `apply_fixture.sh` in a real staged repo, a real `git commit` grades 4/4 deterministic, teardown removes the dir.

## Verification

- `test-emit-legibility-prompt.sh` (16), `test_grade_deterministic.sh` (17), `test_apply_fixture.sh` (17) — all pass.
- `plugin-compliance-check.sh evaluate-plugin` — all green.
- pre-commit (shellcheck, secrets, lints) — green.

## Deferred (per plan)

- Cron / model-release **trigger**.
- `fixture.dir`-copy + external-resource teardown at scale (Slice 3 deferred its `dir` copy demonstration; the code path exists and is schema-documented).

## Notes for reviewers

- New skill *directories* need `/reload-skills` (or a session restart) before `/evaluate:legibility` and `/evaluate:matrix` are invocable.
- The haiku readers are the sanctioned "measurement instrument" exception to always-Opus (`.claude/rules/agent-and-tool-selection.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
