### PR TITLE
feat(adapters): harness-agnostic skill-discovery core + eval harness

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -23,7 +23,7 @@ When adding a workflow, pick the existing domain that fits or extend the table b
 | `Release:` | release-please ecosystem — version bumps, changelog, release-PR doc audit, conflict repair |
 | `PR:` | Cross-cutting PR governance — conflict resolution, conventional-commit enforcement |
 | `Auto-fix:` | Autonomous CI failure remediation triggered by `workflow_run` |
-| `Test:` | Repo test suites — skill-local regression tests |
+| `Test:` | Repo test suites — skill-local regression tests, the adapters (skill-discovery core) suite |
 | `Sync:` | Cross-repo artifact sync — regenerate compiled prompts for the extracted agent CLIs and PR them to their standalone repos |
 | _(none)_ | One-off standalones with no obvious domain peer (e.g. `Renovate`) |
 
@@ -52,6 +52,7 @@ Release: release-please
 Renovate
 Sync: git-repo-agent prompts
 Sync: vault-agent prompts
+Test: Adapters
 Test: Skill scripts
 ```
 

--- a/.github/workflows/test-adapters.yml
+++ b/.github/workflows/test-adapters.yml
@@ -64,6 +64,10 @@ jobs:
         run: bun test
 
       - name: Smoke eval (BM25-only, machinery gate)
+        # pipefail so run-eval's own exit code survives the tee — without it
+        # the pipeline's status is tee's and a crash after the report prints
+        # would pass on the grep alone.
         run: |
+          set -o pipefail
           bun eval/run-eval.ts | tee /tmp/adapters-eval.out
           grep -q '^=== GATE === STATUS=PASS$' /tmp/adapters-eval.out

--- a/.github/workflows/test-adapters.yml
+++ b/.github/workflows/test-adapters.yml
@@ -1,0 +1,69 @@
+name: "Test: Adapters"
+
+# Type-checks, lints, and tests the harness-agnostic skill-discovery core +
+# eval harness in adapters/ (ADR-0022, #2089). pi/tiers.yaml is in the paths
+# filter so the #2093 tier-removal PR runs this suite and fails loudly instead
+# of silently orphaning the eval's baseline arm (the eval degrades to
+# BASELINE_ARM=ABSENT + skipped calibration when the file is absent). The
+# weekly cron surfaces corpus drift (skill-description edits, tier moves
+# outside adapters/**) on main with correct attribution rather than on the
+# next unrelated adapters PR.
+#
+# The smoke eval asserts the eval MACHINERY only (=== GATE === STATUS=PASS):
+# retrieval/token metrics are informational in CI, and the cutover thresholds
+# are never gated here (DESIGN §5.3/§5.6).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'adapters/**'
+      - 'pi/tiers.yaml'
+      - '.github/workflows/test-adapters.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'adapters/**'
+      - 'pi/tiers.yaml'
+      - '.github/workflows/test-adapters.yml'
+  schedule:
+    - cron: '23 5 * * 1'  # weekly corpus-drift check on main
+
+concurrency:
+  group: test-adapters-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: adapters
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      # Tag-pinned per repo convention: every existing workflow pins by tag
+      # and Renovate's github-actions manager maintains them.
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type check
+        run: bunx tsc --noEmit
+
+      - name: Lint and format check
+        run: bunx biome ci .
+
+      - name: Run tests
+        run: bun test
+
+      - name: Smoke eval (BM25-only, machinery gate)
+        run: |
+          bun eval/run-eval.ts | tee /tmp/adapters-eval.out
+          grep -q '^=== GATE === STATUS=PASS$' /tmp/adapters-eval.out

--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,10 @@ git-repo-agent/uv.lock
 # Eval results (transient run data)
 **/eval-results/
 
-# Adapters (skill-discovery core, ADR-0022) — deps + per-run eval output.
+# Adapters (skill-discovery core, ADR-0022) — deps + per-run eval output,
+# scoped to adapters/ (currently the repo's only JS package).
 # No dist/ entry is needed: the package is noEmit (no build output exists).
-node_modules/
+adapters/node_modules/
 adapters/eval/results/
 
 # Temporary files

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ git-repo-agent/uv.lock
 # Eval results (transient run data)
 **/eval-results/
 
+# Adapters (skill-discovery core, ADR-0022) — deps + per-run eval output.
+# No dist/ entry is needed: the package is noEmit (no build output exists).
+node_modules/
+adapters/eval/results/
+
 # Temporary files
 tmp/
 

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -1,0 +1,139 @@
+# adapters/ — harness-agnostic skill discovery (ADR-0022)
+
+A plain-TypeScript skill-discovery core over this marketplace's 400+ skills,
+plus the retrieval eval harness that gates the pi/OpenCode cutovers. Foreign
+harnesses (pi, OpenCode) get a `search_skills` pull tool and a per-turn
+top-k push injection instead of an uncapped static listing; delivery is
+always the model **reading the SKILL.md path** — skills are never copied.
+
+Architecture: [`docs/adrs/0022-adapter-over-export-for-foreign-harnesses.md`](../docs/adrs/0022-adapter-over-export-for-foreign-harnesses.md).
+Scope here (#2089): `core/` + `eval/` + tests. The harness bindings are
+**landing in [#2090](https://github.com/laurigates/claude-plugins/issues/2090)
+(pi) and [#2091](https://github.com/laurigates/claude-plugins/issues/2091)
+(OpenCode)** — the consumer wiring below is documented ahead so the shape is
+stable, but the binding files do not exist yet.
+
+## Layout
+
+| Path | What |
+|------|------|
+| `core/` | Indexer (marketplace scan + DIY frontmatter parse + compatibility filter), BM25 (Lucene IDF, k1=1.2, b=0.75), ollama `/api/embed` client (`search_document:`/`search_query:` prefixes, BM25 fallback), RRF fusion (k=60), L2-normalized Float32Array vector index, XDG content-hash embedding cache, shared render templates |
+| `eval/` | `tasks.json` (committed golden task set, k=5), `run-eval.ts` runner, ranker seam (`hybrid \| bm25Only \| embeddingOnly \| random(seed) \| oracle \| nameSubstring \| descriptionSubstring`), baseline derivation (`pi/tiers.yaml` + the export-opencode glob, computed offline), `results/` (gitignored per-run output) |
+| `pi/` | pi binding — **#2090, not yet present** |
+| `opencode/` | OpenCode binding — **#2091, not yet present** |
+| `tests/` | `bun test` suites: frontmatter diff vs `Bun.YAML`, BM25 goldens + committed `rank_bm25` fixture, indexer over the mini-marketplace fixture, cache, fusion, embeddings fallback matrix, eval meta-tests |
+
+There is **no build step**: `tsconfig.json` is `noEmit` and both harnesses
+consume `.ts` source directly (jiti / Bun). This also sidesteps the repo-wide
+`dist/` gitignore trap — no compiled output exists to be silently swallowed.
+
+## Dev commands
+
+```
+cd adapters && bun install        # once per checkout
+bunx tsc --noEmit                 # type gate (bun runs TS but does not check)
+bunx biome ci .                   # lint + format check
+bun test                          # all suites incl. eval meta-tests
+bun eval/run-eval.ts              # BM25-only smoke eval (no network)
+bun eval/run-eval.ts --with-embeddings   # hybrid, needs ollama at localhost:11434
+```
+
+Justfile equivalents (repo root): `just adapters-test`, `just adapters-check`,
+`just eval-adapter`, `just eval-adapter-hybrid`. CI runs the same commands in
+`.github/workflows/test-adapters.yml`.
+
+## Consumer wiring
+
+**Step 1 for both harnesses is always:**
+
+```
+cd <checkout>/claude-plugins/adapters && bun install
+```
+
+This populates `adapters/node_modules`, which serves the OpenCode binding,
+`eval/`, and `tests/`. The pi binding deliberately resolves nothing from it
+at runtime (pi's extension loader aliases `typebox` and pi types to its own
+bundled copies); the install still matters for type-checking and tests.
+
+### pi (landing in #2090)
+
+```jsonc
+// <project>/.pi/settings.json
+{ "extensions": ["/abs/path/to/claude-plugins/adapters/pi/index.ts"] }
+```
+
+- Registers a `search_skills` tool (pull) and injects pins + top-k into the
+  system prompt per turn via `before_agent_start` (push), replacing the
+  native `<available_skills>` listing.
+- Caveat: project-scope extensions load only post-trust; in `-p`/json/rpc
+  modes with `defaultProjectTrust: ask` the extension is silently skipped —
+  prefer global registration (`~/.pi/agent/settings.json`) or `--approve`
+  for headless runs.
+- Config: `~/.pi/agent/skill-discovery.json`, overridden key-by-key by
+  project `.pi/skill-discovery.json` (`repoRoot`, `k`, `endpoint`, `model`,
+  `pins`, `push`). Missing file = all defaults.
+- Run consumers with no natively installed marketplace skills; `--no-skills`
+  is optional (the binding never feeds the native loader).
+
+### OpenCode (landing in #2091)
+
+```jsonc
+// opencode.json
+{
+  "plugin": [["./../claude-plugins/adapters/opencode/index.ts", { "k": 5, "pins": [] }]],
+  "permission": { "skill": "deny" }
+}
+```
+
+- `permission.skill = "deny"` is the primary native-listing suppression: it
+  removes the `<available_skills>` block and the native `skill` tool in one
+  stable config line. (`"tools": { "skill": false }` is a deprecated-surface
+  alias.) Delivery is the model reading the path `search_skills` returns.
+- Push injection rides `experimental.chat.system.transform` and degrades to
+  a silent no-op on versions without the hook — the binding is pull-first.
+
+## Embeddings (soft dependency)
+
+Hybrid ranking needs a local [ollama](https://ollama.com) with
+`nomic-embed-text` pulled (`ollama pull nomic-embed-text`). When the
+endpoint is unreachable, times out, or errors, the index degrades to
+BM25-only for the session — search never hard-fails on the embedding side.
+Embeddings are cached content-addressed under
+`${XDG_CACHE_HOME:-~/.cache}/claude-plugins-adapters/embeddings/` (never
+in-repo).
+
+## Eval harness
+
+`bun eval/run-eval.ts` emits the structured contract (DESIGN §5.3):
+
+```
+=== RETRIEVAL_IN_TIER === HIT_AT_1= HIT_AT_K= MRR= BASELINE_ARM=PRESENT|ABSENT
+=== RETRIEVAL_EXCLUDED_STRATUM === HIT_AT_1= HIT_AT_K= MRR=
+=== NEGATIVES === TOP1_MARGIN_NEG_P50= ... (report-only)
+=== TOKENS === BASELINE_PI_TOKENS= BASELINE_OC_TOKENS_ESTIMATED= ADAPTER_TOKENS=
+=== CUTOVER === STATUS=UNFROZEN|PASS|FAIL   (informational; frozen only by the §5.6 procedure)
+=== GATE === STATUS=PASS|FAIL               (machinery only — the CI assertion)
+```
+
+Retrieval/token metrics are informational in CI; the correctness teeth are
+the meta-tests in `tests/eval-meta.test.ts` (random-fails-every-seed /
+oracle-passes, substring-ranker separation, per-skill token calibration
+111±20%, trigram leakage lint, schema checks). The #2093/#2094 cutover
+thresholds are frozen only by the documented local hybrid-simulation
+procedure, never by CI. `BASELINE_OC_TOKENS_ESTIMATED` is a pi-template
+proxy, uncalibrated — a real OpenCode measurement session is a #2094
+prerequisite.
+
+To regenerate the BM25 reference fixture (only when deliberately taking a
+fresh corpus snapshot): `uv run tests/gen-bm25-reference.py`.
+
+## What this package is not
+
+- Not a marketplace plugin (no `-plugin` suffix, no marketplace entry, no
+  release-please package — `feat(adapters)` commits bump nothing).
+- Not published to npm (`"private": true`); harnesses load the `.ts` source
+  from this checkout.
+- Not a replacement for the still-operational `pi/tiers.yaml` +
+  `scripts/install-pi.sh` and rulesync export pipelines — those stay
+  authoritative until the eval gate passes and #2093/#2094 execute their
+  documented cutover steps.

--- a/adapters/biome.json
+++ b/adapters/biome.json
@@ -1,7 +1,7 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
   "files": {
-    "includes": ["**", "!node_modules", "!eval/results"]
+    "includes": ["**", "!node_modules", "!eval/results", "!tests/fixtures/bm25-reference.json"]
   },
   "formatter": {
     "enabled": true,
@@ -12,7 +12,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "preset": "recommended"
     }
   },
   "assist": {

--- a/adapters/biome.json
+++ b/adapters/biome.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+  "files": {
+    "includes": ["**", "!node_modules", "!eval/results"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/adapters/bun.lock
+++ b/adapters/bun.lock
@@ -1,0 +1,370 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@laurigates/claude-plugins-adapters",
+      "dependencies": {
+        "@opencode-ai/plugin": "^1.18.3",
+        "typebox": "^1.1",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.4.4",
+        "@earendil-works/pi-coding-agent": "^0.80.10",
+        "@types/bun": "^1.3.14",
+        "typescript": "^5.9.3",
+      },
+    },
+  },
+  "packages": {
+    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
+
+    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
+
+    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+
+    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/client-bedrock-runtime": ["@aws-sdk/client-bedrock-runtime@3.1048.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.11", "@aws-sdk/credential-provider-node": "^3.972.42", "@aws-sdk/eventstream-handler-node": "^3.972.16", "@aws-sdk/middleware-eventstream": "^3.972.12", "@aws-sdk/middleware-websocket": "^3.972.19", "@aws-sdk/token-providers": "3.1048.0", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/fetch-http-handler": "^5.4.2", "@smithy/node-http-handler": "^4.7.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.975.3", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@aws-sdk/xml-builder": "^3.972.36", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.29.4", "@smithy/signature-v4": "^5.6.5", "@smithy/types": "^4.16.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.59", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.61", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/fetch-http-handler": "^5.6.6", "@smithy/node-http-handler": "^4.9.6", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.973.4", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/credential-provider-env": "^3.972.59", "@aws-sdk/credential-provider-http": "^3.972.61", "@aws-sdk/credential-provider-login": "^3.972.66", "@aws-sdk/credential-provider-process": "^3.972.59", "@aws-sdk/credential-provider-sso": "^3.973.3", "@aws-sdk/credential-provider-web-identity": "^3.972.65", "@aws-sdk/nested-clients": "^3.997.33", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/credential-provider-imds": "^4.4.9", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.66", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/nested-clients": "^3.997.33", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-g2fsqm87r/nKthLZ0VkkDBElkGg0PvSa8d97HQ6EilMbJTZ6hxa8FxkSZyJfgPfFdZn0TTmkOffQmTSUcAHIng=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.70", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.59", "@aws-sdk/credential-provider-http": "^3.972.61", "@aws-sdk/credential-provider-ini": "^3.973.4", "@aws-sdk/credential-provider-process": "^3.972.59", "@aws-sdk/credential-provider-sso": "^3.973.3", "@aws-sdk/credential-provider-web-identity": "^3.972.65", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/credential-provider-imds": "^4.4.9", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.59", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.973.3", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/nested-clients": "^3.997.33", "@aws-sdk/token-providers": "3.1088.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.65", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/nested-clients": "^3.997.33", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ=="],
+
+    "@aws-sdk/eventstream-handler-node": ["@aws-sdk/eventstream-handler-node@3.972.29", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-t3tKQRTVXsI2QNPE3CaNjHl0wRO9Xi3acZkAyti2RQsiFmZ9Gi0kArX2ighlRJ1BtDVuul413gThAgzyTfgmWA=="],
+
+    "@aws-sdk/middleware-eventstream": ["@aws-sdk/middleware-eventstream@3.972.24", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-oykin4mDWxNOuYQ7SF1cHzgYeuFEkF4cdRwgvjFFbIklkx09qIFBiOgsORafG9sXZFO3TayMmQuAQYgADXhI8w=="],
+
+    "@aws-sdk/middleware-websocket": ["@aws-sdk/middleware-websocket@3.972.41", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/fetch-http-handler": "^5.6.6", "@smithy/signature-v4": "^5.6.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-LSbGvvYmjc4Br9BPYI2dTLnIclmrSiQbahkP4D6nRGVEv4qsCZ8csVuKBPVEEFCVD+EEngGh8ROls6XpumtwMg=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.33", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/signature-v4-multi-region": "^3.996.41", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/fetch-http-handler": "^5.6.6", "@smithy/node-http-handler": "^4.9.6", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.41", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/signature-v4": "^5.6.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1048.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.11", "@aws-sdk/nested-clients": "^3.997.9", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.8", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.36", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.3.0", "", {}, "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@biomejs/biome": ["@biomejs/biome@2.5.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.4", "@biomejs/cli-darwin-x64": "2.5.4", "@biomejs/cli-linux-arm64": "2.5.4", "@biomejs/cli-linux-arm64-musl": "2.5.4", "@biomejs/cli-linux-x64": "2.5.4", "@biomejs/cli-linux-x64-musl": "2.5.4", "@biomejs/cli-win32-arm64": "2.5.4", "@biomejs/cli-win32-x64": "2.5.4" }, "bin": { "biome": "bin/biome" } }, "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
+
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.80.10", "", { "dependencies": { "@earendil-works/pi-ai": "^0.80.10", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-nwnOR3SuLYGRFfyQm8ri4Nj5VGVAvAM9GuqQd3u7BUQj0d6hmD2F8w7OHAAjThE3CuySIdM+v8E22QJG6/RfCg=="],
+
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.10", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-Moe/H8c87yacDGK9dPbWphZNjVsrb3nTrIHycOQJAkFEnY9PYxOOd74+ny44kATfPU9Dm7aTHefar3pZF+UKUA=="],
+
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.80.10", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.80.10", "@earendil-works/pi-ai": "^0.80.10", "@earendil-works/pi-tui": "^0.80.10", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-aL4apbupCHiVLSXASXvRzH4Q2vmtfrDa+0s909CJuVu/GgGylbDzr7oyF1mPmip5E+VxYYxKWmph4hV04wUcQg=="],
+
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.80.10", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-c2JO29PbhKPEQ6fgHQKAl0WhwuFqzWfzspMmP+8B5tpDuP+0mvarRbKKg8gq4b+pQx/QX+6aVS4ko7deoyjQjg=="],
+
+    "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
+
+    "@mariozechner/clipboard": ["@mariozechner/clipboard@0.3.9", "", { "optionalDependencies": { "@mariozechner/clipboard-darwin-arm64": "0.3.9", "@mariozechner/clipboard-darwin-universal": "0.3.9", "@mariozechner/clipboard-darwin-x64": "0.3.9", "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9", "@mariozechner/clipboard-linux-arm64-musl": "0.3.9", "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-musl": "0.3.9", "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9", "@mariozechner/clipboard-win32-x64-msvc": "0.3.9" } }, "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA=="],
+
+    "@mariozechner/clipboard-darwin-arm64": ["@mariozechner/clipboard-darwin-arm64@0.3.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ=="],
+
+    "@mariozechner/clipboard-darwin-universal": ["@mariozechner/clipboard-darwin-universal@0.3.9", "", { "os": "darwin" }, "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ=="],
+
+    "@mariozechner/clipboard-darwin-x64": ["@mariozechner/clipboard-darwin-x64@0.3.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg=="],
+
+    "@mariozechner/clipboard-linux-arm64-gnu": ["@mariozechner/clipboard-linux-arm64-gnu@0.3.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw=="],
+
+    "@mariozechner/clipboard-linux-arm64-musl": ["@mariozechner/clipboard-linux-arm64-musl@0.3.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ=="],
+
+    "@mariozechner/clipboard-linux-riscv64-gnu": ["@mariozechner/clipboard-linux-riscv64-gnu@0.3.9", "", { "os": "linux", "cpu": "none" }, "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw=="],
+
+    "@mariozechner/clipboard-linux-x64-gnu": ["@mariozechner/clipboard-linux-x64-gnu@0.3.9", "", { "os": "linux", "cpu": "x64" }, "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw=="],
+
+    "@mariozechner/clipboard-linux-x64-musl": ["@mariozechner/clipboard-linux-x64-musl@0.3.9", "", { "os": "linux", "cpu": "x64" }, "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ=="],
+
+    "@mariozechner/clipboard-win32-arm64-msvc": ["@mariozechner/clipboard-win32-arm64-msvc@0.3.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ=="],
+
+    "@mariozechner/clipboard-win32-x64-msvc": ["@mariozechner/clipboard-win32-x64-msvc@0.3.9", "", { "os": "win32", "cpu": "x64" }, "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA=="],
+
+    "@mistralai/mistralai": ["@mistralai/mistralai@2.2.6", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.40.0", "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4", "", { "os": "linux", "cpu": "arm" }, "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
+
+    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.18.3", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@opencode-ai/sdk": "1.18.3", "effect": "4.0.0-beta.83", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.4.3", "@opentui/keymap": ">=0.4.3", "@opentui/solid": ">=0.4.3" }, "optionalPeers": ["@opentui/core", "@opentui/keymap", "@opentui/solid"] }, "sha512-hAm/hZkSCsMSNHVy9DKmFtZAve/qYoIWpduNPcvXnnKK7NMlJEOQitA6CQC67Ym5DFKypDW1TC9YO6S1WdGtpg=="],
+
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.18.3", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-Mevo4e6kQwbvto9E+42KSIVMhp+JBu+SwQhC5AomAvrV6Xkio3U249T+xDILDCXhl5Z/Hi/DlAuVLzpGnuh0gg=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.1", "", {}, "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.2", "", {}, "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug=="],
+
+    "@silvia-odwyer/photon-node": ["@silvia-odwyer/photon-node@0.3.4", "", {}, "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA=="],
+
+    "@smithy/core": ["@smithy/core@3.29.5", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.4.10", "", { "dependencies": { "@smithy/core": "^3.29.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-MJenAe4OKRZUo1LdYYFDCsSHxaHvInIU/z52GsheO9vl1/VSySVCr0zkyKD6TFiGkSUaWGxvKZ/70OvgUZR5HQ=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.6.7", "", { "dependencies": { "@smithy/core": "^3.29.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3zpg8yqqyXzoK2TsRDdkqVOj2RDBFfLXwCczOZ5c7TWB4eiaebfSCsbMjDPYB3PJ9ihV62QaeadZ+wLadZtNGA=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.3", "", { "dependencies": { "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.6.6", "", { "dependencies": { "@smithy/core": "^3.29.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-efP6DN3UTFrzIsGO42/xcabv8jU7+9nwEdphFUH7yL0k010ERyAWaO41KFQIDLcFZLZ8xzIQr4wplFxNzslSGQ=="],
+
+    "@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
+
+    "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
+
+    "effect": ["effect@4.0.0-beta.83", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.8.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.1", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^14.0.0", "yaml": "^2.9.0" } }, "sha512-0wsak8RtgGAr9UWSbVDgJHZcUqMSvicHcvaZv1MbMM7MCGgW4Rn/137J1MHQbwYPcwYGxT/IqehFd+UbYuj78w=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
+
+    "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
+    "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
+
+    "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
+
+    "gaxios": ["gaxios@7.2.0", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg=="],
+
+    "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
+
+    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
+
+    "google-auth-library": ["google-auth-library@10.9.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg=="],
+
+    "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
+
+    "hosted-git-info": ["hosted-git-info@9.0.3", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "ini": ["ini@7.0.0", "", {}, "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
+    "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
+
+    "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
+
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
+    "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
+
+    "marked": ["marked@18.0.5", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w=="],
+
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "msgpackr": ["msgpackr@2.0.4", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA=="],
+
+    "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
+
+    "multipasta": ["multipasta@0.2.8", "", {}, "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q=="],
+
+    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
+
+    "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
+
+    "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
+
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
+    "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
+
+    "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
+
+    "protobufjs": ["protobufjs@7.6.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw=="],
+
+    "pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
+
+    "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "toml": ["toml@4.3.0", "", {}, "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typebox": ["typebox@1.3.6", "", {}, "sha512-Sc8RA0NCMEFmApHNU9ZMzqcpQj46She44J8ffpLM/bdhLNUZKq7DJumcLcsFx1gRmDfQPgCgOmFFJ7rcnfWNyA=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
+
+    "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@aws-sdk/credential-provider-http/@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.7", "", { "dependencies": { "@smithy/core": "^3.29.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-wCU8HCLjAtAVqxxe0j2xff9LcEPw3yjBbg5IdQDIYFnxnPxbxcSLc7rgex7kqm9L/WYOnJEgaWQlfDkZleozMA=="],
+
+    "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1088.0", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/nested-clients": "^3.997.33", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw=="],
+
+    "@aws-sdk/nested-clients/@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.7", "", { "dependencies": { "@smithy/core": "^3.29.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-wCU8HCLjAtAVqxxe0j2xff9LcEPw3yjBbg5IdQDIYFnxnPxbxcSLc7rgex7kqm9L/WYOnJEgaWQlfDkZleozMA=="],
+
+    "@earendil-works/pi-agent-core/typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
+
+    "@earendil-works/pi-ai/typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
+
+    "@earendil-works/pi-coding-agent/typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
+
+    "p-retry/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+  }
+}

--- a/adapters/bun.lock
+++ b/adapters/bun.lock
@@ -6,7 +6,7 @@
       "name": "@laurigates/claude-plugins-adapters",
       "dependencies": {
         "@opencode-ai/plugin": "^1.18.3",
-        "typebox": "^1.1",
+        "typebox": "~1.1.38",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.4",
@@ -331,7 +331,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "typebox": ["typebox@1.3.6", "", {}, "sha512-Sc8RA0NCMEFmApHNU9ZMzqcpQj46She44J8ffpLM/bdhLNUZKq7DJumcLcsFx1gRmDfQPgCgOmFFJ7rcnfWNyA=="],
+    "typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -358,12 +358,6 @@
     "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1088.0", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/nested-clients": "^3.997.33", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw=="],
 
     "@aws-sdk/nested-clients/@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.7", "", { "dependencies": { "@smithy/core": "^3.29.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-wCU8HCLjAtAVqxxe0j2xff9LcEPw3yjBbg5IdQDIYFnxnPxbxcSLc7rgex7kqm9L/WYOnJEgaWQlfDkZleozMA=="],
-
-    "@earendil-works/pi-agent-core/typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
-
-    "@earendil-works/pi-ai/typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
-
-    "@earendil-works/pi-coding-agent/typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
 
     "p-retry/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
   }

--- a/adapters/core/bm25.ts
+++ b/adapters/core/bm25.ts
@@ -1,0 +1,117 @@
+/**
+ * DIY BM25 (DESIGN §2.4; retrieval-design-inputs §2).
+ *
+ * - Tokenizer: lowercase, split /[^a-z0-9]+/, drop empties. Hyphenated and
+ *   namespaced names decompose ("git-commit" → "git", "commit"). No stemming
+ *   (corpus of ~400 short docs).
+ * - Score: Σ_t idf(t) · (tf·(k1+1)) / (tf + k1·(1 − b + b·|d|/avgdl)) with
+ *   k1 = 1.2, b = 0.75 (Robertson & Zaragoza 2009 defaults).
+ * - IDF: Lucene-style ln(1 + (N − df + 0.5)/(df + 0.5)) — non-negative,
+ *   avoiding the classic-Okapi pathology on terms in more than half the
+ *   corpus ("use" appears in nearly every description).
+ */
+
+export const BM25_K1 = 1.2;
+export const BM25_B = 0.75;
+
+export function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length > 0);
+}
+
+export interface Bm25Scored {
+  /** Index of the document in the corpus passed to the constructor. */
+  docIdx: number;
+  score: number;
+}
+
+/**
+ * The shipped IDF is "lucene" (always). "classic-rank-bm25" replicates
+ * rank_bm25.BM25Okapi's epsilon-floored classic IDF and exists solely as the
+ * diff-test seam (tests/bm25.test.ts): scoring with the reference's own IDF
+ * is the only way to assert exact rank equality against it, because the two
+ * IDF curves legitimately reorder close-scored multi-term documents.
+ */
+export type IdfVariant = "lucene" | "classic-rank-bm25";
+
+const RANK_BM25_EPSILON = 0.25;
+
+export class Bm25Index {
+  private readonly postings = new Map<string, Map<number, number>>();
+  private readonly docLengths: number[] = [];
+  private readonly avgdl: number;
+  private readonly n: number;
+  private readonly idfVariant: IdfVariant;
+  /** classic-rank-bm25 only: eps floor = RANK_BM25_EPSILON × mean raw IDF. */
+  private readonly classicEps: number;
+
+  constructor(docs: string[], idfVariant: IdfVariant = "lucene") {
+    this.idfVariant = idfVariant;
+    this.n = docs.length;
+    let totalLen = 0;
+    docs.forEach((doc, docIdx) => {
+      const tokens = tokenize(doc);
+      this.docLengths.push(tokens.length);
+      totalLen += tokens.length;
+      for (const token of tokens) {
+        let perDoc = this.postings.get(token);
+        if (!perDoc) {
+          perDoc = new Map<number, number>();
+          this.postings.set(token, perDoc);
+        }
+        perDoc.set(docIdx, (perDoc.get(docIdx) ?? 0) + 1);
+      }
+    });
+    this.avgdl = this.n > 0 ? totalLen / this.n : 0;
+
+    let classicEps = 0;
+    if (idfVariant === "classic-rank-bm25" && this.postings.size > 0) {
+      let idfSum = 0;
+      for (const perDoc of this.postings.values()) {
+        const df = perDoc.size;
+        idfSum += Math.log(this.n - df + 0.5) - Math.log(df + 0.5);
+      }
+      classicEps = RANK_BM25_EPSILON * (idfSum / this.postings.size);
+    }
+    this.classicEps = classicEps;
+  }
+
+  /** Lucene-style non-negative IDF (shipped), or the classic diff-test seam. */
+  idf(term: string): number {
+    const df = this.postings.get(term)?.size ?? 0;
+    if (this.idfVariant === "classic-rank-bm25") {
+      if (df === 0) return 0;
+      const raw = Math.log(this.n - df + 0.5) - Math.log(df + 0.5);
+      return raw < 0 ? this.classicEps : raw;
+    }
+    return Math.log(1 + (this.n - df + 0.5) / (df + 0.5));
+  }
+
+  /**
+   * Score every document with a non-zero score against the query, sorted by
+   * descending score (ties broken by ascending docIdx for determinism).
+   * Query terms are accumulated as given — duplicates count twice, matching
+   * the rank_bm25 reference the diff test compares against.
+   */
+  score(query: string): Bm25Scored[] {
+    const queryTokens = tokenize(query);
+    if (queryTokens.length === 0) return [];
+    const acc = new Map<number, number>();
+    for (const token of queryTokens) {
+      const perDoc = this.postings.get(token);
+      if (!perDoc) continue;
+      const idf = this.idf(token);
+      for (const [docIdx, tf] of perDoc) {
+        const dl = this.docLengths[docIdx] ?? 0;
+        const norm = tf + BM25_K1 * (1 - BM25_B + (BM25_B * dl) / this.avgdl);
+        const contribution = (idf * (tf * (BM25_K1 + 1))) / norm;
+        acc.set(docIdx, (acc.get(docIdx) ?? 0) + contribution);
+      }
+    }
+    return [...acc.entries()]
+      .map(([docIdx, score]) => ({ docIdx, score }))
+      .sort((a, b) => b.score - a.score || a.docIdx - b.docIdx);
+  }
+}

--- a/adapters/core/cache.ts
+++ b/adapters/core/cache.ts
@@ -1,0 +1,95 @@
+/**
+ * XDG content-hash embedding cache (DESIGN §2.7; retrieval-design-inputs §5).
+ *
+ * - Entry key: sha256(CACHE_SCHEMA_VERSION \0 modelId \0 dims \0 prefixScheme
+ *   \0 skillName \0 description) — content-addressed; edits, renames, model
+ *   swaps, dimension changes, and prefix-scheme changes all auto-invalidate
+ *   with no mtime logic.
+ * - File: ${XDG_CACHE_HOME:-~/.cache}/claude-plugins-adapters/embeddings/
+ *   <sha256(absRepoRoot).slice(0,16)>.json — XDG, never in-repo (in-repo
+ *   caches dirty `git clean -x`, multiply per-worktree, and trip
+ *   coworker-detection). Per-repo-path filename isolates checkouts.
+ * - Write: atomic (.tmp + rename); each build rewrites with only-current
+ *   entries (self-pruning, no LRU bookkeeping).
+ */
+
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+export const CACHE_SCHEMA_VERSION = "1";
+
+export interface CacheFile {
+  version: number;
+  model: string;
+  dims: number;
+  entries: Record<string, number[]>;
+}
+
+export interface CacheKeyInput {
+  model: string;
+  dims: number;
+  prefixScheme: string;
+  skillName: string;
+  description: string;
+}
+
+export function entryKey(input: CacheKeyInput): string {
+  const material = [
+    CACHE_SCHEMA_VERSION,
+    input.model,
+    String(input.dims),
+    input.prefixScheme,
+    input.skillName,
+    input.description,
+  ].join("\0");
+  return createHash("sha256").update(material, "utf8").digest("hex");
+}
+
+export function defaultCacheDir(): string {
+  const xdg = process.env.XDG_CACHE_HOME;
+  const base = xdg && xdg.length > 0 ? xdg : join(homedir(), ".cache");
+  return join(base, "claude-plugins-adapters", "embeddings");
+}
+
+export function cacheFilePath(repoRoot: string, cacheDir?: string): string {
+  const dir = cacheDir ?? defaultCacheDir();
+  const repoHash = createHash("sha256")
+    .update(resolve(repoRoot), "utf8")
+    .digest("hex")
+    .slice(0, 16);
+  return join(dir, `${repoHash}.json`);
+}
+
+/** Corrupt or missing cache files are treated as empty (rebuild, no crash). */
+export function loadCache(filePath: string): CacheFile | null {
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, "utf8");
+  } catch {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as CacheFile;
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      typeof parsed.entries !== "object" ||
+      parsed.entries === null
+    ) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/** Atomic write: serialize to <file>.tmp, then rename over the target. */
+export function saveCache(filePath: string, cache: CacheFile): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.tmp`;
+  writeFileSync(tmpPath, JSON.stringify(cache), "utf8");
+  renameSync(tmpPath, filePath);
+}

