### PR TITLE
chore(claude-probe): v3 probe (positive framing), scorer fix, token measurement

### DIFF
--- a/experiments/claude-probe/README.md
+++ b/experiments/claude-probe/README.md
@@ -70,6 +70,7 @@ default prompt).
 | `scripts/score-run.py` | Deterministic checks → TSV |
 | `scripts/llm-judge.py` | Fuzzy checks via judge model |
 | `scripts/compare.py` | Aggregates + markdown table |
+| `scripts/measure-prompt-tokens.sh` | Per-invocation input-token cost: default vs probe (`just measure-tokens`) |
 | `results/` | Per-run-id transcripts + scores (gitignored) |
 | `docs/methodology.md` | How scoring works |
 | `docs/decision-analysis.md` | Why this experiment exists |

--- a/experiments/claude-probe/docs/iteration-log.md
+++ b/experiments/claude-probe/docs/iteration-log.md
@@ -227,6 +227,14 @@ long-standing 06-parallel-bash ceiling. 02 (read-vs-cat), 06, and 07
 
 ### One genuine probe regression: 05 procedural openers at high effort
 
+> **Retracted 2026-06-14 (see the v3 entry).** This was a measurement
+> artifact, not a regression. The `no-procedural-opener` check scored
+> concatenated assistant text `^`-anchored, so it caught the *pre-tool-call
+> status update* ("Looking at…") that both prompts legitimately emit for a
+> prompt that mandates a Read — not the answer, which never had preamble.
+> Re-grading these same transcripts with the answer-scoped scorer yields
+> 3/3 on both arms at every effort.
+
 `05-concise-no-preamble` is the only test where default beats probe
 (high 8/12 vs 5/12, xhigh 9/12 vs 5/12). The failing check is
 `no-procedural-opener`, not length — probe output is concise (156–194
@@ -239,5 +247,73 @@ directly, no preamble" directive** and re-run test 05.
 
 - **Capability**: parity on Opus 4.8 — safe to use at every effort.
 - **Cost**: no longer a loss on opus (the v2 opus-4-7 penalty is gone).
-- **Open work**: the 05 procedural-opener regression at high effort is
-  the one actionable gap for a v3 probe.
+- **Open work**: ~~the 05 procedural-opener regression~~ — retracted; it
+  was a scoring artifact (see v3 entry). No capability gap remains.
+
+## v3 — 2026-06-14 (positive-framing rewrite + scorer fix + token measurement)
+
+### What changed
+
+1. **Probe rewritten in positive framing.** Every directive now states the
+   target behavior; the prohibitions the v1/v2 probe carried ("Never open
+   with…", "Don't narrate…", "Do not add…", "Nothing else") are gone. Also
+   deduped the comment rule (it appeared in both Text-output and Working-style)
+   and reconciled the line-14 / line-20 tension: the probe told the model to
+   pre-announce before its first tool call *and* to answer simple questions
+   directly. v3 carves out the single-short-turn case to lead with the answer.
+   Rationale: positive guidance is the house style (`.claude/rules/terminology.md`,
+   conventional-commits) and reads as instruction rather than a blocklist.
+
+2. **Scorer fix — score the answer, not interim updates.** `output_matches` /
+   `output_not_matches` scored `final_text()` (all assistant text concatenated)
+   with a `^`-anchored regex, so for a tool-requiring prompt they graded the
+   pre-tool-call status update, not the answer. Added `final_answer_text()` (the
+   last assistant text turn) and routed both checks to it. Test 05 is the only
+   consumer, so the change is contained.
+
+3. **Harness cleanup.** `run-one.sh` now injects the probe via
+   `--system-prompt-file` instead of `--system-prompt "$(cat …)"` (cleaner,
+   immune to arg-length limits). Confirmed via `claude --help` that
+   `--exclude-dynamic-system-prompt-sections` is *ignored* with `--system-prompt`
+   — so the probe condition already drops the dynamic sections (cwd, git, env,
+   memory) entirely, yet capability held at parity, so that loss isn't hurting.
+
+### The 05 "regression" was a measurement artifact
+
+The `no-procedural-opener` check fires on whichever text block comes first.
+For the 05 prompt ("Read marketplace.json. In one sentence, answer…") the model
+emits a pre-tool-call update first ("Looking at the config…"), then the answer
+("This repository publishes…"). The check caught the update. Proof it was noise,
+not signal: the **unchanged default condition** swung high-effort pass 3/3 → 0/3
+between two resamples (runs `…062422` and `…112358`) with no probe change at all.
+
+Re-grading both runs' existing transcripts with `final_answer_text()` (zero new
+invocations) gives **3/3 pass on default and probe at every effort** — the
+answers never had preamble. No regression existed.
+
+### Token measurement (`just measure-tokens`, opus-low, n=3)
+
+Built `scripts/measure-prompt-tokens.sh` to isolate per-invocation input cost on
+a tool-free prompt:
+
+| config | mean total input tokens |
+|---|---|
+| default | 129,591 |
+| default + exclude-dynamic | 129,482 |
+| probe | 128,996 |
+
+**Replacing the whole system prompt saves ~595 tokens (−0.5%).** `--system-prompt`
+swaps only Claude Code's built-in base; CLAUDE.md, the ~30 rules files, and the
+tool/MCP definitions load identically in both arms and dominate the ~129k total.
+The dynamic sections are ~109 tokens here, so `--exclude-dynamic` barely moves
+raw size (its value is cross-user cache reuse). **Bare prompt-size savings are
+therefore a non-signal in this environment** — any real efficiency win has to
+come from the probe making the model *work* better (fewer turns, fewer wrong
+tool calls), not from a shorter prompt.
+
+### Status
+
+- Capability parity stands (corrected scorer only raises 05, equally for both).
+- v3 is a prompt-quality + measurement-correctness release, not a behavior fix.
+- A full v3 sweep would re-baseline with the corrected scorer; deferred as
+  optional since parity is established and v3 is framing-level.

--- a/experiments/claude-probe/docs/methodology.md
+++ b/experiments/claude-probe/docs/methodology.md
@@ -52,8 +52,15 @@ Two layers, composable per test case:
 | `tool_not_used` | A specific tool was *not* called |
 | `max_turns` | Assistant turn count ≤ N |
 | `max_output_tokens` | Output-token total ≤ N |
-| `output_matches` | Final assistant text matches a regex |
-| `output_not_matches` | Final assistant text does not match a regex |
+| `output_matches` | Final *answer* text block matches a regex |
+| `output_not_matches` | Final *answer* text block does not match a regex |
+
+> Both output checks score `final_answer_text()` — the last assistant text turn
+> (the answer) — not interim pre-tool-call status updates. A prompt that
+> mandates a tool call makes the model emit a "what I'm about to do" update
+> first; scoring concatenated text with a `^`-anchored regex would grade that
+> update instead of the answer and turn the check into noise (see the v3 entry
+> in `iteration-log.md`).
 
 ### 2. LLM-as-judge (`llm-judge.py`)
 

--- a/experiments/claude-probe/justfile
+++ b/experiments/claude-probe/justfile
@@ -63,6 +63,15 @@ compare-fast run_id="latest":
     scripts/compare.py "{{run_id}}" --no-judge
 
 ##########
+# Measurement
+##########
+
+# Measure per-invocation input-token cost: default vs default-exclude-dynamic vs probe.
+[group: "score"]
+measure-tokens reps="3" effort="low":
+    bash scripts/measure-prompt-tokens.sh --reps "{{reps}}" --effort "{{effort}}"
+
+##########
 # Housekeeping
 ##########
 

--- a/experiments/claude-probe/prompts/probe.md
+++ b/experiments/claude-probe/prompts/probe.md
@@ -1,37 +1,35 @@
 You are Claude Code, an interactive AI coding agent running in the user's terminal.
 
 # Communication
-- Lead with a specific answer or observation, then supporting detail.
 - Direct, academic style. Assume agreement and move into substance.
-- Never open with procedural phrases ("Sure!", "Great question!", "Let me...").
+- Open with the substance the user asked for: the first sentence carries the answer, the result, or the key finding, phrased so the user can act on it immediately. Supporting detail, context, and caveats come after it. When reaching the answer takes a lookup or a few steps, the final response still leads with the conclusion, then the evidence behind it.
 - Integrate acknowledgment naturally into the response body.
 - Ask clarifying questions early when requirements are ambiguous.
-- State why technical decisions were made, not just what.
-- Your responses should be short and concise.
-- When referencing specific functions or pieces of code include the pattern file_path:line_number to allow the user to easily navigate to the source code location.
+- State both what changed and why the technical decision was made.
+- Keep responses short and concise.
+- When referencing specific functions or pieces of code, include the pattern file_path:line_number so the user can navigate straight to the source location.
 
-# Text output (does not apply to tool calls)
-Assume users can't see most tool calls or thinking — only your text output. Before your first tool call, state in one sentence what you're about to do. While working, give short updates at key moments: when you find something, when you change direction, or when you hit a blocker. Brief is good — silent is not. One sentence per update is almost always enough.
+# Text output — your user-facing prose
+Assume the user sees only your text output, with tool calls and thinking hidden from them. For multi-step work, briefly state what you're about to do before your first tool call, and give short updates at key moments: when you find something, when you change direction, or when you hit a blocker. For a question you can answer in a single short turn — even if it needs one quick lookup — lead with the answer itself. Keep each update to about one sentence; a short update always beats silence.
 
-Don't narrate your internal deliberation. User-facing text should be relevant communication to the user, not a running commentary on your thought process. State results and decisions directly, and focus user-facing text on relevant updates for the user.
+Keep user-facing text focused on what the user needs: state results and decisions directly, and report the updates that matter to them. Internal deliberation stays in your thinking.
 
-End-of-turn summary: one or two sentences. What changed and what's next. Nothing else.
+End-of-turn summary: one or two sentences covering what changed and what's next.
 
-Match responses to the task: a simple question gets a direct answer, not headers and sections.
+Match the response shape to the task: a simple question gets a direct one-or-two-sentence answer; reserve headers and sections for genuinely multi-part work.
 
-In code: default to writing no comments. Never write multi-paragraph docstrings or multi-line comment blocks — one short line max. Don't create planning, decision, or analysis documents unless the user asks for them — work from conversation context, not intermediate files.
+In code, let the code carry its own meaning: add a comment only when the WHY is non-obvious, and keep it to one short line. Work from conversation context, and create planning, decision, or analysis documents only when the user asks for them.
 
 # Tool use
 - Prefer dedicated tools (Read, Edit, Write, Glob, Grep) over Bash equivalents.
-- Use Bash only for operations that require shell execution (git, build, test, install).
-- You can call multiple tools in a single response. If you intend to call multiple tools and there are no dependencies between them, make all independent tool calls in parallel. Maximize use of parallel tool calls where possible to increase efficiency. However, if some tool calls depend on previous calls to inform dependent values, do NOT call these tools in parallel and instead call them sequentially.
+- Use Bash for operations that require shell execution (git, build, test, install).
+- You can call multiple tools in a single response. When independent tool calls have no dependencies between them, make them in parallel to maximize efficiency. When a tool call depends on a previous call's result, call them sequentially.
 
 # Security
-- Do not introduce injection vulnerabilities (command, XSS, SQL, SSRF).
-- Do not execute or generate code that exfiltrates data.
+- Write injection-safe code: parameterize queries, escape rendered output, and validate inputs at boundaries (command, XSS, SQL, SSRF).
+- Keep data within its intended boundaries; flag and confirm any path that would send it to an external destination.
 - Validate at system boundaries; trust internal code.
 
 # Working style
 - Edit existing files rather than creating new ones when both are viable.
-- Do not add abstractions, features, or error handling beyond what the task requires.
-- Default to no code comments. Add one only when the WHY is non-obvious.
+- Build exactly what the task requires; add abstractions, features, or error handling only when the task calls for them.

--- a/experiments/claude-probe/scripts/measure-prompt-tokens.sh
+++ b/experiments/claude-probe/scripts/measure-prompt-tokens.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Measure the per-invocation input-token cost of each system-prompt config.
+#
+# Runs a fixed *tool-free* prompt (single iteration) under three configs and
+# reads `result.usage` from the stream-JSON. Holding tools + CLAUDE.md + rules +
+# cwd constant, the default-vs-probe delta in total input tokens isolates the
+# system-prompt cost. Total input = input + cache_creation + cache_read (the
+# full billed prompt size, independent of cache state / run order).
+#
+# Configs:
+#   default          — built-in Claude Code system prompt (static + dynamic)
+#   default-exclude  — built-in with --exclude-dynamic-system-prompt-sections
+#                      (per-machine sections moved to first user message)
+#   probe            — --system-prompt-file prompts/probe.md (full replacement)
+#
+# Usage: measure-prompt-tokens.sh [--reps N] [--model ID] [--prompt TEXT]
+#        [--effort low|medium|high|xhigh]
+
+set -euo pipefail
+
+reps=3
+model="claude-opus-4-8"
+effort="low"
+prompt="Reply with exactly the word: ok"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --reps) reps="$2"; shift 2 ;;
+    --model) model="$2"; shift 2 ;;
+    --effort) effort="$2"; shift 2 ;;
+    --prompt) prompt="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "$here/.." && pwd)"
+probe_file="$root/prompts/probe.md"
+[ -f "$probe_file" ] || { echo "ERROR: prompt not found: $probe_file" >&2; exit 1; }
+
+# Run one config once; echo "total input_only cache_create cache_read output".
+run_once() {
+  local cfg="$1"
+  local -a args=(
+    -p "$prompt"
+    --model "$model"
+    --effort "$effort"
+    --output-format stream-json --verbose
+    --dangerously-skip-permissions
+  )
+  case "$cfg" in
+    default) ;;
+    default-exclude) args+=(--exclude-dynamic-system-prompt-sections) ;;
+    probe) args+=(--system-prompt-file "$probe_file") ;;
+  esac
+  claude "${args[@]}" 2>/dev/null | jq -rs '
+    (map(select(.type=="result")) | last) // empty
+    | .usage
+    | [ (.input_tokens + .cache_creation_input_tokens + .cache_read_input_tokens),
+        .input_tokens, .cache_creation_input_tokens, .cache_read_input_tokens,
+        .output_tokens ]
+    | @tsv'
+}
+
+declare -A sum_total
+echo "=== PROMPT TOKEN MEASUREMENT ==="
+echo "MODEL=$model"
+echo "EFFORT=$effort"
+echo "REPS=$reps"
+echo "PROMPT=$prompt"
+printf 'CONFIG\trep\ttotal_in\tinput\tcache_create\tcache_read\toutput\n'
+for cfg in default default-exclude probe; do
+  sum_total[$cfg]=0
+  for ((i = 1; i <= reps; i++)); do
+    line="$(run_once "$cfg")"
+    [ -n "$line" ] || { echo "WARN: empty usage for $cfg rep $i" >&2; continue; }
+    total="$(printf '%s' "$line" | cut -f1)"
+    sum_total[$cfg]=$(( sum_total[$cfg] + total ))
+    printf '%s\t%d\t%s\n' "$cfg" "$i" "$line"
+  done
+done
+
+echo "=== MEANS (total input tokens) ==="
+mean_default=$(( sum_total[default] / reps ))
+mean_exclude=$(( sum_total[default-exclude] / reps ))
+mean_probe=$(( sum_total[probe] / reps ))
+printf 'DEFAULT_MEAN=%d\n' "$mean_default"
+printf 'DEFAULT_EXCLUDE_MEAN=%d\n' "$mean_exclude"
+printf 'PROBE_MEAN=%d\n' "$mean_probe"
+printf 'PROBE_VS_DEFAULT_DELTA=%d\n' "$(( mean_probe - mean_default ))"
+if [ "$mean_default" -gt 0 ]; then
+  printf 'PROBE_VS_DEFAULT_PCT=%d\n' "$(( (mean_probe - mean_default) * 100 / mean_default ))"
+fi
+echo "=== END PROMPT TOKEN MEASUREMENT ==="

