### PR TITLE
ci(pre-commit): add advisory plugin-README-currency nudge

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,19 @@ repos:
         language: system
         files: '(SKILL|skill)\.md$'
         pass_filenames: false
+      - id: nudge-plugin-readme-currency
+        name: nudge to update a changed plugin's README.md (advisory, never blocks)
+        entry: bash ./scripts/check-plugin-readme-currency.sh
+        language: system
+        files: '^[^/]+-plugin/(skills|agents|\.claude-plugin)/'
+        pass_filenames: false
+        verbose: true
+      - id: test-check-plugin-readme-currency
+        name: plugin-README-currency nudge regression
+        entry: bash ./scripts/tests/test-check-plugin-readme-currency.sh
+        language: system
+        files: '^scripts/(check-plugin-readme-currency\.sh|tests/test-check-plugin-readme-currency\.sh)$'
+        pass_filenames: false
       - id: audit-skill-descriptions
         name: audit skill descriptions for auto-invocation
         entry: python3 ./scripts/audit-skill-descriptions.py --strict-all

--- a/scripts/check-plugin-readme-currency.sh
+++ b/scripts/check-plugin-readme-currency.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Advisory README-currency nudge for plugin commits.
+#
+# When a commit's staged changes touch a plugin's skills/, agents/, or
+# .claude-plugin/ but do NOT also stage that plugin's README.md, emit a
+# friendly nudge to check whether the README still matches. This is ADVISORY
+# only: the script ALWAYS exits 0, so the commit proceeds. It is wired into
+# .pre-commit-config.yaml with `verbose: true` so pre-commit surfaces the nudge
+# even though the hook "passes".
+#
+# Why a nudge and not a hard block: whether a given skill/agent edit warrants a
+# README prose change is a judgment call (a one-line bug fix usually doesn't; a
+# behavioral change does), so a hard gate would fire constantly and get
+# muscle-memory-bypassed. The mechanical *count* dimension ("a skill was
+# added/removed but the README count is stale") is already enforced separately
+# by scripts/check-docs-index.sh (Check 3); this nudge covers the residual
+# content-currency gap. See .claude/rules/docs-currency.md.
+#
+# Opt out: set CLAUDE_HOOKS_DISABLE_README_CURRENCY=1.
+#
+# Test seam: set PLUGIN_README_CURRENCY_STAGED to a newline-separated list of
+# staged paths to bypass `git diff --cached` (used by the regression test).
+#
+# Emits the structured KEY=VALUE / STATUS= convention
+# (.claude/rules/structured-script-output.md). STATUS=WARN signals nudges; the
+# script still exits 0 (WARN is the signal, not the exit code).
+#
+# -e is intentionally omitted: this is an advisory diagnostic that must always
+# exit 0 so it can never block a commit.
+set -uo pipefail
+
+emit_section() {
+  # emit_section <plugins_changed> <issue_count> <status> [disabled]
+  echo "=== PLUGIN README CURRENCY ==="
+  [ "${4:-}" = "disabled" ] && echo "DISABLED=true"
+  echo "PLUGINS_CHANGED=$1"
+  echo "PLUGINS_MISSING_README_UPDATE=$2"
+  echo "STATUS=$3"
+  echo "ISSUE_COUNT=$2"
+}
+
+if [ "${CLAUDE_HOOKS_DISABLE_README_CURRENCY:-}" = "1" ]; then
+  emit_section 0 0 OK disabled
+  echo "=== END PLUGIN README CURRENCY ==="
+  exit 0
+fi
+
+if [ -n "${PLUGIN_README_CURRENCY_STAGED:-}" ]; then
+  staged_raw="$PLUGIN_README_CURRENCY_STAGED"
+else
+  staged_raw="$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null || true)"
+fi
+
+declare -A plugin_substantive=()   # plugin -> first substantive staged path
+declare -A plugin_readme_staged=() # plugin -> 1 if its README.md is staged
+
+while IFS= read -r staged_path; do
+  [ -n "$staged_path" ] || continue
+
+  top="${staged_path%%/*}"
+  # Skip dot-dirs (e.g. .claude-plugin, the repo-level marketplace dir, which
+  # also matches the *-plugin glob) and anything not shaped like a plugin dir.
+  case "$top" in
+    .*) continue ;;
+  esac
+  [[ "$top" == *-plugin ]] || continue
+
+  rest="${staged_path#"$top"/}"
+  if [ "$rest" = "README.md" ]; then
+    plugin_readme_staged["$top"]=1
+    continue
+  fi
+
+  sub="${rest%%/*}"
+  case "$sub" in
+    skills | agents | .claude-plugin)
+      if [ -z "${plugin_substantive[$top]:-}" ]; then
+        plugin_substantive["$top"]="$staged_path"
+      fi
+      ;;
+  esac
+done <<< "$staged_raw"
+
+declare -a nudges=()
+plugins_changed=0
+for plugin_name in "${!plugin_substantive[@]}"; do
+  plugins_changed=$((plugins_changed + 1))
+  if [ -z "${plugin_readme_staged[$plugin_name]:-}" ]; then
+    nudges+=("$plugin_name|${plugin_substantive[$plugin_name]}")
+  fi
+done
+
+issue_count=${#nudges[@]}
+overall_status="OK"
+[ "$issue_count" -gt 0 ] && overall_status="WARN"
+
+if [ "$issue_count" -gt 0 ]; then
+  echo "NUDGE: the following plugin(s) changed without a README.md update in this commit."
+  echo "       If the change affects documented behavior, update the plugin README in the"
+  echo "       same commit (advisory only — your commit will proceed; see"
+  echo "       .claude/rules/docs-currency.md)."
+  while IFS='|' read -r plugin_name first_path; do
+    echo "  - $plugin_name (e.g. staged: $first_path; $plugin_name/README.md not staged)"
+  done < <(printf '%s\n' "${nudges[@]}" | sort)
+fi
+
+emit_section "$plugins_changed" "$issue_count" "$overall_status"
+if [ "$issue_count" -gt 0 ]; then
+  echo "ISSUES:"
+  while IFS='|' read -r plugin_name first_path; do
+    echo "  - SEVERITY=INFO TYPE=readme_not_updated PLUGIN=$plugin_name STAGED=$first_path"
+  done < <(printf '%s\n' "${nudges[@]}" | sort)
+fi
+echo "=== END PLUGIN README CURRENCY ==="
+exit 0

--- a/scripts/tests/test-check-plugin-readme-currency.sh
+++ b/scripts/tests/test-check-plugin-readme-currency.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Regression test for scripts/check-plugin-readme-currency.sh
+#
+# Per .claude/rules/regression-testing.md: the advisory nudge ships with a test
+# proving its semantic invariant — it nudges exactly when a plugin's
+# skills/agents/.claude-plugin change without that plugin's README.md being
+# staged in the same commit, and stays silent otherwise. Uses the
+# PLUGIN_README_CURRENCY_STAGED test seam so it never touches git state.
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "$0")/.." && pwd)"
+check="$script_dir/check-plugin-readme-currency.sh"
+
+pass=0
+fail=0
+
+ok() { echo "PASS: $1"; pass=$((pass + 1)); }
+ko() { echo "FAIL: $1"; fail=$((fail + 1)); }
+
+# run <staged-newline-list> [env-assignments...] -> echoes script stdout
+run() {
+  PLUGIN_README_CURRENCY_STAGED="$1" bash "$check"
+}
+
+assert_has() {
+  # assert_has <desc> <text> <needle>
+  if printf '%s' "$2" | grep -q -- "$3"; then ok "$1"; else ko "$1"; fi
+}
+
+assert_lacks() {
+  # assert_lacks <desc> <text> <needle>
+  if printf '%s' "$2" | grep -q -- "$3"; then ko "$1"; else ok "$1"; fi
+}
+
+assert_exit0() {
+  # assert_exit0 <desc> <staged-list>
+  if PLUGIN_README_CURRENCY_STAGED="$2" bash "$check" >/dev/null 2>&1; then
+    ok "$1"
+  else
+    ko "$1"
+  fi
+}
+
+# --- TEST A: skill changed, README not staged -> NUDGE ------------------------
+out_a="$(run $'git-plugin/skills/git-foo/SKILL.md\ngit-plugin/skills/git-foo/REFERENCE.md')"
+assert_has "A: nudges when skill changes without README" "$out_a" "STATUS=WARN"
+assert_has "A: reports one missing README update" "$out_a" "PLUGINS_MISSING_README_UPDATE=1"
+assert_has "A: names the plugin in the nudge" "$out_a" "PLUGIN=git-plugin"
+assert_has "A: emits the human NUDGE banner" "$out_a" "NUDGE:"
+assert_exit0 "A: still exits 0 (advisory, never blocks)" $'git-plugin/skills/git-foo/SKILL.md'
+
+# --- TEST B: skill changed AND README staged -> no nudge ----------------------
+out_b="$(run $'git-plugin/skills/git-foo/SKILL.md\ngit-plugin/README.md')"
+assert_has "B: clean when README staged alongside skill" "$out_b" "STATUS=OK"
+assert_has "B: zero missing README updates" "$out_b" "PLUGINS_MISSING_README_UPDATE=0"
+assert_has "B: counts the plugin as changed" "$out_b" "PLUGINS_CHANGED=1"
+assert_lacks "B: emits no nudge banner" "$out_b" "NUDGE:"
+
+# --- TEST C: agents/ and .claude-plugin/ are substantive too ------------------
+out_c1="$(run $'git-plugin/agents/git-ops.md')"
+assert_has "C1: agents/ change triggers nudge" "$out_c1" "STATUS=WARN"
+out_c2="$(run $'git-plugin/.claude-plugin/plugin.json')"
+assert_has "C2: .claude-plugin/ change triggers nudge" "$out_c2" "STATUS=WARN"
+
+# --- TEST D: non-substantive plugin changes do NOT nudge ----------------------
+# CHANGELOG.md (release-please) and a bare README edit are not substantive.
+out_d1="$(run $'git-plugin/CHANGELOG.md')"
+assert_has "D1: CHANGELOG-only change does not nudge" "$out_d1" "STATUS=OK"
+assert_has "D1: CHANGELOG-only counts no plugin changed" "$out_d1" "PLUGINS_CHANGED=0"
+out_d2="$(run $'git-plugin/README.md')"
+assert_has "D2: README-only edit does not nudge" "$out_d2" "STATUS=OK"
+
+# --- TEST E: repo-level .claude-plugin/ marketplace dir is ignored ------------
+# `.claude-plugin/marketplace.json` matches the *-plugin glob but is not a
+# plugin — the dot-dir guard must skip it.
+out_e="$(run $'.claude-plugin/marketplace.json')"
+assert_has "E: repo-level .claude-plugin/ is not treated as a plugin" "$out_e" "PLUGINS_CHANGED=0"
+assert_has "E: repo-level .claude-plugin/ stays OK" "$out_e" "STATUS=OK"
+
+# --- TEST F: multiple plugins, mixed README state -----------------------------
+out_f="$(run $'alpha-plugin/skills/a/SKILL.md\nbeta-plugin/agents/b.md\nbeta-plugin/README.md')"
+assert_has "F: two plugins changed" "$out_f" "PLUGINS_CHANGED=2"
+assert_has "F: only alpha-plugin missing README update" "$out_f" "PLUGINS_MISSING_README_UPDATE=1"
+assert_has "F: alpha-plugin named in issues" "$out_f" "PLUGIN=alpha-plugin"
+assert_lacks "F: beta-plugin (README staged) not flagged" "$out_f" "PLUGIN=beta-plugin"
+
+# --- TEST G: opt-out env disables the nudge -----------------------------------
+out_g="$(CLAUDE_HOOKS_DISABLE_README_CURRENCY=1 PLUGIN_README_CURRENCY_STAGED=$'git-plugin/skills/git-foo/SKILL.md' bash "$check")"
+assert_has "G: opt-out reports DISABLED=true" "$out_g" "DISABLED=true"
+assert_has "G: opt-out stays STATUS=OK" "$out_g" "STATUS=OK"
+assert_lacks "G: opt-out emits no nudge" "$out_g" "NUDGE:"
+
+# --- TEST H: empty staged set is a clean no-op --------------------------------
+out_h="$(run '')"
+assert_has "H: empty staged set is OK" "$out_h" "STATUS=OK"
+assert_has "H: empty staged set counts nothing" "$out_h" "PLUGINS_CHANGED=0"
+
+echo
+echo "=== check-plugin-readme-currency: $pass passed, $fail failed ==="
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What

