### PR TITLE
feat(code-quality-plugin): add bulk-sweep-classify skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ the rules, skills, and hooks that embody it.
 
 | Plugin | Skills | Description |
 |--------|--------|-------------|
-| **code-quality-plugin** | 14 | Code review, refactoring, linting, static analysis, debugging methodology |
+| **code-quality-plugin** | 15 | Code review, refactoring, linting, static analysis, debugging methodology |
 | **software-design-plugin** | 5 | Software design methodology - deep modules, design by contract, GoF pattern selection, legacy seams, pseudocode |
 | **evaluate-plugin** | 6 + 3 agents | Skill evaluation and benchmarking - test effectiveness, grade results |
 | **codebase-attributes-plugin** | 3 | Structured codebase health attributes with severity-based agent routing |

--- a/code-quality-plugin/README.md
+++ b/code-quality-plugin/README.md
@@ -21,6 +21,7 @@ This plugin provides comprehensive code quality tools including automated code r
 | `/code:dep-audit` | Audit dependencies for security vulnerabilities, outdated packages, and license compliance |
 | `/code:test-quality` | Analyze test suite quality — detect test smells, empty assertions, flaky patterns |
 | `/code:complexity` | Analyze code complexity metrics — cyclomatic, cognitive, function length, coupling |
+| `/code-quality:bulk-sweep-classify` | Classify every regex match into four categories before a bulk find-replace/syntax-modernization sweep; scoped transform, allowlist-aware verification |
 | `ast-grep-search` | AST-based code search for structural pattern matching |
 
 ## Agents

--- a/code-quality-plugin/skills/bulk-sweep-classify/SKILL.md
+++ b/code-quality-plugin/skills/bulk-sweep-classify/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: bulk-sweep-classify
+description: "Classify every regex match before a bulk find-replace/syntax-modernization sweep — four match categories, scoped transform, allowlist-aware verification. Use when bulk-renaming commands/tools/paths or migrating syntax across many files."
+allowed-tools: Bash, Read, Grep, Edit
+created: 2026-07-05
+modified: 2026-07-05
+reviewed: 2026-07-05
+---
+
+# Bulk Sweep — Classify Every Match First
+
+When you modernize a syntax across many files with a `regex` / `sed` / `perl`
+pass — a command rename (`/ns:cmd` → `/ns-cmd`), a tool/binary rename, a path or
+import-style migration, an API-version bump in prose — the matched set is
+**heterogeneous even though every hit looks textually identical**. One pattern
+catches genuine stale targets *and* several look-alikes that must NOT be
+transformed. Blindly rewriting all matches corrupts the look-alikes silently: the
+sweep reports success, and the damage surfaces far downstream (a broken designed
+filename, a rewritten immutable record).
+
+**The discipline: enumerate the matches and bucket every one into a category
+before editing.** The regex sees *text*; the transform needs *semantics*.
+
+## When to Use This Skill
+
+| Use this skill when... | Use something else instead when... |
+|------------------------|------------------------------------|
+| A find-replace where the delimiter/token also appears in filenames, config keys, URLs, designs, or historical records | The pattern is structural (function shape, call form) → `ast-grep-search` |
+| Command-syntax migration (`/ns:cmd` → `/ns-cmd`), tool rename in docs, path/import migration, API-version bump in prose | A one-off literal string search with no look-alike risk → `tools-plugin:rg-code-search` |
+| Docs trees mixing live guidance with ADRs / changelogs / design PRDs, all matching the same regex | The whole match-set is genuinely uniform and you have verified it |
+
+## The Four Categories
+
+Read the surrounding line of each match and bucket it. Each category needs
+different handling.
+
+| Category | Handling | Canonical example (command-syntax sweep) |
+|---|---|---|
+| **1. Genuine stale target** | **Transform** | `/configure:mcp` → `/configure-mcp` in live docs |
+| **2. False positive** — merely matches the pattern | **Leave** | `laurigates/dotfiles:latest` (docker tag); `redis://host:6379` (digit after `:`, not a command) |
+| **3. Out-of-scope design** legitimately using the old form — esp. **delimiter embedded in designed filenames/paths** | **Leave** — transforming corrupts the design | `/sync:daily` PRD whose colon also appears in `sync:daily-state.json`, `.claude/commands/sync:daily.md` |
+| **4. Immutable / historical record** matching the pattern | **Supersede-note; do NOT rewrite the body** | Accepted ADRs documenting the old `/namespace:command` convention |
+
+**Category 3 is the sharpest trap.** The delimiter you're replacing (`:`, `/`,
+`.`, `-`) often also appears in **filenames, config keys, or URLs** that the
+matched token participates in. Hyphenating `/sync:daily` → `/sync-daily` also
+rewrites every `sync:daily-state.json` path in the same doc — silently breaking a
+design.
+
+**Category 4** follows the standard supersede-don't-rewrite convention: set
+`Status: Superseded` plus a top-note, leave the body as a historical record.
+
+## Execution
+
+Run this classify-then-transform sweep:
+
+### Step 1: Enumerate every match, deduped, before touching anything
+
+```
+git grep -nhoE '/[a-z][a-z0-9-]*:[a-z][a-z0-9-]*' -- <scope> | sort -u
+```
+
+Adjust the pattern to your migration. The point is a complete, deduped inventory
+in hand *before* any edit.
+
+### Step 2: Tighten the pattern to drop false positives at the source
+
+Drive the false-positive exclusion into the **pattern** wherever you can, so the
+sweep mechanically cannot touch category-2 hits. Example: requiring a letter
+after the colon (`:[a-z]`) excludes `:6379` ports and `redis://` URLs. This
+removes the whole class from manual consideration.
+
+### Step 3: Bucket every remaining hit into categories 1–4
+
+Read the surrounding line of each match. Reserve manual judgment for categories 3
+and 4 — they *look* like real targets and can only be told apart by reading
+intent. Record which files/lines fall into categories 2–4 (the
+**intentionally-preserved set**).
+
+### Step 4: Scope the transform to category-1 files ONLY
+
+```
+perl -i -pe 's{/([a-z][a-z0-9-]*):([a-z][a-z0-9-]*)}{/$1-$2}g' <category-1 files>
+```
+
+Pass only the category-1 files. Hand-handle categories 3 and 4:
+category 3 is left untouched; category 4 gets a supersede/status note with its
+body left intact.
+
+### Step 5: Verify against the preserved set, not literal zero
+
+Re-run the enumeration from Step 1. The correct success test is **NOT** "zero
+matches remain":
+
+> **Zero matches remain *outside the intentionally-preserved set*.**
+
+Categories 3 and 4 are *supposed* to keep matching. Confirm the grep returns
+**only** the category 2–4 lines you identified in Step 3.
+
+## The Verification Trap
+
+The naive success test — *"re-run the grep; it should return nothing"* — is
+**wrong**, because categories 3 and 4 legitimately still match. A verification
+that demands literal zero will either fail spuriously or — worse — pressure you
+into corrupting a category-3 design or rewriting a category-4 record just to force
+the count to zero. Enumerate the preserved buckets up front, then verify the grep
+returns *only* those.
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Enumerate deduped matches | `git grep -nhoE '<pattern>' -- <scope> \| sort -u` |
+| Count matches per file | `git grep -cE '<pattern>' -- <scope>` |
+| Preview a scoped transform | `perl -ne 's{<from>}{<to>}g and print' <files>` |
+| Apply to category-1 files only | `perl -i -pe 's{<from>}{<to>}g' <category-1 files>` |
+| Verify preserved-set only | `git grep -nE '<pattern>' -- <scope>` (expect only categories 2–4) |
+
+## Related
+
+- `verify-upstream-before-patching` / `read-issue-thread-before-contributing` — establish authoritative *intent* before acting, don't trust a surface signal
+- `git-hazards` — an automated pass reporting success is not proof the *result* is correct; verify the content, not the exit code
+- `code-quality-plugin:ast-grep-search` — structural search/replace when the pattern depends on AST shape rather than text

