### PR TITLE
feat(vault-agent): add standalone-install prompt fallback (Phase 0 of extraction)

### DIFF
--- a/vault-agent/docs/adr/0006-standalone-install-prompt-fallback.md
+++ b/vault-agent/docs/adr/0006-standalone-install-prompt-fallback.md
@@ -1,0 +1,87 @@
+# ADR-0006: Standalone-Install Prompt Fallback
+
+- Status: Accepted
+- Date: 2026-07-10
+
+## Context
+
+`vault-agent` lives inside the `claude-plugins` monorepo. At runtime its
+prompt compiler (`prompts/compiler.py`) reads SKILL.md files from the
+sibling `obsidian-plugin` (e.g.
+`obsidian-plugin/skills/vault-frontmatter/SKILL.md`, per ADR-0005) to
+build the four maintenance subagents' system prompts.
+
+Issue [#1973](https://github.com/laurigates/claude-plugins/issues/1973)
+proposes extracting `vault-agent` into its own repository so it can be
+installed via `uv tool install vault-agent` / `uvx vault-agent`. The
+blocker is the runtime dependency on the sibling plugin checkout: a
+standalone install has no `claude-plugins/` parent directory and no
+`obsidian-plugin/skills/` sibling, so `get_compiled_prompt()` would
+compile empty prompts.
+
+This mirrors the problem `git-repo-agent` already solved in its ADR-009.
+
+## Decision
+
+Add a fallback path to the compiler so the package can run in two modes:
+
+1. **Monorepo (dev) mode.** Sibling plugin sources exist under
+   `_PLUGINS_ROOT`. Live-compile from `SKILL.md` for both subagent
+   prompts and per-skill fragments. Behaviour is unchanged from before.
+
+2. **Standalone (installed) mode.** Sibling sources are absent. Read
+   pre-compiled artifacts from `prompts/generated/`:
+   - Subagent prompts: `prompts/generated/<subagent>_skills.md`
+   - Per-skill fragments:
+     `prompts/generated/skills/<plugin>/<skill-name>.md`
+
+`_plugin_skill_available()` probes `_PLUGINS_ROOT / skill_relpath`.
+`get_compiled_prompt()` live-compiles when any of a subagent's skills is
+present and falls back to the pre-compiled bundle otherwise;
+`get_compiled_skill()` falls back per skill, raising `FileNotFoundError`
+only when neither the source nor a generated artifact exists.
+
+The build script (`scripts/compile_prompts.py`) writes both artifact
+trees and exposes a `--check` mode for CI to detect drift between
+sources and pre-compiled output. Unlike `git-repo-agent`'s script it does
+**not** statically parse a blueprint driver — `vault-agent` has no
+blueprint state machine, so the per-skill artifacts are exactly the union
+of the skills the `SUBAGENT_SKILLS` bundles reference.
+
+## Why pre-compilation, not alternatives
+
+| Option | Why not |
+|---|---|
+| Git submodule pulling in `claude-plugins` | Heavy (many MB) for a handful of derived markdown files |
+| Separate PyPI package for prompts | Over-engineered for static markdown |
+| Runtime download from GitHub | Adds a network dependency and offline failure modes |
+
+Pre-compiled markdown is small, version-pinned with the package, and lets
+`uv tool install` work from PyPI alone.
+
+## Implications
+
+- Cross-repo regeneration: when extraction lands (later phases of #1973),
+  the monorepo CI must push regenerated `generated/` files into the
+  standalone repo whenever upstream `SKILL.md` files change. Per-skill
+  granularity keeps the regeneration footprint small.
+- Test coverage: `tests/test_compiler_standalone.py` simulates standalone
+  mode by repointing `_PLUGINS_ROOT` at an empty directory and verifies
+  every subagent and every referenced skill has a fallback (the regression
+  guard for this fix).
+- The compiler does **not** distinguish silently between live and fallback
+  output; both go through the same caching and rendering path.
+
+## Status
+
+This is Phase 0 of #1973 — the standalone-install prerequisite. Subsequent
+phases (creating `laurigates/vault-agent`, PyPI publish, cross-repo sync
+workflow, monorepo cleanup) are tracked separately and require manual
+owner actions.
+
+## Related
+
+- ADR-0005 (skill-source-obsidian-plugin) — where the source SKILL.md
+  files live and why.
+- `git-repo-agent`'s ADR-009 (standalone-install-prompt-fallback) — the
+  proven template this mirrors.

--- a/vault-agent/scripts/compile_prompts.py
+++ b/vault-agent/scripts/compile_prompts.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""CLI tool for inspecting/debugging compiled subagent prompts.
+
+Writes compiled prompts to disk or checks if previously-generated files
+are up-to-date. Runtime compilation is handled by
+vault_agent.prompts.compiler — this script is a thin wrapper for
+debugging, inspection, and shipping the standalone-install fallback
+artifacts (see ADR-0006).
+
+Usage:
+    python scripts/compile_prompts.py              # write to generated/
+    python scripts/compile_prompts.py --check      # verify output matches runtime
+    python scripts/compile_prompts.py --stdout     # print to stdout
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Allow running from scripts/ without installing the package
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from vault_agent.prompts.compiler import (  # noqa: E402
+    SUBAGENT_SKILLS,
+    _generated_skill_path,
+    compile_skill,
+    get_compiled_prompt,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PLUGINS_ROOT = REPO_ROOT.parent
+OUTPUT_DIR = REPO_ROOT / "src" / "vault_agent" / "prompts" / "generated"
+SKILLS_OUTPUT_DIR = OUTPUT_DIR / "skills"
+
+
+def _referenced_skill_relpaths() -> list[str]:
+    """Return every distinct skill path referenced by any subagent bundle.
+
+    vault-agent has no blueprint-driver-style state machine, so the per-skill
+    fallback artifacts are exactly the union of the skills the subagent
+    bundles pull in — nothing more.
+    """
+    seen: set[str] = set()
+    for skill_paths in SUBAGENT_SKILLS.values():
+        seen.update(skill_paths)
+    return sorted(seen)
+
+
+def _process_skill(
+    skill_relpath: str, *, check: bool, stdout: bool
+) -> tuple[bool, bool]:
+    """Compile ``skill_relpath``; return (handled, stale)."""
+    source = PLUGINS_ROOT / skill_relpath
+    if not source.exists():
+        # Standalone install: source not present. Nothing to write or check.
+        return False, False
+    compiled = compile_skill(source)
+    if stdout:
+        print(f"=== {skill_relpath} ===")
+        print(compiled)
+        return True, False
+    output_path = _generated_skill_path(skill_relpath)
+    rel = output_path.relative_to(REPO_ROOT)
+    if check:
+        if not output_path.exists():
+            print(f"MISSING: {rel}")
+            return True, True
+        if output_path.read_text(encoding="utf-8") != compiled:
+            print(f"STALE: {rel}")
+            return True, True
+        print(f"OK: {rel}")
+        return True, False
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(compiled, encoding="utf-8")
+    print(f"Generated {rel} ({compiled.count(chr(10))} lines)")
+    return True, False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Inspect compiled subagent prompts")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Check if generated files match runtime output (exit 1 if stale)",
+    )
+    parser.add_argument(
+        "--stdout",
+        action="store_true",
+        help="Print compiled prompts to stdout instead of writing files",
+    )
+    args = parser.parse_args()
+
+    if args.stdout:
+        for name in SUBAGENT_SKILLS:
+            compiled = get_compiled_prompt(name)
+            print(f"=== {name} ===")
+            print(compiled)
+        for skill_relpath in _referenced_skill_relpaths():
+            _process_skill(skill_relpath, check=False, stdout=True)
+        return 0
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    SKILLS_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    stale = False
+
+    for name in SUBAGENT_SKILLS:
+        output_path = OUTPUT_DIR / f"{name}_skills.md"
+        compiled = get_compiled_prompt(name)
+
+        if args.check:
+            if not output_path.exists():
+                print(f"MISSING: {output_path.relative_to(REPO_ROOT)}")
+                stale = True
+            elif output_path.read_text(encoding="utf-8") != compiled:
+                print(f"STALE: {output_path.relative_to(REPO_ROOT)}")
+                stale = True
+            else:
+                print(f"OK: {output_path.relative_to(REPO_ROOT)}")
+        else:
+            output_path.write_text(compiled, encoding="utf-8")
+            lines = compiled.count("\n")
+            print(f"Generated {output_path.relative_to(REPO_ROOT)} ({lines} lines)")
+
+    for skill_relpath in _referenced_skill_relpaths():
+        _, this_stale = _process_skill(skill_relpath, check=args.check, stdout=False)
+        stale = stale or this_stale
+
+    if args.check and stale:
+        print(
+            "\nGenerated files are stale (runtime compilation handles this automatically)."
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vault-agent/src/vault_agent/prompts/compiler.py
+++ b/vault-agent/src/vault_agent/prompts/compiler.py
@@ -15,6 +15,30 @@ from pathlib import Path
 _MODULE_DIR = Path(__file__).resolve().parent  # prompts/
 _REPO_ROOT = _MODULE_DIR.parent.parent.parent  # vault-agent/
 _PLUGINS_ROOT = _REPO_ROOT.parent  # claude-plugins/
+_GENERATED_DIR = _MODULE_DIR / "generated"  # Pre-compiled subagent prompts
+_GENERATED_SKILLS_DIR = _GENERATED_DIR / "skills"  # Pre-compiled per-skill files
+
+
+def _plugin_skill_available(skill_relpath: str) -> bool:
+    """Return True when ``skill_relpath`` resolves under the monorepo plugins root.
+
+    Live compilation requires sibling plugin checkouts. When ``vault-agent``
+    is installed standalone (e.g. via ``uv tool install``), ``_PLUGINS_ROOT``
+    points at the package's parent directory which does not contain
+    ``obsidian-plugin/skills/*/SKILL.md``. In that case the runtime falls back
+    to pre-compiled artifacts shipped under ``prompts/generated/``.
+    """
+    return (_PLUGINS_ROOT / skill_relpath).exists()
+
+
+def _generated_skill_path(skill_relpath: str) -> Path:
+    """Map ``<plugin>/skills/<skill>/SKILL.md`` → ``generated/skills/<plugin>/<skill>.md``."""
+    parts = Path(skill_relpath).parts
+    if len(parts) >= 4 and parts[1] == "skills" and parts[-1] == "SKILL.md":
+        return _GENERATED_SKILLS_DIR / parts[0] / f"{parts[-2]}.md"
+    # Fallback: flatten the relpath under the generated tree.
+    return _GENERATED_SKILLS_DIR / Path(skill_relpath).with_suffix(".md")
+
 
 # Subagent → list of skill files (relative to PLUGINS_ROOT).
 #
@@ -175,20 +199,44 @@ def compile_subagent(name: str, skill_paths: list[str]) -> str:
 
 @lru_cache(maxsize=None)
 def get_compiled_prompt(subagent_name: str) -> str:
-    """Return the compiled skill bundle for a subagent (cached)."""
+    """Return the compiled skill bundle for a subagent (cached).
+
+    Live compiles from sibling plugin checkouts when present (monorepo dev
+    mode); otherwise falls back to the pre-compiled artifact under
+    ``prompts/generated/<subagent>_skills.md`` shipped with the package
+    (standalone install mode). Returns an empty string if the subagent has
+    no configured skills, no sources, and no pre-compiled fallback.
+    """
     skill_paths = SUBAGENT_SKILLS.get(subagent_name)
     if not skill_paths:
         return ""
-    return compile_subagent(subagent_name, skill_paths)
+    if any(_plugin_skill_available(p) for p in skill_paths):
+        return compile_subagent(subagent_name, skill_paths)
+    fallback = _GENERATED_DIR / f"{subagent_name}_skills.md"
+    if fallback.exists():
+        return fallback.read_text(encoding="utf-8")
+    return ""
 
 
 @lru_cache(maxsize=None)
 def get_compiled_skill(skill_relpath: str) -> str:
     """Compile a single skill file (cached).
 
-    Useful for phased drivers that run one skill per LLM call.
+    ``skill_relpath`` is relative to the plugins root, e.g.
+    ``"obsidian-plugin/skills/vault-frontmatter/SKILL.md"``. Live-compiles
+    from the monorepo plugin tree when present (dev mode); otherwise reads
+    the pre-compiled artifact under ``prompts/generated/skills/<plugin>/<skill>.md``
+    (standalone install mode). Useful for phased drivers that run one skill
+    per LLM call.
+
+    Raises FileNotFoundError if the skill does not exist in either the
+    monorepo plugin tree or the package's pre-compiled ``generated/skills/``
+    directory.
     """
     skill_path = _PLUGINS_ROOT / skill_relpath
-    if not skill_path.exists():
-        raise FileNotFoundError(f"Skill not found: {skill_relpath}")
-    return compile_skill(skill_path)
+    if skill_path.exists():
+        return compile_skill(skill_path)
+    fallback = _generated_skill_path(skill_relpath)
+    if fallback.exists():
+        return fallback.read_text(encoding="utf-8")
+    raise FileNotFoundError(f"Skill not found: {skill_relpath}")

--- a/vault-agent/src/vault_agent/prompts/generated/skills/obsidian-plugin/vault-frontmatter.md
+++ b/vault-agent/src/vault_agent/prompts/generated/skills/obsidian-plugin/vault-frontmatter.md
@@ -1,0 +1,92 @@
+# Vault Frontmatter Maintenance
+
+
+## Canonical Frontmatter Shape
+
+```yaml
+---
+tags:
+  - 🛠️/neovim       # emoji-prefixed category tag
+  - 📝/notes         # note-type tag
+context: work        # work-namespace notes only
+---
+```
+
+Rules:
+1. No `id:` field — removed from all current templates.
+2. 2–3 tags per note; every tag either `emoji/subcategory` or a bare note-type like `📝/moc`.
+3. No bare emoji placeholders (`📝`, `🌱`, `📝/🌱`) — they indicate the tag was never specified.
+4. No `null` tag values — YAML must be valid.
+5. Work-namespace notes (e.g. under `work/`) carry `context: work`; personal notes omit the field.
+
+
+## Detection Patterns
+
+| Issue | Grep pattern | Notes |
+|-------|--------------|-------|
+| Legacy `id:` | `^id:` inside frontmatter block | Strip entire line |
+| Bare placeholder tag | YAML tag value exactly `📝`, `🌱`, or `📝/🌱` | Remove if note has other useful tags; else leave |
+| Null tag | YAML tag value literally `null` | Remove list entry |
+| Templater leak | `<% tp\.` or `\{\{title\}\}` or `\{\{date\}\}` | Replace `{{title}}` with filename stem; strip `<% tp.* %>` |
+| Corrupt emoji | Tag contains Unicode replacement char `\ufffd` | Flag for manual fix — don't guess |
+| Missing work context | File under the work namespace (e.g. `work/`) without `context: work` | Add the line |
+
+
+## Edit Recipes
+
+
+### Strip legacy id
+Before:
+```yaml
+---
+id: 20240118235900
+tags: [🛠️/neovim]
+---
+```
+After:
+```yaml
+---
+tags: [🛠️/neovim]
+---
+```
+
+
+### Remove bare placeholder (keeping useful tags)
+Before:
+```yaml
+tags:
+  - 📝
+  - 🛠️/ansible
+```
+After:
+```yaml
+tags:
+  - 🛠️/ansible
+```
+
+
+### Legacy MOC tag → current
+Before:
+```yaml
+tags:
+  - 🗺️
+```
+After:
+```yaml
+tags:
+  - 📝/moc
+```
+
+
+## Edit Pattern
+
+Use `Edit` with small targeted `old_string` / `new_string` replacements that preserve exact indentation. Never rewrite whole files when a line edit suffices — it minimizes the commit diff and makes reviews easy.
+
+For bulk fixes across many files, drive from a script that emits one `Edit` call per file rather than running `sed` in `Bash`. The commit-per-category pattern (`fix(tags): strip bare 📝 from 639 notes`) relies on keeping all edits in one logical batch.
+
+
+## Safety
+
+- Never write to `.obsidian/`, `.claude/`, `.git/`, `Files/`. The safety hook enforces this.
+- Never add frontmatter to daily notes in `Notes/` or `work/notes/` without verifying — they often don't need any.
+- When in doubt about what a placeholder tag meant, leave the note unchanged and report it rather than guess.

--- a/vault-agent/src/vault_agent/prompts/generated/skills/obsidian-plugin/vault-mocs.md
+++ b/vault-agent/src/vault_agent/prompts/generated/skills/obsidian-plugin/vault-mocs.md
@@ -1,0 +1,136 @@
+# MOC Curation
+
+
+## Canonical MOC Shape
+
+```markdown
+---
+tags: [📝/moc]
+---
+
+
+# Neovim MOC
+
+Central hub for Neovim configuration, plugins, and workflows.
+
+
+## Core
+
+- [[Neovim]] — base configuration
+- [[Lazy.nvim]] — plugin management
+
+
+## Plugins
+
+- [[nvim-treesitter]]
+- [[Mason LSP]]
+
+
+## Keybindings and Workflow
+
+- [[Neovim Keybindings]]
+- [[Neovim Session Management]]
+```
+
+Rules:
+1. Tag is **exactly** `📝/moc` — not `🗺️` (legacy), not `MOC` (flat), not `📝/MOC` (wrong case).
+2. File lives in `Zettelkasten/` (personal) or `work/MOC/` (work).
+3. Filename is `{Subject} MOC.md` — suffix, not prefix.
+4. Body has a one-paragraph description, then `##` section headings, then bullet-list wikilinks.
+5. Never has `id:` or other legacy frontmatter.
+
+
+## Legacy MOC Fixups
+
+| Issue | Fix |
+|-------|-----|
+| `tags: 🗺️` | Rewrite to `tags: [📝/moc]` |
+| `tags: [🗺, 📝/moc]` | Deduplicate to `tags: [📝/moc]` |
+| MOC in `work/z/` instead of `work/MOC/` | Move file |
+| Uses `[[Kanban/Foo]]` path-qualified links | Rewrite to `[[Foo]]` when basename unique |
+
+
+## Coverage Analysis
+
+For each tag category (`🛠️/`, `🔌/`, `💻/`, etc.), the vault-agent `mocs.analyze_mocs` analyzer reports how many tagged notes are NOT linked from any MOC. High uncovered counts indicate:
+
+- **Missing MOC** — the category has 10+ notes but no MOC exists.
+- **Stale MOC** — the MOC exists but hasn't been updated with recent additions.
+- **Tag mismatch** — notes are tagged but don't belong in the relevant MOC.
+
+
+## Offline Fallback (App Closed)
+
+The detection methodology above is unchanged — only the **data source** changes when Obsidian (and its `obsidian` CLI / live link index) is closed. The `obsidian` CLI and `vault-agent` analyzers are the **live-index** path; parsing the `.md` corpus directly with Glob/Grep is the **deterministic headless default**, and for batch/scheduled audits it is often the better choice (reproducible, free of app/index state). `vault-frontmatter` already operates this way.
+
+Parse the corpus directly:
+
+- **Frontmatter** — read each note's YAML block between the leading `---` fences; extract `tags`, `aliases`, `context`. See `vault-frontmatter` for YAML-block mechanics.
+- **Wikilinks** — match `[[Target]]`, `[[Target|Alias]]`, `[[Target#Heading]]`, `[[folder/Target]]`, and `![[embed]]`. Resolve each target to a note by **basename**, then **relative path**, then **alias** (from frontmatter), all **case-insensitive**. Resolve `![[embed]]` against attachments as well as notes — the attachment folder is per-vault configurable, so read it from `.obsidian/app.json` (`attachmentFolderPath`) and fall back to the vault root / `Files/` only when that key is unset.
+
+Coverage analysis offline: for each tag category, count notes whose parsed frontmatter `tags` place them in the category but which no `📝/moc`-tagged note links to (via the resolution cascade). That is the same uncovered count `mocs.analyze_mocs` produces from the live index.
+
+
+## Creating a New MOC
+
+Thresholds (heuristic):
+- ≥ 10 tagged notes in the category AND
+- No existing MOC covers them AND
+- Notes share enough subject to belong in one hub
+
+If all three hold, create `Zettelkasten/{Category} MOC.md`:
+
+```markdown
+---
+tags: [📝/moc]
+---
+
+
+# {Category} MOC
+
+{One-paragraph framing of the category.}
+
+
+## {Section}
+
+- [[Note1]]
+- [[Note2]]
+```
+
+Pick 2–4 `##` sections that reflect natural groupings within the notes — don't force a deep hierarchy.
+
+
+## Extending an Existing MOC
+
+When the analyzer reports orphaned notes that belong in an existing MOC:
+
+1. Read the MOC and find the most appropriate `##` section (or create a new one if 3+ notes fit a new grouping).
+2. Add wikilinks one per bullet, alphabetical within the section.
+3. Keep descriptions brief — one short phrase per link at most.
+
+Don't add a "See also" or "Random" section as a dumping ground. If a note doesn't fit any section, reconsider whether it belongs in this MOC at all.
+
+
+## Never Do
+
+- **Don't create nested MOCs** (MOC of MOCs) unless the vault has 20+ MOCs that justify a top-level index.
+- **Don't dataview-generate MOC content** in place of hand-curated links. Dataview is fine for supplementary sections ("Recent notes in this category"), but the primary content should be hand-picked.
+- **Don't add the `📝/moc` tag to a note that isn't actually a MOC** — it pollutes MOC inventories.
+- **Don't rename existing MOCs** without updating every link (use `vault-wikilinks` rewrite patterns).
+
+
+## Commit Messages
+
+| Action | Commit |
+|--------|--------|
+| New MOC | `feat(mocs): add {Category} MOC covering N notes` |
+| Fixup tag | `fix(mocs): 🗺️ → 📝/moc on work MOCs` |
+| Add orphans | `feat(mocs): link 12 notes into Neovim MOC` |
+| Rewrite path-qualified link | `fix(mocs): unqualify [[Kanban/X]] → [[X]] across 6 MOCs` |
+
+
+## Safety
+
+- Never modify a MOC's section structure without the user's input — they reflect the user's mental model.
+- When adding links, preserve the user's existing sort order (alphabetical, chronological, by-importance — look at the first section to infer).
+- Don't link notes that are tagged but clearly off-topic for the MOC.

--- a/vault-agent/src/vault_agent/prompts/generated/skills/obsidian-plugin/vault-orphans.md
+++ b/vault-agent/src/vault_agent/prompts/generated/skills/obsidian-plugin/vault-orphans.md
@@ -1,0 +1,76 @@
+# Orphan Triage
+
+
+## Classes of Orphan
+
+| Class | Where | Treat as |
+|-------|-------|----------|
+| Inbox items | `Inbox/*.md` | Expected; process via `/process-inbox` |
+| Daily notes | `Notes/YYYY-MM-DD.md`, `work/notes/…` | Expected; they link out but rarely in |
+| Standalone references | `Zettelkasten/*.md` with 0↔0 | **Meaningful** — add linkage |
+| Kanban board notes | `Kanban/*.md` | Usually acceptable; boards are self-contained |
+| Archive / logs | under `Archive/` subfolders | Expected; stale by design |
+
+The vault-agent graph analyzer classifies each automatically.
+
+
+## Offline Fallback (App Closed)
+
+The detection methodology above is unchanged — only the **data source** changes when Obsidian (and its `obsidian` CLI / live link index) is closed. The `obsidian` CLI and `vault-agent` analyzers are the **live-index** path; parsing the `.md` corpus directly with Glob/Grep is the **deterministic headless default**, and for batch/scheduled audits it is often the better choice (reproducible, free of app/index state). `vault-frontmatter` already operates this way.
+
+Parse the corpus directly:
+
+- **Frontmatter** — read each note's YAML block between the leading `---` fences; extract `tags`, `aliases`, `context`. See `vault-frontmatter` for YAML-block mechanics.
+- **Wikilinks** — match `[[Target]]`, `[[Target|Alias]]`, `[[Target#Heading]]`, `[[folder/Target]]`, and `![[embed]]`. Resolve each target to a note by **basename**, then **relative path**, then **alias** (from frontmatter), all **case-insensitive**. Resolve `![[embed]]` against attachments as well as notes — the attachment folder is per-vault configurable, so read it from `.obsidian/app.json` (`attachmentFolderPath`) and fall back to the vault root / `Files/` only when that key is unset.
+
+Build the link graph from the resolved wikilinks: a note is an orphan when no resolved link targets it (zero incoming) **and** it emits no link that resolves (zero outgoing). The class table above (Inbox / daily / Archive) is path-derived and works identically offline.
+
+
+## Triage Workflow
+
+For each meaningful orphan:
+
+1. **Read the note** — is the content still relevant, or is this old/dead content?
+2. **Identify its primary category** — by tag (e.g., `🛠️/neovim` → Neovim MOC) or by title.
+3. **Pick ONE action:**
+   - **Link from a MOC** — add `[[Note]]` to the appropriate MOC under the right section
+   - **Add an inbound link** from a closely related note
+   - **Archive** — move to an `Archive/` subfolder if no longer useful
+   - **Delete** — only if empty or entirely superseded
+
+
+## Never Do
+
+- **Don't add dummy links** like "See also: [[Random]]" just to take the note off the orphan list. That's link pollution.
+- **Don't create a new MOC** just to absorb one orphan — see `vault-mocs` for thresholds.
+- **Don't assume empty = orphan** — some orphans have substantive content that simply wasn't linked.
+
+
+## Linking Heuristics
+
+When adding a note to a MOC, match on:
+
+1. **Primary tag category** — a note tagged `🛠️/neovim` belongs in the Neovim MOC.
+2. **Content topic** — read the first paragraph; pick the MOC that covers that subject.
+3. **Existing cluster** — if notes `A`, `B`, `C` all link to each other but none link from a MOC, add the whole cluster to the MOC under one section heading.
+
+
+## MOC Section Placement
+
+MOCs typically have sections like `## Core Concepts`, `## Tools`, `## Specific Configurations`. Pick the most specific section that fits; create a new `## Something` section only if 3+ notes fall under the same new heading.
+
+
+## Batch Pattern
+
+Never modify 100+ MOC links in one commit — that's unreviewable. Use one commit per MOC:
+
+```
+feat(mocs): link 12 orphaned CLI tool notes into new CLI Tools MOC
+```
+
+
+## Safety
+
+- If a note is substantive and the user's writing style suggests it was important, lean toward linking rather than deleting.
+- If tags are contradictory or missing, link to a broader MOC rather than guessing a specific one.
+- Preserve any existing heading structure in the MOC when inserting links.

--- a/vault-agent/src/vault_agent/prompts/generated/skills/obsidian-plugin/vault-stubs.md
+++ b/vault-agent/src/vault_agent/prompts/generated/skills/obsidian-plugin/vault-stubs.md
@@ -1,0 +1,115 @@
+# Work-namespace Stub Management
+
+
+## Canonical Redirect Stub Format
+
+```yaml
+---
+tags: [redirect]
+context: work
+---
+See [[Zettelkasten/Docker|Docker]] in the main knowledge base.
+```
+
+Properties:
+- Size ≤ 200 bytes (whitespace excluded)
+- Tags is exactly `[redirect]`
+- Body is a single wikilink with alias to the canonical note
+- `context: work`
+
+
+## Classifications (from vault-agent's stubs analyzer)
+
+| Class | Meaning | Action |
+|-------|---------|--------|
+| `clean_redirect` | ≤ 200 B, `redirect` tag, Zettelkasten match | ✓ keep as-is |
+| `broken_redirect` | `redirect` tag but >200 B or missing target | Rewrite body to the canonical one-liner |
+| `stale_duplicate` | Full article, basename exists in Zettelkasten | Merge content into Zettelkasten, convert stub to `clean_redirect` |
+| `ns_original` | Full article, no Zettelkasten match | Legitimate — leave alone |
+
+
+## Consolidation: stale_duplicate → clean_redirect
+
+When a `work/z/Foo.md` has substantive content AND `Zettelkasten/Foo.md` exists, you must decide:
+
+1. **Is the work-namespace content a subset of Zettelkasten?** → Replace stub with canonical redirect. No content merge needed.
+2. **Does the work-namespace note have unique content?** → Merge the unique sections into `Zettelkasten/Foo.md` first, then replace stub.
+3. **Is the work-namespace note *better* than Zettelkasten?** → Rare, but flag for user review. The user decides which becomes canonical.
+
+
+### Merge Heuristic
+
+Compare by section. If a heading in `work/z/Foo.md` has text that doesn't appear in `Zettelkasten/Foo.md`, that text needs migration. Use word-level comparison, not exact match — minor wording differences don't count as "unique content."
+
+When in doubt, **flag for user review** rather than auto-merging. A bad merge is worse than leaving a duplicate.
+
+
+## Conversion Recipe
+
+Replace the whole work-namespace file body:
+
+```yaml
+---
+tags: [redirect]
+context: work
+---
+See [[Zettelkasten/Foo|Foo]] in the main knowledge base.
+```
+
+Commit message:
+```
+refactor(stubs): convert work/z/Foo.md to redirect (content merged into Zettelkasten)
+```
+
+
+## Promoting ns_original → Zettelkasten
+
+Occasionally a file classified `ns_original` is actually general-interest content that belongs in `Zettelkasten/`. Signs:
+- No work-specific references (internal check-ins, internal tools, internal URLs)
+- Could be useful in personal contexts
+
+If promoting:
+1. Move file to `Zettelkasten/Foo.md`
+2. Create a `work/z/Foo.md` redirect stub in its place
+3. Strip `context: work` from the promoted note's frontmatter
+4. Commit as `refactor(stubs): promote Foo from work/z to Zettelkasten`
+
+Don't promote aggressively — the work namespace exists for a reason.
+
+
+## Detection
+
+```bash
+
+# All work-namespace files ordered by size
+fd -e md . work/z -x wc -c {} | sort -n
+
+
+# Ones with `redirect` tag
+rg -l '^tags:.*\bredirect\b' work/z/ --glob '*.md'
+
+
+# Large ones without `redirect` tag (candidates for conversion)
+rg -L -l '^tags:.*\bredirect\b' work/z/ --glob '*.md'
+```
+
+Vault-agent's `analyze_stubs` gives the full classification.
+
+
+## Offline Fallback (App Closed)
+
+The detection methodology above is unchanged — only the **data source** changes when Obsidian (and its `obsidian` CLI / live link index) is closed. The `obsidian` CLI and `vault-agent` analyzers are the **live-index** path; parsing the `.md` corpus directly with the `fd`/`rg` Detection snippet above is the **deterministic headless default**, and for batch/scheduled audits it is often the better choice (reproducible, free of app/index state). `vault-frontmatter` already operates this way.
+
+Parse the corpus directly:
+
+- **Frontmatter** — read each note's YAML block between the leading `---` fences; extract `tags`, `aliases`, `context`. See `vault-frontmatter` for YAML-block mechanics.
+- **Wikilinks** — match `[[Target]]`, `[[Target|Alias]]`, `[[Target#Heading]]`, `[[folder/Target]]`, and `![[embed]]`. Resolve each target to a note by **basename**, then **relative path**, then **alias** (from frontmatter), all **case-insensitive**. Resolve `![[embed]]` against attachments as well as notes — the attachment folder is per-vault configurable, so read it from `.obsidian/app.json` (`attachmentFolderPath`) and fall back to the vault root / `Files/` only when that key is unset.
+
+Classify each stub from parsed inputs only: file size (`wc -c`), the `redirect` frontmatter tag, and a **basename** match against `Zettelkasten/` — the same inputs `analyze_stubs` uses. The redirect body's `[[Zettelkasten/Foo|Foo]]` target is verified with the resolution cascade above.
+
+
+## Safety
+
+- Never delete content without verifying it exists elsewhere. When merging, grep the destination note for a canonical phrase from the source.
+- Preserve `context: work` on stubs (required for work-namespace queries).
+- Don't create stubs for Zettelkasten notes that aren't actually used in work context — that creates noise, not redirection.

--- a/vault-agent/src/vault_agent/prompts/generated/skills/obsidian-plugin/vault-tags.md
+++ b/vault-agent/src/vault_agent/prompts/generated/skills/obsidian-plugin/vault-tags.md
@@ -1,0 +1,96 @@
+# Vault Tag Taxonomy
+
+
+## Canonical Categories
+
+| Emoji | Category | Examples |
+|-------|----------|----------|
+| `🛠️` | Development tools | `🛠️/neovim`, `🛠️/git`, `🛠️/terminal` |
+| `💻` | Programming languages | `💻/python`, `💻/rust`, `💻/typescript` |
+| `☁️` | Systems & infrastructure | `☁️/kubernetes`, `☁️/docker`, `☁️/linux` |
+| `🔌` | Hardware & IoT | `🔌/esp32`, `🔌/arduino`, `🔌/electronics` |
+| `🏠` | Home automation | `🏠/home-assistant`, `🏠/esphome` |
+| `🎮` | Entertainment | `🎮/games`, `🎮/tabletop` |
+| `🤖` | AI & ML | `🤖/comfyui`, `🤖/llm`, `🤖/ai-tools` |
+
+
+### Note-Type Tags
+
+| Tag | Meaning |
+|-----|---------|
+| `📝/moc` | Map of Content |
+| `📝/notes` | General note |
+| `📝/collection` | Resource collection |
+| `📝/guide` | How-to guide |
+| `📋/reference` | Quick reference material |
+| `📋/commands` | Command-line reference |
+| `📅/daily` | Daily note |
+
+
+## Consolidation Table
+
+When auditing reveals duplicate or drifted tags, apply these rewrites:
+
+| Drift / Legacy | Canonical | Reason |
+|----------------|-----------|--------|
+| `🗺️` | `📝/moc` | Old MOC marker |
+| `🔒/security` | `🔍/security` | Standardize on search emoji |
+| `🎨/comfyui` | `🤖/comfyui` | ComfyUI lives under AI |
+| `gaming` | `🎮/games` | Flat → emoji-prefixed |
+| `neovim` (flat) | `🛠️/neovim` | Flat → emoji-prefixed |
+| `softwaredevelopment` | `💻/development` | Concatenated → slash |
+| `project` / `projects` | `💡/project` | Pick one plural form |
+| `Hardware` (title-cased) | `🔌/hardware` | Lowercase, emoji-prefixed |
+
+
+## Bare Placeholder Tags
+
+The tags `📝`, `🌱`, `📝/🌱` are no-ops left over from unfinished template rendering. Treatment:
+
+- If the note has **other useful tags**, remove the placeholder.
+- If the note has **only** a placeholder, leave it flagged for manual review — removing would leave the note untagged, which is a different (but real) problem.
+
+
+## Over-Tagging
+
+More than 5 tags suggests the note mixes topics and should be split, or that tags are being used as keywords. Bring it down to 2–3 by asking "what single category is this note about?" — the rest go in the body as text.
+
+
+## Detection
+
+```bash
+
+# Notes with a bare 📝 or 🌱 tag on its own line
+rg -l '^\s*-\s+(📝|🌱|📝/🌱)\s*$' --glob '*.md'
+
+
+# Notes with competing security prefixes
+rg -l '🔒/security' --glob '*.md'
+rg -l '🔍/security' --glob '*.md'
+
+
+# Flat (non-emoji-prefix) tags
+rg '^\s*-\s+[a-z][a-z0-9_-]+\s*$' --glob '*.md'
+```
+
+
+## Offline Fallback (App Closed)
+
+The detection methodology above is unchanged — only the **data source** changes when Obsidian (and its `obsidian` CLI / live tag index) is closed. The `obsidian tags`/`tag` queries in `search-discovery` are the **live-index** path; parsing the `.md` corpus directly with the `rg` Detection snippets above is the **deterministic headless default**, and for batch/scheduled audits it is often the better choice (reproducible, free of app/index state). `vault-frontmatter` already operates this way.
+
+Tag taxonomy is pure frontmatter — read each note's YAML block between the leading `---` fences and extract `tags` (and `aliases` / `context` where relevant); see `vault-frontmatter` for YAML-block mechanics. The consolidation and bare-placeholder passes need no running app: the `rg` snippets above read tags straight from the files.
+
+
+## Edit Pattern
+
+For each note, use `Edit` with a small `old_string` / `new_string` that touches only the affected tag lines. Preserve indentation and the rest of the frontmatter block exactly.
+
+When renaming a tag across the whole vault, batch into one commit titled `fix(tags): consolidate 🔒/security → 🔍/security (N notes)`.
+
+
+## Anti-Patterns
+
+- Do **not** invent new categories. Use the table above; propose additions via a conventional commit if truly needed.
+- Do **not** use spaces inside tag values (`AI tools` → `🤖/ai-tools`).
+- Do **not** use multiple emoji in one tag (`🛠️🔌/esp32` — pick one).
+- Do **not** add tags purely for search — search works on content and filenames already.

--- a/vault-agent/src/vault_agent/prompts/generated/skills/obsidian-plugin/vault-templates.md
+++ b/vault-agent/src/vault_agent/prompts/generated/skills/obsidian-plugin/vault-templates.md
@@ -1,0 +1,101 @@
+# Templater Convention & Drift Repair
+
+
+## Unrendered Markers
+
+| Marker | Meaning | Fix |
+|--------|---------|-----|
+| `<% tp.file.cursor(N) %>` | Cursor position placeholder | Strip the entire tag |
+| `<% tp.file.title %>` | Filename stem | Replace with actual filename (no `.md`) |
+| `<% tp.date.now("YYYY-MM-DD") %>` | Today's date | Replace with the creation date from frontmatter, or the filename date for daily notes |
+| `{{title}}` | Filename stem (legacy) | Replace with filename stem |
+| `{{date}}` | Today's date (legacy) | Same as above |
+| `<% await tp.system.prompt(...) %>` | User prompt | Strip; requires user to refill |
+
+
+## Detection
+
+```bash
+
+# Find any Templater leak
+rg '<%\s*tp\.' --glob '*.md'
+rg '\{\{title\}\}|\{\{date\}\}' --glob '*.md'
+```
+
+
+## Fixing `<% tp.file.cursor(1) %>`
+
+Before:
+```markdown
+---
+tags: [📝/notes]
+---
+
+<% tp.file.cursor(1) %>
+```
+
+After:
+```markdown
+---
+tags: [📝/notes]
+---
+```
+
+Use `Edit` with `old_string='\n\n<% tp.file.cursor(1) %>'` and `new_string=''` (or adjust for trailing whitespace) — the cursor marker never has meaningful content around it.
+
+
+## Fixing `{{title}}` in daily notes
+
+Before (file `work/notes/2025-03-26.md`):
+```markdown
+
+# {{title}}
+
+
+## Log
+```
+
+After:
+```markdown
+
+# 2025-03-26
+
+
+## Log
+```
+
+Use the filename stem (no `.md`). Don't replace `{{title}}` inside code blocks or quoted text — only in headings / body.
+
+
+## Canonical Template Files
+
+The templates themselves live in `Templates/` and should contain raw Templater syntax — never "fix" them. Only fix notes outside `Templates/`.
+
+| Template | Produces | Sections |
+|----------|----------|----------|
+| `Daily.md` | `Notes/YYYY-MM-DD.md` | Quick Links, Today's Focus, Work, Personal, Tomorrow's Prep, Navigation |
+| `MOC.md` | `Zettelkasten/{Subject} MOC.md` | Title heading + sections |
+| `New.md` | general Zettelkasten notes | Frontmatter + body stub |
+| `Work Daily.md` | `work/notes/YYYY-MM-DD.md` | Log, Thoughts, Discoveries, Todo, Recurring reminders |
+
+
+## Daily Note Structure Drift
+
+Personal daily notes created before 2025 usually lack `## Navigation` and `## Tomorrow's Prep`. Two remediation options:
+
+1. **Retrofit template** — add the missing sections to every old daily note. Usually not worth the diff; users rarely look at old daily notes.
+2. **Leave as-is** — document the change boundary in a single commit message and let old notes age.
+
+Default to #2 unless the user specifically asks for retrofit.
+
+
+## Work Daily Note Drift
+
+Work-namespace daily notes that contain literal `{{title}}` in the heading — fix these.
+
+
+## Safety
+
+- Never edit `Templates/*.md` when fixing leakage — templates are supposed to contain Templater syntax.
+- Never run a blanket `sed -i 's/{{title}}/.../'` — always use file-specific `Edit` calls so the title derivation is correct per file.
+- When you encounter `<% tp.system.prompt(...) %>`, don't guess the answer — flag for user.

--- a/vault-agent/src/vault_agent/prompts/generated/skills/obsidian-plugin/vault-wikilinks.md
+++ b/vault-agent/src/vault_agent/prompts/generated/skills/obsidian-plugin/vault-wikilinks.md
@@ -1,0 +1,102 @@
+# Wikilink Integrity
+
+
+## Link Syntax
+
+```markdown
+[[Note Name]]                      # basename resolution
+[[Note Name|Alias]]                # custom display text
+[[Note Name#Section heading]]      # deep link to heading
+[[folder/Note Name]]               # path-qualified (usually unnecessary)
+![[Image.png]]                     # embed (image, note, PDF)
+```
+
+
+## Resolution Rules
+
+1. **Unqualified target** (`[[Docker]]`) resolves to any note with basename `Docker.md`. If two exist (e.g. `Zettelkasten/Docker.md` and `work/z/Docker.md`), Obsidian picks one non-deterministically — ambiguous.
+2. **Path-qualified target** (`[[Kanban/Main]]`) resolves to `Kanban/Main.md` exactly — no basename fallback.
+3. **Embeds** (`![[X]]`) follow the same resolution. Image embeds typically target files under `Files/`.
+
+
+## Common Breakage Patterns
+
+| Pattern | Fix |
+|---------|-----|
+| `[[OldTopic]]` × many → note doesn't exist | Rewrite to `[[Topic]]` (the actual note) |
+| `[[Development MOC]]` → note was renamed | Rewrite to `[[Development Workflows and Tools MOC]]` |
+| `[[Kanban/X]]` → works but path-qualified is brittle | Rewrite to `[[X]]` when basename is unique |
+| `[[code]]`, `[[project]]` → never were real notes | These were inline-tag syntax errors; delete the link and leave plain text |
+| `[[Gen AI  Some Idea]]` (double space) | Fix the extra whitespace in the link |
+
+
+## Cross-Namespace Ambiguity
+
+When two notes share a basename (e.g. `Docker.md` in both `Zettelkasten/` and `work/z/`), every `[[Docker]]` in the vault becomes ambiguous. Options:
+
+1. **Rename one** so they stop colliding (`work/z/Docker.md` → keep as redirect stub; content lives in `Zettelkasten/Docker.md`).
+2. **Path-qualify the links** that should resolve to the non-canonical copy: `[[work/z/Docker]]`.
+3. **Never use bare `[[Docker]]`** going forward; always path-qualify.
+
+The preferred pattern is #1: keep canonical content in `Zettelkasten/`, make `work/z/` a tiny redirect stub.
+
+
+## Detection
+
+```bash
+
+# Build a set of note basenames
+fd -e md -x basename {} .md
+
+
+# Find all wikilinks
+rg -o '\[\[([^\]|#]+)' --no-filename --glob '*.md'
+
+
+# Broken links: pipe the above through comm(1) against the basename set
+```
+
+A more accurate scan uses the `links.analyze_links` analyzer in vault-agent, which handles aliases, sections, and embeds correctly.
+
+
+## Offline Fallback (App Closed)
+
+The detection methodology above is unchanged — only the **data source** changes when Obsidian (and its `obsidian` CLI / live link index) is closed. The `obsidian` CLI and `vault-agent` analyzers are the **live-index** path; parsing the `.md` corpus directly with the `rg`/`fd` Detection snippet above is the **deterministic headless default**, and for batch/scheduled audits it is often the better choice (reproducible, free of app/index state). `vault-frontmatter` already operates this way.
+
+Parse the corpus directly:
+
+- **Frontmatter** — read each note's YAML block between the leading `---` fences; extract `tags`, `aliases`, `context`. See `vault-frontmatter` for YAML-block mechanics.
+- **Wikilinks** — match `[[Target]]`, `[[Target|Alias]]`, `[[Target#Heading]]`, `[[folder/Target]]`, and `![[embed]]`. Resolve each target to a note by **basename**, then **relative path**, then **alias** (from frontmatter), all **case-insensitive**. Resolve `![[embed]]` against attachments as well as notes — the attachment folder is per-vault configurable, so read it from `.obsidian/app.json` (`attachmentFolderPath`) and fall back to the vault root / `Files/` only when that key is unset.
+
+A link is **broken** when its target resolves to no note after the basename → relpath → alias (case-insensitive) cascade — embeds against attachments included. A target is **ambiguous** when its basename matches 2+ notes (the cross-namespace case above). Feed the Detection snippet's output through this resolution cascade to reproduce the `unresolved` audit headlessly.
+
+
+## Rewriting Strategy
+
+For a known-broken target with many references, rewrite in one commit:
+
+```
+fix(links): rewrite 44 × [[OldTopic]] → [[Topic]]
+```
+
+Use `Edit` with `replace_all=True` for the target string within each note. Don't use shell `sed` — it doesn't handle the frontmatter / codeblock boundary correctly, and Edit's per-file atomicity makes the commit review straightforward.
+
+For small-count broken targets (1–2 references each), report them and let the user decide whether to delete the link, create the note, or redirect.
+
+
+## Ambiguous-Target Handling
+
+Never auto-rewrite an ambiguous link. Report the ambiguity with both candidates and report to the orchestrator which resolution they want:
+
+```
+[[Docker]] in Zettelkasten/Kubernetes.md → candidates:
+  a) Zettelkasten/Docker.md
+  b) work/z/Docker.md (redirect stub)
+```
+
+
+## Safety
+
+- Never rewrite links inside code blocks or YAML frontmatter.
+- Never auto-create missing target notes — that's a content decision, not a maintenance one.
+- Preserve the alias form: `[[Ansible|my ansible]]` → `[[Ansible|my ansible]]`, not `[[Ansible]]`.

--- a/vault-agent/src/vault_agent/prompts/generated/vault-links_skills.md
+++ b/vault-agent/src/vault_agent/prompts/generated/vault-links_skills.md
@@ -1,0 +1,185 @@
+## vault-wikilinks
+
+# Wikilink Integrity
+
+
+## Link Syntax
+
+```markdown
+[[Note Name]]                      # basename resolution
+[[Note Name|Alias]]                # custom display text
+[[Note Name#Section heading]]      # deep link to heading
+[[folder/Note Name]]               # path-qualified (usually unnecessary)
+![[Image.png]]                     # embed (image, note, PDF)
+```
+
+
+## Resolution Rules
+
+1. **Unqualified target** (`[[Docker]]`) resolves to any note with basename `Docker.md`. If two exist (e.g. `Zettelkasten/Docker.md` and `work/z/Docker.md`), Obsidian picks one non-deterministically — ambiguous.
+2. **Path-qualified target** (`[[Kanban/Main]]`) resolves to `Kanban/Main.md` exactly — no basename fallback.
+3. **Embeds** (`![[X]]`) follow the same resolution. Image embeds typically target files under `Files/`.
+
+
+## Common Breakage Patterns
+
+| Pattern | Fix |
+|---------|-----|
+| `[[OldTopic]]` × many → note doesn't exist | Rewrite to `[[Topic]]` (the actual note) |
+| `[[Development MOC]]` → note was renamed | Rewrite to `[[Development Workflows and Tools MOC]]` |
+| `[[Kanban/X]]` → works but path-qualified is brittle | Rewrite to `[[X]]` when basename is unique |
+| `[[code]]`, `[[project]]` → never were real notes | These were inline-tag syntax errors; delete the link and leave plain text |
+| `[[Gen AI  Some Idea]]` (double space) | Fix the extra whitespace in the link |
+
+
+## Cross-Namespace Ambiguity
+
+When two notes share a basename (e.g. `Docker.md` in both `Zettelkasten/` and `work/z/`), every `[[Docker]]` in the vault becomes ambiguous. Options:
+
+1. **Rename one** so they stop colliding (`work/z/Docker.md` → keep as redirect stub; content lives in `Zettelkasten/Docker.md`).
+2. **Path-qualify the links** that should resolve to the non-canonical copy: `[[work/z/Docker]]`.
+3. **Never use bare `[[Docker]]`** going forward; always path-qualify.
+
+The preferred pattern is #1: keep canonical content in `Zettelkasten/`, make `work/z/` a tiny redirect stub.
+
+
+## Detection
+
+```bash
+
+# Build a set of note basenames
+fd -e md -x basename {} .md
+
+
+# Find all wikilinks
+rg -o '\[\[([^\]|#]+)' --no-filename --glob '*.md'
+
+
+# Broken links: pipe the above through comm(1) against the basename set
+```
+
+A more accurate scan uses the `links.analyze_links` analyzer in vault-agent, which handles aliases, sections, and embeds correctly.
+
+
+## Offline Fallback (App Closed)
+
+The detection methodology above is unchanged — only the **data source** changes when Obsidian (and its `obsidian` CLI / live link index) is closed. The `obsidian` CLI and `vault-agent` analyzers are the **live-index** path; parsing the `.md` corpus directly with the `rg`/`fd` Detection snippet above is the **deterministic headless default**, and for batch/scheduled audits it is often the better choice (reproducible, free of app/index state). `vault-frontmatter` already operates this way.
+
+Parse the corpus directly:
+
+- **Frontmatter** — read each note's YAML block between the leading `---` fences; extract `tags`, `aliases`, `context`. See `vault-frontmatter` for YAML-block mechanics.
+- **Wikilinks** — match `[[Target]]`, `[[Target|Alias]]`, `[[Target#Heading]]`, `[[folder/Target]]`, and `![[embed]]`. Resolve each target to a note by **basename**, then **relative path**, then **alias** (from frontmatter), all **case-insensitive**. Resolve `![[embed]]` against attachments as well as notes — the attachment folder is per-vault configurable, so read it from `.obsidian/app.json` (`attachmentFolderPath`) and fall back to the vault root / `Files/` only when that key is unset.
+
+A link is **broken** when its target resolves to no note after the basename → relpath → alias (case-insensitive) cascade — embeds against attachments included. A target is **ambiguous** when its basename matches 2+ notes (the cross-namespace case above). Feed the Detection snippet's output through this resolution cascade to reproduce the `unresolved` audit headlessly.
+
+
+## Rewriting Strategy
+
+For a known-broken target with many references, rewrite in one commit:
+
+```
+fix(links): rewrite 44 × [[OldTopic]] → [[Topic]]
+```
+
+Use `Edit` with `replace_all=True` for the target string within each note. Don't use shell `sed` — it doesn't handle the frontmatter / codeblock boundary correctly, and Edit's per-file atomicity makes the commit review straightforward.
+
+For small-count broken targets (1–2 references each), report them and let the user decide whether to delete the link, create the note, or redirect.
+
+
+## Ambiguous-Target Handling
+
+Never auto-rewrite an ambiguous link. Report the ambiguity with both candidates and report to the orchestrator which resolution they want:
+
+```
+[[Docker]] in Zettelkasten/Kubernetes.md → candidates:
+  a) Zettelkasten/Docker.md
+  b) work/z/Docker.md (redirect stub)
+```
+
+
+## Safety
+
+- Never rewrite links inside code blocks or YAML frontmatter.
+- Never auto-create missing target notes — that's a content decision, not a maintenance one.
+- Preserve the alias form: `[[Ansible|my ansible]]` → `[[Ansible|my ansible]]`, not `[[Ansible]]`.
+
+---
+
+## vault-orphans
+
+# Orphan Triage
+
+
+## Classes of Orphan
+
+| Class | Where | Treat as |
+|-------|-------|----------|
+| Inbox items | `Inbox/*.md` | Expected; process via `/process-inbox` |
+| Daily notes | `Notes/YYYY-MM-DD.md`, `work/notes/…` | Expected; they link out but rarely in |
+| Standalone references | `Zettelkasten/*.md` with 0↔0 | **Meaningful** — add linkage |
+| Kanban board notes | `Kanban/*.md` | Usually acceptable; boards are self-contained |
+| Archive / logs | under `Archive/` subfolders | Expected; stale by design |
+
+The vault-agent graph analyzer classifies each automatically.
+
+
+## Offline Fallback (App Closed)
+
+The detection methodology above is unchanged — only the **data source** changes when Obsidian (and its `obsidian` CLI / live link index) is closed. The `obsidian` CLI and `vault-agent` analyzers are the **live-index** path; parsing the `.md` corpus directly with Glob/Grep is the **deterministic headless default**, and for batch/scheduled audits it is often the better choice (reproducible, free of app/index state). `vault-frontmatter` already operates this way.
+
+Parse the corpus directly:
+
+- **Frontmatter** — read each note's YAML block between the leading `---` fences; extract `tags`, `aliases`, `context`. See `vault-frontmatter` for YAML-block mechanics.
+- **Wikilinks** — match `[[Target]]`, `[[Target|Alias]]`, `[[Target#Heading]]`, `[[folder/Target]]`, and `![[embed]]`. Resolve each target to a note by **basename**, then **relative path**, then **alias** (from frontmatter), all **case-insensitive**. Resolve `![[embed]]` against attachments as well as notes — the attachment folder is per-vault configurable, so read it from `.obsidian/app.json` (`attachmentFolderPath`) and fall back to the vault root / `Files/` only when that key is unset.
+
+Build the link graph from the resolved wikilinks: a note is an orphan when no resolved link targets it (zero incoming) **and** it emits no link that resolves (zero outgoing). The class table above (Inbox / daily / Archive) is path-derived and works identically offline.
+
+
+## Triage Workflow
+
+For each meaningful orphan:
+
+1. **Read the note** — is the content still relevant, or is this old/dead content?
+2. **Identify its primary category** — by tag (e.g., `🛠️/neovim` → Neovim MOC) or by title.
+3. **Pick ONE action:**
+   - **Link from a MOC** — add `[[Note]]` to the appropriate MOC under the right section
+   - **Add an inbound link** from a closely related note
+   - **Archive** — move to an `Archive/` subfolder if no longer useful
+   - **Delete** — only if empty or entirely superseded
+
+
+## Never Do
+
+- **Don't add dummy links** like "See also: [[Random]]" just to take the note off the orphan list. That's link pollution.
+- **Don't create a new MOC** just to absorb one orphan — see `vault-mocs` for thresholds.
+- **Don't assume empty = orphan** — some orphans have substantive content that simply wasn't linked.
+
+
+## Linking Heuristics
+
+When adding a note to a MOC, match on:
+
+1. **Primary tag category** — a note tagged `🛠️/neovim` belongs in the Neovim MOC.
+2. **Content topic** — read the first paragraph; pick the MOC that covers that subject.
+3. **Existing cluster** — if notes `A`, `B`, `C` all link to each other but none link from a MOC, add the whole cluster to the MOC under one section heading.
+
+
+## MOC Section Placement
+
+MOCs typically have sections like `## Core Concepts`, `## Tools`, `## Specific Configurations`. Pick the most specific section that fits; create a new `## Something` section only if 3+ notes fall under the same new heading.
+
+
+## Batch Pattern
+
+Never modify 100+ MOC links in one commit — that's unreviewable. Use one commit per MOC:
+
+```
+feat(mocs): link 12 orphaned CLI tool notes into new CLI Tools MOC
+```
+
+
+## Safety
+
+- If a note is substantive and the user's writing style suggests it was important, lean toward linking rather than deleting.
+- If tags are contradictory or missing, link to a broader MOC rather than guessing a specific one.
+- Preserve any existing heading structure in the MOC when inserting links.

--- a/vault-agent/src/vault_agent/prompts/generated/vault-lint_skills.md
+++ b/vault-agent/src/vault_agent/prompts/generated/vault-lint_skills.md
@@ -1,0 +1,301 @@
+## vault-frontmatter
+
+# Vault Frontmatter Maintenance
+
+
+## Canonical Frontmatter Shape
+
+```yaml
+---
+tags:
+  - 🛠️/neovim       # emoji-prefixed category tag
+  - 📝/notes         # note-type tag
+context: work        # work-namespace notes only
+---
+```
+
+Rules:
+1. No `id:` field — removed from all current templates.
+2. 2–3 tags per note; every tag either `emoji/subcategory` or a bare note-type like `📝/moc`.
+3. No bare emoji placeholders (`📝`, `🌱`, `📝/🌱`) — they indicate the tag was never specified.
+4. No `null` tag values — YAML must be valid.
+5. Work-namespace notes (e.g. under `work/`) carry `context: work`; personal notes omit the field.
+
+
+## Detection Patterns
+
+| Issue | Grep pattern | Notes |
+|-------|--------------|-------|
+| Legacy `id:` | `^id:` inside frontmatter block | Strip entire line |
+| Bare placeholder tag | YAML tag value exactly `📝`, `🌱`, or `📝/🌱` | Remove if note has other useful tags; else leave |
+| Null tag | YAML tag value literally `null` | Remove list entry |
+| Templater leak | `<% tp\.` or `\{\{title\}\}` or `\{\{date\}\}` | Replace `{{title}}` with filename stem; strip `<% tp.* %>` |
+| Corrupt emoji | Tag contains Unicode replacement char `\ufffd` | Flag for manual fix — don't guess |
+| Missing work context | File under the work namespace (e.g. `work/`) without `context: work` | Add the line |
+
+
+## Edit Recipes
+
+
+### Strip legacy id
+Before:
+```yaml
+---
+id: 20240118235900
+tags: [🛠️/neovim]
+---
+```
+After:
+```yaml
+---
+tags: [🛠️/neovim]
+---
+```
+
+
+### Remove bare placeholder (keeping useful tags)
+Before:
+```yaml
+tags:
+  - 📝
+  - 🛠️/ansible
+```
+After:
+```yaml
+tags:
+  - 🛠️/ansible
+```
+
+
+### Legacy MOC tag → current
+Before:
+```yaml
+tags:
+  - 🗺️
+```
+After:
+```yaml
+tags:
+  - 📝/moc
+```
+
+
+## Edit Pattern
+
+Use `Edit` with small targeted `old_string` / `new_string` replacements that preserve exact indentation. Never rewrite whole files when a line edit suffices — it minimizes the commit diff and makes reviews easy.
+
+For bulk fixes across many files, drive from a script that emits one `Edit` call per file rather than running `sed` in `Bash`. The commit-per-category pattern (`fix(tags): strip bare 📝 from 639 notes`) relies on keeping all edits in one logical batch.
+
+
+## Safety
+
+- Never write to `.obsidian/`, `.claude/`, `.git/`, `Files/`. The safety hook enforces this.
+- Never add frontmatter to daily notes in `Notes/` or `work/notes/` without verifying — they often don't need any.
+- When in doubt about what a placeholder tag meant, leave the note unchanged and report it rather than guess.
+
+---
+
+## vault-tags
+
+# Vault Tag Taxonomy
+
+
+## Canonical Categories
+
+| Emoji | Category | Examples |
+|-------|----------|----------|
+| `🛠️` | Development tools | `🛠️/neovim`, `🛠️/git`, `🛠️/terminal` |
+| `💻` | Programming languages | `💻/python`, `💻/rust`, `💻/typescript` |
+| `☁️` | Systems & infrastructure | `☁️/kubernetes`, `☁️/docker`, `☁️/linux` |
+| `🔌` | Hardware & IoT | `🔌/esp32`, `🔌/arduino`, `🔌/electronics` |
+| `🏠` | Home automation | `🏠/home-assistant`, `🏠/esphome` |
+| `🎮` | Entertainment | `🎮/games`, `🎮/tabletop` |
+| `🤖` | AI & ML | `🤖/comfyui`, `🤖/llm`, `🤖/ai-tools` |
+
+
+### Note-Type Tags
+
+| Tag | Meaning |
+|-----|---------|
+| `📝/moc` | Map of Content |
+| `📝/notes` | General note |
+| `📝/collection` | Resource collection |
+| `📝/guide` | How-to guide |
+| `📋/reference` | Quick reference material |
+| `📋/commands` | Command-line reference |
+| `📅/daily` | Daily note |
+
+
+## Consolidation Table
+
+When auditing reveals duplicate or drifted tags, apply these rewrites:
+
+| Drift / Legacy | Canonical | Reason |
+|----------------|-----------|--------|
+| `🗺️` | `📝/moc` | Old MOC marker |
+| `🔒/security` | `🔍/security` | Standardize on search emoji |
+| `🎨/comfyui` | `🤖/comfyui` | ComfyUI lives under AI |
+| `gaming` | `🎮/games` | Flat → emoji-prefixed |
+| `neovim` (flat) | `🛠️/neovim` | Flat → emoji-prefixed |
+| `softwaredevelopment` | `💻/development` | Concatenated → slash |
+| `project` / `projects` | `💡/project` | Pick one plural form |
+| `Hardware` (title-cased) | `🔌/hardware` | Lowercase, emoji-prefixed |
+
+
+## Bare Placeholder Tags
+
+The tags `📝`, `🌱`, `📝/🌱` are no-ops left over from unfinished template rendering. Treatment:
+
+- If the note has **other useful tags**, remove the placeholder.
+- If the note has **only** a placeholder, leave it flagged for manual review — removing would leave the note untagged, which is a different (but real) problem.
+
+
+## Over-Tagging
+
+More than 5 tags suggests the note mixes topics and should be split, or that tags are being used as keywords. Bring it down to 2–3 by asking "what single category is this note about?" — the rest go in the body as text.
+
+
+## Detection
+
+```bash
+
+# Notes with a bare 📝 or 🌱 tag on its own line
+rg -l '^\s*-\s+(📝|🌱|📝/🌱)\s*$' --glob '*.md'
+
+
+# Notes with competing security prefixes
+rg -l '🔒/security' --glob '*.md'
+rg -l '🔍/security' --glob '*.md'
+
+
+# Flat (non-emoji-prefix) tags
+rg '^\s*-\s+[a-z][a-z0-9_-]+\s*$' --glob '*.md'
+```
+
+
+## Offline Fallback (App Closed)
+
+The detection methodology above is unchanged — only the **data source** changes when Obsidian (and its `obsidian` CLI / live tag index) is closed. The `obsidian tags`/`tag` queries in `search-discovery` are the **live-index** path; parsing the `.md` corpus directly with the `rg` Detection snippets above is the **deterministic headless default**, and for batch/scheduled audits it is often the better choice (reproducible, free of app/index state). `vault-frontmatter` already operates this way.
+
+Tag taxonomy is pure frontmatter — read each note's YAML block between the leading `---` fences and extract `tags` (and `aliases` / `context` where relevant); see `vault-frontmatter` for YAML-block mechanics. The consolidation and bare-placeholder passes need no running app: the `rg` snippets above read tags straight from the files.
+
+
+## Edit Pattern
+
+For each note, use `Edit` with a small `old_string` / `new_string` that touches only the affected tag lines. Preserve indentation and the rest of the frontmatter block exactly.
+
+When renaming a tag across the whole vault, batch into one commit titled `fix(tags): consolidate 🔒/security → 🔍/security (N notes)`.
+
+
+## Anti-Patterns
+
+- Do **not** invent new categories. Use the table above; propose additions via a conventional commit if truly needed.
+- Do **not** use spaces inside tag values (`AI tools` → `🤖/ai-tools`).
+- Do **not** use multiple emoji in one tag (`🛠️🔌/esp32` — pick one).
+- Do **not** add tags purely for search — search works on content and filenames already.
+
+---
+
+## vault-templates
+
+# Templater Convention & Drift Repair
+
+
+## Unrendered Markers
+
+| Marker | Meaning | Fix |
+|--------|---------|-----|
+| `<% tp.file.cursor(N) %>` | Cursor position placeholder | Strip the entire tag |
+| `<% tp.file.title %>` | Filename stem | Replace with actual filename (no `.md`) |
+| `<% tp.date.now("YYYY-MM-DD") %>` | Today's date | Replace with the creation date from frontmatter, or the filename date for daily notes |
+| `{{title}}` | Filename stem (legacy) | Replace with filename stem |
+| `{{date}}` | Today's date (legacy) | Same as above |
+| `<% await tp.system.prompt(...) %>` | User prompt | Strip; requires user to refill |
+
+
+## Detection
+
+```bash
+
+# Find any Templater leak
+rg '<%\s*tp\.' --glob '*.md'
+rg '\{\{title\}\}|\{\{date\}\}' --glob '*.md'
+```
+
+
+## Fixing `<% tp.file.cursor(1) %>`
+
+Before:
+```markdown
+---
+tags: [📝/notes]
+---
+
+<% tp.file.cursor(1) %>
+```
+
+After:
+```markdown
+---
+tags: [📝/notes]
+---
+```
+
+Use `Edit` with `old_string='\n\n<% tp.file.cursor(1) %>'` and `new_string=''` (or adjust for trailing whitespace) — the cursor marker never has meaningful content around it.
+
+
+## Fixing `{{title}}` in daily notes
+
+Before (file `work/notes/2025-03-26.md`):
+```markdown
+
+# {{title}}
+
+
+## Log
+```
+
+After:
+```markdown
+
+# 2025-03-26
+
+
+## Log
+```
+
+Use the filename stem (no `.md`). Don't replace `{{title}}` inside code blocks or quoted text — only in headings / body.
+
+
+## Canonical Template Files
+
+The templates themselves live in `Templates/` and should contain raw Templater syntax — never "fix" them. Only fix notes outside `Templates/`.
+
+| Template | Produces | Sections |
+|----------|----------|----------|
+| `Daily.md` | `Notes/YYYY-MM-DD.md` | Quick Links, Today's Focus, Work, Personal, Tomorrow's Prep, Navigation |
+| `MOC.md` | `Zettelkasten/{Subject} MOC.md` | Title heading + sections |
+| `New.md` | general Zettelkasten notes | Frontmatter + body stub |
+| `Work Daily.md` | `work/notes/YYYY-MM-DD.md` | Log, Thoughts, Discoveries, Todo, Recurring reminders |
+
+
+## Daily Note Structure Drift
+
+Personal daily notes created before 2025 usually lack `## Navigation` and `## Tomorrow's Prep`. Two remediation options:
+
+1. **Retrofit template** — add the missing sections to every old daily note. Usually not worth the diff; users rarely look at old daily notes.
+2. **Leave as-is** — document the change boundary in a single commit message and let old notes age.
+
+Default to #2 unless the user specifically asks for retrofit.
+
+
+## Work Daily Note Drift
+
+Work-namespace daily notes that contain literal `{{title}}` in the heading — fix these.
+
+
+## Safety
+
+- Never edit `Templates/*.md` when fixing leakage — templates are supposed to contain Templater syntax.
+- Never run a blanket `sed -i 's/{{title}}/.../'` — always use file-specific `Edit` calls so the title derivation is correct per file.
+- When you encounter `<% tp.system.prompt(...) %>`, don't guess the answer — flag for user.

--- a/vault-agent/src/vault_agent/prompts/generated/vault-mocs_skills.md
+++ b/vault-agent/src/vault_agent/prompts/generated/vault-mocs_skills.md
@@ -1,0 +1,320 @@
+## vault-mocs
+
+# MOC Curation
+
+
+## Canonical MOC Shape
+
+```markdown
+---
+tags: [📝/moc]
+---
+
+
+# Neovim MOC
+
+Central hub for Neovim configuration, plugins, and workflows.
+
+
+## Core
+
+- [[Neovim]] — base configuration
+- [[Lazy.nvim]] — plugin management
+
+
+## Plugins
+
+- [[nvim-treesitter]]
+- [[Mason LSP]]
+
+
+## Keybindings and Workflow
+
+- [[Neovim Keybindings]]
+- [[Neovim Session Management]]
+```
+
+Rules:
+1. Tag is **exactly** `📝/moc` — not `🗺️` (legacy), not `MOC` (flat), not `📝/MOC` (wrong case).
+2. File lives in `Zettelkasten/` (personal) or `work/MOC/` (work).
+3. Filename is `{Subject} MOC.md` — suffix, not prefix.
+4. Body has a one-paragraph description, then `##` section headings, then bullet-list wikilinks.
+5. Never has `id:` or other legacy frontmatter.
+
+
+## Legacy MOC Fixups
+
+| Issue | Fix |
+|-------|-----|
+| `tags: 🗺️` | Rewrite to `tags: [📝/moc]` |
+| `tags: [🗺, 📝/moc]` | Deduplicate to `tags: [📝/moc]` |
+| MOC in `work/z/` instead of `work/MOC/` | Move file |
+| Uses `[[Kanban/Foo]]` path-qualified links | Rewrite to `[[Foo]]` when basename unique |
+
+
+## Coverage Analysis
+
+For each tag category (`🛠️/`, `🔌/`, `💻/`, etc.), the vault-agent `mocs.analyze_mocs` analyzer reports how many tagged notes are NOT linked from any MOC. High uncovered counts indicate:
+
+- **Missing MOC** — the category has 10+ notes but no MOC exists.
+- **Stale MOC** — the MOC exists but hasn't been updated with recent additions.
+- **Tag mismatch** — notes are tagged but don't belong in the relevant MOC.
+
+
+## Offline Fallback (App Closed)
+
+The detection methodology above is unchanged — only the **data source** changes when Obsidian (and its `obsidian` CLI / live link index) is closed. The `obsidian` CLI and `vault-agent` analyzers are the **live-index** path; parsing the `.md` corpus directly with Glob/Grep is the **deterministic headless default**, and for batch/scheduled audits it is often the better choice (reproducible, free of app/index state). `vault-frontmatter` already operates this way.
+
+Parse the corpus directly:
+
+- **Frontmatter** — read each note's YAML block between the leading `---` fences; extract `tags`, `aliases`, `context`. See `vault-frontmatter` for YAML-block mechanics.
+- **Wikilinks** — match `[[Target]]`, `[[Target|Alias]]`, `[[Target#Heading]]`, `[[folder/Target]]`, and `![[embed]]`. Resolve each target to a note by **basename**, then **relative path**, then **alias** (from frontmatter), all **case-insensitive**. Resolve `![[embed]]` against attachments as well as notes — the attachment folder is per-vault configurable, so read it from `.obsidian/app.json` (`attachmentFolderPath`) and fall back to the vault root / `Files/` only when that key is unset.
+
+Coverage analysis offline: for each tag category, count notes whose parsed frontmatter `tags` place them in the category but which no `📝/moc`-tagged note links to (via the resolution cascade). That is the same uncovered count `mocs.analyze_mocs` produces from the live index.
+
+
+## Creating a New MOC
+
+Thresholds (heuristic):
+- ≥ 10 tagged notes in the category AND
+- No existing MOC covers them AND
+- Notes share enough subject to belong in one hub
+
+If all three hold, create `Zettelkasten/{Category} MOC.md`:
+
+```markdown
+---
+tags: [📝/moc]
+---
+
+
+# {Category} MOC
+
+{One-paragraph framing of the category.}
+
+
+## {Section}
+
+- [[Note1]]
+- [[Note2]]
+```
+
+Pick 2–4 `##` sections that reflect natural groupings within the notes — don't force a deep hierarchy.
+
+
+## Extending an Existing MOC
+
+When the analyzer reports orphaned notes that belong in an existing MOC:
+
+1. Read the MOC and find the most appropriate `##` section (or create a new one if 3+ notes fit a new grouping).
+2. Add wikilinks one per bullet, alphabetical within the section.
+3. Keep descriptions brief — one short phrase per link at most.
+
+Don't add a "See also" or "Random" section as a dumping ground. If a note doesn't fit any section, reconsider whether it belongs in this MOC at all.
+
+
+## Never Do
+
+- **Don't create nested MOCs** (MOC of MOCs) unless the vault has 20+ MOCs that justify a top-level index.
+- **Don't dataview-generate MOC content** in place of hand-curated links. Dataview is fine for supplementary sections ("Recent notes in this category"), but the primary content should be hand-picked.
+- **Don't add the `📝/moc` tag to a note that isn't actually a MOC** — it pollutes MOC inventories.
+- **Don't rename existing MOCs** without updating every link (use `vault-wikilinks` rewrite patterns).
+
+
+## Commit Messages
+
+| Action | Commit |
+|--------|--------|
+| New MOC | `feat(mocs): add {Category} MOC covering N notes` |
+| Fixup tag | `fix(mocs): 🗺️ → 📝/moc on work MOCs` |
+| Add orphans | `feat(mocs): link 12 notes into Neovim MOC` |
+| Rewrite path-qualified link | `fix(mocs): unqualify [[Kanban/X]] → [[X]] across 6 MOCs` |
+
+
+## Safety
+
+- Never modify a MOC's section structure without the user's input — they reflect the user's mental model.
+- When adding links, preserve the user's existing sort order (alphabetical, chronological, by-importance — look at the first section to infer).
+- Don't link notes that are tagged but clearly off-topic for the MOC.
+
+---
+
+## vault-tags
+
+# Vault Tag Taxonomy
+
+
+## Canonical Categories
+
+| Emoji | Category | Examples |
+|-------|----------|----------|
+| `🛠️` | Development tools | `🛠️/neovim`, `🛠️/git`, `🛠️/terminal` |
+| `💻` | Programming languages | `💻/python`, `💻/rust`, `💻/typescript` |
+| `☁️` | Systems & infrastructure | `☁️/kubernetes`, `☁️/docker`, `☁️/linux` |
+| `🔌` | Hardware & IoT | `🔌/esp32`, `🔌/arduino`, `🔌/electronics` |
+| `🏠` | Home automation | `🏠/home-assistant`, `🏠/esphome` |
+| `🎮` | Entertainment | `🎮/games`, `🎮/tabletop` |
+| `🤖` | AI & ML | `🤖/comfyui`, `🤖/llm`, `🤖/ai-tools` |
+
+
+### Note-Type Tags
+
+| Tag | Meaning |
+|-----|---------|
+| `📝/moc` | Map of Content |
+| `📝/notes` | General note |
+| `📝/collection` | Resource collection |
+| `📝/guide` | How-to guide |
+| `📋/reference` | Quick reference material |
+| `📋/commands` | Command-line reference |
+| `📅/daily` | Daily note |
+
+
+## Consolidation Table
+
+When auditing reveals duplicate or drifted tags, apply these rewrites:
+
+| Drift / Legacy | Canonical | Reason |
+|----------------|-----------|--------|
+| `🗺️` | `📝/moc` | Old MOC marker |
+| `🔒/security` | `🔍/security` | Standardize on search emoji |
+| `🎨/comfyui` | `🤖/comfyui` | ComfyUI lives under AI |
+| `gaming` | `🎮/games` | Flat → emoji-prefixed |
+| `neovim` (flat) | `🛠️/neovim` | Flat → emoji-prefixed |
+| `softwaredevelopment` | `💻/development` | Concatenated → slash |
+| `project` / `projects` | `💡/project` | Pick one plural form |
+| `Hardware` (title-cased) | `🔌/hardware` | Lowercase, emoji-prefixed |
+
+
+## Bare Placeholder Tags
+
+The tags `📝`, `🌱`, `📝/🌱` are no-ops left over from unfinished template rendering. Treatment:
+
+- If the note has **other useful tags**, remove the placeholder.
+- If the note has **only** a placeholder, leave it flagged for manual review — removing would leave the note untagged, which is a different (but real) problem.
+
+
+## Over-Tagging
+
+More than 5 tags suggests the note mixes topics and should be split, or that tags are being used as keywords. Bring it down to 2–3 by asking "what single category is this note about?" — the rest go in the body as text.
+
+
+## Detection
+
+```bash
+
+# Notes with a bare 📝 or 🌱 tag on its own line
+rg -l '^\s*-\s+(📝|🌱|📝/🌱)\s*$' --glob '*.md'
+
+
+# Notes with competing security prefixes
+rg -l '🔒/security' --glob '*.md'
+rg -l '🔍/security' --glob '*.md'
+
+
+# Flat (non-emoji-prefix) tags
+rg '^\s*-\s+[a-z][a-z0-9_-]+\s*$' --glob '*.md'
+```
+
+
+## Offline Fallback (App Closed)
+
+The detection methodology above is unchanged — only the **data source** changes when Obsidian (and its `obsidian` CLI / live tag index) is closed. The `obsidian tags`/`tag` queries in `search-discovery` are the **live-index** path; parsing the `.md` corpus directly with the `rg` Detection snippets above is the **deterministic headless default**, and for batch/scheduled audits it is often the better choice (reproducible, free of app/index state). `vault-frontmatter` already operates this way.
+
+Tag taxonomy is pure frontmatter — read each note's YAML block between the leading `---` fences and extract `tags` (and `aliases` / `context` where relevant); see `vault-frontmatter` for YAML-block mechanics. The consolidation and bare-placeholder passes need no running app: the `rg` snippets above read tags straight from the files.
+
+
+## Edit Pattern
+
+For each note, use `Edit` with a small `old_string` / `new_string` that touches only the affected tag lines. Preserve indentation and the rest of the frontmatter block exactly.
+
+When renaming a tag across the whole vault, batch into one commit titled `fix(tags): consolidate 🔒/security → 🔍/security (N notes)`.
+
+
+## Anti-Patterns
+
+- Do **not** invent new categories. Use the table above; propose additions via a conventional commit if truly needed.
+- Do **not** use spaces inside tag values (`AI tools` → `🤖/ai-tools`).
+- Do **not** use multiple emoji in one tag (`🛠️🔌/esp32` — pick one).
+- Do **not** add tags purely for search — search works on content and filenames already.
+
+---
+
+## vault-orphans
+
+# Orphan Triage
+
+
+## Classes of Orphan
+
+| Class | Where | Treat as |
+|-------|-------|----------|
+| Inbox items | `Inbox/*.md` | Expected; process via `/process-inbox` |
+| Daily notes | `Notes/YYYY-MM-DD.md`, `work/notes/…` | Expected; they link out but rarely in |
+| Standalone references | `Zettelkasten/*.md` with 0↔0 | **Meaningful** — add linkage |
+| Kanban board notes | `Kanban/*.md` | Usually acceptable; boards are self-contained |
+| Archive / logs | under `Archive/` subfolders | Expected; stale by design |
+
+The vault-agent graph analyzer classifies each automatically.
+
+
+## Offline Fallback (App Closed)
+
+The detection methodology above is unchanged — only the **data source** changes when Obsidian (and its `obsidian` CLI / live link index) is closed. The `obsidian` CLI and `vault-agent` analyzers are the **live-index** path; parsing the `.md` corpus directly with Glob/Grep is the **deterministic headless default**, and for batch/scheduled audits it is often the better choice (reproducible, free of app/index state). `vault-frontmatter` already operates this way.
+
+Parse the corpus directly:
+
+- **Frontmatter** — read each note's YAML block between the leading `---` fences; extract `tags`, `aliases`, `context`. See `vault-frontmatter` for YAML-block mechanics.
+- **Wikilinks** — match `[[Target]]`, `[[Target|Alias]]`, `[[Target#Heading]]`, `[[folder/Target]]`, and `![[embed]]`. Resolve each target to a note by **basename**, then **relative path**, then **alias** (from frontmatter), all **case-insensitive**. Resolve `![[embed]]` against attachments as well as notes — the attachment folder is per-vault configurable, so read it from `.obsidian/app.json` (`attachmentFolderPath`) and fall back to the vault root / `Files/` only when that key is unset.
+
+Build the link graph from the resolved wikilinks: a note is an orphan when no resolved link targets it (zero incoming) **and** it emits no link that resolves (zero outgoing). The class table above (Inbox / daily / Archive) is path-derived and works identically offline.
+
+
+## Triage Workflow
+
+For each meaningful orphan:
+
+1. **Read the note** — is the content still relevant, or is this old/dead content?
+2. **Identify its primary category** — by tag (e.g., `🛠️/neovim` → Neovim MOC) or by title.
+3. **Pick ONE action:**
+   - **Link from a MOC** — add `[[Note]]` to the appropriate MOC under the right section
+   - **Add an inbound link** from a closely related note
+   - **Archive** — move to an `Archive/` subfolder if no longer useful
+   - **Delete** — only if empty or entirely superseded
+
+
+## Never Do
+
+- **Don't add dummy links** like "See also: [[Random]]" just to take the note off the orphan list. That's link pollution.
+- **Don't create a new MOC** just to absorb one orphan — see `vault-mocs` for thresholds.
+- **Don't assume empty = orphan** — some orphans have substantive content that simply wasn't linked.
+
+
+## Linking Heuristics
+
+When adding a note to a MOC, match on:
+
+1. **Primary tag category** — a note tagged `🛠️/neovim` belongs in the Neovim MOC.
+2. **Content topic** — read the first paragraph; pick the MOC that covers that subject.
+3. **Existing cluster** — if notes `A`, `B`, `C` all link to each other but none link from a MOC, add the whole cluster to the MOC under one section heading.
+
+
+## MOC Section Placement
+
+MOCs typically have sections like `## Core Concepts`, `## Tools`, `## Specific Configurations`. Pick the most specific section that fits; create a new `## Something` section only if 3+ notes fall under the same new heading.
+
+
+## Batch Pattern
+
+Never modify 100+ MOC links in one commit — that's unreviewable. Use one commit per MOC:
+
+```
+feat(mocs): link 12 orphaned CLI tool notes into new CLI Tools MOC
+```
+
+
+## Safety
+
+- If a note is substantive and the user's writing style suggests it was important, lean toward linking rather than deleting.
+- If tags are contradictory or missing, link to a broader MOC rather than guessing a specific one.
+- Preserve any existing heading structure in the MOC when inserting links.

--- a/vault-agent/src/vault_agent/prompts/generated/vault-stubs_skills.md
+++ b/vault-agent/src/vault_agent/prompts/generated/vault-stubs_skills.md
@@ -1,0 +1,214 @@
+## vault-stubs
+
+# Work-namespace Stub Management
+
+
+## Canonical Redirect Stub Format
+
+```yaml
+---
+tags: [redirect]
+context: work
+---
+See [[Zettelkasten/Docker|Docker]] in the main knowledge base.
+```
+
+Properties:
+- Size ≤ 200 bytes (whitespace excluded)
+- Tags is exactly `[redirect]`
+- Body is a single wikilink with alias to the canonical note
+- `context: work`
+
+
+## Classifications (from vault-agent's stubs analyzer)
+
+| Class | Meaning | Action |
+|-------|---------|--------|
+| `clean_redirect` | ≤ 200 B, `redirect` tag, Zettelkasten match | ✓ keep as-is |
+| `broken_redirect` | `redirect` tag but >200 B or missing target | Rewrite body to the canonical one-liner |
+| `stale_duplicate` | Full article, basename exists in Zettelkasten | Merge content into Zettelkasten, convert stub to `clean_redirect` |
+| `ns_original` | Full article, no Zettelkasten match | Legitimate — leave alone |
+
+
+## Consolidation: stale_duplicate → clean_redirect
+
+When a `work/z/Foo.md` has substantive content AND `Zettelkasten/Foo.md` exists, you must decide:
+
+1. **Is the work-namespace content a subset of Zettelkasten?** → Replace stub with canonical redirect. No content merge needed.
+2. **Does the work-namespace note have unique content?** → Merge the unique sections into `Zettelkasten/Foo.md` first, then replace stub.
+3. **Is the work-namespace note *better* than Zettelkasten?** → Rare, but flag for user review. The user decides which becomes canonical.
+
+
+### Merge Heuristic
+
+Compare by section. If a heading in `work/z/Foo.md` has text that doesn't appear in `Zettelkasten/Foo.md`, that text needs migration. Use word-level comparison, not exact match — minor wording differences don't count as "unique content."
+
+When in doubt, **flag for user review** rather than auto-merging. A bad merge is worse than leaving a duplicate.
+
+
+## Conversion Recipe
+
+Replace the whole work-namespace file body:
+
+```yaml
+---
+tags: [redirect]
+context: work
+---
+See [[Zettelkasten/Foo|Foo]] in the main knowledge base.
+```
+
+Commit message:
+```
+refactor(stubs): convert work/z/Foo.md to redirect (content merged into Zettelkasten)
+```
+
+
+## Promoting ns_original → Zettelkasten
+
+Occasionally a file classified `ns_original` is actually general-interest content that belongs in `Zettelkasten/`. Signs:
+- No work-specific references (internal check-ins, internal tools, internal URLs)
+- Could be useful in personal contexts
+
+If promoting:
+1. Move file to `Zettelkasten/Foo.md`
+2. Create a `work/z/Foo.md` redirect stub in its place
+3. Strip `context: work` from the promoted note's frontmatter
+4. Commit as `refactor(stubs): promote Foo from work/z to Zettelkasten`
+
+Don't promote aggressively — the work namespace exists for a reason.
+
+
+## Detection
+
+```bash
+
+# All work-namespace files ordered by size
+fd -e md . work/z -x wc -c {} | sort -n
+
+
+# Ones with `redirect` tag
+rg -l '^tags:.*\bredirect\b' work/z/ --glob '*.md'
+
+
+# Large ones without `redirect` tag (candidates for conversion)
+rg -L -l '^tags:.*\bredirect\b' work/z/ --glob '*.md'
+```
+
+Vault-agent's `analyze_stubs` gives the full classification.
+
+
+## Offline Fallback (App Closed)
+
+The detection methodology above is unchanged — only the **data source** changes when Obsidian (and its `obsidian` CLI / live link index) is closed. The `obsidian` CLI and `vault-agent` analyzers are the **live-index** path; parsing the `.md` corpus directly with the `fd`/`rg` Detection snippet above is the **deterministic headless default**, and for batch/scheduled audits it is often the better choice (reproducible, free of app/index state). `vault-frontmatter` already operates this way.
+
+Parse the corpus directly:
+
+- **Frontmatter** — read each note's YAML block between the leading `---` fences; extract `tags`, `aliases`, `context`. See `vault-frontmatter` for YAML-block mechanics.
+- **Wikilinks** — match `[[Target]]`, `[[Target|Alias]]`, `[[Target#Heading]]`, `[[folder/Target]]`, and `![[embed]]`. Resolve each target to a note by **basename**, then **relative path**, then **alias** (from frontmatter), all **case-insensitive**. Resolve `![[embed]]` against attachments as well as notes — the attachment folder is per-vault configurable, so read it from `.obsidian/app.json` (`attachmentFolderPath`) and fall back to the vault root / `Files/` only when that key is unset.
+
+Classify each stub from parsed inputs only: file size (`wc -c`), the `redirect` frontmatter tag, and a **basename** match against `Zettelkasten/` — the same inputs `analyze_stubs` uses. The redirect body's `[[Zettelkasten/Foo|Foo]]` target is verified with the resolution cascade above.
+
+
+## Safety
+
+- Never delete content without verifying it exists elsewhere. When merging, grep the destination note for a canonical phrase from the source.
+- Preserve `context: work` on stubs (required for work-namespace queries).
+- Don't create stubs for Zettelkasten notes that aren't actually used in work context — that creates noise, not redirection.
+
+---
+
+## vault-frontmatter
+
+# Vault Frontmatter Maintenance
+
+
+## Canonical Frontmatter Shape
+
+```yaml
+---
+tags:
+  - 🛠️/neovim       # emoji-prefixed category tag
+  - 📝/notes         # note-type tag
+context: work        # work-namespace notes only
+---
+```
+
+Rules:
+1. No `id:` field — removed from all current templates.
+2. 2–3 tags per note; every tag either `emoji/subcategory` or a bare note-type like `📝/moc`.
+3. No bare emoji placeholders (`📝`, `🌱`, `📝/🌱`) — they indicate the tag was never specified.
+4. No `null` tag values — YAML must be valid.
+5. Work-namespace notes (e.g. under `work/`) carry `context: work`; personal notes omit the field.
+
+
+## Detection Patterns
+
+| Issue | Grep pattern | Notes |
+|-------|--------------|-------|
+| Legacy `id:` | `^id:` inside frontmatter block | Strip entire line |
+| Bare placeholder tag | YAML tag value exactly `📝`, `🌱`, or `📝/🌱` | Remove if note has other useful tags; else leave |
+| Null tag | YAML tag value literally `null` | Remove list entry |
+| Templater leak | `<% tp\.` or `\{\{title\}\}` or `\{\{date\}\}` | Replace `{{title}}` with filename stem; strip `<% tp.* %>` |
+| Corrupt emoji | Tag contains Unicode replacement char `\ufffd` | Flag for manual fix — don't guess |
+| Missing work context | File under the work namespace (e.g. `work/`) without `context: work` | Add the line |
+
+
+## Edit Recipes
+
+
+### Strip legacy id
+Before:
+```yaml
+---
+id: 20240118235900
+tags: [🛠️/neovim]
+---
+```
+After:
+```yaml
+---
+tags: [🛠️/neovim]
+---
+```
+
+
+### Remove bare placeholder (keeping useful tags)
+Before:
+```yaml
+tags:
+  - 📝
+  - 🛠️/ansible
+```
+After:
+```yaml
+tags:
+  - 🛠️/ansible
+```
+
+
+### Legacy MOC tag → current
+Before:
+```yaml
+tags:
+  - 🗺️
+```
+After:
+```yaml
+tags:
+  - 📝/moc
+```
+
+
+## Edit Pattern
+
+Use `Edit` with small targeted `old_string` / `new_string` replacements that preserve exact indentation. Never rewrite whole files when a line edit suffices — it minimizes the commit diff and makes reviews easy.
+
+For bulk fixes across many files, drive from a script that emits one `Edit` call per file rather than running `sed` in `Bash`. The commit-per-category pattern (`fix(tags): strip bare 📝 from 639 notes`) relies on keeping all edits in one logical batch.
+
+
+## Safety
+
+- Never write to `.obsidian/`, `.claude/`, `.git/`, `Files/`. The safety hook enforces this.
+- Never add frontmatter to daily notes in `Notes/` or `work/notes/` without verifying — they often don't need any.
+- When in doubt about what a placeholder tag meant, leave the note unchanged and report it rather than guess.

--- a/vault-agent/tests/test_compiler_standalone.py
+++ b/vault-agent/tests/test_compiler_standalone.py
@@ -1,0 +1,111 @@
+"""Tests for the prompt compiler's standalone-install fallback.
+
+When ``vault-agent`` is installed standalone (e.g. via
+``uv tool install``), the sibling ``obsidian-plugin/skills/`` directory is
+not present. The compiler must fall back to the pre-compiled artifacts
+shipped under ``prompts/generated/`` instead of returning empty strings
+or raising ``FileNotFoundError``.
+
+These tests fake standalone mode by repointing ``_PLUGINS_ROOT`` at a
+directory that contains no ``obsidian-plugin/`` sibling, then re-checking
+the public compiler API.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vault_agent.prompts import compiler
+
+
+def _referenced_skill_relpaths() -> list[str]:
+    """Union of every skill path referenced by any subagent bundle."""
+    seen: set[str] = set()
+    for skill_paths in compiler.SUBAGENT_SKILLS.values():
+        seen.update(skill_paths)
+    return sorted(seen)
+
+
+@pytest.fixture
+def standalone_mode(tmp_path, monkeypatch):
+    """Repoint ``_PLUGINS_ROOT`` at an empty directory.
+
+    Live compilation will fail to find any source SKILL.md, exercising
+    the pre-compiled fallback path. The cache on ``get_compiled_prompt``
+    / ``get_compiled_skill`` must be cleared so the fallback runs.
+    """
+    monkeypatch.setattr(compiler, "_PLUGINS_ROOT", tmp_path)
+    compiler.get_compiled_prompt.cache_clear()
+    compiler.get_compiled_skill.cache_clear()
+    yield tmp_path
+    compiler.get_compiled_prompt.cache_clear()
+    compiler.get_compiled_skill.cache_clear()
+
+
+class TestSubagentFallback:
+    """``get_compiled_prompt()`` reads from generated/ when sources are absent."""
+
+    def test_each_subagent_has_a_fallback(self, standalone_mode):
+        for name in compiler.SUBAGENT_SKILLS:
+            generated = compiler._GENERATED_DIR / f"{name}_skills.md"
+            assert generated.exists(), (
+                f"Standalone install would have no fallback for subagent "
+                f"'{name}'. Run scripts/compile_prompts.py to regenerate "
+                f"{generated.relative_to(compiler._REPO_ROOT)}."
+            )
+
+    def test_fallback_returns_substantive_content(self, standalone_mode):
+        for name in compiler.SUBAGENT_SKILLS:
+            content = compiler.get_compiled_prompt(name)
+            assert len(content) > 500, (
+                f"Subagent '{name}' fallback returned only {len(content)} "
+                f"chars in standalone mode."
+            )
+
+
+class TestPerSkillFallback:
+    """``get_compiled_skill()`` reads from generated/skills/ when sources are absent."""
+
+    def test_each_referenced_skill_has_a_fallback(self, standalone_mode):
+        for relpath in _referenced_skill_relpaths():
+            fallback = compiler._generated_skill_path(relpath)
+            assert fallback.exists(), (
+                f"Standalone install would have no fallback for "
+                f"'{relpath}'. Run scripts/compile_prompts.py to "
+                f"regenerate {fallback.relative_to(compiler._REPO_ROOT)}."
+            )
+
+    def test_fallback_returns_skill_content(self, standalone_mode):
+        for relpath in _referenced_skill_relpaths():
+            content = compiler.get_compiled_skill(relpath)
+            assert content, (
+                f"Skill '{relpath}' returned empty content in standalone "
+                "mode despite a generated fallback file existing."
+            )
+
+    def test_fallback_path_mapping(self):
+        # ``<plugin>/skills/<skill>/SKILL.md`` →
+        #     ``generated/skills/<plugin>/<skill>.md``
+        rel = "obsidian-plugin/skills/vault-frontmatter/SKILL.md"
+        expected = (
+            compiler._GENERATED_SKILLS_DIR / "obsidian-plugin" / "vault-frontmatter.md"
+        )
+        assert compiler._generated_skill_path(rel) == expected
+
+    def test_missing_skill_with_no_fallback_raises(self, standalone_mode):
+        with pytest.raises(FileNotFoundError):
+            compiler.get_compiled_skill("nonexistent/skills/no-such/SKILL.md")
+
+
+class TestMonorepoTakesPrecedence:
+    """Live compilation wins when sources are present (dev mode)."""
+
+    def test_subagent_uses_live_sources(self):
+        # The default fixture-less test runs in monorepo mode: sources
+        # exist, so the result must match a fresh ``compile_subagent``.
+        compiler.get_compiled_prompt.cache_clear()
+        live = compiler.get_compiled_prompt("vault-lint")
+        skill_paths = compiler.SUBAGENT_SKILLS["vault-lint"]
+        if any(compiler._plugin_skill_available(p) for p in skill_paths):
+            assert live == compiler.compile_subagent("vault-lint", skill_paths)
+        compiler.get_compiled_prompt.cache_clear()


### PR DESCRIPTION
## Summary

Phase 0 of #1973 — the standalone-install prerequisite for extracting `vault-agent` into its own repo.

`vault-agent/src/vault_agent/prompts/compiler.py` read `obsidian-plugin` SKILL.md files from the monorepo at runtime and had **no standalone mode**, so `uv tool install vault-agent` outside the monorepo would compile empty prompts. This adds a two-mode compiler that mirrors how `git-repo-agent` already solved the same problem (its ADR-009).

### Design

The compiler now runs in two modes, selected at runtime:

- **Monorepo (dev) mode** — sibling `obsidian-plugin/skills/*/SKILL.md` sources exist; live-compile as before. Dev behaviour is unchanged.
- **Standalone (installed) mode** — sources absent; read pre-compiled artifacts shipped with the package under `prompts/generated/`:
  - subagent bundles: `generated/<subagent>_skills.md`
  - per-skill fragments: `generated/skills/<plugin>/<skill>.md`

`get_compiled_prompt()` live-compiles when any of a subagent's skills is present and falls back to the pre-compiled bundle otherwise; `get_compiled_skill()` falls back per skill, raising `FileNotFoundError` only when neither source nor generated artifact exists.

`scripts/compile_prompts.py` writes both artifact trees, with `--check` (non-zero exit on drift) and `--stdout`. Unlike `git-repo-agent`'s version it does **not** parse a blueprint driver — vault-agent has no blueprint state machine — so the per-skill artifacts are exactly the union of the skills the `SUBAGENT_SKILLS` bundles reference.

### Files added / changed

| File | Change |
|------|--------|
| `src/vault_agent/prompts/compiler.py` | modified — `_GENERATED_DIR`/`_GENERATED_SKILLS_DIR` constants, `_plugin_skill_available()`, `_generated_skill_path()`, fallback branches in `get_compiled_prompt()` and `get_compiled_skill()` |
| `scripts/compile_prompts.py` | new — build/`--check`/`--stdout` wrapper (new `scripts/` dir) |
| `src/vault_agent/prompts/generated/*_skills.md` (4) | new — pre-compiled subagent bundles |
| `src/vault_agent/prompts/generated/skills/obsidian-plugin/*.md` (7) | new — pre-compiled per-skill fragments |
| `tests/test_compiler_standalone.py` | new — standalone-mode regression test (repoints `_PLUGINS_ROOT` at an empty dir) |
| `docs/adr/0006-standalone-install-prompt-fallback.md` | new — ADR (mirrors ADR-009; refs #1973 and ADR-0005) |

### Verification

```
$ uv run pytest
167 passed in 10.55s

$ uv run python scripts/compile_prompts.py --check   # exit 0 (no drift)
$ uv run ruff check <changed files>                  # All checks passed!
$ uv run ruff format --check <changed files>         # clean
```

The standalone regression test (per `.claude/rules/regression-testing.md`) fakes standalone mode and asserts every subagent and every referenced skill resolves from `generated/`, plus the path mapping and the `FileNotFoundError` case.

> Note: `vault-agent` is not a release-please scope, so this `feat(vault-agent)` title intentionally produces no version bump — the correct/intended behaviour. It is not a published plugin, so no marketplace.json / release-please / manifest changes were made.

Refs #1973

**Addresses Phase 0 only; Phases 1–3 (repo creation, PyPI, sync workflow, monorepo removal) remain and require manual owner actions.**
