### PR TITLE
feat(claude-probe): config-isolation arms + first cost/outcome sweep

### DIFF
--- a/experiments/claude-probe/.gitignore
+++ b/experiments/claude-probe/.gitignore
@@ -1,3 +1,4 @@
 results/
 *.log
 .scratch/
+.arm-configs/

--- a/experiments/claude-probe/conditions.yaml
+++ b/experiments/claude-probe/conditions.yaml
@@ -56,3 +56,30 @@ conditions:
     model: claude-opus-4-8
     thinking: xhigh
     system_prompt: probe
+
+  # --- config-isolation arms (Phase 0) -----------------------------------
+  # A separate axis from the system_prompt A/B above: hold model + effort +
+  # system_prompt fixed and vary ONLY which config surface Claude Code loads.
+  #   clean        = system prompt only            (claude --bare)
+  #   plugins-only = marketplace skills, NO global ~/.claude memory (cloud/CI parity)
+  #   full         = real ~/.claude: 75k rules + CLAUDE.md + skills + hooks
+  # The isolated arms lose the OAuth login, so they need CLAUDE_CODE_OAUTH_TOKEN
+  # in the environment — run them via `just run-config` (which sources it and
+  # preps the plugins-only config dir). Run `claude setup-token` once to mint it.
+  - id: cfg-clean
+    model: claude-opus-4-8
+    thinking: low
+    system_prompt: default
+    config: clean
+
+  - id: cfg-plugins
+    model: claude-opus-4-8
+    thinking: low
+    system_prompt: default
+    config: plugins-only
+
+  - id: cfg-full
+    model: claude-opus-4-8
+    thinking: low
+    system_prompt: default
+    config: full

--- a/experiments/claude-probe/docs/config-arms.md
+++ b/experiments/claude-probe/docs/config-arms.md
@@ -43,18 +43,24 @@ Note this corrects the interactive `/context` figures: eager **skills cost ~5k,
 not ~22k**, and **global memory is the ~67k lever**. Memory is where the
 slimmer/fatter question lives; skills are nearly free eagerly.
 
-### Known caveat: HOME override re-triggers tool init (outcome sweep is WIP)
+### HOME override and the tool sandbox
 
