### PR TITLE
feat(project-plugin): add a deterministic loop driver to project-test-loop

### DIFF
--- a/project-plugin/skills/project-test-loop/SKILL.md
+++ b/project-plugin/skills/project-test-loop/SKILL.md
@@ -1,11 +1,11 @@
 ---
 description: Automated TDD test-fix-refactor cycle until tests pass. Use when looping on failing tests, running a TDD cycle, or driving RED/GREEN/REFACTOR until green.
 args: "[test-pattern] [--max-cycles <N>]"
-argument-hint: "Test pattern to focus on, --max-cycles to limit iterations"
-allowed-tools: Read, Edit, Bash
+argument-hint: "Optional test pattern to focus on; --max-cycles <N> to cap iterations (default 10)"
+allowed-tools: Read, Edit, Bash, Bash(bash *)
 created: 2025-12-16
-modified: 2026-06-21
-reviewed: 2026-04-25
+modified: 2026-07-04
+reviewed: 2026-07-04
 name: project-test-loop
 ---
 
@@ -19,172 +19,113 @@ name: project-test-loop
 | Iterating on failing tests with auto fix-and-retry behavior | Use project-distill instead when capturing patterns from a finished session |
 | Bounding TDD iterations with `--max-cycles` to avoid runaway loops | Use project-discovery instead when the test command itself is unknown |
 
-Run automated TDD cycle: test → fix → refactor.
+Run an automated TDD cycle — test -> fix -> refactor — where a deterministic
+driver script (`scripts/run-test-cycle.sh`) does the mechanical work each
+iteration and you make the minimal fix between invocations.
 
-**Note**: Configure project-specific test/build commands in `CLAUDE.md` or `.claude/rules/` for automatic detection.
+## Context
 
-**Steps**:
+- Project markers: !`find . -maxdepth 1 \( -name package.json -o -name pyproject.toml -o -name pytest.ini -o -name Cargo.toml -o -name go.mod -o -name Makefile \) -print`
 
-1. **Detect test command** (if not already configured):
-   - Check `package.json` for `scripts.test` (Node.js)
-   - Check for `pytest` or `python -m unittest` (Python)
-   - Check for `cargo test` (Rust)
-   - Check for `go test ./...` (Go)
-   - Check `Makefile` for test target
-   - If not found, ask user how to run tests
+## Parameters
 
-2. **Run test suite**:
-   ```bash
-   # Run detected test command
-   [test_command]
-   ```
+Parse these from `$ARGUMENTS`:
 
-3. **Analyze results**:
+- **`test-pattern`** (positional, optional) — a pattern passed through to the
+  detected test command to focus the run (e.g. a file, a test-name filter).
+- **`--max-cycles <N>`** (optional, default `10`) — the runaway ceiling; the
+  driver returns `CAP_REACHED` once the cycle count reaches `N`.
 
-   **If tests FAIL**:
-   - Parse failure output
-   - Identify failing tests:
-     * Which tests failed?
-     * What assertions failed?
-     * What was expected vs actual?
-   - Identify root cause:
-     * Bug in implementation?
-     * Missing implementation?
-     * Incorrect test?
-   - Make minimal fix:
-     * Fix only what's needed to pass the failing test
-     * Don't add extra functionality
-     * Don't fix tests (fix code instead)
-   - Re-run tests to confirm fix
-   - Loop back to step 2
+Also pass `--test-cmd "<command>"` to the driver to override auto-detection when
+the project's test command is configured in `CLAUDE.md` / `.claude/rules/` and
+not one of the auto-detected shapes.
 
-   **If tests PASS**:
-   - Check for refactoring opportunities:
-     * Code duplication?
-     * Unclear naming?
-     * Long functions?
-     * Complex logic that can be simplified?
-     * Magic numbers/strings to extract?
-   - If refactoring identified:
-     * Refactor while keeping tests green
-     * Re-run tests after each refactoring
-     * Ensure tests still pass
-   - If no refactoring needed:
-     * Report success
-     * Stop loop
+## Execution
 
-4. **Repeat until**:
-   - All tests pass AND
-   - No obvious refactoring opportunities
+Execute this TDD loop. Each iteration runs the deterministic driver, then you act
+on its `VERDICT`.
 
