### PR TITLE
fix(code-quality-plugin): gate preflight-cue Signal 3 on lintable source extensions

### DIFF
--- a/code-quality-plugin/hooks/code-quality-preflight-cue.sh
+++ b/code-quality-plugin/hooks/code-quality-preflight-cue.sh
@@ -92,12 +92,26 @@ if [ "$cq_is_structural" -eq 0 ] && \
     cq_is_structural=1
 fi
 
-# Signal 3: large payload (>= 50 lines).
+# Signal 3: large payload (>= 50 lines) — but ONLY for source types that
+# /code-quality:code-lint can actually act on. code-lint auto-detects
+# ruff/eslint/biome/clippy/gofmt/shellcheck (see skills/code-lint/SKILL.md); it has
+# no linter for config/data/IaC files (.yaml/.yml/.json/.toml/.tf/.tfvars/.hcl, …),
+# which routinely exceed 50 lines. Firing the cue there points at a skill that does
+# nothing for the file just written — an alarming, non-actionable "blocking error"
+# on routine multi-line config writes (issue #1825). So gate the large-payload signal
+# on the lintable source extensions; Signals 1 (key manifests) and 2 (code symbols)
+# still fire for the structural cases that DO warrant a pre-flight. This generalizes
+# the earlier narrow per-type skips for .d2/.svg (#1730) and small shell wrappers
+# (#1766) into one rule: large payload only counts when the file has a code-lint linter.
 if [ "$cq_is_structural" -eq 0 ]; then
-    cq_line_count=$(printf '%s' "$cq_payload" | wc -l)
-    if [ "$cq_line_count" -ge 50 ]; then
-        cq_is_structural=1
-    fi
+    case "$cq_base_name" in
+        *.py|*.pyi|*.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs|*.rs|*.go|*.sh|*.bash|*.zsh)
+            cq_line_count=$(printf '%s' "$cq_payload" | wc -l)
+            if [ "$cq_line_count" -ge 50 ]; then
+                cq_is_structural=1
+            fi
+            ;;
+    esac
 fi
 
 [ "$cq_is_structural" -eq 0 ] && exit 0

--- a/code-quality-plugin/hooks/test-code-quality-preflight-cue.sh
+++ b/code-quality-plugin/hooks/test-code-quality-preflight-cue.sh
@@ -74,11 +74,15 @@ else
 fi
 
 # --- (c) >=50 lines fires, <50 lines trivial edit is silent ---
+# Fixtures use a lintable source extension (.py) — Signal 3 only fires for file
+# types /code-quality:code-lint can act on (issue #1825). The payload is plain
+# "line" repeats with no public symbols, so Signal 2 stays quiet and this isolates
+# the line-count threshold itself.
 echo "--- Test (c): 50-line payload fires ---"
 CQ_SID_C1="test-sid-c1-$(date +%s%N)"
 # Generate 50 lines of content (no public symbols, not a manifest)
 CQ_50LINES="$(printf 'line\n%.0s' {1..50})"
-CQ_PAYLOAD_C1="$(cq_payload Edit /repo/src/helpers.rb '' "$CQ_50LINES" "$CQ_SID_C1")"
+CQ_PAYLOAD_C1="$(cq_payload Edit /repo/src/helpers.py '' "$CQ_50LINES" "$CQ_SID_C1")"
 CQ_OUT_C1="$(CODE_QUALITY_PREFLIGHT_CUE_CACHE_DIR="$CQ_TEST_CACHE_DIR" bash "$CQ_SCRIPT" <<< "$CQ_PAYLOAD_C1")"
 if echo "$CQ_OUT_C1" | jq -e '.decision == "block"' > /dev/null 2>&1; then
   cq_pass "(c) 50-line payload fires"
@@ -89,7 +93,7 @@ fi
 echo "--- Test (c): <50 lines trivial edit is silent ---"
 CQ_SID_C2="test-sid-c2-$(date +%s%N)"
 CQ_SMALL="$(printf 'line\n%.0s' {1..10})"