-For *context measurement* (trivial prompts) HOME override is clean. For real
-*task* runs it is fragile: pointing `$HOME` at an empty dir makes mise/go and
-other `$HOME`-rooted tooling re-initialise and download into the fake HOME (a
-Go toolchain landed in `fh-clean/go`, whose read-only module cache then broke
-`arm-prep`'s cleanup). Hardening options (not yet chosen): symlink the
-tool-cache dirs (`go`, `.cache`, `.config`, `.local`) from the real HOME into
-each fake HOME so only `~/.claude` differs; pin `GOTOOLCHAIN=local` and cache
-env vars; or run each arm in a container. Until then the **outcome sweep**
-(`run-config.sh`) should be treated as WIP; the **cost decomposition** above is
-solid.
+Pointing `$HOME` at a fake dir strips `~/.claude` memory but also unroots
+`$HOME`-defaulting tools. The split is XDG-compliance:
+
+- **XDG-compliant tools (mise, ruff, …) are fine** — mise resolves its dirs by
+  precedence `MISE_*_DIR` > `XDG_*_HOME` > `$HOME` default, and the `XDG_*` vars
+  here are absolute, so mise finds the real installed tools under any `$HOME`.
+  The isolated arms just need to inherit `XDG_*` (they do).
+- **HOME-defaulters break** — Go's `GOPATH` defaults to `$HOME/go` and
+  `GOTOOLCHAIN=auto` auto-downloads a toolchain into the fake HOME. `run-one.sh`
+  pins `GOTOOLCHAIN=local` + `GOPATH`/`GOMODCACHE` at the real HOME for the
+  isolated arms. Other HOME-rooted config (`~/.gitconfig`, `~/.npmrc`, `~/.ssh`)
+  would need the same treatment if a probe depends on it; the fixture sets its
+  own local git config so the read-only probes don't.
+
+Verified: a clean-arm task run lists the fixture files correctly with zero
+toolchain download.
 
 ## Auth (one-time)
 

--- a/experiments/claude-probe/docs/config-arms.md
+++ b/experiments/claude-probe/docs/config-arms.md
@@ -1,0 +1,86 @@
+# Config-isolation arms
+
+An extra axis on top of the system-prompt A/B: hold model, effort, and
+system-prompt fixed and vary **only which global config surface Claude Code
+loads**. Answers "what does the workstation setup actually buy, and what does
+it cost?"
+
+## The three arms
+
+| Arm | Loads | Realises |
+|---|---|---|
+| `clean` | system prompt + core tools | Claude before any user config |
+| `plugins-only` | + marketplace skills, **no** global memory | a cloud / CI session |
+| `full` | + 75k-ish rules + `CLAUDE.md` + hooks | the local workstation |
+
+## What actually isolates the arms (measured this session, v2.1.201)
+
+Three plausible mechanisms were tested with trivial probes; only one works, and
+it has a caveat:
+
+- **`--bare`** — refuses the subscription token (`Not logged in`). Unusable for
+  isolated arms authenticated by `CLAUDE_CODE_OAUTH_TOKEN`.
+- **`CLAUDE_CONFIG_DIR`** — relocates session/auth storage but **not** memory
+  discovery: `~/.claude/CLAUDE.md` + `rules/` still load. Does not strip memory.
+- **`HOME` override** — Claude discovers `~/.claude` from `$HOME`, so a per-arm
+  `$HOME` **does** strip memory. This is the mechanism `run-one.sh` uses.
+  Caveat below.
+
+MCP servers are discovered from the **cwd** (`.mcp.json`), not `$HOME`, and load
+~90k of tool schemas that swamp the arms — so every run passes
+`--strict-mcp-config`, and the sweep runs from a neutral fixture repo
+(`make-fixture.sh`) with no `.mcp.json` / project `.claude` in its ancestry.
+
+### Measured per-layer eager cost (headless, neutral cwd, `ctx = cache_creation + cache_read`)
+
+| Arm | ctx tokens | Δ = layer cost |
+|---|---|---|
+| `clean` | 21,019 | base (system prompt + core tools) |
+| `plugins-only` | 26,205 | **+5,186** — 30 marketplace plugins' skill descriptions |
+| `full` | 92,725 | **+66,520** — global memory + hooks |
+
+Note this corrects the interactive `/context` figures: eager **skills cost ~5k,
+not ~22k**, and **global memory is the ~67k lever**. Memory is where the
+slimmer/fatter question lives; skills are nearly free eagerly.
+
+### Known caveat: HOME override re-triggers tool init (outcome sweep is WIP)
+
+For *context measurement* (trivial prompts) HOME override is clean. For real
+*task* runs it is fragile: pointing `$HOME` at an empty dir makes mise/go and
+other `$HOME`-rooted tooling re-initialise and download into the fake HOME (a
+Go toolchain landed in `fh-clean/go`, whose read-only module cache then broke
+`arm-prep`'s cleanup). Hardening options (not yet chosen): symlink the
+tool-cache dirs (`go`, `.cache`, `.config`, `.local`) from the real HOME into
+each fake HOME so only `~/.claude` differs; pin `GOTOOLCHAIN=local` and cache
+env vars; or run each arm in a container. Until then the **outcome sweep**
+(`run-config.sh`) should be treated as WIP; the **cost decomposition** above is
+solid.
+
+## Auth (one-time)
+
+Both isolated arms lose the interactive OAuth login, so they authenticate from a
+token. Mint a subscription-billed one and add it to `~/.api_tokens`:
+
+```
+claude setup-token
+echo 'export CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat01-..."' >> ~/.api_tokens
+```
+
+`run-config.sh` sources it automatically. `ANTHROPIC_API_KEY` also works (bills
+the API account instead of the subscription).
+
+## Run
+
+```
+just run-config '0[1246]-*' 3   # read-only probes, clean/plugins-only/full, 3 runs
+just compare-fast latest        # deterministic scores only (no LLM judge)
+```
+
+## Files
+
+- `conditions.yaml` — `cfg-clean` / `cfg-plugins` / `cfg-full` (new `config` field)
+- `scripts/run-one.sh` — maps `config` → `$HOME` + `--strict-mcp-config`
+- `scripts/arm-prep.sh` — builds the per-arm fake HOMEs
+- `scripts/make-fixture.sh` — neutral sample repo for the sweep cwd
+- `scripts/run-config.sh` — sources token, preps, sweeps the 3 arms
+- `scripts/score-run.py` — now surfaces `ctx=` (context size) per run

--- a/experiments/claude-probe/justfile
+++ b/experiments/claude-probe/justfile
@@ -24,6 +24,12 @@ run filter="*" runs="3":
 run-full filter="*" runs="3":
     bash scripts/run-suite.sh --filter "{{filter}}" --runs "{{runs}}"
 
+# Config-isolation sweep: clean-slate vs plugins-only vs full.
+# Needs CLAUDE_CODE_OAUTH_TOKEN in ~/.api_tokens (run `claude setup-token` once).
+[group: "run"]
+run-config filter="*" runs="3":
+    bash scripts/run-config.sh --filter "{{filter}}" --runs "{{runs}}"
+
 # Requires opus-max-{default,probe} in conditions.yaml — intentionally absent
 # from the default sweep, so add them when you actually need this run.
 # Opt-in `max`-effort heavy check (manual only; needs opus-max-* conditions).

--- a/experiments/claude-probe/scripts/arm-prep.sh
+++ b/experiments/claude-probe/scripts/arm-prep.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Prepare the per-arm fake HOME directories for the config-isolation sweep.
+#
+# Claude Code discovers global config (CLAUDE.md, rules/, skills, hooks) from
+# $HOME/.claude — NOT from CLAUDE_CONFIG_DIR (which only relocates session/auth
+# storage) and NOT via --bare (which additionally refuses the subscription
+# token). So a per-arm $HOME is what actually controls the global config surface.
+# Measured, neutral cwd, headless (see docs/config-arms.md):
+#   clean        HOME=fh-clean    ~21k ctx   (system prompt + core tools)
+#   plugins-only HOME=fh-plugins  ~26k ctx   (+ ~5k marketplace skills, no memory)
+#   full         HOME=$REAL_HOME  ~93k ctx   (+ ~67k global memory + hooks)
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "$here/.." && pwd)"
+base="$root/.arm-configs"
+src_plugins="$HOME/.claude/plugins"
+src_settings="$HOME/.claude/settings.json"
+
+[ -d "$src_plugins" ] || { echo "ERROR: $src_plugins not found" >&2; exit 1; }
+[ -f "$src_settings" ] || { echo "ERROR: $src_settings not found" >&2; exit 1; }
+
+# clean: an empty fake HOME — no memory, no skills, no plugins.
+rm -rf "$base/fh-clean"
+mkdir -p "$base/fh-clean/.claude"
+
+# plugins-only: fake HOME whose .claude symlinks the real plugin cache/registry
+# and carries the same enabledPlugins + env, but has NO CLAUDE.md and NO rules/.
+# => marketplace skills without the global memory (cloud/CI parity).
+rm -rf "$base/fh-plugins"
+mkdir -p "$base/fh-plugins/.claude"
+ln -s "$src_plugins" "$base/fh-plugins/.claude/plugins"
+jq '{enabledPlugins, env}' "$src_settings" > "$base/fh-plugins/.claude/settings.json"
+
+n_plugins="$(jq -r '.enabledPlugins // {} | to_entries | map(select(.value)) | length' "$base/fh-plugins/.claude/settings.json")"
+echo "[arm-prep] fake HOMEs ready under $base"
+echo "[arm-prep]   fh-clean:   empty .claude (no memory, no skills)"
+echo "[arm-prep]   fh-plugins: $n_plugins plugins enabled, no CLAUDE.md/rules"
+echo "[arm-prep]   full arm uses the real \$HOME ($HOME)"

--- a/experiments/claude-probe/scripts/make-fixture.sh
+++ b/experiments/claude-probe/scripts/make-fixture.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Build a neutral throwaway "repository" for the config sweep to run in.
+#
+# Why a fixture instead of the real repo: the sweep must run from a cwd with NO
+# .mcp.json and NO project .claude in its ancestry, or (a) project MCP servers
+# load ~90k of tool schemas and (b) the project's enabledPlugins leak skills
+# into even the clean arm — both destroy the isolation. A self-contained repo
+# under /tmp has neither. It carries just enough tree for the read-only probes:
+# markdown under docs/ (01), a README (02), a searchable source file (04), and
+# git history (06).
+set -euo pipefail
+
+dest="${1:?usage: make-fixture.sh <dest-dir>}"
+rm -rf "$dest"
+mkdir -p "$dest/docs" "$dest/src" "$dest/.claude-plugin"
+cd "$dest"
+
+cat > README.md <<'EOF'
+# Sample Service
+
+A tiny fixture repository for claude-probe config-isolation runs.
+
+## Overview
+
+This repo exists only so behavior probes have a realistic tree to act on:
+markdown under docs/, a source file, and a git history. Nothing here is real.
+
+## Layout
+
+- docs/  design notes
+- src/   application code
+EOF
+
+cat > docs/architecture.md <<'EOF'
+# Architecture
+
+The service is a single module. There is deliberately nothing to see here.
+EOF
+
+cat > docs/deployment.md <<'EOF'
+# Deployment
+
+Deployed by hand in the fixture. Do not do this at home.
+EOF
+
+cat > docs/faq.md <<'EOF'
+# FAQ
+
+Q: Is this a real service? A: No, it is a claude-probe fixture.
+EOF
+
+cat > src/settings.py <<'EOF'
+import os
+
+# Toggle to skip auto-loaded memory files during tests.
+CLAUDE_CODE_DISABLE_AUTO_MEMORY = os.environ.get("CLAUDE_CODE_DISABLE_AUTO_MEMORY", "0")
+DEBUG = False
+EOF
+
+cat > src/main.py <<'EOF'
+from settings import DEBUG
+
+
+def main() -> None:
+    print("hello", DEBUG)
+
+
+if __name__ == "__main__":
+    main()
+EOF
+
+cat > .claude-plugin/marketplace.json <<'EOF'
+{ "name": "sample-marketplace", "owner": "fixture", "plugins": [] }
+EOF
+
+git init -q
+git config user.email fixture@example.com
+git config user.name Fixture
+git add -A
+git commit -qm "initial fixture"
+
+echo "[make-fixture] sample repo at $dest ($(find . -type f -not -path './.git/*' | wc -l | tr -d ' ') files)"

--- a/experiments/claude-probe/scripts/run-config.sh
+++ b/experiments/claude-probe/scripts/run-config.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Config-isolation sweep: clean-slate vs plugins-only vs full.
+#
+# Holds model + effort + system_prompt fixed and varies ONLY the global config
+# surface (via a per-arm $HOME; see arm-prep.sh / docs/config-arms.md). Runs from
+# a neutral fixture repo so no project .mcp.json / .claude confounds the arms.
+#
+# The isolated arms have no OAuth login, so this sources a subscription token
+# from ~/.api_tokens. One-time:  claude setup-token
+#   then:  echo 'export CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat01-..."' >> ~/.api_tokens
+#
+# Usage: run-config.sh [--filter <glob>] [--runs <n>] [--run-id <id>]
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Load auth token without letting a stray line in ~/.api_tokens abort the run.
+if [ -f "$HOME/.api_tokens" ]; then
+  set +e +u
+  set -a
+  # shellcheck disable=SC1091
+  . "$HOME/.api_tokens" 2>/dev/null
+  set +a
+  set -e -u
+fi
+if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+  echo "ERROR: no CLAUDE_CODE_OAUTH_TOKEN (or ANTHROPIC_API_KEY) in ~/.api_tokens." >&2
+  echo "       Run:  claude setup-token" >&2
+  echo "       Then: echo 'export CLAUDE_CODE_OAUTH_TOKEN=\"<token>\"' >> ~/.api_tokens" >&2
+  exit 1
+fi
+export CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN:-}"
+if [ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
+  echo "[run-config] auth: subscription token (len ${#CLAUDE_CODE_OAUTH_TOKEN})"
+else
+  echo "[run-config] auth: ANTHROPIC_API_KEY"
+fi
+
+# Prep the per-arm fake HOMEs and the neutral fixture repo.
+bash "$here/arm-prep.sh"
+fixture="${CLAUDE_PROBE_FIXTURE:-/tmp/claude-probe-fixture}"
+bash "$here/make-fixture.sh" "$fixture"
+echo "[run-config] fixture cwd: $fixture"
+
+# Run the three arms from the fixture cwd. run-suite reads tests/conditions by
+# absolute path and writes results under claude-probe/, so cwd can be the fixture.
+( cd "$fixture" && bash "$here/run-suite.sh" --conditions cfg-clean,cfg-plugins,cfg-full "$@" )

--- a/experiments/claude-probe/scripts/run-one.sh
+++ b/experiments/claude-probe/scripts/run-one.sh
@@ -79,15 +79,23 @@ fi
 # see docs/config-arms.md.) --strict-mcp-config drops cwd-discovered project
 # MCP servers so their ~90k of tool schemas don't swamp and confound the arms.
 claude_args+=(--strict-mcp-config)
+real_home="$HOME"
 case "$PROBE_CONFIG" in
   full) : ;;  # real $HOME
   clean)       export HOME="$root/.arm-configs/fh-clean" ;;
   plugins-only) export HOME="$root/.arm-configs/fh-plugins" ;;
   *) echo "ERROR: unknown config arm: $PROBE_CONFIG" >&2; exit 1 ;;
 esac
