### PR TITLE
feat(comfyui-plugin): add comfy-corpus-validation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ the rules, skills, and hooks that embody it.
 |--------|--------|-------------|
 | **api-plugin** | 1 | API integration and testing - REST endpoints, client generation |
 | **blueprint-plugin** | 34 | Blueprint Development methodology - PRD/PRP workflow with version tracking |
-| **comfyui-plugin** | 16 | ComfyUI custom-node pack lifecycle - scaffold, seed repo, gitops adoption, registry publish |
+| **comfyui-plugin** | 17 | ComfyUI custom-node pack lifecycle - scaffold, seed repo, gitops adoption, registry publish |
 | **home-assistant-plugin** | 4 | Home Assistant configuration - automations, scripts, scenes, entities |
 | **obsidian-plugin** | 21 | Obsidian CLI operations - vault management, search, properties, tasks |
 | **project-plugin** | 7 | Project initialization, management, maintenance, and continuous development |

--- a/comfyui-plugin/README.md
+++ b/comfyui-plugin/README.md
@@ -143,6 +143,18 @@ how App Mode turns a finished workflow into a fill-the-form UI.
 **Use when** deciding whether to package part of a workflow as a subgraph, a
 reusable Blueprint, or an App Mode UI.
 
+### comfy-corpus-validation
+
+The method for keeping a pack's *factual* corpus true: the source-of-truth
+ladder (executable ground truth > shipped vendor templates > secondary
+sources), measuring a scheduler's sigma curve instead of asserting what it
+does, escalating or staying silent when sources disagree, and treating
+coverage — what the live install offers that the corpus never describes — as
+a first-class check. Routes to `just corpus-check` in `comfyui-sampler-info`.
+
+**Use when** writing or auditing sampler/scheduler/model metadata, or deciding
+whether to believe a source that says "model M wants sampler S".
+
 ### Workflow-graph node-selection reference
 
 `comfy-cli`, `comfy-conditionals`, `comfy-debug-preview`, `comfy-flow-control`,

--- a/comfyui-plugin/README.md
+++ b/comfyui-plugin/README.md
@@ -147,8 +147,9 @@ reusable Blueprint, or an App Mode UI.
 
 The method for keeping a pack's *factual* corpus true: the source-of-truth
 ladder (executable ground truth > shipped vendor templates > secondary
-sources), measuring a scheduler's sigma curve instead of asserting what it
-does, escalating or staying silent when sources disagree, and treating
+sources), *executing* a scheduler to measure its sigma curve rather than
+asserting — or even source-reading — what it does, escalating or staying
+silent when sources disagree, and treating
 coverage — what the live install offers that the corpus never describes — as
 a first-class check. Routes to `just corpus-check` in `comfyui-sampler-info`.
 

