### PR TITLE
feat(code-quality-plugin): ship code-antipatterns + hidden-failures catalogs as ast-grep rule projects

### DIFF
--- a/.github/workflows/test-skill-scripts.yml
+++ b/.github/workflows/test-skill-scripts.yml
@@ -49,6 +49,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      # ast-grep powers the code-antipatterns / code-hidden-failures rule-project
+      # regression tests (issue #2010). Absent, those tests SKIP; installed, the
+      # `ast-grep test` fixture gate actually runs in CI. Pinned to match the
+      # version the fixtures were authored against.
+      - name: Install ast-grep
+        run: npm install -g @ast-grep/cli@0.43.0
+
       - name: Run skill-local regression tests
         run: bash scripts/run-skill-script-tests.sh
 

--- a/code-quality-plugin/skills/code-antipatterns/REFERENCE.md
+++ b/code-quality-plugin/skills/code-antipatterns/REFERENCE.md
@@ -1,610 +1,74 @@
 # Code Anti-patterns Reference
 
-Comprehensive ast-grep pattern library for detecting anti-patterns across languages.
-
-## JavaScript/TypeScript Patterns
-
-### Async Anti-patterns
-
-```yaml
-# Unhandled Promise - missing catch
-id: unhandled-promise
-language: JavaScript
-severity: high
-message: Promise chain missing error handler
-rule:
-  pattern: $EXPR.then($HANDLER)
-  not:
-    follows:
-      pattern: .catch($$$)
-note: Add .catch() or use try/catch with await
----
-# Promise constructor anti-pattern
-id: promise-constructor-antipattern
-language: JavaScript
-severity: medium
-message: Unnecessary Promise wrapper around async code
-rule:
-  pattern: new Promise(($RESOLVE, $REJECT) => { $ASYNC_CALL.then($$$) })
-fix: $ASYNC_CALL
----
-# Floating promise (missing await)
-id: floating-promise
-language: TypeScript
-severity: high
-message: Promise result not awaited or handled
-rule:
-  pattern: $ASYNC_FUNC($$$)
-  not:
-    any:
-      - inside:
-          pattern: await $$$
-      - inside:
-          pattern: return $$$
-      - inside:
-          pattern: $VAR = $$$
-```
-
-### Error Handling
-
-```yaml
-# Empty catch block
-id: no-empty-catch
-language: JavaScript
-severity: warning
-message: Empty catch block silently swallows errors
-rule:
-  pattern: try { $$$ } catch ($E) { }
-fix: |
-  try { $$$ } catch ($E) {
-    console.error($E);
-    throw $E;
-  }
----
-# Catch without error parameter
-id: catch-without-error
-language: JavaScript
-severity: info
-message: Consider logging the caught error
-rule:
-  pattern: catch { $$$ }
----
-# Generic error catch
-id: generic-error-catch
-language: TypeScript
-severity: info
-message: Consider catching specific error types
-rule:
-  pattern: catch ($E: Error) { $$$ }
-```
-
-### Code Smell Patterns
-
-```yaml
-# Magic numbers
-id: no-magic-numbers
-language: JavaScript
-severity: info
-message: Consider extracting magic number to named constant
-rule:
-  any:
-    - pattern: if ($VAR > 100)
-    - pattern: if ($VAR < 50)
-    - pattern: if ($VAR === 42)
-    - pattern: setTimeout($$$, 5000)
-    - pattern: setInterval($$$, 1000)
-constraints:
-  # Exclude common acceptable values
-  VAR:
-    not:
-      regex: '^(0|1|-1|100)$'
----
-# Long parameter list
-id: long-parameter-list
-language: JavaScript
-severity: medium
-message: Consider using an options object for many parameters
-rule:
-  pattern: function $NAME($A, $B, $C, $D, $E, $$$) { $$$ }
-note: Functions with more than 4 parameters are hard to use correctly
----
-# Nested ternary
-id: no-nested-ternary
-language: JavaScript
-severity: medium
-message: Nested ternary is hard to read
-rule:
-  pattern: $A ? $B : $C
-  has:
-    pattern: $X ? $Y : $Z
-```
-
-### Deprecated Patterns
-
-```yaml
-# var usage
-id: no-var
-language: JavaScript
-severity: info
-message: Use let or const instead of var
-rule:
-  pattern: var $VAR = $$$
-fix: const $VAR = $$$
----
-# arguments object
-id: no-arguments
-language: JavaScript
-severity: info
-message: Use rest parameters instead of arguments
-rule:
-  pattern: arguments[$INDEX]
----
-# Function constructor
-id: no-function-constructor
-language: JavaScript
-severity: error
-message: Function constructor is equivalent to eval
-rule:
-  pattern: new Function($$$)
-```
-
-## Vue 3 Patterns
-
-### Reactivity Issues
-
-```yaml
-# Props mutation
-id: vue-props-mutation
-language: JavaScript
-severity: error
-message: Never mutate props directly
-rule:
-  pattern: props.$PROP = $VALUE
-note: |
-  Use emit('update:propName', value) or create a local copy:
-  const localProp = ref(props.propName)
----
-# Destructuring reactive state
-id: vue-reactive-destructure
-language: JavaScript
-severity: high
-message: Destructuring reactive state loses reactivity
-rule:
-  pattern: const { $$$PROPS } = $REACTIVE_VAR
-  inside:
-    pattern: const $REACTIVE_VAR = reactive($$$)
-fix: const { $$$PROPS } = toRefs($REACTIVE_VAR)
----
-# Watch without immediate or deep when needed
-id: vue-watch-options
-language: JavaScript
-severity: info
-message: Consider if watch needs immediate or deep options
-rule:
-  pattern: watch($SOURCE, $CALLBACK)
-  not:
-    has:
-      pattern: watch($SOURCE, $CALLBACK, { $$$ })
-```
-
-### Composition API Patterns
-
-```yaml
-# Missing onUnmounted cleanup
-id: vue-missing-cleanup
-language: JavaScript
-severity: medium
-message: Event listener should be cleaned up in onUnmounted
-rule:
-  pattern: onMounted(() => { $TARGET.addEventListener($$$) })
-  not:
-    inside:
-      has:
-        pattern: onUnmounted(() => { $TARGET.removeEventListener($$$) })
----
-# Computed with side effects
-id: vue-computed-side-effect
-language: JavaScript
-severity: high
-message: Computed properties should not have side effects
-rule:
-  pattern: computed(() => { $$$ })
-  has:
-    any:
-      - pattern: console.log($$$)
-      - pattern: $VAR = $VALUE
-      - pattern: $OBJ.$PROP = $VALUE
-      - pattern: fetch($$$)
-```
-
-## React Patterns
-
-### Hooks Issues
-
-```yaml
-# useEffect with empty deps but using state
-id: react-missing-deps
-language: JavaScript
-severity: high
-message: useEffect uses variables not in dependency array
-rule:
-  pattern: useEffect(() => { $$$ }, [])
-note: Add used variables to dependency array or use exhaustive-deps lint rule
----
-# useState with object instead of useReducer
-id: react-complex-state
-language: JavaScript
-severity: info
-message: Consider useReducer for complex state objects
-rule:
-  pattern: useState({ $$$PROPS })
-  has:
-    pattern: { $A, $B, $C, $D, $$$ }
----
-# Inline function in JSX
-id: react-inline-function
-language: JavaScript
-severity: info
-message: Inline functions create new references on each render
-rule:
-  any:
-    - pattern: <$COMP onClick={() => $$$} />
-    - pattern: <$COMP onChange={() => $$$} />
-    - pattern: <$COMP onSubmit={() => $$$} />
-note: Use useCallback or extract to a named function
-```
-
-### Component Patterns
-
-```yaml
-# Component without memo for expensive renders
-id: react-missing-memo
-language: JavaScript
-severity: info
-message: Consider React.memo for components receiving object props
-rule:
-  pattern: function $Component({ $$$PROPS }) { $$$ }
-  not:
-    inside:
-      pattern: memo($$$)
----
-# Prop drilling (props passed through multiple levels)
-id: react-prop-drilling
-language: JavaScript
-severity: info
-message: Consider Context or state management for deeply passed props
-rule:
-  pattern: <$Child $PROP={props.$PROP} />
-```
-
-## Python Patterns
-
-### Common Anti-patterns
-
-```yaml
-# Mutable default argument
-id: py-mutable-default
-language: Python
-severity: high
-message: Mutable default argument creates shared state between calls
-rule:
-  any:
-    - pattern: def $FUNC($ARG=[])
-    - pattern: def $FUNC($ARG={})
-    - pattern: def $FUNC($ARG=set())
-fix: |
-  def $FUNC($ARG=None):
-      if $ARG is None:
-          $ARG = []
----
-# Bare except
-id: py-bare-except
-language: Python
-severity: high
-message: Bare except catches all exceptions including KeyboardInterrupt
-rule:
-  pattern: except:
-fix: except Exception:
----
-# Global variable
-id: py-no-global
-language: Python
-severity: medium
-message: Global variables make code hard to test and reason about
-rule:
-  pattern: global $VAR
----
-# Type ignore without reason
-id: py-type-ignore-comment
-language: Python
-severity: info
-message: type: ignore should include a reason
-rule:
-  regex: '# type: ignore$'
-```
-
-### Pythonic Issues
-
-```yaml
-# Using type() instead of isinstance()
-id: py-use-isinstance
-language: Python
-severity: info
-message: Use isinstance() for type checking
-rule:
-  pattern: type($VAR) == $TYPE
-fix: isinstance($VAR, $TYPE)
----
-# Manual iteration with index
-id: py-enumerate
-language: Python
-severity: info
-message: Use enumerate() instead of manual index tracking
-rule:
-  pattern: |
-    for $I in range(len($LIST)):
-        $$$ = $LIST[$I]
-note: Use 'for i, item in enumerate(list):' instead
----
-# Not using with statement for files
-id: py-file-context
-language: Python
-severity: medium
-message: Use context manager (with statement) for file operations
-rule:
-  pattern: $VAR = open($$$)
-  not:
-    inside:
-      pattern: with open($$$) as $VAR:
-```
-
-## Security Patterns
-
-### Injection Risks
-
-```yaml
-# eval usage
-id: no-eval
-language: JavaScript
-severity: critical
-message: eval() is a security risk - never use with user input
-rule:
-  any:
-    - pattern: eval($$$)
-    - pattern: new Function($$$)
-    - pattern: setTimeout($STRING, $$$)
-    - pattern: setInterval($STRING, $$$)
-constraints:
-  STRING:
-    kind: string
----
-# innerHTML XSS
-id: no-innerhtml
-language: JavaScript
-severity: high
-message: innerHTML can lead to XSS - use textContent or sanitize
-rule:
-  any:
-    - pattern: $ELEM.innerHTML = $$$
-    - pattern: $ELEM.outerHTML = $$$
----
-# SQL injection (string concatenation)
-id: sql-injection
-language: JavaScript
-severity: critical
-message: Use parameterized queries instead of string concatenation
-rule:
-  any:
-    - pattern: '"SELECT * FROM " + $VAR'
-    - pattern: '"SELECT " + $$$ + " FROM"'
-    - pattern: '`SELECT * FROM ${$VAR}`'
-    - pattern: '"INSERT INTO " + $VAR'
-    - pattern: '"UPDATE " + $VAR'
-    - pattern: '"DELETE FROM " + $VAR'
----
-# Command injection
-id: command-injection
-language: JavaScript
-severity: critical
-message: Use execFile with array arguments instead of exec with string
-rule:
-  pattern: exec($COMMAND)
-  inside:
-    kind: call_expression
-constraints:
-  COMMAND:
-    any:
-      - kind: template_string
-      - kind: binary_expression
-```
-
-### Secrets and Credentials
-
-```yaml
-# Hardcoded API keys
-id: hardcoded-api-key
-language: JavaScript
-severity: critical
-message: Never hardcode API keys - use environment variables
-rule:
-  any:
-    - pattern: apiKey = '$$$'
-    - pattern: "apiKey: '$$$'"
-    - pattern: API_KEY = '$$$'
-    - pattern: 'x-api-key': '$$$'
-constraints:
-  # Exclude empty strings and placeholders
-  $$$:
-    not:
-      regex: '^(|your-api-key|xxx|placeholder)$'
----
-# Hardcoded passwords
-id: hardcoded-password
-language: JavaScript
-severity: critical
-message: Never hardcode passwords
-rule:
-  any:
-    - pattern: password = '$$$'
-    - pattern: "password: '$$$'"
-    - pattern: pwd = '$$$'
-    - pattern: secret = '$$$'
----
-# JWT secret hardcoded
-id: hardcoded-jwt-secret
-language: JavaScript
-severity: critical
-message: JWT secrets should come from environment variables
-rule:
-  pattern: jwt.sign($$$, '$SECRET', $$$)
-```
-
-## Performance Patterns
-
-### Memory Leaks
-
-```yaml
-# Event listener without cleanup
-id: event-listener-leak
-language: JavaScript
-severity: medium
-message: Event listener may cause memory leak without removal
-rule:
-  pattern: addEventListener($EVENT, $HANDLER)
-  not:
-    inside:
-      has:
-        pattern: removeEventListener($EVENT, $HANDLER)
----
-# setInterval without cleanup
-id: interval-leak
-language: JavaScript
-severity: medium
-message: setInterval should be cleared to prevent memory leaks
-rule:
-  pattern: setInterval($$$)
-  not:
-    inside:
-      has:
-        pattern: clearInterval($$$)
----
-# Closure over large objects
-id: closure-memory
-language: JavaScript
-severity: info
-message: Closure captures entire scope - consider extracting needed values
-rule:
-  pattern: |
-    const $LARGE = $$$;
-    $$$ = () => { $$$ }
-```
-
-### Inefficient Patterns
-
-```yaml
-# Array method chaining creating intermediate arrays
-id: array-chain-performance
-language: JavaScript
-severity: info
-message: Chained array methods create intermediate arrays - consider reduce
-rule:
-  pattern: $ARR.filter($$$).map($$$)
-note: For large arrays, consider using a single reduce() instead
----
-# Synchronous file operations
-id: sync-file-ops
-language: JavaScript
-severity: medium
-message: Synchronous file operations block the event loop
-rule:
-  any:
-    - pattern: fs.readFileSync($$$)
-    - pattern: fs.writeFileSync($$$)
-    - pattern: fs.existsSync($$$)
-note: Use async versions with await or callbacks in production
-```
-
-## Running Multiple Rules
-
-### Create sgconfig.yml
-
-```yaml
-ruleDirs:
-  - rules/javascript
-  - rules/typescript
-  - rules/vue
-  - rules/react
-  - rules/python
-  - rules/security
-
-utilDirs:
-  - rules/utils
-
-testConfigs:
-  testDir: tests
-  snapshotDir: __snapshots__
-
-languageGlobs:
-  - language: TypeScript
-    extensions: [ts, tsx]
-  - language: JavaScript
-    extensions: [js, jsx, mjs, cjs]
-  - language: Python
-    extensions: [py]
-  - language: Vue
-    extensions: [vue]
-```
-
-### Run All Rules
+The detection catalog is an **executable ast-grep rule project**, not prose. Each
+pattern lives in its own rule file under [`rules/lib/`](rules/lib/) with a
+valid/invalid test fixture in [`rules/tests/`](rules/tests/). Run the whole
+catalog in one deterministic pass:
 
 ```bash
-# Scan with all rules
-ast-grep scan
-
-# Scan specific rule
-ast-grep scan -r no-empty-catch
-
-# Output as JSON for processing
-ast-grep scan --json > antipatterns-report.json
-
-# Filter by severity
-ast-grep scan --json | jq '[.[] | select(.severity == "critical" or .severity == "high")]'
+ast-grep scan -c rules/sgconfig.yml --json=compact <path>
 ```
 
