### PR TITLE
feat(git-plugin): modernize git-maintain with git maintenance and geometric repacking

### DIFF
--- a/git-plugin/README.md
+++ b/git-plugin/README.md
@@ -24,7 +24,7 @@ See [`docs/flow.md`](docs/flow.md) for a diagram of how the skills fit together.
 | `/git:pr-feedback` | Review PR workflow results and comments, address substantive feedback from reviewers |
 | `/git:conflicts` | Resolve merge conflicts with zdiff3, rerere, and modern git tooling |
 | `/git:resolve-conflicts` | Resolve merge conflicts in PRs automatically |
-| `/git:maintain` | Repository maintenance and cleanup (prune, gc, verify, branches, stash) |
+| `/git:maintain` | Repository maintenance and cleanup (incremental repack, gc, prune, verify, branches, stash) |
 | `/git:deadbranch` | Survey and clean up stale branches via the deadbranch CLI — dry-run preview, TUI or non-interactive delete, recoverable backups |
 | `/git:derive-docs` | Analyze git history to derive undocumented rules, PRDs, ADRs, and PRPs |
 | `/git:upstream-pr` | Submit clean PRs to upstream repositories from fork work |

--- a/git-plugin/skills/git-maintain/SKILL.md
+++ b/git-plugin/skills/git-maintain/SKILL.md
@@ -1,12 +1,12 @@
 ---
 created: 2025-12-16
-modified: 2026-05-09
-reviewed: 2026-04-25
-allowed-tools: Bash(git status *), Bash(git branch *), Bash(git stash *), Bash(git prune *), Bash(git gc *), Bash(git repack *), Bash(git fsck *), Bash(git rm *), Bash(du *), Read, Glob, TodoWrite
-args: "[--prune] [--gc] [--verify] [--branches] [--stash] [--all]"
-argument-hint: "[--prune] [--gc] [--verify] [--branches] [--stash] [--all]"
+modified: 2026-07-04
+reviewed: 2026-07-04
+allowed-tools: Bash(git status *), Bash(git branch *), Bash(git stash *), Bash(git prune *), Bash(git gc *), Bash(git repack *), Bash(git maintenance *), Bash(git fsck *), Bash(git rm *), Bash(du *), Read, Glob, TodoWrite
+args: "[--prune] [--gc] [--background] [--verify] [--branches] [--stash] [--all]"
+argument-hint: "[--prune] [--gc] [--background] [--verify] [--branches] [--stash] [--all]"
 disable-model-invocation: true
-description: "Repo maintenance — gc, branch pruning, stash cleanup, fsck. Use when asked to clean up the repo, run git gc, delete merged branches, prune stashes, or shrink .git."
+description: "Repo maintenance — incremental repack, gc, branch pruning, stash cleanup, fsck. Use when asked to clean up the repo, run git maintenance/gc, delete merged branches, prune stashes, or shrink .git."
 name: git-maintain
 ---
 
@@ -31,8 +31,9 @@ name: git-maintain
 
 Parse these parameters from the command (all optional):
 
-- `--prune`: Remove unreachable objects and optimize repository
-- `--gc`: Run git garbage collection (aggressive)
+- `--prune`: Remove unreachable objects and run an incremental geometric repack
+- `--gc`: Force a full `git gc` consolidation (only when a repo has degraded badly — prefer the incremental repack)
+- `--background`: Register the repo for hourly background maintenance (`git maintenance start`) instead of a blocking one-shot pass
 - `--verify`: Verify integrity of git objects
 - `--branches`: Clean up merged branches only
 - `--stash`: Clean up stashes only
@@ -66,20 +67,45 @@ Perform repository maintenance and cleanup based on the flags provided.
 - Drop stashes from deleted branches
 - **Require user confirmation** before dropping stashes
 
-### Step 5: Repository optimization (if --prune, --gc, or --all)
+### Step 5: Repository optimization (if --prune, --gc, --background, or --all)
+
+**Prefer incremental maintenance over `gc --aggressive`.** Modern Git (2.31+)
+replaced the blocking, rewrite-everything `git gc --aggressive` pass with
+`git maintenance` and **geometric repacking**, which organizes packfiles in
+logarithmic layers by object count. Geometric repacking is the default for
+manual maintenance in recent Git (2.52+) and avoids the destructive,
+time-consuming "all-in-one" repack. Default to it.
 
 ```bash
-# Prune unreachable objects
-git prune
+# Incremental geometric repack — logarithmic pack layering + on-disk
+# multi-pack index; far cheaper than `gc --aggressive`, safe to run often
+git repack --geometric=2 -d --write-midx
 
-# Run garbage collection
-git gc --aggressive
-
-# Repack objects
-git repack -ad
+# Prune unreachable objects older than the default grace window
+git prune --expire=2.weeks.ago
 
 # Show size improvement
 du -sh .git
+```
+
+For hands-off upkeep (`--background`), register the repo so Git quietly
+pre-fetches, optimizes the commit-graph, and repacks loose objects on a
+schedule instead of blocking on a manual pass:
+
+```bash
+# Register hourly background maintenance (one-time, per repo)
+git maintenance start
+
+# Or run the standard task set once, on demand (non-blocking, incremental)
+git maintenance run --task=commit-graph --task=incremental-repack --task=loose-objects
+```
+
+Reserve a full `git gc` for a repo that has genuinely degraded (only with
+`--gc`); skip `--aggressive` unless a one-off deep repack is explicitly needed:
+
+```bash
+# Full consolidation — only when --gc is requested and the repo is degraded
+git gc
 ```
 
 ### Step 6: Verify repository integrity (if --verify or --all)