--- a/comfyui-plugin/skills/comfy-corpus-validation/REFERENCE.md
+++ b/comfyui-plugin/skills/comfy-corpus-validation/REFERENCE.md
@@ -1,0 +1,206 @@
+# comfy-corpus-validation — worked examples
+
+Three real misses, each worked end to end with the numbers that settled it.
+All values below were verified against a live RES4LYF-equipped ComfyUI
+install and the shipped workflow templates on 2026-07-14.
+
+---
+
+## 1. The `er_sde` disagreement — resolving a Tier-3 conflict at Tier 2
+
+### The situation
+
+Secondary sources split on which sampler Krea 2 wants. A well-ranked
+blog/guide asserted `er_sde`. Other Tier-3 sources disagreed. The tempting
+move — and the one nearly taken — was to believe the better-ranked source,
+because it *looked* more authoritative.
+
+Search ranking is not evidence. Two Tier-3 sources in conflict is not a
+50/50 coin flip to be broken by page rank; it is a signal that **neither is
+sufficient** and the question must be escalated.
+
+### The resolution
+
+ComfyUI ships the vendor's own workflow templates in
+`comfyui_workflow_templates_json/templates/*.json`. The KSampler widget
+values in those templates **are** the vendor's default recipe — not a
+description of it, not an interpretation of it, but the thing itself, as
+loaded when a user clicks the template in the UI.
+
+| Template | sampler | scheduler | steps | CFG |
+|---|---|---|---|---|
+| `image_krea2_turbo_t2i.json` | `euler` | `simple` | 8 | 1 |
+| `flux1_krea_dev.json` | `euler` | `simple` | 20 | 1 |
+
+`euler`, not `er_sde`. The higher-ranked blog was simply wrong, and no amount
+of reading more blogs would have revealed that — only a rung-2 source could.
+
+### The generalizable move
+
+When two Tier-3 sources conflict about "model M wants sampler S":
+
+1. Look for a shipped template for M. It settles the question outright.
+2. Failing that, docs.comfy.org or the HF model card (still Tier 2).
+3. Failing that, **write nothing**. `(no metadata for this option yet)` is an
+   honest UI state. A confidently wrong sentence is not.
+
+---
+
+## 2. The `beta57` measurement that falsified our own prose
+
+### The claim we shipped
+
+PR #72 added a `beta57` scheduler entry to the corpus whose prose said it
+"spends steps in the mid-range rather than at the extremes". That sentence
+was written from model memory — it sounded right, it was internally coherent,
+and nobody could see it was false by reading it. Corrected in #77.
+
+### What `beta57` actually is (Tier 1, from source)
+
+RES4LYF's `__init__.py` registers the token by partially applying **core's
+own** beta scheduler:
+
+```python
+SCHEDULER_HANDLERS["beta57"] = SchedulerHandler(
+    partial(comfy.samplers.beta_scheduler, alpha=0.5, beta=0.7)
+)
+```
+
+Core `beta` defaults to `alpha=0.6, beta=0.6`. So `beta57` is not a new
+algorithm at all — it is `beta` with a different Beta-distribution shape.
+That fact came from **reading the registration**, not from a blog.
+
+### The measurement
+
+Call the real handler against a real `comfy.model_sampling.ModelSamplingDiscrete()`
+at **20 steps**. σ_max = 14.615.
+
+Sigma lists (20 steps → 21 values, terminating at 0):
+
+- `simple`: 14.615, 10.904, 8.303, 6.443, 5.088, 4.082, 3.321, 2.735, 2.276,
+  1.910, 1.613, 1.367, 1.161, 0.984, 0.830, 0.693, 0.569, 0.454, 0.342,
+  0.223, 0.0
+- `beta57`: 14.615, 12.158, 9.188, 6.702, 4.884, 3.601, 2.695, 2.069, 1.613,
+  1.276, 1.024, 0.824, 0.665, 0.536, 0.427, 0.335, 0.256, 0.185, 0.123,
+  0.066, 0.0
+
+Bucket the steps into noise bands as a fraction of σ_max — high > 0.5, mid
+0.1–0.5, low < 0.1:
+
+| scheduler | high | mid | low |
+|---|---|---|---|
+| `simple` | 3 | 8 | 9 |
+| `beta` | 5 | 6 | 9 |
+| `beta57` | 3 | 6 | **11** |
+
+### The verdict
+
+`beta57` takes steps **out of the mid-noise range and spends them at the
+low-noise end** — the exact opposite of what the corpus said. Read the tails
+of the two sigma lists: `beta57`'s final values (0.335, 0.256, 0.185, 0.123,
+0.066) crowd far tighter toward zero than `simple`'s (0.693, 0.569, 0.454,
+0.342, 0.223). That is what "spends steps at the low-noise end" *looks like*
+numerically, and it is visible in ten seconds once the numbers exist.
+
+### The generalizable move
+
+**Never assert what a schedule does. Compute it.** Any prose in the corpus
+containing a step-allocation claim ("front-loads", "concentrates at",
+"spends steps in") is a claim that `corpus_probe.py` can settle mechanically.
+That is precisely why `corpus_check.py`'s BEHAVIOUR section prints the
+measured band table next to any entry whose prose makes such a claim: so the
+reviewer's eye lands on the sentence and the numbers at the same time.
+
+---
+
+## 3. The subgraph-hidden KSampler
+
+### The trap
+
+A naive scan of a template's top-level `nodes` array for a `KSampler` returns
+**nothing** for `image_krea2_turbo_t2i.json` and `flux1_krea_dev.json`. The
+obvious reading — "this template doesn't configure a sampler" — is exactly
+backwards. The KSampler is there; it lives under:
+
+```
+definitions.subgraphs[].nodes
+```
+
+The template is the authoritative Tier-2 answer, and a top-level-only scan
+makes it look silent. Any code that reads templates must walk
+`definitions.subgraphs[]` as well as `nodes`.
+
+### The actual widget vector
+
+The Krea 2 Turbo template's KSampler:
+
+```json
+[735915477938686, "randomize", 8, 1, "euler", "simple", 1]
+```
+
+KSampler `widgets_values` are **positional**, in this order:
+
+| index | field |
+|---|---|
+| 0 | `seed` |
+| 1 | `control_after_generate` |
+| 2 | `steps` |
+| 3 | `cfg` |
+| 4 | `sampler_name` |
+| 5 | `scheduler` |
+| 6 | `denoise` |
+
+So the vector above reads: 8 steps, CFG 1, `euler`, `simple`, denoise 1 —
+which is exactly the row in the table in §1.
+
+### The sibling trap
+
+The Comfy Registry API's `latest_version` is **not** the newest version. Same
+class of mistake: a field whose *name* looks like the answer, trusted without
+checking what it actually contains. Both traps share one rule — **confirm
+what a field means before you believe what it says.**
+
+---
+
+## 4. Provenance straight from Tier 1: which pack ships which scheduler
+
+A live `/object_info/KSampler` on a RES4LYF-equipped install offers:
+
+```
+['simple', 'sgm_uniform', 'karras', 'exponential', 'ddim_uniform',
+ 'beta', 'normal', 'linear_quadratic', 'kl_optimal',
+ 'bong_tangent', 'beta57']
+```
+
+Core `comfy.samplers.SCHEDULER_HANDLERS`, imported **without** custom nodes
+loaded, has only the first nine.
+
+The set difference is mechanical:
+
+```
+{bong_tangent, beta57} = live_install_tokens − core_tokens
+```
+
+That diff *proves* the fact "`beta57` and `bong_tangent` ship with RES4LYF,
+not core" — no blog needed, no memory involved, and it stays correct
+automatically as core adds schedulers or the install's pack set changes. This
+is what Tier 1 buys: a fact that re-derives itself instead of going stale.
+
+`corpus_probe.py` emits exactly this as its `tokens` section, tagging each
+token with its provider via the node's `python_module`, so `corpus_check.py`
+can flag a corpus entry that attributes a token to the wrong provider.
+
+---
+
+## Why all three misses have the same shape
+
+Each was a claim written at a lower rung than the one that could settle it:
+
+| Miss | Written at | Could have been settled at |
+|---|---|---|
+| Krea 2 wants `er_sde` | Tier 3 (a blog) | Tier 2 (the shipped template) |
+| `beta57` "spends steps in the mid-range" | memory | Tier 1 (compute the sigmas) |
+| Krea 2 absent from the corpus | nowhere — nobody asked | Tier 1 (what does the install offer?) |
+
+Which is the whole rule, restated: **a claim about ComfyUI is only as good as
+the highest rung you verified it on.**