-## Quick Reference Commands
+This file is the **narrative + fallback**: it links each pattern to its rule file
+(so the rule `.yml` is the single source of truth for the pattern) and gives the
+per-pattern `ast-grep -p` command to run by hand when `ast-grep scan` isn't
+available. Do not restate the rule bodies here — edit the `.yml` instead.
 
-### JavaScript/TypeScript
+## The rule catalog
 
-```bash
-# All anti-patterns
-ast-grep -p 'console.log($$$)' --lang js
-ast-grep -p 'var $VAR = $$$' --lang js
-ast-grep -p 'try { $$$ } catch ($E) { }' --lang js
-ast-grep -p 'eval($$$)' --lang js
-ast-grep -p ': any' --lang ts
-ast-grep -p '$VAR!' --lang ts
-```
+Rules use `language: tsx` for JS/TS (the Tsx grammar parses `.ts/.tsx/.js/.jsx/
+.mjs/.cjs` — see `languageGlobs` in [`rules/sgconfig.yml`](rules/sgconfig.yml))
+and `language: python` for Python.
 
-### Vue
+| Rule file | Catches | Fallback one-liner |
+|-----------|---------|--------------------|
+| [`no-empty-catch.yml`](rules/lib/no-empty-catch.yml) | `try { … } catch (e) {}` | `ast-grep -p 'try { $$$ } catch ($E) { }' --lang ts` |
+| [`no-console-log.yml`](rules/lib/no-console-log.yml) | `console.log(…)` left in code | `ast-grep -p 'console.log($$$)' --lang ts` |
+| [`no-var.yml`](rules/lib/no-var.yml) | `var x = …` (use let/const) | `ast-grep -p 'var $VAR = $$$' --lang ts` |
+| [`no-eval.yml`](rules/lib/no-eval.yml) | `eval(…)` / `new Function(…)` | `ast-grep -p 'eval($$$)' --lang ts` |
+| [`no-innerhtml.yml`](rules/lib/no-innerhtml.yml) | `el.innerHTML = …` / `outerHTML` (XSS) | `ast-grep -p '$EL.innerHTML = $$$' --lang ts` |
+| [`ts-as-any.yml`](rules/lib/ts-as-any.yml) | `expr as any` | `ast-grep -p '$X as any' --lang ts` |
+| [`ts-any-annotation.yml`](rules/lib/ts-any-annotation.yml) | `: any` annotations | (context/selector — see rule file) |
+| [`no-magic-number.yml`](rules/lib/no-magic-number.yml) | magic numeric timer delays | `ast-grep -p 'setTimeout($F, $N)' --lang ts` |
+| [`vue-props-mutation.yml`](rules/lib/vue-props-mutation.yml) | `props.x = …` | `ast-grep -p 'props.$P = $V' --lang ts` |
+| [`py-mutable-default.yml`](rules/lib/py-mutable-default.yml) | `def f(a=[])` / `def f(a={})` | `ast-grep -p 'def $F($A=[]): $$$' --lang py` |
+| [`py-bare-except.yml`](rules/lib/py-bare-except.yml) | bare `except:` | (context/selector — see rule file) |
+| [`py-global.yml`](rules/lib/py-global.yml) | `global X` | `ast-grep -p 'global $VAR' --lang py` |
+| [`py-use-isinstance.yml`](rules/lib/py-use-isinstance.yml) | `type(x) == T` | `ast-grep -p 'type($V) == $T' --lang py` |
 
-```bash
-ast-grep -p 'props.$PROP = $VALUE' --lang js
-ast-grep -p 'const { $$$PROPS } = reactive($$$)' --lang js
-```
+## Not in the rule project (agent judgment)
 
-### Python
+Some catalog concerns are metrics or heuristics, not single-node structural
+matches, and stay as agent-judgment passes on the code:
 