--- a/adapters/core/embeddings.ts
+++ b/adapters/core/embeddings.ts
@@ -1,0 +1,163 @@
+/**
+ * Ollama /api/embed client (DESIGN §2.5; retrieval-design-inputs §1).
+ *
+ * - POST {endpoint}/api/embed with {"model", "input": string[]} — batch is
+ *   native; response `embeddings: number[][]` in input order (always
+ *   array-of-arrays). Never the legacy /api/embeddings (superseded).
+ * - Task prefixes are mandatory for nomic-embed-text: corpus texts embed as
+ *   `search_document: <text>`, queries as `search_query: <text>`. The prefix
+ *   scheme string is part of the cache key so a prefix change invalidates.
+ * - Fallback contract: fetch rejection (ECONNREFUSED etc.), non-2xx status,
+ *   JSON `error` body (e.g. model not pulled), or AbortSignal.timeout expiry
+ *   all signal "embeddings unavailable" — the index degrades to BM25-only.
+ */
+
+export const DEFAULT_ENDPOINT = "http://localhost:11434";
+export const DEFAULT_MODEL = "nomic-embed-text";
+export const DEFAULT_DIMENSIONS = 768;
+
+/** Recorded in the cache key; changing prefixes invalidates cached vectors. */
+export const PREFIX_SCHEME = "search_document:/search_query:";
+export const DOCUMENT_PREFIX = "search_document: ";
+export const QUERY_PREFIX = "search_query: ";
+
+/** 3 s on the initial probe (embed one short string at build). */
+export const PROBE_TIMEOUT_MS = 3_000;
+/** 30 s on the batch call. */
+export const BATCH_TIMEOUT_MS = 30_000;
+
+export interface EmbedOptions {
+  endpoint: string;
+  model: string;
+  dimensions?: number;
+}
+
+/** Thrown on any unavailability condition; callers degrade to BM25-only. */
+export class EmbedUnavailableError extends Error {
+  constructor(reason: string, cause?: unknown) {
+    super(`embedding endpoint unavailable: ${reason}`);
+    this.name = "EmbedUnavailableError";
+    this.cause = cause;
+  }
+}
+
+/**
+ * Embed a batch of already-prefixed inputs. Throws EmbedUnavailableError on
+ * every failure mode in the fallback contract; never returns partial output.
+ */
+export async function embedBatch(
+  inputs: string[],
+  opts: EmbedOptions,
+  timeoutMs: number = BATCH_TIMEOUT_MS,
+): Promise<number[][]> {
+  if (inputs.length === 0) return [];
+  const body: Record<string, unknown> = { model: opts.model, input: inputs };
+  if (opts.dimensions !== undefined) body.dimensions = opts.dimensions;
+
+  let response: Response;
+  try {
+    response = await fetch(new URL("/api/embed", opts.endpoint), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (err) {
+    throw new EmbedUnavailableError("fetch rejected (endpoint down or timeout)", err);
+  }
+  if (!response.ok) {
+    throw new EmbedUnavailableError(`non-2xx status ${response.status}`);
+  }
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (err) {
+    throw new EmbedUnavailableError("non-JSON response body", err);
+  }
+  if (typeof payload === "object" && payload !== null && "error" in payload) {
+    throw new EmbedUnavailableError(`error body: ${String((payload as { error: unknown }).error)}`);
+  }
+  const embeddings = (payload as { embeddings?: unknown }).embeddings;
+  if (
+    !Array.isArray(embeddings) ||
+    embeddings.length !== inputs.length ||
+    !embeddings.every((row) => Array.isArray(row))
+  ) {
+    throw new EmbedUnavailableError("malformed embeddings payload");
+  }
+  return embeddings as number[][];
+}
+
+/** Embed corpus texts with the mandatory search_document prefix. */
+export function embedDocuments(
+  texts: string[],
+  opts: EmbedOptions,
+  timeoutMs: number = BATCH_TIMEOUT_MS,
+): Promise<number[][]> {
+  return embedBatch(
+    texts.map((t) => `${DOCUMENT_PREFIX}${t}`),
+    opts,
+    timeoutMs,
+  );
+}
+
+/** Embed a query with the mandatory search_query prefix. */
+export async function embedQuery(
+  query: string,
+  opts: EmbedOptions,
+  timeoutMs: number = BATCH_TIMEOUT_MS,
+): Promise<number[]> {
+  const rows = await embedBatch([`${QUERY_PREFIX}${query}`], opts, timeoutMs);
+  const row = rows[0];
+  if (!row) throw new EmbedUnavailableError("empty embeddings payload");
+  return row;
+}
+
+/**
+ * Build-time availability probe: embeds one short string with a short
+ * timeout. Returns true when the endpoint answered correctly.
+ */
+export async function probeEndpoint(opts: EmbedOptions): Promise<boolean> {
+  try {
+    await embedBatch([`${DOCUMENT_PREFIX}probe`], opts, PROBE_TIMEOUT_MS);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** L2-normalize rows into one flat Float32Array (cosine = dot product). */
+export function toNormalizedMatrix(rows: number[][], dims: number): Float32Array {
+  const matrix = new Float32Array(rows.length * dims);
+  rows.forEach((row, i) => {
+    let normSq = 0;
+    for (const v of row) normSq += v * v;
+    const inv = normSq > 0 ? 1 / Math.sqrt(normSq) : 0;
+    for (let j = 0; j < dims; j++) {
+      matrix[i * dims + j] = (row[j] ?? 0) * inv;
+    }
+  });
+  return matrix;
+}
+
+/** Dot product of a normalized query vector against row i of the matrix. */
+export function dotRow(matrix: Float32Array, dims: number, i: number, query: Float32Array): number {
+  let sum = 0;
+  const base = i * dims;
+  for (let j = 0; j < dims; j++) {
+    sum += (matrix[base + j] ?? 0) * (query[j] ?? 0);
+  }
+  return sum;
+}
+
+/** L2-normalize a single vector into a Float32Array. */
+export function normalizeVector(row: number[]): Float32Array {
+  let normSq = 0;
+  for (const v of row) normSq += v * v;
+  const inv = normSq > 0 ? 1 / Math.sqrt(normSq) : 0;
+  const out = new Float32Array(row.length);
+  row.forEach((v, i) => {
+    out[i] = v * inv;
+  });
+  return out;
+}

--- a/adapters/core/embeddings.ts
+++ b/adapters/core/embeddings.ts
@@ -16,10 +16,13 @@ export const DEFAULT_ENDPOINT = "http://localhost:11434";
 export const DEFAULT_MODEL = "nomic-embed-text";
 export const DEFAULT_DIMENSIONS = 768;
 
-/** Recorded in the cache key; changing prefixes invalidates cached vectors. */
-export const PREFIX_SCHEME = "search_document:/search_query:";
 export const DOCUMENT_PREFIX = "search_document: ";
 export const QUERY_PREFIX = "search_query: ";
+/**
+ * Recorded in the cache key; derived from the actual prefixes so any prefix
+ * edit auto-invalidates cached vectors (one source of truth).
+ */
+export const PREFIX_SCHEME = `${DOCUMENT_PREFIX}/${QUERY_PREFIX}`;
 
 /** 3 s on the initial probe (embed one short string at build). */
 export const PROBE_TIMEOUT_MS = 3_000;
@@ -85,7 +88,20 @@ export async function embedBatch(
   ) {
     throw new EmbedUnavailableError("malformed embeddings payload");
   }
-  return embeddings as number[][];
+  const rows = embeddings as number[][];
+  // Width guard: an endpoint that ignores the Matryoshka `dimensions` knob
+  // (older Ollama) would otherwise feed mismatched vectors into a truncating
+  // matrix build — degrade to BM25-only instead of computing wrong cosines.
+  const width = (rows[0] as number[]).length;
+  if (!rows.every((row) => row.length === width)) {
+    throw new EmbedUnavailableError("non-uniform embedding widths in batch");
+  }
+  if (opts.dimensions !== undefined && width !== opts.dimensions) {
+    throw new EmbedUnavailableError(
+      `embedding width ${width} != requested dimensions ${opts.dimensions}`,
+    );
+  }
+  return rows;
 }
 
 /** Embed corpus texts with the mandatory search_document prefix. */

--- a/adapters/core/frontmatter.ts
+++ b/adapters/core/frontmatter.ts
@@ -1,0 +1,92 @@
+/**
+ * DIY minimal frontmatter parser (DESIGN §2.2) — no YAML dependency.
+ *
+ * The core consumes exactly three top-level scalar string fields (`name`,
+ * `description`, `compatibility`) out of frontmatter whose observed shape is
+ * flat `key: value` scalars across all 406 SKILL.md files. Both target
+ * harnesses treat unknown fields as ignorable and read only scalars, so this
+ * parser matches the actual consumer semantics. Verified by a diff test
+ * against Bun.YAML.parse over every real SKILL.md (tests/frontmatter.test.ts).
+ */
+
+const FIELD_RE = /^([A-Za-z][A-Za-z0-9_-]*):\s*(.*)$/;
+const FOLD_MARKERS = new Set([">", ">-", "|", "|-"]);
+
+/**
+ * Return the raw frontmatter text between the leading `---` fence and the
+ * closing `---` fence, or null when the document has no frontmatter.
+ */
+export function extractFrontmatterBlock(text: string): string | null {
+  const lines = text.split("\n");
+  if (lines.length === 0 || (lines[0] ?? "").trim() !== "---") return null;
+  const body: string[] = [];
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    if (line.trim() === "---") return body.join("\n");
+    body.push(line);
+  }
+  // Unclosed fence: no frontmatter.
+  return null;
+}
+
+/**
+ * Parse the scalar top-level fields out of a document's frontmatter.
+ * Returns null when the document has no frontmatter fence. Per-field
+ * fail-safe: unparseable values are treated as absent (never thrown).
+ *
+ * Value handling:
+ * - one level of matching single/double quotes is stripped;
+ * - a bare `>`/`>-`/`|`/`|-` value consumes the following more-indented
+ *   lines joined with spaces (folded) — defensive, since a future skill may
+ *   fold its description;
+ * - lists and nested maps are skipped (no consumed field uses them).
+ */
+export function parseFrontmatter(text: string): Record<string, string> | null {
+  const block = extractFrontmatterBlock(text);
+  if (block === null) return null;
+
+  const fields: Record<string, string> = {};
+  let foldKey: string | null = null;
+  let foldLines: string[] = [];
+
+  const flushFold = () => {
+    if (foldKey !== null) {
+      fields[foldKey] = foldLines.join(" ").trim();
+      foldKey = null;
+      foldLines = [];
+    }
+  };
+
+  for (const line of block.split("\n")) {
+    const m = FIELD_RE.exec(line);
+    if (m) {
+      flushFold();
+      const key = m[1] as string;
+      let value = (m[2] as string).trim();
+      if (FOLD_MARKERS.has(value)) {
+        foldKey = key;
+        foldLines = [];
+        continue;
+      }
+      if (value.length >= 2 && value[0] === '"' && value[value.length - 1] === '"') {
+        // Double-quoted style: strip the quotes and resolve the two escape
+        // sequences observed in the corpus (\" and \\). Verified against
+        // Bun.YAML by the whole-corpus diff test.
+        value = value.slice(1, -1).replace(/\\(["\\])/g, "$1");
+      } else if (value.length >= 2 && value[0] === "'" && value[value.length - 1] === "'") {
+        // Single-quoted style: strip the quotes; '' is the escaped quote.
+        value = value.slice(1, -1).replace(/''/g, "'");
+      }
+      fields[key] = value;
+      continue;
+    }
+    if (foldKey !== null && (line.startsWith(" ") || line.startsWith("\t"))) {
+      foldLines.push(line.trim());
+      continue;
+    }
+    // Continuation of a list / nested map / blank line — not a consumed shape.
+    flushFold();
+  }
+  flushFold();
+  return fields;
+}

--- a/adapters/core/fusion.ts
+++ b/adapters/core/fusion.ts
@@ -1,0 +1,31 @@
+/**
+ * Reciprocal Rank Fusion (DESIGN §2.6; Cormack, Clarke & Büttcher, SIGIR 2009).
+ *
+ * RRFscore(d) = Σ_{r ∈ rankers} 1/(k + rank_r(d)), ranks 1-based, documents
+ * absent from a ranker's list contribute 0. k = 60 is the canonical constant.
+ * Only the top-FUSE_DEPTH entries of each list participate. RRF is rank-only,
+ * which is exactly why it fuses BM25 (unbounded scores) with cosine ([-1,1])
+ * without normalization gymnastics.
+ */
+
+export const RRF_K = 60;
+export const FUSE_DEPTH = 50;
+
+export interface RankedItem {
+  id: string;
+  score: number;
+}
+
+export function rrfFuse(lists: RankedItem[][], fuseDepth: number = FUSE_DEPTH): RankedItem[] {
+  const fused = new Map<string, number>();
+  for (const list of lists) {
+    const top = list.slice(0, fuseDepth);
+    top.forEach((item, i) => {
+      const rank = i + 1; // 1-based
+      fused.set(item.id, (fused.get(item.id) ?? 0) + 1 / (RRF_K + rank));
+    });
+  }
+  return [...fused.entries()]
+    .map(([id, score]) => ({ id, score }))
+    .sort((a, b) => b.score - a.score || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+}

--- a/adapters/core/index.ts
+++ b/adapters/core/index.ts
@@ -1,0 +1,48 @@
+/**
+ * Public surface of the skill-discovery core (DESIGN §2.1).
+ */
+
+export { BM25_B, BM25_K1, Bm25Index, tokenize } from "./bm25.ts";
+export {
+  CACHE_SCHEMA_VERSION,
+  cacheFilePath,
+  defaultCacheDir,
+  entryKey,
+  loadCache,
+  saveCache,
+} from "./cache.ts";
+export {
+  DEFAULT_DIMENSIONS,
+  DEFAULT_ENDPOINT,
+  DEFAULT_MODEL,
+  DOCUMENT_PREFIX,
+  EmbedUnavailableError,
+  embedBatch,
+  embedDocuments,
+  embedQuery,
+  PREFIX_SCHEME,
+  probeEndpoint,
+  QUERY_PREFIX,
+} from "./embeddings.ts";
+export { extractFrontmatterBlock, parseFrontmatter } from "./frontmatter.ts";
+export { FUSE_DEPTH, RRF_K, rrfFuse } from "./fusion.ts";
+export { documentText, scanSkills } from "./indexer.ts";
+export {
+  AVAILABLE_SKILLS_CLOSE,
+  AVAILABLE_SKILLS_OPEN,
+  estimateTokens,
+  INJECTED_BLOCK_TRAILER,
+  renderInjectedBlock,
+  renderSkillEntry,
+  renderToolResult,
+  SEARCH_SKILLS_TOOL_DESCRIPTION,
+} from "./render.ts";
+export { buildIndex, SkillIndex } from "./search.ts";
+export type {
+  IndexOptions,
+  Ranker,
+  SearchFilters,
+  SearchResult,
+  SkillEntry,
+} from "./types.ts";
+export { DEFAULT_K } from "./types.ts";

--- a/adapters/core/indexer.ts
+++ b/adapters/core/indexer.ts
@@ -1,0 +1,109 @@
+/**
+ * Marketplace scanner (DESIGN §2.3).
+ *
+ * Marketplace-first, not a bare repo glob: `.claude-plugin/marketplace.json`
+ * is the discovery root, so a stray non-plugin skills dir cannot leak in.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseFrontmatter } from "./frontmatter.ts";
+import type { SkillEntry } from "./types.ts";
+
+interface MarketplacePlugin {
+  name: string;
+  source: string;
+  description: string;
+  version: string;
+  keywords: string[];
+  category: string;
+}
+
+interface Marketplace {
+  plugins: MarketplacePlugin[];
+}
+
+export interface ScanResult {
+  entries: SkillEntry[];
+  warnings: string[];
+}
+
+/**
+ * Scan the marketplace checkout into SkillEntry[].
+ *
+ * - `name` falls back to the skill directory basename (both harnesses' own
+ *   fallback/keying rule).
+ * - Entries with an absent/empty `description` are dropped with a warning
+ *   (mirrors pi, which silently drops description-less skills, and OpenCode,
+ *   which delists them).
+ * - Compatibility filter: when target === "foreign" (default), drop entries
+ *   whose `compatibility` contains "claude-code". Substring match, not
+ *   equality — the observed corpus is uniformly the bare string, but a future
+ *   list syntax must not silently defeat the filter. Neither harness enforces
+ *   the field itself, so the core is the only place this judgment executes.
+ */
+export function scanSkills(
+  repoRoot: string,
+  target: "foreign" | "claude-code" = "foreign",
+): ScanResult {
+  const marketplacePath = join(repoRoot, ".claude-plugin", "marketplace.json");
+  const marketplace = JSON.parse(readFileSync(marketplacePath, "utf8")) as Marketplace;
+
+  const entries: SkillEntry[] = [];
+  const warnings: string[] = [];
+
+  for (const plugin of marketplace.plugins) {
+    const skillsDir = join(repoRoot, plugin.source, "skills");
+    if (!existsSync(skillsDir)) continue;
+    const skillDirs = readdirSync(skillsDir, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name)
+      .sort();
+    for (const skillDir of skillDirs) {
+      const skillPath = join(skillsDir, skillDir, "SKILL.md");
+      if (!existsSync(skillPath)) continue;
+      const id = `${plugin.name}:${skillDir}`;
+      const frontmatter = parseFrontmatter(readFileSync(skillPath, "utf8"));
+      if (frontmatter === null) {
+        warnings.push(`${id}: no frontmatter — dropped (description required)`);
+        continue;
+      }
+      const description = frontmatter.description ?? "";
+      if (description.trim().length === 0) {
+        warnings.push(`${id}: missing description — dropped`);
+        continue;
+      }
+      const compatibility = frontmatter.compatibility;
+      if (
+        target === "foreign" &&
+        compatibility !== undefined &&
+        compatibility.includes("claude-code")
+      ) {
+        continue;
+      }
+      const name = (frontmatter.name ?? "").trim() || skillDir;
+      const entry: SkillEntry = {
+        id,
+        name,
+        plugin: plugin.name,
+        description,
+        path: skillPath,
+        category: plugin.category,
+        keywords: plugin.keywords,
+      };
+      if (compatibility !== undefined) entry.compatibility = compatibility;
+      entries.push(entry);
+    }
+  }
+  return { entries, warnings };
+}
+
+/**
+ * BM25/embedding document text per entry: name + description. Plugin
+ * keywords/category stay out of the scored text (they exist as filters, and
+ * stuffing them in would let category words outrank intent words in short
+ * descriptions).
+ */
+export function documentText(entry: SkillEntry): string {
+  return `${entry.name} ${entry.description}`;
+}

--- a/adapters/core/render.ts
+++ b/adapters/core/render.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared injected-block / tool-result formatting (DESIGN §3.3), used by both
+ * bindings (#2090/#2091) and by the eval harness's token accounting.
+ *
+ * The injected entry mirrors pi's native XML item shape
+ * (name/description/location, location = absolute SKILL.md path) so the
+ * model's trained behavior toward the block ("read the location") transfers
+ * unchanged.
+ */
+
+export interface RenderableSkill {
+  id: string;
+  description: string;
+  path: string;
+}
+
+export const AVAILABLE_SKILLS_OPEN = "<available_skills>";
+export const AVAILABLE_SKILLS_CLOSE = "</available_skills>";
+
+export const INJECTED_BLOCK_TRAILER =
+  "Skills relevant to the current request are listed above. Read a skill's location path before using it. For anything not listed, call search_skills.";
+
+export const SEARCH_SKILLS_TOOL_DESCRIPTION =
+  "Search the claude-plugins skill catalog by task intent. " +
+  "Returns ranked skills with the SKILL.md path; read that path to load the skill.";
+
+/** One listing entry — the per-skill unit of the standing-token accounting. */
+export function renderSkillEntry(skill: RenderableSkill): string {
+  return `  <skill><name>${skill.id}</name><description>${skill.description}</description><location>${skill.path}</location></skill>`;
+}
+
+/**
+ * The full injected block: pins first, then ranked results, deduped by id,
+ * capped at k entries, wrapped in <available_skills> tags with the one-line
+ * trailer that routes the long tail to the pull tool.
+ */
+export function renderInjectedBlock(
+  pins: RenderableSkill[],
+  ranked: RenderableSkill[],
+  k: number,
+): string {
+  const seen = new Set<string>();
+  const selected: RenderableSkill[] = [];
+  for (const skill of [...pins, ...ranked]) {
+    if (seen.has(skill.id)) continue;
+    seen.add(skill.id);
+    selected.push(skill);
+    if (selected.length >= k) break;
+  }
+  const lines = [
+    AVAILABLE_SKILLS_OPEN,
+    ...selected.map((s) => renderSkillEntry(s)),
+    AVAILABLE_SKILLS_CLOSE,
+    INJECTED_BLOCK_TRAILER,
+  ];
+  return lines.join("\n");
+}
+
+/** Pull-tool result text: ranked entries with the SKILL.md path to read. */
+export function renderToolResult(results: Array<RenderableSkill & { score: number }>): string {
+  if (results.length === 0) return "No matching skills found.";
+  return results
+    .map((r, i) => `${i + 1}. ${r.id} — ${r.description}\n   read: ${r.path}`)
+    .join("\n");
+}
+
+/** chars/4 — the repo's established token proxy (skill-quality.md). */
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}

--- a/adapters/core/search.ts
+++ b/adapters/core/search.ts
@@ -1,0 +1,234 @@
+/**
+ * SkillIndex — wires rankers + fusion + filters (DESIGN §2.1, §2.6).
+ *
+ * search() is async even though BM25 is sync: the query embedding is a
+ * network call in hybrid mode; one signature for both modes keeps the
+ * bindings mode-agnostic. Search never hard-fails on the embedding side —
+ * per-query embedding failures degrade that query to BM25-only (ADR risk
+ * mitigation).
+ */
+
+import { Bm25Index } from "./bm25.ts";
+import { cacheFilePath, entryKey, loadCache, saveCache } from "./cache.ts";
+import {
+  BATCH_TIMEOUT_MS,
+  DEFAULT_DIMENSIONS,
+  DEFAULT_ENDPOINT,
+  DEFAULT_MODEL,
+  dotRow,
+  type EmbedOptions,
+  embedDocuments,
+  embedQuery,
+  normalizeVector,
+  PREFIX_SCHEME,
+  probeEndpoint,
+  toNormalizedMatrix,
+} from "./embeddings.ts";
+import { FUSE_DEPTH, type RankedItem, rrfFuse } from "./fusion.ts";
+import { documentText, scanSkills } from "./indexer.ts";
+import {
+  DEFAULT_K,
+  type IndexOptions,
+  type Ranker,
+  type SearchFilters,
+  type SearchResult,
+  type SkillEntry,
+} from "./types.ts";
+
+export class SkillIndex {
+  readonly entries: SkillEntry[];
+  readonly mode: "hybrid" | "bm25-only";
+  readonly warnings: string[];
+
+  private readonly bm25: Bm25Index;
+  private readonly idToIdx: Map<string, number>;
+  private readonly embedOpts: EmbedOptions | null;
+  /** Row-per-skill, L2-normalized at index time; null in bm25-only mode. */
+  private readonly matrix: Float32Array | null;
+  private readonly dims: number;
+
+  constructor(
+    entries: SkillEntry[],
+    warnings: string[],
+    mode: "hybrid" | "bm25-only",
+    embedOpts: EmbedOptions | null,
+    matrix: Float32Array | null,
+    dims: number,
+  ) {
+    this.entries = entries;
+    this.warnings = warnings;
+    this.mode = mode;
+    this.embedOpts = embedOpts;
+    this.matrix = matrix;
+    this.dims = dims;
+    this.bm25 = new Bm25Index(entries.map((e) => documentText(e)));
+    this.idToIdx = new Map(entries.map((e, i) => [e.id, i]));
+  }
+
+  /** Ranker seam — BM25 over the whole index (eval ablation entry point). */
+  bm25Ranker(): Ranker {
+    return async (query, k) =>
+      this.bm25
+        .score(query)
+        .slice(0, k)
+        .map(({ docIdx, score }) => ({ id: (this.entries[docIdx] as SkillEntry).id, score }));
+  }
+
+  /** Ranker seam — cosine over the whole index; null in bm25-only mode. */
+  embeddingRanker(): Ranker | null {
+    const { matrix, embedOpts } = this;
+    if (matrix === null || embedOpts === null) return null;
+    return async (query, k) => {
+      const queryVec = normalizeVector(await embedQuery(query, embedOpts, BATCH_TIMEOUT_MS));
+      return this.cosineRank(queryVec)
+        .slice(0, k)
+        .map(({ docIdx, score }) => ({ id: (this.entries[docIdx] as SkillEntry).id, score }));
+    };
+  }
+
+  private cosineRank(queryVec: Float32Array): Array<{ docIdx: number; score: number }> {
+    const matrix = this.matrix;
+    if (matrix === null) return [];
+    const scored: Array<{ docIdx: number; score: number }> = [];
+    for (let i = 0; i < this.entries.length; i++) {
+      scored.push({ docIdx: i, score: dotRow(matrix, this.dims, i, queryVec) });
+    }
+    return scored.sort((a, b) => b.score - a.score || a.docIdx - b.docIdx);
+  }
+
+  private candidateIds(filters?: SearchFilters): Set<string> | null {
+    if (!filters) return null;
+    const excluded = new Set(filters.excludeIds ?? []);
+    const plugins = filters.plugins ? new Set(filters.plugins) : null;
+    const ids = new Set<string>();
+    for (const entry of this.entries) {
+      if (excluded.has(entry.id)) continue;
+      if (plugins && !plugins.has(entry.plugin)) continue;
+      if (filters.category && entry.category !== filters.category) continue;
+      ids.add(entry.id);
+    }
+    return ids;
+  }
+
+  /**
+   * Ranked search. In hybrid mode the score is the RRF fusion score
+   * (rank-derived); in bm25-only mode it is the raw BM25 score.
+   */
+  async search(
+    query: string,
+    k: number = DEFAULT_K,
+    filters?: SearchFilters,
+  ): Promise<SearchResult[]> {
+    const candidates = this.candidateIds(filters);
+    const inCandidates = (id: string) => candidates === null || candidates.has(id);
+
+    const bm25List: RankedItem[] = this.bm25
+      .score(query)
+      .map(({ docIdx, score }) => ({ id: (this.entries[docIdx] as SkillEntry).id, score }))
+      .filter((item) => inCandidates(item.id));
+
+    let fused: RankedItem[];
+    if (this.mode === "hybrid" && this.matrix !== null && this.embedOpts !== null) {
+      let embedList: RankedItem[] | null = null;
+      try {
+        const queryVec = normalizeVector(await embedQuery(query, this.embedOpts, BATCH_TIMEOUT_MS));
+        embedList = this.cosineRank(queryVec)
+          .map(({ docIdx, score }) => ({ id: (this.entries[docIdx] as SkillEntry).id, score }))
+          .filter((item) => inCandidates(item.id));
+      } catch {
+        // Per-query embedding failure degrades this query to BM25-only.
+        embedList = null;
+      }
+      fused =
+        embedList === null
+          ? bm25List
+          : rrfFuse([bm25List.slice(0, FUSE_DEPTH), embedList.slice(0, FUSE_DEPTH)]);
+    } else {
+      fused = bm25List;
+    }
+
+    return fused.slice(0, k).map((item) => {
+      const entry = this.entries[this.idToIdx.get(item.id) as number] as SkillEntry;
+      return {
+        id: entry.id,
+        name: entry.name,
+        description: entry.description,
+        path: entry.path,
+        score: item.score,
+      };
+    });
+  }
+}
+
+/**
+ * Build the index: scan the marketplace, then (unless disabled) probe the
+ * embedding endpoint and assemble the L2-normalized vector matrix through
+ * the XDG content-hash cache. Any embedding failure yields mode "bm25-only".
+ */
+export async function buildIndex(opts: IndexOptions): Promise<SkillIndex> {
+  const target = opts.target ?? "foreign";
+  const { entries, warnings } = scanSkills(opts.repoRoot, target);
+
+  const embedOpts: EmbedOptions = {
+    endpoint: opts.embed?.endpoint ?? DEFAULT_ENDPOINT,
+    model: opts.embed?.model ?? DEFAULT_MODEL,
+    ...(opts.embed?.dimensions !== undefined ? { dimensions: opts.embed.dimensions } : {}),
+  };
+  const dims = opts.embed?.dimensions ?? DEFAULT_DIMENSIONS;
+
+  if (opts.embed?.disabled) {
+    return new SkillIndex(entries, warnings, "bm25-only", null, null, dims);
+  }
+
+  if (!(await probeEndpoint(embedOpts))) {
+    return new SkillIndex(entries, warnings, "bm25-only", null, null, dims);
+  }
+
+  try {
+    const filePath = cacheFilePath(opts.repoRoot, opts.cacheDir);
+    const cached = loadCache(filePath);
+    const cacheValid = cached !== null && cached.model === embedOpts.model && cached.dims === dims;
+    const keys = entries.map((entry) =>
+      entryKey({
+        model: embedOpts.model,
+        dims,
+        prefixScheme: PREFIX_SCHEME,
+        skillName: entry.name,
+        description: entry.description,
+      }),
+    );
+
+    const rows: Array<number[] | null> = keys.map((key) =>
+      cacheValid ? ((cached as NonNullable<typeof cached>).entries[key] ?? null) : null,
+    );
+    const missIdx: number[] = [];
+    rows.forEach((row, i) => {
+      if (row === null) missIdx.push(i);
+    });
+    if (missIdx.length > 0) {
+      const embedded = await embedDocuments(
+        missIdx.map((i) => documentText(entries[i] as SkillEntry)),
+        embedOpts,
+      );
+      missIdx.forEach((entryIdx, j) => {
+        rows[entryIdx] = embedded[j] ?? null;
+      });
+    }
+    if (rows.some((row) => row === null)) {
+      return new SkillIndex(entries, warnings, "bm25-only", null, null, dims);
+    }
+
+    // Rewrite with only-current entries (self-pruning).
+    const nextEntries: Record<string, number[]> = {};
+    keys.forEach((key, i) => {
+      nextEntries[key] = rows[i] as number[];
+    });
+    saveCache(filePath, { version: 1, model: embedOpts.model, dims, entries: nextEntries });
+
+    const matrix = toNormalizedMatrix(rows as number[][], dims);
+    return new SkillIndex(entries, warnings, "hybrid", embedOpts, matrix, dims);
+  } catch {
+    // Batch-embed or cache failure after a successful probe: degrade.
+    return new SkillIndex(entries, warnings, "bm25-only", null, null, dims);
+  }
+}

--- a/adapters/core/search.ts
+++ b/adapters/core/search.ts
@@ -80,6 +80,9 @@ export class SkillIndex {
     if (matrix === null || embedOpts === null) return null;
     return async (query, k) => {
       const queryVec = normalizeVector(await embedQuery(query, embedOpts, BATCH_TIMEOUT_MS));
+      if (queryVec.length !== this.dims) {
+        throw new Error(`query embedding width ${queryVec.length} != index dims ${this.dims}`);
+      }
       return this.cosineRank(queryVec)
         .slice(0, k)
         .map(({ docIdx, score }) => ({ id: (this.entries[docIdx] as SkillEntry).id, score }));
@@ -132,6 +135,9 @@ export class SkillIndex {
       let embedList: RankedItem[] | null = null;
       try {
         const queryVec = normalizeVector(await embedQuery(query, this.embedOpts, BATCH_TIMEOUT_MS));
+        if (queryVec.length !== this.dims) {
+          throw new Error(`query embedding width ${queryVec.length} != index dims ${this.dims}`);
+        }
         embedList = this.cosineRank(queryVec)
           .map(({ docIdx, score }) => ({ id: (this.entries[docIdx] as SkillEntry).id, score }))
           .filter((item) => inCandidates(item.id));
@@ -214,7 +220,10 @@ export async function buildIndex(opts: IndexOptions): Promise<SkillIndex> {
         rows[entryIdx] = embedded[j] ?? null;
       });
     }
-    if (rows.some((row) => row === null)) {
+    if (rows.some((row) => row === null || row.length !== dims)) {
+      // Includes the width guard: a cache entry or fresh row whose length
+      // differs from the expected dims must not reach the truncating matrix
+      // build — degrade to BM25-only instead.
       return new SkillIndex(entries, warnings, "bm25-only", null, null, dims);
     }
 

--- a/adapters/core/types.ts
+++ b/adapters/core/types.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared types for the skill-discovery core (ADR-0022, DESIGN §2.1).
+ * Plain TS — no harness imports, no external dependencies (enforced by a
+ * static import check in tests/indexer.test.ts).
+ */
+
+export interface SkillEntry {
+  /** "<plugin>:<skill-dir>" — matches the repo's invocation naming. */
+  id: string;
+  /** Frontmatter name; fallback: skill directory basename. */
+  name: string;
+  /** Marketplace plugin name. */
+  plugin: string;
+  /** Frontmatter description (required; entry dropped if absent). */
+  description: string;
+  /** Absolute path to SKILL.md — the delivery handle (the model reads it). */
+  path: string;
+  /** Raw frontmatter value when present. */
+  compatibility?: string;
+  /** From the marketplace.json plugin entry. */
+  category: string;
+  /** From the marketplace.json plugin entry. */
+  keywords: string[];
+}
+
+export interface SearchResult {
+  id: string;
+  name: string;
+  description: string;
+  path: string;
+  score: number;
+}
+
+export interface SearchFilters {
+  /** Restrict to these plugin names. */
+  plugins?: string[];
+  /** Restrict to one marketplace category. */
+  category?: string;
+  /** Drop specific skill ids (e.g. already-pinned ones). */
+  excludeIds?: string[];
+}
+
+export type Ranker = (query: string, k: number) => Promise<Array<{ id: string; score: number }>>;
+
+export interface IndexOptions {
+  /** Marketplace checkout root. */
+  repoRoot: string;
+  /** Default "foreign": skip `compatibility: claude-code` entries. */
+  target?: "foreign" | "claude-code";
+  embed?: {
+    /** Default "http://localhost:11434". */
+    endpoint?: string;
+    /** Default "nomic-embed-text". */
+    model?: string;
+    /** Default 768; Matryoshka knob (512/256/128/64) — one line of config, else YAGNI. */
+    dimensions?: number;
+    /** Force BM25-only (eval smoke mode). */
+    disabled?: boolean;
+  };
+  /** Default: XDG recipe (core/cache.ts). */
+  cacheDir?: string;
+}
+
+/**
+ * Single source for the push top-k AND the eval hit@k; eval/tasks.json also
+ * carries k and the runner asserts tasks.k === DEFAULT_K (DESIGN §5.1).
+ */
+export const DEFAULT_K = 5;

--- a/adapters/eval/baseline.ts
+++ b/adapters/eval/baseline.ts
@@ -1,0 +1,139 @@
+/**
+ * Baseline derivation (DESIGN §5.1–§5.2).
+ *
+ * Baseline membership is derived at runtime, never stored per task — a
+ * hand-copied column silently drifts (the drift ADR-0022 exists to remove).
+ *
+ * - pi baseline: `pi/tiers.yaml` general tier + cherry-picks. Degrades
+ *   gracefully (returns null) when the file is absent (post-#2093).
+ * - OpenCode baseline: the same `*-plugin/skills/<skill>/SKILL.md` glob
+ *   `scripts/export-opencode.sh` uses, computed offline from the checkout —
+ *   no rulesync run, no network, no `dist/`. Its membership is trivially
+ *   ~100% (whole-corpus, uncurated), which is why the OC comparison is
+ *   reachability-at-cost, not reachability-delta.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseFrontmatter } from "../core/frontmatter.ts";
+import { estimateTokens, renderSkillEntry } from "../core/render.ts";
+
+export interface BaselineSkill {
+  id: string;
+  description: string;
+  path: string;
+}
+
+export interface BaselineSet {
+  ids: Set<string>;
+  skills: BaselineSkill[];
+}
+
+interface TierEntry {
+  tier: "general" | "domain" | "exclude";
+  category?: string;
+  reason?: string;
+  skills?: string[];
+}
+
+interface TiersYaml {
+  version: number;
+  plugins: Record<string, TierEntry>;
+}
+
+function skillDirsOf(repoRoot: string, plugin: string): string[] {
+  const skillsDir = join(repoRoot, plugin, "skills");
+  if (!existsSync(skillsDir)) return [];
+  return readdirSync(skillsDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && existsSync(join(skillsDir, d.name, "SKILL.md")))
+    .map((d) => d.name)
+    .sort();
+}
+
+function toBaselineSkill(repoRoot: string, plugin: string, skillDir: string): BaselineSkill {
+  const path = join(repoRoot, plugin, "skills", skillDir, "SKILL.md");
+  const frontmatter = parseFrontmatter(readFileSync(path, "utf8"));
+  return {
+    id: `${plugin}:${skillDir}`,
+    description: frontmatter?.description ?? "",
+    path,
+  };
+}
+
+/**
+ * The pi-installed set: every skill of every `tier: general` plugin, with a
+ * `skills:` cherry-pick list restricting the plugin to just those dirs.
+ * Returns null when pi/tiers.yaml is absent (BASELINE_ARM=ABSENT degradation).
+ */
+export function derivePiBaseline(repoRoot: string): BaselineSet | null {
+  const tiersPath = join(repoRoot, "pi", "tiers.yaml");
+  if (!existsSync(tiersPath)) return null;
+  const yaml = (Bun as unknown as { YAML: { parse: (text: string) => unknown } }).YAML.parse(
+    readFileSync(tiersPath, "utf8"),
+  ) as TiersYaml;
+
+  const skills: BaselineSkill[] = [];
+  for (const [plugin, entry] of Object.entries(yaml.plugins)) {
+    if (entry.tier !== "general") continue;
+    const dirs = entry.skills ?? skillDirsOf(repoRoot, plugin);
+    for (const dir of dirs) {
+      if (!existsSync(join(repoRoot, plugin, "skills", dir, "SKILL.md"))) continue;
+      skills.push(toBaselineSkill(repoRoot, plugin, dir));
+    }
+  }
+  return { ids: new Set(skills.map((s) => s.id)), skills };
+}
+
+/**
+ * The OpenCode export set: `<repoRoot>/*-plugin/skills/<skill>/SKILL.md`,
+ * the glob scripts/export-opencode.sh iterates.
+ */
+export function deriveOcBaseline(repoRoot: string): BaselineSet {
+  const skills: BaselineSkill[] = [];
+  const topDirs = readdirSync(repoRoot, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && d.name.endsWith("-plugin"))
+    .map((d) => d.name)
+    .sort();
+  for (const plugin of topDirs) {
+    for (const dir of skillDirsOf(repoRoot, plugin)) {
+      skills.push(toBaselineSkill(repoRoot, plugin, dir));
+    }
+  }
+  return { ids: new Set(skills.map((s) => s.id)), skills };
+}
+
+/**
+ * Count the SKILL.md files the export actually produced under
+ * dist/opencode/skills — the same accounting export-opencode.sh emits as
+ * OUTPUT_SKILLS (`find "$out/skills" -name SKILL.md | wc -l`). Used by the
+ * schema meta-test to cross-check the derived OC set. Returns null when
+ * dist/ has not been built locally.
+ */
+export function countExportedOcSkills(repoRoot: string): number | null {
+  const distSkills = join(repoRoot, "dist", "opencode", "skills");
+  if (!existsSync(distSkills)) return null;
+  let count = 0;
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name === "SKILL.md") count++;
+    }
+  };
+  walk(distSkills);
+  return count;
+}
+
+/**
+ * Standing-token accounting for a listing arm: per-skill chars/4 over the
+ * §3.3 XML entry template (the same render the push channel injects), so the
+ * cost model and the injection share one template.
+ */
+export function listingTokens(skills: BaselineSkill[]): { total: number; perSkillMean: number } {
+  if (skills.length === 0) return { total: 0, perSkillMean: 0 };
+  let total = 0;
+  for (const skill of skills) {
+    total += estimateTokens(renderSkillEntry(skill));
+  }
+  return { total, perSkillMean: total / skills.length };
+}

--- a/adapters/eval/probes.ts
+++ b/adapters/eval/probes.ts
@@ -1,0 +1,48 @@
+/**
+ * InvocationProbe seam (DESIGN §5.4).
+ *
+ * Only RetrievalProxyProbe is implemented — the live-quant probe (pi headless
+ * against the mlx quant, OpenCode equivalent) is a seam, not code (§8).
+ * Future live grading is deterministic (transcript grep for the SKILL.md
+ * read / `/skill:name` invocation) — no LLM judge.
+ */
+
+import type { Ranker } from "../core/types.ts";
+import type { EvalTask } from "./rankers.ts";
+
+export type Harness = "pi" | "opencode";
+export type Arm = "baseline" | "adapter";
+
+export interface ProbeResult {
+  /**
+   * Necessary-condition proxy: skills the arm made *reachable* for the task
+   * (never a claim of actual invocation — the live probe measures that).
+   */
+  invoked_skills: string[];
+  /** Live probes record a transcript; the retrieval proxy has none. */
+  transcript_path: string | null;
+  /** Standing tokens/turn the arm pays for its listing (chars/4 proxy). */
+  standing_tokens: number;
+}
+
+export type InvocationProbe = (harness: Harness, arm: Arm, task: EvalTask) => Promise<ProbeResult>;
+
+/**
+ * The retrieval proxy: wraps a Ranker + a token renderer. The adapter arm's
+ * "reachable" set is the ranker's top-k for the task prompt.
+ */
+export function makeRetrievalProxyProbe(
+  ranker: Ranker,
+  k: number,
+  standingTokens: (task: EvalTask, rankedIds: string[]) => number,
+): InvocationProbe {
+  return async (_harness, _arm, task) => {
+    const ranked = await ranker(task.prompt, k);
+    const ids = ranked.map((r) => r.id);
+    return {
+      invoked_skills: ids,
+      transcript_path: null,
+      standing_tokens: standingTokens(task, ids),
+    };
+  };
+}

--- a/adapters/eval/rankers.ts
+++ b/adapters/eval/rankers.ts
@@ -1,0 +1,141 @@
+/**
+ * Ranker seam (DESIGN §5.4) — one seam serving meta-tests, ablation, and
+ * diagnosis: hybrid | bm25Only | embeddingOnly | random(seed) | oracle |
+ * nameSubstring | descriptionSubstring.
+ *
+ * `descriptionSubstring` is the two-sided complement to `nameSubstring`: a
+ * degenerate ranker that must lose to `bm25Only`, proving prompts don't echo
+ * description text any more than they echo names.
+ */
+
+import { tokenize } from "../core/bm25.ts";
+import type { SkillIndex } from "../core/search.ts";
+import type { Ranker, SkillEntry } from "../core/types.ts";
+
+export interface EvalTask {
+  id: string;
+  prompt: string;
+  expected_skills: string[];
+  acceptable_skills: string[];
+  negative: boolean;
+  tags: string[];
+  provenance: string;
+}
+
+export interface TaskSet {
+  version: number;
+  k: number;
+  gate: {
+    cutover_thresholds: Record<string, unknown> & { status?: string };
+  };
+  tasks: EvalTask[];
+}
+
+/** The hybrid (shipping) configuration: whatever mode the index resolved. */
+export function hybridRanker(index: SkillIndex): Ranker {
+  return async (query, k) => (await index.search(query, k)).map(({ id, score }) => ({ id, score }));
+}
+
+export function bm25OnlyRanker(index: SkillIndex): Ranker {
+  return index.bm25Ranker();
+}
+
+/** Throws when the index is in bm25-only mode (no embedding side to ablate). */
+export function embeddingOnlyRanker(index: SkillIndex): Ranker {
+  const ranker = index.embeddingRanker();
+  if (ranker === null) {
+    throw new Error("embeddingOnly ranker requires a hybrid-mode index (run --with-embeddings)");
+  }
+  return ranker;
+}
+
+/** mulberry32 — small deterministic PRNG for the random ranker. */
+function mulberry32(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function hashString(text: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < text.length; i++) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+/**
+ * Deterministic per (seed, query): different tasks get independent
+ * permutations, and the same seed reproduces the same run exactly.
+ */
+export function randomRanker(index: SkillIndex, seed: number): Ranker {
+  return async (query, k) => {
+    const rng = mulberry32((seed ^ hashString(query)) >>> 0);
+    const ids = index.entries.map((e) => e.id);
+    for (let i = ids.length - 1; i > 0; i--) {
+      const j = Math.floor(rng() * (i + 1));
+      const a = ids[i] as string;
+      ids[i] = ids[j] as string;
+      ids[j] = a;
+    }
+    return ids.slice(0, k).map((id, i) => ({ id, score: 1 / (i + 1) }));
+  };
+}
+
+/**
+ * Perfect ranker: expected skills first, then acceptable, then arbitrary
+ * fill. Proves the eval gate is achievable, not aspirational.
+ */
+export function oracleRanker(index: SkillIndex, tasks: EvalTask[]): Ranker {
+  const byPrompt = new Map<string, EvalTask>(tasks.map((t) => [t.prompt, t]));
+  return async (query, k) => {
+    const task = byPrompt.get(query);
+    const targets = task ? [...task.expected_skills, ...task.acceptable_skills] : [];
+    const seen = new Set<string>();
+    const ranked: Array<{ id: string; score: number }> = [];
+    for (const id of targets) {
+      if (seen.has(id) || ranked.length >= k) continue;
+      seen.add(id);
+      ranked.push({ id, score: 1 - ranked.length / (k + 1) });
+    }
+    for (const entry of index.entries) {
+      if (ranked.length >= k) break;
+      if (seen.has(entry.id)) continue;
+      seen.add(entry.id);
+      ranked.push({ id: entry.id, score: 1 - ranked.length / (k + 1) });
+    }
+    return ranked;
+  };
+}
+
+function tokenOverlapRanker(index: SkillIndex, field: (e: SkillEntry) => string): Ranker {
+  const docTokens = index.entries.map((e) => new Set(tokenize(field(e))));
+  return async (query, k) => {
+    const queryTokens = new Set(tokenize(query));
+    const scored: Array<{ id: string; score: number }> = [];
+    index.entries.forEach((entry, i) => {
+      let overlap = 0;
+      for (const token of docTokens[i] as Set<string>) {
+        if (queryTokens.has(token)) overlap++;
+      }
+      if (overlap > 0) scored.push({ id: entry.id, score: overlap });
+    });
+    return scored.sort((a, b) => b.score - a.score || (a.id < b.id ? -1 : 1)).slice(0, k);
+  };
+}
+
+/** Degenerate: matches only skill-name tokens against the query text. */
+export function nameSubstringRanker(index: SkillIndex): Ranker {
+  return tokenOverlapRanker(index, (e) => e.name);
+}
+
+/** Degenerate: matches only description tokens against the query text. */
+export function descriptionSubstringRanker(index: SkillIndex): Ranker {
+  return tokenOverlapRanker(index, (e) => e.description);
+}

--- a/adapters/eval/run-eval.ts
+++ b/adapters/eval/run-eval.ts
@@ -1,0 +1,334 @@
+/**
+ * Eval runner (DESIGN §5.3).
+ *
+ * Smoke mode (default) is BM25-only, zero network — CI has no ollama and the
+ * smoke gate must never flake on the soft dependency. `--with-embeddings`
+ * exercises hybrid fusion when an endpoint is reachable (local dev; the
+ * configuration the cutover thresholds are derived on, §5.6).
+ *
+ * All retrieval/token metrics are informational in CI. `GATE STATUS` asserts
+ * only that the eval *machinery* ran (tasks parse + schema-validate, index
+ * builds, every task scored, per-mode invariants hold); the correctness
+ * teeth live in tests/eval-meta.test.ts. CI never gates on the cutover
+ * thresholds — that comparison is the §5.6 local procedure.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import {
+  estimateTokens,
+  renderInjectedBlock,
+  SEARCH_SKILLS_TOOL_DESCRIPTION,
+} from "../core/render.ts";
+import { buildIndex, type SkillIndex } from "../core/search.ts";
+import { DEFAULT_K } from "../core/types.ts";
+import { type BaselineSet, deriveOcBaseline, derivePiBaseline, listingTokens } from "./baseline.ts";
+import { makeRetrievalProxyProbe } from "./probes.ts";
+import { type EvalTask, hybridRanker, type TaskSet } from "./rankers.ts";
+
+const EVAL_DIR = import.meta.dir;
+const REPO_ROOT = resolve(EVAL_DIR, "..", "..");
+export const TASKS_PATH = join(EVAL_DIR, "tasks.json");
+
+const TAG_RE = /^(stratum|domain):[a-z0-9-]+$/;
+
+export function loadTaskSet(path: string = TASKS_PATH): TaskSet {
+  return JSON.parse(readFileSync(path, "utf8")) as TaskSet;
+}
+
+/**
+ * Schema checks (DESIGN §5.5 item 5). Returns human-readable violations;
+ * empty array = valid.
+ */
+export function validateTaskSet(tasks: TaskSet): string[] {
+  const errors: string[] = [];
+  if (typeof tasks.gate !== "object" || tasks.gate === null) {
+    errors.push("missing top-level gate block");
+  } else if (
+    typeof tasks.gate.cutover_thresholds !== "object" ||
+    tasks.gate.cutover_thresholds === null
+  ) {
+    errors.push("gate block missing cutover_thresholds");
+  }
+  if (tasks.k !== DEFAULT_K) {
+    errors.push(`tasks.k (${tasks.k}) !== DEFAULT_K (${DEFAULT_K})`);
+  }
+  const seenIds = new Set<string>();
+  for (const task of tasks.tasks) {
+    for (const field of [
+      "id",
+      "prompt",
+      "expected_skills",
+      "acceptable_skills",
+      "negative",
+      "tags",
+      "provenance",
+    ] as const) {
+      if (!(field in task)) errors.push(`${task.id ?? "?"}: missing field ${field}`);
+    }
+    if (!Array.isArray(task.acceptable_skills)) {
+      errors.push(`${task.id}: acceptable_skills must be an array (empty when none)`);
+    }
+    if (seenIds.has(task.id)) errors.push(`duplicate task id ${task.id}`);
+    seenIds.add(task.id);
+    for (const tag of task.tags ?? []) {
+      if (!TAG_RE.test(tag)) errors.push(`${task.id}: bad tag ${JSON.stringify(tag)}`);
+    }
+    if (!(task.tags ?? []).some((t) => t.startsWith("stratum:"))) {
+      errors.push(`${task.id}: no stratum:* tag`);
+    }
+  }
+  return errors;
+}
+
+interface TaskScore {
+  task: EvalTask;
+  rankedIds: string[];
+  scores: number[];
+  hitAt1: boolean;
+  hitAtK: boolean;
+  reciprocalRank: number;
+  top1Margin: number | null;
+}
+
+export interface StratumMetrics {
+  taskCount: number;
+  hitAt1: number;
+  hitAtK: number;
+  mrr: number;
+}
+
+export interface EvalRun {
+  mode: "hybrid" | "bm25-only";
+  k: number;
+  baselineArm: "PRESENT" | "ABSENT";
+  inTier: StratumMetrics | null;
+  excluded: StratumMetrics;
+  negMargins: number[];
+  posMargins: number[];
+  baselinePiTokens: number | null;
+  baselineOcTokensEstimated: number;
+  adapterTokens: number;
+  scores: TaskScore[];
+  cutoverStatus: "UNFROZEN" | "PASS" | "FAIL";
+  gateStatus: "PASS" | "FAIL";
+  gateIssues: string[];
+}
+
+function aggregate(scores: TaskScore[]): StratumMetrics {
+  const n = scores.length;
+  if (n === 0) return { taskCount: 0, hitAt1: 0, hitAtK: 0, mrr: 0 };
+  const sum = (f: (s: TaskScore) => number) => scores.reduce((acc, s) => acc + f(s), 0);
+  return {
+    taskCount: n,
+    hitAt1: sum((s) => (s.hitAt1 ? 1 : 0)) / n,
+    hitAtK: sum((s) => (s.hitAtK ? 1 : 0)) / n,
+    mrr: sum((s) => s.reciprocalRank) / n,
+  };
+}
+
+function percentile(values: number[], p: number): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const rank = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[Math.max(0, rank)] as number;
+}
+
+export async function scoreTasks(
+  index: SkillIndex,
+  tasks: EvalTask[],
+  k: number,
+): Promise<TaskScore[]> {
+  const probe = makeRetrievalProxyProbe(hybridRanker(index), k, () => 0);
+  const scores: TaskScore[] = [];
+  for (const task of tasks) {
+    const results = await index.search(task.prompt, k);
+    const rankedIds = results.map((r) => r.id);
+    // Keep the probe seam exercised (same ranker, same ids).
+    await probe("pi", "adapter", task);
+    const targets = new Set([...task.expected_skills, ...task.acceptable_skills]);
+    const expected = new Set(task.expected_skills);
+    const firstTargetRank = rankedIds.findIndex((id) => targets.has(id));
+    scores.push({
+      task,
+      rankedIds,
+      scores: results.map((r) => r.score),
+      hitAt1: rankedIds.length > 0 && expected.has(rankedIds[0] as string),
+      hitAtK: firstTargetRank >= 0,
+      reciprocalRank: firstTargetRank >= 0 ? 1 / (firstTargetRank + 1) : 0,
+      top1Margin:
+        results.length >= 2
+          ? (results[0] as { score: number }).score - (results[1] as { score: number }).score
+          : results.length === 1
+            ? (results[0] as { score: number }).score
+            : null,
+    });
+  }
+  return scores;
+}
+
+export async function runEval(options: {
+  withEmbeddings: boolean;
+  tasksPath?: string;
+  repoRoot?: string;
+}): Promise<EvalRun> {
+  const repoRoot = options.repoRoot ?? REPO_ROOT;
+  const gateIssues: string[] = [];
+
+  const taskSet = loadTaskSet(options.tasksPath ?? TASKS_PATH);
+  const schemaErrors = validateTaskSet(taskSet);
+  gateIssues.push(...schemaErrors);
+  const k = DEFAULT_K;
+
+  const index = await buildIndex({
+    repoRoot,
+    target: "foreign",
+    embed: { disabled: !options.withEmbeddings },
+  });
+  if (index.entries.length === 0) gateIssues.push("index built with zero entries");
+  if (!options.withEmbeddings && index.mode !== "bm25-only") {
+    gateIssues.push(`smoke mode invariant violated: mode=${index.mode}`);
+  }
+
+  const scores = await scoreTasks(index, taskSet.tasks, k);
+  if (scores.length !== taskSet.tasks.length) gateIssues.push("not every task scored");
+
+  // Baselines (runtime-derived, never stored per task).
+  const piBaseline: BaselineSet | null = derivePiBaseline(repoRoot);
+  const ocBaseline = deriveOcBaseline(repoRoot);
+  const baselineArm = piBaseline === null ? "ABSENT" : "PRESENT";
+
+  const positive = scores.filter((s) => !s.task.negative);
+  const negative = scores.filter((s) => s.task.negative);
+
+  // A task is in-tier iff its expected skill is in the installed set — so
+  // baseline reachability is constant 1.0 on that stratum by construction
+  // (DESIGN §5.2 "honest reading"). With the baseline absent, everything
+  // degrades to headroom-only reporting.
+  let inTierScores: TaskScore[] = [];
+  let excludedScores: TaskScore[] = positive;
+  if (piBaseline !== null) {
+    inTierScores = positive.filter((s) =>
+      s.task.expected_skills.some((id) => piBaseline.ids.has(id)),
+    );
+    excludedScores = positive.filter(
+      (s) => !s.task.expected_skills.some((id) => piBaseline.ids.has(id)),
+    );
+  }
+
+  // Metric B — standing tokens/turn (chars/4 over the shared render).
+  const baselinePiTokens = piBaseline === null ? null : listingTokens(piBaseline.skills).total;
+  const baselineOcTokensEstimated = listingTokens(ocBaseline.skills).total;
+  const toolDescriptionTokens = estimateTokens(SEARCH_SKILLS_TOOL_DESCRIPTION);
+  const idToEntry = new Map(index.entries.map((e) => [e.id, e]));
+  let injectedSum = 0;
+  for (const score of positive) {
+    const ranked = score.rankedIds
+      .map((id) => idToEntry.get(id))
+      .filter((e) => e !== undefined)
+      .map((e) => ({ id: e.id, description: e.description, path: e.path }));
+    injectedSum += estimateTokens(renderInjectedBlock([], ranked, k));
+  }
+  const adapterTokens =
+    toolDescriptionTokens + (positive.length > 0 ? Math.round(injectedSum / positive.length) : 0);
+
+  // Cutover block — informational; numeric thresholds exist only after the
+  // §5.6 freeze procedure.
+  const thresholds = taskSet.gate?.cutover_thresholds ?? {};
+  let cutoverStatus: EvalRun["cutoverStatus"] = "UNFROZEN";
+  const inTierMetrics = piBaseline === null ? null : aggregate(inTierScores);
+  if (typeof thresholds.status === "string" && thresholds.status.includes("unfrozen")) {
+    cutoverStatus = "UNFROZEN";
+  } else if (typeof thresholds.in_tier_hit_at_k_min === "number") {
+    cutoverStatus =
+      inTierMetrics !== null && inTierMetrics.hitAtK >= thresholds.in_tier_hit_at_k_min
+        ? "PASS"
+        : "FAIL";
+  }
+
+  return {
+    mode: index.mode,
+    k,
+    baselineArm,
+    inTier: inTierMetrics,
+    excluded: aggregate(excludedScores),
+    negMargins: negative.map((s) => s.top1Margin).filter((m): m is number => m !== null),
+    posMargins: positive.map((s) => s.top1Margin).filter((m): m is number => m !== null),
+    baselinePiTokens,
+    baselineOcTokensEstimated,
+    adapterTokens,
+    scores,
+    cutoverStatus,
+    gateStatus: gateIssues.length === 0 ? "PASS" : "FAIL",
+    gateIssues,
+  };
+}
+
+function fmt(value: number | null): string {
+  return value === null ? "NA" : value.toFixed(4);
+}
+
+export function renderReport(run: EvalRun): string {
+  const lines: string[] = [];
+  lines.push(`=== EVAL === MODE=${run.mode} K=${run.k} TASKS=${run.scores.length}`);
+  if (run.inTier !== null) {
+    lines.push(
+      `=== RETRIEVAL_IN_TIER === HIT_AT_1=${fmt(run.inTier.hitAt1)} HIT_AT_K=${fmt(run.inTier.hitAtK)} MRR=${fmt(run.inTier.mrr)} BASELINE_ARM=${run.baselineArm}`,
+    );
+  } else {
+    lines.push(
+      `=== RETRIEVAL_IN_TIER === HIT_AT_1=NA HIT_AT_K=NA MRR=NA BASELINE_ARM=${run.baselineArm}`,
+    );
+  }
+  lines.push(
+    `=== RETRIEVAL_EXCLUDED_STRATUM === HIT_AT_1=${fmt(run.excluded.hitAt1)} HIT_AT_K=${fmt(run.excluded.hitAtK)} MRR=${fmt(run.excluded.mrr)}`,
+  );
+  lines.push(
+    `=== NEGATIVES === TOP1_MARGIN_NEG_P50=${fmt(percentile(run.negMargins, 50))} TOP1_MARGIN_NEG_P90=${fmt(percentile(run.negMargins, 90))} TOP1_MARGIN_POS_P50=${fmt(percentile(run.posMargins, 50))} TOP1_MARGIN_POS_P90=${fmt(percentile(run.posMargins, 90))}`,
+  );
+  lines.push(
+    `=== TOKENS === BASELINE_PI_TOKENS=${run.baselinePiTokens ?? "NA"} BASELINE_OC_TOKENS_ESTIMATED=${run.baselineOcTokensEstimated} ADAPTER_TOKENS=${run.adapterTokens}`,
+  );
+  lines.push(`=== CUTOVER === STATUS=${run.cutoverStatus}`);
+  lines.push(`=== GATE === STATUS=${run.gateStatus}`);
+  for (const issue of run.gateIssues) lines.push(`GATE_ISSUE=${issue}`);
+  return lines.join("\n");
+}
+
+async function main(): Promise<void> {
+  const withEmbeddings = process.argv.includes("--with-embeddings");
+  const run = await runEval({ withEmbeddings });
+  const report = renderReport(run);
+  console.log(report);
+
+  const resultsDir = join(EVAL_DIR, "results");
+  mkdirSync(resultsDir, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const resultPath = join(resultsDir, `${stamp}-${run.mode}.json`);
+  const { scores, ...summary } = run;
+  writeFileSync(
+    resultPath,
+    JSON.stringify(
+      {
+        ...summary,
+        report,
+        perTask: scores.map((s) => ({
+          id: s.task.id,
+          rankedIds: s.rankedIds,
+          hitAt1: s.hitAt1,
+          hitAtK: s.hitAtK,
+          reciprocalRank: s.reciprocalRank,
+          top1Margin: s.top1Margin,
+        })),
+      },
+      null,
+      2,
+    ),
+  );
+  console.log(`RESULTS_FILE=${resultPath}`);
+  process.exit(run.gateStatus === "PASS" ? 0 : 1);
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/adapters/eval/tasks.json
+++ b/adapters/eval/tasks.json
@@ -1,0 +1,681 @@
+{
+  "version": 1,
+  "k": 5,
+  "gate": {
+    "cutover_thresholds": {
+      "status": "unfrozen — derive via the documented hybrid-simulation procedure before #2093/#2094"
+    }
+  },
+  "tasks": [
+    {
+      "id": "t-gen-001",
+      "prompt": "I'm done editing — get these changes recorded in the repository history with a properly formatted note that links the ticket they resolve.",
+      "expected_skills": ["git-plugin:git-commit"],
+      "acceptable_skills": ["git-plugin:git-commit-workflow"],
+      "negative": false,
+      "tags": ["stratum:paraphrase"],
+      "provenance": "paraphrased-from-description"
+    },
+    {
+      "id": "t-gen-002",
+      "prompt": "This branch is already up on GitHub — get it in front of my teammates for sign-off, with a decent writeup and the right tags attached.",
+      "expected_skills": ["git-plugin:git-pr"],
+      "acceptable_skills": ["git-plugin:git-branch-pr-workflow"],
+      "negative": false,
+      "tags": ["stratum:paraphrase"],
+      "provenance": "paraphrased-from-description"
+    },
+    {
+      "id": "t-gen-003",
+      "prompt": "Before I wipe my uncommitted state in this working copy, can you tell whether another assistant session is operating in the same directory?",
+      "expected_skills": ["git-plugin:git-coworker-check"],
+      "acceptable_skills": [],
+      "negative": false,
+      "tags": ["stratum:paraphrase"],
+      "provenance": "paraphrased-from-description"
+    },
+    {
+      "id": "t-gen-004",
+      "prompt": "From the terminal, grab the error output of the latest broken pipeline execution and give me machine-parseable data about the open change requests on this repository.",
+      "expected_skills": ["git-plugin:gh-cli-agentic"],
+      "acceptable_skills": [],
+      "negative": false,
+      "tags": ["stratum:paraphrase"],
+      "provenance": "paraphrased-from-description"
+    },
+    {
+      "id": "t-gen-005",
+      "prompt": "Before this goes anywhere public, sweep the staged changes for anything that looks like an access token or a password.",
+      "expected_skills": ["git-plugin:git-security-checks"],
+      "acceptable_skills": [],
+      "negative": false,
+      "tags": ["stratum:paraphrase"],
+      "provenance": "paraphrased-from-description"
+    },
+    {
+      "id": "t-gen-006",
+      "prompt": "My local work is ahead of what's on the server — send it up and make sure the branch is wired to its counterpart on GitHub.",
+      "expected_skills": ["git-plugin:git-push"],
+      "acceptable_skills": [],
+      "negative": false,
+      "tags": ["stratum:paraphrase"],
+      "provenance": "paraphrased-from-description"
+    },
+    {
+      "id": "t-gen-007",
+      "prompt": "First time inside this repo — figure out how it's assembled, what verifies it, and how the automation is wired before I touch anything.",
+      "expected_skills": ["project-plugin:project-discovery"],
+      "acceptable_skills": [],
+      "negative": false,
+      "tags": ["stratum:paraphrase"],
+      "provenance": "paraphrased-from-description"
+    },
+    {
+      "id": "t-gen-008",
+      "prompt": "I've got a huge API response saved to disk and need to pull a couple of nested keys out of every element of the list inside it.",
+      "expected_skills": ["tools-plugin:jq-json-processing"],
+      "acceptable_skills": ["tools-plugin:nushell-data-processing"],
+      "negative": false,
+      "tags": ["stratum:paraphrase"],
+      "provenance": "paraphrased-from-description"
+    },
+    {
+      "id": "t-gen-009",
+      "prompt": "Turn this written description of how our services talk to each other into a rendered picture of the system.",
+      "expected_skills": ["tools-plugin:d2-diagrams"],
+      "acceptable_skills": ["tools-plugin:mermaid-diagrams"],
+      "negative": false,
+      "tags": ["stratum:paraphrase"],
+      "provenance": "paraphrased-from-description"
+    },
+    {
+      "id": "t-gen-010",
+      "prompt": "make this run the same on mac and linux terminals",
+      "expected_skills": ["tools-plugin:shell-expert"],
+      "acceptable_skills": [],
+      "negative": false,
+      "tags": ["stratum:terse"],
+      "provenance": "invented-intent"
+    },
+    {
+      "id": "t-gen-011",
+      "prompt": "quick sanity pass that my edit didn't break anything",
+      "expected_skills": ["testing-plugin:test-quick"],
+      "acceptable_skills": ["testing-plugin:test-run", "testing-plugin:test-tier-selection"],
+      "negative": false,
+      "tags": ["stratum:terse"],
+      "provenance": "invented-intent"
+    },
+    {
+      "id": "t-gen-012",
+      "prompt": "things go wrong in this app but nothing ever surfaces — find where it all gets eaten",
+      "expected_skills": ["code-quality-plugin:code-hidden-failures"],
+      "acceptable_skills": [],
+      "negative": false,
+      "tags": ["stratum:terse"],
+      "provenance": "invented-intent"
+    },
+    {
+      "id": "t-gen-013",
+      "prompt": "clear out all these stale todos in one go",
+      "expected_skills": ["taskwarrior-plugin:task-bulk-ops"],
+      "acceptable_skills": ["taskwarrior-plugin:task-reconcile"],
+      "negative": false,
+      "tags": ["stratum:terse"],
+      "provenance": "invented-intent"
+    },
+    {
+      "id": "t-gen-014",
+      "prompt": "Which parts of this codebase are the hardest to follow? I want numbers ranking the worst offenders so I know where to start untangling.",
+      "expected_skills": ["code-quality-plugin:code-complexity"],
+      "acceptable_skills": [],
+      "negative": false,
+      "tags": ["stratum:paraphrase"],
+      "provenance": "paraphrased-from-description"
+    },
+    {
+      "id": "t-gen-015",
+      "prompt": "The suite is all green but I suspect the assertions wouldn't trip on a genuine defect — deliberately sabotage the source and see whether anything complains.",
+      "expected_skills": ["testing-plugin:mutation-testing"],
+      "acceptable_skills": [
+        "testing-plugin:test-quality-analysis",
+        "testing-plugin:test-strategy-review"
+      ],
+      "negative": false,
+      "tags": ["stratum:paraphrase"],
+      "provenance": "paraphrased-from-description"
+    },
+    {
+      "id": "t-gen-016",
+      "prompt": "I have to change an old module that nothing exercises — how do I make it safe to modify without rewriting the whole thing first?",
+      "expected_skills": ["software-design-plugin:design-legacy-seams"],
+      "acceptable_skills": [],
+      "negative": false,
+      "tags": ["stratum:paraphrase"],
+      "provenance": "paraphrased-from-description"
+    },
+    {
+      "id": "t-gen-017",
+      "prompt": "We're moving the persistence layer from one database to another and can't lose records — what's the approach for keeping both in agreement during the changeover?",
+      "expected_skills": ["migration-patterns-plugin:dual-write"],
+      "acceptable_skills": ["migration-patterns-plugin:shadow-mode"],
+      "negative": false,
+      "tags": ["stratum:paraphrase"],
+      "provenance": "paraphrased-from-description"
+    },
+    {
+      "id": "t-gen-018",
+      "prompt": "Before I write any code for this ticket, make sure nobody already has a branch underway or an open change addressing it.",
+      "expected_skills": ["workflow-orchestration-plugin:workflow-preflight"],
+      "acceptable_skills": [],
+      "negative": false,
+      "tags": ["stratum:paraphrase"],
+      "provenance": "paraphrased-from-description"
+    },
+    {
+      "id": "t-gen-019",
+      "prompt": "Here's a rambling voice-memo transcript of everything on my mind about the project — shape it into an organized set of next steps.",
+      "expected_skills": ["prose-plugin:prose-synthesize"],
+      "acceptable_skills": [],
+      "negative": false,
+      "tags": ["stratum:paraphrase"],
+      "provenance": "paraphrased-from-description"
+    },
+    {
+      "id": "t-gen-020",
+      "prompt": "Produce browsable reference pages for our public functions from the inline comments that already document them, plus release notes derived from past changes.",
+      "expected_skills": ["documentation-plugin:docs-generate"],
+      "acceptable_skills": [],
+      "negative": false,
+      "tags": ["stratum:paraphrase"],
+      "provenance": "paraphrased-from-description"
+    },
+    {
+      "id": "t-dom-001",
+      "prompt": "I've got a single-file Python helper that needs requests and rich available, but I don't want to create a whole project or activate any environment first — what's the quickest way to just execute it?",
+      "expected_skills": ["python-plugin:uv-run"],
+      "acceptable_skills": ["python-plugin:uv-project-management"],
+      "negative": false,
+      "tags": ["stratum:paraphrase", "domain:lang"],
+      "provenance": "SKILL.md description of python-plugin/skills/uv-run, read 2026-07-19; prompt hand-paraphrased"
+    },
+    {
+      "id": "t-dom-002",
+      "prompt": "Our Python repo has years of cruft — I'm sure there are whole functions and classes nobody references anymore. Help me find them and strip them out safely.",
+      "expected_skills": ["python-plugin:vulture-dead-code"],
+      "acceptable_skills": ["code-quality-plugin:code-dead-code"],
+      "negative": false,
+      "tags": ["stratum:paraphrase", "domain:lang"],
+      "provenance": "SKILL.md description of python-plugin/skills/vulture-dead-code, read 2026-07-19; prompt hand-paraphrased"
+    },
+    {
+      "id": "t-dom-003",
+      "prompt": "In our TypeScript app I want to know which source modules and package.json entries nothing actually references, so we can trim the bundle and make the pipeline fail when new ones sneak in.",
+      "expected_skills": ["typescript-plugin:knip-dead-code"],
+      "acceptable_skills": [
+        "code-quality-plugin:code-dead-code",
+        "configure-plugin:configure-dead-code"
+      ],
+      "negative": false,
+      "tags": ["stratum:paraphrase", "domain:lang"],
+      "provenance": "SKILL.md description of typescript-plugin/skills/knip-dead-code, read 2026-07-19; prompt hand-paraphrased"
+    },
+    {
+      "id": "t-dom-004",
+      "prompt": "our rust test suite takes forever and a couple of cases fail randomly in CI, sort it out",
+      "expected_skills": ["rust-plugin:cargo-nextest"],
+      "acceptable_skills": ["testing-plugin:test-run", "rust-plugin:rust-development"],
+      "negative": false,
+      "tags": ["stratum:terse", "domain:lang"],
+      "provenance": "SKILL.md description of rust-plugin/skills/cargo-nextest, read 2026-07-19; prompt hand-paraphrased (terse variant)"
+    },
+    {
+      "id": "t-dom-005",
+      "prompt": "My Rust integration test spins up a fake HTTP endpoint, and the client code that retries until it gets a 200 just sits there forever — and it only misbehaves when the whole suite executes at once, never in isolation.",
+      "expected_skills": ["rust-plugin:mockito-http-mocking"],
+      "acceptable_skills": [],
+      "negative": false,
+      "tags": ["stratum:paraphrase", "domain:lang"],
+      "provenance": "SKILL.md description of rust-plugin/skills/mockito-http-mocking, read 2026-07-19; prompt hand-paraphrased"
+    },
+    {
+      "id": "t-dom-006",
+      "prompt": "My Bevy game's frame rate tanks once there are a few thousand entities on screen — I think the way I iterate components each frame and the order everything executes in needs a rework.",
+      "expected_skills": ["bevy-plugin:bevy-ecs-patterns"],
+      "acceptable_skills": ["bevy-plugin:bevy-game-engine"],
+      "negative": false,
+      "tags": ["stratum:paraphrase", "domain:gamedev"],
+      "provenance": "SKILL.md description of bevy-plugin/skills/bevy-ecs-patterns, read 2026-07-19; prompt hand-paraphrased"
+    },
+    {
+      "id": "t-dom-007",
+      "prompt": "I'd like Tailwind-style class names generated on the fly in my Vite project instead of shipping one big stylesheet — how do I wire that up?",
+      "expected_skills": ["css-plugin:unocss"],
+      "acceptable_skills": ["css-plugin:lightning-css"],
+      "negative": false,
+      "tags": ["stratum:paraphrase", "domain:frontend"],
+      "provenance": "SKILL.md description of css-plugin/skills/unocss, read 2026-07-19; prompt hand-paraphrased"
+    },
+    {
+      "id": "t-dom-008",
+      "prompt": "Our dropdown menu can't be operated without a mouse and VoiceOver announces nothing useful when it opens — fix it so we meet the conformance level our public-sector client requires.",
+      "expected_skills": ["accessibility-plugin:accessibility-implementation"],
+      "acceptable_skills": ["configure-plugin:configure-ux-testing"],
+      "negative": false,
+      "tags": ["stratum:paraphrase", "domain:frontend"],
+      "provenance": "SKILL.md description of accessibility-plugin/skills/accessibility-implementation, read 2026-07-19; prompt hand-paraphrased"
+    },
+    {
+      "id": "t-dom-009",
+      "prompt": "I want automated checks that exercise our Express endpoints and assert on status codes and JSON bodies without standing up a real server — what's the idiomatic setup?",
+      "expected_skills": ["api-plugin:api-testing"],
+      "acceptable_skills": [
+        "configure-plugin:configure-api-tests",
+        "configure-plugin:configure-integration-tests"
+      ],
+      "negative": false,
+      "tags": ["stratum:paraphrase", "domain:backend"],
+      "provenance": "SKILL.md description of api-plugin/skills/api-testing, read 2026-07-19; prompt hand-paraphrased"
+    },
+    {
+      "id": "t-dom-010",
+      "prompt": "I'm building an assistant that moves through explicit stages, can pause for a person to approve a step, and picks up where it stopped after a crash. What framework pattern should I reach for?",
+      "expected_skills": ["langchain-plugin:langgraph-agents"],
+      "acceptable_skills": [
+        "langchain-plugin:langchain-development",
+        "langchain-plugin:deep-agents"
+      ],
+      "negative": false,
+      "tags": ["stratum:paraphrase", "domain:ai"],
+      "provenance": "SKILL.md description of langchain-plugin/skills/langgraph-agents, read 2026-07-19; prompt hand-paraphrased"
+    },
+    {
+      "id": "t-dom-011",
+      "prompt": "A chart upgrade died halfway and now the release refuses any further operation, claiming another operation is in progress — get me back to the last good version.",
+      "expected_skills": ["kubernetes-plugin:helm-release-recovery"],
+      "acceptable_skills": [
+        "kubernetes-plugin:helm-debugging",
+        "kubernetes-plugin:helm-release-management"
+      ],
+      "negative": false,
+      "tags": ["stratum:paraphrase", "domain:infra"],
+      "provenance": "SKILL.md description of kubernetes-plugin/skills/helm-release-recovery, read 2026-07-19; prompt hand-paraphrased"
+    },
+    {
+      "id": "t-dom-012",
+      "prompt": "Something errored overnight in one of our Terraform Cloud workspaces — pull down the console output from that execution so we can see what actually broke.",
+      "expected_skills": ["terraform-plugin:tfc-run-logs"],
+      "acceptable_skills": ["terraform-plugin:tfc-run-status", "terraform-plugin:tfc-list-runs"],
+      "negative": false,
+      "tags": ["stratum:paraphrase", "domain:infra"],
+      "provenance": "SKILL.md description of terraform-plugin/skills/tfc-run-logs, read 2026-07-19; prompt hand-paraphrased"
+    },
+    {
+      "id": "t-dom-013",
+      "prompt": "my python docker image is over a gig, shrink it",
+      "expected_skills": ["container-plugin:python-containers"],
+      "acceptable_skills": [
+        "container-plugin:container-development",
+        "configure-plugin:configure-dockerfile"
+      ],
+      "negative": false,
+      "tags": ["stratum:terse", "domain:infra"],
+      "provenance": "SKILL.md description of container-plugin/skills/python-containers, read 2026-07-19; prompt hand-paraphrased (terse variant)"
+    },
+    {
+      "id": "t-dom-014",
+      "prompt": "I changed a domain's mail-routing entries yesterday and some providers still answer with the old values — check what different public servers around the world are currently returning for it.",
+      "expected_skills": ["networking-plugin:dns-tools"],
+      "acceptable_skills": ["networking-plugin:network-diagnostics"],
+      "negative": false,
+      "tags": ["stratum:paraphrase", "domain:infra"],
+      "provenance": "SKILL.md description of networking-plugin/skills/dns-tools, read 2026-07-19; prompt hand-paraphrased"
+    },
+    {
+      "id": "t-dom-015",
+      "prompt": "why is the build red on main?",
+      "expected_skills": ["github-actions-plugin:github-actions-inspection"],
+      "acceptable_skills": ["git-plugin:gh-workflow-monitoring", "git-plugin:gh-cli-agentic"],
+      "negative": false,
+      "tags": ["stratum:terse", "domain:ci"],
+      "provenance": "SKILL.md description of github-actions-plugin/skills/github-actions-inspection, read 2026-07-19; prompt hand-paraphrased (terse variant)"
+    },
+    {
+      "id": "t-dom-016",
+      "prompt": "Our GitHub Actions bill doubled this quarter and I suspect a lot of executions are pointless — kicked off by automation accounts or duplicate pushes with nothing canceling the older ones. Find where the money goes and what to change.",
+      "expected_skills": ["finops-plugin:finops-waste"],
+      "acceptable_skills": [
+        "finops-plugin:github-actions-finops",
+        "finops-plugin:finops-workflows",
+        "finops-plugin:finops-overview"
+      ],
+      "negative": false,
+      "tags": ["stratum:paraphrase", "domain:ci"],
+      "provenance": "SKILL.md description of finops-plugin/skills/finops-waste, read 2026-07-19; prompt hand-paraphrased"
+    },
+    {
+      "id": "t-dom-017",
+      "prompt": "I found a great render in my ComfyUI outputs folder from weeks ago but have no idea which checkpoint or text input made it — can we dig that information out of the image file itself?",
+      "expected_skills": ["comfyui-plugin:comfy-metadata"],
+      "acceptable_skills": [],
+      "negative": false,
+      "tags": ["stratum:paraphrase", "domain:comfyui"],
+      "provenance": "SKILL.md description of comfyui-plugin/skills/comfy-metadata, read 2026-07-19; prompt hand-paraphrased"
+    },
+    {
+      "id": "t-dom-018",
+      "prompt": "My MacBook says only 8 GB remain, but adding up my folders in Finder gets nowhere near the drive's capacity — figure out where it all went and reclaim some of it.",
+      "expected_skills": ["macos-plugin:macos-disk-usage"],
+      "acceptable_skills": ["macos-plugin:macos-performance-triage"],
+      "negative": false,
+      "tags": ["stratum:paraphrase", "domain:host"],
+      "provenance": "SKILL.md description of macos-plugin/skills/macos-disk-usage, read 2026-07-19; prompt hand-paraphrased"
+    },
+    {
+      "id": "t-dom-019",
+      "prompt": "home assistant refuses to restart after my last edit",
+      "expected_skills": ["home-assistant-plugin:ha-validate"],
+      "acceptable_skills": ["home-assistant-plugin:ha-configuration"],
+      "negative": false,
+      "tags": ["stratum:terse", "domain:homeassistant"],
+      "provenance": "SKILL.md description of home-assistant-plugin/skills/ha-validate, read 2026-07-19; prompt hand-paraphrased (terse variant)"
+    },
+    {
+      "id": "t-dom-020",
+      "prompt": "A bunch of notes in my Obsidian vault have no connections in either direction — nothing points at them and they point at nothing. Help me hook them back into the rest of the knowledge network.",
+      "expected_skills": ["obsidian-plugin:vault-orphans"],
+      "acceptable_skills": ["obsidian-plugin:vault-mocs", "obsidian-plugin:search-discovery"],
+      "negative": false,
+      "tags": ["stratum:paraphrase", "domain:obsidian"],
+      "provenance": "SKILL.md description of obsidian-plugin/skills/vault-orphans, read 2026-07-19; prompt hand-paraphrased"
+    },
+    {
+      "id": "t-amb-001",
+      "prompt": "This is a Python repo — go over src/ with the linter, flag any code-quality problems, and apply the safe auto-fixes.",
+      "expected_skills": ["python-plugin:ruff-linting"],
+      "acceptable_skills": ["code-quality-plugin:code-lint", "python-plugin:python-code-quality"],
+      "negative": false,
+      "tags": ["stratum:ambiguity", "domain:linting"],
+      "provenance": "ambiguity-pair"
+    },
+    {
+      "id": "t-amb-002",
+      "prompt": "There's no lint tooling in this TypeScript repo at all yet — get a modern linter set up and hooked into the commit-time checks and the CI pipeline.",
+      "expected_skills": ["configure-plugin:configure-linting"],
+      "acceptable_skills": ["typescript-plugin:biome-tooling", "code-quality-plugin:code-lint"],
+      "negative": false,
+      "tags": ["stratum:ambiguity", "domain:linting"],
+      "provenance": "ambiguity-pair"
+    },
+    {
+      "id": "t-amb-003",
+      "prompt": "I just changed one small function — give me the fastest possible test feedback, skip anything slow, integration, or end-to-end.",
+      "expected_skills": ["testing-plugin:test-quick"],
+      "acceptable_skills": ["testing-plugin:test-run", "testing-plugin:test-tier-selection"],
+      "negative": false,
+      "tags": ["stratum:ambiguity", "domain:testing"],
+      "provenance": "ambiguity-pair"
+    },
+    {
+      "id": "t-amb-004",
+      "prompt": "This project runs on Bun — run its test suite and emit JUnit XML so CI can pick up the results.",
+      "expected_skills": ["typescript-plugin:bun-test"],
+      "acceptable_skills": ["testing-plugin:test-run", "typescript-plugin:bun-development"],
+      "negative": false,
+      "tags": ["stratum:ambiguity", "domain:testing"],
+      "provenance": "ambiguity-pair"
+    },
+    {
+      "id": "t-amb-005",
+      "prompt": "I want a sequence diagram of the auth flow that renders natively when people view the README on GitHub.",
+      "expected_skills": ["tools-plugin:mermaid-diagrams"],
+      "acceptable_skills": ["tools-plugin:d2-diagrams"],
+      "negative": false,
+      "tags": ["stratum:ambiguity", "domain:diagrams"],
+      "provenance": "ambiguity-pair"
+    },
+    {
+      "id": "t-amb-006",
+      "prompt": "Produce an architecture diagram of our deployment topology as a standalone SVG with auto-layout for the docs site.",
+      "expected_skills": ["tools-plugin:d2-diagrams"],
+      "acceptable_skills": ["tools-plugin:mermaid-diagrams"],
+      "negative": false,
+      "tags": ["stratum:ambiguity", "domain:diagrams"],
+      "provenance": "ambiguity-pair"
+    },
+    {
+      "id": "t-amb-007",
+      "prompt": "Our Python service's Docker image has ballooned past a gigabyte — get the size down without breaking the pip-installed native deps.",
+      "expected_skills": ["container-plugin:python-containers"],
+      "acceptable_skills": [
+        "container-plugin:container-development",
+        "configure-plugin:configure-dockerfile"
+      ],
+      "negative": false,
+      "tags": ["stratum:ambiguity", "domain:containers"],
+      "provenance": "ambiguity-pair"
+    },
+    {
+      "id": "t-amb-008",
+      "prompt": "This new repo needs a Dockerfile that follows our standards — it shouldn't run as the superuser, should build in stages, and should start from a minimal base image — write one and audit it.",
+      "expected_skills": ["configure-plugin:configure-dockerfile"],
+      "acceptable_skills": ["container-plugin:container-development"],
+      "negative": false,
+      "tags": ["stratum:ambiguity", "domain:containers"],
+      "provenance": "ambiguity-pair"
+    },
+    {
+      "id": "t-amb-009",
+      "prompt": "Stage what I changed and commit it locally with a proper conventional message that references the issue it fixes.",
+      "expected_skills": ["git-plugin:git-commit"],
+      "acceptable_skills": ["git-plugin:git-commit-workflow", "git-plugin:github-issue-autodetect"],
+      "negative": false,
+      "tags": ["stratum:ambiguity", "domain:git"],
+      "provenance": "ambiguity-pair"
+    },
+    {
+      "id": "t-amb-010",
+      "prompt": "The branch is already pushed — open a pull request for review with a good description, labels, and the linked issue.",
+      "expected_skills": ["git-plugin:git-pr"],
+      "acceptable_skills": ["git-plugin:git-branch-pr-workflow", "git-plugin:github-pr-title"],
+      "negative": false,
+      "tags": ["stratum:ambiguity", "domain:git"],
+      "provenance": "ambiguity-pair"
+    },
+    {
+      "id": "t-amb-011",
+      "prompt": "Hunt down unused exports, unreferenced files, and dependencies we no longer need in this TypeScript codebase.",
+      "expected_skills": ["typescript-plugin:knip-dead-code"],
+      "acceptable_skills": [
+        "code-quality-plugin:code-dead-code",
+        "configure-plugin:configure-dead-code"
+      ],
+      "negative": false,
+      "tags": ["stratum:ambiguity", "domain:dead-code"],
+      "provenance": "ambiguity-pair"
+    },
+    {
+      "id": "t-amb-012",
+      "prompt": "mypy is dragging this project down — move our type checking over to Astral's ty, config and pre-commit hook included.",
+      "expected_skills": ["migration-patterns-plugin:mypy-to-ty"],
+      "acceptable_skills": ["python-plugin:ty-type-checking", "python-plugin:python-code-quality"],
+      "negative": false,
+      "tags": ["stratum:ambiguity", "domain:type-checking"],
+      "provenance": "ambiguity-pair"
+    },
+    {
+      "id": "t-amb-013",
+      "prompt": "CI went red on main — pull the failed workflow run's logs and figure out which step broke and why.",
+      "expected_skills": ["github-actions-plugin:github-actions-inspection"],
+      "acceptable_skills": ["git-plugin:gh-workflow-monitoring", "finops-plugin:finops-workflows"],
+      "negative": false,
+      "tags": ["stratum:ambiguity", "domain:ci"],
+      "provenance": "ambiguity-pair"
+    },
+    {
+      "id": "t-amb-014",
+      "prompt": "Fresh checkout of this Bun project — install the dependencies exactly the way CI would, without touching the lockfile.",
+      "expected_skills": ["typescript-plugin:bun-install"],
+      "acceptable_skills": ["tools-plugin:deps-install", "typescript-plugin:bun-package-manager"],
+      "negative": false,
+      "tags": ["stratum:ambiguity", "domain:dependencies"],
+      "provenance": "ambiguity-pair"
+    },
+    {
+      "id": "t-amb-015",
+      "prompt": "This Python repo still formats with black — switch the formatting stack over to ruff and clean up the leftover config.",
+      "expected_skills": ["migration-patterns-plugin:black-to-ruff-format"],
+      "acceptable_skills": [
+        "python-plugin:ruff-formatting",
+        "configure-plugin:configure-formatting"
+      ],
+      "negative": false,
+      "tags": ["stratum:ambiguity", "domain:formatting"],
+      "provenance": "ambiguity-pair"
+    },
+    {
+      "id": "t-neg-001",
+      "prompt": "Why is this function returning undefined when I call it with an empty array? It works fine with non-empty input.",
+      "expected_skills": [],
+      "acceptable_skills": [],
+      "negative": true,
+      "tags": ["stratum:negative"],
+      "provenance": "authored 2026-07-19, negatives+excluded stratum; generic single-function debugging question — verified no skill covers ad-hoc logic debugging (code-quality-plugin:debugging-methodology is scoped to memory/perf/syscall-level; typescript-plugin:typescript-debugging is Bun inspector setup)"
+    },
+    {
+      "id": "t-neg-002",
+      "prompt": "Rename the variable usr to user everywhere in this file.",
+      "expected_skills": [],
+      "acceptable_skills": [],
+      "negative": true,
+      "tags": ["stratum:negative"],
+      "provenance": "authored 2026-07-19; single-file mechanical edit fully covered by base Edit tool — code-quality-plugin:bulk-sweep-classify is scoped to bulk cross-file sweeps, not one file"
+    },
+    {
+      "id": "t-neg-003",
+      "prompt": "What does CRDT stand for, and can you give me a one-paragraph explanation of how they avoid merge conflicts?",
+      "expected_skills": [],
+      "acceptable_skills": [],
+      "negative": true,
+      "tags": ["stratum:negative"],
+      "provenance": "authored 2026-07-19; pure conceptual Q&A, no operational task — no marketplace skill covers CS concept explanation"
+    },
+    {
+      "id": "t-neg-004",
+      "prompt": "Open src/config.ts and tell me what the default request timeout is set to.",
+      "expected_skills": [],
+      "acceptable_skills": [],
+      "negative": true,
+      "tags": ["stratum:negative"],
+      "provenance": "authored 2026-07-19; single-file lookup fully covered by base Read tool — verified rg/fd/jq tool skills target search workflows, not a named-file value lookup"
+    },
+    {
+      "id": "t-neg-005",
+      "prompt": "There's a typo in the README heading — 'Instalation' should be 'Installation'. Fix it.",
+      "expected_skills": [],
+      "acceptable_skills": [],
+      "negative": true,
+      "tags": ["stratum:negative"],
+      "provenance": "authored 2026-07-19; trivial edit via base tools — configure-plugin:configure-readme is for scaffolding/auditing README structure, not typo fixes (and is exclude-tier anyway)"
+    },
+    {
+      "id": "t-neg-006",
+      "prompt": "Thanks, that fixed it! Before we move on, can you briefly explain why the off-by-one happened in the loop bound?",
+      "expected_skills": [],
+      "acceptable_skills": [],
+      "negative": true,
+      "tags": ["stratum:negative"],
+      "provenance": "authored 2026-07-19; conversational follow-up asking for explanation of already-fixed bug — no skill should fire on acknowledgment + explanation requests"
+    },
+    {
+      "id": "t-neg-007",
+      "prompt": "What's the practical difference between TCP and UDP, and when would I pick one over the other for a game server?",
+      "expected_skills": [],
+      "acceptable_skills": [],
+      "negative": true,
+      "tags": ["stratum:negative"],
+      "provenance": "authored 2026-07-19; conceptual networking question — networking-plugin skills are all operational (dig/nmap/iproute2/oha diagnostics), none covers protocol theory Q&A"
+    },
+    {
+      "id": "t-neg-008",
+      "prompt": "Convert this for-loop into a while loop so I can add an early-exit condition halfway through the body.",
+      "expected_skills": [],
+      "acceptable_skills": [],
+      "negative": true,
+      "tags": ["stratum:negative"],
+      "provenance": "authored 2026-07-19; trivial in-place syntax change via base Edit — code-quality-plugin:code-refactor is scoped to pure-function/immutability/composition refactors, not loop-form swaps"
+    },
+    {
+      "id": "t-exc-001",
+      "prompt": "Every commit in this Python repo should get automatically checked for lint and formatting problems before it lands — install the framework that does that and give me a working config.",
+      "expected_skills": ["configure-plugin:configure-pre-commit"],
+      "acceptable_skills": ["configure-plugin:configure-linting"],
+      "negative": false,
+      "tags": ["stratum:excluded"],
+      "provenance": "authored 2026-07-19; configure-plugin is tier: exclude in pi/tiers.yaml (reason: CC onboarding config); configure-pre-commit/SKILL.md verified to lack compatibility: claude-code marker, so it IS in the adapter's foreign-harness index while the pi general baseline fails closed"
+    },
+    {
+      "id": "t-exc-002",
+      "prompt": "My MacBook keeps warning that the disk is almost full but Finder gives me no clue which folders are responsible — track it down and free up what you safely can.",
+      "expected_skills": ["macos-plugin:macos-disk-usage"],
+      "acceptable_skills": [],
+      "negative": false,
+      "tags": ["stratum:excluded"],
+      "provenance": "authored 2026-07-19; macos-plugin is tier: domain (category: host) in pi/tiers.yaml — never in the pi general baseline; SKILL.md carries no compatibility marker"
+    },
+    {
+      "id": "t-exc-003",
+      "prompt": "I renamed a bunch of notes in my Obsidian vault and now lots of [[wikilinks]] point at nothing — find the broken ones and repair them.",
+      "expected_skills": ["obsidian-plugin:vault-wikilinks"],
+      "acceptable_skills": ["obsidian-plugin:search-discovery"],
+      "negative": false,
+      "tags": ["stratum:excluded"],
+      "provenance": "authored 2026-07-19; obsidian-plugin is tier: domain (category: obsidian) — outside the pi general baseline; no compatibility marker; search-discovery accepted as it also advertises broken-wikilink audit"
+    },
+    {
+      "id": "t-exc-004",
+      "prompt": "In my Home Assistant setup I want the balcony lights to come on at sunset and switch off at midnight — write the automation for me.",
+      "expected_skills": ["home-assistant-plugin:ha-automations"],
+      "acceptable_skills": [],
+      "negative": false,
+      "tags": ["stratum:excluded"],
+      "provenance": "authored 2026-07-19; home-assistant-plugin is tier: domain (category: homeassistant) — outside the pi general baseline; no compatibility marker"
+    },
+    {
+      "id": "t-exc-005",
+      "prompt": "I want to expose our internal ticketing API to the agent over MCP, in Python — scaffold the service with FastMCP and give it operations for creating and searching tickets.",
+      "expected_skills": ["agent-patterns-plugin:mcp-server-authoring"],
+      "acceptable_skills": [],
+      "negative": false,
+      "tags": ["stratum:excluded"],
+      "provenance": "authored 2026-07-19; agent-patterns-plugin is tier: exclude in pi/tiers.yaml, but mcp-server-authoring is one of five skills in it verified to LACK the compatibility: claude-code marker (MCP is harness-agnostic) — so it is in the adapter index while pi's baseline drops the whole plugin"
+    },
+    {
+      "id": "t-exc-006",
+      "prompt": "Before we hand this feature off to a subagent, put together a full requirement prompt packet for it — background research, the relevant codebase context, and explicit validation gates it must pass.",
+      "expected_skills": ["blueprint-plugin:blueprint-prp-create"],
+      "acceptable_skills": ["blueprint-plugin:confidence-scoring"],
+      "negative": false,
+      "tags": ["stratum:excluded"],
+      "provenance": "authored 2026-07-19; blueprint-plugin is tier: exclude (whole 34-skill plugin dropped from pi); blueprint-prp-create/SKILL.md verified marker-free; intent paraphrases the PRP concept without naming it"
+    },
+    {
+      "id": "t-exc-007",
+      "prompt": "Pin the Node and Python versions for this repo with mise so everyone gets the same toolchain, and add a couple of task shortcuts while you're at it.",
+      "expected_skills": ["configure-plugin:configure-mise"],
+      "acceptable_skills": [],
+      "negative": false,
+      "tags": ["stratum:excluded"],
+      "provenance": "authored 2026-07-19; configure-plugin is tier: exclude; configure-mise verified marker-free (mise setup is harness-agnostic despite the plugin's CC-centric exclude reason) — measures adapter headroom over the baseline"
+    },
+    {
+      "id": "t-exc-008",
+      "prompt": "I just changed the MX records for our domain about an hour ago — check whether the change has actually propagated across the major public resolvers.",
+      "expected_skills": ["networking-plugin:dns-tools"],
+      "acceptable_skills": [],
+      "negative": false,
+      "tags": ["stratum:excluded"],
+      "provenance": "authored 2026-07-19; networking-plugin is tier: domain (category: infra) — outside the pi general baseline; no compatibility marker; dns-tools description explicitly covers MX lookup + propagation verification across resolvers"
+    }
+  ]
+}

--- a/adapters/package.json
+++ b/adapters/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@laurigates/claude-plugins-adapters",
+  "private": true,
+  "type": "module",
+  "description": "Harness-agnostic skill-discovery core + eval harness for ADR-0022 (pi/OpenCode bindings land in #2090/#2091)",
+  "scripts": {
+    "check": "bunx tsc --noEmit && bunx biome ci .",
+    "eval": "bun eval/run-eval.ts",
+    "eval:hybrid": "bun eval/run-eval.ts --with-embeddings"
+  },
+  "dependencies": {
+    "@opencode-ai/plugin": "^1.18.3",
+    "typebox": "^1.1"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.4",
+    "@earendil-works/pi-coding-agent": "^0.80.10",
+    "@types/bun": "^1.3.14",
+    "typescript": "^5.9.3"
+  }
+}

--- a/adapters/package.json
+++ b/adapters/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@opencode-ai/plugin": "^1.18.3",
-    "typebox": "^1.1"
+    "typebox": "~1.1.38"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.4",

--- a/adapters/tests/bm25.test.ts
+++ b/adapters/tests/bm25.test.ts
@@ -1,0 +1,142 @@
+/**
+ * BM25 tests (DESIGN §7.1): hand-computed golden values, boundary cases, and
+ * the committed rank_bm25 rank-order diff fixture.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { BM25_B, BM25_K1, Bm25Index, tokenize } from "../core/bm25.ts";
+
+describe("tokenize", () => {
+  test("lowercases, splits on non-alphanumerics, drops empties", () => {
+    expect(tokenize("Git-Commit: push_it 2x!")).toEqual(["git", "commit", "push", "it", "2x"]);
+    expect(tokenize("")).toEqual([]);
+    expect(tokenize("---")).toEqual([]);
+  });
+});
+
+describe("hand-computed golden (3-doc toy corpus)", () => {
+  // Corpus: d0 = "cat dog" (len 2), d1 = "cat cat" (len 2), d2 = "bird" (len 1).
+  // N = 3, avgdl = 5/3, k1 = 1.2, b = 0.75.
+  //
+  // Lucene IDF: idf(t) = ln(1 + (N - df + 0.5)/(df + 0.5))
+  //   idf(cat)  = ln(1 + 1.5/2.5) = ln(1.6)   = 0.47000362924573563
+  //   idf(dog)  = ln(1 + 2.5/1.5) = ln(8/3)   = 0.9808292530117263
+  //
+  // Term score: idf · tf·(k1+1) / (tf + k1·(1 − b + b·|d|/avgdl))
+  //   |d|=2: k1-norm = 1.2·(0.25 + 0.75·2/(5/3)) = 1.2·1.15 = 1.38
+  //   q="cat", d0 (tf=1): 0.470004·(1·2.2)/(1+1.38)  = 0.4344571362775708
+  //   q="cat", d1 (tf=2): 0.470004·(2·2.2)/(2+1.38)  = 0.6118390439885316
+  //   q="dog", d0 (tf=1): 0.980829·2.2/2.38          = 0.9066488893385706
+  //   q="bird", d2 (tf=1, |d|=1): norm=1.2·(0.25+0.45)=0.84; 0.980829·2.2/1.84
+  //                                                  = 1.1727306286009773
+  //   q="cat dog", d0: 0.4344571… + 0.9066488…       = 1.3411060256161413
+  const index = new Bm25Index(["cat dog", "cat cat", "bird"]);
+
+  test("constants are the Robertson & Zaragoza defaults", () => {
+    expect(BM25_K1).toBe(1.2);
+    expect(BM25_B).toBe(0.75);
+  });
+
+  test("q=cat scores both cat docs exactly", () => {
+    const scored = index.score("cat");
+    expect(scored).toHaveLength(2);
+    expect(scored[0]?.docIdx).toBe(1);
+    expect(scored[0]?.score).toBeCloseTo(0.6118390439885316, 9);
+    expect(scored[1]?.docIdx).toBe(0);
+    expect(scored[1]?.score).toBeCloseTo(0.4344571362775708, 9);
+  });
+
+  test("q=dog scores only d0", () => {
+    const scored = index.score("dog");
+    expect(scored).toHaveLength(1);
+    expect(scored[0]?.docIdx).toBe(0);
+    expect(scored[0]?.score).toBeCloseTo(0.9066488893385706, 9);
+  });
+
+  test("q=bird scores the short doc with its own length norm", () => {
+    const scored = index.score("bird");
+    expect(scored[0]?.docIdx).toBe(2);
+    expect(scored[0]?.score).toBeCloseTo(1.1727306286009773, 9);
+  });
+
+  test("multi-term query accumulates per-term contributions", () => {
+    const scored = index.score("cat dog");
+    expect(scored[0]?.docIdx).toBe(0);
+    expect(scored[0]?.score).toBeCloseTo(1.3411060256161413, 9);
+  });
+});
+
+describe("boundary cases", () => {
+  test("term in all docs keeps a non-negative score (Lucene IDF property)", () => {
+    const index = new Bm25Index(["use git", "use jq", "use rg"]);
+    for (const { score } of index.score("use")) {
+      expect(score).toBeGreaterThanOrEqual(0);
+    }
+    expect(index.idf("use")).toBeGreaterThan(0);
+  });
+
+  test("empty query returns empty result", () => {
+    const index = new Bm25Index(["cat dog"]);
+    expect(index.score("")).toEqual([]);
+    expect(index.score("!!!")).toEqual([]);
+  });
+
+  test("query term absent from corpus contributes nothing", () => {
+    const index = new Bm25Index(["cat dog"]);
+    expect(index.score("elephant")).toEqual([]);
+  });
+
+  test("single-doc corpus scores without dividing by zero", () => {
+    const index = new Bm25Index(["lonely document"]);
+    const scored = index.score("lonely");
+    expect(scored).toHaveLength(1);
+    expect(scored[0]?.score).toBeGreaterThan(0);
+    expect(Number.isFinite(scored[0]?.score)).toBe(true);
+  });
+});
+
+describe("rank_bm25 reference diff", () => {
+  // The design called for rank-order equality between the SHIPPED (Lucene
+  // IDF) scorer and rank_bm25 (epsilon-floored classic IDF). Empirically the
+  // two IDF curves legitimately reorder close-scored multi-term documents
+  // (4/10 realistic queries diverge in the tail), so exact cross-variant rank
+  // equality is impossible by construction — recorded design deviation.
+  //
+  // The sound split, preserving the diff-test's verification intent:
+  //  (1) scoring with rank_bm25's OWN IDF (the "classic-rank-bm25" test seam)
+  //      must reproduce the reference ranking EXACTLY — this validates the
+  //      whole shared machinery (tokenizer, postings, tf, length norm,
+  //      accumulation, tie-breaking) against genuine rank_bm25 output;
+  //  (2) the shipped Lucene-IDF path is pinned by the hand-computed goldens
+  //      above, and must still agree with the reference on nonzero-membership
+  //      and the top-1 result for every fixture query.
+  interface Fixture {
+    corpus: Array<{ id: string; text: string }>;
+    cases: Array<{ query: string; expected_rank_order: number[] }>;
+  }
+  const fixture = JSON.parse(
+    readFileSync(join(import.meta.dir, "fixtures", "bm25-reference.json"), "utf8"),
+  ) as Fixture;
+  const docs = fixture.corpus.map((d) => d.text);
+  const classicIndex = new Bm25Index(docs, "classic-rank-bm25");
+  const shippedIndex = new Bm25Index(docs);
+
+  test.each(fixture.cases.map((c) => [c.query, c.expected_rank_order] as const))(
+    "classic-IDF seam reproduces rank_bm25 exactly for %j",
+    (query, expectedOrder) => {
+      const ours = classicIndex.score(query).map((s) => s.docIdx);
+      expect(ours).toEqual(expectedOrder);
+    },
+  );
+
+  test.each(fixture.cases.map((c) => [c.query, c.expected_rank_order] as const))(
+    "shipped Lucene-IDF ranking agrees on membership and top-1 for %j",
+    (query, expectedOrder) => {
+      const ours = shippedIndex.score(query).map((s) => s.docIdx);
+      expect([...ours].sort((a, b) => a - b)).toEqual([...expectedOrder].sort((a, b) => a - b));
+      expect(ours[0]).toBe(expectedOrder[0] as number);
+    },
+  );
+});

--- a/adapters/tests/cache.test.ts
+++ b/adapters/tests/cache.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Embedding-cache tests (DESIGN §7.3): key invalidation on every keyed
+ * dimension, atomic writes, self-pruning rewrite, corrupt-file recovery.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { cacheFilePath, entryKey, loadCache, saveCache } from "../core/cache.ts";
+
+const BASE = {
+  model: "nomic-embed-text",
+  dims: 768,
+  prefixScheme: "search_document:/search_query:",
+  skillName: "git-commit",
+  description: "Commit staged changes.",
+};
+
+describe("entryKey", () => {
+  test("unchanged content hits the same key", () => {
+    expect(entryKey({ ...BASE })).toBe(entryKey({ ...BASE }));
+  });
+
+  test.each([
+    ["description", { description: "Commit staged changes!" }],
+    ["model", { model: "nomic-embed-text:v2" }],
+    ["dims", { dims: 256 }],
+    ["prefixScheme", { prefixScheme: "document:/query:" }],
+    ["skillName", { skillName: "git-commit-workflow" }],
+  ] as const)("changing %s produces a different key", (_label, delta) => {
+    expect(entryKey({ ...BASE, ...delta })).not.toBe(entryKey(BASE));
+  });
+
+  test("field-boundary collisions are impossible (NUL-joined material)", () => {
+    // "ab" + "c" vs "a" + "bc" must not collide.
+    const a = entryKey({ ...BASE, skillName: "ab", description: "c" });
+    const b = entryKey({ ...BASE, skillName: "a", description: "bc" });
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("cacheFilePath", () => {
+  test("is keyed per repo path, under the given cache dir", () => {
+    const a = cacheFilePath("/repo/one", "/cache");
+    const b = cacheFilePath("/repo/two", "/cache");
+    expect(a).not.toBe(b);
+    expect(a.startsWith("/cache/")).toBe(true);
+    expect(a.endsWith(".json")).toBe(true);
+  });
+});
+
+describe("save/load", () => {
+  test("round-trips and leaves no .tmp behind (atomic write)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "adapters-cache-"));
+    const file = join(dir, "cache.json");
+    const cache = { version: 1, model: "m", dims: 4, entries: { abc: [1, 2, 3, 4] } };
+    saveCache(file, cache);
+    expect(loadCache(file)).toEqual(cache);
+    expect(existsSync(`${file}.tmp`)).toBe(false);
+    expect(readdirSync(dir)).toEqual(["cache.json"]);
+  });
+
+  test("rewrite drops entries absent from the current corpus (self-prune)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "adapters-cache-"));
+    const file = join(dir, "cache.json");
+    saveCache(file, { version: 1, model: "m", dims: 2, entries: { old: [1, 2], keep: [3, 4] } });
+    // A build rewrites with only-current entries:
+    saveCache(file, { version: 1, model: "m", dims: 2, entries: { keep: [3, 4] } });
+    expect(Object.keys(loadCache(file)?.entries ?? {})).toEqual(["keep"]);
+  });
+
+  test("a simulated partial write does not corrupt the committed file", () => {
+    const dir = mkdtempSync(join(tmpdir(), "adapters-cache-"));
+    const file = join(dir, "cache.json");
+    saveCache(file, { version: 1, model: "m", dims: 2, entries: { a: [1, 2] } });
+    // Simulate a crash mid-write: a truncated .tmp exists but was never renamed.
+    writeFileSync(`${file}.tmp`, '{"version":1,"model":"m","dims":2,"entr');
+    expect(loadCache(file)?.entries.a).toEqual([1, 2]);
+  });
+
+  test("corrupt cache file is treated as empty (rebuild, no crash)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "adapters-cache-"));
+    const file = join(dir, "cache.json");
+    writeFileSync(file, "not json at all {{{");
+    expect(loadCache(file)).toBeNull();
+    writeFileSync(file, '"a bare string"');
+    expect(loadCache(file)).toBeNull();
+  });
+
+  test("missing cache file loads as empty", () => {
+    expect(loadCache("/nonexistent/path/cache.json")).toBeNull();
+  });
+});

--- a/adapters/tests/embeddings.test.ts
+++ b/adapters/tests/embeddings.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Embeddings client + fallback tests (DESIGN §7.4): the full fallback matrix
+ * (ECONNREFUSED, non-2xx, JSON error body, timeout) each degrading to
+ * bm25-only with a functioning search(); prefix correctness asserted by a
+ * mock /api/embed server; the hybrid happy path through the cache.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { cpSync, existsSync, mkdtempSync, readdirSync, renameSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  EmbedUnavailableError,
+  embedBatch,
+  embedDocuments,
+  embedQuery,
+  probeEndpoint,
+} from "../core/embeddings.ts";
+import { buildIndex } from "../core/search.ts";
+
+const FIXTURE_SRC = join(import.meta.dir, "fixtures", "mini-marketplace-src");
+const DIMS = 8;
+
+let fixtureRoot = "";
+let cacheDir = "";
+
+/** Deterministic per-input mock embedding: seeded by input length + char sum. */
+function mockVector(input: string): number[] {
+  let seed = input.length;
+  for (let i = 0; i < input.length; i++) seed = (seed * 31 + input.charCodeAt(i)) >>> 0;
+  return Array.from({ length: DIMS }, (_, j) => ((seed >> j) % 17) + 1);
+}
+
+interface MockState {
+  receivedInputs: string[][];
+  mode: "ok" | "http500" | "errorBody" | "stall";
+}
+
+const state: MockState = { receivedInputs: [], mode: "ok" };
+let server: ReturnType<typeof Bun.serve>;
+let endpoint = "";
+
+beforeAll(() => {
+  fixtureRoot = mkdtempSync(join(tmpdir(), "mini-marketplace-embed-"));
+  cpSync(FIXTURE_SRC, fixtureRoot, { recursive: true });
+  for (const entry of readdirSync(fixtureRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const src = join(fixtureRoot, entry.name, "skilldirs");
+    if (existsSync(src)) renameSync(src, join(fixtureRoot, entry.name, "skills"));
+  }
+  cacheDir = mkdtempSync(join(tmpdir(), "adapters-embed-cache-"));
+
+  server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname !== "/api/embed") return new Response("not found", { status: 404 });
+      if (state.mode === "http500") return new Response("boom", { status: 500 });
+      if (state.mode === "errorBody") {
+        return Response.json({ error: "model not pulled" });
+      }
+      if (state.mode === "stall") {
+        await new Promise((resolveSleep) => setTimeout(resolveSleep, 5_000));
+      }
+      const body = (await req.json()) as { model: string; input: string[] };
+      state.receivedInputs.push(body.input);
+      return Response.json({ model: body.model, embeddings: body.input.map(mockVector) });
+    },
+  });
+  endpoint = `http://localhost:${server.port}`;
+});
+
+afterAll(() => {
+  server?.stop(true);
+});
+
+const opts = () => ({ endpoint, model: "mock-embed", dimensions: DIMS });
+
+describe("prefix correctness", () => {
+  test("documents are sent with search_document: and queries with search_query:", async () => {
+    state.mode = "ok";
+    state.receivedInputs = [];
+    await embedDocuments(["alpha skill", "beta skill"], opts());
+    await embedQuery("do the thing", opts());
+    expect(state.receivedInputs[0]).toEqual([
+      "search_document: alpha skill",
+      "search_document: beta skill",
+    ]);
+    expect(state.receivedInputs[1]).toEqual(["search_query: do the thing"]);
+  });
+});
+
+describe("fallback matrix", () => {
+  test("ECONNREFUSED (unbound port) throws EmbedUnavailableError", async () => {
+    const dead = { endpoint: "http://127.0.0.1:9", model: "mock-embed" };
+    expect(embedBatch(["x"], dead, 2_000)).rejects.toBeInstanceOf(EmbedUnavailableError);
+    expect(await probeEndpoint(dead)).toBe(false);
+  });
+
+  test("non-2xx status throws EmbedUnavailableError", async () => {
+    state.mode = "http500";
+    expect(embedBatch(["x"], opts())).rejects.toBeInstanceOf(EmbedUnavailableError);
+    expect(await probeEndpoint(opts())).toBe(false);
+  });
+
+  test("JSON error body (model not pulled) throws EmbedUnavailableError", async () => {
+    state.mode = "errorBody";
+    expect(embedBatch(["x"], opts())).rejects.toBeInstanceOf(EmbedUnavailableError);
+    expect(await probeEndpoint(opts())).toBe(false);
+  });
+
+  test("timeout (stalled server) throws EmbedUnavailableError", async () => {
+    state.mode = "stall";
+    expect(embedBatch(["x"], opts(), 300)).rejects.toBeInstanceOf(EmbedUnavailableError);
+    state.mode = "ok";
+  });
+
+  test("each failure mode yields mode bm25-only with a functioning search()", async () => {
+    for (const brokenEndpoint of ["http://127.0.0.1:9"]) {
+      const index = await buildIndex({
+        repoRoot: fixtureRoot,
+        embed: { endpoint: brokenEndpoint, model: "mock-embed", dimensions: DIMS },
+        cacheDir,
+      });
+      expect(index.mode).toBe("bm25-only");
+      expect(index.embeddingRanker()).toBeNull();
+      const results = await index.search("commit staged changes", 3);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0]?.id).toBe("alpha-plugin:normal-skill");
+    }
+    for (const mode of ["http500", "errorBody"] as const) {
+      state.mode = mode;
+      const index = await buildIndex({
+        repoRoot: fixtureRoot,
+        embed: { endpoint, model: "mock-embed", dimensions: DIMS },
+        cacheDir,
+      });
+      expect(index.mode).toBe("bm25-only");
+      const results = await index.search("commit staged changes", 3);
+      expect(results.length).toBeGreaterThan(0);
+    }
+    state.mode = "ok";
+  });
+
+  test("embed.disabled forces bm25-only with zero network", async () => {
+    state.receivedInputs = [];
+    const index = await buildIndex({
+      repoRoot: fixtureRoot,
+      embed: { disabled: true },
+      cacheDir,
+    });
+    expect(index.mode).toBe("bm25-only");
+    expect(state.receivedInputs).toEqual([]);
+  });
+});
+
+describe("hybrid happy path", () => {
+  test("buildIndex probes, batch-embeds misses once, writes the cache, and fuses", async () => {
+    state.mode = "ok";
+    state.receivedInputs = [];
+    const freshCache = mkdtempSync(join(tmpdir(), "adapters-embed-cache2-"));
+    const index = await buildIndex({
+      repoRoot: fixtureRoot,
+      embed: { endpoint, model: "mock-embed", dimensions: DIMS },
+      cacheDir: freshCache,
+    });
+    expect(index.mode).toBe("hybrid");
+    expect(index.embeddingRanker()).not.toBeNull();
+    // probe (1 input) + one batched corpus call (4 foreign entries)
+    const batchCalls = state.receivedInputs.filter((batch) => batch.length > 1);
+    expect(batchCalls).toHaveLength(1);
+    expect(batchCalls[0]).toHaveLength(4);
+
+    const results = await index.search("commit staged changes", 3);
+    expect(results.length).toBeGreaterThan(0);
+    // Hybrid mode returns RRF scores (rank-derived, bounded by lists/(k+1)).
+    expect(results[0]?.score).toBeLessThan(1);
+
+    // Second build: cache hit — no new multi-input batch call.
+    const callsBefore = state.receivedInputs.length;
+    const index2 = await buildIndex({
+      repoRoot: fixtureRoot,
+      embed: { endpoint, model: "mock-embed", dimensions: DIMS },
+      cacheDir: freshCache,
+    });
+    expect(index2.mode).toBe("hybrid");
+    const newBatches = state.receivedInputs.slice(callsBefore).filter((b) => b.length > 1);
+    expect(newBatches).toEqual([]);
+  });
+});

--- a/adapters/tests/eval-meta.test.ts
+++ b/adapters/tests/eval-meta.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Eval meta-tests (DESIGN §5.5) — the CI teeth, per
+ * validate-adversarial-constructions (both halves: broken-fails AND
+ * correct-passes). The cutover comparison itself is the §5.6 local
+ * procedure, not CI.
+ */
+
+import { beforeAll, describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tokenize } from "../core/bm25.ts";
+import { parseFrontmatter } from "../core/frontmatter.ts";
+import type { SkillIndex } from "../core/search.ts";
+import { buildIndex } from "../core/search.ts";
+import type { Ranker } from "../core/types.ts";
+import { DEFAULT_K } from "../core/types.ts";
+import {
+  countExportedOcSkills,
+  deriveOcBaseline,
+  derivePiBaseline,
+  listingTokens,
+} from "../eval/baseline.ts";
+import {
+  bm25OnlyRanker,
+  descriptionSubstringRanker,
+  type EvalTask,
+  nameSubstringRanker,
+  oracleRanker,
+  randomRanker,
+} from "../eval/rankers.ts";
+import { loadTaskSet, TASKS_PATH, validateTaskSet } from "../eval/run-eval.ts";
+
+const REPO_ROOT = resolve(import.meta.dir, "..", "..");
+
+const taskSet = loadTaskSet(TASKS_PATH);
+const positiveTasks = taskSet.tasks.filter((t) => !t.negative);
+let index: SkillIndex;
+
+beforeAll(async () => {
+  index = await buildIndex({ repoRoot: REPO_ROOT, embed: { disabled: true } });
+});
+
+async function hitAtK(ranker: Ranker, tasks: EvalTask[]): Promise<number> {
+  let hits = 0;
+  for (const task of tasks) {
+    const ids = (await ranker(task.prompt, DEFAULT_K)).map((r) => r.id);
+    const targets = new Set([...task.expected_skills, ...task.acceptable_skills]);
+    if (ids.some((id) => targets.has(id))) hits++;
+  }
+  return hits / tasks.length;
+}
+
+async function hitAt1Expected(ranker: Ranker, tasks: EvalTask[]): Promise<number> {
+  let hits = 0;
+  for (const task of tasks) {
+    const ids = (await ranker(task.prompt, DEFAULT_K)).map((r) => r.id);
+    if (ids.length > 0 && task.expected_skills.includes(ids[0] as string)) hits++;
+  }
+  return hits / tasks.length;
+}
+
+describe("5. schema checks", () => {
+  test("task set passes every schema check (gate block, acceptable_skills, tags, k === DEFAULT_K, unique ids)", () => {
+    expect(validateTaskSet(taskSet)).toEqual([]);
+    expect(taskSet.k).toBe(DEFAULT_K);
+  });
+
+  test("every expected/acceptable skill id resolves to a real SKILL.md", () => {
+    const missing: string[] = [];
+    for (const task of taskSet.tasks) {
+      for (const id of [...task.expected_skills, ...task.acceptable_skills]) {
+        const [plugin, skill] = id.split(":", 2) as [string, string];
+        const p = join(REPO_ROOT, plugin, "skills", skill, "SKILL.md");
+        if (!existsSync(p)) missing.push(`${task.id}: ${id}`);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  const distPresent = countExportedOcSkills(REPO_ROOT) !== null;
+  test.skipIf(!distPresent)(
+    "derived OC baseline count matches the export's OUTPUT_SKILLS accounting (dist/ present)",
+    () => {
+      const derived = deriveOcBaseline(REPO_ROOT).ids.size;
+      expect(countExportedOcSkills(REPO_ROOT)).toBe(derived);
+    },
+  );
+});
+
+describe("1. random fails every seed; oracle passes", () => {
+  // Chance bound: k · max|E∪A| / N (DESIGN §5.5.1 — NOT the single-target
+  // 1.25%). At authoring time: k=5, max targets 4, N=363 foreign entries →
+  // ~5.5% worst case; measured random hit@5 max over seeds 0..19 was 7.9%.
+  // The per-seed ceiling is 3× the bound (~16.5%) — far above sampling noise
+  // on ~63 tasks, far below bm25Only (55.6%) and the oracle (100%).
+  test("random(seed) stays at chance level with margin on ALL 20 seeds", async () => {
+    const maxTargets = Math.max(
+      ...positiveTasks.map((t) => t.expected_skills.length + t.acceptable_skills.length),
+    );
+    const chanceBound = (DEFAULT_K * maxTargets) / index.entries.length;
+    const ceiling = 3 * chanceBound;
+    for (let seed = 0; seed < 20; seed++) {
+      const hit = await hitAtK(randomRanker(index, seed), positiveTasks);
+      expect(hit).toBeLessThanOrEqual(ceiling);
+    }
+  });
+
+  test("oracle scores 100% on hit@k AND hit@1", async () => {
+    const oracle = oracleRanker(index, taskSet.tasks);
+    expect(await hitAtK(oracle, positiveTasks)).toBe(1);
+    expect(await hitAt1Expected(oracle, positiveTasks)).toBe(1);
+  });
+});
+
+describe("2. substring rankers lose to bm25Only", () => {
+  test("nameSubstring scores materially below bm25Only on stratum:paraphrase (no name echo)", async () => {
+    const paraphrase = positiveTasks.filter((t) => t.tags.includes("stratum:paraphrase"));
+    expect(paraphrase.length).toBeGreaterThan(10);
+    const bm25 = await hitAtK(bm25OnlyRanker(index), paraphrase);
+    const nameSub = await hitAtK(nameSubstringRanker(index), paraphrase);
+    // Measured at authoring time: bm25 0.406 vs nameSubstring 0.094.
+    expect(nameSub).toBeLessThanOrEqual(bm25 - 0.15);
+  });
+
+  test("descriptionSubstring scores materially below bm25Only across ALL strata (no description echo)", async () => {
+    const bm25 = await hitAtK(bm25OnlyRanker(index), positiveTasks);
+    const descSub = await hitAtK(descriptionSubstringRanker(index), positiveTasks);
+    // Measured at authoring time: bm25 0.556 vs descriptionSubstring 0.460
+    // (gap 0.096). The 0.05 margin is what the measured corpus supports; if
+    // this narrows on a task-set change, re-derive per §5.5 ("the simulation
+    // wins") rather than deleting the assertion.
+    expect(descSub).toBeLessThanOrEqual(bm25 - 0.05);
+  });
+});
+
+describe("3. token calibration (per-skill)", () => {
+  const piBaseline = derivePiBaseline(REPO_ROOT);
+  test.skipIf(piBaseline === null)(
+    "mean rendered tokens/skill over the runtime-derived general tier ∈ 111 ± 20%",
+    () => {
+      // 111 tok/skill was measured on pi 0.80.6 with a real tokenizer. Our
+      // chars/4 proxy over the same render measured −13.6% vs that (94.6
+      // tok/skill over the then-95-skill tier; 104.0 at authoring time with
+      // this checkout's absolute paths) — inside the ±20% band [88.8, 133.2].
+      // Record the offset so future drift is interpretable: a breach means
+      // either the render template diverged from what pi injects, or the
+      // tier's description profile shifted materially.
+      const { perSkillMean } = listingTokens((piBaseline as NonNullable<typeof piBaseline>).skills);
+      expect(perSkillMean).toBeGreaterThanOrEqual(111 * 0.8);
+      expect(perSkillMean).toBeLessThanOrEqual(111 * 1.2);
+    },
+  );
+
+  test.skipIf(piBaseline !== null)("SKIPPED: pi/tiers.yaml absent (post-#2093 degradation)", () => {
+    console.warn("pi/tiers.yaml absent — calibration meta-test skipped (BASELINE_ARM=ABSENT)");
+  });
+});
+
+describe("4. leakage lint (deterministic)", () => {
+  test("no non-negative task shares a token trigram with a target's name+description", () => {
+    const trigrams = (tokens: string[]) => {
+      const set = new Set<string>();
+      for (let i = 0; i + 2 < tokens.length; i++) {
+        set.add(`${tokens[i]} ${tokens[i + 1]} ${tokens[i + 2]}`);
+      }
+      return set;
+    };
+    const offenders: string[] = [];
+    for (const task of positiveTasks) {
+      const promptTrigrams = trigrams(tokenize(task.prompt));
+      for (const id of [...task.expected_skills, ...task.acceptable_skills]) {
+        const [plugin, skill] = id.split(":", 2) as [string, string];
+        const skillPath = join(REPO_ROOT, plugin, "skills", skill, "SKILL.md");
+        if (!existsSync(skillPath)) continue; // covered by the schema check
+        const fm = parseFrontmatter(readFileSync(skillPath, "utf8")) ?? {};
+        const doc = `${fm.name ?? skill} ${fm.description ?? ""}`;
+        const shared = [...promptTrigrams].filter((t) => trigrams(tokenize(doc)).has(t));
+        if (shared.length > 0) {
+          offenders.push(`${task.id} vs ${id}: ${shared.join("; ")}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/adapters/tests/eval-meta.test.ts
+++ b/adapters/tests/eval-meta.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { beforeAll, describe, expect, test } from "bun:test";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { tokenize } from "../core/bm25.ts";
 import { parseFrontmatter } from "../core/frontmatter.ts";
@@ -77,14 +77,54 @@ describe("5. schema checks", () => {
     expect(missing).toEqual([]);
   });
 
-  const distPresent = countExportedOcSkills(REPO_ROOT) !== null;
-  test.skipIf(!distPresent)(
-    "derived OC baseline count matches the export's OUTPUT_SKILLS accounting (dist/ present)",
-    () => {
-      const derived = deriveOcBaseline(REPO_ROOT).ids.size;
-      expect(countExportedOcSkills(REPO_ROOT)).toBe(derived);
-    },
-  );
+  test("every expected/acceptable skill id is present in the built foreign index (reachable by real rankers)", () => {
+    // Disk existence alone is not enough: a target carrying
+    // `compatibility: claude-code` (or lacking a description) is out of the
+    // foreign index, making the task structurally unwinnable for every real
+    // ranker while the oracle still scores 100% — this keeps meta-test 1's
+    // achievability proof honest.
+    const indexIds = new Set(index.entries.map((e) => e.id));
+    const unreachable: string[] = [];
+    for (const task of taskSet.tasks) {
+      for (const id of [...task.expected_skills, ...task.acceptable_skills]) {
+        if (!indexIds.has(id)) unreachable.push(`${task.id}: ${id}`);
+      }
+    }
+    expect(unreachable).toEqual([]);
+  });
+
+  test("derived OC baseline equals a live count of the export glob (dist-independent)", () => {
+    // Independent recount of the exact glob export-opencode.sh iterates
+    // (`*-plugin/skills/*/SKILL.md`), so the assertion holds in CI where the
+    // gitignored dist/ never exists.
+    const derived = deriveOcBaseline(REPO_ROOT).ids.size;
+    let live = 0;
+    for (const top of readdirSync(REPO_ROOT, { withFileTypes: true })) {
+      if (!top.isDirectory() || !top.name.endsWith("-plugin")) continue;
+      const skillsDir = join(REPO_ROOT, top.name, "skills");
+      if (!existsSync(skillsDir)) continue;
+      for (const sub of readdirSync(skillsDir, { withFileTypes: true })) {
+        if (sub.isDirectory() && existsSync(join(skillsDir, sub.name, "SKILL.md"))) live++;
+      }
+    }
+    expect(derived).toBe(live);
+  });
+
+  test("dist/ OUTPUT_SKILLS cross-check (informational — dist is a point-in-time artifact, absent in CI)", () => {
+    const exported = countExportedOcSkills(REPO_ROOT);
+    if (exported === null) {
+      console.warn(
+        "dist/opencode absent — OC export cross-check skipped (runs only after `just export-opencode`; CI always skips)",
+      );
+      return;
+    }
+    const derived = deriveOcBaseline(REPO_ROOT).ids.size;
+    if (exported !== derived) {
+      console.warn(
+        `dist/opencode is stale: exported ${exported} vs derived ${derived} — rerun \`just export-opencode\` (informational, not a failure)`,
+      );
+    }
+  });
 });
 
 describe("1. random fails every seed; oracle passes", () => {
@@ -140,12 +180,24 @@ describe("3. token calibration (per-skill)", () => {
     () => {
       // 111 tok/skill was measured on pi 0.80.6 with a real tokenizer. Our
       // chars/4 proxy over the same render measured −13.6% vs that (94.6
-      // tok/skill over the then-95-skill tier; 104.0 at authoring time with
-      // this checkout's absolute paths) — inside the ±20% band [88.8, 133.2].
-      // Record the offset so future drift is interpretable: a breach means
-      // either the render template diverged from what pi injects, or the
-      // tier's description profile shifted materially.
-      const { perSkillMean } = listingTokens((piBaseline as NonNullable<typeof piBaseline>).skills);
+      // tok/skill over the then-95-skill tier; 104.0 at authoring time) —
+      // inside the ±20% band [88.8, 133.2]. Record the offset so future
+      // drift is interpretable: a breach means either the render template
+      // diverged from what pi injects, or the tier's description profile
+      // shifted materially.
+      //
+      // The render embeds each SKILL.md's absolute <location> path, so the
+      // raw mean shifts with checkout-path length (a shallow clone could
+      // spuriously breach the lower bound). Calibrate over a path-normalized
+      // render: fixed 45-char prefix (the length of the checkout the 111
+      // tok/skill reference was measured in) + the repo-relative path. The
+      // runner's informational TOKENS output keeps real paths.
+      const CANONICAL_PREFIX = "/canonical/checkout/claude-plugins".padEnd(45, "-");
+      const normalized = (piBaseline as NonNullable<typeof piBaseline>).skills.map((s) => ({
+        ...s,
+        path: CANONICAL_PREFIX + s.path.slice(REPO_ROOT.length),
+      }));
+      const { perSkillMean } = listingTokens(normalized);
       expect(perSkillMean).toBeGreaterThanOrEqual(111 * 0.8);
       expect(perSkillMean).toBeLessThanOrEqual(111 * 1.2);
     },

--- a/adapters/tests/fixtures/bm25-reference.json
+++ b/adapters/tests/fixtures/bm25-reference.json
@@ -1,5 +1,5 @@
 {
-  "generator": "tests/gen-bm25-reference.py (rank-bm25 0.2.2)",
+  "generator": "tests/gen-bm25-reference.py (rank-bm25 0.2.2, k1=1.2 b=0.75 \u2014 mirrors core/bm25.ts BM25_K1/BM25_B)",
   "note": "expected_rank_order = doc indices with score>0, by (-score, idx)",
   "corpus": [
     {
@@ -86,43 +86,140 @@
   "cases": [
     {
       "query": "commit my staged changes with a good message",
-      "expected_rank_order": [0, 16, 3, 9, 2, 14, 4, 19, 18, 11, 6, 12, 1, 10, 17]
+      "expected_rank_order": [
+        0,
+        16,
+        3,
+        9,
+        2,
+        14,
+        4,
+        19,
+        18,
+        11,
+        6,
+        12,
+        1,
+        10,
+        17
+      ]
     },
     {
       "query": "open a pull request for review",
-      "expected_rank_order": [1, 14, 3, 4, 16, 19, 9, 18, 2, 8, 11, 0, 13]
+      "expected_rank_order": [
+        1,
+        14,
+        3,
+        4,
+        16,
+        19,
+        9,
+        18,
+        2,
+        8,
+        11,
+        0,
+        13
+      ]
     },
     {
       "query": "run the fast unit tests only",
-      "expected_rank_order": [9, 11, 15, 0, 8, 12, 14, 10]
+      "expected_rank_order": [
+        9,
+        11,
+        15,
+        0,
+        8,
+        12,
+        14,
+        10
+      ]
     },
     {
       "query": "extract fields from a json file",
-      "expected_rank_order": [5, 8, 4, 6, 1, 15, 3, 16, 19, 14, 9, 18]
+      "expected_rank_order": [
+        5,
+        8,
+        4,
+        6,
+        1,
+        15,
+        3,
+        16,
+        19,
+        14,
+        9,
+        18
+      ]
     },
     {
       "query": "recover a failed helm upgrade",
-      "expected_rank_order": [15, 4, 3, 16, 19, 14, 9, 18]
+      "expected_rank_order": [
+        15,
+        4,
+        3,
+        16,
+        19,
+        14,
+        9,
+        18
+      ]
     },
     {
       "query": "check dns record propagation",
-      "expected_rank_order": [16, 3]
+      "expected_rank_order": [
+        16,
+        3
+      ]
     },
     {
       "query": "shrink a python docker image",
-      "expected_rank_order": [17, 18, 12, 10, 11, 3, 16, 19, 14, 9, 4]
+      "expected_rank_order": [
+        17,
+        18,
+        12,
+        10,
+        11,
+        3,
+        16,
+        19,
+        14,
+        9,
+        4
+      ]
     },
     {
       "query": "find unused exports in typescript",
-      "expected_rank_order": [13, 19, 3]
+      "expected_rank_order": [
+        13,
+        19,
+        3
+      ]
     },
     {
       "query": "run a python script without a virtualenv",
-      "expected_rank_order": [11, 17, 9, 12, 3, 10, 16, 19, 14, 18, 4]
+      "expected_rank_order": [
+        11,
+        17,
+        9,
+        12,
+        3,
+        10,
+        16,
+        19,
+        14,
+        18,
+        4
+      ]
     },
     {
       "query": "free up disk space on my mac",
-      "expected_rank_order": [18, 16, 10, 13]
+      "expected_rank_order": [
+        18,
+        16,
+        10,
+        13
+      ]
     }
   ]
 }

--- a/adapters/tests/fixtures/bm25-reference.json
+++ b/adapters/tests/fixtures/bm25-reference.json
@@ -1,0 +1,128 @@
+{
+  "generator": "tests/gen-bm25-reference.py (rank-bm25 0.2.2)",
+  "note": "expected_rank_order = doc indices with score>0, by (-score, idx)",
+  "corpus": [
+    {
+      "id": "git-plugin:git-commit",
+      "text": "git-commit Create commits with conventional messages and issue references. Use when user says \"commit\", \"save changes\", or \"stage and commit\". Local commits only \u2014 see git-push for remote."
+    },
+    {
+      "id": "git-plugin:git-pr",
+      "text": "git-pr Create pull requests with descriptions, labels, and issue references. Use when user says \"create PR\", \"open pull request\", or \"submit for review\". From pushed branches."
+    },
+    {
+      "id": "git-plugin:git-push",
+      "text": "git-push Push local commits to remote \u2014 handles branch tracking, upstream setup, safe push patterns. Use when user says \"push\", \"send to remote\", or \"update remote\". Pushes existing commits \u2014 see git-commit for commits and git-pr for PR creation."
+    },
+    {
+      "id": "git-plugin:git-coworker-check",
+      "text": "git-coworker-check Detect coworker Claude agents in a shared checkout. Use when starting a session in a shared clone, before destructive git ops (stash, reset, checkout), or before bulk-edit / commit-loop workflows."
+    },
+    {
+      "id": "git-plugin:gh-cli-agentic",
+      "text": "gh-cli-agentic gh CLI commands with JSON output for agent workflows. Use when querying PRs, issues, workflow runs, or repo metadata; inspecting PR checks; fetching failed CI logs; or resolving a github.com URL to an API call."
+    },
+    {
+      "id": "tools-plugin:jq-json-processing",
+      "text": "jq-json-processing jq JSON processing: query, filter, transform JSON. Use when parsing JSON files, filtering arrays/objects, transforming structures, or extracting fields from JSON."
+    },
+    {
+      "id": "tools-plugin:d2-diagrams",
+      "text": "d2-diagrams Generate diagrams from text using D2 with automatic layouts and themes. Use when creating architecture diagrams, flowcharts, decision trees, sequence flows, or ERDs."
+    },
+    {
+      "id": "tools-plugin:shell-expert",
+      "text": "shell-expert Shell scripting: bash, zsh, POSIX, CLI tools, cross-platform automation. Use when writing shell scripts, pipes, command-line automation, or portable shell code."
+    },
+    {
+      "id": "tools-plugin:fd-file-finding",
+      "text": "fd-file-finding fd fast file finding: smart defaults, gitignore-aware, parallel. Use when searching for files by name, extension, or pattern across directories."
+    },
+    {
+      "id": "testing-plugin:test-quick",
+      "text": "test-quick Run fast unit tests only, skip slow/integration/E2E. Use when checking units after a change, running affected tests since last commit, watch mode TDD, or sub-30s feedback."
+    },
+    {
+      "id": "testing-plugin:mutation-testing",
+      "text": "mutation-testing Mutation testing with Stryker (TS/JS) and mutmut (Python). Use when finding weak tests that pass on mutated code, or improving test quality through mutation analysis."
+    },
+    {
+      "id": "python-plugin:uv-run",
+      "text": "uv-run Run Python scripts with uv (PEP 723 inline deps, --with for one-off deps). Use when running scripts without venv activation or needing one-off dependencies."
+    },
+    {
+      "id": "python-plugin:ruff-linting",
+      "text": "ruff-linting Python linting with ruff. Fast linting, rule selection, auto-fixing, and config. Use when checking Python code quality, enforcing standards, or finding bugs."
+    },
+    {
+      "id": "typescript-plugin:knip-dead-code",
+      "text": "knip-dead-code Knip dead-code detector for JS/TS: unused files, deps, exports, types. Use when cleaning up codebases, finding dead exports, or enforcing dependency hygiene in CI."
+    },
+    {
+      "id": "typescript-plugin:bun-test",
+      "text": "bun-test Bun test runner with compact agent-friendly output. Use when running bun tests, targeting a pattern, collecting --coverage, watching, or emitting JUnit XML for CI."
+    },
+    {
+      "id": "kubernetes-plugin:helm-release-recovery",
+      "text": "helm-release-recovery Recover from failed Helm deployments \u2014 rollback, fix stuck states (pending-install/upgrade), atomic deployments. Use when the user mentions rollback, failed Helm upgrade, or stuck releases."
+    },
+    {
+      "id": "networking-plugin:dns-tools",
+      "text": "dns-tools DNS resolution and propagation debugging. Use when looking up A/AAAA/MX/TXT records, verifying DNS changes across resolvers, or querying via DoT/DoH."
+    },
+    {
+      "id": "container-plugin:python-containers",
+      "text": "python-containers Python container optimization \u2014 slim images (not Alpine), virtualenv, multi-stage, pip/poetry/uv, musl gotchas (1GB to ~120MB). Use when working with Python containers or optimizing image sizes."
+    },
+    {
+      "id": "macos-plugin:macos-disk-usage",
+      "text": "macos-disk-usage macOS disk-usage forensics and space recovery on APFS. Use when df reports a disk near-full, hunting what's eating space, reclaiming OrbStack/Docker, or pruning caches and local snapshots."
+    },
+    {
+      "id": "obsidian-plugin:vault-orphans",
+      "text": "vault-orphans Triage orphaned notes (zero in/out wikilinks) in an Obsidian vault. Use when finding orphans, linking them into a MOC, or reconnecting Zettelkasten notes."
+    }
+  ],
+  "cases": [
+    {
+      "query": "commit my staged changes with a good message",
+      "expected_rank_order": [0, 16, 3, 9, 2, 14, 4, 19, 18, 11, 6, 12, 1, 10, 17]
+    },
+    {
+      "query": "open a pull request for review",
+      "expected_rank_order": [1, 14, 3, 4, 16, 19, 9, 18, 2, 8, 11, 0, 13]
+    },
+    {
+      "query": "run the fast unit tests only",
+      "expected_rank_order": [9, 11, 15, 0, 8, 12, 14, 10]
+    },
+    {
+      "query": "extract fields from a json file",
+      "expected_rank_order": [5, 8, 4, 6, 1, 15, 3, 16, 19, 14, 9, 18]
+    },
+    {
+      "query": "recover a failed helm upgrade",
+      "expected_rank_order": [15, 4, 3, 16, 19, 14, 9, 18]
+    },
+    {
+      "query": "check dns record propagation",
+      "expected_rank_order": [16, 3]
+    },
+    {
+      "query": "shrink a python docker image",
+      "expected_rank_order": [17, 18, 12, 10, 11, 3, 16, 19, 14, 9, 4]
+    },
+    {
+      "query": "find unused exports in typescript",
+      "expected_rank_order": [13, 19, 3]
+    },
+    {
+      "query": "run a python script without a virtualenv",
+      "expected_rank_order": [11, 17, 9, 12, 3, 10, 16, 19, 14, 18, 4]
+    },
+    {
+      "query": "free up disk space on my mac",
+      "expected_rank_order": [18, 16, 10, 13]
+    }
+  ]
+}

--- a/adapters/tests/fixtures/mini-marketplace-src/.claude-plugin/marketplace.json
+++ b/adapters/tests/fixtures/mini-marketplace-src/.claude-plugin/marketplace.json
@@ -1,0 +1,29 @@
+{
+  "name": "mini-marketplace",
+  "plugins": [
+    {
+      "name": "alpha-plugin",
+      "source": "./alpha-plugin",
+      "description": "Alpha test plugin",
+      "version": "1.0.0",
+      "keywords": ["alpha", "testing"],
+      "category": "test-a"
+    },
+    {
+      "name": "beta-plugin",
+      "source": "./beta-plugin",
+      "description": "Beta test plugin",
+      "version": "1.0.0",
+      "keywords": ["beta"],
+      "category": "test-b"
+    },
+    {
+      "name": "gamma-plugin",
+      "source": "./gamma-plugin",
+      "description": "Gamma test plugin",
+      "version": "1.0.0",
+      "keywords": ["gamma"],
+      "category": "test-a"
+    }
+  ]
+}

--- a/adapters/tests/fixtures/mini-marketplace-src/alpha-plugin/skilldirs/cc-only-skill/SKILL.md
+++ b/adapters/tests/fixtures/mini-marketplace-src/alpha-plugin/skilldirs/cc-only-skill/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: cc-only-skill
+description: Configure Claude Code hooks in settings.json. Use when authoring PreToolUse hooks.
+compatibility: claude-code
+---
+
+# Claude-Code-Only Skill
+
+Must be filtered out under target "foreign" and present under "claude-code".

--- a/adapters/tests/fixtures/mini-marketplace-src/alpha-plugin/skilldirs/normal-skill/SKILL.md
+++ b/adapters/tests/fixtures/mini-marketplace-src/alpha-plugin/skilldirs/normal-skill/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: normal-skill
+description: Commit staged changes with a conventional message. Use when saving work to git history.
+allowed-tools: Bash, Read
+created: 2026-01-01
+modified: 2026-01-01
+---
+
+# Normal Skill
+
+A perfectly ordinary skill body.

--- a/adapters/tests/fixtures/mini-marketplace-src/beta-plugin/skilldirs/no-description/SKILL.md
+++ b/adapters/tests/fixtures/mini-marketplace-src/beta-plugin/skilldirs/no-description/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: no-description
+allowed-tools: Read
+---
+
+# No Description
+
+This skill has no description and must be dropped with a warning.

--- a/adapters/tests/fixtures/mini-marketplace-src/beta-plugin/skilldirs/no-name/SKILL.md
+++ b/adapters/tests/fixtures/mini-marketplace-src/beta-plugin/skilldirs/no-name/SKILL.md
@@ -1,0 +1,7 @@
+---
+description: Inspect JSON payloads and extract nested fields. Use when parsing API responses.
+---
+
+# No Name
+
+The entry's name must fall back to the directory basename "no-name".

--- a/adapters/tests/fixtures/mini-marketplace-src/gamma-plugin/skilldirs/folded-description/SKILL.md
+++ b/adapters/tests/fixtures/mini-marketplace-src/gamma-plugin/skilldirs/folded-description/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: folded-description
+description: >-
+  Render architecture diagrams from text sources.
+  Use when documenting system topology.
+---
+
+# Folded Description
+
+The folded description must join its lines with spaces.

--- a/adapters/tests/fixtures/mini-marketplace-src/gamma-plugin/skilldirs/quoted-description/SKILL.md
+++ b/adapters/tests/fixtures/mini-marketplace-src/gamma-plugin/skilldirs/quoted-description/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: quoted-description
+description: "Debug HTTP APIs: trace requests, inspect headers. Use when a request fails: check status first."
+---
+
+# Quoted Description
+
+The quoted description contains colons and must have quotes stripped.

--- a/adapters/tests/frontmatter.test.ts
+++ b/adapters/tests/frontmatter.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Frontmatter parser tests (DESIGN §2.2, §7.2): unit cases for the DIY
+ * parser, plus the whole-corpus diff test against Bun.YAML.parse over every
+ * real SKILL.md in the checkout — the DIY rule's verify-against-reference
+ * step, with zero added dependency.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { extractFrontmatterBlock, parseFrontmatter } from "../core/frontmatter.ts";
+
+const REPO_ROOT = resolve(import.meta.dir, "..", "..");
+
+describe("parseFrontmatter", () => {
+  test("plain scalar fields", () => {
+    const fm = parseFrontmatter("---\nname: git-commit\ndescription: Commit things.\n---\nbody");
+    expect(fm).toEqual({ name: "git-commit", description: "Commit things." });
+  });
+
+  test("no frontmatter fence returns null", () => {
+    expect(parseFrontmatter("# Just a heading\n")).toBeNull();
+    expect(parseFrontmatter("")).toBeNull();
+  });
+
+  test("unclosed fence returns null", () => {
+    expect(parseFrontmatter("---\nname: x\nno closing fence")).toBeNull();
+  });
+
+  test("strips one level of matching quotes", () => {
+    const fm = parseFrontmatter("---\ndescription: \"Debug: trace, inspect.\"\nother: 'ok'\n---\n");
+    expect(fm?.description).toBe("Debug: trace, inspect.");
+    expect(fm?.other).toBe("ok");
+  });
+
+  test("mismatched quotes are left alone", () => {
+    const fm = parseFrontmatter('---\ndescription: "half quoted\n---\n');
+    expect(fm?.description).toBe('"half quoted');
+  });
+
+  test("folded scalars (>- and |) join continuation lines with spaces", () => {
+    const fm = parseFrontmatter(
+      "---\ndescription: >-\n  Render diagrams.\n  Use when documenting.\nname: x\n---\n",
+    );
+    expect(fm?.description).toBe("Render diagrams. Use when documenting.");
+    expect(fm?.name).toBe("x");
+  });
+
+  test("folded scalar at end of frontmatter is flushed", () => {
+    const fm = parseFrontmatter("---\ndescription: |\n  line one\n  line two\n---\n");
+    expect(fm?.description).toBe("line one line two");
+  });
+
+  test("lists and nested maps are skipped without corrupting scalars", () => {
+    const fm = parseFrontmatter(
+      "---\nname: x\ntags:\n  - one\n  - two\ndescription: after the list\n---\n",
+    );
+    expect(fm?.name).toBe("x");
+    expect(fm?.description).toBe("after the list");
+    // The list field itself parses as an empty scalar (we consume no such field).
+    expect(fm?.tags).toBe("");
+  });
+
+  test("extractFrontmatterBlock returns the raw text between fences", () => {
+    expect(extractFrontmatterBlock("---\na: 1\nb: 2\n---\nrest")).toBe("a: 1\nb: 2");
+    expect(extractFrontmatterBlock("no fence")).toBeNull();
+  });
+});
+
+describe("whole-corpus diff vs Bun.YAML.parse", () => {
+  const yaml = (Bun as unknown as { YAML?: { parse: (t: string) => unknown } }).YAML;
+  const haveYaml = typeof yaml?.parse === "function";
+
+  // Every real */skills/*/SKILL.md in the checkout (406 at design time).
+  const skillFiles: string[] = [];
+  if (haveYaml) {
+    for (const top of readdirSync(REPO_ROOT, { withFileTypes: true })) {
+      if (!top.isDirectory() || !top.name.endsWith("-plugin")) continue;
+      const skillsDir = join(REPO_ROOT, top.name, "skills");
+      let dirs: string[] = [];
+      try {
+        dirs = readdirSync(skillsDir);
+      } catch {
+        continue;
+      }
+      for (const dir of dirs) {
+        const p = join(skillsDir, dir, "SKILL.md");
+        try {
+          readFileSync(p);
+          skillFiles.push(p);
+        } catch {
+          // not a skill dir
+        }
+      }
+    }
+  }
+
+  test.skipIf(!haveYaml)(
+    "name/description/compatibility match Bun.YAML on every real SKILL.md",
+    () => {
+      expect(skillFiles.length).toBeGreaterThan(300);
+      const mismatches: string[] = [];
+      for (const file of skillFiles) {
+        const text = readFileSync(file, "utf8");
+        const block = extractFrontmatterBlock(text);
+        if (block === null) continue;
+        const ours = parseFrontmatter(text) ?? {};
+        let reference: Record<string, unknown>;
+        try {
+          reference = ((yaml as { parse: (t: string) => unknown }).parse(block) ?? {}) as Record<
+            string,
+            unknown
+          >;
+        } catch {
+          // Bun.YAML rejects the file entirely; the DIY parser is fail-safe
+          // per field, so there is nothing to diff against.
+          continue;
+        }
+        for (const field of ["name", "description", "compatibility"] as const) {
+          const refValue = reference[field];
+          if (refValue === undefined || refValue === null) continue;
+          if (typeof refValue !== "string") continue; // non-scalar: out of contract
+          // YAML folded scalars end with a newline and preserve paragraph
+          // breaks; our consumer semantics are single-line, so compare
+          // whitespace-normalized.
+          const normRef = refValue.replace(/\s+/g, " ").trim();
+          const normOurs = (ours[field] ?? "").replace(/\s+/g, " ").trim();
+          if (normRef !== normOurs) {
+            mismatches.push(`${file} [${field}]\n  yaml: ${normRef}\n  ours: ${normOurs}`);
+          }
+        }
+      }
+      expect(mismatches).toEqual([]);
+    },
+  );
+
+  test.skipIf(haveYaml)("SKIPPED: Bun.YAML unavailable in this environment", () => {
+    console.warn("Bun.YAML.parse unavailable — frontmatter diff test skipped, parser unverified");
+  });
+});

--- a/adapters/tests/fusion.test.ts
+++ b/adapters/tests/fusion.test.ts
@@ -1,0 +1,60 @@
+/**
+ * RRF tests (DESIGN §7.4): hand-computed 2-ranker fixture, 1-based ranks,
+ * k = 60 asserted.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { FUSE_DEPTH, RRF_K, rrfFuse } from "../core/fusion.ts";
+
+describe("rrfFuse", () => {
+  test("k constant is the canonical 60", () => {
+    expect(RRF_K).toBe(60);
+    expect(FUSE_DEPTH).toBe(50);
+  });
+
+  test("hand-computed two-ranker fusion with a single-list doc", () => {
+    // listA ranks: d1=1, d2=2, d3=3; listB ranks: d2=1, d4=2.
+    // RRF (1-based, k=60):
+    //   d2 = 1/62 + 1/61 = 0.032523...
+    //   d1 = 1/61         = 0.016393...
+    //   d4 = 1/62         = 0.016129...
+    //   d3 = 1/63         = 0.015873...
+    const fused = rrfFuse([
+      [
+        { id: "d1", score: 9.0 },
+        { id: "d2", score: 5.0 },
+        { id: "d3", score: 1.0 },
+      ],
+      [
+        { id: "d2", score: 0.9 },
+        { id: "d4", score: 0.2 },
+      ],
+    ]);
+    expect(fused.map((f) => f.id)).toEqual(["d2", "d1", "d4", "d3"]);
+    expect(fused[0]?.score).toBeCloseTo(1 / 62 + 1 / 61, 12);
+    expect(fused[1]?.score).toBeCloseTo(1 / 61, 12);
+    expect(fused[2]?.score).toBeCloseTo(1 / 62, 12);
+    expect(fused[3]?.score).toBeCloseTo(1 / 63, 12);
+  });
+
+  test("absent-from-list contributes zero (no penalty term)", () => {
+    const fused = rrfFuse([[{ id: "only", score: 1 }], []]);
+    expect(fused).toEqual([{ id: "only", score: 1 / 61 }]);
+  });
+
+  test("only the top fuseDepth entries of each list participate", () => {
+    const longList = Array.from({ length: 60 }, (_, i) => ({
+      id: `d${i}`,
+      score: 60 - i,
+    }));
+    const fused = rrfFuse([longList], 50);
+    expect(fused).toHaveLength(50);
+    expect(fused.find((f) => f.id === "d59")).toBeUndefined();
+  });
+
+  test("input scores do not influence fusion (rank-only)", () => {
+    const a = rrfFuse([[{ id: "x", score: 1e9 }]]);
+    const b = rrfFuse([[{ id: "x", score: 1e-9 }]]);
+    expect(a[0]?.score).toBe(b[0]?.score);
+  });
+});

--- a/adapters/tests/gen-bm25-reference.py
+++ b/adapters/tests/gen-bm25-reference.py
@@ -1,0 +1,131 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["rank-bm25==0.2.2"]
+# ///
+"""Regenerate tests/fixtures/bm25-reference.json (DESIGN §7.1).
+
+One-shot generator, run via `uv run tests/gen-bm25-reference.py` from
+adapters/. It snapshots ~20 real skill "name description" documents from the
+checkout, scores ~10 queries with the reference implementation
+(rank_bm25.BM25Okapi), and writes the corpus + queries + expected rank order
+to the committed fixture. The bun test (tests/bm25.test.ts) then asserts our
+DIY BM25 reproduces the rank order — NOT the raw scores: rank_bm25 uses an
+epsilon-floored classic IDF while ours uses the Lucene non-negative IDF, so
+absolute scores legitimately differ while rank order should agree on queries
+whose terms are not corpus-saturated.
+
+Tokenization matches core/bm25.ts exactly: lowercase, split [^a-z0-9]+.
+Rank order: documents with score > 0, sorted by (-score, doc index).
+"""
+
+import json
+import re
+from pathlib import Path
+
+from rank_bm25 import BM25Okapi
+
+ADAPTERS = Path(__file__).resolve().parent.parent
+REPO = ADAPTERS.parent
+FIXTURE = ADAPTERS / "tests" / "fixtures" / "bm25-reference.json"
+
+# 20 real skills, spanning plugins and vocabulary. The corpus TEXT is stored
+# in the fixture, so later description edits do not invalidate it — rerun
+# this script only when you deliberately want a fresh snapshot.
+SKILL_IDS = [
+    "git-plugin:git-commit",
+    "git-plugin:git-pr",
+    "git-plugin:git-push",
+    "git-plugin:git-coworker-check",
+    "git-plugin:gh-cli-agentic",
+    "tools-plugin:jq-json-processing",
+    "tools-plugin:d2-diagrams",
+    "tools-plugin:shell-expert",
+    "tools-plugin:fd-file-finding",
+    "testing-plugin:test-quick",
+    "testing-plugin:mutation-testing",
+    "python-plugin:uv-run",
+    "python-plugin:ruff-linting",
+    "typescript-plugin:knip-dead-code",
+    "typescript-plugin:bun-test",
+    "kubernetes-plugin:helm-release-recovery",
+    "networking-plugin:dns-tools",
+    "container-plugin:python-containers",
+    "macos-plugin:macos-disk-usage",
+    "obsidian-plugin:vault-orphans",
+]
+
+QUERIES = [
+    "commit my staged changes with a good message",
+    "open a pull request for review",
+    "run the fast unit tests only",
+    "extract fields from a json file",
+    "recover a failed helm upgrade",
+    "check dns record propagation",
+    "shrink a python docker image",
+    "find unused exports in typescript",
+    "run a python script without a virtualenv",
+    "free up disk space on my mac",
+]
+
+
+def tokenize(text: str) -> list[str]:
+    return [t for t in re.split(r"[^a-z0-9]+", text.lower()) if t]
+
+
+def frontmatter_field(path: Path, field: str) -> str:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if not lines or lines[0].strip() != "---":
+        return ""
+    for line in lines[1:]:
+        if line.strip() == "---":
+            break
+        m = re.match(rf"^{field}:\s*(.*)$", line)
+        if m:
+            value = m.group(1).strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in "'\"":
+                value = value[1:-1]
+            return value
+    return ""
+
+
+def main() -> None:
+    corpus: list[dict[str, str]] = []
+    for skill_id in SKILL_IDS:
+        plugin, skill = skill_id.split(":", 1)
+        path = REPO / plugin / "skills" / skill / "SKILL.md"
+        name = frontmatter_field(path, "name") or skill
+        description = frontmatter_field(path, "description")
+        if not description:
+            raise SystemExit(f"missing description for {skill_id}")
+        corpus.append({"id": skill_id, "text": f"{name} {description}"})
+
+    tokenized = [tokenize(doc["text"]) for doc in corpus]
+    bm25 = BM25Okapi(tokenized)
+
+    cases = []
+    for query in QUERIES:
+        scores = bm25.get_scores(tokenize(query))
+        ranked = sorted(
+            (i for i, s in enumerate(scores) if s > 1e-12),
+            key=lambda i: (-scores[i], i),
+        )
+        cases.append({"query": query, "expected_rank_order": ranked})
+
+    FIXTURE.write_text(
+        json.dumps(
+            {
+                "generator": "tests/gen-bm25-reference.py (rank-bm25 0.2.2)",
+                "note": "expected_rank_order = doc indices with score>0, by (-score, idx)",
+                "corpus": corpus,
+                "cases": cases,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    print(f"wrote {FIXTURE} ({len(corpus)} docs, {len(cases)} queries)")
+
+
+if __name__ == "__main__":
+    main()

--- a/adapters/tests/gen-bm25-reference.py
+++ b/adapters/tests/gen-bm25-reference.py
@@ -100,7 +100,9 @@ def main() -> None:
         corpus.append({"id": skill_id, "text": f"{name} {description}"})
 
     tokenized = [tokenize(doc["text"]) for doc in corpus]
-    bm25 = BM25Okapi(tokenized)
+    # Mirror BM25_K1/BM25_B from core/bm25.ts — rank_bm25's own default is
+    # k1=1.5, which genuinely reorders close-scored tails vs our k1=1.2.
+    bm25 = BM25Okapi(tokenized, k1=1.2, b=0.75)
 
     cases = []
     for query in QUERIES:
@@ -114,7 +116,7 @@ def main() -> None:
     FIXTURE.write_text(
         json.dumps(
             {
-                "generator": "tests/gen-bm25-reference.py (rank-bm25 0.2.2)",
+                "generator": "tests/gen-bm25-reference.py (rank-bm25 0.2.2, k1=1.2 b=0.75 — mirrors core/bm25.ts BM25_K1/BM25_B)",
                 "note": "expected_rank_order = doc indices with score>0, by (-score, idx)",
                 "corpus": corpus,
                 "cases": cases,

--- a/adapters/tests/indexer.test.ts
+++ b/adapters/tests/indexer.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Indexer tests (DESIGN §7.2) over the mini-marketplace fixture, plus the
+ * §1.2 static import-restriction checks.
+ *
+ * Fixture sources live under tests/fixtures/mini-marketplace-src with skill
+ * dirs named `skilldirs/` — NO committed path may contain "/skills/", or
+ * plugin-pr-checks.yml and every repo-wide skill guard would enroll the
+ * fixtures. beforeAll copies the tree to a temp dir, renaming skilldirs/ →
+ * skills/, and tests index the temp tree.
+ */
+
+import { beforeAll, describe, expect, test } from "bun:test";
+import { cpSync, existsSync, mkdtempSync, readdirSync, readFileSync, renameSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { documentText, scanSkills } from "../core/indexer.ts";
+
+const FIXTURE_SRC = join(import.meta.dir, "fixtures", "mini-marketplace-src");
+const ADAPTERS_ROOT = resolve(import.meta.dir, "..");
+
+let fixtureRoot = "";
+
+beforeAll(() => {
+  fixtureRoot = mkdtempSync(join(tmpdir(), "mini-marketplace-"));
+  cpSync(FIXTURE_SRC, fixtureRoot, { recursive: true });
+  for (const entry of readdirSync(fixtureRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const src = join(fixtureRoot, entry.name, "skilldirs");
+    if (existsSync(src)) renameSync(src, join(fixtureRoot, entry.name, "skills"));
+  }
+});
+
+describe("committed-fixture invariant", () => {
+  test("no committed fixture path contains /skills/", () => {
+    const offenders: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (entry.name === "skills") offenders.push(full);
+          else walk(full);
+        }
+      }
+    };
+    walk(FIXTURE_SRC);
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("scanSkills over the mini marketplace", () => {
+  test('target "foreign" filters compatibility: claude-code and drops description-less', () => {
+    const { entries, warnings } = scanSkills(fixtureRoot, "foreign");
+    const ids = entries.map((e) => e.id).sort();
+    expect(ids).toEqual([
+      "alpha-plugin:normal-skill",
+      "beta-plugin:no-name",
+      "gamma-plugin:folded-description",
+      "gamma-plugin:quoted-description",
+    ]);
+    expect(warnings.some((w) => w.includes("beta-plugin:no-description"))).toBe(true);
+    expect(warnings.some((w) => w.includes("cc-only-skill"))).toBe(false); // filtered, not warned
+  });
+
+  test('target "claude-code" keeps the compatibility-marked skill', () => {
+    const { entries } = scanSkills(fixtureRoot, "claude-code");
+    const ids = entries.map((e) => e.id);
+    expect(ids).toContain("alpha-plugin:cc-only-skill");
+    expect(entries).toHaveLength(5);
+    const ccOnly = entries.find((e) => e.id === "alpha-plugin:cc-only-skill");
+    expect(ccOnly?.compatibility).toBe("claude-code");
+  });
+
+  test("name falls back to the skill directory basename", () => {
+    const { entries } = scanSkills(fixtureRoot, "foreign");
+    const noName = entries.find((e) => e.id === "beta-plugin:no-name");
+    expect(noName?.name).toBe("no-name");
+  });
+
+  test("folded description joins with spaces", () => {
+    const { entries } = scanSkills(fixtureRoot, "foreign");
+    const folded = entries.find((e) => e.id === "gamma-plugin:folded-description");
+    expect(folded?.description).toBe(
+      "Render architecture diagrams from text sources. Use when documenting system topology.",
+    );
+  });
+
+  test("quoted description with colons has quotes stripped", () => {
+    const { entries } = scanSkills(fixtureRoot, "foreign");
+    const quoted = entries.find((e) => e.id === "gamma-plugin:quoted-description");
+    expect(quoted?.description).toBe(
+      "Debug HTTP APIs: trace requests, inspect headers. Use when a request fails: check status first.",
+    );
+  });
+
+  test("entries carry marketplace category/keywords and an absolute SKILL.md path", () => {
+    const { entries } = scanSkills(fixtureRoot, "foreign");
+    const normal = entries.find((e) => e.id === "alpha-plugin:normal-skill");
+    expect(normal?.category).toBe("test-a");
+    expect(normal?.keywords).toEqual(["alpha", "testing"]);
+    expect(normal?.path.endsWith("alpha-plugin/skills/normal-skill/SKILL.md")).toBe(true);
+    expect(normal?.path.startsWith("/")).toBe(true);
+  });
+
+  test("document text is name + description, nothing else", () => {
+    const { entries } = scanSkills(fixtureRoot, "foreign");
+    const normal = entries.find((e) => e.id === "alpha-plugin:normal-skill");
+    expect(documentText(normal as NonNullable<typeof normal>)).toBe(
+      `${normal?.name} ${normal?.description}`,
+    );
+    // Keywords/category stay out of the scored text.
+    expect(documentText(normal as NonNullable<typeof normal>)).not.toContain("test-a");
+  });
+});
+
+/**
+ * §1.2 static import-restriction checks. Dependency discipline is enforced
+ * by convention plus this test, not package boundaries.
+ */
+describe("static import restrictions", () => {
+  const IMPORT_RE = /(?:from\s+|import\s+|import\s*\(\s*|require\s*\(\s*)["']([^"']+)["']/g;
+
+  function importSpecifiers(filePath: string): string[] {
+    const source = readFileSync(filePath, "utf8");
+    const specs: string[] = [];
+    for (const match of source.matchAll(IMPORT_RE)) {
+      specs.push(match[1] as string);
+    }
+    return specs;
+  }
+
+  function tsFilesUnder(dir: string): string[] {
+    const files: string[] = [];
+    const walk = (d: string) => {
+      for (const entry of readdirSync(d, { withFileTypes: true })) {
+        const full = join(d, entry.name);
+        if (entry.isDirectory()) walk(full);
+        else if (entry.name.endsWith(".ts")) files.push(full);
+      }
+    };
+    walk(dir);
+    return files;
+  }
+
+  test("core/ imports nothing but node:* and relative paths", () => {
+    const violations: string[] = [];
+    for (const file of tsFilesUnder(join(ADAPTERS_ROOT, "core"))) {
+      for (const spec of importSpecifiers(file)) {
+        if (spec.startsWith("node:") || spec.startsWith("./") || spec.startsWith("../")) continue;
+        violations.push(`${file}: ${spec}`);
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  // pi/ lands in #2090; the restriction is encoded now so a future dep
+  // addition cannot silently depend on unverified jiti-in-binary
+  // node_modules resolution. Skips gracefully while the dir is absent.
+  const piDir = join(ADAPTERS_ROOT, "pi");
+  test.skipIf(!existsSync(piDir))(
+    "pi/ imports only typebox, type-only pi-coding-agent, node:*, and relative paths",
+    () => {
+      const violations: string[] = [];
+      for (const file of tsFilesUnder(piDir)) {
+        const source = readFileSync(file, "utf8");
+        for (const line of source.split("\n")) {
+          const m = /(?:from\s+|import\s+|import\s*\(\s*|require\s*\(\s*)["']([^"']+)["']/.exec(
+            line,
+          );
+          if (!m) continue;
+          const spec = m[1] as string;
+          if (spec.startsWith("node:") || spec.startsWith("./") || spec.startsWith("../")) continue;
+          if (spec === "typebox") continue;
+          if (spec === "@earendil-works/pi-coding-agent" && /^\s*import\s+type\s/.test(line)) {
+            continue; // type-only: erased at transpile time
+          }
+          violations.push(`${file}: ${line.trim()}`);
+        }
+      }
+      expect(violations).toEqual([]);
+    },
+  );
+});

--- a/adapters/tests/render.test.ts
+++ b/adapters/tests/render.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Shared render tests (DESIGN §3.3 shape; used by both bindings and by the
+ * eval token accounting): pins-first ordering, dedupe, k cap, exact XML
+ * entry shape.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  AVAILABLE_SKILLS_CLOSE,
+  AVAILABLE_SKILLS_OPEN,
+  estimateTokens,
+  INJECTED_BLOCK_TRAILER,
+  renderInjectedBlock,
+  renderSkillEntry,
+  renderToolResult,
+} from "../core/render.ts";
+
+const skill = (id: string) => ({
+  id,
+  description: `Description for ${id}`,
+  path: `/abs/${id.replace(":", "/")}/SKILL.md`,
+});
+
+describe("renderSkillEntry", () => {
+  test("exact XML item shape (name/description/location)", () => {
+    expect(renderSkillEntry(skill("git-plugin:git-commit"))).toBe(
+      "  <skill><name>git-plugin:git-commit</name><description>Description for git-plugin:git-commit</description><location>/abs/git-plugin/git-commit/SKILL.md</location></skill>",
+    );
+  });
+});
+
+describe("renderInjectedBlock", () => {
+  test("pins first, then ranked, deduped, capped at k, wrapped with trailer", () => {
+    const pins = [skill("a:pin")];
+    const ranked = [skill("a:pin"), skill("b:one"), skill("c:two"), skill("d:three")];
+    const block = renderInjectedBlock(pins, ranked, 3);
+    const lines = block.split("\n");
+    expect(lines[0]).toBe(AVAILABLE_SKILLS_OPEN);
+    expect(lines[lines.length - 2]).toBe(AVAILABLE_SKILLS_CLOSE);
+    expect(lines[lines.length - 1]).toBe(INJECTED_BLOCK_TRAILER);
+    const entryIds = lines
+      .filter((l) => l.startsWith("  <skill>"))
+      .map((l) => /<name>([^<]+)<\/name>/.exec(l)?.[1]);
+    expect(entryIds).toEqual(["a:pin", "b:one", "c:two"]); // pin deduped, k=3 cap
+  });
+
+  test("empty inputs yield an empty block with the trailer intact", () => {
+    const block = renderInjectedBlock([], [], 5);
+    expect(block).toBe(
+      `${AVAILABLE_SKILLS_OPEN}\n${AVAILABLE_SKILLS_CLOSE}\n${INJECTED_BLOCK_TRAILER}`,
+    );
+  });
+});
+
+describe("renderToolResult", () => {
+  test("numbered entries carry the SKILL.md path to read", () => {
+    const text = renderToolResult([{ ...skill("a:one"), score: 1.5 }]);
+    expect(text).toContain("1. a:one — Description for a:one");
+    expect(text).toContain("read: /abs/a/one/SKILL.md");
+  });
+
+  test("empty result set says so", () => {
+    expect(renderToolResult([])).toBe("No matching skills found.");
+  });
+});
+
+describe("estimateTokens", () => {
+  test("chars/4, rounded up", () => {
+    expect(estimateTokens("abcd")).toBe(1);
+    expect(estimateTokens("abcde")).toBe(2);
+    expect(estimateTokens("")).toBe(0);
+  });
+});

--- a/adapters/tsconfig.json
+++ b/adapters/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["esnext"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "types": ["bun"],
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": ["core/**/*.ts", "eval/**/*.ts", "tests/**/*.ts", "pi/**/*.ts", "opencode/**/*.ts"]
+}

--- a/justfile
+++ b/justfile
@@ -103,6 +103,30 @@ pr-rebase-all:
     done
 
 ####################
+# Adapters (skill-discovery core — ADR-0022)
+####################
+
+# Run the adapters test suite (bun test; includes the eval meta-tests)
+[group: "adapters"]
+adapters-test:
+    cd adapters && bun test
+
+# Type-check + lint the adapters package (local↔CI parity with test-adapters.yml)
+[group: "adapters"]
+adapters-check:
+    cd adapters && bunx tsc --noEmit && bunx biome ci .
+
+# Run the retrieval eval (BM25-only smoke; structured === SECTION === output)
+[group: "adapters"]
+eval-adapter *args:
+    cd adapters && bun eval/run-eval.ts {{args}}
+
+# Run the retrieval eval with hybrid fusion (needs a reachable ollama /api/embed)
+[group: "adapters"]
+eval-adapter-hybrid:
+    cd adapters && bun eval/run-eval.ts --with-embeddings
+
+####################
 # OpenCode export
 ####################
 


### PR DESCRIPTION
## What

Implements the ADR-0022 discovery core + eval gate machinery (#2089): a plain-TS, dependency-light retrieval core over the marketplace checkout, and the eval harness that will gate the #2093/#2094 cutovers.

**Core** (`adapters/core/`):
- Indexer over `marketplace.json` + `*/skills/*/SKILL.md` with DIY frontmatter parse (diff-tested against `Bun.YAML.parse` over all 406 real skills) and `compatibility: claude-code` filtering for foreign harnesses
- DIY BM25 (Lucene non-negative IDF, k1=1.2/b=0.75; diff-tested against `rank_bm25` at matched parameters), ollama `/api/embed` client (nomic task prefixes, batch, width guards, ECONNREFUSED/timeout → BM25-only degradation), RRF k=60 fusion, L2-normalized flat Float32Array, XDG content-hash embedding cache
- `search(query, k, filters)` + a Ranker seam (hybrid / bm25Only / embeddingOnly / random / oracle / nameSubstring / descriptionSubstring) shared by the bindings and the eval

**Eval harness** (`adapters/eval/`):
- 71-task golden set (paraphrase/terse/ambiguity/negative/excluded strata; deterministic trigram leakage lint keeps prompts from echoing descriptions)
- BM25-only zero-network smoke mode (CI) + `--with-embeddings` hybrid mode (local); structured `=== SECTION === KEY=VALUE` output
- CI gates **machinery only** — cutover thresholds are deliberately unfrozen and get derived via the documented hybrid-simulation procedure before #2093/#2094
- Meta-tests per `validate-adversarial-constructions`: random ranker fails all 20 seeds with margin, oracle passes 100%, per-skill token calibration pinned to the measured 111 tok/skill (±20%), degenerate-ranker separations, index-membership reachability

**Repo integration**: `Test: Adapters` workflow (paths include `pi/tiers.yaml` so the #2093 removal PR fails loudly; weekly corpus-drift cron), `.gitignore`, justfile recipes, adapters README.

Nothing in the tier/rulesync pipelines is touched — the incumbents stay fully operational until the eval gate passes (`tool-migration-cutover`).

Built via multi-agent workflow: grounded against upstream pi/OpenCode source, design adversarially reviewed (19 findings reconciled + independently verified), implementation reviewed through 3 lenses (10 findings fixed in `aacf9b0e`).

## Verification

- `bun test`: 92 pass / 3 skip / 0 fail (skips: pi/ dir absent until #2090, dist/ absent, tiers-present notice twin)
- `bunx tsc --noEmit`, `bunx biome ci .`, `actionlint`: clean
- Smoke eval: `=== GATE === STATUS=PASS` (informational metrics: in-tier hit@5 0.370 BM25-only, excluded-stratum 0.694, adapter ~608 standing tokens vs 9,882 pi-baseline / ~42k OC-estimated)

Closes #2089

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5iwac3d7LWd8Jr9iBArXv