### PR TITLE
feat(pi): canonical tier manifest + drift guard

### DIFF
--- a/.github/workflows/plugin-pr-checks.yml
+++ b/.github/workflows/plugin-pr-checks.yml
@@ -160,6 +160,15 @@ jobs:
       - name: Check configure-plugin taxonomy matches components.yaml
         run: bash scripts/check-configure-components.sh --strict
 
+      - name: Self-test the pi-tiers drift guard
+        # Whole-repo invariant: pi/tiers.yaml classifies every marketplace
+        # plugin exactly once and its cherry-picked skill refs resolve. The
+        # self-test proves the guard before it gates the tree.
+        run: bash scripts/tests/test-check-pi-tiers.sh
+
+      - name: Check pi/tiers.yaml matches marketplace
+        run: bash scripts/check-pi-tiers.sh --strict
+
       - name: Install actionlint
         # GitHub Actions YAML schema/best-practice lint — the one workflow gate
         # check-workflow-model.sh does not cover. ubuntu-latest ships Go but does

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -176,6 +176,18 @@ repos:
         language: system
         files: '^configure-plugin/skills/configure-all/(scripts/(list-components\.sh|tests/test-list-components\.sh)|components\.yaml)$'
         pass_filenames: false
+      - id: check-pi-tiers
+        name: pi/tiers.yaml matches marketplace + resolves skill refs (pi-tiers-drift)
+        entry: bash ./scripts/check-pi-tiers.sh --strict
+        language: system
+        files: '^(pi/tiers\.yaml|\.claude-plugin/marketplace\.json|scripts/check-pi-tiers\.sh)$'
+        pass_filenames: false
+      - id: test-check-pi-tiers
+        name: pi-tiers drift guard regression
+        entry: bash ./scripts/tests/test-check-pi-tiers.sh
+        language: system
+        files: '^scripts/(check-pi-tiers\.sh|tests/test-check-pi-tiers\.sh)$'
+        pass_filenames: false
       - id: test-fetch-research-papers
         name: research-radar fetcher parse/dedup/date-filter regression
         entry: bash ./scripts/tests/test-fetch-research-papers.sh

--- a/justfile
+++ b/justfile
@@ -155,3 +155,13 @@ serve-opencode-model:
 [group: "opencode"]
 install-opencode-ocx target=opencode_config:
     ./scripts/install-opencode-ocx.sh "{{target}}"
+
+####################
+# pi (pi.dev) export
+####################
+
+# Verify pi/tiers.yaml matches the marketplace and its skill refs resolve
+# (local↔CI parity: the enforcement path is the script; this is a convenience alias)
+[group: "pi"]
+check-pi-tiers:
+    ./scripts/check-pi-tiers.sh --strict