-```bash
-ast-grep -p 'def $FUNC($ARG=[])' --lang py
-ast-grep -p 'except:' --lang py
-ast-grep -p 'global $VAR' --lang py
-```
+- **Deep nesting / long functions / large parameter lists / cyclomatic
+  complexity** — a metric over a body, not a pattern. Use `/code:complexity`.
+- **Floating promises / unhandled rejections** — the repo toolchain is
+  authoritative; defer to `tsc` + `no-floating-promises`, or the errors track of
+  `/code:hidden-failures`. A broad structural rule would flag every call.
+- **Hardcoded secrets / SQL & command injection** — string-shaped and
+  false-positive-prone; use `gitleaks` / `/code:review` (security) rather than an
+  ast-grep literal-match rule.
 
-### Security
+## Error swallowing is delegated
 
-```bash
-ast-grep -p 'eval($$$)' --lang js
-ast-grep -p '$ELEM.innerHTML = $$$' --lang js
-ast-grep -p 'apiKey = "$$$"' --lang js
-ast-grep -p '"SELECT * FROM " + $VAR' --lang js
-```
+Empty catch, bare `except`, and floating-promise findings share a severity model,
+surfacing recommendations, and privacy redaction with the dedicated scanner.
+`no-empty-catch` / `py-bare-except` are flagged here for completeness, but their
+**triage and remediation** belong to `/code:hidden-failures --track errors` (whose
+own [`rules/`](../code-hidden-failures/rules/) project overlaps on these shared
+patterns by design — one canonical source per pattern, per skill).
+
+## Adding a rule
+
+1. Add `rules/lib/<id>.yml` (`id`, `language`, `severity` ∈
+   hint/info/warning/error, `message`, `rule`).
+2. Add `rules/tests/<id>-test.yml` with `valid:` (clean code — must **not** match)
+   and `invalid:` (the anti-pattern — must match).
+3. `ast-grep test -c rules/sgconfig.yml --skip-snapshot-tests` must pass.
+4. Add a row to the catalog table above.
+
+The regression test
+[`scripts/tests/test-rules-project.sh`](scripts/tests/test-rules-project.sh)
+(run by `just test-skill-scripts`) fails if a rule ships without a fixture or if
+any fixture regresses.

--- a/code-quality-plugin/skills/code-antipatterns/SKILL.md
+++ b/code-quality-plugin/skills/code-antipatterns/SKILL.md
@@ -1,9 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-05-23
-reviewed: 2026-04-25
+modified: 2026-07-06
+reviewed: 2026-07-06
 description: Analyze a codebase for anti-patterns using ast-grep. Use when finding magic numbers, console.logs, var usage, excessive any, eval/innerHTML security issues, or deep nesting.
-allowed-tools: Read, Bash(sg *), Bash(rg *), Glob, Grep, TodoWrite, Task, SlashCommand
+allowed-tools: Read, Bash(ast-grep *), Bash(sg *), Bash(rg *), Glob, Grep, TodoWrite, Task, SlashCommand
 args: "[PATH] [--focus <category>] [--severity <level>]"
 argument-hint: "[PATH] [--focus <category>] [--severity <level>]"
 name: code-antipatterns
@@ -27,7 +27,52 @@ name: code-antipatterns
 
 ## Your Task
 
-Perform comprehensive anti-pattern analysis using ast-grep and parallel agent delegation.
+Perform comprehensive anti-pattern analysis. The **mechanical detection** is one
+deterministic `ast-grep scan` over a shipped rule project — you do **not** re-type
+`sg -p '…'` patterns and do **not** fan out agents just to run them. Your job is
+the **judgment**: severity triage, recommendations, and fix planning on top of the
+scan's structured findings.
+
+### Step 1: Run the deterministic scan
+
+The detection catalog lives as an ast-grep **rule project** in
+[`rules/`](rules/) (one `*.yml` per pattern under `rules/lib/`, each with a
+valid/invalid test fixture in `rules/tests/`). Run the whole catalog in one pass:
+
+```bash
+ast-grep scan -c ${CLAUDE_SKILL_DIR}/rules/sgconfig.yml --json=compact <path>
+```
+
+Each JSON finding carries `ruleId`, `file`, `range` (line/column), `message`, and
+the matched `text`. Parse this — it is the raw finding set for every category
+below. The rules cover: empty catch, `console.log`, `var`, `eval`/`new Function`,
+`innerHTML`/`outerHTML`, `as any` / `: any` annotations, magic-number timers, Vue
+props mutation, Python mutable defaults, bare `except`, `global`, and
+`type() ==`.
+
+**Graceful degradation** — if `ast-grep` (packaged as `ast-grep` or `sg`) is not
+installed, fall back to the per-pattern flow: read [REFERENCE.md](REFERENCE.md),
+which links each rule to its source `.yml`, and run the individual
+`ast-grep -p '<pattern>' --lang <lang>` commands by hand. The rule project is the
+fast path; the reference is the fallback.
+
+### Step 2: Judgment (the agent's actual work)
+
+The scan is mechanical and reproducible; **triage, recommendation, and fix
+planning are the judgment work** — do them yourself on the scan output rather than
+spawning agents to re-run patterns:
+
+- **Severity triage** — promote/demote each finding using the context in the
+  Category tables below and the app type (frontend/backend/CLI/library).
+- **Error-swallowing findings** (empty catch, floating promises, bare except) →
+  **delegate** to `/code:hidden-failures --track errors` for its severity model,
+  surfacing recommendations, and privacy redaction. Do not re-classify them here.
+- **Recommendations & fix planning** — group systemic issues, note which findings
+  ast-grep can auto-`fix`, and recommend process changes (lint rules, pre-commit).
+
+Reserve any parallel `Task` fan-out for **genuinely independent reasoning** (e.g.
+a deep security review or a framework-specific architecture pass) — never for
+running the patterns, which Step 1 already did once, deterministically.
 
 ### Analysis Categories
 
@@ -73,70 +118,16 @@ Rationale: a single source of truth prevents drift between severity
 models, app-context surfacing recommendations, and privacy redaction
 policies. See `code-quality-plugin/skills/code-hidden-failures/SKILL.md`.
 
-### Execution Strategy
+### What the rule project does *not* cover (agent judgment)
 
-**CRITICAL: Use parallel agent delegation for efficiency.**
+Two catalog concerns are not structural single-node matches and stay as
+**agent-judgment** passes on the code, not rules:
 
-Launch multiple specialized agents simultaneously:
-
-```markdown
-## Agent 1: Language Detection & Setup (Explore - quick)
-Detect project stack, identify file patterns, establish analysis scope
-
-## Agent 2: JavaScript/TypeScript Analysis (code-analysis)
-- Use ast-grep for structural pattern matching
-- Focus on: magic values, var usage, deprecated patterns
-- Error swallowing handled separately via `/code:hidden-failures --track errors`
-
-## Agent 3: Async/Promise Analysis (code-analysis)
-- Nested callbacks, Promise constructor anti-pattern
-- Floating promises / unhandled rejections handled via `/code:hidden-failures --track errors`
-
-## Agent 4: Framework-Specific Analysis (code-analysis)
-- Vue: props mutation, reactivity issues
-- React: hooks dependencies, inline functions
-
-## Agent 5: Security Analysis (security-audit)
-- eval, innerHTML, hardcoded secrets, injection risks
-- Use OWASP context
-
-## Agent 6: Complexity Analysis (code-analysis)
-- Function length, nesting depth, parameter counts
-- Cyclomatic complexity indicators
-```
-
-### ast-grep Pattern Examples
-
-For the full YAML rule catalog (with `id:`, `severity:`, `message:`, `fix:`, and `note:` fields), see [REFERENCE.md](REFERENCE.md).
-
-Use these patterns during analysis:
-
-```bash
-# Magic numbers
-ast-grep -p 'if ($VAR > 100)' --lang js
-
-# Console statements
-ast-grep -p 'console.log($$$)' --lang js
-
-# var usage
-ast-grep -p 'var $VAR = $$$' --lang js
-
-# TypeScript any
-ast-grep -p ': any' --lang ts
-ast-grep -p 'as any' --lang ts
-
-# Vue props mutation
-ast-grep -p 'props.$PROP = $VALUE' --lang js
-
-# Security: eval
-ast-grep -p 'eval($$$)' --lang js
-
-# Security: innerHTML
-ast-grep -p '$ELEM.innerHTML = $$$' --lang js
-
-# Python: mutable defaults
-ast-grep -p 'def $FUNC($ARG=[])' --lang py
-```
+- **Deep nesting / long functions / cyclomatic complexity** — a metric over a
+  function body, not a pattern. Use `/code:complexity` or read the flagged files.
+- **Floating promises** — the repo's own toolchain is authoritative; defer to
+  `tsc` + the `no-floating-promises` ESLint rule, or `/code:hidden-failures
+  --track errors`, rather than a broad structural rule that would flag every call.
 
 ### Output Format
 
@@ -193,7 +184,8 @@ After consolidating findings:
 
 ## See Also
 
-- **Reference**: [REFERENCE.md](REFERENCE.md) - Full YAML rule catalog with ast-grep pattern library
+- **Rule project**: [`rules/`](rules/) — the executable ast-grep catalog (`sgconfig.yml` + `rules/lib/*.yml` + `rules/tests/*-test.yml`); run `ast-grep test -c rules/sgconfig.yml --skip-snapshot-tests` to verify every rule against its fixtures
+- **Reference**: [REFERENCE.md](REFERENCE.md) - narrative catalog linking each pattern to its rule file
 - **Skill**: `ast-grep-search` - ast-grep usage reference
 - **Command**: `/code:review` - Comprehensive code review
 - **Agent**: `security-audit` - Deep security analysis

--- a/code-quality-plugin/skills/code-antipatterns/rules/lib/no-console-log.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/lib/no-console-log.yml
@@ -1,0 +1,6 @@
+id: no-console-log
+language: tsx
+severity: info
+message: console.log left in code — use a logger or remove
+rule:
+  pattern: console.log($$$)

