### PR TITLE
fix(hooks-plugin): ignore tool idioms inside # comments in bash-antipatterns

### DIFF
--- a/hooks-plugin/hooks/bash-antipatterns.sh
+++ b/hooks-plugin/hooks/bash-antipatterns.sh
@@ -15,6 +15,51 @@ if [ -z "$COMMAND" ]; then
     exit 0
 fi
 
+# Strip trailing shell comments (an unquoted `#` at a word boundary through end
+# of line) from the scanned view of the command, so a tool idiom that appears
+# only inside a `# comment` — documentation prose, an explanatory aside such as
+# `python3 … # /tmp is allowed for sed -i` — is not mistaken for an executed
+# command (issue #2106). The detectors below care about what the shell would
+# EXECUTE, and the shell discards comments before executing; this is the same
+# class as the echo/printf quoted-`>` false positives (#1701/#1721/#1722) and
+# the ls demotion (#2036).
+#
+# A `#` starts a comment ONLY when it is at the start of the line OR immediately
+# preceded by whitespace or a shell metacharacter (`;`, `|`, `&`, `(`), AND is
+# not inside single or double quotes. A `#` glued to a preceding word char
+# (`http://x#frag`, `foo#bar`) is part of a token, and a `#` inside quotes
+# (`echo "# not a comment"`) is literal text — neither is stripped. Quote state
+# is tracked per line (a shell comment is a per-line construct), so an unbalanced
+# quote on one line cannot swallow the next. The single-quote character is passed
+# in via -v SQ so the awk program can stay single-quoted for the shell.
+strip_trailing_comments() {
+    printf '%s\n' "$1" | awk -v SQ="'" '
+    {
+        line = $0
+        n = length(line)
+        in_s = 0   # inside single quotes
+        in_d = 0   # inside double quotes
+        cut = 0
+        for (i = 1; i <= n; i++) {
+            c = substr(line, i, 1)
+            if (in_s == 1) {
+                if (c == SQ) in_s = 0
+            } else if (in_d == 1) {
+                if (c == "\"") in_d = 0
+            } else if (c == SQ) {
+                in_s = 1
+            } else if (c == "\"") {
+                in_d = 1
+            } else if (c == "#") {
+                if (i == 1) { cut = i; break }
+                p = substr(line, i - 1, 1)
+                if (p == " " || p == "\t" || p == ";" || p == "|" || p == "&" || p == "(") { cut = i; break }
+            }
+        }
+        if (cut > 0) print substr(line, 1, cut - 1); else print line
+    }'
+}
+
 # Strip heredoc body content up front so detectors that scan the whole command
 # string don't false-positive on literal text inside a heredoc body. The main
 # offender is `gh pr create --body "$(cat <<'EOF' ... EOF)"` whose body may
@@ -42,6 +87,15 @@ COMMAND_SHELL_ONLY=$(echo "$COMMAND" | awk '
         if (t == delim) { ih = 0 }
     }
 ')
+
+# Strip trailing `#` comments from the heredoc-stripped view (issue #2106). Done
+# AFTER heredoc stripping (not before) so comment removal only ever touches the
+# executable command text that survives heredoc stripping — never a heredoc body
+# line (already gone) or its closing delimiter. Because COMMAND_NO_STRINGS and
+# COMMAND_NO_DEVNULL derive from COMMAND_SHELL_ONLY, every idiom detector keyed
+# off those views (head/tail, sed -i, echo/printf → file, cat > file,
+# task-output, git chains) becomes comment-immune in one place.
+COMMAND_SHELL_ONLY=$(strip_trailing_comments "$COMMAND_SHELL_ONLY")
 
 # A further-stripped view with quoted-string literals removed (on top of the
 # heredoc stripping above). Detectors that key off *content tokens* an agent

--- a/hooks-plugin/hooks/test-bash-antipatterns.sh
+++ b/hooks-plugin/hooks/test-bash-antipatterns.sh
@@ -1050,6 +1050,65 @@ assert_exit_complex \
     "GUARD INTEGRITY: ssh heredoc 'chmod 777' still blocked (safety, #1900)" 2 \
     "$ssh_chmod_777"
 
