### PR TITLE
feat(foundryvtt-plugin): add FoundryVTT module scaffold + orchestrator

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -289,6 +289,23 @@
       "category": "ci-cd"
     },
     {
+      "name": "foundryvtt-plugin",
+      "source": "./foundryvtt-plugin",
+      "description": "FoundryVTT module lifecycle - scaffold a v13 module (Vite + TS + bun), create + seed the repo, open the gitops adoption PR",
+      "version": "1.0.0",
+      "keywords": [
+        "foundryvtt",
+        "foundry-vtt",
+        "module",
+        "scaffold",
+        "vite",
+        "applicationv2",
+        "libwrapper",
+        "gitops"
+      ],
+      "category": "development"
+    },
+    {
       "name": "git-plugin",
       "source": "./git-plugin",
       "description": "Git workflows - commits, branches, PRs, issue processing, conflict resolution, and repository management",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -84,6 +84,7 @@
     "evaluate-plugin@laurigates-claude-plugins": true,
     "feedback-plugin@laurigates-claude-plugins": true,
     "finops-plugin@laurigates-claude-plugins": true,
+    "foundryvtt-plugin@laurigates-claude-plugins": true,
     "git-plugin@laurigates-claude-plugins": true,
     "github-actions-plugin@laurigates-claude-plugins": true,
     "health-plugin@laurigates-claude-plugins": true,

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -18,6 +18,7 @@
   "evaluate-plugin": "1.10.0",
   "feedback-plugin": "1.8.0",
   "finops-plugin": "1.4.0",
+  "foundryvtt-plugin": "1.0.0",
   "git-plugin": "2.48.0",
   "github-actions-plugin": "1.9.0",
   "health-plugin": "1.16.0",

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install the full plugin collection as a marketplace:
 claude plugin install laurigates/claude-plugins
 ```
 
-This registers all 43 plugins. You can then enable individual plugins as needed.
+This registers all 44 plugins. You can then enable individual plugins as needed.
 
 ### Install Individual Plugins
 

--- a/docs/PLUGIN-MAP.md
+++ b/docs/PLUGIN-MAP.md
@@ -179,6 +179,7 @@ Install based on your project's tech stack and domain.
 | rust-plugin | Project uses Rust |
 | bevy-plugin | Game development with Bevy engine |
 | comfyui-plugin | Building ComfyUI custom-node packs — scaffold, create + seed repo, gitops adoption, Comfy Registry publish |
+| foundryvtt-plugin | Building FoundryVTT v13 modules — scaffold (Vite + TS + bun), create + seed repo, gitops adoption |
 | container-plugin | Project uses Docker containers |
 | kubernetes-plugin | Deploying to Kubernetes clusters |
 | terraform-plugin | Managing infrastructure as code |

--- a/foundryvtt-plugin/.claude-plugin/plugin.json
+++ b/foundryvtt-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "foundryvtt-plugin",
+  "version": "1.0.0",
+  "description": "FoundryVTT module lifecycle - scaffold a v13 module (Vite + TS + bun), create + seed the repo, and open the gitops adoption PR",
+  "keywords": [
+    "foundryvtt",
+    "foundry-vtt",
+    "module",
+    "scaffold",
+    "vite",
+    "applicationv2",
+    "libwrapper",
+    "gitops"
+  ]
+}

--- a/foundryvtt-plugin/README.md
+++ b/foundryvtt-plugin/README.md
@@ -1,0 +1,65 @@
+# FoundryVTT Plugin
+
+End-to-end lifecycle support for **FoundryVTT v13 modules** — from an idea to a
+gitops-adopted repo with release-please distribution, built on a **Vite +
+TypeScript + bun + biome** toolchain.
+
+## Overview
+
+This plugin packages the two skills that build and ship FoundryVTT modules:
+scaffolding a CI-green module repository, and orchestrating the full path from
+idea to a release pipeline (repo creation, seeding, and the gitops adoption PR
+that wires branch protection + release-please credentials via Scalr).
+
+FoundryVTT modules distribute by **GitHub release manifest URL** — `manifest`
+points at `releases/latest/download/module.json` and `download` at
+`releases/latest/download/<id>.zip`. No foundryvtt.com submission is needed to
+install by URL (only to be *listed* in the in-app package browser).
+
+## Skills
+
+### foundryvtt-module-scaffold
+
+Scaffold a new FoundryVTT v13 module repository ready for implementation, in the
+**Vite + TypeScript** architecture (source in `src/`, built to `dist/<id>.mjs`):
+
+- a real `module.json` manifest (GitHub-release distribution), `package.json`
+  (bun scripts), `vite.config.ts` (library build + `vite-plugin-static-copy`
+  for assets + a dev-server proxy to Foundry on `:30000`)
+- strict `tsconfig.json` with **local Foundry ambient shims**
+  (`src/foundry-shims.d.ts`) — keeps the build self-contained and CI-green
+  without the beta, git-only `fvtt-types`
+- `biome.json`, a green Vitest smoke test (Foundry globals stubbed), a justfile
+- CI + release-please + renovate GitHub Actions; release-please bumps both
+  `package.json` and `module.json` `$.version`, and the release job zips `dist/`
+  and attaches the install assets
+- localization, scoped CSS, `CLAUDE.md`, `README.md`, `LICENSE`, and a toolchain ADR
+
+Three variants:
+
+| Variant | Adds |
+|---------|------|
+| `basic` (default) | `init`/`ready` hooks, a registered world setting, i18n, scoped CSS |
+| `app` | an `ApplicationV2`/`HandlebarsApplicationMixin` window + a settings-menu button that opens it (Foundry v13 UI) |
+| `libwrapper` | a `libWrapper`-guarded core-method patch with a manual fallback + a `relationships.recommends` for `lib-wrapper` |
+
+**Use when** bootstrapping / init-ing a new FoundryVTT module repo.
+
+### foundryvtt-module
+
+Orchestrate a module from idea to release-ready: scaffold (via
+`foundryvtt-module-scaffold`), create + seed the GitHub repo, then open the
+gitops PR that adds the `release_please = true` entry and a transient import
+block so Scalr adopts the repo. Stops at the single human gate (merging the
+gitops PR triggers the Scalr apply), then finishes the import-block-removal
+follow-up.
+
+**Use when** releasing or spinning up a new FoundryVTT module with minimal
+manual steps.
+
+## When to Use This Plugin
+
+Install when you build FoundryVTT modules and want a repeatable path from idea to
+a release-pipeline-ready, gitops-adopted repository. The skills are specific to
+the laurigates module family and its gitops/Scalr adoption flow, and target the
+local `foundryvtt-harness` as the run/test environment.

--- a/foundryvtt-plugin/skills/foundryvtt-module-scaffold/SKILL.md
+++ b/foundryvtt-plugin/skills/foundryvtt-module-scaffold/SKILL.md
@@ -1,0 +1,175 @@
+---
+created: 2026-06-26
+modified: 2026-06-26
+reviewed: 2026-06-26
+name: foundryvtt-module-scaffold
+description: >-
+  Scaffold a new FoundryVTT v13 module repo (Vite + TS + bun + biome, CI,
+  release-please) with basic/app/libwrapper variants. Use when bootstrapping or
+  init-ing a foundry module.
+allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
+args: "[--name <repo>] [--display <title>] [--desc <text>] [--variant <basic|app|libwrapper>]"
+argument-hint: --name foundryvtt-x --display "X" --desc "…" --variant basic
+---
+
+# foundryvtt-module-scaffold
+
+Bootstrap a new FoundryVTT v13 **module** repo built with **Vite + TypeScript +
+bun + biome**, leaving only the actual module logic to implement. The generated
+repo passes `just check` (typecheck + build + lint + test) from the first commit
+and distributes via the GitHub-release manifest-URL convention.
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative when... |
+|---|---|
+| Starting a new FoundryVTT module repo — CI-green TS toolchain, release-please, and a basic/app/libwrapper skeleton before writing module logic | You want the full pipeline (repo created + seeded + gitops-adopted) → `foundryvtt-module` |
+| Spinning up a FoundryVTT module backlog idea | Adding a feature to an *existing* module — this creates a **new** repo |
+
+## The architecture it scaffolds
+
+**TypeScript source in `src/` (entry `src/module.ts`), built to `dist/<id>.mjs`
+via Vite library mode.** `vite-plugin-static-copy` places `module.json`, `lang/`,
+`styles/` (and `templates/` for the app variant) into `dist/`, which Foundry
+serves as the module root. `tsc --noEmit` type-checks; Vite emits — decoupled.
+
+- **Type gate**: `bun run typecheck` → `tsc --noEmit`. Foundry globals are typed
+  by loose local ambient shims (`src/foundry-shims.d.ts`), so the build is
+  self-contained and CI-green without the (beta, git-only) `fvtt-types`. Verify
+  the real Foundry API before relying on a shape — the shims are deliberately
+  loose. Opt into `fvtt-types` later if you want richer types.
+- **Build**: `bun run build` → `vite build` → `dist/<id>.mjs` + copied assets.
+- **Dev**: `bun run dev` → Vite dev server on `:30001` proxying everything to
+  Foundry on `:30000` except the module's own files (served with HMR).
+- **Distribute via GitHub release**: `module.json` `manifest` →
+  `releases/latest/download/module.json`, `download` →
+  `releases/latest/download/<id>.zip`. release-please bumps `$.version` in both
+  `package.json` and `module.json`; the release job builds, zips `dist/`, and
+  attaches the assets. No foundryvtt.com submission is needed to install by URL
+  (only to be *listed* in the in-app package browser).
+
+## Three variants
+
+| Variant | Use when | Adds on top of basic |
+|---------|----------|----------------------|
+| `basic` (default) | Settings + lifecycle behavior — the minimal well-formed module. | `init`/`ready` hooks, a registered `world` setting, i18n, scoped CSS. |
+| `app` | The module has a UI panel. | An `ApplicationV2`/`HandlebarsApplicationMixin` window (`src/app.ts` + `templates/app.hbs`) and a `game.settings.registerMenu` button that opens it. |
+| `libwrapper` | The module patches a core/system method. | `src/patches.ts` with a `libWrapper.register(...)` call **and** a manual monkey-patch fallback when lib-wrapper is absent; a `relationships.recommends` entry for `lib-wrapper`. |
+
+**Decision rule:** `basic` for behavior driven by hooks/settings; `app` when the
+module surfaces a window or dialog; `libwrapper` when it overrides a core method
+(the conflict-safe way to do that on Foundry). Variants compose conceptually —
+start from the closest one and add the rest by hand.
+
+## How to run
+
+`scaffold.py` is stdlib-only. Run from the workspace where the module should
+land (e.g. `repos/laurigates/foundryvtt-dev/`).
+
+Basic settings+hooks module:
+
+```sh
+python3 ${CLAUDE_SKILL_DIR}/scaffold.py --name foundryvtt-initiative-tweaks --display "Initiative Tweaks" --desc "Small quality-of-life tweaks to the combat initiative tracker."
+```
+
+Module with an ApplicationV2 UI panel:
+
+```sh
+python3 ${CLAUDE_SKILL_DIR}/scaffold.py --name foundryvtt-party-overview --display "Party Overview" --desc "A dockable party status panel for GMs." --variant app
+```
+
+Module that patches a core method via libWrapper:
+
+```sh
+python3 ${CLAUDE_SKILL_DIR}/scaffold.py --name foundryvtt-token-vision-tweak --display "Token Vision Tweak" --desc "Adjusts token vision drawing via a libWrapper-guarded patch." --variant libwrapper
+```
+
+Flags: `--name` (GitHub repo, e.g. `foundryvtt-x`), `--id` (Foundry module id;
+default = `--name` minus the leading `foundryvtt-`), `--display` (title),
+`--desc`, `--variant {basic,app,libwrapper}`, `--fvtt-min` / `--fvtt-verified`
+(compatibility, default `12` / `13`), `--publisher` (default `laurigates`),
+`--author`, `--dir` (parent dir, default cwd).
+
+It refuses to overwrite an existing directory.
+
+## What you get
+
+A repo where `just check` passes from the first commit: a real `module.json`
+manifest, `package.json` (bun scripts), `vite.config.ts`, strict `tsconfig.json`,
+`biome.json`, `vitest.config.ts` + a green Vitest smoke test (Foundry globals
+stubbed in `tests/setup.ts`), `.github/workflows/` (`ci.yml`,
+`release-please.yml`, `renovate.yml`), `release-please-config.json` + manifest,
+`renovate.json`, a `justfile`, `src/module.ts` + `src/settings.ts` +
+`src/constants.ts` + `src/foundry-shims.d.ts`, `lang/en.json`,
+`styles/<id>.css`, `CLAUDE.md`, `README.md`, `LICENSE`, and an ADR recording the
+toolchain decision. The `app` variant adds `src/app.ts` + `templates/app.hbs`;
+`libwrapper` adds `src/patches.ts`.
+
+## After scaffolding
+
+The generator prints the exact next steps. In order:
+
+```sh
+cd foundryvtt-<name>
+git init -b main
+bun install
+just check
+```
+
+Seed `main` directly (the repo is unprotected until gitops adopts it) — pushing
+a feature branch first would leave `main` missing on origin and force a rename +
+default-branch fixup later. `bun install` writes `bun.lock`, which the seed
+commit must include (CI uses `--frozen-lockfile`).
+
+Then implement, and wire up infra:
+
+1. **Implement the module** — for `basic`, `src/module.ts` + `src/settings.ts`;
+   for `app`, `src/app.ts` + `templates/app.hbs`; for `libwrapper`, replace the
+   `Token._draw` example in `src/patches.ts` with the real target.
+2. **Add the repo to `gitops/repositories.tf`** with `release_please = true` and
+   a `foundryvtt` topic (mirror the `foundryvtt-mcp` entry). On apply, gitops
+   pushes the release-please App credentials.
+
+**Or skip steps entirely:** run the **`/foundryvtt-module`** orchestrator, which
+chains scaffold → `gh repo create` → seed `main` → the gitops PR.
+
+## Hard rules baked into the output
+
+- **`id` is the single source of truth.** `module.json` `id`, the install
+  folder, and the release zip name all derive from `--id`. Lowercase kebab-case
+  only.
+- **ESM-only, paths byte-match the manifest.** `esmodules` references
+  `<id>.mjs`; the Vite output filename is pinned to match. A mismatch is a silent
+  load failure.
+- **Target the harness-pinned Foundry version.** Keep `module.json`
+  `compatibility.{minimum,verified}` in sync with what you test against. Verify
+  the Foundry API against <https://foundryvtt.com/api/> or the live console — not
+  memory.
+- **Do not commit `dist/`.** It is git-ignored and rebuilt; CI builds it for
+  releases.
+- **Scoped CSS.** Every selector is prefixed with the module id — keep it that
+  way so styles never clobber core or other modules.
+- **Never hand-edit `CHANGELOG.md` or the `version` fields** — release-please
+  owns them (it bumps both `package.json` and `module.json`).
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Scaffold a basic module | `python3 ${CLAUDE_SKILL_DIR}/scaffold.py --name foundryvtt-X --display "X" --desc "…"` |
+| Scaffold an app module | `python3 ${CLAUDE_SKILL_DIR}/scaffold.py --name foundryvtt-X --display "X" --desc "…" --variant app` |
+| Verify a generated module | `cd foundryvtt-X && bun install && just check` |
+
+## Notes & deferrals
+
+- The biome pin is single-sourced in `scaffold.py`'s `BIOME_VERSION` constant so
+  `biome.json` and the CI `setup-biome` step never drift.
+- Action/tool versions in the generated workflows are current as of scaffolding;
+  the generated `renovate.yml` (laurigates reusable workflow) bumps them.
+- The generated module uses **local ambient shims**, not `fvtt-types`. This keeps
+  the build green and self-contained; switch `tsconfig` `types` to `fvtt-types`
+  (`github:League-of-Foundry-Developers/foundry-vtt-types#main`) for full API
+  types once you need them.
+- Quench (in-Foundry Mocha runner) and Playwright integration tests against the
+  harness are **not** scaffolded — add them when the module warrants runtime
+  coverage.

--- a/foundryvtt-plugin/skills/foundryvtt-module-scaffold/scaffold.py
+++ b/foundryvtt-plugin/skills/foundryvtt-module-scaffold/scaffold.py
@@ -1,0 +1,1271 @@
+#!/usr/bin/env python3
+"""Scaffold a new FoundryVTT module repo (TypeScript + Vite build, bun, biome).
+
+Generates a CI-green, ready-to-implement FoundryVTT v13 module: a real
+`module.json` manifest (GitHub-release distribution), a Vite library build
+(`src/module.ts` -> `dist/<id>.mjs`), strict TypeScript with local Foundry
+ambient shims, biome lint/format, a Vitest smoke suite, CI + release-please
+workflows (release-please bumps both `package.json` and `module.json` $.version
+and the release job zips `dist/` and attaches it to the GitHub release),
+localization, scoped CSS, a justfile, README, CLAUDE.md, and an ADR recording
+the toolchain decision.
+
+Three variants:
+  - basic      settings + init/ready hooks + i18n + scoped CSS (the default)
+  - app        basic + an ApplicationV2/HandlebarsApplicationMixin window and a
+               settings-menu button that opens it (Foundry v13 UI)
+  - libwrapper basic + a libWrapper-guarded patch of a core method with a manual
+               monkey-patch fallback when lib-wrapper is not active
+
+Distribution is by GitHub release manifest URL: `manifest` points at
+`releases/latest/download/module.json` and `download` at
+`releases/latest/download/<id>.zip`. No foundryvtt.com submission is needed to
+install-by-URL; that is only required to be LISTED in the in-app package browser.
+
+Stdlib only. Run with `python3 scaffold.py` or `uv run scaffold.py`.
+
+Examples
+--------
+Basic settings+hooks module:
+    python3 scaffold.py \
+        --name foundryvtt-initiative-tweaks \
+        --display "Initiative Tweaks" \
+        --desc "Small quality-of-life tweaks to the combat initiative tracker."
+
+Module with an ApplicationV2 UI panel:
+    python3 scaffold.py \
+        --name foundryvtt-party-overview \
+        --display "Party Overview" \
+        --desc "A dockable party status panel for GMs." \
+        --variant app
+
+Module that patches a core method via libWrapper:
+    python3 scaffold.py \
+        --name foundryvtt-token-vision-tweak \
+        --display "Token Vision Tweak" \
+        --desc "Adjusts token vision drawing via a libWrapper-guarded patch." \
+        --variant libwrapper
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import re
+import sys
+from pathlib import Path
+
+AUTHOR_DEFAULT = "Lauri Gates"
+PUBLISHER_DEFAULT = "laurigates"
+
+# Pinned tool versions — kept in ONE place so a pin can never drift between
+# biome.json, the CI setup-biome step, and the justfile.
+BIOME_VERSION = "2.4.15"
+TYPESCRIPT_VERSION = "^5.7.0"
+VITE_VERSION = "^6.0.0"
+VITE_STATIC_COPY_VERSION = "^2.2.0"
+VITEST_VERSION = "^3.0.0"
+
+# FoundryVTT compatibility defaults. `verified` tracks the version the local
+# harness pins; `minimum` is intentionally a little broader. Override per-module
+# with --fvtt-min / --fvtt-verified.
+FVTT_MIN_DEFAULT = "12"
+FVTT_VERIFIED_DEFAULT = "13"
+
+VALID_VARIANTS = ("basic", "app", "libwrapper")
+
+
+# --------------------------------------------------------------------------- #
+# Name derivation
+# --------------------------------------------------------------------------- #
+def derive(name: str, module_id: str | None) -> dict[str, str]:
+    """Derive the family of names a module needs from its repo name + id.
+
+    The repo name (``--name``) is the GitHub repo (e.g.
+    ``foundryvtt-initiative-tweaks``); the module id (``--id``, defaulting to the
+    repo name with a leading ``foundryvtt-`` stripped) is the canonical Foundry
+    identifier that must match the install folder, the zip, and ``module.json``.
+    """
+    if not name.startswith("foundryvtt-"):
+        print(
+            f"warning: repo name '{name}' does not start with 'foundryvtt-' "
+            "(the workspace convention)",
+            file=sys.stderr,
+        )
+    mid = module_id or name.removeprefix("foundryvtt-")
+    if not re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", mid):
+        print(
+            f"error: module id '{mid}' must be lowercase kebab-case "
+            "(letters, digits, single hyphens) — it becomes the install folder, "
+            "the zip name, and the module.json id",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    return {
+        "NAME": name,  # foundryvtt-initiative-tweaks (GitHub repo)
+        "MODULE_ID": mid,  # initiative-tweaks (Foundry id / folder / zip)
+        "MODULE_CLASS": _pascal(mid),  # InitiativeTweaks (TS class prefix)
+    }
+
+
+def _pascal(mid: str) -> str:
+    """initiative-tweaks -> InitiativeTweaks."""
+    return "".join(part[:1].upper() + part[1:] for part in mid.split("-"))
+
+
+# --------------------------------------------------------------------------- #
+# Template substitution — @@TOKEN@@ placeholders (avoids brace conflicts with
+# JSON / JS / TS literal braces).
+# --------------------------------------------------------------------------- #
+def subst(text: str, ctx: dict[str, str]) -> str:
+    for key, val in ctx.items():
+        text = text.replace(f"@@{key}@@", val)
+    return text
+
+
+# --------------------------------------------------------------------------- #
+# Config / metadata templates
+# --------------------------------------------------------------------------- #
+MODULE_JSON = """\
+{
+  "id": "@@MODULE_ID@@",
+  "title": "@@DISPLAY@@",
+  "description": "@@DESC@@",
+  "version": "0.1.0",
+  "compatibility": {
+    "minimum": "@@FVTT_MIN@@",
+    "verified": "@@FVTT_VERIFIED@@"
+  },
+  "authors": [
+    {
+      "name": "@@AUTHOR@@"
+    }
+  ],
+  "esmodules": ["@@MODULE_ID@@.mjs"],
+  "styles": ["styles/@@MODULE_ID@@.css"],
+  "languages": [
+    {
+      "lang": "en",
+      "name": "English",
+      "path": "lang/en.json"
+    }
+  ],
+  "url": "https://github.com/@@PUBLISHER@@/@@NAME@@",
+  "manifest": "https://github.com/@@PUBLISHER@@/@@NAME@@/releases/latest/download/module.json",
+  "download": "https://github.com/@@PUBLISHER@@/@@NAME@@/releases/latest/download/@@MODULE_ID@@.zip",
+  "readme": "https://github.com/@@PUBLISHER@@/@@NAME@@/blob/main/README.md",
+  "changelog": "https://github.com/@@PUBLISHER@@/@@NAME@@/blob/main/CHANGELOG.md",
+  "bugs": "https://github.com/@@PUBLISHER@@/@@NAME@@/issues",
+  @@RELATIONSHIPS@@"flags": {
+    "hotReload": {
+      "extensions": ["css", "hbs", "json"],
+      "paths": ["styles", "templates", "lang"]
+    }
+  }
+}
+"""
+
+RELATIONSHIPS_LIBWRAPPER = """\
+"relationships": {
+    "recommends": [
+      {
+        "id": "lib-wrapper",
+        "type": "module",
+        "reason": "Reduces conflicts when patching core methods.",
+        "manifest": "https://github.com/ruipin/fvtt-lib-wrapper/releases/latest/download/module.json",
+        "compatibility": { "minimum": "1.0.0.0" }
+      }
+    ]
+  },
+  """
+
+PACKAGE_JSON = """\
+{
+  "name": "@@NAME@@",
+  "version": "0.1.0",
+  "description": "@@DESC@@",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write .",
+    "format": "biome format --write .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "check": "bun run typecheck && bun run build && bun run lint && bun run test"
+  },
+  "keywords": [
+    "foundryvtt",
+    "foundry-vtt",
+    "module"
+  ],
+  "author": "@@AUTHOR@@",
+  "license": "MIT",
+  "devDependencies": {
+    "@biomejs/biome": "@@BIOME_VERSION@@",
+    "typescript": "@@TYPESCRIPT_VERSION@@",
+    "vite": "@@VITE_VERSION@@",
+    "vite-plugin-static-copy": "@@VITE_STATIC_COPY_VERSION@@",
+    "vitest": "@@VITEST_VERSION@@"
+  }
+}
+"""
+
+VITE_CONFIG = """\
+import { defineConfig } from 'vite';
+import { viteStaticCopy } from 'vite-plugin-static-copy';
+
+const MODULE_ID = '@@MODULE_ID@@';
+
+// Vite library build: a single ESM bundle at dist/<id>.mjs (the path
+// module.json's `esmodules` references), plus static-copied manifest + assets.
+// Foundry serves dist/ as the module root, so output paths must byte-match the
+// manifest. The dev server proxies everything to Foundry on :30000 except this
+// module's own files, which Vite serves with HMR.
+export default defineConfig(({ mode }) => ({
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    sourcemap: mode === 'development',
+    minify: false,
+    target: 'es2022',
+    lib: {
+      entry: 'src/module.ts',
+      formats: ['es'],
+      fileName: () => `${MODULE_ID}.mjs`,
+    },
+  },
+  plugins: [
+    viteStaticCopy({
+      targets: [
+        { src: 'module.json', dest: '.' },
+        { src: 'lang', dest: '.' },
+        { src: 'styles', dest: '.' },@@STATIC_COPY_TEMPLATES@@
+      ],
+    }),
+  ],
+  server: {
+    port: 30001,
+    proxy: {
+      [`^(?!/modules/${MODULE_ID}/)`]: 'http://localhost:30000/',
+      '/socket.io': { target: 'ws://localhost:30000', ws: true },
+    },
+  },
+}));
+"""
+
+STATIC_COPY_TEMPLATES = "\n        { src: 'templates', dest: '.' },"
+
+TSCONFIG = """\
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "allowJs": true,
+    "checkJs": false,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "skipLibCheck": true,
+    "types": []
+  },
+  "include": ["src"]
+}
+"""
+
+BIOME_JSON = """\
+{
+  "$schema": "https://biomejs.dev/schemas/@@BIOME_VERSION@@/schema.json",
+  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
+  "files": { "includes": ["**"] },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100,
+    "lineEnding": "lf"
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noExplicitAny": "off",
+        "noConsole": "off"
+      },
+      "complexity": {
+        "noThisInStatic": "off"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "always",
+      "trailingCommas": "all",
+      "arrowParentheses": "always"
+    }
+  },
+  "assist": { "enabled": true, "actions": { "source": { "organizeImports": "off" } } }
+}
+"""
+
+VITEST_CONFIG = """\
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    setupFiles: ['tests/setup.ts'],
+  },
+});
+"""
+
+GITIGNORE = """\
+node_modules/
+dist/
+coverage/
+*.log
+
+# Editor
+.vscode/
+.idea/
+*.swp
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Local notes / scratch
+TODO.local.md
+NOTES.local.md
+"""
+
+GITATTRIBUTES = """\
+* text=auto eol=lf
+*.png binary
+*.jpg binary
+*.webp binary
+bun.lock linguist-generated=true
+"""
+
+RP_CONFIG = """\
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "packages": {
+    ".": {
+      "release-type": "node",
+      "package-name": "@@NAME@@",
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "module.json",
+          "jsonpath": "$.version"
+        }
+      ]
+    }
+  },
+  "pull-request-title-pattern": "chore: release ${version}",
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance Improvements" },
+    { "type": "docs", "section": "Documentation" },
+    { "type": "chore", "section": "Miscellaneous", "hidden": false }
+  ],
+  "separate-pull-requests": false
+}
+"""
+
+RP_MANIFEST = """\
+{
+  ".": "0.1.0"
+}
+"""
+
+CI_YML = """\
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint & format (biome)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Biome
+        uses: biomejs/setup-biome@v2
+        with:
+          # Pin to the schema version declared in biome.json. Bump in lockstep
+          # via `biome migrate` when upgrading.
+          version: @@BIOME_VERSION@@
+      - name: Biome check
+        run: biome check .
+
+  typecheck-build:
+    name: Typecheck & build (Vite)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Typecheck
+        run: bun run typecheck
+      - name: Build
+        run: bun run build
+
+  test:
+    name: Tests (Vitest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Run Vitest
+        run: bun run test
+
+  security:
+    name: Security scanning
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # gitleaks scans <prev>^..<head>; the parent commit must be present.
+          fetch-depth: 0
+      - name: Gitleaks secret scan
+        uses: gitleaks/gitleaks-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+"""
+
+RELEASE_PLEASE_YML = """\
+name: "Release: release-please"
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: {}
+
+concurrency:
+  group: release-please-${{ github.repository }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      # When a release is cut, build the module, zip dist/, and attach the
+      # FoundryVTT install assets to the GitHub release. The manifest URL
+      # (releases/latest/download/module.json) and download URL
+      # (releases/latest/download/@@MODULE_ID@@.zip) resolve to these assets.
+      - name: Checkout
+        if: ${{ steps.release.outputs.release_created }}
+        uses: actions/checkout@v4
+      - name: Set up Bun
+        if: ${{ steps.release.outputs.release_created }}
+        uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        if: ${{ steps.release.outputs.release_created }}
+        run: bun install --frozen-lockfile
+      - name: Build module
+        if: ${{ steps.release.outputs.release_created }}
+        run: bun run build
+      - name: Package module zip
+        if: ${{ steps.release.outputs.release_created }}
+        run: |
+          cd dist
+          zip -r ../@@MODULE_ID@@.zip .
+      - name: Upload release assets
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh release upload "${{ steps.release.outputs.tag_name }}" \\
+            @@MODULE_ID@@.zip dist/module.json --clobber
+"""
+
+RENOVATE_JSON = """\
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"]
+}
+"""
+
+RENOVATE_YML = """\
+name: Renovate
+
+on:
+  schedule:
+    - cron: '23 */4 * * *'
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: 'Dry run mode'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'full'
+          - 'lookup'
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  packages: read
+
+jobs:
+  renovate:
+    uses: laurigates/.github/.github/workflows/reusable-renovate.yml@main
+    with:
+      dry-run: ${{ inputs.dryRun || 'false' }}
+"""
+
+JUSTFILE = """\
+# @@NAME@@ — task runner. Run `just` (or `just --list`) for recipes.
+
+# Show available recipes.
+default:
+    @just --list
+
+# Run the Vite dev server (proxies to Foundry on :30000 with HMR).
+dev:
+    bun run dev
+
+# Build the ESM bundle + static assets to dist/.
+build:
+    bun run build
+
+# Typecheck the TypeScript source (tsc --noEmit).
+typecheck:
+    bun run typecheck
+
+# Lint TS/JSON with biome (no changes).
+lint:
+    bun run lint
+
+# Auto-format + auto-fix with biome.
+format:
+    bun run lint:fix
+
+# Run the Vitest suite.
+test:
+    bun run test
+
+# Typecheck + build + lint + test — the local CI gate.
+check: typecheck build lint test
+"""
+
+LICENSE = """\
+MIT License
+
+Copyright (c) @@YEAR@@ @@AUTHOR@@
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+
+# --------------------------------------------------------------------------- #
+# Source templates
+# --------------------------------------------------------------------------- #
+FOUNDRY_SHIMS = """\
+// Ambient declarations for the FoundryVTT client globals this module uses.
+//
+// These keep `tsc` green and self-contained without depending on the (beta,
+// git-only) `fvtt-types` package. They are intentionally loose: their job is to
+// type *our* call sites, not to model the whole Foundry API. ALWAYS verify the
+// real API against https://foundryvtt.com/api/ or the live console before
+// relying on a shape — do not treat these declarations as authoritative.
+//
+// To opt into the full community types instead, add
+//   fvtt-types: "github:League-of-Foundry-Developers/foundry-vtt-types#main"
+// as a devDependency, set tsconfig `compilerOptions.types` to ["fvtt-types"],
+// and delete this file.
+
+export {};
+
+declare global {
+  const game: any;
+  const ui: any;
+  const canvas: any;
+  const CONFIG: any;
+  const CONST: any;
+  const foundry: any;
+  const Token: any;
+  const libWrapper: any;
+
+  const Hooks: {
+    on(hook: string, fn: (...args: any[]) => unknown): number;
+    once(hook: string, fn: (...args: any[]) => unknown): number;
+    off(hook: string, id: number): void;
+    call(hook: string, ...args: any[]): boolean;
+    callAll(hook: string, ...args: any[]): boolean;
+  };
+}
+"""
+
+CONSTANTS_TS = """\
+/** The Foundry module id — must match module.json `id`, the install folder, and
+ * the release zip name. Derived from a single source so it can never drift. */
+export const MODULE_ID = '@@MODULE_ID@@';
+
+/** Human-readable title, used as a console log prefix. */
+export const MODULE_TITLE = '@@DISPLAY@@';
+"""
+
+MODULE_TS = """\
+import { MODULE_ID, MODULE_TITLE } from './constants';
+import { registerSettings } from './settings';@@MODULE_IMPORTS@@
+
+/** Namespaced console logger so module messages are easy to filter. */
+function log(...args: unknown[]): void {
+  console.log(`${MODULE_TITLE} |`, ...args);
+}
+
+// `init` — register settings and wrap methods. `game` data is NOT populated yet.
+Hooks.once('init', () => {
+  log(`Initializing ${MODULE_ID}`);
+  registerSettings();@@INIT_BODY_EXTRA@@
+});
+
+// `ready` — the world and `game.*` are fully populated.
+Hooks.once('ready', () => {
+  log('Ready');@@READY_BODY_EXTRA@@
+});
+"""
+
+SETTINGS_TS = """\
+import { MODULE_ID } from './constants';@@SETTINGS_IMPORTS@@
+
+/** Register this module's settings. Called from the `init` hook. The `name` and
+ * `hint` values are i18n keys (resolved at render time), not literal strings. */
+export function registerSettings(): void {
+  game.settings.register(MODULE_ID, 'enabled', {
+    name: `${MODULE_ID}.Settings.Enabled.Name`,
+    hint: `${MODULE_ID}.Settings.Enabled.Hint`,
+    scope: 'world',
+    config: true,
+    type: Boolean,
+    default: true,
+    requiresReload: false,
+  });
+@@SETTINGS_MENU@@}
+
+/** Read a boolean module setting. */
+export function getSetting(key: string): unknown {
+  return game.settings.get(MODULE_ID, key);
+}
+"""
+
+SETTINGS_MENU_APP = """\
+  game.settings.registerMenu(MODULE_ID, 'openApp', {
+    name: `${MODULE_ID}.Menu.Name`,
+    label: `${MODULE_ID}.Menu.Label`,
+    hint: `${MODULE_ID}.Menu.Hint`,
+    icon: 'fa-solid fa-table-list',
+    type: @@MODULE_CLASS@@App,
+    restricted: false,
+  });
+"""
+
+APP_TS = """\
+import { MODULE_ID, MODULE_TITLE } from './constants';
+
+const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
+
+/**
+ * A minimal Foundry v13 ApplicationV2 window using HandlebarsApplicationMixin.
+ * Templates listed in `static PARTS` are auto-loaded by the mixin on render.
+ * Open it with `new @@MODULE_CLASS@@App().render(true)`.
+ */
+export class @@MODULE_CLASS@@App extends HandlebarsApplicationMixin(ApplicationV2) {
+  static DEFAULT_OPTIONS = {
+    id: `${MODULE_ID}-app`,
+    tag: 'div',
+    classes: [MODULE_ID, `${MODULE_ID}-app`],
+    window: {
+      title: `${MODULE_ID}.App.Title`,
+      icon: 'fa-solid fa-table-list',
+      resizable: true,
+    },
+    position: { width: 480, height: 'auto' },
+    actions: {
+      refresh: @@MODULE_CLASS@@App.#onRefresh,
+    },
+  };
+
+  static PARTS = {
+    main: { template: `modules/${MODULE_ID}/templates/app.hbs` },
+  };
+
+  /** Build the render context the Handlebars template sees. */
+  async _prepareContext(options: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const context = await super._prepareContext(options);
+    return foundry.utils.mergeObject(context, {
+      moduleTitle: MODULE_TITLE,
+      isGM: game.user?.isGM ?? false,
+    });
+  }
+
+  // Declared `static`, but the framework rebinds `this` to the live instance.
+  static async #onRefresh(
+    this: @@MODULE_CLASS@@App,
+    _event: Event,
+    _target: HTMLElement,
+  ): Promise<void> {
+    await this.render();
+  }
+}
+"""
+
+APP_HBS = """\
+<section class="@@MODULE_ID@@-app-body">
+  <h2>{{moduleTitle}}</h2>
+  <p>{{localize "@@MODULE_ID@@.App.Body"}}</p>
+  {{#if isGM}}
+  <p class="@@MODULE_ID@@-gm-note">{{localize "@@MODULE_ID@@.App.GMNote"}}</p>
+  {{/if}}
+  <footer class="@@MODULE_ID@@-app-footer">
+    <button type="button" data-action="refresh">
+      <i class="fa-solid fa-rotate"></i> {{localize "@@MODULE_ID@@.App.Refresh"}}
+    </button>
+  </footer>
+</section>
+"""
+
+PATCHES_TS = """\
+import { MODULE_ID, MODULE_TITLE } from './constants';
+
+/**
+ * Register method patches. Uses libWrapper when the lib-wrapper module is
+ * active (the conflict-safe path) and falls back to a manual monkey-patch with
+ * the same wrapper contract when it is not. Called from the `init` hook.
+ *
+ * The target below is illustrative — replace `Token.prototype._draw` and the
+ * wrapper body with the core/system method you actually need to patch. Verify
+ * the method exists at the targeted Foundry version before relying on it:
+ * https://foundryvtt.com/api/ and https://github.com/ruipin/fvtt-lib-wrapper
+ */
+export function registerPatches(): void {
+  const target = 'Token.prototype._draw';
+
+  // A WRAPPER must always continue the chain by calling `wrapped(...)`.
+  function wrapper(
+    this: unknown,
+    wrapped: (...args: unknown[]) => unknown,
+    ...args: unknown[]
+  ): unknown {
+    // TODO: custom behavior before/after the core call.
+    return wrapped(...args);
+  }
+
+  if (game.modules.get('lib-wrapper')?.active) {
+    libWrapper.register(MODULE_ID, target, wrapper, 'WRAPPER');
+  } else {
+    // Manual fallback: wrap the prototype method directly.
+    const proto = Token.prototype;
+    const original = proto._draw;
+    proto._draw = function (this: unknown, ...args: unknown[]): unknown {
+      return wrapper.call(this, original.bind(this), ...args);
+    };
+  }
+}
+
+/** Nudge the GM to install lib-wrapper if it is missing. Called from `ready`. */
+export function warnIfLibWrapperMissing(): void {
+  if (!game.modules.get('lib-wrapper')?.active && game.user?.isGM) {
+    ui.notifications?.warn(
+      `${MODULE_TITLE}: the lib-wrapper module is recommended to reduce conflicts with other modules.`,
+    );
+  }
+}
+"""
+
+LANG_BASE = """\
+{
+  "@@MODULE_ID@@.Settings.Enabled.Name": "Enable @@DISPLAY@@",
+  "@@MODULE_ID@@.Settings.Enabled.Hint": "Toggle the @@DISPLAY@@ module on or off."@@LANG_EXTRA@@
+}
+"""
+
+LANG_EXTRA_APP = """\
+,
+  "@@MODULE_ID@@.Menu.Name": "@@DISPLAY@@",
+  "@@MODULE_ID@@.Menu.Label": "Open @@DISPLAY@@",
+  "@@MODULE_ID@@.Menu.Hint": "Open the @@DISPLAY@@ panel.",
+  "@@MODULE_ID@@.App.Title": "@@DISPLAY@@",
+  "@@MODULE_ID@@.App.Body": "This is the @@DISPLAY@@ panel. Replace this with your UI.",
+  "@@MODULE_ID@@.App.GMNote": "You are the GM.",
+  "@@MODULE_ID@@.App.Refresh": "Refresh\""""
+
+STYLES_CSS = """\
+/* All selectors are scoped under the module id to avoid clobbering core or
+ * other modules' styles. Keep this prefix on every rule you add. */
+.@@MODULE_ID@@-app-body {
+  padding: 0.75rem;
+}
+
+.@@MODULE_ID@@-app-body h2 {
+  margin-top: 0;
+}
+
+.@@MODULE_ID@@-gm-note {
+  font-style: italic;
+  opacity: 0.8;
+}
+
+.@@MODULE_ID@@-app-footer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 0.5rem;
+}
+"""
+
+TEST_SETUP = """\
+import { vi } from 'vitest';
+
+// Stub the Foundry client globals the module touches so importing src modules
+// under Node (where `game`, `Hooks`, `foundry`, ... do not exist) does not throw.
+vi.stubGlobal('Hooks', {
+  on: vi.fn(),
+  once: vi.fn(),
+  off: vi.fn(),
+  call: vi.fn(),
+  callAll: vi.fn(),
+});
+
+vi.stubGlobal('game', {
+  settings: { register: vi.fn(), registerMenu: vi.fn(), get: vi.fn() },
+  i18n: { localize: (k: string) => k, format: (k: string) => k },
+  user: { isGM: true },
+  modules: { get: () => ({ active: false }) },
+});
+
+vi.stubGlobal('ui', {
+  notifications: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+});
+
+vi.stubGlobal('foundry', {
+  utils: {
+    mergeObject: (a: Record<string, unknown>, b: Record<string, unknown>) => ({ ...a, ...b }),
+  },
+  applications: {
+    api: {
+      ApplicationV2: class {},
+      HandlebarsApplicationMixin: (base: unknown) => base,
+    },
+  },
+});
+
+vi.stubGlobal(
+  'Token',
+  class {
+    _draw(): void {}
+  },
+);
+"""
+
+TEST_MODULE = """\
+import { describe, expect, it } from 'vitest';
+import { MODULE_ID } from '../src/constants';
+import { registerSettings } from '../src/settings';
+
+describe('@@MODULE_ID@@', () => {
+  it('exposes the expected module id', () => {
+    expect(MODULE_ID).toBe('@@MODULE_ID@@');
+  });
+
+  it('registers settings without throwing', () => {
+    expect(() => registerSettings()).not.toThrow();
+  });
+});
+"""
+
+
+# --------------------------------------------------------------------------- #
+# Docs templates
+# --------------------------------------------------------------------------- #
+README = """\
+# @@DISPLAY@@
+
+@@DESC@@
+
+A [FoundryVTT](https://foundryvtt.com/) module (v@@FVTT_MIN@@+; verified on
+v@@FVTT_VERIFIED@@), built with Vite + TypeScript.
+
+## Install
+
+In Foundry, **Add-on Modules → Install Module → Manifest URL**, paste:
+
+```
+https://github.com/@@PUBLISHER@@/@@NAME@@/releases/latest/download/module.json
+```
+
+## Development
+
+Requires [bun](https://bun.sh/). The local [foundryvtt-harness](https://github.com/@@PUBLISHER@@/foundryvtt-harness)
+(or any local Foundry on `:30000`) is the run/test environment.
+
+```
+bun install
+just check        # typecheck + build + lint + test (the CI gate)
+just dev          # Vite dev server with HMR, proxying to Foundry on :30000
+```
+
+To run inside Foundry, build and symlink `dist/` into your Foundry data:
+
+```
+just build
+ln -s "$(pwd)/dist" "<FoundryData>/Data/modules/@@MODULE_ID@@"
+```
+
+(`dist/` is git-ignored and rebuilt; the manifest, lang, styles@@README_TEMPLATES@@ are
+copied into it by the build.)
+
+## Releasing
+
+Conventional-commit `feat:` / `fix:` commits drive
+[release-please](https://github.com/googleapis/release-please): merging its
+release PR tags a version, bumps `package.json` **and** `module.json`, builds the
+module, zips `dist/`, and attaches `@@MODULE_ID@@.zip` + `module.json` to the
+GitHub release — which is what the manifest URL above resolves to.
+
+## License
+
+MIT — see [LICENSE](LICENSE).
+"""
+
+CLAUDE_MD = """\
+# @@DISPLAY@@ (`@@MODULE_ID@@`)
+
+@@CLAUDE_INTRO@@
+
+## Layout
+
+| Path | Role |
+|------|------|
+| `module.json` | The manifest. `id` = `@@MODULE_ID@@` and MUST match the install folder + zip name. release-please bumps `$.version` in lockstep with `package.json`. |
+| `src/module.ts` | ESM entry (`esmodules`). Registers hooks; built to `dist/@@MODULE_ID@@.mjs` by Vite. |
+| `src/settings.ts` | `game.settings` registration (called from `init`). |
+| `src/constants.ts` | `MODULE_ID` / `MODULE_TITLE` — the single source for the id. |
+| `src/foundry-shims.d.ts` | Loose ambient types for the Foundry globals. Keep `tsc` green; verify the real API before trusting a shape. |
+@@CLAUDE_LAYOUT_EXTRA@@| `lang/en.json` | Localization. Keys are namespaced under `@@MODULE_ID@@.`. |
+| `styles/@@MODULE_ID@@.css` | Styles, every selector scoped under `.@@MODULE_ID@@*`. |
+
+## Rules of the road
+
+- **Target the harness-pinned Foundry version.** The local `foundryvtt-harness`
+  pins a specific build; module behavior is version-specific. `module.json`
+  `compatibility.{minimum,verified}` is the manifest source of truth — keep it in
+  sync with what you actually test against, and bump the pin and the code
+  together.
+- **Verify the Foundry API before patching.** `game.*`, document classes, hooks,
+  and the `foundry.applications.*` namespaces change across major versions.
+  Check <https://foundryvtt.com/api/> or the live console — not memory.
+- **ESM only, paths must byte-match the manifest.** `esmodules` references
+  `@@MODULE_ID@@.mjs`; if the Vite output name drifts, the module silently fails
+  to load.
+- **Do not commit `dist/`.** It is a build artifact (git-ignored); CI builds it
+  for releases.
+- **`just check` is the gate.** Typecheck + build + lint + test must pass before
+  pushing.
+
+## Hooks
+
+`init` registers settings (and patches);@@CLAUDE_HOOKS_EXTRA@@ `ready` runs once
+`game.*` is populated. Settings are only readable from `setup` onward.
+"""
+
+ADR_0001 = """\
+# ADR-0001: Vite + bun + TypeScript toolchain for the FoundryVTT module
+
+- Status: Accepted
+- Date: @@DATE@@
+
+## Context
+
+FoundryVTT modules are ESM bundles loaded from a `module.json` manifest. We need
+a build that produces a single ESM file at a stable path, copies the manifest
+and static assets, type-checks our code, and distributes via GitHub releases.
+
+## Decision
+
+- **Vite library build** (`build.lib`, ESM) → `dist/@@MODULE_ID@@.mjs`, with
+  `vite-plugin-static-copy` placing `module.json`, `lang/`, `styles/`@@ADR_TEMPLATES@@
+  into `dist/`. The dev server proxies to Foundry on `:30000` with HMR.
+- **bun** as the package manager/runner; **biome** for lint + format; **Vitest**
+  for unit tests (Foundry globals stubbed in `tests/setup.ts`).
+- **TypeScript with local ambient shims** (`src/foundry-shims.d.ts`) rather than
+  the `fvtt-types` package, which is git-only and still beta for v13. The shims
+  keep the build self-contained and CI-green; richer types can be opted into
+  later by switching `tsconfig` `types` to `fvtt-types`.
+- **Distribution via GitHub release manifest URL**: `manifest` →
+  `releases/latest/download/module.json`, `download` →
+  `releases/latest/download/@@MODULE_ID@@.zip`. release-please bumps both
+  `package.json` and `module.json` `$.version`; the release job builds + zips +
+  attaches the assets.
+
+## Consequences
+
+- No foundryvtt.com submission is required to install by manifest URL (only to be
+  listed in the in-app package browser).
+- Foundry API types are loose — verify against the live API/docs before relying
+  on a shape. This is the deliberate trade for a self-contained, green build.
+"""
+
+
+# --------------------------------------------------------------------------- #
+# Generation
+# --------------------------------------------------------------------------- #
+def build_file_map(ctx: dict[str, str], variant: str) -> dict[str, str]:
+    app = variant == "app"
+    libwrapper = variant == "libwrapper"
+
+    ctx["BIOME_VERSION"] = BIOME_VERSION
+    ctx["TYPESCRIPT_VERSION"] = TYPESCRIPT_VERSION
+    ctx["VITE_VERSION"] = VITE_VERSION
+    ctx["VITE_STATIC_COPY_VERSION"] = VITE_STATIC_COPY_VERSION
+    ctx["VITEST_VERSION"] = VITEST_VERSION
+
+    # module.json relationships (libWrapper recommends) — empty otherwise.
+    ctx["RELATIONSHIPS"] = RELATIONSHIPS_LIBWRAPPER if libwrapper else ""
+
+    # Vite static-copy + README/ADR mentions of the templates/ dir (app only).
+    ctx["STATIC_COPY_TEMPLATES"] = STATIC_COPY_TEMPLATES if app else ""
+    ctx["README_TEMPLATES"] = ", templates" if app else ""
+    ctx["ADR_TEMPLATES"] = ", `templates/`" if app else ""
+
+    # module.ts variant wiring.
+    if libwrapper:
+        ctx["MODULE_IMPORTS"] = (
+            "\nimport { registerPatches, warnIfLibWrapperMissing } from './patches';"
+        )
+        ctx["INIT_BODY_EXTRA"] = "\n  registerPatches();"
+        ctx["READY_BODY_EXTRA"] = "\n  warnIfLibWrapperMissing();"
+    else:
+        ctx["MODULE_IMPORTS"] = ""
+        ctx["INIT_BODY_EXTRA"] = ""
+        ctx["READY_BODY_EXTRA"] = ""
+
+    # settings.ts variant wiring (registerMenu for the app variant).
+    if app:
+        ctx["SETTINGS_IMPORTS"] = (
+            f"\nimport {{ {ctx['MODULE_CLASS']}App }} from './app';"
+        )
+        ctx["SETTINGS_MENU"] = subst(SETTINGS_MENU_APP, ctx)
+    else:
+        ctx["SETTINGS_IMPORTS"] = ""
+        ctx["SETTINGS_MENU"] = ""
+
+    # lang extras (app menu/app strings).
+    ctx["LANG_EXTRA"] = subst(LANG_EXTRA_APP, ctx) if app else ""
+
+    # CLAUDE.md conditional fragments.
+    if app:
+        ctx["CLAUDE_INTRO"] = (
+            "A FoundryVTT v13 module with an ApplicationV2 UI panel, built with "
+            "Vite + TypeScript. The window opens from a settings-menu button "
+            "registered in `init`. See ADR-0001 for the toolchain."
+        )
+        ctx["CLAUDE_LAYOUT_EXTRA"] = (
+            f"| `src/app.ts` | The `{ctx['MODULE_CLASS']}App` ApplicationV2 window. |\n"
+            "| `templates/app.hbs` | Its Handlebars template (auto-loaded via `static PARTS`). |\n"
+        )
+        ctx["CLAUDE_HOOKS_EXTRA"] = ""
+    elif libwrapper:
+        ctx["CLAUDE_INTRO"] = (
+            "A FoundryVTT v13 module that patches a core method, built with Vite "
+            "+ TypeScript. Patches go through libWrapper when active, with a "
+            "manual monkey-patch fallback. See ADR-0001 for the toolchain."
+        )
+        ctx["CLAUDE_LAYOUT_EXTRA"] = (
+            "| `src/patches.ts` | libWrapper-guarded method patch + a manual "
+            "fallback. |\n"
+        )
+        ctx["CLAUDE_HOOKS_EXTRA"] = (
+            " `init` also calls `registerPatches()` (libWrapper registration must "
+            "happen at/after `init`);"
+        )
+    else:
+        ctx["CLAUDE_INTRO"] = (
+            "A FoundryVTT v13 module (settings + lifecycle hooks), built with "
+            "Vite + TypeScript. See ADR-0001 for the toolchain."
+        )
+        ctx["CLAUDE_LAYOUT_EXTRA"] = ""
+        ctx["CLAUDE_HOOKS_EXTRA"] = ""
+
+    files: dict[str, str] = {
+        "module.json": MODULE_JSON,
+        "package.json": PACKAGE_JSON,
+        "vite.config.ts": VITE_CONFIG,
+        "tsconfig.json": TSCONFIG,
+        "biome.json": BIOME_JSON,
+        "vitest.config.ts": VITEST_CONFIG,
+        ".gitignore": GITIGNORE,
+        ".gitattributes": GITATTRIBUTES,
+        "release-please-config.json": RP_CONFIG,
+        ".release-please-manifest.json": RP_MANIFEST,
+        "renovate.json": RENOVATE_JSON,
+        ".github/workflows/ci.yml": CI_YML,
+        ".github/workflows/release-please.yml": RELEASE_PLEASE_YML,
+        ".github/workflows/renovate.yml": RENOVATE_YML,
+        "justfile": JUSTFILE,
+        "LICENSE": LICENSE,
+        "README.md": README,
+        "CLAUDE.md": CLAUDE_MD,
+        "docs/adr/0001-vite-bun-typescript.md": ADR_0001,
+        "src/module.ts": MODULE_TS,
+        "src/settings.ts": SETTINGS_TS,
+        "src/constants.ts": CONSTANTS_TS,
+        "src/foundry-shims.d.ts": FOUNDRY_SHIMS,
+        "lang/en.json": LANG_BASE,
+        "styles/@@MODULE_ID@@.css": STYLES_CSS,
+        "tests/setup.ts": TEST_SETUP,
+        "tests/module.test.ts": TEST_MODULE,
+    }
+    if app:
+        files["src/app.ts"] = APP_TS
+        files["templates/app.hbs"] = APP_HBS
+    if libwrapper:
+        files["src/patches.ts"] = PATCHES_TS
+
+    # Substitute tokens in BOTH paths and bodies (the css filename carries one).
+    return {subst(path, ctx): subst(body, ctx) for path, body in files.items()}
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument(
+        "--name", required=True, help="GitHub repo name, e.g. foundryvtt-initiative-tweaks"
+    )
+    p.add_argument(
+        "--id",
+        default=None,
+        help="Foundry module id (lowercase kebab); default: --name without the "
+        "leading 'foundryvtt-'",
+    )
+    p.add_argument(
+        "--display", required=True, help='module title, e.g. "Initiative Tweaks"'
+    )
+    p.add_argument("--desc", required=True, help="one-line description")
+    p.add_argument("--variant", choices=VALID_VARIANTS, default="basic")
+    p.add_argument("--fvtt-min", default=FVTT_MIN_DEFAULT, help="compatibility.minimum")
+    p.add_argument(
+        "--fvtt-verified", default=FVTT_VERIFIED_DEFAULT, help="compatibility.verified"
+    )
+    p.add_argument("--publisher", default=PUBLISHER_DEFAULT)
+    p.add_argument("--author", default=AUTHOR_DEFAULT)
+    p.add_argument(
+        "--dir", default=".", help="parent directory to create the module in (default: cwd)"
+    )
+    args = p.parse_args()
+
+    ctx = derive(args.name, args.id)
+    ctx.update(
+        DISPLAY=args.display,
+        DESC=args.desc,
+        PUBLISHER=args.publisher,
+        AUTHOR=args.author,
+        FVTT_MIN=args.fvtt_min,
+        FVTT_VERIFIED=args.fvtt_verified,
+        YEAR=str(datetime.date.today().year),
+        DATE=datetime.date.today().isoformat(),
+    )
+
+    parent = Path(args.dir).resolve()
+    target = parent / args.name
+    if target.exists():
+        print(f"error: {target} already exists — refusing to overwrite", file=sys.stderr)
+        return 1
+
+    file_map = build_file_map(ctx, args.variant)
+    for rel, content in file_map.items():
+        dest = target / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content)
+
+    n = len(file_map)
+    print(f"\nScaffolded {args.name} (id: {ctx['MODULE_ID']}, {args.variant}) — {n} files in {target}")
+    print(
+        "\nNext steps:\n"
+        f"  cd {target}\n"
+        "  git init -b main                # seed main directly (no branch juggling)\n"
+        "  bun install                     # TypeScript, Vite, biome, Vitest (writes bun.lock)\n"
+        "  just check                      # typecheck + build + lint + test should pass green\n"
+        "\nThen:\n"
+        + (
+            "  - build the panel in src/app.ts + templates/app.hbs\n"
+            if args.variant == "app"
+            else "  - implement the patch in src/patches.ts (replace the Token._draw example)\n"
+            if args.variant == "libwrapper"
+            else "  - implement the module logic in src/module.ts + src/settings.ts\n"
+        )
+        + "  - add the repo to gitops/repositories.tf with release_please = true and a\n"
+        "    'foundryvtt' topic (gitops pushes the release-please App credentials)\n"
+        "  - or run the /foundryvtt-module orchestrator, which does the gitops wiring\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/foundryvtt-plugin/skills/foundryvtt-module/SKILL.md
+++ b/foundryvtt-plugin/skills/foundryvtt-module/SKILL.md
@@ -1,0 +1,294 @@
+---
+created: 2026-06-26
+modified: 2026-06-26
+reviewed: 2026-06-26
+name: foundryvtt-module
+description: >-
+  FoundryVTT module idea to gitops-adopted repo: scaffold, create + seed the
+  repo, open the gitops adoption PR. Use when releasing or spinning up a new
+  foundry module.
+allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite, AskUserQuestion
+---
+
+# foundryvtt-module
+
+Take a FoundryVTT **module idea** and drive it from empty to release-ready,
+collapsing the manual repo-creation + gitops wiring into one orchestrated pass
+with a single human approval gate.
+
+This is the orchestrator around the `foundryvtt-module-scaffold` skill (which
+only generates the local repo). Use `foundryvtt-module-scaffold` alone if you
+just want the files; use **this** when you want the GitHub repo created, pushed,
+and adopted into gitops too.
+
+## When to Use This Skill
+
+| Use this skill when... | Use the alternative when... |
+|---|---|
+| The user gives an idea and wants the whole pipeline stood up — repo created, seeded, and gitops-adopted | You only want the local files → `foundryvtt-module-scaffold` |
+| Spinning up a new FoundryVTT module end to end | Adding a feature to an *existing* module → edit that repo directly |
+
+Do **not** use it to add a feature to an existing module, or to publish a release
+(release-please + the release workflow automate that once the repo exists).
+
+## The shape it automates
+
+```mermaid
+flowchart LR
+  idea["idea"] --> sc["scaffold.py"] --> gh["gh repo create<br/>+ seed main"] --> gop["gitops PR<br/>(entry + import block)"]
+  gop --> gate["👤 merge gitops PR"] --> apply["Scalr apply:<br/>adopt + release-please<br/>creds + protection"] --> rm["remove import block"] --> impl["implement + release"]
+  classDef g fill:#1b4332,stroke:#2d6a4f,color:#fff
+  classDef m fill:#6a040f,stroke:#9d0208,color:#fff
+  class sc,gh,gop,apply,rm g
+  class gate,impl m
+```
+
+Everything left of the gate is one orchestrated pass. There is **no scaffold
+PR** — the seed goes straight to `main` (the repo is unprotected until adoption).
+The single gate (merging the gitops PR) is intentionally human — it triggers an
+infra `apply` on shared state. Never merge it on the user's behalf.
+
+## Preconditions
+
+- Run from the FoundryVTT workspace (`repos/laurigates/foundryvtt-dev/`) so the
+  new repo lands as a sibling of `foundryvtt-mcp` / `foundryvtt-mediasoup-webrtc`.
+- `gh auth status` is a **personal** account that can create repos. The gitops
+  GitHub App *cannot* create repos on user accounts — that is why the repo is
+  created out-of-band here and then imported into Terraform state.
+- The gitops repo is clean (no uncommitted `repositories.tf` / `main.tf`
+  changes) so the orchestrator's gitops PR is isolated.
+
+## Phase 0 — Derive and confirm the spec
+
+From the idea, derive and **show the user** before creating anything external:
+
+| Field | How to derive | Example |
+|-------|---------------|---------|
+| `--name` | `foundryvtt-<kebab>` (the GitHub repo). | `foundryvtt-initiative-tweaks` |
+| `--id` | Foundry module id; default = `--name` minus `foundryvtt-`. | `initiative-tweaks` |
+| `--display` | Title-case. | `Initiative Tweaks` |
+| `--desc` | One line, manifest-facing. | `Small quality-of-life tweaks to the combat initiative tracker.` |
+| `--variant` | `app` for a UI window; `libwrapper` to patch a core method; else `basic`. | `basic` |
+| `--fvtt-verified` | The major Foundry version the harness pins. | `13` |
+| topics | `["foundryvtt", "module", …]` + facet tags. | `…,"combat","initiative"` |
+
+Confirm the **name, id, and variant** with the user — these are hard to change
+after the repo exists.
+
+## Phase 1 — Preflight (fail fast if the name is taken)
+
+```sh
+test ! -e foundryvtt-initiative-tweaks && echo "local: free" || echo "local: EXISTS"
+```
+
+```sh
+grep -q '"foundryvtt-initiative-tweaks"' ../gitops/repositories.tf && echo "gitops: EXISTS" || echo "gitops: free"
+```
+
+```sh
+gh repo view laurigates/foundryvtt-initiative-tweaks >/dev/null 2>&1 && echo "github: EXISTS" || echo "github: free"
+```
+
+All three must report free. Stop and surface any collision. (The `../gitops`
+path assumes the foundryvtt-dev workspace layout; adjust if the gitops clone is
+elsewhere.)
+
+## Phase 2 — Scaffold + local green check
+
+```sh
+python3 ${CLAUDE_SKILL_DIR}/../foundryvtt-module-scaffold/scaffold.py --name foundryvtt-initiative-tweaks --display "Initiative Tweaks" --desc "Small quality-of-life tweaks to the combat initiative tracker." --variant basic
+```
+
+Then bring the module to green locally:
+
+```sh
+cd foundryvtt-initiative-tweaks
+```
+
+```sh
+git init -b main
+```
+
+```sh
+bun install
+```
+
+```sh
+just check
+```
+
+`just check` (typecheck + build + lint + test) must pass before anything is
+pushed. `bun install` writes `bun.lock` — it must be in the seed commit (CI uses
+`--frozen-lockfile`). If `just check` fails, fix locally and re-run — do not
+create the remote repo on a red module.
+
+## Phase 3 — Create the GitHub repo and seed `main`
+
+Seed `main` **directly** as the first commit — no scaffold branch, no PR. The
+repo has no branch protection yet (gitops adds it on adoption in Phase 5), so
+this is allowed, and it avoids the missing-`main`/rename juggling a feature-branch
+first push would cause. Implementation work afterward goes through feature-branch
+PRs as normal.
+
+```sh
+git add -A
+```
+
+```sh
+git commit -m "feat: scaffold foundryvtt-initiative-tweaks (basic module)"
+```
+
+```sh
+gh repo create laurigates/foundryvtt-initiative-tweaks --public --source . --remote origin --push
+```
+
+> **Branch-protection hook note (expect this):** in a Claude Code session the
+> `branch-protection` hook **will** block the agent from `git add`/`commit` on
+> `main` for a brand-new, not-yet-protected repo (a false positive). Hand the
+> whole seed to the user as one paste-safe line to run with the `! ` prefix:
+>
+> ```
+> cd <repo> && git add -A && git commit -m "feat: scaffold <name> (<variant> module)" && gh repo create laurigates/<name> --public --source . --remote origin --push
+> ```
+>
+> Do **not** work around it by seeding a feature branch — that reintroduces the
+> missing-`main`/rename juggling this phase exists to avoid.
+
+The `--push` makes the seeded `main` the default branch.
+
+## Phase 4 — Open the gitops PR (entry + transient import block)
+
+Two edits in the `gitops/` repo, on a dedicated branch.
+
+**`gitops/repositories.tf`** — add to the active repositories `locals` block,
+next to the other `foundryvtt-*` entries (mirror `foundryvtt-mcp`):
+
+```hcl
+    "foundryvtt-initiative-tweaks" = {
+      description    = "Small quality-of-life tweaks to the combat initiative tracker"
+      visibility     = "public"
+      release_please = true
+      topics         = ["foundryvtt", "module", "combat", "initiative"]
+    }
+```
+
+**`gitops/main.tf`** — add a transient `import` block alongside the existing
+ones at the top of the file:
+
+```hcl
+import {
+  to = github_repository.this["foundryvtt-initiative-tweaks"]
+  id = "foundryvtt-initiative-tweaks"
+}
+```
+
+FoundryVTT modules distribute via GitHub releases — there is **no registry flag**
+(unlike comfy packs' `comfy_registry`). The only adoption flag is
+`release_please = true`, which makes gitops push the release-please App
+credentials on apply.
+
+Validate, branch, commit, push, open the PR (run inside `gitops/`):
+
+```sh
+just check
+```
+
+```sh
+git -C ../gitops switch -c feat/adopt-foundryvtt-initiative-tweaks
+```
+
+```sh
+git -C ../gitops add repositories.tf main.tf
+```
+
+```sh
+git -C ../gitops commit -m "feat: adopt foundryvtt-initiative-tweaks"
+```
+
+```sh
+git -C ../gitops push -u origin feat/adopt-foundryvtt-initiative-tweaks
+```
+
+```sh
+gh pr create -R laurigates/gitops -a laurigates -l chore -l opentofu --title "feat: adopt foundryvtt-initiative-tweaks" --body-file /tmp/gitops-pr-body.md
+```
+
+Write a short body (to `/tmp/gitops-pr-body.md`) rather than `--fill` — it's an
+infra PR that triggers an apply, so spell out what merge does: imports the repo,
+pushes the release-please App credentials, applies the branch-protection ruleset,
+and that a follow-up PR removes the import block. Use labels `chore` + `opentofu`
+(check `gh label list -R laurigates/gitops` if unsure). Set metadata per
+`github-metadata-hygiene` (assignee `laurigates`; skip self-reviewer — the author
+is the running user). Scalr posts a `plan` check; the expected plan **imports**
+the repo and **creates** the release-please var/secret + branch-protection
+ruleset.
+
+## Phase 5 — Human gate, then finish
+
+Hand the user the new repo URL and the **gitops PR** URL. **The user merges the
+gitops PR** — that is the Scalr `apply` trigger on shared infra state. Do not
+merge it for them.
+
+After the user confirms the Scalr apply landed, verify the release-please
+credentials and remove the now-dead import block:
+
+```sh
+gh api repos/laurigates/foundryvtt-initiative-tweaks/actions/variables/RELEASE_PLEASE_APP_ID --jq .name
+```
+
+The variable lookup should return its name. Then open the import-block-removal
+follow-up PR:
+
+```sh
+git -C ../gitops switch -c chore/remove-foundryvtt-initiative-tweaks-import
+```
+
+Remove the `import { … "foundryvtt-initiative-tweaks" … }` block from `main.tf`,
+then:
+
+```sh
+git -C ../gitops commit -am "chore: remove one-time import block for foundryvtt-initiative-tweaks"
+```
+
+```sh
+git -C ../gitops push -u origin chore/remove-foundryvtt-initiative-tweaks-import
+```
+
+```sh
+gh pr create -R laurigates/gitops -a laurigates -l chore --fill --title "chore: remove foundryvtt-initiative-tweaks import block"
+```
+
+## Phase 6 — Hand back to implementation
+
+The pipeline is now live: conventional-commit feature PRs → merge →
+release-please PR → merge → tag → the release workflow builds, zips `dist/`, and
+attaches `<id>.zip` + `module.json` to the GitHub release (the manifest URL).
+Tell the user what's left:
+
+- Implement the module logic (`basic`: `src/module.ts` + `src/settings.ts`;
+  `app`: `src/app.ts` + `templates/app.hbs`; `libwrapper`: replace the
+  `Token._draw` example in `src/patches.ts`).
+- Test against the local `foundryvtt-harness` (`bun run dev`, or build + symlink
+  `dist/` into the harness's `Data/modules/<id>`). Keep `module.json`
+  `compatibility` in sync with the harness-pinned Foundry version.
+- First merged `feat:`/`fix:` commits drive the first release-please PR.
+
+Log durable follow-ups to the user's FoundryVTT taskwarrior project per
+`taskwarrior-cross-session`.
+
+## Failure modes & guards
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| release-please job fails on empty `app-id` | release-please credentials not yet applied | Confirm the Scalr apply landed; `gh api … variables/RELEASE_PLEASE_APP_ID` returns a name; re-run via `workflow_dispatch` |
+| `403 Resource not accessible by integration` on repo create | Tried to create via the gitops App, not a personal token | Create with personal `gh auth`; the App only adopts via import |
+| Scalr plan shows a *create* (not *import*) for the repo | Import block missing or `id` wrong | The `id` is the bare repo name, not `owner/name`; add/fix the import block |
+| `just check` red in gitops | `tofu fmt`/`validate` failure | `just format` then re-check before pushing |
+| Module fails to load in Foundry | `esmodules` path ≠ Vite output, or `id` ≠ folder | The scaffold pins these; confirm `dist/<id>.mjs` exists and the install folder is `<id>` |
+
+## Notes
+
+- The orchestrator never runs `tofu apply` — all applies go through Scalr on
+  merge (see `gitops/CLAUDE.md`). Local gitops work is `plan`/`validate` only.
+- Playwright integration tests against the harness and a Quench in-Foundry suite
+  are not scaffolded; add them later if the module warrants them.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -629,6 +629,39 @@
         }
       ]
     },
