### PR TITLE
refactor(agents-plugin): reposition ci agent to full-scaffold scope + reconcile model rules

### DIFF
--- a/.claude/rules/agent-development.md
+++ b/.claude/rules/agent-development.md
@@ -126,11 +126,12 @@ This is an allowlist — only `worker` and `researcher` can be spawned. To allow
 
 ## Model Selection for Agents
 
+**Default to `model: opus` for every plugin agent.** A subagent's output feeds back into the main loop as a tool result, so a weaker delegate quietly degrades everything downstream. Opus 4.8 at *low* effort beats Sonnet 4.6 at *high* effort on both quality and token efficiency, so **`effort`, not `model`, is the cost lever** for delegated work — dial effort down for mechanical agents, keep the model on Opus. This matches the user-global standard in `~/.claude/rules/agent-and-tool-selection.md` ("Always Use Opus for Subagents").
+
 | Model | Use For |
 |-------|---------|
-| `opus` | Deep reasoning, security analysis, code review, debugging, complex refactoring |
-| `sonnet` | Development workflows, moderate reasoning, multi-step implementation |
-| `haiku` | Structured/mechanical tasks, documentation generation, CI configuration |
+| `opus` | **Default for all subagents** — reasoning, review, debugging, refactoring, *and* mechanical/high-volume work (dial `effort` down for the latter rather than downgrading the model) |
+| `sonnet` / `haiku` | Avoid for subagents. The one sanctioned exception is the `agent-patterns-plugin:cold-read-gate` haiku reader, where a low-capability model is the *measurement instrument*, not a delegate. |
 
 > **Note (2.1.142)**: Fast mode now uses Opus 4.7 by default (previously Opus 4.6). The `CLAUDE_CODE_OPUS_4_6_FAST_MODE_OVERRIDE` env var was deprecated in 2.1.154 and **removed in 2.1.160** (now a no-op) — drop it from agent launch scripts. To use fast mode on Opus 4.6, switch with `/model claude-opus-4-6[1m]` then `/fast on`.
 
@@ -144,7 +145,7 @@ Creates an independent context copy. The agent sees parent history but its chang
 ---
 name: research-agent
 description: Research without polluting main context
-model: sonnet
+model: opus
 context: fork
 tools: Glob, Grep, LS, Read, WebFetch, WebSearch, TodoWrite
 ---
@@ -409,7 +410,7 @@ Explicitly block specific tools while allowing everything else:
 ---
 name: read-only-explorer
 description: Explore codebase without modifications
-model: haiku
+model: opus
 tools: Bash, Read, Grep, Glob
 disallowedTools: Write, Edit, NotebookEdit
 ---
@@ -462,7 +463,7 @@ claude --agents '{"my-agent": {"description": "...", "prompt": "...", "tools": [
 
 - [ ] Agent name is kebab-case
 - [ ] `description` matches real user intents (not just tool jargon)
-- [ ] `model` is appropriate (`haiku` for mechanical, `sonnet` for development, `opus` for deep reasoning)
+- [ ] `model: opus` (the default for all subagents — `effort` is the cost lever, not the model; see Model Selection for Agents). The only sanctioned non-Opus subagent is the cold-read-gate haiku reader.
 - [ ] `tools` uses principle of least privilege
 - [ ] Granular `Bash(command *)` patterns used instead of bare `Bash`
 - [ ] `context: fork` added if agent needs isolated context window

--- a/agents-plugin/README.md
+++ b/agents-plugin/README.md
@@ -14,7 +14,7 @@ See [`docs/flow.md`](docs/flow.md) for a diagram of how `attribute-router` deleg
 | `review` | opus | Code review, commit review, PR review | Teammate preferred — parallel security/performance/correctness review |
 | `debug` | opus | Diagnose and fix bugs | Either — parallel investigation as teammate, single fix as subagent |
 | `docs` | haiku | Generate documentation | Teammate preferred — parallel doc generation across modules |
-| `ci` | haiku | Pipeline configuration | Either — parallel setup as teammate, single workflow as subagent |
+| `ci` | opus | Full CI/CD scaffold (multi-workflow buildout) | Subagent — delegate a from-scratch pipeline; edit single workflows inline |
 | `security-audit` | opus | Vulnerability scanning, OWASP analysis | Teammate preferred — continuous audit alongside development |
 | `refactor` | opus | Code restructuring, SOLID improvements | Either — parallel refactoring with file-locking as teammate |
 | `dependency-audit` | haiku | CVE scanning, outdated packages, licenses | Subagent preferred — quick focused audit |
