### PR TITLE
feat(configure-plugin): add configure-mise skill

### DIFF
--- a/configure-plugin/README.md
+++ b/configure-plugin/README.md
@@ -44,6 +44,7 @@ All commands support two modes:
 | `configure-argocd-automerge` | Auto-merge workflow for ArgoCD Image Updater branches |
 | `configure-claude-plugins` | Configure Claude Code plugin marketplace and GitHub Actions workflows |
 | `configure-gitattributes` | `.gitattributes`: union-merge append-only tables, linguist-generated build output, LF normalization |
+| `configure-gitignore` | `.gitignore`: append a managed Claude Code runtime-state block (worktrees, scheduled-task lock, local settings) |
 | `configure-pre-commit` | Pre-commit hooks for project standards |
 | `configure-release-please` | Release-please workflow configuration |
 | `configure-reusable-workflows` | Install Claude-powered reusable workflows (security, quality, a11y) |
@@ -93,6 +94,7 @@ All commands support two modes:
 | `configure-makefile` | Makefile with standard targets |
 | `configure-justfile` | Justfile with standard recipes (simpler alternative to Make) |
 | `configure-package-management` | Modern package managers (uv for Python, bun for TypeScript) |
+| `configure-mise` | mise tool/runtime version manager — mise.toml, backends, tasks, env, lockfile, migrations |
 | `configure-web-session` | SessionStart hook + install script for Claude Code on the web |
 
 ## Usage

