### PR TITLE
docs(git-plugin): teach gh-workflow-monitoring to de-column a step's log output

### DIFF
--- a/git-plugin/skills/gh-workflow-monitoring/SKILL.md
+++ b/git-plugin/skills/gh-workflow-monitoring/SKILL.md
@@ -4,7 +4,7 @@ description: Monitor GitHub Actions runs with blocking watch commands instead of
 user-invocable: false
 allowed-tools: Bash(gh run *), Bash(gh workflow *), Bash(gh pr *), Read
 created: 2025-01-16
-modified: 2026-05-09
+modified: 2026-07-15
 reviewed: 2026-04-25
 ---
 
@@ -95,6 +95,38 @@ gh run view --job $JOB_ID
 gh run view $RUN_ID --web
 ```
 
+### Extract One Step's Bare Output from `--log`
+
+`gh run view --log` is **tab-delimited**: every line is
+`<job>\t<step>\t<timestamp> <log line>`. To scrape one step's stdout back to
+its bare form — dropping the job and step columns and the per-line
+timestamp — filter to the step name (field-2 substring) and strip the
+timestamp, which is the first space-delimited token of field 3:
+
+```bash
+# All lines from the step whose name contains "clean warm run", de-columned
+gh run view $RUN_ID --log \
+  | awk -F'\t' '/clean warm run/ { sub(/^[^ ]* /, "", $3); print $3 }'
+```
+
+This is the durable way to read a **succeeded** step's output for structured
+markers — `RESULT …`, a `PASS`/`FAIL` line, a JSON blob a job printed — when
+`--log-failed` doesn't apply (nothing failed; you just want the output). The
+whole job's log is one stream, so narrow to the step first, then grep the
+markers:
+
+```bash
+gh run view $RUN_ID --log \
+  | awk -F'\t' '/bench \(clean warm/ { sub(/^[^ ]* /, "", $3); print $3 }' \
+  | grep -E 'RESULT|SANITY'
+```
+
+Notes: match the step name as it appears in the workflow's `name:` (the awk
+`/pattern/` is a plain regex over the whole tab-joined line — anchor with a
+distinctive substring to avoid matching the same text inside a log line);
+`[^ ]*` matches the timestamp because it never contains a space, so a
+mangled first token can't over-strip the line.
+
 ## Workflow Patterns
 
 ### Trigger and Watch
@@ -165,6 +197,7 @@ gh run watch $RUN_ID --compact --exit-status
 | Find in-progress | `gh run list --status in_progress --json databaseId,name` |
 | Latest run ID | `gh run list -L 1 --json databaseId --jq '.[0].databaseId'` |
 | Failed logs | `gh run view $ID --log-failed` |
+| Scrape a succeeded step's stdout | `gh run view $ID --log \| awk -F'\t' '/STEP/{sub(/^[^ ]* /,"",$3);print $3}'` |
 | Trigger + watch | `gh workflow run "$NAME" && sleep 2 && gh run watch --compact` |
 | PR run status | `gh pr checks $PR --json name,state,conclusion` |
 


### PR DESCRIPTION
## What

Extends the **`gh-workflow-monitoring`** skill with the one thing it was missing next to `gh run view --log`: **how to read the log's format and scrape a single step's stdout from it.**

- New subsection **"Extract One Step's Bare Output from `--log`"** — the log is tab-delimited (`<job>\t<step>\t<timestamp> <line>`), so filter to the step name and strip the timestamp:
  ```bash
  gh run view $RUN_ID --log \
    | awk -F'\t' '/clean warm run/ { sub(/^[^ ]* /, "", $3); print $3 }'
  ```
- One row added to the **Agentic Optimizations** table.
- `modified` frontmatter bumped.

The gap it fills: `--log-failed` is for *failed* steps. When a **succeeded** step prints structured markers you want (`RESULT …`, a `PASS`/`FAIL` line, a JSON blob), you need the whole `--log`, and then the tab-delimited de-columning idiom — which is non-obvious (the `-F'\t'` split + timestamp strip) and gets rediscovered each time.

## Why (evidence)

Distilled from a GPU-kernel benchmarking session that dispatched a `bench.yml` workflow to a self-hosted runner ~8 times (once per optimization rung) and hand-rolled this exact `awk -F'\t' '/clean warm run/ {sub(...); print $3}'` extraction each time to pull the reportable `RESULT`/`SANITY` lines out of the run logs. It's a general gh-CLI technique, not repo-specific — hence promoting it here rather than keeping it local.

## Scope / hygiene

- Single file changed: `git-plugin/skills/gh-workflow-monitoring/SKILL.md` (+34/−1).
- `just lint-context-commands git-plugin` → **All context commands OK**; `just lint-compliance git-plugin` → **exit 0**, this skill unflagged (only pre-existing warnings on other skills).
- README catalog entry ("Watch GitHub Actions runs with blocking commands") remains accurate — the addition is within the skill's existing monitoring/diagnosing scope, so no README change (the advisory currency nudge was considered).
- Additive edit to an existing skill → `docs(git-plugin):` conventional commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URdiM1TRP2khTbKj6sh5j5
