### PR TITLE
docs(agent-development): pin agent rosters via Agent() allowlist, not prose

### DIFF
--- a/.claude/rules/agent-development.md
+++ b/.claude/rules/agent-development.md
@@ -114,6 +114,19 @@ tools: Agent(worker, researcher), Read, Bash
 ```
 
 This is an allowlist — only `worker` and `researcher` can be spawned. To allow any subagent without restriction, use `Agent` without parentheses. If `Agent` is omitted, the agent cannot spawn any subagents.
+
+#### Pin a deliberate roster with the allowlist, not prose
+
+When you have designed a fixed set of domain agents (frontend, database, security, …) and want the orchestrator to delegate **only** to them, encode that intent as the `Agent(name1, name2, …)` allowlist above — not as a prose instruction like "please only use my agents." The allowlist is harness-enforced and non-negotiable; a prose preference is a wish the model can override the moment it decides an ad-hoc agent fits the task better. This is the difference between an **invariant** (a boundary stated as a rule) and a **heuristic** (a suggestion the model weighs): models adhere to the former far more reliably, so the roster you actually depend on belongs in frontmatter.
+
+| You want… | Express it as | Why |
+|-----------|---------------|-----|
+| Delegation pinned to a known roster | `tools: Agent(frontend, database, security)` | Harness-enforced; ad-hoc agents outside the set cannot be spawned |
+| Roster plus a deterministic fan-out | The allowlist **and** an orchestration skill that spawns one declared agent per domain | Removes roster choice from the model entirely (see `agent-patterns-plugin:parallel-agent-dispatch`) |
+| Truly open-ended delegation | `Agent` without parentheses | Intentional — only when no fixed roster exists |
+
+The failure this prevents: an orchestrator that "used to respect my agents" starts inventing its own the moment the roster lives only in prose. If the model is spawning agents you didn't intend, the fix is to move the roster from instruction into the `Agent(...)` allowlist.
+
 > **Note (2.1.116+)**: Agent frontmatter `hooks:` and `mcpServers:` are active when the agent runs as a main-thread session via `claude --agent`, not just as subagents.
 
 ### MCP Servers in Agent Definitions (2.1.147 / 2.1.153)


### PR DESCRIPTION
## What

Adds a subsection to `.claude/rules/agent-development.md` ("Pin a deliberate roster with the allowlist, not prose") under Tool Restrictions, recommending that a fixed agent roster be encoded in the harness-enforced `Agent(name1, name2, …)` allowlist rather than expressed as a prose instruction the model can override.

## Why

Distilled from an [r/ClaudeCode thread](https://www.reddit.com/r/ClaudeCode/comments/1ub478v/orchestrating_agents/) where a user's orchestrator "used to respect my agents" but began spawning ad-hoc ones once the desired roster lived only in prose. The thread's recurring advice — frame the roster as an **invariant** (a stated rule) rather than a **heuristic** (a suggestion the model weighs) — maps directly onto a primitive this repo already ships: the `Agent(...)` frontmatter allowlist.

We already had the *mechanism* (documented at `agent-development.md` Tool Restrictions; used live in `agents-plugin/agents/attribute-router.md`). The gap was that it read as an *optional safety feature* rather than the *recommended default* when you have a deliberate roster. This change closes that gap with a quick-reference table mapping intent → expression and names the failure it prevents.

## Scope

- Single rule-file docs edit (13 insertions). No version bump (`docs` scope, and `agent-development` is not a release-please package).
- No new rule file — the insight validated an existing primitive rather than introducing a new pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dypmx5iU6Xhx4LvSA65XsR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dypmx5iU6Xhx4LvSA65XsR)_