### PR TITLE
docs: replace Scalr references with the tofu-in-GitHub-Actions gitops flow

### DIFF
--- a/agent-patterns-plugin/skills/meta-promote/SKILL.md
+++ b/agent-patterns-plugin/skills/meta-promote/SKILL.md
@@ -66,7 +66,7 @@ For each candidate group, read every file and apply this checklist. Every "yes" 
 
 | Signal | What to look for |
 |---|---|
-| Owner-specific identifiers | Org names (`ForumViriumHelsinki`, `laurigates`), GH repo URLs, container registry paths (`ghcr.io/<org>/...`), GitHub App IDs, secret names, named workspaces (Terraform Cloud, Scalr) |
+| Owner-specific identifiers | Org names (`ForumViriumHelsinki`, `laurigates`), GH repo URLs, container registry paths (`ghcr.io/<org>/...`), GitHub App IDs, secret names, named workspaces (Terraform Cloud, Spacelift) |
 | Owner-specific conventions | Label sets (`docs` vs `documentation`), reviewer usernames (`@user` vs bare `user`), project-routing tables, CI tool choices (Renovate vs Dependabot) |
 | Path-scoped frontmatter that differs | A `paths:` glob that genuinely targets a different directory shape per source |
 | Tooling assumptions | Helm chart names, image-updater configurations, deploy-values schemas tied to one stack |

--- a/agent-patterns-plugin/skills/meta-promote/SKILL.md
+++ b/agent-patterns-plugin/skills/meta-promote/SKILL.md
@@ -66,7 +66,7 @@ For each candidate group, read every file and apply this checklist. Every "yes" 
 
 | Signal | What to look for |
 |---|---|
-| Owner-specific identifiers | Org names (`ForumViriumHelsinki`, `laurigates`), GH repo URLs, container registry paths (`ghcr.io/<org>/...`), GitHub App IDs, secret names, named workspaces (Terraform Cloud, Spacelift) |
+| Owner-specific identifiers | Org or user names (`OrgA`, `some-user`), GH repo URLs, container registry paths (`ghcr.io/<org>/...`), GitHub App IDs, secret names, named workspaces (Terraform Cloud, Spacelift) |
 | Owner-specific conventions | Label sets (`docs` vs `documentation`), reviewer usernames (`@user` vs bare `user`), project-routing tables, CI tool choices (Renovate vs Dependabot) |
 | Path-scoped frontmatter that differs | A `paths:` glob that genuinely targets a different directory shape per source |
 | Tooling assumptions | Helm chart names, image-updater configurations, deploy-values schemas tied to one stack |

--- a/comfyui-plugin/README.md
+++ b/comfyui-plugin/README.md
@@ -10,7 +10,8 @@ This plugin packages the three skills that build and ship ComfyUI node packs:
 scaffolding a CI-green repository, orchestrating the full path from idea to a
 live-on-registry pipeline (repo creation, seeding, and the gitops adoption PR
 that wires branch protection + release-please credentials + the registry token
-via Scalr), and adding a reproducible README-screenshot pipeline to a pack.
+via the gitops repo's tofu GitHub Actions workflows), and adding a reproducible
+README-screenshot pipeline to a pack.
 
 ## Skills
 
@@ -49,9 +50,10 @@ internals are modelled with local structural interfaces.
 
 Orchestrate a pack from idea to live-on-registry: scaffold (via
 `comfyui-node-scaffold`), create + seed the GitHub repo, then open the gitops PR
-that adds the `comfy_registry = true` entry and a transient import block so Scalr
-adopts the repo. Stops at the single human gate (merging the gitops PR triggers
-the Scalr apply), then finishes the import-block-removal follow-up.
+that adds the `comfy_registry = true` entry and a transient import block so
+gitops adopts the repo. Stops at the single human gate (merging the gitops PR
+feeds the release-please → `tofu-apply.yml` chain), then finishes the
+import-block-removal follow-up.
 
 **Use when** releasing or spinning up a new comfyui node pack with minimal manual
 steps.
@@ -76,4 +78,4 @@ screenshot pipeline like `comfyui-gallery-loader`.
 
 Install when you build ComfyUI custom-node packs and want a repeatable path from
 idea to a published, registry-adopted repository. The skills are specific to the
-laurigates pack family and its gitops/Scalr adoption flow.
+laurigates pack family and its gitops (tofu-in-GitHub-Actions) adoption flow.

