### PR TITLE
fix(ci): survive version-less issue titles in changelog-review triage

### DIFF
--- a/.github/workflows/changelog-review.yml
+++ b/.github/workflows/changelog-review.yml
@@ -47,7 +47,10 @@ jobs:
         run: |
           # Extract first version number from changelog
           # Handles both "## 2.1.50" and "## [2.1.50]" formats
-          LATEST=$(grep -oP '## \[?\K[0-9]+\.[0-9]+\.[0-9]+' /tmp/changelog.md | head -1)
+          # `|| true` so an unexpectedly version-less changelog reaches the
+          # explicit error guard below instead of dying opaquely on pipefail
+          # (GitHub Actions runs steps with `bash -eo pipefail` by default).
+          LATEST=$(grep -oP '## \[?\K[0-9]+\.[0-9]+\.[0-9]+' /tmp/changelog.md | head -1 || true)
           if [ -z "$LATEST" ]; then
             echo "::error::Failed to extract version from changelog"
             exit 1
@@ -135,7 +138,11 @@ jobs:
             [ -z "$num" ] && continue
             # The version after the arrow is the range's upper bound; fall back
             # to the last version token in the title.
-            upper=$(printf '%s' "$title" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -1)
+            # `|| true`: a version-less issue title makes grep match nothing,
+            # which under `set -euo pipefail` would fail this bare assignment
+            # BEFORE the line below can skip it (the #1638 freeze cause). The
+            # guard then handles the empty case.
+            upper=$(printf '%s' "$title" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -1 || true)
             [ -z "$upper" ] && continue
             # Covered iff LATEST is not newer than this issue's upper bound.
             highest=$(printf '%s\n%s\n' "$LATEST" "$upper" | sort -V | tail -1)
@@ -204,9 +211,12 @@ jobs:
             --excerpt /tmp/excerpt.md --repo-dir "$PWD" --tracked "$TRACKED" --latest "$LATEST")
           echo "$ANALYSIS"
 
-          SUMMARY=$(echo "$ANALYSIS" | grep -E '^SUMMARY=' | head -1 | cut -d= -f2-)
-          ANALYSIS_STATUS=$(echo "$ANALYSIS" | grep -E '^STATUS=' | head -1 | cut -d= -f2-)
-          DEPRECATED_TOKENS=$(echo "$ANALYSIS" | grep -E '^DEPRECATED_TOKENS=' | head -1 | cut -d= -f2-)
+          # `|| true` on each: a field the analyzer doesn't emit makes grep
+          # match nothing, which would fail the bare assignment under
+          # `set -euo pipefail`. Empty values degrade gracefully downstream.
+          SUMMARY=$(echo "$ANALYSIS" | grep -E '^SUMMARY=' | head -1 | cut -d= -f2- || true)
+          ANALYSIS_STATUS=$(echo "$ANALYSIS" | grep -E '^STATUS=' | head -1 | cut -d= -f2- || true)
+          DEPRECATED_TOKENS=$(echo "$ANALYSIS" | grep -E '^DEPRECATED_TOKENS=' | head -1 | cut -d= -f2- || true)
           # Candidate files: the indented lines between CANDIDATES: and the footer.
           CANDIDATE_LIST=$(echo "$ANALYSIS" | awk '
             /^CANDIDATES:/ { f = 1; next }


### PR DESCRIPTION
## Problem

The weekly `changelog-review.yml` workflow froze Claude Code version tracking at 2.1.138 (upstream is 2.1.176) — see #1638. The skip-if-exists step assigns:

```sh
upper=$(printf '%s' "$title" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -1)
[ -z "$upper" ] && continue
```

An open tracking issue with a **version-less title** makes `grep` match nothing. Under `set -euo pipefail` the bare assignment fails (pipefail propagates grep's exit 1) **before** the `[ -z "$upper" ] && continue` guard can skip it, killing the step in ~0.9s with zero output.

## Fix

Append `|| true` to that grep pipeline (the guard then handles the empty case), and to the other grep-based field extractions in these `set -euo pipefail` steps where grep can legitimately match nothing:

- the `LATEST` version extraction (its explicit error-exit guard was unreachable under pipefail);
- the `SUMMARY` / `STATUS` / `DEPRECATED_TOKENS` analyzer-field reads.

Empty matches now degrade to empty values the downstream guards already handle, instead of aborting the step.

## Coverage

Inline workflow YAML — no script-level regression unit here. The audit-script exit-code smoke test added in the scheduled-audits fix (#1680) covers the broader `set -e` + empty-match class.

## Verification

Reproduced the loop body locally with a version-less title (`1638\tno-version-title`): old form exits 1, new form completes and exits 0. `actionlint` introduces zero new findings (pre-existing info/style notes unchanged, 8→8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)