### PR TITLE
feat(opencode): recommend + wire verified ecosystem plugins (subtask2, pty, OCX worktree)

### DIFF
--- a/.github/workflows/test-skill-scripts.yml
+++ b/.github/workflows/test-skill-scripts.yml
@@ -13,6 +13,7 @@ on:
       - '**/skills/**/scripts/**'
       - 'scripts/run-skill-script-tests.sh'
       - 'scripts/configure-opencode.sh'
+      - 'scripts/install-opencode-ocx.sh'
       - 'scripts/tests/test-configure-opencode.sh'
       - 'justfile'
       - '.github/workflows/test-skill-scripts.yml'

--- a/docs/opencode-export.md
+++ b/docs/opencode-export.md
@@ -154,6 +154,90 @@ opencode
 - Switch agents with **Tab** or the `/agents` picker — reach `orchestrator` there
   (and it's the `default_agent`, so it's selected on launch).
 
+## 6. Recommended ecosystem plugins
+
+OpenCode has a community plugin ecosystem that can sharpen the orchestrated
+local-model workflow. Every plugin below was **verified against npm / GitHub /
+opencode.ai/docs** — AI-suggested OpenCode plugin lists have a high fabrication
+rate, so names and install mechanisms here are the real ones, not the
+brainstormed forms.
+
+### How plugins load
+
+A plugin is a JS/TS module. Two load paths:
+
+- **npm package** listed in the `"plugin": [...]` array of `opencode.json` —
+  bare (`opencode-pty`), scoped (`@openspoon/subtask2`), or version-pinned
+  (`opencode-vibeguard@0.1.0`). OpenCode auto-installs them with Bun on startup.
+- **Local file** under `.opencode/plugins/` (project) or
+  `~/.config/opencode/plugins/` (global).
+
+There is **no `github:user/repo` shorthand** and **no central registry** —
+discover plugins by searching npm for the `opencode-plugin` keyword.
+
+### Baked-in defaults
+
+`just configure-opencode` writes a small, curated `plugin:` array (overridable
+via `OPENCODE_PLUGINS` or `just opencode_plugins="…" configure-opencode`):
+
+| Plugin (npm) | Why it's a default |
+|--------------|--------------------|
+| `@openspoon/subtask2` | The only orchestration plugin installable via the npm `plugin:` array. Adds flow-control over `/commands` and **verifies a subtask's output against the codebase before merging it back** — directly strengthens the orchestrator's fan-out. |
+| `opencode-pty` | Runs background/interactive processes (dev servers, test watchers, REPLs) in a pseudo-terminal and can send input (e.g. answer a `y/n` prompt), so a subagent doesn't hang on the synchronous built-in `bash` tool. |
+
+Both are npm, no API key, self-host-friendly.
+
+### Opt-in npm plugins
+
+Add these to your own `plugin:` array (or `OPENCODE_PLUGINS`) if they fit:
+
+| Plugin (real npm name) | What it does | Caveat |
+|------------------------|--------------|--------|
+| `@nick-vi/opencode-type-inject` | Injects TS/Svelte type signatures into file reads so the model skips whole source files (token saver). | TypeScript/Svelte only. Note the scoped name — bare `opencode-type-inject` is **not** the install string. |
+| `opencode-scheduler` | Schedules `opencode run` jobs on the OS-native scheduler (launchd / systemd timers / Task Scheduler, cron as fallback) for overnight maintenance. | Cross-platform — **not** macOS/launchd-only as sometimes claimed. |
+| `opencode-vibeguard` | Redacts secrets/PII to placeholders before context reaches the model, restores locally. | Early `v0.1.0`. Mainly valuable when mixing local + an **external** API; low value for a pure-local setup. Alternative: `opencode-secret-redactor`. |
+| `@f97/opencode-morph-fast-apply` / `@morphllm/opencode-morph-plugin` | Morph "fast apply": lazy edit markers (`// ... existing code ...`) for ~10× faster code patching. | **Requires an external Morph API key** — this breaks a fully-self-hosted-via-mlx setup. Opt in only if you accept an external apply service. Bare `opencode-morph-fast-apply` is a GitHub repo name, not the npm install string. |
+
+### Already covered — do not double-install
+
+The user's existing config lists **`@tarquinen/opencode-dcp`**, which *is*
+"dynamic context pruning" (dedupes repeated tool outputs + a model-invokable
+`compress` tool). The frequently-suggested `opencode-dynamic-context-pruning` is
+the **same package** (that's the GitHub repo name; `@tarquinen/opencode-dcp` is
+its npm name). Do not add a second copy.
+
+### OCX plugins (third-party CLI/registry)
+
+Three real orchestration plugins by `kdcokenny` are distributed via the
+third-party **OCX** CLI + registry (`registry.kdco.dev`), **not** the npm
+`plugin:` array — so they're a separate, explicitly opt-in path with a
+third-party trust dependency. They write into `.opencode/plugin/`.
+
+```
+just install-opencode-ocx        # installs worktree + background-agents via OCX
+```
+
+| OCX plugin | Recipe installs it? | Notes |
+|------------|---------------------|-------|
+| `worktree` | ✅ | Per-session git worktrees so parallel agents avoid branch collisions. Complements our `agent-coworker-detection` discipline. |
+| `background-agents` | ✅ | Async task delegation; persists sub-agent results to disk so they survive context compaction. |
+| `opencode-workspace` | ❌ **excluded by design** | Bundles its own researcher/coder/scribe/reviewer agents + DCP + worktrees (16 components). **Overlaps and competes with the agents + orchestrator we already export** — prefer ours. Documented here for awareness; `install-opencode-ocx` deliberately skips it. |
+
+`install-opencode-ocx` requires the OCX CLI on `PATH` (it does not install OCX
+itself); without it the recipe prints a prerequisite hint and exits cleanly.
+
+### Verified-vs-claimed corrections
+
+So the fabrication-prone forms aren't re-adopted:
+
+| Suggested form | Reality |
+|----------------|---------|
+| `opencode-dynamic-context-pruning` as a *new* install | Same package as the already-installed `@tarquinen/opencode-dcp` — redundant. |
+| bare `opencode-type-inject` | Scoped: `@nick-vi/opencode-type-inject`. |
+| bare `opencode-morph-fast-apply` | `@f97/opencode-morph-fast-apply` or `@morphllm/opencode-morph-plugin`; **needs a Morph API key**. |
+| `opencode-scheduler` = macOS/launchd-only | Cross-platform (launchd/systemd/cron fallback). |
+| `background-agents` / `workspace` / `worktree` via npm `plugin:` array | OCX-distributed (`registry.kdco.dev`), not npm; `workspace` overlaps our exported agents. |
+
 ## Gotchas — common-but-wrong config
 
 A plausible-looking config that does **not** work in OpenCode. If you're adapting

