### PR TITLE
fix(comfyui-plugin): scaffold ships .comfyignore + 3-part frontend-package pin

### DIFF
--- a/comfyui-plugin/skills/comfyui-node-scaffold/SKILL.md
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/SKILL.md
@@ -182,6 +182,26 @@ chains scaffold → `gh repo create` → seed `main` → the gitops PR.
   **passes green unit tests** because modal builders are DOM-uncovered. The stub
   does it right.
 
+## Registry publishing
+
+The generated `publish.yml` builds `web/dist/` then publishes via
+`Comfy-Org/publish-node-action`. Three registry facts worth knowing:
+
+- **Active vs Flagged is a pointer.** The registry serves one *Active* version
+  per node; publishing moves that pointer to the new version. A version that gets
+  **Flagged** (review) stays in the registry but is no longer the Active target —
+  installs fall back to the last Active version. Publishing a fresh good version
+  re-points Active forward.
+- **Flags are content-independent.** A version can be Flagged for reasons
+  unrelated to its file contents (publisher / automated review state), so a
+  byte-identical re-publish can flip status. A Flag does not by itself mean the
+  tarball is bad — check the registry version page.
+- **`.comfyignore` trims the tarball.** comfy-cli builds the published `node.zip`
+  as *git-tracked files − `.comfyignore` matches + `[tool.comfy] includes`*. The
+  scaffold ships a default `.comfyignore` so only the runtime backend, the built
+  `web/dist`, and metadata ship — CI, tests, docs, build inputs, and the TS source
+  stay out. Tarball trimming requires **comfy-cli >= 1.10.3**.
+
 ## Agentic Optimizations
 
 | Context | Command |

--- a/comfyui-plugin/skills/comfyui-node-scaffold/scaffold.py
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/scaffold.py
@@ -122,7 +122,7 @@ classifiers = [
 
 # @@DEP_FLOOR_NOTE@@ @@BACKEND_DEP_NOTE@@
 dependencies = [
-    "comfyui-frontend-package>=1.40",
+    "comfyui-frontend-package>=1.40.0",
 ]
 
 [project.urls]
@@ -1434,6 +1434,53 @@ TODO.local.md
 NOTES.local.md
 """
 
+# Trims the Comfy Registry tarball to runtime-only files. Fully static (no
+# template tokens). Requires comfy-cli >= 1.10.3 to be honored at publish time.
+COMFYIGNORE = """\
+# .comfyignore — trims the Comfy Registry tarball to runtime-only files.
+#
+# comfy-cli builds node.zip as:  git-tracked files − .comfyignore matches
+# + [tool.comfy] includes.  Patterns use gitignore (gitwildmatch) syntax.
+# web/dist is force-shipped via `includes`, so it always survives these rules.
+#
+# Goal: ship only what ComfyUI loads at runtime (the Python backend, the
+# built web/dist bundle, pyproject metadata, README/LICENSE) and keep CI,
+# build inputs, tests, docs, and the screenshot pipeline out of the tarball.
+
+# Build inputs — only the built web/dist is served, never the TS source
+/src/
+tsconfig.json
+biome.json
+knip.json
+vitest.config.js
+package.json
+bun.lock
+uv.lock
+pylock.toml
+
+# Tests
+/tests/
+
+# Docs + screenshot pipeline (Dockerfile, shell scripts, large PNGs)
+/docs/
+/screenshots/
+
+# CI, release automation, repo + agent tooling
+/.github/
+/.claude/
+.pre-commit-config.yaml
+release-please-config.json
+.release-please-manifest.json
+.gitattributes
+.gitignore
+justfile
+CLAUDE.md
+RELEASE-CHECKLIST.md
+
+# Source-form icon (PNG icon + banner display assets are kept)
+icon.svg
+"""
+
 GITATTRIBUTES = "* text=auto eol=lf\n*.png binary\n*.jpg binary\n*.webp binary\nuv.lock linguist-generated=true\nbun.lock linguist-generated=true\n"
 
 LICENSE = """\
@@ -1770,6 +1817,7 @@ def build_file_map(
         "vitest.config.js": VITEST_CONFIG,
         ".pre-commit-config.yaml": PRE_COMMIT,
         ".gitignore": GITIGNORE,
+        ".comfyignore": COMFYIGNORE,
         ".gitattributes": GITATTRIBUTES,
         "release-please-config.json": RP_CONFIG,
         ".release-please-manifest.json": RP_MANIFEST,


### PR DESCRIPTION
Fixes the ComfyUI node-pack scaffold (`comfyui-plugin/skills/comfyui-node-scaffold/`) so every newly scaffolded pack is correct from day one. Three changes, all in the scaffold generator:

## 1. 3-part `comfyui-frontend-package` pin

`scaffold.py`'s injected `pyproject.toml` dependency was `comfyui-frontend-package>=1.40` (2-part). `publish-node-action` rejects the 2-part form, so generated packs recorded **no** supported frontend version in the Comfy Registry. Changed the injected dependency string to `comfyui-frontend-package>=1.40.0`. The human-readable `>= 1.40` prose elsewhere in `scaffold.py`/`SKILL.md` is left untouched — only the actual injected dependency became 3-part.

## 2. Ship a default `.comfyignore`

The scaffold previously emitted no `.comfyignore`, so every new pack shipped the full repo (CI, tests, docs, TS source, screenshot pipeline) into the registry tarball. Added a `COMFYIGNORE` string constant (copied verbatim from the canonical `comfyui-touch-connect/.comfyignore` — fully static, no template tokens) and wired `".comfyignore": COMFYIGNORE` into the `build_file_map()` `files` dict next to `.gitignore`, so the main generation flow writes it. Verified byte-identical to the reference and emitted by an end-to-end scaffold run.

## 3. SKILL.md "Registry publishing" note

Added a brief section covering: the Active-vs-Flagged pointer mechanic on the Comfy Registry, the content-independent-flag gotcha, and the `.comfyignore` tarball-trimming mechanism (requires comfy-cli >= 1.10.3).

## Companion work

8 companion PRs fix the **existing** packs' frontend-package pin. Those packs already have a `.comfyignore`; this PR back-ports it into the generator so the scaffold matches them going forward.

## Verification

- `python3 -c "import ast; ast.parse(...)"` on `scaffold.py` exits 0.
- A throwaway `python3 scaffold.py` run emits `.comfyignore` byte-identical to the reference and a 3-part pin in `pyproject.toml`.
- `scripts/plugin-compliance-check.sh comfyui-plugin` exits 0 (only a pre-existing non-blocking SKILL.md-size WARN).