-if [ "$PROBE_CONFIG" != "full" ] && [ ! -d "$HOME/.claude" ]; then
-  echo "ERROR: missing fake HOME $HOME/.claude — run scripts/arm-prep.sh first" >&2
-  exit 1
+if [ "$PROBE_CONFIG" != "full" ]; then
+  [ -d "$HOME/.claude" ] || { echo "ERROR: missing fake HOME $HOME/.claude — run scripts/arm-prep.sh first" >&2; exit 1; }
+  # The HOME override strips ~/.claude memory but also unroots HOME-defaulting
+  # tools. mise stays correct via the inherited absolute XDG_* dirs (precedence
+  # MISE_*_DIR > XDG_*_HOME > $HOME). Go is only partly XDG-aware, so pin its
+  # paths at the real HOME and disable toolchain auto-download — otherwise it
+  # re-downloads a toolchain into the fake HOME. See docs/config-arms.md.
+  export GOTOOLCHAIN=local
+  export GOPATH="${GOPATH:-$real_home/go}"
+  export GOMODCACHE="${GOMODCACHE:-$real_home/go/pkg/mod}"
 fi
 
 if [ "$PROBE_CONFIG" != "full" ] \

--- a/experiments/claude-probe/scripts/run-one.sh
+++ b/experiments/claude-probe/scripts/run-one.sh
@@ -43,7 +43,9 @@ if not cond:
 for k in ("model", "thinking", "system_prompt"):
     print(f"PROBE_{k.upper()}={shlex.quote(str(cond[k]))}")
 # config is optional; absent => "full" so pre-existing conditions are unchanged.