--- a/code-quality-plugin/skills/code-antipatterns/rules/lib/no-empty-catch.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/lib/no-empty-catch.yml
@@ -1,0 +1,7 @@
+id: no-empty-catch
+language: tsx
+severity: warning
+message: Empty catch block silently swallows errors
+note: Log the error and rethrow, or handle it explicitly. See code-hidden-failures --track errors.
+rule:
+  pattern: "try { $$$ } catch ($E) { }"

--- a/code-quality-plugin/skills/code-antipatterns/rules/lib/no-eval.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/lib/no-eval.yml
@@ -1,0 +1,8 @@
+id: no-eval
+language: tsx
+severity: error
+message: eval / new Function executes arbitrary code — a security risk
+rule:
+  any:
+    - pattern: eval($$$)
+    - pattern: new Function($$$)

--- a/code-quality-plugin/skills/code-antipatterns/rules/lib/no-innerhtml.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/lib/no-innerhtml.yml
@@ -1,0 +1,8 @@
+id: no-innerhtml
+language: tsx
+severity: warning
+message: Assigning innerHTML/outerHTML can introduce XSS — use textContent or sanitize
+rule:
+  any:
+    - pattern: $EL.innerHTML = $$$
+    - pattern: $EL.outerHTML = $$$

--- a/code-quality-plugin/skills/code-antipatterns/rules/lib/no-magic-number.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/lib/no-magic-number.yml
@@ -1,0 +1,11 @@
+id: no-magic-number
+language: tsx
+severity: info
+message: Magic number in a timer — extract to a named constant
+rule:
+  any:
+    - pattern: setTimeout($FN, $N)
+    - pattern: setInterval($FN, $N)
+constraints:
+  N:
+    kind: number

--- a/code-quality-plugin/skills/code-antipatterns/rules/lib/no-var.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/lib/no-var.yml
@@ -1,0 +1,7 @@
+id: no-var
+language: tsx
+severity: info
+message: Use let or const instead of var
+fix: const $VAR = $INIT
+rule:
+  pattern: var $VAR = $INIT

--- a/code-quality-plugin/skills/code-antipatterns/rules/lib/py-bare-except.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/lib/py-bare-except.yml
@@ -1,0 +1,12 @@
+id: py-bare-except
+language: python
+severity: warning
+message: Bare except catches everything, including KeyboardInterrupt — catch a specific type
+rule:
+  pattern:
+    context: |
+      try:
+          pass
+      except:
+          pass
+    selector: except_clause

--- a/code-quality-plugin/skills/code-antipatterns/rules/lib/py-global.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/lib/py-global.yml
@@ -1,0 +1,6 @@
+id: py-global
+language: python
+severity: info
+message: Global mutable state makes code hard to test and reason about
+rule:
+  pattern: global $VAR

--- a/code-quality-plugin/skills/code-antipatterns/rules/lib/py-mutable-default.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/lib/py-mutable-default.yml
@@ -1,0 +1,8 @@
+id: py-mutable-default
+language: python
+severity: warning
+message: Mutable default argument creates shared state between calls
+rule:
+  any:
+    - pattern: "def $FUNC($ARG=[]): $$$"
+    - pattern: "def $FUNC($ARG={}): $$$"

--- a/code-quality-plugin/skills/code-antipatterns/rules/lib/py-use-isinstance.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/lib/py-use-isinstance.yml
@@ -1,0 +1,7 @@
+id: py-use-isinstance
+language: python
+severity: info
+message: Use isinstance() for type checking instead of type() == comparison
+fix: isinstance($VAR, $TYPE)
+rule:
+  pattern: type($VAR) == $TYPE

--- a/code-quality-plugin/skills/code-antipatterns/rules/lib/ts-any-annotation.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/lib/ts-any-annotation.yml
@@ -1,0 +1,8 @@
+id: ts-any-annotation
+language: tsx
+severity: info
+message: "`: any` annotation weakens type safety — use a precise type or unknown"
+rule:
+  pattern:
+    context: "let $X: any = $Y"
+    selector: type_annotation

--- a/code-quality-plugin/skills/code-antipatterns/rules/lib/ts-as-any.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/lib/ts-as-any.yml
@@ -1,0 +1,6 @@
+id: ts-as-any
+language: tsx
+severity: info
+message: "`as any` defeats type checking — use a precise type or unknown"
+rule:
+  pattern: $EXPR as any

--- a/code-quality-plugin/skills/code-antipatterns/rules/lib/vue-props-mutation.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/lib/vue-props-mutation.yml
@@ -1,0 +1,6 @@
+id: vue-props-mutation
+language: tsx
+severity: error
+message: Never mutate props directly — emit an update event or copy into local state
+rule:
+  pattern: props.$PROP = $VALUE

--- a/code-quality-plugin/skills/code-antipatterns/rules/sgconfig.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/sgconfig.yml
@@ -1,0 +1,21 @@
+# ast-grep rule project for the code-antipatterns catalog.
+# Invoke from the skill with:
+#   ast-grep scan -c ${CLAUDE_SKILL_DIR}/rules/sgconfig.yml --json=compact <path>
+# Test the rules (valid/invalid fixtures, no snapshot files needed):
+#   ast-grep test -c ${CLAUDE_SKILL_DIR}/rules/sgconfig.yml --skip-snapshot-tests
+#
+# JS/TS rules use `language: tsx` — the Tsx grammar parses plain TS/JS *and*
+# JSX, so one rule per pattern covers .ts/.tsx/.js/.jsx/.mjs/.cjs. The
+# languageGlobs mapping below routes those extensions to the tsx parser.
+ruleDirs:
+  - lib
+testConfigs:
+  - testDir: tests
+languageGlobs:
+  tsx:
+    - "*.ts"
+    - "*.tsx"
+    - "*.js"
+    - "*.jsx"
+    - "*.mjs"
+    - "*.cjs"

--- a/code-quality-plugin/skills/code-antipatterns/rules/tests/no-console-log-test.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/tests/no-console-log-test.yml
@@ -1,0 +1,5 @@
+id: no-console-log
+valid:
+  - "logger.info('hello');"
+invalid:
+  - "console.log('debug', value);"

--- a/code-quality-plugin/skills/code-antipatterns/rules/tests/no-empty-catch-test.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/tests/no-empty-catch-test.yml
@@ -1,0 +1,5 @@
+id: no-empty-catch
+valid:
+  - "try { risky(); } catch (e) { console.error(e); throw e; }"
+invalid:
+  - "try { risky(); } catch (e) { }"

--- a/code-quality-plugin/skills/code-antipatterns/rules/tests/no-eval-test.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/tests/no-eval-test.yml
@@ -1,0 +1,6 @@
+id: no-eval
+valid:
+  - "const result = JSON.parse(input);"
+invalid:
+  - "const result = eval(input);"
+  - "const fn = new Function('a', 'return a');"

--- a/code-quality-plugin/skills/code-antipatterns/rules/tests/no-innerhtml-test.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/tests/no-innerhtml-test.yml
@@ -1,0 +1,6 @@
+id: no-innerhtml
+valid:
+  - "el.textContent = userInput;"
+invalid:
+  - "el.innerHTML = userInput;"
+  - "el.outerHTML = markup;"

--- a/code-quality-plugin/skills/code-antipatterns/rules/tests/no-magic-number-test.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/tests/no-magic-number-test.yml
@@ -1,0 +1,6 @@
+id: no-magic-number
+valid:
+  - "setTimeout(fn, RETRY_DELAY_MS);"
+invalid:
+  - "setTimeout(fn, 5000);"
+  - "setInterval(poll, 1000);"

--- a/code-quality-plugin/skills/code-antipatterns/rules/tests/no-var-test.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/tests/no-var-test.yml
@@ -1,0 +1,6 @@
+id: no-var
+valid:
+  - "const count = 0;"
+  - "let total = 1;"
+invalid:
+  - "var count = 0;"

--- a/code-quality-plugin/skills/code-antipatterns/rules/tests/py-bare-except-test.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/tests/py-bare-except-test.yml
@@ -1,0 +1,13 @@
+id: py-bare-except
+valid:
+  - |
+    try:
+        do_thing()
+    except ValueError:
+        handle()
+invalid:
+  - |
+    try:
+        do_thing()
+    except:
+        pass

--- a/code-quality-plugin/skills/code-antipatterns/rules/tests/py-global-test.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/tests/py-global-test.yml
@@ -1,0 +1,11 @@
+id: py-global
+valid:
+  - |
+    def f():
+        local = 1
+        return local
+invalid:
+  - |
+    def f():
+        global CONFIG
+        CONFIG = load()

--- a/code-quality-plugin/skills/code-antipatterns/rules/tests/py-mutable-default-test.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/tests/py-mutable-default-test.yml
@@ -1,0 +1,12 @@
+id: py-mutable-default
+valid:
+  - |
+    def f(arg=None):
+        return arg
+invalid:
+  - |
+    def f(arg=[]):
+        return arg
+  - |
+    def g(arg={}):
+        return arg

--- a/code-quality-plugin/skills/code-antipatterns/rules/tests/py-use-isinstance-test.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/tests/py-use-isinstance-test.yml
@@ -1,0 +1,5 @@
+id: py-use-isinstance
+valid:
+  - "if isinstance(value, int): pass"
+invalid:
+  - "if type(value) == int: pass"

--- a/code-quality-plugin/skills/code-antipatterns/rules/tests/ts-any-annotation-test.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/tests/ts-any-annotation-test.yml
@@ -1,0 +1,6 @@
+id: ts-any-annotation
+valid:
+  - "function handler(payload: number) { return payload; }"
+invalid:
+  - "function handler(payload: any) { return payload; }"
+  - "let value: any = 3;"

