### PR TITLE
feat(comfyui-plugin): add standalone-modal scaffold variant for no-widgets packs

### DIFF
--- a/comfyui-plugin/skills/comfyui-node-scaffold/SKILL.md
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-06-04
-modified: 2026-06-06
-reviewed: 2026-06-06
+modified: 2026-06-28
+reviewed: 2026-06-28
 name: comfyui-node-scaffold
 description: >-
   Scaffold a new ComfyUI custom-node repo (TypeScript + bun build, CI,
@@ -67,11 +67,26 @@ inputs, big tap targets, momentum scroll). The modal primitives come from
 | `backend` | Needs to read disk / serve thumbnails / add a node (model thumbnails, file listings). | Adds `<module>.py` (node + aiohttp endpoints, ComfyUI-bundled libs only) + a `tests/conftest.py` that stubs aiohttp/server so pytest is green. Like gallery-loader. | **imports** the kit |
 | `gesture` | The UX is a **canvas interaction**, not a widget — pinch/drag/long-press on nodes or groups (resize, move, region-box). | Empty `NODE_CLASS_MAPPINGS`; a canvas pointer layer in `src/index.ts` with exported pure geometry helpers. Like touch-resize. | **no kit** |
 
-**Decision rule:** `frontend` for a per-widget modal; `gesture` when the
-interaction is on the canvas/node frame itself (no widget to hook); `backend`
-only when the feature genuinely needs the server to read files or serve data. A
-non-bundled Python dependency is never allowed — if you reach for one, it
-belongs in a separate companion pack.
+**The `--widgets` switch picks the modal shape.** On a modal variant
+(`frontend` / `backend`), passing `--widgets a,b` emits the **widget-intercept**
+`src/index.ts` (`TARGET_WIDGETS` + `openPicker` + `widget.onPointerDown`).
+**Omitting `--widgets`** emits a **standalone-modal** `src/index.ts` instead — a
+`registerExtension` skeleton with an `actionBarButtons` entry + a
+`command`/`menuCommand` that calls an exported `openShell()` (no `TARGET_WIDGETS`,
+no per-widget hook). Use the standalone skeleton for a manager / dashboard /
+gallery-actions panel whose modal is launched from the app chrome rather than a
+node widget (e.g. comfyui-touch-manager). It still imports the modal kit, and it
+ships a **jsdom modal-mount smoke test** (`jsdom` added to `devDependencies`)
+that asserts `openShell()` populates the modal body — the empty-modal gap that
+otherwise passes pure-helper unit tests.
+
+**Decision rule:** `frontend`/`backend` **with** `--widgets` for a per-widget
+modal; `frontend`/`backend` **without** `--widgets` for a standalone modal opened
+from the toolbar/command palette; `gesture` when the interaction is on the
+canvas/node frame itself (no widget to hook). Add `backend` only when the feature
+genuinely needs the server to read files or serve data. A non-bundled Python
+dependency is never allowed — if you reach for one, it belongs in a separate
+companion pack.
 
 The `gesture` variant intercepts the **canvas pointer stream** (capture-phase
 `pointerdown`/`move`/`up` on `app.canvas.canvas`), hit-tests against selected
@@ -98,6 +113,13 @@ Pack with a Python backend:
 python3 ${CLAUDE_SKILL_DIR}/scaffold.py --name comfyui-model-gallery --display "Model Gallery" --desc "Touch-first card-grid picker for the folder-backed model combos." --variant backend --widgets lora_name,ckpt_name,vae_name,control_net_name
 ```
 
+Standalone-modal pack (manager/dashboard launched from a toolbar button — modal
+variant, **no** `--widgets`):
+
+```sh
+python3 ${CLAUDE_SKILL_DIR}/scaffold.py --name comfyui-touch-manager --display "Touch Manager" --desc "Touch-first node/extension manager modal opened from the toolbar." --variant backend
+```
+
 Canvas-gesture pack (resize/move/region — no widget, no modal, no kit):
 
 ```sh
