### PR TITLE
fix(opencode): make exported skill names opencode-valid and guard double-install

### DIFF
--- a/.github/workflows/test-skill-scripts.yml
+++ b/.github/workflows/test-skill-scripts.yml
@@ -14,7 +14,11 @@ on:
       - 'scripts/run-skill-script-tests.sh'
       - 'scripts/configure-opencode.sh'
       - 'scripts/install-opencode-ocx.sh'
+      - 'scripts/install-opencode.sh'
+      - 'scripts/export-opencode.sh'
+      - 'scripts/rewrite-skill-name-to-dir.py'
       - 'scripts/tests/test-configure-opencode.sh'
+      - 'scripts/tests/test-rewrite-skill-name-to-dir.sh'
       - 'justfile'
       - '.github/workflows/test-skill-scripts.yml'
   push:
@@ -43,3 +47,6 @@ jobs:
 
       - name: Smoke-test the OpenCode config generator
         run: bash scripts/tests/test-configure-opencode.sh
+
+      - name: Regression-test the OpenCode skill-name rewrite
+        run: bash scripts/tests/test-rewrite-skill-name-to-dir.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,3 +124,9 @@ repos:
         language: system
         files: '^scripts/(check-context-command-execution\.sh|tests/test-check-context-command-execution\.sh)$'
         pass_filenames: false
+      - id: test-rewrite-skill-name-to-dir
+        name: opencode skill-name rewrite regression
+        entry: bash ./scripts/tests/test-rewrite-skill-name-to-dir.sh
+        language: system
+        files: '^scripts/(rewrite-skill-name-to-dir\.py|export-opencode\.sh|install-opencode\.sh|tests/test-rewrite-skill-name-to-dir\.sh)$'
+        pass_filenames: false

--- a/docs/opencode-export.md
+++ b/docs/opencode-export.md
@@ -46,6 +46,19 @@ OpenCode reads **plural** `agents/` and `skills/` directories (singular is
 accepted for back-compat); the export already emits plural, so no rename is
 needed.
 
+### Skill `name` normalization
+
+OpenCode validates skill frontmatter more strictly than Claude Code: `name` must
+match `[a-z0-9-]+` **and** equal the skill's directory name. A handful of source
+skills are valid Claude Code but violate this — display-style names (`UnoCSS`,
+`Lightning CSS`) and unprefixed invocation names (`refocus` in dir
+`project-refocus`, `ground-response` in dir `prompt-engineering-ground-response`).
+The export's staging step (`rewrite-skill-name-to-dir.py`) rewrites each skill's
+`name` to its directory basename, which is always unique and pattern-clean. This
+runs on the disposable staging copy only — **the source tree keeps its house-style
+names.** Without it, OpenCode aborts those skills at launch with `Invalid
+frontmatter … name` / `Name mismatch`.
+
 ## 2. Serve the model
 
 OpenCode talks to any OpenAI-compatible `/v1` endpoint. Serve a local model with
@@ -142,6 +155,15 @@ just setup-opencode .opencode     # project → ./.opencode
 `setup-opencode` = `install-opencode` (copies `agents/` + `skills/` **additively**
 — your own agents/skills are preserved) + `configure-opencode`, then prints the
 serve + run next steps.
+
+> **Install into ONE scope only.** OpenCode *merges* global
+> (`~/.config/opencode`) and project (`./.opencode`) skills, so installing this
+> marketplace into both loads every skill twice and OpenCode reports
+> `Duplicate tool names detected` at launch. `install-opencode` drops a
+> `.claude-plugins-opencode-receipt` marker in each scope it installs into and
+> emits `STATUS=WARN` + a `FIX=` remediation line if the complementary scope
+> already carries one. Pick global *or* project; to switch, remove the other
+> scope's `skills/`, `agents/`, and receipt first.
 
 Then:
 

