### PR TITLE
docs(benchmarks): add marketplace quality benchmark vs claude-plugins-official

### DIFF
--- a/docs/benchmarks/2026-07-marketplace-quality/README.md
+++ b/docs/benchmarks/2026-07-marketplace-quality/README.md
@@ -1,0 +1,41 @@
+# Marketplace Quality Benchmark — 2026-07
+
+Head-to-head quality benchmark of **laurigates/claude-plugins** vs
+**anthropics/claude-plugins-official** (pinned @ `4cd126ba`, 2026-07-02).
+
+Start with **[marketplace-quality-comparison.md](marketplace-quality-comparison.md)** —
+executive summary, two-channel scoreboard, pair capsules, bias audit, and ranked
+adopt/consider/skip takeaways.
+
+## Method in one paragraph
+
+Two channels, never blended: **Channel M** — a deterministic Python pass over both
+full trees (`metrics.json`); **Channel J** — anchored 1–5 judgments, median of two
+independent judges per unit. Nine overlap pairs were staged into anonymous
+`side-A`/`side-B` directories and judged **blind** on six authoring-quality
+dimensions (B1–B6); marketplace infrastructure was judged **open-book** on six
+dimensions (A1–A6). All scored anchors were frozen before judging from published
+Anthropic guidance plus the official repo's own skill-creator references
+(`rubric.md`, including a 12-item house-criteria exclusion list). Every extreme
+score required a verbatim quote, mechanically string-matched against staged files
+(231/231 verified, 0 fabricated); the highest-stakes findings were re-judged by
+adversarial refuters with a symmetric-standard check. Identity leakage and A/B
+position bias were measured and are published in the report's §6 — read it before
+quoting any single number.
+
+## Files
+
+| File | What it is |
+|---|---|
+| `marketplace-quality-comparison.md` | The report (all numeric tables generated from `synthesis.json`) |
+| `rubric.md` | Frozen scoring anchors + provenance + house-criteria exclusion list |
+| `synthesis.json` | Unblinded medians, verdicts, refuter corrections, bias audit |
+| `metrics.json` | Channel M mechanical metrics over both trees (byte-deterministic) |
+| `refutations.json` | Adversarial refuter verdicts for the 10 selected findings |
+| `tier_c.json` | Descriptive (unscored) catalog asymmetries |
+| `judgments/*.json` | All 20 raw judge outputs (18 blind pair + 2 Tier-A), with evidence quotes |
+
+Reproduction scripts (`stage_pairs.py`, `compute_metrics.py`, `quote_check.py`,
+`synthesize.py`, `build_report.py`) ran from a session scratchpad and are not
+committed; the judgments + synthesis here are the complete audit trail for every
+number in the report.

--- a/docs/benchmarks/2026-07-marketplace-quality/judgments/autonomous-loop_j1.json
+++ b/docs/benchmarks/2026-07-marketplace-quality/judgments/autonomous-loop_j1.json
@@ -1,0 +1,116 @@
+{
+  "pair_id": "autonomous-loop",
+  "judge_id": "j1",
+  "dimensions": {
+    "B1": {
+      "score_a": 3,
+      "score_b": 5,
+      "verdict": "B",
+      "rationale": "A's command descriptions state what they do with distinct names but carry no trigger conditions (when-to-use lives only in README/help). B's description front-loads the use case, states concrete trigger phrasings, and its body table explicitly disambiguates from three sibling skills.",
+      "evidence": [
+        {
+          "side": "B",
+          "file": "side-B/project-plugin/skills/project-test-loop/SKILL.md",
+          "quote": "Automated TDD test-fix-refactor cycle until tests pass. Use when looping on failing tests, running a TDD cycle, or driving RED/GREEN/REFACTOR until green."
+        },
+        {
+          "side": "B",
+          "file": "side-B/project-plugin/skills/project-test-loop/SKILL.md",
+          "quote": "| Use this skill when... | Use project-continue instead when... |"
+        }
+      ]
+    },
+    "B2": {
+      "score_a": 4,
+      "score_b": 4,
+      "verdict": "tie",
+      "rationale": "A gives exact runnable commands, explicit ordered cancel steps, and explains the self-reference mechanism; B gives a thorough ordered procedure with decision trees, a specified report format, and explicit stop conditions. Each has one gap: A's help text cites a wrong state-file path; B declares args (--max-cycles, test-pattern) that no step ever parses or applies.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/ralph-loop/commands/cancel-ralph.md",
+          "quote": "1. Check if `.claude/ralph-loop.local.md` exists using Bash: `test -f .claude/ralph-loop.local.md && echo \"EXISTS\" || echo \"NOT_FOUND\"`"
+        },
+        {
+          "side": "B",
+          "file": "side-B/project-plugin/skills/project-test-loop/SKILL.md",
+          "quote": "- Same test fails 3 times in a row (STUCK)"
+        }
+      ]
+    },
+    "B3": {
+      "score_a": 4,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "A's always-loaded command bodies are a few lines each; all mechanics run as executable scripts never read into context, and long-form explanation sits in an on-demand help command and README. B inlines its entire ~190-line procedure plus failure-pattern catalog in one SKILL.md — within lean limits but with no supporting-file split.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/ralph-loop/commands/ralph-loop.md",
+          "quote": "\"${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh\" $ARGUMENTS"
+        }
+      ]
+    },
+    "B4": {
+      "score_a": 5,
+      "score_b": 2,
+      "verdict": "A",
+      "rationale": "A pushes all deterministic work (arg parsing, iteration counting, promise detection, transcript parsing) into robust standalone scripts with input validation, bounded parsing, and atomic state updates, and the command explicitly runs them. B leaves mechanical work — test-command detection, cycle counting, stuck-tracking — as prose the model re-derives each run, with no bundled script.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/ralph-loop/hooks/stop-hook.sh",
+          "quote": "# Capped at the last 100 assistant lines to keep jq's slurp input bounded"
+        },
+        {
+          "side": "B",
+          "file": "side-B/project-plugin/skills/project-test-loop/SKILL.md",
+          "quote": "1. **Detect test command** (if not already configured):"
+        }
+      ]
+    },
+    "B5": {
+      "score_a": 4,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "A applies least-privilege consistently — each command's allowed-tools scoped to exact script paths/commands — uses injection-safe jq --arg construction, hides commands from model invocation, and provides a cancel escape hatch; the infinite-by-default loop is the one risky default, mitigated only by warnings. B's Read/Edit/unscoped-Bash grant is broad but plausibly what a test-fix loop needs, with a guard against gaming tests.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/ralph-loop/commands/ralph-loop.md",
+          "quote": "allowed-tools: [\"Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh:*)\"]"
+        },
+        {
+          "side": "A",
+          "file": "side-A/plugins/ralph-loop/scripts/setup-ralph-loop.sh",
+          "quote": "⚠️  WARNING: This loop cannot be stopped manually! It will run infinitely"
+        }
+      ]
+    },
+    "B6": {
+      "score_a": 3,
+      "score_b": 4,
+      "verdict": "B",
+      "rationale": "A's hook has excellent error paths and self-cleanup, but cross-file duplication has visibly drifted: help.md cites the wrong state-file name (.ralph-loop.local.md), the setup warning ('cannot be stopped manually') contradicts the /cancel-ralph command, and the README references a differently-named plugin's cache path. B is internally coherent with an explicit auto-stop taxonomy, verification after every fix/refactor, and a single-source governance rule the skill points to rather than duplicates.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/ralph-loop/commands/help.md",
+          "quote": "1. Creates `.claude/.ralph-loop.local.md` state file"
+        },
+        {
+          "side": "B",
+          "file": "side-B/project-plugin/skills/project-test-loop/SKILL.md",
+          "quote": "- Error in test command itself (TEST SETUP ISSUE)"
+        }
+      ]
+    }
+  },
+  "identity_leakage": {
+    "recognized": true,
+    "side_a_guess": "Anthropic's official plugins marketplace ralph-wiggum/ralph-loop plugin (README's Windows workaround cites ~/.claude/plugins/cache/claude-plugins-official/ralph-wiggum/, and plugin.json author is Anthropic).",
+    "side_b_guess": "laurigates/claude-plugins (project-plugin:project-test-loop plus its .claude/rules/loop-integrity.md, which I have seen in this environment's project rules).",
+    "leak_evidence": "Side A: 'claude-plugins-official/ralph-wiggum' cache path and author 'Anthropic' in plugin.json. Side B: verbatim match with the loop-integrity.md rule present in this session's loaded project context. Scores were anchored to rubric text only; recognition did not enter the per-dimension judgments."
+  },
+  "overall_comment": "Complementary strengths: A is an engineering-first artifact — deterministic scripts, tight permissions, lean always-loaded surface — weakened by drifted duplicated docs; B is a documentation-first artifact — outstanding triggering, coherent governance and stop conditions — weakened by zero determinism offload and declared-but-unused arguments. A wins B3/B4/B5, B wins B1/B6, B2 ties."
+}

--- a/docs/benchmarks/2026-07-marketplace-quality/judgments/autonomous-loop_j2.json
+++ b/docs/benchmarks/2026-07-marketplace-quality/judgments/autonomous-loop_j2.json
@@ -1,0 +1,121 @@
+{
+  "pair_id": "autonomous-loop",
+  "judge_id": "j2",
+  "dimensions": {
+    "B1": {
+      "score_a": 3,
+      "score_b": 5,
+      "verdict": "B",
+      "rationale": "Side A's command descriptions state what but not when ('Start Ralph Loop in current session'), leaning on the plugin.json description and a /help command; competent but not trigger-rich. Side B's description is third-person, front-loads the key use case, lists realistic trigger phrasings, and its body explicitly disambiguates from three sibling skills.",
+      "evidence": [
+        {
+          "side": "B",
+          "file": "side-B/project-plugin/skills/project-test-loop/SKILL.md",
+          "quote": "Automated TDD test-fix-refactor cycle until tests pass. Use when looping on failing tests, running a TDD cycle, or driving RED/GREEN/REFACTOR until green."
+        },
+        {
+          "side": "B",
+          "file": "side-B/project-plugin/skills/project-test-loop/SKILL.md",
+          "quote": "| Use this skill when... | Use project-continue instead when... |"
+        }
+      ]
+    },
+    "B2": {
+      "score_a": 4,
+      "score_b": 4,
+      "verdict": "tie",
+      "rationale": "Side A gives correct runnable mechanics (script invocation, exact cancel steps) plus the 'why' of the same-prompt loop and an explicit honesty constraint on the exit promise. Side B gives concrete ordered steps, per-ecosystem detection, branch logic, a specified report format, and failure-pattern examples; its one gap is that --max-cycles is declared in args but never operationalized in the steps. Both exceed competent; neither is flawless.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/ralph-loop/commands/ralph-loop.md",
+          "quote": "CRITICAL RULE: If a completion promise is set, you may ONLY output it when the statement is completely and unequivocally TRUE."
+        },
+        {
+          "side": "B",
+          "file": "side-B/project-plugin/skills/project-test-loop/SKILL.md",
+          "quote": "- Same test fails 3 times in a row (STUCK)"
+        }
+      ]
+    },
+    "B3": {
+      "score_a": 5,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A is textbook multi-level disclosure: command bodies are a few lines, all mechanics live in executable scripts that run without being read into context, and long-form explanation sits in a separate on-demand /help command and README. Side B inlines everything — failure-pattern catalog, refactoring checklists, TDD phase details, report template — in one always-loaded SKILL.md with no supporting files.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/ralph-loop/commands/ralph-loop.md",
+          "quote": "\"${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh\" $ARGUMENTS"
+        }
+      ]
+    },
+    "B4": {
+      "score_a": 5,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A pushes all mechanical work (arg parsing, state-file lifecycle, transcript parsing, promise matching, iteration counting) into robust standalone scripts with input validation, error diagnostics, and atomic writes, and the command makes clear the script is to be run. Side B's deterministic gate is the test suite itself (a dedicated tool), but iteration bookkeeping and test-command detection stay as prose with no bundled script.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/ralph-loop/hooks/stop-hook.sh",
+          "quote": "# Validate numeric fields before arithmetic operations"
+        },
+        {
+          "side": "A",
+          "file": "side-A/plugins/ralph-loop/hooks/stop-hook.sh",
+          "quote": "# Capped at the last 100 assistant lines to keep jq's slurp input bounded"
+        }
+      ]
+    },
+    "B5": {
+      "score_a": 4,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A applies exemplary least-privilege (Bash scoped to the exact script path, rm scoped to the exact state file), safe jq parsing, quoted paths, and session isolation; the one blemish is the unlimited-by-default loop, a risky default even though loudly warned. Side B's Read/Edit/Bash grant is broad but arguably necessary for arbitrary test commands, shell surface is minimal, and behavior matches intent — competent, not exceptional.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/ralph-loop/commands/ralph-loop.md",
+          "quote": "allowed-tools: [\"Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh:*)\"]"
+        },
+        {
+          "side": "A",
+          "file": "side-A/plugins/ralph-loop/scripts/setup-ralph-loop.sh",
+          "quote": "⚠️  WARNING: This loop cannot be stopped manually! It will run infinitely"
+        }
+      ]
+    },
+    "B6": {
+      "score_a": 3,
+      "score_b": 4,
+      "verdict": "B",
+      "rationale": "Side A's hook script has excellent failure paths, but the docs carry real inconsistencies: /help twice names the state file '.claude/.ralph-loop.local.md' (actual: ralph-loop.local.md), the setup warning 'cannot be stopped manually' contradicts /cancel-ralph's existence, and script comments say the loop 'feeds your output back as input' while the design docs insist the same prompt repeats. Side B is internally coherent with explicit auto-stop/failure conditions and verification after every fix/refactor, held to 4 by mild duplication and a referenced check script not present in the staged set.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/ralph-loop/commands/help.md",
+          "quote": "1. Creates `.claude/.ralph-loop.local.md` state file"
+        },
+        {
+          "side": "B",
+          "file": "side-B/project-plugin/skills/project-test-loop/SKILL.md",
+          "quote": "Error in test command itself (TEST SETUP ISSUE)"
+        },
+        {
+          "side": "B",
+          "file": "side-B/project-plugin/skills/project-test-loop/SKILL.md",
+          "quote": "Re-run tests after each refactoring"
+        }
+      ]
+    }
+  },
+  "identity_leakage": {
+    "recognized": true,
+    "side_a_guess": "Anthropic's official ralph-wiggum / ralph-loop plugin (author 'Anthropic'; README cites '~/.claude/plugins/cache/claude-plugins-official/ralph-wiggum/')",
+    "side_b_guess": "laurigates/claude-plugins (project-plugin:project-test-loop plus its .claude/rules/loop-integrity.md and cross-references to agent-patterns-plugin siblings)",
+    "leak_evidence": "Side A plugin.json declares author 'Anthropic' and the README's Windows workaround names the claude-plugins-official cache path; Side B's loop-integrity rule cross-references agent-patterns-plugin skills and a scripts/check-loop-integrity.sh regression guard characteristic of that marketplace. Scores were assigned against the anchors before considering origin."
+  },
+  "overall_comment": "Side A is an engineering-quality artifact: minimal always-loaded surface, robust deterministic scripts, and tight least-privilege scoping, but its documentation has drifted (stale state-file names, contradictory descriptions of the stop mechanism). Side B is a single prose skill with excellent triggering, sibling disambiguation, and loop-governance rationale, but it inlines all detail and offloads little mechanics. A wins B3/B4/B5; B wins B1/B6; B2 ties."
+}

--- a/docs/benchmarks/2026-07-marketplace-quality/judgments/claude-md_j1.json
+++ b/docs/benchmarks/2026-07-marketplace-quality/judgments/claude-md_j1.json
@@ -1,0 +1,99 @@
+{
+  "pair_id": "claude-md",
+  "judge_id": "j1",
+  "dimensions": {
+    "B1": {
+      "score_a": 4,
+      "score_b": 5,
+      "verdict": "B",
+      "rationale": "Both sides have third-person, trigger-rich, front-loaded descriptions. Side B additionally disambiguates explicitly against near-miss sibling skills (meta-promote, session-distill, health-skill-audit, blueprint:rules) so an agent can route between overlapping artifacts; side A's skill/command split is disambiguated only in the README, not in the artifacts themselves.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/claude-md-management/skills/claude-md-improver/SKILL.md",
+          "quote": "Use when user asks to check, audit, update, improve, or fix CLAUDE.md files."
+        },
+        {
+          "side": "B",
+          "file": "side-B/agent-patterns-plugin/skills/meta-context-diet/SKILL.md",
+          "quote": "Use when CLAUDE.md feels bloated, trimming context, or promoting a rule into a skill."
+        },
+        {
+          "side": "B",
+          "file": "side-B/agent-patterns-plugin/skills/meta-context-diet/SKILL.md",
+          "quote": "You want to move rules/skills *between scopes* (project → user-global) — use `meta-promote`"
+        }
+      ]
+    },
+    "B2": {
+      "score_a": 4,
+      "score_b": 4,
+      "verdict": "tie",
+      "rationale": "Both give concrete ordered steps, runnable commands, specified output formats, and the reasoning behind rules (side A's good/bad examples with 'why'; side B's litmus tests and dispositions-with-signals). Side B's meta-context-diet leans on external house artifacts (skill-naming.md, /reload-skills) a zero-context agent cannot resolve, and blueprint-claude-md has messy step numbering (6/6b/6c, best-practices interposed before step 12), offsetting its richer reasoning.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/claude-md-management/skills/claude-md-improver/SKILL.md",
+          "quote": "**Why:** Build command was missing, causing confusion about how to run the project."
+        },
+        {
+          "side": "B",
+          "file": "side-B/agent-patterns-plugin/skills/meta-context-diet/SKILL.md",
+          "quote": "The litmus test — *if the user never raises this topic, does the guidance still need to be in context?* If no, it is a skill."
+        }
+      ]
+    },
+    "B3": {
+      "score_a": 4,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A keeps a ~6KB body and pushes rubrics and templates into references/ loaded on demand — clear two-level disclosure. Side B's skills are ~11KB each with everything inline (templates, report formats, disposition mechanics) and no supporting files at all; lean enough not to be deficient, but no progressive disclosure.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/claude-md-management/skills/claude-md-improver/SKILL.md",
+          "quote": "See [references/quality-criteria.md](references/quality-criteria.md) for detailed rubrics."
+        }
+      ]
+    },
+    "B4": {
+      "score_a": 3,
+      "score_b": 3,
+      "verdict": "tie",
+      "rationale": "Both domains are mostly judgment work (quality assessment, classification) with the small mechanical parts delegated to inline commands (side A's find discovery; side B's find/wc inventory and a jq manifest update). Neither bundles scripts, and neither has mechanical work substantial enough to plainly demand one.",
+      "evidence": []
+    },
+    "B5": {
+      "score_a": 4,
+      "score_b": 4,
+      "verdict": "tie",
+      "rationale": "Both gate the destructive act (editing CLAUDE.md) behind explicit user approval with diffs shown first, and both state intent up front. Side B's meta-context-diet has exemplary scoped Bash allowances and per-candidate confirmation, but its sibling blueprint-claude-md grants bare Bash; side A grants bare Bash on the skill and uses the nonstandard 'tools:' frontmatter key, so neither is consistently least-privilege across every component.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/claude-md-management/skills/claude-md-improver/SKILL.md",
+          "quote": "**This skill can write to CLAUDE.md files.** After presenting a quality report and getting user approval, it updates CLAUDE.md files with targeted improvements."
+        },
+        {
+          "side": "B",
+          "file": "side-B/agent-patterns-plugin/skills/meta-context-diet/SKILL.md",
+          "quote": "allowed-tools: Glob, Read, Edit, Write, Bash(git status *), Bash(git diff *), Bash(wc *), Bash(ls *), AskUserQuestion, TodoWrite"
+        }
+      ]
+    },
+    "B6": {
+      "score_a": 3,
+      "score_b": 3,
+      "verdict": "tie",
+      "rationale": "Side A's two cited reference files resolve and content is coherent, but references/update-guidelines.md is orphaned (never referenced from SKILL.md) and duplicates the body's Phase 4 guidance — a two-homes-for-one-fact flaw. Side B is internally coherent with verification steps (git status after writes, diff-before-apply) but references many out-of-artifact house files and has duplicate/irregular step numbering in blueprint-claude-md. Comparable competent-with-blemishes on both sides.",
+      "evidence": []
+    }
+  },
+  "identity_leakage": {
+    "recognized": true,
+    "side_a_guess": "Anthropic's official claude-code plugins repo — the claude-md-management plugin (plugin.json author 'Anthropic', README credits an anthropic.com email).",
+    "side_b_guess": "laurigates/claude-plugins — meta-context-diet (agent-patterns-plugin) and blueprint-claude-md (blueprint-plugin) match skills listed in this session's own environment catalog.",
+    "leak_evidence": "Side A plugin.json: \"author\": {\"name\": \"Anthropic\"...}; Side B skill names/plugins (agent-patterns-plugin:meta-context-diet, blueprint-plugin:blueprint-claude-md) and house-rule references (skill-quality.md, skill-consolidation.md) match the host repo's conventions visible in my system context. Recognition did not influence scores; anchors were applied to staged content only."
+  },
+  "overall_comment": "Two competent takes on CLAUDE.md maintenance. Side A is a small, clean, well-disclosed plugin (lean body, on-demand references, explicit approval gating) marred by an orphaned duplicate reference file and a nonstandard 'tools:' frontmatter key. Side B is denser and more reasoning-rich, with exemplary trigger disambiguation and scoped permissions in one skill, but everything inline (no progressive disclosure), out-of-artifact house references, and untidy step numbering in the other. Net: B edges triggering, A edges context economy, everything else is a wash."
+}

--- a/docs/benchmarks/2026-07-marketplace-quality/judgments/claude-md_j2.json
+++ b/docs/benchmarks/2026-07-marketplace-quality/judgments/claude-md_j2.json
@@ -1,0 +1,92 @@
+{
+  "pair_id": "claude-md",
+  "judge_id": "j2",
+  "dimensions": {
+    "B1": {
+      "score_a": 4,
+      "score_b": 4,
+      "verdict": "tie",
+      "rationale": "Both sides state what the artifact does plus concrete third-person trigger conditions. A front-loads realistic phrasings and near-miss mentions in the description itself; B's descriptions are competent and both B skills add body-level 'When to Use This Skill' disambiguation tables against sibling skills.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/claude-md-management/skills/claude-md-improver/SKILL.md",
+          "quote": "Use when user asks to check, audit, update, improve, or fix CLAUDE.md files."
+        },
+        {
+          "side": "B",
+          "file": "side-B/agent-patterns-plugin/skills/meta-context-diet/SKILL.md",
+          "quote": "Use when CLAUDE.md feels bloated, trimming context, or promoting a rule into a skill."
+        }
+      ]
+    },
+    "B2": {
+      "score_a": 4,
+      "score_b": 4,
+      "verdict": "tie",
+      "rationale": "A gives phased, imperative steps with fully specified report and diff output formats and explains why each addition helps. B's meta-context-diet gives a disposition rubric with litmus tests and reasoning that generalizes; blueprint-claude-md is thorough but has step-numbering oddities and leans on ecosystem context (manifest.json, blueprint modes) a zero-context agent may lack.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/claude-md-management/skills/claude-md-improver/SKILL.md",
+          "quote": "**ALWAYS output the quality report BEFORE making any updates.**"
+        },
+        {
+          "side": "B",
+          "file": "side-B/agent-patterns-plugin/skills/meta-context-diet/SKILL.md",
+          "quote": "The litmus test — *if the user never raises this topic, does the guidance still need to be in context?* If no, it is a skill."
+        }
+      ]
+    },
+    "B3": {
+      "score_a": 4,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "A demonstrates real progressive disclosure: a lean SKILL.md that defers detailed rubrics and templates to on-demand reference files. B is single-file on both skills; meta-context-diet is acceptably lean, but blueprint-claude-md inlines ~318 lines of templates, mutually exclusive mode branches, and full report formats that are always loaded when it triggers.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/claude-md-management/skills/claude-md-improver/SKILL.md",
+          "quote": "See [references/quality-criteria.md](references/quality-criteria.md) for detailed rubrics."
+        }
+      ]
+    },
+    "B4": {
+      "score_a": 3,
+      "score_b": 3,
+      "verdict": "tie",
+      "rationale": "Neither side bundles scripts, but the mechanical work is thin on both: discovery/counting is delegated to concrete CLI one-liners (find on A; find/wc/jq on B), and the core work (quality judgment, classification) is genuinely non-mechanical. Judged relative to the mechanical work that actually exists, both meet the competent anchor."
+    },
+    "B5": {
+      "score_a": 4,
+      "score_b": 4,
+      "verdict": "tie",
+      "rationale": "Both explicitly gate writes behind user approval (A: report-then-approve before Edit; B: per-candidate AskUserQuestion, never bundling approvals, no commits). Neither is consistently least-privilege across every component: A's skill grants unscoped Bash (and uses a 'tools:' key), B's blueprint skill grants unscoped Bash+Write, though meta-context-diet's scoped Bash patterns are exemplary.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/claude-md-management/skills/claude-md-improver/SKILL.md",
+          "quote": "After user approval, apply changes using the Edit tool. Preserve existing content structure."
+        },
+        {
+          "side": "B",
+          "file": "side-B/agent-patterns-plugin/skills/meta-context-diet/SKILL.md",
+          "quote": "Bash(git status *), Bash(git diff *), Bash(wc *), Bash(ls *)"
+        }
+      ]
+    },
+    "B6": {
+      "score_a": 3,
+      "score_b": 3,
+      "verdict": "tie",
+      "rationale": "Both are internally coherent with verification steps (A: validation checklist and report-before-write; B: git status after writes, diff before applying), but each has resolution defects: A ships an orphaned reference file (update-guidelines.md never linked from SKILL.md) and a command that instructs a bash find without Bash in allowed-tools; B references house files and slash-commands that do not resolve within the staged content, and meta-context-diet's Context find commands are not covered by its scoped Bash grants."
+    }
+  },
+  "identity_leakage": {
+    "recognized": true,
+    "side_a_guess": "Anthropic's official claude-code plugins repo (claude-md-management example plugin; README credits an anthropic.com author).",
+    "side_b_guess": "laurigates/claude-plugins marketplace (blueprint-plugin and agent-patterns-plugin skills; meta-context-diet matches a skill available in my own session catalog).",
+    "leak_evidence": "Side A: plugin.json author 'Anthropic' / 'support@anthropic.com' and README 'Isabella He (isabella@anthropic.com)'. Side B: directory names blueprint-plugin/agent-patterns-plugin, house frontmatter fields (created/modified/reviewed), and references to skill-quality.md / skill-consolidation.md / /reload-skills, which match the laurigates house conventions. Recognition did not influence scoring; all scores anchored to staged content only."
+  },
+  "overall_comment": "Close pair. A is the cleaner authoring exemplar: lean body plus on-demand references, fully specified outputs, gated writes — its edge is B3. B's meta-context-diet is individually the strongest artifact in the pair (scoped Bash, disciplined approval flow, reasoning-rich rubric), but blueprint-claude-md drags B on context economy with a long inlined monolith, and both B skills carry unresolved house references within the staged content."
+}