--- a/comfyui-plugin/skills/comfy-corpus-validation/REFERENCE.md
+++ b/comfyui-plugin/skills/comfy-corpus-validation/REFERENCE.md
@@ -113,7 +113,101 @@ reviewer's eye lands on the sentence and the numbers at the same time.
 
 ---
 
-## 3. The subgraph-hidden KSampler
+## 3. `linear_quadratic` — the method catching a bug in the corpus that motivated the method
+
+This one is the best evidence the method works, because nobody knew about it.
+It was found by the **first real run** of `corpus-check` against the live
+install — not by a human noticing something odd. It is also the sharpest form
+of the "measure, don't assert" protocol, because the author of the wrong claim
+had done the *right* thing and still got it backwards.
+
+### The claim we shipped
+
+`schedulers.json` said of `linear_quadratic`:
+
+> "Heavily weighted toward the low-noise end: the linear half of the steps all
+> sit below ~2.5% of max sigma, so most of the budget goes to detail refinement
+> rather than composition."
+
+Specific, mechanistic, and cites a real number. It reads like someone checked.
+
+### The measurement
+
+Against `comfy.model_sampling.ModelSamplingDiscrete()` (σ_max = 14.615), at 20
+steps. The first 11 sigmas barely move:
+
+```
+14.615, 14.578, 14.542, 14.505, 14.469, 14.432, 14.395, 14.359, 14.322, 14.286, 14.249, …
+```
+
+then it dives off a cliff:
+
+```
+…, 14.074, 13.621, 12.890, 11.882, 10.596, 9.032, 7.190, 5.071, 2.675, 0.0
+```
+
+Step allocation by band (fraction of σ_max: high > 0.5, mid 0.1–0.5, low < 0.1):
+
+| scheduler | high | mid | low |
+|---|---|---|---|
+| `simple` (baseline) | 3 | 8 | 9 |
+| `beta57` | 3 | 6 | **11** |
+| `linear_quadratic` | **17** | 3 | **0** |
+
+It spends **more than half its budget barely denoising at all** — 17 of 20
+steps in the high-noise/composition band — and crosses the low-noise detail end
+in a handful of enormous jumps. **Zero** steps in the low band. The corpus said
+"heavily weighted toward the low-noise end". It is the precise opposite.
+
+### Why the author got it wrong — the transferable lesson
+
+`linear_quadratic_schedule` in `comfy/samplers.py`:
+
+```python
+linear_sigma_schedule = [i * threshold_noise / linear_steps for i in range(linear_steps)]
+...
+sigma_schedule = linear_sigma_schedule + quadratic_sigma_schedule + [1.0]
+sigma_schedule = [1.0 - x for x in sigma_schedule]          # <-- THE INVERSION
+return torch.FloatTensor(sigma_schedule) * model_sampling.sigma_max.cpu()
+```
+
+`threshold_noise` defaults to 0.025. So the linear half really *is* built from
+values below 2.5% — the corpus sentence is **literally true of
+`linear_sigma_schedule`**. Then, one line down, `1.0 - x` inverts every value,
+and those 2.5%-of-max entries become **≥97.5% of σ_max**. The author read the
+source, read it correctly, and missed the inversion.
+
+That makes this a sharper case than `beta57`. `beta57` was a memory failure —
+the fix is "go look at the code". This one *was* someone going to look at the
+code. **Source-reading is Tier 1 and it still produced a confidently wrong,
+plausible-sounding, number-citing claim**, because a single line downstream
+inverted the meaning.
+
+> **Reading the source is not the same as computing the output.** The only
+> thing that catches this class is running the function and looking at the
+> numbers it returns.
+
+This is why Protocol 1 says *measure*, not *check the source*. A derivation has
+as many places to go wrong as it has lines; the returned array has none.
+
+### The error had already propagated
+
+Wrong mechanism claims do not stay put. `euler_ancestral_cfg_pp`'s `good_for`
+justified pairing it with `linear_quadratic` on the grounds that the scheduler
+"spends steps at the low-noise end… where an ancestral sampler's per-step noise
+injection gets resolved into detail" — reasoning built directly on top of the
+false premise, in a different file, for a different token.
+
+So a single unmeasured claim had become **load-bearing for other entries'
+recommendations**. That is the real cost of a wrong fact in a corpus: it is not
+one bad sentence, it is a foundation that later entries lean on, and every one
+of them inherits the error while looking independently reasoned.
+
+Both fixed in `comfyui-sampler-info#80`; the tooling that caught it is `#79`.
+
+---
+
+## 4. The subgraph-hidden KSampler
 
 ### The trap
 