--- a/code-quality-plugin/skills/code-antipatterns/rules/tests/ts-as-any-test.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/tests/ts-as-any-test.yml
@@ -1,0 +1,5 @@
+id: ts-as-any
+valid:
+  - "const n = value as number;"
+invalid:
+  - "const n = value as any;"

--- a/code-quality-plugin/skills/code-antipatterns/rules/tests/vue-props-mutation-test.yml
+++ b/code-quality-plugin/skills/code-antipatterns/rules/tests/vue-props-mutation-test.yml
@@ -1,0 +1,5 @@
+id: vue-props-mutation
+valid:
+  - "emit('update:value', next);"
+invalid:
+  - "props.value = next;"

--- a/code-quality-plugin/skills/code-antipatterns/scripts/tests/test-rules-project.sh
+++ b/code-quality-plugin/skills/code-antipatterns/scripts/tests/test-rules-project.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Regression test for the code-antipatterns ast-grep rule project (issue #2010).
+#
+# Semantic invariants (not just "does it parse"):
+#   1. Every rule in rules/lib/ matches its anti-pattern fixture (invalid) and
+#      leaves the clean fixture (valid) untouched — enforced by `ast-grep test`.
+#   2. Every rule ships with a matching test fixture (no rule can land untested).
+#   3. `ast-grep scan -c rules/sgconfig.yml` runs clean and flags a known
+#      anti-pattern sample — the exact command the SKILL.md rewires to.
+#
+# SKIPs (exit 0) when ast-grep is absent, matching the skill's documented
+# graceful-degradation fallback to the per-pattern flow.
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+rules_dir="${script_dir}/../../rules"
+sgconfig="${rules_dir}/sgconfig.yml"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+pass() { echo "PASS: $1"; }
+
+# Resolve the ast-grep binary (packaged as both `ast-grep` and `sg`).
+astgrep=""
+if command -v ast-grep >/dev/null 2>&1; then
+  astgrep="ast-grep"
+elif command -v sg >/dev/null 2>&1; then
+  astgrep="sg"
+else
+  echo "SKIP: ast-grep/sg not installed; cannot run code-antipatterns rule tests"
+  exit 0
+fi
+
+[ -f "$sgconfig" ] || fail "sgconfig.yml missing at $sgconfig"
+
+# Invariant 2: every rule has a fixture (rule count == fixture count, and each
+# rule id has a same-named *-test.yml).
+rule_count=$(find "${rules_dir}/lib" -name '*.yml' -type f | wc -l | tr -d ' ')
+test_count=$(find "${rules_dir}/tests" -name '*-test.yml' -type f | wc -l | tr -d ' ')
+[ "$rule_count" -gt 0 ] || fail "no rule files found under rules/lib"
+[ "$rule_count" = "$test_count" ] || \
+  fail "rule/fixture count mismatch: $rule_count rules vs $test_count fixtures (every rule needs a *-test.yml)"
+pass "every rule ($rule_count) has a matching test fixture"
+
+missing=""
+while IFS= read -r rf; do
+  id="$(basename "$rf" .yml)"
+  [ -f "${rules_dir}/tests/${id}-test.yml" ] || missing="${missing} ${id}"
+done < <(find "${rules_dir}/lib" -name '*.yml' -type f)
+[ -z "$missing" ] || fail "rules without a fixture:${missing}"
+pass "each rule id maps to a tests/<id>-test.yml"
+
+# Invariant 1: valid/invalid fixtures behave (semantic gate).
+if ! "$astgrep" test -c "$sgconfig" --skip-snapshot-tests >/tmp/ap-astgrep-test.$$.log 2>&1; then
+  cat /tmp/ap-astgrep-test.$$.log >&2
+  rm -f /tmp/ap-astgrep-test.$$.log
+  fail "ast-grep test reported failing rule fixtures"
+fi
+rm -f /tmp/ap-astgrep-test.$$.log
+pass "ast-grep test: all rule fixtures pass"
+
+# Invariant 3: the SKILL's scan command runs clean and flags a real sample.
+smoke_dir="$(mktemp -d)"
+[ -n "$smoke_dir" ] || fail "mktemp failed"
+trap 'rm -rf "$smoke_dir"' EXIT
+printf 'var x = 0;\nconsole.log(x);\ntry { risky(); } catch (e) { }\n' > "${smoke_dir}/sample.ts"
+out="$("$astgrep" scan -c "$sgconfig" --json=compact "$smoke_dir" 2>/tmp/ap-scan-err.$$.log)"
+scan_rc=$?
+if [ "$scan_rc" -ne 0 ]; then
+  cat /tmp/ap-scan-err.$$.log >&2
+  rm -f /tmp/ap-scan-err.$$.log
+  fail "ast-grep scan exited non-zero ($scan_rc)"
+fi
+rm -f /tmp/ap-scan-err.$$.log
+if command -v jq >/dev/null 2>&1; then
+  ids="$(printf '%s' "$out" | jq -r '.[].ruleId' | sort -u | tr '\n' ' ')"
+  case "$ids" in
+    *no-var*) : ;;
+    *) fail "scan did not flag no-var on the sample (got: $ids)" ;;
+  esac
+  pass "scan flags known anti-patterns on a sample (ids: $ids)"
+else
+  case "$out" in
+    *no-var*) pass "scan flags known anti-patterns on a sample" ;;
+    *) fail "scan did not flag no-var on the sample" ;;
+  esac
+fi
+
+echo "OK: code-antipatterns rule project ($rule_count rules) verified"
+exit 0

--- a/code-quality-plugin/skills/code-antipatterns/scripts/tests/test-rules-project.sh
+++ b/code-quality-plugin/skills/code-antipatterns/scripts/tests/test-rules-project.sh
@@ -20,14 +20,19 @@ sgconfig="${rules_dir}/sgconfig.yml"
 fail() { echo "FAIL: $1" >&2; exit 1; }
 pass() { echo "PASS: $1"; }
 
-# Resolve the ast-grep binary (packaged as both `ast-grep` and `sg`).
+# Resolve the ast-grep binary. It ships as both `ast-grep` and `sg`, but `sg`
+# also collides with shadow-utils' set-group binary (present on Linux CI
+# runners), so require the resolved command to self-identify as ast-grep before
+# trusting it — otherwise SKIP cleanly rather than running the wrong binary.
 astgrep=""
-if command -v ast-grep >/dev/null 2>&1; then
-  astgrep="ast-grep"
-elif command -v sg >/dev/null 2>&1; then
-  astgrep="sg"
-else
-  echo "SKIP: ast-grep/sg not installed; cannot run code-antipatterns rule tests"
+for cand in ast-grep sg; do
+  if command -v "$cand" >/dev/null 2>&1 && "$cand" --version 2>/dev/null | grep -qiE '^ast[_-]?grep'; then
+    astgrep="$cand"
+    break
+  fi
+done
+if [ -z "$astgrep" ]; then
+  echo "SKIP: ast-grep not installed; cannot run code-antipatterns rule tests"
   exit 0
 fi
 

--- a/code-quality-plugin/skills/code-hidden-failures/REFERENCE-go.md
+++ b/code-quality-plugin/skills/code-hidden-failures/REFERENCE-go.md
@@ -1,5 +1,14 @@
 # Reference — Go Error Swallowing
 
+> **Detection lives in the rule project, not here.** Discarded-error and
+> unchecked-`defer Close` are executable ast-grep rules —
+> [`go-ignore-underscore.yml`](rules/lib/go-ignore-underscore.yml),
+> [`go-defer-close-unchecked.yml`](rules/lib/go-defer-close-unchecked.yml) — run
+> via `ast-grep scan -c rules/sgconfig.yml`. This file is the **judgment
+> reference**: allowlist, severity promotion, remediation, and linter
+> integration. Prefer the project's own `errcheck` / `staticcheck` when
+> configured — the rules surface what those catch, they do not replace them.
+
 Go's error model makes error-swallowing especially easy to detect: any
 function returning `error` whose return is assigned to `_` or discarded is
 a candidate. Prefer the project's own `errcheck` / `staticcheck` (rules