-CQ_PAYLOAD_C2="$(cq_payload Edit /repo/src/helpers.rb '' "$CQ_SMALL" "$CQ_SID_C2")"
+CQ_PAYLOAD_C2="$(cq_payload Edit /repo/src/helpers.py '' "$CQ_SMALL" "$CQ_SID_C2")"
 CQ_OUT_C2="$(CODE_QUALITY_PREFLIGHT_CUE_CACHE_DIR="$CQ_TEST_CACHE_DIR" bash "$CQ_SCRIPT" <<< "$CQ_PAYLOAD_C2")"
 if [ -z "$CQ_OUT_C2" ]; then
   cq_pass "(c) trivial small edit is silent"
@@ -255,6 +259,63 @@ if echo "$CQ_OUT_K2" | jq -r '.reason' | grep -q "evaluate-skill"; then
   cq_pass "(k) skills/ path edit mentions evaluate-skill"
 else
   cq_fail "(k) skills/ path edit should mention evaluate-skill; got: $CQ_OUT_K2"
+fi
+
+# --- (l) config/data/IaC files >=50 lines are silent (issue #1825) ---
+# /code-quality:code-lint has no linter for YAML/JSON/TOML/HCL/Terraform, so a
+# large config write must NOT trip Signal 3 (the large-payload signal) — the cue
+# would point at a skill that does nothing for the file. Signals 1 (manifest
+# basenames) and 2 (code symbols) are unaffected and still fire.
+CQ_60LINES_L="$(printf 'key: value\n%.0s' {1..60})"
+
+echo "--- Test (l): 60-line ArgoCD-style .yaml is silent ---"
+CQ_SID_L1="test-sid-l1-$(date +%s%N)"
+CQ_PAYLOAD_L1="$(cq_payload Write /repo/argocd/applicationsets/fe-app.yaml '' "$CQ_60LINES_L" "$CQ_SID_L1")"
+CQ_OUT_L1="$(CODE_QUALITY_PREFLIGHT_CUE_CACHE_DIR="$CQ_TEST_CACHE_DIR" bash "$CQ_SCRIPT" <<< "$CQ_PAYLOAD_L1")"
+if [ -z "$CQ_OUT_L1" ]; then
+  cq_pass "(l) large .yaml config edit is silent"
+else
+  cq_fail "(l) large .yaml config edit should be silent; got: $CQ_OUT_L1"
+fi
+
+echo "--- Test (l): 60-line Terraform .tf is silent ---"
+CQ_SID_L2="test-sid-l2-$(date +%s%N)"
+CQ_PAYLOAD_L2="$(cq_payload Write /repo/infra/main.tf '' "$CQ_60LINES_L" "$CQ_SID_L2")"
+CQ_OUT_L2="$(CODE_QUALITY_PREFLIGHT_CUE_CACHE_DIR="$CQ_TEST_CACHE_DIR" bash "$CQ_SCRIPT" <<< "$CQ_PAYLOAD_L2")"
+if [ -z "$CQ_OUT_L2" ]; then
+  cq_pass "(l) large .tf config edit is silent"
+else
+  cq_fail "(l) large .tf config edit should be silent; got: $CQ_OUT_L2"
+fi
+
+echo "--- Test (l): large non-manifest .json data file is silent ---"
+CQ_SID_L3="test-sid-l3-$(date +%s%N)"
+CQ_PAYLOAD_L3="$(cq_payload Write /repo/data/fixtures.json '' "$CQ_60LINES_L" "$CQ_SID_L3")"
+CQ_OUT_L3="$(CODE_QUALITY_PREFLIGHT_CUE_CACHE_DIR="$CQ_TEST_CACHE_DIR" bash "$CQ_SCRIPT" <<< "$CQ_PAYLOAD_L3")"
+if [ -z "$CQ_OUT_L3" ]; then
+  cq_pass "(l) large .json data file is silent"
+else
+  cq_fail "(l) large .json data file should be silent; got: $CQ_OUT_L3"
+fi
+
+echo "--- Test (l): manifest .json (package.json) still fires via Signal 1 ---"
+CQ_SID_L4="test-sid-l4-$(date +%s%N)"
+CQ_PAYLOAD_L4="$(cq_payload Write /repo/package.json '' "$CQ_60LINES_L" "$CQ_SID_L4")"
+CQ_OUT_L4="$(CODE_QUALITY_PREFLIGHT_CUE_CACHE_DIR="$CQ_TEST_CACHE_DIR" bash "$CQ_SCRIPT" <<< "$CQ_PAYLOAD_L4")"
+if echo "$CQ_OUT_L4" | jq -e '.decision == "block"' > /dev/null 2>&1; then
+  cq_pass "(l) package.json still fires via Signal 1"
+else
+  cq_fail "(l) package.json should still fire via Signal 1; got: $CQ_OUT_L4"
+fi
+
+echo "--- Test (l): .yaml with a code symbol still fires via Signal 2 ---"
+CQ_SID_L5="test-sid-l5-$(date +%s%N)"
+CQ_PAYLOAD_L5="$(cq_payload Write /repo/config/app.yaml 'export default config' '' "$CQ_SID_L5")"
+CQ_OUT_L5="$(CODE_QUALITY_PREFLIGHT_CUE_CACHE_DIR="$CQ_TEST_CACHE_DIR" bash "$CQ_SCRIPT" <<< "$CQ_PAYLOAD_L5")"
+if echo "$CQ_OUT_L5" | jq -e '.decision == "block"' > /dev/null 2>&1; then
+  cq_pass "(l) .yaml with code symbol still fires via Signal 2"
+else
+  cq_fail "(l) .yaml with code symbol should fire via Signal 2; got: $CQ_OUT_L5"
 fi
 
 # --- Summary ---