--- a/docs/benchmarks/2026-07-marketplace-quality/judgments/code-review_j1.json
+++ b/docs/benchmarks/2026-07-marketplace-quality/judgments/code-review_j1.json
@@ -1,0 +1,107 @@
+{
+  "pair_id": "code-review",
+  "judge_id": "j1",
+  "dimensions": {
+    "B1": {
+      "score_a": 2,
+      "score_b": 5,
+      "verdict": "B",
+      "rationale": "Side A's command description is a bare 5-word phrase with no trigger conditions or contexts. Side B's descriptions state what each artifact does plus concrete third-person triggers front-loaded, and both skills carry explicit sibling-disambiguation tables so overlapping artifacts route correctly.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/code-review/commands/code-review.md",
+          "quote": "description: Code review a pull request"
+        },
+        {
+          "side": "B",
+          "file": "side-B/code-quality-plugin/skills/code-review/SKILL.md",
+          "quote": "description: Code review for quality, security, performance, and architecture. Use when reviewing code, auditing OWASP, checking SOLID, or finding perf bottlenecks and test gaps."
+        },
+        {
+          "side": "B",
+          "file": "side-B/code-quality-plugin/skills/code-review/SKILL.md",
+          "quote": "| Running an end-to-end review across quality, security, perf, and tests | Walking a manual security/correctness checklist → `code-review-checklist` |"
+        }
+      ]
+    },
+    "B2": {
+      "score_a": 5,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A gives a precisely ordered, executable procedure: agent-by-agent tasks, a verbatim 0-100 confidence rubric, an exhaustive false-positive taxonomy, exact output/link formats, and the reasoning behind constraints (why bash substitution in links fails). Side B's steps are competent but high-level category lists with more degrees of freedom left to the executing agent.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/code-review/commands/code-review.md",
+          "quote": "You must provide the full sha. Commands like `https://github.com/owner/repo/blob/$(git rev-parse HEAD)/foo/bar` will not work, since your comment will be directly rendered in Markdown."
+        },
+        {
+          "side": "A",
+          "file": "side-A/plugins/code-review/commands/code-review.md",
+          "quote": "The scale is (give this rubric to the agent verbatim):"
+        }
+      ]
+    },
+    "B3": {
+      "score_a": 3,
+      "score_b": 3,
+      "verdict": "tie",
+      "rationale": "Both sides keep their always-loaded bodies lean (~90-140 lines) and focused on the core procedure; neither inlines bulky reference material, and neither uses multi-level progressive disclosure (nor clearly needs it at this size)."
+    },
+    "B4": {
+      "score_a": 3,
+      "score_b": 3,
+      "verdict": "tie",
+      "rationale": "Code review is judgment-heavy on both sides; both delegate deterministic retrieval to dedicated tools (gh CLI on A; Glob/Grep/gh/git and named external analyzers on B) and neither leaves an obviously scriptable mechanical step as re-derived prose, so neither is penalized for lacking bundled scripts."
+    },
+    "B5": {
+      "score_a": 4,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A scopes Bash to exact gh subcommands and gates the side-effecting comment post behind a repeated eligibility check plus skip-if-already-reviewed. Side B is mostly least-privilege (read-only checklist, no write tools) but the agent's `Bash(gh pr *)` wildcard exceeds review needs (includes merge/close) and the skill's stated 'apply fixes' intent doesn't match its granted toolset.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/code-review/commands/code-review.md",
+          "quote": "allowed-tools: Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*)"
+        },
+        {
+          "side": "A",
+          "file": "side-A/plugins/code-review/commands/code-review.md",
+          "quote": "Use a Haiku agent to repeat the eligibility check from #1, to make sure that the pull request is still eligible for code review."
+        },
+        {
+          "side": "B",
+          "file": "side-B/agents-plugin/agents/review.md",
+          "quote": "Bash(gh pr *), Bash(npm test *), Bash(yarn test *)"
+        }
+      ]
+    },
+    "B6": {
+      "score_a": 2,
+      "score_b": 3,
+      "verdict": "B",
+      "rationale": "Side A's README re-documents the whole command and has visibly drifted: it claims 4 parallel agents with stale roles while the command specifies 5 Sonnet agents with different tasks — duplication plus a direct contradiction across files. Side B has one milder doc mismatch ('automated fixes' vs a read-only toolset and a no-fix agent) but its staged references and cross-skill routing are otherwise coherent, and A's strong in-workflow verification does not offset the stale duplicated README.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/code-review/README.md",
+          "quote": "Launches 4 parallel agents to independently review"
+        },
+        {
+          "side": "A",
+          "file": "side-A/plugins/code-review/commands/code-review.md",
+          "quote": "launch 5 parallel Sonnet agents to independently code review the change"
+        }
+      ]
+    }
+  },
+  "identity_leakage": {
+    "recognized": true,
+    "side_a_guess": "Anthropic's official claude-code repo code-review plugin (plugin.json author Anthropic; README credits Boris Cherny, boris@anthropic.com)",
+    "side_b_guess": "laurigates/claude-plugins code-quality-plugin + agents-plugin (author Lauri Gates, repository https://github.com/laurigates/claude-plugins)",
+    "leak_evidence": "side-A plugin.json: \"author\": {\"name\": \"Anthropic\"...} and README 'Boris Cherny (boris@anthropic.com)'; side-B plugin.json: \"author\": {\"name\": \"Lauri Gates\"}, \"repository\": \"https://github.com/laurigates/claude-plugins\". Recognition did not affect scoring; each side was scored against anchors before comparison."
+  },
+  "overall_comment": "A split verdict: Side A is the stronger executable artifact (exceptional procedural instructions, verbatim scoring rubric, narrowly scoped permissions, re-verification gate) but is undermined by a near-empty trigger description and a stale, contradiction-bearing README. Side B is the stronger catalog citizen (rich triggering descriptions, sibling disambiguation, complete manifest metadata) with competent but looser instructions and a mild docs/toolset mismatch."
+}

--- a/docs/benchmarks/2026-07-marketplace-quality/judgments/code-review_j2.json
+++ b/docs/benchmarks/2026-07-marketplace-quality/judgments/code-review_j2.json
@@ -1,0 +1,109 @@
+{
+  "pair_id": "code-review",
+  "judge_id": "j2",
+  "dimensions": {
+    "B1": {
+      "score_a": 2,
+      "score_b": 5,
+      "verdict": "B",
+      "rationale": "Side A's command description is a bare five-word label with no trigger conditions. Side B's descriptions state what and concrete when-to-use conditions, front-load the key use case, and explicitly disambiguate sibling artifacts via use-this/use-that tables.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/code-review/commands/code-review.md",
+          "quote": "description: Code review a pull request"
+        },
+        {
+          "side": "B",
+          "file": "side-B/code-quality-plugin/skills/code-review/SKILL.md",
+          "quote": "Use when reviewing code, auditing OWASP, checking SOLID, or finding perf bottlenecks and test gaps."
+        },
+        {
+          "side": "B",
+          "file": "side-B/code-quality-plugin/skills/code-review/SKILL.md",
+          "quote": "| Running an end-to-end review across quality, security, perf, and tests | Walking a manual security/correctness checklist → `code-review-checklist` |"
+        }
+      ]
+    },
+    "B2": {
+      "score_a": 5,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A gives numbered, zero-context-executable steps with a verbatim confidence rubric, a false-positive taxonomy, exact output and link formats, and the reasoning behind constraints (e.g. why bash substitution in links fails). Side B's steps are competent but abstract category headings ('Analyze code quality') and 'apply fixes where appropriate and safe' leaves a fresh agent guessing.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/code-review/commands/code-review.md",
+          "quote": "For issues that were flagged due to CLAUDE.md instructions, the agent should double check that the CLAUDE.md actually calls out that issue specifically."
+        },
+        {
+          "side": "A",
+          "file": "side-A/plugins/code-review/commands/code-review.md",
+          "quote": "You must provide the full sha. Commands like `https://github.com/owner/repo/blob/$(git rev-parse HEAD)/foo/bar` will not work, since your comment will be directly rendered in Markdown."
+        }
+      ]
+    },
+    "B3": {
+      "score_a": 3,
+      "score_b": 4,
+      "verdict": "B",
+      "rationale": "Both bodies are lean. Side B additionally splits mutually-exclusive paths into separate lean artifacts (delegated full review vs manual checklist) and pushes execution out via fork/agent delegation, approaching the multi-level disclosure anchor; neither side bundles reference files or scripts.",
+      "evidence": [
+        {
+          "side": "B",
+          "file": "side-B/code-quality-plugin/skills/code-review/SKILL.md",
+          "quote": "**Delegate this task to the `code-review` agent.**"
+        }
+      ]
+    },
+    "B4": {
+      "score_a": 3,
+      "score_b": 3,
+      "verdict": "tie",
+      "rationale": "Code review is judgment-heavy on both sides; each delegates the mechanical parts to dedicated tools (gh CLI on A; linters/ast-grep/agents on B) rather than bundled scripts, and neither leaves clearly script-able work as re-derived prose. Competent on both, exceptional on neither."
+    },
+    "B5": {
+      "score_a": 4,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A scopes allowed-tools to narrow gh subcommands with the single side effect (pr comment) matching stated intent, plus a re-eligibility gate before posting. Side B's skills are scoped, but the review agent grants broad `Bash(gh pr *)` (covers merge/close) and test-run tools while stating it does not run tests — effect exceeding stated intent.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/code-review/commands/code-review.md",
+          "quote": "allowed-tools: Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*)"
+        },
+        {
+          "side": "A",
+          "file": "side-A/plugins/code-review/commands/code-review.md",
+          "quote": "Use a Haiku agent to repeat the eligibility check from #1, to make sure that the pull request is still eligible for code review."
+        }
+      ]
+    },
+    "B6": {
+      "score_a": 2,
+      "score_b": 3,
+      "verdict": "B",
+      "rationale": "Side A's README contradicts its command file (4 vs 5 agents, different agent roster) and its author/version metadata conflicts with plugin.json — duplicated information that has drifted, the anchor-1 defect. Side B is internally coherent with maintained metadata, though it references a hooks.json/agent not included and repeats review categories across three artifacts.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/code-review/README.md",
+          "quote": "Launches 4 parallel agents to independently review"
+        },
+        {
+          "side": "A",
+          "file": "side-A/plugins/code-review/commands/code-review.md",
+          "quote": "launch 5 parallel Sonnet agents to independently code review the change"
+        }
+      ]
+    }
+  },
+  "identity_leakage": {
+    "recognized": true,
+    "side_a_guess": "Anthropic's official claude-code repo code-review plugin (author 'Boris Cherny (boris@anthropic.com)', Anthropic author block, 'Generated with Claude Code' footer).",
+    "side_b_guess": "laurigates/claude-plugins code-quality-plugin (author 'Lauri Gates', repository https://github.com/laurigates/claude-plugins, house frontmatter fields created/modified/reviewed).",
+    "leak_evidence": "side-A plugin.json author 'Anthropic' + README 'Boris Cherny (boris@anthropic.com)'; side-B plugin.json 'repository': 'https://github.com/laurigates/claude-plugins'. Scores were assigned against anchors before considering origin."
+  },
+  "overall_comment": "Side A is a single deeply-engineered command: exceptional instruction quality and tight least-privilege tool scoping, undermined by README/command drift and inconsistent metadata. Side B is a broader, better-maintained plugin surface with exemplary triggering and disambiguation but abstract instructions and an over-broad agent tool grant. Roughly complementary strengths: A wins on execution precision and safety scoping, B on discoverability, disclosure, and coherence."
+}

--- a/docs/benchmarks/2026-07-marketplace-quality/judgments/hooks_j1.json
+++ b/docs/benchmarks/2026-07-marketplace-quality/judgments/hooks_j1.json
@@ -1,0 +1,111 @@
+{
+  "pair_id": "hooks",
+  "judge_id": "j1",
+  "dimensions": {
+    "B1": {
+      "score_a": 5,
+      "score_b": 4,
+      "verdict": "A",
+      "rationale": "Side A descriptions are third-person, front-load the key use case, enumerate concrete trigger events, and every sibling skill carries an explicit 'Use X instead when...' disambiguation table. Side B's descriptions state concrete trigger phrasings (skill and agent both) but have a minor name inconsistency (frontmatter 'writing-hookify-rules' vs directory 'writing-rules' vs 'hookify:writing-rules' references) and less systematic sibling disambiguation.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/hooks-plugin/skills/hooks-configuration/SKILL.md",
+          "quote": "Use when the user mentions hooks, PreToolUse, PostToolUse, SessionStart, SubagentStart, PermissionRequest, or TaskCompleted."
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/hookify/skills/writing-rules/SKILL.md",
+          "quote": "This skill should be used when the user asks to \"create a hookify rule\", \"write a hook rule\", \"configure hookify\""
+        }
+      ]
+    },
+    "B2": {
+      "score_a": 5,
+      "score_b": 4,
+      "verdict": "A",
+      "rationale": "Side A gives ordered imperative steps with detection tables, exact merge/ask-user branches, output formats, and the 'why' behind patterns (e.g. subshell rationale, timeout guidance), enabling generalization. Side B's commands are also concrete and stepwise with worked examples, but the /hookify command says to launch the conversation-analyzer agent while its JSON actually uses subagent_type general-purpose with an inline prompt, a small ambiguity a fresh agent must resolve.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/hooks-plugin/skills/hooks-configuration/SKILL.md",
+          "quote": "Why this works: `( )` creates a subshell, `&` runs it in background"
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/hookify/commands/hookify.md",
+          "quote": "Rule files must be created in the current working directory's `.claude/` folder, NOT the plugin directory."
+        }
+      ]
+    },
+    "B3": {
+      "score_a": 5,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A shows deliberate multi-level disclosure: lean SKILL.md summaries that push schemas, templates, and advanced patterns to per-skill REFERENCE.md files, plus executable hook scripts that run without being read. Side B keeps the engine out of context via Python scripts, but its 375-line writing-rules skill inlines all reference material (operators, event guide, regex tutorial) with no supporting-file split, and the README repeats much of it.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/hooks-plugin/skills/hooks-configuration/SKILL.md",
+          "quote": "For detailed hook schemas and examples, see [REFERENCE.md](REFERENCE.md)."
+        }
+      ]
+    },
+    "B4": {
+      "score_a": 5,
+      "score_b": 4,
+      "verdict": "A",
+      "rationale": "Side A delegates every mechanical check to documented, toggleable shell scripts with bundled regression test scripts (823-line test suite for bash-antipatterns alone) and even converted an LLM prompt hook to a deterministic command hook with recorded rationale. Side B correctly offloads all rule matching to standalone Python with good error handling and lru-cached regexes, but hand-rolls a fragile YAML parser and ships no test harness.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/hooks-plugin/hooks/task-completeness.sh",
+          "quote": "Uses deterministic heuristics instead of LLM judgment."
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/hookify/core/rule_engine.py",
+          "quote": "Cache compiled regexes (max 128 patterns)"
+        }
+      ]
+    },
+    "B5": {
+      "score_a": 5,
+      "score_b": 4,
+      "verdict": "A",
+      "rationale": "Side A gates destructive git ops behind 'ask' decisions, marks side-effecting generator skills disable-model-invocation, JSON-encodes hook reasons via jq -Rs, defers to auto mode to avoid double-gating, and hardens its own bypass so agents cannot self-serve it. Side B is safely fail-open with non-destructive warn defaults and user-confirmed block actions, but its PostToolUse blocking emits a PreToolUse-style permissionDecision payload (effect not matching the documented block semantics) and its catch-all PreToolUse matcher runs Python on every tool call.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/hooks-plugin/hooks/branch-protection.sh",
+          "quote": "on the command line are intentionally NOT honored so that agents cannot"
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/hookify/hooks/pretooluse.py",
+          "quote": "ALWAYS exit 0 - never block operations due to hook errors"
+        }
+      ]
+    },
+    "B6": {
+      "score_a": 4,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A has an exceptional verification culture (nine bundled test scripts, issue-referenced regressions, a feature-flags catalog built to prevent drift) but also visible staleness: the README describes git-session-cleanup as committing staged changes and switching/pulling main while the script only deletes temp files, plus duplicated antipattern tables that drift and skill links to rules files outside the plugin. Side B's references resolve and error handling is thorough, but it carries empty stub modules, a stale '(future)' comment on an implemented feature, heavy README/skill duplication, and no verification/tests.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/hooks-plugin/README.md",
+          "quote": "commits any staged changes, switches to the main/master branch, and pulls the latest changes"
+        }
+      ]
+    }
+  },
+  "identity_leakage": {
+    "recognized": true,
+    "side_a_guess": "laurigates/claude-plugins hooks-plugin (matches the marketplace conventions, env-flag naming, and issue references like #1009/#1600 of that repo)",
+    "side_b_guess": "Anthropic's official claude-code plugins example 'hookify' (plugin.json author is Anthropic <support@anthropic.com>)",
+    "leak_evidence": "Side A: repository https://github.com/laurigates/claude-plugins in plugin.json and CLAUDE_HOOKS_* conventions; Side B: author field 'Anthropic', 'support@anthropic.com', and the well-known hookify plugin structure. Recognition did not influence scoring; both sides were scored against the anchors on staged content only."
+  },
+  "overall_comment": "Side A is a mature, defense-in-depth hooks plugin with strong disclosure architecture, deterministic offload backed by real test suites, and exemplary safety gating; its main weakness is documentation drift (a README section contradicting its script). Side B is a clean, well-designed meta-plugin whose engine offload and fail-open safety are solid, but it is thinner on progressive disclosure, has no tests, and shows several small consistency defects."
+}

--- a/docs/benchmarks/2026-07-marketplace-quality/judgments/hooks_j2.json
+++ b/docs/benchmarks/2026-07-marketplace-quality/judgments/hooks_j2.json
@@ -1,0 +1,75 @@
+{
+  "pair_id": "hooks",
+  "judge_id": "j2",
+  "dimensions": {
+    "B1": {
+      "score_a": 5,
+      "score_b": 4,
+      "verdict": "A",
+      "rationale": "Side A's skill descriptions front-load the key use case, are third-person, enumerate concrete trigger terms, and each sibling skill carries an explicit 'use X instead' disambiguation; side B's skill quotes realistic trigger phrasings but its command descriptions are thinner and less disambiguated.",
+      "evidence": [
+        {"side": "A", "file": "side-A/hooks-plugin/skills/hooks-configuration/SKILL.md", "quote": "Use when the user mentions hooks, PreToolUse, PostToolUse, SessionStart, SubagentStart, PermissionRequest, or TaskCompleted."},
+        {"side": "B", "file": "side-B/plugins/hookify/skills/writing-rules/SKILL.md", "quote": "This skill should be used when the user asks to \"create a hookify rule\", \"write a hook rule\", \"configure hookify\""}
+      ]
+    },
+    "B2": {
+      "score_a": 5,
+      "score_b": 4,
+      "verdict": "A",
+      "rationale": "Side A gives ordered, runnable steps with merge/ask decision flows plus the reasoning behind choices (e.g. when a deterministic hook beats the auto-mode classifier), so an agent can generalize; side B is concrete and imperative with good examples, but its main command inlines a general-purpose Task prompt instead of the shipped agent, leaving a fresh agent to reconcile the two.",
+      "evidence": [
+        {"side": "A", "file": "side-A/hooks-plugin/skills/hooks-permission-request-hook/SKILL.md", "quote": "**Deterministic, auditable rules** — the classifier's probabilistic answer is unsuitable for compliance contexts"},
+        {"side": "B", "file": "side-B/plugins/hookify/commands/hookify.md", "quote": "**FIRST: Load the hookify:writing-rules skill** using the Skill tool to understand rule file format and syntax."},
+        {"side": "B", "file": "side-B/plugins/hookify/commands/hookify.md", "quote": "subagent_type\": \"general-purpose"}
+      ]
+    },
+    "B3": {
+      "score_a": 5,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A shows clear multi-level disclosure: lean SKILL.md bodies that defer schemas and advanced patterns to REFERENCE.md files and executable hook scripts that run without being read; side B's single 375-line SKILL.md inlines a full regex tutorial, operator reference, and examples with no on-demand reference layer.",
+      "evidence": [
+        {"side": "A", "file": "side-A/hooks-plugin/skills/hooks-configuration/SKILL.md", "quote": "For detailed hook schemas and examples, see [REFERENCE.md](REFERENCE.md)."}
+      ]
+    },
+    "B4": {
+      "score_a": 5,
+      "score_b": 4,
+      "verdict": "A",
+      "rationale": "Side A offloads every mechanical check to 14 robust bash hooks with per-hook regression test scripts and deliberately replaced an LLM prompt hook with a deterministic command hook; side B's Python rule engine is a genuine deterministic substrate with good error handling, but rests on a fragile hand-rolled YAML parser and ships no test suite beyond __main__ smoke blocks.",
+      "evidence": [
+        {"side": "A", "file": "side-A/hooks-plugin/README.md", "quote": "task-completeness hook to avoid leaking the full LLM prompt in error output"},
+        {"side": "B", "file": "side-B/plugins/hookify/hooks/pretooluse.py", "quote": "ALWAYS exit 0 - never block operations due to hook errors"}
+      ]
+    },
+    "B5": {
+      "score_a": 5,
+      "score_b": 4,
+      "verdict": "A",
+      "rationale": "Side A gates destructive ops (auto-checkpoint before reset/rm, deny/ask tiers on protected branches), designs the bypass so agents cannot self-serve it, scopes allowed-tools, and marks side-effecting skills disable-model-invocation; side B is injection-safe with scoped tool lists and a warn-by-default fail-open design, competent-plus but without comparable gating depth.",
+      "evidence": [
+        {"side": "A", "file": "side-A/hooks-plugin/hooks/branch-protection.sh", "quote": "intentionally NOT honored so that agents cannot"},
+        {"side": "B", "file": "side-B/plugins/hookify/commands/list.md", "quote": "allowed-tools: [\"Glob\", \"Read\", \"Skill\"]"}
+      ]
+    },
+    "B6": {
+      "score_a": 4,
+      "score_b": 2,
+      "verdict": "A",
+      "rationale": "Side A has an exceptional verification culture (seven test scripts, issue-referenced regression fixes, a signpost-not-copy flags catalog) but carries real staleness — the README describes git-session-cleanup as committing/switching/pulling while the script only deletes temp files, and skill links point outside the plugin. Side B's flagship shipped example is broken twice over (not_contains is defined as a substring check, so the pipe-separated pattern can never appear in a transcript and the rule always fires; the documented stop-event `pattern: .*` form maps to a field the engine never resolves), plus a Python 3.7+ claim its `tuple[...]` annotation violates.",
+      "evidence": [
+        {"side": "A", "file": "side-A/hooks-plugin/README.md", "quote": "commits any staged changes, switches to the main/master branch, and pulls the latest changes"},
+        {"side": "A", "file": "side-A/hooks-plugin/hooks/git-session-cleanup.sh", "quote": "SessionEnd hook - cleans up session temp files"},
+        {"side": "B", "file": "side-B/plugins/hookify/examples/require-tests-stop.local.md", "quote": "pattern: npm test|pytest|cargo test"},
+        {"side": "B", "file": "side-B/plugins/hookify/skills/writing-rules/SKILL.md", "quote": "`not_contains`: Substring must NOT be present"}
+      ]
+    }
+  },
+  "identity_leakage": {
+    "recognized": true,
+    "side_a_guess": "laurigates/claude-plugins hooks-plugin (author 'Lauri Gates', repository URL, issue numbers, and house conventions like CLAUDE_HOOKS_* flags are visible in the artifacts)",
+    "side_b_guess": "Anthropic's official 'hookify' plugin from the claude-code plugins marketplace (author block names Anthropic, support@anthropic.com)",
+    "leak_evidence": "side-A plugin.json: \"repository\": \"https://github.com/laurigates/claude-plugins\"; side-B plugin.json: \"author\": {\"name\": \"Anthropic\", \"email\": \"support@anthropic.com\"}. Recognition did not alter anchor-based scoring; defects and virtues were verified in the staged files themselves."
+  },
+  "overall_comment": "Side A is a mature safety/automation hook suite with deterministic offload, regression tests, and gated destructive actions, weakened mainly by doc staleness (README vs actual cleanup script) and out-of-plugin references. Side B is a well-conceived user-configurable rule engine with clean fail-open error handling, but a bloated single-file skill and multiple shipped examples that contradict its own engine semantics."
+}