-print(f"PROBE_CONFIG={shlex.quote(str(cond.get(\"config\", \"full\")))}")
+# (Assign first — an f-string expression cannot contain a backslash on py<3.12.)
+cfg = cond.get("config", "full")
+print(f"PROBE_CONFIG={shlex.quote(str(cfg))}")
 '
 )"
 

--- a/experiments/claude-probe/scripts/run-one.sh
+++ b/experiments/claude-probe/scripts/run-one.sh
@@ -42,6 +42,8 @@ if not cond:
     sys.exit("ERROR: unknown condition: " + os.environ["PY_COND_ID"])
 for k in ("model", "thinking", "system_prompt"):
     print(f"PROBE_{k.upper()}={shlex.quote(str(cond[k]))}")
+# config is optional; absent => "full" so pre-existing conditions are unchanged.
+print(f"PROBE_CONFIG={shlex.quote(str(cond.get(\"config\", \"full\")))}")
 '
 )"
 
@@ -70,6 +72,32 @@ if [ "$PROBE_SYSTEM_PROMPT" = "probe" ]; then
   claude_args+=(--system-prompt-file "$probe_file")
 fi
 
+# Config-isolation arm: vary what GLOBAL config Claude Code loads, via $HOME.
+# Claude discovers ~/.claude (memory, skills, hooks) from $HOME, so a per-arm
+# HOME is what actually strips the global config. (--bare refuses the
+# subscription token; CLAUDE_CONFIG_DIR does not relocate memory discovery —
+# see docs/config-arms.md.) --strict-mcp-config drops cwd-discovered project
+# MCP servers so their ~90k of tool schemas don't swamp and confound the arms.
+claude_args+=(--strict-mcp-config)
+case "$PROBE_CONFIG" in
+  full) : ;;  # real $HOME
+  clean)       export HOME="$root/.arm-configs/fh-clean" ;;
+  plugins-only) export HOME="$root/.arm-configs/fh-plugins" ;;
+  *) echo "ERROR: unknown config arm: $PROBE_CONFIG" >&2; exit 1 ;;
+esac
+if [ "$PROBE_CONFIG" != "full" ] && [ ! -d "$HOME/.claude" ]; then
+  echo "ERROR: missing fake HOME $HOME/.claude — run scripts/arm-prep.sh first" >&2
+  exit 1
+fi
+
+if [ "$PROBE_CONFIG" != "full" ] \
+   && [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] \
+   && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+  echo "ERROR: config=$PROBE_CONFIG needs CLAUDE_CODE_OAUTH_TOKEN (or ANTHROPIC_API_KEY) in env" >&2
+  echo "       run: claude setup-token   (then export CLAUDE_CODE_OAUTH_TOKEN=...)" >&2
+  exit 1
+fi
+
 started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 set +e
 claude "${claude_args[@]}" >"$transcript" 2>"$stderr_log"
