### PR TITLE
chore(rules): path-scope surface-bound rules to cut always-on context

### DIFF
--- a/.claude/rules/gitattributes.md
+++ b/.claude/rules/gitattributes.md
@@ -1,3 +1,7 @@
+---
+paths:
+  - "**/.gitattributes"
+---
 # .gitattributes Conventions
 
 A repo's `.gitattributes` is a path→attribute map git consults for **merge**,

--- a/.claude/rules/github-actions-security.md
+++ b/.claude/rules/github-actions-security.md
@@ -1,3 +1,7 @@
+---
+paths:
+  - ".github/workflows/**"
+---
 # GitHub Actions Security
 
 The secure-use baseline for every workflow this repo authors and for the example

--- a/.claude/rules/plugin-flow-diagrams.md
+++ b/.claude/rules/plugin-flow-diagrams.md
@@ -1,3 +1,7 @@
+---
+paths:
+  - "**/docs/flow.md"
+---
 # Plugin Flow Diagrams
 
 Codifies when a plugin earns a Mermaid flow diagram, where it lives, and what conventions to follow.

--- a/.claude/rules/skill-argument-handling.md
+++ b/.claude/rules/skill-argument-handling.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "**/skills/**"
+  - "**/SKILL.md"
+---
 # Skill Argument-Handling Audit
 
 A skill's argument surface — its `args` / `argument-hint` frontmatter and the

--- a/.claude/rules/skill-evaluation.md
+++ b/.claude/rules/skill-evaluation.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "**/skills/**"
+  - "**/SKILL.md"
+---
 # Skill Effectiveness Measurement
 
 How we know our skills actually work — and keep working as new Claude models

--- a/.claude/rules/structured-script-output.md
+++ b/.claude/rules/structured-script-output.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "**/*.sh"
+  - "scripts/**"
+---
 # Structured Script Output
 
 Diagnostic shell scripts invoked by skills should emit a Bash-friendly

--- a/.claude/rules/typer-cli-completion.md
+++ b/.claude/rules/typer-cli-completion.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "git-repo-agent/**"
+  - "vault-agent/**"
+---
 # Typer/Click CLI Completion: Bypass shellingham
 
 Python CLIs built on [Typer] (and [Click] under it) ship `--install-completion`

--- a/.claude/rules/version-pinning.md
+++ b/.claude/rules/version-pinning.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "**/SKILL.md"
+  - "**/REFERENCE.md"
+  - "renovate.json"
+---
 # Version Pinning in Skill Examples
 
 Skill markdown ships copy-pasteable examples that pin tool versions — GitHub

--- a/.claude/rules/workflow-model-effort.md
+++ b/.claude/rules/workflow-model-effort.md
@@ -1,3 +1,7 @@
+---
+paths:
+  - ".github/workflows/**"
+---
 # Workflow Model + Effort
 
 The model/effort standard for every Claude invocation in `.github/workflows/*.yml`.

--- a/.claude/rules/workflow-naming.md
+++ b/.claude/rules/workflow-naming.md
@@ -1,3 +1,7 @@
+---
+paths:
+  - ".github/workflows/**"
+---
 # GitHub Actions Workflow Naming
 
 A `<Domain>: <Action> [<target>]` convention for the `name:` field of every GitHub Actions workflow this repo authors — and for the example snippets in any skill that scaffolds workflows.


### PR DESCRIPTION
## What

Prepend `paths:` frontmatter to 10 repo-internal rules in `.claude/rules/` whose subject is a specific file surface, so they load **lazily** (only when a matching file is in context) instead of on **every** prompt. Frontmatter only — no body lines changed.

The repo root `.claude/rules/` had 20 always-on rules (~2,200 lines of always-on context). This roughly halves the always-on rule footprint with zero content change.

## Scoping

| Rule | `paths:` globs |
|---|---|
| `typer-cli-completion.md` | `git-repo-agent/**`, `vault-agent/**` |
| `skill-argument-handling.md` | `**/skills/**`, `**/SKILL.md` |
| `skill-evaluation.md` | `**/skills/**`, `**/SKILL.md` |
| `structured-script-output.md` | `**/*.sh`, `scripts/**` |
| `version-pinning.md` | `**/SKILL.md`, `**/REFERENCE.md`, `renovate.json` |
| `gitattributes.md` | `**/.gitattributes` |
| `plugin-flow-diagrams.md` | `**/docs/flow.md` |
| `workflow-naming.md` | `.github/workflows/**` |
| `workflow-model-effort.md` | `.github/workflows/**` |
| `github-actions-security.md` | `.github/workflows/**` |

## Why these choices

- **Workflow trio** (`workflow-naming`, `workflow-model-effort`, `github-actions-security`) scoped tightly to `.github/workflows/**` only — the consumer-facing convention already ships in the relevant plugin **skills**, so the repo rule only needs to fire when editing this repo's workflow YAML. Adding `**/SKILL.md` would re-inflate to ~350 skill files and defeat the sweep.
- **`loop-integrity.md` deliberately left always-loaded** — it is *behavioral* (governs runtime loops over arbitrary source files), not bound to a file type; scoping it would make it fail to load during the exact activity it governs.

## Safe by construction

`paths:` is native Claude Code (root-relative globs, brace expansion, matched against files-in-context). **No repo validator parses rule frontmatter** — `plugin-compliance-check.sh` and `check-docs-index.sh` only touch SKILL.md / the CLAUDE.md table — so adding `paths:` cannot break CI.

## Verification

- `git diff` shows only prepended frontmatter blocks; no body lines changed (10 files, +46).
- `bash scripts/plugin-compliance-check.sh` — exit 0.
- `bash scripts/check-docs-index.sh` — exit 0.
- Filenames unchanged, so all CLAUDE.md table entries still resolve.

## Follow-ups (separate, not in this PR)

- `terminology.md` / `conventional-commits.md` are `meta-context-diet` candidates (promote / trim).
- The remaining behavioral always-on rules (`gh-json-fields`, `parallel-safe-queries`, `bash-tool-replacements`, `handling-blocked-hooks`, `agent-coworker-detection`, `pr-branch-sync`) correctly stay always-on — they fire on tool choice, not file path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)