### PR TITLE
docs(adrs): ADR-0022 adapter over export for foreign harnesses

### DIFF
--- a/docs/adrs/0022-adapter-over-export-for-foreign-harnesses.md
+++ b/docs/adrs/0022-adapter-over-export-for-foreign-harnesses.md
@@ -1,0 +1,196 @@
+# ADR-0022: Adapter over Export — Runtime Skill Discovery for Foreign Harnesses
+
+---
+date: 2026-07-17
+created: 2026-07-17
+modified: 2026-07-17
+status: Accepted
+deciders: claude-plugins team
+domain: architecture
+relates-to:
+  - ADR-0001  # plugin-based architecture (the canonical source the adapters index)
+  - ADR-0004  # marketplace registry model (marketplace.json is the adapter's discovery root)
+  - ADR-0021  # OKF substrate convergence (the Agent Skills convergence this ADR builds on)
+---
+
+## Context
+
+This marketplace's skills run on two foreign harnesses today, each through a
+hand-maintained **export pipeline**:
+
+| Harness | Pipeline | Curation artifact |
+|---------|----------|-------------------|
+| pi (pi.dev) | `install-pi.sh` copies curated skills into pi's scopes | `pi/tiers.yaml` (tier per plugin, `skills:` cherry-picks, `exclude` list), enforced by `check-pi-tiers.sh` in pre-commit + CI |
+| OpenCode | rulesync export with normalization scripts (`rewrite-skill-name-to-dir.py`, `normalize-skill-allowed-tools.py`) | the export config itself |
+
+Both exist because neither harness budgets its skill listing the way Claude
+Code does (`skillListingBudgetFraction`). Measured on pi 0.80.6: every
+installed skill costs **~111 tokens/turn** of standing context, dead linear
+and uncapped — all ~400 marketplace skills would cost ~45K tokens/turn and
+hang the turn outright on a 128K local context. OpenCode's
+`<available_skills>` listing (embedded in its `skill` tool description) has
+the same linear shape. The tier manifest was the interim answer: curate a
+subset small enough to afford.
+
+Three developments changed the calculus:
+
+1. **Both harnesses converged on the Agent Skills standard.** pi loads Claude
+   Code `SKILL.md` unmodified; OpenCode now natively discovers SKILL.md —
+   including from `.claude/skills/` paths — making most of the rulesync
+   conversion obsolete.
+2. **Both harnesses grew extension APIs sufficient for runtime discovery.**
+   Verified against upstream docs/types: pi extensions have
+   `pi.registerTool()`, `before_agent_start` (system-prompt modification +
+   message injection, with `systemPromptOptions.skills` exposed), and
+   extension-contributed skill paths. OpenCode plugins have custom tools
+   (`tool: {}`), `tools: { skill: false }` / `permission.skill` /
+   `tool.definition` to suppress or rewrite the native listing, and
+   `experimental.chat.system.transform` / `experimental.chat.messages.transform`
+   for per-turn injection.
+3. **The curation manifests drift.** `pi/tiers.yaml` restates facts about
+   skills (which harness they make sense on, which are core) in a parallel
+   artifact that must be hand-synced with the marketplace — the
+   documentation-authoring anti-pattern applied to tooling. Two overlapping
+   solutions (manifest + any future search mechanism) would be worse than
+   either alone.
+
+The goal restated: the Claude Code experience on foreign harnesses — **every
+skill at arm's reach, without filling the context**. Claude Code achieves
+this with three mechanisms: a bounded always-on listing, on-demand bodies,
+and pull-based discovery for the long tail (deferred tools + ToolSearch).
+The foreign harnesses have the middle one natively; the adapter supplies the
+other two.
+
+## Decision
+
+**Foreign harnesses get runtime adapters, not exports.** claude-plugins
+stays Claude-Code-native; each foreign harness gets a thin binding over one
+shared discovery core, and the export pipelines are superseded.
+
+1. **One harness-agnostic core** (`adapters/core/`, plain TS, no harness
+   imports): scans the marketplace checkout (`marketplace.json` +
+   `*/skills/*/SKILL.md`), builds an **embedding index** over
+   name+description (endpoint configurable, default local ollama
+   `/api/embed`; cached by content hash) with a **BM25/keyword fallback**
+   and hybrid rank fusion, and exposes
+   `search(query, k, filters) → [{name, description, path, score}]`.
+   Skills are **not copied**: search returns paths, and delivery is the
+   model `read`ing the SKILL.md — both harnesses' native progressive
+   disclosure. (#2089)
+
+2. **Per-harness bindings**:
+   - **pi** (`adapters/pi/`, stable hooks — leads on full hybrid): a
+     `search_skills` tool (pull) plus per-turn top-k injection via
+     `before_agent_start` (push), suppressing the native uncapped listing.
+     Push exists because a small local quant won't search for a skill it
+     doesn't know exists — ranking against the user message moves the
+     triggering burden into deterministic harness code. (#2090)
+   - **OpenCode** (`adapters/opencode/`, pull-first): `search_skills` via
+     the stable plugin tool surface, native listing disabled via
+     `tools: { skill: false }`; push added behind a version check because
+     the relevant hooks are `experimental.*`-prefixed. (#2091)
+
+3. **Curation moves out of manifests**:
+   - The *exclude* judgment (Claude-Code-authoring meta is noise on any
+     other harness) is a property of the skill, so it moves into the
+     skill's own **`compatibility` frontmatter** — an Agent Skills spec
+     field both harnesses already recognize. One sweep marks the ~exclude
+     set. (#2092)
+   - Per-project scoping (the old domain tier) is subsumed by relevance
+     ranking plus per-project adapter config (`.pi/settings.json` /
+     `opencode.json`) — the same interface shape as Claude Code's
+     `enabledPlugins`. An optional `pins:` list covers skills that must
+     always be visible; there is no always-on "general tier" to maintain.
+
+4. **The export pipelines are superseded, gated on evidence.** Per the
+   tool-migration-cutover rule, nothing is deleted until the adapter is
+   *observed operational*: the eval harness in #2089 runs the same task set
+   on the same local quant, baseline (tier-install / rulesync export)
+   vs adapter, measuring **correct-skill-invocation rate** and **standing
+   tokens/turn**. Adapter meets or beats invocation rate at lower standing
+   cost → the corresponding pipeline is removed in one complete sweep
+   (#2093 for the pi tier system, #2094 for rulesync).
+
+## Consequences
+
+### Positive
+
+- **One source of truth.** The marketplace checkout is the only artifact;
+  adapters index it live. No manifest to hand-sync, no export drift, no
+  per-ecosystem catering in skill authoring.
+- **All skills reachable at bounded cost.** Standing per-turn cost becomes
+  ~top-k plus the tool description (~1–2K tokens) instead of linear in
+  installed skills (~10.4K for the 94-skill general tier; ~45K for all).
+- **The interface claim is tested, not asserted.** Two bindings over one
+  core is what makes "adapter over export" real; a third harness is a new
+  thin binding, not a new pipeline.
+- **Deletions on gate-pass**: `pi/tiers.yaml`, `install-pi.sh`,
+  `check-pi-tiers.sh` + its pre-commit/CI wiring, the tier justfile
+  recipes, the rulesync pipeline and its normalization scripts, and the
+  bulk of both export docs.
+
+### Negative / risks
+
+- **An embedding endpoint becomes a soft dependency.** Mitigated by the
+  BM25 fallback (search never hard-fails) and by the target audience
+  already running a local model server.
+- **OpenCode push rides experimental hooks.** They may break across
+  releases; the binding ships pull-first and degrades gracefully. The
+  cutover gate (#2094) is passable on pull alone.
+- **Ranking misses are the new failure mode.** Curation failed closed
+  (skill not installed → invisible); retrieval fails open but fuzzily
+  (skill ranked low → not surfaced). The eval gate measures exactly this;
+  hybrid BM25+embedding fusion and the push channel are the mitigations.
+- **Weak-model initiative remains the hard part.** Pure pull demonstrably
+  under-triggers on small quants; the push channel is load-bearing, not
+  optional, on pi.
+
+### Neutral
+
+- OpenCode enforces `name` == parent directory (pi doesn't). Bypassing the
+  native `skill` tool sidesteps the old `rewrite-skill-name-to-dir`
+  normalization entirely; it only resurfaces if a pinned set uses native
+  discovery.
+- Claude Code ignores `compatibility` frontmatter; the sweep is inert on
+  the home harness.
+
+## Alternatives considered
+
+- **Keep the tier system alongside a search tool.** Rejected: two
+  overlapping curation mechanisms with different truths — the drift this
+  ADR exists to remove.
+- **Pure pull (search tool only).** Rejected as insufficient for the
+  primary use case: small local quants don't search for skills they don't
+  know exist; the original fidelity criterion (does the model *invoke* the
+  right skill?) is exactly what pure pull endangers.
+- **Pure push (ranked top-k injection only).** Rejected: no recourse when
+  ranking misses on vague intents; the explicit search tool is cheap.
+- **A separate adapter repo.** Rejected: the marketplace is the data
+  source; a second repo re-creates the synchronization problem the adapter
+  removes.
+- **Static per-model listing caps (mimic `skillListingBudgetFraction`).**
+  Rejected: still requires deciding *which* skills make the cap — that's
+  the tier system again with a different constant.
+
+## Implementation
+
+| Issue | Scope | Gate |
+|-------|-------|------|
+| [#2089](https://github.com/laurigates/claude-plugins/issues/2089) | Discovery core + eval harness | — |
+| [#2090](https://github.com/laurigates/claude-plugins/issues/2090) | pi binding (hybrid push+pull) | eval vs tier baseline |
+| [#2091](https://github.com/laurigates/claude-plugins/issues/2091) | OpenCode binding (pull-first) | eval vs rulesync baseline |
+| [#2092](https://github.com/laurigates/claude-plugins/issues/2092) | `compatibility` frontmatter sweep | precedes cutovers |
+| [#2093](https://github.com/laurigates/claude-plugins/issues/2093) | Remove pi tier system | gated on #2090 |
+| [#2094](https://github.com/laurigates/claude-plugins/issues/2094) | Retire rulesync export | gated on #2091 |
+
+## References
+
+- `docs/pi-export.md` — the measured listing-cost data and the original
+  "skill-search extension" deferral this ADR supersedes
+- `docs/opencode-export.md` — the rulesync pipeline being retired
+- [pi extensions API](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/extensions.md),
+  [pi skills](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/skills.md)
+- [OpenCode plugins](https://opencode.ai/docs/plugins/),
+  [OpenCode skills](https://opencode.ai/docs/skills/)
+- [Agent Skills specification](https://agentskills.io/specification)
+  (`compatibility` frontmatter)

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -35,6 +35,7 @@ This repository was created by migrating Claude Code plugin configurations from 
 | [0019](0019-skill-dry-via-library-templating-rejected.md) | Reject Shared-Library / @-Imports / Build-Time Templating for Skill DRY | Accepted | 2026-06 |
 | [0020](0020-blueprint-autonomy-levels.md) | Blueprint Autonomy Levels — Ambient Operations via a Manifest-Gated Level Model | Proposed | 2026-07 |
 | [0021](0021-open-knowledge-format-mapping-not-adopted.md) | Do Not Adopt the Open Knowledge Format (OKF) for Skills; Record Substrate Convergence | Proposed | 2026-07 |
+| [0022](0022-adapter-over-export-for-foreign-harnesses.md) | Adapter over Export — Runtime Skill Discovery for Foreign Harnesses | Accepted | 2026-07 |
 
 ## Categories
 
@@ -66,6 +67,7 @@ This repository was created by migrating Claude Code plugin configurations from 
 ### Architecture Evolution
 - ADR-0015: Adopt Agent Teams and Deprecate Manual Orchestration
 - ADR-0021: Do Not Adopt the Open Knowledge Format (OKF) for Skills
+- ADR-0022: Adapter over Export — Runtime Skill Discovery for Foreign Harnesses
 
 ### Performance & Optimization
 - ADR-0016: Extract Deterministic Skill Procedure into Structured-Output Scripts

--- a/docs/pi-export.md
+++ b/docs/pi-export.md
@@ -148,9 +148,13 @@ what makes this useful for local-model testing.
 ## Out of scope (deferred)
 
 - **A `skill-search` pi extension** (a `search_skills` tool + suppressed default
-  injection). Only worth building if the trimmed Tier-1 general set still feels
+  injection). ~~Only worth building if the trimmed Tier-1 general set still feels
   tight on the smallest local quant. The tier manifest is the cheaper,
-  deterministic answer — defer the extension.
+  deterministic answer — defer the extension.~~ **Un-deferred by
+  [ADR-0022](adrs/0022-adapter-over-export-for-foreign-harnesses.md)**: the
+  extension (now a binding over a harness-agnostic discovery core, #2090) is
+  slated to *supersede* the tier system entirely; the tier pipeline documented
+  here is removed once the adapter passes its eval gate (#2093).
 - **Agent / prompt / hook porting.** Hooks especially are selective: only the
   *safety* hooks would earn a pi `pi.on` port; the style nudges are noise on a
   different harness.


### PR DESCRIPTION
## What

ADR-0022: replace the pi tier-install and OpenCode rulesync export pipelines with **runtime adapters** — one harness-agnostic skill-discovery core (embedding index + BM25 fallback over the marketplace checkout) with thin per-harness bindings, so all ~400 skills stay at arm's reach on foreign harnesses without filling a local model's context.

Key decisions recorded:

- **Adapter over export**: claude-plugins stays Claude-Code-native; foreign harnesses get bindings, not projections. Skills are never copied — search returns paths, the model `read`s the SKILL.md (both harnesses' native progressive disclosure).
- **Retrieval replaces curation**: hybrid push (per-turn top-k injection) + pull (`search_skills` tool). The tier manifest and rulesync config are superseded.
- **Curation facts move into skill frontmatter**: the Claude-only `exclude` judgment becomes Agent Skills `compatibility` frontmatter, recognized by both harnesses.
- **Gated cutover**: nothing is deleted until each adapter is observed meeting/beating its export baseline (correct-skill-invocation rate, standing tokens/turn) on a local quant, per the tool-migration-cutover rule.

Also updates the ADR index and marks the `docs/pi-export.md` "deferred skill-search extension" note as un-deferred by this ADR.

## Implementation issues

| Issue | Scope |
|-------|-------|
| #2089 | Discovery core + eval harness |
| #2090 | pi binding (hybrid push+pull) |
| #2091 | OpenCode binding (pull-first; push hooks are experimental) |
| #2092 | `compatibility` frontmatter sweep |
| #2093 | Remove pi tier system (gated on #2090's eval) |
| #2094 | Retire rulesync export (gated on #2091's eval) |

Grounded against upstream API docs: pi `extensions.md`/`skills.md` (registerTool, `before_agent_start` + `systemPromptOptions.skills`) and sst/opencode plugin types (`tool: {}`, `tools: {skill: false}`, `experimental.chat.system.transform`, `tool.definition`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJMWk8t6RpaLqk7JUSvfXU
