### PR TITLE
fix(hooks-plugin): stop bash-antipatterns blocking echo/printf to stdout and /dev streams

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -130,3 +130,9 @@ repos:
         language: system
         files: '^scripts/(rewrite-skill-name-to-dir\.py|export-opencode\.sh|install-opencode\.sh|tests/test-rewrite-skill-name-to-dir\.sh)$'
         pass_filenames: false
+      - id: test-bash-antipatterns
+        name: bash-antipatterns hook detection regression
+        entry: bash ./hooks-plugin/hooks/test-bash-antipatterns.sh
+        language: system
+        files: '^hooks-plugin/hooks/(bash-antipatterns\.sh|test-bash-antipatterns\.sh)$'
+        pass_filenames: false

--- a/hooks-plugin/hooks/bash-antipatterns.sh
+++ b/hooks-plugin/hooks/bash-antipatterns.sh
@@ -97,17 +97,30 @@ if echo "$COMMAND" | grep -Eq "awk\s+.*>\s*['\"]?[^|]+" && \
     block "REMINDER: Use the Edit tool instead of 'awk' for file modifications. The Edit tool is safer and more precise."
 fi
 
-# Check for cat/echo writing to files (not heredocs in valid bash scripts)
+# Check for echo/printf writing to a FILE (not stdout, a pipe, or a /dev stream).
+#
 # Use [^;&|]* instead of .* to avoid crossing command separators (;, &&, ||, |)
-# which would cause false positives when echo "text" is followed by an unrelated 2>/dev/null
-# Strip single-quoted strings first: content inside single quotes is literal bash text
-# (e.g., kubectl exec -- php -r 'echo "$c->id"') and cannot contain shell redirections.
-# shellcheck disable=SC2001  # bash pattern substitution can't do regex char class `[^']*`
-COMMAND_NO_SQUOTES=$(echo "$COMMAND" | sed "s/'[^']*'//g")
-if echo "$COMMAND_NO_SQUOTES" | grep -Eq '(^|\s)(echo|printf)\s+[^;&|]*>\s*[^&]' && \
-   ! echo "$COMMAND_NO_SQUOTES" | grep -Eq '(echo|printf).*>>\s*/dev/null'; then
-    # Allow echo to /dev/null, but warn about file writes
-    if echo "$COMMAND_NO_SQUOTES" | grep -Eq '(echo|printf)\s+[^;&|>]+>\s*[a-zA-Z/\.]'; then
+# which would cause false positives when echo "text" is followed by an unrelated
+# 2>/dev/null.
+#
+# Scan COMMAND_NO_STRINGS (heredoc bodies AND quoted-string literals stripped) so
+# a `>` that is merely text inside a quoted argument — a section header, prose, or
+# a documented redirect example like `echo "use foo > out.txt"` — is not mistaken
+# for a real shell redirection. Only a `>` that survives quote stripping is an
+# actual redirection operator (issue #1701). Stripping single quotes alone left
+# double-quoted `>` content (the common section-header case) firing this block.
+#
+# Exempt stream targets, mirroring the cat/head/tail /dev exemptions: stdout and
+# pipes leave no surviving `>`, `>&N` fd-duplication is excluded by the `[^&]`
+# after `>`, and a stdout redirect to a `/dev/*` device/stream target (/dev/null,
+# /dev/stderr, /dev/stdout, /dev/tty, /dev/fd/N) is stream handling, not file
+# creation (issue #1701). The exemption requires a non-digit before `>` so a
+# stderr redirect (`2>/dev/null`) accompanying a real file write does not exempt
+# the whole command.
+if echo "$COMMAND_NO_STRINGS" | grep -Eq '(^|\s)(echo|printf)\s+[^;&|]*>\s*[^&]' && \
+   ! echo "$COMMAND_NO_STRINGS" | grep -Eq '[^0-9]>\s*/dev/'; then
+    # Block only when the redirect target is a real file path.
+    if echo "$COMMAND_NO_STRINGS" | grep -Eq '(echo|printf)\s+[^;&|>]*>\s*[a-zA-Z/.]'; then
         block "REMINDER: Use the Write tool instead of 'echo/printf > file' to create files. The Write tool properly handles file creation and provides better error handling."
     fi
 fi

--- a/hooks-plugin/hooks/test-bash-antipatterns.sh
+++ b/hooks-plugin/hooks/test-bash-antipatterns.sh
@@ -163,6 +163,21 @@ assert_exit \
     "echo in compound command before git 2>/dev/null is allowed" 0 \
     "cd /some/repo && git log --oneline -10 -- infra/ 2>/dev/null | head -20; echo '---'; git log --oneline 2>/dev/null | head -20"
 
+# ── echo/printf stream-target & quoted-`>` false-positive regression (issue #1701) ──
+# The block must only fire on a redirect to a real FILE. These check that:
+#   1. a single `> /dev/null` (not just `>>`) is exempt — the comment always
+#      claimed echo-to-/dev/null was allowed, but the old exemption matched only
+#      `>>`, so `echo x > /dev/null` was wrongly blocked;
+#   2. a real file write whose *stderr* is sent to /dev/null still blocks — the
+#      `2>/dev/null` must not exempt the genuine `> realfile.txt` write.
+assert_exit \
+    "echo > /dev/null (single >) is allowed (issue #1701)" 0 \
+    "echo x > /dev/null"
+
+assert_exit \
+    "real file write with unrelated 2>/dev/null still blocks (issue #1701)" 2 \
+    "echo data > realfile.txt 2>/dev/null"
+
 # ── heredoc body false-positive regression ───────────────────────────────────
 # Regression: `gh pr create --body "$(cat <<EOF ... EOF)"` bodies containing
 # example shell commands (e.g. "git add && git commit" shown as documentation
