### PR TITLE
fix(hooks-plugin): reduce false positives across bash-antipatterns, branch-protection, and secret-protection hooks

### DIFF
--- a/.claude/rules/bash-tool-replacements.md
+++ b/.claude/rules/bash-tool-replacements.md
@@ -44,7 +44,7 @@ explicit do/don't table style that worked for `find` in W16.
 
 ## When to keep `find` / `grep` / `rg` in Bash
 
-The hook allows the Bash form in three scenarios:
+The hook allows the Bash form in four scenarios:
 
 1. **Pipelines.** `gh pr list --json title --jq '.[].title' | rg 'feat'`
    is fine — the `|` short-circuits the hook check.
@@ -53,8 +53,13 @@ The hook allows the Bash form in three scenarios:
 3. **Boolean exit-code checks.** `grep -q pattern file && do_thing`
    is fine. The `Grep` tool returns content; it doesn't give you a
    clean shell-conditional exit code.
+4. **File-list / count filter modes.** `grep -l pattern f1 f2`
+   (files-with-matches), `grep -c pattern file` (count), and
+   `grep -L …` (files-without-match) are filters over a known file set,
+   not codebase searches the `Grep` tool replaces. (The uppercase
+   context flag `-C` is *not* exempt — it's a real search.)
 
-In all three cases the hook silently passes the command through. If
+In all four cases the hook silently passes the command through. If
 you're getting blocked anyway, you're not in one of these cases —
 switch to the tool.
 

--- a/hooks-plugin/hooks/README.md
+++ b/hooks-plugin/hooks/README.md
@@ -17,10 +17,10 @@ A PreToolUse hook that intercepts Bash commands and blocks those that should use
 | `cat > file` | Use **Write** tool instead |
 | `timeout cmd` | Remove timeout (Bash tool has its own, human approval time exceeds it anyway) |
 | `find` | Use **Glob** tool instead |
-| `grep`/`rg` | Use **Grep** tool instead |
+| `grep`/`rg` | Use **Grep** tool instead (allows `-q`, `-l`/`-c`/`-L` filter modes, and pipelines) |
 | `ls *pattern*` | Consider **Glob** tool |
-| `cat/tail ...tasks/*.output` | Use **TaskOutput** tool instead |
-| `sleep && cat/tail` | Use **TaskOutput** tool with block parameter |
+| `cat/tail ...tasks/*.output` | Use **Read** tool on the output path (or pipe an extraction for large files) |
+| `sleep && cat/tail ...output` | Use **Read** tool on the output path |
 | `git add -A` / `git add .` | Stage specific files by name instead of broad staging |
 | `git X && git Y` | Run git commands as separate Bash calls (avoids index.lock race condition) |
 | `git reset --hard` | Use safer alternatives; if truly needed, ask user to run manually |

--- a/hooks-plugin/hooks/bash-antipatterns-teach.sh
+++ b/hooks-plugin/hooks/bash-antipatterns-teach.sh
@@ -75,12 +75,15 @@ if [ -z "$hint" ] && \
     hint_key="glob-find"
 fi
 
-# grep/rg as standalone search (not piped, not -q)
+# grep/rg as standalone search (not piped, not -q, not -l/-c/-L filter modes)
+# Mirrors bash-antipatterns.sh: file-list/count modes (-l, -c, -L) are filters,
+# not codebase searches the Grep tool replaces (issue #1592).
 if [ -z "$hint" ] && \
    echo "$COMMAND" | grep -Eq '^\s*(grep|rg)\s+' && \
    ! echo "$COMMAND" | grep -q '|' && \
-   ! echo "$COMMAND" | grep -Eq '(grep|rg)[^|]*\s(-[a-zA-Z]*q[a-zA-Z]*(\s|$)|--quiet(\s|$))'; then
-    hint="Use the Grep tool for codebase searches. Example: Grep(pattern=\"foo\", path=\"src\", -n=true). Keep grep/rg for pipelines or boolean -q checks."
+   ! echo "$COMMAND" | grep -Eq '(grep|rg)[^|]*\s(-[a-zA-Z]*q[a-zA-Z]*(\s|$)|--quiet(\s|$))' && \
+   ! echo "$COMMAND" | grep -Eq '(grep|rg)[^|]*\s(-[a-zA-Z]*[lcL][a-zA-Z]*(\s|$)|--count(\s|$)|--files-with-matches(\s|$)|--files-without-match(\s|$))'; then
+    hint="Use the Grep tool for codebase searches. Example: Grep(pattern=\"foo\", path=\"src\", -n=true). Keep grep/rg for pipelines, boolean -q checks, or -l/-c filter modes."
     hint_key="grep"
 fi
 

--- a/hooks-plugin/hooks/bash-antipatterns.sh
+++ b/hooks-plugin/hooks/bash-antipatterns.sh
@@ -43,6 +43,15 @@ COMMAND_SHELL_ONLY=$(echo "$COMMAND" | awk '
     }
 ')
 
+# A further-stripped view with quoted-string literals removed (on top of the
+# heredoc stripping above). Detectors that key off *content tokens* an agent
+# would only ever read (e.g. task-output file paths like `.../tasks/x.output`)
+# must scan this view, not raw $COMMAND — otherwise a `gh issue create --body
+# "... see run.output ..."` whose prose merely *mentions* such a path triggers
+# the read-task-output block even though no read happens (issue #1591).
+# shellcheck disable=SC2001  # bash pattern substitution can't do `[^']*` char class
+COMMAND_NO_STRINGS=$(echo "$COMMAND_SHELL_ONLY" | sed "s/'[^']*'//g; s/\"[^\"]*\"//g")
+
 # Function to output a blocking message (exit code 2 = blocking error)
 block() {
     echo "$1" >&2
@@ -163,10 +172,15 @@ fi
 # Check for grep/rg command (should use Grep tool)
 # Allow grep -q / grep --quiet: these are boolean exit-code checks the Grep tool
 # cannot replicate (e.g. grep -q pattern file && do_thing).
+# Allow grep -l / -c / -L (and the rg/long-form equivalents): file-list and
+# count modes are filters over a known file set, not codebase searches the Grep
+# tool replaces (issue #1592). The char class is [lcL] (lowercase) so the
+# uppercase context flag -C (grep -C3, a real search) is NOT exempted.
 # Also allow piped grep (already excluded by the '|' check above).
 if echo "$COMMAND" | grep -Eq '^\s*(grep|rg)\s+' && \
    ! echo "$COMMAND" | grep -q '|' && \
-   ! echo "$COMMAND" | grep -Eq '(grep|rg)[^|]*\s(-[a-zA-Z]*q[a-zA-Z]*(\s|$)|--quiet(\s|$))'; then
+   ! echo "$COMMAND" | grep -Eq '(grep|rg)[^|]*\s(-[a-zA-Z]*q[a-zA-Z]*(\s|$)|--quiet(\s|$))' && \
+   ! echo "$COMMAND" | grep -Eq '(grep|rg)[^|]*\s(-[a-zA-Z]*[lcL][a-zA-Z]*(\s|$)|--count(\s|$)|--files-with-matches(\s|$)|--files-without-match(\s|$))'; then
     block "BLOCKED: 'grep -rn pattern src/' →
   Grep(pattern=\"pattern\", path=\"src\", -r=true, -n=true)
 
@@ -175,7 +189,10 @@ BLOCKED: 'rg pattern --type ts' →
 
 The Grep tool is optimized for codebase searches with proper permissions
 and result formatting. Pipelines (… | grep …) and boolean checks
-(grep -q pattern file && do_thing) are still allowed.
+(grep -q pattern file && do_thing) are still allowed; so are the
+file-list/count filter modes (grep -l, grep -c, grep -L).
+If the Grep tool is unavailable in this session, pipe instead — pipelines
+are allowed: rg --files <dir> | rg pattern  (or  … | grep pattern).
 See .claude/rules/bash-tool-replacements.md for the full table."
 fi
 
@@ -184,27 +201,56 @@ if echo "$COMMAND" | grep -Eq '^\s*ls\s+.*\*'; then
     block "REMINDER: Consider using the Glob tool for pattern-based file listing. Glob provides sorted results by modification time and handles large directories better."
 fi
 
-# Check for reading task output files (should use TaskOutput tool)
+# Check for reading task output files (should use the Read tool)
 # Detects patterns like: cat /tmp/claude/*/tasks/*.output, tail ...tasks/...output, sleep && cat ...output
-if echo "$COMMAND" | grep -Eq '(cat|tail|head).*(/tasks/|\.output)' || \
-   echo "$COMMAND" | grep -Eq 'sleep.*&&.*(cat|tail)'; then
-    block "REMINDER: Use the TaskOutput tool instead of Bash commands to read task output. The TaskOutput tool is designed for checking on background tasks - use it with the task_id parameter. Example: TaskOutput with task_id and block=false for non-blocking status checks."
+#
+# Scans COMMAND_NO_STRINGS (heredoc bodies and quoted literals stripped) so that
+# a `gh issue create --body "...mentions run.output..."` whose prose merely names
+# a task-output path is not mistaken for an actual read (issue #1591).
+#
+# TaskOutput is deprecated — its own tool guidance now says to Read the output
+# file path from the task notification. For large structured outputs, an
+# extraction pipeline (`cat … | jq`/`python3`) to a compact summary is allowed
+# and is the context-efficient path; only a *standalone* cat/tail/head read of a
+# task-output file (no pipe) is nudged toward Read here (issue #1591).
+if { echo "$COMMAND_NO_STRINGS" | grep -Eq '(cat|tail|head)\s[^|]*(/tasks/|\.output)' || \
+     echo "$COMMAND_NO_STRINGS" | grep -Eq 'sleep[^|]*&&[^|]*(cat|tail)\s[^|]*(/tasks/|\.output)'; } && \
+   ! echo "$COMMAND_NO_STRINGS" | grep -q '|'; then
+    block "REMINDER: Use the Read tool on the task-output file path from the task
+notification instead of cat/tail/head. (The TaskOutput tool is deprecated.)
+
+For a large structured output file, Read'ing the whole thing is wasteful — pipe
+an extraction to a compact summary instead (pipelines are allowed):
+  cat <output-file> | jq '<filter>'    or    cat <output-file> | python3 …"
 fi
 
-# Check for excessive pipe chains (5+ pipes suggest over-complexity)
-# Uses COMMAND_SHELL_ONLY (heredoc body already stripped above) to avoid
-# counting markdown table pipes or other literal content as shell pipe operators.
-# Strip quoted strings and || operators before counting actual shell pipes
-# - Single-quoted strings contain regex alternation (grep -E '(a|b|c)')
-# - Double-quoted strings may contain literal pipe characters
-# - || is logical OR, not a pipe operator
-PIPE_COUNT=$(echo "$COMMAND_SHELL_ONLY" | sed "s/'[^']*'//g; s/\"[^\"]*\"//g; s/||//g" | tr -cd '|' | wc -c)
-if [ "$PIPE_COUNT" -ge 5 ]; then
-    block "REMINDER: This command has $PIPE_COUNT pipes - consider simplifying. Options:
+# Check for excessive pipe chains (5+ pipes) — but only when a *discouraged head
+# stage* feeds the pipeline. Counting `|` alone false-blocked idiomatic
+# multi-stage analysis pipelines (jq | sort | uniq -c | sort, awk transforms,
+# etc.) over data a prior command produced — there is no shorter form and jq
+# *is* the right tool (issue #1603). A long pipeline whose stages are all
+# legitimate transforms is allowed regardless of length; the block fires only
+# when the data source is a discouraged `cat file |` / `echo |` / `printf |`
+# head, or a redundant `grep … | … grep` text-scrape.
+#
+# Uses COMMAND_SHELL_ONLY (heredoc body stripped) and strips quoted strings and
+# || operators first so regex-alternation literals (grep -E '(a|b|c)') and
+# format-string pipes (curl -w '… | …') are not counted as shell pipes (the
+# bogus "8 pipes" miscount in issue #1592).
+PIPE_BODY=$(echo "$COMMAND_SHELL_ONLY" | sed "s/'[^']*'//g; s/\"[^\"]*\"//g; s/||//g")
+PIPE_COUNT=$(echo "$PIPE_BODY" | tr -cd '|' | wc -c)
+if [ "$PIPE_COUNT" -ge 5 ] && \
+   echo "$PIPE_BODY" | grep -Eq '\b(cat|echo|printf)[[:space:]][^|]*\||grep\b[^|]*\|[^|]*grep\b'; then
+    block "REMINDER: This command has $PIPE_COUNT pipes fed from a discouraged head
+stage (cat/echo/printf, or a redundant grep | grep) - consider simplifying:
 - Use JSON output from the source (--reporter=json, --format=json) and parse with jq
 - Use awk for multi-step text processing in one command
 - Break into multiple steps with intermediate analysis
-- For test failures: use test runner's built-in summary/grouping features"
+- For test failures: use test runner's built-in summary/grouping features
+
+A long pipeline of legitimate transforms (jq | sort | uniq -c | sort, awk, sed)
+over a prior command's output is fine — this block only fires on a cat/echo
+text-scrape head."
 fi
 
 # Check for multi-grep chains parsing test/task output
@@ -281,27 +327,32 @@ Ask the user to run it manually with:
 3. What alternatives you tried"
 fi
 
-# Check for git push -u that would set main/master tracking to a feature branch.
-# Pattern: git push -u origin <branch> (no colon refspec) while on main/master
-# but pushing to a differently-named branch — this sets main's upstream to
-# origin/<feature-branch>, which is wrong.
-# Correct form: git push origin main:<feature-branch> (explicit refspec, no -u)
+# Check for git push -u with a COLON refspec whose source is the protected
+# current branch — `git push -u origin main:feature/x` sets main's upstream to
+# origin/feature/x, which is wrong. The recommended main-branch-dev push
+# (git push origin main:feature/x) should carry NO -u.
+#
+# The no-colon form `git push -u origin feat/x` is intentionally NOT matched:
+# it pushes the local feat/x ref and sets feat/x's upstream, never touching the
+# current branch — the old detector wrongly blocked it on a false "sets main's
+# tracking" premise, the same legitimate pattern as issue #1600.
 if echo "$COMMAND" | grep -Eq '^\s*git\s+push\b' && \
-   echo "$COMMAND" | grep -Eq '\s-u\b' && \
-   echo "$COMMAND" | grep -Eq '\sorigin\s+[a-zA-Z0-9._/-]+\s*$' && \
-   ! echo "$COMMAND" | grep -q ':'; then
-    PUSH_BRANCH=$(echo "$COMMAND" | grep -oE 'origin\s+[a-zA-Z0-9._/-]+' | awk '{print $2}')
+   echo "$COMMAND" | grep -Eq '(\s-[a-zA-Z]*u[a-zA-Z]*\b|--set-upstream\b)' && \
+   echo "$COMMAND" | grep -Eq '\sorigin\s+[a-zA-Z0-9._/@-]+:[a-zA-Z0-9._/-]+'; then
+    PUSH_REFSPEC=$(echo "$COMMAND" | grep -oE 'origin\s+[a-zA-Z0-9._/@-]+:[a-zA-Z0-9._/-]+' | awk '{print $2}')
+    PUSH_SRC=${PUSH_REFSPEC%%:*}
+    PUSH_DST=${PUSH_REFSPEC#*:}
     CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
-    if [ -n "$CURRENT_BRANCH" ] && [ -n "$PUSH_BRANCH" ] && \
-       [ "$CURRENT_BRANCH" != "$PUSH_BRANCH" ] && \
+    if [ -n "$CURRENT_BRANCH" ] && [ "$PUSH_SRC" = "$CURRENT_BRANCH" ] && \
+       [ "$PUSH_SRC" != "$PUSH_DST" ] && \
        { [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ]; }; then
-        block "REMINDER: 'git push -u origin $PUSH_BRANCH' while on '$CURRENT_BRANCH' will set $CURRENT_BRANCH to track origin/$PUSH_BRANCH instead of origin/$CURRENT_BRANCH.
+        block "REMINDER: 'git push -u origin $PUSH_SRC:$PUSH_DST' will set $CURRENT_BRANCH to track origin/$PUSH_DST instead of origin/$CURRENT_BRANCH.
 
 This is the main-branch development pattern: push to a remote feature branch WITHOUT -u:
-  git push origin $CURRENT_BRANCH:$PUSH_BRANCH
+  git push origin $CURRENT_BRANCH:$PUSH_DST
 
 The -u flag is only correct when local and remote branch names match:
-  git push -u origin $CURRENT_BRANCH  (pushes main to origin/main)"
+  git push -u origin $CURRENT_BRANCH  (pushes $CURRENT_BRANCH to origin/$CURRENT_BRANCH)"
     fi
 fi
 

--- a/hooks-plugin/hooks/branch-protection.sh
+++ b/hooks-plugin/hooks/branch-protection.sh
@@ -17,8 +17,12 @@
 #
 # Matches: Bash
 # Detects: git commit, git push, git rebase on main/master
-# Allows: read-only git operations, git merge (local, reversible), and the
-#         initial bootstrap push (a single root commit) that initializes a repo
+# Allows: read-only git operations, git merge (local, reversible), the initial
+#         bootstrap push (a single root commit) that initializes a repo, a push
+#         that explicitly names a non-protected target branch (e.g. git push -u
+#         origin feat/x while parked on main — pushes feat/x, not main; #1600),
+#         and any write in a GitHub wiki checkout (*.wiki, which renders only
+#         master and supports no PRs; #1586)
 
 set -euo pipefail
 
@@ -79,6 +83,22 @@ else
 fi
 [ -z "$CURRENT_BRANCH" ] && exit 0
 
+# Exempt GitHub wiki checkouts. A wiki renders only its `master` branch and
+# supports no pull requests, so "switch to a feature branch" is a dead end and
+# every wiki edit would degrade to full user delegation. Detect via the remote
+# URL (*.wiki.git — robust, survives directory renames) or the working-tree
+# top-level directory name (*.wiki — cheap fallback when there's no remote).
+# (#1586)
+if [ -n "$WORKING_DIR" ]; then
+  WIKI_REMOTE=$(git -C "$WORKING_DIR" remote get-url origin 2>/dev/null || echo "")
+  WIKI_TOPLEVEL=$(git -C "$WORKING_DIR" rev-parse --show-toplevel 2>/dev/null || echo "")
+else
+  WIKI_REMOTE=$(git remote get-url origin 2>/dev/null || echo "")
+  WIKI_TOPLEVEL=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+fi
+case "$WIKI_REMOTE" in *.wiki.git|*.wiki) exit 0 ;; esac
+case "$WIKI_TOPLEVEL" in *.wiki) exit 0 ;; esac
+
 # Only protect main and master
 if [ "$CURRENT_BRANCH" != "main" ] && [ "$CURRENT_BRANCH" != "master" ]; then
   exit 0
@@ -119,6 +139,26 @@ case "$GIT_SUBCMD" in
   push)
     # Allow push to specific remote branch via explicit refspec
     if echo "$COMMAND" | grep -q ':'; then
+      exit 0
+    fi
+    # Allow a push that explicitly names a non-protected branch as its target,
+    # even without a colon refspec. `git push -u origin feat/x` pushes the local
+    # `feat/x` ref (refs/heads/feat/x:refs/heads/feat/x) — the current branch
+    # being main is irrelevant to what gets pushed. Pre-fix this fell through to
+    # deny because only colon refspecs were allowed, even though the push never
+    # touches the protected branch (#1600). PUSH_TARGET is the 2nd positional
+    # (non-flag) token after `push` — i.e. the refspec following the remote.
+    # HEAD/@ are excluded because on a protected checkout they resolve back to
+    # the protected branch, so they must still be denied.
+    PUSH_TARGET=$(echo "$COMMAND" | awk '
+      { for (i = 1; i <= NF; i++) {
+          if ($i == "push") { seen = 1; continue }
+          if (seen && $i !~ /^-/) { n++; if (n == 2) { print $i; exit } }
+      } }')
+    if [ -n "$PUSH_TARGET" ] && \
+       [ "$PUSH_TARGET" != "$CURRENT_BRANCH" ] && \
+       [ "$PUSH_TARGET" != "main" ] && [ "$PUSH_TARGET" != "master" ] && \
+       [ "$PUSH_TARGET" != "HEAD" ] && [ "$PUSH_TARGET" != "@" ]; then
       exit 0
     fi
     # Allow the very first push that bootstraps a repo. When the branch tip is

--- a/hooks-plugin/hooks/secret-protection.sh
+++ b/hooks-plugin/hooks/secret-protection.sh
@@ -68,9 +68,18 @@ fi
 
 # Check Bash commands for sensitive file access and credential exposure
 if [ "$TOOL_NAME" = "Bash" ] && [ -n "$COMMAND" ]; then
-  # Block printing environment variables that likely contain secrets
-  # shellcheck disable=SC2016  # $(...) is a grep pattern, not shell expansion
-  if echo "$COMMAND" | grep -Eq '(echo|printf|cat|env|printenv|export).*\$(.*_(KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL|AUTH)s?)'; then
+  # Block printing environment variables that likely contain secrets.
+  # Match an actual variable *reference* whose name ends in a secret-ish suffix:
+  # `$VAR_KEY`, `${VAR_TOKEN}`, etc. The name is a contiguous identifier
+  # ([A-Za-z0-9_]*) — NOT `.*` — so the match cannot bridge a `$(date …)` command
+  # substitution to a distant unrelated `_KEY` elsewhere on the line. That `.*`
+  # greediness false-blocked routine config echoes like
+  # `echo "$(date) KC_HOSTNAME=$kch FE_KEYCLOAK_URL=$feu"`, where `FE_KEYCLOAK`
+  # contains `_KEY` but is an assignment LHS, not a secret variable reference
+  # (issue #1580). Public config names ($..._HOST, $..._URL, $..._ENDPOINT) are
+  # no longer caught; genuine $..._KEY/_SECRET/_TOKEN/_PASSWORD references are.
+  # shellcheck disable=SC2016  # $... is a grep pattern, not shell expansion
+  if echo "$COMMAND" | grep -Eq '(echo|printf|cat|env|printenv|export)[^|]*\$\{?[A-Za-z0-9_]*_(KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL|AUTH)[Ss]?\b'; then
     block "BLOCKED: Command may expose secret environment variables.
 Use the application's configuration system instead of echoing secrets.
 Set CLAUDE_HOOKS_DISABLE_SECRET_PROTECTION=1 to override."

--- a/hooks-plugin/hooks/test-bash-antipatterns.sh
+++ b/hooks-plugin/hooks/test-bash-antipatterns.sh
@@ -335,6 +335,147 @@ assert_stderr_contains \
     'bash-tool-replacements.md' \
     "head -50 file.md"
 
+# ── grep -l/-c/-L filter-mode exemption (issue #1592) ────────────────────────
+# Regression: grep -l (files-with-matches) and grep -c (count) over a known
+# file set are filters, not codebase searches the Grep tool replaces, but they
+# were blocked by the grep/rg detector. The uppercase context flag -C (a real
+# search) must still be blocked.
+echo ""
+echo "grep -l/-c/-L filter modes are exempt (-C context is not):"
+
+assert_exit \
+    "grep -lE over explicit files is allowed (files-with-matches)" 0 \
+    "grep -lE NOTARY /tmp/a.js /tmp/b.js"
+
+assert_exit \
+    "grep -c count mode is allowed" 0 \
+    "grep -c pattern /tmp/file.js"
+
+assert_exit \
+    "grep -rl (recursive files-with-matches) is allowed" 0 \
+    "grep -rl pattern src/"
+
+assert_exit \
+    "grep -L (files-without-match) is allowed" 0 \
+    "grep -L pattern file1 file2"
+
+assert_exit \
+    "grep --count long form is allowed" 0 \
+    "grep --count pattern file"
+
+assert_exit \
+    "grep -C3 (uppercase context) is still blocked (it's a real search)" 2 \
+    "grep -C3 pattern file"
+
+# ── task-output read → Read tool, not deprecated TaskOutput (issue #1591) ─────
+# Regression: the task-output detector recommended the deprecated TaskOutput
+# tool, fired on quoted/heredoc string content that merely *mentions* a
+# task-output path, and blocked extraction pipelines over large output files.
+echo ""
+echo "task-output reads nudge toward Read, allow extraction pipelines, ignore quoted mentions:"
+
+assert_exit \
+    "standalone cat of a task-output file is nudged toward Read" 2 \
+    "cat /tmp/claude/x/tasks/run.output"
+
+assert_exit \
+    "extraction pipeline over a task-output file is allowed" 0 \
+    "cat /tmp/claude/x/tasks/run.output | jq .results"
+
+assert_exit \
+    "gh issue body merely mentioning a .output path is allowed (quoted string)" 0 \
+    "gh issue create --body 'then tail the run.output file for results'"
+
+# The sleep-then-cat polling form reaches the task-output detector specifically
+# (a bare `cat`/`tail` read is caught by the generic cat/head-tail detectors
+# first). Assert that detector's message recommends Read, not TaskOutput.
+assert_stderr_contains \
+    "task-output block recommends the Read tool, not TaskOutput" \
+    'Use the Read tool' \
+    "sleep 5 && cat /tmp/claude/x/tasks/run.output"
+
+assert_stderr_contains \
+    "task-output block no longer names the deprecated TaskOutput tool as the fix" \
+    'TaskOutput tool is deprecated' \
+    "sleep 5 && cat /tmp/claude/x/tasks/run.output"
+
+# ── pipe-count gates on discouraged head stage, not raw count (issue #1603) ───
+# Regression: a long pipeline of legitimate transforms (jq | sort | uniq -c |
+# sort | …) was hard-blocked purely on pipe count. The block must fire only
+# when a discouraged head stage (cat/echo/printf, or a redundant grep | grep)
+# feeds the pipeline.
+echo ""
+echo "long pipelines of legit transforms pass; cat/echo-headed scrapes still blocked:"
+
+assert_exit \
+    "jq|sort|uniq|sort|head|tail analysis pipeline is allowed (6 pipes, jq head)" 0 \
+    "jq -r '[.a,.b]|@tsv' r.jsonl | sort | uniq -c | sort -k2 | head | tail"
+
+assert_exit \
+    "cat-headed 5+ pipe text-scrape is still blocked" 2 \
+    "cat f.txt | grep x | grep y | sed s/a/b/ | cut -f1 | sort"
+
+assert_exit \
+    "redundant grep | grep | sed | cut | sort chain is still blocked" 2 \
+    "ps aux | grep proc | grep -v grep | awk '{print \$2}' | sort | uniq"
+
+# ── grep block message offers the pipe fallback (issue #1602) ─────────────────
+# Regression: when the Grep tool is unavailable in a session, the block message
+# pointed only at Grep(...). It must also offer the always-allowed pipe form.
+echo ""
+echo "grep block message offers the pipe fallback for sessions without the Grep tool:"
+
+assert_stderr_contains \
+    "grep block message mentions the pipe fallback" \
+    'pipe instead' \
+    "grep -rn pattern src/"
+
+# ── git push -u colon-refspec footgun, no-colon form allowed (issue #1600) ────
+# Regression: the push -u detector blocked the legitimate no-colon form
+# `git push -u origin feat/x` (which pushes feat/x, never touching main) on a
+# false premise. It must instead catch only the real footgun: -u on a colon
+# refspec whose source is the protected branch (git push -u origin main:feat).
+# Run against a throwaway repo on `main` so branch detection has a branch.
+echo ""
+echo "git push -u: no-colon feature push allowed, colon main:feat footgun blocked (#1600):"
+
+PUSH_REPO=$(mktemp -d)
+git -C "$PUSH_REPO" init -q -b main
+git -C "$PUSH_REPO" config user.email t@e.com
+git -C "$PUSH_REPO" config user.name t
+git -C "$PUSH_REPO" config commit.gpgsign false
+git -C "$PUSH_REPO" commit -q --allow-empty -m init
+
+# $HOOK is a relative path in this suite; resolve it to absolute so the
+# subshell `cd "$PUSH_REPO"` below doesn't break the lookup (would exit 127).
+HOOK_ABS="$(cd "$(dirname "$HOOK")" && pwd)/$(basename "$HOOK")"
+
+assert_push_exit() {
+    local desc="$1" expected="$2" cmd="$3"
+    local json exit_code=0
+    json=$(jq -nc --arg cmd "$cmd" '{tool_name:"Bash",tool_input:{command:$cmd}}')
+    ( cd "$PUSH_REPO" && printf '%s' "$json" | bash "$HOOK_ABS" >/dev/null 2>&1 ) || exit_code=$?
+    if [ "$exit_code" -eq "$expected" ]; then
+        printf "  PASS: %s\n" "$desc"; PASS=$((PASS + 1))
+    else
+        printf "  FAIL: %s (expected exit %d, got %d)\n" "$desc" "$expected" "$exit_code"; FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_push_exit \
+    "git push -u origin feat/x (no colon) is allowed from main" 0 \
+    "git push -u origin feat/x"
+
+assert_push_exit \
+    "git push -u origin main:feat/x (colon, source=main) is blocked" 2 \
+    "git push -u origin main:feat/x"
+
+assert_push_exit \
+    "git push origin main:feat/x without -u is allowed" 0 \
+    "git push origin main:feat/x"
+
+rm -rf "$PUSH_REPO"
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/hooks-plugin/hooks/test-branch-protection.sh
+++ b/hooks-plugin/hooks/test-branch-protection.sh
@@ -228,6 +228,77 @@ assert_deny \
   "git -C <master-worktree> push (no refspec) is still denied" \
   "git -C $MASTER_WT push"
 
+# ── push to an explicit non-protected ref from a main checkout (#1600) ───────
+# Regression: `git push -u origin feat/x` while parked on main was denied
+# because only colon refspecs were allowed — but that command pushes feat/x,
+# not main. An explicitly-named non-protected target must be allowed; HEAD and
+# the protected branch itself must still be denied.
+echo ""
+echo "explicit non-protected push target from main is allowed (#1600):"
+
+assert_allow \
+  "git push -u origin feat/x (explicit feature ref) is allowed from main" \
+  "git push -u origin feat/x"
+
+assert_allow \
+  "git push origin feat/x (no -u) is allowed from main" \
+  "git push origin feat/x"
+
+assert_deny \
+  "git push origin main (explicit protected target) is still denied" \
+  "git push origin main"
+
+assert_deny \
+  "git push origin HEAD (resolves to main on a main checkout) is still denied" \
+  "git push origin HEAD"
+
+# ── GitHub wiki checkout exemption (#1586) ───────────────────────────────────
+# Wikis render only `master` and support no PRs, so branch protection would
+# force every wiki edit into full user delegation. A *.wiki checkout (detected
+# by directory name or *.wiki.git remote) is exempt. Built in its own repo
+# whose top-level dir ends in `.wiki`.
+echo ""
+echo "GitHub wiki checkouts are exempt from branch protection (#1586):"
+
+WIKI_PARENT=$(mktemp -d)
+WIKI_REPO="$WIKI_PARENT/myproject.wiki"
+mkdir -p "$WIKI_REPO"
+git -C "$WIKI_REPO" init -q -b master
+git -C "$WIKI_REPO" config user.email "test@example.com"
+git -C "$WIKI_REPO" config user.name "test"
+git -C "$WIKI_REPO" config commit.gpgsign false
+git -C "$WIKI_REPO" commit -q --allow-empty -m init
+git -C "$WIKI_REPO" commit -q --allow-empty -m second
+
+assert_wiki_allow() {
+  local desc="$1" cmd_str="$2"
+  local json out
+  json=$(jq -nc --arg cmd "$cmd_str" '{tool_name:"Bash",tool_input:{command:$cmd}}')
+  out=$( cd "$WIKI_REPO" && printf '%s' "$json" | bash "$HOOK" )
+  if [ -z "$out" ]; then
+    printf "  PASS: %s\n" "$desc"; PASS=$((PASS + 1))
+  else
+    printf "  FAIL: %s\n        expected silent allow, got: %s\n" "$desc" "$out"; FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_wiki_allow \
+  "git add in a *.wiki checkout (by dir name) is allowed on master" \
+  "git add Home.md"
+
+assert_wiki_allow \
+  "git commit in a *.wiki checkout (by dir name) is allowed on master" \
+  "git commit -m 'docs: add page'"
+
+# Now add a *.wiki.git remote and confirm the remote-URL detection path too.
+git -C "$WIKI_REPO" remote add origin "https://github.com/owner/myproject.wiki.git"
+
+assert_wiki_allow \
+  "git add in a checkout with a *.wiki.git remote is allowed" \
+  "git add Home.md"
+
+rm -rf "$WIKI_PARENT"
+
 # ── read-only operations remain silently allowed ────────────────────────────
 echo ""
 echo "read-only git operations remain allowed:"

--- a/hooks-plugin/hooks/test-secret-protection.sh
+++ b/hooks-plugin/hooks/test-secret-protection.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Regression tests for secret-protection.sh
+#
+# Run: bash hooks-plugin/hooks/test-secret-protection.sh
+# Exit 0 = all tests pass, Exit 1 = failures
+#
+# Covers:
+#   - Genuine secret variable references ($API_TOKEN, ${DB_PASSWORD}) are blocked.
+#   - Routine config echoes whose line happens to contain a `_KEY`-suffixed
+#     *name* far from a `$(...)` command substitution are NOT blocked — the
+#     `.*` greediness that bridged `$(date)` to a distant `FE_KEYCLOAK_URL` is
+#     fixed (issue #1580).
+#   - Sensitive file reads (.env, .ssh, credentials) are still blocked.
+set -euo pipefail
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/secret-protection.sh"
+PASS=0
+FAIL=0
+
+assert_exit() {
+    local desc="$1" expected="$2" cmd="$3"
+    local json exit_code=0
+    json=$(jq -nc --arg cmd "$cmd" '{tool_name:"Bash",tool_input:{command:$cmd}}')
+    printf '%s' "$json" | bash "$HOOK" >/dev/null 2>&1 || exit_code=$?
+    if [ "$exit_code" -eq "$expected" ]; then
+        printf "  PASS: %s\n" "$desc"; PASS=$((PASS + 1))
+    else
+        printf "  FAIL: %s (expected exit %d, got %d)\n" "$desc" "$expected" "$exit_code"; FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "=== secret-protection hook tests ==="
+
+# ── secret-env false-positive regression (issue #1580) ───────────────────────
+echo ""
+echo "config NAME=value echoes are allowed; genuine secret var refs are blocked:"
+
+assert_exit \
+    "echo with \$(date) + config names (KC_HOSTNAME, FE_KEYCLOAK_URL) is allowed" 0 \
+    "echo \"\$(date +%H:%M:%S) KC_HOSTNAME=\$kch FE_KEYCLOAK_URL=\$feu\""
+
+assert_exit \
+    "echo of \$..._HOST / \$..._URL config vars is allowed" 0 \
+    "echo \"host=\${SERVICE_HOST} url=\${API_URL} endpoint=\${GRPC_ENDPOINT}\""
+
+assert_exit \
+    "echo \$API_TOKEN (genuine secret ref) is blocked" 2 \
+    "echo \"API_TOKEN=\$API_TOKEN\""
+
+assert_exit \
+    "echo \${DB_PASSWORD} (genuine secret ref) is blocked" 2 \
+    "echo \"value is \${DB_PASSWORD}\""
+
+assert_exit \
+    "printf \$AWS_SECRET_ACCESS_KEY (genuine secret ref) is blocked" 2 \
+    "printf '%s' \"\$AWS_SECRET_ACCESS_KEY\""
+
+assert_exit \
+    "echo \$..._CREDENTIALS (genuine secret ref) is blocked" 2 \
+    "echo \"\$SERVICE_CREDENTIALS\""
+
+# ── full-environment dump still blocked ──────────────────────────────────────
+echo ""
+echo "bare env / printenv dump is still blocked:"
+
+assert_exit \
+    "bare 'env' is blocked" 2 \
+    "env"
+
+assert_exit \
+    "bare 'printenv' is blocked" 2 \
+    "printenv"
+
+assert_exit \
+    "printenv VAR_NAME (specific var) is allowed" 0 \
+    "printenv HOME"
+
+# ── sensitive file reads still blocked ───────────────────────────────────────
+echo ""
+echo "sensitive file access is still blocked:"
+
+assert_exit \
+    "cat .env is blocked" 2 \
+    "cat .env"
+
+assert_exit \
+    "cat ~/.ssh/id_rsa is blocked" 2 \
+    "cat ~/.ssh/id_rsa"
+
+# Note: the Read/Edit/Write file_path check exempts .env.example/.sample/
+# .template; the Bash-command .env matcher is intentionally broad and is out of
+# scope for #1580, so reading a template via `cat` is not asserted here.
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

Triaged the 42 open issues and found a dense, low-risk cluster: **hook
false-positives in `hooks-plugin`**, with one file (`bash-antipatterns.sh`)
implicated in five of them. This PR fixes **7 issues** across three hook
scripts in a single pass, each with a regression test (per
`.claude/rules/regression-testing.md`).

## Issues resolved

| # | Hook | Fix |
|---|------|-----|
| #1592 | bash-antipatterns | Exempt `grep -l`/`-c`/`-L` filter modes (uppercase `-C` context stays blocked); mirrored into the teach variant |
| #1591 | bash-antipatterns | Recommend **Read** (not the deprecated TaskOutput); scan a quote/heredoc-stripped view so prose merely *mentioning* a `.output` path no longer fires; allow extraction pipelines for large outputs |
| #1603 | bash-antipatterns | Gate the 5+-pipe block on a discouraged head stage (`cat`/`echo`/`printf` or redundant `grep \| grep`) instead of raw pipe count — idiomatic `jq \| sort \| uniq -c \| sort` analysis pipelines now pass |
| #1602 | bash-antipatterns | Offer the always-allowed pipe fallback in the `grep`/`rg` block message for sessions without the `Grep` tool |
| #1600 | bash-antipatterns + branch-protection | Stop false-blocking `git push -u origin feat/x` from a `main` checkout (it pushes `feat/x`, never touches `main`); branch-protection now allows an explicitly-named non-protected push target; the bash-antipatterns `-u` detector now catches only the real footgun (`-u` on a `main:feat` colon refspec) |
| #1586 | branch-protection | Exempt GitHub wiki checkouts (`*.wiki` dir or `*.wiki.git` remote) — wikis render only `master` and support no PRs |
| #1580 | secret-protection | Tighten the secret-env regex so the variable name is a contiguous identifier (not greedy `.*`), preventing a `$(date …)` substitution from bridging to a distant `_KEY`-suffixed config name; genuine `$VAR_KEY`/`_SECRET`/`_TOKEN` refs stay blocked |

## Testing

- `test-bash-antipatterns.sh`: 58 passed
- `test-bash-antipatterns-teach.sh`: 22 passed
- `test-branch-protection.sh`: 26 passed
- `test-secret-protection.sh`: 11 passed (new file)
- `scripts/lint-shell-scripts.sh`: 0 errors / 0 warnings

Docs updated in the same commit (`docs-currency`): `bash-tool-replacements.md`
(grep `-l`/`-c` exemption) and `hooks-plugin/hooks/README.md` (Read-over-TaskOutput).

## Out of scope (noted during triage)

- **#1604** (TaskCompleted false mismatch on worktree-isolated work) describes
  an LLM-based task-vs-implementation check, not the heuristic
  `task-completeness.sh` Stop hook in this repo — it's harness behavior.
- **#1627** (git-triage TSV body packing) lives in `git-plugin`; kept out to
  keep this PR single-scope for release-please.

Closes #1580
Closes #1586
Closes #1591
Closes #1592
Closes #1600
Closes #1602
Closes #1603

https://claude.ai/code/session_01LAycLVymEp4vBJ2RsLtNHT

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAycLVymEp4vBJ2RsLtNHT)_