### PR TITLE
fix(hooks-plugin): allow `find … -delete` in bash-antipatterns hook

### DIFF
--- a/hooks-plugin/hooks/bash-antipatterns-teach.sh
+++ b/hooks-plugin/hooks/bash-antipatterns-teach.sh
@@ -68,10 +68,13 @@ if [ -z "$hint" ] && \
 fi
 
 # find -name without directory-discovery flags
+# Mirrors bash-antipatterns.sh: -delete is exempt because Glob can only list, not
+# delete, so the Glob hint is useless for a delete action (issue #1671). -exec/-ok
+# are intentionally not exempt (arbitrary command execution).
 if [ -z "$hint" ] && \
    echo "$COMMAND" | grep -Eq '^\s*find\s+' && \
-   ! echo "$COMMAND" | grep -Eq 'find\s+.*(-maxdepth|-mindepth|-type\s|-print0)'; then
-    hint="Use the Glob tool for filename matching. Example: Glob(pattern=\"**/*.ts\") instead of 'find . -name \"*.ts\"'. Keep 'find' only when you need -maxdepth/-type d/-print0."
+   ! echo "$COMMAND" | grep -Eq 'find\s+.*(-maxdepth|-mindepth|-type\s|-print0|-delete\b)'; then
+    hint="Use the Glob tool for filename matching. Example: Glob(pattern=\"**/*.ts\") instead of 'find . -name \"*.ts\"'. Keep 'find' only when you need -maxdepth/-type d/-print0, or a -delete action."
     hint_key="glob-find"
 fi
 

--- a/hooks-plugin/hooks/bash-antipatterns.sh
+++ b/hooks-plugin/hooks/bash-antipatterns.sh
@@ -156,16 +156,25 @@ fi
 # Check for find command (should use Glob for simple patterns)
 # Allow find when using directory-discovery flags that Glob cannot replicate:
 # -maxdepth, -mindepth, -type, -print0. These are recommended in agentic-permissions.md
-# and shell-scripting.md for context commands. Block simple name-pattern searches
-# and any -exec usage (dangerous; runs arbitrary commands).
+# and shell-scripting.md for context commands.
+#
+# Also allow the -delete action: it performs a filesystem mutation Glob
+# structurally cannot do (Glob only lists), so nudging toward Glob is useless and
+# the agent has no built-in alternative — blocking it is pure friction (issue #1671).
+#
+# -exec/-execdir/-ok/-okdir stay blocked deliberately: they run arbitrary commands,
+# so the agent should compose explicit, reviewable steps rather than execute through
+# find. Block simple name-pattern searches (pure listing Glob can do).
 if echo "$COMMAND" | grep -Eq '^\s*find\s+' && \
