### PR TITLE
test(vault-agent): skip monorepo-only compiler test in standalone checkouts

### DIFF
--- a/vault-agent/tests/test_compiler.py
+++ b/vault-agent/tests/test_compiler.py
@@ -85,7 +85,11 @@ class TestCompileSkill:
             / "vault-frontmatter"
             / "SKILL.md"
         )
-        assert skill.exists(), f"missing {skill}"
+        if not skill.exists():
+            # Standalone checkout (no claude-plugins monorepo sibling): the
+            # live-compile path is exercised in the monorepo; standalone mode
+            # is covered by test_compiler_standalone.py (ADR-0006).
+            pytest.skip("monorepo skill source not present (standalone checkout)")
         out = compile_skill(skill)
         # Frontmatter is stripped
         assert "created:" not in out


### PR DESCRIPTION
Backports the standalone-checkout skipif applied in [laurigates/vault-agent](https://github.com/laurigates/vault-agent) (Phase 1 of #1973) to the monorepo copy, keeping the two `tests/test_compiler.py` files byte-identical until Phase 3 removes the monorepo copy.

`test_compiles_a_real_vault_skill` live-compiles a sibling `obsidian-plugin` SKILL.md that only exists in this monorepo; in the extracted checkout it failed as a hard assert. It now skips cleanly when the source is absent — inert here, where the source exists (verified: 12 passed).

Refs #1973

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VW1p65doFvSXpVemUf8SF3