@@ -35,7 +35,7 @@ Each agent includes a `## Team Configuration` section documenting when to use it
 
 | Best as Teammate | Best as Subagent | Either |
 |------------------|------------------|--------|
-| review, security-audit, research, docs | dependency-audit, performance, search-replace | test, debug, ci, refactor |
+| review, security-audit, research, docs | dependency-audit, performance, search-replace, ci | test, debug, refactor |
 
 ## Design Principles
 
@@ -50,8 +50,8 @@ Each agent includes a `## Team Configuration` section documenting when to use it
 
 | Model | When Used | Agents |
 |-------|-----------|--------|
-| haiku | Structured operations, mechanical tasks | test, docs, ci, dependency-audit, search-replace |
-| opus | Deep reasoning, complex analysis, code restructuring | review, debug, security-audit, performance, refactor, research |
+| haiku | Structured operations, mechanical tasks | test, docs, dependency-audit, search-replace |
+| opus | Deep reasoning, complex analysis, code restructuring | review, debug, security-audit, performance, refactor, research, ci |
 
 ## Usage
 
@@ -64,7 +64,7 @@ Agents are invoked automatically based on task context or explicitly via agent r
 "Review this PR" → review agent
 "This endpoint is returning 500" → debug agent
 "Document the API" → docs agent
-"Set up GitHub Actions" → ci agent
+"Scaffold a full CI/CD pipeline from scratch" → ci agent
 "Check for security vulnerabilities" → security-audit agent
 "Clean up this class, it's too complex" → refactor agent
 "Check for vulnerable dependencies" → dependency-audit agent

--- a/agents-plugin/agents/ci.md
+++ b/agents-plugin/agents/ci.md
@@ -1,18 +1,22 @@
 ---
 name: ci
-model: haiku
+model: opus
 color: "#20BF6B"
-description: Configure CI/CD pipelines. Creates and updates GitHub Actions workflows, build configurations, and deployment automation.
+description: Scaffold a complete CI/CD setup for a repo — multiple GitHub Actions workflows (test, build, release, deploy) in one isolated pass. Use when delegating a full from-scratch pipeline buildout; edit single workflows inline instead.
 tools: Glob, Grep, LS, Read, Edit, Write, Bash(gh pr *), Bash(gh run *), Bash(gh workflow *), Bash(npm *), Bash(yarn *), Bash(bun *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git branch *), TodoWrite
 maxTurns: 15
 created: 2025-12-27
-modified: 2026-05-07
-reviewed: 2026-04-29
+modified: 2026-06-17
+reviewed: 2026-06-17
 ---
 
 # CI Agent
 
-Configure CI/CD pipelines. Creates GitHub Actions workflows and deployment automation.
+Scaffold a complete CI/CD setup — multiple GitHub Actions workflows and deployment automation — in one isolated pass.
+
+## When to delegate to this agent
+
+Reach for this agent to **scaffold a complete CI/CD setup from scratch** — several workflows (test, build, release, deploy) generated together in one isolated buildout. For a single-workflow edit or a one-file tweak, edit `.github/workflows/` directly in the main session: spawning a subagent for a surgical change costs more context than it saves. (Usage telemetry through 2026-06 showed CI work is almost always small inline edits — 175 inline workflow edits vs zero agent dispatches over 37 days — which is why this agent is scoped to the full-buildout case rather than general "configure CI" work.)
 
 ## Tool Selection
 


### PR DESCRIPTION
## What

Two related changes surfaced by the agent-usage audit (see #1684):

1. **`refactor(agents-plugin)`** — reposition the `ci` agent to its one genuinely delegatable scope (scaffolding a complete multi-workflow CI/CD setup) and switch `model: haiku → opus`.
2. **`docs(rules)`** — reconcile `agent-development.md`'s model-selection guidance with the user-global "always Opus for subagents" standard.

## Why

`agents-plugin:ci` fired **0 times in 37 days** while CI work happened constantly — **175 inline `.github/workflows/` edits across 60 sessions**, only 1 CI-skill invocation. It wasn't losing to skills; it was losing to inline editing in the main session. Its old "configure any CI" premise didn't match how CI work actually happens (small, surgical, interleaved). Repositioned to the full-scaffold-from-scratch case, with single-file tweaks steered back to inline editing.

The model fix required first resolving a rule contradiction: `agent-development.md` recommended "haiku for mechanical / sonnet for development" while the user-global rule mandates Opus for every subagent. Reconciled to **"opus default; `effort` is the cost lever; haiku only for the cold-read-gate measurement instrument."**

## Follow-up

Bulk-fixing the remaining **13 non-Opus plugin agents** + adding an enforcement lint is tracked separately (deferred per the "reconcile rules first" decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
