### PR TITLE
feat(workflow-orchestration-plugin): gate checkpoint phases on an independent verifier

### DIFF
--- a/.claude/rules/loop-integrity.md
+++ b/.claude/rules/loop-integrity.md
@@ -1,0 +1,92 @@
+# Loop Integrity
+
+Long-running and self-continuing loops — TDD `test → fix` cycles, multi-phase
+checkpoint refactors, "treadmill" plans that rewrite their own goal file to roll
+into the next phase — share two failure modes that have nothing to do with the
+work itself and everything to do with how the loop *governs* itself:
+
+| Failure | What happens | Symptom |
+|---------|--------------|---------|
+| **Self-judged stop** | The same agent doing the work also decides it's done | The loop optimises for *completion*, not *correctness* — it declares victory the moment the surface symptom clears, rationalising away the residual fault (the bias an agent told to finish always has) |
+| **Drift on self-mutation** | A loop edits its own goal/plan file for the next iteration but leaves no resumable state behind | A fresh session re-enters with no idea what was verified, what changed, or what "done" means — *you are not automating work, you are automating context drift* |
+
+This rule names the two guards that close those gaps. It is the governance
+layer under the looping skills — it does **not** reimplement Claude Code's
+native `/goal` (stop-hook + neutral verifier) or `/loop` (scheduled re-run); it
+distils *why those work* into a bar our own loops can meet.
+
+## Pillar 1 — the stop condition is judged independently
+
+The exit criterion of a loop must be evaluated by an actor **other than** the
+one that produced the work — a fresh, isolated agent reading only the acceptance
+criteria and the artefact, with no memory of the effort that went in. This is
+the same isolation `cold-read-gate` and `adversarial-review` rely on: a reviewer
+that shares the worker's context inherits the worker's motivation to be done.
+
+| | Self-judged (avoid) | Independently judged (prefer) |
+|---|---|---|
+| Who decides "done"? | The worker | A fresh `Agent` / sub-agent that did not do the work |
+| What it reads | Its own reasoning trace | Acceptance criteria + the artefact only |
+| Bias | Toward declaring completion | Toward the criterion as written |
+
+Cheap mechanical exit conditions (a green test suite, a clean `tsc`, exit code
+0) are *already* independent — a failing test does not care how hard you worked.
+The independent-verifier requirement bites when "done" is a judgement
+("the class is now single-purpose", "the docs are accurate"): that judgement
+must come from outside the worker.
+
+## Pillar 2 — every iteration leaves a compact state packet
+
+A loop that re-enters across context limits or session boundaries must, *before
+it mutates its plan toward the next iteration*, write a packet that lets a
+context-free successor pick up cleanly:
+
+| Field | Why a successor needs it |
+|-------|--------------------------|
+| **Objective** | What "done" means for the whole loop, not just this iteration |
+| **Repo / ref** | The exact base the work assumes (branch, base commit) |
+| **Files in scope** | Where the next iteration is allowed to touch |
+| **Exit condition** | The literal criterion that ends the loop |
+| **Verifier result** | What the independent check last returned (pass / fail + why) |
+| **Changed since last run** | What the previous iteration actually did, so the successor doesn't redo or undo it |
+
+The dangerous shape the community flagged: a treadmill that overwrites its goal
+file with the next phase but carries none of the above forward. It keeps moving;
+it stops being *resumable*.
+
+## Bounding runaway
+
+Both pillars assume the loop terminates. Independent verifiers reduce false
+"done"s but can produce false "not done"s, so every loop also needs a hard
+ceiling — `--max-cycles` / `--max-iterations`, "same failure N times in a row =
+stuck", or a phase cap. A loop with no ceiling and a strict verifier can churn
+forever; bound it and surface the stuck state for a human.
+
+## Where this applies
+
+| Skill | How it should meet the bar |
+|-------|----------------------------|
+| `project-plugin:project-test-loop` | Mechanical stop (green suite) is already independent; the ceiling is `--max-cycles` and the "same test fails 3×" stop |
+| `workflow-orchestration-plugin:workflow-checkpoint-refactor` | Phase acceptance gets an independent verifier before `done`; the plan file *is* the state packet (carries verifier result + changed-since fields) |
+| `project-plugin:project-continue` | Reads the state packet to re-enter; never assumes the prior session's reasoning |
+| Any self-mutating "treadmill" plan | Write the packet before rewriting the goal toward the next phase |
+
+## Origin
+
+Distilled from the r/ClaudeCode "Goal and Loop — kinda the same?" discussion,
+where the load-bearing observations were that native `/goal` *"spawns a
+fresh/neutral agent that checks if the conditions are met"* (Pillar 1), that
+self-review is *"fundamentally flawed because the review is not independent —
+agents optimise for completion not correctness"* (Pillar 1), and that a loop
+which *"mutates its own goal file without leaving that packet behind"* is
+*"automating context drift"* (Pillar 2). The packet field list is that comment's
+verbatim shape.
+
+## Related
+
+- `agent-patterns-plugin:adversarial-review` — the isolated second-pass reviewer that a judgement-based stop condition delegates to
+- `agent-patterns-plugin:cold-read-gate` — the isolation pattern both pillars reuse
+- `agent-patterns-plugin:verify-before-plan` — independent review of the loop's *premises* before it starts
+- `.claude/rules/agent-coworker-detection.md` — baseline-drift snapshots, the local-state sibling of the state packet
+- `.claude/rules/pr-branch-sync.md` — the remote sibling: confirm the branch a loop builds on is still live
+- `.claude/rules/regression-testing.md` — `scripts/check-loop-integrity.sh` is this rule's semantic guard

