### PR TITLE
docs(tools-plugin): justfile shared-import + module parameter gotcha

### DIFF
--- a/tools-plugin/skills/justfile-expert/SKILL.md
+++ b/tools-plugin/skills/justfile-expert/SKILL.md
@@ -335,6 +335,34 @@ release version:
     git push origin "v{{version}}"
 ```
 
+**Shared imports + modules: pass per-project values as recipe parameters**
+
+When a monorepo registers submodules (`mod name 'path'`) whose justfiles `import`
+a shared recipe file, hand per-project values to the shared recipes as recipe
+**parameters** — not via a shared *variable*. Two `just` behaviours make the
+variable approach fail:
+
+- An `import` that *defaults* a variable a module also assigns is a **conflict**,
+  not an override: `error: variable `X` has multiple definitions`.
+- An imported recipe that references `{{X}}` is resolved at **load time**, so it
+  forces *every* importing module to define `X` (else `error: variable `X` not
+  defined`) — even modules that never run that recipe.
+
+Passing the value as a recipe argument sidesteps both and keeps it explicit at the
+call site:
+
+```just
+# shared.just — take the value as a parameter, not a shared variable
+[private]
+_flash bin:
+    esptool ... 0x10000 build/{{bin}}.bin
+
+# project justfile
+import 'shared.just'
+bin_name := "my-app"          # this module's own variable
+flash: (_flash bin_name)      # pass it as an argument
+```
+
 ## MCP Integration (just-mcp)
 
 The `just-mcp` MCP server enables AI assistants to discover and execute justfile recipes through the Model Context Protocol, reducing context waste since the AI doesn't need to read the full justfile.


### PR DESCRIPTION
Adds a **Common Patterns** subsection to the `justfile-expert` skill for a non-obvious `just` gotcha in monorepos that register submodules importing a shared recipe file.

## The gotcha

Hand per-project values to shared imported recipes as recipe **parameters**, not via a shared *variable*:

- An `import` that **defaults** a variable a module also assigns is a **conflict**, not an override: `error: variable X has multiple definitions`.
- An imported recipe referencing `{{X}}` is resolved at **load time**, forcing **every** importing module to define `X` (else `variable X not defined`) — even modules that never run that recipe.

The recipe-parameter form (`flash: (_s3-flash bin_name)`) sidesteps both and keeps the value explicit at the call site.

## Evidence

`laurigates/mcu-tinkering-lab` tooling simplification (PR #406): the `esp32-idf.just` shared flash/build recipes hit **both** errors when `bin_name` was a shared import variable; switching to the recipe-parameter form resolved it. Reusable in any `just` monorepo with shared imports + `mod` registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8QTWXn3To4JtR7rcSfpdK