### PR TITLE
feat(skill-catalog-routing): domain-preserving variants + cross-model sweep

### DIFF
--- a/experiments/skill-catalog-routing/FINDINGS.md
+++ b/experiments/skill-catalog-routing/FINDINGS.md
@@ -77,3 +77,52 @@ their ~16.5k tokens specifically on near-miss and opaque-named skills. Shorter
 descriptions can likely recover most of that benefit **only if they preserve the
 capability/domain phrase** rather than the `Use when` trigger tail — the single
 most useful follow-up this experiment points to.
+
+---
+
+# Follow-up: domain-preserving shortening (haiku)
+
+The prediction above is **confirmed**. Run `haiku-ladder2` (all 70 tasks, 2 runs,
+980 transcripts, 0 parse failures) added domain-first variants token-matched to
+the trigger-first ones:
+
+| arm | catalog | tokens | top-1 | near-miss | false-trigger |
+|-----|---------|--------|-------|-----------|---------------|
+| C1 | names | 27.3k | 0.83 | 0.82 | 0.07 |
+| C2 | short (trigger, ≤40c) | 30.3k | 0.90 | 0.85 | 0.10 |
+| **C2d** | **domain-short (≤40c)** | 31.0k | 0.89 | 0.90 | 0.10 |
+| C3 | medium (trigger, ≤80c) | 34.1k | 0.91 | 0.88 | 0.07 |
+| **C3d** | **domain-medium (≤80c)** | 33.8k | **0.97** | **0.95** | **0.03** |
+| C5 | compact (domain head + `Use when`, ≤80c) | 34.6k | 0.95 | 0.93 | 0.05 |
+| C4 | full | 43.8k | 0.99 | 1.00 | 0.05 |
+
+**Domain-first vs trigger-first at equal budget:**
+
+- **~80c: domain-first wins decisively.** `C3d` (domain-medium) hits **0.97 top-1
+  / 0.95 near-miss** vs `C3` (trigger-medium) **0.91 / 0.88** — +0.06 top-1,
+  +0.07 near-miss — and it does so at **half the tokens of the full description**
+  (33.8k vs 43.8k) while landing within 0.02 of full's 0.99. `C3d` also has the
+  **lowest false-trigger rate of any arm (0.03)** — keeping the capability phrase
+  both routes better *and* over-triggers less.
+- **~40c: roughly tied on top-1** (`C2` 0.90 vs `C2d` 0.89), but domain-first
+  already wins on near-miss discrimination (0.90 vs 0.85). At 40 chars there isn't
+  room for the capability phrase to fully pay off.
+
+**Compact (`C5`)** — a compressed capability head *plus* a `Use when` trigger, so
+it stays valid for the real auto-invocation matcher (#1278) — reaches 0.95, just
+below pure domain-medium. For a **production** description the recommendation is
+`C5`-shaped (keep the `Use when` literal); for pure routing signal, the capability
+phrase alone (`C3d`) is marginally stronger.
+
+## The answer to "how short can descriptions be — could shorter be better?"
+
+On haiku: **a ~80-char description that keeps the capability/domain phrase
+(`C3d`/`C5`) recovers ~all of the full description's routing benefit at roughly
+half the token cost, and lowers false-triggering.** The earlier "descriptions
+barely help" pilot reading and the "trigger-only short descriptions underperform"
+ladder reading are both resolved: descriptions help a lot, but the *content* that
+matters is the capability phrase, not the `Use when` trigger tail. "Shorter is
+better" holds — provided you shorten toward the domain, not the trigger.
+
+_Cross-model (sonnet/opus) portability results follow when the `xmodel` run
+completes._

--- a/experiments/skill-catalog-routing/FINDINGS.md
+++ b/experiments/skill-catalog-routing/FINDINGS.md
@@ -124,5 +124,65 @@ ladder reading are both resolved: descriptions help a lot, but the *content* tha
 matters is the capability phrase, not the `Use when` trigger tail. "Shorter is
 better" holds — provided you shorten toward the domain, not the trigger.
 
-_Cross-model (sonnet/opus) portability results follow when the `xmodel` run
-completes._
+---
+
+# Follow-up: cross-model portability (sonnet + opus)
+
+Run `xmodel` (sonnet + opus on C0, C1, C2d, C5, C4 × 70 tasks × 2 runs, 1400
+transcripts, 0 parse failures), placed beside the haiku numbers:
+
+| arm | catalog | tokens | haiku | sonnet | opus |
+|-----|---------|--------|-------|--------|------|
+| C0 | none | 23.1k | 0.00* | 0.00 | 0.00 |
+| C1 | names | 27.3k | 0.83 | 0.65 | 0.88 |
+| C2d | domain-short | 31.0k | 0.89 | 0.64 | 0.93 |
+| C5 | compact | 34.6k | 0.95 | 0.70 | 0.95 |
+| C4 | full | 43.8k | 0.99 | 0.72 | 0.98 |
+
+_(top-1 routing accuracy; *haiku C0 = 0 established in the prior ladder, not
+re-run here.)_
+
+## What it establishes
+
+1. **The catalog is mandatory on every model.** C0 = 0.00 for sonnet and opus
+   too — no model can emit valid skill ids from memory without the listing.
+
+2. **Description value shrinks on the stronger model (the portability signal).**
+   The full-minus-names delta `C4 − C1` is **+0.16 on haiku, +0.10 on opus** —
+   opus recovers more from names alone (C1 = 0.88 vs haiku 0.83), so it leans
+   less on the descriptions. This is the expected direction: the weaker the
+   model, the more the description earns its tokens.
+
+3. **The domain/compact recommendation holds across the whole capability range.**
+   Compact `C5` lands within **0.02–0.04 of full** on every model (haiku
+   0.95 vs 0.99, sonnet 0.70 vs 0.72, opus 0.95 vs 0.98) at ~half the tokens, and
+   `C2d` recovers most of the gap at ~40% of the tokens. "Shorten toward the
+   capability phrase" is a **model-independent** recommendation.
+
+## The sonnet anomaly (honest caveat)
+
+Sonnet's absolute top-1 is low across the board (0.72 even at full) — but **not
+because it misroutes**. It **over-abstains**: it answered `NONE` on **26% of
+route tasks** (where a skill genuinely applies), while abstaining *perfectly* on
+the true-`NONE` set (abstain 1.00, false-trigger 0.00) and keeping the gold skill
+in its **top-2 at 0.95**. This is the router prompt's "prefer NONE over a weak
+match" instruction interacting with sonnet's calibration at `low` effort — it
+declines to commit when uncertain. The effect depresses sonnet's absolute
+numbers but **preserves the relative arm ordering** (C0 = 0 ≪ C1 < C2d < C5 ≈
+C4), so the portability and shortening conclusions still read cleanly off the
+deltas. It is a real behavioral difference between models, not a harness bug —
+and a caution that a forced-choice router's absolute accuracy is entangled with
+each model's abstention temperament.
+
+## Bottom line (both follow-ups)
+
+- **How short can descriptions be?** ~80 chars, if they keep the capability
+  phrase — `C3d`/`C5` recover ~all of full's routing benefit at half the tokens,
+  on every model tested.
+- **Could shorter be better?** Yes: the domain-preserving short forms are cheaper
+  **and** (on haiku) over-trigger less than full.
+- **Keep the trigger for production.** `C5` keeps the literal `Use when` the real
+  auto-invocation matcher needs (#1278) and is within 0.02–0.04 of full
+  everywhere — the recommended description shape.
+- **Weaker models benefit most** from descriptions; strong models route well from
+  names + a short capability phrase.

--- a/experiments/skill-catalog-routing/README.md
+++ b/experiments/skill-catalog-routing/README.md
@@ -25,9 +25,19 @@ sees. Each shorter band is a genuine token-subset of the next.
 |-----|---------|-------------------|------|
 | C0 | none (task only) | 0 | null control (free-recall) |
 | C1 | names only | ~4.2k | isolates the value of descriptions |
-| C2 | names + `Use when <first trigger>` ≤40c | measured | minimal trigger |
-| C3 | names + `Use when <triggers>` ≤80c | measured | mid |
+| C2 | names + `Use when <first trigger>` ≤40c | ~7.2k | minimal trigger (trigger-first) |
+| C2d | names + capability phrase ≤40c | ~7.9k | domain-first, token-matched to C2 |
+| C3 | names + `Use when <triggers>` ≤80c | ~11.0k | mid (trigger-first) |
+| C3d | names + capability phrase ≤80c | ~10.8k | domain-first, token-matched to C3 |
+| C5 | names + capability head + `Use when <trigger>` ≤80c | ~11.5k | compact best-of-both (keeps `Use when`) |
 | C4 | names + full description (current) | ~20.7k | upper anchor (status quo) |
+
+The `C2d`/`C3d`/`C5` arms are the **domain-preserving** follow-up: the haiku
+ladder showed trigger-only shortening (`C2`/`C3`) stalls because it drops the
+leading capability/domain phrase. `C2d`/`C3d` keep that phrase instead (dropping
+the `Use when` tail) at equal budget; `C5` keeps a compressed capability head
+**plus** a `Use when` trigger so it also stays valid for the real auto-invocation
+matcher. `build-catalogs.py` emits all seven catalog variants.
 
 **Measured base**: a router with no catalog costs ~23k input tokens (the user's
 global `~/.claude` memory, a fixed additive constant across all arms). Adding the

--- a/experiments/skill-catalog-routing/catalogs/catalog.compact.json
+++ b/experiments/skill-catalog-routing/catalogs/catalog.compact.json
@@ -1,0 +1,1631 @@
+{
+  "variant": "compact",
+  "source_sha": "0ed1791a1abb10ba687ae115adf637b9f5b9cc59",
+  "skill_count": 406,
+  "entries": [
+    {
+      "id": "accessibility-plugin/accessibility-implementation",
+      "line": "accessibility-plugin/accessibility-implementation: WCAG 2.1/2.2 compliance, ARIA patterns: Use when implementing accessible"
+    },
+    {
+      "id": "accessibility-plugin/design-tokens",
+      "line": "accessibility-plugin/design-tokens: Design tokens and CSS custom properties: Use when implementing design systems"
+    },
+    {
+      "id": "agent-patterns-plugin/adversarial-review",
+      "line": "agent-patterns-plugin/adversarial-review: Adversarial second-pass review that tries: Use when stakes are high and a normal"
+    },
+    {
+      "id": "agent-patterns-plugin/agent-teams",
+      "line": "agent-patterns-plugin/agent-teams: Configure Claude Code agent teams (implicit: Use when running parallel agents"
+    },
+    {
+      "id": "agent-patterns-plugin/cold-read-gate",
+      "line": "agent-patterns-plugin/cold-read-gate: Gate outward-bound text (upstream issues: Use when an artifact must survive"
+    },
+    {
+      "id": "agent-patterns-plugin/custom-agent-definitions",
+      "line": "agent-patterns-plugin/custom-agent-definitions: Write and configure custom agent: Use when creating an agent .md file"
+    },
+    {
+      "id": "agent-patterns-plugin/exclusive-lock-dispatch",
+      "line": "agent-patterns-plugin/exclusive-lock-dispatch: Pre-dump-then-dispatch for tools holding: Use when fanning out parallel agents"
+    },
+    {
+      "id": "agent-patterns-plugin/execution-grounded-review",
+      "line": "agent-patterns-plugin/execution-grounded-review: Execution-grounded review: run tests: Use when verifying an implementation"
+    },
+    {
+      "id": "agent-patterns-plugin/expose-tunable-knob",
+      "line": "agent-patterns-plugin/expose-tunable-knob: Expose a live-adjustable control instead of guessing: Use when tuning visual"
+    },
+    {
+      "id": "agent-patterns-plugin/mcp-code-execution",
+      "line": "agent-patterns-plugin/mcp-code-execution: Scaffold the code execution pattern: Use when agents call many MCP tools"
+    },
+    {
+      "id": "agent-patterns-plugin/mcp-management",
+      "line": "agent-patterns-plugin/mcp-management: Install and configure MCP servers for Claude: Use when adding/enabling servers"
+    },
+    {
+      "id": "agent-patterns-plugin/mcp-server-authoring",
+      "line": "agent-patterns-plugin/mcp-server-authoring: FastMCP authoring for Python MCP servers \u2014 tools, resources: Use when building"
+    },
+    {
+      "id": "agent-patterns-plugin/meta-assimilate",
+      "line": "agent-patterns-plugin/meta-assimilate: Copy, generalize, or merge a project's: Use when assimilating another project's"
+    },
+    {
+      "id": "agent-patterns-plugin/meta-audit",
+      "line": "agent-patterns-plugin/meta-audit: Audit Claude subagent configs: Use when reviewing agents/ for missing"
+    },
+    {
+      "id": "agent-patterns-plugin/meta-context-diet",
+      "line": "agent-patterns-plugin/meta-context-diet: Audit CLAUDE.md and .claude/rules: Use when CLAUDE.md feels bloated"
+    },
+    {
+      "id": "agent-patterns-plugin/meta-promote",
+      "line": "agent-patterns-plugin/meta-promote: Promote rules, skills, or agents from project: Use when reorganizing .claude/"
+    },
+    {
+      "id": "agent-patterns-plugin/multi-model-delegation",
+      "line": "agent-patterns-plugin/multi-model-delegation: Multi-model design consults via PAL (kimi, glm: Use when asking other models"
+    },
+    {
+      "id": "agent-patterns-plugin/parallel-agent-dispatch",
+      "line": "agent-patterns-plugin/parallel-agent-dispatch: Dispatch contract for spawning parallel: Use when fanning out concurrent agents"
+    },
+    {
+      "id": "agent-patterns-plugin/plugin-settings",
+      "line": "agent-patterns-plugin/plugin-settings: Configure per-project plugin settings via: Use when building plugins"
+    },
+    {
+      "id": "agent-patterns-plugin/verify-before-plan",
+      "line": "agent-patterns-plugin/verify-before-plan: Verify orchestrator premises (file: Use when a wave's briefs cite a number"
+    },
+    {
+      "id": "agent-patterns-plugin/wave-based-dispatch",
+      "line": "agent-patterns-plugin/wave-based-dispatch: Sequential-wave dispatch for WO chains: Use when planning dependent multi-WO"
+    },
+    {
+      "id": "agents-plugin/agents-analyze",
+      "line": "agents-plugin/agents-analyze: Audit plugins for sub-agent opportunities: Use when reviewing where sub-agents"
+    },
+    {
+      "id": "api-plugin/api-testing",
+      "line": "api-plugin/api-testing: HTTP API testing with Supertest (TS): Use when the user mentions API testing"
+    },
+    {
+      "id": "bevy-plugin/bevy-ecs-patterns",
+      "line": "bevy-plugin/bevy-ecs-patterns: Advanced Bevy ECS: complex queries: Use when optimizing Bevy architecture"
+    },
+    {
+      "id": "bevy-plugin/bevy-game-engine",
+      "line": "bevy-plugin/bevy-game-engine: Bevy game engine: ECS, rendering, input, and asset: Use when building Bevy games"
+    },
+    {
+      "id": "blog-plugin/blog-post",
+      "line": "blog-plugin/blog-post: Create a blog post via guided prompts with git: Use when writing a quick update"
+    },
+    {
+      "id": "blog-plugin/blog-post-writing",
+      "line": "blog-plugin/blog-post-writing: Style guide for technical blog posts: Use when writing about work done"
+    },
+    {
+      "id": "blueprint-plugin/adr-relationships",
+      "line": "blueprint-plugin/adr-relationships: Domain analysis, conflict detection, and relationship: Use when creating"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-adr-list",
+      "line": "blueprint-plugin/blueprint-adr-list: List ADRs as a markdown table with title: Use when generating an ADR index"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-adr-validate",
+      "line": "blueprint-plugin/blueprint-adr-validate: Validate ADR relationships, domain: Use when auditing ADRs before release"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-autonomy-level3",
+      "line": "blueprint-plugin/blueprint-autonomy-level3: Install blueprint autonomy level 3: Use when enabling out-of-band blueprint"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-autopilot",
+      "line": "blueprint-plugin/blueprint-autopilot: Run due blueprint maintenance: Use when a drift nudge reports blueprint"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-claude-md",
+      "line": "blueprint-plugin/blueprint-claude-md: Generate or update CLAUDE.md from blueprint: Use when adding team instructions"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-curate-docs",
+      "line": "blueprint-plugin/blueprint-curate-docs: Curate library gotchas and project: Use when documenting library knowledge"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-derive-plans",
+      "line": "blueprint-plugin/blueprint-derive-plans: Derive PRDs, ADRs, PRPs from git history, docs: Use when onboarding a project"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-derive-rules",
+      "line": "blueprint-plugin/blueprint-derive-rules: Derive Claude rules from git commit: Use when extracting implicit decisions"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-derive-tests",
+      "line": "blueprint-plugin/blueprint-derive-tests: Derive test regression plans from git: Use when finding untested bug fixes"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-development",
+      "line": "blueprint-plugin/blueprint-development: Generate project-specific rules from PRDs: Use when generating architecture"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-docs-currency",
+      "line": "blueprint-plugin/blueprint-docs-currency: Enforce same-commit landing of code: Use when committing API/format changes"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-docs-list",
+      "line": "blueprint-plugin/blueprint-docs-list: List blueprint documents (ADRs, PRDs, PRPs): Use when listing docs"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-execute",
+      "line": "blueprint-plugin/blueprint-execute: Blueprint meta command: determine and execute: Use when asked 'what's next?'"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-feature-tracker-status",
+      "line": "blueprint-plugin/blueprint-feature-tracker-status: Display feature tracker stats, phase progress: Use when checking feature status"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-feature-tracker-sync",
+      "line": "blueprint-plugin/blueprint-feature-tracker-sync: Sync feature tracker with TODO.md: Use when reconciling TODO.md vs tracker"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-generate-rules",
+      "line": "blueprint-plugin/blueprint-generate-rules: Generate project-specific rules from PRDs: Use when auto-creating architecture"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-init",
+      "line": "blueprint-plugin/blueprint-init: Initialize Blueprint Development: Use when bootstrapping docs/blueprint/"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-migration",
+      "line": "blueprint-plugin/blueprint-migration: Versioned migration procedures for blueprint: Use when blueprint-upgrade needs"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-promote",
+      "line": "blueprint-plugin/blueprint-promote: Move generated artifact to custom layer: Use when promoting a generated rule"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-prp-create",
+      "line": "blueprint-plugin/blueprint-prp-create: Create a PRP (Product Requirement Prompt): Use when planning a feature packet"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-prp-execute",
+      "line": "blueprint-plugin/blueprint-prp-execute: Execute a PRP with validation loop, TDD: Use when asked to execute a PRP"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-rules",
+      "line": "blueprint-plugin/blueprint-rules: Manage modular rules in .claude/rules/ with path-specific globs: Use when adding"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-status",
+      "line": "blueprint-plugin/blueprint-status: Show blueprint version, config, PRD/ADR/PRP: Use when auditing traceability"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-story-audit",
+      "line": "blueprint-plugin/blueprint-story-audit: Audit user stories against codebase and tests: Use when running story audit"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-story-reconcile",
+      "line": "blueprint-plugin/blueprint-story-reconcile: Reconcile PRD requirements with a story-audit: Use when marking PRD entries"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-sync",
+      "line": "blueprint-plugin/blueprint-sync: Check for stale generated content: Use when syncing blueprint after PRD"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-sync-ids",
+      "line": "blueprint-plugin/blueprint-sync-ids: Scan blueprint docs and assign missing: Use when assigning IDs to docs"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-upgrade",
+      "line": "blueprint-plugin/blueprint-upgrade: Upgrade blueprint structure to the latest: Use when migrating between format"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-work-order",
+      "line": "blueprint-plugin/blueprint-work-order: Create a work-order for isolated: Use when breaking a PRP into delegatable"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-workspace-scan",
+      "line": "blueprint-plugin/blueprint-workspace-scan: Discover child blueprint workspaces: Use when adding/removing a child"
+    },
+    {
+      "id": "blueprint-plugin/confidence-scoring",
+      "line": "blueprint-plugin/confidence-scoring: Assess quality of PRPs and work-orders using: Use when evaluating readiness"
+    },
+    {
+      "id": "blueprint-plugin/document-detection",
+      "line": "blueprint-plugin/document-detection: Detect PRD/ADR/PRP opportunities: Use when the user discusses feature"
+    },
+    {
+      "id": "blueprint-plugin/document-linking",
+      "line": "blueprint-plugin/document-linking: Unified ID system for PRDs, ADRs, PRPs, and GitHub issues: Use when linking docs"
+    },
+    {
+      "id": "blueprint-plugin/feature-tracking",
+      "line": "blueprint-plugin/feature-tracking: Track feature implementation against: Use when linking features to PRDs"
+    },
+    {
+      "id": "code-quality-plugin/ast-grep-search",
+      "line": "code-quality-plugin/ast-grep-search: Find and replace code patterns: Use when matching code by AST structure"
+    },
+    {
+      "id": "code-quality-plugin/bulk-sweep-classify",
+      "line": "code-quality-plugin/bulk-sweep-classify: Classify every regex match before a bulk: Use when bulk-renaming"
+    },
+    {
+      "id": "code-quality-plugin/code-antipatterns",
+      "line": "code-quality-plugin/code-antipatterns: Analyze a codebase for anti-patterns using: Use when finding magic numbers"
+    },
+    {
+      "id": "code-quality-plugin/code-complexity",
+      "line": "code-quality-plugin/code-complexity: Analyze code complexity metrics: Use when identifying refactoring targets"
+    },
+    {
+      "id": "code-quality-plugin/code-dead-code",
+      "line": "code-quality-plugin/code-dead-code: Detect dead code, unused exports: Use when reducing maintenance burden"
+    },
+    {
+      "id": "code-quality-plugin/code-dep-audit",
+      "line": "code-quality-plugin/code-dep-audit: Audit dependencies for security: Use when checking supply chain security"
+    },
+    {
+      "id": "code-quality-plugin/code-docs-quality",
+      "line": "code-quality-plugin/code-docs-quality: Analyze docs quality across PRDs, ADRs, PRPs: Use when auditing documentation"
+    },
+    {
+      "id": "code-quality-plugin/code-hidden-failures",
+      "line": "code-quality-plugin/code-hidden-failures: Scan for hidden failures: swallowed errors (empty: Use when failures vanish"
+    },
+    {
+      "id": "code-quality-plugin/code-lint",
+      "line": "code-quality-plugin/code-lint: Universal linter that auto-detects: Use when linting code"
+    },
+    {
+      "id": "code-quality-plugin/code-refactor",
+      "line": "code-quality-plugin/code-refactor: Refactor toward pure functions: Use when extracting pure functions"
+    },
+    {
+      "id": "code-quality-plugin/code-review",
+      "line": "code-quality-plugin/code-review: Code review for quality, security, performance: Use when reviewing code"
+    },
+    {
+      "id": "code-quality-plugin/code-review-checklist",
+      "line": "code-quality-plugin/code-review-checklist: Checklist for security, correctness, and performance: Use when reviewing PRs"
+    },
+    {
+      "id": "code-quality-plugin/code-test-quality",
+      "line": "code-quality-plugin/code-test-quality: Analyze test quality: smells, empty assertions: Use when tests are unreliable"
+    },
+    {
+      "id": "code-quality-plugin/debugging-methodology",
+      "line": "code-quality-plugin/debugging-methodology: Systematic debugging for memory, performance: Use when diagnosing memory leaks"
+    },
+    {
+      "id": "code-quality-plugin/dry-consolidation",
+      "line": "code-quality-plugin/dry-consolidation: Find and extract duplicated code into shared: Use when seeing repeated utilities"
+    },
+    {
+      "id": "codebase-attributes-plugin/attributes-collect",
+      "line": "codebase-attributes-plugin/attributes-collect: Collect codebase health attributes as: Use when assessing project health before"
+    },
+    {
+      "id": "codebase-attributes-plugin/attributes-dashboard",
+      "line": "codebase-attributes-plugin/attributes-dashboard: Codebase health dashboard with scores: Use when wanting a health overview"
+    },
+    {
+      "id": "codebase-attributes-plugin/attributes-route",
+      "line": "codebase-attributes-plugin/attributes-route: Route to specialized agents (security: Use when the user has attribute data"
+    },
+    {
+      "id": "comfyui-plugin/comfy-cli",
+      "line": "comfyui-plugin/comfy-cli: The `comfy` CLI for ComfyUI: Use when the user runs `comfy`"
+    },
+    {
+      "id": "comfyui-plugin/comfy-conditionals",
+      "line": "comfyui-plugin/comfy-conditionals: ComfyUI predicate/boolean nodes: Use when forming the boolean that drives"
+    },
+    {
+      "id": "comfyui-plugin/comfy-corpus-validation",
+      "line": "comfyui-plugin/comfy-corpus-validation: Verify ComfyUI sampler/scheduler facts: source-of-truth: Use when writing"
+    },
+    {
+      "id": "comfyui-plugin/comfy-debug-preview",
+      "line": "comfyui-plugin/comfy-debug-preview: ComfyUI debug/preview nodes: show: Use when inspecting a value mid-graph"
+    },
+    {
+      "id": "comfyui-plugin/comfy-flow-control",
+      "line": "comfyui-plugin/comfy-flow-control: ComfyUI routing nodes: typed switches: Use when wiring where a signal routes"
+    },
+    {
+      "id": "comfyui-plugin/comfy-image-utils",
+      "line": "comfyui-plugin/comfy-image-utils: ComfyUI non-inference image ops: Use when manipulating images"
+    },
+    {
+      "id": "comfyui-plugin/comfy-math-strings",
+      "line": "comfyui-plugin/comfy-math-strings: ComfyUI compute/string nodes: constants, sliders: Use when computing a value"
+    },
+    {
+      "id": "comfyui-plugin/comfy-metadata",
+      "line": "comfyui-plugin/comfy-metadata: Extract/analyze ComfyUI metadata embedded in output: Use when figuring out what"
+    },
+    {
+      "id": "comfyui-plugin/comfy-node",
+      "line": "comfyui-plugin/comfy-node: Orchestrate a ComfyUI node pack from idea to registry: Use when releasing"
+    },
+    {
+      "id": "comfyui-plugin/comfy-registry-lifecycle",
+      "line": "comfyui-plugin/comfy-registry-lifecycle: Comfy Registry release pipeline: Use when debugging a pack's publish"
+    },
+    {
+      "id": "comfyui-plugin/comfy-subgraphs-app-mode",
+      "line": "comfyui-plugin/comfy-subgraphs-app-mode: ComfyUI Subgraphs, Subgraph Blueprints: Use when deciding how to package"
+    },
+    {
+      "id": "comfyui-plugin/comfy-workflow-json",
+      "line": "comfyui-plugin/comfy-workflow-json: Programmatically edit ComfyUI workflow: Use when a workflow JSON is too large"
+    },
+    {
+      "id": "comfyui-plugin/comfy-workflow-layout",
+      "line": "comfyui-plugin/comfy-workflow-layout: Auto-layout a ComfyUI workflow JSON: Use when a workflow's nodes overlap"
+    },
+    {
+      "id": "comfyui-plugin/comfyui-node-authoring",
+      "line": "comfyui-plugin/comfyui-node-authoring: ComfyUI frontend/backend authoring facts: hiding/serializing: Use when writing"
+    },
+    {
+      "id": "comfyui-plugin/comfyui-node-scaffold",
+      "line": "comfyui-plugin/comfyui-node-scaffold: Scaffold a new ComfyUI custom-node repo (TypeScript +: Use when bootstrapping"
+    },
+    {
+      "id": "comfyui-plugin/comfyui-pack-live-smoke",
+      "line": "comfyui-plugin/comfyui-pack-live-smoke: Live-smoke a ComfyUI pack in a running: Use when verifying a pack before opening"
+    },
+    {
+      "id": "comfyui-plugin/comfyui-screenshot-pipeline",
+      "line": "comfyui-plugin/comfyui-screenshot-pipeline: Containerized README-screenshot pipeline: Use when generating pack screenshots"
+    },
+    {
+      "id": "communication-plugin/google-chat-formatting",
+      "line": "communication-plugin/google-chat-formatting: Convert Markdown to Google Chat: Use when formatting messages for Google"
+    },
+    {
+      "id": "communication-plugin/ticket-drafting-guidelines",
+      "line": "communication-plugin/ticket-drafting-guidelines: Guidelines for drafting GitHub issues using: Use when creating issues"
+    },
+    {
+      "id": "component-patterns-plugin/components-version-badge",
+      "line": "component-patterns-plugin/components-version-badge: Version badge with build-info tooltip: Use when adding version display to app"
+    },
+    {
+      "id": "component-patterns-plugin/version-badge-pattern",
+      "line": "component-patterns-plugin/version-badge-pattern: Version badge UI showing build version, git: Use when adding version visibility"
+    },
+    {
+      "id": "configure-plugin/ci-workflows",
+      "line": "configure-plugin/ci-workflows: GitHub Actions workflow standards: Use when checking CI/CD compliance"
+    },
+    {
+      "id": "configure-plugin/claude-security-settings",
+      "line": "configure-plugin/claude-security-settings: Claude Code security settings: permission wildcards, shell: Use when auditing"
+    },
+    {
+      "id": "configure-plugin/config-sync",
+      "line": "configure-plugin/config-sync: Config sync across FVH repos: extract, diff: Use when syncing workflows"
+    },
+    {
+      "id": "configure-plugin/configure-all",
+      "line": "configure-plugin/configure-all: Run all infrastructure standards checks: Use when onboarding a new project"
+    },
+    {
+      "id": "configure-plugin/configure-api-tests",
+      "line": "configure-plugin/configure-api-tests: API contract testing: Pact, OpenAPI: Use when adding consumer/provider"
+    },
+    {
+      "id": "configure-plugin/configure-argocd-automerge",
+      "line": "configure-plugin/configure-argocd-automerge: ArgoCD auto-merge: configure GitHub: Use when setting up argocd-automerge.yml"
+    },
+    {
+      "id": "configure-plugin/configure-cache-busting",
+      "line": "configure-plugin/configure-cache-busting: Cache-busting for Next.js and Vite: Use when adding Vercel/Cloudflare cache"
+    },
+    {
+      "id": "configure-plugin/configure-claude-plugins",
+      "line": "configure-plugin/configure-claude-plugins: Claude plugins marketplace setup: Use when onboarding to claude-plugins"
+    },
+    {
+      "id": "configure-plugin/configure-container",
+      "line": "configure-plugin/configure-container: Container infrastructure: GHCR builds: Use when setting up multi-platform GHCR"
+    },
+    {
+      "id": "configure-plugin/configure-coverage",
+      "line": "configure-plugin/configure-coverage: Code coverage: thresholds and reporters for Vitest: Use when setting thresholds"
+    },
+    {
+      "id": "configure-plugin/configure-dead-code",
+      "line": "configure-plugin/configure-dead-code: Dead-code detection: Knip, Vulture: Use when setting up unused-code scanning"
+    },
+    {
+      "id": "configure-plugin/configure-dockerfile",
+      "line": "configure-plugin/configure-dockerfile: Dockerfile standards: Alpine/slim base, non-root: Use when creating a Dockerfile"
+    },
+    {
+      "id": "configure-plugin/configure-docs",
+      "line": "configure-plugin/configure-docs: Code docs: TSDoc, JSDoc, pydoc, rustdoc: Use when setting up docstrings"
+    },
+    {
+      "id": "configure-plugin/configure-editor",
+      "line": "configure-plugin/configure-editor: EditorConfig and VS Code workspace settings: Use when setting up format-on-save"
+    },
+    {
+      "id": "configure-plugin/configure-feature-flags",
+      "line": "configure-plugin/configure-feature-flags: Feature flags with OpenFeature and providers (GOFF: Use when setting up the SDK"
+    },
+    {
+      "id": "configure-plugin/configure-formatting",
+      "line": "configure-plugin/configure-formatting: Biome formatter for JS/TS/JSON/CSS \u2014 the modern: Use when setting up formatting"
+    },
+    {
+      "id": "configure-plugin/configure-gitattributes",
+      "line": "configure-plugin/configure-gitattributes: Configure .gitattributes: union-merge: Use when setting up .gitattributes"
+    },
+    {
+      "id": "configure-plugin/configure-github-pages",
+      "line": "configure-plugin/configure-github-pages: GitHub Pages deployment workflows for docs sites: Use when setting up Pages"
+    },
+    {
+      "id": "configure-plugin/configure-gitignore",
+      "line": "configure-plugin/configure-gitignore: Manage .gitignore's Claude Code block \u2014 worktrees: Use when onboarding a repo"
+    },
+    {
+      "id": "configure-plugin/configure-instrumentation",
+      "line": "configure-plugin/configure-instrumentation: Observability instrumentation: OpenTelemetry: Use when wiring telemetry"
+    },
+    {
+      "id": "configure-plugin/configure-integration-tests",
+      "line": "configure-plugin/configure-integration-tests: Integration testing: Supertest, pytest: Use when setting up integration tests"
+    },
+    {
+      "id": "configure-plugin/configure-justfile",
+      "line": "configure-plugin/configure-justfile: Check and configure Justfiles with standard: Use when setting up a Justfile"
+    },
+    {
+      "id": "configure-plugin/configure-linting",
+      "line": "configure-plugin/configure-linting: Modern linters: Biome, Ruff, Clippy: Use when setting up linting"
+    },
+    {
+      "id": "configure-plugin/configure-load-tests",
+      "line": "configure-plugin/configure-load-tests: Load testing: k6, Artillery, Locust: Use when setting up load tests"
+    },
+    {
+      "id": "configure-plugin/configure-makefile",
+      "line": "configure-plugin/configure-makefile: Makefile with standard targets (help, test: Use when setting up a Makefile"
+    },
+    {
+      "id": "configure-plugin/configure-mcp",
+      "line": "configure-plugin/configure-mcp: Check and configure MCP servers for project: Use when setting up MCP servers"
+    },
+    {
+      "id": "configure-plugin/configure-memory-profiling",
+      "line": "configure-plugin/configure-memory-profiling: Memory profiling with pytest-memray: Use when setting up memory profiling"
+    },
+    {
+      "id": "configure-plugin/configure-mise",
+      "line": "configure-plugin/configure-mise: mise runtime/tool version manager - mise.toml, backends: Use when setting up"
+    },
+    {
+      "id": "configure-plugin/configure-package-management",
+      "line": "configure-plugin/configure-package-management: Package managers: uv (Python), bun (TypeScript): Use when setting up uv"
+    },
+    {
+      "id": "configure-plugin/configure-pre-commit",
+      "line": "configure-plugin/configure-pre-commit: pre-commit hooks setup and validation: Use when installing hooks"
+    },
+    {
+      "id": "configure-plugin/configure-readme",
+      "line": "configure-plugin/configure-readme: README.md with logo, badges, features, tech stack: Use when creating a README"
+    },
+    {
+      "id": "configure-plugin/configure-release-please",
+      "line": "configure-plugin/configure-release-please: release-please workflow setup and auditing: Use when configuring release-please"
+    },
+    {
+      "id": "configure-plugin/configure-repo",
+      "line": "configure-plugin/configure-repo: Repo onboarding driver: .claude/: Use when onboarding any repo to Claude"
+    },
+    {
+      "id": "configure-plugin/configure-reusable-workflows",
+      "line": "configure-plugin/configure-reusable-workflows: Reusable GitHub Actions workflows: Use when adding OWASP/secret/code-smell"
+    },
+    {
+      "id": "configure-plugin/configure-security",
+      "line": "configure-plugin/configure-security: Security scanning: dependency audits, SAST: Use when setting up Dependabot"
+    },
+    {
+      "id": "configure-plugin/configure-select",
+      "line": "configure-plugin/configure-select: Interactive selector for infrastructure: Use when setting up specific components"
+    },
+    {
+      "id": "configure-plugin/configure-sentry",
+      "line": "configure-plugin/configure-sentry: Sentry error tracking setup: Use when installing the Sentry SDK"
+    },
+    {
+      "id": "configure-plugin/configure-skaffold",
+      "line": "configure-plugin/configure-skaffold: Skaffold for Kubernetes: port forwarding: Use when fixing 0.0.0.0 binding"
+    },
+    {
+      "id": "configure-plugin/configure-status",
+      "line": "configure-plugin/configure-status: Infrastructure compliance status: Use when checking overall compliance"
+    },
+    {
+      "id": "configure-plugin/configure-surface",
+      "line": "configure-plugin/configure-surface: Surface doc-drift gate: scaffold surf.toml + hubs, wire: Use when adding"
+    },
+    {
+      "id": "configure-plugin/configure-tests",
+      "line": "configure-plugin/configure-tests: Test frameworks: Vitest, Jest, pytest: Use when setting up test infrastructure"
+    },
+    {
+      "id": "configure-plugin/configure-ux-testing",
+      "line": "configure-plugin/configure-ux-testing: UX testing: Playwright E2E, axe-core a11y: Use when setting up E2E testing"
+    },
+    {
+      "id": "configure-plugin/configure-web-session",
+      "line": "configure-plugin/configure-web-session: SessionStart hook for Claude Code web sessions: Use when CI tools fail in remote"
+    },
+    {
+      "id": "configure-plugin/configure-workflows",
+      "line": "configure-plugin/configure-workflows: GitHub Actions CI/CD workflows for container: Use when updating outdated action"
+    },
+    {
+      "id": "configure-plugin/configure-worktreeinclude",
+      "line": "configure-plugin/configure-worktreeinclude: Generate a .worktreeinclude so Claude Code copies: Use when worktrees miss .env"
+    },
+    {
+      "id": "configure-plugin/go-feature-flag",
+      "line": "configure-plugin/go-feature-flag: GO Feature Flag (GOFF) self-hosted feature flags: Use when working with GOFF"
+    },
+    {
+      "id": "configure-plugin/multi-repo-discipline",
+      "line": "configure-plugin/multi-repo-discipline: Multi-repo workspace rules: read-only: Use when dispatching agents across"
+    },
+    {
+      "id": "configure-plugin/openfeature",
+      "line": "configure-plugin/openfeature: OpenFeature vendor-agnostic feature flag: Use when implementing feature flags"
+    },
+    {
+      "id": "container-plugin/container-development",
+      "line": "container-plugin/container-development: Container development \u2014 Docker, multi-stage: Use when working with Docker"
+    },
+    {
+      "id": "container-plugin/deploy-handoff",
+      "line": "container-plugin/deploy-handoff: Generate deployment handoff docs \u2014 tech stack: Use when handing off a service"
+    },
+    {
+      "id": "container-plugin/deploy-release",
+      "line": "container-plugin/deploy-release: Create and publish releases via release-please: Use when cutting a release"
+    },
+    {
+      "id": "container-plugin/go-containers",
+      "line": "container-plugin/go-containers: Go container optimization: Use when working with Go containers"
+    },
+    {
+      "id": "container-plugin/nodejs-containers",
+      "line": "container-plugin/nodejs-containers: Node.js container optimization: Use when working with Node.js containers"
+    },
+    {
+      "id": "container-plugin/python-containers",
+      "line": "container-plugin/python-containers: Python container optimization \u2014 slim: Use when working with Python containers"
+    },
+    {
+      "id": "container-plugin/skaffold-filesync",
+      "line": "container-plugin/skaffold-filesync: Skaffold file sync \u2014 copy changed files: Use when optimizing the dev loop"
+    },
+    {
+      "id": "container-plugin/skaffold-orbstack",
+      "line": "container-plugin/skaffold-orbstack: OrbStack-optimized Skaffold for local Kubernetes: Use when configuring Skaffold"
+    },
+    {
+      "id": "container-plugin/skaffold-testing",
+      "line": "container-plugin/skaffold-testing: Container image validation with Skaffold: Use when configuring pre-deploy tests"
+    },
+    {
+      "id": "css-plugin/lightning-css",
+      "line": "css-plugin/lightning-css: Lightning CSS transpilation, bundling: Use when configuring CSS in Vite"
+    },
+    {
+      "id": "css-plugin/unocss",
+      "line": "css-plugin/unocss: UnoCSS atomic CSS engine for on-demand: Use when setting up utility-first CSS"
+    },
+    {
+      "id": "documentation-plugin/claude-blog-sources",
+      "line": "documentation-plugin/claude-blog-sources: Fetch Claude Blog and official Claude Code: Use when researching Claude Code"
+    },
+    {
+      "id": "documentation-plugin/docs-decommission",
+      "line": "documentation-plugin/docs-decommission: Generate DECOMMISSION-<service>.md covering: Use when decommissioning a service"
+    },
+    {
+      "id": "documentation-plugin/docs-generate",
+      "line": "documentation-plugin/docs-generate: Generate or update docs from code annotations: Use when wanting API reference"
+    },
+    {
+      "id": "documentation-plugin/docs-latex",
+      "line": "documentation-plugin/docs-latex: Convert Markdown to LaTeX with TikZ: Use when wanting a presentation-quality"
+    },
+    {
+      "id": "documentation-plugin/docs-sync",
+      "line": "documentation-plugin/docs-sync: Sync docs with actual skills, commands: Use when docs are out of sync"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-improve",
+      "line": "evaluate-plugin/evaluate-improve: Suggest improvements to SKILL.md content: Use when raising pass rates"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-legibility",
+      "line": "evaluate-plugin/evaluate-legibility: Cold-read a SKILL.md: Use when validating whether a skill says"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-matrix",
+      "line": "evaluate-plugin/evaluate-matrix: Cross-model skill evals with real: Use when checking whether a weak model"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-plugin-batch",
+      "line": "evaluate-plugin/evaluate-plugin-batch: Batch evaluate every skill in a plugin: Use when auditing an entire plugin's"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-report",
+      "line": "evaluate-plugin/evaluate-report: View evaluation results and benchmark: Use when reviewing past eval results"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-skill",
+      "line": "evaluate-plugin/evaluate-skill: Evaluate a skill by running test cases: Use when testing whether a skill"
+    },
+    {
+      "id": "feedback-plugin/feedback-session",
+      "line": "feedback-plugin/feedback-session: Analyze session for skill feedback: Use when a skill gave wrong guidance"
+    },
+    {
+      "id": "finops-plugin/finops-caches",
+      "line": "finops-plugin/finops-caches: GitHub Actions cache analysis \u2014 size: Use when investigating cache bloat"
+    },
+    {
+      "id": "finops-plugin/finops-compare",
+      "line": "finops-plugin/finops-compare: FinOps metrics comparison across repos in an org: Use when benchmarking repos"
+    },
+    {
+      "id": "finops-plugin/finops-overview",
+      "line": "finops-plugin/finops-overview: FinOps snapshot \u2014 org billing, workflow: Use when you want a high-level view"
+    },
+    {
+      "id": "finops-plugin/finops-waste",
+      "line": "finops-plugin/finops-waste: Identify GitHub Actions waste \u2014 skipped runs, bot: Use when CI costs are high"
+    },
+    {
+      "id": "finops-plugin/finops-workflows",
+      "line": "finops-plugin/finops-workflows: Analyze workflow runs \u2014 frequency, duration: Use when investigating slow CI"
+    },
+    {
+      "id": "finops-plugin/github-actions-cache-optimization",
+      "line": "finops-plugin/github-actions-cache-optimization: GitHub Actions cache analysis: Use when investigating cache bloat"
+    },
+    {
+      "id": "finops-plugin/github-actions-finops",
+      "line": "finops-plugin/github-actions-finops: GitHub Actions billing, workflow efficiency: Use when investigating CI/CD costs"
+    },
+    {
+      "id": "foundryvtt-plugin/foundryvtt-module",
+      "line": "foundryvtt-plugin/foundryvtt-module: FoundryVTT module idea to gitops-adopted repo: scaffold: Use when releasing"
+    },
+    {
+      "id": "foundryvtt-plugin/foundryvtt-module-scaffold",
+      "line": "foundryvtt-plugin/foundryvtt-module-scaffold: Scaffold a new FoundryVTT v13 module repo (Vite + TS +: Use when bootstrapping"
+    },
+    {
+      "id": "git-plugin/deadbranch",
+      "line": "git-plugin/deadbranch: deadbranch CLI for stale-branch cleanup: Use when asked to clean up branches"
+    },
+    {
+      "id": "git-plugin/gh-cli-agentic",
+      "line": "git-plugin/gh-cli-agentic: gh CLI commands with JSON output for agent workflows: Use when querying PRs"
+    },
+    {
+      "id": "git-plugin/gh-workflow-monitoring",
+      "line": "git-plugin/gh-workflow-monitoring: Monitor GitHub Actions runs with blocking: Use when waiting for CI after push"
+    },
+    {
+      "id": "git-plugin/git-api-pr",
+      "line": "git-plugin/git-api-pr: GitHub API PR creation without local: Use when submitting file changes as a PR"
+    },
+    {
+      "id": "git-plugin/git-branch-naming",
+      "line": "git-plugin/git-branch-naming: Git branch naming conventions \u2014 type prefixes: Use when creating branches"
+    },
+    {
+      "id": "git-plugin/git-branch-pr-workflow",
+      "line": "git-plugin/git-branch-pr-workflow: Branch management and PR workflows \u2014 git: Use when creating branches"
+    },
+    {
+      "id": "git-plugin/git-cli-agentic",
+      "line": "git-plugin/git-cli-agentic: Git commands with porcelain: Use when scripting status/diff/log"
+    },
+    {
+      "id": "git-plugin/git-commit",
+      "line": "git-plugin/git-commit: Create commits with conventional messages and issue: Use when user says \"commit\""
+    },
+    {
+      "id": "git-plugin/git-commit-push-pr",
+      "line": "git-plugin/git-commit-push-pr: End-to-end commit-to-PR workflow: Use when the user says \"create pr\""
+    },
+    {
+      "id": "git-plugin/git-commit-trailers",
+      "line": "git-plugin/git-commit-trailers: Git commit trailer conventions \u2014 BREAKING CHANGE: Use when composing messages"
+    },
+    {
+      "id": "git-plugin/git-commit-workflow",
+      "line": "git-plugin/git-commit-workflow: Conventional commit format, staging: Use when writing commit messages"
+    },
+    {
+      "id": "git-plugin/git-conflicts",
+      "line": "git-plugin/git-conflicts: Resolve merge conflicts file-by-file: Use when a merge/rebase has conflicts"
+    },
+    {
+      "id": "git-plugin/git-coworker-check",
+      "line": "git-plugin/git-coworker-check: Detect coworker Claude agents: Use when starting a session in a shared"
+    },
+    {
+      "id": "git-plugin/git-derive-docs",
+      "line": "git-plugin/git-derive-docs: Derive ADRs, rules, PRDs from git commit history: Use when finding doc gaps"
+    },
+    {
+      "id": "git-plugin/git-fix-pr",
+      "line": "git-plugin/git-fix-pr: Analyze and fix failing PR checks: Use when asked to fix a PR"
+    },
+    {
+      "id": "git-plugin/git-fork-workflow",
+      "line": "git-plugin/git-fork-workflow: Fork management and upstream sync: Use when working with forks"
+    },
+    {
+      "id": "git-plugin/git-issue",
+      "line": "git-plugin/git-issue: Process GitHub issues end-to-end with TDD: Use when asked to work on an issue"
+    },
+    {
+      "id": "git-plugin/git-issue-hierarchy",
+      "line": "git-plugin/git-issue-hierarchy: Manage GitHub sub-issues: Use when breaking issues into sub-tasks"
+    },
+    {
+      "id": "git-plugin/git-issue-manage",
+      "line": "git-plugin/git-issue-manage: GitHub issue admin operations: Use when transferring issues"
+    },
+    {
+      "id": "git-plugin/git-maintain",
+      "line": "git-plugin/git-maintain: Repo maintenance \u2014 incremental repack, gc: Use when asked to clean up the repo"
+    },
+    {
+      "id": "git-plugin/git-pr",
+      "line": "git-plugin/git-pr: Create pull requests with descriptions, labels: Use when user says \"create PR\""
+    },
+    {
+      "id": "git-plugin/git-pr-feedback",
+      "line": "git-plugin/git-pr-feedback: Address PR review comments and resolve: Use when CHANGES_REQUESTED is set"
+    },
+    {
+      "id": "git-plugin/git-pr-sync-check",
+      "line": "git-plugin/git-pr-sync-check: Checks whether the current PR branch is: Use when continuing work on a PR branch"
+    },
+    {
+      "id": "git-plugin/git-pr-watch",
+      "line": "git-plugin/git-pr-watch: Subscribe to a PR's activity and react: Use when watching/monitoring/babysitting"
+    },
+    {
+      "id": "git-plugin/git-push",
+      "line": "git-plugin/git-push: Push local commits to remote \u2014 handles branch: Use when user says \"push\""
+    },
+    {
+      "id": "git-plugin/git-rebase-patterns",
+      "line": "git-plugin/git-rebase-patterns: Advanced git rebase \u2014 linear history, stacked PRs: Use when rebasing branches"
+    },
+    {
+      "id": "git-plugin/git-repo-detection",
+      "line": "git-plugin/git-repo-detection: Detect GitHub repo owner/name from git remotes: Use when needing the owner/repo"
+    },
+    {
+      "id": "git-plugin/git-security-checks",
+      "line": "git-plugin/git-security-checks: Pre-commit security validation and secret: Use when scanning for secrets"
+    },
+    {
+      "id": "git-plugin/git-triage",
+      "line": "git-plugin/git-triage: Triage GitHub issues and PRs \u2014 cross-link, flag: Use when grooming the backlog"
+    },
+    {
+      "id": "git-plugin/git-upstream-pr",
+      "line": "git-plugin/git-upstream-pr: Submit PRs to upstream repos from a fork: Use when contributing changes upstream"
+    },
+    {
+      "id": "git-plugin/git-upstream-pr-diverged",
+      "line": "git-plugin/git-upstream-pr-diverged: Submit a diverged-fork commit to upstream as: Use when direct rebase fails"
+    },
+    {
+      "id": "git-plugin/github-issue-autodetect",
+      "line": "git-plugin/github-issue-autodetect: Auto-detect GitHub issues that staged: Use when committing to ensure proper"
+    },
+    {
+      "id": "git-plugin/github-issue-writing",
+      "line": "git-plugin/github-issue-writing: Create well-structured GitHub issues with clear titles: Use when filing bugs"
+    },
+    {
+      "id": "git-plugin/github-labels",
+      "line": "git-plugin/github-labels: Discover and apply GitHub labels via gh CLI: Use when asked to label a PR/issue"
+    },
+    {
+      "id": "git-plugin/github-pr-title",
+      "line": "git-plugin/github-pr-title: Craft PR titles using conventional commits format: Use when creating PRs"
+    },
+    {
+      "id": "git-plugin/release-please-configuration",
+      "line": "git-plugin/release-please-configuration: release-please monorepo config \u2014 component tags: Use when adding packages"
+    },
+    {
+      "id": "git-plugin/release-please-pr-workflow",
+      "line": "git-plugin/release-please-pr-workflow: Manage release-please PR merging for monorepos: Use when merging release PRs"
+    },
+    {
+      "id": "git-plugin/release-please-protection",
+      "line": "git-plugin/release-please-protection: Block manual edits to release-please files: Use when editing changelogs"
+    },
+    {
+      "id": "github-actions-plugin/claude-code-github-workflows",
+      "line": "github-actions-plugin/claude-code-github-workflows: Claude Code GitHub Actions workflow patterns \u2014 PR reviews: Use when creating"
+    },
+    {
+      "id": "github-actions-plugin/github-actions-auth-security",
+      "line": "github-actions-plugin/github-actions-auth-security: GitHub Actions auth and security for Claude Code: Use when setting up workflow"
+    },
+    {
+      "id": "github-actions-plugin/github-actions-inspection",
+      "line": "github-actions-plugin/github-actions-inspection: Inspect GitHub Actions runs, analyze: Use when investigating CI/CD failures"
+    },
+    {
+      "id": "github-actions-plugin/github-actions-mcp-config",
+      "line": "github-actions-plugin/github-actions-mcp-config: MCP server config for GitHub Actions \u2014 tool: Use when configuring MCP servers"
+    },
+    {
+      "id": "github-actions-plugin/github-issue-search",
+      "line": "github-actions-plugin/github-issue-search: Search GitHub issues for solutions: Use when encountering errors with OSS"
+    },
+    {
+      "id": "github-actions-plugin/github-social-preview",
+      "line": "github-actions-plugin/github-social-preview: Generate 1280x640 PNG social preview images: Use when asked for social preview"
+    },
+    {
+      "id": "github-actions-plugin/github-workflow-auto-fix",
+      "line": "github-actions-plugin/github-workflow-auto-fix: Set up automated CI fixing with Claude: Use when adding a workflow that analyzes"
+    },
+    {
+      "id": "github-actions-plugin/workflow-dev",
+      "line": "github-actions-plugin/workflow-dev: Automated dev loop \u2014 run tests, file: Use when running a continuous dev loop"
+    },
+    {
+      "id": "health-plugin/health-agentic-audit",
+      "line": "health-plugin/health-agentic-audit: Audit skills, commands, and agents for agentic: Use when batch-checking skill"
+    },
+    {
+      "id": "health-plugin/health-audit",
+      "line": "health-plugin/health-audit: Plugin audit against detected stack: Use when cleaning up unused plugins"
+    },
+    {
+      "id": "health-plugin/health-check",
+      "line": "health-plugin/health-check: Claude Code health check \u2014 scans plugins: Use when checking project health"
+    },
+    {
+      "id": "health-plugin/health-plugins",
+      "line": "health-plugin/health-plugins: Diagnose and fix Claude Code plugin: Use when seeing plugin-already-installed"
+    },
+    {
+      "id": "health-plugin/health-skill-audit",
+      "line": "health-plugin/health-skill-audit: Audit skill tree for overlap, split-pressure: Use when finding confusing skill"
+    },
+    {
+      "id": "health-plugin/plugin-registry",
+      "line": "health-plugin/plugin-registry: Claude Code plugin registry structure: Use when troubleshooting plugin"
+    },
+    {
+      "id": "health-plugin/settings-configuration",
+      "line": "health-plugin/settings-configuration: Claude Code settings hierarchy, permission: Use when setting up permissions"
+    },
+    {
+      "id": "home-assistant-plugin/ha-automations",
+      "line": "home-assistant-plugin/ha-automations: Home Assistant automation creation: Use when working with HA triggers"
+    },
+    {
+      "id": "home-assistant-plugin/ha-configuration",
+      "line": "home-assistant-plugin/ha-configuration: Home Assistant YAML configuration: Use when editing configuration.yaml"
+    },
+    {
+      "id": "home-assistant-plugin/ha-entities",
+      "line": "home-assistant-plugin/ha-entities: Home Assistant entity and domain management: Use when working with entity IDs"
+    },
+    {
+      "id": "home-assistant-plugin/ha-validate",
+      "line": "home-assistant-plugin/ha-validate: Validate Home Assistant YAML for syntax errors: Use when validating HA config"
+    },
+    {
+      "id": "hooks-plugin/hooks-configuration",
+      "line": "hooks-plugin/hooks-configuration: Claude Code hooks configuration: Use when the user mentions hooks"
+    },
+    {
+      "id": "hooks-plugin/hooks-permission-request-hook",
+      "line": "hooks-plugin/hooks-permission-request-hook: Generate a PermissionRequest hook: Use when needing a safer alternative"
+    },
+    {
+      "id": "hooks-plugin/hooks-session-end-issue-hook",
+      "line": "hooks-plugin/hooks-session-end-issue-hook: Configure a Stop hook that surfaces unfinished: Use when you want deferred work"
+    },
+    {
+      "id": "hooks-plugin/hooks-session-start-hook",
+      "line": "hooks-plugin/hooks-session-start-hook: Create a SessionStart hook for Claude Code: Use when setting up a repo so"
+    },
+    {
+      "id": "kubernetes-plugin/argocd-login",
+      "line": "kubernetes-plugin/argocd-login: ArgoCD CLI auth with SSO and gRPC-Web: Use when the user mentions ArgoCD login"
+    },
+    {
+      "id": "kubernetes-plugin/helm-chart-development",
+      "line": "kubernetes-plugin/helm-chart-development: Create, test, and package Helm charts: Use when the user mentions Helm charts"
+    },
+    {
+      "id": "kubernetes-plugin/helm-debugging",
+      "line": "kubernetes-plugin/helm-debugging: Debug Helm failures \u2014 template errors: Use when the user mentions Helm errors"
+    },
+    {
+      "id": "kubernetes-plugin/helm-release-management",
+      "line": "kubernetes-plugin/helm-release-management: Manage Helm releases \u2014 install, upgrade: Use when the user mentions deploying"
+    },
+    {
+      "id": "kubernetes-plugin/helm-release-recovery",
+      "line": "kubernetes-plugin/helm-release-recovery: Recover from failed Helm deployments: Use when the user mentions rollback"
+    },
+    {
+      "id": "kubernetes-plugin/helm-values-management",
+      "line": "kubernetes-plugin/helm-values-management: Manage Helm values \u2014 override: Use when the user mentions Helm values"
+    },
+    {
+      "id": "kubernetes-plugin/kubectl-debugging",
+      "line": "kubernetes-plugin/kubectl-debugging: Debug K8s pods/nodes with kubectl: Use when the user mentions kubectl debug"
+    },
+    {
+      "id": "kubernetes-plugin/kubernetes-operations",
+      "line": "kubernetes-plugin/kubernetes-operations: Kubernetes operations \u2014 deployment, management: Use when the user mentions K8s"
+    },
+    {
+      "id": "langchain-plugin/deep-agents",
+      "line": "langchain-plugin/deep-agents: Build hierarchical AI agents: Use when creating orchestrators that"
+    },
+    {
+      "id": "langchain-plugin/langchain-development",
+      "line": "langchain-plugin/langchain-development: LangChain JS/TS framework for building: Use when working with chat models"
+    },
+    {
+      "id": "langchain-plugin/langchain-init",
+      "line": "langchain-plugin/langchain-init: Initialize a new LangChain TypeScript: Use when starting an LLM-powered app"
+    },
+    {
+      "id": "langchain-plugin/langgraph-agents",
+      "line": "langchain-plugin/langgraph-agents: LangGraph stateful AI agents: Use when creating state-machine agents"
+    },
+    {
+      "id": "macos-plugin/endpoint-security-cpu",
+      "line": "macos-plugin/endpoint-security-cpu: macOS EndpointSecurity/EDR high CPU &: Use when Kandji ESF / XProtect pegs"
+    },
+    {
+      "id": "macos-plugin/kitty-session-persistence",
+      "line": "macos-plugin/kitty-session-persistence: Snapshot and restore kitty terminal: Use when surviving WindowServer hangs"
+    },
+    {
+      "id": "macos-plugin/launchservices-health",
+      "line": "macos-plugin/launchservices-health: Diagnose macOS LaunchServices DB bloat: Use when launchservicesd is pegged at"
+    },
+    {
+      "id": "macos-plugin/macos-disk-usage",
+      "line": "macos-plugin/macos-disk-usage: macOS disk-usage forensics and space: Use when df reports a disk near-full"
+    },
+    {
+      "id": "macos-plugin/macos-incident-postmortem",
+      "line": "macos-plugin/macos-incident-postmortem: Reconstruct macOS freeze, panic, or reboot from: Use when investigating hangs"
+    },
+    {
+      "id": "macos-plugin/macos-performance-benchmark",
+      "line": "macos-plugin/macos-performance-benchmark: Repeatable macOS/Apple-Silicon benchmark +: Use when baselining a Mac"
+    },
+    {
+      "id": "macos-plugin/macos-performance-triage",
+      "line": "macos-plugin/macos-performance-triage: Live macOS/Apple-Silicon performance triage \u2014 find what's: Use when fans spin up"
+    },
+    {
+      "id": "macos-plugin/tui-keybinding-debug",
+      "line": "macos-plugin/tui-keybinding-debug: Debug dead TUI/terminal keybindings: Use when a configured key does nothing"
+    },
+    {
+      "id": "migration-patterns-plugin/black-to-ruff-format",
+      "line": "migration-patterns-plugin/black-to-ruff-format: Migrate Python formatting from black to ruff-format: Use when psf/black is"
+    },
+    {
+      "id": "migration-patterns-plugin/dual-write",
+      "line": "migration-patterns-plugin/dual-write: Dual-write pattern for safe data store: Use when planning DB migrations"
+    },
+    {
+      "id": "migration-patterns-plugin/eslint-to-biome",
+      "line": "migration-patterns-plugin/eslint-to-biome: Migrate JS/TS linting from ESLint+Prettier to Biome: Use when .eslintrc*"
+    },
+    {
+      "id": "migration-patterns-plugin/flake8-to-ruff",
+      "line": "migration-patterns-plugin/flake8-to-ruff: Migrate Python linting from flake8/isort to ruff: Use when pycqa/flake8"
+    },
+    {
+      "id": "migration-patterns-plugin/mypy-to-ty",
+      "line": "migration-patterns-plugin/mypy-to-ty: Migrate Python type checking from mypy to ty (Astral): Use when mirrors-mypy is"
+    },
+    {
+      "id": "migration-patterns-plugin/shadow-mode",
+      "line": "migration-patterns-plugin/shadow-mode: Shadow mode / dark-launch for validating: Use when testing replacement services"
+    },
+    {
+      "id": "networking-plugin/dns-tools",
+      "line": "networking-plugin/dns-tools: DNS resolution and propagation debugging: Use when looking up A/AAAA/MX/TXT"
+    },
+    {
+      "id": "networking-plugin/http-load-testing",
+      "line": "networking-plugin/http-load-testing: HTTP load testing with oha: Use when measuring latency percentiles"
+    },
+    {
+      "id": "networking-plugin/interface-state",
+      "line": "networking-plugin/interface-state: Local interface, address, route, and neighbor state: Use when viewing"
+    },
+    {
+      "id": "networking-plugin/layer2-discovery",
+      "line": "networking-plugin/layer2-discovery: Layer 2 device discovery and topology: Use when finding switch port assignments"
+    },
+    {
+      "id": "networking-plugin/network-diagnostics",
+      "line": "networking-plugin/network-diagnostics: Network connectivity and latency diagnostics: Use when tracing routes"
+    },
+    {
+      "id": "networking-plugin/network-discovery",
+      "line": "networking-plugin/network-discovery: Network host and port discovery with nmap: Use when scanning TCP ports"
+    },
+    {
+      "id": "networking-plugin/network-monitoring",
+      "line": "networking-plugin/network-monitoring: Real-time network traffic and per-process: Use when finding which app consumes"
+    },
+    {
+      "id": "obsidian-plugin/bases",
+      "line": "obsidian-plugin/bases: Obsidian Bases (database-over-notes): list base: Use when user mentions Bases"
+    },
+    {
+      "id": "obsidian-plugin/bookmarks",
+      "line": "obsidian-plugin/bookmarks: Obsidian bookmarks: list and add: Use when starring"
+    },
+    {
+      "id": "obsidian-plugin/command-palette",
+      "line": "obsidian-plugin/command-palette: Run, list, and inspect Obsidian commands: Use when triggering a command"
+    },
+    {
+      "id": "obsidian-plugin/dev-tools",
+      "line": "obsidian-plugin/dev-tools: Obsidian plugin/theme dev: DevTools, CDP, JS eval: Use when debugging the app"
+    },
+    {
+      "id": "obsidian-plugin/file-history",
+      "line": "obsidian-plugin/file-history: Obsidian File Recovery and Sync history: inspect, diff: Use when undoing edits"
+    },
+    {
+      "id": "obsidian-plugin/plugins-themes",
+      "line": "obsidian-plugin/plugins-themes: Obsidian community plugins/themes/CSS snippets management: Use when installing"
+    },
+    {
+      "id": "obsidian-plugin/properties",
+      "line": "obsidian-plugin/properties: Obsidian YAML frontmatter properties: read: Use when user mentions frontmatter"
+    },
+    {
+      "id": "obsidian-plugin/publish-sync",
+      "line": "obsidian-plugin/publish-sync: Obsidian Publish and Sync operations: Use when publishing notes"
+    },
+    {
+      "id": "obsidian-plugin/search-discovery",
+      "line": "obsidian-plugin/search-discovery: Obsidian vault search: full-text/grep, tag: Use when exploring backlinks"
+    },
+    {
+      "id": "obsidian-plugin/tasks",
+      "line": "obsidian-plugin/tasks: Obsidian tasks via CLI: list open tasks: Use when user mentions Obsidian tasks"
+    },
+    {
+      "id": "obsidian-plugin/templates",
+      "line": "obsidian-plugin/templates: Obsidian Templates plugin: list, read, insert templates: Use when inserting"
+    },
+    {
+      "id": "obsidian-plugin/vault-files",
+      "line": "obsidian-plugin/vault-files: Obsidian vault file ops via CLI: read, create: Use when managing vault files"
+    },
+    {
+      "id": "obsidian-plugin/vault-frontmatter",
+      "line": "obsidian-plugin/vault-frontmatter: Offline YAML frontmatter maintenance: Use when stripping legacy `id:`"
+    },
+    {
+      "id": "obsidian-plugin/vault-management",
+      "line": "obsidian-plugin/vault-management: Obsidian vault inspection and cross-vault: Use when checking vault info (path"
+    },
+    {
+      "id": "obsidian-plugin/vault-mocs",
+      "line": "obsidian-plugin/vault-mocs: Map-of-Content (MOC) curation for Obsidian: Use when creating a MOC for a tag"
+    },
+    {
+      "id": "obsidian-plugin/vault-orphans",
+      "line": "obsidian-plugin/vault-orphans: Triage orphaned notes (zero in/out wikilinks) in an: Use when finding orphans"
+    },
+    {
+      "id": "obsidian-plugin/vault-stubs",
+      "line": "obsidian-plugin/vault-stubs: Work-namespace redirect-stub classification in an: Use when cleaning stubs"
+    },
+    {
+      "id": "obsidian-plugin/vault-tags",
+      "line": "obsidian-plugin/vault-tags: Emoji-prefixed tag taxonomy for Obsidian: Use when consolidating drifted tags"
+    },
+    {
+      "id": "obsidian-plugin/vault-templates",
+      "line": "obsidian-plugin/vault-templates: Obsidian Templater drift repair: Use when fixing unrendered `<%"
+    },
+    {
+      "id": "obsidian-plugin/vault-wikilinks",
+      "line": "obsidian-plugin/vault-wikilinks: Broken Obsidian wikilink detection: Use when fixing `[[Target]]` links"
+    },
+    {
+      "id": "obsidian-plugin/workspaces",
+      "line": "obsidian-plugin/workspaces: Obsidian editor workspace: list open tabs, recent: Use when checking what's open"
+    },
+    {
+      "id": "project-plugin/changelog-review",
+      "line": "project-plugin/changelog-review: Claude Code changelog analysis for plugin impact: Use when checking new features"
+    },
+    {
+      "id": "project-plugin/project-continue",
+      "line": "project-plugin/project-continue: Resume development from current project: Use when the user asks to continue work"
+    },
+    {
+      "id": "project-plugin/project-discovery",
+      "line": "project-plugin/project-discovery: Project orientation for unfamiliar codebases: Use when entering a new project"
+    },
+    {
+      "id": "project-plugin/project-init",
+      "line": "project-plugin/project-init: Scaffold a new project with base structure: Use when starting a new project"
+    },
+    {
+      "id": "project-plugin/project-refocus",
+      "line": "project-plugin/project-refocus: Refresh the plan to focus on the task at hand: Use when context grew"
+    },
+    {
+      "id": "project-plugin/project-skill-scripts",
+      "line": "project-plugin/project-skill-scripts: Find and create supporting scripts: Use when auditing skills for script"
+    },
+    {
+      "id": "project-plugin/project-test-loop",
+      "line": "project-plugin/project-test-loop: Automated TDD test-fix-refactor cycle until: Use when looping on failing tests"
+    },
+    {
+      "id": "prompt-engineering-plugin/prompt-engineering-ground-response",
+      "line": "prompt-engineering-plugin/prompt-engineering-ground-response: Citation-backed responses with direct quotes from: Use when analyzing long docs"
+    },
+    {
+      "id": "prose-plugin/prose-distill",
+      "line": "prose-plugin/prose-distill: Prose distill: condense verbose text to its essence: Use when asked to condense"
+    },
+    {
+      "id": "prose-plugin/prose-synthesize",
+      "line": "prose-plugin/prose-synthesize: Prose synthesize: turn unstructured notes into: Use when given brain dumps"
+    },
+    {
+      "id": "python-plugin/basedpyright-type-checking",
+      "line": "python-plugin/basedpyright-type-checking: Basedpyright static type checker for Python: Use when setting up type checking"
+    },
+    {
+      "id": "python-plugin/pytest-advanced",
+      "line": "python-plugin/pytest-advanced: Advanced pytest: fixtures, markers, parametrization: Use when implementing test"
+    },
+    {
+      "id": "python-plugin/python-code-quality",
+      "line": "python-plugin/python-code-quality: Python code quality with ruff and ty: Use when the user mentions ruff"
+    },
+    {
+      "id": "python-plugin/python-development",
+      "line": "python-plugin/python-development: Core Python development idioms and language features: Use when mentioning Python"
+    },
+    {
+      "id": "python-plugin/python-packaging",
+      "line": "python-plugin/python-packaging: Build and publish Python packages with uv: Use when the user mentions building"
+    },
+    {
+      "id": "python-plugin/python-testing",
+      "line": "python-plugin/python-testing: Python testing with pytest, coverage: Use when the user mentions pytest"
+    },
+    {
+      "id": "python-plugin/ruff-formatting",
+      "line": "python-plugin/ruff-formatting: Python code formatting with ruff format. Fast: Use when formatting Python files"
+    },
+    {
+      "id": "python-plugin/ruff-linting",
+      "line": "python-plugin/ruff-linting: Python linting with ruff. Fast linting: Use when checking Python code quality"
+    },
+    {
+      "id": "python-plugin/ty-type-checking",
+      "line": "python-plugin/ty-type-checking: ty: Astral's extremely fast Python type checker: Use when checking Python types"
+    },
+    {
+      "id": "python-plugin/uv-advanced-dependencies",
+      "line": "python-plugin/uv-advanced-dependencies: Advanced uv dependencies: Git deps, path: Use when the user mentions git+https"
+    },
+    {
+      "id": "python-plugin/uv-project-management",
+      "line": "python-plugin/uv-project-management: Python project setup, deps, and lockfiles with uv: Use when the user mentions uv"
+    },
+    {
+      "id": "python-plugin/uv-python-versions",
+      "line": "python-plugin/uv-python-versions: Install and manage Python interpreter: Use when the user mentions installing"
+    },
+    {
+      "id": "python-plugin/uv-run",
+      "line": "python-plugin/uv-run: Run Python scripts with uv (PEP 723: Use when running scripts without venv"
+    },
+    {
+      "id": "python-plugin/uv-tool-management",
+      "line": "python-plugin/uv-tool-management: Install and manage global Python CLI tools: Use when the user mentions uv tool"
+    },
+    {
+      "id": "python-plugin/uv-workspaces",
+      "line": "python-plugin/uv-workspaces: Manage multi-package Python projects: Use when the user mentions uv workspaces"
+    },
+    {
+      "id": "python-plugin/vulture-dead-code",
+      "line": "python-plugin/vulture-dead-code: Vulture and deadcode tools for detecting unused: Use when cleaning up codebases"
+    },
+    {
+      "id": "rust-plugin/cargo-llvm-cov",
+      "line": "rust-plugin/cargo-llvm-cov: cargo-llvm-cov: Rust code coverage with LLVM: Use when measuring coverage"
+    },
+    {
+      "id": "rust-plugin/cargo-machete",
+      "line": "rust-plugin/cargo-machete: cargo-machete: detect unused Rust dependencies: Use when auditing Cargo.toml"
+    },
+    {
+      "id": "rust-plugin/cargo-nextest",
+      "line": "rust-plugin/cargo-nextest: cargo-nextest: fast Rust test runner with parallel: Use when running tests"
+    },
+    {
+      "id": "rust-plugin/cargo-worktree-builds",
+      "line": "rust-plugin/cargo-worktree-builds: Share one CARGO_TARGET_DIR across parallel: Use when running cargo/clippy/test"
+    },
+    {
+      "id": "rust-plugin/clippy-advanced",
+      "line": "rust-plugin/clippy-advanced: Advanced Clippy configuration for Rust \u2014 custom rules: Use when configuring"
+    },
+    {
+      "id": "rust-plugin/mockito-http-mocking",
+      "line": "rust-plugin/mockito-http-mocking: mockito HTTP mocking for Rust integration: Use when mocking an HTTP API in Rust"
+    },
+    {
+      "id": "rust-plugin/rust-development",
+      "line": "rust-plugin/rust-development: Rust development \u2014 cargo, clippy, rustfmt, async: Use when mentioning Rust"
+    },
+    {
+      "id": "session-plugin/session-distill",
+      "line": "session-plugin/session-distill: Distill session insights into rules, skill: Use when capturing learnings"
+    },
+    {
+      "id": "session-plugin/session-end",
+      "line": "session-plugin/session-end: End-of-session orchestrator. Previews which: Use when winding down a session"
+    },
+    {
+      "id": "session-plugin/session-spinup",
+      "line": "session-plugin/session-spinup: Read-only session-start briefing of open tasks, git: Use when user says spin up"
+    },
+    {
+      "id": "session-plugin/session-wrap",
+      "line": "session-plugin/session-wrap: End-of-session capture to taskwarrior, optional: Use when user says wrap up"
+    },
+    {
+      "id": "software-design-plugin/design-by-contract",
+      "line": "software-design-plugin/design-by-contract: Design with explicit contracts: Use when designing a function/class"
+    },
+    {
+      "id": "software-design-plugin/design-deep-modules",
+      "line": "software-design-plugin/design-deep-modules: Judge interface depth \u2014 deep modules hide: Use when designing a module/API"
+    },
+    {
+      "id": "software-design-plugin/design-legacy-seams",
+      "line": "software-design-plugin/design-legacy-seams: Get legacy code under test before changing it: Use when changing untested code"
+    },
+    {
+      "id": "software-design-plugin/design-patterns",
+      "line": "software-design-plugin/design-patterns: Select a design pattern from a symptom: Use when a structure resists change"
+    },
+    {
+      "id": "software-design-plugin/design-pseudocode",
+      "line": "software-design-plugin/design-pseudocode: Design a routine by stepwise refinement: Use when designing a complex function"
+    },
+    {
+      "id": "taskwarrior-plugin/install-native-hooks",
+      "line": "taskwarrior-plugin/install-native-hooks: Install opt-in taskwarrior native: Use when hardening a local taskwarrior"
+    },
+    {
+      "id": "taskwarrior-plugin/task-add",
+      "line": "taskwarrior-plugin/task-add: Add a taskwarrior task with blueprint: Use when adding coordination tasks"
+    },
+    {
+      "id": "taskwarrior-plugin/task-bulk-ops",
+      "line": "taskwarrior-plugin/task-bulk-ops: Batch taskwarrior operations without: Use when closing/triaging/modifying many"
+    },
+    {
+      "id": "taskwarrior-plugin/task-claim",
+      "line": "taskwarrior-plugin/task-claim: Claim a taskwarrior task as in-flight (+ACTIVE): Use when picking up a task from"
+    },
+    {
+      "id": "taskwarrior-plugin/task-coordinate",
+      "line": "taskwarrior-plugin/task-coordinate: Surface next N unblocked taskwarrior: Use when planning a parallel-agent wave"
+    },
+    {
+      "id": "taskwarrior-plugin/task-done",
+      "line": "taskwarrior-plugin/task-done: Close a taskwarrior task with landing: Use when finishing a coordination task"
+    },
+    {
+      "id": "taskwarrior-plugin/task-reconcile",
+      "line": "taskwarrior-plugin/task-reconcile: Close taskwarrior tasks whose linked GitHub: Use when stale trackers pile up"
+    },
+    {
+      "id": "taskwarrior-plugin/task-release",
+      "line": "taskwarrior-plugin/task-release: Release a taskwarrior task without closing it \u2014 stops: Use when pausing mid-task"
+    },
+    {
+      "id": "taskwarrior-plugin/task-status",
+      "line": "taskwarrior-plugin/task-status: Read-only taskwarrior queue report \u2014 pending: Use when auditing queue health"
+    },
+    {
+      "id": "terraform-plugin/infrastructure-terraform",
+      "line": "terraform-plugin/infrastructure-terraform: Terraform IaC: HCL, state management: Use when the user mentions Terraform"
+    },
+    {
+      "id": "terraform-plugin/tfc-list-runs",
+      "line": "terraform-plugin/tfc-list-runs: List Terraform Cloud workspace runs filtered by: Use when reviewing run history"
+    },
+    {
+      "id": "terraform-plugin/tfc-plan-json",
+      "line": "terraform-plugin/tfc-plan-json: TFC plan JSON download and analysis: Use when diffing resource changes"
+    },
+    {
+      "id": "terraform-plugin/tfc-run-logs",
+      "line": "terraform-plugin/tfc-run-logs: Retrieve plan and apply logs from: Use when debugging failed plans/applies"
+    },
+    {
+      "id": "terraform-plugin/tfc-run-status",
+      "line": "terraform-plugin/tfc-run-status: Terraform Cloud run status with resource counts: Use when polling a run"
+    },
+    {
+      "id": "terraform-plugin/tfc-workspace-runs",
+      "line": "terraform-plugin/tfc-workspace-runs: List TFC runs across known workspaces (github: Use when checking TFC status"
+    },
+    {
+      "id": "testing-plugin/mutation-testing",
+      "line": "testing-plugin/mutation-testing: Mutation testing with Stryker (TS/JS): Use when finding weak tests that pass"
+    },
+    {
+      "id": "testing-plugin/odiff-image-diffing",
+      "line": "testing-plugin/odiff-image-diffing: odiff pixel-by-pixel image diffing: Use when comparing screenshots"
+    },
+    {
+      "id": "testing-plugin/playwright-cli",
+      "line": "testing-plugin/playwright-cli: Playwright CLI browser automation: Use when automating browser tasks from"
+    },
+    {
+      "id": "testing-plugin/playwright-testing",
+      "line": "testing-plugin/playwright-testing: Playwright E2E testing \u2014 cross-browser, visual: Use when writing E2E tests"
+    },
+    {
+      "id": "testing-plugin/property-based-testing",
+      "line": "testing-plugin/property-based-testing: Property-based testing with fast-check (TS/JS): Use when generating test data"
+    },
+    {
+      "id": "testing-plugin/test-analyze",
+      "line": "testing-plugin/test-analyze: Analyze test results and create a fix plan: Use when triaging failing tests"
+    },
+    {
+      "id": "testing-plugin/test-consult",
+      "line": "testing-plugin/test-consult: Consult the test-architecture agent: Use when asking about coverage gaps"
+    },
+    {
+      "id": "testing-plugin/test-focus",
+      "line": "testing-plugin/test-focus: Run one test file fail-fast for rapid TDD: Use when iterating on a failing spec"
+    },
+    {
+      "id": "testing-plugin/test-full",
+      "line": "testing-plugin/test-full: Run complete test suite in pyramid order: Use when running all tests before a PR"
+    },
+    {
+      "id": "testing-plugin/test-quality-analysis",
+      "line": "testing-plugin/test-quality-analysis: Detect test smells, overmocking, flaky tests: Use when reviewing tests"
+    },
+    {
+      "id": "testing-plugin/test-quick",
+      "line": "testing-plugin/test-quick: Run fast unit tests only, skip: Use when checking units after a change"
+    },
+    {
+      "id": "testing-plugin/test-report",
+      "line": "testing-plugin/test-report: Show cached test status without re-running: Use when checking test health"
+    },
+    {
+      "id": "testing-plugin/test-run",
+      "line": "testing-plugin/test-run: Universal test runner auto-detecting pytest, vitest: Use when running tests"
+    },
+    {
+      "id": "testing-plugin/test-setup",
+      "line": "testing-plugin/test-setup: Configure testing infrastructure with CI/CD: Use when setting up tests"
+    },
+    {
+      "id": "testing-plugin/test-strategy-review",
+      "line": "testing-plugin/test-strategy-review: Evaluate whether a test suite actually: Use when a suite is green but you doubt"
+    },
+    {
+      "id": "testing-plugin/test-tier-selection",
+      "line": "testing-plugin/test-tier-selection: Auto-select test tiers based on change scope \u2014 unit: Use when running tests"
+    },
+    {
+      "id": "testing-plugin/vitest-testing",
+      "line": "testing-plugin/vitest-testing: Vitest test runner \u2014 Vite-native, ESM: Use when setting up tests for Vite"
+    },
+    {
+      "id": "tools-plugin/binary-analysis",
+      "line": "tools-plugin/binary-analysis: Binary analysis: strings, binwalk, hexdump: Use when identifying unknown files"
+    },
+    {
+      "id": "tools-plugin/cli-smoke-recipes",
+      "line": "tools-plugin/cli-smoke-recipes: CLI smoke recipes: expose pure-function: Use when designing data-transform"
+    },
+    {
+      "id": "tools-plugin/d2-diagrams",
+      "line": "tools-plugin/d2-diagrams: Generate diagrams from text using D2: Use when creating architecture diagrams"
+    },
+    {
+      "id": "tools-plugin/deps-install",
+      "line": "tools-plugin/deps-install: Deps install: auto-detect package manager (uv, bun: Use when installing deps"
+    },
+    {
+      "id": "tools-plugin/fd-file-finding",
+      "line": "tools-plugin/fd-file-finding: fd fast file finding: smart defaults: Use when searching for files by name"
+    },
+    {
+      "id": "tools-plugin/generate-image",
+      "line": "tools-plugin/generate-image: Image generation via Gemini 3 Pro Image: aspect: Use when creating artwork"
+    },
+    {
+      "id": "tools-plugin/hf-downloads",
+      "line": "tools-plugin/hf-downloads: Hugging Face model downloads without filling: Use when downloading HF models"
+    },
+    {
+      "id": "tools-plugin/imagemagick-conversion",
+      "line": "tools-plugin/imagemagick-conversion: ImageMagick image manipulation: format conversion: Use when converting"
+    },
+    {
+      "id": "tools-plugin/jq-json-processing",
+      "line": "tools-plugin/jq-json-processing: jq JSON processing: query, filter, transform JSON: Use when parsing JSON files"
+    },
+    {
+      "id": "tools-plugin/justfile-expert",
+      "line": "tools-plugin/justfile-expert: Just command runner expertise \u2014 Justfile syntax: Use when authoring justfiles"
+    },
+    {
+      "id": "tools-plugin/mermaid-diagrams",
+      "line": "tools-plugin/mermaid-diagrams: Render Mermaid diagrams (mmdc) to SVG/PNG/PDF: Use when rendering .mmd"
+    },
+    {
+      "id": "tools-plugin/nushell-data-processing",
+      "line": "tools-plugin/nushell-data-processing: Structured data processing: Use when running multi-step cross-format"
+    },
+    {
+      "id": "tools-plugin/rg-code-search",
+      "line": "tools-plugin/rg-code-search: ripgrep (rg) fast code search: smart: Use when searching for text patterns"
+    },
+    {
+      "id": "tools-plugin/shell-expert",
+      "line": "tools-plugin/shell-expert: Shell scripting: bash, zsh, POSIX, CLI tools: Use when writing shell scripts"
+    },
+    {
+      "id": "tools-plugin/yq-yaml-processing",
+      "line": "tools-plugin/yq-yaml-processing: yq YAML processing: query, filter, transform YAML: Use when parsing configs"
+    },
+    {
+      "id": "typescript-plugin/biome-tooling",
+      "line": "typescript-plugin/biome-tooling: Biome all-in-one JS/TS formatter: Use when setting up formatting/linting"
+    },
+    {
+      "id": "typescript-plugin/bun-add",
+      "line": "typescript-plugin/bun-add: Bun add: install a package, add dev: Use when the user wants to add/install"
+    },
+    {
+      "id": "typescript-plugin/bun-build",
+      "line": "typescript-plugin/bun-build: Bun build: bundle or compile JS/TS: Use when the user wants to bundle"
+    },
+    {
+      "id": "typescript-plugin/bun-debug",
+      "line": "typescript-plugin/bun-debug: Bun debugger via --inspect: Use when the user wants to debug a TS/JS"
+    },
+    {
+      "id": "typescript-plugin/bun-development",
+      "line": "typescript-plugin/bun-development: Bun runtime workflows for running scripts, testing: Use when running a TS file"
+    },
+    {
+      "id": "typescript-plugin/bun-install",
+      "line": "typescript-plugin/bun-install: Bun install: install all deps from: Use when bootstrapping a checkout"
+    },
+    {
+      "id": "typescript-plugin/bun-lockfile-update",
+      "line": "typescript-plugin/bun-lockfile-update: Bun lockfile update (bun.lock): bun update: Use when updating dependencies"
+    },
+    {
+      "id": "typescript-plugin/bun-outdated",
+      "line": "typescript-plugin/bun-outdated: Bun outdated: check which deps have newer versions: Use when auditing freshness"
+    },
+    {
+      "id": "typescript-plugin/bun-package-manager",
+      "line": "typescript-plugin/bun-package-manager: Fast JavaScript package management with Bun: Use when installing all deps"
+    },
+    {
+      "id": "typescript-plugin/bun-publish",
+      "line": "typescript-plugin/bun-publish: Bun publish to npm: Use when the user wants to release"
+    },
+    {
+      "id": "typescript-plugin/bun-publishing",
+      "line": "typescript-plugin/bun-publishing: Publish npm packages built with Bun: package.json config: Use when setting up"
+    },
+    {
+      "id": "typescript-plugin/bun-test",
+      "line": "typescript-plugin/bun-test: Bun test runner with compact agent-friendly output: Use when running bun tests"
+    },
+    {
+      "id": "typescript-plugin/knip-dead-code",
+      "line": "typescript-plugin/knip-dead-code: Knip dead-code detector for JS/TS: unused files: Use when cleaning up codebases"
+    },
+    {
+      "id": "typescript-plugin/nodejs-development",
+      "line": "typescript-plugin/nodejs-development: Node.js development with Bun, Vite, Vue 3: Use when the user mentions Node.js"
+    },
+    {
+      "id": "typescript-plugin/typescript-debugging",
+      "line": "typescript-plugin/typescript-debugging: Modern TypeScript/JavaScript debugging with Bun: Use when setting up interactive"
+    },
+    {
+      "id": "typescript-plugin/typescript-sentry",
+      "line": "typescript-plugin/typescript-sentry: Error monitoring and performance with Sentry SDK: Use when adding Sentry"
+    },
+    {
+      "id": "typescript-plugin/typescript-strict",
+      "line": "typescript-plugin/typescript-strict: TypeScript strict mode: tsconfig.json, strict flags: Use when setting up TS"
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-checkpoint-refactor",
+      "line": "workflow-orchestration-plugin/workflow-checkpoint-refactor: Multi-phase refactoring with checkpoint: Use when refactoring spans 10+ files"
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-preflight",
+      "line": "workflow-orchestration-plugin/workflow-preflight: Pre-work validation before implementation: Use when starting an issue"
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-verify-before-filing",
+      "line": "workflow-orchestration-plugin/workflow-verify-before-filing: Verify accumulated bug claims at upstream: Use when filing upstream reports from"
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-wave-dispatch",
+      "line": "workflow-orchestration-plugin/workflow-wave-dispatch: Sequential-wave dispatch for multi-agent work: Use when planning multi-step work"
+    }
+  ]
+}

--- a/experiments/skill-catalog-routing/catalogs/catalog.domain-medium.json
+++ b/experiments/skill-catalog-routing/catalogs/catalog.domain-medium.json
@@ -1,0 +1,1631 @@
+{
+  "variant": "domain-medium",
+  "source_sha": "0ed1791a1abb10ba687ae115adf637b9f5b9cc59",
+  "skill_count": 406,
+  "entries": [
+    {
+      "id": "accessibility-plugin/accessibility-implementation",
+      "line": "accessibility-plugin/accessibility-implementation: WCAG 2.1/2.2 compliance, ARIA patterns, keyboard nav, focus management, a11y"
+    },
+    {
+      "id": "accessibility-plugin/design-tokens",
+      "line": "accessibility-plugin/design-tokens: Design tokens and CSS custom properties: theme systems, dark mode, component"
+    },
+    {
+      "id": "agent-patterns-plugin/adversarial-review",
+      "line": "agent-patterns-plugin/adversarial-review: Adversarial second-pass review that tries to break code, designs, plans, or ADRs"
+    },
+    {
+      "id": "agent-patterns-plugin/agent-teams",
+      "line": "agent-patterns-plugin/agent-teams: Configure Claude Code agent teams (implicit team, SendMessage, TaskUpdate)"
+    },
+    {
+      "id": "agent-patterns-plugin/cold-read-gate",
+      "line": "agent-patterns-plugin/cold-read-gate: Gate outward-bound text (upstream issues, docs, PR bodies) through isolated"
+    },
+    {
+      "id": "agent-patterns-plugin/custom-agent-definitions",
+      "line": "agent-patterns-plugin/custom-agent-definitions: Write and configure custom agent definitions in Claude Code agents/ directory"
+    },
+    {
+      "id": "agent-patterns-plugin/exclusive-lock-dispatch",
+      "line": "agent-patterns-plugin/exclusive-lock-dispatch: Pre-dump-then-dispatch for tools holding an exclusive lock (Ghidra, migrations"
+    },
+    {
+      "id": "agent-patterns-plugin/execution-grounded-review",
+      "line": "agent-patterns-plugin/execution-grounded-review: Execution-grounded review: run tests first, trace each acceptance criterion"
+    },
+    {
+      "id": "agent-patterns-plugin/expose-tunable-knob",
+      "line": "agent-patterns-plugin/expose-tunable-knob: Expose a live-adjustable control instead of guessing a magic constant"
+    },
+    {
+      "id": "agent-patterns-plugin/mcp-code-execution",
+      "line": "agent-patterns-plugin/mcp-code-execution: Scaffold the code execution pattern for MCP-based agents"
+    },
+    {
+      "id": "agent-patterns-plugin/mcp-management",
+      "line": "agent-patterns-plugin/mcp-management: Install and configure MCP servers for Claude Code"
+    },
+    {
+      "id": "agent-patterns-plugin/mcp-server-authoring",
+      "line": "agent-patterns-plugin/mcp-server-authoring: FastMCP authoring for Python MCP servers \u2014 tools, resources, prompts, TDD"
+    },
+    {
+      "id": "agent-patterns-plugin/meta-assimilate",
+      "line": "agent-patterns-plugin/meta-assimilate: Copy, generalize, or merge a project's .claude/{agents,commands} into"
+    },
+    {
+      "id": "agent-patterns-plugin/meta-audit",
+      "line": "agent-patterns-plugin/meta-audit: Audit Claude subagent configs for completeness, security, and best practices"
+    },
+    {
+      "id": "agent-patterns-plugin/meta-context-diet",
+      "line": "agent-patterns-plugin/meta-context-diet: Audit CLAUDE.md and .claude/rules for always-loaded content that should become"
+    },
+    {
+      "id": "agent-patterns-plugin/meta-promote",
+      "line": "agent-patterns-plugin/meta-promote: Promote rules, skills, or agents from project scope to parent or user-global"
+    },
+    {
+      "id": "agent-patterns-plugin/multi-model-delegation",
+      "line": "agent-patterns-plugin/multi-model-delegation: Multi-model design consults via PAL (kimi, glm, gemini, gpt)"
+    },
+    {
+      "id": "agent-patterns-plugin/parallel-agent-dispatch",
+      "line": "agent-patterns-plugin/parallel-agent-dispatch: Dispatch contract for spawning parallel agents covering worktree collisions"
+    },
+    {
+      "id": "agent-patterns-plugin/plugin-settings",
+      "line": "agent-patterns-plugin/plugin-settings: Configure per-project plugin settings via .claude/plugin-name.local.md files"
+    },
+    {
+      "id": "agent-patterns-plugin/verify-before-plan",
+      "line": "agent-patterns-plugin/verify-before-plan: Verify orchestrator premises (file counts, build state, artefact presence)"
+    },
+    {
+      "id": "agent-patterns-plugin/wave-based-dispatch",
+      "line": "agent-patterns-plugin/wave-based-dispatch: Sequential-wave dispatch for WO chains where output of one feeds the next"
+    },
+    {
+      "id": "agents-plugin/agents-analyze",
+      "line": "agents-plugin/agents-analyze: Audit plugins for sub-agent opportunities \u2014 verbose skills, coverage gaps"
+    },
+    {
+      "id": "api-plugin/api-testing",
+      "line": "api-plugin/api-testing: HTTP API testing with Supertest (TS) and httpx/pytest (Python)"
+    },
+    {
+      "id": "bevy-plugin/bevy-ecs-patterns",
+      "line": "bevy-plugin/bevy-ecs-patterns: Advanced Bevy ECS: complex queries, system scheduling, change detection,"
+    },
+    {
+      "id": "bevy-plugin/bevy-game-engine",
+      "line": "bevy-plugin/bevy-game-engine: Bevy game engine: ECS, rendering, input, and asset management"
+    },
+    {
+      "id": "blog-plugin/blog-post",
+      "line": "blog-plugin/blog-post: Create a blog post via guided prompts with git context auto-populated"
+    },
+    {
+      "id": "blog-plugin/blog-post-writing",
+      "line": "blog-plugin/blog-post-writing: Style guide for technical blog posts \u2014 updates, retrospectives, tutorials, deep"
+    },
+    {
+      "id": "blueprint-plugin/adr-relationships",
+      "line": "blueprint-plugin/adr-relationships: Domain analysis, conflict detection, and relationship validation"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-adr-list",
+      "line": "blueprint-plugin/blueprint-adr-list: List ADRs as a markdown table with title, status, date, domain"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-adr-validate",
+      "line": "blueprint-plugin/blueprint-adr-validate: Validate ADR relationships, domain consistency, and duplicate ADR numbers"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-autonomy-level3",
+      "line": "blueprint-plugin/blueprint-autonomy-level3: Install blueprint autonomy level 3 (ADR-0020): scheduled-autorun +"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-autopilot",
+      "line": "blueprint-plugin/blueprint-autopilot: Run due blueprint maintenance ambiently at autonomy level 2+"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-claude-md",
+      "line": "blueprint-plugin/blueprint-claude-md: Generate or update CLAUDE.md from blueprint artifacts"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-curate-docs",
+      "line": "blueprint-plugin/blueprint-curate-docs: Curate library gotchas and project patterns into .claude/rules/ entries for AI"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-derive-plans",
+      "line": "blueprint-plugin/blueprint-derive-plans: Derive PRDs, ADRs, PRPs from git history, docs, and codebase"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-derive-rules",
+      "line": "blueprint-plugin/blueprint-derive-rules: Derive Claude rules from git commit history"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-derive-tests",
+      "line": "blueprint-plugin/blueprint-derive-tests: Derive test regression plans from git history by finding commits lacking tests"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-development",
+      "line": "blueprint-plugin/blueprint-development: Generate project-specific rules from PRDs for Blueprint Development"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-docs-currency",
+      "line": "blueprint-plugin/blueprint-docs-currency: Enforce same-commit landing of code and docs (APIs, formats, ADRs)"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-docs-list",
+      "line": "blueprint-plugin/blueprint-docs-list: List blueprint documents (ADRs, PRDs, PRPs) with frontmatter metadata"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-execute",
+      "line": "blueprint-plugin/blueprint-execute: Blueprint meta command: determine and execute the next logical action"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-feature-tracker-status",
+      "line": "blueprint-plugin/blueprint-feature-tracker-status: Display feature tracker stats, phase progress, and completion summary"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-feature-tracker-sync",
+      "line": "blueprint-plugin/blueprint-feature-tracker-sync: Sync feature tracker with TODO.md, taskwarrior sidecars, and PRDs"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-generate-rules",
+      "line": "blueprint-plugin/blueprint-generate-rules: Generate project-specific rules from PRDs with path-scoped frontmatter"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-init",
+      "line": "blueprint-plugin/blueprint-init: Initialize Blueprint Development structure"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-migration",
+      "line": "blueprint-plugin/blueprint-migration: Versioned migration procedures for blueprint format upgrades (v1.x to v3.3)"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-promote",
+      "line": "blueprint-plugin/blueprint-promote: Move generated artifact to custom layer to preserve manual edits"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-prp-create",
+      "line": "blueprint-plugin/blueprint-prp-create: Create a PRP (Product Requirement Prompt) with research, context, and validation"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-prp-execute",
+      "line": "blueprint-plugin/blueprint-prp-execute: Execute a PRP with validation loop, TDD, and quality gates"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-rules",
+      "line": "blueprint-plugin/blueprint-rules: Manage modular rules in .claude/rules/ with path-specific globs"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-status",
+      "line": "blueprint-plugin/blueprint-status: Show blueprint version, config, PRD/ADR/PRP counts, and feature tracker progress"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-story-audit",
+      "line": "blueprint-plugin/blueprint-story-audit: Audit user stories against codebase and tests for tier-ranked coverage gaps"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-story-reconcile",
+      "line": "blueprint-plugin/blueprint-story-reconcile: Reconcile PRD requirements with a story-audit drift report"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-sync",
+      "line": "blueprint-plugin/blueprint-sync: Check for stale generated content and offer regeneration or promotion"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-sync-ids",
+      "line": "blueprint-plugin/blueprint-sync-ids: Scan blueprint docs and assign missing PRD/ADR/PRP/WO IDs"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-upgrade",
+      "line": "blueprint-plugin/blueprint-upgrade: Upgrade blueprint structure to the latest format version"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-work-order",
+      "line": "blueprint-plugin/blueprint-work-order: Create a work-order for isolated subagent execution, optionally linked"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-workspace-scan",
+      "line": "blueprint-plugin/blueprint-workspace-scan: Discover child blueprint workspaces and refresh the manifest"
+    },
+    {
+      "id": "blueprint-plugin/confidence-scoring",
+      "line": "blueprint-plugin/confidence-scoring: Assess quality of PRPs and work-orders using systematic confidence scoring"
+    },
+    {
+      "id": "blueprint-plugin/document-detection",
+      "line": "blueprint-plugin/document-detection: Detect PRD/ADR/PRP opportunities in conversations and prompt for document"
+    },
+    {
+      "id": "blueprint-plugin/document-linking",
+      "line": "blueprint-plugin/document-linking: Unified ID system for PRDs, ADRs, PRPs, and GitHub issues with bidirectional"
+    },
+    {
+      "id": "blueprint-plugin/feature-tracking",
+      "line": "blueprint-plugin/feature-tracking: Track feature implementation against requirements with hierarchical FR codes"
+    },
+    {
+      "id": "code-quality-plugin/ast-grep-search",
+      "line": "code-quality-plugin/ast-grep-search: Find and replace code patterns structurally with ast-grep"
+    },
+    {
+      "id": "code-quality-plugin/bulk-sweep-classify",
+      "line": "code-quality-plugin/bulk-sweep-classify: Classify every regex match before a bulk find-replace/syntax-modernization sweep"
+    },
+    {
+      "id": "code-quality-plugin/code-antipatterns",
+      "line": "code-quality-plugin/code-antipatterns: Analyze a codebase for anti-patterns using ast-grep"
+    },
+    {
+      "id": "code-quality-plugin/code-complexity",
+      "line": "code-quality-plugin/code-complexity: Analyze code complexity metrics (cyclomatic, cognitive, function length"
+    },
+    {
+      "id": "code-quality-plugin/code-dead-code",
+      "line": "code-quality-plugin/code-dead-code: Detect dead code, unused exports, unreachable branches, and orphaned files"
+    },
+    {
+      "id": "code-quality-plugin/code-dep-audit",
+      "line": "code-quality-plugin/code-dep-audit: Audit dependencies for security vulnerabilities, outdated packages, and license"
+    },
+    {
+      "id": "code-quality-plugin/code-docs-quality",
+      "line": "code-quality-plugin/code-docs-quality: Analyze docs quality across PRDs, ADRs, PRPs, CLAUDE.md, .claude/rules/"
+    },
+    {
+      "id": "code-quality-plugin/code-hidden-failures",
+      "line": "code-quality-plugin/code-hidden-failures: Scan for hidden failures: swallowed errors (empty catch, || true, 2>/dev/null)"
+    },
+    {
+      "id": "code-quality-plugin/code-lint",
+      "line": "code-quality-plugin/code-lint: Universal linter that auto-detects ruff/eslint/clippy/gofmt for the project"
+    },
+    {
+      "id": "code-quality-plugin/code-refactor",
+      "line": "code-quality-plugin/code-refactor: Refactor toward pure functions, immutability, composition"
+    },
+    {
+      "id": "code-quality-plugin/code-review",
+      "line": "code-quality-plugin/code-review: Code review for quality, security, performance, and architecture"
+    },
+    {
+      "id": "code-quality-plugin/code-review-checklist",
+      "line": "code-quality-plugin/code-review-checklist: Checklist for security, correctness, and performance review"
+    },
+    {
+      "id": "code-quality-plugin/code-test-quality",
+      "line": "code-quality-plugin/code-test-quality: Analyze test quality: smells, empty assertions, flaky patterns, coverage gaps"
+    },
+    {
+      "id": "code-quality-plugin/debugging-methodology",
+      "line": "code-quality-plugin/debugging-methodology: Systematic debugging for memory, performance, and system-level issues"
+    },
+    {
+      "id": "code-quality-plugin/dry-consolidation",
+      "line": "code-quality-plugin/dry-consolidation: Find and extract duplicated code into shared abstractions"
+    },
+    {
+      "id": "codebase-attributes-plugin/attributes-collect",
+      "line": "codebase-attributes-plugin/attributes-collect: Collect codebase health attributes as structured JSON"
+    },
+    {
+      "id": "codebase-attributes-plugin/attributes-dashboard",
+      "line": "codebase-attributes-plugin/attributes-dashboard: Codebase health dashboard with scores and severity for docs, testing, security"
+    },
+    {
+      "id": "codebase-attributes-plugin/attributes-route",
+      "line": "codebase-attributes-plugin/attributes-route: Route to specialized agents (security, test, refactor, docs) based on codebase"
+    },
+    {
+      "id": "comfyui-plugin/comfy-cli",
+      "line": "comfyui-plugin/comfy-cli: The `comfy` CLI for ComfyUI: install/update/bisect custom nodes"
+    },
+    {
+      "id": "comfyui-plugin/comfy-conditionals",
+      "line": "comfyui-plugin/comfy-conditionals: ComfyUI predicate/boolean nodes: compare, AND/OR/XOR/NOT, ternary"
+    },
+    {
+      "id": "comfyui-plugin/comfy-corpus-validation",
+      "line": "comfyui-plugin/comfy-corpus-validation: Verify ComfyUI sampler/scheduler facts: source-of-truth ladder, measured sigma"
+    },
+    {
+      "id": "comfyui-plugin/comfy-debug-preview",
+      "line": "comfyui-plugin/comfy-debug-preview: ComfyUI debug/preview nodes: show text/numbers/JSON/tensor shapes, image"
+    },
+    {
+      "id": "comfyui-plugin/comfy-flow-control",
+      "line": "comfyui-plugin/comfy-flow-control: ComfyUI routing nodes: typed switches, index switches, broadcast (Anything"
+    },
+    {
+      "id": "comfyui-plugin/comfy-image-utils",
+      "line": "comfyui-plugin/comfy-image-utils: ComfyUI non-inference image ops: resize/crop/pad/tile/batch/mask utilities, plus"
+    },
+    {
+      "id": "comfyui-plugin/comfy-math-strings",
+      "line": "comfyui-plugin/comfy-math-strings: ComfyUI compute/string nodes: constants, sliders, math expressions, string"
+    },
+    {
+      "id": "comfyui-plugin/comfy-metadata",
+      "line": "comfyui-plugin/comfy-metadata: Extract/analyze ComfyUI metadata embedded in output files - PNG tEXt, WebP EXIF"
+    },
+    {
+      "id": "comfyui-plugin/comfy-node",
+      "line": "comfyui-plugin/comfy-node: Orchestrate a ComfyUI node pack from idea to registry: scaffold, create + seed"
+    },
+    {
+      "id": "comfyui-plugin/comfy-registry-lifecycle",
+      "line": "comfyui-plugin/comfy-registry-lifecycle: Comfy Registry release pipeline: release-please + lockfile drift traps,"
+    },
+    {
+      "id": "comfyui-plugin/comfy-subgraphs-app-mode",
+      "line": "comfyui-plugin/comfy-subgraphs-app-mode: ComfyUI Subgraphs, Subgraph Blueprints, and App Mode: creating/publishing"
+    },
+    {
+      "id": "comfyui-plugin/comfy-workflow-json",
+      "line": "comfyui-plugin/comfy-workflow-json: Programmatically edit ComfyUI workflow JSON: edge-list link rebuilds"
+    },
+    {
+      "id": "comfyui-plugin/comfy-workflow-layout",
+      "line": "comfyui-plugin/comfy-workflow-layout: Auto-layout a ComfyUI workflow JSON with a layered DAG algorithm"
+    },
+    {
+      "id": "comfyui-plugin/comfyui-node-authoring",
+      "line": "comfyui-plugin/comfyui-node-authoring: ComfyUI frontend/backend authoring facts: hiding/serializing widgets, DOM event"
+    },
+    {
+      "id": "comfyui-plugin/comfyui-node-scaffold",
+      "line": "comfyui-plugin/comfyui-node-scaffold: Scaffold a new ComfyUI custom-node repo (TypeScript + bun build, CI"
+    },
+    {
+      "id": "comfyui-plugin/comfyui-pack-live-smoke",
+      "line": "comfyui-plugin/comfyui-pack-live-smoke: Live-smoke a ComfyUI pack in a running instance: browser-driven and headless"
+    },
+    {
+      "id": "comfyui-plugin/comfyui-screenshot-pipeline",
+      "line": "comfyui-plugin/comfyui-screenshot-pipeline: Containerized README-screenshot pipeline (Docker + Playwright) for ComfyUI"
+    },
+    {
+      "id": "communication-plugin/google-chat-formatting",
+      "line": "communication-plugin/google-chat-formatting: Convert Markdown to Google Chat formatting"
+    },
+    {
+      "id": "communication-plugin/ticket-drafting-guidelines",
+      "line": "communication-plugin/ticket-drafting-guidelines: Guidelines for drafting GitHub issues using What/Why/How format"
+    },
+    {
+      "id": "component-patterns-plugin/components-version-badge",
+      "line": "component-patterns-plugin/components-version-badge: Version badge with build-info tooltip (version, commit, changelog)"
+    },
+    {
+      "id": "component-patterns-plugin/version-badge-pattern",
+      "line": "component-patterns-plugin/version-badge-pattern: Version badge UI showing build version, git commit, and changelog in a tooltip"
+    },
+    {
+      "id": "configure-plugin/ci-workflows",
+      "line": "configure-plugin/ci-workflows: GitHub Actions workflow standards"
+    },
+    {
+      "id": "configure-plugin/claude-security-settings",
+      "line": "configure-plugin/claude-security-settings: Claude Code security settings: permission wildcards, shell operator protections"
+    },
+    {
+      "id": "configure-plugin/config-sync",
+      "line": "configure-plugin/config-sync: Config sync across FVH repos: extract, diff, propagate tooling improvements"
+    },
+    {
+      "id": "configure-plugin/configure-all",
+      "line": "configure-plugin/configure-all: Run all infrastructure standards checks and fixes"
+    },
+    {
+      "id": "configure-plugin/configure-api-tests",
+      "line": "configure-plugin/configure-api-tests: API contract testing: Pact, OpenAPI validation, JSON Schema/Zod"
+    },
+    {
+      "id": "configure-plugin/configure-argocd-automerge",
+      "line": "configure-plugin/configure-argocd-automerge: ArgoCD auto-merge: configure GitHub Actions for image-updater-** branches"
+    },
+    {
+      "id": "configure-plugin/configure-cache-busting",
+      "line": "configure-plugin/configure-cache-busting: Cache-busting for Next.js and Vite: content hashing, CDN cache headers"
+    },
+    {
+      "id": "configure-plugin/configure-claude-plugins",
+      "line": "configure-plugin/configure-claude-plugins: Claude plugins marketplace setup: .claude/settings.json, GitHub Actions, plugin"
+    },
+    {
+      "id": "configure-plugin/configure-container",
+      "line": "configure-plugin/configure-container: Container infrastructure: GHCR builds, Trivy/Grype scanning, devcontainer"
+    },
+    {
+      "id": "configure-plugin/configure-coverage",
+      "line": "configure-plugin/configure-coverage: Code coverage: thresholds and reporters for Vitest, Jest, pytest, Rust"
+    },
+    {
+      "id": "configure-plugin/configure-dead-code",
+      "line": "configure-plugin/configure-dead-code: Dead-code detection: Knip, Vulture, cargo-machete, deadcode"
+    },
+    {
+      "id": "configure-plugin/configure-dockerfile",
+      "line": "configure-plugin/configure-dockerfile: Dockerfile standards: Alpine/slim base, non-root user, multi-stage builds"
+    },
+    {
+      "id": "configure-plugin/configure-docs",
+      "line": "configure-plugin/configure-docs: Code docs: TSDoc, JSDoc, pydoc, rustdoc, TypeDoc, MkDocs, Sphinx"
+    },
+    {
+      "id": "configure-plugin/configure-editor",
+      "line": "configure-plugin/configure-editor: EditorConfig and VS Code workspace settings for team consistency"
+    },
+    {
+      "id": "configure-plugin/configure-feature-flags",
+      "line": "configure-plugin/configure-feature-flags: Feature flags with OpenFeature and providers (GOFF, flagd, LaunchDarkly)"
+    },
+    {
+      "id": "configure-plugin/configure-formatting",
+      "line": "configure-plugin/configure-formatting: Biome formatter for JS/TS/JSON/CSS \u2014 the modern Prettier/ESLint replacement"
+    },
+    {
+      "id": "configure-plugin/configure-gitattributes",
+      "line": "configure-plugin/configure-gitattributes: Configure .gitattributes: union-merge for append-only tables, linguist-generated"
+    },
+    {
+      "id": "configure-plugin/configure-github-pages",
+      "line": "configure-plugin/configure-github-pages: GitHub Pages deployment workflows for docs sites"
+    },
+    {
+      "id": "configure-plugin/configure-gitignore",
+      "line": "configure-plugin/configure-gitignore: Manage .gitignore's Claude Code block \u2014 worktrees, scheduled-task lock, local"
+    },
+    {
+      "id": "configure-plugin/configure-instrumentation",
+      "line": "configure-plugin/configure-instrumentation: Observability instrumentation: OpenTelemetry traces/metrics, structured logging"
+    },
+    {
+      "id": "configure-plugin/configure-integration-tests",
+      "line": "configure-plugin/configure-integration-tests: Integration testing: Supertest, pytest, Testcontainers"
+    },
+    {
+      "id": "configure-plugin/configure-justfile",
+      "line": "configure-plugin/configure-justfile: Check and configure Justfiles with standard recipes"
+    },
+    {
+      "id": "configure-plugin/configure-linting",
+      "line": "configure-plugin/configure-linting: Modern linters: Biome, Ruff, Clippy"
+    },
+    {
+      "id": "configure-plugin/configure-load-tests",
+      "line": "configure-plugin/configure-load-tests: Load testing: k6, Artillery, Locust"
+    },
+    {
+      "id": "configure-plugin/configure-makefile",
+      "line": "configure-plugin/configure-makefile: Makefile with standard targets (help, test, build, clean, lint)"
+    },
+    {
+      "id": "configure-plugin/configure-mcp",
+      "line": "configure-plugin/configure-mcp: Check and configure MCP servers for project integration"
+    },
+    {
+      "id": "configure-plugin/configure-memory-profiling",
+      "line": "configure-plugin/configure-memory-profiling: Memory profiling with pytest-memray for Python"
+    },
+    {
+      "id": "configure-plugin/configure-mise",
+      "line": "configure-plugin/configure-mise: mise runtime/tool version manager - mise.toml, backends"
+    },
+    {
+      "id": "configure-plugin/configure-package-management",
+      "line": "configure-plugin/configure-package-management: Package managers: uv (Python), bun (TypeScript)"
+    },
+    {
+      "id": "configure-plugin/configure-pre-commit",
+      "line": "configure-plugin/configure-pre-commit: pre-commit hooks setup and validation"
+    },
+    {
+      "id": "configure-plugin/configure-readme",
+      "line": "configure-plugin/configure-readme: README.md with logo, badges, features, tech stack sections"
+    },
+    {
+      "id": "configure-plugin/configure-release-please",
+      "line": "configure-plugin/configure-release-please: release-please workflow setup and auditing"
+    },
+    {
+      "id": "configure-plugin/configure-repo",
+      "line": "configure-plugin/configure-repo: Repo onboarding driver: .claude/ directory, SessionStart hook, install_pkgs.sh"
+    },
+    {
+      "id": "configure-plugin/configure-reusable-workflows",
+      "line": "configure-plugin/configure-reusable-workflows: Reusable GitHub Actions workflows for security, quality, accessibility"
+    },
+    {
+      "id": "configure-plugin/configure-security",
+      "line": "configure-plugin/configure-security: Security scanning: dependency audits, SAST, secrets detection"
+    },
+    {
+      "id": "configure-plugin/configure-select",
+      "line": "configure-plugin/configure-select: Interactive selector for infrastructure standards"
+    },
+    {
+      "id": "configure-plugin/configure-sentry",
+      "line": "configure-plugin/configure-sentry: Sentry error tracking setup"
+    },
+    {
+      "id": "configure-plugin/configure-skaffold",
+      "line": "configure-plugin/configure-skaffold: Skaffold for Kubernetes: port forwarding, dotenvx hooks, API version"
+    },
+    {
+      "id": "configure-plugin/configure-status",
+      "line": "configure-plugin/configure-status: Infrastructure compliance status (read-only)"
+    },
+    {
+      "id": "configure-plugin/configure-surface",
+      "line": "configure-plugin/configure-surface: Surface doc-drift gate: scaffold surf.toml + hubs, wire the SHA-pinned"
+    },
+    {
+      "id": "configure-plugin/configure-tests",
+      "line": "configure-plugin/configure-tests: Test frameworks: Vitest, Jest, pytest, cargo-nextest"
+    },
+    {
+      "id": "configure-plugin/configure-ux-testing",
+      "line": "configure-plugin/configure-ux-testing: UX testing: Playwright E2E, axe-core a11y, visual regression"
+    },
+    {
+      "id": "configure-plugin/configure-web-session",
+      "line": "configure-plugin/configure-web-session: SessionStart hook for Claude Code web sessions to install tools (helm"
+    },
+    {
+      "id": "configure-plugin/configure-workflows",
+      "line": "configure-plugin/configure-workflows: GitHub Actions CI/CD workflows for container builds, tests, releases"
+    },
+    {
+      "id": "configure-plugin/configure-worktreeinclude",
+      "line": "configure-plugin/configure-worktreeinclude: Generate a .worktreeinclude so Claude Code copies gitignored env/secret/config"
+    },
+    {
+      "id": "configure-plugin/go-feature-flag",
+      "line": "configure-plugin/go-feature-flag: GO Feature Flag (GOFF) self-hosted feature flags with OpenFeature integration \u2014"
+    },
+    {
+      "id": "configure-plugin/multi-repo-discipline",
+      "line": "configure-plugin/multi-repo-discipline: Multi-repo workspace rules: read-only fixtures, upstream/downstream pairs"
+    },
+    {
+      "id": "configure-plugin/openfeature",
+      "line": "configure-plugin/openfeature: OpenFeature vendor-agnostic feature flag SDK: installation, evaluation"
+    },
+    {
+      "id": "container-plugin/container-development",
+      "line": "container-plugin/container-development: Container development \u2014 Docker, multi-stage builds, Skaffold, non-root users"
+    },
+    {
+      "id": "container-plugin/deploy-handoff",
+      "line": "container-plugin/deploy-handoff: Generate deployment handoff docs \u2014 tech stack, access URLs, config, monitoring"
+    },
+    {
+      "id": "container-plugin/deploy-release",
+      "line": "container-plugin/deploy-release: Create and publish releases via release-please or manual GitHub releases"
+    },
+    {
+      "id": "container-plugin/go-containers",
+      "line": "container-plugin/go-containers: Go container optimization \u2014 scratch/distroless images, static binaries, CGO"
+    },
+    {
+      "id": "container-plugin/nodejs-containers",
+      "line": "container-plugin/nodejs-containers: Node.js container optimization \u2014 Alpine, multi-stage builds, node_modules"
+    },
+    {
+      "id": "container-plugin/python-containers",
+      "line": "container-plugin/python-containers: Python container optimization \u2014 slim images (not Alpine), virtualenv"
+    },
+    {
+      "id": "container-plugin/skaffold-filesync",
+      "line": "container-plugin/skaffold-filesync: Skaffold file sync \u2014 copy changed files to containers without rebuilding"
+    },
+    {
+      "id": "container-plugin/skaffold-orbstack",
+      "line": "container-plugin/skaffold-orbstack: OrbStack-optimized Skaffold for local Kubernetes dev without port-forward"
+    },
+    {
+      "id": "container-plugin/skaffold-testing",
+      "line": "container-plugin/skaffold-testing: Container image validation with Skaffold test/verify stages \u2014"
+    },
+    {
+      "id": "css-plugin/lightning-css",
+      "line": "css-plugin/lightning-css: Lightning CSS transpilation, bundling, and minification"
+    },
+    {
+      "id": "css-plugin/unocss",
+      "line": "css-plugin/unocss: UnoCSS atomic CSS engine for on-demand utility classes"
+    },
+    {
+      "id": "documentation-plugin/claude-blog-sources",
+      "line": "documentation-plugin/claude-blog-sources: Fetch Claude Blog and official Claude Code docs"
+    },
+    {
+      "id": "documentation-plugin/docs-decommission",
+      "line": "documentation-plugin/docs-decommission: Generate DECOMMISSION-<service>.md covering infra, data, access, DNS"
+    },
+    {
+      "id": "documentation-plugin/docs-generate",
+      "line": "documentation-plugin/docs-generate: Generate or update docs from code annotations, docstrings, and git history"
+    },
+    {
+      "id": "documentation-plugin/docs-latex",
+      "line": "documentation-plugin/docs-latex: Convert Markdown to LaTeX with TikZ and compile to PDF"
+    },
+    {
+      "id": "documentation-plugin/docs-sync",
+      "line": "documentation-plugin/docs-sync: Sync docs with actual skills, commands, and agents"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-improve",
+      "line": "evaluate-plugin/evaluate-improve: Suggest improvements to SKILL.md content, descriptions, or tool config from eval"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-legibility",
+      "line": "evaluate-plugin/evaluate-legibility: Cold-read a SKILL.md with a zero-context agent reader to check its intent is"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-matrix",
+      "line": "evaluate-plugin/evaluate-matrix: Cross-model skill evals with real execution and grading \u2014 the executability gate"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-plugin-batch",
+      "line": "evaluate-plugin/evaluate-plugin-batch: Batch evaluate every skill in a plugin and produce a plugin-level report"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-report",
+      "line": "evaluate-plugin/evaluate-report: View evaluation results and benchmark reports for a skill or plugin"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-skill",
+      "line": "evaluate-plugin/evaluate-skill: Evaluate a skill by running test cases and grading results"
+    },
+    {
+      "id": "feedback-plugin/feedback-session",
+      "line": "feedback-plugin/feedback-session: Analyze session for skill feedback and create GitHub issues"
+    },
+    {
+      "id": "finops-plugin/finops-caches",
+      "line": "finops-plugin/finops-caches: GitHub Actions cache analysis \u2014 size, prefix/branch breakdown, stale detection"
+    },
+    {
+      "id": "finops-plugin/finops-compare",
+      "line": "finops-plugin/finops-compare: FinOps metrics comparison across repos in an org"
+    },
+    {
+      "id": "finops-plugin/finops-overview",
+      "line": "finops-plugin/finops-overview: FinOps snapshot \u2014 org billing, workflow stats, cache usage"
+    },
+    {
+      "id": "finops-plugin/finops-waste",
+      "line": "finops-plugin/finops-waste: Identify GitHub Actions waste \u2014 skipped runs, bot triggers, missing concurrency"
+    },
+    {
+      "id": "finops-plugin/finops-workflows",
+      "line": "finops-plugin/finops-workflows: Analyze workflow runs \u2014 frequency, duration, success rates, efficiency"
+    },
+    {
+      "id": "finops-plugin/github-actions-cache-optimization",
+      "line": "finops-plugin/github-actions-cache-optimization: GitHub Actions cache analysis and optimization"
+    },
+    {
+      "id": "finops-plugin/github-actions-finops",
+      "line": "finops-plugin/github-actions-finops: GitHub Actions billing, workflow efficiency, and waste analysis at org or repo"
+    },
+    {
+      "id": "foundryvtt-plugin/foundryvtt-module",
+      "line": "foundryvtt-plugin/foundryvtt-module: FoundryVTT module idea to gitops-adopted repo: scaffold, create + seed the repo"
+    },
+    {
+      "id": "foundryvtt-plugin/foundryvtt-module-scaffold",
+      "line": "foundryvtt-plugin/foundryvtt-module-scaffold: Scaffold a new FoundryVTT v13 module repo (Vite + TS + bun + biome, CI"
+    },
+    {
+      "id": "git-plugin/deadbranch",
+      "line": "git-plugin/deadbranch: deadbranch CLI for stale-branch cleanup \u2014 dry-run preview, TUI"
+    },
+    {
+      "id": "git-plugin/gh-cli-agentic",
+      "line": "git-plugin/gh-cli-agentic: gh CLI commands with JSON output for agent workflows"
+    },
+    {
+      "id": "git-plugin/gh-workflow-monitoring",
+      "line": "git-plugin/gh-workflow-monitoring: Monitor GitHub Actions runs with blocking watch commands instead of polling"
+    },
+    {
+      "id": "git-plugin/git-api-pr",
+      "line": "git-plugin/git-api-pr: GitHub API PR creation without local git"
+    },
+    {
+      "id": "git-plugin/git-branch-naming",
+      "line": "git-plugin/git-branch-naming: Git branch naming conventions \u2014 type prefixes (feat/fix/chore), issue linking"
+    },
+    {
+      "id": "git-plugin/git-branch-pr-workflow",
+      "line": "git-plugin/git-branch-pr-workflow: Branch management and PR workflows \u2014 git switch/restore, GitHub MCP"
+    },
+    {
+      "id": "git-plugin/git-cli-agentic",
+      "line": "git-plugin/git-cli-agentic: Git commands with porcelain and machine-readable output for agent workflows"
+    },
+    {
+      "id": "git-plugin/git-commit",
+      "line": "git-plugin/git-commit: Create commits with conventional messages and issue references"
+    },
+    {
+      "id": "git-plugin/git-commit-push-pr",
+      "line": "git-plugin/git-commit-push-pr: End-to-end commit-to-PR workflow"
+    },
+    {
+      "id": "git-plugin/git-commit-trailers",
+      "line": "git-plugin/git-commit-trailers: Git commit trailer conventions \u2014 BREAKING CHANGE, Co-authored-by, Signed-off-by"
+    },
+    {
+      "id": "git-plugin/git-commit-workflow",
+      "line": "git-plugin/git-commit-workflow: Conventional commit format, staging, and message conventions"
+    },
+    {
+      "id": "git-plugin/git-conflicts",
+      "line": "git-plugin/git-conflicts: Resolve merge conflicts file-by-file"
+    },
+    {
+      "id": "git-plugin/git-coworker-check",
+      "line": "git-plugin/git-coworker-check: Detect coworker Claude agents in a shared checkout"
+    },
+    {
+      "id": "git-plugin/git-derive-docs",
+      "line": "git-plugin/git-derive-docs: Derive ADRs, rules, PRDs from git commit history"
+    },
+    {
+      "id": "git-plugin/git-fix-pr",
+      "line": "git-plugin/git-fix-pr: Analyze and fix failing PR checks"
+    },
+    {
+      "id": "git-plugin/git-fork-workflow",
+      "line": "git-plugin/git-fork-workflow: Fork management and upstream sync"
+    },
+    {
+      "id": "git-plugin/git-issue",
+      "line": "git-plugin/git-issue: Process GitHub issues end-to-end with TDD and parallel work"
+    },
+    {
+      "id": "git-plugin/git-issue-hierarchy",
+      "line": "git-plugin/git-issue-hierarchy: Manage GitHub sub-issues and dependencies (blocked_by/blocking)"
+    },
+    {
+      "id": "git-plugin/git-issue-manage",
+      "line": "git-plugin/git-issue-manage: GitHub issue admin operations"
+    },
+    {
+      "id": "git-plugin/git-maintain",
+      "line": "git-plugin/git-maintain: Repo maintenance \u2014 incremental repack, gc, branch pruning, stash cleanup, fsck"
+    },
+    {
+      "id": "git-plugin/git-pr",
+      "line": "git-plugin/git-pr: Create pull requests with descriptions, labels, and issue references"
+    },
+    {
+      "id": "git-plugin/git-pr-feedback",
+      "line": "git-plugin/git-pr-feedback: Address PR review comments and resolve threads"
+    },
+    {
+      "id": "git-plugin/git-pr-sync-check",
+      "line": "git-plugin/git-pr-sync-check: Checks whether the current PR branch is still live and in sync"
+    },
+    {
+      "id": "git-plugin/git-pr-watch",
+      "line": "git-plugin/git-pr-watch: Subscribe to a PR's activity and react to reviews and CI as they arrive"
+    },
+    {
+      "id": "git-plugin/git-push",
+      "line": "git-plugin/git-push: Push local commits to remote \u2014 handles branch tracking, upstream setup, safe"
+    },
+    {
+      "id": "git-plugin/git-rebase-patterns",
+      "line": "git-plugin/git-rebase-patterns: Advanced git rebase \u2014 linear history, stacked PRs, --update-refs, --onto"
+    },
+    {
+      "id": "git-plugin/git-repo-detection",
+      "line": "git-plugin/git-repo-detection: Detect GitHub repo owner/name from git remotes"
+    },
+    {
+      "id": "git-plugin/git-security-checks",
+      "line": "git-plugin/git-security-checks: Pre-commit security validation and secret detection via gitleaks"
+    },
+    {
+      "id": "git-plugin/git-triage",
+      "line": "git-plugin/git-triage: Triage GitHub issues and PRs \u2014 cross-link, flag stale items, recommend actions"
+    },
+    {
+      "id": "git-plugin/git-upstream-pr",
+      "line": "git-plugin/git-upstream-pr: Submit PRs to upstream repos from a fork \u2014 commit selection, squashing"
+    },
+    {
+      "id": "git-plugin/git-upstream-pr-diverged",
+      "line": "git-plugin/git-upstream-pr-diverged: Submit a diverged-fork commit to upstream as a clean PR via cherry-pick"
+    },
+    {
+      "id": "git-plugin/github-issue-autodetect",
+      "line": "git-plugin/github-issue-autodetect: Auto-detect GitHub issues that staged changes may fix or close. Analyzes diffs"
+    },
+    {
+      "id": "git-plugin/github-issue-writing",
+      "line": "git-plugin/github-issue-writing: Create well-structured GitHub issues with clear titles, descriptions,"
+    },
+    {
+      "id": "git-plugin/github-labels",
+      "line": "git-plugin/github-labels: Discover and apply GitHub labels via gh CLI"
+    },
+    {
+      "id": "git-plugin/github-pr-title",
+      "line": "git-plugin/github-pr-title: Craft PR titles using conventional commits format"
+    },
+    {
+      "id": "git-plugin/release-please-configuration",
+      "line": "git-plugin/release-please-configuration: release-please monorepo config \u2014 component tags, per-package extra-files, tag"
+    },
+    {
+      "id": "git-plugin/release-please-pr-workflow",
+      "line": "git-plugin/release-please-pr-workflow: Manage release-please PR merging for monorepos \u2014 batch merging, conflict"
+    },
+    {
+      "id": "git-plugin/release-please-protection",
+      "line": "git-plugin/release-please-protection: Block manual edits to release-please files (CHANGELOG, version fields)"
+    },
+    {
+      "id": "github-actions-plugin/claude-code-github-workflows",
+      "line": "github-actions-plugin/claude-code-github-workflows: Claude Code GitHub Actions workflow patterns \u2014 PR reviews, issue triage, CI/CD"
+    },
+    {
+      "id": "github-actions-plugin/github-actions-auth-security",
+      "line": "github-actions-plugin/github-actions-auth-security: GitHub Actions auth and security for Claude Code \u2014 OIDC, AWS Bedrock, Vertex AI"
+    },
+    {
+      "id": "github-actions-plugin/github-actions-inspection",
+      "line": "github-actions-plugin/github-actions-inspection: Inspect GitHub Actions runs, analyze logs, debug failures"
+    },
+    {
+      "id": "github-actions-plugin/github-actions-mcp-config",
+      "line": "github-actions-plugin/github-actions-mcp-config: MCP server config for GitHub Actions \u2014 tool permissions, env vars, multi-server"
+    },
+    {
+      "id": "github-actions-plugin/github-issue-search",
+      "line": "github-actions-plugin/github-issue-search: Search GitHub issues for solutions and workarounds"
+    },
+    {
+      "id": "github-actions-plugin/github-social-preview",
+      "line": "github-actions-plugin/github-social-preview: Generate 1280x640 PNG social preview images for GitHub repos using"
+    },
+    {
+      "id": "github-actions-plugin/github-workflow-auto-fix",
+      "line": "github-actions-plugin/github-workflow-auto-fix: Set up automated CI fixing with Claude Code"
+    },
+    {
+      "id": "github-actions-plugin/workflow-dev",
+      "line": "github-actions-plugin/workflow-dev: Automated dev loop \u2014 run tests, file issues for failures, TDD fix on branch"
+    },
+    {
+      "id": "health-plugin/health-agentic-audit",
+      "line": "health-plugin/health-agentic-audit: Audit skills, commands, and agents for agentic output compliance \u2014 optimization"
+    },
+    {
+      "id": "health-plugin/health-audit",
+      "line": "health-plugin/health-audit: Plugin audit against detected stack (Python, Node, Rust, Go, Terraform, Docker"
+    },
+    {
+      "id": "health-plugin/health-check",
+      "line": "health-plugin/health-check: Claude Code health check \u2014 scans plugins, settings, hooks, MCP, runtime state"
+    },
+    {
+      "id": "health-plugin/health-plugins",
+      "line": "health-plugin/health-plugins: Diagnose and fix Claude Code plugin registry corruption \u2014 orphaned entries"
+    },
+    {
+      "id": "health-plugin/health-skill-audit",
+      "line": "health-plugin/health-skill-audit: Audit skill tree for overlap, split-pressure, and consolidation candidates"
+    },
+    {
+      "id": "health-plugin/plugin-registry",
+      "line": "health-plugin/plugin-registry: Claude Code plugin registry structure, installation scopes, and common issues"
+    },
+    {
+      "id": "health-plugin/settings-configuration",
+      "line": "health-plugin/settings-configuration: Claude Code settings hierarchy, permission wildcards, and configuration patterns"
+    },
+    {
+      "id": "home-assistant-plugin/ha-automations",
+      "line": "home-assistant-plugin/ha-automations: Home Assistant automation creation and management"
+    },
+    {
+      "id": "home-assistant-plugin/ha-configuration",
+      "line": "home-assistant-plugin/ha-configuration: Home Assistant YAML configuration management"
+    },
+    {
+      "id": "home-assistant-plugin/ha-entities",
+      "line": "home-assistant-plugin/ha-entities: Home Assistant entity and domain management"
+    },
+    {
+      "id": "home-assistant-plugin/ha-validate",
+      "line": "home-assistant-plugin/ha-validate: Validate Home Assistant YAML for syntax errors, undefined secrets, and duplicate"
+    },
+    {
+      "id": "hooks-plugin/hooks-configuration",
+      "line": "hooks-plugin/hooks-configuration: Claude Code hooks configuration and development"
+    },
+    {
+      "id": "hooks-plugin/hooks-permission-request-hook",
+      "line": "hooks-plugin/hooks-permission-request-hook: Generate a PermissionRequest hook with auto-approve/deny rules"
+    },
+    {
+      "id": "hooks-plugin/hooks-session-end-issue-hook",
+      "line": "hooks-plugin/hooks-session-end-issue-hook: Configure a Stop hook that surfaces unfinished todos at session end"
+    },
+    {
+      "id": "hooks-plugin/hooks-session-start-hook",
+      "line": "hooks-plugin/hooks-session-start-hook: Create a SessionStart hook for Claude Code on the web"
+    },
+    {
+      "id": "kubernetes-plugin/argocd-login",
+      "line": "kubernetes-plugin/argocd-login: ArgoCD CLI auth with SSO and gRPC-Web"
+    },
+    {
+      "id": "kubernetes-plugin/helm-chart-development",
+      "line": "kubernetes-plugin/helm-chart-development: Create, test, and package Helm charts \u2014 Chart.yaml, templates, dependencies"
+    },
+    {
+      "id": "kubernetes-plugin/helm-debugging",
+      "line": "kubernetes-plugin/helm-debugging: Debug Helm failures \u2014 template errors, dry-run, YAML parse errors, value type"
+    },
+    {
+      "id": "kubernetes-plugin/helm-release-management",
+      "line": "kubernetes-plugin/helm-release-management: Manage Helm releases \u2014 install, upgrade, uninstall, list, inspect, history"
+    },
+    {
+      "id": "kubernetes-plugin/helm-release-recovery",
+      "line": "kubernetes-plugin/helm-release-recovery: Recover from failed Helm deployments \u2014 rollback, fix stuck states"
+    },
+    {
+      "id": "kubernetes-plugin/helm-values-management",
+      "line": "kubernetes-plugin/helm-values-management: Manage Helm values \u2014 override precedence, multi-env configs, --set, schema"
+    },
+    {
+      "id": "kubernetes-plugin/kubectl-debugging",
+      "line": "kubernetes-plugin/kubectl-debugging: Debug K8s pods/nodes with kubectl debug \u2014 ephemeral containers, pod copying"
+    },
+    {
+      "id": "kubernetes-plugin/kubernetes-operations",
+      "line": "kubernetes-plugin/kubernetes-operations: Kubernetes operations \u2014 deployment, management, troubleshooting, kubectl mastery"
+    },
+    {
+      "id": "langchain-plugin/deep-agents",
+      "line": "langchain-plugin/deep-agents: Build hierarchical AI agents with the deepagents npm package"
+    },
+    {
+      "id": "langchain-plugin/langchain-development",
+      "line": "langchain-plugin/langchain-development: LangChain JS/TS framework for building LLM-powered apps"
+    },
+    {
+      "id": "langchain-plugin/langchain-init",
+      "line": "langchain-plugin/langchain-init: Initialize a new LangChain TypeScript project"
+    },
+    {
+      "id": "langchain-plugin/langgraph-agents",
+      "line": "langchain-plugin/langgraph-agents: LangGraph stateful AI agents with graph-based workflows"
+    },
+    {
+      "id": "macos-plugin/endpoint-security-cpu",
+      "line": "macos-plugin/endpoint-security-cpu: macOS EndpointSecurity/EDR high CPU & battery drain"
+    },
+    {
+      "id": "macos-plugin/kitty-session-persistence",
+      "line": "macos-plugin/kitty-session-persistence: Snapshot and restore kitty terminal sessions on macOS"
+    },
+    {
+      "id": "macos-plugin/launchservices-health",
+      "line": "macos-plugin/launchservices-health: Diagnose macOS LaunchServices DB bloat and launchservicesd CPU spikes"
+    },
+    {
+      "id": "macos-plugin/macos-disk-usage",
+      "line": "macos-plugin/macos-disk-usage: macOS disk-usage forensics and space recovery on APFS"
+    },
+    {
+      "id": "macos-plugin/macos-incident-postmortem",
+      "line": "macos-plugin/macos-incident-postmortem: Reconstruct macOS freeze, panic, or reboot from DiagnosticReports and shell"
+    },
+    {
+      "id": "macos-plugin/macos-performance-benchmark",
+      "line": "macos-plugin/macos-performance-benchmark: Repeatable macOS/Apple-Silicon benchmark + diagnostics scored PASS/WARN/FAIL"
+    },
+    {
+      "id": "macos-plugin/macos-performance-triage",
+      "line": "macos-plugin/macos-performance-triage: Live macOS/Apple-Silicon performance triage \u2014 find what's heating the Mac (hot"
+    },
+    {
+      "id": "macos-plugin/tui-keybinding-debug",
+      "line": "macos-plugin/tui-keybinding-debug: Debug dead TUI/terminal keybindings \u2014 terminal interception (kitty)"
+    },
+    {
+      "id": "migration-patterns-plugin/black-to-ruff-format",
+      "line": "migration-patterns-plugin/black-to-ruff-format: Migrate Python formatting from black to ruff-format"
+    },
+    {
+      "id": "migration-patterns-plugin/dual-write",
+      "line": "migration-patterns-plugin/dual-write: Dual-write pattern for safe data store transitions"
+    },
+    {
+      "id": "migration-patterns-plugin/eslint-to-biome",
+      "line": "migration-patterns-plugin/eslint-to-biome: Migrate JS/TS linting from ESLint+Prettier to Biome"
+    },
+    {
+      "id": "migration-patterns-plugin/flake8-to-ruff",
+      "line": "migration-patterns-plugin/flake8-to-ruff: Migrate Python linting from flake8/isort to ruff"
+    },
+    {
+      "id": "migration-patterns-plugin/mypy-to-ty",
+      "line": "migration-patterns-plugin/mypy-to-ty: Migrate Python type checking from mypy to ty (Astral)"
+    },
+    {
+      "id": "migration-patterns-plugin/shadow-mode",
+      "line": "migration-patterns-plugin/shadow-mode: Shadow mode / dark-launch for validating new systems under production load"
+    },
+    {
+      "id": "networking-plugin/dns-tools",
+      "line": "networking-plugin/dns-tools: DNS resolution and propagation debugging"
+    },
+    {
+      "id": "networking-plugin/http-load-testing",
+      "line": "networking-plugin/http-load-testing: HTTP load testing with oha"
+    },
+    {
+      "id": "networking-plugin/interface-state",
+      "line": "networking-plugin/interface-state: Local interface, address, route, and neighbor state with iproute2"
+    },
+    {
+      "id": "networking-plugin/layer2-discovery",
+      "line": "networking-plugin/layer2-discovery: Layer 2 device discovery and topology mapping"
+    },
+    {
+      "id": "networking-plugin/network-diagnostics",
+      "line": "networking-plugin/network-diagnostics: Network connectivity and latency diagnostics"
+    },
+    {
+      "id": "networking-plugin/network-discovery",
+      "line": "networking-plugin/network-discovery: Network host and port discovery with nmap"
+    },
+    {
+      "id": "networking-plugin/network-monitoring",
+      "line": "networking-plugin/network-monitoring: Real-time network traffic and per-process bandwidth monitoring"
+    },
+    {
+      "id": "obsidian-plugin/bases",
+      "line": "obsidian-plugin/bases: Obsidian Bases (database-over-notes): list base files/views, create items, run"
+    },
+    {
+      "id": "obsidian-plugin/bookmarks",
+      "line": "obsidian-plugin/bookmarks: Obsidian bookmarks: list and add file/folder/heading/saved-search/URL bookmarks"
+    },
+    {
+      "id": "obsidian-plugin/command-palette",
+      "line": "obsidian-plugin/command-palette: Run, list, and inspect Obsidian commands and hotkeys from the CLI"
+    },
+    {
+      "id": "obsidian-plugin/dev-tools",
+      "line": "obsidian-plugin/dev-tools: Obsidian plugin/theme dev: DevTools, CDP, JS eval, console/error buffers"
+    },
+    {
+      "id": "obsidian-plugin/file-history",
+      "line": "obsidian-plugin/file-history: Obsidian File Recovery and Sync history: inspect, diff, restore previous note"
+    },
+    {
+      "id": "obsidian-plugin/plugins-themes",
+      "line": "obsidian-plugin/plugins-themes: Obsidian community plugins/themes/CSS snippets management"
+    },
+    {
+      "id": "obsidian-plugin/properties",
+      "line": "obsidian-plugin/properties: Obsidian YAML frontmatter properties: read, set, remove on notes"
+    },
+    {
+      "id": "obsidian-plugin/publish-sync",
+      "line": "obsidian-plugin/publish-sync: Obsidian Publish and Sync operations"
+    },
+    {
+      "id": "obsidian-plugin/search-discovery",
+      "line": "obsidian-plugin/search-discovery: Obsidian vault search: full-text/grep, tag listing, link traversal, outline"
+    },
+    {
+      "id": "obsidian-plugin/tasks",
+      "line": "obsidian-plugin/tasks: Obsidian tasks via CLI: list open tasks, create tasks, mark complete"
+    },
+    {
+      "id": "obsidian-plugin/templates",
+      "line": "obsidian-plugin/templates: Obsidian Templates plugin: list, read, insert templates"
+    },
+    {
+      "id": "obsidian-plugin/vault-files",
+      "line": "obsidian-plugin/vault-files: Obsidian vault file ops via CLI: read, create, append, move, rename, delete"
+    },
+    {
+      "id": "obsidian-plugin/vault-frontmatter",
+      "line": "obsidian-plugin/vault-frontmatter: Offline YAML frontmatter maintenance for Obsidian notes"
+    },
+    {
+      "id": "obsidian-plugin/vault-management",
+      "line": "obsidian-plugin/vault-management: Obsidian vault inspection and cross-vault routing via `vault=` prefix"
+    },
+    {
+      "id": "obsidian-plugin/vault-mocs",
+      "line": "obsidian-plugin/vault-mocs: Map-of-Content (MOC) curation for Obsidian vaults"
+    },
+    {
+      "id": "obsidian-plugin/vault-orphans",
+      "line": "obsidian-plugin/vault-orphans: Triage orphaned notes (zero in/out wikilinks) in an Obsidian vault"
+    },
+    {
+      "id": "obsidian-plugin/vault-stubs",
+      "line": "obsidian-plugin/vault-stubs: Work-namespace redirect-stub classification in an Obsidian vault"
+    },
+    {
+      "id": "obsidian-plugin/vault-tags",
+      "line": "obsidian-plugin/vault-tags: Emoji-prefixed tag taxonomy for Obsidian vaults"
+    },
+    {
+      "id": "obsidian-plugin/vault-templates",
+      "line": "obsidian-plugin/vault-templates: Obsidian Templater drift repair"
+    },
+    {
+      "id": "obsidian-plugin/vault-wikilinks",
+      "line": "obsidian-plugin/vault-wikilinks: Broken Obsidian wikilink detection and repair"
+    },
+    {
+      "id": "obsidian-plugin/workspaces",
+      "line": "obsidian-plugin/workspaces: Obsidian editor workspace: list open tabs, recent files, saved Workspaces"
+    },
+    {
+      "id": "project-plugin/changelog-review",
+      "line": "project-plugin/changelog-review: Claude Code changelog analysis for plugin impact"
+    },
+    {
+      "id": "project-plugin/project-continue",
+      "line": "project-plugin/project-continue: Resume development from current project state"
+    },
+    {
+      "id": "project-plugin/project-discovery",
+      "line": "project-plugin/project-discovery: Project orientation for unfamiliar codebases"
+    },
+    {
+      "id": "project-plugin/project-init",
+      "line": "project-plugin/project-init: Scaffold a new project with base structure (git, README, LICENSE, CI"
+    },
+    {
+      "id": "project-plugin/project-refocus",
+      "line": "project-plugin/project-refocus: Refresh the plan to focus on the task at hand"
+    },
+    {
+      "id": "project-plugin/project-skill-scripts",
+      "line": "project-plugin/project-skill-scripts: Find and create supporting scripts for plugin skills"
+    },
+    {
+      "id": "project-plugin/project-test-loop",
+      "line": "project-plugin/project-test-loop: Automated TDD test-fix-refactor cycle until tests pass"
+    },
+    {
+      "id": "prompt-engineering-plugin/prompt-engineering-ground-response",
+      "line": "prompt-engineering-plugin/prompt-engineering-ground-response: Citation-backed responses with direct quotes from source documents"
+    },
+    {
+      "id": "prose-plugin/prose-distill",
+      "line": "prose-plugin/prose-distill: Prose distill: condense verbose text to its essence"
+    },
+    {
+      "id": "prose-plugin/prose-synthesize",
+      "line": "prose-plugin/prose-synthesize: Prose synthesize: turn unstructured notes into a structured, actionable plan"
+    },
+    {
+      "id": "python-plugin/basedpyright-type-checking",
+      "line": "python-plugin/basedpyright-type-checking: Basedpyright static type checker for Python"
+    },
+    {
+      "id": "python-plugin/pytest-advanced",
+      "line": "python-plugin/pytest-advanced: Advanced pytest: fixtures, markers, parametrization, parallel execution"
+    },
+    {
+      "id": "python-plugin/python-code-quality",
+      "line": "python-plugin/python-code-quality: Python code quality with ruff and ty"
+    },
+    {
+      "id": "python-plugin/python-development",
+      "line": "python-plugin/python-development: Core Python development idioms and language features (3.10+)"
+    },
+    {
+      "id": "python-plugin/python-packaging",
+      "line": "python-plugin/python-packaging: Build and publish Python packages with uv"
+    },
+    {
+      "id": "python-plugin/python-testing",
+      "line": "python-plugin/python-testing: Python testing with pytest, coverage, fixtures, and mocking"
+    },
+    {
+      "id": "python-plugin/ruff-formatting",
+      "line": "python-plugin/ruff-formatting: Python code formatting with ruff format. Fast, Black-compatible formatter"
+    },
+    {
+      "id": "python-plugin/ruff-linting",
+      "line": "python-plugin/ruff-linting: Python linting with ruff. Fast linting, rule selection, auto-fixing, and config"
+    },
+    {
+      "id": "python-plugin/ty-type-checking",
+      "line": "python-plugin/ty-type-checking: ty: Astral's extremely fast Python type checker (mypy/Pyright alternative)"
+    },
+    {
+      "id": "python-plugin/uv-advanced-dependencies",
+      "line": "python-plugin/uv-advanced-dependencies: Advanced uv dependencies: Git deps, path deps, editable installs, groups"
+    },
+    {
+      "id": "python-plugin/uv-project-management",
+      "line": "python-plugin/uv-project-management: Python project setup, deps, and lockfiles with uv"
+    },
+    {
+      "id": "python-plugin/uv-python-versions",
+      "line": "python-plugin/uv-python-versions: Install and manage Python interpreter versions with uv"
+    },
+    {
+      "id": "python-plugin/uv-run",
+      "line": "python-plugin/uv-run: Run Python scripts with uv (PEP 723 inline deps, --with for one-off deps)"
+    },
+    {
+      "id": "python-plugin/uv-tool-management",
+      "line": "python-plugin/uv-tool-management: Install and manage global Python CLI tools with uv (pipx alternative)"
+    },
+    {
+      "id": "python-plugin/uv-workspaces",
+      "line": "python-plugin/uv-workspaces: Manage multi-package Python projects with uv workspaces"
+    },
+    {
+      "id": "python-plugin/vulture-dead-code",
+      "line": "python-plugin/vulture-dead-code: Vulture and deadcode tools for detecting unused Python code (functions, classes"
+    },
+    {
+      "id": "rust-plugin/cargo-llvm-cov",
+      "line": "rust-plugin/cargo-llvm-cov: cargo-llvm-cov: Rust code coverage with LLVM instrumentation"
+    },
+    {
+      "id": "rust-plugin/cargo-machete",
+      "line": "rust-plugin/cargo-machete: cargo-machete: detect unused Rust dependencies"
+    },
+    {
+      "id": "rust-plugin/cargo-nextest",
+      "line": "rust-plugin/cargo-nextest: cargo-nextest: fast Rust test runner with parallel execution and advanced"
+    },
+    {
+      "id": "rust-plugin/cargo-worktree-builds",
+      "line": "rust-plugin/cargo-worktree-builds: Share one CARGO_TARGET_DIR across parallel git-worktree agents so Rust deps"
+    },
+    {
+      "id": "rust-plugin/clippy-advanced",
+      "line": "rust-plugin/clippy-advanced: Advanced Clippy configuration for Rust \u2014 custom rules, pedantic/nursery lints"
+    },
+    {
+      "id": "rust-plugin/mockito-http-mocking",
+      "line": "rust-plugin/mockito-http-mocking: mockito HTTP mocking for Rust integration tests: expectation semantics, mock"
+    },
+    {
+      "id": "rust-plugin/rust-development",
+      "line": "rust-plugin/rust-development: Rust development \u2014 cargo, clippy, rustfmt, async, Tokio, Serde, memory safety"
+    },
+    {
+      "id": "session-plugin/session-distill",
+      "line": "session-plugin/session-distill: Distill session insights into rules, skill improvements, recipes, and cross-repo"
+    },
+    {
+      "id": "session-plugin/session-end",
+      "line": "session-plugin/session-end: End-of-session orchestrator. Previews which"
+    },
+    {
+      "id": "session-plugin/session-spinup",
+      "line": "session-plugin/session-spinup: Read-only session-start briefing of open tasks, git state, journal todos"
+    },
+    {
+      "id": "session-plugin/session-wrap",
+      "line": "session-plugin/session-wrap: End-of-session capture to taskwarrior, optional journal, GitHub issues"
+    },
+    {
+      "id": "software-design-plugin/design-by-contract",
+      "line": "software-design-plugin/design-by-contract: Design with explicit contracts \u2014 preconditions, postconditions, invariants"
+    },
+    {
+      "id": "software-design-plugin/design-deep-modules",
+      "line": "software-design-plugin/design-deep-modules: Judge interface depth \u2014 deep modules hide complexity behind small interfaces"
+    },
+    {
+      "id": "software-design-plugin/design-legacy-seams",
+      "line": "software-design-plugin/design-legacy-seams: Get legacy code under test before changing it \u2014 find seams, write"
+    },
+    {
+      "id": "software-design-plugin/design-patterns",
+      "line": "software-design-plugin/design-patterns: Select a design pattern from a symptom \u2014 strategy, observer, factory, adapter"
+    },
+    {
+      "id": "software-design-plugin/design-pseudocode",
+      "line": "software-design-plugin/design-pseudocode: Design a routine by stepwise refinement \u2014 pseudocode the intent before coding"
+    },
+    {
+      "id": "taskwarrior-plugin/install-native-hooks",
+      "line": "taskwarrior-plugin/install-native-hooks: Install opt-in taskwarrior native on-add/on-modify/on-exit hooks: auto-stamp"
+    },
+    {
+      "id": "taskwarrior-plugin/task-add",
+      "line": "taskwarrior-plugin/task-add: Add a taskwarrior task with blueprint linkage and optional GitHub issue"
+    },
+    {
+      "id": "taskwarrior-plugin/task-bulk-ops",
+      "line": "taskwarrior-plugin/task-bulk-ops: Batch taskwarrior operations without the ID-renumbering and stdin foot-guns"
+    },
+    {
+      "id": "taskwarrior-plugin/task-claim",
+      "line": "taskwarrior-plugin/task-claim: Claim a taskwarrior task as in-flight (+ACTIVE) and write a coworker marker"
+    },
+    {
+      "id": "taskwarrior-plugin/task-coordinate",
+      "line": "taskwarrior-plugin/task-coordinate: Surface next N unblocked taskwarrior tasks by urgency, skipping lock-contending"
+    },
+    {
+      "id": "taskwarrior-plugin/task-done",
+      "line": "taskwarrior-plugin/task-done: Close a taskwarrior task with landing commit annotation and optional GitHub"
+    },
+    {
+      "id": "taskwarrior-plugin/task-reconcile",
+      "line": "taskwarrior-plugin/task-reconcile: Close taskwarrior tasks whose linked GitHub issue/PR closed or merged"
+    },
+    {
+      "id": "taskwarrior-plugin/task-release",
+      "line": "taskwarrior-plugin/task-release: Release a taskwarrior task without closing it \u2014 stops +ACTIVE clock"
+    },
+    {
+      "id": "taskwarrior-plugin/task-status",
+      "line": "taskwarrior-plugin/task-status: Read-only taskwarrior queue report \u2014 pending, blocked, ready tasks and drift vs"
+    },
+    {
+      "id": "terraform-plugin/infrastructure-terraform",
+      "line": "terraform-plugin/infrastructure-terraform: Terraform IaC: HCL, state management, modules, plan-apply workflows"
+    },
+    {
+      "id": "terraform-plugin/tfc-list-runs",
+      "line": "terraform-plugin/tfc-list-runs: List Terraform Cloud workspace runs filtered by status or date"
+    },
+    {
+      "id": "terraform-plugin/tfc-plan-json",
+      "line": "terraform-plugin/tfc-plan-json: TFC plan JSON download and analysis"
+    },
+    {
+      "id": "terraform-plugin/tfc-run-logs",
+      "line": "terraform-plugin/tfc-run-logs: Retrieve plan and apply logs from Terraform Cloud runs"
+    },
+    {
+      "id": "terraform-plugin/tfc-run-status",
+      "line": "terraform-plugin/tfc-run-status: Terraform Cloud run status with resource counts and actions"
+    },
+    {
+      "id": "terraform-plugin/tfc-workspace-runs",
+      "line": "terraform-plugin/tfc-workspace-runs: List TFC runs across known workspaces (github, sentry, gcp, onelogin, twingate)"
+    },
+    {
+      "id": "testing-plugin/mutation-testing",
+      "line": "testing-plugin/mutation-testing: Mutation testing with Stryker (TS/JS) and mutmut (Python)"
+    },
+    {
+      "id": "testing-plugin/odiff-image-diffing",
+      "line": "testing-plugin/odiff-image-diffing: odiff pixel-by-pixel image diffing"
+    },
+    {
+      "id": "testing-plugin/playwright-cli",
+      "line": "testing-plugin/playwright-cli: Playwright CLI browser automation \u2014 navigate, screenshot, fill forms, click"
+    },
+    {
+      "id": "testing-plugin/playwright-testing",
+      "line": "testing-plugin/playwright-testing: Playwright E2E testing \u2014 cross-browser, visual regression, API testing, mobile"
+    },
+    {
+      "id": "testing-plugin/property-based-testing",
+      "line": "testing-plugin/property-based-testing: Property-based testing with fast-check (TS/JS) and Hypothesis (Python)"
+    },
+    {
+      "id": "testing-plugin/test-analyze",
+      "line": "testing-plugin/test-analyze: Analyze test results and create a fix plan with subagents"
+    },
+    {
+      "id": "testing-plugin/test-consult",
+      "line": "testing-plugin/test-consult: Consult the test-architecture agent for strategy decisions"
+    },
+    {
+      "id": "testing-plugin/test-focus",
+      "line": "testing-plugin/test-focus: Run one test file fail-fast for rapid TDD \u2014 Playwright, Vitest, Jest, pytest"
+    },
+    {
+      "id": "testing-plugin/test-full",
+      "line": "testing-plugin/test-full: Run complete test suite in pyramid order \u2014 unit, integration, E2E"
+    },
+    {
+      "id": "testing-plugin/test-quality-analysis",
+      "line": "testing-plugin/test-quality-analysis: Detect test smells, overmocking, flaky tests, and coverage issues"
+    },
+    {
+      "id": "testing-plugin/test-quick",
+      "line": "testing-plugin/test-quick: Run fast unit tests only, skip slow/integration/E2E"
+    },
+    {
+      "id": "testing-plugin/test-report",
+      "line": "testing-plugin/test-report: Show cached test status without re-running"
+    },
+    {
+      "id": "testing-plugin/test-run",
+      "line": "testing-plugin/test-run: Universal test runner auto-detecting pytest, vitest, jest, cargo, go test"
+    },
+    {
+      "id": "testing-plugin/test-setup",
+      "line": "testing-plugin/test-setup: Configure testing infrastructure with CI/CD"
+    },
+    {
+      "id": "testing-plugin/test-strategy-review",
+      "line": "testing-plugin/test-strategy-review: Evaluate whether a test suite actually tests what it aims to, using an"
+    },
+    {
+      "id": "testing-plugin/test-tier-selection",
+      "line": "testing-plugin/test-tier-selection: Auto-select test tiers based on change scope \u2014 unit for small, full suite"
+    },
+    {
+      "id": "testing-plugin/vitest-testing",
+      "line": "testing-plugin/vitest-testing: Vitest test runner \u2014 Vite-native, ESM, watch/UI mode, coverage, mocking"
+    },
+    {
+      "id": "tools-plugin/binary-analysis",
+      "line": "tools-plugin/binary-analysis: Binary analysis: strings, binwalk, hexdump, xxd, file, objdump"
+    },
+    {
+      "id": "tools-plugin/cli-smoke-recipes",
+      "line": "tools-plugin/cli-smoke-recipes: CLI smoke recipes: expose pure-function modules via subcommands"
+    },
+    {
+      "id": "tools-plugin/d2-diagrams",
+      "line": "tools-plugin/d2-diagrams: Generate diagrams from text using D2 with automatic layouts and themes"
+    },
+    {
+      "id": "tools-plugin/deps-install",
+      "line": "tools-plugin/deps-install: Deps install: auto-detect package manager (uv, bun, npm, yarn, pnpm, cargo, go)"
+    },
+    {
+      "id": "tools-plugin/fd-file-finding",
+      "line": "tools-plugin/fd-file-finding: fd fast file finding: smart defaults, gitignore-aware, parallel"
+    },
+    {
+      "id": "tools-plugin/generate-image",
+      "line": "tools-plugin/generate-image: Image generation via Gemini 3 Pro Image: aspect ratio, resolution, reference"
+    },
+    {
+      "id": "tools-plugin/hf-downloads",
+      "line": "tools-plugin/hf-downloads: Hugging Face model downloads without filling root disk \u2014 HF_HOME/xet cache"
+    },
+    {
+      "id": "tools-plugin/imagemagick-conversion",
+      "line": "tools-plugin/imagemagick-conversion: ImageMagick image manipulation: format conversion, resizing, batch processing"
+    },
+    {
+      "id": "tools-plugin/jq-json-processing",
+      "line": "tools-plugin/jq-json-processing: jq JSON processing: query, filter, transform JSON"
+    },
+    {
+      "id": "tools-plugin/justfile-expert",
+      "line": "tools-plugin/justfile-expert: Just command runner expertise \u2014 Justfile syntax, recipes, parameters, modules"
+    },
+    {
+      "id": "tools-plugin/mermaid-diagrams",
+      "line": "tools-plugin/mermaid-diagrams: Render Mermaid diagrams (mmdc) to SVG/PNG/PDF \u2014 flowcharts, sequence, ERDs"
+    },
+    {
+      "id": "tools-plugin/nushell-data-processing",
+      "line": "tools-plugin/nushell-data-processing: Structured data processing with nushell \u2014 native tables, multi-format parsing"
+    },
+    {
+      "id": "tools-plugin/rg-code-search",
+      "line": "tools-plugin/rg-code-search: ripgrep (rg) fast code search: smart defaults, regex, file filtering"
+    },
+    {
+      "id": "tools-plugin/shell-expert",
+      "line": "tools-plugin/shell-expert: Shell scripting: bash, zsh, POSIX, CLI tools, cross-platform automation"
+    },
+    {
+      "id": "tools-plugin/yq-yaml-processing",
+      "line": "tools-plugin/yq-yaml-processing: yq YAML processing: query, filter, transform YAML"
+    },
+    {
+      "id": "typescript-plugin/biome-tooling",
+      "line": "typescript-plugin/biome-tooling: Biome all-in-one JS/TS formatter and linter, 15-20x faster than ESLint/Prettier"
+    },
+    {
+      "id": "typescript-plugin/bun-add",
+      "line": "typescript-plugin/bun-add: Bun add: install a package, add dev dependency, pin exact version, or target"
+    },
+    {
+      "id": "typescript-plugin/bun-build",
+      "line": "typescript-plugin/bun-build: Bun build: bundle or compile JS/TS to production bundle or standalone binary"
+    },
+    {
+      "id": "typescript-plugin/bun-debug",
+      "line": "typescript-plugin/bun-debug: Bun debugger via --inspect"
+    },
+    {
+      "id": "typescript-plugin/bun-development",
+      "line": "typescript-plugin/bun-development: Bun runtime workflows for running scripts, testing, building, and initializing"
+    },
+    {
+      "id": "typescript-plugin/bun-install",
+      "line": "typescript-plugin/bun-install: Bun install: install all deps from package.json"
+    },
+    {
+      "id": "typescript-plugin/bun-lockfile-update",
+      "line": "typescript-plugin/bun-lockfile-update: Bun lockfile update (bun.lock): bun update, regeneration, security audits"
+    },
+    {
+      "id": "typescript-plugin/bun-outdated",
+      "line": "typescript-plugin/bun-outdated: Bun outdated: check which deps have newer versions"
+    },
+    {
+      "id": "typescript-plugin/bun-package-manager",
+      "line": "typescript-plugin/bun-package-manager: Fast JavaScript package management with Bun \u2014 install, add, remove, update"
+    },
+    {
+      "id": "typescript-plugin/bun-publish",
+      "line": "typescript-plugin/bun-publish: Bun publish to npm"
+    },
+    {
+      "id": "typescript-plugin/bun-publishing",
+      "line": "typescript-plugin/bun-publishing: Publish npm packages built with Bun: package.json config, CLI tool packaging"
+    },
+    {
+      "id": "typescript-plugin/bun-test",
+      "line": "typescript-plugin/bun-test: Bun test runner with compact agent-friendly output"
+    },
+    {
+      "id": "typescript-plugin/knip-dead-code",
+      "line": "typescript-plugin/knip-dead-code: Knip dead-code detector for JS/TS: unused files, deps, exports, types"
+    },
+    {
+      "id": "typescript-plugin/nodejs-development",
+      "line": "typescript-plugin/nodejs-development: Node.js development with Bun, Vite, Vue 3, Pinia, TypeScript"
+    },
+    {
+      "id": "typescript-plugin/typescript-debugging",
+      "line": "typescript-plugin/typescript-debugging: Modern TypeScript/JavaScript debugging with Bun \u2014 inspector flags, debug.bun.sh"
+    },
+    {
+      "id": "typescript-plugin/typescript-sentry",
+      "line": "typescript-plugin/typescript-sentry: Error monitoring and performance with Sentry SDK for Bun/Node.js/Next.js \u2014 error"
+    },
+    {
+      "id": "typescript-plugin/typescript-strict",
+      "line": "typescript-plugin/typescript-strict: TypeScript strict mode: tsconfig.json, strict flags, Bundler/NodeNext"
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-checkpoint-refactor",
+      "line": "workflow-orchestration-plugin/workflow-checkpoint-refactor: Multi-phase refactoring with checkpoint files that survive context limits"
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-preflight",
+      "line": "workflow-orchestration-plugin/workflow-preflight: Pre-work validation before implementation"
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-verify-before-filing",
+      "line": "workflow-orchestration-plugin/workflow-verify-before-filing: Verify accumulated bug claims at upstream HEAD and dedup against trackers before"
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-wave-dispatch",
+      "line": "workflow-orchestration-plugin/workflow-wave-dispatch: Sequential-wave dispatch for multi-agent work with cross-task dependencies"
+    }
+  ]
+}

--- a/experiments/skill-catalog-routing/catalogs/catalog.domain-short.json
+++ b/experiments/skill-catalog-routing/catalogs/catalog.domain-short.json
@@ -1,0 +1,1631 @@
+{
+  "variant": "domain-short",
+  "source_sha": "0ed1791a1abb10ba687ae115adf637b9f5b9cc59",
+  "skill_count": 406,
+  "entries": [
+    {
+      "id": "accessibility-plugin/accessibility-implementation",
+      "line": "accessibility-plugin/accessibility-implementation: WCAG 2.1/2.2 compliance, ARIA patterns"
+    },
+    {
+      "id": "accessibility-plugin/design-tokens",
+      "line": "accessibility-plugin/design-tokens: Design tokens and CSS custom properties:"
+    },
+    {
+      "id": "agent-patterns-plugin/adversarial-review",
+      "line": "agent-patterns-plugin/adversarial-review: Adversarial second-pass review that"
+    },
+    {
+      "id": "agent-patterns-plugin/agent-teams",
+      "line": "agent-patterns-plugin/agent-teams: Configure Claude Code agent teams"
+    },
+    {
+      "id": "agent-patterns-plugin/cold-read-gate",
+      "line": "agent-patterns-plugin/cold-read-gate: Gate outward-bound text (upstream"
+    },
+    {
+      "id": "agent-patterns-plugin/custom-agent-definitions",
+      "line": "agent-patterns-plugin/custom-agent-definitions: Write and configure custom agent"
+    },
+    {
+      "id": "agent-patterns-plugin/exclusive-lock-dispatch",
+      "line": "agent-patterns-plugin/exclusive-lock-dispatch: Pre-dump-then-dispatch for tools holding"
+    },
+    {
+      "id": "agent-patterns-plugin/execution-grounded-review",
+      "line": "agent-patterns-plugin/execution-grounded-review: Execution-grounded review: run tests"
+    },
+    {
+      "id": "agent-patterns-plugin/expose-tunable-knob",
+      "line": "agent-patterns-plugin/expose-tunable-knob: Expose a live-adjustable control instead"
+    },
+    {
+      "id": "agent-patterns-plugin/mcp-code-execution",
+      "line": "agent-patterns-plugin/mcp-code-execution: Scaffold the code execution pattern"
+    },
+    {
+      "id": "agent-patterns-plugin/mcp-management",
+      "line": "agent-patterns-plugin/mcp-management: Install and configure MCP servers"
+    },
+    {
+      "id": "agent-patterns-plugin/mcp-server-authoring",
+      "line": "agent-patterns-plugin/mcp-server-authoring: FastMCP authoring for Python MCP servers"
+    },
+    {
+      "id": "agent-patterns-plugin/meta-assimilate",
+      "line": "agent-patterns-plugin/meta-assimilate: Copy, generalize, or merge a project's"
+    },
+    {
+      "id": "agent-patterns-plugin/meta-audit",
+      "line": "agent-patterns-plugin/meta-audit: Audit Claude subagent configs"
+    },
+    {
+      "id": "agent-patterns-plugin/meta-context-diet",
+      "line": "agent-patterns-plugin/meta-context-diet: Audit CLAUDE.md and .claude/rules"
+    },
+    {
+      "id": "agent-patterns-plugin/meta-promote",
+      "line": "agent-patterns-plugin/meta-promote: Promote rules, skills, or agents from"
+    },
+    {
+      "id": "agent-patterns-plugin/multi-model-delegation",
+      "line": "agent-patterns-plugin/multi-model-delegation: Multi-model design consults via PAL"
+    },
+    {
+      "id": "agent-patterns-plugin/parallel-agent-dispatch",
+      "line": "agent-patterns-plugin/parallel-agent-dispatch: Dispatch contract for spawning parallel"
+    },
+    {
+      "id": "agent-patterns-plugin/plugin-settings",
+      "line": "agent-patterns-plugin/plugin-settings: Configure per-project plugin settings"
+    },
+    {
+      "id": "agent-patterns-plugin/verify-before-plan",
+      "line": "agent-patterns-plugin/verify-before-plan: Verify orchestrator premises (file"
+    },
+    {
+      "id": "agent-patterns-plugin/wave-based-dispatch",
+      "line": "agent-patterns-plugin/wave-based-dispatch: Sequential-wave dispatch for WO chains"
+    },
+    {
+      "id": "agents-plugin/agents-analyze",
+      "line": "agents-plugin/agents-analyze: Audit plugins for sub-agent"
+    },
+    {
+      "id": "api-plugin/api-testing",
+      "line": "api-plugin/api-testing: HTTP API testing with Supertest (TS)"
+    },
+    {
+      "id": "bevy-plugin/bevy-ecs-patterns",
+      "line": "bevy-plugin/bevy-ecs-patterns: Advanced Bevy ECS: complex queries"
+    },
+    {
+      "id": "bevy-plugin/bevy-game-engine",
+      "line": "bevy-plugin/bevy-game-engine: Bevy game engine: ECS, rendering, input"
+    },
+    {
+      "id": "blog-plugin/blog-post",
+      "line": "blog-plugin/blog-post: Create a blog post via guided prompts"
+    },
+    {
+      "id": "blog-plugin/blog-post-writing",
+      "line": "blog-plugin/blog-post-writing: Style guide for technical blog posts \u2014"
+    },
+    {
+      "id": "blueprint-plugin/adr-relationships",
+      "line": "blueprint-plugin/adr-relationships: Domain analysis, conflict detection,"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-adr-list",
+      "line": "blueprint-plugin/blueprint-adr-list: List ADRs as a markdown table"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-adr-validate",
+      "line": "blueprint-plugin/blueprint-adr-validate: Validate ADR relationships, domain"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-autonomy-level3",
+      "line": "blueprint-plugin/blueprint-autonomy-level3: Install blueprint autonomy level 3"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-autopilot",
+      "line": "blueprint-plugin/blueprint-autopilot: Run due blueprint maintenance ambiently"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-claude-md",
+      "line": "blueprint-plugin/blueprint-claude-md: Generate or update CLAUDE.md from"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-curate-docs",
+      "line": "blueprint-plugin/blueprint-curate-docs: Curate library gotchas and project"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-derive-plans",
+      "line": "blueprint-plugin/blueprint-derive-plans: Derive PRDs, ADRs, PRPs from git"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-derive-rules",
+      "line": "blueprint-plugin/blueprint-derive-rules: Derive Claude rules from git commit"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-derive-tests",
+      "line": "blueprint-plugin/blueprint-derive-tests: Derive test regression plans from git"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-development",
+      "line": "blueprint-plugin/blueprint-development: Generate project-specific rules from"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-docs-currency",
+      "line": "blueprint-plugin/blueprint-docs-currency: Enforce same-commit landing of code"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-docs-list",
+      "line": "blueprint-plugin/blueprint-docs-list: List blueprint documents (ADRs, PRDs"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-execute",
+      "line": "blueprint-plugin/blueprint-execute: Blueprint meta command: determine"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-feature-tracker-status",
+      "line": "blueprint-plugin/blueprint-feature-tracker-status: Display feature tracker stats, phase"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-feature-tracker-sync",
+      "line": "blueprint-plugin/blueprint-feature-tracker-sync: Sync feature tracker with TODO.md"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-generate-rules",
+      "line": "blueprint-plugin/blueprint-generate-rules: Generate project-specific rules from"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-init",
+      "line": "blueprint-plugin/blueprint-init: Initialize Blueprint Development"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-migration",
+      "line": "blueprint-plugin/blueprint-migration: Versioned migration procedures"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-promote",
+      "line": "blueprint-plugin/blueprint-promote: Move generated artifact to custom layer"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-prp-create",
+      "line": "blueprint-plugin/blueprint-prp-create: Create a PRP (Product Requirement"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-prp-execute",
+      "line": "blueprint-plugin/blueprint-prp-execute: Execute a PRP with validation loop, TDD"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-rules",
+      "line": "blueprint-plugin/blueprint-rules: Manage modular rules in .claude/rules/"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-status",
+      "line": "blueprint-plugin/blueprint-status: Show blueprint version, config"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-story-audit",
+      "line": "blueprint-plugin/blueprint-story-audit: Audit user stories against codebase"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-story-reconcile",
+      "line": "blueprint-plugin/blueprint-story-reconcile: Reconcile PRD requirements"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-sync",
+      "line": "blueprint-plugin/blueprint-sync: Check for stale generated content"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-sync-ids",
+      "line": "blueprint-plugin/blueprint-sync-ids: Scan blueprint docs and assign missing"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-upgrade",
+      "line": "blueprint-plugin/blueprint-upgrade: Upgrade blueprint structure"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-work-order",
+      "line": "blueprint-plugin/blueprint-work-order: Create a work-order for isolated"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-workspace-scan",
+      "line": "blueprint-plugin/blueprint-workspace-scan: Discover child blueprint workspaces"
+    },
+    {
+      "id": "blueprint-plugin/confidence-scoring",
+      "line": "blueprint-plugin/confidence-scoring: Assess quality of PRPs and work-orders"
+    },
+    {
+      "id": "blueprint-plugin/document-detection",
+      "line": "blueprint-plugin/document-detection: Detect PRD/ADR/PRP opportunities"
+    },
+    {
+      "id": "blueprint-plugin/document-linking",
+      "line": "blueprint-plugin/document-linking: Unified ID system for PRDs, ADRs, PRPs"
+    },
+    {
+      "id": "blueprint-plugin/feature-tracking",
+      "line": "blueprint-plugin/feature-tracking: Track feature implementation against"
+    },
+    {
+      "id": "code-quality-plugin/ast-grep-search",
+      "line": "code-quality-plugin/ast-grep-search: Find and replace code patterns"
+    },
+    {
+      "id": "code-quality-plugin/bulk-sweep-classify",
+      "line": "code-quality-plugin/bulk-sweep-classify: Classify every regex match before a bulk"
+    },
+    {
+      "id": "code-quality-plugin/code-antipatterns",
+      "line": "code-quality-plugin/code-antipatterns: Analyze a codebase for anti-patterns"
+    },
+    {
+      "id": "code-quality-plugin/code-complexity",
+      "line": "code-quality-plugin/code-complexity: Analyze code complexity metrics"
+    },
+    {
+      "id": "code-quality-plugin/code-dead-code",
+      "line": "code-quality-plugin/code-dead-code: Detect dead code, unused exports"
+    },
+    {
+      "id": "code-quality-plugin/code-dep-audit",
+      "line": "code-quality-plugin/code-dep-audit: Audit dependencies for security"
+    },
+    {
+      "id": "code-quality-plugin/code-docs-quality",
+      "line": "code-quality-plugin/code-docs-quality: Analyze docs quality across PRDs, ADRs"
+    },
+    {
+      "id": "code-quality-plugin/code-hidden-failures",
+      "line": "code-quality-plugin/code-hidden-failures: Scan for hidden failures: swallowed"
+    },
+    {
+      "id": "code-quality-plugin/code-lint",
+      "line": "code-quality-plugin/code-lint: Universal linter that auto-detects"
+    },
+    {
+      "id": "code-quality-plugin/code-refactor",
+      "line": "code-quality-plugin/code-refactor: Refactor toward pure functions"
+    },
+    {
+      "id": "code-quality-plugin/code-review",
+      "line": "code-quality-plugin/code-review: Code review for quality, security"
+    },
+    {
+      "id": "code-quality-plugin/code-review-checklist",
+      "line": "code-quality-plugin/code-review-checklist: Checklist for security, correctness,"
+    },
+    {
+      "id": "code-quality-plugin/code-test-quality",
+      "line": "code-quality-plugin/code-test-quality: Analyze test quality: smells, empty"
+    },
+    {
+      "id": "code-quality-plugin/debugging-methodology",
+      "line": "code-quality-plugin/debugging-methodology: Systematic debugging for memory"
+    },
+    {
+      "id": "code-quality-plugin/dry-consolidation",
+      "line": "code-quality-plugin/dry-consolidation: Find and extract duplicated code into"
+    },
+    {
+      "id": "codebase-attributes-plugin/attributes-collect",
+      "line": "codebase-attributes-plugin/attributes-collect: Collect codebase health attributes as"
+    },
+    {
+      "id": "codebase-attributes-plugin/attributes-dashboard",
+      "line": "codebase-attributes-plugin/attributes-dashboard: Codebase health dashboard with scores"
+    },
+    {
+      "id": "codebase-attributes-plugin/attributes-route",
+      "line": "codebase-attributes-plugin/attributes-route: Route to specialized agents (security"
+    },
+    {
+      "id": "comfyui-plugin/comfy-cli",
+      "line": "comfyui-plugin/comfy-cli: The `comfy` CLI for ComfyUI:"
+    },
+    {
+      "id": "comfyui-plugin/comfy-conditionals",
+      "line": "comfyui-plugin/comfy-conditionals: ComfyUI predicate/boolean nodes:"
+    },
+    {
+      "id": "comfyui-plugin/comfy-corpus-validation",
+      "line": "comfyui-plugin/comfy-corpus-validation: Verify ComfyUI sampler/scheduler facts:"
+    },
+    {
+      "id": "comfyui-plugin/comfy-debug-preview",
+      "line": "comfyui-plugin/comfy-debug-preview: ComfyUI debug/preview nodes: show"
+    },
+    {
+      "id": "comfyui-plugin/comfy-flow-control",
+      "line": "comfyui-plugin/comfy-flow-control: ComfyUI routing nodes: typed switches"
+    },
+    {
+      "id": "comfyui-plugin/comfy-image-utils",
+      "line": "comfyui-plugin/comfy-image-utils: ComfyUI non-inference image ops:"
+    },
+    {
+      "id": "comfyui-plugin/comfy-math-strings",
+      "line": "comfyui-plugin/comfy-math-strings: ComfyUI compute/string nodes: constants"
+    },
+    {
+      "id": "comfyui-plugin/comfy-metadata",
+      "line": "comfyui-plugin/comfy-metadata: Extract/analyze ComfyUI metadata"
+    },
+    {
+      "id": "comfyui-plugin/comfy-node",
+      "line": "comfyui-plugin/comfy-node: Orchestrate a ComfyUI node pack from"
+    },
+    {
+      "id": "comfyui-plugin/comfy-registry-lifecycle",
+      "line": "comfyui-plugin/comfy-registry-lifecycle: Comfy Registry release pipeline:"
+    },
+    {
+      "id": "comfyui-plugin/comfy-subgraphs-app-mode",
+      "line": "comfyui-plugin/comfy-subgraphs-app-mode: ComfyUI Subgraphs, Subgraph Blueprints"
+    },
+    {
+      "id": "comfyui-plugin/comfy-workflow-json",
+      "line": "comfyui-plugin/comfy-workflow-json: Programmatically edit ComfyUI workflow"
+    },
+    {
+      "id": "comfyui-plugin/comfy-workflow-layout",
+      "line": "comfyui-plugin/comfy-workflow-layout: Auto-layout a ComfyUI workflow JSON"
+    },
+    {
+      "id": "comfyui-plugin/comfyui-node-authoring",
+      "line": "comfyui-plugin/comfyui-node-authoring: ComfyUI frontend/backend authoring"
+    },
+    {
+      "id": "comfyui-plugin/comfyui-node-scaffold",
+      "line": "comfyui-plugin/comfyui-node-scaffold: Scaffold a new ComfyUI custom-node repo"
+    },
+    {
+      "id": "comfyui-plugin/comfyui-pack-live-smoke",
+      "line": "comfyui-plugin/comfyui-pack-live-smoke: Live-smoke a ComfyUI pack in a running"
+    },
+    {
+      "id": "comfyui-plugin/comfyui-screenshot-pipeline",
+      "line": "comfyui-plugin/comfyui-screenshot-pipeline: Containerized README-screenshot pipeline"
+    },
+    {
+      "id": "communication-plugin/google-chat-formatting",
+      "line": "communication-plugin/google-chat-formatting: Convert Markdown to Google Chat"
+    },
+    {
+      "id": "communication-plugin/ticket-drafting-guidelines",
+      "line": "communication-plugin/ticket-drafting-guidelines: Guidelines for drafting GitHub issues"
+    },
+    {
+      "id": "component-patterns-plugin/components-version-badge",
+      "line": "component-patterns-plugin/components-version-badge: Version badge with build-info tooltip"
+    },
+    {
+      "id": "component-patterns-plugin/version-badge-pattern",
+      "line": "component-patterns-plugin/version-badge-pattern: Version badge UI showing build version"
+    },
+    {
+      "id": "configure-plugin/ci-workflows",
+      "line": "configure-plugin/ci-workflows: GitHub Actions workflow standards"
+    },
+    {
+      "id": "configure-plugin/claude-security-settings",
+      "line": "configure-plugin/claude-security-settings: Claude Code security settings:"
+    },
+    {
+      "id": "configure-plugin/config-sync",
+      "line": "configure-plugin/config-sync: Config sync across FVH repos: extract"
+    },
+    {
+      "id": "configure-plugin/configure-all",
+      "line": "configure-plugin/configure-all: Run all infrastructure standards checks"
+    },
+    {
+      "id": "configure-plugin/configure-api-tests",
+      "line": "configure-plugin/configure-api-tests: API contract testing: Pact, OpenAPI"
+    },
+    {
+      "id": "configure-plugin/configure-argocd-automerge",
+      "line": "configure-plugin/configure-argocd-automerge: ArgoCD auto-merge: configure GitHub"
+    },
+    {
+      "id": "configure-plugin/configure-cache-busting",
+      "line": "configure-plugin/configure-cache-busting: Cache-busting for Next.js and Vite:"
+    },
+    {
+      "id": "configure-plugin/configure-claude-plugins",
+      "line": "configure-plugin/configure-claude-plugins: Claude plugins marketplace setup:"
+    },
+    {
+      "id": "configure-plugin/configure-container",
+      "line": "configure-plugin/configure-container: Container infrastructure: GHCR builds"
+    },
+    {
+      "id": "configure-plugin/configure-coverage",
+      "line": "configure-plugin/configure-coverage: Code coverage: thresholds and reporters"
+    },
+    {
+      "id": "configure-plugin/configure-dead-code",
+      "line": "configure-plugin/configure-dead-code: Dead-code detection: Knip, Vulture"
+    },
+    {
+      "id": "configure-plugin/configure-dockerfile",
+      "line": "configure-plugin/configure-dockerfile: Dockerfile standards: Alpine/slim base"
+    },
+    {
+      "id": "configure-plugin/configure-docs",
+      "line": "configure-plugin/configure-docs: Code docs: TSDoc, JSDoc, pydoc, rustdoc"
+    },
+    {
+      "id": "configure-plugin/configure-editor",
+      "line": "configure-plugin/configure-editor: EditorConfig and VS Code workspace"
+    },
+    {
+      "id": "configure-plugin/configure-feature-flags",
+      "line": "configure-plugin/configure-feature-flags: Feature flags with OpenFeature"
+    },
+    {
+      "id": "configure-plugin/configure-formatting",
+      "line": "configure-plugin/configure-formatting: Biome formatter for JS/TS/JSON/CSS \u2014"
+    },
+    {
+      "id": "configure-plugin/configure-gitattributes",
+      "line": "configure-plugin/configure-gitattributes: Configure .gitattributes: union-merge"
+    },
+    {
+      "id": "configure-plugin/configure-github-pages",
+      "line": "configure-plugin/configure-github-pages: GitHub Pages deployment workflows"
+    },
+    {
+      "id": "configure-plugin/configure-gitignore",
+      "line": "configure-plugin/configure-gitignore: Manage .gitignore's Claude Code block \u2014"
+    },
+    {
+      "id": "configure-plugin/configure-instrumentation",
+      "line": "configure-plugin/configure-instrumentation: Observability instrumentation:"
+    },
+    {
+      "id": "configure-plugin/configure-integration-tests",
+      "line": "configure-plugin/configure-integration-tests: Integration testing: Supertest, pytest"
+    },
+    {
+      "id": "configure-plugin/configure-justfile",
+      "line": "configure-plugin/configure-justfile: Check and configure Justfiles"
+    },
+    {
+      "id": "configure-plugin/configure-linting",
+      "line": "configure-plugin/configure-linting: Modern linters: Biome, Ruff, Clippy"
+    },
+    {
+      "id": "configure-plugin/configure-load-tests",
+      "line": "configure-plugin/configure-load-tests: Load testing: k6, Artillery, Locust"
+    },
+    {
+      "id": "configure-plugin/configure-makefile",
+      "line": "configure-plugin/configure-makefile: Makefile with standard targets (help"
+    },
+    {
+      "id": "configure-plugin/configure-mcp",
+      "line": "configure-plugin/configure-mcp: Check and configure MCP servers"
+    },
+    {
+      "id": "configure-plugin/configure-memory-profiling",
+      "line": "configure-plugin/configure-memory-profiling: Memory profiling with pytest-memray"
+    },
+    {
+      "id": "configure-plugin/configure-mise",
+      "line": "configure-plugin/configure-mise: mise runtime/tool version manager -"
+    },
+    {
+      "id": "configure-plugin/configure-package-management",
+      "line": "configure-plugin/configure-package-management: Package managers: uv (Python), bun"
+    },
+    {
+      "id": "configure-plugin/configure-pre-commit",
+      "line": "configure-plugin/configure-pre-commit: pre-commit hooks setup and validation"
+    },
+    {
+      "id": "configure-plugin/configure-readme",
+      "line": "configure-plugin/configure-readme: README.md with logo, badges, features"
+    },
+    {
+      "id": "configure-plugin/configure-release-please",
+      "line": "configure-plugin/configure-release-please: release-please workflow setup"
+    },
+    {
+      "id": "configure-plugin/configure-repo",
+      "line": "configure-plugin/configure-repo: Repo onboarding driver: .claude/"
+    },
+    {
+      "id": "configure-plugin/configure-reusable-workflows",
+      "line": "configure-plugin/configure-reusable-workflows: Reusable GitHub Actions workflows"
+    },
+    {
+      "id": "configure-plugin/configure-security",
+      "line": "configure-plugin/configure-security: Security scanning: dependency audits"
+    },
+    {
+      "id": "configure-plugin/configure-select",
+      "line": "configure-plugin/configure-select: Interactive selector for infrastructure"
+    },
+    {
+      "id": "configure-plugin/configure-sentry",
+      "line": "configure-plugin/configure-sentry: Sentry error tracking setup"
+    },
+    {
+      "id": "configure-plugin/configure-skaffold",
+      "line": "configure-plugin/configure-skaffold: Skaffold for Kubernetes: port"
+    },
+    {
+      "id": "configure-plugin/configure-status",
+      "line": "configure-plugin/configure-status: Infrastructure compliance status"
+    },
+    {
+      "id": "configure-plugin/configure-surface",
+      "line": "configure-plugin/configure-surface: Surface doc-drift gate: scaffold"
+    },
+    {
+      "id": "configure-plugin/configure-tests",
+      "line": "configure-plugin/configure-tests: Test frameworks: Vitest, Jest, pytest"
+    },
+    {
+      "id": "configure-plugin/configure-ux-testing",
+      "line": "configure-plugin/configure-ux-testing: UX testing: Playwright E2E, axe-core"
+    },
+    {
+      "id": "configure-plugin/configure-web-session",
+      "line": "configure-plugin/configure-web-session: SessionStart hook for Claude Code web"
+    },
+    {
+      "id": "configure-plugin/configure-workflows",
+      "line": "configure-plugin/configure-workflows: GitHub Actions CI/CD workflows"
+    },
+    {
+      "id": "configure-plugin/configure-worktreeinclude",
+      "line": "configure-plugin/configure-worktreeinclude: Generate a .worktreeinclude so Claude"
+    },
+    {
+      "id": "configure-plugin/go-feature-flag",
+      "line": "configure-plugin/go-feature-flag: GO Feature Flag (GOFF) self-hosted"
+    },
+    {
+      "id": "configure-plugin/multi-repo-discipline",
+      "line": "configure-plugin/multi-repo-discipline: Multi-repo workspace rules: read-only"
+    },
+    {
+      "id": "configure-plugin/openfeature",
+      "line": "configure-plugin/openfeature: OpenFeature vendor-agnostic feature flag"
+    },
+    {
+      "id": "container-plugin/container-development",
+      "line": "container-plugin/container-development: Container development \u2014 Docker"
+    },
+    {
+      "id": "container-plugin/deploy-handoff",
+      "line": "container-plugin/deploy-handoff: Generate deployment handoff docs \u2014 tech"
+    },
+    {
+      "id": "container-plugin/deploy-release",
+      "line": "container-plugin/deploy-release: Create and publish releases via"
+    },
+    {
+      "id": "container-plugin/go-containers",
+      "line": "container-plugin/go-containers: Go container optimization \u2014"
+    },
+    {
+      "id": "container-plugin/nodejs-containers",
+      "line": "container-plugin/nodejs-containers: Node.js container optimization \u2014 Alpine"
+    },
+    {
+      "id": "container-plugin/python-containers",
+      "line": "container-plugin/python-containers: Python container optimization \u2014 slim"
+    },
+    {
+      "id": "container-plugin/skaffold-filesync",
+      "line": "container-plugin/skaffold-filesync: Skaffold file sync \u2014 copy changed files"
+    },
+    {
+      "id": "container-plugin/skaffold-orbstack",
+      "line": "container-plugin/skaffold-orbstack: OrbStack-optimized Skaffold for local"
+    },
+    {
+      "id": "container-plugin/skaffold-testing",
+      "line": "container-plugin/skaffold-testing: Container image validation with Skaffold"
+    },
+    {
+      "id": "css-plugin/lightning-css",
+      "line": "css-plugin/lightning-css: Lightning CSS transpilation, bundling"
+    },
+    {
+      "id": "css-plugin/unocss",
+      "line": "css-plugin/unocss: UnoCSS atomic CSS engine for on-demand"
+    },
+    {
+      "id": "documentation-plugin/claude-blog-sources",
+      "line": "documentation-plugin/claude-blog-sources: Fetch Claude Blog and official Claude"
+    },
+    {
+      "id": "documentation-plugin/docs-decommission",
+      "line": "documentation-plugin/docs-decommission: Generate DECOMMISSION-<service>.md"
+    },
+    {
+      "id": "documentation-plugin/docs-generate",
+      "line": "documentation-plugin/docs-generate: Generate or update docs from code"
+    },
+    {
+      "id": "documentation-plugin/docs-latex",
+      "line": "documentation-plugin/docs-latex: Convert Markdown to LaTeX with TikZ"
+    },
+    {
+      "id": "documentation-plugin/docs-sync",
+      "line": "documentation-plugin/docs-sync: Sync docs with actual skills, commands"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-improve",
+      "line": "evaluate-plugin/evaluate-improve: Suggest improvements to SKILL.md"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-legibility",
+      "line": "evaluate-plugin/evaluate-legibility: Cold-read a SKILL.md with a zero-context"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-matrix",
+      "line": "evaluate-plugin/evaluate-matrix: Cross-model skill evals with real"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-plugin-batch",
+      "line": "evaluate-plugin/evaluate-plugin-batch: Batch evaluate every skill in a plugin"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-report",
+      "line": "evaluate-plugin/evaluate-report: View evaluation results and benchmark"
+    },
+    {
+      "id": "evaluate-plugin/evaluate-skill",
+      "line": "evaluate-plugin/evaluate-skill: Evaluate a skill by running test cases"
+    },
+    {
+      "id": "feedback-plugin/feedback-session",
+      "line": "feedback-plugin/feedback-session: Analyze session for skill feedback"
+    },
+    {
+      "id": "finops-plugin/finops-caches",
+      "line": "finops-plugin/finops-caches: GitHub Actions cache analysis \u2014 size"
+    },
+    {
+      "id": "finops-plugin/finops-compare",
+      "line": "finops-plugin/finops-compare: FinOps metrics comparison across repos"
+    },
+    {
+      "id": "finops-plugin/finops-overview",
+      "line": "finops-plugin/finops-overview: FinOps snapshot \u2014 org billing, workflow"
+    },
+    {
+      "id": "finops-plugin/finops-waste",
+      "line": "finops-plugin/finops-waste: Identify GitHub Actions waste \u2014 skipped"
+    },
+    {
+      "id": "finops-plugin/finops-workflows",
+      "line": "finops-plugin/finops-workflows: Analyze workflow runs \u2014 frequency"
+    },
+    {
+      "id": "finops-plugin/github-actions-cache-optimization",
+      "line": "finops-plugin/github-actions-cache-optimization: GitHub Actions cache analysis"
+    },
+    {
+      "id": "finops-plugin/github-actions-finops",
+      "line": "finops-plugin/github-actions-finops: GitHub Actions billing, workflow"
+    },
+    {
+      "id": "foundryvtt-plugin/foundryvtt-module",
+      "line": "foundryvtt-plugin/foundryvtt-module: FoundryVTT module idea to gitops-adopted"
+    },
+    {
+      "id": "foundryvtt-plugin/foundryvtt-module-scaffold",
+      "line": "foundryvtt-plugin/foundryvtt-module-scaffold: Scaffold a new FoundryVTT v13 module"
+    },
+    {
+      "id": "git-plugin/deadbranch",
+      "line": "git-plugin/deadbranch: deadbranch CLI for stale-branch cleanup"
+    },
+    {
+      "id": "git-plugin/gh-cli-agentic",
+      "line": "git-plugin/gh-cli-agentic: gh CLI commands with JSON output"
+    },
+    {
+      "id": "git-plugin/gh-workflow-monitoring",
+      "line": "git-plugin/gh-workflow-monitoring: Monitor GitHub Actions runs"
+    },
+    {
+      "id": "git-plugin/git-api-pr",
+      "line": "git-plugin/git-api-pr: GitHub API PR creation without local git"
+    },
+    {
+      "id": "git-plugin/git-branch-naming",
+      "line": "git-plugin/git-branch-naming: Git branch naming conventions \u2014 type"
+    },
+    {
+      "id": "git-plugin/git-branch-pr-workflow",
+      "line": "git-plugin/git-branch-pr-workflow: Branch management and PR workflows \u2014 git"
+    },
+    {
+      "id": "git-plugin/git-cli-agentic",
+      "line": "git-plugin/git-cli-agentic: Git commands with porcelain"
+    },
+    {
+      "id": "git-plugin/git-commit",
+      "line": "git-plugin/git-commit: Create commits with conventional"
+    },
+    {
+      "id": "git-plugin/git-commit-push-pr",
+      "line": "git-plugin/git-commit-push-pr: End-to-end commit-to-PR workflow"
+    },
+    {
+      "id": "git-plugin/git-commit-trailers",
+      "line": "git-plugin/git-commit-trailers: Git commit trailer conventions \u2014"
+    },
+    {
+      "id": "git-plugin/git-commit-workflow",
+      "line": "git-plugin/git-commit-workflow: Conventional commit format, staging,"
+    },
+    {
+      "id": "git-plugin/git-conflicts",
+      "line": "git-plugin/git-conflicts: Resolve merge conflicts file-by-file"
+    },
+    {
+      "id": "git-plugin/git-coworker-check",
+      "line": "git-plugin/git-coworker-check: Detect coworker Claude agents"
+    },
+    {
+      "id": "git-plugin/git-derive-docs",
+      "line": "git-plugin/git-derive-docs: Derive ADRs, rules, PRDs from git commit"
+    },
+    {
+      "id": "git-plugin/git-fix-pr",
+      "line": "git-plugin/git-fix-pr: Analyze and fix failing PR checks"
+    },
+    {
+      "id": "git-plugin/git-fork-workflow",
+      "line": "git-plugin/git-fork-workflow: Fork management and upstream sync"
+    },
+    {
+      "id": "git-plugin/git-issue",
+      "line": "git-plugin/git-issue: Process GitHub issues end-to-end"
+    },
+    {
+      "id": "git-plugin/git-issue-hierarchy",
+      "line": "git-plugin/git-issue-hierarchy: Manage GitHub sub-issues"
+    },
+    {
+      "id": "git-plugin/git-issue-manage",
+      "line": "git-plugin/git-issue-manage: GitHub issue admin operations"
+    },
+    {
+      "id": "git-plugin/git-maintain",
+      "line": "git-plugin/git-maintain: Repo maintenance \u2014 incremental repack"
+    },
+    {
+      "id": "git-plugin/git-pr",
+      "line": "git-plugin/git-pr: Create pull requests with descriptions"
+    },
+    {
+      "id": "git-plugin/git-pr-feedback",
+      "line": "git-plugin/git-pr-feedback: Address PR review comments and resolve"
+    },
+    {
+      "id": "git-plugin/git-pr-sync-check",
+      "line": "git-plugin/git-pr-sync-check: Checks whether the current PR branch is"
+    },
+    {
+      "id": "git-plugin/git-pr-watch",
+      "line": "git-plugin/git-pr-watch: Subscribe to a PR's activity and react"
+    },
+    {
+      "id": "git-plugin/git-push",
+      "line": "git-plugin/git-push: Push local commits to remote \u2014 handles"
+    },
+    {
+      "id": "git-plugin/git-rebase-patterns",
+      "line": "git-plugin/git-rebase-patterns: Advanced git rebase \u2014 linear history"
+    },
+    {
+      "id": "git-plugin/git-repo-detection",
+      "line": "git-plugin/git-repo-detection: Detect GitHub repo owner/name from git"
+    },
+    {
+      "id": "git-plugin/git-security-checks",
+      "line": "git-plugin/git-security-checks: Pre-commit security validation"
+    },
+    {
+      "id": "git-plugin/git-triage",
+      "line": "git-plugin/git-triage: Triage GitHub issues and PRs \u2014"
+    },
+    {
+      "id": "git-plugin/git-upstream-pr",
+      "line": "git-plugin/git-upstream-pr: Submit PRs to upstream repos from a fork"
+    },
+    {
+      "id": "git-plugin/git-upstream-pr-diverged",
+      "line": "git-plugin/git-upstream-pr-diverged: Submit a diverged-fork commit"
+    },
+    {
+      "id": "git-plugin/github-issue-autodetect",
+      "line": "git-plugin/github-issue-autodetect: Auto-detect GitHub issues that staged"
+    },
+    {
+      "id": "git-plugin/github-issue-writing",
+      "line": "git-plugin/github-issue-writing: Create well-structured GitHub issues"
+    },
+    {
+      "id": "git-plugin/github-labels",
+      "line": "git-plugin/github-labels: Discover and apply GitHub labels via gh"
+    },
+    {
+      "id": "git-plugin/github-pr-title",
+      "line": "git-plugin/github-pr-title: Craft PR titles using conventional"
+    },
+    {
+      "id": "git-plugin/release-please-configuration",
+      "line": "git-plugin/release-please-configuration: release-please monorepo config \u2014"
+    },
+    {
+      "id": "git-plugin/release-please-pr-workflow",
+      "line": "git-plugin/release-please-pr-workflow: Manage release-please PR merging"
+    },
+    {
+      "id": "git-plugin/release-please-protection",
+      "line": "git-plugin/release-please-protection: Block manual edits to release-please"
+    },
+    {
+      "id": "github-actions-plugin/claude-code-github-workflows",
+      "line": "github-actions-plugin/claude-code-github-workflows: Claude Code GitHub Actions workflow"
+    },
+    {
+      "id": "github-actions-plugin/github-actions-auth-security",
+      "line": "github-actions-plugin/github-actions-auth-security: GitHub Actions auth and security"
+    },
+    {
+      "id": "github-actions-plugin/github-actions-inspection",
+      "line": "github-actions-plugin/github-actions-inspection: Inspect GitHub Actions runs, analyze"
+    },
+    {
+      "id": "github-actions-plugin/github-actions-mcp-config",
+      "line": "github-actions-plugin/github-actions-mcp-config: MCP server config for GitHub Actions \u2014"
+    },
+    {
+      "id": "github-actions-plugin/github-issue-search",
+      "line": "github-actions-plugin/github-issue-search: Search GitHub issues for solutions"
+    },
+    {
+      "id": "github-actions-plugin/github-social-preview",
+      "line": "github-actions-plugin/github-social-preview: Generate 1280x640 PNG social preview"
+    },
+    {
+      "id": "github-actions-plugin/github-workflow-auto-fix",
+      "line": "github-actions-plugin/github-workflow-auto-fix: Set up automated CI fixing with Claude"
+    },
+    {
+      "id": "github-actions-plugin/workflow-dev",
+      "line": "github-actions-plugin/workflow-dev: Automated dev loop \u2014 run tests, file"
+    },
+    {
+      "id": "health-plugin/health-agentic-audit",
+      "line": "health-plugin/health-agentic-audit: Audit skills, commands, and agents"
+    },
+    {
+      "id": "health-plugin/health-audit",
+      "line": "health-plugin/health-audit: Plugin audit against detected stack"
+    },
+    {
+      "id": "health-plugin/health-check",
+      "line": "health-plugin/health-check: Claude Code health check \u2014 scans"
+    },
+    {
+      "id": "health-plugin/health-plugins",
+      "line": "health-plugin/health-plugins: Diagnose and fix Claude Code plugin"
+    },
+    {
+      "id": "health-plugin/health-skill-audit",
+      "line": "health-plugin/health-skill-audit: Audit skill tree for overlap"
+    },
+    {
+      "id": "health-plugin/plugin-registry",
+      "line": "health-plugin/plugin-registry: Claude Code plugin registry structure"
+    },
+    {
+      "id": "health-plugin/settings-configuration",
+      "line": "health-plugin/settings-configuration: Claude Code settings hierarchy"
+    },
+    {
+      "id": "home-assistant-plugin/ha-automations",
+      "line": "home-assistant-plugin/ha-automations: Home Assistant automation creation"
+    },
+    {
+      "id": "home-assistant-plugin/ha-configuration",
+      "line": "home-assistant-plugin/ha-configuration: Home Assistant YAML configuration"
+    },
+    {
+      "id": "home-assistant-plugin/ha-entities",
+      "line": "home-assistant-plugin/ha-entities: Home Assistant entity and domain"
+    },
+    {
+      "id": "home-assistant-plugin/ha-validate",
+      "line": "home-assistant-plugin/ha-validate: Validate Home Assistant YAML for syntax"
+    },
+    {
+      "id": "hooks-plugin/hooks-configuration",
+      "line": "hooks-plugin/hooks-configuration: Claude Code hooks configuration"
+    },
+    {
+      "id": "hooks-plugin/hooks-permission-request-hook",
+      "line": "hooks-plugin/hooks-permission-request-hook: Generate a PermissionRequest hook"
+    },
+    {
+      "id": "hooks-plugin/hooks-session-end-issue-hook",
+      "line": "hooks-plugin/hooks-session-end-issue-hook: Configure a Stop hook that surfaces"
+    },
+    {
+      "id": "hooks-plugin/hooks-session-start-hook",
+      "line": "hooks-plugin/hooks-session-start-hook: Create a SessionStart hook for Claude"
+    },
+    {
+      "id": "kubernetes-plugin/argocd-login",
+      "line": "kubernetes-plugin/argocd-login: ArgoCD CLI auth with SSO and gRPC-Web"
+    },
+    {
+      "id": "kubernetes-plugin/helm-chart-development",
+      "line": "kubernetes-plugin/helm-chart-development: Create, test, and package Helm charts \u2014"
+    },
+    {
+      "id": "kubernetes-plugin/helm-debugging",
+      "line": "kubernetes-plugin/helm-debugging: Debug Helm failures \u2014 template errors"
+    },
+    {
+      "id": "kubernetes-plugin/helm-release-management",
+      "line": "kubernetes-plugin/helm-release-management: Manage Helm releases \u2014 install, upgrade"
+    },
+    {
+      "id": "kubernetes-plugin/helm-release-recovery",
+      "line": "kubernetes-plugin/helm-release-recovery: Recover from failed Helm deployments \u2014"
+    },
+    {
+      "id": "kubernetes-plugin/helm-values-management",
+      "line": "kubernetes-plugin/helm-values-management: Manage Helm values \u2014 override"
+    },
+    {
+      "id": "kubernetes-plugin/kubectl-debugging",
+      "line": "kubernetes-plugin/kubectl-debugging: Debug K8s pods/nodes with kubectl debug"
+    },
+    {
+      "id": "kubernetes-plugin/kubernetes-operations",
+      "line": "kubernetes-plugin/kubernetes-operations: Kubernetes operations \u2014 deployment"
+    },
+    {
+      "id": "langchain-plugin/deep-agents",
+      "line": "langchain-plugin/deep-agents: Build hierarchical AI agents"
+    },
+    {
+      "id": "langchain-plugin/langchain-development",
+      "line": "langchain-plugin/langchain-development: LangChain JS/TS framework for building"
+    },
+    {
+      "id": "langchain-plugin/langchain-init",
+      "line": "langchain-plugin/langchain-init: Initialize a new LangChain TypeScript"
+    },
+    {
+      "id": "langchain-plugin/langgraph-agents",
+      "line": "langchain-plugin/langgraph-agents: LangGraph stateful AI agents"
+    },
+    {
+      "id": "macos-plugin/endpoint-security-cpu",
+      "line": "macos-plugin/endpoint-security-cpu: macOS EndpointSecurity/EDR high CPU &"
+    },
+    {
+      "id": "macos-plugin/kitty-session-persistence",
+      "line": "macos-plugin/kitty-session-persistence: Snapshot and restore kitty terminal"
+    },
+    {
+      "id": "macos-plugin/launchservices-health",
+      "line": "macos-plugin/launchservices-health: Diagnose macOS LaunchServices DB bloat"
+    },
+    {
+      "id": "macos-plugin/macos-disk-usage",
+      "line": "macos-plugin/macos-disk-usage: macOS disk-usage forensics and space"
+    },
+    {
+      "id": "macos-plugin/macos-incident-postmortem",
+      "line": "macos-plugin/macos-incident-postmortem: Reconstruct macOS freeze, panic,"
+    },
+    {
+      "id": "macos-plugin/macos-performance-benchmark",
+      "line": "macos-plugin/macos-performance-benchmark: Repeatable macOS/Apple-Silicon benchmark"
+    },
+    {
+      "id": "macos-plugin/macos-performance-triage",
+      "line": "macos-plugin/macos-performance-triage: Live macOS/Apple-Silicon performance"
+    },
+    {
+      "id": "macos-plugin/tui-keybinding-debug",
+      "line": "macos-plugin/tui-keybinding-debug: Debug dead TUI/terminal keybindings \u2014"
+    },
+    {
+      "id": "migration-patterns-plugin/black-to-ruff-format",
+      "line": "migration-patterns-plugin/black-to-ruff-format: Migrate Python formatting from black"
+    },
+    {
+      "id": "migration-patterns-plugin/dual-write",
+      "line": "migration-patterns-plugin/dual-write: Dual-write pattern for safe data store"
+    },
+    {
+      "id": "migration-patterns-plugin/eslint-to-biome",
+      "line": "migration-patterns-plugin/eslint-to-biome: Migrate JS/TS linting from"
+    },
+    {
+      "id": "migration-patterns-plugin/flake8-to-ruff",
+      "line": "migration-patterns-plugin/flake8-to-ruff: Migrate Python linting from flake8/isort"
+    },
+    {
+      "id": "migration-patterns-plugin/mypy-to-ty",
+      "line": "migration-patterns-plugin/mypy-to-ty: Migrate Python type checking from mypy"
+    },
+    {
+      "id": "migration-patterns-plugin/shadow-mode",
+      "line": "migration-patterns-plugin/shadow-mode: Shadow mode / dark-launch for validating"
+    },
+    {
+      "id": "networking-plugin/dns-tools",
+      "line": "networking-plugin/dns-tools: DNS resolution and propagation debugging"
+    },
+    {
+      "id": "networking-plugin/http-load-testing",
+      "line": "networking-plugin/http-load-testing: HTTP load testing with oha"
+    },
+    {
+      "id": "networking-plugin/interface-state",
+      "line": "networking-plugin/interface-state: Local interface, address, route,"
+    },
+    {
+      "id": "networking-plugin/layer2-discovery",
+      "line": "networking-plugin/layer2-discovery: Layer 2 device discovery and topology"
+    },
+    {
+      "id": "networking-plugin/network-diagnostics",
+      "line": "networking-plugin/network-diagnostics: Network connectivity and latency"
+    },
+    {
+      "id": "networking-plugin/network-discovery",
+      "line": "networking-plugin/network-discovery: Network host and port discovery"
+    },
+    {
+      "id": "networking-plugin/network-monitoring",
+      "line": "networking-plugin/network-monitoring: Real-time network traffic"
+    },
+    {
+      "id": "obsidian-plugin/bases",
+      "line": "obsidian-plugin/bases: Obsidian Bases (database-over-notes):"
+    },
+    {
+      "id": "obsidian-plugin/bookmarks",
+      "line": "obsidian-plugin/bookmarks: Obsidian bookmarks: list and add"
+    },
+    {
+      "id": "obsidian-plugin/command-palette",
+      "line": "obsidian-plugin/command-palette: Run, list, and inspect Obsidian commands"
+    },
+    {
+      "id": "obsidian-plugin/dev-tools",
+      "line": "obsidian-plugin/dev-tools: Obsidian plugin/theme dev: DevTools"
+    },
+    {
+      "id": "obsidian-plugin/file-history",
+      "line": "obsidian-plugin/file-history: Obsidian File Recovery and Sync history:"
+    },
+    {
+      "id": "obsidian-plugin/plugins-themes",
+      "line": "obsidian-plugin/plugins-themes: Obsidian community plugins/themes/CSS"
+    },
+    {
+      "id": "obsidian-plugin/properties",
+      "line": "obsidian-plugin/properties: Obsidian YAML frontmatter properties:"
+    },
+    {
+      "id": "obsidian-plugin/publish-sync",
+      "line": "obsidian-plugin/publish-sync: Obsidian Publish and Sync operations"
+    },
+    {
+      "id": "obsidian-plugin/search-discovery",
+      "line": "obsidian-plugin/search-discovery: Obsidian vault search: full-text/grep"
+    },
+    {
+      "id": "obsidian-plugin/tasks",
+      "line": "obsidian-plugin/tasks: Obsidian tasks via CLI: list open tasks"
+    },
+    {
+      "id": "obsidian-plugin/templates",
+      "line": "obsidian-plugin/templates: Obsidian Templates plugin: list, read"
+    },
+    {
+      "id": "obsidian-plugin/vault-files",
+      "line": "obsidian-plugin/vault-files: Obsidian vault file ops via CLI: read"
+    },
+    {
+      "id": "obsidian-plugin/vault-frontmatter",
+      "line": "obsidian-plugin/vault-frontmatter: Offline YAML frontmatter maintenance"
+    },
+    {
+      "id": "obsidian-plugin/vault-management",
+      "line": "obsidian-plugin/vault-management: Obsidian vault inspection"
+    },
+    {
+      "id": "obsidian-plugin/vault-mocs",
+      "line": "obsidian-plugin/vault-mocs: Map-of-Content (MOC) curation"
+    },
+    {
+      "id": "obsidian-plugin/vault-orphans",
+      "line": "obsidian-plugin/vault-orphans: Triage orphaned notes (zero in/out"
+    },
+    {
+      "id": "obsidian-plugin/vault-stubs",
+      "line": "obsidian-plugin/vault-stubs: Work-namespace redirect-stub"
+    },
+    {
+      "id": "obsidian-plugin/vault-tags",
+      "line": "obsidian-plugin/vault-tags: Emoji-prefixed tag taxonomy for Obsidian"
+    },
+    {
+      "id": "obsidian-plugin/vault-templates",
+      "line": "obsidian-plugin/vault-templates: Obsidian Templater drift repair"
+    },
+    {
+      "id": "obsidian-plugin/vault-wikilinks",
+      "line": "obsidian-plugin/vault-wikilinks: Broken Obsidian wikilink detection"
+    },
+    {
+      "id": "obsidian-plugin/workspaces",
+      "line": "obsidian-plugin/workspaces: Obsidian editor workspace: list open"
+    },
+    {
+      "id": "project-plugin/changelog-review",
+      "line": "project-plugin/changelog-review: Claude Code changelog analysis"
+    },
+    {
+      "id": "project-plugin/project-continue",
+      "line": "project-plugin/project-continue: Resume development from current project"
+    },
+    {
+      "id": "project-plugin/project-discovery",
+      "line": "project-plugin/project-discovery: Project orientation for unfamiliar"
+    },
+    {
+      "id": "project-plugin/project-init",
+      "line": "project-plugin/project-init: Scaffold a new project with base"
+    },
+    {
+      "id": "project-plugin/project-refocus",
+      "line": "project-plugin/project-refocus: Refresh the plan to focus on the task at"
+    },
+    {
+      "id": "project-plugin/project-skill-scripts",
+      "line": "project-plugin/project-skill-scripts: Find and create supporting scripts"
+    },
+    {
+      "id": "project-plugin/project-test-loop",
+      "line": "project-plugin/project-test-loop: Automated TDD test-fix-refactor cycle"
+    },
+    {
+      "id": "prompt-engineering-plugin/prompt-engineering-ground-response",
+      "line": "prompt-engineering-plugin/prompt-engineering-ground-response: Citation-backed responses with direct"
+    },
+    {
+      "id": "prose-plugin/prose-distill",
+      "line": "prose-plugin/prose-distill: Prose distill: condense verbose text"
+    },
+    {
+      "id": "prose-plugin/prose-synthesize",
+      "line": "prose-plugin/prose-synthesize: Prose synthesize: turn unstructured"
+    },
+    {
+      "id": "python-plugin/basedpyright-type-checking",
+      "line": "python-plugin/basedpyright-type-checking: Basedpyright static type checker"
+    },
+    {
+      "id": "python-plugin/pytest-advanced",
+      "line": "python-plugin/pytest-advanced: Advanced pytest: fixtures, markers"
+    },
+    {
+      "id": "python-plugin/python-code-quality",
+      "line": "python-plugin/python-code-quality: Python code quality with ruff and ty"
+    },
+    {
+      "id": "python-plugin/python-development",
+      "line": "python-plugin/python-development: Core Python development idioms"
+    },
+    {
+      "id": "python-plugin/python-packaging",
+      "line": "python-plugin/python-packaging: Build and publish Python packages"
+    },
+    {
+      "id": "python-plugin/python-testing",
+      "line": "python-plugin/python-testing: Python testing with pytest, coverage"
+    },
+    {
+      "id": "python-plugin/ruff-formatting",
+      "line": "python-plugin/ruff-formatting: Python code formatting with ruff format"
+    },
+    {
+      "id": "python-plugin/ruff-linting",
+      "line": "python-plugin/ruff-linting: Python linting with ruff. Fast linting"
+    },
+    {
+      "id": "python-plugin/ty-type-checking",
+      "line": "python-plugin/ty-type-checking: ty: Astral's extremely fast Python type"
+    },
+    {
+      "id": "python-plugin/uv-advanced-dependencies",
+      "line": "python-plugin/uv-advanced-dependencies: Advanced uv dependencies: Git deps, path"
+    },
+    {
+      "id": "python-plugin/uv-project-management",
+      "line": "python-plugin/uv-project-management: Python project setup, deps,"
+    },
+    {
+      "id": "python-plugin/uv-python-versions",
+      "line": "python-plugin/uv-python-versions: Install and manage Python interpreter"
+    },
+    {
+      "id": "python-plugin/uv-run",
+      "line": "python-plugin/uv-run: Run Python scripts with uv (PEP 723"
+    },
+    {
+      "id": "python-plugin/uv-tool-management",
+      "line": "python-plugin/uv-tool-management: Install and manage global Python CLI"
+    },
+    {
+      "id": "python-plugin/uv-workspaces",
+      "line": "python-plugin/uv-workspaces: Manage multi-package Python projects"
+    },
+    {
+      "id": "python-plugin/vulture-dead-code",
+      "line": "python-plugin/vulture-dead-code: Vulture and deadcode tools for detecting"
+    },
+    {
+      "id": "rust-plugin/cargo-llvm-cov",
+      "line": "rust-plugin/cargo-llvm-cov: cargo-llvm-cov: Rust code coverage"
+    },
+    {
+      "id": "rust-plugin/cargo-machete",
+      "line": "rust-plugin/cargo-machete: cargo-machete: detect unused Rust"
+    },
+    {
+      "id": "rust-plugin/cargo-nextest",
+      "line": "rust-plugin/cargo-nextest: cargo-nextest: fast Rust test runner"
+    },
+    {
+      "id": "rust-plugin/cargo-worktree-builds",
+      "line": "rust-plugin/cargo-worktree-builds: Share one CARGO_TARGET_DIR across"
+    },
+    {
+      "id": "rust-plugin/clippy-advanced",
+      "line": "rust-plugin/clippy-advanced: Advanced Clippy configuration for Rust \u2014"
+    },
+    {
+      "id": "rust-plugin/mockito-http-mocking",
+      "line": "rust-plugin/mockito-http-mocking: mockito HTTP mocking for Rust"
+    },
+    {
+      "id": "rust-plugin/rust-development",
+      "line": "rust-plugin/rust-development: Rust development \u2014 cargo, clippy"
+    },
+    {
+      "id": "session-plugin/session-distill",
+      "line": "session-plugin/session-distill: Distill session insights into rules"
+    },
+    {
+      "id": "session-plugin/session-end",
+      "line": "session-plugin/session-end: End-of-session orchestrator. Previews"
+    },
+    {
+      "id": "session-plugin/session-spinup",
+      "line": "session-plugin/session-spinup: Read-only session-start briefing of open"
+    },
+    {
+      "id": "session-plugin/session-wrap",
+      "line": "session-plugin/session-wrap: End-of-session capture to taskwarrior"
+    },
+    {
+      "id": "software-design-plugin/design-by-contract",
+      "line": "software-design-plugin/design-by-contract: Design with explicit contracts \u2014"
+    },
+    {
+      "id": "software-design-plugin/design-deep-modules",
+      "line": "software-design-plugin/design-deep-modules: Judge interface depth \u2014 deep modules"
+    },
+    {
+      "id": "software-design-plugin/design-legacy-seams",
+      "line": "software-design-plugin/design-legacy-seams: Get legacy code under test before"
+    },
+    {
+      "id": "software-design-plugin/design-patterns",
+      "line": "software-design-plugin/design-patterns: Select a design pattern from a symptom \u2014"
+    },
+    {
+      "id": "software-design-plugin/design-pseudocode",
+      "line": "software-design-plugin/design-pseudocode: Design a routine by stepwise refinement"
+    },
+    {
+      "id": "taskwarrior-plugin/install-native-hooks",
+      "line": "taskwarrior-plugin/install-native-hooks: Install opt-in taskwarrior native"
+    },
+    {
+      "id": "taskwarrior-plugin/task-add",
+      "line": "taskwarrior-plugin/task-add: Add a taskwarrior task with blueprint"
+    },
+    {
+      "id": "taskwarrior-plugin/task-bulk-ops",
+      "line": "taskwarrior-plugin/task-bulk-ops: Batch taskwarrior operations without"
+    },
+    {
+      "id": "taskwarrior-plugin/task-claim",
+      "line": "taskwarrior-plugin/task-claim: Claim a taskwarrior task as in-flight"
+    },
+    {
+      "id": "taskwarrior-plugin/task-coordinate",
+      "line": "taskwarrior-plugin/task-coordinate: Surface next N unblocked taskwarrior"
+    },
+    {
+      "id": "taskwarrior-plugin/task-done",
+      "line": "taskwarrior-plugin/task-done: Close a taskwarrior task with landing"
+    },
+    {
+      "id": "taskwarrior-plugin/task-reconcile",
+      "line": "taskwarrior-plugin/task-reconcile: Close taskwarrior tasks whose linked"
+    },
+    {
+      "id": "taskwarrior-plugin/task-release",
+      "line": "taskwarrior-plugin/task-release: Release a taskwarrior task without"
+    },
+    {
+      "id": "taskwarrior-plugin/task-status",
+      "line": "taskwarrior-plugin/task-status: Read-only taskwarrior queue report \u2014"
+    },
+    {
+      "id": "terraform-plugin/infrastructure-terraform",
+      "line": "terraform-plugin/infrastructure-terraform: Terraform IaC: HCL, state management"
+    },
+    {
+      "id": "terraform-plugin/tfc-list-runs",
+      "line": "terraform-plugin/tfc-list-runs: List Terraform Cloud workspace runs"
+    },
+    {
+      "id": "terraform-plugin/tfc-plan-json",
+      "line": "terraform-plugin/tfc-plan-json: TFC plan JSON download and analysis"
+    },
+    {
+      "id": "terraform-plugin/tfc-run-logs",
+      "line": "terraform-plugin/tfc-run-logs: Retrieve plan and apply logs from"
+    },
+    {
+      "id": "terraform-plugin/tfc-run-status",
+      "line": "terraform-plugin/tfc-run-status: Terraform Cloud run status with resource"
+    },
+    {
+      "id": "terraform-plugin/tfc-workspace-runs",
+      "line": "terraform-plugin/tfc-workspace-runs: List TFC runs across known workspaces"
+    },
+    {
+      "id": "testing-plugin/mutation-testing",
+      "line": "testing-plugin/mutation-testing: Mutation testing with Stryker (TS/JS)"
+    },
+    {
+      "id": "testing-plugin/odiff-image-diffing",
+      "line": "testing-plugin/odiff-image-diffing: odiff pixel-by-pixel image diffing"
+    },
+    {
+      "id": "testing-plugin/playwright-cli",
+      "line": "testing-plugin/playwright-cli: Playwright CLI browser automation \u2014"
+    },
+    {
+      "id": "testing-plugin/playwright-testing",
+      "line": "testing-plugin/playwright-testing: Playwright E2E testing \u2014 cross-browser"
+    },
+    {
+      "id": "testing-plugin/property-based-testing",
+      "line": "testing-plugin/property-based-testing: Property-based testing with fast-check"
+    },
+    {
+      "id": "testing-plugin/test-analyze",
+      "line": "testing-plugin/test-analyze: Analyze test results and create a fix"
+    },
+    {
+      "id": "testing-plugin/test-consult",
+      "line": "testing-plugin/test-consult: Consult the test-architecture agent"
+    },
+    {
+      "id": "testing-plugin/test-focus",
+      "line": "testing-plugin/test-focus: Run one test file fail-fast for rapid"
+    },
+    {
+      "id": "testing-plugin/test-full",
+      "line": "testing-plugin/test-full: Run complete test suite in pyramid order"
+    },
+    {
+      "id": "testing-plugin/test-quality-analysis",
+      "line": "testing-plugin/test-quality-analysis: Detect test smells, overmocking, flaky"
+    },
+    {
+      "id": "testing-plugin/test-quick",
+      "line": "testing-plugin/test-quick: Run fast unit tests only, skip"
+    },
+    {
+      "id": "testing-plugin/test-report",
+      "line": "testing-plugin/test-report: Show cached test status without"
+    },
+    {
+      "id": "testing-plugin/test-run",
+      "line": "testing-plugin/test-run: Universal test runner auto-detecting"
+    },
+    {
+      "id": "testing-plugin/test-setup",
+      "line": "testing-plugin/test-setup: Configure testing infrastructure"
+    },
+    {
+      "id": "testing-plugin/test-strategy-review",
+      "line": "testing-plugin/test-strategy-review: Evaluate whether a test suite actually"
+    },
+    {
+      "id": "testing-plugin/test-tier-selection",
+      "line": "testing-plugin/test-tier-selection: Auto-select test tiers based on change"
+    },
+    {
+      "id": "testing-plugin/vitest-testing",
+      "line": "testing-plugin/vitest-testing: Vitest test runner \u2014 Vite-native, ESM"
+    },
+    {
+      "id": "tools-plugin/binary-analysis",
+      "line": "tools-plugin/binary-analysis: Binary analysis: strings, binwalk"
+    },
+    {
+      "id": "tools-plugin/cli-smoke-recipes",
+      "line": "tools-plugin/cli-smoke-recipes: CLI smoke recipes: expose pure-function"
+    },
+    {
+      "id": "tools-plugin/d2-diagrams",
+      "line": "tools-plugin/d2-diagrams: Generate diagrams from text using D2"
+    },
+    {
+      "id": "tools-plugin/deps-install",
+      "line": "tools-plugin/deps-install: Deps install: auto-detect package"
+    },
+    {
+      "id": "tools-plugin/fd-file-finding",
+      "line": "tools-plugin/fd-file-finding: fd fast file finding: smart defaults"
+    },
+    {
+      "id": "tools-plugin/generate-image",
+      "line": "tools-plugin/generate-image: Image generation via Gemini 3 Pro Image:"
+    },
+    {
+      "id": "tools-plugin/hf-downloads",
+      "line": "tools-plugin/hf-downloads: Hugging Face model downloads without"
+    },
+    {
+      "id": "tools-plugin/imagemagick-conversion",
+      "line": "tools-plugin/imagemagick-conversion: ImageMagick image manipulation: format"
+    },
+    {
+      "id": "tools-plugin/jq-json-processing",
+      "line": "tools-plugin/jq-json-processing: jq JSON processing: query, filter"
+    },
+    {
+      "id": "tools-plugin/justfile-expert",
+      "line": "tools-plugin/justfile-expert: Just command runner expertise \u2014 Justfile"
+    },
+    {
+      "id": "tools-plugin/mermaid-diagrams",
+      "line": "tools-plugin/mermaid-diagrams: Render Mermaid diagrams (mmdc)"
+    },
+    {
+      "id": "tools-plugin/nushell-data-processing",
+      "line": "tools-plugin/nushell-data-processing: Structured data processing with nushell"
+    },
+    {
+      "id": "tools-plugin/rg-code-search",
+      "line": "tools-plugin/rg-code-search: ripgrep (rg) fast code search: smart"
+    },
+    {
+      "id": "tools-plugin/shell-expert",
+      "line": "tools-plugin/shell-expert: Shell scripting: bash, zsh, POSIX, CLI"
+    },
+    {
+      "id": "tools-plugin/yq-yaml-processing",
+      "line": "tools-plugin/yq-yaml-processing: yq YAML processing: query, filter"
+    },
+    {
+      "id": "typescript-plugin/biome-tooling",
+      "line": "typescript-plugin/biome-tooling: Biome all-in-one JS/TS formatter"
+    },
+    {
+      "id": "typescript-plugin/bun-add",
+      "line": "typescript-plugin/bun-add: Bun add: install a package, add dev"
+    },
+    {
+      "id": "typescript-plugin/bun-build",
+      "line": "typescript-plugin/bun-build: Bun build: bundle or compile JS/TS"
+    },
+    {
+      "id": "typescript-plugin/bun-debug",
+      "line": "typescript-plugin/bun-debug: Bun debugger via --inspect"
+    },
+    {
+      "id": "typescript-plugin/bun-development",
+      "line": "typescript-plugin/bun-development: Bun runtime workflows for running"
+    },
+    {
+      "id": "typescript-plugin/bun-install",
+      "line": "typescript-plugin/bun-install: Bun install: install all deps from"
+    },
+    {
+      "id": "typescript-plugin/bun-lockfile-update",
+      "line": "typescript-plugin/bun-lockfile-update: Bun lockfile update (bun.lock): bun"
+    },
+    {
+      "id": "typescript-plugin/bun-outdated",
+      "line": "typescript-plugin/bun-outdated: Bun outdated: check which deps have"
+    },
+    {
+      "id": "typescript-plugin/bun-package-manager",
+      "line": "typescript-plugin/bun-package-manager: Fast JavaScript package management"
+    },
+    {
+      "id": "typescript-plugin/bun-publish",
+      "line": "typescript-plugin/bun-publish: Bun publish to npm"
+    },
+    {
+      "id": "typescript-plugin/bun-publishing",
+      "line": "typescript-plugin/bun-publishing: Publish npm packages built with Bun:"
+    },
+    {
+      "id": "typescript-plugin/bun-test",
+      "line": "typescript-plugin/bun-test: Bun test runner with compact"
+    },
+    {
+      "id": "typescript-plugin/knip-dead-code",
+      "line": "typescript-plugin/knip-dead-code: Knip dead-code detector for JS/TS:"
+    },
+    {
+      "id": "typescript-plugin/nodejs-development",
+      "line": "typescript-plugin/nodejs-development: Node.js development with Bun, Vite, Vue"
+    },
+    {
+      "id": "typescript-plugin/typescript-debugging",
+      "line": "typescript-plugin/typescript-debugging: Modern TypeScript/JavaScript debugging"
+    },
+    {
+      "id": "typescript-plugin/typescript-sentry",
+      "line": "typescript-plugin/typescript-sentry: Error monitoring and performance"
+    },
+    {
+      "id": "typescript-plugin/typescript-strict",
+      "line": "typescript-plugin/typescript-strict: TypeScript strict mode: tsconfig.json"
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-checkpoint-refactor",
+      "line": "workflow-orchestration-plugin/workflow-checkpoint-refactor: Multi-phase refactoring with checkpoint"
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-preflight",
+      "line": "workflow-orchestration-plugin/workflow-preflight: Pre-work validation before"
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-verify-before-filing",
+      "line": "workflow-orchestration-plugin/workflow-verify-before-filing: Verify accumulated bug claims at"
+    },
+    {
+      "id": "workflow-orchestration-plugin/workflow-wave-dispatch",
+      "line": "workflow-orchestration-plugin/workflow-wave-dispatch: Sequential-wave dispatch for multi-agent"
+    }
+  ]
+}

--- a/experiments/skill-catalog-routing/catalogs/catalog.full.json
+++ b/experiments/skill-catalog-routing/catalogs/catalog.full.json
@@ -1,7 +1,7 @@
 {
   "variant": "full",
-  "source_sha": "020bfd9049809681d21d5b6469696f079f249bd3",
-  "skill_count": 405,
+  "source_sha": "0ed1791a1abb10ba687ae115adf637b9f5b9cc59",
+  "skill_count": 406,
   "entries": [
     {
       "id": "accessibility-plugin/accessibility-implementation",
@@ -122,6 +122,10 @@
     {
       "id": "blueprint-plugin/blueprint-adr-validate",
       "line": "blueprint-plugin/blueprint-adr-validate: Validate ADR relationships, domain consistency, and duplicate ADR numbers. Use when auditing ADRs before release, finding broken supersedes/extends links, cycles, or number collisions."
+    },
+    {
+      "id": "blueprint-plugin/blueprint-autonomy-level3",
+      "line": "blueprint-plugin/blueprint-autonomy-level3: Install blueprint autonomy level 3 (ADR-0020): scheduled-autorun + approved-work-order-execution GitHub workflows. Use when enabling out-of-band blueprint automation in a repo."
     },
     {
       "id": "blueprint-plugin/blueprint-autopilot",

--- a/experiments/skill-catalog-routing/catalogs/catalog.medium.json
+++ b/experiments/skill-catalog-routing/catalogs/catalog.medium.json
@@ -1,7 +1,7 @@
 {
   "variant": "medium",
-  "source_sha": "020bfd9049809681d21d5b6469696f079f249bd3",
-  "skill_count": 405,
+  "source_sha": "0ed1791a1abb10ba687ae115adf637b9f5b9cc59",
+  "skill_count": 406,
   "entries": [
     {
       "id": "accessibility-plugin/accessibility-implementation",
@@ -122,6 +122,10 @@
     {
       "id": "blueprint-plugin/blueprint-adr-validate",
       "line": "blueprint-plugin/blueprint-adr-validate: Use when auditing ADRs before release, finding broken supersedes/extends links"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-autonomy-level3",
+      "line": "blueprint-plugin/blueprint-autonomy-level3: Use when enabling out-of-band blueprint automation in a repo"
     },
     {
       "id": "blueprint-plugin/blueprint-autopilot",

--- a/experiments/skill-catalog-routing/catalogs/catalog.names.json
+++ b/experiments/skill-catalog-routing/catalogs/catalog.names.json
@@ -1,7 +1,7 @@
 {
   "variant": "names",
-  "source_sha": "020bfd9049809681d21d5b6469696f079f249bd3",
-  "skill_count": 405,
+  "source_sha": "0ed1791a1abb10ba687ae115adf637b9f5b9cc59",
+  "skill_count": 406,
   "entries": [
     {
       "id": "accessibility-plugin/accessibility-implementation",
@@ -122,6 +122,10 @@
     {
       "id": "blueprint-plugin/blueprint-adr-validate",
       "line": "blueprint-plugin/blueprint-adr-validate"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-autonomy-level3",
+      "line": "blueprint-plugin/blueprint-autonomy-level3"
     },
     {
       "id": "blueprint-plugin/blueprint-autopilot",

--- a/experiments/skill-catalog-routing/catalogs/catalog.short.json
+++ b/experiments/skill-catalog-routing/catalogs/catalog.short.json
@@ -1,7 +1,7 @@
 {
   "variant": "short",
-  "source_sha": "020bfd9049809681d21d5b6469696f079f249bd3",
-  "skill_count": 405,
+  "source_sha": "0ed1791a1abb10ba687ae115adf637b9f5b9cc59",
+  "skill_count": 406,
   "entries": [
     {
       "id": "accessibility-plugin/accessibility-implementation",
@@ -122,6 +122,10 @@
     {
       "id": "blueprint-plugin/blueprint-adr-validate",
       "line": "blueprint-plugin/blueprint-adr-validate: Use when auditing ADRs before release"
+    },
+    {
+      "id": "blueprint-plugin/blueprint-autonomy-level3",
+      "line": "blueprint-plugin/blueprint-autonomy-level3: Use when enabling out-of-band blueprint"
     },
     {
       "id": "blueprint-plugin/blueprint-autopilot",

--- a/experiments/skill-catalog-routing/catalogs/catalog_manifest.json
+++ b/experiments/skill-catalog-routing/catalogs/catalog_manifest.json
@@ -1,14 +1,17 @@
 {
-  "source_sha": "020bfd9049809681d21d5b6469696f079f249bd3",
-  "skill_count": 405,
+  "source_sha": "0ed1791a1abb10ba687ae115adf637b9f5b9cc59",
+  "skill_count": 406,
   "content_hashes": {
-    "names": "312a3f2906f4a5ef",
-    "short": "65adefebd659ef37",
-    "medium": "cd0c7b2d4fca78fe",
-    "full": "eb4eea1bd954bc97"
+    "names": "b0d50886f869b5d3",
+    "short": "9983f0600ed963c7",
+    "medium": "5f43577a3a79d1b3",
+    "full": "25e054d10d782563",
+    "domain-short": "eeb08427ca8aba26",
+    "domain-medium": "aa2cc8a6b57007ad",
+    "compact": "85019abf0390ac06"
   },
   "provenance_counts": {
-    "mechanical": 405
+    "mechanical": 406
   },
   "band_char_ceilings": {
     "short": 40,
@@ -164,6 +167,11 @@
       "id": "blueprint-plugin/blueprint-adr-validate",
       "provenance": "mechanical",
       "full_len": 184
+    },
+    {
+      "id": "blueprint-plugin/blueprint-autonomy-level3",
+      "provenance": "mechanical",
+      "full_len": 176
     },
     {
       "id": "blueprint-plugin/blueprint-autopilot",

--- a/experiments/skill-catalog-routing/catalogs/catalog_tokens.json
+++ b/experiments/skill-catalog-routing/catalogs/catalog_tokens.json
@@ -2,9 +2,12 @@
   "measured_with": {
     "note": "total input tokens incl. fixed router+tooling constant"
   },
-  "none": 23157,
-  "names": 27326,
-  "short": 30382,
-  "medium": 34109,
-  "full": 43853
+  "none": 23083,
+  "names": 27264,
+  "short": 30330,
+  "domain-short": 30974,
+  "medium": 34061,
+  "domain-medium": 33839,
+  "compact": 34586,
+  "full": 43836
 }

--- a/experiments/skill-catalog-routing/conditions.yaml
+++ b/experiments/skill-catalog-routing/conditions.yaml
@@ -43,3 +43,18 @@ conditions:
   - {id: opus-C2, model: claude-opus-4-8, effort: low, catalog: short}
   - {id: opus-C3, model: claude-opus-4-8, effort: low, catalog: medium}
   - {id: opus-C4, model: claude-opus-4-8, effort: low, catalog: full}
+
+  # ---- domain-preserving variants (follow-up: finding #4) -------------------
+  # C2d = domain-short (~40c, capability phrase instead of the trigger tail),
+  # C3d = domain-medium (~80c), C5 = compact (domain head + "Use when <trigger>",
+  # keeps the literal "Use when"). Token-matched to C2/C3 so the A/B is
+  # domain-first vs trigger-first at equal budget.
+  # Haiku runs the full new ladder; sonnet/opus run the recommendation
+  # candidates (C2d, C5) alongside the C0/C1/C4 portability anchors.
+  - {id: haiku-C2d, model: claude-haiku-4-5, effort: low, catalog: domain-short}
+  - {id: haiku-C3d, model: claude-haiku-4-5, effort: low, catalog: domain-medium}
+  - {id: haiku-C5, model: claude-haiku-4-5, effort: low, catalog: compact}
+  - {id: sonnet-C2d, model: claude-sonnet-4-6, effort: low, catalog: domain-short}
+  - {id: sonnet-C5, model: claude-sonnet-4-6, effort: low, catalog: compact}
+  - {id: opus-C2d, model: claude-opus-4-8, effort: low, catalog: domain-short}
+  - {id: opus-C5, model: claude-opus-4-8, effort: low, catalog: compact}

--- a/experiments/skill-catalog-routing/scripts/build-arm-prompt.sh
+++ b/experiments/skill-catalog-routing/scripts/build-arm-prompt.sh
@@ -22,30 +22,25 @@ out="$out_dir/system.$variant.md"
 [ -f "$router" ] || { echo "ERROR: router prompt not found: $router" >&2; exit 1; }
 mkdir -p "$out_dir"
 
-case "$variant" in
-  none)
-    # C0 — no catalog. Router prompt only.
-    cp "$router" "$out"
-    ;;
-  names|short|medium|full)
-    catalog="$root/catalogs/catalog.$variant.json"
-    [ -f "$catalog" ] || { echo "ERROR: catalog not found: $catalog — run build-catalogs.py first" >&2; exit 1; }
-    {
-      cat "$router"
-      printf '\n\n## Available skills\n\n'
-      # One skill per line, exactly as stored in the catalog's `line` field.
-      python3 -c '
+if [ "$variant" = "none" ]; then
+  # C0 — no catalog. Router prompt only.
+  cp "$router" "$out"
+else
+  # Any variant whose catalog file exists (names/short/medium/full/domain-*/
+  # compact/…). New variants need no edit here — just a built catalog.
+  catalog="$root/catalogs/catalog.$variant.json"
+  [ -f "$catalog" ] || { echo "ERROR: catalog not found: $catalog — run build-catalogs.py first (unknown variant '$variant'?)" >&2; exit 1; }
+  {
+    cat "$router"
+    printf '\n\n## Available skills\n\n'
+    # One skill per line, exactly as stored in the catalog's `line` field.
+    python3 -c '
 import json, sys
 data = json.load(open(sys.argv[1]))
 for e in data["entries"]:
     print(e["line"])
 ' "$catalog"
-    } > "$out"
-    ;;
-  *)
-    echo "ERROR: unknown catalog variant: $variant" >&2
-    exit 1
-    ;;
-esac
+  } > "$out"
+fi
 
 printf '%s\n' "$out"

--- a/experiments/skill-catalog-routing/scripts/build-catalogs.py
+++ b/experiments/skill-catalog-routing/scripts/build-catalogs.py
@@ -163,6 +163,66 @@ def shorten(desc: str) -> tuple[str, str, str]:
     return short, medium, "mechanical"
 
 
+def _domain_of(desc: str) -> str:
+    """The capability/domain phrase: everything BEFORE the 'Use when' clause.
+
+    Descriptions are '<domain>. Use when <triggers>.' — the domain sentence
+    ('ripgrep fast code search: smart defaults, regex, file filtering') is what
+    the trigger-first short/medium variants dropped. Returns the whole
+    description when there is no 'Use when' marker.
+    """
+    m = _USE_WHEN_RE.search(desc)
+    head = desc[: m.start()] if m else desc
+    return head.strip().rstrip(" .;,")
+
+
+def domain_shorten(desc: str) -> tuple[str, str, str]:
+    """Return (domain_short ≤40c, domain_medium ≤80c, provenance).
+
+    The DOMAIN-preserving counterpart of shorten(): keep the capability phrase,
+    drop the 'Use when' trigger tail. Token-matched to short/medium so the A/B
+    is domain-first vs trigger-first at equal budget. These deliberately do NOT
+    carry 'Use when' — the experiment measures routing signal, not the
+    production auto-invocation matcher (see compact_shorten for that).
+    """
+    domain = _domain_of(desc)
+    if not domain:
+        # Degenerate: 'Use when' at position 0. Fall back to the trigger form.
+        s, m_, _ = shorten(desc)
+        return s, m_, "domain-fallback"
+    d_medium = _truncate_word_boundary(domain, MEDIUM_MAX)
+    d_short = _truncate_word_boundary(domain, SHORT_MAX)
+    return d_short, d_medium, "domain"
+
+
+def compact_shorten(desc: str) -> tuple[str, str]:
+    """Return (compact_text ≤80c, provenance) — the production recommendation
+    candidate: a short domain head PLUS 'Use when <first trigger>', keeping the
+    literal 'Use when' so it stays valid for the real auto-invocation matcher
+    (#1278). Best-of-both: capability phrase for routing + trigger for the
+    matcher, within the medium budget.
+    """
+    domain = _domain_of(desc)
+    short_trigger, _, prov = shorten(desc)  # "Use when <first scenario>" ≤40
+    if prov != "mechanical" or not domain:
+        # No clean domain+trigger split — fall back to the medium trigger form.
+        _, medium, _ = shorten(desc)
+        return _truncate_word_boundary(medium, MEDIUM_MAX), "compact-fallback"
+    # Budget the domain head so "domain: Use when <trigger>" fits ≤80.
+    # Reserve room for ": " + the trigger clause.
+    reserve = len(short_trigger) + 2
+    head_budget = max(0, MEDIUM_MAX - reserve)
+    head = _truncate_word_boundary(domain, head_budget)
+    # Strip a trailing dangling separator (em/en-dash, colon) left by truncating
+    # the domain mid-phrase, so the join reads "<head>: Use when ..." cleanly.
+    head = head.rstrip(" —–-:;,.").strip()
+    if head:
+        combined = f"{head}: {short_trigger}"
+    else:
+        combined = short_trigger
+    return _truncate_word_boundary(combined, MEDIUM_MAX), "compact"
+
+
 def build() -> tuple[list[dict], str]:
     sha = "unknown"
     try:
@@ -182,15 +242,21 @@ def build() -> tuple[list[dict], str]:
             rid = routing_id(path)
             rows.append({
                 "id": rid, "full": "", "medium": "", "short": "",
+                "domain-short": "", "domain-medium": "", "compact": "",
                 "provenance": "empty", "full_len": 0,
             })
             continue
         short, medium, provenance = shorten(desc)
+        d_short, d_medium, _ = domain_shorten(desc)
+        compact, _ = compact_shorten(desc)
         rows.append({
             "id": routing_id(path),
             "full": desc,
             "medium": medium,
             "short": short,
+            "domain-short": d_short,
+            "domain-medium": d_medium,
+            "compact": compact,
             "provenance": provenance,
             "full_len": len(desc),
         })
@@ -208,6 +274,9 @@ def write_catalogs(rows: list[dict], sha: str) -> dict[str, str]:
         "short": lambda r: _line(r["id"], r["short"]),
         "medium": lambda r: _line(r["id"], r["medium"]),
         "full": lambda r: _line(r["id"], r["full"]),
+        "domain-short": lambda r: _line(r["id"], r["domain-short"]),
+        "domain-medium": lambda r: _line(r["id"], r["domain-medium"]),
+        "compact": lambda r: _line(r["id"], r["compact"]),
     }
     hashes = {}
     for variant, render in variants.items():
@@ -269,6 +338,23 @@ def validate(rows: list[dict]) -> int:
         # Monotonicity: short must be a prefix of medium (token-subset).
         if r["short"] and not r["medium"].startswith(r["short"]):
             fail(f"{r['id']} short is not a prefix of medium:\n  short={r['short']!r}\n  medium={r['medium']!r}")
+
+        # Domain-preserving variants: band ceilings + monotone within the domain
+        # ladder. These deliberately do NOT carry 'Use when' (they keep the
+        # capability phrase instead of the trigger tail).
+        if len(r["domain-short"]) > SHORT_MAX:
+            fail(f"{r['id']} domain-short exceeds {SHORT_MAX}c: {len(r['domain-short'])}")
+        if len(r["domain-medium"]) > MEDIUM_MAX:
+            fail(f"{r['id']} domain-medium exceeds {MEDIUM_MAX}c: {len(r['domain-medium'])}")
+        if r["domain-short"] and not r["domain-medium"].startswith(r["domain-short"]):
+            fail(f"{r['id']} domain-short is not a prefix of domain-medium:\n  ds={r['domain-short']!r}\n  dm={r['domain-medium']!r}")
+        # Compact: within the medium ceiling and MUST keep the literal 'Use when'
+        # (it is the best-of-both form intended to stay matcher-valid, #1278)
+        # — except where the source had no clean domain+trigger split.
+        if len(r["compact"]) > MEDIUM_MAX:
+            fail(f"{r['id']} compact exceeds {MEDIUM_MAX}c: {len(r['compact'])}")
+        if r["provenance"] == "mechanical" and _domain_of(r["full"]) and "use when" not in r["compact"].lower():
+            fail(f"{r['id']} compact lost 'Use when': {r['compact']!r}")
 
     total = len(rows)
     print(f"Validated {total} skills; {failures} failures.", file=sys.stderr)

--- a/experiments/skill-catalog-routing/scripts/measure-catalog-tokens.sh
+++ b/experiments/skill-catalog-routing/scripts/measure-catalog-tokens.sh
@@ -52,7 +52,7 @@ printf 'VARIANT\trep\ttotal_input\n'
 
 tmp_json="$root/catalogs/catalog_tokens.json"
 declare -A mean
-for variant in none names short medium full; do
+for variant in none names short domain-short medium domain-medium compact full; do
   arm_prompt="$("$here/build-arm-prompt.sh" "$variant")"
   sum=0; got=0
   for ((i = 1; i <= reps; i++)); do
@@ -73,13 +73,18 @@ for variant in none names short medium full; do
 done
 
 # Emit JSON for the frontier renderer.
-python3 - "$tmp_json" "${mean[none]}" "${mean[names]}" "${mean[short]}" "${mean[medium]}" "${mean[full]}" <<'PY'
+python3 - "$tmp_json" \
+  "${mean[none]}" "${mean[names]}" "${mean[short]}" "${mean[domain-short]}" \
+  "${mean[medium]}" "${mean[domain-medium]}" "${mean[compact]}" "${mean[full]}" <<'PY'
 import json, sys
-out, none, names, short, medium, full = sys.argv[1:7]
+out = sys.argv[1]
+none, names, short, dshort, medium, dmedium, compact, full = (int(x) for x in sys.argv[2:10])
 json.dump({
     "measured_with": {"note": "total input tokens incl. fixed router+tooling constant"},
-    "none": int(none), "names": int(names), "short": int(short),
-    "medium": int(medium), "full": int(full),
+    "none": none, "names": names,
+    "short": short, "domain-short": dshort,
+    "medium": medium, "domain-medium": dmedium,
+    "compact": compact, "full": full,
 }, open(out, "w"), indent=2)
 print(f"wrote {out}")
 PY

--- a/experiments/skill-catalog-routing/scripts/render-frontier.py
+++ b/experiments/skill-catalog-routing/scripts/render-frontier.py
@@ -94,7 +94,7 @@ def main() -> int:
         def g(arm: str, key: str = "top1"):
             c = conds.get(f"{model}-{arm}")
             return c[key] if c else None
-        c0, c1, c2, c3, c4 = (g(a) for a in ARMS)
+        c0, c1, c2, c3, c4 = (g("C0"), g("C1"), g("C2"), g("C3"), g("C4"))
         if c4 is None:
             continue
         catalog_value = f"{c4 - c0:+.2f}" if c0 is not None else "—"

--- a/experiments/skill-catalog-routing/scripts/render-frontier.py
+++ b/experiments/skill-catalog-routing/scripts/render-frontier.py
@@ -23,8 +23,17 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
-ARMS = ["C0", "C1", "C2", "C3", "C4"]
-ARM_CATALOG = {"C0": "none", "C1": "names", "C2": "short", "C3": "medium", "C4": "full"}
+# Ordered by catalog token cost; domain-first variants sit beside their
+# trigger-first counterparts (C2/C2d ~40c, C3/C3d ~80c) for direct comparison.
+ARMS = ["C0", "C1", "C2", "C2d", "C3", "C3d", "C5", "C4"]
+ARM_CATALOG = {
+    "C0": "none", "C1": "names",
+    "C2": "short", "C2d": "domain-short",
+    "C3": "medium", "C3d": "domain-medium",
+    "C5": "compact", "C4": "full",
+}
+# Domain-first vs trigger-first pairs at equal budget (finding #4).
+DOMAIN_PAIRS = [("C2", "C2d"), ("C3", "C3d")]
 MODELS = ["haiku", "sonnet", "opus"]
 PORTABILITY_THRESHOLD = 0.15
 
@@ -95,6 +104,37 @@ def main() -> int:
         slope_s = f"{slope:+.2f}" if slope is not None else "—"
         c3c4 = f"{c3:.2f} vs {c4:.2f}" if c3 is not None else "—"
         lines.append(f"| {model} | {catalog_value} | {desc_value} | {slope_s} | {c3c4} |")
+    lines.append("")
+
+    # Domain-first vs trigger-first at equal budget (finding #4): does keeping
+    # the capability phrase beat keeping the "Use when" trigger tail?
+    lines += ["## Domain-first vs trigger-first (equal budget)", "",
+              "| model | budget | trigger-first | domain-first | Δ (domain−trigger) |",
+              "|---|---|---|---|---|"]
+    for model in MODELS:
+        for trig, dom in DOMAIN_PAIRS:
+            tc = conds.get(f"{model}-{trig}")
+            dc = conds.get(f"{model}-{dom}")
+            if not tc or not dc:
+                continue
+            band = "~40c" if trig == "C2" else "~80c"
+            delta = dc["top1"] - tc["top1"]
+            lines.append(
+                f"| {model} | {band} | {tc['top1']:.2f} ({trig}) | "
+                f"{dc['top1']:.2f} ({dom}) | {delta:+.2f} |"
+            )
+    # Compact (domain + trigger) vs full.
+    lines += ["", "| model | compact C5 top1 | full C4 top1 | C5−C4 | C5 tokens | C4 tokens |",
+              "|---|---|---|---|---|---|"]
+    for model in MODELS:
+        c5 = conds.get(f"{model}-C5")
+        c4 = conds.get(f"{model}-C4")
+        if not c5 or not c4:
+            continue
+        lines.append(
+            f"| {model} | {c5['top1']:.2f} | {c4['top1']:.2f} | {c5['top1'] - c4['top1']:+.2f} "
+            f"| {tokens.get('compact', '—')} | {tokens.get('full', '—')} |"
+        )
     lines.append("")
 
     # Portability read.


### PR DESCRIPTION
## What & why

Two follow-ups to the merged skill-catalog-routing experiment (#2098), closing the open questions its findings named:

1. **Domain-preserving short variant** — the merged haiku ladder found trigger-only shortening (`short`/`medium`, keeping the `Use when` tail) stalls at 0.86–0.88 because it **drops the leading capability/domain phrase**, which carries most of the routing signal. This adds domain-first variants that keep that phrase instead.
2. **Cross-model sweep (sonnet + opus)** — the portability question: do stronger models recover more from names alone (shrinking the description's value)? And does the domain-short recommendation hold across the capability range?

## New catalog variants (`build-catalogs.py`)

| arm | catalog | ~tokens | what it keeps |
|-----|---------|---------|---------------|
| C2 / C3 | trigger-first short/medium (existing) | 7.2k / 11.0k | `Use when <triggers>` tail |
| **C2d / C3d** | domain-first short/medium | 7.9k / 10.8k | capability phrase, token-matched to C2/C3 |
| **C5** | compact | 11.5k | compressed capability head **+** `Use when <trigger>` (stays matcher-valid, #1278) |

Structure-aware extraction, `--validate`-gated (band ceilings; `domain-short ⊆ domain-medium`; `compact` keeps `Use when`). `build-arm-prompt.sh` generalized to accept any built catalog variant; `render-frontier.py` gains a domain-vs-trigger comparison; `conditions.yaml` adds haiku `C2d/C3d/C5` and sonnet/opus `C2d/C5`. Measured tokens confirm the domain variants are budget-matched to their trigger counterparts.

## Runs (bounded scope)

- **Haiku ladder** (C1,C2,C2d,C3,C3d,C5,C4 × 70 tasks × 2 runs, ~980 calls) — running now. Directly tests domain-first vs trigger-first at equal budget.
- **Cross-model** (sonnet+opus on C0,C1,C4,C2d,C5, ~1,400 calls) — deferred until the haiku curve is clean.

## Status

Phase A (code + catalogs) committed and validated; the haiku ladder is running. Findings + cross-model results will land as follow-up commits, and `FINDINGS.md` will be extended with the domain-vs-trigger result and the recommended short form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5qTjZ8EYMrSLAgEdpXop1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5qTjZ8EYMrSLAgEdpXop1)_