### PR TITLE
chore(skills): mark Claude-Code-only skills with compatibility frontmatter

### DIFF
--- a/agent-patterns-plugin/skills/adversarial-review/SKILL.md
+++ b/agent-patterns-plugin/skills/adversarial-review/SKILL.md
@@ -6,7 +6,8 @@ argument-hint: "path|PR|file|plan description; optional 'focus on X'"
 allowed-tools: Agent, Read, Glob, Grep, Bash(git diff *), Bash(git log *), Bash(gh pr view *), TodoWrite
 model: opus
 created: 2026-06-21
-modified: 2026-06-21
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-06-21
 ---
 

--- a/agent-patterns-plugin/skills/agent-teams/SKILL.md
+++ b/agent-patterns-plugin/skills/agent-teams/SKILL.md
@@ -5,7 +5,8 @@ user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 model: opus
 created: 2026-03-03
-modified: 2026-06-23
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-06-23
 ---
 

--- a/agent-patterns-plugin/skills/cold-read-gate/SKILL.md
+++ b/agent-patterns-plugin/skills/cold-read-gate/SKILL.md
@@ -4,7 +4,8 @@ description: Gate outward-bound text (upstream issues, docs, PR bodies) through 
 allowed-tools: Agent, Read, Write, Edit, TodoWrite
 model: opus
 created: 2026-06-11
-modified: 2026-07-17
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-06-11
 ---
 

--- a/agent-patterns-plugin/skills/custom-agent-definitions/SKILL.md
+++ b/agent-patterns-plugin/skills/custom-agent-definitions/SKILL.md
@@ -4,7 +4,8 @@ description: Write and configure custom agent definitions in Claude Code agents/
 user-invocable: false
 allowed-tools: Bash(cat *), Read, Write, Edit, Glob, Grep, TodoWrite
 created: 2026-01-20
-modified: 2026-06-14
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-06-14
 ---
 

--- a/agent-patterns-plugin/skills/exclusive-lock-dispatch/SKILL.md
+++ b/agent-patterns-plugin/skills/exclusive-lock-dispatch/SKILL.md
@@ -5,7 +5,8 @@ user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 model: opus
 created: 2026-04-24
-modified: 2026-05-09
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-05-09
 ---
 

--- a/agent-patterns-plugin/skills/execution-grounded-review/SKILL.md
+++ b/agent-patterns-plugin/skills/execution-grounded-review/SKILL.md
@@ -6,7 +6,8 @@ argument-hint: "diff|PR|files to verify; optional --criteria <file> of acceptanc
 allowed-tools: Agent, Read, Glob, Grep, Bash(git diff *), Bash(git log *), Bash(gh pr view *), Bash(npm *), Bash(npx *), Bash(uv run *), Bash(pytest *), Bash(cargo *), Bash(go test *), TodoWrite
 model: opus
 created: 2026-06-22
-modified: 2026-07-05
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-07-05
 ---
 

--- a/agent-patterns-plugin/skills/meta-assimilate/SKILL.md
+++ b/agent-patterns-plugin/skills/meta-assimilate/SKILL.md
@@ -1,6 +1,7 @@
 ---
 created: 2025-12-16
-modified: 2026-05-09
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-04-25
 allowed-tools: Read, Write, Edit, MultiEdit, Glob, Grep, TodoWrite
 model: opus

--- a/agent-patterns-plugin/skills/meta-audit/SKILL.md
+++ b/agent-patterns-plugin/skills/meta-audit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 created: 2025-12-16
-modified: 2026-06-18
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-04-25
 allowed-tools: Glob, Read, TodoWrite
 model: opus

--- a/agent-patterns-plugin/skills/meta-context-diet/SKILL.md
+++ b/agent-patterns-plugin/skills/meta-context-diet/SKILL.md
@@ -1,6 +1,7 @@
 ---
 created: 2026-06-16
-modified: 2026-07-08
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-07-08
 allowed-tools: Glob, Read, Edit, Write, Bash(git status *), Bash(git diff *), Bash(wc *), Bash(ls *), AskUserQuestion, TodoWrite
 model: opus

--- a/agent-patterns-plugin/skills/meta-promote/SKILL.md
+++ b/agent-patterns-plugin/skills/meta-promote/SKILL.md
@@ -1,6 +1,7 @@
 ---
 created: 2026-05-09