--- a/docs/benchmarks/2026-07-marketplace-quality/judgments/mcp-dev_j1.json
+++ b/docs/benchmarks/2026-07-marketplace-quality/judgments/mcp-dev_j1.json
@@ -1,0 +1,70 @@
+{
+  "pair_id": "mcp-dev",
+  "judge_id": "j1",
+  "dimensions": {
+    "B1": {
+      "score_a": 5,
+      "score_b": 4,
+      "verdict": "A",
+      "rationale": "Side A descriptions enumerate realistic user phrasings, front-load the key use case, and explicitly disambiguate siblings (build-mcp-app defers to build-mcp-server). Side B descriptions are third-person with concrete triggers and distinct names, but phrasings are thinner and sibling disambiguation lives mostly in the body tables rather than the description.",
+      "evidence": [
+        {"side": "A", "file": "side-A/plugins/mcp-server-dev/skills/build-mcp-server/SKILL.md", "quote": "This skill should be used when the user asks to \"build an MCP server\", \"create an MCP\", \"make an MCP integration\""},
+        {"side": "A", "file": "side-A/plugins/mcp-server-dev/skills/build-mcp-app/SKILL.md", "quote": "Use AFTER the build-mcp-server skill has settled the deployment model, or when the user already knows they want UI widgets."},
+        {"side": "B", "file": "side-B/agent-patterns-plugin/skills/mcp-management/SKILL.md", "quote": "Use when adding/enabling servers, updating .mcp.json, managing OAuth remote servers, or troubleshooting connections."}
+      ]
+    },
+    "B2": {
+      "score_a": 5,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A gives a phased, ordered procedure with runnable commands, complete scaffolds, capability-check fallbacks, and pervasive reasoning so an agent generalizes (why remote wins, why tool count matters). Side B is competent pattern knowledge with correct commands, but the scaffolding steps are partly hand-wavy (\"create a directory with typed wrappers\") and lean on portfolio-specific context a zero-context agent lacks.",
+      "evidence": [
+        {"side": "A", "file": "side-A/plugins/mcp-server-dev/skills/build-mcp-server/SKILL.md", "quote": "When handing off, restate the design brief in one paragraph so the next skill doesn't re-ask."},
+        {"side": "A", "file": "side-A/plugins/mcp-server-dev/skills/build-mcp-server/references/tool-design.md", "quote": "Every tool schema is tokens Claude spends *every turn*."}
+      ]
+    },
+    "B3": {
+      "score_a": 4,
+      "score_b": 4,
+      "verdict": "tie",
+      "rationale": "Both apply real progressive disclosure: A routes to 15 on-demand reference files but the build-mcp-app body is heavy (~19KB) and duplicates the picker scaffold found in widget-templates.md; B keeps bodies lean (~6KB) with explicit on-demand REFERENCE splits but duplicates its OAuth troubleshooting table verbatim into the body. Equal-magnitude virtue and defect on each side.",
+      "evidence": [
+        {"side": "A", "file": "side-A/plugins/mcp-server-dev/skills/build-mcp-app/SKILL.md", "quote": "See `references/widget-templates.md` for more widget shapes."},
+        {"side": "B", "file": "side-B/agent-patterns-plugin/skills/mcp-management/REFERENCE.md", "quote": "Supporting material for [`mcp-management`](SKILL.md). Loaded on demand."}
+      ]
+    },
+    "B4": {
+      "score_a": 3,
+      "score_b": 3,
+      "verdict": "tie",
+      "rationale": "Neither side bundles scripts, but neither has much genuinely mechanical work to offload: both are guidance/scaffolding artifacts whose deterministic bits are delegated to existing tools (inspector, mcpb validate/pack, jq one-liners, versions.md verification commands). Judged relative to actual need, both sit at competent."
+    },
+    "B5": {
+      "score_a": 3,
+      "score_b": 4,
+      "verdict": "B",
+      "rationale": "Side B declares explicit least-privilege allowed-tools on two of three skills (scoped Bash patterns), a concrete artifact-level control, docked only for mcp-code-execution's bare Bash grant. Side A declares no tool allowances (not penalized per rubric) and its content is safety-sound with gating advice, but shows no artifact-level permission scoping beyond competent.",
+      "evidence": [
+        {"side": "B", "file": "side-B/agent-patterns-plugin/skills/mcp-server-authoring/SKILL.md", "quote": "allowed-tools: Read, Write, Edit, Grep, Glob, Bash(uv *), Bash(pytest *)"},
+        {"side": "B", "file": "side-B/agent-patterns-plugin/skills/mcp-code-execution/SKILL.md", "quote": "allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite"}
+      ]
+    },
+    "B6": {
+      "score_a": 4,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A has explicit maintenance infrastructure (a versions.md ledger with verification commands), shipping checklists, and failure paths everywhere, though one ledger entry is stale (claims an ext-apps@1.2.2 CDN pin that no longer exists in the cited files) and the picker scaffold is duplicated. Side B is coherent with resolving references and troubleshooting paths, but duplicates its OAuth table across SKILL/REFERENCE and cites a bare blog-root URL as a source.",
+      "evidence": [
+        {"side": "A", "file": "side-A/plugins/mcp-server-dev/skills/build-mcp-server/references/versions.md", "quote": "Every version-sensitive claim in this skill, in one place. When updating the skill, check these first."},
+        {"side": "A", "file": "side-A/plugins/mcp-server-dev/skills/build-mcp-server/references/versions.md", "quote": "`@modelcontextprotocol/ext-apps@1.2.2` CDN pin"}
+      ]
+    }
+  },
+  "identity_leakage": {
+    "recognized": true,
+    "side_a_guess": "Looks like an Anthropic-authored plugin (plugin.json author is Anthropic; style matches official skill-creator conventions), possibly from the official plugins marketplace.",
+    "side_b_guess": "Strongly suspect laurigates/claude-plugins agent-patterns-plugin — the skill names (mcp-server-authoring, mcp-management, mcp-code-execution), portfolio server names (kicad-mcp, pal-mcp-server), and house conventions (created/modified/reviewed frontmatter, Agentic Optimizations tables) match that repo.",
+    "leak_evidence": "side-B plugin.json name 'agent-patterns-plugin' and SKILL.md references to 'pal-mcp-server', 'silverbucket-mcp', 'kicad-mcp' and cross-plugin names like 'configure-plugin:configure-mcp'; side-A plugin.json author block 'Anthropic / support@anthropic.com'. Recognition did not influence scoring; both were judged against the anchors on staged content only."
+  },
+  "overall_comment": "Side A is a deep, procedure-first build path: exceptional triggering and instruction quality with reasoning throughout, at the cost of one bloated body, a duplicated scaffold, and a stale entry in its otherwise-exemplary versions ledger. Side B is disciplined and lean with textbook SKILL/REFERENCE splits and explicit least-privilege tool scoping, but its instructions are shallower, partly portfolio-bound, and it carries its own body/reference duplication. Net: A leads on the substance dimensions (B1, B2, B6); B leads on permissions (B5); B3/B4 tie."
+}

--- a/docs/benchmarks/2026-07-marketplace-quality/judgments/mcp-dev_j2.json
+++ b/docs/benchmarks/2026-07-marketplace-quality/judgments/mcp-dev_j2.json
@@ -1,0 +1,77 @@
+{
+  "pair_id": "mcp-dev",
+  "judge_id": "j2",
+  "dimensions": {
+    "B1": {
+      "score_a": 5,
+      "score_b": 4,
+      "verdict": "A",
+      "rationale": "Side A's descriptions front-load the key use case, enumerate many realistic user phrasings, and explicitly sequence/disambiguate siblings (build-mcp-app says 'Use AFTER the build-mcp-server skill'). Side B's descriptions are third-person with concrete 'Use when' triggers and distinct names, but near-miss coverage lives mostly in in-body tables rather than the triggering description.",
+      "evidence": [
+        {"side": "A", "file": "side-A/plugins/mcp-server-dev/skills/build-mcp-server/SKILL.md", "quote": "This skill should be used when the user asks to \"build an MCP server\", \"create an MCP\", \"make an MCP integration\""},
+        {"side": "A", "file": "side-A/plugins/mcp-server-dev/skills/build-mcp-app/SKILL.md", "quote": "Use AFTER the build-mcp-server skill has settled the deployment model, or when the user already knows they want UI widgets."},
+        {"side": "B", "file": "side-B/agent-patterns-plugin/skills/mcp-server-authoring/SKILL.md", "quote": "Use when building or extending an MCP server, adding a tool/resource, or scaffolding a new server."}
+      ]
+    },
+    "B2": {
+      "score_a": 5,
+      "score_b": 4,
+      "verdict": "A",
+      "rationale": "Side A gives ordered phases, runnable commands, good/bad input-output examples, and explains the why throughout (context-window economics, 'Why it wins'), plus a handoff protocol so downstream skills don't re-ask. Side B is concrete and runnable (TDD steps, jq/uv commands) with some reasoning, but the code-execution scaffold leaves wrapper generation as thin prose a fresh agent must fill in.",
+      "evidence": [
+        {"side": "A", "file": "side-A/plugins/mcp-server-dev/skills/build-mcp-server/SKILL.md", "quote": "When handing off, restate the design brief in one paragraph so the next skill doesn't re-ask."},
+        {"side": "A", "file": "side-A/plugins/mcp-server-dev/skills/build-mcp-server/references/tool-design.md", "quote": "The ceiling isn't a hard protocol limit — it's context-window economics. Every tool schema is tokens Claude spends *every turn*."},
+        {"side": "B", "file": "side-B/agent-patterns-plugin/skills/mcp-server-authoring/SKILL.md", "quote": "Write the failing test against the plain function."},
+        {"side": "B", "file": "side-B/agent-patterns-plugin/skills/mcp-code-execution/REFERENCE.md", "quote": "For each MCP server, create a directory with typed wrappers. Each tool gets its\nown file with an input interface, output interface, JSDoc comment"}
+      ]
+    },
+    "B3": {
+      "score_a": 4,
+      "score_b": 5,
+      "verdict": "B",
+      "rationale": "Side B is textbook progressive disclosure: lean bodies with explicit 'loaded on demand' REFERENCE.md offload and anchored section links. Side A splits detail into 17 topical references along mutually-exclusive deployment paths, but the build-mcp-app body inlines ~200 lines of always-loaded scaffold/testing code (server, widget HTML, preview shim) that could live in references.",
+      "evidence": [
+        {"side": "B", "file": "side-B/agent-patterns-plugin/skills/mcp-code-execution/REFERENCE.md", "quote": "Supporting material for [`mcp-code-execution`](SKILL.md). Loaded on demand."},
+        {"side": "A", "file": "side-A/plugins/mcp-server-dev/skills/build-mcp-app/SKILL.md", "quote": "Open `http://localhost:3000/widget-preview?payload={\"rows\":[...]}` in a normal browser tab and iterate with ordinary devtools."},
+        {"side": "A", "file": "side-A/plugins/mcp-server-dev/skills/build-mcp-app/SKILL.md", "quote": "- `references/iframe-sandbox.md` — CSP/sandbox constraints, the bundle-inlining pattern, image handling, host theming"}
+      ]
+    },
+    "B4": {
+      "score_a": 3,
+      "score_b": 3,
+      "verdict": "tie",
+      "rationale": "Both are guidance/scaffolding artifacts with limited mechanical work of their own; both delegate the deterministic operations they do have to dedicated tools (side A: mcpb validate/pack, MCP Inspector, headless JSON-RPC loop; side B: jq validation one-liners, uv/pytest gates) and point to them clearly. Neither bundles robust standalone scripts with run-vs-read guidance, so neither exceeds the 3 anchor.",
+      "evidence": []
+    },
+    "B5": {
+      "score_a": 4,
+      "score_b": 4,
+      "verdict": "tie",
+      "rationale": "Side A carries pervasive, correct safety guidance — destructive actions gated via elicitation confirmation and destructiveHint, path-containment and no-shell-spawn patterns, secrets never in tool results — and nothing injection-prone. Side B demonstrates least-privilege directly with scoped allowed-tools grants and never-hardcode-secrets ${VAR} guidance, though mcp-code-execution grants bare Bash. Both solidly above competent, neither shows consistent gating across every component.",
+      "evidence": [
+        {"side": "A", "file": "side-A/plugins/mcp-server-dev/skills/build-mcpb/references/local-security.md", "quote": "If you ship write/delete, consider requiring explicit confirmation via elicitation"},
+        {"side": "B", "file": "side-B/agent-patterns-plugin/skills/mcp-server-authoring/SKILL.md", "quote": "allowed-tools: Read, Write, Edit, Grep, Glob, Bash(uv *), Bash(pytest *)"},
+        {"side": "B", "file": "side-B/agent-patterns-plugin/skills/mcp-code-execution/SKILL.md", "quote": "allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite"}
+      ]
+    },
+    "B6": {
+      "score_a": 5,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A maintains a dedicated version-sensitive-claims ledger with verification commands, cross-skill references that resolve, capability-check fallbacks, and per-skill debugging/failure sections. Side B's references resolve and it has troubleshooting paths, but the OAuth triage table is duplicated verbatim in both SKILL.md and REFERENCE.md, and its plugin.json points at a hooks.json absent from the artifact set.",
+      "evidence": [
+        {"side": "A", "file": "side-A/plugins/mcp-server-dev/skills/build-mcp-server/references/versions.md", "quote": "Every version-sensitive claim in this skill, in one place. When updating the skill, check these first."},
+        {"side": "B", "file": "side-B/agent-patterns-plugin/skills/mcp-management/SKILL.md", "quote": "| Authorization prompt repeats | Token not persisted | Check token storage permissions |"},
+        {"side": "B", "file": "side-B/agent-patterns-plugin/skills/mcp-management/REFERENCE.md", "quote": "| Authorization prompt repeats | Token not persisted | Check token storage permissions |"},
+        {"side": "B", "file": "side-B/agent-patterns-plugin/.claude-plugin/plugin.json", "quote": "\"hooks\": \"./hooks.json\""}
+      ]
+    }
+  },
+  "identity_leakage": {
+    "recognized": true,
+    "side_a_guess": "Anthropic's official mcp-server-dev plugin (plugin.json author 'Anthropic', support@anthropic.com)",
+    "side_b_guess": "laurigates/claude-plugins agent-patterns-plugin (skill names mcp-management/mcp-code-execution/mcp-server-authoring and portfolio references like kicad-mcp, silverbucket-mcp, pal-mcp-server match that repo)",
+    "leak_evidence": "Side A's plugin.json declares author Anthropic; side B's mcp-server-authoring names 'the portfolio's MCP servers — kicad-mcp, silverbucket-mcp, pal-mcp-server (and the FVH sibling podio-mcp)' and cross-references agent-patterns-plugin/configure-plugin skills. Scores were assigned against the anchors before considering identity."
+  },
+  "overall_comment": "Side A is a deep, purpose-built MCP-server-development suite: exceptional triggering, why-laden instructions with input/output examples, strong safety content, and a rare maintainability artifact (versions ledger). Side B is disciplined plugin authoring — best-in-class progressive disclosure and explicit least-privilege tool scoping — but shallower instructionally, with duplicated content between SKILL.md and REFERENCE.md and a dangling hooks.json reference. A wins on B1/B2/B6; B wins B3; B4/B5 tie."
+}

--- a/docs/benchmarks/2026-07-marketplace-quality/judgments/pr-commit-workflow_j1.json
+++ b/docs/benchmarks/2026-07-marketplace-quality/judgments/pr-commit-workflow_j1.json
@@ -1,0 +1,121 @@
+{
+  "pair_id": "pr-commit-workflow",
+  "judge_id": "j1",
+  "dimensions": {
+    "B1": {
+      "score_a": 5,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A's descriptions uniformly state what + concrete trigger phrasings, front-load the key use case, and explicitly disambiguate from sibling skills (git-commit vs git-push vs git-pr vs the macro). Side B is split: the pr-review-toolkit agents have excellent trigger coverage with worked scenarios, but the commit-commands descriptions ('Create a git commit') state no trigger conditions at all, averaging to competent.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/git-plugin/skills/git-commit/SKILL.md",
+          "quote": "Use when user says \"commit\", \"save changes\", or \"stage and commit\". Local commits only — see git-push for remote."
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/commit-commands/commands/commit.md",
+          "quote": "description: Create a git commit"
+        }
+      ]
+    },
+    "B2": {
+      "score_a": 4,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A gives ordered, runnable steps with the reasoning behind non-obvious moves (quoted-heredoc escaping, comparing against origin/main, stacked-PR retarget/rebase), plus output formats and error tables; heavy ALWAYS/CRITICAL directive density keeps it just below the top anchor. Side B's commands are concrete but minimal, and commit-push-pr mandates branch creation while its allowed-tools pattern is for a nonexistent 'git checkout --branch' invocation, so the required step is not actually permitted as scoped.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/git-plugin/skills/git-commit/SKILL.md",
+          "quote": "Inside a quoted heredoc (`<<'EOF'`), backticks, `$`, and `\\` are already literal"
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/commit-commands/commands/commit-push-pr.md",
+          "quote": "Bash(git checkout --branch:*)"
+        }
+      ]
+    },
+    "B3": {
+      "score_a": 4,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A shows genuine multi-level disclosure — lean-ish bodies delegating to REFERENCE.md files and executable scripts — though several bodies still inline sizable reference material and the conventional-commit/issue-keyword tables repeat across skills. Side B's bodies are short, but there is no supporting-file structure and two agent descriptions embed multiple full examples in always-loaded frontmatter, taxing the listing budget.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/git-plugin/skills/git-pr-feedback/SKILL.md",
+          "quote": "For feedback categorization, decision trees, commit format, and report templates, see"
+        }
+      ]
+    },
+    "B4": {
+      "score_a": 5,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A offloads the mechanical work (PR readiness probing, closing-keyword audits, sync verdicts, GraphQL data fetch, actionable-PR selection) to bundled scripts with test fixtures, structured KEY=VALUE output, error handling, and explicit run-this instructions. Side B has little mechanical surface — review agents do judgment work — and what mechanical work exists (the clean_gone loop) is at least given as a concrete runnable block, meeting but not exceeding the competent anchor.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/git-plugin/skills/git-pr/scripts/git-pr.sh",
+          "quote": "DATA-ONLY: detects PR readiness (fetch + ahead-count + existing-PR probe),"
+        }
+      ]
+    },
+    "B5": {
+      "score_a": 4,
+      "score_b": 2,
+      "verdict": "A",
+      "rationale": "Side A scopes allowed-tools per skill, gates force-push behind explicit confirmation, marks side-effecting macros disable-model-invocation, and its hooks parse input safely with jq and nudge via 'ask' rather than hard-deny — though several skills grant the effectively-broad 'Bash(bash *)'. Side B's clean_gone runs 'git worktree remove --force' and 'git branch -D' in an unconditional loop with no allowed-tools scoping and no confirmation gate, while its README asserts it is safe — a destructive default that can discard unpushed local commits and uncommitted worktree changes.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/git-plugin/skills/git-pr/SKILL.md",
+          "quote": "Bash(bash *), Bash(git status *)"
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/commit-commands/commands/clean_gone.md",
+          "quote": "git worktree remove --force \"$worktree\""
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/commit-commands/README.md",
+          "quote": "Safe to run - only removes branches already deleted remotely"
+        }
+      ]
+    },
+    "B6": {
+      "score_a": 4,
+      "score_b": 2,
+      "verdict": "A",
+      "rationale": "Side A is internally coherent with verification steps (closing-keyword re-audit, push verification), error-handling tables, and tested scripts, but repeats the same commit-type/issue-keyword content across several skills and links out of the plugin via '../../.claude/rules/' paths that will not resolve for an installed plugin. Side B carries visibly stale internal leftovers — an agent hardcoding another project's 'constants/errorIds.ts' and logging functions, a README pointing contributors at 'claude-cli-internal' and claiming an MIT license/version absent from the manifest, and the invalid 'git checkout --branch' tool pattern.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/git-plugin/skills/git-commit/SKILL.md",
+          "quote": "(../../.claude/rules/conventional-commits.md) for complete reference"
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/pr-review-toolkit/agents/silent-failure-hunter.md",
+          "quote": "Is there an error ID from constants/errorIds.ts for Sentry tracking?"
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/pr-review-toolkit/README.md",
+          "quote": "in claude-cli-internal"
+        }
+      ]
+    }
+  },
+  "identity_leakage": {
+    "recognized": true,
+    "side_a_guess": "laurigates/claude-plugins git-plugin (author 'Lauri Gates', repository URL, house .claude/rules cross-references)",
+    "side_b_guess": "Anthropic's official Claude Code example plugins (commit-commands and pr-review-toolkit; author 'Anthropic', README references claude-cli-internal)",
+    "leak_evidence": "side-A plugin.json: \"author\": {\"name\": \"Lauri Gates\"}, \"repository\": \"https://github.com/laurigates/claude-plugins\"; side-B plugin.json: \"author\": {\"name\": \"Anthropic\", \"email\": \"support@anthropic.com\"} and README 'Project agents: .claude/agents/ in claude-cli-internal'. Scores were assigned against the anchors before considering identity."
+  },
+  "overall_comment": "Side A is a mature, deeply engineered PR/commit workflow suite: strong triggering with sibling disambiguation, reasoned instructions, tested deterministic scripts, and safety-conscious hooks; its main debts are content duplication, out-of-plugin rule references, and some broad Bash grants. Side B pairs excellent review-agent prompt craft with very thin commit commands and shows distribution-hygiene problems: an unusable tool pattern, ungated destructive cleanup, and internal-project leftovers that would misdirect consumers."
+}

--- a/docs/benchmarks/2026-07-marketplace-quality/judgments/pr-commit-workflow_j2.json
+++ b/docs/benchmarks/2026-07-marketplace-quality/judgments/pr-commit-workflow_j2.json
@@ -1,0 +1,126 @@
+{
+  "pair_id": "pr-commit-workflow",
+  "judge_id": "j2",
+  "dimensions": {
+    "B1": {
+      "score_a": 5,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A descriptions front-load the use case, state concrete trigger phrasings, and explicitly disambiguate sibling skills (git-commit vs git-push vs git-commit-push-pr). Side B's agents have excellent trigger-rich descriptions with worked scenarios, but its command descriptions are bare ('Create a git commit') with no trigger conditions, so it averages to competent.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/git-plugin/skills/git-commit/SKILL.md",
+          "quote": "Use when user says \"commit\", \"save changes\", or \"stage and commit\". Local commits only — see git-push for remote."
+        },
+        {
+          "side": "A",
+          "file": "side-A/git-plugin/skills/git-pr-sync-check/SKILL.md",
+          "quote": "Use when continuing work on a PR branch before adding commits."
+        }
+      ]
+    },
+    "B2": {
+      "score_a": 5,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A gives ordered imperative steps with correct runnable commands, specified output formats, and consistently explains the why (origin/main vs local main, quoted-heredoc escaping, stacked-PR squash mechanics), so an agent generalizes beyond the literal steps. Side B's commands are clear and minimal but carry a defect: commit-push-pr instructs branch creation while its allowed-tools pattern uses a nonexistent 'git checkout --branch' flag that will not match the real command.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/git-plugin/skills/git-pr/SKILL.md",
+          "quote": "Always compare against `origin/main` (not local `main`) to avoid including commits that haven't been merged to the remote."
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/commit-commands/commands/commit-push-pr.md",
+          "quote": "Bash(git checkout --branch:*)"
+        }
+      ]
+    },
+    "B3": {
+      "score_a": 4,
+      "score_b": 4,
+      "verdict": "tie",
+      "rationale": "Side A shows genuine multi-level disclosure (SKILL.md -> REFERENCE.md -> executable scripts) but several always-loaded bodies are long, inlining rarely-needed detail like the full stacked-PR essay. Side B's command bodies are exemplary in leanness and its agents are single-file at appropriate size, but there is no deeper disclosure structure. Both land between competent and exceptional.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/git-plugin/skills/git-pr-feedback/SKILL.md",
+          "quote": "For feedback categorization, decision trees, commit format, and report templates, see [REFERENCE.md](REFERENCE.md)."
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/commit-commands/commands/commit.md",
+          "quote": "- Current git diff (staged and unstaged changes): !`git diff HEAD`"
+        }
+      ]
+    },
+    "B4": {
+      "score_a": 5,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A pushes mechanical work (ahead-count, existing-PR probe, closing-keyword audit, actionable-PR selection, sync verdicts) into bundled scripts with structured KEY=VALUE output, offline test seams, and companion test scripts, and the skills say explicitly to run them and parse named fields. Side B has little mechanical work by design; the one deterministic pipeline (clean_gone) is given verbatim rather than re-derived, which is adequate relative to its risk.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/git-plugin/skills/git-pr/scripts/git-pr.sh",
+          "quote": "DATA-ONLY: detects PR readiness (fetch + ahead-count + existing-PR probe),"
+        },
+        {
+          "side": "A",
+          "file": "side-A/git-plugin/skills/git-pr-feedback/scripts/list-actionable-prs.sh",
+          "quote": "Testing: set PR_FEEDBACK_FIXTURE=<path> to read a captured GraphQL response"
+        }
+      ]
+    },
+    "B5": {
+      "score_a": 4,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A scopes allowed-tools narrowly per skill, gates force-push behind explicit user confirmation, uses disable-model-invocation on side-effecting workflows, and its hook nudges with permissionDecision ask rather than hard-denying — but the 'Bash(bash *)' grant in git-pr and git-pr-feedback is effectively arbitrary script execution, breaking consistent least-privilege. Side B's commit commands are tightly scoped, but clean_gone runs 'git worktree remove --force' and 'git branch -D' unconditionally while its README overclaims it is safe, since -D discards local-only commits on gone branches.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/git-plugin/skills/git-push/SKILL.md",
+          "quote": "# CAUTION: Only after explicit user confirmation\ngit push --force-with-lease"
+        },
+        {
+          "side": "A",
+          "file": "side-A/git-plugin/skills/git-pr/SKILL.md",
+          "quote": "allowed-tools: Bash(bash *), Bash(git status *)"
+        }
+      ]
+    },
+    "B6": {
+      "score_a": 4,
+      "score_b": 2,
+      "verdict": "A",
+      "rationale": "Side A has explicit verification steps (post-create closing-keyword audit, push verification), rich error-handling tables, script tests and an evals.json, but duplicates the conventional-commit type tables and heredoc rule across several skills and references repo-level rule files outside the plugin. Side B carries visibly stale, project-specific material in a distributed plugin (errorIds.ts/Statsig logging conventions, a claude-cli-internal maintenance pointer), an author mismatch between README (Daisy) and manifest (Anthropic), a README version claim absent from the manifest, and the invalid checkout flag.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/git-plugin/skills/git-pr/SKILL.md",
+          "quote": "After the PR is created, audit the body: every issue referenced by number must"
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/pr-review-toolkit/agents/silent-failure-hunter.md",
+          "quote": "Error IDs should come from constants/errorIds.ts"
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/pr-review-toolkit/README.md",
+          "quote": "Project agents: `.claude/agents/` in claude-cli-internal"
+        }
+      ]
+    }
+  },
+  "identity_leakage": {
+    "recognized": true,
+    "side_a_guess": "laurigates/claude-plugins git-plugin (install command references laurigates-claude-plugins marketplace; author Lauri Gates; repository URL github.com/laurigates/claude-plugins)",
+    "side_b_guess": "Anthropic's official claude-code repo plugins (commit-commands and pr-review-toolkit; author Anthropic support@anthropic.com; README references claude-cli-internal and daisy@anthropic.com)",
+    "leak_evidence": "Side A plugin.json: repository https://github.com/laurigates/claude-plugins and README install line '/plugin install git-plugin@laurigates-claude-plugins'. Side B plugin.json author 'Anthropic <support@anthropic.com>'; pr-review-toolkit README 'Project agents: .claude/agents/ in claude-cli-internal' and author 'Daisy (daisy@anthropic.com)'. Scores were assigned against the anchors before considering origin."
+  },
+  "overall_comment": "Side A is a mature, engineered plugin: trigger-rich descriptions, why-laden instructions, deterministic scripts with offline test seams and structured output, gated destructive actions, and verification loops — its main debits are some over-long always-loaded bodies, the broad Bash(bash *) grant, and duplicated convention tables. Side B pairs admirably lean commands and well-described review agents with distribution-hygiene defects: stale project-internal conventions baked into an agent, author/version inconsistencies, an invalid tool-permission pattern, and an ungated force-delete cleanup command marketed as safe."
+}

--- a/docs/benchmarks/2026-07-marketplace-quality/judgments/security-guidance_j1.json
+++ b/docs/benchmarks/2026-07-marketplace-quality/judgments/security-guidance_j1.json
@@ -1,0 +1,72 @@
+{
+  "pair_id": "security-guidance",
+  "judge_id": "j1",
+  "dimensions": {
+    "B1": {
+      "score_a": 4,
+      "score_b": 4,
+      "verdict": "tie",
+      "rationale": "Side A's plugin description states what fires and when with the key use case front-loaded, and deterministic hook matchers make triggering exact. Side B's descriptions are third-person with concrete triggers plus explicit disambiguation tables, but its two skills overlap on gitleaks/pre-commit setup and neither description disambiguates from the other.",
+      "evidence": [
+        {"side": "A", "file": "side-A/plugins/security-guidance/.claude-plugin/plugin.json", "quote": "Pattern-based warnings on edits, LLM-powered diff review on Stop, and an agentic commit reviewer that catches injection, XSS, SSRF, hardcoded secrets, and 25+ other vulnerability classes."},
+        {"side": "B", "file": "side-B/configure-plugin/skills/configure-security/SKILL.md", "quote": "Security scanning: dependency audits, SAST, secrets detection. Use when setting up Dependabot, CodeQL, or TruffleHog in CI, or creating a SECURITY.md policy."},
+        {"side": "B", "file": "side-B/git-plugin/skills/git-security-checks/SKILL.md", "quote": "Use when scanning for secrets, setting up gitleaks, or configuring .gitleaks.toml pre-commit security."}
+      ]
+    },
+    "B2": {
+      "score_a": 5,
+      "score_b": 4,
+      "verdict": "A",
+      "rationale": "Side A's user-facing instructions are concrete and provider-specific (exact model-id forms per provider, exact troubleshooting commands, an example org-policy file), and rewake messages tell the model precisely what to do with findings. Side B has ordered imperative steps with a runnable detection script and named output keys, but its dynamic Context commands are broken (find -name with a slash under -maxdepth 1 and stray escaped quotes can never match), leaving a fresh agent with misleading context.",
+      "evidence": [
+        {"side": "A", "file": "side-A/plugins/security-guidance/README.md", "quote": "On 3P providers, check `SECURITY_REVIEW_MODEL` is set to a provider-specific id (not a bare `claude-opus-4-7`)."},
+        {"side": "B", "file": "side-B/configure-plugin/skills/configure-security/SKILL.md", "quote": "Workflows dir: !`find . -maxdepth 1 -type d -name \\'.github/workflows\\'`"}
+      ]
+    },
+    "B3": {
+      "score_a": 5,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A's always-loaded surface is essentially just hooks.json; all logic lives in executable scripts that never enter context — the ideal disclosure profile for its architecture. Side B's configure-security is well layered (lean SKILL.md, REFERENCE.md, script), but git-security-checks inlines 469 lines of reference material with internally duplicated sections (two 'Managing False Positives' blocks, a Tools Reference repeating earlier commands), all loaded on trigger.",
+      "evidence": [
+        {"side": "A", "file": "side-A/plugins/security-guidance/hooks/hooks.json", "quote": "Security guidance plugin — pattern-based warnings on edits, git-diff-based LLM review on stop"}
+      ]
+    },
+    "B4": {
+      "score_a": 5,
+      "score_b": 4,
+      "verdict": "A",
+      "rationale": "Side A delegates everything mechanical to scripts of unusual robustness — cross-platform interpreter shim, ReDoS validation of user regexes, race/fallback logic, rate limits, sentinel GC. Side B properly offloads detection to structured-output scripts and even ships a regression test, but the scripts have minor logic quirks (findings counter interaction makes the sensitive-files section's 'none' line wrong after a gitleaks hit) and less hardening.",
+      "evidence": [
+        {"side": "A", "file": "side-A/plugins/security-guidance/hooks/security_reminder_hook.py", "quote": "Race the agentic reviewer against a delayed single-shot fallback."},
+        {"side": "A", "file": "side-A/plugins/security-guidance/hooks/extensibility.py", "quote": "Custom regexes are validated at load for catastrophic-backtracking"},
+        {"side": "B", "file": "side-B/configure-plugin/skills/configure-security/scripts/tests/test-configure-security.sh", "quote": "# Regression test for configure-security.sh detection."}
+      ]
+    },
+    "B5": {
+      "score_a": 4,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A is injection-safe throughout (quoted plugin-root paths, argv subprocess calls, size caps, an explicit trust model preventing repo-controlled config from suppressing findings) with exemplary privacy disclosure, but its SessionStart hook auto-installs a PyPI package without a user gate and the README does not surface that behavior. Side B is competent — quoted shell, set -uo pipefail, --fix as an explicit opt-in — but grants broad unscoped Bash/Write/WebFetch where narrower rules would do.",
+      "evidence": [
+        {"side": "A", "file": "side-A/plugins/security-guidance/hooks/ensure_agent_sdk.py", "quote": "Otherwise it creates a venv at ~/.claude/security/agent-sdk-venv and installs"}
+      ]
+    },
+    "B6": {
+      "score_a": 5,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A shows heavy maintained-as-a-whole evidence: telemetry-driven fixes with issue references, append-only metric codes, documented fail-open postures, dedup and TTL state handling. Side B's references resolve and it has a regression test, but the duplicated false-positive sections and the broken always-run Context commands are exactly the internal-consistency defects the anchor penalizes.",
+      "evidence": [
+        {"side": "A", "file": "side-A/plugins/security-guidance/hooks/security_reminder_hook.py", "quote": "Reflog fallback for hidden stdout. Analysis of skip_reason=21 emissions"}
+      ]
+    }
+  },
+  "identity_leakage": {
+    "recognized": true,
+    "side_a_guess": "Anthropic's official security-guidance plugin from anthropics/claude-plugins-official (author field 'David Dworken, dworken@anthropic.com', homepage points at anthropics/claude-plugins-official, issue refs like #2043/#2159).",
+    "side_b_guess": "laurigates/claude-plugins (configure-plugin's configure-security and git-plugin's git-security-checks; house conventions like created/modified/reviewed frontmatter, .project-standards.yaml, structured KEY=VALUE script output).",
+    "leak_evidence": "side-A plugin.json: author email dworken@anthropic.com and homepage github.com/anthropics/claude-plugins-official; side-B SKILL.md frontmatter carries the house-only created/modified/reviewed fields and references /configure:all and .project-standards.yaml. Recognition did not influence scores; both sides were scored against the anchors on content."
+  },
+  "overall_comment": "Side A is a production-hardened hooks plugin: near-zero context cost, deterministic offload with exceptional robustness, documented trust model and privacy disclosure — its one soft spot is an ungated SessionStart pip install not surfaced in user docs. Side B is competent skill authoring with genuine strengths (disambiguation tables, structured-output scripts, a regression test) but is dragged down by broken dynamic-context commands, in-file duplication, and one bloated always-loaded skill body."
+}

