### PR TITLE
docs(git-plugin): complete stacked-PR choreography + trial-integration

### DIFF
--- a/git-plugin/skills/git-conflicts/SKILL.md
+++ b/git-plugin/skills/git-conflicts/SKILL.md
@@ -165,7 +165,7 @@ Summarize what was resolved:
 
 ### Squash Merge Pitfall
 
-If the same conflicts keep recurring, the likely cause is squash merges. Squash-merging breaks the common ancestry chain, so stacked or sibling branches lose their merge base. Rerere mitigates this by replaying recorded resolutions, but the root fix is to avoid squash merges on branches with dependents.
+If the same conflicts keep recurring, the likely cause is squash merges. Squash-merging breaks the common ancestry chain, so stacked or sibling branches lose their merge base. Rerere mitigates this by replaying recorded resolutions, but the root fix is to avoid squash merges on branches with dependents. When a squashed base leaves a dependent carrying the now-collapsed commits, recover with `git rebase --onto origin/main <old-base-tip> <dependent>` (see the git-pr skill's Stacked PRs section).
 
 ### When to Abort
 
@@ -173,6 +173,43 @@ Abort with `git merge --abort` or `git rebase --abort` if:
 - Conflicts span many files with incompatible architectural changes
 - Resolution requires understanding business requirements you don't have context for
 - Lock files are the only conflicts (delete, regenerate, commit)
+
+## Pre-Merge Trial Integration (landing a wave of PRs)
+
+When several branches will land together — a wave of parallel feature branches,
+a PR stack, or sibling fixes touching overlapping files — surface and resolve
+the conflicts **once, on a throwaway branch, before touching `main`**. This also
+catches the *silent* failure a plain auto-merge can't: when two branches each add
+the **same** helper/import in non-adjacent spots, git merges both copies with no
+conflict, producing a tree that does not compile. The merge *message* is not
+proof of correctness — only compiling the merged tree is.
+
+```bash
+# rerere on, so the resolution you do here is recorded for the real merges
+git config rerere.enabled true
+git config rerere.autoupdate true
+
+git switch -c trial/integration origin/main
+for b in <branch-1> <branch-2> <branch-3>; do
+  git merge --no-ff --no-edit "origin/$b" || git commit --no-edit   # resolve, then commit
+done
+
+<build + test command>          # e.g. just check / cargo test / npm test — the real gate
+```
+
+If the merged tree builds and tests green, the resolution is validated **and
+rerere has cached it**. Discard the trial branch and do the real merges/rebases
+in order — rerere auto-replays the same resolution on the actual base merge and
+on each dependent's `--onto` rebase (see git-pr Stacked PRs), so you never
+re-resolve by hand:
+
+```bash
+git switch main && git branch -D trial/integration   # the rerere cache persists
+```
+
+Payoff: conflicts surface before `main` is touched (not mid-merge under
+pressure); one resolution is replayed everywhere via rerere; and compiling the
+merged tree catches silent duplicate-addition merges a green merge message hides.
 
 ## Quick Reference
 

--- a/git-plugin/skills/git-pr/SKILL.md
+++ b/git-plugin/skills/git-pr/SKILL.md
@@ -284,6 +284,39 @@ gh pr edit <dep-pr-num> --base "$(gh pr view --json baseRefName --jq .baseRefNam
 Once every dependent has been re-targeted (or you have explicitly chosen
 not to), it is safe to merge the parent with `--delete-branch`.
 
+### After a squash-merge: rebase dependents off the squashed commits
+
+Re-targeting alone keeps the dependent **open**, but its diff is still wrong.
+When the parent is **squash-merged** (the release-please / conventional-commit
+default), its commits collapse into one new commit on the base with a fresh
+SHA — so a re-targeted dependent still carries the parent's *original* commits
+in its history and now double-counts the parent's work. Drop them by replaying
+only the dependent's own commits onto the updated base:
+
+```bash
+git fetch origin
+git rebase --onto origin/main <old-parent-tip> <dependent-branch>
+git push --force-with-lease origin <dependent-branch>
+git log --oneline origin/main..HEAD   # verify: only the dependent's own commits
+```
+
+Capture `<old-parent-tip>` with `git rev-parse <parent-branch>` **before**
+merging the parent (the branch is deleted on merge, so grab the SHA first). A
+*merge*-merged parent keeps its patch-ids, so a plain `git rebase origin/main`
+auto-skips the duplicates instead — but squash is the common default, so assume
+the `--onto` form. If the dependent and the parent edited the same lines, expect
+a conflict here: resolve it once and let `git rerere` replay it across this and
+any sibling dependent (see the git-conflicts skill).
+
+### Stacked PRs get no CI until retargeted
+
+CI configured with `on: pull_request: branches: [main]` only runs for PRs
+**targeting `main`**. A dependent PR based on a feature branch therefore shows
+**no checks at all** until it is re-targeted — its pre-merge verification falls
+to a local build/test run in the meantime. Retarget early (or verify locally);
+don't wait on a green check that will never appear while the PR's base is a
+feature branch.
+
 ## Pre-merge Checklist Guidelines
 
 Include only actions **before** merging:


### PR DESCRIPTION
## What

Two gaps surfaced by a real 7-PR wave landing (gh-board Wave 7):

**git-pr — Stacked PRs section** already covered retargeting dependents before deleting the base, but stopped there. Added:
- The post-squash **`git rebase --onto origin/main <old-parent-tip> <dependent>`** cleanup that drops the collapsed base commits from a re-targeted dependent (capture the tip *before* merging the parent).
- The caveat that **`pull_request: branches: [main]` CI never runs on a PR based on a feature branch** — stacked PRs show no checks until retargeted, so verification falls to a local build/test.

**git-conflicts** — added a **Pre-Merge Trial Integration** section: merge all wave branches into a throwaway branch and *compile/test the merged tree* before touching `main`. This surfaces conflicts early **and** the silent failure a plain auto-merge hides (two branches adding the same helper/import in non-adjacent spots → both copies kept → won't compile). Resolve once; `rerere` replays it across the real merges and the `--onto` rebases. Cross-linked the `--onto` recovery from the existing Squash Merge Pitfall note.

## Why

Surveyed the plugin skills: retarget-before-delete and `rerere` basics existed, but the `--onto` squash cleanup, the stacked-PR CI-trigger caveat, and pre-merge trial-integration were absent end-to-end. All three were load-bearing in landing the wave cleanly with one conflict resolved a single time.