### PR TITLE
feat(agent-patterns-plugin): add target-branch preflight to parallel-agent-dispatch

### DIFF
--- a/agent-patterns-plugin/skills/parallel-agent-dispatch/REFERENCE.md
+++ b/agent-patterns-plugin/skills/parallel-agent-dispatch/REFERENCE.md
@@ -469,3 +469,45 @@ target_root=$(git -C "<target-dir>" rev-parse --show-toplevel)
 | When the target's enclosing repo ≠ the session repo, do not assume `isolation: "worktree"` isolated the target. | The harness worktrees the session repo; the nested repo is absent from it. |
 | (a) Create the **nested repo's** worktree explicitly off its own `origin/main` and point the agent at that path; **or** (b) brief the agent to `git -C <nested-repo> fetch && git -C <nested-repo> worktree add <path> origin/main` as its first step. | Both give the agent a real isolated checkout of the repo it edits, instead of the blocked shared checkout. |
 | Have the agent operate inside that nested-repo worktree (prefix `git -C "$WORKTREE"`, per the #1480 cwd-reset rule) and open its PR from there. | Keeps the work isolated and avoids the shared-checkout collisions `shared-checkout-branch-isolation.md` guards against. |
+
+## Target-branch preflight (#1969)
+
+`isolation: "worktree"` names the fresh worktree's branch **automatically** (an
+`agent-<hash>` name). When the project convention is a **fixed** per-issue /
+per-milestone name (`feat/m4-sampling-adapter-io`), the agent is told to
+**rename** onto it near the end of its run. Git refuses to check out — or rename
+onto — a branch **already checked out in another worktree**, so if a concurrent
+session picked the same conventional name for the same task, the refusal surfaces
+only at that end-of-task rename.
+
+Observed (laurigates/loractl M4): two sessions independently dispatched the same
+milestone task, both auto-named worktrees, both told to rename onto
+`feat/m4-sampling-adapter-io`. The second finished ~25 min / ~400K tokens in, hit
+the rename refusal (the first had already checked the name out and committed a
+complete duplicate implementation), fell back to a `-wip` suffix, and flagged the
+collision in its return notes. Both reached PR-open independently — two duplicate
+PRs for one issue, needing a full reconciliation pass (diff the two, keep the
+better, port the other's improvements, close the loser). A preflight would have
+stopped at least one session before it started.
+
+### Detection (before dispatch, or as the agent's first step)
+
+```sh
+target="feat/m4-sampling-adapter-io"
+git branch -a --list "$target"                 # local + remote-tracking refs
+git worktree list | grep -F "[$target]"        # same name checked out elsewhere
+git ls-remote --heads origin "$target"         # a peer already pushed it
+```
+
+Any hit ⇒ another session may already own this exact task. **Stop and reconcile**
+(compare/merge with the existing branch/PR — see
+`.claude/rules/concurrent-session-pr-check.md`) rather than racing to a duplicate.
+
+### Rules
+
+| Rule | Why |
+|------|-----|
+| Check the fixed target name against local refs, other worktrees, **and** the remote before substantive work. | The rename-time refusal is the most expensive place to discover the collision; the preflight is one cheap round of `git` reads. |
+| A hit is a **stop/merge decision**, not a rename-with-suffix workaround. | Two sessions on the same conventional name are almost always doing the same task; a `-wip` fallback just produces the duplicate PR. |
+| Prefer pushing under the target name via **explicit refspec** (`git push origin HEAD:$target`) over renaming the worktree branch. | A refspec push never touches the local branch, so it sidesteps the "already checked out in another worktree" refusal entirely; a genuine peer collision then still surfaces — cheaply — as a non-fast-forward reject at push time. |
+| Acute in shared multi-session portfolios (one clone, concurrent Claude Code sessions). | A conventional per-issue/milestone name is exactly what two independent sessions pick identically. |

--- a/agent-patterns-plugin/skills/parallel-agent-dispatch/SKILL.md
+++ b/agent-patterns-plugin/skills/parallel-agent-dispatch/SKILL.md
@@ -5,8 +5,8 @@ user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 model: opus
 created: 2026-04-21
-modified: 2026-07-01
-reviewed: 2026-07-01
+modified: 2026-07-05
+reviewed: 2026-07-05
 ---
 
 # Parallel Agent Dispatch
@@ -53,10 +53,34 @@ Before spawning, the orchestrator must verify:
 | Main working tree is clean (`git status --porcelain` empty) | Agents inherit cwd; uncommitted changes cross-contaminate worktrees |
 | No existing worktree at each planned path (`git worktree list`) | Nested or duplicate worktrees are the #1 source of salvage work |
 | Each agent gets a **unique** branch name | Prevents commits landing on the wrong branch when cwd resolution drifts |
+| **Fixed target branch name not already taken** (see Target-branch preflight below) | A conventional per-issue/milestone name is one two sessions pick identically; the collision otherwise surfaces only at end-of-task rename |
 | Shared counters snapshot (next ADR/PRP number, feature-tracker IDs) | Prevents numbering collisions in parallel doc writes |
 
 If any check fails, **refuse to dispatch** and report the blocker. Do not
 "clean up" uncommitted user work — surface it and ask.
+
+**Target-branch preflight (#1969).** `isolation: "worktree"` auto-names the fresh
+worktree's branch; when the agent is told to **rename** onto a **fixed**
+conventional target name (`feat/m4-…`), git refuses a name already checked out in
+another worktree — so a collision with a concurrent session that picked the same
+name surfaces only at that end-of-task rename, deep into the run (real case: two
+sessions both reached PR-open ~25 min / ~400K tokens in → duplicate-PR reconcile).
+Make it a **cheap up-front stop/merge decision** — before dispatching, or as the
+agent's *first* step:
+
+```bash
+target="feat/m4-sampling-adapter-io"
+git branch -a --list "$target"            # local + remote-tracking refs
+git worktree list | grep -F "[$target]"  # checked out elsewhere
+git ls-remote --heads origin "$target"   # a peer already pushed it
+```
+
+Any hit ⇒ another session may already own this task — **stop and reconcile**, not
+race to a duplicate PR (acute in shared multi-session portfolios —
+`.claude/rules/concurrent-session-pr-check.md`). **Mitigation:** push under the
+target name via explicit refspec (`git push origin HEAD:$target`) instead of
+renaming — sidesteps the "already checked out" refusal. See
+[REFERENCE.md](REFERENCE.md) "Target-branch preflight (#1969)".
 
 **Transient worktree leaks (#1319).** While a wave runs, a file a child wrote
 inside its worktree can briefly appear in the **parent** as an untracked entry

--- a/scripts/check-agent-failure-contract.sh
+++ b/scripts/check-agent-failure-contract.sh
@@ -162,6 +162,19 @@ require_marker "$dispatch_skill" "completion manifest" "the manifest language in
 require_marker "$reference_md" "#1601" "the completion-manifest reference (issue #1601)"
 require_marker "$reference_md" "Completion manifest" "the manifest line in the refactor-brief template (issue #1601)"
 
+# Regression #1969: an isolation:"worktree" dispatch creates a fresh worktree
+# with an AUTO-GENERATED branch name; when the agent later RENAMES onto a fixed
+# conventional target name already checked out by a concurrent session's
+# worktree, git refuses — and the collision surfaces only at end-of-task rename,
+# ~25 min / ~400K tokens deep, after both sessions reached PR-open (two duplicate
+# PRs). The fix adds a target-branch preflight to Pillar 1 (check the fixed name
+# is free via git branch -a --list / worktree list / ls-remote BEFORE work) plus
+# the refspec-push mitigation that sidesteps the "already checked out" refusal.
+# Assert BOTH the load-bearing preflight idiom and the issue reference survive.
+require_marker "$dispatch_skill" "Target-branch preflight" "the target-branch preflight subsection (issue #1969)"
+require_marker "$dispatch_skill" "git ls-remote --heads origin" "the remote target-name check (issue #1969)"
+require_marker "$dispatch_skill" "#1969" "the issue reference"
+
 if [ "$errors" -ne 0 ]; then
   echo
   echo "The loud-failure contract (issue #1422) and the hook-thrashing heuristic"


### PR DESCRIPTION
## What

Adds a **target-branch preflight** to `parallel-agent-dispatch`'s Pillar 1 (Worktree Preflight): before an `isolation: "worktree"` agent begins substantive work — or, better, in the orchestrating script before calling `agent()` — check whether the intended **fixed** conventional target branch name is already in use, via `git branch -a --list`, `git worktree list`, and `git ls-remote --heads origin`. Any hit is surfaced as a cheap up-front stop/merge decision. Also notes the refspec-push mitigation (`git push origin HEAD:<target>`) that sidesteps the git "already checked out in another worktree" refusal entirely.

- SKILL.md: new preflight table row + a concise `Target-branch preflight (#1969)` subsection (kept under the size ceiling).
- REFERENCE.md: full worked example (the loractl M4 collision) + detection snippet + rules table.
- `scripts/check-agent-failure-contract.sh`: `#1969` regression markers (the preflight subsection, the `git ls-remote --heads origin` check, the issue reference).
- Frontmatter `modified`/`reviewed` bumped to 2026-07-05.

## Why

`isolation: "worktree"` creates a fresh worktree with an **auto-generated** branch name; the agent was told to rename onto a fixed conventional target name (`feat/m4-…`). Git refuses to check out or rename onto a branch already checked out in another worktree, so a collision with a concurrent session that picked the same name for the same task surfaced only at **end-of-task rename** — ~25 min / ~400K tokens deep. In the reported case two sessions independently reached PR-open (two duplicate PRs for one issue), needing a full reconciliation pass that a preflight would have avoided for at least one session. Acute in shared multi-session portfolios where a conventional per-issue/milestone name is exactly what two independent sessions pick identically.

The skill's description already claimed to cover "worktree collisions"; this closes the specific fixed-target-name-collision-discovered-at-rename shape it missed.

Closes #1969