@@ -26,12 +35,11 @@ errcheck ./...
 staticcheck -checks SA4006,SA5001 ./...
 ```
 
-Fall back to ast-grep:
-
-```bash
-sg -p '_ = $EXPR($$$)' --lang go
-sg -p 'defer $F.Close()' --lang go
-```
+Fall back to the rule project — `go-ignore-underscore` and
+`go-defer-close-unchecked` in [`rules/lib/`](rules/lib/), run via
+`ast-grep scan -c rules/sgconfig.yml --json=compact <path>` (per-pattern
+equivalents: `sg -p '_ = $CALL($$$)' --lang go`,
+`sg -p 'defer $F.Close()' --lang go`).
 
 ## Allowlist (classify as Low)
 

--- a/code-quality-plugin/skills/code-hidden-failures/REFERENCE-js.md
+++ b/code-quality-plugin/skills/code-hidden-failures/REFERENCE-js.md
@@ -1,5 +1,15 @@
 # Reference — JavaScript / TypeScript Error Swallowing
 
+> **Detection lives in the rule project, not here.** The structural patterns
+> (empty catch, empty `.catch`, `void`-ignore) are executable ast-grep rules —
+> [`js-empty-catch.yml`](rules/lib/js-empty-catch.yml),
+> [`js-promise-catch-empty.yml`](rules/lib/js-promise-catch-empty.yml),
+> [`js-void-ignore.yml`](rules/lib/js-void-ignore.yml) — run in one pass via
+> `ast-grep scan -c rules/sgconfig.yml`. This file is the **judgment reference**:
+> allowlist, severity promotion, and remediation templates. The heuristic
+> patterns below (floating promises, error-boundary silence) stay
+> toolchain-deferred / Grep-based.
+
 Detection rules for `.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`, `.cjs`. Use
 `sg` (ast-grep) for structural matching where possible; fall back to Grep
 for the heuristic ones.
@@ -20,13 +30,13 @@ for the heuristic ones.
 
 ### ast-grep commands
 
-```bash
-sg -p 'try { $$$ } catch ($E) {}' --lang ts
-sg -p 'try { $$$ } catch ($E) { }' --lang tsx
-sg -p '$EXPR.catch(() => {})' --lang ts
-sg -p '$EXPR.catch(($E) => {})' --lang ts
-sg -p 'void $EXPR($$$)' --lang ts
-```
+The structural patterns above are the executable rules in
+[`rules/lib/`](rules/lib/) (`js-empty-catch`, `js-promise-catch-empty`,
+`js-void-ignore`) — run them as one pass with
+`ast-grep scan -c rules/sgconfig.yml --json=compact <path>`. As a per-pattern
+fallback when `ast-grep scan` is unavailable, the equivalent one-liners are
+`sg -p 'try { $$$ } catch ($E) { }' --lang ts`,
+`sg -p '$EXPR.catch(() => {})' --lang ts`, and `sg -p 'void $EXPR($$$)' --lang ts`.
 
 For floating promises the repo's own toolchain is authoritative — defer to
 `tsc --noImplicitAny` + `no-floating-promises` ESLint rule when configured;

--- a/code-quality-plugin/skills/code-hidden-failures/REFERENCE-python.md
+++ b/code-quality-plugin/skills/code-hidden-failures/REFERENCE-python.md
@@ -1,5 +1,14 @@
 # Reference — Python Error Swallowing
 
+> **Detection lives in the rule project, not here.** Bare and broad
+> `except … : pass` are executable ast-grep rules —
+> [`py-bare-except-pass.yml`](rules/lib/py-bare-except-pass.yml),
+> [`py-broad-except-pass.yml`](rules/lib/py-broad-except-pass.yml) — run via
+> `ast-grep scan -c rules/sgconfig.yml`. This file is the **judgment reference**:
+> allowlist, severity promotion, and remediation templates. The remaining
+> heuristic patterns (typed-except-pass, suppress-misuse, floating asyncio tasks)
+> stay Grep/`sg`-based per the commands below.
+
 Detection rules for `.py`. Use `sg --lang py` for structural matches.
 
 ## Patterns
@@ -18,9 +27,12 @@ Detection rules for `.py`. Use `sg --lang py` for structural matches.
 
 ### ast-grep commands
 
+`py-bare-except-pass` and `py-broad-except-pass` are executable rules in
+[`rules/lib/`](rules/lib/) — run them (and the rest of the errors catalog) with
+`ast-grep scan -c rules/sgconfig.yml --json=compact <path>`. The remaining
+patterns that are not yet rules stay as per-pattern `sg` commands:
+
 ```bash
-sg -p $'try:\n  $$$\nexcept:\n  pass' --lang py
-sg -p $'try:\n  $$$\nexcept Exception:\n  pass' --lang py
 sg -p $'with suppress($TYPE):\n  $$$' --lang py
 ```
 

--- a/code-quality-plugin/skills/code-hidden-failures/REFERENCE-rust.md
+++ b/code-quality-plugin/skills/code-hidden-failures/REFERENCE-rust.md
@@ -1,5 +1,14 @@
 # Reference — Rust Error Swallowing
 
+> **Detection lives in the rule project, not here.** `let _ = <Result>` and
+> `.ok();` discards are executable ast-grep rules —
+> [`rs-let-underscore-result.yml`](rules/lib/rs-let-underscore-result.yml),
+> [`rs-ok-discard.yml`](rules/lib/rs-ok-discard.yml) — run via
+> `ast-grep scan -c rules/sgconfig.yml`. This file is the **judgment reference**:
+> allowlist, severity promotion, remediation, and the clippy lints to recommend.
+> Prefer `cargo clippy` when available — the rules surface what it catches, they
+> do not replace it.
+
 Rust's `Result` and `#[must_use]` make the compiler a first line of defense.
 This skill's job is to find the *runtime* suppressions — the places where
 `.ok()`, `let _ =`, and friends discard errors deliberately. Prefer
@@ -19,9 +28,12 @@ This skill's job is to find the *runtime* suppressions — the places where
 
 ### ast-grep commands
 
+`rs-let-underscore-result` and `rs-ok-discard` are executable rules in
+[`rules/lib/`](rules/lib/) — run them (and the rest of the errors catalog) with
+`ast-grep scan -c rules/sgconfig.yml --json=compact <path>`. The remaining
+patterns that are not yet rules stay as per-pattern `sg` commands:
+
 ```bash
-sg -p 'let _ = $EXPR;' --lang rust
-sg -p '$EXPR.ok();' --lang rust
 sg -p '$EXPR.map_err(|_| $$)' --lang rust
 ```
 

--- a/code-quality-plugin/skills/code-hidden-failures/SKILL.md
+++ b/code-quality-plugin/skills/code-hidden-failures/SKILL.md
@@ -1,8 +1,8 @@
 ---
 created: 2026-04-14
-modified: 2026-06-18
-reviewed: 2026-05-29
-allowed-tools: Bash(bash *), Bash(sg *), Bash(grep *), Read, Grep, Glob, Edit, Write, TodoWrite
+modified: 2026-07-06
+reviewed: 2026-07-06
+allowed-tools: Bash(bash *), Bash(ast-grep *), Bash(sg *), Bash(grep *), Read, Grep, Glob, Edit, Write, TodoWrite
 args: "[PATH] [--track <errors|degradation|both>] [--lang <shell|js|py|go|rust|auto>] [--severity <low|med|high>] [--emit-patch] [--fix]"
 argument-hint: "[PATH] [--track both] [--lang LANG] [--severity LEVEL] [--emit-patch|--fix]"
 description: "Scan for hidden failures: swallowed errors (empty catch, || true, 2>/dev/null) and silent degradation (success on zero results). Use when failures vanish or success masks empty output."
@@ -74,19 +74,40 @@ From the context commands above, determine which language matchers to run.
 For the app-context matrix (signals → surfacing channel), load
 [REFERENCE-surfacing.md](REFERENCE-surfacing.md).
 
-#### Step A2: Run language-specific matchers
+#### Step A2: Run the matchers
 
-Load only the REFERENCE files for languages actually present in the path:
+The **AST-shaped** swallowed-error patterns (js/ts, python, go, rust) live as an
+ast-grep **rule project** in [`rules/`](rules/) (one `*.yml` per pattern under
+`rules/lib/`, each with a valid/invalid fixture in `rules/tests/`). Run the whole
+catalog in one deterministic pass — do **not** re-type `sg -p '…'` per language:
 
-| Language | File | Tool |
-|----------|------|------|
-| Shell / bash | [REFERENCE-shell.md](REFERENCE-shell.md) | `bash ${CLAUDE_SKILL_DIR}/scripts/scan-shell.sh <path>` |
-| JavaScript / TypeScript | [REFERENCE-js.md](REFERENCE-js.md) | `sg` ast-grep with language-specific patterns |
-| Python | [REFERENCE-python.md](REFERENCE-python.md) | `sg` with `--lang py` |
-| Go | [REFERENCE-go.md](REFERENCE-go.md) | Prefer repo's `errcheck` if configured, else `sg --lang go` |
-| Rust | [REFERENCE-rust.md](REFERENCE-rust.md) | `sg --lang rust` + `clippy::let_underscore_must_use` hints |
+```bash
+ast-grep scan -c ${CLAUDE_SKILL_DIR}/rules/sgconfig.yml --json=compact <path>
+```
 
-For each matcher, capture: `file:line`, matched snippet, surrounding function
+Each finding carries `ruleId`, `file`, `range` (line/column), `message`, and the
+matched `text` — the raw finding set for Steps A3–A6.
+
+The **shell / bash** track stays grep-based — `|| true`, `2>/dev/null` in context,
+and xtrace suppression are line-shaped, not AST-shaped:
+
+```bash
+bash ${CLAUDE_SKILL_DIR}/scripts/scan-shell.sh <path>
+```
+
+| Track | Tool | Reference (linked from rule files) |
+|-------|------|------------------------------------|
+| JS / TS, Python, Go, Rust | `ast-grep scan -c rules/sgconfig.yml` (one pass) | [REFERENCE-js.md](REFERENCE-js.md), [REFERENCE-python.md](REFERENCE-python.md), [REFERENCE-go.md](REFERENCE-go.md), [REFERENCE-rust.md](REFERENCE-rust.md) |
+| Shell / bash | `scripts/scan-shell.sh` (grep-based) | [REFERENCE-shell.md](REFERENCE-shell.md) |
+
+**Graceful degradation** — if `ast-grep` (packaged as `ast-grep` or `sg`) is not
+installed, fall back to the per-pattern flow: read the `REFERENCE-{js,python,go,
+rust}.md` files (each links its patterns to the rule `.yml`) and run the
+individual `sg -p '<pattern>' --lang <lang>` commands by hand. Prefer the repo's
+own `errcheck`/`staticcheck` (Go) or `cargo clippy` (Rust) when configured — the
+rule project surfaces what those linters would catch, it does not replace them.
+
+For every finding, capture: `file:line`, matched snippet, surrounding function
 name if discoverable.
 
 #### Step A3: Classify severity
@@ -197,6 +218,7 @@ Totals: errors(high=N med=N low=N)  degradation(high=N med=N low=N)  across M fi
 
 ## See Also
 
+- [`rules/`](rules/) — the executable ast-grep catalog for the errors track (`sgconfig.yml` + `rules/lib/*.yml` + `rules/tests/*-test.yml`); run `ast-grep test -c rules/sgconfig.yml --skip-snapshot-tests` to verify every rule against its fixtures
 - `/code:antipatterns` — delegates here for the error-swallowing category
 - `/code:review` — prose code review
 - `.claude/rules/shell-scripting.md` — canonical allowlist for shell `\|\| true` / `2>/dev/null`