--- a/pi/tiers.yaml
+++ b/pi/tiers.yaml
@@ -1,0 +1,106 @@
+# pi/tiers.yaml — canonical classification of claude-plugins skills into pi (pi.dev) install tiers.
+#
+# WHY THIS EXISTS
+#   pi (https://pi.dev) loads Claude Code SKILL.md files unmodified, but — unlike
+#   Claude Code — it does NOT budget the up-front skill-description listing
+#   (no `skillListingBudgetFraction`). Every installed skill costs ~111 tokens of
+#   standing per-turn context (measured, pi 0.80.6). Dumping all ~400 skills adds
+#   ~45K tokens/turn and wedges the agent on a local model's small context window.
+#   This manifest is the single source of truth for WHICH skills install WHERE, so
+#   the standing cost stays bounded. See docs/pi-export.md for the full rationale.
+#
+# TIERS
+#   general  -> ~/.pi/agent/skills/  (always-on, every project; keep this set lean)
+#   domain   -> .pi/skills/          (only in matching project types; per-repo opt-in)
+#   exclude  -> never installed      (Claude-Code-authoring meta; pure budget waste in pi)
+#
+# FIELDS
+#   tier      required. one of general | domain | exclude
+#   skills    optional cherry-pick. When present, ONLY these skill dirs install at this
+#             tier (the rest of the plugin's skills are dropped). Absence = whole plugin.
+#             Use for large plugins whose always-relevant core is a subset (e.g. git).
+#   category  domain plugins only. grouping hint for per-project selection.
+#   reason    exclude plugins only. why it doesn't belong in pi.
+#
+# INVARIANTS (enforced by scripts/check-pi-tiers.sh; pre-commit + CI)
+#   - every plugin in .claude-plugin/marketplace.json appears here exactly once
+#   - every name under `skills:` is a real dir under <plugin>/skills/
+#
+# Editing: move a plugin between tiers, or add/remove names under a `skills:`
+# cherry-pick list, freely — the guard only enforces the invariants above, not
+# any particular assignment. Keep the general tier lean (it is standing per-turn
+# context in EVERY project); prefer a domain category when in doubt.
+
+version: 1
+
+plugins:
+  # ── Tier 1: general (always-on, ~/.pi/agent/skills/) ───────────────────────
+  git-plugin:
+    tier: general
+    # Core "any project, any turn" set. The situational tail (release-please-*,
+    # git-triage, git-fork/upstream-*, git-rebase-patterns, git-issue-hierarchy,
+    # deadbranch, git-maintain, github-labels, ...) is intentionally dropped —
+    # promote individually if a project needs it.
+    skills:
+      - git-commit
+      - git-commit-workflow
+      - git-branch-pr-workflow
+      - git-push
+      - git-pr
+      - git-cli-agentic
+      - gh-cli-agentic
+      - git-coworker-check
+      - git-repo-detection
+      - git-security-checks
+  project-plugin:
+    tier: general
+    # Only the harness-agnostic orientation skill; the rest (project-continue,
+    # project-refocus, project-test-loop, changelog-review) are Claude-Code-workflow.
+    skills:
+      - project-discovery
+  tools-plugin: { tier: general }            # fd/rg/jq/yq/d2/mermaid/shell/... universal
+  code-quality-plugin: { tier: general }     # lint/review/complexity/dead-code/refactor
+  testing-plugin: { tier: general }          # framework-agnostic test runners + analysis
+  software-design-plugin: { tier: general }  # contracts, deep modules, patterns, legacy seams
+  documentation-plugin: { tier: general }
+  migration-patterns-plugin: { tier: general }
+  workflow-orchestration-plugin: { tier: general }
+  prose-plugin: { tier: general }
+  communication-plugin: { tier: general }
+  prompt-engineering-plugin: { tier: general }
+  codebase-attributes-plugin: { tier: general }
+  taskwarrior-plugin: { tier: general }      # cross-project personal workflow
+
+  # ── Tier 2: domain (per-project, .pi/skills/) ──────────────────────────────
+  python-plugin:            { tier: domain, category: lang }
+  typescript-plugin:        { tier: domain, category: lang }
+  rust-plugin:              { tier: domain, category: lang }
+  bevy-plugin:              { tier: domain, category: gamedev }
+  css-plugin:               { tier: domain, category: frontend }
+  component-patterns-plugin: { tier: domain, category: frontend }
+  accessibility-plugin:     { tier: domain, category: frontend }
+  api-plugin:               { tier: domain, category: backend }
+  langchain-plugin:         { tier: domain, category: ai }
+  container-plugin:         { tier: domain, category: infra }
+  kubernetes-plugin:        { tier: domain, category: infra }
+  terraform-plugin:         { tier: domain, category: infra }
+  github-actions-plugin:    { tier: domain, category: ci }
+  finops-plugin:            { tier: domain, category: ci }
+  networking-plugin:        { tier: domain, category: infra }
+  comfyui-plugin:           { tier: domain, category: comfyui }
+  foundryvtt-plugin:        { tier: domain, category: foundryvtt }
+  home-assistant-plugin:    { tier: domain, category: homeassistant }
+  obsidian-plugin:          { tier: domain, category: obsidian }
+  macos-plugin:             { tier: domain, category: host }
+  blog-plugin:              { tier: domain, category: content }
+
+  # ── Tier 0: exclude (never installed into pi) ──────────────────────────────
+  hooks-plugin:          { tier: exclude, reason: "Claude Code hook authoring; pi has no equivalent hook system" }
+  health-plugin:         { tier: exclude, reason: "Claude Code health/registry diagnostics; CC-specific" }
+  feedback-plugin:       { tier: exclude, reason: "Claude Code skill-feedback tooling; CC-specific" }
+  evaluate-plugin:       { tier: exclude, reason: "Claude Code skill-evaluation tooling; CC-specific" }
+  agents-plugin:         { tier: exclude, reason: "Claude Code subagent authoring/analysis; pi has its own sub-agents" }
+  agent-patterns-plugin: { tier: exclude, reason: "Claude Code agent-orchestration/worktree-dispatch/MCP authoring; harness-specific" }
+  configure-plugin:      { tier: exclude, reason: "Claude Code + repo onboarding config (settings.json, MCP, claude-plugins); CC-specific" }
+  blueprint-plugin:      { tier: exclude, reason: "PRD/ADR/PRP methodology, heavily CC-workflow-coupled (34 skills); promote individually if wanted" }
+  session-plugin:        { tier: exclude, reason: "Claude Code session wrap/spinup/distill; CC-specific" }

