### PR TITLE
feat(macos-disk-usage): add usual-suspects fast-path scan

### DIFF
--- a/macos-plugin/skills/macos-disk-usage/SKILL.md
+++ b/macos-plugin/skills/macos-disk-usage/SKILL.md
@@ -2,10 +2,10 @@
 name: macos-disk-usage
 description: macOS disk-usage forensics and space recovery on APFS. Use when df reports a disk near-full, hunting what's eating space, reclaiming OrbStack/Docker, or pruning caches and local snapshots.
 user-invocable: false
-allowed-tools: Bash(uname *), Bash(df *), Bash(du *), Bash(diskutil *), Bash(tmutil *), Bash(docker *), Bash(brew *), Bash(go *), Bash(pip *), Bash(uv *), Bash(dust *), Bash(dua *), Bash(gdu *), Bash(ncdu *), Bash(mise *), Read, Grep, Glob, TodoWrite
+allowed-tools: Bash(bash *), Bash(uname *), Bash(df *), Bash(du *), Bash(find *), Bash(diskutil *), Bash(tmutil *), Bash(docker *), Bash(brew *), Bash(go *), Bash(pip *), Bash(uv *), Bash(dust *), Bash(dua *), Bash(gdu *), Bash(ncdu *), Bash(mise *), Read, Grep, Glob, TodoWrite
 created: 2026-06-21
-modified: 2026-06-21
-reviewed: 2026-06-21
+modified: 2026-07-18
+reviewed: 2026-07-18
 ---
 
 # macOS Disk Usage & Space Recovery
