### PR TITLE
feat(git-plugin): surface systematic CI failure across bot PRs in git-triage

### DIFF
--- a/git-plugin/skills/git-triage/SKILL.md
+++ b/git-plugin/skills/git-triage/SKILL.md
@@ -5,8 +5,8 @@ args: "[--type issues|prs|both] [--batch N] [--repo owner/name] [--days-stale-is
 argument-hint: "--type both --batch 10 (defaults: days-stale-issue=90, days-stale-pr=30, current repo)"
 allowed-tools: Bash(bash *), Bash(gh issue *), Bash(gh pr *), Bash(gh api *), Bash(gh repo *), Bash(git log *), Bash(rg *), Read, Grep, Glob, AskUserQuestion, TodoWrite
 created: 2026-04-22
-modified: 2026-06-10
-reviewed: 2026-06-10
+modified: 2026-06-14
+reviewed: 2026-06-14
 ---
 
 # /git:triage
@@ -65,7 +65,8 @@ bash "${CLAUDE_SKILL_DIR}/scripts/git-triage.sh" --home-dir "$HOME" --project-di
 Parse `STATUS=` and `ISSUES:` from the output. Per item it emits
 `ISSUE_<n>_AGE_DAYS` / `ISSUE_<n>_REFS` / `ISSUE_<n>_STALE_CANDIDATE` and
 `PR_<n>_CATEGORY` / `PR_<n>_AGE_DAYS` / `PR_<n>_CLOSES` (plus the underlying
-enum fields). If `--repo` was provided, pass it through; the script reads the
+enum fields). It also rolls up `SYSTEMATIC_FAILURE_*` groups (see Step 4).
+If `--repo` was provided, pass it through; the script reads the
 current repo from `origin` otherwise. Sort each set by age (oldest first if
 `--oldest-first`) and build a TodoWrite list with one entry per item.
 
@@ -113,6 +114,22 @@ both `UNKNOWN`), trigger a fresh view and re-run the script, or inspect:
 ```bash
 gh pr view <n> --repo $REPO --json mergeable,mergeStateStatus
 ```
+
+**Systematic failures.** When ≥2 bot-authored `needs-fix` PRs share an
+identical failing-check signature, the script groups them under
+`SYSTEMATIC_FAILURE_<k>_SIGNATURE` (the sorted `|`-joined failed check names)
+and `SYSTEMATIC_FAILURE_<k>_PRS` (the PR list); `SYSTEMATIC_FAILURE_COUNT`
+holds the number of groups. These almost always have **one** shared root
+cause — e.g. Dependabot can't update `bun.lock`, so every npm-bump PR fails
+the `bun install --frozen-lockfile` step *before* lint/typecheck/tests run, and
+"Lint FAILURE / Type Check FAILURE" is misleading (nothing was linted). For
+each group, read the install step's log once before assuming code defects:
+```bash
+gh pr checks <n> --repo $REPO --json name,state,conclusion,detailsUrl
+gh run view <run-id> --repo $REPO --log-failed
+```
+Diagnose the shared cause once and present a single grouped row (Step 6) /
+blocker (Step 8) instead of N independent `needs-fix` PRs.
 
 ### Step 5: Cross-link issues and PRs
 
@@ -179,7 +196,7 @@ After per-item actions, emit a structured summary:
 
 1. **Actions taken** — count of issues closed, PRs merged, with numbers.
 2. **Quick wins** — `still-valid` issues whose body suggests <30 min of work (single file, doc edit, config tweak).
-3. **Blockers** — `changes-requested` PRs and issues blocked on external factors.
+3. **Blockers** — `changes-requested` PRs and issues blocked on external factors. For each `SYSTEMATIC_FAILURE_*` group, emit one "systematic failure — likely shared root cause" line naming the PRs and the shared check signature, rather than N independent `needs-fix` entries.
 4. **Decisions needed** — `still-valid` issues whose body ends in a question or "how should we…".
 5. **Handoff recommendations** per category:
 