--- a/scripts/export-opencode.sh
+++ b/scripts/export-opencode.sh
@@ -67,6 +67,14 @@ echo "STAGED_AGENTS=$export_agent_count"
 python3 "$export_script_dir/normalize-skill-allowed-tools.py" \
     "$export_staging/.claude/skills"/*/SKILL.md >/dev/null
 
+# 3b. Rewrite each skill's `name` to its directory basename. OpenCode requires
+#     name to be [a-z0-9-]+ AND to equal the directory name; a few source skills
+#     carry display-style names (UnoCSS) or unprefixed invocation names (refocus
+#     in dir project-refocus) that are valid Claude Code but rejected by OpenCode.
+#     Staging-only — the source tree keeps its house-style names.
+python3 "$export_script_dir/rewrite-skill-name-to-dir.py" \
+    "$export_staging/.claude/skills"/*/SKILL.md
+
 # 4. Convert claudecode -> opencode.
 ( cd "$export_staging" && bunx "rulesync@${export_rulesync_version}" convert \
     --from claudecode --to opencode --features skills,subagents --silent )

--- a/scripts/install-opencode.sh
+++ b/scripts/install-opencode.sh
@@ -20,6 +20,32 @@ fi
 echo "=== OPENCODE INSTALL ==="
 echo "TARGET=$install_target"
 
+# Cross-scope duplicate guard. OpenCode MERGES global (~/.config/opencode) and
+# project (<cwd>/.opencode) skills, so installing this marketplace into BOTH
+# scopes loads every skill twice -> "Duplicate tool names detected" at launch.
+# A receipt file marks each scope we install into; if the COMPLEMENTARY scope
+# already carries one, warn loudly (do not block — re-installing one scope is fine).
+install_receipt=".claude-plugins-opencode-receipt"
+install_global_dir="${OPENCODE_CONFIG:-$HOME/.config/opencode}"
+if [ "${install_global_dir#\~}" != "$install_global_dir" ]; then
+    install_global_dir="${HOME}${install_global_dir#\~}"
+fi
+install_project_dir="$PWD/.opencode"
+
+case "$install_target" in
+    "$install_global_dir"|"$install_global_dir"/) install_other="$install_project_dir" ;;
+    *.opencode|*.opencode/) install_other="$install_global_dir" ;;
+    *) install_other="" ;;
+esac
+
+install_dup_warned=0
+if [ -n "$install_other" ] && [ -f "$install_other/$install_receipt" ]; then
+    install_dup_warned=1
+    echo "DUPLICATE_SCOPE_DETECTED=$install_other"
+    echo "WARNING=this marketplace is already installed in the complementary scope; OpenCode merges global + project skills, so launching there will report duplicate tool names"
+    echo "FIX=install into ONE scope only — remove the other with: rm -f \"$install_other/$install_receipt\" && rm -rf \"$install_other/skills\" \"$install_other/agents\""
+fi
+
 install_tmp="$(mktemp -d)"
 trap 'rm -rf "$install_tmp"' EXIT
 
@@ -31,8 +57,19 @@ cp -R "$install_tmp/skills/." "$install_target/skills/"
 
 install_agents="$(find "$install_target/agents" -name '*.md' 2>/dev/null | wc -l | tr -d ' ')"
 install_skills="$(find "$install_target/skills" -name 'SKILL.md' 2>/dev/null | wc -l | tr -d ' ')"
+
+# Drop a receipt so a later install into the complementary scope can detect us.
+printf 'installed_at_count=%s\nskills=%s\nagents=%s\n' \
+    "$install_target" "$install_skills" "$install_agents" > "$install_target/$install_receipt"
+
 echo "INSTALLED_AGENTS=$install_agents"
 echo "INSTALLED_SKILLS=$install_skills"