@@ -263,6 +278,38 @@ OUTER
 assert_exit_complex \
     "cat > /tmp/body.md heredoc fed to gh issue edit --body-file is allowed" 0 \
     "$issuebody_cmd"
+
+# ── echo/printf double-quoted-`>` & /dev-stream regression (issue #1701) ──────
+# These cases carry double quotes, so they need jq-based JSON (assert_exit's
+# printf cannot escape them). The block scans the quoted-string-stripped view, so
+# a `>` inside a double-quoted argument is text, not a redirection; and a stdout
+# redirect to a /dev/* stream target is stream handling, not file creation.
+echo ""
+echo "echo/printf with double-quoted '>' or /dev stream target is allowed (issue #1701):"
+
+assert_exit_complex \
+    "echo with literal '>' inside double quotes (no redirection) is allowed" 0 \
+    'echo "use foo > bar.txt to write"'
+
+assert_exit_complex \
+    "echo section header containing '>' is allowed" 0 \
+    'echo "=== build > test ==="; git status'
+
+assert_exit_complex \
+    "echo redirected to /dev/stderr is allowed (stream, not a file)" 0 \
+    'echo "error happened" > /dev/stderr'
+
+assert_exit_complex \
+    "printf redirected to /dev/stderr is allowed (stream, not a file)" 0 \
+    'printf "%s\n" "warning" > /dev/stderr'
+
+assert_exit_complex \
+    "echo redirected to /dev/tty is allowed (stream, not a file)" 0 \
+    'echo hi > /dev/tty'
+
+assert_exit_complex \
+    "echo to a real double-quoted-content file still blocks" 2 \
+    'echo "content" > realfile.txt'
 
 # True positive preserved: a heredoc commit message to /tmp passed to git commit -F
 # still earns the reminder, because the command actually composes a git commit.

--- a/hooks-plugin/hooks/test-bash-antipatterns.sh
+++ b/hooks-plugin/hooks/test-bash-antipatterns.sh
@@ -516,7 +516,12 @@ assert_stderr_contains \
 echo ""
 echo "git push -u: no-colon feature push allowed, colon main:feat footgun blocked (#1600):"
 
-PUSH_REPO=$(mktemp -d)
+# Guard the sandbox dir before any `git -C "$PUSH_REPO" …`. If mktemp fails and
+# PUSH_REPO is empty, `git -C "" init` silently falls back to the CWD — which, in
+# a shared checkout, re-inits the real repo and writes a junk identity into its
+# config (the issue #1692 shared-checkout leak; observed once here). Fail fast.
+PUSH_REPO=$(mktemp -d) || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
+[ -n "$PUSH_REPO" ] && [ -d "$PUSH_REPO" ] || { echo "FATAL: invalid sandbox dir '$PUSH_REPO'" >&2; exit 1; }
 git -C "$PUSH_REPO" init -q -b main
 git -C "$PUSH_REPO" config user.email t@e.com
 git -C "$PUSH_REPO" config user.name t


### PR DESCRIPTION
## Summary

Fixes #1701. The `bash-antipatterns` hook's "use the Write tool instead of `echo`/`printf` > file" reminder fired on commands that **write no file**, blocking benign diagnostic output.

Three concrete, reproducible over-triggers (all verified against the hook before/after):

| Command | Before | After |
|---|---|---|
| `echo x > /dev/null` | ❌ blocked (comment claimed it was allowed; exemption matched only `>>`) | ✅ allowed |
| `echo "err" > /dev/stderr` (also `/dev/stdout`, `/dev/tty`, `/dev/fd/N`) | ❌ blocked as a "file write" | ✅ allowed (stream, not a file) |
| `echo "use foo > bar.txt"` / `echo "=== build > test ==="` (literal `>` inside double quotes) | ❌ blocked | ✅ allowed |
| `echo data > realfile.txt` | ✅ blocked | ✅ still blocked |
| `echo data > realfile.txt 2>/dev/null` (real write, stderr to /dev/null) | ✅ blocked | ✅ still blocked |

## Root cause

The block stripped only **single**-quoted strings, so a `>` inside a **double**-quoted argument (the common section-header case) was read as a redirection operator. And the `/dev/null` exemption matched only `>>`, never a single `>`, and didn't cover other `/dev/*` stream targets.

## Fix

- Scan the existing `COMMAND_NO_STRINGS` view (heredoc bodies **and** both quote types stripped), so only a `>` that survives quote-stripping counts as a real redirection.
- Exempt stdout redirects to `/dev/*` stream targets, mirroring the `cat`/`head`/`tail` `/dev` exemptions. The exemption requires a **non-digit before `>`**, so an unrelated `2>/dev/null` on a genuine file write does **not** exempt the whole command.

## Tests / enforcement

- Adds 8 regression cases to `hooks-plugin/hooks/test-bash-antipatterns.sh` (now **71 passed, 0 failed**).
- Wires the existing hook test suite into pre-commit (it was not previously enforced), keyed to the hook + its test, per `.claude/rules/regression-testing.md`.
- `shellcheck` clean on both files.

The "Related" pipe-miscount note in #1701 (`grep … | grep -v … | sort | uniq -c | sort -rn`) does **not** reproduce on current `main` (4 pipes < the 5-pipe threshold, and no `cat`/`echo` head), so it's out of scope here.

> ⚠️ During this work the shared checkout's `.git/config` was flipped to `core.bare = true` mid-commit (the open #1692 hazard — concurrent agent fleet), with a junk `[user] t@e.com` injected. Both were repaired locally (no commits/files lost); flagging so #1692 has another datapoint.

Closes #1701

🤖 Generated with [Claude Code](https://claude.com/claude-code)