### PR TITLE
feat(blueprint-plugin): ambient blueprint operations via autonomy levels (ADR-0020)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ the rules, skills, and hooks that embody it.
 | Plugin | Skills | Description |
 |--------|--------|-------------|
 | **api-plugin** | 1 | API integration and testing - REST endpoints, client generation |
-| **blueprint-plugin** | 33 | Blueprint Development methodology - PRD/PRP workflow with version tracking |
+| **blueprint-plugin** | 34 | Blueprint Development methodology - PRD/PRP workflow with version tracking |
 | **comfyui-plugin** | 3 | ComfyUI custom-node pack lifecycle - scaffold, seed repo, gitops adoption, registry publish |
 | **home-assistant-plugin** | 4 | Home Assistant configuration - automations, scripts, scenes, entities |
 | **obsidian-plugin** | 21 | Obsidian CLI operations - vault management, search, properties, tasks |

--- a/blueprint-plugin/README.md
+++ b/blueprint-plugin/README.md
@@ -63,6 +63,7 @@ PRD (Product Requirements) → PRP (Product Requirement Prompt) → Work-Order �
 | Skill | Description |
 |-------|-------------|
 | `blueprint-execute` | **Smart meta command** - Analyzes repository state and executes the next logical blueprint action (idempotent) |
+| `blueprint-autopilot` | **Level-2 ambient executor** (ADR-0020) - Runs due agent-judgment maintenance tasks quietly and drafts `work-order-draft` proposal issues; no menus, one-line receipt |
 | `blueprint-status` | Show blueprint version, configuration, and traceability report |
 | `blueprint-upgrade` | Upgrade to latest blueprint format |
 | `blueprint-rules` | Manage modular rules |

