### PR TITLE
feat(code-quality-plugin): offload dry-consolidation discovery to jscpd + ast-grep

### DIFF
--- a/code-quality-plugin/README.md
+++ b/code-quality-plugin/README.md
@@ -80,6 +80,7 @@ Refactors code applying functional programming principles:
 ```
 
 Finds and extracts duplicated code into shared abstractions:
+- Discovers clones deterministically with `jscpd` (token-based, 150+ languages) plus `ast-grep` shape confirmation, falling back to Grep when `npx`/`jscpd` is unavailable
 - Utility functions (string helpers, formatters, validators)
 - UI components (dialogs, pagination, error states)
 - Custom hooks (delete confirmation, form state, mutations)

--- a/code-quality-plugin/skills/dry-consolidation/SKILL.md
+++ b/code-quality-plugin/skills/dry-consolidation/SKILL.md
@@ -2,11 +2,11 @@
 name: dry-consolidation
 description: Find and extract duplicated code into shared abstractions. Use when seeing repeated utilities, copy-pasted components, duplicated hooks, or boilerplate repeated across files.
 args: "[PATH] [--scope <utilities|components|hooks|all>] [--dry-run]"
-allowed-tools: Read, Write, Edit, MultiEdit, Grep, Glob, Bash(npx tsc *), Bash(npm run *), Bash(npx *), Bash(bun *), Bash(pnpm *), Bash(yarn *), Bash(pytest *), Bash(cargo *), TodoWrite, Task
+allowed-tools: Read, Write, Edit, MultiEdit, Grep, Glob, Bash(npx tsc *), Bash(npm run *), Bash(npx *), Bash(bun *), Bash(pnpm *), Bash(yarn *), Bash(pytest *), Bash(cargo *), Bash(ast-grep *), Bash(sg *), TodoWrite, Task
 model: opus
 argument-hint: path or directory to scan for duplication
 created: 2026-02-06
-modified: 2026-07-04
+modified: 2026-07-06
 reviewed: 2026-02-06
 agent: general-purpose
 context: fork
@@ -24,6 +24,7 @@ Systematic extraction of duplicated code into shared, tested abstractions.
 | Copy-pasted utility functions across components | Looking for anti-patterns without fixing → `/code:antipatterns` |
 | Repeated UI patterns (dialogs, pagination, error states) | Functional refactoring of a file or directory → `/code:refactor` |
 | Duplicated hooks or state management boilerplate | Structural code search only → `ast-grep-search` |
+| Near-duplicate copy-paste with renamed vars needs enumerating (jscpd finds the clusters here) | Matching one known structural pattern → `ast-grep-search` |
 | Import blocks are bloated from repeated inline patterns | Linting/formatting issues → `/lint:check` |
 
 ## Context
@@ -44,27 +45,63 @@ Systematic extraction of duplicated code into shared, tested abstractions.
 
 Execute this 7-step consolidation workflow. Use TodoWrite to track each extraction as a separate task.
 
-### Step 1: Scan for duplicated patterns
+### Step 1: Discover duplicate clusters (deterministic clone detection)
 
-Scan the target path for duplicated patterns. Search for these duplication signals:
+Enumerate duplicate ranges with a deterministic clone detector, then read **only the reported ranges** — not whole candidate files. This keeps discovery reproducible and cheap. Token-based detection (jscpd) finds copy-paste independent of whitespace/formatting and of the enclosing symbol name — clone pairs a name-based Grep misses when the wrapping function is renamed. ast-grep (1b) then adds tolerance for variables renamed *inside* the block.
 
-**Identical function bodies:**
+#### 1a. Token-based near-duplicates with jscpd
+
+`jscpd` is a token-based copy/paste detector that supports 150+ languages despite the "js" in the name; `npx` runs it with no global install. Run it over the target path:
+
+```bash
+npx jscpd --reporters json --min-tokens 50 --output /tmp/jscpd-dry --silent <path>
 ```
-Grep for function/method signatures that appear in multiple files.
-Look for identical multi-line blocks (3+ lines) across files.
+
+It writes `/tmp/jscpd-dry/jscpd-report.json`. Read that report and parse its `duplicates` array — each entry gives the exact file/line ranges of a clone pair plus its size in tokens/lines:
+
+```json
+{
+  "duplicates": [
+    {
+      "format": "tsx",
+      "lines": 12,
+      "tokens": 84,
+      "firstFile":  { "name": "src/UserList.tsx",  "start": 20, "end": 32 },
+      "secondFile": { "name": "src/OrderList.tsx", "start": 15, "end": 27 }
+    }
+  ],
+  "statistics": { "total": { "clones": 3, "duplicatedLines": 40, "duplicatedTokens": 252, "percentage": 5.1 } }
+}
 ```
 
-**Repeated inline patterns:**
+For each reported clone, **Read only the line ranges** (`Read` with `offset`/`limit` around `start`/`end`) to confirm the duplication and classify it — do not Read whole candidate files. jscpd similarity is high by construction for a reported clone (a `--min-tokens` match); note the tokens/lines for the Extraction Plan.
+
+#### 1b. Structural confirmation with ast-grep
+
+Once jscpd surfaces a cluster, confirm it is the same *shape* — same call-shape / same block modulo captured variables — with ast-grep metavariables. `$VAR` / `$INIT` match any identifier/expression, so a block differing only in renamed captures still matches:
+
+```bash
+ast-grep -p 'const $VAR = useState($INIT)' --lang tsx <path>
+```
+
+Use this to separate a genuine extractable duplicate from a coincidental token overlap before planning the extraction. (For a standalone structural search without extraction, use the `ast-grep-search` skill.)
+
+#### 1c. Graceful fallback (Grep) when the detector is unavailable
+
+When `npx`/`jscpd` is unavailable, or the ecosystem has no `npx` on PATH, fall back to agent-driven text search:
+
+1. Use Grep to find repeated function names, variable patterns, and import clusters
+2. Use Glob to identify files with similar structure (e.g., all `*List.tsx`, all `*Detail.tsx`)
+3. Read candidate files to confirm duplication and measure scope
+
+This fallback has lower recall for near-duplicates (renamed variables, reordered params) — prefer the jscpd path when available, and reserve Grep for when it is not.
+
+**Duplication signals to classify** (both the jscpd and the Grep path feed the same categories in Step 2):
 - Utility functions defined identically in multiple files (string truncation, date formatting, validation)
 - Identical error handling blocks (try/catch patterns, error state JSX)
 - Copy-pasted UI fragments (pagination controls, confirmation dialogs, loading states)
 - Repeated hook/state management patterns (delete confirmation + mutation + handler)
 - Duplicated import blocks that signal repeated inline implementations
-
-**Search strategy:**
-1. Use Grep to find repeated function names, variable patterns, and import clusters
-2. Use Glob to identify files with similar structure (e.g., all `*List.tsx`, all `*Detail.tsx`)
-3. Read candidate files to confirm duplication and measure scope
 
 ### Step 2: Classify duplications
 
@@ -100,8 +137,12 @@ Present the plan to the user before proceeding (unless `--dry-run` was not speci
 - Replaces: [N] identical blocks across [M] files
 - Consumers: [list of files]
 - Parameters: [any variations that need to be parameterized]
+- Duplicated: [N] tokens / [N] lines (from jscpd; blank when the Grep fallback was used)
+- Similarity: [N]% (from jscpd; "exact" when ast-grep-confirmed as the same shape)
 - Estimated lines saved: [N]
 ```
