### PR TITLE
docs: refresh comfyui-plugin skill counts in catalog docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Experimental testing harness lives under experiments/claude-probe/.
 
-A curated collection of 44 Claude Code plugins providing 380+ skills and 21 agents for development workflows.
+A curated collection of 44 Claude Code plugins providing 400+ skills and 21 agents for development workflows.
 
 ## Install the Marketplace
 
@@ -80,7 +80,7 @@ the rules, skills, and hooks that embody it.
 |--------|--------|-------------|
 | **api-plugin** | 1 | API integration and testing - REST endpoints, client generation |
 | **blueprint-plugin** | 34 | Blueprint Development methodology - PRD/PRP workflow with version tracking |
-| **comfyui-plugin** | 3 | ComfyUI custom-node pack lifecycle - scaffold, seed repo, gitops adoption, registry publish |
+| **comfyui-plugin** | 16 | ComfyUI custom-node pack lifecycle - scaffold, seed repo, gitops adoption, registry publish |
 | **home-assistant-plugin** | 4 | Home Assistant configuration - automations, scripts, scenes, entities |
 | **obsidian-plugin** | 21 | Obsidian CLI operations - vault management, search, properties, tasks |
 | **project-plugin** | 7 | Project initialization, management, maintenance, and continuous development |

--- a/docs/diagrams/plugin-relationships.d2
+++ b/docs/diagrams/plugin-relationships.d2
@@ -259,7 +259,7 @@ domain: {
     class: domain
   }
   comfyui: {
-    label: "comfyui\n3 skills"
+    label: "comfyui\n16 skills"
     shape: rectangle
     class: domain
   }


### PR DESCRIPTION
## What

Refresh the top-level catalog docs so the stated `comfyui-plugin` skill count matches disk. Closes the two mechanical count-drift findings that `scripts/check-docs-index.sh` surfaces:

- **README.md:83** — `comfyui-plugin` stated **3** skills, **16** on disk (`doc_count_drift`).
- **docs/diagrams/plugin-relationships.d2** — the `comfyui` node label stated **3 skills**, **16** on disk (`diagram_count_drift`).

Also bumped the README intro headline `380+ skills` → `400+ skills` (`TOTAL_SKILLS=400` from the audit).

## Why

`comfyui-plugin` grew from 3 to 16 skills (the shared ComfyUI reference skills added in #2025) but the catalog counts were not refreshed, so the mechanical docs-index audit reported `STATUS=WARN, ISSUE_COUNT=2`.

## Verification

`bash scripts/check-docs-index.sh` (and `--strict`) now emit `STATUS=OK, ISSUE_COUNT=0`.

```
=== DOCS INDEX AUDIT ===
RULES_ON_DISK=41
RULES_IN_TABLE=41
MARKETPLACE_PLUGINS=44
TOTAL_SKILLS=400
TOTAL_AGENTS=21
DIAGRAM_NODES=33
RULES_CHECKED=41
STATUS=OK
ISSUE_COUNT=0
=== END DOCS INDEX AUDIT ===
```

The `.svg` render is intentionally left untouched — it is generated and not parsed by the check.

## Scope

This addresses only the **Layer 1 mechanical count drift** for #1460. The broader **Layer 2 substantive content read-through** of #1460 remains open and is intentionally out of scope here, hence `Refs #1460` (not `Closes`).

Refs #1460
