### PR TITLE
fix(hooks-plugin): allow find -path and offer Glob-unavailable fallback

### DIFF
--- a/.claude/rules/bash-tool-replacements.md
+++ b/.claude/rules/bash-tool-replacements.md
@@ -12,7 +12,7 @@ replacement.
 
 | Wrong (Bash) | Right (tool) | When the Bash form is genuinely fine |
 |---|---|---|
-| `find . -name '*.ts'` | `Glob(pattern="**/*.ts")` | Need `-maxdepth`, `-mindepth`, `-type d`, `-print0`, or `-mtime` — Glob can't do directory-discovery flags |
+| `find . -name '*.ts'` | `Glob(pattern="**/*.ts")` | Need `-maxdepth`, `-mindepth`, `-type d`, `-path`, `-print0`, or `-mtime` — Glob can't do directory-discovery flags |
 | `find . -name '*.md' -type d` | `find . -name '*.md' -type d` | Already correct — `-type d` is the directory-discovery flag the hook explicitly allows |
 | `grep -rn 'foo' src/` | `Grep(pattern="foo", path="src", -r=true, -n=true)` | Piped into another command (`gh pr list \| rg 'foo'`), or you need `-q` for an exit-code boolean check |
 | `rg 'foo' --type ts` | `Grep(pattern="foo", glob="*.ts")` | Same exceptions as `grep` |
@@ -23,7 +23,7 @@ replacement.
 
 The hook's allowed-exception logic for each:
 
-- **`find`** — passes through `-maxdepth`, `-mindepth`, `-type` (with a space after), `-print0`. Use these when Glob genuinely can't replace `find`.
+- **`find`** — passes through `-maxdepth`, `-mindepth`, `-type` (with a space after), `-path` (a full-path glob like `'*/hooks/test-*.sh'` — a structural query, not a `-name '*.ext'` search), `-print0`. Use these when Glob genuinely can't replace `find`. When Glob is unavailable in the session, keep `find` but add a directory-discovery flag (e.g. `-type f`) so the hook allows it.
 - **`grep` / `rg`** — passes through any pipeline (anything with `|`), and `-q` / `--quiet` (boolean exit-code checks like `grep -q pattern file && do_thing`).
 - **`cat` / `head` / `tail`** — passes through when the file path is `/dev/stdin`, `/dev/null`, or a here-doc target. The hook is checking for *file reads*, not stream handling.
 
@@ -49,7 +49,9 @@ The hook allows the Bash form in four scenarios:
 1. **Pipelines.** `gh pr list --json title --jq '.[].title' | rg 'feat'`
    is fine — the `|` short-circuits the hook check.
 2. **Directory-discovery flags.** `find . -maxdepth 2 -type d` is the
-   right form. `Glob` doesn't expose directory-type filters.
+   right form. `Glob` doesn't expose directory-type filters. `-path`
+   (a full-path glob, `find . -path '*/hooks/test-*.sh'`) is allowed
+   too — it's a structural query, not a `-name '*.ext'` search.
 3. **Boolean exit-code checks.** `grep -q pattern file && do_thing`
    is fine. The `Grep` tool returns content; it doesn't give you a
    clean shell-conditional exit code.

--- a/hooks-plugin/hooks/bash-antipatterns.sh
+++ b/hooks-plugin/hooks/bash-antipatterns.sh
@@ -180,6 +180,11 @@ fi
 # -maxdepth, -mindepth, -type, -print0. These are recommended in agentic-permissions.md
 # and shell-scripting.md for context commands.
 #
+# Also allow -path: a `find … -path '<glob>'` filters on the full path structure
+# (e.g. '*/hooks/test-*.sh'), which is a directory-structure query, not the
+# `-name '*.ext'` codebase search Glob replaces. Without this exemption a
+# -path-only find got redirected to Glob even though it is structural (issue #1800).
+#
 # Also allow the -delete action: it performs a filesystem mutation Glob
 # structurally cannot do (Glob only lists), so nudging toward Glob is useless and
 # the agent has no built-in alternative — blocking it is pure friction (issue #1671).
@@ -188,15 +193,17 @@ fi
 # so the agent should compose explicit, reviewable steps rather than execute through
 # find. Block simple name-pattern searches (pure listing Glob can do).
 if echo "$COMMAND" | grep -Eq '^\s*find\s+' && \
