### PR TITLE
feat(agent-patterns-plugin): deepen mcp-server-authoring's build path

### DIFF
--- a/agent-patterns-plugin/README.md
+++ b/agent-patterns-plugin/README.md
@@ -112,7 +112,7 @@ Design and scaffold the MCP code execution pattern for agent systems.
 - Security checklist for sandboxed execution environments
 
 #### `mcp-server-authoring`
-Producer-side patterns for **building** a Python MCP server with FastMCP — the shared conventions behind `kicad-mcp`, `silverbucket-mcp`, and `pal-mcp-server`.
+Producer-side patterns for **building** a Python MCP server with FastMCP — an ordered, reasoned build path (scaffold → tools → resources → tests → release) for any server you own.
 
 **When to use:**
 - Building or scaffolding a new MCP server
@@ -123,7 +123,7 @@ Producer-side patterns for **building** a Python MCP server with FastMCP — the
 **Features:**
 - FastMCP server skeleton (SDK-bundled and standalone `fastmcp`)
 - Tool / resource / prompt decorators with type-hint-driven schemas
-- Portfolio toolchain conventions (uv, ruff, pytest, release-please)
+- Toolchain wiring (uv, ruff, pytest, release-please) with the reasoning at each step
 - TDD pattern testing the underlying function, not the decorator
 
 #### `agent-teams`