--- a/justfile
+++ b/justfile
@@ -105,6 +105,10 @@ opencode_config := env_var_or_default("OPENCODE_CONFIG", "~/.config/opencode")
 opencode_model := env_var_or_default("OPENCODE_MODEL", "Qwen3-30B-A3B")
 opencode_port := env_var_or_default("OPENCODE_PORT", "8080")
 opencode_provider := "mlx-local"
+# Default ecosystem plugins baked into the generated config (verified npm packages,
+# no API key, self-host-friendly). Override with OPENCODE_PLUGINS or `just opencode_plugins=…`.
+# Full verified menu (incl. opt-in + OCX plugins) in docs/opencode-export.md.
+opencode_plugins := env_var_or_default("OPENCODE_PLUGINS", "@openspoon/subtask2 opencode-pty")
 
 # Project skills + subagents to OpenCode format via rulesync (output: dist/opencode)
 [group: "opencode"]
@@ -123,7 +127,8 @@ configure-opencode target=opencode_config:
     ./scripts/configure-opencode.sh "{{target}}" \
         --provider "{{opencode_provider}}" \
         --model "{{opencode_model}}" \
-        --port "{{opencode_port}}"
+        --port "{{opencode_port}}" \
+        --plugins "{{opencode_plugins}}"
 
 # Install + configure, then print the serve + run next steps
 [group: "opencode"]
@@ -140,3 +145,8 @@ setup-opencode target=opencode_config: (install-opencode target) (configure-open
 [group: "opencode"]
 serve-opencode-model:
     mlx_lm.server --model {{opencode_model}} --port {{opencode_port}}
+
+# Opt-in: install OCX orchestration plugins (worktree + background-agents; excludes workspace)
+[group: "opencode"]
+install-opencode-ocx target=opencode_config:
+    ./scripts/install-opencode-ocx.sh "{{target}}"

--- a/scripts/configure-opencode.sh
+++ b/scripts/configure-opencode.sh
@@ -16,21 +16,25 @@
 # NOT the common-but-wrong shape (`providers`/`api_base`/`tools:` list). See
 # docs/opencode-export.md "Gotchas".
 #
-# Usage: ./scripts/configure-opencode.sh <target> [--provider P] [--model M] [--port N]
+# Usage: ./scripts/configure-opencode.sh <target> [--provider P] [--model M] [--port N] [--plugins "a b c"]
 set -euo pipefail
 
-config_target="${1:?usage: configure-opencode.sh <target> [--provider P] [--model M] [--port N]}"
+config_target="${1:?usage: configure-opencode.sh <target> [--provider P] [--model M] [--port N] [--plugins LIST]}"
 shift || true
 
 config_provider="mlx-local"
 config_model="Qwen3-30B-A3B"
 config_port="8080"
+# Default ecosystem plugins (verified npm packages, no API key, self-host-friendly).
+# See docs/opencode-export.md "Recommended ecosystem plugins".
+config_plugins="@openspoon/subtask2 opencode-pty"
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --provider) config_provider="$2"; shift 2 ;;
         --model)    config_model="$2";    shift 2 ;;
         --port)     config_port="$2";     shift 2 ;;