@@ -106,8 +128,9 @@ python3 ${CLAUDE_SKILL_DIR}/scaffold.py --name comfyui-touch-resize --display "T
 
 Flags: `--name` (repo + served URL segment), `--display` (Comfy DisplayName),
 `--desc`, `--variant {frontend,backend,gesture}`, `--widgets` (CSV → the TS
-stub's `TARGET_WIDGETS`; modal variants only), `--publisher` (default
-`laurigates`), `--dir` (parent dir, default cwd).
+stub's `TARGET_WIDGETS`; on a modal variant, **omitting** it emits the
+standalone-modal skeleton instead of the widget-intercept one), `--publisher`
+(default `laurigates`), `--dir` (parent dir, default cwd).
 
 It refuses to overwrite an existing directory.
 

--- a/comfyui-plugin/skills/comfyui-node-scaffold/scaffold.py
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/scaffold.py
@@ -67,6 +67,11 @@ MODAL_KIT_VERSION = "^0.2.0"
 # every generated biome pin stays on this single version.
 BIOME_VERSION = "2.4.15"
 COMFY_FRONTEND_TYPES_VERSION = "^1.43.0"
+# jsdom is added to devDependencies ONLY for the standalone-modal variant, whose
+# smoke test mounts the modal under a DOM (`@vitest-environment jsdom`). The
+# widget/gesture variants test pure helpers under the node environment and don't
+# need it. See issue #1806.
+JSDOM_VERSION = "^29.0.0"
 
 
 # --------------------------------------------------------------------------- #
