### PR TITLE
docs(rules): capture gh head:-exact-match and Actions set -e $() gotchas

### DIFF
--- a/.claude/rules/gh-json-fields.md
+++ b/.claude/rules/gh-json-fields.md
@@ -183,6 +183,32 @@ Symptom signature: a state check reports an issue closed/missing, but
 authoritative. (Observed 2026-06-21: a 39-issue repo's open-state check missed
 two issues that were genuinely open.)
 
+## Search qualifiers: `head:` is exact-match, not a prefix
+
+`gh pr list --search "head:<X>"` (and the underlying GitHub search `head:`
+qualifier) matches PRs whose head branch is **exactly** `<X>` — it is **not** a
+prefix/glob match. So `gh pr list --search "head:feat/wo-"` matches a branch
+literally named `feat/wo-` (usually none), returning **zero** — not "every
+`feat/wo-*` branch". The failure is silent: the command succeeds, the count is
+just wrong, and any budget/threshold keyed on that count never fires.
+
+```bash
+# Wrong — reads as "PRs on feat/wo-* branches"; actually matches the exact name feat/wo-
+COUNT=$(gh pr list --state all --search "head:feat/wo- created:>=$TODAY" --json number --jq 'length')  # ~always 0
+
+# Right — enumerate head branches and prefix-filter in jq
+COUNT=$(gh pr list --state all --limit 200 --json headRefName,createdAt \
+  --jq --arg d "$TODAY" '[.[] | select(.headRefName | startswith("feat/wo-")) | select(.createdAt | startswith($d))] | length')
+```
+
+Note `gh pr list --head "<branch>"` (the flag, not the search qualifier) **is**
+an exact-branch filter and is correct for "PRs on this one branch". Reserve the
+`--search "head:"` form for a known full branch name; reach for `--json
+headRefName` + `startswith` whenever you mean a **prefix**. (Observed 2026-07-18:
+a level-3 daily-budget count keyed on `--search "head:blueprint/wo-"` was always
+0, so the budget never enforced — caught only by an adversarial review, not by
+CI.)
+
 ## Related
 
 - `.claude/rules/github-metadata-hygiene.md` (parent

--- a/.claude/rules/shell-scripting.md
+++ b/.claude/rules/shell-scripting.md
@@ -132,6 +132,40 @@ This is distinct from hook scripts, which *should* fail fast — the rule is
 that emits its own PASS/WARN/FAIL per section wants to run every section, so drop
 `-e`/`pipefail` and guard only unset vars.
 
+#### `set -e` + `OUT=$(cmd-that-exits-nonzero)` aborts *before* the next line
+
+Under `set -e` (which GitHub Actions applies to every `run:` block by default —
+`bash -eo pipefail`), a command substitution whose command **exits non-zero**
+fails the whole statement, so the script aborts **at the assignment**, before
+any code that inspects `OUT`. A script deliberately designed to exit `1` as a
+*signal* (an invalid-input parser, a validator that carries its verdict in
+`STATUS=`/`VALID=` output) is the classic trap: the intended "read the output,
+branch on it" step never runs.
+
+```yaml
+# Wrong (GitHub Actions run: — set -eo pipefail): parser exits 1 on bad input,
+# so the step aborts here; the `valid=` output and the reject branch never run.
+- run: |
+    OUT=$(bash validate.sh --in x)      # validate.sh exits 1 on invalid → step dies
+    echo "valid=$(printf '%s\n' "$OUT" | grep -m1 '^VALID=' | cut -d= -f2)" >> "$GITHUB_OUTPUT"
+- if: steps.x.outputs.valid != 'true'   # never reached
+  run: echo "rejected"
+```
+
+```yaml
+# Right: neutralize the exit so the verdict flows through the OUTPUT, not $?
+- run: |
+    OUT=$(bash validate.sh --in x) || true
+    echo "valid=$(printf '%s\n' "$OUT" | grep -m1 '^VALID=' | cut -d= -f2)" >> "$GITHUB_OUTPUT"
+```
+
+Applies anywhere `set -e` is active (an Actions `run:`, a `set -euo pipefail`
+script). Prefer a script whose exit code and its structured `STATUS=` output
+agree *and* a caller that reads the output — capture with `|| true` when you
+mean to branch on the content rather than abort on the exit. (Observed
+2026-07-18: a workflow's "reject an invalid packet + comment" step was dead code
+because `OUT=$(bash parser.sh)` aborted the step before the comment path.)
+
 ### Block Function
 
 Hook scripts that block tool use (exit code 2) must use a standard `block()` function:


### PR DESCRIPTION
Two durable gotchas distilled from implementing ADR-0020 level 3 (#2005 / #2103) — both silently broke real code and were caught only by an adversarial review, not CI:

- **`.claude/rules/gh-json-fields.md`** — `gh pr list --search "head:<X>"` matches an **exact** branch name, not a prefix. A daily-budget count keyed on `--search "head:blueprint/wo-"` was always `0`, so the budget never enforced. Use `--json headRefName` + `startswith` for a prefix; `--head <branch>` (the flag) is the correct exact-branch filter.
- **`.claude/rules/shell-scripting.md`** — under `set -e` (GitHub Actions' default `bash -eo pipefail` for `run:`), `OUT=$(cmd-that-exits-nonzero)` aborts the step **before** the next line, turning a "read the output and branch" step into dead code. Capture with `|| true` when the verdict is carried in the output, not `$?`.

Docs-only; no plugin package touched (no release bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