--- a/scripts/check-pi-tiers.sh
+++ b/scripts/check-pi-tiers.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Drift guard for the pi (pi.dev) install-tier manifest (single source of
+# truth: pi/tiers.yaml). Keeps the manifest in lockstep with the plugin
+# marketplace and the on-disk skill tree so a tier assignment can't silently
+# rot as plugins/skills come and go.
+#
+# Invariants:
+#   1. Marketplace <-> manifest agree: every plugin in
+#      .claude-plugin/marketplace.json appears in pi/tiers.yaml exactly once
+#      (TYPE=plugin_unclassified when missing from the manifest,
+#      TYPE=plugin_duplicate when listed more than once), and every plugin in
+#      the manifest is a real marketplace plugin (TYPE=plugin_not_in_marketplace).
+#   2. Every name under any `skills:` cherry-pick list resolves to a real
+#      <plugin>/skills/<name>/SKILL.md (TYPE=skill_ref_missing).
+#
+# Emits the structured KEY=VALUE / STATUS= convention
+# (.claude/rules/structured-script-output.md).
+#
+# Usage: bash scripts/check-pi-tiers.sh [--strict] [--root <repo-root>]
+# --strict exits 1 on any issue (default: exit 1 only on ERROR).
+
+set -uo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+strict=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --strict) strict=true; shift ;;
+    --root) root_dir="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+manifest="${root_dir}/pi/tiers.yaml"
+marketplace="${root_dir}/.claude-plugin/marketplace.json"
+
+echo "=== PI TIERS DRIFT ==="
+
+pt_issue_count=0
+pt_status="OK"
+pt_issues_list=""
+
+add_issue() {
+  pt_issues_list="${pt_issues_list}  - SEVERITY=$1 TYPE=$2 MSG=$3\n"
+  pt_issue_count=$((pt_issue_count + 1))
+  if [ "$1" = "ERROR" ]; then
+    pt_status="ERROR"
+  elif [ "$1" = "WARN" ] && [ "$pt_status" = "OK" ]; then
+    pt_status="WARN"
+  fi
+}
+
+finish() {
+  echo "STATUS=${pt_status}"
+  echo "ISSUE_COUNT=${pt_issue_count}"
+  if [ -n "$pt_issues_list" ]; then
+    echo "ISSUES:"
+    echo -e "$pt_issues_list" | sed '/^$/d'
+  fi
+  echo "=== END PI TIERS DRIFT ==="
+  if [ "$pt_status" = "ERROR" ]; then exit 1; fi
+  if [ "$strict" = "true" ] && [ "$pt_issue_count" -gt 0 ]; then exit 1; fi
+  exit 0
+}
+
+command -v jq >/dev/null 2>&1 || add_issue "ERROR" "missing_jq" "jq is required to parse marketplace.json but is not installed"
+for req in "$manifest" "$marketplace"; do
+  if [ ! -f "$req" ]; then
+    add_issue "ERROR" "missing_input" "required file not found: ${req}"
+  fi
+done
+[ "$pt_status" = "ERROR" ] && finish
+
+# ---------------------------------------------------------------------------
+# Parse the manifest: emit one PLUGIN=<name> per plugin key and one
+# SKILL=<plugin> <skill> per cherry-picked skill (tracking the current plugin).
+# Plugin keys are 2-space-indented `<name>-plugin:` (block or flow form);
+# skill items are 6-space-indented `- <name>` under a `skills:` list.
+# ---------------------------------------------------------------------------
+manifest_records="$(awk '
+  /^  [a-z][a-z0-9-]*-plugin:/ {
+    line=$0
+    sub(/^  /, "", line)
+    sub(/:.*/, "", line)
+    plugin=line
+    print "PLUGIN=" plugin
+    next
+  }
+  /^      - [a-z][a-z0-9-]+[[:space:]]*$/ {
+    skill=$2
+    print "SKILL=" plugin " " skill
+    next
+  }
+' "$manifest")"
+
+# Manifest plugin set + duplicate detection.
+declare -A manifest_plugin_count=()
+while IFS= read -r line; do
+  case "$line" in
+    PLUGIN=*)
+      p="${line#PLUGIN=}"
+      manifest_plugin_count["$p"]=$(( ${manifest_plugin_count["$p"]:-0} + 1 ))
+      ;;
+  esac
+done <<< "$manifest_records"
+
+manifest_plugin_total=${#manifest_plugin_count[@]}
+
+# Marketplace plugin set.
+declare -A mkt_set=()
+mkt_count=0
+while IFS= read -r p; do
+  [ -n "$p" ] || continue
+  mkt_set["$p"]=1
+  mkt_count=$((mkt_count + 1))
+done < <(jq -r '.plugins[].name' "$marketplace" | sort)
+
+# Check 1a: every marketplace plugin classified exactly once.
+for p in "${!mkt_set[@]}"; do
+  n=${manifest_plugin_count["$p"]:-0}
+  if [ "$n" -eq 0 ]; then
+    add_issue "ERROR" "plugin_unclassified" "$p is in marketplace.json but not classified in pi/tiers.yaml"
+  elif [ "$n" -gt 1 ]; then
+    add_issue "ERROR" "plugin_duplicate" "$p appears $n times in pi/tiers.yaml (expected exactly once)"
+  fi
+done
+
+# Check 1b: every manifest plugin is a real marketplace plugin.
+for p in "${!manifest_plugin_count[@]}"; do
+  if [ -z "${mkt_set[$p]:-}" ]; then
+    add_issue "ERROR" "plugin_not_in_marketplace" "$p is classified in pi/tiers.yaml but not published in marketplace.json"
+  fi
+done
+
+# Check 2: every cherry-picked skill ref resolves to a real SKILL.md.
+skill_ref_total=0
+while IFS= read -r line; do
+  case "$line" in
+    SKILL=*)
+      rest="${line#SKILL=}"
+      plugin="${rest%% *}"
+      skill="${rest#* }"
+      skill_ref_total=$((skill_ref_total + 1))
+      if [ ! -f "${root_dir}/${plugin}/skills/${skill}/SKILL.md" ]; then
+        add_issue "ERROR" "skill_ref_missing" "${plugin}/skills/${skill}/SKILL.md referenced in pi/tiers.yaml does not exist"
+      fi
+      ;;
+  esac
+done <<< "$manifest_records"
+
+echo "MARKETPLACE_PLUGINS=${mkt_count}"
+echo "MANIFEST_PLUGINS=${manifest_plugin_total}"
+echo "SKILL_REFS=${skill_ref_total}"
+
+finish

