### PR TITLE
feat(health-plugin): extend usage telemetry to plugin agents

### DIFF
--- a/docs/adrs/0018-health-usage-scope-from-session-telemetry.md
+++ b/docs/adrs/0018-health-usage-scope-from-session-telemetry.md
@@ -69,6 +69,16 @@ enough to compute, with `jq` over the JSONL set:
 - **Dormant**: skills whose most-recent invocation is older than N days.
 - **Hot/cold ranking**: invocation counts per skill, per tool.
 
+The same mechanism extends to **plugin agents**: a subagent dispatch is a
+`tool_use` with `.name == "Agent"` (or the `"Task"` alias) and
+`.input.subagent_type` naming the agent in `plugin:agent` form. Matched against
+the installed agent inventory (`<plugin>/agents/<name>.md`), this yields
+`AGENTS_NEVER_FIRED` / `AGENTS_DORMANT` alongside the skill rollups. Agents are
+the harder blind spot — they are not auto-invoked from a description the way
+skills are, but are chosen explicitly by an orchestrator, so a never-fired agent
+is a signal that the orchestrator never reaches for it (discoverability, or
+genuine redundancy with a skill).
+
 ### The constraint the data imposes
 
 The investigation also surfaced the load-bearing design constraint: this data is
@@ -118,11 +128,16 @@ SKILLS_ENABLED=210
 SKILLS_FIRED=63
 SKILLS_NEVER_FIRED=147
 SKILLS_DORMANT=12
+AGENTS_ENABLED=20
+AGENTS_FIRED=12
+AGENTS_NEVER_FIRED=8
+AGENTS_DORMANT=0
 STATUS=WARN
-ISSUE_COUNT=2
+ISSUE_COUNT=3
 ISSUES:
   - SEVERITY=WARN TYPE=never_fired COUNT=147 MSG=enabled skills with zero invocations in window (use --verbose to list)
   - SEVERITY=WARN TYPE=dormant COUNT=12 MSG=skills not invoked in 30+ days (use --verbose to list)