-echo "STATUS=OK"
-echo "ISSUE_COUNT=0"
+echo "RECEIPT=$install_target/$install_receipt"
+if [ "$install_dup_warned" -eq 1 ]; then
+    echo "STATUS=WARN"
+    echo "ISSUE_COUNT=1"
+else
+    echo "STATUS=OK"
+    echo "ISSUE_COUNT=0"
+fi
 echo "=== END OPENCODE INSTALL ==="

--- a/scripts/rewrite-skill-name-to-dir.py
+++ b/scripts/rewrite-skill-name-to-dir.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Rewrite each SKILL.md `name` frontmatter field to its directory basename.
+
+OpenCode validates skill frontmatter more strictly than Claude Code:
+
+  1. `name` must match `[a-z0-9-]+` (lowercase alphanumeric with hyphens).
+  2. `name` must equal the skill's directory name.
+
+This repo's house style diverges on both points for a handful of skills:
+
+  - Two auto-discovered skills carry display-style names (`UnoCSS`,
+    `Lightning CSS`) that fail rule 1.
+  - User-invocable skills use the *unprefixed* invocation name (`refocus`,
+    `ground-response`) while their directory is plugin-prefixed
+    (`project-refocus`, `prompt-engineering-ground-response`), failing rule 2.
+
+Both are valid Claude Code (the `name` field there is a display/invocation label,
+not a directory-coupled identifier), so the source tree is left untouched.
+`export-opencode.sh` runs this over its disposable staging copy, where the skill
+directory basenames are already globally unique and `[a-z0-9-]+`-clean — so
+setting `name = basename` satisfies both OpenCode rules at once.
+
+Usage:
+  rewrite-skill-name-to-dir.py [--check] [PATH ...]
+
+  --check   Report files that WOULD change, exit 1 if any. No writes.
+  PATH      SKILL.md files; defaults to */skills/*/SKILL.md under cwd.
+"""
+from __future__ import annotations
+
+import glob
+import re
+import sys
+from pathlib import Path
+
+FM_RE = re.compile(r"^(---\n)(.*?\n)(---\n)", re.DOTALL)
+# `$` (MULTILINE) anchors just before the line's newline, so the matched span
+# excludes the trailing `\n` — the replacement must not re-add one.
+NAME_RE = re.compile(r"^name:[ \t]*(.*?)[ \t]*$", re.MULTILINE)
+
+
+def rewrite(text: str, dir_name: str) -> tuple[str, bool]:
+    """Set the frontmatter `name` field to dir_name. Returns (text, changed)."""
+    m = FM_RE.match(text)
+    if not m:
+        return text, False
+    head, body, tail = m.group(1), m.group(2), m.group(3)
+    nm = NAME_RE.search(body)
+    if not nm:
+        return text, False
+    current = nm.group(1).strip().strip("\"'")
+    if current == dir_name:
+        return text, False
+    new_body = body[: nm.start()] + f"name: {dir_name}" + body[nm.end() :]
+    return head + new_body + tail + text[m.end() :], True
+
+
+def process(path: Path, check: bool) -> bool:
+    """Return True if the file changed (or would change in --check mode)."""
+    text = path.read_text(encoding="utf-8")
+    new_text, changed = rewrite(text, path.parent.name)
+    if changed and not check:
+        path.write_text(new_text, encoding="utf-8")
+    return changed
+
+
+def main(argv: list[str]) -> int:
+    check = "--check" in argv
+    args = [a for a in argv if a != "--check"]
+    if args:
+        paths = [Path(p) for p in args]
+    else:
+        paths = [Path(p) for p in glob.glob("*/skills/*/SKILL.md")]
+
+    changed_any = False
+    for path in paths:
+        if not path.is_file():
+            continue
+        if process(path, check):
+            changed_any = True
+            verb = "would rewrite" if check else "rewrote"
+            print(f"{verb} name in {path}", file=sys.stderr)
+
+    if check and changed_any:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/tests/test-rewrite-skill-name-to-dir.sh
+++ b/scripts/tests/test-rewrite-skill-name-to-dir.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Regression test for scripts/rewrite-skill-name-to-dir.py and its wiring into the
+# OpenCode export/install pipeline.
+#
+# Motivating bug: `opencode` validates skill frontmatter strictly —
+#   1. `name` must match [a-z0-9-]+
+#   2. `name` must equal the skill's directory name
+# Four exported skills failed at launch: `UnoCSS`/`Lightning CSS` (rule 1) and
+# `refocus`/`ground-response` in plugin-prefixed dirs (rule 2). The fix rewrites
+# each staged skill's `name` to its directory basename during export.
+#
+# Guards:
+#   A. an invalid display-style name (UnoCSS) is rewritten to the dir basename
+#   B. an unprefixed name (refocus) in a prefixed dir is rewritten to the dir
+#   C. a name already equal to the dir is left untouched (idempotent)
+#   D. --check exits 1 when a rewrite is needed, 0 when clean
+#   E. the rewritten frontmatter is valid YAML and opencode-name-valid
+#   F. export-opencode.sh still invokes the rewrite step (wiring not dropped)
+#   G. install-opencode.sh still carries the cross-scope duplicate guard
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+rewriter="$repo_root/scripts/rewrite-skill-name-to-dir.py"
+
+pass_count=0
+fail_count=0
+assert() {
+  if [ "$2" = "true" ]; then
+    pass_count=$((pass_count + 1))
+  else
+    echo "FAIL: $1" >&2
+    fail_count=$((fail_count + 1))
+  fi
+}
+name_of() { grep -m1 '^name:' "$1" | sed 's/^name:[[:space:]]*//'; }
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# Fixtures: (dir, original-name)
+mk_skill() {
+  mkdir -p "$tmp/$1"
+  printf -- '---\nname: %s\ndescription: x. Use when y.\nallowed-tools: Read\n---\n\n# body\n' \
+    "$2" > "$tmp/$1/SKILL.md"
+}
+mk_skill unocss "UnoCSS"
+mk_skill project-refocus "refocus"
+mk_skill git-push "git-push"
+
+echo "=== TEST D: --check exits 1 on needed rewrite ==="
+check_rc=0
+python3 "$rewriter" --check "$tmp"/*/SKILL.md >/dev/null 2>&1 || check_rc=$?
+assert "--check should exit 1 when rewrites are pending" \
+  "$([ "$check_rc" -eq 1 ] && echo true || echo false)"
+
+echo "=== apply rewrite ==="
+python3 "$rewriter" "$tmp"/*/SKILL.md >/dev/null 2>&1
+
+echo "=== TEST A: invalid display name -> dir basename ==="
+assert "unocss name rewritten to 'unocss'" \
+  "$([ "$(name_of "$tmp/unocss/SKILL.md")" = "unocss" ] && echo true || echo false)"
+
+echo "=== TEST B: unprefixed name -> prefixed dir basename ==="
+assert "project-refocus name rewritten to 'project-refocus'" \
+  "$([ "$(name_of "$tmp/project-refocus/SKILL.md")" = "project-refocus" ] && echo true || echo false)"
+
+echo "=== TEST C: matching name left untouched ==="
+assert "git-push name unchanged" \
+  "$([ "$(name_of "$tmp/git-push/SKILL.md")" = "git-push" ] && echo true || echo false)"
+
+echo "=== TEST D2: --check exits 0 after rewrite (idempotent) ==="
+check_rc=0
+python3 "$rewriter" --check "$tmp"/*/SKILL.md >/dev/null 2>&1 || check_rc=$?
+assert "--check should exit 0 when clean" \
+  "$([ "$check_rc" -eq 0 ] && echo true || echo false)"
+
+echo "=== TEST E: rewritten frontmatter is valid + opencode-name-valid ==="
+e_ok="true"
+for f in "$tmp"/*/SKILL.md; do
+  d="$(basename "$(dirname "$f")")"
+  python3 - "$f" "$d" <<'PY' || e_ok="false"
+import re, sys, yaml
+f, d = sys.argv[1], sys.argv[2]
+fm = re.match(r"^---\n(.*?)\n---", open(f).read(), re.S).group(1)
+data = yaml.safe_load(fm)
+name = data["name"]
+assert re.fullmatch(r"[a-z0-9-]+", name), f"invalid name {name!r}"
+assert name == d, f"name {name!r} != dir {d!r}"
+PY
+done
+assert "all rewritten skills are valid YAML and opencode-name-valid" "$e_ok"
+
+echo "=== TEST F: export-opencode.sh invokes the rewrite step ==="
+assert "export wiring present" \
+  "$(grep -q 'rewrite-skill-name-to-dir.py' "$repo_root/scripts/export-opencode.sh" && echo true || echo false)"
+
+echo "=== TEST G: install-opencode.sh carries the cross-scope duplicate guard ==="
+assert "install cross-scope guard present" \
+  "$(grep -q 'DUPLICATE_SCOPE_DETECTED' "$repo_root/scripts/install-opencode.sh" && echo true || echo false)"
+
+echo "=== RESULTS: $pass_count passed, $fail_count failed ==="
+[ "$fail_count" -eq 0 ]


