### PR TITLE
refactor(configure-plugin): sharpen cross-plugin skill boundaries

### DIFF
--- a/api-plugin/skills/api-testing/SKILL.md
+++ b/api-plugin/skills/api-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 created: 2025-12-16
-modified: 2026-05-09
+modified: 2026-07-05
 reviewed: 2026-04-25
 name: api-testing
 description: HTTP API testing with Supertest (TS) and httpx/pytest (Python). Use when the user mentions API testing, Supertest, httpx, REST/GraphQL validation, or HTTP response errors.
@@ -14,7 +14,7 @@ Expert knowledge for testing HTTP APIs with Supertest (TypeScript/JavaScript) an
 
 ## When to Use This Skill
 
-| Use this skill when... | Use api-tests instead when... |
+| Use this skill when... | Use `configure-plugin:configure-api-tests` instead when... |
 |---|---|
 | Writing Supertest endpoint tests against an Express/Fastify app | Setting up Pact consumer/provider contract testing infrastructure |
 | Writing httpx + pytest tests for a Python REST/GraphQL API | Validating an OpenAPI specification or wiring schema (Zod/AJV) checks into CI |

--- a/configure-plugin/skills/configure-integration-tests/SKILL.md
+++ b/configure-plugin/skills/configure-integration-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 created: 2025-12-16
-modified: 2026-06-18
+modified: 2026-07-05
 reviewed: 2025-12-16
 description: "Integration testing: Supertest, pytest, Testcontainers. Use when setting up integration tests, creating docker-compose.test.yml, or separating from unit tests."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite
@@ -17,7 +17,7 @@ Check and configure integration testing infrastructure for testing service inter
 
 | Use this skill when... | Use another approach when... |
 |------------------------|------------------------------|
-| Setting up integration testing infrastructure with Supertest, pytest, or Testcontainers | Writing individual integration test cases for specific endpoints |
+| Setting up integration testing infrastructure with Supertest, pytest, or Testcontainers | Writing individual integration test cases for specific endpoints (use `api-plugin:api-testing`) |
 | Creating docker-compose.test.yml for local test service containers | Running existing integration tests (`bun test`, `pytest -m integration`) |
 | Auditing integration test setup for completeness (fixtures, factories, CI) | Configuring unit test runners (`/configure:tests` instead) |
 | Adding integration test jobs to GitHub Actions with service containers | Debugging a specific failing integration test |
@@ -242,6 +242,7 @@ For detailed templates and code examples, see [REFERENCE.md](REFERENCE.md).
 ## See Also
 
 - `/configure:tests` - Unit testing configuration
+- `api-plugin:api-testing` - Writing the Supertest / httpx+pytest tests this skill scaffolds infrastructure for
 - `/configure:api-tests` - API contract testing
 - `/configure:coverage` - Coverage configuration
 - `/configure:all` - Run all compliance checks

--- a/configure-plugin/skills/configure-sentry/SKILL.md
+++ b/configure-plugin/skills/configure-sentry/SKILL.md
@@ -24,6 +24,7 @@ Check and configure Sentry error tracking integration against project standards.
 | Adding source map upload and release tracking to CI/CD | Configuring Sentry alerting rules or notification channels |
 | Verifying Sentry configuration across frontend, Next.js, Node.js, or Python projects | Installing a different error tracking tool (e.g., Bugsnag, Rollbar) |
 | Adding profiling, structured logging, or enrichment helpers | Configuring Sentry alerting rules or notification channels |
+| Project-level setup and compliance auditing | Day-to-day SDK usage patterns — spans, breadcrumbs, cron monitoring, replay (use `typescript-plugin:typescript-sentry`) |
 
 ## Context
 
@@ -213,4 +214,5 @@ For detailed configuration check tables, initialization templates, and CI/CD wor
 - `/configure:all` - Run all compliance checks
 - `/configure:status` - Quick compliance overview
 - `/configure:workflows` - GitHub Actions integration
+- `typescript-plugin:typescript-sentry` - Day-to-day Sentry SDK usage for Bun/Node.js/Next.js (spans, breadcrumbs, cron monitoring, replay)
 - `sentry` MCP server - Sentry API access for project verification


### PR DESCRIPTION
Supersedes #1979. During the stacked-chain merge, a HEAD race caused the branch to be force-pushed with main's tip instead of the rebased commits; GitHub auto-closed #1979 as an empty diff, and a closed PR whose head moved cannot be reopened. The branch now carries the correct rebased commits — identical content to #1979.

Name-reference boundary sharpening per `.claude/rules/skill-consolidation.md` — see #1979 for the full description and verify-premise findings. Two per-plugin commits: `refactor(configure-plugin)` (configure-sentry ↔ typescript-sentry, configure-integration-tests ↔ api-testing) and `refactor(api-plugin)` (api-testing routes contract-testing intents to the canonical configure-api-tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3hXn6UreyfMsBuZ2LsC6z