### PR TITLE
chore(claude-probe): migrate model/effort matrix to Opus 4.8

### DIFF
--- a/experiments/claude-probe/README.md
+++ b/experiments/claude-probe/README.md
@@ -10,8 +10,8 @@ Runs the same small prompts against `claude -p` in two configurations:
 - **probe** — `--system-prompt "$(cat prompts/probe.md)"` (a minimal
   replacement; our global rules + plugin infrastructure do the rest)
 
-Both configurations run across multiple model / thinking combinations
-(see `conditions.yaml`). Transcripts are captured as stream-JSON, then
+Both configurations run across multiple effort levels on a single model
+(`claude-opus-4-8`; see `conditions.yaml`). Transcripts are captured as stream-JSON, then
 scored deterministically (tool selection, turn count, output budget)
 and with an LLM judge (fuzzy quality criteria).
 
@@ -27,29 +27,31 @@ either the repo root (`just claude-probe::run …`) or from this
 directory (`just run …`).
 
 ```sh
-# Day-to-day (sonnet, cheap): 4 conditions × tests × runs.
+# Day-to-day (opus-low, cheap): default+probe × tests × runs.
 just claude-probe::run
 
 # Narrow to one test.
 just claude-probe::run 01-glob-vs-find
 
-# Confirmation pass on opus (expensive — reserve for stable probe versions).
-just claude-probe::run-opus
+# Confirmation pass — all 8 conditions (4 efforts × 2 prompts). Expensive.
+just claude-probe::run-full
+
+# Opt-in heavy check on `max` effort (manual only — needs opus-max-* conditions).
+just claude-probe::run-max
 
 # Single invocation for fast iteration.
-just claude-probe::run-one 01-glob-vs-find sonnet-medium-probe
+just claude-probe::run-one 01-glob-vs-find opus-low-probe
 
 # Score and aggregate the last run (LLM judge on Haiku).
 just claude-probe::compare
 just claude-probe::compare-fast   # skip LLM judge
-
-# Full 8-condition sweep across both tiers (very expensive).
-just claude-probe::run-all
 ```
 
-The model tier split (`run-sonnet` vs `run-opus`) exists because a full
-8-test Opus sweep burns through a monthly quota fast. Iterate on sonnet
-until a probe version looks stable, then confirm on opus.
+The effort tier (`run` = opus-low vs `run-full` = all four efforts) is the
+cost lever: a full 8-test sweep across four efforts burns through a monthly
+quota fast. Iterate on opus-low until a probe version looks stable, then
+confirm with `run-full`. `max` effort is opt-in only (`run-max`) for the
+occasional heavy check.
 
 See `docs/methodology.md` for the scoring rubric and why each variable
 is what it is. `docs/decision-analysis.md` has the original motivation
@@ -61,7 +63,7 @@ default prompt).
 | Path | Contents |
 |---|---|
 | `prompts/probe.md` | The minimal system-prompt override under test |
-| `conditions.yaml` | Model × thinking × prompt matrix |
+| `conditions.yaml` | Effort × prompt matrix (model fixed to opus-4-8) |
 | `tests/*.yaml` | One test case per file |
 | `scripts/run-one.sh` | One (test, condition, run) invocation |
 | `scripts/run-suite.sh` | Cartesian sweep |
@@ -74,9 +76,10 @@ default prompt).
 
 ## Cost notes
 
-A full run is 96 Opus invocations (8 tests × 4 conditions × 3 runs).
-The LLM judge adds one Haiku invocation per `llm_judge` check. When
-iterating on a single test, prefer `just run-one` over `just run`.
+A full sweep (`run-full`) is 192 Opus invocations (8 tests × 8
+conditions × 3 runs). The LLM judge adds one Haiku invocation per
+`llm_judge` check. When iterating on a single test, prefer
+`just run-one` over `just run`.
 
 ## Not a plugin
 

--- a/experiments/claude-probe/conditions.yaml
+++ b/experiments/claude-probe/conditions.yaml
@@ -1,52 +1,58 @@
-# Condition matrix: cartesian product of (model/effort) x (system_prompt).
+# Condition matrix: cartesian product of (effort) x (system_prompt).
 #
 # `effort` maps to `claude --effort <level>` (low|medium|high|xhigh|max).
 # `system_prompt: default` = no override (baseline Claude Code).
 # `system_prompt: probe`   = --system-prompt "$(cat prompts/probe.md)".
 #