--- a/configure-plugin/skills/configure-mise/REFERENCE.md
+++ b/configure-plugin/skills/configure-mise/REFERENCE.md
@@ -1,0 +1,216 @@
+# configure-mise — Reference
+
+Detailed templates and mapping tables for [`/configure:mise`](SKILL.md). Loaded on demand; no size limit.
+
+## Config file resolution
+
+mise merges config from several files, most-specific wins. Project files override the global one; `*.local.toml` overrides its sibling.
+
+| File | Scope | Commit? |
+|------|-------|---------|
+| `~/.config/mise/config.toml` | global (all projects) | dotfiles only |
+| `mise.toml` *(preferred)* / `.mise.toml` / `.config/mise.toml` | project | **yes** |
+| `mise.local.toml` / `.mise.local.toml` | project, machine-local | **no** — gitignore |
+| `.tool-versions`, `.nvmrc`, `.python-version` | legacy (asdf/nvm/pyenv) | honored only with `legacy_version_file = true` |
+
+`mise.lock` pins resolved versions+checksums for reproducible installs — commit it. Regenerate with `mise lock`.
+
+## Backend cheat-sheet
+
+```toml
+[tools]
+# core runtimes — multi-version as a list
+python = ["3.12", "3.13"]
+node   = "lts"            # or "latest", "22", "20.11.0"
+go     = "1.23"
+rust   = "latest"
+bun    = "latest"
+
+# Python CLIs via pipx backend (routed through uvx)
+"pipx:ruff"       = "latest"
+"pipx:pre-commit" = "latest"
+"pipx:ansible"    = "latest"
+# extra uvx args:
+"pipx:mlx-lm"     = { version = "latest", uvx_args = "--prerelease allow" }
+
+# standalone CLI binaries via aqua (checksums + provenance) — org/repo names
+"aqua:BurntSushi/ripgrep"           = "latest"   # rg
+"aqua:sharkdp/fd"                   = "latest"
+"aqua:sharkdp/bat"                  = "latest"
+"aqua:jqlang/jq"                    = "latest"
+"aqua:mikefarah/yq"                 = "latest"
+"aqua:cli/cli"                      = "latest"   # gh
+"aqua:kubernetes/kubectl"           = "latest"
+"aqua:helm/helm"                    = "latest"
+"aqua:hashicorp/terraform"          = "latest"
+"aqua:jesseduffield/lazygit"        = "latest"
+"aqua:gitleaks/gitleaks"            = "latest"
+
+# other backends when aqua lacks the tool
+"npm:typescript-language-server" = "latest"
+"go:golang.org/x/tools/gopls"    = "latest"
+"cargo:tokei"                    = "latest"
+"github:starship/starship"       = "latest"
+
+# short names mise knows natively (core registry)
+just     = "latest"
+neovim   = "nightly"
+chezmoi  = "latest"
+uv       = "latest"          # register uv as managed so pipx: → uvx works
+```
+
+### Version pin granularity
+
+| Spec | Allows | Use for |
+|------|--------|---------|
+| `"latest"` | any new release on upgrade | dev tooling where churn is fine |
+| `"3"` | minor + patch within major | loose runtime pin |
+| `"3.13"` | patch within minor | typical library runtime |
+| `"3.13.2"` | exact | reproducibility-critical tools |
+| `mise use --pin` | writes exact resolved version | freeze without hand-editing |
+
+## `[env]` — environment & secrets
+
+```toml
+[env]
+EDITOR = "nvim"
+NODE_ENV = "development"
+
+# prepend to PATH (project-local bin)
+_.path = ["./bin", "./node_modules/.bin"]
+
+# load secrets/vars from a gitignored file — NEVER inline secrets
+_.file = ".env.local"
+
+# load from multiple files (later wins)
+# _.file = [".env", ".env.local"]
+
+# source a script's exports
+# _.source = "./scripts/env.sh"
+```
+
+`_.file` values are not committed; keep the referenced file in `.gitignore`. For the dotfiles global config this is how `~/.api_tokens` is loaded (`_.file = "~/.api_tokens"`).
+
+## `[tasks]` — replacing Make/just
+
+```toml
+[tasks.test]
+description = "Run the test suite"
+run = "pytest -x -q"
+
+[tasks.lint]
+description = "Lint everything"
+run = [
+  "ruff check .",
+  "ruff format --check .",
+]
+
+# aggregate task with dependencies (run after its deps)
+[tasks.ci]
+description = "Full local CI"
+depends = ["lint", "test"]
+
+# alias + multi-line shell
+[tasks.check]
+alias = "c"
+description = "Quick checks"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+echo "running checks…"
+ruff check .
+"""
+
+# file-based tasks live in `mise-tasks/<name>` or `.mise/tasks/<name>`
+# and are auto-discovered — no [tasks] entry needed.
+```
+
+Run with `mise run <name>` (or `mise run c`). List with `mise tasks`. `mise watch <name>` re-runs on file change. `depends` replaces Makefile prerequisites; `run` as a list runs steps sequentially.
+
+### Makefile → `[tasks]` mapping
+
+| Makefile | mise |
+|----------|------|
+| `target: dep1 dep2` | `[tasks.target]` + `depends = ["dep1","dep2"]` |
+| recipe lines (tab-indented) | `run = "…"` or `run = ["…","…"]` |
+| `.PHONY` | n/a — tasks aren't files |
+| `$(VAR)` | `[env]` var or task-level `env = {…}` |
+| `make target` | `mise run target` |
+
+## `[settings]` — common knobs
+
+```toml
+[settings]
+experimental = true          # enable newer backends/features
+legacy_version_file = true   # keep honoring .tool-versions/.nvmrc during migration
+pipx.uvx = true              # route pipx: backend through uvx (jdx/mise#7477)
+# activate_aggressive = true # switch versions even mid-directory (global dotfiles use this)
+# idiomatic_version_file_enable_tools = ["python"]  # opt-in legacy files per tool
+```
+
+Set `pipx.uvx = true` whenever any `pipx:` tool is present — mise only auto-detects uvx when `uv` is itself mise-managed, so register `uv = "latest"` under `[tools]` too.
+
+## Migration worked examples
+
+### asdf (`.tool-versions`)
+
+```
+# .tool-versions
+python 3.13.2
+nodejs 20.11.0
+terraform 1.7.5
+```
+→
+```toml
+[tools]
+python = "3.13.2"
+node = "20.11.0"
+"aqua:hashicorp/terraform" = "1.7.5"
+
+[settings]
+legacy_version_file = true   # until .tool-versions is removed
+```
+asdf plugin name `nodejs` → mise core `node`. Verify with `mise install && mise current`, then delete `.tool-versions`.
+
+### Homebrew CLI tools → mise
+
+Keep in Homebrew: GUI casks, services/daemons (postgresql, mosquitto), build deps (cmake, ninja), platform glue (mas), and bootstrap (mise itself, chezmoi, git). Move *standalone CLI binaries* to mise:
+
+| `brew install …` | mise |
+|------------------|------|
+| `kubectl` | `"aqua:kubernetes/kubectl"` |
+| `ripgrep` | `"aqua:BurntSushi/ripgrep"` |
+| `jq` | `"aqua:jqlang/jq"` |
+| `gh` | `"aqua:cli/cli"` |
+| `terraform` | `"aqua:hashicorp/terraform"` |
+| `python@3.13` | core `python = "3.13"` |
+
+### nvm / pyenv
+
+`.nvmrc` `20.11.0` → `node = "20.11.0"`. `.python-version` `3.13.2` (one per line) → `python = ["3.13.2", …]`.
+
+## Verification commands
+
+```bash
+mise trust                 # required before mise uses a new/edited config
+mise install               # materialize all tools
+mise lock                  # write/refresh mise.lock (commit it)
+mise doctor                # health check
+mise current               # active versions per tool
+mise ls --json             # installed tools (machine-readable, parallel-safe)
+mise outdated              # what could upgrade
+mise ls-remote <tool>      # available versions before pinning
+```
+
+## Gotchas
+
+- **Trust**: mise refuses untrusted config files; `mise trust` (or `mise trust --all`) after writing.
+- **`pipx:` resolution** depends on a mise-managed `uv` + `pipx.uvx = true`.
+- **aqua names** are `org/repo` and must match the aqua-registry; otherwise fall back to `github:`/`cargo:`/`go:`.
+- **Stale tool copies**: a global tool can reappear from another node version's `node_modules` or from `~/.default-npm-packages` re-seeding — see the global `mise-stale-tool-copies` rule.
+- **One-off version**: `mise exec <tool>@<ver> -- <cmd>` scopes a version to a single command; `mise use` *changes the default* (global `dependency-management` rule).
+- **node ≥26** prebuilt binaries need `libatomic.so.1` — absent on some minimal Linux/appliances; gate or pin.
+
+## Sources
+
+Distilled from the laurigates dotfiles mise setup (`private_dot_config/mise/config.toml.tmpl`, `docs/mise-migration-guide.md`, `docs/mise-quick-reference.md`, `docs/adrs/0002-unified-tool-version-management-mise.md`) and the global `mise-stale-tool-copies` / `dependency-management` rules.

