### PR TITLE
fix(hooks-plugin): exempt log-stream pipelines from grep-chain scrape detectors

### DIFF
--- a/hooks-plugin/hooks/bash-antipatterns.sh
+++ b/hooks-plugin/hooks/bash-antipatterns.sh
@@ -275,10 +275,40 @@ fi
 # || operators first so regex-alternation literals (grep -E '(a|b|c)') and
 # format-string pipes (curl -w '… | …') are not counted as shell pipes (the
 # bogus "8 pipes" miscount in issue #1592).
+#
+# Log-stream sources — `kubectl logs`, `journalctl`, `docker logs`, `stern`, … —
+# emit an unstructured text stream with no --json/jq alternative, so
+# `… | grep <inc> | grep -v <exc> | tail` is the *idiomatic* read path during
+# incident diagnosis, not a data-processing scrape to nudge away from. Detect the
+# log-stream head once and exempt these pipelines from the grep-chain scrape
+# detectors (this block's `grep | grep` clause and the multi-grep chain block
+# below) — issue #1833. The `<tool> logs` arm requires the `logs` subcommand to
+# sit in the same pipe segment as a known log-producing CLI (`[^|]*[[:space:]]logs`)
+# so an unrelated `ls logs/` does not match. The cat/echo/printf scrape head and
+# the `ps … | grep … | grep -v grep` process-scrape (issue #1603) are NOT
+# log streams, so they keep firing.
+LOG_STREAM_RE='\b(journalctl|stern)\b|\b(kubectl|oc|docker|podman|nerdctl|nomad|heroku|gcloud|crictl|flyctl|fly|k)\b[^|]*[[:space:]]logs\b'
+IS_LOG_STREAM=false
+if echo "$COMMAND_SHELL_ONLY" | grep -Eq "$LOG_STREAM_RE"; then
+    IS_LOG_STREAM=true
+fi
+
 PIPE_BODY=$(echo "$COMMAND_SHELL_ONLY" | sed "s/'[^']*'//g; s/\"[^\"]*\"//g; s/||//g")
 PIPE_COUNT=$(echo "$PIPE_BODY" | tr -cd '|' | wc -c)
-if [ "$PIPE_COUNT" -ge 5 ] && \
-   echo "$PIPE_BODY" | grep -Eq '\b(cat|echo|printf)[[:space:]][^|]*\||grep\b[^|]*\|[^|]*grep\b'; then
+
+# A discouraged head is a cat/echo/printf source OR a redundant `grep | grep`
+# text-scrape. A log-stream-sourced pipeline is neither — its grep stages filter
+# an unstructured stream that has no structured alternative — so the grep | grep
+# clause is suppressed for log streams (issue #1833). The cat/echo/printf head
+# still fires regardless (a log stream never has one).
+DISCOURAGED_HEAD=false
+if echo "$PIPE_BODY" | grep -Eq '\b(cat|echo|printf)[[:space:]][^|]*\|'; then
+    DISCOURAGED_HEAD=true
+elif [ "$IS_LOG_STREAM" = false ] && echo "$PIPE_BODY" | grep -Eq 'grep\b[^|]*\|[^|]*grep\b'; then
+    DISCOURAGED_HEAD=true
+fi
+
+if [ "$PIPE_COUNT" -ge 5 ] && [ "$DISCOURAGED_HEAD" = true ]; then
     block "REMINDER: This command has $PIPE_COUNT pipes fed from a discouraged head
 stage (cat/echo/printf, or a redundant grep | grep) - consider simplifying:
 - Use JSON output from the source (--reporter=json, --format=json) and parse with jq
@@ -293,7 +323,14 @@ fi
 
 # Check for multi-grep chains parsing test/task output
 # Pattern: grep ... | grep ... with sed/cut suggests parsing structured output as text
-if echo "$COMMAND" | grep -Eq 'grep.*\|.*grep.*\|.*(sed|cut|awk)' && \
+#
+# Exempt log-stream sources (kubectl logs / journalctl / docker logs / …): an
+# unstructured log stream has no structured-output alternative, so a
+# `grep | grep -v | sed | tail` over it is the idiomatic incident-diagnosis read,
+# and the Error/fail tokens this keys on are exactly what log diagnostics search
+# for (issue #1833). IS_LOG_STREAM is computed in the pipe-count block above.
+if [ "$IS_LOG_STREAM" = false ] && \
+   echo "$COMMAND" | grep -Eq 'grep.*\|.*grep.*\|.*(sed|cut|awk)' && \
    echo "$COMMAND" | grep -Eq '(\.output|/tasks/|Error|fail|FAIL)'; then
     block "REMINDER: Parsing test output with grep chains is fragile. Better alternatives:
 - Use --reporter=json (Bun, Vitest, Jest) and parse with jq

--- a/hooks-plugin/hooks/test-bash-antipatterns.sh
+++ b/hooks-plugin/hooks/test-bash-antipatterns.sh
@@ -532,6 +532,47 @@ assert_exit \
     "redundant grep | grep | sed | cut | sort chain is still blocked" 2 \
     "ps aux | grep proc | grep -v grep | awk '{print \$2}' | sort | uniq"
 
