### PR TITLE
feat(code-quality-plugin): route code-targeted bulk sweeps through ast-grep

### DIFF
--- a/code-quality-plugin/README.md
+++ b/code-quality-plugin/README.md
@@ -21,7 +21,7 @@ This plugin provides comprehensive code quality tools including automated code r
 | `/code:dep-audit` | Audit dependencies for security vulnerabilities, outdated packages, and license compliance |
 | `/code:test-quality` | Analyze test suite quality — detect test smells, empty assertions, flaky patterns |
 | `/code:complexity` | Analyze code complexity metrics — cyclomatic, cognitive, function length, coupling |
-| `/code-quality:bulk-sweep-classify` | Classify every regex match into four categories before a bulk find-replace/syntax-modernization sweep; scoped transform, allowlist-aware verification |
+| `/code-quality:bulk-sweep-classify` | Route a bulk sweep by target: code renames go through `ast-grep-search` structurally; prose/docs sweeps use the four-category classify-then-transform discipline with allowlist-aware verification |
 | `ast-grep-search` | AST-based code search for structural pattern matching |
 
 ## Agents

--- a/code-quality-plugin/skills/bulk-sweep-classify/SKILL.md
+++ b/code-quality-plugin/skills/bulk-sweep-classify/SKILL.md
@@ -3,8 +3,8 @@ name: bulk-sweep-classify
 description: "Classify every regex match before a bulk find-replace/syntax-modernization sweep — four match categories, scoped transform, allowlist-aware verification. Use when bulk-renaming commands/tools/paths or migrating syntax across many files."
 allowed-tools: Bash, Read, Grep, Edit
 created: 2026-07-05
-modified: 2026-07-05
-reviewed: 2026-07-05
+modified: 2026-07-06
+reviewed: 2026-07-06
 ---
 
 # Bulk Sweep — Classify Every Match First
@@ -25,7 +25,7 @@ before editing.** The regex sees *text*; the transform needs *semantics*.
 
 | Use this skill when... | Use something else instead when... |
 |------------------------|------------------------------------|
-| A find-replace where the delimiter/token also appears in filenames, config keys, URLs, designs, or historical records | The pattern is structural (function shape, call form) → `ast-grep-search` |
+| A find-replace where the delimiter/token also appears in filenames, config keys, URLs, designs, or historical records | The pattern is structural (function shape, call form) → `code-quality-plugin:ast-grep-search`. **Also** when the rename is *textually simple but code-targeted* (an API rename, call-site migration, or import-path change in **source files**): route it through `ast-grep-search` first — structural matching won't touch strings/comments/URLs, so category-2 false positives shrink to near-zero (see the routing step below) |
 | Command-syntax migration (`/ns:cmd` → `/ns-cmd`), tool rename in docs, path/import migration, API-version bump in prose | A one-off literal string search with no look-alike risk → `tools-plugin:rg-code-search` |
 | Docs trees mixing live guidance with ADRs / changelogs / design PRDs, all matching the same regex | The whole match-set is genuinely uniform and you have verified it |
 
@@ -51,6 +51,31 @@ design.
 `Status: Superseded` plus a top-note, leave the body as a historical record.
 
 ## Execution
+
+### Step 0: Route by sweep target — code vs. prose/docs
+
+Before enumerating, decide **what** you are sweeping. This picks the transform
+engine and shrinks the classify workload:
+
+- **Sweep target is code** — an API rename, call-site migration, or import-path
+  change in **source files**. Do the transform *structurally* with
+  `ast-grep -p '<old>' -r '<new>' --lang <l>`, delegating the transform
+  mechanics to `code-quality-plugin:ast-grep-search`. An ast-grep pattern
+  matches **AST nodes**, so it inherently won't match inside strings, comments,
+  or URLs — the whole **category-2 false-positive bucket shrinks to near-zero**.
+  The classify pass then focuses on **categories 3 (designed filenames/paths)
+  and 4 (immutable records) only**, and Steps 1–2's false-positive tightening is
+  largely unnecessary. Proceed to Step 3 with the ast-grep result in hand.
+
+- **Sweep target is prose/docs/mixed** — command renames in markdown, tool names
+  in docs trees, an API-version bump in prose. Regex sees *text*, not semantics,
+  so the **four-category discipline below is unchanged and remains this skill's
+  core case.** Run the full Step 1 → Step 5 pipeline.
+
+The decision hinges on whether a structural matcher *can* see your target: code
+has an AST, prose does not. When in doubt (a rename that spans both source and
+its surrounding docs), split it — ast-grep the source, then run the
+four-category pass over the docs.
 
 Run this classify-then-transform sweep:
 
@@ -96,6 +121,12 @@ matches remain":
 
 Categories 3 and 4 are *supposed* to keep matching. Confirm the grep returns
 **only** the category 2–4 lines you identified in Step 3.
+
+For the **code route** (Step 0), the preserved set is whatever ast-grep's
+structural match legitimately leaves behind — the old form still cited inside
+**strings, comments, or URLs** that the AST matcher never touched. Verify it the
+same way: re-run the enumeration and confirm the only remaining matches are those
+non-code occurrences (plus any categories 3/4), not genuine call sites.
 
 ## The Verification Trap
 

