### PR TITLE
fix(git-plugin): normalize issue refs in git-issue-hierarchy

### DIFF
--- a/git-plugin/skills/git-issue-hierarchy/SKILL.md
+++ b/git-plugin/skills/git-issue-hierarchy/SKILL.md
@@ -4,8 +4,8 @@ modified: 2026-06-18
 reviewed: 2026-04-25
 name: git-issue-hierarchy
 description: "Manage GitHub sub-issues and dependencies (blocked_by/blocking). Use when breaking issues into sub-tasks, checking progress, or viewing a dependency graph."
-args: "<parent-issue> [--add <N...>] [--remove <N...>] [--create \"title\"] [--status] [--deps] [--blocking] [--block <N>] [--blocked-by <N>] [--unblock <N>]"
-argument-hint: <parent-issue> [--add N] [--status] [--deps] [--blocked-by N]
+args: "<parent-issue (number | #N | URL)> [--add <N...>] [--remove <N...>] [--create \"title\"] [--status] [--deps] [--blocking] [--block <N>] [--blocked-by <N>] [--unblock <N>]"
+argument-hint: "<parent-issue (number|#N|URL)> [--add N] [--status] [--deps] [--blocked-by N]"
 user-invocable: true
 allowed-tools: Bash(gh api *), Bash(gh issue *), Bash(git remote *), Read, Grep, Glob, TodoWrite
 ---
@@ -28,19 +28,23 @@ allowed-tools: Bash(gh api *), Bash(gh issue *), Bash(git remote *), Read, Grep,
 
 Parse these parameters from the command:
 
+Every issue argument — `<parent-issue>` and each `<N>` flag value below — is
+accepted as a bare number, `#N`, or a full GitHub issue URL, and normalized to a
+`(number, repo)` pair in Step 0.
+
 | Parameter | Description |
 |-----------|-------------|
-| `<parent-issue>` | Issue number to manage as parent |
-| `--add <N...>` | Add existing issues as sub-issues |
+| `<parent-issue>` | Parent issue as a bare number, `#N`, or full GitHub issue URL (`https://github.com/<owner>/<repo>/issues/<N>`) — see Step 0 |
+| `--add <N...>` | Add existing issues as sub-issues (each `N` as number, `#N`, or URL) |
 | `--create "<title>"` | Create a new issue and add it as sub-issue |
-| `--remove <N...>` | Remove sub-issues from parent |
+| `--remove <N...>` | Remove sub-issues from parent (each `N` as number, `#N`, or URL) |
 | `--status` | Show sub-issue completion progress |
 | `--list` | List all sub-issues of the parent |
 | `--deps` | Show dependency graph (blocked_by + blocking + sub-issues) for the issue |
 | `--blocking` | List issues the parent is blocking |
-| `--block <N>` | Mark issue N as blocked by the parent (parent blocks N) |
-| `--blocked-by <N>` | Mark the parent as blocked by issue N |
-| `--unblock <N>` | Remove blocking relationship with issue N in either direction |
+| `--block <N>` | Mark issue N as blocked by the parent (parent blocks N); `N` as number, `#N`, or URL |
+| `--blocked-by <N>` | Mark the parent as blocked by issue N; `N` as number, `#N`, or URL |
+| `--unblock <N>` | Remove blocking relationship with issue N in either direction; `N` as number, `#N`, or URL |
 
 ## When to Use
 
@@ -71,6 +75,39 @@ both — a sub-issue is implicitly ordered by its parent's scope.
 
 Execute the requested issue hierarchy operation.
 
+### Step 0: Normalize issue references
+
+Before any API call, normalize `<parent-issue>` **and every issue value passed
+to a flag** (`--add`, `--remove`, `--block`, `--blocked-by`, `--unblock`) into a
+`(number, repo)` pair. Accept these forms:
+
+| Input form | Extract |
+|------------|---------|
+| `123` | number `123`, repo = current remote |
+| `#123` | number `123`, repo = current remote |
+| `https://github.com/<owner>/<repo>/issues/123` | number `123`, repo = `<owner>/<repo>` |
+| `.../issues/123#issuecomment-...` | number `123` (drop the `#...` fragment), repo = `<owner>/<repo>` |
+
+Rules:
+
+1. Strip a leading `#`; strip a URL `#...` fragment after the number. A token is
+   an issue ref only if, after stripping, it is all digits **or** matches the
+   `/issues/<digits>` URL shape (require trailing digits — a `/pull/<N>`,
+   `/discussions/<N>`, or bare `/issues` list URL is **not** a ref).
+2. For the plural flags (`--add`/`--remove`, which take `<N...>`), normalize
+   each space-separated value independently; never split a single URL into two
+   refs.
+3. For a URL whose `<owner>/<repo>` differs from the current remote (Step 1
+   `REPO`), record it as **cross-repo** and carry `-R <owner>/<repo>` on every
+   `gh issue` call and target `repos/<owner>/<repo>/…` on every `gh api` call
+   for that issue. Sub-issue and dependency links require both endpoints to live
+   in the **same** repo — if a normalized ref points at a different repo than
+   the parent, surface that rather than issuing a mismatched cross-repo link.
+
+Downstream steps use the normalized `$PARENT`, `$N`, and `$CHILD` **numbers**;
+where a ref was cross-repo, substitute its `<owner>/<repo>` for `$OWNER`/`$REPO_NAME`
+and add `-R <owner>/<repo>` to the corresponding `gh issue` call.
+
 ### Step 1: Resolve Repository Context
 
 ```bash
@@ -78,6 +115,10 @@ REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 OWNER=$(echo "$REPO" | cut -d/ -f1)
 REPO_NAME=$(echo "$REPO" | cut -d/ -f2)
 ```
