### PR TITLE
feat(hooks-plugin): add # allow-timeout escape hatch to the timeout block

### DIFF
--- a/hooks-plugin/README.md
+++ b/hooks-plugin/README.md
@@ -26,7 +26,7 @@ A PreToolUse hook that intercepts Bash commands and blocks those that should use
 | `sed -i` (repo files; `/tmp`/scratch targets exempt, #2052) | Use **Edit** tool instead |
 | `echo > file` | Use **Write** tool instead |
 | `cat > file` | Use **Write** tool instead |
-| `timeout cmd` | Remove timeout (human approval time exceeds it) |
+| `timeout cmd` | Remove timeout (human approval time exceeds it); append `# allow-timeout` for genuinely-unbounded processes (#2041) |
 | `git add -A` / `git add .` | Stage specific files by name instead |
 | Multi-grep test parsing | Use `--reporter=json` instead |
 | `curl \| sh` / `wget \| bash` | Download first, review, then execute |

--- a/hooks-plugin/hooks/README.md
+++ b/hooks-plugin/hooks/README.md
@@ -15,7 +15,7 @@ A PreToolUse hook that intercepts Bash commands and blocks those that should use
 | `sed -i` on repo files (targets under `/tmp`, `/private/tmp`, `/var/folders`, `$TMPDIR` are exempt — #2052) | Use **Edit** tool instead |
 | `echo > file` | Use **Write** tool instead |
 | `cat > file` | Use **Write** tool instead |
-| `timeout cmd` | Remove timeout (Bash tool has its own, human approval time exceeds it anyway) |
+| `timeout cmd` | Remove timeout (Bash tool has its own, human approval time exceeds it anyway); append a `# allow-timeout` comment to bound a genuinely-never-exiting process (REPL, stdio server) — #2041 |
 | `cat/tail ...tasks/*.output` | Use **Read** tool on the output path (or pipe an extraction for large files) |
 | `sleep && cat/tail ...output` | Use **Read** tool on the output path |
 | `git add -A` / `git add .` | Stage specific files by name instead of broad staging |

--- a/hooks-plugin/hooks/bash-antipatterns.sh
+++ b/hooks-plugin/hooks/bash-antipatterns.sh
@@ -233,8 +233,23 @@ if echo "$COMMAND_SHELL_ONLY" | grep -Eq 'cat\s*>\s*[^|]' && \
 fi
 
 # Check for timeout command
-if echo "$COMMAND" | grep -Eq '^\s*timeout\s+'; then
-    block "REMINDER: The 'timeout' command is usually unnecessary - the Bash tool has its own timeout parameter. Human approval time typically exceeds any timeout value anyway. Remove the timeout wrapper and use the command directly."
+#
+# Escape hatch (issue #2041): a trailing `# allow-timeout` comment passes the
+# block. `timeout` is usually redundant (the Bash tool has its own timeout
+# parameter), but there is a legitimate minority case: bounding a process that
+# genuinely never exits on its own — an interactive REPL, or a stdio MCP
+# server launched to warm a build cache (`uvx --refresh --from git+… <srv>`).
+# For those, the Bash-tool timeout kills the whole tool call and returns an
+# error state, whereas `timeout N cmd` produces a clean exit 124 with the
+# captured output — a strictly better signal. The comment is a deliberate,
+# visible opt-in the agent must type per-command, so the default steer stays.
+if echo "$COMMAND" | grep -Eq '^\s*timeout\s+' && \
+   ! echo "$COMMAND" | grep -Eq '#[[:space:]]*allow-timeout\b'; then
+    block "REMINDER: The 'timeout' command is usually unnecessary - the Bash tool has its own timeout parameter. Human approval time typically exceeds any timeout value anyway. Remove the timeout wrapper and use the command directly.
+
+If the wrapped process genuinely never exits on its own (a REPL, a stdio
+server warming a cache) and you need a clean in-command bound with captured
+output, append a '# allow-timeout' comment to the command to pass this check."
 fi
 
 # NOTE: `find` is intentionally NOT blocked here.

--- a/hooks-plugin/hooks/test-bash-antipatterns.sh
+++ b/hooks-plugin/hooks/test-bash-antipatterns.sh
@@ -831,6 +831,32 @@ assert_exit \
     "GUARD INTEGRITY: tail README.md (no flag) still blocked (#1848)" 2 \
     "tail README.md"
 
+# ── timeout escape hatch (issue #2041) ───────────────────────────────────────
+# The timeout block stays (the Bash tool's own timeout parameter is usually
+# the right bound), but a trailing `# allow-timeout` comment passes it — the
+# escape hatch for processes that genuinely never exit on their own (REPLs,
+# stdio MCP servers warming a cache), where `timeout N cmd`'s clean exit 124
+# with captured output beats the Bash-tool timeout's error state.
+echo ""
+echo "timeout: blocked by default, '# allow-timeout' escape hatch passes (#2041):"
+
+assert_exit \
+    "bare timeout wrapper is still blocked" 2 \
+    "timeout 30 some-server --serve"
+
+assert_exit \
+    "timeout with '# allow-timeout' comment is allowed (#2041)" 0 \
+    "timeout 30 uvx --refresh --from git+https://x/y srv # allow-timeout"
+
+assert_exit \
+    "timeout with '#allow-timeout' (no space) is allowed (#2041)" 0 \
+    "timeout 10 python3 repl.py #allow-timeout"
+
+assert_stderr_contains \
+    "timeout block message documents the escape hatch" \
+    "# allow-timeout" \
+    "timeout 30 some-server --serve"
+
 # ── heredoc body inside a command substitution (issue #2058) ─────────────────
 # Regression: `gh pr create --body "$(cat <<'EOF' … EOF)"` was blocked by the
 # cat-write detector when the heredoc BODY happened to contain a `cat > file`


### PR DESCRIPTION
**Stacked on PR1 (#2077)** — base is `fix/bash-antipatterns-false-positives`; retarget to `main` before merging once #2077 lands.

## What

Adds the `# allow-timeout` escape hatch to the bash-antipatterns `timeout` hard block.

## Why

The block is right for the majority case (the Bash tool has its own timeout parameter), but it had zero override for the legitimate minority: bounding a process that genuinely never exits on its own — an interactive REPL, or a stdio MCP server launched to warm a build cache (`uvx --refresh --from git+… <srv>`). For those, the Bash-tool timeout kills the whole tool call and returns an error state, while `timeout N cmd` yields a clean exit 124 with the captured output — a strictly better signal (#2041).

## How

- A trailing `# allow-timeout` comment (with or without the space after `#`) passes the block; everything else still blocks. The comment is a deliberate, visible, per-command opt-in, so the default steer is unchanged.
- The block message now documents the escape hatch.
- Regression tests: bare `timeout` still blocks; both comment forms pass; the message names the hatch (`test-bash-antipatterns.sh` 131 passed / 0 failed on this branch).
- Both hooks-plugin READMEs updated in the same commit (docs-currency).

Closes #2041

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Li27NSA3Cpro1QfmmZn5gm