+        --plugins)  config_plugins="$2";  shift 2 ;;
         *) echo "unknown argument: $1" >&2; exit 2 ;;
     esac
 done
@@ -42,11 +46,23 @@ fi
 
 config_baseurl="http://127.0.0.1:${config_port}/v1"
 
+# Build the JSON array fragment from the space-separated plugin list. Manual
+# quoting is safe — plugin names are @/scope/-/alnum only, no JSON metacharacters.
+config_plugins_json=""
+for config_plugin in $config_plugins; do
+    if [ -z "$config_plugins_json" ]; then
+        config_plugins_json="\"$config_plugin\""
+    else
+        config_plugins_json="$config_plugins_json, \"$config_plugin\""
+    fi
+done
+
 echo "=== OPENCODE CONFIGURE ==="
 echo "TARGET=$config_target"
 echo "PROVIDER=$config_provider"
 echo "MODEL=$config_model"
 echo "BASEURL=$config_baseurl"
+echo "PLUGINS=$config_plugins"
 
 mkdir -p "$config_target/agents"
 
@@ -71,13 +87,14 @@ cat > "$config_json" <<JSON
       "models": { "$config_model": { "name": "$config_model" } }
     }
   },
+  "plugin": [$config_plugins_json],
   "model": "$config_provider/$config_model",
   "default_agent": "orchestrator"
 }
 JSON
 echo "CONFIG_WRITTEN=$config_json"
 if [ "$config_json" != "$config_target/opencode.json" ]; then
-    echo "MERGE_HINT=existing opencode.json kept; merge provider/model/default_agent from the .opencode-sample by hand"
+    echo "MERGE_HINT=existing opencode.json kept; merge provider/model/default_agent and APPEND the plugin entries to your existing plugin array (do not replace it) from the .opencode-sample"
 fi
 
 # --- agents/orchestrator.md (generated artifact, always rewritten) -----------

--- a/scripts/install-opencode-ocx.sh
+++ b/scripts/install-opencode-ocx.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# install-opencode-ocx.sh — opt-in installer for the OCX-distributed OpenCode
+# orchestration plugins that complement (rather than overlap) our exported setup.
+#
+# Installs ONLY the non-overlapping plugins:
+#   - worktree           — per-session git worktrees for parallel agents
+#   - background-agents  — async task delegation with on-disk result persistence
+#
+# DELIBERATELY EXCLUDED: opencode-workspace. It bundles its own researcher/coder/
+# reviewer agents + DCP + worktrees, which overlap and compete with the agents +
+# orchestrator we already export. Prefer ours. See docs/opencode-export.md.
+#
+# These plugins are distributed via the third-party OCX CLI + registry
+# (registry.kdco.dev), NOT the npm `plugin:` array — so this is a separate,
+# explicitly opt-in path with a third-party trust dependency. OCX must already be
+# installed and on PATH; this script does not install OCX itself.
+#
+# Usage: ./scripts/install-opencode-ocx.sh [target]   (target reserved for future scoping)
+set -euo pipefail
+
+ocx_target="${1:-~/.config/opencode}"
+
+echo "=== OPENCODE OCX INSTALL ==="
+echo "TARGET=$ocx_target"
+echo "EXCLUDED=opencode-workspace (overlaps our exported agents/orchestrator — prefer ours)"
+
+if ! command -v ocx >/dev/null 2>&1; then
+    echo "OCX_AVAILABLE=false"
+    echo "PREREQUISITE=the OCX CLI is required and was not found on PATH"
+    echo "HINT=install the OCX CLI (kdcokenny OpenCode ecosystem; registry at https://registry.kdco.dev), then re-run"
+    echo "STATUS=SKIP"
+    echo "ISSUE_COUNT=0"
+    echo "=== END OPENCODE OCX INSTALL ==="
+    exit 0
+fi
+echo "OCX_AVAILABLE=true"
+
+ocx_issue_count=0
+for ocx_plugin in worktree background-agents; do
+    echo "INSTALLING=$ocx_plugin"
+    if ocx add "kdco/$ocx_plugin" --from https://registry.kdco.dev; then
+        echo "INSTALLED=$ocx_plugin"
+    else
+        echo "FAILED=$ocx_plugin"
+        ocx_issue_count=$((ocx_issue_count + 1))
+    fi
+done
+
+if [ "$ocx_issue_count" -eq 0 ]; then
+    echo "STATUS=OK"
+else
+    echo "STATUS=ERROR"
+fi
+echo "ISSUE_COUNT=$ocx_issue_count"
+echo "=== END OPENCODE OCX INSTALL ==="

