### PR TITLE
ci: put go-installed actionlint on PATH in plugin-pr-checks

### DIFF
--- a/.github/workflows/plugin-pr-checks.yml
+++ b/.github/workflows/plugin-pr-checks.yml
@@ -121,9 +121,12 @@ jobs:
 
       - name: Install actionlint
         # GitHub Actions YAML schema/best-practice lint — the one workflow gate
-        # check-workflow-model.sh does not cover. ubuntu-latest ships Go and
-        # adds $HOME/go/bin to PATH.
-        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+        # check-workflow-model.sh does not cover. ubuntu-latest ships Go but does
+        # NOT put $(go env GOPATH)/bin on PATH, so the installed binary is invisible
+        # to the next (fresh-shell) step unless we add it to $GITHUB_PATH here.
+        run: |
+          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Lint workflows with actionlint
         # Two documented, tracked suppressions keep this a green blocking gate


### PR DESCRIPTION
## Problem

The `compliance` check fails on **every open PR** (#1784, #1785, #1786) with:

```
actionlint: command not found  (exit 127)
```

The `Install actionlint` step runs `go install …/actionlint`, which places the binary in `$(go env GOPATH)/bin` (`/home/runner/go/bin`). That directory is **not** on PATH on ubuntu-latest, and each `run:` step is a fresh shell — so the subsequent `Lint workflows with actionlint` step can't find it. The step's comment claiming the runner adds `$HOME/go/bin` to PATH is incorrect.

Introduced in c49cba74 (the actionlint/shell-lint gate wiring).

## Fix

Append `$(go env GOPATH)/bin` to `$GITHUB_PATH` in the install step. `GITHUB_PATH` writes apply to *subsequent* steps, so the lint step resolves the binary.

## Follow-up

Once merged, the three open PRs need a branch update to pick this up. #1785 and #1786 also edit this step (changing the `actionlint` flags), so they'll need a trivial conflict resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)