--- a/scripts/tests/test-check-pi-tiers.sh
+++ b/scripts/tests/test-check-pi-tiers.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Regression test for check-pi-tiers.sh (the pi/tiers.yaml drift guard).
+# Fixtures prove each invariant fires:
+#   A. clean fixture → STATUS=OK, exit 0
+#   B. marketplace plugin missing from the manifest → plugin_unclassified
+#   C. manifest names a plugin not in marketplace → plugin_not_in_marketplace
+#   D. cherry-picked skill ref with no SKILL.md → skill_ref_missing
+#   E. plugin classified twice → plugin_duplicate
+# Exit 0 on success, non-zero on failure.
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+guard="${script_dir}/../check-pi-tiers.sh"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+pass() { echo "PASS: $1"; }
+
+[ -f "$guard" ] || fail "check-pi-tiers.sh not found at $guard"
+
+sandbox="$(mktemp -d)"
+[ -n "$sandbox" ] || fail "mktemp -d returned empty"
+trap 'rm -rf "$sandbox"' EXIT
+
+build_fixture() {
+  rm -rf "${sandbox:?}/pi" "${sandbox:?}/.claude-plugin" \
+         "${sandbox:?}/foo-plugin" "${sandbox:?}/bar-plugin"
+  mkdir -p "${sandbox}/pi" "${sandbox}/.claude-plugin" \
+           "${sandbox}/foo-plugin/skills/foo-core" \
+           "${sandbox}/bar-plugin/skills/bar-only"
+  printf -- '---\nname: foo-core\n---\n' > "${sandbox}/foo-plugin/skills/foo-core/SKILL.md"
+  printf -- '---\nname: bar-only\n---\n' > "${sandbox}/bar-plugin/skills/bar-only/SKILL.md"
+
+  cat > "${sandbox}/.claude-plugin/marketplace.json" <<'JSON'
+{
+  "name": "test-marketplace",
+  "plugins": [
+    { "name": "foo-plugin", "source": "./foo-plugin" },
+    { "name": "bar-plugin", "source": "./bar-plugin" }
+  ]
+}
+JSON
+
+  cat > "${sandbox}/pi/tiers.yaml" <<'YAML'
+version: 1
+
+plugins:
+  foo-plugin:
+    tier: general
+    skills:
+      - foo-core
+  bar-plugin: { tier: domain, category: lang }
+YAML
+}
+
+# -----------------------------------------------------------------------------
+# Case A: clean fixture → STATUS=OK, exit 0
+# -----------------------------------------------------------------------------
+build_fixture
+outA="$(bash "$guard" --strict --root "$sandbox")" || fail "expected exit 0 on clean fixture:\n$outA"
+echo "$outA" | grep -q "^STATUS=OK$" || fail "expected STATUS=OK on clean fixture:\n$outA"
+pass "clean fixture passes"
+
+# -----------------------------------------------------------------------------
+# Case B: marketplace plugin missing from the manifest → plugin_unclassified
+# -----------------------------------------------------------------------------
+build_fixture
+# Drop bar-plugin from the manifest, leaving it in the marketplace.
+cat > "${sandbox}/pi/tiers.yaml" <<'YAML'
+version: 1
+
+plugins:
+  foo-plugin:
+    tier: general
+    skills:
+      - foo-core
+YAML
+outB="$(bash "$guard" --strict --root "$sandbox")" && fail "expected failure for unclassified plugin"
+echo "$outB" | grep -q "TYPE=plugin_unclassified" || fail "expected plugin_unclassified issue:\n$outB"
+pass "marketplace plugin missing from manifest fails"
+
+# -----------------------------------------------------------------------------
+# Case C: manifest names a plugin not in marketplace → plugin_not_in_marketplace
+# -----------------------------------------------------------------------------
+build_fixture
+cat >> "${sandbox}/pi/tiers.yaml" <<'YAML'
+  ghost-plugin: { tier: exclude, reason: "not real" }
+YAML
+outC="$(bash "$guard" --strict --root "$sandbox")" && fail "expected failure for manifest plugin absent from marketplace"
+echo "$outC" | grep -q "TYPE=plugin_not_in_marketplace" || fail "expected plugin_not_in_marketplace issue:\n$outC"
+pass "manifest plugin not in marketplace fails"
+
+# -----------------------------------------------------------------------------
+# Case D: cherry-picked skill ref with no SKILL.md → skill_ref_missing
+# -----------------------------------------------------------------------------
+build_fixture
+cat > "${sandbox}/pi/tiers.yaml" <<'YAML'
+version: 1
+
+plugins:
+  foo-plugin:
+    tier: general
+    skills:
+      - foo-core
+      - foo-ghost
+  bar-plugin: { tier: domain, category: lang }
+YAML
+outD="$(bash "$guard" --strict --root "$sandbox")" && fail "expected failure for missing skill ref"
+echo "$outD" | grep -q "TYPE=skill_ref_missing" || fail "expected skill_ref_missing issue:\n$outD"
+pass "missing cherry-picked skill ref fails"
+
+# -----------------------------------------------------------------------------
+# Case E: plugin classified twice → plugin_duplicate
+# -----------------------------------------------------------------------------
+build_fixture
+cat >> "${sandbox}/pi/tiers.yaml" <<'YAML'
+  bar-plugin: { tier: exclude, reason: "duplicate" }
+YAML
+outE="$(bash "$guard" --strict --root "$sandbox")" && fail "expected failure for duplicated plugin"
+echo "$outE" | grep -q "TYPE=plugin_duplicate" || fail "expected plugin_duplicate issue:\n$outE"
+pass "plugin classified twice fails"
+
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
## What