-# Tiers:
-#   opus-*    — expensive, reserve for confirmation runs
-#   sonnet-*  — cheap, use for day-to-day iteration
+# Model is fixed to claude-opus-4-8 — Opus 4.8 on *low* effort beats Sonnet
+# on both cost and quality (see ~/.claude/rules/agent-and-tool-selection.md),
+# so the cost lever is now *effort*, not model tier.
+#
+# Efforts under automated test: low, medium, high, xhigh (4 × 2 prompts = 8).
+# `max` is opt-in only — add an `opus-max-*` pair manually / via `just run-max`
+# for the occasional heavy check; it is never in the default sweep. (`ultracode`
+# is a workflow opt-in, not an `--effort` level, so it is out of scope here.)
+#
+# IDs keep the `opus-` prefix so a one-off `max` or comparison condition can be
+# added later without collision.
 
 conditions:
-  # Sonnet tier — cheap iteration
-  - id: sonnet-xhigh-default
-    model: claude-sonnet-4-6
-    thinking: xhigh
+  - id: opus-low-default
+    model: claude-opus-4-8
+    thinking: low
     system_prompt: default
 
-  - id: sonnet-xhigh-probe
-    model: claude-sonnet-4-6
-    thinking: xhigh
-    system_prompt: probe
-
-  - id: sonnet-medium-default
-    model: claude-sonnet-4-6
-    thinking: medium
-    system_prompt: default
-
-  - id: sonnet-medium-probe
-    model: claude-sonnet-4-6
-    thinking: medium
-    system_prompt: probe
-
-  # Opus tier — confirmation / spot-check
-  - id: opus-xhigh-default
-    model: claude-opus-4-7
-    thinking: xhigh
-    system_prompt: default
-
-  - id: opus-xhigh-probe
-    model: claude-opus-4-7
-    thinking: xhigh
+  - id: opus-low-probe
+    model: claude-opus-4-8
+    thinking: low
     system_prompt: probe
 
   - id: opus-medium-default
-    model: claude-opus-4-7
+    model: claude-opus-4-8
     thinking: medium
     system_prompt: default
 
   - id: opus-medium-probe
-    model: claude-opus-4-7
+    model: claude-opus-4-8
     thinking: medium
+    system_prompt: probe
+
+  - id: opus-high-default
+    model: claude-opus-4-8
+    thinking: high
+    system_prompt: default
+
+  - id: opus-high-probe
+    model: claude-opus-4-8
+    thinking: high
+    system_prompt: probe
+
+  - id: opus-xhigh-default
+    model: claude-opus-4-8
+    thinking: xhigh
+    system_prompt: default
+
+  - id: opus-xhigh-probe
+    model: claude-opus-4-8
+    thinking: xhigh
     system_prompt: probe

--- a/experiments/claude-probe/docs/iteration-log.md
+++ b/experiments/claude-probe/docs/iteration-log.md
@@ -130,3 +130,44 @@ room to expand. The probe is tonally calibrated for sonnet, not opus.
   opus, either stick with default or work on a v3 that adds
   opus-specific brevity scaffolding without re-introducing the bulk
   of the default prompt.
+
+## Harness migration — 2026-06-14 (model axis → effort axis)
+
+### What changed
+
+The condition matrix collapsed its **model** axis to a single model,
+`claude-opus-4-8`, and expanded its **effort** axis from two levels
+(`medium`, `xhigh`) to a four-level sweep (`low`, `medium`, `high`,
+`xhigh`). `max` is opt-in only (`just run-max`), never in the automated
+default. Eight conditions (4 efforts × 2 prompts) replace the previous
+eight (2 models × 2 efforts × 2 prompts).
+
+Recipe changes: `run` is now opus-low default+probe (cheapest meaningful
+A/B); `run-full` sweeps all four efforts; `run-max` is the manual heavy
+check. The old model-tier recipes (`run-sonnet`, `run-opus`, `run-all`)
+are removed. The Python aggregation scripts and `run-one.sh` /
+`run-suite.sh` needed no change — they resolve conditions generically.
+
+### Why
+
+Opus 4.8 on *low* effort beats Sonnet on both cost and quality (codified
+in `~/.claude/rules/agent-and-tool-selection.md`), so the original
+"sonnet=cheap iteration, opus=confirmation" model tiering is obsolete.
+Effort is now the cost lever on a single, best-available model.
+
+### Status of prior measurements
+
+The v2 numbers above were taken on `claude-opus-4-7` and
+`claude-sonnet-4-6` — they are now **historical baselines**. The next
+`run-full` re-establishes the v2 probe baseline on Opus 4.8.
+
+### Open hypothesis to re-check
+
+The v2 finding was that the probe *saved* output tokens on sonnet but
+*cost* tokens on opus-4-7 under extended thinking (cost grew with
+effort). On Opus 4.8 across `low → xhigh`:
+
+- Does the "cost grows with effort" pattern reproduce — i.e. does the
+  probe's token premium over default widen as effort rises?
+- Is the probe still at **capability parity** with the default prompt
+  across all four efforts?

