### PR TITLE
feat(opencode): export plugin command hooks to OpenCode JS plugins

### DIFF
--- a/.github/workflows/test-skill-scripts.yml
+++ b/.github/workflows/test-skill-scripts.yml
@@ -17,8 +17,11 @@ on:
       - 'scripts/install-opencode.sh'
       - 'scripts/export-opencode.sh'
       - 'scripts/rewrite-skill-name-to-dir.py'
+      - 'scripts/generate-opencode-hook-plugins.py'
       - 'scripts/tests/test-configure-opencode.sh'
       - 'scripts/tests/test-rewrite-skill-name-to-dir.sh'
+      - 'scripts/tests/test-export-opencode-hooks.sh'
+      - '*-plugin/hooks.json'
       - 'justfile'
       - '.github/workflows/test-skill-scripts.yml'
   push:
@@ -50,3 +53,6 @@ jobs:
 
       - name: Regression-test the OpenCode skill-name rewrite
         run: bash scripts/tests/test-rewrite-skill-name-to-dir.sh
+
+      - name: Regression-test the OpenCode hook-plugin export
+        run: bash scripts/tests/test-export-opencode-hooks.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -194,6 +194,12 @@ repos:
         language: system
         files: '^scripts/(rewrite-skill-name-to-dir\.py|export-opencode\.sh|install-opencode\.sh|tests/test-rewrite-skill-name-to-dir\.sh)$'
         pass_filenames: false
