### PR TITLE
fix(session-plugin): base session-survey PRS on --author, not local branch

### DIFF
--- a/session-plugin/scripts/session-survey.sh
+++ b/session-plugin/scripts/session-survey.sh
@@ -148,12 +148,31 @@ if have "$gh_bin" && "$gh_bin" auth status >/dev/null 2>&1; then
   gh_ready=true
 fi
 
+# Open PRs to surface as loose threads. Base this on the repo's actual open
+# PRs (--author @me), NOT the locally-checked-out branch: refspec pushes
+# (git push origin HEAD:refs/heads/<branch>) from parallel worktree agents
+# leave no local branch, so a branch-keyed lookup silently misses them (#1915).
+# The --head lookup is unioned in to also catch PRs authored by others on the
+# branch we happen to have checked out.
 prs_json="[]"
-if [ "$gh_ready" = true ] && [ -n "$git_branch" ]; then
-  prs_json=$( (cd "$project_dir" && "$gh_bin" pr list --head "$git_branch" \
+if [ "$gh_ready" = true ]; then
+  author_prs=$( (cd "$project_dir" && "$gh_bin" pr list --author @me --state open \
     --json number,title,url,state,updatedAt 2>/dev/null) || echo "[]")
-  [ -n "$prs_json" ] || prs_json="[]"
-  have jq && pr_count=$(printf '%s' "$prs_json" | jq 'length' 2>/dev/null || echo 0)
+  [ -n "$author_prs" ] || author_prs="[]"
+  head_prs="[]"
+  if [ -n "$git_branch" ]; then
+    head_prs=$( (cd "$project_dir" && "$gh_bin" pr list --head "$git_branch" \
+      --json number,title,url,state,updatedAt 2>/dev/null) || echo "[]")
+    [ -n "$head_prs" ] || head_prs="[]"
+  fi
+  if have jq; then
+    prs_json=$(printf '%s\n%s' "$author_prs" "$head_prs" \
+      | jq -s 'add | unique_by(.number)' 2>/dev/null || echo "[]")
+    [ -n "$prs_json" ] || prs_json="[]"
+    pr_count=$(printf '%s' "$prs_json" | jq 'length' 2>/dev/null || echo 0)
+  else
+    prs_json="$author_prs"
+  fi
 fi
 
 # GitHub drift (spinup): assigned-open issues minus those tracked in taskwarrior

--- a/session-plugin/scripts/tests/test-session-survey.sh
+++ b/session-plugin/scripts/tests/test-session-survey.sh
@@ -58,12 +58,21 @@ TASKSTUB
 chmod +x "$STUB/task"
 
 # gh stub: auth ok; issue/pr lists from fixtures.
+# "pr list" branches on the query: --author and --head can serve distinct
+# fixtures (defaulting to GH_PR_FIXTURE) so tests can exercise the #1915 union.
 cat > "$STUB/gh" <<'GHSTUB'
 #!/usr/bin/env bash
+args="$*"
 case "$1 $2" in
   "auth status") exit 0 ;;
   "issue list")  cat "$GH_ISSUE_FIXTURE" 2>/dev/null || echo "[]" ;;
-  "pr list")     cat "$GH_PR_FIXTURE" 2>/dev/null || echo "[]" ;;
+  "pr list")
+    case "$args" in
+      *--author*) cat "${GH_PR_AUTHOR_FIXTURE:-$GH_PR_FIXTURE}" 2>/dev/null || echo "[]" ;;
+      *--head*)   cat "${GH_PR_HEAD_FIXTURE:-$GH_PR_FIXTURE}" 2>/dev/null || echo "[]" ;;
+      *)          cat "$GH_PR_FIXTURE" 2>/dev/null || echo "[]" ;;
+    esac
+    ;;
   *) echo "[]" ;;
 esac
 GHSTUB
@@ -121,6 +130,20 @@ check "G: commits section present" "$out" "=== COMMITS ==="
 check "G: recent commit subject surfaced" "$out" "second commit"
 out=$(run)
 check_absent "G: commits omitted without the flag" "$out" "=== COMMITS ==="
+
+# --- TEST H: authored PR with no matching local branch is surfaced (#1915) ---
+# Refspec-pushed PRs leave no local branch; --author @me must still find them.
+echo '[{"number":27,"title":"feat: refspec-pushed PR","url":"http://x/27","state":"OPEN","updatedAt":"2026-07-02T10:00:00Z"}]' > "$SANDBOX/author-prs.json"
+export GH_PR_AUTHOR_FIXTURE="$SANDBOX/author-prs.json" GH_PR_HEAD_FIXTURE=/dev/null
+out=$(run)
+check "H: authored PR counted despite no local branch" "$out" "PR_COUNT=1"
+check "H: authored PR number surfaced" "$out" "PR_1_NUMBER=27"
+
+# --- TEST I: author + head PRs are unioned and deduped by number (#1915) -----
+export GH_PR_HEAD_FIXTURE="$SANDBOX/author-prs.json"
+out=$(run)
+check "I: overlapping author/head PR deduped" "$out" "PR_COUNT=1"
+unset GH_PR_AUTHOR_FIXTURE GH_PR_HEAD_FIXTURE
 
 # --- TEST F: no-git / no-tools degrade cleanly ------------------------------
 out=$(SESSION_SURVEY_TASK_BIN=/nonexistent/task SESSION_SURVEY_GH_BIN=/nonexistent/gh \


### PR DESCRIPTION
## Problem

The `session-survey.sh` PRS section gated PR detection on the locally-checked-out branch (`gh pr list --head $git_branch`). Refspec-pushed PRs — the standard pattern for parallel worktree agents that push via `git push origin HEAD:refs/heads/<branch>` and leave no local branch — were silently missed, so a session with 7 open authored PRs reported `PR_COUNT=0`.

## Fix

Base the section on the repo's actual open PRs (`gh pr list --author @me --state open`), unioned with the existing `--head` lookup and deduped by number so PRs authored by others on the checked-out branch are still caught. Without `jq`, the count falls back to the author list (matching prior no-jq behaviour).

## Tests

- Extended the `gh` stub in `test-session-survey.sh` to serve distinct `--author` / `--head` fixtures.
- **TEST H** (the #1915 case): an authored PR with no matching local branch now yields `PR_COUNT=1` / `PR_1_NUMBER=27` — fails on the old branch-keyed code.
- **TEST I**: overlapping author/head PRs are unioned and deduped (`PR_COUNT=1`).
- Full suite green (`PASS=26 FAIL=0`); `just lint-shell`, `just lint-compliance`, and shellcheck clean.

Closes #1915