### PR TITLE
test(git-repo-agent): add _score_ci regression tests for per-file scanning

### DIFF
--- a/git-repo-agent/tests/test_health_check_detection.py
+++ b/git-repo-agent/tests/test_health_check_detection.py
@@ -2,13 +2,13 @@
 
 Tests that _score_quality correctly detects formatters and type checkers
 from various config file patterns, including standalone configs and
-pre-commit hooks.
+pre-commit hooks. Also covers _score_ci per-file feature scanning.
 """
 
 from pathlib import Path
 import tempfile
 
-from git_repo_agent.tools.health_check import _score_quality
+from git_repo_agent.tools.health_check import _score_ci, _score_quality
 
 
 def _make_repo(*files: str, file_contents: dict[str, str] | None = None) -> Path:
@@ -162,3 +162,104 @@ class TestTypeCheckerDetection:
         repo = _make_repo()
         _, findings = _score_quality(repo)
         assert "No type checking configured" in findings
+
+
+# --- CI scoring ---
+
+
+class TestCiScoring:
+    """Regression tests for _score_ci per-file feature scanning.
+
+    _score_ci awards 8 points for having workflow files, plus 3 each for
+    pull_request, push-to-main/master, release, and cache features. The
+    push-to-main check must match "push" and "main"/"master" within a
+    single workflow file — the old aggregated-content scan let the two
+    keywords match across different files (cross-file false positive).
+    """
+
+    def test_cross_file_push_main_not_credited(self):
+        """Regression: 'push' in one file + 'main' in another must not score.
+
+        The pre-fix implementation concatenated all workflow contents into
+        one string, so 'push' in ci.yml and 'main' in deploy.yml satisfied
+        the push-to-main check even though no single workflow had both.
+        """
+        repo = _make_repo(
+            ".github/workflows/ci.yml",
+            ".github/workflows/deploy.yml",
+            file_contents={
+                ".github/workflows/ci.yml": "on:\n  push:\n",
+                ".github/workflows/deploy.yml": (
+                    "on:\n  workflow_dispatch:\nenv:\n  BRANCH: main\n"
+                ),
+            },
+        )
+        score, findings = _score_ci(repo)
+        assert score == 8  # workflows present, no feature credited
+        assert findings == []
+
+    def test_single_file_push_main_credited(self):
+        repo = _make_repo(
+            ".github/workflows/ci.yml",
+            file_contents={
+                ".github/workflows/ci.yml": "on:\n  push:\n    branches: [main]\n"
+            },
+        )
+        score, _ = _score_ci(repo)
+        assert score == 11  # 8 base + 3 push-to-main
+
+    def test_single_file_push_master_credited(self):
+        repo = _make_repo(
+            ".github/workflows/ci.yml",
+            file_contents={
+                ".github/workflows/ci.yml": "on:\n  push:\n    branches: [master]\n"
+            },
+        )
+        score, _ = _score_ci(repo)
+        assert score == 11  # 8 base + 3 push-to-master
+
+    def test_all_features_single_file(self):
+        repo = _make_repo(
+            ".github/workflows/ci.yml",
+            file_contents={
+                ".github/workflows/ci.yml": (
+                    "on:\n"
+                    "  pull_request:\n"
+                    "  push:\n"
+                    "    branches: [main]\n"
+                    "  release:\n"
+                    "jobs:\n"
+                    "  test:\n"
+                    "    steps:\n"
+                    "      - uses: actions/cache@v4\n"
+                )
+            },
+        )
+        score, _ = _score_ci(repo)
+        assert score == 20  # 8 base + 4 features x 3
+
+    def test_features_spread_across_files(self):
+        """Independent features still accumulate across separate files."""
+        repo = _make_repo(
+            ".github/workflows/pr.yml",
+            ".github/workflows/release.yml",
+            file_contents={
+                ".github/workflows/pr.yml": "on:\n  pull_request:\n",
+                ".github/workflows/release.yml": "on:\n  release:\n",
+            },
+        )
+        score, _ = _score_ci(repo)
+        assert score == 14  # 8 base + pull_request + release
+
+    def test_empty_workflows_dir_reports_finding(self):
+        repo = _make_repo()
+        (repo / ".github" / "workflows").mkdir(parents=True)
+        score, findings = _score_ci(repo)
+        assert score == 0
+        assert ".github/workflows/ exists but has no workflow files" in findings
+
+    def test_no_ci_configuration(self):
+        repo = _make_repo()
+        score, findings = _score_ci(repo)
+        assert score == 0
+        assert "No CI/CD configuration found" in findings


### PR DESCRIPTION
Adds the regression tests requested in the review of #1950 (per `.claude/rules/regression-testing.md`). A previous claude[bot] job wrote equivalent tests but couldn't push (its commit `8bf1d1ab` was stranded in the CI runner); this PR recreates them and — unlike that job — actually ran them.

**What's covered** (`TestCiScoring` in `git-repo-agent/tests/test_health_check_detection.py`):

| Test | Locks in |
|------|----------|
| `test_cross_file_push_main_not_credited` | `push` in file A + `main` in file B must **not** credit push-to-main — the cross-file false positive #1950 fixes (score stays 8) |
| `test_single_file_push_main_credited` | `on: push: branches: [main]` in one file scores 11 |
| `test_single_file_push_master_credited` | `master` accepted alongside `main` |
| `test_all_features_single_file` | All four features in one file → full 20 (8 + 4×3) |
| `test_features_spread_across_files` | Independent features still accumulate across separate files |
| `test_empty_workflows_dir_reports_finding` | Empty `.github/workflows/` → finding + score 0 |
| `test_no_ci_configuration` | No CI config → finding + score 0 |

**Verified:** `uv run pytest tests/test_health_check_detection.py -q` → **26 passed** (19 pre-existing + 7 new) on top of the #1950 head (`642a2a86`).

This PR targets the `perf-optimize-score-ci-10339205551505661863` branch — merge it to fold the tests into #1950.

Refs #1950

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmPRXDQERsCSX3N7uYyMxf

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmPRXDQERsCSX3N7uYyMxf)_