+
+The `Duplicated` and `Similarity` fields come from jscpd's report (tokens/lines per clone, and the cluster's percentage) — a quantified `--dry-run` report instead of a best-effort narrative. When the Grep fallback (1c) supplied the cluster, leave them blank or note "grep-estimated".
 
 ### Step 4: Extract shared abstractions
 
@@ -192,6 +233,8 @@ After all phases complete, report:
 
 | Context | Approach |
 |---------|----------|
+| Deterministic clone scan | `npx jscpd --reporters json --min-tokens 50 --output /tmp/jscpd-dry --silent <path>` then parse `duplicates[]` for exact ranges |
+| Structural shape confirm | `ast-grep -p '<pattern with $METAVARS>' --lang <lang> <path>` |
 | Quick scan | Use `--dry-run` to see duplication report without changes |
 | Focused extraction | Use `--scope utilities` to extract only utility functions |
 | Large codebase | Scope to specific directory: `/code:dry-consolidation src/components/` |

--- a/code-quality-plugin/skills/dry-consolidation/scripts/tests/test-dry-consolidation.sh
+++ b/code-quality-plugin/skills/dry-consolidation/scripts/tests/test-dry-consolidation.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Regression test for dry-consolidation Step 1 clone-detection offload (issue #2012).
+#
+# Semantic invariants (not just a parse check): a future bulk edit that
+# "tightens" the skill could silently revert Step 1 from the deterministic
+# jscpd + ast-grep clone detector back to the old agent-driven Grep-only scan,
+# or drop the quantified Extraction Plan fields. This guards all three:
+#   1. Step 1 invokes jscpd (the token-based clone detector).
+#   2. Step 1 uses ast-grep for structural shape confirmation.
+#   3. Step 1 retains the graceful Grep fallback for when npx/jscpd is absent.
+#   4. The Extraction Plan format gained the quantified fields (tokens/lines
+#      duplicated + similarity) sourced from jscpd's report.
+#
+# Exit 0 on success, non-zero on failure.
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+skill_md="${script_dir}/../../SKILL.md"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+pass() {
+  echo "PASS: $1"
+}
+
+[ -f "$skill_md" ] || fail "SKILL.md not found at $skill_md"
+
+body="$(cat "$skill_md")"
+
+# 1. jscpd is the clone-detection engine of Step 1.
+grep -q 'npx jscpd' <<<"$body" \
+  || fail "Step 1 no longer invokes 'npx jscpd' (clone detection reverted?)"
+grep -q -- '--reporters json' <<<"$body" \
+  || fail "jscpd invocation dropped '--reporters json' (JSON report is what the agent parses)"
+pass "Step 1 invokes jscpd with a JSON report"
+
+# 2. ast-grep confirms structural shape (rename-tolerant, modulo captured vars).
+grep -q 'ast-grep -p' <<<"$body" \
+  || fail "Step 1 lost the 'ast-grep -p' structural-confirmation step"
+pass "Step 1 uses ast-grep for structural shape confirmation"
+
+# 3. The graceful Grep fallback survives (non-JS / no-npx ecosystems).
+grep -qi 'fallback' <<<"$body" \
+  || fail "Step 1 lost its graceful fallback path"
+grep -q 'Use Grep to find repeated function names' <<<"$body" \
+  || fail "Step 1 lost the Grep fallback search strategy"
+pass "Step 1 retains the graceful Grep fallback"
+
+# 4. Extraction Plan gained the quantified fields from jscpd's report.
+grep -q '^- Duplicated:.*tokens.*lines' <<<"$body" \
+  || fail "Extraction Plan lost the 'Duplicated: N tokens / N lines' quantified field"
+grep -q '^- Similarity:' <<<"$body" \
+  || fail "Extraction Plan lost the 'Similarity' quantified field"
+pass "Extraction Plan carries the quantified tokens/lines/similarity fields"
+
+echo "ALL PASS: dry-consolidation jscpd offload invariants intact"


### PR DESCRIPTION
## Summary

Replaces `dry-consolidation` Step 1 (duplicate **discovery**) — previously agent-driven Grep/Glob/whole-file-Read — with a deterministic clone detector, keeping Steps 2–7 (naming the abstraction, interface, parameterizing variants) unchanged.

- **1a — jscpd**: `npx jscpd --reporters json --min-tokens 50` enumerates clone pairs with exact file/line ranges + tokens/lines/percentage. The agent reads **only the reported ranges** (Read offset/limit), never whole candidate files. jscpd supports 150+ languages despite the name; `npx` needs no global install.
- **1b — ast-grep**: `ast-grep -p` with metavariables confirms same-shape-modulo-captured-vars once a cluster surfaces (the rename-tolerant half jscpd's token-exact matcher can't do).
- **1c — graceful Grep fallback**: when `npx`/`jscpd` is unavailable or the ecosystem has no `npx` on PATH, falls back to the original agent-driven text search.
- **Extraction Plan** gains quantified fields (`Duplicated: N tokens / N lines`, `Similarity: N%`) from jscpd's report — a real `--dry-run` report instead of a narrative.
- **When-to-Use** table gains the jscpd/ast-grep division of labor; **Agentic Optimizations** gains jscpd + ast-grep rows.

## Acceptance criteria

- [x] Step 1 uses jscpd with graceful fallback to Grep when unavailable / non-JS-no-npx
- [x] Agent reads only reported duplicate ranges, not whole files
- [x] Extraction Plan gained the quantified fields (tokens/lines, similarity)
- [x] When-to-Use table updated with the jscpd division of labor

## Regression guard

`code-quality-plugin/skills/dry-consolidation/scripts/tests/test-dry-consolidation.sh` (auto-discovered by `just test-skill-scripts`) is a **semantic** gate: it asserts Step 1 invokes `npx jscpd` with a JSON report, uses `ast-grep -p`, retains the Grep fallback, and that the Extraction Plan keeps the `Duplicated`/`Similarity` quantified fields — so a future bulk edit can't silently revert the offload.

## Verification

- `just test-skill-scripts` — new test + siblings green (TOTAL=4, FAILED=0)
- `just lint-context-commands` — all context commands OK
- jscpd JSON shape confirmed via a sample-dir run (`duplicates[].{format,lines,tokens,firstFile{name,start,end},secondFile{...}}`, `statistics.total.{clones,duplicatedLines,duplicatedTokens,percentage}`)
- pre-commit gates passed on commit

Closes #2012

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYeX8HpTsjhYz5LChFmdVg