--- a/docs/benchmarks/2026-07-marketplace-quality/judgments/security-guidance_j2.json
+++ b/docs/benchmarks/2026-07-marketplace-quality/judgments/security-guidance_j2.json
@@ -1,0 +1,101 @@
+{
+  "pair_id": "security-guidance",
+  "judge_id": "j2",
+  "dimensions": {
+    "B1": {
+      "score_a": 4,
+      "score_b": 4,
+      "verdict": "tie",
+      "rationale": "A's plugin description is third-person, front-loaded, and precise about what fires when, with deterministic hook matchers as trigger conditions; B's two skill descriptions state concrete trigger contexts and add explicit sibling-disambiguation tables. Neither fully covers near-miss phrasings to the 5 anchor.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/security-guidance/.claude-plugin/plugin.json",
+          "quote": "Pattern-based warnings on edits, LLM-powered diff review on Stop, and an agentic commit reviewer that catches injection, XSS, SSRF"
+        },
+        {
+          "side": "B",
+          "file": "side-B/git-plugin/skills/git-security-checks/SKILL.md",
+          "quote": "Use when scanning for secrets, setting up gitleaks, or configuring .gitleaks.toml pre-commit security."
+        }
+      ]
+    },
+    "B2": {
+      "score_a": 5,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "A's README gives exact, runnable, provider-specific configuration and troubleshooting with the reasoning behind each knob, and hook rewake messages constrain the agent precisely. B's configure-security has concrete ordered steps but its Context commands are broken (escaped quotes inside find -name, path components under -maxdepth 1) and it invokes an undocumented ${CLAUDE_SKILL_DIR} variable, so a zero-context agent would hit dead commands.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/security-guidance/README.md",
+          "quote": "On 3P providers, check `SECURITY_REVIEW_MODEL` is set to a provider-specific id (not a bare `claude-opus-4-7`)."
+        }
+      ]
+    },
+    "B3": {
+      "score_a": 5,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "A loads nothing into context: all behavior lives in executable hooks that run without being read, the ideal disclosure profile. B is mixed — configure-security properly offloads templates to REFERENCE.md, but git-security-checks inlines a 469-line command catalog with repeated sections that loads on every trigger.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/security-guidance/hooks/hooks.json",
+          "quote": "Security guidance plugin — pattern-based warnings on edits, git-diff-based LLM review on stop"
+        }
+      ]
+    },
+    "B4": {
+      "score_a": 5,
+      "score_b": 4,
+      "verdict": "A",
+      "rationale": "A pushes every mechanical operation into robust standalone code: regex rules as pure data with an import-time sync assert, ReDoS validation of user regexes, atomic log rotation, and interpreter fallback. B also delegates well — both skills bundle structured-output scripts with explicit run instructions and a regression test — but the scripts are simpler and one skill still carries much re-derivable command prose.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/security-guidance/hooks/extensibility.py",
+          "quote": "Custom regexes are validated at load for catastrophic-backtracking"
+        },
+        {
+          "side": "B",
+          "file": "side-B/configure-plugin/skills/configure-security/scripts/tests/test-configure-security.sh",
+          "quote": "Regression test for configure-security.sh detection."
+        }
+      ]
+    },
+    "B5": {
+      "score_a": 5,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "A is exceptional: quoted plugin-root paths, an additive-only trust model so repo-controlled guidance cannot suppress findings, provenance banners against prompt-injection confusion, restrictive file modes, kill switches, and explicit privacy documentation. B is competently scoped (git-security-checks limits to Bash+Read, scripts are quoted and non-destructive) but grants broad tool lists and documents history-rewrite/force-push flows without a stronger gate.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/security-guidance/hooks/_base.py",
+          "quote": "0600 on creation; existing files keep their mode."
+        }
+      ]
+    },
+    "B6": {
+      "score_a": 5,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "A shows heavy maintenance evidence — import-time desync asserts run in CI, append-only telemetry codes, categorized failure paths, cooldowns, and graceful degradation — with only a trivially stale docstring. B has resolving references and a real regression test, but duplicates its 'Managing False Positives' section within one skill, pins conflicting gitleaks revs across the two skills (v8.22.1 vs v8.30.1), and ships broken Context commands.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/plugins/security-guidance/hooks/patterns.py",
+          "quote": "Fail loudly at import time if a pattern is added without a RuleId."
+        }
+      ]
+    }
+  },
+  "overall_comment": "Side A is production-grade defensive engineering: zero context cost, deterministic triggering, injection-aware trust modeling, and pervasive failure-path telemetry. Side B is competent skill authoring with genuine strengths (progressive disclosure in one skill, structured-output scripts, a regression test) but is dragged down by broken context commands, an inconsistent plugin-root variable, intra-file duplication, and conflicting version pins. A wins every dimension except trigger/discoverability, which ties.",
+  "identity_leakage": {
+    "recognized": true,
+    "side_a_guess": "Anthropic's official security-guidance plugin (claude-plugins-official; author email dworken@anthropic.com and anthropics/claude-plugins-official URLs appear verbatim).",
+    "side_b_guess": "laurigates/claude-plugins (configure-plugin and git-plugin layout, house frontmatter fields created/modified/reviewed, 'When to Use This Skill' tables, .api_tokens references).",
+    "leak_evidence": "side-A plugin.json: \"homepage\": \"https://github.com/anthropics/claude-plugins-official/tree/main/plugins/security-guidance\" and author dworken@anthropic.com; side-B skills use the house 'When to Use This Skill' table convention and .api_tokens gitignore pattern matching the judge's environment context. Recognition did not affect scoring — anchors were applied to content only."
+  }
+}

--- a/docs/benchmarks/2026-07-marketplace-quality/judgments/session-reporting_j1.json
+++ b/docs/benchmarks/2026-07-marketplace-quality/judgments/session-reporting_j1.json
@@ -1,0 +1,131 @@
+{
+  "pair_id": "session-reporting",
+  "judge_id": "j1",
+  "dimensions": {
+    "B1": {
+      "score_a": 5,
+      "score_b": 2,
+      "verdict": "A",
+      "rationale": "Side A descriptions front-load the action, state third-person trigger phrasings, and every skill carries sibling-disambiguation ('Use alternative when...') covering near-miss contexts. Side B's description is specific about what it produces but states no invocation conditions or user contexts at all.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/session-plugin/skills/session-spinup/SKILL.md",
+          "quote": "Use when user says spin up, what was I doing, or pick up where I left off."
+        },
+        {
+          "side": "A",
+          "file": "side-A/session-plugin/skills/session-wrap/SKILL.md",
+          "quote": "| User says \"wrap up\", \"session wrap\", \"done for now\" | Full end-of-session pass incl. distill/feedback"
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/session-report/skills/session-report/SKILL.md",
+          "quote": "description: Generate an explorable HTML report of Claude Code session usage (tokens, cache, subagents, skills, expensive prompts) from ~/.claude/projects transcripts."
+        }
+      ]
+    },
+    "B2": {
+      "score_a": 5,
+      "score_b": 4,
+      "verdict": "A",
+      "rationale": "Side A gives concrete ordered steps with runnable commands, explains the why throughout (UUID-vs-numeric-ID rationale, the Stop-hook race behind the AskUserQuestion rule), and branches for auto/manual/plan modes. Side B's steps are also concrete with an exact input->output markup example, but rely on a <skill-dir> placeholder and carry less generalizing rationale.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/session-plugin/skills/session-wrap/SKILL.md",
+          "quote": "\"Apply? (y/n)\" text question: ending the turn fires Stop hooks, which can"
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/session-report/skills/session-report/SKILL.md",
+          "quote": "<div class=\"take bad\"><div class=\"fig\">41.2%</div><div class=\"txt\"><b>cc-monitor</b> consumed 41% of the week across just 3 sessions</div></div>"
+        }
+      ]
+    },
+    "B3": {
+      "score_a": 5,
+      "score_b": 4,
+      "verdict": "A",
+      "rationale": "Side A shows clean three-level disclosure: lean skill bodies, per-skill REFERENCE.md loaded on demand (with the shared config schema single-sourced in one of them), and an executable collector that runs without being read. Side B's body is lean and its script/template are on-demand artifacts, but the agent must partially read the 569-line template to edit it.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/session-plugin/skills/session-spinup/REFERENCE.md",
+          "quote": "*interpret* its output, not how to reproduce it."
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/session-report/skills/session-report/SKILL.md",
+          "quote": "The template is the source of interactivity (sorting, expand/collapse, block-char bars). Your job is data + narrative, not markup."
+        }
+      ]
+    },
+    "B4": {
+      "score_a": 5,
+      "score_b": 5,
+      "verdict": "tie",
+      "rationale": "Both sides push all mechanical work into robust standalone scripts with explicit run-don't-reimplement contracts. Side A's shared collector has a stated read-only contract, test seams, and its own regression test; side B's analyzer documents empirically-discovered JSONL semantics, dedupes by requestId/uuid, and degrades gracefully on parse errors.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/session-plugin/scripts/session-survey.sh",
+          "quote": "READ-ONLY by contract: detection + survey + dedup + staleness only. All writes"
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/session-report/skills/session-report/analyze-sessions.mjs",
+          "quote": "LAST one carries the final `output_tokens`. We dedupe by requestId and keep"
+        }
+      ]
+    },
+    "B5": {
+      "score_a": 4,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A gates every destructive path (AskUserQuestion for all writes, cross-repo PRs gated in every mode, never-push-to-default, injection-safe jq hook parsing), but its allowed-tools include Bash(bash *), which is close to arbitrary execution on nominally read-only skills. Side B has essentially no dangerous surface and controls what little it has - competent for its risk profile, nothing exceptional.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/session-plugin/skills/session-distill/SKILL.md",
+          "quote": "gate it behind `AskUserQuestion` in every mode"
+        },
+        {
+          "side": "A",
+          "file": "side-A/session-plugin/skills/session-spinup/SKILL.md",
+          "quote": "allowed-tools: Bash(bash *), Read, TodoWrite"
+        }
+      ]
+    },
+    "B6": {
+      "score_a": 5,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A has regression tests with documented semantic invariants, idempotent once-per-session hook markers, explicit edge-case and failure-path tables, and single-source-of-truth config docs; only minor staleness (the distill REFERENCE.md still titled 'project-distill'). Side B's references resolve and errors are tolerated, but the script header still names 'analyze-sessions.js' at a 'scripts/' path and there is no verification step or test.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/session-plugin/hooks/test-session-end-nudge.sh",
+          "quote": "the emitted JSON must mention session-plugin:session-end"
+        },
+        {
+          "side": "A",
+          "file": "side-A/session-plugin/skills/session-distill/REFERENCE.md",
+          "quote": "# project-distill Reference"
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/session-report/skills/session-report/analyze-sessions.mjs",
+          "quote": " *   node scripts/analyze-sessions.js [--dir <projects-dir>] [--json] [--since <ISO|7d|24h>] [--top N]"
+        }
+      ]
+    }
+  },
+  "overall_comment": "Side A is a mature multi-skill plugin: exemplary triggering and disambiguation, shared deterministic collector with tests, gated writes, and progressive disclosure - its only real blemish is the broad Bash(bash *) grant and a couple of stale doc fragments. Side B is a well-engineered single-purpose skill whose analyzer script is genuinely excellent, but its frontmatter states no trigger conditions, it has no manifest/README/tests, and maintainability signals are thinner. A wins on 5 of 6 dimensions; determinism offload is a tie at the top anchor.",
+  "identity_leakage": {
+    "recognized": true,
+    "side_a_guess": "laurigates/claude-plugins session-plugin (plugin.json author 'Lauri Gates', repository laurigates/claude-plugins; matches session-plugin skills visible in my environment)",
+    "side_b_guess": "Unknown - reads like a personal Claude Code usage-analytics plugin from another marketplace; no identifying strings",
+    "leak_evidence": "side-A/session-plugin/.claude-plugin/plugin.json contains \"repository\": \"https://github.com/laurigates/claude-plugins\" and author name; recognition did not influence scores, which were anchored per-dimension before comparison."
+  }
+}

--- a/docs/benchmarks/2026-07-marketplace-quality/judgments/session-reporting_j2.json
+++ b/docs/benchmarks/2026-07-marketplace-quality/judgments/session-reporting_j2.json
@@ -1,0 +1,111 @@
+{
+  "pair_id": "session-reporting",
+  "judge_id": "j2",
+  "dimensions": {
+    "B1": {
+      "score_a": 5,
+      "score_b": 2,
+      "verdict": "A",
+      "rationale": "Side A's descriptions are third-person, front-load the key use case, list concrete user phrasings, and disambiguate the four sibling skills from each other (wrap vs end vs distill vs spinup). Side B's description states what the skill does and its data source but gives no trigger conditions or user contexts, falling short of the anchor-3 'what AND when' bar.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/session-plugin/skills/session-spinup/SKILL.md",
+          "quote": "Use when user says spin up, what was I doing, or pick up where I left off."
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/session-report/skills/session-report/SKILL.md",
+          "quote": "Generate an explorable HTML report of Claude Code session usage (tokens, cache, subagents, skills, expensive prompts)"
+        }
+      ]
+    },
+    "B2": {
+      "score_a": 5,
+      "score_b": 5,
+      "verdict": "tie",
+      "rationale": "Both sides give concrete ordered steps with runnable commands, exact output formats, and the reasoning behind constraints. Side A explains why AskUserQuestion replaces freeform y/n confirmation (Stop-hook race); side B gives exact HTML markup examples, class semantics, and concrete anomaly thresholds so a fresh agent generalizes correctly.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/session-plugin/skills/session-end/SKILL.md",
+          "quote": "Never end the turn on a freeform \"y/n\" text question — ending the turn"
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/session-report/skills/session-report/SKILL.md",
+          "quote": "The `.fig` is one short number (a %, a count, or a multiplier like `12×`)."
+        }
+      ]
+    },
+    "B3": {
+      "score_a": 5,
+      "score_b": 5,
+      "verdict": "tie",
+      "rationale": "Side A keeps SKILL.md bodies focused and pushes schema, examples, and mechanics to per-skill REFERENCE.md files, with deterministic collection in a script never read into context. Side B's 43-line body delegates all parsing to a script and all presentation to a template that is copied and edited only at marked blocks — textbook multi-level disclosure.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/session-plugin/skills/session-spinup/SKILL.md",
+          "quote": "Example briefing: [REFERENCE.md](REFERENCE.md)."
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/session-report/skills/session-report/SKILL.md",
+          "quote": "The template is the source of interactivity (sorting, expand/collapse, block-char bars). Your job is data + narrative, not markup."
+        }
+      ]
+    },
+    "B4": {
+      "score_a": 5,
+      "score_b": 5,
+      "verdict": "tie",
+      "rationale": "Side A's shared collector handles all mechanical survey/dedup/staleness work, is documented, degrades cleanly without git/task/gh, carries test seams and a regression suite, and is explicitly run-not-read. Side B's analyzer offloads all transcript parsing/aggregation with documented empirical dedupe logic, per-line error tolerance, and CLI flags; the skill explicitly runs it.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/session-plugin/scripts/session-survey.sh",
+          "quote": "READ-ONLY by contract: detection + survey + dedup + staleness only. All writes"
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/session-report/skills/session-report/analyze-sessions.mjs",
+          "quote": "LAST one carries the final `output_tokens`. We dedupe by requestId and keep"
+        }
+      ]
+    },
+    "B5": {
+      "score_a": 4,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A gates every write path behind AskUserQuestion, keeps the collector read-only by contract, parses hook input safely via jq, and makes nudges offer-only — but the recurring Bash(bash *) grant is effectively arbitrary shell execution, a real least-privilege gap that keeps it off 5. Side B is competently safe (read-only analysis, non-destructive output, no injection surface) with nothing exceptional and no note on embedding potentially sensitive prompt text into a file written to the cwd.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/session-plugin/skills/session-wrap/SKILL.md",
+          "quote": "allowed-tools: Bash(bash *), Bash(task *), Bash(git *), Bash(gh *), Read, Write, Edit, AskUserQuestion, TodoWrite"
+        }
+      ]
+    },
+    "B6": {
+      "score_a": 4,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A has regression tests for both hooks and the collector with documented semantic invariants, single-sourced config schema, and resolving cross-references — but shows staleness (session-distill's REFERENCE.md is still titled 'project-distill Reference' after the move, and the README links to docs outside the plugin). Side B's references resolve and it handles empty data and oversized JSON gracefully, but carries stale internal comments (script header/usage still say scripts/analyze-sessions.js) and has no verification step or tests.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/session-plugin/hooks/test-session-end-nudge.sh",
+          "quote": "Semantic invariant (per .claude/rules/regression-testing.md): when the"
+        }
+      ]
+    }
+  },
+  "identity_leakage": {
+    "recognized": true,
+    "side_a_guess": "laurigates/claude-plugins session-plugin (self-referencing repo paths like laurigates/claude-plugins in session-distill, .claude/rules/* citations, author 'Lauri Gates' in plugin.json)",
+    "side_b_guess": "Unknown — a personal Claude Code usage-analytics plugin; no self-identifying strings recognized",
+    "leak_evidence": "side-A/session-plugin/skills/session-distill/SKILL.md contains 'gh pr create -R laurigates/claude-plugins' and plugin.json lists author Lauri Gates; scoring was done against the anchors regardless"
+  },
+  "overall_comment": "Both sides are strong plugin-authoring work with excellent determinism offload and progressive disclosure. Side A wins on triggering (explicit user phrasings + sibling disambiguation across four skills), gating of destructive writes, and a regression-test culture; its weaknesses are a broad Bash(bash *) grant and minor post-refactor staleness. Side B is a tight, well-engineered single-skill artifact whose description lacks trigger conditions and which carries stale internal path comments."
+}

--- a/docs/benchmarks/2026-07-marketplace-quality/judgments/skill-authoring_j1.json
+++ b/docs/benchmarks/2026-07-marketplace-quality/judgments/skill-authoring_j1.json
@@ -1,0 +1,121 @@
+{
+  "pair_id": "skill-authoring",
+  "judge_id": "j1",
+  "dimensions": {
+    "B1": {
+      "score_a": 5,
+      "score_b": 4,
+      "verdict": "A",
+      "rationale": "Side A descriptions front-load the key use case, state concrete third-person trigger conditions, and disambiguate sibling gates inside the description itself (legibility vs matrix vs skill). Side B has excellent quoted trigger phrases but its two skill-creation artifacts (skill-creator and skill-development) both match 'create a skill' with only partial scoping to tell them apart.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/evaluate-plugin/skills/evaluate-matrix/SKILL.md",
+          "quote": "Use when checking whether a weak model can actually do a skill, not just comprehend it."
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/plugin-dev/skills/skill-development/SKILL.md",
+          "quote": "when the user wants to \"create a skill\", \"add a skill to plugin\", \"write a new skill\""
+        }
+      ]
+    },
+    "B2": {
+      "score_a": 5,
+      "score_b": 4,
+      "verdict": "A",
+      "rationale": "Side A gives ordered imperative steps with exact runnable commands, specified output formats to parse (RUN_DIR=, WORKDIR=), and the reasoning behind constraints (serialization due to rate limits, the delta-verify gate rationale). Side B's skill-creator is strong on explain-the-why, but hook-development's dual hooks.json format guidance could mislead a zero-context agent about which shape to write.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/evaluate-plugin/skills/evaluate-matrix/SKILL.md",
+          "quote": "dispatches — one at a time, never a parallel batch"
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/skill-creator/skills/skill-creator/SKILL.md",
+          "quote": "that's a yellow flag"
+        }
+      ]
+    },
+    "B3": {
+      "score_a": 5,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A keeps skill bodies lean (~120-260 lines) with schemas, design docs, and executable scripts loaded only on demand — clear three-level disclosure. Side B has references/examples/scripts structure but its always-loaded bodies are heavy (hook-development ~713 lines, skill-development ~640 lines) and exceed the leanness targets they themselves prescribe.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/evaluate-plugin/skills/evaluate-skill/SKILL.md",
+          "quote": "see `evaluate-plugin/references/schemas.md`"
+        }
+      ]
+    },
+    "B4": {
+      "score_a": 5,
+      "score_b": 4,
+      "verdict": "A",
+      "rationale": "Side A delegates grading, run scaffolding, fixture setup, aggregation, and report rendering to documented scripts with structured KEY=value output contracts and even ships tests for the scripts. Side B also bundles a solid script suite (quick_validate, run_eval/run_loop, hook validators) with usage docs, but scripts have human-oriented output and no test coverage.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/evaluate-plugin/scripts/grade_deterministic.py",
+          "quote": "WITHOUT spending LLM judge tokens"
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh",
+          "quote": "Validates hooks.json structure and checks for common issues"
+        }
+      ]
+    },
+    "B5": {
+      "score_a": 5,
+      "score_b": 3,
+      "verdict": "A",
+      "rationale": "Side A scopes allowed-tools narrowly per skill and agent, gates destructive applies behind user confirmation plus a delta-verify gate with an explicit --force-apply override, and its fixture script guards teardown against deleting outside the temp root while documenting that setup commands are untrusted. Side B teaches injection safety well but its create-plugin command grants unscoped Bash where narrower rules would do.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/evaluate-plugin/scripts/apply_fixture.sh",
+          "quote": "refusing to tear down a path outside the temp root"
+        }
+      ]
+    },
+    "B6": {
+      "score_a": 4,
+      "score_b": 2,
+      "verdict": "A",
+      "rationale": "Side A has explicit failure paths, script tests, and single-source-of-truth discipline, but evaluate-legibility Step 1 claims its Context block ran a script the Context block does not actually run (a recoverable stale reference). Side B contradicts itself on the plugin hooks.json format (wrapper required vs. direct-format example later, and the bundled validator only accepts the direct format), carries a stale word-count claim, and duplicates an entire skill's content into a reference file.",
+      "evidence": [
+        {
+          "side": "A",
+          "file": "side-A/evaluate-plugin/skills/evaluate-legibility/SKILL.md",
+          "quote": "The Context block above ran `emit-legibility-prompt.sh`"
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/plugin-dev/skills/hook-development/SKILL.md",
+          "quote": "`hooks` field is required wrapper containing actual hook events"
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/plugin-dev/skills/hook-development/SKILL.md",
+          "quote": "In plugins, define hooks in `hooks/hooks.json`:"
+        },
+        {
+          "side": "B",
+          "file": "side-B/plugins/plugin-dev/skills/skill-development/SKILL.md",
+          "quote": "Lean SKILL.md (1,651 words)"
+        }
+      ]
+    }
+  },
+  "identity_leakage": {
+    "recognized": true,
+    "side_a_guess": "laurigates/claude-plugins (evaluate-plugin and project-plugin, with the house .claude/rules files)",
+    "side_b_guess": "Anthropic official marketplace plugins (plugin-dev and skill-creator)",
+    "leak_evidence": "Side A plugin.json lists author Lauri Gates / repository laurigates/claude-plugins and references house rules like .claude/rules/skill-evaluation.md; side B plugin.json lists author Anthropic (support@anthropic.com) and the skill-creator content matches the official skill-creator style. I scored strictly against the rubric anchors on staged content; recognition was not used as a scoring input."
+  },
+  "overall_comment": "Side A wins on artifact hygiene: leaner always-loaded bodies, tighter tool scoping, gated destructive actions, structured machine-parseable script contracts with tests, and in-description sibling disambiguation. Side B's skill-creator carries exceptional explain-the-why instruction quality and a genuinely systematic eval loop, but the pair-scored artifacts are dragged down by bloated skill bodies, one unscoped Bash grant, and internal contradictions/staleness in hook-development and skill-development. Side A's one notable defect is a stale Context-block claim in evaluate-legibility."
+}

--- a/docs/benchmarks/2026-07-marketplace-quality/judgments/skill-authoring_j2.json
+++ b/docs/benchmarks/2026-07-marketplace-quality/judgments/skill-authoring_j2.json
@@ -1,0 +1,76 @@
+{
+  "pair_id": "skill-authoring",
+  "judge_id": "j2",
+  "dimensions": {
+    "B1": {
+      "score_a": 5,
+      "score_b": 4,
+      "verdict": "A",
+      "rationale": "Side A's descriptions front-load the key use case, state concrete 'Use when' conditions, and disambiguate sibling gates inside the description itself (executability vs comprehension vs effectiveness). Side B's trigger-phrase lists are exemplary per-artifact, but skill-creator and skill-development both trigger on 'create a skill' with no cross-disambiguation, so Claude cannot reliably tell which to load.",
+      "evidence": [
+        {"side": "A", "file": "side-A/evaluate-plugin/skills/evaluate-legibility/SKILL.md", "quote": "Use when validating whether a skill says clearly when to invoke it and how to start."},
+        {"side": "A", "file": "side-A/evaluate-plugin/skills/evaluate-matrix/SKILL.md", "quote": "the executability gate. Use when checking whether a weak model can actually do a skill"},
+        {"side": "B", "file": "side-B/plugins/plugin-dev/skills/hook-development/SKILL.md", "quote": "asks to \"create a hook\", \"add a PreToolUse/PostToolUse/Stop hook\""},
+        {"side": "B", "file": "side-B/plugins/skill-creator/skills/skill-creator/SKILL.md", "quote": "Create new skills, modify and improve existing skills"}
+      ]
+    },
+    "B2": {
+      "score_a": 5,
+      "score_b": 4,
+      "verdict": "A",
+      "rationale": "Side A gives ordered imperative steps with exact runnable script invocations, output templates, a worked input->output example, and the 'why' behind each constraint (fixtures, serialization). Side B's skill-creator excels at explaining the why, but hook-development contradicts itself on the plugin hooks.json format (wrapper required earlier, direct format shown later for plugins), which would leave a zero-context agent guessing which shape to emit.",
+      "evidence": [
+        {"side": "A", "file": "side-A/evaluate-plugin/skills/evaluate-matrix/SKILL.md", "quote": "without one a context-needing skill fails on haiku purely for lack of fixtures, a false negative that poisons this gate"},
+        {"side": "B", "file": "side-B/plugins/plugin-dev/skills/hook-development/SKILL.md", "quote": "hooks` field is required wrapper containing actual hook events"},
+        {"side": "B", "file": "side-B/plugins/plugin-dev/skills/hook-development/SKILL.md", "quote": "In plugins, define hooks in"}
+      ]
+    },
+    "B3": {
+      "score_a": 5,
+      "score_b": 4,
+      "verdict": "A",
+      "rationale": "Side A's bodies are lean (511-1564 words), push schemas to references/, design rationale to docs/, and prompt assembly into an executable script that runs without being read. Side B implements textbook three-level disclosure in plugin-dev, but skill-creator's ~4,600-word body inlines Claude.ai/Cowork variants and repeats its core loop, and skill-development duplicates skill-creator content it also ships as a reference file.",
+      "evidence": [
+        {"side": "A", "file": "side-A/evaluate-plugin/skills/evaluate-legibility/scripts/emit-legibility-prompt.sh", "quote": "The body of evaluate-legibility/SKILL.md stays declarative: it invokes this"},
+        {"side": "B", "file": "side-B/plugins/skill-creator/skills/skill-creator/SKILL.md", "quote": "Repeating one more time the core loop here for emphasis"}
+      ]
+    },
+    "B4": {
+      "score_a": 5,
+      "score_b": 4,
+      "verdict": "A",
+      "rationale": "Both sides offload heavily to scripts. Side A's grader is explicitly token-frugal, scripts emit structured KEY=value output, validate arguments, and ship their own test suite with fixtures; skills state exactly when to run each script. Side B's tooling is broad and documented, but validate-hook-schema.sh cannot parse the wrapper format its own SKILL.md tells plugin authors to validate with it, and hook-linter's unquoted-variable regex is noise-prone.",
+      "evidence": [
+        {"side": "A", "file": "side-A/evaluate-plugin/scripts/grade_deterministic.py", "quote": "WITHOUT spending LLM judge tokens"},
+        {"side": "B", "file": "side-B/plugins/skill-creator/skills/skill-creator/SKILL.md", "quote": "write and run a script rather than eyeballing it"}
+      ]
+    },
+    "B5": {
+      "score_a": 5,
+      "score_b": 4,
+      "verdict": "A",
+      "rationale": "Side A scopes allowed-tools per skill and agent, documents the untrusted-shell blast radius of eval fixtures, guards teardown against poisoned paths, and gates the only destructive action (writing a live SKILL.md) behind AskUserQuestion plus a delta-verify gate with an explicit recorded override. Side B teaches injection safety and validation well and its agents are narrowly tooled, but its create-plugin command grants unscoped Bash and no comparable gates exist.",
+      "evidence": [
+        {"side": "A", "file": "side-A/evaluate-plugin/scripts/apply_fixture.sh", "quote": "Refuse to remove anything outside the temp root — the setup commands are"},
+        {"side": "B", "file": "side-B/plugins/plugin-dev/agents/plugin-validator.md", "quote": "No hardcoded credentials in any files"}
+      ]
+    },
+    "B6": {
+      "score_a": 5,
+      "score_b": 2,
+      "verdict": "A",
+      "rationale": "Side A's references resolve, error paths are explicit (STATUS=ERROR stop conditions), scripts have regression tests, and a SessionStart drift probe detects stale eval results — maintained as a coherent whole. Side B ships all three plugin-dev agent files with leftover conversational transcript debris after a stray code fence, an internal contradiction on the plugin hooks.json format, and a validator that rejects the format its docs mandate.",
+      "evidence": [
+        {"side": "A", "file": "side-A/evaluate-plugin/hooks/evaluate-drift-probe.sh", "quote": "Detects eval-results that are older than the SKILL.md they evaluate"},
+        {"side": "B", "file": "side-B/plugins/plugin-dev/agents/plugin-validator.md", "quote": "Excellent work! The agent-development skill is now complete and all 6 skills are documented in the README"}
+      ]
+    }
+  },
+  "identity_leakage": {
+    "recognized": true,
+    "side_a_guess": "laurigates/claude-plugins — the evaluate-plugin (author 'Lauri Gates', repository https://github.com/laurigates/claude-plugins in plugin.json, house rules like skill-quality.md)",
+    "side_b_guess": "Anthropic's official claude-code plugins marketplace — plugin-dev and skill-creator (author 'Anthropic', support@anthropic.com in both plugin.json files)",
+    "leak_evidence": "side-A/evaluate-plugin/.claude-plugin/plugin.json carries \"author\": {\"name\": \"Lauri Gates\"} and repository laurigates/claude-plugins; side-B plugin.json files carry \"author\": {\"name\": \"Anthropic\", \"email\": \"support@anthropic.com\"}. Scores were anchored to the rubric text only; recognition was not used to adjust them."
+  },
+  "overall_comment": "Side A is tighter on every dimension judged: lean imperative skills, token-frugal deterministic grading with its own tests, safety gates on the one destructive path, and drift detection. Side B contains genuinely excellent teaching content and a rich script toolkit, but is dragged down by concrete maintenance defects: transcript debris left in all three plugin-dev agent definitions, a wrapper-vs-direct hooks.json contradiction, a validator that cannot parse the documented plugin format, and a bloated, self-repeating skill-creator body."
+}

