### PR TITLE
fix(project-plugin): anchor changelog deprecation extraction to the verb; refresh removed env-var note

### DIFF
--- a/.claude/rules/agent-development.md
+++ b/.claude/rules/agent-development.md
@@ -132,7 +132,7 @@ This is an allowlist — only `worker` and `researcher` can be spawned. To allow
 | `sonnet` | Development workflows, moderate reasoning, multi-step implementation |
 | `haiku` | Structured/mechanical tasks, documentation generation, CI configuration |
 
-> **Note (2.1.142)**: Fast mode now uses Opus 4.7 by default (previously Opus 4.6). The `CLAUDE_CODE_OPUS_4_6_FAST_MODE_OVERRIDE` env var is deprecated (removal scheduled 2026-06-01) — drop it from agent launch scripts.
+> **Note (2.1.142)**: Fast mode now uses Opus 4.7 by default (previously Opus 4.6). The `CLAUDE_CODE_OPUS_4_6_FAST_MODE_OVERRIDE` env var was deprecated in 2.1.154 and **removed in 2.1.160** (now a no-op) — drop it from agent launch scripts. To use fast mode on Opus 4.6, switch with `/model claude-opus-4-6[1m]` then `/fast on`.
 
 ## Context Isolation
 

--- a/project-plugin/skills/changelog-review/scripts/analyze-changelog.sh
+++ b/project-plugin/skills/changelog-review/scripts/analyze-changelog.sh
@@ -96,13 +96,26 @@ if [ "$DEPRECATION" -gt 0 ]; then
   # AgentOutputTool). This deliberately skips lowercase prose words and
   # command-style `/output-style` tokens; the DEPRECATION count still surfaces
   # those for human review in the issue body.
