### PR TITLE
fix(ci): make scheduled-audit scripts exit 0 under set -euo pipefail

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,3 +93,9 @@ repos:
         language: system
         files: '^scripts/(plugin-compliance-check\.sh|tests/test-plugin-compliance-skill-size\.sh)$'
         pass_filenames: false
+      - id: test-audit-scripts-exit
+        name: scheduled-audits scripts exit 0 under set -euo pipefail (scheduled-audits)
+        entry: bash ./scripts/tests/test-audit-scripts-exit.sh
+        language: system
+        files: '^scripts/(blueprint-health-check\.sh|infra-compliance-check\.sh|tests/test-audit-scripts-exit\.sh)$'
+        pass_filenames: false

--- a/scripts/blueprint-health-check.sh
+++ b/scripts/blueprint-health-check.sh
@@ -18,10 +18,14 @@ stale_skills=0
 missing_plugin_json_fields=0
 missing_frontmatter_fields=0
 
-# Temporary storage for results
-declare -a stale_skills_list
-declare -a plugin_compliance_list
-declare -a frontmatter_issues_list
+# Temporary storage for results.
+# Use empty-assignment (arr=()) rather than `declare -a arr`: a `declare`d
+# array with no element assigned is treated as unset under `set -u`, so a later
+# "${#arr[@]}" / "${arr[@]}" on a still-empty array aborts the script (the
+# frontmatter_issues_list case when a run has zero frontmatter issues).
+stale_skills_list=()
+plugin_compliance_list=()
+frontmatter_issues_list=()
 
 # Helper function: Extract YAML frontmatter field
 extract_field() {
@@ -56,7 +60,7 @@ days_since_date() {
 cd "$REPO_ROOT" || exit 1
 while IFS= read -r -d '' plugin_dir; do
   plugin_name=$(basename "$plugin_dir")
-  ((total_plugins++))
+  total_plugins=$((total_plugins+1))
 
   # Check plugin.json existence and validation
   plugin_json="$plugin_dir/.claude-plugin/plugin.json"
@@ -68,7 +72,7 @@ while IFS= read -r -d '' plugin_dir; do
     json_name=$(jq -r '.name // ""' "$plugin_json" 2>/dev/null || echo "")
     if [ -z "$json_name" ]; then
       plugin_json_issues+="Missing 'name'. "
-      ((missing_plugin_json_fields++))
+      missing_plugin_json_fields=$((missing_plugin_json_fields+1))
     elif [ "$json_name" != "$plugin_name" ]; then
       plugin_json_issues+="Name mismatch ('$json_name' vs '$plugin_name'). "
     fi
@@ -83,13 +87,13 @@ while IFS= read -r -d '' plugin_dir; do
       value=$(jq -r ".$field // \"\"" "$plugin_json" 2>/dev/null || echo "")
       if [ -z "$value" ] || [ "$value" = "null" ]; then
         plugin_json_issues+="Missing '$field'. "
-        ((missing_plugin_json_fields++))
+        missing_plugin_json_fields=$((missing_plugin_json_fields+1))
       fi
     done
   else
     has_plugin_json="✗"
     plugin_json_issues="File missing"
-    ((missing_plugin_json_fields++))
+    missing_plugin_json_fields=$((missing_plugin_json_fields+1))
   fi
 
   # Check README.md existence
@@ -102,8 +106,8 @@ while IFS= read -r -d '' plugin_dir; do
   # 2. Find all skills in this plugin
   plugin_skill_count=0
   while IFS= read -r -d '' skill_file; do
-    ((total_skills++))
-    ((plugin_skill_count++))
+    total_skills=$((total_skills+1))
+    plugin_skill_count=$((plugin_skill_count+1))
 
     skill_name=$(basename "$(dirname "$skill_file")")
 
@@ -132,7 +136,7 @@ while IFS= read -r -d '' plugin_dir; do
     if [ -n "$missing_required" ]; then
       missing_required="${missing_required%, }"
       frontmatter_issues_list+=("$plugin_name | $skill_name | Required: $missing_required")
-      ((missing_frontmatter_fields++))
+      missing_frontmatter_fields=$((missing_frontmatter_fields+1))
     fi
 
     if [ -n "$missing_recommended" ]; then
@@ -145,7 +149,7 @@ while IFS= read -r -d '' plugin_dir; do
       days_stale=$(days_since_date "$skill_modified")
       if [ "$days_stale" != "N/A" ] && [ "$days_stale" -gt "$STALE_THRESHOLD_DAYS" ]; then
         stale_skills_list+=("$plugin_name | $skill_name | $skill_modified | $days_stale")
-        ((stale_skills++))
+        stale_skills=$((stale_skills+1))
       fi
     fi
   done < <(find "$plugin_dir/skills" -type f \( -iname "SKILL.md" -o -iname "skill.md" \) -print0 2>/dev/null || true)

--- a/scripts/infra-compliance-check.sh
+++ b/scripts/infra-compliance-check.sh
@@ -62,11 +62,11 @@ for plugin in "${plugin_dirs[@]}"; do
     [ "$rm_entry" != "null" ] && [ -n "$rm_entry" ] && has_manifest="✅"
   fi
 
-  ((registry_total += 4))
-  [ "$has_json" = "✅" ] && ((registry_pass++)) || true
-  [ "$has_market" = "✅" ] && ((registry_pass++)) || true
-  [ "$has_config" = "✅" ] && ((registry_pass++)) || true
-  [ "$has_manifest" = "✅" ] && ((registry_pass++)) || true
+  registry_total=$((registry_total+4))
+  [ "$has_json" = "✅" ] && registry_pass=$((registry_pass+1)) || true
+  [ "$has_market" = "✅" ] && registry_pass=$((registry_pass+1)) || true
+  [ "$has_config" = "✅" ] && registry_pass=$((registry_pass+1)) || true
+  [ "$has_manifest" = "✅" ] && registry_pass=$((registry_pass+1)) || true
 
   row_status="✅"
   for s in "$has_json" "$has_market" "$has_config" "$has_manifest"; do
@@ -131,8 +131,8 @@ while IFS= read -r -d '' wf; do
   # Count checks
   checks=("$checkout_ok" "$claude_ok" "$perms_ok" "$filters_ok")
   for c in "${checks[@]}"; do
-    [ "$c" != "N/A" ] && ((workflow_total++)) || true
-    [ "$c" = "✅" ] && ((workflow_pass++)) || true
+    [ "$c" != "N/A" ] && workflow_total=$((workflow_total+1)) || true
+    [ "$c" = "✅" ] && workflow_pass=$((workflow_pass+1)) || true
   done
 
   row_status="✅"
@@ -149,7 +149,7 @@ done < <(find .github/workflows -maxdepth 1 -name '*.yml' -print0 2>/dev/null | 
 ##########
 
 for plugin in "${plugin_dirs[@]}"; do
-  ((version_total++))
+  version_total=$((version_total+1))
 
   pj_ver="N/A"; mf_ver="N/A"; mp_ver="N/A"
 
@@ -173,7 +173,7 @@ for plugin in "${plugin_dirs[@]}"; do
     done
   fi
 
-  [ "$match" = "✅" ] && ((version_pass++)) || true
+  [ "$match" = "✅" ] && version_pass=$((version_pass+1)) || true
   version_rows+=("$plugin | $pj_ver | $mf_ver | $mp_ver | $match")
 done
 
@@ -182,7 +182,7 @@ done
 ##########
 
 for plugin in "${plugin_dirs[@]}"; do
-  ((skill_total++))
+  skill_total=$((skill_total+1))
 
   sc=0
   [ -d "${plugin}/skills" ] && \
@@ -191,7 +191,7 @@ for plugin in "${plugin_dirs[@]}"; do
   total_skills_count=$((total_skills_count + sc))
   has_skills="✅"
   [ "$sc" -eq 0 ] && has_skills="❌"
-  [ "$has_skills" = "✅" ] && ((skill_pass++)) || true
+  [ "$has_skills" = "✅" ] && skill_pass=$((skill_pass+1)) || true
 
   skill_rows+=("$plugin | $sc | $has_skills")
 done
@@ -205,14 +205,14 @@ avg_skills="N/A"
 
 while IFS= read -r -d '' wf; do
   wf_name=$(basename "$wf")
-  ((security_total++))
+  security_total=$((security_total+1))
 
   if grep -qiE '(ghp_|gho_|github_pat_|sk-|Bearer [A-Za-z0-9])' "$wf" 2>/dev/null; then
     security_rows+=("🔴 | $wf_name | Token pattern detected")
   elif grep -qiE '(token|key|secret|password)[[:space:]]*[:=][[:space:]]*["'"'"'][A-Za-z0-9+/=]{20,}' "$wf" 2>/dev/null; then
     security_rows+=("🔴 | $wf_name | Potential hardcoded secret")
   else
-    ((security_pass++)) || true
+    security_pass=$((security_pass+1)) || true
   fi
 done < <(find .github/workflows -maxdepth 1 -name '*.yml' -print0 2>/dev/null | sort -z)
 
@@ -220,7 +220,7 @@ done < <(find .github/workflows -maxdepth 1 -name '*.yml' -print0 2>/dev/null | 
 while IFS= read -r -d '' skill_file; do
   at_field=$(head -50 "$skill_file" 2>/dev/null | grep -m1 "^allowed-tools:" | sed 's/^[^:]*:[[:space:]]*//' || echo "")
   if echo "$at_field" | grep -qE '(^|,\s*)Bash(\s*,|$)' 2>/dev/null; then
-    ((security_total++))
+    security_total=$((security_total+1))
     security_rows+=("🟡 | ${skill_file#./} | Broad Bash permission (no command pattern)")
   fi
 done < <(find . -path '*/skills/*' \( -iname "SKILL.md" -o -iname "skill.md" \) -print0 2>/dev/null)

--- a/scripts/tests/test-audit-scripts-exit.sh
+++ b/scripts/tests/test-audit-scripts-exit.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Smoke test for the scheduled-audits scripts (scripts/blueprint-health-check.sh
+# and scripts/infra-compliance-check.sh).
+#
+# Guards the class of bug that froze the monthly scheduled-audits.yml jobs:
+# under `set -euo pipefail`, both scripts must run to completion and exit 0.
+#
+# Two footguns motivated this test:
+#   1. `((var++))` / `((var += N))` returns exit 1 when the pre-increment value
+#      is 0, which `set -e` turns into a silent script-killing abort. Fixed by
+#      switching to the assignment form `var=$((var+1))` (always exit 0).
+#   2. A `declare -a arr` array with no element ever assigned is treated as
+#      UNSET under `set -u`, so a later "${#arr[@]}" / "${arr[@]}" on a still-
+#      empty array aborts the script. Fixed by seeding with `arr=()`.
+#
+# Both bugs are invisible in CI's failure log (the script dies before emitting
+# anything), so a positive "exit 0 and produced output" assertion is the only
+# reliable regression signal.
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+
+pass_count=0
+fail_count=0
+
+assert() {
+  # assert <description> <condition-result-string "true"/"false">
+  if [ "$2" = "true" ]; then
+    pass_count=$((pass_count + 1))
+  else
+    echo "FAIL: $1" >&2
+    fail_count=$((fail_count + 1))
+  fi
+}
+
+run_audit() {
+  # run_audit <label> <script-path> <expected-first-line-substring>
+  local label="$1" script="$2" needle="$3"
+  local out err audit_status
+  out="$(mktemp)"
+  err="$(mktemp)"
+
+  bash "$script" >"$out" 2>"$err"
+  audit_status=$?
+
+  echo "=== $label ==="
+  assert "$label exits 0 under set -euo pipefail" \
+    "$([ "$audit_status" -eq 0 ] && echo true || echo false)"
+  assert "$label writes nothing to stderr" \
+    "$([ ! -s "$err" ] && echo true || echo false)"
+  assert "$label produces a non-empty markdown report" \
+    "$([ -s "$out" ] && echo true || echo false)"
+  assert "$label report contains '$needle'" \
+    "$(grep -q "$needle" "$out" && echo true || echo false)"
+
+  if [ "$audit_status" -ne 0 ] && [ -s "$err" ]; then
+    echo "  stderr:" >&2
+    sed 's/^/    /' "$err" >&2
+  fi
+
+  rm -f "$out" "$err"
+}
+
+run_audit "blueprint-health-check.sh" \
+  "$repo_root/scripts/blueprint-health-check.sh" \
+  "Monthly Blueprint Health"
+
+run_audit "infra-compliance-check.sh" \
+  "$repo_root/scripts/infra-compliance-check.sh" \
+  "Infrastructure Compliance Dashboard"
+
+echo ""
+echo "Passed: $pass_count, Failed: $fail_count"
+[ "$fail_count" -eq 0 ]


### PR DESCRIPTION
## Problem

`scheduled-audits.yml`'s monthly blueprint-health and infra-compliance jobs have failed **every run** (Mar–Jun 2026), so the monthly health/compliance issues are never created. Both `scripts/blueprint-health-check.sh` and `scripts/infra-compliance-check.sh` die silently under `set -euo pipefail`.

## Root causes (two footguns, the second masked by the first)

1. **`((var++))` / `((var += N))` returns exit 1 when the pre-increment value is 0**, which `set -e` turns into a script-killing abort with no output. Switched every occurrence to the assignment form `var=$((var+1))` (always exit 0).
2. **A `declare -a arr` array with no element ever assigned is treated as _unset_ under `set -u`**, so `"${#frontmatter_issues_list[@]}"` aborted `blueprint-health-check.sh` on a zero-issue run (reproduced on bash 5.3, not just old bash). Seeded the three arrays with `arr=()` instead.

Both bugs were invisible in CI's failure log because the script died at the first `((total_plugins++))` before reaching either — consistent with "no `unbound variable` in CI log." The second bug surfaced only once the first was fixed and the script ran further.

## Regression coverage

Adds `scripts/tests/test-audit-scripts-exit.sh` asserting both scripts exit 0 and emit their markdown report, wired into `.pre-commit-config.yaml` scoped to those files (matches the existing `test-*` hook pattern).

## Verification

- Both scripts exit 0 with clean stderr locally; smoke test 8/8.
- `shellcheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)