### PR TITLE
docs(hooks-plugin): catalog plugin feature flags + coverage guard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -133,6 +133,18 @@ repos:
         language: system
         files: '^(\.claude-plugin/marketplace\.json|\.claude/settings\.json)$'
         pass_filenames: false
+      - id: check-feature-flags-catalog
+        name: every plugin env flag is documented (feature-flags-catalog)
+        entry: bash ./scripts/check-feature-flags-catalog.sh --strict
+        language: system
+        files: '^((hooks-plugin|git-plugin|taskwarrior-plugin)/.*\.sh|taskwarrior-plugin/skills/install-native-hooks/templates/.*|hooks-plugin/docs/feature-flags\.md|scripts/check-feature-flags-catalog\.sh|scripts/tests/test-check-feature-flags-catalog\.sh)$'
+        pass_filenames: false
+      - id: test-check-feature-flags-catalog
+        name: feature-flags catalog guard regression
+        entry: bash ./scripts/tests/test-check-feature-flags-catalog.sh
+        language: system
+        files: '^scripts/(check-feature-flags-catalog\.sh|tests/test-check-feature-flags-catalog\.sh)$'
+        pass_filenames: false
       - id: test-fetch-research-papers
         name: research-radar fetcher parse/dedup/date-filter regression
         entry: bash ./scripts/tests/test-fetch-research-papers.sh

--- a/hooks-plugin/README.md
+++ b/hooks-plugin/README.md
@@ -6,6 +6,11 @@ Claude Code hooks for enforcing best practices and workflow automation.
 
 This plugin provides pre-built hooks that can be installed in any project to enforce consistent behavior and remind Claude to use the correct tools.
 
+> **Toggling behavior:** every env var that turns a hook on/off or tunes it —
+> across hooks-plugin, git-plugin, and taskwarrior-plugin — is indexed in
+> [`docs/feature-flags.md`](docs/feature-flags.md) (opt-in / opt-out / tunable,
+> with source pointers). The per-hook `Toggle:` lines below are the deep detail.
+
 ## Available Hooks
 
 ### bash-antipatterns.sh

--- a/hooks-plugin/docs/feature-flags.md
+++ b/hooks-plugin/docs/feature-flags.md
@@ -83,17 +83,23 @@ explicit action, not an env flag. Their own opt-out knobs are listed below.
 
 ## Keeping this current
 
-This table is a hand-maintained index, so it can drift from the sources. To
-re-derive the full flag set (the authoritative truth) and spot anything missing:
+This table is a hand-maintained index, so it could drift from the sources — but
+the drift is **enforced deterministically**, not left to memory. A pre-commit
+guard fails the commit when any flag read in a plugin source is missing a row
+here:
 
 ```
-rg -oN --no-filename 'CLAUDE_HOOKS_[A-Z_]+|CLAUDE_TASKWARRIOR_[A-Z_]+' -g '*.sh' -g 'templates/*' */ | sort -u
+scripts/check-feature-flags-catalog.sh --strict
 ```
 
-Any flag that one-liner prints which is absent from the tables above is a gap to
-backfill. (A pre-commit coverage guard that fails when a source flag is missing
-from this catalog would make the drift deterministic rather than relying on the
-grep — a reasonable follow-up.)
+It runs automatically (pre-commit id `check-feature-flags-catalog`) whenever a
+plugin `*.sh`, a native-hook template, or this file changes. So adding a flag to
+a hook without documenting it here is a red commit, not a silent gap. To re-derive
+the raw flag set by hand:
+
+```
+rg -oN --no-filename 'CLAUDE_HOOKS_[A-Z_]+|CLAUDE_TASKWARRIOR_[A-Z_]+' -g '*.sh' -g '**/templates/*' -g '!**/tests/**' */ | sort -u
+```
 
 ## Related
 