--- a/code-quality-plugin/skills/code-hidden-failures/rules/lib/go-defer-close-unchecked.yml
+++ b/code-quality-plugin/skills/code-hidden-failures/rules/lib/go-defer-close-unchecked.yml
@@ -1,0 +1,6 @@
+id: go-defer-close-unchecked
+language: go
+severity: warning
+message: "`defer f.Close()` drops any write/close error — capture it into a named return on writers"
+rule:
+  pattern: defer $F.Close()

--- a/code-quality-plugin/skills/code-hidden-failures/rules/lib/go-ignore-underscore.yml
+++ b/code-quality-plugin/skills/code-hidden-failures/rules/lib/go-ignore-underscore.yml
@@ -1,0 +1,7 @@
+id: go-ignore-underscore
+language: go
+severity: warning
+message: Error result assigned to _ is discarded — check it or wrap it
+note: Prefer the project's errcheck / staticcheck (SA4006) when configured.
+rule:
+  pattern: _ = $CALL($$$)

--- a/code-quality-plugin/skills/code-hidden-failures/rules/lib/js-empty-catch.yml
+++ b/code-quality-plugin/skills/code-hidden-failures/rules/lib/js-empty-catch.yml
@@ -1,0 +1,6 @@
+id: js-empty-catch
+language: tsx
+severity: warning
+message: Empty catch block silently swallows the error
+rule:
+  pattern: "try { $$$ } catch ($E) { }"

--- a/code-quality-plugin/skills/code-hidden-failures/rules/lib/js-promise-catch-empty.yml
+++ b/code-quality-plugin/skills/code-hidden-failures/rules/lib/js-promise-catch-empty.yml
@@ -1,0 +1,9 @@
+id: js-promise-catch-empty
+language: tsx
+severity: warning
+message: Promise .catch handler discards the rejection
+rule:
+  any:
+    - pattern: $EXPR.catch(() => {})
+    - pattern: $EXPR.catch(($E) => {})
+    - pattern: $EXPR.catch(() => null)

--- a/code-quality-plugin/skills/code-hidden-failures/rules/lib/js-void-ignore.yml
+++ b/code-quality-plugin/skills/code-hidden-failures/rules/lib/js-void-ignore.yml
@@ -1,0 +1,6 @@
+id: js-void-ignore
+language: tsx
+severity: info
+message: "`void`-ing a promise discards its rejection — confirm this is intentional fire-and-forget"
+rule:
+  pattern: void $EXPR($$$)

--- a/code-quality-plugin/skills/code-hidden-failures/rules/lib/py-bare-except-pass.yml
+++ b/code-quality-plugin/skills/code-hidden-failures/rules/lib/py-bare-except-pass.yml
@@ -1,0 +1,12 @@
+id: py-bare-except-pass
+language: python
+severity: warning
+message: "Bare `except: pass` swallows every exception, including KeyboardInterrupt"
+rule:
+  pattern:
+    context: |
+      try:
+          pass
+      except:
+          pass
+    selector: except_clause

--- a/code-quality-plugin/skills/code-hidden-failures/rules/lib/py-broad-except-pass.yml
+++ b/code-quality-plugin/skills/code-hidden-failures/rules/lib/py-broad-except-pass.yml
@@ -1,0 +1,12 @@
+id: py-broad-except-pass
+language: python
+severity: warning
+message: "`except Exception: pass` swallows all errors — log and re-raise, or narrow the type"
+rule:
+  pattern:
+    context: |
+      try:
+          pass
+      except Exception:
+          pass
+    selector: except_clause

--- a/code-quality-plugin/skills/code-hidden-failures/rules/lib/rs-let-underscore-result.yml
+++ b/code-quality-plugin/skills/code-hidden-failures/rules/lib/rs-let-underscore-result.yml
@@ -1,0 +1,6 @@
+id: rs-let-underscore-result
+language: rust
+severity: warning
+message: "`let _ = <expr>` discards a Result — propagate with ? or handle the error"
+rule:
+  pattern: let _ = $EXPR;

--- a/code-quality-plugin/skills/code-hidden-failures/rules/lib/rs-ok-discard.yml
+++ b/code-quality-plugin/skills/code-hidden-failures/rules/lib/rs-ok-discard.yml
@@ -1,0 +1,6 @@
+id: rs-ok-discard
+language: rust
+severity: warning
+message: "`.ok();` as a statement throws away the error arm of a Result"
+rule:
+  pattern: $EXPR.ok();

--- a/code-quality-plugin/skills/code-hidden-failures/rules/sgconfig.yml
+++ b/code-quality-plugin/skills/code-hidden-failures/rules/sgconfig.yml
@@ -1,0 +1,24 @@
+# ast-grep rule project for the code-hidden-failures ERRORS track
+# (swallowed errors: empty catch, ignored returns, discarded Results).
+# The shell track stays grep-based (see REFERENCE-shell.md) — bash suppressions
+# like `|| true` / `2>/dev/null` are line-shaped, not AST-shaped.
+#
+# Invoke from the skill with:
+#   ast-grep scan -c ${CLAUDE_SKILL_DIR}/rules/sgconfig.yml --json=compact <path>
+# Test the rules (valid/invalid fixtures, no snapshot files needed):
+#   ast-grep test -c ${CLAUDE_SKILL_DIR}/rules/sgconfig.yml --skip-snapshot-tests
+#
+# JS/TS rules use `language: tsx` — the Tsx grammar parses plain TS/JS *and*
+# JSX, so one rule per pattern covers .ts/.tsx/.js/.jsx/.mjs/.cjs.
+ruleDirs:
+  - lib
+testConfigs:
+  - testDir: tests
+languageGlobs:
+  tsx:
+    - "*.ts"
+    - "*.tsx"
+    - "*.js"
+    - "*.jsx"
+    - "*.mjs"
+    - "*.cjs"

--- a/code-quality-plugin/skills/code-hidden-failures/rules/tests/go-defer-close-unchecked-test.yml
+++ b/code-quality-plugin/skills/code-hidden-failures/rules/tests/go-defer-close-unchecked-test.yml
@@ -1,0 +1,17 @@
+id: go-defer-close-unchecked
+valid:
+  - |
+    package main
+    func f() {
+        defer func() {
+            if cerr := w.Close(); cerr != nil {
+                retErr = cerr
+            }
+        }()
+    }
+invalid:
+  - |
+    package main
+    func f() {
+        defer w.Close()
+    }

--- a/code-quality-plugin/skills/code-hidden-failures/rules/tests/go-ignore-underscore-test.yml
+++ b/code-quality-plugin/skills/code-hidden-failures/rules/tests/go-ignore-underscore-test.yml
@@ -1,0 +1,15 @@
+id: go-ignore-underscore
+valid:
+  - |
+    package main
+    func f() {
+        if err := doThing(); err != nil {
+            return
+        }
+    }
+invalid:
+  - |
+    package main
+    func f() {
+        _ = doThing()
+    }

--- a/code-quality-plugin/skills/code-hidden-failures/rules/tests/js-empty-catch-test.yml
+++ b/code-quality-plugin/skills/code-hidden-failures/rules/tests/js-empty-catch-test.yml
@@ -1,0 +1,5 @@
+id: js-empty-catch
+valid:
+  - "try { risky(); } catch (e) { logger.error(e); throw e; }"
+invalid:
+  - "try { risky(); } catch (e) { }"

--- a/code-quality-plugin/skills/code-hidden-failures/rules/tests/js-promise-catch-empty-test.yml
+++ b/code-quality-plugin/skills/code-hidden-failures/rules/tests/js-promise-catch-empty-test.yml
@@ -1,0 +1,7 @@
+id: js-promise-catch-empty
+valid:
+  - "fetchUser(id).catch((err) => { logger.error(err); return null; });"
+invalid:
+  - "fetchUser(id).catch(() => {});"
+  - "fetchUser(id).catch((err) => {});"
+  - "fetchUser(id).catch(() => null);"

--- a/code-quality-plugin/skills/code-hidden-failures/rules/tests/js-void-ignore-test.yml
+++ b/code-quality-plugin/skills/code-hidden-failures/rules/tests/js-void-ignore-test.yml
@@ -1,0 +1,5 @@
+id: js-void-ignore
+valid:
+  - "await sync();"
+invalid:
+  - "void sync();"

--- a/code-quality-plugin/skills/code-hidden-failures/rules/tests/py-bare-except-pass-test.yml
+++ b/code-quality-plugin/skills/code-hidden-failures/rules/tests/py-bare-except-pass-test.yml
@@ -1,0 +1,13 @@
+id: py-bare-except-pass
+valid:
+  - |
+    try:
+        do_thing()
+    except ValueError:
+        handle()
+invalid:
+  - |
+    try:
+        do_thing()
+    except:
+        pass

--- a/code-quality-plugin/skills/code-hidden-failures/rules/tests/py-broad-except-pass-test.yml
+++ b/code-quality-plugin/skills/code-hidden-failures/rules/tests/py-broad-except-pass-test.yml
@@ -1,0 +1,14 @@
+id: py-broad-except-pass
+valid:
+  - |
+    try:
+        do_thing()
+    except Exception:
+        logger.exception("failed")
+        raise
+invalid:
+  - |
+    try:
+        do_thing()
+    except Exception:
+        pass

--- a/code-quality-plugin/skills/code-hidden-failures/rules/tests/rs-let-underscore-result-test.yml
+++ b/code-quality-plugin/skills/code-hidden-failures/rules/tests/rs-let-underscore-result-test.yml
@@ -1,0 +1,12 @@
+id: rs-let-underscore-result
+valid:
+  - |
+    fn f() -> Result<(), Error> {
+        do_thing()?;
+        Ok(())
+    }
+invalid:
+  - |
+    fn f() {
+        let _ = do_thing();
+    }