@@ -98,13 +124,25 @@ Report any issues found.
 ## Safe Operations
 
 These operations are safe and non-destructive:
-- `git gc` - Garbage collection
+- `git repack --geometric=2 -d --write-midx` - Incremental geometric repack (preferred)
+- `git maintenance run` / `git maintenance start` - Incremental background upkeep
+- `git gc` - Full garbage collection (reserve for degraded repos)
 - `git prune` - Prune unreachable objects
 - `git fsck` - Verify integrity
 
 These require user confirmation:
 - `git branch -d` - Delete branches
 - `git stash drop` - Drop stashes
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Routine optimize | `git repack --geometric=2 -d --write-midx` |
+| Hands-off upkeep | `git maintenance start` |
+| One-shot incremental pass | `git maintenance run --task=incremental-repack --task=commit-graph` |
+| Integrity check | `git fsck --full --strict` |
+| Size before/after | `du -sh .git` |
 
 ## See Also
 

--- a/scripts/plugin-compliance-check.sh
+++ b/scripts/plugin-compliance-check.sh
@@ -593,6 +593,22 @@ check_skill_body() {
       done
     fi
 
+    # Regression: git-maintain must prefer modern incremental maintenance over
+    # the legacy blocking `git gc --aggressive` / `git repack -ad` pass. Git 2.31+
+    # introduced `git maintenance` and geometric repacking (default for manual
+    # maintenance in 2.52+), which organizes packfiles in logarithmic layers and
+    # avoids the destructive all-in-one repack. A bulk edit reverting to
+    # `gc --aggressive` as the default would silently restore the slow path, so
+    # assert the two load-bearing modern commands survive.
+    if [ "$skill_name" = "git-maintain" ]; then
+      for token in 'git repack --geometric' 'git maintenance'; do
+        if ! grep -qF "$token" "$skill_file"; then
+          issues+=("❌ ${plugin}/${skill_name}: SKILL.md must prefer modern incremental maintenance token '${token}' over 'gc --aggressive'")
+          has_errors=true
+        fi
+      done
+    fi
+
     # Regression: execution-grounded-review is the execution-grounded verifier in
     # the agent-patterns review family — the one thing that distinguishes it from
     # adversarial-review (which reads a design) is that it RUNS the suite first


### PR DESCRIPTION
## Summary

Reviewed the GitHub-Blog Git-evolution history against `git-plugin` and modernized the one skill that was teaching a pattern the evolution explicitly retired.

`/git:maintain` Step 5 ran the legacy blocking `git gc --aggressive` + `git repack -ad` pass — exactly the destructive "all-in-one" repack that **`git maintenance`** (Git 2.31, 2021) and **geometric repacking** (default for manual maintenance in 2.52+) were built to replace.

## Changes

- **`git-maintain/SKILL.md`**
  - Step 5 defaults to `git repack --geometric=2 -d --write-midx` (logarithmic pack layering + on-disk multi-pack index); full `git gc` is reserved for genuinely degraded repos, and `--aggressive` is no longer the default.
  - New `--background` flag registers hourly `git maintenance start` upkeep (or `git maintenance run --task=...` for a one-shot incremental pass).
  - Added an **Agentic Optimizations** table; refreshed **Safe Operations** and the parameters list; `git maintenance` added to `allowed-tools`; description/dates updated.
- **`scripts/plugin-compliance-check.sh`** — semantic guard scoped to `git-maintain` asserting `git repack --geometric` and `git maintenance` survive, so a bulk edit can't silently revert to `gc --aggressive`.
- **`git-plugin/README.md`** — skill-table description updated to match.

## Verification

- `git repack --geometric=2 -d --write-midx`, `git maintenance run --task=...`, and `git prune --expire=...` all confirmed working on the environment's Git 2.43.
- `plugin-compliance-check.sh git-plugin` passes (Body ✅); the new guard fires when either modern command is removed.

## Scope notes (assessment of the rest of the evolution list)

Already adopted, no change needed: `git switch`/`git restore` (used throughout), `git rebase --update-refs` (covered in `git-rebase-patterns`). Deliberately not added here: a dedicated `/git:worktree` skill and a monorepo-scale skill (Scalar / sparse-checkout / partial clone / FSMonitor) — larger net-new additions worth a separate scoping decision. The 2024–2026 items (`git replay`, `git last-modified`, `git history`, parallel hooks) were left out as niche or version-unverifiable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApCAdRs4ei762sZjyTvSE3

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApCAdRs4ei762sZjyTvSE3)_