### PR TITLE
fix(blueprint-plugin): clarify work-order handoff is user-invocable

### DIFF
--- a/blueprint-plugin/skills/blueprint-story-audit/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-story-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-04-25
-modified: 2026-06-18
+modified: 2026-07-04
 reviewed: 2026-04-25
 description: Audit user stories against codebase and tests for tier-ranked coverage gaps. Use when running story audit, PRD reconciliation, or surfacing PRD-code drift.
 args: "[--scope <area>] [--prd <path>] [--no-write] [--report-only]"
@@ -179,7 +179,7 @@ Skip this step if `--report-only` is set.
 Use AskUserQuestion to offer the three downstream paths the audit unlocks:
 
 - **Reconcile drift in the PRD** → run `/blueprint:story-reconcile` against this audit
-- **Dispatch a work-order for a Tier-1 gap** → run `/blueprint:work-order` per row
+- **Dispatch a work-order for a Tier-1 gap** → recommend the user run `/blueprint:work-order` per row (a user-invocable command — surface it for the user to run, don't invoke it via the Skill tool)
 - **I'll act on the artifact later** → exit; the artifact is the durable output
 
 Don't loop. The audit is the durable artifact; the user owns the next step.

--- a/blueprint-plugin/skills/blueprint-story-reconcile/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-story-reconcile/SKILL.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-04-25
-modified: 2026-06-18
+modified: 2026-07-04
 reviewed: 2026-04-25
 description: Reconcile PRD requirements with a story-audit drift report. Use when marking PRD entries implemented/partial/missing, or promoting code-only stories into the PRD.
 args: "[--audit <path>] [--prd <path>] [--apply-all] [--dry-run]"
@@ -178,7 +178,7 @@ Choose `<scope>` as the PRD prefix shared by edits (e.g. `prd-001`) or omit if m
 
 Use AskUserQuestion to surface the obvious follow-on:
 
-- **Open work-orders for ❌ entries** → invoke `/blueprint:work-order` per Tier-3 row
+- **Open work-orders for ❌ entries** → recommend the user run `/blueprint:work-order` per Tier-3 row (a user-invocable command — surface it for the user to run, don't invoke it via the Skill tool)
 - **Re-run the audit to confirm green** → invoke `/blueprint:story-audit`
 - **I'm done** → exit
 

--- a/blueprint-plugin/skills/blueprint-story-reconcile/scripts/tests/test-work-order-handoff.sh
+++ b/blueprint-plugin/skills/blueprint-story-reconcile/scripts/tests/test-work-order-handoff.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Regression test for issue #1906: story-reconcile / story-audit referenced
+# `/blueprint:work-order` in a way that read as "invoke it via the Skill tool".
+#
+# Root cause: `blueprint-work-order` carries `disable-model-invocation: true`,
+# so it never appears in the model's skill list and cannot be invoked via the
+# Skill tool — the model can only SURFACE it for the user to run. A reporter
+# searched the list, misread the reference as "skill doesn't exist", and stalled.
+#
+# The fix reworded both handoff steps to make clear the command is
+# user-invocable and must be surfaced, not Skill-tool-invoked. This test pins
+# two semantic invariants against a future bulk edit (including this issue's own
+# preliminary hint, which wrongly wanted the ref repointed to a different skill):
+#
+#   1. Both handoff steps still reference the CORRECT command
+#      `/blueprint:work-order` (not repointed to blueprint-prp-create/anything).
+#   2. Each handoff step carries the clarifying `user-invocable` token so the
+#      "surface it, don't Skill-invoke it" intent survives.
+#
+# Exit 0 on success, non-zero on failure.
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+reconcile_skill="${script_dir}/../../SKILL.md"
+audit_skill="${script_dir}/../../../blueprint-story-audit/SKILL.md"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+pass() { echo "PASS: $1"; }
+
+[ -f "$reconcile_skill" ] || fail "story-reconcile SKILL.md not found at $reconcile_skill"
+[ -f "$audit_skill" ]     || fail "story-audit SKILL.md not found at $audit_skill"
+
+# The single line in each skill that hands off the work-order follow-on action.
+# story-reconcile Step 9: "Open work-orders for ..." ; story-audit Step 8:
+# "Dispatch a work-order for a Tier-1 gap ...". Both point at /blueprint:work-order.
+reconcile_handoff="$(grep -m1 'Open work-orders' "$reconcile_skill" || true)"
+audit_handoff="$(grep -m1 'Dispatch a work-order' "$audit_skill" || true)"
+
+[ -n "$reconcile_handoff" ] || fail "story-reconcile lost its 'Open work-orders' handoff line"
+[ -n "$audit_handoff" ]     || fail "story-audit lost its 'Dispatch a work-order' handoff line"
+
+# Invariant 1: the handoff still names the correct command (guards a repoint to
+# a different skill such as blueprint-prp-create).
+case "$reconcile_handoff" in
+  *'/blueprint:work-order'*) pass "story-reconcile handoff references /blueprint:work-order" ;;
+  *) fail "story-reconcile handoff no longer references /blueprint:work-order: $reconcile_handoff" ;;
+esac
+case "$audit_handoff" in
+  *'/blueprint:work-order'*) pass "story-audit handoff references /blueprint:work-order" ;;
+  *) fail "story-audit handoff no longer references /blueprint:work-order: $audit_handoff" ;;
+esac
+
+# Invariant 2: the handoff clarifies the command is user-invocable / surfaced,
+# not Skill-tool-invoked (the #1906 fix). Match case-insensitively on the
+# hyphenated token so a rewording of the surrounding prose still passes.
+case "${reconcile_handoff,,}" in
+  *user-invocable*) pass "story-reconcile handoff clarifies user-invocable" ;;
+  *) fail "story-reconcile handoff missing 'user-invocable' clarification (#1906): $reconcile_handoff" ;;
+esac
+case "${audit_handoff,,}" in
+  *user-invocable*) pass "story-audit handoff clarifies user-invocable" ;;
+  *) fail "story-audit handoff missing 'user-invocable' clarification (#1906): $audit_handoff" ;;
+esac
+
+echo "OK: work-order handoff invariants hold (#1906)"


