### PR TITLE
fix(git-plugin): honor -F body-file alias and defer on unreadable body in pr-issue-link hook

### DIFF
--- a/git-plugin/hooks/test-validate-pr-issue-links.sh
+++ b/git-plugin/hooks/test-validate-pr-issue-links.sh
@@ -127,6 +127,46 @@ assert_exit \
     "same-command heredoc body-file (file not yet written) is allowed" 0 \
     "$(make_json "$SAME_CMD_BODYFILE")"
 
+# ── -F / --body-file resolvable at hook time (regression: issue #1913) ──────
+# Regression (issue #1913): a compliant PR created with the -F short alias for
+# --body-file — where the body file contains Closes #N — was false-blocked
+# because the guard/extraction only recognized the long --body-file form. All
+# resolvable -F forms whose file carries the keyword must be allowed.
+echo ""
+echo "-F / --body-file alias with keyword in the file (issue #1913):"
+
+BODYFILE=$(mktemp)
+printf '## Summary\n\nCloses #42\n' > "$BODYFILE"
+# shellcheck disable=SC2064  # expand BODYFILE now so the trap removes this exact file
+trap "rm -rf '$TMPDIR' '$BODYFILE'" EXIT
+
+assert_exit \
+    "-F <file> (space form) with Closes in the file is allowed" 0 \
+    "$(make_json "gh pr create --title 'feat: add feature' -F $BODYFILE")"
+
+assert_exit \
+    "-F<file> (attached form) with Closes in the file is allowed" 0 \
+    "$(make_json "gh pr create --title 'feat: add feature' -F$BODYFILE")"
+
+assert_exit \
+    "-F=<file> (equals form) with Closes in the file is allowed" 0 \
+    "$(make_json "gh pr create --title 'feat: add feature' -F=$BODYFILE")"
+
+# ── Unresolvable body-file/-F paths defer, not block (issue #1913) ──────────
+# When a body-file/-F path cannot be read at PreToolUse time (missing file or
+# stdin sentinel), the keyword may live inside it — defer (exit 0) rather than
+# emit a false-positive block.
+echo ""
+echo "unresolvable body-file/-F paths defer instead of blocking (issue #1913):"
+
+assert_exit \
+    "--body-file <missing> defers (file unreadable at hook time)" 0 \
+    "$(make_json "gh pr create --title 'feat: add feature' --body-file /nonexistent/pr-body-$$.md")"
+
+assert_exit \
+    "-F - (stdin) defers (cannot resolve stdin at hook time)" 0 \
+    "$(make_json "gh pr create --title 'feat: add feature' -F -")"
+
 # ── Missing closing keywords should block ───────────────────────────────────
 echo ""
 echo "missing closing keywords (should block):"
