### PR TITLE
docs(git-plugin): document grouped-PR title-pattern tagging wedge + recovery

### DIFF
--- a/git-plugin/skills/release-please-configuration/SKILL.md
+++ b/git-plugin/skills/release-please-configuration/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-28
-modified: 2026-05-29
-reviewed: 2026-05-29
+modified: 2026-07-04
+reviewed: 2026-07-04
 name: release-please-configuration
 description: "release-please monorepo config — component tags, per-package extra-files, tag migration. Use when adding packages or fixing duplicate-tag / no-bump failures."
 user-invocable: false
@@ -111,6 +111,71 @@ plugin:
 **Cause:** Empty `component` field (the `:` with nothing after it indicates empty string)
 
 **Fix:** Ensure every package has `"component": "package-name"` set
+
+### Common Failure: Merged Release PR Never Tagged
+
+**Symptom:** Every run after a grouped release PR merges aborts with:
+
+```
+There are untagged, merged release PRs outstanding - aborting
+```
+
+The workflow log also carries the tell:
+
+```
+pullRequestTitlePattern miss the part of '${component}'
+pullRequestTitlePattern miss the part of '${scope}'
+```
+
+**Cause:** A custom `pull-request-title-pattern` (or `group-pull-request-title-pattern`)
+containing `${version}` — or `${component}` / `${scope}` — on a **grouped** release
+PR (`separate-pull-requests: false`). Because a grouped PR spans many packages, there
+is no single version/component to substitute, so the pattern renders a **bare** title
+(e.g. `chore: release` with nothing after it). On the tagging pass release-please
+re-parses the merged PR's title back through that same pattern to recover which
+releases it represents; the bare title no longer matches the pattern, so the PR is
+never tagged. It stays `autorelease: pending`, and every subsequent run refuses to
+proceed while an untagged merged release PR is outstanding.
+
+**Fix:** Drop the custom title patterns. The release-please **defaults** round-trip
+correctly for grouped PRs — they render a parseable title and the tagging pass
+recovers the releases from it.
+
+```json
+// WRONG - ${version} on a grouped PR renders a bare, unparseable title
+{
+  "separate-pull-requests": false,
+  "pull-request-title-pattern": "chore: release ${version}"
+}
+
+// CORRECT - omit the custom pattern; the default round-trips
+{
+  "separate-pull-requests": false
+}
+```
+
+### Recovery: Unwedge an Already-Merged Untagged PR
+
+Once a grouped release PR has merged with a bare title, dropping the config fixes
+future runs but the **already-merged** PR is still stuck at `autorelease: pending`,
+so runs keep aborting. Relabel it to `autorelease: tagged` so release-please stops
+treating it as outstanding, then dispatch a fresh run to cut the releases:
+
+```bash
+# Create the label first if the repo lacks it — release-please only
+# auto-creates `autorelease: tagged` when it successfully tags a PR.
+gh label create "autorelease: tagged" --color 2A7A2A --description "release-please tagged"
+
+# Relabel the stuck merged PR
+gh pr edit $PR_NUMBER --add-label "autorelease: tagged" --remove-label "autorelease: pending"
+
+# Dispatch a fresh run — with no tags cut, it recomputes the same releases
+# into a new, parseable release PR (or tags directly on the next merge).
+gh workflow run release-please.yml
+```
+
+No tags were cut for the wedged PR, so release-please recomputes the identical set
+of releases on the next run; the relabel only removes the "outstanding" blocker.
 
 ## Per-Package `extra-files` for Custom Version Locations
 

--- a/git-plugin/skills/release-please-configuration/scripts/tests/test-grouped-pr-tagging-wedge.sh
+++ b/git-plugin/skills/release-please-configuration/scripts/tests/test-grouped-pr-tagging-wedge.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Regression guard: the grouped-PR title-pattern tagging wedge + relabel
+# recovery must survive future bulk edits of the SKILL.md body.
+#
+# Issue #1911: with `separate-pull-requests: false`, a custom
+# `pull-request-title-pattern` containing `${version}` renders a bare, un-parseable
+# grouped release-PR title, so release-please never tags the merged PR and every
+# subsequent run aborts with "untagged, merged release PRs outstanding". The fix
+# documents both the failure (drop the custom pattern) and the recovery (relabel
+# `autorelease: pending` -> `autorelease: tagged`, then dispatch a fresh run).
+#
+# This asserts the load-bearing tokens remain so a "tightening" pass can't
+# silently drop the entry (co-located per the collision-avoidance rule — the
+# guard lives here, not in the shared plugin-compliance-check.sh).
+#
+# Run: bash git-plugin/skills/release-please-configuration/scripts/tests/test-grouped-pr-tagging-wedge.sh
+# Exit 0 = all pass, Exit 1 = a required token is missing.
+set -uo pipefail
+
+SKILL="$(cd "$(dirname "$0")/../.." && pwd)/SKILL.md"
+PASS=0
+FAIL=0
+
+if [ ! -f "$SKILL" ]; then
+  echo "FAIL: SKILL.md not found at $SKILL" >&2
+  exit 1
+fi
+
+assert_contains() {
+  local label="$1" needle="$2"
+  if grep -qF -- "$needle" "$SKILL"; then
+    echo "PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $label — missing '$needle'" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# The failure symptom (the abort message that identifies the wedge)
+assert_contains "abort-symptom" "untagged, merged release PRs outstanding"
+# The log tell that pins the diagnosis to the title pattern
+assert_contains "log-tell" 'pullRequestTitlePattern miss the part'
+# The root-cause knob
+assert_contains "title-pattern-cause" "pull-request-title-pattern"
+# The recovery labels (both source and target)
+assert_contains "recovery-target-label" "autorelease: tagged"
+assert_contains "recovery-source-label" "autorelease: pending"
+
+echo "---"
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Documents a release-please monorepo failure mode the `git-plugin:release-please-configuration` skill did not cover (cost an extra diagnosis loop in a real 18-package tagging failure).

Adds two subsections to the skill:

1. **Common Failure: Merged Release PR Never Tagged** — with `separate-pull-requests: false`, a custom `pull-request-title-pattern`/`group-pull-request-title-pattern` containing `${version}` (or `${component}`/`${scope}`) renders a **bare** grouped-PR title. Release-please re-parses the merged PR title on the tagging pass, fails to match the pattern, never tags the PR, and every subsequent run aborts with `There are untagged, merged release PRs outstanding - aborting`. Log tell: `pullRequestTitlePattern miss the part of '${component}'`. Fix: drop the custom patterns — the defaults round-trip.

2. **Recovery: Unwedge an Already-Merged Untagged PR** — relabel the stuck merged PR `autorelease: pending` → `autorelease: tagged` (create the label first; release-please only auto-creates it on a successful tag), then `gh workflow run release-please.yml`. With no tags cut, it recomputes the same releases into a new, parseable PR.

Bumps `modified:`/`reviewed:` to 2026-07-04.

## Regression guard

Per the parallel-PR collision-avoidance rule, the semantic guard lives in a **co-located** test (`scripts/tests/test-grouped-pr-tagging-wedge.sh`), not the shared `plugin-compliance-check.sh`. It asserts the load-bearing tokens (abort symptom, log tell, `pull-request-title-pattern`, and both recovery labels) survive future bulk edits. Auto-discovered by `just test-skill-scripts`.

## Checks

- `just lint-compliance` — exit 0 (git-plugin Body ✅; pre-existing WARN on Size/Descriptions unchanged)
- `just lint-shell` on the new test — 0 errors/warnings
- `just lint-context-commands` — OK
- Co-located test — 5/5 pass

Closes #1911