### PR TITLE
ci: add weekly research-radar workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -33,6 +33,7 @@ Auto-fix: CI failures
 Claude: @mentions
 Claude: Changelog review
 Claude: PR review
+Claude: Research radar
 PR: Auto-resolve conflicts
 PR: Enforce conventional commits
 Plugin: Enablement drift

--- a/.github/workflows/research-radar.yml
+++ b/.github/workflows/research-radar.yml
@@ -1,0 +1,258 @@
+name: "Claude: Research radar"
+
+on:
+  schedule:
+    # Weekly on Wednesdays at 09:00 UTC
+    - cron: '0 9 * * 3'
+  workflow_dispatch:
+    inputs:
+      since_days:
+        description: 'Look back this many days when gathering papers'
+        required: false
+        default: '8'
+        type: string
+      force:
+        description: 'Assess even if a research-radar issue for the current week already exists'
+        required: false
+        default: 'false'
+        type: boolean
+
+permissions:
+  contents: read
+  issues: write
+  id-token: write
+
+jobs:
+  gather:
+    runs-on: ubuntu-latest
+    outputs:
+      candidate_count: ${{ steps.fetch.outputs.candidate_count }}
+      should_skip: ${{ steps.existing.outputs.should_skip }}
+      iso_week: ${{ steps.week.outputs.iso_week }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Compute ISO week
+        id: week
+        run: echo "iso_week=$(date -u +%G-W%V)" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure research-radar label exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create research-radar \
+            --repo "$GITHUB_REPOSITORY" \
+            --color 1d76db \
+            --description "Surfaced research papers worth considering for the plugins" \
+            2>/dev/null || true
+
+      # Gather IDs already surfaced in prior research-radar issues so the same
+      # paper is never written up twice. The assess job embeds a machine-readable
+      # block (<!-- research-radar-ids: ... -->) in every issue it opens; we parse
+      # those back out here. --json | jq keeps the empty case exit-0
+      # (.claude/rules/parallel-safe-queries.md).
+      - name: Collect already-surfaced paper IDs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --label research-radar \
+            --state all \
+            --limit 30 \
+            --json body \
+            --jq '.[].body' > "$RUNNER_TEMP/prior-bodies.txt" || true
+          grep -oE '<!-- research-radar-ids:[^>]*-->' "$RUNNER_TEMP/prior-bodies.txt" 2>/dev/null \
+            | sed -E 's/<!-- research-radar-ids:[[:space:]]*//; s/[[:space:]]*-->//' \
+            | tr ' ' '\n' \
+            | grep -v '^$' \
+            | sort -u > "$RUNNER_TEMP/seen-ids.txt" || true
+          echo "Already-surfaced IDs: $(wc -l < "$RUNNER_TEMP/seen-ids.txt")"
+
+      - name: Fetch and normalize candidate papers
+        id: fetch
+        run: |
+          set -uo pipefail
+          SINCE="${{ inputs.since_days || '8' }}"
+          bash scripts/fetch-research-papers.sh \
+            --since-days "$SINCE" \
+            --seen-file "$RUNNER_TEMP/seen-ids.txt" \
+            --out research-candidates.json | tee "$RUNNER_TEMP/radar-summary.txt"
+          COUNT="$(grep -m1 '^CANDIDATE_COUNT=' "$RUNNER_TEMP/radar-summary.txt" | cut -d= -f2)"
+          echo "candidate_count=${COUNT:-0}" >> "$GITHUB_OUTPUT"
+
+      # Idempotency: one research-radar issue per ISO week. force=true bypasses.
+      - name: Check for existing issue this week
+        id: existing
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FORCE: ${{ inputs.force }}
+          WEEK: ${{ steps.week.outputs.iso_week }}
+        run: |
+          set -uo pipefail
+          if [ "$FORCE" = "true" ]; then
+            echo "Force flag set — bypassing skip-if-exists"
+            echo "should_skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          ISSUE=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --label research-radar \
+            --state open \
+            --json number,title \
+            --jq ".[] | select(.title | test(\"$WEEK\")) | .number" \
+            | head -1)
+          if [ -n "$ISSUE" ]; then
+            echo "Open research-radar issue #$ISSUE already covers $WEEK — skipping"
+            echo "should_skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No open research-radar issue for $WEEK — assessment will run"
+            echo "should_skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload candidate set for assess job
+        if: steps.fetch.outputs.candidate_count != '0' && steps.existing.outputs.should_skip != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: research-candidates
+          path: research-candidates.json
+          retention-days: 7
+
+  claude-assess:
+    needs: gather
+    if: needs.gather.outputs.candidate_count != '0' && needs.gather.outputs.should_skip != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download candidate set
+        uses: actions/download-artifact@v4
+        with:
+          name: research-candidates
+          path: .
+
+      - name: Assess papers and open an issue when relevant
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ github.token }}
+          # Bounded read-assess-write: read the candidate JSON, judge relevance,
+          # open at most one issue. 20 turns is ample; if it can't finish, the
+          # prompt is wrong and we want to fail fast.
+          claude_args: "--model sonnet --max-turns 20"
+          prompt: |
+            You are the RESEARCH RADAR for the `laurigates/claude-plugins` repository — a
+            collection of Claude Code plugins (skills, agents, rules) for development
+            workflows. Your job: scan recent AI/agent research and open ONE GitHub issue
+            summarizing only the papers that suggest a *specific, actionable* improvement to
+            an existing plugin or rule. If nothing clears that bar, open NO issue.
+
+            ## Pre-computed input (use this — do not re-fetch)
+
+            - `research-candidates.json` in the repo root: a JSON array of recent papers,
+              each `{id, title, url, source, published, abstract, upvotes}`, already
+              deduplicated against papers surfaced in prior research-radar issues. Read it
+              once with `Read` (or `jq` via Bash). Do NOT use WebFetch/WebSearch — the
+              candidate set is the authoritative input.
+            - ISO week: ${{ needs.gather.outputs.iso_week }}
+            - Candidate count: ${{ needs.gather.outputs.candidate_count }}
+
+            ## Efficiency rules
+
+            - `TodoWrite` once at the start to plan, then minimal narration.
+            - Read `research-candidates.json` once. You may `jq` it to pre-filter by keyword.
+            - Do not read plugin source files — you are mapping ideas to plugin *names*, not
+              editing them. Follow-up application is human/`@claude`-driven work.
+
+            ## Step 1: Read and triage the candidates
+
+            Read `research-candidates.json`. For each paper, judge relevance to THIS plugin
+            collection. A paper CLEARS THE BAR only if it implies a concrete change to one of
+            these areas — not mere topical interest:
+
+            | Area | Plugin / rules |
+            |------|----------------|
+            | Agent orchestration, multi-agent, delegation | `agent-patterns-plugin`, `agents-plugin` |
+            | Skill / capability evaluation, self-improvement, best-of-N | `evaluate-plugin`, `feedback-plugin` |
+            | Prompting techniques, grounding, citations | `prompt-engineering-plugin` |
+            | Skill design, context management, memory, tool use | `.claude/rules/skill-*.md`, `CLAUDE.md` |
+            | Verification, adversarial review, test generation | `agent-patterns-plugin`, `testing-plugin` |
+
+            Reference point: PR #1593 adopted "RHO verify + best-of-N" (arXiv:2606.05922) into
+            `evaluate-plugin` and `feedback-plugin`. That is the calibre of match worth
+            surfacing — a paper with a technique we could actually adopt.
+
+            Be selective. Most papers will NOT clear the bar. Aim for the few highest-signal
+            matches (typically 0–5). Prefer higher `upvotes` as a weak tie-breaker, not a
+            criterion.
+
+            ## Step 2: Decide
+
+            - **If zero papers clear the bar:** open no issue. Print one line explaining that
+              nothing was actionable this week, and finish. This is a valid, common outcome.
+            - **If one or more clear the bar:** open exactly ONE issue (Step 3).
+
+            ## Step 3: Open one issue
+
+            Use the What / Why / How framing (concise, positive — see
+            `communication-plugin:ticket-drafting-guidelines`). Group findings by target
+            plugin/rule. For each paper: title (linked to its `url`), the `id`, a one-line
+            takeaway, and a concrete "consider applying to X" suggestion.
+
+            End the body with a machine-readable block listing the `id` of every paper you
+            included — the next run parses this to avoid re-surfacing the same papers:
+
+                <!-- research-radar-ids: <id1> <id2> ... -->
+
+            ```bash
+            gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "Research radar: ${{ needs.gather.outputs.iso_week }}" \
+              --label "research-radar" \
+              --assignee laurigates \
+              --body "$(cat <<'EOF'
+            ## What
+
+            Recent AI/agent research that may be worth applying to the plugins (week ${{ needs.gather.outputs.iso_week }}).
+
+            ## Why
+
+            Surfaced automatically so adoptable techniques (cf. PR #1593, RHO + best-of-N) don't depend on someone happening to read the right paper.
+
+            ## How — candidates
+
+            ### <target plugin or rule>
+            - **[<paper title>](<url>)** (`<id>`) — <one-line takeaway>. Consider: <concrete suggestion>.
+
+            (Group additional findings under their target plugin/rule. Omit areas with no match.)
+
+            ---
+            Sources: HuggingFace daily papers, arXiv (cs.AI/CL/LG/SE/HC), lab blogs. Triaged from ${{ needs.gather.outputs.candidate_count }} candidates.
+
+            🤖 Surfaced by the Research radar workflow
+
+            <!-- research-radar-ids: <id1> <id2> -->
+            EOF
+            )"
+            ```
+
+            ## Step 4: Sanity check
+
+            Confirm at most one issue was created and that the `<!-- research-radar-ids: -->`
+            block lists exactly the papers you wrote up. Do not edit any repo files.
+          additional_permissions: |
+            Read
+            Grep
+            Glob
+            TodoWrite
+            Bash(gh issue *)
+            Bash(gh label *)
+            Bash(cat *)
+            Bash(jq *)
+          plugin_marketplaces: |
+            https://github.com/laurigates/claude-plugins.git
+          plugins: |
+            evaluate-plugin@laurigates-claude-plugins
+            agent-patterns-plugin@laurigates-claude-plugins
+            communication-plugin@laurigates-claude-plugins

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,3 +75,9 @@ repos:
         language: system
         files: '^(\.claude-plugin/marketplace\.json|\.claude/settings\.json)$'
         pass_filenames: false
