### PR TITLE
feat(code-quality-plugin): offload code-complexity metrics to lizard

### DIFF
--- a/code-quality-plugin/skills/code-complexity/SKILL.md
+++ b/code-quality-plugin/skills/code-complexity/SKILL.md
@@ -3,11 +3,11 @@ name: code-complexity
 description: Analyze code complexity metrics (cyclomatic, cognitive, function length, coupling). Use when identifying refactoring targets, tracking codebase health, or reviewing large changes.
 args: "[PATH] [--threshold <number>] [--format <summary|detailed|json>]"
 argument-hint: path or directory to analyze for complexity
-allowed-tools: Bash(npx *), Bash(radon *), Bash(cargo *), Read, Grep, Glob, TodoWrite
+allowed-tools: Bash(npx *), Bash(radon *), Bash(cargo *), Bash(lizard *), Read, Grep, Glob, TodoWrite
 model: opus
 created: 2026-04-10
-modified: 2026-05-04
-reviewed: 2026-04-10
+modified: 2026-07-06
+reviewed: 2026-07-06
 ---
 
 # /code:complexity
@@ -34,26 +34,78 @@ Measure and report code complexity metrics.
 - `--threshold`: Complexity threshold for flagging (default: 10)
 - `--format`: Output format — `summary` (default), `detailed`, `json`
 
+## Metric Computation: Offload, Never Count By Hand
+
+Complexity metrics (cyclomatic complexity, NLOC, parameter count, function
+length, nesting depth) are **computed by a tool**, never by eyeballing function
+boundaries or counting branches by hand. Hand-counting is token-hungry,
+irreproducible run-to-run, and exactly the mechanical work that belongs in a
+deterministic substrate.
+
+- **Language-native fast paths** (use when the project already has them
+  configured): `radon` for Python, `cargo clippy` for Rust, the ESLint
+  `complexity` rule for JS/TS when an ESLint config exists.
+- **`lizard` — the uniform fallback for every language.** One tool computes
+  cyclomatic complexity (CCN), NLOC, parameter count (PARAM), function length,
+  and nesting depth (ND) across JS/TS/Go/Python/Rust/C/C++/Java with
+  machine-readable output. It is the deterministic answer wherever a
+  language-native tool is absent — always the JS/TS and Go path when ESLint
+  complexity isn't configured.
+
+### Install lizard (tool-installation priority)
+
+```bash
+uv tool install lizard
+```
+
+Alternative: `mise use -g pipx:lizard` (mise `pipx:` backend, runs via uvx).
+
 ## Execution
 
 Execute this complexity analysis:
 
 ### Step 1: Detect project language and available tools
 
-Check for language-specific complexity tools:
-- JavaScript/TypeScript: Check for `eslint` with complexity rule, or use manual AST analysis
-- Python: Check for `radon` (cyclomatic + maintainability index)
-- Rust: Use `cargo clippy` cognitive complexity warnings
-- Go: Use manual function length analysis
+Check for language-specific complexity tools, falling back to `lizard`:
+
+- **JavaScript/TypeScript**: use the ESLint `complexity` rule when an ESLint
+  config is present; otherwise use `lizard`.
+- **Python**: use `radon` (cyclomatic + maintainability index); `lizard` is a
+  fallback if `radon` is unavailable.
+- **Rust**: use `cargo clippy` cognitive-complexity warnings; `lizard` is a
+  fallback.
+- **Go**: use `lizard`.
+- **Any other language / no native tool**: use `lizard`.
+
+Confirm `lizard` is installed (`uv tool install lizard`) before using the
+fallback path.
 
 ### Step 2: Measure function-level complexity
 
-**JavaScript/TypeScript:**
+**JavaScript/TypeScript (ESLint complexity rule, when configured):**
 