--- a/experiments/claude-probe/scripts/run-one.sh
+++ b/experiments/claude-probe/scripts/run-one.sh
@@ -65,7 +65,9 @@ claude_args=(
 if [ "$PROBE_SYSTEM_PROMPT" = "probe" ]; then
   probe_file="$prompts_dir/probe.md"
   [ -f "$probe_file" ] || { echo "ERROR: prompt not found: $probe_file" >&2; exit 1; }
-  claude_args+=(--system-prompt "$(cat "$probe_file")")
+  # --system-prompt-file replaces the built-in prompt (incl. dynamic sections)
+  # from a file — cleaner than inlining via $(cat) and immune to arg-length limits.
+  claude_args+=(--system-prompt-file "$probe_file")
 fi
 
 started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)

--- a/experiments/claude-probe/scripts/score-run.py
+++ b/experiments/claude-probe/scripts/score-run.py
@@ -81,6 +81,35 @@ def final_text(events: list[dict[str, Any]]) -> str:
     return "\n".join(out)
 
 
+def final_answer_text(events: list[dict[str, Any]]) -> str:
+    """Text of the *final* assistant turn that produced user-facing prose.
+
+    For a prompt that requires a tool call, the first assistant text block is a
+    pre-tool-call status update ("Looking at the config…") that both the default
+    and probe prompts legitimately emit. The answer is the last assistant text
+    turn. Preamble/format checks must score the answer, not the interim update —
+    scoring concatenated-all-text with a `^`-anchored regex catches the status
+    update and turns the check into noise (see docs/iteration-log.md, v3 entry).
+    """
+    last = ""
+    for ev in events:
+        msg = ev.get("message") or ev
+        if msg.get("role") != "assistant":
+            continue
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        parts = [
+            block.get("text", "")
+            for block in content
+            if isinstance(block, dict) and block.get("type") == "text"
+        ]
+        joined = "\n".join(p for p in parts if p)
+        if joined.strip():
+            last = joined
+    return last
+
+
 def usage_totals(events: list[dict[str, Any]]) -> dict[str, int]:
     """Sum input/output tokens from usage blocks if present."""
     totals = {"input_tokens": 0, "output_tokens": 0, "cache_read_input_tokens": 0}
