### PR TITLE
feat(pi): tier-driven installer + local-model recipes

### DIFF
--- a/.github/workflows/plugin-pr-checks.yml
+++ b/.github/workflows/plugin-pr-checks.yml
@@ -169,6 +169,12 @@ jobs:
       - name: Check pi/tiers.yaml matches marketplace
         run: bash scripts/check-pi-tiers.sh --strict
 
+      - name: Self-test the pi tier-driven installer
+        # The installer resolves tiers to skill dirs (general->global,
+        # domain->project, exclude->never). Hermetic fixture test; runs
+        # unconditionally so the installer contract stays verified.
+        run: bash scripts/tests/test-install-pi.sh
+
       - name: Install actionlint
         # GitHub Actions YAML schema/best-practice lint — the one workflow gate
         # check-workflow-model.sh does not cover. ubuntu-latest ships Go but does

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -188,6 +188,12 @@ repos:
         language: system
         files: '^scripts/(check-pi-tiers\.sh|tests/test-check-pi-tiers\.sh)$'
         pass_filenames: false
+      - id: test-install-pi
+        name: pi tier-driven installer regression
+        entry: bash ./scripts/tests/test-install-pi.sh
+        language: system
+        files: '^scripts/(install-pi\.sh|tests/test-install-pi\.sh)$'
+        pass_filenames: false
       - id: test-fetch-research-papers
         name: research-radar fetcher parse/dedup/date-filter regression
         entry: bash ./scripts/tests/test-fetch-research-papers.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,17 @@ gh pr create --title "feat(git-plugin): add new workflow"
 6. **Test** - Verify skills load and work
 7. **Create PR** - Use conventional commit format for title (drives automation)
 
+## Local-model export
+
+Run this marketplace's skills inside local-model coding agents. Two targets, two docs:
+
+| Target | Source of truth | Doc | Recipes |
+|--------|-----------------|-----|---------|
+| **pi** (pi.dev) | `pi/tiers.yaml` (tier classification, enforced by `scripts/check-pi-tiers.sh`) | [`docs/pi-export.md`](docs/pi-export.md) | `just check-pi-tiers`, `pi-tiers`, `install-pi`, `install-pi-domain <cat>`, `serve-pi-model`, `setup-pi` (group `pi`) |
+| **OpenCode** | rulesync export | [`docs/opencode-export.md`](docs/opencode-export.md) | `just export-opencode`, `install-opencode`, `setup-opencode` (group `opencode`) |
+
+pi loads Claude Code `SKILL.md` unmodified but does **not** budget the skill listing (~111 tok/skill, uncapped), so `pi/tiers.yaml` curates which skills install where (`general` → `~/.pi/agent/skills/`, a `domain` category → `.pi/skills/`, `exclude` → never). See `docs/pi-export.md`.
+
 ## Blueprint (constrained dogfooding)
 
 This repo runs `blueprint-plugin` against itself in a deliberately constrained mode. State lives in `docs/blueprint/`; see `docs/blueprint/README.md` for the full rationale.