--- a/git-plugin/skills/git-triage/scripts/git-triage.sh
+++ b/git-plugin/skills/git-triage/scripts/git-triage.sh
@@ -193,22 +193,48 @@ if [ "$triage_type" != "issues" ]; then
   pr_total=$(echo "$prs_json" | jq 'length')
   echo "PRS_FETCHED=${pr_total}"
 
-  # Closing-keyword extraction runs in its OWN jq pass keyed by PR number, so a
-  # multi-line bot PR body (embedded tabs/newlines) can never shift the
-  # categorization enum columns. Packing `body` into the enum @tsv row used to
-  # do exactly that — every column slid right, WORST_CHECK held the whole body,
-  # and every PR fell through to `uncategorized` (issue #1627). The closing
-  # refs are single tokens (`#NNN`), so they stay TSV-safe on their own line.
+  # Per-PR metadata runs in its OWN jq pass keyed by PR number, so a multi-line
+  # bot PR body (embedded tabs/newlines) can never shift the categorization enum
+  # columns. Packing `body` into the enum @tsv row used to do exactly that —
+  # every column slid right, WORST_CHECK held the whole body, and every PR fell
+  # through to `uncategorized` (issue #1627). This pass emits three TSV-safe
+  # fields: closing refs (single `#NNN` tokens), a bot-author flag, and the
+  # failing-check signature (sorted FAILURE check names joined by `|`, no tabs).
+  #
+  # Bot detection mirrors git-pr-feedback's automation-author convention (#1420):
+  # author.is_bot, the well-known automation logins, or a *[bot]/*-bot login.
+  # The signature feeds the systematic-failure roll-up below (issue #1628).
+  # Empty fields are emitted as the literal `none` because `read` with a
+  # tab IFS collapses consecutive tabs (tab is IFS-whitespace) — an empty
+  # closes/signature field would otherwise shift every later column. The
+  # script translates `none` back to empty after the split.
   declare -A pr_closes_map=()
