### PR TITLE
feat(taskwarrior-plugin): reconcile issue/PR drift, adopt native scheduling, dedup shared logic

### DIFF
--- a/scripts/plugin-compliance-check.sh
+++ b/scripts/plugin-compliance-check.sh
@@ -337,6 +337,42 @@ check_skill_body() {
       fi
     fi
 
+    # Regression: task-reconcile is the only skill that ACTS on the stale-task
+    # drift task-status detects. Its load-bearing invariants are (1) a bulk
+    # `task import` round-trip for leaf tasks, (2) a default-safe dry-run with an
+    # explicit --apply to mutate. A bulk edit that drops either silently turns
+    # off the safety preview or the JSON close path. Scoped to this skill.
+    if [ "$skill_name" = "task-reconcile" ]; then
+      for token in "task import" "--apply" "dry-run"; do
+        if ! grep -q -- "$token" "$skill_file"; then
+          issues+=("❌ ${plugin}/${skill_name}: SKILL.md must retain '${token}' (reconcile JSON-close path / dry-run safety)")
+          has_errors=true
+        fi
+      done
+    fi
+
+    # Regression: task-coordinate / task-status select dispatch candidates from
+    # taskwarrior's native +READY virtual tag (subsumes -BLOCKED, respects
+    # wait:/scheduled:). A bulk edit reverting to the hand-rolled
+    # `-BLOCKED -ACTIVE` filter would silently re-surface waiting/future-scheduled
+    # work as candidates. Guard that +READY survives.
+    if [ "$skill_name" = "task-coordinate" ] || [ "$skill_name" = "task-status" ]; then
+      if ! grep -q "+READY" "$skill_file"; then
+        issues+=("❌ ${plugin}/${skill_name}: SKILL.md must use the native '+READY' tag for ready-candidate selection (native scheduling adoption)")
+        has_errors=true
+      fi
+    fi
+
+    # Regression: install-native-hooks must document that `task import` bypasses
+    # taskwarrior native hooks — the caveat that keeps reconcile's bulk path and
+    # the opt-in hooks from being mistaken for overlapping enforcement. Scoped.
+    if [ "$skill_name" = "install-native-hooks" ]; then
+      if ! grep -q "task import" "$skill_file"; then
+        issues+=("❌ ${plugin}/${skill_name}: SKILL.md must document that 'task import' bypasses native hooks")
+        has_errors=true
+      fi
+    fi
+
     # Regression: evaluate-legibility's Step-3 triage and the cold-reader prompt
     # depend on the verdict vocabulary (`clear` / `needs-revision`) and the
     # QUESTIONS / HESITATIONS critique headings reused from cold-read-gate. A

--- a/taskwarrior-plugin/.claude-plugin/plugin.json
+++ b/taskwarrior-plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "taskwarrior-plugin",
   "version": "1.5.0",
-  "description": "Coordination layer for multi-agent work using taskwarrior - parallel-safe queries, urgency scoring, and optional GitHub linkage via ghid/ghpr UDAs",
+  "description": "Coordination layer for multi-agent work using taskwarrior - parallel-safe queries, urgency scoring, GitHub issue/PR reconciliation, and native scheduling (wait/scheduled/due/recur)",
   "hooks": {
     "SessionStart": [
       {
@@ -24,6 +24,8 @@
     "queue",
     "local-first",
     "urgency",
-    "github-integration"
+    "github-integration",
+    "reconcile",
+    "scheduling"
   ]
 }

--- a/taskwarrior-plugin/README.md
+++ b/taskwarrior-plugin/README.md
@@ -15,7 +15,7 @@ GitHub issues are the system of record for work the team should see. Taskwarrior
 | Cost to read 50 items | 50 API calls or rate limit | Single `task export \| jq` |
 | Discovery surface | GitHub UI | Agent-queryable shell |
 
-Both systems stay in sync via UDAs (`ghid`, `ghpr`) and tags (`+gh`, `+pr_ready`, `+blocked_on_merge`). This plugin's skills detect GitHub remotes automatically and offer the linkage; repositories without a remote operate in local-only mode.
+Both systems stay in sync via UDAs (`ghid`, `ghpr`) and tags (`+gh`, `+pr_ready`). This plugin's skills detect GitHub remotes automatically and offer the linkage; repositories without a remote operate in local-only mode. `/taskwarrior:task-reconcile` closes the loop the other way — when an issue or PR closes, it retires the local task that mirrored it, so the queue never silently accumulates stale trackers.
 
 ## Skills
 
@@ -25,8 +25,10 @@ Both systems stay in sync via UDAs (`ghid`, `ghpr`) and tags (`+gh`, `+pr_ready`
 | `/taskwarrior:task-claim` | Claim a pending task as in-flight: marks it `+ACTIVE` (`task start`), stamps identity UDAs (`agent` / `pid` / `host` / `branch` / `worktree`), and writes a `/git:coworker-check` session marker so destructive git ops in the clone are guarded |
 | `/taskwarrior:task-release` | Release an active claim without closing: stops the `+ACTIVE` clock, annotates the handoff state, drains `pid`, and drops the coworker-check marker. Pairs with `task-claim` for pause / handoff |
 | `/taskwarrior:task-done` | Close a task, annotate with commit hash, drain the linked feature-tracker entry; auto-stops the `+ACTIVE` claim and offers to close the linked GitHub issue |
-| `/taskwarrior:task-status` | Read-only consolidated queue + drift report scoped to the current project; surfaces in-flight claims and stale claims (>N hours); folds in `gh pr status` when GitHub is present |
-| `/taskwarrior:task-coordinate` | Surface the next N unblocked **and unclaimed** tasks (in the current project) sorted by urgency that do not contend on an exclusive lock — input for parallel / wave dispatch. Excludes `+ACTIVE` by default so dispatch waves never overlap with another agent's claim |
+| `/taskwarrior:task-status` | Read-only consolidated queue + drift report scoped to the current project; surfaces in-flight claims, stale claims (>N hours), and `+OVERDUE` tasks; folds in `gh pr status` when GitHub is present |
+| `/taskwarrior:task-coordinate` | Surface the next N **`+READY` and unclaimed** tasks (in the current project) sorted by urgency that do not contend on an exclusive lock — input for parallel / wave dispatch. Uses taskwarrior's native `+READY` set so `wait:`-deferred and future-`scheduled:` work never appears |
+| `/taskwarrior:task-reconcile` | Close tasks whose linked GitHub issue/PR has closed or merged, so the queue does not accumulate stale trackers. Dry-run preview by default; `--apply` closes (bulk `task import` for leaf tasks, per-task `task done` for tasks that block others) |
+| `/taskwarrior:install-native-hooks` | **Opt-in** installer for taskwarrior native `on-add` / `on-modify` hooks that auto-stamp `project` and warn on mis-parsed hyphenated tags. Writes to the user's global `<data>/hooks/` only on explicit invocation |
 
 ### Identity / claim lifecycle
 
@@ -102,8 +104,12 @@ The identity UDAs power `task-coordinate`'s "In flight" / "Stale claims" section
 | `+gh` | Linked to a GitHub issue or PR |
 | `+pr_ready` | Implementation done, open PR, waiting on merge |
 | `+needs_review` | Ready for review |
-| `+blocked_on_merge` | Waiting on another PR to merge |
+| `+blocked_on_merge` | Waiting on another PR to merge (prefer `wait:<date>` — it auto-unhides) |
 | `+blocked` | Blocked on external factor |
+
+> Prefer the native scheduling fields (`wait:` / `scheduled:` / `due:`) over
+> hand-managed `+blocked*` tags where a date is known — see **Native scheduling
+> fields** below. The tags remain for genuinely date-less blockers.
 
 > **Tag naming gotcha.** Taskwarrior parses `-` mid-token as exclude-filter
 > syntax even inside a `+tag` argument, so `+blocked-on-merge` is parsed as
@@ -122,6 +128,51 @@ Both pass → GitHub mode: `ghid` / `ghpr` fields are offered, PR status is fold
 Either fails → local-only mode: taskwarrior operates standalone, GitHub-specific prompts are skipped.
 
 Override via `.claude/taskwarrior-plugin.local.md` (see `agent-patterns-plugin:plugin-settings`).
+
+## Keeping the queue in sync
+
+GitHub issues and PRs close; the local tasks that mirror them do not, unless
+something retires them. `/taskwarrior:task-reconcile` is that something:
+
+1. Snapshots pending tasks carrying `ghid` / `ghpr`.
+2. Batch-checks upstream state via `gh` (cached per number).
+3. Closes the stale set — **leaf** tasks via a bulk `task export | jq | task import`
+   round-trip, tasks that **block others** via per-task `task done` so
+   taskwarrior's dependency auto-unblock fires (`task import` skips that pass).
+
+It defaults to a **dry-run preview** and never closes a task whose upstream
+state could not be read. `task-status` already *detects* this drift; reconcile
+*acts* on it. See the skill's `REFERENCE.md` for the bulk-vs-done routing and
+`task import` round-trip caveats.
+
+## Native scheduling fields
+
+Prefer taskwarrior's native date fields over hand-managed `+blocked*` tags —
+`task-add` accepts them and `task-coordinate` / `task-status` read them:
+
+| Field | Effect | Replaces |
+|-------|--------|----------|
+| `wait:<date>` | Hides the task until the date (auto-unhides) | `+blocked_on_merge` bookkeeping |
+| `scheduled:<date>` | Task becomes `+READY` only once the date passes | manual deferral |
+| `due:<date>` | Feeds urgency; surfaces as `+DUE` / `+OVERDUE` | manual priority bumps |
+| `recur:<freq>` (+ `due:`) | Repeating maintenance chores | re-filing by hand |
+| `until:<date>` | Auto-deletes the task on the date | stale short-lived trackers |
+
+`task-coordinate` and `task-status` rank candidates from taskwarrior's native
+`+READY` virtual tag (pending, unblocked, not waiting, scheduled-due), which
+subsumes the old `-BLOCKED` filter and automatically respects `wait:` /
+`scheduled:`.
+
+## Shared scripts
+
+Logic shared across skills lives in `taskwarrior-plugin/scripts/` and is invoked
+from skill bodies as `${CLAUDE_SKILL_DIR}/../../scripts/<name>.sh`:
+
+| Script | Used by | Purpose |
+|--------|---------|---------|
+| `ensure-udas.sh` | `task-add`, `task-claim`, drift-probe hook | Single source of the 10-UDA set; idempotent install + `--check` |
+| `resolve-project.sh` | `task-add`, `task-coordinate`, `task-status`, `task-reconcile` | The `--project` > `--all` > git-toplevel > cwd ladder |
+| `detect-gh-mode.sh` | GitHub-mode skills | Remote + `gh auth` probe (no stderr-emitting Context probes) |
 
 ## Flow
 

--- a/taskwarrior-plugin/docs/flow.md
+++ b/taskwarrior-plugin/docs/flow.md
@@ -10,6 +10,7 @@ flowchart TD
     CLAIM[/taskwarrior:task-claim/]:::fix
     RELEASE[/taskwarrior:task-release/]:::fix
     DONE[/taskwarrior:task-done/]:::fix
+    RECONCILE[/taskwarrior:task-reconcile/]:::fix
 
     GH{{GitHub remote?}}:::prompt
     STORE[(~/.task/)]
@@ -38,7 +39,14 @@ flowchart TD
     DONE -->|annotate commit, auto-stop| STORE
     DONE -->|optional| CLOSEGH[gh issue close / gh pr comment]:::fix
 
-    COORD -->|wave of unclaimed| DISPATCH[parallel-agent-dispatch / workflow-wave-dispatch]:::router
+    STORE -->|ghid/ghpr tasks| RECONCILE
+    GHSTATE{{issue/PR closed?}}:::prompt
+    RECONCILE --> GHSTATE
+    GHSTATE -->|yes| RCLOSE[bulk import / task done + annotate]:::fix
+    GHSTATE -->|no| RKEEP[keep live]:::check
+    RCLOSE --> STORE
+
+    COORD -->|+READY wave of unclaimed| DISPATCH[parallel-agent-dispatch / workflow-wave-dispatch]:::router
 
     classDef router fill:#4a9eff,stroke:#222,color:#fff
     classDef check fill:#8fbc8f,stroke:#222,color:#000
@@ -63,8 +71,10 @@ flowchart TD
 | `task-claim` | Claim a pending task (sets `+ACTIVE` + identity UDAs + session marker) |
 | `task-release` | Release an active claim without closing (handoff) |
 | `task-done` | Close / annotate tasks (auto-stops `+ACTIVE`) |
-| `task-status` | Read queue state, including in-flight + stale claims |
-| `task-coordinate` | Query unblocked + unclaimed candidates for a dispatch wave |
+| `task-status` | Read queue state, including in-flight + stale claims and `+OVERDUE` |
+| `task-coordinate` | Query `+READY` + unclaimed candidates for a dispatch wave |
+| `task-reconcile` | Close tasks whose linked GitHub issue/PR closed or merged (dry-run by default) |
+| `install-native-hooks` | Opt-in installer for taskwarrior native on-add/on-modify hooks (not in the diagram — a one-off setup action, not part of the task lifecycle) |
 
 ## Claim lifecycle
 

--- a/taskwarrior-plugin/docs/task-tracking.md
+++ b/taskwarrior-plugin/docs/task-tracking.md
@@ -25,8 +25,28 @@ Declared in `~/.taskrc`. `task-add` installs them on first use (with confirmatio
 | `+gh` | Linked to a GitHub issue or PR |
 | `+pr_ready` | Implementation done, open PR, waiting on merge |
 | `+needs_review` | Ready for review |
-| `+blocked_on_merge` | Waiting on another PR to merge |
+| `+blocked_on_merge` | Waiting on another PR to merge (prefer `wait:` — see below) |
 | `+blocked` | Blocked on external factor |
+
+## Native scheduling fields
+
+Taskwarrior's built-in date fields express deferral and deadlines more precisely
+than tags, and the read skills understand them natively. Prefer them over
+hand-managed `+blocked*` tags whenever a date is known:
+
+| Field | Meaning | Virtual tag it drives |
+|-------|---------|-----------------------|
+| `wait:<date>` | Hide the task until the date, then auto-unhide | `+WAITING` (hidden from default reports) |
+| `scheduled:<date>` | Earliest sensible start; gates readiness | `+READY` only once passed |
+| `due:<date>` | Deadline; feeds urgency | `+DUE` (≤7d), `+OVERDUE` (past) |
+| `recur:<freq>` (+ `due:`) | Repeat the task on a cadence | `+PARENT` / `+CHILD` instances |
+| `until:<date>` | Auto-delete the task on the date | — |
+
+`task-coordinate` and `task-status` select dispatch candidates from the native
+`+READY` set (pending, unblocked, not waiting, scheduled-due) rather than a
+hand-rolled `-BLOCKED -ACTIVE` filter — so a task parked with `wait:` until a PR
+merges, or `scheduled:` for next week, stays out of the candidate pool until it
+is genuinely actionable.
 
 ## Lifecycle
 
@@ -52,7 +72,9 @@ task add "WO-060: document format spec" bpid:WO-060 +wo project:myrepo depends:5
 # → taskwarrior assigns ID 53
 ```
 
-The `-BLOCKED` virtual attribute in `task-coordinate` and `task-status` automatically hides depends-blocked tasks from dispatch candidates — no manual filtering needed.
+The native `+READY` virtual tag in `task-coordinate` and `task-status`
+automatically hides depends-blocked tasks (and `wait:`-deferred / future-`scheduled:`
+tasks) from dispatch candidates — no manual filtering needed.
 
 ### 3. ★ KEY: `depends:` + `task done` auto-unblocks the chain
 
@@ -93,6 +115,17 @@ task depends:"$TASKID" export | jq '.[] | {id, description, urgency}'
 
 Include these in the close-out report so the orchestrator knows the next ready task immediately.
 
+### 6. Reconcile linked tasks against GitHub
+
+Tasks that mirror a GitHub issue (`ghid`) or PR (`ghpr`) go stale when the
+upstream item closes or merges — and nothing closes them automatically.
+`/taskwarrior:task-reconcile` retires that drift: it batch-checks upstream state
+and closes the stale set (leaf tasks via a bulk `task export | jq | task import`
+round-trip; tasks that block others via per-task `task done` so the auto-unblock
+in step 3 still fires). It defaults to a dry-run preview and never closes a task
+whose upstream state could not be read. Run it after a batch of PRs merge, or
+when `task-status` flags `drift: stale-open`.
+
 ## Parallel-Safe Queries
 
 All taskwarrior queries use `export | jq` — never bare `list`, `next`, or similar commands — because these exit 1 on an empty result and cancel sibling Bash calls in parallel batches.
@@ -116,7 +149,8 @@ When urgency rankings feel wrong, the common culprits are missing `project:` tag
 
 - `/taskwarrior:task-add` — file tasks with UDA linkage and `depends:` ordering
 - `/taskwarrior:task-done` — close + annotate + check unblocked siblings
-- `/taskwarrior:task-coordinate` — surface next unblocked candidates for a wave
+- `/taskwarrior:task-coordinate` — surface next `+READY` candidates for a wave
 - `/taskwarrior:task-status` — full queue audit with drift detection
+- `/taskwarrior:task-reconcile` — close tasks whose linked issue/PR closed/merged
 - `.claude/rules/parallel-safe-queries.md` — the `export | jq` idiom (zero parallel-batch errors)
 - `blueprint-plugin:feature-tracking` — blueprint IDs that `bpid` links to

--- a/taskwarrior-plugin/hooks/taskwarrior-drift-probe.sh
+++ b/taskwarrior-plugin/hooks/taskwarrior-drift-probe.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 # taskwarrior-drift-probe.sh — SessionStart probe for taskwarrior-plugin drift.
 #
-# The plugin's task-add skill references custom UDAs (bpid, bpdoc, bpms, ghid,
-# ghpr, agent, pid, host, branch, worktree). If those UDAs are not declared in
+# The plugin's skills reference custom UDAs (bpid, bpdoc, bpms, ghid, ghpr,
+# agent, pid, host, branch, worktree). If those UDAs are not declared in
 # ~/.taskrc, `task add` silently drops the field. This probe surfaces that gap
 # at session start so the user can install the UDAs via `/taskwarrior:task-add`
-# (which offers the install).
+# (which offers the install). The canonical UDA list lives in the shared
+# scripts/ensure-udas.sh — this probe calls it in --check mode so the list is
+# single-sourced and never mutates ~/.taskrc from a SessionStart hook.
 #
 # No-ops when ~/.taskrc is absent OR the task binary is missing.
 
@@ -44,28 +46,21 @@ if ! command -v task >/dev/null 2>&1; then
     exit 0
 fi
 
-# UDAs the plugin's task-add skill emits.
-required_udas=(bpid bpdoc bpms ghid ghpr agent pid host branch worktree)
-
-missing=()
-for uda in "${required_udas[@]}"; do
-    # Match either inline taskrc form (uda.<name>.type=...) or include-based.
-    # `task _udas` is the authoritative list; fall back to grep on taskrc.
-    if task _udas 2>/dev/null | grep -qx "$uda"; then
-        continue
+# Single-source the required-UDA list: ask the shared ensure-udas.sh script
+# (which task-add / task-claim also use) what is missing, in --check mode so it
+# never mutates ~/.taskrc from a SessionStart probe.
+ENSURE_UDAS="${SCRIPT_DIR}/../scripts/ensure-udas.sh"
+if [ -f "$ENSURE_UDAS" ]; then
+    uda_report=$(bash "$ENSURE_UDAS" --check 2>/dev/null || true)
+    missing_count=$(printf '%s\n' "$uda_report" | grep -m1 '^UDAS_MISSING=' | cut -d= -f2)
+    missing_count="${missing_count:-0}"
+    if [ "$missing_count" -gt 0 ] 2>/dev/null; then
+        list=$(printf '%s\n' "$uda_report" | grep -m1 '^MISSING_NAMES=' | cut -d= -f2)
+        drift_add_finding warn \
+            udas_missing \
+            "${missing_count} UDA(s) missing from ~/.taskrc: ${list}" \
+            "/taskwarrior:task-add"
     fi
-    if grep -qE "^uda\.${uda}\.type" "$TASKRC" 2>/dev/null; then
-        continue
-    fi
-    missing+=("$uda")
-done
-
-if [ "${#missing[@]}" -gt 0 ]; then
-    list=$(IFS=, ; printf '%s' "${missing[*]}")
-    drift_add_finding warn \
-        udas_missing \
-        "${#missing[@]} UDA(s) missing from ~/.taskrc: ${list}" \
-        "/taskwarrior:task-add"
 fi
 
 drift_emit

--- a/taskwarrior-plugin/scripts/detect-gh-mode.sh
+++ b/taskwarrior-plugin/scripts/detect-gh-mode.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# detect-gh-mode.sh — single source of truth for GitHub-mode detection.
+#
+# GitHub mode (offer ghid/ghpr linkage, fold in PR status, reconcile against
+# issues/PRs) is active only when the repo has a remote AND gh is authenticated.
+# task-add / task-status / task-done / task-reconcile each made this same two-
+# check probe; this consolidates it.
+#
+# Run from a skill body, never a Context backtick — `git remote get-url` writes
+# to stderr in a remote-less repo, which aborts a Context command.
+#
+# Flags:
+#   --project-dir=<dir>   Directory to probe (default: cwd)
+#
+# Output: structured KEY=VALUE block. GH_MODE=on only when both checks pass.
+#
+# Exit code: always 0 (probe result is in GH_MODE, not the exit code, so this
+# stays parallel-safe in a Bash batch).
+
+set -uo pipefail
+
+gh_dir="$PWD"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --project-dir=*) gh_dir="${1#*=}" ;;
+    --project-dir) shift; gh_dir="${1:-$PWD}" ;;
+    *) ;;
+  esac
+  shift
+done
+
+echo "=== GITHUB MODE ==="
+
+gh_remote=""
+gh_remote=$(git -C "$gh_dir" remote get-url origin 2>/dev/null || true)
+if [ -n "$gh_remote" ]; then
+  echo "REMOTE_PRESENT=true"
+else
+  echo "REMOTE_PRESENT=false"
+fi
+
+gh_auth=false
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  gh_auth=true
+fi
+echo "GH_AUTHENTICATED=${gh_auth}"
+
+if [ -n "$gh_remote" ] && [ "$gh_auth" = true ]; then
+  echo "GH_MODE=on"
+else
+  echo "GH_MODE=off"
+fi
+echo "STATUS=OK"
+echo "=== END GITHUB MODE ==="
+exit 0

--- a/taskwarrior-plugin/scripts/ensure-udas.sh
+++ b/taskwarrior-plugin/scripts/ensure-udas.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# ensure-udas.sh — single source of truth for the taskwarrior-plugin UDA set.
+#
+# The plugin's skills (task-add, task-claim, task-reconcile) and the
+# SessionStart drift-probe all need the same 10 UDAs declared in ~/.taskrc.
+# Before this script the install block was copy-pasted into task-add and
+# task-claim; this consolidates it so the canonical set lives in one place.
+#
+# Idempotent: only declares UDAs that `task _udas` does not already report.
+# UDA declarations persist in ~/.taskrc, so callers should confirm with the
+# user before running on first use per host.
+#
+# Flags:
+#   --check    Report missing UDAs without installing (STATUS=WARN if any
+#              missing, STATUS=OK if all present). Default is install mode.
+#
+# Output: structured KEY=VALUE block (see
+# .claude/rules/structured-script-output.md) so callers can roll it up.
+#
+# Exit codes:
+#   0 - all UDAs present, or install succeeded (or --check with none missing)
+#   1 - task binary missing, or an install command failed
+
+set -uo pipefail
+
+uda_check_only=false
+for arg in "$@"; do
+  case "$arg" in
+    --check) uda_check_only=true ;;
+    *) ;;
+  esac
+done
+
+echo "=== TASKWARRIOR UDAS ==="
+
+if ! command -v task >/dev/null 2>&1; then
+  echo "TASK_AVAILABLE=false"
+  echo "STATUS=ERROR"
+  echo "ISSUE_COUNT=1"
+  echo "ISSUES:"
+  echo "  - SEVERITY=ERROR TYPE=task_missing MSG=task binary not found on PATH"
+  echo "=== END TASKWARRIOR UDAS ==="
+  exit 1
+fi
+echo "TASK_AVAILABLE=true"
+
+# Canonical UDA set: name<TAB>type<TAB>label.
+# Linkage UDAs (set by task-add, read by task-reconcile/task-status/task-done).
+# Identity UDAs (set by task-claim, drained by task-release/task-done).
+uda_specs=(
+  "bpid	string	Blueprint ID"
+  "bpdoc	string	Blueprint doc"
+  "bpms	string	Milestone"
+  "ghid	numeric	GH Issue"
+  "ghpr	numeric	GH PR"
+  "agent	string	Agent ID"
+  "pid	numeric	Agent PID"
+  "host	string	Host"
+  "branch	string	Git branch"
+  "worktree	string	Worktree path"
+)
+
+present_udas=""
+present_udas=$(task _udas 2>/dev/null || true)
+
+uda_missing=()
+for spec in "${uda_specs[@]}"; do
+  uda_name="${spec%%	*}"
+  if printf '%s\n' "$present_udas" | grep -qx "$uda_name"; then
+    continue
+  fi
+  uda_missing+=("$spec")
+done
+
+echo "UDAS_REQUIRED=${#uda_specs[@]}"
+echo "UDAS_MISSING=${#uda_missing[@]}"
+
+if [ "${#uda_missing[@]}" -eq 0 ]; then
+  echo "STATUS=OK"
+  echo "ISSUE_COUNT=0"
+  echo "=== END TASKWARRIOR UDAS ==="
+  exit 0
+fi
+
+missing_names=""
+for spec in "${uda_missing[@]}"; do
+  missing_names="${missing_names:+$missing_names,}${spec%%	*}"
+done
+echo "MISSING_NAMES=${missing_names}"
+
+if [ "$uda_check_only" = true ]; then
+  echo "STATUS=WARN"
+  echo "ISSUE_COUNT=${#uda_missing[@]}"
+  echo "ISSUES:"
+  for spec in "${uda_missing[@]}"; do
+    echo "  - SEVERITY=WARN TYPE=uda_missing UDA=${spec%%	*} MSG=declare with --install or /taskwarrior:task-add"
+  done
+  echo "=== END TASKWARRIOR UDAS ==="
+  exit 0
+fi
+
+install_failures=0
+installed=""
+for spec in "${uda_missing[@]}"; do
+  uda_name="${spec%%	*}"
+  rest="${spec#*	}"
+  uda_type="${rest%%	*}"
+  uda_label="${rest#*	}"
+  # rc.confirmation=no is REQUIRED: `task config` prompts by default, and a
+  # non-interactive call without it exits 0 WITHOUT writing the value — the UDA
+  # silently fails to persist and `task add ghid:N` then appends to description.
+  # </dev/null guards against any residual prompt consuming the caller's stdin.
+  if task rc.confirmation=no config "uda.${uda_name}.type" "$uda_type" </dev/null >/dev/null 2>&1 \
+     && task rc.confirmation=no config "uda.${uda_name}.label" "$uda_label" </dev/null >/dev/null 2>&1; then
+    installed="${installed:+$installed,}${uda_name}"
+  else
+    install_failures=$((install_failures + 1))
+  fi
+done
+
+echo "UDAS_INSTALLED=${installed:-none}"
+if [ "$install_failures" -gt 0 ]; then
+  echo "STATUS=ERROR"
+  echo "ISSUE_COUNT=${install_failures}"
+  echo "=== END TASKWARRIOR UDAS ==="
+  exit 1
+fi
+
+echo "STATUS=OK"
+echo "ISSUE_COUNT=0"
+echo "=== END TASKWARRIOR UDAS ==="
+exit 0

--- a/taskwarrior-plugin/scripts/resolve-project.sh
+++ b/taskwarrior-plugin/scripts/resolve-project.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# resolve-project.sh — single source of truth for the project-scope ladder.
+#
+# task-add / task-coordinate / task-status / task-reconcile all default to the
+# current repo's project so an agent in repo A is not distracted by tasks from
+# repos B and C. Before this script the resolution ladder was reimplemented in
+# each skill; this consolidates it.
+#
+# Resolution order:
+#   1. --project=<name>  → explicit override
+#   2. --all             → no project (prints empty PROJECT=)
+#   3. basename of git toplevel (run here where stderr/exit are tolerated)
+#   4. basename of the cwd (no git repo)
+#
+# Run from the body of a skill, never a Context backtick — git probes write to
+# stderr in a no-git cwd, which aborts a Context command (issue #1351).
+#
+# Flags:
+#   --project=<name>    Explicit project override
+#   --all               Emit empty PROJECT (cross-project scope)
+#   --project-dir=<dir> Directory to resolve from (default: cwd)
+#
+# Output: structured KEY=VALUE block. PROJECT is empty for --all.
+#
+# Exit code: always 0 (resolution never fails — falls back to cwd basename).
+
+set -uo pipefail
+
+proj_override=""
+proj_all=false
+proj_dir="$PWD"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --project=*) proj_override="${1#*=}" ;;
+    --project) shift; proj_override="${1:-}" ;;
+    --all) proj_all=true ;;
+    --project-dir=*) proj_dir="${1#*=}" ;;
+    --project-dir) shift; proj_dir="${1:-$PWD}" ;;
+    *) ;;
+  esac
+  shift
+done
+
+echo "=== PROJECT SCOPE ==="
+
+if [ "$proj_all" = true ]; then
+  echo "PROJECT="
+  echo "SOURCE=all"
+  echo "STATUS=OK"
+  echo "=== END PROJECT SCOPE ==="
+  exit 0
+fi
+
+if [ -n "$proj_override" ]; then
+  echo "PROJECT=${proj_override}"
+  echo "SOURCE=override"
+  echo "STATUS=OK"
+  echo "=== END PROJECT SCOPE ==="
+  exit 0
+fi
+
+proj_toplevel=""
+proj_toplevel=$(git -C "$proj_dir" rev-parse --show-toplevel 2>/dev/null || true)
+
+if [ -n "$proj_toplevel" ]; then
+  echo "PROJECT=$(basename "$proj_toplevel")"
+  echo "SOURCE=git-toplevel"
+  echo "STATUS=OK"
+  echo "=== END PROJECT SCOPE ==="
+  exit 0
+fi
+
+echo "PROJECT=$(basename "$proj_dir")"
+echo "SOURCE=cwd"
+echo "STATUS=OK"
+echo "=== END PROJECT SCOPE ==="
+exit 0

--- a/taskwarrior-plugin/skills/install-native-hooks/SKILL.md
+++ b/taskwarrior-plugin/skills/install-native-hooks/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: install-native-hooks
+description: Install opt-in taskwarrior native on-add/on-modify hooks that auto-stamp project and warn on mis-parsed tags. Use when hardening a local taskwarrior store.
+args: "[--check] [--uninstall]"
+allowed-tools: Bash(task *), Bash(bash *), Read, TodoWrite
+argument-hint: optional --check (preview) or --uninstall
+created: 2026-06-20
+modified: 2026-06-20
+reviewed: 2026-06-20
+---
+
+# /taskwarrior:install-native-hooks
+
+Install the plugin's **opt-in** taskwarrior native hooks into the user's
+taskwarrior hooks directory (`<data.location>/hooks/`). These are taskwarrior's
+own `on-add` / `on-modify` hooks — distinct from Claude Code hooks — and run on
+every local `task add` / `task modify`, regardless of whether the change came
+from a plugin skill.
+
+This skill writes to the user's global taskwarrior config and is **strictly
+opt-in**: it runs only when the user explicitly invokes it. Nothing else in the
+plugin (no SessionStart hook, no `chezmoi apply`) installs these.
+
+## When to Use This Skill
+
+| Use this skill when... | Use a sibling skill instead when... |
+|---|---|
+| Hardening a local store so every `task add` gets auto-stamped + tag-checked | Closing stale issue/PR trackers — use `task-reconcile` |
+| You want the hyphenated-tag warning enforced outside the plugin skills | Filing or claiming a single task — use `task-add` / `task-claim` |
+
+## What gets installed
+
+| Hook | Fires on | Behaviour |
+|------|----------|-----------|
+| `on-add-taskwarrior-plugin` | `task add` | Auto-stamps `project` from the git toplevel / cwd basename when unset; warns (never rejects) on a hyphenated `+tag` in the description (the form taskwarrior mis-parses) |
+| `on-modify-taskwarrior-plugin` | `modify` / `annotate` / `done` / `start` / `stop` | Warns on a hyphenated tag in the modified description; extension point for convention enforcement |
+
+Both **fail open** — on any error (missing `jq`, bad JSON) they pass the task
+through unchanged and exit 0, so a broken hook never blocks `task add`.
+
+> **`task import` bypasses native hooks.** Taskwarrior does **not** run
+> `on-add`/`on-modify` hooks during `task import`. So `/taskwarrior:task-reconcile`'s
+> bulk close path (which uses `task import`) is unaffected by these hooks — they
+> complement reconciliation, they do not gate it.
+
+## Context
+
+- Task CLI available: !`task --version`
+
+## Parameters
+
+Parse `$ARGUMENTS`:
+
+- `--check` — report which hooks are present without installing.
+- `--uninstall` — remove the plugin's hooks.
+
+## Execution
+
+Execute this install workflow:
+
+### Step 1: Preview
+
+Run the installer in check mode to show the resolved hooks directory and current
+state:
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/install-hooks.sh" --check --templates-dir "${CLAUDE_SKILL_DIR}/templates"
+```
+
+Read `HOOKS_DIR=` and the per-hook `present`/`absent` lines.
+
+### Step 2: Confirm
+
+Because this writes to the user's global taskwarrior config, confirm with
+**AskUserQuestion** (not a freeform prompt — see
+`.claude/rules/skill-execution-structure.md`): show the hooks dir and the two
+hooks, and offer install / cancel. Skip the confirm only if `--check` or
+`--uninstall` was passed.
+
+### Step 3: Install (or uninstall)
+
+On confirmation:
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/install-hooks.sh" --templates-dir "${CLAUDE_SKILL_DIR}/templates"
+```
+
+For `--uninstall`:
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/install-hooks.sh" --uninstall --templates-dir "${CLAUDE_SKILL_DIR}/templates"
+```
+
+### Step 4: Verify and report
+
+Confirm the hooks are executable and exercise them safely in a scratch store —
+add a throwaway task with no project and a hyphenated tag, confirm the project is
+stamped and the warning prints, then delete it.
+
+> Smoke test (blockquoted so the tag-lint skips the intentionally-broken tag):
+> `TASKDATA="$(mktemp -d)" task add "smoke +bad-tag test"` — the on-add hook
+> stamps `project` and prints the hyphenated-tag warning. Remove the scratch dir
+> afterwards.
+
+Report `INSTALLED=` / `REMOVED=`, the hooks dir, and a reminder that the hooks
+fail open and are bypassed by `task import`.
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Preview | `bash scripts/install-hooks.sh --check --templates-dir templates` |
+| Install | `bash scripts/install-hooks.sh --templates-dir templates` |
+| Uninstall | `bash scripts/install-hooks.sh --uninstall --templates-dir templates` |
+| Resolve hooks dir | `task _get rc.data.location` → `<that>/hooks` |
+
+## Quick Reference
+
+| Flag | Purpose |
+|------|---------|
+| _(none)_ | Confirm, then install both hooks |
+| `--check` | Report hooks dir + present/absent, no write |
+| `--uninstall` | Remove the plugin's hooks |
+
+## Related
+
+- `/taskwarrior:task-reconcile` — bulk close uses `task import`, which bypasses these native hooks (by design)
+- `/taskwarrior:task-add` — the skill that already stamps project + warns on hyphenated tags; these hooks extend that to ad-hoc `task add`
+- `scripts/lint-taskwarrior-tags.sh` — the docs-side guard for the same hyphenated-tag class
+- `.claude/rules/skill-execution-structure.md` — AskUserQuestion confirmation gate

--- a/taskwarrior-plugin/skills/install-native-hooks/scripts/install-hooks.sh
+++ b/taskwarrior-plugin/skills/install-native-hooks/scripts/install-hooks.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# install-hooks.sh — copy the opt-in taskwarrior native hooks into the user's
+# taskwarrior hooks directory. Invoked by /taskwarrior:install-native-hooks
+# ONLY on explicit user request — never by chezmoi apply or a SessionStart hook.
+#
+# Resolves the hooks dir from taskwarrior's own config (data.location/hooks),
+# falling back to ~/.task/hooks, and copies the on-add / on-modify templates
+# with the execute bit set.
+#
+# Flags:
+#   --templates-dir=<dir>  Directory holding the template hook files (required)
+#   --check                Report what would be installed without copying
+#   --uninstall            Remove the plugin's hooks instead of installing
+#
+# Output: structured KEY=VALUE block. Exit 0 on success, 1 on error.
+
+set -uo pipefail
+
+tmpl_dir=""
+mode="install"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --templates-dir=*) tmpl_dir="${1#*=}" ;;
+    --templates-dir) shift; tmpl_dir="${1:-}" ;;
+    --check) mode="check" ;;
+    --uninstall) mode="uninstall" ;;
+    *) ;;
+  esac
+  shift
+done
+
+echo "=== TASKWARRIOR NATIVE HOOKS ==="
+
+if ! command -v task >/dev/null 2>&1; then
+  echo "TASK_AVAILABLE=false"
+  echo "STATUS=ERROR"
+  echo "ISSUE_COUNT=1"
+  echo "=== END TASKWARRIOR NATIVE HOOKS ==="
+  exit 1
+fi
+
+# Resolve hooks dir: <data.location>/hooks, expanding a leading ~.
+data_loc=$(task _get rc.data.location 2>/dev/null || true)
+case "$data_loc" in
+  "~"/*) data_loc="${HOME}/${data_loc#~/}" ;;
+  "~") data_loc="${HOME}" ;;
+esac
+[ -z "$data_loc" ] && data_loc="${HOME}/.task"
+hooks_dir="${data_loc}/hooks"
+echo "HOOKS_DIR=${hooks_dir}"
+
+hook_names=(on-add-taskwarrior-plugin on-modify-taskwarrior-plugin)
+
+if [ "$mode" = "uninstall" ]; then
+  removed=0
+  for h in "${hook_names[@]}"; do
+    if [ -e "${hooks_dir}/${h}" ]; then
+      rm -f "${hooks_dir}/${h}" && removed=$((removed + 1))
+    fi
+  done
+  echo "REMOVED=${removed}"
+  echo "STATUS=OK"
+  echo "ISSUE_COUNT=0"
+  echo "=== END TASKWARRIOR NATIVE HOOKS ==="
+  exit 0
+fi
+
+if [ "$mode" = "check" ]; then
+  echo "MODE=check"
+  for h in "${hook_names[@]}"; do
+    present=$([ -e "${hooks_dir}/${h}" ] && echo present || echo absent)
+    echo "HOOK ${h}=${present}"
+  done
+  echo "STATUS=OK"
+  echo "ISSUE_COUNT=0"
+  echo "=== END TASKWARRIOR NATIVE HOOKS ==="
+  exit 0
+fi
+
+if [ -z "$tmpl_dir" ] || [ ! -d "$tmpl_dir" ]; then
+  echo "STATUS=ERROR"
+  echo "ISSUE_COUNT=1"
+  echo "ISSUES:"
+  echo "  - SEVERITY=ERROR TYPE=templates_missing MSG=pass --templates-dir pointing at the skill templates/ dir"
+  echo "=== END TASKWARRIOR NATIVE HOOKS ==="
+  exit 1
+fi
+
+mkdir -p "$hooks_dir" 2>/dev/null || true
+installed=0
+failures=0
+for h in "${hook_names[@]}"; do
+  if [ ! -f "${tmpl_dir}/${h}" ]; then
+    failures=$((failures + 1))
+    continue
+  fi
+  if cp "${tmpl_dir}/${h}" "${hooks_dir}/${h}" && chmod +x "${hooks_dir}/${h}"; then
+    installed=$((installed + 1))
+  else
+    failures=$((failures + 1))
+  fi
+done
+
+echo "INSTALLED=${installed}"
+if [ "$failures" -gt 0 ]; then
+  echo "STATUS=ERROR"
+  echo "ISSUE_COUNT=${failures}"
+else
+  echo "STATUS=OK"
+  echo "ISSUE_COUNT=0"
+fi
+echo "=== END TASKWARRIOR NATIVE HOOKS ==="
+[ "$failures" -eq 0 ]

--- a/taskwarrior-plugin/skills/install-native-hooks/templates/on-add-taskwarrior-plugin
+++ b/taskwarrior-plugin/skills/install-native-hooks/templates/on-add-taskwarrior-plugin
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# on-add-taskwarrior-plugin — taskwarrior NATIVE hook (lives in <data>/hooks/).
+#
+# Installed opt-in by /taskwarrior:install-native-hooks. Runs inside `task add`,
+# AFTER the CLI parses the task but BEFORE it is saved. Receives ONE line of
+# JSON on stdin (the task) and must echo the task JSON back as the first line
+# of stdout; later stdout lines are shown as feedback. Exit 0 allows, non-zero
+# rejects the add.
+#
+# Behaviour:
+#   1. Auto-stamp `project` from the git toplevel / cwd basename when unset, so
+#      tasks added outside the plugin skills still get scoped.
+#   2. Warn (feedback only — never rejects) when the description carries a
+#      hyphenated `+word-word` substring, the symptom of a tag the CLI
+#      mis-parsed as `+word` AND `-word` (it never became a real tag).
+#
+# SAFETY: a broken on-add hook breaks EVERY `task add`. This hook therefore
+# fails OPEN — on any error (missing jq, bad JSON) it echoes stdin unchanged
+# and exits 0.
+
+set -uo pipefail
+
+read -r task_json || exit 0
+
+# Fail open if jq is unavailable.
+if ! command -v jq >/dev/null 2>&1; then
+  printf '%s\n' "$task_json"
+  exit 0
+fi
+
+out_json="$task_json"
+
+# 1. Stamp project from repo/cwd when missing.
+current_project=$(printf '%s' "$task_json" | jq -r '.project // empty' 2>/dev/null || true)
+if [ -z "$current_project" ]; then
+  repo_top=$(git rev-parse --show-toplevel 2>/dev/null || true)
+  proj_base=$(basename "${repo_top:-$PWD}")
+  if [ -n "$proj_base" ] && [ "$proj_base" != "/" ]; then
+    stamped=$(printf '%s' "$out_json" | jq -c --arg p "$proj_base" '.project = $p' 2>/dev/null || true)
+    [ -n "$stamped" ] && out_json="$stamped"
+  fi
+fi
+
+# Echo the (possibly modified) task back — this is the contract.
+printf '%s\n' "$out_json"
+
+# 2. Hyphenated-tag warning (feedback only).
+desc=$(printf '%s' "$task_json" | jq -r '.description // ""' 2>/dev/null || true)
+if printf '%s' "$desc" | grep -qE '\+[a-z][a-z0-9_]*-[a-z]'; then
+  echo "taskwarrior-plugin: description contains a hyphenated +tag, which taskwarrior mis-parses (it never lands). Use underscores or camelCase, e.g. +blocked_on_merge."
+fi
+
+exit 0

--- a/taskwarrior-plugin/skills/install-native-hooks/templates/on-modify-taskwarrior-plugin
+++ b/taskwarrior-plugin/skills/install-native-hooks/templates/on-modify-taskwarrior-plugin
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# on-modify-taskwarrior-plugin — taskwarrior NATIVE hook (lives in <data>/hooks/).
+#
+# Installed opt-in by /taskwarrior:install-native-hooks. Runs inside any task
+# modification (modify, annotate, done, start, stop), AFTER processing but
+# BEFORE save. Receives TWO lines of JSON on stdin (the ORIGINAL task, then the
+# MODIFIED task) and must echo the modified task JSON back as the first line of
+# stdout; later stdout lines are feedback. Exit 0 allows, non-zero rejects.
+#
+# Behaviour: warns (feedback only — never rejects) when the modified
+# description carries a hyphenated `+word-word` substring (a mis-parsed tag).
+# This is the modify-time counterpart of the on-add warning. Extend here for
+# project-specific convention enforcement.
+#
+# SAFETY: fails OPEN — on any error it echoes the modified task unchanged and
+# exits 0, so a broken hook never blocks legitimate task edits.
+#
+# NOTE: native hooks do NOT fire on `task import`, so bulk reconciliation
+# (/taskwarrior:task-reconcile --apply, bulk path) bypasses this hook by design.
+
+set -uo pipefail
+
+read -r _original_json || exit 0
+read -r modified_json || { printf '%s\n' "$_original_json"; exit 0; }
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf '%s\n' "$modified_json"
+  exit 0
+fi
+
+# Echo the modified task back unchanged — this hook only advises.
+printf '%s\n' "$modified_json"
+
+desc=$(printf '%s' "$modified_json" | jq -r '.description // ""' 2>/dev/null || true)
+if printf '%s' "$desc" | grep -qE '\+[a-z][a-z0-9_]*-[a-z]'; then
+  echo "taskwarrior-plugin: description contains a hyphenated +tag, which taskwarrior mis-parses (it never lands). Use underscores or camelCase, e.g. +blocked_on_merge."
+fi
+
+exit 0

--- a/taskwarrior-plugin/skills/task-add/SKILL.md
+++ b/taskwarrior-plugin/skills/task-add/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: task-add
 description: Add a taskwarrior task with blueprint linkage and optional GitHub issue. Use when adding coordination tasks, linking a blueprint WO, or mirroring a GitHub issue locally.
-args: "[description] [project:<name>] [--no-project]"
-allowed-tools: Bash(task *), Bash(git config *), Bash(git rev-parse *), Bash(gh auth *), Bash(gh issue *), Bash(gh api *), Read, TodoWrite
+args: "[description] [project:<name>] [--no-project] [due:<date>] [scheduled:<date>] [wait:<date>] [recur:<freq>] [until:<date>]"
+allowed-tools: Bash(task *), Bash(git config *), Bash(git rev-parse *), Bash(gh auth *), Bash(gh issue *), Bash(gh api *), Bash(bash *), Read, TodoWrite
 argument-hint: short task description
 created: 2026-04-24
-modified: 2026-06-02
-reviewed: 2026-06-02
+modified: 2026-06-20
+reviewed: 2026-06-20
 ---
 
 # /taskwarrior:task-add
@@ -42,6 +42,13 @@ Parse `$ARGUMENTS`:
 - Optional inline `project:<name>` to override the auto-detected project.
 - Optional `--no-project` to file the task without any project (cross-cutting work).
 - Optional inline `bpid:WO-012` / `bpdoc:docs/wo/012.md` / `bpms:M6` / `ghid:145` / `ghpr:99` fields.
+- Optional native scheduling fields (prefer these over manual `+blocked*` bookkeeping):
+  - `due:<date>` — deadline. Feeds urgency and surfaces the task as `+DUE` / `+OVERDUE` in `task-coordinate` / `task-status`.
+  - `scheduled:<date>` — earliest start. The task only becomes `+READY` once this date passes, so future work stays out of dispatch candidates.
+  - `wait:<date>` — hide the task entirely until the date. Use for "blocked on merge until X" instead of a hand-managed `+blocked_on_merge` tag — taskwarrior auto-unhides it.
+  - `recur:<freq>` (e.g. `weekly`, `monthly`) with a `due:` — repeating maintenance chores. Requires `due:`.
+  - `until:<date>` — auto-delete the task on that date. Use for short-lived trackers that should expire if not actioned.
+  - Dates accept taskwarrior synonyms (`today`, `eow`, `eom`, `monday`, `due-4d`, ISO `2026-07-01`).
 - Optional tags: `+wo`, `+prp`, `+fr`, `+re`, `+gh`, `+pr_ready`, `+needs_review`, `+blocked_on_merge`, `+blocked`.
 
 > **Tag naming gotcha — hyphens silently break tags.** Taskwarrior parses
@@ -77,35 +84,24 @@ Execute this workflow:
 
 ### Step 1: Ensure UDAs exist
 
-If `task _udas` output lacks any of `bpid`, `bpdoc`, `bpms`, `ghid`, `ghpr` (linkage UDAs) or `agent`, `pid`, `host`, `branch`, `worktree` (identity UDAs populated by `/taskwarrior:task-claim`), offer to install them:
+The canonical 10-UDA set (5 linkage: `bpid` / `bpdoc` / `bpms` / `ghid` /
+`ghpr`; 5 identity: `agent` / `pid` / `host` / `branch` / `worktree`) lives in
+one place — the shared `ensure-udas.sh` script. Check for missing UDAs:
 
 ```bash
-# Linkage UDAs
-task config uda.bpid.type string
-task config uda.bpid.label "Blueprint ID"
-task config uda.bpdoc.type string
-task config uda.bpdoc.label "Blueprint doc"
-task config uda.bpms.type string
-task config uda.bpms.label "Milestone"
-task config uda.ghid.type numeric
-task config uda.ghid.label "GH Issue"
-task config uda.ghpr.type numeric
-task config uda.ghpr.label "GH PR"
-
-# Identity UDAs (populated by task-claim, drained by task-release / task-done)
-task config uda.agent.type string
-task config uda.agent.label "Agent ID"
-task config uda.pid.type numeric
-task config uda.pid.label "Agent PID"
-task config uda.host.type string
-task config uda.host.label "Host"
-task config uda.branch.type string
-task config uda.branch.label "Git branch"
-task config uda.worktree.type string
-task config uda.worktree.label "Worktree path"
+bash "${CLAUDE_SKILL_DIR}/../../scripts/ensure-udas.sh" --check
 ```
 
-Install only with user confirmation on first run per host. Identity UDAs are not set by `task-add` itself — `/taskwarrior:task-claim` stamps them when an agent picks the task up.
+If it reports `UDAS_MISSING` greater than 0, confirm with the user (declarations
+persist in `~/.taskrc`), then install them on first run per host:
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/../../scripts/ensure-udas.sh"
+```
+
+Identity UDAs are not set by `task-add` itself — `/taskwarrior:task-claim`
+stamps them when an agent picks the task up. The same script backs the
+SessionStart drift-probe, so the install logic is single-sourced.
 
 ### Step 2: Detect GitHub mode
 
@@ -162,10 +158,16 @@ task add "$DESCRIPTION" \
   bpms:"$BPMS" \
   ghid:"$GHID" \
   ghpr:"$GHPR" \
+  due:"$DUE" \
+  scheduled:"$SCHEDULED" \
+  wait:"$WAIT" \
   +wo +gh
 ```
 
-Run with only the fields that were provided; omit empty UDAs entirely rather than passing `uda:""`.
+Run with only the fields that were provided; omit empty UDAs and empty date
+fields entirely rather than passing `uda:""` / `due:""`. For a recurring chore,
+pass `recur:weekly due:monday` (recurrence requires a `due:`); for a
+self-expiring tracker, add `until:eom`.
 
 #### Capture the stable UUID
 
@@ -220,7 +222,7 @@ Print:
 | Capture stable UUID after add | `task +LATEST _get uuid` |
 | Duplicate check by bpid | `task bpid:WO-012 export \| jq '.[] \| {id, status}'` |
 | Pre-fill from issue | `gh issue view 145 --json number,title,body,labels` |
-| Next unblocked | `task status:pending -BLOCKED export \| jq '.[:3]'` |
+| Next ready (unblocked + scheduled-due) | `task status:pending +READY export \| jq '.[:3]'` |
 | Skip empty filter exit | Always use `export \| jq`, never `list` |
 
 ## Quick Reference
@@ -234,6 +236,11 @@ Print:
 | `bpms:` | Milestone |
 | `ghid:` | GitHub issue number |
 | `ghpr:` | GitHub PR number |
+| `due:` | Deadline — feeds urgency, surfaces `+DUE`/`+OVERDUE` |
+| `scheduled:` | Earliest start — gates `+READY` |
+| `wait:` | Hide until date (auto-unhides) — prefer over `+blocked_on_merge` |
+| `recur:` | Repeat frequency (needs `due:`) |
+| `until:` | Auto-delete date |
 | `+wo` | Work order |
 | `+prp` | PRP |
 | `+fr` | Feature request |

--- a/taskwarrior-plugin/skills/task-claim/SKILL.md
+++ b/taskwarrior-plugin/skills/task-claim/SKILL.md
@@ -48,22 +48,20 @@ Execute this claim workflow:
 
 ### Step 1: Ensure identity UDAs exist
 
-If `task _udas` output lacks `agent`, `pid`, `host`, `branch`, or `worktree`, install them on first run per host:
+The identity UDAs (`agent` / `pid` / `host` / `branch` / `worktree`) are part of
+the canonical set in the shared `ensure-udas.sh` script. Check for missing UDAs:
 
 ```bash
-task config uda.agent.type string
-task config uda.agent.label "Agent ID"
-task config uda.pid.type numeric
-task config uda.pid.label "Agent PID"
-task config uda.host.type string
-task config uda.host.label "Host"
-task config uda.branch.type string
-task config uda.branch.label "Git branch"
-task config uda.worktree.type string
-task config uda.worktree.label "Worktree path"
+bash "${CLAUDE_SKILL_DIR}/../../scripts/ensure-udas.sh" --check
 ```
 
-Confirm with the user before installing — UDA declarations live in `~/.taskrc` and persist across sessions.
+If it reports `UDAS_MISSING` greater than 0, confirm with the user (declarations
+persist in `~/.taskrc`) and install — the script is idempotent and installs the
+full linkage + identity set in one pass:
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/../../scripts/ensure-udas.sh"
+```
 
 ### Step 2: Load the task and check active state
 

--- a/taskwarrior-plugin/skills/task-coordinate/SKILL.md
+++ b/taskwarrior-plugin/skills/task-coordinate/SKILL.md
@@ -63,17 +63,21 @@ Execute this workflow:
 ### Step 1: Load unblocked pending tasks
 
 Substitute the literal project name into the filter (no `$()` command
-substitution — shell-operator protections will reject it). Default
-behaviour excludes both `+BLOCKED` (depends-blocked) and `+ACTIVE`
-(already claimed via `/taskwarrior:task-claim`):
+substitution — shell-operator protections will reject it). Use taskwarrior's
+native `+READY` virtual tag, which means *pending, unblocked, not waiting, and
+either unscheduled or scheduled before now* — so it subsumes the old
+`-BLOCKED` clause AND respects `scheduled:` / `wait:` dates. Add `-ACTIVE` to
+exclude tasks already claimed via `/taskwarrior:task-claim`:
 
 ```bash
-task project:myrepo status:pending -BLOCKED -ACTIVE export \
-  | jq 'sort_by(-.urgency) | .[] | {id, description, urgency, tags, bpid, depends}'
+task project:myrepo status:pending +READY -ACTIVE export \
+  | jq 'sort_by(-.urgency) | .[] | {id, description, urgency, tags, bpid, depends, due, scheduled}'
 ```
 
 With `--include-active`, drop the `-ACTIVE` clause so already-claimed
 tasks compete for ranking. With `--all`, drop the `project:` clause.
+`+READY` automatically hides `wait:`-deferred and future-`scheduled:` tasks,
+so a task parked with `wait:` until a PR merges never appears as a candidate.
 Never use `task next` — exits 1 on empty.
 
 ### Step 1b: Snapshot in-flight claims
@@ -188,11 +192,12 @@ report only, per the v1 design.
 
 | Context | Command |
 |---------|---------|
-| Project unclaimed + unblocked | `task project:myrepo status:pending -BLOCKED -ACTIVE export \| jq 'sort_by(-.urgency)'` |
+| Project ready + unclaimed | `task project:myrepo status:pending +READY -ACTIVE export \| jq 'sort_by(-.urgency)'` |
 | Include claimed (rare) | drop `-ACTIVE` clause |
+| Overdue candidates | `task project:myrepo status:pending +OVERDUE export \| jq 'sort_by(-.urgency)'` |
 | In-flight snapshot | `task project:myrepo +ACTIVE export \| jq '.[] \| {id, agent, branch, start}'` |
 | Stale claims | `task project:myrepo +ACTIVE start.before:now-4h export \| jq` |
-| Cross-project (`--all`) | `task status:pending -BLOCKED -ACTIVE export \| jq 'sort_by(-.urgency)'` |
+| Cross-project (`--all`) | `task status:pending +READY -ACTIVE export \| jq 'sort_by(-.urgency)'` |
 | Same-lock siblings | Filter on `tags` / bpid prefix locally, not via `task` filter |
 | Wave brief | `--wave` flag emits table with exclusion column |
 | Skip failing-filter variants | Never `task next`, always `export \| jq` |

--- a/taskwarrior-plugin/skills/task-reconcile/REFERENCE.md
+++ b/taskwarrior-plugin/skills/task-reconcile/REFERENCE.md
@@ -1,0 +1,88 @@
+# task-reconcile reference
+
+Detailed behaviour of the GitHub issue/PR ↔ task reconciliation, the two close
+paths, and the `task import` constraints that shape the design.
+
+## Why reconciliation is a skill, not a hook
+
+`task import` does **not** fire taskwarrior native (`~/.task/hooks/`) hooks, and
+reconciliation needs `gh` calls to learn upstream state — neither fits an
+`on-modify` hook. So the close logic lives in a skill-invoked script that the
+agent runs on demand (or that `task-status`/session skills suggest when drift is
+detected). The optional native hooks installed by
+`/taskwarrior:install-native-hooks` are for *enforcement on add/modify*, a
+separate concern.
+
+## Classification authority
+
+A task can carry both `ghid` (issue) and `ghpr` (PR). The PR signal wins:
+
+| Task has | Upstream state | Verdict |
+|----------|----------------|---------|
+| `ghpr` | `MERGED` | `pr-merged` (stale — work landed) |
+| `ghpr` | `CLOSED` | `pr-closed` (stale — abandoned PR) |
+| `ghpr` | `OPEN` | `live` (keep — work lives in the PR, even if a linked issue closed) |
+| `ghid` only | `CLOSED` | `issue-closed` (stale) |
+| `ghid` only | `OPEN` | `live` |
+| either | `UNKNOWN` (fetch failed) | `live` — never close on uncertainty |
+
+Upstream state is read with `gh issue view N --json state` / `gh pr view N
+--json state`, cached per number so a queue with many tasks pointing at the same
+issue/PR makes one call each. PR state uses the `state` enum
+(`MERGED`/`OPEN`/`CLOSED`) per `.claude/rules/gh-json-fields.md` — never a
+`merged` field.
+
+## The two close paths — and why
+
+| Path | Used for | Mechanism | Trade-off |
+|------|----------|-----------|-----------|
+| **bulk** | leaf stale tasks (no dependents) | one `task export \| jq \| task import` round-trip: set `status=completed`, `end`, append `reconcile:` annotation | fast; **skips** dependency auto-unblock and native hooks |
+| **done** | stale tasks that `+BLOCKING` others | per-task `task <uuid> annotate` then `task rc.confirmation=no <uuid> done </dev/null` | fires taskwarrior's auto-unblock so dependents become ready |
+
+The split exists because `task import` writes the completed state directly and
+**does not run the dependency-unblock pass** that `task done` performs. A stale
+task that blocks others must therefore close via `task done`, or its dependents
+would stay `+BLOCKED` forever. Leaf trackers (the common case — an `issue #N`
+mirror with no dependents) take the fast bulk path.
+
+## `task import` round-trip gotchas
+
+The bulk path round-trips JSON through `task import`. To keep it safe:
+
+- **Preserve `uuid` and `entry`.** Import matches on `uuid` to *update* the
+  existing task rather than create a duplicate; `entry` is the creation
+  timestamp. The jq transform only sets `status`/`end`/`annotations` and leaves
+  everything else (including `uuid`/`entry`) untouched.
+- **Do not write derived fields back.** `id` and `urgency` in the export are
+  display-derived; importing them is harmless but pointless — the transform
+  leaves them as-is and taskwarrior recomputes.
+- **Dates use taskwarrior basic ISO** (`YYYYMMDDTHHMMSSZ`), computed once via
+  `date -u +%Y%m%dT%H%M%SZ` and applied to both `end` and the annotation
+  `entry`.
+- **Annotation before/with close.** The bulk transform appends the `reconcile:`
+  annotation in the same import that sets `completed`, so the reason is captured
+  atomically. The per-task path annotates first, then closes — if `done` fails
+  (unresolved deps), the annotation still landed.
+
+## Stale numeric IDs
+
+The script addresses every mutation by **UUID**, never numeric ID. Numeric IDs
+are a display index over pending tasks and shift whenever any task completes —
+exactly what happens mid-reconciliation as the stale set closes. See
+`~/.claude/rules/taskwarrior-bulk-operations.md`.
+
+## Parallel-safety
+
+Every read uses `task ... export | jq`, which returns `[]` and exits 0 on an
+empty result — so the script is safe to invoke inside a parallel Bash batch
+(`.claude/rules/parallel-safe-queries.md`). The script's own exit code is 0 on
+any clean run (dry-run or apply); failures surface in `STATUS=`/`ISSUE_COUNT=`,
+not the exit code.
+
+## What it never does
+
+- Never closes a task whose upstream state is `UNKNOWN` (fetch failed).
+- Never closes a `live` task.
+- Never deletes tasks — only transitions stale ones to `completed`.
+- Never mutates GitHub — it reads issue/PR state only. Closing the GitHub side
+  is `task-done`'s job (`gh issue close` / `gh pr comment`).

--- a/taskwarrior-plugin/skills/task-reconcile/SKILL.md
+++ b/taskwarrior-plugin/skills/task-reconcile/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: task-reconcile
+description: Close taskwarrior tasks whose linked GitHub issue/PR closed or merged. Use when stale trackers pile up, after a PR-merge sweep, or auditing queue drift.
+args: "[--apply] [--project=<name>] [--all]"
+allowed-tools: Bash(task *), Bash(gh issue *), Bash(gh pr *), Bash(jq *), Bash(bash *), Bash(git rev-parse *), Read, TodoWrite
+argument-hint: optional --apply to close (default dry-run preview)
+created: 2026-06-20
+modified: 2026-06-20
+reviewed: 2026-06-20
+---
+
+# /taskwarrior:task-reconcile
+
+Close the tasks that have gone stale because the GitHub issue or PR they
+mirror has closed or merged. `task-status` *detects* this drift; this skill
+*acts* on it, so the queue does not silently fill with trackers for work that
+already shipped.
+
+## When to Use This Skill
+
+| Use this skill when... | Use a sibling skill instead when... |
+|---|---|
+| Stale `ghid`/`ghpr` tasks have piled up after issues/PRs closed | Auditing queue health without mutating it — use `task-status` |
+| Sweeping the queue after a batch of PRs merged | Closing one specific task by ID with a landing commit — use `task-done` |
+| Reconciling the local queue against GitHub as the source of record | Filing a new linked task — use `task-add` |
+
+## Context
+
+- Task CLI available: !`task --version`
+- Git repo detected: !`find . -maxdepth 1 -name '.git' -print -quit`
+- GH auth: !`gh auth status`
+
+GitHub-mode and project resolution run in the body (Step 1) via the bundled
+scripts, where stderr suppression and exit-code handling are available — git /
+gh probes in a Context backtick abort the skill in a no-git/no-remote cwd.
+
+## Parameters
+
+Parse `$ARGUMENTS`:
+
+- `--apply` — perform the close. Without it the skill runs a **dry-run preview**
+  first, then asks once before closing.
+- `--project=<name>` — override the auto-detected project filter.
+- `--all` — reconcile across every project (rare; usually you want one repo).
+- `--limit=N` — cap how many linked tasks are inspected (default 200).
+
+## Execution
+
+Execute this reconciliation workflow:
+
+### Step 1: Resolve scope
+
+Run the shared project resolver (handles `--project` / `--all` / git-toplevel /
+cwd, with no stderr-emitting git probes):
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/../../scripts/resolve-project.sh" --project-dir "$(pwd)"
+```
+
+Read `PROJECT=` from the output. GitHub mode must be on (an authenticated `gh`
+plus a remote) — the reconcile script reports `GH_AVAILABLE=false` and exits
+cleanly if not.
+
+### Step 2: Dry-run classification
+
+Run the reconcile script **without** `--apply` to classify every linked task:
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/reconcile.sh" --project=PROJECT --project-dir "$(pwd)"
+```
+
+It emits one `TASK ...` line per linked task with its `upstream` state, a
+`verdict` (`live` / `issue-closed` / `pr-merged` / `pr-closed`), and the
+close `method` it would use (`bulk` / `done` / `keep`). Render the stale set as
+a table for the user, and read the `STALE_COUNT` / `BULK_COUNT` / `DONE_COUNT`
+summary.
+
+### Step 3: Confirm and apply
+
+If `STALE_COUNT` is 0, report "queue is in sync" and stop.
+
+If `--apply` was passed in `$ARGUMENTS`, skip straight to running with `--apply`.
+Otherwise confirm once with **AskUserQuestion** (never a freeform "y/n" — see
+`.claude/rules/skill-execution-structure.md`): "Close N stale task(s)?" with
+options to proceed, review the table again, or cancel.
+
+On confirmation, re-run with `--apply`:
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/reconcile.sh" --apply --project=PROJECT --project-dir "$(pwd)"
+```
+
+Each closed task is annotated with the reason (`reconcile: PR #45 merged`).
+Leaf tasks close via a bulk `task import` round-trip; tasks that block others
+close via per-task `task done` so taskwarrior's dependency auto-unblock fires
+(see [REFERENCE.md](REFERENCE.md) for why the two paths differ).
+
+### Step 4: Report
+
+Print `CLOSED_COUNT`, the per-task verdicts, and any `UNKNOWN_UPSTREAM` count
+(tasks whose issue/PR could not be fetched — left untouched, never closed on
+uncertainty). Suggest `/taskwarrior:task-status` to confirm the queue is clean.
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Dry-run classify | `bash scripts/reconcile.sh --project=PROJECT` |
+| Apply the close | `bash scripts/reconcile.sh --apply --project=PROJECT` |
+| Cross-project sweep | `bash scripts/reconcile.sh --all` |
+| Linked-task snapshot | `task project:PROJECT status:pending export \| jq '[.[] \| select(.ghid != null or .ghpr != null)]'` |
+| Issue state | `gh issue view N --json state --jq '.state'` |
+| PR state (per gh-json-fields) | `gh pr view N --json state --jq '.state'` |
+| Skip empty-filter failures | Always `export \| jq`, never `list` |
+
+## Quick Reference
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--apply` | off (dry-run) | Perform the close |
+| `--project=<name>` | repo basename | Override the project filter |
+| `--all` | off | Reconcile across every project |
+| `--limit=N` | 200 | Max linked tasks to inspect |
+
+| Verdict | Meaning | Close method |
+|---------|---------|--------------|
+| `live` | Issue/PR still open | keep |
+| `issue-closed` | `ghid` issue is CLOSED | bulk / done |
+| `pr-merged` | `ghpr` PR is MERGED | bulk / done |
+| `pr-closed` | `ghpr` PR closed unmerged | bulk / done |
+
+## Related
+
+- `/taskwarrior:task-status` — detects the drift this skill resolves
+- `/taskwarrior:task-done` — close one task with a landing commit
+- `/taskwarrior:task-add` — file the linked tasks this skill later reconciles
+- `.claude/rules/gh-json-fields.md` — `state`/`mergedAt` (never a `merged` field)
+- `.claude/rules/parallel-safe-queries.md` — the `export | jq` idiom
+- `taskwarrior-plugin/skills/task-reconcile/REFERENCE.md` — bulk-vs-done routing, `task import` caveats

--- a/taskwarrior-plugin/skills/task-reconcile/scripts/reconcile.sh
+++ b/taskwarrior-plugin/skills/task-reconcile/scripts/reconcile.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# reconcile.sh — close taskwarrior tasks whose linked GitHub issue/PR has
+# closed or merged, so the queue does not silently accumulate stale trackers.
+#
+# task-status DETECTS this drift (drift: stale-open) but never acts on it.
+# This script is the action: it snapshots pending tasks carrying ghid/ghpr,
+# batch-checks upstream state via gh (few calls, cached per number), classifies
+# each task live/stale, and — with --apply — closes the stale set.
+#
+# Close routing (the load-bearing nuance):
+#   * Leaf stale tasks (no dependents)  → bulk `task import` round-trip
+#     (one pass; set status=completed + end + reconcile annotation).
+#   * Stale tasks that BLOCK others     → per-task `task done`
+#     (fires taskwarrior's dependency auto-unblock, which `task import` does
+#     NOT — import bypasses native hooks and the unblock pass).
+#
+# Default is DRY-RUN: classify and print, mutate nothing. Pass --apply to close.
+#
+# Flags:
+#   --apply              Perform the close (default: dry-run, no mutation)
+#   --project=<name>     Scope to one project (default: resolved by caller)
+#   --all                Cross-project scope (no project filter)
+#   --project-dir=<dir>  Directory for gh/git probes (default: cwd)
+#   --limit=<n>          Max linked tasks to inspect (default 200)
+#
+# Output: structured KEY=VALUE block (.claude/rules/structured-script-output.md),
+# one TASK line per linked task, then a summary. Always exit 0 on a clean run so
+# the script stays parallel-safe in a Bash batch (failures surface in STATUS).
+#
+# Exit codes:
+#   0 - clean run (dry-run or apply); see STATUS for OK/WARN/ERROR
+#   1 - task binary missing
+
+set -uo pipefail
+
+rc_apply=false
+rc_project=""
+rc_all=false
+rc_dir="$PWD"
+rc_limit=200
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --apply) rc_apply=true ;;
+    --project=*) rc_project="${1#*=}" ;;
+    --project) shift; rc_project="${1:-}" ;;
+    --all) rc_all=true ;;
+    --project-dir=*) rc_dir="${1#*=}" ;;
+    --project-dir) shift; rc_dir="${1:-$PWD}" ;;
+    --limit=*) rc_limit="${1#*=}" ;;
+    --limit) shift; rc_limit="${1:-200}" ;;
+    *) ;;
+  esac
+  shift
+done
+
+echo "=== TASK RECONCILE ==="
+
+# gh resolves the default repo from the working directory, so operate there.
+cd "$rc_dir" 2>/dev/null || true
+
+if ! command -v task >/dev/null 2>&1; then
+  echo "TASK_AVAILABLE=false"
+  echo "STATUS=ERROR"
+  echo "ISSUE_COUNT=1"
+  echo "=== END TASK RECONCILE ==="
+  exit 1
+fi
+
+gh_ok=false
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  gh_ok=true
+fi
+echo "GH_AVAILABLE=${gh_ok}"
+
+if [ "$gh_ok" != true ]; then
+  echo "STATUS=WARN"
+  echo "ISSUE_COUNT=1"
+  echo "ISSUES:"
+  echo "  - SEVERITY=WARN TYPE=gh_unavailable MSG=reconcile needs an authenticated gh; run gh auth login"
+  echo "=== END TASK RECONCILE ==="
+  exit 0
+fi
+
+# --- Build the project filter ---------------------------------------------
+proj_filter=()
+if [ "$rc_all" != true ] && [ -n "$rc_project" ]; then
+  proj_filter=("project:${rc_project}")
+fi
+echo "SCOPE=${rc_project:-ALL}"
+echo "MODE=$([ "$rc_apply" = true ] && echo apply || echo dry-run)"
+
+# --- Snapshot linked pending tasks (parallel-safe export | jq) -------------
+linked_json=$(task "${proj_filter[@]}" status:pending export 2>/dev/null \
+  | jq -c "[.[] | select(.ghid != null or .ghpr != null)] | .[:${rc_limit}]" 2>/dev/null || echo "[]")
+linked_count=$(printf '%s' "$linked_json" | jq 'length' 2>/dev/null || echo 0)
+echo "TOTAL_LINKED=${linked_count}"
+
+if [ "$linked_count" -eq 0 ]; then
+  echo "STALE_COUNT=0"
+  echo "STATUS=OK"
+  echo "ISSUE_COUNT=0"
+  echo "=== END TASK RECONCILE ==="
+  exit 0
+fi
+
+# Tasks that block others — closing these via bulk import would skip the
+# dependency auto-unblock, so they route to per-task `task done`.
+blocking_uuids=$(task "${proj_filter[@]}" status:pending +BLOCKING export 2>/dev/null \
+  | jq -r '.[].uuid' 2>/dev/null || true)
+
+is_blocking() {
+  printf '%s\n' "$blocking_uuids" | grep -qx "$1"
+}
+
+# --- Cache upstream state per number --------------------------------------
+declare -A issue_state
+declare -A pr_state
+
+issue_state_for() {
+  local n="$1"
+  if [ -n "${issue_state[$n]:-}" ]; then printf '%s' "${issue_state[$n]}"; return; fi
+  local s
+  s=$(gh issue view "$n" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+  [ -z "$s" ] && s="UNKNOWN"
+  issue_state[$n]="$s"
+  printf '%s' "$s"
+}
+
+pr_state_for() {
+  local n="$1"
+  if [ -n "${pr_state[$n]:-}" ]; then printf '%s' "${pr_state[$n]}"; return; fi
+  local s
+  s=$(gh pr view "$n" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+  [ -z "$s" ] && s="UNKNOWN"
+  pr_state[$n]="$s"
+  printf '%s' "$s"
+}
+
+# --- Classify each task ----------------------------------------------------
+bulk_uuids=()
+declare -A reason_for
+done_uuids=()
+stale_count=0
+live_count=0
+unknown_count=0
+
+task_count=$(printf '%s' "$linked_json" | jq 'length')
+i=0
+while [ "$i" -lt "$task_count" ]; do
+  row=$(printf '%s' "$linked_json" | jq -c ".[$i]")
+  t_id=$(printf '%s' "$row" | jq -r '.id')
+  t_uuid=$(printf '%s' "$row" | jq -r '.uuid')
+  t_ghid=$(printf '%s' "$row" | jq -r '.ghid // empty')
+  t_ghpr=$(printf '%s' "$row" | jq -r '.ghpr // empty')
+
+  verdict="live"
+  reason=""
+  upstream="-"
+
+  # PR signal takes authority over issue when both are present: a merged PR
+  # means the work landed; an open PR means keep the task even if a linked
+  # issue closed (the work lives in the PR).
+  if [ -n "$t_ghpr" ]; then
+    upstream=$(pr_state_for "$t_ghpr")
+    case "$upstream" in
+      MERGED) verdict="pr-merged"; reason="PR #${t_ghpr} merged" ;;
+      CLOSED) verdict="pr-closed"; reason="PR #${t_ghpr} closed unmerged" ;;
+      OPEN) verdict="live" ;;
+      *) verdict="live"; unknown_count=$((unknown_count + 1)) ;;
+    esac
+  elif [ -n "$t_ghid" ]; then
+    upstream=$(issue_state_for "$t_ghid")
+    case "$upstream" in
+      CLOSED) verdict="issue-closed"; reason="issue #${t_ghid} closed" ;;
+      OPEN) verdict="live" ;;
+      *) verdict="live"; unknown_count=$((unknown_count + 1)) ;;
+    esac
+  fi
+
+  method="keep"
+  if [ "$verdict" != "live" ]; then
+    stale_count=$((stale_count + 1))
+    if is_blocking "$t_uuid"; then
+      method="done"
+      done_uuids+=("$t_uuid")
+    else
+      method="bulk"
+      bulk_uuids+=("$t_uuid")
+    fi
+    reason_for[$t_uuid]="$reason"
+  else
+    live_count=$((live_count + 1))
+  fi
+
+  echo "TASK id=${t_id} uuid=${t_uuid} ghid=${t_ghid:--} ghpr=${t_ghpr:--} upstream=${upstream} verdict=${verdict} method=${method}"
+  i=$((i + 1))
+done
+
+echo "STALE_COUNT=${stale_count}"
+echo "LIVE_COUNT=${live_count}"
+echo "BULK_COUNT=${#bulk_uuids[@]}"
+echo "DONE_COUNT=${#done_uuids[@]}"
+[ "$unknown_count" -gt 0 ] && echo "UNKNOWN_UPSTREAM=${unknown_count}"
+
+# --- Dry-run stops here ----------------------------------------------------
+if [ "$rc_apply" != true ]; then
+  echo "APPLIED=false"
+  echo "STATUS=OK"
+  echo "ISSUE_COUNT=${stale_count}"
+  echo "=== END TASK RECONCILE ==="
+  exit 0
+fi
+
+if [ "$stale_count" -eq 0 ]; then
+  echo "APPLIED=true"
+  echo "CLOSED_COUNT=0"
+  echo "STATUS=OK"
+  echo "ISSUE_COUNT=0"
+  echo "=== END TASK RECONCILE ==="
+  exit 0
+fi
+
+now_tw=$(date -u +%Y%m%dT%H%M%SZ)
+closed=0
+apply_failures=0
+
+# Per-task `task done` for blocking tasks (fires dependency auto-unblock).
+for u in "${done_uuids[@]}"; do
+  task "$u" annotate "reconcile: ${reason_for[$u]}" </dev/null >/dev/null 2>&1 || true
+  # "done" is quoted so shellcheck does not read it as a loop terminator (SC1010).
+  if task rc.confirmation=no "$u" "done" </dev/null >/dev/null 2>&1; then
+    closed=$((closed + 1))
+  else
+    apply_failures=$((apply_failures + 1))
+  fi
+done
+
+# Bulk JSON round-trip for leaf tasks (no dependents). Preserves uuid/entry;
+# sets status/end and appends the reconcile annotation in one import. NOTE:
+# `task import` does NOT fire native (~/.task/hooks) on-modify hooks — that is
+# acceptable for a close, and is why blocking tasks above use `task done`.
+if [ "${#bulk_uuids[@]}" -gt 0 ]; then
+  reasons_json="{}"
+  for u in "${bulk_uuids[@]}"; do
+    reasons_json=$(printf '%s' "$reasons_json" | jq --arg u "$u" --arg r "${reason_for[$u]}" '. + {($u): $r}')
+  done
+  uuid_list=$(printf '%s\n' "${bulk_uuids[@]}" | jq -R . | jq -cs .)
+
+  import_payload=$(task "${proj_filter[@]}" status:pending export 2>/dev/null | jq -c \
+    --argjson uuids "$uuid_list" \
+    --argjson reasons "$reasons_json" \
+    --arg now "$now_tw" '
+      [ .[]
+        | select(.uuid as $u | $uuids | index($u))
+        | .status = "completed"
+        | .end = $now
+        | .annotations = ((.annotations // []) + [{entry: $now, description: ("reconcile: " + ($reasons[.uuid] // "linked item closed"))}])
+      ]')
+
+  imported=$(printf '%s' "$import_payload" | jq 'length' 2>/dev/null || echo 0)
+  if printf '%s' "$import_payload" | task import >/dev/null 2>&1; then
+    closed=$((closed + imported))
+  else
+    apply_failures=$((apply_failures + imported))
+  fi
+fi
+
+echo "APPLIED=true"
+echo "CLOSED_COUNT=${closed}"
+if [ "$apply_failures" -gt 0 ]; then
+  echo "STATUS=WARN"
+  echo "ISSUE_COUNT=${apply_failures}"
+  echo "ISSUES:"
+  echo "  - SEVERITY=WARN TYPE=close_failed MSG=${apply_failures} task(s) failed to close; re-run dry-run to inspect"
+else
+  echo "STATUS=OK"
+  echo "ISSUE_COUNT=0"
+fi
+echo "=== END TASK RECONCILE ==="
+exit 0

--- a/taskwarrior-plugin/skills/task-status/SKILL.md
+++ b/taskwarrior-plugin/skills/task-status/SKILL.md
@@ -76,7 +76,7 @@ project name into the filter — do **not** use `$()` command substitution
 in the inline command (shell-operator protections will reject it).
 
 ```bash
-task project:myrepo status:pending export | jq '.[] | {id, description, urgency, tags, bpid, bpdoc, ghid, ghpr, agent, pid, host, branch, worktree, start, modified, depends}'
+task project:myrepo status:pending export | jq '.[] | {id, description, urgency, tags, bpid, bpdoc, ghid, ghpr, agent, pid, host, branch, worktree, start, modified, depends, due, scheduled, wait}'
 ```
 
 For completeness also pull recently-completed in the same project:
@@ -144,10 +144,10 @@ Pass --all for cross-project view, --project=<name> to override.
 
 Output these sections, in order:
 
-1. **Summary**: pending count, in-flight count, ready count (unblocked + unclaimed), blocked count, stale count, stale-claim count
+1. **Summary**: pending count, in-flight count, ready count (`+READY` + unclaimed), blocked count, overdue count, stale count, stale-claim count
 2. **In flight**: `+ACTIVE` tasks with `agent` / `branch` / `host` / `worktree` and time since `start`. Sorted by `start` ascending (oldest first). Section header notes `--mine` / `--all` scope.
 3. **Stale claims** (>4h or `--stale-claim-after`): subset of "In flight" with `start.before:now-Nh`. Recommend `/taskwarrior:task-release <id>` per row — the report never auto-stops.
-4. **Ready for dispatch**: top 5 by urgency with no `depends:`, no `+blocked*` tags, and not `+ACTIVE`. These are what `/taskwarrior:task-coordinate` would emit.
+4. **Ready for dispatch**: top 5 by urgency from `+READY -ACTIVE` (taskwarrior's native ready set — unblocked, not waiting, scheduled-due). These are what `/taskwarrior:task-coordinate` would emit. Flag any `+OVERDUE` rows (past `due:`) at the top.
 5. **By milestone**: table of pending tasks per `bpms`
 6. **Blocked**: tasks waiting on dependencies or external factors
 7. **PR-ready** (GitHub mode): tasks with green PRs ready to close
@@ -162,7 +162,8 @@ Each row cites the command to act on it (`/taskwarrior:task-done 7`,
 |---------|---------|
 | Project queue JSON | `task project:myrepo status:pending export \| jq` |
 | Cross-project queue (`--all`) | `task status:pending export \| jq` |
-| Ready-for-dispatch (excludes claimed) | `task project:myrepo status:pending -BLOCKED -ACTIVE export \| jq 'sort_by(-.urgency) \| .[:5]'` |
+| Ready-for-dispatch (excludes claimed) | `task project:myrepo status:pending +READY -ACTIVE export \| jq 'sort_by(-.urgency) \| .[:5]'` |
+| Overdue tasks | `task project:myrepo status:pending +OVERDUE export \| jq 'sort_by(-.urgency)'` |
 | In flight | `task project:myrepo +ACTIVE export \| jq '.[] \| {id, agent, branch, host, start}'` |
 | Stale claims (>4h) | `task project:myrepo +ACTIVE start.before:now-4h export \| jq` |
 | Mine (claimed by this agent) | `task project:myrepo +ACTIVE agent:claude-${CLAUDE_SESSION_ID:0:8} export \| jq` |
@@ -176,7 +177,9 @@ Each row cites the command to act on it (`/taskwarrior:task-done 7`,
 |--------|-----------|
 | `project:<name>` | Single project (default scope) |
 | `status:pending` | Open tasks |
-| `-BLOCKED` | Exclude `depends:`-blocked |
+| `+READY` | Native ready set: unblocked, not waiting, scheduled-due |
+| `-BLOCKED` | Exclude `depends:`-blocked (subsumed by `+READY`) |
+| `+DUE` / `+OVERDUE` | Due within 7 days / past `due:` |
 | `+ACTIVE` / `-ACTIVE` | Tasks with `task start` time set / not set |
 | `start.before:now-4h` | Stale claims |
 | `agent:claude-<sid>` | Mine (UDA-based) |


### PR DESCRIPTION
## Context

Audited `taskwarrior-plugin` (6 skills, 10 UDAs) against the Taskwarrior 3.x feature surface and the third-party ecosystem. Closes three gaps the user flagged.

### 1. Stale-task accumulation (headline)
`task-status` *detected* issue/PR drift (`drift: stale-open`) but nothing acted on it, so the queue silently filled with trackers for already-closed work. New **`/taskwarrior:task-reconcile`**:
- Snapshots pending `ghid`/`ghpr` tasks (parallel-safe `export | jq`).
- Batch-checks upstream state via `gh`, cached per number, reading the `state` enum / `mergedAt` (never the `merged` field — `gh-json-fields.md`).
- **Dry-run preview by default**; `--apply` closes with a per-task `reconcile:` annotation.
- **Leaf** tasks close via a bulk `task export | jq | task import` round-trip (preserves `uuid`/`entry`); tasks that **block others** close via per-task `task done` so dependency auto-unblock fires (`task import` skips that pass).
- Never closes on `UNKNOWN` upstream state.

### 2. Native feature adoption
- `task-add` accepts `due:`/`scheduled:`/`wait:`/`recur:`/`until:`.
- `task-coordinate` + `task-status` select candidates from the native **`+READY`** virtual tag (subsumes the hand-rolled `-BLOCKED -ACTIVE`, respects `wait:`/`scheduled:`) and surface **`+OVERDUE`**.
- `wait:` is now preferred over `+blocked_on_merge` bookkeeping.

### 3. De-duplication
- Extracted `taskwarrior-plugin/scripts/{ensure-udas,resolve-project,detect-gh-mode}.sh`, invoked from skill bodies via `${CLAUDE_SKILL_DIR}/../../scripts/`.
- `ensure-udas.sh` is the single source of the 10-UDA set; the drift-probe hook now calls it in `--check` mode.
- Fixed a latent bug: `task config` needs `rc.confirmation=no` or UDAs silently fail to persist non-interactively (the old inline install blocks had this).

### Opt-in native hooks
`/taskwarrior:install-native-hooks` installs taskwarrior `on-add`/`on-modify` hooks (auto-stamp `project`, warn on hyphenated tags). **Strictly user-invoked** — never written by `chezmoi`/SessionStart. Both fail open. Documents loudly that `task import` bypasses native hooks by design.

### Ecosystem verdict
**bugwarrior not adopted** — heavyweight (cron daemon) and has the *same* close-on-upstream-close gap we fix here (GothenburgBitFactory/bugwarrior#377, #658). Our `gh`-native approach is lighter and owns the close logic.

## Regression guards
`scripts/plugin-compliance-check.sh` `check_skill_body()`:
- `task-reconcile` retains `task import` / `--apply` / `dry-run`.
- `task-coordinate` / `task-status` retain `+READY`.
- `install-native-hooks` documents the `task import` bypass.

## Verification
End-to-end in an isolated `TASKDATA`/`TASKRC` store against real **issue #1417 (closed)**, **issue #1017 (open)**, **PR #1712 (merged)**:
- Classification: `issue-closed` → bulk, `live` → keep, `pr-merged` → bulk. ✅
- Apply: only stale tasks closed, with correct `reconcile:` annotations; live task untouched; **UUIDs preserved**. ✅
- Blocking path: a stale blocker routed to `task done` and **auto-unblocked** its dependent (proving it wasn't bulk-imported). ✅
- Native fields: `wait:` auto-hides, `scheduled:` held out of `+READY`, `due:` surfaces via `+OVERDUE`. ✅

All pre-commit hooks pass (shellcheck, tag lint, context-command execution, compliance guards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)