-   ! echo "$COMMAND" | grep -Eq 'find\s+.*(-maxdepth|-mindepth|-type\s|-print0)'; then
+   ! echo "$COMMAND" | grep -Eq 'find\s+.*(-maxdepth|-mindepth|-type\s|-print0|-delete\b)'; then
     block "BLOCKED: 'find . -name \"*.ts\"' →
   Glob(pattern=\"**/*.ts\")
 
 The Glob tool is faster and optimized for codebase searches. If you
 need -maxdepth, -mindepth, -type d, or -print0 for directory discovery
 that Glob cannot do, keep find with those flags — the hook allows it.
+Glob can only list, not act: for 'find … -delete' keep find — the hook
+allows it too. (-exec/-ok stay blocked: run explicit steps instead.)
 See .claude/rules/bash-tool-replacements.md for the full table."
 fi
 

--- a/hooks-plugin/hooks/test-bash-antipatterns-teach.sh
+++ b/hooks-plugin/hooks/test-bash-antipatterns-teach.sh
@@ -104,6 +104,9 @@ echo "find without directory-discovery flags:"
 assert_emits "find -name only emits Glob hint" "find . -name '*.ts'" "Glob tool"
 assert_silent "find -maxdepth -type d is exempt" "find . -maxdepth 1 -type d"
 assert_silent "find -type f -print0 is exempt" "find . -type f -print0"
+# issue #1671: -delete is exempt (Glob cannot delete); -exec is not (arbitrary exec)
+assert_silent "find -name -delete is exempt (Glob cannot delete)" "find . -name '*.tmp' -delete"
+assert_emits "find -name -exec still emits Glob hint" "find . -name '*.log' -exec rm {} +" "Glob tool"
 
 echo ""
 echo "grep / rg standalone searches:"

--- a/hooks-plugin/hooks/test-bash-antipatterns.sh
+++ b/hooks-plugin/hooks/test-bash-antipatterns.sh
@@ -58,6 +58,22 @@ assert_exit \
     "find -exec (dangerous, no discovery flags) is blocked" 2 \
     "find . -exec ls {}"
 
+# Regression (issue #1671): find with a -delete action must be allowed even with
+# no directory-discovery flag — Glob can only list, it cannot delete, so the
+# Glob nudge is useless and blocking is pure friction. -exec/-ok stay blocked
+# (arbitrary command execution) — the agent should run explicit steps instead.
+assert_exit \
+    "find -name -delete is allowed (Glob cannot delete; issue #1671)" 0 \
+    "find . -name '*.tmp' -delete"
+
+assert_exit \
+    "find -maxdepth -type -delete is allowed (issue #1671 exact repro)" 0 \
+    "find /tmp/x -maxdepth 2 -name claude -type l -delete"
+
+assert_exit \
+    "find -name -exec rm (arbitrary execution) stays blocked" 2 \
+    "find . -name '*.log' -exec rm {} +"
+
 # ── cat pipeline regression ──────────────────────────────────────────────────
 # Regression: cat file | command was blocked even though cat is feeding a
 # pipeline — the Read tool cannot replace cat in pipelines where data flows


### PR DESCRIPTION
## What

Make the `bash-antipatterns` hook's `find` detector action-aware: stop blocking
`find … -delete`.

## Why

`find . -name '*.tmp' -delete` (and any delete-action `find` without a
directory-discovery flag) was hard-blocked by the PreToolUse hook, which pointed
at the **Glob tool**. Glob can only *list* — it cannot delete — so the suggested
alternative structurally cannot do the job, leaving the agent no built-in path
and forcing a hand-rolled shell-glob workaround (issue #1671).

The originally-reported repro
(`find … -maxdepth 2 -name claude -type l -delete`) passed only *incidentally*
because it also carried `-maxdepth`. The general delete-action class
(`find . -name '*.tmp' -delete`) was still blocked — verified before fixing.

## How

- Add `-delete\b` to the find exemption alternation in **both** the blocking hook
  (`bash-antipatterns.sh`) and its teaching mirror (`bash-antipatterns-teach.sh`).
- `-exec`/`-execdir`/`-ok`/`-okdir` **stay blocked deliberately**: they run
  arbitrary commands, so the agent should compose explicit, reviewable steps
  rather than execute through `find`. This preserves the existing `-exec` block
  and its test — per the project's "verify a suggestion before applying it" rule,
  I did not blindly apply the issue's broader suggestion to also allow `-exec`.
- Block/hint messages updated to explain the `-delete` carve-out.

## Tests

Regression tests added to both suites (per `.claude/rules/regression-testing.md`):

| Case | Expected |
|------|----------|
| `find . -name '*.tmp' -delete` | allowed |
| `find /tmp/x -maxdepth 2 -name claude -type l -delete` (#1671 exact repro) | allowed |
| `find . -name '*.log' -exec rm {} +` | still blocked |

`test-bash-antipatterns.sh`: 61 passed, 0 failed.
`test-bash-antipatterns-teach.sh`: 24 passed, 0 failed.
`shellcheck` + `scripts/lint-shell-scripts.sh`: clean.

Closes #1671

## Note on sibling issue #1587

While scoping this I empirically re-checked #1587 (bash-antipatterns false
positives: heredoc→`gh` chains and pattern-matching inside quoted strings). Both
of its reproductions now **pass** (exit 0) — already resolved by prior PRs
(#1584/#1591/#1592). #1587 looks closeable as already-fixed; left untouched here
to keep this PR scoped to the same file's one remaining bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