--- a/experiments/claude-probe/docs/methodology.md
+++ b/experiments/claude-probe/docs/methodology.md
@@ -16,12 +16,12 @@ harm* and *may reduce token waste and friction*.
 
 | Axis | Values | Notes |
 |---|---|---|
-| Model / thinking | `opus-xhigh`, `opus-medium` | Fixed via `conditions.yaml` |
+| Effort | `low`, `medium`, `high`, `xhigh` | Model fixed to `claude-opus-4-8`; `max` opt-in only |
 | System prompt | `default` (none) vs `probe` (`prompts/probe.md`) | `--system-prompt` replaces |
 | Tests | `tests/*.yaml` | Start with 8 seeds |
 | Runs | 3 per cell | Samples the model's stochasticity |
 
-Four conditions × 8 tests × 3 runs = 96 invocations per full suite.
+Eight conditions × 8 tests × 3 runs = 192 invocations per full suite.
 
 ## Invocation
 

--- a/experiments/claude-probe/justfile
+++ b/experiments/claude-probe/justfile
@@ -13,26 +13,24 @@ help:
 # Running
 ##########
 
-# Default: iterate on sonnet (4 conditions × filter × runs). Cheap.
+# Default: cheapest meaningful A/B — opus-low, default+probe only.
 [group: "run"]
-run filter="*" runs="3": (run-sonnet filter runs)
-
-# Sonnet-only sweep — 4 conditions, recommended for day-to-day iteration.
-[group: "run"]
-run-sonnet filter="*" runs="3":
+run filter="*" runs="3":
     bash scripts/run-suite.sh --filter "{{filter}}" --runs "{{runs}}" \
-        --conditions sonnet-xhigh-default,sonnet-xhigh-probe,sonnet-medium-default,sonnet-medium-probe
+        --conditions opus-low-default,opus-low-probe
 
-# Opus-only sweep — 4 conditions, reserve for confirmation runs. Expensive.
+# Confirmation pass — all 8 conditions (4 efforts × 2 prompts). Expensive.
 [group: "run"]
-run-opus filter="*" runs="3":
-    bash scripts/run-suite.sh --filter "{{filter}}" --runs "{{runs}}" \
-        --conditions opus-xhigh-default,opus-xhigh-probe,opus-medium-default,opus-medium-probe
-
-# Full 8-condition sweep (sonnet + opus). Expensive — think before running.
-[group: "run"]
-run-all filter="*" runs="3":
+run-full filter="*" runs="3":
     bash scripts/run-suite.sh --filter "{{filter}}" --runs "{{runs}}"
+
+# Requires opus-max-{default,probe} in conditions.yaml — intentionally absent
+# from the default sweep, so add them when you actually need this run.
+# Opt-in `max`-effort heavy check (manual only; needs opus-max-* conditions).
+[group: "run"]
+run-max filter="*" runs="3":
+    bash scripts/run-suite.sh --filter "{{filter}}" --runs "{{runs}}" \
+        --conditions opus-max-default,opus-max-probe
 
 # Run a single (test, condition, run_n) triple for fast iteration.
 [group: "run"]


### PR DESCRIPTION
## What

Migrate the `experiments/claude-probe/` A/B harness from tiering **by model** (sonnet=cheap iteration, opus-4-7=confirm) to tiering **by effort** on a single model, `claude-opus-4-8`.

## Why

Opus 4.8 on *low* effort beats Sonnet on both cost and quality (codified in `~/.claude/rules/agent-and-tool-selection.md`), so the original model tiering is obsolete. Effort is now the cost lever.

## Changes

| File | Change |
|---|---|
| `conditions.yaml` | 8 conditions, all `claude-opus-4-8`, keyed by effort (low/medium/high/xhigh × default/probe); `max` is opt-in only |
| `justfile` | `run` = opus-low default+probe; `run-full` = all 8; `run-max` = opt-in max-effort. Dropped `run-sonnet`/`run-opus`/`run-all` |
| `README.md` | Quickstart recipes, effort-tier rationale, cost note (96 → 192 invocations) |
| `docs/methodology.md` | Variables table fixed to opus-4-8 + 4-level effort; "96" → "192" |
| `docs/iteration-log.md` | 2026-06-14 migration entry; v2 opus-4-7/sonnet numbers are now historical; open hypothesis for the next run |

The `run-one.sh` / `run-suite.sh` / Python scripts are condition-agnostic and needed no change.

## Verification (live)

- `just conditions` lists the 8 new `opus-<effort>-<prompt>` IDs
- `just run-one 01-glob-vs-find opus-low-probe` → meta sidecar shows `"model": "claude-opus-4-8"`, `"thinking": "low"`
- `just compare-fast` aggregates the new IDs cleanly

Re-establishing the v2 baseline on Opus 4.8 is tracked separately (taskwarrior task 222); this PR is the config/docs migration only. Not a published plugin — no marketplace/release-please changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)