### PR TITLE
fix(hooks-plugin): fix two bash-antipatterns false-positives

### DIFF
--- a/.claude/rules/bash-tool-replacements.md
+++ b/.claude/rules/bash-tool-replacements.md
@@ -1,39 +1,45 @@
 # Bash → Tool Replacements
 
-Two search/list patterns in Bash — `grep`/`rg` and `cat`/`head`/`tail` — are
-blocked by the `bash-antipatterns` hook because dedicated Claude Code tools
-cover the same ground faster, with structured output, and without paying the
-parallel-batch cost.
+One list pattern in Bash — `cat`/`head`/`tail` — is blocked by the
+`bash-antipatterns` hook because the dedicated `Read` tool covers the same ground
+faster, with structured output, and without paying the parallel-batch cost.
 
 The hook is a soft-block (exit 2) — by the time you read this, you've probably
 already been blocked. Use this table to pick the right replacement.
 
-> **`find` is no longer blocked.** The `find→Glob` redirect was demoted from a
-> hard block to an **opt-in teach nudge** (`bash-antipatterns-teach.sh`, enabled
-> via `CLAUDE_HOOKS_ENABLE_BASH_ANTIPATTERNS_TEACH=1`). It never did safety work
-> — it always exempted the dangerous `-exec` form and only blocked simple `-name`
-> searches — and it hard-dead-ended subagents whose toolset doesn't grant Glob
-> (PreToolUse hooks fire in every context; Glob is not always available). `find`
-> in any form now passes. Glob is still the most *context-efficient* choice for a
-> broad `**/*.ext` sweep in the main session, and `fd` is the more ergonomic
-> shell alternative (`fd -e ts`, gitignore-aware by default) — prefer either over
-> a naive recursive `find` dump, but neither is enforced.
+> **`find` and `grep`/`rg` are no longer blocked.** Both redirects were demoted
+> from a hard block to an **opt-in teach nudge** (`bash-antipatterns-teach.sh`,
+> enabled via `CLAUDE_HOOKS_ENABLE_BASH_ANTIPATTERNS_TEACH=1`). Neither did safety
+> work: the `find→Glob` block always exempted the dangerous `-exec` form and only
+> blocked simple `-name` searches; the `grep/rg→Grep` block always exempted
+> pipelines, boolean `-q` checks, and `-l/-c/-L` filter modes, blocking only
+> benign line-numbered file reads. Both hard-dead-ended subagents whose toolset
+> doesn't grant `Glob`/`Grep` (PreToolUse hooks fire in every context; those tools
+> are not always available — #1909, where `ToolSearch(select:Grep)` returned "No
+> matching deferred tools found" and every blocked search cost a retry). `find`
+> and `grep`/`rg` in any form now pass. `Glob`/`Grep`/`fd` remain the most
+> *context-efficient* choices for a broad sweep in the main session — prefer them,
+> but neither is enforced.
 
 ## The replacement table
 
-| Wrong (Bash) | Right (tool) | When the Bash form is genuinely fine |
+Only the `cat`/`head`/`tail` rows are **blocked** (exit 2). The `grep`/`rg`/`find`
+rows are **nudges** — the Bash form runs; the tool is the more context-efficient
+choice when it's available in your session.
+
+| Bash | Preferred tool | Enforcement |
 |---|---|---|
-| `grep -rn 'foo' src/` | `Grep(pattern="foo", path="src", -r=true, -n=true)` | Piped into another command (`gh pr list \| rg 'foo'`), or you need `-q` for an exit-code boolean check |
-| `rg 'foo' --type ts` | `Grep(pattern="foo", glob="*.ts")` | Same exceptions as `grep` |
-| `cat /abs/path/file.md` | `Read(file_path="/abs/path/file.md")` | Piping a *here-doc* into a command — that's a `cat <<EOF` heredoc, not a file read |
-| `head -50 file.md` | `Read(file_path="/abs/path/file.md", limit=50)` | Inside a hook script where Bash is the only option |
-| `tail -50 file.md` | `Read(file_path=..., offset=<lines - 50>, limit=50)` | Same |
-| `ls -1 docs/` | `Glob(pattern="docs/*")` *or* `Bash("ls -1 docs/")` | `ls` is fine for directory listing — the hook only blocks `ls *.glob` patterns |
+| `grep -rn 'foo' src/` | `Grep(pattern="foo", path="src", -r=true, -n=true)` | Nudge (opt-in teach hook) — Bash form runs |
+| `rg 'foo' --type ts` | `Grep(pattern="foo", glob="*.ts")` | Nudge — same as `grep` |
+| `cat /abs/path/file.md` | `Read(file_path="/abs/path/file.md")` | **Blocked** — except a *here-doc* (`cat <<EOF`) or a pipeline (`cat file \| jq`) |
+| `head -50 file.md` | `Read(file_path="/abs/path/file.md", limit=50)` | **Blocked** — except in a pipeline, or inside a hook script |
+| `tail -50 file.md` | `Read(file_path=..., offset=<lines - 50>, limit=50)` | **Blocked** — same |
+| `ls -1 docs/` | `Glob(pattern="docs/*")` *or* `Bash("ls -1 docs/")` | Reminder only on `ls *.glob` patterns |
 
