### PR TITLE
docs(typescript): modernize bun-lockfile-update (text bun.lock + Renovate consolidation)

### DIFF
--- a/typescript-plugin/skills/bun-lockfile-update/SKILL.md
+++ b/typescript-plugin/skills/bun-lockfile-update/SKILL.md
@@ -3,20 +3,20 @@ created: 2025-12-16
 modified: 2026-05-09
 reviewed: 2026-04-25
 name: bun-lockfile-update
-description: "Bun lockfile update (bun.lockb): bun update, regeneration, security audits. Use when updating dependencies, resolving lockfile conflicts, or regenerating bun.lockb."
+description: "Bun lockfile update (bun.lock): bun update, regeneration, security audits. Use when updating dependencies, resolving lockfile conflicts, or regenerating bun.lock."
 allowed-tools: Bash, Read, Grep, Glob
 ---
 
 # Bun Lockfile Update
 
-Comprehensive guidance for updating Bun lockfiles (`bun.lockb`) with proper dependency management practices.
+Comprehensive guidance for updating Bun lockfiles (`bun.lock`) with proper dependency management practices.
 
 ## When to Use This Skill
 
 | Use this skill when... | Use bun-outdated instead when... |
 |---|---|
 | Running `bun update` to refresh dependencies | Auditing what is outdated without changing anything |
-| Resolving a `bun.lockb` merge conflict by regenerating | Reviewing major version gaps before deciding to upgrade |
+| Resolving a `bun.lock` merge conflict by regenerating | Reviewing major version gaps before deciding to upgrade |
 | Patching a security vulnerability in a specific package | Listing newer versions for a single package |
 | Performing a major version upgrade workflow | Use bun-install when bootstrapping a fresh checkout |
 
@@ -53,7 +53,7 @@ bun update --latest <package-name>
 ### Regenerate Lockfile
 ```bash
 # Regenerate lockfile from package.json (clean install)
-rm bun.lockb
+rm bun.lock
 bun install
 
 # Or force regeneration
@@ -70,7 +70,7 @@ Respects semver ranges in `package.json`:
 bun update
 
 # Review changes
-git diff bun.lockb package.json
+git diff bun.lock package.json
 
 # Test thoroughly
 bun test
@@ -91,7 +91,7 @@ Updates to absolute latest versions:
 bun update --latest
 
 # Review ALL changes carefully
-git diff bun.lockb package.json
+git diff bun.lock package.json
 
 # Test exhaustively (breaking changes likely)
 bun test
@@ -150,7 +150,7 @@ bun update --latest typescript
 2. **Execute update command**
 3. **Review changes:**
    ```bash
-   git diff bun.lockb package.json
+   git diff bun.lock package.json
    ```
 
 ### Post-Update Validation
@@ -188,14 +188,14 @@ bun update --latest typescript
 ### Commit Changes
 ```bash
 # For safe updates
-git add bun.lockb
+git add bun.lock
 git commit -m "chore(deps): update dependencies
 
 Updates all dependencies to latest compatible versions.
 All tests passing."
 
 # For aggressive updates
-git add bun.lockb package.json
+git add bun.lock package.json
 git commit -m "chore(deps): upgrade dependencies to latest
 
 BREAKING CHANGES:
@@ -216,7 +216,7 @@ All tests passing."
 # Weekly/monthly routine
 bun update
 bun test
-git add bun.lockb
+git add bun.lock
 git commit -m "chore(deps): update dependencies"
 ```
 
@@ -235,7 +235,7 @@ bun audit
 
 # Test and commit
 bun test
-git add bun.lockb package.json
+git add bun.lock package.json
 git commit -m "fix(deps): patch security vulnerability in <package>
 
 Fixes: CVE-XXXX-XXXXX"
@@ -281,21 +281,21 @@ See docs/migration/react-18.md for details."
 ```
 
 ### Scenario 4: Lockfile Conflict Resolution
-**Goal:** Resolve merge conflict in `bun.lockb`
+**Goal:** Resolve merge conflict in `bun.lock`
 
 ```bash
 # 1. Accept either version (doesn't matter which)
-git checkout --theirs bun.lockb  # Or --ours
+git checkout --theirs bun.lock  # Or --ours
 
 # 2. Regenerate lockfile from package.json
-rm bun.lockb
+rm bun.lock
 bun install
 
 # 3. Verify installation
 bun test
 
 # 4. Commit resolution
-git add bun.lockb
+git add bun.lock
 git commit -m "chore: resolve lockfile merge conflict"
 ```
 
@@ -322,10 +322,16 @@ bun run build
 
 ## Bun-Specific Features
 