### PR DESCRIPTION
## What

The `code-quality-preflight-cue.sh` PostToolUse hook's **Signal 3** (large payload ≥ 50 lines) fired on *any* non-excluded file purely on length. Routine multi-line **config/data/IaC** writes — ArgoCD/Helm YAML, Terraform, large non-manifest JSON — therefore tripped an alarming `[code-quality] Large/structural edit detected` blocking error pointing at `/code-quality:code-lint`, which has **no linter for those file types** (it auto-detects ruff/eslint/biome/clippy/gofmt/shellcheck only). The cue was non-actionable: it named a skill that does nothing for the file just written.

## Fix

Gate Signal 3 on the **lintable source extensions** code-lint can actually act on:

`.py .pyi · .ts .tsx .js .jsx .mjs .cjs · .rs · .go · .sh .bash .zsh`

- Signal 1 (key manifests — `plugin.json`/`package.json`/…) and Signal 2 (code-symbol lines) are **unchanged**, so structural cases that *do* warrant a pre-flight still fire.
- This generalizes the earlier narrow per-type skips for `.d2`/`.svg` (#1730) and small shell wrappers (#1766) into one durable rule — "large payload only counts when the file has a code-lint linter" — instead of adding a third skip-list (the maintainer's preferred **Option 1** in the issue).

## Tests

`code-quality-plugin/hooks/test-code-quality-preflight-cue.sh` — **26/26 pass**:

- Moved test (c)'s firing fixture from `.rb` (no code-lint linter, so it should no longer fire) to `.py`, isolating the line-count threshold.
- Added test block **(l)**: large `.yaml` / `.tf` / non-manifest `.json` stay **silent**, while a manifest `package.json` still fires via Signal 1 and a `.yaml` containing a code symbol still fires via Signal 2.

Also verified: `shellcheck` clean on the hook, `scripts/lint-shell-scripts.sh` → 0 errors/0 warnings, pre-commit hooks pass.

## Verification done

- [x] Confirmed the diagnosis against the hook source (Signal 3 at the large-payload path)
- [x] Confirmed `code-lint` handles shell (shellcheck) → `.sh/.bash/.zsh` kept in the allowlist, preserving #1766 intent
- [x] Regression test added and green

Closes #1825

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — autonomous scheduled run (work-on-claude-plugins-issues).