--- a/docs/benchmarks/2026-07-marketplace-quality/judgments/tier-a_j1.json
+++ b/docs/benchmarks/2026-07-marketplace-quality/judgments/tier-a_j1.json
@@ -1,0 +1,67 @@
+{
+  "pair_id": "tier-a",
+  "judge_id": "j1",
+  "dimensions": {
+    "A1": {
+      "score_ours": 4,
+      "score_official": 4,
+      "verdict": "tie",
+      "rationale": "Both manifests carry all required fields with valid values, kebab-case names, fully-resolving sources, zero orphan entries, zero entry-vs-plugin.json version mismatches, and a $schema for editor validation. Neither reaches 5 on 'complete recommended metadata': ours' marketplace entries omit author/license entirely (license in only 24/44 plugin.json, author 25/44, repository 23/44); official's entries omit license (0/255) and version (14/255, deliberate for SHA-pinned externals) and author on 85/255, and in-repo plugin.json mostly lack version (12/39) and license (1/39). Ours compensates with automated entry↔plugin.json sync (validate-plugin-configs.yml); official compensates with homepage on 239/255 entries and structured pinned sources. Same partial-metadata defect on both sides — tie at 4.",
+      "evidence": [
+        {"side": "ours", "file": ".claude-plugin/marketplace.json", "quote": "\"$schema\": \"https://json.schemastore.org/claude-code-marketplace.json\""},
+        {"side": "official", "file": ".claude-plugin/marketplace.json", "quote": "\"$schema\": \"https://anthropic.com/claude-code/marketplace.schema.json\""}
+      ]
+    },
+    "A2": {
+      "score_ours": 5,
+      "score_official": 4,
+      "verdict": "ours",
+      "rationale": "Ours: 21 workflows, 10 PR-triggered, covering schema/structure compliance (plugin-compliance-check.sh), config sync (validate-plugin-configs), frontmatter/case checks, workflow-model audit, enablement-drift, plus a genuine regression culture — 30 check-*.sh guards each pinning a fixed defect (check-loop-integrity, check-git-sandbox-guards, check-version-pin-coverage) and a dedicated CI job running skill-local regression tests (test-skill-scripts.yml). That is semantic gates plus regression culture: 5. Official: 9 workflows with an invariant-based composite validator (I1–I11, SHA-pin as hard error), frontmatter validation, per-plugin license enforcement, MCP URL liveness, and an AI policy scan of external entries with verdict caching — deep semantic gates scaled to its curation model. But check_scripts=0 and no test harness for its own automation scripts; the regression culture leg of anchor 5 is thinner (defects are encoded in workflow comments, not guarding checks), so 4.",
+      "evidence": [
+        {"side": "ours", "file": ".github/workflows/test-skill-scripts.yml", "quote": "Runs the skill-local regression tests that ship next to a skill's extracted"},
+        {"side": "official", "file": ".github/workflows/scan-plugins.yml", "quote": "Claude policy scan of changed external marketplace entries."}
+      ]
+    },
+    "A3": {
+      "score_ours": 5,
+      "score_official": 3,
+      "verdict": "ours",
+      "rationale": "Ours: valid semver on all 44 plugins, bumped by release-please per package with the version authoritative in the marketplace/manifest and synced into plugin.json via extra-files jsonpath (no conflicting duplicate — sync is automated and CI-guarded), 44 per-plugin CHANGELOGs, and the strategy documented in .claude/rules/release-please.md. Fully automated release+changelog generation applied in practice: 5. Official: external entries use a deliberate, coherent commit-SHA scheme with nightly automated bumps (bump-plugin-shas.yml) — that satisfies anchor 3's 'deliberate commit-SHA versioning' — but in-repo plugins mostly have no version (12/39), zero changelogs anywhere, and no release automation for its own plugins, so it does not reach the automated-changelog bar of 5. Competent-but-mixed: 3.",
+      "evidence": [
+        {"side": "ours", "file": "release-please-config.json", "quote": "\"$schema\": \"https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json\""}
+      ]
+    },
+    "A4": {
+      "score_ours": 4,
+      "score_official": 5,
+      "verdict": "official",
+      "rationale": "Official's distribution model carries the maximum supply-chain risk (204 external vendor refs) and controls it exceptionally: every external source pinned to a full 40-char SHA alongside a human-readable ref, a nightly validated bump pipeline with per-entry isolation and a revert workflow, MCP URL liveness checks, per-plugin Apache LICENSE enforcement in CI, an external-PR scope guard whose allowlist is derived from the live marketplace, an AI policy scan for credential-exfiltration/cross-service hops, and SHA-pinned third-party actions: 5. Ours is self-contained (44 in-repo sources — no external-pin risk, per the symmetry rule), declares MIT at root and in 24/44 plugin.json, uses ${CLAUDE_PLUGIN_ROOT}/relative paths, and adds Renovate plus a version-pin coverage guard for executable pins inside skill content. Residual gaps for a repo that distributes to others: GitHub Actions in its own workflows are tag-pinned (actions/checkout@v6) rather than SHA-pinned, and license metadata is inconsistent across plugins: 4.",
+      "evidence": [
+        {"side": "official", "file": ".claude-plugin/marketplace.json", "quote": "\"sha\": \"0f325999a7106eadb2d0ecbcccabf6c12dc06aef\""},
+        {"side": "official", "file": ".github/workflows/bump-plugin-shas.yml", "quote": "Nightly sweep: for each external entry whose upstream HEAD has moved past"},
+        {"side": "ours", "file": "scripts/check-version-pin-coverage.sh", "quote": "Every executable version pin in skill markdown"}
+      ]
+    },
+    "A5": {
+      "score_ours": 3,
+      "score_official": 4,
+      "verdict": "official",
+      "rationale": "Ours has rich navigability — per-plugin READMEs, a tiered PLUGIN-MAP with install order and presets, keywords/category on every entry — but fails the accuracy leg: marketplace.json has NO top-level description (the documented 'No marketplace description provided' warning class), README says '43 Claude Code plugins' then 'registers all 44 plugins' in the same page, and PLUGIN-MAP claims '42 plugins and 300+ skills' against 44 plugins / 384 skills on disk, plus 78 unresolved relative links. Anchor 5 explicitly requires counts/claims kept in sync with source; ours' drift caps it at 3 despite the depth. Official: top-level marketplace description present, README accurately documents structure/install/contribution with no count claims to drift, description on all 255 entries, homepage on 239, category on 241, READMEs on in-repo plugins; only 7 broken relative links. Not 5 — external vendored entries lack in-repo per-plugin docs and there is no catalog index beyond the manifest — but a solid 4.",
+      "evidence": [
+        {"side": "ours", "file": "docs/PLUGIN-MAP.md", "quote": "Navigation guide for 42 plugins and 300+ skills. Start here."},
+        {"side": "official", "file": ".claude-plugin/marketplace.json", "quote": "Directory of popular Claude Code extensions including development tools, productivity plugins, and MCP integrations"}
+      ]
+    },
+    "A6": {
+      "score_ours": 5,
+      "score_official": 4,
+      "verdict": "ours",
+      "rationale": "Ours: MIT license, author/repository attribution, contribution guidance (CLAUDE.md plugin lifecycle + conventional-commit rules), and — decisive for anchor 5 — systematic skill-effectiveness measurement that is demonstrably used: a dedicated evaluate-plugin (eval cases, grading, cross-model matrix, legibility cold-reads, benchmark reports), a maintained golden-set.json canary tier wired to house rules, and scheduled audit workflows filing issues. That is measured-not-asserted quality: 5. Official: Apache-2.0 license, clear ownership, a documented external-submission process with quality/security standards, and a governance mechanism that is actually enforced in CI (policy prompt + schema + scan workflow + scope guard) — strong governance. But skill *effectiveness* of the cataloged plugins is not measured by the marketplace itself (the scan is security/policy review; the eval harness it ships lives inside the skill-creator plugin as a product, with no evidence it gates the catalog): 4.",
+      "evidence": [
+        {"side": "ours", "file": "evaluate-plugin/golden-set.json", "quote": "The cross-model (Tier-2) canary set. ~15-25 representative, high-traffic, or high-risk skills"},
+        {"side": "official", "file": "README.md", "quote": "External plugins must meet quality and security standards for approval."}
+      ]
+    }
+  },
+  "overall_comment": "Two strong repos optimized for different models. Ours (first-party monorepo) leads on release discipline (full release-please semver + 44 changelogs vs. no changelogs), validation depth with a genuine regression culture (30 defect-pinning check scripts + skill-script test CI), and measured skill quality (evaluate-plugin + golden set). Official (curated directory) leads exactly where its model's risks live: exemplary supply-chain control of 204 external SHA-pinned sources (nightly validated bumps, revert path, liveness checks, scope guard, AI policy scan) and accurate, description-complete catalog docs. Ours' most fixable defects are catalog-claim drift (42/43/44 plugin counts across PLUGIN-MAP/README/manifest), the missing top-level marketplace description, and inconsistent per-plugin license/author metadata; official's are the absence of versioning/changelogs for its in-repo plugins and zero test coverage of its own automation scripts. Net: 3 dimensions to ours, 2 to official, 1 tie."
+}

--- a/docs/benchmarks/2026-07-marketplace-quality/judgments/tier-a_j2.json
+++ b/docs/benchmarks/2026-07-marketplace-quality/judgments/tier-a_j2.json
@@ -1,0 +1,125 @@
+{
+  "pair_id": "tier-a",
+  "judge_id": "j2",
+  "dimensions": {
+    "A1": {
+      "score_ours": 4,
+      "score_official": 3,
+      "verdict": "ours",
+      "rationale": "Ours: all 44 marketplace entries carry name/source/description/version/keywords/category, a $schema for editor validation, every source resolves, zero orphans/dupes, and plugin.json versions are mechanically kept identical to marketplace entries (version_mismatches: []). Falls short of 5 because recommended metadata is incomplete in plugin.json (license 24/44, repository 23/44, author 25/44) and no rename history. Official: all required fields valid, no dupes or orphaned entries, $schema present, rich homepage/author/category on external entries — solidly competent — but recommended metadata is largely absent from in-repo plugin.json files (version 12/39, license 1/39, repository 1/39, keywords 6/39) and only 14/255 entries declare a version, so entry-vs-plugin.json metadata completeness/consistency is well below the 5 anchor.",
+      "evidence": [
+        {
+          "side": "ours",
+          "file": ".claude-plugin/marketplace.json",
+          "quote": "\"$schema\": \"https://json.schemastore.org/claude-code-marketplace.json\""
+        }
+      ]
+    },
+    "A2": {
+      "score_ours": 5,
+      "score_official": 5,
+      "verdict": "tie",
+      "rationale": "Both repos run semantic gates well beyond syntax, each scaled to its actual surface. Ours (44 first-party plugins, 384 skills): plugin-pr-checks compliance script + Claude skill-quality review, validate-plugin-configs with auto-fix sync of release-please/marketplace/PLUGIN-MAP, 30 check-* regression scripts, and a dedicated workflow running skill-local regression tests — an explicit fixed-defect-gains-a-check culture. Official (curation of ~204 external SHA-pinned refs): the real `claude plugin validate` with a tiered invariant system, frontmatter validation, per-plugin license enforcement, MCP URL liveness probes, and a schema-constrained Claude security/privacy policy scan as a required check, plus revert-on-failure automation. Same depth relative to what could actually break on each side.",
+      "evidence": [
+        {
+          "side": "ours",
+          "file": ".github/workflows/test-skill-scripts.yml",
+          "quote": "Runs the skill-local regression tests that ship next to a skill's extracted"
+        },
+        {
+          "side": "official",
+          "file": ".github/workflows/scan-plugins.yml",
+          "quote": "Claude policy scan of changed external marketplace entries."
+        },
+        {
+          "side": "official",
+          "file": ".github/workflows/validate-plugins.yml",
+          "quote": "Official curated marketplace: SHA-pin (I5) is a HARD error."
+        }
+      ]
+    },
+    "A3": {
+      "score_ours": 5,
+      "score_official": 4,
+      "verdict": "ours",
+      "rationale": "Ours: full release-please monorepo automation — per-plugin semver in a single manifest, 44 generated CHANGELOGs, conventional-commit-driven bumps, extra-files jsonpath writing the version into each plugin.json so marketplace/plugin.json never conflict (mismatches: 0), and a CI sync check guarding the whole scheme. Version does appear in both plugin.json and marketplace entry (docs advise against), but automation keeps them provably consistent. Official: for the 204 external entries the deliberate commit-SHA scheme is exemplary and automated (nightly validated SHA bumps with per-entry PRs and revert-on-failure) — but the 51 in-repo plugins mostly declare no version (12/39), have zero changelogs anywhere in the repo, and no bump discipline, so users of in-repo plugins track the git SHA implicitly with no release notes.",
+      "evidence": [
+        {
+          "side": "ours",
+          "file": "release-please-config.json",
+          "quote": "\"$schema\": \"https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json\""
+        },
+        {
+          "side": "official",
+          "file": ".github/workflows/bump-plugin-shas.yml",
+          "quote": "Nightly sweep: for each external entry whose upstream HEAD has moved past"
+        }
+      ]
+    },
+    "A4": {
+      "score_ours": 4,
+      "score_official": 5,
+      "verdict": "official",
+      "rationale": "Official carries the far larger supply-chain surface (204 external vendor refs) and controls it exceptionally: exact 40-char SHA pins enforced as a hard validation error, nightly validated bump automation with GitHub-signed commits and tamper-abort revert logic, a derived-allowlist scope guard on non-member PRs, auto-close of out-of-scope external PRs, per-plugin Apache LICENSE enforcement in CI, and MCP endpoint liveness checks — a textbook 5 for its risk profile. Ours is self-contained (44 in-repo sources, no external pinning risk), uses ${CLAUDE_PLUGIN_ROOT} for hook paths, ships a root MIT LICENSE, and has Renovate managing pinned versions in skill examples with a pin-coverage check — its actual risks are controlled — but license declaration is incomplete (24/44 plugin.json) and workflow actions are tag-pinned (checkout@v6) rather than full-SHA-pinned, so it sits at 4 rather than 5 on provenance rigor.",
+      "evidence": [
+        {
+          "side": "official",
+          "file": ".github/workflows/external-pr-scope-guard.yml",
+          "quote": "a non-member PR may only ADD marketplace.json entries whose source repo already backs a live plugin here"
+        },
+        {
+          "side": "official",
+          "file": ".github/workflows/validate-licenses.yml",
+          "quote": "Check every plugin has an Apache 2.0 LICENSE file"
+        },
+        {
+          "side": "ours",
+          "file": "hooks-plugin/.claude-plugin/plugin.json",
+          "quote": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/bash-antipatterns.sh"
+        }
+      ]
+    },
+    "A5": {
+      "score_ours": 4,
+      "score_official": 3,
+      "verdict": "ours",
+      "rationale": "Ours: 44/44 plugins have READMEs, every entry carries description/keywords/category, and docs/PLUGIN-MAP.md provides a tiered install-order navigation layer plus decision trees — well past the 3 anchor. It misses 5 on the exact criterion the anchor names: counts do not match disk — README claims '43 Claude Code plugins' (44 exist, and even contradicts itself two paragraphs later with 'all 44 plugins') and PLUGIN-MAP claims '42 plugins and 300+ skills' against 44 plugins/384 skills, despite the repo shipping docs-refresh tooling meant to prevent exactly this. Official: top-level marketplace description present, a clear README covering structure/install/submission, and per-entry descriptions with homepages — competent — but per-plugin README coverage is partial in external_plugins (5/16) and there is no navigable catalog/index of the 255 entries.",
+      "evidence": [
+        {
+          "side": "ours",
+          "file": "docs/PLUGIN-MAP.md",
+          "quote": "Navigation guide for 42 plugins and 300+ skills. Start here."
+        },
+        {
+          "side": "ours",
+          "file": "README.md",
+          "quote": "A curated collection of 43 Claude Code plugins providing 360+ skills and 21 agents"
+        }
+      ]
+    },
+    "A6": {
+      "score_ours": 5,
+      "score_official": 4,
+      "verdict": "ours",
+      "rationale": "Ours: ownership signals present (MIT LICENSE, author/repository fields, CLAUDE.md contribution/lifecycle guidance) plus systematic, in-repo eval infrastructure that is demonstrably used — evaluate-plugin ships eval-case running, deterministic grading scripts, cross-model matrix evals, cold-read legibility gating, a golden-set, and batch plugin reports, backed by house rules requiring regression checks for fixed skill bugs. That is measured skill quality, the 5 anchor. Official: strong documented governance — Anthropic ownership, per-entry authors, a public submission process, and an enforced security/privacy policy review with a JSON verdict schema running as a required CI check (evidence of actual use) — but skill *effectiveness* of the marketplace's own plugins is not measured; the skill-creator eval harness is shipped as a product rather than applied to the catalog, so it lands at 4.",
+      "evidence": [
+        {
+          "side": "ours",
+          "file": "evaluate-plugin/.claude-plugin/plugin.json",
+          "quote": "Skill evaluation and benchmarking - test skill effectiveness with behavioral eval cases, grade results, and track quality improvements"
+        },
+        {
+          "side": "official",
+          "file": ".github/policy/prompt.md",
+          "quote": "You are a security and privacy reviewer evaluating a Claude Code plugin for the"
+        },
+        {
+          "side": "official",
+          "file": "README.md",
+          "quote": "Third-party partners can submit plugins for inclusion in the marketplace."
+        }
+      ]
+    }
+  },
+  "overall_comment": "Two strong repos optimized for different jobs. Ours is a first-party monorepo with exemplary release discipline (release-please semver + 44 changelogs), complete manifest metadata kept in sync mechanically, deep regression-test/check-script culture, and genuinely used eval infrastructure — its weakest spots are stale plugin/skill counts in README/PLUGIN-MAP and incomplete license/repository fields in half the plugin.json files. Official is a curation platform whose supply-chain controls (hard SHA-pin enforcement, nightly validated bumps with signed commits and auto-revert, external-PR scope guards, per-plugin license CI, Claude policy scans) are the best-in-class reference for its distribution model, but its in-repo plugins are thin on versioning, changelogs, and recommended metadata. Net: ours wins on manifest integrity, release discipline, docs, and eval governance; official wins decisively on supply-chain safety; validation CI depth is a tie relative to each surface."
+}