+  - SEVERITY=WARN TYPE=agent_never_fired COUNT=8 MSG=installed plugin agents never spawned in history (use --verbose to list)
 === END USAGE TELEMETRY ===
 ```
 

--- a/health-plugin/README.md
+++ b/health-plugin/README.md
@@ -25,7 +25,7 @@ Diagnose and fix Claude Code configuration issues including plugin registry, set
 | `stack` | Enabled plugins vs project tech stack | `health-audit` |
 | `agentic` | Skill/command/agent agentic-optimisation compliance | `health-agentic-audit` |
 | `runtime` | `~/.claude.json` bloat (dead projects/githubRepoPaths, orphaned MCP). Read-only | `check-runtime.sh` |
-| `usage` | Never-fired and dormant skills mined from session telemetry. Read-only, local-leaning ([ADR-0018](../docs/adrs/0018-health-usage-scope-from-session-telemetry.md)) | `check-usage.sh` |
+| `usage` | Never-fired and dormant skills *and* plugin agents mined from session telemetry. Read-only, local-leaning ([ADR-0018](../docs/adrs/0018-health-usage-scope-from-session-telemetry.md)) | `check-usage.sh` |
 | `all` | All of the above (default) | — |
 
 These internal skills are auto-discoverable but not user-invocable — use `/health:check` instead.
@@ -85,10 +85,10 @@ Surface skills you have enabled but rarely or never invoke, mined from local
 session transcripts (`~/.claude/projects/*/*.jsonl`):
 
 ```bash
-# Never-fired + dormant (last invoked 30+ days ago) skills
+# Never-fired + dormant (last invoked 30+ days ago) skills and plugin agents
 /health:check --scope=usage
 
-# List the offending skill names, custom dormancy window
+# List the offending skill/agent names, custom dormancy window
 bash health-plugin/skills/health-check/scripts/check-usage.sh \
   --home-dir "$HOME" --project-dir "$(pwd)" --window-days 60 --verbose
 ```

--- a/health-plugin/skills/health-check/SKILL.md
+++ b/health-plugin/skills/health-check/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-02-04
-modified: 2026-06-16
-reviewed: 2026-06-16
+modified: 2026-06-17
+reviewed: 2026-06-17
 description: "Claude Code health check — scans plugins, settings, hooks, MCP, runtime state, usage telemetry, permissions, marketplace with optional fixes. Use when checking project health or troubleshooting setup."
 allowed-tools: Bash(bash *), Bash(pre-commit *), Read, Glob, Grep, TodoWrite, AskUserQuestion
 args: "[--scope=all|registry|stack|agentic|runtime|usage] [--fix] [--dry-run] [--verbose]"
@@ -48,7 +48,7 @@ Parse these from `$ARGUMENTS`:
 | `stack` | Enabled plugins vs detected project tech stack |
 | `agentic` | Skill/command/agent agentic-optimisation compliance |
 | `runtime` | `~/.claude.json` bloat (dead `projects[]`, dead `githubRepoPaths[*]`, orphaned `disabledMcpServers`, duplicate MCP naming). Read-only audit. |
-| `usage` | Session-telemetry mining of `~/.claude/projects/*/*.jsonl` for never-fired and dormant skills. Read-only, local-leaning (SKIPs when history is insufficient). |
+| `usage` | Session-telemetry mining of `~/.claude/projects/*/*.jsonl` for never-fired and dormant skills *and* plugin agents. Read-only, local-leaning (SKIPs when history is insufficient). |
 | `all` | Environment checks + all five audits |
 
 ## Execution
@@ -183,9 +183,9 @@ For `--scope=usage` or `all`:
 bash "${CLAUDE_SKILL_DIR}/scripts/check-usage.sh" --home-dir "$HOME" --project-dir "$(pwd)"
 ```
 
-Parse `STATUS=`, `HISTORY_AVAILABLE=`, `TRANSCRIPTS_SCANNED=`, `SKILLS_ENABLED=`, `SKILLS_FIRED=`, `SKILLS_NEVER_FIRED=`, `SKILLS_DORMANT=`, `SCHEMA_DRIFT_SUSPECTED=`, and `ISSUES:`. Pass `--verbose` to list every never-fired / dormant skill (default rolls each category into one issue line). Pass `--window-days N` to change the dormancy threshold (default 30).
+Parse `STATUS=`, `HISTORY_AVAILABLE=`, `TRANSCRIPTS_SCANNED=`, `SKILLS_ENABLED=`, `SKILLS_FIRED=`, `SKILLS_NEVER_FIRED=`, `SKILLS_DORMANT=`, `AGENTS_ENABLED=`, `AGENTS_FIRED=`, `AGENTS_NEVER_FIRED=`, `AGENTS_DORMANT=`, `SCHEMA_DRIFT_SUSPECTED=`, and `ISSUES:`. Pass `--verbose` to list every never-fired / dormant skill and agent (default rolls each category into one issue line). Pass `--window-days N` to change the dormancy threshold (default 30).
 
-The usage scope mines local session transcripts (`~/.claude/projects/*/*.jsonl`) for skill-invocation recency: **never-fired** skills (enabled but zero invocations in history) and **dormant** skills (last invoked more than the window ago). Findings are **advisory review candidates**, not a delete list — a skill can be correct yet rarely needed. The audit is **read-only** (no `--fix` path).
+The usage scope mines local session transcripts (`~/.claude/projects/*/*.jsonl`) for skill- and agent-invocation recency: **never-fired** skills/agents (installed but zero invocations in history) and **dormant** skills/agents (last invoked more than the window ago). Agent invocations are read from `Agent`/`Task` `tool_use` events keyed by `subagent_type`. Findings are **advisory review candidates**, not a delete list — a skill or agent can be correct yet rarely needed (recovery, migration, on-demand subagents gated behind a parent skill). The audit is **read-only** (no `--fix` path).
 
 > **Local-leaning.** Session history is local and long-lived, so this scope is near-useless in a remote/web sandbox (a fresh clone has ≤1 transcript). It emits `STATUS=SKIP` with `HISTORY_AVAILABLE=false` when there are fewer than two transcripts rather than reporting every skill as never-fired. If `TRANSCRIPTS_SCANNED>0` but zero tool calls parse, it emits `STATUS=WARN TYPE=schema_drift` (the transcript JSON shape changed) instead of a bogus all-never-fired result.
 

--- a/health-plugin/skills/health-check/scripts/check-usage.sh
+++ b/health-plugin/skills/health-check/scripts/check-usage.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # Check Usage Telemetry (~/.claude/projects/*/*.jsonl)
-# Mines local session transcripts for skill-invocation recency to surface:
+# Mines local session transcripts for skill- and agent-invocation recency to surface:
 #   - never-fired skills : enabled skills with zero invocations in any transcript
 #   - dormant skills     : skills whose most-recent invocation is older than the window