+    "foundryvtt-plugin": {
+      "component": "foundryvtt-plugin",
+      "release-type": "simple",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        }
+      ],
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance"
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactoring"
+        },
+        {
+          "type": "docs",
+          "section": "Documentation"
+        }
+      ]
+    },
     "git-plugin": {
       "component": "git-plugin",
       "release-type": "simple",


### PR DESCRIPTION
## Summary

A new `foundryvtt-plugin` that bootstraps FoundryVTT v13 **modules** end-to-end, mirroring `comfyui-plugin`'s scaffold + orchestrator shape. Two skills:

- **`foundryvtt-module-scaffold`** — a stdlib-only `scaffold.py` that generates a CI-green **Vite + TypeScript + bun + biome** module repo in three variants:
  - `basic` — `init`/`ready` hooks, a registered world setting, i18n, scoped CSS
  - `app` — an `ApplicationV2`/`HandlebarsApplicationMixin` window + a settings-menu button (Foundry v13 UI)
  - `libwrapper` — a `libWrapper`-guarded core-method patch with a manual fallback + `relationships.recommends`
- **`foundryvtt-module`** — the orchestrator (idea → scaffold → green check → `gh repo create` + seed `main` → gitops adoption PR → human gate → finish), adapted from `comfy-node`.

## Design notes

- **Distribution** is by GitHub-release manifest URL (`releases/latest/download/module.json` + `<id>.zip`); release-please bumps both `package.json` and `module.json` `$.version`, and the release job zips `dist/` and attaches the assets. No foundryvtt.com submission needed to install by URL.
- **TypeScript globals** are typed by local ambient shims (`src/foundry-shims.d.ts`) rather than the beta, git-only `fvtt-types` — keeps the generated build self-contained and CI-green. Documented opt-in to `fvtt-types` for richer types.
- **No registry flag** in gitops (unlike comfy's `comfy_registry`): foundry modules distribute via GitHub releases, so adoption is just `release_please = true` + `foundryvtt` topics.
- Conventions verified against current FoundryVTT v13 + Vite docs (ApplicationV2 namespace, `relationships`, libWrapper, `vite-plugin-static-copy`).

## Verification

Generated all three variants and ran the full gate on each — **typecheck + build + lint + test all green**. Biome's exact formatting baked into the templates so generated repos pass `biome check` with zero writes. All repo compliance checks pass (plugin-compliance ✅×8, enablement-drift OK, description audit, docs-index).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
