### PR TITLE
fix(session-plugin): prevent cross-project bleed in session-spinup

### DIFF
--- a/session-plugin/skills/session-spinup/REFERENCE.md
+++ b/session-plugin/skills/session-spinup/REFERENCE.md
@@ -15,8 +15,7 @@ schema lives in [session-wrap/REFERENCE.md](../session-wrap/REFERENCE.md).
 The cross-project `+ACTIVE` footnote shape:
 
 ```
-note: +ACTIVE lock on project:claude-plugins from a previous session —
-run session-wrap to close it if done.
+Stale +ACTIVE elsewhere: task #123 in project:claude-plugins is still +ACTIVE — release with /task-release if you've moved on.
 ```
 
 If multiple projects are detectable (monorepo, multi-package), survey
@@ -69,6 +68,8 @@ Next moves:
   • Resume #237 — check PR #1774 review state
   • Tackle yesterday's todo: nudge PR #1607 reviewers
   • Confirm Hetzner shutdown date (#240)
+
+Stale +ACTIVE elsewhere: task #5 in bluepad32.own is still +ACTIVE — release with /task-release if you've moved on.
 ```
 
 ## Edge cases

--- a/session-plugin/skills/session-spinup/SKILL.md
+++ b/session-plugin/skills/session-spinup/SKILL.md
@@ -53,7 +53,7 @@ where X may now be unblocked.
 dataview machinery in the journal · weeks-stale tasks with no recent
 annotation (that's `task-status`'s job) · `+ACTIVE` tasks from a
 *different* project than the cwd — those are stale locks; at most one
-footnote line, never a scope hijack.
+footnote line ("Stale +ACTIVE elsewhere" at the end of the briefing), never a scope hijack.
 
 ## Execution
 
@@ -67,7 +67,7 @@ Tiered precedence — full table in [REFERENCE.md](REFERENCE.md):
 2. `+ACTIVE` task's project, only when cwd is ambiguous
 3. git remote name as last resort
 
-A cross-project `+ACTIVE` task never overrides an unambiguous cwd.
+A cross-project `+ACTIVE` task never overrides an unambiguous cwd. When cwd unambiguously maps to a project, all subsequent queries must be scoped *only* to that project.
 
 ### Step 2: Survey (parallel-safe)
 
@@ -85,9 +85,12 @@ extraction snippet in [REFERENCE.md](REFERENCE.md).
 ### Step 3: Present
 
 Compact briefing, one section per source, then 2-4 concrete "next moves".
+The spin-up sections (taskwarrior / daily note / git) must reflect *only* the cwd project.
 Say "git state: clean" / "nothing pending under `project:<name>`"
 explicitly rather than omitting sections. Example briefing in
 [REFERENCE.md](REFERENCE.md).
+
+If a `+ACTIVE` task exists in a different project than the cwd-mapped one, do NOT include it in the cwd project's sections. Append a single line under a clearly separate "Stale +ACTIVE elsewhere" notice at the very end of the briefing.
 
 ### Step 4: Offer next moves
 


### PR DESCRIPTION
Fixes #1439 and #1440 by explicitly instructing the agent to never let `+ACTIVE` tasks from other projects bleed into the cwd-scoped briefing sections, and to properly format them as a trailing footnote instead.

---
*PR created automatically by Jules for task [15248749903858457252](https://jules.google.com/task/15248749903858457252) started by @laurigates*