### PR TITLE
feat(agent-patterns): teach mcp-server-authoring to report progress

### DIFF
--- a/agent-patterns-plugin/skills/mcp-server-authoring/SKILL.md
+++ b/agent-patterns-plugin/skills/mcp-server-authoring/SKILL.md
@@ -151,7 +151,55 @@ Ollama, a database), and exclude it from the fast quality gate.
 `version` field fights the automation; let the commit history be the source of
 truth.
 
-### Step 7 — Choose transport before you ship
+### Step 7 — Report progress from any tool that can run long
+
+A tool that takes more than a few seconds — a model call, a subprocess, a crawl —
+is a black box to the client. Take a `Context` and report:
+
+```python
+from mcp.server.fastmcp import Context
+
+@mcp.tool()
+async def analyze(path: str, ctx: Context) -> str:
+    """Analyze a repository."""
+    files = discover(path)
+    for i, f in enumerate(files, 1):
+        await ctx.report_progress(i, len(files), f"analyzing {f.name}")   # message shows in the client
+        await inspect(f)
+    return summarize(files)
+```
+
+**Why it is not cosmetic**: progress notifications reset the client's **idle
+timeout**. A tool that emits nothing can be aborted for idleness *while it is
+still working* (Claude Code: 30 min stdio, 5 min HTTP/SSE). For a single long
+`await` with no natural increments, spawn a task that re-reports elapsed time on
+an interval — a heartbeat is both a status line and a keepalive.
+
+**What the user actually sees** (verified against Claude Code 2.1.207 — behavior,
+not a documented contract): the `message` is rendered on the in-flight tool row,
+whitespace-collapsed and truncated at 200 chars.
+
+| You send | Client shows |
+|---|---|
+| `message` + `progress`/`total` | `analyzing auth.py (42%)` |
+| `message` only | `analyzing auth.py` |
+| `progress` only | `Processing… 7` |
+| nothing | `Calling <server>…` ← the black box |
+
+**Report cost back in the *result*, not the progress line.** Progress reaches only
+the user's terminal; **nothing can reach the calling model mid-call**. Token counts,
+elapsed time, and anything the agent should reason about must ride back in the tool
+result (or its `_meta`), or the agent stays blind to what its own delegation cost.
+
+**Don't reach for the other channels**: `notifications/message` (the `logging`
+capability) is *silently dropped* by Claude Code — no handler is registered. For
+stdio servers, plain **stderr** is the debug path (`claude --debug mcp`).
+
+`ctx.report_progress` no-ops when the client sends no `progressToken`, so it is
+always safe to call. Keep it best-effort: a failed notification must never fail the
+tool call it describes.
+
+### Step 8 — Choose transport before you ship
 
 | Transport | When | Run |
 |-----------|------|-----|
@@ -176,6 +224,8 @@ guards against:
 - [ ] Tools raise on bad input (no sentinel returns) — else errors reach the model as ambiguous data.
 - [ ] Unit tests cover the plain functions; the live-backend path is a single `integration`-marked test — else the fast gate is slow and flaky.
 - [ ] `uv run ruff check . && uv run pytest -m "not integration"` is green — the fast quality gate.
+- [ ] Any tool that can run long calls `ctx.report_progress` — else the client shows a silent spinner and may abort the call on its idle timeout.
+- [ ] Cost/telemetry the agent should see (tokens, duration) is in the tool *result*, not only the progress message — progress never reaches the model.
 - [ ] Transport chosen deliberately (stdio unless the server must be shared).
 
 For the full primitive/transport reference, packaging, and the SDK inspector, see


### PR DESCRIPTION
## What

Adds **Step 7 — Report progress from any tool that can run long** to the `mcp-server-authoring` skill (transport becomes Step 8), plus two shipping-checklist items.

## Why

The skill had **no mention of progress, notifications, or timeouts**. A server built from it ships tools that are silent black boxes — which is exactly what happened in `pal-mcp-server`: every tool call showed only `⏺ Calling pal 2 times…`, with no way to tell a thinking model from a hung one.

Wiring progress into that server surfaced three facts the skill should have supplied up front. **Two are not in the MCP docs**, which is the argument for encoding them here rather than rediscovering them:

1. **Progress notifications reset the client's idle timeout.** A tool that emits nothing can be *aborted for idleness while it is still working* (Claude Code: 30 min stdio, 5 min HTTP/SSE). This is what makes reporting a correctness concern rather than a nicety — and it's the fact most likely to be missed.
2. **The `message` field is rendered on the in-flight tool row.** Verified against the Claude Code 2.1.207 binary: whitespace-collapsed, truncated at 200 chars, `(nn%)` suffix when `total` is set. Marked in the skill as *observed behavior, not a documented contract*, so a future reader knows its epistemic status.
3. **Nothing can reach the calling model mid-call.** Cost/telemetry the agent should reason about (tokens, duration) must ride back in the tool *result* — putting it only in the progress message means the user sees it and the agent never does. Easy to get wrong, invisible when you do.

Also records a dead end so nobody re-walks it: `notifications/message` (the `logging` capability) is **silently dropped** by Claude Code — no handler is registered — so stderr is the debug path for stdio servers.

## Notes

- Guidance uses the idiomatic FastMCP form (`ctx.report_progress(...)`), verified against the installed SDK — it no-ops when the client sends no `progressToken`, so it is always safe to call.
- Skill is 259 lines, comfortably inside budget.
- Real-world instance of the gap: laurigates/pal-mcp-server#63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wryFZuz4HEs1oqY9EJfGo