### PR TITLE
feat(session-plugin): surface untracked assigned GitHub issues in spinup

### DIFF
--- a/session-plugin/hooks/session-spinup-nudge.sh
+++ b/session-plugin/hooks/session-spinup-nudge.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # SessionStart hook — offers session-plugin:session-spinup when a fresh
 # session opens with open threads worth surfacing: pending or +ACTIVE
-# taskwarrior tasks for the cwd's project, uncommitted changes, or unpushed
-# commits. Injects context (additionalContext) instead of blocking — a
-# SessionStart nudge should inform, not force a turn.
+# taskwarrior tasks for the cwd's project, uncommitted changes, unpushed
+# commits, or open GitHub issues assigned to the user in the cwd repo.
+# Injects context (additionalContext) instead of blocking — a SessionStart
+# nudge should inform, not force a turn.
 #
 # Fires only on source=startup|resume (silent on clear/compact — those are
 # mid-session continuations), at most once per session_id.
@@ -52,6 +53,21 @@ if command -v "$task_bin" >/dev/null 2>&1; then
         | jq 'length' 2>/dev/null || echo 0)
     if [ "${open_count:-0}" -gt 0 ] 2>/dev/null; then
         threads="${threads}${open_count} open taskwarrior task(s) under project:${project}; "
+    fi
+fi
+
+# GitHub issues: open issues assigned to the user in the cwd repo. Gated on a
+# fast `gh auth status` so an unauthenticated machine pays no network cost.
+# Coarse count only — the skill does precise dedup against taskwarrior, but a
+# tracked issue already trips the taskwarrior signal above, so over-counting
+# here at worst restates an existing reason, never invents a false one.
+# SESSION_NUDGE_GH_BIN is a test seam — see test-session-spinup-nudge.sh.
+gh_bin="${SESSION_NUDGE_GH_BIN:-gh}"
+if command -v "$gh_bin" >/dev/null 2>&1 && "$gh_bin" auth status >/dev/null 2>&1; then
+    issue_count=$( (cd "$cwd" && "$gh_bin" issue list --assignee @me --state open \
+        --json number --jq 'length' 2>/dev/null) || echo 0)
+    if [ "${issue_count:-0}" -gt 0 ] 2>/dev/null; then
+        threads="${threads}${issue_count} assigned GitHub issue(s); "
     fi
 fi
 

--- a/session-plugin/hooks/test-session-spinup-nudge.sh
+++ b/session-plugin/hooks/test-session-spinup-nudge.sh
@@ -27,12 +27,27 @@ done
 echo "wip" > "$REPO_DIRTY/wip.txt"
 
 run_hook_output() {
-    local session_id="$1" cwd="$2" source_kind="$3"
+    local session_id="$1" cwd="$2" source_kind="$3" gh_bin="${4:-/nonexistent/gh}"
     jq -nc --arg sid "$session_id" --arg cwd "$cwd" --arg src "$source_kind" \
         '{session_id: $sid, cwd: $cwd, source: $src}' \
         | HOME="$TEST_HOME" SESSION_NUDGE_TASK_BIN=/nonexistent/task \
+          SESSION_NUDGE_GH_BIN="$gh_bin" \
           bash "$HOOK" 2>/dev/null || true
 }