--- a/scripts/tests/test-configure-opencode.sh
+++ b/scripts/tests/test-configure-opencode.sh
@@ -81,6 +81,39 @@ assert "original opencode.json preserved" \
 assert "second run writes opencode.json.opencode-sample" \
   "$([ -f "$fixture/opencode.json.opencode-sample" ] && echo true || echo false)"
 
+echo "=== TEST D: default plugin array (no redundant dcp) ==="
+# Fresh fixture so we assert against the primary opencode.json, not a .sample.
+plugfix="$(mktemp -d)"
+bash "$configure" "$plugfix" >/dev/null   # no --plugins → script default
+assert "default plugin array contains @openspoon/subtask2 + opencode-pty, valid JSON, no redundant dcp" \
+  "$(python3 - "$plugfix/opencode.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+p = d.get("plugin")
+ok = (
+    isinstance(p, list)
+    and "@openspoon/subtask2" in p
+    and "opencode-pty" in p
+    # @tarquinen/opencode-dcp IS dynamic context pruning; never bake a second copy.
+    and not any("dynamic-context-pruning" in x or "opencode-dcp" in x for x in p)
+)
+print("true" if ok else "false")
+PY
+)"
+rm -rf "$plugfix"
+
+echo "=== TEST E: empty plugin list → valid empty array ==="
+emptyfix="$(mktemp -d)"
+bash "$configure" "$emptyfix" --plugins "" >/dev/null
+assert "--plugins '' yields a valid empty plugin array" \
+  "$(python3 - "$emptyfix/opencode.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+print("true" if d.get("plugin") == [] else "false")
+PY
+)"
+rm -rf "$emptyfix"
+
 echo ""
 echo "=== SUMMARY ==="
 echo "PASSED=$pass_count"


### PR DESCRIPTION
## Summary

Follow-up to #1709. Acts on a brainstormed list of OpenCode ecosystem plugins — **verified against npm / GitHub / opencode.ai** before adoption, since the list carried the usual fabrications.

### Key verification findings
- `opencode-dynamic-context-pruning` is the **same package** as the already-installed `@tarquinen/opencode-dcp` → redundant, dropped.
- `@openspoon/subtask2` is the **only** orchestration plugin installable via the npm `plugin:` array (verifies subtask output before merge).
- The kdcokenny trio (`background-agents`, `workspace`, `worktree`) is **OCX-distributed** (third-party registry), not npm. `opencode-workspace` bundles its own agents that **overlap our exported agents + orchestrator**.
- `opencode-type-inject` → `@nick-vi/opencode-type-inject` (scoped). Morph fast-apply → needs a **Morph API key** (breaks fully-local). `opencode-scheduler` is cross-platform, not launchd-only.

## Changes

- **`scripts/configure-opencode.sh`** — `--plugins` arg; emits a valid `plugin:` JSON array (empty list → `[]`); broadened merge hint to say *append* (don't replace) the user's existing `plugin` array.
- **`justfile`** — `opencode_plugins` var (default `@openspoon/subtask2 opencode-pty`, overridable via `OPENCODE_PLUGINS`); `configure-opencode` passes `--plugins`; new opt-in `install-opencode-ocx` recipe.
- **`scripts/install-opencode-ocx.sh`** (new) — installs only the non-overlapping OCX plugins (`worktree` + `background-agents`); **excludes `opencode-workspace`** by design; skips cleanly with a prerequisite hint when `ocx` isn't on PATH.
- **`docs/opencode-export.md`** — "Recommended ecosystem plugins" section: load mechanism, baked-in defaults, opt-in menu with caveats, the dcp-redundancy note, the OCX trio + workspace overlap warning, and a verified-vs-claimed correction table.
- **`scripts/tests/test-configure-opencode.sh`** — extended to 8 asserts: default array contains subtask2+pty and **no redundant dcp**; empty `--plugins` → valid `[]`.

## Test plan

- [x] `just configure-opencode` → `"plugin": ["@openspoon/subtask2","opencode-pty"]`, valid JSON
- [x] `just opencode_plugins="" configure-opencode` → `"plugin": []`
- [x] `just install-opencode-ocx` with no `ocx` → prerequisite hint, `STATUS=SKIP`, exit 0
- [x] Smoke test 8/8; skill-script runner green; shellcheck clean; `just --list` shows the recipe
- [ ] `ocx`-present install of worktree + background-agents — requires the OCX CLI (documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)