### PR TITLE
fix(comfyui): scaffold family-spec icon/banner + document the framing gate

### DIFF
--- a/comfyui-plugin/skills/comfy-registry-lifecycle/SKILL.md
+++ b/comfyui-plugin/skills/comfy-registry-lifecycle/SKILL.md
@@ -344,11 +344,40 @@ Without `[tool.comfy] Icon`, the registry shows a generic placeholder.
 
 ### Icon design system
 
-- **400×400 SVG**, dark squircle tile (`#12121a`→`#1f1f2a` gradient,
-  `rx≈76`), ~56 px inner padding, one bespoke glyph centred.
-- **Glyph colour encodes the sub-family** so a set of packs reads as a
-  family (e.g. amber for one facet, blue for another). Keep tile, corner
-  radius, and stroke weight uniform across packs.
+The exact spec every pack shares (canonical — the scaffold's `icon.svg`
+placeholder and every hand-drawn glyph target this):
+
+- **400×400 canvas**, `viewBox 0 0 400 400`.
+- **Dark inset tile**, verbatim:
+  `<rect x="28" y="28" width="344" height="344" rx="76" fill="url(#tile)" stroke="#2a2a36" stroke-width="2"/>`
+  where `#tile` is a **vertical** gradient `#1f1f2a`→`#12121a`
+  (`x1=0 y1=0 x2=0 y2=1`). The 28 px inset is the family margin — not
+  full-bleed.
+- **One bespoke pictographic glyph**, centred, filling the tile. **No
+  letters** in final art — every sibling uses a pictogram; a letter is a
+  placeholder only.
+- **Glyph colour encodes the sub-family**: **`#ffb02e` (orange)** for
+  touch/interaction packs, **`#6ba6ff` (blue)** for info/gallery packs.
+  Secondary accents (`#ffd866`, `#6bff8e`) appear sparingly. Keep tile,
+  radius, stroke, and gradient **identical** across packs.
+
+**Framing gate (the consistency check).** Because the tile is the outermost
+drawn element, a correctly-framed icon *always* trims to the same box —
+run it on every pack:
+
+```sh
+identify -format '%wx%h / %@\n' icon.png    # MUST be: 400x400 / 346x346+27+27
+```
+
+A `512x512 / 512x512+0+0` result is the classic drift: a full-bleed tile on
+the wrong canvas, which renders visibly larger and off-palette on the
+registry grid. This is exactly how `comfyui-touch-shim` shipped the raw
+512×512 green-letter scaffold placeholder while the other 10 packs matched —
+the trim box is the one-line audit that catches it across the fleet:
+
+```sh
+for d in comfyui-*/; do printf '%-28s %s\n' "$d" "$(identify -format '%wx%h/%@' "$d/icon.png" 2>/dev/null)"; done
+```
 
 ### Rasterize SVG with cairosvg — NOT ImageMagick
 