--- a/comfyui-plugin/skills/comfy-node/SKILL.md
+++ b/comfyui-plugin/skills/comfy-node/SKILL.md
@@ -37,7 +37,7 @@ Do **not** use it to add a node to an existing pack, or to publish a release
 ```mermaid
 flowchart LR
   idea["idea"] --> sc["scaffold.py"] --> gh["gh repo create<br/>+ seed main"] --> gop["gitops PR<br/>(entry + import block)"]
-  gop --> gate["👤 merge gitops PR"] --> apply["Scalr apply:<br/>adopt + secrets + protection"] --> rm["remove import block"] --> impl["implement + release"]
+  gop --> gate["👤 merge gitops PR"] --> apply["tofu-apply on release:<br/>adopt + secrets + protection"] --> rm["remove import block"] --> impl["implement + release"]
   classDef g fill:#1b4332,stroke:#2d6a4f,color:#fff
   classDef m fill:#6a040f,stroke:#9d0208,color:#fff
   class sc,gh,gop,apply,rm g
@@ -46,8 +46,10 @@ flowchart LR
 
 Everything left of the gate is one orchestrated pass. There is **no scaffold
 PR** — the seed goes straight to `main` (see Phase 3 for why). The single gate
-(merging the gitops PR) is intentionally human — it triggers an infra `apply`
-on shared state. Never merge it on the user's behalf.
+(merging the gitops PR) is intentionally human — it feeds the apply pipeline on
+shared infra state (release-please cuts a gitops release, whose publication
+triggers the `tofu-apply.yml` GitHub Actions workflow). Never merge it on the
+user's behalf.
 
 ## Preconditions
 
@@ -235,18 +237,20 @@ labels `chore` + `opentofu` (both exist in the gitops repo; check
 `gh label list -R laurigates/gitops` if unsure).
 
 Set metadata per `github-metadata-hygiene` (assignee `laurigates`; skip
-self-reviewer — the author is the running user). Scalr posts a `plan` check on
-the PR; the expected plan **imports** the repo and **creates** the
+self-reviewer — the author is the running user). The `tofu-plan.yml` workflow
+posts the plan as a comment on the PR; the expected plan **imports** the repo
+and **creates** the
 `REGISTRY_ACCESS_TOKEN` secret + release-please var/secret + branch-protection
 ruleset.
 
 ## Phase 5 — Human gate, then finish
 
 Hand the user the new repo URL and the **gitops PR** URL. **The user merges the
-gitops PR** — that is the Scalr `apply` trigger on shared infra state. Do not
-merge it for them.
+gitops PR** — that starts the apply chain on shared infra state (release-please
+cuts a gitops release PR; merging that publishes a release, which triggers
+`tofu-apply.yml`). Do not merge it for them.
 
-After the user confirms the Scalr apply landed, verify the wiring and remove the
+After the user confirms the tofu apply landed, verify the wiring and remove the
 now-dead import block:
 
 ```sh
@@ -296,16 +300,18 @@ DOM test gap) to `project:comfyui-nodes` per `taskwarrior-cross-session`.
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| `publish.yml` fails `Option '--token' requires an argument` | `comfy_registry` flag not yet applied | Confirm the Scalr apply landed; `gh secret list` shows `REGISTRY_ACCESS_TOKEN`; re-run `gh workflow run publish.yml -R laurigates/<name>` |
+| `publish.yml` fails `Option '--token' requires an argument` | `comfy_registry` flag not yet applied | Confirm the tofu apply landed; `gh secret list` shows `REGISTRY_ACCESS_TOKEN`; re-run `gh workflow run publish.yml -R laurigates/<name>` |
 | release-please job fails on empty `app-id` | `release_please` credentials not applied, or repo on the legacy PAT workflow | The scaffold ships the App-token `release-please.yml`; confirm apply landed, re-run via `workflow_dispatch` |
 | `403 Resource not accessible by integration` on repo create | Tried to create via the gitops App, not a personal token | Create with personal `gh auth`; the App only adopts via import |
-| Scalr plan shows a *create* (not *import*) for the repo | Import block missing or `id` wrong | The `id` is the bare repo name, not `owner/name`; add/fix the import block |
+| The tofu plan shows a *create* (not *import*) for the repo | Import block missing or `id` wrong | The `id` is the bare repo name, not `owner/name`; add/fix the import block |
 | `just check` red in gitops | `tofu fmt`/`validate` failure | `just format` then re-check before pushing |
 
 ## Notes
 
-- The orchestrator never runs `tofu apply` — all applies go through Scalr on
-  merge (see `gitops/CLAUDE.md`). Local gitops work is `plan`/`validate` only.
+- The orchestrator never runs `tofu apply` — all applies go through the gitops
+  repo's `tofu-apply.yml` GitHub Actions workflow, triggered by publishing the
+  release-please release (see `gitops/CLAUDE.md`). Local gitops work is
+  `plan`/`validate` only.
 - The scaffold now emits the registry finishing-pass pieces (icon/banner SVGs +
   wiring, renovate + registry-health + clear-autorelease workflows) and audits
   for the rest; `just assets` (rsvg-convert) produces the served PNGs. See the