--- a/docs/benchmarks/2026-07-marketplace-quality/marketplace-quality-comparison.md
+++ b/docs/benchmarks/2026-07-marketplace-quality/marketplace-quality-comparison.md
@@ -1,0 +1,226 @@
+# Marketplace Quality Benchmark: laurigates/claude-plugins vs anthropics/claude-plugins-official
+
+*Run date: 2026-07-02/03 · Official pinned @ `4cd126ba` · 9 blind pairs · 2 judges/unit · refuter-verified · quote-gated*
+
+## 1. Executive summary
+
+**Two strong marketplaces optimized for different jobs.** laurigates/claude-plugins is a deep first-party *product monorepo* — it wins on release discipline, eval infrastructure, regression culture, trigger discoverability, context economy, and robustness. anthropics/claude-plugins-official is a curated *directory* — it wins exactly where its model's risks live (supply-chain control of 204 SHA-pinned vendor refs) and, more pointedly for us, **its flagship plugins beat ours on instruction depth in three head-to-head pairs** (security-guidance, mcp-dev, autonomous-loop).
+
+Headline numbers (Tier B, 9 blind pairs × 2 judges × 6 dimensions; medians): ours takes the pair verdict in **5 of 9** (hooks 6-0, pr-commit 6-0, skill-authoring 6-0, session-reporting 5-0-1, code-review 3-2-1), official in **3 of 9** (security-guidance 0-5-1, autonomous-loop, mcp-dev), one even (claude-md). By dimension across pairs, ours leads B1 discoverability (7/9), B3 context economy (6/9), B6 robustness (6/9), B5 safety (5/9); the official side makes B2 instruction quality (4v3) and B4 determinism offload (3v2, 4 ties) genuinely contested. Tier A: ours 4 dimensions, official 1 (supply-chain, their home turf — deliberately included), 1 tie after adversarial adjustment.
+
+Every extreme score was evidence-gated: **231/231 quotes mechanically verified** against staged files, zero fabricated. All 10 selected findings were adversarially re-judged (8 upheld — including two *pro-official* wins — 2 adjusted, both trimming pro-ours margins; none overturned). Read the **Bias & limitations** section before quoting any single number: blinding failed to conceal identity (authors' names ship in the artifacts), and side-A position and pair composition are confounded at n=9.
+
+### Tier B scoreboard — authoring quality (blind, per-pair medians)
+
+| Dimension | Pair wins (ours / official / tie) | Mean median ours | Mean median official |
+|---|---|---|---|
+| **B1 Trigger & discoverability** | 7 / 1 / 1 | 4.72 | 3.44 |
+| **B2 Instruction quality** | 4 / 3 / 2 | 4.17 | 4.28 |
+| **B3 Context economy** | 6 / 3 / 0 | 4.0 | 3.89 |
+| **B4 Determinism offload** | 3 / 2 / 4 | 3.94 | 3.89 |
+| **B5 Safety & permissions** | 5 / 3 / 1 | 3.89 | 3.67 |
+| **B6 Robustness & maintainability** | 6 / 2 / 1 | 3.67 | 3.0 |
+
+### Tier B pair matrix
+
+| Pair | B1 | B2 | B3 | B4 | B5 | B6 | Outcome |
+|---|---|---|---|---|---|---|---|
+| autonomous-loop | 5v3 ours✓ | 4v4 tie | 3v4.5 offi | 2.5v5 offi✓ | 3v4 offi | 4v3 ours | 2-3-1 → **official** |
+| claude-md | 4.5v4 ours~ | 4v4 tie | 3v4 offi | 3v3 tie | 4v4 tie | 3v3 tie | 1-1-4 → **even** |
+| code-review | 5v2 ours≊ | 3v5 offi✓ | 3.5v3 ours~ | 3v3 tie | 3v4 offi | 3v2 ours | 3-2-1 → **ours** |
+| hooks | 5v4 ours | 5v4 ours | 5v3 ours✓ | 5v4 ours | 5v4 ours | 4v2.5 ours | 6-0-0 → **ours** |
+| mcp-dev | 4v5 offi | 3.5v5 offi | 4.5v4 ours~ | 3v3 tie | 4v3.5 ours~ | 3v4.5 offi | 2-3-1 → **official** |
+| pr-commit-workflow | 5v3 ours✓ | 4.5v3 ours | 4v3.5 ours~ | 5v3 ours✓ | 4v2.5 ours | 4v2 ours | 6-0-0 → **ours** |
+| security-guidance | 4v4 tie | 3.5v5 offi | 3v5 offi | 4v5 offi | 3v4.5 offi | 3v5 offi | 0-5-1 → **official** |
+| session-reporting | 5v2 ours✓ | 5v4.5 ours~ | 5v4.5 ours~ | 5v5 tie | 4v3 ours | 4.5v3 ours | 5-0-1 → **ours** |
+| skill-authoring | 5v4 ours | 5v4 ours | 5v3.5 ours | 5v4 ours | 5v3.5 ours | 4.5v2 ours✓ | 6-0-0 → **ours** |
+
+Cell = median ours **v** median official + per-dimension winner. ✓ refuter-upheld · ≊ refuter-adjusted · ~ judges split · ? refuter did not run (quota).
+
+### Tier A scoreboard — marketplace infrastructure (open-book)
+
+| Dimension | Median ours | Median official | Verdict | Confidence |
+|---|---|---|---|---|
+| **A1 Manifest schema & integrity** | 4 | 3.5 | ours | judges split |
+| **A2 Validation CI depth** | 5 | 4.5 | ours | judges split |
+| **A3 Versioning & release discipline** | 5 | 3.5 | ours | unanimous |
+| **A4 Supply-chain & distribution safety** | 4 | 5 | official | unanimous |
+| **A5 Docs & navigability** | 3.5 | 3.5 | tie | refuter-adjusted |
+| **A6 Governance & eval infrastructure** | 5 | 4 | ours | unanimous |
+
+## 2. Methodology & rubric provenance
+
+**Design.** Two channels, never blended: **Channel M** — one deterministic Python pass over both full trees (byte-identical across runs); **Channel J** — anchored 1–5 judgments, median of 2 independent judges per unit. Tier B (authoring quality, 6 dimensions) judged **blind** on 9 staged overlap pairs (`side-A`/`side-B`, deterministic balanced assignment, blinding manifest withheld from judges). Tier A (infrastructure, 6 dimensions) judged **open-book** per repo. Tier C is descriptive only.
+
+**Rubric provenance.** All scored anchors were frozen *before* judging, derived only from published Anthropic guidance (code.claude.com skills/plugins/plugin-marketplaces/hooks docs, the Agent Skills engineering post) and the official repo's own skill-creator/plugin-dev references. Our house rules were read only to build a 12-item exclusion list (e.g. the literal “Use when” phrasing, `created/modified` dates, char-count gates, `REFERENCE.md` naming — none scored). Full rubric: `bench/rubric.md`.
+
+**Anti-bias machinery.** Independent-then-compare scoring (each side scored against anchors before comparison); every extreme score (1/2/4/5) requires a verbatim quote, mechanically string-matched against staged files (231 checked, 0 failed); refute-prompted verifiers re-judged the 10 highest-stakes findings including a symmetric-standard check; identity leakage self-reported per judgment and published; A/B position bias measured and published.
+
+**Scale.** 32 successful agent runs: 18 blind pair judges + 2 Tier-A judges + 1 rubric derivation + 1 quote-check + 10 adversarial refuters; ~9M subagent tokens including a quota-aborted first wave. Official repo pinned at `4cd126ba` (2026-07-02); ours at working tree of `main` (728bb0c7 era, 2026-07-02).
+
+## 3. Tier A findings
+
+Both Tier-A judges converged on the same shape: *two strong repos optimized for different distribution models*.
+
+**Where ours leads.**
+- **A3 Versioning & release (5 v 3.5, unanimous):** full release-please monorepo automation — per-plugin semver, 44 generated changelogs, version synced into each `plugin.json` via `extra-files` jsonpath with zero entry-vs-plugin mismatches, CI-guarded. Official's in-repo plugins are mostly unversioned with no changelogs (their SHA-pin scheme covers *external* refs only).
+- **A6 Governance & eval (5 v 4, unanimous):** the decisive anchor-5 evidence was *measured* skill quality: evaluate-plugin's eval cases, deterministic grading, cross-model matrix, cold-read legibility gating, and a golden set (*“The cross-model (Tier-2) canary set. ~15-25 representative, high-traffic, or high-risk skills”*). Official's AI policy scan (`.github/policy/prompt.md`) is strong governance for *intake*, less so for measuring skill effectiveness.
+- **A2 Validation CI depth (5 v 4.5, split then reconciled):** 21 workflows incl. semantic gates and a genuine regression culture — 30 `check-*.sh` scripts each pinning a fixed defect, plus per-skill script tests in CI. Official's validation is also semantic (SHA-pin hard errors, license checks, MCP liveness, AI policy scan) and one judge scored it equal; the margin is thin.
+- **A1 Manifest integrity (4 v 3.5, split):** both manifests are valid and orphan-free with `$schema`; ours carries version/keywords/category on every entry (official: version on 14/255, author on 170/255), but ours omits author/license in entries and license in 20 of 44 `plugin.json`.
+
+**Where official leads.**
+- **A4 Supply-chain (4 v 5, unanimous):** their model carries the maximum risk — 204 external vendor refs — and controls it exceptionally: exact 40-char SHA pins enforced as a **hard validation error**, nightly validated bump automation with tamper-abort revert, MCP URL liveness checks, per-plugin Apache LICENSE enforcement, and a derived-allowlist scope guard that auto-closes out-of-scope external PRs (*“a non-member PR may only ADD marketplace.json entries whose source repo already backs a live plugin here”*). Ours controls the risks it actually has (first-party only, `${CLAUDE_PLUGIN_ROOT}` paths, version-pin coverage checks) — 4, not 5, for lacking license validation across its own components.
+- **A5 Docs & navigability — refuter-adjusted to a tie (3.5 v 3.5), with a symmetric-standard violation flagged.** Judges initially split, and the refuter found *both* sides fail the accuracy leg the anchor names: ours claims “Navigation guide for 42 plugins and 300+ skills” (actual: 44/384) and “43 Claude Code plugins” in the README, with no top-level marketplace `description`; official's catalog description is accurate but its per-plugin docs are thinner. The pre-registered stale-docs finding from the exploration phase was independently rediscovered by both judges.
+
+## 4. Tier B pair capsules
+
+### security-guidance
+
+**Outcome: 0-5-1 → official.** Official staged as side-A. Official sources: plugins/security-guidance. Ours: configure-plugin/skills/configure-security, git-plugin/skills/git-security-checks.
+
+The clearest official win (0-5-1). **security-guidance (official)** is production-hardened: near-zero always-loaded context cost, deterministic hook offload with exceptional robustness, a documented trust model and privacy disclosure; its one soft spot is an ungated SessionStart `pip install`. **configure-security + git-security-checks (ours)** has genuine strengths (disambiguation tables, structured-output scripts, a regression test) but is dragged down by **broken dynamic-context commands, in-file duplication, and one bloated always-loaded skill body**.
+
+### autonomous-loop
+
+**Outcome: 2-3-1 → official.** Official staged as side-A. Official sources: plugins/ralph-loop. Ours: project-plugin/skills/project-test-loop, .claude/rules/loop-integrity.md.
+
+Judges found complementary strengths. **ralph-loop (official)** is the engineering-first artifact: a real loop driver (`stop-hook.sh`, capped-input jq parsing — *“Capped at the last 100 assistant lines to keep jq's slurp input bounded”*), tight permissions, lean surface. **project-test-loop + loop-integrity (ours)** is documentation-first: outstanding triggering (*“Use when looping on failing tests, running a TDD cycle”*) and the strongest governance thinking (independent stop conditions), but **zero determinism offload** — the loop is prose the model re-derives, and declared arguments go unused. The B4 2v5 loss was adversarially re-checked and **upheld**.
+
+### mcp-dev
+
+**Outcome: 2-3-1 → official.** Official staged as side-A. Official sources: plugins/mcp-server-dev. Ours: agent-patterns-plugin/skills/mcp-server-authoring, agent-patterns-plugin/skills/mcp-management, agent-patterns-plugin/skills/mcp-code-execution, agent-patterns-plugin/.claude-plugin/plugin.json.
+
+**mcp-server-dev (official)** wins on substance: a deep, procedure-first build path with reasoning throughout (B1/B2/B6), at the cost of one bloated body and a duplicated scaffold. **Our mcp trio** is disciplined and lean — textbook SKILL/REFERENCE splits, explicit least-privilege tool scoping (B5 to ours) — but its instructions are shallower and partly portfolio-bound. 2-3-1 to official.
+
+### code-review
+
+**Outcome: 3-2-1 → ours.** Official staged as side-A. Official sources: plugins/code-review. Ours: code-quality-plugin/skills/code-review, code-quality-plugin/skills/code-review-checklist, agents-plugin/agents/review.md, code-quality-plugin/.claude-plugin/plugin.json, code-quality-plugin/README.md.
+
+A genuine split. **Official's code-review** is the stronger *executable* artifact — exceptional procedural instructions with a verbatim scoring rubric, false-positive re-verification, confidence thresholds (B2 5v3, refuter-**upheld**) — but its command has a near-empty trigger description (B1 2) and a stale README contradicting its own toolset. **Ours (code-quality:code-review + agents review)** is the stronger *catalog citizen*: rich trigger descriptions, sibling disambiguation, complete metadata (B1 refuter-adjusted from 5v2 to 4v2, still ours), with competent but looser instructions. Net 3-2-1 to ours — and the clearest “adopt their instruction depth” signal in the run.
+
+### claude-md
+
+**Outcome: 1-1-4 → even.** Official staged as side-A. Official sources: plugins/claude-md-management. Ours: blueprint-plugin/skills/blueprint-claude-md, agent-patterns-plugin/skills/meta-context-diet.
+
+The closest pair — four ties. **claude-md-management (official)** is a small, clean, well-disclosed plugin (lean body, on-demand references, explicit approval gating) marred by an orphaned duplicate reference file and a nonstandard `tools:` frontmatter key. **blueprint-claude-md + meta-context-diet (ours)** is denser and more reasoning-rich with exemplary trigger disambiguation, but inlines everything (no progressive disclosure in one skill) and references house rules that don't ship with the artifact.
+
+### hooks
+
+**Outcome: 6-0-0 → ours.** Official staged as side-B. Official sources: plugins/hookify. Ours: hooks-plugin.
+
+Clean sweep for **hooks-plugin (ours)**: defense-in-depth safety hooks, deterministic offload backed by real test suites, strong disclosure architecture, exemplary safety gating; its noted weakness is documentation drift (a README section contradicting a script). **hookify (official)** is a well-designed meta-plugin (its rule engine is solid, fail-open by design) but thinner on progressive disclosure, ships no tests, and carries several small consistency defects.
+
+### pr-commit-workflow
+
+**Outcome: 6-0-0 → ours.** Official staged as side-B. Official sources: plugins/pr-review-toolkit, plugins/commit-commands. Ours: git-plugin/skills/git-commit, git-plugin/skills/git-commit-workflow, git-plugin/skills/git-commit-trailers, git-plugin/skills/git-commit-push-pr, git-plugin/skills/git-pr, git-plugin/skills/git-pr-feedback, git-plugin/skills/git-pr-sync-check, git-plugin/skills/git-pr-watch, git-plugin/skills/git-push, git-plugin/skills/git-fix-pr, git-plugin/skills/git-api-pr, git-plugin/skills/git-branch-pr-workflow, git-plugin/skills/github-pr-title, git-plugin/.claude-plugin/plugin.json, git-plugin/README.md, git-plugin/hooks.
+
+**git-plugin's commit/PR suite (ours)** sweeps 6-0: strong triggering with sibling disambiguation (*“Use when user says ‘commit’… see git-push for remote”*), reasoned instructions, tested deterministic scripts, safety-conscious hooks. **pr-review-toolkit + commit-commands (official)** pairs excellent review-agent prompt craft with very thin commit commands and real distribution-hygiene problems — including an **ungated `git worktree remove --force`** in `clean_gone.md` (B5 evidence). The B1 and B4 margins (5v3) were adversarially re-checked and **upheld**.
+
+### session-reporting
+
+**Outcome: 5-0-1 → ours.** Official staged as side-B. Official sources: plugins/session-report. Ours: session-plugin.
+
+**session-plugin (ours)** wins 5-0-1: exemplary triggering and disambiguation across four skills, a shared deterministic collector with tests, gated writes. **session-report (official)** is a well-engineered single skill whose analyzer script is genuinely excellent (*token-accounting dedupe by requestId* — B4 tied at 5v5), but its frontmatter states no trigger conditions and it ships no manifest-level docs or tests.
+
+### skill-authoring
+
+**Outcome: 6-0-0 → ours.** Official staged as side-B. Official sources: plugins/skill-creator, plugins/plugin-dev. Ours: .claude/rules/skill-development.md, .claude/rules/skill-quality.md, .claude/rules/skill-naming.md, .claude/rules/skill-argument-handling.md, .claude/rules/skill-execution-structure.md, evaluate-plugin, project-plugin/skills/project-skill-scripts.
+
+**Ours (evaluate-plugin + skill rules + project-skill-scripts)** wins 6-0 on artifact hygiene: leaner bodies, tighter tool scoping, gated destructive actions, machine-parseable script contracts with tests. **skill-creator + plugin-dev (official)** carries exceptional explain-the-why instruction craft and a genuinely systematic eval loop — but the staged artifacts are dragged down by bloated skill bodies, an unscoped Bash grant, and internal contradictions in hook-development/skill-development (B6 4v2, refuter-**upheld**).
+
+
+## 5. Tier C — descriptive asymmetries (unscored)
+
+These asymmetries are **deliberately unscored** — they describe different jobs, not different quality.
+
+- **Distribution models.** Ours: 44 in-repo first-party plugins, release-driven. Theirs: a 255-entry curated directory — 51 in-repo (36 first-party plugins + example-plugin + 15 vendored MCP wrappers) + 204 SHA-pinned external refs across 179 vendor repos, freshness governed by nightly automation rather than releases.
+- **Archetypes they have that we don't:** 12 LSP-config plugins (inline `lspServers` manifests), 15 vendored MCP-wrapper plugins (some shipping a TS server + bun.lock), and a whole external-vendor intake pipeline (form-based submissions, AI policy scan, scope guards).
+- **Archetypes we have that they don't:** deep domain skill suites (configure 51, git 38, blueprint 33, obsidian 21 skills), 75 hook files vs their 17, per-plugin release/changelog machinery, and a self-hosted eval stack (evaluate-plugin) used in CI.
+- **Category shape:** theirs skews development/productivity/database (a general-audience directory); ours skews development/infrastructure/ai/quality (a practitioner's toolchain).
+
+
+| | ours | official |
+|---|---|---|
+| Marketplace entries | 44 | 255 |
+| Source types | 44 in-repo | {"git-subdir": 71, "github": 2, "in-repo": 51, "url": 131} |
+| Unique external vendor repos | 0 | 179 |
+| LSP-config plugins | 0 | 12 |
+| Vendored MCP wrappers (external_plugins/) | 0 | 15 |
+| Top categories | ai 4, automation 3, ci-cd 2, communication 2, development 10, documentation 2 | (none) 14, automation 1, database 34, deployment 8, design 6, development 109 |
+
+## 6. Bias & limitations audit
+
+| Bias measurement | Value |
+|---|---|
+| Judgments with identity leakage | 18/18 (rate 1.0) |
+| Mean margin ours−official, leaked judgments | +0.37 |
+| Mean margin ours−official, clean judgments | n/a — no clean judgments exist |
+| Mean score given to side-A / side-B (identity-blind) | 4.287 / 3.472 |
+| Mean margin ours−official when ours staged as A / as B | +1.333 / -0.4 |
+| Evidence quotes mechanically verified | 231 checked, 230 exact + 1 normalized, 0 failed |
+| Findings dropped for fabricated evidence | 0 |
+
+
+This benchmark was designed by the maintainer of one of the two repos being compared. The controls below are what keep it honest; read them before quoting any single number.
+
+1. **Blinding failed to conceal identity — leakage rate 1.0 (18/18 judgments).** Both sides ship self-identifying metadata (`"author": "Anthropic"` / `"repository": ...laurigates...`), and judges honestly reported recognizing both sides in every pair. Per the pre-registered design, content was not redacted (redaction mutates the evidence being judged). Consequently the planned leaked-vs-clean score comparison is void — there are no clean judgments. Debiasing therefore rests entirely on: anchors frozen from neutral published sources before any judging; the independent-then-compare protocol; the mechanical quote gate (231/231 verified, 0 fabricated); and adversarial refuters prompted to overturn (which did trim two pro-ours margins and uphold two pro-official wins).
+2. **Position and composition are confounded.** Side-A won 7 of 8 decided pairs; the identity-blind mean score was 4.29 for side-A vs 3.47 for side-B; ours' margin was +1.33 when staged as A vs −0.40 as B. With n=9 pairs assigned deterministically (balanced 5/4 but not counterbalanced), a first-position halo cannot be separated from genuinely stronger artifacts happening to sit at A. Both sides won and lost from side-A; the only side-B pair win was ours (code-review). Treat close pairs (claude-md, mcp-dev, autonomous-loop, code-review) as directional; a replication with swapped sides would resolve this.
+3. **Pair scoping is judgment-laden.** Ours staged curated subsets for two pairs (13 of git-plugin's 38 skills; 5 rules + evaluate-plugin for skill-authoring); official plugins were staged whole. Subsetting could cut either way (drops weak siblings; loses ecosystem context).
+4. **House-convention metrics were excluded from scoring** and appear only in the supplementary table; scored anchors trace to published Anthropic guidance and the official repo's own skill-creator references (see rubric provenance). The rubric's exclusion list names 12 house criteria that were kept out.
+5. **Judges and refuters are the same model family as both repos' tooling** (Claude), with training exposure to both projects plausible; the identity-leakage field exists precisely because this cannot be ruled out.
+6. **Tier C is descriptive, not scored** — catalog breadth (their 255-entry directory, LSP/MCP archetypes) vs domain-skill depth (our 384 skills) is apples-vs-oranges, and scoring it would launder coverage into quality.
+
+## 7. Takeaways for laurigates/claude-plugins
+
+Ranked by evidence strength × expected value for laurigates/claude-plugins.
+
+**Adopt**
+1. **Fix the A5 accuracy defects** — `docs/PLUGIN-MAP.md` header (“42 plugins and 300+ skills” → 44/384), README “43 Claude Code plugins”, and add a top-level `description` to marketplace.json. Found independently by exploration, both Tier-A judges, and the refuter; it is the difference between A5 tie and A5 win, and `docs-refresh` exists precisely for this.
+2. **Rebuild configure-security along security-guidance's shape** (pair lost 0-5-1, the run's clearest signal): fix its broken dynamic-context commands, split the bloated always-loaded body into references, dedupe in-file repetition; consider a deterministic hook-based scan entry point with a documented trust model.
+3. **Give project-test-loop a deterministic loop driver** (B4 2v5, refuter-upheld): a stop-hook/driver script in the ralph-loop mold — bounded parsing, capped iterations — instead of prose the model re-derives; wire the declared-but-unused arguments or remove them.
+4. **Adopt rubric-style instruction depth in code-review** (B2 3v5, refuter-upheld): embed a verbatim scoring rubric, confidence thresholds, and a false-positive re-verification pass in code-quality:code-review — their command shows the shape; ours has the better triggering to carry it.
+5. **Deepen mcp-server-authoring's build path** (pair 2-3-1): procedure-first steps with explain-the-why reasoning, de-duplicate body/reference overlap, and un-bind portfolio-specific assumptions.
+
+**Consider**
+6. **Complete per-plugin metadata**: license missing in 20/44 plugin.json, author/license absent from marketplace entries — the only thing between us and A1 anchor-5.
+7. **License-validation CI** (their `validate-licenses.yml`): cheap gate; ours currently checks none of its own components.
+8. **Split the specific bloated bodies the judges flagged** (configure-security's always-loaded body; blueprint-claude-md's all-inline skill): Channel M shows body bloat is localized on our side (4 of 384 skills over ~5k tokens, max ~6k, vs 3 of 29 and max ~8k theirs) — targeted splits beat a new lint. Also worth a look: 175 of our skills grant bare `Bash` in allowed-tools where a scoped grant would do.
+
+**Skip (for now)**
+9. **SHA-pin + bump/revert automation** — no external refs in our model; the A4 anchor explicitly does not penalize absent risk. Revisit only if we ever reference external sources.
+10. **AI policy-scan intake pipeline & PR scope guards** — built for third-party submissions we don't accept.
+11. **Command-file architecture** — their command-heavy plugins repeatedly lost B1 (near-empty trigger descriptions); our skills-only migration is vindicated by the data.
+
+## 8. Appendices
+
+
+### Channel M — mechanical metrics
+
+| Metric (Channel M, deterministic) | ours | official |
+|---|---|---|
+| Marketplace entries | 44 | 255 |
+| In-repo skills (SKILL.md) | 384 | 29 |
+| Commands / agents / hook scripts | 0 / 21 / 69 | 29 / 26 / 17 |
+| Frontmatter description rate | 1.0 | 1.0 |
+| Description trigger-clause rate (generic regex) | 1.0 | 0.862 |
+| SKILL.md tokens, median / p90 | 1766.5 / 2800 | 2103 / 5633 |
+| Skills over ~5k tokens | 4 | 3 |
+| Skills with scripts / with extra reference md | 40 / 125 | 5 / 16 |
+| allowed-tools: scoped-bash / no-bash / bare-bash / absent | 165 / 44 / 175 / 0 | 1 / 6 / 0 / 22 |
+| Unresolved relative md links (incl. illustrative) | 78/546 | 7/21 |
+| Per-plugin CHANGELOGs | 44 | 0 |
+| CI workflows (PR-triggered) | 21 (10) | 9 (8) |
+| check-*/lint-* scripts | 30 / 5 | 0 / 0 |
+| plugin.json field presence: version/author/license | 44/25/24 of 44 | 12/35/1 of 39 |
+| Marketplace version mismatches (entry vs plugin.json) | 0 | 0 |
+
+### House-convention supplementary (excluded from scores)
+
+| House-convention metric (NOT scored) | ours | official |
+|---|---|---|
+| Literal “Use when” in description | 1.0 | 0.414 |
+| created/modified date frontmatter | 1.0 | 0.0 |
+| argument-hint present | 0.456 | 0.034 |
+
+### Artifacts
+All run artifacts live in the session scratchpad `bench/`: `rubric.md` (frozen anchors + exclusion list), `judgments/*.json` (20 schema-validated judgments), `quote_check.json`, `refutations.json`, `synthesis.json`, `metrics.json`, `tier_c.json`, `blinding` manifest (withheld during judging), staging trees, and the scripts (`stage_pairs.py`, `compute_metrics.py`, `quote_check.py`, `synthesize.py`, `build_report.py`).

--- a/docs/benchmarks/2026-07-marketplace-quality/metrics.json
+++ b/docs/benchmarks/2026-07-marketplace-quality/metrics.json
@@ -1,0 +1,261 @@
+{
+  "official": {
+    "agents": {
+      "models": {
+        "(unset)": 10,
+        "inherit": 7,
+        "opus": 3,
+        "sonnet": 6
+      }
+    },
+    "house_convention_supplementary": {
+      "_note": "House conventions of laurigates/claude-plugins; NOT scored, context only.",
+      "argument_hint_rate": 0.034,
+      "created_modified_dates_rate": 0.0,
+      "sh_scripts_with_section_headers": 0,
+      "use_when_literal_rate": 0.414
+    },
+    "links": {
+      "_note": "Unresolved relative md links after placeholder filtering; residual may include illustrative example paths, not only genuine breakage.",
+      "broken": 7,
+      "broken_rate": 0.3333,
+      "broken_sample": [
+        "plugins/claude-code-setup/skills/claude-automation-recommender/references/skills-reference.md -> openapi-template.yaml",
+        "plugins/claude-code-setup/skills/claude-automation-recommender/references/skills-reference.md -> examples/unit-test.ts",
+        "plugins/claude-code-setup/skills/claude-automation-recommender/references/skills-reference.md -> examples/integration-test.ts",
+        "plugins/claude-code-setup/skills/claude-automation-recommender/references/skills-reference.md -> templates/",
+        "plugins/claude-code-setup/skills/claude-automation-recommender/references/skills-reference.md -> checklist.md",
+        "plugins/plugin-dev/skills/command-development/references/documentation-patterns.md -> CONTRIBUTING.md",
+        "plugins/plugin-dev/skills/command-development/references/documentation-patterns.md -> LICENSE"
+      ],
+      "relative_links_checked": 21
+    },
+    "manifest": {
+      "entries": 255,
+      "entry_field_presence": {
+        "author": 170,
+        "category": 241,
+        "description": 255,
+        "keywords": 1,
+        "license": 0,
+        "version": 14
+      },
+      "in_repo_entries": 51,
+      "in_repo_missing_dir": [],
+      "plugin_dirs_not_in_manifest": [
+        "plugins/example-plugin"
+      ],
+      "plugin_dirs_on_disk": 39,
+      "source_types": {
+        "git-subdir": 71,
+        "github": 2,
+        "in-repo-path": 51,
+        "url": 131
+      }
+    },
+    "plugin_json": {
+      "count": 39,
+      "field_presence": {
+        "author": 35,
+        "description": 39,
+        "keywords": 6,
+        "license": 1,
+        "name": 39,
+        "repository": 1,
+        "version": 12
+      },
+      "version_mismatches": []
+    },
+    "root": "/private/tmp/claude-502/-Users-lgates-repos-laurigates-claude-plugins/22f8c419-8c63-4f08-a9e5-70dc268bb07c/scratchpad/bench/official",
+    "skills_scored": {
+      "allowed_tools_classes": {
+        "no-bash": 6,
+        "scoped-bash": 1,
+        "unrestricted(absent)": 22
+      },
+      "desc_len_dist": {
+        "count": 29,
+        "max": 906,
+        "mean": 347.2,
+        "median": 329,
+        "p90": 525
+      },
+      "frontmatter_description_rate": 1.0,
+      "frontmatter_name_rate": 1.0,
+      "skills_over_5k_tokens": 3,
+      "skills_with_reference_mds": 16,
+      "skills_with_scripts": 5,
+      "token_estimate_dist": {
+        "count": 29,
+        "max": 8246,
+        "mean": 2701.1,
+        "median": 2103,
+        "p90": 5633
+      },
+      "trigger_clause_rate": 0.862
+    },
+    "totals": {
+      "agents": 26,
+      "changelogs": 0,
+      "check_scripts": 0,
+      "commands": 29,
+      "files": 407,
+      "hook_scripts": 17,
+      "hooks_json": 5,
+      "lint_scripts": 0,
+      "md_files": 205,
+      "skills": 29,
+      "workflow_names": [
+        "bump-plugin-shas.yml",
+        "check-mcp-urls.yml",
+        "close-external-prs.yml",
+        "external-pr-scope-guard.yml",
+        "revert-failed-bumps.yml",
+        "scan-plugins.yml",
+        "validate-frontmatter.yml",
+        "validate-licenses.yml",
+        "validate-plugins.yml"
+      ],
+      "workflows": 9,
+      "workflows_pr_triggered": 8
+    }
+  },
+  "ours": {
+    "agents": {
+      "models": {
+        "opus": 21
+      }
+    },
+    "house_convention_supplementary": {
+      "_note": "House conventions of laurigates/claude-plugins; NOT scored, context only.",
+      "argument_hint_rate": 0.456,
+      "created_modified_dates_rate": 1.0,
+      "sh_scripts_with_section_headers": 129,
+      "use_when_literal_rate": 1.0
+    },
+    "links": {
+      "_note": "Unresolved relative md links after placeholder filtering; residual may include illustrative example paths, not only genuine breakage.",
+      "broken": 78,
+      "broken_rate": 0.1429,
+      "broken_sample": [
+        "agent-patterns-plugin/README.md -> docs/adrs/0015-agent-teams-adoption.md",
+        "blueprint-plugin/skills/blueprint-adr-list/SKILL.md -> docs/adrs/0001-use-react.md",
+        "blueprint-plugin/skills/blueprint-adr-list/SKILL.md -> docs/adrs/0002-use-postgres.md",
+        "blueprint-plugin/skills/blueprint-adr-list/SKILL.md -> docs/adrs/0003-migrate-to-vite.md",
+        "blueprint-plugin/skills/blueprint-curate-docs/REFERENCE.md -> src/path/file.ts",
+        "blueprint-plugin/skills/blueprint-development/templates/implementation-skill-template.md -> '[endpoint]'",
+        "blueprint-plugin/skills/blueprint-development/templates/implementation-skill-template.md -> [input]",
+        "blueprint-plugin/skills/blueprint-development/templates/implementation-skill-template.md -> [params]",
+        "blueprint-plugin/skills/blueprint-development/templates/quality-skill-template.md -> [scope]",
+        "blueprint-plugin/templates/blueprint-readme.md -> ../adrs/0005-blueprint-development-methodology.md",
+        "blueprint-plugin/templates/blueprint-readme.md -> ../adrs/0011-blueprint-state-in-docs-directory.md",
+        "blueprint-plugin/templates/document-management-rule.md -> ../adrs/0001-database-choice.md",
+        "blueprint-plugin/templates/document-management-rule.md -> ../prds/user-authentication.md",
+        "blueprint-plugin/templates/document-management-rule.md -> ../prds/user-authentication.md",
+        "blueprint-plugin/templates/document-management-rule.md -> ../prds/payment-processing.md",
+        "communication-plugin/skills/google-chat-formatting/REFERENCE.md -> url",
+        "communication-plugin/skills/ticket-drafting-guidelines/SKILL.md -> URL",
+        "configure-plugin/skills/configure-memory-profiling/SKILL.md -> REFERENCE.md",
+        "configure-plugin/skills/configure-memory-profiling/SKILL.md -> REFERENCE.md",
+        "configure-plugin/skills/configure-memory-profiling/SKILL.md -> REFERENCE.md"
+      ],
+      "relative_links_checked": 546
+    },
+    "manifest": {
+      "entries": 44,
+      "entry_field_presence": {
+        "author": 0,
+        "category": 44,
+        "description": 44,
+        "keywords": 44,
+        "license": 0,
+        "version": 44
+      },
+      "in_repo_entries": 44,
+      "in_repo_missing_dir": [],
+      "plugin_dirs_not_in_manifest": [],
+      "plugin_dirs_on_disk": 44,
+      "source_types": {
+        "in-repo-path": 44
+      }
+    },
+    "plugin_json": {
+      "count": 44,
+      "field_presence": {
+        "author": 25,
+        "description": 44,
+        "keywords": 44,
+        "license": 24,
+        "name": 44,
+        "repository": 23,
+        "version": 44
+      },
+      "version_mismatches": []
+    },
+    "root": "/Users/lgates/repos/laurigates/claude-plugins",
+    "skills_scored": {
+      "allowed_tools_classes": {
+        "bare-bash": 175,
+        "no-bash": 44,
+        "scoped-bash": 165
+      },
+      "desc_len_dist": {
+        "count": 384,
+        "max": 275,
+        "mean": 166.6,
+        "median": 163.0,
+        "p90": 186
+      },
+      "frontmatter_description_rate": 1.0,
+      "frontmatter_name_rate": 1.0,
+      "skills_over_5k_tokens": 4,
+      "skills_with_reference_mds": 125,
+      "skills_with_scripts": 40,
+      "token_estimate_dist": {
+        "count": 384,
+        "max": 6080,
+        "mean": 1874.8,
+        "median": 1766.5,
+        "p90": 2800
+      },
+      "trigger_clause_rate": 1.0
+    },
+    "totals": {
+      "agents": 21,
+      "changelogs": 44,
+      "check_scripts": 30,
+      "commands": 0,
+      "files": 8722,
+      "hook_scripts": 69,
+      "hooks_json": 6,
+      "lint_scripts": 5,
+      "md_files": 809,
+      "skills": 384,
+      "workflow_names": [
+        "auto-resolve-conflicts.yml",
+        "changelog-review.yml",
+        "claude-code-review.yml",
+        "claude.yml",
+        "clear-autorelease-labels.yml",
+        "enforce-conventional-commits.yml",
+        "fix-release-conflicts.yml",
+        "github-workflow-auto-fix.yml",
+        "lint-context-commands.yml",
+        "obsidian-cli-changelog.yml",
+        "plugin-enablement-drift.yml",
+        "plugin-pr-checks.yml",
+        "release-please.yml",
+        "release-pr-doc-audit.yml",
+        "renovate.yml",
+        "research-radar.yml",
+        "scheduled-audits.yml",
+        "skill-splitter.yml",
+        "test-skill-scripts.yml",
+        "validate-plugin-configs.yml",
+        "workflow-model-audit.yml"
+      ],
+      "workflows": 21,
+      "workflows_pr_triggered": 10
+    }
+  }
+}

--- a/docs/benchmarks/2026-07-marketplace-quality/refutations.json
+++ b/docs/benchmarks/2026-07-marketplace-quality/refutations.json
@@ -1,0 +1,132 @@
+[
+  {
+    "corrected": [
+      3,
+      3,
+      "tie"
+    ],
+    "dim": "A5",
+    "pair": "tier-a",
+    "reason": "inter-judge disagreement (gap 1, opposite verdicts)",
+    "reasoning": "Verified facts. OURS (A): marketplace.json has NO top-level description (the documented warning class named in the A5 anchor text) but has $schema and description+keywords+category on all 44 entries; all 44 plugins have READMEs; README.md line 5 says '43 Claude Code plugins' while line 15 says 'registers all 44 plugins' (44 on disk \u2014 self-contradiction on one page); docs/PLUGIN-MAP.md header says ",
+    "symmetric_violation": true,
+    "verdict": "adjusted"
+  },
+  {
+    "corrected": [
+      2,
+      4,
+      "B"
+    ],
+    "dim": "B1",
+    "pair": "code-review",
+    "reason": "load-bearing decisive margin (3.0 pts, both judges agree)",
+    "reasoning": "Evidence quotes verified on both sides. A=2 upheld: the sole command's description (\"Code review a pull request\") concretely states what it does (above anchor-1 vague/absent) but gives no trigger conditions or user contexts and is imperative, not third-person \u2014 squarely between anchors 1 and 3; the README's when-to-use sections are not the frontmatter/description triggering surface B1 scores. B=5 ",
+    "symmetric_violation": true,
+    "verdict": "adjusted"
+  },
+  {
+    "corrected": [
+      5,
+      2,
+      "A"
+    ],
+    "dim": "B1",
+    "pair": "session-reporting",
+    "reason": "load-bearing decisive margin (3.0 pts, both judges agree)",
+    "reasoning": "All cited quotes verified against the files. Side A's four skill descriptions are third-person, front-loaded, carry concrete user phrasings (\"spin up\", \"what was I doing\", \"wrap up\", \"done for now\", \"winding down a session\"), and each skill explicitly disambiguates from its siblings and near-miss cross-plugin skills \u2014 meeting every anchor-5 element (phrasings, near-miss coverage, front-loading, si",
+    "symmetric_violation": false,
+    "verdict": "upheld"
+  },
+  {
+    "corrected": [
+      5,
+      2,
+      "A"
+    ],
+    "dim": "B4",
+    "pair": "autonomous-loop",
+    "reason": "load-bearing decisive margin (2.5 pts, both judges agree)",
+    "reasoning": "Both judges' evidence quotes verified verbatim in side-A/plugins/ralph-loop/hooks/stop-hook.sh (lines 37, 96) and side-B SKILL.md (line 28). Side A delegates every mechanical step (arg parsing, state-file lifecycle, iteration counting, bounded transcript parsing, promise matching) to two bundled scripts that are robust under attack: numeric validation before arithmetic, jq-failure branch, session ",
+    "symmetric_violation": false,
+    "verdict": "upheld"
+  },
+  {
+    "corrected": [
+      4,
+      2,
+      "A"
+    ],
+    "dim": "B6",
+    "pair": "skill-authoring",
+    "reason": "load-bearing decisive margin (2.5 pts, both judges agree)",
+    "reasoning": "Every cited defect verified by direct reading and execution. Side B: (1) hook-development/SKILL.md flatly contradicts itself on plugin hooks.json format (wrapper mandated L64-119, direct format shown L340-381); (2) its bundled validate-hook-schema.sh crashes (jq error, exit 5) on the wrapper format the same doc mandates and instructs users to validate with; (3) plugin-validator.md ends with a stra",
+    "symmetric_violation": false,
+    "verdict": "upheld"
+  },
+  {
+    "corrected": [
+      3,
+      5,
+      "B"
+    ],
+    "dim": "B1",
+    "pair": "autonomous-loop",
+    "reason": "load-bearing decisive margin (2.0 pts, both judges agree)",
+    "reasoning": "Both cited quotes exist verbatim in side-B's SKILL.md. B meets every anchor-5 element: front-loaded key use case surviving truncation, third-person description with three realistic trigger phrasings, and explicit in-artifact disambiguation from three named siblings (project-continue/project-distill/project-discovery). Side A's command descriptions (\"Start Ralph Loop in current session\", \"Cancel ac",
+    "symmetric_violation": false,
+    "verdict": "upheld"
+  },
+  {
+    "corrected": [
+      5,
+      3,
+      "A"
+    ],
+    "dim": "B2",
+    "pair": "code-review",
+    "reason": "load-bearing decisive margin (2.0 pts, both judges agree)",
+    "reasoning": "All cited quotes verified verbatim in side-A/plugins/code-review/commands/code-review.md. Side A meets every anchor-5 element: 8 ordered steps with per-agent tasks, a verbatim 0-100 confidence rubric, an 8-item false-positive taxonomy, two exact output templates with a worked link example, and stated reasoning (why bash substitution in links fails, why not to run builds, why CLAUDE.md may not appl",
+    "symmetric_violation": false,
+    "verdict": "upheld"
+  },
+  {
+    "corrected": [
+      5,
+      3,
+      "A"
+    ],
+    "dim": "B3",
+    "pair": "hooks",
+    "reason": "load-bearing decisive margin (2.0 pts, both judges agree)",
+    "reasoning": "Cited evidence verified: the REFERENCE.md deferral quote exists at side-A hooks-configuration/SKILL.md:133, and the pattern is systemic \u2014 3 of 4 side-A skills pair a lean body (276/193/179 lines) with a per-skill REFERENCE.md (370/258/117 lines) holding schemas, script templates, and extra patterns, plus executable hook scripts that run without being read and disable-model-invocation path splittin",
+    "symmetric_violation": false,
+    "verdict": "upheld"
+  },
+  {
+    "corrected": [
+      5,
+      3,
+      "A"
+    ],
+    "dim": "B1",
+    "pair": "pr-commit-workflow",
+    "reason": "load-bearing decisive margin (2.0 pts, both judges agree)",
+    "reasoning": "All cited quotes verified verbatim. Side A's 12 skill descriptions uniformly state what + concrete third-person trigger phrasings (\"commit\"/\"save changes\"; \"push\"/\"send to remote\"), front-load the key use case, and explicitly cross-disambiguate the collision-prone commit/push/PR cluster (git-commit \u2192 \"see git-push for remote\"; git-push \u2192 \"see git-commit... and git-pr\") \u2014 the literal anchor-5 featu",
+    "symmetric_violation": false,
+    "verdict": "upheld"
+  },
+  {
+    "corrected": [
+      5,
+      3,
+      "A"
+    ],
+    "dim": "B4",
+    "pair": "pr-commit-workflow",
+    "reason": "load-bearing decisive margin (2.0 pts, both judges agree)",
+    "reasoning": "Both judges' evidence checks out verbatim. Side A's git-pr.sh (line 3: \"DATA-ONLY: detects PR readiness (fetch + ahead-count + existing-PR probe)\") and list-actionable-prs.sh (line 19: \"Testing: set PR_FEEDBACK_FIXTURE=<path> to read a captured GraphQL response\") exist as quoted. Attacking the A=5: the scripts genuinely meet anchor 5 \u2014 they are robust (git-pr.sh guards missing jq and not-a-repo wi",
+    "symmetric_violation": false,
+    "verdict": "upheld"
+  }
+]

--- a/docs/benchmarks/2026-07-marketplace-quality/rubric.md
+++ b/docs/benchmarks/2026-07-marketplace-quality/rubric.md
@@ -1,0 +1,407 @@
+# Frozen Scoring Rubric — Claude Code Plugin Marketplace Quality Benchmark
+
+**Status: FROZEN.** Every scored anchor traces to a published, non-house source
+(see `## Source list`). House-only conventions are quarantined in
+`## House-only criteria excluded from scoring` and MUST NOT influence any score.
+
+## How to score
+
+- Each dimension is scored **1–5**. Anchors are defined for **1, 3, 5**; **2 and 4
+  are interpolations** (2 = between the 1 and 3 anchors; 4 = between 3 and 5).
+- **Anchor 3 = competent, typical published-guidance-compliant work.**
+  **Anchor 5 = exceptional, evidence-heavy.** **Anchor 1 = clearly deficient.**
+- **Symmetry:** the same defect scores the same regardless of which side exhibits
+  it. Anchors do not presuppose either side's architecture. Where a dimension
+  depends on what risks/needs an artifact actually has (B4 scripts, A2 CI surface,
+  A4 supply chain), judge **relative to the risks that artifact actually has** — an
+  artifact with no exposure to a risk is not penalized for lacking a control for it.
+- **Tier B** (skill/plugin-authoring) is judged **blind, per pair** on artifact
+  content alone. **Tier A** (marketplace/infrastructure) is judged **open-book, per
+  repo**.
+
+---
+
+## Tier B — Plugin-authoring quality (judged blind, per pair)
+
+### B1 — Trigger & discoverability
+
+Whether an artifact's frontmatter/description lets Claude (and the user) know
+*when* to invoke it: a description that states what the thing does **and** the
+concrete conditions under which to use it, written in the third person, with a
+name distinct enough not to overlap sibling artifacts. Descriptions are the
+primary triggering mechanism and are truncated from the end in the skill listing,
+so the key use case belongs first.
+
+- **1 — Deficient.** Description is tool-centric or vague ("Provides guidance for
+  X", "Do the thing"), states no trigger conditions, is written in the second
+  person, or is absent; or the name collides/overlaps with a sibling so Claude
+  cannot tell which to load.
+  Sources: skills (description "what the skill does and when to use it… Claude
+  uses this to decide"); best-practices (name/description drive triggering);
+  skill-development (bad-description examples).
+- **3 — Competent.** Description states what the artifact does **and** concrete
+  conditions or user contexts for invoking it, in the third person; the name is
+  distinct and non-overlapping.
+  Sources: best-practices; skill-development (third-person + specific trigger
+  phrases); skills (frontmatter `description`).
+- **5 — Exceptional.** As 3, plus trigger conditions cover realistic phrasings and
+  near-miss contexts, the key use case is front-loaded so it survives description
+  truncation, and the artifact is explicitly disambiguated from sibling artifacts
+  that could otherwise both match.
+  Sources: skills ("Put the key use case first"; 1,536-char end-truncation);
+  skill-creator (should-trigger / should-not-trigger coverage, near-misses).
+
+### B2 — Instruction quality
+
+Whether a zero-context agent could execute the instructions correctly: concrete
+ordered steps, correct and runnable commands, unambiguous phrasing, output format
+stated where it matters, and degrees of freedom constrained appropriately (neither
+under-specified nor smothered in rigid MUST/NEVER directives). The skill is written
+for another Claude instance, so it should carry the non-obvious procedural detail.
+
+- **1 — Deficient.** Instructions are vague ("process the document appropriately"),
+  skip required steps, or give commands that are wrong or won't run; a fresh agent
+  would have to guess to proceed.
+  Sources: skill-creator (vague instruction → inconsistent behavior in
+  analysis.json example); skill-development (imperative, concrete steps).
+- **3 — Competent.** Concrete, ordered, imperative-form steps; commands are correct
+  and runnable; output format is specified where relevant; a zero-context agent
+  could follow them to a correct result.
+  Sources: skill-creator (imperative form, define output formats, examples
+  pattern); skill-development (Step 4, imperative/infinitive).
+- **5 — Exceptional.** As 3, plus the reasoning ("the why") is given so the agent
+  generalizes beyond the literal steps, freedom is constrained just enough (not
+  over-rigid, not under-specified), and input→output examples remove ambiguity.
+  Sources: skill-creator ("Explain the why"; theory-of-mind; ALWAYS/NEVER is a
+  "yellow flag"); skill-development.
+
+### B3 — Context economy / progressive disclosure
+
+Whether the always-loaded surface (SKILL.md body) is lean and detail is pushed to
+supporting files/scripts loaded only on demand, rather than bloat that taxes the
+context window on every load. Every line of the body is a recurring token cost.
+
+- **1 — Deficient.** The body is bloated — large reference material, exhaustive
+  options, or rarely-used detail inlined so it is always loaded when the artifact
+  triggers.
+  Sources: skill-development (Mistake 2, single 8,000-word file); skills ("Keep the
+  body concise… every line is a recurring token cost").
+- **3 — Competent.** The body is reasonably lean and focused on the core procedure;
+  longer or infrequently-needed detail lives in supporting files that the body
+  references by name.
+  Sources: skills ("Keep SKILL.md under 500 lines. Move detailed reference material
+  to separate files"); best-practices (progressive disclosure); skill-development.
+- **5 — Exceptional.** Clear multi-level progressive disclosure — concise body,
+  on-demand reference files, and executable scripts that run without being read
+  into context — with mutually-exclusive or rarely-combined paths split so unused
+  detail costs nothing.
+  Sources: best-practices (three-level disclosure; conditional bundling to reduce
+  token usage); skill-development; skill-creator (add a hierarchy layer near the
+  limit).
+
+### B4 — Determinism offload
+
+Whether mechanical, repeatable, or deterministic work (parsing, counting, fixed
+transforms, validation) is delegated to bundled scripts or dedicated tools rather
+than left as prose the model re-derives each run — and whether those scripts are
+robust. Judge relative to whether such work actually exists: a pure-reference
+artifact with no mechanical work is not penalized for having no scripts.
+
+- **1 — Deficient.** Clearly mechanical/repeatable work is left as prose the model
+  re-derives every invocation, with no script or tool where one would plainly help.
+  Sources: best-practices ("sorting a list via token generation is far more
+  expensive than running a sorting algorithm"); skill-creator (bundle a repeatedly
+  rewritten script).
+- **3 — Competent.** Deterministic/repetitive operations are delegated to bundled
+  scripts or dedicated tools, and the artifact points to them clearly.
+  Sources: skill-development (scripts/ for deterministic reliability / repeatedly
+  rewritten code); best-practices (code as executable tools).
+- **5 — Exceptional.** As 3, plus scripts are robust (handle their inputs/errors,
+  are documented, run standalone) and the artifact makes explicit whether Claude
+  should *run* a script or *read* it as reference.
+  Sources: best-practices ("clear whether Claude should run scripts directly or
+  read them into context"); skill-development (scripts executable and documented).
+
+### B5 — Safety & permissions
+
+Whether tool allowances are least-privilege, shell is injection-safe, defaults are
+non-destructive, destructive actions are gated, and the artifact's effect matches
+its stated intent. `allowed-tools` grants standing permission, so a skill can grant
+itself broad access; the hard enforcement of allow/deny belongs to the permission
+system, and shell that interpolates untrusted input must be injection-safe.
+
+- **1 — Deficient.** Over-broad or unnecessary tool access (e.g. blanket
+  `Bash(*)` where narrow rules would do); shell built from unquoted/unsanitized
+  interpolation (injection-prone); destructive or irreversible actions run without
+  any gate; or content whose effect exceeds or contradicts its stated intent.
+  Sources: skills ("a skill can grant itself broad tool access"); hooks
+  (shell-form requires careful quoting; injection risk); skill-creator (Principle
+  of Lack of Surprise — no malware/exfiltration; intent must match).
+- **3 — Competent.** Tool allowances are scoped to what the artifact needs; shell
+  is injection-safe (exec-form or quoted paths; safe `jq` parsing of inputs); no
+  dangerous defaults; behavior matches stated intent.
+  Sources: skills (`allowed-tools` scoping; deny rules); hooks (exec form vs shell
+  form; `jq` safe extraction); skill-creator.
+- **5 — Exceptional.** As 3, plus destructive/irreversible actions are explicitly
+  gated (confirmation, manual-only invocation, or a hard permission/hook backstop),
+  and least-privilege is applied consistently across every bundled component.
+  Sources: hooks (PreToolUse deny / permission system for hard enforcement; exit 2
+  to block); skills (deny rules; `disable-model-invocation` for side-effecting
+  workflows).
+
+### B6 — Robustness & maintainability
+
+Whether references resolve, content is internally consistent (no contradictions or
+duplication across files, no stale material), and the workflow has error/verification
+paths where it needs them. Information should live in one place, not two.
+
+- **1 — Deficient.** Broken or missing references, contradictory or duplicated
+  content across files, visibly stale material, TODO/debug leftovers, or no
+  error/verification path where the workflow plainly needs one.
+  Sources: skill-development (referenced files must exist; "information should live
+  in either SKILL.md or references, not both"); marketplace-considerations (no
+  TODO/debug code; comprehensive error handling).
+- **3 — Competent.** References resolve and are consistent; content is internally
+  coherent with no obvious staleness; the workflow includes basic error handling or
+  a verification step.
+  Sources: skill-development (validation checklist; no duplication);
+  marketplace-considerations (anticipate mistakes; helpful diagnostics).
+- **5 — Exceptional.** As 3, plus explicit failure paths and a verification/
+  self-check step, single-source-of-truth content, and evidence the artifact is
+  maintained as a coherent whole (graceful degradation, idempotency where relevant).
+  Sources: skill-development (no duplicated information; validate); best-practices
+  (iterate; capture successful approaches and common mistakes);
+  marketplace-considerations (graceful degradation, idempotency, diagnostics).
+
+---
+
+## Tier A — Marketplace/infrastructure quality (judged open-book, per repo)
+
+### A1 — Manifest schema & integrity
+
+Whether `marketplace.json` and each `plugin.json` carry required fields with valid
+values, names are kebab-case, sources resolve, and there are no duplicate names or
+orphaned entries. `marketplace.json` requires `name`, `owner`, and `plugins`; each
+plugin entry requires `name` and `source`; `plugin.json` requires a kebab-case
+`name` and uses semver for `version`; source paths must be relative without `..`.
+
+- **1 — Deficient.** Manifests miss required fields, use invalid values (non-kebab
+  name, non-semver version, `..` in a source path), contain duplicate plugin names,
+  or list entries whose plugin/source does not exist (orphans).
+  Sources: plugins-reference / manifest-reference (name regex; semver; relative
+  `./` paths, no `..`); plugin-marketplaces (required fields; duplicate-name error;
+  source path-traversal check).
+- **3 — Competent.** Both manifests carry all required fields with valid values;
+  names are kebab-case; every source resolves; no duplicates or orphans; the repo
+  passes `claude plugin validate`.
+  Sources: plugin-marketplaces (required fields; `claude plugin validate`);
+  manifest-reference.
+- **5 — Exceptional.** As 3, plus complete recommended metadata (description,
+  version, author, license, keywords/category, repository/homepage) that is
+  consistent between each marketplace entry and its `plugin.json`; a `$schema` for
+  editor validation; and rename/removal history maintained so identifier changes do
+  not break existing installs.
+  Sources: manifest-reference (recommended metadata block); plugin-marketplaces
+  (`$schema`; entry-vs-`plugin.json` version-mismatch warning; `renames`).
+
+### A2 — Validation CI depth
+
+Whether automated validation gates the repo, and how deep it goes — syntax/schema
+only, versus semantic gates plus a regression culture. Judge relative to the repo's
+surface: a large multi-plugin marketplace has more that can break than a single-
+plugin repo, and the anchor is "checks scale to what could actually break."
+
+- **1 — Deficient.** No automated validation; malformed manifests, duplicate names,
+  path traversal, or unparseable frontmatter can merge undetected.
+  Sources: plugin-marketplaces (the validator exists and reports these classes —
+  its absence is the deficiency).
+- **3 — Competent.** Automated syntax/schema validation runs in CI (equivalent to
+  `claude plugin validate`), catching malformed manifests, duplicate names, source
+  path traversal, and unparseable skill/agent/command frontmatter.
+  Sources: plugin-marketplaces (validator scope: schema errors, duplicate names,
+  path traversal, per-entry `plugin.json`, YAML frontmatter, `hooks.json`).
+- **5 — Exceptional.** As 3, plus semantic gates beyond syntax (schema validation
+  of evals/behavior, hook-schema and hook-behavior tests, or content/quality
+  checks) and a regression culture where a fixed defect gains a guarding check.
+  Sources: skill-creator (`quick_validate.py`, `run_eval` harness); plugin-dev
+  (`validate-hook-schema.sh`, `test-hook.sh`, `validate-settings.sh`).
+
+### A3 — Versioning & release discipline
+
+Whether versions are valid semver (or a deliberate commit-SHA scheme), bumped on
+release, declared in a single authoritative place, and supported by changelog/
+release automation. Claude Code resolves a version from `plugin.json`, then the
+marketplace entry, then the git SHA; a stale pinned version silently starves users
+of updates.
+
+- **1 — Deficient.** No versioning strategy — versions absent where pinning is
+  intended, or pinned versions that never bump so users never receive updates; no
+  changelog.
+  Sources: plugin-marketplaces (Warning: a stale pinned `version` "does nothing for
+  existing users").
+- **3 — Competent.** Consistent, valid semver (or deliberate commit-SHA
+  versioning), bumped on release, with the version declared in one authoritative
+  place (not conflictingly in both `plugin.json` and the marketplace entry).
+  Sources: manifest-reference (semver MAJOR/MINOR/PATCH); plugin-marketplaces
+  (version resolution order; "avoid setting version in both").
+- **5 — Exceptional.** As 3, plus automated release/changelog generation and a
+  coherent, documented version-resolution or release-channel strategy applied in
+  practice.
+  Sources: plugin-marketplaces (release channels; version resolution);
+  manifest-reference (maintain a changelog; bump version on changes).
+
+### A4 — Supply-chain & distribution safety
+
+Whether the supply-chain risks the distribution model **actually has** are
+controlled: external sources pinned against mutable refs, provenance/integrity,
+license correctness, scope guards, and plugin references that stay inside the
+plugin. A self-contained repo with no external refs has no pinning risk and is
+judged on license and path-safety alone — it is not penalized for lacking pins it
+has no use for.
+
+- **1 — Deficient.** The model's real risks are uncontrolled — external plugin or
+  dependency sources tracked from mutable refs with no pin or provenance, a missing
+  or incorrect license, or scripts/configs referencing paths outside the plugin
+  (e.g. `..`) instead of `${CLAUDE_PLUGIN_ROOT}`/relative paths.
+  Sources: plugin-marketplaces (SHA pinning; relative-path rule, no `..`);
+  manifest-reference (SPDX license); plugin-marketplaces (`${CLAUDE_PLUGIN_ROOT}`).
+- **3 — Competent.** The risks the model actually has are controlled — external
+  sources pinned to a tag/SHA where mutability matters, license declared, and all
+  plugin references resolve within the plugin via `${CLAUDE_PLUGIN_ROOT}` or
+  relative paths with no `..`.
+  Sources: plugin-marketplaces (`ref`/`sha` pinning; relative paths resolve within
+  marketplace root); manifest-reference (license SPDX).
+- **5 — Exceptional.** As 3, with provenance/integrity strengthened to the model's
+  risk profile: exact 40-character SHA pins (or npm version/registry pins),
+  liveness/reachability handled, scope or allowlist guards where the repo
+  distributes to others, and licenses validated across bundled components.
+  Sources: plugin-marketplaces (full-SHA pin; npm `version`/`registry`;
+  `strictKnownMarketplaces`; read-only seed); manifest-reference (license).
+
+### A5 — Docs & navigability
+
+Whether the marketplace and each plugin carry accurate descriptions and docs, the
+catalog is discoverable, and its claims (plugin list, counts) match what is on
+disk. A missing top-level description is a documented warning; per-plugin READMEs
+and metadata aid discovery.
+
+- **1 — Deficient.** Sparse or misleading docs — no marketplace/plugin
+  descriptions, no README, or catalog claims (counts, plugin lists) that do not
+  match the repo contents.
+  Sources: plugin-marketplaces ("No marketplace description provided" warning);
+  manifest-reference (description; README; "keep description current").
+- **3 — Competent.** The marketplace and each plugin carry accurate descriptions
+  and a README; the catalog is discoverable and its claims match disk.
+  Sources: manifest-reference (description, README, keywords); plugin-marketplaces
+  (top-level `description`).
+- **5 — Exceptional.** As 3, plus per-plugin (and per-skill) documentation, a
+  navigable catalog/index using keywords/categories and homepage/repository links,
+  and counts/claims kept in sync with source as a single source of truth.
+  Sources: manifest-reference (homepage, repository, keywords, changelog);
+  plugin-marketplaces (`category`, `tags`).
+
+### A6 — Governance & eval infrastructure
+
+Whether there is an ownership/contribution signal (license, author, repository,
+contribution guidance) and whether skill quality is *measured* rather than asserted
+— the baseline-comparison eval loop, trigger-accuracy tuning, and blind A/B being
+the published mechanisms.
+
+- **1 — Deficient.** No license, ownership, or contribution signal, and no
+  quality-evaluation tooling; quality rests entirely on ad-hoc judgment.
+  Sources: manifest-reference (license/author/repository for attribution &
+  contribution); skills ("Evaluate and iterate on a skill" — its absence is the
+  gap).
+- **3 — Competent.** An ownership/contribution signal exists (license, author,
+  repository, or basic contribution guidance) and some quality evaluation is
+  practiced (e.g. a baseline-comparison eval loop or equivalent).
+  Sources: skills (baseline comparison: with-skill vs disabled); skill-creator;
+  manifest-reference.
+- **5 — Exceptional.** As 3, plus systematic evaluation infrastructure — measurable
+  skill effectiveness (baseline-vs-with-skill benchmarking, trigger-accuracy
+  tuning, blind A/B), a documented governance/contribution process, and evidence it
+  is actually used.
+  Sources: skill-creator (benchmark mode with mean±stddev deltas; description
+  optimization loop; blind comparison); skills (eval workflow; `/doctor` for
+  listing health).
+
+---
+
+## House-only criteria excluded from scoring
+
+These appear in the house rules (`skill-quality.md`, `skill-argument-handling.md`)
+but are **not independently supported** by the allowed sources, so they carry **no
+score**. The neutral, published-supported version (where one exists) is what the
+anchors above use instead.
+
+- **Specific character-count size thresholds** (≤10,000 chars OK / 26,000-char hard
+  ceiling) — house `skill-quality.md`. Published guidance supports *leanness* ("under
+  500 lines", "<5k words") but not these literal char gates. B3 scores leanness/
+  progressive disclosure, not a char count.
+- **Mandatory "When to Use This Skill" decision table** placed immediately after the
+  title, with a "Use X instead when…" column — house `skill-quality.md`. Published
+  guidance puts "when to use" in the `description`, not a required body section.
+- **Mandatory "Agentic Optimizations" table** near the end — house
+  `skill-quality.md`. No published requirement for this section.
+- **Literal "Use when…" clause** in the description — house `skill-quality.md`. The
+  neutral, published version is "description states concrete trigger conditions"
+  (B1); the exact phrase is not required.
+- **Specific description-length band** (≤150-char target, >300-char ERROR) — house
+  `skill-quality.md`. The *listing budget and 1,536-char truncation* are published
+  and inform B1's front-loading anchor, but the 150/300 numbers are house thresholds.
+- **`created` / `modified` / `reviewed` date frontmatter fields** — house
+  `skill-quality.md`. Not in the published frontmatter schema; not scored.
+- **Model-selection policy** (`opus`/`sonnet` extremes-only; `haiku` banned) — house
+  `skill-quality.md`. The `model` field is published, but this policy is a house
+  convention.
+- **`allowed-tools` as a *required* frontmatter field** — house `skill-quality.md`.
+  Published schema marks only `description` as recommended and `name`/`allowed-tools`
+  as optional. B5 scores whether tool allowances are *least-privilege when present*,
+  not their mandatory presence.
+- **Literal `REFERENCE.md` filename** (uppercase, specific name) — house
+  `skill-quality.md`. Published guidance uses a `references/` directory with any
+  filename; B3 scores on-demand supporting files, not a filename.
+- **Positive-only writing style** ("describe what to do, not what to avoid") as a
+  scored requirement — house `skill-quality.md`. Related to skill-creator's
+  "explain the why / avoid rigid MUSTs" (which B2 uses) but the strict positive-
+  framing rule is house-specific.
+- **The 9-axis argument-handling rubric and the haiku-vs-opus cold-read sweep
+  methodology** — house `skill-argument-handling.md`. This is house *evaluation
+  tooling*, not a scored artifact property. The underlying published concepts —
+  `argument-hint` indicates expected arguments, `$ARGUMENTS`/`$N` substitution — are
+  folded into B2 (instruction quality) where relevant, without the house rubric.
+- **Repo-specific commit/PR conventions** (conventional-commit scopes, plugin-name
+  scoping, release-please dogfooding) — house `CLAUDE.md`. Out of scope for
+  artifact-content scoring.
+
+---
+
+## Source list
+
+Published Anthropic documentation (consulted):
+
+- Extend Claude with skills — https://code.claude.com/docs/en/skills
+- Best Practices for Writing Effective Agent Skills (Anthropic engineering / agent
+  skills best-practices) — https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills
+  and https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices
+- Create and distribute a plugin marketplace — https://code.claude.com/docs/en/plugin-marketplaces
+- Plugins reference (plugin manifest schema, components) — https://code.claude.com/docs/en/plugins-reference
+- Safety & permissions in hooks — https://code.claude.com/docs/en/hooks
+
+Official marketplace repo authoring references (local, read in full):
+
+- `official/plugins/skill-creator/skills/skill-creator/SKILL.md` (skill-creator)
+- `official/plugins/skill-creator/skills/skill-creator/references/schemas.md`
+  (eval / grading / benchmark / comparison JSON schemas)
+- `official/plugins/plugin-dev/skills/skill-development/SKILL.md`
+- `official/plugins/plugin-dev/skills/plugin-structure/references/manifest-reference.md`
+- `official/plugins/plugin-dev/skills/command-development/references/marketplace-considerations.md`
+- Referenced as evidence of semantic validation tooling: `skill-creator/.../scripts/`
+  (`quick_validate.py`, `run_eval.py`, `aggregate_benchmark.py`) and
+  `plugin-dev/skills/hook-development/scripts/` (`validate-hook-schema.sh`,
+  `test-hook.sh`), `plugin-settings/scripts/validate-settings.sh`
+
+Diff-only inputs (read to build the exclusion list; **not** anchor sources):
+
+- `laurigates/claude-plugins/.claude/rules/skill-quality.md`
+- `laurigates/claude-plugins/.claude/rules/skill-argument-handling.md`

--- a/docs/benchmarks/2026-07-marketplace-quality/synthesis.json
+++ b/docs/benchmarks/2026-07-marketplace-quality/synthesis.json
@@ -1,0 +1,1012 @@
+{
+  "bias_audit": {
+    "judgments_total": 18,
+    "judgments_with_leakage": 18,
+    "leakage_rate": 1.0,
+    "mean_margin_ours_minus_official_clean": null,
+    "mean_margin_ours_minus_official_leaked": 0.37,
+    "position_bias": {
+      "mean_margin_when_ours_is_A": 1.333,
+      "mean_margin_when_ours_is_B": -0.4,
+      "mean_score_side_a": 4.287,
+      "mean_score_side_b": 3.472
+    },
+    "quote_check": {
+      "counts": {
+        "exact": 230,
+        "normalized": 1
+      },
+      "findings_dropped": [],
+      "total_evidence": 231
+    }
+  },
+  "blinding": {
+    "autonomous-loop": {
+      "A": "official",
+      "B": "ours",
+      "file_counts": {
+        "A": 8,
+        "B": 2
+      },
+      "official_sources": [
+        "plugins/ralph-loop"
+      ],
+      "ours_sources": [
+        "project-plugin/skills/project-test-loop",
+        ".claude/rules/loop-integrity.md"
+      ],
+      "task": "Run autonomous iterate-until-done loops (e.g. test-fix cycles) safely and effectively."
+    },
+    "claude-md": {
+      "A": "official",
+      "B": "ours",
+      "file_counts": {
+        "A": 9,
+        "B": 2
+      },
+      "official_sources": [
+        "plugins/claude-md-management"
+      ],
+      "ours_sources": [
+        "blueprint-plugin/skills/blueprint-claude-md",
+        "agent-patterns-plugin/skills/meta-context-diet"
+      ],
+      "task": "Help users create, maintain, and optimize CLAUDE.md / project memory and context files."
+    },
+    "code-review": {
+      "A": "official",
+      "B": "ours",
+      "file_counts": {
+        "A": 3,
+        "B": 5
+      },
+      "official_sources": [
+        "plugins/code-review"
+      ],
+      "ours_sources": [
+        "code-quality-plugin/skills/code-review",
+        "code-quality-plugin/skills/code-review-checklist",
+        "agents-plugin/agents/review.md",
+        "code-quality-plugin/.claude-plugin/plugin.json",
+        "code-quality-plugin/README.md"
+      ],
+      "task": "Enable high-quality code review (quality, security, performance, architecture) of diffs/PRs."
+    },
+    "hooks": {
+      "A": "ours",
+      "B": "official",
+      "file_counts": {
+        "A": 36,
+        "B": 23
+      },
+      "official_sources": [
+        "plugins/hookify"
+      ],
+      "ours_sources": [
+        "hooks-plugin"
+      ],
+      "task": "Help users create, configure, and manage Claude Code hooks (safety, automation, event handling)."
+    },
+    "mcp-dev": {
+      "A": "official",
+      "B": "ours",
+      "file_counts": {
+        "A": 21,
+        "B": 6
+      },
+      "official_sources": [
+        "plugins/mcp-server-dev"
+      ],
+      "ours_sources": [
+        "agent-patterns-plugin/skills/mcp-server-authoring",
+        "agent-patterns-plugin/skills/mcp-management",
+        "agent-patterns-plugin/skills/mcp-code-execution",
+        "agent-patterns-plugin/.claude-plugin/plugin.json"
+      ],
+      "task": "Help users build, configure, and manage MCP servers and MCP-based agent integrations."
+    },
+    "pr-commit-workflow": {
+      "A": "ours",
+      "B": "official",
+      "file_counts": {
+        "A": 35,
+        "B": 14
+      },
+      "official_sources": [
+        "plugins/pr-review-toolkit",
+        "plugins/commit-commands"
+      ],
+      "ours_sources": [
+        "git-plugin/skills/git-commit",
+        "git-plugin/skills/git-commit-workflow",
+        "git-plugin/skills/git-commit-trailers",
+        "git-plugin/skills/git-commit-push-pr",
+        "git-plugin/skills/git-pr",
+        "git-plugin/skills/git-pr-feedback",
+        "git-plugin/skills/git-pr-sync-check",
+        "git-plugin/skills/git-pr-watch",
+        "git-plugin/skills/git-push",
+        "git-plugin/skills/git-fix-pr",
+        "git-plugin/skills/git-api-pr",
+        "git-plugin/skills/git-branch-pr-workflow",
+        "git-plugin/skills/github-pr-title",
+        "git-plugin/.claude-plugin/plugin.json",
+        "git-plugin/README.md",
+        "git-plugin/hooks"
+      ],
+      "task": "Support commit creation and pull-request lifecycle workflows (commit messages, PR creation, review response, CI follow-up)."
+    },
+    "security-guidance": {
+      "A": "official",
+      "B": "ours",
+      "file_counts": {
+        "A": 14,
+        "B": 6
+      },
+      "official_sources": [
+        "plugins/security-guidance"
+      ],
+      "ours_sources": [
+        "configure-plugin/skills/configure-security",
+        "git-plugin/skills/git-security-checks"
+      ],
+      "task": "Provide security guidance and scanning for codebases (secrets, dependencies, SAST, security policy)."
+    },
+    "session-reporting": {
+      "A": "ours",
+      "B": "official",
+      "file_counts": {
+        "A": 15,
+        "B": 3
+      },
+      "official_sources": [
+        "plugins/session-report"
+      ],
+      "ours_sources": [
+        "session-plugin"
+      ],
+      "task": "Summarize, report on, and wrap up Claude Code work sessions."
+    },
+    "skill-authoring": {
+      "A": "ours",
+      "B": "official",
+      "file_counts": {
+        "A": 37,
+        "B": 79
+      },
+      "official_sources": [
+        "plugins/skill-creator",
+        "plugins/plugin-dev"
+      ],
+      "ours_sources": [
+        ".claude/rules/skill-development.md",
+        ".claude/rules/skill-quality.md",
+        ".claude/rules/skill-naming.md",
+        ".claude/rules/skill-argument-handling.md",
+        ".claude/rules/skill-execution-structure.md",
+        "evaluate-plugin",
+        "project-plugin/skills/project-skill-scripts"
+      ],
+      "task": "Help users author, validate, and evaluate high-quality skills and plugins for Claude Code."
+    }
+  },
+  "dim_rollup": {
+    "B1": {
+      "mean_median_official": 3.44,
+      "mean_median_ours": 4.72,
+      "pair_wins": {
+        "official": 1,
+        "ours": 7,
+        "tie": 1
+      }
+    },
+    "B2": {
+      "mean_median_official": 4.28,
+      "mean_median_ours": 4.17,
+      "pair_wins": {
+        "official": 3,
+        "ours": 4,
+        "tie": 2
+      }
+    },
+    "B3": {
+      "mean_median_official": 3.89,
+      "mean_median_ours": 4.0,
+      "pair_wins": {
+        "official": 3,
+        "ours": 6,
+        "tie": 0
+      }
+    },
+    "B4": {
+      "mean_median_official": 3.89,
+      "mean_median_ours": 3.94,
+      "pair_wins": {
+        "official": 2,
+        "ours": 3,
+        "tie": 4
+      }
+    },
+    "B5": {
+      "mean_median_official": 3.67,
+      "mean_median_ours": 3.89,
+      "pair_wins": {
+        "official": 3,
+        "ours": 5,
+        "tie": 1
+      }
+    },
+    "B6": {
+      "mean_median_official": 3.0,
+      "mean_median_ours": 3.67,
+      "pair_wins": {
+        "official": 2,
+        "ours": 6,
+        "tie": 1
+      }
+    }
+  },
+  "pair_table": {
+    "autonomous-loop": {
+      "B1": {
+        "confidence": "verified",
+        "judge_verdicts": [
+          "ours",
+          "ours"
+        ],
+        "margin_ours_minus_official": 2.0,
+        "median_official": 3.0,
+        "median_ours": 5.0,
+        "refuter": {
+          "corrected_official": 3,
+          "corrected_ours": 5,
+          "corrected_winner": "ours",
+          "reason_selected": "load-bearing decisive margin (2.0 pts, both judges agree)",
+          "symmetric_violation": false,
+          "verdict": "upheld"
+        },
+        "verdict": "ours"
+      },
+      "B2": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "tie",
+          "tie"
+        ],
+        "margin_ours_minus_official": 0.0,
+        "median_official": 4.0,
+        "median_ours": 4.0,
+        "verdict": "tie"
+      },
+      "B3": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "official",
+          "official"
+        ],
+        "margin_ours_minus_official": -1.5,
+        "median_official": 4.5,
+        "median_ours": 3.0,
+        "verdict": "official"
+      },
+      "B4": {
+        "confidence": "verified",
+        "judge_verdicts": [
+          "official",
+          "official"
+        ],
+        "margin_ours_minus_official": -2.5,
+        "median_official": 5.0,
+        "median_ours": 2.5,
+        "refuter": {
+          "corrected_official": 5,
+          "corrected_ours": 2,
+          "corrected_winner": "official",
+          "reason_selected": "load-bearing decisive margin (2.5 pts, both judges agree)",
+          "symmetric_violation": false,
+          "verdict": "upheld"
+        },
+        "verdict": "official"
+      },
+      "B5": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "official",
+          "official"
+        ],
+        "margin_ours_minus_official": -1.0,
+        "median_official": 4.0,
+        "median_ours": 3.0,
+        "verdict": "official"
+      },
+      "B6": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "ours",
+          "ours"
+        ],
+        "margin_ours_minus_official": 1.0,
+        "median_official": 3.0,
+        "median_ours": 4.0,
+        "verdict": "ours"
+      }
+    },
+    "claude-md": {
+      "B1": {
+        "confidence": "split",
+        "judge_verdicts": [
+          "ours",
+          "tie"
+        ],
+        "margin_ours_minus_official": 0.5,
+        "median_official": 4.0,
+        "median_ours": 4.5,
+        "verdict": "ours"
+      },
+      "B2": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "tie",
+          "tie"
+        ],
+        "margin_ours_minus_official": 0.0,
+        "median_official": 4.0,
+        "median_ours": 4.0,
+        "verdict": "tie"
+      },
+      "B3": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "official",
+          "official"
+        ],
+        "margin_ours_minus_official": -1.0,
+        "median_official": 4.0,
+        "median_ours": 3.0,
+        "verdict": "official"
+      },
+      "B4": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "tie",
+          "tie"
+        ],
+        "margin_ours_minus_official": 0.0,
+        "median_official": 3.0,
+        "median_ours": 3.0,
+        "verdict": "tie"
+      },
+      "B5": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "tie",
+          "tie"
+        ],
+        "margin_ours_minus_official": 0.0,
+        "median_official": 4.0,
+        "median_ours": 4.0,
+        "verdict": "tie"
+      },
+      "B6": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "tie",
+          "tie"
+        ],
+        "margin_ours_minus_official": 0.0,
+        "median_official": 3.0,
+        "median_ours": 3.0,
+        "verdict": "tie"
+      }
+    },
+    "code-review": {
+      "B1": {
+        "confidence": "refuter-adjusted",
+        "judge_verdicts": [
+          "ours",
+          "ours"
+        ],
+        "margin_ours_minus_official": 3.0,
+        "median_official": 2.0,
+        "median_official_adjusted": 2,
+        "median_ours": 5.0,
+        "median_ours_adjusted": 4,
+        "refuter": {
+          "corrected_official": 2,
+          "corrected_ours": 4,
+          "corrected_winner": "ours",
+          "reason_selected": "load-bearing decisive margin (3.0 pts, both judges agree)",
+          "symmetric_violation": true,
+          "verdict": "adjusted"
+        },
+        "verdict": "ours"
+      },
+      "B2": {
+        "confidence": "verified",
+        "judge_verdicts": [
+          "official",
+          "official"
+        ],
+        "margin_ours_minus_official": -2.0,
+        "median_official": 5.0,
+        "median_ours": 3.0,
+        "refuter": {
+          "corrected_official": 5,
+          "corrected_ours": 3,
+          "corrected_winner": "official",
+          "reason_selected": "load-bearing decisive margin (2.0 pts, both judges agree)",
+          "symmetric_violation": false,
+          "verdict": "upheld"
+        },
+        "verdict": "official"
+      },
+      "B3": {
+        "confidence": "split",
+        "judge_verdicts": [
+          "tie",
+          "ours"
+        ],
+        "margin_ours_minus_official": 0.5,
+        "median_official": 3.0,
+        "median_ours": 3.5,
+        "verdict": "ours"
+      },
+      "B4": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "tie",
+          "tie"
+        ],
+        "margin_ours_minus_official": 0.0,
+        "median_official": 3.0,
+        "median_ours": 3.0,
+        "verdict": "tie"
+      },
+      "B5": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "official",
+          "official"
+        ],
+        "margin_ours_minus_official": -1.0,
+        "median_official": 4.0,
+        "median_ours": 3.0,
+        "verdict": "official"
+      },
+      "B6": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "ours",
+          "ours"
+        ],
+        "margin_ours_minus_official": 1.0,
+        "median_official": 2.0,
+        "median_ours": 3.0,
+        "verdict": "ours"
+      }
+    },
+    "hooks": {
+      "B1": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "ours",
+          "ours"
+        ],
+        "margin_ours_minus_official": 1.0,
+        "median_official": 4.0,
+        "median_ours": 5.0,
+        "verdict": "ours"
+      },
+      "B2": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "ours",
+          "ours"
+        ],
+        "margin_ours_minus_official": 1.0,
+        "median_official": 4.0,
+        "median_ours": 5.0,
+        "verdict": "ours"
+      },
+      "B3": {
+        "confidence": "verified",
+        "judge_verdicts": [
+          "ours",
+          "ours"
+        ],
+        "margin_ours_minus_official": 2.0,
+        "median_official": 3.0,
+        "median_ours": 5.0,
+        "refuter": {
+          "corrected_official": 3,
+          "corrected_ours": 5,
+          "corrected_winner": "ours",
+          "reason_selected": "load-bearing decisive margin (2.0 pts, both judges agree)",
+          "symmetric_violation": false,
+          "verdict": "upheld"
+        },
+        "verdict": "ours"
+      },
+      "B4": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "ours",
+          "ours"
+        ],
+        "margin_ours_minus_official": 1.0,
+        "median_official": 4.0,
+        "median_ours": 5.0,
+        "verdict": "ours"
+      },
+      "B5": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "ours",
+          "ours"
+        ],
+        "margin_ours_minus_official": 1.0,
+        "median_official": 4.0,
+        "median_ours": 5.0,
+        "verdict": "ours"
+      },
+      "B6": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "ours",
+          "ours"
+        ],
+        "margin_ours_minus_official": 1.5,
+        "median_official": 2.5,
+        "median_ours": 4.0,
+        "verdict": "ours"
+      }
+    },
+    "mcp-dev": {
+      "B1": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "official",
+          "official"
+        ],
+        "margin_ours_minus_official": -1.0,
+        "median_official": 5.0,
+        "median_ours": 4.0,
+        "verdict": "official"
+      },
+      "B2": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "official",
+          "official"
+        ],
+        "margin_ours_minus_official": -1.5,
+        "median_official": 5.0,
+        "median_ours": 3.5,
+        "verdict": "official"
+      },
+      "B3": {
+        "confidence": "split",
+        "judge_verdicts": [
+          "tie",
+          "ours"
+        ],
+        "margin_ours_minus_official": 0.5,
+        "median_official": 4.0,
+        "median_ours": 4.5,
+        "verdict": "ours"
+      },
+      "B4": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "tie",
+          "tie"
+        ],
+        "margin_ours_minus_official": 0.0,
+        "median_official": 3.0,
+        "median_ours": 3.0,
+        "verdict": "tie"
+      },
+      "B5": {
+        "confidence": "split",
+        "judge_verdicts": [
+          "ours",
+          "tie"
+        ],
+        "margin_ours_minus_official": 0.5,
+        "median_official": 3.5,
+        "median_ours": 4.0,
+        "verdict": "ours"
+      },
+      "B6": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "official",
+          "official"
+        ],
+        "margin_ours_minus_official": -1.5,
+        "median_official": 4.5,
+        "median_ours": 3.0,
+        "verdict": "official"
+      }
+    },
+    "pr-commit-workflow": {
+      "B1": {
+        "confidence": "verified",
+        "judge_verdicts": [
+          "ours",
+          "ours"
+        ],
+        "margin_ours_minus_official": 2.0,
+        "median_official": 3.0,
+        "median_ours": 5.0,
+        "refuter": {
+          "corrected_official": 3,
+          "corrected_ours": 5,
+          "corrected_winner": "ours",
+          "reason_selected": "load-bearing decisive margin (2.0 pts, both judges agree)",
+          "symmetric_violation": false,
+          "verdict": "upheld"
+        },
+        "verdict": "ours"
+      },
+      "B2": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "ours",
+          "ours"
+        ],
+        "margin_ours_minus_official": 1.5,
+        "median_official": 3.0,
+        "median_ours": 4.5,
+        "verdict": "ours"
+      },
+      "B3": {
+        "confidence": "split",
+        "judge_verdicts": [
+          "ours",
+          "tie"
+        ],
+        "margin_ours_minus_official": 0.5,
+        "median_official": 3.5,
+        "median_ours": 4.0,
+        "verdict": "ours"
+      },
+      "B4": {
+        "confidence": "verified",
+        "judge_verdicts": [
+          "ours",
+          "ours"
+        ],
+        "margin_ours_minus_official": 2.0,
+        "median_official": 3.0,
+        "median_ours": 5.0,
+        "refuter": {
+          "corrected_official": 3,
+          "corrected_ours": 5,
+          "corrected_winner": "ours",
+          "reason_selected": "load-bearing decisive margin (2.0 pts, both judges agree)",
+          "symmetric_violation": false,
+          "verdict": "upheld"
+        },
+        "verdict": "ours"
+      },
+      "B5": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "ours",
+          "ours"
+        ],
+        "margin_ours_minus_official": 1.5,
+        "median_official": 2.5,
+        "median_ours": 4.0,
+        "verdict": "ours"
+      },
+      "B6": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "ours",
+          "ours"
+        ],
+        "margin_ours_minus_official": 2.0,
+        "median_official": 2.0,
+        "median_ours": 4.0,
+        "verdict": "ours"
+      }
+    },
+    "security-guidance": {
+      "B1": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "tie",
+          "tie"
+        ],
+        "margin_ours_minus_official": 0.0,
+        "median_official": 4.0,
+        "median_ours": 4.0,
+        "verdict": "tie"
+      },
+      "B2": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "official",
+          "official"
+        ],
+        "margin_ours_minus_official": -1.5,
+        "median_official": 5.0,
+        "median_ours": 3.5,
+        "verdict": "official"
+      },
+      "B3": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "official",
+          "official"
+        ],
+        "margin_ours_minus_official": -2.0,
+        "median_official": 5.0,
+        "median_ours": 3.0,
+        "verdict": "official"
+      },
+      "B4": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "official",
+          "official"
+        ],
+        "margin_ours_minus_official": -1.0,
+        "median_official": 5.0,
+        "median_ours": 4.0,
+        "verdict": "official"
+      },
+      "B5": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "official",
+          "official"
+        ],
+        "margin_ours_minus_official": -1.5,
+        "median_official": 4.5,
+        "median_ours": 3.0,
+        "verdict": "official"
+      },
+      "B6": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "official",
+          "official"
+        ],
+        "margin_ours_minus_official": -2.0,
+        "median_official": 5.0,
+        "median_ours": 3.0,
+        "verdict": "official"
+      }
+    },
+    "session-reporting": {
+      "B1": {
+        "confidence": "verified",
+        "judge_verdicts": [
+          "ours",
+          "ours"
+        ],
+        "margin_ours_minus_official": 3.0,
+        "median_official": 2.0,
+        "median_ours": 5.0,
+        "refuter": {
+          "corrected_official": 2,
+          "corrected_ours": 5,
+          "corrected_winner": "ours",
+          "reason_selected": "load-bearing decisive margin (3.0 pts, both judges agree)",
+          "symmetric_violation": false,
+          "verdict": "upheld"
+        },
+        "verdict": "ours"
+      },
+      "B2": {
+        "confidence": "split",
+        "judge_verdicts": [
+          "ours",
+          "tie"
+        ],
+        "margin_ours_minus_official": 0.5,
+        "median_official": 4.5,
+        "median_ours": 5.0,
+        "verdict": "ours"
+      },
+      "B3": {
+        "confidence": "split",
+        "judge_verdicts": [
+          "ours",
+          "tie"
+        ],
+        "margin_ours_minus_official": 0.5,
+        "median_official": 4.5,
+        "median_ours": 5.0,
+        "verdict": "ours"
+      },
+      "B4": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "tie",
+          "tie"
+        ],
+        "margin_ours_minus_official": 0.0,
+        "median_official": 5.0,
+        "median_ours": 5.0,
+        "verdict": "tie"
+      },
+      "B5": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "ours",
+          "ours"
+        ],
+        "margin_ours_minus_official": 1.0,
+        "median_official": 3.0,
+        "median_ours": 4.0,
+        "verdict": "ours"
+      },
+      "B6": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "ours",
+          "ours"
+        ],
+        "margin_ours_minus_official": 1.5,
+        "median_official": 3.0,
+        "median_ours": 4.5,
+        "verdict": "ours"
+      }
+    },
+    "skill-authoring": {
+      "B1": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "ours",
+          "ours"
+        ],
+        "margin_ours_minus_official": 1.0,
+        "median_official": 4.0,
+        "median_ours": 5.0,
+        "verdict": "ours"
+      },
+      "B2": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "ours",
+          "ours"
+        ],
+        "margin_ours_minus_official": 1.0,
+        "median_official": 4.0,
+        "median_ours": 5.0,
+        "verdict": "ours"
+      },
+      "B3": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "ours",
+          "ours"
+        ],
+        "margin_ours_minus_official": 1.5,
+        "median_official": 3.5,
+        "median_ours": 5.0,
+        "verdict": "ours"
+      },
+      "B4": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "ours",
+          "ours"
+        ],
+        "margin_ours_minus_official": 1.0,
+        "median_official": 4.0,
+        "median_ours": 5.0,
+        "verdict": "ours"
+      },
+      "B5": {
+        "confidence": "high",
+        "judge_verdicts": [
+          "ours",
+          "ours"
+        ],
+        "margin_ours_minus_official": 1.5,
+        "median_official": 3.5,
+        "median_ours": 5.0,
+        "verdict": "ours"
+      },
+      "B6": {
+        "confidence": "verified",
+        "judge_verdicts": [
+          "ours",
+          "ours"
+        ],
+        "margin_ours_minus_official": 2.5,
+        "median_official": 2.0,
+        "median_ours": 4.5,
+        "refuter": {
+          "corrected_official": 2,
+          "corrected_ours": 4,
+          "corrected_winner": "ours",
+          "reason_selected": "load-bearing decisive margin (2.5 pts, both judges agree)",
+          "symmetric_violation": false,
+          "verdict": "upheld"
+        },
+        "verdict": "ours"
+      }
+    }
+  },
+  "tier_a": {
+    "A1": {
+      "confidence": "split",
+      "judge_verdicts": [
+        "tie",
+        "ours"
+      ],
+      "margin_ours_minus_official": 0.5,
+      "median_official": 3.5,
+      "median_ours": 4.0,
+      "verdict": "ours"
+    },
+    "A2": {
+      "confidence": "split",
+      "judge_verdicts": [
+        "ours",
+        "tie"
+      ],
+      "margin_ours_minus_official": 0.5,
+      "median_official": 4.5,
+      "median_ours": 5.0,
+      "verdict": "ours"
+    },
+    "A3": {
+      "confidence": "high",
+      "judge_verdicts": [
+        "ours",
+        "ours"
+      ],
+      "margin_ours_minus_official": 1.5,
+      "median_official": 3.5,
+      "median_ours": 5.0,
+      "verdict": "ours"
+    },
+    "A4": {
+      "confidence": "high",
+      "judge_verdicts": [
+        "official",
+        "official"
+      ],
+      "margin_ours_minus_official": -1.0,
+      "median_official": 5.0,
+      "median_ours": 4.0,
+      "verdict": "official"
+    },
+    "A5": {
+      "confidence": "refuter-adjusted",
+      "judge_verdicts": [
+        "official",
+        "ours"
+      ],
+      "margin_ours_minus_official": 0.0,
+      "median_official": 3.5,
+      "median_ours": 3.5,
+      "refuter": {
+        "corrected_official": 3,
+        "corrected_ours": 3,
+        "corrected_winner": "tie",
+        "symmetric_violation": true,
+        "verdict": "adjusted"
+      },
+      "verdict": "tie"
+    },
+    "A6": {
+      "confidence": "high",
+      "judge_verdicts": [
+        "ours",
+        "ours"
+      ],
+      "margin_ours_minus_official": 1.0,
+      "median_official": 4.0,
+      "median_ours": 5.0,
+      "verdict": "ours"
+    }
+  }
+}