+
+If Step 0 normalized `<parent-issue>` to a **cross-repo** URL, use that URL's
+`<owner>/<repo>` as `$OWNER`/`$REPO_NAME` (and pass `-R <owner>/<repo>` to the
+`gh issue view` below) instead of the current remote.
 
 Verify the parent issue exists:
 

--- a/git-plugin/skills/git-issue-hierarchy/scripts/tests/test-issue-ref-normalization.sh
+++ b/git-plugin/skills/git-issue-hierarchy/scripts/tests/test-issue-ref-normalization.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Semantic regression guard for git-issue-hierarchy (issue #1660).
+#
+# The skill consumes every issue argument (`<parent-issue>` and each `<N>` flag
+# value: --add/--remove/--block/--blocked-by/--unblock) as a bare numeric ID
+# piped straight into `gh api repos/$OWNER/$REPO/issues/$N/...`. The
+# argument-handling sweep (.claude/rules/skill-argument-handling.md) flagged the
+# input-form gap (axis 1) + cross-context gap (axis 9): a user pasting `#N` or a
+# GitHub issue URL — or a URL pointing at a DIFFERENT repo — had it silently
+# ignored. The fix adds a Step 0 that normalizes `N | #N | URL -> (number, repo)`
+# and carries `-R <owner>/<repo>` for cross-repo refs.
+#
+# This guard asserts the fix survives future bulk edits. It pins a
+# NORMALIZATION-specific marker (`normaliz`) plus the cross-repo `-R ` plumbing.
+# It deliberately does NOT reuse the bare `/issues/` token that the sibling
+# git-issue guard uses — in this skill `/issues/` already appears throughout as
+# `gh api ...` endpoint paths, so that token would pass spuriously here.
+#
+# Exit 0 on success, non-zero on failure.
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+skill_md="${script_dir}/../../SKILL.md"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+pass() {
+  echo "PASS: $1"
+}
+
+[ -f "$skill_md" ] || fail "SKILL.md not found at $skill_md"
+
+body="$(cat "$skill_md")"
+
+# 1. A normalization step must be present (case-insensitive `normaliz` catches
+#    "Normalize" / "normalization" / "normalized").
+grep -iq 'normaliz' <<<"$body" \
+  || fail "SKILL.md dropped the issue-ref normalization step (no 'normaliz' marker); #N / URL forms would be ignored again"
+pass "normalization marker present"
+
+# 2. Cross-repo (#N/URL pointing at another repo) plumbing must be present.
+grep -q -- '-R ' <<<"$body" \
+  || fail "SKILL.md dropped cross-repo '-R ' plumbing; a URL for a different repo would hit the wrong remote"
+pass "cross-repo -R plumbing present"
+
+# 3. The normalization must actually cover the URL form (axis 1), not just #N.
+grep -q '/issues/<N>\|/issues/<digits>\|/issues/123' <<<"$body" \
+  || fail "SKILL.md normalization no longer references the /issues/<N> URL shape"
+pass "issue-URL form referenced in normalization"
+
+# 4. The Step 0 heading anchors the normalization at the start of Execution.
+grep -q '^### Step 0: Normalize issue references' <<<"$body" \
+  || fail "SKILL.md lost the 'Step 0: Normalize issue references' section heading"
+pass "Step 0 normalization heading present"
+
+echo "STATUS=OK"


### PR DESCRIPTION
Part of the skill argument-handling sweep (#1660) — PR 1, the highest-confidence slice.

## Problem

`git-issue-hierarchy` consumed every issue argument (`<parent-issue>` and each `<N>` flag value for `--add`/`--remove`/`--block`/`--blocked-by`/`--unblock`) as a **bare numeric ID** piped straight into `gh api repos/$OWNER/$REPO/issues/$N/...`. So:

- A user pasting `#N` or a full GitHub issue URL had it silently ignored (input-form gap, rubric axis 1).
- A URL pointing at a **different** repo than the current remote had no `-R owner/repo` plumbing (cross-context gap, axis 9).

This is the same class and fix already landed for `git-issue` / `git-issue-manage`.

## Fix

- **Step 0: Normalize issue references** — maps `N | #N | URL -> (number, repo)` for `<parent-issue>` and every flag value, carrying `-R <owner>/<repo>` on cross-repo refs and guarding sub-issue/dependency links against repo mismatch.
- Updated `args` / `argument-hint` and the `## Parameters` table to advertise the accepted forms.
- Step 1 now uses a cross-repo parent URL's `<owner>/<repo>` instead of the current remote.

## Regression guard

Per `.claude/rules/regression-testing.md`, added a **co-located** semantic guard (`git-plugin/skills/git-issue-hierarchy/scripts/tests/test-issue-ref-normalization.sh`, auto-discovered by `just test-skill-scripts`) asserting the SKILL.md retains the `normaliz` marker + the `-R ` cross-repo plumbing + the Step 0 heading. Verified RED on `origin/main`, GREEN after the fix. It deliberately does **not** reuse the `/issues/` token the `git-issue` guard uses (in this skill `/issues/` already appears as `gh api` endpoint paths, so it would pass spuriously).

The remaining sweep PRs (code-refactor / meta-assimilate, workflow-preflight, git-commit-push-pr / blueprint-work-order, and the §7 methodology refinements + A3 haiku cold-read) stay tracked under #1660.

## Checks

- `just lint-compliance` — pass (exit 0)
- `just lint-shell` — pass (0 errors)
- `just test-skill-scripts` — pass (53/53)

Closes #1660