### PR TITLE
feat(comfyui-plugin): add shim variant to comfyui-node-scaffold

### DIFF
--- a/comfyui-plugin/README.md
+++ b/comfyui-plugin/README.md
@@ -28,14 +28,16 @@ Scaffold a new ComfyUI custom-node repository ready for implementation, in the
 - vitest (imports the `.ts` source) + pytest harness
 - `src/index.ts` + `src/comfyui-shims.d.ts`, `__init__.py`
   (`WEB_DIRECTORY = "./web/dist"`), `CLAUDE.md`, and a migration ADR
-- Three variants: `frontend` (per-widget modal), `backend` (adds a node +
-  aiohttp endpoints), `gesture` (canvas pointer layer — pinch/drag)
+- Four variants: `frontend` (per-widget modal), `backend` (adds a node +
+  aiohttp endpoints), `gesture` (canvas pointer layer — pinch/drag), `shim`
+  (scoped CSS injection + commands — no modal, for papering over upstream
+  frontend bugs)
 
 The `frontend`/`backend` (modal) variants consume the shared
 [`@laurigates/comfy-modal-kit`](https://www.npmjs.com/package/@laurigates/comfy-modal-kit)
 primitives via an `import` (inlined by `bun build`) — they no longer copy
-`modal-shell.js` / `modal-fuzzy.js` in. The `gesture` variant has no kit
-dependency.
+`modal-shell.js` / `modal-fuzzy.js` in. The `gesture` and `shim` variants have
+no kit dependency.
 
 The generated `CLAUDE.md` teaches the pack to **verify the LiteGraph/canvas API
 against the frontend sourcemap** (the `api-*.js.map` chunk) before coding against

--- a/comfyui-plugin/skills/comfyui-node-scaffold/SKILL.md
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/SKILL.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-06-04
-modified: 2026-07-01
-reviewed: 2026-07-01
+modified: 2026-07-04
+reviewed: 2026-07-04
 name: comfyui-node-scaffold
 description: >-
   Scaffold a new ComfyUI custom-node repo (TypeScript + bun build, CI,
@@ -59,13 +59,14 @@ inputs, big tap targets, momentum scroll). The modal primitives come from
 `@laurigates/comfy-modal-kit` (`openModalShell` / `fuzzyRank` /
 `highlightMatches`) — **imported, not copied** — and `bun build` inlines them.
 
-## Three variants
+## Four variants
 
 | Variant | Use when | Shape | Modal kit |
 |---------|----------|-------|-----------|
 | `frontend` (default) | No Python needed — pure widget UX (seed/numeric keypad, prompt editor, tooltips, enum recipes). | Empty `NODE_CLASS_MAPPINGS`; widget-intercept modal in `src/index.ts`. Like sampler-info / touch-numeric. | **imports** the kit |
 | `backend` | Needs to read disk / serve thumbnails / add a node (model thumbnails, file listings). | Adds `<module>.py` (node + aiohttp endpoints, ComfyUI-bundled libs only) + a `tests/conftest.py` that stubs aiohttp/server so pytest is green. Like gallery-loader. | **imports** the kit |
 | `gesture` | The UX is a **canvas interaction**, not a widget — pinch/drag/long-press on nodes or groups (resize, move, region-box). | Empty `NODE_CLASS_MAPPINGS`; a canvas pointer layer in `src/index.ts` with exported pure geometry helpers. Like touch-resize. | **no kit** |
+| `shim` | The pack's whole job is **injecting scoped CSS / registering commands** to paper over upstream frontend bugs — no modal, no widget hook. | Empty `NODE_CLASS_MAPPINGS`; a `SHIMS` registry in `src/index.ts` with `applyCssShim`/`removeCssShim`, one managed `<style>` per shim driven by a boolean setting, + a jsdom lifecycle smoke test. Like comfyui-touch-shim. | **no kit** |
 
 **The `--widgets` switch picks the modal shape.** On a modal variant
 (`frontend` / `backend`), passing `--widgets a,b` emits the **widget-intercept**
@@ -83,7 +84,9 @@ otherwise passes pure-helper unit tests.
 **Decision rule:** `frontend`/`backend` **with** `--widgets` for a per-widget
 modal; `frontend`/`backend` **without** `--widgets` for a standalone modal opened
 from the toolbar/command palette; `gesture` when the interaction is on the
-canvas/node frame itself (no widget to hook). Add `backend` only when the feature
+canvas/node frame itself (no widget to hook); `shim` when the pack only injects
+scoped CSS / registers commands to paper over an upstream frontend bug (no modal,
+no widget). Add `backend` only when the feature
 genuinely needs the server to read files or serve data. A non-bundled Python
 dependency is never allowed — if you reach for one, it belongs in a separate
 companion pack.
@@ -95,6 +98,19 @@ the gesture lands on a selected target. It is a no-op when `app.canvas` is
 absent, so the native control always survives. Pure math (distance, hit-test,
 scale-clamp) lives in exported, unit-tested helpers; DOM/canvas wiring stays
 below them. It has **no** `@laurigates/comfy-modal-kit` dependency.
+
+The `shim` variant is a home for **small, individually-toggleable stopgap
+fixes** that paper over upstream ComfyUI-frontend bugs. It has **no modal and no
+widget hook**: `src/index.ts` is a `SHIMS` registry where each entry injects a
+scoped, managed `<style>` tag (idempotent `applyCssShim`/`removeCssShim`, one
+`<style>` per shim) driven by a boolean setting, plus a command. Every shim
+links the upstream issue it papers over (in `upstream` + the settings tooltip)
+and is deleted the release the upstream fix ships; selectors should target
+stable `data-testid` hooks and every shim must **fail soft** (a dead selector
+styles nothing, never throws). The lifecycle helpers are exported and covered by
+a jsdom smoke test (inject / idempotent / remove; `jsdom` added to
+`devDependencies`). It has **no** `@laurigates/comfy-modal-kit` dependency. Like
+comfyui-touch-shim.
 
 ## How to run
 
@@ -126,11 +142,18 @@ Canvas-gesture pack (resize/move/region — no widget, no modal, no kit):
 python3 ${CLAUDE_SKILL_DIR}/scaffold.py --name comfyui-touch-resize --display "Touch Resize" --desc "Selection-gated pinch-to-resize for ComfyUI nodes and groups on touch devices." --variant gesture
 ```
 
+CSS/shim pack (scoped `<style>` injection + commands — no modal, no widget, no kit):
+
+```sh
+python3 ${CLAUDE_SKILL_DIR}/scaffold.py --name comfyui-touch-shim --display "Touch Shim" --desc "Stopgap mobile CSS shims for upstream ComfyUI frontend bugs." --variant shim
+```
+
 Flags: `--name` (repo + served URL segment), `--display` (Comfy DisplayName),
-`--desc`, `--variant {frontend,backend,gesture}`, `--widgets` (CSV → the TS
+`--desc`, `--variant {frontend,backend,gesture,shim}`, `--widgets` (CSV → the TS
 stub's `TARGET_WIDGETS`; on a modal variant, **omitting** it emits the
-standalone-modal skeleton instead of the widget-intercept one), `--publisher`
-(default `laurigates`), `--dir` (parent dir, default cwd).
+standalone-modal skeleton instead of the widget-intercept one; ignored by
+`gesture` and `shim`), `--publisher` (default `laurigates`), `--dir` (parent dir,
+default cwd).
 
 It refuses to overwrite an existing directory.
 
@@ -195,7 +218,9 @@ Then implement, and wire up infra:
    For the `backend` variant, fill in `<module>.py`'s node + endpoints; widen
    `ALLOWED_EXTENSIONS` explicitly for any new file type read off disk. For the
    `gesture` variant, tune the pinch layer
-   (`selectedNodes`/`nodeScreenRect`/`scaledSize`).
+   (`selectedNodes`/`nodeScreenRect`/`scaledSize`). For the `shim` variant,
+   replace the placeholder `SHIMS` entry — link the upstream issue, point the
+   selector at a stable `data-testid`, keep each shim fail-soft.
 2. **Add the repo to `gitops/repositories.tf`** with `comfy_registry = true`
    (and `release_please = true`). On apply, gitops pushes both the release-please
    App credentials **and** the `REGISTRY_ACCESS_TOKEN` secret. No per-repo secret
@@ -211,7 +236,8 @@ chains scaffold → `gh repo create` → seed `main` → the gitops PR.
   `web/dist/` (it is generated; rebuild with `bun run build` and commit).
 - **Modal primitives come from `@laurigates/comfy-modal-kit`** (modal variants)
   — import them; never copy `modal-shell.js`/`modal-fuzzy.js` into the pack.
-  `bun build` inlines the imported code. The gesture variant has no kit.
+  `bun build` inlines the imported code. The `gesture` and `shim` variants have
+  no kit (no modal at all).
 - **Pack directory name is part of the served URL** (`/extensions/<name>/index.js`).
 - **No non-bundled Python deps.** `dependencies` is `comfyui-frontend-package`
   only; the backend variant may use ComfyUI-bundled `aiohttp` / `folder_paths` /
@@ -253,6 +279,7 @@ The generated `publish.yml` builds `web/dist/` then publishes via
 |---------|---------|
 | Scaffold a frontend pack | `python3 ${CLAUDE_SKILL_DIR}/scaffold.py --name comfyui-X --display "X" --desc "…" --variant frontend --widgets a,b` |
 | Scaffold a gesture pack | `python3 ${CLAUDE_SKILL_DIR}/scaffold.py --name comfyui-X --display "X" --desc "…" --variant gesture` |
+| Scaffold a CSS/shim pack | `python3 ${CLAUDE_SKILL_DIR}/scaffold.py --name comfyui-X --display "X" --desc "…" --variant shim` |
 | Verify a generated pack | `cd comfyui-X && bun install && just check` |
 
 ## Notes & deferrals

--- a/comfyui-plugin/skills/comfyui-node-scaffold/scaffold.py
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/scaffold.py
@@ -748,6 +748,141 @@ app.registerExtension({
 });
 """
 
+# --------------------------------------------------------------------------- #
+# TypeScript source — shim variant (CSS-injection + command, no modal-kit dep)
+# --------------------------------------------------------------------------- #
+INDEX_TS_SHIM = """\
+// @@DISPLAY@@ — ComfyUI frontend extension (CSS/shim pack).
+//
+// TypeScript source in `src/`, built to ESM via `bun build` and emitted to
+// `web/dist/` (served at /extensions/@@NAME@@/index.js — the pack directory
+// name IS the URL segment). Do not rename the pack dir without syncing
+// EXT_NAME below. See ADR-0001.
+//
+// Pattern ("the shim vein"): a home for SMALL, individually-toggleable stopgap
+// fixes that paper over upstream ComfyUI-frontend bugs. Unlike the sibling
+// packs there is NO modal and NO widget hook — each shim injects a scoped,
+// managed `<style>` tag (driven by a boolean setting) and the pack registers
+// commands. Every shim links the upstream issue it papers over (in `upstream`
+// + the settings tooltip) and is deleted the release the upstream fix ships.
+//
+// CSS selectors should target stable `data-testid` hooks where the frontend
+// provides them; anything keyed on compiled Tailwind class chains is brittle
+// across frontend releases and is expected to rot — each shim must FAIL SOFT
+// (a dead selector styles nothing, never throws).
+//
+// This variant has NO @@MODAL_KIT_PKG@@ dependency — there is no widget to
+// hook and no modal to open. The CSS-shim lifecycle helpers are exported and
+// unit-tested (tests/js); the registerExtension wiring below is exercised in
+// the manual browser matrix.
+//
+// ComfyUI serves its frontend API at runtime from `/scripts/app.js`. The
+// emitted import string stays `/scripts/app.js` (bun's `--external '/scripts/*'`
+// keeps it unbundled); the type is supplied via a `paths` mapping in
+// tsconfig.json that points the import at `src/comfyui-shims.d.ts`. See ADR-0001.
+import type { ComfyApp } from "@comfyorg/comfyui-frontend-types";
+import { app } from "/scripts/app.js";
+
+const EXT_NAME = "@@NAME@@";
+
+// ============================================================
+// Shim registry
+// ============================================================
+
+export interface CssShim {
+  /** PascalCase suffix of the `@@DISPLAY_NOSPACE@@.<Id>` boolean setting. */
+  id: string;
+  /** Settings-UI label. */
+  name: string;
+  /** Upstream issue this shim papers over. Delete the shim when it closes. */
+  upstream: string;
+  /** One-line settings tooltip (the upstream URL is appended). */
+  tooltip: string;
+  css: string;
+}
+
+// Placeholder shim — replace with a real stopgap. Every shim MUST link an
+// upstream issue and carry non-empty css/tooltip (asserted in tests/js). The
+// selector below is inert (nothing matches `[data-testid="@@SHORT@@-example"]`),
+// so it fails soft until you point it at a real hook.
+const exampleShim: CssShim = {
+  id: "Example",
+  name: "@@DISPLAY@@ example shim",
+  upstream: "https://github.com/Comfy-Org/ComfyUI_frontend/issues",
+  tooltip: "Replace this placeholder with a real stopgap for an upstream frontend bug.",
+  css: `
+[data-testid="@@SHORT@@-example"] {
+  outline: 1px solid transparent;
+}
+`,
+};
+
+export const SHIMS: CssShim[] = [exampleShim];
+
+// ============================================================
+// CSS shim lifecycle — one managed <style> per shim, idempotent
+// ============================================================
+
+export function styleElementId(shim: Pick<CssShim, "id">): string {
+  return `${EXT_NAME}-${shim.id}`;
+}
+
+export function applyCssShim(shim: CssShim, doc: Document = document): void {
+  if (doc.getElementById(styleElementId(shim))) return;
+  const style = doc.createElement("style");
+  style.id = styleElementId(shim);
+  style.textContent = `/* ${EXT_NAME}: ${shim.name} — stopgap for ${shim.upstream} */${shim.css}`;
+  doc.head.appendChild(style);
+}
+
+export function removeCssShim(shim: Pick<CssShim, "id">, doc: Document = document): void {
+  doc.getElementById(styleElementId(shim))?.remove();
+}
+
+// ============================================================
+// Wiring — a boolean setting per shim (apply/remove on change) + a command
+// ============================================================
+
+type ExtensionSettings = NonNullable<Parameters<ComfyApp["registerExtension"]>[0]["settings"]>;
+
+function shimSettings(): ExtensionSettings {
+  return SHIMS.map((shim) => ({
+    id: `@@DISPLAY_NOSPACE@@.${shim.id}`,
+    name: shim.name,
+    type: "boolean",
+    defaultValue: true,
+    tooltip: `${shim.tooltip} Stopgap for ${shim.upstream}`,
+    // Fires once at registration with the stored value, then on every toggle.
+    onChange: (value: unknown) => {
+      if (value) applyCssShim(shim);
+      else removeCssShim(shim);
+    },
+  })) as ExtensionSettings;
+}
+
+app.registerExtension({
+  name: "comfy.@@SHORT@@",
+  settings: shimSettings(),
+  commands: [
+    {
+      id: "@@SHORT@@.reapply-shims",
+      label: "Re-apply @@DISPLAY@@ CSS shims",
+      // TODO: replace with a real command, or drop `commands`/`menuCommands`
+      // entirely if this pack is settings-only.
+      function: () => {
+        for (const shim of SHIMS) applyCssShim(shim);
+      },
+    },
+  ],
+  menuCommands: [
+    {
+      path: ["Extensions", "@@DISPLAY@@"],
+      commands: ["@@SHORT@@.reapply-shims"],
+    },
+  ],
+});
+"""
+
 COMFYUI_SHIMS = """\
 // ComfyUI serves its frontend API at runtime from `/scripts/app.js`. The
 // `@comfyorg/comfyui-frontend-types` package only types the bare-package
@@ -1171,6 +1306,52 @@ describe("@@NAME@@ standalone modal", () => {
     expect(modal.bodyEl.querySelector(".@@SHORT@@-body")).not.toBeNull();
     expect(modal.bodyEl.textContent).toContain("@@DISPLAY@@");
     modal.close();
+  });
+});
+"""
+
+JS_TEST_SHIM = """\
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+// Vitest transpiles TypeScript, so the test imports the `.ts` source directly
+// (no build step). Importing the module also runs the registerExtension wiring
+// against tests/js/__mocks__/app.js. There is no modal in this pack — the
+// meaningful smoke is the CSS-shim lifecycle (inject / idempotent / remove),
+// which is jsdom-checkable. The `@vitest-environment jsdom` docblock above
+// gives this one file a DOM; the rest of the suite stays on the node
+// environment.
+import { applyCssShim, removeCssShim, SHIMS, styleElementId } from "../../src/index.ts";
+
+describe("@@NAME@@ shim registry", () => {
+  it("every shim links its upstream issue and carries non-empty CSS + tooltip", () => {
+    for (const shim of SHIMS) {
+      expect(shim.upstream).toMatch(/^https:\\/\\//);
+      expect(shim.css.trim()).not.toBe("");
+      expect(shim.tooltip.trim()).not.toBe("");
+    }
+  });
+
+  it("shim ids are unique", () => {
+    const ids = SHIMS.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe("@@NAME@@ CSS shim lifecycle", () => {
+  const shim = SHIMS[0];
+
+  it("apply injects one managed <style>, idempotently", () => {
+    applyCssShim(shim);
+    applyCssShim(shim);
+    const styles = document.querySelectorAll(`#${styleElementId(shim)}`);
+    expect(styles.length).toBe(1);
+    expect(styles[0].textContent).toContain(shim.upstream);
+  });
+
+  it("remove deletes the managed <style> and tolerates absence", () => {
+    removeCssShim(shim);
+    expect(document.getElementById(styleElementId(shim))).toBeNull();
+    removeCssShim(shim); // second remove is a no-op, not a throw
   });
 });
 """
@@ -1949,11 +2130,13 @@ def build_file_map(
 ) -> dict[str, str]:
     backend = variant == "backend"
     gesture = variant == "gesture"
-    modal = not gesture  # frontend or backend → consumes the kit
+    shim = variant == "shim"
+    modal = variant in ("frontend", "backend")  # consumes the modal kit
     # A modal variant scaffolded with NO target widgets has nothing to hook, so
     # the per-widget intercept vein is provably inapplicable. Emit a
     # standalone-modal skeleton (toolbar button + command opening a modal)
     # instead. Still depends on the modal kit (modal == True). See issue #1806.
+    # The gesture and shim variants are NOT modal, so they never take this path.
     standalone = modal and not widgets
 
     # Shared pinned versions injected into every templated config.
@@ -2002,10 +2185,11 @@ def build_file_map(
         ctx["DEPENDENCIES_BLOCK"] = ""
         ctx["KIT_PKG_NOTE"] = ""
 
-    # The standalone-modal smoke test mounts the modal under jsdom; only that
-    # variant needs jsdom in devDependencies. See issue #1806.
+    # The standalone-modal smoke test mounts the modal under jsdom (issue #1806);
+    # the shim smoke test asserts the CSS-shim <style> lifecycle under jsdom too.
+    # Both need jsdom in devDependencies.
     ctx["JSDOM_DEV_DEP"] = (
-        f'\n    "jsdom": "{JSDOM_VERSION}",' if standalone else ""
+        f'\n    "jsdom": "{JSDOM_VERSION}",' if (standalone or shim) else ""
     )
 
     # CLAUDE.md conditional fragments.
@@ -2020,6 +2204,13 @@ def build_file_map(
             "Frontend-only ComfyUI custom-node pack in the canvas-gesture vein. "
             "`__init__.py` is a loader stub; the whole extension is TypeScript in "
             "`src/`, built to `web/dist/` via bun. See ADR-0001."
+        )
+    elif shim:
+        ctx["CLAUDE_INTRO"] = (
+            "Frontend-only ComfyUI custom-node pack in the CSS/shim vein — "
+            "scoped `<style>` injection + commands, no modal. `__init__.py` is a "
+            "loader stub; the whole extension is TypeScript in `src/`, built to "
+            "`web/dist/` via bun. See ADR-0001."
         )
     else:
         ctx["CLAUDE_INTRO"] = (
@@ -2051,19 +2242,26 @@ def build_file_map(
         else "No Python dependencies. The pack is frontend-only; a feature "
         "genuinely needing Python belongs in a separate companion pack."
     )
-    ctx["KIT_RULE"] = (
-        f"**Modal primitives come from `{MODAL_KIT_PKG}`** — import them, do NOT "
-        "copy `modal-shell.js`/`modal-fuzzy.js` into the pack. `bun build` inlines "
-        "the imported code into `web/dist`."
-        if modal
-        else "**No modal kit.** This gesture pack has no widget to hook and no "
-        "modal; it adds a canvas pointer layer with self-contained pure helpers."
-    )
-    ctx["KIT_DEV_NOTE"] = (
-        f"{MODAL_KIT_PKG} (inlined at build)"
-        if modal
-        else "(no modal kit — gesture pack)"
-    )
+    if modal:
+        ctx["KIT_RULE"] = (
+            f"**Modal primitives come from `{MODAL_KIT_PKG}`** — import them, do NOT "
+            "copy `modal-shell.js`/`modal-fuzzy.js` into the pack. `bun build` inlines "
+            "the imported code into `web/dist`."
+        )
+        ctx["KIT_DEV_NOTE"] = f"{MODAL_KIT_PKG} (inlined at build)"
+    elif shim:
+        ctx["KIT_RULE"] = (
+            "**No modal kit.** This shim pack has no widget to hook and no modal; it "
+            "injects scoped, managed `<style>` tags (one per shim, driven by a boolean "
+            "setting) and registers commands."
+        )
+        ctx["KIT_DEV_NOTE"] = "(no modal kit — CSS/shim pack)"
+    else:
+        ctx["KIT_RULE"] = (
+            "**No modal kit.** This gesture pack has no widget to hook and no "
+            "modal; it adds a canvas pointer layer with self-contained pure helpers."
+        )
+        ctx["KIT_DEV_NOTE"] = "(no modal kit — gesture pack)"
     ctx["RESTART_NOTE"] = (
         f" Changes to `{ctx['PY_MODULE']}.py` (backend) DO require a ComfyUI restart."
         if backend
@@ -2147,6 +2345,42 @@ def build_file_map(
             "- ComfyUI: modern Vue frontend (`comfyui-frontend-package >= 1.40`) for the\n"
             "  `registerExtension` action-bar/command launcher API."
         )
+    elif shim:
+        ctx["DEP_FLOOR_NOTE"] = (
+            "Floor tied to the registerExtension boolean-settings API."
+        )
+        ctx["WHAT_DESC"] = "the CSS shims it injects and the upstream bugs they paper over"
+        ctx["VEIN"] = (
+            "A home for SMALL, individually-toggleable stopgap fixes in the *CSS/shim* "
+            "vein: a frontend extension that papers over upstream ComfyUI-frontend bugs "
+            "by injecting scoped, managed `<style>` tags — one per shim, driven by a "
+            "boolean setting — and registers commands. There are **no target widgets to "
+            "hook** and **no modal**, so there is no `TARGET_WIDGETS` / `onPointerDown` "
+            "wrapping and **no `" + MODAL_KIT_PKG + "` dependency**. Every shim links the "
+            "upstream issue it papers over (in `upstream` + the settings tooltip) and is "
+            "deleted the release the upstream fix ships. Selectors target stable "
+            "`data-testid` hooks where the frontend provides them; anything keyed on "
+            "compiled Tailwind class chains is brittle and expected to rot, so each shim "
+            "**fails soft** (a dead selector styles nothing, never throws). The CSS-shim "
+            "lifecycle helpers are exported so the jsdom smoke test can prove inject / "
+            "idempotent / remove."
+        )
+        ctx["EXT_ROW_DESC"] = (
+            "The extension: CSS-shim registry + boolean-setting lifecycle (no kit)."
+        )
+        ctx["HOOK_RULE"] = (
+            "**Selectors are version-sensitive.** Each shim injects CSS keyed on "
+            "frontend DOM. Prefer stable `data-testid` hooks; keep every shim FAIL-SOFT "
+            "(a dead selector styles nothing) so a frontend change never breaks the pack."
+        )
+        ctx["FAMILY_BLURB"] = (
+            "> small, individually-toggleable CSS shims that paper over upstream\n"
+            "> frontend bugs, additive and self-contained — each deleted when its fix ships."
+        )
+        ctx["COMPAT_BULLET"] = (
+            "- ComfyUI: modern Vue frontend (`comfyui-frontend-package >= 1.40`) for the\n"
+            "  `registerExtension` boolean-settings + command API."
+        )
     else:
         ctx["DEP_FLOOR_NOTE"] = "Floor tied to widget.onPointerDown availability."
         ctx["WHAT_DESC"] = "the widgets it enhances and the modal it opens"
@@ -2208,7 +2442,9 @@ def build_file_map(
         ".github/workflows/clear-autorelease-labels.yml": CLEAR_AUTORELEASE_YML,
         "docs/blueprint/adrs/0001-adopt-typescript-bun-build.md": ADR_0001,
         "src/index.ts": (
-            INDEX_TS_GESTURE
+            INDEX_TS_SHIM
+            if shim
+            else INDEX_TS_GESTURE
             if gesture
             else INDEX_TS_STANDALONE
             if standalone
@@ -2218,7 +2454,9 @@ def build_file_map(
         "tests/test_init.py": TEST_INIT,
         "tests/js/__mocks__/app.js": APP_MOCK,
         "tests/js/index.test.js": (
-            JS_TEST_GESTURE
+            JS_TEST_SHIM
+            if shim
+            else JS_TEST_GESTURE
             if gesture
             else JS_TEST_STANDALONE
             if standalone
@@ -2318,7 +2556,9 @@ def main() -> int:
     )
     p.add_argument("--desc", required=True, help="one-line description")
     p.add_argument(
-        "--variant", choices=["frontend", "backend", "gesture"], default="frontend"
+        "--variant",
+        choices=["frontend", "backend", "gesture", "shim"],
+        default="frontend",
     )
     p.add_argument(
         "--widgets",
@@ -2346,7 +2586,8 @@ def main() -> int:
     widgets = [w.strip() for w in args.widgets.split(",") if w.strip()]
     # A modal variant (frontend/backend) with no --widgets gets the
     # standalone-modal skeleton instead of the per-widget intercept. See #1806.
-    standalone = args.variant != "gesture" and not widgets
+    # gesture and shim are NOT modal, so they never take the standalone path.
+    standalone = args.variant in ("frontend", "backend") and not widgets
 
     parent = Path(args.dir).resolve()
     target = parent / args.name
@@ -2370,7 +2611,11 @@ def main() -> int:
         "  git init -b main                       # seed main directly (no branch juggling)\n"
         "  uv sync --group dev\n"
         "  bun install                            # TypeScript, Biome, Vitest, knip"
-        + (", comfy-modal-kit\n" if args.variant != "gesture" else "\n")
+        + (
+            ", comfy-modal-kit\n"
+            if args.variant in ("frontend", "backend")
+            else "\n"
+        )
         + "  pre-commit install\n"
         "  just check                              # typecheck + build + lint + test should pass green\n"
         "\nThen:\n"
@@ -2378,6 +2623,10 @@ def main() -> int:
             "  - tune the pinch layer in src/index.ts "
             "(selectedNodes/nodeScreenRect/scaledSize; groups + affordance TODOs)\n"
             if args.variant == "gesture"
+            else "  - implement the CSS shims in src/index.ts (replace the placeholder "
+            "SHIMS entry; link the upstream issue, keep each shim fail-soft — no "
+            "comfy-modal-kit)\n"
+            if args.variant == "shim"
             else "  - implement the modal in src/index.ts (openShell body via "
             "openModalShell; tune the action-bar/command launcher; import fuzzyRank "
             "from @laurigates/comfy-modal-kit for search)\n"

--- a/comfyui-plugin/skills/comfyui-node-scaffold/scripts/tests/test-shim-variant.sh
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/scripts/tests/test-shim-variant.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# test-shim-variant.sh — regression test for the CSS/shim scaffold variant
+# (issue #1930).
+#
+# The scaffold previously offered only frontend/backend/gesture. A pack whose
+# whole job is injecting scoped CSS + registering commands (no modal, no
+# comfy-modal-kit) — like comfyui-touch-shim — had to be scaffolded as a
+# standalone-modal skeleton and then hand-gutted. This test EXECUTES the
+# generator and asserts:
+#   1. shim variant → CSS-shim index.ts (SHIMS registry + applyCssShim/
+#      removeCssShim, NO comfy-modal-kit import, NO openModalShell); package.json
+#      has NO comfy-modal-kit dependency but DOES add the jsdom devDep; the
+#      vitest suite asserts the shim <style> lifecycle
+#   2. frontend + --widgets → the widget-intercept index.ts is UNCHANGED (has
+#      `const TARGET_WIDGETS`, no SHIMS, no jsdom) — guards against the shim
+#      branch over-applying to the modal variants
+#
+# Requires python3; SKIPs cleanly when it is unavailable.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCAFFOLD="${SCRIPT_DIR}/../../scaffold.py"
+
+pass=0
+fail=0
+check() { # check <description> <expected> <actual>
+    if [ "$2" = "$3" ]; then
+        pass=$((pass + 1))
+    else
+        fail=$((fail + 1))
+        printf 'FAIL: %s\n  expected: %s\n  actual:   %s\n' "$1" "$2" "$3" >&2
+    fi
+}
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "SKIP: python3 not available" >&2
+    exit 0
+fi
+if [ ! -f "$SCAFFOLD" ]; then
+    echo "FAIL: scaffold.py not found at $SCAFFOLD" >&2
+    exit 1
+fi
+
+WORK="$(mktemp -d)"
+[ -n "$WORK" ] || { echo "mktemp failed" >&2; exit 1; }
+trap 'rm -rf "$WORK"' EXIT
+
+# 1. Shim variant.
+python3 "$SCAFFOLD" --name comfyui-shim-probe --display "Shim Probe" \
+    --desc "x" --variant shim --dir "$WORK" >/dev/null 2>&1
+SH="$WORK/comfyui-shim-probe"
+SH_INDEX="$SH/src/index.ts"
+SH_TEST="$SH/tests/js/index.test.js"
+SH_PKG="$SH/package.json"
+
+if [ ! -f "$SH_INDEX" ]; then
+    echo "FAIL: shim scaffold did not produce src/index.ts" >&2
+    exit 1
+fi
+
+# The CSS-shim registry + lifecycle are the load-bearing exports.
+if grep -q 'export const SHIMS' "$SH_INDEX"; then
+    check "shim index.ts declares the SHIMS registry" "present" "present"
+else
+    check "shim index.ts declares the SHIMS registry" "present" "absent"
+fi
+if grep -q 'export function applyCssShim' "$SH_INDEX"; then
+    check "shim index.ts exports applyCssShim()" "present" "present"
+else
+    check "shim index.ts exports applyCssShim()" "present" "absent"
+fi
+if grep -q 'export function removeCssShim' "$SH_INDEX"; then
+    check "shim index.ts exports removeCssShim()" "present" "present"
+else
+    check "shim index.ts exports removeCssShim()" "present" "absent"
+fi
+# No modal-kit dependency: neither an import from the package nor openModalShell.
+if grep -qE 'import .* from "@laurigates/comfy-modal-kit"' "$SH_INDEX"; then
+    check "shim index.ts does NOT import the modal kit" "absent" "present"
+else
+    check "shim index.ts does NOT import the modal kit" "absent" "absent"
+fi
+if grep -q 'openModalShell' "$SH_INDEX"; then
+    check "shim index.ts does NOT use openModalShell" "absent" "present"
+else
+    check "shim index.ts does NOT use openModalShell" "absent" "absent"
+fi
+if grep -q 'const TARGET_WIDGETS' "$SH_INDEX"; then
+    check "shim index.ts has NO widget-intercept vein" "absent" "present"
+else
+    check "shim index.ts has NO widget-intercept vein" "absent" "absent"
+fi
+# package.json: no comfy-modal-kit runtime dep, but the jsdom devDep is added.
+if grep -q 'comfy-modal-kit' "$SH_PKG"; then
+    check "shim package.json has NO comfy-modal-kit dependency" "absent" "present"
+else
+    check "shim package.json has NO comfy-modal-kit dependency" "absent" "absent"
+fi
+if grep -q '"jsdom"' "$SH_PKG"; then
+    check "shim package.json declares jsdom devDependency" "present" "present"
+else
+    check "shim package.json declares jsdom devDependency" "present" "absent"
+fi
+# vitest suite asserts the shim <style> lifecycle under jsdom.
+if grep -q '@vitest-environment jsdom' "$SH_TEST"; then
+    check "shim smoke test runs under jsdom" "present" "present"
+else
+    check "shim smoke test runs under jsdom" "present" "absent"
+fi
+if grep -q 'applyCssShim' "$SH_TEST" && grep -q 'removeCssShim' "$SH_TEST"; then
+    check "shim smoke test exercises the apply/remove lifecycle" "present" "present"
+else
+    check "shim smoke test exercises the apply/remove lifecycle" "present" "absent"
+fi
+
+# 2. Frontend + widgets: the shim branch must NOT over-apply.
+python3 "$SCAFFOLD" --name comfyui-widget-probe --display "Widget Probe" \
+    --desc "x" --variant frontend --widgets ckpt_name --dir "$WORK" >/dev/null 2>&1
+WG="$WORK/comfyui-widget-probe"
+WG_INDEX="$WG/src/index.ts"
+WG_PKG="$WG/package.json"
+
+if grep -q 'const TARGET_WIDGETS' "$WG_INDEX"; then
+    check "widget variant keeps the intercept vein" "present" "present"
+else
+    check "widget variant keeps the intercept vein" "present" "absent"
+fi
+if grep -q 'export const SHIMS' "$WG_INDEX"; then
+    check "widget variant does NOT emit the shim registry" "absent" "present"
+else
+    check "widget variant does NOT emit the shim registry" "absent" "absent"
+fi
+if grep -q 'comfy-modal-kit' "$WG_PKG"; then
+    check "widget variant keeps the comfy-modal-kit dependency" "present" "present"
+else
+    check "widget variant keeps the comfy-modal-kit dependency" "present" "absent"
+fi
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What

Adds a fourth `--variant shim` to `comfyui-node-scaffold` for packs whose whole job is **injecting scoped CSS / registering commands** to paper over upstream ComfyUI-frontend bugs — no modal, no widget hook, no `comfy-modal-kit`. Previously the scaffold only offered `frontend`/`backend`/`gesture`, so building `comfyui-touch-shim` meant scaffolding the `frontend` standalone-modal skeleton and hand-gutting it (removing the kit dep, rewriting `src/index.ts` into a CSS-shim registry, rewriting the vitest suite, rewriting the README/CLAUDE.md vein copy).

## How

Mirrors the reference implementation `laurigates/comfyui-touch-shim`:

- **`src/index.ts`** (`INDEX_TS_SHIM`): a `SHIMS` registry with idempotent `applyCssShim`/`removeCssShim` (one managed `<style>` per shim, `styleElementId`), a boolean-setting `onChange` lifecycle, and a command — **no** `comfy-modal-kit` import, **no** `openModalShell`.
- **`tests/js/index.test.js`** (`JS_TEST_SHIM`): asserts every shim links an upstream issue + non-empty css/tooltip, unique ids, and the `<style>` inject/idempotent/remove lifecycle under jsdom; `jsdom` added to `devDependencies`.
- **`build_file_map`** redefines `modal = variant in ("frontend","backend")` so `shim` never receives the kit or the standalone/widget vein; adds an `elif shim:` vein branch (VEIN/HOOK_RULE/COMPAT_BULLET/etc.), generalizes `KIT_RULE`/`KIT_DEV_NOTE`/`CLAUDE_INTRO` for the no-kit shim, and gates the jsdom devDep on `standalone or shim`.
- **`main()`** adds `shim` to `--variant choices`, excludes it from the `standalone` recompute, and adds a shim next-steps hint + kit-free bun-install line.
- **SKILL.md / README.md**: "Three variants" → four, shim table row + example command + decision-rule/flags/hard-rule updates (docs land in the same commit).

Existing variants are behavior-identical (`modal` is unchanged for frontend/backend/gesture).

## Regression guard

`scripts/tests/test-shim-variant.sh` (auto-discovered by `just test-skill-scripts`) executes the generator and asserts the shim semantics (`SHIMS` + apply/remove, no kit import, no `openModalShell`, no `TARGET_WIDGETS`, no `comfy-modal-kit` dep, jsdom devDep, lifecycle test) **plus a negative case** that `frontend --widgets` still emits the widget-intercept index with the kit — guarding against the shim branch over-applying.

## Verification

- Generated shim pack passes `just check` fully green: `tsc --noEmit`, `bun build`, `ruff`, `biome@2.4.15`, pytest (2), vitest (4).
- `test-shim-variant.sh`: 13/13 pass. `test-standalone-variant.sh` + `test-finishing-pass.sh` still pass (no over-apply).
- `just lint-shell`, `just lint-compliance` (comfyui-plugin all ✅), `just lint-context-commands` clean.

Closes #1930

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWCDunYaycouvKnRtYHSpZ