### PR TITLE
fix(tools-plugin): correct d2-config keys in d2-diagrams in-file config example

### DIFF
--- a/tools-plugin/skills/d2-diagrams/SKILL.md
+++ b/tools-plugin/skills/d2-diagrams/SKILL.md
@@ -5,8 +5,8 @@ user-invocable: false
 allowed-tools: Bash(d2 *), Read, Write, Grep, Glob, TodoWrite
 model: sonnet
 created: 2025-12-26
-modified: 2026-05-09
-reviewed: 2026-02-06
+modified: 2026-07-18
+reviewed: 2026-07-18
 ---
 
 # D2 Diagrams
@@ -289,9 +289,9 @@ box: {
 ```d2
 vars: {
   d2-config: {
-    layout: elk
-    theme: 4
-    dark-theme: 200
+    layout-engine: elk
+    theme-id: 4
+    dark-theme-id: 200
     pad: 20
     sketch: true
   }


### PR DESCRIPTION
## What

The `tools-plugin:d2-diagrams` skill's **Configuration in File** example used `d2-config` keys that d2 rejects — `layout`/`theme`/`dark-theme` are "not a valid config". Renamed to the correct `layout-engine` / `theme-id` / `dark-theme-id`.

## Verification

Compiled the corrected block on the locally installed d2 (matches the issue's verified v0.7.1):

```
success: successfully compiled d2test.d2 to d2test.svg
```

An agent following the old example verbatim hit a hard compile error and had to fall back to CLI flags.

Closes #2099

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcHDso9XS29z77D52LieCZ