-   **OR stop if**:
-   - User intervention needed
-   - Blocked by external dependency
-   - Unclear how to fix failure
+### Step 1: Run one test cycle
 
-5. **Report results**:
-   ```
-   🧪 Test Loop Results:
+Invoke the driver (auto-detects the test command from the project markers above:
+`package.json` test script, `pytest`/`pyproject.toml`, `cargo test`, `go test`,
+or a `Makefile` `test:` target):
 
-   Cycles: [N] iterations
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/run-test-cycle.sh" --pattern "$0" --max-cycles 10
+```
 
-   Fixes Applied:
-   - [Fix 1]: [Brief description]
-   - [Fix 2]: [Brief description]
+Substitute the parsed `test-pattern` for `--pattern` (omit it if none) and the
+parsed `--max-cycles` value. Read the `VERDICT=` line from the structured output
+and the bounded `=== TEST OUTPUT ===` tail.
 
-   Refactorings Performed:
-   - [Refactor 1]: [Brief description]
-   - [Refactor 2]: [Brief description]
+### Step 2: Branch on the verdict
 
-   Current Status:
-   ✅ All tests pass
-   ✅ Code refactored
-   📝 Ready for commit
+| `VERDICT` | Meaning | Do |
+|---|---|---|
+| `GREEN` | Test command exited 0 — suite passes | Go to Step 3 (refactor), then stop |
+| `CONTINUE` | Suite failing, ceiling not reached | Make a minimal fix (Step 2a), then repeat Step 1 |
+| `STUCK` | Same failing signature 3 cycles running — no progress | Stop; report the blocker and ask for input |
+| `CAP_REACHED` | Cycle count hit `--max-cycles` | Stop; report remaining failures |
+| `SETUP_ERROR` | No test command could be detected/run | Stop; ask how to run tests, or re-invoke with `--test-cmd` |
 
-   OR
+### Step 2a: Make the minimal fix (on `CONTINUE`)
 