--- a/code-quality-plugin/skills/bulk-sweep-classify/scripts/tests/test-bulk-sweep-classify.sh
+++ b/code-quality-plugin/skills/bulk-sweep-classify/scripts/tests/test-bulk-sweep-classify.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# test-bulk-sweep-classify.sh — semantic regression test for the
+# bulk-sweep-classify skill's code-vs-prose routing (issue #2013).
+#
+# The skill routes code-targeted bulk sweeps (API renames, call-site migrations,
+# import-path changes in source files) through structural matching
+# (`ast-grep`, delegating to `code-quality-plugin:ast-grep-search`) so that the
+# category-2 false-positive bucket (strings/comments/URLs that merely match the
+# text) shrinks to near-zero — while the four-category discipline stays the
+# unchanged core case for prose/docs/mixed sweeps.
+#
+# This test pins the semantic invariants a bulk edit could silently break:
+#   1. The code-vs-prose routing decision appears BEFORE Step 1 (Step 0).
+#   2. The code route delegates transform mechanics to ast-grep-search by name.
+#   3. The four-category discipline is still present (categories 1–4 retained).
+#   4. The Step 5 verification note covers the code route's preserved set
+#      (strings/comments/URLs the structural matcher legitimately leaves).
+#
+# Pure text-invariant checks — no external tooling required.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_FILE="${SCRIPT_DIR}/../../SKILL.md"
+
+pass=0
+fail=0
+
+check() { # check <description> <condition-exit-status>
+    if [ "$1" -eq 0 ]; then
+        pass=$((pass + 1))
+    else
+        fail=$((fail + 1))
+        printf 'FAIL: %s\n' "$2" >&2
+    fi
+}
+
+if [ ! -f "$SKILL_FILE" ]; then
+    echo "FAIL: SKILL.md not found at $SKILL_FILE" >&2
+    exit 1
+fi
+
+# Byte offsets of the anchoring headings, so we can assert ordering.
+routing_line=$(grep -n '^### Step 0: Route by sweep target' "$SKILL_FILE" | head -1 | cut -d: -f1)
+step1_line=$(grep -n '^### Step 1:' "$SKILL_FILE" | head -1 | cut -d: -f1)
+
+# 1. Routing decision exists AND precedes Step 1.
+if [ -n "$routing_line" ] && [ -n "$step1_line" ] && [ "$routing_line" -lt "$step1_line" ]; then
+    check 0 ""
+else
+    check 1 "code-vs-prose routing (Step 0) must appear before Step 1 (routing=${routing_line:-none} step1=${step1_line:-none})"
+fi
+
+# 2. The code route delegates to ast-grep-search by name-based cross-reference.
+grep -q 'code-quality-plugin:ast-grep-search' "$SKILL_FILE"
+check $? "code route must delegate transform mechanics to code-quality-plugin:ast-grep-search"
+
+# The routing text must actually name the structural ast-grep transform.
+grep -q "ast-grep -p '<old>' -r '<new>' --lang" "$SKILL_FILE"
+check $? "code route must show the ast-grep -p/-r structural transform form"
+
+# 3. The four-category discipline is retained (all four categories present).
+grep -q '^## The Four Categories' "$SKILL_FILE"
+check $? "the four-category section heading must remain"
+
+for cat in \
+    '1. Genuine stale target' \
+    '2. False positive' \
+    '3. Out-of-scope design' \
+    '4. Immutable / historical record'; do
+    grep -qF "$cat" "$SKILL_FILE"
+    check $? "category retained: ${cat}"
+done
+
+# The prose/docs route must explicitly keep the four-category discipline.
+grep -qi 'four-category discipline' "$SKILL_FILE"
+check $? "prose/docs route must explicitly retain the four-category discipline"
+
+# 4. Step 5 verification note covers the code route's preserved set.
+grep -qi 'code route' "$SKILL_FILE"
+check $? "Step 5 verification must reference the code route's preserved set"
+
+grep -qi 'strings, comments, or URLs' "$SKILL_FILE"
+check $? "Step 5 must describe the structural-match preserved set (strings/comments/URLs)"
+
+echo "bulk-sweep-classify routing test: ${pass} passed, ${fail} failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary

Adds an explicit routing step to `code-quality-plugin:bulk-sweep-classify` so a
bulk sweep is directed by its target:

- **Code target** (API rename, call-site migration, import-path change in
  source) → transform structurally with `ast-grep -p '<old>' -r '<new>'
  --lang <l>`, delegating mechanics to `code-quality-plugin:ast-grep-search`.
  Structural matching won't touch strings/comments/URLs, so category-2 false
  positives shrink to near-zero and the classify pass focuses on categories 3
  (designed filenames/paths) and 4 (immutable records) only.
- **Prose/docs/mixed target** → the existing four-category classify-then-
  transform discipline is unchanged and explicitly retained as the core case.

Also:
- Sharpened the When-to-Use row so a *textually simple but code-targeted* rename
  also prefers the structural route.
- Updated the Step 5 verification note so the code route's preserved set (old
  form left in strings/comments/URLs) is verified the same way.
- Updated the plugin README skill entry in the same commit (docs-currency).

## Regression guard

`code-quality-plugin/skills/bulk-sweep-classify/scripts/tests/test-bulk-sweep-classify.sh`
(run by `just test-skill-scripts`) asserts the semantic invariants: the routing
decision precedes Step 1, the code route delegates to `ast-grep-search` by name
and shows the `ast-grep -p/-r` form, all four categories remain, the prose route
retains the four-category discipline, and Step 5 covers the code-route preserved
set. 11 checks pass.

## Verification

- `just test-skill-scripts` (scoped): 1 passed, 0 failed
- `just lint-context-commands`: all context commands OK
- Pre-commit hooks: passed (only advisory README-currency nudge, addressed)
- SKILL.md size: 8,559 chars (OK band)

Closes #2013

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYeX8HpTsjhYz5LChFmdVg