### PR TITLE
refactor(configure-plugin): rebuild configure-security along security-guidance's shape

### DIFF
--- a/configure-plugin/skills/configure-security/REFERENCE.md
+++ b/configure-plugin/skills/configure-security/REFERENCE.md
@@ -1,5 +1,20 @@
 # configure-security Reference
 
+## Standards Tracking (`.project-standards.yaml`)
+
+Record the configured security components so `/configure:status` and
+`/configure:all` can track coverage:
+
+```yaml
+components:
+  security: "2025.1"
+  security_dependency_audit: true
+  security_sast: true
+  security_secret_detection: true
+  security_policy: true
+  security_dependabot: true
+```
+
 ## Compliance Report Format
 
 ```

--- a/configure-plugin/skills/configure-security/SKILL.md
+++ b/configure-plugin/skills/configure-security/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-16
-modified: 2026-06-18
-reviewed: 2026-06-10
+modified: 2026-07-04
+reviewed: 2026-07-04
 description: "Security scanning: dependency audits, SAST, secrets detection. Use when setting up Dependabot, CodeQL, or TruffleHog in CI, or creating a SECURITY.md policy."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix] [--type <dependencies|sast|secrets|all>]"
@@ -26,12 +26,13 @@ Check and configure security scanning tools for dependency audits, SAST, and sec
 ## Context
 
 - Package files: !`find . -maxdepth 1 \( -name 'package.json' -o -name 'pyproject.toml' -o -name 'Cargo.toml' -o -name 'go.mod' \)`
-- Gitleaks config: !`find . -maxdepth 1 -name \'.gitleaks.toml\'`
-- Pre-commit config: !`find . -maxdepth 1 -name \'.pre-commit-config.yaml\'`
-- Workflows dir: !`find . -maxdepth 1 -type d -name \'.github/workflows\'`
-- Dependabot config: !`find . -maxdepth 1 -name \'.github/dependabot.yml\'`
-- CodeQL workflow: !`find . -path '*/.github/workflows/*' -maxdepth 3 -name 'codeql*'`
-- Security policy: !`find . -maxdepth 1 -name \'SECURITY.md\'`
+- Gitleaks config: !`find . -maxdepth 1 -name '.gitleaks.toml'`
+- Pre-commit config: !`find . -maxdepth 1 -name '.pre-commit-config.yaml'`
+- Workflows dir: !`find . -maxdepth 2 -type d -path '*/.github/workflows'`
+- Dependabot config: !`find . -maxdepth 2 -path '*/.github/dependabot.yml'`
+- CodeQL workflow: !`find . -maxdepth 3 -path '*/.github/workflows/codeql*'`
+- Security policy: !`find . -maxdepth 1 -name 'SECURITY.md'`
+
 **Security scanning layers:**
 1. **Dependency auditing** - Check for known vulnerabilities in dependencies
 2. **SAST (Static Application Security Testing)** - Analyze code for security issues