--- a/.claude/rules/regression-testing.md
+++ b/.claude/rules/regression-testing.md
@@ -59,6 +59,7 @@ The audit script in this repo is the canonical example — it pairs a human repo
 | Blueprint upgrade target drift (migrations added without updating `blueprint-upgrade`) | `scripts/check-blueprint-upgrade-target.sh` |
 | Hyphenated taskwarrior tag names in plugin docs (parser silently swallows them) | `scripts/lint-taskwarrior-tags.sh` |
 | Plugin agent body missing `## Tool Selection` section (agents re-discover hook-blocked idioms) | `scripts/check-agent-tool-selection.sh` |
+| A looping skill loses its independent stop condition or compact-state-packet fields (checkpoint plan drops `Verifier result`/`Changed since last run`/`Exit condition`/the independent-verifier step, or a sibling skill loses its `loop-integrity.md` cross-reference) | `scripts/check-loop-integrity.sh --strict` (+ `scripts/tests/test-check-loop-integrity.sh`); wired into `.pre-commit-config.yaml`. See `.claude/rules/loop-integrity.md` |
 | Plugin agent `model:` drifts off `opus` (a weaker delegate's output re-enters the main loop and degrades downstream work; `effort`, not `model`, is the cost lever) | `scripts/check-agent-model.sh` |
 | Agent-dispatch skills lose the loud-failure contract (dispatched agents may surrender with one-word summaries) | `scripts/check-agent-failure-contract.sh` |
 | Skill description exceeds listing-budget length band (>200 WARN, >300 ERROR) | `scripts/plugin-compliance-check.sh` → `check_skill_descriptions()` (length axis); `audit-skill-descriptions.py --strict-length` in pre-commit + CI |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -142,6 +142,18 @@ repos:
         language: system
         files: '^scripts/(check-git-sandbox-guards\.sh|tests/test-check-git-sandbox-guards\.sh)$'
         pass_filenames: false
+      - id: check-loop-integrity
+        name: looping skills keep an independent stop condition + state packet (loop-integrity.md)
+        entry: bash ./scripts/check-loop-integrity.sh --strict
+        language: system
+        files: '(loop-integrity\.md|workflow-checkpoint-refactor/SKILL\.md|project-test-loop/SKILL\.md|adversarial-review/SKILL\.md|check-loop-integrity\.sh)$'
+        pass_filenames: false
+      - id: test-check-loop-integrity
+        name: loop-integrity guard regression
+        entry: bash ./scripts/tests/test-check-loop-integrity.sh
+        language: system
+        files: '^scripts/(check-loop-integrity\.sh|tests/test-check-loop-integrity\.sh)$'
+        pass_filenames: false
       - id: test-check-driver-freshness
         name: driver-freshness equal-date invariant + epoch diagnostics (#1704)
         entry: bash ./scripts/tests/test-check-driver-freshness.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ Claude Code plugin collection providing skills and agents for development workfl
 | `.claude/rules/docs-currency.md` | Code and the docs describing it land in the **same commit** (stub → `blueprint:blueprint-docs-currency`) |
 | `.claude/rules/agent-cli-worktree-safety.md` | Data-loss-prevention conventions for the sibling Python/Typer CLI projects (`git-repo-agent`, `vault-agent`); path-scoped, not repo-wide |
 | `.claude/rules/version-pinning.md` | Version pins in skill examples (`uses:`/`FROM`/`image:`/`rev:`) are a Renovate-managed surface — SHA+comment convention, the coverage guard, and what's illustrative vs. managed |
+| `.claude/rules/loop-integrity.md` | Long-running/self-continuing loops need an **independent** stop condition (a fresh verifier judges "done", not the worker) and a **compact state packet** each iteration (objective/ref/files/verifier-result/changed-since/exit-condition) — else they optimize for completion over correctness or automate context drift |
 
 ## Creating New Skills
 

--- a/agent-patterns-plugin/skills/adversarial-review/SKILL.md
+++ b/agent-patterns-plugin/skills/adversarial-review/SKILL.md
@@ -175,3 +175,4 @@ review can't resolve.
 - `agents-plugin` security-audit / `/security-review` — the security lens
 - `.claude/rules/terminology.md` — defines *Adversarial review* and *Red-team*
 - `.claude/rules/skill-fork-context.md` — the `[1m]` parallel-dispatch caveat
+- `.claude/rules/loop-integrity.md` — looping skills delegate their stop-condition judgement to an isolated reviewer like this one (Pillar 1)

--- a/project-plugin/skills/project-test-loop/SKILL.md
+++ b/project-plugin/skills/project-test-loop/SKILL.md
@@ -4,7 +4,7 @@ args: "[test-pattern] [--max-cycles <N>]"
 argument-hint: "Test pattern to focus on, --max-cycles to limit iterations"
 allowed-tools: Read, Edit, Bash
 created: 2025-12-16
-modified: 2026-05-09
+modified: 2026-06-21
 reviewed: 2026-04-25
 name: project-test-loop
 ---
@@ -173,6 +173,13 @@ Stop and report if:
 - Error in test command itself (TEST SETUP ISSUE)
 - External dependency unavailable (BLOCKED)
 - Unclear how to fix (NEEDS USER INPUT)
+
+**Loop integrity**: this loop's stop condition is the test suite itself — an
+*independent*, mechanical judge (a failing test does not care how hard you
+worked), which is exactly what `.claude/rules/loop-integrity.md` Pillar 1 asks
+for. The `--max-cycles` flag and the "same test fails 3×" rule are the runaway
+ceiling. Do **not** make tests pass by editing the tests — that converts the
+independent judge into a self-judged loop.
 
 **Integration with Blueprint Development**:
 

--- a/scripts/check-loop-integrity.sh
+++ b/scripts/check-loop-integrity.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# check-loop-integrity.sh — semantic guard for the loop-integrity convention.
+#
+# THE CONVENTION (.claude/rules/loop-integrity.md)
+# Long-running / self-continuing loops carry two invariants:
+#   Pillar 1 — the stop condition is judged INDEPENDENTLY (a fresh verifier, not
+#              the worker, decides "done"; else the loop optimises for completion
+#              over correctness).
+#   Pillar 2 — each iteration leaves a COMPACT STATE PACKET (objective, ref,
+#              files-in-scope, exit condition, verifier result, changed-since)
+#              so a context-free successor can re-enter cleanly.
+#
+# WHY A SEMANTIC GUARD
+# These invariants live as prose + a plan-file schema across four files. A
+# bulk-edit agent "tightening" the checkpoint skill could silently drop the
+# Verifier-result field or the independent-verifier step, reverting the skill to
+# a self-judged loop with a passing YAML parse. A syntactic check would miss it.
+# This guard asserts the load-bearing tokens survive (regression-testing.md:
+# semantic > syntactic).
+#
+# Output: structured KEY=VALUE per .claude/rules/structured-script-output.md.
+#   --strict  exit 1 when ISSUE_COUNT > 0 (for pre-commit / CI). Default: report.
+
+set -uo pipefail
+
+STRICT=0
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+for arg in "$@"; do
+    case "$arg" in
+        --strict) STRICT=1 ;;
+        *) [ -d "$arg" ] && ROOT_DIR="$arg" ;;
+    esac
+done
+
+RULE="$ROOT_DIR/.claude/rules/loop-integrity.md"
+CHECKPOINT="$ROOT_DIR/workflow-orchestration-plugin/skills/workflow-checkpoint-refactor/SKILL.md"
+TEST_LOOP="$ROOT_DIR/project-plugin/skills/project-test-loop/SKILL.md"
+ADVERSARIAL="$ROOT_DIR/agent-patterns-plugin/skills/adversarial-review/SKILL.md"
+
+issue_count=0
+declare -a issues=()
+
+# require FILE TOKEN MESSAGE — assert a literal token is present (file must exist).
+require() {
+    local file="$1" token="$2" msg="$3" rel
+    rel="${file#"$ROOT_DIR"/}"
+    if [ ! -f "$file" ]; then
+        issue_count=$((issue_count + 1))
+        issues+=("  - SEVERITY=ERROR FILE=$rel MSG=missing file ($msg)")
+        return
+    fi
+    if ! grep -qF "$token" "$file"; then
+        issue_count=$((issue_count + 1))
+        issues+=("  - SEVERITY=ERROR FILE=$rel TOKEN=\"$token\" MSG=$msg")
+    fi
+}
+
+# Rule file — both pillars must remain articulated.
+require "$RULE" "independently" "Pillar 1 (independent stop condition) dropped from the rule"
+require "$RULE" "compact state packet" "Pillar 2 (state packet) dropped from the rule"
+require "$RULE" "Verifier result" "state-packet field list dropped from the rule"
+
+# Checkpoint skill — the plan file IS the state packet; gate stays independent.
+require "$CHECKPOINT" "Verifier result" "checkpoint plan format lost the Verifier-result field (reverts to self-judged done)"
+require "$CHECKPOINT" "Changed since last run" "checkpoint plan format lost the changed-since field (resume redoes/undoes work)"
+require "$CHECKPOINT" "Exit condition" "checkpoint plan format lost the top-level exit condition"
+require "$CHECKPOINT" "independent verifier" "checkpoint phase gate lost the independent-verifier step"
+require "$CHECKPOINT" "loop-integrity.md" "checkpoint skill lost its loop-integrity cross-reference"
+
+# Sibling skills — keep the cross-reference so the convention stays discoverable.
+require "$TEST_LOOP" "loop-integrity.md" "project-test-loop lost its loop-integrity cross-reference"
+require "$ADVERSARIAL" "loop-integrity.md" "adversarial-review lost its loop-integrity (Pillar 1) cross-reference"
+
+status="OK"
+[ "$issue_count" -gt 0 ] && status="ERROR"
+
+echo "=== LOOP INTEGRITY ==="
+echo "RULE_PRESENT=$([ -f "$RULE" ] && echo true || echo false)"
+echo "STATUS=$status"
+echo "ISSUE_COUNT=$issue_count"
+if [ "$issue_count" -gt 0 ]; then
+    echo "ISSUES:"
+    printf '%s\n' "${issues[@]}"
+    echo ""
+    echo "FIX: restore the missing token; see .claude/rules/loop-integrity.md"
+fi
+echo "=== END LOOP INTEGRITY ==="
+
+if [ "$STRICT" -eq 1 ] && [ "$issue_count" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/scripts/tests/test-check-loop-integrity.sh
+++ b/scripts/tests/test-check-loop-integrity.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Regression tests for scripts/check-loop-integrity.sh (loop-integrity convention).
+#
+# Run: bash scripts/tests/test-check-loop-integrity.sh
+# Exit 0 = all tests pass, Exit 1 = failures
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GUARD="$SCRIPT_DIR/check-loop-integrity.sh"
+PASS=0
+FAIL=0
+
+WORK=$(mktemp -d) || { echo "mktemp -d failed" >&2; exit 1; }
+[ -n "$WORK" ] && [ -d "$WORK" ] || { echo "bad sandbox dir" >&2; exit 1; }
+trap 'rm -rf "$WORK"' EXIT
+
+# Build a fixture root with all four files carrying the required tokens.
+seed_clean() {
+  local root="$1"
+  mkdir -p "$root/.claude/rules"
+  mkdir -p "$root/workflow-orchestration-plugin/skills/workflow-checkpoint-refactor"
+  mkdir -p "$root/project-plugin/skills/project-test-loop"
+  mkdir -p "$root/agent-patterns-plugin/skills/adversarial-review"
+
+  cat > "$root/.claude/rules/loop-integrity.md" <<'EOF'
+The stop condition is judged independently.
+Every iteration leaves a compact state packet.
+Fields: Verifier result, Changed since last run.
+EOF
+
+  cat > "$root/workflow-orchestration-plugin/skills/workflow-checkpoint-refactor/SKILL.md" <<'EOF'
+Exit condition: all phases done.
+- Verifier result: PASS
+- Changed since last run: nothing
+gate done on an independent verifier.
+See .claude/rules/loop-integrity.md
+EOF
+
+  cat > "$root/project-plugin/skills/project-test-loop/SKILL.md" <<'EOF'
+See .claude/rules/loop-integrity.md
+EOF
+
+  cat > "$root/agent-patterns-plugin/skills/adversarial-review/SKILL.md" <<'EOF'
+See .claude/rules/loop-integrity.md
+EOF
+}
+
+run_count() {
+  bash "$GUARD" "$1" 2>&1 | grep -E '^ISSUE_COUNT=' | cut -d= -f2
+}
+
+assert_count() {
+  local desc="$1" expected="$2" dir="$3" got
+  got=$(run_count "$dir")
+  if [ "$got" = "$expected" ]; then
+    printf "  PASS: %s\n" "$desc"; PASS=$((PASS + 1))
+  else
+    printf "  FAIL: %s (expected ISSUE_COUNT=%s, got %s)\n" "$desc" "$expected" "$got"; FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== check-loop-integrity regression tests ==="
+
+# 1. Fully-populated fixture → no issues.
+clean="$WORK/clean"; seed_clean "$clean"
+assert_count "clean fixture (all tokens present)" 0 "$clean"
+
+# 2. Checkpoint skill loses the Verifier-result field → flagged (self-judged revert).
+no_verifier="$WORK/no_verifier"; seed_clean "$no_verifier"
+ck="$no_verifier/workflow-orchestration-plugin/skills/workflow-checkpoint-refactor/SKILL.md"
+# Strip the Verifier-result line.
+grep -v 'Verifier result' "$ck" > "$ck.tmp" && mv "$ck.tmp" "$ck"
+assert_count "checkpoint missing Verifier-result is flagged" 1 "$no_verifier"
+
+# 3. Rule file loses Pillar 1 (independent stop condition) → flagged.
+no_pillar1="$WORK/no_pillar1"; seed_clean "$no_pillar1"
+rule="$no_pillar1/.claude/rules/loop-integrity.md"
+grep -v 'independently' "$rule" > "$rule.tmp" && mv "$rule.tmp" "$rule"
+assert_count "rule missing Pillar 1 is flagged" 1 "$no_pillar1"
+
+# 4. Sibling skill loses its cross-reference → flagged.
+no_xref="$WORK/no_xref"; seed_clean "$no_xref"
+tl="$no_xref/project-plugin/skills/project-test-loop/SKILL.md"
+: > "$tl"   # empty out the cross-reference
+assert_count "test-loop missing cross-reference is flagged" 1 "$no_xref"
+
+# 5. --strict exits non-zero on issues, zero when clean.
+if bash "$GUARD" --strict "$clean" >/dev/null 2>&1; then
+  printf "  PASS: --strict exits 0 on clean fixture\n"; PASS=$((PASS + 1))
+else
+  printf "  FAIL: --strict should exit 0 on clean fixture\n"; FAIL=$((FAIL + 1))
+fi
+if bash "$GUARD" --strict "$no_pillar1" >/dev/null 2>&1; then
+  printf "  FAIL: --strict should exit 1 when issues found\n"; FAIL=$((FAIL + 1))
+else
+  printf "  PASS: --strict exits 1 when issues found\n"; PASS=$((PASS + 1))
+fi
+
+echo ""
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/workflow-orchestration-plugin/skills/workflow-checkpoint-refactor/SKILL.md
+++ b/workflow-orchestration-plugin/skills/workflow-checkpoint-refactor/SKILL.md
@@ -5,7 +5,7 @@ args: "[--init|--continue|--status|--phase=N]"
 allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(npm run *), Bash(npx *), Bash(uv run *), Bash(cargo *), Read, Write, Edit, Grep, Glob, Task, TodoWrite
 argument-hint: "--init to create plan, --continue to resume, --status to check progress"
 created: 2026-02-08
-modified: 2026-05-09
+modified: 2026-06-21
 reviewed: 2026-02-14
 ---
 
@@ -39,7 +39,12 @@ Multi-phase refactoring with persistent state that survives context limits and s
 
 ## Plan File Format
 
-The plan file (`REFACTOR_PLAN.md`) serves as persistent state:
+The plan file (`REFACTOR_PLAN.md`) serves as persistent state. It is the loop's
+**compact state packet** (`.claude/rules/loop-integrity.md`): a fresh session,
+or a sub-agent with no memory of prior phases, must be able to re-enter from this
+file alone. Every phase therefore carries not just *what to do* but *what was
+verified* and *what changed* — without those, resuming across a context limit
+silently redoes or undoes work.
 
 ```markdown
 # Refactor Plan: {description}
@@ -47,6 +52,7 @@ The plan file (`REFACTOR_PLAN.md`) serves as persistent state:
 Created: {date}
 Last updated: {date}
 Base commit: {hash}
+Exit condition: {the literal criterion that ends the whole refactor — e.g. "all phases done, full suite + tsc green on base"}
 
 ## Overview
 {What is being refactored and why}
@@ -55,7 +61,9 @@ Base commit: {hash}
 - **Status**: done | in-progress | pending | needs-review
 - **Files**: file1.ts, file2.ts, file3.ts
 - **Description**: {what this phase does}
-- **Acceptance criteria**: {how to verify success}
+- **Acceptance criteria**: {how to verify success — the phase's exit condition}
+- **Verifier result**: {what the independent check returned — PASS/FAIL + the criterion it judged; filled in at the phase boundary}
+- **Changed since last run**: {what this phase actually touched, so a successor doesn't redo or undo it}
 - **Result**: {summary of changes made, filled in after completion}
 
 ## Phase 2: {phase name}
@@ -63,6 +71,8 @@ Base commit: {hash}
 - **Files**: file4.ts, file5.ts
 - **Description**: {what this phase does}
 - **Acceptance criteria**: {how to verify success}
+- **Verifier result**: {empty until verified}
+- **Changed since last run**: {empty until completed}
 - **Result**: {empty until completed}
 
 ...
@@ -116,10 +126,23 @@ For each phase:
    - Fix errors if straightforward
    - If complex, mark phase as `needs-review` with error details
    - Commit partial work with `WIP:` prefix
-6. If validation passes:
-   - Update plan file: set status to `done`, write result summary
-   - Commit: `git add -u && git commit -m "refactor phase N: {description}"`
-7. If more phases remain, proceed to next phase or suggest `--continue`
+6. If validation passes, **gate `done` on an independent verifier** when the
+   acceptance criteria are a judgement (e.g. "the class is now single-purpose"),
+   not a purely mechanical check (a green suite / clean `tsc` is already
+   independent — a failing test does not care how hard you worked):
+   - Dispatch a fresh `Task` sub-agent that reads **only** this phase's
+     acceptance criteria and the resulting diff — not the worker's reasoning —
+     and judges whether the criteria are met. The worker is biased toward
+     declaring completion; the loop's stop condition must come from outside it
+     (`.claude/rules/loop-integrity.md`, Pillar 1).
+   - Record the verdict in the phase's **Verifier result** field (PASS/FAIL +
+     the criterion judged).
+   - If the verifier returns FAIL, leave status `in-progress`/`needs-review`
+     and address the gap before marking `done`.
+7. Once verified, update the plan file: set status to `done`, fill **Verifier
+   result**, **Changed since last run**, and **Result**, then commit:
+   `git add -u && git commit -m "refactor phase N: {description}"`
+8. If more phases remain, proceed to next phase or suggest `--continue`
 
 ### Step 5: Sub-agent delegation (for large phases)
 
@@ -165,3 +188,5 @@ For phases with 7+ files, delegate to Task sub-agent with:
 
 - [code-review-checklist](../../../code-quality-plugin/skills/code-review-checklist/SKILL.md) - Review refactored code
 - [refactoring-patterns](../../../code-quality-plugin/skills/refactoring-patterns/SKILL.md) - Refactoring techniques
+- [adversarial-review](../../../agent-patterns-plugin/skills/adversarial-review/SKILL.md) - The isolated verifier a judgement-based phase gate delegates to
+- `.claude/rules/loop-integrity.md` - Why the plan file is a state packet and why `done` is judged independently


### PR DESCRIPTION
## Summary

Adds a **loop-integrity** governance rule and applies it to the repo's self-continuing loops. Distilled from the r/ClaudeCode "Goal and Loop — kinda the same?" discussion: a loop that judges its own "done" optimizes for *completion* over *correctness*, and a loop that mutates its own plan without leaving a resumable packet is *automating context drift*.

### New rule — `.claude/rules/loop-integrity.md`

Two pillars every long-running / self-mutating loop must meet:

| Pillar | Requirement |
|--------|-------------|
| **1 — Independent stop** | The exit criterion is judged by a fresh actor that did **not** do the work (reads only acceptance criteria + artefact). Mechanical checks — a green suite, clean `tsc` — are *already* independent; the bite is on *judgement* criteria. |
| **2 — Compact state packet** | Each iteration leaves `objective / ref / files-in-scope / exit-condition / verifier-result / changed-since` before mutating its plan, so a context-free successor can re-enter. |

Plus a runaway ceiling (`--max-cycles` / "stuck N×"). It distils *why* native `/goal` + `/loop` work rather than reimplementing them.

### Skill upgrades

- **`workflow-checkpoint-refactor`** (feat) — the plan file is now an explicit state packet (top-level `Exit condition`; per-phase `Verifier result` + `Changed since last run`), and a phase whose acceptance criteria are a *judgement* gates `done` on a fresh `Task` sub-agent rather than the worker's self-assessment.
- **`project-test-loop`** (docs) — notes its green-suite stop is already an independent judge (Pillar 1) and warns against editing tests to pass.
- **`adversarial-review`** (docs) — flagged as the isolated verifier a judgement-based stop delegates to.

### Regression guard

`scripts/check-loop-integrity.sh` (+ `scripts/tests/test-check-loop-integrity.sh`, 6 cases) — a **semantic** gate asserting the load-bearing tokens survive bulk edits (the `Verifier result` / `Changed since last run` / `Exit condition` fields, the independent-verifier step, and the cross-references). Wired into `.pre-commit-config.yaml`. Per `regression-testing.md`, this is the convention's semantic backstop.

## Plugin lifecycle

- New rule added to the `CLAUDE.md` Rules table (keeps `check-docs-index.sh` balanced: 36 on disk = 36 in table).
- New regression entry in `regression-testing.md`.

## Verification

- `check-loop-integrity.sh --strict` → `STATUS=OK`, exit 0
- `test-check-loop-integrity.sh` → 6/6 PASS
- `plugin-compliance-check.sh` → exit 0 (checkpoint skill 8.2K chars, well under limit)
- `lint-shell-scripts.sh` → 0 errors
- `check-git-sandbox-guards.sh --strict` → exit 0 (new scripts' `mktemp` guarded)

Commits split along plugin paths so the doc-only cross-references don't leak a version bump into `project-plugin` / `agent-patterns-plugin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEaprELs5XAtFvCXBW9XeE)_