@@ -162,7 +256,7 @@ what a field means before you believe what it says.**
 
 ---
 
-## 4. Provenance straight from Tier 1: which pack ships which scheduler
+## 5. Provenance straight from Tier 1: which pack ships which scheduler
 
 A live `/object_info/KSampler` on a RES4LYF-equipped install offers:
 
@@ -192,7 +286,7 @@ can flag a corpus entry that attributes a token to the wrong provider.
 
 ---
 
-## Why all three misses have the same shape
+## Why all four misses have the same shape
 
 Each was a claim written at a lower rung than the one that could settle it:
 
@@ -201,6 +295,11 @@ Each was a claim written at a lower rung than the one that could settle it:
 | Krea 2 wants `er_sde` | Tier 3 (a blog) | Tier 2 (the shipped template) |
 | `beta57` "spends steps in the mid-range" | memory | Tier 1 (compute the sigmas) |
 | Krea 2 absent from the corpus | nowhere — nobody asked | Tier 1 (what does the install offer?) |
+| `linear_quadratic` "weighted toward the low-noise end" | Tier 1 **read**, not run | Tier 1 **executed** (compute the sigmas) |
+
+The last row is the one to internalize. Tier 1 is not a *place you looked* — it
+is a *thing you ran*. Reading `samplers.py` and executing `samplers.py` are
+different rungs, and only one of them returns numbers that cannot argue back.
 
 Which is the whole rule, restated: **a claim about ComfyUI is only as good as
 the highest rung you verified it on.**

