### PR TITLE
feat(opencode): script full local-MLX orchestration setup and document the pipeline

### DIFF
--- a/.github/workflows/test-skill-scripts.yml
+++ b/.github/workflows/test-skill-scripts.yml
@@ -12,6 +12,8 @@ on:
     paths:
       - '**/skills/**/scripts/**'
       - 'scripts/run-skill-script-tests.sh'
+      - 'scripts/configure-opencode.sh'
+      - 'scripts/tests/test-configure-opencode.sh'
       - 'justfile'
       - '.github/workflows/test-skill-scripts.yml'
   push:
@@ -19,6 +21,7 @@ on:
     paths:
       - '**/skills/**/scripts/**'
       - 'scripts/run-skill-script-tests.sh'
+      - 'scripts/configure-opencode.sh'
 
 concurrency:
   group: test-skill-scripts-${{ github.event.pull_request.number || github.ref }}
@@ -36,3 +39,6 @@ jobs:
 
       - name: Run skill-local regression tests
         run: bash scripts/run-skill-script-tests.sh
+
+      - name: Smoke-test the OpenCode config generator
+        run: bash scripts/tests/test-configure-opencode.sh

--- a/docs/opencode-export.md
+++ b/docs/opencode-export.md
@@ -1,0 +1,188 @@
+# OpenCode export & local-MLX orchestration
+
+This repo's Claude Code skills and subagents can run inside
+[OpenCode](https://opencode.ai) against a **local** model served with MLX. This
+doc covers the whole pipeline: convert → install → configure → serve → run.
+
+The conversion engine is [`scripts/export-opencode.sh`](../scripts/export-opencode.sh)
+(rulesync, `claudecode → opencode`). The install/configure/serve steps are
+justfile recipes in the `opencode` group that wrap
+[`scripts/install-opencode.sh`](../scripts/install-opencode.sh) and
+[`scripts/configure-opencode.sh`](../scripts/configure-opencode.sh).
+
+## Pipeline overview
+
+```mermaid
+flowchart LR
+    src["claude-plugins<br/>skills + agents"] -->|just export-opencode| dist["dist/opencode/<br/>{agents,skills}"]
+    dist -->|just install-opencode| cfg["~/.config/opencode/<br/>or .opencode/"]
+    gen["just configure-opencode"] -->|opencode.json + orchestrator.md| cfg
+    mlx["mlx_lm.server<br/>:8080 /v1"] -->|OpenAI-compatible| oc
+    cfg --> oc["opencode (TUI)"]
+    classDef step fill:#4a9eff,color:#fff
+    classDef serve fill:#ffa500,color:#000
+    class src,dist,cfg,gen step
+    class mlx serve
+```
+
+`just setup-opencode` runs install + configure in one shot and prints the
+serve/run next steps.
+
+## 1. Export
+
+```
+just export-opencode
+```
+
+Produces `dist/opencode/{agents,skills}/`. What converts:
+
+| Surface | Fidelity |
+|---------|----------|
+| **Skills** | Near-lossless — `SKILL.md`, `REFERENCE.md`, and `scripts/` travel together. |
+| **Subagents** | Structural — rulesync drops `model`, `tools`, and `maxTurns` from the frontmatter (OpenCode's agent schema differs). The prompt body and `description` survive. |
+| **Hooks** | Intentionally **not** exported. Claude Code plugin hooks reference `${CLAUDE_PLUGIN_ROOT}` scripts rulesync can't resolve, and OpenCode has no model-evaluation (prompt) hook. Hand-port per plugin (see the `export-opencode.sh` header). |
+
+OpenCode reads **plural** `agents/` and `skills/` directories (singular is
+accepted for back-compat); the export already emits plural, so no rename is
+needed.
+
+## 2. Serve the model
+
+OpenCode talks to any OpenAI-compatible `/v1` endpoint. Serve a local model with
+[mlx-lm](https://github.com/ml-explore/mlx-lm):
+
+```
+uv tool install mlx-lm
+just serve-opencode-model
+```
+
+`serve-opencode-model` runs `mlx_lm.server --model <model> --port <port>` with
+the configured defaults. Override per invocation:
+
+```
+just opencode_model=mlx-community/Qwen3-30B-A3B-4bit opencode_port=8080 serve-opencode-model
+```
+
+Verify it's up:
+
+```
+curl -s localhost:8080/v1/models
+```
+
+The response should list your model id. The model id is **your** choice — any id
+your local `mlx_lm.server` exposes (an MLX MoE like `Qwen3-30B-A3B`, a 4-bit
+community quant, etc.). It is a recipe variable, not a fixed value.
+
+## 3. Provider config
+
+`just configure-opencode` generates this `opencode.json` (real OpenCode schema):
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "mlx-local": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Local MLX",
+      "options": { "baseURL": "http://127.0.0.1:8080/v1" },
+      "models": { "<model-id>": { "name": "<model-id>" } }
+    }
+  },
+  "model": "mlx-local/<model-id>",
+  "default_agent": "orchestrator"
+}
+```
+
+`<model-id>` and the port come from the `opencode_model` / `opencode_port`
+recipe variables. The generator is **non-destructive**: if `opencode.json`
+already exists it writes `opencode.json.opencode-sample` instead and prints a
+merge hint, so a hand-tuned config is never clobbered.
+
+## 4. Orchestrator agent
+
+`configure-opencode` also writes `agents/orchestrator.md` — a read-only primary
+agent that decomposes a request and fans out to the exported subagents:
+
+```markdown
+---
+description: Central router that decomposes a request and delegates to specialized subagents concurrently.
+mode: primary
+model: mlx-local/<model-id>
+temperature: 0.1
+permission:
+  edit: deny
+  bash: deny
+  webfetch: deny
+  write: deny
+---
+
+# The Orchestrator
+You analyze the request, inspect project topology read-only (read/glob/grep/list),
+and dispatch specialized subagents via the `task` tool — issuing multiple `task`
+calls in one turn for independent work. You never edit files or run bash directly.
+```
+
+Why `permission:` and not `tools:`: OpenCode's agent frontmatter uses a
+`permission:` map (`allow` / `ask` / `deny` per built-in capability). The
+`tools:` form is a deprecated `name: bool` map, not a YAML list. The orchestrator
+denies `edit` / `write` / `bash` / `webfetch` so it can only read and delegate —
+the actual file edits and shell work happen inside the subagents it dispatches
+with the built-in `task` tool.
+
+OpenCode's built-in tools are: `read, write, edit, glob, grep, list, bash, task,
+skill`.
+
+## 5. Install + run
+
+```
+just setup-opencode               # global  → ~/.config/opencode
+just setup-opencode .opencode     # project → ./.opencode
+```
+
+`setup-opencode` = `install-opencode` (copies `agents/` + `skills/` **additively**
+— your own agents/skills are preserved) + `configure-opencode`, then prints the
+serve + run next steps.
+
+Then:
+
+```
+cd <project>
+opencode
+```
+
+- Run `/init` once to have OpenCode write an `AGENTS.md` for the project.
+- Switch agents with **Tab** or the `/agents` picker — reach `orchestrator` there
+  (and it's the `default_agent`, so it's selected on launch).
+
+## Gotchas — common-but-wrong config
+
+A plausible-looking config that does **not** work in OpenCode. If you're adapting
+a brainstorm or an older snippet, check it against this table:
+
+| Looks right | Actually | Use instead |
+|-------------|----------|-------------|
+| `"providers": { id: { api_base, api_key }}` | No such keys | `"provider": { id: { "npm", "options": { "baseURL" }, "models" }}` |
+| `"attention": { enabled }` in `opencode.json` | Lives in `tui.json` | Omit from `opencode.json` |
+| `tools:` as a YAML list in agent frontmatter | `tools:` is a deprecated `name: bool` map | `permission:` map (`allow`/`ask`/`deny`) |
+| `get_symbols_overview` builtin tool | Not a builtin | Builtins: `read, write, edit, glob, grep, list, bash, task, skill` |
+| `Leader+Down` / arrow keys to switch subagents | Unverified keybinds | **Tab** or `/agents` |
+| A fixed garbled model id (e.g. `Qwen3.6-35B-A3B`) | Not a real id | Set your own MLX model id via `opencode_model` |
+
+## Limitations
+
+- **Agent orchestration metadata is dropped on export** — `model`, `tools`, and
+  `maxTurns` don't survive rulesync's `claudecode → opencode` conversion. The
+  generated `orchestrator.md` re-establishes a primary agent by hand; exported
+  subagents keep only their prompt + description.
+- **Hooks are not exported** — hand-port per plugin (see the
+  `export-opencode.sh` header).
+- **Local-model capability** — a local MLX model is smaller than a frontier
+  model; complex orchestration may need a larger quant or a stronger model id.
+
+## Related
+
+- [`scripts/export-opencode.sh`](../scripts/export-opencode.sh) — conversion engine
+- [`scripts/install-opencode.sh`](../scripts/install-opencode.sh) — additive installer
+- [`scripts/configure-opencode.sh`](../scripts/configure-opencode.sh) — config + orchestrator generator
+- [`scripts/tests/test-configure-opencode.sh`](../scripts/tests/test-configure-opencode.sh) — schema regression guard
+- [OpenCode docs](https://opencode.ai/docs) — upstream source of truth for the schema

--- a/justfile
+++ b/justfile
@@ -100,7 +100,43 @@ pr-rebase-all:
 # OpenCode export
 ####################
 
+# Defaults are overridable via environment or `just opencode_model=… <recipe>`.
+opencode_config := env_var_or_default("OPENCODE_CONFIG", "~/.config/opencode")
+opencode_model := env_var_or_default("OPENCODE_MODEL", "Qwen3-30B-A3B")
+opencode_port := env_var_or_default("OPENCODE_PORT", "8080")
+opencode_provider := "mlx-local"
+
 # Project skills + subagents to OpenCode format via rulesync (output: dist/opencode)
 [group: "opencode"]
 export-opencode *args:
     ./scripts/export-opencode.sh {{args}}
+
+# Install exported agents + skills additively into an OpenCode config dir
+# (default: global ~/.config/opencode; pass `.opencode` for a project install)
+[group: "opencode"]
+install-opencode target=opencode_config:
+    ./scripts/install-opencode.sh "{{target}}"
+
+# Generate opencode.json + agents/orchestrator.md (non-destructive to existing config)
+[group: "opencode"]
+configure-opencode target=opencode_config:
+    ./scripts/configure-opencode.sh "{{target}}" \
+        --provider "{{opencode_provider}}" \
+        --model "{{opencode_model}}" \
+        --port "{{opencode_port}}"
+
+# Install + configure, then print the serve + run next steps
+[group: "opencode"]
+setup-opencode target=opencode_config: (install-opencode target) (configure-opencode target)
+    @echo ""
+    @echo "Next steps:"
+    @echo "  1. Install the server:  uv tool install mlx-lm"
+    @echo "  2. Serve the model:     just serve-opencode-model"
+    @echo "     (or: mlx_lm.server --model {{opencode_model}} --port {{opencode_port}})"
+    @echo "  3. Verify it is up:     curl -s localhost:{{opencode_port}}/v1/models"
+    @echo "  4. Run OpenCode:        cd <project> && opencode   (Tab or /agents to reach orchestrator)"
+
+# Serve the local model via mlx-lm (OpenAI-compatible /v1 on the configured port)
+[group: "opencode"]
+serve-opencode-model:
+    mlx_lm.server --model {{opencode_model}} --port {{opencode_port}}

--- a/scripts/configure-opencode.sh
+++ b/scripts/configure-opencode.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# configure-opencode.sh — generate a runnable OpenCode config for a local
+# MLX-served model plus an orchestrator primary agent that fans out to the
+# exported subagents.
+#
+# Generates two artifacts into <target>:
+#   - opencode.json       (provider + model + default_agent)
+#   - agents/orchestrator.md  (read-only primary agent that delegates via `task`)
+#
+# Non-destructive: if <target>/opencode.json already exists it writes
+# opencode.json.opencode-sample instead and prints a merge instruction, so an
+# existing hand-tuned config is never clobbered. The orchestrator agent is
+# always (re)written — it is a generated artifact.
+#
+# Schema is validated against https://opencode.ai/docs (provider/model/agent),
+# NOT the common-but-wrong shape (`providers`/`api_base`/`tools:` list). See
+# docs/opencode-export.md "Gotchas".
+#
+# Usage: ./scripts/configure-opencode.sh <target> [--provider P] [--model M] [--port N]
+set -euo pipefail
+
+config_target="${1:?usage: configure-opencode.sh <target> [--provider P] [--model M] [--port N]}"
+shift || true
+
+config_provider="mlx-local"
+config_model="Qwen3-30B-A3B"
+config_port="8080"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --provider) config_provider="$2"; shift 2 ;;
+        --model)    config_model="$2";    shift 2 ;;
+        --port)     config_port="$2";     shift 2 ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+# Expand a leading ~ to $HOME (justfile variables are not tilde-expanded).
+if [ "${config_target#\~}" != "$config_target" ]; then
+    config_target="${HOME}${config_target#\~}"
+fi
+
+config_baseurl="http://127.0.0.1:${config_port}/v1"
+
+echo "=== OPENCODE CONFIGURE ==="
+echo "TARGET=$config_target"
+echo "PROVIDER=$config_provider"
+echo "MODEL=$config_model"
+echo "BASEURL=$config_baseurl"
+
+mkdir -p "$config_target/agents"
+
+# --- opencode.json (non-destructive) -----------------------------------------
+config_json="$config_target/opencode.json"
+if [ -e "$config_json" ]; then
+    config_json="$config_target/opencode.json.opencode-sample"
+    echo "CONFIG_EXISTS=true"
+else
+    echo "CONFIG_EXISTS=false"
+fi
+
+# Unquoted heredoc so $config_* expand; \$schema stays a literal JSON key.
+cat > "$config_json" <<JSON
+{
+  "\$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "$config_provider": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Local MLX",
+      "options": { "baseURL": "$config_baseurl" },
+      "models": { "$config_model": { "name": "$config_model" } }
+    }
+  },
+  "model": "$config_provider/$config_model",
+  "default_agent": "orchestrator"
+}
+JSON
+echo "CONFIG_WRITTEN=$config_json"
+if [ "$config_json" != "$config_target/opencode.json" ]; then
+    echo "MERGE_HINT=existing opencode.json kept; merge provider/model/default_agent from the .opencode-sample by hand"
+fi
+
+# --- agents/orchestrator.md (generated artifact, always rewritten) -----------
+config_agent="$config_target/agents/orchestrator.md"
+cat > "$config_agent" <<MD
+---
+description: Central router that decomposes a request and delegates to specialized subagents concurrently.
+mode: primary
+model: $config_provider/$config_model
+temperature: 0.1
+permission:
+  edit: deny
+  bash: deny
+  webfetch: deny
+  write: deny
+---
+
+# The Orchestrator
+
+You analyze the request, inspect project topology read-only (read/glob/grep/list),
+and dispatch specialized subagents via the \`task\` tool — issuing multiple \`task\`
+calls in one turn for independent work. You never edit files or run bash directly.
+
+Workflow:
+
+1. Decompose the request into independent units of work.
+2. For each unit, pick the most specialized exported subagent (see \`agents/\`).
+3. Issue the \`task\` calls — parallel ones in a single turn when the work is independent.
+4. Gather the subagents' results and synthesize a single answer.
+MD
+echo "AGENT_WRITTEN=$config_agent"
+
+echo "STATUS=OK"
+echo "ISSUE_COUNT=0"
+echo "=== END OPENCODE CONFIGURE ==="

--- a/scripts/install-opencode.sh
+++ b/scripts/install-opencode.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# install-opencode.sh — export this marketplace's skills + subagents to OpenCode
+# format and install them additively into an OpenCode config directory.
+#
+# Runs export-opencode.sh into a disposable temp dir, then copies agents/ and
+# skills/ into <target>/{agents,skills}. The copy is ADDITIVE: the user's own
+# agents/skills under <target> are preserved (no rm -rf of the target trees).
+#
+# Usage: ./scripts/install-opencode.sh <target>
+set -euo pipefail
+
+install_script_dir="$(cd "$(dirname "$0")" && pwd)"
+install_target="${1:?usage: install-opencode.sh <target>}"
+
+# Expand a leading ~ to $HOME (justfile variables are not tilde-expanded).
+if [ "${install_target#\~}" != "$install_target" ]; then
+    install_target="${HOME}${install_target#\~}"
+fi
+
+echo "=== OPENCODE INSTALL ==="
+echo "TARGET=$install_target"
+
+install_tmp="$(mktemp -d)"
+trap 'rm -rf "$install_tmp"' EXIT
+
+"$install_script_dir/export-opencode.sh" "$install_tmp" >/dev/null
+
+mkdir -p "$install_target/agents" "$install_target/skills"
+cp -R "$install_tmp/agents/." "$install_target/agents/"
+cp -R "$install_tmp/skills/." "$install_target/skills/"
+
+install_agents="$(find "$install_target/agents" -name '*.md' 2>/dev/null | wc -l | tr -d ' ')"
+install_skills="$(find "$install_target/skills" -name 'SKILL.md' 2>/dev/null | wc -l | tr -d ' ')"
+echo "INSTALLED_AGENTS=$install_agents"
+echo "INSTALLED_SKILLS=$install_skills"
+echo "STATUS=OK"
+echo "ISSUE_COUNT=0"
+echo "=== END OPENCODE INSTALL ==="

--- a/scripts/tests/test-configure-opencode.sh
+++ b/scripts/tests/test-configure-opencode.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Regression test for scripts/configure-opencode.sh.
+#
+# Guards the generated OpenCode config against drifting back to the broken
+# brainstorm schema (`providers`/`api_base`/`tools:` list). Asserts:
+#   A. opencode.json is valid JSON with `provider` (NOT `providers`), the
+#      `provider/model` model string, and `default_agent`.
+#   B. agents/orchestrator.md frontmatter is valid YAML with `mode: primary`
+#      and a `permission:` map (NOT a `tools:` list).
+#   C. a second run is non-destructive: an existing opencode.json is kept and
+#      the new config lands in opencode.json.opencode-sample.
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+configure="$repo_root/scripts/configure-opencode.sh"
+
+pass_count=0
+fail_count=0
+
+assert() {
+  if [ "$2" = "true" ]; then
+    pass_count=$((pass_count + 1))
+  else
+    echo "FAIL: $1" >&2
+    fail_count=$((fail_count + 1))
+  fi
+}
+
+fixture="$(mktemp -d)"
+trap 'rm -rf "$fixture"' EXIT
+
+echo "=== TEST A: opencode.json schema ==="
+bash "$configure" "$fixture" --provider mlx-local --model Qwen3-30B-A3B --port 8080 >/dev/null
+
+assert "opencode.json exists" \
+  "$([ -f "$fixture/opencode.json" ] && echo true || echo false)"
+assert "opencode.json is valid JSON with provider (not providers) + model + default_agent" \
+  "$(python3 - "$fixture/opencode.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+ok = (
+    "provider" in d and "providers" not in d
+    and "api_base" not in json.dumps(d)
+    and d.get("model") == "mlx-local/Qwen3-30B-A3B"
+    and d.get("default_agent") == "orchestrator"
+    and d["provider"]["mlx-local"]["npm"] == "@ai-sdk/openai-compatible"
+)
+print("true" if ok else "false")
+PY
+)"
+
+echo "=== TEST B: orchestrator.md frontmatter ==="
+assert "agents/orchestrator.md exists" \
+  "$([ -f "$fixture/agents/orchestrator.md" ] && echo true || echo false)"
+assert "orchestrator frontmatter is valid YAML with mode: primary and a permission map (no tools: list)" \
+  "$(python3 - "$fixture/agents/orchestrator.md" <<'PY'
+import sys
+text = open(sys.argv[1]).read()
+parts = text.split("---", 2)
+ok = len(parts) >= 3
+fm = parts[1] if ok else ""
+try:
+    import yaml
+    meta = yaml.safe_load(fm)
+except Exception:
+    meta = None
+if isinstance(meta, dict):
+    ok = ok and meta.get("mode") == "primary" and isinstance(meta.get("permission"), dict) and "tools" not in meta
+else:
+    # No PyYAML available — fall back to line checks on the frontmatter block.
+    ok = ok and "mode: primary" in fm and "permission:" in fm and "\ntools:" not in ("\n" + fm)
+print("true" if ok else "false")
+PY
+)"
+
+echo "=== TEST C: non-destructive second run ==="
+bash "$configure" "$fixture" --provider mlx-local --model Qwen3-30B-A3B --port 8080 >/dev/null
+assert "original opencode.json preserved" \
+  "$([ -f "$fixture/opencode.json" ] && echo true || echo false)"
+assert "second run writes opencode.json.opencode-sample" \
+  "$([ -f "$fixture/opencode.json.opencode-sample" ] && echo true || echo false)"
+
+echo ""
+echo "=== SUMMARY ==="
+echo "PASSED=$pass_count"
+echo "FAILED=$fail_count"
+if [ "$fail_count" -gt 0 ]; then echo "STATUS=FAIL"; exit 1; fi
+echo "STATUS=OK"


### PR DESCRIPTION
## Summary

Bridges the gap from OpenCode *conversion* (`export-opencode.sh`) to a **runnable** local setup: install the exported agents/skills, generate a corrected `opencode.json` for an MLX-served model, add an `orchestrator` primary agent that fans out to subagents via the `task` tool, and document the whole pipeline.

## Changes

**`justfile`** — new `opencode`-group recipes + overridable vars (`opencode_config`/`opencode_model`/`opencode_port`/`opencode_provider`):
- `install-opencode [target]` — additively copy exported `agents/` + `skills/` into a config dir (default `~/.config/opencode`; pass `.opencode` for project)
- `configure-opencode [target]` — generate `opencode.json` + `agents/orchestrator.md`, **non-destructive**
- `setup-opencode [target]` — install + configure, then print serve/run next steps
- `serve-opencode-model` — `mlx_lm.server` on the configured model/port

**`scripts/{install,configure}-opencode.sh`** — generation logic (heredocs) extracted into scripts mirroring `export-opencode.sh`, so it's testable without `just` and is a single source of truth. An existing `opencode.json` is kept; the new one lands as `opencode.json.opencode-sample` with a merge hint.

**`docs/opencode-export.md`** — the doc `export-opencode.sh` already referenced: Mermaid pipeline diagram, export-fidelity table, serve/provider/orchestrator sections, and a "common-but-wrong" gotchas table.

**`scripts/tests/test-configure-opencode.sh`** — schema regression guard (valid JSON with `provider` not `providers`; orchestrator frontmatter with `mode: primary` + `permission:` map), wired into the `Test: Skill scripts` workflow.

## Schema verification

Confirmed against live OpenCode docs (context7): `default_agent` is a real top-level key; `provider` block shape (`npm`/`options.baseURL`/`models`); agent `mode: primary` + `permission:` map. The corrections table in the doc documents the broken brainstorm shapes (`providers`/`api_base`/`tools:` list) so they aren't re-adopted.

## Test plan

- [x] `configure-opencode` → valid JSON + valid YAML orchestrator; re-run is non-destructive (`.opencode-sample`)
- [x] `install-opencode` → 22 agents, 366 skills
- [x] Smoke test 6/6; full skill-script runner 58/58; shellcheck clean
- [ ] Serve via `mlx_lm.server` + launch `opencode` and exercise the orchestrator's `task` fan-out — requires a local MLX model + TUI (documented for local run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)