-  while IFS=$'\t' read -r ck_num ck_closes; do
-    [ -z "$ck_num" ] && continue
-    pr_closes_map["$ck_num"]="$ck_closes"
+  declare -A pr_isbot_map=()
+  declare -A pr_sig_map=()
+  while IFS=$'\t' read -r meta_num meta_closes meta_isbot meta_sig; do
+    [ -z "$meta_num" ] && continue
+    pr_closes_map["$meta_num"]="$meta_closes"
+    pr_isbot_map["$meta_num"]="$meta_isbot"
+    [ "$meta_sig" = "none" ] && meta_sig=""
+    pr_sig_map["$meta_num"]="$meta_sig"
   done < <(echo "$prs_json" | jq -r '
-    .[] | [
-      (.number|tostring),
-      ([ (.body // "") | scan("(?i)(?:closes|fixes|resolves)[[:space:]]+#[0-9]+") ]
-        | map(sub("^[^#]*";"")) | unique | join(","))
-    ] | @tsv' 2>/dev/null)
+    ["dependabot[bot]","renovate[bot]","release-please[bot]","github-actions[bot]","fvh-buildbot"] as $automation
+    | .[]
+    | (.author.login // "") as $login
+    | [
+        (.number|tostring),
+        (([ (.body // "") | scan("(?i)(?:closes|fixes|resolves)[[:space:]]+#[0-9]+") ]
+          | map(sub("^[^#]*";"")) | unique | join(",")) | if . == "" then "none" else . end),
+        (( (.author.is_bot // false)
+          or (($automation | index($login)) != null)
+          or ($login | test("(?i)(\\[bot\\]$|-bot$)")) ) | tostring),
+        (([ .statusCheckRollup[]? | select(.conclusion == "FAILURE") | (.name // .context // "check") ]
+          | unique | join("|")) | if . == "" then "none" else . end)
+      ] | @tsv' 2>/dev/null)
+
+  # Accumulator for the systematic-failure roll-up (#1628): failing-check
+  # signature → comma-joined list of the bot-authored needs-fix PRs sharing it.
+  declare -A sys_prs=()
 
   # Per-PR: pull the enum fields + worst CI conclusion, then categorize purely.
   # worst conclusion: FAILURE > CANCELLED > SUCCESS; null/empty → none.
@@ -228,6 +254,13 @@ if [ "$triage_type" != "issues" ]; then
     echo "PR_${pr_num}_CATEGORY=${pr_category}"
     pr_closes="${pr_closes_map[$pr_num]:-}"
     echo "PR_${pr_num}_CLOSES=${pr_closes:-none}"
+    # Group bot-authored needs-fix PRs by their failing-check signature (#1628).
+    if [ "$pr_category" = "needs-fix" ] && [ "${pr_isbot_map[$pr_num]:-false}" = "true" ]; then
+      pr_sig="${pr_sig_map[$pr_num]:-}"
+      if [ -n "$pr_sig" ]; then
+        sys_prs["$pr_sig"]="${sys_prs[$pr_sig]:+${sys_prs[$pr_sig]},}#${pr_num}"
+      fi
+    fi
   done < <(echo "$prs_json" | jq -r '
     def worst(rollup):
       ([rollup[]?.conclusion]) as $c
@@ -244,6 +277,28 @@ if [ "$triage_type" != "issues" ]; then
       (if (.reviewDecision // "") == "" then "null" else .reviewDecision end),
       worst(.statusCheckRollup // [])
     ] | @tsv' 2>/dev/null)
+
+  # Systematic-failure roll-up (#1628): when ≥2 bot-authored PRs share an
+  # identical failing-check signature, they almost always have ONE shared root
+  # cause (e.g. Dependabot can't update bun.lock → every npm-bump PR fails the
+  # frozen-lockfile step before lint/typecheck/tests even run). Surface a single
+  # grouped hint so triage diagnoses the shared cause once — and reads
+  # `--log-failed` for the install step — instead of treating N PRs as N
+  # independent code defects. Iterate keys in sorted order for deterministic
+  # output; only signatures shared by ≥2 PRs are emitted.
+  sys_idx=0
+  if [ "${#sys_prs[@]}" -gt 0 ]; then
+    while IFS= read -r sys_sig; do
+      [ -z "$sys_sig" ] && continue
+      sys_csv="${sys_prs[$sys_sig]}"
+      sys_commas=$(printf '%s' "$sys_csv" | tr -cd ',' | wc -c)
+      [ $((sys_commas + 1)) -ge 2 ] || continue
+      sys_idx=$((sys_idx + 1))
+      echo "SYSTEMATIC_FAILURE_${sys_idx}_SIGNATURE=${sys_sig}"
+      echo "SYSTEMATIC_FAILURE_${sys_idx}_PRS=${sys_csv}"
+    done < <(printf '%s\n' "${!sys_prs[@]}" | sort)
+  fi
+  echo "SYSTEMATIC_FAILURE_COUNT=${sys_idx}"
 fi
 
 echo "STATUS=${triage_status}"

--- a/git-plugin/skills/git-triage/scripts/tests/test-git-triage.sh
+++ b/git-plugin/skills/git-triage/scripts/tests/test-git-triage.sh
@@ -194,4 +194,73 @@ if echo "$rout" | grep -q "Bumps foo from"; then
 fi
 pass "#1627: PR body never leaks into KEY=VALUE output"
 
+# -----------------------------------------------------------------------------
+# Enhancement #1628: when ≥2 bot-authored needs-fix PRs share an identical
+# failing-check signature, they almost always have ONE shared root cause (e.g.
+# Dependabot can't update bun.lock → every npm-bump PR fails the frozen-lockfile
+# step before lint/typecheck run). The script rolls them into a single
+# SYSTEMATIC_FAILURE_* hint. The fixture below mixes:
+#   #1202,#1203,#1204  bot PRs, identical signature (orders vary)  → grouped
+#   #1300              human PR, same signature                    → excluded (not a bot)
+#   #1301              bot PR, solo "E2E" signature                → excluded (count 1)
+# Signature names are sorted by `unique`, so input order does not matter.
+# -----------------------------------------------------------------------------
+prs1628_fixture="${work_dir}/prs-1628.json"
+cat > "$prs1628_fixture" <<'JSON'
+[
+  {"number":1202,"title":"chore(deps): bump a","updatedAt":"2026-06-09T00:00:00Z","isDraft":false,
+   "mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"",
+   "author":{"login":"dependabot[bot]","is_bot":true},
+   "statusCheckRollup":[{"name":"Lint","conclusion":"FAILURE"},{"name":"Type Check","conclusion":"FAILURE"},{"name":"Unit Tests","conclusion":"FAILURE"}],"body":""},
+  {"number":1203,"title":"chore(deps): bump b","updatedAt":"2026-06-09T00:00:00Z","isDraft":false,
+   "mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"",
+   "author":{"login":"dependabot[bot]","is_bot":true},
+   "statusCheckRollup":[{"name":"Type Check","conclusion":"FAILURE"},{"name":"Lint","conclusion":"FAILURE"},{"name":"Unit Tests","conclusion":"FAILURE"}],"body":""},
+  {"number":1204,"title":"chore(deps): bump c","updatedAt":"2026-06-09T00:00:00Z","isDraft":false,
+   "mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"",
+   "author":{"login":"renovate[bot]"},
+   "statusCheckRollup":[{"name":"Unit Tests","conclusion":"FAILURE"},{"name":"Lint","conclusion":"FAILURE"},{"name":"Type Check","conclusion":"FAILURE"}],"body":""},
+  {"number":1300,"title":"human fix","updatedAt":"2026-06-09T00:00:00Z","isDraft":false,
+   "mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"REVIEW_REQUIRED",
+   "author":{"login":"alice"},
+   "statusCheckRollup":[{"name":"Lint","conclusion":"FAILURE"},{"name":"Type Check","conclusion":"FAILURE"},{"name":"Unit Tests","conclusion":"FAILURE"}],"body":""},
+  {"number":1301,"title":"chore(deps): solo","updatedAt":"2026-06-09T00:00:00Z","isDraft":false,
+   "mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"",
+   "author":{"login":"dependabot[bot]","is_bot":true},
+   "statusCheckRollup":[{"name":"E2E","conclusion":"FAILURE"}],"body":""}
+]
+JSON
+
+unset GIT_TRIAGE_ISSUES_FIXTURE
+export GIT_TRIAGE_PRS_FIXTURE="$prs1628_fixture"
+
+sout="$(bash "$triage_script" --type prs --days-stale-pr 30)"
+
+# Exactly one systematic-failure group is emitted.
+echo "$sout" | grep -q "^SYSTEMATIC_FAILURE_COUNT=1$" \
+  || fail "#1628 expected SYSTEMATIC_FAILURE_COUNT=1, got:\n$(echo "$sout" | grep '^SYSTEMATIC_FAILURE_COUNT=')"
+pass "#1628: exactly one systematic-failure group emitted"
+
+# The group lists the three bot PRs with the shared signature.
+echo "$sout" | grep -q "^SYSTEMATIC_FAILURE_1_PRS=#1202,#1203,#1204$" \
+  || fail "#1628 expected grouped PRs '#1202,#1203,#1204', got:\n$(echo "$sout" | grep '^SYSTEMATIC_FAILURE_1_PRS=')"
+pass "#1628: the three bot PRs sharing a signature are grouped (order-independent)"
+
+# The signature is the sorted, |-joined failing-check names.
+echo "$sout" | grep -q "^SYSTEMATIC_FAILURE_1_SIGNATURE=Lint|Type Check|Unit Tests$" \
+  || fail "#1628 expected signature 'Lint|Type Check|Unit Tests', got:\n$(echo "$sout" | grep '^SYSTEMATIC_FAILURE_1_SIGNATURE=')"
+pass "#1628: signature is the sorted |-joined failing-check names"
+
+# A human-authored PR with the SAME signature is not folded into the bot group.
+if echo "$sout" | grep -q "#1300"; then
+  fail "#1628: human-authored PR #1300 must not be grouped as a systematic bot failure"
+fi
+pass "#1628: human-authored PR with the same signature is excluded"
+
+# A bot PR whose signature is unique (count 1) is not grouped.
+if echo "$sout" | grep -q "#1301"; then
+  fail "#1628: solo-signature bot PR #1301 must not be grouped (count 1)"
+fi
+pass "#1628: solo-signature bot PR is excluded (needs >=2 to be systematic)"
+
 echo "ALL TESTS PASSED"


### PR DESCRIPTION
## What

When multiple bot dependency PRs fail CI with an **identical** check signature, they almost always share **one** root cause — but `/git:triage` presented them as N independent `needs-fix` PRs, hiding the shared cause. The canonical case (from the issue, on a Bun repo):

> Three bot PRs all failed CI with an identical Lint + Type Check + Unit Tests signature. In reality `bun install --frozen-lockfile` aborted *before* lint/typecheck/tests ran — so "Lint FAILURE / Type Check FAILURE" was misleading; nothing was actually linted. The fix was per-bot, not per-PR.

This builds directly on [#1627](https://github.com/laurigates/claude-plugins/issues/1627) (merged) — now that the categorization columns are correct, the per-PR worst-check signature is reliable enough to group on.

## How

- The per-PR metadata jq pass (introduced by #1627) now also emits:
  - a **bot-author flag** — `author.is_bot`, the well-known automation logins (dependabot/renovate/release-please/github-actions/fvh-buildbot), or a `*[bot]`/`*-bot` login (mirrors `git-pr-feedback`'s convention from #1420)
  - a **failing-check signature** — the sorted, `|`-joined names of checks whose `conclusion` is `FAILURE`
- After categorization, bot-authored `needs-fix` PRs sharing a signature are rolled up into:
  ```
  SYSTEMATIC_FAILURE_<k>_SIGNATURE=Lint|Type Check|Unit Tests
  SYSTEMATIC_FAILURE_<k>_PRS=#1202,#1203,#1204
  SYSTEMATIC_FAILURE_COUNT=1
  ```
- The SKILL surfaces a single grouped "likely shared root cause" hint (Step 4 + Step 8) and points triage at the install-step log (`gh run view --log-failed`) before assuming code defects.

Only groups of **≥2** are emitted; human-authored PRs and solo-signature bot PRs are excluded.

Empty `closes`/`signature` fields are emitted as the literal `none` because bash `read` with a tab `IFS` collapses consecutive tabs (tab is IFS-whitespace) — an empty field would otherwise shift every later column (caught and fixed during development).

## Test

New `#1628` block in `test-git-triage.sh` with a fixture that mixes:

| PR | Author | Signature | Outcome |
|----|--------|-----------|---------|
| #1202, #1203, #1204 | bot | identical (input order varied) | **grouped** |
| #1300 | human (`alice`) | same signature | excluded (not a bot) |
| #1301 | bot | solo `E2E` | excluded (count 1) |

Asserts `SYSTEMATIC_FAILURE_COUNT=1`, the grouped PR list (order-independent via `unique` sort), the joined signature, and that #1300/#1301 are not grouped. All 16 tests pass; `shellcheck` and pre-commit clean.

Closes #1628

🤖 Generated with [Claude Code](https://claude.com/claude-code)