--- a/comfyui-plugin/skills/comfyui-node-scaffold/SKILL.md
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/SKILL.md
@@ -300,8 +300,16 @@ The generated `publish.yml` builds `web/dist/` then publishes via
   `comfyui-screenshot-pipeline` skill wires the screenshots). The
   finishing-pass audit at the end of a scaffold flags this so it isn't silently
   forgotten (issue #1877).
-- Icon/banner ship as **source SVGs**; the PNGs the registry serves are produced
-  by `just assets` (rsvg-convert), not at scaffold time (stdlib-only generator).
+- Icon/banner ship as **source SVGs** in the pack-family spec (400×400 dark
+  inset tile `rect 28,28,344,344 rx76` + one accent glyph; 1344×576 family
+  banner) — canonical spec in `comfy-registry-lifecycle` "Icon design system".
+  The emitted glyph is a **placeholder letter**: replace it with a bespoke
+  pictogram (no sibling pack ships a letter) in the family accent (`#ffb02e`
+  touch / `#6ba6ff` info-gallery). The PNGs the registry serves are produced by
+  `just assets` (rsvg-convert), not at scaffold time (stdlib-only generator);
+  that recipe also **gates framing** — the tile must trim to `346×346+27+27` on
+  a 400×400 canvas, which catches an icon that drifted off-spec (the trap that
+  left `comfyui-touch-shim` shipping the raw 512×512 full-bleed placeholder).
   Edit the SVG and re-run `just assets` to keep the PNG in sync.
 - Action/tool versions in the generated workflows mirror the reference packs as
   of scaffolding; Dependabot/Renovate will bump them. The biome pin is

--- a/comfyui-plugin/skills/comfyui-node-scaffold/scaffold.py
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/scaffold.py
@@ -1137,8 +1137,13 @@ check: typecheck build lint test
 # Rasterize icon.svg + banner.svg to the PNGs the registry serves (commit them).
 [group: "assets"]
 assets:
-    rsvg-convert -w 512 -h 512 icon.svg -o icon.png
-    rsvg-convert -w 1400 -h 400 banner.svg -o banner.png
+    rsvg-convert -w 400 -h 400 icon.svg -o icon.png
+    rsvg-convert -w 1344 -h 576 banner.svg -o banner.png
+    # Consistency gate: the family tile must trim to 346x346+27+27 on a 400x400
+    # canvas. A mismatch means the icon drifted off the family spec (wrong
+    # canvas size or a full-bleed tile) — see comfy-registry-lifecycle. Skipped
+    # when ImageMagick's `identify` is absent (rsvg-convert is the only hard dep).
+    command -v identify >/dev/null 2>&1 && { test "$(identify -format '%wx%h/%@' icon.png)" = "400x400/346x346+27+27" || { echo "icon.png off family spec (want 400x400/346x346+27+27)"; exit 1; }; } || true
 """
 
 BIOME_JSON = """\
@@ -2183,35 +2188,79 @@ the primitives that were previously copied byte-identically across packs.
 # GitHub URL wired into pyproject.toml `[tool.comfy]`. Editing the SVG and
 # re-running `just assets` keeps the two in sync — no hand-drawn PNG to drift.
 # --------------------------------------------------------------------------- #
+# The pack-family icon spec (canonical: comfy-registry-lifecycle "Icon design
+# system"). 400x400 canvas, dark inset tile `rect 28,28,344,344 rx76` with the
+# vertical `#1f1f2a->#12121a` gradient + `#2a2a36` stroke, and ONE glyph in the
+# family accent. The tile is the outermost drawn element, so a correctly-framed
+# icon always trims to `346x346+27+27` (`identify -format '%@' icon.png`) — that
+# invariant is the consistency gate (`just assets` checks it). The placeholder
+# renders the pack initial; REPLACE the <text> with a bespoke pictogram before
+# release (no sibling pack uses a letter in its final art). Accent: #ffb02e for
+# touch/interaction packs, #6ba6ff for info/gallery packs.
 ICON_SVG = """\
-<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-label="@@DISPLAY@@">
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400" viewBox="0 0 400 400" role="img" aria-label="@@DISPLAY@@">
   <title>@@DISPLAY@@</title>
   <defs>
-    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#2d6a4f"/>
-      <stop offset="1" stop-color="#1b4332"/>
+    <linearGradient id="tile" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1f1f2a"/>
+      <stop offset="1" stop-color="#12121a"/>
     </linearGradient>
   </defs>
-  <rect x="0" y="0" width="512" height="512" rx="96" fill="url(#g)"/>
-  <text x="256" y="256" fill="#ffffff" font-family="Inter, Segoe UI, system-ui, sans-serif"
-        font-size="248" font-weight="700" text-anchor="middle" dominant-baseline="central">@@INITIAL@@</text>
+  <rect x="28" y="28" width="344" height="344" rx="76" fill="url(#tile)" stroke="#2a2a36" stroke-width="2"/>
+  <!-- PLACEHOLDER glyph — replace with a bespoke orange (#ffb02e) pictogram. -->
+  <text x="200" y="212" fill="#ffb02e" font-family="Inter, Segoe UI, system-ui, sans-serif"
+        font-size="210" font-weight="700" text-anchor="middle" dominant-baseline="central">@@INITIAL@@</text>
 </svg>
 """
 
+# 1344x576 (exact 21:9) family banner template: dark constellation backdrop,
+# warm glow + sweep arc, the icon tile scaled 0.5 on the left, wordmark +
+# tagline. Swap the placeholder <text> glyph for the same bespoke pictogram used
+# in icon.svg once it's drawn.
 BANNER_SVG = """\
-<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="400" viewBox="0 0 1400 400" role="img" aria-label="@@DISPLAY@@">
+<svg xmlns="http://www.w3.org/2000/svg" width="1344" height="576" viewBox="0 0 1344 576" role="img" aria-label="@@DISPLAY@@">
   <title>@@DISPLAY@@</title>
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0" stop-color="#1b4332"/>
-      <stop offset="1" stop-color="#2d6a4f"/>
+    <linearGradient id="tile" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1f1f2a"/>
+      <stop offset="1" stop-color="#12121a"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="52%" cy="42%" r="55%">
+      <stop offset="0" stop-color="#ff8a00" stop-opacity="0.42"/>
+      <stop offset="0.45" stop-color="#b85e00" stop-opacity="0.18"/>
+      <stop offset="1" stop-color="#000000" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="sweep" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ff9a1f" stop-opacity="0"/>
+      <stop offset="0.55" stop-color="#ff9a1f" stop-opacity="0.55"/>
+      <stop offset="1" stop-color="#ff9a1f" stop-opacity="0"/>
     </linearGradient>
   </defs>
-  <rect x="0" y="0" width="1400" height="400" fill="url(#bg)"/>
-  <text x="80" y="188" fill="#ffffff" font-family="Inter, Segoe UI, system-ui, sans-serif"
-        font-size="104" font-weight="700" dominant-baseline="middle">@@DISPLAY@@</text>
-  <text x="84" y="272" fill="#95d5b2" font-family="Inter, Segoe UI, system-ui, sans-serif"
-        font-size="40" font-weight="400" dominant-baseline="middle">@@DESC@@</text>
+  <rect width="1344" height="576" fill="#000000"/>
+  <rect width="1344" height="576" fill="url(#glow)"/>
+  <g stroke="#ffb86b" stroke-opacity="0.13" stroke-width="1.5" fill="none">
+    <path d="M470 120 L640 250 L560 400 L760 470 L900 300 L1080 180"/>
+    <path d="M640 250 L900 300 M560 400 L900 300 M470 120 L560 400 M760 470 L1080 380 M900 300 L1180 250"/>
+    <path d="M430 470 L560 400 M1080 180 L1180 250 L1080 380"/>
+  </g>
+  <g fill="#ffce8a" fill-opacity="0.55">
+    <circle cx="470" cy="120" r="3"/><circle cx="640" cy="250" r="3.5"/>
+    <circle cx="560" cy="400" r="3"/><circle cx="760" cy="470" r="3"/>
+    <circle cx="900" cy="300" r="4"/><circle cx="1080" cy="180" r="3"/>
+    <circle cx="1180" cy="250" r="3"/><circle cx="1080" cy="380" r="3"/>
+    <circle cx="430" cy="470" r="2.5"/>
+  </g>
+  <path d="M0 520 C 360 420, 900 540, 1344 360" stroke="url(#sweep)" stroke-width="6" fill="none"/>
+  <g transform="translate(96,188) scale(0.5)">
+    <rect x="28" y="28" width="344" height="344" rx="76" fill="url(#tile)" stroke="#2a2a36" stroke-width="2"/>
+    <!-- PLACEHOLDER glyph — mirror icon.svg's bespoke pictogram here. -->
+    <text x="200" y="212" fill="#ffb02e" font-family="Inter, Segoe UI, system-ui, sans-serif"
+          font-size="210" font-weight="700" text-anchor="middle" dominant-baseline="central">@@INITIAL@@</text>
+  </g>
+  <text x="334" y="300" font-family="Helvetica, Arial, sans-serif" font-weight="bold"
+        font-size="120" fill="#f5f5f7" letter-spacing="-2">@@DISPLAY@@</text>
+  <text x="340" y="372" font-family="Helvetica, Arial, sans-serif" font-weight="500"
+        font-size="44" fill="#ffb02e">@@DESC@@</text>
 </svg>
 """
 


### PR DESCRIPTION
## Why

The `comfyui-node-scaffold` icon/banner **placeholders** did not match the pack family — and its comment claimed they did ("styled to the mobile-first family palette"). A pack scaffolded and shipped without hand-replacing the placeholder became the sole registry outlier (`comfyui-touch-shim`, fixed in [comfyui-touch-shim#18](https://github.com/laurigates/comfyui-touch-shim/pull/18)).

| | Family (10 packs) | Scaffold placeholder (before) |
|---|---|---|
| Icon | 400×400, inset tile `rect 28,28,344,344 rx76`, `#1f1f2a→#12121a`, orange/blue pictogram | **512×512 full-bleed `rx96`, green `#2d6a4f→#1b4332`, letter** |
| Banner | 1344×576 family template | **1400×400 green letter banner** |

This is the generator half of a scaffold-fix-backport: the instance fix landed on the pack; this fixes the source so future packs scaffold in-family.

## Change

- **`scaffold.py` `ICON_SVG`** → 400×400 family tile + accent-orange placeholder letter (a letter is explicitly a placeholder to swap for a bespoke pictogram; tile/radius/gradient/stroke/accent are the invariants).
- **`scaffold.py` `BANNER_SVG`** → the 1344×576 family banner template (constellation backdrop, glow, sweep arc, icon-tile scaled 0.5, wordmark + tagline).
- **`just assets`** → rasterize at 400×400 / 1344×576 and **gate the framing**: `icon.png` must trim to `346×346+27+27` (the tile is the outermost element, so this holds for placeholder and final art alike; a `512×512+0+0` full-bleed fails). Skipped when ImageMagick's `identify` is absent (`rsvg-convert` stays the only hard dep).
- **`comfy-registry-lifecycle` "Icon design system"** → made exact: verbatim tile rect, vertical gradient, stroke, the `#ffb02e` (touch) vs `#6ba6ff` (info/gallery) accent convention, no-letters rule, and a fleet-wide framing-audit one-liner. `comfyui-node-scaffold`'s SKILL.md bullet now points at that canonical spec (link, don't duplicate).

## Verification

- A freshly scaffolded pack rasterizes to `400x400 / 346x346+27+27`; the real `just assets` gate passes.
- `test-shim-variant.sh` (13), `test-standalone-variant.sh` (9), `test-finishing-pass.sh` (13) all green; `scaffold.py` parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)