-Analyze files for:
-- Cyclomatic complexity via ESLint: `npx eslint --rule '{"complexity": ["warn", 1]}' --format json`
-- Function length (count lines between function boundaries)
-- Nesting depth (count nested blocks)
+```bash
+npx eslint --rule '{"complexity":["warn",1]}' --format json .
+```
+
+**JavaScript/TypeScript, Go, or any language without a native tool (lizard):**
+
+```bash
+# Warnings only — one line per function exceeding the CCN threshold
+lizard -C 10 --warnings_only .
+
+# Full machine-readable metrics for every function (CSV)
+lizard --csv .
+```
+
+`lizard` emits, per function: NLOC, CCN (cyclomatic complexity), token count,
+PARAM (parameter count), length, and ND (nesting depth) — the complete metric
+set, so no branch counting or line counting is done by hand. Restrict to a
+language when needed with `-l js`, `-l typescript`, `-l go`, etc. The
+`--warnings_only` run exits non-zero when any function exceeds the threshold.
+
+**CSV column order** (for `lizard --csv`): `NLOC, CCN, token, PARAM, length,
+location, file, function, long_name, start_line, end_line`.
 
 **Python (Radon):**
 ```bash
@@ -65,14 +117,6 @@ radon mi ${1:-.} -s
 ```bash
 cargo clippy -- -W clippy::cognitive_complexity
 ```
-
-**Manual analysis (all languages):**
-
-When dedicated tools are unavailable, scan source files directly:
-1. Count function/method definitions
-2. Measure lines per function
-3. Count control flow branches (if/else/switch/match/for/while)
-4. Measure nesting depth
 
 ### Step 3: Identify hotspots
 
@@ -94,6 +138,10 @@ For each source file:
 - Maximum complexity function
 - Lines of code vs lines of logic
 - Import/dependency count (coupling indicator)
+
+The `lizard` default (non-CSV) run already prints per-file NLOC, average NLOC,
+average CCN, average token count, and function count — use it for the file-level
+roll-up.
 
 ### Step 5: Report results
 
@@ -123,15 +171,18 @@ Recommendations:
 ## Post-Actions
 
 - If many high-complexity functions → suggest `/code:refactor` for the worst offenders
-- If complexity tools not installed → suggest `pip install radon` or equivalent
+- If complexity tools not installed → suggest `uv tool install lizard` (uniform, all languages) or `pip install radon` (Python)
 - If setting up complexity budgets → suggest adding ESLint complexity rule via `/configure:linting`
 
 ## Agentic Optimizations
 
 | Context | Command |
 |---|---|
+| Uniform CCN warnings (all languages) | `lizard -C 10 --warnings_only .` |
+| Uniform full metrics (machine-readable) | `lizard --csv .` |
+| JS/TS only via lizard | `lizard -l javascript -l typescript -C 10 --warnings_only .` |
+| Go only via lizard | `lizard -l go -C 10 --warnings_only .` |
 | Python cyclomatic | `radon cc . -s -a --min B -j` |
 | Python maintainability | `radon mi . -s -j` |
-| JS/TS complexity | `npx eslint --rule '{"complexity":["warn",1]}' --format json .` |
+| JS/TS complexity (ESLint, when configured) | `npx eslint --rule '{"complexity":["warn",1]}' --format json .` |
 | Rust cognitive | `cargo clippy -- -W clippy::cognitive_complexity 2>&1` |
-| Quick file length scan | Glob for source files, Read and count function lengths |

--- a/code-quality-plugin/skills/code-complexity/scripts/tests/test-code-complexity.sh
+++ b/code-quality-plugin/skills/code-complexity/scripts/tests/test-code-complexity.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# test-code-complexity.sh — semantic regression test for the code-complexity
+# skill's lizard offload (issue #2011).
+#
+# Before #2011 the JS/TS and Go paths instructed the agent to "use manual AST
+# analysis" / "manual function length analysis" and to "count lines between
+# function boundaries" / count nesting depth by hand — token-hungry,
+# irreproducible work that belongs in a deterministic tool
+# (`.claude/rules/offload-to-deterministic-substrate.md`). The fix routes JS/TS
+# and Go (and every non-native-tool language) through `lizard`.
+#
+# This test encodes the SEMANTIC invariant, not a bare parse check:
+#   1. the SKILL.md no longer instructs manual AST / manual function-length /
+#      hand line-counting / hand nesting-depth analysis (outside blockquotes,
+#      which may cite the banned forms as gotchas);
+#   2. the SKILL.md references `lizard` with machine-readable flags
+#      (`--warnings_only` and `--csv`), and the uniform `-C <n> --warnings_only`
+#      invocation the Agentic Optimizations table advertises;
+#   3. when `lizard` is installed, it actually computes CCN/NLOC/PARAM/length on
+#      a JS and a Go sample and its documented flags behave as the SKILL claims
+#      (the tool exists, the flags are real, the CSV column set is present) —
+#      closing the syntactic-vs-semantic gap. SKIPs the exec checks cleanly when
+#      lizard is unavailable.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_FILE="${SCRIPT_DIR}/../../SKILL.md"
+
+pass=0
+fail=0
+check() { # check <description> <expected> <actual>
+    if [ "$2" = "$3" ]; then
+        pass=$((pass + 1))
+    else
+        fail=$((fail + 1))
+        printf 'FAIL: %s\n  expected: %s\n  actual:   %s\n' "$1" "$2" "$3" >&2
+    fi
+}
+
+# Non-blockquote view of the SKILL.md: gotcha callouts (lines starting with `>`)
+# may legitimately cite the banned "manual" phrasing; the actual instructions
+# must not. Matches the repo's hyphenated-tag / mcp-tool lint convention.
+body_no_quotes() { grep -v '^[[:space:]]*>' "$SKILL_FILE"; }
+
+# --- 1. The manual-analysis instructions are gone (outside callouts) ---
+for phrase in \
+    "manual AST analysis" \
+    "manual function length analysis" \
+    "count lines between function boundaries"; do
+    if body_no_quotes | grep -qi "$phrase"; then
+        check "manual instruction removed: '$phrase'" "absent" "present"
+    else
+        check "manual instruction removed: '$phrase'" "absent" "absent"
+    fi
+done
+
+# --- 2. lizard is referenced with machine-readable flags ---
+if grep -q 'lizard' "$SKILL_FILE"; then
+    check "SKILL.md references lizard" "present" "present"
+else
+    check "SKILL.md references lizard" "present" "absent"
+fi
+for flag in "\-\-warnings_only" "\-\-csv" "\-C 10 \-\-warnings_only"; do
+    if grep -Eq "lizard.*${flag}|${flag}" "$SKILL_FILE"; then
+        check "SKILL.md documents lizard flag: '${flag//\\/}'" "present" "present"
+    else
+        check "SKILL.md documents lizard flag: '${flag//\\/}'" "present" "absent"
+    fi
+done
+
+# JS/TS and Go must be routed to lizard, not to hand analysis.
+if grep -Eqi 'go.*lizard|lizard.*go' "$SKILL_FILE"; then
+    check "Go path routed to lizard" "present" "present"
+else
+    check "Go path routed to lizard" "present" "absent"
+fi
+
+# --- 3. Execute lizard to confirm the documented behaviour (SKIP if absent) ---
+if ! command -v lizard >/dev/null 2>&1; then
+    echo "SKIP: lizard CLI not available (install: uv tool install lizard)" >&2
+else
+    SCRATCH="$(mktemp -d)"
+    [ -n "$SCRATCH" ] || { echo "mktemp failed" >&2; exit 1; }
+    trap 'rm -rf "$SCRATCH"' EXIT
+
+    cat > "$SCRATCH/sample.js" <<'JS'
+function complex(a, b, c) {
+  if (a) {
+    if (b) {
+      for (let i = 0; i < c; i++) {
+        if (i % 2) { console.log(i); } else { console.log(-i); }
+      }
+    } else if (c) { return b; }
+  }
+  return a;
+}
+JS
+    cat > "$SCRATCH/sample.go" <<'GO'
+package main
+func Complex(a, b, c int) int {
+  if a > 0 {
+    if b > 0 {
+      for i := 0; i < c; i++ {
+        if i%2 == 0 { return i } else { return -i }
+      }
+    }
+  }
+  return a
+}
+GO
+
+    # --warnings_only reports the over-threshold functions from BOTH languages.
+    warn_out="$(lizard -C 3 --warnings_only "$SCRATCH/sample.js" "$SCRATCH/sample.go" 2>/dev/null)"
+    if grep -q 'sample.js' <<<"$warn_out" && grep -q 'CCN' <<<"$warn_out"; then
+        check "lizard --warnings_only reports JS CCN" "yes" "yes"
+    else
+        check "lizard --warnings_only reports JS CCN" "yes" "no"
+    fi
+    if grep -q 'sample.go' <<<"$warn_out"; then
+        check "lizard --warnings_only reports Go function" "yes" "yes"
+    else
+        check "lizard --warnings_only reports Go function" "yes" "no"
+    fi
+
+    # --csv produces machine-readable rows with the documented column set.
+    csv_out="$(lizard --csv "$SCRATCH/sample.js" "$SCRATCH/sample.go" 2>/dev/null)"
+    js_row="$(grep 'sample.js' <<<"$csv_out" | grep 'complex' | head -1)"
+    # Columns: NLOC,CCN,token,PARAM,length,location,file,function,long_name,start,end
+    ccn="$(cut -d, -f2 <<<"$js_row")"
+    param="$(cut -d, -f4 <<<"$js_row")"
+    if [ "$ccn" -ge 3 ] 2>/dev/null; then
+        check "lizard --csv reports numeric CCN (>=3) for complex fn" "yes" "yes"
+    else
+        check "lizard --csv reports numeric CCN (>=3) for complex fn" "yes" "got:'$ccn'"
+    fi
+    if [ "$param" = "3" ]; then
+        check "lizard --csv reports PARAM count (3)" "yes" "yes"
+    else
+        check "lizard --csv reports PARAM count (3)" "yes" "got:'$param'"
+    fi
+fi
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary

Replaces the manual/by-eye AST and line-counting instructions in the `code-quality-plugin:code-complexity` skill with a `lizard` offload.

Before this change the Python (radon) and Rust (clippy) paths offloaded properly, but the **JS/TS** and **Go** paths instructed the agent to "use manual AST analysis" / "manual function length analysis" and to "count lines between function boundaries" / count nesting depth by hand — token-hungry, irreproducible run-to-run work that belongs in a deterministic tool (`offload-to-deterministic-substrate.md`).

## Changes

- Route JS/TS, Go, and every language without a native tool through **`lizard`** (`uv tool install lizard`; mise `pipx:` backend as alternative). One tool computes CCN, NLOC, PARAM, function length, and nesting depth across JS/TS/Go/Python/Rust/C/C++/Java with machine-readable `--warnings_only` / `--csv` output.
- Keep the language-native fast paths (radon, clippy, ESLint `complexity` rule when configured) and use lizard as the uniform fallback — replacing **every** manual-analysis branch (JS/TS and Go).
- Update the Agentic Optimizations table with the compact lizard invocations (`lizard -C 10 --warnings_only`, `lizard --csv`).
- Install guidance follows the tool-installation priority (`uv tool install` → mise pipx backend).

## Acceptance criteria

- [x] No execution step instructs manual/by-eye AST or line counting
- [x] JS/TS and Go paths use lizard with machine-readable output
- [x] Agentic Optimizations table updated with the lizard invocations
- [x] Install guidance follows the tool-installation priority

## Regression guard

`code-quality-plugin/skills/code-complexity/scripts/tests/test-code-complexity.sh` — a **semantic** guard: asserts the SKILL.md no longer instructs manual AST / manual function-length / hand line-counting for JS/TS/Go (outside gotcha blockquotes) and references lizard with machine-readable flags; when lizard is installed it also **executes** it on JS + Go samples to confirm the documented `--warnings_only`/`--csv` flags and CCN/PARAM columns behave as claimed. Verified installed and run against real samples (lizard 1.23.0).

## Verification

- `just test-skill-scripts` — 66/66 pass (new test included)
- `just lint-context-commands` on the skill — clean

Closes #2011