--- a/hooks-plugin/docs/feature-flags.md
+++ b/hooks-plugin/docs/feature-flags.md
@@ -1,0 +1,104 @@
+# Feature Flags Catalog
+
+A single index of the **environment variables that toggle or tune plugin
+behavior** across this marketplace. Without it, the flags are discoverable only
+by grepping the hook sources — exactly the drift `documentation-authoring.md`
+warns against.
+
+Each row points at its **source file**, which is the authoritative definition
+(default value + logic). This catalog is a signpost, not a second copy of the
+logic — when a flag's behavior is in question, read the source.
+
+Three shapes:
+
+- **Opt-in** — the feature is **off** until you set the flag. New experimental /
+  teaching behaviors default off so they don't surprise.
+- **Opt-out** — the feature is **on** until you set the flag. Guardrails default
+  on, with the flag as an escape hatch.
+- **Tunable** — a value (path, timeout, threshold), not a boolean on/off.
+
+> Scope: only plugin-defined flags are cataloged. Claude Code **harness** flags
+> (`CLAUDE_CODE_*`, `ENABLE_TOOL_SEARCH`, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`,
+> …) are documented by Claude Code, not here.
+
+## Opt-in (OFF by default → `export <FLAG>=1` to enable)
+
+| Flag | Enables | Plugin · source |
+|---|---|---|
+| `CLAUDE_HOOKS_ENABLE_BASH_ANTIPATTERNS_TEACH` | PostToolUse "teach" hook — augments tool output with a non-blocking nudge instead of blocking (carries the `find→Glob` and other soft nudges) | hooks · `hooks/bash-antipatterns-teach.sh` |
+| `CLAUDE_HOOKS_ENABLE_CALENDAR_ESTIMATES` | Stop hook nudging the agent to restate estimates in tokens / effort tiers instead of calendar time | hooks · `hooks/no-calendar-estimates.sh` |
+| `CLAUDE_HOOKS_ENABLE_EVENT_LOGGER` | Dev/debug hook logging every hook event to a file | hooks · `hooks/event-logger.sh` |
+
+**Non-env opt-in:** the taskwarrior **native hooks** (`on-modify`, `on-exit`
+ghsync queue) are installed by running `/taskwarrior:install-native-hooks` — an
+explicit action, not an env flag. Their own opt-out knobs are listed below.
+
+## Opt-out (ON by default → `export <FLAG>=1` to disable)
+
+### hooks-plugin
+
+| Flag | Disables | Source |
+|---|---|---|
+| `CLAUDE_HOOKS_DISABLE_SECRET_PROTECTION` | Blocking access to secret files / env-var exposure | `hooks/secret-protection.sh` |
+| `CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION` | Blocking writes on `main`/`master` (**human-operator only** — inline prefixes are ignored so agents can't self-serve) | `hooks/branch-protection.sh` |
+| `CLAUDE_HOOKS_DISABLE_AUTO_CHECKPOINT` | Auto-stash checkpoint before destructive git/`rm -rf` ops | `hooks/auto-checkpoint.sh` |
+| `CLAUDE_HOOKS_DISABLE_PERMISSION_AUTO` | Auto-approve/deny of safe/dangerous ops at PermissionRequest | `hooks/permission-auto-approve.sh` |
+| `CLAUDE_HOOKS_DISABLE_PERMISSION_REQUEST` | The permission-request hook | `skills/hooks-permission-request-hook/` |
+| `CLAUDE_HOOKS_DISABLE_TASK_COMPLETENESS` | Stop-hook heuristics for incomplete work (TODO/conflict markers/debug artifacts) | `hooks/task-completeness.sh` |
+| `CLAUDE_HOOKS_DISABLE_TEST_VERIFICATION` | Stop-hook reminder to run tests when code changed | `hooks/test-verification.sh` |
+| `CLAUDE_HOOKS_DISABLE_DRIFT_NUDGE` | The consolidated drift-aggregator SessionStart nudge | `hooks/drift-aggregator.sh` |
+
+### git-plugin
+
+| Flag | Disables | Source |
+|---|---|---|
+| `CLAUDE_HOOKS_DISABLE_BRANCH_SYNC` | PreToolUse nudge when a PR branch is behind / merged before commit/push | `git-plugin/hooks/check-branch-sync-on-push.sh` |
+
+### taskwarrior-plugin
+
+| Flag | Disables | Source |
+|---|---|---|
+| `CLAUDE_TASKWARRIOR_DRIFT_NO_RECONCILE` | The reconcile dry-run portion of the drift probe | `hooks/taskwarrior-drift-probe.sh` |
+| `CLAUDE_TASKWARRIOR_DRIFT_NO_STALE_CLAIMS` | The stale-`+ACTIVE`-claim portion of the drift probe | `hooks/taskwarrior-drift-probe.sh` |
+| `CLAUDE_TASKWARRIOR_NO_GHSYNC_QUEUE` | Draining the on-exit ghsync queue in the probe | `hooks/taskwarrior-drift-probe.sh` |
+| `CLAUDE_TASKWARRIOR_NO_SCHEDULED_RECONCILE` | The scheduled (LaunchAgent) reconcile run | `scripts/scheduled-reconcile.sh` |
+| `CLAUDE_TASKWARRIOR_RECONCILE_NO_DESKTOP` | Desktop notification from scheduled reconcile | `scripts/scheduled-reconcile.sh` |
+| `CLAUDE_TASKWARRIOR_RECONCILE_NO_TELEGRAM` | Telegram notification from scheduled reconcile | `scripts/scheduled-reconcile.sh` |
+| `CLAUDE_TASKWARRIOR_NO_MARKER_UPKEEP` | Session-marker upkeep in the native `on-exit` hook | `skills/install-native-hooks/templates/on-exit-taskwarrior-plugin` |
+| `CLAUDE_TASKWARRIOR_NO_CLAIM_EXPIRY` | Claim-expiry handling in the native `on-modify` hook | `skills/install-native-hooks/templates/on-modify-taskwarrior-plugin` |
+
+## Tunables (a value, not on/off)
+
+| Flag | Default | Controls | Source |
+|---|---|---|---|
+| `CLAUDE_HOOKS_EVENT_LOG` | `~/.claude/hook-events.log` | Event-logger output path | `hooks/event-logger.sh` |
+| `CLAUDE_HOOKS_EVENT_LOGGER_VERBOSE` | off | Log full JSON input (vs one-line summary) | `hooks/event-logger.sh` |
+| `CLAUDE_HOOKS_TEST_TIMEOUT` | `45` (s) | Test-verification timeout | `hooks/test-verification.sh` |
+| `CLAUDE_HOOKS_BRANCH_SYNC_TTL` | `300` (s) | Per-session+branch sync-check cache TTL | `git-plugin/hooks/check-branch-sync-on-push.sh` |
+| `CLAUDE_TASKWARRIOR_DRIFT_STALE_TTL` | `14400` (s) | Age before a `+ACTIVE` claim counts as stale | `hooks/taskwarrior-drift-probe.sh` |
+| `CLAUDE_TASKWARRIOR_DRIFT_STALE_LIMIT` | `50` | Max stale claims reported | `hooks/taskwarrior-drift-probe.sh` |
+| `CLAUDE_TASKWARRIOR_DRIFT_CACHE_DIR` | `$TMPDIR/claude-taskwarrior-drift` | Drift-probe cache location | `scripts/drain-ghsync-queue.sh` |
+| `CLAUDE_TASKWARRIOR_GHSYNC_QUEUE` | (unset) | ghsync queue file path | `scripts/drain-ghsync-queue.sh` |
+| `CLAUDE_TASKWARRIOR_CLAIM_TTL_HOURS` | see source | Native-hook claim TTL | `skills/install-native-hooks/templates/on-modify-taskwarrior-plugin` |
+
+## Keeping this current
+
+This table is a hand-maintained index, so it can drift from the sources. To
+re-derive the full flag set (the authoritative truth) and spot anything missing:
+
+```
+rg -oN --no-filename 'CLAUDE_HOOKS_[A-Z_]+|CLAUDE_TASKWARRIOR_[A-Z_]+' -g '*.sh' -g 'templates/*' */ | sort -u
+```
+
+Any flag that one-liner prints which is absent from the tables above is a gap to
+backfill. (A pre-commit coverage guard that fails when a source flag is missing
+from this catalog would make the drift deterministic rather than relying on the
+grep — a reasonable follow-up.)
+
+## Related
+
+- `hooks-plugin/README.md` — per-hook behavior tables (the deep detail each row here points at)
+- `hooks-plugin/docs/teach-mode-experiment.md` — rationale for the opt-in teach hook
+- `.claude/rules/bash-tool-replacements.md` — what the teach hook nudges toward
+- `.claude/rules/pr-branch-sync.md` — the branch-sync guard family
+- `.claude/rules/drift-detection-triggering.md` — the taskwarrior drift-probe design

--- a/scripts/check-feature-flags-catalog.sh
+++ b/scripts/check-feature-flags-catalog.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Guard against drift between the env feature-flags defined in plugin sources and
+# the catalog that documents them (hooks-plugin/docs/feature-flags.md).
+#
+# The catalog is a hand-maintained index, so a newly-added CLAUDE_HOOKS_* /
+# CLAUDE_TASKWARRIOR_* flag can silently land in a hook without a catalog entry —
+# exactly the drift documentation-authoring.md warns about. This makes the check
+# deterministic instead of relying on someone re-running the regeneration grep.
+#
+# The check: every flag READ in a plugin source must appear in the catalog. A
+# new flag added to a hook without a catalog row fails the gate.
+#
+# Sources scanned: *.sh under plugin dirs + the native-hook templates/ files.
+# Excluded: generated copies (dist/), this script, and dedicated tests/ dirs.
+# tests/ are excluded because fixtures construct *fake* flags (e.g. a SAMPLE flag
+# to prove the gate fires) that would read as undocumented. A name-based test-*.sh
+# exclusion is NOT used — it would wrongly drop the real test-verification.sh
+# hook; the test-*.sh fixtures that live beside hooks only reference real,
+# already-cataloged flags, so scanning them is harmless.
+#
+# The catalog may legitimately document MORE than the scan finds — e.g. flags
+# read by hooks the skills GENERATE into a user's project (permission-request)
+# rather than ship as an in-repo .sh — so a "dangling" reverse-check would
+# false-positive and is deliberately omitted.
+#
+# Emits the structured KEY=value / STATUS= convention
+# (.claude/rules/structured-script-output.md) so scheduled-audits can roll it up.
+#
+# Usage:
+#   check-feature-flags-catalog.sh [--project-dir <path>] [--strict]
+#
+#   --project-dir   Repo root to scan (default: git toplevel, else cwd)
+#   --strict        Exit 1 when a source flag is missing from the catalog
+#                   (default: always exit 0; DANGLING is a warning either way)
+set -uo pipefail
+
+PROJECT_DIR=""
+STRICT=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --project-dir) PROJECT_DIR="$2"; shift 2 ;;
+        --strict) STRICT=1; shift ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [ -z "$PROJECT_DIR" ]; then
+    PROJECT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+fi
+
+DOC_REL="hooks-plugin/docs/feature-flags.md"
+DOC="$PROJECT_DIR/$DOC_REL"
+
+FLAG_RE='CLAUDE_HOOKS_[A-Z_]+|CLAUDE_TASKWARRIOR_[A-Z_]+'
+
+echo "=== FEATURE FLAGS CATALOG ==="
+
+if [ ! -f "$DOC" ]; then
+    echo "DOC=$DOC_REL"
+    echo "STATUS=ERROR"
+    echo "ISSUE_COUNT=1"
+    echo "ISSUES:"
+    echo "  - SEVERITY=ERROR TYPE=missing_doc MSG=catalog not found at $DOC_REL"
+    echo "=== END FEATURE FLAGS CATALOG ==="
+    [ "$STRICT" = "1" ] && exit 1 || exit 0
+fi
+
+# Flags actually read in plugin sources (the authoritative set).
+source_flags=$(rg -oN --no-filename "$FLAG_RE" \
+    -g '*.sh' -g '**/templates/*' \
+    -g '!**/tests/**' -g '!dist/**' -g '!scripts/check-feature-flags-catalog.sh' \
+    "$PROJECT_DIR" 2>/dev/null | sort -u)
+
+# Flags named anywhere in the catalog.
+catalog_flags=$(rg -oN --no-filename "$FLAG_RE" "$DOC" 2>/dev/null | sort -u)
+
+source_count=$(printf '%s\n' "$source_flags" | grep -c . || true)
+catalog_count=$(printf '%s\n' "$catalog_flags" | grep -c . || true)
+
+# MISSING: read in a source, absent from the catalog.
+missing=$(comm -23 <(printf '%s\n' "$source_flags") <(printf '%s\n' "$catalog_flags"))
+missing_count=$(printf '%s\n' "$missing" | grep -c . || true)
+
+if [ "$missing_count" -gt 0 ]; then
+    overall="ERROR"
+else
+    overall="OK"
+fi
+
+echo "DOC=$DOC_REL"
+echo "SOURCE_FLAG_COUNT=$source_count"
+echo "CATALOG_FLAG_COUNT=$catalog_count"
+echo "MISSING_COUNT=$missing_count"
+echo "STATUS=$overall"
+echo "ISSUE_COUNT=$missing_count"
+
+if [ "$missing_count" -gt 0 ]; then
+    echo "ISSUES:"
+    while IFS= read -r f; do
+        [ -z "$f" ] && continue
+        echo "  - SEVERITY=ERROR TYPE=missing_from_catalog FLAG=$f MSG=flag read in a source but absent from $DOC_REL"
+    done <<< "$missing"
+fi
+
+echo "=== END FEATURE FLAGS CATALOG ==="
+
+if [ "$STRICT" = "1" ] && [ "$missing_count" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/scripts/tests/test-check-feature-flags-catalog.sh
+++ b/scripts/tests/test-check-feature-flags-catalog.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016   # file-level (must precede first command): the printf format strings intentionally emit literal ${...} / %s into generated fixture scripts
+# Regression tests for check-feature-flags-catalog.sh
+#
+# Run: bash scripts/tests/test-check-feature-flags-catalog.sh
+# Exit 0 = all tests pass, Exit 1 = failures
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/check-feature-flags-catalog.sh"
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() { printf "  PASS: %s\n" "$1"; PASS=$((PASS + 1)); }
+fail() { printf "  FAIL: %s\n" "$1"; FAIL=$((FAIL + 1)); }
+
+# Build a throwaway project: a catalog doc + one hook reading a flag.
+# $1 = flag the hook reads, $2 = flag the catalog documents (empty = none).
+make_project() {
+    local hook_flag="$1" doc_flag="${2:-}"
+    local dir; dir="$(mktemp -d)"
+    mkdir -p "$dir/hooks-plugin/docs" "$dir/hooks-plugin/hooks"
+    {
+        echo "# Feature Flags Catalog"
+        [ -n "$doc_flag" ] && echo "| \`$doc_flag\` | does a thing | src |"
+    } > "$dir/hooks-plugin/docs/feature-flags.md"
+    printf '#!/usr/bin/env bash\n[ "${%s:-}" = "1" ] && exit 0\n' "$hook_flag" \
+        > "$dir/hooks-plugin/hooks/sample.sh"
+    echo "$dir"
+}
+
+echo "=== check-feature-flags-catalog tests ==="
+
+# 1. Real repo is clean and strict-passes.
+out=$(bash "$SCRIPT" --project-dir "$REPO_ROOT" --strict 2>&1); rc=$?
+if [ "$rc" -eq 0 ] && echo "$out" | grep -qx "STATUS=OK"; then
+    pass "real repo passes --strict (STATUS=OK, exit 0)"
+else
+    fail "real repo should pass --strict (got exit $rc): $out"
+fi
+
+# 2. A documented flag → OK.
+d=$(make_project "CLAUDE_HOOKS_ENABLE_SAMPLE" "CLAUDE_HOOKS_ENABLE_SAMPLE")
+out=$(bash "$SCRIPT" --project-dir "$d" --strict 2>&1); rc=$?
+if [ "$rc" -eq 0 ] && echo "$out" | grep -qx "MISSING_COUNT=0"; then
+    pass "documented flag → STATUS=OK, exit 0"
+else
+    fail "documented flag should pass (got exit $rc): $out"
+fi
+rm -rf "$d"
+
+# 3. An UNDOCUMENTED flag → strict fails (exit 1) and names the flag.
+d=$(make_project "CLAUDE_HOOKS_ENABLE_SAMPLE" "")
+out=$(bash "$SCRIPT" --project-dir "$d" --strict 2>&1); rc=$?
+if [ "$rc" -eq 1 ] \
+   && echo "$out" | grep -qx "MISSING_COUNT=1" \
+   && echo "$out" | grep -q "FLAG=CLAUDE_HOOKS_ENABLE_SAMPLE"; then
+    pass "undocumented flag → strict exit 1, names the flag"
+else
+    fail "undocumented flag should fail --strict (got exit $rc): $out"
+fi
+rm -rf "$d"
+
+# 4. Without --strict, a gap reports ERROR but still exits 0 (audit-friendly).
+d=$(make_project "CLAUDE_TASKWARRIOR_NO_SAMPLE" "")
+out=$(bash "$SCRIPT" --project-dir "$d" 2>&1); rc=$?
+if [ "$rc" -eq 0 ] && echo "$out" | grep -qx "STATUS=ERROR"; then
+    pass "gap without --strict → STATUS=ERROR but exit 0"
+else
+    fail "non-strict gap should exit 0 with STATUS=ERROR (got exit $rc): $out"
+fi
+rm -rf "$d"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What

Adds `hooks-plugin/docs/feature-flags.md` — a single cross-plugin index of every env var that toggles or tunes plugin behavior (hooks-plugin, git-plugin, taskwarrior-plugin) — **and a pre-commit guard that keeps it honest**.

Follow-up to the discussion in #1871.

## The catalog

Grouped by shape, each row pointing at its **authoritative source file** (signpost, not a logic copy — `documentation-authoring.md`):

- **Opt-in** (OFF by default) — 3 flags, all hooks-plugin (teach hook, calendar-estimates nudge, event logger) + the non-env `/taskwarrior:install-native-hooks` opt-in.
- **Opt-out** (ON by default) — the guardrail hooks across hooks/git/taskwarrior.
- **Tunable** — paths, timeouts, thresholds.

Harness flags (`CLAUDE_CODE_*`, `ENABLE_TOOL_SEARCH`) are explicitly out of scope.

## The coverage guard (the drift can't return silently)

`scripts/check-feature-flags-catalog.sh --strict` — a pre-commit hook that **fails the commit** when any `CLAUDE_HOOKS_*` / `CLAUDE_TASKWARRIOR_*` flag read in a plugin source has no catalog row. Emits the `STATUS=`/`ISSUE_COUNT=` structured-output convention.

Design notes (each a real edge hit while building):
- Excludes `dist/` and dedicated `tests/` dirs — test fixtures construct *fake* flags to prove the gate fires.
- Does **not** exclude `test-*.sh` by name — that would wrongly drop the real `test-verification.sh` hook.
- No reverse "dangling" check — skill-**generated** hooks (permission-request scaffolds `scripts/permission-request.sh` into the user's project) read flags with no in-repo `.sh`, so the catalog legitimately documents more than the scan finds.

Plus a regression test (`scripts/tests/test-check-feature-flags-catalog.sh`, wired into pre-commit): clean repo passes `--strict`; a documented flag passes; an **undocumented** flag fails `--strict` and is named; a non-strict gap reports `ERROR` but exits 0.

## Verification

- Guard on real tree: `STATUS=OK`, `MISSING_COUNT=0`
- Regression test: 4 passed, 0 failed
- shellcheck / lint-shell-scripts: clean

`docs`/`ci` only — no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)