+      - id: test-export-opencode-hooks
+        name: opencode hook-plugin export regression (#1605)
+        entry: bash ./scripts/tests/test-export-opencode-hooks.sh
+        language: system
+        files: '^(scripts/(generate-opencode-hook-plugins\.py|export-opencode\.sh|install-opencode\.sh|tests/test-export-opencode-hooks\.sh)|[^/]+-plugin/hooks\.json)$'
+        pass_filenames: false
       - id: check-git-sandbox-guards
         name: shell test sandboxes guard mktemp against shared-checkout leak (#1692)
         entry: bash ./scripts/check-git-sandbox-guards.sh --strict

--- a/docs/opencode-export.md
+++ b/docs/opencode-export.md
@@ -40,7 +40,7 @@ Produces `dist/opencode/{agents,skills}/`. What converts:
 |---------|----------|
 | **Skills** | Near-lossless — `SKILL.md`, `REFERENCE.md`, and `scripts/` travel together. |
 | **Subagents** | Structural — rulesync drops `model`, `tools`, and `maxTurns` from the frontmatter (OpenCode's agent schema differs). The prompt body and `description` survive. |
-| **Hooks** | Intentionally **not** exported. Claude Code plugin hooks reference `${CLAUDE_PLUGIN_ROOT}` scripts rulesync can't resolve, and OpenCode has no model-evaluation (prompt) hook. Hand-port per plugin (see the `export-opencode.sh` header). |
+| **Hooks** | `command`-type **PreToolUse / PostToolUse** hooks export via our own generator (`generate-opencode-hook-plugins.py`, not rulesync — see [Hooks](#hooks)). `prompt`/`agent` hooks and SessionStart / PreCompact have no OpenCode equivalent and are skipped with a per-plugin report. |
 
 OpenCode reads **plural** `agents/` and `skills/` directories (singular is
 accepted for back-compat); the export already emits plural, so no rename is
@@ -58,6 +58,46 @@ The export's staging step (`rewrite-skill-name-to-dir.py`) rewrites each skill's
 runs on the disposable staging copy only — **the source tree keeps its house-style
 names.** Without it, OpenCode aborts those skills at launch with `Invalid
 frontmatter … name` / `Name mismatch`.
+
+### Hooks
+
+Hooks bypass rulesync entirely: rulesync reads the consumer `.claude/settings.json`
+surface, passes `${CLAUDE_PLUGIN_ROOT}` through literally, and never copies the
+referenced scripts ([dyoshikawa/rulesync#1317](https://github.com/dyoshikawa/rulesync/issues/1317)) —
+so its output threw `ENOENT` on every matched tool call. Instead,
+[`scripts/generate-opencode-hook-plugins.py`](../scripts/generate-opencode-hook-plugins.py)
+(issue [#1605](https://github.com/laurigates/claude-plugins/issues/1605)) projects
+each plugin's `hooks.json` directly:
+
+```
+dist/opencode/
+  plugins/<plugin>-hooks.js            # one OpenCode plugin per hook-bearing plugin
+  hook-scripts/<plugin>/hooks/*.sh     # the referenced scripts, copied
+```
+
+The generated JS resolves its scripts relative to itself
+(`../hook-scripts/<plugin>/`) and exports `CLAUDE_PLUGIN_ROOT` at that root, so
+the scripts run unmodified. The two trees must travel together —
+`install-opencode.sh` copies both.
+
+| Claude Code | OpenCode | Semantics |
+|-------------|----------|-----------|
+| `PreToolUse` command hook | `tool.execute.before` | exit 2 or JSON `permissionDecision: "deny"` → **throw** (blocks the call); `"ask"` → `console.warn` + allow (OpenCode has no prompt-from-hook) |
+| `PostToolUse` command hook | `tool.execute.after` | exit-2 stderr / JSON `decision: "block"` reason / `additionalContext` appended to the model-visible tool output |
+| `prompt` / `agent` hooks | — | skipped: OpenCode has no model-evaluation hook (by design) |
+| `SessionStart` / `PreCompact` | — | skipped: no context-injection equivalent |
+
+Matchers translate too: bare tool names (`Bash` → `bash`), path-scoped forms
+(`Write(docs/prds/**)` → `write` + glob on `filePath`), and `Skill(name)`
+(→ the `skill` tool). Everything that cannot export is reported per plugin on
+the export output **and** in the generated file's header comment. A script
+that goes missing at runtime **fails open** (`console.error` + allow) rather
+than blocking every matched call.
+
+Regression guard: [`scripts/tests/test-export-opencode-hooks.sh`](../scripts/tests/test-export-opencode-hooks.sh)
+asserts every referenced script resolves, blocking semantics survive, no
+literal `${CLAUDE_PLUGIN_ROOT}` reaches generated code, and prompt hooks stay
+skipped.
 
 ## 2. Serve the model
 
@@ -308,14 +348,18 @@ a brainstorm or an older snippet, check it against this table:
   `maxTurns` don't survive rulesync's `claudecode → opencode` conversion. The
   generated `orchestrator.md` re-establishes a primary agent by hand; exported
   subagents keep only their prompt + description.
-- **Hooks are not exported** — hand-port per plugin (see the
-  `export-opencode.sh` header).
+- **Hook export is partial by platform design** — `prompt`/`agent` hooks and
+  SessionStart / PreCompact command hooks have no OpenCode equivalent and are
+  skipped with a per-plugin report; PreToolUse `permissionDecision: "ask"`
+  degrades to a non-blocking warning (see [Hooks](#hooks)).
 - **Local-model capability** — a local MLX model is smaller than a frontier
   model; complex orchestration may need a larger quant or a stronger model id.
 
 ## Related
 
 - [`scripts/export-opencode.sh`](../scripts/export-opencode.sh) — conversion engine
+- [`scripts/generate-opencode-hook-plugins.py`](../scripts/generate-opencode-hook-plugins.py) — hooks.json → OpenCode JS plugin generator
+- [`scripts/tests/test-export-opencode-hooks.sh`](../scripts/tests/test-export-opencode-hooks.sh) — hooks-export regression guard
 - [`scripts/install-opencode.sh`](../scripts/install-opencode.sh) — additive installer
 - [`scripts/configure-opencode.sh`](../scripts/configure-opencode.sh) — config + orchestrator generator
 - [`scripts/tests/test-configure-opencode.sh`](../scripts/tests/test-configure-opencode.sh) — schema regression guard

--- a/scripts/export-opencode.sh
+++ b/scripts/export-opencode.sh
@@ -4,9 +4,11 @@
 #
 # Source is read-only; output is fully reproducible. Skills convert near-losslessly;
 # subagents convert structurally (rulesync drops model/tools/maxTurns — see
-# docs/opencode-export.md). Hooks are intentionally NOT exported: Claude Code plugin
-# hooks reference ${CLAUDE_PLUGIN_ROOT} scripts that rulesync cannot resolve, and
-# OpenCode has no model-evaluation (prompt) hook. Hooks are hand-ported per-plugin.
+# docs/opencode-export.md). Hooks bypass rulesync entirely (it reads the consumer
+# .claude/settings.json surface, not plugin marketplaces — issue #1605): command-type
+# PreToolUse/PostToolUse hooks are projected into OpenCode JS plugins by
+# generate-opencode-hook-plugins.py; prompt/agent hooks and SessionStart/PreCompact
+# have no OpenCode equivalent and are skipped with a per-plugin report.
 #
 # Source skills keep the compact comma-string `allowed-tools` form; this script
 # normalizes them to YAML lists in its disposable staging copy only (rulesync aborts
@@ -83,6 +85,12 @@ python3 "$export_script_dir/rewrite-skill-name-to-dir.py" \
 rm -rf "$export_out_dir"
 mkdir -p "$export_out_dir"
 cp -R "$export_staging/.opencode/." "$export_out_dir/"
+
+# 6. Generate OpenCode hook plugins straight from each plugin's hooks.json
+#    (no rulesync involvement — see the header and issue #1605). Emits
+#    plugins/<plugin>-hooks.js + hook-scripts/<plugin>/hooks/*.sh.
+python3 "$export_script_dir/generate-opencode-hook-plugins.py" \
+    "$export_repo_root" "$export_out_dir"
 
 export_out_skills="$(find "$export_out_dir/skills" -name SKILL.md 2>/dev/null | wc -l | tr -d ' ')"
 export_out_agents="$(find "$export_out_dir/agents" -name '*.md' 2>/dev/null | wc -l | tr -d ' ')"

--- a/scripts/generate-opencode-hook-plugins.py
+++ b/scripts/generate-opencode-hook-plugins.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""Generate OpenCode JS plugins from Claude Code plugin hooks.json manifests.
+
+Part of the OpenCode export pipeline (scripts/export-opencode.sh, issue #1605).
+rulesync cannot export marketplace plugin hooks — it reads the consumer
+.claude/settings.json surface, passes ${CLAUDE_PLUGIN_ROOT} through literally,
+and never copies the referenced scripts (dyoshikawa/rulesync#1317) — so this
+generator projects them directly:
+
+  <plugin>/hooks.json  ->  <out>/plugins/<plugin>-hooks.js
+  <plugin>/hooks/*.sh  ->  <out>/hook-scripts/<plugin>/hooks/*.sh  (referenced scripts only)
+
+Fidelity contract (what exports and how):
+  - PreToolUse  command hooks -> "tool.execute.before": exit code 2 or JSON
+    permissionDecision "deny" -> throw (OpenCode's blocking mechanism); JSON
+    permissionDecision "ask" -> console.warn + allow (OpenCode cannot prompt
+    from a hook).
+  - PostToolUse command hooks -> "tool.execute.after": exit-2 stderr / JSON
+    decision "block" reason / additionalContext appended to the model-visible
+    tool output string.
+
+Skipped, loudly (reported on stdout and in the generated JS header):
+  - prompt / agent hooks — OpenCode has no model-evaluation hook (by design).
+  - SessionStart / PreCompact / other events — no context-injection equivalent.
+  - command strings not shaped `bash ${CLAUDE_PLUGIN_ROOT}/hooks/<script>.sh`.
+
+A missing script at runtime FAILS OPEN (console.error + allow) — deliberately
+NOT the rulesync skeleton's throw-ENOENT-on-every-matched-call failure mode.
+
+Usage: generate-opencode-hook-plugins.py <repo_root> <out_dir>
+"""
+
+import json
+import re
+import shutil
+import sys
+from pathlib import Path
+
+EXPORTABLE_EVENTS = {"PreToolUse": "before", "PostToolUse": "after"}
+
+# Claude Code tool name -> OpenCode built-in tool name.
+CLAUDE_TO_OPENCODE_TOOL = {
+    "Bash": "bash",
+    "Write": "write",
+    "Edit": "edit",
+    "Read": "read",
+    "Glob": "glob",
+    "Grep": "grep",
+    "LS": "list",
+    "Task": "task",
+    "Skill": "skill",
+    "WebFetch": "webfetch",
+    "TodoWrite": "todowrite",
+}
+
+COMMAND_RE = re.compile(
+    r"^bash \$\{CLAUDE_PLUGIN_ROOT\}/hooks/([A-Za-z0-9._-]+\.sh)$"
+)
+MATCHER_WITH_ARG_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)\((.*)\)$")
+
+
+def glob_to_regex(pattern):
+    """Translate a Claude Code matcher glob (docs/prds/**) to a JS regex source.
+
+    `**` crosses path separators; `*` and `?` stay within one component.
+    """
+    out = []
+    i = 0
+    while i < len(pattern):
+        if pattern[i : i + 2] == "**":
+            out.append(".*")
+            i += 2
+        elif pattern[i] == "*":
+            out.append("[^/]*")
+            i += 1
+        elif pattern[i] == "?":
+            out.append("[^/]")
+            i += 1
+        else:
+            out.append(re.escape(pattern[i]))
+            i += 1
+    return "^" + "".join(out) + "$"
+
+
+def normalize_timeout(value):
+    """hooks.json timeouts are seconds, but several manifests carry
+    millisecond-intended values (3000, 5000). Claude Code caps hook timeouts
+    at 600s, so anything above that is treated as milliseconds."""
+    if not isinstance(value, (int, float)) or value <= 0:
+        return 60
+    if value > 600:
+        return max(1, int(value / 1000))
+    return int(value)
+
+
+def parse_matcher(matcher):
+    """Return a list of {tool, path_re, skill_name} dicts (one per `|` alternative),
+    or None when the matcher cannot be translated."""
+    matcher = (matcher or "").strip()
+    if matcher == "":
+        return [{"tool": None, "path_re": None, "skill_name": None}]
+    results = []
+    # Only split alternation when no parenthesised argument is present.
+    alternatives = matcher.split("|") if "(" not in matcher else [matcher]
+    for alt in alternatives:
+        alt = alt.strip()
+        m = MATCHER_WITH_ARG_RE.match(alt)
+        if m:
+            tool_name, arg = m.group(1), m.group(2)
+            opencode_tool = CLAUDE_TO_OPENCODE_TOOL.get(tool_name)
+            if opencode_tool is None:
+                return None
+            if tool_name in ("Write", "Edit", "Read"):
+                results.append(
+                    {"tool": opencode_tool, "path_re": glob_to_regex(arg), "skill_name": None}
+                )
+            elif tool_name == "Skill":
+                results.append(
+                    {"tool": opencode_tool, "path_re": None, "skill_name": arg}
+                )
+            else:
+                return None
+        else:
+            # Bare tool name; MCP tool matchers (mcp__*) pass through verbatim.
+            opencode_tool = CLAUDE_TO_OPENCODE_TOOL.get(alt, alt)
+            results.append({"tool": opencode_tool, "path_re": None, "skill_name": None})
+    return results
+
+
+def js_export_name(plugin_name):
+    return "".join(p.capitalize() for p in re.split(r"[^A-Za-z0-9]+", plugin_name) if p) + "Hooks"
+
+
+JS_TEMPLATE = """// Generated by scripts/generate-opencode-hook-plugins.py — DO NOT EDIT.
+// Source: {plugin}/hooks.json (Claude Code plugin hooks -> OpenCode plugin).
+// Layout: this file lives in <scope>/plugins/; its scripts live in
+// <scope>/hook-scripts/{plugin}/hooks/, and CLAUDE_PLUGIN_ROOT is exported at
+// that root so the scripts' own plugin-root references keep resolving.
+//
+// Semantics:
+//   PreToolUse  -> tool.execute.before  (exit 2 / JSON deny -> throw = block;
+//                                        JSON "ask" -> warn + allow: no prompt hook)
+//   PostToolUse -> tool.execute.after   (block reason / additionalContext appended
+//                                        to the model-visible tool output)
+//   Missing or crashing scripts FAIL OPEN (console.error + allow).
+{skip_report}
+import {{ fileURLToPath }} from "node:url";
+
+const PLUGIN_ROOT = fileURLToPath(new URL("../hook-scripts/{plugin}", import.meta.url));
+
+const BEFORE = {before_json};
+
+const AFTER = {after_json};
+
+// OpenCode tool name -> Claude Code tool name (what the scripts expect on stdin).
+const CLAUDE_TOOL_NAMES = {{
+  bash: "Bash", write: "Write", edit: "Edit", read: "Read", glob: "Glob",
+  grep: "Grep", list: "LS", task: "Task", skill: "Skill",
+  webfetch: "WebFetch", todowrite: "TodoWrite",
+}};
+
+function claudeToolName(tool) {{
+  return CLAUDE_TOOL_NAMES[tool] ?? tool.charAt(0).toUpperCase() + tool.slice(1);
+}}
+
+// OpenCode args are camelCase (filePath); Claude hook payloads are snake_case.
+function toToolInput(args) {{
+  const out = {{}};
+  for (const [k, v] of Object.entries(args ?? {{}}))
+    out[k.replace(/([A-Z])/g, "_$1").toLowerCase()] = v;
+  return out;
+}}
+
+function matches(entry, tool, args, directory) {{
+  if (entry.tool !== null && entry.tool !== tool) return false;
+  if (entry.pathRe) {{
+    let p = args?.filePath ?? args?.file_path ?? "";
+    if (typeof p !== "string" || p === "") return false;
+    if (directory && p.startsWith(directory + "/")) p = p.slice(directory.length + 1);
+    if (!new RegExp(entry.pathRe).test(p)) return false;
+  }}
+  if (entry.skillName) {{
+    const candidates = [args?.name, args?.skill, args?.skillName, args?.id];
+    if (!candidates.includes(entry.skillName)) return false;
+  }}
+  return true;
+}}
+
+function parseDecision(stdout) {{
+  const t = (stdout ?? "").trim();
+  if (!t.startsWith("{{")) return {{}};
+  try {{
+    const j = JSON.parse(t);
+    const hso = j.hookSpecificOutput ?? {{}};
+    return {{
+      deny: hso.permissionDecision === "deny" || j.decision === "block",
+      ask: hso.permissionDecision === "ask",
+      reason: hso.permissionDecisionReason ?? j.reason ?? "",
+      context: hso.additionalContext ?? "",
+    }};
+  }} catch {{
+    return {{}};
+  }}
+}}
+
+async function runHook(entry, payload, directory) {{
+  const script = PLUGIN_ROOT + "/hooks/" + entry.script;
+  try {{
+    const proc = Bun.spawn(["bash", script], {{
+      cwd: directory,
+      stdin: new TextEncoder().encode(JSON.stringify(payload)),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {{
+        ...process.env,
+        CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT,
+        CLAUDE_PROJECT_DIR: directory ?? "",
+      }},
+    }});
+    const killTimer = setTimeout(() => proc.kill(), (entry.timeout ?? 60) * 1000);
+    const exitCode = await proc.exited;
+    clearTimeout(killTimer);
+    return {{
+      exitCode,
+      stdout: await new Response(proc.stdout).text(),
+      stderr: await new Response(proc.stderr).text(),
+    }};
+  }} catch (err) {{
+    // Fail open: a missing/broken hook script must never block tool calls.
+    console.error(`[{plugin}-hooks] ${{entry.script}}: ${{err}}`);
+    return null;
+  }}
+}}
+
+export const {export_name} = async ({{ directory }}) => {{
+  // tool.execute.after does not carry args; capture them per call in before.
+  const argsByCall = new Map();
+  return {{
+    "tool.execute.before": async (input, output) => {{
+      if (input.callID !== undefined) {{
+        if (argsByCall.size > 1000)
+          argsByCall.delete(argsByCall.keys().next().value);
+        argsByCall.set(input.callID, output.args);
+      }}
+      for (const entry of BEFORE) {{
+        if (!matches(entry, input.tool, output.args, directory)) continue;
+        const res = await runHook(entry, {{
+          hook_event_name: "PreToolUse",
+          tool_name: claudeToolName(input.tool),
+          tool_input: toToolInput(output.args),
+          session_id: input.sessionID ?? "",
+          cwd: directory ?? "",
+          transcript_path: "",
+        }}, directory);
+        if (!res) continue;
+        if (res.exitCode === 2)
+          throw new Error(res.stderr.trim() || `Blocked by ${{entry.script}}`);
+        if (res.exitCode !== 0) {{
+          console.error(`[{plugin}-hooks] ${{entry.script}} exited ${{res.exitCode}}: ${{res.stderr.trim()}}`);
+          continue;
+        }}
+        const d = parseDecision(res.stdout);
+        if (d.deny) throw new Error(d.reason || `Blocked by ${{entry.script}}`);
+        if (d.ask)
+          console.warn(`[{plugin}-hooks] ${{entry.script}} requested confirmation (OpenCode cannot prompt; allowing): ${{d.reason}}`);
+      }}
+    }},
+    "tool.execute.after": async (input, output) => {{
+      const args = argsByCall.get(input.callID);
+      argsByCall.delete(input.callID);
+      for (const entry of AFTER) {{
+        if (!matches(entry, input.tool, args, directory)) continue;
+        const res = await runHook(entry, {{
+          hook_event_name: "PostToolUse",
+          tool_name: claudeToolName(input.tool),
+          tool_input: toToolInput(args),
+          tool_response: {{ output: typeof output.output === "string" ? output.output : "" }},
+          session_id: input.sessionID ?? "",
+          cwd: directory ?? "",
+          transcript_path: "",
+        }}, directory);
+        if (!res) continue;
+        const notes = [];
+        if (res.exitCode === 2) {{
+          if (res.stderr.trim()) notes.push(res.stderr.trim());
+        }} else if (res.exitCode === 0) {{
+          const d = parseDecision(res.stdout);
+          if (d.deny && d.reason) notes.push(d.reason);
+          if (d.context) notes.push(d.context);
+        }} else {{
+          console.error(`[{plugin}-hooks] ${{entry.script}} exited ${{res.exitCode}}: ${{res.stderr.trim()}}`);
+        }}
+        if (notes.length && typeof output.output === "string")
+          output.output += `\\n\\n[${{entry.script}}] ` + notes.join("\\n");
+      }}
+    }},
+  }};
+}};
+"""
+
+
+def process_plugin(plugin_dir, out_dir):
+    """Returns (exported_count, skipped list of (event, matcher, kind, reason),
+    copied script names)."""
+    hooks_json = plugin_dir / "hooks.json"
+    manifest = json.loads(hooks_json.read_text())
+    plugin = plugin_dir.name
+
+    entries = {"before": [], "after": []}
+    skipped = []
+    scripts = set()
+
+    for event, groups in (manifest.get("hooks") or {}).items():
+        slot = EXPORTABLE_EVENTS.get(event)
+        for group in groups:
+            matcher = group.get("matcher", "")
+            for hook in group.get("hooks", []):
+                kind = hook.get("type", "command")
+                if slot is None:
+                    skipped.append((event, matcher, kind, "no OpenCode equivalent for this event"))
+                    continue
+                if kind != "command":
+                    skipped.append((event, matcher, kind, "OpenCode has no model-evaluation hook"))
+                    continue
+                cmd = (hook.get("command") or "").strip()
+                m = COMMAND_RE.match(cmd)
+                if not m:
+                    skipped.append((event, matcher, kind, f"unparseable command: {cmd}"))
+                    continue
+                script = m.group(1)
+                parsed = parse_matcher(matcher)
+                if parsed is None:
+                    skipped.append((event, matcher, kind, "untranslatable matcher"))
+                    continue
+                if not (plugin_dir / "hooks" / script).is_file():
+                    skipped.append((event, matcher, kind, f"referenced script missing: hooks/{script}"))
+                    continue
+                timeout = normalize_timeout(hook.get("timeout", 60))
+                for alt in parsed:
+                    entries[slot].append(
+                        {
+                            "tool": alt["tool"],
+                            "pathRe": alt["path_re"],
+                            "skillName": alt["skill_name"],
+                            "script": script,
+                            "timeout": timeout,
+                        }
+                    )
+                scripts.add(script)
+
+    exported = len(entries["before"]) + len(entries["after"])
+    if exported == 0:
+        return 0, skipped, []
+
+    scripts_dst = out_dir / "hook-scripts" / plugin / "hooks"
+    scripts_dst.mkdir(parents=True, exist_ok=True)
+    for script in sorted(scripts):
+        shutil.copy2(plugin_dir / "hooks" / script, scripts_dst / script)
+
+    if skipped:
+        lines = ["//", "// Skipped (not exportable to OpenCode):"]
+        for event, matcher, kind, reason in skipped:
+            shown = matcher or '""'
+            lines.append(f"//   - {event} [{shown}] type={kind}: {reason}")
+        skip_report = "\n".join(lines)
+    else:
+        skip_report = "//"
+
+    js = JS_TEMPLATE.format(
+        plugin=plugin,
+        export_name=js_export_name(plugin),
+        skip_report=skip_report,
+        before_json=json.dumps(entries["before"], indent=2),
+        after_json=json.dumps(entries["after"], indent=2),
+    )
+    plugins_dst = out_dir / "plugins"
+    plugins_dst.mkdir(parents=True, exist_ok=True)
+    (plugins_dst / f"{plugin}-hooks.js").write_text(js)
+    return exported, skipped, sorted(scripts)
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(__doc__.strip().splitlines()[-1], file=sys.stderr)
+        return 2
+    repo_root = Path(sys.argv[1]).resolve()
+    out_dir = Path(sys.argv[2]).resolve()
+
+    print("=== OPENCODE HOOK EXPORT ===")
+    generated = total_exported = total_skipped = total_scripts = 0
+    plugin_dirs = sorted(
+        p.parent for p in repo_root.glob("*-plugin/hooks.json")
+    )
+    for plugin_dir in plugin_dirs:
+        exported, skipped, scripts = process_plugin(plugin_dir, out_dir)
+        js_path = f"plugins/{plugin_dir.name}-hooks.js" if exported else "-"
+        print(
+            f"PLUGIN={plugin_dir.name} JS={js_path} "
+            f"EXPORTED={exported} SKIPPED={len(skipped)}"
+        )
+        for event, matcher, kind, reason in skipped:
+            shown = matcher if matcher else '""'
+            print(f"  SKIP event={event} matcher={shown} type={kind} reason={reason}")
+        if exported:
+            generated += 1
+        total_exported += exported
+        total_skipped += len(skipped)
+        total_scripts += len(scripts)
+
+    print(f"HOOK_PLUGINS_SCANNED={len(plugin_dirs)}")
+    print(f"HOOK_PLUGINS_GENERATED={generated}")
+    print(f"EXPORTED_HOOKS={total_exported}")
+    print(f"SKIPPED_HOOKS={total_skipped}")
+    print(f"COPIED_SCRIPTS={total_scripts}")
+    print("STATUS=OK")
+    print("=== END OPENCODE HOOK EXPORT ===")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/install-opencode.sh
+++ b/scripts/install-opencode.sh
@@ -2,9 +2,10 @@
 # install-opencode.sh — export this marketplace's skills + subagents to OpenCode
 # format and install them additively into an OpenCode config directory.
 #
-# Runs export-opencode.sh into a disposable temp dir, then copies agents/ and
-# skills/ into <target>/{agents,skills}. The copy is ADDITIVE: the user's own
-# agents/skills under <target> are preserved (no rm -rf of the target trees).
+# Runs export-opencode.sh into a disposable temp dir, then copies agents/,
+# skills/, plugins/ (generated hook plugins), and hook-scripts/ into <target>.
+# The copy is ADDITIVE: the user's own agents/skills/plugins under <target>
+# are preserved (no rm -rf of the target trees).
 #
 # Usage: ./scripts/install-opencode.sh <target>
 set -euo pipefail
@@ -43,7 +44,7 @@ if [ -n "$install_other" ] && [ -f "$install_other/$install_receipt" ]; then
     install_dup_warned=1
     echo "DUPLICATE_SCOPE_DETECTED=$install_other"
     echo "WARNING=this marketplace is already installed in the complementary scope; OpenCode merges global + project skills, so launching there will report duplicate tool names"
-    echo "FIX=install into ONE scope only — remove the other with: rm -f \"$install_other/$install_receipt\" && rm -rf \"$install_other/skills\" \"$install_other/agents\""
+    echo "FIX=install into ONE scope only — remove the other with: rm -f \"$install_other/$install_receipt\" && rm -rf \"$install_other/skills\" \"$install_other/agents\" \"$install_other/hook-scripts\" && rm -f \"$install_other\"/plugins/*-plugin-hooks.js"
 fi
 
 install_tmp="$(mktemp -d)"
@@ -55,8 +56,17 @@ mkdir -p "$install_target/agents" "$install_target/skills"
 cp -R "$install_tmp/agents/." "$install_target/agents/"
 cp -R "$install_tmp/skills/." "$install_target/skills/"
 
+# Generated hook plugins (plugins/<plugin>-hooks.js) resolve their scripts via
+# ../hook-scripts/<plugin>/, so the two trees must travel together.
+if [ -d "$install_tmp/plugins" ]; then
+    mkdir -p "$install_target/plugins" "$install_target/hook-scripts"
+    cp -R "$install_tmp/plugins/." "$install_target/plugins/"
+    cp -R "$install_tmp/hook-scripts/." "$install_target/hook-scripts/"
+fi
+
 install_agents="$(find "$install_target/agents" -name '*.md' 2>/dev/null | wc -l | tr -d ' ')"
 install_skills="$(find "$install_target/skills" -name 'SKILL.md' 2>/dev/null | wc -l | tr -d ' ')"
+install_hook_plugins="$(find "$install_target/plugins" -name '*-plugin-hooks.js' 2>/dev/null | wc -l | tr -d ' ')"
 
 # Drop a receipt so a later install into the complementary scope can detect us.
 printf 'installed_at_count=%s\nskills=%s\nagents=%s\n' \
@@ -64,6 +74,7 @@ printf 'installed_at_count=%s\nskills=%s\nagents=%s\n' \
 
 echo "INSTALLED_AGENTS=$install_agents"
 echo "INSTALLED_SKILLS=$install_skills"
+echo "INSTALLED_HOOK_PLUGINS=$install_hook_plugins"
 echo "RECEIPT=$install_target/$install_receipt"
 if [ "$install_dup_warned" -eq 1 ]; then
     echo "STATUS=WARN"

--- a/scripts/tests/test-export-opencode-hooks.sh
+++ b/scripts/tests/test-export-opencode-hooks.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# test-export-opencode-hooks.sh — regression tests for
+# scripts/generate-opencode-hook-plugins.py (issue #1605).
+#
+# Guards the OpenCode hooks-export acceptance criteria:
+#   (a) every generated plugins/<plugin>-hooks.js resolves its referenced
+#       scripts (they are copied under hook-scripts/<plugin>/hooks/),
+#   (b) blocking semantics are preserved (exit 2 / JSON deny -> throw),
+#   (c) no literal ${CLAUDE_PLUGIN_ROOT} survives into generated JS
+#       (the rulesync failure mode this generator replaces),
+#   (d) prompt/agent hooks and unsupported events are skipped, not broken.
+set -uo pipefail
+
+test_script_dir="$(cd "$(dirname "$0")" && pwd)"
+test_repo_root="$(cd "$test_script_dir/../.." && pwd)"
+test_generator="$test_repo_root/scripts/generate-opencode-hook-plugins.py"
+
+pass=0
+fail=0
+
+check() {
+    local label="$1"
+    shift
+    if "$@" >/dev/null 2>&1; then
+        pass=$((pass + 1))
+    else
+        fail=$((fail + 1))
+        echo "FAIL: $label"
+    fi
+}
+
+check_not() {
+    local label="$1"
+    shift
+    if "$@" >/dev/null 2>&1; then
+        fail=$((fail + 1))
+        echo "FAIL: $label"
+    else
+        pass=$((pass + 1))
+    fi
+}
+
+test_tmp="$(mktemp -d)"
+[ -n "$test_tmp" ] && [ -d "$test_tmp" ] || { echo "FAIL: mktemp"; exit 1; }
+trap 'rm -rf "$test_tmp"' EXIT
+
+# --- Fixture suite: synthetic plugin covering every skip class ------------
+fixture_root="$test_tmp/fixture-root"
+mkdir -p "$fixture_root/synthetic-plugin/hooks"
+cat > "$fixture_root/synthetic-plugin/hooks/guard.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+cat > "$fixture_root/synthetic-plugin/hooks/cue.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+cat > "$fixture_root/synthetic-plugin/hooks.json" <<'JSON'
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {"type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/guard.sh", "timeout": 10},
+          {"type": "prompt", "prompt": "evaluate something", "timeout": 15},
+          {"type": "command", "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/oddball.py"}
+        ]
+      },
+      {
+        "matcher": "Write(docs/adrs/**)",
+        "hooks": [
+          {"type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/guard.sh", "timeout": 3000}
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {"type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/missing.sh"}
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {"type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/cue.sh", "timeout": 5}
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {"type": "command", "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/cue.sh"}
+        ]
+      }
+    ]
+  }
+}
+JSON
+
+fixture_out="$test_tmp/fixture-out"
+fixture_report="$(python3 "$test_generator" "$fixture_root" "$fixture_out")" || {
+    echo "FAIL: generator exited non-zero on fixture"
+    echo "$fixture_report"
+    exit 1
+}
+
+fixture_js="$fixture_out/plugins/synthetic-plugin-hooks.js"
+check "fixture: JS emitted" test -f "$fixture_js"
+check "fixture: exported command hooks counted" \
+    grep -q "PLUGIN=synthetic-plugin JS=plugins/synthetic-plugin-hooks.js EXPORTED=3 SKIPPED=4" <<<"$fixture_report"
+check "fixture: prompt hook skipped with reason" \
+    grep -q "type=prompt reason=OpenCode has no model-evaluation hook" <<<"$fixture_report"
+check "fixture: unparseable command skipped" \
+    grep -q "reason=unparseable command: python3" <<<"$fixture_report"
+check "fixture: missing script skipped" \
+    grep -q "reason=referenced script missing: hooks/missing.sh" <<<"$fixture_report"
+check "fixture: SessionStart skipped" \
+    grep -q "SKIP event=SessionStart" <<<"$fixture_report"
+check "fixture: referenced scripts copied" \
+    test -f "$fixture_out/hook-scripts/synthetic-plugin/hooks/guard.sh"
+check "fixture: unreferenced missing script not copied" \
+    bash -c "! test -e '$fixture_out/hook-scripts/synthetic-plugin/hooks/missing.sh'"
+check "fixture: path-glob matcher compiled" \
+    grep -q '"pathRe": "\^docs/adrs/\.\*\$"' "$fixture_js"
+check "fixture: ms-intended timeout normalized to seconds" \
+    grep -q '"timeout": 3' "$fixture_js"
+# The skip-report header comment may cite skipped commands verbatim; the
+# invariant is that no placeholder reaches executable (non-comment) code.
+check_not "fixture: no literal CLAUDE_PLUGIN_ROOT placeholder in JS code" \
+    bash -c "grep -vE '^\s*//' '$fixture_js' | grep -qF '\${CLAUDE_PLUGIN_ROOT}'"
+check "fixture: blocking preserved (throw on exit 2 / deny)" \
+    grep -q "throw new Error" "$fixture_js"
+check "fixture: fail-open marker present" \
+    grep -q "Fail open" "$fixture_js"
+
+# --- Real-repo suite -------------------------------------------------------
+repo_out="$test_tmp/repo-out"
+repo_report="$(python3 "$test_generator" "$test_repo_root" "$repo_out")" || {
+    echo "FAIL: generator exited non-zero on repo"
+    echo "$repo_report"
+    exit 1
+}
+
+for plugin in git-plugin terraform-plugin blueprint-plugin code-quality-plugin; do
+    check "repo: $plugin hooks JS generated" test -f "$repo_out/plugins/$plugin-hooks.js"
+done
+# PreCompact-only / SessionStart-only plugins must not emit an empty JS plugin.
+check_not "repo: agent-patterns-plugin (PreCompact-only) emits no JS" \
+    test -e "$repo_out/plugins/agent-patterns-plugin-hooks.js"
+check_not "repo: codebase-attributes-plugin (SessionStart-only) emits no JS" \
+    test -e "$repo_out/plugins/codebase-attributes-plugin-hooks.js"
+
+# Acceptance criterion (a): every script a generated JS references resolves.
+while IFS=: read -r js script; do
+    plugin_name="$(basename "$js" | sed 's/-hooks\.js$//')"
+    check "repo: $plugin_name references resolvable script $script" \
+        test -f "$repo_out/hook-scripts/$plugin_name/hooks/$script"
+done < <(grep -o '"script": "[^"]*"' "$repo_out"/plugins/*.js \
+    | sed 's/"script": "//; s/"$//')
+
+# The prompt-type PR-issue-link hook must not leak into the git plugin's
+# executable code (the skip-report comment legitimately cites its matcher).
+check_not "repo: prompt hook (create_pull_request) not exported" \
+    bash -c "grep -vE '^\s*//' '$repo_out/plugins/git-plugin-hooks.js' | grep -q 'create_pull_request'"
+check "repo: git-plugin prompt hook reported as skipped" \
+    grep -q "matcher=mcp__github__create_pull_request type=prompt" <<<"$repo_report"
+
+for js in "$repo_out"/plugins/*.js; do
+    check_not "repo: $(basename "$js") has no literal CLAUDE_PLUGIN_ROOT placeholder in code" \
+        bash -c "grep -vE '^\s*//' '$js' | grep -qF '\${CLAUDE_PLUGIN_ROOT}'"
+done
+
+# Acceptance criterion (b): generated JS is valid ESM (node treats .mjs as ESM).
+if command -v node >/dev/null 2>&1; then
+    for js in "$fixture_js" "$repo_out"/plugins/*.js; do
+        cp "$js" "$test_tmp/syntax-check.mjs"
+        check "syntax: $(basename "$js") parses as ESM" \
+            node --check "$test_tmp/syntax-check.mjs"
+    done
+fi
+
+echo ""
+echo "PASS=$pass FAIL=$fail"
+[ "$fail" -eq 0 ] || exit 1
+echo "OK: OpenCode hooks export regression tests passed"


### PR DESCRIPTION
## What

Resolves the hooks-export tracking issue by **not waiting for rulesync**: [dyoshikawa/rulesync#1317](https://github.com/dyoshikawa/rulesync/issues/1317) is still open with zero activity, and the mismatch is architectural (rulesync reads the consumer `.claude/settings.json` surface, not plugin `hooks.json` manifests; it passes `${CLAUDE_PLUGIN_ROOT}` through literally and never copies the referenced scripts, so its skeleton threw `ENOENT` on every matched call). Instead, a new generator projects plugin hooks directly into OpenCode plugins as part of the existing export pipeline.

Closes #1605

## How

`scripts/generate-opencode-hook-plugins.py` (wired into `export-opencode.sh` step 6) emits per hook-bearing plugin:

- `plugins/<plugin>-hooks.js` — a self-contained OpenCode plugin
- `hook-scripts/<plugin>/hooks/*.sh` — the referenced scripts, copied; `CLAUDE_PLUGIN_ROOT` is exported at that root so the scripts run unmodified

| Claude Code | OpenCode | Semantics |
|---|---|---|
| `PreToolUse` command hook | `tool.execute.before` | exit 2 / JSON `permissionDecision: "deny"` → **throw** (blocks); `"ask"` → warn + allow (OpenCode cannot prompt from a hook) |
| `PostToolUse` command hook | `tool.execute.after` | block reason / `additionalContext` appended to the model-visible tool output |
| `prompt` / `agent` hooks | — | skipped (no OpenCode model-evaluation hook — by design, per the issue) |
| `SessionStart` / `PreCompact` | — | skipped (no context-injection equivalent) |

Everything skipped is reported loudly on the export output **and** in the generated JS header. A script missing at runtime **fails open** (`console.error` + allow) — deliberately the opposite of rulesync's throw-on-ENOENT. Matchers translate: bare tool names (`Bash` → `bash`), path globs (`Write(docs/prds/**)` → glob on `filePath`), and `Skill(name)`. Millisecond-intended `timeout` values (3000/5000) are normalized to seconds.

Repo result: 4 plugins generated (`git-plugin` 3 hooks, `terraform-plugin` 1, `blueprint-plugin` 17, `code-quality-plugin` 2 = 23 exported), 9 skipped with reasons; `agent-patterns-plugin` (PreCompact-only) and `codebase-attributes-plugin` (SessionStart-only) correctly emit nothing.

`install-opencode.sh` now copies `plugins/` + `hook-scripts/` together (they resolve relatively) and reports `INSTALLED_HOOK_PLUGINS`.

## Verification

- **Live smoke under bun** (OpenCode's runtime): `terraform apply -auto-approve` blocked via throw with the real script's message; innocuous commands and non-matching tools pass; a frontmatter-less write to `docs/prds/` blocked while the same content outside the glob passes; the code-quality cue appended to `output.output` via the before-hook args capture; a missing script failed open instead of blocking.
- **Regression guard**: `scripts/tests/test-export-opencode-hooks.sh` (53 checks — synthetic fixture covering every skip class + real-repo assertions that every referenced script resolves, blocking semantics survive, no literal `${CLAUDE_PLUGIN_ROOT}` reaches generated code, prompt hooks stay skipped, and each JS parses as ESM). Wired into `.pre-commit-config.yaml` and `test-skill-scripts.yml`.
- **Full pipeline**: `./scripts/export-opencode.sh` end-to-end (rulesync 8.28.1) → 384 skills, 21 agents, 4 hook plugins, `STATUS=OK`; installer smoke shows all trees land.
- Local gates: `lint-shell-scripts.sh`, `check-git-sandbox-guards.sh --strict`, `check-workflow-model.sh` all green. (Remote pre-commit hooks — shellcheck/actionlint — couldn't initialize in this sandbox; CI covers them.)

## Docs

`docs/opencode-export.md` gains a Hooks section (layout, semantics table, fidelity gaps) and updated fidelity/limitations rows; `export-opencode.sh` header updated — same commit per docs-currency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BkDd9oTpYauG8srkyCGYNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkDd9oTpYauG8srkyCGYNK)_