### PR TITLE
chore(configure-plugin): refresh configure-repo reviewed date

### DIFF
--- a/configure-plugin/skills/configure-repo/SKILL.md
+++ b/configure-plugin/skills/configure-repo/SKILL.md
@@ -6,7 +6,7 @@ args: "[--check-only] [--skip-health] [--skip-migrations]"
 argument-hint: "[--check-only] [--skip-health] [--skip-migrations]"
 created: 2026-04-14
 modified: 2026-06-22
-reviewed: 2026-06-22
+reviewed: 2026-06-25
 ---
 
 # /configure:repo


### PR DESCRIPTION
## What

Bump `configure-repo/SKILL.md` `reviewed:` from 2026-06-22 → 2026-06-25.

## Why

`configure-worktreeinclude` (a `configure-repo` driver dependency, added in #1818) was modified 2026-06-25 — newer than the driver's `reviewed:` date. `check-driver-freshness` flags this and **blocks all commits** repo-wide (pre-commit) and reds CI.

The driver already wires `/configure:worktreeinclude` (Step 3d, the dependency table, and the related list), so no behaviour change is needed — only a re-review of the already-correct driver.

## Verification

`scripts/check-driver-freshness.sh` → `OK: Driver is fresh.` (all 10 dependencies ≤ reviewed date; driver age 0 days). All pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)