--- a/blueprint-plugin/README.md
+++ b/blueprint-plugin/README.md
@@ -295,6 +295,46 @@ Run `/blueprint:status` to see:
 /blueprint:sync-ids --link-issues # Also create GitHub issues for orphans
 ```
 
+## Automation (Autonomy Levels)
+
+Blueprint operations can run ambiently instead of user-initiated, governed by
+the manifest `automation` block (format 3.4.0, ADR-0020 in claude-plugins):
+
+```json
+"automation": {
+  "autonomy_level": 0,
+  "interaction_mode": "normal",
+  "work_orders": { "auto_draft": false, "auto_execute": false }
+}
+```
+
+| Level | Name | What runs automatically |
+|-------|------|-------------------------|
+| 0 | manual | Nothing — today's fully interactive behavior (default; a missing block ≡ 0) |
+| 1 | ambient bookkeeping | `scripts/blueprint-autorun.sh` executes **deterministic** due tasks (the `sync-ids` id-registry sweep) via the SessionStart probe; due agent-judgment tasks surface as drift-aggregator findings |
+| 2 | quiet autopilot | + due agent-judgment tasks run in-session; `interaction_mode` defaults to `quiet`; work-order **drafts** may be filed when `work_orders.auto_draft` is true |
+| 3 | scheduled pipeline | Reserved (out-of-band scheduled runs + approved work-order execution; not yet implemented) |
+
+The runner implements the `task_registry` `auto_run`/`schedule` contract:
+a task runs only when `enabled: true` **and** `auto_run: true` **and** its
+schedule interval has elapsed since `last_completed_at` (written back with
+`last_result` and `stats.runs`). `on-change` tasks are event-driven
+(PostToolUse hooks) and `on-demand` tasks never auto-run. Work-order creation
+stays human-only at every level — automation may at most *draft* proposals
+(GitHub issues labeled `work-order-draft`) that a human promotes via
+`/blueprint:work-order --from-issue N`.
+
+```bash
+# Dry-run the due-ness computation (no execution, no writeback)
+bash <plugin-root>/scripts/blueprint-autorun.sh --report
+
+# Kill levels 1-2 locally regardless of manifest
+export BLUEPRINT_AUTORUN_DISABLE=1
+
+# Tune the SessionStart probe debounce (seconds, default 3600)
+export BLUEPRINT_AUTORUN_TTL=7200
+```
+
 ## Feature Tracking (Optional)
 
 Track implementation progress against requirements documents using hierarchical FR codes.

--- a/blueprint-plugin/docs/hook-plans/p1-feature-tracker-auto-sync.md
+++ b/blueprint-plugin/docs/hook-plans/p1-feature-tracker-auto-sync.md
@@ -2,7 +2,7 @@
 
 **Priority**: P1 (Important)
 **Type**: PostToolUse
-**Status**: Planned
+**Status**: Implemented — `hooks/sync-feature-tracker.sh` (gated on `automation.autonomy_level >= 1`, ADR-0020; freshness/statistics refresh only, per Open Question 1's decision)
 
 ## Overview
 

--- a/blueprint-plugin/hooks.json
+++ b/blueprint-plugin/hooks.json
@@ -10,6 +10,11 @@
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/blueprint-drift-probe.sh",
             "timeout": 3000
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/blueprint-autorun-probe.sh",
+            "timeout": 5000
           }
         ]
       }

--- a/blueprint-plugin/hooks.json
+++ b/blueprint-plugin/hooks.json
@@ -179,6 +179,26 @@
       ]
     },
     {
+      "matcher": "Write(docs/**)",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/sync-feature-tracker.sh",
+          "timeout": 5000
+        }
+      ]
+    },
+    {
+      "matcher": "Edit(docs/**)",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/sync-feature-tracker.sh",
+          "timeout": 5000
+        }
+      ]
+    },
+    {
       "matcher": "Write",
       "hooks": [
         {

--- a/blueprint-plugin/hooks/blueprint-autorun-probe.sh
+++ b/blueprint-plugin/hooks/blueprint-autorun-probe.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# blueprint-autorun-probe.sh — SessionStart probe implementing the level-1
+# rung of ADR-0020 (blueprint autonomy levels).
+#
+# When docs/blueprint/manifest.json is present and automation.autonomy_level
+# is >= 1, runs scripts/blueprint-autorun.sh (TTL-debounced per
+# .claude/rules/drift-detection-triggering.md):
+#   - deterministic due tasks are executed silently by the runner
+#   - due AGENT-JUDGMENT tasks become drift findings via drift-protocol.sh:
+#       level 1  -> one finding per due task, remediation /blueprint:<task>
+#       level 2+ -> one aggregated finding, remediation /blueprint:autopilot
+#
+# Level 0 / missing automation block is a complete no-op (empty signal file).
+# Opt out entirely with BLUEPRINT_AUTORUN_DISABLE=1; tune the debounce with
+# BLUEPRINT_AUTORUN_TTL (seconds, default 3600). Test seams:
+# BLUEPRINT_AUTORUN_BIN (runner path), CLAUDE_BLUEPRINT_AUTORUN_CACHE_DIR.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Resolve protocol library (ships from hooks-plugin; siblings under the
+# marketplace dir when installed).
+PROTO_LIB="${SCRIPT_DIR}/../../hooks-plugin/hooks/lib/drift-protocol.sh"
+if [ ! -f "$PROTO_LIB" ]; then
+    for candidate in \
+        "${CLAUDE_PLUGIN_ROOT:-}/../hooks-plugin/hooks/lib/drift-protocol.sh" \
+        "$HOME/.claude/plugins/hooks-plugin/hooks/lib/drift-protocol.sh"; do
+        if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+            PROTO_LIB="$candidate"
+            break
+        fi
+    done
+fi
+if [ ! -f "$PROTO_LIB" ]; then
+    exit 0
+fi
+# shellcheck source=../../hooks-plugin/hooks/lib/drift-protocol.sh
+# shellcheck disable=SC1091  # PROTO_LIB resolves at runtime via fallback chain
+. "$PROTO_LIB"
+
+drift_init "blueprint-autorun"
+drift_no_op_if_missing "docs/blueprint/manifest.json"
+drift_no_op_if_command_missing jq
+
+MANIFEST="${DRIFT_CWD}/docs/blueprint/manifest.json"
+
+if [ "${BLUEPRINT_AUTORUN_DISABLE:-0}" = "1" ]; then
+    drift_emit
+    exit 0
+fi
+
+autorun_level=$(jq -r '.automation.autonomy_level // 0' "$MANIFEST" 2>/dev/null || echo 0)
+case "$autorun_level" in
+    ''|*[!0-9]*) autorun_level=0 ;;
+esac
+if [ "$autorun_level" -lt 1 ]; then
+    drift_emit
+    exit 0
+fi
+
+AUTORUN_BIN="${BLUEPRINT_AUTORUN_BIN:-${SCRIPT_DIR}/../scripts/blueprint-autorun.sh}"
+if [ ! -f "$AUTORUN_BIN" ]; then
+    drift_emit
+    exit 0
+fi
+
+# TTL debounce: cache the runner's output per project so the run happens at
+# most once per interval. Claim the window (touch) BEFORE running so a killed
+# run degrades to "no change" instead of re-running every session.
+cache_base="${CLAUDE_BLUEPRINT_AUTORUN_CACHE_DIR:-${TMPDIR:-/tmp}/claude-blueprint-autorun}"
+project_key=$(printf '%s' "$DRIFT_CWD" | cksum | awk '{print $1}')
+cache_file="${cache_base}/${project_key}.out"
+autorun_ttl="${BLUEPRINT_AUTORUN_TTL:-3600}"
+
+mkdir -p "$cache_base" 2>/dev/null || { drift_emit; exit 0; }
+
+cache_fresh=0
+if [ -f "$cache_file" ]; then
+    # GNU form first: on GNU, `stat -f %m` succeeds but prints the MOUNT POINT
+    # (non-numeric), so it must not be the first candidate. BSD lacks -c and
+    # falls through to -f %m (mtime there). Guard non-numeric to 0 (= stale).
+    cache_mtime=$(stat -c %Y "$cache_file" 2>/dev/null || stat -f %m "$cache_file" 2>/dev/null || echo 0)
+    case "$cache_mtime" in
+        ''|*[!0-9]*) cache_mtime=0 ;;
+    esac
+    probe_now=$(date +%s)
+    if [ $((probe_now - cache_mtime)) -lt "$autorun_ttl" ]; then
+        cache_fresh=1
+    fi
+fi
+
+if [ "$cache_fresh" -eq 0 ]; then
+    touch "$cache_file" 2>/dev/null
+    bash "$AUTORUN_BIN" --project-dir "$DRIFT_CWD" > "${cache_file}.tmp" 2>/dev/null \
+        && mv -f "${cache_file}.tmp" "$cache_file" \
+        || rm -f "${cache_file}.tmp"
+fi
+
+if [ ! -s "$cache_file" ]; then
+    drift_emit
+    exit 0
+fi
+
+due_tasks=$(grep -m1 '^DUE_AGENT_TASKS=' "$cache_file" | cut -d= -f2 | tr -d '\r' || true)
+
+if [ -n "$due_tasks" ]; then
+    if [ "$autorun_level" -ge 2 ]; then
+        due_count=$(printf '%s' "$due_tasks" | awk -F',' '{print NF}')
+        drift_add_finding info \
+            autorun_tasks_due \
+            "${due_count} blueprint task(s) due (${due_tasks})" \
+            "/blueprint:autopilot"
+    else
+        finding_count=0
+        old_ifs="$IFS"
+        IFS=','
+        for due_task in $due_tasks; do
+            [ -n "$due_task" ] || continue
+            [ "$finding_count" -ge 3 ] && break
+            task_schedule=$(grep -m1 "^TASK=${due_task} KIND=agent" "$cache_file" \
+                | sed -n 's/.*SCHEDULE=\([^ ]*\).*/\1/p' || true)
+            drift_add_finding info \
+                task_due \
+                "blueprint task ${due_task} due (${task_schedule:-scheduled})" \
+                "/blueprint:${due_task}"
+            finding_count=$((finding_count + 1))
+        done
+        IFS="$old_ifs"
+    fi
+fi
+
+drift_emit
+exit 0

--- a/blueprint-plugin/hooks/blueprint-drift-probe.sh
+++ b/blueprint-plugin/hooks/blueprint-drift-probe.sh
@@ -2,7 +2,7 @@
 # blueprint-drift-probe.sh — SessionStart probe for blueprint-plugin drift.
 #
 # Checks (when docs/blueprint/manifest.json is present):
-#   1. manifest.format_version vs the plugin's current format version (3.3.0)
+#   1. manifest.format_version vs the plugin's current format version (3.4.0)
 #   2. generated.rules[].content_hash vs current hash of the file on disk
 #   3. docs/blueprint/feature_tracker.json `last_updated` vs TODO.md mtime
 #
@@ -38,7 +38,7 @@ fi
 drift_init "blueprint-plugin"
 drift_no_op_if_missing "docs/blueprint/manifest.json"
 
-CURRENT_FORMAT_VERSION="3.3.0"
+CURRENT_FORMAT_VERSION="3.4.0"
 MANIFEST="${DRIFT_CWD}/docs/blueprint/manifest.json"
 
 # ---- check 1: format_version drift ----
@@ -97,7 +97,12 @@ if [ -f "$TRACKER" ] && [ -f "$TODO" ]; then
         elif date -d "$tracker_iso" "+%s" >/dev/null 2>&1; then
             tracker_epoch=$(date -d "$tracker_iso" "+%s" 2>/dev/null)
         fi
-        todo_epoch=$(stat -f %m "$TODO" 2>/dev/null || stat -c %Y "$TODO" 2>/dev/null || echo "")
+        # GNU form first: on GNU, `stat -f %m` succeeds but prints the MOUNT
+        # POINT (non-numeric); BSD lacks -c and falls through to -f %m (mtime).
+        todo_epoch=$(stat -c %Y "$TODO" 2>/dev/null || stat -f %m "$TODO" 2>/dev/null || echo "")
+        case "$todo_epoch" in
+            *[!0-9]*) todo_epoch="" ;;
+        esac
         if [ -n "$tracker_epoch" ] && [ -n "$todo_epoch" ] && [ "$todo_epoch" -gt "$tracker_epoch" ]; then
             drift_add_finding warn \
                 feature_tracker_stale \

--- a/blueprint-plugin/hooks/sync-feature-tracker.sh
+++ b/blueprint-plugin/hooks/sync-feature-tracker.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# PostToolUse hook — feature-tracker freshness auto-sync on docs changes.
+#
+# Implements docs/hook-plans/p1-feature-tracker-auto-sync.md as the on-change
+# half of the ADR-0020 level-1 rung. Fires after Write/Edit under docs/**.
+#
+# Bounded auto-apply on an unambiguous fact only: when the changed document
+# references feature codes that ALREADY EXIST in the tracker, refresh the
+# tracker's last_updated date and recompute the statistics block (a pure
+# function of the tracker itself). It never creates feature codes and never
+# changes a feature's status — those need judgment and stay with
+# /blueprint:feature-tracker-sync (p1 plan, Open Question 1).
+#
+# Gates: BLUEPRINT_SKIP_HOOKS=1, missing tracker, autonomy_level < 1, or
+# task_registry["feature-tracker-sync"].enabled == false -> silent no-op.
+# Non-blocking: always exits 0.
+
+set -euo pipefail
+
+if [ "${BLUEPRINT_SKIP_HOOKS:-0}" = "1" ]; then
+    exit 0
+fi
+
+INPUT=$(cat)
+
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)
+if [ -z "$FILE_PATH" ]; then
+    exit 0
+fi
+
+# Only document changes under docs/ are signals; the tracker itself and the
+# manifest are outputs, not signals (self-trigger guard).
+case "$FILE_PATH" in
+    docs/blueprint/feature-tracker.json|docs/blueprint/manifest.json) exit 0 ;;
+    docs/*) ;;
+    *) exit 0 ;;
+esac
+
+TRACKER="docs/blueprint/feature-tracker.json"
+MANIFEST="docs/blueprint/manifest.json"
+
+[ -f "$TRACKER" ] || exit 0
+[ -f "$MANIFEST" ] || exit 0
+[ -f "$FILE_PATH" ] || exit 0
+
+# Malformed tracker: warn, never mutate.
+if ! jq -e . "$TRACKER" >/dev/null 2>&1; then
+    echo "WARNING: feature-tracker.json is not valid JSON; skipping auto-sync" >&2
+    exit 0
+fi
+
+autorun_level=$(jq -r '.automation.autonomy_level // 0' "$MANIFEST" 2>/dev/null || echo 0)
+case "$autorun_level" in
+    ''|*[!0-9]*) autorun_level=0 ;;
+esac
+[ "$autorun_level" -ge 1 ] || exit 0
+
+# Note: jq's // treats an explicit `false` as absent, so read the raw value
+# and treat only the literal "false" as disabled (null/missing => enabled).
+task_enabled=$(jq -r '.task_registry["feature-tracker-sync"].enabled' "$MANIFEST" 2>/dev/null || echo true)
+[ "$task_enabled" != "false" ] || exit 0
+
+# Extract feature codes from the changed file: frontmatter `feature-codes:`
+# array plus inline FRn(.m)* references.
+frontmatter_codes=$(head -50 "$FILE_PATH" | awk '
+    /^feature-codes:/ { in_codes = 1; next }
+    in_codes && /^[[:space:]]*-/ { gsub(/^[[:space:]]*-[[:space:]]*/, ""); print }
+    in_codes && /^[a-z]/ { exit }
+' | tr -d '\r' || true)
+inline_codes=$(grep -oE 'FR[0-9]+(\.[0-9]+)*' "$FILE_PATH" 2>/dev/null | sort -u || true)
+
+all_codes=$(printf '%s\n%s\n' "$frontmatter_codes" "$inline_codes" | grep -E '^FR[0-9]' | sort -u || true)
+[ -n "$all_codes" ] || exit 0
+
+# Count how many referenced codes exist in the tracker (top-level FRn
+# categories or nested FRn.m features at any depth).
+codes_json=$(printf '%s\n' "$all_codes" | jq -R -s 'split("\n") | map(select(length > 0))')
+matched=$(jq --argjson codes "$codes_json" '
+    [.. | objects | keys[]? | select(test("^FR[0-9]"))] as $tracked |
+    [$codes[] | select(. as $c | $tracked | index($c))] | length
+' "$TRACKER" 2>/dev/null || echo 0)
+
+if [ -z "$matched" ] || [ "$matched" = "0" ]; then
+    exit 0
+fi
+
+# Refresh last_updated and recompute statistics. Feature objects are the
+# nested objects carrying name+status+phase — the has("phase") filter keeps
+# phases[].status entries out of the counts.
+today=$(date -u +%Y-%m-%d)
+jq --arg today "$today" '
+    ([.. | objects | select(has("status") and has("phase") and has("name"))]) as $feats |
+    .last_updated = $today |
+    .statistics = {
+        total_features: ($feats | length),
+        complete: ([$feats[] | select(.status == "complete")] | length),
+        partial: ([$feats[] | select(.status == "partial")] | length),
+        in_progress: ([$feats[] | select(.status == "in_progress")] | length),
+        not_started: ([$feats[] | select(.status == "not_started")] | length),
+        blocked: ([$feats[] | select(.status == "blocked")] | length),
+        completion_percentage: (if ($feats | length) > 0
+            then (([$feats[] | select(.status == "complete")] | length) * 100 / ($feats | length) | floor)
+            else 0 end)
+    }
+' "$TRACKER" > "${TRACKER}.tmp" && mv "${TRACKER}.tmp" "$TRACKER"
+
+total=$(jq -r '.statistics.total_features' "$TRACKER" 2>/dev/null || echo "?")
+complete=$(jq -r '.statistics.complete' "$TRACKER" 2>/dev/null || echo "?")
+echo "INFO: Feature tracker refreshed: ${matched} tracked code(s) referenced by ${FILE_PATH}; completion ${complete}/${total}" >&2
+exit 0

--- a/blueprint-plugin/hooks/test-blueprint-autorun-probe.sh
+++ b/blueprint-plugin/hooks/test-blueprint-autorun-probe.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Regression tests for blueprint-autorun-probe.sh (ADR-0020 SessionStart rung).
+#
+# Pins the semantic contract:
+#   - level 0 / missing automation block emits an empty signal (runner never invoked)
+#   - BLUEPRINT_AUTORUN_DISABLE=1 emits an empty signal (runner never invoked)
+#   - level 1 emits one finding per due agent task, remediation /blueprint:<task>
+#   - level 2 emits one aggregated finding, remediation /blueprint:autopilot
+#   - TTL cache: a fresh cache re-emits findings WITHOUT re-invoking the runner
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROBE="${SCRIPT_DIR}/blueprint-autorun-probe.sh"
+
+pass=0
+fail=0
+ok() { pass=$((pass + 1)); printf 'ok   - %s\n' "$1"; }
+notok() { fail=$((fail + 1)); printf 'FAIL - %s\n' "$1"; }
+
+work=$(mktemp -d)
+if [ -z "$work" ] || [ ! -d "$work" ]; then
+    echo "FATAL: mktemp failed" >&2
+    exit 1
+fi
+trap 'rm -f "$work/stub-invocations"; rm -rf "$work"' EXIT
+
+# Stub runner: logs every invocation, prints canned autorun output.
+STUB="$work/stub-autorun.sh"
+cat > "$STUB" <<'EOF'
+#!/usr/bin/env bash
+echo "invoked $*" >> "$STUB_LOG"
+cat <<'OUT'
+=== BLUEPRINT AUTORUN ===
+MODE=apply
+MANIFEST=docs/blueprint/manifest.json
+AUTONOMY_LEVEL=1
+TASK=adr-validate KIND=agent SCHEDULE=weekly STATE=due REMEDIATION=/blueprint:adr-validate
+TASK=feature-tracker-sync KIND=agent SCHEDULE=daily STATE=due REMEDIATION=/blueprint:feature-tracker-sync
+DUE_AGENT_TASKS=adr-validate,feature-tracker-sync
+RAN_COUNT=0
+STATUS=OK
+ISSUE_COUNT=0
+=== END BLUEPRINT AUTORUN ===
+OUT
+EOF
+chmod +x "$STUB"
+
+make_project() {
+    # make_project <level>  (level "none" omits the automation block)
+    local proj lvl="$1"
+    proj=$(mktemp -d)
+    if [ -z "$proj" ] || [ ! -d "$proj" ]; then
+        echo "FATAL: mktemp failed" >&2
+        exit 1
+    fi
+    mkdir -p "$proj/docs/blueprint"
+    if [ "$lvl" = "none" ]; then
+        printf '{"format_version": "3.3.0", "task_registry": {}}\n' > "$proj/docs/blueprint/manifest.json"
+    else
+        printf '{"format_version": "3.4.0", "automation": {"autonomy_level": %s}, "task_registry": {}}\n' "$lvl" \
+            > "$proj/docs/blueprint/manifest.json"
+    fi
+    printf '%s' "$proj"
+}
+
+run_probe() {
+    # run_probe <project_dir> <session_id> [env pairs...]
+    local proj="$1" sid="$2"
+    shift 2
+    printf '{"session_id": "%s", "cwd": "%s"}' "$sid" "$proj" \
+        | env STUB_LOG="$work/stub-invocations" \
+              CLAUDE_DRIFT_SIGNALS_DIR="$work/signals" \
+              CLAUDE_BLUEPRINT_AUTORUN_CACHE_DIR="$work/cache-$sid" \
+              BLUEPRINT_AUTORUN_BIN="$STUB" \
+              "$@" bash "$PROBE"
+}
+
+signal_file() { printf '%s/signals/%s/blueprint-autorun.json' "$work" "$1"; }
+stub_count() { wc -l < "$work/stub-invocations" 2>/dev/null | tr -d ' ' || echo 0; }
+
+: > "$work/stub-invocations"
+
+# ---- Test A: level 0 -> empty signal, runner not invoked ----
+proj=$(make_project 0)
+run_probe "$proj" sidA
+sig=$(signal_file sidA)
+if [ -f "$sig" ] && [ "$(jq '.findings | length' "$sig")" = "0" ]; then
+    ok "A: level 0 emits empty signal"
+else
+    notok "A: level 0 signal wrong ($(cat "$sig" 2>/dev/null))"
+fi
+[ "$(stub_count)" = "0" ] && ok "A: runner not invoked at level 0" || notok "A: runner invoked at level 0"
+rm -rf "$proj"
+
+# ---- Test B: missing automation block behaves as level 0 ----
+proj=$(make_project none)
+run_probe "$proj" sidB
+sig=$(signal_file sidB)
+[ "$(jq '.findings | length' "$sig")" = "0" ] && ok "B: 3.3.0 manifest is a no-op" || notok "B: 3.3.0 manifest produced findings"
+[ "$(stub_count)" = "0" ] && ok "B: runner not invoked without automation block" || notok "B: runner invoked without automation block"
+rm -rf "$proj"
+
+# ---- Test C: opt-out env -> empty signal, runner not invoked ----
+proj=$(make_project 1)
+run_probe "$proj" sidC BLUEPRINT_AUTORUN_DISABLE=1
+sig=$(signal_file sidC)
+[ "$(jq '.findings | length' "$sig")" = "0" ] && ok "C: opt-out emits empty signal" || notok "C: opt-out produced findings"
+[ "$(stub_count)" = "0" ] && ok "C: runner not invoked when opted out" || notok "C: runner invoked when opted out"
+rm -rf "$proj"
+
+# ---- Test D: level 1 -> per-task findings with /blueprint:<task> remediation ----
+proj=$(make_project 1)
+run_probe "$proj" sidD
+sig=$(signal_file sidD)
+n_findings=$(jq '.findings | length' "$sig")
+[ "$n_findings" = "2" ] && ok "D: two findings at level 1" || notok "D: findings=$n_findings"
+rem1=$(jq -r '.findings[0].remediation_skill' "$sig")
+[ "$rem1" = "/blueprint:adr-validate" ] && ok "D: per-task remediation skill" || notok "D: remediation=$rem1"
+kind1=$(jq -r '.findings[0].kind' "$sig")
+[ "$kind1" = "task_due" ] && ok "D: task_due kind" || notok "D: kind=$kind1"
+[ "$(stub_count)" = "1" ] && ok "D: runner invoked once" || notok "D: runner invocations=$(stub_count)"
+
+# ---- Test E: fresh TTL cache -> findings re-emitted, runner NOT re-invoked ----
+rm -rf "$work/signals"
+run_probe "$proj" sidD
+sig=$(signal_file sidD)
+[ "$(jq '.findings | length' "$sig")" = "2" ] && ok "E: cached findings re-emitted" || notok "E: cache did not re-emit"
+[ "$(stub_count)" = "1" ] && ok "E: runner not re-invoked on fresh cache" || notok "E: runner re-invoked ($(stub_count))"
+
+# ---- Test F: stale cache -> runner re-invoked ----
+touch -t 202001010000 "$work/cache-sidD/"*.out
+run_probe "$proj" sidD
+[ "$(stub_count)" = "2" ] && ok "F: stale cache re-runs runner" || notok "F: invocations=$(stub_count)"
+rm -rf "$proj"
+
+# ---- Test G: level 2 -> one aggregated finding -> /blueprint:autopilot ----
+proj=$(make_project 2)
+run_probe "$proj" sidG
+sig=$(signal_file sidG)
+[ "$(jq '.findings | length' "$sig")" = "1" ] && ok "G: single aggregated finding at level 2" || notok "G: findings=$(jq '.findings | length' "$sig")"
+remg=$(jq -r '.findings[0].remediation_skill' "$sig")
+[ "$remg" = "/blueprint:autopilot" ] && ok "G: autopilot remediation at level 2" || notok "G: remediation=$remg"
+rm -rf "$proj"
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ] || exit 1
+exit 0

--- a/blueprint-plugin/hooks/test-sync-feature-tracker.sh
+++ b/blueprint-plugin/hooks/test-sync-feature-tracker.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Regression tests for sync-feature-tracker.sh (ADR-0020 on-change rung;
+# implements docs/hook-plans/p1-feature-tracker-auto-sync.md).
+#
+# Pins the semantic contract:
+#   - level 0 / missing tracker / disabled task / BLUEPRINT_SKIP_HOOKS are no-ops
+#   - referencing an EXISTING tracked code refreshes last_updated + statistics
+#   - unknown codes never create tracker entries (p1 Open Question 1)
+#   - per-feature status is never changed; phases[].status never counts as a feature
+#   - writes to the tracker/manifest themselves are self-trigger-guarded
+#   - malformed tracker JSON is left untouched (exit 0)
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="${SCRIPT_DIR}/sync-feature-tracker.sh"
+
+pass=0
+fail=0
+ok() { pass=$((pass + 1)); printf 'ok   - %s\n' "$1"; }
+notok() { fail=$((fail + 1)); printf 'FAIL - %s\n' "$1"; }
+
+make_project() {
+    # make_project <level>
+    local proj
+    proj=$(mktemp -d)
+    if [ -z "$proj" ] || [ ! -d "$proj" ]; then
+        echo "FATAL: mktemp failed" >&2
+        exit 1
+    fi
+    mkdir -p "$proj/docs/blueprint" "$proj/docs/prps"
+    cat > "$proj/docs/blueprint/manifest.json" <<EOF
+{
+  "format_version": "3.4.0",
+  "automation": { "autonomy_level": $1 },
+  "task_registry": {
+    "feature-tracker-sync": { "enabled": true, "auto_run": true, "schedule": "daily" }
+  }
+}
+EOF
+    cat > "$proj/docs/blueprint/feature-tracker.json" <<'EOF'
+{
+  "version": "1.0.0",
+  "last_updated": "2026-01-01",
+  "project": "fixture",
+  "source_document": "REQUIREMENTS.md",
+  "phases": [
+    { "id": "phase-1", "name": "Phase one", "status": "in_progress" }
+  ],
+  "features": {
+    "FR1": {
+      "name": "Category one",
+      "features": {
+        "FR1.1": { "name": "Feature A", "status": "complete", "phase": "phase-1" },
+        "FR1.2": { "name": "Feature B", "status": "not_started", "phase": "phase-1" }
+      }
+    }
+  }
+}
+EOF
+    printf '%s' "$proj"
+}
+
+run_hook() {
+    # run_hook <project_dir> <file_path> [env pairs...]
+    local proj="$1" fp="$2"
+    shift 2
+    (cd "$proj" && printf '{"tool_input": {"file_path": "%s"}}' "$fp" | env "$@" bash "$HOOK" 2>/dev/null)
+}
+
+write_prp() {
+    # write_prp <project_dir> <codes...>
+    local proj="$1"
+    shift
+    {
+        printf -- '---\nfeature-codes:\n'
+        for c in "$@"; do printf '  - %s\n' "$c"; done
+        printf -- '---\n\n# Fixture PRP\n'
+    } > "$proj/docs/prps/fixture.md"
+}
+
+tracker_last() { jq -r '.last_updated' "$1/docs/blueprint/feature-tracker.json"; }
+
+# ---- Test A: level 1 + existing code -> last_updated refreshed + stats recomputed ----
+proj=$(make_project 1)
+write_prp "$proj" FR1.1
+run_hook "$proj" "docs/prps/fixture.md" X=1
+rc=$?
+[ "$rc" -eq 0 ] && ok "A: exit 0" || notok "A: exit $rc"
+[ "$(tracker_last "$proj")" != "2026-01-01" ] && ok "A: last_updated refreshed" || notok "A: last_updated stale"
+stats_total=$(jq -r '.statistics.total_features' "$proj/docs/blueprint/feature-tracker.json")
+[ "$stats_total" = "2" ] && ok "A: phases excluded from feature count" || notok "A: total_features=$stats_total (phase leaked in?)"
+stats_pct=$(jq -r '.statistics.completion_percentage' "$proj/docs/blueprint/feature-tracker.json")
+[ "$stats_pct" = "50" ] && ok "A: completion percentage" || notok "A: completion=$stats_pct"
+fr_status=$(jq -r '.features.FR1.features["FR1.1"].status' "$proj/docs/blueprint/feature-tracker.json")
+[ "$fr_status" = "complete" ] && ok "A: per-feature status untouched" || notok "A: status mutated ($fr_status)"
+rm -rf "$proj"
+
+# ---- Test B: unknown codes -> tracker untouched, no new entries ----
+proj=$(make_project 1)
+write_prp "$proj" FR9.9
+run_hook "$proj" "docs/prps/fixture.md" X=1
+[ "$(tracker_last "$proj")" = "2026-01-01" ] && ok "B: unknown code leaves tracker untouched" || notok "B: tracker mutated for unknown code"
+if jq -e '.. | objects | select(has("FR9.9"))' "$proj/docs/blueprint/feature-tracker.json" >/dev/null 2>&1; then
+    notok "B: unknown code was created"
+else
+    ok "B: unknown code not created"
+fi
+rm -rf "$proj"
+
+# ---- Test C: level 0 -> no-op ----
+proj=$(make_project 0)
+write_prp "$proj" FR1.1
+run_hook "$proj" "docs/prps/fixture.md" X=1
+[ "$(tracker_last "$proj")" = "2026-01-01" ] && ok "C: level 0 is a no-op" || notok "C: level 0 mutated tracker"
+rm -rf "$proj"
+
+# ---- Test D: disabled task -> no-op ----
+proj=$(make_project 1)
+jq '.task_registry["feature-tracker-sync"].enabled = false' "$proj/docs/blueprint/manifest.json" \
+    > "$proj/docs/blueprint/manifest.json.tmp" && mv "$proj/docs/blueprint/manifest.json.tmp" "$proj/docs/blueprint/manifest.json"
+write_prp "$proj" FR1.1
+run_hook "$proj" "docs/prps/fixture.md" X=1
+[ "$(tracker_last "$proj")" = "2026-01-01" ] && ok "D: enabled:false wins" || notok "D: disabled task ran"
+rm -rf "$proj"
+
+# ---- Test E: BLUEPRINT_SKIP_HOOKS + non-docs path + self-trigger guard ----
+proj=$(make_project 1)
+write_prp "$proj" FR1.1
+run_hook "$proj" "docs/prps/fixture.md" BLUEPRINT_SKIP_HOOKS=1
+[ "$(tracker_last "$proj")" = "2026-01-01" ] && ok "E: BLUEPRINT_SKIP_HOOKS honored" || notok "E: skip-hooks ignored"
+run_hook "$proj" "src/main.py" X=1
+[ "$(tracker_last "$proj")" = "2026-01-01" ] && ok "E: non-docs path ignored" || notok "E: non-docs path mutated tracker"
+run_hook "$proj" "docs/blueprint/feature-tracker.json" X=1
+[ "$(tracker_last "$proj")" = "2026-01-01" ] && ok "E: tracker write self-guarded" || notok "E: self-trigger loop"
+rm -rf "$proj"
+
+# ---- Test F: inline FR references (no frontmatter) also count ----
+proj=$(make_project 1)
+printf '# Notes\n\nThis touches FR1.2 directly.\n' > "$proj/docs/prps/fixture.md"
+run_hook "$proj" "docs/prps/fixture.md" X=1
+[ "$(tracker_last "$proj")" != "2026-01-01" ] && ok "F: inline code reference detected" || notok "F: inline reference missed"
+rm -rf "$proj"
+
+# ---- Test G: malformed tracker -> untouched, exit 0 ----
+proj=$(make_project 1)
+printf '{ not json' > "$proj/docs/blueprint/feature-tracker.json"
+write_prp "$proj" FR1.1
+run_hook "$proj" "docs/prps/fixture.md" X=1
+rc=$?
+[ "$rc" -eq 0 ] && ok "G: malformed tracker exits 0" || notok "G: exit $rc"
+[ "$(cat "$proj/docs/blueprint/feature-tracker.json")" = "{ not json" ] && ok "G: malformed tracker untouched" || notok "G: malformed tracker rewritten"
+rm -rf "$proj"
+
+# ---- Test H: missing tracker -> silent no-op ----
+proj=$(make_project 1)
+rm "$proj/docs/blueprint/feature-tracker.json"
+write_prp "$proj" FR1.1
+run_hook "$proj" "docs/prps/fixture.md" X=1
+[ $? -eq 0 ] && ok "H: missing tracker no-op" || notok "H: missing tracker errored"
+rm -rf "$proj"
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ] || exit 1
+exit 0

--- a/blueprint-plugin/scripts/blueprint-autorun.sh
+++ b/blueprint-plugin/scripts/blueprint-autorun.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# blueprint-autorun.sh — implement the manifest task_registry auto-run contract.
+#
+# Reads docs/blueprint/manifest.json, computes due-ness for every task with
+# enabled:true + auto_run:true (schedule vs last_completed_at), executes the
+# DETERMINISTIC due tasks directly (no model in the loop), and reports due
+# AGENT-JUDGMENT tasks without executing them (the SessionStart probe turns
+# those into drift findings; the level-2 autopilot skill executes them).
+#
+# Task-kind split (see ADR-0020 and
+# .claude/rules/offload-to-deterministic-substrate.md):
+#   deterministic : sync-ids (id-registry sweep — replays the
+#                   auto-sync-id-registry.sh registration over all documents)
+#   agent-judgment: everything else (adr-validate, feature-tracker-sync,
+#                   story-audit, ...) — surfaced as due, never executed here.
+#
+# Schedule semantics:
+#   daily/weekly : due when last_completed_at is null/unparseable or older
+#                  than the interval
+#   on-change    : event-driven (PostToolUse hooks) — never runner-due
+#   on-demand    : never due
+#
+# Execution is gated on automation.autonomy_level >= 1 (missing block = 0).
+# --report computes due-ness only: no execution, no writeback.
+# BLUEPRINT_AUTORUN_DISABLE=1 makes the whole script a no-op.
+#
+# Output follows .claude/rules/structured-script-output.md.
+# Exit 0 on OK/WARN, 1 on ERROR (parallel-safe).
+#
+# Usage: blueprint-autorun.sh [--project-dir DIR] [--report]
+
+# set -u only (no -e/pipefail): this is a run-every-section collector — a
+# single failing task must not abort the remaining tasks (see
+# .claude/rules/shell-scripting.md "Error Handling Flags").
+set -u
+
+project_dir="."
+run_mode="apply"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --project-dir)
+            project_dir="${2:-.}"
+            shift 2
+            ;;
+        --report)
+            run_mode="report"
+            shift
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+section_open() { printf '=== BLUEPRINT AUTORUN ===\n'; }
+section_close() { printf '=== END BLUEPRINT AUTORUN ===\n'; }
+
+finish() {
+    # finish <status> <issue_count> [extra KEY=VALUE lines already printed]
+    printf 'STATUS=%s\n' "$1"
+    printf 'ISSUE_COUNT=%s\n' "$2"
+    section_close
+    if [ "$1" = "ERROR" ]; then
+        exit 1
+    fi
+    exit 0
+}
+
+section_open
+printf 'MODE=%s\n' "$run_mode"
+
+if [ "${BLUEPRINT_AUTORUN_DISABLE:-0}" = "1" ]; then
+    printf 'AUTORUN=disabled_by_env\n'
+    printf 'DUE_AGENT_TASKS=\n'
+    printf 'RAN_COUNT=0\n'
+    finish OK 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    printf 'AUTORUN=jq_unavailable\n'
+    printf 'DUE_AGENT_TASKS=\n'
+    printf 'RAN_COUNT=0\n'
+    finish OK 0
+fi
+
+manifest=""
+if [ -f "${project_dir}/docs/blueprint/manifest.json" ]; then
+    manifest="${project_dir}/docs/blueprint/manifest.json"
+elif [ -f "${project_dir}/docs/blueprint/.manifest.json" ]; then
+    manifest="${project_dir}/docs/blueprint/.manifest.json"
+fi
+
+if [ -z "$manifest" ]; then
+    printf 'AUTORUN=no_manifest\n'
+    printf 'DUE_AGENT_TASKS=\n'
+    printf 'RAN_COUNT=0\n'
+    finish OK 0
+fi
+printf 'MANIFEST=%s\n' "$manifest"
+
+autonomy_level=$(jq -r '.automation.autonomy_level // 0' "$manifest" 2>/dev/null || echo 0)
+case "$autonomy_level" in
+    ''|*[!0-9]*) autonomy_level=0 ;;
+esac
+printf 'AUTONOMY_LEVEL=%s\n' "$autonomy_level"
+
+# Deterministic ISO-8601 UTC -> epoch (BSD fills unspecified fields with the
+# current wall clock, so the format string pins every field; see
+# .claude/rules/shell-scripting.md "GNU vs BSD Tool Differences").
+iso_to_epoch() {
+    local iso_ts="$1"
+    if date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$iso_ts" "+%s" >/dev/null 2>&1; then
+        date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$iso_ts" "+%s" 2>/dev/null
+    elif date -u -d "$iso_ts" "+%s" >/dev/null 2>&1; then
+        date -u -d "$iso_ts" "+%s" 2>/dev/null
+    else
+        echo ""
+    fi
+}
+
+now_epoch=$(date -u +%s)
+now_iso=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+is_deterministic() {
+    case "$1" in
+        sync-ids) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Replay the auto-sync-id-registry.sh registration over every blueprint
+# document. Registry completeness only (path/status/title/counters) — the
+# relates_to/github_issues cross-refs are the write-time PostToolUse hook's
+# job and existing values are preserved by the merge.
+run_sync_ids() {
+    local docs_seen=0
+    local doc_file frontmatter doc_id doc_status doc_title doc_created
+
+    if ! jq -e '.id_registry' "$manifest" >/dev/null 2>&1; then
+        jq '. + {"id_registry": {"last_prd": 0, "last_prp": 0, "documents": {}, "github_issues": {}}}' \
+            "$manifest" > "${manifest}.tmp" && mv "${manifest}.tmp" "$manifest" || return 1
+    fi
+
+    while IFS= read -r doc_file; do
+        [ -f "$doc_file" ] || continue
+        frontmatter=$(awk '/^---$/{if(++n==2)exit}n' "$doc_file" | tail -n +2)
+        [ -n "$frontmatter" ] || continue
+        doc_id=$(printf '%s\n' "$frontmatter" | grep -m1 "^id:" | sed 's/^id:[[:space:]]*//' | tr -d '\r' || true)
+        [ -n "$doc_id" ] || continue
+
+        doc_status=$(printf '%s\n' "$frontmatter" | grep -m1 "^status:" | sed 's/^status:[[:space:]]*//' | tr -d '\r' || true)
+        doc_title=$(printf '%s\n' "$frontmatter" | grep -m1 "^title:" | sed 's/^title:[[:space:]]*//' | tr -d '\r' || true)
+        if [ -z "$doc_title" ]; then
+            doc_title=$(grep -m1 "^# " "$doc_file" | sed 's/^# //' | tr -d '\r' || true)
+        fi
+        doc_created=$(printf '%s\n' "$frontmatter" | grep -m1 "^created:" | sed 's/^created:[[:space:]]*//' | tr -d '\r' || true)
+
+        local rel_path="${doc_file#"${project_dir}"/}"
+        jq --arg id "$doc_id" \
+           --arg doc_path "$rel_path" \
+           --arg doc_status "${doc_status:-unknown}" \
+           --arg title "${doc_title:-untitled}" \
+           --arg created "${doc_created:-$now_iso}" \
+           '.id_registry.documents[$id] =
+              ((.id_registry.documents[$id] // {"created": $created, "relates_to": [], "github_issues": []})
+               + {path: $doc_path, status: $doc_status, title: $title}) |
+            (if ($id | startswith("PRD-")) then
+               .id_registry.last_prd = ([.id_registry.last_prd // 0, (($id | ltrimstr("PRD-")) | tonumber? // 0)] | max)
+             elif ($id | startswith("PRP-")) then
+               .id_registry.last_prp = ([.id_registry.last_prp // 0, (($id | ltrimstr("PRP-")) | tonumber? // 0)] | max)
+             else . end)' \
+           "$manifest" > "${manifest}.tmp" && mv "${manifest}.tmp" "$manifest" || return 1
+        docs_seen=$((docs_seen + 1))
+    done < <(find "${project_dir}/docs/prds" "${project_dir}/docs/adrs" "${project_dir}/docs/prps" \
+                  "${project_dir}/docs/blueprint/work-orders" \
+                  -maxdepth 1 -type f -name '*.md' 2>/dev/null)
+
+    printf '%s' "$docs_seen"
+    return 0
+}
+
+record_task_result() {
+    # record_task_result <task> <result>
+    jq --arg task "$1" --arg result "$2" --arg ts "$now_iso" \
+       '.task_registry[$task].last_completed_at = $ts |
+        .task_registry[$task].last_result = $result |
+        .task_registry[$task].stats.runs = ((.task_registry[$task].stats.runs // 0) + 1)' \
+       "$manifest" > "${manifest}.tmp" && mv "${manifest}.tmp" "$manifest"
+}
+
+due_agent_tasks=""
+ran_count=0
+issue_count=0
+overall_status="OK"
+
+while IFS=$'\t' read -r task_name task_enabled task_auto task_schedule task_last; do
+    [ -n "$task_name" ] || continue
+
+    if [ "$task_enabled" != "true" ] || [ "$task_auto" != "true" ]; then
+        printf 'TASK=%s STATE=skipped REASON=%s\n' "$task_name" \
+            "$([ "$task_enabled" != "true" ] && echo disabled || echo manual)"
+        continue
+    fi
+
+    task_state="not_due"
+    case "$task_schedule" in
+        on-demand)
+            task_state="on_demand"
+            ;;
+        on-change)
+            task_state="event_driven"
+            ;;
+        daily|weekly)
+            interval=86400
+            [ "$task_schedule" = "weekly" ] && interval=604800
+            if [ -z "$task_last" ] || [ "$task_last" = "null" ]; then
+                task_state="due"
+            else
+                last_epoch=$(iso_to_epoch "$task_last")
+                if [ -z "$last_epoch" ] || [ $((now_epoch - last_epoch)) -ge "$interval" ]; then
+                    task_state="due"
+                fi
+            fi
+            ;;
+        *)
+            task_state="unknown_schedule"
+            ;;
+    esac
+
+    if [ "$task_state" != "due" ]; then
+        printf 'TASK=%s SCHEDULE=%s STATE=%s\n' "$task_name" "$task_schedule" "$task_state"
+        continue
+    fi
+
+    if is_deterministic "$task_name"; then
+        if [ "$run_mode" = "report" ] || [ "$autonomy_level" -lt 1 ]; then
+            printf 'TASK=%s KIND=deterministic SCHEDULE=%s STATE=due\n' "$task_name" "$task_schedule"
+            continue
+        fi
+        case "$task_name" in
+            sync-ids)
+                docs_count=$(run_sync_ids)
+                sync_rc=$?
+                if [ "$sync_rc" -eq 0 ]; then
+                    record_task_result "$task_name" "ok"
+                    printf 'TASK=%s KIND=deterministic SCHEDULE=%s STATE=ran DOCS=%s\n' \
+                        "$task_name" "$task_schedule" "$docs_count"
+                    ran_count=$((ran_count + 1))
+                else
+                    record_task_result "$task_name" "error: sync-ids sweep failed"
+                    printf 'TASK=%s KIND=deterministic SCHEDULE=%s STATE=error\n' \
+                        "$task_name" "$task_schedule"
+                    issue_count=$((issue_count + 1))
+                    overall_status="WARN"
+                fi
+                ;;
+        esac
+    else
+        printf 'TASK=%s KIND=agent SCHEDULE=%s STATE=due REMEDIATION=/blueprint:%s\n' \
+            "$task_name" "$task_schedule" "$task_name"
+        if [ -z "$due_agent_tasks" ]; then
+            due_agent_tasks="$task_name"
+        else
+            due_agent_tasks="${due_agent_tasks},${task_name}"
+        fi
+    fi
+done < <(
+    jq -r '(.task_registry // {}) | to_entries[] |
+           [.key,
+            (.value.enabled // false | tostring),
+            (.value.auto_run // false | tostring),
+            (.value.schedule // "on-demand"),
+            (.value.last_completed_at // "null")] | @tsv' \
+       "$manifest" 2>/dev/null
+)
+
+printf 'DUE_AGENT_TASKS=%s\n' "$due_agent_tasks"
+printf 'RAN_COUNT=%s\n' "$ran_count"
+finish "$overall_status" "$issue_count"

--- a/blueprint-plugin/scripts/get-automation-config.sh
+++ b/blueprint-plugin/scripts/get-automation-config.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# get-automation-config.sh — read the manifest automation block (ADR-0020).
+#
+# Shared helper for blueprint skills that honor interaction_mode / autonomy
+# levels. Exit-0-safe in every degraded case (no manifest, no jq, no
+# automation block) — those all report level 0 / normal, i.e. today's fully
+# interactive behavior.
+#
+# EFFECTIVE_INTERACTION_MODE resolution: an explicit interaction_mode in the
+# manifest wins; when the key is ABSENT, level >= 2 defaults to quiet and
+# levels 0-1 default to normal.
+#
+# Output follows .claude/rules/structured-script-output.md.
+#
+# Usage: get-automation-config.sh [--project-dir DIR]
+
+set -u
+
+project_dir="."
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --project-dir)
+            project_dir="${2:-.}"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+emit() {
+    # emit <level> <mode> <effective> <auto_draft> <auto_execute> <source>
+    printf '=== BLUEPRINT AUTOMATION ===\n'
+    printf 'AUTONOMY_LEVEL=%s\n' "$1"
+    printf 'INTERACTION_MODE=%s\n' "$2"
+    printf 'EFFECTIVE_INTERACTION_MODE=%s\n' "$3"
+    printf 'WO_AUTO_DRAFT=%s\n' "$4"
+    printf 'WO_AUTO_EXECUTE=%s\n' "$5"
+    printf 'SOURCE=%s\n' "$6"
+    printf 'STATUS=OK\n'
+    printf 'ISSUE_COUNT=0\n'
+    printf '=== END BLUEPRINT AUTOMATION ===\n'
+    exit 0
+}
+
+manifest=""
+if [ -f "${project_dir}/docs/blueprint/manifest.json" ]; then
+    manifest="${project_dir}/docs/blueprint/manifest.json"
+elif [ -f "${project_dir}/docs/blueprint/.manifest.json" ]; then
+    manifest="${project_dir}/docs/blueprint/.manifest.json"
+fi
+
+if [ -z "$manifest" ] || ! command -v jq >/dev/null 2>&1; then
+    emit 0 unset normal false false none
+fi
+
+if ! jq -e '.automation' "$manifest" >/dev/null 2>&1; then
+    emit 0 unset normal false false "${manifest}:no_automation_block"
+fi
+
+auto_level=$(jq -r '.automation.autonomy_level // 0' "$manifest" 2>/dev/null || echo 0)
+case "$auto_level" in
+    ''|*[!0-9]*) auto_level=0 ;;
+esac
+
+if jq -e '.automation | has("interaction_mode")' "$manifest" >/dev/null 2>&1; then
+    declared_mode=$(jq -r '.automation.interaction_mode' "$manifest" 2>/dev/null || echo normal)
+    case "$declared_mode" in
+        quiet|normal|interactive) effective_mode="$declared_mode" ;;
+        *) declared_mode="normal"; effective_mode="normal" ;;
+    esac
+else
+    declared_mode="unset"
+    if [ "$auto_level" -ge 2 ]; then
+        effective_mode="quiet"
+    else
+        effective_mode="normal"
+    fi
+fi
+
+# jq's // treats explicit false as absent — read raw and compare literally.
+wo_draft=$(jq -r '.automation.work_orders.auto_draft' "$manifest" 2>/dev/null || echo false)
+[ "$wo_draft" = "true" ] || wo_draft=false
+wo_execute=$(jq -r '.automation.work_orders.auto_execute' "$manifest" 2>/dev/null || echo false)
+[ "$wo_execute" = "true" ] || wo_execute=false
+
+emit "$auto_level" "$declared_mode" "$effective_mode" "$wo_draft" "$wo_execute" "$manifest"

--- a/blueprint-plugin/scripts/tests/test-blueprint-autorun.sh
+++ b/blueprint-plugin/scripts/tests/test-blueprint-autorun.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Regression tests for blueprint-autorun.sh (ADR-0020 level-1 runner).
+#
+# Pins the semantic contract:
+#   - no manifest / disabled env / jq path are silent no-ops (exit 0)
+#   - level 0 never executes (due deterministic tasks report STATE=due)
+#   - level 1 executes a due deterministic task (sync-ids sweep), registers
+#     documents in id_registry, and writes back last_completed_at/stats
+#   - --report never writes back
+#   - agent-judgment due tasks are surfaced in DUE_AGENT_TASKS, never executed
+#   - enabled:false always wins over auto_run:true
+#   - on-change/on-demand schedules are never runner-due
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUTORUN="${SCRIPT_DIR}/../blueprint-autorun.sh"
+
+pass=0
+fail=0
+
+ok() { pass=$((pass + 1)); printf 'ok   - %s\n' "$1"; }
+notok() { fail=$((fail + 1)); printf 'FAIL - %s\n' "$1"; }
+
+assert_contains() {
+    # assert_contains <label> <needle> <haystack>
+    if printf '%s' "$3" | grep -qF -- "$2"; then
+        ok "$1"
+    else
+        notok "$1 (missing: $2)"
+    fi
+}
+
+assert_not_contains() {
+    if printf '%s' "$3" | grep -qF -- "$2"; then
+        notok "$1 (unexpected: $2)"
+    else
+        ok "$1"
+    fi
+}
+
+make_sandbox() {
+    local sb
+    sb=$(mktemp -d)
+    if [ -z "$sb" ] || [ ! -d "$sb" ]; then
+        echo "FATAL: mktemp failed" >&2
+        exit 1
+    fi
+    printf '%s' "$sb"
+}
+
+write_manifest() {
+    # write_manifest <dir> <autonomy_level> <sync_auto> <sync_schedule> <sync_last> <sync_enabled>
+    local dir="$1" lvl="$2" sync_auto="$3" sync_sched="$4" sync_last="$5" sync_enabled="${6:-true}"
+    mkdir -p "$dir/docs/blueprint"
+    local last_json="null"
+    [ "$sync_last" != "null" ] && last_json="\"$sync_last\""
+    cat > "$dir/docs/blueprint/manifest.json" <<EOF
+{
+  "format_version": "3.4.0",
+  "automation": {
+    "autonomy_level": $lvl,
+    "interaction_mode": "normal",
+    "work_orders": { "auto_draft": false, "auto_execute": false }
+  },
+  "task_registry": {
+    "sync-ids": {
+      "enabled": $sync_enabled,
+      "auto_run": $sync_auto,
+      "last_completed_at": $last_json,
+      "last_result": null,
+      "schedule": "$sync_sched",
+      "stats": {}
+    },
+    "adr-validate": {
+      "enabled": true,
+      "auto_run": true,
+      "last_completed_at": null,
+      "last_result": null,
+      "schedule": "weekly",
+      "stats": {}
+    },
+    "curate-docs": {
+      "enabled": true,
+      "auto_run": true,
+      "last_completed_at": null,
+      "last_result": null,
+      "schedule": "on-demand",
+      "stats": {}
+    },
+    "claude-md": {
+      "enabled": true,
+      "auto_run": true,
+      "last_completed_at": null,
+      "last_result": null,
+      "schedule": "on-change",
+      "stats": {}
+    }
+  }
+}
+EOF
+}
+
+write_doc() {
+    # write_doc <dir> <relpath> <id>
+    local dir="$1" rel="$2" doc_id="$3"
+    mkdir -p "$dir/$(dirname "$rel")"
+    cat > "$dir/$rel" <<EOF
+---
+id: $doc_id
+status: Accepted
+created: 2026-07-01
+---
+
+# Fixture doc $doc_id
+EOF
+}
+
+# ---- Test A: no manifest -> silent no-op ----
+sb=$(make_sandbox)
+out=$(bash "$AUTORUN" --project-dir "$sb")
+rc=$?
+[ "$rc" -eq 0 ] && ok "A: exit 0 without manifest" || notok "A: exit $rc without manifest"
+assert_contains "A: reports no_manifest" "AUTORUN=no_manifest" "$out"
+rm -rf "$sb"
+
+# ---- Test B: level 0 never executes ----
+sb=$(make_sandbox)
+write_manifest "$sb" 0 true daily null
+write_doc "$sb" "docs/adrs/0001-test.md" "ADR-0001"
+out=$(bash "$AUTORUN" --project-dir "$sb")
+assert_contains "B: level 0 reports due, does not run" "TASK=sync-ids KIND=deterministic SCHEDULE=daily STATE=due" "$out"
+last=$(jq -r '.task_registry["sync-ids"].last_completed_at' "$sb/docs/blueprint/manifest.json")
+[ "$last" = "null" ] && ok "B: no writeback at level 0" || notok "B: writeback happened at level 0 ($last)"
+rm -rf "$sb"
+
+# ---- Test C: level 1 executes due sync-ids sweep + writeback ----
+sb=$(make_sandbox)
+write_manifest "$sb" 1 true daily null
+write_doc "$sb" "docs/adrs/0001-test.md" "ADR-0001"
+write_doc "$sb" "docs/prds/0002-feature.md" "PRD-0002"
+out=$(bash "$AUTORUN" --project-dir "$sb")
+assert_contains "C: sync-ids ran" "TASK=sync-ids KIND=deterministic SCHEDULE=daily STATE=ran DOCS=2" "$out"
+assert_contains "C: ran count" "RAN_COUNT=1" "$out"
+reg_path=$(jq -r '.id_registry.documents["ADR-0001"].path' "$sb/docs/blueprint/manifest.json")
+[ "$reg_path" = "docs/adrs/0001-test.md" ] && ok "C: ADR registered with relative path" || notok "C: ADR registration ($reg_path)"
+last_prd=$(jq -r '.id_registry.last_prd' "$sb/docs/blueprint/manifest.json")
+[ "$last_prd" = "2" ] && ok "C: last_prd counter updated" || notok "C: last_prd counter ($last_prd)"
+last=$(jq -r '.task_registry["sync-ids"].last_completed_at' "$sb/docs/blueprint/manifest.json")
+[ "$last" != "null" ] && ok "C: last_completed_at written" || notok "C: last_completed_at not written"
+runs=$(jq -r '.task_registry["sync-ids"].stats.runs' "$sb/docs/blueprint/manifest.json")
+[ "$runs" = "1" ] && ok "C: stats.runs incremented" || notok "C: stats.runs ($runs)"
+
+# ---- Test D: fresh last_completed_at -> not due ----
+out=$(bash "$AUTORUN" --project-dir "$sb")
+assert_contains "D: fresh task not due" "TASK=sync-ids SCHEDULE=daily STATE=not_due" "$out"
+rm -rf "$sb"
+
+# ---- Test E: --report never writes back ----
+sb=$(make_sandbox)
+write_manifest "$sb" 1 true daily null
+write_doc "$sb" "docs/adrs/0001-test.md" "ADR-0001"
+out=$(bash "$AUTORUN" --project-dir "$sb" --report)
+assert_contains "E: report mode reports due" "TASK=sync-ids KIND=deterministic SCHEDULE=daily STATE=due" "$out"
+last=$(jq -r '.task_registry["sync-ids"].last_completed_at' "$sb/docs/blueprint/manifest.json")
+[ "$last" = "null" ] && ok "E: report mode no writeback" || notok "E: report mode wrote back"
+if jq -e '.id_registry' "$sb/docs/blueprint/manifest.json" >/dev/null 2>&1; then
+    notok "E: report mode initialized id_registry"
+else
+    ok "E: report mode left manifest untouched"
+fi
+rm -rf "$sb"
+
+# ---- Test F: agent-judgment tasks surfaced, never executed ----
+sb=$(make_sandbox)
+write_manifest "$sb" 1 false daily null
+out=$(bash "$AUTORUN" --project-dir "$sb")
+assert_contains "F: adr-validate due as agent task" "TASK=adr-validate KIND=agent SCHEDULE=weekly STATE=due REMEDIATION=/blueprint:adr-validate" "$out"
+assert_contains "F: DUE_AGENT_TASKS lists adr-validate" "DUE_AGENT_TASKS=adr-validate" "$out"
+adr_last=$(jq -r '.task_registry["adr-validate"].last_completed_at' "$sb/docs/blueprint/manifest.json")
+[ "$adr_last" = "null" ] && ok "F: agent task not marked completed" || notok "F: agent task falsely completed"
+rm -rf "$sb"
+
+# ---- Test G: enabled:false always wins; on-change/on-demand never due ----
+sb=$(make_sandbox)
+write_manifest "$sb" 1 true daily null false
+out=$(bash "$AUTORUN" --project-dir "$sb")
+assert_contains "G: disabled task skipped" "TASK=sync-ids STATE=skipped REASON=disabled" "$out"
+assert_contains "G: on-demand never due" "TASK=curate-docs SCHEDULE=on-demand STATE=on_demand" "$out"
+assert_contains "G: on-change is event-driven" "TASK=claude-md SCHEDULE=on-change STATE=event_driven" "$out"
+assert_not_contains "G: curate-docs not in due list" "curate-docs" "$(printf '%s' "$out" | grep '^DUE_AGENT_TASKS=')"
+rm -rf "$sb"
+
+# ---- Test H: BLUEPRINT_AUTORUN_DISABLE=1 is a no-op ----
+sb=$(make_sandbox)
+write_manifest "$sb" 1 true daily null
+out=$(BLUEPRINT_AUTORUN_DISABLE=1 bash "$AUTORUN" --project-dir "$sb")
+assert_contains "H: env opt-out" "AUTORUN=disabled_by_env" "$out"
+last=$(jq -r '.task_registry["sync-ids"].last_completed_at' "$sb/docs/blueprint/manifest.json")
+[ "$last" = "null" ] && ok "H: opt-out mutates nothing" || notok "H: opt-out wrote back"
+rm -rf "$sb"
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ] || exit 1
+exit 0

--- a/blueprint-plugin/scripts/tests/test-get-automation-config.sh
+++ b/blueprint-plugin/scripts/tests/test-get-automation-config.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Regression tests for get-automation-config.sh (ADR-0020 interaction_mode).
+#
+# Pins the semantic contract:
+#   - no manifest / no automation block -> level 0, effective normal, exit 0
+#   - explicit interaction_mode always wins (even "normal" at level 2)
+#   - ABSENT interaction_mode key: level >= 2 defaults quiet, levels 0-1 normal
+#   - invalid interaction_mode values degrade to normal
+#   - work_orders flags read literally (jq // explicit-false pitfall)
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../get-automation-config.sh"
+
+pass=0
+fail=0
+ok() { pass=$((pass + 1)); printf 'ok   - %s\n' "$1"; }
+notok() { fail=$((fail + 1)); printf 'FAIL - %s\n' "$1"; }
+
+get_key() { printf '%s\n' "$2" | grep -m1 "^$1=" | cut -d= -f2; }
+
+make_project() {
+    local proj
+    proj=$(mktemp -d)
+    if [ -z "$proj" ] || [ ! -d "$proj" ]; then
+        echo "FATAL: mktemp failed" >&2
+        exit 1
+    fi
+    mkdir -p "$proj/docs/blueprint"
+    printf '%s' "$proj"
+}
+
+# ---- A: no manifest ----
+proj=$(make_project)
+rm -rf "$proj/docs"
+out=$(bash "$HELPER" --project-dir "$proj")
+rc=$?
+[ "$rc" -eq 0 ] && ok "A: exit 0 without manifest" || notok "A: exit $rc"
+[ "$(get_key EFFECTIVE_INTERACTION_MODE "$out")" = "normal" ] && ok "A: effective normal" || notok "A: effective wrong"
+[ "$(get_key AUTONOMY_LEVEL "$out")" = "0" ] && ok "A: level 0" || notok "A: level wrong"
+rm -rf "$proj"
+
+# ---- B: manifest without automation block ----
+proj=$(make_project)
+printf '{"format_version": "3.3.0"}\n' > "$proj/docs/blueprint/manifest.json"
+out=$(bash "$HELPER" --project-dir "$proj")
+[ "$(get_key AUTONOMY_LEVEL "$out")" = "0" ] && ok "B: 3.3.0 manifest reads level 0" || notok "B: level wrong"
+[ "$(get_key EFFECTIVE_INTERACTION_MODE "$out")" = "normal" ] && ok "B: effective normal" || notok "B: effective wrong"
+rm -rf "$proj"
+
+# ---- C: level 2, interaction_mode key ABSENT -> effective quiet ----
+proj=$(make_project)
+printf '{"automation": {"autonomy_level": 2}}\n' > "$proj/docs/blueprint/manifest.json"
+out=$(bash "$HELPER" --project-dir "$proj")
+[ "$(get_key INTERACTION_MODE "$out")" = "unset" ] && ok "C: declared mode unset" || notok "C: declared wrong"
+[ "$(get_key EFFECTIVE_INTERACTION_MODE "$out")" = "quiet" ] && ok "C: level 2 defaults quiet" || notok "C: effective wrong"
+rm -rf "$proj"
+
+# ---- D: level 2, explicit normal wins over the quiet default ----
+proj=$(make_project)
+printf '{"automation": {"autonomy_level": 2, "interaction_mode": "normal"}}\n' > "$proj/docs/blueprint/manifest.json"
+out=$(bash "$HELPER" --project-dir "$proj")
+[ "$(get_key EFFECTIVE_INTERACTION_MODE "$out")" = "normal" ] && ok "D: explicit normal wins at level 2" || notok "D: explicit mode overridden"
+rm -rf "$proj"
+
+# ---- E: level 1, explicit quiet ----
+proj=$(make_project)
+printf '{"automation": {"autonomy_level": 1, "interaction_mode": "quiet"}}\n' > "$proj/docs/blueprint/manifest.json"
+out=$(bash "$HELPER" --project-dir "$proj")
+[ "$(get_key EFFECTIVE_INTERACTION_MODE "$out")" = "quiet" ] && ok "E: explicit quiet at level 1" || notok "E: explicit quiet ignored"
+rm -rf "$proj"
+
+# ---- F: invalid mode degrades to normal; level 1 absent key stays normal ----
+proj=$(make_project)
+printf '{"automation": {"autonomy_level": 2, "interaction_mode": "silent"}}\n' > "$proj/docs/blueprint/manifest.json"
+out=$(bash "$HELPER" --project-dir "$proj")
+[ "$(get_key EFFECTIVE_INTERACTION_MODE "$out")" = "normal" ] && ok "F: invalid mode degrades to normal" || notok "F: invalid mode accepted"
+printf '{"automation": {"autonomy_level": 1}}\n' > "$proj/docs/blueprint/manifest.json"
+out=$(bash "$HELPER" --project-dir "$proj")
+[ "$(get_key EFFECTIVE_INTERACTION_MODE "$out")" = "normal" ] && ok "F: level 1 absent key stays normal" || notok "F: level 1 defaulted quiet"
+rm -rf "$proj"
+
+# ---- G: work_orders flags read literally ----
+proj=$(make_project)
+printf '{"automation": {"autonomy_level": 2, "work_orders": {"auto_draft": true, "auto_execute": false}}}\n' > "$proj/docs/blueprint/manifest.json"
+out=$(bash "$HELPER" --project-dir "$proj")
+[ "$(get_key WO_AUTO_DRAFT "$out")" = "true" ] && ok "G: auto_draft true" || notok "G: auto_draft wrong"
+[ "$(get_key WO_AUTO_EXECUTE "$out")" = "false" ] && ok "G: auto_execute false" || notok "G: auto_execute wrong"
+rm -rf "$proj"
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ] || exit 1
+exit 0

--- a/blueprint-plugin/skills/blueprint-autopilot/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-autopilot/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: blueprint-autopilot
+description: Run due blueprint maintenance ambiently at autonomy level 2+. Use when a drift nudge reports blueprint tasks due or suggests /blueprint:autopilot.
+allowed-tools: Read, Glob, Grep, Bash, Task
+created: 2026-07-05
+modified: 2026-07-05
+reviewed: 2026-07-05
+---
+
+# blueprint-autopilot
+
+The level-2 executor of the ADR-0020 autonomy model: runs due
+**agent-judgment** maintenance tasks and (optionally) drafts work-order
+proposals — quietly, with a one-line receipt. The inverse of
+`/blueprint:execute`: no menus, no questions, act then report.
+
+## When to Use This Skill
+
+| Use this skill when... | Use /blueprint:execute instead when... |
+|------------------------|----------------------------------------|
+| The session-start drift nudge says blueprint tasks are due (`→ /blueprint:autopilot`) | The user wants an interactive "what's next?" menu |
+| `automation.autonomy_level` ≥ 2 and ambient maintenance should just happen | The user wants to drive each action themselves |
+| A work-order proposal should be drafted from a ready PRP without interrupting the user | The user wants to create a real work order now (`/blueprint:work-order`) |
+
+## Context
+
+- Automation config: !`bash ${CLAUDE_SKILL_DIR}/../../scripts/get-automation-config.sh`
+- Due tasks (report mode, no writes): !`bash ${CLAUDE_SKILL_DIR}/../../scripts/blueprint-autorun.sh --report`
+
+## Execution
+
+Execute this autopilot pass:
+
+### Step 1: Gate on autonomy level
+
+Read `AUTONOMY_LEVEL` from the Context automation config. If it is **below
+2**, stop immediately with the single line
+`Autopilot inactive (autonomy_level N) — raise automation.autonomy_level in docs/blueprint/manifest.json to enable.`
+Nothing else. Also stop (silently, one line) when `BLUEPRINT_AUTORUN_DISABLE=1`
+is set in the environment.
+
+### Step 2: Run due agent-judgment tasks (budget: 2 per pass)
+
+From the Context `--report` output, collect the `DUE_AGENT_TASKS` list. Take
+at most the **first 2** (session token budget — the rest surface again next
+session). For each task, dispatch ONE subagent (Task tool) with a focused
+brief:
+
+- `adr-validate` → run the `/blueprint:adr-validate --report-only` procedure;
+  return the findings summary only
+- `feature-tracker-sync` → run the full-sync reconciliation in report-then-apply
+  form, applying only unambiguous updates (drain evidence-backed completed WOs,
+  recompute stats); ambiguous discrepancies are reported, not resolved
+- `story-audit` → run the audit and write only its dated artifact under
+  `docs/blueprint/audits/`
+- any other task → run its skill's `--report-only`/dry-run form; never its
+  mutating form
+
+Each task's brief MUST state: work quietly, never `AskUserQuestion` (autopilot
+runs unattended), and return a one-line result. Tasks whose skills would
+require interactive confirmation for writes stay report-only here — autopilot
+never bypasses a write gate.
+
+After a task's subagent returns successfully, record completion in the
+manifest:
+
+```bash
+jq --arg task "<task>" --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+   '.task_registry[$task].last_completed_at = $ts |
+    .task_registry[$task].last_result = "ok (autopilot)" |
+    .task_registry[$task].stats.runs = ((.task_registry[$task].stats.runs // 0) + 1)' \
+   docs/blueprint/manifest.json > docs/blueprint/manifest.json.tmp \
+   && mv docs/blueprint/manifest.json.tmp docs/blueprint/manifest.json
+```
+
+On a failed subagent, record `last_result = "error: <one-line reason>"` but do
+NOT update `last_completed_at` (the task stays due).
+
+### Step 3: Work-order auto-draft (only when `WO_AUTO_DRAFT=true`)
+
+Skip this step entirely unless the Context config shows `WO_AUTO_DRAFT=true`.
+Work-order **creation stays human-only** (`/blueprint:work-order` keeps
+`disable-model-invocation: true` — never invoke it from autopilot). Autopilot
+may only file *proposals*:
+
+1. **Find ready PRPs**: scan `docs/prps/*.md` frontmatter for
+   `confidence: 9` or higher (the `confidence-scoring` bar for delegation).
+2. **Exclude PRPs that already have a work order or draft**: a WO exists when
+   the manifest `id_registry` maps the PRP to a `WO-*` document, when a tracker
+   `tasks.pending` entry carries `source: <PRP-id>`, or when an open GitHub
+   issue labeled `work-order-draft` or `work-order` names the PRP id:
+
+   ```bash
+   gh issue list --state open --label work-order-draft --limit 100 --json number,title
+   gh issue list --state open --label work-order --limit 100 --json number,title
+   ```
+
+3. **Cap**: if ≥ 5 open `work-order-draft` issues exist, draft nothing and
+   note the cap in the receipt.
+4. **File the draft** for each remaining ready PRP (at most 2 per pass):
+   a GitHub issue titled `[work-order-draft] <PRP-id>: <PRP title>`, labeled
+   `work-order-draft`, whose body is the full work-order packet built from the
+   PRP (objective, minimal context, TDD requirements copied verbatim, success
+   criteria, file list) plus the promotion instruction:
+   `Promote with /blueprint:work-order --from-issue <N>`.
+   Create the label first if missing
+   (`gh label create work-order-draft --description "Auto-drafted work-order proposal (ADR-0020)" --color FBCA04`).
+5. **No GitHub remote / `gh` unauthenticated**: write local draft files to
+   `docs/blueprint/work-orders/drafts/NNN-<slug>.md` instead (same packet,
+   `status: draft` frontmatter). Never touch `tasks.pending` or the
+   `id_registry` — those mutate at promotion time only.
+
+### Step 4: One-line receipt
+
+End with exactly one summary line, e.g.:
+`Autopilot: ran adr-validate (2 findings), feature-tracker-sync (1 WO drained); drafted 1 work-order proposal (#214).`
+If nothing was due and nothing drafted:
+`Autopilot: nothing due.`
+
+## Guardrails
+
+- Never `AskUserQuestion`; never end on a question. Autopilot is fire-and-report.
+- Never invoke `/blueprint:work-order` or `/blueprint:prp-execute` (human-only
+  by design; the draft-issue side channel is the only WO surface here).
+- Bounded per pass: ≤ 2 agent tasks, ≤ 2 drafts, draft cap 5 open issues — no
+  loops, no self-continuation (see `.claude/rules/loop-integrity.md`).
+- `enabled: false` tasks never run regardless of level.
+- Drafts are additive and closable; closing a `work-order-draft` issue is a
+  valid human veto and autopilot re-drafts only if the PRP still qualifies AND
+  no open draft exists (a closed draft for the same PRP id counts as a veto —
+  check `--state all` before re-drafting and skip PRPs with a closed,
+  unpromoted draft).
+
+## Agentic Optimizations
+
+| Context | Command |
+|---------|---------|
+| Gate + config in one call | `bash <plugin>/scripts/get-automation-config.sh` |
+| Due-ness without writes | `bash <plugin>/scripts/blueprint-autorun.sh --report` |
+| Draft dedupe (parallel-safe) | `gh issue list --state all --label work-order-draft --limit 100 --json number,title,state` |
+| Kill switch | `BLUEPRINT_AUTORUN_DISABLE=1` |

--- a/blueprint-plugin/skills/blueprint-execute/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-execute/SKILL.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-01-14
-modified: 2026-05-09
+modified: 2026-07-05
 reviewed: 2026-04-25
 description: "Blueprint meta command: determine and execute the next logical action. Use when asked 'what's next?', 'continue blueprint', or 'run blueprint' without a subcommand."
 allowed-tools: Read, Glob, Bash, AskUserQuestion, SlashCommand, Task
@@ -27,6 +27,22 @@ Intelligent meta command that analyzes repository state and executes the appropr
 For detailed AskUserQuestion templates, examples, and common workflows, see [REFERENCE.md](REFERENCE.md).
 
 ---
+
+## Interaction Mode
+
+Before any closing `AskUserQuestion` menu, resolve the automation config:
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/../../scripts/get-automation-config.sh"
+```
+
+When `EFFECTIVE_INTERACTION_MODE=quiet` **and** this invocation was
+automation-initiated (autopilot, session bookend, drift-nudge follow-up — not
+a slash command the user typed), skip closing navigation menus ("what next?" /
+"create another?" style): apply the safe default and end with a one-line
+receipt instead. Quiet mode never skips confirmation gates that guard writes —
+only navigation menus. A direct user invocation always behaves fully
+interactively (explicit intent overrides quiet; see ADR-0020).
 
 ## Phase 0: Parallel Context Gathering
 

--- a/blueprint-plugin/skills/blueprint-feature-tracker-sync/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-feature-tracker-sync/SKILL.md
@@ -33,6 +33,22 @@ Synchronize the feature tracker JSON with TODO.md and manage task progress.
 
 ---
 
+## Interaction Mode
+
+Before any closing `AskUserQuestion` menu, resolve the automation config:
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/../../scripts/get-automation-config.sh"
+```
+
+When `EFFECTIVE_INTERACTION_MODE=quiet` **and** this invocation was
+automation-initiated (autopilot, session bookend, drift-nudge follow-up — not
+a slash command the user typed), skip closing navigation menus ("what next?" /
+"create another?" style): apply the safe default and end with a one-line
+receipt instead. Quiet mode never skips confirmation gates that guard writes —
+only navigation menus. A direct user invocation always behaves fully
+interactively (explicit intent overrides quiet; see ADR-0020).
+
 ## Mode Selection (run first)
 
 Decide which mode applies before any work:

--- a/blueprint-plugin/skills/blueprint-init/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-init/SKILL.md
@@ -153,6 +153,14 @@ Initialize Blueprint Development in this project.
    - **Fully automatic**: all tasks get `auto_run: true`, default schedules
    - **Manual only**: all `auto_run: false`, all schedules set to `on-demand`
 
+   The same selection sets `automation.autonomy_level` (the ADR-0020 level
+   model — what actually *executes* the auto_run contract):
+   - **Prompt** / **Manual only** → `autonomy_level: 0` (nothing runs unattended)
+   - **Auto-run safe** → `autonomy_level: 1` (deterministic due tasks run via
+     the SessionStart probe; due agent tasks surface as drift findings)
+   - **Fully automatic** → `autonomy_level: 2` (quiet autopilot also runs due
+     agent tasks in-session; `interaction_mode` defaults to `quiet`)
+
 4a. **Ask about generated-rules output path** (use AskUserQuestion):
 
    Only prompt when `.claude/rules/` already exists and contains files (i.e., hand-authored rules that pre-date blueprint). Skip silently in fresh repos and use the default.
@@ -250,10 +258,10 @@ Initialize Blueprint Development in this project.
    └── skills/                      # Custom skill overrides (optional)
    ```
 
-7. **Create `manifest.json`** (v3.3.0 schema — canonical filename is `docs/blueprint/manifest.json`, no dot prefix):
+7. **Create `manifest.json`** (v3.4.0 schema — canonical filename is `docs/blueprint/manifest.json`, no dot prefix):
    ```json
    {
-     "format_version": "3.3.0",
+     "format_version": "3.4.0",
      "created_at": "[ISO timestamp]",
      "updated_at": "[ISO timestamp]",
      "created_by": {
@@ -286,6 +294,14 @@ Initialize Blueprint Development in this project.
      "custom_overrides": {
        "skills": [],
        "commands": []
+     },
+     "automation": {
+       "autonomy_level": "[based on maintenance task choice: 0 for Prompt/Manual, 1 for Auto-run safe, 2 for Fully automatic]",
+       "interaction_mode": "normal",
+       "work_orders": {
+         "auto_draft": false,
+         "auto_execute": false
+       }
      },
      "task_registry": {
        "derive-plans": {

--- a/blueprint-plugin/skills/blueprint-migration/migrations/v3.3-to-v3.4.md
+++ b/blueprint-plugin/skills/blueprint-migration/migrations/v3.3-to-v3.4.md
@@ -1,0 +1,183 @@
+# Migration: v3.3 → v3.4
+
+This document describes the migration from blueprint format version 3.3 to 3.4.
+
+## Overview
+
+Version 3.4 adds the **automation block** — the manifest surface for the
+autonomy-level model (ADR-0020 in the claude-plugins repository). All changes
+are purely additive — nothing is moved, renamed, or deleted. A manifest without
+the block behaves exactly like autonomy level 0 (fully manual, today's
+behavior), so upgrading is safe and reversible.
+
+Key additions:
+
+- `manifest.json` gains an `automation` object:
+
+  ```json
+  "automation": {
+    "autonomy_level": 0,
+    "interaction_mode": "normal",
+    "work_orders": { "auto_draft": false, "auto_execute": false }
+  }
+  ```
+
+- `autonomy_level` semantics:
+
+  | Level | Name | Effect |
+  |-------|------|--------|
+  | 0 | manual | nothing runs automatically (default) |
+  | 1 | ambient bookkeeping | `scripts/blueprint-autorun.sh` executes deterministic due tasks (via the SessionStart probe); due agent-judgment tasks surface as drift findings |
+  | 2 | quiet autopilot | + the `blueprint-autopilot` skill runs due agent tasks in-session; `interaction_mode` defaults to `quiet`; work-order **drafts** may be filed when `work_orders.auto_draft` is true |
+  | 3 | scheduled pipeline | + out-of-band scheduled runs (deferred; requires the loop-integrity machinery) |
+
+- `interaction_mode`: `"quiet" | "normal" | "interactive"` — quiet suppresses
+  closing `AskUserQuestion` menus in blueprint skills for automation-initiated
+  flows (direct slash-command invocation always stays interactive).
+- `work_orders.auto_draft` / `work_orders.auto_execute`: both default false.
+  `auto_draft` allows level ≥ 2 automation to file `work-order-draft` GitHub
+  issues; the committing act stays with the human-invoked
+  `/blueprint:work-order --from-issue N`. `auto_execute` is reserved for
+  level 3.
+
+The existing `task_registry` `auto_run`/`schedule`/`last_completed_at` fields
+are unchanged in shape — v3.4 is the version where they become *load-bearing*
+(the runner reads and writes them).
+
+## Manifest Path
+
+All `jq` commands in this document use `$MANIFEST` to refer to the resolved manifest path.
+When running via `/blueprint:upgrade`, `$MANIFEST` is set in Step 2 of that skill.
+When running standalone, resolve it first:
+
+```bash
+if [[ -z "${MANIFEST:-}" ]]; then
+  if [[ -f docs/blueprint/manifest.json ]]; then
+    MANIFEST=docs/blueprint/manifest.json
+  elif [[ -f docs/blueprint/.manifest.json ]]; then
+    MANIFEST=docs/blueprint/.manifest.json
+  else
+    echo "ERROR: no manifest found. Run /blueprint:init first."; exit 1
+  fi
+fi
+```
+
+## Pre-Migration Checks
+
+```bash
+# 1. Manifest exists
+test -f "$MANIFEST"
+
+# 2. Version is 3.3.x
+version=$(jq -r '.format_version // "1.0.0"' "$MANIFEST")
+if [[ ! "$version" =~ ^3\.3 ]]; then
+  echo "ERROR: Expected v3.3.x, found $version"
+  exit 1
+fi
+
+# 3. Working tree clean
+git status --porcelain
+```
+
+**Confirmation**: "Current version is v{version}. Proceed with migration to v3.4.0?"
+
+## Migration Steps
+
+### Step 1: Choose the initial autonomy level
+
+Map from the existing `task_registry` state — the same mapping
+`/blueprint:init`'s maintenance-task question uses:
+
+- Any task already has `auto_run: true` → suggest **level 1** (the user
+  previously opted into auto-running; v3.4 makes that real).
+- All `auto_run: false` → suggest **level 0** (no behavior change).
+
+Ask the user (AskUserQuestion) unless running non-interactively (`-y`), in
+which case default to the suggestion above — never higher.
+
+### Step 2: Add the `automation` block
+
+```bash
+level=0   # or 1, per Step 1
+jq --argjson lvl "$level" '
+  .automation = {
+    "autonomy_level": $lvl,
+    "interaction_mode": "normal",
+    "work_orders": { "auto_draft": false, "auto_execute": false }
+  }
+' "$MANIFEST" > "$MANIFEST".tmp && \
+mv "$MANIFEST".tmp "$MANIFEST"
+```
+
+### Step 3: Bump `format_version` and record upgrade history
+
+```bash
+jq '
+  .format_version = "3.4.0" |
+  .updated_at = (now | strftime("%Y-%m-%dT%H:%M:%SZ")) |
+  .upgrade_history = ((.upgrade_history // []) + [{
+    "from": "3.3.0",
+    "to": "3.4.0",
+    "date": (now | strftime("%Y-%m-%dT%H:%M:%SZ")),
+    "changes": [
+      "Added automation block (autonomy_level, interaction_mode, work_orders)",
+      "task_registry auto_run/schedule contract now executed by blueprint-autorun"
+    ]
+  }])
+' "$MANIFEST" > "$MANIFEST".tmp && \
+mv "$MANIFEST".tmp "$MANIFEST"
+```
+
+## Post-Migration Verification
+
+```bash
+# 1. format_version is 3.4.0
+jq -r '.format_version' "$MANIFEST"
+# Expected: 3.4.0
+
+# 2. automation block present with expected defaults
+jq '.automation' "$MANIFEST"
+
+# 3. Upgrade history recorded
+jq '.upgrade_history[-1]' "$MANIFEST"
+
+# 4. Dry-run the runner (report mode, no writes)
+bash "$(dirname "$(command -v blueprint-autorun.sh 2>/dev/null || echo .)")"/blueprint-autorun.sh --report
+# Or, from a plugin checkout:
+# bash <plugin-root>/scripts/blueprint-autorun.sh --report
+```
+
+## Migration Summary Template
+
+```
+Blueprint Migration Complete (v3.3 → v3.4)
+
+Automation contract enabled:
+- autonomy_level: {0|1}
+- interaction_mode: normal
+- work_orders: auto_draft=false, auto_execute=false
+
+Manifest updated:
+- format_version: 3.4.0
+- upgrade_history entry added
+
+Next steps:
+1. Review task_registry auto_run flags — level 1 only executes tasks with
+   enabled:true AND auto_run:true
+2. Raise autonomy_level when ready (1 = ambient bookkeeping,
+   2 = quiet autopilot + work-order drafts)
+3. Commit the migration
+```
+
+## Rollback
+
+Because v3.4 is purely additive, rollback is straightforward:
+
+```bash
+jq 'del(.automation) | .format_version = "3.3.0"' "$MANIFEST" \
+  > "$MANIFEST".tmp && \
+mv "$MANIFEST".tmp "$MANIFEST"
+```
+
+Any `last_completed_at`/`last_result`/`stats` values the runner wrote remain
+valid v3.3 data (the fields existed in 3.3; they were simply never written).

--- a/blueprint-plugin/skills/blueprint-story-reconcile/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-story-reconcile/SKILL.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-04-25
-modified: 2026-07-04
+modified: 2026-07-05
 reviewed: 2026-04-25
 description: Reconcile PRD requirements with a story-audit drift report. Use when marking PRD entries implemented/partial/missing, or promoting code-only stories into the PRD.
 args: "[--audit <path>] [--prd <path>] [--apply-all] [--dry-run]"
@@ -43,6 +43,22 @@ Parse `$ARGUMENTS`:
 - `--prd <path>`: Limit edits to a single PRD. Default: every PRD referenced by the audit's drift table.
 - `--apply-all`: Skip per-row prompts and apply every drift entry as an edit. Use only when the audit was reviewed elsewhere.
 - `--dry-run`: Show the planned edits as unified diffs without writing.
+
+## Interaction Mode
+
+Before any closing `AskUserQuestion` menu, resolve the automation config:
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/../../scripts/get-automation-config.sh"
+```
+
+When `EFFECTIVE_INTERACTION_MODE=quiet` **and** this invocation was
+automation-initiated (autopilot, session bookend, drift-nudge follow-up — not
+a slash command the user typed), skip closing navigation menus ("what next?" /
+"create another?" style): apply the safe default and end with a one-line
+receipt instead. Quiet mode never skips confirmation gates that guard writes —
+only navigation menus. A direct user invocation always behaves fully
+interactively (explicit intent overrides quiet; see ADR-0020).
 
 ## Execution
 

--- a/blueprint-plugin/skills/blueprint-sync-ids/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-sync-ids/SKILL.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-01-20
-modified: 2026-06-10
+modified: 2026-07-05
 reviewed: 2026-06-10
 description: Scan blueprint docs and assign missing PRD/ADR/PRP/WO IDs. Use when assigning IDs to docs; --dry-run to preview, --link-issues to create GitHub issues for orphans.
 args: "[--dry-run] [--link-issues]"
@@ -26,6 +26,22 @@ Scan all PRDs, ADRs, PRPs, and work-orders, assign IDs to documents missing them
 |------|-------------|
 | `--dry-run` | Preview changes without modifying files |
 | `--link-issues` | Also create GitHub issues for orphan documents |
+
+## Interaction Mode
+
+Before any closing `AskUserQuestion` menu, resolve the automation config:
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/../../scripts/get-automation-config.sh"
+```
+
+When `EFFECTIVE_INTERACTION_MODE=quiet` **and** this invocation was
+automation-initiated (autopilot, session bookend, drift-nudge follow-up — not
+a slash command the user typed), skip closing navigation menus ("what next?" /
+"create another?" style): apply the safe default and end with a one-line
+receipt instead. Quiet mode never skips confirmation gates that guard writes —
+only navigation menus. A direct user invocation always behaves fully
+interactively (explicit intent overrides quiet; see ADR-0020).
 
 ## Prerequisites
 

--- a/blueprint-plugin/skills/blueprint-sync/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 created: 2025-12-22
-modified: 2026-05-09
+modified: 2026-07-05
 reviewed: 2026-05-03
 description: "Check for stale generated content and offer regeneration or promotion. Use when syncing blueprint after PRD changes, or reconciling .claude/rules/ drift."
 args: "[--dry-run]"
@@ -25,6 +25,22 @@ Check the status of generated content and offer options for modified or stale fi
 | Flag | Description |
 |------|-------------|
 | `--dry-run` | Preview sync status report without interactive prompts or file modifications |
+
+## Interaction Mode
+
+Before any closing `AskUserQuestion` menu, resolve the automation config:
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/../../scripts/get-automation-config.sh"
+```
+
+When `EFFECTIVE_INTERACTION_MODE=quiet` **and** this invocation was
+automation-initiated (autopilot, session bookend, drift-nudge follow-up — not
+a slash command the user typed), skip closing navigation menus ("what next?" /
+"create another?" style): apply the safe default and end with a one-line
+receipt instead. Quiet mode never skips confirmation gates that guard writes —
+only navigation menus. A direct user invocation always behaves fully
+interactively (explicit intent overrides quiet; see ADR-0020).
 
 ## Steps
 

--- a/blueprint-plugin/skills/blueprint-upgrade/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-upgrade/SKILL.md
@@ -20,7 +20,7 @@ Upgrade the blueprint structure to the latest format version.
 | You're adding the v3.2 task registry or v3.3 monorepo workspaces | Use blueprint-execute instead when you want auto-detection of next step |
 | You're running batch upgrades across repos with `--non-interactive`/`-y` | Use blueprint-status instead to first audit current version |
 
-**Current Format Version**: 3.3.0
+**Current Format Version**: 3.4.0
 
 This command delegates version-specific migration logic to the `blueprint-migration` skill.
 
@@ -73,7 +73,7 @@ If a migration step would require any prompt not listed above, **abort the upgra
      exit 1
    fi
    current=$(jq -r '.format_version // "1.0.0"' "$MANIFEST")
-   target="3.3.0"
+   target="3.4.0"
    ```
 
    **Important**: Store the resolved `$MANIFEST` path. Use it in every `jq` invocation throughout this skill and in all delegated migration steps. This avoids silent failures when the filename differs from what a command hard-codes.
@@ -87,7 +87,8 @@ If a migration step would require any prompt not listed above, **abort the upgra
    | 3.0.x        | 3.1.0      | `migrations/v3.0-to-v3.1.md` |
    | 3.1.x        | 3.2.0      | inline (step 3a) |
    | 3.2.x        | 3.3.0      | `migrations/v3.2-to-v3.3.md` |
-   | 3.3.0        | 3.3.0      | Already up to date |
+   | 3.3.x        | 3.4.0      | `migrations/v3.3-to-v3.4.md` |
+   | 3.4.0        | 3.4.0      | Already up to date |
 
 3. **Check for deprecated generated commands**:
 
@@ -179,12 +180,24 @@ If a migration step would require any prompt not listed above, **abort the upgra
 
    All changes are purely additive — standalone projects get no new top-level keys beyond `format_version` and `upgrade_history`.
 
+---
+
+3c. **v3.3 → v3.4 migration: Automation block (autonomy levels)**:
+
+   Delegate to `skills/blueprint-migration/migrations/v3.3-to-v3.4.md`. Summary of what it does:
+
+   a. Suggest an initial `autonomy_level` from existing `task_registry` state (any `auto_run: true` → suggest level 1; otherwise level 0). Confirm with the user; in `$NONINTERACTIVE` mode take the suggestion, never higher.
+   b. Add the `automation` block (`autonomy_level`, `interaction_mode: "normal"`, `work_orders: {auto_draft: false, auto_execute: false}`) to `$MANIFEST`.
+   c. Bump `format_version` to `3.4.0` and append an entry to `upgrade_history`.
+
+   Purely additive — a missing `automation` block already behaves as level 0, so the migration changes no behavior until the user raises the level. See ADR-0020 (claude-plugins) for the level model.
+
 4. **Display upgrade plan**:
    ```
    Blueprint Upgrade
 
    Current version: v{current}
-   Target version: v3.3.0
+   Target version: v3.4.0
 
    Major changes in v3.0:
    - Blueprint state moves from .claude/blueprints/ to docs/blueprint/
@@ -205,6 +218,12 @@ If a migration step would require any prompt not listed above, **abort the upgra
    - Cross-workspace references (`<path>/ADR-NNN`, `/ADR-NNN`)
    - Optional portfolio feature tracking via implemented_by links
 
+   Major changes in v3.4:
+   - `automation` block: autonomy_level (0 manual / 1 ambient bookkeeping /
+     2 quiet autopilot / 3 scheduled pipeline), interaction_mode, work_orders
+   - task_registry auto_run/schedule contract becomes executable
+     (scripts/blueprint-autorun.sh + SessionStart probe)
+
    (For v2.0 changes when upgrading from v1.x:)
    - PRDs, ADRs, PRPs move to docs/ (project documentation)
    - Custom overrides in .claude/skills/
@@ -217,7 +236,7 @@ If a migration step would require any prompt not listed above, **abort the upgra
 
    Otherwise, use AskUserQuestion:
    ```
-   question: "Ready to upgrade blueprint from v{current} to v3.3.0?"
+   question: "Ready to upgrade blueprint from v{current} to v3.4.0?"
    options:
      - "Yes, upgrade now" → proceed
      - "Show detailed migration steps" → display migration document
@@ -232,6 +251,7 @@ If a migration step would require any prompt not listed above, **abort the upgra
    - For v3.0 → v3.1: Load `migrations/v3.0-to-v3.1.md`
    - For v3.1 → v3.2: Execute inline step 3a above
    - For v3.2 → v3.3: Load `migrations/v3.2-to-v3.3.md` (see step 3b summary)
+   - For v3.3 → v3.4: Load `migrations/v3.3-to-v3.4.md` (see step 3c summary)
    - Execute each step with user confirmation for destructive operations
 
 7. **v1.x → v2.0 migration overview** (from migration document):

--- a/blueprint-plugin/skills/blueprint-work-order/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-work-order/SKILL.md
@@ -1,6 +1,6 @@
 ---
 created: 2025-12-16
-modified: 2026-05-09
+modified: 2026-07-05
 reviewed: 2026-04-25
 description: Create a work-order for isolated subagent execution, optionally linked to a GitHub issue. Use when breaking a PRP into delegatable tasks or spawning from an issue.
 args: "[--no-publish] [--from-issue N]"
@@ -30,6 +30,22 @@ Generate a work-order document for isolated subagent execution with optional Git
 | `--from-prp NAME` | Create work-order from existing PRP (auto-populates context) |
 
 **Default behavior**: Creates both local work-order AND GitHub issue with `work-order` label.
+
+## Interaction Mode
+
+Before any closing `AskUserQuestion` menu, resolve the automation config:
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/../../scripts/get-automation-config.sh"
+```
+
+When `EFFECTIVE_INTERACTION_MODE=quiet` **and** this invocation was
+automation-initiated (autopilot, session bookend, drift-nudge follow-up — not
+a slash command the user typed), skip closing navigation menus ("what next?" /
+"create another?" style): apply the safe default and end with a one-line
+receipt instead. Quiet mode never skips confirmation gates that guard writes —
+only navigation menus. A direct user invocation always behaves fully
+interactively (explicit intent overrides quiet; see ADR-0020).
 
 ## Prerequisites
 

--- a/blueprint-plugin/skills/blueprint-work-order/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-work-order/SKILL.md
@@ -26,7 +26,7 @@ Generate a work-order document for isolated subagent execution with optional Git
 | Flag | Description |
 |------|-------------|
 | `--no-publish` | Create local work-order only, skip GitHub issue creation |
-| `--from-issue N` | Create work-order from existing GitHub issue #N |
+| `--from-issue N` | Create work-order from existing GitHub issue #N (a `work-order-draft` proposal issue is promoted: packet consumed, label swapped to `work-order`) |
 | `--from-prp NAME` | Create work-order from existing PRP (auto-populates context) |
 
 **Default behavior**: Creates both local work-order AND GitHub issue with `work-order` label.
@@ -97,6 +97,21 @@ When `--from-issue N` is provided:
    - Extract objective from title/body
    - Extract any TDD requirements or success criteria if present
    - Note existing labels
+
+2a. **Promote a `work-order-draft` proposal** (ADR-0020 auto-draft channel):
+
+   If the issue carries the `work-order-draft` label, it is an auto-drafted
+   proposal from `/blueprint:autopilot` — its body already IS the full
+   work-order packet (title form `[work-order-draft] PRP-NNN: <title>`).
+   Promotion is the human committing act the draft channel preserves:
+   - Consume the packet verbatim as the work-order content (the draft body
+     supersedes step 3's re-generation; still verify the referenced PRP exists
+     and its confidence is current — warn if it dropped below 9)
+   - In step 4, additionally swap the labels:
+     `gh issue edit N --remove-label "work-order-draft" --add-label "work-order"`
+   - Proceed with the normal save path (Step 6): the local WO file,
+     `feature-tracker.json` `tasks.pending`, and the manifest `id_registry`
+     mutate HERE, at promotion — never at draft time
 
 3. **Generate work-order**:
    - Number matches issue number (e.g., issue #42 → work-order `042-...`)

--- a/docs/PLUGIN-MAP.md
+++ b/docs/PLUGIN-MAP.md
@@ -33,7 +33,7 @@ The development loop: plan, code, commit, ship.
 
 | Plugin | Skills | Purpose |
 |--------|--------|---------|
-| blueprint-plugin | 33 | PRD/ADR/PRP/TRP methodology, `/blueprint:execute` auto-pilot, monorepo portfolio tracking, story-audit/reconcile |
+| blueprint-plugin | 34 | PRD/ADR/PRP/TRP methodology, `/blueprint:execute` auto-pilot, ambient autonomy levels (`/blueprint:autopilot`), monorepo portfolio tracking, story-audit/reconcile |
 | git-plugin | 38 + 1 agent | Commits, branches, PRs, issues, forks, worktrees, release-please |
 | project-plugin | 7 | Project init, modernization, maintenance |
 | session-plugin | 4 | Session bookends: spinup briefing, wrap capture, end orchestrator, distill |

--- a/docs/adrs/0020-blueprint-autonomy-levels.md
+++ b/docs/adrs/0020-blueprint-autonomy-levels.md
@@ -1,0 +1,202 @@
+# ADR-0020: Blueprint Autonomy Levels — Ambient Operations via a Manifest-Gated Level Model
+
+---
+id: ADR-0020
+date: 2026-07-05
+created: 2026-07-05
+modified: 2026-07-05
+status: Proposed
+deciders: claude-plugins team
+domain: automation
+relates-to:
+  - ADR-0005
+  - ADR-0011
+  - ADR-0016
+  - ADR-0017
+---
+
+## Context
+
+Blueprint operations are entirely user-initiated today. Work orders require the
+human-only `/blueprint:work-order` command (`disable-model-invocation: true`);
+maintenance tasks (`sync-ids`, `feature-tracker-sync`, `adr-validate`,
+drain-wave) require manual sweeps; and many skills end in `AskUserQuestion`
+menus. The goal driving this ADR: make blueprint **ambient** — its bookkeeping
+runs itself and work orders get *proposed* automatically, while the user only
+interacts with blueprint when they explicitly want to.
+
+Three facts shape the design:
+
+1. **The manifest already carries a dormant automation contract.** Every
+   `task_registry` entry has `enabled`, `auto_run`, `schedule`
+   (`weekly`/`daily`/`on-change`/`on-demand`), `last_completed_at`, and
+   `last_result` fields — and `/blueprint:init` already *asks the user* how
+   maintenance tasks should run and stores `auto_run` accordingly. Nothing
+   implements the contract: no code computes due-ness or executes a due task.
+
+2. **Registry tasks split into two kinds, and the kind determines which rail
+   can run them** (per `.claude/rules/offload-to-deterministic-substrate.md`):
+   *deterministic* tasks (the id-registry sweep behind `sync-ids`, tracker
+   timestamp bookkeeping, drain-wave evidence moves) are runnable by command
+   hooks/scripts with no model in the loop; *agent-judgment* tasks
+   (`adr-validate`, `story-audit`, `curate-docs`, work-order drafting) need a
+   model, so a command hook can only *surface* them.
+
+3. **The automation rails already exist.** The SessionStart drift-probe →
+   `drift-aggregator` pipe (`hooks-plugin/hooks/lib/drift-protocol.sh`) is the
+   notify-only rail; PostToolUse hooks like
+   `blueprint-plugin/hooks/auto-sync-id-registry.sh` are the working precedent
+   for silent bounded auto-apply; `.github/workflows/scheduled-audits.yml`
+   already runs a scheduled blueprint health job. What is missing is a
+   *coherent, user-facing model* of how much autonomy blueprint has in a given
+   repo — and the executors that honor it.
+
+The tension to resolve: work orders are human-only *by design* (WO files are
+gitignored and may carry sensitive detail; the committing act mutates
+`tasks.pending` and the `id_registry`). Any automation must preserve that
+safeguard rather than delete it.
+
+## Decision
+
+Adopt a **tiered autonomy-level model**, expressed in a new manifest
+`automation` block (format 3.3.0 → 3.4.0, purely additive):
+
+```json
+"automation": {
+  "autonomy_level": 0,
+  "interaction_mode": "normal",
+  "work_orders": { "auto_draft": false, "auto_execute": false }
+}
+```
+
+| Level | Name | What runs automatically | Executor rail | Work-order stance |
+|-------|------|-------------------------|---------------|-------------------|
+| 0 | manual | nothing (today's behavior) | — | human `/blueprint:work-order` only |
+| 1 | ambient bookkeeping | deterministic due tasks; on-change syncs; session-end drain | SessionStart/PostToolUse command hooks + `scripts/blueprint-autorun.sh` | unchanged |
+| 2 | quiet autopilot | + agent-judgment due tasks in-session; quiet interaction mode | `blueprint-autopilot` skill, triggered by the drift nudge | + auto-**draft** WO issues; human promotes via `--from-issue` |
+| 3 | scheduled pipeline (deferred) | + out-of-band cron runs; approved-WO execution → PRs | GitHub Actions + claude-code-action | + auto-execute **approved** WOs; human reviews the PR |
+
+### The deterministic runner (level 1)
+
+`blueprint-plugin/scripts/blueprint-autorun.sh` implements the dormant
+contract: it computes due-ness (`schedule` vs `last_completed_at`), executes
+**deterministic** due tasks directly (currently: the `sync-ids` id-registry
+sweep), writes back `last_completed_at`/`last_result`/`stats`, and reports due
+**agent-judgment** tasks without executing them. It emits the
+`=== SECTION ===`/`KEY=VALUE`/`STATUS=` convention
+(`.claude/rules/structured-script-output.md`) and offers `--report` for a
+dry-run. A SessionStart probe (`hooks/blueprint-autorun-probe.sh`, TTL-debounced
+per `.claude/rules/drift-detection-triggering.md`) runs it and emits one drift
+finding per due agent task into the existing aggregator pipe. `on-change` tasks
+are event-driven (PostToolUse hooks), never runner-driven; `on-demand` tasks are
+never due.
+
+### The draft-issue side channel (level 2)
+
+Automation never invokes `/blueprint:work-order` — `disable-model-invocation:
+true` stays on it (and on `/blueprint:prp-execute`) permanently. Instead, the
+level-2 `blueprint-autopilot` skill scans ready PRPs (confidence ≥ 9, via
+`confidence-scoring`) that lack a work order and files GitHub issues labeled
+`work-order-draft` carrying the full WO packet (or local files under
+`docs/blueprint/work-orders/drafts/` in `--no-publish` repos). The *committing*
+act — real WO file, `work-order` label, `tasks.pending` + `id_registry`
+mutation — remains the human-invoked `/blueprint:work-order --from-issue N`
+promotion. Drafts are deduped by label + PRP id and capped (default 5 open).
+
+### Interaction mode
+
+`automation.interaction_mode: "quiet" | "normal" | "interactive"` lets skills
+skip their closing `AskUserQuestion` menus and end with a one-line receipt.
+Level ≥ 2 defaults to `quiet`. **Direct invocation always wins**: a slash
+command the user typed behaves fully interactively at every level — quiet mode
+governs automation-initiated flows and closing menus only.
+
+### Safety rails
+
+- `enabled: false` always wins — a disabled task never runs at any level (this
+  repo's constrained-dogfooding disables stay authoritative).
+- `BLUEPRINT_AUTORUN_DISABLE=1` kills levels 1–2 locally regardless of manifest.
+- Probes are read-only and TTL-debounced; auto-apply is bounded to
+  deterministic, unambiguous facts (drift rules).
+- A missing `automation` block ≡ level 0 — 3.3.0 manifests keep working
+  unchanged.
+- Level 3 (deferred until a consumer repo wants it) requires the
+  `.claude/rules/loop-integrity.md` machinery: an independent verifier (CI +
+  fresh reviewer, never the executing agent) and issue-comment state packets
+  per iteration; `blueprint-autorun.yml` follows the `blueprint-health` job
+  pattern in `scheduled-audits.yml` with `--model opus --effort` pinned.
+
+This repository dogfoods at level 1 with only the already-enabled read-leaning
+tasks; consumer repos opt higher.
+
+## Options Considered
+
+1. **Ambient bookkeeping only** (hooks + deterministic script, no model
+   executor). Rejected as the whole answer: it never touches work-order
+   proposal — the headline ask — and leaves the AskUserQuestion chattiness
+   intact. It survives as **level 1**.
+
+2. **Quiet in-session autopilot** (auto-invocable skill runs due tasks and
+   drafts WOs). Right for in-session ambience but leaves nothing running when
+   no session opens. Survives as **level 2**.
+
+3. **Out-of-band scheduled pipeline** (GitHub Actions runs everything,
+   including executing approved WOs into PRs). Highest risk: headless
+   execution quality, loop-integrity machinery required up front, and this
+   constrained repo cannot dogfood it. Survives as **level 3**, designed but
+   deferred.
+
+4. **Fully autonomous WO creation** (drop `disable-model-invocation` and let
+   the model create real work orders). Rejected: it deletes a deliberate
+   safeguard on a mutating, potentially sensitive act. The draft-issue side
+   channel gets the ambient benefit while the committing act stays human.
+
+5. **A single boolean `auto_run` implementation with no level model.**
+   Rejected: the existing per-task flags cannot express "notify vs execute vs
+   draft" distinctions, every downstream repo would re-derive its own policy,
+   and there would be no single knob to answer "how out-of-the-way is
+   blueprint here?".
+
+## Consequences
+
+### Positive
+
+- The manifest's dormant `auto_run`/`schedule` contract finally executes, and
+  `blueprint-init`'s existing maintenance-task question maps onto a real
+  behavior (`Manual only` → 0, `Prompt` → 0, `Auto-run safe` → 1,
+  `Fully automatic` → 2).
+- One user-facing knob (`autonomy_level`) answers how ambient blueprint is in
+  a repo; each level is an independently shippable rung.
+- The human-only work-order safeguard is preserved as level semantics rather
+  than deleted; proposals land where humans already review things (labeled
+  GitHub issues).
+- Deterministic work moves onto the deterministic substrate (ADR-0016), and
+  surfacing reuses the existing drift-aggregator pipe (ADR-0017) instead of a
+  new nudge channel.
+
+### Negative
+
+- A format bump (3.4.0) with migration surface: `blueprint-upgrade`,
+  `blueprint-init`, the drift probe's `CURRENT_FORMAT_VERSION`, and
+  `check-blueprint-upgrade-target.sh` all move together.
+- Quiet mode threads a manifest read through ~6–12 skills — a recurring
+  maintenance surface.
+- More autonomy means more silent writes (manifest timestamps, id-registry
+  refreshes); the structured output and `last_result` writeback are the audit
+  trail, but a user who never reads them sees less of what blueprint does.
+
+### Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Autopilot mis-fires in sessions where blueprint is irrelevant | Level-gated silent exit; only triggered by a drift finding that says tasks are due |
+| Draft-issue noise if confidence scoring is generous | Dedupe by label + PRP id; open-draft cap; drafts are additive and closable |
+| Ambient token cost at session start | TTL debounce; deterministic tasks cost zero model tokens; one-task-per-session budget for agent tasks |
+| Level 3 runaway loops | Deferred entirely; ships only with loop-integrity verifier + state packets + run budgets |
+
+## Related ADRs
+
+- [ADR-0005: Blueprint Development Methodology](0005-blueprint-development-methodology.md) — the document hierarchy this automates
+- [ADR-0011: Blueprint State in docs/ Directory](0011-blueprint-state-in-docs-directory.md) — where the manifest and work orders live
+- [ADR-0016: Extract Deterministic Skill Procedure into Structured-Output Scripts](0016-deterministic-script-extraction-for-token-efficiency.md) — the deterministic-substrate principle level 1 applies
+- [ADR-0017: Hook-Based Behavioral Cues for Multi-Plugin Utilization](0017-hook-based-behavioral-cues-for-plugin-utilization.md) — the token-budget contract the autorun probe's findings obey

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -33,6 +33,7 @@ This repository was created by migrating Claude Code plugin configurations from 
 | [0017](0017-hook-based-behavioral-cues-for-plugin-utilization.md) | Hook-Based Behavioral Cues for Multi-Plugin Utilization | Proposed | 2026-06 |
 | [0018](0018-health-usage-scope-from-session-telemetry.md) | Usage-Telemetry Scope for health-plugin | Proposed | 2026-06 |
 | [0019](0019-skill-dry-via-library-templating-rejected.md) | Reject Shared-Library / @-Imports / Build-Time Templating for Skill DRY | Accepted | 2026-06 |
+| [0020](0020-blueprint-autonomy-levels.md) | Blueprint Autonomy Levels — Ambient Operations via a Manifest-Gated Level Model | Proposed | 2026-07 |
 
 ## Categories
 
@@ -56,6 +57,7 @@ This repository was created by migrating Claude Code plugin configurations from 
 - ADR-0010: Proactive Document Detection
 - ADR-0011: Blueprint State in docs/ Directory
 - ADR-0012: Blog Plugin for Project Documentation
+- ADR-0020: Blueprint Autonomy Levels
 
 ### CI/CD & Infrastructure
 - ADR-0014: Reusable GitHub Workflows in Plugin Repository (Superseded)

--- a/docs/blueprint/README.md
+++ b/docs/blueprint/README.md
@@ -19,7 +19,7 @@ See `manifest.json#task_registry` (each disabled task carries a `context.disable
 | Task | Enabled | Why |
 |------|---------|-----|
 | `adr-validate` | ✓ | Detects orphans, broken `supersedes` chains, and missing domain tags across 16 ADRs |
-| `sync-ids` | ✓ | Reconciles document ID frontmatter; **always run with `--dry-run` first** |
+| `sync-ids` | ✓ | Reconciles document ID frontmatter; **always run with `--dry-run` first**. The deterministic id-registry *sweep* (never assigns IDs) additionally has `auto_run: true` — see Automation below |
 | `feature-tracker-sync` | ✓ | Read-leaning sync against `TODO.md` (no tracker enabled yet) |
 | `story-audit` | ✓ | Read-only audit: capability map ↔ PRD stories ↔ tests, tier-ranked. Writes one dated artifact under `docs/blueprint/audits/` |
 | `story-reconcile` | ✓ | Phase 2 of story-audit. Mutates PRDs only (idempotent inline markers + wholesale `## Known Drift` section); confirms each PRD before writing |
@@ -28,6 +28,18 @@ See `manifest.json#task_registry` (each disabled task carries a `context.disable
 | `generate-rules` | ✗ | No subdirectory output path yet — re-enable once configurable ([#1043](https://github.com/laurigates/claude-plugins/issues/1043)) |
 | `claude-md` | ✗ | "Regenerate completely" prompt is too easy to mis-click |
 | `curate-docs` | ✗ | Default off in blueprint init |
+
+## Automation (autonomy level 1)
+
+The manifest carries an `automation` block (format 3.4.0, ADR-0020) pinned at
+**level 1 — ambient bookkeeping**: the SessionStart probe may execute
+*deterministic* due tasks (currently only the `sync-ids` id-registry sweep,
+which registers existing document IDs and never assigns new ones) and surfaces
+due agent-judgment tasks as drift findings. Levels 2–3 (quiet autopilot,
+scheduled pipeline) stay off here — this repo is the plugin's upstream, and the
+constrained-dogfooding rationale in "Why constrained?" applies doubly to
+autonomous agent execution. `enabled: false` tasks never run at any level, and
+`BLUEPRINT_AUTORUN_DISABLE=1` switches the whole rail off locally.
 
 ## Directory structure
 

--- a/docs/blueprint/manifest.json
+++ b/docs/blueprint/manifest.json
@@ -1,7 +1,7 @@
 {
-  "format_version": "3.3.0",
+  "format_version": "3.4.0",
   "created_at": "2026-04-16T00:00:00Z",
-  "updated_at": "2026-04-16T00:00:00Z",
+  "updated_at": "2026-07-05T00:00:00Z",
   "created_by": {
     "blueprint_plugin": "3.25.2"
   },
@@ -26,6 +26,17 @@
   "custom_overrides": {
     "skills": [],
     "commands": []
+  },
+  "automation": {
+    "autonomy_level": 1,
+    "interaction_mode": "normal",
+    "work_orders": {
+      "auto_draft": false,
+      "auto_execute": false
+    },
+    "context": {
+      "rationale": "Constrained dogfooding stays at level 1: deterministic bookkeeping (sync-ids sweep) may auto-run; agent-judgment tasks only surface as drift findings. Levels 2-3 are for consumer repos (ADR-0020)."
+    }
   },
   "task_registry": {
     "derive-plans": {
@@ -81,12 +92,14 @@
     },
     "sync-ids": {
       "enabled": true,
-      "auto_run": false,
+      "auto_run": true,
       "last_completed_at": null,
       "last_result": null,
-      "schedule": "on-change",
+      "schedule": "weekly",
       "stats": {},
-      "context": {}
+      "context": {
+        "rationale": "Deterministic id-registry sweep (blueprint-autorun.sh). The on-change registration is already handled by the auto-sync-id-registry.sh PostToolUse hook; the weekly runner sweep catches documents added outside Write/Edit (e.g. git operations)."
+      }
     },
     "claude-md": {
       "enabled": false,
@@ -130,5 +143,16 @@
         "rationale": "Phase 2 of the story-audit workflow. Mutates PRD files only (never code), with idempotent inline markers and a wholesale-replaced Known Drift section. Confirms each PRD's edits via AskUserQuestion before writing."
       }
     }
-  }
+  },
+  "upgrade_history": [
+    {
+      "from": "3.3.0",
+      "to": "3.4.0",
+      "date": "2026-07-05T00:00:00Z",
+      "changes": [
+        "Added automation block (autonomy_level 1: ambient bookkeeping)",
+        "sync-ids auto_run enabled as weekly deterministic sweep"
+      ]
+    }
+  ]
 }

--- a/docs/diagrams/plugin-relationships.d2
+++ b/docs/diagrams/plugin-relationships.d2
@@ -78,7 +78,7 @@ core: {
   style.bold: true
 
   blueprint: {
-    label: "blueprint\n33 skills"
+    label: "blueprint\n34 skills"
     shape: hexagon
     style.fill: "#fbbf24"
     style.stroke: "#b45309"

--- a/session-plugin/skills/session-end/SKILL.md
+++ b/session-plugin/skills/session-end/SKILL.md
@@ -66,6 +66,18 @@ failure mode.
 | Taskwarrior sync | `TASK_AVAILABLE=true` AND `OPEN_TASKS` ≥ 1 in the Step 1 digest |
 | Blueprint tracker-sync | `UNDRAINED_COUNT` ≥ 1 in the Step 1 digest's `BLUEPRINT` section. Non-blueprint / tracker-missing repos auto-disqualify (count is 0) → silent skip. If `blueprint-plugin` isn't installed, note it and skip (as with Feedback) |
 
+**Blueprint auto-drain (ADR-0020 level 1):** when the qualifying repo's
+`docs/blueprint/manifest.json` has `automation.autonomy_level` ≥ 1 **and**
+`task_registry["feature-tracker-sync"].auto_run == true`, the Blueprint
+tracker-sync pass is **auto-confirmed**: leave it out of the Step 3 question,
+run it in Step 4 order without asking, and report a one-line receipt in Step 5
+(`Blueprint tracker-sync: drained N WO(s) automatically (auto_run)`). All other
+passes still go through the Step 3 confirmation. Check the gate with:
+
+```sh
+jq -r 'if ((.automation.autonomy_level // 0) >= 1) and (.task_registry["feature-tracker-sync"].auto_run == true) then "auto" else "ask" end' docs/blueprint/manifest.json 2>/dev/null
+```
+
 If **nothing** qualifies, say so in one line and end — no preview, no
 question.
 


### PR DESCRIPTION
## Summary

Makes blueprint operations **ambient** instead of user-initiated, per the tiered autonomy-level model in the new **ADR-0020**. The key discovery: the manifest `task_registry` already carried a dormant automation contract (`auto_run`, `schedule`, `last_completed_at`, `last_result` — and `/blueprint:init` already asks the user how tasks should run) that nothing executed. This PR implements it.

| Level | Name | What runs automatically |
|-------|------|-------------------------|
| 0 | manual | nothing (today's behavior; missing `automation` block ≡ 0) |
| 1 | ambient bookkeeping | deterministic due tasks via `scripts/blueprint-autorun.sh` + SessionStart probe; on-change feature-tracker sync; session-end auto-drain |
| 2 | quiet autopilot | + due agent-judgment tasks in-session via `/blueprint:autopilot`; quiet interaction mode; work-order **draft** proposals |
| 3 | scheduled pipeline | designed in ADR-0020, deliberately deferred |

## What changed (one commit per phase)

- **ADR-0020** (`docs/adrs/0020-blueprint-autonomy-levels.md`) — the level model, manifest 3.4.0 `automation` block, draft-issue side channel, safety rails
- **Level-1 runner** — `blueprint-plugin/scripts/blueprint-autorun.sh` (due-ness engine, deterministic `sync-ids` id-registry sweep, `last_completed_at`/`stats` writeback, `--report` dry-run) + TTL-debounced SessionStart probe emitting drift-aggregator findings for due agent tasks; manifest **format 3.4.0** (additive migration `v3.3-to-v3.4.md`; upgrade/init skills + drift-probe version bumped); dogfooding manifest migrated to level 1
- **On-change sync** — `hooks/sync-feature-tracker.sh` implements the shelf-ready `p1-feature-tracker-auto-sync` hook plan (freshness + statistics refresh only; never creates codes or changes statuses), gated on level ≥ 1; `session-plugin:session-end` auto-confirms the blueprint drain pass when `feature-tracker-sync.auto_run` is set
- **Quiet mode** — `scripts/get-automation-config.sh` + a shared Interaction Mode section in the six menu-ending skills; quiet suppresses closing *navigation* menus only, never write-guarding confirmations; direct slash-command invocation always stays interactive
- **Autopilot + WO auto-draft** — new auto-invocable `/blueprint:autopilot` (level ≥ 2 gate, ≤ 2 tasks + ≤ 2 drafts per pass, no questions, one-line receipt). Work-order *creation stays human-only*: `disable-model-invocation` is preserved on `/blueprint:work-order`; automation may only file `work-order-draft` issues, and `--from-issue N` now promotes them (packet consumed, label swapped, tracker/`id_registry` mutate only at promotion)

Also fixes a latent GNU-stat bug in `blueprint-drift-probe.sh` (`stat -f %m` prints the mount point on Linux, silently breaking the tracker-staleness check).

## Safety rails

- `enabled: false` always wins; `BLUEPRINT_AUTORUN_DISABLE=1` kills levels 1–2 locally
- Probes are read-only + TTL-debounced (`drift-detection-triggering.md`); deterministic auto-apply only on unambiguous facts
- No self-continuing loops: hard per-pass caps, closed-draft veto, draft cap 5 (`loop-integrity.md`)
- 3.3.0 manifests keep working unchanged (missing block = level 0)

## Test plan

- [x] `test-blueprint-autorun.sh` — 23 assertions (due-ness, writeback, report mode, level gating, enabled:false, schedules, opt-out)
- [x] `test-blueprint-autorun-probe.sh` — 15 assertions (level gating, TTL cache, per-task vs autopilot findings, opt-out)
- [x] `test-sync-feature-tracker.sh` — 16 assertions (freshness/stats refresh, unknown codes never created, phases excluded from counts, self-trigger guard, malformed JSON)
- [x] `test-get-automation-config.sh` — 13 assertions (effective-mode resolution, explicit-false jq pitfall)
- [x] `scripts/run-skill-script-tests.sh` — 65 total, 0 failed
- [x] `check-blueprint-upgrade-target.sh`, `plugin-compliance-check.sh`, `lint-context-commands.sh`, `check-docs-index.sh`, `lint-shell-scripts.sh` all green (the one `check-context-command-execution.sh` FAIL is pre-existing in `project-plugin/skills/project-init`, untouched here)

Refs ADR-0020

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y98JSyiJLti5ckFnpBwstw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y98JSyiJLti5ckFnpBwstw)_