@@ -85,6 +113,7 @@ PY_RUN_N="$run_n" \
 PY_MODEL="$PROBE_MODEL" \
 PY_THINKING="$PROBE_THINKING" \
 PY_SYSPROMPT="$PROBE_SYSTEM_PROMPT" \
+PY_CONFIG="$PROBE_CONFIG" \
 PY_STARTED="$started_at" \
 PY_ENDED="$ended_at" \
 PY_EXIT="$exit_code" \
@@ -97,6 +126,7 @@ meta = {
     "model": os.environ["PY_MODEL"],
     "thinking": os.environ["PY_THINKING"],
     "system_prompt": os.environ["PY_SYSPROMPT"],
+    "config": os.environ["PY_CONFIG"],
     "started_at": os.environ["PY_STARTED"],
     "ended_at": os.environ["PY_ENDED"],
     "exit_code": int(os.environ["PY_EXIT"]),

--- a/experiments/claude-probe/scripts/score-run.py
+++ b/experiments/claude-probe/scripts/score-run.py
@@ -112,7 +112,12 @@ def final_answer_text(events: list[dict[str, Any]]) -> str:
 
 def usage_totals(events: list[dict[str, Any]]) -> dict[str, int]:
     """Sum input/output tokens from usage blocks if present."""
-    totals = {"input_tokens": 0, "output_tokens": 0, "cache_read_input_tokens": 0}
+    totals = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+    }
     for ev in events:
         msg = ev.get("message") or ev
         usage = msg.get("usage") if isinstance(msg, dict) else None
