### PR TITLE
chore: remove stray root-level fix-check-docs-index.sh

### DIFF
--- a/fix-check-docs-index.sh
+++ b/fix-check-docs-index.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-# Adding the new skills into README.md
-sed -i 's/taskwarrior-plugin.*| 6 |/taskwarrior-plugin | 8 |/' README.md
-sed -i 's/taskwarrior\\n6 skills/taskwarrior\\n8 skills/' docs/diagrams/plugin-relationships.d2


### PR DESCRIPTION
## Summary

Removes `fix-check-docs-index.sh` — a one-off `sed` fixup script accidentally committed to the **repo root** in #1828. It bumped the taskwarrior skill count 6→8 in `README.md` and `docs/diagrams/plugin-relationships.d2`.

## Why it's safe to delete
- **Its edits already landed** — both `README.md` and `plugin-relationships.d2` show `8` today.
- **Referenced nowhere** — `grep -rn fix-check-docs-index` across the repo returns nothing (no CI, justfile, or pre-commit reference).
- **Recoverable** — it's in git history (added in #1828) if ever needed.

## Why it should go
Its non-compliant `#!/bin/bash` shebang fails the repo-wide `lint-shell-scripts` pre-commit gate (wired in #1776) on **every** commit, regardless of what you're changing. Count drift is the job of `scripts/check-docs-index.sh` + the `docs-refresh` skill, not a checked-in throwaway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)