### PR TITLE
ci: add vault-agent prompt-sync workflow (Phase 2 of #1973)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,6 +24,7 @@ When adding a workflow, pick the existing domain that fits or extend the table b
 | `PR:` | Cross-cutting PR governance — conflict resolution, conventional-commit enforcement |
 | `Auto-fix:` | Autonomous CI failure remediation triggered by `workflow_run` |
 | `Test:` | Repo test suites — skill-local regression tests |
+| `Sync:` | Cross-repo artifact sync — regenerate compiled prompts for the extracted agent CLIs and PR them to their standalone repos |
 | _(none)_ | One-off standalones with no obvious domain peer (e.g. `Renovate`) |
 
 ### Sorted name list
@@ -49,6 +50,8 @@ Release: Fix release-please conflicts
 Release: PR documentation audit
 Release: release-please
 Renovate
+Sync: git-repo-agent prompts
+Sync: vault-agent prompts
 Test: Skill scripts
 ```
 

--- a/.github/workflows/sync-git-repo-agent-prompts.yml
+++ b/.github/workflows/sync-git-repo-agent-prompts.yml
@@ -44,8 +44,11 @@ jobs:
 
       - name: Detect changes
         id: diff
+        # git status --porcelain, not git diff --quiet: a NEW skill added to
+        # the compiler's bundle map emits a new UNTRACKED per-skill fragment,
+        # which `git diff` cannot see — the sync would silently skip it.
         run: |
-          if git diff --quiet -- git-repo-agent/src/git_repo_agent/prompts/generated/; then
+          if [ -z "$(git status --porcelain -- git-repo-agent/src/git_repo_agent/prompts/generated/)" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/sync-vault-agent-prompts.yml
+++ b/.github/workflows/sync-vault-agent-prompts.yml
@@ -1,16 +1,17 @@
-name: "Sync: git-repo-agent prompts"
+name: "Sync: vault-agent prompts"
 
-# Regenerates git-repo-agent's pre-compiled subagent prompts from this repo's
-# plugin skills and opens a PR on laurigates/git-repo-agent (issue #1017).
+# Regenerates vault-agent's pre-compiled subagent prompts from this repo's
+# obsidian-plugin skills and opens a PR on laurigates/vault-agent (issue #1973).
 #
-# git-repo-agent was extracted into its own repo but its compiler reads plugin
-# SKILL.md files from this monorepo (ADR-009). The pre-compiled artifacts under
-# git-repo-agent/src/git_repo_agent/prompts/generated/ are shipped in the wheel,
-# so they must be refreshed here (where the plugin sources live) and pushed to
-# the standalone repo whenever an upstream skill changes.
+# vault-agent was extracted into its own repo but its compiler reads plugin
+# SKILL.md files from this monorepo (vault-agent ADR-0005/ADR-0006). The
+# pre-compiled artifacts under vault-agent/src/vault_agent/prompts/generated/
+# are shipped in the wheel, so they must be refreshed here (where the plugin
+# sources live) and pushed to the standalone repo whenever an upstream skill
+# changes.
 #
 # Cross-repo push needs a token with contents + pull-requests write on
-# laurigates/git-repo-agent, stored as the GIT_REPO_AGENT_SYNC_TOKEN secret
+# laurigates/vault-agent, stored as the VAULT_AGENT_SYNC_TOKEN secret
 # (a fine-scoped PAT or a GitHub App token). Until that secret is provisioned
 # this runs on manual dispatch only; uncomment the `push:` trigger below to make
 # it event-driven once the secret exists.
@@ -20,9 +21,9 @@ on:
   # push:
   #   branches: [main]
   #   paths:
-  #     - '*/skills/*/SKILL.md'
-  #     - 'git-repo-agent/scripts/compile_prompts.py'
-  #     - 'git-repo-agent/src/git_repo_agent/prompts/compiler.py'
+  #     - 'obsidian-plugin/skills/*/SKILL.md'
+  #     - 'vault-agent/scripts/compile_prompts.py'
+  #     - 'vault-agent/src/vault_agent/prompts/compiler.py'
 
 permissions:
   contents: read
@@ -40,44 +41,44 @@ jobs:
           enable-cache: true
 
       - name: Regenerate compiled prompts
-        run: uv run --project git-repo-agent python git-repo-agent/scripts/compile_prompts.py
+        run: uv run --project vault-agent python vault-agent/scripts/compile_prompts.py
 
       - name: Detect changes
         id: diff
         run: |
-          if git diff --quiet -- git-repo-agent/src/git_repo_agent/prompts/generated/; then
+          if git diff --quiet -- vault-agent/src/vault_agent/prompts/generated/; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Checkout git-repo-agent
+      - name: Checkout vault-agent
         if: steps.diff.outputs.changed == 'true'
         uses: actions/checkout@v6
         with:
-          repository: laurigates/git-repo-agent
-          token: ${{ secrets.GIT_REPO_AGENT_SYNC_TOKEN }}
+          repository: laurigates/vault-agent
+          token: ${{ secrets.VAULT_AGENT_SYNC_TOKEN }}
           path: _standalone
 
       - name: Copy regenerated prompts into the standalone checkout
         if: steps.diff.outputs.changed == 'true'
         run: |
           rsync -a --delete \
-            git-repo-agent/src/git_repo_agent/prompts/generated/ \
-            _standalone/src/git_repo_agent/prompts/generated/
+            vault-agent/src/vault_agent/prompts/generated/ \
+            _standalone/src/vault_agent/prompts/generated/
 
-      - name: Open sync PR on git-repo-agent
+      - name: Open sync PR on vault-agent
         if: steps.diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           path: _standalone
-          token: ${{ secrets.GIT_REPO_AGENT_SYNC_TOKEN }}
+          token: ${{ secrets.VAULT_AGENT_SYNC_TOKEN }}
           branch: sync/generated-prompts
           delete-branch: true
           commit-message: "chore: sync compiled prompts from claude-plugins"
           title: "chore: sync compiled prompts from claude-plugins"
           body: |
-            Regenerated `src/git_repo_agent/prompts/generated/` from the upstream
+            Regenerated `src/vault_agent/prompts/generated/` from the upstream
             plugin skills in laurigates/claude-plugins.
 
-            Automated by `.github/workflows/sync-git-repo-agent-prompts.yml`.
+            Automated by `.github/workflows/sync-vault-agent-prompts.yml`.

--- a/.github/workflows/sync-vault-agent-prompts.yml
+++ b/.github/workflows/sync-vault-agent-prompts.yml
@@ -45,8 +45,11 @@ jobs:
 
       - name: Detect changes
         id: diff
+        # git status --porcelain, not git diff --quiet: a NEW skill added to
+        # SUBAGENT_SKILLS emits a new UNTRACKED per-skill fragment, which
+        # `git diff` cannot see — the sync would silently skip it.
         run: |
-          if git diff --quiet -- vault-agent/src/vault_agent/prompts/generated/; then
+          if [ -z "$(git status --porcelain -- vault-agent/src/vault_agent/prompts/generated/)" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What

Adds `.github/workflows/sync-vault-agent-prompts.yml` — the Phase 2 cross-repo sync for the vault-agent extraction (#1973), mirroring the git-repo-agent sync workflow (#1972). On upstream `obsidian-plugin/skills/*/SKILL.md` changes it regenerates `vault-agent/src/vault_agent/prompts/generated/` and opens a PR on [laurigates/vault-agent](https://github.com/laurigates/vault-agent).

Also brings the sync pair under the workflow naming convention as a new `Sync:` domain (the git-repo-agent sync is renamed `"Sync: git-repo-agent prompts"`; neither was registered in the workflows README before — both are now). No `workflow_run` cross-references exist for the renamed workflow.

**Second commit — change-detection fix found in pre-merge review**: `git diff --quiet` only sees modified *tracked* files, so a new skill added to the compiler's bundle map (a new *untracked* per-skill fragment) was invisible — `changed=false` and the sync silently skipped. Both sync workflows now use `git status --porcelain`. Verified locally: regenerate on current main is byte-clean (`changed=false`), and a probe file under `generated/skills/` flips the new logic to `changed=true` while the old logic still reported false.

## Why draft

**Gated on the `VAULT_AGENT_SYNC_TOKEN` secret** (contents + pull-requests write on laurigates/vault-agent), which is an owner-provisioned credential — per the tool-migration-cutover rule this stays a draft until the secret exists and a `workflow_dispatch` run has been observed opening a real sync PR. The `push:` trigger ships commented out and is enabled in a follow-up once that operational signal lands.

## Post-merge follow-ups (owner)

Tracked on #1973 (per the follow-up-issue convention):
- [ ] Provision `VAULT_AGENT_SYNC_TOKEN` (fine-scoped PAT or App token)
- [ ] `workflow_dispatch` run observed opening a sync PR on vault-agent
- [ ] Enable the `push:` trigger

Refs #1973

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VW1p65doFvSXpVemUf8SF3