--- a/code-quality-plugin/skills/code-hidden-failures/rules/tests/rs-ok-discard-test.yml
+++ b/code-quality-plugin/skills/code-hidden-failures/rules/tests/rs-ok-discard-test.yml
@@ -1,0 +1,13 @@
+id: rs-ok-discard
+valid:
+  - |
+    fn f() {
+        if let Err(err) = writeln!(out, "x") {
+            eprintln!("{err}");
+        }
+    }
+invalid:
+  - |
+    fn f() {
+        writeln!(out, "x").ok();
+    }

--- a/code-quality-plugin/skills/code-hidden-failures/scripts/tests/test-rules-project.sh
+++ b/code-quality-plugin/skills/code-hidden-failures/scripts/tests/test-rules-project.sh
@@ -25,13 +25,19 @@ sgconfig="${rules_dir}/sgconfig.yml"
 fail() { echo "FAIL: $1" >&2; exit 1; }
 pass() { echo "PASS: $1"; }
 
+# Resolve the ast-grep binary. It ships as both `ast-grep` and `sg`, but `sg`
+# also collides with shadow-utils' set-group binary (present on Linux CI
+# runners), so require the resolved command to self-identify as ast-grep before
+# trusting it — otherwise SKIP cleanly rather than running the wrong binary.
 astgrep=""
-if command -v ast-grep >/dev/null 2>&1; then
-  astgrep="ast-grep"
-elif command -v sg >/dev/null 2>&1; then
-  astgrep="sg"
-else
-  echo "SKIP: ast-grep/sg not installed; cannot run code-hidden-failures rule tests"
+for cand in ast-grep sg; do
+  if command -v "$cand" >/dev/null 2>&1 && "$cand" --version 2>/dev/null | grep -qiE '^ast[_-]?grep'; then
+    astgrep="$cand"
+    break
+  fi
+done
+if [ -z "$astgrep" ]; then
+  echo "SKIP: ast-grep not installed; cannot run code-hidden-failures rule tests"
   exit 0
 fi
 

--- a/code-quality-plugin/skills/code-hidden-failures/scripts/tests/test-rules-project.sh
+++ b/code-quality-plugin/skills/code-hidden-failures/scripts/tests/test-rules-project.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Regression test for the code-hidden-failures ERRORS-track ast-grep rule
+# project (issue #2010).
+#
+# Semantic invariants (not just "does it parse"):
+#   1. Every rule in rules/lib/ matches its swallowed-error fixture (invalid)
+#      and leaves the correct-handling fixture (valid) untouched — enforced by
+#      `ast-grep test`.
+#   2. Every rule ships with a matching test fixture (no rule lands untested).
+#   3. `ast-grep scan -c rules/sgconfig.yml` runs clean and flags a known
+#      swallowed error — the exact command the SKILL.md rewires to.
+#
+# The shell track stays grep-based (REFERENCE-shell.md + scan-shell.sh) and is
+# intentionally NOT part of this rule project.
+#
+# SKIPs (exit 0) when ast-grep is absent, matching the skill's documented
+# graceful-degradation fallback to the per-pattern flow.
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+rules_dir="${script_dir}/../../rules"
+sgconfig="${rules_dir}/sgconfig.yml"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+pass() { echo "PASS: $1"; }
+
+astgrep=""
+if command -v ast-grep >/dev/null 2>&1; then
+  astgrep="ast-grep"
+elif command -v sg >/dev/null 2>&1; then
+  astgrep="sg"
+else
+  echo "SKIP: ast-grep/sg not installed; cannot run code-hidden-failures rule tests"
+  exit 0
+fi
+
+[ -f "$sgconfig" ] || fail "sgconfig.yml missing at $sgconfig"
+
+rule_count=$(find "${rules_dir}/lib" -name '*.yml' -type f | wc -l | tr -d ' ')
+test_count=$(find "${rules_dir}/tests" -name '*-test.yml' -type f | wc -l | tr -d ' ')
+[ "$rule_count" -gt 0 ] || fail "no rule files found under rules/lib"
+[ "$rule_count" = "$test_count" ] || \
+  fail "rule/fixture count mismatch: $rule_count rules vs $test_count fixtures (every rule needs a *-test.yml)"
+pass "every rule ($rule_count) has a matching test fixture"
+
+missing=""
+while IFS= read -r rf; do
+  id="$(basename "$rf" .yml)"
+  [ -f "${rules_dir}/tests/${id}-test.yml" ] || missing="${missing} ${id}"
+done < <(find "${rules_dir}/lib" -name '*.yml' -type f)
+[ -z "$missing" ] || fail "rules without a fixture:${missing}"
+pass "each rule id maps to a tests/<id>-test.yml"
+
+# Errors track covers four languages — assert the language spread survives edits.
+for lang_prefix in js py go rs; do
+  if ! find "${rules_dir}/lib" -name "${lang_prefix}-*.yml" -type f | grep -q .; then
+    fail "errors track lost its ${lang_prefix}-* rules (js/py/go/rust must all be present)"
+  fi
+done
+pass "errors track covers js, py, go, and rust"
+
+if ! "$astgrep" test -c "$sgconfig" --skip-snapshot-tests >/tmp/hf-astgrep-test.$$.log 2>&1; then
+  cat /tmp/hf-astgrep-test.$$.log >&2
+  rm -f /tmp/hf-astgrep-test.$$.log
+  fail "ast-grep test reported failing rule fixtures"
+fi
+rm -f /tmp/hf-astgrep-test.$$.log
+pass "ast-grep test: all rule fixtures pass"
+
+smoke_dir="$(mktemp -d)"
+[ -n "$smoke_dir" ] || fail "mktemp failed"
+trap 'rm -rf "$smoke_dir"' EXIT
+printf 'try:\n    do_thing()\nexcept:\n    pass\n' > "${smoke_dir}/sample.py"
+out="$("$astgrep" scan -c "$sgconfig" --json=compact "$smoke_dir" 2>/tmp/hf-scan-err.$$.log)"
+scan_rc=$?
+if [ "$scan_rc" -ne 0 ]; then
+  cat /tmp/hf-scan-err.$$.log >&2
+  rm -f /tmp/hf-scan-err.$$.log
+  fail "ast-grep scan exited non-zero ($scan_rc)"
+fi
+rm -f /tmp/hf-scan-err.$$.log
+if command -v jq >/dev/null 2>&1; then
+  ids="$(printf '%s' "$out" | jq -r '.[].ruleId' | sort -u | tr '\n' ' ')"
+  case "$ids" in
+    *py-bare-except-pass*) pass "scan flags known swallowed errors on a sample (ids: $ids)" ;;
+    *) fail "scan did not flag py-bare-except-pass on the sample (got: $ids)" ;;
+  esac
+else
+  case "$out" in
+    *py-bare-except-pass*) pass "scan flags known swallowed errors on a sample" ;;
+    *) fail "scan did not flag py-bare-except-pass on the sample" ;;
+  esac
+fi
+
+echo "OK: code-hidden-failures errors-track rule project ($rule_count rules) verified"
+exit 0


### PR DESCRIPTION
## Summary

Packages the detection catalogs of `code-quality-plugin:code-antipatterns` and `code-quality-plugin:code-hidden-failures` (errors track) as real ast-grep **rule projects** shipped inside the skill dirs, and rewires each `SKILL.md` to run one deterministic `ast-grep scan` instead of re-typing `sg -p '…'` patterns or fanning out agents just to run them (per `offload-to-deterministic-substrate`: the agent decides; the substrate verifies).

## What changed

- **`code-antipatterns/rules/`** — 13 rules (JS/TS via the `tsx` grammar + `languageGlobs` so one rule covers `.ts/.tsx/.js/.jsx/.mjs/.cjs`; Python): empty catch, `console.log`, `var`, `eval`/`new Function`, `innerHTML`/`outerHTML`, `as any` / `: any`, magic-number timers, Vue props mutation, mutable defaults, bare `except`, `global`, `type() ==`. The **mandatory parallel-agent fan-out** (whose only job was running patterns) is removed; agents now do judgment only — severity triage, recommendations, fix planning.
- **`code-hidden-failures/rules/`** — 9 errors-track rules (js/py/go/rust: empty catch, empty `.catch`, `void`-ignore, bare/broad `except: pass`, discarded `_ =`, unchecked `defer Close`, `let _ = <Result>`, `.ok()` discard). The **shell track stays grep-based** (`|| true` / `2>/dev/null` are line-shaped, not AST-shaped) and the degradation/surfacing narrative stays in REFERENCE.
- **Rewired execution** — the mechanical scan is now `ast-grep scan -c ${CLAUDE_SKILL_DIR}/rules/sgconfig.yml --json=compact <path>`.
- **REFERENCE files link to the rule `.yml`** instead of restating patterns (docs-currency / link-don't-duplicate); each keeps its allowlist / severity-promotion / remediation as the per-pattern fallback.
- **Graceful degradation** documented — fall back to the per-pattern `sg -p` flow when `ast-grep` is absent.

## Regression guard

`ast-grep test` fixtures (valid + invalid) for **every** rule, runnable in CI:

```
ast-grep test -c rules/sgconfig.yml --skip-snapshot-tests   # no snapshot files to maintain
```

Skill-local wrappers `scripts/tests/test-rules-project.sh` (auto-discovered by `just test-skill-scripts`) enforce the **semantic** invariants: every rule ships a fixture, all fixtures pass (valid→no-match, invalid→match), the errors track keeps js/py/go/rust coverage, and the exact `ast-grep scan -c rules/sgconfig.yml` command runs clean on a sample. Both wrappers SKIP gracefully when ast-grep is absent.

## Verification

- `ast-grep test` — code-antipatterns 13/13 pass, code-hidden-failures 9/9 pass.
- `just test-skill-scripts` — both new wrappers PASS, `FAILED=0` repo-wide.
- `scripts/lint-context-commands.sh` on both skills — all context commands OK.
- `ast-grep scan -c .../sgconfig.yml --json=compact <sample>` — runs clean, flags expected findings.

Closes #2010

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYeX8HpTsjhYz5LChFmdVg