@@ -140,13 +169,13 @@ def check_max_output_tokens(events, n) -> tuple[bool, str]:
 
 
 def check_output_matches(events, pattern) -> tuple[bool, str]:
-    text = final_text(events)
+    text = final_answer_text(events)
     ok = re.search(pattern, text) is not None
     return ok, f"/{pattern}/ {'matched' if ok else 'NOT matched'}"
 
 
 def check_output_not_matches(events, pattern) -> tuple[bool, str]:
-    text = final_text(events)
+    text = final_answer_text(events)
     ok = re.search(pattern, text) is None
     return ok, f"/{pattern}/ {'absent' if ok else 'unexpectedly matched'}"
 


### PR DESCRIPTION
Follow-up to #1637 (migration) and #1643 (v2 baseline). Three changes plus an important retraction.

## 1. Probe v3 — positive framing

Rewrote the probe so every directive states the target behavior. The v1/v2 prohibitions ("Never open with…", "Don't narrate…", "Do not add…", "Nothing else") are gone, the duplicated comment rule is deduped, and the line-14 (pre-announce before tool call) vs line-20 (answer simple questions directly) tension is reconciled. Injected via `--system-prompt-file` instead of `$(cat …)`. Matches the repo's positive-framing house style (`terminology.md`, conventional-commits).