--- a/comfyui-plugin/skills/comfy-corpus-validation/SKILL.md
+++ b/comfyui-plugin/skills/comfy-corpus-validation/SKILL.md
@@ -23,7 +23,8 @@ in one day, each caught by luck: a blog-sourced sampler recommendation that
 the vendor's own template contradicted, a schedule-behaviour claim written
 from model memory that computing the sigmas falsified, and a model family
 absent from the corpus entirely because nothing ever asked what the live
-install offers that we describe.
+install offers that we describe. The first real run of the tooling below
+immediately found a fourth nobody knew about.
 
 ## The core rule
 
@@ -71,7 +72,15 @@ This is the only thing that caught the `beta57` error: the corpus claimed it
 "spends steps in the mid-range rather than at the extremes". Measurement
 showed it does the exact opposite — it takes steps *out of* the mid range and
 spends them at the low-noise end. No amount of plausible reasoning would have
-found that; one computation did. Full numbers in `REFERENCE.md`.
+found that; one computation did.
+
+**Reading the source is not the same as executing it.** The first real run of
+`corpus-check` caught a *fourth* error: `linear_quadratic`'s prose was written
+by reading `comfy/samplers.py` — correctly — but missing the `1.0 - x`
+inversion one line down, so the claim came out exactly backwards (it spends 17
+of 20 steps at *high* noise, not low). Source-reading is Tier 1 and still
+produced a confident falsehood. Only running the function and looking at the
+numbers it returns catches this class. Full numbers in `REFERENCE.md`.
 
 ### 2. Disagreement means escalate or stay silent
 
@@ -159,9 +168,10 @@ entries where it can drift.
 
 ## See also
 
