### PR TITLE
refactor: make Obsidian vault skills and vault-agent vault-agnostic

### DIFF
--- a/docs/session-plugin-workflow.md
+++ b/docs/session-plugin-workflow.md
@@ -7,7 +7,7 @@ landed 2026-06-10 (session-plugin created: generalized `session-spinup` /
 `session-end` orchestrator per D3, single collapsed Stop nudge per D4).
 Remaining: Phase 4 (fast↔slow label wiring via gitops) and the dotfiles-side
 cleanup (remove chezmoi copies of the user-level skills/hooks, add the user's
-FVH `session-plugin.local.md` to the chezmoi source).
+vault-specific `session-plugin.local.md` to the chezmoi source).
 Tracking task: taskwarrior `project:claude-plugins.session-plugin` (172)
 Epic: [#1504](https://github.com/laurigates/claude-plugins/issues/1504) · Phase 1 remediation: [#1503](https://github.com/laurigates/claude-plugins/issues/1503)
 
@@ -79,9 +79,9 @@ Reuse `scripts/plugin-compliance-check.sh`, `scripts/audit-skill-descriptions.py
   skills are blueprint-independent (`init`, `discovery`, `test-loop`,
   `skill-scripts`) vs blueprint-coupled (`continue` ↔ `blueprint-execute`).
 
-### Phase 2 — Generalize + promote `session-spinup` / `session-wrap` → `session-plugin` (de-FVH)
-- Extract FVH/LakuVault specifics (vault path `~/Documents/LakuVault/FVH/notes/`,
-  `## Log`/`## Todo` section targets, `fvh.*` project-naming map, scope-detection
+### Phase 2 — Generalize + promote `session-spinup` / `session-wrap` → `session-plugin` (generalize the journaling backend)
+- Extract vault-specific journaling config (vault path `~/Documents/YourVault/Journal/notes/`,
+  `## Log`/`## Todo` section targets, `<scope>.*` project-naming map, scope-detection
   heuristics) into per-user config via `agent-patterns-plugin:plugin-settings`
   (`.claude/session-plugin.local.md`).
 - Generalize the second destination to an optional **journal/notes** integration
@@ -91,7 +91,7 @@ Reuse `scripts/plugin-compliance-check.sh`, `scripts/audit-skill-descriptions.py
   marketplace.json, release-please-config.json, .release-please-manifest.json,
   docs/PLUGIN-MAP.md).
 - Migrate the two nudge hooks into the plugin.
-- **Write the user's actual FVH config to `.local.md` so nothing breaks for them.**
+- **Write the user's actual vault config to `.local.md` so nothing breaks for them.**
 - Remove the chezmoi `exact_dot_claude/skills/{session-wrap,session-spinup}` copies.
 - Add regression checks (`.claude/rules/regression-testing.md`).
 

--- a/obsidian-plugin/README.md
+++ b/obsidian-plugin/README.md
@@ -246,7 +246,7 @@ The skills above wrap the Obsidian CLI and require a running Obsidian instance. 
 **File**: `skills/vault-orphans/SKILL.md` — Orphan note triage heuristics.
 
 ### Vault Stubs
-**File**: `skills/vault-stubs/SKILL.md` — FVH/z redirect-stub pattern (for vaults using the LakuVault work-namespace convention).
+**File**: `skills/vault-stubs/SKILL.md` — Work-namespace redirect-stub pattern (for vaults using a work-namespace convention).
 
 ### Vault MOCs
 **File**: `skills/vault-mocs/SKILL.md` — Map-of-Content curation, convention drift repair.

--- a/obsidian-plugin/skills/vault-frontmatter/SKILL.md
+++ b/obsidian-plugin/skills/vault-frontmatter/SKILL.md
@@ -26,7 +26,7 @@ Offline, file-level repair of YAML frontmatter. Complements the `properties` ski
 - Removing unrendered Templater markers (`<% tp.file.cursor() %>`, `{{title}}`)
 - Cleaning up `null` entries inside `tags:` lists
 - Adding missing frontmatter blocks to notes that lack one
-- Ensuring FVH notes carry `context: fvh`
+- Ensuring work-namespace notes carry `context: work`
 - Normalizing tag case / pluralization drift
 
 ## Canonical Frontmatter Shape
@@ -36,7 +36,7 @@ Offline, file-level repair of YAML frontmatter. Complements the `properties` ski
 tags:
   - 🛠️/neovim       # emoji-prefixed category tag
   - 📝/notes         # note-type tag
-context: fvh         # FVH notes only
+context: work        # work-namespace notes only
 ---
 ```
 
@@ -45,7 +45,7 @@ Rules:
 2. 2–3 tags per note; every tag either `emoji/subcategory` or a bare note-type like `📝/moc`.
 3. No bare emoji placeholders (`📝`, `🌱`, `📝/🌱`) — they indicate the tag was never specified.
 4. No `null` tag values — YAML must be valid.
-5. FVH/* notes carry `context: fvh`; personal notes omit the field.
+5. Work-namespace notes (e.g. under `work/`) carry `context: work`; personal notes omit the field.
 
 ## Detection Patterns
 
@@ -56,7 +56,7 @@ Rules:
 | Null tag | YAML tag value literally `null` | Remove list entry |
 | Templater leak | `<% tp\.` or `\{\{title\}\}` or `\{\{date\}\}` | Replace `{{title}}` with filename stem; strip `<% tp.* %>` |
 | Corrupt emoji | Tag contains Unicode replacement char `\ufffd` | Flag for manual fix — don't guess |
-| Missing FVH context | File under `FVH/` without `context: fvh` | Add the line |
+| Missing work context | File under the work namespace (e.g. `work/`) without `context: work` | Add the line |
 
 ## Edit Recipes
 
@@ -109,7 +109,7 @@ For bulk fixes across many files, drive from a script that emits one `Edit` call
 ## Safety
 
 - Never write to `.obsidian/`, `.claude/`, `.git/`, `Files/`. The safety hook enforces this.
-- Never add frontmatter to daily notes in `Notes/` or `FVH/notes/` without verifying — they often don't need any.
+- Never add frontmatter to daily notes in `Notes/` or `work/notes/` without verifying — they often don't need any.
 - When in doubt about what a placeholder tag meant, leave the note unchanged and report it rather than guess.
 
 ## Related Skills

--- a/obsidian-plugin/skills/vault-mocs/SKILL.md
+++ b/obsidian-plugin/skills/vault-mocs/SKILL.md
@@ -49,7 +49,7 @@ Central hub for Neovim configuration, plugins, and workflows.
 
 Rules:
 1. Tag is **exactly** `📝/moc` — not `🗺️` (legacy), not `MOC` (flat), not `📝/MOC` (wrong case).
-2. File lives in `Zettelkasten/` (personal) or `FVH/MOC/` (work).
+2. File lives in `Zettelkasten/` (personal) or `work/MOC/` (work).
 3. Filename is `{Subject} MOC.md` — suffix, not prefix.
 4. Body has a one-paragraph description, then `##` section headings, then bullet-list wikilinks.
 5. Never has `id:` or other legacy frontmatter.
@@ -60,7 +60,7 @@ Rules:
 |-------|-----|
 | `tags: 🗺️` | Rewrite to `tags: [📝/moc]` |
 | `tags: [🗺, 📝/moc]` | Deduplicate to `tags: [📝/moc]` |
-| MOC in `FVH/z/` instead of `FVH/MOC/` | Move file |
+| MOC in `work/z/` instead of `work/MOC/` | Move file |
 | Uses `[[Kanban/Foo]]` path-qualified links | Rewrite to `[[Foo]]` when basename unique |
 
 ## Coverage Analysis
@@ -119,7 +119,7 @@ Don't add a "See also" or "Random" section as a dumping ground. If a note doesn'
 | Action | Commit |
 |--------|--------|
 | New MOC | `feat(mocs): add {Category} MOC covering N notes` |
-| Fixup tag | `fix(mocs): 🗺️ → 📝/moc on FVH MOCs` |
+| Fixup tag | `fix(mocs): 🗺️ → 📝/moc on work MOCs` |
 | Add orphans | `feat(mocs): link 12 notes into Neovim MOC` |
 | Rewrite path-qualified link | `fix(mocs): unqualify [[Kanban/X]] → [[X]] across 6 MOCs` |
 

--- a/obsidian-plugin/skills/vault-orphans/SKILL.md
+++ b/obsidian-plugin/skills/vault-orphans/SKILL.md
@@ -16,7 +16,7 @@ allowed-tools: Read, Edit, Grep, Glob
 |---|---|
 | Triaging orphan notes (zero incoming, zero outgoing wikilinks) for archive vs. reconnect | Building a new MOC hub the orphans should link into — use `vault-mocs` |
 | Distinguishing expected orphans (inbox, daily notes) from meaningful ones | Discovering the orphan list itself via the running CLI — use `search-discovery` |
-| Suggesting archival paths for stale isolated Zettelkasten notes | Classifying or consolidating FVH/z redirect stubs — use `vault-stubs` |
+| Suggesting archival paths for stale isolated Zettelkasten notes | Classifying or consolidating work-namespace redirect stubs — use `vault-stubs` |
 
 An "orphan" is a note with no incoming wikilinks AND no outgoing wikilinks — disconnected from the knowledge graph. Some orphans are expected; others are the most productive places to add structure.
 
@@ -25,7 +25,7 @@ An "orphan" is a note with no incoming wikilinks AND no outgoing wikilinks — d
 | Class | Where | Treat as |
 |-------|-------|----------|
 | Inbox items | `Inbox/*.md` | Expected; process via `/process-inbox` |
-| Daily notes | `Notes/YYYY-MM-DD.md`, `FVH/notes/…` | Expected; they link out but rarely in |
+| Daily notes | `Notes/YYYY-MM-DD.md`, `work/notes/…` | Expected; they link out but rarely in |
 | Standalone references | `Zettelkasten/*.md` with 0↔0 | **Meaningful** — add linkage |
 | Kanban board notes | `Kanban/*.md` | Usually acceptable; boards are self-contained |
 | Archive / logs | under `Archive/` subfolders | Expected; stale by design |

--- a/obsidian-plugin/skills/vault-stubs/SKILL.md
+++ b/obsidian-plugin/skills/vault-stubs/SKILL.md
@@ -3,29 +3,29 @@ created: 2026-04-17
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: vault-stubs
-description: "LakuVault FVH/z redirect-stub classification. Use when cleaning stubs, converting duplicates to redirects, or merging content into Zettelkasten."
+description: "Work-namespace redirect-stub classification in an Obsidian vault. Use when cleaning stubs, converting duplicates to redirects, or merging content into Zettelkasten."
 user-invocable: false
 allowed-tools: Read, Edit, Write, Grep, Glob
 ---
 
-# FVH/z Stub Management
+# Work-namespace Stub Management
 
 ## When to Use This Skill
 
 | Use this skill when... | Use the alternative instead when... |
 |---|---|
-| Classifying and consolidating FVH/z redirect stubs in LakuVault | Triaging generic orphan notes outside the FVH namespace — use `vault-orphans` |
-| Promoting an FVH-only note into the canonical Zettelkasten location | Repairing the wikilinks that point at the moved note afterwards — use `vault-wikilinks` |
-| Merging unique FVH content back into a Zettelkasten note | Adding the merged note into a Map of Content hub — use `vault-mocs` |
+| Classifying and consolidating work-namespace redirect stubs in the vault | Triaging generic orphan notes outside the work namespace — use `vault-orphans` |
+| Promoting a work-namespace note into the canonical Zettelkasten location | Repairing the wikilinks that point at the moved note afterwards — use `vault-wikilinks` |
+| Merging unique work-namespace content back into a Zettelkasten note | Adding the merged note into a Map of Content hub — use `vault-mocs` |
 
-In LakuVault, the `FVH/z/` directory is a work-namespace knowledge base that mirrors select Zettelkasten notes as tiny redirect stubs. Content lives in `Zettelkasten/`; `FVH/z/` points to it so work-context queries still find the topic.
+A work-namespace subtree (a directory such as `work/z/`) is a knowledge base that mirrors select Zettelkasten notes as tiny redirect stubs. Content lives in `Zettelkasten/`; the work-namespace subtree points to it so work-context queries still find the topic.
 
 ## Canonical Redirect Stub Format
 
 ```yaml
 ---
 tags: [redirect]
-context: fvh
+context: work
 ---
 See [[Zettelkasten/Docker|Docker]] in the main knowledge base.
 ```
@@ -34,7 +34,7 @@ Properties:
 - Size ≤ 200 bytes (whitespace excluded)
 - Tags is exactly `[redirect]`
 - Body is a single wikilink with alias to the canonical note
-- `context: fvh`
+- `context: work`
 
 ## Classifications (from vault-agent's stubs analyzer)
 
@@ -43,64 +43,64 @@ Properties:
 | `clean_redirect` | ≤ 200 B, `redirect` tag, Zettelkasten match | ✓ keep as-is |
 | `broken_redirect` | `redirect` tag but >200 B or missing target | Rewrite body to the canonical one-liner |
 | `stale_duplicate` | Full article, basename exists in Zettelkasten | Merge content into Zettelkasten, convert stub to `clean_redirect` |
-| `fvh_original` | Full article, no Zettelkasten match | Legitimate — leave alone |
+| `ns_original` | Full article, no Zettelkasten match | Legitimate — leave alone |
 
 ## Consolidation: stale_duplicate → clean_redirect
 
-When a `FVH/z/Foo.md` has substantive content AND `Zettelkasten/Foo.md` exists, you must decide:
+When a `work/z/Foo.md` has substantive content AND `Zettelkasten/Foo.md` exists, you must decide:
 
-1. **Is the FVH/z content a subset of Zettelkasten?** → Replace stub with canonical redirect. No content merge needed.
-2. **Does FVH/z have unique content?** → Merge the unique sections into `Zettelkasten/Foo.md` first, then replace stub.
-3. **Is FVH/z *better* than Zettelkasten?** → Rare, but flag for user review. The user decides which becomes canonical.
+1. **Is the work-namespace content a subset of Zettelkasten?** → Replace stub with canonical redirect. No content merge needed.
+2. **Does the work-namespace note have unique content?** → Merge the unique sections into `Zettelkasten/Foo.md` first, then replace stub.
+3. **Is the work-namespace note *better* than Zettelkasten?** → Rare, but flag for user review. The user decides which becomes canonical.
 
 ### Merge Heuristic
 
-Compare by section. If a heading in `FVH/z/Foo.md` has text that doesn't appear in `Zettelkasten/Foo.md`, that text needs migration. Use word-level comparison, not exact match — minor wording differences don't count as "unique content."
+Compare by section. If a heading in `work/z/Foo.md` has text that doesn't appear in `Zettelkasten/Foo.md`, that text needs migration. Use word-level comparison, not exact match — minor wording differences don't count as "unique content."
 
 When in doubt, **flag for user review** rather than auto-merging. A bad merge is worse than leaving a duplicate.
 
 ## Conversion Recipe
 
-Replace the whole FVH/z file body:
+Replace the whole work-namespace file body:
 
 ```yaml
 ---
 tags: [redirect]
-context: fvh
+context: work
 ---
 See [[Zettelkasten/Foo|Foo]] in the main knowledge base.
 ```
 
 Commit message:
 ```
-refactor(stubs): convert FVH/z/Foo.md to redirect (content merged into Zettelkasten)
+refactor(stubs): convert work/z/Foo.md to redirect (content merged into Zettelkasten)
 ```
 
-## Promoting fvh_original → Zettelkasten
+## Promoting ns_original → Zettelkasten
 
-Occasionally a file classified `fvh_original` is actually general-interest content that belongs in `Zettelkasten/`. Signs:
-- No FVH-specific references (ICT check-in, silverbucket, internal URLs)
+Occasionally a file classified `ns_original` is actually general-interest content that belongs in `Zettelkasten/`. Signs:
+- No work-specific references (internal check-ins, internal tools, internal URLs)
 - Could be useful in personal contexts
 
 If promoting:
 1. Move file to `Zettelkasten/Foo.md`
-2. Create a `FVH/z/Foo.md` redirect stub in its place
-3. Strip `context: fvh` from the promoted note's frontmatter
-4. Commit as `refactor(stubs): promote Foo from FVH/z to Zettelkasten`
+2. Create a `work/z/Foo.md` redirect stub in its place
+3. Strip `context: work` from the promoted note's frontmatter
+4. Commit as `refactor(stubs): promote Foo from work/z to Zettelkasten`
 
-Don't promote aggressively — the FVH namespace exists for a reason.
+Don't promote aggressively — the work namespace exists for a reason.
 
 ## Detection
 
 ```bash
-# All FVH/z files ordered by size
-fd -e md . FVH/z -x wc -c {} | sort -n
+# All work-namespace files ordered by size
+fd -e md . work/z -x wc -c {} | sort -n
 
 # Ones with `redirect` tag
-rg -l '^tags:.*\bredirect\b' FVH/z/ --glob '*.md'
+rg -l '^tags:.*\bredirect\b' work/z/ --glob '*.md'
 
 # Large ones without `redirect` tag (candidates for conversion)
-rg -L -l '^tags:.*\bredirect\b' FVH/z/ --glob '*.md'
+rg -L -l '^tags:.*\bredirect\b' work/z/ --glob '*.md'
 ```
 
 Vault-agent's `analyze_stubs` gives the full classification.
@@ -108,8 +108,8 @@ Vault-agent's `analyze_stubs` gives the full classification.
 ## Safety
 
 - Never delete content without verifying it exists elsewhere. When merging, grep the destination note for a canonical phrase from the source.
-- Preserve `context: fvh` on stubs (required for FVH namespace queries).
-- Don't create stubs for Zettelkasten notes that aren't actually used in FVH context — that creates noise, not redirection.
+- Preserve `context: work` on stubs (required for work-namespace queries).
+- Don't create stubs for Zettelkasten notes that aren't actually used in work context — that creates noise, not redirection.
 
 ## Related Skills
 

--- a/obsidian-plugin/skills/vault-templates/SKILL.md
+++ b/obsidian-plugin/skills/vault-templates/SKILL.md
@@ -61,7 +61,7 @@ Use `Edit` with `old_string='\n\n<% tp.file.cursor(1) %>'` and `new_string=''` (
 
 ## Fixing `{{title}}` in daily notes
 
-Before (file `FVH/notes/2025-03-26.md`):
+Before (file `work/notes/2025-03-26.md`):
 ```markdown
 # {{title}}
 
@@ -86,7 +86,7 @@ The templates themselves live in `Templates/` and should contain raw Templater s
 | `Daily.md` | `Notes/YYYY-MM-DD.md` | Quick Links, Today's Focus, Work, Personal, Tomorrow's Prep, Navigation |
 | `MOC.md` | `Zettelkasten/{Subject} MOC.md` | Title heading + sections |
 | `New.md` | general Zettelkasten notes | Frontmatter + body stub |
-| `FVH Daily.md` | `FVH/notes/YYYY-MM-DD.md` | Log, Thoughts, Discoveries, Todo, Recurring reminders |
+| `Work Daily.md` | `work/notes/YYYY-MM-DD.md` | Log, Thoughts, Discoveries, Todo, Recurring reminders |
 
 ## Daily Note Structure Drift
 
@@ -97,9 +97,9 @@ Personal daily notes created before 2025 usually lack `## Navigation` and `## To
 
 Default to #2 unless the user specifically asks for retrofit.
 
-## FVH Daily Note Drift
+## Work Daily Note Drift
 
-7 FVH daily notes contain literal `{{title}}` in the heading — fix these.
+Work-namespace daily notes that contain literal `{{title}}` in the heading — fix these.
 
 ## Safety
 

--- a/obsidian-plugin/skills/vault-wikilinks/SKILL.md
+++ b/obsidian-plugin/skills/vault-wikilinks/SKILL.md
@@ -3,7 +3,7 @@ created: 2026-04-17
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: vault-wikilinks
-description: "Broken Obsidian wikilink detection and repair. Use when fixing `[[Target]]` links, rewriting renamed-note refs, or resolving Zettelkasten/FVH paths."
+description: "Broken Obsidian wikilink detection and repair. Use when fixing `[[Target]]` links, rewriting renamed-note refs, or resolving Zettelkasten/work-namespace paths."
 user-invocable: false
 allowed-tools: Read, Edit, Grep, Glob
 ---
@@ -15,7 +15,7 @@ allowed-tools: Read, Edit, Grep, Glob
 | Use this skill when... | Use the alternative instead when... |
 |---|---|
 | Repairing broken `[[Target]]` wikilinks after a note rename or move | Discovering which links Obsidian flags as unresolved in the first place — use `search-discovery` |
-| Resolving cross-namespace ambiguity between `Zettelkasten/` and `FVH/z/` notes | Reorganising or merging the FVH/z stub itself — use `vault-stubs` |
+| Resolving cross-namespace ambiguity between `Zettelkasten/` and `work/z/` notes | Reorganising or merging the work-namespace stub itself — use `vault-stubs` |
 | Unqualifying path-prefixed `[[Kanban/X]]` links to bare basenames | Reconnecting orphan notes that have no links at all — use `vault-orphans` |
 
 Obsidian resolves `[[Target]]` by looking for a note whose basename is `Target.md` anywhere in the vault. Links break silently when a note is renamed, moved, or was never created. Ambiguity arises when two notes share a basename.
@@ -32,7 +32,7 @@ Obsidian resolves `[[Target]]` by looking for a note whose basename is `Target.m
 
 ## Resolution Rules
 
-1. **Unqualified target** (`[[Docker]]`) resolves to any note with basename `Docker.md`. If two exist (e.g. `Zettelkasten/Docker.md` and `FVH/z/Docker.md`), Obsidian picks one non-deterministically — ambiguous.
+1. **Unqualified target** (`[[Docker]]`) resolves to any note with basename `Docker.md`. If two exist (e.g. `Zettelkasten/Docker.md` and `work/z/Docker.md`), Obsidian picks one non-deterministically — ambiguous.
 2. **Path-qualified target** (`[[Kanban/Main]]`) resolves to `Kanban/Main.md` exactly — no basename fallback.
 3. **Embeds** (`![[X]]`) follow the same resolution. Image embeds typically target files under `Files/`.
 
@@ -40,7 +40,7 @@ Obsidian resolves `[[Target]]` by looking for a note whose basename is `Target.m
 
 | Pattern | Fix |
 |---------|-----|
-| `[[AnsibleFVH]]` × many → note doesn't exist | Rewrite to `[[Ansible]]` (the actual note) |
+| `[[OldTopic]]` × many → note doesn't exist | Rewrite to `[[Topic]]` (the actual note) |
 | `[[Development MOC]]` → note was renamed | Rewrite to `[[Development Workflows and Tools MOC]]` |
 | `[[Kanban/X]]` → works but path-qualified is brittle | Rewrite to `[[X]]` when basename is unique |
 | `[[code]]`, `[[project]]` → never were real notes | These were inline-tag syntax errors; delete the link and leave plain text |
@@ -48,13 +48,13 @@ Obsidian resolves `[[Target]]` by looking for a note whose basename is `Target.m
 
 ## Cross-Namespace Ambiguity
 
-When two notes share a basename (e.g. `Docker.md` in both `Zettelkasten/` and `FVH/z/`), every `[[Docker]]` in the vault becomes ambiguous. Options:
+When two notes share a basename (e.g. `Docker.md` in both `Zettelkasten/` and `work/z/`), every `[[Docker]]` in the vault becomes ambiguous. Options:
 
-1. **Rename one** so they stop colliding (`FVH/z/Docker.md` → keep as redirect stub; content lives in `Zettelkasten/Docker.md`).
-2. **Path-qualify the links** that should resolve to the non-canonical copy: `[[FVH/z/Docker]]`.
+1. **Rename one** so they stop colliding (`work/z/Docker.md` → keep as redirect stub; content lives in `Zettelkasten/Docker.md`).
+2. **Path-qualify the links** that should resolve to the non-canonical copy: `[[work/z/Docker]]`.
 3. **Never use bare `[[Docker]]`** going forward; always path-qualify.
 
-The preferred pattern is #1: keep canonical content in `Zettelkasten/`, make `FVH/z/` a tiny redirect stub.
+The preferred pattern is #1: keep canonical content in `Zettelkasten/`, make `work/z/` a tiny redirect stub.
 
 ## Detection
 
@@ -75,7 +75,7 @@ A more accurate scan uses the `links.analyze_links` analyzer in vault-agent, whi
 For a known-broken target with many references, rewrite in one commit:
 
 ```
-fix(links): rewrite 44 × [[AnsibleFVH]] → [[Ansible]]
+fix(links): rewrite 44 × [[OldTopic]] → [[Topic]]
 ```
 
 Use `Edit` with `replace_all=True` for the target string within each note. Don't use shell `sed` — it doesn't handle the frontmatter / codeblock boundary correctly, and Edit's per-file atomicity makes the commit review straightforward.
@@ -89,7 +89,7 @@ Never auto-rewrite an ambiguous link. Report the ambiguity with both candidates 
 ```
 [[Docker]] in Zettelkasten/Kubernetes.md → candidates:
   a) Zettelkasten/Docker.md
-  b) FVH/z/Docker.md (redirect stub)
+  b) work/z/Docker.md (redirect stub)
 ```
 
 ## Safety

--- a/session-plugin/skills/session-spinup/REFERENCE.md
+++ b/session-plugin/skills/session-spinup/REFERENCE.md
@@ -50,7 +50,7 @@ terminal-only view can't see.
 ## Example briefing
 
 ```
-Spin-up — project: fvh.cost-attribution (cwd: repos/ForumViriumHelsinki/infrastructure)
+Spin-up — project: work.cost-attribution (cwd: repos/<org>/infrastructure)
 
   taskwarrior (3 pending)
     +ACTIVE  #237 "Cluster fallback rules"

--- a/session-plugin/skills/session-wrap/REFERENCE.md
+++ b/session-plugin/skills/session-wrap/REFERENCE.md
@@ -28,36 +28,36 @@ Markdown body sections the skills read as context:
 - **Project naming map** — context → `project:` slug table so wraps land
   under consistent taskwarrior projects.
 
-### Worked example (FVH/Obsidian user config)
+### Worked example (Obsidian journal config)
 
 ```markdown
 ---
 journal: obsidian
-journal_path: ~/Documents/LakuVault/FVH/notes
-journal_template: ~/Documents/LakuVault/Templates/FVH Daily.md
+journal_path: ~/Documents/YourVault/Journal/notes
+journal_template: ~/Documents/YourVault/Templates/Daily.md
 journal_log_heading: "## Log"
 journal_todo_heading: "## Todo"
 journal_todo_stop: "### Recurring reminders"
-journal_scopes: [fvh, infrastructure]
+journal_scopes: [work, infrastructure]
 ---
 
 # Scope detection
 
 The session is in journal scope if ANY of: the taskwarrior project is
-`fvh.*` or `infrastructure*`; the cwd contains `ForumViriumHelsinki` or
-`repos/ForumVirium`; the user says so ("this is FVH work"); the
-conversation references FVH repos, Podio items, Hetzner, GKE, fvh.fi.
-Default to out-of-scope when in doubt.
+`work.*` or `infrastructure*`; the cwd contains the work-org directory
+(e.g. `repos/<org>`); the user says so ("this is work"); the
+conversation references work repos, ticket items, or internal
+infrastructure. Default to out-of-scope when in doubt.
 
 # Project naming map
 
 | Context | project: |
 |---|---|
-| FVH infrastructure work | `fvh.<area>` (e.g. `fvh.cost-attribution`) |
-| FVH simpl-eval | `infrastructure.simpl-eval` |
+| Work infrastructure | `work.<area>` (e.g. `work.cost-attribution`) |
+| A work sub-project | `infrastructure.<name>` |
 | claude-plugins work | `claude-plugins`, `claude-plugins.friction` |
 | Dotfiles / chezmoi | `dotfiles` |
-| Immeral D&D vault | `immeral` |
+| Personal vault | `immeral` |
 ```
 
 ## Journal append mechanics

--- a/vault-agent/README.md
+++ b/vault-agent/README.md
@@ -63,10 +63,43 @@ Skill prompts live in [`../obsidian-plugin/skills/vault-*`](../obsidian-plugin/s
 | `health` | 0–100 health score | No |
 | `report` | Formatted audit | No |
 | `lint` | Bare 📝/🌱 tags, legacy `id:`, Templater leakage, `🗺️ → 📝/moc`, null tags | No |
-| `links` | Rule-table rewrites (e.g. `[[AnsibleFVH]] → [[Ansible]]`), `[[Kanban/X]] → [[X]]` | No |
+| `links` | Rule-table rewrites (e.g. `[[OldTopic]] → [[Topic]]`), `[[Kanban/X]] → [[X]]` | No |
 | `stubs` | Rewrite `broken_redirect` stubs; report `stale_duplicate` for user review | Partially — merging requires LLM |
 | `mocs` | Inventory, coverage, missing-MOC candidates | Proposing new MOCs requires LLM |
 | `maintain` | Runs all deterministic modes in one worktree | No for deterministic path |
+
+## Configuration
+
+vault-agent ships generic defaults that work on any Obsidian vault. A vault
+that uses a dedicated "work" namespace subtree, a custom daily-notes layout, or
+a known broken-link rewrite table can override the defaults with a
+`.vault-agent.toml` file in the vault root (or the path named by
+`$VAULT_AGENT_CONFIG`):
+
+```toml
+[vault]
+# Subtree holding redirect stubs (default ["work", "z"] → work/z/)
+work_namespace = ["work", "z"]
+# Frontmatter `context:` value required on work-namespace notes (default "work")
+context_value = "work"
+# Directories whose notes are daily notes — few backlinks expected
+# (default [["Notes"], ["work", "notes"]])
+daily_dirs = [["Notes"], ["work", "notes"]]
+
+# Broken-wikilink rewrite table: old target → canonical target (default empty)
+[vault.broken_link_rewrites]
+OldTopic = "Topic"
+```
+
+| Key | Controls | Default |
+|-----|----------|---------|
+| `work_namespace` | Stub-subtree dir classified by the `stubs` mode | `["work", "z"]` |
+| `context_value` | `context:` value the `lint`/audit expects on namespace notes | `"work"` |
+| `daily_dirs` | Dirs treated as daily notes (expected orphans) | `["Notes"], ["work", "notes"]` |
+| `broken_link_rewrites` | Rule-table rewrites applied by the `links` mode | `{}` (empty) |
+
+Omitted keys keep their default, so a partial config is fine. Without a config
+file, every value falls back to the generic defaults above.
 
 ## Subagent tiers
 
@@ -110,7 +143,7 @@ uv run pytest
 Full audit against a real vault:
 
 ```bash
-uv run vault-agent analyze ~/Documents/LakuVault
+uv run vault-agent analyze ~/Documents/YourVault
 ```
 
 ## Status

--- a/vault-agent/docs/adr/0002-worktree-without-pr.md
+++ b/vault-agent/docs/adr/0002-worktree-without-pr.md
@@ -5,7 +5,7 @@
 
 ## Context
 
-The target vault (LakuVault) is an Obsidian vault that the user actively edits in the Obsidian desktop app. The vault IS a git repository, but there is no remote. We still want:
+The target vault is an Obsidian vault that the user actively edits in the Obsidian desktop app. The vault IS a git repository, but there is no remote. We still want:
 
 - Diff visibility when the agent mass-edits hundreds of files
 - Cheap rollback if the agent misbehaves

--- a/vault-agent/docs/adr/0003-model-tier-per-mode.md
+++ b/vault-agent/docs/adr/0003-model-tier-per-mode.md
@@ -8,7 +8,7 @@
 Vault maintenance has a wide complexity spectrum:
 
 - Stripping `id:` from frontmatter is mechanical — any model size works.
-- Classifying a FVH/z stub as "redirect vs. promote" requires reading two full notes and judging overlap.
+- Classifying a work-namespace stub as "redirect vs. promote" requires reading two full notes and judging overlap.
 - Proposing a new MOC with curated section structure over 17 orphaned notes requires holding the whole cluster in context and recognizing natural groupings.
 
 Using one model tier for everything means overpaying on the easy cases or underperforming on the hard ones.

--- a/vault-agent/src/vault_agent/agents/vault_links.py
+++ b/vault-agent/src/vault_agent/agents/vault_links.py
@@ -12,7 +12,7 @@ except ImportError:  # pragma: no cover
 
 _DESCRIPTION = (
     "Repair broken wikilinks. Applies rule-table rewrites (e.g. "
-    "[[AnsibleFVH]] → [[Ansible]]), unqualifies [[Kanban/X]] → [[X]], "
+    "[[OldTopic]] → [[Topic]]), unqualifies [[Kanban/X]] → [[X]], "
     "and reports cross-namespace ambiguous targets for user decision."
 )
 

--- a/vault-agent/src/vault_agent/agents/vault_stubs.py
+++ b/vault-agent/src/vault_agent/agents/vault_stubs.py
@@ -1,4 +1,4 @@
-"""vault-stubs subagent — FVH/z redirect stub consolidation."""
+"""vault-stubs subagent — work-namespace redirect stub consolidation."""
 
 from __future__ import annotations
 
@@ -11,8 +11,8 @@ except ImportError:  # pragma: no cover
 
 
 _DESCRIPTION = (
-    "Classify FVH/z/ files (clean_redirect / broken_redirect / "
-    "stale_duplicate / fvh_original) and consolidate stale duplicates "
+    "Classify work-namespace files (clean_redirect / broken_redirect / "
+    "stale_duplicate / ns_original) and consolidate stale duplicates "
     "into redirect stubs pointing to Zettelkasten canonical notes, "
     "merging unique content first."
 )

--- a/vault-agent/src/vault_agent/analyzers/audit.py
+++ b/vault-agent/src/vault_agent/analyzers/audit.py
@@ -13,6 +13,7 @@ from vault_agent.analyzers.links import LinkReport, analyze_links
 from vault_agent.analyzers.mocs import MocReport, analyze_mocs
 from vault_agent.analyzers.stubs import StubReport, analyze_stubs
 from vault_agent.analyzers.vault_index import VaultIndex, scan
+from vault_agent.config import VaultConfig, load_config
 
 
 @dataclass
@@ -26,6 +27,7 @@ class VaultAudit:
     mocs: MocReport
     duplicates: DuplicateReport
     health: HealthScore
+    config: VaultConfig
 
     def to_dict(self) -> dict:
         return {
@@ -41,12 +43,16 @@ class VaultAudit:
         }
 
 
-def run_audit(vault_root: Path | str) -> VaultAudit:
+def run_audit(
+    vault_root: Path | str, config: VaultConfig | None = None
+) -> VaultAudit:
+    if config is None:
+        config = load_config(vault_root)
     index = scan(vault_root)
-    fm = analyze_frontmatter(index)
+    fm = analyze_frontmatter(index, config)
     lnk = analyze_links(index)
-    graph = analyze_graph(index)
-    stubs = analyze_stubs(index)
+    graph = analyze_graph(index, config=config)
+    stubs = analyze_stubs(index, config)
     mocs = analyze_mocs(index)
     dups = analyze_duplicates(index)
     health = compute_health(
@@ -62,4 +68,5 @@ def run_audit(vault_root: Path | str) -> VaultAudit:
         mocs=mocs,
         duplicates=dups,
         health=health,
+        config=config,
     )

--- a/vault-agent/src/vault_agent/analyzers/duplicates.py
+++ b/vault-agent/src/vault_agent/analyzers/duplicates.py
@@ -1,7 +1,7 @@
 """Duplicate-note detector.
 
   * Same basename in multiple paths (e.g. ``Zettelkasten/Docker.md`` and
-    ``FVH/z/Docker.md``). Some are legitimate redirect stubs — the stubs
+    ``work/z/Docker.md``). Some are legitimate redirect stubs — the stubs
     analyzer classifies those separately. This one emits the raw list.
   * ``Untitled``, ``Untitled 1``, ``Untitled 2`` style placeholders.
 """

--- a/vault-agent/src/vault_agent/analyzers/frontmatter.py
+++ b/vault-agent/src/vault_agent/analyzers/frontmatter.py
@@ -1,6 +1,6 @@
 """Frontmatter & tag analyzers.
 
-Detects the pain points found by the LakuVault audit:
+Detects the pain points found by an Obsidian vault audit:
   * bare placeholder tags (``📝``, ``🌱``, ``📝/🌱``)
   * legacy ``id:`` fields
   * ``null`` tag values
@@ -8,7 +8,7 @@ Detects the pain points found by the LakuVault audit:
   * over/under-tagging
   * taxonomy duplicates (e.g. ``🔍/security`` vs ``🔒/security``)
   * Templater leakage (``<% tp.file.cursor(1) %>``, ``{{title}}``)
-  * FVH notes missing ``context: fvh``
+  * work-namespace notes missing ``context: <value>``
   * corrupted emoji bytes (``\\ufffd``)
 """
 
@@ -18,6 +18,7 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from vault_agent.config import DEFAULT_CONFIG, VaultConfig
 from vault_agent.analyzers.vault_index import Note, VaultIndex
 
 # Tag value treated as a no-op placeholder when it appears alone (no /subcategory).
@@ -63,7 +64,7 @@ class FrontmatterReport:
     notes_over_tagged: list[Path] = field(default_factory=list)  # > 5 tags
     notes_with_templater_leak: list[Path] = field(default_factory=list)
     notes_with_corrupt_emoji: list[Path] = field(default_factory=list)
-    fvh_notes_missing_context: list[Path] = field(default_factory=list)
+    ns_notes_missing_context: list[Path] = field(default_factory=list)
     # Tag string → count of notes using it (across whole vault)
     tag_frequency: dict[str, int] = field(default_factory=dict)
     # Candidate duplicate tag groups: canonical → variants
@@ -86,17 +87,17 @@ class FrontmatterReport:
             "notes_with_corrupt_emoji": [
                 str(p) for p in self.notes_with_corrupt_emoji
             ],
-            "fvh_notes_missing_context": [
-                str(p) for p in self.fvh_notes_missing_context
+            "ns_notes_missing_context": [
+                str(p) for p in self.ns_notes_missing_context
             ],
             "tag_frequency": self.tag_frequency,
             "tag_duplicate_candidates": self.tag_duplicate_candidates,
         }
 
 
-def _is_fvh_note(note: Note) -> bool:
-    """A note lives under FVH/ if its relative path starts with that segment."""
-    return note.rel_path.parts and note.rel_path.parts[0] == "FVH"
+def _is_work_ns_note(note: Note, config: VaultConfig) -> bool:
+    """A note lives in the work namespace if its first path part is the namespace root."""
+    return bool(note.rel_path.parts) and note.rel_path.parts[0] == config.namespace_root
 
 
 def _normalize_for_dupe_detection(tag: str) -> str:
@@ -109,7 +110,9 @@ def _normalize_for_dupe_detection(tag: str) -> str:
     return lower
 
 
-def analyze_frontmatter(index: VaultIndex) -> FrontmatterReport:
+def analyze_frontmatter(
+    index: VaultIndex, config: VaultConfig = DEFAULT_CONFIG
+) -> FrontmatterReport:
     """Run every frontmatter/tag check over the index in one pass."""
     report = FrontmatterReport(total_notes=len(index.notes))
     dupe_groups: dict[str, set[str]] = {}
@@ -125,9 +128,9 @@ def analyze_frontmatter(index: VaultIndex) -> FrontmatterReport:
         if "id" in fm:
             report.notes_with_legacy_id.append(note.path)
 
-        # FVH notes: require context: fvh
-        if _is_fvh_note(note) and fm.get("context") != "fvh":
-            report.fvh_notes_missing_context.append(note.path)
+        # Work-namespace notes: require the configured context value.
+        if _is_work_ns_note(note, config) and fm.get("context") != config.context_value:
+            report.ns_notes_missing_context.append(note.path)
 
         # Tags
         tags = note.tags

--- a/vault-agent/src/vault_agent/analyzers/graph.py
+++ b/vault-agent/src/vault_agent/analyzers/graph.py
@@ -1,8 +1,9 @@
 """Knowledge-graph analyzer: orphans, hubs, incoming-link counts.
 
 "Orphan" = note with zero incoming wikilinks AND zero outgoing wikilinks.
-Daily notes (files under ``Notes/`` or ``FVH/notes/``) and inbox files
-are listed separately because they are expected to have few links.
+Daily notes (files under the configured daily-note dirs, e.g. ``Notes/``
+or ``work/notes/``) and inbox files are listed separately because they
+are expected to have few links.
 """
 
 from __future__ import annotations
@@ -11,6 +12,7 @@ from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from vault_agent.config import DEFAULT_CONFIG, VaultConfig
 from vault_agent.analyzers.vault_index import Note, VaultIndex
 
 # Top-level directories whose notes are expected to be weakly connected.
@@ -19,15 +21,9 @@ _EXPECTED_ORPHAN_DIRS: frozenset[str] = frozenset(
     {"Inbox", "Notes", "truecharts-migration", "radio-hacking"}
 )
 
-# Daily-note directories (expected to have few backlinks).
-_DAILY_DIRS: tuple[tuple[str, ...], ...] = (
-    ("Notes",),
-    ("FVH", "notes"),
-)
 
-
-def _is_daily_note(note: Note) -> bool:
-    for prefix in _DAILY_DIRS:
+def _is_daily_note(note: Note, config: VaultConfig) -> bool:
+    for prefix in config.daily_dirs:
         if note.rel_path.parts[: len(prefix)] == prefix:
             return True
     return False
@@ -59,7 +55,9 @@ class GraphReport:
         }
 
 
-def analyze_graph(index: VaultIndex, *, hub_limit: int = 20) -> GraphReport:
+def analyze_graph(
+    index: VaultIndex, *, hub_limit: int = 20, config: VaultConfig = DEFAULT_CONFIG
+) -> GraphReport:
     # Incoming counts via resolved targets.
     incoming = Counter()
     for note in index.notes:
@@ -74,7 +72,7 @@ def analyze_graph(index: VaultIndex, *, hub_limit: int = 20) -> GraphReport:
         has_incoming = incoming.get(note.path, 0) > 0
         has_outgoing = len(note.wikilinks) > 0
         if not has_incoming and not has_outgoing:
-            if _is_expected_orphan(note) or _is_daily_note(note):
+            if _is_expected_orphan(note) or _is_daily_note(note, config):
                 report.expected_orphans.append(note.path)
             else:
                 report.meaningful_orphans.append(note.path)

--- a/vault-agent/src/vault_agent/analyzers/health.py
+++ b/vault-agent/src/vault_agent/analyzers/health.py
@@ -5,7 +5,7 @@ Five equally-weighted sub-scores (each 0–20):
   * tags        — % of notes with clean tags (no bare placeholder, no legacy id:)
   * links       — 1 − (broken_links / total_links)
   * orphans     — 1 − (meaningful_orphans / total_meaningful_notes)
-  * stubs       — % of FVH/z files classified as CLEAN_REDIRECT or FVH_ORIGINAL
+  * stubs       — % of work-namespace files classified as CLEAN_REDIRECT or NS_ORIGINAL
   * mocs        — 1 − (unlinked_category_notes / total_category_notes)
 
 Missing sub-scores contribute 0. An empty vault (0 notes) scores 100.
@@ -62,7 +62,7 @@ def compute_health(
     link_score = _ratio_score(links.broken_count, links.total_wikilinks)
     orphan_score = _ratio_score(len(graph.meaningful_orphans), total_notes)
 
-    # Stubs: CLEAN_REDIRECT or FVH_ORIGINAL are "good". BROKEN_REDIRECT and
+    # Stubs: CLEAN_REDIRECT or NS_ORIGINAL are "good". BROKEN_REDIRECT and
     # STALE_DUPLICATE count against the score.
     bad_stubs = sum(
         1

--- a/vault-agent/src/vault_agent/analyzers/links.py
+++ b/vault-agent/src/vault_agent/analyzers/links.py
@@ -3,7 +3,7 @@
 Detects:
   * broken wikilinks (target has no matching ``.md`` anywhere)
   * ambiguous targets (same basename in multiple paths, e.g.
-    ``Zettelkasten/Docker.md`` and ``FVH/z/Docker.md``)
+    ``Zettelkasten/Docker.md`` and ``work/z/Docker.md``)
   * path-qualified links that happen to resolve (e.g. ``[[Kanban/X]]``
     — obsidian resolves these, but they are an anti-pattern in this
     vault because Kanban boards also appear by basename)

--- a/vault-agent/src/vault_agent/analyzers/stubs.py
+++ b/vault-agent/src/vault_agent/analyzers/stubs.py
@@ -1,12 +1,14 @@
-"""FVH/z redirect-stub classifier.
+"""Work-namespace redirect-stub classifier.
 
-Convention: ``FVH/z/Foo.md`` is a redirect stub pointing to
+Convention: ``work/z/Foo.md`` is a redirect stub pointing to
 ``Zettelkasten/Foo.md``. Proper stubs are tiny (<200 bytes), tagged
 ``redirect``, and contain only ``See [[Zettelkasten/Foo|Foo]] in the
 main knowledge base.``
 
-Stale stubs: files under ``FVH/z/`` that were never converted — they
-contain full article content and duplicate what's in Zettelkasten.
+Stale stubs: files under the work namespace (``work/z/`` by default)
+that were never converted — they contain full article content and
+duplicate what's in Zettelkasten. The namespace subtree is configurable
+via :class:`vault_agent.config.VaultConfig`.
 """
 
 from __future__ import annotations
@@ -15,22 +17,22 @@ from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 
+from vault_agent.config import DEFAULT_CONFIG, VaultConfig
 from vault_agent.analyzers.vault_index import Note, VaultIndex
 
-_FVH_STUB_DIR: tuple[str, ...] = ("FVH", "z")
 _CLEAN_STUB_MAX_BYTES = 200
 
 
 class StubClass(str, Enum):
-    """Classification of a FVH/z file."""
+    """Classification of a work-namespace file."""
 
     CLEAN_REDIRECT = "clean_redirect"
     # Has redirect tag but body is suspiciously large, or missing zettelkasten target
     BROKEN_REDIRECT = "broken_redirect"
     # Stale full article; no redirect tag; basename exists in Zettelkasten
     STALE_DUPLICATE = "stale_duplicate"
-    # Original FVH/z content with no canonical version elsewhere
-    FVH_ORIGINAL = "fvh_original"
+    # Original namespace content with no canonical version elsewhere
+    NS_ORIGINAL = "ns_original"
 
 
 @dataclass
@@ -68,8 +70,9 @@ class StubReport:
         }
 
 
-def _is_fvh_z(note: Note) -> bool:
-    return note.rel_path.parts[: len(_FVH_STUB_DIR)] == _FVH_STUB_DIR
+def _is_work_ns(note: Note, config: VaultConfig) -> bool:
+    ns = config.work_namespace
+    return note.rel_path.parts[: len(ns)] == ns
 
 
 def _has_redirect_tag(note: Note) -> bool:
@@ -83,11 +86,13 @@ def _canonical_in_zettelkasten(index: VaultIndex, basename: str) -> Path | None:
     return None
 
 
-def analyze_stubs(index: VaultIndex) -> StubReport:
+def analyze_stubs(
+    index: VaultIndex, config: VaultConfig = DEFAULT_CONFIG
+) -> StubReport:
     report = StubReport()
 
     for note in index.notes:
-        if not _is_fvh_z(note):
+        if not _is_work_ns(note, config):
             continue
         report.total_stubs += 1
         canonical = _canonical_in_zettelkasten(index, note.basename)
@@ -101,7 +106,7 @@ def analyze_stubs(index: VaultIndex) -> StubReport:
             if canonical is not None:
                 cls = StubClass.STALE_DUPLICATE
             else:
-                cls = StubClass.FVH_ORIGINAL
+                cls = StubClass.NS_ORIGINAL
 
         report.classifications.append(
             StubClassification(

--- a/vault-agent/src/vault_agent/config.py
+++ b/vault-agent/src/vault_agent/config.py
@@ -1,0 +1,95 @@
+"""Vault layout conventions — overridable, with generic defaults.
+
+A small bundle of the vault-specific conventions the analyzers and fixers
+depend on. The defaults work on any Obsidian vault; a vault that uses a
+work-namespace subtree, a custom daily-notes layout, or a known
+broken-link rewrite table can override them.
+
+Override mechanism: a ``.vault-agent.toml`` file in the vault root (or the
+path named by ``$VAULT_AGENT_CONFIG``). Example::
+
+    [vault]
+    work_namespace = ["work", "z"]
+    context_value = "work"
+    daily_dirs = [["Notes"], ["work", "notes"]]
+
+    [vault.broken_link_rewrites]
+    OldTopic = "Topic"
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_CONFIG_FILENAME = ".vault-agent.toml"
+
+
+@dataclass(frozen=True)
+class VaultConfig:
+    """Vault conventions threaded into the analyzers and fixers."""
+
+    # Work-namespace subtree holding redirect stubs (e.g. ``work/z``).
+    work_namespace: tuple[str, ...] = ("work", "z")
+    # Frontmatter ``context:`` value required on work-namespace notes.
+    context_value: str = "work"
+    # Directories whose notes are daily notes (few backlinks expected).
+    daily_dirs: tuple[tuple[str, ...], ...] = (("Notes",), ("work", "notes"))
+    # Broken-wikilink rewrite table: old target → canonical target.
+    broken_link_rewrites: Mapping[str, str] = field(default_factory=dict)
+
+    @property
+    def namespace_root(self) -> str:
+        """First path part of the work namespace (e.g. ``work``)."""
+        return self.work_namespace[0] if self.work_namespace else ""
+
+
+DEFAULT_CONFIG = VaultConfig()
+
+
+def _config_path(vault_root: Path | str | None) -> Path | None:
+    """Resolve the config-file path from ``$VAULT_AGENT_CONFIG`` or the vault root."""
+    env = os.environ.get("VAULT_AGENT_CONFIG")
+    if env:
+        return Path(env).expanduser()
+    if vault_root is None:
+        return None
+    return Path(vault_root).expanduser() / _CONFIG_FILENAME
+
+
+def _from_mapping(data: Mapping[str, object]) -> VaultConfig:
+    """Build a :class:`VaultConfig` from a parsed TOML mapping.
+
+    Accepts either a top-level mapping or one nested under a ``[vault]``
+    table. Unknown keys are ignored; omitted keys keep their default.
+    """
+    vault = data.get("vault", data)
+    if not isinstance(vault, Mapping):
+        vault = data
+    kwargs: dict[str, object] = {}
+    if "work_namespace" in vault:
+        kwargs["work_namespace"] = tuple(vault["work_namespace"])
+    if "context_value" in vault:
+        kwargs["context_value"] = str(vault["context_value"])
+    if "daily_dirs" in vault:
+        kwargs["daily_dirs"] = tuple(tuple(d) for d in vault["daily_dirs"])
+    if "broken_link_rewrites" in vault:
+        kwargs["broken_link_rewrites"] = dict(vault["broken_link_rewrites"])
+    return VaultConfig(**kwargs)  # type: ignore[arg-type]
+
+
+def load_config(vault_root: Path | str | None = None) -> VaultConfig:
+    """Load vault conventions from a config file, or return generic defaults.
+
+    Looks for ``$VAULT_AGENT_CONFIG`` first, then ``.vault-agent.toml`` in
+    ``vault_root``. Returns :data:`DEFAULT_CONFIG` when no file is found.
+    """
+    path = _config_path(vault_root)
+    if path is None or not path.is_file():
+        return DEFAULT_CONFIG
+    with path.open("rb") as fh:
+        data = tomllib.load(fh)
+    return _from_mapping(data)

--- a/vault-agent/src/vault_agent/fixers/link_patcher.py
+++ b/vault-agent/src/vault_agent/fixers/link_patcher.py
@@ -31,21 +31,17 @@ from __future__ import annotations
 
 import difflib
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 
 from vault_agent.analyzers.vault_index import VaultIndex
 
-# Rule table: broken target → canonical target.
-# Sourced from the LakuVault audit; extend as new patterns emerge.
-BROKEN_LINK_REWRITES: dict[str, str] = {
-    # Top broken target in LakuVault — 44 references
-    "AnsibleFVH": "Ansible",
-    # Renamed MOC
-    "Development MOC": "Development Workflows and Tools MOC",
-    "Development Workflows": "Development Workflows and Tools MOC",
-}
+# Rule table: broken target → canonical target (e.g. ``{"OldTopic": "Topic"}``).
+# Empty by default — populate it per vault via ``VaultConfig.broken_link_rewrites``
+# (see ``vault_agent.config``) as known-broken patterns emerge from an audit.
+BROKEN_LINK_REWRITES: dict[str, str] = {}
 
 
 @dataclass
@@ -300,19 +296,23 @@ def propose_rewrites(
     index: VaultIndex,
     *,
     min_references: int = 3,
+    rewrites: Mapping[str, str] | None = None,
 ) -> list[RewriteProposal]:
     """Compute per-target :class:`RewriteProposal`s for LLM-tier triage.
 
     ``audit_broken`` is the ``(target, reference_count)`` list from
     ``VaultAudit.links.top_broken(...)``. We filter to targets with at
     least ``min_references`` references (per #1073's threshold) and
-    compute candidates + tier for each.
+    compute candidates + tier for each. Targets already covered by the
+    rule table (``rewrites``, defaulting to :data:`BROKEN_LINK_REWRITES`)
+    are skipped.
     """
+    table = rewrites if rewrites is not None else BROKEN_LINK_REWRITES
     proposals: list[RewriteProposal] = []
     for target, count in audit_broken:
         if count < min_references:
             continue
-        if target in BROKEN_LINK_REWRITES:
+        if target in table:
             continue  # rule table covers this; skip LLM pass
         candidates = fuzzy_basename_candidates(target, index)
         tier = classify_match(target, candidates)

--- a/vault-agent/src/vault_agent/fixers/stub_rewriter.py
+++ b/vault-agent/src/vault_agent/fixers/stub_rewriter.py
@@ -1,4 +1,4 @@
-"""Rewrite FVH/z stubs to the canonical redirect-body shape.
+"""Rewrite work-namespace stubs to the canonical redirect-body shape.
 
 Deterministic functions in this module:
 
@@ -32,11 +32,12 @@ from pathlib import Path
 
 from vault_agent.analyzers.stubs import StubClass, analyze_stubs
 from vault_agent.analyzers.vault_index import VaultIndex
+from vault_agent.config import DEFAULT_CONFIG, VaultConfig
 
 
 CANONICAL_REDIRECT_TEMPLATE = """---
 tags: [redirect]
-context: fvh
+context: {context}
 ---
 See [[Zettelkasten/{basename}|{basename}]] in the main knowledge base.
 """
@@ -166,9 +167,11 @@ class StubRewriteResult:
     previous_size: int
 
 
-def rewrite_broken_redirects(index: VaultIndex) -> list[StubRewriteResult]:
+def rewrite_broken_redirects(
+    index: VaultIndex, config: VaultConfig = DEFAULT_CONFIG
+) -> list[StubRewriteResult]:
     """Rewrite ``broken_redirect`` files to canonical redirect shape."""
-    report = analyze_stubs(index)
+    report = analyze_stubs(index, config)
     results: list[StubRewriteResult] = []
     for cls in report.classifications:
         if cls.cls != StubClass.BROKEN_REDIRECT:
@@ -179,7 +182,9 @@ def rewrite_broken_redirects(index: VaultIndex) -> list[StubRewriteResult]:
             continue
         basename = cls.canonical_path.stem
         previous_size = cls.size_bytes
-        new_body = CANONICAL_REDIRECT_TEMPLATE.format(basename=basename)
+        new_body = CANONICAL_REDIRECT_TEMPLATE.format(
+            basename=basename, context=config.context_value
+        )
         cls.path.write_text(new_body, encoding="utf-8")
         results.append(
             StubRewriteResult(

--- a/vault-agent/src/vault_agent/links_mode.py
+++ b/vault-agent/src/vault_agent/links_mode.py
@@ -2,7 +2,7 @@
 
 Two deterministic passes:
 
-  1. Rule-table rewrites (e.g. ``[[AnsibleFVH]]`` → ``[[Ansible]]``)
+  1. Rule-table rewrites (e.g. ``[[OldTopic]]`` → ``[[Topic]]``)
   2. Path-qualified Kanban link unqualification
 
 Ambiguous cross-namespace targets are reported for user decision —
@@ -18,7 +18,6 @@ from pathlib import Path
 from vault_agent.analyzers.audit import VaultAudit, run_audit
 from vault_agent.analyzers.vault_index import VaultIndex, scan
 from vault_agent.fixers.link_patcher import (
-    BROKEN_LINK_REWRITES,
     apply_rewrites,
     summarize_rewrites,
     unqualify_kanban_links,
@@ -61,7 +60,7 @@ def plan_links(audit: VaultAudit) -> LinksPlan:
     # Only rules with a unique resolvable target.
     available = {
         old: new
-        for old, new in BROKEN_LINK_REWRITES.items()
+        for old, new in audit.config.broken_link_rewrites.items()
         if len(index.resolve(new)) == 1
     }
     # Count Kanban-qualified links that could be unqualified

--- a/vault-agent/src/vault_agent/main.py
+++ b/vault-agent/src/vault_agent/main.py
@@ -503,7 +503,7 @@ def stubs(
         help="Output format: text, json, plain. Default: plain when not a TTY.",
     ),
 ) -> None:
-    """Classify FVH/z stubs; fix broken_redirects; report stale_duplicates."""
+    """Classify work-namespace stubs; fix broken_redirects; report stale_duplicates."""
     _ensure_vault(vault)
     if not dry_run:
         _ensure_git_repo(vault)

--- a/vault-agent/src/vault_agent/maintain.py
+++ b/vault-agent/src/vault_agent/maintain.py
@@ -14,9 +14,9 @@ from pathlib import Path
 
 from vault_agent.analyzers.audit import run_audit
 from vault_agent.analyzers.vault_index import scan
+from vault_agent.config import DEFAULT_CONFIG, VaultConfig
 from vault_agent.fixers.id_stripper import strip_legacy_id
 from vault_agent.fixers.link_patcher import (
-    BROKEN_LINK_REWRITES,
     apply_rewrites,
     summarize_rewrites,
     unqualify_kanban_links,
@@ -99,12 +99,14 @@ def _run_lint_in(handle: WorktreeHandle, vault: Path) -> list[str]:
     return commits
 
 
-def _run_links_in(handle: WorktreeHandle) -> list[str]:
+def _run_links_in(
+    handle: WorktreeHandle, config: VaultConfig = DEFAULT_CONFIG
+) -> list[str]:
     commits: list[str] = []
     wt_index = scan(handle.worktree_path)
     applicable = {
         old: new
-        for old, new in BROKEN_LINK_REWRITES.items()
+        for old, new in config.broken_link_rewrites.items()
         if len(wt_index.resolve(new)) == 1
     }
     results = apply_rewrites(wt_index, applicable)
@@ -125,13 +127,18 @@ def _run_links_in(handle: WorktreeHandle) -> list[str]:
     return commits
 
 
-def _run_stubs_in(handle: WorktreeHandle) -> list[str]:
+def _run_stubs_in(
+    handle: WorktreeHandle, config: VaultConfig = DEFAULT_CONFIG
+) -> list[str]:
     commits: list[str] = []
     wt_index = scan(handle.worktree_path)
-    results = rewrite_broken_redirects(wt_index)
+    results = rewrite_broken_redirects(wt_index, config)
     c = sum(1 for r in results if r.changed)
     if c:
-        msg = f"fix(stubs): restore canonical redirect body in {c} FVH/z files"
+        msg = (
+            f"fix(stubs): restore canonical redirect body in "
+            f"{c} work-namespace files"
+        )
         if commit_all(handle, msg):
             commits.append(msg)
     return commits
@@ -173,9 +180,9 @@ def run_maintain(
     if "lint" in modes:
         all_commits.extend(_run_lint_in(handle, vault))
     if "links" in modes:
-        all_commits.extend(_run_links_in(handle))
+        all_commits.extend(_run_links_in(handle, audit.config))
     if "stubs" in modes:
-        all_commits.extend(_run_stubs_in(handle))
+        all_commits.extend(_run_stubs_in(handle, audit.config))
     # mocs writes are deferred to the LLM-backed subagent.
 
     return MaintainResult(

--- a/vault-agent/src/vault_agent/prompts/orchestrator.md
+++ b/vault-agent/src/vault_agent/prompts/orchestrator.md
@@ -1,6 +1,6 @@
 # Vault Maintenance Orchestrator
 
-You are the vault-agent orchestrator. You coordinate specialized subagents to keep an Obsidian vault healthy: consistent tags, intact links, sensible MOC coverage, proper FVH/z stubs, no Templater leakage.
+You are the vault-agent orchestrator. You coordinate specialized subagents to keep an Obsidian vault healthy: consistent tags, intact links, sensible MOC coverage, proper work-namespace stubs, no Templater leakage.
 
 ## Role
 
@@ -10,7 +10,7 @@ You receive a pre-computed audit of the vault (frontmatter / links / graph / stu
 
 - **vault-lint** (haiku) — mechanical fixes: bare emoji tags, legacy `id:`, null tags, Templater leakage, `🗺️ → 📝/moc`
 - **vault-links** (sonnet) — broken wikilink repair, cross-namespace ambiguity reporting
-- **vault-stubs** (sonnet) — FVH/z redirect-stub classification and consolidation
+- **vault-stubs** (sonnet) — work-namespace redirect-stub classification and consolidation
 - **vault-mocs** (opus) — MOC coverage analysis, new-MOC proposals, orphan linkage
 
 Delegate via the `Task` tool with the subagent name and a specific scoped instruction.
@@ -42,9 +42,9 @@ When the mode is complete, emit a short summary (what was changed, which commits
 | `tags` | `fix(tags): strip bare 📝 from 639 notes` |
 | `tags` | `fix(tags): consolidate 🔒/security → 🔍/security (4 notes)` |
 | `id` | `fix(frontmatter): remove legacy id: field from 128 notes` |
-| `templater` | `fix(templates): render {{title}} in 7 FVH daily notes` |
-| `links` | `fix(links): rewrite 44 × [[AnsibleFVH]] → [[Ansible]]` |
-| `stubs` | `refactor(stubs): convert FVH/z/ArgoCD to redirect (content in Zettelkasten)` |
+| `templater` | `fix(templates): render {{title}} in 7 work daily notes` |
+| `links` | `fix(links): rewrite 44 × [[OldTopic]] → [[Topic]]` |
+| `stubs` | `refactor(stubs): convert work/z/ArgoCD to redirect (content in Zettelkasten)` |
 | `mocs` | `feat(mocs): add Embedded Systems MOC covering 17 notes` |
 
 ## Dry-Run Mode

--- a/vault-agent/src/vault_agent/prompts/vault_links.md
+++ b/vault-agent/src/vault_agent/prompts/vault_links.md
@@ -10,7 +10,7 @@ Given an audit's `links` section (broken targets + ambiguous collisions), apply 
 
 These have explicit rule-table entries and are already applied by the deterministic fixer before you start:
 
-- `[[AnsibleFVH]]` → `[[Ansible]]` (FVH/z/Ansible.md is canonical)
+- `[[OldTopic]]` → `[[Topic]]` (work/z/Topic.md is canonical)
 - `[[Development MOC]]` → `[[Development Workflows and Tools MOC]]` (renamed)
 - `[[Kanban/X]]` → `[[X]]` when `X` is a unique basename
 
@@ -55,7 +55,7 @@ Then act per tier:
 
 Report these without editing:
 
-- **Cross-namespace ambiguity** — e.g. `[[Docker]]` when both `Zettelkasten/Docker.md` and `FVH/z/Docker.md` exist. User picks canonical.
+- **Cross-namespace ambiguity** — e.g. `[[Docker]]` when both `Zettelkasten/Docker.md` and `work/z/Docker.md` exist. User picks canonical.
 - **Broken targets with <3 references** — low leverage, high risk of wrong guess. List them under "deferred".
 - **Inline-tag syntax broken targets** (handled by the `skip` tier). Suggest stripping the brackets rather than linking anywhere.
 

--- a/vault-agent/src/vault_agent/prompts/vault_stubs.md
+++ b/vault-agent/src/vault_agent/prompts/vault_stubs.md
@@ -1,35 +1,35 @@
 # vault-stubs subagent
 
-You classify and consolidate FVH/z files. This mode requires per-file content judgment; a bulk-rewrite is unsafe.
+You classify and consolidate work-namespace files. This mode requires per-file content judgment; a bulk-rewrite is unsafe.
 
 ## Role
 
-For each file under `FVH/z/`, decide whether it should be:
+For each file under the work namespace (`work/z/` by default), decide whether it should be:
 
 1. A clean redirect stub (≤200 B, `tags: [redirect]`, pointing to `Zettelkasten/<same-basename>`)
-2. Promoted to `Zettelkasten/` (if general-interest content with no FVH specifics)
-3. Left as FVH-original content (if FVH-specific)
+2. Promoted to `Zettelkasten/` (if general-interest content with no namespace specifics)
+3. Left as namespace-original content (if namespace-specific)
 
 ## Input
 
-The audit's `stubs` section classifies every FVH/z file into one of:
+The audit's `stubs` section classifies every work-namespace file into one of:
 
 - `clean_redirect` — no action needed
 - `broken_redirect` — has `redirect` tag but wrong body; the deterministic Python fixer has already rewritten these before you started
 - `stale_duplicate` — full article, basename exists in Zettelkasten; **this is your primary work**
-- `fvh_original` — no Zettelkasten counterpart, leave alone
+- `ns_original` — no Zettelkasten counterpart, leave alone
 
 ## Per-File Decision Flow (stale_duplicate)
 
 For each file the audit reports as `stale_duplicate`:
 
-1. **Read both files**: `FVH/z/Foo.md` and `Zettelkasten/Foo.md`.
-2. **Diff by heading.** Call the Python helper to list sections that exist in FVH/z but not in Zettelkasten:
+1. **Read both files**: `work/z/Foo.md` and `Zettelkasten/Foo.md`.
+2. **Diff by heading.** Call the Python helper to list sections that exist in the work namespace but not in Zettelkasten:
 
    ```bash
    uv run python -c "
    from vault_agent.fixers.stub_rewriter import unique_sections
-   src = open('FVH/z/Foo.md').read()
+   src = open('work/z/Foo.md').read()
    dst = open('Zettelkasten/Foo.md').read()
    for h in unique_sections(src, dst):
        print(h)
@@ -40,17 +40,17 @@ For each file the audit reports as `stale_duplicate`:
 
    | Outcome | When | Action |
    |---------|------|--------|
-   | **Pure subset** | `unique_sections` returns `[]` | Overwrite FVH/z with canonical redirect body |
-   | **Merge-then-redirect** | One or more unique sections with substantive content | Edit the Zettelkasten file to append each unique section, commit the merge, **then** overwrite FVH/z |
-   | **Coincidental collision** | Basenames match but topics differ (e.g. `FVH/z/Kafka.md` is an FVH Slack-integration note, `Zettelkasten/Kafka.md` is about Apache Kafka) | Flag for user. Report as "likely coincidental collision, not a stub". Do NOT redirect |
-   | **FVH/z is better** | Rare — FVH/z has a fuller canonical version | Flag for user review, don't auto-merge |
+   | **Pure subset** | `unique_sections` returns `[]` | Overwrite the work-namespace file with canonical redirect body |
+   | **Merge-then-redirect** | One or more unique sections with substantive content | Edit the Zettelkasten file to append each unique section, commit the merge, **then** overwrite the work-namespace file |
+   | **Coincidental collision** | Basenames match but topics differ (e.g. `work/z/Kafka.md` is a work-specific Slack-integration note, `Zettelkasten/Kafka.md` is about Apache Kafka) | Flag for user. Report as "likely coincidental collision, not a stub". Do NOT redirect |
+   | **Work-namespace copy is better** | Rare — the work-namespace file has a fuller canonical version | Flag for user review, don't auto-merge |
 
-4. **Never delete content that doesn't appear in Zettelkasten.** Before calling `Write` to overwrite the FVH/z file with the canonical redirect, verify the merge landed:
+4. **Never delete content that doesn't appear in Zettelkasten.** Before calling `Write` to overwrite the work-namespace file with the canonical redirect, verify the merge landed:
 
    ```bash
    uv run python -c "
    from vault_agent.fixers.stub_rewriter import verify_canonical_phrase_present
-   src = open('FVH/z/Foo.md').read()
+   src = open('work/z/Foo.md').read()
    dst = open('Zettelkasten/Foo.md').read()
    assert verify_canonical_phrase_present(src, dst), 'Merge check FAILED — abort overwrite'
    "
@@ -60,12 +60,13 @@ For each file the audit reports as `stale_duplicate`:
 
 ## Canonical Redirect Body
 
-Use the template from `vault_agent.fixers.stub_rewriter.CANONICAL_REDIRECT_TEMPLATE`:
+Use the template from `vault_agent.fixers.stub_rewriter.CANONICAL_REDIRECT_TEMPLATE`
+(the `context:` value comes from the vault config, defaulting to `work`):
 
 ```yaml
 ---
 tags: [redirect]
-context: fvh
+context: work
 ---
 See [[Zettelkasten/Foo|Foo]] in the main knowledge base.
 ```
@@ -75,13 +76,13 @@ See [[Zettelkasten/Foo|Foo]] in the main knowledge base.
 One commit per file for `stale_duplicate` that required a merge:
 
 ```
-refactor(stubs): merge FVH/z/Foo.md into Zettelkasten, convert stub
+refactor(stubs): merge work/z/Foo.md into Zettelkasten, convert stub
 ```
 
 One batch commit for pure-subset conversions:
 
 ```
-refactor(stubs): convert N FVH/z files to redirect stubs
+refactor(stubs): convert N work-namespace files to redirect stubs
 ```
 
 Flagged coincidental collisions get **no commit**. Report them in the summary.
@@ -92,8 +93,8 @@ If the stale_duplicate classification is ambiguous — e.g., basename collision 
 
 ## Never Do
 
-- **Don't bulk-rewrite** all FVH/z files — content judgment is required per file.
-- **Don't promote** `fvh_original` to Zettelkasten without explicit user input.
+- **Don't bulk-rewrite** all work-namespace files — content judgment is required per file.
+- **Don't promote** `ns_original` to Zettelkasten without explicit user input.
 - **Don't delete** content that doesn't appear verbatim in the Zettelkasten copy; always merge first.
 - **Don't `git push`** — vault-agent has no remote.
 - **Don't skip the `verify_canonical_phrase_present` check**; if it fails, abort.

--- a/vault-agent/src/vault_agent/reporting.py
+++ b/vault-agent/src/vault_agent/reporting.py
@@ -39,7 +39,7 @@ def render_terminal(audit: VaultAudit, console: Console | None = None) -> None:
     t.add_row("> 5 tags", str(len(fm.notes_over_tagged)))
     t.add_row("Templater leakage", str(len(fm.notes_with_templater_leak)))
     t.add_row("Corrupt emoji bytes", str(len(fm.notes_with_corrupt_emoji)))
-    t.add_row("FVH missing context", str(len(fm.fvh_notes_missing_context)))
+    t.add_row("Namespace notes missing context", str(len(fm.ns_notes_missing_context)))
     console.print(t)
 
     t = Table(title="Links", show_edge=False)
@@ -66,7 +66,7 @@ def render_terminal(audit: VaultAudit, console: Console | None = None) -> None:
     t.add_row("Expected orphans (Inbox, daily)", str(len(graph.expected_orphans)))
     console.print(t)
 
-    t = Table(title="Stubs (FVH/z)", show_edge=False)
+    t = Table(title="Stubs (work namespace)", show_edge=False)
     t.add_column("Class", justify="left")
     t.add_column("Count", justify="right")
     for cls, count in stubs.count_by_class().items():
@@ -128,7 +128,7 @@ def render_markdown(audit: VaultAudit) -> str:
     lines.append(f"- Null tags: {len(fm.notes_with_null_tags)}")
     lines.append(f"- Templater leakage: {len(fm.notes_with_templater_leak)}")
     lines.append(f"- Corrupt emoji: {len(fm.notes_with_corrupt_emoji)}")
-    lines.append(f"- FVH missing context: {len(fm.fvh_notes_missing_context)}")
+    lines.append(f"- Namespace notes missing context: {len(fm.ns_notes_missing_context)}")
     lines.append("")
 
     lines.append("## Links\n")
@@ -148,7 +148,7 @@ def render_markdown(audit: VaultAudit) -> str:
     lines.append(f"- Expected orphans: {len(graph.expected_orphans)}")
     lines.append("")
 
-    lines.append("## Stubs (FVH/z)\n")
+    lines.append("## Stubs (work namespace)\n")
     for cls, count in stubs.count_by_class().items():
         lines.append(f"- {cls}: {count}")
     lines.append("")

--- a/vault-agent/src/vault_agent/stubs_mode.py
+++ b/vault-agent/src/vault_agent/stubs_mode.py
@@ -1,4 +1,4 @@
-"""vault-agent stubs — FVH/z classification and redirect repair.
+"""vault-agent stubs — work-namespace classification and redirect repair.
 
 Deterministic: rewrite ``broken_redirect`` files to the canonical
 redirect body.
@@ -26,7 +26,7 @@ class StubsPlan:
     broken_redirects: list[Path]
     stale_duplicates: list[Path]  # reported, not auto-fixed
     clean_redirects: int
-    fvh_originals: int
+    ns_originals: int
 
 
 @dataclass
@@ -50,13 +50,13 @@ def plan_stubs(audit: VaultAudit) -> StubsPlan:
             stale.append(c.path)
         elif c.cls == StubClass.CLEAN_REDIRECT:
             clean += 1
-        elif c.cls == StubClass.FVH_ORIGINAL:
+        elif c.cls == StubClass.NS_ORIGINAL:
             original += 1
     return StubsPlan(
         broken_redirects=sorted(broken),
         stale_duplicates=sorted(stale),
         clean_redirects=clean,
-        fvh_originals=original,
+        ns_originals=original,
     )
 
 
@@ -75,10 +75,13 @@ def run_stubs(vault: Path, *, apply: bool = False) -> StubsResult:
 
     # Rewrite broken redirects inside the worktree.
     wt_index = scan(handle.worktree_path)
-    results = rewrite_broken_redirects(wt_index)
+    results = rewrite_broken_redirects(wt_index, audit.config)
     changed = sum(1 for r in results if r.changed)
     if changed:
-        msg = f"fix(stubs): restore canonical redirect body in {changed} FVH/z files"
+        msg = (
+            f"fix(stubs): restore canonical redirect body in "
+            f"{changed} work-namespace files"
+        )
         if commit_all(handle, msg):
             commits.append(msg)
 
@@ -92,7 +95,7 @@ def render_dry_run(plan: StubsPlan) -> str:
         "Dry run — no files touched.",
         "",
         f"  clean_redirect  : {plan.clean_redirects} (OK, no action)",
-        f"  fvh_original    : {plan.fvh_originals} (OK, no action)",
+        f"  ns_original     : {plan.ns_originals} (OK, no action)",
         f"  broken_redirect : {len(plan.broken_redirects)} (will rewrite to canonical body)",
         f"  stale_duplicate : {len(plan.stale_duplicates)} (needs LLM-backed content merge — not auto-fixed)",
         "",

--- a/vault-agent/tests/test_analyzers.py
+++ b/vault-agent/tests/test_analyzers.py
@@ -116,7 +116,7 @@ class TestVaultIndex:
             tmp_path,
             {
                 "Zettelkasten/Docker.md": "main\n",
-                "FVH/z/Docker.md": "stub\n",
+                "work/z/Docker.md": "stub\n",
                 "Kanban/Main.md": "# kanban\n",
             },
         )
@@ -189,19 +189,19 @@ class TestFrontmatter:
         report = analyze_frontmatter(scan(vault))
         assert len(report.notes_with_templater_leak) == 2
 
-    def test_detects_missing_fvh_context(self, tmp_path: Path) -> None:
+    def test_detects_missing_ns_context(self, tmp_path: Path) -> None:
         vault = _make_vault(
             tmp_path,
             {
-                "FVH/z/Ansible.md": """
+                "work/z/Ansible.md": """
                     ---
                     tags: [🛠️/ansible]
                     ---
                     body
                 """,
-                "FVH/z/Proper.md": """
+                "work/z/Proper.md": """
                     ---
-                    context: fvh
+                    context: work
                     tags: [🛠️/proper]
                     ---
                     body
@@ -209,7 +209,7 @@ class TestFrontmatter:
             },
         )
         report = analyze_frontmatter(scan(vault))
-        assert len(report.fvh_notes_missing_context) == 1
+        assert len(report.ns_notes_missing_context) == 1
 
     def test_tag_duplicate_candidates(self, tmp_path: Path) -> None:
         vault = _make_vault(
@@ -255,7 +255,7 @@ class TestLinks:
             tmp_path,
             {
                 "Zettelkasten/Docker.md": "# main\n",
-                "FVH/z/Docker.md": "# stub\n",
+                "work/z/Docker.md": "# stub\n",
                 "Zettelkasten/Note.md": "See [[Docker]].\n",
             },
         )
@@ -330,10 +330,10 @@ class TestStubs:
             tmp_path,
             {
                 "Zettelkasten/Docker.md": "# Main\n",
-                "FVH/z/Docker.md": """
+                "work/z/Docker.md": """
                     ---
                     tags: [redirect]
-                    context: fvh
+                    context: work
                     ---
                     See [[Zettelkasten/Docker|Docker]] in the main knowledge base.
                 """,
@@ -348,10 +348,10 @@ class TestStubs:
             tmp_path,
             {
                 "Zettelkasten/Docker.md": "# Main\n",
-                "FVH/z/Docker.md": """
+                "work/z/Docker.md": """
                     ---
                     tags: [🌱]
-                    context: fvh
+                    context: work
                     ---
                     Lots and lots of duplicated docker content here. """ + ("x" * 300),
             },
@@ -359,21 +359,21 @@ class TestStubs:
         report = analyze_stubs(scan(vault))
         assert report.classifications[0].cls == StubClass.STALE_DUPLICATE
 
-    def test_fvh_original(self, tmp_path: Path) -> None:
+    def test_ns_original(self, tmp_path: Path) -> None:
         vault = _make_vault(
             tmp_path,
             {
-                "FVH/z/FvhOnly.md": """
+                "work/z/NsOnly.md": """
                     ---
                     tags: [🛠️/internal]
-                    context: fvh
+                    context: work
                     ---
-                    FVH-only content, no zettelkasten counterpart.
+                    Namespace-only content, no zettelkasten counterpart.
                 """,
             },
         )
         report = analyze_stubs(scan(vault))
-        assert report.classifications[0].cls == StubClass.FVH_ORIGINAL
+        assert report.classifications[0].cls == StubClass.NS_ORIGINAL
 
 
 # ---------------------------------------------------------------------------
@@ -404,17 +404,17 @@ class TestMocs:
         vault = _make_vault(
             tmp_path,
             {
-                "FVH/z/Data MOC.md": """
+                "work/z/Data MOC.md": """
                     ---
                     tags: [🗺️]
-                    context: fvh
+                    context: work
                     ---
                     [[Thing]]
                 """,
-                "FVH/z/Thing.md": """
+                "work/z/Thing.md": """
                     ---
                     tags: [☁️/data]
-                    context: fvh
+                    context: work
                     ---
                 """,
             },
@@ -434,7 +434,7 @@ class TestDuplicates:
             tmp_path,
             {
                 "Zettelkasten/Docker.md": "# A\n",
-                "FVH/z/Docker.md": "# B\n",
+                "work/z/Docker.md": "# B\n",
                 "Inbox/Untitled.md": "\n",
                 "Inbox/Untitled 1.md": "\n",
             },

--- a/vault-agent/tests/test_link_patcher.py
+++ b/vault-agent/tests/test_link_patcher.py
@@ -28,32 +28,32 @@ class TestApplyRewrites:
         vault = _make_vault(
             tmp_path,
             {
-                "FVH/z/Ansible.md": "# Ansible\n",
-                "FVH/notes/2024-01-01.md": "See [[AnsibleFVH]] and [[AnsibleFVH|ansible stuff]].\n",
+                "work/z/Topic.md": "# Topic\n",
+                "work/notes/2024-01-01.md": "See [[OldTopic]] and [[OldTopic|topic stuff]].\n",
             },
         )
         index = scan(vault)
-        results = apply_rewrites(index)
+        results = apply_rewrites(index, {"OldTopic": "Topic"})
         changed = [r for r in results if r.changed]
         assert len(changed) == 1
-        assert changed[0].per_rule_counts == {"AnsibleFVH": 2}
-        content = (vault / "FVH/notes/2024-01-01.md").read_text()
-        assert "[[Ansible]]" in content
-        assert "[[Ansible|ansible stuff]]" in content
-        assert "AnsibleFVH" not in content
+        assert changed[0].per_rule_counts == {"OldTopic": 2}
+        content = (vault / "work/notes/2024-01-01.md").read_text()
+        assert "[[Topic]]" in content
+        assert "[[Topic|topic stuff]]" in content
+        assert "OldTopic" not in content
 
     def test_skips_rule_when_target_not_unique(self, tmp_path: Path) -> None:
-        # If Ansible resolves to two notes, the rule is skipped.
+        # If Topic resolves to two notes, the rule is skipped.
         vault = _make_vault(
             tmp_path,
             {
-                "A/Ansible.md": "# a\n",
-                "B/Ansible.md": "# b\n",
-                "Notes.md": "See [[AnsibleFVH]]\n",
+                "A/Topic.md": "# a\n",
+                "B/Topic.md": "# b\n",
+                "Notes.md": "See [[OldTopic]]\n",
             },
         )
         index = scan(vault)
-        results = apply_rewrites(index)
+        results = apply_rewrites(index, {"OldTopic": "Topic"})
         assert all(not r.changed for r in results)
 
     def test_preserves_alias_and_section(self, tmp_path: Path) -> None:
@@ -84,15 +84,15 @@ class TestSummarize:
         vault = _make_vault(
             tmp_path,
             {
-                "FVH/z/Ansible.md": "# a\n",
-                "A.md": "[[AnsibleFVH]]\n",
-                "B.md": "[[AnsibleFVH]] [[AnsibleFVH]]\n",
+                "work/z/Topic.md": "# a\n",
+                "A.md": "[[OldTopic]]\n",
+                "B.md": "[[OldTopic]] [[OldTopic]]\n",
             },
         )
         index = scan(vault)
-        results = apply_rewrites(index)
+        results = apply_rewrites(index, {"OldTopic": "Topic"})
         totals = summarize_rewrites(results)
-        assert totals["AnsibleFVH"] == 3
+        assert totals["OldTopic"] == 3
 
 
 class TestUnqualifyKanban:

--- a/vault-agent/tests/test_link_triage.py
+++ b/vault-agent/tests/test_link_triage.py
@@ -12,7 +12,6 @@ from vault_agent.analyzers.audit import run_audit
 from vault_agent.analyzers.vault_index import scan
 from vault_agent.fixers.link_patcher import (
     BasenameMatch,
-    BROKEN_LINK_REWRITES,
     ConfidenceTier,
     classify_match,
     fuzzy_basename_candidates,
@@ -68,8 +67,8 @@ class TestFuzzyBasenameCandidates:
 
 class TestClassifyMatch:
     def test_auto_when_ratio_above_0_9(self) -> None:
-        candidates = [BasenameMatch("Ansible", 0.95)]
-        assert classify_match("AnsibleFVH", candidates) == ConfidenceTier.AUTO
+        candidates = [BasenameMatch("Topic", 0.95)]
+        assert classify_match("Topc", candidates) == ConfidenceTier.AUTO
 
     def test_confirm_when_between(self) -> None:
         candidates = [BasenameMatch("Kafka", 0.78)]
@@ -106,17 +105,19 @@ class TestProposeRewrites:
 
     def test_skips_rule_table_entries(self, tmp_path: Path) -> None:
         # Build a vault where a rule-table target appears as broken.
-        # Rule table entry "AnsibleFVH" → "Ansible" — create several broken refs.
-        files = {"Zettelkasten/Ansible.md": "# ansible\n"}
+        # Rule table entry "OldTopic" → "Topic" — create several broken refs.
+        rewrites = {"OldTopic": "Topic"}
+        files = {"Zettelkasten/Topic.md": "# topic\n"}
         for i in range(5):
-            files[f"Zettelkasten/Other{i}.md"] = "[[AnsibleFVH]]\n"
+            files[f"Zettelkasten/Other{i}.md"] = "[[OldTopic]]\n"
         vault = _make_vault(tmp_path, files)
         audit = run_audit(vault)
-        proposals = propose_rewrites(audit.links.top_broken(20), audit.index)
+        proposals = propose_rewrites(
+            audit.links.top_broken(20), audit.index, rewrites=rewrites
+        )
         targets = {p.target for p in proposals}
-        assert "AnsibleFVH" not in targets
-        # Assumption: at least one rule-table entry exists to skip.
-        assert "AnsibleFVH" in BROKEN_LINK_REWRITES
+        # The rule-table target is skipped (covered by the deterministic rewrite).
+        assert "OldTopic" not in targets
 
     def test_produces_tier_for_each(self, tmp_path: Path) -> None:
         # Build a vault with at least 3 refs to "Pythn" (close to "Python").

--- a/vault-agent/tests/test_links_mode.py
+++ b/vault-agent/tests/test_links_mode.py
@@ -10,20 +10,20 @@ class TestRenderDryRun:
         # Regression for #1075: a target that will be auto-rewritten by the
         # rule-table must not also appear under "not auto-fixed".
         plan = LinksPlan(
-            rewrites_available={"AnsibleFVH": "Ansible"},
+            rewrites_available={"OldTopic": "Topic"},
             kanban_candidates=0,
             ambiguous_basenames=[],
-            low_leverage_broken=[("AnsibleFVH", 44), ("Nuuka REST API 2.0", 10)],
+            low_leverage_broken=[("OldTopic", 44), ("Some REST API 2.0", 10)],
         )
         output = render_dry_run(plan)
         # The rule-table entry stays in the top section.
-        assert "[[AnsibleFVH]] → [[Ansible]]" in output
+        assert "[[OldTopic]] → [[Topic]]" in output
         # But is filtered out of the bottom section.
         low_leverage_section = output.split(
             "Low-leverage broken targets (for reference — not auto-fixed):"
         )[1]
-        assert "AnsibleFVH" not in low_leverage_section
-        assert "Nuuka REST API 2.0" in low_leverage_section
+        assert "OldTopic" not in low_leverage_section
+        assert "Some REST API 2.0" in low_leverage_section
 
     def test_no_rule_table_matches_still_renders(self) -> None:
         plan = LinksPlan(

--- a/vault-agent/tests/test_stub_merge_helpers.py
+++ b/vault-agent/tests/test_stub_merge_helpers.py
@@ -20,7 +20,7 @@ from vault_agent.fixers.stub_rewriter import (
 )
 
 
-SAMPLE_FVH = textwrap.dedent(
+SAMPLE_WORK = textwrap.dedent(
     """
     ---
     tags:
@@ -33,9 +33,9 @@ SAMPLE_FVH = textwrap.dedent(
 
     Install ArgoCD with helm. Pin the chart version.
 
-    ## FVH-specific notes
+    ## Namespace-specific notes
 
-    On our cluster the ingress host is argocd.forum.fi.
+    On our cluster the ingress host is argocd.internal.example.
 
     ## Troubleshooting
 
@@ -76,9 +76,9 @@ class TestSectionHeadings:
 
 
 class TestUniqueSections:
-    def test_flags_fvh_specific_section(self) -> None:
-        uniq = unique_sections(SAMPLE_FVH, SAMPLE_ZETTEL)
-        assert uniq == ["FVH-specific notes"]
+    def test_flags_namespace_specific_section(self) -> None:
+        uniq = unique_sections(SAMPLE_WORK, SAMPLE_ZETTEL)
+        assert uniq == ["Namespace-specific notes"]
 
     def test_empty_when_full_subset(self) -> None:
         # Source is a strict subset of the destination.
@@ -89,12 +89,12 @@ class TestUniqueSections:
 
 class TestVerifyCanonicalPhrase:
     def test_passes_when_source_phrases_in_destination(self) -> None:
-        assert verify_canonical_phrase_present(SAMPLE_FVH, SAMPLE_ZETTEL) is True
+        assert verify_canonical_phrase_present(SAMPLE_WORK, SAMPLE_ZETTEL) is True
 
     def test_fails_when_destination_has_no_shared_phrase(self) -> None:
-        fvh = "## Installation\n\nInstall via apt-get. Works on Debian."
+        work = "## Installation\n\nInstall via apt-get. Works on Debian."
         zettel = "## Basics\n\nCompletely different topic about Kafka streams."
-        assert verify_canonical_phrase_present(fvh, zettel) is False
+        assert verify_canonical_phrase_present(work, zettel) is False
 
     def test_near_empty_source_passes_vacuously(self) -> None:
         # A 1-word source has no distinguishable phrase; we return True
@@ -117,6 +117,7 @@ class TestBodyDigest:
 
 class TestCanonicalRedirectTemplate:
     def test_renders_basename(self, tmp_path: Path) -> None:
-        rendered = CANONICAL_REDIRECT_TEMPLATE.format(basename="Kafka")
+        rendered = CANONICAL_REDIRECT_TEMPLATE.format(basename="Kafka", context="work")
         assert "[[Zettelkasten/Kafka|Kafka]]" in rendered
         assert "tags: [redirect]" in rendered
+        assert "context: work" in rendered


### PR DESCRIPTION
## What

Makes the Obsidian-vault tooling **vault-agnostic** by replacing private-vault
(LakuVault / FVH work-namespace) references with generic, configurable
equivalents. The tooling previously hardcoded the author's vault structure
(`FVH/z`, `context: fvh`, an `AnsibleFVH → Ansible` rewrite table), which is
meaningless or broken for any other vault.

## Changes

- **obsidian-plugin** `vault-*` skills: `FVH/z` → `work/z` work-namespace,
  `context: fvh` → `context: work`, `fvh_original` → `ns_original`, neutral
  link-rewrite examples. `vault-stubs` retitled "Work-namespace Stub Management".
- **session-plugin** journaling examples + `docs/session-plugin-workflow.md`:
  generic `~/Documents/YourVault/Journal` paths and `[work, infrastructure]` scopes.
- **vault-agent**: new `VaultConfig` (`.vault-agent.toml` / `$VAULT_AGENT_CONFIG`)
  with generic defaults (work/z namespace, context `work`, empty broken-link
  table); `FVH_*` → `NS_*` renames; prompts, README, ADRs, and tests updated.

## Out of scope (intentionally untouched)

Forum Virium **org/CI** references — `fvh-buildbot`, FVH GitHub repos, Terraform
Cloud workspaces, `config-sync` — are the real public org, not the private
vault, so they are left as-is.

## Verification

- `vault-agent`: **160 tests pass**; `VaultConfig` defaults work on any vault.
- `obsidian-plugin`: full `plugin-compliance-check.sh` ✅.
- Zero `fvh` / `lakuvault` remain in the genericized areas; org-FVH references
  confirmed intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
