### PR TITLE
feat(adapters): pi extension binding — hybrid push+pull skill discovery

### DIFF
--- a/adapters/README.md
+++ b/adapters/README.md
@@ -19,7 +19,7 @@ stable, but the binding files do not exist yet.
 |------|------|
 | `core/` | Indexer (marketplace scan + DIY frontmatter parse + compatibility filter), BM25 (Lucene IDF, k1=1.2, b=0.75), ollama `/api/embed` client (`search_document:`/`search_query:` prefixes, BM25 fallback), RRF fusion (k=60), L2-normalized Float32Array vector index, XDG content-hash embedding cache, shared render templates |
 | `eval/` | `tasks.json` (committed golden task set, k=5), `run-eval.ts` runner, ranker seam (`hybrid \| bm25Only \| embeddingOnly \| random(seed) \| oracle \| nameSubstring \| descriptionSubstring`), baseline derivation (`pi/tiers.yaml` + the export-opencode glob, computed offline), `results/` (gitignored per-run output) |
-| `pi/` | pi binding — **#2090, not yet present** |
+| `pi/` | pi binding (#2090) — default-exported extension factory: `search_skills` pull tool + `before_agent_start` push injection, `skill-discovery.json` config |
 | `opencode/` | OpenCode binding — **#2091, not yet present** |
 | `tests/` | `bun test` suites: frontmatter diff vs `Bun.YAML`, BM25 goldens + committed `rank_bm25` fixture, indexer over the mini-marketplace fixture, cache, fusion, embeddings fallback matrix, eval meta-tests |
 
@@ -55,23 +55,49 @@ This populates `adapters/node_modules`, which serves the OpenCode binding,
 at runtime (pi's extension loader aliases `typebox` and pi types to its own
 bundled copies); the install still matters for type-checking and tests.
 
-### pi (landing in #2090)
+### pi
+
+1. `cd <checkout>/claude-plugins/adapters && bun install` (once per checkout).
+   The pi binding resolves nothing from `node_modules` at pi runtime — pi's
+   extension loader aliases `typebox` to its bundled copy and the pi types
+   are `import type`-only — but skipping the install still surfaces as an
+   explicit "run `bun install` in `<checkout>/adapters`" error rather than a
+   bare resolution stack, and the install is required for `tsc`/`bun test`.
+2. Register the extension file:
 
 ```jsonc
 // <project>/.pi/settings.json
 { "extensions": ["/abs/path/to/claude-plugins/adapters/pi/index.ts"] }
 ```
 
-- Registers a `search_skills` tool (pull) and injects pins + top-k into the
-  system prompt per turn via `before_agent_start` (push), replacing the
-  native `<available_skills>` listing.
-- Caveat: project-scope extensions load only post-trust; in `-p`/json/rpc
-  modes with `defaultProjectTrust: ask` the extension is silently skipped —
-  prefer global registration (`~/.pi/agent/settings.json`) or `--approve`
-  for headless runs.
+- Registers a `search_skills` tool (pull) and injects pins + ranked top-k
+  into the system prompt per turn via `before_agent_start` (push), replacing
+  the native `<available_skills>` listing in place (before the
+  `Current working directory:` line). The binding never contributes paths
+  via `resources_discover` — that would refeed the uncapped native listing
+  it exists to replace.
+- **Trust caveat**: project-scope extensions load only **post-trust**; in
+  `-p`/json/rpc modes with `defaultProjectTrust: ask` (the default) the
+  extension is **silently skipped** — prefer global registration
+  (`~/.pi/agent/settings.json`) or `--approve` for headless runs.
 - Config: `~/.pi/agent/skill-discovery.json`, overridden key-by-key by
-  project `.pi/skill-discovery.json` (`repoRoot`, `k`, `endpoint`, `model`,
-  `pins`, `push`). Missing file = all defaults.
+  project `.pi/skill-discovery.json`. Missing file = all defaults
+  (`repoRoot` derives from the extension's own location in this checkout):
+
+```jsonc
+// .pi/skill-discovery.json — all keys optional
+{
+  "repoRoot": "/abs/path/to/claude-plugins", // marketplace checkout to index
+  "k": 5,                                    // push top-k (and search_skills default)
+  "endpoint": "http://localhost:11434",      // embedding endpoint
+  "model": "nomic-embed-text",               // embedding model
+  "pins": ["git-plugin:git-commit"],         // always injected; ranked results fill k after pins
+  "push": true                               // false = pull-only (debug/ablation)
+}
+```
+
+  Unknown pins warn and are skipped; malformed config files are ignored
+  with a warning (never fatal to the session).
 - Run consumers with no natively installed marketplace skills; `--no-skills`
   is optional (the binding never feeds the native loader).
 

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -7,11 +7,13 @@ top-k push injection instead of an uncapped static listing; delivery is
 always the model **reading the SKILL.md path** — skills are never copied.
 
 Architecture: [`docs/adrs/0022-adapter-over-export-for-foreign-harnesses.md`](../docs/adrs/0022-adapter-over-export-for-foreign-harnesses.md).
-Scope here (#2089): `core/` + `eval/` + tests. The harness bindings are
-**landing in [#2090](https://github.com/laurigates/claude-plugins/issues/2090)
-(pi) and [#2091](https://github.com/laurigates/claude-plugins/issues/2091)
-(OpenCode)** — the consumer wiring below is documented ahead so the shape is
-stable, but the binding files do not exist yet.
+`core/` + `eval/` + tests landed in
+[#2089](https://github.com/laurigates/claude-plugins/issues/2089); the pi
+binding (`pi/`) landed in
+[#2090](https://github.com/laurigates/claude-plugins/issues/2090). The
+OpenCode binding
+([#2091](https://github.com/laurigates/claude-plugins/issues/2091)) is
+documented ahead so the shape is stable, but its files do not exist yet.
 
 ## Layout
 
@@ -97,7 +99,9 @@ bundled copies); the install still matters for type-checking and tests.
 ```
 
   Unknown pins warn and are skipped; malformed config files are ignored
-  with a warning (never fatal to the session).
+  with a warning (never fatal to the session). Warnings — including the
+  BM25-only degradation notice when the embedding endpoint is unreachable —
+  are emitted once per session on stderr, prefixed `skill-discovery:`.
 - Run consumers with no natively installed marketplace skills; `--no-skills`
   is optional (the binding never feeds the native loader).
 

--- a/adapters/pi/config.ts
+++ b/adapters/pi/config.ts
@@ -20,6 +20,16 @@ import { DEFAULT_ENDPOINT, DEFAULT_K, DEFAULT_MODEL } from "../core/index.ts";
 
 export const CONFIG_FILE_NAME = "skill-discovery.json";
 
+/**
+ * pi's config dir name, hardcoded deliberately: pi exports `CONFIG_DIR_NAME`
+ * for this (pi-api.md §1), but it is a runtime *value* export and the DESIGN
+ * §1.2 import-surface restriction (enforced by the static check in
+ * tests/indexer.test.ts) allows only type-only imports from
+ * `@earendil-works/pi-coding-agent`. If pi ever renames the dir, this one
+ * constant is the only line to change.
+ */
+export const PI_CONFIG_DIR = ".pi";
+
 export interface SkillDiscoveryConfig {
   /** Marketplace checkout root; default derived from the extension's own location. */
   repoRoot: string;
@@ -135,8 +145,8 @@ export function loadConfig(opts: {
   globalPath?: string;
   projectPath?: string;
 }): LoadedConfig {
-  const globalPath = opts.globalPath ?? join(homedir(), ".pi", "agent", CONFIG_FILE_NAME);
-  const projectPath = opts.projectPath ?? join(process.cwd(), ".pi", CONFIG_FILE_NAME);
+  const globalPath = opts.globalPath ?? join(homedir(), PI_CONFIG_DIR, "agent", CONFIG_FILE_NAME);
+  const projectPath = opts.projectPath ?? join(process.cwd(), PI_CONFIG_DIR, CONFIG_FILE_NAME);
   const warnings: string[] = [];
 
   const readPartial = (path: string): Partial<SkillDiscoveryConfig> => {

--- a/adapters/pi/config.ts
+++ b/adapters/pi/config.ts
@@ -1,0 +1,188 @@
+/**
+ * skill-discovery.json load/merge for the pi binding (DESIGN §3.4).
+ *
+ * pi settings keys are a fixed set with no extension-config slot, so config
+ * lives in a dedicated file: global `~/.pi/agent/skill-discovery.json`,
+ * overridden key-by-key by project `.pi/skill-discovery.json` (same
+ * precedence direction as pi's own settings). Missing file = all defaults —
+ * the zero-config path works.
+ *
+ * Parsing is fail-safe per field (wrong-typed fields are ignored with a
+ * warning; malformed JSON ignores the whole file with a warning) so a config
+ * typo cannot take the session down — mirrors pi's own lenient resource
+ * loading.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_ENDPOINT, DEFAULT_K, DEFAULT_MODEL } from "../core/index.ts";
+
+export const CONFIG_FILE_NAME = "skill-discovery.json";
+
+export interface SkillDiscoveryConfig {
+  /** Marketplace checkout root; default derived from the extension's own location. */
+  repoRoot: string;
+  /** Push top-k (also the search_skills default k). */
+  k: number;
+  /** Embedding endpoint. */
+  endpoint: string;
+  /** Embedding model. */
+  model: string;
+  /** Always-injected skill ids ("plugin:skill"); ranked results fill k after pins. */
+  pins: string[];
+  /** false = pull-only (debug/ablation). */
+  push: boolean;
+}
+
+export function defaultConfig(defaultRepoRoot: string): SkillDiscoveryConfig {
+  return {
+    repoRoot: defaultRepoRoot,
+    k: DEFAULT_K,
+    endpoint: DEFAULT_ENDPOINT,
+    model: DEFAULT_MODEL,
+    pins: [],
+    push: true,
+  };
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+/**
+ * Parse one config file's JSON text into a partial config, fail-safe per
+ * field. `source` labels warnings so a consumer can tell which file (global
+ * vs project) carried the bad value.
+ */
+export function parseConfigText(
+  text: string,
+  source: string,
+): { partial: Partial<SkillDiscoveryConfig>; warnings: string[] } {
+  const warnings: string[] = [];
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { partial: {}, warnings: [`${source}: invalid JSON — file ignored (${message})`] };
+  }
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return { partial: {}, warnings: [`${source}: not a JSON object — file ignored`] };
+  }
+
+  const obj = raw as Record<string, unknown>;
+  const partial: Partial<SkillDiscoveryConfig> = {};
+  const ignore = (field: string, expected: string) => {
+    warnings.push(`${source}: "${field}" is not ${expected} — field ignored`);
+  };
+
+  for (const [key, value] of Object.entries(obj)) {
+    switch (key) {
+      case "repoRoot":
+      case "endpoint":
+      case "model":
+        if (typeof value === "string" && value.trim().length > 0) partial[key] = value;
+        else ignore(key, "a non-empty string");
+        break;
+      case "k":
+        if (typeof value === "number" && Number.isInteger(value) && value >= 1) partial.k = value;
+        else ignore(key, "an integer >= 1");
+        break;
+      case "pins":
+        if (isStringArray(value)) partial.pins = value;
+        else ignore(key, "an array of strings");
+        break;
+      case "push":
+        if (typeof value === "boolean") partial.push = value;
+        else ignore(key, "a boolean");
+        break;
+      default:
+        warnings.push(`${source}: unknown key "${key}" — ignored`);
+    }
+  }
+  return { partial, warnings };
+}
+
+/** Key-by-key merge: later partials override earlier ones. */
+export function mergeConfig(
+  base: SkillDiscoveryConfig,
+  ...overrides: Partial<SkillDiscoveryConfig>[]
+): SkillDiscoveryConfig {
+  const merged = { ...base };
+  for (const override of overrides) {
+    for (const [key, value] of Object.entries(override)) {
+      if (value !== undefined) {
+        (merged as Record<string, unknown>)[key] = value;
+      }
+    }
+  }
+  return merged;
+}
+
+export interface LoadedConfig {
+  config: SkillDiscoveryConfig;
+  warnings: string[];
+}
+
+/**
+ * Load global ← project config. `globalPath`/`projectPath` are injectable so
+ * tests never touch the real home directory; defaults follow pi's own
+ * settings locations.
+ */
+export function loadConfig(opts: {
+  defaultRepoRoot: string;
+  globalPath?: string;
+  projectPath?: string;
+}): LoadedConfig {
+  const globalPath = opts.globalPath ?? join(homedir(), ".pi", "agent", CONFIG_FILE_NAME);
+  const projectPath = opts.projectPath ?? join(process.cwd(), ".pi", CONFIG_FILE_NAME);
+  const warnings: string[] = [];
+
+  const readPartial = (path: string): Partial<SkillDiscoveryConfig> => {
+    if (!existsSync(path)) return {};
+    let text: string;
+    try {
+      text = readFileSync(path, "utf8");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      warnings.push(`${path}: unreadable — file ignored (${message})`);
+      return {};
+    }
+    const { partial, warnings: fileWarnings } = parseConfigText(text, path);
+    warnings.push(...fileWarnings);
+    return partial;
+  };
+
+  const config = mergeConfig(
+    defaultConfig(opts.defaultRepoRoot),
+    readPartial(globalPath),
+    readPartial(projectPath),
+  );
+  return { config, warnings };
+}
+
+/**
+ * Resolve pin ids against the index entries, in pin order. Unknown pins warn
+ * and are skipped; duplicates are deduped (DESIGN §3.4).
+ */
+export function resolvePins<T extends { id: string }>(
+  pins: string[],
+  entries: ReadonlyArray<T>,
+): { resolved: T[]; warnings: string[] } {
+  const byId = new Map(entries.map((entry) => [entry.id, entry]));
+  const seen = new Set<string>();
+  const resolved: T[] = [];
+  const warnings: string[] = [];
+  for (const pin of pins) {
+    if (seen.has(pin)) continue;
+    seen.add(pin);
+    const entry = byId.get(pin);
+    if (entry === undefined) {
+      warnings.push(`pin "${pin}" not found in the skill index — skipped`);
+      continue;
+    }
+    resolved.push(entry);
+  }
+  return { resolved, warnings };
+}

--- a/adapters/pi/index.ts
+++ b/adapters/pi/index.ts
@@ -103,6 +103,29 @@ export interface PushContext {
   config: SkillDiscoveryConfig;
 }
 
+/** Session warning emitted once when the index degraded to BM25-only (DESIGN §2.5). */
+export const BM25_ONLY_MODE_WARNING =
+  "embedding endpoint unreachable — degraded to BM25-only ranking for this session";
+
+/**
+ * Emit each not-yet-seen warning once, prefixed for attribution. pi exposes
+ * no extension-facing logging API (pi-api.md), so the default sink is
+ * `console.warn` — extension code runs in pi's process, where stderr reaches
+ * the user. The `seen` set is session-scoped (cleared on session_shutdown)
+ * so per-turn pin warnings do not repeat every turn.
+ */
+export function emitWarningsOnce(
+  seen: Set<string>,
+  warnings: readonly string[],
+  sink: (message: string) => void = (message) => console.warn(message),
+): void {
+  for (const warning of warnings) {
+    if (seen.has(warning)) continue;
+    seen.add(warning);
+    sink(`skill-discovery: ${warning}`);
+  }
+}
+
 /**
  * Build the per-turn system prompt: strip the native listing, rank against
  * the user prompt, inject pins + ranked top-k (pins first, deduped via the
@@ -132,9 +155,15 @@ export async function buildTurnSystemPrompt(
 export async function handleBeforeAgentStart(
   event: { prompt: string; systemPrompt: string },
   ctx: PushContext,
+  onWarnings?: (warnings: string[]) => void,
 ): Promise<{ systemPrompt: string } | undefined> {
   if (!ctx.config.push) return undefined;
-  const { systemPrompt } = await buildTurnSystemPrompt(event.systemPrompt, event.prompt, ctx);
+  const { systemPrompt, warnings } = await buildTurnSystemPrompt(
+    event.systemPrompt,
+    event.prompt,
+    ctx,
+  );
+  if (warnings.length > 0) onWarnings?.(warnings);
   return { systemPrompt };
 }
 
@@ -143,13 +172,15 @@ export async function handleBeforeAgentStart(
  * `details: {}` is always present — the AgentToolResult type declares it
  * required while docs examples omit it, so the defensive choice is to always
  * supply it. Failures throw (pi's convention) rather than being encoded in
- * content.
+ * content. `defaultK` is the config-level default (config.k, which is also
+ * the push top-k); an explicit `params.k` from the model always wins.
  */
 export async function runSearchSkills(
   index: Pick<SkillSearchIndex, "search">,
   params: { query: string; k?: number },
+  defaultK: number = DEFAULT_K,
 ): Promise<{ content: Array<{ type: "text"; text: string }>; details: Record<string, never> }> {
-  const results = await index.search(params.query, params.k ?? DEFAULT_K);
+  const results = await index.search(params.query, params.k ?? defaultK);
   return { content: [{ type: "text", text: renderToolResult(results) }], details: {} };
 }
 
@@ -211,19 +242,37 @@ const skillDiscovery = async (pi: ExtensionAPI): Promise<void> => {
 
   let loaded: { config: SkillDiscoveryConfig; warnings: string[] } | null = null;
   let indexPromise: Promise<SkillIndex> | null = null;
+  /** Warnings already surfaced this session — emitted once, not per turn. */
+  const warned = new Set<string>();
 
   const getConfig = (): SkillDiscoveryConfig => {
     loaded ??= loadConfig({ defaultRepoRoot: DEFAULT_REPO_ROOT });
+    // Surface config-file warnings ("ignored with a warning" is the
+    // documented fail-safe contract); the dedupe set makes this once per
+    // session even though getConfig runs every turn.
+    emitWarningsOnce(warned, loaded.warnings);
     return loaded.config;
   };
 
   const ensureIndex = (): Promise<SkillIndex> => {
     if (indexPromise === null) {
       const config = getConfig();
-      indexPromise = buildIndex({
+      const built = buildIndex({
         repoRoot: config.repoRoot,
         embed: { endpoint: config.endpoint, model: config.model },
+      }).then((index) => {
+        // DESIGN §2.5: degradation is silent in the core; the binding logs
+        // the resolved mode once.
+        if (index.mode === "bm25-only") emitWarningsOnce(warned, [BM25_ONLY_MODE_WARNING]);
+        return index;
       });
+      // A rejected build must not poison the whole session: clear the cache
+      // so the next call retries, while the current caller still sees the
+      // original rejection. Identity-guarded so a newer retry isn't clobbered.
+      built.catch(() => {
+        if (indexPromise === built) indexPromise = null;
+      });
+      indexPromise = built;
     }
     return indexPromise;
   };
@@ -244,7 +293,9 @@ const skillDiscovery = async (pi: ExtensionAPI): Promise<void> => {
       "After search_skills returns, read the SKILL.md path of the best match before acting.",
     ],
     async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
-      return runSearchSkills(await ensureIndex(), params);
+      // config.k is the tool's default k too (config.ts / README contract);
+      // an explicit params.k from the model wins.
+      return runSearchSkills(await ensureIndex(), params, getConfig().k);
     },
   });
 
@@ -255,6 +306,7 @@ const skillDiscovery = async (pi: ExtensionAPI): Promise<void> => {
   pi.on("session_shutdown", () => {
     loaded = null;
     indexPromise = null;
+    warned.clear();
   });
 
   pi.on("before_agent_start", async (event) => {
@@ -263,6 +315,7 @@ const skillDiscovery = async (pi: ExtensionAPI): Promise<void> => {
     return handleBeforeAgentStart(
       { prompt: event.prompt, systemPrompt: event.systemPrompt },
       { index, config },
+      (warnings) => emitWarningsOnce(warned, warnings),
     );
   });
 };

--- a/adapters/pi/index.ts
+++ b/adapters/pi/index.ts
@@ -1,0 +1,270 @@
+/**
+ * pi extension binding (#2090, DESIGN §3) over the shared discovery core.
+ *
+ * Default-exports the pi extension factory. Registers the `search_skills`
+ * pull tool and a `before_agent_start` push handler that replaces pi's
+ * native uncapped `<available_skills>` listing with pins + ranked top-k,
+ * rendered by the same core/render.ts template the eval token accounting
+ * uses.
+ *
+ * Runtime import surface is deliberately restricted (DESIGN §1.2, enforced
+ * by the static import check in tests/indexer.test.ts): `typebox` (pi's
+ * extension loader aliases it to its bundled 1.1.x copy — the local install
+ * serves only tsc/bun test), TYPE-ONLY imports from
+ * `@earendil-works/pi-coding-agent` (erased at transpile time; the live API
+ * object is the factory parameter), `node:*`, and relative paths into
+ * ../core/. The binding never uses `resources_discover` — contributed paths
+ * would feed the uncapped native listing this binding exists to replace.
+ */
+
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+  AVAILABLE_SKILLS_CLOSE,
+  AVAILABLE_SKILLS_OPEN,
+  buildIndex,
+  DEFAULT_K,
+  INJECTED_BLOCK_TRAILER,
+  renderInjectedBlock,
+  renderToolResult,
+  SEARCH_SKILLS_TOOL_DESCRIPTION,
+  type SearchFilters,
+  type SearchResult,
+  type SkillIndex,
+} from "../core/index.ts";
+import { loadConfig, resolvePins, type SkillDiscoveryConfig } from "./config.ts";
+
+const PI_DIR = dirname(fileURLToPath(import.meta.url));
+/** The bun package root — where `bun install` must have been run. */
+export const ADAPTERS_DIR = resolve(PI_DIR, "..");
+/**
+ * repoRoot default: the extension lives inside the checkout it indexes
+ * (adapters/pi/index.ts → two dirs up), so the common case is zero-config.
+ */
+export const DEFAULT_REPO_ROOT = resolve(ADAPTERS_DIR, "..");
+
+/** The stable structural marker pi appends the skills block before. */
+export const CWD_MARKER = "Current working directory:";
+
+/**
+ * Remove the `<available_skills>…</available_skills>` block from a system
+ * prompt (indexOf/slice, not regex — no backtracking surface). The 4-line
+ * native preamble is left in place: tag boundaries are stable structural
+ * markers, prose isn't, and a preamble with no block after it is harmless.
+ *
+ * - No block present (the expected consumer state): no-op.
+ * - Malformed (open tag without close): input returned unchanged.
+ * - Our own previously injected block (close tag followed by the trailer
+ *   line) is removed including the trailer, making strip+inject idempotent.
+ */
+export function stripAvailableSkillsBlock(systemPrompt: string): string {
+  const open = systemPrompt.indexOf(AVAILABLE_SKILLS_OPEN);
+  if (open === -1) return systemPrompt;
+  const closeStart = systemPrompt.indexOf(AVAILABLE_SKILLS_CLOSE, open);
+  if (closeStart === -1) return systemPrompt;
+  let end = closeStart + AVAILABLE_SKILLS_CLOSE.length;
+  if (systemPrompt[end] === "\n") end += 1;
+  if (systemPrompt.startsWith(INJECTED_BLOCK_TRAILER, end)) {
+    end += INJECTED_BLOCK_TRAILER.length;
+    if (systemPrompt[end] === "\n") end += 1;
+  }
+  return systemPrompt.slice(0, open) + systemPrompt.slice(end);
+}
+
+/**
+ * Insert the rendered block where the native listing sat: before the
+ * trailing "Current working directory:" line when locatable, else appended
+ * at the end (DESIGN §3.3).
+ */
+export function injectSkillsBlock(systemPrompt: string, block: string): string {
+  const markerIdx = systemPrompt.lastIndexOf(CWD_MARKER);
+  if (markerIdx === -1) {
+    return systemPrompt.endsWith("\n")
+      ? `${systemPrompt}${block}\n`
+      : `${systemPrompt}\n${block}\n`;
+  }
+  const lineStart = systemPrompt.lastIndexOf("\n", markerIdx) + 1;
+  return `${systemPrompt.slice(0, lineStart)}${block}\n${systemPrompt.slice(lineStart)}`;
+}
+
+/**
+ * The minimal index surface the binding consumes — lets tests stub it with
+ * a small typed object instead of building a real index or running pi.
+ * The real SkillIndex satisfies it structurally.
+ */
+export interface SkillSearchIndex {
+  entries: ReadonlyArray<{ id: string; name: string; description: string; path: string }>;
+  search(query: string, k?: number, filters?: SearchFilters): Promise<SearchResult[]>;
+}
+
+export interface PushContext {
+  index: SkillSearchIndex;
+  config: SkillDiscoveryConfig;
+}
+
+/**
+ * Build the per-turn system prompt: strip the native listing, rank against
+ * the user prompt, inject pins + ranked top-k (pins first, deduped via the
+ * excludeIds filter, capped at k by the shared renderer).
+ */
+export async function buildTurnSystemPrompt(
+  systemPrompt: string,
+  userPrompt: string,
+  ctx: PushContext,
+): Promise<{ systemPrompt: string; warnings: string[] }> {
+  const { resolved: pins, warnings } = resolvePins(ctx.config.pins, ctx.index.entries);
+  const filters = pins.length > 0 ? { excludeIds: pins.map((pin) => pin.id) } : undefined;
+  const ranked = await ctx.index.search(userPrompt, ctx.config.k, filters);
+  const block = renderInjectedBlock(pins, ranked, ctx.config.k);
+  return {
+    systemPrompt: injectSkillsBlock(stripAvailableSkillsBlock(systemPrompt), block),
+    warnings,
+  };
+}
+
+/**
+ * The before_agent_start push handler body (DESIGN §3.3). Takes only the
+ * event fields it needs; `event.systemPromptOptions` is deliberately not
+ * accepted — treating it as read-only by construction (mutations can leak
+ * into future prompt rebuilds).
+ */
+export async function handleBeforeAgentStart(
+  event: { prompt: string; systemPrompt: string },
+  ctx: PushContext,
+): Promise<{ systemPrompt: string } | undefined> {
+  if (!ctx.config.push) return undefined;
+  const { systemPrompt } = await buildTurnSystemPrompt(event.systemPrompt, event.prompt, ctx);
+  return { systemPrompt };
+}
+
+/**
+ * search_skills execute body: top-k results with the SKILL.md path to read.
+ * `details: {}` is always present — the AgentToolResult type declares it
+ * required while docs examples omit it, so the defensive choice is to always
+ * supply it. Failures throw (pi's convention) rather than being encoded in
+ * content.
+ */
+export async function runSearchSkills(
+  index: Pick<SkillSearchIndex, "search">,
+  params: { query: string; k?: number },
+): Promise<{ content: Array<{ type: "text"; text: string }>; details: Record<string, never> }> {
+  const results = await index.search(params.query, params.k ?? DEFAULT_K);
+  return { content: [{ type: "text", text: renderToolResult(results) }], details: {} };
+}
+
+const MODULE_RESOLUTION_CODES = new Set([
+  "ERR_MODULE_NOT_FOUND",
+  "MODULE_NOT_FOUND",
+  "ERR_PACKAGE_PATH_NOT_EXPORTED",
+]);
+
+/**
+ * Rethrow helper for the fresh-clone failure mode: a module-resolution error
+ * gets an explicit "run `bun install` in <checkout>/adapters" message so the
+ * consumer gets a diagnosable error instead of a bare resolution stack (and
+ * pi's silent-skip in headless pre-trust modes doesn't compound an
+ * undiagnosed one). Non-resolution errors pass through unchanged.
+ */
+export function wrapModuleResolutionError(
+  err: unknown,
+  specifier: string,
+  adaptersDir: string = ADAPTERS_DIR,
+): unknown {
+  const code =
+    typeof err === "object" && err !== null && "code" in err
+      ? String((err as { code: unknown }).code)
+      : "";
+  const message = err instanceof Error ? err.message : String(err);
+  const isResolution =
+    MODULE_RESOLUTION_CODES.has(code) || /cannot (find|resolve) (module|package)/i.test(message);
+  if (!isResolution) return err;
+  return new Error(
+    `skill-discovery: failed to resolve "${specifier}" — run \`bun install\` in ${adaptersDir} (original: ${message})`,
+    { cause: err },
+  );
+}
+
+/**
+ * The binding's first import-dependent action (DESIGN §3.1). At pi runtime
+ * the extension loader aliases/virtualizes "typebox" to pi's bundled copy,
+ * so this never resolves from adapters/node_modules under pi; a dynamic
+ * import keeps the failure catchable so the bun-install hint above can fire
+ * where a static top-level import would abort module load first.
+ */
+async function importTypebox(): Promise<typeof import("typebox")> {
+  try {
+    return await import("typebox");
+  } catch (err) {
+    throw wrapModuleResolutionError(err, "typebox");
+  }
+}
+
+/**
+ * pi extension factory. Heavy work (index build) happens on session_start,
+ * not here — factories run in invocations that never start a session;
+ * teardown in session_shutdown. The index is built lazily and cached across
+ * turns; config is read once per session.
+ */
+const skillDiscovery = async (pi: ExtensionAPI): Promise<void> => {
+  const { Type } = await importTypebox();
+
+  let loaded: { config: SkillDiscoveryConfig; warnings: string[] } | null = null;
+  let indexPromise: Promise<SkillIndex> | null = null;
+
+  const getConfig = (): SkillDiscoveryConfig => {
+    loaded ??= loadConfig({ defaultRepoRoot: DEFAULT_REPO_ROOT });
+    return loaded.config;
+  };
+
+  const ensureIndex = (): Promise<SkillIndex> => {
+    if (indexPromise === null) {
+      const config = getConfig();
+      indexPromise = buildIndex({
+        repoRoot: config.repoRoot,
+        embed: { endpoint: config.endpoint, model: config.model },
+      });
+    }
+    return indexPromise;
+  };
+
+  pi.registerTool({
+    name: "search_skills",
+    label: "Search skills",
+    description: SEARCH_SKILLS_TOOL_DESCRIPTION,
+    parameters: Type.Object({
+      query: Type.String({ description: "What you are trying to do, in plain words" }),
+      k: Type.Optional(Type.Number({ minimum: 1, maximum: 20 })),
+    }),
+    promptSnippet: "search_skills: find task-specific skills by describing the task",
+    // Bullets are appended flat with no tool-name prefix — each must name
+    // the tool explicitly.
+    promptGuidelines: [
+      "Use search_skills when a task looks routine enough that a skill may exist for it.",
+      "After search_skills returns, read the SKILL.md path of the best match before acting.",
+    ],
+    async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
+      return runSearchSkills(await ensureIndex(), params);
+    },
+  });
+
+  pi.on("session_start", async () => {
+    await ensureIndex();
+  });
+
+  pi.on("session_shutdown", () => {
+    loaded = null;
+    indexPromise = null;
+  });
+
+  pi.on("before_agent_start", async (event) => {
+    const config = getConfig();
+    const index = await ensureIndex();
+    return handleBeforeAgentStart(
+      { prompt: event.prompt, systemPrompt: event.systemPrompt },
+      { index, config },
+    );
+  });
+};
+
+export default skillDiscovery;

--- a/adapters/tests/indexer.test.ts
+++ b/adapters/tests/indexer.test.ts
@@ -152,31 +152,30 @@ describe("static import restrictions", () => {
     expect(violations).toEqual([]);
   });
 
-  // pi/ lands in #2090; the restriction is encoded now so a future dep
-  // addition cannot silently depend on unverified jiti-in-binary
-  // node_modules resolution. Skips gracefully while the dir is absent.
+  // pi/ restriction (#2090): a future dep addition must not silently depend
+  // on unverified jiti-in-binary node_modules resolution. Type-only imports
+  // from the pi package (single- or multi-line) are erased at transpile
+  // time, so they are scrubbed before scanning; any remaining pi-package
+  // specifier — i.e. a value import — is a violation.
   const piDir = join(ADAPTERS_ROOT, "pi");
-  test.skipIf(!existsSync(piDir))(
-    "pi/ imports only typebox, type-only pi-coding-agent, node:*, and relative paths",
-    () => {
-      const violations: string[] = [];
-      for (const file of tsFilesUnder(piDir)) {
-        const source = readFileSync(file, "utf8");
-        for (const line of source.split("\n")) {
-          const m = /(?:from\s+|import\s+|import\s*\(\s*|require\s*\(\s*)["']([^"']+)["']/.exec(
-            line,
-          );
-          if (!m) continue;
-          const spec = m[1] as string;
-          if (spec.startsWith("node:") || spec.startsWith("./") || spec.startsWith("../")) continue;
-          if (spec === "typebox") continue;
-          if (spec === "@earendil-works/pi-coding-agent" && /^\s*import\s+type\s/.test(line)) {
-            continue; // type-only: erased at transpile time
-          }
-          violations.push(`${file}: ${line.trim()}`);
-        }
+  test("pi/ exists (the #2090 binding is present)", () => {
+    expect(existsSync(piDir)).toBe(true);
+  });
+
+  test("pi/ imports only typebox, type-only pi-coding-agent, node:*, and relative paths", () => {
+    const violations: string[] = [];
+    for (const file of tsFilesUnder(piDir)) {
+      const source = readFileSync(file, "utf8").replace(
+        /import\s+type\s+[^;]*?from\s+["']@earendil-works\/pi-coding-agent["'];?/g,
+        "",
+      );
+      for (const match of source.matchAll(IMPORT_RE)) {
+        const spec = match[1] as string;
+        if (spec.startsWith("node:") || spec.startsWith("./") || spec.startsWith("../")) continue;
+        if (spec === "typebox") continue;
+        violations.push(`${file}: ${spec}`);
       }
-      expect(violations).toEqual([]);
-    },
-  );
+    }
+    expect(violations).toEqual([]);
+  });
 });

--- a/adapters/tests/pi-binding.test.ts
+++ b/adapters/tests/pi-binding.test.ts
@@ -1,0 +1,400 @@
+/**
+ * pi binding tests (DESIGN §7.5) — pure helpers only, no live pi. The
+ * ExtensionAPI surface is mocked with a minimal typed stub; harness-level
+ * behavior (jiti loading, trust gating, prompt emission) is out of scope.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionAPI, ToolDefinition } from "@earendil-works/pi-coding-agent";
+import type { SearchFilters, SearchResult } from "../core/index.ts";
+import {
+  AVAILABLE_SKILLS_CLOSE,
+  AVAILABLE_SKILLS_OPEN,
+  DEFAULT_ENDPOINT,
+  DEFAULT_K,
+  DEFAULT_MODEL,
+  INJECTED_BLOCK_TRAILER,
+} from "../core/index.ts";
+import {
+  CONFIG_FILE_NAME,
+  defaultConfig,
+  loadConfig,
+  mergeConfig,
+  parseConfigText,
+  resolvePins,
+} from "../pi/config.ts";
+import skillDiscovery, {
+  buildTurnSystemPrompt,
+  CWD_MARKER,
+  DEFAULT_REPO_ROOT,
+  handleBeforeAgentStart,
+  injectSkillsBlock,
+  runSearchSkills,
+  type SkillSearchIndex,
+  stripAvailableSkillsBlock,
+  wrapModuleResolutionError,
+} from "../pi/index.ts";
+
+// --- fixtures -------------------------------------------------------------
+
+const NATIVE_BLOCK = [
+  AVAILABLE_SKILLS_OPEN,
+  "  <skill><name>foo</name><description>Foo skill</description><location>/abs/foo/SKILL.md</location></skill>",
+  AVAILABLE_SKILLS_CLOSE,
+].join("\n");
+
+const PREAMBLE = "You are pi.\n\nSkills may be listed below.\n";
+const PROMPT_WITH_BLOCK = `${PREAMBLE}${NATIVE_BLOCK}\n${CWD_MARKER} /work/dir\n`;
+const PROMPT_WITHOUT_BLOCK = `${PREAMBLE}${CWD_MARKER} /work/dir\n`;
+const PROMPT_NO_MARKER = "You are pi. No cwd line here.";
+
+const entry = (id: string) => ({
+  id,
+  name: id.split(":")[1] as string,
+  description: `Description for ${id}`,
+  path: `/abs/${id.replace(":", "/")}/SKILL.md`,
+});
+
+const ENTRIES = [entry("a:pin"), entry("b:one"), entry("c:two"), entry("d:three")];
+
+function stubIndex(overrides?: Partial<SkillSearchIndex>): SkillSearchIndex & {
+  calls: Array<{ query: string; k: number | undefined; filters: SearchFilters | undefined }>;
+} {
+  const calls: Array<{
+    query: string;
+    k: number | undefined;
+    filters: SearchFilters | undefined;
+  }> = [];
+  return {
+    calls,
+    entries: ENTRIES,
+    async search(query, k, filters) {
+      calls.push({ query, k, filters });
+      const excluded = new Set(filters?.excludeIds ?? []);
+      return ENTRIES.filter((e) => !excluded.has(e.id))
+        .slice(0, k ?? DEFAULT_K)
+        .map((e, i) => ({ ...e, score: 1 / (i + 1) }) satisfies SearchResult);
+    },
+    ...overrides,
+  };
+}
+
+// --- strip ----------------------------------------------------------------
+
+describe("stripAvailableSkillsBlock", () => {
+  test("removes the native block, keeping preamble and cwd line", () => {
+    const stripped = stripAvailableSkillsBlock(PROMPT_WITH_BLOCK);
+    expect(stripped).not.toContain(AVAILABLE_SKILLS_OPEN);
+    expect(stripped).not.toContain(AVAILABLE_SKILLS_CLOSE);
+    expect(stripped).toContain("Skills may be listed below.");
+    expect(stripped).toContain(`${CWD_MARKER} /work/dir`);
+    expect(stripped).toBe(PROMPT_WITHOUT_BLOCK);
+  });
+
+  test("block-absent prompt passes through unchanged", () => {
+    expect(stripAvailableSkillsBlock(PROMPT_WITHOUT_BLOCK)).toBe(PROMPT_WITHOUT_BLOCK);
+  });
+
+  test("malformed unclosed block returns the input unchanged", () => {
+    const malformed = `${PREAMBLE}${AVAILABLE_SKILLS_OPEN}\n  <skill>oops\n${CWD_MARKER} /w\n`;
+    expect(stripAvailableSkillsBlock(malformed)).toBe(malformed);
+  });
+
+  test("removes a previously injected block including the trailer line", () => {
+    const block = `${AVAILABLE_SKILLS_OPEN}\n${AVAILABLE_SKILLS_CLOSE}\n${INJECTED_BLOCK_TRAILER}`;
+    const injected = injectSkillsBlock(PROMPT_WITHOUT_BLOCK, block);
+    expect(stripAvailableSkillsBlock(injected)).toBe(PROMPT_WITHOUT_BLOCK);
+  });
+});
+
+// --- inject ---------------------------------------------------------------
+
+describe("injectSkillsBlock", () => {
+  const BLOCK = `${AVAILABLE_SKILLS_OPEN}\n${AVAILABLE_SKILLS_CLOSE}\n${INJECTED_BLOCK_TRAILER}`;
+
+  test("inserts immediately before the Current working directory line", () => {
+    const result = injectSkillsBlock(PROMPT_WITHOUT_BLOCK, BLOCK);
+    const lines = result.split("\n");
+    const cwdIdx = lines.findIndex((l) => l.startsWith(CWD_MARKER));
+    expect(cwdIdx).toBeGreaterThan(0);
+    expect(lines[cwdIdx - 1]).toBe(INJECTED_BLOCK_TRAILER);
+    expect(lines).toContain(AVAILABLE_SKILLS_OPEN);
+  });
+
+  test("appends at the end when no marker is present", () => {
+    const result = injectSkillsBlock(PROMPT_NO_MARKER, BLOCK);
+    expect(result.startsWith(PROMPT_NO_MARKER)).toBe(true);
+    expect(result.trimEnd().endsWith(INJECTED_BLOCK_TRAILER)).toBe(true);
+  });
+
+  test("strip+inject is idempotent on prompts with and without the block", () => {
+    const edit = (prompt: string) => injectSkillsBlock(stripAvailableSkillsBlock(prompt), BLOCK);
+    for (const prompt of [PROMPT_WITH_BLOCK, PROMPT_WITHOUT_BLOCK, PROMPT_NO_MARKER]) {
+      const once = edit(prompt);
+      expect(edit(once)).toBe(once);
+    }
+  });
+});
+
+// --- config ---------------------------------------------------------------
+
+describe("pi config", () => {
+  test("defaults", () => {
+    const config = defaultConfig("/repo");
+    expect(config).toEqual({
+      repoRoot: "/repo",
+      k: DEFAULT_K,
+      endpoint: DEFAULT_ENDPOINT,
+      model: DEFAULT_MODEL,
+      pins: [],
+      push: true,
+    });
+  });
+
+  test("parseConfigText accepts valid fields and warns on bad ones", () => {
+    const { partial, warnings } = parseConfigText(
+      JSON.stringify({ k: 3, pins: ["a:pin"], push: false, endpoint: 7, unknownKey: true }),
+      "test.json",
+    );
+    expect(partial).toEqual({ k: 3, pins: ["a:pin"], push: false });
+    expect(warnings.some((w) => w.includes('"endpoint"'))).toBe(true);
+    expect(warnings.some((w) => w.includes("unknownKey"))).toBe(true);
+  });
+
+  test("parseConfigText ignores a malformed file with a warning", () => {
+    const { partial, warnings } = parseConfigText("{not json", "bad.json");
+    expect(partial).toEqual({});
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("invalid JSON");
+  });
+
+  test("non-integer or out-of-range k is ignored", () => {
+    expect(parseConfigText(JSON.stringify({ k: 0 }), "s").partial).toEqual({});
+    expect(parseConfigText(JSON.stringify({ k: 2.5 }), "s").partial).toEqual({});
+  });
+
+  test("mergeConfig: project overrides global key-by-key", () => {
+    const merged = mergeConfig(
+      defaultConfig("/repo"),
+      { k: 3, pins: ["a:pin"] }, // global
+      { k: 7 }, // project
+    );
+    expect(merged.k).toBe(7);
+    expect(merged.pins).toEqual(["a:pin"]); // untouched by project
+    expect(merged.repoRoot).toBe("/repo");
+  });
+
+  test("loadConfig: missing files yield all defaults", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-config-"));
+    const { config, warnings } = loadConfig({
+      defaultRepoRoot: "/repo",
+      globalPath: join(dir, "absent-global.json"),
+      projectPath: join(dir, "absent-project.json"),
+    });
+    expect(config).toEqual(defaultConfig("/repo"));
+    expect(warnings).toEqual([]);
+  });
+
+  test("loadConfig: global <- project precedence over real files", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-config-"));
+    const globalPath = join(dir, "global", CONFIG_FILE_NAME);
+    const projectPath = join(dir, "project", CONFIG_FILE_NAME);
+    mkdirSync(join(dir, "global"));
+    mkdirSync(join(dir, "project"));
+    writeFileSync(globalPath, JSON.stringify({ k: 3, pins: ["a:pin"], model: "custom-model" }));
+    writeFileSync(projectPath, JSON.stringify({ k: 7, push: false }));
+    const { config, warnings } = loadConfig({
+      defaultRepoRoot: "/repo",
+      globalPath,
+      projectPath,
+    });
+    expect(config.k).toBe(7);
+    expect(config.push).toBe(false);
+    expect(config.pins).toEqual(["a:pin"]);
+    expect(config.model).toBe("custom-model");
+    expect(config.endpoint).toBe(DEFAULT_ENDPOINT);
+    expect(warnings).toEqual([]);
+  });
+});
+
+// --- pins -----------------------------------------------------------------
+
+describe("resolvePins", () => {
+  test("resolves known pins in order, warns and skips unknown, dedupes", () => {
+    const { resolved, warnings } = resolvePins(
+      ["c:two", "nope:missing", "a:pin", "c:two"],
+      ENTRIES,
+    );
+    expect(resolved.map((r) => r.id)).toEqual(["c:two", "a:pin"]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('"nope:missing"');
+  });
+});
+
+// --- search_skills tool result --------------------------------------------
+
+describe("runSearchSkills", () => {
+  test("result shape: text content plus always-present details: {}", async () => {
+    const index = stubIndex();
+    const result = await runSearchSkills(index, { query: "commit my work" });
+    expect(result.details).toEqual({});
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]?.type).toBe("text");
+    expect(result.content[0]?.text).toContain("a:pin");
+    expect(result.content[0]?.text).toContain("read: /abs/a/pin/SKILL.md");
+    expect(index.calls[0]?.k).toBe(DEFAULT_K);
+  });
+
+  test("explicit k is passed through", async () => {
+    const index = stubIndex();
+    await runSearchSkills(index, { query: "q", k: 2 });
+    expect(index.calls[0]?.k).toBe(2);
+  });
+
+  test("failures propagate as thrown errors, never encoded in content", async () => {
+    const failing: Pick<SkillSearchIndex, "search"> = {
+      search: async () => {
+        throw new Error("index unavailable");
+      },
+    };
+    await expect(runSearchSkills(failing, { query: "q" })).rejects.toThrow("index unavailable");
+  });
+});
+
+// --- push channel ---------------------------------------------------------
+
+describe("buildTurnSystemPrompt / handleBeforeAgentStart", () => {
+  const config = { ...defaultConfig("/repo"), k: 3, pins: ["c:two"] };
+
+  test("pins first, ranked fill k, native block replaced in place", async () => {
+    const index = stubIndex();
+    const { systemPrompt, warnings } = await buildTurnSystemPrompt(
+      PROMPT_WITH_BLOCK,
+      "what do I do",
+      { index, config },
+    );
+    expect(warnings).toEqual([]);
+    // Ranking used the user prompt and excluded the pin.
+    expect(index.calls[0]?.query).toBe("what do I do");
+    expect(index.calls[0]?.filters?.excludeIds).toEqual(["c:two"]);
+    const ids = [...systemPrompt.matchAll(/<name>([^<]+)<\/name>/g)].map((m) => m[1]);
+    expect(ids).toEqual(["c:two", "a:pin", "b:one"]); // pin first, k=3 cap
+    expect(ids).not.toContain("foo"); // native block gone
+    // Injected where the native block sat: before the cwd line.
+    const lines = systemPrompt.split("\n");
+    const cwdIdx = lines.findIndex((l) => l.startsWith(CWD_MARKER));
+    expect(lines[cwdIdx - 1]).toBe(INJECTED_BLOCK_TRAILER);
+  });
+
+  test("unknown pins warn and are skipped", async () => {
+    const index = stubIndex();
+    const { warnings } = await buildTurnSystemPrompt(PROMPT_WITHOUT_BLOCK, "q", {
+      index,
+      config: { ...config, pins: ["nope:missing"] },
+    });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("nope:missing");
+  });
+
+  test("push: false yields undefined (pull-only mode)", async () => {
+    const index = stubIndex();
+    const result = await handleBeforeAgentStart(
+      { prompt: "q", systemPrompt: PROMPT_WITH_BLOCK },
+      { index, config: { ...config, push: false } },
+    );
+    expect(result).toBeUndefined();
+    expect(index.calls).toHaveLength(0);
+  });
+
+  test("event and systemPromptOptions are treated as read-only", async () => {
+    const index = stubIndex();
+    const systemPromptOptions = Object.freeze({ cwd: "/work/dir" });
+    const event = Object.freeze({
+      prompt: "q",
+      systemPrompt: PROMPT_WITH_BLOCK,
+      systemPromptOptions,
+    });
+    const result = await handleBeforeAgentStart(event, { index, config });
+    expect(result?.systemPrompt).toContain(AVAILABLE_SKILLS_OPEN);
+    expect(event.systemPrompt).toBe(PROMPT_WITH_BLOCK); // input untouched
+    expect(systemPromptOptions).toEqual({ cwd: "/work/dir" });
+  });
+});
+
+// --- module-resolution rethrow --------------------------------------------
+
+describe("wrapModuleResolutionError", () => {
+  test("resolution errors get the bun-install hint", () => {
+    const err = Object.assign(new Error('Cannot find package "typebox"'), {
+      code: "ERR_MODULE_NOT_FOUND",
+    });
+    const wrapped = wrapModuleResolutionError(err, "typebox", "/checkout/adapters");
+    expect(wrapped).toBeInstanceOf(Error);
+    const message = (wrapped as Error).message;
+    expect(message).toContain("run `bun install` in /checkout/adapters");
+    expect(message).toContain('"typebox"');
+    expect((wrapped as Error).cause).toBe(err);
+  });
+
+  test("message-only resolution errors (no code) are also wrapped", () => {
+    const err = new Error("Cannot find module 'typebox' from '/x/pi/index.ts'");
+    const wrapped = wrapModuleResolutionError(err, "typebox", "/a");
+    expect((wrapped as Error).message).toContain("bun install");
+  });
+
+  test("unrelated errors pass through unchanged", () => {
+    const err = new Error("boom");
+    expect(wrapModuleResolutionError(err, "typebox", "/a")).toBe(err);
+  });
+});
+
+// --- factory over a minimal typed ExtensionAPI stub -----------------------
+
+describe("extension factory", () => {
+  function createMockPi() {
+    const tools: ToolDefinition[] = [];
+    const handlers = new Map<string, (event: unknown, ctx: unknown) => unknown>();
+    const mock = {
+      registerTool(tool: ToolDefinition) {
+        tools.push(tool);
+      },
+      on(event: string, handler: (event: unknown, ctx: unknown) => unknown) {
+        handlers.set(event, handler);
+      },
+    };
+    return { pi: mock as unknown as ExtensionAPI, tools, handlers };
+  }
+
+  test("registers search_skills and the session/push handlers", async () => {
+    const { pi, tools, handlers } = createMockPi();
+    await skillDiscovery(pi);
+
+    expect(tools).toHaveLength(1);
+    const tool = tools[0] as ToolDefinition;
+    expect(tool.name).toBe("search_skills");
+    expect(tool.label).toBe("Search skills");
+    expect(tool.description).toContain("read that path to load the skill");
+    expect(tool.promptSnippet).toContain("search_skills");
+    for (const bullet of tool.promptGuidelines ?? []) {
+      expect(bullet).toContain("search_skills"); // bullets must name the tool
+    }
+    const parameters = tool.parameters as unknown as {
+      required?: string[];
+      properties?: Record<string, { type?: string }>;
+    };
+    expect(parameters.required).toEqual(["query"]);
+    expect(parameters.properties?.query?.type).toBe("string");
+    expect(parameters.properties?.k?.type).toBe("number");
+
+    for (const eventName of ["session_start", "session_shutdown", "before_agent_start"]) {
+      expect(handlers.has(eventName)).toBe(true);
+    }
+  });
+
+  test("zero-config repoRoot default points at the marketplace checkout", () => {
+    expect(existsSync(join(DEFAULT_REPO_ROOT, ".claude-plugin", "marketplace.json"))).toBe(true);
+  });
+});

--- a/adapters/tests/pi-binding.test.ts
+++ b/adapters/tests/pi-binding.test.ts
@@ -27,9 +27,11 @@ import {
   resolvePins,
 } from "../pi/config.ts";
 import skillDiscovery, {
+  BM25_ONLY_MODE_WARNING,
   buildTurnSystemPrompt,
   CWD_MARKER,
   DEFAULT_REPO_ROOT,
+  emitWarningsOnce,
   handleBeforeAgentStart,
   injectSkillsBlock,
   runSearchSkills,
@@ -254,6 +256,18 @@ describe("runSearchSkills", () => {
     expect(index.calls[0]?.k).toBe(2);
   });
 
+  test("configured default k (config.k) is used when params.k is absent", async () => {
+    const index = stubIndex();
+    await runSearchSkills(index, { query: "q" }, 9);
+    expect(index.calls[0]?.k).toBe(9);
+  });
+
+  test("explicit params.k wins over the configured default", async () => {
+    const index = stubIndex();
+    await runSearchSkills(index, { query: "q", k: 2 }, 9);
+    expect(index.calls[0]?.k).toBe(2);
+  });
+
   test("failures propagate as thrown errors, never encoded in content", async () => {
     const failing: Pick<SkillSearchIndex, "search"> = {
       search: async () => {
@@ -299,6 +313,29 @@ describe("buildTurnSystemPrompt / handleBeforeAgentStart", () => {
     expect(warnings[0]).toContain("nope:missing");
   });
 
+  test("pin warnings are forwarded to the onWarnings callback", async () => {
+    const index = stubIndex();
+    const received: string[][] = [];
+    await handleBeforeAgentStart(
+      { prompt: "q", systemPrompt: PROMPT_WITHOUT_BLOCK },
+      { index, config: { ...config, pins: ["nope:missing"] } },
+      (warnings) => received.push(warnings),
+    );
+    expect(received).toHaveLength(1);
+    expect(received[0]?.[0]).toContain("nope:missing");
+  });
+
+  test("onWarnings is not called when there are no warnings", async () => {
+    const index = stubIndex();
+    const received: string[][] = [];
+    await handleBeforeAgentStart(
+      { prompt: "q", systemPrompt: PROMPT_WITHOUT_BLOCK },
+      { index, config },
+      (warnings) => received.push(warnings),
+    );
+    expect(received).toHaveLength(0);
+  });
+
   test("push: false yields undefined (pull-only mode)", async () => {
     const index = stubIndex();
     const result = await handleBeforeAgentStart(
@@ -321,6 +358,26 @@ describe("buildTurnSystemPrompt / handleBeforeAgentStart", () => {
     expect(result?.systemPrompt).toContain(AVAILABLE_SKILLS_OPEN);
     expect(event.systemPrompt).toBe(PROMPT_WITH_BLOCK); // input untouched
     expect(systemPromptOptions).toEqual({ cwd: "/work/dir" });
+  });
+});
+
+// --- session warning emission ---------------------------------------------
+
+describe("emitWarningsOnce", () => {
+  test("emits each warning once with the skill-discovery prefix", () => {
+    const seen = new Set<string>();
+    const sunk: string[] = [];
+    emitWarningsOnce(seen, ["bad config", "unknown pin"], (m) => sunk.push(m));
+    emitWarningsOnce(seen, ["bad config", "unknown pin"], (m) => sunk.push(m)); // repeat turn
+    expect(sunk).toEqual(["skill-discovery: bad config", "skill-discovery: unknown pin"]);
+  });
+
+  test("new warnings still emit after earlier ones were seen", () => {
+    const seen = new Set<string>();
+    const sunk: string[] = [];
+    emitWarningsOnce(seen, ["first"], (m) => sunk.push(m));
+    emitWarningsOnce(seen, ["first", BM25_ONLY_MODE_WARNING], (m) => sunk.push(m));
+    expect(sunk).toEqual(["skill-discovery: first", `skill-discovery: ${BM25_ONLY_MODE_WARNING}`]);
   });
 });
 


### PR DESCRIPTION
## What

The pi extension binding (`adapters/pi/`) over the discovery core landed in #2089. Implements ADR-0022 §2's pi half.

- **Pull**: `registerTool` `search_skills` (TypeBox params, always-present `details: {}`) returning top-k `{name, description, path}`; the model reads the returned SKILL.md via pi's native progressive disclosure.
- **Push**: `before_agent_start` string-strips the `<available_skills>` block from `event.systemPrompt` and re-injects pins + ranked top-k in pi's native XML shape, returning the edited string as `result.systemPrompt`. This is the load-bearing channel — small local quants don't search for skills they don't know exist.
- **Suppression**: the native uncapped listing (~111 tok/skill) never reaches the model; standing cost becomes the tool description + top-k.
- **Config**: `.pi/skill-discovery.json` (global←project key-by-key merge), pins, k, endpoint; unknown pins and malformed config warn once per session on stderr and are skipped.

### Upstream-contract notes

- `systemPromptOptions` is treated as **read-only** — mutating it does not rebuild the current turn's prompt (pi passes the already-built string); only the returned `systemPrompt` takes effect.
- `typebox` is imported **dynamically** so a missing `adapters/node_modules` surfaces as a diagnosable "run bun install in <checkout>/adapters" error rather than a jiti module-load abort. pi's loader aliases `typebox` to its bundled 1.1.38 at runtime; the local pin matches it exactly.
- `resources_discover` is deliberately **never** used — contributing skill paths would refeed the uncapped native listing.

Reviewed through upstream-API and test-integrity lenses; 6 distinct defects found and fixed in `ee17734c` (config.k not threaded to the tool, warnings computed but never surfaced, rejected-index-promise cached for the session, docs divergence).

## Verification

- `bun test`: 127 pass / 2 skip / 0 fail; `tsc --noEmit`, `biome ci`: clean
- Smoke eval still `=== GATE === STATUS=PASS`
- The §1.2 static import-restriction test now exercises `pi/` (typebox / type-only pi / `node:*` / relative only)

Closes #2090

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5iwac3d7LWd8Jr9iBArXv