--- a/agent-patterns-plugin/skills/mcp-server-authoring/REFERENCE.md
+++ b/agent-patterns-plugin/skills/mcp-server-authoring/REFERENCE.md
@@ -1,0 +1,96 @@
+# MCP Server Authoring — Reference
+
+Deeper reference for the ordered build path in [SKILL.md](SKILL.md). Loaded on
+demand; the SKILL body holds the procedure and the *why*.
+
+## Primitives in full
+
+| Primitive | Decorator | Use for | Notes |
+|-----------|-----------|---------|-------|
+| **Tool** | `@mcp.tool()` | Actions with side effects / computation the model invokes | Type hints define the input schema; the docstring is the description the model reads |
+| **Resource** | `@mcp.resource("scheme://{id}")` | Read-only data the client can fetch by URI | Path params map to function args; the URI template is the addressing scheme |
+| **Prompt** | `@mcp.prompt()` | Reusable prompt templates the client can surface | Returns a string or a list of messages |
+
+Design rules that apply to every primitive:
+
+- **Type hints are the contract.** Annotate every parameter and the return — the
+  SDK derives the JSON schema from them. Prefer precise types (`Literal`, enums,
+  `pydantic` models) over bare `dict`/`Any`.
+- **Docstrings are user-facing.** The first line becomes the description the model
+  selects on; write it as intent, not implementation.
+- **Fail loudly.** Raise on bad input; let the SDK surface the error rather than
+  returning a sentinel the model has to interpret.
+
+## Standalone vs bundled FastMCP
+
+| Package | Import | When |
+|---------|--------|------|
+| Official SDK (`mcp[cli]`) | `from mcp.server.fastmcp import FastMCP` | Default — bundled inspector (`mcp dev`), one dependency |
+| Standalone (`fastmcp`) | `from fastmcp import FastMCP` | When you need a standalone-only feature |
+
+Both expose the same high-level decorator API (`@mcp.tool()`, `@mcp.resource()`,
+`@mcp.prompt()`, `mcp.run()`). Pin one in `pyproject.toml` so the import path is
+stable; mixing them in one project is a source of confusing import errors.
+
+## Transport & registration
+
+| Transport | When | Run | Notes |
+|-----------|------|-----|-------|
+| **stdio** | Local servers the client launches as a subprocess | `mcp.run()` / `mcp.run(transport="stdio")` | No network, no auth, no port; the client owns the lifecycle |
+| **streamable-http** | Remote / shared servers over HTTP | `mcp.run(transport="streamable-http")` | Pulls in auth, a bound port, and deployment; use only when the server must be shared |
+
+Consumer-side registration of a stdio server (`.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "my-server": {
+      "command": "uvx",
+      "args": ["my-server"],
+      "env": { "MY_API_TOKEN": "${MY_API_TOKEN}" }
+    }
+  }
+}
+```
+
+Reference secrets with `${VAR}` env indirection — never hardcode them. The
+consumer side is covered by `agent-patterns-plugin:mcp-management`.
+
+## Toolchain rationale
+
+A common, well-supported Python toolchain for a server:
+
+| Concern | Tool | Command | Why |
+|---------|------|---------|-----|
+| Deps / venv | `uv` + `pyproject.toml` + `uv.lock` | `uv sync --group dev` | Reproducible, fast; lockfile pins the exact tree |
+| Lint + format | `ruff` | `uv run ruff check . && uv run ruff format .` | One tool for both, fast enough for pre-commit |
+| Type check | `ty` (or `mypy`) | `uv run ty check .` | Type hints are already the tool schema — check them |
+| Tests | `pytest` | `uv run pytest -m "not integration"` | Marker split keeps the fast gate deterministic |
+| Release | release-please | automated on push to `main` | Conventional commits drive version + changelog |
+
+**Integration marker convention**: tests that hit a live backend (a real API, a
+database, a local model) are marked `integration` and excluded from the fast
+quality gate so the inner loop stays deterministic. Run them explicitly with
+`uv run pytest -m integration` in CI or before a release.
+
+## Inspecting a server
+
+```bash
+uv run mcp dev src/my_server/__init__.py   # launch the SDK inspector UI
+```
+
+The inspector lists every registered tool/resource/prompt with its derived
+schema, so you can confirm the model sees what you intended before wiring the
+server into a client. A tool that shows an empty input schema in the inspector is
+the signature of a missing type annotation.
+
+## Packaging & distribution
+
+- The `uv init --package` layout produces a `[project.scripts]` console-script
+  entrypoint. Keep `main()` as the entrypoint target so `uvx <server>` and the
+  `.mcp.json` `command` resolve the same way.
+- Publish to PyPI (or an index) if the server is meant to be installed by name;
+  otherwise a `uvx --from git+https://... my-server` reference works for a
+  git-hosted server.
+- Ship a `README.md` documenting the required env vars and the `.mcp.json`
+  snippet a consumer pastes — that snippet is the server's real public API.

--- a/agent-patterns-plugin/skills/mcp-server-authoring/SKILL.md
+++ b/agent-patterns-plugin/skills/mcp-server-authoring/SKILL.md
@@ -4,16 +4,15 @@ description: FastMCP authoring for Python MCP servers — tools, resources, prom
 user-invocable: false
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(uv *), Bash(pytest *)
 created: 2026-06-17
-modified: 2026-06-17
-reviewed: 2026-06-17
+modified: 2026-07-04
+reviewed: 2026-07-04
 ---
 
 # MCP Server Authoring
 
 Producer-side patterns for **building** a Python Model Context Protocol server
-with the official SDK's `FastMCP` (or the standalone `fastmcp` package). The
-shared conventions behind the portfolio's MCP servers — `kicad-mcp`,
-`silverbucket-mcp`, `pal-mcp-server` (and the FVH sibling `podio-mcp`).
+with the official SDK's `FastMCP` (or the standalone `fastmcp` package). Applies
+to any Python MCP server you own — the guidance is portfolio-independent.
 
 For *consuming* / installing servers into a project, this is the wrong skill —
 see the table below.
@@ -27,93 +26,160 @@ see the table below.
 | Wiring a server's tests, lint, release-please | An agent calls 50+ MCP tools and needs the code-execution pattern → `agent-patterns-plugin:mcp-code-execution` |
 | Choosing transport (stdio vs HTTP) for a server you own | Managing OAuth for a remote server you consume → `mcp-management` |
 
-## Server skeleton (FastMCP)
+## The Build Path
 
-`FastMCP` is bundled in the official `mcp` SDK; the standalone `fastmcp` package
-(used by `kicad-mcp`) exposes the same high-level API.
+Build a server in this order. Each step's *why* is the load-bearing part — it is
+what lets you generalize past the example.
+
+### Step 1 — Scaffold the project
+
+```bash
+uv init --package my-server && cd my-server
+uv add "mcp[cli]"          # bundled SDK; or `uv add fastmcp` for the standalone package
+uv add --group dev pytest ruff ty
+```
+
+**Why `uv init --package`**: it lays down a `src/` package + `pyproject.toml`
+with a console-script entrypoint, so the server installs as a real command
+(`uvx my-server`) rather than a loose script. That is what a consumer's
+`.mcp.json` will invoke.
+
+**Why one dependency choice up front**: `FastMCP` ships two ways — bundled in the
+official `mcp` SDK (`from mcp.server.fastmcp import FastMCP`) and as the
+standalone `fastmcp` package (`from fastmcp import FastMCP`). They expose the
+same high-level decorator API; pick one and pin it in `pyproject.toml` so the
+import path is stable. Prefer the bundled SDK unless you need a standalone-only
+feature.
+
+### Step 2 — Write the entrypoint as a thin shim
 
 ```python
-# from the bundled SDK (pal-mcp-server, silverbucket-mcp pin `mcp>=1.0`)
+# src/my_server/__init__.py
 from mcp.server.fastmcp import FastMCP
-# kicad-mcp pins the standalone package: from fastmcp import FastMCP
 
-mcp = FastMCP("silverbucket")  # server name surfaced to the client
-
-
-@mcp.tool()
-def list_projects(active_only: bool = True) -> list[dict]:
-    """List Silverbucket projects. Docstring becomes the tool description."""
-    return _client.projects(active_only=active_only)
+mcp = FastMCP("my-server")  # the name surfaced to the client
 
 
-if __name__ == "__main__":
+def main() -> None:
     mcp.run()  # defaults to stdio transport
 ```
 
-Keep the entrypoint a thin shim: `FastMCP` instance + decorated functions +
-`mcp.run()`. Business logic lives in plain, separately-tested modules the tools
-call — the decorators are the MCP boundary, not where logic accretes.
+**Why a thin shim**: the `FastMCP` instance + `mcp.run()` is the MCP *boundary*,
+not where logic lives. Keep business logic in plain, separately-tested modules
+the tools call. Decorators that accrete logic become untestable — you end up
+needing a live MCP client to exercise a pure computation.
 
-## Tools, resources, prompts
+### Step 3 — Add a tool
 
-| Primitive | Decorator | Use for | Notes |
-|-----------|-----------|---------|-------|
-| **Tool** | `@mcp.tool()` | Actions with side effects / computation the model invokes | Type hints define the input schema; the docstring is the description the model reads |
-| **Resource** | `@mcp.resource("scheme://{id}")` | Read-only data the client can fetch by URI | Path params map to function args |
-| **Prompt** | `@mcp.prompt()` | Reusable prompt templates the client can surface | Returns a string or message list |
+A tool is an action or computation the model invokes. Write it as a typed,
+docstringed plain function, then decorate it:
 
-- **Type hints are the contract.** Annotate every parameter and the return — the
-  SDK derives the JSON schema from them. Prefer precise types (`Literal`, enums,
-  `pydantic` models) over bare `dict`/`Any`.
-- **Docstrings are user-facing.** The first line becomes the tool description the
-  model selects on; write it as intent, not implementation.
-- **Fail loudly.** Raise on bad input; let the SDK surface the error rather than
-  returning a sentinel the model has to interpret.
+```python
+from my_server.catalog import list_items  # plain, tested module
 
-## Transport & registration
+@mcp.tool()
+def list_catalog(active_only: bool = True) -> list[dict]:
+    """List catalog items. The first docstring line becomes the tool description."""
+    return list_items(active_only=active_only)
+```
 
-| Transport | When | Run |
-|-----------|------|-----|
-| **stdio** | Local servers launched by the client (the default for all portfolio servers) | `mcp.run()` or `mcp.run(transport="stdio")` |
-| **HTTP / SSE** | Remote / shared servers | `mcp.run(transport="streamable-http")` |
+**Why type hints are the contract**: the SDK derives the tool's JSON input schema
+from the annotations. Precise types (`Literal`, enums, `pydantic` models) give the
+model a schema it can fill correctly; a bare `dict`/`Any` gives it nothing to
+validate against.
 
-Consumers register a stdio server in `.mcp.json` with `command` + `args` and
-`${VAR}` env references (never hardcoded secrets) — see `mcp-management` for the
-consumer side.
+**Why the docstring is user-facing**: the first line becomes the description the
+model reads when *selecting* the tool. Write it as intent ("List catalog items"),
+not implementation.
 
-## Portfolio conventions
+**Why you fail loudly**: raise on bad input and let the SDK surface the error.
+Returning a sentinel (`None`, `{"error": ...}`) forces the model to interpret an
+ad-hoc convention instead of seeing a clean error.
 
-Every MCP server here follows the same toolchain (matches `pal-mcp-server`'s
-`CLAUDE.md` and the repo standards):
+### Step 4 — Add resources and prompts (when they fit)
+
+| Primitive | Decorator | Use for |
+|-----------|-----------|---------|
+| **Resource** | `@mcp.resource("scheme://{id}")` | Read-only data the client fetches by URI; path params map to function args |
+| **Prompt** | `@mcp.prompt()` | Reusable prompt templates the client surfaces; returns a string or message list |
+
+```python
+@mcp.resource("item://{item_id}")
+def get_item(item_id: str) -> dict:
+    """Fetch one catalog item by id."""
+    return load_item(item_id)
+```
+
+**Why the split matters**: a *tool* is a verb the model calls to act; a *resource*
+is a noun the client reads by URI without model action. Modeling read-only data as
+a resource keeps it out of the tool-selection surface, so the model isn't offered a
+"tool" whose only job is to fetch. See `REFERENCE.md` for the full primitive table.
+
+### Step 5 — Test the function, not the decorator (TDD)
+
+RED → GREEN → REFACTOR against the underlying function:
+
+```python
+# tests/test_catalog.py
+def test_list_catalog_filters_inactive(fake_store):
+    fake_store.seed([{"id": 1, "active": True}, {"id": 2, "active": False}])
+    assert [i["id"] for i in list_items(active_only=True)] == [1]
+```
+
+1. Write the failing test against the plain function.
+2. Implement the minimum logic; decorate it with `@mcp.tool()`.
+3. Refactor while green.
+
+**Why test the plain function**: the decorator is a thin registration wrapper —
+exercising it needs a live MCP session and tests the SDK, not your logic. Testing
+the underlying function is fast and deterministic. Reserve a single
+`integration`-marked end-to-end test for the live-backend path (a real API,
+Ollama, a database), and exclude it from the fast quality gate.
+
+### Step 6 — Wire lint, types, and release
 
 | Concern | Tool | Command |
 |---------|------|---------|
 | Deps / venv | `uv` + `pyproject.toml` + `uv.lock` | `uv sync --group dev` |
 | Lint + format | `ruff` | `uv run ruff check . && uv run ruff format .` |
-| Type check | `ty` / `mypy` | `uv run ty check .` |
+| Type check | `ty` (or `mypy`) | `uv run ty check .` |
 | Tests | `pytest` | `uv run pytest -m "not integration"` |
 | Release | release-please (conventional commits) | automated on push to `main` |
 
-- **Conventional commits** drive release-please — `feat:` minor, `fix:` patch,
-  `feat!:` major. Don't hand-edit `CHANGELOG.md` or the `version` field.
-- **Integration tests that hit a live backend** (Ollama, a real API) are marked
-  `integration` and excluded from the fast quality gate.
+**Why conventional commits**: they drive release-please's version bumps —
+`feat:` minor, `fix:` patch, `feat!:` major. Hand-editing `CHANGELOG.md` or the
+`version` field fights the automation; let the commit history be the source of
+truth.
 
-## TDD for a new tool
+### Step 7 — Choose transport before you ship
 
-RED → GREEN → REFACTOR, testing the underlying function, not the decorator:
+| Transport | When | Run |
+|-----------|------|-----|
+| **stdio** | Local servers the client launches as a subprocess | `mcp.run()` or `mcp.run(transport="stdio")` |
+| **HTTP** | Remote / shared servers reachable over the network | `mcp.run(transport="streamable-http")` |
 
-```python
-# tests/test_projects.py
-def test_list_projects_filters_inactive(fake_client):
-    fake_client.seed([{"id": 1, "active": True}, {"id": 2, "active": False}])
-    assert [p["id"] for p in list_projects(active_only=True)] == [1]
-```
+**Why stdio is the default**: a locally-launched server needs no network, no auth,
+and no port — the client owns its lifecycle over stdin/stdout. Reach for HTTP only
+when the server must be *shared* (multiple clients, a remote host), which then pulls
+in auth and deployment concerns stdio avoids. Consumers register a stdio server in
+`.mcp.json` with `command` + `args` and `${VAR}` env references (never hardcoded
+secrets) — see `mcp-management` for the consumer side.
 
-1. Write the failing test against the plain function.
-2. Implement the minimum logic; decorate it with `@mcp.tool()`.
-3. Refactor; keep the suite green. Add an `integration`-marked end-to-end test
-   only for the live-backend path.
+## Shipping Checklist
+
+Before a server is done, confirm each — the failure mode after each is what it
+guards against:
+
+- [ ] Entrypoint is a console script (`uvx <server>` runs it) — else a consumer's `.mcp.json` can't launch it.
+- [ ] Every tool parameter and return is type-annotated — else the model gets an empty input schema.
+- [ ] Every tool's first docstring line reads as intent — else tool selection degrades.
+- [ ] Tools raise on bad input (no sentinel returns) — else errors reach the model as ambiguous data.
+- [ ] Unit tests cover the plain functions; the live-backend path is a single `integration`-marked test — else the fast gate is slow and flaky.
+- [ ] `uv run ruff check . && uv run pytest -m "not integration"` is green — the fast quality gate.
+- [ ] Transport chosen deliberately (stdio unless the server must be shared).
+
+For the full primitive/transport reference, packaging, and the SDK inspector, see
+[REFERENCE.md](REFERENCE.md).
 
 ## Agentic Optimizations
 


### PR DESCRIPTION
## What

Reworks `mcp-server-authoring` into an **ordered, reasoned build path** — scaffold → entrypoint shim → tool → resources/prompts → TDD → lint/release → transport — with the *why* foregrounded at each step, plus a shipping checklist that names the failure mode each item guards against.

## Why

The 2026-07 mcp-dev benchmark (PR #1917) went 2-3-1 to the official `mcp-server-dev`; our trio held context economy and won permissions but lost B1/B2/B6 — judges found the instructions shallower and partly portfolio-bound. The winning shape is a phased procedure with pervasive reasoning and failure paths everywhere. This closes that instructional-depth gap while keeping the lean SKILL/REFERENCE split the B3 tie valued.

## How

- **Deepen**: each build step now carries runnable commands + one or two sentences of reasoning (why a thin shim, why type hints are the contract, why test the plain function not the decorator, why stdio is the default). Added a shipping checklist with per-item failure modes.
- **De-bind from the portfolio**: removed the hardcoded server names (`kicad-mcp`, `silverbucket-mcp`, `pal-mcp-server`, `podio-mcp`), the "default for all portfolio servers" phrasing, and the "matches pal-mcp-server's CLAUDE.md" note — replaced with server-agnostic guidance. Kept the real standalone-vs-bundled FastMCP distinction, framed generically.
- **Keep it lean**: extracted the fuller primitive/transport/packaging/inspector reference into a new `REFERENCE.md`; SKILL body is 9.5KB (under the 10KB WARN band). Required sections (When-to-Use, Agentic Optimizations, Quick Reference) intact; dates bumped.
- **docs-currency**: README description + features bullet updated in the same commit.

Evidence: `docs/benchmarks/2026-07-marketplace-quality/judgments/mcp-dev_j{1,2}.json`.

## Checks

`scripts/plugin-compliance-check.sh agent-patterns-plugin` is all-green for the plugin (size WARNs shown are pre-existing, on unrelated skills); pre-commit hooks pass. Doc/enhancement edit with no hook/script bug, so no new regression guard per `.claude/rules/regression-testing.md`.

Closes #1922