@@ -395,6 +400,114 @@ app.registerExtension({
 export function clampToTargets(name: string): boolean {
   return TARGET_WIDGETS.has(name);
 }
+"""
+
+# --------------------------------------------------------------------------- #
+# TypeScript source — standalone-modal variant (modal kit, NO target widgets)
+# Used when a modal variant is scaffolded with no --widgets: the UI is a modal
+# launched from the app chrome (a manager / dashboard / gallery-actions panel),
+# not a per-widget interception. No TARGET_WIDGETS / openPicker / enhanceNode.
+# --------------------------------------------------------------------------- #
+INDEX_TS_STANDALONE = """\
+// @@DISPLAY@@ — ComfyUI frontend extension (standalone-modal pack).
+//
+// TypeScript source in `src/`, built to ESM via `bun build` and emitted to
+// `web/dist/` (served at /extensions/@@NAME@@/index.js — the pack directory
+// name IS the URL segment). Do not rename the pack dir without syncing
+// EXT_NAME below (used for log prefixes and any /@@PY_MODULE@@/ fetches).
+// See ADR-0001.
+//
+// Pattern ("the standalone-modal vein"): instead of intercepting a per-node
+// widget, this pack opens a STANDALONE modal from the app chrome — an action-bar
+// button plus a command (palette/hotkey-bindable) and a menu entry. There are
+// NO target widgets to hook (a manager, dashboard, or gallery-actions panel),
+// so there is no TARGET_WIDGETS / onPointerDown wrapping. Additive + mobile-first.
+//
+// The shared modal primitives come from @@MODAL_KIT_PKG@@. They are NOT copied
+// into this pack — `bun build` INLINES the imported code into web/dist. To add
+// fuzzy search to the modal, import the matcher from the same package:
+//   import { fuzzyRank, highlightMatches } from "@@MODAL_KIT_PKG@@";
+//   fuzzyRank(query, [primaryField, ...otherFields]) -> { score, primaryMatches } | null
+import { openModalShell } from "@@MODAL_KIT_PKG@@";
+// ComfyUI serves its frontend API at runtime from `/scripts/app.js`. The
+// emitted import string stays `/scripts/app.js` (bun's `--external '/scripts/*'`
+// keeps it unbundled); the type is supplied via a `paths` mapping in
+// tsconfig.json that points the import at `src/comfyui-shims.d.ts`. See ADR-0001.
+import { app } from "/scripts/app.js";
+
+const EXT_NAME = "@@NAME@@";
+const OPEN_COMMAND_ID = "@@SHORT@@.open";
+
+// ============================================================
+// Modal
+// ============================================================
+
+// CONTRACT: openModalShell has NO `body` option — it returns a controller
+// ({ bodyEl, close, setBusy, setStatus, ... }) with an EMPTY bodyEl that you
+// fill AFTER opening. Passing `body:` is silently ignored and the dialog
+// renders empty (a bug that passes green unit tests — only a jsdom/browser
+// check catches it). Always: open, then modal.bodyEl.appendChild(...).
+//
+// Exported so the jsdom mount smoke test (tests/js) can call it without the app
+// chrome and assert the body is non-empty. Replace the placeholder body with the
+// real manager/dashboard UI; use fuzzyRank for search and fetch
+// /@@PY_MODULE@@/… for any backend data.
+export function openShell(): ReturnType<typeof openModalShell> {
+  const modal = openModalShell({
+    title: "@@DISPLAY@@",
+    onClose: () => {},
+  });
+
+  // TODO: build the real modal body. This skeleton proves the modal-shell
+  // wiring works end to end. Use fuzzyRank for search.
+  const body = document.createElement("div");
+  body.className = "@@SHORT@@-body";
+  body.textContent = "@@DISPLAY@@ — implement me.";
+  modal.bodyEl.appendChild(body);
+
+  return modal;
+}
+
+function openShellSafe(): void {
+  try {
+    openShell();
+  } catch (e) {
+    console.warn(`[${EXT_NAME}] open failed`, e);
+  }
+}
+
+// ============================================================
+// Wiring — launch the modal from the app chrome, not a node widget
+// ============================================================
+
+app.registerExtension({
+  name: "comfy.@@SHORT@@",
+  // An action-bar button in the top bar. `icon` is required — swap the lucide
+  // class for one that fits the pack (see comfyui-frontend-types for the set).
+  actionBarButtons: [
+    {
+      icon: "icon-[lucide--layout-dashboard]",
+      label: "@@DISPLAY@@",
+      tooltip: "Open @@DISPLAY@@",
+      onClick: openShellSafe,
+    },
+  ],
+  // A command (command palette / hotkey-bindable) that opens the same modal.
+  commands: [
+    {
+      id: OPEN_COMMAND_ID,
+      label: "Open @@DISPLAY@@",
+      function: openShellSafe,
+    },
+  ],
+  // A menu-bar entry pointing at the command above.
+  menuCommands: [
+    {
+      path: ["Extensions", "@@DISPLAY@@"],
+      commands: [OPEN_COMMAND_ID],
+    },
+  ],
+});
 """
 
 # --------------------------------------------------------------------------- #
@@ -921,7 +1034,7 @@ PACKAGE_JSON = """\
     "typescript": "^5.7.0",
     "@comfyorg/comfyui-frontend-types": "@@COMFY_FRONTEND_TYPES_VERSION@@",
     "@biomejs/biome": "^@@BIOME_VERSION@@",
-    "vitest": "^4.1.7",
+    "vitest": "^4.1.7",@@JSDOM_DEV_DEP@@
     "knip": "^5.0.0"
   }
 }