+# ── tool idioms inside `#` comments are ignored (issue #2106) ─────────────────
+# Regression: the detectors scan the command string, so a tool idiom appearing
+# only inside a trailing `# comment` — documentation prose, an explanatory aside
+# — was mistaken for an executed command. The hook now strips unquoted
+# word-boundary `#` comments from the heredoc-stripped view before matching, so
+# an idiom that lives only in a comment passes. Genuine executed idioms and
+# idioms inside QUOTES (which are literal text, not comments) must be unaffected.
+echo ""
+echo "tool idioms inside '#' comments are ignored (issue #2106):"
+
+# Primary repro from the issue: the only `sed -i` token is in a trailing comment.
+assert_exit_complex \
+    "sed -i only inside a trailing '# comment' is allowed (#2106 exact repro)" 0 \
+    "python3 -c \"open('/tmp/x','w').write('hi')\"  # /tmp is allowed for sed -i"
+
+assert_exit \
+    "cat > file only inside a trailing '# comment' is allowed (#2106)" 0 \
+    "echo hi  # example: cat > backup.txt"
+
+assert_exit \
+    "find token only inside a trailing '# comment' is allowed (#2106)" 0 \
+    "echo done  # then find . -name '*.log'"
+
+assert_exit \
+    "head -50 file only inside a trailing '# comment' is allowed (#2106)" 0 \
+    "echo hi  # remember head -50 notes.md"
+
+# Quote protection: a `#` INSIDE quotes is literal text, not a comment. The
+# quoted idiom must NOT be treated as a comment (i.e. the `#` must not truncate
+# the command), and the quoted-string strip then removes it — so this passes.
+assert_exit_complex \
+    "echo \"# has sed -i inside quotes\" is allowed (# inside quotes is not a comment, #2106)" 0 \
+    'echo "# has sed -i inside quotes"'
+
+# Word-boundary: a `#` glued to a preceding non-space char (URL fragment, token)
+# is part of the word, NOT a comment — behaviour is unchanged from a plain word.
+assert_exit_complex \
+    "URL fragment 'foo#sed' (# glued to a word char) is not a comment (#2106)" 0 \
+    'curl "http://example.com/x#sed" | cat'
+
+# GUARD INTEGRITY: a genuine executed `sed -i <file>` still blocks — the comment
+# strip must not weaken any real detection.
+assert_exit \
+    "GUARD INTEGRITY: real sed -i on a repo file still blocked (#2106)" 2 \
+    "sed -i 's/a/b/' src/main.py"
+
+# GUARD INTEGRITY: a real idiom followed by an unrelated trailing comment still
+# blocks — stripping the comment leaves the executed command intact.
+assert_exit \
+    "GUARD INTEGRITY: real sed -i with a trailing comment still blocked (#2106)" 2 \
+    "sed -i 's/a/b/' src/main.py  # fix the typo"
+
+# GUARD INTEGRITY: a `#` inside a double-quoted string must NOT be read as a
+# comment that truncates the command — the real `> script.sh` write after the
+# quoted string still fires the echo/printf → file block.
+assert_exit_complex \
+    "GUARD INTEGRITY: quoted '#' does not hide a real file write after it (#2106)" 2 \
+    'echo "#!/bin/sh" > script.sh'
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## What

The PreToolUse `bash-antipatterns.sh` hook scans the whole Bash command string, so a blocked tool idiom (`sed -i`, `cat > file`, `head`/`tail`, `echo`/`printf` → file, task-output reads, git chains, …) that appears **only inside a trailing `# comment`** was mistaken for an executed command and wrongly blocked (false positive).

## Why

Repro (no `sed -i` is executed, yet the hook blocks with *"Use the Edit tool instead of 'sed -i'"*):

```bash
python3 -c "open('/tmp/x','w').write('hi')"  # /tmp is allowed for sed -i
```

The comment `# … sed -i` is not quoted, so it survives the `COMMAND_NO_STRINGS` quote-strip and the `sed -i` detector fires on it. This is the same false-positive class as the prior echo/printf quoted-`>` fixes (#1701 / #1721 / #1722) and the `ls` demotion (#2036): the detectors care about what the shell would **execute**, and the shell discards comments before executing.

## How

- Add a `strip_trailing_comments` helper — a quote-aware, word-boundary-aware `awk` pass (single-quote char passed via `-v SQ` so the program stays single-quoted for the shell).
- Apply it to `COMMAND_SHELL_ONLY` **after** heredoc stripping (heredoc-first ordering), so comment removal only ever touches surviving executable text — never a heredoc body line (already stripped) or its closing delimiter. `COMMAND_NO_STRINGS` / `COMMAND_NO_DEVNULL` derive from it, so **every** idiom detector keyed off those views becomes comment-immune in one place.
- A `#` is treated as a comment only at a **word boundary** (start of line, or preceded by whitespace / `;` `|` `&` `(`) **and outside** single/double quotes. So `http://x#frag`, `foo#bar`, and `# inside quotes` are left intact; per-line quote tracking means an unbalanced quote can't swallow the next line.
- The `timeout` escape hatch keeps reading the **raw** command, so `# allow-timeout` is unaffected.

This is a false-positive fix on a *style* nudge, not a change to any safety block — the network-pipe-to-shell guard, `chmod 777`, `git add -A`, block-device writes, etc. still fire exactly as before.

## Tests

Added regression cases in `test-bash-antipatterns.sh`:

- `sed -i` / `cat > file` / `find` / `head -50` appearing **only** inside a trailing `# comment` → allowed (the `sed -i` case is the issue's exact repro).
- `echo "# has sed -i inside quotes"` and a glued `foo#sed` URL fragment → the `#` is **not** treated as a comment.
- **Guards**: a real `sed -i <file>` still blocks (with and without an unrelated trailing comment), and a quoted `#` cannot hide a real `> file` write after it (`echo "#!/bin/sh" > script.sh` still blocks).

Full suite: **140 passed / 0 failed** (131 baseline + 9 new). `shellcheck` clean; `scripts/lint-shell-scripts.sh` reports 0 errors.

Closes #2106
