### PR TITLE
fix(hooks-plugin): stop bash-antipatterns blocking head/tail identifiers in heredocs

### DIFF
--- a/hooks-plugin/hooks/bash-antipatterns.sh
+++ b/hooks-plugin/hooks/bash-antipatterns.sh
@@ -73,8 +73,16 @@ See .claude/rules/bash-tool-replacements.md for the full table."
 fi
 
 # Check for head/tail used to read files (not in pipelines)
-if echo "$COMMAND" | grep -Eq '^\s*(head|tail)\s+(-[0-9n]+\s+)?[^|]' && \
-   ! echo "$COMMAND" | grep -q '|'; then
+#
+# Scan COMMAND_SHELL_ONLY (heredoc bodies stripped) so a `head`/`tail` token that
+# is an identifier inside a quoted heredoc payload handed to another interpreter
+# — e.g. `python3 - <<'PY' … head = txt[:idx] … PY` — is not mistaken for a
+# `head <file>` invocation (issue #1848). The `[^|=]` (was `[^|]`) also excludes
+# the assignment form `head = "x"` / `tail = …` at line start (a Python/awk
+# variable in a single-quoted multi-line script the heredoc strip does not cover);
+# a real `head`/`tail` file argument never begins with `=`.
+if echo "$COMMAND_SHELL_ONLY" | grep -Eq '^\s*(head|tail)\s+(-[0-9n]+\s+)?[^|=]' && \
+   ! echo "$COMMAND_SHELL_ONLY" | grep -q '|'; then
     block "BLOCKED: 'head -50 file.md' →
   Read(file_path=\"/abs/path/to/file.md\", limit=50)
 

--- a/hooks-plugin/hooks/test-bash-antipatterns.sh
+++ b/hooks-plugin/hooks/test-bash-antipatterns.sh
@@ -720,6 +720,58 @@ assert_exit_complex \
     "GUARD INTEGRITY: #1701 mixed write echo x > realfile.txt 2>/dev/null still blocks" 2 \
     'echo data > realfile.txt 2>/dev/null'
 
+# ── head/tail as an identifier, not a file read (issue #1848) ─────────────────
+# Regression: a `head`/`tail` token that is a *variable* — inside a quoted
+# heredoc payload handed to python3/jq/awk (`python3 - <<'PY' … head = … PY`),
+# or an assignment `head = …` at the start of a line in an inline script — was
+# matched as the `head <file>` antipattern and blocked. The detector now scans
+# the heredoc-stripped view and excludes the `= ` assignment form (`[^|=]`).
+echo ""
+echo "head/tail as an identifier (heredoc body / assignment) is not the file-read antipattern (#1848):"
+
+heredoc_head_var_cmd=$(cat <<'OUTER'
+python3 - <<'PY'
+head = "x"
+print(head)
+PY
+OUTER
+)
+assert_exit_complex \
+    "head as a python var inside a single-quoted heredoc is allowed (#1848 repro)" 0 \
+    "$heredoc_head_var_cmd"
+
+heredoc_tail_var_cmd=$(cat <<'OUTER'
+python3 - <<'PY'
+tail = txt[idx:]
+print(tail)
+PY
+OUTER
+)
+assert_exit_complex \
+    "tail as a python var inside a single-quoted heredoc is allowed (#1848)" 0 \
+    "$heredoc_tail_var_cmd"
+
+inline_head_assign_cmd=$(cat <<'OUTER'
+python3 -c '
+head = data[:n]
+print(head)
+'
+OUTER
+)
+assert_exit_complex \
+    "head = assignment at line start in inline python is allowed (#1848 [^|=] guard)" 0 \
+    "$inline_head_assign_cmd"
+
+# GUARD INTEGRITY: switching to the heredoc-stripped view must NOT weaken the
+# genuine head/tail file-read nudge.
+assert_exit \
+    "GUARD INTEGRITY: head -50 file.md still blocked (#1848)" 2 \
+    "head -50 file.md"
+
+assert_exit \
+    "GUARD INTEGRITY: tail README.md (no flag) still blocked (#1848)" 2 \
+    "tail README.md"
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## What

The `bash-antipatterns` PreToolUse hook blocked a `Bash` call whose body was a Python script passed via a single-quoted heredoc (`python3 - <<'PY' … PY`) because the payload contained a variable named `head` (e.g. `head = txt[:idx]`). The hook misread the `head`/`tail` identifier as the `head <file>` file-read antipattern.

## Why it was wrong

The head/tail detector scanned the **raw** command string and used `[^|]` after the command token, so two non-invocations matched:

1. A `head`/`tail` token inside a quoted heredoc payload handed to another interpreter (`python3`/`jq`/`awk`) — the heredoc body was never stripped before scanning.
2. An assignment `head = "x"` at the start of a line — `[^|]` happily matched the `=`.

## Fix

- Scan `COMMAND_SHELL_ONLY` (heredoc bodies already stripped for this exact class of false positive elsewhere in the hook) instead of raw `$COMMAND`.
- Change `[^|]` → `[^|=]` so the `head = …` / `tail = …` assignment form is excluded (covers an inline single-quoted multi-line script the heredoc strip doesn't cover). A genuine `head`/`tail` file argument never begins with `=`, so real blocks are unaffected.

## Tests

Added 5 regression cases to `test-bash-antipatterns.sh`:
- the issue's exact repro (`python3 - <<'PY' … head = "x" … PY`) → allowed
- a `tail` heredoc variant → allowed
- an inline `python3 -c '…'` with `head = …` at line start → allowed
- two guard-integrity checks that genuine `head -50 file.md` / `tail README.md` still **block**

Full suite: **101 passed, 0 failed**. `shellcheck` clean. Verified via `scripts/run-skill-script-tests.sh` (the CI path).

## Selection rationale (scheduled issue-resolution run)

Picked from the open-issues-without-PRs set as the first node in the dependency sequence: a self-contained, fully verifiable bug (label `bug`) with a concrete reproducer, no blockers, and nothing depending on it — ideal for autonomous resolution under the project's regression-testing rule.

Closes #1848