@@ -1005,6 +1118,32 @@ describe("@@NAME@@ gesture helpers", () => {
   it("uniform-scales and clamps to a minimum size", () => {
     expect(scaledSize([200, 100], 1.5)).toEqual([300, 150]);
     expect(scaledSize([200, 100], 0.1, [120, 60])).toEqual([120, 60]);
+  });
+});
+"""
+
+JS_TEST_STANDALONE = """\
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+// Vitest transpiles TypeScript, so the test imports the `.ts` source directly
+// (no build step). Importing the module also runs the registerExtension wiring
+// against tests/js/__mocks__/app.js. The standalone modal is launched from the
+// app chrome, so the meaningful smoke test is a jsdom modal-MOUNT check:
+// openShell() must populate modal.bodyEl. This is exactly the empty-modal gap
+// (openModalShell returns an EMPTY bodyEl you fill after opening) that passes
+// pure-helper unit tests but ships a blank dialog — so it is asserted here from
+// the first commit. The `@vitest-environment jsdom` docblock above gives this
+// one file a DOM; the rest of the suite stays on the node environment. Replace
+// with assertions on the real modal body as it lands.
+import { openShell } from "../../src/index.ts";
+
+describe("@@NAME@@ standalone modal", () => {
+  it("mounts a non-empty body into the modal shell", () => {
+    const modal = openShell();
+    expect(modal.bodyEl).toBeTruthy();
+    expect(modal.bodyEl.querySelector(".@@SHORT@@-body")).not.toBeNull();
+    expect(modal.bodyEl.textContent).toContain("@@DISPLAY@@");
+    modal.close();
   });
 });
 """
@@ -1667,6 +1806,11 @@ def build_file_map(
     backend = variant == "backend"
     gesture = variant == "gesture"
     modal = not gesture  # frontend or backend → consumes the kit
+    # A modal variant scaffolded with NO target widgets has nothing to hook, so
+    # the per-widget intercept vein is provably inapplicable. Emit a
+    # standalone-modal skeleton (toolbar button + command opening a modal)
+    # instead. Still depends on the modal kit (modal == True). See issue #1806.
+    standalone = modal and not widgets
 
     # Shared pinned versions injected into every templated config.
     ctx["BIOME_VERSION"] = BIOME_VERSION
@@ -1708,6 +1852,12 @@ def build_file_map(
     else:
         ctx["DEPENDENCIES_BLOCK"] = ""
         ctx["KIT_PKG_NOTE"] = ""
+
+    # The standalone-modal smoke test mounts the modal under jsdom; only that
+    # variant needs jsdom in devDependencies. See issue #1806.
+    ctx["JSDOM_DEV_DEP"] = (
+        f'\n    "jsdom": "{JSDOM_VERSION}",' if standalone else ""
+    )
 
     # CLAUDE.md conditional fragments.
     if backend:
@@ -1813,6 +1963,41 @@ def build_file_map(
             "- ComfyUI: modern Vue frontend (`comfyui-frontend-package >= 1.40`) for\n"
             "  the canvas pointer-event model (`app.canvas`, `ds.scale`/`ds.offset`)."
         )
+    elif standalone:
+        ctx["DEP_FLOOR_NOTE"] = (
+            "Floor tied to the registerExtension action-bar/command API."
+        )
+        ctx["WHAT_DESC"] = "the modal it opens and how the user launches it"
+        ctx["VEIN"] = (
+            "A mobile-first ComfyUI usability pack in the *standalone-modal* vein: "
+            "instead of intercepting a per-node widget, a frontend extension opens "
+            "a STANDALONE modal from the app chrome — an action-bar button plus a "
+            "command (palette/hotkey-bindable) and a menu entry. There are **no "
+            "target widgets to hook** (a manager, dashboard, or gallery-actions "
+            "panel), so there is no `TARGET_WIDGETS` / `onPointerDown` wrapping. "
+            "The modal is **touch-first** (16px inputs to avoid iOS zoom, big tap "
+            f"targets, momentum scroll); its primitives come from `{MODAL_KIT_PKG}` "
+            "(`openModalShell` / `fuzzyRank` / `highlightMatches`), imported and "
+            "inlined by `bun build` — not copied into the pack. `openShell()` is "
+            "exported so the jsdom mount test can prove the modal body renders."
+        )
+        ctx["EXT_ROW_DESC"] = (
+            "The extension: action-bar/command launcher + modal (consumes the kit)."
+        )
+        ctx["HOOK_RULE"] = (
+            "**Launcher API is version-sensitive.** The modal opens from "
+            "`registerExtension`'s `actionBarButtons` / `commands` / `menuCommands`. "
+            "If a future frontend renames or drops one, keep at least one launcher "
+            "(button OR command) wired so the modal stays reachable."
+        )
+        ctx["FAMILY_BLURB"] = (
+            "> touch-friendly HTML modals launched from the toolbar/command palette\n"
+            "> that replace clunky native LiteGraph dialogs, additive and self-contained."
+        )
+        ctx["COMPAT_BULLET"] = (
+            "- ComfyUI: modern Vue frontend (`comfyui-frontend-package >= 1.40`) for the\n"
+            "  `registerExtension` action-bar/command launcher API."
+        )
     else:
         ctx["DEP_FLOOR_NOTE"] = "Floor tied to widget.onPointerDown availability."
         ctx["WHAT_DESC"] = "the widgets it enhances and the modal it opens"
@@ -1869,11 +2054,23 @@ def build_file_map(
         ".github/workflows/release-please.yml": RELEASE_PLEASE_YML,
         ".github/workflows/renovate.yml": RENOVATE_YML,
         "docs/blueprint/adrs/0001-adopt-typescript-bun-build.md": ADR_0001,
-        "src/index.ts": INDEX_TS_GESTURE if gesture else INDEX_TS_MODAL,
+        "src/index.ts": (
+            INDEX_TS_GESTURE
+            if gesture
+            else INDEX_TS_STANDALONE
+            if standalone
+            else INDEX_TS_MODAL
+        ),
         "src/comfyui-shims.d.ts": COMFYUI_SHIMS,
         "tests/test_init.py": TEST_INIT,
         "tests/js/__mocks__/app.js": APP_MOCK,
-        "tests/js/index.test.js": JS_TEST_GESTURE if gesture else JS_TEST_MODAL,
+        "tests/js/index.test.js": (
+            JS_TEST_GESTURE
+            if gesture
+            else JS_TEST_STANDALONE
+            if standalone
+            else JS_TEST_MODAL
+        ),
     }
     if backend:
         files["__init__.py"] = INIT_BACKEND
@@ -1924,6 +2121,9 @@ def main() -> int:
         DATE=datetime.date.today().isoformat(),
     )
     widgets = [w.strip() for w in args.widgets.split(",") if w.strip()]
+    # A modal variant (frontend/backend) with no --widgets gets the
+    # standalone-modal skeleton instead of the per-widget intercept. See #1806.
+    standalone = args.variant != "gesture" and not widgets
 
     parent = Path(args.dir).resolve()
     target = parent / args.name
@@ -1955,6 +2155,10 @@ def main() -> int:
             "  - tune the pinch layer in src/index.ts "
             "(selectedNodes/nodeScreenRect/scaledSize; groups + affordance TODOs)\n"
             if args.variant == "gesture"
+            else "  - implement the modal in src/index.ts (openShell body via "
+            "openModalShell; tune the action-bar/command launcher; import fuzzyRank "
+            "from @laurigates/comfy-modal-kit for search)\n"
+            if standalone
             else "  - implement the modal in src/index.ts (TARGET_WIDGETS + openPicker; "
             "import fuzzyRank from @laurigates/comfy-modal-kit for search)\n"
         )

--- a/comfyui-plugin/skills/comfyui-node-scaffold/scripts/tests/test-standalone-variant.sh
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/scripts/tests/test-standalone-variant.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# test-standalone-variant.sh — regression test for the standalone-modal scaffold
+# variant (issue #1806).
+#
+# Before the fix, `scaffold.py --variant backend` with NO --widgets emitted the
+# per-widget intercept "vein" (TARGET_WIDGETS / openPicker / enhanceNode /
+# widget.onPointerDown) — wrong for a backend pack whose UI is a standalone
+# modal opened from a toolbar button / command. This test EXECUTES the generator
+# and asserts:
+#   1. backend + no widgets  → standalone index.ts (no `const TARGET_WIDGETS`,
+#      has `openShell` + `actionBarButtons`) and the jsdom modal-mount smoke test
+#      + jsdom in devDependencies
+#   2. backend + widgets     → the widget-intercept index.ts is UNCHANGED
+#      (has `const TARGET_WIDGETS`, no `openShell`, no jsdom) — guards against
+#      the standalone branch over-applying
+#
+# Requires python3; SKIPs cleanly when it is unavailable.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCAFFOLD="${SCRIPT_DIR}/../../scaffold.py"
+
+pass=0
+fail=0
+check() { # check <description> <expected> <actual>
+    if [ "$2" = "$3" ]; then
+        pass=$((pass + 1))
+    else
+        fail=$((fail + 1))
+        printf 'FAIL: %s\n  expected: %s\n  actual:   %s\n' "$1" "$2" "$3" >&2
+    fi
+}
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "SKIP: python3 not available" >&2
+    exit 0
+fi
+if [ ! -f "$SCAFFOLD" ]; then
+    echo "FAIL: scaffold.py not found at $SCAFFOLD" >&2
+    exit 1
+fi
+
+WORK="$(mktemp -d)"
+[ -n "$WORK" ] || { echo "mktemp failed" >&2; exit 1; }
+trap 'rm -rf "$WORK"' EXIT
+
+# 1. Standalone variant: backend, no --widgets.
+python3 "$SCAFFOLD" --name comfyui-sb-standalone --display "SB Standalone" \
+    --desc "x" --variant backend --dir "$WORK" >/dev/null 2>&1
+SB="$WORK/comfyui-sb-standalone"
+SB_INDEX="$SB/src/index.ts"
+SB_TEST="$SB/tests/js/index.test.js"
+SB_PKG="$SB/package.json"
+
+# `const TARGET_WIDGETS` is the widget-vein declaration; the standalone index.ts
+# only mentions TARGET_WIDGETS in an explanatory comment, never declares it.
+if grep -q 'const TARGET_WIDGETS' "$SB_INDEX"; then
+    check "standalone index.ts has NO widget-intercept vein" "absent" "present"
+else
+    check "standalone index.ts has NO widget-intercept vein" "absent" "absent"
+fi
+if grep -q 'export function openShell' "$SB_INDEX"; then
+    check "standalone index.ts exports openShell()" "present" "present"
+else
+    check "standalone index.ts exports openShell()" "present" "absent"
+fi
+if grep -q 'actionBarButtons' "$SB_INDEX"; then
+    check "standalone index.ts registers an action-bar launcher" "present" "present"
+else
+    check "standalone index.ts registers an action-bar launcher" "present" "absent"
+fi
+if grep -q '@vitest-environment jsdom' "$SB_TEST"; then
+    check "standalone smoke test runs under jsdom" "present" "present"
+else
+    check "standalone smoke test runs under jsdom" "present" "absent"
+fi
+if grep -q 'openShell' "$SB_TEST"; then
+    check "standalone smoke test mounts the modal (openShell)" "present" "present"
+else
+    check "standalone smoke test mounts the modal (openShell)" "present" "absent"
+fi
+if grep -q '"jsdom"' "$SB_PKG"; then
+    check "standalone package.json declares jsdom devDependency" "present" "present"
+else
+    check "standalone package.json declares jsdom devDependency" "present" "absent"
+fi
+
+# 2. Widget variant: backend WITH --widgets. The standalone branch must NOT apply.
+python3 "$SCAFFOLD" --name comfyui-sb-widget --display "SB Widget" \
+    --desc "x" --variant backend --widgets ckpt_name --dir "$WORK" >/dev/null 2>&1
+WG="$WORK/comfyui-sb-widget"
+WG_INDEX="$WG/src/index.ts"
+WG_PKG="$WG/package.json"
+
+if grep -q 'const TARGET_WIDGETS' "$WG_INDEX"; then
+    check "widget variant keeps the intercept vein" "present" "present"
+else
+    check "widget variant keeps the intercept vein" "present" "absent"
+fi
+if grep -q 'export function openShell' "$WG_INDEX"; then
+    check "widget variant does NOT emit standalone openShell" "absent" "present"
+else
+    check "widget variant does NOT emit standalone openShell" "absent" "absent"
+fi
+if grep -q '"jsdom"' "$WG_PKG"; then
+    check "widget variant does NOT add jsdom" "absent" "present"
+else
+    check "widget variant does NOT add jsdom" "absent" "absent"
+fi
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What

`comfyui-node-scaffold`'s modal variants (`frontend` / `backend`) now emit a **standalone-modal** `src/index.ts` when scaffolded with **no `--widgets`**, instead of the per-widget intercept "vein". The standalone skeleton is a `registerExtension` with an `actionBarButtons` entry + `commands`/`menuCommands` calling an exported `openShell()` (which uses `openModalShell` from `@laurigates/comfy-modal-kit`) — no `TARGET_WIDGETS` / `openPicker` / `enhanceNode` / `widget.onPointerDown`.

It ships a **jsdom modal-mount smoke test** (`jsdom` added to `devDependencies` for this variant only) asserting `openShell()` populates the modal body — the empty-modal gap the scaffold's own notes flag, which passes pure-helper unit tests but ships a blank dialog.

The widget-intercept (`--widgets a,b`) and `gesture` variants are unchanged.

## Why

For a backend pack whose UI is a standalone modal opened from a toolbar button / command (a node manager, dashboard, gallery-actions panel — the `comfyui-touch-manager` case), the per-widget vein is provably inapplicable (no widgets to hook) and got deleted wholesale, breaking the scaffold's "CI-green skeleton you only fill in" promise.

## Design decision

The issue offered two routes — (a) the no-widgets heuristic (`modal variant && no --widgets ⇒ standalone`) or (b) an explicit `--ui standalone|widget` flag / 4th variant. This PR implements **(a)**, the issue's primary suggestion: lower-risk, minimal, and it covers the observed case. An explicit flag is more orthogonal (a frontend standalone pack already benefits here too, since the heuristic applies to both modal variants) and remains a possible follow-up if a use case needs the UI shape chosen fully independently of widgets.

## How

- `INDEX_TS_STANDALONE` + `JS_TEST_STANDALONE` templates in `scaffold.py`.
- `build_file_map` computes `standalone = modal and not widgets` and selects `src/index.ts`, `tests/js/index.test.js`, the vein-conditional CLAUDE/README fragments (`VEIN`/`WHAT_DESC`/`EXT_ROW_DESC`/`HOOK_RULE`/…), and a `jsdom` devDependency accordingly. `DEPENDENCIES_BLOCK`/`KIT_RULE` stay correct (standalone still depends on the kit).
- SKILL.md variant decision table documents that omitting `--widgets` on a modal variant yields the standalone-modal skeleton, with an example.
- `scripts/tests/test-standalone-variant.sh` regression check (auto-discovered) asserts the standalone shape for no-widgets and that the widget variant is unaffected.

## Verification

A scaffolded `--variant backend` (no widgets) pack passes green end-to-end: `tsc --noEmit`, `bun build`, `biome check`, `knip`, and the jsdom `vitest` test. The full variant matrix (frontend±widgets, backend±widgets, gesture) was checked to select the correct template + jsdom dep. The `@comfyorg/comfyui-frontend-types` `ComfyExtension` type confirms `actionBarButtons` / `commands` / `menuCommands` are valid properties, so the skeleton stays `tsc`-strict clean.

Closes #1806

🤖 Generated with [Claude Code](https://claude.com/claude-code)