-  # Chop the replacement clause first ("…in favor of `Read`", "…use X instead")
-  # so we extract the *deprecated* subject, not its replacement — otherwise a
-  # common replacement name like `Read` would over-match across the repo.
+  # Tokens: identifiers that are the *subject* of a deprecation, not merely
+  # co-located with a deprecation keyword. Anchoring to the verb is what keeps
+  # the bridge precise — the looser "any backtick token on a line containing
+  # 'removed'/'no longer'" form produced false positives like `SendMessage`
+  # ("messages relayed via `SendMessage` … no longer carry authority" — a
+  # hardening, not a deprecation), `enabledPlugins` ("stale `enabledPlugins`
+  # entries referencing removed marketplaces"), and `mcpServers` ("no longer
+  # strips inline `mcpServers`"). Two grammatical shapes are matched:
+  #   verb-first  — "Deprecated/Removed/Renamed/Unshipped … `Token`"
+  #   token-first — "`Token` … is/are/now/been deprecated/removed/renamed"
+  # `[^`]{0,40}` can't cross a backtick, so verb-first always grabs the first
+  # backticked identifier after the verb (the subject), never a replacement
+  # named later in an "in favor of `Other`" clause.
   mapfile -t tokens < <(
-    grep -iE 'deprecat|removed|renamed|unshipped|no longer' "$excerpt" 2>/dev/null \
-      | sed -E 's/ (in favor of|instead of|replaced by|→|, use | use ).*$//' \
-      | grep -oE '`[^`]+`' 2>/dev/null \
+    {
+      grep -oE '(Deprecated|Removed|Renamed|Unshipped|Un-shipped)[^`]{0,40}`[^`]+`' "$excerpt" 2>/dev/null \
+        | grep -oE '`[^`]+`$'
+      grep -oE '`[^`]+`[^`]{0,40}(is|are|now|been)[[:space:]]+(deprecated|removed|renamed)' "$excerpt" 2>/dev/null \
+        | grep -oE '^`[^`]+`'
+    } 2>/dev/null \
       | tr -d '`' \
       | grep -E '[A-Z]' 2>/dev/null \
       | grep -E '^[A-Za-z][A-Za-z0-9_]{2,}$' 2>/dev/null \

--- a/project-plugin/skills/changelog-review/scripts/tests/test-analyze-changelog.sh
+++ b/project-plugin/skills/changelog-review/scripts/tests/test-analyze-changelog.sh
@@ -29,6 +29,13 @@ cat > "$REPO/fake-plugin/hooks/bash-antipatterns.sh" <<'EOF'
 # REMINDER: Use the Read tool on the task-output file path.
 # (The TaskOutput tool is deprecated.)
 EOF
+# Identifiers that appear NEAR deprecation keywords in the changelog but are not
+# themselves being deprecated (the #1638 sweep false positives). Referenced here
+# so that a too-loose extractor WOULD surface them — making the negative
+# assertions below meaningful.
+cat > "$REPO/fake-plugin/hooks/coexist.sh" <<'EOF'
+# uses SendMessage between agents; reads enabledPlugins and mcpServers config
+EOF
 : > "$REPO/.claude/rules/skill-development.md"
 
 run() {
@@ -93,6 +100,29 @@ run "## 2.1.99
 assert_eq "DEPRECATION still counted" "1" "$(field DEPRECATION)"
 assert_eq "ACTIONABLE_DEPRECATION stays 0 (token not in repo)" "0" "$(field ACTIONABLE_DEPRECATION)"
 assert_absent "no fake-plugin candidate surfaced" "fake-plugin/hooks"
+
+# ── verb-anchored extraction rejects co-located non-deprecations (#1638 sweep) ─
+# Real shapes from the 2.1.138→2.1.176 sweep where a deprecation keyword sat on
+# the same line as a live identifier that was NOT being deprecated.
+echo ""
+echo "co-located identifiers (not the deprecation subject) do not raise the flag:"
+run "## 2.1.166
+- Hardened cross-session messaging: messages relayed via \`SendMessage\` from other Claude sessions no longer carry user authority
+## 2.1.153
+- \`--strict-mcp-config\` no longer strips inline \`mcpServers\` from explicitly-passed agent definitions
+## 2.1.152
+- Fixed /doctor reporting for stale \`enabledPlugins\` entries referencing removed marketplaces or dropped plugins"
+
+assert_eq "DEPRECATION count still fires on the coarse keywords" "3" "$(field DEPRECATION)"
+assert_eq "ACTIONABLE_DEPRECATION stays 0 (none is the deprecation subject)" "0" "$(field ACTIONABLE_DEPRECATION)"
+assert_absent "SendMessage not surfaced as a candidate" "coexist.sh"
+
+# Counterpart true positive: the same verb-first shape that the sweep correctly
+# caught (an env var that was genuinely removed) still surfaces.
+run "## 2.1.160
+- Removed \`TaskOutput\`; it is now a no-op"
+assert_eq "verb-first 'Removed \`X\`' still raises the flag" "1" "$(field ACTIONABLE_DEPRECATION)"
+assert_contains "the removed identifier is surfaced" "DEPRECATED_TOKENS=TaskOutput"
 
 # ── oversized batch (review stall) flags WARN ────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

Follow-up to #1639, driven by running the merged analyzer over the full
**2.1.138 → 2.1.176** backlog (the range the frozen tracking state never
reviewed). The sweep flagged 4 deprecated identifiers we reference; triage
against the actual changelog lines found **1 real, 3 false positives**:

| Token | Verdict | Why |
|-------|---------|-----|
| `CLAUDE_CODE_OPUS_4_6_FAST_MODE_OVERRIDE` | ✅ real | deprecated 2.1.154, **removed (no-op) 2.1.160** |
| `SendMessage` | ❌ false | "relayed messages **no longer** carry authority" — a hardening |
| `enabledPlugins` | ❌ false | "stale entries referencing **removed** marketplaces" |
| `mcpServers` | ❌ false | "**no longer** strips inline `mcpServers`" |

All three false positives matched only because a deprecation keyword sat on the
same line as a live identifier.

## Changes

1. **`.claude/rules/agent-development.md`** — the one real find. The note still
   said `CLAUDE_CODE_OPUS_4_6_FAST_MODE_OVERRIDE` was "deprecated (removal
   scheduled 2026-06-01)"; it was actually **removed (no-op) in 2.1.160** and the
   date has passed. Updated to reflect the removal and the `/model … [1m]` +
   `/fast on` path.

2. **`analyze-changelog.sh`** — the deprecation→plugin-code extractor now
   anchors to the deprecation **verb** instead of pulling every backtick token
   off any line containing a deprecation keyword:
   - verb-first: `Deprecated/Removed/Renamed/Unshipped … \`Token\``
   - token-first: `\`Token\` … is/are/now/been deprecated/removed/renamed`

   `[^\`]{0,40}` can't cross a backtick, so verb-first always grabs the
   *subject*, never a replacement named later in an "in favor of `Other`"
   clause. The coarse `DEPRECATION` count is unchanged — awareness of
   "no longer"/"removed" lines is preserved; only the actionable bridge got
   more precise.

3. **`test-analyze-changelog.sh`** — adds the three real false-positive shapes
   (asserting `ACTIONABLE_DEPRECATION=0` and that co-located identifiers are not
   surfaced) plus a verb-first true-positive counterpart. 23 assertions pass.

## Verification

Re-running the full sweep with the refined analyzer:

```
DEPRECATION=44                 ← coarse awareness signal unchanged
ACTIONABLE_DEPRECATION=1
DEPRECATED_TOKENS=CLAUDE_CODE_OPUS_4_6_FAST_MODE_OVERRIDE   ← only the true positive
STATUS=WARN
```

- `test-analyze-changelog.sh`: 23 passed
- `scripts/lint-shell-scripts.sh`: 0 errors / 0 warnings

## Note

This still doesn't ratchet the tracking JSON (out of scope here). Once the
scheduled workflow re-triages 2.1.138 → 2.1.176 through the now-precise
analyzer, `CLAUDE_CODE_OPUS_4_6_FAST_MODE_OVERRIDE` is already handled by this
PR, so that triage issue should come back clean on the actionable-deprecation
axis.

Refs #1638

https://claude.ai/code/session_01LAycLVymEp4vBJ2RsLtNHT

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAycLVymEp4vBJ2RsLtNHT)_