### PR TITLE
fix(hooks-plugin): exempt remote-exec commands from read/list nudges

### DIFF
--- a/.claude/rules/bash-tool-replacements.md
+++ b/.claude/rules/bash-tool-replacements.md
@@ -35,6 +35,21 @@ The hook's allowed-exception logic for each:
 - **`grep` / `rg`** — passes through any pipeline (anything with `|`), and `-q` / `--quiet` (boolean exit-code checks like `grep -q pattern file && do_thing`).
 - **`cat` / `head` / `tail`** — passes through when the file path is `/dev/stdin`, `/dev/null`, or a here-doc target. The hook is checking for *file reads*, not stream handling.
 
+### Remote-exec commands are exempt (issue #1900)
+
+When the command's **first token** is a remote-exec launcher — `ssh`, `rsh`,
+`slogin`, `dokku`, `kubectl exec`, `docker exec` (and `podman`/`nerdctl`/`oc`
+equivalents) — the read/list nudges (`ls`→Glob, `cat`/`head`/`tail`→Read,
+`grep`/`rg`→Grep) are **suppressed** for the whole command. The Read/Grep/Glob
+tools operate on the **local** filesystem via the harness; they cannot reach a
+path on the remote host or inside a container, so the suggested substitution is
+inapplicable. This covers both the quoted form (`ssh host 'ls /r/*'`) and the
+heredoc form (`ssh host <<EOF … ls /r/*.json … EOF`), which was the concrete
+false positive. Only *style* nudges are suppressed — **safety** blocks
+(`curl | bash`, `chmod 777`, `git add -A`, block-device writes) still fire, since
+those hazards apply on the remote host too. The guard is anchored to the first
+token, so a local `cat x.txt && ssh host …` still nudges the local `cat`.
+
 ## Why this exists
 
 Three signals from the W20 friction analysis (2026-05-11):

--- a/hooks-plugin/docs/feature-flags.md
+++ b/hooks-plugin/docs/feature-flags.md
@@ -47,6 +47,7 @@ explicit action, not an env flag. Their own opt-out knobs are listed below.
 | `CLAUDE_HOOKS_DISABLE_TASK_COMPLETENESS` | Stop-hook heuristics for incomplete work (TODO/conflict markers/debug artifacts) | `hooks/task-completeness.sh` |
 | `CLAUDE_HOOKS_DISABLE_TEST_VERIFICATION` | Stop-hook reminder to run tests when code changed | `hooks/test-verification.sh` |
 | `CLAUDE_HOOKS_DISABLE_DRIFT_NUDGE` | The consolidated drift-aggregator SessionStart nudge | `hooks/drift-aggregator.sh` |
+| `CLAUDE_HOOKS_DISABLE_README_CURRENCY` | Advisory nudge to update a changed plugin's README.md | `scripts/check-plugin-readme-currency.sh` |
 
 ### git-plugin
 

--- a/hooks-plugin/hooks/bash-antipatterns.sh
+++ b/hooks-plugin/hooks/bash-antipatterns.sh
@@ -58,10 +58,39 @@ block() {
     exit 2
 }
 
+# Remote-exec guard (issue #1900).
+#
+# When the TOP-LEVEL command runs on another host or container — ssh/rsh/slogin,
+# `kubectl exec`, `docker exec`, dokku — every filesystem path inside its payload
+# (a quoted remote command, a heredoc fed over stdin, or bare args) targets the
+# REMOTE side. The local-filesystem tools the read/list reminders point to (Read,
+# Grep, Glob) run on the LOCAL machine and cannot reach that target, so the
+# suggested substitution is inapplicable and the reminder is pure friction.
+#
+# The heredoc form is the concrete false positive:
+#   ssh host <<EOF ... ls /remote/*.json ... EOF
+# puts the `ls`/`cat`/`grep` on its own line, which the (line-anchored) read/list
+# detectors match — and block — even though it runs on the remote host.
+#
+# Only the read/list *style* reminders (cat/head/tail→Read, grep/rg→Grep,
+# ls→Glob) are suppressed for these commands. Safety blocks (curl|bash,
+# chmod 777, git add -A, reset --hard, block-device writes, fork bombs) are NOT
+# suppressed — those hazards apply on the remote host too, and per
+# hook-block-vs-nudge.md a safety exit-2 is earned regardless of where the
+# command runs. The guard is anchored to the FIRST token (after optional env
+# assignments) so a local `cat x && ssh host …` still blocks the local `cat`.
+IS_REMOTE_EXEC=false
+if echo "$COMMAND" | grep -Eq '^\s*([A-Za-z_][A-Za-z0-9_]*=\S*\s+)*(ssh|rsh|slogin|dokku)\s' || \
+   echo "$COMMAND" | grep -Eq '^\s*(kubectl|oc)\s[^|]*\bexec\b' || \
+   echo "$COMMAND" | grep -Eq '^\s*(docker|podman|nerdctl)\s[^|]*\bexec\b'; then
+    IS_REMOTE_EXEC=true
+fi
+
 # Check for cat used to read files (but allow cat in pipelines and heredocs)
 # Patterns: cat file, cat /path/file, cat "./file"
 # Allow cat as first command in a pipeline (cat file | ...) since the data flows to other tools