--- a/docs/pi-export.md
+++ b/docs/pi-export.md
@@ -1,0 +1,162 @@
+# pi (pi.dev) export & local-model orchestration
+
+Run this marketplace's skills inside **pi** ([pi.dev](https://pi.dev),
+`@earendil-works/pi-coding-agent`) against a **local model** (mlx_lm.server /
+ollama). The sibling of [`opencode-export.md`](opencode-export.md) — same goal
+(local-model testing of our skills), a much thinner pipeline.
+
+## Why pi needs almost no pipeline
+
+pi loads Claude Code `SKILL.md` files **unmodified**. Validated this session
+(pi 0.80.6): pi is *strictly more lenient* than OpenCode/rulesync — it accepts
+display-name `name:` values (`UnoCSS`), unprefixed names (`ground-response`),
+comma-string `allowed-tools`, and extra frontmatter, all of which the OpenCode
+export's `rewrite-skill-name-to-dir.py` / `normalize-skill-allowed-tools.py`
+layer had to rewrite. **None of that normalization is needed for pi.** pi also
+reads `CLAUDE.md` natively and does the same progressive disclosure as Claude
+Code (only `name`+`description` surfaced up front; the body loads on demand via
+`read` / `/skill:name`), so there is no separate search tool to build.
+
+So the only thing worth building is a **curated installer**, not an export
+pipeline.
+
+## The one real gap: pi doesn't budget the skill listing
+
+Claude Code caps the up-front skill-description listing at
+`skillListingBudgetFraction × context`. **pi has no such budget** — every
+installed skill costs ~111 tokens of standing per-turn context (measured, pi
+0.80.6), dead linear and uncapped:
+
+| Installed skills | Standing cost/turn | On a 128K local context |
+|------------------|--------------------|-------------------------|
+| ~20 | ~2.2K | negligible |
+| 94 (Tier-1 general) | ~10.4K | ~8% — fine |
+| ~200 | ~22K | tight |
+| all ~400 | ~45K | fatal (401 skills hangs the turn >2min; ≤200 fine) |
+
+On the user's 1M-context Claude at `skillListingBudgetFraction 0.1` this is
+invisible; on a small local quant it wedges the agent. **Conclusion: don't dump
+all skills into pi.** Curate by *tier* using pi's two native scopes.
+
+## Tiers → pi's two native scopes
+
+pi discovers skills from `~/.pi/agent/skills/` (global) **and** `.pi/skills/`
+(per-project) and merges them. That maps cleanly onto a tier model:
+
+| Tier | pi scope | Meaning |
+|------|----------|---------|
+| `general` | `~/.pi/agent/skills/` | Always-on, every project. Keep lean (94 skills ≈ 10.4K tok/turn). |
+| `domain` | `.pi/skills/` | Installed only in a matching project type, by `category`. |
+| `exclude` | never installed | Claude-Code-authoring meta (hooks, blueprint, agent orchestration): pure budget waste in pi. |
+
+The classification is the single source of truth in
+[`../pi/tiers.yaml`](../pi/tiers.yaml) — **read it there**, don't restate the
+assignments here. Its header block documents the schema (`tier`, optional
+`skills:` cherry-pick, `category`, `reason`). Large general plugins (e.g.
+git-plugin) cherry-pick a core subset via the `skills:` list rather than
+installing every skill.
+
+The manifest is enforced by `scripts/check-pi-tiers.sh` (wired into
+`.pre-commit-config.yaml` and the `Plugin: PR checks` workflow): every
+marketplace plugin is classified exactly once, and every cherry-picked skill
+name resolves to a real `SKILL.md`.
+
+## Pipeline
+
+```
+pi/tiers.yaml ──▶ install-pi.sh ──▶ ~/.pi/agent/skills/   (general → global)
+                              └────▶ <project>/.pi/skills/ (a domain → project)
+                     mlx_lm.server ──▶ models.json ──▶ pi --model mlx-local/<id>
+```
+
+### 1. Install the curated skills
+
+```
+just pi-tiers                    # print the install plan (no writes)
+just install-pi                  # general tier → ~/.pi/agent/skills/
+just install-pi-domain infra     # an infra project's domain tier → .pi/skills/
+```
+
+`install-pi.sh` copies additively (existing skills under the target are
+preserved) and drops a `.claude-plugins-pi-receipt`. Flags: `--scope
+global|project`, `--category <cat>`, `--dry-run`, `--list`. Env overrides
+`PI_HOME` (default `~/.pi/agent`) and `PI_PROJECT_DIR` (default `$PWD`) exist for
+tests / non-standard layouts.
+
+### 2. Serve the model
+
+```
+uv tool install mlx-lm
+just serve-pi-model              # mlx_lm.server --model <pi_model> --port 8080
+curl -s localhost:8080/v1/models # verify it is up
+```
+
+`pi_model` / `pi_port` are overridable (`just pi_model=… serve-pi-model`, or
+`PI_MODEL` / `PI_PORT`).
+
+### 3. Point pi at the local endpoint — `~/.pi/agent/models.json`
+
+pi reads custom OpenAI-compatible providers from `~/.pi/agent/models.json`
+(re-read on every in-session `/model` switch — no restart needed). For an
+mlx_lm.server / ollama endpoint:
+
+```json
+{
+  "providers": {
+    "mlx-local": {
+      "baseUrl": "http://localhost:8080/v1",
+      "api": "openai-completions",
+      "apiKey": "mlx",
+      "compat": {
+        "supportsDeveloperRole": false,
+        "supportsReasoningEffort": false
+      },
+      "models": [
+        {
+          "id": "mlx-community/Qwen3.6-35B-A3B-4bit",
+          "name": "Qwen3.6 35B A3B 4bit (local)",
+          "contextWindow": 128000,
+          "maxTokens": 32000,
+          "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+        }
+      ]
+    }
+  }
+}
+```
+
+The `compat` flags matter for local servers: many OpenAI-compatible servers
+don't understand the `developer` role reasoning-capable models use
+(`supportsDeveloperRole: false` sends the system prompt as a plain system
+message), nor `reasoning_effort` (`supportsReasoningEffort: false`).
+
+`just setup-pi` runs `install-pi` then prints this block (with your `pi_model` /
+`pi_port` interpolated) plus the run command.
+
+### 4. Run pi against the local model
+
+```
+cd <project>
+pi --model mlx-local/mlx-community/Qwen3.6-35B-A3B-4bit
+```
+
+The end-to-end question this answers: does a **small local model actually
+invoke** a skill (not merely list it)? That is the real fidelity test — listing
+is cheap; a weak quant choosing and reading the right `SKILL.md` on intent is
+what makes this useful for local-model testing.
+
+## Out of scope (deferred)
+
+- **A `skill-search` pi extension** (a `search_skills` tool + suppressed default
+  injection). Only worth building if the trimmed Tier-1 general set still feels
+  tight on the smallest local quant. The tier manifest is the cheaper,
+  deterministic answer — defer the extension.
+- **Agent / prompt / hook porting.** Hooks especially are selective: only the
+  *safety* hooks would earn a pi `pi.on` port; the style nudges are noise on a
+  different harness.
+
+## Related
+
+- [`../pi/tiers.yaml`](../pi/tiers.yaml) — the tier classification (source of truth)
+- [`opencode-export.md`](opencode-export.md) — the sibling local-model export (heavier rulesync pipeline)
+- [pi custom-provider docs](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/custom-provider.md) — upstream `models.json` schema