@@ -124,14 +125,9 @@ For gitleaks, TruffleHog, and CI workflow configuration templates, see [REFERENC
 
 ### Step 7: Create security policy
 
-Create `SECURITY.md` with:
-- Supported versions table
-- Vulnerability reporting process (email, expected response time, disclosure policy)
-- Information to include in reports
-- Security best practices for users and contributors
-- Automated security tools list
-
-For the SECURITY.md template, see [REFERENCE.md](REFERENCE.md).
+Create `SECURITY.md` from the template (supported-versions table, vulnerability
+reporting process, report contents, best practices, automated-tools list) in
+[REFERENCE.md](REFERENCE.md).
 
 ### Step 8: Configure CI/CD integration
 
@@ -146,17 +142,8 @@ For the CI security workflow template, see [REFERENCE.md](REFERENCE.md).
 
 ### Step 9: Update standards tracking
 
-Update `.project-standards.yaml`:
-
-```yaml
-components:
-  security: "2025.1"
-  security_dependency_audit: true
-  security_sast: true
-  security_secret_detection: true
-  security_policy: true
-  security_dependabot: true
-```
+Update `.project-standards.yaml` with the `security` component keys. For the
+exact block, see [REFERENCE.md](REFERENCE.md).
 
 ### Step 10: Report configuration results
 
@@ -174,14 +161,6 @@ For the results report format, see [REFERENCE.md](REFERENCE.md).
 | Secret detection only | `/configure:security --type secrets` |
 | SAST scanning only | `/configure:security --type sast` |
 | Verify secrets scan | `gitleaks detect --source . --verbose` |
-
-## Flags
-
-| Flag | Description |
-|------|-------------|
-| `--check-only` | Report status without offering fixes |
-| `--fix` | Apply all fixes automatically without prompting |
-| `--type <type>` | Focus on specific security type (dependencies, sast, secrets, all) |
 
 ## Error Handling
 

--- a/configure-plugin/skills/configure-security/scripts/tests/test-configure-security.sh
+++ b/configure-plugin/skills/configure-security/scripts/tests/test-configure-security.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2016  # grep/sed patterns contain literal backticks/$, not expansions
 # Regression test for configure-security.sh detection.
 # A planted fixture WITH Dependabot + CodeQL + gitleaks + SECURITY.md must report
 # all four present; a bare fixture must report them missing with STATUS=WARN.
@@ -54,5 +55,64 @@ echo "$out2" | grep -q "^STATUS=WARN$" || fail "expected STATUS=WARN for bare pr
 echo "$out2" | grep -q "^ISSUE_COUNT=4$" || fail "expected ISSUE_COUNT=4 for bare project:\n$out2"
 pass "bare project reports all security layers missing and STATUS=WARN"
 rm -rf "$bare"
+
+# -----------------------------------------------------------------------------
+# Case 3: SKILL.md `## Context` find commands must actually DETECT present files
+#   (Regression, issue #1919): the commands shipped escaped single quotes
+#   (`-name \'.gitleaks.toml\'`) that make find match a literal quoted filename
+#   → always report MISSING even when the file exists, plus slash-in-`-name`
+#   (never matches basename) and `-maxdepth` after `-path` (GNU find warns to
+#   stderr → aborts the skill). This case extracts each Context find command
+#   from SKILL.md, runs it against a fully-configured fixture, and asserts:
+#     (a) exit 0 with EMPTY stderr (no abort), and
+#     (b) NON-EMPTY output (the file is actually detected).
+#   The escaped-quote / slash-in-name forms fail (b); the maxdepth-after-path
+#   form fails (a) on GNU find. Also asserts the antipattern shapes are absent.
+# -----------------------------------------------------------------------------
+skill_md="${script_dir}/../../SKILL.md"
+[ -f "$skill_md" ] || fail "SKILL.md not found at $skill_md"
+
+# Antipattern greps over Context command lines (`^- Label: !`...``). Patterns are
+# grep regexes containing literal backticks — SC2016 does not apply.
+# Escaped single quotes (\'): match a literal quoted filename → always MISSING.
+grep -nE "^- .*!\`[^\`]*\\\\'" "$skill_md" \
+  && fail "SKILL.md Context command contains an escaped single quote (\\') — matches a literal quoted filename"
+# Slash inside a -name argument: -name matches the basename only, so it never matches.
+grep -nE "^- .*!\`[^\`]*-name '[^']*/" "$skill_md" \
+  && fail "SKILL.md Context command uses a slash inside -name (never matches a basename)"
+# -maxdepth appearing AFTER -path on one command: GNU find warns to stderr → aborts the skill.
+grep -nE "^- .*!\`[^\`]*-path[^\`]*-maxdepth" "$skill_md" \
+  && fail "SKILL.md Context command places -maxdepth after -path (GNU find warns to stderr, aborting the skill)"
+
+# Fully-configured fixture — every file the Context commands probe for is present.
+ctx="$(mktemp -d)"
+mkdir -p "${ctx}/.github/workflows"
+printf '{}' > "${ctx}/package.json"
+printf 'version: 2\n' > "${ctx}/.github/dependabot.yml"
+printf 'name: CodeQL\n' > "${ctx}/.github/workflows/codeql.yml"
+printf '[allowlist]\n' > "${ctx}/.gitleaks.toml"
+printf 'repos: []\n' > "${ctx}/.pre-commit-config.yaml"
+printf '# Security Policy\n' > "${ctx}/SECURITY.md"
+
+# Extract each `- Label: !`<cmd>`` Context find command and execute it in the fixture.
+ctx_cmds="$(grep -oE '^- [^:]*: !`find[^`]*`' "$skill_md" | sed -E 's/^- [^:]*: !`//; s/`$//')"
+[ -n "$ctx_cmds" ] || fail "no Context find commands extracted from SKILL.md"
+
+ctx_count=0
+while IFS= read -r ctx_cmd; do
+  [ -n "$ctx_cmd" ] || continue
+  ctx_count=$((ctx_count + 1))
+  ctx_err="$(mktemp)"
+  ctx_out="$(cd "$ctx" && eval "$ctx_cmd" 2>"$ctx_err")"
+  ctx_rc=$?
+  [ "$ctx_rc" -eq 0 ] || fail "Context command exited non-zero ($ctx_rc): $ctx_cmd"
+  [ -s "$ctx_err" ] && fail "Context command wrote to stderr [$(cat "$ctx_err")]: $ctx_cmd"
+  [ -n "$ctx_out" ] || fail "Context command detected nothing in a fully-configured project: $ctx_cmd"
+  rm -f "$ctx_err"
+done <<< "$ctx_cmds"
+
+[ "$ctx_count" -ge 6 ] || fail "expected >=6 Context find commands, extracted $ctx_count"
+pass "all $ctx_count SKILL.md Context find commands detect present files (exit 0, no stderr, non-empty)"
+rm -rf "$ctx"
 
 echo "ALL TESTS PASSED"


### PR DESCRIPTION
## What

Rebuilds `configure-plugin/skills/configure-security` toward the `security-guidance` benchmark shape (issue from the 0-5-1 blind-judge signal in PR #1917), fixing the three concrete judge-cited defects on our side.

## Defects fixed

1. **Broken dynamic-context commands.** Four `## Context` find commands shipped escaped single quotes (`-name \'.gitleaks.toml\'`), which make `find` match a *literal quoted filename* — so the file is always reported MISSING even when it exists. Two more used a slash inside `-name` (matches basename only → never hits), and one placed `-maxdepth` after `-path` (GNU `find` warns to stderr, aborting the skill). Rewritten to the repo-standard `find . -path '*/<dir>/*'` idiom with `-maxdepth` first. All seven commands now detect present files (exit 0, empty stderr) and pass the semantic backstop (`check-context-command-execution.sh --strict`: 7 PASS / 0 FAIL).
2. **In-file duplication.** The three flags (`--check-only`/`--fix`/`--type`) were restated in Parameters, Agentic Optimizations, and a redundant Flags table. Dropped the Flags table — Parameters is canonical; Agentic Optimizations keeps commands (not a flag re-list).
3. **Bloated always-loaded body.** Step 7 inlined the SECURITY.md contents and Step 9 inlined the standards YAML; both pushed to the already-referenced REFERENCE.md, keeping the steps to imperative one-liners. SKILL.md drops 8271 → 7754 chars.

Out of scope (deliberately, per the plan): the hook-based scan entry point / trust-model rebuild — a separate design decision, not this PR.

## Regression guard

Co-located `scripts/tests/test-configure-security.sh` gains a Case 3 (per `.claude/rules/regression-testing.md`) that:
- greps out the escaped-quote / slash-in-`-name` / `-maxdepth`-after-`-path` antipatterns on Context command lines, and
- **executes** every extracted Context `find` command against a fully-configured fixture, asserting each detects its file (exit 0, empty stderr, non-empty output).

Verified to **fail** on the pre-fix commands (empty output → MISSING) and **pass** on the fixed ones.

## Checks

- `just lint-shell` (test) — pass
- `just lint-context-commands` — pass
- `check-context-command-execution.sh --strict` (configure-security) — 7 PASS / 0 FAIL
- `just test-skill-scripts` (co-located test) — pass
- `just lint-compliance` — pass (exit 0, no errors)

Closes #1919