+
+# Stub gh: `auth status` succeeds; `issue list` reports a fixed count via the
+# GH_STUB_ISSUE_COUNT env var (0 = none, so the issue signal stays silent).
+GH_STUB_DIR=$(mktemp -d) || { echo "mktemp -d failed" >&2; exit 1; }
+trap 'rm -rf "$TEST_HOME" "$REPO_CLEAN" "$REPO_DIRTY" "$GH_STUB_DIR"' EXIT
+cat > "$GH_STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+    auth) exit 0 ;;
+    issue) echo "${GH_STUB_ISSUE_COUNT:-0}" ;;
+    *) exit 1 ;;
+esac
+STUB
+chmod +x "$GH_STUB_DIR/gh"
 
 assert_contains() {
     local desc="$1" pattern="$2" actual="$3"
@@ -77,6 +92,24 @@ if echo "$output" | grep -q '"decision"'; then
 else
     printf "  PASS: spinup nudge does not block\n"; PASS=$((PASS + 1))
 fi
+
+echo ""
+echo "GitHub issues signal (gh-auth-gated):"
+export GH_STUB_ISSUE_COUNT=0
+output=$(run_hook_output "sp-gh-zero" "$REPO_CLEAN" "startup" "$GH_STUB_DIR/gh")
+assert_silent "clean repo + zero assigned issues stays silent" "$output"
+export GH_STUB_ISSUE_COUNT=2
+output=$(run_hook_output "sp-gh-two" "$REPO_CLEAN" "startup" "$GH_STUB_DIR/gh")
+assert_contains "assigned issues emit additionalContext" 'additionalContext' "$output"
+assert_contains "context mentions assigned GitHub issue(s)" 'assigned GitHub issue' "$output"
+assert_contains "issue-only nudge still references the skill" 'session-plugin:session-spinup' "$output"
+unset GH_STUB_ISSUE_COUNT
+
+echo ""
+echo "unauthenticated gh adds no thread (gate holds):"
+# /nonexistent/gh fails `command -v`, so the issue block is skipped entirely.
+output=$(run_hook_output "sp-gh-noauth" "$REPO_CLEAN" "startup" "/nonexistent/gh")
+assert_silent "clean repo + no gh binary stays silent" "$output"
 
 echo ""
 echo "once-per-session marker:"

--- a/session-plugin/skills/session-spinup/REFERENCE.md
+++ b/session-plugin/skills/session-spinup/REFERENCE.md
@@ -22,6 +22,37 @@ If multiple projects are detectable (monorepo, multi-package), survey
 each in its own section. If the cwd maps to no known project, list
 options with `task _projects` and ask once.
 
+## GitHub issue dedup against taskwarrior
+
+Surface an assigned open issue only when no surveyed task already tracks
+it. Build the set of already-tracked issue numbers from the tasks, then
+filter the `gh issue list` output:
+
+```sh
+# Issue numbers already represented in taskwarrior: the ghid UDA, plus any
+# #N or .../issues/N reference in a description or annotation.
+tracked=$(task project:<name> '(status:pending or +ACTIVE)' export | jq -r '
+    .[] | (.ghid // empty),
+          (.description, (.annotations[]?.description // "")
+           | scan("(?:#|issues/)([0-9]+)") | .[0])
+' | sort -u)
+
+# Assigned, open, in the cwd repo, minus the tracked set.
+gh issue list --assignee @me --state open \
+    --json number,title,url,updatedAt --jq '.[]' \
+| jq -c --argjson tracked "$(printf '%s\n' $tracked | jq -R . | jq -s 'map(tonumber)')" '
+    select(.number as $n | ($tracked | index($n)) | not)'
+```
+
+A simpler inline alternative when the task set is small: read the issue
+numbers from the surveyed tasks by eye and skip any `gh issue list` row
+whose `number` appears among them. The point is the same — show the task,
+not a duplicate issue line.
+
+When the cwd has no GitHub remote (`gh repo view` fails), skip the issue
+source entirely; it is the only source scoped to a GitHub repo rather than
+a taskwarrior project.
+
 ## Journal todo extraction
 
 Walk back from today (first existing note wins), extract unchecked
@@ -58,6 +89,9 @@ Spin-up — project: work.cost-attribution (cwd: repos/<org>/infrastructure)
     pending  #240 "Confirm Hetzner db01-03 shutdown date with Aapo (#838)"
     pending  #243 "OpenCost re-evaluation date (ADR-0029 deferred)"
 
+  github issues (1 assigned, untracked)
+    #851 "OpenCost pods OOMKilled on >2k namespaces" — filed 2d ago, no task
+
   journal 2026-05-12.md (yesterday)
     - [ ] Nudge production GKE Standard PR #1607 reviewers (stale 7d)
 
@@ -66,6 +100,7 @@ Spin-up — project: work.cost-attribution (cwd: repos/<org>/infrastructure)
 
 Next moves:
   • Resume #237 — check PR #1774 review state
+  • Triage assigned issue #851 (filed since last session, not yet tracked)
   • Tackle yesterday's todo: nudge PR #1607 reviewers
   • Confirm Hetzner shutdown date (#240)
 
@@ -76,6 +111,9 @@ Stale +ACTIVE elsewhere: task #5 in bluepad32.own is still +ACTIVE — release w
 
 - **No journal note in the last 7 days** — silently skip that source;
   still show taskwarrior + git state.
+- **No GitHub remote, or every assigned issue is already tracked** — skip
+  the GitHub-issues section silently; it earns a line only when there is a
+  genuinely untracked assigned issue.
 - **No tasks for the project** — say `nothing pending under
   project:<name>` explicitly rather than an empty-looking section.
 - **Clean tree, no PRs** — one line: `git state: clean`.

--- a/session-plugin/skills/session-spinup/SKILL.md
+++ b/session-plugin/skills/session-spinup/SKILL.md
@@ -3,8 +3,8 @@ name: session-spinup
 description: Read-only session-start briefing of open tasks, git state, journal todos. Use when user says spin up, what was I doing, or pick up where I left off.
 allowed-tools: Bash(task *), Bash(git *), Bash(gh *), Read, TodoWrite
 created: 2026-05-13
-modified: 2026-06-10
-reviewed: 2026-06-10
+modified: 2026-06-22
+reviewed: 2026-06-22
 ---
 
 # session-spinup
@@ -36,8 +36,13 @@ Schema: [session-wrap/REFERENCE.md](../session-wrap/REFERENCE.md).
 | Source | When | What comes from there |
 |---|---|---|
 | **taskwarrior** | Every spin-up | Pending tasks for the inferred project; `+ACTIVE` tasks; recently-annotated tasks |
+| **GitHub issues** | Every spin-up with a GitHub remote | Open issues assigned to you in the **cwd repo** that no surveyed task already references — the issues opened on GitHub but never mirrored into taskwarrior |
 | **Journal** | Only when configured + in scope | Unchecked `- [ ]` items under the todo heading, most recent note ≤7 days back |
 | **git state** | Every spin-up | Current branch, uncommitted changes, unpushed commits, open PRs from this branch |
+
+GitHub issues close a drift gap: opening an issue does **not** create a
+taskwarrior task, so without this source a freshly-filed assigned issue is
+invisible to spinup and the "pending work" picture is silently wrong.
 
 ## The signal filter
 
@@ -47,13 +52,18 @@ as wrap; 10+ means trim.
 **SURFACE**: open PR from a recent branch (especially review/CI-stale) ·
 `+ACTIVE` task (work was mid-flight) · unchecked journal todo ·
 real uncommitted edits · unpushed commits · task annotated "blocked on X"
-where X may now be unblocked.
+where X may now be unblocked · **open assigned GitHub issue with no
+matching taskwarrior task** (the drift case — filed on GitHub, never
+mirrored locally).
 
-**DO NOT SURFACE**: completed tasks · merged PRs · recurring-reminder /
-dataview machinery in the journal · weeks-stale tasks with no recent
-annotation (that's `task-status`'s job) · `+ACTIVE` tasks from a
-*different* project than the cwd — those are stale locks; at most one
-footnote line ("Stale +ACTIVE elsewhere" at the end of the briefing), never a scope hijack.
+**DO NOT SURFACE**: completed tasks · merged PRs · closed issues ·
+issues assigned to someone else · **a GitHub issue already represented
+by a surfaced taskwarrior task** (dedup by issue number — show the task,
+not the issue) · recurring-reminder / dataview machinery in the journal ·
+weeks-stale tasks with no recent annotation (that's `task-status`'s job) ·
+`+ACTIVE` tasks from a *different* project than the cwd — those are stale
+locks; at most one footnote line ("Stale +ACTIVE elsewhere" at the end of
+the briefing), never a scope hijack.
 
 ## Execution
 
@@ -76,7 +86,18 @@ task project:<name> '(status:pending or +ACTIVE)' export | jq '.[]'
 git status --porcelain
 git log '@{u}..HEAD' --oneline
 gh pr list --head "$(git branch --show-current)" --json number,title,url,state,createdAt --jq '.[]'
+gh issue list --assignee @me --state open --json number,title,url,updatedAt --jq '.[]'
 ```
+
+`gh issue list` with no `-R` targets the cwd repo and `--json` returns
+`[]` (exit 0) on no matches, keeping the batch parallel-safe. Skip it when
+the cwd maps to no GitHub remote.
+
+**Dedup before surfacing issues.** Collect every issue number the surveyed
+tasks already reference (a `ghid` UDA, or a `#N` / `issues/N` token in any
+description or annotation) and drop those from the `gh issue list` result.
+What remains is the drift set — assigned, open, and untracked locally.
+Dedup snippet in [REFERENCE.md](REFERENCE.md).
 
 Journal source (only when configured + in scope): walk back from today
 up to 7 days, first existing note wins, extract unchecked todos —
@@ -112,4 +133,5 @@ runs the skill. Pre-silence:
 | Open + in-flight tasks (exit-0 on empty) | `task project:<name> '(status:pending or +ACTIVE)' export \| jq '.[]'` |
 | Unpushed commits | `git log '@{u}..HEAD' --oneline` |
 | Branch PRs | `gh pr list --head <branch> --json number,title,url,state --jq '.[]'` |
+| Assigned open issues (cwd repo, exit-0 on empty) | `gh issue list --assignee @me --state open --json number,title,url,updatedAt --jq '.[]'` |
 | Known projects | `task _projects` |


### PR DESCRIPTION
## What

`session-spinup` now surfaces **open GitHub issues assigned to you in the cwd repo** that no taskwarrior task already references — and the SessionStart nudge detects them too.

## Why

Opening a GitHub issue does not create a taskwarrior task. Spinup previously saw assigned issues only when they were manually mirrored locally, so freshly-filed issues were invisible and the pending-work picture silently drifted.

## How

- **Survey** adds `gh issue list --assignee @me --state open` scoped to the cwd repo (`--json` → exit-0 on empty, parallel-safe).
- **Dedup by issue number** against surveyed tasks (`ghid` UDA or `#N` / `issues/N` refs) so a mirrored issue shows once, as the task — not twice. Snippet + worked example in `REFERENCE.md`.
- **SessionStart nudge** gains a `gh auth status`-gated assigned-issue count, so an issue-only session (clean tree, no tasks) still gets nudged. Unauthenticated machines pay no network cost. `SESSION_NUDGE_GH_BIN` test seam mirrors the existing `SESSION_NUDGE_TASK_BIN`.

## Tests

5 new nudge-hook regression tests (zero-issue silence, issue-only fire, skill reference, gate-holds-when-gh-absent). **13/13 pass.** Compliance ✅, shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)