### PR TITLE
feat(comfyui-plugin): add shared ComfyUI reference skills for authoring, registry lifecycle, and live-smoke

### DIFF
--- a/comfyui-plugin/README.md
+++ b/comfyui-plugin/README.md
@@ -6,12 +6,16 @@ on the Comfy Registry.
 
 ## Overview
 
-This plugin packages the three skills that build and ship ComfyUI node packs:
+This plugin packages the skills that build and ship ComfyUI node packs:
 scaffolding a CI-green repository, orchestrating the full path from idea to a
 live-on-registry pipeline (repo creation, seeding, and the gitops adoption PR
 that wires branch protection + release-please credentials + the registry token
-via the gitops repo's tofu GitHub Actions workflows), and adding a reproducible
-README-screenshot pipeline to a pack.
+via the gitops repo's tofu GitHub Actions workflows), adding a reproducible
+README-screenshot pipeline to a pack, plus a set of ComfyUI reference skills —
+frontend/backend authoring facts, the registry release pipeline, live-smoke
+testing, workflow-JSON editing, and workflow-graph node-selection reference —
+useful in **any** ComfyUI pack or install, not just this plugin's own scaffold
+output.
 
 ## Skills
 
@@ -76,8 +80,90 @@ pack — the piece `comfyui-node-scaffold` intentionally defers:
 **Use when** generating README screenshots for a comfyui pack, or wiring up the
 screenshot pipeline like `comfyui-gallery-loader`.
 
+### comfyui-node-authoring
+
+ComfyUI frontend/backend facts for writing or patching a custom node's code:
+pack layout (vanilla `web/js/` and TS+bun-build), hiding a widget correctly,
+the `widget.serialize = false` + append-last rule for non-persisted widgets,
+DOM event isolation on the canvas, endpoint/subfolder-safety patterns, the
+tooltip lookup chain, canvas hit-testing, and how to verify an undocumented
+LiteGraph/Vue API against the frontend's own sourcemap instead of guessing.
+
+**Use when** writing or patching a ComfyUI custom node's frontend or backend
+code.
+
+### comfy-registry-lifecycle
+
+The Comfy Registry release pipeline end to end: release-please +
+`uv.lock`/`bun.lock` drift traps, the empty-`web/dist` publish-action bug and
+how to verify a publish actually shipped the frontend, version status states
+(Pending/Active/Flagged), phantom versions, `Release-As` footers stripped by
+squash-merge, the `registry-health` workflow, and generating a registry
+icon/banner (with `scripts/registry_banner_bg.py` +
+`registry_banner_compose.py`).
+
+**Use when** setting up, debugging, or auditing a pack's release-please →
+`publish.yml` → registry.comfy.org pipeline, or when a published node's
+frontend or artwork isn't showing up correctly.
+
+### comfyui-pack-live-smoke
+
+Stand a pack up in a real running ComfyUI instance and exercise it end to
+end before publishing — both browser-driven (chrome-devtools MCP) and
+headless API-driven (queue a workflow JSON, poll for completion) variants.
+Catches frontend↔backend contract bugs (gating predicates, empty modals,
+route mismatches) that pytest/vitest miss because they test each half in
+isolation. Reads the target host from the `COMFYUI_HOST` environment
+variable (default `127.0.0.1:8188`) — set it per-machine in
+`.claude/settings.local.json`'s `env` block.
+
+**Use when** verifying a pack before opening a registry/gitops PR, or
+confirming an edited/built workflow JSON actually runs.
+
+### comfy-workflow-json
+
+Programmatically edit ComfyUI workflow JSON with a Python script instead of
+hand-editing: the edge-list rebuild pattern for mutating links without
+hand-surgery, the two link-encoding schemas (top-level array vs
+subgraph-internal dict), preserving the `extra` block (App Mode config
+lives there), and a JSON-only diagnostic for a swapped positive/negative
+wiring bug.
+
+**Use when** a workflow JSON exceeds a file-read size limit, when splicing
+or rewiring nodes programmatically, or when a round-trip transform is
+silently dropping App Mode or canvas state.
+
+### comfy-subgraphs-app-mode
+
+ComfyUI's interactive Subgraph, Subgraph Blueprint, and App Mode
+(linear-mode) features: creating/editing/publishing subgraphs, why a
+Blueprint instance is an isolated snapshot rather than a live reference, and
+how App Mode turns a finished workflow into a fill-the-form UI.
+
+**Use when** deciding whether to package part of a workflow as a subgraph, a
+reusable Blueprint, or an App Mode UI.
+
+### Workflow-graph node-selection reference
+
+`comfy-cli`, `comfy-conditionals`, `comfy-debug-preview`, `comfy-flow-control`,
+`comfy-image-utils`, `comfy-math-strings`, `comfy-metadata`, and
+`comfy-workflow-layout` are a set of "which node do I use for X" reference
+skills covering the `comfy` CLI and the wider node ecosystem (predicates and
+branching, debug/preview/telemetry nodes, flow-control/routing, image
+processing, math/string utilities, output-metadata extraction, and
+auto-layout). Each documents which installed custom-node pack owns a given
+primitive and the gotchas around it (type coercion, `ExecutionBlocker`
+propagation, save-node widget shapes, and so on).
+
+**Use when** building or debugging a workflow graph and unsure which node
+(or which of several similar nodes) is the right one.
+
 ## When to Use This Plugin
 
 Install when you build ComfyUI custom-node packs and want a repeatable path from
-idea to a published, registry-adopted repository. The skills are specific to the
-laurigates pack family and its gitops (tofu-in-GitHub-Actions) adoption flow.
+idea to a published, registry-adopted repository. `comfyui-node-scaffold`,
+`comfy-node`, and `comfyui-screenshot-pipeline` are specific to the laurigates
+pack family and its gitops (tofu-in-GitHub-Actions) adoption flow; the
+remaining skills (node authoring, registry lifecycle, live-smoke, workflow-JSON
+editing, subgraphs/App Mode, and the workflow-graph node-selection reference)
+are general ComfyUI knowledge useful in any pack repo or ComfyUI install.

--- a/comfyui-plugin/skills/comfy-cli/SKILL.md
+++ b/comfyui-plugin/skills/comfy-cli/SKILL.md
@@ -1,0 +1,321 @@
+---
+name: comfy-cli
+description: >-
+  The `comfy` CLI for ComfyUI: install/update/bisect custom nodes, snapshot/restore state, publish to the registry, run workflows headlessly. Use when the user runs `comfy`, `comfy node`, or `comfy run`.
+---
+
+# comfy CLI on this install
+
+`comfy` (comfy-cli) is the upstream Comfy Org Python CLI. Installed here via
+`uv tool` at `~/.local/share/uv/tools/comfy-cli/` (binary symlink at
+`~/.local/bin/comfy`). The default workspace is already pinned to
+your ComfyUI install's root — never pass `--workspace`, never run `set-default` once it's pinned.
+
+The service runs via systemd on `0.0.0.0:8188` (see project `CLAUDE.md`). The
+CLI's lifecycle commands assume *it* owns the process. Most don't apply here.
+The useful surface is **custom-node management**, **headless API execution**,
+and **snapshots**. Almost everything else is either a no-op or actively
+conflicts with the systemd unit.
+
+## What to use
+
+| Task | Command |
+|---|---|
+| List installed custom nodes | `comfy node simple-show installed` |
+| Install a custom node by registry name | `comfy node install <name>` |
+| Install a node directly from the comfy registry by ID (use when Manager's curated list lags or the node was just published) | `comfy node registry-install <node-id>` |
+| Install all custom nodes referenced by an imported workflow | `comfy node install-deps --workflow path/to/workflow.json` |
+| Update one or more nodes | `comfy node update <name> [<name> ...]` |
+| Update every custom node + Comfy core | `comfy node update all` |
+| Reinstall a node's `requirements.txt` (after a venv rebuild or import error) | `comfy node fix <name>` |
+| Snapshot current node state to JSON | `comfy node save-snapshot --output snapshots/$(date -I).json` |
+| Restore a snapshot | `comfy node restore-snapshot snapshots/<file>.json` |
+| Bisect which custom node is breaking startup | `comfy node bisect start` then `good`/`bad` |
+| Generate a dep manifest for a workflow you're sharing | `comfy node deps-in-workflow --workflow X.json --output X.deps.json` |
+| Run an API-format workflow against the running server | `comfy run --workflow path.json --port 8188 --timeout 600 --verbose` |
+| Show installed models in a table | `comfy model list` |
+| Inspect workspace / running-server state | `comfy which`, `comfy env` |
+
+## What NOT to use here
+
+| Command | Why not |
+|---|---|
+| `comfy launch [--background]` | Spawns a second ComfyUI process competing for port 8188 and the GPU against the systemd unit. Use `sudo systemctl start/stop comfyui.service` instead — the project `CLAUDE.md` covers this. |
+| `comfy stop` | Only stops a `comfy launch --background` process — has no effect on the systemd-managed instance. |
+| `comfy install` | Already installed. The directory is the install. |
+| `comfy update comfy` / `comfy update all` | These do `git pull` + `pip install -r requirements.txt` inside `.venv/`. Functionally identical to the manual recipe in project `CLAUDE.md`, but `update all` ALSO mass-updates every custom node (often breaks pinned workflows). Prefer the manual `git pull` + `.venv/bin/python -m pip install -r requirements.txt`, then `comfy node update <specific>` only when needed. |
+| `comfy standalone` | Builds a portable Python interpreter — irrelevant; we have `.venv/`. |
+| `comfy set-default` | Already pinned to your install root — re-running it is a no-op at best. |
+| `comfy manager enable-gui / disable-gui / clear` | Operates on ComfyUI-Manager's reserved-startup-action state. The Manager web UI handles this fine; the CLI flags are rarely needed. |
+
+## Recipes
+
+### Importing a workflow with unknown custom nodes
+
+When a downloaded workflow references nodes that aren't installed, the page
+shows red boxes on load. Instead of hunting through ComfyUI-Manager:
+
+```sh
+comfy node install-deps --workflow user/default/workflows/<topic>/<file>.json
+# Then ask the user to:
+# ! sudo systemctl restart comfyui.service
+```
+
+Restart is required so the new nodes import. `--workflow` accepts both
+`.json` and embedded-metadata `.png` exports.
+
+### Running a workflow headlessly
+
+`comfy run --workflow X.json` requires the **API-format** export, not the
+regular UI workflow JSON. To get one: open the workflow in the web UI →
+Settings → "Enable Dev mode Options" → top menu shows "Save (API Format)".
+
+```sh
+comfy run \
+  --workflow path/to/workflow_api.json \
+  --port 8188 \
+  --timeout 600 \
+  --verbose
+```
+
+The default `--timeout 30` is too low for any video or multi-step workflow on
+this install (Wan 2.2 I2V at 8 steps is ~60–120 s on a 4090). Bump it.
+
+`--host` defaults to localhost; the systemd unit binds `0.0.0.0:8188` so
+local connection works without flags. Output files land in `output/` as
+usual — the CLI doesn't relocate them.
+
+### Safe mass node update (with the post-install venv-mismatch workaround)
+
+Bulk updates frequently break a workflow somewhere. The non-obvious gotcha:
+**`comfy node update`'s post-install pip step runs against comfy-cli's pipx
+venv, not ComfyUI's `.venv/`** — every newly-introduced custom-node Python
+dep ends up in the wrong interpreter where ComfyUI can't see it. You have
+to reinstall each pack's `requirements.txt` against `.venv/` manually.
+
+Full recipe (verified 2026-05-08):
+
+```sh
+# 1. Snapshot for rollback
+mkdir -p snapshots
+comfy node save-snapshot --output snapshots/$(date -I)-pre-update.json
+
+# 2. User stops the service (sudo, not the agent's shell)
+#    ! sudo systemctl stop comfyui.service
+
+# 3. Update core
+git -C <comfyui-root> pull --ff-only
+.venv/bin/python -m pip install -r requirements.txt
+
+# 4. Update every custom node (DO NOT trust its post-install pip step)
+comfy node update all
+
+# 5. Manually reinstall every node's requirements into the CORRECT venv
+for req in custom_nodes/*/requirements.txt; do
+  echo ">>> $(dirname "$req" | sed 's|custom_nodes/||')"
+  ./.venv/bin/python -m pip install --quiet -r "$req" 2>&1 | tail -3
+done
+
+# 6. Pin transformers <5 (see Pitfalls — diffusers/peft chain breaks otherwise)
+.venv/bin/python -m pip install 'transformers>=4.50.3,<5'
+
+# 7. Re-apply local hot-patches (project CLAUDE.md tracks them, e.g. WanVideoWrapper)
+
+# 8. User restarts the service
+#    ! sudo systemctl restart comfyui.service
+```
+
+The snapshot captures git refs of every custom node + the core ComfyUI commit
++ the `pip freeze` of `.venv/`. Restoring rolls all three back:
+
+```sh
+comfy node restore-snapshot snapshots/$(date -I)-pre-update.json
+git -C <comfyui-root> reset --hard <pre-update-sha>
+```
+
+After restart, verify health with the PID-filtered journal query (see
+"Reading the right service boot in journalctl" pitfall).
+
+### Bisecting a startup `IMPORT FAILED`
+
+Project `CLAUDE.md` lists two known-broken packs (`comfyui-depthflow-nodes`,
+`comfyui_magicclothing`) that fail on every startup and are non-fatal. If a
+**new** pack is breaking the service:
+
+```sh
+sudo systemctl stop comfyui.service
+comfy node bisect start
+# CLI launches ComfyUI with half the nodes disabled. Test load.
+comfy node bisect bad   # if the failure reproduces
+comfy node bisect good  # if it doesn't
+# Repeat until a single node is identified, then:
+comfy node bisect reset
+sudo systemctl start comfyui.service
+```
+
+Run this only with the systemd unit stopped — bisect spawns its own
+`comfy launch` instances and will fight the unit for port 8188 otherwise.
+
+### Reinstalling a node's deps after a venv rebuild
+
+If `python3 -m venv --upgrade .venv` (or a full venv recreate to fix the
+broken-shebang issue from project `CLAUDE.md`) leaves a custom node missing
+its Python deps:
+
+```sh
+comfy node fix <node-name>             # one node
+comfy node fix all                     # every installed node
+```
+
+This re-runs each node's `requirements.txt` against the current `.venv/`.
+Faster than reinstalling the node itself, which clones the repo again.
+
+## Pitfalls
+
+- **`comfy run` rejects UI workflow JSON.** It needs the API-format export.
+  The error is unhelpful — usually a JSON parse failure or
+  `KeyError: 'class_type'`. If a workflow is imported from
+  `user/default/workflows/`, those are *UI* exports — re-export through the
+  web UI as API format first.
+- **`--port 8188` is required for `comfy run` here.** The CLI defaults to
+  hitting the port the *CLI* would launch on, not the systemd unit's port.
+  Without `--port`, the run hangs until `--timeout`.
+- **`comfy node install <repo-url>` is registry-only.** It takes a registry
+  name (matched against ComfyUI-Manager's `custom-node-list.json`), not a
+  GitHub URL. To install from a URL, `git clone` into `custom_nodes/` and
+  `comfy node fix <dirname>` to install its requirements.
+- **`comfy node install <node-id>` 404s with `Node 'X@unknown' not found` for
+  recently-published nodes.** The default channel checks the bundled
+  ComfyUI-Manager `custom-node-list.json`, which is rebuilt on a separate
+  cadence from the comfy registry itself. New publishes — and any version
+  still in `NodeVersionStatusPending` while the auto security scan runs —
+  aren't there yet. Workaround: `comfy node registry-install <node-id>`
+  (hidden subcommand) downloads the published `node.zip` straight from
+  `cdn.comfy.org` via the registry API at
+  `api.comfy.org/nodes/<id>/versions` — same artifact, bypasses the
+  curated list. Use this for first-party installs of your own packs right
+  after `comfy node publish`.
+- **`NodeVersionStatusPending` transitions to `Active` automatically.**
+  Every published version is held as `Pending` until the (private)
+  automated security scan finishes — no publisher action required, just
+  wait (observed ≤ a few hours). Check status with
+  `curl -s 'https://api.comfy.org/nodes/<id>/versions' | jq '.[] | {version,status}'`.
+  Until it transitions, `comfy node install` won't see it but
+  `comfy node registry-install` will.
+- **`NodeVersionStatusFlagged` does NOT auto-clear** (distinct from
+  Pending). The scan flagged the version; it stays non-installable and
+  `comfy node install` falls back to the older Active version. The public
+  API exposes no reason — it's only on `registry.comfy.org`. Republishing
+  re-runs the scan; flags can be false positives (an identical change
+  flagged some laurigates packs but not their siblings). Full
+  publishing/status playbook: `.claude/rules/comfy-registry-publishing.md`.
+- **A green `comfy node publish` can still ship a broken tarball.** For
+  TS-built packs the registry `node.zip` shipped an empty `web/dist/`
+  (dead frontend) for weeks despite passing runs — root cause was
+  `publish-node-action@v1` lacking `skip_checkout`. Always verify by
+  downloading the `node.zip` from the version's `downloadUrl` and checking
+  for `web/dist/index.js`. See `comfy-registry-publishing.md`.
+- **Restart is not automatic.** `comfy node install/update/uninstall` modifies
+  `custom_nodes/` but does not signal the running server. New nodes don't
+  load until the service restarts. The CLI prints a "restart required"
+  notice; honor it via `! sudo systemctl restart comfyui.service` (the agent
+  can't `sudo` — ask the user).
+- **`comfy model download` ignores this install's family-subfolder
+  convention.** Project `CLAUDE.md` requires placement under
+  `models/<category>/<family>/...`. The CLI takes a `--relative-path` but
+  no awareness of family layout, so prefer the
+  `hf download → /tmp/staging → mv` recipe in project `CLAUDE.md` for any
+  model that has a family folder. `comfy model download` is acceptable for
+  one-off files at category root (e.g. a `.pth` upscaler going to
+  `models/upscale_models/`).
+- **`comfy model remove`** physically deletes files. If a workflow still
+  references the model, it crashes on next run. Prefer `mv` to a backup dir
+  for anything you might want back.
+- **Updating comfy-cli.** When the CLI prints a "New version available"
+  notice on each invocation, upgrade via `uv tool upgrade comfy-cli`
+  (per global tool-installation priority — uv tool replaced the prior
+  pipx install here). Verify with `comfy --version`. Don't
+  `pip install --upgrade` against the system Python or the ComfyUI
+  `.venv/` — the binary is a uv-tool symlink to its own isolated venv
+  at `~/.local/share/uv/tools/comfy-cli/`, so pip-into-other-interpreters
+  is a no-op for the `comfy` command. If a stray `comfy-cli` is still
+  installed inside the ComfyUI `.venv/` from a previous era, uninstall
+  it (`.venv/bin/python -m pip uninstall -y comfy-cli`) — the in-venv
+  copy is unused now that uv tool owns the symlinks.
+- **`comfy node update`'s post-install pip uses the WRONG venv.** The
+  ComfyUI-Manager subprocess that handles `requirements.txt` for newly-
+  updated nodes is invoked with `comfy-cli`'s `sys.executable`
+  (`~/.local/pipx/venvs/comfy-cli/bin/python`), not the install's `.venv/`.
+  Symptom: post-update logs show `EXECUTE => ['~/.local/pipx/
+  venvs/comfy-cli/bin/python', '-m', 'uv', 'pip', 'install', ...]`, and
+  the new packages don't appear in `.venv/bin/python -m pip list`. Fix:
+  loop over `custom_nodes/*/requirements.txt` and reinstall against the
+  correct interpreter (see "Safe mass node update" recipe). The same bug
+  affects `comfy node fix` and `comfy node install` for the same reason.
+- **transformers 5.x breaks the diffusers/peft chain.** ComfyUI core's
+  `requirements.txt` is `transformers>=4.50.3` with no upper bound, so
+  any pip re-resolve may pull `transformers==5.x`. transformers 5.0
+  removed `HybridCache` and `FLAX_WEIGHTS_NAME`; `peft<0.18` and most
+  installed `diffusers` releases (≤0.35.x as of 2026-05) import those
+  symbols at the top level, so half the diffusion-using custom nodes
+  (`brushnet`, `hunyuanvideowrapper`, `fluxtrainer`, `HiDream-Sampler`,
+  `FramePackWrapper`, `nunchaku`, …) fail with
+  `ImportError: cannot import name 'HybridCache' from 'transformers'`.
+  Fix: `pip install 'transformers>=4.50.3,<5'` (and optionally
+  `pip install --upgrade peft` to 0.19+ for forward compatibility).
+  Re-pin after every core upgrade until either (a) ComfyUI core adds
+  `transformers<5` upper-bound, or (b) installed diffusers/peft releases
+  support transformers 5.x.
+- **ComfyUI-Manager-installed packs are tarball snapshots, not git
+  clones.** The Manager pulls registry zip/tarballs and unpacks into
+  `custom_nodes/<name>/`, with no `.git` directory. So `git pull` /
+  `git log` won't work, and the version is pinned to whatever the
+  registry served at install time — often weeks behind upstream master.
+  Before patching a pack's source, check upstream: a closed issue with a
+  recent release tag may already contain the fix. Quick recipes:
+
+    ```sh
+    # See current upstream of one file without cloning
+    gh api repos/<owner>/<repo>/contents/<path> --jq '.content' | base64 -d
+
+    # Install/upgrade pack from upstream master, replacing the snapshot
+    rm -rf custom_nodes/<dir-name>
+    git -C custom_nodes clone https://github.com/<owner>/<RepoName>
+    ./.venv/bin/python -m pip install -r custom_nodes/<RepoName>/requirements.txt
+    ```
+
+  After a fresh clone, the dir name is the GitHub repo's CamelCase form
+  (e.g. `ComfyUI-Thumbnails`), not Manager's lowercase form. That can
+  matter — see the next pitfall.
+- **Custom-node JS hardcodes the GitHub CamelCase dir name in relative
+  imports.** ComfyUI serves a pack's `web/` at
+  `/extensions/<dir-name>/...`, where `<dir-name>` is the on-disk
+  directory. Many packs' JS does `import "../../<RepoName>/js/foo.js"`
+  with the GitHub CamelCase name — fine for a fresh `git clone`, broken
+  when ComfyUI-Manager normalized the dir to lowercase. Symptom: console
+  errors on relative imports / `[vite:preloadError]` / 404s on the
+  pack's own JS in the network tab. Fix: rename the dir to match the JS
+  imports (`mv custom_nodes/<lower> custom_nodes/<RepoName>`), then
+  restart the service. (Do not also fix the JS — upstream churns it.)
+- **Reading the right service boot in `journalctl`.** `journalctl -u
+  comfyui.service -b` is *system* boot, not service restart — every
+  ComfyUI run since the last reboot is in there. Filter to the current
+  service run by `MainPID`:
+
+    ```sh
+    PID=$(systemctl show comfyui.service -p MainPID --value)
+    journalctl _PID=$PID --no-pager
+    ```
+
+  Or `--since "$(systemctl show comfyui.service -p ActiveEnterTimestamp
+  --value | cut -d' ' -f2-)"` if filtering by date. The `-b` form will
+  silently match the *first* "Import times for custom nodes:" block,
+  which is whichever ComfyUI run came first after the last reboot — a
+  trap when comparing pre/post update.
+
+## References
+
+- comfy-cli source: <https://github.com/Comfy-Org/comfy-cli>
+- API workflow format: <https://docs.comfy.org/development/comfyui-server/comms_overview>
+- ComfyUI-Manager registry: <https://github.com/ltdrdata/ComfyUI-Manager>
+- Snapshot format: <https://github.com/Comfy-Org/comfy-cli/blob/main/comfy_cli/command/custom_nodes/cm_cli_util.py>

--- a/comfyui-plugin/skills/comfy-cli/SKILL.md
+++ b/comfyui-plugin/skills/comfy-cli/SKILL.md
@@ -1,7 +1,11 @@
 ---
+created: 2026-07-07
+modified: 2026-07-07
+reviewed: 2026-07-07
 name: comfy-cli
 description: >-
   The `comfy` CLI for ComfyUI: install/update/bisect custom nodes, snapshot/restore state, publish to the registry, run workflows headlessly. Use when the user runs `comfy`, `comfy node`, or `comfy run`.
+allowed-tools: Bash, Read, Grep, Glob
 ---
 
 # comfy CLI on this install
@@ -16,6 +20,13 @@ CLI's lifecycle commands assume *it* owns the process. Most don't apply here.
 The useful surface is **custom-node management**, **headless API execution**,
 and **snapshots**. Almost everything else is either a no-op or actively
 conflicts with the systemd unit.
+
+## When to Use This Skill
+
+| Use this skill when... | Use instead when... |
+|---|---|
+| The user asks to use the `comfy` CLI - install/update/bisect nodes, snapshot/restore, publish, run workflows headlessly | Managing custom nodes via the ComfyUI-Manager UI directly |
+| Running a workflow via `comfy run --workflow ... --port ...` | Running headlessly over the raw HTTP API -> `comfyui-pack-live-smoke` |
 
 ## What to use
 

--- a/comfyui-plugin/skills/comfy-conditionals/SKILL.md
+++ b/comfyui-plugin/skills/comfy-conditionals/SKILL.md
@@ -1,7 +1,11 @@
 ---
+created: 2026-07-07
+modified: 2026-07-07
+reviewed: 2026-07-07
 name: comfy-conditionals
 description: >-
   ComfyUI predicate/boolean nodes: compare, AND/OR/XOR/NOT, ternary, null/empty/type probes, ExecutionBlocker. Use when forming the boolean that drives a workflow switch or blocker.
+allowed-tools: Bash, Read, Grep, Glob
 ---
 
 # ComfyUI conditionals
@@ -17,6 +21,13 @@ Four packs contribute predicate primitives. The split:
 | `comfyui-impact-pack` | `ImpactCompare` + `ImpactConditionalBranch` (lazy) + `ImpactIfNone` + `ImpactConditionalStopIteration` (Impact-iterator loop control) |
 | `comfyui_essentials` | `SimpleCondition` (ternary), `SimpleComparison` (typed, epsilon-aware), `SimpleMathCondition` (boolean from math) |
 | `comfyui-logicutils` | Bit-banging + regex-on-strings logic gates: `AContainsB`, bitwise And/Or/Xor/Not/Shift, generic Invert |
+
+## When to Use This Skill
+
+| Use this skill when... | Use instead when... |
+|---|---|
+| Forming the boolean/predicate that drives a switch or blocker in a workflow | Routing the signal after the decision is made -> `comfy-flow-control` |
+| Comparing values, combining booleans, detecting null/empty | Computing a numeric (non-boolean) value -> `comfy-math-strings` |
 
 ## Sources of truth
 

--- a/comfyui-plugin/skills/comfy-conditionals/SKILL.md
+++ b/comfyui-plugin/skills/comfy-conditionals/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: comfy-conditionals
+description: >-
+  ComfyUI predicate/boolean nodes: compare, AND/OR/XOR/NOT, ternary, null/empty/type probes, ExecutionBlocker. Use when forming the boolean that drives a workflow switch or blocker.
+---
+
+# ComfyUI conditionals
+
+Predicates → boolean → branch. *How the decision is formed*, not where
+the signal goes after.
+
+Four packs contribute predicate primitives. The split:
+
+| Pack | Primary niche |
+|---|---|
+| `comfyui-easy-use` | `easy ifElse`, `easy compare`, `easy blocker`, and the `easy is*` probes — the broadest, most-used predicate kit |
+| `comfyui-impact-pack` | `ImpactCompare` + `ImpactConditionalBranch` (lazy) + `ImpactIfNone` + `ImpactConditionalStopIteration` (Impact-iterator loop control) |
+| `comfyui_essentials` | `SimpleCondition` (ternary), `SimpleComparison` (typed, epsilon-aware), `SimpleMathCondition` (boolean from math) |
+| `comfyui-logicutils` | Bit-banging + regex-on-strings logic gates: `AContainsB`, bitwise And/Or/Xor/Not/Shift, generic Invert |
+
+## Sources of truth
+
+- `custom_nodes/comfyui-easy-use/py/nodes/logic.py` — ifElse, compare, blocker, is* probes
+- `custom_nodes/comfyui-impact-pack/modules/impact/special_samplers.py` — ImpactCompare, ImpactConditionalBranch
+- `custom_nodes/comfyui_essentials/misc.py` — SimpleMath / SimpleCondition / SimpleComparison
+- `custom_nodes/comfyui-logicutils/logic_gates.py` — logic gate nodes
+
+## Which compare node?
+
+| Need | Best node | Why |
+|---|---|---|
+| Compare two ANY values, any op (`==`, `!=`, `<`, `>`, `<=`, `>=`) | `easy compare` | Multi-op switcher widget, no type lock |
+| Compare two INT/FLOAT, return BOOLEAN | `ImpactCompare` | Op picker (`a=b`, `a<>b`, `a>b`, `a<b`, `a>=b`, `a<=b`, `tt`/`ff` constants) |
+| Compare two FLOAT with epsilon tolerance | `SimpleComparison` (essentials) | Floats are unsafe under `==` — epsilon-aware |
+| Compare a string against a regex / substring | `LogicGateCompareString` / `AContainsB` (logicutils) | The only regex-on-string predicate available |
+| Quick math → boolean (e.g. `(a+b) > c`) | `SimpleMathCondition` | Computes the expression and returns BOOLEAN in one node |
+| Detect null / unwired input | `easy isNone` or `ImpactIfNone` | Returns BOOLEAN + passes value through |
+| Detect empty mask (all zeros) | `easy isMaskEmpty` | Specifically tests MASK type |
+| Detect SDXL vs SD1 model | `easy isSDXL` | Probes CLIP / pipe and identifies arch |
+| Detect file path exists on disk | `easy isFileExist` | For input-validation gates |
+
+### Type coercion footgun
+
+`ImpactConditionalBranch.cond` is **BOOLEAN**. Don't feed it:
+
+- `SimpleMathCondition` output → that's FLOAT (0.0 / 1.0) — convert via comparator first
+- `easy compare` output → that IS BOOLEAN, fine
+- `LogicGateCompare` output → BOOLEAN, fine
+- A raw INT from a math node → not BOOLEAN; pass through `ImpactCompare` (`a > 0`) or convert
+
+When in doubt, route through `easy compare` and pick the comparison operator that yields the boolean you want.
+
+## Boolean algebra
+
+For combining multiple predicates into one branch input:
+
+| Operator | Node |
+|---|---|
+| AND / OR / XOR | `ImpactLogicalOperators` (op picker) |
+| NOT | `ImpactNeg` |
+| Bit-wise AND / OR / XOR / NOT / shift | logicutils `LogicGateBitwiseAnd` etc. (work on INT, not BOOLEAN) |
+| Generic invert (works on any truthy/falsy) | `LogicGateInvertBasic` |
+
+```
+isMaskEmpty(face_mask) ──┐
+                         ▼
+                ImpactNeg (NOT)  ──┐
+                                   ▼
+            ImpactLogicalOperators (AND) ──→ ImpactConditionalBranch
+                                   ▲
+isFileExist(reference.png) ────────┘
+```
+
+This combination says: "face mask is non-empty AND reference image
+exists on disk → run the detailer branch".
+
+## Branching
+
+### Lazy if-then-else (skips the discarded branch)
+
+| Node | Behavior |
+|---|---|
+| `easy ifElse` | BOOLEAN selector, `on_true` / `on_false` inputs; only the chosen one is evaluated upstream |
+| `ImpactConditionalBranch` | BOOLEAN `cond`; lazy `tt_value` / `ff_value` inputs |
+| `ImpactConditionalBranchSelMode` | Same, but selection happens at execution time rather than prompt-queue time — needed when `cond` depends on something computed earlier in the same queue |
+
+These are **predicate-side** nodes that ALSO act as switches — they
+form the boolean *and* route in one step. If your predicate is simple
+(one comparison) and the branches are large (samplers, models),
+`ImpactConditionalBranch` is the cleanest single-node solution.
+
+If the predicate is complex (multi-criteria), form it explicitly in
+this skill's primitives, then pass the resulting BOOLEAN to a switch
+from `comfy-flow-control`.
+
+### Ternary (compute, don't route)
+
+`SimpleCondition` (essentials) — given `condition`, returns `value_if_true`
+or `value_if_false`. Both inputs are computed (eager), so it's a *value
+picker*, not an execution gate. Use it for selecting between two
+constants or already-computed scalars; never for selecting between
+sampler chains.
+
+## ExecutionBlocker — the kill-path primitive
+
+`easy blocker` is the canonical "kill this path" node. Behavior:
+
+- Input: any value + `continue` BOOLEAN.
+- If `continue=True`: pass the value through unchanged.
+- If `continue=False`: returns an `ExecutionBlocker` *sentinel*.
+
+The sentinel propagates downstream: any node that receives an
+`ExecutionBlocker` on any input is **silently skipped** (its
+`execute()` is never called). The skip cascades through the rest of
+the graph downstream of the blocker.
+
+```
+LoadImage ── easy compare (size > 1024) ─┐
+                                         ▼
+LoadImage ──────────────► easy blocker ───► ResizeImage ─► KSampler ─► SaveImage
+                            ▲ continue
+```
+
+When the loaded image is smaller than 1024px, the blocker fires;
+ResizeImage / KSampler / SaveImage are all skipped without errors.
+
+### ExecutionBlocker gotchas
+
+- **Preview Bridge swallows the sentinel** — see `comfy-flow-control`
+  gotchas. The blocker fires, but a Preview Bridge tee downstream
+  reports nothing visibly, *and* fails to propagate the abort. Use
+  `FastPreview` (kjnodes) downstream of a blocker if you need
+  visual confirmation.
+- **Cannot be visualized** — there's no "is this currently blocked?"
+  light. Add an `easy showAnything` on the BOOLEAN that drives the
+  blocker to confirm at queue time.
+- **No partial recovery** — once a path is blocked, every downstream
+  node in that chain is skipped, period. To preserve a parallel path
+  through the same upstream value, tee BEFORE the blocker, not after.
+
+## Null / empty / type probes
+
+| Probe | Returns BOOLEAN when |
+|---|---|
+| `easy isNone` | Input is None / unwired / a placeholder |
+| `ImpactIfNone` | Same, plus passes the non-None value through (combines probe + pass-through) |
+| `easy isMaskEmpty` | All mask pixels are zero (no positive area) |
+| `easy isFileExist` | Filesystem path resolves to a real file |
+| `easy isSDXL` | The CLIP / pipe / model identifies as SDXL architecture |
+
+Use cases:
+
+- Detector pipelines: `isMaskEmpty(face_mask)` → blocker to skip
+  detailer when no face is found.
+- Optional reference image: `isFileExist(ref_path)` → switch between
+  "use reference" and "no reference" branches.
+- Multi-architecture workflows that need different sampler defaults:
+  `isSDXL(pipe)` → switch sampler configuration.
+
+## Logicutils — strings, bits, regex
+
+`comfyui-logicutils` is the sole source for:
+
+- **Regex / substring on strings** — `LogicGateCompareString` (also
+  registered as `AContainsB`). Pass a regex pattern in `b`, a string
+  in `a`, get BOOLEAN.
+- **Bitwise integer ops** — for flags packed into a single INT.
+  Niche; mostly useful when interfacing with external systems that
+  send flag bitmasks.
+- **`LogicGateInvertBasic`** — generic invert that handles any
+  truthy/falsy input (more lenient than `ImpactNeg`, which expects
+  strict BOOLEAN).
+
+## Iterator stop
+
+`ImpactConditionalStopIteration` — only useful inside an Impact
+detector→detailer iterator loop. Takes a BOOLEAN; when True, halts
+the iterator's next round. The iterator must support stop signals
+(detector-pipeline variants do; non-iterating Impact paths ignore it).
+
+## Recipes
+
+### Skip face-detailer when no face detected
+
+```
+LoadImage ──► BBoxDetector ──► IMAGE/MASK output
+                                    │
+                                    ▼
+                            easy isMaskEmpty ──► (BOOLEAN)
+                                                    │
+                                                    ▼ (invert: empty → skip)
+                                              ImpactNeg
+                                                    │
+                                                    ▼
+                            ┌───────► easy blocker ◄────── (the image+mask payload)
+                            │           continue
+                            ▼
+                  (downstream FaceDetailer chain, silently skipped on empty)
+```
+
+`isMaskEmpty` → True when no face found → ImpactNeg flips it → False
+→ blocker fires → FaceDetailer + SaveImage chain is skipped without
+error.
+
+### Multi-criteria gate
+
+"Run the high-quality upscale path only if **the image is large AND
+the reference exists AND we're not in SDXL mode**":
+
+```
+GetImageSize&Count(image) ──► width  ──► easy compare (> 1024) ──┐ (BOOL)
+                                                                  │
+easy isFileExist(ref_path) ──► (BOOL) ───────────────────────────┤
+                                                                  │
+easy isSDXL(pipe) ──► ImpactNeg (NOT SDXL) ──► (BOOL) ───────────┤
+                                                                  ▼
+                                              ImpactLogicalOperators (AND of 3)
+                                                                  │
+                                                                  ▼
+                                                  ImpactConditionalBranch
+                                                  tt = upscale chain
+                                                  ff = passthrough
+```
+
+Three independent predicates combined with AND. The downstream branch
+is fully lazy: when any predicate is False, none of the upscale chain
+runs.
+
+### Distinguish "first run" from "rerun" via file existence
+
+Useful for caching: if an output file already exists, skip
+regeneration.
+
+```
+easy isFileExist("output/cached_step1.png") ──► (BOOL)
+                                                  │
+                                                  ▼
+                                  ImpactConditionalBranch
+                                  tt = LoadImage from cache
+                                  ff = run full pipeline + SaveImage
+```
+
+## Gotchas
+
+- **Floats and equality**: `easy compare` with `==` on FLOATs is a
+  trap. Use `SimpleComparison` (epsilon-aware) or `easy compare` with
+  `<` / `>` instead. `1.0 + 2.0 == 3.0` is True, but `0.1 + 0.2 == 0.3`
+  is False.
+- **Lazy branch + `ComfyExecutionBlocker`**: lazy nodes
+  (`easy ifElse`, `ImpactConditionalBranch`) *won't* evaluate the
+  unselected branch, but they pass through whatever node-graph value
+  the selected branch produces — including an `ExecutionBlocker`
+  sentinel. If both branches can emit blockers, plan the merge
+  carefully.
+- **`SimpleMathCondition` returns FLOAT** (1.0 / 0.0), not BOOLEAN.
+  Pass through `ImpactCompare` (`> 0.5`) before feeding a switch that
+  wants BOOLEAN.
+- **`easy isNone` on a pipe**: pipes (`PIPE_LINE`) are tuples — `isNone`
+  returns False on an empty pipe (the tuple exists, just with None
+  fields). To detect missing pipe content, unpack with `pipeOut` and
+  probe individual fields.
+- **`AContainsB` is regex, not substring**: special characters need
+  escaping. To do a plain substring check, escape with `\Q...\E` or
+  use Python regex-special escapes manually.
+
+## Cross-refs
+
+- `comfy-flow-control` — once the boolean is formed, this skill points
+  at the switches that consume it (typed switches, ExecutionBlocker
+  propagation, broadcast routing).
+- `comfy-math-strings` — math primitives that feed comparisons
+  (constants, sliders, SimpleMath expressions, `GetImageSize&Count`
+  outputs).
+- `comfy-debug-preview` — `ShowAnything` / `ShowText` for inspecting
+  the BOOLEAN being passed to a branch at queue time.
+
+## Things this skill does NOT cover
+
+- **Switching / routing AFTER the decision** — that's `comfy-flow-control`.
+- **Numerical computation that doesn't yield a BOOLEAN** —
+  arithmetic, math expressions, string formatting → `comfy-math-strings`.
+- **Image / mask manipulation upstream of the probe** — getting a
+  mask in the first place via segmentation, detection, etc. is
+  model-inference work, not utility.
+- **Sampler-time conditionals** — model_sampling, CFG scheduling,
+  step gating *within* the diffusion loop is sampler/model territory,
+  not workflow logic.

--- a/comfyui-plugin/skills/comfy-debug-preview/SKILL.md
+++ b/comfyui-plugin/skills/comfy-debug-preview/SKILL.md
@@ -1,7 +1,11 @@
 ---
+created: 2026-07-07
+modified: 2026-07-07
+reviewed: 2026-07-07
 name: comfy-debug-preview
 description: >-
   ComfyUI debug/preview nodes: show text/numbers/JSON/tensor shapes, image previews, counts, VRAM/CPU telemetry, timing. Use when inspecting a value mid-graph without changing it.
+allowed-tools: Bash, Read, Grep, Glob
 ---
 
 # ComfyUI debug & preview
@@ -24,6 +28,13 @@ The split:
 | `comfyui_yvann-nodes` | `FloatsVisualizer` (render a float array as a histogram image) |
 | `comfyui-impact-pack` | `Preview Bridge (Image)` / `Preview Bridge (Latent)` — tee inspection while passing through |
 | `comfyui-easy-use` | `easy showAnything`, `easy showLoaderSettingsNames`, `imageCount`, `imagesCountInDirectory` |
+
+## When to Use This Skill
+
+| Use this skill when... | Use instead when... |
+|---|---|
+| Inspecting a value mid-graph without changing it (show/log/preview nodes) | Extracting metadata from a finished output file -> `comfy-metadata` |
+| Checking VRAM/CPU/timing during a run | Computing the value being displayed -> `comfy-math-strings` |
 
 ## Sources of truth
 

--- a/comfyui-plugin/skills/comfy-debug-preview/SKILL.md
+++ b/comfyui-plugin/skills/comfy-debug-preview/SKILL.md
@@ -1,0 +1,301 @@
+---
+name: comfy-debug-preview
+description: >-
+  ComfyUI debug/preview nodes: show text/numbers/JSON/tensor shapes, image previews, counts, VRAM/CPU telemetry, timing. Use when inspecting a value mid-graph without changing it.
+---
+
+# ComfyUI debug & preview
+
+Inspect values mid-graph without changing them. Read / log /
+visualize / time / report. Nothing in this skill mutates the data
+flow — these nodes either pass through unchanged (Preview Bridge,
+TimerNodeKJ) or are pure sinks (ShowText, CConsoleAny).
+
+The split:
+
+| Pack | Niche |
+|---|---|
+| `comfyui-custom-scripts` (pysssss) | `ShowText` — display text in node widget UI |
+| `comfyui_essentials` | `DisplayAny`, `ConsoleDebug`, `DebugTensorShape`, `BatchCount` |
+| `comfyui-kjnodes` | `PreviewImageOrMask`, `FastPreview`, `VRAM_Debug`, `TimerNodeKJ`, `Sleep`, `Get(Image\|Mask\|Latent)SizeAndCount` |
+| `ComfyUI-Crystools` | `CConsoleAny`, `CConsoleAnyToJson`, `CUtilsStatSystem` (CPU/GPU/RAM monitor), `CImageLoadWithMetadata`, `CMetadataExtractor`, `CMetadataCompare` |
+| `bjornulf_custom_nodes` | `ShowFloat`, `ShowInt`, `ShowStringText`, `ShowJson`, `ImageDetails`, `VideoDetails` |
+| `comfyui-dream-project` | `DreamStringToLog`, `DreamIntToLog`, `DreamFloatToLog`, `DreamJoinLog`, `DreamLogFile` |
+| `comfyui_yvann-nodes` | `FloatsVisualizer` (render a float array as a histogram image) |
+| `comfyui-impact-pack` | `Preview Bridge (Image)` / `Preview Bridge (Latent)` — tee inspection while passing through |
+| `comfyui-easy-use` | `easy showAnything`, `easy showLoaderSettingsNames`, `imageCount`, `imagesCountInDirectory` |
+
+## Sources of truth
+
+- `custom_nodes/comfyui-custom-scripts/py/show_text.py` — pysssss ShowText
+- `custom_nodes/comfyui_essentials/misc.py` — DisplayAny, ConsoleDebug, DebugTensorShape
+- `custom_nodes/comfyui-kjnodes/nodes/nodes.py` — VRAM_Debug, TimerNodeKJ, Sleep, Get*SizeAndCount, FastPreview, PreviewImageOrMask
+- `custom_nodes/ComfyUI-Crystools/crystools/nodes_*.py` — CConsoleAny*, CUtilsStatSystem, metadata nodes
+
+## Show-this-value decision
+
+| Value type | Best node | Why |
+|---|---|---|
+| STRING (short) | pysssss `ShowText` | Renders in the node widget; auto-resizes; persists in workflow JSON |
+| STRING (long / multiline) | bjornulf `ShowStringText` or pysssss `ShowText` | Both wrap text; `ShowText` truncates after ~10 lines but expands on hover |
+| ANY (don't know the type) | essentials `DisplayAny` or `easy showAnything` | Coerces to STRING and renders |
+| FLOAT / INT | bjornulf `ShowFloat` / `ShowInt` | Specific formatters; cleaner display than `DisplayAny` |
+| JSON / dict / list | bjornulf `ShowJson` or Crystools `CConsoleAnyToJson` | Pretty-prints with indentation |
+| Tensor (latent / image) shape | essentials `DebugTensorShape` | Logs (B, C, H, W) to console; doesn't display in node UI |
+| Float curve over a batch | yvann `FloatsVisualizer` | Renders the array as a histogram image |
+| Console log (no widget) | essentials `ConsoleDebug`, Crystools `CConsoleAny`, dream `DreamStringToLog` | Output to server stdout/log only — invisible in editor; useful for batch jobs |
+| Image (tee with passthrough) | impact `Preview Bridge` | Pass-through + preview in one node — see the data, keep the chain |
+| Image (just preview, no passthrough) | ComfyUI core `PreviewImage` or kjnodes `PreviewImageOrMask` | The kjnodes variant auto-detects whether the input is image or mask |
+
+### Where the display goes
+
+- **Node-widget UI** (visible in the workflow editor): `ShowText`,
+  `ShowFloat`, `ShowInt`, `ShowStringText`, `ShowJson`, `DisplayAny`,
+  `easy showAnything`. These render INSIDE the node's body, expanding
+  the node to fit the value.
+- **Server log / console** (`journalctl -u comfyui.service` on this
+  install): `ConsoleDebug`, `DebugTensorShape`, `CConsoleAny`,
+  `DreamStringToLog`. No editor display — use these for batch jobs
+  running headless via `comfy run`.
+- **On-disk log file**: `DreamLogFile` appends to a configurable
+  file path; useful for cross-queue tracking.
+- **Visible as image preview**: `PreviewImageOrMask`, `FastPreview`,
+  `FloatsVisualizer`. The preview shows in the standard preview pane.
+
+## Counts and sizes
+
+| Need | Node | Outputs |
+|---|---|---|
+| Image batch (B, H, W) | kjnodes `GetImageSizeAndCount` | width, height, batch_count |
+| Mask (B, H, W) | kjnodes `GetMaskSizeAndCount` | width, height, batch_count |
+| Latent (B, C, H, W) | kjnodes `GetLatentSizeAndCount` | width, height, batch_count |
+| Just N (batch size) | essentials `BatchCount` | int |
+| Image batch count (easy-use variant) | `easy imageCount` | int |
+| Count image files in a directory | `easy imagesCountInDirectory` | int (with offset/limit) |
+| Image file's metadata | bjornulf `ImageDetails` | width, height, channels, format, mode |
+| Video file's metadata | bjornulf `VideoDetails` | width, height, fps, duration, codec |
+
+`Get*SizeAndCount` is the canonical choice — it emits w/h/batch as
+separate INTs that you can wire to math nodes or display.
+
+## System telemetry
+
+For figuring out what's eating VRAM / CPU / RAM mid-graph:
+
+| Node | What it reports | When called |
+|---|---|---|
+| Crystools `CUtilsStatSystem` | CPU %, RAM used/total, GPU VRAM used/total (per-card) | Re-polls every time its output is consumed |
+| kjnodes `VRAM_Debug` | One-shot VRAM snapshot to console | When the node executes |
+| kjnodes `TimerNodeKJ` | Wall-clock elapsed time between start/end of a section | When the end node executes |
+| kjnodes `Sleep` | Pauses execution for N seconds (throttling, not telemetry) | When executed |
+
+### Per-section timing
+
+```
+                ┌─► TimerNodeKJ (start) ──────► (just a pass-through tag)
+                │
+upstream value ─┤
+                │   (do stuff in between)
+                │
+                └─► TimerNodeKJ (end) ──► duration_seconds (FLOAT)
+                                              │
+                                              ▼
+                                  bjornulf `ShowFloat`
+                                  or DreamFloatToLog
+```
+
+Wire the same TimerNodeKJ id on both sides — the node remembers the
+start timestamp keyed by its instance and emits a duration on the
+"end" port.
+
+## Preview Bridge and the ExecutionBlocker pitfall
+
+Impact's `Preview Bridge (Image)` / `Preview Bridge (Latent)` are the
+workhorse "see this *and* pass it through" nodes. Wire an image in,
+get the same image out, plus a preview in the editor.
+
+**Critical pitfall**: Preview Bridge **silently consumes
+`ExecutionBlocker` sentinels**. If a path through the bridge gets
+blocked upstream, the bridge:
+
+1. Shows nothing in the preview (no error, no indicator).
+2. Does NOT propagate the blocker downstream — it converts the
+   blocked path into a "no-op pass-through" of nothing.
+
+Consequence: if you tee `Preview Bridge` off a path that may be
+blocked (e.g. behind an `easy blocker`), the downstream consumer of
+the bridge's output silently sees a None — not a blocker — and
+either errors with a type mismatch or proceeds with garbage.
+
+**Workaround**: when blockers may appear in the path, use kjnodes
+`FastPreview` downstream of the bridge — `FastPreview` passes
+sentinels through correctly. Or branch the preview off BEFORE the
+blocker, not after.
+
+## Metadata extraction
+
+For lightweight in-graph metadata reads (read PNG-embedded workflow
+JSON during a workflow run):
+
+| Node | Use |
+|---|---|
+| Crystools `CImageLoadWithMetadata` | Load image + emit its `image.info` PNG metadata as JSON |
+| Crystools `CMetadataExtractor` | Pull a specific key from a metadata blob |
+| Crystools `CMetadataCompare` | Diff two metadata blobs and report differences |
+| bjornulf `ImageDetails` | Read width/height/format from any image — doesn't surface workflow JSON |
+
+For batch / cross-output-directory analysis ("which prompt produced
+all these images?", "scan output/ and find runs that used model X"),
+use the dedicated **`comfy-metadata`** skill — it covers the full
+range of metadata sources (PNG tEXt, WebP EXIF Make/Model, MP4
+container, kijai WanVideoWrapper's `comment` blob, VHS metadata,
+`.latent` safetensors) and the scripts/scanners for batch
+inspection.
+
+The Crystools nodes here are for **inline** metadata reads as part
+of a workflow's logic; `comfy-metadata` is for **offline** analysis.
+
+## Counter-pattern: timing/profiling vs the wrong layer
+
+If a workflow is slow and you want to find the slow node:
+
+- ✅ Use `TimerNodeKJ` around suspected sections.
+- ✅ Use `CUtilsStatSystem` to log VRAM through the run.
+- ✅ Check the ComfyUI server log (`journalctl -u comfyui.service`)
+  — every node logs its execution time at the end of the run.
+- ❌ Don't add `Sleep` "to give the GPU time" — it doesn't help,
+  ComfyUI is synchronous within a queue.
+
+For deep model-level profiling (CUDA timelines, sageattn vs flash
+attention comparisons, kernel-level), this skill is the wrong layer
+— consult the model-family skill (e.g. `wan` for radial sage
+attention discussion).
+
+## Recipes
+
+### "Why is my prompt different from what I typed?"
+
+After all wildcard expansion, LoRA trigger autoload, and string
+manipulation, you want to see the literal STRING that hits the text
+encoder:
+
+```
+(your full prompt-assembly chain)
+                │
+                ▼
+       (output STRING)
+                │
+       ┌────────┴────────┐
+       │                 │
+       ▼                 ▼
+  CLIPTextEncode    ShowText (pysssss)
+```
+
+The `ShowText` widget will display the resolved prompt — visible in
+the editor after queue. Useful for catching wildcards that didn't
+resolve (`__styles__` remained literal because the file was
+missing), or LoRA tags that came back empty.
+
+### Per-step time budget
+
+You want to know how long each sampler in a 3-sampler chain takes:
+
+```
+LoadImage ─► TimerNodeKJ(start, id=t1) ─► Sampler#1 ─► TimerNodeKJ(end, id=t1) ─► dt1
+                                              │              │
+                                              │              ▼ DreamFloatToLog
+                                              │
+                                              └► TimerNodeKJ(start, id=t2) ─► Sampler#2 ─► …
+```
+
+Three Timer pairs, three durations logged. After the run, check
+the server log or the `DreamLogFile` output for a per-sampler
+breakdown.
+
+### VRAM watch during a long batch
+
+```
+LoadImage ──► CUtilsStatSystem ──► (continues to KSampler)
+                    │
+                    ▼ (writes a line per-poll to log)
+              DreamStringToLog
+```
+
+`CUtilsStatSystem` polls VRAM on each evaluation. Wire its output
+through a logger so each queue tick records GPU state — easy to
+correlate OOMs with workflow position.
+
+### Surface batch counts before sampling
+
+```
+LoadImageBatchFromDir ──► IMAGE ───────► (downstream sampler)
+                            │
+                            ▼
+                  GetImageSizeAndCount ──► width / height / batch_count
+                                                          │
+                                                          ▼
+                                                   ShowInt
+```
+
+Before queuing a big batch, glance at the count to confirm you
+didn't accidentally load a directory of 500 images when you meant 5.
+
+## Gotchas
+
+- **`ShowText` updates AFTER queue completion**, not live during the
+  run. For mid-run display you need a console log
+  (`DebugTensorShape`, `CConsoleAny`) plus tailing the server log.
+- **`Preview Bridge` swallows `ExecutionBlocker`** — see above.
+  Mitigations: tee off the path BEFORE any potential blocker, or use
+  `FastPreview` downstream.
+- **`CUtilsStatSystem` only polls when its output is consumed**.
+  Wiring it to nothing means it never runs. Wire the output to a
+  console logger or a `ShowFloat` to make it actually poll.
+- **`DisplayAny` truncates large strings** to ~10 lines / ~1000 chars.
+  For longer values use `ShowStringText` (bjornulf) which scrolls,
+  or `DreamStringToLog` which writes to the server log without
+  truncation.
+- **`TimerNodeKJ` start/end pairing**: the `id` parameter must
+  match between the start and end instances. Multiple Timer pairs
+  with the same id cross-pollute their start times.
+- **`Sleep` is on the *graph* execution thread**, not GPU. It blocks
+  the entire queue, including unrelated parallel branches. Use only
+  when intentionally throttling.
+- **`FloatsVisualizer` renders to image at fixed resolution** — the
+  output is an IMAGE, not a graph object. Wire it through
+  `PreviewImage` to display.
+- **`DreamLogFile` opens the file in append mode each call** — for
+  high-frequency logging in a loop, file IO becomes the bottleneck.
+  Use a console logger instead and tail the server log offline.
+- **Crystools metadata nodes operate on PNG `image.info` only** —
+  they don't read MP4/WebP/EXIF. For those, the offline
+  `comfy-metadata` skill covers the full range.
+
+## Cross-refs
+
+- `comfy-math-strings` — formatting numeric / string values before
+  display (the math is in math-strings; the show is here).
+- `comfy-flow-control` — Preview Bridge as a routing tee
+  (flow-control's gotcha list also covers the blocker pitfall).
+- `comfy-metadata` — deep metadata extraction across output
+  directories: PNG tEXt / iTXt, WebP EXIF, MP4 container, kijai
+  WanVideoWrapper / VHS `comment` blobs, `.latent` safetensors.
+  When the question is "what produced this output file?" (offline /
+  retrospective), reach for `comfy-metadata`. When the question is
+  "what is this *current* image's PNG metadata?" (inline / live),
+  use the Crystools nodes documented here.
+- `comfy-conditionals` — `easy showAnything` on a BOOLEAN to
+  confirm a predicate at queue time before trusting the branch
+  decision.
+
+## Things this skill does NOT cover
+
+- **Offline / batch metadata analysis** — → `comfy-metadata`.
+- **Performance profiling at the model layer** (sageattn vs flash,
+  KV cache, attention slicing) — → model-family skills (`wan`,
+  `z-image`).
+- **Workflow-level reorganization to make a graph more debuggable**
+  (auto-layout, group cohesion) — → `comfy-workflow-layout`.
+- **Computing the values being displayed** — → `comfy-math-strings`.
+- **The `simplify` user-level skill** (review changed code) — that's
+  a Claude Code agent skill, not a ComfyUI workflow skill.

--- a/comfyui-plugin/skills/comfy-flow-control/SKILL.md
+++ b/comfyui-plugin/skills/comfy-flow-control/SKILL.md
@@ -1,7 +1,11 @@
 ---
+created: 2026-07-07
+modified: 2026-07-07
+reviewed: 2026-07-07
 name: comfy-flow-control
 description: >-
   ComfyUI routing nodes: typed switches, index switches, broadcast (Anything Everywhere), pipe/context bundles, for/while loops, ExecutionBlocker gates. Use when wiring where a signal routes in a workflow.
+allowed-tools: Bash, Read, Grep, Glob
 ---
 
 # ComfyUI flow control
@@ -12,6 +16,13 @@ the signal go* once the decision is made.
 Six packs on this install contribute flow-control primitives. Each has
 overlapping options and pack-specific quirks — the goal of this skill
 is to pick the right one in one decision, not browse a dropdown.
+
+## When to Use This Skill
+
+| Use this skill when... | Use instead when... |
+|---|---|
+| Wiring how a signal routes, switches, broadcasts, loops, or is gated | Forming the predicate that drives the route -> `comfy-conditionals` |
+| Picking a switch / index-switch / broadcast node | Debugging or inspecting a routed value -> `comfy-debug-preview` |
 
 ## Sources of truth
 

--- a/comfyui-plugin/skills/comfy-flow-control/SKILL.md
+++ b/comfyui-plugin/skills/comfy-flow-control/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: comfy-flow-control
+description: >-
+  ComfyUI routing nodes: typed switches, index switches, broadcast (Anything Everywhere), pipe/context bundles, for/while loops, ExecutionBlocker gates. Use when wiring where a signal routes in a workflow.
+---
+
+# ComfyUI flow control
+
+Routing, switching, broadcast, bundling, looping, gating. *Where does
+the signal go* once the decision is made.
+
+Six packs on this install contribute flow-control primitives. Each has
+overlapping options and pack-specific quirks — the goal of this skill
+is to pick the right one in one decision, not browse a dropdown.
+
+## Sources of truth
+
+- `custom_nodes/rgthree-comfy/__init__.py` — context bundles, Any Switch, Power Lora Loader, fast groups muter (frontend-only)
+- `custom_nodes/cg-use-everywhere/__init__.py` — broadcast "Anything Everywhere" sentinels
+- `custom_nodes/ComfyUI-Crystools/crystools/nodes_switch.py` — type-typed CSwitchBoolean* family
+- `custom_nodes/comfyui-impact-pack/modules/impact/special_samplers.py` and `core.py` — ImpactSwitch (`GeneralSwitch`/`GeneralInversedSwitch`), ImpactConditionalBranch, ExecutionOrderController
+- `custom_nodes/comfyui-easy-use/py/nodes/logic.py` and `flow.py` — easy switches, pipes, forLoop, whileLoop, blocker
+- ComfyUI core — built-in `ComfySwitchNode` (boolean toggle between two same-type inputs)
+
+## Pick-a-switch decision
+
+| You have… | Selector | Best node | Why |
+|---|---|---|---|
+| 2 IMAGE inputs, BOOLEAN selector | bool | `easy imageSwitch` or Crystools `CSwitchBooleanImage` | Lazy: only the chosen branch runs |
+| 2 ANY inputs, BOOLEAN selector | bool | Crystools `CSwitchBooleanAny` | Lazy; cleanest signature |
+| 2 STRING inputs, BOOLEAN selector | bool | `easy textSwitch` or Crystools `CSwitchBooleanString` | Both lazy |
+| 2 CONDITIONING inputs, BOOLEAN | bool | Crystools `CSwitchBooleanConditioning` | Lazy; native CONDITIONING type |
+| 2 LATENT / MASK inputs, BOOLEAN | bool | Crystools `CSwitchBooleanLatent` / `CSwitchBooleanMask` | Lazy; typed |
+| N ANY inputs, INT selector (3-20) | index | `easy anythingIndexSwitch` (up to 20) | Only easy-use scales past 2 inputs |
+| N IMAGE / TEXT / CONDITIONING, INT | index | `easy imageIndexSwitch` / `easy textIndexSwitch` / `easy conditioningIndexSwitch` | Typed N-way |
+| K ANY inputs, "first non-None wins" | any | rgthree `Any Switch` | Pick the first connected/non-empty input |
+| 1 ANY input → 2 ANY outputs (demux) | bool | Crystools `CSwitchFromAny` | Unique: output-side mux. Bool routes the *one* input to one of two outputs |
+| 2 BOOLEAN inputs that disagree | logic | `easy compare` or `ImpactCompare` then a switch above | Predicate formation lives in `comfy-conditionals` |
+| Toggle entire LoRA stack on/off | bool | rgthree `Power Lora Loader` with toggles per row | Single node holds the stack + per-LoRA enable/strength |
+| Mute/bypass a whole group of nodes | mouse | rgthree fast groups muter (frontend) | Right-click group → Mute / Bypass. No node needed |
+
+### Input-side vs output-side mux
+
+- **Input-side mux** (the standard pattern): N inputs → 1 output. The
+  switch decides which input to forward. The bool/index selector reads
+  *before* the upstream graph evaluates, so unselected branches can
+  often be skipped (see lazy-vs-eager below).
+- **Output-side mux** (Crystools `CSwitchFromAny` only): 1 input → 2
+  outputs. The bool picks which output port receives the value; the
+  other port emits None / a default. Use this when *one upstream*
+  feeds two divergent downstream paths and you want to send it to only
+  one at a time.
+
+### Lazy vs eager evaluation
+
+Lazy switches mark unselected branches as "do not evaluate", so the
+upstream chain feeding the discarded branch is skipped entirely. Saves
+GPU and time. Eager switches force every upstream branch to compute
+even if its output gets thrown away.
+
+| Lazy (skip unselected upstream) | Eager (run all branches always) |
+|---|---|
+| `easy ifElse`, `easy imageSwitch`, `easy textSwitch`, `easy anythingIndexSwitch` (and the typed `*IndexSwitch` siblings), `easy blocker` (downstream blocker) | `ImpactSwitch` / `GeneralSwitch` (data routing only) |
+| All `CSwitchBoolean*` (Crystools) | `CSwitchFromAny` (must compute input before routing) |
+| `ImpactConditionalBranch`, `ImpactConditionalBranchSelMode` | rgthree `Any Switch` (selects after upstream resolves) |
+
+When the unselected branch is cheap (a constant or a small VAEDecode),
+the difference is invisible. When it's a sampler chain, lazy switches
+save tens of seconds per queue.
+
+## Broadcast routing — `cg-use-everywhere`
+
+The `Anything Everywhere` family doesn't have output ports. You wire a
+value (model / clip / vae / seed / conditioning / anything) *into* the
+node, and it acts as an invisible producer: any *unconnected* input
+slot of the matching type elsewhere in the graph receives the value
+automatically.
+
+| Node | Use when |
+|---|---|
+| `Anything Everywhere` | One MODEL or VAE is reused by 6 nodes scattered across the graph — declare once, skip 6 reroute wires |
+| `Anything Somewhere` | Regex-filtered: broadcasts only to inputs whose *socket name* matches the regex you set on the broadcaster |
+| `Anything Everywhere Triplet` | Positive + negative + latent triplet bundle (the SDXL/Flux conditioning trio) |
+| `Seed Everywhere` | Deprecated; the frontend auto-rewrites to a regular `Anything Everywhere` connected to INT |
+
+**Silent-failure mode**: if two broadcasters carry compatible types
+and both could match an empty socket, *one of them wins* (depends on
+node id ordering) and the other is silently ignored. Color the broadcasters
+in the UI so the routing is visible — they're invisible by design and
+hard to debug otherwise. When debugging, replace with explicit reroutes
+to see exactly where each value lands.
+
+Use broadcast for **scalars and constants** (seed, model, vae, a
+shared prompt). Avoid for transient intermediate values whose meaning
+shifts as the graph runs — explicit wires there make the workflow
+more legible.
+
+## Context vs pipe bundles
+
+Both rgthree's `Context` and easy-use's `pipeIn`/`pipeOut` carry a
+multi-typed bundle on a single wire. They are not interchangeable.
+
+| | rgthree Context | easy-use pipe |
+|---|---|---|
+| Wire type | `RGTHREE_CONTEXT` (custom) | `PIPE_LINE` (custom) |
+| Field access | Named (model / clip / vae / positive / negative / latent / image / seed) | Positional (model, pos, neg, latent, vae, clip, image, seed) |
+| Override / edit mid-graph | `Context Merge` / `Context Merge Big` | `pipeEdit` |
+| Unpack | `Context Switch` selects between multiple full contexts; individual fields auto-emerge from the Context node's right side | `pipeOut` emits all 8 slots; or downstream nodes consume `PIPE_LINE` directly |
+| Bridge between | Convert manually: unpack with `Context` outputs → repack with `pipeIn` (and vice-versa) | Same, reverse |
+| Best for | Sharing a stable model/clip/vae across many subgraphs | easy-use's own ecosystem (its samplers and pre-samplers expect PIPE_LINE) |
+
+Mixing the two in one workflow is allowed but every cross-bridge is a
+manual repack. Pick one bundle convention per workflow.
+
+## Loops
+
+Easy-use ships the only general-purpose loop primitives in this
+install. Use sparingly — ComfyUI's execution model wasn't designed for
+iteration, and loops expand at prompt-queue time to a sequence of
+copied subgraph nodes (so an N=50 loop is N=50 sampler instances in
+the graph, not one node looping).
+
+| Loop | Setup |
+|---|---|
+| `easy forLoopStart` → body → `easy forLoopEnd` | `total` count (INT), `values_1..N` carry state through iterations |
+| `easy whileLoopStart` → body → `easy whileLoopEnd` | `condition` (BOOLEAN) checked after each iteration; emits FLOW_CONTROL token + state |
+
+Best practice:
+
+- Keep loop bodies short. Each iteration replicates the entire subgraph
+  in the queue, so 30 iterations × 50 nodes ≈ 1500-node queue.
+- Always have an exit predicate. `whileLoopEnd` with no terminating
+  condition will hang the queue forever.
+- The state-carry slots (`values_*`) are how you accumulate — write to
+  them at the end, read at the start.
+- For per-image batch iteration, prefer ComfyUI's native batch
+  semantics (let the sampler process a batch) over a loop. Loops are
+  for iteration where each round depends on the previous round's
+  output.
+
+## Execution gating
+
+| Primitive | What it does |
+|---|---|
+| `easy blocker` | Pass-through; if `continue=False` returns an `ExecutionBlocker` sentinel. Any downstream node touching the sentinel is silently skipped. |
+| `ImpactConditionalStopIteration` | Inside an Impact iterator (detector → detailer loop), halts the loop when its BOOLEAN input is True. |
+| `ImpactExecutionOrderController` | Pins a side-effect node (SaveImage, log, webhook) to run before / after a designated other node. Used when ComfyUI's free reordering picks the wrong sequence. |
+
+`ExecutionBlocker` is the canonical "kill this path" primitive in
+ComfyUI — see `comfy-conditionals` for predicate formation and
+detailed semantics (Preview Bridge consumes the sentinel silently;
+SaveImage downstream is the abort target).
+
+## Recipes
+
+### Toggleable LoRA stack with bypass
+
+You have 3–8 LoRAs stacked into a chain. You want each one individually
+toggleable, with a master "all off" too.
+
+```
+UNETLoader ─┐
+            │
+            ▼
+rgthree Power Lora Loader  ← per-row: enabled (bool), name, strength
+            │
+            ▼
+ModelSamplingAuraFlow (or whatever)
+```
+
+- One node holds the stack. UI per-row toggle + strength.
+- Group the loader + downstream sampler nodes; right-click → Mute
+  Group to bypass the whole branch when prototyping.
+- To make a *single* LoRA toggleable as a separate node, wrap with
+  Crystools `CSwitchBooleanAny`: bool=on → goes through `LoraLoaderModelOnly`,
+  bool=off → bypasses straight to the next stage.
+
+### Optional upscale pass with lazy switch
+
+User sometimes wants a 2× upscale, sometimes doesn't. Without lazy
+evaluation, the upscale chain (model loader + KSampler + VAEDecode)
+runs even when discarded.
+
+```
+                              ┌── on_true: UpscaleModelLoader → Sampler → VAEDecode ──┐
+SaveImage upstream ────────── ┤                                                       ├── SaveImage
+                              └── on_false: passthrough ─────────────────────────────┘
+                                 ▲
+                                 │
+                              Crystools CSwitchBooleanImage (lazy)
+```
+
+- The Crystools switch is lazy → when bool=False, the entire upscale
+  chain is skipped, not just discarded.
+- Bool can come from a `PrimitiveBoolean`, a `RgthreeContext` field, or
+  an `easy compare` predicate.
+
+### Migrating a workflow off broadcast wires for review
+
+When sharing a workflow that uses `Anything Everywhere`, the rest of
+the graph has unconnected input sockets that "look" wrong but work
+fine because of the broadcaster. For readability when sending the
+workflow to someone:
+
+1. Right-click `Anything Everywhere` → "Show connections" (frontend
+   flag in the rgthree side panel) — renders dashed lines.
+2. Manually wire what the broadcaster was implicitly doing.
+3. Delete the broadcaster node.
+
+Reverse the process when receiving a wired workflow you want to
+clean up.
+
+## Gotchas
+
+- **`ComfySwitchNode` (core)** is widget-overridden by an input.
+  When you wire a BOOLEAN into the `switch` slot of `ComfySwitchNode`,
+  the node's own widget value is ignored — the connected input wins.
+  This bites you when the widget shows False but a connected
+  PrimitiveBoolean(True) is in effect.
+- **`Any Switch` (rgthree)** is eager — it evaluates *all* upstream
+  inputs before picking the first non-None. Don't use it as a
+  performance optimizer; use a typed `CSwitchBoolean*` for laziness.
+- **`Preview Bridge` swallows `ExecutionBlocker`**: if you tee a path
+  through Preview Bridge to inspect it, and the path is blocked, the
+  Preview shows nothing and the downstream abort doesn't propagate
+  through the bridge. Use `FastPreview` (`comfyui-kjnodes`) downstream
+  of a Preview Bridge when blockers may appear, or wire previews off
+  branches that can't be blocked.
+- **`ImpactConditionalBranch.cond` is BOOLEAN, not INT/FLOAT**.
+  `SimpleMathCondition` (essentials) returns FLOAT — convert with a
+  comparator before feeding the branch.
+- **Context Big silently drops mismatched slots**. If you wire an
+  `IMAGE` to a `Context Big.latent` slot the wire is ignored at
+  evaluation. Hover the Context outputs to check what's actually
+  populated.
+- **Easy-use loops expand at queue-time, not runtime**. A loop of 50
+  iterations becomes 50 copies of the body inside the queue's prompt
+  graph. Very large loops can OOM the *frontend* (browser) before
+  even reaching the backend.
+
+## Cross-refs
+
+- `comfy-conditionals` — forming the boolean / index that feeds these
+  switches. Predicates, comparisons, null checks, ExecutionBlocker
+  patterns.
+- `comfy-prompting` — `Power Lora Loader` plays nicely with LoRA
+  trigger-word autoload nodes; see the cross-ref there for the full
+  recipe.
+- `comfy-debug-preview` — Preview Bridge details, FastPreview as the
+  blocker-aware alternative.
+- `comfy-math-strings` — primitive sources (PrimitiveBoolean, INT/FLOAT
+  constants, sliders) that drive these switches.
+
+## Things this skill does NOT cover
+
+- **Predicate formation** — how to build the boolean that feeds a
+  switch. → `comfy-conditionals`.
+- **Reroute nodes for visual cleanup** — those are frontend-only and
+  don't affect execution; covered by `comfy-workflow-layout` and
+  rgthree's UI affordances.
+- **Sampler / model routing** (KSampler vs DPMPP vs Euler, model
+  loader switching) — that's model-family work; see `wan`, `z-image`,
+  `hidream-o1` skills.
+- **Subgraph composition** — packaging part of a workflow into a
+  reusable subgraph. That's a project `CLAUDE.md` topic under
+  "Editing workflow JSON".

--- a/comfyui-plugin/skills/comfy-image-utils/SKILL.md
+++ b/comfyui-plugin/skills/comfy-image-utils/SKILL.md
@@ -1,7 +1,11 @@
 ---
+created: 2026-07-07
+modified: 2026-07-07
+reviewed: 2026-07-07
 name: comfy-image-utils
 description: >-
   ComfyUI non-inference image ops: resize/crop/pad/tile/batch/mask utilities, plus image-to-text captioners (Florence-2, WD14, BLIP, DeepDanbooru). Use when manipulating images or generating captions/tags in a workflow.
+allowed-tools: Bash, Read, Grep, Glob
 ---
 
 # ComfyUI image utilities
@@ -28,6 +32,13 @@ The split:
 | `comfyui-florence2` | Florence-2 vision-language for captioning (PromptGen LoRAs) |
 | `comfyui-wd14-tagger` | WD14 ONNX booru-style tagger |
 | `comfyui-art-venture` | BLIP captioner, DeepDanbooru anime tagger |
+
+## When to Use This Skill
+
+| Use this skill when... | Use instead when... |
+|---|---|
+| Manipulating images/masks outside of model inference (resize, crop, tile, batch) | Running a diffusion/inference node on an image -> the relevant model-family skill |
+| Generating a caption/tag from an image (Florence-2, WD14, BLIP) | Extracting metadata already embedded in an output -> `comfy-metadata` |
 
 ## Sources of truth
 

--- a/comfyui-plugin/skills/comfy-image-utils/SKILL.md
+++ b/comfyui-plugin/skills/comfy-image-utils/SKILL.md
@@ -1,0 +1,416 @@
+---
+name: comfy-image-utils
+description: >-
+  ComfyUI non-inference image ops: resize/crop/pad/tile/batch/mask utilities, plus image-to-text captioners (Florence-2, WD14, BLIP, DeepDanbooru). Use when manipulating images or generating captions/tags in a workflow.
+---
+
+# ComfyUI image utilities
+
+Image manipulation that doesn't go through a diffusion model. Plus
+**image-to-text** inference (Florence-2, WD14, BLIP, DeepDanbooru),
+which is included here because the input is an image and the
+node-level setup (model downloads, ONNX dependencies, HF cache paths)
+is the bulk of the work.
+
+The split:
+
+| Pack | Niche |
+|---|---|
+| `comfyui-kjnodes` | Batch ops, resize-v2, crop-by-mask, channel split/merge, Get*SizeAndCount, LoadAndResizeImage (exposes `image_path`) |
+| `comfyui_essentials` | Resize / Flip / Crop / Tile-Untile / Composite, list↔batch conversion, Mask family (Blur, Flip, FromColor, BoundingBox) |
+| `comfyui-easy-use` | `imageCount`, `imageInsetCrop`, `imagesCountInDirectory` |
+| `comfyui-tooling-nodes` | Base64 load, image cache, ApplyMaskToImage, WebSocket send, Tile Extract/Merge |
+| `ComfyUI-Crystools` | `CImageGetResolution`, `CImageLoadWithMetadata`, `CImageSaveWithExtraMetadata` |
+| `bjornulf_custom_nodes` | ResizeImage, ResizeImagePercentage, GrayscaleTransform, RemoveTransparency, LoadImageWithTransparency |
+| `comfyui_yvann-nodes` | RepeatImageToCount |
+| `comfyui-custom-scripts` (pysssss) | ConstrainImage (max-dimensions resize with aspect-preserve) |
+| `comfyui-various` | image_ops / channel_ops / color_ops / image_sequence / mask_sequence_ops modules |
+| `comfyui-florence2` | Florence-2 vision-language for captioning (PromptGen LoRAs) |
+| `comfyui-wd14-tagger` | WD14 ONNX booru-style tagger |
+| `comfyui-art-venture` | BLIP captioner, DeepDanbooru anime tagger |
+
+## Sources of truth
+
+- `custom_nodes/comfyui-kjnodes/nodes/image_nodes.py` — batch / resize / channel / size+count
+- `custom_nodes/comfyui_essentials/image.py` and `mask.py` — Image*/Mask* family
+- `custom_nodes/comfyui-tooling-nodes/` — base64, cache, websocket, tiling
+- `custom_nodes/comfyui-florence2/` — Florence-2 loaders + caption nodes
+- `custom_nodes/comfyui-wd14-tagger/` — WD14 ONNX wrapper
+- `custom_nodes/comfyui-art-venture/modules/interrogate/` — BLIP, DeepDanbooru
+
+## Resize decision
+
+| You want… | Best node | Why |
+|---|---|---|
+| Resize to specific width × height | essentials `ImageResize` | Canonical, scale-mode picker |
+| Resize keeping aspect ratio, target one dimension | kjnodes `ImageResizeKJv2` | `keep_proportion` flag plus more interpolation options |
+| Resize to a percentage of original | bjornulf `ResizeImagePercentage` | Single-input scale factor |
+| Constrain to max dimensions (downsize only) | pysssss `ConstrainImage` | One-sided cap, preserves aspect, no upscale |
+| Load + resize in one step + expose source filename | kjnodes `LoadAndResizeImage` | Bonus `image_path` STRING output for filename-templated saves |
+| Crop region by coordinates | essentials `ImageCrop` | xywh widgets |
+| Crop to bounds of a mask | kjnodes `ImageCropByMask` | Fits to non-zero region of input mask |
+| Inset-crop (chop edges) | `easy imageInsetCrop` | Crop from edges by pixels or % |
+| Pad on all sides | kjnodes `ImagePadKJ` | Top/bottom/left/right + fill color |
+
+### Latent-friendly sizing
+
+Many models require dimensions divisible by 8 (or 16 for some
+WanVideo configs). `ImageResizeKJv2` has a `divisible_by` widget;
+essentials `ImageResize` does not. For latent-aligned resize, prefer
+kjnodes' v2; otherwise pre-compute the target size via SimpleMath
+(see `comfy-math-strings`).
+
+## Batch operations
+
+| Need | Best node |
+|---|---|
+| Concat two batches | kjnodes `ImageConcatenate` |
+| Concat N batches | kjnodes `ImageConcatMulti` |
+| Batch N images into one tensor (from separate IMAGE outputs) | kjnodes `ImageBatchMulti` |
+| Extract specific indices | kjnodes `GetImagesFromBatchIndexed` |
+| Extract a contiguous range | kjnodes `GetImageRangeFromBatch` |
+| Reverse the batch order | kjnodes `ReverseImageBatch` |
+| Shuffle (random) | kjnodes `ShuffleImageBatch` |
+| Pick one image by index | essentials `ImageFromBatch` |
+| Duplicate one image N times | essentials `ImageExpandBatch` |
+| Repeat batch K times | essentials `ImageBatchMultiple` |
+| Match a target batch size by repeating | yvann `RepeatImageToCount` |
+| Batch tensor → list of images | essentials `ImageBatchToList` |
+| List of images → batch tensor | essentials `ImageListToBatch` |
+| Count batch size | essentials `BatchCount`, `easy imageCount` |
+
+The **batch ↔ list distinction** matters: `LIST` is a Python list of
+single-image tensors processed by `INPUT_IS_LIST=True` nodes;
+`BATCH` is a single 4D tensor `(B, H, W, C)`. Many downstream nodes
+(samplers, VAE) expect BATCH. Convert with `ImageListToBatch` before
+the sampler.
+
+## Mask utilities
+
+| Need | Best node |
+|---|---|
+| Gaussian blur a mask | essentials `MaskBlur` |
+| Horizontal/vertical flip | essentials `MaskFlip` |
+| Combine N masks into a batch | essentials `MaskBatch` |
+| Make a mask from a color range in an image | essentials `MaskFromColor` |
+| Get the (x, y, w, h) bounding box of mask | essentials `MaskBoundingBox` |
+| Get mask dimensions | kjnodes `GetMaskSizeAndCount` |
+| Apply a mask to an image (alpha composite) | tooling-nodes `ApplyMaskToImage` |
+| Mask → grayscale image | (use `ApplyMaskToImage` on a white image) |
+
+For mask **shape detection** (face mask covers a region; is it
+empty?), the `easy isMaskEmpty` probe lives in `comfy-conditionals`.
+
+## Image I/O
+
+| Need | Node |
+|---|---|
+| Load image from base64 string (API input) | tooling-nodes `LoadImageBase64` |
+| Load mask from base64 | tooling-nodes `LoadMaskBase64` |
+| Cache image in memory (reuse across queue runs) | tooling-nodes `Save Image Cache` / `Load Image Cache` |
+| Send image over WebSocket | tooling-nodes `Send Image WebSocket` (for streaming to external tools) |
+| Load image preserving alpha channel | bjornulf `LoadImageWithTransparency` |
+| Convert RGBA → RGB (replace alpha with color) | bjornulf `RemoveTransparency` |
+| Convert image to grayscale | bjornulf `GrayscaleTransform` |
+| Save image with custom PNG metadata | Crystools `CImageSaveWithExtraMetadata` |
+| Load image + emit PNG metadata as JSON | Crystools `CImageLoadWithMetadata` |
+| Get image dimensions (no batch) | Crystools `CImageGetResolution` |
+
+For batch / cross-output-directory metadata analysis (figure out
+which model produced a directory of outputs), use the **`comfy-metadata`**
+skill — it covers PNG tEXt / iTXt, WebP EXIF, MP4 container metadata
+(kijai WanVideoWrapper's `comment` blob), and `.latent` safetensors.
+
+## Tiling
+
+| Need | Node |
+|---|---|
+| Repeat image as a tile pattern | essentials `ImageTile` |
+| Undo `ImageTile` | essentials `ImageUntile` |
+| Extract a specific tile from a grid layout | tooling-nodes `ExtractImageTile` |
+| Reconstruct from extracted tiles | tooling-nodes `MergeImageTile` |
+| Extract tile-shaped mask | tooling-nodes `ExtractMaskTile` |
+
+For **tiled diffusion** (split a large image into tiles, run each
+through a sampler, stitch), that's a model-level pattern — see
+`comfyui-tiled-diffusion` (separate pack) or the
+`comfyui-inpaint-cropandstitch` skill referenced in
+`portrait-outpaint`.
+
+## Channel ops
+
+| Need | Node |
+|---|---|
+| Split RGBA into 4 masks | kjnodes `SplitImageChannels` |
+| Merge 4 masks (R, G, B, A) → RGBA image | kjnodes `MergeImageChannels` |
+| Grayscale | bjornulf `GrayscaleTransform` |
+
+The kjnodes split/merge pair is the workhorse for any
+per-channel image processing.
+
+## Image → prompt (image-to-text inference)
+
+These nodes are **inference nodes** in the sense that they run a
+neural network, but they're not diffusion — they produce text from
+an image. They live in this skill because the input is an image and
+because users coming from `comfy-prompting` need the node-level
+setup details.
+
+### Decision: which captioner?
+
+| Source | Output style | Best for | Setup |
+|---|---|---|---|
+| **Florence-2 PromptGen** | SD/Flux-friendly natural-language ("portrait of a woman in red, sitting, soft light") | Photoreal / general-purpose | Auto-downloads ~1.5 GB on first run; PEFT LoRA adapters for prompt style |
+| **WD14Tagger** | Booru-style comma-separated tags ("1girl, solo, red_dress, sitting") | Anime / illustration prompts | ONNX model auto-downloads; needs `onnxruntime` |
+| **BLIP** (art-venture) | Short generic caption ("a woman in a red dress") | Quick descriptions; older / smaller model | Auto-downloads from HF |
+| **DeepDanbooru** (art-venture) | Anime tag classifier | Specific to anime / booru tags | Auto-downloads model |
+
+### Florence-2 setup
+
+Nodes:
+- `DownloadAndLoadFlorence2Model` — auto-fetch from HF on first run
+- `Florence2ModelLoader` — load from a local path (after the first run, point at the cached path)
+- `DownloadAndLoadFlorence2Lora` — apply a PEFT LoRA adapter (PromptGen variants are LoRAs on top of base Florence-2)
+
+The first run downloads to the HF cache. On a small-root-disk install,
+set `HF_HOME` to a larger data disk to keep models off the small root — see `~/.claude/rules/huggingface-downloads.md`. Florence-2
+weights for the base model are ~1.5 GB; PromptGen LoRA adapters are
+~50 MB.
+
+Florence-2 variants and their use:
+
+| Variant | Use |
+|---|---|
+| `microsoft/Florence-2-base` | Base — generic captioning |
+| `microsoft/Florence-2-large` | Larger, better quality |
+| `MiaoshouAI/Florence-2-large-PromptGen-v2.0` | Optimized for SD/Flux prompts |
+| `gokaygokay/Florence-2-Flux-Captioner` | Flux-prompt-style captions |
+| `microsoft/Florence-2-large-ft` | Fine-tuned on DocVQA / OCR — useful for screenshots |
+
+### WD14 setup
+
+Single node: `WD14Tagger`. ONNX-based, requires `onnxruntime` (CPU)
+or `onnxruntime-gpu` for CUDA acceleration. The ONNX model
+auto-downloads to the WD14 pack's model directory on first run.
+
+Configurables:
+- `model`: WD14 model variant (Convnext, ViT, SwinV2, MoAT) — newer variants are slightly more accurate
+- `threshold` (general tags): 0.35 default; raise to filter weak tags
+- `threshold_character`: tags for specific known characters
+- `exclude_tags`: comma-separated tags to skip ("1girl, solo")
+- `replace_underscore`: convert booru underscores to spaces
+- `trailing_comma`: append `,` after the output
+
+### BLIP and DeepDanbooru (art-venture)
+
+`BlipLoader` (or `DownloadAndLoadBlip` for one-step) + `BlipCaption`.
+First-run download ~500 MB. Output is a short caption.
+
+`DeepDanbooruCaption` for anime — single node, auto-downloads model
+weights.
+
+### Caption chaining
+
+For best-quality prompts, chain:
+
+```
+LoadImage ──► Florence-2 PromptGen ──► STRING (caption)
+                                          │
+                                          ▼ (optional)
+                                  Searge_LLM_Node
+                                  (add cinematic detail, camera direction)
+                                          │
+                                          ▼
+                                  CLIPTextEncode (or model-specific encoder)
+```
+
+The Florence-2 → LLM chain produces more nuanced prompts than either
+alone. See `comfy-prompting` for the LLM-side details.
+
+## Recipes
+
+### Sortable per-day output filename with source basename
+
+User wants outputs at `output/2026-05-13/143055_michael.png` where
+`michael` is stripped from the source filename `michael.jpg`. Project
+CLAUDE.md covers the native `%date:%`/`%NodeName.widget%` syntax;
+when the native approach fails (e.g. extension stripping), use:
+
+```
+LoadAndResizeImage (kjnodes) ─► image_path (STRING, full path)
+                                       │
+                                       ▼
+                          StringFunction (pysssss, regex)
+                          find:    "^.*/|\.(png|jpg|jpeg|webp)$"
+                          replace: ""
+                                       │
+                                       ▼ (bare basename, no path, no ext)
+                          JoinStringMulti (kjnodes)
+                          in_1: "nsfw/%date:yyyy-MM-dd%/%date:hhmmss%_%ksampler.sampler_name%_%ksampler.scheduler%_s%ksampler.seed%_"
+                          in_2: <bare basename>   # the <descriptor> segment
+                                       │
+                                       ▼
+                          easy imageSave (filename_prefix STRING input)
+```
+
+`%date:%` tokens pass through verbatim into the SaveImage prefix
+substitution (resolved at save time). String manipulation chain lives
+in `comfy-math-strings`; the save node lives in easy-use. The full
+required prefix shape (mandatory sampler/scheduler/seed) is the "Output
+filename_prefix convention" in `.claude/rules/editing-workflow-json.md`.
+
+### Caption a folder of images for batch dataset prep
+
+You have 100 photos in `input/dataset/` and want a `.txt` next to
+each with a Florence-2 caption:
+
+```
+easy imagesCountInDirectory ──► count
+                                  │
+                                  ▼ (drives forLoopStart iteration count)
+                          easy forLoopStart (total = count)
+                                  │
+                                  ▼ (per-iteration)
+                  LoadImage (path = `input/dataset/{index}.jpg`)
+                                  │
+                                  ▼
+                          Florence-2 PromptGen ──► caption STRING
+                                                       │
+                                                       ▼
+                                                  SaveText (bjornulf)
+                                                  path: `input/dataset/{index}.txt`
+                                  │
+                                  ▼
+                          easy forLoopEnd
+```
+
+Pattern hits two skills: this one for Florence-2; `comfy-flow-control`
+for the for-loop primitives.
+
+### Mask-driven crop + paste workflow
+
+You have a portrait, a face mask, want to upscale only the face:
+
+```
+LoadImage ──► IMAGE
+   │
+   ▼
+GenerateFaceMask (whatever)
+   │
+   ▼ MASK
+   │
+   ▼
+ImageCropByMask (kjnodes) ──► cropped IMAGE (face region only)
+   │                       └─► crop coords (for paste-back)
+   ▼
+(upscale chain: sampler, etc.)
+   │
+   ▼ upscaled face
+   │
+   ▼
+ImageComposite (essentials, alpha-paste using mask) ──► final image
+```
+
+`ImageCropByMask` returns both the cropped image and the bbox; the
+bbox is needed to paste the result back to the right location.
+
+### Tile-based large-image processing
+
+```
+LoadImage (4096×4096) ──► IMAGE
+                            │
+                            ▼
+                  ExtractImageTile (tooling-nodes, 2×2 grid)
+                            │
+                            ▼ 4 IMAGE tiles
+                            │
+                            ▼ (process each through a sampler)
+                            │
+                            ▼ 4 processed tiles
+                            │
+                            ▼
+                  MergeImageTile (tooling-nodes) ──► final 4096×4096
+```
+
+For sampler-aware tiled diffusion (overlap, blending across tile
+seams), reach for `comfyui-tiled-diffusion` instead — these
+tooling-node tile ops are pure image-level.
+
+## Gotchas
+
+- **`LoadAndResizeImage.image_path` is a full path**, not just a
+  basename. Strip the dir component via `StringFunction` regex
+  (see Recipe 1) or use the native `%LoadImage.image%` substitution
+  if not using `LoadAndResizeImage`.
+- **`ImageResize` defaults are not latent-aligned**. The result may
+  be 519×731, which crashes the VAE on some models. Use
+  `ImageResizeKJv2` with `divisible_by=8` or pre-compute via
+  SimpleMath.
+- **`ImageBatchMulti` slots are dynamic**. Adding/removing inputs
+  rewrites the slot count. After heavy editing, re-add the node to
+  compact unused slots.
+- **`MaskFromColor` is RGB-only**. RGBA images need
+  `RemoveTransparency` first (or split channels and feed RGB).
+- **WD14Tagger needs `onnxruntime`, not torch**. The pack ships its
+  own ONNX session; CUDA acceleration requires `onnxruntime-gpu`
+  (which on this install would need: `.venv/bin/python -m pip
+  install onnxruntime-gpu`).
+- **Florence-2 first run downloads to `~/.cache/huggingface`** by
+  default. On a small-root-disk install, set `HF_HOME` to a larger data
+  disk (a systemd unit's `Environment=` block, or your shell profile).
+  Otherwise the ~1.5 GB weights fill the small
+  root partition. See `~/.claude/rules/huggingface-downloads.md`.
+- **BLIP captions are short** (~10-15 words). For longer prompts,
+  prefer Florence-2 PromptGen or chain BLIP output through a local
+  LLM.
+- **`DeepDanbooru` and `WD14Tagger` produce overlapping but
+  non-identical tag vocabularies**. Stick with one for a given
+  workflow; mixing produces redundant `1girl, 1_girl, solo, person`
+  pile-ups.
+- **Tooling-nodes' `Load Image Cache` is in-memory only**. The cache
+  doesn't survive a service restart. For persistent caching, save to
+  disk via `SaveImage` with a known filename and reload.
+- **`ImageComposite` (essentials)** requires both images to be the
+  same size. Resize one or use `ImagePadKJ` to match dimensions
+  first.
+- **`SplitImageChannels` always emits 4 MASKs** (R, G, B, A). On an
+  RGB input, the alpha channel comes back as a fully-white mask
+  (not None) — wire only the channels you need.
+- **`RepeatImageToCount` doesn't broadcast smaller dimensions**. If
+  the input batch has 1 image and target count is 5, you get 5
+  copies of that image — useful when matching a batch dimension to
+  drive a per-frame conditioning input.
+
+## Cross-refs
+
+- `comfy-prompting` — when to reach for image-to-prompt nodes;
+  wildcard / LLM combination with caption output.
+- `comfy-conditionals` — `easy isMaskEmpty` to gate mask-driven
+  branches; `MaskBoundingBox` to compute "is the region large
+  enough?" predicates.
+- `comfy-flow-control` — index switches over batches; for-loop
+  iteration over image directories.
+- `comfy-math-strings` — string manipulation for filename
+  templating (the recipe above); resolution math.
+- `comfy-debug-preview` — `Get*SizeAndCount`,
+  `CImageGetResolution`, `ImageDetails` for inspecting batches and
+  source images.
+- `comfy-metadata` — offline / cross-file metadata extraction across
+  output directories; the Crystools nodes here are for inline reads,
+  comfy-metadata is for retrospective analysis.
+- `photo-restore`, `portrait-outpaint`, `video-extend` — task-level
+  skills that combine these image utilities with model inference.
+
+## Things this skill does NOT cover
+
+- **Model inference on images** — KSampler, VAEEncode/Decode,
+  ControlNet apply, IPAdapter. Those are model-family work; see
+  `wan` / `z-image` / `hidream-o1` / task skills.
+- **Tiled diffusion at the sampler level** — see
+  `comfyui-tiled-diffusion` and the inpaint-cropandstitch workflow
+  referenced in `portrait-outpaint`.
+- **Image-format conversion at the file level** (JPEG quality, WebP
+  encoding parameters) — that's `tools-plugin:imagemagick-conversion`
+  territory for external CLI work.
+- **3D / depth / mesh manipulation** — depthanythingv2,
+  depthflow-nodes (broken on this install per project CLAUDE.md).

--- a/comfyui-plugin/skills/comfy-math-strings/SKILL.md
+++ b/comfyui-plugin/skills/comfy-math-strings/SKILL.md
@@ -1,7 +1,11 @@
 ---
+created: 2026-07-07
+modified: 2026-07-07
+reviewed: 2026-07-07
 name: comfy-math-strings
 description: >-
   ComfyUI compute/string nodes: constants, sliders, math expressions, string concat/split/replace/regex, type conversion, JSON/list utilities. Use when computing a value or assembling a string in a workflow.
+allowed-tools: Bash, Read, Grep, Glob
 ---
 
 # ComfyUI math & strings
@@ -22,6 +26,13 @@ The split:
 | `comfyui-easy-use` | `easy string` / `easy int` / `easy float` identity nodes, `easy rangeInt` |
 | `comfyui-dream-project` | `DreamCalculation`, `DreamLinear`, sine/saw/triangle waves (animation-flavored, see "out of scope") |
 | `comfyui_yvann-nodes` | `FloatToInt`, `InvertFloats`, `MaskToFloat`, `FloatsToWeightsStrategy` |
+
+## When to Use This Skill
+
+| Use this skill when... | Use instead when... |
+|---|---|
+| Computing a value or assembling a string in a workflow | Forming a boolean from that computation -> `comfy-conditionals` |
+| Converting between types (anything -> int/float/string) | Displaying the result -> `comfy-debug-preview` |
 
 ## Sources of truth
 

--- a/comfyui-plugin/skills/comfy-math-strings/SKILL.md
+++ b/comfyui-plugin/skills/comfy-math-strings/SKILL.md
@@ -1,0 +1,342 @@
+---
+name: comfy-math-strings
+description: >-
+  ComfyUI compute/string nodes: constants, sliders, math expressions, string concat/split/replace/regex, type conversion, JSON/list utilities. Use when computing a value or assembling a string in a workflow.
+---
+
+# ComfyUI math & strings
+
+Compute and assemble. Numbers in, numbers out; strings in, strings
+out; primitives that hold a constant; sliders that expose a tunable.
+
+The split:
+
+| Pack | Niche |
+|---|---|
+| `comfyui-kjnodes` | Primitives (BOOL / INT / Float / String / Multiline), SimpleCalculatorKJ, JoinStrings / JoinStringMulti, AppendStringsToList, Something/WidgetToString |
+| `comfyui_essentials` | Math hierarchy: SimpleMath / SimpleMathFloat / SimpleMathInt / SimpleMathDual (AST-based) |
+| `comfyui-custom-scripts` (pysssss) | `MathExpression` (full numpy + math imports), `StringFunction` (regex), `StringNodes` (split/case/trim) |
+| `comfyui-mxtoolkit` | `mxSeed`, `mxSlider`, `mxSlider2D` widget-driven values |
+| `bjornulf_custom_nodes` | `AnythingToText` / `AnythingToInt` / `AnythingToFloat`, TextReplace, CombineTexts, RandomLineFromInput |
+| `ComfyUI-Crystools` | `CBoolean` / `CInteger` / `CFloat` / `CText` / `CTextML` primitives, `CJsonFile` / `CJsonExtractor` / `CListAny` / `CListString` |
+| `comfyui-easy-use` | `easy string` / `easy int` / `easy float` identity nodes, `easy rangeInt` |
+| `comfyui-dream-project` | `DreamCalculation`, `DreamLinear`, sine/saw/triangle waves (animation-flavored, see "out of scope") |
+| `comfyui_yvann-nodes` | `FloatToInt`, `InvertFloats`, `MaskToFloat`, `FloatsToWeightsStrategy` |
+
+## Sources of truth
+
+- `custom_nodes/comfyui-kjnodes/nodes/nodes.py` — primitives, JoinStrings, Something/WidgetToString
+- `custom_nodes/comfyui_essentials/misc.py` — SimpleMath family
+- `custom_nodes/comfyui-custom-scripts/py/math_expression.py` — pysssss MathExpression
+- `custom_nodes/comfyui-mxtoolkit/` — slider widgets
+- `custom_nodes/ComfyUI-Crystools/crystools/nodes_*.py` — primitives, list helpers, JSON extractor
+- `custom_nodes/bjornulf_custom_nodes/` — Anything-To-* converters
+
+## Math — which node?
+
+| Need | Best node | Why |
+|---|---|---|
+| Single FLOAT expression, simple ops | `SimpleMathFloat` (essentials) | Tight; one expression in, FLOAT out |
+| Single INT expression | `SimpleMathInt` | Same, INT result |
+| Multi-variable expression (a, b, c, d) — `(a+b)/c` etc. | `SimpleMath` | AST-based eval over named inputs; safe (no module imports) |
+| Two values, binary op (add/sub/mul/div/pow) | `SimpleMathDual` | Op picker widget |
+| Many variables (a–j) | `SimpleCalculatorKJ` (kjnodes) | Up to 10 named inputs |
+| Need numpy / math import — `np.sqrt`, `math.pi`, `np.clip`, etc. | `MathExpression` (pysssss) | Full module access, expression as string |
+| Animation curve over a frame index — linear ramp, sine wave | `DreamLinear`, `DreamSineWave` etc. | Built-in time/frame parameter |
+| Float ↔ INT | yvann `FloatToInt` (round/ceil/floor), `AnythingToInt` (bjornulf) | yvann has the rounding mode; bjornulf is the lenient any-input version |
+| Invert FLOAT (1−x or −x) | yvann `InvertFloats` | Mode picker |
+
+### Math hierarchy in one line
+
+`SimpleMathFloat` < `SimpleMath` < `SimpleCalculatorKJ` < `MathExpression`
+
+Pick the simplest one that compiles. `MathExpression` (pysssss) is the
+"escape hatch" — full numpy + math imports, but a typo crashes the
+node with an opaque traceback. Use it only when AST-safe `SimpleMath`
+can't express what you need.
+
+### `SimpleMath` syntax
+
+Variables: `a`, `b`, `c`, `d` (wire them as inputs).
+Operators: `+ - * / // % **`, parentheses, unary `-`.
+Functions: `min`, `max`, `abs`, `round`, `int`, `float`.
+
+```
+SimpleMath:
+   expression: int(sqrt(a * 1000000 * b) / 8) * 8
+   a = megapixels
+   b = aspect_ratio
+   → width snapped to multiple of 8
+```
+
+`SimpleMath` does NOT support `sqrt` natively — drop to
+`MathExpression` for that. Actual AST-safe set is limited; check the
+node source for the allowed call list.
+
+### `MathExpression` syntax
+
+```
+import numpy as np
+import math
+
+# Expression — single line:
+int(math.sqrt(a * 1e6 * b) / 8) * 8
+
+# Or use numpy:
+int(np.sqrt(a * 1e6 * b) / 8) * 8
+```
+
+You write an expression string referencing input variable names that
+the node has registered. The node has `math` and `numpy` (as `np`)
+already imported. Errors surface as red node + traceback in the
+server log; nothing in the workflow UI.
+
+## Strings — concat, replace, regex, split
+
+| Need | Best node |
+|---|---|
+| Concat a few strings with a delimiter | `JoinStrings` (kjnodes, 5-arg) |
+| Concat many | `JoinStringMulti` (kjnodes, dynamic N inputs) |
+| Concat 2 with no delimiter | `CombineTexts` (bjornulf) |
+| Find/replace literal | `TextReplace` (bjornulf) |
+| Find/replace regex | `StringFunction` (pysssss; regex_mode toggle) |
+| Pick random line from multiline | `RandomLineFromInput` (bjornulf) |
+| Split on delimiter | `StringNodes` (pysssss, operation picker) or `TextSplitByDelimiter` (mixlab) |
+| Add line numbers | `AddLineNumbers` (bjornulf) |
+| Tokenize | `DreamStringTokenizer` (dream-project, word-splitter) |
+| Build STRING from a list | `AppendStringsToList` (kjnodes) |
+
+### Single-line vs multiline
+
+- `StringConstant` (kjnodes) — single line, no embedded newlines
+- `StringConstantMultiline` (kjnodes) — multiline, ideal for prompt
+  bodies, JSON snippets, multi-clause text
+- `CText` (Crystools) — single line
+- `CTextML` (Crystools) — multiline
+
+Pick multiline for any string longer than ~80 chars or any string
+with embedded newlines. Single-line variants are for short labels and
+filenames.
+
+### Regex via `StringFunction`
+
+```
+StringFunction (pysssss):
+   action: replace
+   regex_mode: ON
+   text:    "michael.jpg"
+   find:    "\.(png|jpg|jpeg|webp)$"
+   replace: ""
+   → "michael"
+```
+
+Useful for stripping extensions from a filename (the exact pattern
+we hit in the `comfy-image-utils` recipe set). Action picker also
+supports `append`, `replace`, `tidy tags` (the last one normalizes
+commas/spaces in tag lists for booru-style prompts).
+
+## Type conversion
+
+`bjornulf`'s `AnythingTo*` family is the most lenient — it accepts
+literally any input type and produces the named scalar:
+
+| Node | Output | Notes |
+|---|---|---|
+| `AnythingToText` | STRING | `str(x)`-equivalent on any input |
+| `AnythingToInt` | INT | Coerces float / string / bool; raises if string isn't parseable |
+| `AnythingToFloat` | FLOAT | Same, FLOAT target |
+| `SomethingToString` (kjnodes) | STRING | Similar to bjornulf's AnythingToText |
+| `WidgetToString` (kjnodes) | STRING | Reads a specific widget by name from a target node — useful for surfacing arbitrary widget values into the data flow |
+
+`easy string` / `easy int` / `easy float` (easy-use) are **identity
+nodes** — they don't convert, just pass through. Their purpose is to
+expose a widget UI for a value that downstream nodes will consume; a
+debug-friendly handle.
+
+## Primitives & sliders
+
+| Source | What it gives you |
+|---|---|
+| kjnodes `INTConstant` / `FloatConstant` / `StringConstant` / `BOOLConstant` / `StringConstantMultiline` | Plain widget-input constants |
+| Crystools `CInteger` / `CFloat` / `CText` / `CTextML` / `CBoolean` | Same, plus some have widget toggle for live update |
+| mxtoolkit `mxSlider` | Single tunable INT or FLOAT slider with live drag |
+| mxtoolkit `mxSlider2D` | 2D drag-pad emitting two independent values |
+| mxtoolkit `mxSeed` | INT pass-through with a seed-control widget (random / fixed / increment) |
+| `easy rangeInt` | Emit a range of INTs — `start`, `end`, plus `step` mode or `num_steps` mode |
+| `RepeatImageToCount` is image-specific (covered in `comfy-image-utils`); for value-list repetition use Python via JoinString | |
+
+### Seed strategy
+
+ComfyUI core's `Seed` node and the `seed` widget on `KSampler` both
+support fixed/random/increment. `mxSeed` adds a slider-style UI and a
+pass-through value (useful when one seed feeds multiple samplers and
+you want it visible). `Seed Everywhere` (cg-use-everywhere) is
+deprecated in favor of `Anything Everywhere` connected to an INT.
+
+## JSON & lists (Crystools)
+
+| Node | Use |
+|---|---|
+| `CJsonFile` | Load a JSON file from disk; emits the parsed structure as a JSON object |
+| `CJsonExtractor` | Extract values from a JSON object via dot-path / JSONPath syntax |
+| `CListAny` | Build / pass a list of any type |
+| `CListString` | Build a list of strings (sometimes more convenient than concatenation) |
+
+Typical use: load a config JSON, extract one value, feed into a
+downstream node. The Crystools JSON nodes don't do JSON-write; for
+that, save text via bjornulf `SaveText` or use the `MathExpression`
+escape hatch.
+
+## Recipes
+
+### Resolution math from megapixels + aspect ratio
+
+You want a target image size of "≈1 MP, 16:9 aspect, both dimensions
+divisible by 8".
+
+```
+PrimitiveFloat (mp = 1.0) ──┐
+                            ▼
+PrimitiveFloat (ar = 16/9) ─►  MathExpression (pysssss)
+                            ▲     expression: int(math.sqrt(a * 1e6 * b) / 8) * 8
+                            │     a = mp, b = ar
+                            ▼
+                          width = 1336 (for ar=1.78)
+                          (compute height by 1e6/width or as another expression)
+```
+
+Two `MathExpression` nodes: one for width, one for height = `int((a * 1e6) / b / 8) * 8`
+with the same `mp` input and width as `b`. The 8-snapping handles
+SD/Flux/Wan latent alignment automatically.
+
+### Filename templating
+
+`SaveImage.filename_prefix` accepts `%date:yyyy-MM-dd%` / `%date:hhmmss%`
+substitution plus `%NodeName.widget%`. The **required shape** (mandatory
+sampler/scheduler/seed run-signature) is the "Output filename_prefix
+convention" in `.claude/rules/editing-workflow-json.md`; its "SaveImage
+filename substitution" section covers the native syntax. When the native
+substitution isn't enough (e.g. you need to strip an extension from a
+source filename), assemble the prefix via:
+
+```
+LoadAndResizeImage ──► image_path (STRING, kjnodes)
+                            │
+                            ▼
+                StringFunction (pysssss)
+                   action: replace, regex: ON
+                   find:    "\.(png|jpg|jpeg|webp)$"
+                   replace: ""
+                            │
+                            ▼ (basename without ext, STRING)
+              JoinStringMulti (kjnodes)
+                 in_1: "nsfw/%date:yyyy-MM-dd%/%date:hhmmss%_%ksampler.sampler_name%_%ksampler.scheduler%_s%ksampler.seed%_"
+                 in_2: <stripped basename>   # the <descriptor> segment
+                            │
+                            ▼
+              easy imageSave (filename_prefix STRING input)
+```
+
+The `%date:...%` tokens are passed through verbatim; SaveImage's
+internal substitution resolves them at save time. The
+`%LoadImage.image%` widget-substitution is bypassed entirely — we
+build the final string in the graph.
+
+### Build a comma-separated tag list from individual triggers
+
+Three LoRA trigger words plus a manual prompt, combined:
+
+```
+LoraLoaderVanilla (lora_1) ──► civitai_tags_list (STRING)  ──┐
+LoraLoaderVanilla (lora_2) ──► civitai_tags_list (STRING)  ──┤
+LoraLoaderVanilla (lora_3) ──► civitai_tags_list (STRING)  ──┤
+PrimitiveStringMultiline ("a portrait of a woman") ───────────┤
+                                                              ▼
+                                              JoinStringMulti (delimiter = ", ")
+                                                              │
+                                                              ▼
+                                                       CLIPTextEncode
+```
+
+Empty trigger strings produce an extra `, ` — pipe through
+`StringFunction` (action: tidy tags) to collapse redundant separators.
+
+### Range-driven batch
+
+Generate 10 images at incrementing CFG values:
+
+```
+easy rangeInt
+   start: 3,  end: 12,  num_steps: 10
+        │
+        ▼ (emits 10 INTs at execution)
+   (route into a forLoopStart, each iteration sets KSampler.cfg)
+```
+
+Pair with `easy forLoopStart` / `forLoopEnd` (see `comfy-flow-control`)
+for actual iteration.
+
+## Gotchas
+
+- **`SimpleMath` ≠ `MathExpression`.** Essentials' SimpleMath is
+  AST-safe (no imports, limited function set — no `sqrt`, no `numpy`).
+  Pysssss MathExpression has full `math` + `numpy` access. Don't mix
+  them up.
+- **kjnodes Constants vs Crystools Constants** — they look
+  interchangeable. They mostly are, but Crystools' `CFloat` /
+  `CInteger` widgets default to wider ranges and Crystools' multiline
+  `CTextML` has different newline handling on Windows. Pick one pack
+  per workflow for consistency.
+- **`MathExpression` errors are server-side**. The node turns red but
+  the error message ("Error executing MathExpression: NameError")
+  lives in the ComfyUI server log (`journalctl -u comfyui.service`
+  on this install). Add a `ShowAnything` on the output to confirm
+  it's emitting what you expect.
+- **`StringFunction` regex syntax is Python `re`**. Forward slashes
+  are NOT escapes; backslashes are. `\.(png|jpg|jpeg|webp)$` works.
+  `/\\.(png|jpg|jpeg|webp)$/` does not — that's JavaScript syntax.
+- **`AnythingToInt` on a non-numeric string crashes**. `"3.14"` →
+  fails; `"3"` → works; `3.14` (float) → 3. To coerce a possibly
+  non-numeric STRING, route through `MathExpression` with
+  `int(float(a) if a else 0)` and a defensive try wrapper.
+- **`JoinStringMulti` shrinks dynamic inputs**. The first time you
+  add a downstream consumer, the node grows its slot count. If you
+  later disconnect, the empty slots stay around. Drop and re-add the
+  node to compact.
+- **`easy rangeInt` `num_steps` is INCLUSIVE on both ends**, so
+  `start=0, end=10, num_steps=11` gives `[0, 1, 2, ..., 10]`. With
+  `num_steps=10`, you get `[0, 1.11, ..., 10]` — not integer.
+  Prefer the `step` mode when you want integer-only spacing.
+
+## Cross-refs
+
+- `comfy-conditionals` — feeding math output through a comparator
+  to form a boolean predicate.
+- `comfy-debug-preview` — `ShowAnything` / `DisplayAny` / `ShowFloat`
+  for inspecting intermediate math results.
+- `comfy-flow-control` — `easy rangeInt` feeding `forLoopStart`;
+  primitives as switch selectors.
+- `comfy-prompting` — string assembly for prompts (this skill is the
+  primitive layer; `comfy-prompting` is the application).
+- Project CLAUDE.md "SaveImage filename substitution" — native
+  `%date:%`/`%NodeName.widget%` syntax that complements the
+  string-graph approach.
+
+## Things this skill does NOT cover
+
+- **Animation schedulers** — `DreamSineWave`, `DreamSawWave`,
+  `DreamTriangleWave`, `FloatsToWeightsStrategy`, frame-counter ops.
+  These are math primitives but their application (AnimateDiff /
+  IPAdapter transitions / weight schedules over frames) is its own
+  domain. Future `comfy-animation-schedules` skill will cover this.
+  For now: the nodes exist, they emit FLOATs / FLOAT lists driven by
+  a frame index; consult the `comfyui-dream-project` and
+  `comfyui_yvann-nodes` repos for application examples.
+- **Display-only nodes** — `ShowText`, `DisplayAny`, `ShowFloat`,
+  Crystools `CConsoleAny*`. Those are inspection, not computation;
+  see `comfy-debug-preview`.
+- **Image / mask arithmetic** — `ImageBlend`, `MaskComposite`. Those
+  are pixel ops, not scalar math; see `comfy-image-utils`.
+- **Sampler internals** — `cfg`, `denoise`, step counts. Math-driven
+  scheduling of those values is fine, but the values themselves
+  live in the model-family skills.

--- a/comfyui-plugin/skills/comfy-metadata/REFERENCE.md
+++ b/comfyui-plugin/skills/comfy-metadata/REFERENCE.md
@@ -1,0 +1,278 @@
+# ComfyUI metadata format reference
+
+Code anchors in a real install (upstream pulls move these line numbers;
+re-grep when they drift). Everything below is verified against real
+output files in a ComfyUI install's `output/` directory.
+
+## The two JSON forms
+
+Every save path writes **two** related JSON blobs:
+
+| Key | Form | Shape |
+|---|---|---|
+| `prompt` | API form | flat dict `{node_id: {inputs, class_type, _meta}}` — what the backend actually executed |
+| `workflow` | UI form | graph form with `nodes`, `links`, `groups`, `extra`, `last_node_id`, `last_link_id` — what the frontend renders |
+
+The summarizer in `comfy_meta.py` reads the **API form** because it
+flattens reroutes/links/etc. into resolved `inputs` values, which is
+easier to walk than the UI graph. If you need to *re-import* a workflow
+into the ComfyUI editor, use the UI form via `extract -k workflow`.
+
+`extra_pnginfo` is the open extension slot: any custom node can stash
+JSON-serializable data there. By convention the UI's workflow JSON lives
+under `extra_pnginfo["workflow"]`, which is why the second tEXt chunk is
+named `workflow`. Other plug-ins (e.g. for citation metadata, model
+provenance) sometimes add their own keys — the toolkit preserves them
+in `extract`'s raw output but ignores them in the summary.
+
+## PNG — `tEXt` chunks
+
+`nodes.py:1652–1658` (core `SaveImage`):
+
+```python
+metadata = PngInfo()
+metadata.add_text("prompt", json.dumps(prompt))
+for x in extra_pnginfo:
+    metadata.add_text(x, json.dumps(extra_pnginfo[x]))
+img.save(path, pnginfo=metadata, compress_level=...)
+```
+
+PIL exposes the chunks as plain strings in `Image.info`:
+
+```python
+img = PIL.Image.open(path)
+prompt   = json.loads(img.info["prompt"])      # API form
+workflow = json.loads(img.info["workflow"])    # UI form
+```
+
+The `--disable-metadata` server flag short-circuits this whole block
+(see `_create_png_metadata` at `comfy_api/latest/_ui.py:85–95`).
+
+## Animated PNG (APNG)
+
+`comfy_api/latest/_ui.py:98–120`. Uses `PngInfo.add()` with a
+zero-terminated key, so the resulting chunks are `iTXt` (international
+text, UTF-8) rather than `tEXt`. PIL still surfaces them via
+`Image.info[key]`; behaviour from a reader's perspective is identical.
+
+## WebP — EXIF (the awkward one)
+
+`comfy_api/latest/_ui.py:123–135`:
+
+```python
+exif = pil_image.getexif()
+exif[0x0110] = "prompt:{}".format(json.dumps(prompt))      # Model
+tag = 0x010F                                                # Make
+for key, value in extra_pnginfo.items():
+    exif[tag] = "{}:{}".format(key, json.dumps(value))
+    tag -= 1                                                # 0x010E, 0x010D, ...
+img.save(path, exif=exif, ...)
+```
+
+**Two consequences:**
+
+1. The value is **not** pure JSON — it's `"<key>:<json>"` (literal colon
+   separator). Strip the prefix before `json.loads`. The toolkit does
+   `value.split(":", 1)[1]`.
+2. `extra_pnginfo` keys are placed in **descending tag order** starting
+   from `0x010F`, not by name. To find the `workflow` blob, walk every
+   EXIF tag in `getexif()` and split on the first `:` to identify each
+   one by its embedded key.
+
+The toolkit handles both — see `comfy_meta._read_webp` for the
+implementation.
+
+Real example: a Flux-Kontext PNG re-saved as WebP through `SaveAnimatedWEBP`
+yields `exif` bytes ~45 KB. Tag `0x0110` holds `prompt:{...}`; tag
+`0x010F` holds `workflow:{...}`.
+
+## MP4 / WebM — two distinct dialects
+
+Native ComfyUI `SaveVideo` (`comfy_extras/nodes_video.py:85–112`):
+
+```python
+metadata = {}
+metadata.update(cls.hidden.extra_pnginfo)       # workflow ends up here
+metadata["prompt"] = cls.hidden.prompt
+output_container.metadata[key] = json.dumps(value) if not str else value
+```
+
+→ Container metadata has **per-key tags**: `prompt`, `workflow`, plus
+any extra. Each value is a JSON string. Read with:
+
+```python
+import av
+c = av.open(path)
+prompt   = json.loads(c.metadata["prompt"])
+workflow = json.loads(c.metadata["workflow"])
+```
+
+**Kijai WanVideoWrapper** (and VideoHelperSuite, MMAudio) take a
+different approach: one container tag named `comment` (MP4) or `COMMENT`
+(Matroska/WebM) holds a single JSON object:
+
+```json
+{"prompt": "<json-string>", "workflow": "<json-string>"}
+```
+
+So the prompt JSON is **double-encoded** — once for the inner string,
+once for the wrapping object. Reader:
+
+```python
+import av, json
+c = av.open(path)
+blob = c.metadata.get("comment") or c.metadata.get("COMMENT")
+wrap = json.loads(blob)                  # outer
+prompt   = json.loads(wrap["prompt"])    # inner
+workflow = json.loads(wrap["workflow"])
+```
+
+Verified empirically:
+
+| File | format | Metadata keys |
+|---|---|---|
+| `output/WanVideoWrapper_I2V_00001.mp4` (kijai) | `mov,mp4,m4a,3gp,3g2,mj2` | `major_brand, minor_version, compatible_brands, creation_time, encoder, comment` |
+| `output/mmaudio_00001.webm` (kijai) | `matroska,webm` | `COMMENT, creation_time, ENCODER` |
+
+The toolkit auto-detects which dialect is in play: per-key first, fall
+back to the `comment`/`COMMENT` blob.
+
+### MP4 metadata atom support
+
+MP4 (`isom`/`moov`) only natively supports a fixed list of atom names
+in its `udta` box, which is why kijai picked `comment` (one of the
+universally-supported ones). FFmpeg writes per-key tags via free-form
+`-metadata key=value` flags, which it stores as ITU-style `©XXX` atoms;
+PyAV exposes those as plain lowercase keys. WebM/Matroska is more
+permissive — any tag name works, conventionally uppercase.
+
+### Re-encoding gotcha
+
+Container metadata survives stream-copy (`ffmpeg -c copy`) and `mv`/`cp`
+but is dropped by re-encode unless you pass `-map_metadata 0`. If you
+need to convert formats while preserving workflow data:
+
+```sh
+ffmpeg -i in.mp4 -c copy -map_metadata 0 out.mov
+# Or, if a real re-encode is needed:
+ffmpeg -i in.mp4 -map_metadata 0 -c:v libx264 -crf 18 out.mp4
+```
+
+## Audio (FLAC / OGG / MP3 / WAV)
+
+`comfy_api/latest/_ui.py:261–319` (`AudioSaveHelper`). Same shape as
+native SaveVideo — per-key container tags via PyAV, each value is
+`json.dumps(...)`. Reader is identical to the per-key MP4 path.
+
+## `.latent` files
+
+`nodes.py:498–520` (core `SaveLatent`). Saves a safetensors with header
+metadata:
+
+```python
+metadata = {}
+metadata["prompt"] = json.dumps(prompt)
+for x in extra_pnginfo:
+    metadata[x] = json.dumps(extra_pnginfo[x])
+# ... tae_latent_channels etc. for compatibility ...
+safetensors.save_file({"latent": ...}, path, metadata=metadata)
+```
+
+Reader:
+
+```python
+from safetensors import safe_open
+with safe_open(path, framework="pt") as f:
+    meta = f.metadata() or {}
+    prompt   = json.loads(meta["prompt"])
+    workflow = json.loads(meta["workflow"])
+```
+
+Latents aren't currently saved on this install (no `*.latent` under
+`output/`), but the code path is there and the toolkit covers it for
+when a workflow does emit them.
+
+## What goes into `extra_pnginfo`
+
+The frontend sends two things:
+
+- `extra_pnginfo["workflow"]` — the UI graph (set unconditionally for any
+  prompt that came from the web UI)
+- arbitrary custom-node additions — e.g. citation extensions write
+  `extra_pnginfo["citations"]`; some packs write `extra_pnginfo["pysssss_prompts"]`
+  or similar
+
+Every key in `extra_pnginfo` becomes a separate top-level metadata entry
+on every output format (PNG tEXt chunk, WebP EXIF tag, MP4 metadata key,
+etc.), so a single output can have more than the canonical two JSON
+blobs. The toolkit's `extract` returns them all under the raw key map;
+`summary` ignores anything it doesn't understand.
+
+## Compatibility quirks
+
+### Animated PNG / iTXt vs tEXt
+
+PIL's `PngInfo.add_text` writes `tEXt` (Latin-1) for the still path and
+the manual `metadata.add(b"tEXt", b"key\x00...")` form, while the
+animated path uses `PngInfo.add()` with a raw byte sequence which often
+ends up as `iTXt`. Both surface identically through `Image.info[key]`,
+so readers don't need to care. Writers that round-trip the metadata
+should re-call `add_text` rather than copying chunk bytes.
+
+### WebP EXIF tag exhaustion
+
+`_create_webp_metadata` starts at `0x010F` and decrements per
+`extra_pnginfo` key. There's no overflow guard — if a workflow stuffs
+hundreds of keys into `extra_pnginfo`, tags eventually collide with
+standard EXIF tags (orientation `0x0112`, x-resolution `0x011A`, …).
+In practice `extra_pnginfo` only ever has `workflow` plus maybe one or
+two pack-specific keys, so this hasn't bitten anyone yet. The toolkit
+just walks every tag; collision with a numeric EXIF value would be
+detected by the failing `value.split(":", 1)`.
+
+### kijai vs native — which one will I see?
+
+This install is dominated by **kijai** Wan workflows, so most MP4s here
+have the single `comment` blob, not per-key tags. After 2026-03 ComfyUI
+also has a native `SaveVideo` node (`comfy_extras/nodes_video.py`); if
+you build a workflow with that instead of `WanVideoWrapper.save_video`,
+you'll see per-key tags. The toolkit reads both transparently.
+
+## Code anchors (verify against current `git HEAD`)
+
+| What | File | Line(s) |
+|---|---|---|
+| Core `SaveImage` PNG write | `nodes.py` | 1652–1658 |
+| Core `SaveLatent` | `nodes.py` | 498–520 |
+| PNG metadata builder | `comfy_api/latest/_ui.py` | 85–95 |
+| Animated PNG metadata builder | `comfy_api/latest/_ui.py` | 98–120 |
+| WebP EXIF metadata builder | `comfy_api/latest/_ui.py` | 123–135 |
+| Native `SaveVideo` video container write | `comfy_api/latest/_ui.py` | 317–319 |
+| Native `SaveVideo` node | `comfy_extras/nodes_video.py` | 85–112 |
+| Audio metadata builder | `comfy_api/latest/_ui.py` | 261–319 |
+| `--disable-metadata` flag | `app/cmd_args.py` | search for `disable-metadata` |
+
+When upstream renames `comfy_api/latest/_ui.py` or moves the helpers
+(historically: this code used to live inline in `SaveImage`), update
+this table.
+
+## Sanity-check commands
+
+```sh
+# Confirm a PNG has the workflow tEXt chunk
+.venv/bin/python -c "from PIL import Image; print(list(Image.open('foo.png').info))"
+
+# Confirm an MP4 has container metadata
+.venv/bin/python -c "import av; print(list(av.open('foo.mp4').metadata))"
+
+# Strip JSON values to one line for quick eyeballing
+.venv/bin/python -c "
+import json, sys
+from PIL import Image
+i = Image.open(sys.argv[1])
+for k in ('prompt','workflow'):
+    if k in i.info:
+        d = json.loads(i.info[k])
+        print(f'{k}: {len(i.info[k]):,} chars, {len(d) if hasattr(d,\"__len__\") else \"?\"} top-level keys')
+" foo.png
+```

--- a/comfyui-plugin/skills/comfy-metadata/SKILL.md
+++ b/comfyui-plugin/skills/comfy-metadata/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: comfy-metadata
+description: >-
+  Extract/analyze ComfyUI metadata embedded in output files - PNG tEXt, WebP EXIF, MP4/WebM container, .latent safetensors. Use when figuring out what prompt/settings produced a file, or comparing runs.
+---
+
+# ComfyUI output metadata
+
+Every image/video/audio file ComfyUI emits embeds the **API-form prompt**
+and the **UI-form workflow** that produced it. The encoding varies by
+file format and by which save-node wrote it (core vs. kijai vs. VHS).
+This skill is the canonical reference for *where* the data lives, *how*
+to read it back, and a small Python toolkit to do it reliably across
+every format on disk in this install.
+
+## Quick reference
+
+| Format | Saved by | Where the JSON lives | Encoding |
+|---|---|---|---|
+| **PNG** still | core `SaveImage`, kijai PNG path | `tEXt` chunks (PIL `Image.info["prompt"]` and `["workflow"]`) | each value is a JSON string |
+| **Animated PNG** | core `SaveAnimatedPNG` | `iTXt` chunks (same keys) | each value is a JSON string |
+| **WebP** still + animated | core `SaveAnimatedWEBP` | EXIF tags: `0x0110` (Model) holds `"prompt:<json>"`, `0x010F` (Make) holds `"workflow:<json>"`, lower tags hold further `extra_pnginfo` keys | one EXIF string per key, `"key:json"` prefix |
+| **MP4** native | core `SaveVideo` | Container metadata, separate keys: `prompt`, `workflow`, plus any extra | each value is a JSON string |
+| **MP4** kijai (`WanVideoWrapper_*.mp4`) | `WanVideoWrapper.save_video` | Container metadata, single key `comment` | one JSON object: `{"prompt": "<json>", "workflow": "<json>"}` (double-encoded) |
+| **WebM / Matroska** | core `SaveVideo`; kijai/MMAudio | Container metadata: per-key (native) or single `COMMENT` (kijai) | same patterns as MP4 |
+| **FLAC / OGG / MP3 / WAV** | core `SaveAudio` | Container metadata: `prompt`, `extra_pnginfo`* keys | each value is a JSON string |
+| **`.latent`** | core `SaveLatent` | safetensors header metadata: `prompt`, `workflow` | each value is a JSON string |
+
+The library handles all of these uniformly. See `REFERENCE.md` for code
+anchors, exact byte-level details, and edge cases (the `_create_webp_metadata`
+EXIF tag walk, `extra_pnginfo` keys beyond `workflow`, the kijai
+double-encoded `comment` format, fp8-scaled safetensors metadata, etc.).
+
+## Toolkit
+
+`scripts/comfy_meta.py` is a single self-contained Python file. It works
+as both a library and a CLI with four subcommands. It uses **PIL** (for
+PNG/WebP), **PyAV** (for MP4/WebM/audio), and **safetensors** (for
+`.latent`) — all already installed in `.venv/`.
+
+Run via the project venv:
+
+```sh
+.venv/bin/python .claude/skills/comfy-metadata/scripts/comfy_meta.py <subcommand> ...
+```
+
+### Library use (batch scripts)
+
+For ad-hoc batch work — renaming, indexing, clustering — calling the CLI
+once per file is slow. Import `comfy_meta` directly instead. It has no
+package wrapper, so add its dir to `sys.path` first:
+
+```python
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(".claude/skills/comfy-metadata/scripts")))
+import comfy_meta
+
+for p in pathlib.Path("output").iterdir():
+    if not p.is_file():
+        continue
+    ex = comfy_meta.extract(p)        # {"prompt": <api-dict>, "workflow": <ui-dict>}
+    prompt = ex.get("prompt")
+    if not isinstance(prompt, dict) or not prompt:
+        continue                       # no embedded metadata
+    summary = comfy_meta.summarize(prompt)
+    print(p.name, summary.sampler, summary.scheduler, summary.seed)
+```
+
+`extract()` returns parsed JSON for both halves; `summarize()` walks the
+API prompt and yields a `Summary` dataclass. See
+`scripts/rename_outputs.py` for a full example that builds new filenames
+from `summary.samplers[0]` and the source file's mtime.
+
+### The UI workflow half is useful too
+
+`summarize()` covers the API `prompt`, but `extract()["workflow"]` (the
+UI form) carries data the summarizer doesn't surface — most usefully
+**save-node widgets**. A workflow that wrote itself to `nsfw/<date>/…`
+self-labels its outputs:
+
+```python
+ex = comfy_meta.extract(p)
+workflow = ex.get("workflow") or {}
+for n in workflow.get("nodes", []) or []:
+    wv = n.get("widgets_values")
+    # SaveImage / SaveWEBM: list[0] is the filename_prefix
+    if isinstance(wv, list) and wv and isinstance(wv[0], str) and wv[0].startswith("nsfw/"):
+        return "nsfw"
+    # VHS_VideoCombine: dict["filename_prefix"]
+    if isinstance(wv, dict) and str(wv.get("filename_prefix", "")).startswith("nsfw/"):
+        return "nsfw"
+```
+
+`rename_outputs.py`'s NSFW classifier combines this self-label signal
+with API-prompt asset-name token matching (model / text-encoder / LoRA
+names). The same approach works for any other categorisation the UI
+workflow encodes that the API prompt strips out: node titles, custom
+properties, group names, etc.
+
+### `extract` — dump the embedded JSON
+
+```sh
+# Both prompt + workflow as one JSON object on stdout
+.venv/bin/python .../comfy_meta.py extract output/WanVideoWrapper_I2V_00001.png
+
+# Just one half (suitable for piping to jq)
+.venv/bin/python .../comfy_meta.py extract -k prompt   path/to.png | jq .
+.venv/bin/python .../comfy_meta.py extract -k workflow path/to.mp4  | jq '.nodes | length'
+
+# Re-import a downloaded JPEG/MP4 back into ComfyUI by saving its workflow:
+.venv/bin/python .../comfy_meta.py extract -k workflow some.mp4 > user/default/workflows/2026-05/recovered.json
+```
+
+### `summary` — one-line, analysis-friendly settings
+
+The summarizer walks the API-form prompt and pulls out the fields that
+actually matter for "what was different between run A and run B": model,
+text encoders, VAE, every sampler invocation (sampler/scheduler/steps/
+cfg/denoise/seed), latent dims, num_frames, every LoRA + strength, and
+the positive/negative prompt text.
+
+```sh
+.venv/bin/python .../comfy_meta.py summary output/WanVideoWrapper_I2V_00001.mp4
+```
+
+Output is JSON; use `-p` for a human-readable two-column print instead.
+
+### `scan` — index a directory into JSONL
+
+Walk a tree (recursively by default) and emit one JSON record per output
+file. Use this to build a queryable index of every render on disk.
+
+```sh
+.venv/bin/python .../comfy_meta.py scan output/ -o /tmp/runs.jsonl
+
+# Then analyze with jq:
+jq -r '[.path, .summary.steps, .summary.cfg, .summary.sampler] | @tsv' /tmp/runs.jsonl
+
+# Group by sampler+steps+cfg to see what combinations were used:
+jq -s 'group_by(.summary.sampler+"|"+(.summary.steps|tostring)+"|"+(.summary.cfg|tostring))
+       | map({key: .[0].summary | "\(.sampler) steps=\(.steps) cfg=\(.cfg)", count: length})' \
+  /tmp/runs.jsonl
+```
+
+Files without embedded metadata (e.g. phone photos in the same tree)
+get `{"path": "...", "error": "no metadata"}` so the index still
+covers everything.
+
+### `diff` — what changed between two runs
+
+```sh
+.venv/bin/python .../comfy_meta.py diff a.mp4 b.mp4
+```
+
+Prints a unified diff of the summarized settings. Useful when one of two
+near-identical workflows produced a better result and you want to see
+which knob actually moved.
+
+## What the summary captures
+
+```text
+model:        UNETLoader.unet_name / CheckpointLoaderSimple.ckpt_name
+              / WanVideoModelLoader.model / Image-Edit's diffusion path
+text_encoders [list]: CLIPLoader / DualCLIPLoader / TripleCLIPLoader
+              / LoadWanVideoT5TextEncoder / TextEncoderLoaderHiDream …
+vae:          VAELoader.vae_name / WanVideoVAELoader.model_name
+samplers [list]: every KSampler / KSamplerAdvanced / WanVideoSampler /
+              WanVideoSamplerv2 / SamplerCustomAdvanced — each with
+              {sampler, scheduler, steps, cfg, denoise, seed, start_step,
+               end_step, add_noise} as found
+latent_dims:  width × height from EmptyLatentImage / EmptySD3LatentImage /
+              EmptyMochiLatentVideo / WanVideoEmptyEmbeds / etc.
+num_frames:   from WanVideoEmptyEmbeds.num_frames / Empty*Video.length
+loras [list]: every LoraLoader / LoraLoaderModelOnly / Power Lora Loader
+              entry — {name, model_strength, clip_strength}
+shift:        ModelSamplingAuraFlow / ModelSamplingSD3 shift values
+positive [list], negative [list]: CLIPTextEncode-style text inputs, with
+              the upstream node's title as a hint when present
+```
+
+Heuristic, not exhaustive — but covers ~95% of the workflows on this
+install. New node-types missing from the summarizer are still preserved
+in the raw `prompt` half of `extract`; add them to `comfy_meta.py`'s
+`SUMMARIZERS` registry when a class becomes worth pulling out.
+
+## When the toolkit returns "no metadata"
+
+A few cases that look like ComfyUI outputs but lack the JSON:
+
+- **ComfyUI launched with `--disable-metadata`** — the save nodes
+  short-circuit before adding tEXt/EXIF/container tags.
+- **Re-encoded with ffmpeg** — `ffmpeg -i in.mp4 -c copy out.mp4` *does*
+  preserve container metadata; `-c:v libx264 …` (re-encode) typically
+  drops it unless `-map_metadata 0` is passed.
+- **Re-saved through an image editor** (Affinity, Photoshop, GIMP) —
+  most strip tEXt chunks and rewrite EXIF.
+- **Output from a frontend that bypasses save nodes** (custom HTTP
+  pipelines, Hugging Face Spaces wrapping ComfyUI, …).
+
+For the second case, when you `mv` or `cp` files between dirs the
+metadata is fine — the OS-level operations preserve byte content. Only
+re-encoding strips it.
+
+## Privacy note
+
+The embedded `prompt` JSON contains **the full positive and negative
+text prompts**, the exact `seed`, file paths to LoRAs/checkpoints/VAEs
+(which can leak local directory structure like
+`models/loras/lgates/private_face_v1.safetensors`), and sometimes
+authoring metadata in `extra_pnginfo`. Before sharing a ComfyUI output
+file publicly, decide whether you want to ship the metadata with it.
+
+To strip metadata in-place (lossless):
+
+- **PNG**: `oxipng --strip safe file.png` (keeps colorspace, strips text)
+- **WebP**: re-encode with `cwebp -metadata none` or `magick convert in.webp -strip out.webp`
+- **MP4/WebM**: `ffmpeg -i in.mp4 -c copy -map_metadata -1 out.mp4`
+
+Or set `--disable-metadata` on the ComfyUI server (in `comfyui.service`)
+if you want all future outputs to be metadata-free — but the toolkit
+becomes useless then.
+
+## Related skills
+
+- `comfy-workflow-layout` — once you've extracted a workflow with
+  `extract -k workflow`, run it through `scripts/layout_workflow.py` to
+  tidy node positions before importing.
+- `comfy-cli` — `comfy node install-deps <workflow.json>` consumes a
+  workflow JSON file; pipe `extract -k workflow` straight into a temp
+  file to install the missing custom nodes for an imported workflow.

--- a/comfyui-plugin/skills/comfy-metadata/SKILL.md
+++ b/comfyui-plugin/skills/comfy-metadata/SKILL.md
@@ -1,7 +1,11 @@
 ---
+created: 2026-07-07
+modified: 2026-07-07
+reviewed: 2026-07-07
 name: comfy-metadata
 description: >-
   Extract/analyze ComfyUI metadata embedded in output files - PNG tEXt, WebP EXIF, MP4/WebM container, .latent safetensors. Use when figuring out what prompt/settings produced a file, or comparing runs.
+allowed-tools: Bash, Read, Grep, Glob
 ---
 
 # ComfyUI output metadata
@@ -12,6 +16,13 @@ file format and by which save-node wrote it (core vs. kijai vs. VHS).
 This skill is the canonical reference for *where* the data lives, *how*
 to read it back, and a small Python toolkit to do it reliably across
 every format on disk in this install.
+
+## When to Use This Skill
+
+| Use this skill when... | Use instead when... |
+|---|---|
+| Figuring out what prompt/settings produced an existing output file | Inspecting a *live* in-graph value during a run -> `comfy-debug-preview` |
+| Scanning, organizing, or comparing a directory of outputs | Auto-arranging the layout of a workflow JSON -> `comfy-workflow-layout` |
 
 ## Quick reference
 

--- a/comfyui-plugin/skills/comfy-metadata/scripts/comfy_meta.py
+++ b/comfyui-plugin/skills/comfy-metadata/scripts/comfy_meta.py
@@ -1,0 +1,678 @@
+#!/usr/bin/env python3
+"""Read and analyze workflow metadata embedded in ComfyUI output files.
+
+Library + CLI. Run with the project venv:
+
+    .venv/bin/python .claude/skills/comfy-metadata/scripts/comfy_meta.py <cmd> ...
+
+Subcommands:
+    extract  <file>             dump prompt+workflow JSON (or one half via -k)
+    summary  <file>             one-record summary of generation settings
+    scan     <dir>              walk a tree, write one JSONL line per file
+    diff     <file_a> <file_b>  unified diff of summarized settings
+
+The summarizer recognizes the common loader / sampler / lora / latent /
+text-encode node classes used in this install (core + WanVideoWrapper +
+Qwen-Image-Edit + Flux + SDXL + HiDream). Unknown nodes are preserved
+in the raw `prompt` half of `extract` but ignored by `summary`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import difflib
+import io
+import json
+import os
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Raw extraction per file format
+# ---------------------------------------------------------------------------
+
+PNG_EXTS = {".png", ".apng"}
+WEBP_EXTS = {".webp"}
+PIL_EXTS = PNG_EXTS | WEBP_EXTS | {".jpg", ".jpeg", ".tiff", ".gif"}
+VIDEO_EXTS = {".mp4", ".mov", ".webm", ".mkv", ".avi"}
+AUDIO_EXTS = {".flac", ".ogg", ".mp3", ".wav", ".m4a", ".opus"}
+LATENT_EXTS = {".latent"}
+
+
+def _read_pil(path: Path) -> dict[str, str]:
+    """Return raw key→string map from PIL Image.info (PNG tEXt / WebP EXIF / etc.)."""
+    from PIL import Image  # lazy
+
+    out: dict[str, str] = {}
+    with Image.open(path) as img:
+        # PNG tEXt / iTXt chunks land directly in Image.info as strings
+        for k, v in img.info.items():
+            if isinstance(v, str) and k in {"prompt", "workflow"}:
+                out[k] = v
+            elif isinstance(v, str) and v.startswith(("prompt:", "workflow:")):
+                # belt + braces — shouldn't happen for PNG but harmless
+                k2, _, val = v.partition(":")
+                out[k2] = val
+
+        # WebP: metadata lives in EXIF tags, encoded as "key:json"
+        if "exif" in img.info or img.format == "WEBP":
+            try:
+                exif = img.getexif()
+                for _, raw in exif.items():
+                    if isinstance(raw, bytes):
+                        try:
+                            raw = raw.decode("utf-8", "ignore")
+                        except Exception:
+                            continue
+                    if not isinstance(raw, str) or ":" not in raw:
+                        continue
+                    k2, _, val = raw.partition(":")
+                    k2 = k2.strip()
+                    if k2 in {"prompt", "workflow"} and val.lstrip().startswith(("{", "[")):
+                        out.setdefault(k2, val)
+            except Exception:
+                pass
+    return out
+
+
+def _read_container(path: Path) -> dict[str, str]:
+    """Return raw key→string map from a video/audio container.
+
+    Handles both ComfyUI dialects:
+        - native SaveVideo / SaveAudio: per-key tags (`prompt`, `workflow`, …)
+        - kijai WanVideoWrapper / VHS: single `comment` (or uppercase `COMMENT`)
+          holding a JSON object `{"prompt": <str>, "workflow": <str>}`
+    """
+    import av  # lazy
+
+    out: dict[str, str] = {}
+    with av.open(str(path)) as c:
+        meta = dict(c.metadata)
+
+    # Lowercase the keys we care about for the per-key path
+    for k, v in meta.items():
+        if k.lower() in {"prompt", "workflow"} and isinstance(v, str):
+            out[k.lower()] = v
+
+    if "prompt" not in out:
+        # kijai / VHS dialect
+        blob = meta.get("comment") or meta.get("COMMENT")
+        if isinstance(blob, str) and blob.lstrip().startswith("{"):
+            try:
+                wrap = json.loads(blob)
+                if isinstance(wrap, dict):
+                    for k in ("prompt", "workflow"):
+                        v = wrap.get(k)
+                        if isinstance(v, str):
+                            out[k] = v
+                        elif v is not None:
+                            out[k] = json.dumps(v)
+            except json.JSONDecodeError:
+                pass
+    return out
+
+
+def _read_latent(path: Path) -> dict[str, str]:
+    from safetensors import safe_open  # lazy
+
+    out: dict[str, str] = {}
+    with safe_open(str(path), framework="numpy") as f:
+        meta = f.metadata() or {}
+        for k in ("prompt", "workflow"):
+            if k in meta:
+                out[k] = meta[k]
+    return out
+
+
+def read_raw_metadata(path: str | os.PathLike[str]) -> dict[str, str]:
+    """Read raw key→JSON-string map from a ComfyUI output file.
+
+    Returns an empty dict if the file has no recognized embedded JSON.
+    Raises FileNotFoundError if `path` doesn't exist.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(str(p))
+    ext = p.suffix.lower()
+    if ext in PIL_EXTS:
+        return _read_pil(p)
+    if ext in VIDEO_EXTS or ext in AUDIO_EXTS:
+        return _read_container(p)
+    if ext in LATENT_EXTS:
+        return _read_latent(p)
+    return {}
+
+
+def extract(path: str | os.PathLike[str]) -> dict[str, Any]:
+    """Return parsed `{"prompt": <api-dict>, "workflow": <ui-dict>}`.
+
+    Keys that fail to parse as JSON are dropped silently. Missing keys are
+    simply absent from the result. Use `read_raw_metadata` for the raw strings.
+    """
+    raw = read_raw_metadata(path)
+    out: dict[str, Any] = {}
+    for k, v in raw.items():
+        try:
+            out[k] = json.loads(v)
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Summarizer — walk the API-form prompt and pull out interesting fields
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class SamplerCall:
+    node_id: str
+    class_type: str
+    sampler: str | None = None
+    scheduler: str | None = None
+    steps: int | float | None = None
+    cfg: float | None = None
+    denoise: float | None = None
+    seed: int | None = None
+    start_step: int | None = None
+    end_step: int | None = None
+    add_noise: Any = None
+
+
+@dataclasses.dataclass
+class LoraEntry:
+    name: str
+    model_strength: float | None = None
+    clip_strength: float | None = None
+
+
+@dataclasses.dataclass
+class Summary:
+    models: list[str] = dataclasses.field(default_factory=list)
+    text_encoders: list[str] = dataclasses.field(default_factory=list)
+    vaes: list[str] = dataclasses.field(default_factory=list)
+    samplers: list[SamplerCall] = dataclasses.field(default_factory=list)
+    loras: list[LoraEntry] = dataclasses.field(default_factory=list)
+    width: int | None = None
+    height: int | None = None
+    num_frames: int | None = None
+    shift: float | None = None
+    positive: list[str] = dataclasses.field(default_factory=list)
+    negative: list[str] = dataclasses.field(default_factory=list)
+    output_filenames: list[str] = dataclasses.field(default_factory=list)
+    node_count: int = 0
+
+    @property
+    def sampler(self) -> str | None:
+        return self.samplers[0].sampler if self.samplers else None
+
+    @property
+    def scheduler(self) -> str | None:
+        return self.samplers[0].scheduler if self.samplers else None
+
+    @property
+    def steps(self) -> int | float | None:
+        return self.samplers[0].steps if self.samplers else None
+
+    @property
+    def cfg(self) -> float | None:
+        return self.samplers[0].cfg if self.samplers else None
+
+    @property
+    def seed(self) -> int | None:
+        return self.samplers[0].seed if self.samplers else None
+
+    def to_dict(self) -> dict[str, Any]:
+        d = dataclasses.asdict(self)
+        # Add convenience top-level fields the analyst usually wants
+        d["sampler"] = self.sampler
+        d["scheduler"] = self.scheduler
+        d["steps"] = self.steps
+        d["cfg"] = self.cfg
+        d["seed"] = self.seed
+        return d
+
+
+# class_type → keys to pull out
+_MODEL_LOADERS = {
+    "UNETLoader": "unet_name",
+    "CheckpointLoaderSimple": "ckpt_name",
+    "CheckpointLoader": "ckpt_name",
+    "WanVideoModelLoader": "model",
+    "UnetLoaderGGUF": "unet_name",
+    "DiffusersLoader": "model_path",
+    "DiffusionModelLoader": "model_name",
+}
+
+_TEXT_ENCODER_LOADERS = {
+    "CLIPLoader": "clip_name",
+    "DualCLIPLoader": ("clip_name1", "clip_name2"),
+    "TripleCLIPLoader": ("clip_name1", "clip_name2", "clip_name3"),
+    "QuadrupleCLIPLoader": ("clip_name1", "clip_name2", "clip_name3", "clip_name4"),
+    "LoadWanVideoT5TextEncoder": "model_name",
+    "WanVideoT5TextEncode": None,  # encode-only, not a loader
+    "TextEncoderLoaderHiDream": "text_encoder",
+}
+
+_VAE_LOADERS = {
+    "VAELoader": "vae_name",
+    "WanVideoVAELoader": "model_name",
+}
+
+_LORA_LOADERS = {
+    "LoraLoader": ("lora_name", "strength_model", "strength_clip"),
+    "LoraLoaderModelOnly": ("lora_name", "strength_model", None),
+    "LoraLoaderAdvanced": ("lora_name", "strength_model", "strength_clip"),
+    "WanVideoLoraSelect": ("lora", "strength", None),
+    "LoRALoader|pysssss": ("lora_name", "strength_model", "strength_clip"),
+}
+
+_SAMPLERS = {
+    "KSampler",
+    "KSamplerAdvanced",
+    "SamplerCustom",
+    "SamplerCustomAdvanced",
+    "WanVideoSampler",
+    "WanVideoSamplerv2",
+    "WanVideoSamplerV2",
+    "Kontext_KSampler",
+}
+
+# Helper nodes that decompose what a single KSampler bundles together.
+# When the workflow uses `SamplerCustomAdvanced`, the sampler/scheduler/
+# steps/cfg/seed values live in these auxiliary nodes; harvest them all
+# and stitch onto the SamplerCustomAdvanced call below.
+_AUX_SAMPLER_FIELDS = {
+    "KSamplerSelect": {"sampler": "sampler_name"},
+    "BasicScheduler": {"scheduler": "scheduler", "steps": "steps", "denoise": "denoise"},
+    "AlignYourStepsScheduler": {"scheduler": "scheduler", "steps": "steps", "denoise": "denoise"},
+    "SDTurboScheduler": {"steps": "steps", "denoise": "denoise"},
+    "BetaSamplingScheduler": {"steps": "steps", "denoise": "denoise"},
+    "RandomNoise": {"seed": "noise_seed"},
+    "CFGGuider": {"cfg": "cfg"},
+    "BasicGuider": {},  # no cfg widget, just signals "CFG=1 (uncond skipped)"
+    "DualCFGGuider": {"cfg": "cfg_conds"},
+}
+
+_LATENT_DIM_NODES = {
+    "EmptyLatentImage",
+    "EmptySD3LatentImage",
+    "ModelSamplingSD3",
+    "EmptyMochiLatentVideo",
+    "EmptyLTXVLatentVideo",
+    "EmptyHunyuanLatentVideo",
+    "WanVideoEmptyEmbeds",
+    "WanVideoImageToVideoEncode",
+    "WanVideoImageToVideoEncodev2",
+    "ImageScale",
+    "ImageScaleBy",
+    "FluxKontextImageScale",
+}
+
+_SHIFT_NODES = {"ModelSamplingAuraFlow", "ModelSamplingSD3", "ModelSamplingFlux"}
+
+_TEXT_ENCODE_NODES = {
+    "CLIPTextEncode",
+    "CLIPTextEncodeFlux",
+    "CLIPTextEncodeSDXL",
+    "CLIPTextEncodeSD3",
+    "TextEncodeQwenImageEdit",
+    "TextEncodeQwenImageEditPlus",
+    "WanVideoTextEncode",
+    "WanVideoTextEncodeCached",
+}
+
+
+def _push_unique(lst: list[str], val: Any) -> None:
+    if isinstance(val, str) and val and val not in lst:
+        lst.append(val)
+
+
+def _coalesce(*vals: Any) -> Any:
+    for v in vals:
+        if v is not None:
+            return v
+    return None
+
+
+def _scalar_or_none(v: Any) -> Any:
+    """Reject ComfyUI link-form values like ['66', 1] — those are node refs.
+
+    ComfyUI stores either a literal widget value (int/float/str) or a
+    2-list `[upstream_node_id, output_slot]`. The summarizer only cares
+    about literals; the linked-value case means the dim is computed
+    upstream and isn't recoverable without graph traversal.
+    """
+    if isinstance(v, list):
+        return None
+    return v
+
+
+def summarize(api_prompt: dict[str, Any]) -> Summary:
+    """Walk the API-form prompt and pull out generation settings.
+
+    `api_prompt` is the dict from `extract(...)["prompt"]` — i.e. the
+    flat `{node_id: {inputs, class_type, _meta}}` shape that the ComfyUI
+    backend executes.
+    """
+    s = Summary()
+    if not isinstance(api_prompt, dict):
+        return s
+    s.node_count = len(api_prompt)
+
+    # Index node titles for prompting-vs-not classification
+    title_for: dict[str, str] = {}
+    for nid, node in api_prompt.items():
+        if isinstance(node, dict):
+            title_for[nid] = (node.get("_meta", {}) or {}).get("title", "") or ""
+
+    # First pass: harvest auxiliary sampler fields keyed by node_id. The
+    # SamplerCustomAdvanced chain spreads sampler/scheduler/cfg/seed across
+    # separate helper nodes, so collect them up front and merge below.
+    aux_fields: dict[str, Any] = {}
+    has_basic_guider = False
+    for nid, node in api_prompt.items():
+        if not isinstance(node, dict):
+            continue
+        cls = node.get("class_type")
+        if cls in _AUX_SAMPLER_FIELDS:
+            inputs = node.get("inputs", {}) or {}
+            for out_key, in_key in _AUX_SAMPLER_FIELDS[cls].items():
+                v = _scalar_or_none(inputs.get(in_key))
+                if v is not None and out_key not in aux_fields:
+                    aux_fields[out_key] = v
+            if cls == "BasicGuider":
+                has_basic_guider = True
+
+    for nid, node in api_prompt.items():
+        if not isinstance(node, dict):
+            continue
+        cls = node.get("class_type")
+        inputs = node.get("inputs", {}) or {}
+        if not isinstance(inputs, dict):
+            continue
+
+        if cls in _MODEL_LOADERS:
+            _push_unique(s.models, inputs.get(_MODEL_LOADERS[cls]))
+
+        if cls in _TEXT_ENCODER_LOADERS:
+            keys = _TEXT_ENCODER_LOADERS[cls]
+            if isinstance(keys, tuple):
+                for k in keys:
+                    _push_unique(s.text_encoders, inputs.get(k))
+            elif isinstance(keys, str):
+                _push_unique(s.text_encoders, inputs.get(keys))
+
+        if cls in _VAE_LOADERS:
+            _push_unique(s.vaes, inputs.get(_VAE_LOADERS[cls]))
+
+        if cls in _LORA_LOADERS:
+            name_key, m_key, c_key = _LORA_LOADERS[cls]
+            name = inputs.get(name_key)
+            if name:
+                s.loras.append(
+                    LoraEntry(
+                        name=name,
+                        model_strength=inputs.get(m_key) if m_key else None,
+                        clip_strength=inputs.get(c_key) if c_key else None,
+                    )
+                )
+
+        if cls in _SAMPLERS:
+            g = lambda k: _scalar_or_none(inputs.get(k))  # noqa: E731
+            # For SamplerCustomAdvanced the widget fields are all None on
+            # the sampler node itself; merge in the harvested aux_fields.
+            use_aux = cls == "SamplerCustomAdvanced"
+            cfg_default = 1.0 if (use_aux and has_basic_guider and "cfg" not in aux_fields) else None
+            s.samplers.append(
+                SamplerCall(
+                    node_id=nid,
+                    class_type=cls,
+                    sampler=g("sampler_name") or g("sampler") or (aux_fields.get("sampler") if use_aux else None),
+                    scheduler=g("scheduler") or (aux_fields.get("scheduler") if use_aux else None),
+                    steps=g("steps") or (aux_fields.get("steps") if use_aux else None),
+                    cfg=g("cfg") if g("cfg") is not None else (aux_fields.get("cfg", cfg_default) if use_aux else None),
+                    denoise=g("denoise") if g("denoise") is not None else (aux_fields.get("denoise") if use_aux else None),
+                    seed=g("seed") or g("noise_seed") or (aux_fields.get("seed") if use_aux else None),
+                    start_step=g("start_step") or g("start_at_step"),
+                    end_step=g("end_step") or g("end_at_step"),
+                    add_noise=g("add_noise"),
+                )
+            )
+
+        if cls in _LATENT_DIM_NODES:
+            s.width = _coalesce(_scalar_or_none(inputs.get("width")), s.width)
+            s.height = _coalesce(_scalar_or_none(inputs.get("height")), s.height)
+            s.num_frames = _coalesce(
+                _scalar_or_none(inputs.get("num_frames")),
+                _scalar_or_none(inputs.get("length")),
+                _scalar_or_none(inputs.get("frames")),
+                s.num_frames,
+            )
+
+        if cls in _SHIFT_NODES and "shift" in inputs:
+            s.shift = _coalesce(_scalar_or_none(inputs.get("shift")), s.shift)
+
+        if cls in _TEXT_ENCODE_NODES:
+            title = title_for.get(nid, "").lower()
+            for key in ("text", "positive_prompt", "negative_prompt", "prompt"):
+                val = inputs.get(key)
+                if isinstance(val, str) and val.strip():
+                    if (
+                        "negative" in title
+                        or "negative" in key
+                        or (key == "prompt" and "neg" in title)
+                    ):
+                        if val not in s.negative:
+                            s.negative.append(val)
+                    else:
+                        if val not in s.positive:
+                            s.positive.append(val)
+
+        if cls in {"SaveImage", "SaveVideo", "SaveAudio", "SaveAnimatedWEBP", "SaveAnimatedPNG", "imageSaveSimple", "VHS_VideoCombine"}:
+            fp = inputs.get("filename_prefix")
+            if isinstance(fp, str):
+                s.output_filenames.append(fp)
+
+    return s
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _cmd_extract(args: argparse.Namespace) -> int:
+    try:
+        data = extract(args.file)
+    except FileNotFoundError:
+        print(f"error: {args.file}: not found", file=sys.stderr)
+        return 2
+    if args.key:
+        if args.key not in data:
+            print(f"error: {args.file}: no '{args.key}' metadata", file=sys.stderr)
+            return 1
+        out = data[args.key]
+    else:
+        out = data
+    json.dump(out, sys.stdout, indent=2 if args.pretty else None, ensure_ascii=False)
+    sys.stdout.write("\n")
+    return 0
+
+
+def _cmd_summary(args: argparse.Namespace) -> int:
+    try:
+        data = extract(args.file)
+    except FileNotFoundError:
+        print(f"error: {args.file}: not found", file=sys.stderr)
+        return 2
+    if "prompt" not in data:
+        print(f"error: {args.file}: no embedded prompt", file=sys.stderr)
+        return 1
+    s = summarize(data["prompt"]).to_dict()
+    s["path"] = str(args.file)
+    if args.pretty:
+        _pretty_print_summary(s)
+    else:
+        json.dump(s, sys.stdout, indent=2, ensure_ascii=False, default=str)
+        sys.stdout.write("\n")
+    return 0
+
+
+def _pretty_print_summary(s: dict[str, Any]) -> None:
+    def line(label: str, value: Any) -> None:
+        if value is None or value == [] or value == "":
+            return
+        print(f"  {label:14} {value}")
+
+    print(s.get("path", ""))
+    line("model", ", ".join(s["models"]) if s["models"] else None)
+    line("text_encoders", ", ".join(s["text_encoders"]) if s["text_encoders"] else None)
+    line("vae", ", ".join(s["vaes"]) if s["vaes"] else None)
+    line("dims", f"{s['width']}x{s['height']}" if s["width"] and s["height"] else None)
+    line("num_frames", s["num_frames"])
+    line("shift", s["shift"])
+    for i, sc in enumerate(s["samplers"]):
+        prefix = "sampler" if i == 0 else f"sampler[{i}]"
+        # Render "sampler/scheduler" but drop None halves cleanly
+        algo = "/".join(x for x in (sc.get("sampler"), sc.get("scheduler")) if x) or "?"
+        parts = [f"steps={sc['steps']}", f"cfg={sc['cfg']}"]
+        if sc.get("denoise") is not None:
+            parts.append(f"denoise={sc['denoise']}")
+        parts.append(f"seed={sc['seed']}")
+        line(prefix, f"{algo} {' '.join(parts)}")
+    for lo in s["loras"]:
+        ms = lo["model_strength"]
+        cs = lo["clip_strength"]
+        strs = f"m={ms}" + (f" c={cs}" if cs is not None else "")
+        line("lora", f"{lo['name']} ({strs})")
+    for i, p in enumerate(s["positive"]):
+        line(f"pos[{i}]", (p[:120] + "...") if len(p) > 123 else p)
+    for i, n in enumerate(s["negative"]):
+        line(f"neg[{i}]", (n[:120] + "...") if len(n) > 123 else n)
+
+
+def _iter_files(root: Path, recursive: bool) -> Iterable[Path]:
+    if root.is_file():
+        yield root
+        return
+    pattern = "**/*" if recursive else "*"
+    for p in root.glob(pattern):
+        if p.is_file() and p.suffix.lower() in (
+            PIL_EXTS | VIDEO_EXTS | AUDIO_EXTS | LATENT_EXTS
+        ):
+            yield p
+
+
+def _cmd_scan(args: argparse.Namespace) -> int:
+    root = Path(args.dir)
+    if not root.exists():
+        print(f"error: {root}: not found", file=sys.stderr)
+        return 2
+
+    out_stream: Any
+    if args.out and args.out != "-":
+        out_stream = open(args.out, "w", encoding="utf-8")  # noqa: SIM115
+    else:
+        out_stream = sys.stdout
+
+    n_ok = n_err = 0
+    try:
+        for p in sorted(_iter_files(root, recursive=not args.no_recursive)):
+            rec: dict[str, Any] = {"path": str(p)}
+            try:
+                stat = p.stat()
+                rec["size"] = stat.st_size
+                rec["mtime"] = stat.st_mtime
+                data = extract(p)
+                if "prompt" not in data:
+                    rec["error"] = "no metadata"
+                    n_err += 1
+                else:
+                    rec["summary"] = summarize(data["prompt"]).to_dict()
+                    n_ok += 1
+            except Exception as e:
+                rec["error"] = f"{type(e).__name__}: {e}"
+                n_err += 1
+            out_stream.write(json.dumps(rec, ensure_ascii=False, default=str) + "\n")
+    finally:
+        if out_stream is not sys.stdout:
+            out_stream.close()
+
+    if args.verbose:
+        print(f"scan: {n_ok} indexed, {n_err} skipped/error", file=sys.stderr)
+    return 0
+
+
+def _cmd_diff(args: argparse.Namespace) -> int:
+    def lines_for(path: str) -> list[str]:
+        data = extract(path)
+        if "prompt" not in data:
+            return [f"# {path}: no embedded prompt"]
+        s = summarize(data["prompt"]).to_dict()
+        s["path"] = path
+        import contextlib
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            _pretty_print_summary(s)
+        return buf.getvalue().splitlines(keepends=True)
+
+    a_lines = lines_for(args.file_a)
+    b_lines = lines_for(args.file_b)
+    sys.stdout.writelines(
+        difflib.unified_diff(
+            a_lines, b_lines, fromfile=args.file_a, tofile=args.file_b, n=2
+        )
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="comfy_meta",
+        description="Read ComfyUI workflow metadata embedded in output files.",
+    )
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    ex = sub.add_parser("extract", help="dump embedded prompt+workflow JSON")
+    ex.add_argument("file")
+    ex.add_argument(
+        "-k",
+        "--key",
+        choices=("prompt", "workflow"),
+        help="dump only one half (default: both)",
+    )
+    ex.add_argument("-p", "--pretty", action="store_true", help="indent the JSON")
+    ex.set_defaults(func=_cmd_extract)
+
+    su = sub.add_parser("summary", help="one-record summary of settings")
+    su.add_argument("file")
+    su.add_argument(
+        "-p", "--pretty", action="store_true", help="human-readable instead of JSON"
+    )
+    su.set_defaults(func=_cmd_summary)
+
+    sc = sub.add_parser("scan", help="walk a directory and emit JSONL")
+    sc.add_argument("dir")
+    sc.add_argument("-o", "--out", help="output file ('-' for stdout, default stdout)")
+    sc.add_argument(
+        "--no-recursive", action="store_true", help="only the top-level directory"
+    )
+    sc.add_argument("-v", "--verbose", action="store_true", help="print summary to stderr")
+    sc.set_defaults(func=_cmd_scan)
+
+    df = sub.add_parser("diff", help="diff summarized settings of two files")
+    df.add_argument("file_a")
+    df.add_argument("file_b")
+    df.set_defaults(func=_cmd_diff)
+
+    args = ap.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/comfyui-plugin/skills/comfy-registry-lifecycle/SKILL.md
+++ b/comfyui-plugin/skills/comfy-registry-lifecycle/SKILL.md
@@ -18,6 +18,13 @@ failures below live in this flow (or the CI that gates it) and are easy to
 ship without noticing, because the pipeline reports green while the
 registry artifact is broken.
 
+## When to Use This Skill
+
+| Use this skill when... | Use instead when... |
+|---|---|
+| Setting up or debugging a pack's release-please -> publish.yml -> registry pipeline | Writing the pack's frontend/backend code itself -> `comfyui-node-authoring` |
+| A published node's frontend or artwork isn't showing up correctly | Smoke-testing the pack in a running instance -> `comfyui-pack-live-smoke` |
+
 ## 1. `uv.lock` self-version drifts — release-please has no native uv.lock support
 
 The lockfile records the **workspace package's own version** in its

--- a/comfyui-plugin/skills/comfy-registry-lifecycle/SKILL.md
+++ b/comfyui-plugin/skills/comfy-registry-lifecycle/SKILL.md
@@ -1,0 +1,376 @@
+---
+created: 2026-07-07
+modified: 2026-07-07
+reviewed: 2026-07-07
+name: comfy-registry-lifecycle
+description: >-
+  Comfy Registry release pipeline: release-please + lockfile drift traps, the empty-web/dist publish bug, version status states, phantom versions, icon/banner generation. Use when debugging a pack's publish pipeline.
+allowed-tools: Bash, Read, Grep, Glob, Write, Edit
+---
+
+# comfy-registry-lifecycle
+
+A ComfyUI custom-node pack's release flow: conventional commits →
+release-please bumps `pyproject.toml` + `CHANGELOG.md` → merge the release
+PR → the published GitHub release triggers `publish.yml` →
+`Comfy-Org/publish-node-action` publishes to registry.comfy.org. The
+failures below live in this flow (or the CI that gates it) and are easy to
+ship without noticing, because the pipeline reports green while the
+registry artifact is broken.
+
+## 1. `uv.lock` self-version drifts — release-please has no native uv.lock support
+
+The lockfile records the **workspace package's own version** in its
+`[[package]]` entry. release-please's `python` release-type bumps
+`pyproject.toml` but **not** `uv.lock`
+([googleapis/release-please#2561](https://github.com/googleapis/release-please/issues/2561)),
+so the lock's self-version silently trails `pyproject.toml` across releases.
+There is **no uv/`pyproject.toml` setting** to omit the project's own
+version from the lock, so the lock must be kept in sync explicitly.
+
+**Fix — a structured `toml` `extra-files` updater** in
+`release-please-config.json` (the declarative equivalent of
+`uv lock --upgrade-package`, not a hand-edit):
+
+```json
+"extra-files": [
+  {
+    "type": "toml",
+    "path": "uv.lock",
+    "jsonpath": "$.package[?(@.name.value=='<pack-name>')].version"
+  }
+]
+```
+
+`<pack-name>` is the directory/package name. The `toml` updater parses the
+lock and sets only the matched `version` value at the JSONPath — everything
+else stays byte-stable. Note `.name.value` (release-please's TOML AST wraps
+scalar values).
+
+To repair an already-drifted lock once: `uv lock` regenerates it to match
+`pyproject.toml` (the only diff is the self-version line, plus occasional uv
+specifier normalization like `>=1.40` → `>=1.40.0`).
+
+**Sweeps miss packs — check before the first release, not after.** A pack
+created after a fix sweep can silently lack the updater. Before merging any
+pack's release PR — and when scaffolding or auditing a pack — confirm
+`grep -c extra-files release-please-config.json` ≥ 1 and that the release
+PR's changed files include `uv.lock`. Adding the updater to `main` while a
+release PR is open regenerates that PR to include the lock bump.
+
+## 2. The registry "Updates" changelog — use native `COMFY_NODE_CHANGELOG`, not a post-publish PUT
+
+`comfy node publish` sets the per-version changelog **natively** via the
+`COMFY_NODE_CHANGELOG` env var
+([Comfy-Org/comfy-cli#467](https://github.com/Comfy-Org/comfy-cli/issues/467),
+released in comfy-cli 1.11+), populating the registry's "Updates" section
+atomically at publish time.
+
+**Do not** hand-roll a post-publish step that resolves the version UUID and
+`PUT`s to `https://api.comfy.org/publishers/.../versions/{id}`. A
+hand-rolled step that extracts `node_id`/`version` via `python3 -c 'import
+tomllib'` fails on every release with `ModuleNotFoundError: No module named
+'tomllib'`, because `Comfy-Org/publish-node-action` pins **Python 3.10**
+and `tomllib` is 3.11+ stdlib. Under `bash -e` it dies before any `|| exit
+0` guard — the node still publishes, but the Updates section is empty and
+the job shows red, which is easy to miss.
+
+**Correct shape**: a step *before* the publish-node-action step that
+flattens the release notes to plain text (the registry renders Updates as
+plain text) and exports it, so the action's `comfy node publish` reads it
+from the job environment:
+
+```yaml
+- name: Compute registry changelog from release notes
+  if: github.event_name == 'release' && github.event.release.body != ''
+  env:
+    RELEASE_BODY: ${{ github.event.release.body }}   # via env, not inline interpolation
+  run: |
+    changelog=$(python3 <<'PY'
+    # pure-`re` markdown→plaintext flatten (no tomllib); prints the changelog
+    PY
+    )
+    {
+      echo "COMFY_NODE_CHANGELOG<<__CHANGELOG_EOF__"
+      echo "$changelog"
+      echo "__CHANGELOG_EOF__"
+    } >> "$GITHUB_ENV"
+```
+
+`$GITHUB_ENV` exports the var to all later steps in the job, including the
+composite `publish-node-action` run. No PUT, no UUID lookup, no `tomllib`.
+
+## 3. Bumping a shared frontend-kit dependency: regenerate the lockfile *and* the built bundle together
+
+For a TS-built pack that consumes a shared TypeScript package inlined at
+build time (`bun build` bundles the import into `web/dist`), bumping the
+version range in `package.json` looks like a one-line change but silently
+desyncs **two** other committed artifacts, and CI catches each with a
+different, non-obvious error:
+
+- **`bun.lock` goes stale** — its pinned resolution still satisfies the
+  *old* range, so it isn't touched by hand-editing `package.json`. CI runs
+  `bun install --frozen-lockfile`, which fails with `error: No version
+  matching "^X.Y.0" found for specifier "<pkg>" (but package exists)` — a
+  confusing message, since the version genuinely is published; the real
+  problem is the *lockfile's stale resolution*.
+- **`web/dist` goes stale** — the committed bundle still contains the old
+  inlined code. A "verify committed `web/dist` is up to date" CI gate (a
+  `git diff --exit-code -- web/dist` after a fresh build) fails.
+
+Both gates are correct — the footgun is that the fix requires **two**
+commands, and the second failure only surfaces *after* the first is fixed
+(the frozen-lockfile failure blocks the build step that would otherwise
+reveal the dist-drift):
+
+```sh
+bun install   # regenerates bun.lock to resolve the new range
+bun run build # rebuilds web/dist against the new dependency version
+git add bun.lock web/dist/index.js
+```
+
+Commit both in the same commit as the `package.json` bump — don't split
+them, and don't stop after fixing the lockfile install failure without also
+rebuilding `web/dist`.
+
+Across a whole pack set, check for consistency (range equals locked version
+in every consumer):
+
+```sh
+for repo in <pack-glob>; do
+  [ -f "$repo/package.json" ] || continue
+  range=$(grep -o '"<shared-pkg>": *"[^"]*"' "$repo/package.json" | grep -o '\^[0-9.]*')
+  locked=$(grep -o '<shared-pkg>@[0-9.]*' "$repo/bun.lock" 2>/dev/null | head -1)
+  echo "$repo | range=$range | $locked"
+done
+```
+
+## The empty-`web/dist` publish trap
+
+For TS-built packs, the registry tarball is supposed to force-ship the
+built frontend via `[tool.comfy] includes = ["web/dist"]`. The trap: a
+published tarball can contain `web/dist/` as an **empty directory** — no
+`index.js` — while `publish.yml` reports green.
+
+Root cause is the publish action, not the include:
+
+- `Comfy-Org/publish-node-action@v1` (and tags `1.0.0` / `1.0.1`) run an
+  **unconditional `actions/checkout@v4`** that wipes the git-ignored
+  `web/dist` a prior `bun run build` step produced. **None of the tagged
+  releases have a `skip_checkout` input.**
+- `skip_checkout` exists **only on the action's `main` branch** (added
+  2025-05-03, commit `c742414d`; no tagged release carries it).
+- `comfy node publish` then packs git-tracked files + `includes`; its
+  `zip_files` walks an included dir's contents **only if the dir exists at
+  pack time** — if absent it writes an empty-dir entry. A wiped `web/dist`
+  → empty `web/dist/` in the tarball.
+
+**Fix** — pin the action to the commit that gates checkout on
+`skip_checkout` (no tag has it yet):
+
+```yaml
+      - name: Publish Custom Node
+        # @v1/1.0.x lack skip_checkout and wipe the built web/dist. Pin
+        # the main commit that gates checkout on skip_checkout (no tag has it).
+        uses: Comfy-Org/publish-node-action@d2366e7abb6ab16f3bb03e3520ae25c8cf749bc9  # v1.0.2-dev (main HEAD; skip_checkout not yet tagged)
+        with:
+          personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}
+          skip_checkout: 'true'
+```
+
+`skip_checkout: 'true'` is **silently ignored** by `@v1` — passing it
+without repinning does nothing, which is exactly what lets this hide for
+weeks.
+
+### Verify a publish actually shipped the frontend
+
+Never trust a green `publish.yml` run — it succeeds even when the tarball
+is empty. Download the real artifact and inspect it:
+
+```sh
+python3 - <<'PY'
+import json, urllib.request, zipfile, io
+nid, ver = "<node-id>", "<version>"
+d = json.load(urllib.request.urlopen(f"https://api.comfy.org/nodes/{nid}/versions"))
+v = next(x for x in d if x["version"] == ver)
+z = zipfile.ZipFile(io.BytesIO(urllib.request.urlopen(v["downloadUrl"]).read()))
+print([n for n in z.namelist() if n.startswith("web/dist/") and n.endswith((".js",".css"))])
+PY
+```
+
+Empty list ⇒ broken tarball. The `downloadUrl`
+(`cdn.comfy.org/<owner>/<id>/<ver>/node.zip`) is in each version object.
+
+## Version status: Pending vs Flagged vs Active
+
+`api.comfy.org/nodes/<id>/versions` returns every version with a `status`:
+
+| Status | Meaning | Action |
+|---|---|---|
+| `NodeVersionStatusPending` | held while the automated security scan runs | **auto-transitions** to Active, usually < a few hours — just wait |
+| `NodeVersionStatusActive` | scan passed; installable | none |
+| `NodeVersionStatusFlagged` | scan flagged it | **stuck** — does NOT auto-clear. Reason is only on `registry.comfy.org` (the public API exposes none). Republishing re-runs the scan; appeal via Comfy-Org if a false positive |
+
+`comfy node install` resolves to the **highest-semver Active** version. So
+while a fixed version is Pending, installs still serve the older (possibly
+broken) Active one. `comfy node registry-install` can fetch a Pending
+version directly.
+
+Flag false-positives are real: an identical commit can flag one pack but
+not a structurally-identical sibling. Don't assume your code is the
+problem — check the dashboard reason first.
+
+## Phantom versions (higher semver, ahead of git)
+
+A version published once from a stale local copy can sit in the registry
+**ahead of git** (e.g. `0.2.0` Active while git is at `0.1.7`). Because
+install resolves to highest-semver Active, that phantom becomes the
+clean-install target and **outranks every later fix** below it. Two ways
+out:
+
+1. Release a version **> the phantom** (`Release-As`, below) — the fix must
+   outrank it.
+2. **Remove the phantom** from the registry dashboard — then the next
+   Active version wins.
+
+## `Release-As` is stripped by squash-merge
+
+To force release-please to a specific version (e.g. to leapfrog a
+phantom), a commit needs a `Release-As: X.Y.Z` **trailer**. The trap:
+**GitHub squash-merge rebuilds the commit body from the PR description**,
+so the trailer only survives if it's a clean line in the *PR description*
+— a trailer that lives only in the branch commit, or sits inside backticks
+or mid-sentence, is dropped and release-please falls back to a plain patch
+bump. Reliable options:
+
+- **"Rebase and merge"** the trigger PR — preserves the commit message
+  verbatim, trailer intact.
+- Or put `Release-As: X.Y.Z` as a plain last line of the **PR description**
+  (no backticks) for squash.
+
+Do **not** hand-edit `.release-please-manifest.json` / `CHANGELOG.md` to
+force a version — it conflicts with the automation.
+
+## Standing feedback: the `registry-health` workflow
+
+A `.github/workflows/registry-health.yml` (runs after publish, daily, and
+on demand) that looks up the `pyproject.toml` version in the registry and
+**fails + opens a `registry-health` issue** when that version is Flagged,
+stuck Pending, missing, or outranked by a phantom — auto-closing when
+healthy — is the early-warning the publish pipeline lacks on its own.
+Worth adding to any new pack.
+
+## Backport to the scaffold
+
+If `publish.yml` is generated by a scaffold template (as it is for
+`comfyui-node-scaffold` → `scaffold.py`), fix the template in the same
+sweep as any live packs, or every newly-scaffolded pack inherits the same
+broken step.
+
+## Icons & banners
+
+Without `[tool.comfy] Icon`, the registry shows a generic placeholder.
+
+### Icon design system
+
+- **400×400 SVG**, dark squircle tile (`#12121a`→`#1f1f2a` gradient,
+  `rx≈76`), ~56 px inner padding, one bespoke glyph centred.
+- **Glyph colour encodes the sub-family** so a set of packs reads as a
+  family (e.g. amber for one facet, blue for another). Keep tile, corner
+  radius, and stroke weight uniform across packs.
+
+### Rasterize SVG with cairosvg — NOT ImageMagick
+
+ImageMagick's internal MSVG renderer **silently drops `stroke`,
+`fill="none"`, and gradients** — only *filled* shapes render, so
+stroke-based glyphs come out half-missing and a gradient tile goes flat
+black. Use cairosvg:
+
+```sh
+uvx --from cairosvg cairosvg icon.svg -o icon.png -W 400 -H 400
+```
+
+`magick`/ImageMagick is fine for PNG compositing/montages — just never for
+SVG→PNG of stroke art. If neither `rsvg-convert` nor `inkscape`/`resvg` is
+available, cairosvg via `uvx` is the reliable fallback path.
+
+### Banners (21:9) — AI background + composited branding
+
+Diffusion is the right tool for the *background*, the wrong tool for
+*icons* and *text*. Generate a clean background, then composite crisp
+branding on top. `scripts/registry_banner_bg.py` and
+`registry_banner_compose.py` (this skill's `scripts/`) implement this
+two-step pipeline against a running ComfyUI instance:
+
+```sh
+python3 scripts/registry_banner_bg.py \
+  --accent "warm amber and orange" --seed 101 --out bg.png \
+  --host "${COMFYUI_HOST:-127.0.0.1:8188}"
+```
+
+Generates a 1344×576 (exact 21:9) abstract on-brand texture with **no
+text/letters/logo/symbols** requested in the prompt.
+
+```sh
+python3 scripts/registry_banner_compose.py \
+  --bg bg.png --icon icon.png --name "Display Name" \
+  --tagline "Short tagline" --accent '#ffb02e' --out banner.png
+```
+
+Composites the icon + name wordmark + tagline with ImageMagick. Text stays
+sharp and correctly spelled this way — never trust a diffusion model to
+render pack names.
+
+### Wiring into the registry (`pyproject.toml` `[tool.comfy]`)
+
+- `Icon` / `Banner` are **URLs**, not tarball paths. Use
+  raw.githubusercontent off the default branch:
+  `Icon = "https://raw.githubusercontent.com/<owner>/<repo>/main/icon.png"`
+- They 404 on the PR branch and resolve the instant the PR merges to
+  `main` (icon + version land together). Keep the art files and the
+  metadata change in the **same PR**.
+- Leave `[tool.comfy] includes` unchanged — the icon is fetched from the
+  URL, not shipped in the publish tarball.
+
+### release-please owns the version — never hand-bump
+
+Add Icon/Banner + art with a conventional-commit PR (`fix:` → patch,
+`feat:` → minor). **Do not touch `version`.** Squash-merge → release-please
+opens a release PR with the bump → merge that → it cuts the GitHub Release
+(which publishes).
+
+### `publish.yml` — trigger on the release event, not the pyproject path
+
+A publish workflow triggering on `push: paths: [pyproject.toml]` re-fires
+on *any* pyproject edit and 400s with `"node version already exists"`. Fix
+it to fire once per real release:
+
+```yaml
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+```
+
+release-please emits a *published* Release when its release PR merges →
+publish runs exactly once with the bumped version. Bonus: merging the icon
+PR itself no longer triggers a spurious publish.
+
+### Verify after merge
+
+```sh
+curl -sI https://raw.githubusercontent.com/<owner>/<repo>/main/icon.png   # 200 image/png
+gh run list -R <owner>/<repo> --workflow=publish.yml -L1                  # release/success
+curl -s https://api.comfy.org/nodes/<id>/versions                        # new version present
+```
+
+## Verify
+
+**#1/#2/lockfile issues**: static-checkable (YAML + actionlint; `uv lock`
+diff is one line), but the changelog path is only exercised at real
+publish time. Definitive proof = the **next release's publish job goes
+green with a populated Updates section**.
+
+**publish action pin**: the pack-set consistency check above returning
+`range == locked` for every consumer, plus a downloaded-tarball inspection
+showing a non-empty `web/dist/`.

--- a/comfyui-plugin/skills/comfy-registry-lifecycle/scripts/registry_banner_bg.py
+++ b/comfyui-plugin/skills/comfy-registry-lifecycle/scripts/registry_banner_bg.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Generate a 21:9 banner BACKGROUND via the local ComfyUI Flux2 Klein API.
+
+Background only — composite the crisp icon + wordmark on top afterwards with
+registry_banner_compose.py. So the prompt aims for clean, dark, on-brand
+abstract texture with negative space and NO text/symbols (diffusion can't be
+trusted to spell, and the icon/wordmark are added sharply in the compose step).
+
+Flux2 Klein topology mirrors tooling/.claude/rules/flux2-klein.md (distilled:
+UNETLoader + CLIPLoader type=flux2 + Qwen3-8B encoder + Flux2 VAE +
+EmptyFlux2LatentImage + FluxGuidance=4 + KSampler euler/simple 4 steps cfg=1 +
+ConditioningZeroOut negative).
+
+Run under the ComfyUI venv (stdlib only, but keeps things uniform):
+  ComfyUI/.venv/bin/python tooling/scripts/registry_banner_bg.py \
+    --accent "warm amber and orange" --seed 101 --out bg.png
+
+See also: tooling/.claude/rules/comfy-registry-icons-banners.md
+"""
+import argparse, json, time, urllib.request, urllib.parse, sys
+
+DEF_PROMPT = (
+    "Abstract dark user-interface background wallpaper, deep charcoal near-black base, "
+    "soft {accent} glow with gentle light streaks and faint bokeh, subtle geometric tech "
+    "grid fading into shadow, smooth premium gradient, minimal and clean, generous empty "
+    "negative space, cinematic soft studio lighting, high-end software branding backdrop. "
+    "No text, no words, no letters, no logo, no symbols, no UI elements, no people."
+)
+
+
+def build_graph(text, seed, w, h, model):
+    return {
+        "unet": {"class_type": "UNETLoader", "inputs": {"unet_name": model, "weight_dtype": "default"}},
+        "clip": {"class_type": "CLIPLoader", "inputs": {"clip_name": "qwen_3_8b_fp8mixed.safetensors", "type": "flux2"}},
+        "vae":  {"class_type": "VAELoader", "inputs": {"vae_name": "Flux2/flux2-vae.safetensors"}},
+        "pos":  {"class_type": "CLIPTextEncode", "inputs": {"clip": ["clip", 0], "text": text}},
+        "zero": {"class_type": "ConditioningZeroOut", "inputs": {"conditioning": ["pos", 0]}},
+        "guid": {"class_type": "FluxGuidance", "inputs": {"conditioning": ["pos", 0], "guidance": 4.0}},
+        "lat":  {"class_type": "EmptyFlux2LatentImage", "inputs": {"width": w, "height": h, "batch_size": 1}},
+        "ks":   {"class_type": "KSampler", "inputs": {"model": ["unet", 0], "positive": ["guid", 0],
+                  "negative": ["zero", 0], "latent_image": ["lat", 0], "seed": seed, "steps": 4,
+                  "cfg": 1.0, "sampler_name": "euler", "scheduler": "simple", "denoise": 1.0}},
+        "dec":  {"class_type": "VAEDecode", "inputs": {"samples": ["ks", 0], "vae": ["vae", 0]}},
+        "save": {"class_type": "SaveImage", "inputs": {"images": ["dec", 0], "filename_prefix": "registry_banner"}},
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", required=True, help="output PNG path")
+    ap.add_argument("--accent", default="cool blue and azure",
+                    help='accent phrase, e.g. "warm amber and orange" / "cool blue and azure"')
+    ap.add_argument("--seed", type=int, default=1)
+    ap.add_argument("--width", type=int, default=1344, help="must be /16; 1344x576 = exact 21:9")
+    ap.add_argument("--height", type=int, default=576)
+    ap.add_argument("--prompt", default=None, help="override the default background prompt")
+    ap.add_argument("--model", default="Flux2/flux-2-klein-9b-fp8.safetensors")
+    ap.add_argument("--host", default="http://127.0.0.1:8188")
+    a = ap.parse_args()
+
+    text = a.prompt or DEF_PROMPT.format(accent=a.accent)
+    graph = build_graph(text, a.seed, a.width, a.height, a.model)
+
+    data = json.dumps({"prompt": graph}).encode()
+    req = urllib.request.Request(f"{a.host}/prompt", data=data, headers={"Content-Type": "application/json"})
+    pid = json.loads(urllib.request.urlopen(req, timeout=60).read())["prompt_id"]
+    print(f"submitted {pid} ({a.width}x{a.height} seed={a.seed})", flush=True)
+
+    t0 = time.time()
+    while time.time() - t0 < 300:
+        h = json.loads(urllib.request.urlopen(f"{a.host}/history/{pid}", timeout=30).read())
+        if pid in h:
+            img = h[pid]["outputs"]["save"]["images"][0]
+            q = urllib.parse.urlencode({"filename": img["filename"], "subfolder": img.get("subfolder", ""), "type": img.get("type", "output")})
+            open(a.out, "wb").write(urllib.request.urlopen(f"{a.host}/view?{q}", timeout=60).read())
+            print(f"-> {a.out}")
+            return
+        time.sleep(2)
+    sys.exit("timed out waiting for ComfyUI")
+
+
+if __name__ == "__main__":
+    main()

--- a/comfyui-plugin/skills/comfy-registry-lifecycle/scripts/registry_banner_compose.py
+++ b/comfyui-plugin/skills/comfy-registry-lifecycle/scripts/registry_banner_compose.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Composite crisp branding onto a banner background -> final 21:9 banner.png.
+
+Layout: icon squircle at left, DisplayName wordmark + tagline to its right,
+over a slightly darkened background for legibility. Text is drawn with magick
+(sharp, correctly spelled) — never bake the pack name into the diffusion prompt.
+
+  ComfyUI/.venv/bin/python tooling/scripts/registry_banner_compose.py \
+    --bg bg.png --icon icon.png --name "Touch Resize" \
+    --tagline "Pinch-to-resize nodes on touch" --accent '#ffb02e' --out banner.png
+
+Inputs: --bg from registry_banner_bg.py, --icon the cairosvg-rendered 400x400
+icon (see comfy-registry-icons-banners.md — rasterize with cairosvg, NOT magick).
+
+See also: tooling/.claude/rules/comfy-registry-icons-banners.md
+"""
+import argparse, subprocess, sys
+
+BOLD = "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"
+REG = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--bg", required=True, help="background PNG (registry_banner_bg.py)")
+    ap.add_argument("--icon", required=True, help="400x400 icon PNG (cairosvg-rendered)")
+    ap.add_argument("--name", required=True, help="DisplayName wordmark, e.g. 'Touch Resize'")
+    ap.add_argument("--tagline", required=True, help="one-line tagline")
+    ap.add_argument("--accent", default="#6ba6ff", help="tagline colour hex (family accent)")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--bold-font", default=BOLD)
+    ap.add_argument("--reg-font", default=REG)
+    a = ap.parse_args()
+
+    cmd = [
+        "magick", a.bg, "-brightness-contrast", "-12x4",
+        "(", a.icon, "-resize", "300x300", ")",
+        "-gravity", "NorthWest", "-geometry", "+72+138", "-composite",
+        "-gravity", "NorthWest",
+        # wordmark: soft shadow then light fill
+        "-font", a.bold_font, "-pointsize", "94",
+        "-fill", "rgba(0,0,0,0.55)", "-annotate", "+437+205", a.name,
+        "-fill", "#e8e8ea", "-annotate", "+434+202", a.name,
+        # tagline in the family accent colour
+        "-font", a.reg_font, "-pointsize", "37", "-fill", a.accent, "-annotate", "+438+320", a.tagline,
+        a.out,
+    ]
+    r = subprocess.run(cmd)
+    if r.returncode != 0:
+        sys.exit(f"magick failed ({r.returncode})")
+    print(f"-> {a.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/comfyui-plugin/skills/comfy-subgraphs-app-mode/SKILL.md
+++ b/comfyui-plugin/skills/comfy-subgraphs-app-mode/SKILL.md
@@ -31,6 +31,12 @@ its internal link table) live in **`comfy-workflow-json`** — that skill is
 the authority for **programmatic** subgraph edits. This skill is about the
 **interactive** features and what they mean for reuse.
 
+## When to Use This Skill
+
+| Use this skill when... | Use instead when... |
+|---|---|
+| Deciding whether to package part of a workflow as a subgraph, Blueprint, or App Mode UI | Editing the JSON shape of a subgraph programmatically -> `comfy-workflow-json` |
+
 ## Subgraphs — the basics
 
 A subgraph packages selected nodes into a single collapsible "super node"

--- a/comfyui-plugin/skills/comfy-subgraphs-app-mode/SKILL.md
+++ b/comfyui-plugin/skills/comfy-subgraphs-app-mode/SKILL.md
@@ -1,0 +1,152 @@
+---
+created: 2026-07-07
+modified: 2026-07-07
+reviewed: 2026-07-07
+name: comfy-subgraphs-app-mode
+description: >-
+  ComfyUI Subgraphs, Subgraph Blueprints, and App Mode: creating/publishing subgraphs, why Blueprint instances are snapshots not live refs, turning a workflow into a form UI. Use when deciding how to package a workflow stage.
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# comfy-subgraphs-app-mode
+
+Three frontend features for reusing and simplifying workflows, each
+**version-gated**:
+
+| Feature | Frontend gate |
+|---|---|
+| Subgraphs (group → super-node) | 1.24.3+ |
+| Subgraph **Parameters Panel** ("Edit Subgraph Widgets") | 0.3.66+ |
+| Subgraph **Blueprints** (publish to node library) | 1.27.7+ |
+| **App Mode** (a.k.a. "linear mode") | 1.41.13+ |
+
+Check the running frontend if any of these ever appear missing:
+
+```sh
+<venv>/bin/python -c "import comfyui_frontend_package as p; print(p.__version__)"
+```
+
+The editor-side mechanics (the JSON shape of `definitions.subgraphs[]` and
+its internal link table) live in **`comfy-workflow-json`** — that skill is
+the authority for **programmatic** subgraph edits. This skill is about the
+**interactive** features and what they mean for reuse.
+
+## Subgraphs — the basics
+
+A subgraph packages selected nodes into a single collapsible "super node"
+with exposed input/output slots. Authoring is interactive:
+
+- **Create**: select nodes → click the subgraph icon in the selection
+  toolbox. ComfyUI auto-exposes the relevant inputs/outputs.
+- **Edit**: double-click empty space *inside* the subgraph (not on a
+  widget), or use its edit button. A navigation bar shows the current
+  level; **Esc** or the nav bar exits. Right-click a slot to
+  rename/delete/disconnect; the slot labeled **1** is the spare for adding
+  a new connection.
+- **Parameters Panel** (0.3.66+): select the subgraph and click **Edit
+  Subgraph Widgets** to reorder/hide its surfaced widgets *without*
+  entering it.
+- **Nesting**: subgraphs can contain subgraphs; the nav bar tracks depth.
+- **Unpack**: right-click → **Unpack subgraph** (or the toolbox button)
+  flattens it back to loose nodes.
+- **Bypass / color / rename**: a subgraph behaves like any node.
+
+A plain subgraph lives **inside one workflow's JSON**
+(`definitions.subgraphs[]`). Copy-pasting it into another workflow carries
+the definition along — reuse-by-copy-paste, fine for one-off porting but
+not a library.
+
+## Subgraph Blueprints — the reusable "library of stages"
+
+This is the answer to "can I reuse a stage across many workflows."
+**Blueprints** promote a subgraph into the **node library** so it can be
+dragged or searched into any workflow like a built-in node.
+
+- **Publish**: select the subgraph → click the **book (publish)** icon in
+  the selection toolbox, or selection-toolbox menu → **Add Subgraph to
+  Library**. Name it in the dialog (the subgraph's name is the default).
+  It then appears in the node library, searchable and draggable.
+- **Reuse**: drag or search the blueprint into any workflow. Add as many
+  instances as you like.
+- **Manage**: edit/delete blueprints from the dedicated button in the node
+  library (panel section labeled "Comfy Blueprints").
+
+### The one caveat that changes how you use them
+
+**Instances are isolated snapshots, not live references.** Each placed
+instance is an independent copy you can edit freely; editing one does
+**not** affect the others — and crucially, **editing the master blueprint
+does not propagate to instances already dropped into workflows.** The docs
+are explicit that "link instances, synchronous editing" are *not yet*
+supported.
+
+Practical consequences:
+
+- Treat a blueprint like a **stamp/palette entry**, not a symbol with live
+  instances. It's "insert a fresh copy of this stage," not "reference one
+  canonical stage everywhere."
+- **Versioning is manual.** Improve a stage → re-publish (new name, or
+  overwrite — the frontend warns on overwrite). Existing workflows keep
+  their old embedded copy until you delete the instance and drop the new
+  one in. There is no "update all instances."
+- Good blueprint candidates are **stable, rarely-churning stages** (a
+  standard sampler pass, a diffusion core, a reference-latent block, a
+  standard upscale-and-save tail). Volatile experiment stages are poor
+  candidates — you'll be re-stamping constantly.
+
+### Where blueprints live on disk
+
+Publishing goes through the **userdata API** (`POST
+/userdata/<file>/publish`), so blueprints are stored **server-side**
+(under `user/default/` on a self-hosted install) — shared across every
+browser and workflow hitting that install, not trapped in one browser's
+local storage. They survive a service restart; they do **not** live in any
+individual workflow's JSON.
+
+## App Mode — workflow → simple app UI
+
+App Mode (the frontend's internal name is **linear mode**) hides the node
+graph behind a purpose-built input/output panel: you pick which node
+inputs become user controls and which outputs get displayed, and end users
+just fill the form and hit **Run**. Available on both self-hosted and
+Comfy Cloud installs.
+
+- **Enter**: top-left icon → **Enter app mode**, or the breadcrumb dropdown
+  at the top of the canvas.
+- **App Builder** (opens automatically the first time, 4 steps):
+  1. **Select Inputs** — click nodes to expose as controls (prompts,
+     sliders, image uploads, model pickers). They preview in the right
+     panel.
+  2. **Select Outputs** — choose which Preview/Save nodes show in the
+     final UI.
+  3. **Preview** — verify the assembled layout.
+  4. **Set Default View** — choose whether the workflow opens in **App** or
+     **Node Graph** mode, then **Apply**.
+- **Run UI**: right-side input panel, a Run button, a left sidebar
+  (rebuild, assets, workflow panel), a Cancel-this-run button during
+  execution, and queue/results toggles. Collapses to a tab view on
+  narrow/mobile screens.
+- **Save**: `Ctrl/Cmd + S` like any workflow.
+- **Share**: left-sidebar **Share** → **Create a link** generates a URL
+  encoding the workflow, layout, and node bindings. **Share links are
+  Comfy-Cloud-only** — on a self-hosted install you can build and run apps,
+  but a "Create a link" share won't produce a publicly reachable URL.
+
+### App config is stored *in the workflow JSON*
+
+App Mode persists under `extra.linearMode` and `extra.linearData` in the
+workflow JSON (alongside `extra.ds`, `extra.frontendVersion`, etc.). This
+matters for **programmatic edits**: any transform script that round-trips
+a workflow must **preserve the `extra` block**, or it silently strips the
+app configuration. If you rebuild a workflow from scratch in a builder
+script, the app config is gone and has to be reconfigured in the UI. See
+`comfy-workflow-json`.
+
+## Decision: blueprint vs app mode vs neither
+
+| Goal | Use |
+|---|---|
+| Reuse the same *stage* (sampler pass, edit core) across many workflows | **Subgraph Blueprint** (re-stamp; manual version bumps) |
+| Tidy one big workflow into readable super-nodes | **Subgraph** (no publish) |
+| Hand a non-graph user a fill-the-form UI on a finished workflow | **App Mode** |
+| Share that app UI as a public URL | App Mode **on Comfy Cloud** (self-hosted can't mint share links) |

--- a/comfyui-plugin/skills/comfy-workflow-json/SKILL.md
+++ b/comfyui-plugin/skills/comfy-workflow-json/SKILL.md
@@ -1,0 +1,195 @@
+---
+created: 2026-07-07
+modified: 2026-07-07
+reviewed: 2026-07-07
+name: comfy-workflow-json
+description: >-
+  Programmatically edit ComfyUI workflow JSON: edge-list link rebuilds, link-encoding schemas, preserving the extra block (App Mode config). Use when a workflow JSON is too large to hand-edit or a transform drops state.
+allowed-tools: Bash, Read, Grep, Glob, Write, Edit
+---
+
+# comfy-workflow-json
+
+Workflow JSONs routinely exceed a Read tool's size limit (a moderately
+complex workflow can be 25k+ tokens). Don't chunk-read or hand-edit large
+workflow files — write a Python transform script that uses `json.load` /
+`json.dump`.
+
+## Edge-list rebuild — mutate links without hand-surgery
+
+In-place link surgery (patching the flat `links` array *and* every node's
+`inputs[].link` / `outputs[].links` by hand) is error-prone — the
+silent-failure mode is a link id present in one place but not the other.
+The robust alternative:
+
+1. **Extract** edges to plain dicts: `[{src, src_slot, dst, dst_slot,
+   type}]` from `wf['links']`.
+2. **Mutate** that edge list (redirect an edge's `dst` to a new node, drop
+   edges touching a deleted node, append new edges) and add/remove nodes
+   from `wf['nodes']`.
+3. **Rebuild** authoritatively: clear every node's `inputs[].link` → `None`
+   and `outputs[].links` → `[]`, then re-number all edges 1..N into
+   `wf['links']` and re-populate both endpoints' link refs from the edge
+   list. Set `last_link_id` / `last_node_id`.
+
+`dst_slot` indexes the node's `inputs` array (widget entries included);
+`src_slot` indexes `outputs`. New nodes get `id = max(existing)+1`. To
+insert node X between src and `Target.model`: find the edge with
+`dst==Target, dst_slot==0`, repoint its `dst` to X, then append
+`X→Target.model`. This keeps the socket-array / links-table invariant
+correct by construction.
+
+## Don't template off a live working JSON
+
+A reference/comparison builder must clone a **clean, stable** template, not
+a workflow the user actively edits in the UI. A file you generated earlier
+can be silently reshaped between sessions (extra LoRAs, a swapped
+VAE-decode, a converted negative) — basing new variants on it inherits that
+drift and breaks structural assumptions a from-scratch builder made (e.g. a
+`ConditioningZeroOut` lookup can raise if the template gained unexpected
+nodes). Pick one canonical clean template, hardcode the per-variant deltas,
+and never read a user's live working copy as a template.
+
+## Running the workflow after editing it
+
+To execute a workflow JSON headlessly (queue it, poll, collect outputs)
+without the browser, see the **`comfyui-pack-live-smoke`** skill's
+headless-API section. This is the fastest way to verify an edited or built
+workflow actually runs — the gold-standard check beyond JSON link-integrity
+validation.
+
+## Authoritative schema
+
+The exact format ComfyUI validates against is the frontend's **zod
+schema** — there is no published JSON Schema. If uncertain about a field,
+extract the schema from the frontend's own sourcemap rather than guessing
+(see `comfyui-node-authoring`'s sourcemap-verification recipe):
+
+```sh
+FE=<comfyui-root>/.venv/lib/python3.10/site-packages/comfyui_frontend_package/static/assets
+python3 -c "import json,glob; m=json.load(open(glob.glob('$FE/api-*.js.map')[0])); i=m['sources'].index('../../src/platform/workflow/validation/schemas/workflowSchema.ts'); print(m['sourcesContent'][i])" > workflowSchema.ts
+```
+
+Re-extract after a frontend bump (the bundle hash changes) and keep the
+extracted file checked in with a provenance note, so uncertain transforms
+have a fast source of truth without re-extracting every time.
+
+Schema facts that drive transforms:
+
+- **Two top-level versions.** `version: 0.4` → `zComfyWorkflow`; `version:
+  1` → `zComfyWorkflow1`. They differ in link encoding and graph-state
+  fields (see table below). A frontend can emit either — don't hardcode an
+  assumption about which one you'll see.
+- **`.passthrough()` everywhere.** Unknown keys are preserved, not
+  rejected. `json.load`→mutate→`json.dump` is safe; the schema won't strip
+  fields you don't touch (this is why preserving `extra` works for free).
+- **`id`/slot fields accept strings or ints** (`zNodeId`, `zSlotIndex`).
+  GroupNode hacks node ids to `"<id>:<i>"` strings, and subgraph slot ids
+  are UUIDs. Don't assume integer node ids.
+- **`widgets_values` is array *or* object** (`zWidgetValues = array |
+  record`). Most core nodes use the positional array; some use a keyed
+  record. Index-based widget edits break on the record form.
+
+### Link encoding by version
+
+| Where | Format |
+|---|---|
+| Top-level `links`, **0.4** (`zComfyLink`) | tuple `[id, origin_id, origin_slot, target_id, target_slot, type]` |
+| Top-level `links`, **v1** (`zComfyLinkObject`) | dict `{id, origin_id, origin_slot, target_id, target_slot, type, parentId?}` |
+| **Subgraph-internal** `links` (any host version) | dict `zComfyLinkObject` — subgraph definitions always follow the v1 schema |
+| `floatingLinks` | dict `zComfyLinkObject` |
+
+This is why a 0.4 workflow with subgraphs has **tuple** links at the
+top level but **dict** links inside `definitions.subgraphs[]`: the
+subgraph definition (`zSubgraphDefinition`) extends `zComfyWorkflow1`, so
+it carries v1 object-links regardless of the host workflow's version. v1
+also replaces `last_node_id`/`last_link_id` with a `state` object
+(`{lastNodeId, lastLinkId, lastGroupId, lastRerouteId}`).
+
+## Subgraph format
+
+Newer workflows wrap part of the graph in **subgraphs**
+(`wf['definitions']['subgraphs'][i]`). Each subgraph has its own `nodes`,
+`inputs`, `outputs`, **and an internal `links` table whose format differs
+from the top-level**:
+
+| Where | Link format |
+|---|---|
+| Top-level `wf['links']` | flat array `[id, src, src_slot, dst, dst_slot, type]` |
+| Subgraph `sg['links']` | array of dicts `{id, origin_id, origin_slot, target_id, target_slot, type}` |
+
+When splicing a node into a subgraph, **both** the new node's input/output
+`links` arrays **and** the subgraph's internal `links` table must
+reference the new link ids. A link id present in a socket array but
+missing from the links table is the silent-failure mode — the workflow
+loads but the splice is invisible.
+
+A subgraph **published as a Blueprint** (node-library reuse) is a separate
+concern from this on-disk shape: the blueprint itself lives server-side via
+the userdata API, while each *placed instance* is a plain embedded
+`definitions.subgraphs[]` copy like any other. Editing the JSON never
+touches the blueprint, and there is no live link back to it (instances are
+snapshots). See `comfy-subgraphs-app-mode`.
+
+## Preserve the `extra` block (App Mode config lives there)
+
+Round-trip transforms must **carry `wf['extra']` through unchanged** — it
+holds editor and feature state, not just cosmetics:
+
+| Key | What it is |
+|---|---|
+| `extra.ds` | canvas pan/zoom |
+| `extra.frontendVersion` | authoring frontend version |
+| `extra.favoritedWidgets` | pinned widgets |
+| `extra.linearMode` / `extra.linearData` | **App Mode** input/output bindings + layout |
+
+`json.load` → mutate nodes → `json.dump` preserves `extra` for free. The
+failure mode is **rebuilding a workflow from scratch** in a builder script:
+the new dict has no `extra`, so any App Mode configuration the user set up
+in the UI is silently dropped and must be reconfigured. If a workflow has
+been App-Mode-configured, prefer an in-place transform over a
+from-scratch rebuild, or copy the old `extra.linearMode`/`extra.linearData`
+across. See `comfy-subgraphs-app-mode` for the App Mode feature itself.
+
+## Diagnosing a swapped-conditioning wiring bug
+
+Symptom: a workflow generates outputs that **look like the input image with
+only minor changes**, even at `denoise=1.0`. With CFG-distilled/Lightning-
+style LoRAs (`CFG=1.0`) the symptom is especially common because the
+negative path is ignored, so an empty positive conditioning falls back to
+"reconstruct the reference image."
+
+A real root cause found this way: the node *titled* `positive-prompt` and
+the node *titled* `negative-prompt` were wired into the sampler's
+`negative` and `positive` inputs respectively. Titles say one thing, links
+say the other.
+
+Diagnostic recipe — JSON-only, no UI required:
+
+```python
+import json
+wf = json.load(open(path))
+by_id = {n["id"]: n for n in wf["nodes"]}
+ks = next(n for n in wf["nodes"] if n["type"] == "KSampler")  # or KSamplerAdvanced
+pos_link = next(i for i in ks["inputs"] if i["name"] == "positive")["link"]
+neg_link = next(i for i in ks["inputs"] if i["name"] == "negative")["link"]
+src_of = lambda lid: next(L[1] for L in wf["links"] if L[0] == lid)
+print("positive source:", by_id[src_of(pos_link)].get("title"))
+print("negative source:", by_id[src_of(neg_link)].get("title"))
+```
+
+Fix: swap link source nodes in both the `links` table and the source
+nodes' `outputs[0].links` arrays — a 10-line transform once you know the
+link IDs. Same pattern applies to `SamplerCustomAdvanced` (via
+`BasicGuider`/`CFGGuider`) and any subgraph-internal sampler; the
+link-table layout is what matters, not which sampler family.
+
+## Naming conventions are per-install
+
+Many installs adopt their own save-node `filename_prefix` convention
+(dated buckets, sampler/scheduler/seed tokens, per-workflow kebab-case
+node-title slugs) to keep output sortable and runs distinguishable. That
+convention — and any audit script enforcing it — is specific to how a
+given install organizes its `output/` directory, not a portable ComfyUI
+fact; design one for your own install rather than importing someone else's
+verbatim.

--- a/comfyui-plugin/skills/comfy-workflow-json/SKILL.md
+++ b/comfyui-plugin/skills/comfy-workflow-json/SKILL.md
@@ -15,6 +15,13 @@ complex workflow can be 25k+ tokens). Don't chunk-read or hand-edit large
 workflow files — write a Python transform script that uses `json.load` /
 `json.dump`.
 
+## When to Use This Skill
+
+| Use this skill when... | Use instead when... |
+|---|---|
+| A workflow JSON is too large to hand-edit, or you're splicing/rewiring nodes programmatically | Auto-arranging node *positions* -> `comfy-workflow-layout` |
+| A round-trip transform is silently dropping App Mode or canvas state | Deciding whether to use a subgraph/Blueprint/App Mode at all -> `comfy-subgraphs-app-mode` |
+
 ## Edge-list rebuild — mutate links without hand-surgery
 
 In-place link surgery (patching the flat `links` array *and* every node's

--- a/comfyui-plugin/skills/comfy-workflow-layout/SKILL.md
+++ b/comfyui-plugin/skills/comfy-workflow-layout/SKILL.md
@@ -1,7 +1,11 @@
 ---
+created: 2026-07-07
+modified: 2026-07-07
+reviewed: 2026-07-07
 name: comfy-workflow-layout
 description: >-
   Auto-layout a ComfyUI workflow JSON with a layered DAG algorithm. Use when a workflow's nodes overlap, are messy or cramped, or were imported and need tidying before use.
+allowed-tools: Bash, Read, Grep, Glob
 ---
 
 # ComfyUI workflow auto-layout
@@ -21,6 +25,12 @@ In practice on Wan 2.2 workflows in this install, output bounding-box
 area ranges from −13% to +23% of a hand-arranged layout (typically
 within ±10%), with 0 node overlaps. Without median layering it would
 be 2× larger.
+
+## When to Use This Skill
+
+| Use this skill when... | Use instead when... |
+|---|---|
+| A workflow's nodes overlap, are messy/cramped, or were imported and need tidying | Editing the graph's wiring/links -> `comfy-workflow-json` |
 
 ## Pipeline (default mode)
 

--- a/comfyui-plugin/skills/comfy-workflow-layout/SKILL.md
+++ b/comfyui-plugin/skills/comfy-workflow-layout/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: comfy-workflow-layout
+description: >-
+  Auto-layout a ComfyUI workflow JSON with a layered DAG algorithm. Use when a workflow's nodes overlap, are messy or cramped, or were imported and need tidying before use.
+---
+
+# ComfyUI workflow auto-layout
+
+`scripts/layout_workflow.py` runs a layered (Sugiyama-style) DAG layout
+over the nodes in a workflow JSON: median layering (each node sits at
+the midpoint between its earliest and latest possible depth, so source
+and sink nodes spread across columns instead of piling up at the edges),
+a barycenter sweep within each layer to reduce edge crossings, and a
+group-cohesion post-pass that clusters members of the same authored
+group contiguously within each column. Group bounding boxes are re-fit
+around their final members. Pure stdlib, no deps. Visual goal is "the
+editor is readable again with comparable density to a hand-tuned
+layout" — link routing is left to ComfyUI.
+
+In practice on Wan 2.2 workflows in this install, output bounding-box
+area ranges from −13% to +23% of a hand-arranged layout (typically
+within ±10%), with 0 node overlaps. Without median layering it would
+be 2× larger.
+
+## Pipeline (default mode)
+
+1. **Detect group membership** by which nodes' centers sit in each
+   group's authored bounding box. Tie-break to the smallest group.
+2. **Absorb leaf singletons** — ungrouped nodes whose neighbors are
+   ≥2/3 in one group join that group's membership for layout
+   purposes. Single-pass; central hub nodes (whose connections fan out
+   across many groups) stay as singletons.
+3. **Median layering** — each node's column index is the average of
+   its longest-path-from-sources and longest-path-from-sinks depth.
+   Source nodes whose only consumer is at depth 8 land near depth 7,
+   not 0. Sink nodes whose only producer is at depth 1 land near 1.
+4. **Barycenter sweep** within each layer to minimize edge crossings.
+5. **Group-cohesion clustering** — within each layer, re-permute so
+   nodes sharing a group sit contiguously. Cluster order within a
+   layer follows each cluster's median barycenter index.
+6. **Vertically center** each column around the layer band's
+   midpoint so short columns float to center rather than top-align.
+7. **Recompute group bounding boxes** to wrap the final positions
+   (skip with `--no-groups`).
+
+`--strict-groups` switches to a two-level mode where each group becomes
+its own bounded super-node region with a separate outer DAG between
+groups. Looser packing (typically +30-50% area) but stronger visual
+separation between groups; reach for it when the user prefers visible
+group containers over compactness.
+
+## When to reach for this
+
+- User pulled a workflow from somewhere and the nodes overlap.
+- A workflow grew organically and is now unreadable in the editor.
+- After bulk-editing a graph (added a Phantom tail, swapped sampler
+  versions, refactored loaders) and the layout no longer reflects flow.
+- User says "auto-arrange", "lay out", "clean up positions", or
+  references the script by name.
+
+Skip this for ~5–8 node workflows — hand-arrange is faster and the
+result will be tidier than what a layered algorithm produces on a tiny
+graph.
+
+## Default invocation (safe A/B)
+
+From the install root, run the script via the venv on the target file:
+
+```
+.venv/bin/python scripts/layout_workflow.py user/default/workflows/2026-05/<file>.json
+```
+
+This writes `<file>-laidout.json` next to the original. Open **both** in
+ComfyUI side-by-side (or load one, eyeball, then load the other) and
+confirm the laid-out version is actually better before committing to
+overwrite. ComfyUI picks up the new file on page reload — no service
+restart needed.
+
+The script prints a one-line summary on completion
+(`42 nodes (cohesion, 3 absorbed), 13 layers, 7 groups recomputed -> ...`).
+Pass `--quiet` to suppress it. In `--strict-groups` mode the summary
+shape is different (`42 nodes in 8 supers (7 group + 1 singleton (3
+absorbed)), 5 outer layers, ...`).
+
+## Tune the spacing
+
+Defaults are `--col-gap 40` (pixels between layers) and `--row-gap 20`
+(pixels between nodes within a layer). If the output looks cramped,
+raise the gaps. If sparse, lower them.
+
+```
+.venv/bin/python scripts/layout_workflow.py --col-gap 60 --row-gap 30 \
+  user/default/workflows/2026-05/<file>.json
+```
+
+Useful starting points: 30/15 for tight, 40/20 default, 60/30 for roomy,
+80/40 for very large workflows where the user wants whitespace. In
+`--strict-groups` mode the inner gap uses these values; the outer
+between-groups gap is fixed at 60×80 (source constants `SUPER_COL_GAP`
+/ `SUPER_ROW_GAP`).
+
+## Mode flags
+
+```
+.venv/bin/python scripts/layout_workflow.py --strict-groups <file>.json
+```
+
+Two-level group-aware layout: each group renders as its own bounded
+region in a separate outer DAG. Looser packing, stronger group
+separation. Use when the user wants visible group containers more than
+compactness.
+
+```
+.venv/bin/python scripts/layout_workflow.py --no-cohesion <file>.json
+```
+
+Skip the group-cohesion pass — group members may scatter across the
+layer based purely on barycenter. Useful when a workflow has groups
+that fight DAG topology (e.g. one logical "group" spans many depths).
+
+```
+.venv/bin/python scripts/layout_workflow.py --no-absorb <file>.json
+```
+
+Don't absorb ungrouped leaf nodes into adjacent groups. Useful when
+the user has deliberately placed nodes outside a group and wants the
+layout to honor that.
+
+```
+.venv/bin/python scripts/layout_workflow.py --no-groups <file>.json
+```
+
+Skip the group bounding-box recompute. Positions still shift, so the
+old bounding boxes will end up wrong — only useful for debugging.
+
+## Commit the result
+
+After confirming the laid-out version looks good, two paths:
+
+```
+mv user/default/workflows/2026-05/<file>-laidout.json \
+   user/default/workflows/2026-05/<file>.json
+```
+
+Or re-run with `--in-place` to overwrite directly (no A/B copy
+produced):
+
+```
+.venv/bin/python scripts/layout_workflow.py --in-place \
+  user/default/workflows/2026-05/<file>.json
+```
+
+`--in-place` and `-o / --output` are mutually exclusive.
+
+Per project `CLAUDE.md`, do not commit workflow JSONs unless asked —
+workflows under `user/default/workflows/` are user data, intentionally
+untracked.
+
+## Batch a directory
+
+Once the user confirms one workflow lays out cleanly, the rest in the
+same bucket usually follow. Batch with `--in-place`:
+
+```
+for f in user/default/workflows/nsfw/2026-05/*.json; do
+  case "$f" in *-laidout.json) continue ;; esac
+  .venv/bin/python scripts/layout_workflow.py --in-place --verify "$f"
+done
+```
+
+The `case` skips already-laid-out outputs left over from earlier A/B
+runs. `--verify` aborts on overlap, which is cheap and reasonable for
+batch jobs. **Always run on one workflow first**, eyeball it, then
+batch — unwinding 30 simultaneously-broken layouts is painful.
+
+## What gets preserved vs rewritten
+
+| Preserved | Rewritten |
+|---|---|
+| `id`, `revision`, `last_node_id`, `last_link_id` | `nodes[*].pos` |
+| `links`, `config`, `extra`, `version` | `groups[*].bounding` |
+| `nodes[*].size`, `.order`, `.widgets_values` | |
+| `nodes[*].inputs`, `.outputs` | |
+| `nodes[*].title`, `.properties`, `.flags` | |
+| `nodes[*].mode`, `.color`, `.bgcolor` | |
+| `groups[*].title`, `.color` | |
+
+Only positions move. Wiring, widget values, sizes, group identities,
+and colors all carry through unchanged. Group **membership** is
+detected from the original bounding boxes; the new bounding box is
+rewritten to wrap the same members in their final positions.
+
+Pass `--verify` to assert no node overlaps in the output before
+writing. Cheap; reach for it when batching or when iterating on gap
+values.
+
+## Known limitations
+
+1. **Reroute nodes** consume a full layer's column width even though
+   they're tiny. Acceptable cost; don't try to special-case them.
+2. **Note placement** is "above the nearest old neighbor" using
+   original positions. If multiple Notes share a buddy they stack and
+   may collide with the layer above. Hand-fix in the editor if it
+   bothers you.
+3. **Cycles in the underlying node DAG** abort the script with an
+   error. A valid ComfyUI workflow shouldn't have any; if you hit one,
+   the workflow itself is broken. Cycles in the *super* graph
+   (`--strict-groups` mode, groups feeding each other through
+   different members) are silently broken with a DFS feedback-arc-set
+   pass; the dropped edges only affect outer-layer assignment, not the
+   final node positions or wiring.
+4. **Hand-tuned layouts that overlap groups deliberately** (e.g. two
+   groups sharing a horizontal column with one above the other) won't
+   be reproduced — the algorithm doesn't pack groups in 2D. The
+   default mode comes within ±10% of hand-tuned area on average; the
+   `--strict-groups` mode is typically +30-50% larger because each
+   group claims its own outer cell.
+5. **Workflows where most nodes are ungrouped** still benefit from
+   median layering and cohesion, but the absorption step has nothing
+   to absorb so the singleton spread is whatever it is. Authoring
+   groups around the leaf clusters before running the script gives
+   noticeably better output.
+
+## When NOT to use this
+
+- Small workflows (~5–8 nodes). Hand-arrange is faster.
+- The user deliberately designed a non-DAG layout for visual reasons —
+  e.g. parallel branches arranged top-to-bottom for clarity, or a
+  "before / after" comparison stacked vertically. Auto-layout will
+  collapse parallel branches according to their depth.
+- The workflow uses `Note` nodes as section labels with hand-placed
+  positioning. They survive but the placement won't match the user's
+  intent.
+
+## After running
+
+Surface the output path so the user can navigate to it directly. After
+overwriting in place, remind the user to **reload the page** in ComfyUI
+to pick up the new positions — no service restart needed (and don't
+restart, per project `CLAUDE.md` that would kill any running
+generation). After producing `<stem>-laidout.json`, offer to `mv` it
+over the original once the user confirms the new layout looks good.

--- a/comfyui-plugin/skills/comfyui-node-authoring/SKILL.md
+++ b/comfyui-plugin/skills/comfyui-node-authoring/SKILL.md
@@ -16,6 +16,13 @@ shipped despite green tests. These apply to any custom-node pack regardless
 of build system — hand-authored `web/js/*.js`, or a TypeScript+bun-build pack
 (the layout `comfyui-node-scaffold` generates).
 
+## When to Use This Skill
+
+| Use this skill when... | Use instead when... |
+|---|---|
+| Writing or patching a custom node's frontend or backend code | Setting up the pack's release/publish pipeline -> `comfy-registry-lifecycle` |
+| Verifying an undocumented LiteGraph/Vue API shape | Smoke-testing the finished pack live -> `comfyui-pack-live-smoke` |
+
 ## Pack layout
 
 ```

--- a/comfyui-plugin/skills/comfyui-node-authoring/SKILL.md
+++ b/comfyui-plugin/skills/comfyui-node-authoring/SKILL.md
@@ -1,0 +1,374 @@
+---
+created: 2026-07-07
+modified: 2026-07-07
+reviewed: 2026-07-07
+name: comfyui-node-authoring
+description: >-
+  ComfyUI frontend/backend authoring facts: hiding/serializing widgets, DOM event isolation, endpoints, tooltip lookup, canvas hit-testing, sourcemap verification. Use when writing or patching a custom node's code.
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# comfyui-node-authoring
+
+Facts about how ComfyUI's frontend and backend actually behave, gathered from
+reverse-engineering the (minified) frontend bundle and from real bugs that
+shipped despite green tests. These apply to any custom-node pack regardless
+of build system — hand-authored `web/js/*.js`, or a TypeScript+bun-build pack
+(the layout `comfyui-node-scaffold` generates).
+
+## Pack layout
+
+```
+<pack>/
+  __init__.py             # NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS, WEB_DIRECTORY
+  <name>.py                # backend node(s) + any /<your>/<endpoint> routes
+  web/
+    js/<name>.js            # vanilla-JS frontend extension (hand-authored layout)
+    css/<name>.css          # NOT auto-loaded — inject a <link> from the JS
+  # — or, for a TS+bun-build pack (comfyui-node-scaffold) —
+  src/index.ts              # TypeScript source; WEB_DIRECTORY = "./web/dist"
+  web/dist/                 # built output, committed
+```
+
+The pack directory name becomes the served URL segment
+(`/extensions/<pack-dir>/...`). Keep it lowercase-kebab so the path is
+predictable.
+
+**`web/dist` ships only in the registry tarball, never a bare git clone**, for
+TS-built packs — it's git-ignored. `git clone`/nightly installs land `main`
+without it (the extension is dead until `bun run build` runs locally); only a
+correctly-configured registry publish ships a prebuilt frontend. See
+`comfy-registry-lifecycle` for the publish-pipeline traps that can silently
+break this.
+
+## Frontend import paths
+
+From a vanilla `web/js/<file>.js`, reach the comfy frontend exports with
+**3 ups**:
+
+```js
+import { app } from "../../../scripts/app.js";
+```
+
+Two ups (the rgthree convention) only works for files at `web/<file>.js`.
+
+## Hiding a widget while keeping it serializable
+
+To take over a node's input UI with a DOM widget while leaving the
+underlying widget's value reachable by the backend, set BOTH:
+
+```js
+widget.hidden = true;
+widget.options = widget.options || {};
+widget.options.hidden = true;
+widget.computeSize = () => [0, -4];
+// Belt-and-braces for frontends that position DOM elements regardless of `hidden`:
+for (const key of ["element", "inputEl"]) {
+    const el = widget[key];
+    if (el?.style) el.style.display = "none";
+}
+```
+
+The `hidden` / `options.hidden` pair is what the frontend reads internally.
+Setting only `widget.type = "hidden_something"` (the old pattern) is
+insufficient — STRING widgets create a DOM input element positioned by
+canvas coords that ignores the type change.
+
+## A non-serializable widget must set `widget.serialize = false` AND be appended last
+
+When a pack adds a helper widget to a node — a `"button"` opener, a label,
+any control the user shouldn't have persisted — it MUST both (1) set
+`widget.serialize = false` **on the widget object itself** and (2) be
+**appended to the end** of `node.widgets`. Getting either wrong silently
+corrupts the `widgets_values` of *every opened workflow*, and the frontend
+then autosaves the corrupted graph back to disk.
+
+The frontend's save/restore loops key on `widget.serialize`, **not**
+`widget.options.serialize`:
+
+```js
+// save (serialize): index-based, non-compacting
+for (const [n, r] of widgets.entries()) { if (r.serialize === false) continue; wv[n] = r.value }
+// restore (configure): compacting counter
+if (wv) { let t = 0; for (const w of widgets) if (w.serialize !== false) { if (t >= wv.length) break; w.value = wv[t++] } }
+```
+
+Two traps:
+
+1. **`addWidget(type, name, value, cb, { serialize: false })` is
+   INEFFECTIVE.** `addWidget` stores the option in `widget.options.serialize`
+   and never sets `widget.serialize` — so the loops above still treat the
+   widget as serializable. You must assign `widget.serialize = false`
+   directly (the frontend's own non-serialized widgets do exactly this).
+2. **Position matters even with `serialize = false`.** Save is *index-based*
+   (`wv[rawIndex]`) but restore is *compacting* (`wv[t++]`). A skipped
+   widget placed **before** real widgets leaves a hole → a leading `null` on
+   save → every value shifts by one on the next open. A serializable widget
+   at index 0 (e.g. `unshift`ed in `nodeCreated`, which runs *before*
+   `configure()` restores values) consumes `wv[0]` outright.
+
+```ts
+const btn = node.addWidget?.("button", "…", null, cb, { serialize: false });
+if (btn) btn.serialize = false;   // the flag the frontend actually checks
+// do NOT unshift/splice it to the front — addWidget appends to the end; leave it there
+```
+
+Add a `serialize?: boolean` field to the pack's local widget interface so
+this type-checks. To verify live in a devtools console:
+
+```js
+const n = app.graph._nodes.find(n => n.widgets?.some(w => w.name.includes("…")));
+const b = n.widgets.at(-1); b.serialize === false;   // true
+n.serialize().widgets_values;                        // dense, no leading/trailing null
+```
+
+## DOM widget event isolation
+
+LiteGraph processes pointer/wheel events on the canvas. To make a DOM widget
+interactive (scroll, tap, type) without the canvas hijacking or zooming the
+events:
+
+```js
+const stop = (e) => e.stopPropagation();
+for (const ev of ["pointerdown","pointermove","pointerup","click",
+                  "dblclick","contextmenu","touchstart","touchmove",
+                  "touchend","keydown","keyup"]) {
+    root.addEventListener(ev, stop, { capture: false });
+}
+scrollEl.addEventListener("wheel", (e) => {
+    scrollEl.scrollTop += e.deltaY;
+    e.preventDefault();
+    e.stopPropagation();
+}, { passive: false });
+```
+
+## Reusing core endpoints
+
+- `/api/view?filename=<name>&type=input|output|temp&subfolder=<sub>&preview=webp;75`
+  returns a webp thumbnail; handles subfolder-escape checks. Works only for
+  the three managed roots — arbitrary absolute paths must be served by your
+  own endpoint.
+- `folder_paths.annotated_filepath()` parses `name [input|output|temp]`.
+- `PromptServer.instance.routes.get("/your_pack/something")` registers an
+  HTTP endpoint. Call from JS via `fetch("/your_pack/...")`.
+
+## Subfolder safety
+
+When accepting a `subfolder` query param under a managed root:
+
+```python
+target = os.path.abspath(os.path.join(root, subfolder or ""))
+if os.path.commonpath([target, os.path.abspath(root)]) != os.path.abspath(root):
+    return web.json_response({"ok": False, "error": "subfolder escapes root"}, status=400)
+```
+
+Without this, `subfolder=../../etc` reads anywhere on disk that ComfyUI can
+reach.
+
+## Cheap metadata in listing endpoints
+
+`PIL.Image.open(path)` is lazy — only the file header is decoded until pixel
+data is accessed. So `.size`, `.mode`, and `.format` are nearly free and safe
+to call inside an `os.scandir` listing loop, even for directories of 100+
+images. Wrap in `try/except` so a single broken file doesn't kill the
+listing, and do **not** call `im.load()` or access pixels in the listing
+loop — that forces a full decode and turns the loop into a multi-second
+operation.
+
+```python
+width: int | None = None
+height: int | None = None
+try:
+    with Image.open(entry.path) as im:
+        width, height = im.size
+except Exception:
+    pass
+```
+
+## Sibling-module imports must be relative
+
+ComfyUI imports each pack as a **package** (`custom_nodes.<pack>`) and does
+**not** put the pack dir on `sys.path`. A backend file pulling in a sibling
+module with a bare absolute `import xmp_meta` raises `ModuleNotFoundError` at
+load time, dropping the **whole pack** (node + frontend). Use a relative
+import with an absolute fallback so pytest (which runs with the pack root on
+`sys.path`) still works:
+
+```python
+try:
+    from . import xmp_meta          # ComfyUI runtime: package import
+except ImportError:
+    import xmp_meta                 # pytest: flat import
+```
+
+The pytest suite hides this bug — guard it with a test that imports the
+backend as a package submodule with the pack dir removed from `sys.path`. A
+bare `import` also passes a registry security scan, so the only signal is
+the runtime `IMPORT FAILED`.
+
+## Frontend-bundle reverse-engineering
+
+When a frontend behavior isn't documented (e.g. "how do I hide this
+widget"), grep the minified frontend bundle for property tokens:
+
+```sh
+grep -oE ".{60}<token>.{30}" \
+  <venv>/lib/python*/site-packages/comfyui_frontend_package/static/assets/core-*.js \
+  | head -10
+```
+
+Property names survive minification (only variables are mangled), so
+`grep -oE "[a-zA-Z_]+\.hidden\b"` is enough to find that the frontend uses
+`widget.hidden = true` / `widget.options.hidden = true` as the canonical
+hide toggles.
+
+### Verify against the sourcemap for anything non-trivial
+
+For a LiteGraph / canvas API whose shape you need precisely, don't trust a
+guessed property name or an old tutorial — the shipped bundle renames
+properties under minification and forks rename further. The frontend ships
+`.js.map` files with `sourcesContent` (the original TypeScript). LiteGraph is
+bundled in the **`api-*.js.map`** chunk:
+
+```sh
+cd <pack>/.venv/lib/python*/site-packages/comfyui_frontend_package/static/assets
+grep -l 'LGraphGroup' *.js.map        # find the chunk (usually api-*.js.map)
+```
+
+This recovers **full Vue component source too**, not just LiteGraph
+classes — the original `.vue` (template + `<script setup>` + scoped CSS) is
+in `sourcesContent` keyed by a `../../src/...` path. When a UI behaviour
+lives in the app itself (a topbar, a tab, a dialog) rather than in a pack,
+grep the maps for the `.vue` filename:
+
+```sh
+grep -l 'WorkflowTabs.vue' *.js.map   # the component's chunk (e.g. GraphView-*.js.map)
+```
+
+To extract a class/value cleanly, load the map as JSON and slice
+`sourcesContent` (the minified `.js` itself is useless for names):
+
+```sh
+python3 - <<'PY'
+import json
+m = json.load(open("api-<hash>.js.map"))
+for name, src in zip(m["sources"], m["sourcesContent"] or []):
+    if src and "class LGraphGroup" in src:
+        i = src.index("class LGraphGroup"); print(name); print(src[i:i+2000]); break
+PY
+```
+
+Record what you confirm in the pack's `CLAUDE.md` (a "Verified frontend
+API" table), and note the `comfyui-frontend-package` version — re-verify
+after a bump.
+
+### Facts confirmed this way (recheck on version bump)
+
+| Symbol | Finding |
+|---|---|
+| `LiteGraph.NODE_TITLE_HEIGHT` | `= 30`. A node's `pos` is the body top-left; the title bar sits *above* it. A group's `pos` is the whole-box top-left (title drawn inside) — **no** title offset. |
+| `canvas.selectedItems` | `Set<Positionable>` = all selected nodes, groups, and reroutes. Groups and reroutes are individually selectable here. |
+| `canvas.selected_nodes` | `Dictionary<LGraphNode>` (nodes only). |
+| `LGraphGroup.pos` / `.size` | getters/setters over `_pos`/`_size`; the **`size` setter self-clamps** to `minWidth=140`/`minHeight=80`. |
+| `LGraphGroup.recomputeInsideNodes()` | present — call it after mutating a group's size/pos so membership stays correct. |
+| `LGraphGroup.id` | defaults to `-1`, not guaranteed unique → use a selection-index fallback when keying. |
+| Canvas zoom | **wheel-driven** (`processMouseWheel → ds.changeScale`; browsers send pinch-zoom as ctrl+wheel). |
+
+Two implementation gotchas that follow:
+
+- **Discriminate items by shape, not `instanceof`.** The class is renamed
+  under minification (and forks rename further), so `x instanceof
+  LGraphGroup` is fragile. Filter by structure instead: a node has a
+  `computeSize()` method; a group has `pos`+`size`+a string `title` but no
+  `computeSize`; a reroute has no `size`.
+- **Suppress native zoom via a `wheel` interceptor, not just pointer
+  events.** Because zoom is wheel-driven, `e.stopImmediatePropagation()` on
+  `pointerdown`/`pointermove` alone will not stop a pinch-zoom. While a
+  gesture is locked, also intercept `wheel` in the capture phase with
+  `passive: false` and `preventDefault()`.
+
+## Behavioural / touch / visibility bugs: reproduce live, don't trust a static read
+
+Reading the source tells you what the code *says*; for an **interaction
+bug** — hover-gating, touch reachability, z-index overlap, focus, a tap that
+"does nothing" — a static CSS/template read is not enough to confirm the
+mechanism. Reproduce against a live instance (see `comfyui-pack-live-smoke`)
+before concluding.
+
+Technique that settled a real case (a workflow-tab close button unreachable
+on touch — ComfyUI_frontend #13279 / PR #13280):
+
+- Drive it with the chrome-devtools MCP: `emulate` a mobile viewport with the
+  `touch`+`mobile` flags, then **confirm the media state you think you're
+  testing** — `matchMedia('(hover: none)').matches` must be `true`, else
+  you're not actually testing touch.
+- Prove tap reachability with `document.elementFromPoint(cx, cy)` at the
+  target control's centre: if it returns an *overlay* element instead of the
+  button/its child, the control is visually present but **tap-intercepted**
+  — a failure a CSS read of `visibility` alone will miss.
+- Mutate-and-recheck live: inject the candidate fix as a `<style>` and
+  re-run the same `elementFromPoint` + a real `.click()`, watching the
+  result, before committing to it.
+
+When a bug is reported as conditional ("works with a few, breaks with
+many"), treat that as ground truth and reproduce the *conditional* rather
+than defending a first theory that only explains part of it.
+
+## Reading INPUT_TYPES tooltip metadata from JS
+
+Tooltips declared in a node's Python `INPUT_TYPES` are surfaced to the
+frontend at **multiple distinct locations** — there is no single `tooltip`
+field. A JS extension that wants to read them needs to walk this lookup
+chain:
+
+| Source | Path | When populated |
+|---|---|---|
+| Widget option | `widget.options.tooltip` | Canvas-rendered widgets (most common) |
+| Input slot | `node.inputs[i].tooltip` | Wired-socket inputs that round-tripped through the loader |
+| Raw node def | `node.constructor.nodeData.input.required\|optional[name][1].tooltip` | Always — fallback when neither of the above was populated |
+| Output socket | `node.constructor.nodeData.output_tooltips[i]` | Outputs (array indexed by slot) |
+| Node-level | `node.constructor.nodeData.description` | Whole-node hover / final fallback |
+
+`node.constructor.nodeData` is the full registered node definition — same
+shape Python's `INPUT_TYPES` returned, with `[type, opts]` tuples preserved.
+Don't assume `widget.options.tooltip` exists for every widget; DOM widgets
+and dynamically-created widgets often don't get it copied over, so the
+`nodeData` fallback matters.
+
+## Hit-testing the canvas from a frontend extension
+
+To map a pointer event to a node / widget / socket / title region:
+
+```js
+const [gx, gy] = canvas.convertEventToCanvasOffset(e);            // screen → graph
+const node = canvas.graph.getNodeOnPos(gx, gy, canvas.visible_nodes);
+// Socket hit (most precise — uses canonical socket positions):
+const p = node.getConnectionPos(/* isInput */ true, slotIndex);   // [x, y] in graph coords
+// Widget hit:
+//   widget.last_y is the y-offset within the node, set on each draw
+//   widget.computeSize(node.size[0]) returns [w, h]; fall back to
+//   LiteGraph.NODE_WIDGET_HEIGHT (20) when computeSize is absent
+// Title-region hit: ly ∈ [-LiteGraph.NODE_TITLE_HEIGHT, 0]
+```
+
+`canvas.visible_nodes` is what's currently on-screen — pass it to
+`getNodeOnPos` so off-screen / culled nodes don't false-hit. Sockets need a
+tolerance radius (≈14 px works for touch, ≈8 px for mouse).
+
+## Smoke-testing a new pack
+
+`from server import PromptServer` won't import standalone — the ComfyUI
+runtime sets up `sys.path` and package import order specially, so local
+import tests fail with confusing `ModuleNotFoundError`s. Verify syntax only
+with `python -m py_compile`, then stand the pack up in a real running
+instance and drive it end to end — see the **`comfyui-pack-live-smoke`**
+skill for the full recipe (browser-driven and headless-API variants,
+including how to point it at any host via `COMFYUI_HOST`).
+
+## When to skip
+
+The pack clearly owns the file (its own JS logic, not a LiteGraph call), or
+you already verified the symbol this session / from a recent one at the
+same `comfyui-frontend-package` version. Live reproduction is for
+*behavioural* bugs; a pure symbol/shape lookup doesn't need a running
+server.

--- a/comfyui-plugin/skills/comfyui-pack-live-smoke/SKILL.md
+++ b/comfyui-plugin/skills/comfyui-pack-live-smoke/SKILL.md
@@ -27,6 +27,13 @@ This is where bugs that ship green actually surface.
 > `is_loopback || override`. The headline feature was dead in the common
 > case; only a browser smoke caught it.
 
+## When to Use This Skill
+
+| Use this skill when... | Use instead when... |
+|---|---|
+| Verifying a pack end-to-end in a running ComfyUI instance before opening a PR | Writing the pack's code in the first place -> `comfyui-node-authoring` |
+| Confirming an edited/built workflow JSON actually runs | Editing the workflow JSON itself -> `comfy-workflow-json` |
+
 ## Target host — `COMFYUI_HOST`
 
 Every recipe below reads the target instance from the `COMFYUI_HOST`

--- a/comfyui-plugin/skills/comfyui-pack-live-smoke/SKILL.md
+++ b/comfyui-plugin/skills/comfyui-pack-live-smoke/SKILL.md
@@ -1,0 +1,159 @@
+---
+created: 2026-07-07
+modified: 2026-07-07
+reviewed: 2026-07-07
+name: comfyui-pack-live-smoke
+description: >-
+  Live-smoke a ComfyUI pack in a running instance: browser-driven and headless API-driven checks catch frontend/backend bugs unit tests miss. Use when verifying a pack before opening a registry PR.
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# comfyui-pack-live-smoke
+
+A ComfyUI pack's `just check` (pytest + vitest + tsc + build) can be fully
+green while the pack is **broken in the running app**, because the two
+halves are tested in isolation: pytest stubs `server`/`folder_paths`, vitest
+only covers DOM-free pure helpers, and the modal DOM + the frontend↔backend
+contract (route names, JSON shapes, **gating predicates**) are exercised by
+*neither*. Stand the pack up in a real ComfyUI and click through it (or
+drive it headlessly over the API) before opening the registry/gitops PR.
+This is where bugs that ship green actually surface.
+
+> Canonical break (`comfyui-touch-manager`, 2026-06): every gate green,
+> jsdom modal mount green — yet live in the running app the **Install-from-URL
+> button was disabled on the normal `127.0.0.1` setup**. The frontend gated
+> on `config.allow_remote_install` *alone* (the non-loopback env override)
+> while the backend `/install` gate actually permits the clone when
+> `is_loopback || override`. The headline feature was dead in the common
+> case; only a browser smoke caught it.
+
+## Target host — `COMFYUI_HOST`
+
+Every recipe below reads the target instance from the `COMFYUI_HOST`
+environment variable, defaulting to `127.0.0.1:8188` (a local/CPU-fork
+smoke). Set it in `.claude/settings.local.json`'s `env` block (gitignored,
+per-machine) to point at a different install without hardcoding a host in
+any command:
+
+```json
+{ "env": { "COMFYUI_HOST": "192.0.2.10:8188" } }
+```
+
+## Lesson 1: frontend gating must mirror the backend gate's *full* predicate
+
+When the backend enforces a security/permission gate, the frontend's
+show/enable/disable logic must replicate the **entire** predicate, not a
+convenient sub-flag. Gating on a partial predicate silently disables a
+feature in the case the backend would have allowed.
+
+- Extract the predicate into a **pure, exported helper** and unit-test it
+  (`installPermitted(config) => config.is_loopback || config.allow_remote_install`),
+  rather than leaving it as inline DOM logic — inline gating is exactly
+  what a pure-helper unit-test suite skips, so the bug ships green.
+- The backend stays the real gate; the frontend mirror is UX only. Keep the
+  helper's predicate textually aligned with the backend's `if not (...)`
+  check.
+
+## Browser-driven smoke (chrome-devtools MCP)
+
+| Friction | Fix |
+|---|---|
+| `new_page`/`list_pages` fail: *"browser is already running for …/chrome-devtools-mcp/chrome-profile"* | A **stale automation Chrome** (a prior MCP session) holds the profile. It's the MCP's own profile (`--enable-automation`, `--remote-debugging-pipe`), not your real browser — `kill <parent-pid>` it, then re-`new_page`. |
+| Clicking a ComfyUI **Vue dialog** button (confirm/cancel) via MCP `click` silently no-ops (dialog stays open) | The synthetic MCP click doesn't reach the Vue overlay handler. Use `evaluate_script` → `[...document.querySelectorAll("button")].find(b => b.textContent.trim() === "Confirm").click()` (a real in-page DOM click the handler catches). |
+| Result **toasts** (`extensionManager.toast`, ~4 s `life`) vanish before you can assert | Don't assert on the transient toast. Assert on a **persistent** signal instead — an in-modal status banner, the re-rendered list, or the backend state via `curl`. |
+| Backend behaviour without the whole UI | The pack's routes answer over plain HTTP: `curl -s http://$COMFYUI_HOST/<route>` isolates backend vs. frontend instantly. |
+
+`resize_page` to a phone width (~390–500px) and re-open the modal to verify
+the touch layout (tap-target size, full-width modal, no iOS zoom).
+
+### Minimal browser-smoke recipe
+
+1. Bring up a ComfyUI instance (CPU is fine for a fork: `python main.py
+   --cpu`), or point at an existing one via `COMFYUI_HOST`.
+2. Symlink the pack into `custom_nodes/`; `bun run build` so
+   `web/dist/index.js` is current; hard-reload the browser after any
+   frontend rebuild (no restart); **restart** the server after any backend
+   `.py` change.
+3. Click every tab/action; exercise the headline feature end-to-end (e.g.
+   actually install from a GitHub URL and confirm the clone + restart
+   prompt).
+4. Clean up: remove any test-installed packs from `custom_nodes/`, stop the
+   server.
+
+## Headless API-driven smoke
+
+For verifying a workflow (or a backend node's registration/endpoints)
+without opening a browser — the fastest gold-standard check beyond JSON
+link-integrity validation.
+
+ComfyUI's `/prompt` endpoint does **not** accept the saved UI workflow
+JSON — it wants the **API-format prompt**: `{node_id: {class_type,
+inputs}}`. The browser frontend converts UI→API (`graphToPrompt`) before
+POSTing; running headless means reimplementing that conversion. A
+`comfy_run.py`-style script (queue, poll `/history`, print output
+filenames or `node_errors`) is the reusable shape:
+
+```sh
+python3 comfy_run.py --host "${COMFYUI_HOST:-127.0.0.1:8188}" --timeout 600 wf.json
+```
+
+Run it from the ComfyUI install root so relative workflow paths resolve.
+The service must be up: `curl -sf http://$COMFYUI_HOST/object_info
+>/dev/null`.
+
+### Smoke a new node's registration + endpoints
+
+```sh
+.venv/bin/python -m py_compile custom_nodes/<pack>/<name>.py     # syntax only, doesn't import standalone
+# restart the service (systemd: sudo systemctl restart comfyui.service; else however yours restarts)
+curl -s "http://${COMFYUI_HOST:-127.0.0.1:8188}/object_info/<NodeClassName>"   # verify registration
+curl -s "http://${COMFYUI_HOST:-127.0.0.1:8188}/<your_endpoint>"              # smoke your routes
+```
+
+`from server import PromptServer` won't import standalone — the ComfyUI
+runtime sets up `sys.path` and package import order specially, so a plain
+local import test fails with a confusing `ModuleNotFoundError`. Restart +
+`curl` is the reliable check.
+
+### The conversion gotchas a naive UI→API converter gets wrong
+
+1. **`input_order` is not always present.** `/object_info/<Node>` exposes
+   `input.input_order` for *some* node types but `None` for many. Fall back
+   to the dict-insertion order of `input.required` + `input.optional`.
+2. **`control_after_generate` inserts a phantom widget value.** A
+   `seed`/`noise_seed` input with `control_after_generate: true` produces
+   an **extra** entry in `widgets_values` that is not a node input — consume
+   one extra slot after any such widget or every later value shifts by one.
+3. **Bypassed (mode 4) / muted (mode 2) nodes pass through.** Such a node
+   is dropped from the API prompt, and each of its outputs reconnects to
+   its **first same-typed input**. Resolve link sources recursively until a
+   non-bypassed producer is found.
+4. **Dynamic-combo widgets can mis-map.** A widget type that reveals extra
+   sub-widgets when set to a given value breaks the positional
+   `widgets_values` walk if the converter doesn't special-case it — the
+   `/prompt` call **succeeds** but later widgets silently take
+   default/garbage values. A workflow with such a node may need to be run
+   through the UI instead of a naive headless converter.
+
+Connection inputs (`MODEL`, `CLIP`, `LATENT`, `CONDITIONING`, `IMAGE`,
+`VAE`) become `[src_node_id_str, src_slot]`; everything else is a widget
+value. A widget that was converted-to-input (its `inputs[]` entry has a
+non-null `link`) is read from the link, **not** from `widgets_values`.
+
+### API endpoints used
+
+| Call | Purpose |
+|---|---|
+| `GET /object_info` | per-node-type input schema (order, types, control flags) — drives the conversion |
+| `POST /prompt` `{prompt: <api>}` | queue; returns `{prompt_id}`. HTTP 400 with `error` + `node_errors` on a bad graph |
+| `GET /history/<prompt_id>` | poll; when the id appears, `status.status_str` is `success`/`error` and `outputs[*].images[]` lists `{filename, subfolder, type}` |
+
+Poll `/history` with a short in-script `time.sleep` loop — not a shell
+`sleep`-chain. Do **not** busy-poll `/queue`.
+
+## When to skip
+
+A pure refactor with no behaviour change and no frontend↔backend contract
+touched, or the pack was already smoked this session at the same
+`comfyui-frontend-package` version. Otherwise, for anything that adds/
+changes a route, a gate, or modal wiring, smoke it before the PR.


### PR DESCRIPTION
## Summary

Extracts genuinely shared ComfyUI knowledge that had independently accreted in two separate local-only workspaces — `laurigates/comfyui-nodes` (this marketplace's pack-authoring repo) and a personal GPU-lab tooling repo (operating a live ComfyUI install) — into this plugin, so both workspaces (and any future pack repo opened standalone) get it via the plugin instead of duplicating it.

The overlap was concrete: the tooling repo's registry-publishing rule documented publish-pipeline bugs (the empty-`web/dist` tarball trap, `uv.lock` drift, the native `COMFY_NODE_CHANGELOG` env var) in the *same 8 laurigates packs* that `comfyui-nodes`' release-pipeline rule also documented, with zero cross-reference — two of those footguns were independently rediscovered by parallel Claude Code sessions because neither side knew the other's rule existed.

- **New skill `comfyui-node-authoring`** — merges `writing-custom-nodes.md`, `comfyui-frontend-api.md`, and `comfyui-widget-serialize-placement.md`: pack layout, widget hide/serialize rules, DOM event isolation, endpoint/subfolder safety, sourcemap verification, tooltip lookup chain, canvas hit-testing.
- **New skill `comfy-registry-lifecycle`** — merges `comfy-pack-release-pipeline.md`, `comfy-registry-publishing.md`, and `comfy-registry-icons-banners.md` (+ its `registry_banner_bg.py`/`registry_banner_compose.py` scripts): release-please/lockfile drift traps, the empty-`web/dist` publish-action bug, version status states, phantom versions, icon/banner generation.
- **New skill `comfyui-pack-live-smoke`** — promotes `comfyui-pack-live-smoke.md` and folds in `comfy-api-run`'s headless API-driven variant. Reads its target host from a new `COMFYUI_HOST` env var (default `127.0.0.1:8188`) instead of a hardcoded loopback or hostname.
- **New skills `comfy-workflow-json` and `comfy-subgraphs-app-mode`** — genericized from `editing-workflow-json.md` and `subgraphs-and-app-mode.md` (install-specific naming-convention content dropped; the portable JSON-format/API facts kept).
- **Moved as-is** (light genericization scan only): `comfy-cli`, `comfy-conditionals`, `comfy-debug-preview`, `comfy-flow-control`, `comfy-image-utils`, `comfy-math-strings`, `comfy-metadata` (+ `scripts/comfy_meta.py`), `comfy-workflow-layout` — generic ComfyUI node-selection reference, not tied to either workspace.

Genericized host-specific literals (`/mnt/sabrent/...`, the systemd install path, a `/home/lgates` path) out of the moved content; ran a repo-wide grep for `popos`/`/mnt/sabrent`/`intra.lakuz.com`/home-path leaks before opening this PR — clean.

## Test plan

- [x] `just lint-compliance` — no new-content-specific blockers (pre-existing SKILL.md size warnings match the marketplace baseline)
- [x] `python3 scripts/audit-skill-descriptions.py --strict-length` — all 13 new/moved descriptions ≤300 chars, all with a "Use when..." trigger clause
- [x] `bash scripts/check-version-pin-coverage.sh --strict` — the one pinned `uses:` ref (untagged `publish-node-action` commit) carries a `# vX.Y.Z`-shaped comment
- [x] `grep -rniE 'popos|/mnt/sabrent|intra\.lakuz\.com|/home/lgates' comfyui-plugin/` — clean
- [x] Pre-commit hooks green on the actual commit
- [ ] Once merged: remove the now-duplicated rule files from `laurigates/comfyui-nodes/.claude/rules/` and the GPU-lab tooling repo's `.claude/rules/`, leaving a one-line pointer where useful, and wire `COMFYUI_HOST` into the tooling repo's `comfy_run.py` default (already done on that repo's working tree, pending its own commit)