### PR TITLE
fix(hooks-plugin): resolve branch-protection branch from hook-input cwd in worktrees

### DIFF
--- a/hooks-plugin/hooks/branch-protection.sh
+++ b/hooks-plugin/hooks/branch-protection.sh
@@ -34,6 +34,11 @@ INPUT=$(cat)
 
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+# The directory the Bash command actually runs in. In a git worktree this is
+# the worktree path (with its own per-worktree HEAD), not the main checkout —
+# so the branch lookup must run here, not in the hook's own process cwd, or a
+# correctly-branched worktree gets misread as `main`. See #1695.
+HOOK_CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 
 # Only applies to Bash tool
 [ "$TOOL_NAME" != "Bash" ] && exit 0
@@ -75,9 +80,18 @@ EOF
 # and deny legitimate writes against a feature-branch worktree. See #1389.
 WORKING_DIR=$(echo "$COMMAND" | grep -oE 'git[[:space:]]+-C[[:space:]]+[^[:space:]]+' | head -1 | awk '{print $NF}' || true)
 
+# Resolve the directory all branch/repo lookups run in, in precedence order:
+#   1. `git -C <path>` — the command explicitly targets that dir (#1389)
+#   2. the hook-input cwd — the worktree the Bash command runs in (#1695)
+#   3. (empty) — fall back to the hook's own process cwd
+# Without (2), a plain `git add`/`git rm` (no -C) issued from a feature-branch
+# worktree resolved its branch in the hook process's cwd (the main checkout)
+# and was wrongly denied as if on `main`.
+EFFECTIVE_DIR="${WORKING_DIR:-${HOOK_CWD:-}}"
+
 # Get current branch (silently fail if not in a git repo)
-if [ -n "$WORKING_DIR" ]; then
-  CURRENT_BRANCH=$(git -C "$WORKING_DIR" branch --show-current 2>/dev/null || echo "")
+if [ -n "$EFFECTIVE_DIR" ]; then
+  CURRENT_BRANCH=$(git -C "$EFFECTIVE_DIR" branch --show-current 2>/dev/null || echo "")
 else
   CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
 fi
@@ -89,9 +103,9 @@ fi
 # URL (*.wiki.git — robust, survives directory renames) or the working-tree
 # top-level directory name (*.wiki — cheap fallback when there's no remote).
 # (#1586)
-if [ -n "$WORKING_DIR" ]; then
-  WIKI_REMOTE=$(git -C "$WORKING_DIR" remote get-url origin 2>/dev/null || echo "")
-  WIKI_TOPLEVEL=$(git -C "$WORKING_DIR" rev-parse --show-toplevel 2>/dev/null || echo "")
+if [ -n "$EFFECTIVE_DIR" ]; then
+  WIKI_REMOTE=$(git -C "$EFFECTIVE_DIR" remote get-url origin 2>/dev/null || echo "")
+  WIKI_TOPLEVEL=$(git -C "$EFFECTIVE_DIR" rev-parse --show-toplevel 2>/dev/null || echo "")
 else
   WIKI_REMOTE=$(git remote get-url origin 2>/dev/null || echo "")
   WIKI_TOPLEVEL=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
@@ -165,10 +179,10 @@ case "$GIT_SUBCMD" in
     # the repo's only commit (a single root commit), there is no prior history
     # to open a PR against — pushing it to main is how an empty remote gets
     # initialized. The normal protection resumes as soon as a second commit
-    # exists. Branch detection respects `git -C <path>` for the same reason as
-    # CURRENT_BRANCH above (#1389).
-    if [ -n "$WORKING_DIR" ]; then
-      COMMIT_COUNT=$(git -C "$WORKING_DIR" rev-list --count HEAD 2>/dev/null || echo "")
+    # exists. Branch detection respects `git -C <path>` and the hook-input cwd
+    # for the same reason as CURRENT_BRANCH above (#1389, #1695).
+    if [ -n "$EFFECTIVE_DIR" ]; then
+      COMMIT_COUNT=$(git -C "$EFFECTIVE_DIR" rev-list --count HEAD 2>/dev/null || echo "")
     else
       COMMIT_COUNT=$(git rev-list --count HEAD 2>/dev/null || echo "")
     fi

--- a/hooks-plugin/hooks/test-branch-protection.sh
+++ b/hooks-plugin/hooks/test-branch-protection.sh
@@ -12,6 +12,8 @@
 #   - `git push origin main:fix/foo` with explicit refspec is allowed.
 #   - Plain `git commit` / `git push` on main is denied.
 #   - `git -C <feature-worktree> commit` from a cwd on main is allowed (#1389).
+#   - A plain write (no `-C`) from a feature-worktree input `cwd` is allowed,
+#     while the same from a master-worktree `cwd` is denied (#1695).
 #   - The initial bootstrap push (single root commit) to main is allowed, and
 #     resumes denying once a second commit exists.
 set -euo pipefail
