### PR TITLE
feat(rust-plugin): add mockito-http-mocking skill

### DIFF
--- a/rust-plugin/README.md
+++ b/rust-plugin/README.md
@@ -52,6 +52,12 @@ This plugin provides expert knowledge for Rust development with a focus on:
 - GitHub Actions integration
 - Test groups and timeouts
 
+**mockito-http-mocking** - HTTP API mocking in integration tests
+- Expectation semantics (`matched()` equals-count trap, `expect_at_least`)
+- Mock matching order (first created wins; specific before catch-all)
+- Taming polling clients against instant mock servers (error backoff, `task.abort()`)
+- teloxide long-poll specifics and a diagnosis checklist
+
 **cargo-llvm-cov** - Code coverage with LLVM
 - LLVM-based coverage instrumentation
 - Multiple output formats (HTML, LCOV, JSON, Cobertura)

--- a/rust-plugin/skills/mockito-http-mocking/SKILL.md
+++ b/rust-plugin/skills/mockito-http-mocking/SKILL.md
@@ -1,0 +1,141 @@
+---
+created: 2026-07-03
+modified: 2026-07-03
+name: mockito-http-mocking
+description: "mockito HTTP mocking for Rust integration tests: expectation semantics, mock matching order, and taming polling clients against instant mock servers. Use when mocking an HTTP API in Rust tests, when a wait-until-matched loop hangs, or when tests pass alone but hang under concurrent load."
+user-invocable: false
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# mockito-http-mocking - HTTP API Mocking in Rust Tests
+
+mockito spins up a real local HTTP server per test and matches incoming
+requests against declared mocks. Two of its semantics are routinely
+misread, and one interaction with polling clients produces hangs that only
+appear under concurrent load. All three were debugged live against a
+teloxide long-polling bot (truenas-ai-sentinel PR #12); the patterns apply
+to any Rust client that re-requests an endpoint in a loop.
+
+## When to Use This Skill
+
+| Use this skill when... | Use sibling skill instead when... |
+|---|---|
+| Mocking an HTTP API (Bot APIs, REST backends) in integration tests | Running/parallelizing the tests -- use `cargo-nextest` |
+| A `matched()` wait loop hangs or a mock "never gets hit" | Authoring async test code in general -- use `rust-development` |
+| Tests pass alone but hang/flake when the suite runs concurrently | Measuring coverage of the tests -- use `cargo-llvm-cov` |
+| Layering specific and catch-all mocks on one path | |
+
+## Semantics That Bite
+
+### 1. `matched()` means "hit count EQUALS the expectation" — not "was hit"
+
+The default expectation is **exactly 1**. A mock hit twice makes
+`matched()` return `false` again, so a wait-until-matched loop that raced
+past one hit silently un-matches:
+
+```rust
+// Wrong for anything a client may hit repeatedly: matched() flips back
+// to false on the second hit.
+let m = server.mock("POST", "/x").with_body("ok").create_async().await;
+
+// Right: "at least once" is what a readiness wait actually means.
+let m = server.mock("POST", "/x").with_body("ok")
+    .expect_at_least(1).create_async().await;
+while !m.matched_async().await { tokio::time::sleep(Duration::from_millis(50)).await; }
+```
+
+Reserve exact `expect(n)` / `expect(0)` for the final `assert_async()`
+after the client has been stopped — `expect(0)` plus a settle delay is the
+correct shape for "this endpoint must never be called".
+
+### 2. Mocks match in creation order — first match wins
+
+When several mocks cover the same method + path, mockito uses the **first
+created** mock whose matchers accept the request. Create specific
+body-matched mocks **before** the catch-all:
+
+```rust
+// Specific first: requests carrying {"offset":2} get the empty response...
+let drained = server.mock("POST", "/api/poll")
+    .match_body(Matcher::PartialJsonString(r#"{"offset":2}"#.into()))
+    .with_body(r#"{"ok":true,"result":[]}"#)
+    .create_async().await;
+// ...everything else falls through to the catch-all batch.
+let batch = server.mock("POST", "/api/poll")
+    .with_body(one_update_json())
+    .create_async().await;
+```
+
+`Matcher::PartialJsonString` compares **values**, not just keys —
+`{"offset":0,...}` does *not* match a `{"offset":2}` partial. Verify with a
+raw `reqwest` probe when in doubt; guessing the matching semantics from a
+failing dispatcher test conflates several failure modes.
+
+## Polling Clients Against an Instant Mock Server
+
+Real long polling holds the HTTP connection server-side. mockito responds
+**instantly**, so a long-poll client (`getUpdates`-style loops, SQS-style
+receive loops) degenerates into a hot request loop at ~100% CPU. Two
+consequences:
+
+- The flood starves everything sharing the runtime/machine — tests that
+  pass in isolation **hang under concurrent suite load** (the tell:
+  `cargo nextest run --test x <one_test>` passes in milliseconds, the full
+  run gets killed after minutes with SIGTERM, and `ps` shows the test
+  binary spinning at 100% CPU).
+- Graceful-shutdown paths that wait for the poll loop to notice a stop
+  flag may never get scheduled.
+
+### Fix A: make the "drained" mock trigger the client's error backoff
+
+Respond **500** on the post-consumption poll request. Well-behaved clients
+(teloxide, most SDKs) back off exponentially on errors, turning the hot
+loop into a gentle retry — while the mock still counts as matched, which
+is usually the "update was consumed" signal the test waits on:
+
+```rust
+let drained = server.mock("POST", "/api/poll")
+    .match_body(Matcher::PartialJsonString(r#"{"offset":2}"#.into()))
+    .with_status(500)
+    .with_body(r#"{"ok":false,"error_code":500,"description":"drained (test backoff)"}"#)
+    .expect_at_least(1)
+    .create_async().await;
+```
+
+### Fix B: `task.abort()` instead of graceful shutdown in tests
+
+A test does not need to prove graceful shutdown on every run. After the
+awaited assertion signal fires, cancel the client task outright:
+
+```rust
+wait_until_matched(&send).await;
+task.abort();
+let _ = task.await;            // JoinError::is_cancelled — expected
+send.assert_async().await;
+```
+
+Keep one dedicated test for graceful shutdown if the shutdown path itself
+is under test; don't pay its flake risk in every dispatcher test.
+
+## Client-Specific Notes
+
+- **teloxide** `Polling` sends `{"offset":0,"timeout":N}` on its **first**
+  request — the offset field is present, not absent. Body matchers and
+  "no offset yet" assumptions must account for it. Method paths are
+  PascalCase: `/bot<token>/GetUpdates`, `/GetMe`, `/SendMessage`.
+- **Dispatcher-driven bots** fetch `GetMe` at startup — mock it or the
+  dispatcher never polls.
+
+## Diagnosis Checklist
+
+| Symptom | Likely cause |
+|---|---|
+| Wait loop times out though the endpoint was clearly called | `matched()` vs expectation mismatch — use `expect_at_least(1)` |
+| Specific mock never matches; catch-all serves everything | Catch-all was created first — reorder |
+| Test passes alone, hangs in the full suite; binary at 100% CPU | Hot poll loop — apply Fix A + Fix B |
+| Client errors repeatedly right after startup | A required bootstrap call (e.g. `GetMe`) has no mock |
+
+When the failure resists reasoning, probe empirically: point the client at
+a raw `tokio::net::TcpListener` that logs request lines and bodies — five
+minutes of captured traffic beats an hour of guessing what the client
+sends.


### PR DESCRIPTION
## What

New skill `rust-plugin/skills/mockito-http-mocking/SKILL.md`: mockito expectation semantics, mock matching order, and patterns for testing polling HTTP clients against instant mock servers. README catalog updated.

## Why (session evidence)

Distilled from executing PRP-001 in `truenas-ai-sentinel` ([PR #12](https://github.com/laurigates/truenas-ai-sentinel/pull/12)). Three independent traps compounded into a hard-to-diagnose failure — tests passed alone but hung the full suite at 100% CPU:

1. `Mock::matched()` returns "hit count **equals** the expectation" (default exactly 1), so a wait-until-matched loop un-matches when a polling client hits the mock twice → needs `expect_at_least(1)`.
2. mockito matches mocks in **creation order** (first match wins), so specific `PartialJsonString` body mocks must be created before catch-alls — and `PartialJson` compares values, not just keys (verified empirically).
3. A long-poll client against an instant mock server degenerates into a hot request loop that starves concurrent tests. Fixes: respond 500 on the drained mock so the client's error backoff engages, and `task.abort()` instead of graceful shutdown in tests.

Plus teloxide specifics (first poll sends `{"offset":0}`, PascalCase method paths, GetMe bootstrap). None of this is covered by `cargo-nextest` / `rust-development`; it's mockito/polling-domain knowledge that applies to any Rust repo mocking an HTTP API.

The project-specific distillation landed as a repo rule in truenas-ai-sentinel; this skill carries the generalized patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CohRpmxsCZR65m31hrk7T9