--- a/justfile
+++ b/justfile
@@ -160,8 +160,46 @@ install-opencode-ocx target=opencode_config:
 # pi (pi.dev) export
 ####################
 
+# Local-model defaults (overridable via environment or `just pi_model=… <recipe>`).
+pi_model := env_var_or_default("PI_MODEL", "mlx-community/Qwen3.6-35B-A3B-4bit")
+pi_port := env_var_or_default("PI_PORT", "8080")
+
 # Verify pi/tiers.yaml matches the marketplace and its skill refs resolve
 # (local↔CI parity: the enforcement path is the script; this is a convenience alias)
 [group: "pi"]
 check-pi-tiers:
     ./scripts/check-pi-tiers.sh --strict
+
+# Print the tier install plan (what lands where) without writing anything
+[group: "pi"]
+pi-tiers:
+    ./scripts/install-pi.sh --list
+
+# Install the general tier into pi's global skills dir (~/.pi/agent/skills)
+[group: "pi"]
+install-pi:
+    ./scripts/install-pi.sh --scope global
+
+# Install a domain category into the project skills dir (.pi/skills)
+[group: "pi"]
+install-pi-domain category:
+    ./scripts/install-pi.sh --category "{{category}}" --scope project
+
+# Serve the local model via mlx-lm (OpenAI-compatible /v1 on the configured port)
+[group: "pi"]
+serve-pi-model:
+    mlx_lm.server --model {{pi_model}} --port {{pi_port}}
+
+# Install the general tier globally, then print the models.json + run next steps
+[group: "pi"]
+setup-pi: install-pi
+    @echo ""
+    @echo "Next steps:"
+    @echo "  1. Install the server:  uv tool install mlx-lm"
+    @echo "  2. Serve the model:     just serve-pi-model"
+    @echo "     (or: mlx_lm.server --model {{pi_model}} --port {{pi_port}})"
+    @echo "  3. Add a local provider to ~/.pi/agent/models.json:"
+    @echo '     {"providers":{"mlx-local":{"baseUrl":"http://localhost:{{pi_port}}/v1","api":"openai-completions","apiKey":"mlx","compat":{"supportsDeveloperRole":false,"supportsReasoningEffort":false},"models":[{"id":"{{pi_model}}","name":"{{pi_model}} (local)","contextWindow":128000,"maxTokens":32000,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0}}]}}}'
+    @echo "     (full block + rationale: docs/pi-export.md)"
+    @echo "  4. Run pi:              cd <project> && pi --model mlx-local/{{pi_model}}"
+    @echo "  5. Per-project domain:  just install-pi-domain <category>   (see: just pi-tiers)"