-`REFERENCE.md` — the three misses worked end to end with the real numbers:
-the `er_sde` disagreement and its Tier-2 resolution, the `beta57` sigma
-measurement that falsified our own prose (with the sigma lists and band
-table), the subgraph-hidden KSampler and its exact `widgets_values` vector,
-and how a Tier-1 `/object_info` diff mechanically proves which pack provides
-which scheduler.
+`REFERENCE.md` — the four misses worked end to end with the real numbers: the
+`er_sde` disagreement and its Tier-2 resolution, the `beta57` sigma
+measurement that falsified our own prose, the `linear_quadratic` inversion
+that survived a correct reading of the source (and had already propagated into
+another entry's reasoning), the subgraph-hidden KSampler and its exact
+`widgets_values` vector, and how a Tier-1 `/object_info` diff mechanically
+proves which pack provides which scheduler.

--- a/comfyui-plugin/skills/comfy-corpus-validation/SKILL.md
+++ b/comfyui-plugin/skills/comfy-corpus-validation/SKILL.md
@@ -1,0 +1,167 @@
+---
+created: 2026-07-14
+modified: 2026-07-14
+reviewed: 2026-07-14
+name: comfy-corpus-validation
+description: >-
+  Verify ComfyUI sampler/scheduler facts: source-of-truth ladder, measured sigma curves, coverage gaps. Use when writing or auditing sampler corpus metadata.
+allowed-tools: Bash, Read, Grep, Glob, Write, Edit
+---
+
+# comfy-corpus-validation
+
+`comfyui-sampler-info` ships a JSON **corpus** (`web/data/samplers.json`,
+`web/data/schedulers.json`, `web/data/models.json`) of human-written facts
+about ComfyUI's sampler and scheduler tokens — year, family, ODE order,
+summary, `good_for`, `pairs_with`, and per-model default recipes. The pack's
+entire value is that those facts are **true**. A wrong fact is worse than a
+missing one: the UI presents it with the same confidence either way.
+
+This skill is the method for making corpus claims verifiable instead of
+remembered. It exists because three factual misses shipped or nearly shipped
+in one day, each caught by luck: a blog-sourced sampler recommendation that
+the vendor's own template contradicted, a schedule-behaviour claim written
+from model memory that computing the sigmas falsified, and a model family
+absent from the corpus entirely because nothing ever asked what the live
+install offers that we describe.
+
+## The core rule
+
+> **A claim about ComfyUI is only as good as the highest rung you verified it
+> on. Never write a Tier-3 claim that a Tier-1/2 source could settle but
+> didn't.**
+
+## When to Use This Skill
+
+| Use this skill when... | Use instead when... |
+|---|---|
+| Adding or editing an entry in `web/data/*.json` (sampler, scheduler, model recipe) | Reading generation settings *out of* an output PNG/WebP/MP4 -> `comfy-metadata` |
+| Auditing whether the corpus's existing facts are still true | Checking whether the *pack itself* works in a live install -> `comfyui-pack-live-smoke` |
+| A source claims "model M wants sampler S" and you must decide whether to believe it | Debugging the pack's publish/release pipeline -> `comfy-registry-lifecycle` |
+| Asking what the install offers that the corpus says nothing about | Writing the pack's frontend/backend code -> `comfyui-node-authoring` |
+
+`comfyui-pack-live-smoke` verifies the pack *functions*. This skill verifies
+its *facts are true*. A pack can be perfectly working and comprehensively
+wrong.
+
+## The source-of-truth ladder
+
+| Tier | Source | Settles |
+|---|---|---|
+| **1. Executable ground truth** | `/object_info/<NodeClass>` on a live install (token lists + `python_module`); `comfy/samplers.py` (`SCHEDULER_HANDLERS`, `KSAMPLER_NAMES`, `SAMPLER_NAMES`); custom-node source; **computing the sigma curve** by calling the real handler | Does the token exist? Who provides it (core vs which pack)? What does the schedule *actually do*? |
+| **2. Shipped vendor artifacts** | `comfyui_workflow_templates_json/templates/*.json` — the KSampler widget values in the official template **are** the vendor's default recipe; docs.comfy.org; the HF model card | What does the vendor actually recommend for model M? |
+| **3. Secondary sources** | Blogs, tutorials, Civitai, Reddit | *Discovering* claims. Never the sole basis for one. |
+| **4. Empirical testing** | Your own generation results | Legitimate — but must be **labelled** (`source.kind: "empirical"`), and where possible backed by a Tier-1 mechanism. |
+
+Tier 1 beats Tier 2 beats Tier 3. Tier 4 is not a lower Tier 3 — it is a
+different kind of claim (yours, not someone's), and honest labelling is what
+keeps it usable.
+
+## The three protocols
+
+### 1. Measure behaviour, never assert it
+
+Any claim about *what a schedule does* — "concentrates steps at the low-noise
+end", "front-loads denoising", "spends steps in the mid-range" — is
+**computed, not remembered**. Call the real handler against a real
+`ModelSampling`, get the sigma list, bucket the steps into noise bands, and
+read the answer off the table.
+
+This is the only thing that caught the `beta57` error: the corpus claimed it
+"spends steps in the mid-range rather than at the extremes". Measurement
+showed it does the exact opposite — it takes steps *out of* the mid range and
+spends them at the low-noise end. No amount of plausible reasoning would have
+found that; one computation did. Full numbers in `REFERENCE.md`.
+
+### 2. Disagreement means escalate or stay silent
+
+When two Tier-3 sources conflict, **resolve at Tier 1/2, or do not write the
+claim.** Never break the tie by picking the better-ranked blog — search
+ranking is not evidence. A top-ranked guide said Krea 2 wants `er_sde`;
+ComfyUI's own shipped workflow template says `euler`. The template is the
+vendor's recipe and it wins. When no Tier-1/2 source can settle it, the
+correct corpus entry is *no entry* — the UI's `(no metadata for this option
+yet)` is honest; a confident wrong sentence is not.
+
+### 3. Coverage is a first-class check
+
+Ask, every time: **"what does the live install offer that the corpus says
+nothing about?"** Krea 2 was missing from the corpus entirely, and nothing in
+the process ever asked the question, so the gap stayed invisible until a user
+did. An undescribed token is a visible hole in the pack's UI. Coverage is not
+a nice-to-have audit; it is one of the three checks `corpus-check` runs.
+
+## Two traps that will bite you
+
+**Template samplers hide inside subgraphs.** In `image_krea2_turbo_t2i.json`
+and `flux1_krea_dev.json` the `KSampler` node lives under
+`definitions.subgraphs[].nodes`, **not** top-level `nodes`. A naive
+top-level scan returns nothing, which reads as "this template configures no
+sampler" — exactly backwards, since the template is the authoritative answer.
+Always walk `definitions.subgraphs[]` too.
+
+**A field that looks like the answer isn't.** The Comfy Registry API's
+`latest_version` is *not* the newest version. Same class of error: a
+plausibly-named field is not evidence. Check what the field means before
+trusting what it says.
+
+## Running the check
+
+Ground truth is **regenerated on demand, never committed** — a committed
+snapshot is just another stale secondary source.
+
+```
+COMFY_SSH_HOST=popos.intra.lakuz.com just corpus-check
+```
+
+Two halves, split because only one of them needs a GPU box:
+
+- **`scripts/corpus_probe.py`** runs *on a ComfyUI host* (needs torch +
+  ComfyUI importable). It emits ground truth as JSON on stdout:
+  - `tokens` — sampler/scheduler tokens the live install offers, each tagged
+    with its provider (core vs which custom-node pack).
+  - `schedulers` — the **measured** sigma curve per scheduler plus the step
+    allocation across low/mid/high noise bands.
+  - `templates` — `{template, sampler, scheduler, steps, cfg}` rows from the
+    shipped workflow templates, **including subgraph-nested KSamplers**.
+- **`scripts/corpus_check.py`** runs *locally*, stdlib-only. It consumes the
+  probe JSON plus `web/data/*.json` and emits a structured
+  `=== SECTION ===` / `KEY=VALUE` / `STATUS=` report.
+
+### Reading the report
+
+| Section | What it means | What to do about it |
+|---|---|---|
+| **COVERAGE** | Tokens the install offers that the corpus doesn't describe (resolved exact → alias → prefix) | Write the entry, or accept the hole deliberately |
+| **RECIPES** | Every `models.json` entry citing `source.template` re-checked against the probe's template rows | A FAIL means **upstream changed the template** — that is the point, not a bug. Re-read the template and update the recipe |
+| **BEHAVIOUR** | The measured band table shown beside any entry whose prose makes a step-allocation claim | Read the prose against the numbers. If they disagree, the prose is wrong |
+
+A RECIPES FAIL is the check earning its keep: it means the vendor moved and
+the corpus didn't.
+
+## Labelling provenance
+
+Any corpus entry may carry a `source` field. `kind` is one of:
+
+| `kind` | Meaning |
+|---|---|
+| `vendor-default` | From a shipped workflow template — **the only kind carrying a machine-checkable `template`**, and the only one `corpus-check` can re-verify |
+| `vendor-doc` | docs.comfy.org or the model card |
+| `pack-provided` | Documented by the custom-node pack that ships the token |
+| `community` | Tier 3. Use sparingly, and never for a claim Tier 1/2 could settle |
+| `empirical` | Your own testing. Honest, and must say so |
+| `paper` | The originating paper |
+
+`models.json` stores each model family's vendor-default recipe **exactly
+once**, with the template it came from — so the recipe has one home and one
+checkable provenance, rather than being restated in prose across several
+entries where it can drift.
+
+## See also
+
+`REFERENCE.md` — the three misses worked end to end with the real numbers:
+the `er_sde` disagreement and its Tier-2 resolution, the `beta57` sigma
+measurement that falsified our own prose (with the sigma lists and band
+table), the subgraph-hidden KSampler and its exact `widgets_values` vector,
+and how a Tier-1 `/object_info` diff mechanically proves which pack provides
+which scheduler.

--- a/docs/diagrams/plugin-relationships.d2
+++ b/docs/diagrams/plugin-relationships.d2
@@ -259,7 +259,7 @@ domain: {
     class: domain
   }
   comfyui: {
-    label: "comfyui\n16 skills"
+    label: "comfyui\n17 skills"
     shape: rectangle
     class: domain
   }


### PR DESCRIPTION
## What

Adds `comfyui-plugin/skills/comfy-corpus-validation/` (SKILL.md + REFERENCE.md) — the method for keeping the `comfyui-sampler-info` pack's JSON corpus (`web/data/samplers.json`, `schedulers.json`, `models.json`) factually true, rather than merely plausible.

## Why

Three factual misses shipped or nearly shipped in one day, each caught by luck rather than process:

1. **A blog said Krea 2 wants `er_sde`.** ComfyUI's own shipped workflow template says `euler`. The better-ranked secondary source was nearly believed.
2. **`beta57` "spends steps in the mid-range rather than at the extremes"** — written from model memory into the corpus (#72). Actually computing the sigma schedule showed it does the exact opposite. Corrected in #77.
3. **Krea 2 was absent from the corpus entirely** — nothing in the process ever asked "what does the live install offer that we describe nothing about?", so the gap was invisible until a user found it.

All three have one shape: a claim written at a lower rung than the one that could have settled it.

## What the skill encodes

- **The core rule** — a claim about ComfyUI is only as good as the highest rung you verified it on; never write a Tier-3 claim a Tier-1/2 source could settle.
- **The source-of-truth ladder** — executable ground truth (`/object_info`, `comfy/samplers.py`, computing the sigma curve) > shipped vendor artifacts (workflow templates, docs, model cards) > secondary sources > labelled empirical.
- **Three protocols** — measure behaviour rather than assert it; on disagreement escalate or stay silent; treat coverage as a first-class check.
- **Two traps** — template samplers hide inside `definitions.subgraphs[].nodes` (a top-level scan reads as "no sampler configured"), and a plausibly-named field is not the answer (`latest_version` is not the newest version).
- **How to run and read `just corpus-check`** (the probe/check scripts landing in `comfyui-sampler-info`).

`REFERENCE.md` works all three misses end to end with the numbers verified today — the template widget vectors, the measured sigma lists and noise-band table for `simple`/`beta`/`beta57` at 20 steps, and the `/object_info` diff that mechanically proves `beta57`/`bong_tangent` ship with RES4LYF rather than core.

## Also

- Skill-count drift bumps: `comfyui-plugin` 16 → 17 in root `README.md` and `docs/diagrams/plugin-relationships.d2`.
- New `### comfy-corpus-validation` section in `comfyui-plugin/README.md`.

## Verification

- `python3 scripts/audit-skill-descriptions.py --strict-all --strict-length` → exit 0
- `just lint-compliance` → exit 0, no findings for the new skill (SKILL.md 8 990 chars, description 148 chars)
- `scripts/check-docs-index.sh` → comfyui-plugin count clean (remaining WARNs are pre-existing drift on `main` for networking/testing plugins)
- pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEuU96jmbA4EXRSdcLgx3p