### PR TITLE
fix(hooks-plugin): demote ls→Glob exit-2 block to opt-in teach nudge

### DIFF
--- a/.claude/rules/bash-tool-replacements.md
+++ b/.claude/rules/bash-tool-replacements.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-05-11
-modified: 2026-07-04
-reviewed: 2026-07-04
+modified: 2026-07-10
+reviewed: 2026-07-10
 ---
 
 # Bash → Tool Replacements
@@ -13,25 +13,29 @@ faster, with structured output, and without paying the parallel-batch cost.
 The hook is a soft-block (exit 2) — by the time you read this, you've probably
 already been blocked. Use this table to pick the right replacement.
 
-> **`find` and `grep`/`rg` are no longer blocked.** Both redirects were demoted
-> from a hard block to an **opt-in teach nudge** (`bash-antipatterns-teach.sh`,
-> enabled via `CLAUDE_HOOKS_ENABLE_BASH_ANTIPATTERNS_TEACH=1`). Neither did safety
-> work: the `find→Glob` block always exempted the dangerous `-exec` form and only
+> **`find`, `grep`/`rg`, and `ls` are no longer blocked.** All three redirects
+> were demoted from a hard block to an **opt-in teach nudge**
+> (`bash-antipatterns-teach.sh`, enabled via
+> `CLAUDE_HOOKS_ENABLE_BASH_ANTIPATTERNS_TEACH=1`). None did safety work: the
+> `find→Glob` block always exempted the dangerous `-exec` form and only
 > blocked simple `-name` searches; the `grep/rg→Grep` block always exempted
 > pipelines, boolean `-q` checks, and `-l/-c/-L` filter modes, blocking only