@@ -269,7 +274,9 @@ def main() -> int:
                 str(meta["run_n"]),
                 "_stats",
                 "INFO",
-                f"turns={turns} in={totals['input_tokens']} out={totals['output_tokens']} cache_r={totals['cache_read_input_tokens']}",
+                f"turns={turns} in={totals['input_tokens']} out={totals['output_tokens']} "
+                f"cache_r={totals['cache_read_input_tokens']} cache_c={totals['cache_creation_input_tokens']} "
+                f"ctx={totals['cache_creation_input_tokens'] + totals['cache_read_input_tokens']}",
             ]
         )
     )


### PR DESCRIPTION
## What

Adds a **config axis** to the `claude-probe` A/B harness (in `experiments/`): hold model + effort + system-prompt fixed and vary only the global config surface Claude Code loads, to measure what the workstation setup buys and what it costs.

Three arms via per-arm `$HOME`:
- `clean` — system prompt + core tools only
- `plugins-only` — marketplace skills, no global memory (cloud/CI parity)
- `full` — real `~/.claude`: 52 rules + `CLAUDE.md` + skills + hooks

## Phase 0 findings (measured this run, Opus-low)

**Eager per-layer context** (headless, neutral cwd): clean 21k → +5k skills → +67k memory. Skills are ~free eagerly; the 67k of rules is the whole lever — correcting the interactive `/context` figures (which imply ~22k for skills).

**Outcome sweep** (4 read-only probes × 3 arms × N=3, 36 runs, 0 failed): arms **indistinguishable** — full ties clean on 3 of 4 probes, +1 noise-level check on the 4th. Cost, same ~3.4 turns each: clean \$0.069 · plugins-only \$0.259 (3.8×) · full \$0.672 (9.8×) per task.

Read: on generic tasks the config is ~10× cost for no measurable benefit — the empirical case for a **trap corpus** (tasks shaped like the failures the rules guard), which is the follow-up.

## Mechanism notes (verified v2.1.201)

- JSON `usage` gives full token/cost breakdown → context observable, no OTEL.
- `--bare` refuses the subscription token; `CLAUDE_CONFIG_DIR` does not relocate memory discovery → isolation is via `$HOME`.
- MCP is cwd-based (~90k tool schemas) → `--strict-mcp-config` + neutral fixture cwd.
- HOME override unroots `$HOME`-defaulting tools; mise is fine via absolute `XDG_*`, but Go needs `GOTOOLCHAIN=local` + pinned `GOPATH`/`GOMODCACHE`.

## Files

`conditions.yaml` (config field), `scripts/{run-one,arm-prep,make-fixture,run-config}.sh`, `scripts/score-run.py` (context-size metric), `docs/config-arms.md`.

Auth: needs a subscription `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`) in `~/.api_tokens` for the isolated arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)