--- a/configure-plugin/skills/configure-mise/SKILL.md
+++ b/configure-plugin/skills/configure-mise/SKILL.md
@@ -1,0 +1,207 @@
+---
+created: 2026-06-24
+modified: 2026-06-24
+reviewed: 2026-06-24
+description: "mise runtime/tool version manager - mise.toml, backends (pipx/aqua/npm/cargo/go), tasks, env, lockfile. Use when setting up, pinning runtimes/CLI tools, or migrating from asdf/nvm/pyenv/brew/Make."
+allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
+args: "[--check-only] [--fix] [--global] [--migrate <asdf|nvm|pyenv|brew|makefile>]"
+argument-hint: "[--check-only] [--fix] [--global] [--migrate <source>]"
+name: configure-mise
+---
+
+# /configure:mise
+
+Set up and audit [mise](https://mise.jdx.dev/) as the unified manager for language runtimes, CLI tools, environment variables, and project tasks. mise replaces asdf/nvm/pyenv (runtimes), `cargo install`/`brew install` (CLI binaries), and Make/just (tasks) behind one `mise.toml`.
+
+## When to Use This Skill
+
+| Use this skill when... | Use another approach when... |
+|------------------------|------------------------------|
+| Setting up `mise.toml` to pin a project's runtimes and CLI tools | Installing one tool ad-hoc — run `mise use <tool>@<ver>` directly |
+| Picking the right backend for a tool (core / `pipx:` / `aqua:` / `npm:` / `cargo:` / `go:`) | The project only needs Python/JS *libraries* — use `/configure:package-management` (uv/bun) |
+| Migrating from `.tool-versions`/asdf, `.nvmrc`, `.python-version`, Homebrew, or a Makefile | Defining build/test recipes only, no version management — use `/configure:justfile` or `/configure:makefile` |
+| Adding `[tasks]`, `[env]`, secret loading, or a `mise.lock` for reproducible installs | Running a specific runtime version once — `mise exec <tool>@<ver> -- <cmd>` (see global rule `mise-stale-tool-copies` / `dependency-management`) |
+| Auditing an existing mise setup for pinning, lockfile, trust, and backend correctness | Configuring CI runtime install — that consumes the `mise.toml` this skill produces (`jdx/mise-action`) |
+
+## Context
+
+- Project root: !`pwd`
+- mise config (project): !`find . -maxdepth 2 \( -name 'mise.toml' -o -name '.mise.toml' -o -path './.config/mise.toml' -o -name 'mise.local.toml' \)`
+- Lockfile: !`find . -maxdepth 1 -name 'mise.lock'`
+- Legacy version files: !`find . -maxdepth 2 \( -name '.tool-versions' -o -name '.nvmrc' -o -name '.python-version' -o -name '.ruby-version' -o -name '.go-version' \)`
+- Things mise can absorb: !`find . -maxdepth 1 \( -name 'Makefile' -o -name 'justfile' -o -name 'Brewfile' \)`
+
+## Parameters
+
+Parse from command arguments:
+
+- `--check-only`: Audit and report; make no changes (CI/review mode).
+- `--fix`: Apply the recommended config without prompting for each step.
+- `--global`: Target the **global** config (`~/.config/mise/config.toml`) instead of a project `mise.toml`.
+- `--migrate <source>`: Convert an existing setup into `mise.toml`. Sources: `asdf` (`.tool-versions`), `nvm` (`.nvmrc`), `pyenv` (`.python-version`), `brew` (Brewfile CLI tools), `makefile` (targets → `[tasks]`).
+
+## Backend Selection (the core decision)
+
+mise installs every tool through a *backend*. Picking the right one mirrors the user's tool-install priority (`dependency-management` rule): **mise first, with the most secure/fastest backend**.
+
+| Tool kind | Backend | Syntax | Why |
+|-----------|---------|--------|-----|
+| Language runtime | core | `python = ["3.12","3.13"]`, `node = "lts"`, `go = "1.23"`, `rust = "latest"` | Native version switching, the reason mise exists |
+| Python CLI tool | `pipx:` | `"pipx:ruff" = "latest"` | Routed through `uvx` (fast); set `pipx.uvx = true` |
+| Standalone CLI binary | `aqua:` | `"aqua:BurntSushi/ripgrep" = "latest"` | Checksums + SLSA provenance + Cosign — the secure default |
+| Node global | `npm:` | `"npm:typescript-language-server" = "latest"` | When no aqua entry exists |
+| Rust tool (no aqua) | `cargo:` | `"cargo:tokei" = "latest"` | Builds from source; prefer aqua if available |
+| Go tool (no aqua) | `go:` | `"go:golang.org/x/tools/gopls" = "latest"` | Installs via `go install` |
+| GitHub release (no aqua) | `github:` | `"github:starship/starship" = "latest"` | Direct release-asset fetch |
+
+Rule of thumb: **runtime → core; Python CLI → `pipx:`; everything else → `aqua:` first**, falling back to `npm:`/`cargo:`/`go:`/`github:` only when the aqua registry lacks the tool. Verify aqua availability at <https://github.com/aquaproj/aqua-registry>.
+
+## Execution
+
+### Step 1: Detect current state
+
+From Context, classify the repo:
+
+- **No mise, has legacy version files** (`.tool-versions`, `.nvmrc`, `.python-version`) → migration candidate.
+- **No mise, has Makefile/Brewfile** → task/tool migration candidate.
+- **Has `mise.toml`** → audit mode (Step 5).
+- **Greenfield** → fresh `mise.toml`.
+
+Detect which runtimes the project already implies: `pyproject.toml`/`.python-version` → Python; `package.json`/`.nvmrc` → Node; `go.mod` → Go; `Cargo.toml` → Rust.
+
+### Step 2: Choose config target and naming
+
+| Target | File | Committed? |
+|--------|------|-----------|
+| Project (default) | `mise.toml` at repo root | yes — pins the team to the same versions |
+| Project, local overrides | `mise.local.toml` | no — add to `.gitignore` |
+| Global (`--global`) | `~/.config/mise/config.toml` | n/a (dotfiles) |
+
+Prefer the modern `mise.toml` name over legacy `.mise.toml`. Use `mise.local.toml` for machine-specific or secret-bearing overrides and ensure it is gitignored.
+
+### Step 3: Build the `[tools]` block
+
+Pin runtimes the project needs, then add CLI tools by backend (table above). Pin **as loosely as safe**: `python = "3.13"` (allow patch upgrades) for libraries; exact pins (`opentofu = "1.11.2"`) for tools where reproducibility matters. Detect latest stable versions with WebSearch/`mise ls-remote <tool>` before writing.
+
+Minimal example:
+
+```toml
+[tools]
+python = "3.13"
+node = "lts"
+"pipx:ruff" = "latest"
+"pipx:pre-commit" = "latest"
+"aqua:jqlang/jq" = "latest"
+"aqua:cli/cli" = "latest"   # gh
+```
+
+### Step 4: Add `[env]`, `[tasks]`, `[settings]` as needed
+
+- **`[env]`** — project env vars and PATH; load secrets from a gitignored file with `_.file = ".env.local"` (never inline secrets). See REFERENCE.md.
+- **`[tasks]`** — migrate Makefile/just recipes here so `mise run <task>` replaces `make <target>`. Supports `depends`, `alias`, multi-line `run`. See REFERENCE.md for the full grammar.
+- **`[settings]`** — set `pipx.uvx = true` whenever any `pipx:` tool is present (works around `jdx/mise#7477`); `experimental = true` for newer backends; `legacy_version_file = true` to keep honoring `.tool-versions`/`.nvmrc` during migration.
+
+### Step 5: Audit (always; the whole job when `--check-only`)
+
+Report a compliance table:
+
+```
+mise Configuration Report
+=========================
+Config file            mise.toml                 [PRESENT | MISSING]
+Runtimes pinned        python, node              [PINNED | UNPINNED]
+CLI backends           aqua / pipx               [SECURE | cargo-from-source | mixed]
+pipx.uvx setting       true                      [SET | MISSING (pipx tools present)]
+Lockfile               mise.lock                 [COMMITTED | MISSING]
+Local overrides        mise.local.toml           [GITIGNORED | TRACKED ⚠ | n/a]
+Trust                  trusted                    [TRUSTED | UNTRUSTED]
+Legacy files remaining .tool-versions            [MIGRATED | STILL PRESENT]
+
+Overall: [N issues]
+```
+
+Checks: every runtime pinned; CLI tools prefer `aqua:` over `cargo:`/source builds; `pipx.uvx = true` present if any `pipx:` tool; `mise.lock` committed; `mise.local.toml` gitignored if present; config trusted (`mise trust`). If `--check-only`, stop here.
+
+### Step 6: Apply (with `--fix` or on confirmation)
+
+1. Write/patch the target config (Step 2 file).
+2. `mise trust` the config (required before mise will use a new/edited file).
+3. `mise install` to materialize tools.
+4. `mise lock` to generate/refresh `mise.lock`, then track it (`git add mise.lock`).
+5. If `mise.local.toml` exists, ensure `.gitignore` covers it.
+6. `mise doctor` to verify the setup is healthy.
+
+### Step 7: Migrations (`--migrate <source>`)
+
+| Source | Action |
+|--------|--------|
+| `asdf` | Read `.tool-versions`, map each line to a `[tools]` entry, keep `legacy_version_file = true`, then remove `.tool-versions` once verified. asdf plugin names usually match mise core/aqua names. |
+| `nvm` | `.nvmrc` → `node = "<ver>"`. |
+| `pyenv` | `.python-version` → `python = "<ver>"` (a list if multiple). |
+| `brew` | Move CLI tools (not casks/services/build-deps) from Brewfile to `aqua:`/core backends; leave GUI apps, fonts, daemons, and compilers in Homebrew. |
+| `makefile` | Convert each target to a `[tasks.<name>]` with `run`; map prerequisites to `depends`. See REFERENCE.md task grammar. |
+
+Always verify with `mise install && mise doctor` before deleting the source file. See [REFERENCE.md](REFERENCE.md) for per-source mapping tables and worked examples.
+
+### Step 8: CI integration (mention, don't duplicate)
+
+A committed `mise.toml` + `mise.lock` is consumed in CI by `jdx/mise-action` (`mise install` then `mise run <task>`), giving local↔CI parity (the `local-ci-parity` rule). Point the user to `/configure:ci-workflows` rather than writing the workflow here.
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Audit only | `/configure:mise --check-only` |
+| Auto-configure | `/configure:mise --fix` |
+| List installed tools (JSON) | `mise ls --json` |
+| Show active versions | `mise current` |
+| Available versions of a tool | `mise ls-remote <tool>` |
+| Show outdated | `mise outdated` |
+| Diagnose | `mise doctor` |
+| Generate lockfile | `mise lock` |
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--check-only` | Report status without modifying files |
+| `--fix` | Apply the recommended config without per-step prompts |
+| `--global` | Target `~/.config/mise/config.toml` instead of project `mise.toml` |
+| `--migrate <source>` | Convert `asdf`/`nvm`/`pyenv`/`brew`/`makefile` into `mise.toml` |
+
+## Examples
+
+```bash
+# Audit an existing setup
+/configure:mise --check-only
+
+# Set up mise.toml for the current project
+/configure:mise
+
+# Auto-configure, no prompts
+/configure:mise --fix
+
+# Migrate an asdf project
+/configure:mise --migrate asdf
+
+# Convert Makefile targets into mise tasks
+/configure:mise --migrate makefile
+```
+
+## Error Handling
+
+- **mise not installed**: Offer the install one-liner (`curl https://mise.run | sh`) or note it is itself a Homebrew bootstrap tool; do not block the audit.
+- **Untrusted config**: mise refuses to load an untrusted file — run `mise trust` after writing.
+- **`pipx:` tool fails to resolve**: ensure `uv` is a mise-managed tool and `pipx.uvx = true` is set (`jdx/mise#7477`).
+- **aqua package not found**: the `org/repo` name must match an aqua-registry entry; fall back to `github:`/`cargo:`/`go:` or core.
+- **Tool "keeps coming back" after removal**: stale per-node-version copies + `~/.default-npm-packages` re-seeding — see the global `mise-stale-tool-copies` rule.
+- **node ≥26 on minimal Linux**: prebuilt binaries link `libatomic.so.1`; gate `node` to platforms that have it (chezmoi-style `os` guard) or pin an older line.
+
+## See Also
+
+- `/configure:package-management` — uv/bun for Python/JS **libraries** (mise installs the runtimes; uv/bun manage deps)
+- `/configure:justfile`, `/configure:makefile` — task runners mise's `[tasks]` can replace
+- `/configure:ci-workflows` — CI that consumes `mise.toml` via `jdx/mise-action`
+- Global rules: `dependency-management` (tool-install priority, `mise exec` vs `mise use`), `mise-stale-tool-copies` (per-version cleanup)
+- [REFERENCE.md](REFERENCE.md) — full `[tasks]`/`[env]`/`[settings]` grammar, backend cheat-sheet, migration mapping tables
+- **mise docs**: <https://mise.jdx.dev/> · **aqua registry**: <https://github.com/aquaproj/aqua-registry>

--- a/docs/PLUGIN-MAP.md
+++ b/docs/PLUGIN-MAP.md
@@ -24,7 +24,7 @@ Install these first. They configure the environment other plugins rely on.
 |--------|--------|---------|
 | health-plugin | 7 | Diagnose config issues, audit plugin selection |
 | hooks-plugin | 4 | Enforce best practices via lifecycle hooks |
-| configure-plugin | 46 | Infrastructure standards (CI, linting, testing, Docker, repo onboarding) |
+| configure-plugin | 50 | Infrastructure standards (CI, linting, testing, Docker, repo onboarding) |
 | agent-patterns-plugin | 17 | Agent orchestration, MCP management, delegation |
 
 ### Tier 1 - Core Workflow


### PR DESCRIPTION
## Summary

Adds **`/configure:mise`** — audit and configure [mise](https://mise.jdx.dev/) as the unified manager for language runtimes, CLI tools, env vars, and project tasks. Fills a real gap: `configure-package-management` only mentions mise incidentally as an install vehicle for uv/bun; nothing configured mise itself.

## What it covers

- **Backend selection** decision table (core / `pipx:` / `aqua:` / `npm:` / `cargo:` / `go:` / `github:`) mirroring the portfolio's tool-install priority
- `mise.toml` vs `mise.local.toml` vs global config scoping; `mise.lock` for reproducible installs
- `[tools]` / `[env]` / `[tasks]` / `[settings]` grammar (with `pipx.uvx = true` for `jdx/mise#7477`)
- Migrations from **asdf / `.tool-versions` / nvm / pyenv / Homebrew / Makefile**
- Audit mode (`--check-only`) + auto-configure (`--fix`)

`REFERENCE.md` carries the detailed grammar and per-source migration mapping tables (keeps SKILL.md lean).

## Provenance

Distilled from the laurigates dotfiles mise setup (`config.toml.tmpl`, ADR-0002, migration + quick-reference docs) and the global tooling rules (`dependency-management`, `mise-stale-tool-copies`), cross-linking those rather than duplicating.

## Lifecycle updates

- `configure-plugin/README.md` skills table (+1 row)
- `docs/PLUGIN-MAP.md` count (49 → 50)

(Plugin-level metadata — marketplace/release-please/manifest/settings — unchanged, since this adds a *skill* to an existing plugin.)

## Verification

- Context commands pass `lint-context-commands.sh` and the bare-sandbox execution check (`FAIL=0`)
- `plugin-compliance-check.sh`: description 196 chars (within band); only advisory is the >10k-char size note (shared by 66 skills, well under the 26k ceiling, detail offloaded to REFERENCE.md)
- pre-commit hooks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)