### PR TITLE
docs(rules): add hook-block-vs-nudge — block for safety, nudge for style

### DIFF
--- a/.claude/rules/hook-block-vs-nudge.md
+++ b/.claude/rules/hook-block-vs-nudge.md
@@ -1,0 +1,61 @@
+---
+paths:
+  - "**/hooks/**"
+  - "**/*hook*.sh"
+  - "**/bash-antipatterns*.sh"
+---
+
+# Hook Enforcement: Block for Safety, Nudge for Style
+
+A PreToolUse hook can **hard-block** (exit 2) or emit a **non-blocking nudge**
+(a PostToolUse teach-mode hint, or an advisory message). That choice is not
+cosmetic: picking *block* for a non-safety concern imposes a recurring tax and,
+worse, can dead-end the agent.
+
+## The rule
+
+Hard-block (exit 2) **only** when the command risks **safety or correctness**
+with no easy recovery — data loss, secret exposure, irreversible shared-state
+mutation, protected-branch writes. For **style / efficiency / consistency**
+preferences ("use tool X instead of shell Y"), prefer a **non-blocking nudge**.
+
+## Why a hard block on a style preference backfires
+
+| Cost | Detail |
+|---|---|
+| **Subagent dead-end** | PreToolUse hooks fire in **every** context, including subagents — but the tool you redirect to (`Glob`, `Grep`, …) is not granted in every subagent toolset. A hard block can leave an agent with no shell form *and* no tool: no path forward. |
+| **Fighting model fluency** | The model writes `find` / `grep` reliably; forcing an alternative it's less fluent in, that's sometimes unavailable, is a bad trade for a style win. |
+| **False-positive treadmill** | Every block needs an exemption list (pipelines, flags, edge forms) that accretes patches over time. |
+
+A non-blocking nudge keeps the steer (it teaches the better tool) without any of
+these costs — the command still runs, so nothing is ever dead-ended.
+
+## The litigation test (separate safety from style)
+
+When deciding whether an existing block earns its exit-2, look at what it
+**exempts**. If the block lets the genuinely dangerous form through, it was never
+doing safety work — its only justification is style, which does not warrant a
+hard block.
+
+> Canonical tell: the `find`→`Glob` block always **exempted** `find -exec` (the
+> arbitrary-execution form) and only blocked simple `find -name` searches. So it
+> did no safety work; it fired in subagents lacking `Glob` (dead-ends); and it
+> needed 4+ false-positive patches. It was demoted to the opt-in teach nudge in
+> `bash-antipatterns-teach.sh` (claude-plugins #1871). The `cat` / `sed` /
+> `echo > file` blocks **stayed** — those prevent real data-loss / correctness
+> problems, so the exit-2 is earned.
+
+## Quick test before adding (or keeping) a hard block
+
+1. Does the command risk irreversible harm (data, secrets, shared state)? If no → nudge.
+2. Does the block exempt the *dangerous* variant while blocking benign ones? If yes → it's style; nudge.
+3. Does the redirect target a tool that may be absent in a subagent? If yes → never hard-block; nudge.
+4. Add a regression test for whichever you choose (`regression-testing.md`).
+
+## Related
+
+- `.claude/rules/bash-tool-replacements.md` — the find/grep/cat substitutions and which ones still block
+- `.claude/rules/handling-blocked-hooks.md` — the consumer side: what an agent does when a block fires
+- `.claude/rules/offload-to-deterministic-substrate.md` — hooks as deterministic enforcement; don't double-gate auto mode
+- `.claude/rules/prompt-agent-hooks.md` — when to reach for prompt/agent hooks
+- `hooks-plugin/docs/teach-mode-experiment.md` — the non-blocking PostToolUse teach mechanism this rule points to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ Claude Code plugin collection providing skills and agents for development workfl
 | `.claude/rules/skill-argument-handling.md` | 9-axis rubric for `args`/`argument-hint`/parsing-vs-intent fit; the haiku+opus cold-read **sweep** that finds mismatches and the model delta that calibrates it |
 | `.claude/rules/skill-execution-structure.md` | Imperative execution patterns for user-invocable skills |
 | `.claude/rules/handling-blocked-hooks.md` | How to respond when hooks block commands |
+| `.claude/rules/hook-block-vs-nudge.md` | **Block (exit 2) only for safety; nudge for style** — why a hard block on a tool-substitution dead-ends subagents lacking the tool, and the "what does it exempt?" litigation test |
 | `.claude/rules/hooks-reference.md` | Complete hook event reference (2.1.50+): all events, schemas, timeouts, PermissionRequest |
 | `.claude/rules/prompt-agent-hooks.md` | **When to use prompt/agent hooks** — decision tree, config schema, prompts guide |
 | `.claude/rules/agent-development.md` | Agent configuration, isolation, background execution, memory, and teams |


### PR DESCRIPTION
## What

Distills a reusable hook-design principle from this session's `find→Glob` re-litigation (#1871) into `.claude/rules/hook-block-vs-nudge.md`.

## The principle

A PreToolUse hook should **hard-block (exit 2) only for safety/correctness** (data loss, secret exposure, irreversible state, protected-branch writes). For **style/efficiency/consistency** substitutions ("use tool X instead of shell Y"), prefer a **non-blocking nudge** — because:

- **Subagent dead-end** — PreToolUse hooks fire in every context, but the redirect target (`Glob`, `Grep`) isn't granted in every subagent toolset → a hard block can leave no shell form *and* no tool.
- **Fighting model fluency** — forcing an alternative the model writes less reliably, that's sometimes absent, is a bad trade for a style win.
- **False-positive treadmill** — every block accretes an exemption list over time.

## The litigation test

When deciding whether a block earns its exit-2, look at **what it exempts**. The `find→Glob` block always exempted the dangerous `find -exec` form and only blocked benign `-name` searches → it was never doing safety work, so style was its only justification → demote to a nudge. The `cat`/`sed`/`echo > file` blocks stayed — they prevent real data loss.

Path-scoped to hook-authoring surfaces; registered in the CLAUDE.md rules table (docs-currency).

Captured via `/session-end` distill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)