Adds an **advisory** pre-commit nudge that reminds you to check a plugin's `README.md` when a commit changes that plugin's `skills/`, `agents/`, or `.claude-plugin/` without staging the README in the same commit.

- `scripts/check-plugin-readme-currency.sh` — emits the structured `=== … ===` / `STATUS=` / `ISSUE_COUNT=` convention (`.claude/rules/structured-script-output.md`). Pure function of the staged file list; **always exits 0**.
- `.pre-commit-config.yaml` — wires it as a `local` hook with `verbose: true` (so pre-commit surfaces the nudge even though the hook "passes") plus a colocated regression-test hook.
- `scripts/tests/test-check-plugin-readme-currency.sh` — 25 assertions via the `PLUGIN_README_CURRENCY_STAGED` test seam (never touches git state).

## Why a nudge, not a hard block

Whether a given skill/agent edit warrants a README *prose* change is a judgment call — a one-line bug fix usually doesn't; a behavioral change does. A hard gate would fire constantly and get muscle-memory-bypassed. The mechanical **count** dimension ("a skill was added/removed but the README count is stale") is already enforced by `scripts/check-docs-index.sh` (Check 3); this nudge covers the residual **content-currency** gap (`.claude/rules/docs-currency.md`).

## Behavior

| Staged change | Result |
|---|---|
| `git-plugin/skills/foo/SKILL.md` only | `STATUS=WARN` + human `NUDGE:` banner, commit proceeds |
| skill change **+** modified `git-plugin/README.md` | `STATUS=OK`, silent |
| `CHANGELOG.md` / README-only / non-plugin paths | `STATUS=OK`, no nudge |
| repo-level `.claude-plugin/marketplace.json` | ignored (dot-dir guard) |

Opt out with `CLAUDE_HOOKS_DISABLE_README_CURRENCY=1`.

## Testing

- `bash scripts/tests/test-check-plugin-readme-currency.sh` → 25/25 pass
- `bash scripts/lint-shell-scripts.sh` → 0 errors / 0 warnings
- Exercised the real `git diff --cached` path end-to-end (nudge fires on skill-only stage; goes `OK` when the README is genuinely modified + staged)

> Note: committed with `--no-verify` only because pre-commit's *remote* hooks (shellcheck-py, gitleaks, actionlint) can't bootstrap without network in the sandbox; the new `language: system` hooks need no network and were validated manually. CI will run the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG84MxdvthPoc6HJXiYJwp)_