### PR TITLE
feat(kubernetes-plugin): guard skaffold cluster writes in validate-kubectl-context hook

### DIFF
--- a/kubernetes-plugin/README.md
+++ b/kubernetes-plugin/README.md
@@ -228,12 +228,20 @@ Skills are automatically activated based on user queries:
 ### Context Safety
 All skills emphasize **explicit context specification**:
 ```bash
-# Always use --context
+# Always use --context / --kube-context
 kubectl --context=prod-cluster get pods
 helm --kube-context=prod-cluster status myapp
+skaffold --kube-context=prod-cluster deploy
 ```
 
 Never rely on current context to prevent accidental operations on wrong clusters.
+
+The `validate-kubectl-context.sh` PreToolUse hook enforces this for **all three
+tools**: it blocks cluster-mutating `kubectl`, `helm`, and `skaffold` commands
+that omit an explicit context flag. `skaffold` is included because
+`skaffold deploy/run/dev/delete` write to the *current* kubectl context by
+default and would otherwise bypass the guard (see issue #1870). Pin the context
+per-command with `--kube-context`, or in `skaffold.yaml` via `deploy.kubeContext`.
 
 ### Atomic Deployments
 Use atomic flags for production:

--- a/kubernetes-plugin/hooks/test-validate-kubectl-context.sh
+++ b/kubernetes-plugin/hooks/test-validate-kubectl-context.sh
@@ -240,6 +240,66 @@ assert_exit \
     "helm verify is allowed (local provenance check)" 0 \
     '{"tool_name":"Bash","tool_input":{"command":"helm verify mychart-1.0.0.tgz"}}'
 
+# ── skaffold enforcement tests (issue #1870) ────────────────────────────────
+# skaffold deploys to the current kubectl context by default, so context-less
+# cluster writes must be blocked exactly like kubectl/helm.
+echo ""
+echo "skaffold enforcement (#1870):"
+
+assert_exit \
+    "skaffold deploy without --kube-context is blocked" 2 \
+    '{"tool_name":"Bash","tool_input":{"command":"skaffold deploy"}}'
+
+assert_exit \
+    "skaffold run without --kube-context is blocked" 2 \
+    '{"tool_name":"Bash","tool_input":{"command":"skaffold run"}}'
+
+assert_exit \
+    "skaffold delete without --kube-context is blocked" 2 \
+    '{"tool_name":"Bash","tool_input":{"command":"skaffold delete"}}'
+
+assert_exit \
+    "skaffold dev without --kube-context is blocked" 2 \
+    '{"tool_name":"Bash","tool_input":{"command":"skaffold dev"}}'
+
+assert_exit \
+    "skaffold deploy with --kube-context=NAME is allowed" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"skaffold --kube-context=staging deploy"}}'
+
+assert_exit \
+    "skaffold run with --kube-context NAME is allowed" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"skaffold run --kube-context kind-dev"}}'
+
+assert_exit \
+    "skaffold build (safe subcommand) is allowed" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"skaffold build"}}'
+
+assert_exit \
+    "skaffold render (safe subcommand, no cluster write) is allowed" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"skaffold render"}}'
+
+assert_exit \
+    "skaffold diagnose (safe subcommand) is allowed" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"skaffold diagnose"}}'
+
+assert_exit \
+    "skaffold version (safe subcommand) is allowed" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"skaffold version"}}'
+
+# Prose/quote false-positive guards for skaffold (same class as kubectl/helm)
+assert_exit \
+    "skaffold in double-quoted grep pattern is allowed" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"grep -n \"skaffold deploy\" justfile"}}'
+
+assert_exit \
+    "skaffold mid-prose in echo is allowed" 0 \
+    '{"tool_name":"Bash","tool_input":{"command":"echo remember to run skaffold later"}}'
+
+# env-prefixed skaffold deploy is still a real invocation → blocked
+assert_exit \
+    "env-prefixed skaffold deploy without --kube-context is still blocked" 2 \
+    '{"tool_name":"Bash","tool_input":{"command":"SKAFFOLD_DEFAULT_REPO=reg.example.com skaffold deploy"}}'
+
 # ── Edge cases ───────────────────────────────────────────────────────────────
 echo ""
 echo "Edge cases:"

--- a/kubernetes-plugin/hooks/validate-kubectl-context.sh
+++ b/kubernetes-plugin/hooks/validate-kubectl-context.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-# PreToolUse hook for Bash tool - validates kubectl/helm commands include --context
+# PreToolUse hook for Bash tool - validates kubectl/helm/skaffold commands include a context
 #
 # This hook enforces explicit Kubernetes context selection to prevent accidental
-# operations on the wrong cluster. It blocks kubectl and helm commands that don't
-# specify a --context flag.
+# operations on the wrong cluster. It blocks kubectl, helm, and skaffold commands
+# that perform cluster writes without specifying a context flag
+# (kubectl --context, helm/skaffold --kube-context).
 #
 # Configuration (add to .claude/settings.json or plugin.json):
 # {