-   ! echo "$COMMAND" | grep -Eq 'find\s+.*(-maxdepth|-mindepth|-type\s|-print0|-delete\b)'; then
+   ! echo "$COMMAND" | grep -Eq 'find\s+.*(-maxdepth|-mindepth|-type\s|-path\s|-print0|-delete\b)'; then
     block "BLOCKED: 'find . -name \"*.ts\"' →
   Glob(pattern=\"**/*.ts\")
 
 The Glob tool is faster and optimized for codebase searches. If you
-need -maxdepth, -mindepth, -type d, or -print0 for directory discovery
-that Glob cannot do, keep find with those flags — the hook allows it.
-Glob can only list, not act: for 'find … -delete' keep find — the hook
-allows it too. (-exec/-ok stay blocked: run explicit steps instead.)
+need -maxdepth, -mindepth, -type d, -path, or -print0 for directory
+discovery that Glob cannot do, keep find with those flags — the hook
+allows it. Glob can only list, not act: for 'find … -delete' keep find —
+the hook allows it too. (-exec/-ok stay blocked: run explicit steps instead.)
+If the Glob tool is unavailable in this session, keep find but add a
+directory-discovery flag so the hook allows it: find . -type f -name '*.ts'
 See .claude/rules/bash-tool-replacements.md for the full table."
 fi
 

--- a/hooks-plugin/hooks/test-bash-antipatterns.sh
+++ b/hooks-plugin/hooks/test-bash-antipatterns.sh
@@ -90,6 +90,18 @@ assert_exit \
     "find -name -exec rm (arbitrary execution) stays blocked" 2 \
     "find . -name '*.log' -exec rm {} +"
 
+# Regression (issue #1800): find with a -path glob is a directory-structure query,
+# not a `-name '*.ext'` codebase search Glob replaces, so it must be allowed.
+# The dead-end this prevents: hook redirects to Glob, but Glob is unavailable in
+# the session, leaving no working path forward.
+assert_exit \
+    "find -path glob is allowed (structural query; issue #1800)" 0 \
+    "find taskwarrior-plugin -path '*/hooks/test-*.sh'"
+
+assert_exit \
+    "find -path with -type is allowed (issue #1800)" 0 \
+    "find . -path '*/hooks/*' -type f"
+
 # ── cat pipeline regression ──────────────────────────────────────────────────
 # Regression: cat file | command was blocked even though cat is feeding a
 # pipeline — the Read tool cannot replace cat in pipelines where data flows
@@ -386,6 +398,14 @@ assert_stderr_contains \
 assert_stderr_contains \
     "find block message points at rule file" \
     'bash-tool-replacements.md' \
+    "find . -name '*.ts'"
+
+# Regression (issue #1800): when Glob is unavailable in the session, the redirect
+# to Glob is a dead-end. The block message must offer a find-with-flag fallback so
+# the agent has a working path forward rather than looping on an absent tool.
+assert_stderr_contains \
+    "find block message offers a Glob-unavailable fallback" \
+    'If the Glob tool is unavailable in this session' \
     "find . -name '*.ts'"
 
 assert_stderr_contains \


### PR DESCRIPTION
## Summary

Fixes the `find -path` dead-end in `bash-antipatterns` (hooks-plugin) reported in #1800: the hook blocked a `find … -path '<glob>'` and redirected to the **Glob tool**, but Glob can be **unavailable** in the session — the hook says "use Glob", the harness says "Glob unavailable, use find", leaving no working path forward.

## Changes

- **`hooks-plugin/hooks/bash-antipatterns.sh`** — add `-path` to the `find` allowed-exception set. A full-path glob like `'*/hooks/test-*.sh'` is a directory-structure query, not the `-name '*.ext'` codebase search Glob replaces. Also add a **Glob-unavailable fallback** line to the block message (mirrors the grep block's existing fallback) pointing at `find … -type f`, so the agent always has a working alternative.
- **`hooks-plugin/hooks/test-bash-antipatterns.sh`** — regression tests (per `.claude/rules/regression-testing.md`): `-path` glob allowed with and without `-type`, and the block message carries the fallback line.
- **`.claude/rules/bash-tool-replacements.md`** — the table/text the hook cites now lists `-path` and the Glob-unavailable guidance.

## Verification

```
bash hooks-plugin/hooks/test-bash-antipatterns.sh   # 89 passed, 0 failed
bash scripts/lint-shell-scripts.sh                  # 0 error(s), 0 warning(s)
shellcheck hooks-plugin/hooks/bash-antipatterns.sh  # clean
```

Pre-commit (shellcheck + bash-antipatterns regression suite) passes.

Closes #1800

---

### Selection note (scheduled `work-on-claude-plugins-issues` run)

No open PRs existed, so all 27 open issues were candidates. After dependency sequencing, the two CI-failure roots (#1777, #1782) were found **already fixed** on `main` by c767a3b4 (#1787) — they append `$(go env GOPATH)/bin` to `$GITHUB_PATH` exactly as suggested. They are stale and should be closed (not actioned here — closing was out of this task's stated scope). #1800 was the next dependency-free, single-PR bug fix and was selected and resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