Adds `pi/tiers.yaml` — the canonical, skill-granular classification of all 44 marketplace plugins into pi ([pi.dev](https://pi.dev)) install tiers — plus `scripts/check-pi-tiers.sh`, the drift guard that locks it.

Slice 1 of the pi integration. It carries no consumers yet: it makes the manifest a *source of truth* rather than a file that exists. The installer that reads it lands in a follow-up.

## Why

pi loads Claude Code `SKILL.md` files **unmodified** (validated on pi 0.80.6 — it is strictly more lenient than OpenCode/rulesync, so none of the OpenCode normalization layer is needed). But unlike Claude Code, pi does **not** budget the up-front skill-description listing — there is no `skillListingBudgetFraction`.

Measured: **~111 tokens/skill**, dead linear, uncapped.

| Installed skills | Standing cost/turn | On a 128K local context |
|---|---|---|
| 94 (Tier-1 general) | ~10.4K | ~8% — fine |
| all ~400 | ~45K | fatal (401 skills hangs the turn >2min) |

So: don't dump all skills into pi. Curate by tier, using pi's two native scopes.

## The manifest

| Tier | pi scope | Meaning |
|---|---|---|
| `general` | `~/.pi/agent/skills/` | Always-on, every project (94 skills) |
| `domain` | `.pi/skills/` | Per-project, selected by `category` |
| `exclude` | never installed | Claude-Code-authoring meta — pure budget waste in pi |

Large general plugins cherry-pick a core subset via a `skills:` list rather than installing every skill (git-plugin: **10 of 38**). The file's header block is its own spec.

## The guard

`scripts/check-pi-tiers.sh` enforces two invariants:

1. Every plugin in `marketplace.json` is classified in `pi/tiers.yaml` **exactly once** — `plugin_unclassified` / `plugin_duplicate` / `plugin_not_in_marketplace`.
2. Every name under a `skills:` cherry-pick list resolves to a real `<plugin>/skills/<name>/SKILL.md` — `skill_ref_missing`.

Emits the structured `KEY=VALUE` / `STATUS=` convention. Wired into `.pre-commit-config.yaml` and the `compliance` job of `plugin-pr-checks.yml` in the established self-test-then-guard order, plus a `just check-pi-tiers` alias for local↔CI parity.

## Verification

- `bash scripts/check-pi-tiers.sh --strict` → `STATUS=OK`, exit 0 (44/44 plugins, 11 skill refs).
- `bash scripts/tests/test-check-pi-tiers.sh` → `ALL TESTS PASSED` (5 fixtures: clean, unclassified, not-in-marketplace, missing skill ref, duplicate).
- Bogus plugin added to the manifest → guard exits 1 with `TYPE=plugin_not_in_marketplace`; reverted.
- `pre-commit` green (both new hooks fired); `shellcheck`, `lint-shell-scripts.sh`, `check-git-sandbox-guards.sh`, `check-docs-index.sh` all clean.

## Notes

- `pi` is deliberately **not** a release-please package (no `-plugin` suffix), so this cuts no plugin version bump — matching the `blueprint`-scope convention.
- The top-level `pi/` dir is inert to existing tooling: `*-plugin` globs, `check-enabled-plugins-drift`, and the docs-index checks all ignore non-`-plugin` dirs.
- Follow-up PR adds `scripts/install-pi.sh` (reads this manifest), the local-model `just` recipes, and `docs/pi-export.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Rc33NHzxPWeJdURoyYLex