--- a/docs/benchmarks/2026-07-marketplace-quality/tier_c.json
+++ b/docs/benchmarks/2026-07-marketplace-quality/tier_c.json
@@ -1,0 +1,83 @@
+{
+  "official": {
+    "categories": {
+      "(none)": 14,
+      "automation": 1,
+      "database": 34,
+      "deployment": 8,
+      "design": 6,
+      "development": 109,
+      "learning": 3,
+      "location": 2,
+      "math": 1,
+      "migration": 1,
+      "monitoring": 17,
+      "productivity": 45,
+      "security": 13,
+      "testing": 1
+    },
+    "entries": 255,
+    "external_plugins_vendored": [
+      "asana",
+      "context7",
+      "discord",
+      "fakechat",
+      "firebase",
+      "github",
+      "gitlab",
+      "greptile",
+      "imessage",
+      "laravel-boost",
+      "linear",
+      "playwright",
+      "serena",
+      "telegram",
+      "terraform"
+    ],
+    "lsp_config_plugins": {
+      "count": 12,
+      "names": [
+        "clangd-lsp",
+        "csharp-lsp",
+        "gopls-lsp",
+        "jdtls-lsp",
+        "kotlin-lsp",
+        "lua-lsp",
+        "php-lsp",
+        "pyright-lsp",
+        "ruby-lsp",
+        "rust-analyzer-lsp",
+        "swift-lsp",
+        "typescript-lsp"
+      ]
+    },
+    "source_types": {
+      "git-subdir": 71,
+      "github": 2,
+      "in-repo": 51,
+      "url": 131
+    },
+    "unique_external_repos": 179
+  },
+  "ours": {
+    "categories": {
+      "ai": 4,
+      "automation": 3,
+      "ci-cd": 2,
+      "communication": 2,
+      "development": 10,
+      "documentation": 2,
+      "gamedev": 1,
+      "infrastructure": 6,
+      "language": 4,
+      "quality": 4,
+      "testing": 1,
+      "utilities": 3,
+      "ux": 2
+    },
+    "entries": 44,
+    "source_types": {
+      "in-repo": 44
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds `docs/benchmarks/2026-07-marketplace-quality/` — a two-channel quality benchmark of this marketplace against **anthropics/claude-plugins-official** (pinned @ `4cd126ba`, 2026-07-02), with the full audit trail (frozen rubric, 20 raw judgments, synthesis, refutations, mechanical metrics).

## Headline result

| | ours | official | even/tie |
|---|---|---|---|
| Tier B pair verdicts (9 blind pairs) | **5** | 3 | 1 |
| Tier A infrastructure (6 open-book dims) | **4** | 1 | 1 |

- Ours sweeps hooks, pr-commit-workflow, skill-authoring (6-0 each), session-reporting (5-0-1); wins Tier A release discipline, eval/governance, CI depth.
- Official cleanly wins **security-guidance (0-5-1)**, **autonomous-loop**, **mcp-dev**, and Tier A supply-chain — the losses are the most actionable output.
- Integrity: 231/231 evidence quotes mechanically verified (0 fabricated); all 10 high-stakes findings adversarially refuted (8 upheld incl. two pro-official, 2 adjusted — both trimming pro-ours margins, 0 overturned); metrics byte-deterministic; every report cell mechanically reconciled against `synthesis.json`.
- **Read §6 (bias & limitations) before quoting numbers**: blinding failed to conceal identity (18/18 leakage — author metadata ships in the artifacts), and side-A position is confounded with pair composition at n=9.

## Follow-up issues

Filed from the report's §7 adopt list — linked here so they survive the merge:

- #1918 — docs: fix catalog accuracy (PLUGIN-MAP/README counts, marketplace description) — the A5 tie-breaker
- #1919 — refactor(configure-plugin): rebuild configure-security along security-guidance's shape (pair lost 0-5-1)
- #1920 — feat(project-plugin): deterministic loop driver for project-test-loop (B4 2.5v5, refuter-upheld)
- #1921 — feat(code-quality-plugin): rubric-style instruction depth in code-review (B2 3v5, refuter-upheld)
- #1922 — feat(agent-patterns-plugin): deepen mcp-server-authoring's build path (pair 2-3-1)

## Method (one paragraph)

Channel M: deterministic Python metrics over both full trees. Channel J: anchored 1–5 judgments, median of 2 independent judges per unit; 9 overlap pairs staged blind into anonymous side-A/side-B dirs; anchors frozen before judging from published Anthropic guidance + the official repo's own skill-creator references (12 house-only criteria explicitly excluded from scoring). Catalog breadth (Tier C) is descriptive, never scored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01694LMd6WSmErpLNisnTBW9