-> benign line-numbered file reads. Both hard-dead-ended subagents whose toolset
-> doesn't grant `Glob`/`Grep` (PreToolUse hooks fire in every context; those tools
-> are not always available — #1909, where `ToolSearch(select:Grep)` returned "No
-> matching deferred tools found" and every blocked search cost a retry). `find`
-> and `grep`/`rg` in any form now pass. `Glob`/`Grep`/`fd` remain the most
-> *context-efficient* choices for a broad sweep in the main session — prefer them,
-> but neither is enforced.
+> benign line-numbered file reads; the `ls→Glob` block guarded a read-only
+> listing whose regex (`^\s*ls\s+.*\*`) also false-positived on compound
+> commands that merely *start* with `ls` and contain a `*` anywhere later
+> (#2036). All three hard-dead-ended subagents whose toolset doesn't grant
+> `Glob`/`Grep` (PreToolUse hooks fire in every context; those tools are not
+> always available — #1909, where `ToolSearch(select:Grep)` returned "No
+> matching deferred tools found" and every blocked search cost a retry; #1416
+> for the `ls`→Glob branch). `find`, `grep`/`rg`, and `ls` in any form now
+> pass. `Glob`/`Grep`/`fd` remain the most *context-efficient* choices for a
+> broad sweep in the main session — prefer them, but none is enforced.
 
 ## The replacement table
 
-Only the `cat`/`head`/`tail` rows are **blocked** (exit 2). The `grep`/`rg`/`find`
-rows are **nudges** — the Bash form runs; the tool is the more context-efficient
-choice when it's available in your session.
+Only the `cat`/`head`/`tail` rows are **blocked** (exit 2). The
+`grep`/`rg`/`find`/`ls` rows are **nudges** — the Bash form runs; the tool is
+the more context-efficient choice when it's available in your session.
 
 | Bash | Preferred tool | Enforcement |
 |---|---|---|
@@ -40,11 +44,12 @@ choice when it's available in your session.
 | `cat /abs/path/file.md` | `Read(file_path="/abs/path/file.md")` | **Blocked** — except a *here-doc* (`cat <<EOF`) or a pipeline (`cat file \| jq`) |
 | `head -50 file.md` | `Read(file_path="/abs/path/file.md", limit=50)` | **Blocked** — except in a pipeline, or inside a hook script |
 | `tail -50 file.md` | `Read(file_path=..., offset=<lines - 50>, limit=50)` | **Blocked** — same |
-| `ls -1 docs/` | `Glob(pattern="docs/*")` *or* `Bash("ls -1 docs/")` | Reminder only on `ls *.glob` patterns |
+| `ls -1 docs/*.md` | `Glob(pattern="docs/*.md")` | Nudge (opt-in teach hook) — Bash form runs (#2036) |
 
 The hook's logic for each:
 
 - **`grep` / `rg`** — never blocked (demoted to the opt-in teach nudge, #1909/#1871). `Grep` is the context-efficient choice when present, but the Bash form always runs.
+- **`ls`** — never blocked (demoted to the opt-in teach nudge, #2036). `Glob` is the context-efficient choice for pattern listings when present, but the Bash form always runs.
 - **`cat` / `head` / `tail`** — blocked for a plain file read; passes through when the file path is `/dev/stdin`, `/dev/null`, a here-doc target, or a pipeline. The hook is checking for *file reads*, not stream handling.
 
 ### Remote-exec commands are exempt (issue #1900)
@@ -77,10 +82,18 @@ hard block taught *less* effectively than it cost, and it dead-ended subagents
 lacking the `Grep` tool. That block has since been **demoted to the opt-in teach
 nudge** (#1909), following the same litigation as `find` (#1871): a block that
 exempts every dangerous form is doing style work, not safety work, and style
-wants a nudge (see `.claude/rules/hook-block-vs-nudge.md`). Only the
-`cat`/`head`/`tail` blocks remain — those prevent real context-budget waste on
-plain file reads with a clean `Read` substitution, and never dead-end anyone
-(pipelines and heredocs pass).
+wants a nudge (see `.claude/rules/hook-block-vs-nudge.md`).
+
+The `ls`→Glob block followed in W28 (#2036): 63 events / 44 sessions with a
+**31.8%** same-session repeat-block rate on the 2026-07-10 re-run (33.3% on
+2026-07-06) — sustained ≥30% over two consecutive readings, the same
+"resistant to teaching" profile that justified the `find` and `grep`
+demotions. Its regex also false-positived on compound commands that merely
+start with `ls` and contain a `*` anywhere later (e.g.
+`ls -1 dir | head; find . -name '*.jsonl'`). Only the `cat`/`head`/`tail`
+blocks remain — those prevent real context-budget waste on plain file reads
+with a clean `Read` substitution, and never dead-end anyone (pipelines and
+heredocs pass).
 
 ## When to reach for `grep` / `rg` in Bash
 
@@ -99,8 +112,9 @@ codebase search; keep `grep`/`rg` for the cases where the tool doesn't fit:
    toolset (some subagents), `grep`/`rg` is the only search you have — and the
    hook won't stop it (#1909).
 
-`find` is likewise never blocked. Reach for `Glob` or `fd` when you want the
-context-efficient / ergonomic option, but the hook won't stop a plain `find`.
+`find` and `ls` are likewise never blocked. Reach for `Glob` or `fd` when you
+want the context-efficient / ergonomic option, but the hook won't stop a plain
+`find` or an `ls` glob (#2036).
 
 ## Related
 
@@ -109,8 +123,9 @@ context-efficient / ergonomic option, but the hook won't stop a plain `find`.
   exits non-zero on empty results, cancelling sibling tool calls
 - `hooks-plugin/hooks/bash-antipatterns.sh` — the hook that
   implements the `cat`/`head`/`tail` blocks (and comments explaining why
-  `find` and `grep`/`rg` are no longer among them)
+  `find`, `grep`/`rg`, and `ls` are no longer among them)
 - `hooks-plugin/hooks/bash-antipatterns-teach.sh` — the opt-in teach
-  hook that carries the non-blocking `find→Glob` and `grep`/`rg`→`Grep` nudges
+  hook that carries the non-blocking `find→Glob`, `grep`/`rg`→`Grep`, and
+  `ls`→`Glob` nudges
 - `.claude/rules/hook-block-vs-nudge.md` — the litigation test behind the
-  `find`/`grep` demotions (block for safety, nudge for style)
+  `find`/`grep`/`ls` demotions (block for safety, nudge for style)

--- a/hooks-plugin/README.md
+++ b/hooks-plugin/README.md
@@ -27,7 +27,6 @@ A PreToolUse hook that intercepts Bash commands and blocks those that should use
 | `echo > file` | Use **Write** tool instead |
 | `cat > file` | Use **Write** tool instead |
 | `timeout cmd` | Remove timeout (human approval time exceeds it) |
-| `grep`/`rg` | Use **Grep** tool instead |
 | `git add -A` / `git add .` | Stage specific files by name instead |
 | 5+ pipe chain | Simplify with JSON output or awk |
 | Multi-grep test parsing | Use `--reporter=json` instead |
@@ -35,6 +34,11 @@ A PreToolUse hook that intercepts Bash commands and blocks those that should use
 | Fork bombs | Blocked unconditionally |
 | `chmod 777` | Use restrictive permissions (755, 644, 600) |
 | Write to block device | Blocked unconditionally |
+
+`find` (#1871), `grep`/`rg` (#1909), and `ls <glob>` (#2036) are **not**
+blocked — those redirects were demoted to non-blocking hints in the opt-in
+teach hook (`bash-antipatterns-teach.sh`). See
+`.claude/rules/hook-block-vs-nudge.md` for the block-vs-nudge litigation.
 
 ### git-stash-session-init.sh
 
@@ -372,15 +376,17 @@ CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 claude
 
 `bash-antipatterns-teach.sh` is an opt-in PostToolUse companion to the existing
 PreToolUse `bash-antipatterns.sh`. Where the PreToolUse hook exits 2 to block
-soft-teach patterns (`cat`, `find -name`, `grep`/`rg`, `head`/`tail`, `ls *.glob`),
-the teach hook lets the command run and prepends a corrective hint to the
-tool result the agent sees via `hookSpecificOutput.updatedToolOutput` (Claude
-Code 2.1.121+). The goal is to drop the W20-measured 21% same-session
-repeat-block rate on `grep`/`rg` toward the ~10% floor of established blocks.
+the remaining soft-teach patterns (`cat`, `head`/`tail`), the teach hook lets
+the command run and prepends a corrective hint to the tool result the agent
+sees via `hookSpecificOutput.updatedToolOutput` (Claude Code 2.1.121+). The
+`find -name` (#1871), `grep`/`rg` (#1909), and `ls <glob>` (#2036) patterns
+have been fully demoted: the PreToolUse hook no longer blocks them at all, and
+their steers live only in this teach hook. The goal is to drop the measured
+same-session repeat-block rates (21% W20 for `grep`/`rg`, 31.8% W28 for
+`ls`→Glob) toward the ~10% floor of established blocks.
 
-Phase 1 is opt-in only — the hook is wired into `plugin.json` but no-ops
-unless `CLAUDE_HOOKS_ENABLE_BASH_ANTIPATTERNS_TEACH=1` is set. The existing
-PreToolUse blocks remain in place. See
+The hook is opt-in — it is wired into `plugin.json` but no-ops
+unless `CLAUDE_HOOKS_ENABLE_BASH_ANTIPATTERNS_TEACH=1` is set. See
 [`docs/teach-mode-experiment.md`](docs/teach-mode-experiment.md) for the full
 hypothesis, rollout plan, and W21 evaluation criteria.
 

--- a/hooks-plugin/hooks/README.md
+++ b/hooks-plugin/hooks/README.md
@@ -16,14 +16,22 @@ A PreToolUse hook that intercepts Bash commands and blocks those that should use
 | `echo > file` | Use **Write** tool instead |
 | `cat > file` | Use **Write** tool instead |
 | `timeout cmd` | Remove timeout (Bash tool has its own, human approval time exceeds it anyway) |
-| `find` | Use **Glob** tool instead |
-| `grep`/`rg` | Use **Grep** tool instead (allows `-q`, `-l`/`-c`/`-L` filter modes, and pipelines) |
-| `ls *pattern*` | Consider **Glob** tool |
 | `cat/tail ...tasks/*.output` | Use **Read** tool on the output path (or pipe an extraction for large files) |
 | `sleep && cat/tail ...output` | Use **Read** tool on the output path |
 | `git add -A` / `git add .` | Stage specific files by name instead of broad staging |
 | `git X && git Y` | Run git commands as separate Bash calls (avoids index.lock race condition) |
 | `git reset --hard` | Use safer alternatives; if truly needed, ask user to run manually |
+
+### Demoted to opt-in teach nudges (not blocked)
+
+`find` (→ **Glob**, #1871), `grep`/`rg` (→ **Grep**, #1909), and `ls <glob>`
+(→ **Glob**, #2036) are intentionally **not** blocked by this hook. None of
+those blocks did safety work, and each hard-dead-ended subagents whose toolset
+lacks the suggested tool. The steers survive as non-blocking hints in
+`bash-antipatterns-teach.sh`, opt-in via
+`CLAUDE_HOOKS_ENABLE_BASH_ANTIPATTERNS_TEACH=1`. See
+`.claude/rules/bash-tool-replacements.md` and
+`.claude/rules/hook-block-vs-nudge.md`.
 
 ### Handling Blocked Commands
 

--- a/hooks-plugin/hooks/bash-antipatterns.sh
+++ b/hooks-plugin/hooks/bash-antipatterns.sh
@@ -247,10 +247,26 @@ fi
 # toward Grep without dead-ending anyone.
 # See .claude/rules/bash-tool-replacements.md for the grep/rg/Grep guidance.
 
-# Check for ls used for file listing (should often use Glob)
-if [ "$IS_REMOTE_EXEC" = false ] && echo "$COMMAND" | grep -Eq '^\s*ls\s+.*\*'; then
-    block "REMINDER: Consider using the Glob tool for pattern-based file listing. Glob provides sorted results by modification time and handles large directories better."
-fi
+# NOTE: `ls` is intentionally NOT blocked here.
+#
+# The ls→Glob redirect was demoted from a hard block to a non-blocking teach
+# nudge (bash-antipatterns-teach.sh, opt-in via CLAUDE_HOOKS_ENABLE_BASH_ANTIPATTERNS_TEACH=1),
+# mirroring the find→Glob (#1871) and grep/rg→Grep (#1909) demotions. Same
+# reasoning applies point-for-point under hook-block-vs-nudge.md's litigation
+# test: the block did NO safety work (listing files destroys nothing; the only
+# justification was style/context-efficiency); it hard-DEAD-ENDED subagents
+# whose toolset doesn't grant the Glob tool (PreToolUse Bash hooks fire in every
+# context, but Glob is not always available — #1416); its regex
+# `^\s*ls\s+.*\*` was a compound-command false positive (it matched any command
+# that merely STARTS with ls and contains a `*` anywhere later, e.g.
+# `ls -1 dir | head; find . -name "*.jsonl"` — the `*` in the unrelated find
+# clause tripped the block); and it carried the highest same-session
+# repeat-block rate of any pattern (31.8% W28 re-run, 33.3% W28 — sustained
+# ≥30% over two consecutive readings, issue #2036). The model writes ls
+# reliably; blocking a tool it's fluent in to force one that is sometimes
+# absent is a bad trade. Context efficiency is preserved by the opt-in teach
+# nudge (`glob-ls`), which steers toward Glob without dead-ending anyone.
+# See .claude/rules/bash-tool-replacements.md for the ls/Glob guidance.
 
 # Check for reading task output files (should use the Read tool)
 # Detects patterns like: cat /tmp/claude/*/tasks/*.output, tail ...tasks/...output, sleep && cat ...output

--- a/hooks-plugin/hooks/test-bash-antipatterns.sh
+++ b/hooks-plugin/hooks/test-bash-antipatterns.sh
@@ -151,6 +151,34 @@ assert_exit \
     "grep in pipeline is allowed (piped output has different semantics)" 0 \
     "git log --oneline | grep pattern"
 
+# ── ls is no longer blocked ──────────────────────────────────────────────────
+# The ls→Glob redirect was demoted from a hard block to an opt-in teach nudge
+# (bash-antipatterns-teach.sh), mirroring the find (#1871) and grep/rg (#1909)
+# demotions. The block did no safety work (listing files destroys nothing), it
+# hard-dead-ended subagents lacking the Glob tool (#1416), and its regex
+# `^\s*ls\s+.*\*` false-positived on compound commands that merely START with
+# ls and contain a `*` anywhere later (issue #2036). So `ls` in EVERY form is
+# now allowed by this hook. The Glob steer survives as a non-blocking nudge in
+# the companion teach hook (see test-bash-antipatterns-teach.sh, `glob-ls`).
+echo ""
+echo "ls is no longer blocked (demoted to opt-in teach nudge, #2036):"
+
+assert_exit \
+    "ls -1 foo/*.json is allowed (was blocked; now teach-only, #2036)" 0 \
+    "ls -1 foo/*.json"
+
+assert_exit \
+    "plain ls *.md is allowed (was blocked; now teach-only, #2036)" 0 \
+    "ls *.md"
+
+assert_exit \
+    "compound 'ls dir | head; find …' is allowed (regex crossed separators, #2036)" 0 \
+    "ls -1 ~/x | head; find . -name '*.jsonl'"
+
+assert_exit \
+    "ls -la /tmp/*.log is allowed" 0 \
+    "ls -la /tmp/*.log"
+
 # ── echo/printf file-write detection ─────────────────────────────────────────
 # Regression: echo "---"; git ... 2>/dev/null was falsely blocked because
 # the regex used .* which crossed the ; command separator and matched the


### PR DESCRIPTION
## Summary

Removes the exit-2 hard block on `ls … *` from `bash-antipatterns.sh`, mirroring the `find`→Glob (#1871) and `grep`/`rg`→Grep (#1909) demotions. The Glob steer survives as the existing non-blocking `glob-ls` hint in `bash-antipatterns-teach.sh` (opt-in via `CLAUDE_HOOKS_ENABLE_BASH_ANTIPATTERNS_TEACH=1`) — the teach hook already carried it, so no teach-hook change was needed.

## Why (hook-block-vs-nudge litigation)

- **No safety work.** Listing files destroys nothing; the block's only justification was style/context-efficiency, which wants a nudge (`.claude/rules/hook-block-vs-nudge.md`).
- **Subagent dead-end.** PreToolUse Bash hooks fire in every context, but the Glob tool is not always granted (#1416) — a blocked `ls` with no Glob is a hard dead-end.
- **Compound-command false positive.** The regex `^\s*ls\s+.*\*` matched any command that merely *starts* with `ls` and contains a `*` anywhere later — e.g. `ls -1 ~/x | head; find . -name '*.jsonl'` was blocked because of the `*` in the unrelated `find` clause.
- **W28 friction evidence.** 63 events / 44 sessions / **31.8%** same-session repeat-block rate (33.3% on the 2026-07-06 reading) — sustained ≥30% over two consecutive readings, the same resistant-to-teaching profile that justified the `find` and `grep` demotions.

## Changes

| File | Change |
|---|---|
| `hooks-plugin/hooks/bash-antipatterns.sh` | Delete the `ls` block; add a demotion NOTE comment matching the adjacent `find`/`grep` ones |
| `hooks-plugin/hooks/test-bash-antipatterns.sh` | Regression tests: `ls -1 foo/*.json`, plain `ls *.md`, `ls -la /tmp/*.log`, and the compound false-positive shape all exit 0 |
| `.claude/rules/bash-tool-replacements.md` | Move `ls` into the demoted/nudge set; add W28 numbers; only `cat`/`head`/`tail` remain hard blocks (reconciles the pre-existing doc/behavior mismatch) |
| `hooks-plugin/README.md`, `hooks-plugin/hooks/README.md` | Anti-pattern tables updated: `find`/`grep`/`ls` documented as teach-nudge-only |

## Verification

- `bash hooks-plugin/hooks/test-bash-antipatterns.sh` — 113 passed, 0 failed (includes the 4 new `ls` assertions; wired into pre-commit)
- `bash hooks-plugin/hooks/test-bash-antipatterns-teach.sh` — 24 passed (existing `glob-ls` nudge unchanged)
- `bash hooks-plugin/hooks/test-bash-antipatterns-git-env-isolation.sh` — 3 passed
- Manual repro: `{"tool_name":"Bash","tool_input":{"command":"ls -1 /tmp/*.json"}}` → exit 0; compound `ls … | head; find … -name "*.jsonl"` → exit 0; `cat file.txt` still exits 2
- `bash scripts/lint-shell-scripts.sh` — 0 errors

The <15% W30 repeat-block acceptance criterion from #2036 is a post-merge monitoring item, not a PR gate.

Closes #2036

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USX4W2ofQLBZdPRHXr5CCo

---
_Generated by [Claude Code](https://claude.ai/code/session_01USX4W2ofQLBZdPRHXr5CCo)_