### PR TITLE
feat(skill-catalog-routing): add skill-catalog discovery/routing experiment

### DIFF
--- a/experiments/skill-catalog-routing/.gitignore
+++ b/experiments/skill-catalog-routing/.gitignore
@@ -1,0 +1,3 @@
+results/
+.arm-prompts/
+*.log

--- a/experiments/skill-catalog-routing/CLAUDE.md
+++ b/experiments/skill-catalog-routing/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+## What this is
+
+`skill-catalog-routing` is an **A/B testing harness for skill discovery**. It
+measures whether giving a model the concatenated `name + description` catalog of
+every skill helps it **route** a user request to the correct skill, and how short
+those descriptions can be while still working. It runs `claude -p` under a
+catalog-free `--system-prompt-file` with a varying amount of catalog injected,
+captures stream-JSON, and scores the router's decision **deterministically**
+(skill-id match — no LLM judge). See `README.md` for the arm ladder and metrics.
+
+It lives under `experiments/` deliberately. It is **not a plugin** — not in
+`.claude-plugin/marketplace.json`, not versioned by release-please, not scanned
+by plugin-compliance. The parent repo conventions (`../../CLAUDE.md`) still
+apply; the plugin lifecycle does not. Commit scope: `skill-catalog-routing`
+(matches no release-please package, so work here never triggers a release).
+
+## Architecture — the pipeline
+
+```
+SKILL.md frontmatter ─► build-catalogs.py ─► catalogs/catalog.{names,short,medium,full}.json (committed)
+                                                            │
+conditions.yaml (model × catalog) ─┐                        │  build-arm-prompt.sh
+tasks/*.yaml (prompt + gold) ──────┴─► run-suite.sh ─► run-one.sh ─► claude -p (stream-json)
+                                                            │            ─► results/<run>/<task>.<cond>.runN.jsonl
+                                              score-run.py (parse last JSON, id↔gold) ◄─┘
+                                                            │
+                              compare.py ─► results.json + report.md ─► render-frontier.py ─► frontier.md
+```
+
+## Non-obvious invariants (read before touching the harness)
+
+- **Catalog-free system prompt is load-bearing.** `--system-prompt-file`
+  *replaces* the built-in prompt, stripping Claude Code's own ~22k skill listing.
+  If any arm leaked the built-in listing, the whole comparison would be
+  meaningless. `run-one.sh` asserts the null (C0) arm carries no catalog body.
+- **Neutral cwd is load-bearing.** `run-one.sh` runs `claude` from a fresh
+  `mktemp -d`, NOT the plugins repo — otherwise the repo's own `CLAUDE.md` and
+  rules (which name many skills) load from cwd and contaminate every arm.
+  Measured: repo-cwd base ~50k tokens vs neutral-cwd base ~23k. The residual 23k
+  is the user's global `~/.claude` memory — a fixed additive constant across all
+  arms, so it cannot confound the *relative* catalog comparison (mild
+  external-validity caveat only).
+- **Root sandbox needs `IS_SANDBOX=1`.** `--dangerously-skip-permissions` refuses
+  to run as root without it; the router calls no tools, so this only keeps the
+  turn non-interactive. `</dev/null` stops the CLI waiting on stdin.
+- **Grade the last JSON line, not the preamble.** A low-effort model emits a
+  reasoning preamble before the decision; `score-run.py` parses only the LAST
+  JSON object with a `skill` key (claude-probe's hard-won discipline). The router
+  system prompt and a constant task-framing wrapper (added in `run-one.sh`) force
+  the JSON-only contract — without them, models slip into doing the task or
+  asking questions (observed: haiku on the first smoke test).
+- **Shortening is structure-aware, never end-truncation.** Descriptions are
+  `<domain>. Use when <triggers>.` — the routing-relevant triggers sit at the
+  END. `build-catalogs.py` locates the `Use when` clause and truncates THAT,
+  always keeping the literal `Use when` (issue #1278 class). `--validate` asserts
+  every band keeps `Use when`, respects its char ceiling, and that short ⊆ medium
+  (a genuine token-subset). Re-run and re-validate after any change.
+- **The leakage gate is the study's key instrument.** `check-tasks.py` flags any
+  task whose prompt echoes its gold skill's distinctive NAME tokens
+  (`name_overlap` ≥ 0.34 WARN, ≥ 0.5 ERROR). If tasks leak names, names-only (C1)
+  wins by string overlap and description length stops mattering — the experiment
+  measures nothing. Keep the whole set at `name_overlap = 0.0`.
+- **The pilot IS the validity gate.** If haiku C4 ≈ C1 across the pilot subset,
+  the task set is too leaky/easy — fix the tasks before spending on the full
+  sweep. Do not promote to sonnet/opus until the haiku curve is clean and
+  monotone.
+
+## Cost discipline
+
+Every run is a real `claude -p` call; the full matrix is 15 arms × 70 tasks × N
+runs. Gate it: haiku pilot (2 arms × 20 tasks × 3) → haiku full ladder → sonnet +
+opus. Effort is fixed `low`. Same-arm calls reuse a cached system prompt, so cost
+falls sharply after the first call per arm. `results/` is gitignored; the durable
+artifacts are `catalogs/`, `tasks/`, the scripts, and any findings written up in
+this directory.
+
+## Commits
+
+Use `skill-catalog-routing` as the conventional-commit scope
+(`feat(skill-catalog-routing): …`, `chore(skill-catalog-routing): …`).

--- a/experiments/skill-catalog-routing/FINDINGS-pilot.md
+++ b/experiments/skill-catalog-routing/FINDINGS-pilot.md
@@ -1,0 +1,78 @@
+# Pilot findings
+
+Run `pilot` — haiku C1 (names only) vs C4 (full descriptions), 20-task subset
+(r01–r10, n01–n06, z01–z04), 3 runs each; plus a 20-call opus-C4 gold-check.
+140 transcripts, **0 parse failures, 0 false triggers**.
+
+## Results
+
+| arm | top-1 | near-miss | false-trigger | abstain | catalog tokens |
+|-----|-------|-----------|---------------|---------|----------------|
+| haiku-C1 (names only) | 0.98 | 0.94 | 0.00 | 1.00 | 27.3k |
+| haiku-C4 (full desc)  | 1.00 | 1.00 | 0.00 | 1.00 | 43.9k |
+| **opus-C4 (gold-check)** | **1.00** | **1.00** | 0.00 | 1.00 | 43.9k |
+
+Measured token ladder (real input tokens, over the 23.2k base): names +4.2k,
+short +7.2k, medium +11.0k, full +20.7k.
+
+## What the pilot establishes
+
+1. **The instrument is valid.** opus-C4 routed all 16 pilot route tasks to their
+   gold (100%) — an independent strong-model confirmation that the gold labels
+   are correct. The task set has 0 lexical leakage (`name_overlap = 0.0`), the
+   JSON contract held on every call (0 parse fails), and abstention was perfect
+   (0 false triggers on the `NONE` tasks). Isolation is clean: the built-in
+   ~22k skill listing is absent (base 23.2k, full catalog 43.9k).
+
+2. **Skill NAMES carry almost all of the routing signal.** Names-only (C1)
+   already routes at 0.98 top-1 / 0.94 near-miss on haiku. Adding the entire
+   description corpus (+16.5k tokens, C1→C4) buys **+0.02 top-1 and +0.06
+   near-miss**. The one place a description actually changed the answer was the
+   deliberately-ambiguous pair `git-commit` vs `git-commit-workflow` (n01): with
+   names alone haiku picked the wrong sibling 1/3 of the time; with descriptions
+   it was always right. That is the shape of where descriptions earn their keep —
+   near-miss discrimination between same-family skills — and nowhere else in the
+   pilot.
+
+## What this means for the pre-registered gate
+
+The gate was: *"the instrument MUST separate C1 from C4; if it doesn't, the task
+set is leaky — fix before spending more."* The separation is minimal (+0.02
+top-1), but the cause is **not** a leaky/miscalibrated task set (leakage 0, golds
+verified). The cause is a genuine property of the corpus: the routing ids are
+`<plugin>/<skill-slug>` and the slugs are semantically rich
+(`macos-performance-triage`, `helm-release-recovery`, `cargo-machete`…), so a
+model maps symptom→name by meaning without needing the description. **"Names are
+near-sufficient for routing" is itself the headline finding**, and it directly
+supports the "could shorter be better?" hypothesis: most of the 20.7k-token
+catalog is redundant for discovery given the names.
+
+## Caveats
+
+- **Small subset, two extremes only.** 20 tasks (near-miss = 6 tasks × 3 runs =
+  18 rows); C2/C3 and C0 were not run, and only haiku. The description effect is
+  near the ceiling, so the current task set has little dynamic range to resolve a
+  *length* curve — C1–C4 would likely all cluster near 1.00.
+- **C0 (no catalog) is the untested, most decision-relevant arm.** The smoke test
+  showed haiku-C0 could not emit a valid id without a catalog (answered NONE), so
+  C4−C0 is expected to be large. That would complete the story: the catalog's
+  value is real and lives **in the names**, while the descriptions add a thin
+  near-miss margin on top.
+
+## Recommended next step
+
+The value of a full 5-arm × 3-model sweep on the *current* tasks is limited: the
+accuracy curve would be nearly flat near the ceiling. Two better options:
+
+- **(A) Cheap, high-information:** run **C0 + C1 + C4 across all three models**
+  (haiku/sonnet/opus). This quantifies the *true* catalog value (C4−C0), confirms
+  names-carry-most-signal across the capability range, and measures whether weak
+  models lean on descriptions more than strong ones — without paying for a flat
+  C2/C3 middle.
+- **(B) Restore dynamic range first:** harden the near-miss set with genuinely
+  **name-opaque** discriminators (pairs whose slugs don't reveal the difference),
+  then run the full ladder so C2/C3 can actually separate. This is the only way
+  to draw a real "how short is too short" curve.
+
+Both are sound; (A) is the fast path to the headline numbers, (B) is needed for a
+precise length threshold.

--- a/experiments/skill-catalog-routing/FINDINGS.md
+++ b/experiments/skill-catalog-routing/FINDINGS.md
@@ -1,0 +1,79 @@
+# Findings — skill-catalog routing
+
+Two runs, both deterministic-graded, 0 parse failures throughout:
+
+- **pilot** — haiku C1 vs C4 on a 20-task subset + opus-C4 gold-check (`FINDINGS-pilot.md`)
+- **haiku-ladder** — haiku C0→C4 across all **70 tasks**, 2 runs (700 transcripts)
+
+The full-set ladder **corrects the pilot's tentative headline**: the 20-task
+pilot subset happened to use transparent-named skills, so names-only looked
+near-sufficient (0.98). Across the full 70-task set, descriptions matter a lot.
+
+## Haiku ladder (all 70 tasks)
+
+| arm | catalog | tokens | top-1 | near-miss | false-trigger | abstain |
+|-----|---------|--------|-------|-----------|---------------|---------|
+| C0 | none | 23.2k | **0.00** | 0.00 | 0.03 | 0.97 |
+| C1 | names only | 27.3k | 0.83 | 0.80 | 0.10 | 0.90 |
+| C2 | short (`Use when …` ≤40c) | 30.4k | 0.86 | 0.85 | 0.07 | 0.93 |
+| C3 | medium (`Use when …` ≤80c) | 34.1k | 0.88 | 0.82 | 0.07 | 0.93 |
+| C4 | full description | 43.9k | **1.00** | 1.00 | 0.07 | 0.93 |
+
+## What this establishes
+
+1. **The catalog is essential, and it lives in the ids.** With no catalog (C0) a
+   model scores **0.00** — it cannot emit a valid `<plugin>/<skill>` id from
+   memory and abstains 97% of the time. C4 − C0 = **+1.00**. There is no routing
+   without the listing; the entire question is how much *description* to attach to
+   the ids.
+
+2. **Names alone are a strong but incomplete baseline.** Names-only routes at
+   **0.83** top-1 / 0.80 near-miss. Good, but a sixth of requests go to the wrong
+   skill — and names-only also has the **worst false-trigger rate (0.10)**: with
+   nothing but ids, the model over-grabs a loosely-related skill for out-of-scope
+   requests.
+
+3. **Full descriptions close the gap — to a perfect 1.00.** C4 − C1 = **+0.17**
+   top-1 and +0.20 near-miss, and full is the only arm that hits ceiling.
+   Descriptions win exactly where names *can't* disambiguate — near-miss
+   same-family pairs (ruff lint vs format, finops caches vs waste, obsidian
+   search vs tasks) and **opaque-named skills** (`comfy-metadata`,
+   `langgraph-agents`, `design-legacy-seams`). 9 route tasks flipped from wrong
+   (names) to right (full).
+
+4. **"Shorter is better" is NOT supported *as implemented* — and the reason is
+   the actionable insight.** The short/medium variants (C2, C3) only reach
+   0.86–0.88 — barely above names, far below full. But that is an artifact of
+   *what* was trimmed: our structure-aware shortening kept the `Use when …`
+   trigger clause and **dropped the leading domain sentence** ("ripgrep fast code
+   search: smart defaults, regex, file filtering"). The ladder shows that domain
+   sentence carries most of the routing signal for a forced-choice router — more
+   than the trigger clause. So the lesson is not "descriptions can't be short"
+   but **"if you shorten, keep the domain/capability phrase, not (only) the `Use
+   when` triggers."** A short variant built the other way around is the obvious
+   next test.
+
+5. **Descriptions modestly improve precision.** False-triggering drops from 0.10
+   (names) to 0.07 (any description) — a small but real over-triggering reduction.
+
+## Caveats / open questions
+
+- **Haiku only, 2 runs.** Cross-model (sonnet/opus) is the portability question:
+  do stronger models need the description less (recover more from names)? The
+  pilot's opus-C4 = 1.00 hints opus is strong with full descriptions but says
+  nothing about opus-C1.
+- **The shortening direction confound (finding #4)** means the current C2/C3 do
+  not answer "what is the optimal description length" — they answer "trigger-only
+  short descriptions underperform." A domain-preserving short variant is needed to
+  draw the real length/accuracy frontier.
+- Gold labels are verified (opus-C4 = 100% on the pilot route set); the task set
+  has 0 lexical leakage; isolation strips the built-in listing (base 23.2k).
+
+## Bottom line
+
+For skill **discovery/routing**: the id list is mandatory (no catalog → 0%),
+names get you ~83%, and full descriptions are needed to reach ceiling — they earn
+their ~16.5k tokens specifically on near-miss and opaque-named skills. Shorter
+descriptions can likely recover most of that benefit **only if they preserve the
+capability/domain phrase** rather than the `Use when` trigger tail — the single
+most useful follow-up this experiment points to.

--- a/experiments/skill-catalog-routing/README.md
+++ b/experiments/skill-catalog-routing/README.md
@@ -1,0 +1,107 @@
+# skill-catalog-routing
+
+An A/B testing harness measuring whether the **skill catalog** (the concatenated
+`name + description` of every skill) helps a model **route** a user request to
+the right skill — and how short those descriptions can be while still working.
+
+## The questions
+
+1. **Does the catalog help?** Compare a router with the full catalog in context
+   against one with no catalog (or names only).
+2. **How short can descriptions be** while still enabling correct selection?
+3. **Could shorter be *better*** — not just cheaper, but fewer false triggers?
+4. **How does this vary by model** (haiku / sonnet / opus)?
+
+This mirrors the sibling `experiments/claude-probe/` harness: `claude -p` +
+`--system-prompt-file`, deterministic scoring, `compare.py` rollups, gitignored
+`results/`, commit scope = experiment name (matches no release-please package).
+
+## The arms — a monotone information ladder
+
+The independent variable is `catalog`: how much of the skill listing the router
+sees. Each shorter band is a genuine token-subset of the next.
+
+| arm | catalog | ~tokens over base | role |
+|-----|---------|-------------------|------|
+| C0 | none (task only) | 0 | null control (free-recall) |
+| C1 | names only | ~4.2k | isolates the value of descriptions |
+| C2 | names + `Use when <first trigger>` ≤40c | measured | minimal trigger |
+| C3 | names + `Use when <triggers>` ≤80c | measured | mid |
+| C4 | names + full description (current) | ~20.7k | upper anchor (status quo) |
+
+**Measured base**: a router with no catalog costs ~23k input tokens (the user's
+global `~/.claude` memory, a fixed additive constant across all arms). Adding the
+full catalog brings it to ~43.7k. Crucially the base does **not** contain Claude
+Code's own ~22k skill listing — `--system-prompt-file` replaces the built-in
+prompt and strips it, so the only skill vocabulary the model sees is the one we
+inject, for every arm including C0.
+
+## Layout
+
+| path | contents |
+|------|----------|
+| `catalogs/` | committed catalog variants (`catalog.{names,short,medium,full}.json`) + `catalog_manifest.json` (source SHA, hashes, provenance) |
+| `prompts/system-router.md` | the catalog-free router system prompt (JSON-out contract) |
+| `conditions.yaml` | 15 arms = 3 models × 5 catalog variants (effort fixed low) |
+| `tasks/*.yaml` | 70 labeled tasks: 30 route, 20 near-miss (10 pairs), 20 abstention (`gold: NONE`) |
+| `scripts/build-catalogs.py` | frontmatter → the 4 variants + manifest (structure-aware shortening, `--validate`) |
+| `scripts/check-tasks.py` | schema + lexical-leakage gate over the task set |
+| `scripts/build-arm-prompt.sh` | assemble router + injected catalog for an arm |
+| `scripts/run-one.sh` / `run-suite.sh` | one triple / the cartesian sweep |
+| `scripts/score-run.py` | parse the router's last-line JSON, match id ↔ gold |
+| `scripts/compare.py` | per-condition routing metrics → `results.json` + `report.md` |
+| `scripts/render-frontier.py` | accuracy-vs-length curves + per-model degradation slope |
+| `scripts/measure-catalog-tokens.sh` | real input tokens per catalog variant |
+| `results/` | gitignored transcripts + reports |
+
+## Quickstart
+
+```sh
+# (Re)build + validate the catalogs from SKILL.md frontmatter.
+scripts/build-catalogs.py --validate
+
+# Validate the task set (schema + leakage gate).
+scripts/check-tasks.py --strict
+
+# PILOT GATE (~120 calls): haiku, C1 (names) vs C4 (full), 20-task subset, 3 runs.
+# The instrument MUST separate C1 from C4; if it doesn't, the task set is leaky.
+bash scripts/run-suite.sh \
+  --tasks r01,r02,r03,r04,r05,r06,r07,r08,r09,r10,n01,n02,n03,n04,n05,n06,z01,z02,z03,z04 \
+  --conditions haiku-C1,haiku-C4 --runs 3 --run-id pilot
+scripts/compare.py pilot
+scripts/render-frontier.py pilot
+
+# One (task, condition, run) for iteration.
+bash scripts/run-one.sh r01 haiku-C4 1 results/adhoc
+
+# Real token cost per catalog variant.
+bash scripts/measure-catalog-tokens.sh
+```
+
+If `just` is installed, the same recipes are `just <recipe>` (see `justfile` /
+the root `just skill-catalog-routing::<recipe>`).
+
+## Metrics
+
+Per (model × arm), pooled over runs: **top-1** routing accuracy, **near-miss**
+discrimination accuracy, **top-2** (runner-up counts) on near-miss,
+**false-trigger** rate (fraction of `gold: NONE` where a skill was wrongly
+picked), **abstain** accuracy, and **parse-fail** rate. `render-frontier.py`
+turns these into the accuracy-vs-tokens curve, the false-trigger curve, and the
+per-model degradation slope (C4−C2) — the portability signal.
+
+## Cost discipline
+
+Every run is a real `claude -p` call. The full matrix (15 arms × 70 tasks × N
+runs) is large, so it is **gated**: the haiku pilot (2 arms × 20 tasks × 3 runs)
+must first show a clean C4 − C1 separation; only then does the haiku full ladder
+run, then sonnet/opus on a clean monotone curve. Effort is fixed `low` (routing
+is shallow classification; higher effort lets the model reason around a terse
+catalog and washes out the length signal). Same-arm calls reuse a cached system
+prompt, so cost drops sharply after warmup.
+
+## Not a plugin
+
+Lives under `experiments/` deliberately — a dogfooding harness, not something to
+publish. Not in `.claude-plugin/marketplace.json`, not release-please-versioned,
+not wired into plugin-compliance scripts. Commit scope: `skill-catalog-routing`.

--- a/experiments/skill-catalog-routing/catalogs/catalog.full.json
+++ b/experiments/skill-catalog-routing/catalogs/catalog.full.json
@@ -1,0 +1,1627 @@
+{
+  "variant": "full",
+  "source_sha": "020bfd9049809681d21d5b6469696f079f249bd3",
+  "skill_count": 405,
+  "entries": [
+    {
+      "id": "accessibility-plugin/accessibility-implementation",
+      "line": "accessibility-plugin/accessibility-implementation: WCAG 2.1/2.2 compliance, ARIA patterns, keyboard nav, focus management, a11y testing. Use when implementing accessible components or user mentions WCAG/ARIA/screen readers."
+    },
+    {
+      "id": "accessibility-plugin/design-tokens",
+      "line": "accessibility-plugin/design-tokens: Design tokens and CSS custom properties: theme systems, dark mode, component libraries. Use when implementing design systems or user mentions tokens, CSS variables, or theming."
+    },
+    {
+      "id": "agent-patterns-plugin/adversarial-review",
+      "line": "agent-patterns-plugin/adversarial-review: Adversarial second-pass review that tries to break code, designs, plans, or ADRs. Use when stakes are high and a normal review already ran."
+    },
+    {
+      "id": "agent-patterns-plugin/agent-teams",
+      "line": "agent-patterns-plugin/agent-teams: Configure Claude Code agent teams (implicit team, SendMessage, TaskUpdate). Use when running parallel agents, coordinating with messaging, or setting up a lead/teammate architecture."
+    },
+    {
+      "id": "agent-patterns-plugin/cold-read-gate",
+      "line": "agent-patterns-plugin/cold-read-gate: Gate outward-bound text (upstream issues, docs, PR bodies) through isolated haiku fresh-reader critique before publishing. Use when an artifact must survive a reader with zero project context."
+    },
+    {
+      "id": "agent-patterns-plugin/custom-agent-definitions",
+      "line": "agent-patterns-plugin/custom-agent-definitions: Write and configure custom agent definitions in Claude Code agents/ directory. Use when creating an agent .md file, defining a specialized agent, or configuring agent tools."
+    },
+    {
+      "id": "agent-patterns-plugin/exclusive-lock-dispatch",
+      "line": "agent-patterns-plugin/exclusive-lock-dispatch: Pre-dump-then-dispatch for tools holding an exclusive lock (Ghidra, migrations, single-writer caches). Use when fanning out parallel agents needing a non-concurrent resource."
+    },
+    {
+      "id": "agent-patterns-plugin/execution-grounded-review",
+      "line": "agent-patterns-plugin/execution-grounded-review: Execution-grounded review: run tests first, trace each acceptance criterion to execution evidence. Use when verifying an implementation meets spec."
+    },
+    {
+      "id": "agent-patterns-plugin/expose-tunable-knob",
+      "line": "agent-patterns-plugin/expose-tunable-knob: Expose a live-adjustable control instead of guessing a magic constant for a parameter the agent cannot itself perceive. Use when tuning visual, audio, or UX output (color, size, position, timing, volume) that only the user can judge."
+    },
+    {
+      "id": "agent-patterns-plugin/mcp-code-execution",
+      "line": "agent-patterns-plugin/mcp-code-execution: Scaffold the code execution pattern for MCP-based agents. Use when agents call many MCP tools, intermediate data exceeds context, you need loops, or PII must stay out of context."
+    },
+    {
+      "id": "agent-patterns-plugin/mcp-management",
+      "line": "agent-patterns-plugin/mcp-management: Install and configure MCP servers for Claude Code. Use when adding/enabling servers, updating .mcp.json, managing OAuth remote servers, or troubleshooting connections."
+    },
+    {
+      "id": "agent-patterns-plugin/mcp-server-authoring",
+      "line": "agent-patterns-plugin/mcp-server-authoring: FastMCP authoring for Python MCP servers \u2014 tools, resources, prompts, TDD, release-please. Use when building or extending an MCP server, adding a tool/resource, or scaffolding a new server."
+    },
+    {
+      "id": "agent-patterns-plugin/meta-assimilate",
+      "line": "agent-patterns-plugin/meta-assimilate: Copy, generalize, or merge a project's .claude/{agents,commands} into user-scoped configuration. Use when assimilating another project's Claude setup or generalizing an agent."
+    },
+    {
+      "id": "agent-patterns-plugin/meta-audit",
+      "line": "agent-patterns-plugin/meta-audit: Audit Claude subagent configs for completeness, security, and best practices. Use when reviewing agents/ for missing frontmatter, overprivileged tools, or bad model choices."
+    },
+    {
+      "id": "agent-patterns-plugin/meta-context-diet",
+      "line": "agent-patterns-plugin/meta-context-diet: Audit CLAUDE.md and .claude/rules for always-loaded content that should become an on-demand skill. Use when CLAUDE.md feels bloated, trimming context, or promoting a rule into a skill."
+    },
+    {
+      "id": "agent-patterns-plugin/meta-promote",
+      "line": "agent-patterns-plugin/meta-promote: Promote rules, skills, or agents from project scope to parent or user-global scope. Use when reorganizing .claude/ directories or when sibling repos hold near-duplicate rules."
+    },
+    {
+      "id": "agent-patterns-plugin/multi-model-delegation",
+      "line": "agent-patterns-plugin/multi-model-delegation: Multi-model design consults via PAL (kimi, glm, gemini, gpt). Use when asking other models to brainstorm a design or reconciling their split answers."
+    },
+    {
+      "id": "agent-patterns-plugin/parallel-agent-dispatch",
+      "line": "agent-patterns-plugin/parallel-agent-dispatch: Dispatch contract for spawning parallel agents covering worktree collisions, scope overflow, and silent exits. Use when fanning out concurrent agents or authoring a lead prompt."
+    },
+    {
+      "id": "agent-patterns-plugin/plugin-settings",
+      "line": "agent-patterns-plugin/plugin-settings: Configure per-project plugin settings via .claude/plugin-name.local.md files. Use when building plugins with user-configurable behavior, storing agent state, or controlling hooks."
+    },
+    {
+      "id": "agent-patterns-plugin/verify-before-plan",
+      "line": "agent-patterns-plugin/verify-before-plan: Verify orchestrator premises (file counts, build state, artefact presence) before dispatching parallel subagents. Use when a wave's briefs cite a number, path, or behaviour not yet checked."
+    },
+    {
+      "id": "agent-patterns-plugin/wave-based-dispatch",
+      "line": "agent-patterns-plugin/wave-based-dispatch: Sequential-wave dispatch for WO chains where output of one feeds the next, shared locks, or shared files prevent fan-out. Use when planning dependent multi-WO landings."
+    },
+    {
+      "id": "agents-plugin/agents-analyze",
+      "line": "agents-plugin/agents-analyze: Audit plugins for sub-agent opportunities \u2014 verbose skills, coverage gaps, over-permissions. Use when reviewing where sub-agents would help or auditing agents against the always-Opus standard."
+    },
+    {
+      "id": "api-plugin/api-testing",
+      "line": "api-plugin/api-testing: HTTP API testing with Supertest (TS) and httpx/pytest (Python). Use when the user mentions API testing, Supertest, httpx, REST/GraphQL validation, or HTTP response errors."
+    },
+    {
+      "id": "bevy-plugin/bevy-ecs-patterns",
+      "line": "bevy-plugin/bevy-ecs-patterns: Advanced Bevy ECS: complex queries, system scheduling, change detection, and performance tuning. Use when optimizing Bevy architecture or implementing complex game systems."
+    },
+    {
+      "id": "bevy-plugin/bevy-game-engine",
+      "line": "bevy-plugin/bevy-game-engine: Bevy game engine: ECS, rendering, input, and asset management. Use when building Bevy games, working with entities/components/systems, or mentioning Rust gamedev or 2D/3D games."
+    },
+    {
+      "id": "blog-plugin/blog-post",
+      "line": "blog-plugin/blog-post: Create a blog post via guided prompts with git context auto-populated. Use when writing a quick update, retrospective, tutorial, deep dive, or devlog entry."
+    },
+    {
+      "id": "blog-plugin/blog-post-writing",
+      "line": "blog-plugin/blog-post-writing: Style guide for technical blog posts \u2014 updates, retrospectives, tutorials, deep dives. Use when writing about work done, documenting a project, or mentioning blog/post/devlog."
+    },
+    {
+      "id": "blueprint-plugin/adr-relationships",
+      "line": "blueprint-plugin/adr-relationships: Domain analysis, conflict detection, and relationship validation for Architecture Decision Records. Use when creating or validating ADRs to ensure consistency."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-adr-list",
+      "line": "blueprint-plugin/blueprint-adr-list: List ADRs as a markdown table with title, status, date, domain. Use when generating an ADR index, auditing ADR status, or reviewing all architecture decisions."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-adr-validate",
+      "line": "blueprint-plugin/blueprint-adr-validate: Validate ADR relationships, domain consistency, and duplicate ADR numbers. Use when auditing ADRs before release, finding broken supersedes/extends links, cycles, or number collisions."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-autopilot",
+      "line": "blueprint-plugin/blueprint-autopilot: Run due blueprint maintenance ambiently at autonomy level 2+. Use when a drift nudge reports blueprint tasks due or suggests /blueprint:autopilot."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-claude-md",
+      "line": "blueprint-plugin/blueprint-claude-md: Generate or update CLAUDE.md from blueprint artifacts. Use when adding team instructions, converting inline content to @imports, or setting up CLAUDE.local.md."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-curate-docs",
+      "line": "blueprint-plugin/blueprint-curate-docs: Curate library gotchas and project patterns into .claude/rules/ entries for AI context. Use when documenting library knowledge for PRP reuse."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-derive-plans",
+      "line": "blueprint-plugin/blueprint-derive-plans: Derive PRDs, ADRs, PRPs from git history, docs, and codebase. Use when onboarding a project to blueprint, generating a PRD or ADRs retroactively, or extracting features from conventional commits."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-derive-rules",
+      "line": "blueprint-plugin/blueprint-derive-rules: Derive Claude rules from git commit history. Use when extracting implicit decisions from commits or codifying code-style, testing, and API-design rules."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-derive-tests",
+      "line": "blueprint-plugin/blueprint-derive-tests: Derive test regression plans from git history by finding commits lacking tests. Use when finding untested bug fixes, coverage gaps, or generating a test backlog."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-development",
+      "line": "blueprint-plugin/blueprint-development: Generate project-specific rules from PRDs for Blueprint Development. Use when generating architecture, testing, or quality rules from requirements documents."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-docs-currency",
+      "line": "blueprint-plugin/blueprint-docs-currency: Enforce same-commit landing of code and docs (APIs, formats, ADRs). Use when committing API/format changes, promoting research to docs/, or landing an ADR decision."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-docs-list",
+      "line": "blueprint-plugin/blueprint-docs-list: List blueprint documents (ADRs, PRDs, PRPs) with frontmatter metadata. Use when listing docs, auditing statuses, or generating an index for project documentation."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-execute",
+      "line": "blueprint-plugin/blueprint-execute: Blueprint meta command: determine and execute the next logical action. Use when asked 'what's next?', 'continue blueprint', or 'run blueprint' without a subcommand."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-feature-tracker-status",
+      "line": "blueprint-plugin/blueprint-feature-tracker-status: Display feature tracker stats, phase progress, and completion summary. Use when checking feature status, viewing blocked features, or seeing ready-to-start work."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-feature-tracker-sync",
+      "line": "blueprint-plugin/blueprint-feature-tracker-sync: Sync feature tracker with TODO.md, taskwarrior sidecars, and PRDs. Use when reconciling TODO.md vs tracker, draining WO entries, or recalculating stats."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-generate-rules",
+      "line": "blueprint-plugin/blueprint-generate-rules: Generate project-specific rules from PRDs with path-scoped frontmatter. Use when auto-creating architecture, testing, or quality rules from docs/prds/."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-init",
+      "line": "blueprint-plugin/blueprint-init: Initialize Blueprint Development structure. Use when bootstrapping docs/blueprint/ with manifest, PRD/ADR/PRP directories, and feature tracking for the first time."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-migration",
+      "line": "blueprint-plugin/blueprint-migration: Versioned migration procedures for blueprint format upgrades (v1.x to v3.3). Use when blueprint-upgrade needs version-specific logic, content hashing, or rollback."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-promote",
+      "line": "blueprint-plugin/blueprint-promote: Move generated artifact to custom layer to preserve manual edits. Use when promoting a generated rule, preserving .claude/rules/ changes, or stopping sync warnings."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-prp-create",
+      "line": "blueprint-plugin/blueprint-prp-create: Create a PRP (Product Requirement Prompt) with research, context, and validation gates. Use when planning a feature packet for subagent execution with TDD and confidence scoring."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-prp-execute",
+      "line": "blueprint-plugin/blueprint-prp-execute: Execute a PRP with validation loop, TDD, and quality gates. Use when asked to execute a PRP, run a planned feature from docs/prps/, or delegate a PRP to subagents."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-rules",
+      "line": "blueprint-plugin/blueprint-rules: Manage modular rules in .claude/rules/ with path-specific globs. Use when adding or listing rules, syncing with CLAUDE.md, or validating path frontmatter."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-status",
+      "line": "blueprint-plugin/blueprint-status: Show blueprint version, config, PRD/ADR/PRP counts, and feature tracker progress. Use when auditing traceability, orphan docs, or stale generated content."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-story-audit",
+      "line": "blueprint-plugin/blueprint-story-audit: Audit user stories against codebase and tests for tier-ranked coverage gaps. Use when running story audit, PRD reconciliation, or surfacing PRD-code drift."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-story-reconcile",
+      "line": "blueprint-plugin/blueprint-story-reconcile: Reconcile PRD requirements with a story-audit drift report. Use when marking PRD entries implemented/partial/missing, or promoting code-only stories into the PRD."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-sync",
+      "line": "blueprint-plugin/blueprint-sync: Check for stale generated content and offer regeneration or promotion. Use when syncing blueprint after PRD changes, or reconciling .claude/rules/ drift."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-sync-ids",
+      "line": "blueprint-plugin/blueprint-sync-ids: Scan blueprint docs and assign missing PRD/ADR/PRP/WO IDs. Use when assigning IDs to docs; --dry-run to preview, --link-issues to create GitHub issues for orphans."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-upgrade",
+      "line": "blueprint-plugin/blueprint-upgrade: Upgrade blueprint structure to the latest format version. Use when migrating between format versions, enabling monorepo workspaces, or batch upgrading repos."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-work-order",
+      "line": "blueprint-plugin/blueprint-work-order: Create a work-order for isolated subagent execution, optionally linked to a GitHub issue. Use when breaking a PRP into delegatable tasks or spawning from an issue."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-workspace-scan",
+      "line": "blueprint-plugin/blueprint-workspace-scan: Discover child blueprint workspaces and refresh the manifest. Use when adding/removing a child blueprint or when status shows stale portfolio data."
+    },
+    {
+      "id": "blueprint-plugin/confidence-scoring",
+      "line": "blueprint-plugin/confidence-scoring: Assess quality of PRPs and work-orders using systematic confidence scoring. Use when evaluating readiness for execution or subagent delegation."
+    },
+    {
+      "id": "blueprint-plugin/document-detection",
+      "line": "blueprint-plugin/document-detection: Detect PRD/ADR/PRP opportunities in conversations and prompt for document creation. Use when the user discusses feature requirements, tech trade-offs, or implementation plans."
+    },
+    {
+      "id": "blueprint-plugin/document-linking",
+      "line": "blueprint-plugin/document-linking: Unified ID system for PRDs, ADRs, PRPs, and GitHub issues with bidirectional links. Use when linking docs, finding orphans, auto-assigning IDs, or validating cross-doc references."
+    },
+    {
+      "id": "blueprint-plugin/feature-tracking",
+      "line": "blueprint-plugin/feature-tracking: Track feature implementation against requirements with hierarchical FR codes and TODO.md sync. Use when linking features to PRDs or recalculating completion stats."
+    },
+    {
+      "id": "code-quality-plugin/ast-grep-search",
+      "line": "code-quality-plugin/ast-grep-search: Find and replace code patterns structurally with ast-grep. Use when matching code by AST structure, finding functions with specific signatures, or detecting anti-patterns regex cannot match."
+    },
+    {
+      "id": "code-quality-plugin/bulk-sweep-classify",
+      "line": "code-quality-plugin/bulk-sweep-classify: Classify every regex match before a bulk find-replace/syntax-modernization sweep \u2014 four match categories, scoped transform, allowlist-aware verification. Use when bulk-renaming commands/tools/paths or migrating syntax across many files."
+    },
+    {
+      "id": "code-quality-plugin/code-antipatterns",
+      "line": "code-quality-plugin/code-antipatterns: Analyze a codebase for anti-patterns using ast-grep. Use when finding magic numbers, console.logs, var usage, excessive any, eval/innerHTML security issues, or deep nesting."
+    },
+    {
+      "id": "code-quality-plugin/code-complexity",
+      "line": "code-quality-plugin/code-complexity: Analyze code complexity metrics (cyclomatic, cognitive, function length, coupling). Use when identifying refactoring targets, tracking codebase health, or reviewing large changes."
+    },
+    {
+      "id": "code-quality-plugin/code-dead-code",
+      "line": "code-quality-plugin/code-dead-code: Detect dead code, unused exports, unreachable branches, and orphaned files. Use when reducing maintenance burden, cleaning up after refactors, or auditing codebase health."
+    },
+    {
+      "id": "code-quality-plugin/code-dep-audit",
+      "line": "code-quality-plugin/code-dep-audit: Audit dependencies for security vulnerabilities, outdated packages, and license compliance. Use when checking supply chain security, preparing releases, or responding to CVEs."
+    },
+    {
+      "id": "code-quality-plugin/code-docs-quality",
+      "line": "code-quality-plugin/code-docs-quality: Analyze docs quality across PRDs, ADRs, PRPs, CLAUDE.md, .claude/rules/. Use when auditing documentation, checking for stale ADRs/PRDs, or validating rule frontmatter structure."
+    },
+    {
+      "id": "code-quality-plugin/code-hidden-failures",
+      "line": "code-quality-plugin/code-hidden-failures: Scan for hidden failures: swallowed errors (empty catch, || true, 2>/dev/null) and silent degradation (success on zero results). Use when failures vanish or success masks empty output."
+    },
+    {
+      "id": "code-quality-plugin/code-lint",
+      "line": "code-quality-plugin/code-lint: Universal linter that auto-detects ruff/eslint/clippy/gofmt for the project language. Use when linting code, auto-fixing, formatting, or running pre-commit checks."
+    },
+    {
+      "id": "code-quality-plugin/code-refactor",
+      "line": "code-quality-plugin/code-refactor: Refactor toward pure functions, immutability, composition. Use when extracting pure functions, removing side effects, replacing loops with map/filter/reduce, or separating I/O."
+    },
+    {
+      "id": "code-quality-plugin/code-review",
+      "line": "code-quality-plugin/code-review: Code review for quality, security, performance, and architecture. Use when reviewing code, auditing OWASP, checking SOLID, or finding perf bottlenecks and test gaps."
+    },
+    {
+      "id": "code-quality-plugin/code-review-checklist",
+      "line": "code-quality-plugin/code-review-checklist: Checklist for security, correctness, and performance review. Use when reviewing PRs, checking for secrets/injection, verifying error handling, or auditing N+1 queries."
+    },
+    {
+      "id": "code-quality-plugin/code-test-quality",
+      "line": "code-quality-plugin/code-test-quality: Analyze test quality: smells, empty assertions, flaky patterns, coverage gaps. Use when tests are unreliable, coverage is misleading, or after major refactors."
+    },
+    {
+      "id": "code-quality-plugin/debugging-methodology",
+      "line": "code-quality-plugin/debugging-methodology: Systematic debugging for memory, performance, and system-level issues. Use when diagnosing memory leaks, tracing syscalls with strace/eBPF, profiling, or reasoning about races."
+    },
+    {
+      "id": "code-quality-plugin/dry-consolidation",
+      "line": "code-quality-plugin/dry-consolidation: Find and extract duplicated code into shared abstractions. Use when seeing repeated utilities, copy-pasted components, duplicated hooks, or boilerplate repeated across files."
+    },
+    {
+      "id": "codebase-attributes-plugin/attributes-collect",
+      "line": "codebase-attributes-plugin/attributes-collect: Collect codebase health attributes as structured JSON. Use when assessing project health before routing to specialized agents via attributes-route."
+    },
+    {
+      "id": "codebase-attributes-plugin/attributes-dashboard",
+      "line": "codebase-attributes-plugin/attributes-dashboard: Codebase health dashboard with scores and severity for docs, testing, security, and CI/CD. Use when wanting a health overview or terminal-style summary with action suggestions."
+    },
+    {
+      "id": "codebase-attributes-plugin/attributes-route",
+      "line": "codebase-attributes-plugin/attributes-route: Route to specialized agents (security, test, refactor, docs) based on codebase health attributes by severity. Use when the user has attribute data and wants automated remediation."
+    },
+    {
+      "id": "comfyui-plugin/comfy-cli",
+      "line": "comfyui-plugin/comfy-cli: The `comfy` CLI for ComfyUI: install/update/bisect custom nodes, snapshot/restore state, publish to the registry, run workflows headlessly. Use when the user runs `comfy`, `comfy node`, or `comfy run`."
+    },
+    {
+      "id": "comfyui-plugin/comfy-conditionals",
+      "line": "comfyui-plugin/comfy-conditionals: ComfyUI predicate/boolean nodes: compare, AND/OR/XOR/NOT, ternary, null/empty/type probes, ExecutionBlocker. Use when forming the boolean that drives a workflow switch or blocker."
+    },
+    {
+      "id": "comfyui-plugin/comfy-corpus-validation",
+      "line": "comfyui-plugin/comfy-corpus-validation: Verify ComfyUI sampler/scheduler facts: source-of-truth ladder, measured sigma curves, coverage gaps. Use when writing or auditing sampler corpus metadata."
+    },
+    {
+      "id": "comfyui-plugin/comfy-debug-preview",
+      "line": "comfyui-plugin/comfy-debug-preview: ComfyUI debug/preview nodes: show text/numbers/JSON/tensor shapes, image previews, counts, VRAM/CPU telemetry, timing. Use when inspecting a value mid-graph without changing it."
+    },
+    {
+      "id": "comfyui-plugin/comfy-flow-control",
+      "line": "comfyui-plugin/comfy-flow-control: ComfyUI routing nodes: typed switches, index switches, broadcast (Anything Everywhere), pipe/context bundles, for/while loops, ExecutionBlocker gates. Use when wiring where a signal routes in a workflow."
+    },
+    {
+      "id": "comfyui-plugin/comfy-image-utils",
+      "line": "comfyui-plugin/comfy-image-utils: ComfyUI non-inference image ops: resize/crop/pad/tile/batch/mask utilities, plus image-to-text captioners (Florence-2, WD14, BLIP, DeepDanbooru). Use when manipulating images or generating captions/tags in a workflow."
+    },
+    {
+      "id": "comfyui-plugin/comfy-math-strings",
+      "line": "comfyui-plugin/comfy-math-strings: ComfyUI compute/string nodes: constants, sliders, math expressions, string concat/split/replace/regex, type conversion, JSON/list utilities. Use when computing a value or assembling a string in a workflow."
+    },
+    {
+      "id": "comfyui-plugin/comfy-metadata",
+      "line": "comfyui-plugin/comfy-metadata: Extract/analyze ComfyUI metadata embedded in output files - PNG tEXt, WebP EXIF, MP4/WebM container, .latent safetensors. Use when figuring out what prompt/settings produced a file, or comparing runs."
+    },
+    {
+      "id": "comfyui-plugin/comfy-node",
+      "line": "comfyui-plugin/comfy-node: Orchestrate a ComfyUI node pack from idea to registry: scaffold, create + seed the repo, open the gitops adoption PR. Use when releasing or spinning up a new comfyui node pack."
+    },
+    {
+      "id": "comfyui-plugin/comfy-registry-lifecycle",
+      "line": "comfyui-plugin/comfy-registry-lifecycle: Comfy Registry release pipeline: release-please + lockfile drift traps, the empty-web/dist publish bug, version status states, phantom versions, icon/banner generation. Use when debugging a pack's publish pipeline."
+    },
+    {
+      "id": "comfyui-plugin/comfy-subgraphs-app-mode",
+      "line": "comfyui-plugin/comfy-subgraphs-app-mode: ComfyUI Subgraphs, Subgraph Blueprints, and App Mode: creating/publishing subgraphs, why Blueprint instances are snapshots not live refs, turning a workflow into a form UI. Use when deciding how to package a workflow stage."
+    },
+    {
+      "id": "comfyui-plugin/comfy-workflow-json",
+      "line": "comfyui-plugin/comfy-workflow-json: Programmatically edit ComfyUI workflow JSON: edge-list link rebuilds, link-encoding schemas, preserving the extra block (App Mode config). Use when a workflow JSON is too large to hand-edit or a transform drops state."
+    },
+    {
+      "id": "comfyui-plugin/comfy-workflow-layout",
+      "line": "comfyui-plugin/comfy-workflow-layout: Auto-layout a ComfyUI workflow JSON with a layered DAG algorithm. Use when a workflow's nodes overlap, are messy or cramped, or were imported and need tidying before use."
+    },
+    {
+      "id": "comfyui-plugin/comfyui-node-authoring",
+      "line": "comfyui-plugin/comfyui-node-authoring: ComfyUI frontend/backend authoring facts: hiding/serializing widgets, DOM event isolation, endpoints, tooltip lookup, canvas hit-testing, sourcemap verification. Use when writing or patching a custom node's code."
+    },
+    {
+      "id": "comfyui-plugin/comfyui-node-scaffold",
+      "line": "comfyui-plugin/comfyui-node-scaffold: Scaffold a new ComfyUI custom-node repo (TypeScript + bun build, CI, release-please, vitest+pytest) consuming @laurigates/comfy-modal-kit. Use when bootstrapping or init-ing a comfyui node pack."
+    },
+    {
+      "id": "comfyui-plugin/comfyui-pack-live-smoke",
+      "line": "comfyui-plugin/comfyui-pack-live-smoke: Live-smoke a ComfyUI pack in a running instance: browser-driven and headless API-driven checks catch frontend/backend bugs unit tests miss. Use when verifying a pack before opening a registry PR."
+    },
+    {
+      "id": "comfyui-plugin/comfyui-screenshot-pipeline",
+      "line": "comfyui-plugin/comfyui-screenshot-pipeline: Containerized README-screenshot pipeline (Docker + Playwright) for ComfyUI custom-node packs. Use when generating pack screenshots, adding `just screenshots`, or capturing modal/gesture node UI."
+    },
+    {
+      "id": "communication-plugin/google-chat-formatting",
+      "line": "communication-plugin/google-chat-formatting: Convert Markdown to Google Chat formatting. Use when formatting messages for Google Chat or converting Markdown documents to Google Chat syntax."
+    },
+    {
+      "id": "communication-plugin/ticket-drafting-guidelines",
+      "line": "communication-plugin/ticket-drafting-guidelines: Guidelines for drafting GitHub issues using What/Why/How format. Use when creating issues, drafting tickets, or writing bug reports with concise and positive framing."
+    },
+    {
+      "id": "component-patterns-plugin/components-version-badge",
+      "line": "component-patterns-plugin/components-version-badge: Version badge with build-info tooltip (version, commit, changelog). Use when adding version display to app header/footer for Next.js, Nuxt, SvelteKit, Vite, React, Vue, or Svelte."
+    },
+    {
+      "id": "component-patterns-plugin/version-badge-pattern",
+      "line": "component-patterns-plugin/version-badge-pattern: Version badge UI showing build version, git commit, and changelog in a tooltip. Use when adding version visibility for support or debugging. Works with React, Vue, Svelte, and JS."
+    },
+    {
+      "id": "configure-plugin/ci-workflows",
+      "line": "configure-plugin/ci-workflows: GitHub Actions workflow standards. Use when checking CI/CD compliance, referencing canonical workflow shapes, or another skill needs workflow structure guidance."
+    },
+    {
+      "id": "configure-plugin/claude-security-settings",
+      "line": "configure-plugin/claude-security-settings: Claude Code security settings: permission wildcards, shell operator protections, project-level allowlists. Use when auditing or hardening .claude/settings.json permissions."
+    },
+    {
+      "id": "configure-plugin/config-sync",
+      "line": "configure-plugin/config-sync: Config sync across FVH repos: extract, diff, propagate tooling improvements. Use when syncing workflows or configs across multiple repos."
+    },
+    {
+      "id": "configure-plugin/configure-all",
+      "line": "configure-plugin/configure-all: Run all infrastructure standards checks and fixes. Use when onboarding a new project, doing a full compliance audit, or batch-fixing with --fix."
+    },
+    {
+      "id": "configure-plugin/configure-api-tests",
+      "line": "configure-plugin/configure-api-tests: API contract testing: Pact, OpenAPI validation, JSON Schema/Zod. Use when adding consumer/provider contract tests or detecting breaking API changes in CI."
+    },
+    {
+      "id": "configure-plugin/configure-argocd-automerge",
+      "line": "configure-plugin/configure-argocd-automerge: ArgoCD auto-merge: configure GitHub Actions for image-updater-** branches. Use when setting up argocd-automerge.yml or verifying PAT permissions."
+    },
+    {
+      "id": "configure-plugin/configure-cache-busting",
+      "line": "configure-plugin/configure-cache-busting: Cache-busting for Next.js and Vite: content hashing, CDN cache headers. Use when adding Vercel/Cloudflare cache headers or auditing static asset caching."
+    },
+    {
+      "id": "configure-plugin/configure-claude-plugins",
+      "line": "configure-plugin/configure-claude-plugins: Claude plugins marketplace setup: .claude/settings.json, GitHub Actions, plugin pinning. Use when onboarding to claude-plugins, setting up claude.yml, pinning plugins, or overriding global plugins."
+    },
+    {
+      "id": "configure-plugin/configure-container",
+      "line": "configure-plugin/configure-container: Container infrastructure: GHCR builds, Trivy/Grype scanning, devcontainer. Use when setting up multi-platform GHCR workflows or adding container scanning to CI."
+    },
+    {
+      "id": "configure-plugin/configure-coverage",
+      "line": "configure-plugin/configure-coverage: Code coverage: thresholds and reporters for Vitest, Jest, pytest, Rust. Use when setting thresholds, adding Codecov/Coveralls, or wiring lcov/HTML reports."
+    },
+    {
+      "id": "configure-plugin/configure-dead-code",
+      "line": "configure-plugin/configure-dead-code: Dead-code detection: Knip, Vulture, cargo-machete, deadcode. Use when setting up unused-code scanning, migrating tools, or adding dead-code CI checks."
+    },
+    {
+      "id": "configure-plugin/configure-dockerfile",
+      "line": "configure-plugin/configure-dockerfile: Dockerfile standards: Alpine/slim base, non-root user, multi-stage builds. Use when creating a Dockerfile, hardening security, or auditing image size."
+    },
+    {
+      "id": "configure-plugin/configure-docs",
+      "line": "configure-plugin/configure-docs: Code docs: TSDoc, JSDoc, pydoc, rustdoc, TypeDoc, MkDocs, Sphinx. Use when setting up docstrings, configuring a docs generator, or enforcing doc coverage in CI."
+    },
+    {
+      "id": "configure-plugin/configure-editor",
+      "line": "configure-plugin/configure-editor: EditorConfig and VS Code workspace settings for team consistency. Use when setting up format-on-save, recommended extensions, or debug configurations."
+    },
+    {
+      "id": "configure-plugin/configure-feature-flags",
+      "line": "configure-plugin/configure-feature-flags: Feature flags with OpenFeature and providers (GOFF, flagd, LaunchDarkly). Use when setting up the SDK, configuring a relay proxy, or adding flag test helpers."
+    },
+    {
+      "id": "configure-plugin/configure-formatting",
+      "line": "configure-plugin/configure-formatting: Biome formatter for JS/TS/JSON/CSS \u2014 the modern Prettier/ESLint replacement. Also Ruff (Python) and rustfmt. Use when setting up formatting, replacing Prettier, or wiring CI format checks."
+    },
+    {
+      "id": "configure-plugin/configure-gitattributes",
+      "line": "configure-plugin/configure-gitattributes: Configure .gitattributes: union-merge for append-only tables, linguist-generated for build output, LF normalization. Use when setting up .gitattributes or taming append-only merge conflicts."
+    },
+    {
+      "id": "configure-plugin/configure-github-pages",
+      "line": "configure-plugin/configure-github-pages: GitHub Pages deployment workflows for docs sites. Use when setting up Pages, migrating to actions/deploy-pages, or auditing Pages action versions."
+    },
+    {
+      "id": "configure-plugin/configure-gitignore",
+      "line": "configure-plugin/configure-gitignore: Manage .gitignore's Claude Code block \u2014 worktrees, scheduled-task lock, local settings. Use when onboarding a repo or .gitignore lacks Claude entries."
+    },
+    {
+      "id": "configure-plugin/configure-instrumentation",
+      "line": "configure-plugin/configure-instrumentation: Observability instrumentation: OpenTelemetry traces/metrics, structured logging, Sentry. Use when wiring telemetry, tracing, or logging into a repo."
+    },
+    {
+      "id": "configure-plugin/configure-integration-tests",
+      "line": "configure-plugin/configure-integration-tests: Integration testing: Supertest, pytest, Testcontainers. Use when setting up integration tests, creating docker-compose.test.yml, or separating from unit tests."
+    },
+    {
+      "id": "configure-plugin/configure-justfile",
+      "line": "configure-plugin/configure-justfile: Check and configure Justfiles with standard recipes. Use when setting up a Justfile, auditing for missing recipes, or migrating from Makefile to Justfile."
+    },
+    {
+      "id": "configure-plugin/configure-linting",
+      "line": "configure-plugin/configure-linting: Modern linters: Biome, Ruff, Clippy. Use when setting up linting, migrating ESLint/Prettier to Biome, or wiring lint into pre-commit and CI."
+    },
+    {
+      "id": "configure-plugin/configure-load-tests",
+      "line": "configure-plugin/configure-load-tests: Load testing: k6, Artillery, Locust. Use when setting up load tests, auditing smoke/stress/spike/soak coverage, or adding CI performance regression detection."
+    },
+    {
+      "id": "configure-plugin/configure-makefile",
+      "line": "configure-plugin/configure-makefile: Makefile with standard targets (help, test, build, clean, lint). Use when setting up a Makefile, auditing missing targets, or adding language-specific targets."
+    },
+    {
+      "id": "configure-plugin/configure-mcp",
+      "line": "configure-plugin/configure-mcp: Check and configure MCP servers for project integration. Use when setting up MCP servers, checking MCP status, or adding new servers to a project."
+    },
+    {
+      "id": "configure-plugin/configure-memory-profiling",
+      "line": "configure-plugin/configure-memory-profiling: Memory profiling with pytest-memray for Python. Use when setting up memory profiling, adding CI memory regression detection, or setting memory thresholds."
+    },
+    {
+      "id": "configure-plugin/configure-mise",
+      "line": "configure-plugin/configure-mise: mise runtime/tool version manager - mise.toml, backends (pipx/aqua/npm/cargo/go), tasks, env, lockfile. Use when setting up, pinning runtimes/CLI tools, or migrating from asdf/nvm/pyenv/brew/Make."
+    },
+    {
+      "id": "configure-plugin/configure-package-management",
+      "line": "configure-plugin/configure-package-management: Package managers: uv (Python), bun (TypeScript). Use when setting up uv or bun, migrating from pip/npm/yarn/poetry/pipenv, or resolving lockfile conflicts."
+    },
+    {
+      "id": "configure-plugin/configure-pre-commit",
+      "line": "configure-plugin/configure-pre-commit: pre-commit hooks setup and validation. Use when installing hooks, configuring frontend/infrastructure/python project types, or migrating to pre-commit."
+    },
+    {
+      "id": "configure-plugin/configure-readme",
+      "line": "configure-plugin/configure-readme: README.md with logo, badges, features, tech stack sections. Use when creating a README, auditing missing sections, or adding shields.io badges."
+    },
+    {
+      "id": "configure-plugin/configure-release-please",
+      "line": "configure-plugin/configure-release-please: release-please workflow setup and auditing. Use when configuring release-please, upgrading release-please-action, or adding a package to a monorepo config."
+    },
+    {
+      "id": "configure-plugin/configure-repo",
+      "line": "configure-plugin/configure-repo: Repo onboarding driver: .claude/ directory, SessionStart hook, install_pkgs.sh. Use when onboarding any repo to Claude Code with the claude-plugins marketplace."
+    },
+    {
+      "id": "configure-plugin/configure-reusable-workflows",
+      "line": "configure-plugin/configure-reusable-workflows: Reusable GitHub Actions workflows for security, quality, accessibility. Use when adding OWASP/secret/code-smell scans or WCAG checks to PR pipelines."
+    },
+    {
+      "id": "configure-plugin/configure-security",
+      "line": "configure-plugin/configure-security: Security scanning: dependency audits, SAST, secrets detection. Use when setting up Dependabot, CodeQL, or TruffleHog in CI, or creating a SECURITY.md policy."
+    },
+    {
+      "id": "configure-plugin/configure-select",
+      "line": "configure-plugin/configure-select: Interactive selector for infrastructure standards. Use when setting up specific components or building infrastructure incrementally instead of running /configure:all."
+    },
+    {
+      "id": "configure-plugin/configure-sentry",
+      "line": "configure-plugin/configure-sentry: Sentry error tracking setup. Use when installing the Sentry SDK, fixing hardcoded DSNs, or adding source map upload for frontend, Next.js, Node, or Python."
+    },
+    {
+      "id": "configure-plugin/configure-skaffold",
+      "line": "configure-plugin/configure-skaffold: Skaffold for Kubernetes: port forwarding, dotenvx hooks, API version. Use when fixing 0.0.0.0 binding, adding secret generation hooks, or creating skaffold.yaml."
+    },
+    {
+      "id": "configure-plugin/configure-status",
+      "line": "configure-plugin/configure-status: Infrastructure compliance status (read-only). Use when checking overall compliance, generating a report, or reviewing project health without making changes."
+    },
+    {
+      "id": "configure-plugin/configure-surface",
+      "line": "configure-plugin/configure-surface: Surface doc-drift gate: scaffold surf.toml + hubs, wire the SHA-pinned pre-commit/Action. Use when adding a docs-governed-like-code CI gate."
+    },
+    {
+      "id": "configure-plugin/configure-tests",
+      "line": "configure-plugin/configure-tests: Test frameworks: Vitest, Jest, pytest, cargo-nextest. Use when setting up test infrastructure, migrating to a modern framework, or validating coverage config."
+    },
+    {
+      "id": "configure-plugin/configure-ux-testing",
+      "line": "configure-plugin/configure-ux-testing: UX testing: Playwright E2E, axe-core a11y, visual regression. Use when setting up E2E testing, screenshot assertions, browser automation, or a11y CI workflows."
+    },
+    {
+      "id": "configure-plugin/configure-web-session",
+      "line": "configure-plugin/configure-web-session: SessionStart hook for Claude Code web sessions to install tools (helm, terraform, gitleaks, just). Use when CI tools fail in remote sessions due to missing binaries."
+    },
+    {
+      "id": "configure-plugin/configure-workflows",
+      "line": "configure-plugin/configure-workflows: GitHub Actions CI/CD workflows for container builds, tests, releases. Use when updating outdated action versions, adding multi-platform builds, or auditing workflows."
+    },
+    {
+      "id": "configure-plugin/configure-worktreeinclude",
+      "line": "configure-plugin/configure-worktreeinclude: Generate a .worktreeinclude so Claude Code copies gitignored env/secret/config files into new worktrees. Use when worktrees miss .env or local config."
+    },
+    {
+      "id": "configure-plugin/go-feature-flag",
+      "line": "configure-plugin/go-feature-flag: GO Feature Flag (GOFF) self-hosted feature flags with OpenFeature integration \u2014 config, relay proxy, targeting, rollouts. Use when working with GOFF or flags.goff.yaml."
+    },
+    {
+      "id": "configure-plugin/multi-repo-discipline",
+      "line": "configure-plugin/multi-repo-discipline: Multi-repo workspace rules: read-only fixtures, upstream/downstream pairs. Use when dispatching agents across sibling repos or editing another repo's .claude/."
+    },
+    {
+      "id": "configure-plugin/openfeature",
+      "line": "configure-plugin/openfeature: OpenFeature vendor-agnostic feature flag SDK: installation, evaluation, providers. Use when implementing feature flags, A/B testing, or progressive rollouts."
+    },
+    {
+      "id": "container-plugin/container-development",
+      "line": "container-plugin/container-development: Container development \u2014 Docker, multi-stage builds, Skaffold, non-root users, Alpine/slim images, security hardening. Use when working with Docker, Dockerfiles, docker-compose, or container security."
+    },
+    {
+      "id": "container-plugin/deploy-handoff",
+      "line": "container-plugin/deploy-handoff: Generate deployment handoff docs \u2014 tech stack, access URLs, config, monitoring, dev checklist. Use when handing off a service, documenting deployments, or creating client-facing summaries."
+    },
+    {
+      "id": "container-plugin/deploy-release",
+      "line": "container-plugin/deploy-release: Create and publish releases via release-please or manual GitHub releases. Use when cutting a release, tagging a version, or setting up release-please config."
+    },
+    {
+      "id": "container-plugin/go-containers",
+      "line": "container-plugin/go-containers: Go container optimization \u2014 scratch/distroless images, static binaries, CGO, ldflags, trimpath (846MB to 2.5MB). Use when working with Go containers or optimizing Go image sizes."
+    },
+    {
+      "id": "container-plugin/nodejs-containers",
+      "line": "container-plugin/nodejs-containers: Node.js container optimization \u2014 Alpine, multi-stage builds, node_modules caching, BuildKit mounts (900MB to ~100MB). Use when working with Node.js containers or optimizing image sizes."
+    },
+    {
+      "id": "container-plugin/python-containers",
+      "line": "container-plugin/python-containers: Python container optimization \u2014 slim images (not Alpine), virtualenv, multi-stage, pip/poetry/uv, musl gotchas (1GB to ~120MB). Use when working with Python containers or optimizing image sizes."
+    },
+    {
+      "id": "container-plugin/skaffold-filesync",
+      "line": "container-plugin/skaffold-filesync: Skaffold file sync \u2014 copy changed files to containers without rebuilding. Use when optimizing the dev loop, configuring sync rules, or the user mentions hot reload or fast iteration."
+    },
+    {
+      "id": "container-plugin/skaffold-orbstack",
+      "line": "container-plugin/skaffold-orbstack: OrbStack-optimized Skaffold for local Kubernetes dev without port-forward. Use when configuring Skaffold with OrbStack, k8s.orb.local, LoadBalancer, or eliminating port-forward."
+    },
+    {
+      "id": "container-plugin/skaffold-testing",
+      "line": "container-plugin/skaffold-testing: Container image validation with Skaffold test/verify stages \u2014 container-structure-tests, security scans. Use when configuring pre-deploy tests or integration tests in Skaffold."
+    },
+    {
+      "id": "css-plugin/lightning-css",
+      "line": "css-plugin/lightning-css: Lightning CSS transpilation, bundling, and minification. Use when configuring CSS in Vite, replacing PostCSS/autoprefixer, setting browser targets, or enabling CSS modules."
+    },
+    {
+      "id": "css-plugin/unocss",
+      "line": "css-plugin/unocss: UnoCSS atomic CSS engine for on-demand utility classes. Use when setting up utility-first CSS, configuring presets (wind3/wind4, icons, typography), or integrating with Vite."
+    },
+    {
+      "id": "documentation-plugin/claude-blog-sources",
+      "line": "documentation-plugin/claude-blog-sources: Fetch Claude Blog and official Claude Code docs. Use when researching Claude Code capabilities, CLAUDE.md optimization, memory hierarchy, or @import patterns."
+    },
+    {
+      "id": "documentation-plugin/docs-decommission",
+      "line": "documentation-plugin/docs-decommission: Generate DECOMMISSION-<service>.md covering infra, data, access, DNS, dependencies, monitoring, and financial checklists. Use when decommissioning a service."
+    },
+    {
+      "id": "documentation-plugin/docs-generate",
+      "line": "documentation-plugin/docs-generate: Generate or update docs from code annotations, docstrings, and git history. Use when wanting API reference, README from code, or CHANGELOG from conventional commits."
+    },
+    {
+      "id": "documentation-plugin/docs-latex",
+      "line": "documentation-plugin/docs-latex: Convert Markdown to LaTeX with TikZ and compile to PDF. Use when wanting a presentation-quality PDF, a professional report with diagrams, or print-ready documentation."
+    },
+    {
+      "id": "documentation-plugin/docs-sync",
+      "line": "documentation-plugin/docs-sync: Sync docs with actual skills, commands, and agents. Use when docs are out of sync, updating the skill catalog, or regenerating command reference to fix mismatches."
+    },
+    {
+      "id": "evaluate-plugin/evaluate-improve",
+      "line": "evaluate-plugin/evaluate-improve: Suggest improvements to SKILL.md content, descriptions, or tool config from eval results. Use when raising pass rates, fixing triggering, or iterating on a skill after evaluation."
+    },
+    {
+      "id": "evaluate-plugin/evaluate-legibility",
+      "line": "evaluate-plugin/evaluate-legibility: Cold-read a SKILL.md with a zero-context agent reader to check its intent is legible. Use when validating whether a skill says clearly when to invoke it and how to start."
+    },
+    {
+      "id": "evaluate-plugin/evaluate-matrix",
+      "line": "evaluate-plugin/evaluate-matrix: Cross-model skill evals with real execution and grading \u2014 the executability gate. Use when checking whether a weak model can actually do a skill, not just comprehend it."
+    },
+    {
+      "id": "evaluate-plugin/evaluate-plugin-batch",
+      "line": "evaluate-plugin/evaluate-plugin-batch: Batch evaluate every skill in a plugin and produce a plugin-level report. Use when auditing an entire plugin's quality or validating before a release."
+    },
+    {
+      "id": "evaluate-plugin/evaluate-report",
+      "line": "evaluate-plugin/evaluate-report: View evaluation results and benchmark reports for a skill or plugin. Use when reviewing past eval results, comparing benchmark runs, or tracking quality trends."
+    },
+    {
+      "id": "evaluate-plugin/evaluate-skill",
+      "line": "evaluate-plugin/evaluate-skill: Evaluate a skill by running test cases and grading results. Use when testing whether a skill produces correct guidance, validating improvements, or benchmarking before release."
+    },
+    {
+      "id": "feedback-plugin/feedback-session",
+      "line": "feedback-plugin/feedback-session: Analyze session for skill feedback and create GitHub issues. Use when a skill gave wrong guidance, a command failed, you found a better pattern, or a skill worked well."
+    },
+    {
+      "id": "finops-plugin/finops-caches",
+      "line": "finops-plugin/finops-caches: GitHub Actions cache analysis \u2014 size, prefix/branch breakdown, stale detection. Use when investigating cache bloat, stale caches, or auditing cache key strategies."
+    },
+    {
+      "id": "finops-plugin/finops-compare",
+      "line": "finops-plugin/finops-compare: FinOps metrics comparison across repos in an org. Use when benchmarking repos, identifying worst-performing ones, or doing org-wide CI cost analysis."
+    },
+    {
+      "id": "finops-plugin/finops-overview",
+      "line": "finops-plugin/finops-overview: FinOps snapshot \u2014 org billing, workflow stats, cache usage. Use when you want a high-level view of CI spending or workflow health before diving deeper."
+    },
+    {
+      "id": "finops-plugin/finops-waste",
+      "line": "finops-plugin/finops-waste: Identify GitHub Actions waste \u2014 skipped runs, bot triggers, missing concurrency \u2014 and suggest fixes. Use when CI costs are high or workflows run too often."
+    },
+    {
+      "id": "finops-plugin/finops-workflows",
+      "line": "finops-plugin/finops-workflows: Analyze workflow runs \u2014 frequency, duration, success rates, efficiency. Use when investigating slow CI, high failure rates, or run patterns over time."
+    },
+    {
+      "id": "finops-plugin/github-actions-cache-optimization",
+      "line": "finops-plugin/github-actions-cache-optimization: GitHub Actions cache analysis and optimization. Use when investigating cache bloat, finding stale caches, optimizing keys, or comparing cache usage across repos."
+    },
+    {
+      "id": "finops-plugin/github-actions-finops",
+      "line": "finops-plugin/github-actions-finops: GitHub Actions billing, workflow efficiency, and waste analysis at org or repo level. Use when investigating CI/CD costs, wasted runs, or optimizing triggers."
+    },
+    {
+      "id": "foundryvtt-plugin/foundryvtt-module",
+      "line": "foundryvtt-plugin/foundryvtt-module: FoundryVTT module idea to gitops-adopted repo: scaffold, create + seed the repo, open the gitops adoption PR. Use when releasing or spinning up a new foundry module."
+    },
+    {
+      "id": "foundryvtt-plugin/foundryvtt-module-scaffold",
+      "line": "foundryvtt-plugin/foundryvtt-module-scaffold: Scaffold a new FoundryVTT v13 module repo (Vite + TS + bun + biome, CI, release-please) with basic/app/libwrapper variants. Use when bootstrapping or init-ing a foundry module."
+    },
+    {
+      "id": "git-plugin/deadbranch",
+      "line": "git-plugin/deadbranch: deadbranch CLI for stale-branch cleanup \u2014 dry-run preview, TUI or non-interactive delete, protects main/develop/WIP. Use when asked to clean up branches, prune branches, or remove stale branches."
+    },
+    {
+      "id": "git-plugin/gh-cli-agentic",
+      "line": "git-plugin/gh-cli-agentic: gh CLI commands with JSON output for agent workflows. Use when querying PRs, issues, workflow runs, or repo metadata; inspecting PR checks; fetching failed CI logs; or resolving a github.com URL to an API call."
+    },
+    {
+      "id": "git-plugin/gh-workflow-monitoring",
+      "line": "git-plugin/gh-workflow-monitoring: Monitor GitHub Actions runs with blocking watch commands instead of polling loops. Use when waiting for CI after push, following a workflow to completion, or diagnosing failed runs with --log-failed."
+    },
+    {
+      "id": "git-plugin/git-api-pr",
+      "line": "git-plugin/git-api-pr: GitHub API PR creation without local git. Use when submitting file changes as a PR without local commits \u2014 quick fixes, typos, config updates, or bypassing local git state."
+    },
+    {
+      "id": "git-plugin/git-branch-naming",
+      "line": "git-plugin/git-branch-naming: Git branch naming conventions \u2014 type prefixes (feat/fix/chore), issue linking, kebab-case. Use when creating branches or setting up repo conventions."
+    },
+    {
+      "id": "git-plugin/git-branch-pr-workflow",
+      "line": "git-plugin/git-branch-pr-workflow: Branch management and PR workflows \u2014 git switch/restore, GitHub MCP. Use when creating branches, opening PRs, or working with feature branches."
+    },
+    {
+      "id": "git-plugin/git-cli-agentic",
+      "line": "git-plugin/git-cli-agentic: Git commands with porcelain and machine-readable output for agent workflows. Use when scripting status/diff/log, porcelain=v2, --numstat counts, custom --format placeholders, or branch tracking info."
+    },
+    {
+      "id": "git-plugin/git-commit",
+      "line": "git-plugin/git-commit: Create commits with conventional messages and issue references. Use when user says \"commit\", \"save changes\", or \"stage and commit\". Local commits only \u2014 see git-push for remote."
+    },
+    {
+      "id": "git-plugin/git-commit-push-pr",
+      "line": "git-plugin/git-commit-push-pr: End-to-end commit-to-PR workflow. Use when the user says \"create pr\", \"commit and pr\", \"push and pr\", or wants to go from uncommitted changes to an open PR."
+    },
+    {
+      "id": "git-plugin/git-commit-trailers",
+      "line": "git-plugin/git-commit-trailers: Git commit trailer conventions \u2014 BREAKING CHANGE, Co-authored-by, Signed-off-by. Use when composing messages with trailers or parsing via git interpret-trailers."
+    },
+    {
+      "id": "git-plugin/git-commit-workflow",
+      "line": "git-plugin/git-commit-workflow: Conventional commit format, staging, and message conventions. Use when writing commit messages, staging files, grouping changes, or auto-detecting linked issues."
+    },
+    {
+      "id": "git-plugin/git-conflicts",
+      "line": "git-plugin/git-conflicts: Resolve merge conflicts file-by-file. Use when a merge/rebase has conflicts, a PR can't merge, \"fix conflicts\" is requested, or branches have diverged."
+    },
+    {
+      "id": "git-plugin/git-coworker-check",
+      "line": "git-plugin/git-coworker-check: Detect coworker Claude agents in a shared checkout. Use when starting a session in a shared clone, before destructive git ops (stash, reset, checkout), or before bulk-edit / commit-loop workflows."
+    },
+    {
+      "id": "git-plugin/git-derive-docs",
+      "line": "git-plugin/git-derive-docs: Derive ADRs, rules, PRDs from git commit history. Use when finding doc gaps, detecting unrecorded decisions, deriving conventions from commits, or generating skeleton docs."
+    },
+    {
+      "id": "git-plugin/git-fix-pr",
+      "line": "git-plugin/git-fix-pr: Analyze and fix failing PR checks. Use when asked to fix a PR, resolve red CI checks, auto-fix lint/test failures, or reproduce CI errors locally before pushing."
+    },
+    {
+      "id": "git-plugin/git-fork-workflow",
+      "line": "git-plugin/git-fork-workflow: Fork management and upstream sync. Use when working with forks, syncing with upstream, detecting divergence, or preparing commits for contribution."
+    },
+    {
+      "id": "git-plugin/git-issue",
+      "line": "git-plugin/git-issue: Process GitHub issues end-to-end with TDD and parallel work. Use when asked to work on an issue, fix issue #N, pick issues to tackle, or batch-process several."
+    },
+    {
+      "id": "git-plugin/git-issue-hierarchy",
+      "line": "git-plugin/git-issue-hierarchy: Manage GitHub sub-issues and dependencies (blocked_by/blocking). Use when breaking issues into sub-tasks, checking progress, or viewing a dependency graph."
+    },
+    {
+      "id": "git-plugin/git-issue-manage",
+      "line": "git-plugin/git-issue-manage: GitHub issue admin operations. Use when transferring issues, pinning, locking discussions, creating dev branches from issues, bulk ops, or managing custom fields."
+    },
+    {
+      "id": "git-plugin/git-maintain",
+      "line": "git-plugin/git-maintain: Repo maintenance \u2014 incremental repack, gc, branch pruning, stash cleanup, fsck. Use when asked to clean up the repo, run git maintenance/gc, delete merged branches, prune stashes, or shrink .git."
+    },
+    {
+      "id": "git-plugin/git-pr",
+      "line": "git-plugin/git-pr: Create pull requests with descriptions, labels, and issue references. Use when user says \"create PR\", \"open pull request\", or \"submit for review\". From pushed branches."
+    },
+    {
+      "id": "git-plugin/git-pr-feedback",
+      "line": "git-plugin/git-pr-feedback: Address PR review comments and resolve threads. Use when CHANGES_REQUESTED is set, working through unresolved review threads, or replying to reviewer feedback."
+    },
+    {
+      "id": "git-plugin/git-pr-sync-check",
+      "line": "git-plugin/git-pr-sync-check: Checks whether the current PR branch is still live and in sync (merged/behind/changes-requested). Use when continuing work on a PR branch before adding commits."
+    },
+    {
+      "id": "git-plugin/git-pr-watch",
+      "line": "git-plugin/git-pr-watch: Subscribe to a PR's activity and react to reviews and CI as they arrive. Use when watching/monitoring/babysitting a PR after opening it, or unsubscribing with --unsubscribe."
+    },
+    {
+      "id": "git-plugin/git-push",
+      "line": "git-plugin/git-push: Push local commits to remote \u2014 handles branch tracking, upstream setup, safe push patterns. Use when user says \"push\", \"send to remote\", or \"update remote\". Pushes existing commits \u2014 see git-commit for commits and git-pr for PR creation."
+    },
+    {
+      "id": "git-plugin/git-rebase-patterns",
+      "line": "git-plugin/git-rebase-patterns: Advanced git rebase \u2014 linear history, stacked PRs, --update-refs, --onto. Use when rebasing branches, cleaning history, managing PR stacks, or fixing merge-heavy branches."
+    },
+    {
+      "id": "git-plugin/git-repo-detection",
+      "line": "git-plugin/git-repo-detection: Detect GitHub repo owner/name from git remotes. Use when needing the owner/repo identifier for GitHub CLI or API calls, especially across multiple repos."
+    },
+    {
+      "id": "git-plugin/git-security-checks",
+      "line": "git-plugin/git-security-checks: Pre-commit security validation and secret detection via gitleaks. Use when scanning for secrets, setting up gitleaks, or configuring .gitleaks.toml pre-commit security."
+    },
+    {
+      "id": "git-plugin/git-triage",
+      "line": "git-plugin/git-triage: Triage GitHub issues and PRs \u2014 cross-link, flag stale items, recommend actions. Use when grooming the backlog, pre-release cleanup, or asked to triage issues/PRs."
+    },
+    {
+      "id": "git-plugin/git-upstream-pr",
+      "line": "git-plugin/git-upstream-pr: Submit PRs to upstream repos from a fork \u2014 commit selection, squashing, cross-fork creation. Use when contributing changes upstream or cherry-picking fork commits."
+    },
+    {
+      "id": "git-plugin/git-upstream-pr-diverged",
+      "line": "git-plugin/git-upstream-pr-diverged: Submit a diverged-fork commit to upstream as a clean PR via cherry-pick with re-derive fallback, message scrubbing, and regression checks. Use when direct rebase fails."
+    },
+    {
+      "id": "git-plugin/github-issue-autodetect",
+      "line": "git-plugin/github-issue-autodetect: Auto-detect GitHub issues that staged changes may fix or close. Analyzes diffs, paths, and issue metadata to suggest closing keywords (Fixes/Closes/Resolves) for commit messages. Use when committing to ensure proper issue linkage."
+    },
+    {
+      "id": "git-plugin/github-issue-writing",
+      "line": "git-plugin/github-issue-writing: Create well-structured GitHub issues with clear titles, descriptions, and acceptance criteria. Use when filing bugs, requesting features, or structuring issue content."
+    },
+    {
+      "id": "git-plugin/github-labels",
+      "line": "git-plugin/github-labels: Discover and apply GitHub labels via gh CLI. Use when asked to label a PR/issue, list available labels, or create new labels for a repository."
+    },
+    {
+      "id": "git-plugin/github-pr-title",
+      "line": "git-plugin/github-pr-title: Craft PR titles using conventional commits format. Use when creating PRs or ensuring consistent PR naming. PR titles MUST follow conventional commits to drive release-please automation and maintain consistent git history."
+    },
+    {
+      "id": "git-plugin/release-please-configuration",
+      "line": "git-plugin/release-please-configuration: release-please monorepo config \u2014 component tags, per-package extra-files, tag migration. Use when adding packages or fixing duplicate-tag / no-bump failures."
+    },
+    {
+      "id": "git-plugin/release-please-pr-workflow",
+      "line": "git-plugin/release-please-pr-workflow: Manage release-please PR merging for monorepos \u2014 batch merging, conflict resolution via PR closure/recreation, iterative processing. Use when merging release PRs, handling PR conflicts, or managing release automation in monorepos."
+    },
+    {
+      "id": "git-plugin/release-please-protection",
+      "line": "git-plugin/release-please-protection: Block manual edits to release-please files (CHANGELOG, version fields). Use when editing changelogs, bumping versions, or releasing to avoid conflicting with automation."
+    },
+    {
+      "id": "github-actions-plugin/claude-code-github-workflows",
+      "line": "github-actions-plugin/claude-code-github-workflows: Claude Code GitHub Actions workflow patterns \u2014 PR reviews, issue triage, CI/CD integration. Use when creating or modifying workflows that integrate Claude Code."
+    },
+    {
+      "id": "github-actions-plugin/github-actions-auth-security",
+      "line": "github-actions-plugin/github-actions-auth-security: GitHub Actions auth and security for Claude Code \u2014 OIDC, AWS Bedrock, Vertex AI, secrets, permission scoping. Use when setting up workflow authentication or security."
+    },
+    {
+      "id": "github-actions-plugin/github-actions-inspection",
+      "line": "github-actions-plugin/github-actions-inspection: Inspect GitHub Actions runs, analyze logs, debug failures. Use when investigating CI/CD failures, checking workflow status, or debugging GitHub Actions issues."
+    },
+    {
+      "id": "github-actions-plugin/github-actions-mcp-config",
+      "line": "github-actions-plugin/github-actions-mcp-config: MCP server config for GitHub Actions \u2014 tool permissions, env vars, multi-server setups. Use when configuring MCP servers in GitHub Actions workflows."
+    },
+    {
+      "id": "github-actions-plugin/github-issue-search",
+      "line": "github-actions-plugin/github-issue-search: Search GitHub issues for solutions and workarounds. Use when encountering errors with OSS libraries, finding upstream bug workarounds, or researching known issues."
+    },
+    {
+      "id": "github-actions-plugin/github-social-preview",
+      "line": "github-actions-plugin/github-social-preview: Generate 1280x640 PNG social preview images for GitHub repos using nano-banana-pro. Use when asked for social preview, Open Graph image, or repo images for social media."
+    },
+    {
+      "id": "github-actions-plugin/github-workflow-auto-fix",
+      "line": "github-actions-plugin/github-workflow-auto-fix: Set up automated CI fixing with Claude Code. Use when adding a workflow that analyzes failures, applies fixes, and files issues; pass --reusable for a multi-repo workflow_call template."
+    },
+    {
+      "id": "github-actions-plugin/workflow-dev",
+      "line": "github-actions-plugin/workflow-dev: Automated dev loop \u2014 run tests, file issues for failures, TDD fix on branch, open PR, watch CI. Use when running a continuous dev loop, autonomous TDD, or fix-and-PR cycles."
+    },
+    {
+      "id": "health-plugin/health-agentic-audit",
+      "line": "health-plugin/health-agentic-audit: Audit skills, commands, and agents for agentic output compliance \u2014 optimization tables, bare CLI commands. Use when batch-checking skill documentation quality."
+    },
+    {
+      "id": "health-plugin/health-audit",
+      "line": "health-plugin/health-audit: Plugin audit against detected stack (Python, Node, Rust, Go, Terraform, Docker, K8s). Use when cleaning up unused plugins or discovering stack-relevant ones for a project."
+    },
+    {
+      "id": "health-plugin/health-check",
+      "line": "health-plugin/health-check: Claude Code health check \u2014 scans plugins, settings, hooks, MCP, runtime state, usage telemetry, permissions, marketplace with optional fixes. Use when checking project health or troubleshooting setup."
+    },
+    {
+      "id": "health-plugin/health-plugins",
+      "line": "health-plugin/health-plugins: Diagnose and fix Claude Code plugin registry corruption \u2014 orphaned entries, stale keys, scope conflicts. Use when seeing plugin-already-installed errors or registry drift."
+    },
+    {
+      "id": "health-plugin/health-skill-audit",
+      "line": "health-plugin/health-skill-audit: Audit skill tree for overlap, split-pressure, and consolidation candidates. Use when finding confusing skill clusters or surfacing REFERENCE.md extraction candidates."
+    },
+    {
+      "id": "health-plugin/plugin-registry",
+      "line": "health-plugin/plugin-registry: Claude Code plugin registry structure, installation scopes, and common issues. Use when troubleshooting plugin installation problems or manually fixing registry entries."
+    },
+    {
+      "id": "health-plugin/settings-configuration",
+      "line": "health-plugin/settings-configuration: Claude Code settings hierarchy, permission wildcards, and configuration patterns. Use when setting up permissions, debugging settings issues, or understanding allowed tools."
+    },
+    {
+      "id": "home-assistant-plugin/ha-automations",
+      "line": "home-assistant-plugin/ha-automations: Home Assistant automation creation and management. Use when working with HA triggers, conditions, actions, scripts, scenes, or blueprints."
+    },
+    {
+      "id": "home-assistant-plugin/ha-configuration",
+      "line": "home-assistant-plugin/ha-configuration: Home Assistant YAML configuration management. Use when editing configuration.yaml, setting up integrations, configuring secrets, or troubleshooting HA configuration."
+    },
+    {
+      "id": "home-assistant-plugin/ha-entities",
+      "line": "home-assistant-plugin/ha-entities: Home Assistant entity and domain management. Use when working with entity IDs, device classes, template entities, groups, or domain-specific attribute customizations."
+    },
+    {
+      "id": "home-assistant-plugin/ha-validate",
+      "line": "home-assistant-plugin/ha-validate: Validate Home Assistant YAML for syntax errors, undefined secrets, and duplicate keys. Use when validating HA config, diagnosing YAML errors, or running hass check_config."
+    },
+    {
+      "id": "hooks-plugin/hooks-configuration",
+      "line": "hooks-plugin/hooks-configuration: Claude Code hooks configuration and development. Use when the user mentions hooks, PreToolUse, PostToolUse, SessionStart, SubagentStart, PermissionRequest, or TaskCompleted."
+    },
+    {
+      "id": "hooks-plugin/hooks-permission-request-hook",
+      "line": "hooks-plugin/hooks-permission-request-hook: Generate a PermissionRequest hook with auto-approve/deny rules. Use when needing a safer alternative to --dangerouslySkipPermissions tailored to your project stack."
+    },
+    {
+      "id": "hooks-plugin/hooks-session-end-issue-hook",
+      "line": "hooks-plugin/hooks-session-end-issue-hook: Configure a Stop hook that surfaces unfinished todos at session end. Use when you want deferred work automatically flagged for GitHub issue creation."
+    },
+    {
+      "id": "hooks-plugin/hooks-session-start-hook",
+      "line": "hooks-plugin/hooks-session-start-hook: Create a SessionStart hook for Claude Code on the web. Use when setting up a repo so dependencies install and tests/linters run automatically on remote session start."
+    },
+    {
+      "id": "kubernetes-plugin/argocd-login",
+      "line": "kubernetes-plugin/argocd-login: ArgoCD CLI auth with SSO and gRPC-Web. Use when the user mentions ArgoCD login, argocd authentication, SSO auth, or accessing ArgoCD applications and clusters."
+    },
+    {
+      "id": "kubernetes-plugin/helm-chart-development",
+      "line": "kubernetes-plugin/helm-chart-development: Create, test, and package Helm charts \u2014 Chart.yaml, templates, dependencies, repo publishing. Use when the user mentions Helm charts, helm lint/template/package, or Kubernetes packaging."
+    },
+    {
+      "id": "kubernetes-plugin/helm-debugging",
+      "line": "kubernetes-plugin/helm-debugging: Debug Helm failures \u2014 template errors, dry-run, YAML parse errors, value type errors, resource conflicts. Use when the user mentions Helm errors or template rendering issues."
+    },
+    {
+      "id": "kubernetes-plugin/helm-release-management",
+      "line": "kubernetes-plugin/helm-release-management: Manage Helm releases \u2014 install, upgrade, uninstall, list, inspect, history. Use when the user mentions deploying Helm charts, upgrading releases, or managing Kubernetes deployments."
+    },
+    {
+      "id": "kubernetes-plugin/helm-release-recovery",
+      "line": "kubernetes-plugin/helm-release-recovery: Recover from failed Helm deployments \u2014 rollback, fix stuck states (pending-install/upgrade), atomic deployments. Use when the user mentions rollback, failed Helm upgrade, or stuck releases."
+    },
+    {
+      "id": "kubernetes-plugin/helm-values-management",
+      "line": "kubernetes-plugin/helm-values-management: Manage Helm values \u2014 override precedence, multi-env configs, --set, schema validation, secrets. Use when the user mentions Helm values, env-specific configs, or values.yaml."
+    },
+    {
+      "id": "kubernetes-plugin/kubectl-debugging",
+      "line": "kubernetes-plugin/kubectl-debugging: Debug K8s pods/nodes with kubectl debug \u2014 ephemeral containers, pod copying, debug profiles, interactive sessions. Use when the user mentions kubectl debug or debugging pods."
+    },
+    {
+      "id": "kubernetes-plugin/kubernetes-operations",
+      "line": "kubernetes-plugin/kubernetes-operations: Kubernetes operations \u2014 deployment, management, troubleshooting, kubectl mastery. Use when the user mentions K8s, kubectl, pods, deployments, services, ingress, or cluster stability."
+    },
+    {
+      "id": "langchain-plugin/deep-agents",
+      "line": "langchain-plugin/deep-agents: Build hierarchical AI agents with the deepagents npm package. Use when creating orchestrators that plan multi-step tasks, delegate to child agents, or maintain persistent memory."
+    },
+    {
+      "id": "langchain-plugin/langchain-development",
+      "line": "langchain-plugin/langchain-development: LangChain JS/TS framework for building LLM-powered apps. Use when working with chat models, prompt templates, LCEL chains, tool binding, or RAG pipelines."
+    },
+    {
+      "id": "langchain-plugin/langchain-init",
+      "line": "langchain-plugin/langchain-init: Initialize a new LangChain TypeScript project. Use when starting an LLM-powered app, scaffolding an AI agent project, or setting up LangChain from scratch."
+    },
+    {
+      "id": "langchain-plugin/langgraph-agents",
+      "line": "langchain-plugin/langgraph-agents: LangGraph stateful AI agents with graph-based workflows. Use when creating state-machine agents with checkpoints, human-in-the-loop, streaming execution, or subgraph composition."
+    },
+    {
+      "id": "macos-plugin/endpoint-security-cpu",
+      "line": "macos-plugin/endpoint-security-cpu: macOS EndpointSecurity/EDR high CPU & battery drain. Use when Kandji ESF / XProtect pegs a core; trace the exec storm via powermetrics + eslogger."
+    },
+    {
+      "id": "macos-plugin/kitty-session-persistence",
+      "line": "macos-plugin/kitty-session-persistence: Snapshot and restore kitty terminal sessions on macOS. Use when surviving WindowServer hangs without losing tabs, configuring snapshots, or restoring after a force-reboot."
+    },
+    {
+      "id": "macos-plugin/launchservices-health",
+      "line": "macos-plugin/launchservices-health: Diagnose macOS LaunchServices DB bloat and launchservicesd CPU spikes. Use when launchservicesd is pegged at high CPU or WindowServer XPC stalls are suspected."
+    },
+    {
+      "id": "macos-plugin/macos-disk-usage",
+      "line": "macos-plugin/macos-disk-usage: macOS disk-usage forensics and space recovery on APFS. Use when df reports a disk near-full, hunting what's eating space, reclaiming OrbStack/Docker, or pruning caches and local snapshots."
+    },
+    {
+      "id": "macos-plugin/macos-incident-postmortem",
+      "line": "macos-plugin/macos-incident-postmortem: Reconstruct macOS freeze, panic, or reboot from DiagnosticReports and shell history. Use when investigating hangs, panics, watchdog timeouts, jetsam, or thermal throttling."
+    },
+    {
+      "id": "macos-plugin/macos-performance-benchmark",
+      "line": "macos-plugin/macos-performance-benchmark: Repeatable macOS/Apple-Silicon benchmark + diagnostics scored PASS/WARN/FAIL with saved reports. Use when baselining a Mac, verifying it performs to spec, or tracking CPU/memory/disk/thermal health."
+    },
+    {
+      "id": "macos-plugin/macos-performance-triage",
+      "line": "macos-plugin/macos-performance-triage: Live macOS/Apple-Silicon performance triage \u2014 find what's heating the Mac (hot WindowServer, GPU compositing, a CPU-heavy browser/Electron app) and attribute it to the driving process. Use when fans spin up, the Mac is hot/slow, or WindowServer/an app shows high CPU/GPU."
+    },
+    {
+      "id": "macos-plugin/tui-keybinding-debug",
+      "line": "macos-plugin/tui-keybinding-debug: Debug dead TUI/terminal keybindings \u2014 terminal interception (kitty), layout-impossible chords, legacy key aliasing. Use when a configured key does nothing in a TUI, fzf, or shell app."
+    },
+    {
+      "id": "migration-patterns-plugin/black-to-ruff-format",
+      "line": "migration-patterns-plugin/black-to-ruff-format: Migrate Python formatting from black to ruff-format. Use when psf/black is in .pre-commit-config.yaml or [tool.black] exists in pyproject.toml."
+    },
+    {
+      "id": "migration-patterns-plugin/dual-write",
+      "line": "migration-patterns-plugin/dual-write: Dual-write pattern for safe data store transitions. Use when planning DB migrations, switching storage backends, or reviewing code writing to multiple systems simultaneously."
+    },
+    {
+      "id": "migration-patterns-plugin/eslint-to-biome",
+      "line": "migration-patterns-plugin/eslint-to-biome: Migrate JS/TS linting from ESLint+Prettier to Biome. Use when .eslintrc* or eslint.config.* exists and no biome.json is present."
+    },
+    {
+      "id": "migration-patterns-plugin/flake8-to-ruff",
+      "line": "migration-patterns-plugin/flake8-to-ruff: Migrate Python linting from flake8/isort to ruff. Use when pycqa/flake8 or PyCQA/isort is in .pre-commit-config.yaml or [tool.flake8]/[tool.isort] config exists."
+    },
+    {
+      "id": "migration-patterns-plugin/mypy-to-ty",
+      "line": "migration-patterns-plugin/mypy-to-ty: Migrate Python type checking from mypy to ty (Astral). Use when mirrors-mypy is in .pre-commit-config.yaml or [tool.mypy] config exists."
+    },
+    {
+      "id": "migration-patterns-plugin/shadow-mode",
+      "line": "migration-patterns-plugin/shadow-mode: Shadow mode / dark-launch for validating new systems under production load. Use when testing replacement services, comparing behavior, or planning traffic mirroring for migrations."
+    },
+    {
+      "id": "networking-plugin/dns-tools",
+      "line": "networking-plugin/dns-tools: DNS resolution and propagation debugging. Use when looking up A/AAAA/MX/TXT records, verifying DNS changes across resolvers, or querying via DoT/DoH."
+    },
+    {
+      "id": "networking-plugin/http-load-testing",
+      "line": "networking-plugin/http-load-testing: HTTP load testing with oha. Use when measuring latency percentiles, finding a server's breaking point, or validating SLA targets under coordinated-omission correction."
+    },
+    {
+      "id": "networking-plugin/interface-state",
+      "line": "networking-plugin/interface-state: Local interface, address, route, and neighbor state with iproute2. Use when viewing or configuring a host's own IPs, links, routes, or ARP/NDP cache \u2014 the ifconfig/route/arp replacement."
+    },
+    {
+      "id": "networking-plugin/layer2-discovery",
+      "line": "networking-plugin/layer2-discovery: Layer 2 device discovery and topology mapping. Use when finding switch port assignments, enumerating hosts via ARP, or identifying unknown devices by MAC vendor."
+    },
+    {
+      "id": "networking-plugin/network-diagnostics",
+      "line": "networking-plugin/network-diagnostics: Network connectivity and latency diagnostics. Use when tracing routes, comparing ping latency across endpoints, or inspecting local socket/port usage."
+    },
+    {
+      "id": "networking-plugin/network-discovery",
+      "line": "networking-plugin/network-discovery: Network host and port discovery with nmap. Use when scanning TCP ports, enumerating hosts on a subnet, or identifying running services and versions."
+    },
+    {
+      "id": "networking-plugin/network-monitoring",
+      "line": "networking-plugin/network-monitoring: Real-time network traffic and per-process bandwidth monitoring. Use when finding which app consumes bandwidth, inspecting active connections, or capturing traffic samples."
+    },
+    {
+      "id": "obsidian-plugin/bases",
+      "line": "obsidian-plugin/bases: Obsidian Bases (database-over-notes): list base files/views, create items, run view queries with json/csv/tsv/md output. Use when user mentions Bases or .base files."
+    },
+    {
+      "id": "obsidian-plugin/bookmarks",
+      "line": "obsidian-plugin/bookmarks: Obsidian bookmarks: list and add file/folder/heading/saved-search/URL bookmarks. Use when starring or saving notes for quick access."
+    },
+    {
+      "id": "obsidian-plugin/command-palette",
+      "line": "obsidian-plugin/command-palette: Run, list, and inspect Obsidian commands and hotkeys from the CLI. Use when triggering a command, enumerating commands, or checking hotkey bindings."
+    },
+    {
+      "id": "obsidian-plugin/dev-tools",
+      "line": "obsidian-plugin/dev-tools: Obsidian plugin/theme dev: DevTools, CDP, JS eval, console/error buffers, CSS/DOM inspection, mobile emulation, screenshots. Use when debugging the app."
+    },
+    {
+      "id": "obsidian-plugin/file-history",
+      "line": "obsidian-plugin/file-history: Obsidian File Recovery and Sync history: inspect, diff, restore previous note versions. Use when undoing edits, restoring versions, or recovering files."
+    },
+    {
+      "id": "obsidian-plugin/plugins-themes",
+      "line": "obsidian-plugin/plugins-themes: Obsidian community plugins/themes/CSS snippets management. Use when installing, enabling, switching theme, or toggling restricted mode."
+    },
+    {
+      "id": "obsidian-plugin/properties",
+      "line": "obsidian-plugin/properties: Obsidian YAML frontmatter properties: read, set, remove on notes. Use when user mentions frontmatter, metadata, tags, aliases, status, or dates."
+    },
+    {
+      "id": "obsidian-plugin/publish-sync",
+      "line": "obsidian-plugin/publish-sync: Obsidian Publish and Sync operations. Use when publishing notes, managing change sets, pausing/resuming sync, or recovering sync-deleted files."
+    },
+    {
+      "id": "obsidian-plugin/search-discovery",
+      "line": "obsidian-plugin/search-discovery: Obsidian vault search: full-text/grep, tag listing, link traversal, outline, orphan/dead-end detection, broken wikilink audit. Use when exploring backlinks."
+    },
+    {
+      "id": "obsidian-plugin/tasks",
+      "line": "obsidian-plugin/tasks: Obsidian tasks via CLI: list open tasks, create tasks, mark complete. Use when user mentions Obsidian tasks, todos, checklists, or completion."
+    },
+    {
+      "id": "obsidian-plugin/templates",
+      "line": "obsidian-plugin/templates: Obsidian Templates plugin: list, read, insert templates with {{date}}/{{time}}/{{title}} variables. Use when inserting or applying a template."
+    },
+    {
+      "id": "obsidian-plugin/vault-files",
+      "line": "obsidian-plugin/vault-files: Obsidian vault file ops via CLI: read, create, append, move, rename, delete, listings, daily/random notes. Use when managing vault files."
+    },
+    {
+      "id": "obsidian-plugin/vault-frontmatter",
+      "line": "obsidian-plugin/vault-frontmatter: Offline YAML frontmatter maintenance for Obsidian notes. Use when stripping legacy `id:`, cleaning Templater markers, or fixing bare emoji tags."
+    },
+    {
+      "id": "obsidian-plugin/vault-management",
+      "line": "obsidian-plugin/vault-management: Obsidian vault inspection and cross-vault routing via `vault=` prefix. Use when checking vault info (path, size, file count) or targeting a non-active vault."
+    },
+    {
+      "id": "obsidian-plugin/vault-mocs",
+      "line": "obsidian-plugin/vault-mocs: Map-of-Content (MOC) curation for Obsidian vaults. Use when creating a MOC for a tag, extending with orphans, fixing legacy MOC tags, or analyzing coverage."
+    },
+    {
+      "id": "obsidian-plugin/vault-orphans",
+      "line": "obsidian-plugin/vault-orphans: Triage orphaned notes (zero in/out wikilinks) in an Obsidian vault. Use when finding orphans, linking them into a MOC, or reconnecting Zettelkasten notes."
+    },
+    {
+      "id": "obsidian-plugin/vault-stubs",
+      "line": "obsidian-plugin/vault-stubs: Work-namespace redirect-stub classification in an Obsidian vault. Use when cleaning stubs, converting duplicates to redirects, or merging content into Zettelkasten."
+    },
+    {
+      "id": "obsidian-plugin/vault-tags",
+      "line": "obsidian-plugin/vault-tags: Emoji-prefixed tag taxonomy for Obsidian vaults. Use when consolidating drifted tags, collapsing bare emoji placeholders, or reducing over-tagging."
+    },
+    {
+      "id": "obsidian-plugin/vault-templates",
+      "line": "obsidian-plugin/vault-templates: Obsidian Templater drift repair. Use when fixing unrendered `<% tp.file.cursor() %>` markers or replacing `{{title}}`/`{{date}}` placeholders."
+    },
+    {
+      "id": "obsidian-plugin/vault-wikilinks",
+      "line": "obsidian-plugin/vault-wikilinks: Broken Obsidian wikilink detection and repair. Use when fixing `[[Target]]` links, rewriting renamed-note refs, or resolving Zettelkasten/work-namespace paths."
+    },
+    {
+      "id": "obsidian-plugin/workspaces",
+      "line": "obsidian-plugin/workspaces: Obsidian editor workspace: list open tabs, recent files, saved Workspaces. Use when checking what's open, switching layouts, or opening files into tabs."
+    },
+    {
+      "id": "project-plugin/changelog-review",
+      "line": "project-plugin/changelog-review: Claude Code changelog analysis for plugin impact. Use when checking new features, breaking changes, or upgrade opportunities from a Claude Code release."
+    },
+    {
+      "id": "project-plugin/project-continue",
+      "line": "project-plugin/project-continue: Resume development from current project state. Use when the user asks to continue work, pick up where we left off, find the next task, or resume a TDD cycle after a break."
+    },
+    {
+      "id": "project-plugin/project-discovery",
+      "line": "project-plugin/project-discovery: Project orientation for unfamiliar codebases. Use when entering a new project, exploring unknown repos, or working on shaky assumptions about build, test, lint, or CI setup."
+    },
+    {
+      "id": "project-plugin/project-init",
+      "line": "project-plugin/project-init: Scaffold a new project with base structure (git, README, LICENSE, CI, pre-commit). Use when starting a new project, initializing a repo, or bootstrapping Python/Node/Rust/Go."
+    },
+    {
+      "id": "project-plugin/project-refocus",
+      "line": "project-plugin/project-refocus: Refresh the plan to focus on the task at hand. Use when context grew, completed steps muddy it, or you want to clear context and continue in auto mode."
+    },
+    {
+      "id": "project-plugin/project-skill-scripts",
+      "line": "project-plugin/project-skill-scripts: Find and create supporting scripts for plugin skills. Use when auditing skills for script opportunities, improving token efficiency, or extracting bash blocks from SKILL.md."
+    },
+    {
+      "id": "project-plugin/project-test-loop",
+      "line": "project-plugin/project-test-loop: Automated TDD test-fix-refactor cycle until tests pass. Use when looping on failing tests, running a TDD cycle, or driving RED/GREEN/REFACTOR until green."
+    },
+    {
+      "id": "prompt-engineering-plugin/prompt-engineering-ground-response",
+      "line": "prompt-engineering-plugin/prompt-engineering-ground-response: Citation-backed responses with direct quotes from source documents. Use when analyzing long docs, answering codebase/spec questions, or when response accuracy is critical."
+    },
+    {
+      "id": "prose-plugin/prose-distill",
+      "line": "prose-plugin/prose-distill: Prose distill: condense verbose text to its essence. Use when asked to condense, tighten, shorten, reduce verbosity, or omit needless words while preserving substance."
+    },
+    {
+      "id": "prose-plugin/prose-synthesize",
+      "line": "prose-plugin/prose-synthesize: Prose synthesize: turn unstructured notes into a structured, actionable plan. Use when given brain dumps, stream-of-consciousness, or scattered thoughts needing order."
+    },
+    {
+      "id": "python-plugin/basedpyright-type-checking",
+      "line": "python-plugin/basedpyright-type-checking: Basedpyright static type checker for Python. Use when setting up type checking, configuring LSP, or comparing type checkers (basedpyright, pyright, mypy alternative)."
+    },
+    {
+      "id": "python-plugin/pytest-advanced",
+      "line": "python-plugin/pytest-advanced: Advanced pytest: fixtures, markers, parametrization, parallel execution. Use when implementing test infrastructure, writing fixtures, or running with coverage."
+    },
+    {
+      "id": "python-plugin/python-code-quality",
+      "line": "python-plugin/python-code-quality: Python code quality with ruff and ty. Use when the user mentions ruff, ty, linting, formatting, type checking, or Python code style."
+    },
+    {
+      "id": "python-plugin/python-development",
+      "line": "python-plugin/python-development: Core Python development idioms and language features (3.10+). Use when mentioning Python, type hints, or async. For scripts see uv-run; for project setup see uv-project-management."
+    },
+    {
+      "id": "python-plugin/python-packaging",
+      "line": "python-plugin/python-packaging: Build and publish Python packages with uv. Use when the user mentions building packages, publishing to PyPI, wheel/sdist creation, or entry points."
+    },
+    {
+      "id": "python-plugin/python-testing",
+      "line": "python-plugin/python-testing: Python testing with pytest, coverage, fixtures, and mocking. Use when the user mentions pytest, unit tests, coverage, fixtures, mocking, or writing Python tests."
+    },
+    {
+      "id": "python-plugin/ruff-formatting",
+      "line": "python-plugin/ruff-formatting: Python code formatting with ruff format. Fast, Black-compatible formatter. Use when formatting Python files, enforcing style, or checking format compliance."
+    },
+    {
+      "id": "python-plugin/ruff-linting",
+      "line": "python-plugin/ruff-linting: Python linting with ruff. Fast linting, rule selection, auto-fixing, and config. Use when checking Python code quality, enforcing standards, or finding bugs."
+    },
+    {
+      "id": "python-plugin/ty-type-checking",
+      "line": "python-plugin/ty-type-checking: ty: Astral's extremely fast Python type checker (mypy/Pyright alternative). Use when checking Python types or setting up type checking. Triggers: ty, mypy alternative."
+    },
+    {
+      "id": "python-plugin/uv-advanced-dependencies",
+      "line": "python-plugin/uv-advanced-dependencies: Advanced uv dependencies: Git deps, path deps, editable installs, groups, extras, custom indexes. Use when the user mentions git+https deps, editable installs, or private indexes."
+    },
+    {
+      "id": "python-plugin/uv-project-management",
+      "line": "python-plugin/uv-project-management: Python project setup, deps, and lockfiles with uv. Use when the user mentions uv, creating Python projects, managing dependencies, lockfiles, or pyproject.toml."
+    },
+    {
+      "id": "python-plugin/uv-python-versions",
+      "line": "python-plugin/uv-python-versions: Install and manage Python interpreter versions with uv. Use when the user mentions installing Python versions, .python-version, uv python, or managing CPython/PyPy."
+    },
+    {
+      "id": "python-plugin/uv-run",
+      "line": "python-plugin/uv-run: Run Python scripts with uv (PEP 723 inline deps, --with for one-off deps). Use when running scripts without venv activation or needing one-off dependencies."
+    },
+    {
+      "id": "python-plugin/uv-tool-management",
+      "line": "python-plugin/uv-tool-management: Install and manage global Python CLI tools with uv (pipx alternative). Use when the user mentions uv tool, uvx, installing CLI tools globally, or pipx replacement."
+    },
+    {
+      "id": "python-plugin/uv-workspaces",
+      "line": "python-plugin/uv-workspaces: Manage multi-package Python projects with uv workspaces. Use when the user mentions uv workspaces, Python monorepo, shared lockfiles, or member dependencies."
+    },
+    {
+      "id": "python-plugin/vulture-dead-code",
+      "line": "python-plugin/vulture-dead-code: Vulture and deadcode tools for detecting unused Python code (functions, classes, imports). Use when cleaning up codebases or removing dead code. Triggers vulture, deadcode."
+    },
+    {
+      "id": "rust-plugin/cargo-llvm-cov",
+      "line": "rust-plugin/cargo-llvm-cov: cargo-llvm-cov: Rust code coverage with LLVM instrumentation. Use when measuring coverage, enforcing thresholds, generating reports, or integrating codecov/coveralls."
+    },
+    {
+      "id": "rust-plugin/cargo-machete",
+      "line": "rust-plugin/cargo-machete: cargo-machete: detect unused Rust dependencies. Use when auditing Cargo.toml, optimizing build times, or cleaning up dependency bloat."
+    },
+    {
+      "id": "rust-plugin/cargo-nextest",
+      "line": "rust-plugin/cargo-nextest: cargo-nextest: fast Rust test runner with parallel execution and advanced filtering. Use when running tests, setting up CI, or diagnosing flaky/slow tests."
+    },
+    {
+      "id": "rust-plugin/cargo-worktree-builds",
+      "line": "rust-plugin/cargo-worktree-builds: Share one CARGO_TARGET_DIR across parallel git-worktree agents so Rust deps compile once. Use when running cargo/clippy/test in several worktrees concurrently, when parallel agent builds rebuild dependencies N times, or when N worktrees blow up disk with N copies of target/."
+    },
+    {
+      "id": "rust-plugin/clippy-advanced",
+      "line": "rust-plugin/clippy-advanced: Advanced Clippy configuration for Rust \u2014 custom rules, pedantic/nursery lints, clippy.toml, IDE and CI integration. Use when configuring or enforcing lint standards."
+    },
+    {
+      "id": "rust-plugin/mockito-http-mocking",
+      "line": "rust-plugin/mockito-http-mocking: mockito HTTP mocking for Rust integration tests: expectation semantics, mock matching order, and taming polling clients against instant mock servers. Use when mocking an HTTP API in Rust tests, when a wait-until-matched loop hangs, or when tests pass alone but hang under concurrent load."
+    },
+    {
+      "id": "rust-plugin/rust-development",
+      "line": "rust-plugin/rust-development: Rust development \u2014 cargo, clippy, rustfmt, async, Tokio, Serde, memory safety. Use when mentioning Rust, cargo, ownership, lifetimes, fearless concurrency, or async programming."
+    },
+    {
+      "id": "session-plugin/session-distill",
+      "line": "session-plugin/session-distill: Distill session insights into rules, skill improvements, recipes, and cross-repo promotions to marketplace plugins. Use when capturing learnings, codifying workflow into .claude/rules, or promoting a session-invented pattern into a specific plugin/skill as a PR."
+    },
+    {
+      "id": "session-plugin/session-end",
+      "line": "session-plugin/session-end: End-of-session orchestrator. Previews which of wrap/distill/feedback/taskwarrior-sync qualify, single confirm, then sequence. Use when winding down a session."
+    },
+    {
+      "id": "session-plugin/session-spinup",
+      "line": "session-plugin/session-spinup: Read-only session-start briefing of open tasks, git state, journal todos. Use when user says spin up, what was I doing, or pick up where I left off."
+    },
+    {
+      "id": "session-plugin/session-wrap",
+      "line": "session-plugin/session-wrap: End-of-session capture to taskwarrior, optional journal, GitHub issues. Use when user says wrap up, session wrap, or done for now."
+    },
+    {
+      "id": "software-design-plugin/design-by-contract",
+      "line": "software-design-plugin/design-by-contract: Design with explicit contracts \u2014 preconditions, postconditions, invariants, guard clauses. Use when designing a function/class, hardening a boundary, or adding assertions."
+    },
+    {
+      "id": "software-design-plugin/design-deep-modules",
+      "line": "software-design-plugin/design-deep-modules: Judge interface depth \u2014 deep modules hide complexity behind small interfaces. Use when designing a module/API, reviewing a class boundary, or reducing complexity."
+    },
+    {
+      "id": "software-design-plugin/design-legacy-seams",
+      "line": "software-design-plugin/design-legacy-seams: Get legacy code under test before changing it \u2014 find seams, write characterization tests. Use when changing untested code, breaking dependencies, or taming legacy."
+    },
+    {
+      "id": "software-design-plugin/design-patterns",
+      "line": "software-design-plugin/design-patterns: Select a design pattern from a symptom \u2014 strategy, observer, factory, adapter, decorator. Use when a structure resists change, or choosing between Gang-of-Four patterns."
+    },
+    {
+      "id": "software-design-plugin/design-pseudocode",
+      "line": "software-design-plugin/design-pseudocode: Design a routine by stepwise refinement \u2014 pseudocode the intent before coding, then promote it to comments. Use when designing a complex function or non-trivial algorithm."
+    },
+    {
+      "id": "taskwarrior-plugin/install-native-hooks",
+      "line": "taskwarrior-plugin/install-native-hooks: Install opt-in taskwarrior native on-add/on-modify/on-exit hooks: auto-stamp project, enforce claims, batch GitHub sync, maintain coworker markers. Use when hardening a local taskwarrior store."
+    },
+    {
+      "id": "taskwarrior-plugin/task-add",
+      "line": "taskwarrior-plugin/task-add: Add a taskwarrior task with blueprint linkage and optional GitHub issue. Use when adding coordination tasks, linking a blueprint WO, or mirroring a GitHub issue locally."
+    },
+    {
+      "id": "taskwarrior-plugin/task-bulk-ops",
+      "line": "taskwarrior-plugin/task-bulk-ops: Batch taskwarrior operations without the ID-renumbering and stdin foot-guns. Use when closing/triaging/modifying many tasks in one pass, bulk `task done` loops, or scripting task queries."
+    },
+    {
+      "id": "taskwarrior-plugin/task-claim",
+      "line": "taskwarrior-plugin/task-claim: Claim a taskwarrior task as in-flight (+ACTIVE) and write a coworker marker. Use when picking up a task from task-coordinate output before starting implementation."
+    },
+    {
+      "id": "taskwarrior-plugin/task-coordinate",
+      "line": "taskwarrior-plugin/task-coordinate: Surface next N unblocked taskwarrior tasks by urgency, skipping lock-contending tasks. Use when planning a parallel-agent wave or choosing tasks for a dispatch slot."
+    },
+    {
+      "id": "taskwarrior-plugin/task-done",
+      "line": "taskwarrior-plugin/task-done: Close a taskwarrior task with landing commit annotation and optional GitHub issue/PR close. Use when finishing a coordination task or marking a work order complete."
+    },
+    {
+      "id": "taskwarrior-plugin/task-reconcile",
+      "line": "taskwarrior-plugin/task-reconcile: Close taskwarrior tasks whose linked GitHub issue/PR closed or merged. Use when stale trackers pile up, after a PR-merge sweep, or auditing queue drift."
+    },
+    {
+      "id": "taskwarrior-plugin/task-release",
+      "line": "taskwarrior-plugin/task-release: Release a taskwarrior task without closing it \u2014 stops +ACTIVE clock and annotates state for handoff. Use when pausing mid-task, handing off to another agent, or aborting cleanly."
+    },
+    {
+      "id": "taskwarrior-plugin/task-status",
+      "line": "taskwarrior-plugin/task-status: Read-only taskwarrior queue report \u2014 pending, blocked, ready tasks and drift vs linked PRs. Use when auditing queue health, orienting before a wave, or for standup summaries."
+    },
+    {
+      "id": "terraform-plugin/infrastructure-terraform",
+      "line": "terraform-plugin/infrastructure-terraform: Terraform IaC: HCL, state management, modules, plan-apply workflows. Use when the user mentions Terraform, HCL, terraform plan/apply, tfstate, or IaC provisioning."
+    },
+    {
+      "id": "terraform-plugin/tfc-list-runs",
+      "line": "terraform-plugin/tfc-list-runs: List Terraform Cloud workspace runs filtered by status or date. Use when reviewing run history, finding failed runs, or auditing infra changes. Requires TFE_TOKEN."
+    },
+    {
+      "id": "terraform-plugin/tfc-plan-json",
+      "line": "terraform-plugin/tfc-plan-json: TFC plan JSON download and analysis. Use when diffing resource changes, inspecting replacements, or feeding plan data downstream. Requires TFE_TOKEN."
+    },
+    {
+      "id": "terraform-plugin/tfc-run-logs",
+      "line": "terraform-plugin/tfc-run-logs: Retrieve plan and apply logs from Terraform Cloud runs. Use when debugging failed plans/applies or reviewing TFC run output. Requires TFE_TOKEN."
+    },
+    {
+      "id": "terraform-plugin/tfc-run-status",
+      "line": "terraform-plugin/tfc-run-status: Terraform Cloud run status with resource counts and actions. Use when polling a run, checking pass/fail, or seeing if it can be applied or canceled. Requires TFE_TOKEN."
+    },
+    {
+      "id": "terraform-plugin/tfc-workspace-runs",
+      "line": "terraform-plugin/tfc-workspace-runs: List TFC runs across known workspaces (github, sentry, gcp, onelogin, twingate). Use when checking TFC status or listing runs by workspace. Requires TFE_TOKEN."
+    },
+    {
+      "id": "testing-plugin/mutation-testing",
+      "line": "testing-plugin/mutation-testing: Mutation testing with Stryker (TS/JS) and mutmut (Python). Use when finding weak tests that pass on mutated code, or improving test quality through mutation analysis."
+    },
+    {
+      "id": "testing-plugin/odiff-image-diffing",
+      "line": "testing-plugin/odiff-image-diffing: odiff pixel-by-pixel image diffing. Use when comparing screenshots, detecting visual regressions, diffing before/after PNGs, asserting golden images."
+    },
+    {
+      "id": "testing-plugin/playwright-cli",
+      "line": "testing-plugin/playwright-cli: Playwright CLI browser automation \u2014 navigate, screenshot, fill forms, click. Use when automating browser tasks from the shell; 4-10x more token-efficient than Playwright MCP."
+    },
+    {
+      "id": "testing-plugin/playwright-testing",
+      "line": "testing-plugin/playwright-testing: Playwright E2E testing \u2014 cross-browser, visual regression, API testing, mobile emulation. Use when writing E2E tests or setting up automated UI testing for web apps."
+    },
+    {
+      "id": "testing-plugin/property-based-testing",
+      "line": "testing-plugin/property-based-testing: Property-based testing with fast-check (TS/JS) and Hypothesis (Python). Use when generating test data, finding edge cases, testing properties, or writing QuickCheck-style tests."
+    },
+    {
+      "id": "testing-plugin/test-analyze",
+      "line": "testing-plugin/test-analyze: Analyze test results and create a fix plan with subagents. Use when triaging failing tests, analyzing JUnit XML, planning fixes for accessibility/security, or categorizing flaky/E2E failures."
+    },
+    {
+      "id": "testing-plugin/test-consult",
+      "line": "testing-plugin/test-consult: Consult the test-architecture agent for strategy decisions. Use when asking about coverage gaps, test pyramid, framework selection, flaky-test remediation, or how to test X."
+    },
+    {
+      "id": "testing-plugin/test-focus",
+      "line": "testing-plugin/test-focus: Run one test file fail-fast for rapid TDD \u2014 Playwright, Vitest, Jest, pytest, cargo, go test. Use when iterating on a failing spec, headed/debug mode, or serial WebGL tests."
+    },
+    {
+      "id": "testing-plugin/test-full",
+      "line": "testing-plugin/test-full: Run complete test suite in pyramid order \u2014 unit, integration, E2E. Use when running all tests before a PR, generating coverage reports, or doing pre-commit verification."
+    },
+    {
+      "id": "testing-plugin/test-quality-analysis",
+      "line": "testing-plugin/test-quality-analysis: Detect test smells, overmocking, flaky tests, and coverage issues. Use when reviewing tests, improving test quality, or analyzing test effectiveness and reliability."
+    },
+    {
+      "id": "testing-plugin/test-quick",
+      "line": "testing-plugin/test-quick: Run fast unit tests only, skip slow/integration/E2E. Use when checking units after a change, running affected tests since last commit, watch mode TDD, or sub-30s feedback."
+    },
+    {
+      "id": "testing-plugin/test-report",
+      "line": "testing-plugin/test-report: Show cached test status without re-running. Use when checking test health, standup status, coverage summary, history, or identifying flaky tests from recent runs."
+    },
+    {
+      "id": "testing-plugin/test-run",
+      "line": "testing-plugin/test-run: Universal test runner auto-detecting pytest, vitest, jest, cargo, go test. Use when running tests, targeting a file/pattern, running with coverage, or watch-mode dev loops."
+    },
+    {
+      "id": "testing-plugin/test-setup",
+      "line": "testing-plugin/test-setup: Configure testing infrastructure with CI/CD. Use when setting up tests, scaffolding test dirs, adding pre-commit hooks, GitHub Actions workflows, Codecov, or coverage badges."
+    },
+    {
+      "id": "testing-plugin/test-strategy-review",
+      "line": "testing-plugin/test-strategy-review: Evaluate whether a test suite actually tests what it aims to, using an adversarial pass plus a tests-hidden cold read, then verify every finding against the code. Use when a suite is green but you doubt it would catch a real regression."
+    },
+    {
+      "id": "testing-plugin/test-tier-selection",
+      "line": "testing-plugin/test-tier-selection: Auto-select test tiers based on change scope \u2014 unit for small, full suite for large. Use when running tests, discussing testing strategy, or after code modifications."
+    },
+    {
+      "id": "testing-plugin/vitest-testing",
+      "line": "testing-plugin/vitest-testing: Vitest test runner \u2014 Vite-native, ESM, watch/UI mode, coverage, mocking, snapshots. Use when setting up tests for Vite projects, migrating from Jest, or needing fast execution."
+    },
+    {
+      "id": "tools-plugin/binary-analysis",
+      "line": "tools-plugin/binary-analysis: Binary analysis: strings, binwalk, hexdump, xxd, file, objdump. Use when identifying unknown files, extracting strings, hunting credentials, or entropy analysis."
+    },
+    {
+      "id": "tools-plugin/cli-smoke-recipes",
+      "line": "tools-plugin/cli-smoke-recipes: CLI smoke recipes: expose pure-function modules via subcommands with a bulk-smoke justfile recipe. Use when designing data-transform modules or authoring smoke tests."
+    },
+    {
+      "id": "tools-plugin/d2-diagrams",
+      "line": "tools-plugin/d2-diagrams: Generate diagrams from text using D2 with automatic layouts and themes. Use when creating architecture diagrams, flowcharts, decision trees, sequence flows, or ERDs."
+    },
+    {
+      "id": "tools-plugin/deps-install",
+      "line": "tools-plugin/deps-install: Deps install: auto-detect package manager (uv, bun, npm, yarn, pnpm, cargo, go) and run the right install. Use when installing deps or syncing lockfiles."
+    },
+    {
+      "id": "tools-plugin/fd-file-finding",
+      "line": "tools-plugin/fd-file-finding: fd fast file finding: smart defaults, gitignore-aware, parallel. Use when searching for files by name, extension, or pattern across directories."
+    },
+    {
+      "id": "tools-plugin/generate-image",
+      "line": "tools-plugin/generate-image: Image generation via Gemini 3 Pro Image: aspect ratio, resolution, reference images. Use when creating artwork, product photos, or mockups with AI."
+    },
+    {
+      "id": "tools-plugin/hf-downloads",
+      "line": "tools-plugin/hf-downloads: Hugging Face model downloads without filling root disk \u2014 HF_HOME/xet cache redirection, token/gated-repo auth, staging pattern. Use when downloading HF models, hf download errors, ENOSPC during downloads, or GatedRepoError/401s."
+    },
+    {
+      "id": "tools-plugin/imagemagick-conversion",
+      "line": "tools-plugin/imagemagick-conversion: ImageMagick image manipulation: format conversion, resizing, batch processing, quality. Use when converting, resizing, batch-processing, or generating thumbnails."
+    },
+    {
+      "id": "tools-plugin/jq-json-processing",
+      "line": "tools-plugin/jq-json-processing: jq JSON processing: query, filter, transform JSON. Use when parsing JSON files, filtering arrays/objects, transforming structures, or extracting fields from JSON."
+    },
+    {
+      "id": "tools-plugin/justfile-expert",
+      "line": "tools-plugin/justfile-expert: Just command runner expertise \u2014 Justfile syntax, recipes, parameters, modules, shebang recipes. Use when authoring justfiles, project commands, or task automation."
+    },
+    {
+      "id": "tools-plugin/mermaid-diagrams",
+      "line": "tools-plugin/mermaid-diagrams: Render Mermaid diagrams (mmdc) to SVG/PNG/PDF \u2014 flowcharts, sequence, ERDs, class, state, Gantt, pie, gitGraph. Use when rendering .mmd or embedding diagrams in GitHub Markdown."
+    },
+    {
+      "id": "tools-plugin/nushell-data-processing",
+      "line": "tools-plugin/nushell-data-processing: Structured data processing with nushell \u2014 native tables, multi-format parsing (JSON/YAML/TOML/CSV/XML), pipelines, group-by. Use when running multi-step cross-format transforms awkward in jq."
+    },
+    {
+      "id": "tools-plugin/rg-code-search",
+      "line": "tools-plugin/rg-code-search: ripgrep (rg) fast code search: smart defaults, regex, file filtering. Use when searching for text patterns, code snippets, or doing multi-file analysis."
+    },
+    {
+      "id": "tools-plugin/shell-expert",
+      "line": "tools-plugin/shell-expert: Shell scripting: bash, zsh, POSIX, CLI tools, cross-platform automation. Use when writing shell scripts, pipes, command-line automation, or portable shell code."
+    },
+    {
+      "id": "tools-plugin/yq-yaml-processing",
+      "line": "tools-plugin/yq-yaml-processing: yq YAML processing: query, filter, transform YAML. Use when parsing configs, modifying Kubernetes manifests or GitHub Actions workflows, or transforming YAML."
+    },
+    {
+      "id": "typescript-plugin/biome-tooling",
+      "line": "typescript-plugin/biome-tooling: Biome all-in-one JS/TS formatter and linter, 15-20x faster than ESLint/Prettier. Use when setting up formatting/linting or migrating from ESLint+Prettier."
+    },
+    {
+      "id": "typescript-plugin/bun-add",
+      "line": "typescript-plugin/bun-add: Bun add: install a package, add dev dependency, pin exact version, or target a workspace. Use when the user wants to add/install a specific package with bun."
+    },
+    {
+      "id": "typescript-plugin/bun-build",
+      "line": "typescript-plugin/bun-build: Bun build: bundle or compile JS/TS to production bundle or standalone binary. Use when the user wants to bundle, compile, or build for browser/bun/node target."
+    },
+    {
+      "id": "typescript-plugin/bun-debug",
+      "line": "typescript-plugin/bun-debug: Bun debugger via --inspect. Use when the user wants to debug a TS/JS file interactively, break at first line, wait for attach, or debug tests with --inspect-brk."
+    },
+    {
+      "id": "typescript-plugin/bun-development",
+      "line": "typescript-plugin/bun-development: Bun runtime workflows for running scripts, testing, building, and initializing projects with agent-optimized flags. Use when running a TS file, watch/hot reload, configuring `bun test`, bundling/compiling, or scaffolding a Bun project."
+    },
+    {
+      "id": "typescript-plugin/bun-install",
+      "line": "typescript-plugin/bun-install: Bun install: install all deps from package.json. Use when bootstrapping a checkout, running a reproducible CI install (--frozen-lockfile), or deploying (--production)."
+    },
+    {
+      "id": "typescript-plugin/bun-lockfile-update",
+      "line": "typescript-plugin/bun-lockfile-update: Bun lockfile update (bun.lock): bun update, regeneration, security audits. Use when updating dependencies, resolving lockfile conflicts, or regenerating bun.lock."
+    },
+    {
+      "id": "typescript-plugin/bun-outdated",
+      "line": "typescript-plugin/bun-outdated: Bun outdated: check which deps have newer versions. Use when auditing freshness, spotting major updates, or deciding between bun update and bun update --latest."
+    },
+    {
+      "id": "typescript-plugin/bun-package-manager",
+      "line": "typescript-plugin/bun-package-manager: Fast JavaScript package management with Bun \u2014 install, add, remove, update. Use when installing all deps, adding/removing packages, running `bun update`/`outdated`, managing workspaces, doing a `--frozen-lockfile` CI install, or debugging conflicts."
+    },
+    {
+      "id": "typescript-plugin/bun-publish",
+      "line": "typescript-plugin/bun-publish: Bun publish to npm. Use when the user wants to release to npm, preview with --dry-run, publish a scoped package with --access public, or enable --provenance signing."
+    },
+    {
+      "id": "typescript-plugin/bun-publishing",
+      "line": "typescript-plugin/bun-publishing: Publish npm packages built with Bun: package.json config, CLI tool packaging, provenance signing, release automation. Use when setting up `publishConfig`/`files`/`bin`, packaging a CLI, enabling `--provenance`, or wiring release-please."
+    },
+    {
+      "id": "typescript-plugin/bun-test",
+      "line": "typescript-plugin/bun-test: Bun test runner with compact agent-friendly output. Use when running bun tests, targeting a pattern, collecting --coverage, watching, or emitting JUnit XML for CI."
+    },
+    {
+      "id": "typescript-plugin/knip-dead-code",
+      "line": "typescript-plugin/knip-dead-code: Knip dead-code detector for JS/TS: unused files, deps, exports, types. Use when cleaning up codebases, finding dead exports, or enforcing dependency hygiene in CI."
+    },
+    {
+      "id": "typescript-plugin/nodejs-development",
+      "line": "typescript-plugin/nodejs-development: Node.js development with Bun, Vite, Vue 3, Pinia, TypeScript. Use when the user mentions Node.js, Bun, Vite, Vue, Pinia, npm, pnpm, or modern JS/TS frameworks."
+    },
+    {
+      "id": "typescript-plugin/typescript-debugging",
+      "line": "typescript-plugin/typescript-debugging: Modern TypeScript/JavaScript debugging with Bun \u2014 inspector flags, debug.bun.sh, VSCode launch.json, memory profiling, heap analysis. Use when setting up interactive debugging, investigating leaks, CPU profiling with `--cpu-prof`, or sourcemaps."
+    },
+    {
+      "id": "typescript-plugin/typescript-sentry",
+      "line": "typescript-plugin/typescript-sentry: Error monitoring and performance with Sentry SDK for Bun/Node.js/Next.js \u2014 error capture, breadcrumbs, spans, cron monitoring, source maps, structured logging, profiling. Use when adding Sentry, instrumenting cron, or uploading sourcemaps."
+    },
+    {
+      "id": "typescript-plugin/typescript-strict",
+      "line": "typescript-plugin/typescript-strict: TypeScript strict mode: tsconfig.json, strict flags, Bundler/NodeNext moduleResolution, verbatimModuleSyntax. Use when setting up TS or migrating to stricter type safety."
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-checkpoint-refactor",
+      "line": "workflow-orchestration-plugin/workflow-checkpoint-refactor: Multi-phase refactoring with checkpoint files that survive context limits. Use when refactoring spans 10+ files, needs phased rollout, or risks running out of context mid-session."
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-preflight",
+      "line": "workflow-orchestration-plugin/workflow-preflight: Pre-work validation before implementation. Use when starting an issue or fix to verify remote state, check for existing PRs, and detect branch conflicts before coding."
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-verify-before-filing",
+      "line": "workflow-orchestration-plugin/workflow-verify-before-filing: Verify accumulated bug claims at upstream HEAD and dedup against trackers before filing issues. Use when filing upstream reports from backlogs, audit docs, or git-history findings."
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-wave-dispatch",
+      "line": "workflow-orchestration-plugin/workflow-wave-dispatch: Sequential-wave dispatch for multi-agent work with cross-task dependencies. Use when planning multi-step work, fixing parallel-dispatch order, or gating waves on verification."
+    }
+  ]
+}

--- a/experiments/skill-catalog-routing/catalogs/catalog.medium.json
+++ b/experiments/skill-catalog-routing/catalogs/catalog.medium.json
@@ -1,0 +1,1627 @@
+{
+  "variant": "medium",
+  "source_sha": "020bfd9049809681d21d5b6469696f079f249bd3",
+  "skill_count": 405,
+  "entries": [
+    {
+      "id": "accessibility-plugin/accessibility-implementation",
+      "line": "accessibility-plugin/accessibility-implementation: Use when implementing accessible components or user mentions WCAG/ARIA/screen"
+    },
+    {
+      "id": "accessibility-plugin/design-tokens",
+      "line": "accessibility-plugin/design-tokens: Use when implementing design systems or user mentions tokens, CSS variables,"
+    },
+    {
+      "id": "agent-patterns-plugin/adversarial-review",
+      "line": "agent-patterns-plugin/adversarial-review: Use when stakes are high and a normal review already ran"
+    },
+    {
+      "id": "agent-patterns-plugin/agent-teams",
+      "line": "agent-patterns-plugin/agent-teams: Use when running parallel agents, coordinating with messaging, or setting up"
+    },
+    {
+      "id": "agent-patterns-plugin/cold-read-gate",
+      "line": "agent-patterns-plugin/cold-read-gate: Use when an artifact must survive a reader with zero project context"
+    },
+    {
+      "id": "agent-patterns-plugin/custom-agent-definitions",
+      "line": "agent-patterns-plugin/custom-agent-definitions: Use when creating an agent .md file, defining a specialized agent,"
+    },
+    {
+      "id": "agent-patterns-plugin/exclusive-lock-dispatch",
+      "line": "agent-patterns-plugin/exclusive-lock-dispatch: Use when fanning out parallel agents needing a non-concurrent resource"
+    },
+    {
+      "id": "agent-patterns-plugin/execution-grounded-review",
+      "line": "agent-patterns-plugin/execution-grounded-review: Use when verifying an implementation meets spec"
+    },
+    {
+      "id": "agent-patterns-plugin/expose-tunable-knob",
+      "line": "agent-patterns-plugin/expose-tunable-knob: Use when tuning visual, audio, or UX output (color, size, position, timing"
+    },
+    {
+      "id": "agent-patterns-plugin/mcp-code-execution",
+      "line": "agent-patterns-plugin/mcp-code-execution: Use when agents call many MCP tools, intermediate data exceeds context, you need"
+    },
+    {
+      "id": "agent-patterns-plugin/mcp-management",
+      "line": "agent-patterns-plugin/mcp-management: Use when adding/enabling servers, updating .mcp.json, managing OAuth remote"
+    },
+    {
+      "id": "agent-patterns-plugin/mcp-server-authoring",
+      "line": "agent-patterns-plugin/mcp-server-authoring: Use when building or extending an MCP server, adding a tool/resource,"
+    },
+    {
+      "id": "agent-patterns-plugin/meta-assimilate",
+      "line": "agent-patterns-plugin/meta-assimilate: Use when assimilating another project's Claude setup or generalizing an agent"
+    },
+    {
+      "id": "agent-patterns-plugin/meta-audit",
+      "line": "agent-patterns-plugin/meta-audit: Use when reviewing agents/ for missing frontmatter, overprivileged tools, or bad"
+    },
+    {
+      "id": "agent-patterns-plugin/meta-context-diet",
+      "line": "agent-patterns-plugin/meta-context-diet: Use when CLAUDE.md feels bloated, trimming context, or promoting a rule into"
+    },
+    {
+      "id": "agent-patterns-plugin/meta-promote",
+      "line": "agent-patterns-plugin/meta-promote: Use when reorganizing .claude/ directories or when sibling repos hold"
+    },
+    {
+      "id": "agent-patterns-plugin/multi-model-delegation",
+      "line": "agent-patterns-plugin/multi-model-delegation: Use when asking other models to brainstorm a design or reconciling their split"
+    },
+    {
+      "id": "agent-patterns-plugin/parallel-agent-dispatch",
+      "line": "agent-patterns-plugin/parallel-agent-dispatch: Use when fanning out concurrent agents or authoring a lead prompt"
+    },
+    {
+      "id": "agent-patterns-plugin/plugin-settings",
+      "line": "agent-patterns-plugin/plugin-settings: Use when building plugins with user-configurable behavior, storing agent state"
+    },
+    {
+      "id": "agent-patterns-plugin/verify-before-plan",
+      "line": "agent-patterns-plugin/verify-before-plan: Use when a wave's briefs cite a number, path, or behaviour not yet checked"
+    },
+    {
+      "id": "agent-patterns-plugin/wave-based-dispatch",
+      "line": "agent-patterns-plugin/wave-based-dispatch: Use when planning dependent multi-WO landings"
+    },
+    {
+      "id": "agents-plugin/agents-analyze",
+      "line": "agents-plugin/agents-analyze: Use when reviewing where sub-agents would help or auditing agents against"
+    },
+    {
+      "id": "api-plugin/api-testing",
+      "line": "api-plugin/api-testing: Use when the user mentions API testing, Supertest, httpx, REST/GraphQL"
+    },
+    {
+      "id": "bevy-plugin/bevy-ecs-patterns",
+      "line": "bevy-plugin/bevy-ecs-patterns: Use when optimizing Bevy architecture or implementing complex game systems"
+    },
+    {
+      "id": "bevy-plugin/bevy-game-engine",
+      "line": "bevy-plugin/bevy-game-engine: Use when building Bevy games, working with entities/components/systems,"
+    },
+    {
+      "id": "blog-plugin/blog-post",
+      "line": "blog-plugin/blog-post: Use when writing a quick update, retrospective, tutorial, deep dive, or devlog"
+    },
+    {
+      "id": "blog-plugin/blog-post-writing",
+      "line": "blog-plugin/blog-post-writing: Use when writing about work done, documenting a project, or mentioning"
+    },
+    {
+      "id": "blueprint-plugin/adr-relationships",
+      "line": "blueprint-plugin/adr-relationships: Use when creating or validating ADRs to ensure consistency"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-adr-list",
+      "line": "blueprint-plugin/blueprint-adr-list: Use when generating an ADR index, auditing ADR status, or reviewing all"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-adr-validate",
+      "line": "blueprint-plugin/blueprint-adr-validate: Use when auditing ADRs before release, finding broken supersedes/extends links"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-autopilot",
+      "line": "blueprint-plugin/blueprint-autopilot: Use when a drift nudge reports blueprint tasks due or suggests"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-claude-md",
+      "line": "blueprint-plugin/blueprint-claude-md: Use when adding team instructions, converting inline content to @imports,"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-curate-docs",
+      "line": "blueprint-plugin/blueprint-curate-docs: Use when documenting library knowledge for PRP reuse"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-derive-plans",
+      "line": "blueprint-plugin/blueprint-derive-plans: Use when onboarding a project to blueprint, generating a PRD or ADRs"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-derive-rules",
+      "line": "blueprint-plugin/blueprint-derive-rules: Use when extracting implicit decisions from commits or codifying code-style"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-derive-tests",
+      "line": "blueprint-plugin/blueprint-derive-tests: Use when finding untested bug fixes, coverage gaps, or generating a test"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-development",
+      "line": "blueprint-plugin/blueprint-development: Use when generating architecture, testing, or quality rules from requirements"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-docs-currency",
+      "line": "blueprint-plugin/blueprint-docs-currency: Use when committing API/format changes, promoting research to docs/, or landing"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-docs-list",
+      "line": "blueprint-plugin/blueprint-docs-list: Use when listing docs, auditing statuses, or generating an index for project"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-execute",
+      "line": "blueprint-plugin/blueprint-execute: Use when asked 'what's next?', 'continue blueprint', or 'run blueprint' without"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-feature-tracker-status",
+      "line": "blueprint-plugin/blueprint-feature-tracker-status: Use when checking feature status, viewing blocked features, or seeing"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-feature-tracker-sync",
+      "line": "blueprint-plugin/blueprint-feature-tracker-sync: Use when reconciling TODO.md vs tracker, draining WO entries, or recalculating"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-generate-rules",
+      "line": "blueprint-plugin/blueprint-generate-rules: Use when auto-creating architecture, testing, or quality rules from docs/prds/"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-init",
+      "line": "blueprint-plugin/blueprint-init: Use when bootstrapping docs/blueprint/ with manifest, PRD/ADR/PRP directories"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-migration",
+      "line": "blueprint-plugin/blueprint-migration: Use when blueprint-upgrade needs version-specific logic, content hashing,"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-promote",
+      "line": "blueprint-plugin/blueprint-promote: Use when promoting a generated rule, preserving .claude/rules/ changes,"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-prp-create",
+      "line": "blueprint-plugin/blueprint-prp-create: Use when planning a feature packet for subagent execution with TDD"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-prp-execute",
+      "line": "blueprint-plugin/blueprint-prp-execute: Use when asked to execute a PRP, run a planned feature from docs/prps/,"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-rules",
+      "line": "blueprint-plugin/blueprint-rules: Use when adding or listing rules, syncing with CLAUDE.md, or validating path"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-status",
+      "line": "blueprint-plugin/blueprint-status: Use when auditing traceability, orphan docs, or stale generated content"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-story-audit",
+      "line": "blueprint-plugin/blueprint-story-audit: Use when running story audit, PRD reconciliation, or surfacing PRD-code drift"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-story-reconcile",
+      "line": "blueprint-plugin/blueprint-story-reconcile: Use when marking PRD entries implemented/partial/missing, or promoting code-only"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-sync",
+      "line": "blueprint-plugin/blueprint-sync: Use when syncing blueprint after PRD changes, or reconciling .claude/rules/"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-sync-ids",
+      "line": "blueprint-plugin/blueprint-sync-ids: Use when assigning IDs to docs; --dry-run to preview, --link-issues to create"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-upgrade",
+      "line": "blueprint-plugin/blueprint-upgrade: Use when migrating between format versions, enabling monorepo workspaces,"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-work-order",
+      "line": "blueprint-plugin/blueprint-work-order: Use when breaking a PRP into delegatable tasks or spawning from an issue"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-workspace-scan",
+      "line": "blueprint-plugin/blueprint-workspace-scan: Use when adding/removing a child blueprint or when status shows stale portfolio"
+    },
+    {
+      "id": "blueprint-plugin/confidence-scoring",
+      "line": "blueprint-plugin/confidence-scoring: Use when evaluating readiness for execution or subagent delegation"
+    },
+    {
+      "id": "blueprint-plugin/document-detection",
+      "line": "blueprint-plugin/document-detection: Use when the user discusses feature requirements, tech trade-offs,"
+    },
+    {
+      "id": "blueprint-plugin/document-linking",
+      "line": "blueprint-plugin/document-linking: Use when linking docs, finding orphans, auto-assigning IDs, or validating"
+    },
+    {
+      "id": "blueprint-plugin/feature-tracking",
+      "line": "blueprint-plugin/feature-tracking: Use when linking features to PRDs or recalculating completion stats"
+    },
+    {
+      "id": "code-quality-plugin/ast-grep-search",
+      "line": "code-quality-plugin/ast-grep-search: Use when matching code by AST structure, finding functions with specific"
+    },
+    {
+      "id": "code-quality-plugin/bulk-sweep-classify",
+      "line": "code-quality-plugin/bulk-sweep-classify: Use when bulk-renaming commands/tools/paths or migrating syntax across many"
+    },
+    {
+      "id": "code-quality-plugin/code-antipatterns",
+      "line": "code-quality-plugin/code-antipatterns: Use when finding magic numbers, console.logs, var usage, excessive any"
+    },
+    {
+      "id": "code-quality-plugin/code-complexity",
+      "line": "code-quality-plugin/code-complexity: Use when identifying refactoring targets, tracking codebase health, or reviewing"
+    },
+    {
+      "id": "code-quality-plugin/code-dead-code",
+      "line": "code-quality-plugin/code-dead-code: Use when reducing maintenance burden, cleaning up after refactors, or auditing"
+    },
+    {
+      "id": "code-quality-plugin/code-dep-audit",
+      "line": "code-quality-plugin/code-dep-audit: Use when checking supply chain security, preparing releases, or responding"
+    },
+    {
+      "id": "code-quality-plugin/code-docs-quality",
+      "line": "code-quality-plugin/code-docs-quality: Use when auditing documentation, checking for stale ADRs/PRDs, or validating"
+    },
+    {
+      "id": "code-quality-plugin/code-hidden-failures",
+      "line": "code-quality-plugin/code-hidden-failures: Use when failures vanish or success masks empty output"
+    },
+    {
+      "id": "code-quality-plugin/code-lint",
+      "line": "code-quality-plugin/code-lint: Use when linting code, auto-fixing, formatting, or running pre-commit checks"
+    },
+    {
+      "id": "code-quality-plugin/code-refactor",
+      "line": "code-quality-plugin/code-refactor: Use when extracting pure functions, removing side effects, replacing loops"
+    },
+    {
+      "id": "code-quality-plugin/code-review",
+      "line": "code-quality-plugin/code-review: Use when reviewing code, auditing OWASP, checking SOLID, or finding perf"
+    },
+    {
+      "id": "code-quality-plugin/code-review-checklist",
+      "line": "code-quality-plugin/code-review-checklist: Use when reviewing PRs, checking for secrets/injection, verifying error"
+    },
+    {
+      "id": "code-quality-plugin/code-test-quality",
+      "line": "code-quality-plugin/code-test-quality: Use when tests are unreliable, coverage is misleading, or after major refactors"
+    },
+    {
+      "id": "code-quality-plugin/debugging-methodology",
+      "line": "code-quality-plugin/debugging-methodology: Use when diagnosing memory leaks, tracing syscalls with strace/eBPF, profiling"
+    },
+    {
+      "id": "code-quality-plugin/dry-consolidation",
+      "line": "code-quality-plugin/dry-consolidation: Use when seeing repeated utilities, copy-pasted components, duplicated hooks,"
+    },
+    {
+      "id": "codebase-attributes-plugin/attributes-collect",
+      "line": "codebase-attributes-plugin/attributes-collect: Use when assessing project health before routing to specialized agents via"
+    },
+    {
+      "id": "codebase-attributes-plugin/attributes-dashboard",
+      "line": "codebase-attributes-plugin/attributes-dashboard: Use when wanting a health overview or terminal-style summary with action"
+    },
+    {
+      "id": "codebase-attributes-plugin/attributes-route",
+      "line": "codebase-attributes-plugin/attributes-route: Use when the user has attribute data and wants automated remediation"
+    },
+    {
+      "id": "comfyui-plugin/comfy-cli",
+      "line": "comfyui-plugin/comfy-cli: Use when the user runs `comfy`, `comfy node`, or `comfy run`"
+    },
+    {
+      "id": "comfyui-plugin/comfy-conditionals",
+      "line": "comfyui-plugin/comfy-conditionals: Use when forming the boolean that drives a workflow switch or blocker"
+    },
+    {
+      "id": "comfyui-plugin/comfy-corpus-validation",
+      "line": "comfyui-plugin/comfy-corpus-validation: Use when writing or auditing sampler corpus metadata"
+    },
+    {
+      "id": "comfyui-plugin/comfy-debug-preview",
+      "line": "comfyui-plugin/comfy-debug-preview: Use when inspecting a value mid-graph without changing it"
+    },
+    {
+      "id": "comfyui-plugin/comfy-flow-control",
+      "line": "comfyui-plugin/comfy-flow-control: Use when wiring where a signal routes in a workflow"
+    },
+    {
+      "id": "comfyui-plugin/comfy-image-utils",
+      "line": "comfyui-plugin/comfy-image-utils: Use when manipulating images or generating captions/tags in a workflow"
+    },
+    {
+      "id": "comfyui-plugin/comfy-math-strings",
+      "line": "comfyui-plugin/comfy-math-strings: Use when computing a value or assembling a string in a workflow"
+    },
+    {
+      "id": "comfyui-plugin/comfy-metadata",
+      "line": "comfyui-plugin/comfy-metadata: Use when figuring out what prompt/settings produced a file, or comparing runs"
+    },
+    {
+      "id": "comfyui-plugin/comfy-node",
+      "line": "comfyui-plugin/comfy-node: Use when releasing or spinning up a new comfyui node pack"
+    },
+    {
+      "id": "comfyui-plugin/comfy-registry-lifecycle",
+      "line": "comfyui-plugin/comfy-registry-lifecycle: Use when debugging a pack's publish pipeline"
+    },
+    {
+      "id": "comfyui-plugin/comfy-subgraphs-app-mode",
+      "line": "comfyui-plugin/comfy-subgraphs-app-mode: Use when deciding how to package a workflow stage"
+    },
+    {
+      "id": "comfyui-plugin/comfy-workflow-json",
+      "line": "comfyui-plugin/comfy-workflow-json: Use when a workflow JSON is too large to hand-edit or a transform drops state"
+    },
+    {
+      "id": "comfyui-plugin/comfy-workflow-layout",
+      "line": "comfyui-plugin/comfy-workflow-layout: Use when a workflow's nodes overlap, are messy or cramped, or were imported"
+    },
+    {
+      "id": "comfyui-plugin/comfyui-node-authoring",
+      "line": "comfyui-plugin/comfyui-node-authoring: Use when writing or patching a custom node's code"
+    },
+    {
+      "id": "comfyui-plugin/comfyui-node-scaffold",
+      "line": "comfyui-plugin/comfyui-node-scaffold: Use when bootstrapping or init-ing a comfyui node pack"
+    },
+    {
+      "id": "comfyui-plugin/comfyui-pack-live-smoke",
+      "line": "comfyui-plugin/comfyui-pack-live-smoke: Use when verifying a pack before opening a registry PR"
+    },
+    {
+      "id": "comfyui-plugin/comfyui-screenshot-pipeline",
+      "line": "comfyui-plugin/comfyui-screenshot-pipeline: Use when generating pack screenshots, adding `just screenshots`, or capturing"
+    },
+    {
+      "id": "communication-plugin/google-chat-formatting",
+      "line": "communication-plugin/google-chat-formatting: Use when formatting messages for Google Chat or converting Markdown documents"
+    },
+    {
+      "id": "communication-plugin/ticket-drafting-guidelines",
+      "line": "communication-plugin/ticket-drafting-guidelines: Use when creating issues, drafting tickets, or writing bug reports with concise"
+    },
+    {
+      "id": "component-patterns-plugin/components-version-badge",
+      "line": "component-patterns-plugin/components-version-badge: Use when adding version display to app header/footer for Next.js, Nuxt"
+    },
+    {
+      "id": "component-patterns-plugin/version-badge-pattern",
+      "line": "component-patterns-plugin/version-badge-pattern: Use when adding version visibility for support or debugging. Works with React"
+    },
+    {
+      "id": "configure-plugin/ci-workflows",
+      "line": "configure-plugin/ci-workflows: Use when checking CI/CD compliance, referencing canonical workflow shapes,"
+    },
+    {
+      "id": "configure-plugin/claude-security-settings",
+      "line": "configure-plugin/claude-security-settings: Use when auditing or hardening .claude/settings.json permissions"
+    },
+    {
+      "id": "configure-plugin/config-sync",
+      "line": "configure-plugin/config-sync: Use when syncing workflows or configs across multiple repos"
+    },
+    {
+      "id": "configure-plugin/configure-all",
+      "line": "configure-plugin/configure-all: Use when onboarding a new project, doing a full compliance audit,"
+    },
+    {
+      "id": "configure-plugin/configure-api-tests",
+      "line": "configure-plugin/configure-api-tests: Use when adding consumer/provider contract tests or detecting breaking API"
+    },
+    {
+      "id": "configure-plugin/configure-argocd-automerge",
+      "line": "configure-plugin/configure-argocd-automerge: Use when setting up argocd-automerge.yml or verifying PAT permissions"
+    },
+    {
+      "id": "configure-plugin/configure-cache-busting",
+      "line": "configure-plugin/configure-cache-busting: Use when adding Vercel/Cloudflare cache headers or auditing static asset"
+    },
+    {
+      "id": "configure-plugin/configure-claude-plugins",
+      "line": "configure-plugin/configure-claude-plugins: Use when onboarding to claude-plugins, setting up claude.yml, pinning plugins"
+    },
+    {
+      "id": "configure-plugin/configure-container",
+      "line": "configure-plugin/configure-container: Use when setting up multi-platform GHCR workflows or adding container scanning"
+    },
+    {
+      "id": "configure-plugin/configure-coverage",
+      "line": "configure-plugin/configure-coverage: Use when setting thresholds, adding Codecov/Coveralls, or wiring lcov/HTML"
+    },
+    {
+      "id": "configure-plugin/configure-dead-code",
+      "line": "configure-plugin/configure-dead-code: Use when setting up unused-code scanning, migrating tools, or adding dead-code"
+    },
+    {
+      "id": "configure-plugin/configure-dockerfile",
+      "line": "configure-plugin/configure-dockerfile: Use when creating a Dockerfile, hardening security, or auditing image size"
+    },
+    {
+      "id": "configure-plugin/configure-docs",
+      "line": "configure-plugin/configure-docs: Use when setting up docstrings, configuring a docs generator, or enforcing doc"
+    },
+    {
+      "id": "configure-plugin/configure-editor",
+      "line": "configure-plugin/configure-editor: Use when setting up format-on-save, recommended extensions, or debug"
+    },
+    {
+      "id": "configure-plugin/configure-feature-flags",
+      "line": "configure-plugin/configure-feature-flags: Use when setting up the SDK, configuring a relay proxy, or adding flag test"
+    },
+    {
+      "id": "configure-plugin/configure-formatting",
+      "line": "configure-plugin/configure-formatting: Use when setting up formatting, replacing Prettier, or wiring CI format checks"
+    },
+    {
+      "id": "configure-plugin/configure-gitattributes",
+      "line": "configure-plugin/configure-gitattributes: Use when setting up .gitattributes or taming append-only merge conflicts"
+    },
+    {
+      "id": "configure-plugin/configure-github-pages",
+      "line": "configure-plugin/configure-github-pages: Use when setting up Pages, migrating to actions/deploy-pages, or auditing Pages"
+    },
+    {
+      "id": "configure-plugin/configure-gitignore",
+      "line": "configure-plugin/configure-gitignore: Use when onboarding a repo or .gitignore lacks Claude entries"
+    },
+    {
+      "id": "configure-plugin/configure-instrumentation",
+      "line": "configure-plugin/configure-instrumentation: Use when wiring telemetry, tracing, or logging into a repo"
+    },
+    {
+      "id": "configure-plugin/configure-integration-tests",
+      "line": "configure-plugin/configure-integration-tests: Use when setting up integration tests, creating docker-compose.test.yml,"
+    },
+    {
+      "id": "configure-plugin/configure-justfile",
+      "line": "configure-plugin/configure-justfile: Use when setting up a Justfile, auditing for missing recipes, or migrating from"
+    },
+    {
+      "id": "configure-plugin/configure-linting",
+      "line": "configure-plugin/configure-linting: Use when setting up linting, migrating ESLint/Prettier to Biome, or wiring lint"
+    },
+    {
+      "id": "configure-plugin/configure-load-tests",
+      "line": "configure-plugin/configure-load-tests: Use when setting up load tests, auditing smoke/stress/spike/soak coverage,"
+    },
+    {
+      "id": "configure-plugin/configure-makefile",
+      "line": "configure-plugin/configure-makefile: Use when setting up a Makefile, auditing missing targets, or adding"
+    },
+    {
+      "id": "configure-plugin/configure-mcp",
+      "line": "configure-plugin/configure-mcp: Use when setting up MCP servers, checking MCP status, or adding new servers"
+    },
+    {
+      "id": "configure-plugin/configure-memory-profiling",
+      "line": "configure-plugin/configure-memory-profiling: Use when setting up memory profiling, adding CI memory regression detection,"
+    },
+    {
+      "id": "configure-plugin/configure-mise",
+      "line": "configure-plugin/configure-mise: Use when setting up, pinning runtimes/CLI tools, or migrating from"
+    },
+    {
+      "id": "configure-plugin/configure-package-management",
+      "line": "configure-plugin/configure-package-management: Use when setting up uv or bun, migrating from pip/npm/yarn/poetry/pipenv,"
+    },
+    {
+      "id": "configure-plugin/configure-pre-commit",
+      "line": "configure-plugin/configure-pre-commit: Use when installing hooks, configuring frontend/infrastructure/python project"
+    },
+    {
+      "id": "configure-plugin/configure-readme",
+      "line": "configure-plugin/configure-readme: Use when creating a README, auditing missing sections, or adding shields.io"
+    },
+    {
+      "id": "configure-plugin/configure-release-please",
+      "line": "configure-plugin/configure-release-please: Use when configuring release-please, upgrading release-please-action, or adding"
+    },
+    {
+      "id": "configure-plugin/configure-repo",
+      "line": "configure-plugin/configure-repo: Use when onboarding any repo to Claude Code with the claude-plugins marketplace"
+    },
+    {
+      "id": "configure-plugin/configure-reusable-workflows",
+      "line": "configure-plugin/configure-reusable-workflows: Use when adding OWASP/secret/code-smell scans or WCAG checks to PR pipelines"
+    },
+    {
+      "id": "configure-plugin/configure-security",
+      "line": "configure-plugin/configure-security: Use when setting up Dependabot, CodeQL, or TruffleHog in CI, or creating"
+    },
+    {
+      "id": "configure-plugin/configure-select",
+      "line": "configure-plugin/configure-select: Use when setting up specific components or building infrastructure incrementally"
+    },
+    {
+      "id": "configure-plugin/configure-sentry",
+      "line": "configure-plugin/configure-sentry: Use when installing the Sentry SDK, fixing hardcoded DSNs, or adding source map"
+    },
+    {
+      "id": "configure-plugin/configure-skaffold",
+      "line": "configure-plugin/configure-skaffold: Use when fixing 0.0.0.0 binding, adding secret generation hooks, or creating"
+    },
+    {
+      "id": "configure-plugin/configure-status",
+      "line": "configure-plugin/configure-status: Use when checking overall compliance, generating a report, or reviewing project"
+    },
+    {
+      "id": "configure-plugin/configure-surface",
+      "line": "configure-plugin/configure-surface: Use when adding a docs-governed-like-code CI gate"
+    },
+    {
+      "id": "configure-plugin/configure-tests",
+      "line": "configure-plugin/configure-tests: Use when setting up test infrastructure, migrating to a modern framework,"
+    },
+    {
+      "id": "configure-plugin/configure-ux-testing",
+      "line": "configure-plugin/configure-ux-testing: Use when setting up E2E testing, screenshot assertions, browser automation,"
+    },
+    {
+      "id": "configure-plugin/configure-web-session",
+      "line": "configure-plugin/configure-web-session: Use when CI tools fail in remote sessions due to missing binaries"
+    },
+    {
+      "id": "configure-plugin/configure-workflows",
+      "line": "configure-plugin/configure-workflows: Use when updating outdated action versions, adding multi-platform builds,"
+    },
+    {
+      "id": "configure-plugin/configure-worktreeinclude",
+      "line": "configure-plugin/configure-worktreeinclude: Use when worktrees miss .env or local config"
+    },
+    {
+      "id": "configure-plugin/go-feature-flag",
+      "line": "configure-plugin/go-feature-flag: Use when working with GOFF or flags.goff.yaml"
+    },
+    {
+      "id": "configure-plugin/multi-repo-discipline",
+      "line": "configure-plugin/multi-repo-discipline: Use when dispatching agents across sibling repos or editing another repo's"
+    },
+    {
+      "id": "configure-plugin/openfeature",
+      "line": "configure-plugin/openfeature: Use when implementing feature flags, A/B testing, or progressive rollouts"
+    },
+    {
+      "id": "container-plugin/container-development",
+      "line": "container-plugin/container-development: Use when working with Docker, Dockerfiles, docker-compose, or container"
+    },
+    {
+      "id": "container-plugin/deploy-handoff",
+      "line": "container-plugin/deploy-handoff: Use when handing off a service, documenting deployments, or creating"
+    },
+    {
+      "id": "container-plugin/deploy-release",
+      "line": "container-plugin/deploy-release: Use when cutting a release, tagging a version, or setting up release-please"
+    },
+    {
+      "id": "container-plugin/go-containers",
+      "line": "container-plugin/go-containers: Use when working with Go containers or optimizing Go image sizes"
+    },
+    {
+      "id": "container-plugin/nodejs-containers",
+      "line": "container-plugin/nodejs-containers: Use when working with Node.js containers or optimizing image sizes"
+    },
+    {
+      "id": "container-plugin/python-containers",
+      "line": "container-plugin/python-containers: Use when working with Python containers or optimizing image sizes"
+    },
+    {
+      "id": "container-plugin/skaffold-filesync",
+      "line": "container-plugin/skaffold-filesync: Use when optimizing the dev loop, configuring sync rules, or the user mentions"
+    },
+    {
+      "id": "container-plugin/skaffold-orbstack",
+      "line": "container-plugin/skaffold-orbstack: Use when configuring Skaffold with OrbStack, k8s.orb.local, LoadBalancer,"
+    },
+    {
+      "id": "container-plugin/skaffold-testing",
+      "line": "container-plugin/skaffold-testing: Use when configuring pre-deploy tests or integration tests in Skaffold"
+    },
+    {
+      "id": "css-plugin/lightning-css",
+      "line": "css-plugin/lightning-css: Use when configuring CSS in Vite, replacing PostCSS/autoprefixer, setting"
+    },
+    {
+      "id": "css-plugin/unocss",
+      "line": "css-plugin/unocss: Use when setting up utility-first CSS, configuring presets (wind3/wind4, icons"
+    },
+    {
+      "id": "documentation-plugin/claude-blog-sources",
+      "line": "documentation-plugin/claude-blog-sources: Use when researching Claude Code capabilities, CLAUDE.md optimization, memory"
+    },
+    {
+      "id": "documentation-plugin/docs-decommission",
+      "line": "documentation-plugin/docs-decommission: Use when decommissioning a service"
+    },
+    {
+      "id": "documentation-plugin/docs-generate",
+      "line": "documentation-plugin/docs-generate: Use when wanting API reference, README from code, or CHANGELOG from conventional"
+    },
+    {
+      "id": "documentation-plugin/docs-latex",
+      "line": "documentation-plugin/docs-latex: Use when wanting a presentation-quality PDF, a professional report"
+    },
+    {
+      "id": "documentation-plugin/docs-sync",
+      "line": "documentation-plugin/docs-sync: Use when docs are out of sync, updating the skill catalog, or regenerating"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-improve",
+      "line": "evaluate-plugin/evaluate-improve: Use when raising pass rates, fixing triggering, or iterating on a skill after"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-legibility",
+      "line": "evaluate-plugin/evaluate-legibility: Use when validating whether a skill says clearly when to invoke it and how"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-matrix",
+      "line": "evaluate-plugin/evaluate-matrix: Use when checking whether a weak model can actually do a skill, not just"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-plugin-batch",
+      "line": "evaluate-plugin/evaluate-plugin-batch: Use when auditing an entire plugin's quality or validating before a release"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-report",
+      "line": "evaluate-plugin/evaluate-report: Use when reviewing past eval results, comparing benchmark runs, or tracking"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-skill",
+      "line": "evaluate-plugin/evaluate-skill: Use when testing whether a skill produces correct guidance, validating"
+    },
+    {
+      "id": "feedback-plugin/feedback-session",
+      "line": "feedback-plugin/feedback-session: Use when a skill gave wrong guidance, a command failed, you found a better"
+    },
+    {
+      "id": "finops-plugin/finops-caches",
+      "line": "finops-plugin/finops-caches: Use when investigating cache bloat, stale caches, or auditing cache key"
+    },
+    {
+      "id": "finops-plugin/finops-compare",
+      "line": "finops-plugin/finops-compare: Use when benchmarking repos, identifying worst-performing ones, or doing"
+    },
+    {
+      "id": "finops-plugin/finops-overview",
+      "line": "finops-plugin/finops-overview: Use when you want a high-level view of CI spending or workflow health before"
+    },
+    {
+      "id": "finops-plugin/finops-waste",
+      "line": "finops-plugin/finops-waste: Use when CI costs are high or workflows run too often"
+    },
+    {
+      "id": "finops-plugin/finops-workflows",
+      "line": "finops-plugin/finops-workflows: Use when investigating slow CI, high failure rates, or run patterns over time"
+    },
+    {
+      "id": "finops-plugin/github-actions-cache-optimization",
+      "line": "finops-plugin/github-actions-cache-optimization: Use when investigating cache bloat, finding stale caches, optimizing keys,"
+    },
+    {
+      "id": "finops-plugin/github-actions-finops",
+      "line": "finops-plugin/github-actions-finops: Use when investigating CI/CD costs, wasted runs, or optimizing triggers"
+    },
+    {
+      "id": "foundryvtt-plugin/foundryvtt-module",
+      "line": "foundryvtt-plugin/foundryvtt-module: Use when releasing or spinning up a new foundry module"
+    },
+    {
+      "id": "foundryvtt-plugin/foundryvtt-module-scaffold",
+      "line": "foundryvtt-plugin/foundryvtt-module-scaffold: Use when bootstrapping or init-ing a foundry module"
+    },
+    {
+      "id": "git-plugin/deadbranch",
+      "line": "git-plugin/deadbranch: Use when asked to clean up branches, prune branches, or remove stale branches"
+    },
+    {
+      "id": "git-plugin/gh-cli-agentic",
+      "line": "git-plugin/gh-cli-agentic: Use when querying PRs, issues, workflow runs, or repo metadata; inspecting PR"
+    },
+    {
+      "id": "git-plugin/gh-workflow-monitoring",
+      "line": "git-plugin/gh-workflow-monitoring: Use when waiting for CI after push, following a workflow to completion,"
+    },
+    {
+      "id": "git-plugin/git-api-pr",
+      "line": "git-plugin/git-api-pr: Use when submitting file changes as a PR without local commits \u2014 quick fixes"
+    },
+    {
+      "id": "git-plugin/git-branch-naming",
+      "line": "git-plugin/git-branch-naming: Use when creating branches or setting up repo conventions"
+    },
+    {
+      "id": "git-plugin/git-branch-pr-workflow",
+      "line": "git-plugin/git-branch-pr-workflow: Use when creating branches, opening PRs, or working with feature branches"
+    },
+    {
+      "id": "git-plugin/git-cli-agentic",
+      "line": "git-plugin/git-cli-agentic: Use when scripting status/diff/log, porcelain=v2, --numstat counts, custom"
+    },
+    {
+      "id": "git-plugin/git-commit",
+      "line": "git-plugin/git-commit: Use when user says \"commit\", \"save changes\", or \"stage and commit\". Local"
+    },
+    {
+      "id": "git-plugin/git-commit-push-pr",
+      "line": "git-plugin/git-commit-push-pr: Use when the user says \"create pr\", \"commit and pr\", \"push and pr\", or wants"
+    },
+    {
+      "id": "git-plugin/git-commit-trailers",
+      "line": "git-plugin/git-commit-trailers: Use when composing messages with trailers or parsing via git interpret-trailers"
+    },
+    {
+      "id": "git-plugin/git-commit-workflow",
+      "line": "git-plugin/git-commit-workflow: Use when writing commit messages, staging files, grouping changes,"
+    },
+    {
+      "id": "git-plugin/git-conflicts",
+      "line": "git-plugin/git-conflicts: Use when a merge/rebase has conflicts, a PR can't merge, \"fix conflicts\" is"
+    },
+    {
+      "id": "git-plugin/git-coworker-check",
+      "line": "git-plugin/git-coworker-check: Use when starting a session in a shared clone, before destructive git ops"
+    },
+    {
+      "id": "git-plugin/git-derive-docs",
+      "line": "git-plugin/git-derive-docs: Use when finding doc gaps, detecting unrecorded decisions, deriving conventions"
+    },
+    {
+      "id": "git-plugin/git-fix-pr",
+      "line": "git-plugin/git-fix-pr: Use when asked to fix a PR, resolve red CI checks, auto-fix lint/test failures"
+    },
+    {
+      "id": "git-plugin/git-fork-workflow",
+      "line": "git-plugin/git-fork-workflow: Use when working with forks, syncing with upstream, detecting divergence,"
+    },
+    {
+      "id": "git-plugin/git-issue",
+      "line": "git-plugin/git-issue: Use when asked to work on an issue, fix issue #N, pick issues to tackle,"
+    },
+    {
+      "id": "git-plugin/git-issue-hierarchy",
+      "line": "git-plugin/git-issue-hierarchy: Use when breaking issues into sub-tasks, checking progress, or viewing"
+    },
+    {
+      "id": "git-plugin/git-issue-manage",
+      "line": "git-plugin/git-issue-manage: Use when transferring issues, pinning, locking discussions, creating dev"
+    },
+    {
+      "id": "git-plugin/git-maintain",
+      "line": "git-plugin/git-maintain: Use when asked to clean up the repo, run git maintenance/gc, delete merged"
+    },
+    {
+      "id": "git-plugin/git-pr",
+      "line": "git-plugin/git-pr: Use when user says \"create PR\", \"open pull request\", or \"submit for review\""
+    },
+    {
+      "id": "git-plugin/git-pr-feedback",
+      "line": "git-plugin/git-pr-feedback: Use when CHANGES_REQUESTED is set, working through unresolved review threads,"
+    },
+    {
+      "id": "git-plugin/git-pr-sync-check",
+      "line": "git-plugin/git-pr-sync-check: Use when continuing work on a PR branch before adding commits"
+    },
+    {
+      "id": "git-plugin/git-pr-watch",
+      "line": "git-plugin/git-pr-watch: Use when watching/monitoring/babysitting a PR after opening it, or unsubscribing"
+    },
+    {
+      "id": "git-plugin/git-push",
+      "line": "git-plugin/git-push: Use when user says \"push\", \"send to remote\", or \"update remote\". Pushes existing"
+    },
+    {
+      "id": "git-plugin/git-rebase-patterns",
+      "line": "git-plugin/git-rebase-patterns: Use when rebasing branches, cleaning history, managing PR stacks, or fixing"
+    },
+    {
+      "id": "git-plugin/git-repo-detection",
+      "line": "git-plugin/git-repo-detection: Use when needing the owner/repo identifier for GitHub CLI or API calls"
+    },
+    {
+      "id": "git-plugin/git-security-checks",
+      "line": "git-plugin/git-security-checks: Use when scanning for secrets, setting up gitleaks, or configuring"
+    },
+    {
+      "id": "git-plugin/git-triage",
+      "line": "git-plugin/git-triage: Use when grooming the backlog, pre-release cleanup, or asked to triage"
+    },
+    {
+      "id": "git-plugin/git-upstream-pr",
+      "line": "git-plugin/git-upstream-pr: Use when contributing changes upstream or cherry-picking fork commits"
+    },
+    {
+      "id": "git-plugin/git-upstream-pr-diverged",
+      "line": "git-plugin/git-upstream-pr-diverged: Use when direct rebase fails"
+    },
+    {
+      "id": "git-plugin/github-issue-autodetect",
+      "line": "git-plugin/github-issue-autodetect: Use when committing to ensure proper issue linkage"
+    },
+    {
+      "id": "git-plugin/github-issue-writing",
+      "line": "git-plugin/github-issue-writing: Use when filing bugs, requesting features, or structuring issue content"
+    },
+    {
+      "id": "git-plugin/github-labels",
+      "line": "git-plugin/github-labels: Use when asked to label a PR/issue, list available labels, or create new labels"
+    },
+    {
+      "id": "git-plugin/github-pr-title",
+      "line": "git-plugin/github-pr-title: Use when creating PRs or ensuring consistent PR naming. PR titles MUST follow"
+    },
+    {
+      "id": "git-plugin/release-please-configuration",
+      "line": "git-plugin/release-please-configuration: Use when adding packages or fixing duplicate-tag / no-bump failures"
+    },
+    {
+      "id": "git-plugin/release-please-pr-workflow",
+      "line": "git-plugin/release-please-pr-workflow: Use when merging release PRs, handling PR conflicts, or managing release"
+    },
+    {
+      "id": "git-plugin/release-please-protection",
+      "line": "git-plugin/release-please-protection: Use when editing changelogs, bumping versions, or releasing to avoid conflicting"
+    },
+    {
+      "id": "github-actions-plugin/claude-code-github-workflows",
+      "line": "github-actions-plugin/claude-code-github-workflows: Use when creating or modifying workflows that integrate Claude Code"
+    },
+    {
+      "id": "github-actions-plugin/github-actions-auth-security",
+      "line": "github-actions-plugin/github-actions-auth-security: Use when setting up workflow authentication or security"
+    },
+    {
+      "id": "github-actions-plugin/github-actions-inspection",
+      "line": "github-actions-plugin/github-actions-inspection: Use when investigating CI/CD failures, checking workflow status, or debugging"
+    },
+    {
+      "id": "github-actions-plugin/github-actions-mcp-config",
+      "line": "github-actions-plugin/github-actions-mcp-config: Use when configuring MCP servers in GitHub Actions workflows"
+    },
+    {
+      "id": "github-actions-plugin/github-issue-search",
+      "line": "github-actions-plugin/github-issue-search: Use when encountering errors with OSS libraries, finding upstream bug"
+    },
+    {
+      "id": "github-actions-plugin/github-social-preview",
+      "line": "github-actions-plugin/github-social-preview: Use when asked for social preview, Open Graph image, or repo images for social"
+    },
+    {
+      "id": "github-actions-plugin/github-workflow-auto-fix",
+      "line": "github-actions-plugin/github-workflow-auto-fix: Use when adding a workflow that analyzes failures, applies fixes, and files"
+    },
+    {
+      "id": "github-actions-plugin/workflow-dev",
+      "line": "github-actions-plugin/workflow-dev: Use when running a continuous dev loop, autonomous TDD, or fix-and-PR cycles"
+    },
+    {
+      "id": "health-plugin/health-agentic-audit",
+      "line": "health-plugin/health-agentic-audit: Use when batch-checking skill documentation quality"
+    },
+    {
+      "id": "health-plugin/health-audit",
+      "line": "health-plugin/health-audit: Use when cleaning up unused plugins or discovering stack-relevant ones"
+    },
+    {
+      "id": "health-plugin/health-check",
+      "line": "health-plugin/health-check: Use when checking project health or troubleshooting setup"
+    },
+    {
+      "id": "health-plugin/health-plugins",
+      "line": "health-plugin/health-plugins: Use when seeing plugin-already-installed errors or registry drift"
+    },
+    {
+      "id": "health-plugin/health-skill-audit",
+      "line": "health-plugin/health-skill-audit: Use when finding confusing skill clusters or surfacing REFERENCE.md extraction"
+    },
+    {
+      "id": "health-plugin/plugin-registry",
+      "line": "health-plugin/plugin-registry: Use when troubleshooting plugin installation problems or manually fixing"
+    },
+    {
+      "id": "health-plugin/settings-configuration",
+      "line": "health-plugin/settings-configuration: Use when setting up permissions, debugging settings issues, or understanding"
+    },
+    {
+      "id": "home-assistant-plugin/ha-automations",
+      "line": "home-assistant-plugin/ha-automations: Use when working with HA triggers, conditions, actions, scripts, scenes,"
+    },
+    {
+      "id": "home-assistant-plugin/ha-configuration",
+      "line": "home-assistant-plugin/ha-configuration: Use when editing configuration.yaml, setting up integrations, configuring"
+    },
+    {
+      "id": "home-assistant-plugin/ha-entities",
+      "line": "home-assistant-plugin/ha-entities: Use when working with entity IDs, device classes, template entities, groups,"
+    },
+    {
+      "id": "home-assistant-plugin/ha-validate",
+      "line": "home-assistant-plugin/ha-validate: Use when validating HA config, diagnosing YAML errors, or running hass"
+    },
+    {
+      "id": "hooks-plugin/hooks-configuration",
+      "line": "hooks-plugin/hooks-configuration: Use when the user mentions hooks, PreToolUse, PostToolUse, SessionStart"
+    },
+    {
+      "id": "hooks-plugin/hooks-permission-request-hook",
+      "line": "hooks-plugin/hooks-permission-request-hook: Use when needing a safer alternative to --dangerouslySkipPermissions tailored"
+    },
+    {
+      "id": "hooks-plugin/hooks-session-end-issue-hook",
+      "line": "hooks-plugin/hooks-session-end-issue-hook: Use when you want deferred work automatically flagged for GitHub issue creation"
+    },
+    {
+      "id": "hooks-plugin/hooks-session-start-hook",
+      "line": "hooks-plugin/hooks-session-start-hook: Use when setting up a repo so dependencies install and tests/linters run"
+    },
+    {
+      "id": "kubernetes-plugin/argocd-login",
+      "line": "kubernetes-plugin/argocd-login: Use when the user mentions ArgoCD login, argocd authentication, SSO auth,"
+    },
+    {
+      "id": "kubernetes-plugin/helm-chart-development",
+      "line": "kubernetes-plugin/helm-chart-development: Use when the user mentions Helm charts, helm lint/template/package,"
+    },
+    {
+      "id": "kubernetes-plugin/helm-debugging",
+      "line": "kubernetes-plugin/helm-debugging: Use when the user mentions Helm errors or template rendering issues"
+    },
+    {
+      "id": "kubernetes-plugin/helm-release-management",
+      "line": "kubernetes-plugin/helm-release-management: Use when the user mentions deploying Helm charts, upgrading releases,"
+    },
+    {
+      "id": "kubernetes-plugin/helm-release-recovery",
+      "line": "kubernetes-plugin/helm-release-recovery: Use when the user mentions rollback, failed Helm upgrade, or stuck releases"
+    },
+    {
+      "id": "kubernetes-plugin/helm-values-management",
+      "line": "kubernetes-plugin/helm-values-management: Use when the user mentions Helm values, env-specific configs, or values.yaml"
+    },
+    {
+      "id": "kubernetes-plugin/kubectl-debugging",
+      "line": "kubernetes-plugin/kubectl-debugging: Use when the user mentions kubectl debug or debugging pods"
+    },
+    {
+      "id": "kubernetes-plugin/kubernetes-operations",
+      "line": "kubernetes-plugin/kubernetes-operations: Use when the user mentions K8s, kubectl, pods, deployments, services, ingress"
+    },
+    {
+      "id": "langchain-plugin/deep-agents",
+      "line": "langchain-plugin/deep-agents: Use when creating orchestrators that plan multi-step tasks, delegate to child"
+    },
+    {
+      "id": "langchain-plugin/langchain-development",
+      "line": "langchain-plugin/langchain-development: Use when working with chat models, prompt templates, LCEL chains, tool binding"
+    },
+    {
+      "id": "langchain-plugin/langchain-init",
+      "line": "langchain-plugin/langchain-init: Use when starting an LLM-powered app, scaffolding an AI agent project,"
+    },
+    {
+      "id": "langchain-plugin/langgraph-agents",
+      "line": "langchain-plugin/langgraph-agents: Use when creating state-machine agents with checkpoints, human-in-the-loop"
+    },
+    {
+      "id": "macos-plugin/endpoint-security-cpu",
+      "line": "macos-plugin/endpoint-security-cpu: Use when Kandji ESF / XProtect pegs a core; trace the exec storm via"
+    },
+    {
+      "id": "macos-plugin/kitty-session-persistence",
+      "line": "macos-plugin/kitty-session-persistence: Use when surviving WindowServer hangs without losing tabs, configuring"
+    },
+    {
+      "id": "macos-plugin/launchservices-health",
+      "line": "macos-plugin/launchservices-health: Use when launchservicesd is pegged at high CPU or WindowServer XPC stalls are"
+    },
+    {
+      "id": "macos-plugin/macos-disk-usage",
+      "line": "macos-plugin/macos-disk-usage: Use when df reports a disk near-full, hunting what's eating space, reclaiming"
+    },
+    {
+      "id": "macos-plugin/macos-incident-postmortem",
+      "line": "macos-plugin/macos-incident-postmortem: Use when investigating hangs, panics, watchdog timeouts, jetsam, or thermal"
+    },
+    {
+      "id": "macos-plugin/macos-performance-benchmark",
+      "line": "macos-plugin/macos-performance-benchmark: Use when baselining a Mac, verifying it performs to spec, or tracking"
+    },
+    {
+      "id": "macos-plugin/macos-performance-triage",
+      "line": "macos-plugin/macos-performance-triage: Use when fans spin up, the Mac is hot/slow, or WindowServer/an app shows high"
+    },
+    {
+      "id": "macos-plugin/tui-keybinding-debug",
+      "line": "macos-plugin/tui-keybinding-debug: Use when a configured key does nothing in a TUI, fzf, or shell app"
+    },
+    {
+      "id": "migration-patterns-plugin/black-to-ruff-format",
+      "line": "migration-patterns-plugin/black-to-ruff-format: Use when psf/black is in .pre-commit-config.yaml or [tool.black] exists"
+    },
+    {
+      "id": "migration-patterns-plugin/dual-write",
+      "line": "migration-patterns-plugin/dual-write: Use when planning DB migrations, switching storage backends, or reviewing code"
+    },
+    {
+      "id": "migration-patterns-plugin/eslint-to-biome",
+      "line": "migration-patterns-plugin/eslint-to-biome: Use when .eslintrc* or eslint.config.* exists and no biome.json is present"
+    },
+    {
+      "id": "migration-patterns-plugin/flake8-to-ruff",
+      "line": "migration-patterns-plugin/flake8-to-ruff: Use when pycqa/flake8 or PyCQA/isort is in .pre-commit-config.yaml"
+    },
+    {
+      "id": "migration-patterns-plugin/mypy-to-ty",
+      "line": "migration-patterns-plugin/mypy-to-ty: Use when mirrors-mypy is in .pre-commit-config.yaml or [tool.mypy] config"
+    },
+    {
+      "id": "migration-patterns-plugin/shadow-mode",
+      "line": "migration-patterns-plugin/shadow-mode: Use when testing replacement services, comparing behavior, or planning traffic"
+    },
+    {
+      "id": "networking-plugin/dns-tools",
+      "line": "networking-plugin/dns-tools: Use when looking up A/AAAA/MX/TXT records, verifying DNS changes across"
+    },
+    {
+      "id": "networking-plugin/http-load-testing",
+      "line": "networking-plugin/http-load-testing: Use when measuring latency percentiles, finding a server's breaking point,"
+    },
+    {
+      "id": "networking-plugin/interface-state",
+      "line": "networking-plugin/interface-state: Use when viewing or configuring a host's own IPs, links, routes, or ARP/NDP"
+    },
+    {
+      "id": "networking-plugin/layer2-discovery",
+      "line": "networking-plugin/layer2-discovery: Use when finding switch port assignments, enumerating hosts via ARP,"
+    },
+    {
+      "id": "networking-plugin/network-diagnostics",
+      "line": "networking-plugin/network-diagnostics: Use when tracing routes, comparing ping latency across endpoints, or inspecting"
+    },
+    {
+      "id": "networking-plugin/network-discovery",
+      "line": "networking-plugin/network-discovery: Use when scanning TCP ports, enumerating hosts on a subnet, or identifying"
+    },
+    {
+      "id": "networking-plugin/network-monitoring",
+      "line": "networking-plugin/network-monitoring: Use when finding which app consumes bandwidth, inspecting active connections,"
+    },
+    {
+      "id": "obsidian-plugin/bases",
+      "line": "obsidian-plugin/bases: Use when user mentions Bases or .base files"
+    },
+    {
+      "id": "obsidian-plugin/bookmarks",
+      "line": "obsidian-plugin/bookmarks: Use when starring or saving notes for quick access"
+    },
+    {
+      "id": "obsidian-plugin/command-palette",
+      "line": "obsidian-plugin/command-palette: Use when triggering a command, enumerating commands, or checking hotkey"
+    },
+    {
+      "id": "obsidian-plugin/dev-tools",
+      "line": "obsidian-plugin/dev-tools: Use when debugging the app"
+    },
+    {
+      "id": "obsidian-plugin/file-history",
+      "line": "obsidian-plugin/file-history: Use when undoing edits, restoring versions, or recovering files"
+    },
+    {
+      "id": "obsidian-plugin/plugins-themes",
+      "line": "obsidian-plugin/plugins-themes: Use when installing, enabling, switching theme, or toggling restricted mode"
+    },
+    {
+      "id": "obsidian-plugin/properties",
+      "line": "obsidian-plugin/properties: Use when user mentions frontmatter, metadata, tags, aliases, status, or dates"
+    },
+    {
+      "id": "obsidian-plugin/publish-sync",
+      "line": "obsidian-plugin/publish-sync: Use when publishing notes, managing change sets, pausing/resuming sync,"
+    },
+    {
+      "id": "obsidian-plugin/search-discovery",
+      "line": "obsidian-plugin/search-discovery: Use when exploring backlinks"
+    },
+    {
+      "id": "obsidian-plugin/tasks",
+      "line": "obsidian-plugin/tasks: Use when user mentions Obsidian tasks, todos, checklists, or completion"
+    },
+    {
+      "id": "obsidian-plugin/templates",
+      "line": "obsidian-plugin/templates: Use when inserting or applying a template"
+    },
+    {
+      "id": "obsidian-plugin/vault-files",
+      "line": "obsidian-plugin/vault-files: Use when managing vault files"
+    },
+    {
+      "id": "obsidian-plugin/vault-frontmatter",
+      "line": "obsidian-plugin/vault-frontmatter: Use when stripping legacy `id:`, cleaning Templater markers, or fixing bare"
+    },
+    {
+      "id": "obsidian-plugin/vault-management",
+      "line": "obsidian-plugin/vault-management: Use when checking vault info (path, size, file count) or targeting a non-active"
+    },
+    {
+      "id": "obsidian-plugin/vault-mocs",
+      "line": "obsidian-plugin/vault-mocs: Use when creating a MOC for a tag, extending with orphans, fixing legacy MOC"
+    },
+    {
+      "id": "obsidian-plugin/vault-orphans",
+      "line": "obsidian-plugin/vault-orphans: Use when finding orphans, linking them into a MOC, or reconnecting Zettelkasten"
+    },
+    {
+      "id": "obsidian-plugin/vault-stubs",
+      "line": "obsidian-plugin/vault-stubs: Use when cleaning stubs, converting duplicates to redirects, or merging content"
+    },
+    {
+      "id": "obsidian-plugin/vault-tags",
+      "line": "obsidian-plugin/vault-tags: Use when consolidating drifted tags, collapsing bare emoji placeholders,"
+    },
+    {
+      "id": "obsidian-plugin/vault-templates",
+      "line": "obsidian-plugin/vault-templates: Use when fixing unrendered `<% tp.file.cursor() %>` markers or replacing"
+    },
+    {
+      "id": "obsidian-plugin/vault-wikilinks",
+      "line": "obsidian-plugin/vault-wikilinks: Use when fixing `[[Target]]` links, rewriting renamed-note refs, or resolving"
+    },
+    {
+      "id": "obsidian-plugin/workspaces",
+      "line": "obsidian-plugin/workspaces: Use when checking what's open, switching layouts, or opening files into tabs"
+    },
+    {
+      "id": "project-plugin/changelog-review",
+      "line": "project-plugin/changelog-review: Use when checking new features, breaking changes, or upgrade opportunities from"
+    },
+    {
+      "id": "project-plugin/project-continue",
+      "line": "project-plugin/project-continue: Use when the user asks to continue work, pick up where we left off, find"
+    },
+    {
+      "id": "project-plugin/project-discovery",
+      "line": "project-plugin/project-discovery: Use when entering a new project, exploring unknown repos, or working on shaky"
+    },
+    {
+      "id": "project-plugin/project-init",
+      "line": "project-plugin/project-init: Use when starting a new project, initializing a repo, or bootstrapping"
+    },
+    {
+      "id": "project-plugin/project-refocus",
+      "line": "project-plugin/project-refocus: Use when context grew, completed steps muddy it, or you want to clear context"
+    },
+    {
+      "id": "project-plugin/project-skill-scripts",
+      "line": "project-plugin/project-skill-scripts: Use when auditing skills for script opportunities, improving token efficiency"
+    },
+    {
+      "id": "project-plugin/project-test-loop",
+      "line": "project-plugin/project-test-loop: Use when looping on failing tests, running a TDD cycle, or driving"
+    },
+    {
+      "id": "prompt-engineering-plugin/prompt-engineering-ground-response",
+      "line": "prompt-engineering-plugin/prompt-engineering-ground-response: Use when analyzing long docs, answering codebase/spec questions, or when"
+    },
+    {
+      "id": "prose-plugin/prose-distill",
+      "line": "prose-plugin/prose-distill: Use when asked to condense, tighten, shorten, reduce verbosity, or omit needless"
+    },
+    {
+      "id": "prose-plugin/prose-synthesize",
+      "line": "prose-plugin/prose-synthesize: Use when given brain dumps, stream-of-consciousness, or scattered thoughts"
+    },
+    {
+      "id": "python-plugin/basedpyright-type-checking",
+      "line": "python-plugin/basedpyright-type-checking: Use when setting up type checking, configuring LSP, or comparing type checkers"
+    },
+    {
+      "id": "python-plugin/pytest-advanced",
+      "line": "python-plugin/pytest-advanced: Use when implementing test infrastructure, writing fixtures, or running"
+    },
+    {
+      "id": "python-plugin/python-code-quality",
+      "line": "python-plugin/python-code-quality: Use when the user mentions ruff, ty, linting, formatting, type checking,"
+    },
+    {
+      "id": "python-plugin/python-development",
+      "line": "python-plugin/python-development: Use when mentioning Python, type hints, or async. For scripts see uv-run;"
+    },
+    {
+      "id": "python-plugin/python-packaging",
+      "line": "python-plugin/python-packaging: Use when the user mentions building packages, publishing to PyPI, wheel/sdist"
+    },
+    {
+      "id": "python-plugin/python-testing",
+      "line": "python-plugin/python-testing: Use when the user mentions pytest, unit tests, coverage, fixtures, mocking,"
+    },
+    {
+      "id": "python-plugin/ruff-formatting",
+      "line": "python-plugin/ruff-formatting: Use when formatting Python files, enforcing style, or checking format"
+    },
+    {
+      "id": "python-plugin/ruff-linting",
+      "line": "python-plugin/ruff-linting: Use when checking Python code quality, enforcing standards, or finding bugs"
+    },
+    {
+      "id": "python-plugin/ty-type-checking",
+      "line": "python-plugin/ty-type-checking: Use when checking Python types or setting up type checking. Triggers: ty, mypy"
+    },
+    {
+      "id": "python-plugin/uv-advanced-dependencies",
+      "line": "python-plugin/uv-advanced-dependencies: Use when the user mentions git+https deps, editable installs, or private"
+    },
+    {
+      "id": "python-plugin/uv-project-management",
+      "line": "python-plugin/uv-project-management: Use when the user mentions uv, creating Python projects, managing dependencies"
+    },
+    {
+      "id": "python-plugin/uv-python-versions",
+      "line": "python-plugin/uv-python-versions: Use when the user mentions installing Python versions, .python-version, uv"
+    },
+    {
+      "id": "python-plugin/uv-run",
+      "line": "python-plugin/uv-run: Use when running scripts without venv activation or needing one-off"
+    },
+    {
+      "id": "python-plugin/uv-tool-management",
+      "line": "python-plugin/uv-tool-management: Use when the user mentions uv tool, uvx, installing CLI tools globally, or pipx"
+    },
+    {
+      "id": "python-plugin/uv-workspaces",
+      "line": "python-plugin/uv-workspaces: Use when the user mentions uv workspaces, Python monorepo, shared lockfiles,"
+    },
+    {
+      "id": "python-plugin/vulture-dead-code",
+      "line": "python-plugin/vulture-dead-code: Use when cleaning up codebases or removing dead code. Triggers vulture"
+    },
+    {
+      "id": "rust-plugin/cargo-llvm-cov",
+      "line": "rust-plugin/cargo-llvm-cov: Use when measuring coverage, enforcing thresholds, generating reports,"
+    },
+    {
+      "id": "rust-plugin/cargo-machete",
+      "line": "rust-plugin/cargo-machete: Use when auditing Cargo.toml, optimizing build times, or cleaning up dependency"
+    },
+    {
+      "id": "rust-plugin/cargo-nextest",
+      "line": "rust-plugin/cargo-nextest: Use when running tests, setting up CI, or diagnosing flaky/slow tests"
+    },
+    {
+      "id": "rust-plugin/cargo-worktree-builds",
+      "line": "rust-plugin/cargo-worktree-builds: Use when running cargo/clippy/test in several worktrees concurrently, when"
+    },
+    {
+      "id": "rust-plugin/clippy-advanced",
+      "line": "rust-plugin/clippy-advanced: Use when configuring or enforcing lint standards"
+    },
+    {
+      "id": "rust-plugin/mockito-http-mocking",
+      "line": "rust-plugin/mockito-http-mocking: Use when mocking an HTTP API in Rust tests, when a wait-until-matched loop"
+    },
+    {
+      "id": "rust-plugin/rust-development",
+      "line": "rust-plugin/rust-development: Use when mentioning Rust, cargo, ownership, lifetimes, fearless concurrency,"
+    },
+    {
+      "id": "session-plugin/session-distill",
+      "line": "session-plugin/session-distill: Use when capturing learnings, codifying workflow into .claude/rules,"
+    },
+    {
+      "id": "session-plugin/session-end",
+      "line": "session-plugin/session-end: Use when winding down a session"
+    },
+    {
+      "id": "session-plugin/session-spinup",
+      "line": "session-plugin/session-spinup: Use when user says spin up, what was I doing, or pick up where I left off"
+    },
+    {
+      "id": "session-plugin/session-wrap",
+      "line": "session-plugin/session-wrap: Use when user says wrap up, session wrap, or done for now"
+    },
+    {
+      "id": "software-design-plugin/design-by-contract",
+      "line": "software-design-plugin/design-by-contract: Use when designing a function/class, hardening a boundary, or adding assertions"
+    },
+    {
+      "id": "software-design-plugin/design-deep-modules",
+      "line": "software-design-plugin/design-deep-modules: Use when designing a module/API, reviewing a class boundary, or reducing"
+    },
+    {
+      "id": "software-design-plugin/design-legacy-seams",
+      "line": "software-design-plugin/design-legacy-seams: Use when changing untested code, breaking dependencies, or taming legacy"
+    },
+    {
+      "id": "software-design-plugin/design-patterns",
+      "line": "software-design-plugin/design-patterns: Use when a structure resists change, or choosing between Gang-of-Four patterns"
+    },
+    {
+      "id": "software-design-plugin/design-pseudocode",
+      "line": "software-design-plugin/design-pseudocode: Use when designing a complex function or non-trivial algorithm"
+    },
+    {
+      "id": "taskwarrior-plugin/install-native-hooks",
+      "line": "taskwarrior-plugin/install-native-hooks: Use when hardening a local taskwarrior store"
+    },
+    {
+      "id": "taskwarrior-plugin/task-add",
+      "line": "taskwarrior-plugin/task-add: Use when adding coordination tasks, linking a blueprint WO, or mirroring"
+    },
+    {
+      "id": "taskwarrior-plugin/task-bulk-ops",
+      "line": "taskwarrior-plugin/task-bulk-ops: Use when closing/triaging/modifying many tasks in one pass, bulk `task done`"
+    },
+    {
+      "id": "taskwarrior-plugin/task-claim",
+      "line": "taskwarrior-plugin/task-claim: Use when picking up a task from task-coordinate output before starting"
+    },
+    {
+      "id": "taskwarrior-plugin/task-coordinate",
+      "line": "taskwarrior-plugin/task-coordinate: Use when planning a parallel-agent wave or choosing tasks for a dispatch slot"
+    },
+    {
+      "id": "taskwarrior-plugin/task-done",
+      "line": "taskwarrior-plugin/task-done: Use when finishing a coordination task or marking a work order complete"
+    },
+    {
+      "id": "taskwarrior-plugin/task-reconcile",
+      "line": "taskwarrior-plugin/task-reconcile: Use when stale trackers pile up, after a PR-merge sweep, or auditing queue"
+    },
+    {
+      "id": "taskwarrior-plugin/task-release",
+      "line": "taskwarrior-plugin/task-release: Use when pausing mid-task, handing off to another agent, or aborting cleanly"
+    },
+    {
+      "id": "taskwarrior-plugin/task-status",
+      "line": "taskwarrior-plugin/task-status: Use when auditing queue health, orienting before a wave, or for standup"
+    },
+    {
+      "id": "terraform-plugin/infrastructure-terraform",
+      "line": "terraform-plugin/infrastructure-terraform: Use when the user mentions Terraform, HCL, terraform plan/apply, tfstate, or IaC"
+    },
+    {
+      "id": "terraform-plugin/tfc-list-runs",
+      "line": "terraform-plugin/tfc-list-runs: Use when reviewing run history, finding failed runs, or auditing infra changes"
+    },
+    {
+      "id": "terraform-plugin/tfc-plan-json",
+      "line": "terraform-plugin/tfc-plan-json: Use when diffing resource changes, inspecting replacements, or feeding plan data"
+    },
+    {
+      "id": "terraform-plugin/tfc-run-logs",
+      "line": "terraform-plugin/tfc-run-logs: Use when debugging failed plans/applies or reviewing TFC run output. Requires"
+    },
+    {
+      "id": "terraform-plugin/tfc-run-status",
+      "line": "terraform-plugin/tfc-run-status: Use when polling a run, checking pass/fail, or seeing if it can be applied"
+    },
+    {
+      "id": "terraform-plugin/tfc-workspace-runs",
+      "line": "terraform-plugin/tfc-workspace-runs: Use when checking TFC status or listing runs by workspace. Requires TFE_TOKEN"
+    },
+    {
+      "id": "testing-plugin/mutation-testing",
+      "line": "testing-plugin/mutation-testing: Use when finding weak tests that pass on mutated code, or improving test quality"
+    },
+    {
+      "id": "testing-plugin/odiff-image-diffing",
+      "line": "testing-plugin/odiff-image-diffing: Use when comparing screenshots, detecting visual regressions, diffing"
+    },
+    {
+      "id": "testing-plugin/playwright-cli",
+      "line": "testing-plugin/playwright-cli: Use when automating browser tasks from the shell; 4-10x more token-efficient"
+    },
+    {
+      "id": "testing-plugin/playwright-testing",
+      "line": "testing-plugin/playwright-testing: Use when writing E2E tests or setting up automated UI testing for web apps"
+    },
+    {
+      "id": "testing-plugin/property-based-testing",
+      "line": "testing-plugin/property-based-testing: Use when generating test data, finding edge cases, testing properties,"
+    },
+    {
+      "id": "testing-plugin/test-analyze",
+      "line": "testing-plugin/test-analyze: Use when triaging failing tests, analyzing JUnit XML, planning fixes"
+    },
+    {
+      "id": "testing-plugin/test-consult",
+      "line": "testing-plugin/test-consult: Use when asking about coverage gaps, test pyramid, framework selection"
+    },
+    {
+      "id": "testing-plugin/test-focus",
+      "line": "testing-plugin/test-focus: Use when iterating on a failing spec, headed/debug mode, or serial WebGL tests"
+    },
+    {
+      "id": "testing-plugin/test-full",
+      "line": "testing-plugin/test-full: Use when running all tests before a PR, generating coverage reports, or doing"
+    },
+    {
+      "id": "testing-plugin/test-quality-analysis",
+      "line": "testing-plugin/test-quality-analysis: Use when reviewing tests, improving test quality, or analyzing test"
+    },
+    {
+      "id": "testing-plugin/test-quick",
+      "line": "testing-plugin/test-quick: Use when checking units after a change, running affected tests since last"
+    },
+    {
+      "id": "testing-plugin/test-report",
+      "line": "testing-plugin/test-report: Use when checking test health, standup status, coverage summary, history,"
+    },
+    {
+      "id": "testing-plugin/test-run",
+      "line": "testing-plugin/test-run: Use when running tests, targeting a file/pattern, running with coverage,"
+    },
+    {
+      "id": "testing-plugin/test-setup",
+      "line": "testing-plugin/test-setup: Use when setting up tests, scaffolding test dirs, adding pre-commit hooks"
+    },
+    {
+      "id": "testing-plugin/test-strategy-review",
+      "line": "testing-plugin/test-strategy-review: Use when a suite is green but you doubt it would catch a real regression"
+    },
+    {
+      "id": "testing-plugin/test-tier-selection",
+      "line": "testing-plugin/test-tier-selection: Use when running tests, discussing testing strategy, or after code"
+    },
+    {
+      "id": "testing-plugin/vitest-testing",
+      "line": "testing-plugin/vitest-testing: Use when setting up tests for Vite projects, migrating from Jest, or needing"
+    },
+    {
+      "id": "tools-plugin/binary-analysis",
+      "line": "tools-plugin/binary-analysis: Use when identifying unknown files, extracting strings, hunting credentials,"
+    },
+    {
+      "id": "tools-plugin/cli-smoke-recipes",
+      "line": "tools-plugin/cli-smoke-recipes: Use when designing data-transform modules or authoring smoke tests"
+    },
+    {
+      "id": "tools-plugin/d2-diagrams",
+      "line": "tools-plugin/d2-diagrams: Use when creating architecture diagrams, flowcharts, decision trees, sequence"
+    },
+    {
+      "id": "tools-plugin/deps-install",
+      "line": "tools-plugin/deps-install: Use when installing deps or syncing lockfiles"
+    },
+    {
+      "id": "tools-plugin/fd-file-finding",
+      "line": "tools-plugin/fd-file-finding: Use when searching for files by name, extension, or pattern across directories"
+    },
+    {
+      "id": "tools-plugin/generate-image",
+      "line": "tools-plugin/generate-image: Use when creating artwork, product photos, or mockups with AI"
+    },
+    {
+      "id": "tools-plugin/hf-downloads",
+      "line": "tools-plugin/hf-downloads: Use when downloading HF models, hf download errors, ENOSPC during downloads,"
+    },
+    {
+      "id": "tools-plugin/imagemagick-conversion",
+      "line": "tools-plugin/imagemagick-conversion: Use when converting, resizing, batch-processing, or generating thumbnails"
+    },
+    {
+      "id": "tools-plugin/jq-json-processing",
+      "line": "tools-plugin/jq-json-processing: Use when parsing JSON files, filtering arrays/objects, transforming structures"
+    },
+    {
+      "id": "tools-plugin/justfile-expert",
+      "line": "tools-plugin/justfile-expert: Use when authoring justfiles, project commands, or task automation"
+    },
+    {
+      "id": "tools-plugin/mermaid-diagrams",
+      "line": "tools-plugin/mermaid-diagrams: Use when rendering .mmd or embedding diagrams in GitHub Markdown"
+    },
+    {
+      "id": "tools-plugin/nushell-data-processing",
+      "line": "tools-plugin/nushell-data-processing: Use when running multi-step cross-format transforms awkward in jq"
+    },
+    {
+      "id": "tools-plugin/rg-code-search",
+      "line": "tools-plugin/rg-code-search: Use when searching for text patterns, code snippets, or doing multi-file"
+    },
+    {
+      "id": "tools-plugin/shell-expert",
+      "line": "tools-plugin/shell-expert: Use when writing shell scripts, pipes, command-line automation, or portable"
+    },
+    {
+      "id": "tools-plugin/yq-yaml-processing",
+      "line": "tools-plugin/yq-yaml-processing: Use when parsing configs, modifying Kubernetes manifests or GitHub Actions"
+    },
+    {
+      "id": "typescript-plugin/biome-tooling",
+      "line": "typescript-plugin/biome-tooling: Use when setting up formatting/linting or migrating from ESLint+Prettier"
+    },
+    {
+      "id": "typescript-plugin/bun-add",
+      "line": "typescript-plugin/bun-add: Use when the user wants to add/install a specific package with bun"
+    },
+    {
+      "id": "typescript-plugin/bun-build",
+      "line": "typescript-plugin/bun-build: Use when the user wants to bundle, compile, or build for browser/bun/node"
+    },
+    {
+      "id": "typescript-plugin/bun-debug",
+      "line": "typescript-plugin/bun-debug: Use when the user wants to debug a TS/JS file interactively, break at first"
+    },
+    {
+      "id": "typescript-plugin/bun-development",
+      "line": "typescript-plugin/bun-development: Use when running a TS file, watch/hot reload, configuring `bun test`"
+    },
+    {
+      "id": "typescript-plugin/bun-install",
+      "line": "typescript-plugin/bun-install: Use when bootstrapping a checkout, running a reproducible CI install"
+    },
+    {
+      "id": "typescript-plugin/bun-lockfile-update",
+      "line": "typescript-plugin/bun-lockfile-update: Use when updating dependencies, resolving lockfile conflicts, or regenerating"
+    },
+    {
+      "id": "typescript-plugin/bun-outdated",
+      "line": "typescript-plugin/bun-outdated: Use when auditing freshness, spotting major updates, or deciding between bun"
+    },
+    {
+      "id": "typescript-plugin/bun-package-manager",
+      "line": "typescript-plugin/bun-package-manager: Use when installing all deps, adding/removing packages, running `bun"
+    },
+    {
+      "id": "typescript-plugin/bun-publish",
+      "line": "typescript-plugin/bun-publish: Use when the user wants to release to npm, preview with --dry-run, publish"
+    },
+    {
+      "id": "typescript-plugin/bun-publishing",
+      "line": "typescript-plugin/bun-publishing: Use when setting up `publishConfig`/`files`/`bin`, packaging a CLI, enabling"
+    },
+    {
+      "id": "typescript-plugin/bun-test",
+      "line": "typescript-plugin/bun-test: Use when running bun tests, targeting a pattern, collecting --coverage"
+    },
+    {
+      "id": "typescript-plugin/knip-dead-code",
+      "line": "typescript-plugin/knip-dead-code: Use when cleaning up codebases, finding dead exports, or enforcing dependency"
+    },
+    {
+      "id": "typescript-plugin/nodejs-development",
+      "line": "typescript-plugin/nodejs-development: Use when the user mentions Node.js, Bun, Vite, Vue, Pinia, npm, pnpm, or modern"
+    },
+    {
+      "id": "typescript-plugin/typescript-debugging",
+      "line": "typescript-plugin/typescript-debugging: Use when setting up interactive debugging, investigating leaks, CPU profiling"
+    },
+    {
+      "id": "typescript-plugin/typescript-sentry",
+      "line": "typescript-plugin/typescript-sentry: Use when adding Sentry, instrumenting cron, or uploading sourcemaps"
+    },
+    {
+      "id": "typescript-plugin/typescript-strict",
+      "line": "typescript-plugin/typescript-strict: Use when setting up TS or migrating to stricter type safety"
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-checkpoint-refactor",
+      "line": "workflow-orchestration-plugin/workflow-checkpoint-refactor: Use when refactoring spans 10+ files, needs phased rollout, or risks running out"
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-preflight",
+      "line": "workflow-orchestration-plugin/workflow-preflight: Use when starting an issue or fix to verify remote state, check for existing"
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-verify-before-filing",
+      "line": "workflow-orchestration-plugin/workflow-verify-before-filing: Use when filing upstream reports from backlogs, audit docs, or git-history"
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-wave-dispatch",
+      "line": "workflow-orchestration-plugin/workflow-wave-dispatch: Use when planning multi-step work, fixing parallel-dispatch order, or gating"
+    }
+  ]
+}

--- a/experiments/skill-catalog-routing/catalogs/catalog.names.json
+++ b/experiments/skill-catalog-routing/catalogs/catalog.names.json
@@ -1,0 +1,1627 @@
+{
+  "variant": "names",
+  "source_sha": "020bfd9049809681d21d5b6469696f079f249bd3",
+  "skill_count": 405,
+  "entries": [
+    {
+      "id": "accessibility-plugin/accessibility-implementation",
+      "line": "accessibility-plugin/accessibility-implementation"
+    },
+    {
+      "id": "accessibility-plugin/design-tokens",
+      "line": "accessibility-plugin/design-tokens"
+    },
+    {
+      "id": "agent-patterns-plugin/adversarial-review",
+      "line": "agent-patterns-plugin/adversarial-review"
+    },
+    {
+      "id": "agent-patterns-plugin/agent-teams",
+      "line": "agent-patterns-plugin/agent-teams"
+    },
+    {
+      "id": "agent-patterns-plugin/cold-read-gate",
+      "line": "agent-patterns-plugin/cold-read-gate"
+    },
+    {
+      "id": "agent-patterns-plugin/custom-agent-definitions",
+      "line": "agent-patterns-plugin/custom-agent-definitions"
+    },
+    {
+      "id": "agent-patterns-plugin/exclusive-lock-dispatch",
+      "line": "agent-patterns-plugin/exclusive-lock-dispatch"
+    },
+    {
+      "id": "agent-patterns-plugin/execution-grounded-review",
+      "line": "agent-patterns-plugin/execution-grounded-review"
+    },
+    {
+      "id": "agent-patterns-plugin/expose-tunable-knob",
+      "line": "agent-patterns-plugin/expose-tunable-knob"
+    },
+    {
+      "id": "agent-patterns-plugin/mcp-code-execution",
+      "line": "agent-patterns-plugin/mcp-code-execution"
+    },
+    {
+      "id": "agent-patterns-plugin/mcp-management",
+      "line": "agent-patterns-plugin/mcp-management"
+    },
+    {
+      "id": "agent-patterns-plugin/mcp-server-authoring",
+      "line": "agent-patterns-plugin/mcp-server-authoring"
+    },
+    {
+      "id": "agent-patterns-plugin/meta-assimilate",
+      "line": "agent-patterns-plugin/meta-assimilate"
+    },
+    {
+      "id": "agent-patterns-plugin/meta-audit",
+      "line": "agent-patterns-plugin/meta-audit"
+    },
+    {
+      "id": "agent-patterns-plugin/meta-context-diet",
+      "line": "agent-patterns-plugin/meta-context-diet"
+    },
+    {
+      "id": "agent-patterns-plugin/meta-promote",
+      "line": "agent-patterns-plugin/meta-promote"
+    },
+    {
+      "id": "agent-patterns-plugin/multi-model-delegation",
+      "line": "agent-patterns-plugin/multi-model-delegation"
+    },
+    {
+      "id": "agent-patterns-plugin/parallel-agent-dispatch",
+      "line": "agent-patterns-plugin/parallel-agent-dispatch"
+    },
+    {
+      "id": "agent-patterns-plugin/plugin-settings",
+      "line": "agent-patterns-plugin/plugin-settings"
+    },
+    {
+      "id": "agent-patterns-plugin/verify-before-plan",
+      "line": "agent-patterns-plugin/verify-before-plan"
+    },
+    {
+      "id": "agent-patterns-plugin/wave-based-dispatch",
+      "line": "agent-patterns-plugin/wave-based-dispatch"
+    },
+    {
+      "id": "agents-plugin/agents-analyze",
+      "line": "agents-plugin/agents-analyze"
+    },
+    {
+      "id": "api-plugin/api-testing",
+      "line": "api-plugin/api-testing"
+    },
+    {
+      "id": "bevy-plugin/bevy-ecs-patterns",
+      "line": "bevy-plugin/bevy-ecs-patterns"
+    },
+    {
+      "id": "bevy-plugin/bevy-game-engine",
+      "line": "bevy-plugin/bevy-game-engine"
+    },
+    {
+      "id": "blog-plugin/blog-post",
+      "line": "blog-plugin/blog-post"
+    },
+    {
+      "id": "blog-plugin/blog-post-writing",
+      "line": "blog-plugin/blog-post-writing"
+    },
+    {
+      "id": "blueprint-plugin/adr-relationships",
+      "line": "blueprint-plugin/adr-relationships"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-adr-list",
+      "line": "blueprint-plugin/blueprint-adr-list"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-adr-validate",
+      "line": "blueprint-plugin/blueprint-adr-validate"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-autopilot",
+      "line": "blueprint-plugin/blueprint-autopilot"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-claude-md",
+      "line": "blueprint-plugin/blueprint-claude-md"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-curate-docs",
+      "line": "blueprint-plugin/blueprint-curate-docs"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-derive-plans",
+      "line": "blueprint-plugin/blueprint-derive-plans"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-derive-rules",
+      "line": "blueprint-plugin/blueprint-derive-rules"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-derive-tests",
+      "line": "blueprint-plugin/blueprint-derive-tests"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-development",
+      "line": "blueprint-plugin/blueprint-development"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-docs-currency",
+      "line": "blueprint-plugin/blueprint-docs-currency"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-docs-list",
+      "line": "blueprint-plugin/blueprint-docs-list"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-execute",
+      "line": "blueprint-plugin/blueprint-execute"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-feature-tracker-status",
+      "line": "blueprint-plugin/blueprint-feature-tracker-status"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-feature-tracker-sync",
+      "line": "blueprint-plugin/blueprint-feature-tracker-sync"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-generate-rules",
+      "line": "blueprint-plugin/blueprint-generate-rules"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-init",
+      "line": "blueprint-plugin/blueprint-init"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-migration",
+      "line": "blueprint-plugin/blueprint-migration"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-promote",
+      "line": "blueprint-plugin/blueprint-promote"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-prp-create",
+      "line": "blueprint-plugin/blueprint-prp-create"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-prp-execute",
+      "line": "blueprint-plugin/blueprint-prp-execute"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-rules",
+      "line": "blueprint-plugin/blueprint-rules"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-status",
+      "line": "blueprint-plugin/blueprint-status"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-story-audit",
+      "line": "blueprint-plugin/blueprint-story-audit"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-story-reconcile",
+      "line": "blueprint-plugin/blueprint-story-reconcile"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-sync",
+      "line": "blueprint-plugin/blueprint-sync"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-sync-ids",
+      "line": "blueprint-plugin/blueprint-sync-ids"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-upgrade",
+      "line": "blueprint-plugin/blueprint-upgrade"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-work-order",
+      "line": "blueprint-plugin/blueprint-work-order"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-workspace-scan",
+      "line": "blueprint-plugin/blueprint-workspace-scan"
+    },
+    {
+      "id": "blueprint-plugin/confidence-scoring",
+      "line": "blueprint-plugin/confidence-scoring"
+    },
+    {
+      "id": "blueprint-plugin/document-detection",
+      "line": "blueprint-plugin/document-detection"
+    },
+    {
+      "id": "blueprint-plugin/document-linking",
+      "line": "blueprint-plugin/document-linking"
+    },
+    {
+      "id": "blueprint-plugin/feature-tracking",
+      "line": "blueprint-plugin/feature-tracking"
+    },
+    {
+      "id": "code-quality-plugin/ast-grep-search",
+      "line": "code-quality-plugin/ast-grep-search"
+    },
+    {
+      "id": "code-quality-plugin/bulk-sweep-classify",
+      "line": "code-quality-plugin/bulk-sweep-classify"
+    },
+    {
+      "id": "code-quality-plugin/code-antipatterns",
+      "line": "code-quality-plugin/code-antipatterns"
+    },
+    {
+      "id": "code-quality-plugin/code-complexity",
+      "line": "code-quality-plugin/code-complexity"
+    },
+    {
+      "id": "code-quality-plugin/code-dead-code",
+      "line": "code-quality-plugin/code-dead-code"
+    },
+    {
+      "id": "code-quality-plugin/code-dep-audit",
+      "line": "code-quality-plugin/code-dep-audit"
+    },
+    {
+      "id": "code-quality-plugin/code-docs-quality",
+      "line": "code-quality-plugin/code-docs-quality"
+    },
+    {
+      "id": "code-quality-plugin/code-hidden-failures",
+      "line": "code-quality-plugin/code-hidden-failures"
+    },
+    {
+      "id": "code-quality-plugin/code-lint",
+      "line": "code-quality-plugin/code-lint"
+    },
+    {
+      "id": "code-quality-plugin/code-refactor",
+      "line": "code-quality-plugin/code-refactor"
+    },
+    {
+      "id": "code-quality-plugin/code-review",
+      "line": "code-quality-plugin/code-review"
+    },
+    {
+      "id": "code-quality-plugin/code-review-checklist",
+      "line": "code-quality-plugin/code-review-checklist"
+    },
+    {
+      "id": "code-quality-plugin/code-test-quality",
+      "line": "code-quality-plugin/code-test-quality"
+    },
+    {
+      "id": "code-quality-plugin/debugging-methodology",
+      "line": "code-quality-plugin/debugging-methodology"
+    },
+    {
+      "id": "code-quality-plugin/dry-consolidation",
+      "line": "code-quality-plugin/dry-consolidation"
+    },
+    {
+      "id": "codebase-attributes-plugin/attributes-collect",
+      "line": "codebase-attributes-plugin/attributes-collect"
+    },
+    {
+      "id": "codebase-attributes-plugin/attributes-dashboard",
+      "line": "codebase-attributes-plugin/attributes-dashboard"
+    },
+    {
+      "id": "codebase-attributes-plugin/attributes-route",
+      "line": "codebase-attributes-plugin/attributes-route"
+    },
+    {
+      "id": "comfyui-plugin/comfy-cli",
+      "line": "comfyui-plugin/comfy-cli"
+    },
+    {
+      "id": "comfyui-plugin/comfy-conditionals",
+      "line": "comfyui-plugin/comfy-conditionals"
+    },
+    {
+      "id": "comfyui-plugin/comfy-corpus-validation",
+      "line": "comfyui-plugin/comfy-corpus-validation"
+    },
+    {
+      "id": "comfyui-plugin/comfy-debug-preview",
+      "line": "comfyui-plugin/comfy-debug-preview"
+    },
+    {
+      "id": "comfyui-plugin/comfy-flow-control",
+      "line": "comfyui-plugin/comfy-flow-control"
+    },
+    {
+      "id": "comfyui-plugin/comfy-image-utils",
+      "line": "comfyui-plugin/comfy-image-utils"
+    },
+    {
+      "id": "comfyui-plugin/comfy-math-strings",
+      "line": "comfyui-plugin/comfy-math-strings"
+    },
+    {
+      "id": "comfyui-plugin/comfy-metadata",
+      "line": "comfyui-plugin/comfy-metadata"
+    },
+    {
+      "id": "comfyui-plugin/comfy-node",
+      "line": "comfyui-plugin/comfy-node"
+    },
+    {
+      "id": "comfyui-plugin/comfy-registry-lifecycle",
+      "line": "comfyui-plugin/comfy-registry-lifecycle"
+    },
+    {
+      "id": "comfyui-plugin/comfy-subgraphs-app-mode",
+      "line": "comfyui-plugin/comfy-subgraphs-app-mode"
+    },
+    {
+      "id": "comfyui-plugin/comfy-workflow-json",
+      "line": "comfyui-plugin/comfy-workflow-json"
+    },
+    {
+      "id": "comfyui-plugin/comfy-workflow-layout",
+      "line": "comfyui-plugin/comfy-workflow-layout"
+    },
+    {
+      "id": "comfyui-plugin/comfyui-node-authoring",
+      "line": "comfyui-plugin/comfyui-node-authoring"
+    },
+    {
+      "id": "comfyui-plugin/comfyui-node-scaffold",
+      "line": "comfyui-plugin/comfyui-node-scaffold"
+    },
+    {
+      "id": "comfyui-plugin/comfyui-pack-live-smoke",
+      "line": "comfyui-plugin/comfyui-pack-live-smoke"
+    },
+    {
+      "id": "comfyui-plugin/comfyui-screenshot-pipeline",
+      "line": "comfyui-plugin/comfyui-screenshot-pipeline"
+    },
+    {
+      "id": "communication-plugin/google-chat-formatting",
+      "line": "communication-plugin/google-chat-formatting"
+    },
+    {
+      "id": "communication-plugin/ticket-drafting-guidelines",
+      "line": "communication-plugin/ticket-drafting-guidelines"
+    },
+    {
+      "id": "component-patterns-plugin/components-version-badge",
+      "line": "component-patterns-plugin/components-version-badge"
+    },
+    {
+      "id": "component-patterns-plugin/version-badge-pattern",
+      "line": "component-patterns-plugin/version-badge-pattern"
+    },
+    {
+      "id": "configure-plugin/ci-workflows",
+      "line": "configure-plugin/ci-workflows"
+    },
+    {
+      "id": "configure-plugin/claude-security-settings",
+      "line": "configure-plugin/claude-security-settings"
+    },
+    {
+      "id": "configure-plugin/config-sync",
+      "line": "configure-plugin/config-sync"
+    },
+    {
+      "id": "configure-plugin/configure-all",
+      "line": "configure-plugin/configure-all"
+    },
+    {
+      "id": "configure-plugin/configure-api-tests",
+      "line": "configure-plugin/configure-api-tests"
+    },
+    {
+      "id": "configure-plugin/configure-argocd-automerge",
+      "line": "configure-plugin/configure-argocd-automerge"
+    },
+    {
+      "id": "configure-plugin/configure-cache-busting",
+      "line": "configure-plugin/configure-cache-busting"
+    },
+    {
+      "id": "configure-plugin/configure-claude-plugins",
+      "line": "configure-plugin/configure-claude-plugins"
+    },
+    {
+      "id": "configure-plugin/configure-container",
+      "line": "configure-plugin/configure-container"
+    },
+    {
+      "id": "configure-plugin/configure-coverage",
+      "line": "configure-plugin/configure-coverage"
+    },
+    {
+      "id": "configure-plugin/configure-dead-code",
+      "line": "configure-plugin/configure-dead-code"
+    },
+    {
+      "id": "configure-plugin/configure-dockerfile",
+      "line": "configure-plugin/configure-dockerfile"
+    },
+    {
+      "id": "configure-plugin/configure-docs",
+      "line": "configure-plugin/configure-docs"
+    },
+    {
+      "id": "configure-plugin/configure-editor",
+      "line": "configure-plugin/configure-editor"
+    },
+    {
+      "id": "configure-plugin/configure-feature-flags",
+      "line": "configure-plugin/configure-feature-flags"
+    },
+    {
+      "id": "configure-plugin/configure-formatting",
+      "line": "configure-plugin/configure-formatting"
+    },
+    {
+      "id": "configure-plugin/configure-gitattributes",
+      "line": "configure-plugin/configure-gitattributes"
+    },
+    {
+      "id": "configure-plugin/configure-github-pages",
+      "line": "configure-plugin/configure-github-pages"
+    },
+    {
+      "id": "configure-plugin/configure-gitignore",
+      "line": "configure-plugin/configure-gitignore"
+    },
+    {
+      "id": "configure-plugin/configure-instrumentation",
+      "line": "configure-plugin/configure-instrumentation"
+    },
+    {
+      "id": "configure-plugin/configure-integration-tests",
+      "line": "configure-plugin/configure-integration-tests"
+    },
+    {
+      "id": "configure-plugin/configure-justfile",
+      "line": "configure-plugin/configure-justfile"
+    },
+    {
+      "id": "configure-plugin/configure-linting",
+      "line": "configure-plugin/configure-linting"
+    },
+    {
+      "id": "configure-plugin/configure-load-tests",
+      "line": "configure-plugin/configure-load-tests"
+    },
+    {
+      "id": "configure-plugin/configure-makefile",
+      "line": "configure-plugin/configure-makefile"
+    },
+    {
+      "id": "configure-plugin/configure-mcp",
+      "line": "configure-plugin/configure-mcp"
+    },
+    {
+      "id": "configure-plugin/configure-memory-profiling",
+      "line": "configure-plugin/configure-memory-profiling"
+    },
+    {
+      "id": "configure-plugin/configure-mise",
+      "line": "configure-plugin/configure-mise"
+    },
+    {
+      "id": "configure-plugin/configure-package-management",
+      "line": "configure-plugin/configure-package-management"
+    },
+    {
+      "id": "configure-plugin/configure-pre-commit",
+      "line": "configure-plugin/configure-pre-commit"
+    },
+    {
+      "id": "configure-plugin/configure-readme",
+      "line": "configure-plugin/configure-readme"
+    },
+    {
+      "id": "configure-plugin/configure-release-please",
+      "line": "configure-plugin/configure-release-please"
+    },
+    {
+      "id": "configure-plugin/configure-repo",
+      "line": "configure-plugin/configure-repo"
+    },
+    {
+      "id": "configure-plugin/configure-reusable-workflows",
+      "line": "configure-plugin/configure-reusable-workflows"
+    },
+    {
+      "id": "configure-plugin/configure-security",
+      "line": "configure-plugin/configure-security"
+    },
+    {
+      "id": "configure-plugin/configure-select",
+      "line": "configure-plugin/configure-select"
+    },
+    {
+      "id": "configure-plugin/configure-sentry",
+      "line": "configure-plugin/configure-sentry"
+    },
+    {
+      "id": "configure-plugin/configure-skaffold",
+      "line": "configure-plugin/configure-skaffold"
+    },
+    {
+      "id": "configure-plugin/configure-status",
+      "line": "configure-plugin/configure-status"
+    },
+    {
+      "id": "configure-plugin/configure-surface",
+      "line": "configure-plugin/configure-surface"
+    },
+    {
+      "id": "configure-plugin/configure-tests",
+      "line": "configure-plugin/configure-tests"
+    },
+    {
+      "id": "configure-plugin/configure-ux-testing",
+      "line": "configure-plugin/configure-ux-testing"
+    },
+    {
+      "id": "configure-plugin/configure-web-session",
+      "line": "configure-plugin/configure-web-session"
+    },
+    {
+      "id": "configure-plugin/configure-workflows",
+      "line": "configure-plugin/configure-workflows"
+    },
+    {
+      "id": "configure-plugin/configure-worktreeinclude",
+      "line": "configure-plugin/configure-worktreeinclude"
+    },
+    {
+      "id": "configure-plugin/go-feature-flag",
+      "line": "configure-plugin/go-feature-flag"
+    },
+    {
+      "id": "configure-plugin/multi-repo-discipline",
+      "line": "configure-plugin/multi-repo-discipline"
+    },
+    {
+      "id": "configure-plugin/openfeature",
+      "line": "configure-plugin/openfeature"
+    },
+    {
+      "id": "container-plugin/container-development",
+      "line": "container-plugin/container-development"
+    },
+    {
+      "id": "container-plugin/deploy-handoff",
+      "line": "container-plugin/deploy-handoff"
+    },
+    {
+      "id": "container-plugin/deploy-release",
+      "line": "container-plugin/deploy-release"
+    },
+    {
+      "id": "container-plugin/go-containers",
+      "line": "container-plugin/go-containers"
+    },
+    {
+      "id": "container-plugin/nodejs-containers",
+      "line": "container-plugin/nodejs-containers"
+    },
+    {
+      "id": "container-plugin/python-containers",
+      "line": "container-plugin/python-containers"
+    },
+    {
+      "id": "container-plugin/skaffold-filesync",
+      "line": "container-plugin/skaffold-filesync"
+    },
+    {
+      "id": "container-plugin/skaffold-orbstack",
+      "line": "container-plugin/skaffold-orbstack"
+    },
+    {
+      "id": "container-plugin/skaffold-testing",
+      "line": "container-plugin/skaffold-testing"
+    },
+    {
+      "id": "css-plugin/lightning-css",
+      "line": "css-plugin/lightning-css"
+    },
+    {
+      "id": "css-plugin/unocss",
+      "line": "css-plugin/unocss"
+    },
+    {
+      "id": "documentation-plugin/claude-blog-sources",
+      "line": "documentation-plugin/claude-blog-sources"
+    },
+    {
+      "id": "documentation-plugin/docs-decommission",
+      "line": "documentation-plugin/docs-decommission"
+    },
+    {
+      "id": "documentation-plugin/docs-generate",
+      "line": "documentation-plugin/docs-generate"
+    },
+    {
+      "id": "documentation-plugin/docs-latex",
+      "line": "documentation-plugin/docs-latex"
+    },
+    {
+      "id": "documentation-plugin/docs-sync",
+      "line": "documentation-plugin/docs-sync"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-improve",
+      "line": "evaluate-plugin/evaluate-improve"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-legibility",
+      "line": "evaluate-plugin/evaluate-legibility"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-matrix",
+      "line": "evaluate-plugin/evaluate-matrix"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-plugin-batch",
+      "line": "evaluate-plugin/evaluate-plugin-batch"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-report",
+      "line": "evaluate-plugin/evaluate-report"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-skill",
+      "line": "evaluate-plugin/evaluate-skill"
+    },
+    {
+      "id": "feedback-plugin/feedback-session",
+      "line": "feedback-plugin/feedback-session"
+    },
+    {
+      "id": "finops-plugin/finops-caches",
+      "line": "finops-plugin/finops-caches"
+    },
+    {
+      "id": "finops-plugin/finops-compare",
+      "line": "finops-plugin/finops-compare"
+    },
+    {
+      "id": "finops-plugin/finops-overview",
+      "line": "finops-plugin/finops-overview"
+    },
+    {
+      "id": "finops-plugin/finops-waste",
+      "line": "finops-plugin/finops-waste"
+    },
+    {
+      "id": "finops-plugin/finops-workflows",
+      "line": "finops-plugin/finops-workflows"
+    },
+    {
+      "id": "finops-plugin/github-actions-cache-optimization",
+      "line": "finops-plugin/github-actions-cache-optimization"
+    },
+    {
+      "id": "finops-plugin/github-actions-finops",
+      "line": "finops-plugin/github-actions-finops"
+    },
+    {
+      "id": "foundryvtt-plugin/foundryvtt-module",
+      "line": "foundryvtt-plugin/foundryvtt-module"
+    },
+    {
+      "id": "foundryvtt-plugin/foundryvtt-module-scaffold",
+      "line": "foundryvtt-plugin/foundryvtt-module-scaffold"
+    },
+    {
+      "id": "git-plugin/deadbranch",
+      "line": "git-plugin/deadbranch"
+    },
+    {
+      "id": "git-plugin/gh-cli-agentic",
+      "line": "git-plugin/gh-cli-agentic"
+    },
+    {
+      "id": "git-plugin/gh-workflow-monitoring",
+      "line": "git-plugin/gh-workflow-monitoring"
+    },
+    {
+      "id": "git-plugin/git-api-pr",
+      "line": "git-plugin/git-api-pr"
+    },
+    {
+      "id": "git-plugin/git-branch-naming",
+      "line": "git-plugin/git-branch-naming"
+    },
+    {
+      "id": "git-plugin/git-branch-pr-workflow",
+      "line": "git-plugin/git-branch-pr-workflow"
+    },
+    {
+      "id": "git-plugin/git-cli-agentic",
+      "line": "git-plugin/git-cli-agentic"
+    },
+    {
+      "id": "git-plugin/git-commit",
+      "line": "git-plugin/git-commit"
+    },
+    {
+      "id": "git-plugin/git-commit-push-pr",
+      "line": "git-plugin/git-commit-push-pr"
+    },
+    {
+      "id": "git-plugin/git-commit-trailers",
+      "line": "git-plugin/git-commit-trailers"
+    },
+    {
+      "id": "git-plugin/git-commit-workflow",
+      "line": "git-plugin/git-commit-workflow"
+    },
+    {
+      "id": "git-plugin/git-conflicts",
+      "line": "git-plugin/git-conflicts"
+    },
+    {
+      "id": "git-plugin/git-coworker-check",
+      "line": "git-plugin/git-coworker-check"
+    },
+    {
+      "id": "git-plugin/git-derive-docs",
+      "line": "git-plugin/git-derive-docs"
+    },
+    {
+      "id": "git-plugin/git-fix-pr",
+      "line": "git-plugin/git-fix-pr"
+    },
+    {
+      "id": "git-plugin/git-fork-workflow",
+      "line": "git-plugin/git-fork-workflow"
+    },
+    {
+      "id": "git-plugin/git-issue",
+      "line": "git-plugin/git-issue"
+    },
+    {
+      "id": "git-plugin/git-issue-hierarchy",
+      "line": "git-plugin/git-issue-hierarchy"
+    },
+    {
+      "id": "git-plugin/git-issue-manage",
+      "line": "git-plugin/git-issue-manage"
+    },
+    {
+      "id": "git-plugin/git-maintain",
+      "line": "git-plugin/git-maintain"
+    },
+    {
+      "id": "git-plugin/git-pr",
+      "line": "git-plugin/git-pr"
+    },
+    {
+      "id": "git-plugin/git-pr-feedback",
+      "line": "git-plugin/git-pr-feedback"
+    },
+    {
+      "id": "git-plugin/git-pr-sync-check",
+      "line": "git-plugin/git-pr-sync-check"
+    },
+    {
+      "id": "git-plugin/git-pr-watch",
+      "line": "git-plugin/git-pr-watch"
+    },
+    {
+      "id": "git-plugin/git-push",
+      "line": "git-plugin/git-push"
+    },
+    {
+      "id": "git-plugin/git-rebase-patterns",
+      "line": "git-plugin/git-rebase-patterns"
+    },
+    {
+      "id": "git-plugin/git-repo-detection",
+      "line": "git-plugin/git-repo-detection"
+    },
+    {
+      "id": "git-plugin/git-security-checks",
+      "line": "git-plugin/git-security-checks"
+    },
+    {
+      "id": "git-plugin/git-triage",
+      "line": "git-plugin/git-triage"
+    },
+    {
+      "id": "git-plugin/git-upstream-pr",
+      "line": "git-plugin/git-upstream-pr"
+    },
+    {
+      "id": "git-plugin/git-upstream-pr-diverged",
+      "line": "git-plugin/git-upstream-pr-diverged"
+    },
+    {
+      "id": "git-plugin/github-issue-autodetect",
+      "line": "git-plugin/github-issue-autodetect"
+    },
+    {
+      "id": "git-plugin/github-issue-writing",
+      "line": "git-plugin/github-issue-writing"
+    },
+    {
+      "id": "git-plugin/github-labels",
+      "line": "git-plugin/github-labels"
+    },
+    {
+      "id": "git-plugin/github-pr-title",
+      "line": "git-plugin/github-pr-title"
+    },
+    {
+      "id": "git-plugin/release-please-configuration",
+      "line": "git-plugin/release-please-configuration"
+    },
+    {
+      "id": "git-plugin/release-please-pr-workflow",
+      "line": "git-plugin/release-please-pr-workflow"
+    },
+    {
+      "id": "git-plugin/release-please-protection",
+      "line": "git-plugin/release-please-protection"
+    },
+    {
+      "id": "github-actions-plugin/claude-code-github-workflows",
+      "line": "github-actions-plugin/claude-code-github-workflows"
+    },
+    {
+      "id": "github-actions-plugin/github-actions-auth-security",
+      "line": "github-actions-plugin/github-actions-auth-security"
+    },
+    {
+      "id": "github-actions-plugin/github-actions-inspection",
+      "line": "github-actions-plugin/github-actions-inspection"
+    },
+    {
+      "id": "github-actions-plugin/github-actions-mcp-config",
+      "line": "github-actions-plugin/github-actions-mcp-config"
+    },
+    {
+      "id": "github-actions-plugin/github-issue-search",
+      "line": "github-actions-plugin/github-issue-search"
+    },
+    {
+      "id": "github-actions-plugin/github-social-preview",
+      "line": "github-actions-plugin/github-social-preview"
+    },
+    {
+      "id": "github-actions-plugin/github-workflow-auto-fix",
+      "line": "github-actions-plugin/github-workflow-auto-fix"
+    },
+    {
+      "id": "github-actions-plugin/workflow-dev",
+      "line": "github-actions-plugin/workflow-dev"
+    },
+    {
+      "id": "health-plugin/health-agentic-audit",
+      "line": "health-plugin/health-agentic-audit"
+    },
+    {
+      "id": "health-plugin/health-audit",
+      "line": "health-plugin/health-audit"
+    },
+    {
+      "id": "health-plugin/health-check",
+      "line": "health-plugin/health-check"
+    },
+    {
+      "id": "health-plugin/health-plugins",
+      "line": "health-plugin/health-plugins"
+    },
+    {
+      "id": "health-plugin/health-skill-audit",
+      "line": "health-plugin/health-skill-audit"
+    },
+    {
+      "id": "health-plugin/plugin-registry",
+      "line": "health-plugin/plugin-registry"
+    },
+    {
+      "id": "health-plugin/settings-configuration",
+      "line": "health-plugin/settings-configuration"
+    },
+    {
+      "id": "home-assistant-plugin/ha-automations",
+      "line": "home-assistant-plugin/ha-automations"
+    },
+    {
+      "id": "home-assistant-plugin/ha-configuration",
+      "line": "home-assistant-plugin/ha-configuration"
+    },
+    {
+      "id": "home-assistant-plugin/ha-entities",
+      "line": "home-assistant-plugin/ha-entities"
+    },
+    {
+      "id": "home-assistant-plugin/ha-validate",
+      "line": "home-assistant-plugin/ha-validate"
+    },
+    {
+      "id": "hooks-plugin/hooks-configuration",
+      "line": "hooks-plugin/hooks-configuration"
+    },
+    {
+      "id": "hooks-plugin/hooks-permission-request-hook",
+      "line": "hooks-plugin/hooks-permission-request-hook"
+    },
+    {
+      "id": "hooks-plugin/hooks-session-end-issue-hook",
+      "line": "hooks-plugin/hooks-session-end-issue-hook"
+    },
+    {
+      "id": "hooks-plugin/hooks-session-start-hook",
+      "line": "hooks-plugin/hooks-session-start-hook"
+    },
+    {
+      "id": "kubernetes-plugin/argocd-login",
+      "line": "kubernetes-plugin/argocd-login"
+    },
+    {
+      "id": "kubernetes-plugin/helm-chart-development",
+      "line": "kubernetes-plugin/helm-chart-development"
+    },
+    {
+      "id": "kubernetes-plugin/helm-debugging",
+      "line": "kubernetes-plugin/helm-debugging"
+    },
+    {
+      "id": "kubernetes-plugin/helm-release-management",
+      "line": "kubernetes-plugin/helm-release-management"
+    },
+    {
+      "id": "kubernetes-plugin/helm-release-recovery",
+      "line": "kubernetes-plugin/helm-release-recovery"
+    },
+    {
+      "id": "kubernetes-plugin/helm-values-management",
+      "line": "kubernetes-plugin/helm-values-management"
+    },
+    {
+      "id": "kubernetes-plugin/kubectl-debugging",
+      "line": "kubernetes-plugin/kubectl-debugging"
+    },
+    {
+      "id": "kubernetes-plugin/kubernetes-operations",
+      "line": "kubernetes-plugin/kubernetes-operations"
+    },
+    {
+      "id": "langchain-plugin/deep-agents",
+      "line": "langchain-plugin/deep-agents"
+    },
+    {
+      "id": "langchain-plugin/langchain-development",
+      "line": "langchain-plugin/langchain-development"
+    },
+    {
+      "id": "langchain-plugin/langchain-init",
+      "line": "langchain-plugin/langchain-init"
+    },
+    {
+      "id": "langchain-plugin/langgraph-agents",
+      "line": "langchain-plugin/langgraph-agents"
+    },
+    {
+      "id": "macos-plugin/endpoint-security-cpu",
+      "line": "macos-plugin/endpoint-security-cpu"
+    },
+    {
+      "id": "macos-plugin/kitty-session-persistence",
+      "line": "macos-plugin/kitty-session-persistence"
+    },
+    {
+      "id": "macos-plugin/launchservices-health",
+      "line": "macos-plugin/launchservices-health"
+    },
+    {
+      "id": "macos-plugin/macos-disk-usage",
+      "line": "macos-plugin/macos-disk-usage"
+    },
+    {
+      "id": "macos-plugin/macos-incident-postmortem",
+      "line": "macos-plugin/macos-incident-postmortem"
+    },
+    {
+      "id": "macos-plugin/macos-performance-benchmark",
+      "line": "macos-plugin/macos-performance-benchmark"
+    },
+    {
+      "id": "macos-plugin/macos-performance-triage",
+      "line": "macos-plugin/macos-performance-triage"
+    },
+    {
+      "id": "macos-plugin/tui-keybinding-debug",
+      "line": "macos-plugin/tui-keybinding-debug"
+    },
+    {
+      "id": "migration-patterns-plugin/black-to-ruff-format",
+      "line": "migration-patterns-plugin/black-to-ruff-format"
+    },
+    {
+      "id": "migration-patterns-plugin/dual-write",
+      "line": "migration-patterns-plugin/dual-write"
+    },
+    {
+      "id": "migration-patterns-plugin/eslint-to-biome",
+      "line": "migration-patterns-plugin/eslint-to-biome"
+    },
+    {
+      "id": "migration-patterns-plugin/flake8-to-ruff",
+      "line": "migration-patterns-plugin/flake8-to-ruff"
+    },
+    {
+      "id": "migration-patterns-plugin/mypy-to-ty",
+      "line": "migration-patterns-plugin/mypy-to-ty"
+    },
+    {
+      "id": "migration-patterns-plugin/shadow-mode",
+      "line": "migration-patterns-plugin/shadow-mode"
+    },
+    {
+      "id": "networking-plugin/dns-tools",
+      "line": "networking-plugin/dns-tools"
+    },
+    {
+      "id": "networking-plugin/http-load-testing",
+      "line": "networking-plugin/http-load-testing"
+    },
+    {
+      "id": "networking-plugin/interface-state",
+      "line": "networking-plugin/interface-state"
+    },
+    {
+      "id": "networking-plugin/layer2-discovery",
+      "line": "networking-plugin/layer2-discovery"
+    },
+    {
+      "id": "networking-plugin/network-diagnostics",
+      "line": "networking-plugin/network-diagnostics"
+    },
+    {
+      "id": "networking-plugin/network-discovery",
+      "line": "networking-plugin/network-discovery"
+    },
+    {
+      "id": "networking-plugin/network-monitoring",
+      "line": "networking-plugin/network-monitoring"
+    },
+    {
+      "id": "obsidian-plugin/bases",
+      "line": "obsidian-plugin/bases"
+    },
+    {
+      "id": "obsidian-plugin/bookmarks",
+      "line": "obsidian-plugin/bookmarks"
+    },
+    {
+      "id": "obsidian-plugin/command-palette",
+      "line": "obsidian-plugin/command-palette"
+    },
+    {
+      "id": "obsidian-plugin/dev-tools",
+      "line": "obsidian-plugin/dev-tools"
+    },
+    {
+      "id": "obsidian-plugin/file-history",
+      "line": "obsidian-plugin/file-history"
+    },
+    {
+      "id": "obsidian-plugin/plugins-themes",
+      "line": "obsidian-plugin/plugins-themes"
+    },
+    {
+      "id": "obsidian-plugin/properties",
+      "line": "obsidian-plugin/properties"
+    },
+    {
+      "id": "obsidian-plugin/publish-sync",
+      "line": "obsidian-plugin/publish-sync"
+    },
+    {
+      "id": "obsidian-plugin/search-discovery",
+      "line": "obsidian-plugin/search-discovery"
+    },
+    {
+      "id": "obsidian-plugin/tasks",
+      "line": "obsidian-plugin/tasks"
+    },
+    {
+      "id": "obsidian-plugin/templates",
+      "line": "obsidian-plugin/templates"
+    },
+    {
+      "id": "obsidian-plugin/vault-files",
+      "line": "obsidian-plugin/vault-files"
+    },
+    {
+      "id": "obsidian-plugin/vault-frontmatter",
+      "line": "obsidian-plugin/vault-frontmatter"
+    },
+    {
+      "id": "obsidian-plugin/vault-management",
+      "line": "obsidian-plugin/vault-management"
+    },
+    {
+      "id": "obsidian-plugin/vault-mocs",
+      "line": "obsidian-plugin/vault-mocs"
+    },
+    {
+      "id": "obsidian-plugin/vault-orphans",
+      "line": "obsidian-plugin/vault-orphans"
+    },
+    {
+      "id": "obsidian-plugin/vault-stubs",
+      "line": "obsidian-plugin/vault-stubs"
+    },
+    {
+      "id": "obsidian-plugin/vault-tags",
+      "line": "obsidian-plugin/vault-tags"
+    },
+    {
+      "id": "obsidian-plugin/vault-templates",
+      "line": "obsidian-plugin/vault-templates"
+    },
+    {
+      "id": "obsidian-plugin/vault-wikilinks",
+      "line": "obsidian-plugin/vault-wikilinks"
+    },
+    {
+      "id": "obsidian-plugin/workspaces",
+      "line": "obsidian-plugin/workspaces"
+    },
+    {
+      "id": "project-plugin/changelog-review",
+      "line": "project-plugin/changelog-review"
+    },
+    {
+      "id": "project-plugin/project-continue",
+      "line": "project-plugin/project-continue"
+    },
+    {
+      "id": "project-plugin/project-discovery",
+      "line": "project-plugin/project-discovery"
+    },
+    {
+      "id": "project-plugin/project-init",
+      "line": "project-plugin/project-init"
+    },
+    {
+      "id": "project-plugin/project-refocus",
+      "line": "project-plugin/project-refocus"
+    },
+    {
+      "id": "project-plugin/project-skill-scripts",
+      "line": "project-plugin/project-skill-scripts"
+    },
+    {
+      "id": "project-plugin/project-test-loop",
+      "line": "project-plugin/project-test-loop"
+    },
+    {
+      "id": "prompt-engineering-plugin/prompt-engineering-ground-response",
+      "line": "prompt-engineering-plugin/prompt-engineering-ground-response"
+    },
+    {
+      "id": "prose-plugin/prose-distill",
+      "line": "prose-plugin/prose-distill"
+    },
+    {
+      "id": "prose-plugin/prose-synthesize",
+      "line": "prose-plugin/prose-synthesize"
+    },
+    {
+      "id": "python-plugin/basedpyright-type-checking",
+      "line": "python-plugin/basedpyright-type-checking"
+    },
+    {
+      "id": "python-plugin/pytest-advanced",
+      "line": "python-plugin/pytest-advanced"
+    },
+    {
+      "id": "python-plugin/python-code-quality",
+      "line": "python-plugin/python-code-quality"
+    },
+    {
+      "id": "python-plugin/python-development",
+      "line": "python-plugin/python-development"
+    },
+    {
+      "id": "python-plugin/python-packaging",
+      "line": "python-plugin/python-packaging"
+    },
+    {
+      "id": "python-plugin/python-testing",
+      "line": "python-plugin/python-testing"
+    },
+    {
+      "id": "python-plugin/ruff-formatting",
+      "line": "python-plugin/ruff-formatting"
+    },
+    {
+      "id": "python-plugin/ruff-linting",
+      "line": "python-plugin/ruff-linting"
+    },
+    {
+      "id": "python-plugin/ty-type-checking",
+      "line": "python-plugin/ty-type-checking"
+    },
+    {
+      "id": "python-plugin/uv-advanced-dependencies",
+      "line": "python-plugin/uv-advanced-dependencies"
+    },
+    {
+      "id": "python-plugin/uv-project-management",
+      "line": "python-plugin/uv-project-management"
+    },
+    {
+      "id": "python-plugin/uv-python-versions",
+      "line": "python-plugin/uv-python-versions"
+    },
+    {
+      "id": "python-plugin/uv-run",
+      "line": "python-plugin/uv-run"
+    },
+    {
+      "id": "python-plugin/uv-tool-management",
+      "line": "python-plugin/uv-tool-management"
+    },
+    {
+      "id": "python-plugin/uv-workspaces",
+      "line": "python-plugin/uv-workspaces"
+    },
+    {
+      "id": "python-plugin/vulture-dead-code",
+      "line": "python-plugin/vulture-dead-code"
+    },
+    {
+      "id": "rust-plugin/cargo-llvm-cov",
+      "line": "rust-plugin/cargo-llvm-cov"
+    },
+    {
+      "id": "rust-plugin/cargo-machete",
+      "line": "rust-plugin/cargo-machete"
+    },
+    {
+      "id": "rust-plugin/cargo-nextest",
+      "line": "rust-plugin/cargo-nextest"
+    },
+    {
+      "id": "rust-plugin/cargo-worktree-builds",
+      "line": "rust-plugin/cargo-worktree-builds"
+    },
+    {
+      "id": "rust-plugin/clippy-advanced",
+      "line": "rust-plugin/clippy-advanced"
+    },
+    {
+      "id": "rust-plugin/mockito-http-mocking",
+      "line": "rust-plugin/mockito-http-mocking"
+    },
+    {
+      "id": "rust-plugin/rust-development",
+      "line": "rust-plugin/rust-development"
+    },
+    {
+      "id": "session-plugin/session-distill",
+      "line": "session-plugin/session-distill"
+    },
+    {
+      "id": "session-plugin/session-end",
+      "line": "session-plugin/session-end"
+    },
+    {
+      "id": "session-plugin/session-spinup",
+      "line": "session-plugin/session-spinup"
+    },
+    {
+      "id": "session-plugin/session-wrap",
+      "line": "session-plugin/session-wrap"
+    },
+    {
+      "id": "software-design-plugin/design-by-contract",
+      "line": "software-design-plugin/design-by-contract"
+    },
+    {
+      "id": "software-design-plugin/design-deep-modules",
+      "line": "software-design-plugin/design-deep-modules"
+    },
+    {
+      "id": "software-design-plugin/design-legacy-seams",
+      "line": "software-design-plugin/design-legacy-seams"
+    },
+    {
+      "id": "software-design-plugin/design-patterns",
+      "line": "software-design-plugin/design-patterns"
+    },
+    {
+      "id": "software-design-plugin/design-pseudocode",
+      "line": "software-design-plugin/design-pseudocode"
+    },
+    {
+      "id": "taskwarrior-plugin/install-native-hooks",
+      "line": "taskwarrior-plugin/install-native-hooks"
+    },
+    {
+      "id": "taskwarrior-plugin/task-add",
+      "line": "taskwarrior-plugin/task-add"
+    },
+    {
+      "id": "taskwarrior-plugin/task-bulk-ops",
+      "line": "taskwarrior-plugin/task-bulk-ops"
+    },
+    {
+      "id": "taskwarrior-plugin/task-claim",
+      "line": "taskwarrior-plugin/task-claim"
+    },
+    {
+      "id": "taskwarrior-plugin/task-coordinate",
+      "line": "taskwarrior-plugin/task-coordinate"
+    },
+    {
+      "id": "taskwarrior-plugin/task-done",
+      "line": "taskwarrior-plugin/task-done"
+    },
+    {
+      "id": "taskwarrior-plugin/task-reconcile",
+      "line": "taskwarrior-plugin/task-reconcile"
+    },
+    {
+      "id": "taskwarrior-plugin/task-release",
+      "line": "taskwarrior-plugin/task-release"
+    },
+    {
+      "id": "taskwarrior-plugin/task-status",
+      "line": "taskwarrior-plugin/task-status"
+    },
+    {
+      "id": "terraform-plugin/infrastructure-terraform",
+      "line": "terraform-plugin/infrastructure-terraform"
+    },
+    {
+      "id": "terraform-plugin/tfc-list-runs",
+      "line": "terraform-plugin/tfc-list-runs"
+    },
+    {
+      "id": "terraform-plugin/tfc-plan-json",
+      "line": "terraform-plugin/tfc-plan-json"
+    },
+    {
+      "id": "terraform-plugin/tfc-run-logs",
+      "line": "terraform-plugin/tfc-run-logs"
+    },
+    {
+      "id": "terraform-plugin/tfc-run-status",
+      "line": "terraform-plugin/tfc-run-status"
+    },
+    {
+      "id": "terraform-plugin/tfc-workspace-runs",
+      "line": "terraform-plugin/tfc-workspace-runs"
+    },
+    {
+      "id": "testing-plugin/mutation-testing",
+      "line": "testing-plugin/mutation-testing"
+    },
+    {
+      "id": "testing-plugin/odiff-image-diffing",
+      "line": "testing-plugin/odiff-image-diffing"
+    },
+    {
+      "id": "testing-plugin/playwright-cli",
+      "line": "testing-plugin/playwright-cli"
+    },
+    {
+      "id": "testing-plugin/playwright-testing",
+      "line": "testing-plugin/playwright-testing"
+    },
+    {
+      "id": "testing-plugin/property-based-testing",
+      "line": "testing-plugin/property-based-testing"
+    },
+    {
+      "id": "testing-plugin/test-analyze",
+      "line": "testing-plugin/test-analyze"
+    },
+    {
+      "id": "testing-plugin/test-consult",
+      "line": "testing-plugin/test-consult"
+    },
+    {
+      "id": "testing-plugin/test-focus",
+      "line": "testing-plugin/test-focus"
+    },
+    {
+      "id": "testing-plugin/test-full",
+      "line": "testing-plugin/test-full"
+    },
+    {
+      "id": "testing-plugin/test-quality-analysis",
+      "line": "testing-plugin/test-quality-analysis"
+    },
+    {
+      "id": "testing-plugin/test-quick",
+      "line": "testing-plugin/test-quick"
+    },
+    {
+      "id": "testing-plugin/test-report",
+      "line": "testing-plugin/test-report"
+    },
+    {
+      "id": "testing-plugin/test-run",
+      "line": "testing-plugin/test-run"
+    },
+    {
+      "id": "testing-plugin/test-setup",
+      "line": "testing-plugin/test-setup"
+    },
+    {
+      "id": "testing-plugin/test-strategy-review",
+      "line": "testing-plugin/test-strategy-review"
+    },
+    {
+      "id": "testing-plugin/test-tier-selection",
+      "line": "testing-plugin/test-tier-selection"
+    },
+    {
+      "id": "testing-plugin/vitest-testing",
+      "line": "testing-plugin/vitest-testing"
+    },
+    {
+      "id": "tools-plugin/binary-analysis",
+      "line": "tools-plugin/binary-analysis"
+    },
+    {
+      "id": "tools-plugin/cli-smoke-recipes",
+      "line": "tools-plugin/cli-smoke-recipes"
+    },
+    {
+      "id": "tools-plugin/d2-diagrams",
+      "line": "tools-plugin/d2-diagrams"
+    },
+    {
+      "id": "tools-plugin/deps-install",
+      "line": "tools-plugin/deps-install"
+    },
+    {
+      "id": "tools-plugin/fd-file-finding",
+      "line": "tools-plugin/fd-file-finding"
+    },
+    {
+      "id": "tools-plugin/generate-image",
+      "line": "tools-plugin/generate-image"
+    },
+    {
+      "id": "tools-plugin/hf-downloads",
+      "line": "tools-plugin/hf-downloads"
+    },
+    {
+      "id": "tools-plugin/imagemagick-conversion",
+      "line": "tools-plugin/imagemagick-conversion"
+    },
+    {
+      "id": "tools-plugin/jq-json-processing",
+      "line": "tools-plugin/jq-json-processing"
+    },
+    {
+      "id": "tools-plugin/justfile-expert",
+      "line": "tools-plugin/justfile-expert"
+    },
+    {
+      "id": "tools-plugin/mermaid-diagrams",
+      "line": "tools-plugin/mermaid-diagrams"
+    },
+    {
+      "id": "tools-plugin/nushell-data-processing",
+      "line": "tools-plugin/nushell-data-processing"
+    },
+    {
+      "id": "tools-plugin/rg-code-search",
+      "line": "tools-plugin/rg-code-search"
+    },
+    {
+      "id": "tools-plugin/shell-expert",
+      "line": "tools-plugin/shell-expert"
+    },
+    {
+      "id": "tools-plugin/yq-yaml-processing",
+      "line": "tools-plugin/yq-yaml-processing"
+    },
+    {
+      "id": "typescript-plugin/biome-tooling",
+      "line": "typescript-plugin/biome-tooling"
+    },
+    {
+      "id": "typescript-plugin/bun-add",
+      "line": "typescript-plugin/bun-add"
+    },
+    {
+      "id": "typescript-plugin/bun-build",
+      "line": "typescript-plugin/bun-build"
+    },
+    {
+      "id": "typescript-plugin/bun-debug",
+      "line": "typescript-plugin/bun-debug"
+    },
+    {
+      "id": "typescript-plugin/bun-development",
+      "line": "typescript-plugin/bun-development"
+    },
+    {
+      "id": "typescript-plugin/bun-install",
+      "line": "typescript-plugin/bun-install"
+    },
+    {
+      "id": "typescript-plugin/bun-lockfile-update",
+      "line": "typescript-plugin/bun-lockfile-update"
+    },
+    {
+      "id": "typescript-plugin/bun-outdated",
+      "line": "typescript-plugin/bun-outdated"
+    },
+    {
+      "id": "typescript-plugin/bun-package-manager",
+      "line": "typescript-plugin/bun-package-manager"
+    },
+    {
+      "id": "typescript-plugin/bun-publish",
+      "line": "typescript-plugin/bun-publish"
+    },
+    {
+      "id": "typescript-plugin/bun-publishing",
+      "line": "typescript-plugin/bun-publishing"
+    },
+    {
+      "id": "typescript-plugin/bun-test",
+      "line": "typescript-plugin/bun-test"
+    },
+    {
+      "id": "typescript-plugin/knip-dead-code",
+      "line": "typescript-plugin/knip-dead-code"
+    },
+    {
+      "id": "typescript-plugin/nodejs-development",
+      "line": "typescript-plugin/nodejs-development"
+    },
+    {
+      "id": "typescript-plugin/typescript-debugging",
+      "line": "typescript-plugin/typescript-debugging"
+    },
+    {
+      "id": "typescript-plugin/typescript-sentry",
+      "line": "typescript-plugin/typescript-sentry"
+    },
+    {
+      "id": "typescript-plugin/typescript-strict",
+      "line": "typescript-plugin/typescript-strict"
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-checkpoint-refactor",
+      "line": "workflow-orchestration-plugin/workflow-checkpoint-refactor"
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-preflight",
+      "line": "workflow-orchestration-plugin/workflow-preflight"
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-verify-before-filing",
+      "line": "workflow-orchestration-plugin/workflow-verify-before-filing"
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-wave-dispatch",
+      "line": "workflow-orchestration-plugin/workflow-wave-dispatch"
+    }
+  ]
+}

--- a/experiments/skill-catalog-routing/catalogs/catalog.short.json
+++ b/experiments/skill-catalog-routing/catalogs/catalog.short.json
@@ -1,0 +1,1627 @@
+{
+  "variant": "short",
+  "source_sha": "020bfd9049809681d21d5b6469696f079f249bd3",
+  "skill_count": 405,
+  "entries": [
+    {
+      "id": "accessibility-plugin/accessibility-implementation",
+      "line": "accessibility-plugin/accessibility-implementation: Use when implementing accessible"
+    },
+    {
+      "id": "accessibility-plugin/design-tokens",
+      "line": "accessibility-plugin/design-tokens: Use when implementing design systems"
+    },
+    {
+      "id": "agent-patterns-plugin/adversarial-review",
+      "line": "agent-patterns-plugin/adversarial-review: Use when stakes are high and a normal"
+    },
+    {
+      "id": "agent-patterns-plugin/agent-teams",
+      "line": "agent-patterns-plugin/agent-teams: Use when running parallel agents"
+    },
+    {
+      "id": "agent-patterns-plugin/cold-read-gate",
+      "line": "agent-patterns-plugin/cold-read-gate: Use when an artifact must survive"
+    },
+    {
+      "id": "agent-patterns-plugin/custom-agent-definitions",
+      "line": "agent-patterns-plugin/custom-agent-definitions: Use when creating an agent .md file"
+    },
+    {
+      "id": "agent-patterns-plugin/exclusive-lock-dispatch",
+      "line": "agent-patterns-plugin/exclusive-lock-dispatch: Use when fanning out parallel agents"
+    },
+    {
+      "id": "agent-patterns-plugin/execution-grounded-review",
+      "line": "agent-patterns-plugin/execution-grounded-review: Use when verifying an implementation"
+    },
+    {
+      "id": "agent-patterns-plugin/expose-tunable-knob",
+      "line": "agent-patterns-plugin/expose-tunable-knob: Use when tuning visual"
+    },
+    {
+      "id": "agent-patterns-plugin/mcp-code-execution",
+      "line": "agent-patterns-plugin/mcp-code-execution: Use when agents call many MCP tools"
+    },
+    {
+      "id": "agent-patterns-plugin/mcp-management",
+      "line": "agent-patterns-plugin/mcp-management: Use when adding/enabling servers"
+    },
+    {
+      "id": "agent-patterns-plugin/mcp-server-authoring",
+      "line": "agent-patterns-plugin/mcp-server-authoring: Use when building"
+    },
+    {
+      "id": "agent-patterns-plugin/meta-assimilate",
+      "line": "agent-patterns-plugin/meta-assimilate: Use when assimilating another project's"
+    },
+    {
+      "id": "agent-patterns-plugin/meta-audit",
+      "line": "agent-patterns-plugin/meta-audit: Use when reviewing agents/ for missing"
+    },
+    {
+      "id": "agent-patterns-plugin/meta-context-diet",
+      "line": "agent-patterns-plugin/meta-context-diet: Use when CLAUDE.md feels bloated"
+    },
+    {
+      "id": "agent-patterns-plugin/meta-promote",
+      "line": "agent-patterns-plugin/meta-promote: Use when reorganizing .claude/"
+    },
+    {
+      "id": "agent-patterns-plugin/multi-model-delegation",
+      "line": "agent-patterns-plugin/multi-model-delegation: Use when asking other models"
+    },
+    {
+      "id": "agent-patterns-plugin/parallel-agent-dispatch",
+      "line": "agent-patterns-plugin/parallel-agent-dispatch: Use when fanning out concurrent agents"
+    },
+    {
+      "id": "agent-patterns-plugin/plugin-settings",
+      "line": "agent-patterns-plugin/plugin-settings: Use when building plugins"
+    },
+    {
+      "id": "agent-patterns-plugin/verify-before-plan",
+      "line": "agent-patterns-plugin/verify-before-plan: Use when a wave's briefs cite a number"
+    },
+    {
+      "id": "agent-patterns-plugin/wave-based-dispatch",
+      "line": "agent-patterns-plugin/wave-based-dispatch: Use when planning dependent multi-WO"
+    },
+    {
+      "id": "agents-plugin/agents-analyze",
+      "line": "agents-plugin/agents-analyze: Use when reviewing where sub-agents"
+    },
+    {
+      "id": "api-plugin/api-testing",
+      "line": "api-plugin/api-testing: Use when the user mentions API testing"
+    },
+    {
+      "id": "bevy-plugin/bevy-ecs-patterns",
+      "line": "bevy-plugin/bevy-ecs-patterns: Use when optimizing Bevy architecture"
+    },
+    {
+      "id": "bevy-plugin/bevy-game-engine",
+      "line": "bevy-plugin/bevy-game-engine: Use when building Bevy games"
+    },
+    {
+      "id": "blog-plugin/blog-post",
+      "line": "blog-plugin/blog-post: Use when writing a quick update"
+    },
+    {
+      "id": "blog-plugin/blog-post-writing",
+      "line": "blog-plugin/blog-post-writing: Use when writing about work done"
+    },
+    {
+      "id": "blueprint-plugin/adr-relationships",
+      "line": "blueprint-plugin/adr-relationships: Use when creating"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-adr-list",
+      "line": "blueprint-plugin/blueprint-adr-list: Use when generating an ADR index"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-adr-validate",
+      "line": "blueprint-plugin/blueprint-adr-validate: Use when auditing ADRs before release"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-autopilot",
+      "line": "blueprint-plugin/blueprint-autopilot: Use when a drift nudge reports blueprint"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-claude-md",
+      "line": "blueprint-plugin/blueprint-claude-md: Use when adding team instructions"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-curate-docs",
+      "line": "blueprint-plugin/blueprint-curate-docs: Use when documenting library knowledge"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-derive-plans",
+      "line": "blueprint-plugin/blueprint-derive-plans: Use when onboarding a project"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-derive-rules",
+      "line": "blueprint-plugin/blueprint-derive-rules: Use when extracting implicit decisions"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-derive-tests",
+      "line": "blueprint-plugin/blueprint-derive-tests: Use when finding untested bug fixes"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-development",
+      "line": "blueprint-plugin/blueprint-development: Use when generating architecture"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-docs-currency",
+      "line": "blueprint-plugin/blueprint-docs-currency: Use when committing API/format changes"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-docs-list",
+      "line": "blueprint-plugin/blueprint-docs-list: Use when listing docs"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-execute",
+      "line": "blueprint-plugin/blueprint-execute: Use when asked 'what's next?'"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-feature-tracker-status",
+      "line": "blueprint-plugin/blueprint-feature-tracker-status: Use when checking feature status"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-feature-tracker-sync",
+      "line": "blueprint-plugin/blueprint-feature-tracker-sync: Use when reconciling TODO.md vs tracker"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-generate-rules",
+      "line": "blueprint-plugin/blueprint-generate-rules: Use when auto-creating architecture"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-init",
+      "line": "blueprint-plugin/blueprint-init: Use when bootstrapping docs/blueprint/"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-migration",
+      "line": "blueprint-plugin/blueprint-migration: Use when blueprint-upgrade needs"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-promote",
+      "line": "blueprint-plugin/blueprint-promote: Use when promoting a generated rule"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-prp-create",
+      "line": "blueprint-plugin/blueprint-prp-create: Use when planning a feature packet"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-prp-execute",
+      "line": "blueprint-plugin/blueprint-prp-execute: Use when asked to execute a PRP"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-rules",
+      "line": "blueprint-plugin/blueprint-rules: Use when adding"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-status",
+      "line": "blueprint-plugin/blueprint-status: Use when auditing traceability"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-story-audit",
+      "line": "blueprint-plugin/blueprint-story-audit: Use when running story audit"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-story-reconcile",
+      "line": "blueprint-plugin/blueprint-story-reconcile: Use when marking PRD entries"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-sync",
+      "line": "blueprint-plugin/blueprint-sync: Use when syncing blueprint after PRD"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-sync-ids",
+      "line": "blueprint-plugin/blueprint-sync-ids: Use when assigning IDs to docs"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-upgrade",
+      "line": "blueprint-plugin/blueprint-upgrade: Use when migrating between format"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-work-order",
+      "line": "blueprint-plugin/blueprint-work-order: Use when breaking a PRP into delegatable"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-workspace-scan",
+      "line": "blueprint-plugin/blueprint-workspace-scan: Use when adding/removing a child"
+    },
+    {
+      "id": "blueprint-plugin/confidence-scoring",
+      "line": "blueprint-plugin/confidence-scoring: Use when evaluating readiness"
+    },
+    {
+      "id": "blueprint-plugin/document-detection",
+      "line": "blueprint-plugin/document-detection: Use when the user discusses feature"
+    },
+    {
+      "id": "blueprint-plugin/document-linking",
+      "line": "blueprint-plugin/document-linking: Use when linking docs"
+    },
+    {
+      "id": "blueprint-plugin/feature-tracking",
+      "line": "blueprint-plugin/feature-tracking: Use when linking features to PRDs"
+    },
+    {
+      "id": "code-quality-plugin/ast-grep-search",
+      "line": "code-quality-plugin/ast-grep-search: Use when matching code by AST structure"
+    },
+    {
+      "id": "code-quality-plugin/bulk-sweep-classify",
+      "line": "code-quality-plugin/bulk-sweep-classify: Use when bulk-renaming"
+    },
+    {
+      "id": "code-quality-plugin/code-antipatterns",
+      "line": "code-quality-plugin/code-antipatterns: Use when finding magic numbers"
+    },
+    {
+      "id": "code-quality-plugin/code-complexity",
+      "line": "code-quality-plugin/code-complexity: Use when identifying refactoring targets"
+    },
+    {
+      "id": "code-quality-plugin/code-dead-code",
+      "line": "code-quality-plugin/code-dead-code: Use when reducing maintenance burden"
+    },
+    {
+      "id": "code-quality-plugin/code-dep-audit",
+      "line": "code-quality-plugin/code-dep-audit: Use when checking supply chain security"
+    },
+    {
+      "id": "code-quality-plugin/code-docs-quality",
+      "line": "code-quality-plugin/code-docs-quality: Use when auditing documentation"
+    },
+    {
+      "id": "code-quality-plugin/code-hidden-failures",
+      "line": "code-quality-plugin/code-hidden-failures: Use when failures vanish"
+    },
+    {
+      "id": "code-quality-plugin/code-lint",
+      "line": "code-quality-plugin/code-lint: Use when linting code"
+    },
+    {
+      "id": "code-quality-plugin/code-refactor",
+      "line": "code-quality-plugin/code-refactor: Use when extracting pure functions"
+    },
+    {
+      "id": "code-quality-plugin/code-review",
+      "line": "code-quality-plugin/code-review: Use when reviewing code"
+    },
+    {
+      "id": "code-quality-plugin/code-review-checklist",
+      "line": "code-quality-plugin/code-review-checklist: Use when reviewing PRs"
+    },
+    {
+      "id": "code-quality-plugin/code-test-quality",
+      "line": "code-quality-plugin/code-test-quality: Use when tests are unreliable"
+    },
+    {
+      "id": "code-quality-plugin/debugging-methodology",
+      "line": "code-quality-plugin/debugging-methodology: Use when diagnosing memory leaks"
+    },
+    {
+      "id": "code-quality-plugin/dry-consolidation",
+      "line": "code-quality-plugin/dry-consolidation: Use when seeing repeated utilities"
+    },
+    {
+      "id": "codebase-attributes-plugin/attributes-collect",
+      "line": "codebase-attributes-plugin/attributes-collect: Use when assessing project health before"
+    },
+    {
+      "id": "codebase-attributes-plugin/attributes-dashboard",
+      "line": "codebase-attributes-plugin/attributes-dashboard: Use when wanting a health overview"
+    },
+    {
+      "id": "codebase-attributes-plugin/attributes-route",
+      "line": "codebase-attributes-plugin/attributes-route: Use when the user has attribute data"
+    },
+    {
+      "id": "comfyui-plugin/comfy-cli",
+      "line": "comfyui-plugin/comfy-cli: Use when the user runs `comfy`"
+    },
+    {
+      "id": "comfyui-plugin/comfy-conditionals",
+      "line": "comfyui-plugin/comfy-conditionals: Use when forming the boolean that drives"
+    },
+    {
+      "id": "comfyui-plugin/comfy-corpus-validation",
+      "line": "comfyui-plugin/comfy-corpus-validation: Use when writing"
+    },
+    {
+      "id": "comfyui-plugin/comfy-debug-preview",
+      "line": "comfyui-plugin/comfy-debug-preview: Use when inspecting a value mid-graph"
+    },
+    {
+      "id": "comfyui-plugin/comfy-flow-control",
+      "line": "comfyui-plugin/comfy-flow-control: Use when wiring where a signal routes"
+    },
+    {
+      "id": "comfyui-plugin/comfy-image-utils",
+      "line": "comfyui-plugin/comfy-image-utils: Use when manipulating images"
+    },
+    {
+      "id": "comfyui-plugin/comfy-math-strings",
+      "line": "comfyui-plugin/comfy-math-strings: Use when computing a value"
+    },
+    {
+      "id": "comfyui-plugin/comfy-metadata",
+      "line": "comfyui-plugin/comfy-metadata: Use when figuring out what"
+    },
+    {
+      "id": "comfyui-plugin/comfy-node",
+      "line": "comfyui-plugin/comfy-node: Use when releasing"
+    },
+    {
+      "id": "comfyui-plugin/comfy-registry-lifecycle",
+      "line": "comfyui-plugin/comfy-registry-lifecycle: Use when debugging a pack's publish"
+    },
+    {
+      "id": "comfyui-plugin/comfy-subgraphs-app-mode",
+      "line": "comfyui-plugin/comfy-subgraphs-app-mode: Use when deciding how to package"
+    },
+    {
+      "id": "comfyui-plugin/comfy-workflow-json",
+      "line": "comfyui-plugin/comfy-workflow-json: Use when a workflow JSON is too large"
+    },
+    {
+      "id": "comfyui-plugin/comfy-workflow-layout",
+      "line": "comfyui-plugin/comfy-workflow-layout: Use when a workflow's nodes overlap"
+    },
+    {
+      "id": "comfyui-plugin/comfyui-node-authoring",
+      "line": "comfyui-plugin/comfyui-node-authoring: Use when writing"
+    },
+    {
+      "id": "comfyui-plugin/comfyui-node-scaffold",
+      "line": "comfyui-plugin/comfyui-node-scaffold: Use when bootstrapping"
+    },
+    {
+      "id": "comfyui-plugin/comfyui-pack-live-smoke",
+      "line": "comfyui-plugin/comfyui-pack-live-smoke: Use when verifying a pack before opening"
+    },
+    {
+      "id": "comfyui-plugin/comfyui-screenshot-pipeline",
+      "line": "comfyui-plugin/comfyui-screenshot-pipeline: Use when generating pack screenshots"
+    },
+    {
+      "id": "communication-plugin/google-chat-formatting",
+      "line": "communication-plugin/google-chat-formatting: Use when formatting messages for Google"
+    },
+    {
+      "id": "communication-plugin/ticket-drafting-guidelines",
+      "line": "communication-plugin/ticket-drafting-guidelines: Use when creating issues"
+    },
+    {
+      "id": "component-patterns-plugin/components-version-badge",
+      "line": "component-patterns-plugin/components-version-badge: Use when adding version display to app"
+    },
+    {
+      "id": "component-patterns-plugin/version-badge-pattern",
+      "line": "component-patterns-plugin/version-badge-pattern: Use when adding version visibility"
+    },
+    {
+      "id": "configure-plugin/ci-workflows",
+      "line": "configure-plugin/ci-workflows: Use when checking CI/CD compliance"
+    },
+    {
+      "id": "configure-plugin/claude-security-settings",
+      "line": "configure-plugin/claude-security-settings: Use when auditing"
+    },
+    {
+      "id": "configure-plugin/config-sync",
+      "line": "configure-plugin/config-sync: Use when syncing workflows"
+    },
+    {
+      "id": "configure-plugin/configure-all",
+      "line": "configure-plugin/configure-all: Use when onboarding a new project"
+    },
+    {
+      "id": "configure-plugin/configure-api-tests",
+      "line": "configure-plugin/configure-api-tests: Use when adding consumer/provider"
+    },
+    {
+      "id": "configure-plugin/configure-argocd-automerge",
+      "line": "configure-plugin/configure-argocd-automerge: Use when setting up argocd-automerge.yml"
+    },
+    {
+      "id": "configure-plugin/configure-cache-busting",
+      "line": "configure-plugin/configure-cache-busting: Use when adding Vercel/Cloudflare cache"
+    },
+    {
+      "id": "configure-plugin/configure-claude-plugins",
+      "line": "configure-plugin/configure-claude-plugins: Use when onboarding to claude-plugins"
+    },
+    {
+      "id": "configure-plugin/configure-container",
+      "line": "configure-plugin/configure-container: Use when setting up multi-platform GHCR"
+    },
+    {
+      "id": "configure-plugin/configure-coverage",
+      "line": "configure-plugin/configure-coverage: Use when setting thresholds"
+    },
+    {
+      "id": "configure-plugin/configure-dead-code",
+      "line": "configure-plugin/configure-dead-code: Use when setting up unused-code scanning"
+    },
+    {
+      "id": "configure-plugin/configure-dockerfile",
+      "line": "configure-plugin/configure-dockerfile: Use when creating a Dockerfile"
+    },
+    {
+      "id": "configure-plugin/configure-docs",
+      "line": "configure-plugin/configure-docs: Use when setting up docstrings"
+    },
+    {
+      "id": "configure-plugin/configure-editor",
+      "line": "configure-plugin/configure-editor: Use when setting up format-on-save"
+    },
+    {
+      "id": "configure-plugin/configure-feature-flags",
+      "line": "configure-plugin/configure-feature-flags: Use when setting up the SDK"
+    },
+    {
+      "id": "configure-plugin/configure-formatting",
+      "line": "configure-plugin/configure-formatting: Use when setting up formatting"
+    },
+    {
+      "id": "configure-plugin/configure-gitattributes",
+      "line": "configure-plugin/configure-gitattributes: Use when setting up .gitattributes"
+    },
+    {
+      "id": "configure-plugin/configure-github-pages",
+      "line": "configure-plugin/configure-github-pages: Use when setting up Pages"
+    },
+    {
+      "id": "configure-plugin/configure-gitignore",
+      "line": "configure-plugin/configure-gitignore: Use when onboarding a repo"
+    },
+    {
+      "id": "configure-plugin/configure-instrumentation",
+      "line": "configure-plugin/configure-instrumentation: Use when wiring telemetry"
+    },
+    {
+      "id": "configure-plugin/configure-integration-tests",
+      "line": "configure-plugin/configure-integration-tests: Use when setting up integration tests"
+    },
+    {
+      "id": "configure-plugin/configure-justfile",
+      "line": "configure-plugin/configure-justfile: Use when setting up a Justfile"
+    },
+    {
+      "id": "configure-plugin/configure-linting",
+      "line": "configure-plugin/configure-linting: Use when setting up linting"
+    },
+    {
+      "id": "configure-plugin/configure-load-tests",
+      "line": "configure-plugin/configure-load-tests: Use when setting up load tests"
+    },
+    {
+      "id": "configure-plugin/configure-makefile",
+      "line": "configure-plugin/configure-makefile: Use when setting up a Makefile"
+    },
+    {
+      "id": "configure-plugin/configure-mcp",
+      "line": "configure-plugin/configure-mcp: Use when setting up MCP servers"
+    },
+    {
+      "id": "configure-plugin/configure-memory-profiling",
+      "line": "configure-plugin/configure-memory-profiling: Use when setting up memory profiling"
+    },
+    {
+      "id": "configure-plugin/configure-mise",
+      "line": "configure-plugin/configure-mise: Use when setting up"
+    },
+    {
+      "id": "configure-plugin/configure-package-management",
+      "line": "configure-plugin/configure-package-management: Use when setting up uv"
+    },
+    {
+      "id": "configure-plugin/configure-pre-commit",
+      "line": "configure-plugin/configure-pre-commit: Use when installing hooks"
+    },
+    {
+      "id": "configure-plugin/configure-readme",
+      "line": "configure-plugin/configure-readme: Use when creating a README"
+    },
+    {
+      "id": "configure-plugin/configure-release-please",
+      "line": "configure-plugin/configure-release-please: Use when configuring release-please"
+    },
+    {
+      "id": "configure-plugin/configure-repo",
+      "line": "configure-plugin/configure-repo: Use when onboarding any repo to Claude"
+    },
+    {
+      "id": "configure-plugin/configure-reusable-workflows",
+      "line": "configure-plugin/configure-reusable-workflows: Use when adding OWASP/secret/code-smell"
+    },
+    {
+      "id": "configure-plugin/configure-security",
+      "line": "configure-plugin/configure-security: Use when setting up Dependabot"
+    },
+    {
+      "id": "configure-plugin/configure-select",
+      "line": "configure-plugin/configure-select: Use when setting up specific components"
+    },
+    {
+      "id": "configure-plugin/configure-sentry",
+      "line": "configure-plugin/configure-sentry: Use when installing the Sentry SDK"
+    },
+    {
+      "id": "configure-plugin/configure-skaffold",
+      "line": "configure-plugin/configure-skaffold: Use when fixing 0.0.0.0 binding"
+    },
+    {
+      "id": "configure-plugin/configure-status",
+      "line": "configure-plugin/configure-status: Use when checking overall compliance"
+    },
+    {
+      "id": "configure-plugin/configure-surface",
+      "line": "configure-plugin/configure-surface: Use when adding"
+    },
+    {
+      "id": "configure-plugin/configure-tests",
+      "line": "configure-plugin/configure-tests: Use when setting up test infrastructure"
+    },
+    {
+      "id": "configure-plugin/configure-ux-testing",
+      "line": "configure-plugin/configure-ux-testing: Use when setting up E2E testing"
+    },
+    {
+      "id": "configure-plugin/configure-web-session",
+      "line": "configure-plugin/configure-web-session: Use when CI tools fail in remote"
+    },
+    {
+      "id": "configure-plugin/configure-workflows",
+      "line": "configure-plugin/configure-workflows: Use when updating outdated action"
+    },
+    {
+      "id": "configure-plugin/configure-worktreeinclude",
+      "line": "configure-plugin/configure-worktreeinclude: Use when worktrees miss .env"
+    },
+    {
+      "id": "configure-plugin/go-feature-flag",
+      "line": "configure-plugin/go-feature-flag: Use when working with GOFF"
+    },
+    {
+      "id": "configure-plugin/multi-repo-discipline",
+      "line": "configure-plugin/multi-repo-discipline: Use when dispatching agents across"
+    },
+    {
+      "id": "configure-plugin/openfeature",
+      "line": "configure-plugin/openfeature: Use when implementing feature flags"
+    },
+    {
+      "id": "container-plugin/container-development",
+      "line": "container-plugin/container-development: Use when working with Docker"
+    },
+    {
+      "id": "container-plugin/deploy-handoff",
+      "line": "container-plugin/deploy-handoff: Use when handing off a service"
+    },
+    {
+      "id": "container-plugin/deploy-release",
+      "line": "container-plugin/deploy-release: Use when cutting a release"
+    },
+    {
+      "id": "container-plugin/go-containers",
+      "line": "container-plugin/go-containers: Use when working with Go containers"
+    },
+    {
+      "id": "container-plugin/nodejs-containers",
+      "line": "container-plugin/nodejs-containers: Use when working with Node.js containers"
+    },
+    {
+      "id": "container-plugin/python-containers",
+      "line": "container-plugin/python-containers: Use when working with Python containers"
+    },
+    {
+      "id": "container-plugin/skaffold-filesync",
+      "line": "container-plugin/skaffold-filesync: Use when optimizing the dev loop"
+    },
+    {
+      "id": "container-plugin/skaffold-orbstack",
+      "line": "container-plugin/skaffold-orbstack: Use when configuring Skaffold"
+    },
+    {
+      "id": "container-plugin/skaffold-testing",
+      "line": "container-plugin/skaffold-testing: Use when configuring pre-deploy tests"
+    },
+    {
+      "id": "css-plugin/lightning-css",
+      "line": "css-plugin/lightning-css: Use when configuring CSS in Vite"
+    },
+    {
+      "id": "css-plugin/unocss",
+      "line": "css-plugin/unocss: Use when setting up utility-first CSS"
+    },
+    {
+      "id": "documentation-plugin/claude-blog-sources",
+      "line": "documentation-plugin/claude-blog-sources: Use when researching Claude Code"
+    },
+    {
+      "id": "documentation-plugin/docs-decommission",
+      "line": "documentation-plugin/docs-decommission: Use when decommissioning a service"
+    },
+    {
+      "id": "documentation-plugin/docs-generate",
+      "line": "documentation-plugin/docs-generate: Use when wanting API reference"
+    },
+    {
+      "id": "documentation-plugin/docs-latex",
+      "line": "documentation-plugin/docs-latex: Use when wanting a presentation-quality"
+    },
+    {
+      "id": "documentation-plugin/docs-sync",
+      "line": "documentation-plugin/docs-sync: Use when docs are out of sync"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-improve",
+      "line": "evaluate-plugin/evaluate-improve: Use when raising pass rates"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-legibility",
+      "line": "evaluate-plugin/evaluate-legibility: Use when validating whether a skill says"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-matrix",
+      "line": "evaluate-plugin/evaluate-matrix: Use when checking whether a weak model"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-plugin-batch",
+      "line": "evaluate-plugin/evaluate-plugin-batch: Use when auditing an entire plugin's"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-report",
+      "line": "evaluate-plugin/evaluate-report: Use when reviewing past eval results"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-skill",
+      "line": "evaluate-plugin/evaluate-skill: Use when testing whether a skill"
+    },
+    {
+      "id": "feedback-plugin/feedback-session",
+      "line": "feedback-plugin/feedback-session: Use when a skill gave wrong guidance"
+    },
+    {
+      "id": "finops-plugin/finops-caches",
+      "line": "finops-plugin/finops-caches: Use when investigating cache bloat"
+    },
+    {
+      "id": "finops-plugin/finops-compare",
+      "line": "finops-plugin/finops-compare: Use when benchmarking repos"
+    },
+    {
+      "id": "finops-plugin/finops-overview",
+      "line": "finops-plugin/finops-overview: Use when you want a high-level view"
+    },
+    {
+      "id": "finops-plugin/finops-waste",
+      "line": "finops-plugin/finops-waste: Use when CI costs are high"
+    },
+    {
+      "id": "finops-plugin/finops-workflows",
+      "line": "finops-plugin/finops-workflows: Use when investigating slow CI"
+    },
+    {
+      "id": "finops-plugin/github-actions-cache-optimization",
+      "line": "finops-plugin/github-actions-cache-optimization: Use when investigating cache bloat"
+    },
+    {
+      "id": "finops-plugin/github-actions-finops",
+      "line": "finops-plugin/github-actions-finops: Use when investigating CI/CD costs"
+    },
+    {
+      "id": "foundryvtt-plugin/foundryvtt-module",
+      "line": "foundryvtt-plugin/foundryvtt-module: Use when releasing"
+    },
+    {
+      "id": "foundryvtt-plugin/foundryvtt-module-scaffold",
+      "line": "foundryvtt-plugin/foundryvtt-module-scaffold: Use when bootstrapping"
+    },
+    {
+      "id": "git-plugin/deadbranch",
+      "line": "git-plugin/deadbranch: Use when asked to clean up branches"
+    },
+    {
+      "id": "git-plugin/gh-cli-agentic",
+      "line": "git-plugin/gh-cli-agentic: Use when querying PRs"
+    },
+    {
+      "id": "git-plugin/gh-workflow-monitoring",
+      "line": "git-plugin/gh-workflow-monitoring: Use when waiting for CI after push"
+    },
+    {
+      "id": "git-plugin/git-api-pr",
+      "line": "git-plugin/git-api-pr: Use when submitting file changes as a PR"
+    },
+    {
+      "id": "git-plugin/git-branch-naming",
+      "line": "git-plugin/git-branch-naming: Use when creating branches"
+    },
+    {
+      "id": "git-plugin/git-branch-pr-workflow",
+      "line": "git-plugin/git-branch-pr-workflow: Use when creating branches"
+    },
+    {
+      "id": "git-plugin/git-cli-agentic",
+      "line": "git-plugin/git-cli-agentic: Use when scripting status/diff/log"
+    },
+    {
+      "id": "git-plugin/git-commit",
+      "line": "git-plugin/git-commit: Use when user says \"commit\""
+    },
+    {
+      "id": "git-plugin/git-commit-push-pr",
+      "line": "git-plugin/git-commit-push-pr: Use when the user says \"create pr\""
+    },
+    {
+      "id": "git-plugin/git-commit-trailers",
+      "line": "git-plugin/git-commit-trailers: Use when composing messages"
+    },
+    {
+      "id": "git-plugin/git-commit-workflow",
+      "line": "git-plugin/git-commit-workflow: Use when writing commit messages"
+    },
+    {
+      "id": "git-plugin/git-conflicts",
+      "line": "git-plugin/git-conflicts: Use when a merge/rebase has conflicts"
+    },
+    {
+      "id": "git-plugin/git-coworker-check",
+      "line": "git-plugin/git-coworker-check: Use when starting a session in a shared"
+    },
+    {
+      "id": "git-plugin/git-derive-docs",
+      "line": "git-plugin/git-derive-docs: Use when finding doc gaps"
+    },
+    {
+      "id": "git-plugin/git-fix-pr",
+      "line": "git-plugin/git-fix-pr: Use when asked to fix a PR"
+    },
+    {
+      "id": "git-plugin/git-fork-workflow",
+      "line": "git-plugin/git-fork-workflow: Use when working with forks"
+    },
+    {
+      "id": "git-plugin/git-issue",
+      "line": "git-plugin/git-issue: Use when asked to work on an issue"
+    },
+    {
+      "id": "git-plugin/git-issue-hierarchy",
+      "line": "git-plugin/git-issue-hierarchy: Use when breaking issues into sub-tasks"
+    },
+    {
+      "id": "git-plugin/git-issue-manage",
+      "line": "git-plugin/git-issue-manage: Use when transferring issues"
+    },
+    {
+      "id": "git-plugin/git-maintain",
+      "line": "git-plugin/git-maintain: Use when asked to clean up the repo"
+    },
+    {
+      "id": "git-plugin/git-pr",
+      "line": "git-plugin/git-pr: Use when user says \"create PR\""
+    },
+    {
+      "id": "git-plugin/git-pr-feedback",
+      "line": "git-plugin/git-pr-feedback: Use when CHANGES_REQUESTED is set"
+    },
+    {
+      "id": "git-plugin/git-pr-sync-check",
+      "line": "git-plugin/git-pr-sync-check: Use when continuing work on a PR branch"
+    },
+    {
+      "id": "git-plugin/git-pr-watch",
+      "line": "git-plugin/git-pr-watch: Use when watching/monitoring/babysitting"
+    },
+    {
+      "id": "git-plugin/git-push",
+      "line": "git-plugin/git-push: Use when user says \"push\""
+    },
+    {
+      "id": "git-plugin/git-rebase-patterns",
+      "line": "git-plugin/git-rebase-patterns: Use when rebasing branches"
+    },
+    {
+      "id": "git-plugin/git-repo-detection",
+      "line": "git-plugin/git-repo-detection: Use when needing the owner/repo"
+    },
+    {
+      "id": "git-plugin/git-security-checks",
+      "line": "git-plugin/git-security-checks: Use when scanning for secrets"
+    },
+    {
+      "id": "git-plugin/git-triage",
+      "line": "git-plugin/git-triage: Use when grooming the backlog"
+    },
+    {
+      "id": "git-plugin/git-upstream-pr",
+      "line": "git-plugin/git-upstream-pr: Use when contributing changes upstream"
+    },
+    {
+      "id": "git-plugin/git-upstream-pr-diverged",
+      "line": "git-plugin/git-upstream-pr-diverged: Use when direct rebase fails"
+    },
+    {
+      "id": "git-plugin/github-issue-autodetect",
+      "line": "git-plugin/github-issue-autodetect: Use when committing to ensure proper"
+    },
+    {
+      "id": "git-plugin/github-issue-writing",
+      "line": "git-plugin/github-issue-writing: Use when filing bugs"
+    },
+    {
+      "id": "git-plugin/github-labels",
+      "line": "git-plugin/github-labels: Use when asked to label a PR/issue"
+    },
+    {
+      "id": "git-plugin/github-pr-title",
+      "line": "git-plugin/github-pr-title: Use when creating PRs"
+    },
+    {
+      "id": "git-plugin/release-please-configuration",
+      "line": "git-plugin/release-please-configuration: Use when adding packages"
+    },
+    {
+      "id": "git-plugin/release-please-pr-workflow",
+      "line": "git-plugin/release-please-pr-workflow: Use when merging release PRs"
+    },
+    {
+      "id": "git-plugin/release-please-protection",
+      "line": "git-plugin/release-please-protection: Use when editing changelogs"
+    },
+    {
+      "id": "github-actions-plugin/claude-code-github-workflows",
+      "line": "github-actions-plugin/claude-code-github-workflows: Use when creating"
+    },
+    {
+      "id": "github-actions-plugin/github-actions-auth-security",
+      "line": "github-actions-plugin/github-actions-auth-security: Use when setting up workflow"
+    },
+    {
+      "id": "github-actions-plugin/github-actions-inspection",
+      "line": "github-actions-plugin/github-actions-inspection: Use when investigating CI/CD failures"
+    },
+    {
+      "id": "github-actions-plugin/github-actions-mcp-config",
+      "line": "github-actions-plugin/github-actions-mcp-config: Use when configuring MCP servers"
+    },
+    {
+      "id": "github-actions-plugin/github-issue-search",
+      "line": "github-actions-plugin/github-issue-search: Use when encountering errors with OSS"
+    },
+    {
+      "id": "github-actions-plugin/github-social-preview",
+      "line": "github-actions-plugin/github-social-preview: Use when asked for social preview"
+    },
+    {
+      "id": "github-actions-plugin/github-workflow-auto-fix",
+      "line": "github-actions-plugin/github-workflow-auto-fix: Use when adding a workflow that analyzes"
+    },
+    {
+      "id": "github-actions-plugin/workflow-dev",
+      "line": "github-actions-plugin/workflow-dev: Use when running a continuous dev loop"
+    },
+    {
+      "id": "health-plugin/health-agentic-audit",
+      "line": "health-plugin/health-agentic-audit: Use when batch-checking skill"
+    },
+    {
+      "id": "health-plugin/health-audit",
+      "line": "health-plugin/health-audit: Use when cleaning up unused plugins"
+    },
+    {
+      "id": "health-plugin/health-check",
+      "line": "health-plugin/health-check: Use when checking project health"
+    },
+    {
+      "id": "health-plugin/health-plugins",
+      "line": "health-plugin/health-plugins: Use when seeing plugin-already-installed"
+    },
+    {
+      "id": "health-plugin/health-skill-audit",
+      "line": "health-plugin/health-skill-audit: Use when finding confusing skill"
+    },
+    {
+      "id": "health-plugin/plugin-registry",
+      "line": "health-plugin/plugin-registry: Use when troubleshooting plugin"
+    },
+    {
+      "id": "health-plugin/settings-configuration",
+      "line": "health-plugin/settings-configuration: Use when setting up permissions"
+    },
+    {
+      "id": "home-assistant-plugin/ha-automations",
+      "line": "home-assistant-plugin/ha-automations: Use when working with HA triggers"
+    },
+    {
+      "id": "home-assistant-plugin/ha-configuration",
+      "line": "home-assistant-plugin/ha-configuration: Use when editing configuration.yaml"
+    },
+    {
+      "id": "home-assistant-plugin/ha-entities",
+      "line": "home-assistant-plugin/ha-entities: Use when working with entity IDs"
+    },
+    {
+      "id": "home-assistant-plugin/ha-validate",
+      "line": "home-assistant-plugin/ha-validate: Use when validating HA config"
+    },
+    {
+      "id": "hooks-plugin/hooks-configuration",
+      "line": "hooks-plugin/hooks-configuration: Use when the user mentions hooks"
+    },
+    {
+      "id": "hooks-plugin/hooks-permission-request-hook",
+      "line": "hooks-plugin/hooks-permission-request-hook: Use when needing a safer alternative"
+    },
+    {
+      "id": "hooks-plugin/hooks-session-end-issue-hook",
+      "line": "hooks-plugin/hooks-session-end-issue-hook: Use when you want deferred work"
+    },
+    {
+      "id": "hooks-plugin/hooks-session-start-hook",
+      "line": "hooks-plugin/hooks-session-start-hook: Use when setting up a repo so"
+    },
+    {
+      "id": "kubernetes-plugin/argocd-login",
+      "line": "kubernetes-plugin/argocd-login: Use when the user mentions ArgoCD login"
+    },
+    {
+      "id": "kubernetes-plugin/helm-chart-development",
+      "line": "kubernetes-plugin/helm-chart-development: Use when the user mentions Helm charts"
+    },
+    {
+      "id": "kubernetes-plugin/helm-debugging",
+      "line": "kubernetes-plugin/helm-debugging: Use when the user mentions Helm errors"
+    },
+    {
+      "id": "kubernetes-plugin/helm-release-management",
+      "line": "kubernetes-plugin/helm-release-management: Use when the user mentions deploying"
+    },
+    {
+      "id": "kubernetes-plugin/helm-release-recovery",
+      "line": "kubernetes-plugin/helm-release-recovery: Use when the user mentions rollback"
+    },
+    {
+      "id": "kubernetes-plugin/helm-values-management",
+      "line": "kubernetes-plugin/helm-values-management: Use when the user mentions Helm values"
+    },
+    {
+      "id": "kubernetes-plugin/kubectl-debugging",
+      "line": "kubernetes-plugin/kubectl-debugging: Use when the user mentions kubectl debug"
+    },
+    {
+      "id": "kubernetes-plugin/kubernetes-operations",
+      "line": "kubernetes-plugin/kubernetes-operations: Use when the user mentions K8s"
+    },
+    {
+      "id": "langchain-plugin/deep-agents",
+      "line": "langchain-plugin/deep-agents: Use when creating orchestrators that"
+    },
+    {
+      "id": "langchain-plugin/langchain-development",
+      "line": "langchain-plugin/langchain-development: Use when working with chat models"
+    },
+    {
+      "id": "langchain-plugin/langchain-init",
+      "line": "langchain-plugin/langchain-init: Use when starting an LLM-powered app"
+    },
+    {
+      "id": "langchain-plugin/langgraph-agents",
+      "line": "langchain-plugin/langgraph-agents: Use when creating state-machine agents"
+    },
+    {
+      "id": "macos-plugin/endpoint-security-cpu",
+      "line": "macos-plugin/endpoint-security-cpu: Use when Kandji ESF / XProtect pegs"
+    },
+    {
+      "id": "macos-plugin/kitty-session-persistence",
+      "line": "macos-plugin/kitty-session-persistence: Use when surviving WindowServer hangs"
+    },
+    {
+      "id": "macos-plugin/launchservices-health",
+      "line": "macos-plugin/launchservices-health: Use when launchservicesd is pegged at"
+    },
+    {
+      "id": "macos-plugin/macos-disk-usage",
+      "line": "macos-plugin/macos-disk-usage: Use when df reports a disk near-full"
+    },
+    {
+      "id": "macos-plugin/macos-incident-postmortem",
+      "line": "macos-plugin/macos-incident-postmortem: Use when investigating hangs"
+    },
+    {
+      "id": "macos-plugin/macos-performance-benchmark",
+      "line": "macos-plugin/macos-performance-benchmark: Use when baselining a Mac"
+    },
+    {
+      "id": "macos-plugin/macos-performance-triage",
+      "line": "macos-plugin/macos-performance-triage: Use when fans spin up"
+    },
+    {
+      "id": "macos-plugin/tui-keybinding-debug",
+      "line": "macos-plugin/tui-keybinding-debug: Use when a configured key does nothing"
+    },
+    {
+      "id": "migration-patterns-plugin/black-to-ruff-format",
+      "line": "migration-patterns-plugin/black-to-ruff-format: Use when psf/black is"
+    },
+    {
+      "id": "migration-patterns-plugin/dual-write",
+      "line": "migration-patterns-plugin/dual-write: Use when planning DB migrations"
+    },
+    {
+      "id": "migration-patterns-plugin/eslint-to-biome",
+      "line": "migration-patterns-plugin/eslint-to-biome: Use when .eslintrc*"
+    },
+    {
+      "id": "migration-patterns-plugin/flake8-to-ruff",
+      "line": "migration-patterns-plugin/flake8-to-ruff: Use when pycqa/flake8"
+    },
+    {
+      "id": "migration-patterns-plugin/mypy-to-ty",
+      "line": "migration-patterns-plugin/mypy-to-ty: Use when mirrors-mypy is"
+    },
+    {
+      "id": "migration-patterns-plugin/shadow-mode",
+      "line": "migration-patterns-plugin/shadow-mode: Use when testing replacement services"
+    },
+    {
+      "id": "networking-plugin/dns-tools",
+      "line": "networking-plugin/dns-tools: Use when looking up A/AAAA/MX/TXT"
+    },
+    {
+      "id": "networking-plugin/http-load-testing",
+      "line": "networking-plugin/http-load-testing: Use when measuring latency percentiles"
+    },
+    {
+      "id": "networking-plugin/interface-state",
+      "line": "networking-plugin/interface-state: Use when viewing"
+    },
+    {
+      "id": "networking-plugin/layer2-discovery",
+      "line": "networking-plugin/layer2-discovery: Use when finding switch port assignments"
+    },
+    {
+      "id": "networking-plugin/network-diagnostics",
+      "line": "networking-plugin/network-diagnostics: Use when tracing routes"
+    },
+    {
+      "id": "networking-plugin/network-discovery",
+      "line": "networking-plugin/network-discovery: Use when scanning TCP ports"
+    },
+    {
+      "id": "networking-plugin/network-monitoring",
+      "line": "networking-plugin/network-monitoring: Use when finding which app consumes"
+    },
+    {
+      "id": "obsidian-plugin/bases",
+      "line": "obsidian-plugin/bases: Use when user mentions Bases"
+    },
+    {
+      "id": "obsidian-plugin/bookmarks",
+      "line": "obsidian-plugin/bookmarks: Use when starring"
+    },
+    {
+      "id": "obsidian-plugin/command-palette",
+      "line": "obsidian-plugin/command-palette: Use when triggering a command"
+    },
+    {
+      "id": "obsidian-plugin/dev-tools",
+      "line": "obsidian-plugin/dev-tools: Use when debugging the app"
+    },
+    {
+      "id": "obsidian-plugin/file-history",
+      "line": "obsidian-plugin/file-history: Use when undoing edits"
+    },
+    {
+      "id": "obsidian-plugin/plugins-themes",
+      "line": "obsidian-plugin/plugins-themes: Use when installing"
+    },
+    {
+      "id": "obsidian-plugin/properties",
+      "line": "obsidian-plugin/properties: Use when user mentions frontmatter"
+    },
+    {
+      "id": "obsidian-plugin/publish-sync",
+      "line": "obsidian-plugin/publish-sync: Use when publishing notes"
+    },
+    {
+      "id": "obsidian-plugin/search-discovery",
+      "line": "obsidian-plugin/search-discovery: Use when exploring backlinks"
+    },
+    {
+      "id": "obsidian-plugin/tasks",
+      "line": "obsidian-plugin/tasks: Use when user mentions Obsidian tasks"
+    },
+    {
+      "id": "obsidian-plugin/templates",
+      "line": "obsidian-plugin/templates: Use when inserting"
+    },
+    {
+      "id": "obsidian-plugin/vault-files",
+      "line": "obsidian-plugin/vault-files: Use when managing vault files"
+    },
+    {
+      "id": "obsidian-plugin/vault-frontmatter",
+      "line": "obsidian-plugin/vault-frontmatter: Use when stripping legacy `id:`"
+    },
+    {
+      "id": "obsidian-plugin/vault-management",
+      "line": "obsidian-plugin/vault-management: Use when checking vault info (path"
+    },
+    {
+      "id": "obsidian-plugin/vault-mocs",
+      "line": "obsidian-plugin/vault-mocs: Use when creating a MOC for a tag"
+    },
+    {
+      "id": "obsidian-plugin/vault-orphans",
+      "line": "obsidian-plugin/vault-orphans: Use when finding orphans"
+    },
+    {
+      "id": "obsidian-plugin/vault-stubs",
+      "line": "obsidian-plugin/vault-stubs: Use when cleaning stubs"
+    },
+    {
+      "id": "obsidian-plugin/vault-tags",
+      "line": "obsidian-plugin/vault-tags: Use when consolidating drifted tags"
+    },
+    {
+      "id": "obsidian-plugin/vault-templates",
+      "line": "obsidian-plugin/vault-templates: Use when fixing unrendered `<%"
+    },
+    {
+      "id": "obsidian-plugin/vault-wikilinks",
+      "line": "obsidian-plugin/vault-wikilinks: Use when fixing `[[Target]]` links"
+    },
+    {
+      "id": "obsidian-plugin/workspaces",
+      "line": "obsidian-plugin/workspaces: Use when checking what's open"
+    },
+    {
+      "id": "project-plugin/changelog-review",
+      "line": "project-plugin/changelog-review: Use when checking new features"
+    },
+    {
+      "id": "project-plugin/project-continue",
+      "line": "project-plugin/project-continue: Use when the user asks to continue work"
+    },
+    {
+      "id": "project-plugin/project-discovery",
+      "line": "project-plugin/project-discovery: Use when entering a new project"
+    },
+    {
+      "id": "project-plugin/project-init",
+      "line": "project-plugin/project-init: Use when starting a new project"
+    },
+    {
+      "id": "project-plugin/project-refocus",
+      "line": "project-plugin/project-refocus: Use when context grew"
+    },
+    {
+      "id": "project-plugin/project-skill-scripts",
+      "line": "project-plugin/project-skill-scripts: Use when auditing skills for script"
+    },
+    {
+      "id": "project-plugin/project-test-loop",
+      "line": "project-plugin/project-test-loop: Use when looping on failing tests"
+    },
+    {
+      "id": "prompt-engineering-plugin/prompt-engineering-ground-response",
+      "line": "prompt-engineering-plugin/prompt-engineering-ground-response: Use when analyzing long docs"
+    },
+    {
+      "id": "prose-plugin/prose-distill",
+      "line": "prose-plugin/prose-distill: Use when asked to condense"
+    },
+    {
+      "id": "prose-plugin/prose-synthesize",
+      "line": "prose-plugin/prose-synthesize: Use when given brain dumps"
+    },
+    {
+      "id": "python-plugin/basedpyright-type-checking",
+      "line": "python-plugin/basedpyright-type-checking: Use when setting up type checking"
+    },
+    {
+      "id": "python-plugin/pytest-advanced",
+      "line": "python-plugin/pytest-advanced: Use when implementing test"
+    },
+    {
+      "id": "python-plugin/python-code-quality",
+      "line": "python-plugin/python-code-quality: Use when the user mentions ruff"
+    },
+    {
+      "id": "python-plugin/python-development",
+      "line": "python-plugin/python-development: Use when mentioning Python"
+    },
+    {
+      "id": "python-plugin/python-packaging",
+      "line": "python-plugin/python-packaging: Use when the user mentions building"
+    },
+    {
+      "id": "python-plugin/python-testing",
+      "line": "python-plugin/python-testing: Use when the user mentions pytest"
+    },
+    {
+      "id": "python-plugin/ruff-formatting",
+      "line": "python-plugin/ruff-formatting: Use when formatting Python files"
+    },
+    {
+      "id": "python-plugin/ruff-linting",
+      "line": "python-plugin/ruff-linting: Use when checking Python code quality"
+    },
+    {
+      "id": "python-plugin/ty-type-checking",
+      "line": "python-plugin/ty-type-checking: Use when checking Python types"
+    },
+    {
+      "id": "python-plugin/uv-advanced-dependencies",
+      "line": "python-plugin/uv-advanced-dependencies: Use when the user mentions git+https"
+    },
+    {
+      "id": "python-plugin/uv-project-management",
+      "line": "python-plugin/uv-project-management: Use when the user mentions uv"
+    },
+    {
+      "id": "python-plugin/uv-python-versions",
+      "line": "python-plugin/uv-python-versions: Use when the user mentions installing"
+    },
+    {
+      "id": "python-plugin/uv-run",
+      "line": "python-plugin/uv-run: Use when running scripts without venv"
+    },
+    {
+      "id": "python-plugin/uv-tool-management",
+      "line": "python-plugin/uv-tool-management: Use when the user mentions uv tool"
+    },
+    {
+      "id": "python-plugin/uv-workspaces",
+      "line": "python-plugin/uv-workspaces: Use when the user mentions uv workspaces"
+    },
+    {
+      "id": "python-plugin/vulture-dead-code",
+      "line": "python-plugin/vulture-dead-code: Use when cleaning up codebases"
+    },
+    {
+      "id": "rust-plugin/cargo-llvm-cov",
+      "line": "rust-plugin/cargo-llvm-cov: Use when measuring coverage"
+    },
+    {
+      "id": "rust-plugin/cargo-machete",
+      "line": "rust-plugin/cargo-machete: Use when auditing Cargo.toml"
+    },
+    {
+      "id": "rust-plugin/cargo-nextest",
+      "line": "rust-plugin/cargo-nextest: Use when running tests"
+    },
+    {
+      "id": "rust-plugin/cargo-worktree-builds",
+      "line": "rust-plugin/cargo-worktree-builds: Use when running cargo/clippy/test"
+    },
+    {
+      "id": "rust-plugin/clippy-advanced",
+      "line": "rust-plugin/clippy-advanced: Use when configuring"
+    },
+    {
+      "id": "rust-plugin/mockito-http-mocking",
+      "line": "rust-plugin/mockito-http-mocking: Use when mocking an HTTP API in Rust"
+    },
+    {
+      "id": "rust-plugin/rust-development",
+      "line": "rust-plugin/rust-development: Use when mentioning Rust"
+    },
+    {
+      "id": "session-plugin/session-distill",
+      "line": "session-plugin/session-distill: Use when capturing learnings"
+    },
+    {
+      "id": "session-plugin/session-end",
+      "line": "session-plugin/session-end: Use when winding down a session"
+    },
+    {
+      "id": "session-plugin/session-spinup",
+      "line": "session-plugin/session-spinup: Use when user says spin up"
+    },
+    {
+      "id": "session-plugin/session-wrap",
+      "line": "session-plugin/session-wrap: Use when user says wrap up"
+    },
+    {
+      "id": "software-design-plugin/design-by-contract",
+      "line": "software-design-plugin/design-by-contract: Use when designing a function/class"
+    },
+    {
+      "id": "software-design-plugin/design-deep-modules",
+      "line": "software-design-plugin/design-deep-modules: Use when designing a module/API"
+    },
+    {
+      "id": "software-design-plugin/design-legacy-seams",
+      "line": "software-design-plugin/design-legacy-seams: Use when changing untested code"
+    },
+    {
+      "id": "software-design-plugin/design-patterns",
+      "line": "software-design-plugin/design-patterns: Use when a structure resists change"
+    },
+    {
+      "id": "software-design-plugin/design-pseudocode",
+      "line": "software-design-plugin/design-pseudocode: Use when designing a complex function"
+    },
+    {
+      "id": "taskwarrior-plugin/install-native-hooks",
+      "line": "taskwarrior-plugin/install-native-hooks: Use when hardening a local taskwarrior"
+    },
+    {
+      "id": "taskwarrior-plugin/task-add",
+      "line": "taskwarrior-plugin/task-add: Use when adding coordination tasks"
+    },
+    {
+      "id": "taskwarrior-plugin/task-bulk-ops",
+      "line": "taskwarrior-plugin/task-bulk-ops: Use when closing/triaging/modifying many"
+    },
+    {
+      "id": "taskwarrior-plugin/task-claim",
+      "line": "taskwarrior-plugin/task-claim: Use when picking up a task from"
+    },
+    {
+      "id": "taskwarrior-plugin/task-coordinate",
+      "line": "taskwarrior-plugin/task-coordinate: Use when planning a parallel-agent wave"
+    },
+    {
+      "id": "taskwarrior-plugin/task-done",
+      "line": "taskwarrior-plugin/task-done: Use when finishing a coordination task"
+    },
+    {
+      "id": "taskwarrior-plugin/task-reconcile",
+      "line": "taskwarrior-plugin/task-reconcile: Use when stale trackers pile up"
+    },
+    {
+      "id": "taskwarrior-plugin/task-release",
+      "line": "taskwarrior-plugin/task-release: Use when pausing mid-task"
+    },
+    {
+      "id": "taskwarrior-plugin/task-status",
+      "line": "taskwarrior-plugin/task-status: Use when auditing queue health"
+    },
+    {
+      "id": "terraform-plugin/infrastructure-terraform",
+      "line": "terraform-plugin/infrastructure-terraform: Use when the user mentions Terraform"
+    },
+    {
+      "id": "terraform-plugin/tfc-list-runs",
+      "line": "terraform-plugin/tfc-list-runs: Use when reviewing run history"
+    },
+    {
+      "id": "terraform-plugin/tfc-plan-json",
+      "line": "terraform-plugin/tfc-plan-json: Use when diffing resource changes"
+    },
+    {
+      "id": "terraform-plugin/tfc-run-logs",
+      "line": "terraform-plugin/tfc-run-logs: Use when debugging failed plans/applies"
+    },
+    {
+      "id": "terraform-plugin/tfc-run-status",
+      "line": "terraform-plugin/tfc-run-status: Use when polling a run"
+    },
+    {
+      "id": "terraform-plugin/tfc-workspace-runs",
+      "line": "terraform-plugin/tfc-workspace-runs: Use when checking TFC status"
+    },
+    {
+      "id": "testing-plugin/mutation-testing",
+      "line": "testing-plugin/mutation-testing: Use when finding weak tests that pass"
+    },
+    {
+      "id": "testing-plugin/odiff-image-diffing",
+      "line": "testing-plugin/odiff-image-diffing: Use when comparing screenshots"
+    },
+    {
+      "id": "testing-plugin/playwright-cli",
+      "line": "testing-plugin/playwright-cli: Use when automating browser tasks from"
+    },
+    {
+      "id": "testing-plugin/playwright-testing",
+      "line": "testing-plugin/playwright-testing: Use when writing E2E tests"
+    },
+    {
+      "id": "testing-plugin/property-based-testing",
+      "line": "testing-plugin/property-based-testing: Use when generating test data"
+    },
+    {
+      "id": "testing-plugin/test-analyze",
+      "line": "testing-plugin/test-analyze: Use when triaging failing tests"
+    },
+    {
+      "id": "testing-plugin/test-consult",
+      "line": "testing-plugin/test-consult: Use when asking about coverage gaps"
+    },
+    {
+      "id": "testing-plugin/test-focus",
+      "line": "testing-plugin/test-focus: Use when iterating on a failing spec"
+    },
+    {
+      "id": "testing-plugin/test-full",
+      "line": "testing-plugin/test-full: Use when running all tests before a PR"
+    },
+    {
+      "id": "testing-plugin/test-quality-analysis",
+      "line": "testing-plugin/test-quality-analysis: Use when reviewing tests"
+    },
+    {
+      "id": "testing-plugin/test-quick",
+      "line": "testing-plugin/test-quick: Use when checking units after a change"
+    },
+    {
+      "id": "testing-plugin/test-report",
+      "line": "testing-plugin/test-report: Use when checking test health"
+    },
+    {
+      "id": "testing-plugin/test-run",
+      "line": "testing-plugin/test-run: Use when running tests"
+    },
+    {
+      "id": "testing-plugin/test-setup",
+      "line": "testing-plugin/test-setup: Use when setting up tests"
+    },
+    {
+      "id": "testing-plugin/test-strategy-review",
+      "line": "testing-plugin/test-strategy-review: Use when a suite is green but you doubt"
+    },
+    {
+      "id": "testing-plugin/test-tier-selection",
+      "line": "testing-plugin/test-tier-selection: Use when running tests"
+    },
+    {
+      "id": "testing-plugin/vitest-testing",
+      "line": "testing-plugin/vitest-testing: Use when setting up tests for Vite"
+    },
+    {
+      "id": "tools-plugin/binary-analysis",
+      "line": "tools-plugin/binary-analysis: Use when identifying unknown files"
+    },
+    {
+      "id": "tools-plugin/cli-smoke-recipes",
+      "line": "tools-plugin/cli-smoke-recipes: Use when designing data-transform"
+    },
+    {
+      "id": "tools-plugin/d2-diagrams",
+      "line": "tools-plugin/d2-diagrams: Use when creating architecture diagrams"
+    },
+    {
+      "id": "tools-plugin/deps-install",
+      "line": "tools-plugin/deps-install: Use when installing deps"
+    },
+    {
+      "id": "tools-plugin/fd-file-finding",
+      "line": "tools-plugin/fd-file-finding: Use when searching for files by name"
+    },
+    {
+      "id": "tools-plugin/generate-image",
+      "line": "tools-plugin/generate-image: Use when creating artwork"
+    },
+    {
+      "id": "tools-plugin/hf-downloads",
+      "line": "tools-plugin/hf-downloads: Use when downloading HF models"
+    },
+    {
+      "id": "tools-plugin/imagemagick-conversion",
+      "line": "tools-plugin/imagemagick-conversion: Use when converting"
+    },
+    {
+      "id": "tools-plugin/jq-json-processing",
+      "line": "tools-plugin/jq-json-processing: Use when parsing JSON files"
+    },
+    {
+      "id": "tools-plugin/justfile-expert",
+      "line": "tools-plugin/justfile-expert: Use when authoring justfiles"
+    },
+    {
+      "id": "tools-plugin/mermaid-diagrams",
+      "line": "tools-plugin/mermaid-diagrams: Use when rendering .mmd"
+    },
+    {
+      "id": "tools-plugin/nushell-data-processing",
+      "line": "tools-plugin/nushell-data-processing: Use when running multi-step cross-format"
+    },
+    {
+      "id": "tools-plugin/rg-code-search",
+      "line": "tools-plugin/rg-code-search: Use when searching for text patterns"
+    },
+    {
+      "id": "tools-plugin/shell-expert",
+      "line": "tools-plugin/shell-expert: Use when writing shell scripts"
+    },
+    {
+      "id": "tools-plugin/yq-yaml-processing",
+      "line": "tools-plugin/yq-yaml-processing: Use when parsing configs"
+    },
+    {
+      "id": "typescript-plugin/biome-tooling",
+      "line": "typescript-plugin/biome-tooling: Use when setting up formatting/linting"
+    },
+    {
+      "id": "typescript-plugin/bun-add",
+      "line": "typescript-plugin/bun-add: Use when the user wants to add/install"
+    },
+    {
+      "id": "typescript-plugin/bun-build",
+      "line": "typescript-plugin/bun-build: Use when the user wants to bundle"
+    },
+    {
+      "id": "typescript-plugin/bun-debug",
+      "line": "typescript-plugin/bun-debug: Use when the user wants to debug a TS/JS"
+    },
+    {
+      "id": "typescript-plugin/bun-development",
+      "line": "typescript-plugin/bun-development: Use when running a TS file"
+    },
+    {
+      "id": "typescript-plugin/bun-install",
+      "line": "typescript-plugin/bun-install: Use when bootstrapping a checkout"
+    },
+    {
+      "id": "typescript-plugin/bun-lockfile-update",
+      "line": "typescript-plugin/bun-lockfile-update: Use when updating dependencies"
+    },
+    {
+      "id": "typescript-plugin/bun-outdated",
+      "line": "typescript-plugin/bun-outdated: Use when auditing freshness"
+    },
+    {
+      "id": "typescript-plugin/bun-package-manager",
+      "line": "typescript-plugin/bun-package-manager: Use when installing all deps"
+    },
+    {
+      "id": "typescript-plugin/bun-publish",
+      "line": "typescript-plugin/bun-publish: Use when the user wants to release"
+    },
+    {
+      "id": "typescript-plugin/bun-publishing",
+      "line": "typescript-plugin/bun-publishing: Use when setting up"
+    },
+    {
+      "id": "typescript-plugin/bun-test",
+      "line": "typescript-plugin/bun-test: Use when running bun tests"
+    },
+    {
+      "id": "typescript-plugin/knip-dead-code",
+      "line": "typescript-plugin/knip-dead-code: Use when cleaning up codebases"
+    },
+    {
+      "id": "typescript-plugin/nodejs-development",
+      "line": "typescript-plugin/nodejs-development: Use when the user mentions Node.js"
+    },
+    {
+      "id": "typescript-plugin/typescript-debugging",
+      "line": "typescript-plugin/typescript-debugging: Use when setting up interactive"
+    },
+    {
+      "id": "typescript-plugin/typescript-sentry",
+      "line": "typescript-plugin/typescript-sentry: Use when adding Sentry"
+    },
+    {
+      "id": "typescript-plugin/typescript-strict",
+      "line": "typescript-plugin/typescript-strict: Use when setting up TS"
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-checkpoint-refactor",
+      "line": "workflow-orchestration-plugin/workflow-checkpoint-refactor: Use when refactoring spans 10+ files"
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-preflight",
+      "line": "workflow-orchestration-plugin/workflow-preflight: Use when starting an issue"
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-verify-before-filing",
+      "line": "workflow-orchestration-plugin/workflow-verify-before-filing: Use when filing upstream reports from"
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-wave-dispatch",
+      "line": "workflow-orchestration-plugin/workflow-wave-dispatch: Use when planning multi-step work"
+    }
+  ]
+}

--- a/experiments/skill-catalog-routing/catalogs/catalog_manifest.json
+++ b/experiments/skill-catalog-routing/catalogs/catalog_manifest.json
@@ -1,0 +1,2044 @@
+{
+  "source_sha": "020bfd9049809681d21d5b6469696f079f249bd3",
+  "skill_count": 405,
+  "content_hashes": {
+    "names": "312a3f2906f4a5ef",
+    "short": "65adefebd659ef37",
+    "medium": "cd0c7b2d4fca78fe",
+    "full": "eb4eea1bd954bc97"
+  },
+  "provenance_counts": {
+    "mechanical": 405
+  },
+  "band_char_ceilings": {
+    "short": 40,
+    "medium": 80
+  },
+  "per_skill": [
+    {
+      "id": "accessibility-plugin/accessibility-implementation",
+      "provenance": "mechanical",
+      "full_len": 172
+    },
+    {
+      "id": "accessibility-plugin/design-tokens",
+      "provenance": "mechanical",
+      "full_len": 176
+    },
+    {
+      "id": "agent-patterns-plugin/adversarial-review",
+      "provenance": "mechanical",
+      "full_len": 139
+    },
+    {
+      "id": "agent-patterns-plugin/agent-teams",
+      "provenance": "mechanical",
+      "full_len": 182
+    },
+    {
+      "id": "agent-patterns-plugin/cold-read-gate",
+      "provenance": "mechanical",
+      "full_len": 192
+    },
+    {
+      "id": "agent-patterns-plugin/custom-agent-definitions",
+      "provenance": "mechanical",
+      "full_len": 173
+    },
+    {
+      "id": "agent-patterns-plugin/exclusive-lock-dispatch",
+      "provenance": "mechanical",
+      "full_len": 174
+    },
+    {
+      "id": "agent-patterns-plugin/execution-grounded-review",
+      "provenance": "mechanical",
+      "full_len": 147
+    },
+    {
+      "id": "agent-patterns-plugin/expose-tunable-knob",
+      "provenance": "mechanical",
+      "full_len": 233
+    },
+    {
+      "id": "agent-patterns-plugin/mcp-code-execution",
+      "provenance": "mechanical",
+      "full_len": 178
+    },
+    {
+      "id": "agent-patterns-plugin/mcp-management",
+      "provenance": "mechanical",
+      "full_len": 167
+    },
+    {
+      "id": "agent-patterns-plugin/mcp-server-authoring",
+      "provenance": "mechanical",
+      "full_len": 189
+    },
+    {
+      "id": "agent-patterns-plugin/meta-assimilate",
+      "provenance": "mechanical",
+      "full_len": 175
+    },
+    {
+      "id": "agent-patterns-plugin/meta-audit",
+      "provenance": "mechanical",
+      "full_len": 173
+    },
+    {
+      "id": "agent-patterns-plugin/meta-context-diet",
+      "provenance": "mechanical",
+      "full_len": 184
+    },
+    {
+      "id": "agent-patterns-plugin/meta-promote",
+      "provenance": "mechanical",
+      "full_len": 175
+    },
+    {
+      "id": "agent-patterns-plugin/multi-model-delegation",
+      "provenance": "mechanical",
+      "full_len": 149
+    },
+    {
+      "id": "agent-patterns-plugin/parallel-agent-dispatch",
+      "provenance": "mechanical",
+      "full_len": 177
+    },
+    {
+      "id": "agent-patterns-plugin/plugin-settings",
+      "provenance": "mechanical",
+      "full_len": 179
+    },
+    {
+      "id": "agent-patterns-plugin/verify-before-plan",
+      "provenance": "mechanical",
+      "full_len": 189
+    },
+    {
+      "id": "agent-patterns-plugin/wave-based-dispatch",
+      "provenance": "mechanical",
+      "full_len": 168
+    },
+    {
+      "id": "agents-plugin/agents-analyze",
+      "provenance": "mechanical",
+      "full_len": 192
+    },
+    {
+      "id": "api-plugin/api-testing",
+      "provenance": "mechanical",
+      "full_len": 171
+    },
+    {
+      "id": "bevy-plugin/bevy-ecs-patterns",
+      "provenance": "mechanical",
+      "full_len": 172
+    },
+    {
+      "id": "bevy-plugin/bevy-game-engine",
+      "provenance": "mechanical",
+      "full_len": 177
+    },
+    {
+      "id": "blog-plugin/blog-post",
+      "provenance": "mechanical",
+      "full_len": 156
+    },
+    {
+      "id": "blog-plugin/blog-post-writing",
+      "provenance": "mechanical",
+      "full_len": 175
+    },
+    {
+      "id": "blueprint-plugin/adr-relationships",
+      "provenance": "mechanical",
+      "full_len": 159
+    },
+    {
+      "id": "blueprint-plugin/blueprint-adr-list",
+      "provenance": "mechanical",
+      "full_len": 159
+    },
+    {
+      "id": "blueprint-plugin/blueprint-adr-validate",
+      "provenance": "mechanical",
+      "full_len": 184
+    },
+    {
+      "id": "blueprint-plugin/blueprint-autopilot",
+      "provenance": "mechanical",
+      "full_len": 146
+    },
+    {
+      "id": "blueprint-plugin/blueprint-claude-md",
+      "provenance": "mechanical",
+      "full_len": 159
+    },
+    {
+      "id": "blueprint-plugin/blueprint-curate-docs",
+      "provenance": "mechanical",
+      "full_len": 141
+    },
+    {
+      "id": "blueprint-plugin/blueprint-derive-plans",
+      "provenance": "mechanical",
+      "full_len": 195
+    },
+    {
+      "id": "blueprint-plugin/blueprint-derive-rules",
+      "provenance": "mechanical",
+      "full_len": 152
+    },
+    {
+      "id": "blueprint-plugin/blueprint-derive-tests",
+      "provenance": "mechanical",
+      "full_len": 161
+    },
+    {
+      "id": "blueprint-plugin/blueprint-development",
+      "provenance": "mechanical",
+      "full_len": 157
+    },
+    {
+      "id": "blueprint-plugin/blueprint-docs-currency",
+      "provenance": "mechanical",
+      "full_len": 164
+    },
+    {
+      "id": "blueprint-plugin/blueprint-docs-list",
+      "provenance": "mechanical",
+      "full_len": 162
+    },
+    {
+      "id": "blueprint-plugin/blueprint-execute",
+      "provenance": "mechanical",
+      "full_len": 164
+    },
+    {
+      "id": "blueprint-plugin/blueprint-feature-tracker-status",
+      "provenance": "mechanical",
+      "full_len": 161
+    },
+    {
+      "id": "blueprint-plugin/blueprint-feature-tracker-sync",
+      "provenance": "mechanical",
+      "full_len": 152
+    },
+    {
+      "id": "blueprint-plugin/blueprint-generate-rules",
+      "provenance": "mechanical",
+      "full_len": 151
+    },
+    {
+      "id": "blueprint-plugin/blueprint-init",
+      "provenance": "mechanical",
+      "full_len": 163
+    },
+    {
+      "id": "blueprint-plugin/blueprint-migration",
+      "provenance": "mechanical",
+      "full_len": 163
+    },
+    {
+      "id": "blueprint-plugin/blueprint-promote",
+      "provenance": "mechanical",
+      "full_len": 164
+    },
+    {
+      "id": "blueprint-plugin/blueprint-prp-create",
+      "provenance": "mechanical",
+      "full_len": 178
+    },
+    {
+      "id": "blueprint-plugin/blueprint-prp-execute",
+      "provenance": "mechanical",
+      "full_len": 163
+    },
+    {
+      "id": "blueprint-plugin/blueprint-rules",
+      "provenance": "mechanical",
+      "full_len": 154
+    },
+    {
+      "id": "blueprint-plugin/blueprint-status",
+      "provenance": "mechanical",
+      "full_len": 154
+    },
+    {
+      "id": "blueprint-plugin/blueprint-story-audit",
+      "provenance": "mechanical",
+      "full_len": 155
+    },
+    {
+      "id": "blueprint-plugin/blueprint-story-reconcile",
+      "provenance": "mechanical",
+      "full_len": 162
+    },
+    {
+      "id": "blueprint-plugin/blueprint-sync",
+      "provenance": "mechanical",
+      "full_len": 153
+    },
+    {
+      "id": "blueprint-plugin/blueprint-sync-ids",
+      "provenance": "mechanical",
+      "full_len": 163
+    },
+    {
+      "id": "blueprint-plugin/blueprint-upgrade",
+      "provenance": "mechanical",
+      "full_len": 157
+    },
+    {
+      "id": "blueprint-plugin/blueprint-work-order",
+      "provenance": "mechanical",
+      "full_len": 163
+    },
+    {
+      "id": "blueprint-plugin/blueprint-workspace-scan",
+      "provenance": "mechanical",
+      "full_len": 147
+    },
+    {
+      "id": "blueprint-plugin/confidence-scoring",
+      "provenance": "mechanical",
+      "full_len": 143
+    },
+    {
+      "id": "blueprint-plugin/document-detection",
+      "provenance": "mechanical",
+      "full_len": 175
+    },
+    {
+      "id": "blueprint-plugin/document-linking",
+      "provenance": "mechanical",
+      "full_len": 179
+    },
+    {
+      "id": "blueprint-plugin/feature-tracking",
+      "provenance": "mechanical",
+      "full_len": 163
+    },
+    {
+      "id": "code-quality-plugin/ast-grep-search",
+      "provenance": "mechanical",
+      "full_len": 190
+    },
+    {
+      "id": "code-quality-plugin/bulk-sweep-classify",
+      "provenance": "mechanical",
+      "full_len": 236
+    },
+    {
+      "id": "code-quality-plugin/code-antipatterns",
+      "provenance": "mechanical",
+      "full_len": 173
+    },
+    {
+      "id": "code-quality-plugin/code-complexity",
+      "provenance": "mechanical",
+      "full_len": 179
+    },
+    {
+      "id": "code-quality-plugin/code-dead-code",
+      "provenance": "mechanical",
+      "full_len": 171
+    },
+    {
+      "id": "code-quality-plugin/code-dep-audit",
+      "provenance": "mechanical",
+      "full_len": 175
+    },
+    {
+      "id": "code-quality-plugin/code-docs-quality",
+      "provenance": "mechanical",
+      "full_len": 177
+    },
+    {
+      "id": "code-quality-plugin/code-hidden-failures",
+      "provenance": "mechanical",
+      "full_len": 184
+    },
+    {
+      "id": "code-quality-plugin/code-lint",
+      "provenance": "mechanical",
+      "full_len": 163
+    },
+    {
+      "id": "code-quality-plugin/code-refactor",
+      "provenance": "mechanical",
+      "full_len": 176
+    },
+    {
+      "id": "code-quality-plugin/code-review",
+      "provenance": "mechanical",
+      "full_len": 165
+    },
+    {
+      "id": "code-quality-plugin/code-review-checklist",
+      "provenance": "mechanical",
+      "full_len": 167
+    },
+    {
+      "id": "code-quality-plugin/code-test-quality",
+      "provenance": "mechanical",
+      "full_len": 159
+    },
+    {
+      "id": "code-quality-plugin/debugging-methodology",
+      "provenance": "mechanical",
+      "full_len": 176
+    },
+    {
+      "id": "code-quality-plugin/dry-consolidation",
+      "provenance": "mechanical",
+      "full_len": 174
+    },
+    {
+      "id": "codebase-attributes-plugin/attributes-collect",
+      "provenance": "mechanical",
+      "full_len": 147
+    },
+    {
+      "id": "codebase-attributes-plugin/attributes-dashboard",
+      "provenance": "mechanical",
+      "full_len": 176
+    },
+    {
+      "id": "codebase-attributes-plugin/attributes-route",
+      "provenance": "mechanical",
+      "full_len": 179
+    },
+    {
+      "id": "comfyui-plugin/comfy-cli",
+      "provenance": "mechanical",
+      "full_len": 201
+    },
+    {
+      "id": "comfyui-plugin/comfy-conditionals",
+      "provenance": "mechanical",
+      "full_len": 179
+    },
+    {
+      "id": "comfyui-plugin/comfy-corpus-validation",
+      "provenance": "mechanical",
+      "full_len": 155
+    },
+    {
+      "id": "comfyui-plugin/comfy-debug-preview",
+      "provenance": "mechanical",
+      "full_len": 177
+    },
+    {
+      "id": "comfyui-plugin/comfy-flow-control",
+      "provenance": "mechanical",
+      "full_len": 203
+    },
+    {
+      "id": "comfyui-plugin/comfy-image-utils",
+      "provenance": "mechanical",
+      "full_len": 217
+    },
+    {
+      "id": "comfyui-plugin/comfy-math-strings",
+      "provenance": "mechanical",
+      "full_len": 205
+    },
+    {
+      "id": "comfyui-plugin/comfy-metadata",
+      "provenance": "mechanical",
+      "full_len": 200
+    },
+    {
+      "id": "comfyui-plugin/comfy-node",
+      "provenance": "mechanical",
+      "full_len": 176
+    },
+    {
+      "id": "comfyui-plugin/comfy-registry-lifecycle",
+      "provenance": "mechanical",
+      "full_len": 214
+    },
+    {
+      "id": "comfyui-plugin/comfy-subgraphs-app-mode",
+      "provenance": "mechanical",
+      "full_len": 223
+    },
+    {
+      "id": "comfyui-plugin/comfy-workflow-json",
+      "provenance": "mechanical",
+      "full_len": 217
+    },
+    {
+      "id": "comfyui-plugin/comfy-workflow-layout",
+      "provenance": "mechanical",
+      "full_len": 170
+    },
+    {
+      "id": "comfyui-plugin/comfyui-node-authoring",
+      "provenance": "mechanical",
+      "full_len": 212
+    },
+    {
+      "id": "comfyui-plugin/comfyui-node-scaffold",
+      "provenance": "mechanical",
+      "full_len": 194
+    },
+    {
+      "id": "comfyui-plugin/comfyui-pack-live-smoke",
+      "provenance": "mechanical",
+      "full_len": 195
+    },
+    {
+      "id": "comfyui-plugin/comfyui-screenshot-pipeline",
+      "provenance": "mechanical",
+      "full_len": 194
+    },
+    {
+      "id": "communication-plugin/google-chat-formatting",
+      "provenance": "mechanical",
+      "full_len": 144
+    },
+    {
+      "id": "communication-plugin/ticket-drafting-guidelines",
+      "provenance": "mechanical",
+      "full_len": 166
+    },
+    {
+      "id": "component-patterns-plugin/components-version-badge",
+      "provenance": "mechanical",
+      "full_len": 179
+    },
+    {
+      "id": "component-patterns-plugin/version-badge-pattern",
+      "provenance": "mechanical",
+      "full_len": 179
+    },
+    {
+      "id": "configure-plugin/ci-workflows",
+      "provenance": "mechanical",
+      "full_len": 161
+    },
+    {
+      "id": "configure-plugin/claude-security-settings",
+      "provenance": "mechanical",
+      "full_len": 172
+    },
+    {
+      "id": "configure-plugin/config-sync",
+      "provenance": "mechanical",
+      "full_len": 137
+    },
+    {
+      "id": "configure-plugin/configure-all",
+      "provenance": "mechanical",
+      "full_len": 144
+    },
+    {
+      "id": "configure-plugin/configure-api-tests",
+      "provenance": "mechanical",
+      "full_len": 154
+    },
+    {
+      "id": "configure-plugin/configure-argocd-automerge",
+      "provenance": "mechanical",
+      "full_len": 145
+    },
+    {
+      "id": "configure-plugin/configure-cache-busting",
+      "provenance": "mechanical",
+      "full_len": 153
+    },
+    {
+      "id": "configure-plugin/configure-claude-plugins",
+      "provenance": "mechanical",
+      "full_len": 197
+    },
+    {
+      "id": "configure-plugin/configure-container",
+      "provenance": "mechanical",
+      "full_len": 160
+    },
+    {
+      "id": "configure-plugin/configure-coverage",
+      "provenance": "mechanical",
+      "full_len": 155
+    },
+    {
+      "id": "configure-plugin/configure-dead-code",
+      "provenance": "mechanical",
+      "full_len": 150
+    },
+    {
+      "id": "configure-plugin/configure-dockerfile",
+      "provenance": "mechanical",
+      "full_len": 150
+    },
+    {
+      "id": "configure-plugin/configure-docs",
+      "provenance": "mechanical",
+      "full_len": 160
+    },
+    {
+      "id": "configure-plugin/configure-editor",
+      "provenance": "mechanical",
+      "full_len": 150
+    },
+    {
+      "id": "configure-plugin/configure-feature-flags",
+      "provenance": "mechanical",
+      "full_len": 158
+    },
+    {
+      "id": "configure-plugin/configure-formatting",
+      "provenance": "mechanical",
+      "full_len": 188
+    },
+    {
+      "id": "configure-plugin/configure-gitattributes",
+      "provenance": "mechanical",
+      "full_len": 190
+    },
+    {
+      "id": "configure-plugin/configure-github-pages",
+      "provenance": "mechanical",
+      "full_len": 146
+    },
+    {
+      "id": "configure-plugin/configure-gitignore",
+      "provenance": "mechanical",
+      "full_len": 150
+    },
+    {
+      "id": "configure-plugin/configure-instrumentation",
+      "provenance": "mechanical",
+      "full_len": 148
+    },
+    {
+      "id": "configure-plugin/configure-integration-tests",
+      "provenance": "mechanical",
+      "full_len": 159
+    },
+    {
+      "id": "configure-plugin/configure-justfile",
+      "provenance": "mechanical",
+      "full_len": 154
+    },
+    {
+      "id": "configure-plugin/configure-linting",
+      "provenance": "mechanical",
+      "full_len": 140
+    },
+    {
+      "id": "configure-plugin/configure-load-tests",
+      "provenance": "mechanical",
+      "full_len": 158
+    },
+    {
+      "id": "configure-plugin/configure-makefile",
+      "provenance": "mechanical",
+      "full_len": 159
+    },
+    {
+      "id": "configure-plugin/configure-mcp",
+      "provenance": "mechanical",
+      "full_len": 146
+    },
+    {
+      "id": "configure-plugin/configure-memory-profiling",
+      "provenance": "mechanical",
+      "full_len": 154
+    },
+    {
+      "id": "configure-plugin/configure-mise",
+      "provenance": "mechanical",
+      "full_len": 196
+    },
+    {
+      "id": "configure-plugin/configure-package-management",
+      "provenance": "mechanical",
+      "full_len": 155
+    },
+    {
+      "id": "configure-plugin/configure-pre-commit",
+      "provenance": "mechanical",
+      "full_len": 151
+    },
+    {
+      "id": "configure-plugin/configure-readme",
+      "provenance": "mechanical",
+      "full_len": 143
+    },
+    {
+      "id": "configure-plugin/configure-release-please",
+      "provenance": "mechanical",
+      "full_len": 155
+    },
+    {
+      "id": "configure-plugin/configure-repo",
+      "provenance": "mechanical",
+      "full_len": 160
+    },
+    {
+      "id": "configure-plugin/configure-reusable-workflows",
+      "provenance": "mechanical",
+      "full_len": 149
+    },
+    {
+      "id": "configure-plugin/configure-security",
+      "provenance": "mechanical",
+      "full_len": 157
+    },
+    {
+      "id": "configure-plugin/configure-select",
+      "provenance": "mechanical",
+      "full_len": 166
+    },
+    {
+      "id": "configure-plugin/configure-sentry",
+      "provenance": "mechanical",
+      "full_len": 155
+    },
+    {
+      "id": "configure-plugin/configure-skaffold",
+      "provenance": "mechanical",
+      "full_len": 161
+    },
+    {
+      "id": "configure-plugin/configure-status",
+      "provenance": "mechanical",
+      "full_len": 156
+    },
+    {
+      "id": "configure-plugin/configure-surface",
+      "provenance": "mechanical",
+      "full_len": 140
+    },
+    {
+      "id": "configure-plugin/configure-tests",
+      "provenance": "mechanical",
+      "full_len": 158
+    },
+    {
+      "id": "configure-plugin/configure-ux-testing",
+      "provenance": "mechanical",
+      "full_len": 159
+    },
+    {
+      "id": "configure-plugin/configure-web-session",
+      "provenance": "mechanical",
+      "full_len": 165
+    },
+    {
+      "id": "configure-plugin/configure-workflows",
+      "provenance": "mechanical",
+      "full_len": 166
+    },
+    {
+      "id": "configure-plugin/configure-worktreeinclude",
+      "provenance": "mechanical",
+      "full_len": 150
+    },
+    {
+      "id": "configure-plugin/go-feature-flag",
+      "provenance": "mechanical",
+      "full_len": 168
+    },
+    {
+      "id": "configure-plugin/multi-repo-discipline",
+      "provenance": "mechanical",
+      "full_len": 159
+    },
+    {
+      "id": "configure-plugin/openfeature",
+      "provenance": "mechanical",
+      "full_len": 157
+    },
+    {
+      "id": "container-plugin/container-development",
+      "provenance": "mechanical",
+      "full_len": 199
+    },
+    {
+      "id": "container-plugin/deploy-handoff",
+      "provenance": "mechanical",
+      "full_len": 188
+    },
+    {
+      "id": "container-plugin/deploy-release",
+      "provenance": "mechanical",
+      "full_len": 157
+    },
+    {
+      "id": "container-plugin/go-containers",
+      "provenance": "mechanical",
+      "full_len": 178
+    },
+    {
+      "id": "container-plugin/nodejs-containers",
+      "provenance": "mechanical",
+      "full_len": 185
+    },
+    {
+      "id": "container-plugin/python-containers",
+      "provenance": "mechanical",
+      "full_len": 194
+    },
+    {
+      "id": "container-plugin/skaffold-filesync",
+      "provenance": "mechanical",
+      "full_len": 182
+    },
+    {
+      "id": "container-plugin/skaffold-orbstack",
+      "provenance": "mechanical",
+      "full_len": 177
+    },
+    {
+      "id": "container-plugin/skaffold-testing",
+      "provenance": "mechanical",
+      "full_len": 176
+    },
+    {
+      "id": "css-plugin/lightning-css",
+      "provenance": "mechanical",
+      "full_len": 172
+    },
+    {
+      "id": "css-plugin/unocss",
+      "provenance": "mechanical",
+      "full_len": 174
+    },
+    {
+      "id": "documentation-plugin/claude-blog-sources",
+      "provenance": "mechanical",
+      "full_len": 158
+    },
+    {
+      "id": "documentation-plugin/docs-decommission",
+      "provenance": "mechanical",
+      "full_len": 157
+    },
+    {
+      "id": "documentation-plugin/docs-generate",
+      "provenance": "mechanical",
+      "full_len": 165
+    },
+    {
+      "id": "documentation-plugin/docs-latex",
+      "provenance": "mechanical",
+      "full_len": 167
+    },
+    {
+      "id": "documentation-plugin/docs-sync",
+      "provenance": "mechanical",
+      "full_len": 163
+    },
+    {
+      "id": "evaluate-plugin/evaluate-improve",
+      "provenance": "mechanical",
+      "full_len": 179
+    },
+    {
+      "id": "evaluate-plugin/evaluate-legibility",
+      "provenance": "mechanical",
+      "full_len": 170
+    },
+    {
+      "id": "evaluate-plugin/evaluate-matrix",
+      "provenance": "mechanical",
+      "full_len": 169
+    },
+    {
+      "id": "evaluate-plugin/evaluate-plugin-batch",
+      "provenance": "mechanical",
+      "full_len": 150
+    },
+    {
+      "id": "evaluate-plugin/evaluate-report",
+      "provenance": "mechanical",
+      "full_len": 160
+    },
+    {
+      "id": "evaluate-plugin/evaluate-skill",
+      "provenance": "mechanical",
+      "full_len": 176
+    },
+    {
+      "id": "feedback-plugin/feedback-session",
+      "provenance": "mechanical",
+      "full_len": 168
+    },
+    {
+      "id": "finops-plugin/finops-caches",
+      "provenance": "mechanical",
+      "full_len": 163
+    },
+    {
+      "id": "finops-plugin/finops-compare",
+      "provenance": "mechanical",
+      "full_len": 149
+    },
+    {
+      "id": "finops-plugin/finops-overview",
+      "provenance": "mechanical",
+      "full_len": 151
+    },
+    {
+      "id": "finops-plugin/finops-waste",
+      "provenance": "mechanical",
+      "full_len": 155
+    },
+    {
+      "id": "finops-plugin/finops-workflows",
+      "provenance": "mechanical",
+      "full_len": 150
+    },
+    {
+      "id": "finops-plugin/github-actions-cache-optimization",
+      "provenance": "mechanical",
+      "full_len": 161
+    },
+    {
+      "id": "finops-plugin/github-actions-finops",
+      "provenance": "mechanical",
+      "full_len": 158
+    },
+    {
+      "id": "foundryvtt-plugin/foundryvtt-module",
+      "provenance": "mechanical",
+      "full_len": 165
+    },
+    {
+      "id": "foundryvtt-plugin/foundryvtt-module-scaffold",
+      "provenance": "mechanical",
+      "full_len": 176
+    },
+    {
+      "id": "git-plugin/deadbranch",
+      "provenance": "mechanical",
+      "full_len": 195
+    },
+    {
+      "id": "git-plugin/gh-cli-agentic",
+      "provenance": "mechanical",
+      "full_len": 210
+    },
+    {
+      "id": "git-plugin/gh-workflow-monitoring",
+      "provenance": "mechanical",
+      "full_len": 199
+    },
+    {
+      "id": "git-plugin/git-api-pr",
+      "provenance": "mechanical",
+      "full_len": 172
+    },
+    {
+      "id": "git-plugin/git-branch-naming",
+      "provenance": "mechanical",
+      "full_len": 149
+    },
+    {
+      "id": "git-plugin/git-branch-pr-workflow",
+      "provenance": "mechanical",
+      "full_len": 143
+    },
+    {
+      "id": "git-plugin/git-cli-agentic",
+      "provenance": "mechanical",
+      "full_len": 199
+    },
+    {
+      "id": "git-plugin/git-commit",
+      "provenance": "mechanical",
+      "full_len": 177
+    },
+    {
+      "id": "git-plugin/git-commit-push-pr",
+      "provenance": "mechanical",
+      "full_len": 156
+    },
+    {
+      "id": "git-plugin/git-commit-trailers",
+      "provenance": "mechanical",
+      "full_len": 161
+    },
+    {
+      "id": "git-plugin/git-commit-workflow",
+      "provenance": "mechanical",
+      "full_len": 161
+    },
+    {
+      "id": "git-plugin/git-conflicts",
+      "provenance": "mechanical",
+      "full_len": 151
+    },
+    {
+      "id": "git-plugin/git-coworker-check",
+      "provenance": "mechanical",
+      "full_len": 196
+    },
+    {
+      "id": "git-plugin/git-derive-docs",
+      "provenance": "mechanical",
+      "full_len": 172
+    },
+    {
+      "id": "git-plugin/git-fix-pr",
+      "provenance": "mechanical",
+      "full_len": 161
+    },
+    {
+      "id": "git-plugin/git-fork-workflow",
+      "provenance": "mechanical",
+      "full_len": 147
+    },
+    {
+      "id": "git-plugin/git-issue",
+      "provenance": "mechanical",
+      "full_len": 159
+    },
+    {
+      "id": "git-plugin/git-issue-hierarchy",
+      "provenance": "mechanical",
+      "full_len": 155
+    },
+    {
+      "id": "git-plugin/git-issue-manage",
+      "provenance": "mechanical",
+      "full_len": 162
+    },
+    {
+      "id": "git-plugin/git-maintain",
+      "provenance": "mechanical",
+      "full_len": 195
+    },
+    {
+      "id": "git-plugin/git-pr",
+      "provenance": "mechanical",
+      "full_len": 168
+    },
+    {
+      "id": "git-plugin/git-pr-feedback",
+      "provenance": "mechanical",
+      "full_len": 159
+    },
+    {
+      "id": "git-plugin/git-pr-sync-check",
+      "provenance": "mechanical",
+      "full_len": 160
+    },
+    {
+      "id": "git-plugin/git-pr-watch",
+      "provenance": "mechanical",
+      "full_len": 173
+    },
+    {
+      "id": "git-plugin/git-push",
+      "provenance": "mechanical",
+      "full_len": 237
+    },
+    {
+      "id": "git-plugin/git-rebase-patterns",
+      "provenance": "mechanical",
+      "full_len": 171
+    },
+    {
+      "id": "git-plugin/git-repo-detection",
+      "provenance": "mechanical",
+      "full_len": 153
+    },
+    {
+      "id": "git-plugin/git-security-checks",
+      "provenance": "mechanical",
+      "full_len": 168
+    },
+    {
+      "id": "git-plugin/git-triage",
+      "provenance": "mechanical",
+      "full_len": 162
+    },
+    {
+      "id": "git-plugin/git-upstream-pr",
+      "provenance": "mechanical",
+      "full_len": 163
+    },
+    {
+      "id": "git-plugin/git-upstream-pr-diverged",
+      "provenance": "mechanical",
+      "full_len": 168
+    },
+    {
+      "id": "git-plugin/github-issue-autodetect",
+      "provenance": "mechanical",
+      "full_len": 230
+    },
+    {
+      "id": "git-plugin/github-issue-writing",
+      "provenance": "mechanical",
+      "full_len": 167
+    },
+    {
+      "id": "git-plugin/github-labels",
+      "provenance": "mechanical",
+      "full_len": 142
+    },
+    {
+      "id": "git-plugin/github-pr-title",
+      "provenance": "mechanical",
+      "full_len": 221
+    },
+    {
+      "id": "git-plugin/release-please-configuration",
+      "provenance": "mechanical",
+      "full_len": 157
+    },
+    {
+      "id": "git-plugin/release-please-pr-workflow",
+      "provenance": "mechanical",
+      "full_len": 230
+    },
+    {
+      "id": "git-plugin/release-please-protection",
+      "provenance": "mechanical",
+      "full_len": 169
+    },
+    {
+      "id": "github-actions-plugin/claude-code-github-workflows",
+      "provenance": "mechanical",
+      "full_len": 160
+    },
+    {
+      "id": "github-actions-plugin/github-actions-auth-security",
+      "provenance": "mechanical",
+      "full_len": 166
+    },
+    {
+      "id": "github-actions-plugin/github-actions-inspection",
+      "provenance": "mechanical",
+      "full_len": 159
+    },
+    {
+      "id": "github-actions-plugin/github-actions-mcp-config",
+      "provenance": "mechanical",
+      "full_len": 149
+    },
+    {
+      "id": "github-actions-plugin/github-issue-search",
+      "provenance": "mechanical",
+      "full_len": 163
+    },
+    {
+      "id": "github-actions-plugin/github-social-preview",
+      "provenance": "mechanical",
+      "full_len": 169
+    },
+    {
+      "id": "github-actions-plugin/github-workflow-auto-fix",
+      "provenance": "mechanical",
+      "full_len": 185
+    },
+    {
+      "id": "github-actions-plugin/workflow-dev",
+      "provenance": "mechanical",
+      "full_len": 173
+    },
+    {
+      "id": "health-plugin/health-agentic-audit",
+      "provenance": "mechanical",
+      "full_len": 159
+    },
+    {
+      "id": "health-plugin/health-audit",
+      "provenance": "mechanical",
+      "full_len": 171
+    },
+    {
+      "id": "health-plugin/health-check",
+      "provenance": "mechanical",
+      "full_len": 200
+    },
+    {
+      "id": "health-plugin/health-plugins",
+      "provenance": "mechanical",
+      "full_len": 171
+    },
+    {
+      "id": "health-plugin/health-skill-audit",
+      "provenance": "mechanical",
+      "full_len": 166
+    },
+    {
+      "id": "health-plugin/plugin-registry",
+      "provenance": "mechanical",
+      "full_len": 169
+    },
+    {
+      "id": "health-plugin/settings-configuration",
+      "provenance": "mechanical",
+      "full_len": 173
+    },
+    {
+      "id": "home-assistant-plugin/ha-automations",
+      "provenance": "mechanical",
+      "full_len": 138
+    },
+    {
+      "id": "home-assistant-plugin/ha-configuration",
+      "provenance": "mechanical",
+      "full_len": 165
+    },
+    {
+      "id": "home-assistant-plugin/ha-entities",
+      "provenance": "mechanical",
+      "full_len": 166
+    },
+    {
+      "id": "home-assistant-plugin/ha-validate",
+      "provenance": "mechanical",
+      "full_len": 171
+    },
+    {
+      "id": "hooks-plugin/hooks-configuration",
+      "provenance": "mechanical",
+      "full_len": 173
+    },
+    {
+      "id": "hooks-plugin/hooks-permission-request-hook",
+      "provenance": "mechanical",
+      "full_len": 164
+    },
+    {
+      "id": "hooks-plugin/hooks-session-end-issue-hook",
+      "provenance": "mechanical",
+      "full_len": 149
+    },
+    {
+      "id": "hooks-plugin/hooks-session-start-hook",
+      "provenance": "mechanical",
+      "full_len": 166
+    },
+    {
+      "id": "kubernetes-plugin/argocd-login",
+      "provenance": "mechanical",
+      "full_len": 159
+    },
+    {
+      "id": "kubernetes-plugin/helm-chart-development",
+      "provenance": "mechanical",
+      "full_len": 186
+    },
+    {
+      "id": "kubernetes-plugin/helm-debugging",
+      "provenance": "mechanical",
+      "full_len": 174
+    },
+    {
+      "id": "kubernetes-plugin/helm-release-management",
+      "provenance": "mechanical",
+      "full_len": 181
+    },
+    {
+      "id": "kubernetes-plugin/helm-release-recovery",
+      "provenance": "mechanical",
+      "full_len": 189
+    },
+    {
+      "id": "kubernetes-plugin/helm-values-management",
+      "provenance": "mechanical",
+      "full_len": 173
+    },
+    {
+      "id": "kubernetes-plugin/kubectl-debugging",
+      "provenance": "mechanical",
+      "full_len": 174
+    },
+    {
+      "id": "kubernetes-plugin/kubernetes-operations",
+      "provenance": "mechanical",
+      "full_len": 182
+    },
+    {
+      "id": "langchain-plugin/deep-agents",
+      "provenance": "mechanical",
+      "full_len": 178
+    },
+    {
+      "id": "langchain-plugin/langchain-development",
+      "provenance": "mechanical",
+      "full_len": 154
+    },
+    {
+      "id": "langchain-plugin/langchain-init",
+      "provenance": "mechanical",
+      "full_len": 155
+    },
+    {
+      "id": "langchain-plugin/langgraph-agents",
+      "provenance": "mechanical",
+      "full_len": 178
+    },
+    {
+      "id": "macos-plugin/endpoint-security-cpu",
+      "provenance": "mechanical",
+      "full_len": 146
+    },
+    {
+      "id": "macos-plugin/kitty-session-persistence",
+      "provenance": "mechanical",
+      "full_len": 171
+    },
+    {
+      "id": "macos-plugin/launchservices-health",
+      "provenance": "mechanical",
+      "full_len": 159
+    },
+    {
+      "id": "macos-plugin/macos-disk-usage",
+      "provenance": "mechanical",
+      "full_len": 188
+    },
+    {
+      "id": "macos-plugin/macos-incident-postmortem",
+      "provenance": "mechanical",
+      "full_len": 172
+    },
+    {
+      "id": "macos-plugin/macos-performance-benchmark",
+      "provenance": "mechanical",
+      "full_len": 198
+    },
+    {
+      "id": "macos-plugin/macos-performance-triage",
+      "provenance": "mechanical",
+      "full_len": 271
+    },
+    {
+      "id": "macos-plugin/tui-keybinding-debug",
+      "provenance": "mechanical",
+      "full_len": 183
+    },
+    {
+      "id": "migration-patterns-plugin/black-to-ruff-format",
+      "provenance": "mechanical",
+      "full_len": 143
+    },
+    {
+      "id": "migration-patterns-plugin/dual-write",
+      "provenance": "mechanical",
+      "full_len": 174
+    },
+    {
+      "id": "migration-patterns-plugin/eslint-to-biome",
+      "provenance": "mechanical",
+      "full_len": 128
+    },
+    {
+      "id": "migration-patterns-plugin/flake8-to-ruff",
+      "provenance": "mechanical",
+      "full_len": 161
+    },
+    {
+      "id": "migration-patterns-plugin/mypy-to-ty",
+      "provenance": "mechanical",
+      "full_len": 136
+    },
+    {
+      "id": "migration-patterns-plugin/shadow-mode",
+      "provenance": "mechanical",
+      "full_len": 180
+    },
+    {
+      "id": "networking-plugin/dns-tools",
+      "provenance": "mechanical",
+      "full_len": 149
+    },
+    {
+      "id": "networking-plugin/http-load-testing",
+      "provenance": "mechanical",
+      "full_len": 167
+    },
+    {
+      "id": "networking-plugin/interface-state",
+      "provenance": "mechanical",
+      "full_len": 186
+    },
+    {
+      "id": "networking-plugin/layer2-discovery",
+      "provenance": "mechanical",
+      "full_len": 161
+    },
+    {
+      "id": "networking-plugin/network-diagnostics",
+      "provenance": "mechanical",
+      "full_len": 150
+    },
+    {
+      "id": "networking-plugin/network-discovery",
+      "provenance": "mechanical",
+      "full_len": 148
+    },
+    {
+      "id": "networking-plugin/network-monitoring",
+      "provenance": "mechanical",
+      "full_len": 171
+    },
+    {
+      "id": "obsidian-plugin/bases",
+      "provenance": "mechanical",
+      "full_len": 165
+    },
+    {
+      "id": "obsidian-plugin/bookmarks",
+      "provenance": "mechanical",
+      "full_len": 132
+    },
+    {
+      "id": "obsidian-plugin/command-palette",
+      "provenance": "mechanical",
+      "full_len": 148
+    },
+    {
+      "id": "obsidian-plugin/dev-tools",
+      "provenance": "mechanical",
+      "full_len": 152
+    },
+    {
+      "id": "obsidian-plugin/file-history",
+      "provenance": "mechanical",
+      "full_len": 152
+    },
+    {
+      "id": "obsidian-plugin/plugins-themes",
+      "provenance": "mechanical",
+      "full_len": 135
+    },
+    {
+      "id": "obsidian-plugin/properties",
+      "provenance": "mechanical",
+      "full_len": 144
+    },
+    {
+      "id": "obsidian-plugin/publish-sync",
+      "provenance": "mechanical",
+      "full_len": 143
+    },
+    {
+      "id": "obsidian-plugin/search-discovery",
+      "provenance": "mechanical",
+      "full_len": 156
+    },
+    {
+      "id": "obsidian-plugin/tasks",
+      "provenance": "mechanical",
+      "full_len": 142
+    },
+    {
+      "id": "obsidian-plugin/templates",
+      "provenance": "mechanical",
+      "full_len": 142
+    },
+    {
+      "id": "obsidian-plugin/vault-files",
+      "provenance": "mechanical",
+      "full_len": 137
+    },
+    {
+      "id": "obsidian-plugin/vault-frontmatter",
+      "provenance": "mechanical",
+      "full_len": 144
+    },
+    {
+      "id": "obsidian-plugin/vault-management",
+      "provenance": "mechanical",
+      "full_len": 157
+    },
+    {
+      "id": "obsidian-plugin/vault-mocs",
+      "provenance": "mechanical",
+      "full_len": 156
+    },
+    {
+      "id": "obsidian-plugin/vault-orphans",
+      "provenance": "mechanical",
+      "full_len": 154
+    },
+    {
+      "id": "obsidian-plugin/vault-stubs",
+      "provenance": "mechanical",
+      "full_len": 164
+    },
+    {
+      "id": "obsidian-plugin/vault-tags",
+      "provenance": "mechanical",
+      "full_len": 147
+    },
+    {
+      "id": "obsidian-plugin/vault-templates",
+      "provenance": "mechanical",
+      "full_len": 142
+    },
+    {
+      "id": "obsidian-plugin/vault-wikilinks",
+      "provenance": "mechanical",
+      "full_len": 159
+    },
+    {
+      "id": "obsidian-plugin/workspaces",
+      "provenance": "mechanical",
+      "full_len": 152
+    },
+    {
+      "id": "project-plugin/changelog-review",
+      "provenance": "mechanical",
+      "full_len": 152
+    },
+    {
+      "id": "project-plugin/project-continue",
+      "provenance": "mechanical",
+      "full_len": 171
+    },
+    {
+      "id": "project-plugin/project-discovery",
+      "provenance": "mechanical",
+      "full_len": 173
+    },
+    {
+      "id": "project-plugin/project-init",
+      "provenance": "mechanical",
+      "full_len": 174
+    },
+    {
+      "id": "project-plugin/project-refocus",
+      "provenance": "mechanical",
+      "full_len": 151
+    },
+    {
+      "id": "project-plugin/project-skill-scripts",
+      "provenance": "mechanical",
+      "full_len": 173
+    },
+    {
+      "id": "project-plugin/project-test-loop",
+      "provenance": "mechanical",
+      "full_len": 154
+    },
+    {
+      "id": "prompt-engineering-plugin/prompt-engineering-ground-response",
+      "provenance": "mechanical",
+      "full_len": 171
+    },
+    {
+      "id": "prose-plugin/prose-distill",
+      "provenance": "mechanical",
+      "full_len": 167
+    },
+    {
+      "id": "prose-plugin/prose-synthesize",
+      "provenance": "mechanical",
+      "full_len": 167
+    },
+    {
+      "id": "python-plugin/basedpyright-type-checking",
+      "provenance": "mechanical",
+      "full_len": 166
+    },
+    {
+      "id": "python-plugin/pytest-advanced",
+      "provenance": "mechanical",
+      "full_len": 159
+    },
+    {
+      "id": "python-plugin/python-code-quality",
+      "provenance": "mechanical",
+      "full_len": 132
+    },
+    {
+      "id": "python-plugin/python-development",
+      "provenance": "mechanical",
+      "full_len": 180
+    },
+    {
+      "id": "python-plugin/python-packaging",
+      "provenance": "mechanical",
+      "full_len": 147
+    },
+    {
+      "id": "python-plugin/python-testing",
+      "provenance": "mechanical",
+      "full_len": 161
+    },
+    {
+      "id": "python-plugin/ruff-formatting",
+      "provenance": "mechanical",
+      "full_len": 156
+    },
+    {
+      "id": "python-plugin/ruff-linting",
+      "provenance": "mechanical",
+      "full_len": 157
+    },
+    {
+      "id": "python-plugin/ty-type-checking",
+      "provenance": "mechanical",
+      "full_len": 167
+    },
+    {
+      "id": "python-plugin/uv-advanced-dependencies",
+      "provenance": "mechanical",
+      "full_len": 179
+    },
+    {
+      "id": "python-plugin/uv-project-management",
+      "provenance": "mechanical",
+      "full_len": 160
+    },
+    {
+      "id": "python-plugin/uv-python-versions",
+      "provenance": "mechanical",
+      "full_len": 164
+    },
+    {
+      "id": "python-plugin/uv-run",
+      "provenance": "mechanical",
+      "full_len": 156
+    },
+    {
+      "id": "python-plugin/uv-tool-management",
+      "provenance": "mechanical",
+      "full_len": 163
+    },
+    {
+      "id": "python-plugin/uv-workspaces",
+      "provenance": "mechanical",
+      "full_len": 157
+    },
+    {
+      "id": "python-plugin/vulture-dead-code",
+      "provenance": "mechanical",
+      "full_len": 172
+    },
+    {
+      "id": "rust-plugin/cargo-llvm-cov",
+      "provenance": "mechanical",
+      "full_len": 166
+    },
+    {
+      "id": "rust-plugin/cargo-machete",
+      "provenance": "mechanical",
+      "full_len": 134
+    },
+    {
+      "id": "rust-plugin/cargo-nextest",
+      "provenance": "mechanical",
+      "full_len": 155
+    },
+    {
+      "id": "rust-plugin/cargo-worktree-builds",
+      "provenance": "mechanical",
+      "full_len": 275
+    },
+    {
+      "id": "rust-plugin/clippy-advanced",
+      "provenance": "mechanical",
+      "full_len": 165
+    },
+    {
+      "id": "rust-plugin/mockito-http-mocking",
+      "provenance": "mechanical",
+      "full_len": 288
+    },
+    {
+      "id": "rust-plugin/rust-development",
+      "provenance": "mechanical",
+      "full_len": 177
+    },
+    {
+      "id": "session-plugin/session-distill",
+      "provenance": "mechanical",
+      "full_len": 262
+    },
+    {
+      "id": "session-plugin/session-end",
+      "provenance": "mechanical",
+      "full_len": 158
+    },
+    {
+      "id": "session-plugin/session-spinup",
+      "provenance": "mechanical",
+      "full_len": 148
+    },
+    {
+      "id": "session-plugin/session-wrap",
+      "provenance": "mechanical",
+      "full_len": 130
+    },
+    {
+      "id": "software-design-plugin/design-by-contract",
+      "provenance": "mechanical",
+      "full_len": 171
+    },
+    {
+      "id": "software-design-plugin/design-deep-modules",
+      "provenance": "mechanical",
+      "full_len": 162
+    },
+    {
+      "id": "software-design-plugin/design-legacy-seams",
+      "provenance": "mechanical",
+      "full_len": 163
+    },
+    {
+      "id": "software-design-plugin/design-patterns",
+      "provenance": "mechanical",
+      "full_len": 169
+    },
+    {
+      "id": "software-design-plugin/design-pseudocode",
+      "provenance": "mechanical",
+      "full_len": 171
+    },
+    {
+      "id": "taskwarrior-plugin/install-native-hooks",
+      "provenance": "mechanical",
+      "full_len": 193
+    },
+    {
+      "id": "taskwarrior-plugin/task-add",
+      "provenance": "mechanical",
+      "full_len": 169
+    },
+    {
+      "id": "taskwarrior-plugin/task-bulk-ops",
+      "provenance": "mechanical",
+      "full_len": 187
+    },
+    {
+      "id": "taskwarrior-plugin/task-claim",
+      "provenance": "mechanical",
+      "full_len": 163
+    },
+    {
+      "id": "taskwarrior-plugin/task-coordinate",
+      "provenance": "mechanical",
+      "full_len": 165
+    },
+    {
+      "id": "taskwarrior-plugin/task-done",
+      "provenance": "mechanical",
+      "full_len": 164
+    },
+    {
+      "id": "taskwarrior-plugin/task-reconcile",
+      "provenance": "mechanical",
+      "full_len": 152
+    },
+    {
+      "id": "taskwarrior-plugin/task-release",
+      "provenance": "mechanical",
+      "full_len": 178
+    },
+    {
+      "id": "taskwarrior-plugin/task-status",
+      "provenance": "mechanical",
+      "full_len": 174
+    },
+    {
+      "id": "terraform-plugin/infrastructure-terraform",
+      "provenance": "mechanical",
+      "full_len": 163
+    },
+    {
+      "id": "terraform-plugin/tfc-list-runs",
+      "provenance": "mechanical",
+      "full_len": 163
+    },
+    {
+      "id": "terraform-plugin/tfc-plan-json",
+      "provenance": "mechanical",
+      "full_len": 149
+    },
+    {
+      "id": "terraform-plugin/tfc-run-logs",
+      "provenance": "mechanical",
+      "full_len": 144
+    },
+    {
+      "id": "terraform-plugin/tfc-run-status",
+      "provenance": "mechanical",
+      "full_len": 168
+    },
+    {
+      "id": "terraform-plugin/tfc-workspace-runs",
+      "provenance": "mechanical",
+      "full_len": 159
+    },
+    {
+      "id": "testing-plugin/mutation-testing",
+      "provenance": "mechanical",
+      "full_len": 166
+    },
+    {
+      "id": "testing-plugin/odiff-image-diffing",
+      "provenance": "mechanical",
+      "full_len": 149
+    },
+    {
+      "id": "testing-plugin/playwright-cli",
+      "provenance": "mechanical",
+      "full_len": 174
+    },
+    {
+      "id": "testing-plugin/playwright-testing",
+      "provenance": "mechanical",
+      "full_len": 165
+    },
+    {
+      "id": "testing-plugin/property-based-testing",
+      "provenance": "mechanical",
+      "full_len": 177
+    },
+    {
+      "id": "testing-plugin/test-analyze",
+      "provenance": "mechanical",
+      "full_len": 191
+    },
+    {
+      "id": "testing-plugin/test-consult",
+      "provenance": "mechanical",
+      "full_len": 173
+    },
+    {
+      "id": "testing-plugin/test-focus",
+      "provenance": "mechanical",
+      "full_len": 173
+    },
+    {
+      "id": "testing-plugin/test-full",
+      "provenance": "mechanical",
+      "full_len": 169
+    },
+    {
+      "id": "testing-plugin/test-quality-analysis",
+      "provenance": "mechanical",
+      "full_len": 165
+    },
+    {
+      "id": "testing-plugin/test-quick",
+      "provenance": "mechanical",
+      "full_len": 171
+    },
+    {
+      "id": "testing-plugin/test-report",
+      "provenance": "mechanical",
+      "full_len": 162
+    },
+    {
+      "id": "testing-plugin/test-run",
+      "provenance": "mechanical",
+      "full_len": 172
+    },
+    {
+      "id": "testing-plugin/test-setup",
+      "provenance": "mechanical",
+      "full_len": 174
+    },
+    {
+      "id": "testing-plugin/test-strategy-review",
+      "provenance": "mechanical",
+      "full_len": 236
+    },
+    {
+      "id": "testing-plugin/test-tier-selection",
+      "provenance": "mechanical",
+      "full_len": 166
+    },
+    {
+      "id": "testing-plugin/vitest-testing",
+      "provenance": "mechanical",
+      "full_len": 176
+    },
+    {
+      "id": "tools-plugin/binary-analysis",
+      "provenance": "mechanical",
+      "full_len": 161
+    },
+    {
+      "id": "tools-plugin/cli-smoke-recipes",
+      "provenance": "mechanical",
+      "full_len": 166
+    },
+    {
+      "id": "tools-plugin/d2-diagrams",
+      "provenance": "mechanical",
+      "full_len": 165
+    },
+    {
+      "id": "tools-plugin/deps-install",
+      "provenance": "mechanical",
+      "full_len": 153
+    },
+    {
+      "id": "tools-plugin/fd-file-finding",
+      "provenance": "mechanical",
+      "full_len": 144
+    },
+    {
+      "id": "tools-plugin/generate-image",
+      "provenance": "mechanical",
+      "full_len": 147
+    },
+    {
+      "id": "tools-plugin/hf-downloads",
+      "provenance": "mechanical",
+      "full_len": 228
+    },
+    {
+      "id": "tools-plugin/imagemagick-conversion",
+      "provenance": "mechanical",
+      "full_len": 162
+    },
+    {
+      "id": "tools-plugin/jq-json-processing",
+      "provenance": "mechanical",
+      "full_len": 162
+    },
+    {
+      "id": "tools-plugin/justfile-expert",
+      "provenance": "mechanical",
+      "full_len": 163
+    },
+    {
+      "id": "tools-plugin/mermaid-diagrams",
+      "provenance": "mechanical",
+      "full_len": 177
+    },
+    {
+      "id": "tools-plugin/nushell-data-processing",
+      "provenance": "mechanical",
+      "full_len": 191
+    },
+    {
+      "id": "tools-plugin/rg-code-search",
+      "provenance": "mechanical",
+      "full_len": 152
+    },
+    {
+      "id": "tools-plugin/shell-expert",
+      "provenance": "mechanical",
+      "full_len": 160
+    },
+    {
+      "id": "tools-plugin/yq-yaml-processing",
+      "provenance": "mechanical",
+      "full_len": 158
+    },
+    {
+      "id": "typescript-plugin/biome-tooling",
+      "provenance": "mechanical",
+      "full_len": 154
+    },
+    {
+      "id": "typescript-plugin/bun-add",
+      "provenance": "mechanical",
+      "full_len": 157
+    },
+    {
+      "id": "typescript-plugin/bun-build",
+      "provenance": "mechanical",
+      "full_len": 159
+    },
+    {
+      "id": "typescript-plugin/bun-debug",
+      "provenance": "mechanical",
+      "full_len": 161
+    },
+    {
+      "id": "typescript-plugin/bun-development",
+      "provenance": "mechanical",
+      "full_len": 235
+    },
+    {
+      "id": "typescript-plugin/bun-install",
+      "provenance": "mechanical",
+      "full_len": 167
+    },
+    {
+      "id": "typescript-plugin/bun-lockfile-update",
+      "provenance": "mechanical",
+      "full_len": 162
+    },
+    {
+      "id": "typescript-plugin/bun-outdated",
+      "provenance": "mechanical",
+      "full_len": 160
+    },
+    {
+      "id": "typescript-plugin/bun-package-manager",
+      "provenance": "mechanical",
+      "full_len": 249
+    },
+    {
+      "id": "typescript-plugin/bun-publish",
+      "provenance": "mechanical",
+      "full_len": 165
+    },
+    {
+      "id": "typescript-plugin/bun-publishing",
+      "provenance": "mechanical",
+      "full_len": 236
+    },
+    {
+      "id": "typescript-plugin/bun-test",
+      "provenance": "mechanical",
+      "full_len": 163
+    },
+    {
+      "id": "typescript-plugin/knip-dead-code",
+      "provenance": "mechanical",
+      "full_len": 163
+    },
+    {
+      "id": "typescript-plugin/nodejs-development",
+      "provenance": "mechanical",
+      "full_len": 159
+    },
+    {
+      "id": "typescript-plugin/typescript-debugging",
+      "provenance": "mechanical",
+      "full_len": 245
+    },
+    {
+      "id": "typescript-plugin/typescript-sentry",
+      "provenance": "mechanical",
+      "full_len": 239
+    },
+    {
+      "id": "typescript-plugin/typescript-strict",
+      "provenance": "mechanical",
+      "full_len": 170
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-checkpoint-refactor",
+      "provenance": "mechanical",
+      "full_len": 179
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-preflight",
+      "provenance": "mechanical",
+      "full_len": 167
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-verify-before-filing",
+      "provenance": "mechanical",
+      "full_len": 180
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-wave-dispatch",
+      "provenance": "mechanical",
+      "full_len": 175
+    }
+  ]
+}

--- a/experiments/skill-catalog-routing/catalogs/catalog_tokens.json
+++ b/experiments/skill-catalog-routing/catalogs/catalog_tokens.json
@@ -1,0 +1,10 @@
+{
+  "measured_with": {
+    "note": "total input tokens incl. fixed router+tooling constant"
+  },
+  "none": 23157,
+  "names": 27326,
+  "short": 30382,
+  "medium": 34109,
+  "full": 43853
+}

--- a/experiments/skill-catalog-routing/conditions.yaml
+++ b/experiments/skill-catalog-routing/conditions.yaml
@@ -1,0 +1,45 @@
+# Condition matrix: cartesian product of (model) × (catalog variant).
+#
+# The independent variable is `catalog` — how much of the skill listing the
+# router sees — on a monotone information ladder:
+#   none   = C0  no catalog (task only; null control, free-recall)
+#   names  = C1  ids only, no descriptions            (~5.8k tok)
+#   short  = C2  "Use when <first trigger>"  ≤40 char
+#   medium = C3  "Use when <triggers>"       ≤80 char
+#   full   = C4  the current full description         (~22.9k tok)
+#
+# The catalog is injected into a catalog-free `--system-prompt-file` (built by
+# build-arm-prompt.sh) so the ONLY skill vocabulary the model sees is the one we
+# inject — Claude Code's own ~22-25k built-in skill listing is stripped by the
+# system-prompt replacement, for every arm including C0. run-one.sh asserts that.
+#
+# `effort` is fixed to `low`: routing is shallow classification, and higher
+# effort lets the model reason around a terse catalog, washing out the
+# description-length signal we are trying to measure.
+#
+# Models are the three pinned aliases in this repo (there is NO `fable` here):
+#   haiku  = claude-haiku-4-5
+#   sonnet = claude-sonnet-4-6
+#   opus   = claude-opus-4-8
+
+conditions:
+  # ---- haiku (weak-model measurement instrument) ----------------------------
+  - {id: haiku-C0, model: claude-haiku-4-5, effort: low, catalog: none}
+  - {id: haiku-C1, model: claude-haiku-4-5, effort: low, catalog: names}
+  - {id: haiku-C2, model: claude-haiku-4-5, effort: low, catalog: short}
+  - {id: haiku-C3, model: claude-haiku-4-5, effort: low, catalog: medium}
+  - {id: haiku-C4, model: claude-haiku-4-5, effort: low, catalog: full}
+
+  # ---- sonnet ---------------------------------------------------------------
+  - {id: sonnet-C0, model: claude-sonnet-4-6, effort: low, catalog: none}
+  - {id: sonnet-C1, model: claude-sonnet-4-6, effort: low, catalog: names}
+  - {id: sonnet-C2, model: claude-sonnet-4-6, effort: low, catalog: short}
+  - {id: sonnet-C3, model: claude-sonnet-4-6, effort: low, catalog: medium}
+  - {id: sonnet-C4, model: claude-sonnet-4-6, effort: low, catalog: full}
+
+  # ---- opus (upper anchor) --------------------------------------------------
+  - {id: opus-C0, model: claude-opus-4-8, effort: low, catalog: none}
+  - {id: opus-C1, model: claude-opus-4-8, effort: low, catalog: names}
+  - {id: opus-C2, model: claude-opus-4-8, effort: low, catalog: short}
+  - {id: opus-C3, model: claude-opus-4-8, effort: low, catalog: medium}
+  - {id: opus-C4, model: claude-opus-4-8, effort: low, catalog: full}

--- a/experiments/skill-catalog-routing/justfile
+++ b/experiments/skill-catalog-routing/justfile
@@ -1,0 +1,107 @@
+# skill-catalog-routing — does the skill catalog help an agent route, and how
+# short can descriptions be? Run `just` or `just help` for the recipe list.
+
+set positional-arguments
+
+default: help
+
+# List all recipes.
+help:
+    @just --list
+
+##########
+# Build
+##########
+
+# (Re)build the four catalog variants + manifest from SKILL.md frontmatter.
+[group: "build"]
+build-catalogs:
+    scripts/build-catalogs.py
+
+# Build + assert the invariants (Use-when preserved, band ceilings, monotone).
+[group: "build"]
+check-catalogs:
+    scripts/build-catalogs.py --validate
+
+##########
+# Running
+##########
+
+# PILOT GATE (~120 calls): haiku, C1 (names) vs C4 (full), 20-task subset, 3 runs.
+# The instrument MUST separate C1 from C4. If it doesn't, the task set is leaky.
+[group: "run"]
+run-pilot runs="3":
+    bash scripts/run-suite.sh \
+      --tasks r01,r02,r03,r04,r05,r06,r07,r08,r09,r10,n01,n02,n03,n04,n05,n06,z01,z02,z03,z04 \
+      --conditions haiku-C1,haiku-C4 --runs "{{runs}}"
+
+# Haiku full ladder (C0-C4) over all tasks — the next gate after the pilot.
+[group: "run"]
+run-haiku filter="*" runs="3":
+    bash scripts/run-suite.sh --filter "{{filter}}" --runs "{{runs}}" \
+      --conditions haiku-C0,haiku-C1,haiku-C2,haiku-C3,haiku-C4
+
+# Full cross-model sweep (all 15 conditions × all tasks). Expensive.
+[group: "run"]
+run-full filter="*" runs="3":
+    bash scripts/run-suite.sh --filter "{{filter}}" --runs "{{runs}}"
+
+# One (task, condition, run) triple for fast iteration.
+[group: "run"]
+run-one task condition run_n="1":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    run_id="adhoc-$(date -u +%Y%m%d-%H%M%S)"
+    mkdir -p "results/${run_id}"
+    bash scripts/run-one.sh "{{task}}" "{{condition}}" "{{run_n}}" "results/${run_id}"
+    printf '%s' "${run_id}" > results/LATEST
+    echo "run_id=${run_id}"
+
+##########
+# Scoring
+##########
+
+# Score one transcript to a TSV row.
+[group: "score"]
+score transcript:
+    scripts/score-run.py "{{transcript}}"
+
+# Aggregate + score a run (default: latest) into results.json + report.md.
+[group: "score"]
+compare run_id="latest":
+    scripts/compare.py "{{run_id}}"
+
+# Render the accuracy-vs-length frontier from a compared run.
+[group: "score"]
+frontier run_id="latest":
+    scripts/render-frontier.py "{{run_id}}"
+
+##########
+# Measurement
+##########
+
+# Measure real input tokens per catalog variant → catalogs/catalog_tokens.json.
+[group: "score"]
+measure-tokens reps="1" model="claude-haiku-4-5":
+    bash scripts/measure-catalog-tokens.sh --reps "{{reps}}" --model "{{model}}"
+
+##########
+# Housekeeping
+##########
+
+# List task ids.
+[group: "meta"]
+tasks:
+    @find tasks -maxdepth 1 -name '*.yaml' -exec basename {} .yaml \; | sort
+
+# List condition ids.
+[group: "meta"]
+conditions:
+    @python3 -c 'import yaml; [print(c["id"]) for c in yaml.safe_load(open("conditions.yaml"))["conditions"]]'
+
+# Delete all results (confirmed).
+[group: "meta"]
+[confirm("delete all results/?")]
+clean:
+    rm -rf results .arm-prompts
+    mkdir -p results

--- a/experiments/skill-catalog-routing/prompts/system-router.md
+++ b/experiments/skill-catalog-routing/prompts/system-router.md
@@ -1,0 +1,44 @@
+You are a **skill-routing classifier**. You do NOT help the user, do NOT perform
+their task, and do NOT ask questions. You emit exactly one routing decision and
+stop. This overrides any other instinct to be helpful or to gather more context.
+
+# Your task
+
+Read the user's request and choose the ONE pre-built skill that best handles it,
+or `NONE` if no available skill genuinely fits.
+
+A skill is identified by `<plugin>/<skill>` (e.g. `tools-plugin/rg-code-search`).
+The skills available to you are listed below under "## Available skills". Each
+line is `<id>` or `<id>: <description>`. The list may carry only ids, may be
+shortened, or may be absent entirely — decide using exactly what is shown and
+nothing you recall from elsewhere. Never invent an id that is not listed; if no
+list is shown, answer `NONE` unless you are genuinely confident an id exists.
+
+Prefer `NONE` over a weak or approximate match — a wrong skill is worse than
+none. Do not perform the request. Do not ask for clarification. Do not explain
+at length.
+
+# Output contract (MANDATORY)
+
+Your entire reply is at most a few short lines. The LAST line MUST be exactly one
+JSON object and nothing after it:
+
+{"skill": "<plugin>/<skill> or NONE", "confidence": 0.0-1.0, "runner_up": "<plugin>/<skill> or NONE"}
+
+- `skill`      — the single best-matching id, or the literal `NONE`
+- `confidence` — 0.0–1.0
+- `runner_up`  — the second-best id, or `NONE`
+
+## Example
+
+User request: "I need to spin up a local Postgres in a container for testing."
+Your reply:
+{"skill": "container-plugin/container-development", "confidence": 0.6, "runner_up": "NONE"}
+
+## Example (nothing fits)
+
+User request: "Write me a haiku about autumn."
+Your reply:
+{"skill": "NONE", "confidence": 0.9, "runner_up": "NONE"}
+
+Emit only the decision. The JSON object must be valid and must be the final line.

--- a/experiments/skill-catalog-routing/scripts/build-arm-prompt.sh
+++ b/experiments/skill-catalog-routing/scripts/build-arm-prompt.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Assemble the per-arm router system prompt: prompts/system-router.md followed by
+# the injected catalog body for the given variant. Writes
+# .arm-prompts/system.<variant>.md and prints its path.
+#
+# The result is a COMPLETE system-prompt replacement (used with
+# --system-prompt-file), so Claude Code's own built-in skill listing never
+# appears — the only skill vocabulary the model sees is the catalog we inject.
+#
+# Usage: build-arm-prompt.sh <none|names|short|medium|full>
+
+set -euo pipefail
+
+variant="${1:?usage: build-arm-prompt.sh <none|names|short|medium|full>}"
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "$here/.." && pwd)"
+router="$root/prompts/system-router.md"
+out_dir="$root/.arm-prompts"
+out="$out_dir/system.$variant.md"
+
+[ -f "$router" ] || { echo "ERROR: router prompt not found: $router" >&2; exit 1; }
+mkdir -p "$out_dir"
+
+case "$variant" in
+  none)
+    # C0 — no catalog. Router prompt only.
+    cp "$router" "$out"
+    ;;
+  names|short|medium|full)
+    catalog="$root/catalogs/catalog.$variant.json"
+    [ -f "$catalog" ] || { echo "ERROR: catalog not found: $catalog — run build-catalogs.py first" >&2; exit 1; }
+    {
+      cat "$router"
+      printf '\n\n## Available skills\n\n'
+      # One skill per line, exactly as stored in the catalog's `line` field.
+      python3 -c '
+import json, sys
+data = json.load(open(sys.argv[1]))
+for e in data["entries"]:
+    print(e["line"])
+' "$catalog"
+    } > "$out"
+    ;;
+  *)
+    echo "ERROR: unknown catalog variant: $variant" >&2
+    exit 1
+    ;;
+esac
+
+printf '%s\n' "$out"

--- a/experiments/skill-catalog-routing/scripts/build-catalogs.py
+++ b/experiments/skill-catalog-routing/scripts/build-catalogs.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env -S uv run --script --quiet
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pyyaml>=6"]
+# ///
+"""Build the skill-catalog variants used as experiment arms.
+
+Enumerates every `*-plugin/skills/*/SKILL.md` (the same 405-skill corpus the
+repo's `scripts/audit-skill-descriptions.py` audits), reads the FULL
+`description` from frontmatter (the audit's `--json` display-truncates it to
+~100 chars — we must read the real text), and emits four catalog variants plus
+a manifest:
+
+    catalog.names.json    ids only, no descriptions           (arm C1)
+    catalog.short.json    "Use when <first trigger>"  ≤40c    (arm C2)
+    catalog.medium.json   "Use when <triggers>"       ≤80c    (arm C3)
+    catalog.full.json     the current full description         (arm C4)
+    catalog_manifest.json source SHA, content hashes, per-skill provenance
+
+Design invariants (see the experiment plan and .claude/rules/skill-quality.md):
+
+* The routing id is `<plugin>/<skill-dir>` (unique across plugins; matches the
+  golden-set convention `tools-plugin/rg-code-search`). That id is what the
+  model is asked to emit and what the grader matches on.
+* Shortening is STRUCTURE-AWARE, never end-truncation of the whole string.
+  Descriptions are `<domain>. Use when <triggers>.` — the routing-relevant part
+  (the triggers) sits at the END, and naive truncation would delete it and the
+  literal `Use when` substring that auto-invocation depends on (issue #1278).
+  So we locate the `Use when` clause and truncate THAT, always retaining the
+  literal `Use when` marker.
+* The bands are genuine token-subsets: short ⊆ medium ⊆ full. `short` truncates
+  the first trigger scenario to ≤40c; `medium` truncates the whole trigger
+  clause to ≤80c; short's cut point ≤ medium's, so short is a prefix of medium.
+
+Each catalog is `{"variant": ..., "source_sha": ..., "entries": [{id, text}]}`
+where `text` is `""` for the names variant and `"<id>: <desc>"` otherwise — the
+exact line injected into the router system prompt.
+
+Usage:
+    build-catalogs.py                 # write all four + manifest
+    build-catalogs.py --validate      # rebuild, then assert invariants, exit 1 on failure
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+# experiments/skill-catalog-routing/scripts/build-catalogs.py -> repo root
+REPO_ROOT = Path(__file__).resolve().parents[3]
+OUT_DIR = Path(__file__).resolve().parents[1] / "catalogs"
+
+SHORT_MAX = 40
+MEDIUM_MAX = 80
+
+# Case-insensitive locator for the trigger clause. We keep the ORIGINAL casing
+# of whatever matched (usually "Use when") so the literal survives.
+_USE_WHEN_RE = re.compile(r"\buse when\b", re.IGNORECASE)
+# Scenario separators inside a trigger clause: commas, semicolons, " or ".
+_SCENARIO_SPLIT_RE = re.compile(r",|;|\bor\b", re.IGNORECASE)
+
+
+def find_skills(root: Path) -> list[Path]:
+    """All SKILL.md under *-plugin/skills/ (mirrors audit-skill-descriptions.py)."""
+    skills: list[Path] = []
+    for plugin_dir in sorted(root.glob("*-plugin")):
+        if not plugin_dir.is_dir():
+            continue
+        skills_dir = plugin_dir / "skills"
+        if not skills_dir.is_dir():
+            continue
+        for skill_md in sorted(skills_dir.rglob("SKILL.md")):
+            skills.append(skill_md)
+    return skills
+
+
+def read_full_description(path: Path) -> str | None:
+    """Parse frontmatter and return the FULL description string (not truncated)."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    if not text.startswith("---"):
+        return None
+    parts = text.split("\n---", 1)
+    if len(parts) < 2:
+        return None
+    fm_text = parts[0].lstrip("-").lstrip("\n")
+    try:
+        data = yaml.safe_load(fm_text)
+    except yaml.YAMLError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    desc = data.get("description")
+    if not isinstance(desc, str):
+        return None
+    # Collapse internal whitespace (block scalars fold to multi-space); the
+    # listing the model sees is single-line.
+    return " ".join(desc.split())
+
+
+def routing_id(path: Path) -> str:
+    rel = path.relative_to(REPO_ROOT)
+    return f"{rel.parts[0]}/{path.parent.name}"
+
+
+def _truncate_word_boundary(s: str, n: int) -> str:
+    """Truncate to ≤ n chars at a word boundary, stripping trailing punctuation
+    and dangling conjunctions."""
+    s = s.strip()
+    if len(s) <= n:
+        return s.rstrip(" ,;.").strip()
+    cut = s[:n]
+    # Only back off to a word boundary if we actually cut mid-word (the char at
+    # the cut point is not a space). A cut that lands exactly on a boundary is
+    # kept — this preserves a scenario token that fit exactly (e.g. a long
+    # slash-joined "watching/monitoring/babysitting").
+    if s[n] != " " and " " in cut:
+        cut = cut[: cut.rfind(" ")]
+    cut = cut.rstrip(" ,;.")
+    # Drop a dangling trailing conjunction/preposition — but never "use"/"when",
+    # which are the literal marker auto-invocation depends on (#1278).
+    words = cut.split()
+    while words and words[-1].lower() in {"or", "and", "the", "a", "to", "of", "for", "in", "on", "with"}:
+        words.pop()
+    return " ".join(words)
+
+
+def shorten(desc: str) -> tuple[str, str, str]:
+    """Return (short_text, medium_text, provenance) for a full description.
+
+    provenance: "mechanical" (extracted from a Use-when clause) or
+    "prefix" (no Use-when marker present; fall back to a leading prefix).
+    """
+    m = _USE_WHEN_RE.search(desc)
+    if not m:
+        # No trigger marker — take leading prefixes. Monotone by construction
+        # (short prefix ⊆ medium prefix).
+        medium = _truncate_word_boundary(desc, MEDIUM_MAX)
+        short = _truncate_word_boundary(desc, SHORT_MAX)
+        return short, medium, "prefix"
+
+    clause = desc[m.start():].strip()  # "Use when <triggers>."
+    # medium: truncate the whole clause to ≤80, always keeping "Use when".
+    medium = _truncate_word_boundary(clause, MEDIUM_MAX)
+    # short: first scenario only, truncated to ≤40.
+    # The clause is "Use when <scenario1>, <scenario2>, ...". Split the part
+    # AFTER "Use when" on scenario separators and keep the first.
+    prefix_len = m.end() - m.start()  # length of "Use when" as it appeared
+    marker = clause[:prefix_len]  # preserve original casing, e.g. "Use when"
+    rest = clause[prefix_len:].lstrip()
+    first_scenario = _SCENARIO_SPLIT_RE.split(rest, maxsplit=1)[0].strip()
+    short_candidate = f"{marker} {first_scenario}".strip()
+    short = _truncate_word_boundary(short_candidate, SHORT_MAX)
+    return short, medium, "mechanical"
+
+
+def build() -> tuple[list[dict], str]:
+    sha = "unknown"
+    try:
+        sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=REPO_ROOT, capture_output=True, text=True, check=True,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, OSError):
+        pass
+
+    rows = []
+    for path in find_skills(REPO_ROOT):
+        desc = read_full_description(path)
+        if desc is None or not desc.strip():
+            # Skills with no usable description are still real routing targets;
+            # keep the id with an empty description so the closed set is complete.
+            rid = routing_id(path)
+            rows.append({
+                "id": rid, "full": "", "medium": "", "short": "",
+                "provenance": "empty", "full_len": 0,
+            })
+            continue
+        short, medium, provenance = shorten(desc)
+        rows.append({
+            "id": routing_id(path),
+            "full": desc,
+            "medium": medium,
+            "short": short,
+            "provenance": provenance,
+            "full_len": len(desc),
+        })
+    return rows, sha
+
+
+def _line(rid: str, text: str) -> str:
+    return f"{rid}: {text}" if text else rid
+
+
+def write_catalogs(rows: list[dict], sha: str) -> dict[str, str]:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    variants = {
+        "names": lambda r: _line(r["id"], ""),
+        "short": lambda r: _line(r["id"], r["short"]),
+        "medium": lambda r: _line(r["id"], r["medium"]),
+        "full": lambda r: _line(r["id"], r["full"]),
+    }
+    hashes = {}
+    for variant, render in variants.items():
+        entries = [{"id": r["id"], "line": render(r)} for r in rows]
+        body = "\n".join(e["line"] for e in entries)
+        payload = {
+            "variant": variant,
+            "source_sha": sha,
+            "skill_count": len(entries),
+            "entries": entries,
+        }
+        out = OUT_DIR / f"catalog.{variant}.json"
+        out.write_text(json.dumps(payload, indent=2) + "\n")
+        hashes[variant] = hashlib.sha256(body.encode()).hexdigest()[:16]
+    return hashes
+
+
+def write_manifest(rows: list[dict], sha: str, hashes: dict[str, str]) -> None:
+    prov = {}
+    for r in rows:
+        prov[r["provenance"]] = prov.get(r["provenance"], 0) + 1
+    manifest = {
+        "source_sha": sha,
+        "skill_count": len(rows),
+        "content_hashes": hashes,
+        "provenance_counts": prov,
+        "band_char_ceilings": {"short": SHORT_MAX, "medium": MEDIUM_MAX},
+        "per_skill": [
+            {"id": r["id"], "provenance": r["provenance"], "full_len": r["full_len"]}
+            for r in rows
+        ],
+    }
+    (OUT_DIR / "catalog_manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+
+
+def validate(rows: list[dict]) -> int:
+    """Assert the load-bearing invariants; return count of failures."""
+    failures = 0
+
+    def fail(msg: str) -> None:
+        nonlocal failures
+        failures += 1
+        print(f"FAIL: {msg}", file=sys.stderr)
+
+    for r in rows:
+        if not r["full"]:
+            continue  # empty-description skills are exempt from band checks
+        # Band ceilings.
+        if len(r["short"]) > SHORT_MAX:
+            fail(f"{r['id']} short exceeds {SHORT_MAX}c: {len(r['short'])}")
+        if len(r["medium"]) > MEDIUM_MAX:
+            fail(f"{r['id']} medium exceeds {MEDIUM_MAX}c: {len(r['medium'])}")
+        # Use-when preservation for mechanically-extracted variants (#1278 class).
+        if r["provenance"] == "mechanical":
+            if "use when" not in r["short"].lower():
+                fail(f"{r['id']} short lost 'Use when': {r['short']!r}")
+            if "use when" not in r["medium"].lower():
+                fail(f"{r['id']} medium lost 'Use when': {r['medium']!r}")
+        # Monotonicity: short must be a prefix of medium (token-subset).
+        if r["short"] and not r["medium"].startswith(r["short"]):
+            fail(f"{r['id']} short is not a prefix of medium:\n  short={r['short']!r}\n  medium={r['medium']!r}")
+
+    total = len(rows)
+    print(f"Validated {total} skills; {failures} failures.", file=sys.stderr)
+    return failures
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--validate", action="store_true", help="assert invariants; exit 1 on any failure")
+    args = ap.parse_args()
+
+    rows, sha = build()
+    hashes = write_catalogs(rows, sha)
+    write_manifest(rows, sha, hashes)
+
+    prov = {}
+    for r in rows:
+        prov[r["provenance"]] = prov.get(r["provenance"], 0) + 1
+    print(f"Wrote {len(rows)} skills to {OUT_DIR.relative_to(REPO_ROOT)}/ (sha {sha[:8]})")
+    print(f"Provenance: {prov}")
+    print(f"Content hashes: {hashes}")
+
+    if args.validate:
+        return 1 if validate(rows) else 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/skill-catalog-routing/scripts/check-tasks.py
+++ b/experiments/skill-catalog-routing/scripts/check-tasks.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env -S uv run --script --quiet
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pyyaml>=6"]
+# ///
+"""Validate the task set: schema, gold/near_miss resolve to catalog ids, and the
+lexical-leakage gate.
+
+The leakage gate is the study's most important instrument. If a task echoes its
+gold skill's own NAME tokens, then names-only (C1) can win by string overlap and
+description length stops mattering — the experiment would measure nothing. We
+compute `name_overlap` = fraction of the gold skill's distinctive name tokens
+that appear in the task prompt, and flag anything above the threshold.
+
+Emits a structured `=== TASK AUDIT ===` report (see
+.claude/rules/structured-script-output.md). `--strict` exits 1 on any ERROR.
+
+Usage:
+    check-tasks.py            # audit, human report
+    check-tasks.py --strict   # exit 1 on schema errors or leakage over threshold
+    check-tasks.py --json     # machine-readable
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+
+NAME_OVERLAP_ERROR = 0.5   # over half the name tokens echoed → hard leak
+NAME_OVERLAP_WARN = 0.34   # a third echoed → review
+
+# Generic tokens that appear in many skill names AND naturally in symptom prose;
+# echoing these is not meaningful leakage.
+GENERIC = {
+    "code", "test", "tests", "git", "check", "run", "build", "file", "files",
+    "search", "review", "audit", "plugin", "config", "python", "rust", "node",
+    "management", "development", "workflow", "tool", "tools", "analysis", "add",
+    "status", "install", "advanced", "cli", "quality", "docs", "data",
+}
+STOP = {
+    "a", "an", "the", "to", "of", "for", "in", "on", "and", "or", "with", "my",
+    "i", "is", "are", "it", "this", "that", "how", "do", "can", "need", "want",
+    "am", "have", "has", "get", "there", "when", "use", "using", "some", "any",
+    "me", "we", "our", "your", "but", "so", "up", "out", "into", "from", "at",
+}
+
+
+def tokenize(text: str) -> set[str]:
+    words = re.findall(r"[a-z0-9]+", text.lower())
+    out = set()
+    for w in words:
+        if w in STOP or len(w) < 3:
+            continue
+        # crude singularization
+        if w.endswith("s") and len(w) > 3:
+            w = w[:-1]
+        out.add(w)
+    return out
+
+
+def name_tokens(skill_id: str) -> set[str]:
+    slug = skill_id.split("/", 1)[-1]
+    toks = {t for t in re.split(r"[-_]", slug.lower()) if len(t) >= 3}
+    # drop the plugin-name echo and generic tokens
+    return {t for t in toks if t not in GENERIC}
+
+
+def catalog_ids() -> set[str]:
+    path = ROOT / "catalogs" / "catalog.names.json"
+    if not path.exists():
+        sys.exit("no catalog.names.json — run build-catalogs.py first")
+    return {e["id"] for e in json.loads(path.read_text())["entries"]}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--strict", action="store_true")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    ids = catalog_ids()
+    task_files = sorted((ROOT / "tasks").glob("*.yaml"))
+    rows = []
+    errors = 0
+    warns = 0
+
+    for tf in task_files:
+        rec = {"task": tf.stem, "issues": []}
+        try:
+            t = yaml.safe_load(tf.read_text())
+        except yaml.YAMLError as e:
+            rec["issues"].append(("ERROR", f"yaml parse: {e}"))
+            rows.append(rec); errors += 1
+            continue
+        prompt = str(t.get("prompt", "")).strip()
+        gold = str(t.get("gold", "")).strip()
+        near = t.get("near_miss")
+        rec["gold"] = gold
+
+        if not prompt:
+            rec["issues"].append(("ERROR", "missing prompt"))
+        if not gold:
+            rec["issues"].append(("ERROR", "missing gold"))
+        is_none = gold.upper() == "NONE"
+        if not is_none and gold not in ids:
+            rec["issues"].append(("ERROR", f"gold not in catalog: {gold}"))
+        if near:
+            if near not in ids:
+                rec["issues"].append(("ERROR", f"near_miss not in catalog: {near}"))
+            if near == gold:
+                rec["issues"].append(("ERROR", "near_miss equals gold"))
+
+        # Leakage gate (only meaningful for route tasks with a real gold).
+        overlap = 0.0
+        if not is_none and gold in ids:
+            nt = name_tokens(gold)
+            pt = tokenize(prompt)
+            if nt:
+                hit = nt & pt
+                overlap = round(len(hit) / len(nt), 3)
+                rec["leaked_tokens"] = sorted(hit)
+                if overlap >= NAME_OVERLAP_ERROR:
+                    rec["issues"].append(("ERROR", f"name_overlap {overlap} ≥ {NAME_OVERLAP_ERROR}: {sorted(hit)}"))
+                elif overlap >= NAME_OVERLAP_WARN:
+                    rec["issues"].append(("WARN", f"name_overlap {overlap} ≥ {NAME_OVERLAP_WARN}: {sorted(hit)}"))
+        rec["name_overlap"] = overlap
+
+        for sev, _ in rec["issues"]:
+            if sev == "ERROR":
+                errors += 1
+            elif sev == "WARN":
+                warns += 1
+        rows.append(rec)
+
+    if args.json:
+        print(json.dumps(rows, indent=2))
+    else:
+        print("=== TASK AUDIT ===")
+        n_none = sum(1 for r in rows if r.get("gold", "").upper() == "NONE")
+        n_route = len(rows) - n_none
+        print(f"TASK_COUNT={len(rows)}")
+        print(f"ROUTE_TASKS={n_route}")
+        print(f"NONE_TASKS={n_none}")
+        print(f"ERROR_COUNT={errors}")
+        print(f"WARN_COUNT={warns}")
+        if errors or warns:
+            print("ISSUES:")
+            for r in rows:
+                for sev, msg in r["issues"]:
+                    print(f"  - SEVERITY={sev} TASK={r['task']} MSG={msg}")
+        print(f"STATUS={'ERROR' if errors else ('WARN' if warns else 'OK')}")
+        print(f"ISSUE_COUNT={errors + warns}")
+        print("=== END TASK AUDIT ===")
+
+    if args.strict and errors:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/skill-catalog-routing/scripts/compare.py
+++ b/experiments/skill-catalog-routing/scripts/compare.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env -S uv run --script --quiet
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pyyaml>=6"]
+# ///
+"""Aggregate scored routing transcripts for a run-id into per-condition metrics.
+
+Walks results/<run_id>/*.jsonl, scores each with score-run.py, joins against the
+task metadata (gold type: route / near_miss / none), and emits:
+
+  * results/<run_id>/scores.tsv      raw per-transcript rows
+  * results/<run_id>/results.json    per-condition metrics (for render-frontier.py)
+  * results/<run_id>/report.md       a markdown metrics table
+
+Metrics per condition (pooled over runs):
+  n_route        gradeable route tasks (gold != NONE)
+  top1           top-1 routing accuracy over route tasks
+  near_miss      accuracy over the near-miss discrimination subset
+  top2_nearmiss  (predicted OR runner_up == gold) over near-miss subset
+  false_trigger  fraction of gold=NONE tasks where a skill was (wrongly) picked
+  abstain        fraction of gold=NONE tasks correctly answered NONE
+  parse_fail     fraction of all transcripts whose decision did not parse
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+
+
+def resolve_run_id(arg: str | None) -> str:
+    if arg and arg != "latest":
+        return arg
+    latest = ROOT / "results" / "LATEST"
+    if not latest.exists():
+        sys.exit("no results/LATEST — pass a run-id explicitly")
+    return latest.read_text().strip()
+
+
+def load_task_meta() -> dict[str, dict]:
+    meta = {}
+    for tf in sorted((ROOT / "tasks").glob("*.yaml")):
+        t = yaml.safe_load(tf.read_text())
+        gold = str(t.get("gold", "NONE"))
+        is_none = gold.strip().upper() == "NONE"
+        meta[tf.stem] = {
+            "gold": gold,
+            "is_none": is_none,
+            "is_near_miss": bool(t.get("near_miss")) and not is_none,
+        }
+    return meta
+
+
+def score(transcript: Path) -> list[str] | None:
+    proc = subprocess.run(
+        [str(HERE / "score-run.py"), str(transcript)],
+        capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        print(f"WARN: score-run failed for {transcript.name}: {proc.stderr}", file=sys.stderr)
+        return None
+    line = proc.stdout.strip()
+    return line.split("\t") if line else None
+
+
+def wilson(p: float, n: int) -> tuple[float, float]:
+    """95% Wilson interval half-widths are folded into (lo, hi)."""
+    if n == 0:
+        return (0.0, 0.0)
+    z = 1.96
+    denom = 1 + z * z / n
+    centre = (p + z * z / (2 * n)) / denom
+    half = z * ((p * (1 - p) / n + z * z / (4 * n * n)) ** 0.5) / denom
+    return (max(0.0, centre - half), min(1.0, centre + half))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("run_id", nargs="?", default="latest")
+    args = ap.parse_args()
+
+    run_id = resolve_run_id(args.run_id)
+    run_dir = ROOT / "results" / run_id
+    if not run_dir.is_dir():
+        sys.exit(f"no such run: {run_dir}")
+
+    transcripts = sorted(run_dir.glob("*.jsonl"))
+    if not transcripts:
+        sys.exit(f"no transcripts under {run_dir}")
+
+    task_meta = load_task_meta()
+    rows = [r for t in transcripts if (r := score(t))]
+
+    # Persist raw scores.
+    header = ["task_id", "condition_id", "run_n", "gold", "predicted",
+              "runner_up", "confidence", "correct", "parse"]
+    with (run_dir / "scores.tsv").open("w") as f:
+        f.write("\t".join(header) + "\n")
+        for r in rows:
+            f.write("\t".join(r) + "\n")
+
+    # Aggregate per condition.
+    agg: dict[str, dict] = collections.defaultdict(lambda: {
+        "route_correct": 0, "route_n": 0,
+        "nm_correct": 0, "nm_top2": 0, "nm_n": 0,
+        "none_abstain": 0, "none_n": 0,
+        "parse_fail": 0, "total": 0,
+    })
+    for task_id, cond, _run_n, gold, predicted, runner_up, _conf, correct, parse in rows:
+        m = task_meta.get(task_id)
+        if m is None:
+            continue
+        a = agg[cond]
+        a["total"] += 1
+        if parse != "ok":
+            a["parse_fail"] += 1
+        if m["is_none"]:
+            a["none_n"] += 1
+            if parse == "ok" and predicted == "NONE":
+                a["none_abstain"] += 1
+        else:
+            a["route_n"] += 1
+            if correct == "1":
+                a["route_correct"] += 1
+            if m["is_near_miss"]:
+                a["nm_n"] += 1
+                if correct == "1":
+                    a["nm_correct"] += 1
+                if parse == "ok" and (predicted == m["gold"] or runner_up == m["gold"]):
+                    a["nm_top2"] += 1
+
+    # Optional measured catalog tokens.
+    tokens = {}
+    tok_path = run_dir.parent.parent / "catalogs" / "catalog_tokens.json"
+    if tok_path.exists():
+        tokens = json.loads(tok_path.read_text())
+
+    def rate(num: int, den: int) -> float:
+        return round(num / den, 4) if den else 0.0
+
+    results = {}
+    for cond, a in sorted(agg.items()):
+        top1 = rate(a["route_correct"], a["route_n"])
+        lo, hi = wilson(top1, a["route_n"])
+        results[cond] = {
+            "n_route": a["route_n"],
+            "top1": top1,
+            "top1_ci": [round(lo, 4), round(hi, 4)],
+            "near_miss": rate(a["nm_correct"], a["nm_n"]),
+            "top2_nearmiss": rate(a["nm_top2"], a["nm_n"]),
+            "false_trigger": rate(a["none_n"] - a["none_abstain"], a["none_n"]),
+            "abstain": rate(a["none_abstain"], a["none_n"]),
+            "parse_fail": rate(a["parse_fail"], a["total"]),
+            "total": a["total"],
+        }
+    out = {"run_id": run_id, "conditions": results, "catalog_tokens": tokens}
+    (run_dir / "results.json").write_text(json.dumps(out, indent=2) + "\n")
+
+    # Markdown report.
+    cols = ["top1", "near_miss", "top2_nearmiss", "false_trigger", "abstain", "parse_fail"]
+    lines = [f"# skill-catalog-routing run {run_id}", "",
+             f"Transcripts: {len(transcripts)}  ·  scored rows: {len(rows)}", "",
+             "| condition | " + " | ".join(cols) + " | n_route |",
+             "|" + "---|" * (len(cols) + 2)]
+    for cond in sorted(results):
+        r = results[cond]
+        cells = [f"{r[c]:.2f}" for c in cols]
+        lines.append(f"| {cond} | " + " | ".join(cells) + f" | {r['n_route']} |")
+    report = "\n".join(lines)
+    print(report)
+    (run_dir / "report.md").write_text(report + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/skill-catalog-routing/scripts/measure-catalog-tokens.sh
+++ b/experiments/skill-catalog-routing/scripts/measure-catalog-tokens.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Measure the real per-invocation input-token cost of each catalog variant.
+# Adapted from experiments/claude-probe/scripts/measure-prompt-tokens.sh.
+#
+# For each variant, assemble its arm system prompt (router + catalog), run a
+# fixed tiny tool-free prompt once, and read `result.usage` total input tokens
+# from the stream-JSON. The arm's system prompt is the only thing that varies,
+# so the total input is the catalog's real token cost (+ a fixed router/tooling
+# constant). Writes catalogs/catalog_tokens.json for render-frontier.py.
+#
+# Usage: measure-catalog-tokens.sh [--reps N] [--model ID] [--effort LEVEL]
+
+set -uo pipefail
+
+reps=1
+model="claude-haiku-4-5"
+effort="low"
+prompt="Reply with exactly the word: ok"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --reps) reps="$2"; shift 2 ;;
+    --model) model="$2"; shift 2 ;;
+    --effort) effort="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "$here/.." && pwd)"
+
+measure_once() {
+  local arm_prompt="$1"
+  local neutral; neutral="$(mktemp -d)"
+  ( cd "$neutral" && IS_SANDBOX=1 claude -p "$prompt" \
+    --model "$model" --effort "$effort" \
+    --system-prompt-file "$arm_prompt" \
+    --strict-mcp-config \
+    --output-format stream-json --verbose \
+    --dangerously-skip-permissions </dev/null 2>/dev/null ) | jq -rs '
+      (map(select(.type=="result")) | last) // empty
+      | .usage
+      | (.input_tokens + .cache_creation_input_tokens + .cache_read_input_tokens)'
+  rm -rf "$neutral"
+}
+
+echo "=== CATALOG TOKEN MEASUREMENT ==="
+echo "MODEL=$model"
+echo "EFFORT=$effort"
+echo "REPS=$reps"
+printf 'VARIANT\trep\ttotal_input\n'
+
+tmp_json="$root/catalogs/catalog_tokens.json"
+declare -A mean
+for variant in none names short medium full; do
+  arm_prompt="$("$here/build-arm-prompt.sh" "$variant")"
+  sum=0; got=0
+  for ((i = 1; i <= reps; i++)); do
+    val="$(measure_once "$arm_prompt")"
+    if [ -z "$val" ] || ! [[ "$val" =~ ^[0-9]+$ ]]; then
+      echo "WARN: empty/invalid usage for $variant rep $i" >&2
+      continue
+    fi
+    printf '%s\t%d\t%s\n' "$variant" "$i" "$val"
+    sum=$(( sum + val )); got=$(( got + 1 ))
+  done
+  if [ "$got" -gt 0 ]; then
+    mean[$variant]=$(( sum / got ))
+  else
+    mean[$variant]=0
+  fi
+  printf '%s_MEAN=%d\n' "$variant" "${mean[$variant]}"
+done
+
+# Emit JSON for the frontier renderer.
+python3 - "$tmp_json" "${mean[none]}" "${mean[names]}" "${mean[short]}" "${mean[medium]}" "${mean[full]}" <<'PY'
+import json, sys
+out, none, names, short, medium, full = sys.argv[1:7]
+json.dump({
+    "measured_with": {"note": "total input tokens incl. fixed router+tooling constant"},
+    "none": int(none), "names": int(names), "short": int(short),
+    "medium": int(medium), "full": int(full),
+}, open(out, "w"), indent=2)
+print(f"wrote {out}")
+PY
+echo "=== END CATALOG TOKEN MEASUREMENT ==="

--- a/experiments/skill-catalog-routing/scripts/render-frontier.py
+++ b/experiments/skill-catalog-routing/scripts/render-frontier.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env -S uv run --script --quiet
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Render the accuracy-vs-length frontier from a run's results.json.
+
+Answers the experiment's headline questions as curves, per model:
+  1. accuracy vs catalog size (C0→C4): does the catalog help, and where is the
+     diminishing-returns knee?
+  2. false-trigger rate vs catalog size: does a bigger catalog over-trigger?
+  3. per-model degradation slope (top1[C4] − top1[C2]): weak models leaning on
+     description length is the portability signal (cf. evaluate-plugin's
+     opus−haiku ≥ 0.2 flag).
+
+Usage: render-frontier.py [<run-id>]   (defaults to results/LATEST)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+ARMS = ["C0", "C1", "C2", "C3", "C4"]
+ARM_CATALOG = {"C0": "none", "C1": "names", "C2": "short", "C3": "medium", "C4": "full"}
+MODELS = ["haiku", "sonnet", "opus"]
+PORTABILITY_THRESHOLD = 0.15
+
+
+def resolve_run_id(argv: list[str]) -> str:
+    if len(argv) > 1 and argv[1] != "latest":
+        return argv[1]
+    latest = ROOT / "results" / "LATEST"
+    if not latest.exists():
+        sys.exit("no results/LATEST — pass a run-id")
+    return latest.read_text().strip()
+
+
+def main() -> int:
+    run_id = resolve_run_id(sys.argv)
+    results_path = ROOT / "results" / run_id / "results.json"
+    if not results_path.exists():
+        sys.exit(f"no results.json for {run_id} — run compare.py first")
+    data = json.loads(results_path.read_text())
+    conds = data["conditions"]
+    tokens = data.get("catalog_tokens", {})
+
+    lines = [f"# Frontier — run {run_id}", ""]
+
+    if tokens:
+        lines += ["## Measured catalog tokens", ""]
+        lines += ["| arm | catalog | tokens |", "|---|---|---|"]
+        for arm in ARMS:
+            cat = ARM_CATALOG[arm]
+            lines.append(f"| {arm} | {cat} | {tokens.get(cat, '—')} |")
+        lines.append("")
+
+    # Per-model tables.
+    for model in MODELS:
+        present = [a for a in ARMS if f"{model}-{a}" in conds]
+        if not present:
+            continue
+        lines += [f"## {model}", "",
+                  "| arm | catalog | tokens | top1 | near_miss | false_trigger | abstain |",
+                  "|---|---|---|---|---|---|---|"]
+        for arm in present:
+            r = conds[f"{model}-{arm}"]
+            cat = ARM_CATALOG[arm]
+            tok = tokens.get(cat, "—")
+            lines.append(
+                f"| {arm} | {cat} | {tok} | {r['top1']:.2f} | {r['near_miss']:.2f} "
+                f"| {r['false_trigger']:.2f} | {r['abstain']:.2f} |"
+            )
+        lines.append("")
+
+    # Headline deltas.
+    lines += ["## Headline signals", ""]
+    lines += ["| model | C4−C0 (catalog value) | C4−C1 (desc value) | "
+              "C4−C2 (length slope) | C3 vs C4 top1 |",
+              "|---|---|---|---|---|"]
+    slopes = {}
+    for model in MODELS:
+        def g(arm: str, key: str = "top1"):
+            c = conds.get(f"{model}-{arm}")
+            return c[key] if c else None
+        c0, c1, c2, c3, c4 = (g(a) for a in ARMS)
+        if c4 is None:
+            continue
+        catalog_value = f"{c4 - c0:+.2f}" if c0 is not None else "—"
+        desc_value = f"{c4 - c1:+.2f}" if c1 is not None else "—"
+        slope = (c4 - c2) if c2 is not None else None
+        slopes[model] = slope
+        slope_s = f"{slope:+.2f}" if slope is not None else "—"
+        c3c4 = f"{c3:.2f} vs {c4:.2f}" if c3 is not None else "—"
+        lines.append(f"| {model} | {catalog_value} | {desc_value} | {slope_s} | {c3c4} |")
+    lines.append("")
+
+    # Portability read.
+    if "haiku" in slopes and "opus" in slopes and slopes["haiku"] is not None and slopes["opus"] is not None:
+        gap = slopes["haiku"] - slopes["opus"]
+        lines += ["## Portability", ""]
+        if gap >= PORTABILITY_THRESHOLD:
+            lines.append(
+                f"⚠️ haiku degrades {gap:+.2f} more than opus when descriptions shrink "
+                f"(C4−C2 slope gap ≥ {PORTABILITY_THRESHOLD}). Weak models lean on "
+                "description length — shortening is safe on opus but harms haiku."
+            )
+        else:
+            lines.append(
+                f"Shortening headroom is comparable across models (haiku−opus slope gap "
+                f"{gap:+.2f} < {PORTABILITY_THRESHOLD}). Shorter descriptions are "
+                "roughly as safe on the weak model as on the strong one."
+            )
+        lines.append("")
+
+    report = "\n".join(lines)
+    print(report)
+    (ROOT / "results" / run_id / "frontier.md").write_text(report + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/skill-catalog-routing/scripts/run-one.sh
+++ b/experiments/skill-catalog-routing/scripts/run-one.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Run a single (task, condition, run_n) triple. Writes a stream-JSON transcript
+# to $RUN_DIR/<task>.<condition>.run<N>.jsonl plus a .meta.json sidecar.
+#
+# Adapted from experiments/claude-probe/scripts/run-one.sh. Differences:
+#   * the arm is defined by which CATALOG variant is injected, not a fixed probe
+#   * the system prompt is assembled per-arm by build-arm-prompt.sh
+#   * no per-task fixtures / config-isolation arms (routing is read-only)
+#   * asserts the assembled system prompt carries no built-in skill listing
+#
+# Usage: run-one.sh <task-id> <condition-id> <run-n> <run-dir>
+
+set -euo pipefail
+
+task_id="${1:?usage: run-one.sh <task-id> <condition-id> <run-n> <run-dir>}"
+condition_id="${2:?condition-id required}"
+run_n="${3:?run-n required}"
+run_dir="${4:?run-dir required}"
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "$here/.." && pwd)"
+tasks_dir="$root/tasks"
+conditions_file="$root/conditions.yaml"
+
+task_file="$tasks_dir/${task_id}.yaml"
+[ -f "$task_file" ] || { echo "ERROR: task not found: $task_file" >&2; exit 1; }
+
+# Extract the task prompt and wrap it in a constant framing that reinforces the
+# routing contract (a low-effort model otherwise slips into doing the task or
+# asking questions). The wrapper is identical for every task and every arm, so
+# it does not bias the catalog comparison.
+task_prompt="$(
+  PY_TASK_FILE="$task_file" python3 -c '
+import os, sys, yaml
+t = yaml.safe_load(open(os.environ["PY_TASK_FILE"]))
+body = t["prompt"].strip()
+sys.stdout.write(
+    "Route this user request to the best skill (or NONE). "
+    "Do not perform it or ask questions — output only the routing decision, "
+    "ending with the required JSON line.\n\n"
+    "=== USER REQUEST ===\n" + body + "\n=== END USER REQUEST ==="
+)
+'
+)"
+
+# Extract condition fields.
+eval "$(
+  PY_COND_FILE="$conditions_file" PY_COND_ID="$condition_id" python3 -c '
+import os, sys, yaml, shlex
+data = yaml.safe_load(open(os.environ["PY_COND_FILE"]))
+cond = next((c for c in data["conditions"] if c["id"] == os.environ["PY_COND_ID"]), None)
+if not cond:
+    sys.exit("ERROR: unknown condition: " + os.environ["PY_COND_ID"])
+for k in ("model", "effort", "catalog"):
+    print(f"ROUTE_{k.upper()}={shlex.quote(str(cond[k]))}")
+'
+)"
+
+# Assemble the arm system prompt (router + injected catalog) and locate it.
+arm_prompt="$("$here/build-arm-prompt.sh" "$ROUTE_CATALOG")"
+[ -f "$arm_prompt" ] || { echo "ERROR: arm prompt not built: $arm_prompt" >&2; exit 1; }
+
+# Contamination guard: the assembled prompt is a COMPLETE system-prompt
+# replacement, so it must not carry Claude Code's built-in skill listing. We
+# can't read the effective prompt back, but we CAN assert our own file is clean:
+# for the null arm there must be no "## Available skills" body, and the file must
+# not contain the harness's own meta-skill markers.
+if [ "$ROUTE_CATALOG" = "none" ]; then
+  if grep -q "^## Available skills" "$arm_prompt"; then
+    echo "ERROR: C0 (none) arm prompt unexpectedly carries a catalog body" >&2
+    exit 1
+  fi
+fi
+
+out_base="$run_dir/${task_id}.${condition_id}.run${run_n}"
+transcript="$out_base.jsonl"
+meta="$out_base.meta.json"
+stderr_log="$out_base.stderr.log"
+
+mkdir -p "$run_dir"
+
+# Assemble the claude invocation. The router is a pure classification turn.
+#   * run from a NEUTRAL cwd (a fresh temp dir) so the plugins repo's own
+#     CLAUDE.md / rules — which name many skills — do not load and contaminate
+#     the arms. Only our injected catalog is the skill vocabulary. (Measured:
+#     from-repo cwd base ~50k tokens vs neutral-cwd base ~23k; the built-in
+#     ~22k skill listing is absent under the system-prompt replacement.)
+#   * --system-prompt-file REPLACES the built-in prompt (strips the listing).
+#   * IS_SANDBOX=1 lets --dangerously-skip-permissions run as root in the
+#     sandbox (the router needs no tools; this just keeps it non-interactive).
+#   * </dev/null so the CLI never waits on stdin.
+neutral_cwd="$(mktemp -d)"
+claude_args=(
+  -p "$task_prompt"
+  --model "$ROUTE_MODEL"
+  --effort "$ROUTE_EFFORT"
+  --system-prompt-file "$arm_prompt"
+  --strict-mcp-config
+  --output-format stream-json
+  --verbose
+  --dangerously-skip-permissions
+)
+
+started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+set +e
+( cd "$neutral_cwd" && IS_SANDBOX=1 claude "${claude_args[@]}" ) >"$transcript" 2>"$stderr_log" </dev/null
+exit_code=$?
+set -e
+ended_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+rm -rf "$neutral_cwd"
+
+# Write meta sidecar.
+PY_META_OUT="$meta" \
+PY_TASK_ID="$task_id" \
+PY_COND_ID="$condition_id" \
+PY_RUN_N="$run_n" \
+PY_MODEL="$ROUTE_MODEL" \
+PY_EFFORT="$ROUTE_EFFORT" \
+PY_CATALOG="$ROUTE_CATALOG" \
+PY_STARTED="$started_at" \
+PY_ENDED="$ended_at" \
+PY_EXIT="$exit_code" \
+python3 -c '
+import json, os
+meta = {
+    "task_id": os.environ["PY_TASK_ID"],
+    "condition_id": os.environ["PY_COND_ID"],
+    "run_n": int(os.environ["PY_RUN_N"]),
+    "model": os.environ["PY_MODEL"],
+    "effort": os.environ["PY_EFFORT"],
+    "catalog": os.environ["PY_CATALOG"],
+    "started_at": os.environ["PY_STARTED"],
+    "ended_at": os.environ["PY_ENDED"],
+    "exit_code": int(os.environ["PY_EXIT"]),
+}
+json.dump(meta, open(os.environ["PY_META_OUT"], "w"), indent=2)
+'
+
+echo "[run-one] $task_id / $condition_id / run$run_n -> exit=$exit_code"
+exit "$exit_code"

--- a/experiments/skill-catalog-routing/scripts/run-suite.sh
+++ b/experiments/skill-catalog-routing/scripts/run-suite.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Run the routing suite: N runs of each (task × condition) pair.
+# Adapted from experiments/claude-probe/scripts/run-suite.sh (tasks/, not tests/).
+#
+# Usage: run-suite.sh [--filter <glob>] [--runs <n>] [--conditions <csv>] [--run-id <id>]
+# Defaults: --runs 3, all conditions, run-id = timestamp.
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "$here/.." && pwd)"
+
+runs=3
+filter="*"
+tasks_csv=""
+conditions_csv=""
+run_id=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --filter) filter="$2"; shift 2 ;;
+    --tasks) tasks_csv="$2"; shift 2 ;;
+    --runs) runs="$2"; shift 2 ;;
+    --conditions) conditions_csv="$2"; shift 2 ;;
+    --run-id) run_id="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+[ -z "$run_id" ] && run_id="$(date -u +%Y%m%d-%H%M%S)"
+run_dir="$root/results/$run_id"
+mkdir -p "$run_dir"
+
+# Resolve task files: explicit --tasks csv wins, else glob on --filter.
+task_files=()
+if [ -n "$tasks_csv" ]; then
+  IFS=',' read -ra want <<< "$tasks_csv"
+  for t in "${want[@]}"; do
+    tf="$root/tasks/${t}.yaml"
+    [ -f "$tf" ] || { echo "no such task: $t ($tf)" >&2; exit 1; }
+    task_files+=("$tf")
+  done
+else
+  mapfile -t task_files < <(find "$root/tasks" -maxdepth 1 -type f -name "${filter}.yaml" | sort)
+fi
+[ "${#task_files[@]}" -gt 0 ] || { echo "no tasks matched (filter=$filter tasks=$tasks_csv)" >&2; exit 1; }
+
+# Resolve conditions.
+if [ -n "$conditions_csv" ]; then
+  IFS=',' read -ra conditions <<< "$conditions_csv"
+else
+  mapfile -t conditions < <(
+    python3 -c '
+import yaml
+data = yaml.safe_load(open("'"$root"'/conditions.yaml"))
+for c in data["conditions"]:
+    print(c["id"])
+'
+  )
+fi
+
+echo "[run-suite] run_id=$run_id"
+echo "[run-suite] runs=$runs  conditions=${conditions[*]}"
+echo "[run-suite] tasks=${#task_files[@]}  dir=$run_dir"
+
+total=0
+failed=0
+for tf in "${task_files[@]}"; do
+  task_id="$(basename "$tf" .yaml)"
+  for cond in "${conditions[@]}"; do
+    for ((n=1; n<=runs; n++)); do
+      total=$((total+1))
+      if ! "$here/run-one.sh" "$task_id" "$cond" "$n" "$run_dir"; then
+        failed=$((failed+1))
+      fi
+    done
+  done
+done
+
+echo "[run-suite] done. $total runs, $failed failed."
+echo "[run-suite] results: $run_dir"
+printf '%s' "$run_id" > "$root/results/LATEST"

--- a/experiments/skill-catalog-routing/scripts/score-run.py
+++ b/experiments/skill-catalog-routing/scripts/score-run.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env -S uv run --script --quiet
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pyyaml>=6"]
+# ///
+"""Score one routing transcript against its task's gold label.
+
+Reads a stream-JSON transcript (from `claude -p --output-format stream-json`),
+extracts the router's decision from the LAST JSON object in the final assistant
+text (the "grade the answer, not the preamble" discipline from claude-probe),
+and grades it against the task YAML's `gold` field.
+
+Emits ONE TSV data row to stdout:
+
+    task_id  condition_id  run_n  gold  predicted  runner_up  confidence  correct  parse
+
+  * gold       — the task's correct skill id, or NONE
+  * predicted  — the router's chosen id (normalized), or NONE, or PARSE_FAIL
+  * runner_up  — the router's second choice (normalized), or NONE
+  * confidence — the router's stated confidence (or "")
+  * correct    — 1 if predicted == gold (after normalization), else 0
+  * parse      — ok | parse_fail | empty
+
+Normalization: case-insensitive; a bare `<skill>` with no plugin prefix is
+resolved against the catalog id set if unambiguous. Ids not in the catalog are
+kept verbatim (they simply won't match a gold that is in the catalog).
+
+The scorer never needs an LLM — routing is a deterministic id match.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+
+
+@lru_cache(maxsize=1)
+def catalog_ids() -> tuple[frozenset[str], dict[str, str]]:
+    """Return (full id set, bare-name -> id map for unambiguous bare names)."""
+    path = ROOT / "catalogs" / "catalog.names.json"
+    ids = set()
+    if path.exists():
+        data = json.loads(path.read_text())
+        ids = {e["id"] for e in data["entries"]}
+    bare_counts: dict[str, list[str]] = {}
+    for rid in ids:
+        bare = rid.split("/", 1)[-1]
+        bare_counts.setdefault(bare.lower(), []).append(rid)
+    bare_map = {b: v[0] for b, v in bare_counts.items() if len(v) == 1}
+    return frozenset(ids), bare_map
+
+
+def load_transcript(path: Path) -> list[dict[str, Any]]:
+    events = []
+    with path.open() as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return events
+
+
+def final_answer_text(events: list[dict[str, Any]]) -> str:
+    """Text of the final assistant turn that produced prose (claude-probe)."""
+    last = ""
+    for ev in events:
+        msg = ev.get("message") or ev
+        if msg.get("role") != "assistant":
+            continue
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        parts = [
+            b.get("text", "")
+            for b in content
+            if isinstance(b, dict) and b.get("type") == "text"
+        ]
+        joined = "\n".join(p for p in parts if p)
+        if joined.strip():
+            last = joined
+    return last
+
+
+_JSON_OBJ_RE = re.compile(r"\{[^{}]*\}")
+
+
+def parse_decision(text: str) -> dict | None:
+    """Return the LAST parseable JSON object with a `skill` key, or None."""
+    candidates = _JSON_OBJ_RE.findall(text)
+    for blob in reversed(candidates):
+        try:
+            obj = json.loads(blob)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and "skill" in obj:
+            return obj
+    return None
+
+
+def normalize(value: Any) -> str:
+    """Normalize a predicted id to a catalog id or NONE."""
+    if value is None:
+        return "NONE"
+    s = str(value).strip().strip("`'\"").strip()
+    if not s or s.upper() == "NONE":
+        return "NONE"
+    ids, bare_map = catalog_ids()
+    # exact (case-insensitive) match against catalog ids
+    for rid in ids:
+        if rid.lower() == s.lower():
+            return rid
+    # bare skill name, unambiguous
+    bare = s.split("/", 1)[-1].lower()
+    if bare in bare_map:
+        return bare_map[bare]
+    # unknown id — keep as-is (won't match an in-catalog gold)
+    return s
+
+
+def load_task(task_id: str) -> dict[str, Any]:
+    return yaml.safe_load((ROOT / "tasks" / f"{task_id}.yaml").read_text())
+
+
+def parse_name(transcript: Path) -> tuple[str, str, int]:
+    """(task_id, condition_id, run_n) from '<task>.<condition>.run<N>.jsonl'."""
+    stem = transcript.name[: -len(".jsonl")]
+    m = re.match(r"^(?P<task>.+)\.(?P<cond>[^.]+)\.run(?P<n>\d+)$", stem)
+    if not m:
+        raise ValueError(f"cannot parse transcript name: {transcript.name}")
+    return m["task"], m["cond"], int(m["n"])
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("transcript")
+    args = ap.parse_args()
+
+    transcript = Path(args.transcript)
+    task_id, cond_id, run_n = parse_name(transcript)
+    task = load_task(task_id)
+    gold = normalize(task.get("gold"))
+
+    events = load_transcript(transcript)
+    text = final_answer_text(events)
+    decision = parse_decision(text)
+
+    if not text.strip():
+        parse = "empty"
+        predicted, runner_up, conf = "PARSE_FAIL", "NONE", ""
+    elif decision is None:
+        parse = "parse_fail"
+        predicted, runner_up, conf = "PARSE_FAIL", "NONE", ""
+    else:
+        parse = "ok"
+        predicted = normalize(decision.get("skill"))
+        runner_up = normalize(decision.get("runner_up"))
+        conf = str(decision.get("confidence", ""))
+
+    correct = 1 if (parse == "ok" and predicted == gold) else 0
+    row = [task_id, cond_id, str(run_n), gold, predicted, runner_up, conf, str(correct), parse]
+    print("\t".join(row))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/skill-catalog-routing/tasks/n01.yaml
+++ b/experiments/skill-catalog-routing/tasks/n01.yaml
@@ -1,0 +1,9 @@
+description: Pair 1 git-commit vs git-commit-push-pr — "local only, not sending anywhere remote" makes local commit correct, not the end-to-end PR flow.
+prompt: |
+  I've finished this change and want to record it in my local history with a
+  proper conventional message and an issue reference. I'm not ready to send it
+  anywhere remote yet — just capture the snapshot here on my machine.
+gold: git-plugin/git-commit
+near_miss: git-plugin/git-commit-push-pr
+plugin: git-plugin
+pair: 1

--- a/experiments/skill-catalog-routing/tasks/n02.yaml
+++ b/experiments/skill-catalog-routing/tasks/n02.yaml
@@ -1,0 +1,9 @@
+description: Pair 1 git-commit-push-pr vs git-commit — "take it all the way to an open pull request in one go" is the end-to-end flow, not a local-only save.
+prompt: |
+  My working tree has uncommitted changes and I want to take them all the way to
+  an open pull request in one go — get them recorded, sent up to the remote
+  branch, and a PR opened against main without me driving each step by hand.
+gold: git-plugin/git-commit-push-pr
+near_miss: git-plugin/git-commit
+plugin: git-plugin
+pair: 1

--- a/experiments/skill-catalog-routing/tasks/n03.yaml
+++ b/experiments/skill-catalog-routing/tasks/n03.yaml
@@ -1,0 +1,9 @@
+description: Pair 2 test-quick vs test-full — "just the fast unit-level checks, skip slow integration/browser, sub-minute feedback" points at the fast subset, not the whole suite.
+prompt: |
+  Before I record this change I just want the fast unit-level checks to run —
+  skip the slow integration and browser stuff. I only touched a couple of
+  modules and I need sub-minute feedback on whether I broke anything.
+gold: testing-plugin/test-quick
+near_miss: testing-plugin/test-full
+plugin: testing-plugin
+pair: 2

--- a/experiments/skill-catalog-routing/tasks/n04.yaml
+++ b/experiments/skill-catalog-routing/tasks/n04.yaml
@@ -1,0 +1,9 @@
+description: Pair 2 test-full vs test-quick — "entire suite end to end incl. browser-driven cases plus coverage before a release PR" is the complete suite, not the fast subset.
+prompt: |
+  I'm about to open a release pull request and want the entire suite exercised
+  end to end — the unit level, the integration level, and the browser-driven
+  cases — plus a coverage report. Take as long as it needs; I want everything.
+gold: testing-plugin/test-full
+near_miss: testing-plugin/test-quick
+plugin: testing-plugin
+pair: 2

--- a/experiments/skill-catalog-routing/tasks/n05.yaml
+++ b/experiments/skill-catalog-routing/tasks/n05.yaml
@@ -1,0 +1,9 @@
+description: Pair 3 fd-file-finding vs rg-code-search — "locate files whose name matches, I want the paths not what's inside" is name-based file location, not in-file text search.
+prompt: |
+  I need to locate every file whose name matches a certain pattern across these
+  directories — say all the ones ending in a given extension. I want the list of
+  paths back, not anything about the contents inside them.
+gold: tools-plugin/fd-file-finding
+near_miss: tools-plugin/rg-code-search
+plugin: tools-plugin
+pair: 3

--- a/experiments/skill-catalog-routing/tasks/n06.yaml
+++ b/experiments/skill-catalog-routing/tasks/n06.yaml
@@ -1,0 +1,9 @@
+description: Pair 3 rg-code-search vs fd-file-finding — "every place in the source a function is called, the matching lines" is text-inside-files, not locating files by name.
+prompt: |
+  I'm trying to track down every place in the source where a particular function
+  is invoked. I need the actual matching lines and their locations inside the
+  files, with regex support so I can match a few call variants at once.
+gold: tools-plugin/rg-code-search
+near_miss: tools-plugin/fd-file-finding
+plugin: tools-plugin
+pair: 3

--- a/experiments/skill-catalog-routing/tasks/n07.yaml
+++ b/experiments/skill-catalog-routing/tasks/n07.yaml
@@ -1,0 +1,9 @@
+description: Pair 4 ruff-linting vs ruff-formatting — "catch likely bugs and rule violations, auto-fix them, not reflowing whitespace" is the checker, not the reformatter.
+prompt: |
+  My Python code needs a quality pass — I want to catch likely bugs, unused
+  imports, and violations of our chosen rule set, and auto-fix the ones that can
+  be. I'm not trying to reflow whitespace, just enforce the correctness rules.
+gold: python-plugin/ruff-linting
+near_miss: python-plugin/ruff-formatting
+plugin: python-plugin
+pair: 4

--- a/experiments/skill-catalog-routing/tasks/n08.yaml
+++ b/experiments/skill-catalog-routing/tasks/n08.yaml
@@ -1,0 +1,9 @@
+description: Pair 4 ruff-formatting vs ruff-linting — "reflow to consistent style, normalize indentation/spacing, not detecting bugs" is the reformatter, not the checker.
+prompt: |
+  I want my Python files reflowed to a consistent house style — indentation,
+  line length, and spacing normalized automatically so the layout is uniform.
+  I'm not looking to detect bugs or flag rule violations, just fix the shape.
+gold: python-plugin/ruff-formatting
+near_miss: python-plugin/ruff-linting
+plugin: python-plugin
+pair: 4

--- a/experiments/skill-catalog-routing/tasks/n09.yaml
+++ b/experiments/skill-catalog-routing/tasks/n09.yaml
@@ -1,0 +1,9 @@
+description: Pair 5 helm-release-recovery vs helm-release-management — "upgrade stuck in pending, wedged, roll it back to the previous revision, unstick it" is the failure-recovery path, not routine management.
+prompt: |
+  Our last chart upgrade to the cluster got stuck in a pending state and never
+  finished — the deployment is wedged and now nothing will apply. I need to roll
+  it back to the last working revision and get it out of the stuck condition.
+gold: kubernetes-plugin/helm-release-recovery
+near_miss: kubernetes-plugin/helm-release-management
+plugin: kubernetes-plugin
+pair: 5

--- a/experiments/skill-catalog-routing/tasks/n10.yaml
+++ b/experiments/skill-catalog-routing/tasks/n10.yaml
@@ -1,0 +1,9 @@
+description: Pair 5 helm-release-management vs helm-release-recovery — "deploy a new version, list what's installed, review revision history, everything healthy/routine" is normal lifecycle, not fixing a failure.
+prompt: |
+  I want to deploy a new version of our chart to the cluster and, while I'm at
+  it, list what's currently installed and review the revision history. Nothing's
+  broken — everything is healthy, this is just routine day-to-day upkeep.
+gold: kubernetes-plugin/helm-release-management
+near_miss: kubernetes-plugin/helm-release-recovery
+plugin: kubernetes-plugin
+pair: 5

--- a/experiments/skill-catalog-routing/tasks/n11.yaml
+++ b/experiments/skill-catalog-routing/tasks/n11.yaml
@@ -1,0 +1,9 @@
+description: Pair 6 macos-performance-triage vs macos-performance-benchmark — "fans roaring right now, find which process is driving the heat this instant" is live attribution, not a repeatable scored baseline.
+prompt: |
+  My Mac's fans are roaring right at this moment and it feels sluggish —
+  something is pegging the CPU or GPU this very instant. Help me figure out
+  which running process is driving the heat so I can quiet it down now.
+gold: macos-plugin/macos-performance-triage
+near_miss: macos-plugin/macos-performance-benchmark
+plugin: macos-plugin
+pair: 6

--- a/experiments/skill-catalog-routing/tasks/n12.yaml
+++ b/experiments/skill-catalog-routing/tasks/n12.yaml
@@ -1,0 +1,9 @@
+description: Pair 6 macos-performance-benchmark vs macos-performance-triage — "establish a baseline, repeatable scored run I can save and compare over time" is the scored/report path, not live triage.
+prompt: |
+  I want to establish a baseline for this Mac and verify it runs to spec — a
+  repeatable scored pass I can save and compare against later to track its CPU,
+  memory, disk, and thermal health over successive weeks.
+gold: macos-plugin/macos-performance-benchmark
+near_miss: macos-plugin/macos-performance-triage
+plugin: macos-plugin
+pair: 6

--- a/experiments/skill-catalog-routing/tasks/n13.yaml
+++ b/experiments/skill-catalog-routing/tasks/n13.yaml
@@ -1,0 +1,9 @@
+description: Pair 7 finops-caches vs finops-waste — "Actions storage ballooning, saved build artifacts keyed per branch are stale/bloated, breakdown of what's taking space" is the storage-size analysis, not run-frequency waste.
+prompt: |
+  Our GitHub Actions storage keeps ballooning and I suspect the saved build
+  artifacts keyed per branch are stale and bloated. I want a breakdown of what's
+  eating the space, split by prefix and branch, and which entries are old.
+gold: finops-plugin/finops-caches
+near_miss: finops-plugin/finops-waste
+plugin: finops-plugin
+pair: 7

--- a/experiments/skill-catalog-routing/tasks/n14.yaml
+++ b/experiments/skill-catalog-routing/tasks/n14.yaml
@@ -1,0 +1,9 @@
+description: Pair 7 finops-waste vs finops-caches — "workflows fire too often, redundant skipped runs, bot-triggered builds, jobs that don't cancel superseded runs" is the run-frequency inefficiency, not storage size.
+prompt: |
+  Our CI bill is high because workflows fire way too often — lots of redundant
+  runs that end up skipped, builds kicked off by bots, and jobs that never cancel
+  a superseded run. I want those inefficiencies pinpointed with fixes suggested.
+gold: finops-plugin/finops-waste
+near_miss: finops-plugin/finops-caches
+plugin: finops-plugin
+pair: 7

--- a/experiments/skill-catalog-routing/tasks/n15.yaml
+++ b/experiments/skill-catalog-routing/tasks/n15.yaml
@@ -1,0 +1,9 @@
+description: Pair 8 tfc-run-status vs tfc-run-logs — "where does it stand, did it pass, how many resources will it add/change, ready to apply or cancel" is the status/counts view, not the detailed output logs.
+prompt: |
+  I've got a Terraform Cloud run in progress and I just want to know where it
+  stands — did it pass, how many resources will it add or change, and is it ready
+  to be applied or should I cancel it? Just the summary state, not the details.
+gold: terraform-plugin/tfc-run-status
+near_miss: terraform-plugin/tfc-run-logs
+plugin: terraform-plugin
+pair: 8

--- a/experiments/skill-catalog-routing/tasks/n16.yaml
+++ b/experiments/skill-catalog-routing/tasks/n16.yaml
@@ -1,0 +1,9 @@
+description: Pair 8 tfc-run-logs vs tfc-run-status — "apply failed, dig into the detailed plan and apply output, the full transcript to debug" is the log-retrieval path, not the pass/fail status.
+prompt: |
+  My Terraform Cloud apply just failed and I need to dig into the detailed plan
+  and apply output to figure out what went wrong — the full run transcript, line
+  by line, so I can debug the error. A pass/fail summary won't help me here.
+gold: terraform-plugin/tfc-run-logs
+near_miss: terraform-plugin/tfc-run-status
+plugin: terraform-plugin
+pair: 8

--- a/experiments/skill-catalog-routing/tasks/n17.yaml
+++ b/experiments/skill-catalog-routing/tasks/n17.yaml
@@ -1,0 +1,9 @@
+description: Pair 9 search-discovery vs tasks — "notes with no incoming links, broken wikilinks, trace backlinks, map how things connect" is vault link/text exploration, not managing to-do items.
+prompt: |
+  In my Obsidian vault I want to find notes that nothing links to, audit the
+  broken wikilinks, and trace the backlinks between notes so I can see how
+  everything connects and what's dangling out on its own.
+gold: obsidian-plugin/search-discovery
+near_miss: obsidian-plugin/tasks
+plugin: obsidian-plugin
+pair: 9

--- a/experiments/skill-catalog-routing/tasks/n18.yaml
+++ b/experiments/skill-catalog-routing/tasks/n18.yaml
@@ -1,0 +1,9 @@
+description: Pair 9 tasks vs search-discovery — "see all open to-do checkboxes, add new ones, mark finished items done" is to-do item management, not link/text exploration.
+prompt: |
+  In my Obsidian vault I want to pull up all my open to-do checkboxes, add a
+  couple of new ones for this week, and tick off the items I've already
+  finished. Basically manage my checklist items across the notes.
+gold: obsidian-plugin/tasks
+near_miss: obsidian-plugin/search-discovery
+plugin: obsidian-plugin
+pair: 9

--- a/experiments/skill-catalog-routing/tasks/n19.yaml
+++ b/experiments/skill-catalog-routing/tasks/n19.yaml
@@ -1,0 +1,9 @@
+description: Pair 10 code-dead-code vs code-dep-audit — "exports nothing imports, unreachable branches, files no longer referenced" is the unused-code detector, not the dependency/vulnerability auditor.
+prompt: |
+  After a big refactor I want to find exports that nothing imports anymore,
+  branches that can never be reached, and files no longer referenced anywhere in
+  the project, so I can strip out the cruft and shrink maintenance burden.
+gold: code-quality-plugin/code-dead-code
+near_miss: code-quality-plugin/code-dep-audit
+plugin: code-quality-plugin
+pair: 10

--- a/experiments/skill-catalog-routing/tasks/n20.yaml
+++ b/experiments/skill-catalog-routing/tasks/n20.yaml
@@ -1,0 +1,9 @@
+description: Pair 10 code-dep-audit vs code-dead-code — "third-party packages for known vulnerabilities, which are outdated, license compliance" is the supply-chain dependency auditor, not unused-code detection.
+prompt: |
+  Before this release I need to vet our third-party packages for known security
+  vulnerabilities, flag which ones are outdated and need bumping, and confirm
+  their licenses are all compliant with our policy.
+gold: code-quality-plugin/code-dep-audit
+near_miss: code-quality-plugin/code-dead-code
+plugin: code-quality-plugin
+pair: 10

--- a/experiments/skill-catalog-routing/tasks/r01.yaml
+++ b/experiments/skill-catalog-routing/tasks/r01.yaml
@@ -1,0 +1,7 @@
+description: Stale-merged-branch cleanup with dry-run preview + protection for main/develop; unambiguous vs git-maintain (broad gc/repack).
+prompt: |
+  My local repo has piled up dozens of old feature lines that were merged into main ages ago. I'd like a safe, interactive way to preview which ones are truly gone and remove them, while it refuses to ever touch main or develop.
+gold: git-plugin/deadbranch
+plugin: git-plugin
+name_transparency: opaque
+length_band: mid

--- a/experiments/skill-catalog-routing/tasks/r02.yaml
+++ b/experiments/skill-catalog-routing/tasks/r02.yaml
@@ -1,0 +1,7 @@
+description: A configured shortcut does nothing inside a terminal app; points to terminal-interception/chord debugging, not general config.
+prompt: |
+  I mapped a key combination in my terminal-based editor, but pressing it does absolutely nothing — yet the same combo works fine in other apps. I need to figure out whether the terminal itself is eating the keystroke or the chord is impossible to send.
+gold: macos-plugin/tui-keybinding-debug
+plugin: macos-plugin
+name_transparency: opaque
+length_band: mid

--- a/experiments/skill-catalog-routing/tasks/r03.yaml
+++ b/experiments/skill-catalog-routing/tasks/r03.yaml
@@ -1,0 +1,7 @@
+description: Sweep a subnet for live hosts + open ports + service versions (nmap). Distinct from ARP layer2 or bandwidth monitoring.
+prompt: |
+  I want to sweep my office subnet to see which machines are actually up, and for each one enumerate the open TCP ports plus the running services and their versions.
+gold: networking-plugin/network-discovery
+plugin: networking-plugin
+name_transparency: transparent
+length_band: short

--- a/experiments/skill-catalog-routing/tasks/r04.yaml
+++ b/experiments/skill-catalog-routing/tasks/r04.yaml
@@ -1,0 +1,7 @@
+description: Batch resize + reformat many photos into thumbnails. Distinct from pixel diffing or AI image generation.
+prompt: |
+  I have a couple hundred pictures in a mix of formats and I need to shrink them all into small thumbnails and reformat them into one consistent output format in a single pass.
+gold: tools-plugin/imagemagick-conversion
+plugin: tools-plugin
+name_transparency: opaque
+length_band: short

--- a/experiments/skill-catalog-routing/tasks/r05.yaml
+++ b/experiments/skill-catalog-routing/tasks/r05.yaml
@@ -1,0 +1,7 @@
+description: Chart deploy stuck in pending-upgrade, needs rollback to a working revision. Distinct from ordinary install/upgrade management.
+prompt: |
+  My Kubernetes chart deploy got wedged partway through and is now frozen in a pending-upgrade state, so every new attempt is refused. I need to get it back to the last good revision and unstick it.
+gold: kubernetes-plugin/helm-release-recovery
+plugin: kubernetes-plugin
+name_transparency: transparent
+length_band: mid

--- a/experiments/skill-catalog-routing/tasks/r06.yaml
+++ b/experiments/skill-catalog-routing/tasks/r06.yaml
@@ -1,0 +1,7 @@
+description: Smart-home YAML won't start; suspect syntax error / undefined secret / duplicate key. Distinct from general config editing.
+prompt: |
+  After I edited my smart-home YAML files the whole system refuses to start up. I suspect there's a syntax mistake, a duplicate key, or a secret I referenced that was never defined, and I want to pinpoint it before restarting.
+gold: home-assistant-plugin/ha-validate
+plugin: home-assistant-plugin
+name_transparency: transparent
+length_band: mid

--- a/experiments/skill-catalog-routing/tasks/r07.yaml
+++ b/experiments/skill-catalog-routing/tasks/r07.yaml
@@ -1,0 +1,7 @@
+description: Recover an earlier version of an Obsidian note after an accidental overwrite. Distinct from publish/sync recovery.
+prompt: |
+  I accidentally clobbered a big section of text in one of my notes yesterday and saved over it. I want to look at earlier saved versions of that note and roll it back to how it was.
+gold: obsidian-plugin/file-history
+plugin: obsidian-plugin
+name_transparency: transparent
+length_band: short

--- a/experiments/skill-catalog-routing/tasks/r08.yaml
+++ b/experiments/skill-catalog-routing/tasks/r08.yaml
@@ -1,0 +1,7 @@
+description: Find + remove unused Rust dependencies to speed builds. Distinct from Rust test running or coverage.
+prompt: |
+  My Rust project's dependency manifest has almost certainly collected crates that nothing imports anymore, and it's dragging out build times. I want to detect the ones that are genuinely unused and drop them.
+gold: rust-plugin/cargo-machete
+plugin: rust-plugin
+name_transparency: opaque
+length_band: short

--- a/experiments/skill-catalog-routing/tasks/r09.yaml
+++ b/experiments/skill-catalog-routing/tasks/r09.yaml
@@ -1,0 +1,7 @@
+description: Build a wheel + publish a finished Python library to PyPI. Distinct from project/dependency setup.
+prompt: |
+  My Python library is finally done and I want to turn it into a distributable wheel and push it up to PyPI so other people can install it.
+gold: python-plugin/python-packaging
+plugin: python-plugin
+name_transparency: transparent
+length_band: short

--- a/experiments/skill-catalog-routing/tasks/r10.yaml
+++ b/experiments/skill-catalog-routing/tasks/r10.yaml
@@ -1,0 +1,7 @@
+description: Retrieve the raw plan/apply console output of a failed Terraform Cloud run to debug. Distinct from run status/counts or listing runs.
+prompt: |
+  A Terraform Cloud apply just failed and I need to pull the full raw console output from that run — the actual error trace as it happened — so I can see exactly where it blew up.
+gold: terraform-plugin/tfc-run-logs
+plugin: terraform-plugin
+name_transparency: opaque
+length_band: mid

--- a/experiments/skill-catalog-routing/tasks/r11.yaml
+++ b/experiments/skill-catalog-routing/tasks/r11.yaml
@@ -1,0 +1,7 @@
+description: Figure out what prompt/settings produced an AI-generated PNG from embedded output metadata. Distinct from mid-graph value inspection.
+prompt: |
+  I have an AI-generated PNG sitting in my outputs folder and I can't remember how I made it. I want to pull out whatever prompt and generation settings are embedded in the file so I can reproduce or compare it.
+gold: comfyui-plugin/comfy-metadata
+plugin: comfyui-plugin
+name_transparency: opaque
+length_band: mid

--- a/experiments/skill-catalog-routing/tasks/r12.yaml
+++ b/experiments/skill-catalog-routing/tasks/r12.yaml
@@ -1,0 +1,7 @@
+description: Condense wordy text down to its essence. Distinct from turning scattered notes into a structured plan.
+prompt: |
+  This paragraph I wrote is bloated and repetitive. Help me tighten it right down to its core meaning, cutting every needless word while keeping the substance intact.
+gold: prose-plugin/prose-distill
+plugin: prose-plugin
+name_transparency: transparent
+length_band: short

--- a/experiments/skill-catalog-routing/tasks/r13.yaml
+++ b/experiments/skill-catalog-routing/tasks/r13.yaml
@@ -1,0 +1,7 @@
+description: Measure test-suite strength by deliberately breaking code and seeing if tests notice. Distinct from smell/flaky quality analysis.
+prompt: |
+  My suite is all green but I don't trust that it would actually catch a real regression. I want to gauge how strong the checks really are by deliberately introducing small faults into the code and seeing whether any check fails.
+gold: testing-plugin/mutation-testing
+plugin: testing-plugin
+name_transparency: transparent
+length_band: short

--- a/experiments/skill-catalog-routing/tasks/r14.yaml
+++ b/experiments/skill-catalog-routing/tasks/r14.yaml
@@ -1,0 +1,7 @@
+description: Make a web component usable by screen-reader/keyboard users and meet WCAG (ARIA, focus). Distinct from theming/design-tokens.
+prompt: |
+  An audit flagged that my custom dropdown component can't be operated by screen-reader or keyboard-only users and doesn't meet the web compliance standards. I need to fix the ARIA roles and focus handling so it passes.
+gold: accessibility-plugin/accessibility-implementation
+plugin: accessibility-plugin
+name_transparency: transparent
+length_band: mid

--- a/experiments/skill-catalog-routing/tasks/r15.yaml
+++ b/experiments/skill-catalog-routing/tasks/r15.yaml
@@ -1,0 +1,7 @@
+description: Shrink an oversized Docker image for a compiled Go service via scratch/distroless + static binary. Distinct from Node/Python image optimization.
+prompt: |
+  My compiled Go service builds into an enormous Docker image — hundreds of megabytes. I want to slim it down dramatically using a minimal base and a static binary so it ends up tiny.
+gold: container-plugin/go-containers
+plugin: container-plugin
+name_transparency: transparent
+length_band: mid

--- a/experiments/skill-catalog-routing/tasks/r16.yaml
+++ b/experiments/skill-catalog-routing/tasks/r16.yaml
@@ -1,0 +1,7 @@
+description: Resolve a stalled merge/rebase where both branches changed the same lines. Distinct from rebase history-cleanup patterns.
+prompt: |
+  My merge halted partway through and several files are now marked because both sides changed the same lines. I need to work through them one by one and settle which version wins in each spot.
+gold: git-plugin/git-conflicts
+plugin: git-plugin
+name_transparency: transparent
+length_band: short

--- a/experiments/skill-catalog-routing/tasks/r17.yaml
+++ b/experiments/skill-catalog-routing/tasks/r17.yaml
@@ -1,0 +1,7 @@
+description: Sweep local tracker entries still open even though their linked GitHub issues/PRs closed or merged. Distinct from read-only queue reports.
+prompt: |
+  A bunch of entries in my local to-do tracker are still showing as open, but the GitHub issues and pull requests they point to have already merged or been closed. I want to sweep those out and mark them finished.
+gold: taskwarrior-plugin/task-reconcile
+plugin: taskwarrior-plugin
+name_transparency: opaque
+length_band: mid

--- a/experiments/skill-catalog-routing/tasks/r18.yaml
+++ b/experiments/skill-catalog-routing/tasks/r18.yaml
@@ -1,0 +1,7 @@
+description: Stop needless conflicts on append-only files via union-merge, flag generated output. Distinct from ignore-file setup.
+prompt: |
+  Whenever two branches both add lines to the same append-only changelog table we get pointless merge clashes. I want git to auto-union those append-only files, and I also want generated build output marked so it stops cluttering diffs.
+gold: configure-plugin/configure-gitattributes
+plugin: configure-plugin
+name_transparency: opaque
+length_band: mid

--- a/experiments/skill-catalog-routing/tasks/r19.yaml
+++ b/experiments/skill-catalog-routing/tasks/r19.yaml
@@ -1,0 +1,7 @@
+description: Turn Markdown into a typeset, print-ready PDF with diagrams. Distinct from API doc generation or plain diagram rendering.
+prompt: |
+  I've got a Markdown write-up and I want to turn it into a really polished, print-ready PDF — proper typesetting, page layout, and a few embedded technical diagrams.
+gold: documentation-plugin/docs-latex
+plugin: documentation-plugin
+name_transparency: opaque
+length_band: short

--- a/experiments/skill-catalog-routing/tasks/r20.yaml
+++ b/experiments/skill-catalog-routing/tasks/r20.yaml
@@ -1,0 +1,7 @@
+description: Flag wasteful CI — bot-triggered runs, missing concurrency, skipped runs — with fixes. Distinct from run-duration analysis or billing overview.
+prompt: |
+  Our GitHub Actions bill keeps climbing and I think a lot of it is runs that never needed to happen — bot-triggered rebuilds, jobs with no concurrency cancellation, redundant runs on every push. I want those pinpointed with concrete fixes.
+gold: finops-plugin/finops-waste
+plugin: finops-plugin
+name_transparency: opaque
+length_band: short

--- a/experiments/skill-catalog-routing/tasks/r21.yaml
+++ b/experiments/skill-catalog-routing/tasks/r21.yaml
@@ -1,0 +1,7 @@
+description: Scan for swallowed errors + silent degradation (empty catch, piped-to-null, success on zero results). Distinct from generic antipattern scan.
+prompt: |
+  I'm worried our codebase quietly eats errors — empty catch blocks, things routed to /dev/null, functions that report success even when they actually produced nothing. I want all those silent-swallow spots surfaced.
+gold: code-quality-plugin/code-hidden-failures
+plugin: code-quality-plugin
+name_transparency: transparent
+length_band: mid

--- a/experiments/skill-catalog-routing/tasks/r22.yaml
+++ b/experiments/skill-catalog-routing/tasks/r22.yaml
@@ -1,0 +1,7 @@
+description: Flatten a merge-heavy branch into linear history and manage a stack of dependent PRs. Distinct from resolving active conflicts.
+prompt: |
+  My feature branch is a tangle of merge commits and I want to flatten it into clean linear history. On top of that I'm juggling a stack of dependent pull requests that all need their bases kept in order.
+gold: git-plugin/git-rebase-patterns
+plugin: git-plugin
+name_transparency: transparent
+length_band: mid

--- a/experiments/skill-catalog-routing/tasks/r23.yaml
+++ b/experiments/skill-catalog-routing/tasks/r23.yaml
@@ -1,0 +1,7 @@
+description: Turn on the tightest type-safety flags in tsconfig and sort module resolution. Distinct from lint/format tooling or debugging.
+prompt: |
+  I want to crank my tsconfig up to the tightest possible type-safety settings and sort out the module-resolution flags to match a modern bundler setup. Expect the compiler to start complaining and I want to migrate cleanly.
+gold: typescript-plugin/typescript-strict
+plugin: typescript-plugin
+name_transparency: transparent
+length_band: short

--- a/experiments/skill-catalog-routing/tasks/r24.yaml
+++ b/experiments/skill-catalog-routing/tasks/r24.yaml
@@ -1,0 +1,7 @@
+description: Starting a 2D interactive graphics app in Rust with ECS — wiring entities, rendering, input, assets. Distinct from advanced ECS perf tuning.
+prompt: |
+  I'm just starting a 2D real-time interactive graphics application in Rust built around an entity-component-system, and I need help wiring up the basics — spawning entities, the rendering pipeline, reading player input, and loading assets.
+gold: bevy-plugin/bevy-game-engine
+plugin: bevy-plugin
+name_transparency: transparent
+length_band: mid

--- a/experiments/skill-catalog-routing/tasks/r25.yaml
+++ b/experiments/skill-catalog-routing/tasks/r25.yaml
@@ -1,0 +1,7 @@
+description: Build an AI workflow as a stateful graph/state-machine with checkpoints + human-in-the-loop + streaming. Distinct from generic LLM chains or orchestrator agents.
+prompt: |
+  I'm building an AI assistant modeled as a state machine — it should support checkpoints so it can pause and resume, allow a human approval step midway, and stream its progress as it moves between states.
+gold: langchain-plugin/langgraph-agents
+plugin: langchain-plugin
+name_transparency: opaque
+length_band: mid

--- a/experiments/skill-catalog-routing/tasks/r26.yaml
+++ b/experiments/skill-catalog-routing/tasks/r26.yaml
@@ -1,0 +1,7 @@
+description: On-demand atomic utility CSS classes generated only for what's used, with icon/typography presets, wired into Vite. Distinct from CSS transpile/minify.
+prompt: |
+  I want a utility-first styling setup where the atomic classes are generated on demand — only for the ones I actually use — with presets for icons and typography, all hooked into my Vite build.
+gold: css-plugin/unocss
+plugin: css-plugin
+name_transparency: opaque
+length_band: short

--- a/experiments/skill-catalog-routing/tasks/r27.yaml
+++ b/experiments/skill-catalog-routing/tasks/r27.yaml
@@ -1,0 +1,7 @@
+description: Write automated checks that hit REST endpoints and assert on HTTP responses (Supertest/httpx). Distinct from contract testing (Pact/OpenAPI).
+prompt: |
+  I need to write automated checks that fire real requests at my REST endpoints and assert on the HTTP responses — status codes, bodies, error cases — for both a TypeScript service and a Python one.
+gold: api-plugin/api-testing
+plugin: api-plugin
+name_transparency: transparent
+length_band: short

--- a/experiments/skill-catalog-routing/tasks/r28.yaml
+++ b/experiments/skill-catalog-routing/tasks/r28.yaml
@@ -1,0 +1,7 @@
+description: Get untested old code safely under characterization tests before changing it. Distinct from contracts/patterns/pseudocode design skills.
+prompt: |
+  I have to modify a big chunk of old, untested code and I'm nervous about breaking behavior I don't fully understand. I want to pin its current behavior down with tests first — finding the right places to insert them — before I touch anything.
+gold: software-design-plugin/design-legacy-seams
+plugin: software-design-plugin
+name_transparency: opaque
+length_band: mid

--- a/experiments/skill-catalog-routing/tasks/r29.yaml
+++ b/experiments/skill-catalog-routing/tasks/r29.yaml
@@ -1,0 +1,7 @@
+description: Safe DB transition by sending data to both old and new store during cutover. Distinct from shadow/dark-launch traffic mirroring.
+prompt: |
+  We're moving data from our old database to a new store and I want a safe transition where, during cutover, every change lands in both systems simultaneously so they stay in sync until we fully switch over.
+gold: migration-patterns-plugin/dual-write
+plugin: migration-patterns-plugin
+name_transparency: opaque
+length_band: short

--- a/experiments/skill-catalog-routing/tasks/r30.yaml
+++ b/experiments/skill-catalog-routing/tasks/r30.yaml
@@ -1,0 +1,7 @@
+description: Give the user a live control for a perceptual param (timing/color) the agent can't judge itself, instead of guessing a constant. Distinct from other agent patterns.
+prompt: |
+  I'm fiddling with the timing and color of a UI animation, but honestly I can't tell from the code what looks right — that's a judgment only a person watching it can make. Rather than me guessing a magic number, I'd like to hand the user a live control they can nudge until it feels right.
+gold: agent-patterns-plugin/expose-tunable-knob
+plugin: agent-patterns-plugin
+name_transparency: opaque
+length_band: mid

--- a/experiments/skill-catalog-routing/tasks/z01.yaml
+++ b/experiments/skill-catalog-routing/tasks/z01.yaml
@@ -1,0 +1,7 @@
+description: Pure high-level architecture opinion; no catalog skill gives monolith-vs-microservices advice (software-design skills are code-level GoF/contract patterns).
+prompt: |
+  We're a startup with three engineers building an MVP. Should we go with a
+  monolith or microservices to start? I'm not asking you to write anything —
+  I just want your honest take on the tradeoffs given our size.
+gold: NONE
+kind: plain

--- a/experiments/skill-catalog-routing/tasks/z02.yaml
+++ b/experiments/skill-catalog-routing/tasks/z02.yaml
@@ -1,0 +1,6 @@
+description: Variable-naming advice is ordinary conversation; no catalog skill names identifiers (code-quality skills analyze/refactor, they don't suggest names).
+prompt: |
+  I've got a boolean that tracks whether the user has already dismissed the
+  cookie consent banner. What's a clear, readable name for it?
+gold: NONE
+kind: plain

--- a/experiments/skill-catalog-routing/tasks/z03.yaml
+++ b/experiments/skill-catalog-routing/tasks/z03.yaml
@@ -1,0 +1,6 @@
+description: Plain science explanation for a child's question; no catalog skill covers general-knowledge teaching.
+prompt: |
+  My daughter asked me why the sky is blue and I completely blanked. Can you
+  explain it simply enough that I could repeat it back to a six-year-old?
+gold: NONE
+kind: plain

--- a/experiments/skill-catalog-routing/tasks/z04.yaml
+++ b/experiments/skill-catalog-routing/tasks/z04.yaml
@@ -1,0 +1,6 @@
+description: Cooking suggestion from pantry items; no cooking/recipe skill exists in the catalog.
+prompt: |
+  I've got chicken thighs, a bag of spinach, and a can of coconut milk in the
+  fridge. What could I make for dinner tonight without a shop run?
+gold: NONE
+kind: plain

--- a/experiments/skill-catalog-routing/tasks/z05.yaml
+++ b/experiments/skill-catalog-routing/tasks/z05.yaml
@@ -1,0 +1,6 @@
+description: Travel itinerary planning; no travel skill in the catalog.
+prompt: |
+  We'll have four days in Lisbon in early October. Could you sketch a relaxed
+  itinerary that isn't too rushed and leaves room for good food?
+gold: NONE
+kind: plain

--- a/experiments/skill-catalog-routing/tasks/z06.yaml
+++ b/experiments/skill-catalog-routing/tasks/z06.yaml
@@ -1,0 +1,6 @@
+description: Creative poetry request; prose skills condense/organize existing text and blog skills write posts — none writes a birthday poem.
+prompt: |
+  Could you write me a short, warm birthday poem for my mum? She's turning 70
+  and she's happiest out in her garden.
+gold: NONE
+kind: plain

--- a/experiments/skill-catalog-routing/tasks/z07.yaml
+++ b/experiments/skill-catalog-routing/tasks/z07.yaml
@@ -1,0 +1,6 @@
+description: Personal tax question; no legal/tax/finance-advice skill in the catalog (finops is GitHub Actions CI cost).
+prompt: |
+  If I do a bit of freelance design on the side while staying employed
+  full-time here in Finland, roughly how does that change my tax situation?
+gold: NONE
+kind: plain

--- a/experiments/skill-catalog-routing/tasks/z08.yaml
+++ b/experiments/skill-catalog-routing/tasks/z08.yaml
@@ -1,0 +1,6 @@
+description: Personal productivity / motivation advice; no catalog skill addresses procrastination.
+prompt: |
+  I've been putting off a big quarterly report for two weeks now and the
+  deadline is creeping up. Any advice on how to actually get myself started?
+gold: NONE
+kind: plain

--- a/experiments/skill-catalog-routing/tasks/z09.yaml
+++ b/experiments/skill-catalog-routing/tasks/z09.yaml
@@ -1,0 +1,6 @@
+description: Natural-language translation; no translation skill in the catalog.
+prompt: |
+  How do you say "where is the nearest pharmacy?" in Portuguese? Travelling
+  next week and want to have a few phrases ready.
+gold: NONE
+kind: plain

--- a/experiments/skill-catalog-routing/tasks/z10.yaml
+++ b/experiments/skill-catalog-routing/tasks/z10.yaml
@@ -1,0 +1,6 @@
+description: General cultural/trivia opinion; no catalog skill covers music history.
+prompt: |
+  Who would you say were the most influential jazz musicians of the 20th
+  century, and what made each of them matter?
+gold: NONE
+kind: plain

--- a/experiments/skill-catalog-routing/tasks/z11.yaml
+++ b/experiments/skill-catalog-routing/tasks/z11.yaml
@@ -1,0 +1,6 @@
+description: Consumer hardware buying advice; no purchasing-advice skill (macos skills diagnose an existing Mac, they don't recommend purchases).
+prompt: |
+  I'm shopping for a new laptop for photo editing, budget around 1500 euros.
+  Which specs should I prioritise and which are safe to skimp on?
+gold: NONE
+kind: plain

--- a/experiments/skill-catalog-routing/tasks/z12.yaml
+++ b/experiments/skill-catalog-routing/tasks/z12.yaml
@@ -1,0 +1,6 @@
+description: Math homework walkthrough; no catalog skill teaches algebra.
+prompt: |
+  Can you walk me through solving a quadratic equation with the quadratic
+  formula? I've completely forgotten how it works since school.
+gold: NONE
+kind: plain

--- a/experiments/skill-catalog-routing/tasks/z13.yaml
+++ b/experiments/skill-catalog-routing/tasks/z13.yaml
@@ -1,0 +1,8 @@
+description: "Baits git-commit via the word 'committed', but the intent is deadline realism / time-management advice, not version control."
+prompt: |
+  I've committed to shipping this whole feature by Friday and now I'm second-
+  guessing myself. Can you help me sanity-check whether that's actually a
+  realistic promise given how much is left?
+gold: NONE
+kind: near-miss-none
+baits: git-plugin/git-commit

--- a/experiments/skill-catalog-routing/tasks/z14.yaml
+++ b/experiments/skill-catalog-routing/tasks/z14.yaml
@@ -1,0 +1,8 @@
+description: "Baits python-plugin via 'python', but it's about a pet snake, not the language."
+prompt: |
+  My eleven-year-old is begging us for a pet python. Are they actually
+  manageable for a first-time reptile owner, and what would we need to set up
+  for one?
+gold: NONE
+kind: near-miss-none
+baits: python-plugin/python-development

--- a/experiments/skill-catalog-routing/tasks/z15.yaml
+++ b/experiments/skill-catalog-routing/tasks/z15.yaml
@@ -1,0 +1,7 @@
+description: "Baits rust-plugin via 'rust', but it's iron oxide on a bike chain, not the language."
+prompt: |
+  There's a fair bit of rust on my bike chain after it sat out in the rain all
+  winter. What's the best way to get it off without wrecking the drivetrain?
+gold: NONE
+kind: near-miss-none
+baits: rust-plugin/rust-development

--- a/experiments/skill-catalog-routing/tasks/z16.yaml
+++ b/experiments/skill-catalog-routing/tasks/z16.yaml
@@ -1,0 +1,7 @@
+description: "Baits git deadbranch/git-maintain via 'prune branches', but it's about a literal apple tree."
+prompt: |
+  When's the right time of year to prune the branches on an apple tree? Mine
+  got pretty overgrown this summer and I don't want to hurt next year's fruit.
+gold: NONE
+kind: near-miss-none
+baits: git-plugin/deadbranch

--- a/experiments/skill-catalog-routing/tasks/z17.yaml
+++ b/experiments/skill-catalog-routing/tasks/z17.yaml
@@ -1,0 +1,8 @@
+description: "Baits kubernetes-operations via 'Kubernetes', but it's a pure conceptual 'what is it / why popular' explainer with no cluster or operation to perform."
+prompt: |
+  I keep seeing Kubernetes in job postings but I've never touched it. In plain
+  language, what problem does it actually solve and why did everyone end up
+  adopting it? Just trying to understand the concept.
+gold: NONE
+kind: near-miss-none
+baits: kubernetes-plugin/kubernetes-operations

--- a/experiments/skill-catalog-routing/tasks/z18.yaml
+++ b/experiments/skill-catalog-routing/tasks/z18.yaml
@@ -1,0 +1,8 @@
+description: "Baits networking-plugin via 'networking', but it's about social/professional networking at an event, not computer networks."
+prompt: |
+  I'm quite introverted and there's a big industry conference next month.
+  Any tips for networking with people there without it feeling forced or
+  draining?
+gold: NONE
+kind: near-miss-none
+baits: networking-plugin/network-diagnostics

--- a/experiments/skill-catalog-routing/tasks/z19.yaml
+++ b/experiments/skill-catalog-routing/tasks/z19.yaml
@@ -1,0 +1,8 @@
+description: "Baits kubernetes helm skills via 'helm/take the helm', but it's a leadership-transition question, not Helm charts."
+prompt: |
+  I'm taking the helm of our team as the new lead next month. It's my first
+  time managing former peers — any advice on making that transition go
+  smoothly?
+gold: NONE
+kind: near-miss-none
+baits: kubernetes-plugin/helm-release-management

--- a/experiments/skill-catalog-routing/tasks/z20.yaml
+++ b/experiments/skill-catalog-routing/tasks/z20.yaml
@@ -1,0 +1,8 @@
+description: "Baits terraform-plugin via 'terraforming', but it's a sci-fi/planetary-science curiosity, not infrastructure-as-code."
+prompt: |
+  In science fiction they're always terraforming Mars to make it habitable.
+  How realistic is that actually, and what would be the hardest part to pull
+  off with anything like today's science?
+gold: NONE
+kind: near-miss-none
+baits: terraform-plugin/infrastructure-terraform

--- a/justfile
+++ b/justfile
@@ -5,6 +5,7 @@ set positional-arguments
 
 # Subdirectory modules — invoke via `just <mod>::recipe`.
 mod claude-probe 'experiments/claude-probe'
+mod skill-catalog-routing 'experiments/skill-catalog-routing'
 
 # Show available recipes
 default:


### PR DESCRIPTION
## What & why

An A/B testing harness under `experiments/skill-catalog-routing/` that empirically answers: **does the skill catalog (the concatenated `name + description` of every skill) help a model route a request to the right skill, and how short can those descriptions be while still working — could shorter even be *better*?** Requested to evaluate whether the ~22.9k-token skill listing earns its context cost, and how it varies by model.

It mirrors the sibling `experiments/claude-probe/` harness: `claude -p` + `--system-prompt-file`, deterministic scoring, gitignored `results/`, commit scope matching no release-please package (never triggers a plugin release).

## Design

**Arms — a monotone information ladder** (independent variable = how much catalog the router sees), all 405 skills:

| arm | catalog | measured tokens |
|-----|---------|-----------------|
| C0 | none (null control) | 23.0k base |
| C1 | names only | +4.2k |
| C2 | names + `Use when <first trigger>` ≤40c | — |
| C3 | names + `Use when <triggers>` ≤80c | — |
| C4 | names + full description (current) | +20.7k |

- **Isolation (load-bearing):** `--system-prompt-file` replaces the built-in prompt and **strips Claude Code's own ~22k skill listing**; `run-one.sh` runs from a neutral cwd so the repo's `CLAUDE.md`/rules don't leak skill names. Measured base 23k vs full-catalog 43.7k confirms the built-in listing is absent — the only skill vocabulary is the injected catalog, for every arm including C0.
- **Structure-aware shortening:** descriptions are `<domain>. Use when <triggers>.` — `build-catalogs.py` truncates the `Use when` clause (never end-truncation), always preserving the literal `Use when` (issue #1278 class) so short ⊆ medium ⊆ full as token-subsets. `--validate` asserts this over all 405.
- **70 labeled tasks:** 30 route + 20 near-miss (10 adjacent-skill pairs) + 20 abstention (`gold: NONE`, incl. 8 near-miss-to-none). Authored symptom-framed; `check-tasks.py` leakage gate keeps `name_overlap = 0.0` so the signal is semantic, not string-overlap.
- **Grading:** deterministic skill-id match on the router's last-line JSON (no LLM judge — a real cost/simplicity win over claude-probe).
- **Models:** haiku/sonnet/opus (the three pinned aliases; there is no `fable` in this repo). Effort fixed `low`.

## Contents

`catalogs/` (committed variants + manifest), `tasks/*.yaml`, `prompts/system-router.md`, `conditions.yaml`, and `scripts/` (`build-catalogs.py`, `check-tasks.py`, `build-arm-prompt.sh`, `run-one.sh`, `run-suite.sh`, `score-run.py`, `compare.py`, `render-frontier.py`, `measure-catalog-tokens.sh`). Registered as a root `justfile` module.

## Status

Harness built and validated end-to-end (catalogs `--validate` clean; all 70 tasks 0 errors / 0 leakage; single-call smoke test routes correctly and emits the JSON contract). The **~120-call haiku pilot gate** (C1 vs C4, 20-task subset, 3 runs) plus a 20-call opus-C4 gold-verification pass are running now; the pilot's C4−C1 separation is the experiment's own validity check. Full cross-model sweep is **deferred pending pilot results** (per plan) to avoid committing quota to a possibly-leaky instrument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5qTjZ8EYMrSLAgEdpXop1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5qTjZ8EYMrSLAgEdpXop1)_