### PR TITLE
feat(configure-plugin): add configure-surface doc-drift gate skill

### DIFF
--- a/configure-plugin/.claude-plugin/plugin.json
+++ b/configure-plugin/.claude-plugin/plugin.json
@@ -44,6 +44,8 @@
     "onboarding",
     "repo-setup",
     "stack-aware",
-    "driver"
+    "driver",
+    "docs-drift",
+    "surface"
   ]
 }

--- a/configure-plugin/README.md
+++ b/configure-plugin/README.md
@@ -77,6 +77,7 @@ All commands support two modes:
 | `configure-formatting` | Code formatting (Biome, Prettier, Ruff, rustfmt) |
 | `configure-dead-code` | Dead code detection (Knip, Vulture, cargo-machete) |
 | `configure-docs` | Documentation standards and generators |
+| `configure-surface` | Surface doc↔code drift gate (deterministic, SHA-pinned) |
 | `configure-security` | Security scanning (dependency audits, SAST, secrets) |
 
 ### Infrastructure

--- a/configure-plugin/skills/configure-surface/SKILL.md
+++ b/configure-plugin/skills/configure-surface/SKILL.md
@@ -1,0 +1,205 @@
+---
+created: 2026-06-14
+modified: 2026-06-14
+reviewed: 2026-06-14
+description: "Surface doc-drift gate: scaffold surf.toml + hubs, wire the SHA-pinned pre-commit/Action. Use when adding a docs-governed-like-code CI gate."
+allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebFetch
+args: "[--check-only] [--fix] [--pin <tag>]"
+argument-hint: "[--check-only] [--fix] [--pin v0.6.2]"
+name: configure-surface
+language: rust
+---
+
+# /configure:surface
+
+Scaffold and harden [Surface](https://github.com/Connorrmcd6/surface) — a deterministic
+"documentation governed like code" gate. Surface anchors prose claims to code symbols, stores an
+AST-normalized logic fingerprint per symbol, and **blocks CI/commits when the fingerprint drifts**
+until a human re-runs `surf verify`. It ignores cosmetic edits and catches flipped operators,
+relaxed comparisons, and dropped `await`.
+
+> **⚠️ Experimental — adopt defensively.** As of 2026-06 Surface is a young, single-maintainer
+> project (no crates.io publish, bus-factor 1). The engine and release hygiene vetted well, but
+> treat it as a pinned, optional gate — never an unpinned dependency. This skill defaults to
+> **SHA-pinned** installs and **fail-closed** checksum verification.
+
+## When to Use This Skill
+
+| Use this skill when... | Use another approach when... |
+|------------------------|------------------------------|
+| Adding a deterministic doc↔code drift gate to CI/pre-commit | Enforcing same-commit doc discipline by convention (`blueprint:blueprint-docs-currency`) |
+| You want specific prose claims pinned to specific functions | Detecting stale *generated* content (`blueprint:blueprint-sync`) |
+| You want an offline, no-LLM gate that fails the build on logic drift | You want semantic "is the doc still true?" judgment (`code-quality:code-review`) |
+| Hardening an existing Surface setup (pin by SHA, verify checksums) | Generating docs from code (`documentation:docs-generate`) |
+
+## Context
+
+- surf.toml: !`find . -maxdepth 2 -name 'surf.toml'`
+- Hubs dir: !`find . -maxdepth 2 -type d -name 'hubs'`
+- Pre-commit config: !`find . -maxdepth 1 -name '.pre-commit-config.yaml'`
+- Workflows: !`find .github/workflows -maxdepth 1 -name '*.yml'`
+- Language markers: !`find . -maxdepth 1 \( -name 'Cargo.toml' -o -name 'package.json' -o -name 'pyproject.toml' -o -name 'go.mod' \)`
+
+## Parameters
+
+Parse from `$ARGUMENTS`:
+
+- `--check-only`: Report Surface adoption status and pin hygiene; make no changes (CI mode).
+- `--fix`: Apply scaffolding and hardening without prompting.
+- `--pin <tag>`: Release tag to install/pin (default: latest stable; resolve its commit SHA before writing any `uses:` ref).
+
+## Execution
+
+Execute this Surface configuration workflow:
+
+### Step 1: Detect current state
+
+From Context, classify the repo:
+
+| Signal | Meaning |
+|--------|---------|
+| `surf.toml` present | Surface already initialised — go to hardening (Step 5) |
+| Hubs dir present, no `surf.toml` | Partial setup — repair |
+| Neither | Greenfield — full scaffold |
+| Language marker | Surface supports Rust, TypeScript/JS (TSX grammar), Python, Go. Warn if none match — anchors only resolve in supported languages. |
+
+If `--check-only`, report the table and the pin audit from Step 5, then stop.
+
+### Step 2: Confirm the maturity trade-off
+
+Before writing files, surface the experimental posture (the blockquote above) and confirm with
+`AskUserQuestion` unless `--fix` is set: adopt as a **pinned optional gate** (recommended) or skip.
+Record the chosen pin tag.
+
+### Step 3: Resolve the pinned ref
+
+Resolve the chosen tag to an immutable commit SHA so every `uses:` and `rev:` is reproducible:
+
+```bash
+git ls-remote https://github.com/Connorrmcd6/surface refs/tags/<tag>
+```
+
+Land the Action ref as `Connorrmcd6/surface@<sha> # <tag>` and the pre-commit `rev:` as `<tag>`
+(github-tags datasource — Renovate manages both; see `.claude/rules/version-pinning.md`). Do **not**
+hand-transcribe a SHA from memory.
+
+### Step 4: Scaffold (greenfield)
+
+1. Create `surf.toml`:
+   ```toml
+   hubs = ["hubs/*.md"]
+   ```
+2. Create `hubs/` with one starter hub anchoring a real, stable symbol the team relies on. Hub shape:
+   ```markdown
+   ---
+   summary: One-line description of what this hub governs.
+   anchors:
+     - claim: >
+         The prose claim about behaviour that must stay true.
+       at: src/path/file.ts > symbolName
+       hash: ""   # surf verify seals this after you confirm the prose
+   refs: []
+   ---
+
+   # Title
+
+   Longer explanation a reviewer reads when the gate flags drift.
+   ```
+3. Run `surf lint` (every anchor resolves to exactly one symbol), then `surf verify` to seal hashes.
+
+### Step 5: Wire + harden the gates
+
+**Pre-commit** — add to `.pre-commit-config.yaml` (requires `surf` on PATH; pair with
+`/configure:web-session` to install it in Claude Code web sessions):
+
+```yaml
+- repo: https://github.com/Connorrmcd6/surface
+  rev: v0.6.2   # --pin tag; Renovate-managed (github-tags)
+  hooks:
+    - id: surf-lint   # anchors resolve
+    - id: surf-check  # the gate — blocks on drift
+```
+
+**GitHub Action** — scaffold `.github/workflows/` with a **SHA-pinned** ref:
+
+```yaml
+name: "Docs: Surface drift gate"
+on: [pull_request]
+jobs:
+  surface:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: Connorrmcd6/surface@004c9169f182fb5e577d389749e6447521e6e6aa # v0.6.2
+        with:
+          args: check
+```
+
+> **Residual supply-chain caveat (track upstream).** Even when the Action is SHA-pinned, Surface's
+> `action.yml` currently pipes `install.sh` from the **`main`** branch
+> (`raw.githubusercontent.com/.../main/install.sh`) rather than the pinned ref — so a compromised
+> `main` reaches pinned consumers. The download is checksum-verified (fail-closed), which bounds the
+> risk, but the *installer script* itself is unpinned. Until the upstream fix (use
+> `${{ github.action_path }}/install.sh`) lands, the maximally-cautious option is to **vendor**
+> `install.sh` at the pinned ref into your repo and run that. See the issue/PR this skill links in
+> "Upstream contributions".
+
+### Step 6: Document the JSON → reviewer handoff
+
+Surface keeps semantic judgment out of its deterministic core and emits JSON for reviewer plugins
+(`surf check --format json`). Note in the repo (e.g. CONTRIBUTING or the workflow) that a drift
+verdict can be handed to `code-quality:code-review` / `verify` to judge whether the claim is still
+*true* before a human runs `surf verify`. That is the division of labour Surface is designed for and
+where our skills add the most value.
+
+### Step 7: Report
+
+Print: scaffold actions taken, the resolved pin (`<sha> # <tag>`), pre-commit + Action wiring status,
+and the hardening checklist below with each item ✓/✗.
+
+## Hardening checklist
+
+| Control | Target state |
+|---------|-------------|
+| Action ref | SHA-pinned with `# <tag>` comment, not a floating major |
+| Installer | Checksum-verified (default) or vendored at the pinned ref |
+| Pin freshness | `rev:` / `uses:` Renovate-visible (github-tags shape) |
+| Gate scope | `surf check --base <ref>` to diff-scope to changed files in CI |
+| Fallback | macOS Intel / Windows unsupported — document `cargo install --git` source fallback |
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Status + pin audit | `/configure:surface --check-only` |
+| Scaffold + harden | `/configure:surface --fix --pin v0.6.2` |
+| The gate (CI) | `surf check` |
+| Scope to changed files | `surf check --base origin/main` |
+| Machine-readable verdict | `surf check --format json` |
+| Re-seal after human review | `surf verify` |
+| Anchors resolve | `surf lint` |
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--check-only` | Report adoption + pin hygiene without modifying files |
+| `--fix` | Apply scaffolding and hardening without prompting |
+| `--pin <tag>` | Release tag to install/pin (resolved to a SHA before writing refs) |
+
+## Upstream contributions
+
+This skill tracks two improvements we proposed upstream (the repo is third-party; we cannot file
+directly from this marketplace, so the artifacts live with the adopting team):
+
+- **Issue**: `action.yml` fetches `install.sh` from `main`, defeating SHA-pinning for the installer.
+- **PR**: run the bundled `${{ github.action_path }}/install.sh` so the installer matches the pinned ref.
+
+## See Also
+
+- `/configure:web-session` — install `surf` in Claude Code web sessions
+- `/configure:pre-commit` — pre-commit framework setup this plugs into
+- `blueprint:blueprint-docs-currency` — same-commit doc discipline (the convention-level complement)
+- `blueprint:blueprint-sync` — drift detection for *generated* content
+- `code-quality:code-review` — the semantic reviewer for Surface's JSON verdicts
+- Surface docs: https://surface.gradientdev.xyz/ · License: Apache-2.0

--- a/configure-plugin/skills/configure-surface/SKILL.md
+++ b/configure-plugin/skills/configure-surface/SKILL.md
@@ -135,14 +135,13 @@ jobs:
           args: check
 ```
 
-> **Residual supply-chain caveat (track upstream).** Even when the Action is SHA-pinned, Surface's
-> `action.yml` currently pipes `install.sh` from the **`main`** branch
-> (`raw.githubusercontent.com/.../main/install.sh`) rather than the pinned ref — so a compromised
-> `main` reaches pinned consumers. The download is checksum-verified (fail-closed), which bounds the
-> risk, but the *installer script* itself is unpinned. Until the upstream fix (use
-> `${{ github.action_path }}/install.sh`) lands, the maximally-cautious option is to **vendor**
-> `install.sh` at the pinned ref into your repo and run that. See the issue/PR this skill links in
-> "Upstream contributions".
+> **Installer-pin caveat (version-dependent).** Surface's `action.yml` historically piped
+> `install.sh` from the mutable **`main`** branch, so even a SHA-pinned `uses:` did not pin the
+> installer. This is **fixed upstream**: `action.yml` now runs the bundled
+> `${{ github.action_path }}/install.sh` at the pinned ref. The fix is merged to `main` but ships in
+> the **first release after v0.6.2** — pinning the current latest tag (v0.6.2) or earlier still
+> carries the gap. Pin a ref at or after the fixed release and the installer is pinned automatically;
+> for an older ref, **vendor** `install.sh` at that ref and run it. See "Upstream contributions".
 
 ### Step 6: Document the JSON → reviewer handoff
 
@@ -189,11 +188,11 @@ and the hardening checklist below with each item ✓/✗.
 
 ## Upstream contributions
 
-This skill tracks two improvements we proposed upstream (the repo is third-party; we cannot file
-directly from this marketplace, so the artifacts live with the adopting team):
+The installer-pin gap was reported and **fixed upstream**:
 
-- **Issue**: `action.yml` fetches `install.sh` from `main`, defeating SHA-pinning for the installer.
-- **PR**: run the bundled `${{ github.action_path }}/install.sh` so the installer matches the pinned ref.
+- **PR (merged)**: `action.yml` now runs the bundled `${{ github.action_path }}/install.sh`, so a
+  SHA-pinned `uses:` also pins the installer. Lands in the first tagged release after v0.6.2 — until
+  then, the version-dependent caveat in Step 5 applies to v0.6.2 and earlier.
 
 ## See Also
 

--- a/configure-plugin/skills/configure-surface/SKILL.md
+++ b/configure-plugin/skills/configure-surface/SKILL.md
@@ -73,7 +73,9 @@ Record the chosen pin tag.
 
 ### Step 3: Resolve the pinned ref
 
-Resolve the chosen tag to an immutable commit SHA so every `uses:` and `rev:` is reproducible:
+Resolve the chosen tag to the **commit SHA it points at** so every `uses:` and `rev:` is
+reproducible — a release tag can be re-pointed to a different commit after the fact, so the SHA the
+tag resolved to (with the tag kept in a trailing comment) is the real immutable anchor:
 
 ```bash
 git ls-remote https://github.com/Connorrmcd6/surface refs/tags/<tag>
@@ -135,13 +137,15 @@ jobs:
           args: check
 ```
 
-> **Installer-pin caveat (version-dependent).** Surface's `action.yml` historically piped
-> `install.sh` from the mutable **`main`** branch, so even a SHA-pinned `uses:` did not pin the
-> installer. This is **fixed upstream**: `action.yml` now runs the bundled
-> `${{ github.action_path }}/install.sh` at the pinned ref. The fix is merged to `main` but ships in
-> the **first release after v0.6.2** — pinning the current latest tag (v0.6.2) or earlier still
-> carries the gap. Pin a ref at or after the fixed release and the installer is pinned automatically;
-> for an older ref, **vendor** `install.sh` at that ref and run it. See "Upstream contributions".
+> **Installer pin (the release-tag SHA is the anchor).** Pin the **commit SHA of a verified release
+> tag** (the `@<sha> # vX.Y.Z` form above); a tag can be re-pointed after release, so the SHA — not
+> the tag — is the real immutable anchor. The installer-pin gap (Surface's `action.yml` historically
+> piped `install.sh` from mutable `main`) is **fixed upstream**: `action.yml` now runs the bundled
+> `${{ github.action_path }}/install.sh` at the pinned ref. That fix is on `main` (commit `d83101b`)
+> but not yet in a tagged release — the example's `v0.6.2` SHA predates it. Until the first release
+> after v0.6.2 is cut, you can pin `d83101b` in your **own** repo to get the installer pin today,
+> then move to that release's tag-SHA once you've verified it. Pinning v0.6.2 or earlier keeps the
+> gap; vendor `install.sh` at that ref if you must stay there.
 
 ### Step 6: Document the JSON → reviewer handoff
 


### PR DESCRIPTION
## Summary

Adds `configure-surface` to `configure-plugin` — a skill that scaffolds and **hardens** [Surface](https://github.com/Connorrmcd6/surface), a deterministic "documentation governed like code" gate. Surface anchors prose claims to code symbols, stores an AST-normalized logic fingerprint per symbol, and blocks CI/commits when the fingerprint drifts until a human re-runs `surf verify`.

This is the deterministic doc↔code drift layer we don't currently have: `blueprint-docs-currency` enforces same-commit discipline *by convention*, and `blueprint-sync` hashes *whole generated files* — neither pins a specific prose claim to a specific function the way Surface does.

## Due diligence (3-agent audit of the upstream repo)

| Axis | Verdict | Notes |
|------|---------|-------|
| Code quality | 🟢 Solid | Pure zero-I/O `surf-core`; 97 engine tests pass (quiet-on-cosmetic / loud-on-logic verified across Rust/TS/Py/Go); zero `unsafe`; lean deps |
| Release + git hygiene | 🟢 Mature-for-age | Fail-closed checksum install, npm provenance, pinned toolchain, 100% conventional commits, CI = fmt+clippy+test+rustsec+dogfood |
| Ecosystem maturity | 🔴 No-signal-yet | 8 days old, bus-factor 1, no crates.io, 14 stars |

**Posture:** the code/process are strong; the only real risk is maturity. The skill therefore defaults to a **pinned, optional, experimental** gate — SHA-pinned Action ref + version comment, pre-commit `rev` pin, fail-closed checksum verification, and a documented vendoring mitigation.

## Changes

- `configure-plugin/skills/configure-surface/SKILL.md` — new skill (140-char description, "When to Use" + "Agentic Optimizations" tables, execution-structured)
- `configure-plugin/README.md` — skills table row under Code Quality
- `configure-plugin/.claude-plugin/plugin.json` — `docs-drift`, `surface` keywords

## Validation

- Description: 140 chars, contains `Use when` trigger
- `lint-context-commands.sh`: clean (removed a `command -v` Context line per regression #1205)
- `check-version-pin-coverage.sh`: no new findings — `uses:`/`rev:` pins in Renovate-managed shapes
- `plugin-compliance-check.sh`: no errors

## Upstream contribution (prepared, out of marketplace scope to file)

While vetting, the audit found that Surface's `action.yml` fetches `install.sh` from `main`, which defeats SHA-pinning of the installer. A ready-to-submit issue + one-line fix (`run: sh "${{ github.action_path }}/install.sh"`) are prepared for the upstream repo; the skill documents this caveat and the vendoring mitigation in the meantime.

🤖 Draft for review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwUhcbN9ds2tNAw6eSkUKm)_