### PR TITLE
docs(readme): note the experimental harness under experiments/claude-probe/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Claude Plugins
 
+> Experimental testing harness lives under experiments/claude-probe/.
+
 A curated collection of 42 Claude Code plugins providing 360+ skills and 21 agents for development workflows.
 
 ## Install the Marketplace


### PR DESCRIPTION
## Summary

Adds a one-line pointer at the top of the root `README.md` to the experimental testing harness directory `experiments/claude-probe/` (which exists on `main`).

## Provenance

Recovered from a session stash created while landing the always-Opus agent work (#1691), alongside the `mcp-server-authoring` skill (#1697). This note had never been committed; split into its own PR since it's unrelated to the skill.

One line, README-only — no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)