+#   - never-fired agents : installed plugin agents never spawned via the Agent/Task tool
+#   - dormant agents     : agents whose most-recent invocation is older than the window
 #
 # Read-only audit. Local-leaning by design: session history is local and
 # long-lived, so a fresh clone (remote/web sandbox) has little or no history.
@@ -94,6 +96,11 @@ window_cutoff=$((now_epoch - window_days * 86400))
 declare -A fired_last_seen=()
 declare -A fired_count=()
 declare -a fired_tokens=()   # raw tokens for loose substring fallback
+# Agent invocations mirror the skill maps: agent_last_seen[token]=max_mtime,
+# agent_count[token]=N, agent_tokens=raw tokens for the loose fallback.
+declare -A agent_last_seen=()
+declare -A agent_count=()
+declare -a agent_tokens=()
 total_tool_use=0
 
 file_mtime() {
@@ -130,6 +137,22 @@ for tfile in "${transcript_files[@]}"; do
         *" ${key} "*) ;;
         *) fired_tokens+=("$key") ;;
       esac
+    elif [ "$kind" = "AGENT" ]; then
+      total_tool_use=$((total_tool_use + 1))
+      # subagent_type is namespaced (e.g. agents-plugin:security-audit);
+      # normalize_token reduces it to the last segment, which matches the
+      # agent's filename basename in the inventory below.
+      key=$(normalize_token "$token")
+      [ -z "$key" ] && continue
+      agent_count["$key"]=$(( ${agent_count["$key"]:-0} + 1 ))
+      prev=${agent_last_seen["$key"]:-0}
+      if [ "$mtime" -gt "$prev" ]; then
+        agent_last_seen["$key"]=$mtime
+      fi
+      case " ${agent_tokens[*]-} " in
+        *" ${key} "*) ;;
+        *) agent_tokens+=("$key") ;;
+      esac
     fi
   done < <(jq -rc '
     select(.type=="assistant")
@@ -137,6 +160,8 @@ for tfile in "${transcript_files[@]}"; do
     | select(.type=="tool_use")
     | if .name=="Skill"
       then "SKILL\t" + ((.input.skill // .input.command // .input.name // "") | tostring)
+      elif (.name=="Agent" or .name=="Task")
+      then "AGENT\t" + ((.input.subagent_type // "") | tostring)
       else "TOOL\t" + (.name | tostring)
       end
   ' "$tfile" 2>/dev/null)
@@ -218,6 +243,66 @@ echo "SKILLS_FIRED=${skills_fired}"
 echo "SKILLS_NEVER_FIRED=${skills_never}"
 echo "SKILLS_DORMANT=${skills_dormant}"
 
+# --- Discover installed plugin agent inventory --------------------------------
+# Plugin agents live at <plugin>/agents/<name>.md; the filename basename is the
+# agent's name and matches the normalized subagent_type recorded above.
+declare -a enabled_agents=()
+declare -A agent_seen=()
+if [ -d "$skills_dir" ]; then
+  while IFS= read -r amd; do
+    [ -n "$amd" ] || continue
+    aname=$(basename "$amd" .md)
+    # Dedup: the plugin cache can hold multiple versions of the same plugin.
+    [ -n "${agent_seen[$aname]+x}" ] && continue
+    agent_seen["$aname"]=1
+    enabled_agents+=("$aname")
+  done < <(find "$skills_dir" -path '*/.claude/worktrees/*' -prune -o \
+             -path '*/agents/*.md' -type f -print 2>/dev/null)
+fi
+
+agents_enabled=${#enabled_agents[@]}
+echo "AGENTS_ENABLED=${agents_enabled}"
+
+# Mirror skill_is_fired() against the agent maps (exact key then loose substring).
+agent_is_fired() {
+  local ag="$1"
+  if [ -n "${agent_last_seen[$ag]+x}" ]; then
+    printf '%s' "${agent_last_seen[$ag]}"
+    return 0
+  fi
+  local tok
+  for tok in "${agent_tokens[@]}"; do
+    case "$ag" in *"$tok"*) printf '%s' "${agent_last_seen[$tok]}"; return 0 ;; esac
+    case "$tok" in *"$ag"*) printf '%s' "${agent_last_seen[$tok]}"; return 0 ;; esac
+  done
+  return 1
+}
+
+agents_fired=0
+agents_never=0
+agents_dormant=0
+agent_never_list=""
+agent_dormant_list=""
+
+if [ "$agents_enabled" -gt 0 ]; then
+  for ag in "${enabled_agents[@]}"; do
+    if agent_last_hit=$(agent_is_fired "$ag"); then
+      agents_fired=$((agents_fired + 1))
+      if [ "${agent_last_hit:-0}" -lt "$window_cutoff" ]; then
+        agents_dormant=$((agents_dormant + 1))
+        agent_dormant_list="${agent_dormant_list}${ag} "
+      fi
+    else
+      agents_never=$((agents_never + 1))
+      agent_never_list="${agent_never_list}${ag} "
+    fi
+  done
+fi
+
+echo "AGENTS_FIRED=${agents_fired}"
+echo "AGENTS_NEVER_FIRED=${agents_never}"
+echo "AGENTS_DORMANT=${agents_dormant}"
+
 # --- Roll up issues (advisory; read-only audit) -------------------------------
 if [ "$skills_enabled" -eq 0 ]; then
   usage_issues="${usage_issues}  - SEVERITY=INFO TYPE=no_skill_inventory MSG=no SKILL.md files found under ${skills_dir} (cannot compute never-fired without an inventory)\n"
@@ -242,6 +327,26 @@ if [ "$skills_dormant" -gt 0 ]; then
     usage_issues="${usage_issues}  - SEVERITY=WARN TYPE=dormant COUNT=${skills_dormant} SKILLS=${dormant_list% }\n"
   else
     usage_issues="${usage_issues}  - SEVERITY=WARN TYPE=dormant COUNT=${skills_dormant} MSG=skills not invoked in ${window_days}+ days (advisory; use --verbose to list)\n"
+  fi
+fi
+
+if [ "$agents_never" -gt 0 ]; then
+  usage_issue_count=$((usage_issue_count + 1))
+  [ "$usage_status" = "OK" ] && usage_status="WARN"
+  if [ "$verbose_mode" = true ]; then
+    usage_issues="${usage_issues}  - SEVERITY=WARN TYPE=agent_never_fired COUNT=${agents_never} AGENTS=${agent_never_list% }\n"
+  else
+    usage_issues="${usage_issues}  - SEVERITY=WARN TYPE=agent_never_fired COUNT=${agents_never} MSG=installed plugin agents never spawned in history (advisory review candidates; use --verbose to list)\n"
+  fi
+fi
+
+if [ "$agents_dormant" -gt 0 ]; then
+  usage_issue_count=$((usage_issue_count + 1))
+  [ "$usage_status" = "OK" ] && usage_status="WARN"
+  if [ "$verbose_mode" = true ]; then
+    usage_issues="${usage_issues}  - SEVERITY=WARN TYPE=agent_dormant COUNT=${agents_dormant} AGENTS=${agent_dormant_list% }\n"
+  else
+    usage_issues="${usage_issues}  - SEVERITY=WARN TYPE=agent_dormant COUNT=${agents_dormant} MSG=agents not invoked in ${window_days}+ days (advisory; use --verbose to list)\n"
   fi
 fi
 

--- a/health-plugin/skills/health-check/scripts/tests/test-check-usage.sh
+++ b/health-plugin/skills/health-check/scripts/tests/test-check-usage.sh
@@ -34,6 +34,10 @@ tool_event() {   # $1 = tool name
 chat_event() {
   jq -nc '{type:"assistant",message:{content:[{type:"text",text:"hello"}]}}'
 }
+# Emit one assistant-event JSONL line containing an Agent tool_use.
+agent_event() {  # $1 = subagent_type token (may be namespaced, e.g. plug:agent)
+  jq -nc --arg s "$1" '{type:"assistant",message:{content:[{type:"tool_use",name:"Agent",input:{subagent_type:$s}}]}}'
+}
 
 make_home() { mkdir -p "$1/.claude/projects/proj"; }
 make_skills() {  # $1 = skills root, remaining = skill dir names
@@ -42,6 +46,14 @@ make_skills() {  # $1 = skills root, remaining = skill dir names
   for s in "$@"; do
     mkdir -p "${root}/plug-plugin/skills/${s}"
     printf -- '---\nname: %s\n---\nbody\n' "$s" > "${root}/plug-plugin/skills/${s}/SKILL.md"
+  done
+}
+make_agents() {  # $1 = inventory root, remaining = agent names (file <name>.md)
+  local root="$1"; shift
+  local a
+  mkdir -p "${root}/plug-plugin/agents"
+  for a in "$@"; do
+    printf -- '---\nname: %s\n---\nbody\n' "$a" > "${root}/plug-plugin/agents/${a}.md"
   done
 }
 
@@ -122,5 +134,37 @@ echo "$out5" | grep -q "^TRANSCRIPTS_SCANNED=2$" || fail "Case5 expected TRANSCR
 echo "$out5" | grep -q "worktrees" && fail "Case5 must not leak a worktrees path:\n$out5"
 pass "worktree clones pruned from transcript scan"
 rm -rf "$home5" "$skills5"
+
+# -----------------------------------------------------------------------------
+# Case 6: agent never-fired + dormant classification from namespaced subagent_type
+#   security-audit: fired recently (active)
+#   git-ops:        fired long ago (dormant)
+#   ci:             never fired
+# Guards the AGENT-track extension: subagent_type is namespaced in transcripts
+# (plug:agent) and must normalize to the agent's filename basename in inventory.
+# -----------------------------------------------------------------------------
+home6="$(mktemp -d)"; make_home "$home6"
+inv6="$(mktemp -d)"; make_skills "$inv6" health-check; make_agents "$inv6" security-audit git-ops ci
+
+recent6="$home6/.claude/projects/proj/recent.jsonl"
+old6="$home6/.claude/projects/proj/old.jsonl"
+{ agent_event "agents-plugin:security-audit"; tool_event "Bash"; } > "$recent6"
+agent_event "git-plugin:git-ops" > "$old6"
+old6_ts=$(( $(date +%s) - 60*86400 ))
+touch -d "@${old6_ts}" "$old6" 2>/dev/null || touch -t "$(date -r "$old6_ts" +%Y%m%d%H%M 2>/dev/null || echo 202001010000)" "$old6"
+
+out6="$(bash "$check_script" --home-dir "$home6" --skills-dir "$inv6" --project-dir /tmp --window-days 30)"
+echo "$out6" | grep -q "^AGENTS_ENABLED=3$" || fail "Case6 expected AGENTS_ENABLED=3:\n$out6"
+echo "$out6" | grep -q "^AGENTS_FIRED=2$" || fail "Case6 expected AGENTS_FIRED=2:\n$out6"
+echo "$out6" | grep -q "^AGENTS_NEVER_FIRED=1$" || fail "Case6 expected AGENTS_NEVER_FIRED=1 (ci):\n$out6"
+echo "$out6" | grep -q "^AGENTS_DORMANT=1$" || fail "Case6 expected AGENTS_DORMANT=1 (git-ops):\n$out6"
+pass "agent never-fired + dormant classified from namespaced subagent_type"
+
+# Case 6b: --verbose lists the offending agent names
+out6b="$(bash "$check_script" --home-dir "$home6" --skills-dir "$inv6" --project-dir /tmp --window-days 30 --verbose)"
+echo "$out6b" | grep -q "TYPE=agent_never_fired .*AGENTS=.*ci" || fail "Case6b expected ci in verbose agent_never_fired list:\n$out6b"
+echo "$out6b" | grep -q "TYPE=agent_dormant .*AGENTS=.*git-ops" || fail "Case6b expected git-ops in verbose agent_dormant list:\n$out6b"
+pass "--verbose lists offending agent names"
+rm -rf "$home6" "$inv6"
 
 echo "ALL TESTS PASSED"


### PR DESCRIPTION
## What

Extends `health-plugin`'s usage telemetry (`check-usage.sh`, ADR-0018) to cover **plugin agents**, not just skills. `--scope=usage` now also reports `AGENTS_ENABLED / AGENTS_FIRED / AGENTS_NEVER_FIRED / AGENTS_DORMANT`, classifying the installed `<plugin>/agents/<name>.md` inventory against `Agent`/`Task` `tool_use` events keyed by `subagent_type`.

## Why

Agent usage was a blind spot in the very telemetry built to answer "is this agent earning its keep?". A 37-day transcript scan found **12 of 20 plugin agents firing and 8 dark** — invisible until now. Run `/health:check --scope=usage --verbose` to regenerate.

## Notes

- The agent inventory **dedups by name** across cached plugin versions; the existing skill track does not (a pre-existing inflation — `SKILLS_ENABLED` over-counts on multi-version caches — noted for follow-up, out of scope here).
- Regression coverage: `test-check-usage.sh` Case 6/6b — namespaced `subagent_type` normalizes to the agent filename, and `--verbose` lists offending agent names. All 7 cases pass; `shellcheck` clean.
- Docs (SKILL.md, README, ADR-0018) updated in the same commit per docs-currency.

The local `check-driver-freshness` hook needs #1683 (CI does not run that hook), but the two PRs are independently mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