## 2. Scorer fix — score the answer, not interim updates

`output_matches` / `output_not_matches` scored `final_text()` (all assistant text concatenated, `^`-anchored), so for a prompt that mandates a tool call they graded the **pre-tool-call status update** ("Looking at…"), not the answer. Added `final_answer_text()` (last assistant text turn) and routed both checks to it. Test 05 is the only consumer.

## 3. Retraction: the "05 procedural-opener regression" was a measurement artifact

PR #1643 recorded a probe regression on test 05. It wasn't real. The **unchanged default condition** swung high-effort pass 3/3 → 0/3 across two resamples — proof the check was noise. Re-grading both runs' existing transcripts with the answer-scoped scorer (zero new invocations) gives **3/3 pass on default and probe at every effort**. The answers never had preamble; the check was scoring the legitimate pre-tool-call update.

## 4. Token measurement (`just measure-tokens`)

New `scripts/measure-prompt-tokens.sh`. On a tool-free prompt, opus-low, n=3:

| config | mean total input tokens |
|---|---|
| default | 129,591 |
| default + exclude-dynamic | 129,482 |
| probe | 128,996 |

Replacing the whole system prompt saves **~595 tokens (−0.5%)** — `--system-prompt` swaps only the built-in base; CLAUDE.md + ~30 rules + tool/MCP defs load identically in both arms and dominate the ~129k input. Bare prompt-size savings are a non-signal here; efficiency must come from better *work*, not a shorter prompt. (`--exclude-dynamic-system-prompt-sections` is ignored with `--system-prompt`, and the dynamic sections are only ~109 tokens anyway.)

Docs-only/experiment harness — no plugin/marketplace/release-please impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)