--- a/docs/PLUGIN-MAP.md
+++ b/docs/PLUGIN-MAP.md
@@ -46,7 +46,7 @@ Automated quality enforcement.
 | Plugin | Skills | Purpose |
 |--------|--------|---------|
 | testing-plugin | 16 | Test execution, TDD, Vitest, Playwright, Playwright CLI, mutation testing |
-| code-quality-plugin | 14 | Review, refactoring, linting, ast-grep, debugging, silent degradation, dead code, dep audit, test quality, complexity |
+| code-quality-plugin | 15 | Review, refactoring, linting, ast-grep, debugging, silent degradation, dead code, dep audit, test quality, complexity, bulk-sweep classification |
 | software-design-plugin | 5 | Deep modules, design by contract, GoF pattern selection, legacy seams, design by pseudocode |
 | documentation-plugin | 5 | API docs, README generation, knowledge graphs |
 | evaluate-plugin | 6 + 3 agents | Skill evaluation, benchmarking, quality improvement |

--- a/docs/diagrams/plugin-relationships.d2
+++ b/docs/diagrams/plugin-relationships.d2
@@ -119,7 +119,7 @@ quality: {
     class: quality
   }
   code-quality: {
-    label: "code-quality\n14 skills"
+    label: "code-quality\n15 skills"
     shape: rectangle
     class: quality
   }


### PR DESCRIPTION
## What

Adds `code-quality-plugin/skills/bulk-sweep-classify/SKILL.md` — a new skill that promotes the user-global rule `bulk-syntax-sweep-classify-matches` into a reusable, imperative procedure for safe bulk find-replace / syntax-modernization sweeps.

Metadata updated in the same commit:
- `/code-quality:bulk-sweep-classify` row added to `code-quality-plugin/README.md`
- code-quality-plugin skill count bumped 14 → 15 in `docs/PLUGIN-MAP.md`, root `README.md`, and `docs/diagrams/plugin-relationships.d2`

`bash scripts/check-docs-index.sh --strict` passes (`STATUS=OK`, `ISSUE_COUNT=0`).

## Why

A bulk regex/sed/perl sweep (command rename `/ns:cmd` → `/ns-cmd`, tool rename, path/import migration, API-version bump in prose) matches a **heterogeneous** set even though every hit looks textually identical. Blindly rewriting all matches silently corrupts look-alikes — a designed filename like `sync:daily-state.json`, or an immutable ADR body — while the sweep still reports success; the damage surfaces far downstream.

The skill enforces the discipline:
- **Enumerate** deduped matches before touching anything
- **Tighten** the pattern to drop false positives at the source
- **Bucket** every hit into four categories: genuine stale target → transform / false positive → leave / out-of-scope design with embedded delimiter → leave / immutable historical record → supersede-note (don't rewrite the body)
- **Scope** the transform to category-1 files only
- **Verify** against the intentionally-preserved set — "zero matches OUTSIDE the preserved set", never literal zero (categories 3 & 4 are supposed to keep matching)

Refs #1967

## Remaining follow-up

- Add a pointer-stub in `laurigates/dotfiles` `.claude/rules/bulk-syntax-sweep-classify-matches.md` referencing the promoted skill (`code-quality-plugin:bulk-sweep-classify`), per the documentation-authoring "link, don't duplicate" convention. Not done here (out of scope for this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)