### PR TITLE
feat(code-quality-plugin): adopt rubric-style instruction depth in code-review

### DIFF
--- a/code-quality-plugin/skills/code-review/SKILL.md
+++ b/code-quality-plugin/skills/code-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2025-12-16
-modified: 2026-06-15
-reviewed: 2026-04-25
+modified: 2026-07-04
+reviewed: 2026-07-04
 allowed-tools: Task, TodoWrite, Glob, Read
 model: opus
 description: Code review for quality, security, performance, and architecture. Use when reviewing code, auditing OWASP, checking SOLID, or finding perf bottlenecks and test gaps.
@@ -69,7 +69,20 @@ The code-review agent should:
 
 6. **Apply fixes** where appropriate and safe
 
-7. **Generate report** with:
+7. **Re-verify each candidate finding** (false-positive gate — run BEFORE reporting):
+   For every candidate finding from steps 1–5, re-read the cited code at the
+   reported `file:line` and confirm the claim actually holds against the current
+   source — not against a remembered or assumed shape. A finding survives only if
+   the re-read confirms it; drop the rest. See "Re-verification Pass" below.
+
+8. **Score every surviving finding** against the anchors below:
+   - Assign a **severity** (Critical/High/Medium/Low) using the "Severity Rubric".
+   - Assign a **confidence** (High/Medium/Low) using the "Confidence Scale", and
+     drop or explicitly flag findings below the reporting threshold.
+
+9. **Generate report** with:
+   - Surviving findings ranked most-severe first, each carrying its
+     `severity`, `confidence`, and verified `file:line`
    - Summary of issues found/fixed
    - Remaining manual interventions needed
    - Improvement recommendations
@@ -84,6 +97,46 @@ The agent has expertise in:
 - LSP integration for accurate diagnostics
 - Security vulnerability patterns (OWASP)
 - Performance analysis and optimization
+
+## Severity Rubric
+
+Score every surviving finding against these anchors. Rank the report
+most-severe first.
+
+| Severity | Criteria |
+|----------|----------|
+| **Critical** | Exploitable security hole, data loss/corruption, or a crash on a common path. Ship-blocker — must fix before merge. |
+| **High** | A real correctness bug that misbehaves on realistic input, a serious perf regression (N+1, unbounded growth), or an auth/validation gap without a known exploit. Fix before merge. |
+| **Medium** | Bug on an edge case, missing error handling, a test gap over important behavior, or a maintainability problem that will bite soon. Fix or file a follow-up. |
+| **Low** | Style, naming, minor readability, or a nit with no behavioral impact. Optional. |
+
+## Confidence Scale
+
+Assign each finding a confidence and let it gate what reaches the report. A
+finding whose defect you cannot demonstrate from the code in front of you is a
+guess, and guesses erode trust in the review.
+
+| Confidence | Meaning | Reporting rule |
+|------------|---------|----------------|
+| **High** | The defect is provable from the cited code — you can name the input and the wrong result. | Report. |
+| **Medium** | The defect is likely but depends on context you could not fully see. | Report, labeled as needing confirmation. |
+| **Low** | Speculative — a hunch not grounded in the code as read. | Drop, or downgrade to a one-line "consider checking X" note; never present as a defect. |
+
+The reporting threshold is **Medium**: report High and Medium findings; do not
+present Low-confidence hunches as findings.
+
+## Re-verification Pass
+
+Before the report step, re-check every candidate finding against the actual
+code. This kills false positives mechanically rather than trusting the initial
+read:
+
+1. Re-open the finding's `file:line` with `Read` and confirm the cited code
+   still says what the finding claims (line numbers drift; assumptions decay).
+2. Confirm the failure the finding describes is reachable — name the concrete
+   input or state that triggers it. If you cannot, it is Low confidence.
+3. Keep only findings that survive both checks. Every reported finding must
+   carry a verified `file:line`, a severity, and a confidence.
 
 ## Agent Teams (Optional)
 

