### PR TITLE
fix(permissions): drop dead Write(.claude/rules/**) allow rule

### DIFF
--- a/.claude/rules/agentic-permissions.md
+++ b/.claude/rules/agentic-permissions.md
@@ -278,18 +278,19 @@ These narrow rules carry over into auto mode and skip the classifier. Avoid broa
 
 Claude Code's built-in classifier treats `.claude/**` as a protected directory (except for `.claude/commands`, `.claude/agents`, `.claude/skills`, and `.claude/worktrees` — see `auto-mode.md`). Writes route through the classifier in auto mode and prompt in lower modes. Subagents observe this denial as a hard block on `Edit`/`Write`, regardless of the parent session's permission mode.
 
-`Edit(<glob>)` and `Write(<glob>)` allow rules in `settings.json` resolve at step 1 of the decision chain and override the protected-path check. Use this to carve out documentation directories under `.claude/` that should be subagent-writable:
+An `Edit(<glob>)` allow rule in `settings.json` resolves at step 1 of the decision chain and overrides the protected-path check. Use this to carve out documentation directories under `.claude/` that should be subagent-writable:
 
 ```json
 {
   "permissions": {
     "allow": [
-      "Edit(.claude/rules/**)",
-      "Write(.claude/rules/**)"
+      "Edit(.claude/rules/**)"
     ]
   }
 }
 ```
+
+One `Edit(<glob>)` rule covers **all** file-editing tools — `Edit`, `Write`, and `NotebookEdit`. A matching `Write(<glob>)` rule is dead weight: file permission checks only consult `Edit(path)` rules, so Claude Code warns on startup (`Write(...) is not matched by file permission checks — only Edit(path) rules are`) and ignores it. Do not pair a `Write(<glob>)` allow rule with the `Edit(<glob>)` one.
 
 This repo carves out `.claude/rules/**` because the files there are documentation read by humans and injected into agent context — not configuration that affects the harness. Skills, agents, and commands directories are already in Claude Code's default carve-out for the same reason; rules belong in the same trust tier.
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,7 +32,6 @@
       "Bash(rg *)",
       "Edit(.claude/rules/**)",
       "WebFetch(domain:agentic-patterns.com)",
-      "Write(.claude/rules/**)",
       "mcp__chrome-devtools",
       "mcp__context7",
       "mcp__github__issue_read",


### PR DESCRIPTION
## What

Removes the redundant `Write(.claude/rules/**)` entry from `.claude/settings.json` and corrects `.claude/rules/agentic-permissions.md`, which taught pairing `Edit(<glob>)` with `Write(<glob>)`.

## Why

Every Claude Code launch printed this warning:

> Permission allow rule (.claude/settings.json): `Write(.claude/rules/**)` is not matched by file permission checks — only `Edit(path)` rules are. Use `Edit(.claude/rules/**)` instead (Edit rules cover all file-editing tools).

File permission checks only consult `Edit(path)` rules, and a single `Edit(<glob>)` rule already covers `Write` and `NotebookEdit`. The `Edit(.claude/rules/**)` rule is already present, so the paired `Write(...)` rule was never matched — pure dead weight producing a recurring startup warning.

## How

- `settings.json`: delete the `Write(.claude/rules/**)` line (`Edit(.claude/rules/**)` remains, unchanged).
- `agentic-permissions.md`: rewrite the carve-out guidance to a single `Edit(<glob>)` rule and add a note that one `Edit` rule covers all file-editing tools, so a `Write(<glob>)` companion is dead weight that trips the startup warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpbmjpEJmjRvk3me4PJLai