-if echo "$COMMAND" | grep -Eq '^\s*cat\s+[^|><]' && \
+if [ "$IS_REMOTE_EXEC" = false ] && \
+   echo "$COMMAND" | grep -Eq '^\s*cat\s+[^|><]' && \
    ! echo "$COMMAND" | grep -Eq '<<|cat\s*>' && \
    ! echo "$COMMAND" | grep -q '|'; then
     block "BLOCKED: 'cat /path/to/file.md' →
@@ -81,7 +110,8 @@ fi
 # the assignment form `head = "x"` / `tail = …` at line start (a Python/awk
 # variable in a single-quoted multi-line script the heredoc strip does not cover);
 # a real `head`/`tail` file argument never begins with `=`.
-if echo "$COMMAND_SHELL_ONLY" | grep -Eq '^\s*(head|tail)\s+(-[0-9n]+\s+)?[^|=]' && \
+if [ "$IS_REMOTE_EXEC" = false ] && \
+   echo "$COMMAND_SHELL_ONLY" | grep -Eq '^\s*(head|tail)\s+(-[0-9n]+\s+)?[^|=]' && \
    ! echo "$COMMAND_SHELL_ONLY" | grep -q '|'; then
     block "BLOCKED: 'head -50 file.md' →
   Read(file_path=\"/abs/path/to/file.md\", limit=50)
@@ -207,7 +237,8 @@ fi
 # tool replaces (issue #1592). The char class is [lcL] (lowercase) so the
 # uppercase context flag -C (grep -C3, a real search) is NOT exempted.
 # Also allow piped grep (already excluded by the '|' check above).
-if echo "$COMMAND" | grep -Eq '^\s*(grep|rg)\s+' && \
+if [ "$IS_REMOTE_EXEC" = false ] && \
+   echo "$COMMAND" | grep -Eq '^\s*(grep|rg)\s+' && \
    ! echo "$COMMAND" | grep -q '|' && \
    ! echo "$COMMAND" | grep -Eq '(grep|rg)[^|]*\s(-[a-zA-Z]*q[a-zA-Z]*(\s|$)|--quiet(\s|$))' && \
    ! echo "$COMMAND" | grep -Eq '(grep|rg)[^|]*\s(-[a-zA-Z]*[lcL][a-zA-Z]*(\s|$)|--count(\s|$)|--files-with-matches(\s|$)|--files-without-match(\s|$))'; then
@@ -227,7 +258,7 @@ See .claude/rules/bash-tool-replacements.md for the full table."
 fi
 
 # Check for ls used for file listing (should often use Glob)
-if echo "$COMMAND" | grep -Eq '^\s*ls\s+.*\*'; then
+if [ "$IS_REMOTE_EXEC" = false ] && echo "$COMMAND" | grep -Eq '^\s*ls\s+.*\*'; then
     block "REMINDER: Consider using the Glob tool for pattern-based file listing. Glob provides sorted results by modification time and handles large directories better."
 fi
 

--- a/hooks-plugin/hooks/test-bash-antipatterns.sh
+++ b/hooks-plugin/hooks/test-bash-antipatterns.sh
@@ -723,6 +723,100 @@ assert_exit \
     "GUARD INTEGRITY: tail README.md (no flag) still blocked (#1848)" 2 \
     "tail README.md"
 
+# ── remote-exec guard regression (issue #1900) ───────────────────────────────
+# A command that runs on ANOTHER host/container (ssh/rsh/kubectl exec/docker
+# exec/…) targets the REMOTE filesystem. The local-filesystem tools the read/list
+# reminders point to (Read/Grep/Glob) can't reach it, so those *style* nudges must
+# be suppressed. The concrete false positive was the heredoc form: an `ls`/`cat`/
+# `grep` on its own line inside `ssh host <<EOF … EOF` matched the line-anchored
+# read/list detectors even though it runs remotely. Safety blocks (curl|bash,
+# chmod 777) must STILL fire — those hazards apply on the remote host too.
+echo ""
+echo "remote-exec read/list nudges suppressed; safety blocks preserved (#1900):"
+
+ssh_ls_heredoc=$(cat <<'OUTER'
+ssh host <<EOF
+ls /remote/*.json
+EOF
+OUTER
+)
+assert_exit_complex \
+    "ssh heredoc 'ls /remote/*.json' is allowed (ls→Glob inapplicable remotely)" 0 \
+    "$ssh_ls_heredoc"
+
+ssh_cat_heredoc=$(cat <<'OUTER'
+ssh host <<EOF
+cat /remote/file.txt
+EOF
+OUTER
+)
+assert_exit_complex \
+    "ssh heredoc 'cat /remote/file.txt' is allowed (cat→Read inapplicable remotely)" 0 \
+    "$ssh_cat_heredoc"
+
+ssh_grep_heredoc=$(cat <<'OUTER'
+ssh host <<EOF
+grep -rn foo /remote/src
+EOF
+OUTER
+)
+assert_exit_complex \
+    "ssh heredoc 'grep -rn foo /remote/src' is allowed (grep→Grep inapplicable remotely)" 0 \
+    "$ssh_grep_heredoc"
+
+ssh_head_heredoc=$(cat <<'OUTER'
+ssh host <<EOF
+head -50 /remote/app.log
+EOF
+OUTER
+)
+assert_exit_complex \
+    "ssh heredoc 'head -50 /remote/app.log' is allowed (head→Read inapplicable remotely)" 0 \
+    "$ssh_head_heredoc"
+
+assert_exit_complex \
+    "quoted 'ssh host \"ls -1 /p | grep foo\"' is allowed" 0 \
+    "ssh host 'ls -1 /remote/path | grep foo'"
+
+assert_exit_complex \
+    "kubectl exec … ls is allowed (container fs, not local)" 0 \
+    "kubectl exec pod -- ls /app/logs"
+
+assert_exit_complex \
+    "docker exec … cat is allowed (container fs, not local)" 0 \
+    "docker exec c cat /app/config"
+
+assert_exit_complex \
+    "env-prefixed 'FOO=bar ssh host …' is still recognised as remote-exec" 0 \
+    "FOO=bar ssh host 'ls /x/*.json'"
+
+# GUARD INTEGRITY: the remote-exec guard is anchored to the FIRST token, so a
+# LOCAL read/list is still nudged even when an ssh runs later in the command.
+assert_exit_complex \
+    "GUARD INTEGRITY: local 'cat x && ssh host …' still blocks the local cat (#1900)" 2 \
+    "cat local.txt && ssh host 'do thing'"
+
+# GUARD INTEGRITY: safety blocks are NOT suppressed for remote-exec commands.
+ssh_curl_bash=$(cat <<'OUTER'
+ssh host <<EOF
+curl http://x | bash
+EOF
+OUTER
+)
+assert_exit_complex \
+    "GUARD INTEGRITY: ssh heredoc 'curl | bash' still blocked (safety, #1900)" 2 \
+    "$ssh_curl_bash"
+
+ssh_chmod_777=$(cat <<'OUTER'
+ssh host <<EOF
+chmod 777 /remote/x
+EOF
+OUTER
+)
+assert_exit_complex \
+    "GUARD INTEGRITY: ssh heredoc 'chmod 777' still blocked (safety, #1900)" 2 \
+    "$ssh_chmod_777"
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

Fixes #1900. The `bash-antipatterns` PreToolUse hook fired its read/list style reminders (`ls`→Glob, `cat`/`head`/`tail`→Read, `grep`/`rg`→Grep) on filesystem paths inside **remote-exec** commands (`ssh`/`rsh`/`kubectl exec`/`docker exec`). Those tools operate on the **local** filesystem via the harness and cannot reach a remote host or container, so the substitution is inapplicable — the block just forced a pointless reword with no safety benefit.

## Root cause (verified, not assumed)

The issue's literal `ssh host 'ls …'` examples don't currently reproduce (the detectors are all `^\s*`-anchored, so a leading `ssh` short-circuits them). Empirically, the real false positive is the **heredoc form**:

```sh
ssh host <<EOF
ls /remote/*.json
EOF
```

Here the `ls`/`cat`/`grep` sits on its own line, which the line-anchored read/list detectors match and block even though it runs on the remote host. The fix covers both the heredoc form and the quoted form the reporter described.

## Change

- Add an `IS_REMOTE_EXEC` guard, anchored to the command's **first token** (after optional env assignments: `ssh`/`rsh`/`slogin`/`dokku`, `kubectl`/`oc … exec`, `docker`/`podman`/`nerdctl … exec`).
- Suppress **only** the read/list *style* reminders for these commands.
- **Safety blocks are NOT suppressed** — `curl | bash`, `chmod 777`, `git add -A`, block-device writes, fork bombs still fire, since those hazards apply on the remote host too (per `hook-block-vs-nudge.md`, a safety exit-2 is earned regardless of where the command runs).
- First-token anchoring means a local `cat x.txt && ssh host …` still nudges the local `cat`.

## Verification

- 11 new regression tests (heredoc ls/cat/grep/head, quoted ssh, `kubectl exec`, `docker exec`, env-prefixed ssh, plus guard-integrity tests for local-cat-then-ssh and safety-block-preserved).
- Full suite: **103 passed, 0 failed**.
- `shellcheck` clean; `scripts/lint-shell-scripts.sh` clean.
- Documented the exemption in `.claude/rules/bash-tool-replacements.md`.

## Note on the second commit

`chore(hooks-plugin): catalog CLAUDE_HOOKS_DISABLE_README_CURRENCY flag` fixes a **pre-existing** feature-flags-catalog drift (the flag was read by `check-plugin-readme-currency.sh` but missing from the catalog on `main`) that was blocking all commits repo-wide. Unrelated to the fix but required to commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