-The hook's allowed-exception logic for each:
+The hook's logic for each:
 
-- **`grep` / `rg`** — passes through any pipeline (anything with `|`), and `-q` / `--quiet` (boolean exit-code checks like `grep -q pattern file && do_thing`).
-- **`cat` / `head` / `tail`** — passes through when the file path is `/dev/stdin`, `/dev/null`, or a here-doc target. The hook is checking for *file reads*, not stream handling.
+- **`grep` / `rg`** — never blocked (demoted to the opt-in teach nudge, #1909/#1871). `Grep` is the context-efficient choice when present, but the Bash form always runs.
+- **`cat` / `head` / `tail`** — blocked for a plain file read; passes through when the file path is `/dev/stdin`, `/dev/null`, a here-doc target, or a pipeline. The hook is checking for *file reads*, not stream handling.
 
 ### Remote-exec commands are exempt (issue #1900)
 
@@ -60,33 +66,35 @@ Three signals from the W20 friction analysis (2026-05-11):
 | `grep` / `rg` vs `Grep` | 41 / 33 | 24% | **21%** |
 | `cat`/`head`/`tail` vs `Read` | 29 / 24 | 17% | low |
 
-The `grep` / `rg` 21% same-session repeat-block rate is the outlier:
-the hook is teaching less effectively for this pattern than for `find`
-or `git &&` (both at 8-12%). This rule fills the gap with the same
-explicit do/don't table style that worked for `find` in W16.
+The `grep` / `rg` 21% same-session repeat-block rate was the outlier — the
+hard block taught *less* effectively than it cost, and it dead-ended subagents
+lacking the `Grep` tool. That block has since been **demoted to the opt-in teach
+nudge** (#1909), following the same litigation as `find` (#1871): a block that
+exempts every dangerous form is doing style work, not safety work, and style
+wants a nudge (see `.claude/rules/hook-block-vs-nudge.md`). Only the
+`cat`/`head`/`tail` blocks remain — those prevent real context-budget waste on
+plain file reads with a clean `Read` substitution, and never dead-end anyone
+(pipelines and heredocs pass).
 
-## When to keep `grep` / `rg` in Bash
+## When to reach for `grep` / `rg` in Bash
 
-The hook allows the `grep`/`rg` Bash form in three scenarios:
+`grep`/`rg` are no longer blocked in any form — the Bash command always runs.
+Reach for the `Grep` tool when it's available and you want the context-efficient
+codebase search; keep `grep`/`rg` for the cases where the tool doesn't fit:
 
-1. **Pipelines.** `gh pr list --json title --jq '.[].title' | rg 'feat'`
-   is fine — the `|` short-circuits the hook check.
-2. **Boolean exit-code checks.** `grep -q pattern file && do_thing`
-   is fine. The `Grep` tool returns content; it doesn't give you a
-   clean shell-conditional exit code.
+1. **Pipelines.** `gh pr list --json title --jq '.[].title' | rg 'feat'` —
+   `Grep` can't sit mid-pipeline.
+2. **Boolean exit-code checks.** `grep -q pattern file && do_thing` — the
+   `Grep` tool returns content, not a clean shell-conditional exit code.
 3. **File-list / count filter modes.** `grep -l pattern f1 f2`
-   (files-with-matches), `grep -c pattern file` (count), and
-   `grep -L …` (files-without-match) are filters over a known file set,
-   not codebase searches the `Grep` tool replaces. (The uppercase
-   context flag `-C` is *not* exempt — it's a real search.)
+   (files-with-matches), `grep -c pattern file` (count), `grep -L …`
+   (files-without-match) — filters over a known file set, not codebase searches.
+4. **Sessions without the `Grep` tool.** If `Grep` isn't in the session's
+   toolset (some subagents), `grep`/`rg` is the only search you have — and the
+   hook won't stop it (#1909).
 
-In all three cases the hook silently passes the command through. If
-you're getting blocked anyway, you're not in one of these cases —
-switch to the tool.
-
-`find` needs no exception list — it is never blocked. Reach for `Glob`
-or `fd` when you want the context-efficient / ergonomic option, but the
-hook won't stop a plain `find`.
+`find` is likewise never blocked. Reach for `Glob` or `fd` when you want the
+context-efficient / ergonomic option, but the hook won't stop a plain `find`.
 
 ## Related
 
@@ -94,7 +102,9 @@ hook won't stop a plain `find`.
   doubly painful in parallel batches: it both fires the hook AND
   exits non-zero on empty results, cancelling sibling tool calls
 - `hooks-plugin/hooks/bash-antipatterns.sh` — the hook that
-  implements the `grep`/`rg` and `cat`/`head`/`tail` blocks (and a
-  comment explaining why `find` is no longer among them)
+  implements the `cat`/`head`/`tail` blocks (and comments explaining why
+  `find` and `grep`/`rg` are no longer among them)
 - `hooks-plugin/hooks/bash-antipatterns-teach.sh` — the opt-in teach
-  hook that carries the non-blocking `find→Glob` nudge
+  hook that carries the non-blocking `find→Glob` and `grep`/`rg`→`Grep` nudges
+- `.claude/rules/hook-block-vs-nudge.md` — the litigation test behind the
+  `find`/`grep` demotions (block for safety, nudge for style)

--- a/hooks-plugin/hooks/bash-antipatterns.sh
+++ b/hooks-plugin/hooks/bash-antipatterns.sh
@@ -229,33 +229,23 @@ fi
 # opt-in teach nudge, which steers toward Glob without dead-ending anyone.
 # See .claude/rules/bash-tool-replacements.md for the find/Glob/fd guidance.
 
-# Check for grep/rg command (should use Grep tool)
-# Allow grep -q / grep --quiet: these are boolean exit-code checks the Grep tool
-# cannot replicate (e.g. grep -q pattern file && do_thing).
-# Allow grep -l / -c / -L (and the rg/long-form equivalents): file-list and
-# count modes are filters over a known file set, not codebase searches the Grep
-# tool replaces (issue #1592). The char class is [lcL] (lowercase) so the
-# uppercase context flag -C (grep -C3, a real search) is NOT exempted.
-# Also allow piped grep (already excluded by the '|' check above).
-if [ "$IS_REMOTE_EXEC" = false ] && \
-   echo "$COMMAND" | grep -Eq '^\s*(grep|rg)\s+' && \
-   ! echo "$COMMAND" | grep -q '|' && \
-   ! echo "$COMMAND" | grep -Eq '(grep|rg)[^|]*\s(-[a-zA-Z]*q[a-zA-Z]*(\s|$)|--quiet(\s|$))' && \
-   ! echo "$COMMAND" | grep -Eq '(grep|rg)[^|]*\s(-[a-zA-Z]*[lcL][a-zA-Z]*(\s|$)|--count(\s|$)|--files-with-matches(\s|$)|--files-without-match(\s|$))'; then
-    block "BLOCKED: 'grep -rn pattern src/' →
-  Grep(pattern=\"pattern\", path=\"src\", -r=true, -n=true)
-
-BLOCKED: 'rg pattern --type ts' →
-  Grep(pattern=\"pattern\", glob=\"*.ts\")
-
-The Grep tool is optimized for codebase searches with proper permissions
-and result formatting. Pipelines (… | grep …) and boolean checks
-(grep -q pattern file && do_thing) are still allowed; so are the
-file-list/count filter modes (grep -l, grep -c, grep -L).
-If the Grep tool is unavailable in this session, pipe instead — pipelines
-are allowed: rg --files <dir> | rg pattern  (or  … | grep pattern).
-See .claude/rules/bash-tool-replacements.md for the full table."
-fi
+# NOTE: `grep`/`rg` are intentionally NOT blocked here.
+#
+# The grep/rg→Grep redirect was demoted from a hard block to a non-blocking teach
+# nudge (bash-antipatterns-teach.sh, opt-in via CLAUDE_HOOKS_ENABLE_BASH_ANTIPATTERNS_TEACH=1),
+# mirroring the find→Glob demotion (#1871). Same reasoning applies point-for-point
+# under hook-block-vs-nudge.md's litigation test: the block did NO safety work (it
+# always EXEMPTED the genuinely dangerous forms — pipelines, boolean -q checks,
+# -l/-c/-L filter modes — and only blocked benign line-numbered file reads); it
+# hard-DEAD-ENDED subagents whose toolset doesn't grant the Grep tool (PreToolUse
+# Bash hooks fire in every context, but Grep is not always available — #1909, where
+# `ToolSearch(select:Grep)` returned "No matching deferred tools found" and every
+# blocked search cost a retry cycle); and it carried the worst same-session
+# repeat-block rate of any pattern (21%, W20). The model writes grep/rg reliably;
+# blocking a tool it's fluent in to force one that is sometimes absent is a bad
+# trade. Context efficiency is preserved by the opt-in teach nudge, which steers
+# toward Grep without dead-ending anyone.
+# See .claude/rules/bash-tool-replacements.md for the grep/rg/Grep guidance.
 
 # Check for ls used for file listing (should often use Glob)
 if [ "$IS_REMOTE_EXEC" = false ] && echo "$COMMAND" | grep -Eq '^\s*ls\s+.*\*'; then
@@ -352,7 +342,29 @@ fi
 # `grep | grep -v | sed | tail` over it is the idiomatic incident-diagnosis read,
 # and the Error/fail tokens this keys on are exactly what log diagnostics search
 # for (issue #1833). IS_LOG_STREAM is computed in the pipe-count block above.
+#
+# Also exempt greps over explicit source/config FILE operands (issue #1914): the
+# generic case-sensitive tokens `Error`/`fail`/`FAIL` match substrings that appear
+# in ordinary workflow YAML and source — a `grep -n 'app-id|fail-fast|…'
+# reusable-release-please.yml | … | awk` spot-checking GitHub Actions files has
+# nothing to do with test output, but it fired this heuristic. A grep whose
+# operands name explicit `.yml`/`.md`/`.json`/source-file paths is reading source,
+# not scraping a test/task-output stream, so IS_SOURCE_FILE_GREP suppresses the
+# block. The stdin-scrape (`cat r.txt | grep Error | … | sed`) and `/tasks/*.output`
+# forms have no such source-file operand and keep firing.
+#
+# Scan COMMAND_NO_STRINGS (quoted literals stripped) so the extension match keys on
+# a real file OPERAND, not a source name that merely appears inside the search
+# pattern. This also lets the char class stop at pipes/separators without a quoted
+# pattern's own `|` (e.g. grep -n 'app-id|fail-fast' file.yml) cutting the scan
+# short before the file operand.
+IS_SOURCE_FILE_GREP=false
+if echo "$COMMAND_NO_STRINGS" | grep -Eq '(grep|rg)\b[^|;&]*\.(yml|yaml|md|json|ts|tsx|js|py|tf|toml|sh|rs|go)\b'; then
+    IS_SOURCE_FILE_GREP=true
+fi
+
 if [ "$IS_LOG_STREAM" = false ] && \
+   [ "$IS_SOURCE_FILE_GREP" = false ] && \
    echo "$COMMAND" | grep -Eq 'grep.*\|.*grep.*\|.*(sed|cut|awk)' && \
    echo "$COMMAND" | grep -Eq '(\.output|/tasks/|Error|fail|FAIL)'; then
     block "REMINDER: Parsing test output with grep chains is fragile. Better alternatives:

--- a/hooks-plugin/hooks/test-bash-antipatterns.sh
+++ b/hooks-plugin/hooks/test-bash-antipatterns.sh
@@ -103,12 +103,17 @@ assert_exit \
     "cat file | command || echo fallback is allowed (pipeline)" 0 \
     "cat ~/.claude/settings.json 2>/dev/null | python3 -m json.tool 2>/dev/null | grep -A5 -i hook || echo not found"
 
-# ── grep -q exemption regression ─────────────────────────────────────────────
-# Regression: grep -q was blocked even though the Grep tool does not support
-# boolean exit-code checks. grep -q is the standard shell idiom for testing
-# whether a pattern exists (e.g. grep -q pattern file && do_thing).
+# ── grep/rg is no longer blocked ─────────────────────────────────────────────
+# The grep/rg→Grep redirect was demoted from a hard block to an opt-in teach
+# nudge (bash-antipatterns-teach.sh), mirroring the find→Glob demotion (#1871).
+# The block did no safety work — it always EXEMPTED pipelines, boolean -q checks,
+# and -l/-c/-L filter modes, blocking only benign line-numbered file reads — and
+# it hard-dead-ended subagents lacking the Grep tool (#1909: ToolSearch could not
+# find Grep, so every blocked search cost a retry). So grep/rg in EVERY form is
+# now allowed by this hook. The Grep steer survives as a non-blocking nudge in the
+# companion teach hook (see test-bash-antipatterns-teach.sh).
 echo ""
-echo "grep -q exemption (exit-code checks allowed, plain searches blocked):"
+echo "grep/rg is no longer blocked (demoted to opt-in teach nudge):"
 
 assert_exit \
     "grep -q is allowed (boolean check)" 0 \
@@ -131,12 +136,16 @@ assert_exit \
     "rg --quiet pattern file"
 
 assert_exit \
-    "grep pattern file (no -q, no pipe) is blocked" 2 \
+    "grep pattern file (plain search) is allowed (was blocked; now teach-only, #1909)" 0 \
     "grep pattern file"
 
 assert_exit \
-    "grep -n pattern file (no -q, no pipe) is blocked" 2 \
+    "grep -n pattern file (line-numbered file read) is allowed (was blocked; now teach-only, #1909)" 0 \
     "grep -n pattern file"
+
+assert_exit \
+    "rg pattern --type ts is allowed (was blocked; now teach-only, #1909)" 0 \
+    "rg pattern --type ts"
 
 assert_exit \
     "grep in pipeline is allowed (piped output has different semantics)" 0 \
@@ -360,21 +369,6 @@ assert_stderr_contains() {
 }
 
 assert_stderr_contains \
-    "grep block message names Grep substitution" \
-    'Grep(pattern="pattern", path="src", -r=true, -n=true)' \
-    "grep -rn pattern src/"
-
-assert_stderr_contains \
-    "rg block message also names Grep substitution" \
-    'Grep(pattern="pattern", glob="*.ts")' \
-    "rg pattern --type ts"
-
-assert_stderr_contains \
-    "grep block message points at rule file" \
-    'bash-tool-replacements.md' \
-    "grep -rn pattern src/"
-
-assert_stderr_contains \
     "cat block message names Read substitution" \
     'Read(file_path="/path/to/file.md")' \
     "cat /home/user/file.md"
@@ -399,13 +393,14 @@ assert_stderr_contains \
     'bash-tool-replacements.md' \
     "head -50 file.md"
 
-# ── grep -l/-c/-L filter-mode exemption (issue #1592) ────────────────────────
-# Regression: grep -l (files-with-matches) and grep -c (count) over a known
-# file set are filters, not codebase searches the Grep tool replaces, but they
-# were blocked by the grep/rg detector. The uppercase context flag -C (a real
-# search) must still be blocked.
+# ── grep flag forms all allowed post-demotion (issue #1592, #1909) ───────────
+# Regression: grep -l (files-with-matches), grep -c (count), grep -L, and even
+# the -C context search are all allowed now that the grep/rg block is demoted to
+# an opt-in teach nudge (#1909). Previously -l/-c/-L were exempted while -C stayed
+# blocked; the demotion removes the whole block, so every form passes. These
+# remain as regression guards that the block does not creep back in.
 echo ""
-echo "grep -l/-c/-L filter modes are exempt (-C context is not):"
+echo "grep flag forms are all allowed post-demotion (#1592, #1909):"
 
 assert_exit \
     "grep -lE over explicit files is allowed (files-with-matches)" 0 \
@@ -428,7 +423,7 @@ assert_exit \
     "grep --count pattern file"
 
 assert_exit \
-    "grep -C3 (uppercase context) is still blocked (it's a real search)" 2 \
+    "grep -C3 (uppercase context) is allowed post-demotion (#1909)" 0 \
     "grep -C3 pattern file"
 
 # ── task-output read → Read tool, not deprecated TaskOutput (issue #1591) ─────
@@ -524,16 +519,25 @@ assert_exit \
     "GUARD: cat-headed grep|grep|sed scrape over a file still blocks (#1833)" 2 \
     "cat r.txt | grep Error | grep -v warn | sed s/a/b/ | tail"
 
-# ── grep block message offers the pipe fallback (issue #1602) ─────────────────
-# Regression: when the Grep tool is unavailable in a session, the block message
-# pointed only at Grep(...). It must also offer the always-allowed pipe form.
+# ── multi-grep test-output heuristic exempts source/config file greps (#1914) ──
+# Regression: the "Parsing test output with grep chains is fragile" heuristic
+# fired on a multi-pattern `grep -n 'app-id|fail-fast|…' reusable-*.yml | … | awk`
+# spot-checking GitHub Actions workflow YAML — the generic case-sensitive tokens
+# Error/fail/FAIL match ordinary YAML substrings (fail-fast, failure) with no test
+# runner involved. A grep whose operands name explicit source/config file paths
+# (.yml/.md/.json/…) is reading source, not scraping a test/task-output stream, so
+# it must be ALLOWED. The stdin-scrape and /tasks/*.output forms (which have no
+# source-file operand) must STILL block.
 echo ""
-echo "grep block message offers the pipe fallback for sessions without the Grep tool:"
+echo "multi-grep over source/config YAML is exempt; genuine test-output scrapes still block (#1914):"
 
-assert_stderr_contains \
-    "grep block message mentions the pipe fallback" \
-    'pipe instead' \
-    "grep -rn pattern src/"
+assert_exit \
+    "multi-grep over reusable-*.yml workflow files (issue repro) is allowed" 0 \
+    "grep -n 'app-id|timeout-minutes|fail-fast' reusable-release-please.yml | head; echo '---'; grep -n 'skip-on-release' reusable-container-build.yml | awk '{print}'"
+
+assert_exit \
+    "GUARD: grep chain over a .output file (no source-file operand) still blocks" 2 \
+    "grep -n Error run.output | grep -v warn | sed s/a/b/"
 
 # ── git push -u colon-refspec footgun, no-colon form allowed (issue #1600) ────
 # Regression: the push -u detector blocked the legitimate no-colon form


### PR DESCRIPTION
Fixes two independent false-positives in the `bash-antipatterns` PreToolUse hook, both surfaced by session feedback. Same file, grouped per the triage hint.

## #1909 — grep/rg block prescribes the Grep tool even when unavailable

Demoted the grep/rg to Grep **hard block** to an **opt-in teach nudge**, mirroring the find to Glob demotion (#1871). Under the litigation test in `hook-block-vs-nudge.md` the block earned no exit-2: it always exempted the genuinely useful forms (pipelines, boolean `-q`, `-l`/`-c`/`-L` filter modes) and blocked only benign line-numbered file reads, yet it hard-dead-ended subagents whose toolset does not grant the Grep tool — in the reported session `ToolSearch(select:Grep)` returned "No matching deferred tools found", so every blocked search cost a retry. The steer already survives as a non-blocking nudge in `bash-antipatterns-teach.sh` (unchanged).

## #1914 — test-output heuristic misfires on multi-pattern grep over workflow YAML

The "Parsing test output with grep chains is fragile" heuristic keys on the generic case-sensitive tokens `Error`/`fail`/`FAIL`, which match ordinary source substrings (`fail-fast`, `failure`) in workflow YAML — a multi-pattern grep spot-checking `reusable-*.yml` files has nothing to do with test output. Added an `IS_SOURCE_FILE_GREP` guard (mirroring the existing `IS_LOG_STREAM` exemption) that suppresses the block when a grep names explicit source/config file operands (`.yml`/`.md`/`.json` and other source extensions). It scans the quoted-string-stripped view so a search pattern containing punctuation cannot confuse the operand match. The stdin-scrape and task-output (`/tasks/*.output`) forms keep firing.

## Tests & checks

- Inverted the two grep-blocking assertions and removed the now-moot block-message assertions; added a `#1909` allowed-forms section and a `#1914` section (issue-repro allowed plus a genuine task-output-scrape guard that still blocks).
- `bash hooks-plugin/hooks/test-bash-antipatterns.sh` → 102 passed, 0 failed.
- `bash hooks-plugin/hooks/test-bash-antipatterns-teach.sh` → 24 passed, 0 failed.
- `just lint-compliance` (exit 0, no errors); `bash scripts/lint-shell-scripts.sh` (0 errors); `shellcheck` clean.
- `.claude/rules/bash-tool-replacements.md` updated in the same commit (docs-currency).

Closes #1909
Closes #1914