-### Binary Lockfile
-- Bun uses binary lockfile format (`bun.lockb`)
-- Much faster to parse than `package-lock.json` or `yarn.lock`
-- Not human-readable (use `bun pm ls` to inspect)
+### Lockfile Format (`bun.lock`)
+- Since **Bun 1.2** the default lockfile is the text-based `bun.lock` (JSONC) —
+  human-readable and reviewable in `git diff` / PRs.
+- The legacy binary `bun.lockb` is still supported but no longer the default;
+  `bun install` under Bun ≥ 1.2 migrates an existing `bun.lockb` to `bun.lock`
+  (force it with `bun install --save-text-lockfile`).
+- Because it is text, `bun.lock` merge conflicts can be reviewed and often
+  resolved directly — though regenerating (below) is still the simplest fix.
+- Commit exactly one lockfile: keep `bun.lock` and delete any stale `bun.lockb`
+  once migrated.
 
 ### Workspaces
 ```bash
@@ -351,7 +357,7 @@ bun install --lockfile-only
 ```bash
 # Symptoms: Install errors, checksum mismatches
 # Solution: Regenerate lockfile
-rm bun.lockb
+rm bun.lock
 bun install
 ```
 
@@ -370,7 +376,7 @@ bun install --force
 rm -rf ~/.bun/install/cache
 
 # Reinstall
-rm -rf node_modules bun.lockb
+rm -rf node_modules bun.lock
 bun install
 ```
 
@@ -379,7 +385,7 @@ bun install
 # Symptoms: Package version doesn't match expectations
 # Solution: Verify package.json and regenerate lockfile
 cat package.json  # Check version ranges
-rm bun.lockb
+rm bun.lock
 bun install
 ```
 

--- a/typescript-plugin/skills/bun-lockfile-update/SKILL.md
+++ b/typescript-plugin/skills/bun-lockfile-update/SKILL.md
@@ -395,9 +395,29 @@ bun audit --json > audit-report.json
 ```
 
 ### Automated Updates
-```bash
-# Use Renovate or Dependabot for automated PRs
-# Configure in .github/renovate.json or .github/dependabot.yml
+
+Use **Renovate** for automated dependency PRs — it regenerates and commits
+`bun.lock` natively when it patches `package.json`, so update/pin PRs ship a
+synchronized lockfile with no extra configuration.
+
+- **Do not use Dependabot for bun projects.** Dependabot does not maintain
+  `bun.lock`, so its PRs leave the lockfile out of sync. Consolidate on
+  Renovate (remove `.github/dependabot.yml`).
+- **There is no bun value for `postUpdateOptions`.** The allowed values are
+  npm/pnpm/yarn/bundler/go/nuget only; an invented value (e.g. `bunDedupe`)
+  fails Renovate's `allowedValues` validation and breaks the **entire**
+  config. No option is needed to get a matching lockfile on update.
+- **Enable `lockFileMaintenance`** for the periodic full-lockfile refresh
+  (its `enabled` defaults to `false`, so set it explicitly). Bun support for
+  this was a regression fixed in Renovate PR #38694 (Oct 2025).
+
+```json
+// renovate.json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "lockFileMaintenance": { "enabled": true }
+}
 ```
 
 ### Review Dependencies


### PR DESCRIPTION
Modernizes the `bun-lockfile-update` skill on two axes. Two commits:

## 1. Text `bun.lock` (Bun 1.2+)

The skill referenced the legacy binary `bun.lockb` throughout, and the "Binary Lockfile" section claimed the lockfile is binary and not human-readable — false since **Bun 1.2** made the text-based `bun.lock` (JSONC) the default.

- Swapped all operational references (`rm` / `git diff` / `git add` / `git checkout`, intro line, frontmatter description) from `bun.lockb` → `bun.lock`.
- Rewrote the lockfile-format section: `bun.lock` is the reviewable text default since 1.2; `bun.lockb` is legacy and auto-migrates on `bun install`; commit exactly one lockfile.

## 2. Consolidate automated updates on Renovate

The "Automated Updates" section recommended *"Renovate **or** Dependabot"*, which contradicts the bun consolidation: Dependabot does not maintain `bun.lock` and leaves it out of sync.

- Renovate regenerates/commits `bun.lock` natively (no extra config).
- **No bun value for `postUpdateOptions`** — allowed values are npm/pnpm/yarn/bundler/go/nuget only; an invented value breaks the entire config.
- **Enable `lockFileMaintenance`** for periodic refresh (`enabled` defaults to `false`; bun support fixed in Renovate PR #38694, Oct 2025), with a minimal `renovate.json` example.

## Context

Surfaced while reconciling ForumViriumHelsinki/R4C-Cesium-Viewer#912 (Renovate-for-Bun / deprecate Dependabot), whose comment asked to codify the pattern in claude-plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)