### PR DESCRIPTION
story-reconcile Step 9 and story-audit Step 8 referenced `/blueprint:work-order` with "invoke" phrasing, which reads as a Skill-tool invocation. `blueprint-work-order` carries `disable-model-invocation: true`, so it never appears in the model's skill list and cannot be invoked via the Skill tool — the model can only surface it for the user to run. A reporter searched the skill list, misread the reference as "skill doesn't exist", stalled, and filed plain GitHub issues instead.

## Fix

The command reference is correct (`/blueprint:work-order` is the right invocation for the `blueprint-work-order` directory per `skill-naming.md`) and the `disable-model-invocation` gate is deliberate (work-order creates GitHub issues / spawns subagents and should require explicit user action). So this is a doc reword, not a repoint or an invocation-behavior change — both handoff steps now say to **recommend the user run** the command and mark it a **user-invocable command** to surface, not Skill-tool-invoke.

## Regression guard

Adds a co-located guard `blueprint-plugin/skills/blueprint-story-reconcile/scripts/tests/test-work-order-handoff.sh` (auto-discovered by `just test-skill-scripts`) pinning two invariants: both handoffs still reference `/blueprint:work-order` (guards a future repoint) and both carry the `user-invocable` clarification (guards the reword). Verified failing on the pre-fix text and passing after.

## Checks

- `just lint-compliance` — pass (0 errors; blueprint-story-audit size WARN is pre-existing)
- `just lint-shell` — 0 errors
- `just test-skill-scripts` — TOTAL=53 FAILED=0 STATUS=OK

Closes #1906