+# ── log-stream sources exempt from grep-chain scrape detectors (issue #1833) ──
+# Regression: read-only log-diagnostic pipelines — `kubectl logs … | grep <inc>
+# | grep -v <exc> | tail`, `journalctl … | grep | grep -v | sed`, `docker logs …`
+# — fired the grep-chain scrape detectors (the pipe-count "redundant grep | grep"
+# block and the multi-grep chain block) during incident diagnosis. A log stream
+# is unstructured text with no --json/jq alternative, so filter+exclude+tail is
+# the idiomatic read path, not a data-processing antipattern. These must pass;
+# the cat/echo/printf scrape head and the `ps … | grep | grep -v grep` process
+# scrape (above) must STILL block.
+echo ""
+echo "log-stream pipelines (kubectl logs/journalctl/docker logs) are exempt; non-log scrapes still block (#1833):"
+
+assert_exit_complex \
+    "kubectl logs | grep -iE | grep -ivE | tail (issue exact repro) is allowed" 0 \
+    'kubectl logs -n ns pod --since=6m 2>&1 | grep -iE "ephemeral|proof|403|Forbidden" | grep -ivE "git/config|HTTP 401 error at path" | tail -15'
+
+assert_exit_complex \
+    "kubectl logs grep|grep|sed chain with 'Error' is allowed (multi-grep block exempt)" 0 \
+    'kubectl logs -n ns pod --since=6m 2>&1 | grep -iE "Error|Forbidden" | grep -ivE "git/config" | sed s/x/y/ | tail -15'
+
+assert_exit_complex \
+    "kubectl logs 5-pipe grep|grep is allowed (pipe-count block exempt)" 0 \
+    'kubectl logs -n ns pod 2>&1 | grep -iE "ephemeral|403" | grep -ivE "noise" | grep -v other | cut -f1 | tail -15'
+
+assert_exit_complex \
+    "journalctl | grep | grep -v | sed chain is allowed" 0 \
+    'journalctl -u svc --since "6 min ago" | grep -i fail | grep -v ignore | sed s/a/b/ | tail'
+
+assert_exit_complex \
+    "docker logs | grep | grep -v | sed chain is allowed" 0 \
+    'docker logs mycontainer 2>&1 | grep -i error | grep -v healthcheck | sed s/a/b/ | tail'
+
+# Guard integrity: the log-stream exemption must NOT weaken the non-log scrapes.
+assert_exit \
+    "GUARD: ps aux | grep | grep -v grep process scrape still blocks (#1833)" 2 \
+    "ps aux | grep proc | grep -v grep | sed s/a/b/ | cut -f1 | sort"
+
+assert_exit \
+    "GUARD: cat-headed grep|grep|sed scrape over a file still blocks (#1833)" 2 \
+    "cat r.txt | grep Error | grep -v warn | sed s/a/b/ | tail"
+
 # ── grep block message offers the pipe fallback (issue #1602) ─────────────────
 # Regression: when the Grep tool is unavailable in a session, the block message
 # pointed only at Grep(...). It must also offer the always-allowed pipe form.


### PR DESCRIPTION
## Summary

Closes #1833.

`hooks-plugin`'s `bash-antipatterns.sh` PreToolUse hook fired on **read-only
log-diagnostic pipelines** during incident diagnosis (~4× in one session),
forcing command splits / write-to-file detours mid-investigation:

```sh
kubectl logs -n <ns> <pod> --since=6m 2>&1 \
  | grep -iE "ephemeral|proof|403|Forbidden" \
  | grep -ivE "git/config|HTTP 401 error at path" \
  | tail -15
```

A log stream is **unstructured text with no `--json`/`jq` alternative**, so
`grep <include> | grep -v <exclude> | tail` is the *idiomatic* read path, not
a data-processing scrape the hook should nudge away from.

## Root cause

Two grep-chain scrape detectors mis-fired on log streams:

1. The **pipe-count** block (`≥5 pipes` + "redundant `grep | grep`" head) — the
   wording the issue quotes.
2. The **multi-grep chain** block (`grep | grep | sed` + an `Error|fail|FAIL`
   token) — log diagnostics search for exactly those tokens, so it co-triggers.

## Fix

A single `IS_LOG_STREAM` discriminator detects a log-stream head
(`journalctl`/`stern`, or a `logs` subcommand on a known container/k8s CLI —
`kubectl|oc|docker|podman|nerdctl|nomad|heroku|gcloud|crictl|flyctl|fly|k` — in
the same pipe segment), and gates **both** detectors on it.

Deliberately **not** weakened:

- The `cat`/`echo`/`printf` scrape head still fires (a log stream never has one).
- The `ps … | grep | grep -v grep` process scrape (#1603 guard) still fires —
  `ps` is not a log stream. This is why the fix keys on the *source*, not on the
  presence of `grep -v` (which would have broken that guard).

The `<tool> logs` arm requires `logs` to sit in the same pipe segment as a known
CLI, so an unrelated `ls logs/` is not treated as a log stream.

## Tests

New `#1833` regression section in `test-bash-antipatterns.sh` — 7 cases:
the issue's exact repro, the multi-grep and pipe-count paths, `journalctl`,
`docker logs`, plus two **guard-integrity** cases (`ps aux` scrape and a
cat-headed file scrape must stay blocked).

- `bash hooks-plugin/hooks/test-bash-antipatterns.sh` → **96 passed, 0 failed**
- `shellcheck` clean; `scripts/lint-shell-scripts.sh` → 0 errors/0 warnings
- sibling teach (24/24) and git-env-isolation (3/3) suites green

🤖 Generated with [Claude Code](https://claude.com/claude-code)