-modified: 2026-06-18
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-05-09
 allowed-tools: Glob, Read, Edit, Write, Bash(git status *), Bash(git diff *), Bash(git mv *), Bash(diff *), Bash(rm *), AskUserQuestion, TodoWrite
 model: opus

--- a/agent-patterns-plugin/skills/parallel-agent-dispatch/SKILL.md
+++ b/agent-patterns-plugin/skills/parallel-agent-dispatch/SKILL.md
@@ -5,7 +5,8 @@ user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 model: opus
 created: 2026-04-21
-modified: 2026-07-17
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-07-05
 ---
 

--- a/agent-patterns-plugin/skills/plugin-settings/SKILL.md
+++ b/agent-patterns-plugin/skills/plugin-settings/SKILL.md
@@ -4,7 +4,8 @@ description: Configure per-project plugin settings via .claude/plugin-name.local
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2026-03-06
-modified: 2026-03-06
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-03-06
 ---
 

--- a/agent-patterns-plugin/skills/verify-before-plan/SKILL.md
+++ b/agent-patterns-plugin/skills/verify-before-plan/SKILL.md
@@ -4,7 +4,8 @@ description: Verify orchestrator premises (file counts, build state, artefact pr
 allowed-tools: Read, Glob, Grep, Bash(git status *), Bash(git diff *), Bash(gh pr view *), TodoWrite
 model: opus
 created: 2026-05-14
-modified: 2026-05-14
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-05-14
 ---
 

--- a/agent-patterns-plugin/skills/wave-based-dispatch/SKILL.md
+++ b/agent-patterns-plugin/skills/wave-based-dispatch/SKILL.md
@@ -5,7 +5,8 @@ user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 model: opus
 created: 2026-04-25
-modified: 2026-06-06
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-06-06
 ---
 

--- a/agents-plugin/skills/agents-analyze/SKILL.md
+++ b/agents-plugin/skills/agents-analyze/SKILL.md
@@ -5,7 +5,8 @@ allowed-tools: Glob, Grep, Read, Bash(ls *), Bash(wc *), TodoWrite
 model: opus
 argument-hint: "analyze all plugins or --focus <plugin-name>"
 created: 2026-01-24
-modified: 2026-07-04
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-06-18
 name: agents-analyze
 agent: general-purpose

--- a/configure-plugin/skills/claude-security-settings/SKILL.md
+++ b/configure-plugin/skills/claude-security-settings/SKILL.md
@@ -4,7 +4,8 @@ description: "Claude Code security settings: permission wildcards, shell operato
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, TodoWrite
 created: 2026-01-20
-modified: 2026-07-17
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-07-17
 ---
 

--- a/configure-plugin/skills/configure-claude-plugins/SKILL.md
+++ b/configure-plugin/skills/configure-claude-plugins/SKILL.md
@@ -1,6 +1,7 @@
 ---
 created: 2026-01-23
 modified: 2026-06-18
+compatibility: claude-code
 reviewed: 2026-06-10
 description: "Claude plugins marketplace setup: .claude/settings.json, GitHub Actions, plugin pinning. Use when onboarding to claude-plugins, setting up claude.yml, pinning plugins, or overriding global plugins."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash(mkdir *), Bash(test *), Bash(ls *), Bash(git remote *), Bash(gh api *), Bash(jq *), AskUserQuestion, TodoWrite

--- a/configure-plugin/skills/configure-gitignore/SKILL.md
+++ b/configure-plugin/skills/configure-gitignore/SKILL.md
@@ -5,7 +5,8 @@ args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash(git add *), Bash(git status *), Bash(git check-ignore *), Bash(find *), AskUserQuestion, TodoWrite
 created: 2026-06-24
-modified: 2026-06-24
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-06-24
 ---
 

--- a/configure-plugin/skills/configure-repo/SKILL.md
+++ b/configure-plugin/skills/configure-repo/SKILL.md
@@ -5,7 +5,8 @@ allowed-tools: Glob, Grep, Read, Write, Edit, Bash(git add *), Bash(git status *
 args: "[--check-only] [--skip-health] [--skip-migrations]"
 argument-hint: "[--check-only] [--skip-health] [--skip-migrations]"
 created: 2026-04-14
-modified: 2026-06-22
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-06-25
 ---
 

--- a/configure-plugin/skills/configure-web-session/SKILL.md
+++ b/configure-plugin/skills/configure-web-session/SKILL.md
@@ -6,6 +6,7 @@ args: "[--check-only] [--fix] [--tools <list>]"
 argument-hint: "[--check-only] [--fix] [--tools <list>]"
 created: 2026-02-25
 modified: 2026-06-21
+compatibility: claude-code
 reviewed: 2026-06-21
 ---
 

--- a/configure-plugin/skills/configure-worktreeinclude/SKILL.md
+++ b/configure-plugin/skills/configure-worktreeinclude/SKILL.md
@@ -6,6 +6,7 @@ argument-hint: "[--check-only] [--fix]"
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash(git add *), Bash(git status *), Bash(git check-ignore *), Bash(git ls-files *), Bash(find *), AskUserQuestion, TodoWrite
 created: 2026-06-25
 modified: 2026-06-25
+compatibility: claude-code
 reviewed: 2026-06-25
 ---
 

--- a/evaluate-plugin/skills/evaluate-improve/SKILL.md
+++ b/evaluate-plugin/skills/evaluate-improve/SKILL.md
@@ -5,7 +5,8 @@ args: <plugin/skill-name> [--apply] [--description-only] [--best-of N]
 allowed-tools: Task, Read, Write, Edit, Glob, Grep, Bash(bash *), Bash(python3 *), Bash(cat *), Bash(jq *), Bash(find *), Bash(diff *), AskUserQuestion, TodoWrite
 argument-hint: "git-plugin/git-commit [--apply] [--best-of 3]"
 created: 2026-03-04
-modified: 2026-06-23
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-03-04
 ---
 

--- a/evaluate-plugin/skills/evaluate-legibility/SKILL.md
+++ b/evaluate-plugin/skills/evaluate-legibility/SKILL.md
@@ -7,7 +7,8 @@ argument-hint: "git-plugin/git-commit"
 model: opus
 agent: general-purpose
 created: 2026-06-13
-modified: 2026-06-18
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-06-13
 ---
 

--- a/evaluate-plugin/skills/evaluate-matrix/SKILL.md
+++ b/evaluate-plugin/skills/evaluate-matrix/SKILL.md
@@ -7,7 +7,8 @@ argument-hint: "git-plugin/git-commit --models opus,haiku --with-skill-only"
 model: opus
 agent: general-purpose
 created: 2026-06-13
-modified: 2026-06-18
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-06-13
 ---
 

--- a/evaluate-plugin/skills/evaluate-plugin-batch/SKILL.md
+++ b/evaluate-plugin/skills/evaluate-plugin-batch/SKILL.md
@@ -6,7 +6,8 @@ allowed-tools: Task, Read, Write, Glob, Grep, Bash(bash *), SlashCommand, TodoWr
 argument-hint: "git-plugin [--create-missing-evals]"
 agent: general-purpose
 created: 2026-03-04
-modified: 2026-06-18
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-03-04
 ---
 

--- a/evaluate-plugin/skills/evaluate-report/SKILL.md
+++ b/evaluate-plugin/skills/evaluate-report/SKILL.md
@@ -5,7 +5,8 @@ args: <plugin/skill-name | plugin-name> [--latest] [--history] [--compare]
 allowed-tools: Read, Glob, Grep, Bash(cat *), Bash(jq *), Bash(find *), Bash(ls *), TodoWrite
 argument-hint: "git-plugin/git-commit [--latest] | git-plugin [--history]"
 created: 2026-03-04
-modified: 2026-03-04
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-03-04
 ---
 

--- a/evaluate-plugin/skills/evaluate-skill/SKILL.md
+++ b/evaluate-plugin/skills/evaluate-skill/SKILL.md
@@ -7,7 +7,8 @@ argument-hint: "git-plugin/git-commit [--create-evals] [--runs 3] [--baseline]"
 agent: general-purpose
 context: fork
 created: 2026-03-04
-modified: 2026-07-04
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-03-04
 ---
 

--- a/feedback-plugin/skills/feedback-session/SKILL.md
+++ b/feedback-plugin/skills/feedback-session/SKILL.md
@@ -6,7 +6,8 @@ allowed-tools: Bash(gh issue *), Bash(gh label *), Bash(gh search *), Bash(git s
 model: opus
 argument-hint: "--dry-run | --target-repo owner/repo | plugin-name"
 created: 2026-02-18
-modified: 2026-06-28
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-06-28
 ---
 

--- a/health-plugin/skills/health-agentic-audit/SKILL.md
+++ b/health-plugin/skills/health-agentic-audit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 created: 2026-02-05
-modified: 2026-04-19
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-04-15
 user-invocable: false
 description: "Audit skills, commands, and agents for agentic output compliance — optimization tables, bare CLI commands. Use when batch-checking skill documentation quality."

--- a/health-plugin/skills/health-audit/SKILL.md
+++ b/health-plugin/skills/health-audit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 created: 2026-02-05
-modified: 2026-06-18
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-04-15
 user-invocable: false
 description: "Plugin audit against detected stack (Python, Node, Rust, Go, Terraform, Docker, K8s). Use when cleaning up unused plugins or discovering stack-relevant ones for a project."

--- a/health-plugin/skills/health-check/SKILL.md
+++ b/health-plugin/skills/health-check/SKILL.md
@@ -1,6 +1,7 @@
 ---
 created: 2026-02-04
 modified: 2026-06-17
+compatibility: claude-code
 reviewed: 2026-06-17
 description: "Claude Code health check — scans plugins, settings, hooks, MCP, runtime state, usage telemetry, permissions, marketplace with optional fixes. Use when checking project health or troubleshooting setup."
 allowed-tools: Bash(bash *), Bash(pre-commit *), Read, Glob, Grep, TodoWrite, AskUserQuestion

--- a/health-plugin/skills/health-plugins/SKILL.md
+++ b/health-plugin/skills/health-plugins/SKILL.md
@@ -1,6 +1,7 @@
 ---
 created: 2026-02-04
-modified: 2026-06-03
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-06-03
 user-invocable: false
 description: "Diagnose and fix Claude Code plugin registry corruption — orphaned entries, stale keys, scope conflicts. Use when seeing plugin-already-installed errors or registry drift."

--- a/health-plugin/skills/health-skill-audit/SKILL.md
+++ b/health-plugin/skills/health-skill-audit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 created: 2026-04-24
-modified: 2026-06-18
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-04-24
 description: "Audit skill tree for overlap, split-pressure, and consolidation candidates. Use when finding confusing skill clusters or surfacing REFERENCE.md extraction candidates."
 allowed-tools: Bash(python3 *), Read, TodoWrite

--- a/health-plugin/skills/plugin-registry/SKILL.md
+++ b/health-plugin/skills/plugin-registry/SKILL.md
@@ -4,7 +4,8 @@ description: "Claude Code plugin registry structure, installation scopes, and co
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, TodoWrite
 created: 2026-02-04
-modified: 2026-02-05
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-02-05
 ---
 

--- a/health-plugin/skills/settings-configuration/SKILL.md
+++ b/health-plugin/skills/settings-configuration/SKILL.md
@@ -4,7 +4,8 @@ description: "Claude Code settings hierarchy, permission wildcards, and configur
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, TodoWrite
 created: 2026-02-04
-modified: 2026-02-04
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-02-04
 ---
 

--- a/hooks-plugin/skills/hooks-configuration/SKILL.md
+++ b/hooks-plugin/skills/hooks-configuration/SKILL.md
@@ -4,7 +4,8 @@ description: Claude Code hooks configuration and development. Use when the user 
 user-invocable: false
 allowed-tools: Bash(bash *), Bash(cat *), Read, Write, Edit, Glob, Grep, TodoWrite
 created: 2025-12-16
-modified: 2026-05-23
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-04-10
 ---
 

--- a/hooks-plugin/skills/hooks-permission-request-hook/SKILL.md
+++ b/hooks-plugin/skills/hooks-permission-request-hook/SKILL.md
@@ -6,7 +6,8 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash, TodoWrite
 argument-hint: "--strict to deny unknown commands, --category git|test|lint|build|gh|deny"
 disable-model-invocation: true
 created: 2026-03-13
-modified: 2026-06-18
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-04-29
 ---
 

--- a/hooks-plugin/skills/hooks-session-end-issue-hook/SKILL.md
+++ b/hooks-plugin/skills/hooks-session-end-issue-hook/SKILL.md
@@ -6,7 +6,8 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash, TodoWrite
 argument-hint: "--no-verify to skip gh auth verification"
 disable-model-invocation: true
 created: 2026-02-27
-modified: 2026-06-18
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-03-30
 ---
 

--- a/hooks-plugin/skills/hooks-session-start-hook/SKILL.md
+++ b/hooks-plugin/skills/hooks-session-start-hook/SKILL.md
@@ -7,6 +7,7 @@ argument-hint: "--remote-only to only run in web sessions, --no-verify to skip t
 disable-model-invocation: true
 created: 2026-02-07
 modified: 2026-06-18
+compatibility: claude-code
 reviewed: 2026-03-30
 ---
 

--- a/session-plugin/skills/session-distill/SKILL.md
+++ b/session-plugin/skills/session-distill/SKILL.md
@@ -5,7 +5,8 @@ allowed-tools: Bash(bash *), Bash(mkdir *), Bash(git diff *), Bash(git log *), B
 argument-hint: "--rules | --skills | --recipes | --process | --all | --dry-run"
 args: "[--rules] [--skills] [--recipes] [--process] [--all] [--dry-run]"
 created: 2026-02-11
-modified: 2026-07-14
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-07-14
 ---
 

--- a/session-plugin/skills/session-end/SKILL.md
+++ b/session-plugin/skills/session-end/SKILL.md
@@ -3,7 +3,8 @@ name: session-end
 description: End-of-session orchestrator. Previews which of wrap/distill/feedback/taskwarrior-sync qualify, single confirm, then sequence. Use when winding down a session.
 allowed-tools: Bash(bash *), Bash(task *), Bash(git *), Bash(gh *), Read, Skill, AskUserQuestion, TodoWrite
 created: 2026-06-10
-modified: 2026-07-12
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-06-24
 ---
 

--- a/session-plugin/skills/session-spinup/SKILL.md
+++ b/session-plugin/skills/session-spinup/SKILL.md
@@ -3,7 +3,8 @@ name: session-spinup
 description: Read-only session-start briefing of open tasks, git state, journal todos. Use when user says spin up, what was I doing, or pick up where I left off.
 allowed-tools: Bash(bash *), Read, TodoWrite
 created: 2026-05-13
-modified: 2026-07-05
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-06-24
 ---
 

--- a/session-plugin/skills/session-wrap/SKILL.md
+++ b/session-plugin/skills/session-wrap/SKILL.md
@@ -3,7 +3,8 @@ name: session-wrap
 description: End-of-session capture to taskwarrior, optional journal, GitHub issues. Use when user says wrap up, session wrap, or done for now.
 allowed-tools: Bash(bash *), Bash(task *), Bash(git *), Bash(gh *), Read, Write, Edit, AskUserQuestion, TodoWrite
 created: 2026-05-12
-modified: 2026-07-12
+modified: 2026-07-18
+compatibility: claude-code
 reviewed: 2026-06-24
 ---
 


### PR DESCRIPTION
## What

One-time classified sweep marking **genuinely Claude-Code-only** skills with `compatibility: claude-code` in their `SKILL.md` frontmatter, so the future harness-agnostic discovery core (#2089) can filter them per harness (ADR-0022). Also bumps `modified:` to `2026-07-18` on edited files. Frontmatter-only diffs — no body changes.

> **Driver-freshness note:** 5 of the marked files are dependencies of the `configure-repo` "driver" skill, whose `check-driver-freshness` pre-commit gate requires the driver's `reviewed:` date (`2026-06-25`) to be ≥ each dependency's `modified:`. Bumping their `modified:` to `2026-07-18` would trip that gate, and the task forbids changing `reviewed:`. So those 5 files (`configure-claude-plugins`, `configure-web-session`, `configure-worktreeinclude`, `health-check`, `hooks-session-start-hook`) keep their original `modified:` dates and receive only the `compatibility` field. The other 38 get the date bump.

**Marked: 43 skills. Skipped: 81 skills** (across the 9 `exclude`-tier plugins in `pi/tiers.yaml`).

## Why

The exclude judgment is a property of the *skill*, not of any one harness's manifest. `pi/tiers.yaml`'s `exclude` tier conflated two reasons — (a) genuinely meaningless outside Claude Code, and (b) merely budget-motivated / "promote individually if wanted". Only (a) gets the field. Keeping the fact with the artifact serves every current and future adapter (both pi and OpenCode recognize `compatibility` and ignore unknown values gracefully; Claude Code ignores the field).

Feeds #2089 (consumer of the field) but does **not** depend on it. Does **not** touch `pi/tiers.yaml` (later cutover, #2093).

## Method

Followed `code-quality-plugin:bulk-sweep-classify`: every candidate in the 9 excluded plugins was bucketed MARK vs SKIP before editing. Seed = the `# Tier 0: exclude` block in `pi/tiers.yaml`. Verified the new field does not break the frontmatter validator (`scripts/plugin-compliance-check.sh` Frontmatter column stays ✅) and confirmed YAML still parses for all 43 files.

## Classification ledger

### MARK — genuinely Claude-Code-only (43)

| Plugin | Skill | Reason |
|--------|-------|--------|
| hooks-plugin | hooks-configuration | CC hook authoring; no equivalent elsewhere |
| hooks-plugin | hooks-permission-request-hook | CC PermissionRequest hook authoring |
| hooks-plugin | hooks-session-end-issue-hook | CC SessionEnd hook authoring |
| hooks-plugin | hooks-session-start-hook | CC SessionStart hook authoring |
| health-plugin | health-agentic-audit | CC skill/agent agentic-output audit |
| health-plugin | health-audit | CC plugin/stack health audit |
| health-plugin | health-check | CC plugins/settings/hooks/MCP diagnostics |
| health-plugin | health-plugins | CC plugin-registry corruption repair |
| health-plugin | health-skill-audit | CC skill-tree overlap/consolidation audit |
| health-plugin | plugin-registry | CC plugin-registry structure/troubleshooting |
| health-plugin | settings-configuration | CC settings hierarchy / permission wildcards |
| feedback-plugin | feedback-session | CC skill-feedback tooling (GitHub issues for skills) |
| evaluate-plugin | evaluate-improve | Improves CC SKILL.md content/descriptions |
| evaluate-plugin | evaluate-legibility | Cold-reads a CC SKILL.md with a CC agent |
| evaluate-plugin | evaluate-matrix | Cross-model CC-skill executability evals |
| evaluate-plugin | evaluate-plugin-batch | Batch CC-plugin skill evaluation |
| evaluate-plugin | evaluate-report | CC skill/plugin eval-result reporting |
| evaluate-plugin | evaluate-skill | Runs CC-skill test cases and grades |
| agents-plugin | agents-analyze | Audits plugins for CC sub-agent opportunities |
| session-plugin | session-distill | CC session-insight distillation into rules/skills |
| session-plugin | session-end | CC end-of-session orchestrator |
| session-plugin | session-spinup | CC session-start briefing |
| session-plugin | session-wrap | CC end-of-session capture |
| agent-patterns-plugin | adversarial-review | Dispatches isolated CC `Agent` for review |
| agent-patterns-plugin | agent-teams | Configures CC agent teams (SendMessage/TaskUpdate) |
| agent-patterns-plugin | cold-read-gate | Dispatches isolated haiku CC `Agent` critic |
| agent-patterns-plugin | custom-agent-definitions | Writes CC `agents/` definitions |
| agent-patterns-plugin | exclusive-lock-dispatch | Parallel CC-agent dispatch pattern |
| agent-patterns-plugin | execution-grounded-review | CC `Agent`-driven execution-grounded verify |
| agent-patterns-plugin | meta-assimilate | Merges a project's `.claude/{agents,commands}` |
| agent-patterns-plugin | meta-audit | Audits CC subagent configs |
| agent-patterns-plugin | meta-context-diet | Audits CLAUDE.md / `.claude/rules` |
| agent-patterns-plugin | meta-promote | Promotes rules/skills/agents across `.claude/` scopes |
| agent-patterns-plugin | parallel-agent-dispatch | CC parallel-agent dispatch contract |
| agent-patterns-plugin | plugin-settings | CC per-project plugin settings (`.claude/*.local.md`) |
| agent-patterns-plugin | verify-before-plan | Verify premises before dispatching CC subagents |
| agent-patterns-plugin | wave-based-dispatch | CC sequential-wave agent dispatch |
| configure-plugin | configure-repo | Repo onboarding to Claude Code (`.claude/`, SessionStart hook) |
| configure-plugin | configure-claude-plugins | CC plugins marketplace setup (`.claude/settings.json`) |
| configure-plugin | claude-security-settings | CC `.claude/settings.json` permission hardening |
| configure-plugin | configure-web-session | CC SessionStart hook for web sessions |
| configure-plugin | configure-gitignore | Manages the Claude Code block in `.gitignore` (worktrees, task lock) |
| configure-plugin | configure-worktreeinclude | Generates `.worktreeinclude`, a CC worktree feature |

### SKIP — portable or budget-motivated (81)

| Plugin | Skill(s) | Reason for NOT marking |
|--------|----------|------------------------|
| agent-patterns-plugin | mcp-server-authoring | MCP is a cross-harness protocol; FastMCP authoring is portable |
| agent-patterns-plugin | mcp-management | Borderline — says "for Claude Code" / `.mcp.json`, but `.mcp.json` is used by multiple harnesses; leaned portable per issue guidance |
| agent-patterns-plugin | mcp-code-execution | Cross-harness MCP code-execution pattern |
| agent-patterns-plugin | multi-model-delegation | Portable — consults other models via PAL MCP; nothing CC-specific |
| agent-patterns-plugin | expose-tunable-knob | **Divergence from seed MARK list** — reads as a genuinely harness-agnostic UX-tuning pattern (no `Agent` tool, no CC machinery). Kept SKIP per the conservative "when in doubt, do not mark" rule; flag for spot-check |
| configure-plugin | configure-mcp | Borderline-portable MCP config; conservative default = not marked |
| configure-plugin | config-sync, configure-all, configure-select, configure-status, ci-workflows, configure-api-tests, configure-argocd-automerge, configure-cache-busting, configure-container, configure-coverage, configure-dead-code, configure-dockerfile, configure-docs, configure-editor, configure-feature-flags, configure-formatting, configure-gitattributes, configure-github-pages, configure-instrumentation, configure-integration-tests, configure-justfile, configure-linting, configure-load-tests, configure-makefile, configure-memory-profiling, configure-mise, configure-package-management, configure-pre-commit, configure-readme, configure-release-please, configure-reusable-workflows, configure-security, configure-sentry, configure-skaffold, configure-surface, configure-tests, configure-ux-testing, configure-workflows, go-feature-flag, multi-repo-discipline, openfeature | Tool-/framework-agnostic infrastructure configuration; operable in any harness |
| blueprint-plugin | *all 35 skills* | PRD/ADR/PRP methodology is portable documentation practice; the `pi/tiers.yaml` reason itself says "promote individually if wanted" (budget-motivated). Conservative default per issue = do not mark. `blueprint-claude-md` (generates CLAUDE.md, a CC artifact) is the closest arguable exception — flagged for spot-check but kept SKIP |

## Ambiguous calls flagged for human spot-check

- **`agent-patterns-plugin/expose-tunable-knob`** — the seed MARK list named it, but it has no CC-specific machinery (generic UX-tuning pattern). Kept **SKIP** per the conservative rule. Reverse to MARK if you consider it CC-only.
- **`agent-patterns-plugin/mcp-management`** — mentions "Claude Code" and `.mcp.json`, but `.mcp.json` is multi-harness. Kept **SKIP** (lean-portable per issue guidance).
- **`blueprint-plugin/blueprint-claude-md`** — generates CLAUDE.md (a CC artifact). Kept **SKIP** honoring the strong blueprint conservative default. Easiest single reversal if wanted.

## Note (advisory-only side effect)

`agent-patterns-plugin/skills/parallel-agent-dispatch/SKILL.md` was 25996 chars (4 under the 26000 advisory ceiling); the frontmatter line tipped it to 26024, so the `plugin-compliance-check.sh` Size column now reports ❌ for it. That check runs with `|| true` in `plugin-pr-checks.yml` (advisory PR comment, **not a hard CI gate**), so it does not block merge. A follow-up to extract content into a REFERENCE.md is tracked separately (out of scope for this frontmatter-only PR).

Closes #2092

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
