### PR TITLE
fix(hooks-plugin): defer safety gating to auto mode, drop prompt classifier

### DIFF
--- a/hooks-plugin/.claude-plugin/plugin.json
+++ b/hooks-plugin/.claude-plugin/plugin.json
@@ -177,18 +177,6 @@
         ]
       }
     ],
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "You are classifying a USER prompt for safety before Claude processes it. Context: $ARGUMENTS\n\nCRITICAL: The input is ALWAYS a message from the HUMAN USER, never from the AI agent. You are evaluating what the user typed. Do NOT confuse the user's message with something the AI assistant would say. Questions, feedback, and conversational messages from the user are ALWAYS safe — your job is only to catch explicitly dangerous operations.\n\nFIRST CHECK — Explicit confirmations: If the user is explicitly confirming, overriding, or reaffirming a previous safety warning (e.g., 'I confirm I want to push to main', 'override the protection', 'yes, push to main', 'intend to push to main', 'go ahead and push to main'), this is an informed confirmation — respond with {\"ok\": true} immediately. Do NOT re-block a confirmation.\n\nSECOND CHECK — Questions and feedback: If the user is asking a question, giving feedback, discussing plans, or making conversational remarks (e.g., 'does the plan look ready?', 'what do you think?', 'looks good', 'can you explain this?'), respond with {\"ok\": true} immediately. User questions and feedback are always safe.\n\nOtherwise, check if the prompt EXPLICITLY requests one of these specific dangerous actions:\n1. Destructive filesystem: explicitly delete directories, rm -rf, permanently overwrite important files\n2. Destructive git: explicitly force push (--force or -f), reset --hard discarding commits, delete branches with unsaved work\n3. Push to protected branch: explicitly push directly to 'main' or 'master' branch (not feature branches)\n4. Production system operations: explicitly deploy to production, drop/truncate database tables, restart production services\n\nIMPORTANT: The vast majority of prompts are safe. Apply strict criteria — only flag when the dangerous action is unambiguous and explicitly stated:\n- 'commit and push' → SAFE (standard development workflow, not targeting a protected branch)\n- 'push my changes' or 'push to origin' → SAFE (no protected branch specified)\n- 'push to main' or 'push to master' → UNSAFE (explicitly targeting protected branch)\n- 'force push' → UNSAFE (explicitly destructive)\n- 'reset --hard' → UNSAFE (explicitly discards work)\n- 'merge to main' or 'merge branch into main' → SAFE (local merge is reversible, standard feature-branch workflow)\n- 'branch then merge to main' → SAFE (standard feature-branch workflow)\n- 'does the plan look ready?' → SAFE (user asking a question)\n- 'should I proceed?' → SAFE (user asking a question)\n- 'fix this bug', 'add feature', 'refactor', 'run tests', 'create a PR' → SAFE\n\nNote: Local git merge operations are safe and reversible. Only flag push/force-push to protected branches, not local merges.\n\nRespond with {\"ok\": true} for safe prompts. Respond with {\"ok\": false, \"reason\": \"Potentially dangerous operation detected: [specific action]. To proceed, please re-submit your request and explicitly confirm you intend to [restate the dangerous action].\"} only for clearly dangerous prompts.",
-            "timeout": 15,
-            "statusMessage": "Classifying prompt..."
-          }
-        ]
-      }
-    ],
     "SessionEnd": [
       {
         "matcher": "",

--- a/hooks-plugin/README.md
+++ b/hooks-plugin/README.md
@@ -91,6 +91,8 @@ A PreToolUse hook that blocks access to sensitive files and prevents credential 
 
 A PreToolUse hook that blocks write operations on protected branches (main, master).
 
+**Defers to auto mode.** Under permission mode `"auto"`, Claude Code routes the actual tool call through its own classifier with full environment context, which already covers force-push and protected-branch pushes. This hook would only double-gate that (and re-introduce blunt false positives), so it exits early when `permission_mode == "auto"`. It still enforces in `default`/`plan`/`acceptEdits` and — crucially — in web/remote/CI and non-Opus sessions where auto mode is unavailable.
+
 | Operation | Behavior |
 |-----------|----------|
 | Read-only git (status, diff, log, show) | Allowed |
@@ -223,16 +225,6 @@ A `type: "agent"` hook that verifies task implementation quality when a team tas
 | Type | `agent` (multi-turn with tool access) |
 | Timeout | 60s |
 | Checks | TODO/FIXME comments, debug artifacts, test presence |
-
-### UserPromptSubmit — Prompt Safety Classification (prompt)
-
-A `type: "prompt"` hook that classifies user prompts for safety before Claude processes them. Flags destructive operations (force push, rm -rf, production deployments).
-
-| Aspect | Detail |
-|--------|--------|
-| Type | `prompt` (single-turn LLM call) |
-| Timeout | 15s |
-| Scope | Only flags explicitly destructive requests |
 
 ## Installation
 

--- a/hooks-plugin/hooks/branch-protection.sh
+++ b/hooks-plugin/hooks/branch-protection.sh
@@ -7,6 +7,9 @@
 #     per .claude/rules/handling-blocked-hooks.md.
 #   - Destructive operations (reset, rebase): prompts user to approve via "ask"
 #   - Read-only operations: always allowed silently
+#   - Under permission mode "auto": defers entirely to auto mode's classifier
+#     (exits early) to avoid double-gating; still enforces in every other mode
+#     and in surfaces where auto mode is unavailable (web/remote/CI, non-Opus).
 #
 # Toggle: a human operator can export CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1
 # in their shell environment (e.g. in a personal repo / dotfiles / main-branch-
@@ -39,6 +42,17 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 # so the branch lookup must run here, not in the hook's own process cwd, or a
 # correctly-branched worktree gets misread as `main`. See #1695.
 HOOK_CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+
+# Defer to auto mode. Under permission mode "auto", Claude Code routes the
+# actual tool call through its own classifier with full environment context
+# (CLAUDE.md, trusted-repo config, force-push / protected-branch soft_deny).
+# This deterministic guard would only double-gate that and re-introduce the
+# blunt false positives auto mode avoids. So enforce ONLY outside auto mode —
+# which still covers default/plan/acceptEdits and, crucially, web/remote/CI and
+# non-Opus sessions where auto mode is unavailable. permission_mode is a common
+# hook input field; absent (older clients) it's empty and enforcement proceeds.
+PERMISSION_MODE=$(echo "$INPUT" | jq -r '.permission_mode // empty')
+[ "$PERMISSION_MODE" = "auto" ] && exit 0
 
 # Only applies to Bash tool
 [ "$TOOL_NAME" != "Bash" ] && exit 0

--- a/hooks-plugin/hooks/test-branch-protection.sh
+++ b/hooks-plugin/hooks/test-branch-protection.sh
@@ -381,6 +381,44 @@ assert_allow \
   "git log on main is allowed" \
   "git log --oneline"
 
+# ── auto mode: the hook defers to auto mode's own classifier ────────────────
+echo ""
+echo "auto mode defers to the classifier (no double-gating):"
+
+# run_hook_mode <command-string> <permission_mode> — like run_hook but stamps
+# the permission_mode field that real clients send.
+run_hook_mode() {
+  local cmd_str="$1" mode_val="$2"
+  local input
+  input=$(jq -nc --arg cmd "$cmd_str" --arg cwd "$TEST_REPO" --arg mode "$mode_val" \
+    '{tool_name:"Bash",cwd:$cwd,permission_mode:$mode,tool_input:{command:$cmd}}')
+  ( cd "$TEST_REPO"; printf '%s' "$input" | bash "$HOOK" )
+}
+
+# A bare `git commit` on main is denied in default mode but must be silently
+# allowed under permission_mode "auto" — auto mode's classifier owns the call.
+out=$(run_hook_mode "git commit -m 'feat: x'" "auto")
+if [ -z "$out" ]; then
+  printf "  PASS: %s\n" "git commit on main is allowed under permission_mode=auto"
+  PASS=$((PASS + 1))
+else
+  printf "  FAIL: %s\n        expected silent allow, got: %s\n" \
+    "git commit on main under auto" "$out"
+  FAIL=$((FAIL + 1))
+fi
+
+# The same command in default mode (explicit) must still be denied — the gate
+# is auto-specific, not a blanket disable.
+out=$(run_hook_mode "git commit -m 'feat: x'" "default")
+if echo "$out" | grep -q '"permissionDecision":"deny"'; then
+  printf "  PASS: %s\n" "git commit on main is still denied under permission_mode=default"
+  PASS=$((PASS + 1))
+else
+  printf "  FAIL: %s\n        expected deny, got: %s\n" \
+    "git commit on main under default" "${out:-<empty>}"
+  FAIL=$((FAIL + 1))
+fi
+
 # ── Summary ─────────────────────────────────────────────────────────────────
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## What

Two `hooks-plugin` blocking hooks duplicated work that Claude Code **auto mode** now does — and did it more bluntly, with no execution context:

1. **Removed the `UserPromptSubmit` prompt classifier.** It was a `type:"prompt"` LLM call on *every* prompt, judging raw prompt text. With auto mode as the default permission mode, the real tool call is already classified with full environment context (CLAUDE.md, trusted repos, force-push/protected-branch `soft_deny`). The text-only classifier added per-prompt cost/latency and false-positived on benign slash commands.
2. **Gated `branch-protection.sh` on `permission_mode == "auto"`** — it exits early under auto mode (no double-gating) but still enforces in `default`/`plan`/`acceptEdits` and in web/remote/CI and non-Opus sessions where auto mode is unavailable.

## Why

The trigger: `/git-conflicts <pr> --push` (a skill that pushes the *PR's* branch, never main) was blocked by the prompt classifier — it pattern-matched the bare token "push" → "push to protected branch" with no idea what the command does or which branch is checked out. Per the [auto-mode docs](https://code.claude.com/docs/en/auto-mode-config), auto mode classifies the **actual tool call**, not prompt text, so the deterministic Bash hooks + auto mode are a strictly better-targeted net.

A `type:"prompt"` hook can't read `permission_mode`, so it can't self-gate — hence removal rather than gating for that one. `branch-protection.sh` is a `command` hook and *can* read it, so it's gated instead of removed (preserves the non-auto-mode fallback, and its stricter commit-on-main enforcement everywhere auto mode isn't active).

## Tests

`bash hooks-plugin/hooks/test-branch-protection.sh` → 33 passed (2 new: allow under `auto`, still deny under `default`). shellcheck clean, `plugin.json` validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)