### PR TITLE
fix(ci): allow the release-please bot in release-pr-doc-audit

### DIFF
--- a/.github/workflows/release-pr-doc-audit.yml
+++ b/.github/workflows/release-pr-doc-audit.yml
@@ -23,6 +23,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # release-please PRs are authored by the laurigates-release-please bot.
+          # Without allow-listing it, claude-code-action's human-actor guard
+          # rejects the run with "non-human actor", failing every release PR audit.
+          allowed_bots: "claude[bot],claude,laurigates-release-please[bot],laurigates-release-please"
           claude_args: "--model haiku --max-turns 50"
           additional_permissions: |
             Read


### PR DESCRIPTION
## Problem

`release-pr-doc-audit.yml` runs on every release-please PR (the common case), but `anthropics/claude-code-action@v1` rejects bot-authored PRs with a `non-human actor` error when `allowed_bots` is unset. CI log confirms: `ALLOWED_BOTS:` empty + `non-human actor: laurigates-release-please (type: Bot)`. So the doc-compliance audit fails on every release PR.

## Fix

Add `allowed_bots` listing the Claude bot and the release-please bot (both the `[bot]` GitHub-login form and the bare name), matching the sibling-workflow convention:

```yaml
allowed_bots: "claude[bot],claude,laurigates-release-please[bot],laurigates-release-please"
```

## Verification

Config-only. The bot-actor guard can only be exercised by a real bot-authored PR event, so this is verified **post-merge** on the next release-please PR (or a re-triggered `synchronize`) rather than locally. YAML parses; `actionlint` clean (0 findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)