### PR DESCRIPTION
## Problem

Launching OpenCode in a project that had this marketplace exported/installed produced three classes of failure (from a test-project launch log):

| Error | Root cause |
|---|---|
| `Invalid frontmatter … name must be lowercase alphanumeric with hyphens` (`unocss`, `lightning-css`) | Source `name:` is `UnoCSS` / `Lightning CSS` — valid Claude Code, rejected by OpenCode's stricter `[a-z0-9-]+` rule |
| `Name mismatch … "refocus" vs "project-refocus"` (+ `ground-response`) | Our convention uses the *unprefixed* invocation name in a *plugin-prefixed* directory; OpenCode requires `name` == directory name |
| `Duplicate tool names detected` (262+) | The marketplace was installed in **both** `~/.config/opencode/skills` and the project's `.opencode/skills`; OpenCode merges global + project, loading every skill twice |

OpenCode validates skill frontmatter more strictly than Claude Code. In Claude Code `name` is a display/invocation label, not a directory-coupled identifier, so the source skills are correct as-is — the fix lives in the export pipeline, not the source tree.

## Changes

- **`scripts/rewrite-skill-name-to-dir.py`** (new) — rewrites each *staged* skill's `name` to its directory basename (always unique + pattern-clean), fixing both the invalid-name and name-mismatch classes at once. Runs on the disposable export staging copy only; the source tree keeps its house-style names.
- **`scripts/export-opencode.sh`** — wires the rewrite in as step 3b (after `allowed-tools` normalize, before rulesync convert). Verified end-to-end: **0/366 invalid-or-mismatch** after a full export (was 4).
- **`scripts/install-opencode.sh`** — drops a per-scope receipt and emits `STATUS=WARN` + a `FIX=` remediation line when the complementary scope (global ↔ project `.opencode`) already carries one — the double-install case behind the duplicate-tool-name warnings.
- **`scripts/tests/test-rewrite-skill-name-to-dir.sh`** (new, 8 checks) — regression test wired into pre-commit and the *Test: Skill scripts* workflow, per `.claude/rules/regression-testing.md`. Also guards that the export/install wiring isn't silently dropped later.
- **`docs/opencode-export.md`** — documents the name normalization and the "install into ONE scope only" rule.

## Verification

- Full `export-opencode.sh` run → 366 skills exported, 0 invalid-or-mismatch (previously the 4 named above).
- `install-opencode.sh` cross-scope guard tested in a sandbox: clean install → `STATUS=OK`; second install in the complementary scope → `STATUS=WARN` with the exact cleanup command.
- shellcheck clean, ruff clean, `py_compile` OK, repo shell lint exit 0, regression test 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbJ2WZsEpFNYNMykcj8ERt