--- a/code-quality-plugin/skills/code-review/scripts/tests/test-code-review-rubric-depth.sh
+++ b/code-quality-plugin/skills/code-review/scripts/tests/test-code-review-rubric-depth.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Regression guard for code-review/SKILL.md rubric depth (issue #1921).
+#
+# The code-review skill lost the "instruction quality" axis to the official
+# marketplace code-review plugin because ours described WHAT to review without
+# constraining HOW findings are scored and verified. #1921 folded three
+# load-bearing constructs directly into the skill body:
+#   1. a Severity Rubric with explicit Critical/High/Medium/Low anchors,
+#   2. a Confidence Scale with a reporting threshold,
+#   3. a Re-verification Pass that re-checks each candidate finding against the
+#      actual code (a false-positive gate) BEFORE the report step.
+# It also must retain the `context: fork` canary (issue #980) that already lived
+# in the frontmatter — this guard co-verifies it so a rubric-depth bulk edit
+# can't strip it.
+#
+# This is a semantic guard (per .claude/rules/regression-testing.md): a future
+# bulk edit that "tightens" the skill and silently drops any of these markers
+# would revert the instruction-depth improvement. Auto-discovered by
+# `just test-skill-scripts` (scripts/run-skill-script-tests.sh).
+#
+# Exit 0 on success, non-zero on any failure.
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+skill_md="${script_dir}/../../SKILL.md"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+pass() {
+  echo "PASS: $1"
+}
+
+[ -f "$skill_md" ] || fail "SKILL.md not found at $skill_md"
+
+# 1. Severity Rubric section with all four anchors.
+grep -q '^## Severity Rubric$' "$skill_md" \
+  || fail "SKILL.md missing '## Severity Rubric' heading (rubric depth, #1921)"
+for anchor in Critical High Medium Low; do
+  grep -q "\*\*${anchor}\*\*" "$skill_md" \
+    || fail "Severity Rubric missing the **${anchor}** severity anchor (#1921)"
+done
+pass "Severity Rubric present with Critical/High/Medium/Low anchors"
+
+# 2. Confidence Scale section with a reporting threshold.
+grep -q '^## Confidence Scale$' "$skill_md" \
+  || fail "SKILL.md missing '## Confidence Scale' heading (#1921)"
+grep -qi 'confidence' "$skill_md" \
+  || fail "SKILL.md dropped the 'confidence' token (#1921)"
+grep -qi 'threshold' "$skill_md" \
+  || fail "Confidence Scale missing a reporting threshold (#1921)"
+pass "Confidence Scale present with a reporting threshold"
+
+# 3. Re-verification Pass — the false-positive gate before reporting.
+grep -q '^## Re-verification Pass$' "$skill_md" \
+  || fail "SKILL.md missing '## Re-verification Pass' heading (false-positive gate, #1921)"
+grep -qi 'false.positive' "$skill_md" \
+  || fail "Re-verification Pass dropped the false-positive-gate rationale (#1921)"
+# The re-verification MUST precede the report step in the numbered analysis flow.
+reverify_line="$(grep -n 'Re-verify each candidate finding' "$skill_md" | head -1 | cut -d: -f1)"
+report_line="$(grep -n 'Generate report' "$skill_md" | head -1 | cut -d: -f1)"
+[ -n "$reverify_line" ] || fail "missing 'Re-verify each candidate finding' analysis step (#1921)"
+[ -n "$report_line" ] || fail "missing 'Generate report' analysis step (#1921)"
+[ "$reverify_line" -lt "$report_line" ] \
+  || fail "Re-verification step must come BEFORE report generation (#1921): reverify=$reverify_line report=$report_line"
+pass "Re-verification Pass present and ordered before report generation"
+
+# 4. The #980 canary must survive this rubric-depth edit.
+grep -q '^context: fork$' "$skill_md" \
+  || fail "SKILL.md lost the 'context: fork' canary (issue #980)"
+pass "context: fork canary preserved (#980)"
+
+# 5. Size floor: the skill body must stay under the compliance ERROR ceiling.
+size_chars="$(wc -c < "$skill_md")"
+[ "$size_chars" -le 26000 ] \
+  || fail "SKILL.md is ${size_chars} chars, over the 26000-char ERROR ceiling (skill-quality.md)"
+pass "SKILL.md size ${size_chars} chars is within the compliance ceiling"
+
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
## What

Fold rubric-style instruction depth into `code-quality-plugin/skills/code-review`, which lost the instruction-quality axis (B2, 3 v 5) to the official marketplace code-review plugin in the PR #1917 benchmark (refuter-upheld). Our skill described *what* to review without constraining *how* findings are scored and verified.

## How

Three load-bearing constructs are now embedded directly in the skill body (not deferred to the non-existent code-review agent):

- **Severity Rubric** — explicit Critical/High/Medium/Low anchors; findings are ranked most-severe first instead of listed flat.
- **Confidence Scale** — a Medium reporting threshold that drops speculative hunches rather than presenting them as defects.
- **Re-verification Pass** — a false-positive gate inserted as an analysis step *before* report generation: each candidate finding is re-read against the actual `file:line` and its concrete trigger named before it survives.

The trigger `description` and When-to-Use table are unchanged — that side of the pair already wins per the benchmark. The `context: fork` #980 canary is preserved.

## Regression guard

Per the parallel-PR collision-avoidance discipline, the guard is **co-located** in the skill's own `scripts/tests/test-code-review-rubric-depth.sh` (auto-discovered by `just test-skill-scripts`) rather than in the shared `plugin-compliance-check.sh`. It semantically asserts the rubric heading, confidence threshold, the *ordered* re-verification step (before report generation), and the #980 canary all survive future bulk edits.

## Checks

- `just lint-compliance` — pass (no code-review findings)
- `just lint-shell` on the new test — 0 errors/warnings
- `just lint-context-commands` on the SKILL.md — pass
- `just test-skill-scripts` — 53/53 pass, including the new guard
- Skill body 6648 chars, well under the 26000 ceiling

Closes #1921