+      - id: test-fetch-research-papers
+        name: research-radar fetcher parse/dedup/date-filter regression
+        entry: bash ./scripts/tests/test-fetch-research-papers.sh
+        language: system
+        files: '^scripts/(fetch-research-papers\.sh|tests/test-fetch-research-papers\.sh)$'
+        pass_filenames: false

--- a/scripts/fetch-research-papers.sh
+++ b/scripts/fetch-research-papers.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# Fetch recent AI/agent research from HuggingFace daily papers, arXiv, and lab
+# blogs; normalize to a single JSON candidate array for the "Claude: Research
+# radar" workflow (.github/workflows/research-radar.yml).
+#
+# The workflow hands the JSON to Claude, which judges each item's relevance to
+# THIS plugin collection and opens at most one GitHub issue. This script is the
+# deterministic pre-compute step — it does no relevance judgement of its own.
+#
+# Multi-format feed parsing (HF JSON + arXiv Atom XML + blog RSS/Atom) is done
+# in an inline python3 block: pure bash/jq cannot parse the XML feeds, and
+# python3 is present on GitHub runners and in the web sandbox. The bash wrapper
+# owns flag parsing, network fetch, and the structured KEY=value summary
+# (.claude/rules/structured-script-output.md).
+#
+# Usage:
+#   fetch-research-papers.sh [--since-days N] [--seen-file PATH] [--out PATH]
+#
+#   --since-days N   Only keep items published within the last N days (default 8)
+#   --seen-file P    Newline-delimited paper IDs already surfaced in prior
+#                    issues; matching items are dropped. Default: none.
+#   --out P          Write the JSON candidate array here (default /tmp/research-candidates.json)
+#
+# Exit 0 always (parallel-safe; see .claude/rules/parallel-safe-queries.md) —
+# a per-source network failure degrades to fewer candidates, never an abort.
+set -uo pipefail
+
+since_days=8
+seen_file=""
+out_file="/tmp/research-candidates.json"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --since-days) since_days="$2"; shift 2 ;;
+    --seen-file) seen_file="$2"; shift 2 ;;
+    --out) out_file="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+# arXiv categories most likely to surface agent / prompting / eval / SWE work.
+arxiv_cats="cat:cs.AI+OR+cat:cs.CL+OR+cat:cs.LG+OR+cat:cs.SE+OR+cat:cs.HC"
+
+# Lab / vendor research feeds. Best-effort: a 404 or non-feed response is
+# skipped silently. Add feeds here as they prove reachable and useful.
+blog_feeds=(
+  "https://openai.com/blog/rss.xml"
+  "https://www.anthropic.com/rss.xml"
+)
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT
+
+# --- Fetch (each source isolated; failures are non-fatal) ---------------------
+# Test seam: RR_FIXTURE_DIR stages hf.json / arxiv.xml / blog-*.xml so the
+# normalize+dedup+date-filter logic can be exercised offline (see
+# scripts/tests/test-fetch-research-papers.sh). When set, no network is touched.
+if [ -n "${RR_FIXTURE_DIR:-}" ] && [ -d "${RR_FIXTURE_DIR:-}" ]; then
+  cp "$RR_FIXTURE_DIR"/* "$work_dir/" 2>/dev/null || true
+else
+  curl -fsSL --max-time 45 \
+    "https://huggingface.co/api/daily_papers" \
+    -o "$work_dir/hf.json" 2>/dev/null || true
+
+  curl -fsSL --max-time 45 \
+    "http://export.arxiv.org/api/query?search_query=${arxiv_cats}&sortBy=submittedDate&sortOrder=descending&max_results=80" \
+    -o "$work_dir/arxiv.xml" 2>/dev/null || true
+
+  blog_idx=0
+  for feed in "${blog_feeds[@]}"; do
+    blog_idx=$((blog_idx + 1))
+    curl -fsSL --max-time 30 "$feed" \
+      -o "$work_dir/blog-${blog_idx}.xml" 2>/dev/null || true
+  done
+fi
+
+# --- Normalize + dedup + date-filter (python3) --------------------------------
+RR_WORK_DIR="$work_dir" \
+RR_SINCE_DAYS="$since_days" \
+RR_SEEN_FILE="$seen_file" \
+RR_OUT="$out_file" \
+python3 <<'PYEOF'
+import datetime as dt
+import glob
+import json
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+work_dir = os.environ["RR_WORK_DIR"]
+since_days = int(os.environ.get("RR_SINCE_DAYS") or "8")
+seen_file = os.environ.get("RR_SEEN_FILE") or ""
+out_file = os.environ["RR_OUT"]
+
+# RR_TODAY pins "today" for deterministic offline tests; defaults to the real date.
+_today_raw = os.environ.get("RR_TODAY") or ""
+try:
+    today = dt.date.fromisoformat(_today_raw) if _today_raw else dt.date.today()
+except ValueError:
+    today = dt.date.today()
+cutoff = (today - dt.timedelta(days=since_days)).isoformat()
+
+seen = set()
+if seen_file and os.path.isfile(seen_file):
+    with open(seen_file, encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            tok = line.strip()
+            if tok:
+                seen.add(tok)
+
+
+def clean(text, limit=600):
+    text = re.sub(r"\s+", " ", (text or "")).strip()
+    return text[:limit]
+
+
+def arxiv_id(raw):
+    # http://arxiv.org/abs/2606.05922v1 -> 2606.05922
+    m = re.search(r"(\d{4}\.\d{4,5})", raw or "")
+    return m.group(1) if m else (raw or "").strip()
+
+
+records = {}  # id -> record (dedup within this run too)
+
+
+def add(rec):
+    rid = rec.get("id")
+    if not rid or rid in seen or rid in records:
+        return
+    if (rec.get("published") or "")[:10] < cutoff:
+        return
+    records[rid] = rec
+
+
+# --- HuggingFace daily papers (JSON) ---
+hf_path = os.path.join(work_dir, "hf.json")
+if os.path.isfile(hf_path):
+    try:
+        with open(hf_path, encoding="utf-8", errors="replace") as fh:
+            data = json.load(fh)
+        for item in data if isinstance(data, list) else []:
+            paper = item.get("paper") or {}
+            pid = arxiv_id(paper.get("id") or item.get("id") or "")
+            if not pid:
+                continue
+            published = (item.get("publishedAt") or paper.get("publishedAt") or "")[:10]
+            add({
+                "id": pid,
+                "title": clean(paper.get("title") or item.get("title"), 300),
+                "url": f"https://huggingface.co/papers/{pid}",
+                "source": "huggingface",
+                "published": published,
+                "abstract": clean(paper.get("summary") or paper.get("abstract")),
+                "upvotes": paper.get("upvotes") or item.get("upvotes") or 0,
+            })
+    except Exception as exc:  # noqa: BLE001 - best-effort source
+        print(f"hf parse skipped: {exc}", file=sys.stderr)
+
+# --- arXiv (Atom XML) ---
+arxiv_path = os.path.join(work_dir, "arxiv.xml")
+if os.path.isfile(arxiv_path):
+    try:
+        ns = {"a": "http://www.w3.org/2005/Atom"}
+        root = ET.parse(arxiv_path).getroot()
+        for entry in root.findall("a:entry", ns):
+            raw_id = (entry.findtext("a:id", default="", namespaces=ns) or "")
+            pid = arxiv_id(raw_id)
+            if not pid:
+                continue
+            published = (entry.findtext("a:published", default="", namespaces=ns) or "")[:10]
+            add({
+                "id": pid,
+                "title": clean(entry.findtext("a:title", default="", namespaces=ns), 300),
+                "url": f"https://arxiv.org/abs/{pid}",
+                "source": "arxiv",
+                "published": published,
+                "abstract": clean(entry.findtext("a:summary", default="", namespaces=ns)),
+                "upvotes": 0,
+            })
+    except Exception as exc:  # noqa: BLE001 - best-effort source
+        print(f"arxiv parse skipped: {exc}", file=sys.stderr)
+
+# --- Lab blogs (RSS or Atom) ---
+for blog_path in sorted(glob.glob(os.path.join(work_dir, "blog-*.xml"))):
+    try:
+        root = ET.parse(blog_path).getroot()
+        # RSS: <rss><channel><item><link/><title/><description/><pubDate/>
+        items = root.findall(".//item")
+        for it in items:
+            link = (it.findtext("link") or "").strip()
+            if not link:
+                continue
+            published = ""
+            pub = it.findtext("pubDate") or ""
+            m = re.search(r"(\d{1,2})\s+(\w{3})\s+(\d{4})", pub)
+            if m:
+                try:
+                    published = dt.datetime.strptime(
+                        f"{m.group(1)} {m.group(2)} {m.group(3)}", "%d %b %Y"
+                    ).date().isoformat()
+                except ValueError:
+                    published = ""
+            add({
+                "id": link,
+                "title": clean(it.findtext("title"), 300),
+                "url": link,
+                "source": "blog",
+                "published": published or today.isoformat(),
+                "abstract": clean(it.findtext("description")),
+                "upvotes": 0,
+            })
+        # Atom: <feed><entry><link href=.../><title/><summary/><published/>
+        if not items:
+            ns = {"a": "http://www.w3.org/2005/Atom"}
+            for entry in root.findall("a:entry", ns):
+                link_el = entry.find("a:link", ns)
+                link = (link_el.get("href") if link_el is not None else "") or ""
+                if not link:
+                    continue
+                published = (entry.findtext("a:published", default="", namespaces=ns)
+                             or entry.findtext("a:updated", default="", namespaces=ns) or "")[:10]
+                add({
+                    "id": link,
+                    "title": clean(entry.findtext("a:title", default="", namespaces=ns), 300),
+                    "url": link,
+                    "source": "blog",
+                    "published": published or today.isoformat(),
+                    "abstract": clean(entry.findtext("a:summary", default="", namespaces=ns)),
+                    "upvotes": 0,
+                })
+    except Exception as exc:  # noqa: BLE001 - best-effort source
+        print(f"blog parse skipped ({blog_path}): {exc}", file=sys.stderr)
+
+candidates = sorted(
+    records.values(),
+    key=lambda r: (r.get("upvotes", 0), r.get("published", "")),
+    reverse=True,
+)
+
+with open(out_file, "w", encoding="utf-8") as fh:
+    json.dump(candidates, fh, ensure_ascii=False, indent=2)
+
+# Per-source counts for the structured summary.
+counts = {"huggingface": 0, "arxiv": 0, "blog": 0}
+for rec in candidates:
+    counts[rec["source"]] = counts.get(rec["source"], 0) + 1
+
+with open(os.path.join(work_dir, "counts.env"), "w", encoding="utf-8") as fh:
+    fh.write(f"TOTAL={len(candidates)}\n")
+    fh.write(f"HF={counts['huggingface']}\n")
+    fh.write(f"ARXIV={counts['arxiv']}\n")
+    fh.write(f"BLOG={counts['blog']}\n")
+PYEOF
+
+# --- Structured summary (.claude/rules/structured-script-output.md) -----------
+total=0; hf=0; arxiv=0; blog=0
+if [ -f "$work_dir/counts.env" ]; then
+  # shellcheck disable=SC1090
+  while IFS='=' read -r k v; do
+    case "$k" in
+      TOTAL) total="$v" ;;
+      HF) hf="$v" ;;
+      ARXIV) arxiv="$v" ;;
+      BLOG) blog="$v" ;;
+    esac
+  done < "$work_dir/counts.env"
+fi
+
+radar_status="OK"
+[ "$total" -eq 0 ] && radar_status="WARN"
+
+echo "=== RESEARCH RADAR ==="
+echo "SINCE_DAYS=$since_days"
+echo "OUT_FILE=$out_file"
+echo "HF_COUNT=$hf"
+echo "ARXIV_COUNT=$arxiv"
+echo "BLOG_COUNT=$blog"
+echo "CANDIDATE_COUNT=$total"
+echo "STATUS=$radar_status"
+echo "ISSUE_COUNT=0"
+echo "=== END RESEARCH RADAR ==="
+
+exit 0

--- a/scripts/tests/test-fetch-research-papers.sh
+++ b/scripts/tests/test-fetch-research-papers.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Offline regression test for scripts/fetch-research-papers.sh.
+#
+# Exercises the normalize + dedup + date-filter logic without network via the
+# RR_FIXTURE_DIR / RR_TODAY test seams. Guards the invariants that a bulk edit
+# could silently break:
+#   1. All three source formats parse (HF JSON, arXiv Atom, blog RSS).
+#   2. The same arXiv id from HF and arXiv is merged to ONE record.
+#   3. --seen-file IDs are dropped.
+#   4. Items older than --since-days are filtered out.
+#   5. The structured summary emits CANDIDATE_COUNT / STATUS / per-source counts.
+#
+# SKIPs (exit 0) when python3 or jq is unavailable. Non-zero only on real failure.
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+target="$repo_root/scripts/fetch-research-papers.sh"
+
+if ! command -v python3 >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: python3 and jq required"
+  exit 0
+fi
+
+fail=0
+check() {
+  # check <description> <actual> <expected>
+  if [ "$2" = "$3" ]; then
+    echo "PASS: $1 ($2)"
+  else
+    echo "FAIL: $1 — expected '$3', got '$2'"
+    fail=1
+  fi
+}
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+fixtures="$work/fixtures"
+mkdir -p "$fixtures"
+
+# HF daily papers fixture: two papers, one recent + one old. The recent one
+# (2606.05922) is also present in the arXiv fixture to prove cross-source merge.
+cat > "$fixtures/hf.json" <<'JSON'
+[
+  {"publishedAt": "2026-06-10T00:00:00.000Z",
+   "paper": {"id": "2606.05922", "title": "RHO verify and best-of-N", "summary": "A technique.", "upvotes": 90}},
+  {"publishedAt": "2026-06-09T00:00:00.000Z",
+   "paper": {"id": "2606.00001", "title": "Recent HF only paper", "summary": "Another.", "upvotes": 5}},
+  {"publishedAt": "2026-01-01T00:00:00.000Z",
+   "paper": {"id": "2601.99999", "title": "Old paper", "summary": "Stale.", "upvotes": 1000}}
+]
+JSON
+
+# arXiv Atom fixture: re-lists 2606.05922 (dedup target) + a unique recent paper.
+cat > "$fixtures/arxiv.xml" <<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://arxiv.org/abs/2606.05922v2</id>
+    <title>RHO verify and best-of-N</title>
+    <summary>Same paper, arXiv copy.</summary>
+    <published>2026-06-10T00:00:00Z</published>
+  </entry>
+  <entry>
+    <id>http://arxiv.org/abs/2606.07777v1</id>
+    <title>Arxiv only recent paper</title>
+    <summary>Unique to arXiv.</summary>
+    <published>2026-06-11T00:00:00Z</published>
+  </entry>
+</feed>
+XML
+
+# Blog RSS fixture: one recent item with an explicit pubDate.
+cat > "$fixtures/blog-1.xml" <<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <title>Agentic eval post</title>
+      <link>https://example.com/blog/agentic-eval</link>
+      <description>A blog post.</description>
+      <pubDate>Wed, 10 Jun 2026 12:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>
+XML
+
+run() {
+  # run <out> <since_days> [seen_file]
+  RR_FIXTURE_DIR="$fixtures" RR_TODAY="2026-06-13" \
+    bash "$target" --since-days "$2" --out "$1" \
+    ${3:+--seen-file "$3"}
+}
+
+# --- Case 1: no seen-file, 8-day window (cutoff 2026-06-05) -------------------
+summary="$(run "$work/out1.json" 8)"
+total1="$(jq 'length' "$work/out1.json")"
+# Expected survivors: 2606.05922 (merged), 2606.00001, 2606.07777, blog → 4.
+# Excluded: 2601.99999 (old, outside window).
+check "Case 1 candidate count (date-filter + cross-source merge)" "$total1" "4"
+
+dup_count="$(jq '[.[] | select(.id == "2606.05922")] | length' "$work/out1.json")"
+check "Case 1 arXiv id merged to single record" "$dup_count" "1"
+
+hf_only_present="$(jq 'any(.[]; .id == "2606.00001")' "$work/out1.json")"
+check "Case 1 HF-only recent paper kept" "$hf_only_present" "true"
+
+old_present="$(jq 'any(.[]; .id == "2601.99999")' "$work/out1.json")"
+check "Case 1 old paper filtered out" "$old_present" "false"
+
+blog_present="$(jq 'any(.[]; .source == "blog")' "$work/out1.json")"
+check "Case 1 blog RSS parsed" "$blog_present" "true"
+
+count_line="$(printf '%s\n' "$summary" | grep -m1 '^CANDIDATE_COUNT=' | cut -d= -f2)"
+check "Case 1 structured CANDIDATE_COUNT matches" "$count_line" "4"
+status_line="$(printf '%s\n' "$summary" | grep -m1 '^STATUS=' | cut -d= -f2)"
+check "Case 1 STATUS=OK when non-empty" "$status_line" "OK"
+
+# --- Case 2: seen-file drops a surfaced id -----------------------------------
+seen="$work/seen.txt"
+printf '2606.05922\n' > "$seen"
+run "$work/out2.json" 8 "$seen" >/dev/null
+seen_present="$(jq 'any(.[]; .id == "2606.05922")' "$work/out2.json")"
+check "Case 2 seen id dropped" "$seen_present" "false"
+total2="$(jq 'length' "$work/out2.json")"
+check "Case 2 count drops by one" "$total2" "3"
+
+# --- Case 3: narrow window excludes everything (STATUS=WARN) ------------------
+# since-days 1 from 2026-06-13 → cutoff 2026-06-12; only 2606.07777 (06-11)? no,
+# 06-11 < 06-12 → excluded too. All filtered → empty, exit 0, STATUS=WARN.
+summary3="$(run "$work/out3.json" 1)"
+total3="$(jq 'length' "$work/out3.json")"
+check "Case 3 narrow window filters all" "$total3" "0"
+status3="$(printf '%s\n' "$summary3" | grep -m1 '^STATUS=' | cut -d= -f2)"
+check "Case 3 STATUS=WARN on empty" "$status3" "WARN"
+exit3=0
+run "$work/out3b.json" 1 >/dev/null 2>&1 || exit3=$?
+check "Case 3 exit 0 even when empty (parallel-safe)" "$exit3" "0"
+
+echo "=== TEST SUMMARY ==="
+if [ "$fail" -eq 0 ]; then
+  echo "STATUS=PASS"
+  exit 0
+else
+  echo "STATUS=FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## What

A self-contained **"Claude: Research radar"** GitHub Actions workflow that watches recent AI/agent research weekly and opens one GitHub issue when a paper suggests a concrete, adoptable improvement to a plugin or rule — and opens nothing when nothing clears the bar.

## Why

The improvements in #1593 (RHO verify + best-of-N, from arXiv:2606.05922) came from someone manually reading the right paper. This makes that discovery continuous so adoptable techniques don't depend on chance.

## How

Mirrors the existing scheduled-Claude pattern (`changelog-review.yml`): a deterministic bash `gather` job pre-computes a candidate set, then a bounded `claude-code-action` job judges relevance and opens at most one issue.

| File | Role |
|------|------|
| `scripts/fetch-research-papers.sh` | Fetch + normalize HuggingFace daily papers, arXiv (cs.AI/CL/LG/SE/HC), and lab blogs into one JSON array; dedup against IDs surfaced in prior issues; date-filter; structured `KEY=value` summary. `RR_FIXTURE_DIR`/`RR_TODAY` seams enable offline testing. Exit-0 on empty (parallel-safe). |
| `.github/workflows/research-radar.yml` | Weekly Wed 09:00 UTC + `workflow_dispatch`; per-ISO-week skip-if-exists idempotency; **issue-only** output; surfaced-IDs embedded in the issue body (no committed state file, no weekly PR churn). |
| `scripts/tests/test-fetch-research-papers.sh` | Offline regression test (parse, cross-source merge, seen-file dedup, date cutoff, structured summary), wired into pre-commit. |
| `.github/workflows/README.md`, `.pre-commit-config.yaml` | Register the workflow name and the test hook. |

## Verification

- `shellcheck` + `actionlint` clean; pre-commit green.
- Fetcher run against live network: 152 candidates / 14 days (HF 49, arXiv 74, blog 29), exit 0.
- Seen-file dedup drops a matched ID (count -1).
- Offline test: 12/12 assertions pass (including empty -> `STATUS=WARN`, exit 0).

## Notes

- **Auth:** uses the existing `CLAUDE_CODE_OAUTH_TOKEN` secret; the assess job creates issues with the default `GITHUB_TOKEN` (no PR/push, so no elevated token needed).
- **Known false alarm:** this PR modifies `.github/workflows/`, so the *Plugin: PR checks* Claude step will show `401 Workflow validation failed` — the OIDC platform limitation in #1204; it clears on merge.
- The two lab-blog feeds are best-effort; a 404 in CI is skipped silently. HF + arXiv are the reliable core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)