@@ -176,6 +177,49 @@ Available contexts can be listed with:
   kubectl config get-contexts
 
 Using explicit --kube-context prevents accidental deployments to production or other critical clusters."
+    fi
+fi
+
+# Check if this is a skaffold command
+#
+# skaffold performs cluster writes (deploy/delete/run/dev/debug/apply) using the
+# *current* kubectl context, so it can silently mutate the wrong cluster exactly
+# like kubectl/helm. Issue #1870: `skaffold deploy` deployed a dev stack into a
+# production GKE cluster because the current context was prod and skaffold was
+# unguarded. skaffold accepts the same `--kube-context` flag as helm.
+if is_invocation skaffold; then
+
+    # skaffold subcommands that never touch a cluster — safe without a context.
+    # Everything not listed here (deploy, delete, run, dev, debug, apply, verify)
+    # falls through to the --kube-context requirement, failing safe on unknown
+    # subcommands.
+    SAFE_SKAFFOLD_SUBCOMMANDS="build|render|diagnose|init|fix|schema|config|completion|version|filter|inspect|credits|survey|test|options|help|lsp|apiserver"
+
+    # Allow safe commands
+    if echo "$COMMAND_CLEAN" | grep -Eq "skaffold\s+($SAFE_SKAFFOLD_SUBCOMMANDS)"; then
+        exit 0
+    fi
+
+    # Check if --kube-context is specified (skaffold uses --kube-context, like helm)
+    if ! echo "$COMMAND_CLEAN" | grep -Eq '\s--kube-context[= ]'; then
+        block "SKAFFOLD SAFETY: Missing --kube-context flag.
+
+skaffold deploys to the CURRENT kubectl context by default, which can silently
+push a dev stack into production. Always pin the context explicitly:
+
+  skaffold --kube-context=CONTEXT_NAME deploy
+  skaffold --kube-context=staging run
+
+Alternatively, pin the context in skaffold.yaml so every run is safe:
+
+  deploy:
+    kubeContext: staging
+
+Available contexts can be listed with:
+  kubectl config get-contexts
+
+Using an explicit --kube-context (or a pinned deploy.kubeContext) prevents
+accidental deploys to production or other critical clusters."
     fi
 fi
 


### PR DESCRIPTION
## Summary

`kubernetes-plugin`'s `validate-kubectl-context.sh` PreToolUse hook enforced an explicit context on `kubectl` and `helm`, but **`skaffold` bypassed the guard entirely**. `skaffold deploy/run/dev/delete` write to the *current* kubectl context by default, so the hook's protection had a hole exactly where the blast radius is largest (multi-resource deploys).

Fixes the near-miss in #1870, where `just glitchtip-dev` ran `skaffold deploy` against a **production** GKE cluster (current context was prod) and deployed a dev GlitchTip stack — app, Postgres, and a 2Gi GCP persistent disk — into production, with the only signal being pods not appearing in the intended kind cluster.

## What changed

- **`hooks/validate-kubectl-context.sh`** — new `skaffold` block mirroring the existing `helm` block:
  - Cluster-mutating subcommands (`deploy`, `run`, `dev`, `debug`, `delete`, `apply`, `verify`, …) require `--kube-context`.
  - Chart/local subcommands (`build`, `render`, `diagnose`, `init`, `fix`, `schema`, `config`, `version`, …) are allowed without a context.
  - Unknown subcommands **fail safe** (require a context).
  - The block message suggests either `--kube-context=NAME` or a pinned `deploy.kubeContext` in `skaffold.yaml`.
  - Detection reuses the existing heredoc / quoted-string / command-position stripping, so prose mentions of "skaffold" (grep patterns, echo args, commit messages) are not treated as invocations.
- **`hooks/test-validate-kubectl-context.sh`** — 13 new regression tests (block/allow, safe subcommands, prose/quote false-positives, env-prefixed invocation). **53 total, all passing.**
- **`README.md`** — documents skaffold coverage in the Context Safety section (docs land in the same commit per `docs-currency`).

## Scope note

`helm` was already guarded by this hook (the issue mentioned both). The only real gap was `skaffold`, so this PR adds skaffold coverage only.

## Verification

```
bash kubernetes-plugin/hooks/test-validate-kubectl-context.sh   # 53 passed, 0 failed
shellcheck kubernetes-plugin/hooks/validate-kubectl-context.sh  # clean
bash scripts/lint-shell-scripts.sh                              # 0 errors, 0 warnings
```

Closes #1870

## Context: issue sequencing

This was picked as the first actionable item from a scheduled sweep of open issues (no open PRs existed). It was chosen as a self-contained, no-dependency safety fix, ahead of the research-tracker issues (#1470, #1657, #1873 — explicitly "not PR-ready" pending more data) and the larger multi-part enhancements (#1585, #1660, #1877).

🤖 Generated with [Claude Code](https://claude.com/claude-code)