--- a/scripts/install-pi.sh
+++ b/scripts/install-pi.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# install-pi.sh — install this marketplace's skills into a pi (pi.dev) skills
+# directory, curated by tier (pi/tiers.yaml).
+#
+# pi loads Claude Code SKILL.md files unmodified but does not budget the
+# up-front skill-description listing, so dumping all ~400 skills wedges a
+# local model's small context. This installer copies only the tier-appropriate
+# set: the `general` tier into pi's global skills dir (~/.pi/agent/skills), a
+# `domain` category into the per-project skills dir (<cwd>/.pi/skills). `exclude`
+# plugins are never copied. Cherry-picked plugins (a `skills:` list in the
+# manifest) install only their listed skills.
+#
+# The copy is ADDITIVE: existing skills under the target are preserved.
+#
+# Usage:
+#   install-pi.sh [--scope global|project] [--category <cat>]
+#                 [--dry-run] [--list] [--root <repo-root>]
+#
+#   (no flags)          general tier -> global scope
+#   --category <cat>    that domain category -> project scope
+#   --scope <s>         override the derived scope
+#   --list              print the install plan (what lands where); no writes
+#   --dry-run           rehearse a full run; no writes
+#   --root <dir>        repo root holding pi/tiers.yaml + plugins (default: ../)
+#
+# Env overrides (for tests / non-standard layouts):
+#   PI_HOME         global pi agent dir (default: ~/.pi/agent) -> $PI_HOME/skills
+#   PI_PROJECT_DIR  project dir (default: $PWD)                -> .pi/skills
+set -euo pipefail
+
+pi_script_dir="$(cd "$(dirname "$0")" && pwd)"
+pi_root="$(cd "$pi_script_dir/.." && pwd)"
+pi_scope=""
+pi_category=""
+pi_dry_run=false
+pi_list=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --scope) pi_scope="$2"; shift 2 ;;
+    --category) pi_category="$2"; shift 2 ;;
+    --dry-run) pi_dry_run=true; shift ;;
+    --list) pi_list=true; shift ;;
+    --root) pi_root="$2"; shift 2 ;;
+    *) echo "install-pi.sh: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+pi_manifest="${pi_root}/pi/tiers.yaml"
+
+echo "=== PI INSTALL ==="
+
+if [ ! -f "$pi_manifest" ]; then
+  echo "STATUS=ERROR"
+  echo "ISSUE_COUNT=1"
+  echo "ISSUES:"
+  echo "  - SEVERITY=ERROR TYPE=missing_manifest MSG=pi/tiers.yaml not found at ${pi_manifest}"
+  echo "=== END PI INSTALL ==="
+  exit 1
+fi
+
+# Mode + default scope. A category selects the domain tier and defaults to a
+# per-project install; otherwise the general tier defaults to a global install.
+if [ -n "$pi_category" ]; then
+  pi_mode="domain"
+  [ -n "$pi_scope" ] || pi_scope="project"
+else
+  pi_mode="general"
+  [ -n "$pi_scope" ] || pi_scope="global"
+fi
+
+case "$pi_scope" in
+  global) pi_dest="${PI_HOME:-$HOME/.pi/agent}/skills" ;;
+  project) pi_dest="${PI_PROJECT_DIR:-$PWD}/.pi/skills" ;;
+  *) echo "install-pi.sh: --scope must be global or project, got: $pi_scope" >&2; exit 2 ;;
+esac
+
+# Expand a leading ~ (env overrides may carry one).
+if [ "${pi_dest#\~}" != "$pi_dest" ]; then
+  pi_dest="${HOME}${pi_dest#\~}"
+fi
+
+echo "MODE=$pi_mode"
+echo "SCOPE=$pi_scope"
+[ -n "$pi_category" ] && echo "CATEGORY=$pi_category"
+echo "DEST=$pi_dest"
+
+# ---------------------------------------------------------------------------
+# Parse the manifest into per-plugin tier/category + cherry-pick skill lists.
+# Records: PLUGIN <name> | TIER <name> <val> | CATEGORY <name> <val>
+#          | SKILL <name> <skill>
+# ---------------------------------------------------------------------------
+pi_records="$(awk '
+  /^  [a-z][a-z0-9-]*-plugin:/ {
+    line=$0
+    sub(/^  /, "", line)
+    name=line
+    sub(/:.*/, "", name)
+    plugin=name
+    print "PLUGIN " plugin
+    # Flow form: `name: { tier: X, category: Y }` on the same line.
+    if (line ~ /{/) {
+      braces=line
+      sub(/^[^{]*{/, "", braces)
+      if (match(braces, /tier:[[:space:]]*[a-z]+/)) {
+        t=substr(braces, RSTART, RLENGTH); sub(/tier:[[:space:]]*/, "", t)
+        print "TIER " plugin " " t
+      }
+      if (match(braces, /category:[[:space:]]*[a-z]+/)) {
+        c=substr(braces, RSTART, RLENGTH); sub(/category:[[:space:]]*/, "", c)
+        print "CATEGORY " plugin " " c
+      }
+    }
+    next
+  }
+  /^    tier:[[:space:]]*[a-z]+/ {
+    t=$2; print "TIER " plugin " " t; next
+  }
+  /^    category:[[:space:]]*[a-z]+/ {
+    c=$2; print "CATEGORY " plugin " " c; next
+  }
+  /^      - [a-z][a-z0-9-]+[[:space:]]*$/ {
+    print "SKILL " plugin " " $2; next
+  }
+' "$pi_manifest")"
+
+declare -A pi_tier=()
+declare -A pi_cat=()
+declare -A pi_cherry=()   # plugin -> space-separated cherry-picked skills
+declare -a pi_plugin_order=()
+while IFS= read -r rec; do
+  # shellcheck disable=SC2086  # deliberate word-split of a space-joined record
+  set -- $rec
+  case "$1" in
+    PLUGIN) pi_plugin_order+=("$2") ;;
+    TIER) pi_tier["$2"]="$3" ;;
+    CATEGORY) pi_cat["$2"]="$3" ;;
+    SKILL) pi_cherry["$2"]="${pi_cherry[$2]:-} $3" ;;
+  esac
+done <<< "$pi_records"
+
+# ---------------------------------------------------------------------------
+# Select the plugins for this run and resolve each to its skill dirs.
+# ---------------------------------------------------------------------------
+pi_planned=0
+pi_copied=0
+pi_issue_count=0
+pi_issues=""
+
+skills_of() {
+  # Emit the skill dir names to install for a plugin: the cherry-pick list if
+  # present, else every skill dir on disk.
+  local plugin="$1"
+  if [ -n "${pi_cherry[$plugin]:-}" ]; then
+    # shellcheck disable=SC2086  # deliberate word-split of the space-joined skill list
+    printf '%s\n' ${pi_cherry[$plugin]}
+  else
+    local d
+    for d in "${pi_root}/${plugin}/skills"/*/; do
+      [ -d "$d" ] || continue
+      basename "$d"
+    done
+  fi
+}
+
+for plugin in "${pi_plugin_order[@]}"; do
+  tier="${pi_tier[$plugin]:-}"
+  if [ "$pi_mode" = "general" ]; then
+    [ "$tier" = "general" ] || continue
+  else
+    [ "$tier" = "domain" ] || continue
+    [ "${pi_cat[$plugin]:-}" = "$pi_category" ] || continue
+  fi
+
+  while IFS= read -r skill; do
+    [ -n "$skill" ] || continue
+    src="${pi_root}/${plugin}/skills/${skill}"
+    if [ ! -f "${src}/SKILL.md" ]; then
+      pi_issues="${pi_issues}  - SEVERITY=WARN TYPE=skill_missing MSG=${plugin}/skills/${skill}/SKILL.md not found; skipped\n"
+      pi_issue_count=$((pi_issue_count + 1))
+      continue
+    fi
+    pi_planned=$((pi_planned + 1))
+    echo "PLAN=${pi_dest}/${skill} <- ${plugin}/skills/${skill}"
+    if [ "$pi_dry_run" = false ] && [ "$pi_list" = false ]; then
+      mkdir -p "${pi_dest}/${skill}"
+      cp -R "${src}/." "${pi_dest}/${skill}/"
+      pi_copied=$((pi_copied + 1))
+    fi
+  done < <(skills_of "$plugin")
+done
+
+echo "PLANNED_SKILLS=$pi_planned"
+
+pi_receipt=".claude-plugins-pi-receipt"
+if [ "$pi_dry_run" = true ] || [ "$pi_list" = true ]; then
+  echo "DRY_RUN=true"
+  echo "COPIED_SKILLS=0"
+else
+  echo "COPIED_SKILLS=$pi_copied"
+  # Drop a receipt so a later run can detect a prior install into this dir.
+  mkdir -p "$pi_dest"
+  printf 'installed_at=%s\nmode=%s\nscope=%s\ncategory=%s\nskills=%s\n' \
+    "$pi_dest" "$pi_mode" "$pi_scope" "${pi_category:-}" "$pi_copied" \
+    > "${pi_dest}/${pi_receipt}"
+  echo "RECEIPT=${pi_dest}/${pi_receipt}"
+fi
+
+if [ "$pi_issue_count" -gt 0 ]; then
+  echo "STATUS=WARN"
+  echo "ISSUE_COUNT=$pi_issue_count"
+  echo "ISSUES:"
+  echo -e "$pi_issues" | sed '/^$/d'
+else
+  echo "STATUS=OK"
+  echo "ISSUE_COUNT=0"
+fi
+echo "=== END PI INSTALL ==="
+exit 0

--- a/scripts/tests/test-install-pi.sh
+++ b/scripts/tests/test-install-pi.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Regression test for install-pi.sh (the tier-driven pi skills installer).
+# Uses a fixture repo (manifest + fake plugins) so paths are hermetic.
+# Asserts:
+#   A. general tier lands the cherry-picked core (foo-core, foo-extra) — the
+#      full plugin's other skills are NOT installed
+#   B. --category infra lands only infra-domain skills; other domains absent
+#   C. exclude-tier plugins are never copied
+#   D. --dry-run writes nothing
+#   E. a real run drops the receipt
+# Exit 0 on success, non-zero on failure.
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+installer="${script_dir}/../install-pi.sh"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+pass() { echo "PASS: $1"; }
+
+[ -f "$installer" ] || fail "install-pi.sh not found at $installer"
+
+sandbox="$(mktemp -d)"
+[ -n "$sandbox" ] || fail "mktemp -d returned empty"
+trap 'rm -rf "$sandbox"' EXIT
+
+fixture="${sandbox}/repo"
+
+build_fixture() {
+  rm -rf "${fixture:?}"
+  mkdir -p "${fixture}/pi"
+
+  # A general plugin with a cherry-pick list (core = foo-core, foo-extra;
+  # foo-noise exists on disk but is NOT listed, so must be dropped).
+  for s in foo-core foo-extra foo-noise; do
+    mkdir -p "${fixture}/gen-plugin/skills/${s}"
+    printf -- '---\nname: %s\n---\n' "$s" > "${fixture}/gen-plugin/skills/${s}/SKILL.md"
+  done
+  # A domain/infra plugin (no cherry-pick -> all skills).
+  mkdir -p "${fixture}/box-plugin/skills/box-run"
+  printf -- '---\nname: box-run\n---\n' > "${fixture}/box-plugin/skills/box-run/SKILL.md"
+  # A domain/lang plugin (different category — must not appear for infra).
+  mkdir -p "${fixture}/lang-plugin/skills/lang-fmt"
+  printf -- '---\nname: lang-fmt\n---\n' > "${fixture}/lang-plugin/skills/lang-fmt/SKILL.md"
+  # An exclude plugin (never copied).
+  mkdir -p "${fixture}/meta-plugin/skills/meta-thing"
+  printf -- '---\nname: meta-thing\n---\n' > "${fixture}/meta-plugin/skills/meta-thing/SKILL.md"
+
+  cat > "${fixture}/pi/tiers.yaml" <<'YAML'
+version: 1
+
+plugins:
+  gen-plugin:
+    tier: general
+    skills:
+      - foo-core
+      - foo-extra
+  box-plugin: { tier: domain, category: infra }
+  lang-plugin: { tier: domain, category: lang }
+  meta-plugin: { tier: exclude, reason: "meta" }
+YAML
+}
+
+# -----------------------------------------------------------------------------
+# Case A: general tier lands cherry-picked core, drops the unlisted skill
+# -----------------------------------------------------------------------------
+build_fixture
+gdest="${sandbox}/pi-home"
+PI_HOME="$gdest" bash "$installer" --root "$fixture" --scope global >/dev/null 2>&1 \
+  || fail "general install exited non-zero"
+[ -f "${gdest}/skills/foo-core/SKILL.md" ] || fail "foo-core (cherry-picked) not installed"
+[ -f "${gdest}/skills/foo-extra/SKILL.md" ] || fail "foo-extra (cherry-picked) not installed"
+[ -e "${gdest}/skills/foo-noise" ] && fail "foo-noise (unlisted) should NOT be installed"
+[ -e "${gdest}/skills/box-run" ] && fail "domain skill leaked into a general install"
+pass "general tier lands only the cherry-picked core"
+
+# -----------------------------------------------------------------------------
+# Case B: --category infra lands only infra-domain skills
+# -----------------------------------------------------------------------------
+build_fixture
+pdest="${sandbox}/proj"
+mkdir -p "$pdest"
+PI_PROJECT_DIR="$pdest" bash "$installer" --root "$fixture" --category infra >/dev/null 2>&1 \
+  || fail "infra install exited non-zero"
+[ -f "${pdest}/.pi/skills/box-run/SKILL.md" ] || fail "infra skill box-run not installed"
+[ -e "${pdest}/.pi/skills/lang-fmt" ] && fail "lang-domain skill leaked into an infra install"
+[ -e "${pdest}/.pi/skills/foo-core" ] && fail "general skill leaked into a domain install"
+pass "--category infra lands only infra-domain skills"
+
+# -----------------------------------------------------------------------------
+# Case C: exclude-tier plugins are never copied
+# -----------------------------------------------------------------------------
+# (covered implicitly above, asserted explicitly here across both scopes)
+[ -e "${gdest}/skills/meta-thing" ] && fail "exclude plugin copied into global scope"
+[ -e "${pdest}/.pi/skills/meta-thing" ] && fail "exclude plugin copied into project scope"
+pass "exclude-tier plugins are never copied"
+
+# -----------------------------------------------------------------------------
+# Case D: --dry-run writes nothing
+# -----------------------------------------------------------------------------
+build_fixture
+ddest="${sandbox}/dry"
+PI_HOME="$ddest" bash "$installer" --root "$fixture" --scope global --dry-run >/dev/null 2>&1 \
+  || fail "dry-run exited non-zero"
+[ -d "$ddest" ] && [ -n "$(find "$ddest" -mindepth 1 2>/dev/null)" ] && fail "--dry-run wrote to disk"
+pass "--dry-run writes nothing"
+
+# -----------------------------------------------------------------------------
+# Case E: a real run drops the receipt
+# -----------------------------------------------------------------------------
+[ -f "${gdest}/skills/.claude-plugins-pi-receipt" ] || fail "receipt not dropped after real install"
+pass "real run drops the receipt"
+
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
> **Stacked on #2048** (base = `feat/pi-tier-manifest`). Merge #2048 first. Per `git-hazards.md` #3: **retarget this PR to `main` _before_ merging #2048**, or GitHub auto-closes it when the base branch is deleted — and a closed PR whose base is gone cannot be reopened.

## What

Slices 2 + 3 of the pi integration. Consumes the `pi/tiers.yaml` manifest locked by #2048 — the piece that actually gets skills into [pi](https://pi.dev) and points a local model at them.

## The installer — `scripts/install-pi.sh`

Reads the manifest, populates pi's two native scopes **additively** (existing skills under the target are preserved):

| Invocation | Tier | Target |
|---|---|---|
| *(no flags)* | `general` | `~/.pi/agent/skills/` (94 skills) |
| `--category <cat>` | `domain` | `<project>/.pi/skills/` |
| — | `exclude` | never copied |

Cherry-picked plugins install **only** their listed skills — git-plugin lands its core **10**, not all 38. Flags: `--scope global|project`, `--category <cat>`, `--dry-run`, `--list`. `PI_HOME` / `PI_PROJECT_DIR` override targets for hermetic tests. Drops a `.claude-plugins-pi-receipt`; emits the structured `KEY=VALUE` / `STATUS=` block.

## Recipes — `just` group `pi`

| Recipe | Does |
|---|---|
| `pi-tiers` | Print the install plan (what lands where), no writes |
| `install-pi` | general tier → global scope |
| `install-pi-domain <cat>` | that domain → project `.pi/skills/` |
| `serve-pi-model` | `mlx_lm.server --model <pi_model> --port <pi_port>` |
| `setup-pi` | `install-pi`, then print the `models.json` provider block + run command |

`pi_model` / `pi_port` are overridable (`PI_MODEL` / `PI_PORT`).

## Docs — `docs/pi-export.md`

The canonical narrative (paralleling `docs/opencode-export.md`): the fidelity finding (pi loads `SKILL.md` **unmodified** — the whole OpenCode rulesync normalization layer is unnecessary), the ~111 tok/skill listing math, the tier→scope mapping, the `~/.pi/agent/models.json` local-provider schema **including the `compat` flags local servers need** (`supportsDeveloperRole` / `supportsReasoningEffort` — many OpenAI-compatible servers reject the `developer` role and `reasoning_effort`), and the pipeline. It **references** `pi/tiers.yaml` as source of truth rather than restating the assignments (`documentation-authoring.md`). `CLAUDE.md` gains a Local-model export pointer covering both pi and OpenCode.

## Verification

- `bash scripts/tests/test-install-pi.sh` → `ALL TESTS PASSED` — hermetic fixture repo asserting: general tier lands **only** the cherry-picked core (unlisted sibling skill dropped); `--category infra` lands only infra-domain skills (lang domain and general both absent); `exclude` plugins never copied in either scope; `--dry-run` writes nothing; receipt dropped.
- `just pi-tiers` on the real repo → `PLANNED_SKILLS=94`, exactly **10** git-plugin skills.
- `--category infra --list` → 29 skills from container/kubernetes/networking/terraform only.
- Real run into a throwaway `PI_HOME` → 94 skill dirs, `git-commit/SKILL.md` present, `hooks-configuration` (exclude tier) absent, receipt written. `--dry-run` into a fresh dir → 0 files.
- `pre-commit` green (installer regression hook fired); `shellcheck`, `lint-shell-scripts.sh`, `check-git-sandbox-guards.sh`, `check-docs-index.sh` clean.

## Notes

- `feat(pi)` is deliberately **not** a release-please package (no `-plugin` suffix) → no plugin version bump.
- Deferred (documented in the doc): the `skill-search` pi extension — only worth building if the trimmed 94-skill general set still feels tight on the smallest local quant; the tier manifest is the cheaper deterministic answer. Agent/hook porting is a separate follow-up.
- The end-to-end "does a small **local** model actually *invoke* a skill (not just list it)" run is the remaining manual step this PR unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Rc33NHzxPWeJdURoyYLex