@@ -139,6 +179,16 @@ MULTILINE_NO_CLOSE=$(printf 'gh pr create --title "feat: add feature" --body "##
 assert_exit \
     "multi-line body without closing keywords is blocked" 2 \
     "$(make_json "$MULTILINE_NO_CLOSE")"
+
+# A readable -F body file that genuinely lacks a closing keyword must still
+# block when commits reference an issue — the #1913 fix must not defer here.
+BODYFILE_NOKEY=$(mktemp)
+printf '## Summary\n\nNo closing keyword here.\n' > "$BODYFILE_NOKEY"
+# shellcheck disable=SC2064  # expand the filenames now so the trap removes these exact files
+trap "rm -rf '$TMPDIR' '$BODYFILE' '$BODYFILE_NOKEY'" EXIT
+assert_exit \
+    "-F <file> whose readable content lacks closing keywords is blocked" 2 \
+    "$(make_json "gh pr create --title 'feat: add feature' -F $BODYFILE_NOKEY")"
 
 # ── Summary ─────────────────────────────────────────────────────────────────
 echo ""

--- a/git-plugin/hooks/validate-pr-issue-links.sh
+++ b/git-plugin/hooks/validate-pr-issue-links.sh
@@ -27,12 +27,19 @@ CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 if [ -z "$COMMAND" ]; then exit 0; fi
 if ! echo "$COMMAND" | grep -qE '(^|\s)gh\s+pr\s+create'; then exit 0; fi
 
-# Extract body content from --body-file (preferred pattern for multi-line bodies)
-# Uses perl instead of grep -P for macOS BSD grep compatibility
+# Extract body content from --body-file / -F (preferred pattern for multi-line
+# bodies). gh accepts the long form (--body-file <path> or --body-file=<path>)
+# and its documented short alias -F, in space (-F <path>), attached (-F<path>),
+# and equals (-F=<path>) forms. Uses perl instead of grep -P for macOS BSD grep
+# compatibility.
 BODY=""
-if echo "$COMMAND" | grep -qE '\-\-body-file'; then
-    BODY_FILE=$(echo "$COMMAND" | perl -ne 'if (/--body-file[= ](\S+)/) { print $1; }' 2>/dev/null || true)
-    if [ -n "$BODY_FILE" ] && [ -f "$BODY_FILE" ]; then
+BODY_FILE=""
+BODY_FILE_SPECIFIED=false
+if echo "$COMMAND" | grep -qE '(^|[[:space:]])(--body-file([= ]|$)|-F)'; then
+    BODY_FILE_SPECIFIED=true
+    BODY_FILE=$(echo "$COMMAND" | perl -ne 'if (/(?:--body-file[= ]|-F[= ]?)(\S+)/) { print $1; exit; }' 2>/dev/null || true)
+    # "-" is the stdin sentinel and cannot be resolved at PreToolUse time.
+    if [ -n "$BODY_FILE" ] && [ "$BODY_FILE" != "-" ] && [ -f "$BODY_FILE" ] && [ -r "$BODY_FILE" ]; then
         BODY=$(cat "$BODY_FILE")
     fi
 fi
@@ -70,6 +77,16 @@ fi
 # (which still guards against suffix words like "prefixes"/"discloses").
 COMMAND_UNESCAPED=$(printf '%s' "$COMMAND" | sed 's/\\[nrt]/ /g')
 if echo "$COMMAND_UNESCAPED" | grep -qiE '\b(closes?|fixes?|resolves?)[: ]+#[0-9]+'; then
+    exit 0
+fi
+
+# A body-file/-F path was specified but could not be resolved at PreToolUse
+# time — the path is the stdin sentinel "-", the file does not exist yet, or it
+# is unreadable. We cannot inspect its contents, so the closing keyword may well
+# be inside that unresolved file. Defer (exit 0) rather than emit a
+# false-positive block (see .claude/rules/hook-block-vs-nudge.md: never
+# hard-block on unresolvable input).
+if [ "$BODY_FILE_SPECIFIED" = true ] && [ -z "$BODY" ]; then
     exit 0
 fi
 


### PR DESCRIPTION
The `validate-pr-issue-links` PreToolUse hook recognized only the long `--body-file` form when extracting a PR body to scan for closing keywords. A fully compliant PR created with gh's documented `-F` alias (space, attached, or equals form) — where the body file contains `Closes #N` — was false-blocked, because `-F` never matched the guard/extraction so the body stayed empty and the git-log branch blocked.

## Changes
- Broaden the guard and perl extraction to also match `-F <path>`, `-F<path>`, and `-F=<path>` alongside `--body-file`.
- Add a defer branch: when a body-file/-F path is specified but cannot be resolved at PreToolUse time (stdin sentinel `-`, missing, or unreadable file), `exit 0` instead of falling through to the blocking git-log check (per `hook-block-vs-nudge.md`: never hard-block on unresolvable input). A readable body file that genuinely lacks a closing keyword still blocks.
- Regression tests in `test-validate-pr-issue-links.sh` cover the three `-F` forms with a keyword in the file, the unreadable/stdin defer cases, and a readable-but-noncompliant `-F` file that must still block. Suite: 18/18 pass.

Note: the hook lives in `git-plugin/hooks/` (the issue title says hooks-plugin).

Closes #1913