@@ -68,7 +70,10 @@ run_hook() {
   local cmd_str="$1"
   shift
   local input
-  input=$(jq -nc --arg cmd "$cmd_str" '{tool_name:"Bash",tool_input:{command:$cmd}}')
+  # Mirror the hook's real input: `cwd` is the directory the Bash command runs
+  # in (here, the TEST_REPO checkout on main). #1695's fix reads this field.
+  input=$(jq -nc --arg cmd "$cmd_str" --arg cwd "$TEST_REPO" \
+    '{tool_name:"Bash",cwd:$cwd,tool_input:{command:$cmd}}')
   (
     cd "$TEST_REPO"
     # Apply any extra env-var assignments passed as remaining args.
@@ -227,6 +232,71 @@ assert_deny \
 assert_deny \
   "git -C <master-worktree> push (no refspec) is still denied" \
   "git -C $MASTER_WT push"
+
+# ── worktree cwd branch detection (#1695 regression) ────────────────────────
+# A plain `git add`/`git rm` (NO `-C`) issued from inside a feature-branch
+# worktree must read the branch from that worktree, not the hook's own process
+# cwd. Pre-fix the hook ran `git branch --show-current` in its process cwd (the
+# main checkout) and wrongly denied writes on a correctly-branched worktree.
+# Here the hook process cwd is TEST_REPO (on main) while the input `cwd` points
+# at the worktree — exactly the shape the hook receives in practice.
+echo ""
+echo "worktree cwd branch detection (#1695):"
+
+# run_hook_cwd <command-string> <cwd> — like run_hook but with an explicit
+# input `cwd` and a hook process cwd pinned to TEST_REPO (main).
+run_hook_cwd() {
+  local cmd_str="$1" cwd_val="$2"
+  local input
+  input=$(jq -nc --arg cmd "$cmd_str" --arg cwd "$cwd_val" \
+    '{tool_name:"Bash",cwd:$cwd,tool_input:{command:$cmd}}')
+  ( cd "$TEST_REPO" && printf '%s' "$input" | bash "$HOOK" )
+}
+
+assert_cwd_allow() {
+  local desc="$1" cmd_str="$2" cwd_val="$3"
+  local out
+  out=$(run_hook_cwd "$cmd_str" "$cwd_val")
+  if [ -z "$out" ]; then
+    printf "  PASS: %s\n" "$desc"; PASS=$((PASS + 1))
+  else
+    printf "  FAIL: %s\n        expected silent allow, got: %s\n" "$desc" "$out"; FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_cwd_deny() {
+  local desc="$1" cmd_str="$2" cwd_val="$3"
+  local out
+  out=$(run_hook_cwd "$cmd_str" "$cwd_val")
+  if echo "$out" | grep -q '"permissionDecision":"deny"'; then
+    printf "  PASS: %s\n" "$desc"; PASS=$((PASS + 1))
+  else
+    printf "  FAIL: %s\n        expected deny, got: %s\n" "$desc" "${out:-<empty>}"; FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_cwd_allow \
+  "plain git add from a feature-worktree cwd is allowed (no -C)" \
+  "git add file.txt" "$FEATURE_WT"
+
+assert_cwd_allow \
+  "plain git rm from a feature-worktree cwd is allowed (no -C)" \
+  "git rm file.txt" "$FEATURE_WT"
+
+assert_cwd_allow \
+  "plain git commit from a feature-worktree cwd is allowed (no -C)" \
+  "git commit -m foo" "$FEATURE_WT"
+
+# Negative: when the input cwd is a worktree on a protected branch, a plain
+# write must still be denied — proving the cwd path resolves the real branch,
+# not a blanket allow.
+assert_cwd_deny \
+  "plain git add from a master-worktree cwd is still denied (no -C)" \
+  "git add file.txt" "$MASTER_WT"
+
+assert_cwd_deny \
+  "plain git commit from a master-worktree cwd is still denied (no -C)" \
+  "git commit -m foo" "$MASTER_WT"
 
 # ── push to an explicit non-protected ref from a main checkout (#1600) ───────
 # Regression: `git push -u origin feat/x` while parked on main was denied


### PR DESCRIPTION
## What

The `branch-protection` PreToolUse hook (`hooks-plugin/hooks/branch-protection.sh`) resolved the current branch in its **own process cwd** (the main checkout) whenever the command lacked a `git -C <path>`. A plain `git add` / `git rm` / `git commit` issued from inside a **feature-branch worktree** was therefore misread as being on `main` and wrongly denied — forcing a filesystem-`rm` + `git commit -a` workaround that bypasses the staging-time guard entirely (defeating the hook's purpose).

## Fix

Thread the hook-input `.cwd` field — the directory the Bash command actually runs in (the worktree, which has its own per-worktree `HEAD`) — into the branch, wiki-exemption, and bootstrap commit-count lookups via a single `EFFECTIVE_DIR` with precedence:

1. `git -C <path>` — command explicitly targets that dir (#1389)
2. hook-input `cwd` — the worktree the command runs in (**#1695**)
3. process cwd — last-resort fallback (unchanged behavior)

Sibling hooks (`git-stash-session-init.sh`, `task-completeness.sh`, `test-verification.sh`, …) already read `.cwd` from input the same way.

## Tests

Added a `#1695` regression section to `test-branch-protection.sh` (5 cases): plain writes with no `-C` from a **feature-worktree** `cwd` are allowed; the same from a **master-worktree** `cwd` are still denied (proving it resolves the real branch, not a blanket allow). Full suite: **31 passed, 0 failed**. `shellcheck` and `scripts/lint-shell-scripts.sh` clean.

Verified end-to-end against the issue's exact repro (real worktree on `chore/my-change`, plain `git rm`, input `cwd` = worktree): now allowed.

Closes #1695

🤖 Generated with [Claude Code](https://claude.com/claude-code)