--- a/comfyui-plugin/skills/comfyui-node-scaffold/scaffold.py
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/scaffold.py
@@ -1722,8 +1722,9 @@ RELEASE_CHECKLIST = """\
 
 - [ ] Register the publisher / confirm `PublisherId` in `pyproject.toml` `[tool.comfy]`.
 - [ ] Add the repo to `gitops/repositories.tf` with `comfy_registry = true` and
-      `release_please = true` (do not configure via the GitHub UI). On the Scalr
-      apply, gitops pushes `REGISTRY_ACCESS_TOKEN`, `RELEASE_PLEASE_APP_ID` (var),
+      `release_please = true` (do not configure via the GitHub UI). On the gitops
+      apply (the `tofu-apply.yml` workflow, triggered by the gitops release),
+      gitops pushes `REGISTRY_ACCESS_TOKEN`, `RELEASE_PLEASE_APP_ID` (var),
       and `RELEASE_PLEASE_PRIVATE_KEY` (secret) automatically — no manual secret
       creation. The `/comfy-node` orchestrator does this wiring for you.
 - [ ] Verify the secrets landed: `gh secret list -R laurigates/<name>`.

--- a/foundryvtt-plugin/README.md
+++ b/foundryvtt-plugin/README.md
@@ -9,7 +9,8 @@ TypeScript + bun + biome** toolchain.
 This plugin packages the two skills that build and ship FoundryVTT modules:
 scaffolding a CI-green module repository, and orchestrating the full path from
 idea to a release pipeline (repo creation, seeding, and the gitops adoption PR
-that wires branch protection + release-please credentials via Scalr).
+that wires branch protection + release-please credentials via the gitops repo's
+tofu GitHub Actions workflows).
 
 FoundryVTT modules distribute by **GitHub release manifest URL** — `manifest`
 points at `releases/latest/download/module.json` and `download` at
@@ -50,9 +51,9 @@ Three variants:
 Orchestrate a module from idea to release-ready: scaffold (via
 `foundryvtt-module-scaffold`), create + seed the GitHub repo, then open the
 gitops PR that adds the `release_please = true` entry and a transient import
-block so Scalr adopts the repo. Stops at the single human gate (merging the
-gitops PR triggers the Scalr apply), then finishes the import-block-removal
-follow-up.
+block so gitops adopts the repo. Stops at the single human gate (merging the
+gitops PR feeds the release-please → `tofu-apply.yml` chain), then finishes the
+import-block-removal follow-up.
 
 **Use when** releasing or spinning up a new FoundryVTT module with minimal
 manual steps.
@@ -61,5 +62,5 @@ manual steps.
 
 Install when you build FoundryVTT modules and want a repeatable path from idea to
 a release-pipeline-ready, gitops-adopted repository. The skills are specific to
-the laurigates module family and its gitops/Scalr adoption flow, and target the
-local `foundryvtt-harness` as the run/test environment.
+the laurigates module family and its gitops (tofu-in-GitHub-Actions) adoption
+flow, and target the local `foundryvtt-harness` as the run/test environment.

--- a/foundryvtt-plugin/skills/foundryvtt-module/SKILL.md
+++ b/foundryvtt-plugin/skills/foundryvtt-module/SKILL.md
@@ -36,7 +36,7 @@ Do **not** use it to add a feature to an existing module, or to publish a releas
 ```mermaid
 flowchart LR
   idea["idea"] --> sc["scaffold.py"] --> gh["gh repo create<br/>+ seed main"] --> gop["gitops PR<br/>(entry + import block)"]
-  gop --> gate["👤 merge gitops PR"] --> apply["Scalr apply:<br/>adopt + release-please<br/>creds + protection"] --> rm["remove import block"] --> impl["implement + release"]
+  gop --> gate["👤 merge gitops PR"] --> apply["tofu-apply on release:<br/>adopt + release-please<br/>creds + protection"] --> rm["remove import block"] --> impl["implement + release"]
   classDef g fill:#1b4332,stroke:#2d6a4f,color:#fff
   classDef m fill:#6a040f,stroke:#9d0208,color:#fff
   class sc,gh,gop,apply,rm g
@@ -45,8 +45,10 @@ flowchart LR
 
 Everything left of the gate is one orchestrated pass. There is **no scaffold
 PR** — the seed goes straight to `main` (the repo is unprotected until adoption).
-The single gate (merging the gitops PR) is intentionally human — it triggers an
-infra `apply` on shared state. Never merge it on the user's behalf.
+The single gate (merging the gitops PR) is intentionally human — it feeds the
+apply pipeline on shared infra state (release-please cuts a gitops release,
+whose publication triggers the `tofu-apply.yml` GitHub Actions workflow). Never
+merge it on the user's behalf.
 
 ## Preconditions
 
@@ -219,17 +221,18 @@ pushes the release-please App credentials, applies the branch-protection ruleset
 and that a follow-up PR removes the import block. Use labels `chore` + `opentofu`
 (check `gh label list -R laurigates/gitops` if unsure). Set metadata per
 `github-metadata-hygiene` (assignee `laurigates`; skip self-reviewer — the author
-is the running user). Scalr posts a `plan` check; the expected plan **imports**
-the repo and **creates** the release-please var/secret + branch-protection
-ruleset.
+is the running user). The `tofu-plan.yml` workflow posts the plan as a comment
+on the PR; the expected plan **imports** the repo and **creates** the
+release-please var/secret + branch-protection ruleset.
 
 ## Phase 5 — Human gate, then finish
 
 Hand the user the new repo URL and the **gitops PR** URL. **The user merges the
-gitops PR** — that is the Scalr `apply` trigger on shared infra state. Do not
-merge it for them.
+gitops PR** — that starts the apply chain on shared infra state (release-please
+cuts a gitops release PR; merging that publishes a release, which triggers
+`tofu-apply.yml`). Do not merge it for them.
 
-After the user confirms the Scalr apply landed, verify the release-please
+After the user confirms the tofu apply landed, verify the release-please
 credentials and remove the now-dead import block:
 
 ```sh
@@ -280,15 +283,17 @@ Log durable follow-ups to the user's FoundryVTT taskwarrior project per
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| release-please job fails on empty `app-id` | release-please credentials not yet applied | Confirm the Scalr apply landed; `gh api … variables/RELEASE_PLEASE_APP_ID` returns a name; re-run via `workflow_dispatch` |
+| release-please job fails on empty `app-id` | release-please credentials not yet applied | Confirm the tofu apply landed; `gh api … variables/RELEASE_PLEASE_APP_ID` returns a name; re-run via `workflow_dispatch` |
 | `403 Resource not accessible by integration` on repo create | Tried to create via the gitops App, not a personal token | Create with personal `gh auth`; the App only adopts via import |
-| Scalr plan shows a *create* (not *import*) for the repo | Import block missing or `id` wrong | The `id` is the bare repo name, not `owner/name`; add/fix the import block |
+| The tofu plan shows a *create* (not *import*) for the repo | Import block missing or `id` wrong | The `id` is the bare repo name, not `owner/name`; add/fix the import block |
 | `just check` red in gitops | `tofu fmt`/`validate` failure | `just format` then re-check before pushing |
 | Module fails to load in Foundry | `esmodules` path ≠ Vite output, or `id` ≠ folder | The scaffold pins these; confirm `dist/<id>.mjs` exists and the install folder is `<id>` |
 
 ## Notes
 
-- The orchestrator never runs `tofu apply` — all applies go through Scalr on
-  merge (see `gitops/CLAUDE.md`). Local gitops work is `plan`/`validate` only.
+- The orchestrator never runs `tofu apply` — all applies go through the gitops
+  repo's `tofu-apply.yml` GitHub Actions workflow, triggered by publishing the
+  release-please release (see `gitops/CLAUDE.md`). Local gitops work is
+  `plan`/`validate` only.
 - Playwright integration tests against the harness and a Quench in-Foundry suite
   are not scaffolded; add them later if the module warrants them.


### PR DESCRIPTION
## What

Removes all remaining Scalr references from skill/README/scaffold content, replacing them with the current gitops flow: OpenTofu in GitHub Actions (`tofu-plan.yml` posts the plan on PRs; merging feeds release-please, whose published release triggers `tofu-apply.yml` — gitops ADR-0001).

## Why

The gitops repo migrated off Scalr; skills describing a "Scalr apply" gate would mislead agents running the comfy-node / foundryvtt-module adoption flows.

## Changes

- `comfyui-plugin/skills/comfy-node/SKILL.md` + `foundryvtt-plugin/skills/foundryvtt-module/SKILL.md` — mermaid flow, plan-check description, human-gate wording, failure-modes table, and apply notes now describe the tofu-plan/release-please/tofu-apply chain
- Both plugin READMEs — adoption-flow prose updated
- `comfyui-node-scaffold/scaffold.py` — release-checklist template updated
- `agent-patterns-plugin/skills/meta-promote/SKILL.md` — generic TACO workspace example swapped (Scalr → Spacelift) to avoid implying Scalr is in use

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2WWGkovQdiqtbYxQH9JA8