@@ -62,6 +62,29 @@ tmutil listlocalsnapshots /
 # Thin them (reclaims purgeable space invisible to du); needs sudo
 sudo tmutil thinlocalsnapshots / 999999999999 4
 ```
+
+## Step 1.5: Fast-path — the usual-suspects scan
+
+Step 1 gives the honest *total*; this gives *where it went* without re-deriving the hunt by hand each time. `scripts/scan-suspects.sh` reads a public catalog of known reclaim targets (`scripts/suspects.tsv` — dev caches, build-artifact dirs, VM images), `du`s the ones that exist on this machine, and emits a ranked rollup with the **cleanup command and safety tier already attached**:
+
+```bash
+# Whole home (thorough; slower — du walks every tree)
+bash "${CLAUDE_SKILL_DIR}/scripts/scan-suspects.sh" --home-dir "$HOME" --root "$HOME"
+
+# Bound the build-artifact search to where projects live, raise the noise floor
+bash "${CLAUDE_SKILL_DIR}/scripts/scan-suspects.sh" --root ~/repos --min-mb 1000
+```
+
+Output follows the structured `SUSPECT id=… tier=… size_kb=… cmd="…"` convention, plus a ranked human table and per-tier totals (`TIER_SAFE_KB=…`, `RECLAIMABLE_SAFE=…`). Work the tiers exactly as Step 4 — exhaust `safe` before `decision`, never blind-delete `userdata`.
+
+**This augments Step 1, it does not replace it.** The scan is pure measurement; the judgment stays with the agent — reading the APFS `Avail`-not-`Capacity %` picture, checking purgeable snapshots when `du` and `df` disagree, and deciding *which* `decision`/`userdata` items to actually remove.
+
+**The `UNKNOWN` lines are the feedback loop.** Any big directory *not* in the catalog is surfaced as `UNKNOWN size_kb=… path=…`. When one recurs, add it to `suspects.tsv` **as a pattern** (never a machine-specific path — this repo is public) and open a PR; the catalog grows from real findings. Catalog columns and placeholders (`{dir}`, `{parent}`) are documented in the file's header.
+
+Two operational notes:
+
+- **Runtime scales with disk size** — `du` walks every tree, so a full disk can take a minute or two. Bound with `--root <project-dir>` and `--min-mb`; swap in `dust` (Step 3) if you want the walk parallelised.
+- **The catalog is the shared artifact; the scan *output* is machine-specific** — keep it in scratch, never commit it.
 
 ## Step 2: The OrbStack / Docker recovery play
 
@@ -126,6 +149,7 @@ Work top-down — exhaust the safe tier before touching anything that needs a de
 
 | Context | Command |
 |---------|---------|
+| Ranked usual-suspects rollup | `bash "${CLAUDE_SKILL_DIR}/scripts/scan-suspects.sh" --root ~/repos` |
 | Honest free space | `df -h / \| awk 'NR==2{print $4" avail"}'` |
 | Container free space | `diskutil apfs list \| grep -i 'Capacity In Use\|Free'` |
 | Top home consumers | `du -hx -d1 ~ 2>/dev/null \| sort -h \| tail -15` |
@@ -138,6 +162,7 @@ Work top-down — exhaust the safe tier before touching anything that needs a de
 
 | Need | Command |
 |------|---------|
+| Fast-path suspect scan | `bash "${CLAUDE_SKILL_DIR}/scripts/scan-suspects.sh"` |
 | Honest free space | `df -h /` (read `Avail`, not `Capacity %`) |
 | APFS container truth | `diskutil apfs list` |
 | Disk hog scan | `du -hx -d1 <dir>` or `dust -d2 -r <dir>` |

--- a/macos-plugin/skills/macos-disk-usage/scripts/scan-suspects.sh
+++ b/macos-plugin/skills/macos-disk-usage/scripts/scan-suspects.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# macos-disk-usage — usual-suspects fast-path scan.
+#
+# Extracts the mechanical "where does disk usually go" step of the
+# macos-disk-usage skill into a deterministic artifact. Reads the public
+# catalog (suspects.tsv) of KNOWN reclaim targets — dev caches, build-artifact
+# dirs, VM images — du's the ones that exist on THIS machine, and emits a ranked
+# rollup with the cleanup command and safety tier already attached. It also
+# surfaces big directories NOT in the catalog, so real findings feed back into
+# the catalog (grow it via PR, scrubbed to patterns).
+#
+# The agent still owns the judgment the catalog can't encode: reading the honest
+# df/APFS/snapshot picture (Step 1), deciding which `decision`/`userdata` items
+# to actually delete, and interpreting a `Capacity %` that lies. This script only
+# does the repeatable measurement.
+#
+# The du/find core is portable BY DESIGN so the regression test runs offline on
+# Linux CI against a PLANTED fixture home via the injectable seams:
+#   --home-dir <path>   base for catalog `path` targets + default scan root
+#   --root <path>       root(s) to scan for build-artifact dirs (repeatable)
+#   --catalog <file>    catalog TSV (default: sibling suspects.tsv)
+#   --min-mb <n>        unclassified-dir reporting threshold (default 500)
+#   --top <n>           rows in the ranked table (default 25)
+# The macOS-specific suspects are DATA (catalog rows); on Linux they simply don't
+# exist and are skipped, so there is no Darwin guard here (the SKILL enforces it).
+#
+# Emits the structured KEY=value / STATUS= convention
+# (.claude/rules/structured-script-output.md). Exit 0 on a clean run.
+set -uo pipefail
+
+home_dir=""
+catalog=""
+min_mb=500
+top_n=25
+roots=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --home-dir) home_dir="$2"; shift 2 ;;
+    --root)     roots+=("$2"); shift 2 ;;
+    --catalog)  catalog="$2"; shift 2 ;;
+    --min-mb)   min_mb="$2"; shift 2 ;;
+    --top)      top_n="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+: "${home_dir:=$HOME}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${catalog:=${script_dir}/suspects.tsv}"
+[ "${#roots[@]}" -gt 0 ] || roots=("$home_dir")
+min_kb=$(( min_mb * 1024 ))
+
+# KB -> human (input already in KB; 1 unit == 1 KiB).
+hsize() {
+  awk -v k="$1" 'BEGIN{
+    u="KMGT"; s=k; i=1;
+    while (s>=1024 && i<4) { s/=1024; i++ }
+    if (i==1) printf "%d%s", s, substr(u,i,1);
+    else      printf "%.1f%s", s, substr(u,i,1)
+  }'
+}
+
+# Accumulators for the ranked table + tier totals. Newline-delimited
+# "size_kb<TAB>tier<TAB>id<TAB>path" records; paths never contain a tab.
+results=""
+reported=""              # newline-delimited reported paths, for unclassified exclusion
+safe_kb=0; decision_kb=0; userdata_kb=0
+
+record() {  # size_kb tier id path
+  results+="$1	$2	$3	$4
+"
+  reported+="$4
+"
+  case "$2" in
+    safe)     safe_kb=$(( safe_kb + $1 )) ;;
+    decision) decision_kb=$(( decision_kb + $1 )) ;;
+    userdata) userdata_kb=$(( userdata_kb + $1 )) ;;
+  esac
+}
+
+echo "=== MACOS DISK SUSPECTS SCAN ==="
+echo "HOME_DIR=$home_dir"
+echo "ROOTS=${roots[*]}"
+echo "CATALOG=$catalog"
+echo "MIN_MB=$min_mb"
+
+if [ ! -f "$catalog" ]; then
+  echo "STATUS=ERROR_NO_CATALOG"
+  exit 1
+fi
+
+# --- Pass 1: fixed-path suspects -------------------------------------------
+echo "--- FIXED-PATH SUSPECTS ---"
+# shellcheck disable=SC2034  # regen,note are catalog columns for humans, not read here
+while IFS=$'\t' read -r kind id target marker tier command regen note; do
+  case "$kind" in \#*|kind|"") continue ;; esac
+  [ "$kind" = "path" ] || continue
+  case "$target" in
+    /*) p="$target" ;;
+    *)  p="$home_dir/$target" ;;
+  esac
+  [ -e "$p" ] || continue
+  size=$(du -skx "$p" 2>/dev/null | awk 'NR==1{print $1}')
+  [ -n "${size:-}" ] || continue
+  cmd=${command//\{dir\}/$p}
+  echo "SUSPECT id=$id tier=$tier size_kb=$size path=$p cmd=\"$cmd\""
+  record "$size" "$tier" "$id" "$p"
+done < "$catalog"
+
+# --- Pass 2: build-artifact dirs under the scan roots ----------------------
+echo "--- BUILD-ARTIFACT DIRS ---"
+# shellcheck disable=SC2034  # regen,note are catalog columns for humans, not read here
+while IFS=$'\t' read -r kind id target marker tier command regen note; do
+  case "$kind" in \#*|kind|"") continue ;; esac
+  [ "$kind" = "dir" ] || continue
+  for root in "${roots[@]}"; do
+    [ -d "$root" ] || continue
+    while IFS= read -r d; do
+      [ -n "$d" ] || continue
+      parent=$(dirname "$d")
+      if [ "$marker" != "-" ] && [ ! -e "$parent/$marker" ]; then
+        continue
+      fi
+      size=$(du -skx "$d" 2>/dev/null | awk 'NR==1{print $1}')
+      [ -n "${size:-}" ] || continue
+      cmd=${command//\{dir\}/$d}
+      cmd=${cmd//\{parent\}/$parent}
+      echo "SUSPECT id=$id tier=$tier size_kb=$size path=$d cmd=\"$cmd\""
+      record "$size" "$tier" "$id" "$d"
+    done < <(find "$root" -type d -name "$target" -prune -print 2>/dev/null)
+  done
+done < "$catalog"
+
+# --- Pass 3: unclassified big dirs (feedback loop) -------------------------
+# A dir is "covered" when it equals, contains, or sits inside a reported path,
+# so known suspects don't reappear here as noise. What survives is a candidate
+# for a new catalog entry.
+echo "--- UNCLASSIFIED (>= ${min_mb}M, not in catalog) ---"
+is_covered() {  # candidate
+  local c="$1" r
+  while IFS= read -r r; do
+    [ -n "$r" ] || continue
+    [ "$c" = "$r" ] && return 0
+    case "$c" in "$r"/*) return 0 ;; esac   # candidate inside a reported path
+    case "$r" in "$c"/*) return 0 ;; esac   # candidate contains a reported path
+  done <<EOF
+$reported
+EOF
+  return 1
+}
+unclassified=""
+for root in "${roots[@]}"; do
+  [ -d "$root" ] || continue
+  while IFS=$'\t' read -r kb path; do
+    [ -n "${kb:-}" ] || continue
+    [ "$kb" -ge "$min_kb" ] 2>/dev/null || continue
+    [ "$path" = "$root" ] && continue
+    is_covered "$path" && continue
+    unclassified+="$kb	$path
+"
+  done < <(du -kx -d 2 "$root" 2>/dev/null)
+done
+if [ -n "$unclassified" ]; then
+  # De-nest: biggest first, then skip any dir that is an ancestor or descendant
+  # of one already emitted, so a parent and its child don't both appear.
+  emitted=""
+  count=0
+  while IFS=$'\t' read -r kb path; do
+    [ -n "${kb:-}" ] || continue
+    [ "$count" -ge 15 ] && break
+    skip=0
+    while IFS= read -r e; do
+      [ -n "$e" ] || continue
+      case "$path" in "$e"/*) skip=1; break ;; esac
+      case "$e" in "$path"/*) skip=1; break ;; esac
+    done <<EOF
+$emitted
+EOF
+    [ "$skip" -eq 1 ] && continue
+    echo "UNKNOWN size_kb=$kb path=$path"
+    emitted+="$path
+"
+    count=$(( count + 1 ))
+  done < <(printf '%s' "$unclassified" | sort -rn)
+else
+  echo "UNKNOWN none"
+fi
+
+# --- Ranked table + tier totals --------------------------------------------
+echo "--- RANKED (top ${top_n} by size) ---"
+if [ -n "$results" ]; then
+  rank=0
+  printf '%s' "$results" | sort -rn | head -n "$top_n" | while IFS=$'\t' read -r kb tier id path; do
+    [ -n "${kb:-}" ] || continue
+    rank=$(( rank + 1 ))
+    printf '%d\t%s\t%-8s\t%s\t%s\n' "$rank" "$(hsize "$kb")" "$tier" "$id" "$path"
+  done
+else
+  echo "(no known suspects present)"
+fi
+
+echo "--- TIER TOTALS ---"
+echo "TIER_SAFE_KB=$safe_kb"
+echo "TIER_DECISION_KB=$decision_kb"
+echo "TIER_USERDATA_KB=$userdata_kb"
+echo "RECLAIMABLE_SAFE=$(hsize "$safe_kb")"
+echo "RECLAIMABLE_DECISION=$(hsize "$decision_kb")"
+echo "STATUS=OK"

--- a/macos-plugin/skills/macos-disk-usage/scripts/suspects.tsv
+++ b/macos-plugin/skills/macos-disk-usage/scripts/suspects.tsv
@@ -1,0 +1,33 @@
+# macos-disk-usage usual-suspects catalog. Tab-separated; consumed by scan-suspects.sh.
+# Columns: kind(path|dir)  id  target  marker  tier(safe|decision|userdata)  command  regen  note
+#   path: literal path (relative to --home-dir unless absolute); du'd if it exists.
+#   dir : basename found under --root; counted only if <marker> exists in its parent (- = no marker).
+#   command placeholders: {dir} = matched path, {parent} = its parent dir.
+# Patterns only - never machine-specific paths (this repo is public).
+kind	id	target	marker	tier	command	regen	note
+path	uv-cache	.cache/uv	-	safe	uv cache clean	re-downloaded on next resolve	fails if a uv process holds the lock
+path	pip-cache	.cache/pip	-	safe	pip cache purge	re-downloaded	-
+path	pre-commit-cache	.cache/pre-commit	-	safe	pre-commit clean	rebuilt on next hook run	-
+path	hf-cache	.cache/huggingface	-	decision	rm -rf {dir}	re-downloaded from HF, large and slow	relocate via tools-plugin:hf-downloads (HF_HOME)
+path	ollama-models	.ollama/models	-	decision	ollama rm <model>	re-pulled from registry, large	pick per-model, never bulk-delete
+path	bun-store	.bun/install	-	safe	bun pm cache rm	re-fetched on next install	slows next offline install
+path	npm-cache	.npm/_cacache	-	safe	npm cache clean --force	re-downloaded	-
+path	cargo-registry-cache	.cargo/registry/cache	-	safe	rm -rf {dir}	re-downloaded on next build	-
+path	gradle-caches	.gradle/caches	-	safe	rm -rf {dir}	re-downloaded on next build	-
+path	go-build-cache	Library/Caches/go-build	-	safe	go clean -cache	rebuilt on next go build	-
+path	go-modcache	go/pkg/mod	-	safe	go clean -modcache	re-downloaded	go clean handles read-only perms
+path	brew-cache	Library/Caches/Homebrew	-	safe	brew cleanup -s	re-downloaded on next install	-
+path	playwright-cache	Library/Caches/ms-playwright	-	safe	rm -rf {dir}	re-downloaded on next install	-
+path	xcode-derived	Library/Developer/Xcode/DerivedData	-	safe	rm -rf {dir}	rebuilt on next Xcode build	-
+path	xcode-devicesupport	Library/Developer/Xcode/iOS DeviceSupport	-	safe	rm -rf {dir}	re-created when device reconnects	-
+path	xcode-archives	Library/Developer/Xcode/Archives	-	userdata	(review)	NOT regenerable - shipped app archives	keep releases you need
+path	simulator-caches	Library/Developer/CoreSimulator/Caches	-	decision	xcrun simctl delete unavailable	rebuilt on demand	can be tens of GB
+path	orbstack-image	Library/Group Containers/HUAQ24HBR6.dev.orbstack/data/data.img.raw	-	decision	docker system prune -a -f	OrbStack auto-shrinks after in-VM prune	never delete the .raw directly
+path	docker-desktop-vms	Library/Containers/com.docker.docker/Data/vms	-	decision	docker system prune -a -f	manual reclaim on Docker Desktop	-
+path	trash	.Trash	-	userdata	rm -rf {dir}/*	permanent	confirm before emptying
+dir	rust-target	target	Cargo.toml	safe	cargo clean --manifest-path {parent}/Cargo.toml	rebuilt on next cargo build	matched only beside a Cargo.toml
+dir	node-modules	node_modules	package.json	safe	rm -rf {dir}	restored by npm/bun/yarn install	-
+dir	py-venv-dot	.venv	-	safe	rm -rf {dir}	recreate via uv venv or python -m venv	skip the active env
+dir	py-venv	venv	-	safe	rm -rf {dir}	recreate via uv venv or python -m venv	skip the active env
+dir	next-build	.next	package.json	safe	rm -rf {dir}	rebuilt by next build	-
+dir	python-cache	__pycache__	-	safe	rm -rf {dir}	regenerated on import	many small dirs

--- a/macos-plugin/skills/macos-disk-usage/scripts/tests/test-scan-suspects.sh
+++ b/macos-plugin/skills/macos-disk-usage/scripts/tests/test-scan-suspects.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Regression test for scan-suspects.sh.
+#
+# Runs entirely offline on Linux CI against a PLANTED fixture home via the
+# injectable --home-dir / --root seams — never against the real system. Asserts
+# the SEMANTIC invariants:
+#   - Fixed-path suspects present on disk are detected with the right tier
+#     (uv=safe, ollama=decision).
+#   - A build-artifact dir counts ONLY when its marker sibling exists: a
+#     target/ beside Cargo.toml is matched as rust-target; a target/ WITHOUT a
+#     Cargo.toml is not (marker discipline).
+#   - node_modules beside package.json is matched.
+#   - The ranked table orders by real size (biggest fixture = rank 1).
+#   - Tier totals separate safe from decision.
+#   - A big dir NOT in the catalog surfaces as UNKNOWN (the feedback loop).
+#   - A missing catalog reports STATUS=ERROR_NO_CATALOG and exits non-zero.
+#   - An empty home degrades gracefully (STATUS=OK, no suspects, exit 0).
+# Exit 0 on success ("ALL TESTS PASSED"); non-zero on any failure.
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+scan="${script_dir}/../scan-suspects.sh"
+catalog="${script_dir}/../suspects.tsv"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+pass() { echo "PASS: $1"; }
+
+for dep in du find awk sort dirname dd; do
+  command -v "$dep" >/dev/null 2>&1 || { echo "SKIP: $dep not installed"; exit 0; }
+done
+
+[ -f "$scan" ] || fail "scan-suspects.sh not found at $scan"
+[ -f "$catalog" ] || fail "suspects.tsv not found at $catalog"
+
+mkfile() { mkdir -p "$(dirname "$1")"; dd if=/dev/zero of="$1" bs=1024 count="$2" 2>/dev/null; }
+
+fx="$(mktemp -d)"
+trap 'rm -rf "$fx"' EXIT
+
+# --- Plant the fixture home ------------------------------------------------
+mkfile "$fx/.cache/uv/blob"                 5000   # fixed path, tier=safe
+mkfile "$fx/.ollama/models/blob"            2000   # fixed path, tier=decision
+# rust project: target/ beside Cargo.toml -> matched (mkfile creates proj/ first)
+mkfile "$fx/repos/proj/target/artifact"     8000   # dir rust-target, biggest
+: > "$fx/repos/proj/Cargo.toml"
+# target/ WITHOUT Cargo.toml -> marker discipline: must NOT match
+mkfile "$fx/repos/norust/target/artifact"   3000
+# node project: node_modules beside package.json -> matched
+mkfile "$fx/repos/webapp/node_modules/dep"  1000   # dir node-modules, tier=safe
+: > "$fx/repos/webapp/package.json"
+# a big dir not in the catalog -> should surface as UNKNOWN
+mkfile "$fx/BigMovies/recording.mov"        4000
+
+out="$(bash "$scan" --home-dir "$fx" --root "$fx" --min-mb 1 --top 25)"
+rc=$?
+[ "$rc" -eq 0 ] || fail "scan exited non-zero ($rc)"
+grep -q '^STATUS=OK$' <<<"$out" || fail "missing STATUS=OK"
+pass "scan runs clean on the fixture"
+
+grep -q 'SUSPECT id=uv-cache tier=safe ' <<<"$out" || fail "uv-cache not detected as safe"
+pass "fixed-path uv-cache detected (safe)"
+
+grep -q 'SUSPECT id=ollama-models tier=decision ' <<<"$out" || fail "ollama not detected as decision"
+pass "fixed-path ollama-models detected (decision)"
+
+# rust-target matched, and matched at proj/ (has Cargo.toml)
+grep -q 'SUSPECT id=rust-target .*proj/target' <<<"$out" || fail "rust-target not matched beside Cargo.toml"
+pass "rust-target matched beside Cargo.toml"
+
+# marker discipline: the markerless norust/target must NOT be a rust-target hit
+if grep 'SUSPECT id=rust-target' <<<"$out" | grep -q 'norust'; then
+  fail "markerless target/ was wrongly counted as rust-target"
+fi
+pass "markerless target/ correctly skipped (marker discipline)"
+
+grep -q 'SUSPECT id=node-modules .*webapp/node_modules' <<<"$out" || fail "node-modules not matched"
+pass "node-modules matched beside package.json"
+
+# ranked rank-1 (biggest) is the 8000KB rust-target; field 4 is the id
+rank1_id="$(awk -F'\t' '$1=="1"{print $4}' <<<"$out")"
+[ "$rank1_id" = "rust-target" ] || fail "rank 1 should be rust-target, got '$rank1_id'"
+pass "ranked table orders by real size (rust-target #1)"
+
+# tier totals: safe (uv+target+node_modules) far exceeds decision (ollama only)
+safe_kb="$(grep -oE '^TIER_SAFE_KB=[0-9]+' <<<"$out" | cut -d= -f2)"
+dec_kb="$(grep -oE '^TIER_DECISION_KB=[0-9]+' <<<"$out" | cut -d= -f2)"
+[ "${safe_kb:-0}" -gt "${dec_kb:-0}" ] || fail "safe total ($safe_kb) should exceed decision ($dec_kb)"
+[ "${dec_kb:-0}" -ge 2000 ] || fail "decision total should be >= 2000 (ollama), got '$dec_kb'"
+pass "tier totals separate safe from decision (safe=$safe_kb decision=$dec_kb)"
+
+grep -q 'UNKNOWN .*BigMovies' <<<"$out" || fail "uncatalogued BigMovies not surfaced as UNKNOWN"
+pass "uncatalogued big dir surfaced as UNKNOWN (feedback loop)"
+
+# --- Missing catalog ------------------------------------------------------
+out_nocat="$(bash "$scan" --home-dir "$fx" --catalog "$fx/does-not-exist.tsv" 2>&1)"
+rc_nocat=$?
+grep -q '^STATUS=ERROR_NO_CATALOG$' <<<"$out_nocat" || fail "missing catalog should report ERROR_NO_CATALOG"
+[ "$rc_nocat" -ne 0 ] || fail "missing catalog should exit non-zero"
+pass "missing catalog fails loudly"
+
+# --- Empty home degrades gracefully ---------------------------------------
+empty="$(mktemp -d)"; trap 'rm -rf "$fx" "$empty"' EXIT
+out_empty="$(bash "$scan" --home-dir "$empty" --root "$empty" --min-mb 1)"
+rc_empty=$?
+[ "$rc_empty" -eq 0 ] || fail "empty home should exit 0"
+grep -q '^STATUS=OK$' <<<"$out_empty" || fail "empty home should still report STATUS=OK"
+grep -q '^SUSPECT ' <<<"$out_empty" && fail "empty home should surface no suspects"
+pass "empty home degrades gracefully"
+
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
## What

Adds a **usual-suspects fast-path** to the `macos-disk-usage` skill: a public catalog of known reclaim targets plus a scan script that measures the ones present on the machine and emits a ranked rollup with the cleanup command and safety tier already attached.

Born from a real cleanup session (disk at 2.1 GiB free → 103 GiB) where the hunt — OrbStack image, `~/.cache/{uv,huggingface,pre-commit}`, Rust `target/`, Ollama models — was re-derived by hand. This encodes that hunt once.

## Why this shape (catalog + scan, split by layer)

The improvement is **`offload-to-deterministic-substrate`**: the "where does disk go" scan was living in the agent's reasoning loop, re-derived each session. It splits cleanly into two layers, and because this repo is **public**, the split is forced (not just tidy):

- **`scripts/suspects.tsv`** — the *catalog of patterns* + command + safety tier + regen note. Universal, reviewable, versioned. **No machine-specific paths** (`verify-machine-facts-before-publishing`).
- **`scripts/scan-suspects.sh`** — applies the catalog to *this* filesystem, producing the ranked, sized, machine-specific list. Output is ephemeral, never committed.

A per-user corpus committed to a public repo would leak personal infra; a static catalog can't know sizes. The combination is the only shape that survives.

## Contents

| File | Role |
|---|---|
| `scripts/suspects.tsv` | Public pattern catalog (26 entries: dev caches, build-artifact dirs, VM images). Columns + `{dir}`/`{parent}` placeholders documented in-header. |
| `scripts/scan-suspects.sh` | Reads the catalog, `du`s fixed-path suspects + marker-gated build-artifact dirs under `--root`, emits structured `SUSPECT`/`RANKED`/`TIER` output. Uncatalogued big dirs surface as `UNKNOWN` — the feedback loop that grows the catalog. |
| `scripts/tests/test-scan-suspects.sh` | Offline Linux-CI regression against a planted fixture home. |
| `SKILL.md` | New **Step 1.5: Fast-path**, framed as an *augment* to (not a replacement for) the honest df/APFS/snapshot judgment in Step 1. |

## Design notes

- **Catalog under `scripts/` (not `references/`)** so catalog edits trigger `test-skill-scripts.yml` (a malformed TSV fails CI) and the script locates it as a sibling.
- **Portable `du`/`find` core** with `--home-dir`/`--root` seams, so the test runs on Linux CI even though the skill is macOS-only (macOS suspects are just data rows, absent on Linux).
- **Marker discipline**: a `target/` counts as `rust-target` only beside a `Cargo.toml`; `node_modules/` only beside `package.json` — no false positives on generically-named dirs.

## Verification

- `shellcheck` clean on both scripts
- `test-scan-suspects.sh` — 11 assertions pass (detection, marker discipline, ranking, tier totals, `UNKNOWN` surfacing, missing-catalog + empty-home graceful paths)
- `pre-commit run --files` — clean
- Real smoke run on darwin emits `STATUS=OK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KafgqdX9oeKiUDAjZqAeAB