-   ⚠️ Blocked: [Reason]
-   📝 Next steps: [Recommendation]
-   ```
+Read the `=== TEST OUTPUT ===` tail and identify the failure:
 
-**TDD Cycle Details**:
+1. Which tests failed, expected vs actual.
+2. Root cause: missing implementation, wrong return value, missing edge case,
+   integration issue.
+3. Apply the **minimal** fix to the code — fix only what the failing test needs.
+   Do **not** edit the tests to make them pass; that converts the suite's
+   independent judge into a self-judged loop (see Loop integrity below).
 
-### RED Phase (If starting new feature)
-1. Write failing test describing desired behavior
-2. Run tests → Should FAIL (expected)
-3. This command picks up from here
+Then repeat Step 1. The driver increments the cycle counter and re-checks.
 
-### GREEN Phase (This command handles)
-1. Run tests
-2. If fail → Make minimal fix
-3. Re-run tests → Should PASS
-4. Loop until all pass
+### Step 3: Refactor while green (on `GREEN`)
 
-### REFACTOR Phase (This command handles)
-1. Tests pass
-2. Look for improvements
-3. Refactor
-4. Re-run tests → Should STILL PASS
-5. Loop until no improvements
+With the suite passing, look for improvements — duplicated code, magic numbers,
+long functions, unclear names, complex conditionals — and refactor **without
+changing behavior**. Re-run Step 1 after each refactoring to confirm the suite
+stays green. When no improvement remains, report success and stop.
 
-**Common Failure Patterns**:
+### Step 4: Report
 
-**Pattern: Missing Implementation**
-- **Symptom**: `undefined is not a function`, `NameError`, etc.
-- **Fix**: Implement the missing function/class/method
-- **Minimal**: Just the signature, return dummy value
+Summarize cycles run, fixes applied, refactorings performed, and the final
+status (all green / blocked with reason + recommended next step).
 
-**Pattern: Wrong Return Value**
-- **Symptom**: `Expected X but got Y`
-- **Fix**: Update implementation to return correct value
-- **Minimal**: Don't add extra logic, just fix the return
+## Loop integrity
 
-**Pattern: Missing Edge Case**
-- **Symptom**: Test fails for specific input
-- **Fix**: Handle the edge case
-- **Minimal**: Add condition for this case only
+This loop's stop condition is the test suite itself — an **independent**,
+mechanical judge (a failing test does not care how hard you worked), which is
+exactly what `.claude/rules/loop-integrity.md` Pillar 1 asks for. The driver
+script makes that judge deterministic: `GREEN` is the suite's own exit 0, not
+your opinion. The `--max-cycles` ceiling (`CAP_REACHED`) and the same-failure-3x
+rule (`STUCK`) are the runaway bound. Do **not** make tests pass by editing the
+tests — that converts the independent judge into a self-judged loop.
 
-**Pattern: Integration Issue**
-- **Symptom**: Test fails when components interact
-- **Fix**: Fix the integration point
-- **Minimal**: Fix just the integration, not entire components
+## Common failure patterns
 
-**Refactoring Opportunities**:
+| Symptom | Fix (minimal) |
+|---|---|
+| `undefined is not a function`, `NameError` | Implement the missing function/class; just the signature + a dummy return |
+| `Expected X but got Y` | Correct the return value only — no extra logic |
+| Fails for a specific input | Handle that edge case with a single condition |
+| Fails when components interact | Fix the integration point, not the whole component |
 
-**Look for**:
-- Duplicated code → Extract to function
-- Magic numbers → Extract to constants
-- Long functions → Break into smaller functions
-- Complex conditionals → Extract to well-named functions
-- Unclear names → Rename to be descriptive
-- Comments explaining code → Refactor code to be self-explanatory
+## Auto-stop conditions
 
-**Don't**:
-- Change behavior
-- Add new functionality
-- Skip test runs
-- Make tests pass by changing tests
+Stop and report if: all tests pass with no refactoring left (SUCCESS, `GREEN`);
+`STUCK` (same failure 3× — the driver's no-progress signal); `CAP_REACHED`
+(`--max-cycles`); `SETUP_ERROR` (test command itself broken / undetectable); or
+the fix is unclear (NEEDS USER INPUT).
 
-**Auto-Stop Conditions**:
+## Agentic Optimizations
 
-Stop and report if:
-- All tests pass + no refactoring needed (SUCCESS)
-- Same test fails 3 times in a row (STUCK)
-- Error in test command itself (TEST SETUP ISSUE)
-- External dependency unavailable (BLOCKED)
-- Unclear how to fix (NEEDS USER INPUT)
-
-**Loop integrity**: this loop's stop condition is the test suite itself — an
-*independent*, mechanical judge (a failing test does not care how hard you
-worked), which is exactly what `.claude/rules/loop-integrity.md` Pillar 1 asks
-for. The `--max-cycles` flag and the "same test fails 3×" rule are the runaway
-ceiling. Do **not** make tests pass by editing the tests — that converts the
-independent judge into a self-judged loop.
-
-**Integration with Blueprint Development**:
-
-This command applies project-specific skills:
-- **Testing strategies**: Knows how to structure tests
-- **Implementation guides**: Knows how to implement fixes
-- **Quality standards**: Knows what to refactor
-- **Architecture patterns**: Knows where code should go
+| Context | Command |
+|---------|---------|
+| One cycle, auto-detect | `bash "${CLAUDE_SKILL_DIR}/scripts/run-test-cycle.sh" --max-cycles 10` |
+| Focus a pattern | `bash "${CLAUDE_SKILL_DIR}/scripts/run-test-cycle.sh" --pattern "$0"` |
+| Override the test command | `bash "${CLAUDE_SKILL_DIR}/scripts/run-test-cycle.sh" --test-cmd "pytest -x -q"` |
+| Start a fresh loop (reset cycle state) | `bash "${CLAUDE_SKILL_DIR}/scripts/run-test-cycle.sh" --reset` |
+| Read the verdict | `bash "${CLAUDE_SKILL_DIR}/scripts/run-test-cycle.sh" --max-cycles 10 \| grep -E '^VERDICT='` |

--- a/project-plugin/skills/project-test-loop/scripts/run-test-cycle.sh
+++ b/project-plugin/skills/project-test-loop/scripts/run-test-cycle.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# run-test-cycle.sh — deterministic per-cycle driver for /project:test-loop.
+#
+# THE PROBLEM (issue #1920)
+# The test-fix-refactor loop used to be pure prose the model re-derived on every
+# invocation: detect the test command, run it, count cycles, decide whether the
+# suite is green, whether it's stuck, whether the --max-cycles ceiling is hit.
+# That is exactly the mechanical, repeatable, verifiable work that belongs in a
+# deterministic substrate, not the agent's reasoning loop
+# (.claude/rules/offload-to-deterministic-substrate.md).
+#
+# WHAT THIS DRIVES (and what it deliberately does NOT)
+# The model still does the one genuinely model-shaped step — reading the failure
+# and making the minimal fix — between invocations. This script does everything
+# mechanical AROUND that:
+#   - detect the test command (or take --test-cmd)
+#   - run the suite once, bound the captured output (last N lines)
+#   - read + increment a persistent cycle counter (survives across invocations)
+#   - hash the failing-suite signature to detect no-progress (same failure 3x)
+#   - enforce the --max-cycles ceiling
+#   - emit a single VERDICT the model branches on
+#
+# This is the mechanical, INDEPENDENT stop condition loop-integrity.md Pillar 1
+# asks for: the suite's own exit code — not the worker's opinion — decides
+# "done". STUCK and CAP_REACHED are the runaway ceiling.
+#
+# VERDICT (the line the model reads):
+#   GREEN        test command exited 0 — suite passes, stop and (optionally) refactor
+#   CONTINUE     suite failing, progress still possible — model fixes, re-invokes
+#   STUCK        same failing signature 3 cycles running — no progress, stop
+#   CAP_REACHED  cycle count reached --max-cycles — stop
+#   SETUP_ERROR  no test command could be detected / it could not run
+#
+# OUTPUT: structured KEY=VALUE per .claude/rules/structured-script-output.md,
+# plus a bounded === TEST OUTPUT === tail so the model can read the failure.
+#
+# Usage:
+#   run-test-cycle.sh [--pattern <p>] [--max-cycles <N>] [--test-cmd <cmd>]
+#                     [--state-file <path>] [--project-dir <dir>] [--reset]
+#
+# Exit code parallels STATUS: 0 for OK/WARN (GREEN/CONTINUE/STUCK/CAP_REACHED),
+# 1 for ERROR (SETUP_ERROR) — see structured-script-output.md.
+
+set -uo pipefail
+
+pattern=""
+max_cycles=10
+test_cmd_override=""
+state_file=""
+project_dir="."
+reset=0
+tail_lines=100
+stuck_threshold=3
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --pattern) pattern="${2:-}"; shift 2 ;;
+    --max-cycles) max_cycles="${2:-}"; shift 2 ;;
+    --test-cmd) test_cmd_override="${2:-}"; shift 2 ;;
+    --state-file) state_file="${2:-}"; shift 2 ;;
+    --project-dir) project_dir="${2:-}"; shift 2 ;;
+    --tail-lines) tail_lines="${2:-}"; shift 2 ;;
+    --stuck-threshold) stuck_threshold="${2:-}"; shift 2 ;;
+    --reset) reset=1; shift ;;
+    *) shift ;;
+  esac
+done
+
+# --max-cycles must be a positive integer; fall back to the default otherwise.
+case "$max_cycles" in
+  ''|*[!0-9]*) max_cycles=10 ;;
+esac
+[ "$max_cycles" -lt 1 ] && max_cycles=1
+
+emit_setup_error() {
+  local msg="$1"
+  echo "=== TEST CYCLE ==="
+  echo "VERDICT=SETUP_ERROR"
+  echo "TEST_COMMAND="
+  echo "STATUS=ERROR"
+  echo "ISSUE_COUNT=1"
+  echo "ISSUES:"
+  echo "  - SEVERITY=ERROR TYPE=test_setup MSG=$msg"
+  echo "=== END TEST CYCLE ==="
+  exit 1
+}
+
+# --- Resolve state file (persists the cycle counter + failure history) --------
+# Default lives under the git dir (never committed, gitignored) so repeated runs
+# accumulate state without polluting the working tree; falls back to cwd.
+if [ -z "$state_file" ]; then
+  git_dir="$(git -C "$project_dir" rev-parse --git-dir 2>/dev/null)"
+  if [ -n "$git_dir" ]; then
+    case "$git_dir" in
+      /*) state_file="$git_dir/project-test-loop-state" ;;
+      *) state_file="$project_dir/$git_dir/project-test-loop-state" ;;
+    esac
+  else
+    state_file="$project_dir/.project-test-loop-state"
+  fi
+fi
+
+if [ "$reset" -eq 1 ]; then
+  rm -f "$state_file"
+fi
+
+# State file schema (deterministic, grep-parseable):
+#   CYCLE=<int>
+#   SIG=<hash>        (repeated, most-recent-last — the failure-signature history)
+prev_cycle=0
+if [ -f "$state_file" ]; then
+  prev_cycle="$(grep -E '^CYCLE=' "$state_file" 2>/dev/null | tail -n1 | cut -d= -f2)"
+  case "$prev_cycle" in ''|*[!0-9]*) prev_cycle=0 ;; esac
+fi
+
+# --- Detect the test command --------------------------------------------------
+detect_test_command() {
+  local dir="$1"
+  if [ -n "$test_cmd_override" ]; then
+    printf '%s' "$test_cmd_override"
+    return 0
+  fi
+  if [ -f "$dir/package.json" ] && grep -qE '"test"[[:space:]]*:' "$dir/package.json"; then
+    printf '%s' "npm test"
+    return 0
+  fi
+  if [ -f "$dir/pyproject.toml" ] || [ -f "$dir/pytest.ini" ] || [ -f "$dir/setup.cfg" ] || [ -f "$dir/tox.ini" ]; then
+    printf '%s' "pytest"
+    return 0
+  fi
+  if [ -f "$dir/Cargo.toml" ]; then
+    printf '%s' "cargo test"
+    return 0
+  fi
+  if [ -f "$dir/go.mod" ]; then
+    printf '%s' "go test ./..."
+    return 0
+  fi
+  if [ -f "$dir/Makefile" ] && grep -qE '^test:' "$dir/Makefile"; then
+    printf '%s' "make test"
+    return 0
+  fi
+  return 1
+}
+
+test_cmd="$(detect_test_command "$project_dir")" \
+  || emit_setup_error "no test command detected (checked package.json, pytest/pyproject, Cargo.toml, go.mod, Makefile) — pass --test-cmd or configure it in CLAUDE.md"
+
+# Append the caller-supplied pattern to the detected command, if any.
+full_cmd="$test_cmd"
+[ -n "$pattern" ] && full_cmd="$test_cmd $pattern"
+
+# --- Run the suite ------------------------------------------------------------
+output_log="$(mktemp)"
+trap 'rm -f "$output_log"' EXIT
+
+( cd "$project_dir" && eval "$full_cmd" ) >"$output_log" 2>&1
+test_exit=$?
+
+# --- Compute a stable failure signature ---------------------------------------
+# Normalize volatile parts (durations, timestamps, memory addresses, tmp paths)
+# so an identical failure across cycles hashes identically — that is what lets us
+# detect "no progress". Bounded to the last $tail_lines to keep the hash cheap.
+hash_cmd=""
+if command -v sha256sum >/dev/null 2>&1; then
+  hash_cmd="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then
+  hash_cmd="shasum -a 256"
+fi
+
+signature=""
+if [ -n "$hash_cmd" ]; then
+  signature="$(
+    tail -n "$tail_lines" "$output_log" \
+      | sed -E \
+          -e 's/[0-9]+\.[0-9]+ ?(s|ms|seconds|secs)//g' \
+          -e 's/in [0-9]+\.[0-9]+s//g' \
+          -e 's/0x[0-9a-fA-F]+//g' \
+          -e 's/[0-9]{4}-[0-9]{2}-[0-9]{2}[T ][0-9:]+//g' \
+          -e 's#/tmp/[^ ]+##g' \
+      | $hash_cmd | cut -d' ' -f1
+  )"
+fi
+
+# --- Decide the verdict -------------------------------------------------------
+this_cycle=$((prev_cycle + 1))
+
+status="WARN"
+issue_count=0
+
+if [ "$test_exit" -eq 0 ]; then
+  verdict="GREEN"
+  status="OK"
+  # Reset the state on green — the loop is complete.
+  rm -f "$state_file"
+else
+  # Persist the incremented cycle + signature history (most recent last).
+  prior_sigs=""
+  if [ -f "$state_file" ]; then
+    prior_sigs="$(grep -E '^SIG=' "$state_file" 2>/dev/null || true)"
+  fi
+  {
+    echo "CYCLE=$this_cycle"
+    [ -n "$prior_sigs" ] && printf '%s\n' "$prior_sigs"
+    [ -n "$signature" ] && echo "SIG=$signature"
+  } >"$state_file"
+
+  # Count trailing identical signatures (no-progress detection).
+  repeat_run=0
+  if [ -n "$signature" ]; then
+    while IFS= read -r s; do
+      if [ "$s" = "SIG=$signature" ]; then
+        repeat_run=$((repeat_run + 1))
+      else
+        repeat_run=0
+      fi
+    done < <(grep -E '^SIG=' "$state_file" 2>/dev/null)
+  fi
+
+  if [ -n "$signature" ] && [ "$repeat_run" -ge "$stuck_threshold" ]; then
+    verdict="STUCK"
+    issue_count=1
+  elif [ "$this_cycle" -ge "$max_cycles" ]; then
+    verdict="CAP_REACHED"
+    issue_count=1
+  else
+    verdict="CONTINUE"
+  fi
+fi
+
+# --- Emit structured result ---------------------------------------------------
+echo "=== TEST CYCLE ==="
+echo "VERDICT=$verdict"
+echo "TEST_COMMAND=$full_cmd"
+echo "TEST_EXIT=$test_exit"
+echo "CYCLE=$this_cycle"
+echo "MAX_CYCLES=$max_cycles"
+echo "STUCK_THRESHOLD=$stuck_threshold"
+[ -n "$signature" ] && echo "FAILURE_SIGNATURE=$signature"
+echo "STATUS=$status"
+echo "ISSUE_COUNT=$issue_count"
+echo "=== END TEST CYCLE ==="
+
+# Bounded transcript so the model can read the failure without re-running.
+echo "=== TEST OUTPUT (last $tail_lines lines) ==="
+tail -n "$tail_lines" "$output_log"
+echo "=== END TEST OUTPUT ==="
+
+# Exit 0 for every non-setup verdict (OK/WARN) so callers batching this stay safe.
+exit 0

--- a/project-plugin/skills/project-test-loop/scripts/tests/test-run-test-cycle.sh
+++ b/project-plugin/skills/project-test-loop/scripts/tests/test-run-test-cycle.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016   # file-level: the SKILL.md guards grep for the LITERAL '$ARGUMENTS' string
+# Regression test for run-test-cycle.sh — the deterministic per-cycle driver
+# added for issue #1920 (project-test-loop scored 2.5/5 on determinism offload
+# because the loop was prose the model re-derived every invocation).
+#
+# Asserts the mechanical verdicts the model branches on:
+#   GREEN        — suite passes (exit 0)
+#   CONTINUE     — suite failing, ceiling not hit
+#   CAP_REACHED  — cycle count reached --max-cycles
+#   STUCK        — same failing signature N cycles running (no progress)
+#   SETUP_ERROR  — no test command could be detected
+# Plus a semantic guard that SKILL.md keeps wiring its declared arguments
+# ($ARGUMENTS parse, --max-cycles, the driver-script reference) so a future
+# bulk edit can't silently revert the skill to argument-less prose.
+#
+# Exit 0 on success, non-zero on failure.
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+driver="${script_dir}/../run-test-cycle.sh"
+skill_md="${script_dir}/../../SKILL.md"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+pass() { echo "PASS: $1"; }
+
+[ -f "$driver" ] || fail "run-test-cycle.sh not found at $driver"
+
+verdict_of() { echo "$1" | grep -E '^VERDICT=' | head -n1 | cut -d= -f2; }
+
+proj="$(mktemp -d)"
+trap 'rm -rf "$proj"' EXIT
+
+# -----------------------------------------------------------------------------
+# Case 1: green suite → VERDICT=GREEN, STATUS=OK
+# -----------------------------------------------------------------------------
+sf="$(mktemp -u)"
+out="$(bash "$driver" --test-cmd "true" --project-dir "$proj" --state-file "$sf")"
+[ "$(verdict_of "$out")" = "GREEN" ] || fail "green suite should yield GREEN, got:\n$out"
+echo "$out" | grep -q "^STATUS=OK$" || fail "green suite should be STATUS=OK, got:\n$out"
+[ -f "$sf" ] && fail "green suite must reset state file, but it still exists"
+pass "green suite → GREEN and resets state"
+
+# -----------------------------------------------------------------------------
+# Case 2: failing suite below the cap → VERDICT=CONTINUE
+# -----------------------------------------------------------------------------
+sf="$(mktemp -u)"
+out="$(bash "$driver" --test-cmd "echo fail-A; false" --project-dir "$proj" --state-file "$sf" --max-cycles 5)"
+[ "$(verdict_of "$out")" = "CONTINUE" ] || fail "first failing cycle under cap should be CONTINUE, got:\n$out"
+echo "$out" | grep -q "^CYCLE=1$" || fail "first cycle should report CYCLE=1, got:\n$out"
+rm -f "$sf"
+pass "failing suite under cap → CONTINUE"
+
+# -----------------------------------------------------------------------------
+# Case 3: cycle count reaches --max-cycles → VERDICT=CAP_REACHED
+# Vary output each cycle so STUCK does not pre-empt the cap.
+# -----------------------------------------------------------------------------
+sf="$(mktemp -u)"
+v=""
+for n in 1 2 3; do
+  out="$(bash "$driver" --test-cmd "echo attempt-$n; false" --project-dir "$proj" --state-file "$sf" --max-cycles 3)"
+  v="$(verdict_of "$out")"
+done
+[ "$v" = "CAP_REACHED" ] || fail "3rd cycle at --max-cycles 3 should be CAP_REACHED, got:\n$out"
+echo "$out" | grep -q "^CYCLE=3$" || fail "cap verdict should report CYCLE=3, got:\n$out"
+rm -f "$sf"
+pass "cycle == --max-cycles → CAP_REACHED"
+
+# -----------------------------------------------------------------------------
+# Case 4: identical failure 3× → VERDICT=STUCK (before the cap)
+# Same output every cycle → same signature → no-progress detection fires.
+# High cap so CAP_REACHED cannot pre-empt STUCK.
+# -----------------------------------------------------------------------------
+sf="$(mktemp -u)"
+v=""
+for n in 1 2 3; do
+  out="$(bash "$driver" --test-cmd "echo always-the-same-failure; false" --project-dir "$proj" --state-file "$sf" --max-cycles 20 --stuck-threshold 3)"
+  v="$(verdict_of "$out")"
+done
+[ "$v" = "STUCK" ] || fail "identical failure 3× should be STUCK, got:\n$out"
+rm -f "$sf"
+pass "same failure 3× → STUCK"
+
+# -----------------------------------------------------------------------------
+# Case 5: no detectable test command → VERDICT=SETUP_ERROR, exit 1
+# -----------------------------------------------------------------------------
+empty="$(mktemp -d)"
+sf="$(mktemp -u)"
+if out="$(bash "$driver" --project-dir "$empty" --state-file "$sf")"; then
+  fail "undetectable test command should exit non-zero, but exit was 0:\n$out"
+fi
+[ "$(verdict_of "$out")" = "SETUP_ERROR" ] || fail "undetectable test command should be SETUP_ERROR, got:\n$out"
+rm -rf "$empty"; rm -f "$sf"
+pass "no test command detected → SETUP_ERROR (exit 1)"
+
+# -----------------------------------------------------------------------------
+# Case 6: detection picks up a Makefile test target
+# -----------------------------------------------------------------------------
+mk="$(mktemp -d)"
+printf 'test:\n\t@true\n' > "$mk/Makefile"
+sf="$(mktemp -u)"
+out="$(bash "$driver" --project-dir "$mk" --state-file "$sf")"
+echo "$out" | grep -q "^TEST_COMMAND=make test$" || fail "Makefile test target should detect 'make test', got:\n$out"
+rm -rf "$mk"; rm -f "$sf"
+pass "Makefile test target detected as 'make test'"
+
+# -----------------------------------------------------------------------------
+# Case 7: SKILL.md semantic guard — the declared args stay wired into the body.
+# Protects against a bulk edit reverting to argument-less prose (the #1920 gap).
+# -----------------------------------------------------------------------------
+if [ -f "$skill_md" ]; then
+  grep -qF '$ARGUMENTS' "$skill_md" || fail "SKILL.md must parse \$ARGUMENTS (declared args were unused before #1920)"
+  grep -qF -- '--max-cycles' "$skill_md" || fail "SKILL.md must reference --max-cycles (the runaway ceiling)"
+  grep -qF 'run-test-cycle.sh' "$skill_md" || fail "SKILL.md must invoke the run-test-cycle.sh driver (determinism offload)"
+  grep -qF 'loop-integrity.md' "$skill_md" || fail "SKILL.md must keep its loop-integrity.md cross-reference"
+  pass "SKILL.md keeps \$ARGUMENTS parse, --max-cycles, driver reference, loop-integrity link"
+else
+  echo "SKIP: SKILL.md not found at $skill_md"
+fi
+
+echo "ALL PASS"


### PR DESCRIPTION
Adds a deterministic per-cycle driver to `project-test-loop`, closing the two defects that lost B4 (determinism offload, 2.5/5) against `ralph-loop` in the marketplace-quality benchmark (PR #1917): the loop was pure prose the model re-derived every invocation, and it declared `args` (`test-pattern`, `--max-cycles`) it never parsed.

## What

- **New `scripts/run-test-cycle.sh`** — a per-cycle driver the model invokes each iteration. It does the mechanical work: detect the test command (package.json test script / pytest / cargo / go / Makefile, or `--test-cmd` override), run it, bound the captured output, persist + increment a cycle counter, hash the normalized failing-suite signature to detect no-progress, enforce the `--max-cycles` ceiling, and emit one `VERDICT` (`GREEN`/`CONTINUE`/`STUCK`/`CAP_REACHED`/`SETUP_ERROR`) in the structured `=== SECTION ===` / `KEY=VALUE` / `STATUS=` format. The model still makes the minimal fix between invocations — the one genuinely model-shaped step.
- **Rewrote `SKILL.md`** into `skill-execution-structure` shape: `## Context` (project markers), `## Parameters` (`$ARGUMENTS` -> `test-pattern` + `--max-cycles`), imperative `## Execution` that calls the driver each cycle and branches on the verdict. Preserves the `loop-integrity.md` cross-reference required by `check-loop-integrity.sh`.

## Why

This is the deterministic, **independent** stop condition `.claude/rules/loop-integrity.md` Pillar 1 asks for (`GREEN` is the suite's own exit 0, not the worker's opinion; `CAP_REACHED`/`STUCK` are the runaway bound), made a substrate per `offload-to-deterministic-substrate`. It does not reimplement native `/loop` — it drives one cycle per invocation.

## Regression guard

Co-located `scripts/tests/test-run-test-cycle.sh` (auto-discovered by `run-skill-script-tests.sh`) exercises all five verdicts + Makefile detection, and semantically asserts `SKILL.md` retains the `$ARGUMENTS` parse, `--max-cycles`, the driver reference, and the `loop-integrity.md` link so a bulk edit cannot silently revert to argument-less prose. (Per the collision-avoidance rule, the guard lives in the co-located test, not the shared compliance script.)

## Checks

`just lint-compliance` (project-plugin all ✅), `just lint-shell`, `just lint-context-commands`, `check-loop-integrity.sh --strict`, and `run-skill-script-tests.sh` all green.

Closes #1920