### PR TITLE
docs(blueprint-plugin): mark merged cues live in registry

### DIFF
--- a/blueprint-plugin/docs/behavioral-cue-registry.md
+++ b/blueprint-plugin/docs/behavioral-cue-registry.md
@@ -14,9 +14,9 @@ now this file is hand-maintained.
 | Hook script | Plugin | Event | Matcher | Channel | Dedup key | Trigger summary |
 |---|---|---|---|---|---|---|
 | `blueprint-plugin/hooks/blueprint-structural-cue.sh` | `blueprint-plugin` | `PostToolUse` | `Edit\|Write` | `updatedToolOutput` | `~/.cache/blueprint-structural-cue/<session_id>` | Manifest edit (`plugin.json`, `marketplace.json`), public-symbol/export line, TS `export interface/type`, exported Go/Rust types, route registration, or schema/IDL files (`*.proto`, `*.graphql`, `openapi*`) — widened by #1616. Excludes `docs/adrs/**` and `docs/prds/**`. Bypass: `BLUEPRINT_SKIP_HOOKS=1`. |
-| `codebase-attributes-plugin/hooks/attributes-health-cue.sh` | `codebase-attributes-plugin` | `SessionStart` | `""` (all) | `additionalContext` | `~/.cache/attributes-health-cue/<session_id>` | `.claude/attributes.json` present in project root. _(PR #1619, pending merge.)_ |
+| `codebase-attributes-plugin/hooks/attributes-health-cue.sh` | `codebase-attributes-plugin` | `SessionStart` | `""` (all) | `additionalContext` | `~/.cache/attributes-health-cue/<session_id>` | `.claude/attributes.json` present in project root. |
 | `session-plugin/hooks/session-end-nudge.sh` | `session-plugin` | `Stop` | _(none)_ | `decision:block` | `~/.cache/claude-session-end-nudge/<session_id>` | ≥6 genuine user turns + wind-down phrase in last 3 user messages + distillable surface (taskwarrior or `.claude/rules/`/justfile). Skips when session-wrap/end/distill skill already in transcript. Appends taskwarrior state-sync cue when open tasks exist (#1618). |
-| `code-quality-plugin/hooks/code-quality-preflight-cue.sh` | `code-quality-plugin` | `PostToolUse` | `Edit\|Write` | `decision:block` + `continueOnBlock` | `~/.cache/code-quality-preflight-cue/<session_id>` | Large or structurally significant edit. _(PR #1623, pending merge.)_ |
+| `code-quality-plugin/hooks/code-quality-preflight-cue.sh` | `code-quality-plugin` | `PostToolUse` | `Edit\|Write` | `decision:block` + `continueOnBlock` | `~/.cache/code-quality-preflight-cue/<session_id>` | Public-symbol line, manifest (`plugin.json`, `marketplace.json`, `package.json`, `Cargo.toml`, `pyproject.toml`), or payload ≥50 lines; excludes docs/tests/lockfiles. |
 | `session-plugin/hooks/session-spinup-nudge.sh` | `session-plugin` | `SessionStart` | `""` (`startup\|resume` only) | `additionalContext` | `~/.cache/claude-session-spinup-nudge/<session_id>` | Uncommitted changes, unpushed commits, or open taskwarrior tasks for the project at session start. Pre-ADR-0017; included for completeness. |
 | `hooks-plugin/hooks/bash-antipatterns-teach.sh` | `hooks-plugin` | `PostToolUse` | `Bash` | `updatedToolOutput` | `${TMPDIR}/claude-bash-teach-seen/<session_id>` | Soft-teach antipatterns: `cat file`→Read; `head`/`tail file`→Read with offset/limit; `find -name` without discovery flags→Glob; standalone `grep`/`rg`→Grep; `ls *glob*`→Glob. Opt-in: no-ops unless `CLAUDE_HOOKS_ENABLE_BASH_ANTIPATTERNS_TEACH=1`. Pre-ADR-0017; included for completeness. |
 
@@ -27,7 +27,7 @@ Two rows fire on `PostToolUse` with matcher `Edit|Write`:
 | Cue | Detection focus |
 |-----|----------------|
 | `blueprint-structural-cue.sh` | Manifests and public-symbol export lines |
-| `code-quality-preflight-cue.sh` _(#1623, pending)_ | Large or structurally significant edits |
+| `code-quality-preflight-cue.sh` | Large or structurally significant edits |
 
 Both hooks may fire on the same edit event. Mitigations:
 


### PR DESCRIPTION
## Summary

Follow-up to #1624. Two registry rows carried `(pending merge)` annotations that are now stale — both PRs have merged:

- **#1619** `attributes-health-cue.sh` → drop `(PR #1619, pending merge.)`
- **#1623** `code-quality-preflight-cue.sh` → drop `(PR #1623, pending merge.)` and replace the placeholder trigger text with the cue's real detection (public-symbol line, manifest, or payload ≥50 lines; excludes docs/tests/lockfiles)
- Collision-audit table: drop the `(#1623, pending)` note

Pure docs accuracy change — 1 file, +3/−3.

Refs #1599
Refs #1615

https://claude.ai/code/session_01CviK9baM61wLFdLcCwuFcY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CviK9baM61wLFdLcCwuFcY)_