### PR TITLE
feat(adapters): OpenCode plugin binding — pull-first skill discovery

### DIFF
--- a/adapters/README.md
+++ b/adapters/README.md
@@ -9,11 +9,10 @@ always the model **reading the SKILL.md path** — skills are never copied.
 Architecture: [`docs/adrs/0022-adapter-over-export-for-foreign-harnesses.md`](../docs/adrs/0022-adapter-over-export-for-foreign-harnesses.md).
 `core/` + `eval/` + tests landed in
 [#2089](https://github.com/laurigates/claude-plugins/issues/2089); the pi
-binding (`pi/`) landed in
-[#2090](https://github.com/laurigates/claude-plugins/issues/2090). The
-OpenCode binding
-([#2091](https://github.com/laurigates/claude-plugins/issues/2091)) is
-documented ahead so the shape is stable, but its files do not exist yet.
+binding (`pi/`) in
+[#2090](https://github.com/laurigates/claude-plugins/issues/2090); the
+OpenCode binding (`opencode/`) in
+[#2091](https://github.com/laurigates/claude-plugins/issues/2091).
 
 ## Layout
 
@@ -22,7 +21,7 @@ documented ahead so the shape is stable, but its files do not exist yet.
 | `core/` | Indexer (marketplace scan + DIY frontmatter parse + compatibility filter), BM25 (Lucene IDF, k1=1.2, b=0.75), ollama `/api/embed` client (`search_document:`/`search_query:` prefixes, BM25 fallback), RRF fusion (k=60), L2-normalized Float32Array vector index, XDG content-hash embedding cache, shared render templates |
 | `eval/` | `tasks.json` (committed golden task set, k=5), `run-eval.ts` runner, ranker seam (`hybrid \| bm25Only \| embeddingOnly \| random(seed) \| oracle \| nameSubstring \| descriptionSubstring`), baseline derivation (`pi/tiers.yaml` + the export-opencode glob, computed offline), `results/` (gitignored per-run output) |
 | `pi/` | pi binding (#2090) — default-exported extension factory: `search_skills` pull tool + `before_agent_start` push injection, `skill-discovery.json` config |
-| `opencode/` | OpenCode binding — **#2091, not yet present** |
+| `opencode/` | OpenCode binding (#2091) — named `SkillDiscoveryPlugin` plugin: `search_skills` tool (pull), `experimental.chat.system.transform` push injection + defensive listing strip, `experimental.chat.messages.transform` ranking-input capture, `[path, options]` tuple config |
 | `tests/` | `bun test` suites: frontmatter diff vs `Bun.YAML`, BM25 goldens + committed `rank_bm25` fixture, indexer over the mini-marketplace fixture, cache, fusion, embeddings fallback matrix, eval meta-tests |
 
 There is **no build step**: `tsconfig.json` is `noEmit` and both harnesses
@@ -105,7 +104,21 @@ bundled copies); the install still matters for type-checking and tests.
 - Run consumers with no natively installed marketplace skills; `--no-skills`
   is optional (the binding never feeds the native loader).
 
-### OpenCode (landing in #2091)
+### OpenCode
+
+Step 1 (as above):
+
+```
+cd <checkout>/claude-plugins/adapters && bun install
+```
+
+The plugin file resolves `@opencode-ai/plugin` from `adapters/node_modules`
+— OpenCode's background-install into config dirs does not cover a
+checkout-resident plugin. A missing install surfaces as an explicit
+"run `bun install` in `<checkout>/adapters`" error at plugin load.
+
+Step 2 — wire the plugin (path-like specs resolve relative to the declaring
+config file; the tuple form carries the options):
 
 ```jsonc
 // opencode.json
@@ -118,9 +131,24 @@ bundled copies); the install still matters for type-checking and tests.
 - `permission.skill = "deny"` is the primary native-listing suppression: it
   removes the `<available_skills>` block and the native `skill` tool in one
   stable config line. (`"tools": { "skill": false }` is a deprecated-surface
-  alias.) Delivery is the model reading the path `search_skills` returns.
-- Push injection rides `experimental.chat.system.transform` and degrades to
-  a silent no-op on versions without the hook — the binding is pull-first.
+  alias — the top-level `tools` boolean map is normalized into root
+  `permission` upstream.) Delivery is the model reading the path
+  `search_skills` returns. The binding also defensively strips any
+  remaining `<available_skills>` element in `system.transform` for
+  consumers who forgot the config line.
+- Options (all optional): `repoRoot` (default: this checkout, derived from
+  the plugin file's location), `k` (push top-k, default 5), `endpoint` /
+  `model` (embeddings; default `http://localhost:11434` /
+  `nomic-embed-text`), `pins` (skill ids always injected first; unknown ids
+  warn and skip). Invalid values warn and fall back to defaults.
+- Push injection rides `experimental.chat.system.transform` (declared
+  unconditionally — older OpenCode versions silently never call unknown
+  hook names) and ranks against the latest user message captured via
+  `experimental.chat.messages.transform`; the first turn injects pins only,
+  and the ranked list can be one turn stale if the hooks race — the binding
+  is pull-first by design. At init the binding logs the server version from
+  `GET /global/health` (informational, never gating) to aid "why no
+  injected block" debugging.
 
 ## Embeddings (soft dependency)
 

--- a/adapters/core/index.ts
+++ b/adapters/core/index.ts
@@ -36,6 +36,7 @@ export {
   renderSkillEntry,
   renderToolResult,
   SEARCH_SKILLS_TOOL_DESCRIPTION,
+  stripAvailableSkillsBlocks,
 } from "./render.ts";
 export { buildIndex, SkillIndex } from "./search.ts";
 export type {

--- a/adapters/core/render.ts
+++ b/adapters/core/render.ts
@@ -56,6 +56,29 @@ export function renderInjectedBlock(
   return lines.join("\n");
 }
 
+/**
+ * Remove every `<available_skills>…</available_skills>` span from a
+ * system-prompt element, keeping the surrounding text (DESIGN §3.3
+ * indexOf/slice approach, shared with the pi binding).
+ *
+ * Substring granularity is load-bearing for the OpenCode binding: upstream
+ * request.ts pre-joins the ENTIRE system prompt (agent prompt + env + native
+ * skills block + instructions) into a single array element before the
+ * system.transform hook fires, so dropping whole matching elements would
+ * delete the whole prompt. A malformed span (open tag with no close after
+ * it) is left untouched rather than truncating the element.
+ */
+export function stripAvailableSkillsBlocks(element: string): string {
+  let out = element;
+  for (;;) {
+    const open = out.indexOf(AVAILABLE_SKILLS_OPEN);
+    if (open === -1) return out;
+    const close = out.indexOf(AVAILABLE_SKILLS_CLOSE, open);
+    if (close === -1) return out; // unclosed: leave as-is, never truncate
+    out = out.slice(0, open) + out.slice(close + AVAILABLE_SKILLS_CLOSE.length);
+  }
+}
+
 /** Pull-tool result text: ranked entries with the SKILL.md path to read. */
 export function renderToolResult(results: Array<RenderableSkill & { score: number }>): string {
   if (results.length === 0) return "No matching skills found.";

--- a/adapters/opencode/config.ts
+++ b/adapters/opencode/config.ts
@@ -1,0 +1,96 @@
+/**
+ * OpenCode binding options — PluginOptions normalization + defaults
+ * (DESIGN §4.1; schema = §3.4 fields minus `push`).
+ *
+ * Options arrive via the `[name, options]` tuple form in opencode.json's
+ * `plugin` array. This module is pure (no @opencode-ai/plugin import) so
+ * tests exercise it without the harness package in play.
+ */
+
+import { resolve } from "node:path";
+import { DEFAULT_ENDPOINT, DEFAULT_K, DEFAULT_MODEL } from "../core/index.ts";
+
+export interface OpencodeBindingConfig {
+  /** Marketplace checkout root. Default: derived from import.meta (§4.1). */
+  repoRoot: string;
+  /** Push top-k (pins + ranked, deduped). Default DEFAULT_K. */
+  k: number;
+  /** Embedding endpoint. Default DEFAULT_ENDPOINT. */
+  endpoint: string;
+  /** Embedding model. Default DEFAULT_MODEL. */
+  model: string;
+  /** Skill ids ("plugin:skill") always injected first; unknown ids warn and skip. */
+  pins: string[];
+}
+
+/**
+ * The binding file lives inside the checkout it indexes
+ * (adapters/opencode/config.ts → two dirs up), so the common case is
+ * zero-config.
+ */
+export const DEFAULT_REPO_ROOT = resolve(import.meta.dir, "..", "..");
+
+const KNOWN_KEYS = new Set(["repoRoot", "k", "endpoint", "model", "pins"]);
+
+function stringOption(
+  options: Record<string, unknown>,
+  key: string,
+  fallback: string,
+  warnings: string[],
+): string {
+  const value = options[key];
+  if (value === undefined) return fallback;
+  if (typeof value === "string" && value.length > 0) return value;
+  warnings.push(`option "${key}" must be a non-empty string; using default`);
+  return fallback;
+}
+
+/**
+ * Normalize the raw PluginOptions record into a full config. Invalid values
+ * warn and fall back to the default — the binding never hard-fails on
+ * config (pull-first, ADR risk mitigation).
+ */
+export function resolveOptions(options?: Record<string, unknown>): {
+  config: OpencodeBindingConfig;
+  warnings: string[];
+} {
+  const raw = options ?? {};
+  const warnings: string[] = [];
+
+  for (const key of Object.keys(raw)) {
+    if (!KNOWN_KEYS.has(key)) warnings.push(`unknown option "${key}" ignored`);
+  }
+
+  let k = DEFAULT_K;
+  if (raw.k !== undefined) {
+    if (typeof raw.k === "number" && Number.isInteger(raw.k) && raw.k >= 1) {
+      k = raw.k;
+    } else {
+      warnings.push(`option "k" must be an integer >= 1; using default ${DEFAULT_K}`);
+    }
+  }
+
+  let pins: string[] = [];
+  if (raw.pins !== undefined) {
+    if (Array.isArray(raw.pins)) {
+      for (const pin of raw.pins) {
+        if (typeof pin === "string" && pin.length > 0) pins.push(pin);
+        else warnings.push(`pin ${JSON.stringify(pin)} is not a skill id string; skipped`);
+      }
+    } else {
+      warnings.push('option "pins" must be an array of skill ids; using none');
+      pins = [];
+    }
+  }
+
+  return {
+    config: {
+      repoRoot: stringOption(raw, "repoRoot", DEFAULT_REPO_ROOT, warnings),
+      k,
+      endpoint: stringOption(raw, "endpoint", DEFAULT_ENDPOINT, warnings),
+      model: stringOption(raw, "model", DEFAULT_MODEL, warnings),
+      pins,
+    },
+    warnings,
+  };
+}

--- a/adapters/opencode/index.ts
+++ b/adapters/opencode/index.ts
@@ -1,0 +1,199 @@
+/**
+ * OpenCode binding for the skill-discovery core (ADR-0022, DESIGN §4, #2091).
+ *
+ * Consumer wiring (adapters/README.md): step 1 is always
+ * `cd <checkout>/adapters && bun install` — this file resolves
+ * @opencode-ai/plugin from adapters/node_modules (OpenCode's
+ * background-install into config dirs does not cover a checkout-resident
+ * plugin). Then, in opencode.json:
+ *
+ *   {
+ *     "plugin": [["<path-to>/adapters/opencode/index.ts", { "k": 5, "pins": [] }]],
+ *     "permission": { "skill": "deny" }
+ *   }
+ *
+ * Native-listing suppression (§4.3): the PRIMARY mechanism is the
+ * consumer-side `"permission": { "skill": "deny" }` line above — a
+ * "*"-pattern deny makes SystemPrompt.skills() omit the whole
+ * <available_skills> block and hides the native `skill` tool, on a stable
+ * (non-experimental) config surface. (`"tools": { "skill": false }` is the
+ * deprecated-surface alias, normalized into permission upstream.) The
+ * system.transform filter below is only the DEFENSIVE secondary for
+ * consumers who forgot the config line.
+ */
+
+import type { Hooks, Plugin, ToolDefinition } from "@opencode-ai/plugin";
+import {
+  AVAILABLE_SKILLS_OPEN,
+  buildIndex,
+  DEFAULT_K,
+  renderInjectedBlock,
+  renderToolResult,
+  SEARCH_SKILLS_TOOL_DESCRIPTION,
+  type SkillEntry,
+  type SkillIndex,
+} from "../core/index.ts";
+import { DEFAULT_REPO_ROOT, type OpencodeBindingConfig, resolveOptions } from "./config.ts";
+
+const LOG_PREFIX = "[skill-discovery]";
+
+/**
+ * The one runtime dependency. Type-only imports above are erased at
+ * transpile time, so a missing adapters/node_modules surfaces exactly here —
+ * rethrown with an explicit remedy instead of a bare resolution stack
+ * (DESIGN §4.1).
+ */
+export async function loadToolApi(
+  importer: () => Promise<typeof import("@opencode-ai/plugin")> = () =>
+    import("@opencode-ai/plugin"),
+): Promise<typeof import("@opencode-ai/plugin").tool> {
+  try {
+    return (await importer()).tool;
+  } catch (cause) {
+    throw new Error(
+      `${LOG_PREFIX} could not resolve @opencode-ai/plugin — run \`bun install\` in ${DEFAULT_REPO_ROOT}/adapters (populates adapters/node_modules; see adapters/README.md)`,
+      { cause },
+    );
+  }
+}
+
+/** Pins are ids ("plugin:skill") resolved against the index; unknown pins warn and skip (§3.4). */
+export function resolvePins(
+  ids: string[],
+  entries: SkillEntry[],
+): { pins: SkillEntry[]; unknown: string[] } {
+  const byId = new Map(entries.map((e) => [e.id, e]));
+  const pins: SkillEntry[] = [];
+  const unknown: string[] = [];
+  for (const id of ids) {
+    const entry = byId.get(id);
+    if (entry) pins.push(entry);
+    else unknown.push(id);
+  }
+  return { pins, unknown };
+}
+
+interface PluginState {
+  index: SkillIndex;
+  pins: SkillEntry[];
+}
+
+/**
+ * Named Plugin export (§4.1): OpenCode resolves the path-like spec relative
+ * to the declaring config file and calls every exported Plugin-typed const.
+ */
+export const SkillDiscoveryPlugin: Plugin = async (input, options) => {
+  const { config, warnings } = resolveOptions(options);
+  for (const warning of warnings) console.warn(`${LOG_PREFIX} ${warning}`);
+
+  const tool = await loadToolApi();
+
+  // Heavy work (index build) is lazy and memoized: the factory returns
+  // fast, and a build failure surfaces on first use, not at plugin load.
+  let statePromise: Promise<PluginState> | null = null;
+  const getState = (): Promise<PluginState> => {
+    statePromise ??= (async () => {
+      const index = await buildIndex({
+        repoRoot: config.repoRoot,
+        embed: { endpoint: config.endpoint, model: config.model },
+      });
+      const { pins, unknown } = resolvePins(config.pins, index.entries);
+      for (const id of unknown) console.warn(`${LOG_PREFIX} unknown pin "${id}" skipped`);
+      return { index, pins };
+    })();
+    return statePromise;
+  };
+
+  // §4.4 informational (non-gating) version probe: a user debugging
+  // "why no injected block" gets an answer without us gating behavior on
+  // semver — unknown hook keys are silently never called on older
+  // OpenCode versions, so declaring them below is a harmless no-op there.
+  void fetch(new URL("/global/health", input.serverUrl))
+    .then(async (res) => {
+      const body = (await res.json()) as { healthy?: boolean; version?: string };
+      console.log(
+        `${LOG_PREFIX} opencode ${body.version ?? "unknown version"} at ${input.serverUrl}; ` +
+          "push injection rides experimental.chat.system.transform (a silent no-op on versions without the hook — the binding is pull-first)",
+      );
+    })
+    .catch(() => {
+      // Health endpoint unreachable: purely informational, never gate.
+    });
+
+  // Ranking input for the push channel (§4.4 recorded defensive choice):
+  // system.transform receives only {sessionID?, model} — no user prompt —
+  // so the latest user-message text is captured in messages.transform
+  // (which sees the full message array) into this closure slot.
+  let latestUserMessage: string | null = null;
+  let pushFailureLogged = false;
+
+  const hooks: Hooks = {
+    tool: {
+      search_skills: tool({
+        description: SEARCH_SKILLS_TOOL_DESCRIPTION,
+        args: {
+          query: tool.schema.string().describe("What you are trying to do, in plain words"),
+          k: tool.schema.number().int().min(1).max(20).optional(),
+        },
+        async execute(args, _ctx) {
+          const { index } = await getState();
+          const results = await index.search(args.query, args.k ?? DEFAULT_K);
+          return renderToolResult(results);
+        },
+      }) satisfies ToolDefinition,
+    },
+
+    "experimental.chat.messages.transform": async (_input, output) => {
+      // One-turn-stale caveat (§4.4): if, on some version, system.transform
+      // for a request fires before this hook has seen that request's
+      // message, the injection ranks against the PREVIOUS turn's message —
+      // pins are unaffected and search_skills is the recourse. Accepted
+      // over message-array injection, which would mutate persisted
+      // conversation shape with an input that carries no sessionID.
+      for (let i = output.messages.length - 1; i >= 0; i--) {
+        const message = output.messages[i];
+        if (message?.info.role !== "user") continue;
+        const text = message.parts
+          .flatMap((part) => (part.type === "text" && !part.synthetic ? [part.text] : []))
+          .join("\n")
+          .trim();
+        if (text.length > 0) latestUserMessage = text;
+        break;
+      }
+    },
+
+    // Declared unconditionally (§4.4): Plugin.trigger only calls hook names
+    // it knows, so on older OpenCode versions this is silently never
+    // invoked and the binding degrades to pull-only.
+    "experimental.chat.system.transform": async (_input, output) => {
+      // Defensive strip (§4.3 secondary): drop any element carrying the
+      // native <available_skills> block. Whole-element filter/append only —
+      // OpenCode may collapse system[1..n] into one string after the hook,
+      // so positions are never relied on. v2-rewrite note: SkillGuidance
+      // drops <location> from the native block but keeps the
+      // <available_skills> tag this grep matches — re-check at cutover
+      // (#2094).
+      output.system = output.system.filter((element) => !element.includes(AVAILABLE_SKILLS_OPEN));
+
+      try {
+        const { index, pins } = await getState();
+        const ranked =
+          latestUserMessage === null
+            ? [] // first turn with no captured message: inject pins only
+            : await index.search(latestUserMessage, config.k, {
+                excludeIds: pins.map((pin) => pin.id),
+              });
+        output.system.push(renderInjectedBlock(pins, ranked, config.k));
+      } catch (error) {
+        // Push is best-effort by design; the pull tool remains the recourse.
+        if (!pushFailureLogged) {
+          pushFailureLogged = true;
+          console.warn(`${LOG_PREFIX} push injection failed: ${String(error)}`);
+        }
+      }
+    },
+  };
+  return hooks;
+};
+
+export type { OpencodeBindingConfig };

--- a/adapters/opencode/index.ts
+++ b/adapters/opencode/index.ts
@@ -32,6 +32,7 @@ import {
   SEARCH_SKILLS_TOOL_DESCRIPTION,
   type SkillEntry,
   type SkillIndex,
+  stripAvailableSkillsBlocks,
 } from "../core/index.ts";
 import { DEFAULT_REPO_ROOT, type OpencodeBindingConfig, resolveOptions } from "./config.ts";
 
@@ -153,8 +154,13 @@ export const SkillDiscoveryPlugin: Plugin = async (input, options) => {
       for (let i = output.messages.length - 1; i >= 0; i--) {
         const message = output.messages[i];
         if (message?.info.role !== "user") continue;
+        // Skip both upstream part flags: `synthetic` (OpenCode-generated
+        // text) and `ignored` (text OpenCode excludes from the request) —
+        // neither should drive the push ranking.
         const text = message.parts
-          .flatMap((part) => (part.type === "text" && !part.synthetic ? [part.text] : []))
+          .flatMap((part) =>
+            part.type === "text" && !part.synthetic && !part.ignored ? [part.text] : [],
+          )
           .join("\n")
           .trim();
         if (text.length > 0) latestUserMessage = text;
@@ -166,14 +172,32 @@ export const SkillDiscoveryPlugin: Plugin = async (input, options) => {
     // it knows, so on older OpenCode versions this is silently never
     // invoked and the binding degrades to pull-only.
     "experimental.chat.system.transform": async (_input, output) => {
-      // Defensive strip (§4.3 secondary): drop any element carrying the
-      // native <available_skills> block. Whole-element filter/append only —
-      // OpenCode may collapse system[1..n] into one string after the hook,
-      // so positions are never relied on. v2-rewrite note: SkillGuidance
-      // drops <location> from the native block but keeps the
-      // <available_skills> tag this grep matches — re-check at cutover
+      // In-place mutation is the upstream contract: request.ts (verified at
+      // v1.18.3 and dev) reads the SAME local `system` array after the
+      // trigger — Plugin.trigger does no copy-back, so reassigning
+      // `output.system` is silently discarded. Every change below mutates
+      // the original array object (index writes / length=0 + push).
+      //
+      // Defensive strip (§4.3 secondary): remove the native
+      // <available_skills>…</available_skills> span by SUBSTRING, keeping
+      // the rest of the element — upstream pre-joins the entire system
+      // prompt into ONE element before this hook fires, so dropping whole
+      // matching elements would delete the whole prompt. Elements that
+      // were nothing but the block are removed. v2-rewrite note:
+      // SkillGuidance drops <location> from the native block but keeps the
+      // <available_skills> tag this scan matches — re-check at cutover
       // (#2094).
-      output.system = output.system.filter((element) => !element.includes(AVAILABLE_SKILLS_OPEN));
+      const kept: string[] = [];
+      for (const element of output.system) {
+        if (!element.includes(AVAILABLE_SKILLS_OPEN)) {
+          kept.push(element);
+          continue;
+        }
+        const stripped = stripAvailableSkillsBlocks(element);
+        if (stripped.trim().length > 0) kept.push(stripped);
+      }
+      output.system.length = 0;
+      output.system.push(...kept);
 
       try {
         const { index, pins } = await getState();
@@ -183,7 +207,13 @@ export const SkillDiscoveryPlugin: Plugin = async (input, options) => {
             : await index.search(latestUserMessage, config.k, {
                 excludeIds: pins.map((pin) => pin.id),
               });
-        output.system.push(renderInjectedBlock(pins, ranked, config.k));
+        // Nothing selected (no pins, no captured message or no ranked
+        // hits): inject nothing — an empty <available_skills> block with
+        // the "listed above" trailer would be self-contradictory, and
+        // search_skills remains the routing surface.
+        if (pins.length + ranked.length > 0) {
+          output.system.push(renderInjectedBlock(pins, ranked, config.k));
+        }
       } catch (error) {
         // Push is best-effort by design; the pull tool remains the recourse.
         if (!pushFailureLogged) {

--- a/adapters/tests/indexer.test.ts
+++ b/adapters/tests/indexer.test.ts
@@ -178,4 +178,22 @@ describe("static import restrictions", () => {
     }
     expect(violations).toEqual([]);
   });
+
+  // opencode/ (#2091): the documented single runtime dependency is
+  // @opencode-ai/plugin (value, type, and dynamic `import(...)` forms all
+  // allowed — the binding deliberately funnels the value import through one
+  // dynamic import for the bun-install rethrow). Anything else — including
+  // a direct @opencode-ai/sdk import, which is only a transitive dep of the
+  // plugin package and would be a phantom dependency — is a violation.
+  test("opencode/ imports only @opencode-ai/plugin, node:*, and relative paths", () => {
+    const violations: string[] = [];
+    for (const file of tsFilesUnder(join(ADAPTERS_ROOT, "opencode"))) {
+      for (const spec of importSpecifiers(file)) {
+        if (spec.startsWith("node:") || spec.startsWith("./") || spec.startsWith("../")) continue;
+        if (spec === "@opencode-ai/plugin") continue;
+        violations.push(`${file}: ${spec}`);
+      }
+    }
+    expect(violations).toEqual([]);
+  });
 });

--- a/adapters/tests/opencode-binding.test.ts
+++ b/adapters/tests/opencode-binding.test.ts
@@ -1,0 +1,351 @@
+/**
+ * OpenCode binding tests (#2091): stubbed PluginInput/Hooks harness — no
+ * live OpenCode required. Covers system.transform strip+inject (block
+ * present / absent / positions collapsed), messages.transform capture,
+ * tool execute output shape, options handling, and the module-resolution
+ * rethrow.
+ *
+ * The index is built over the mini-marketplace fixture (same skilldirs/ →
+ * skills/ rename trick as indexer.test.ts) with the embed endpoint pointed
+ * at an unbound local port, so every test runs deterministic BM25-only
+ * with zero network.
+ */
+
+import { beforeAll, describe, expect, test } from "bun:test";
+import { cpSync, existsSync, mkdtempSync, readdirSync, renameSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import type { Hooks, PluginInput, ToolContext } from "@opencode-ai/plugin";
+import type { Model, Part } from "@opencode-ai/sdk";
+import {
+  AVAILABLE_SKILLS_CLOSE,
+  AVAILABLE_SKILLS_OPEN,
+  DEFAULT_ENDPOINT,
+  DEFAULT_K,
+  DEFAULT_MODEL,
+  INJECTED_BLOCK_TRAILER,
+} from "../core/index.ts";
+import { scanSkills } from "../core/indexer.ts";
+import { DEFAULT_REPO_ROOT, resolveOptions } from "../opencode/config.ts";
+import { loadToolApi, resolvePins, SkillDiscoveryPlugin } from "../opencode/index.ts";
+
+const FIXTURE_SRC = join(import.meta.dir, "fixtures", "mini-marketplace-src");
+/** Unbound port: fetch rejects fast → index degrades to bm25-only, no network. */
+const DEAD_ENDPOINT = "http://127.0.0.1:1";
+
+let fixtureRoot = "";
+
+beforeAll(() => {
+  fixtureRoot = mkdtempSync(join(tmpdir(), "oc-binding-"));
+  cpSync(FIXTURE_SRC, fixtureRoot, { recursive: true });
+  for (const entry of readdirSync(fixtureRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const src = join(fixtureRoot, entry.name, "skilldirs");
+    if (existsSync(src)) renameSync(src, join(fixtureRoot, entry.name, "skills"));
+  }
+});
+
+const STUB_MODEL = { modelID: "stub", providerID: "stub" } as unknown as Model;
+const STUB_TOOL_CONTEXT = {
+  sessionID: "ses_stub",
+  messageID: "msg_stub",
+  agent: "stub",
+} as unknown as ToolContext;
+
+function stubInput(): PluginInput {
+  return {
+    // Unbound port again: the informational health probe is fire-and-forget
+    // and must never gate — a rejected fetch is the exercised path here.
+    serverUrl: new URL(DEAD_ENDPOINT),
+    directory: fixtureRoot,
+    worktree: fixtureRoot,
+  } as unknown as PluginInput;
+}
+
+function makeHooks(options?: Record<string, unknown>): Promise<Hooks> {
+  return SkillDiscoveryPlugin(stubInput(), {
+    repoRoot: fixtureRoot,
+    endpoint: DEAD_ENDPOINT,
+    ...options,
+  });
+}
+
+function userMessage(text: string): { info: { role: "user" }; parts: Part[] } {
+  return {
+    info: { role: "user" },
+    parts: [{ type: "text", text } as unknown as Part],
+  };
+}
+
+function assistantMessage(text: string): { info: { role: "assistant" }; parts: Part[] } {
+  return {
+    info: { role: "assistant" },
+    parts: [{ type: "text", text } as unknown as Part],
+  };
+}
+
+type MessagesOutput = Parameters<NonNullable<Hooks["experimental.chat.messages.transform"]>>[1];
+
+async function runSystemTransform(hooks: Hooks, system: string[]): Promise<string[]> {
+  const output = { system };
+  await hooks["experimental.chat.system.transform"]?.({ model: STUB_MODEL }, output);
+  return output.system;
+}
+
+async function runMessagesTransform(hooks: Hooks, messages: MessagesOutput["messages"]) {
+  await hooks["experimental.chat.messages.transform"]?.({}, { messages });
+}
+
+describe("options handling (resolveOptions)", () => {
+  test("missing options yield all defaults", () => {
+    const { config, warnings } = resolveOptions(undefined);
+    expect(config).toEqual({
+      repoRoot: DEFAULT_REPO_ROOT,
+      k: DEFAULT_K,
+      endpoint: DEFAULT_ENDPOINT,
+      model: DEFAULT_MODEL,
+      pins: [],
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test("DEFAULT_REPO_ROOT is the checkout root (two dirs above opencode/)", () => {
+    expect(DEFAULT_REPO_ROOT).toBe(resolve(import.meta.dir, "..", ".."));
+  });
+
+  test("valid options pass through", () => {
+    const { config, warnings } = resolveOptions({
+      repoRoot: "/somewhere",
+      k: 3,
+      endpoint: "http://embed:1234",
+      model: "custom-model",
+      pins: ["a:one", "b:two"],
+    });
+    expect(config.repoRoot).toBe("/somewhere");
+    expect(config.k).toBe(3);
+    expect(config.endpoint).toBe("http://embed:1234");
+    expect(config.model).toBe("custom-model");
+    expect(config.pins).toEqual(["a:one", "b:two"]);
+    expect(warnings).toEqual([]);
+  });
+
+  test("invalid values warn and fall back to defaults", () => {
+    const { config, warnings } = resolveOptions({
+      k: 0,
+      repoRoot: 42,
+      pins: "not-an-array",
+      endpoint: "",
+    });
+    expect(config.k).toBe(DEFAULT_K);
+    expect(config.repoRoot).toBe(DEFAULT_REPO_ROOT);
+    expect(config.pins).toEqual([]);
+    expect(config.endpoint).toBe(DEFAULT_ENDPOINT);
+    expect(warnings).toHaveLength(4);
+  });
+
+  test("non-string pin entries are skipped with a warning, strings kept", () => {
+    const { config, warnings } = resolveOptions({ pins: ["a:one", 7, null] });
+    expect(config.pins).toEqual(["a:one"]);
+    expect(warnings).toHaveLength(2);
+  });
+
+  test("unknown option keys warn and are ignored", () => {
+    const { config, warnings } = resolveOptions({ push: false });
+    expect(config.k).toBe(DEFAULT_K);
+    expect(warnings.some((w) => w.includes('unknown option "push"'))).toBe(true);
+  });
+});
+
+describe("resolvePins", () => {
+  test("known pins resolve in order; unknown pins are reported", () => {
+    const { entries } = scanSkills(fixtureRoot, "foreign");
+    const { pins, unknown } = resolvePins(
+      ["gamma-plugin:quoted-description", "nope:missing", "alpha-plugin:normal-skill"],
+      entries,
+    );
+    expect(pins.map((p) => p.id)).toEqual([
+      "gamma-plugin:quoted-description",
+      "alpha-plugin:normal-skill",
+    ]);
+    expect(unknown).toEqual(["nope:missing"]);
+  });
+});
+
+describe("module-resolution failure", () => {
+  test("rethrows with the bun-install remedy and preserves the cause", async () => {
+    const cause = new Error("Cannot find module '@opencode-ai/plugin'");
+    const promise = loadToolApi(() => Promise.reject(cause));
+    await expect(promise).rejects.toThrow(/run `bun install` in .*\/adapters/);
+    await expect(promise).rejects.toMatchObject({ cause });
+  });
+
+  test("resolves the real tool() helper when the package is installed", async () => {
+    const tool = await loadToolApi();
+    expect(typeof tool).toBe("function");
+    expect(typeof tool.schema.string).toBe("function");
+  });
+});
+
+describe("search_skills tool", () => {
+  test("execute returns the numbered ToolResult string with SKILL.md paths", async () => {
+    const hooks = await makeHooks();
+    const definition = hooks.tool?.search_skills;
+    expect(definition).toBeDefined();
+    const result = await definition?.execute(
+      { query: "render architecture diagrams for system topology", k: 2 },
+      STUB_TOOL_CONTEXT,
+    );
+    expect(typeof result).toBe("string");
+    const text = result as string;
+    const lines = text.split("\n");
+    expect(lines[0]).toMatch(/^1\. gamma-plugin:folded-description — /);
+    expect(text).toContain(`read: ${fixtureRoot}/gamma-plugin/skills/folded-description/SKILL.md`);
+    // Only one fixture doc matches these query tokens (BM25 returns
+    // positive-scoring docs only), so k=2 still yields a single entry.
+    expect(lines.filter((l) => /^\d+\. /.test(l))).toHaveLength(1);
+  });
+
+  test("k caps the result list", async () => {
+    const hooks = await makeHooks();
+    // "use when" appears in every fixture description → all 4 docs score.
+    const result = await hooks.tool?.search_skills?.execute(
+      { query: "use when", k: 2 },
+      STUB_TOOL_CONTEXT,
+    );
+    const lines = (result as string).split("\n");
+    expect(lines.filter((l) => /^\d+\. /.test(l))).toHaveLength(2);
+  });
+
+  test("no-match queries return the empty-result sentence, never throw", async () => {
+    const hooks = await makeHooks();
+    const result = await hooks.tool?.search_skills?.execute(
+      { query: "zzz qqq xyzzy" },
+      STUB_TOOL_CONTEXT,
+    );
+    expect(result).toBe("No matching skills found.");
+  });
+
+  test("tool description routes the model to read the returned path", async () => {
+    const hooks = await makeHooks();
+    expect(hooks.tool?.search_skills?.description).toContain("read that path to load the skill");
+  });
+});
+
+describe("experimental.chat.system.transform — strip + inject", () => {
+  const NATIVE_BLOCK = `${AVAILABLE_SKILLS_OPEN}\n  <skill><name>native</name><description>d</description><location>/x</location></skill>\n${AVAILABLE_SKILLS_CLOSE}`;
+
+  test("native block element is stripped and one adapter block appended", async () => {
+    const hooks = await makeHooks();
+    const system = await runSystemTransform(hooks, ["You are opencode.", NATIVE_BLOCK, "cwd: /x"]);
+    const withBlock = system.filter((s) => s.includes(AVAILABLE_SKILLS_OPEN));
+    expect(withBlock).toHaveLength(1); // only the adapter's own block survives
+    expect(withBlock[0]).not.toContain("<name>native</name>");
+    expect(withBlock[0]?.endsWith(INJECTED_BLOCK_TRAILER)).toBe(true);
+    expect(system[0]).toBe("You are opencode.");
+    expect(system).toContain("cwd: /x");
+  });
+
+  test("block absent (permission.skill deny did its job): elements untouched, block appended", async () => {
+    const hooks = await makeHooks();
+    const system = await runSystemTransform(hooks, ["header", "body"]);
+    expect(system.slice(0, 2)).toEqual(["header", "body"]);
+    expect(system).toHaveLength(3);
+    expect(system[2]?.startsWith(AVAILABLE_SKILLS_OPEN)).toBe(true);
+  });
+
+  test("positions collapsed: the block is found by content, never by index", async () => {
+    const hooks = await makeHooks();
+    // Simulates a pre-collapsed / reordered array: the native block rides
+    // inside a merged element at a non-canonical position.
+    const merged = `environment details\n${NATIVE_BLOCK}\ntrailing instructions`;
+    const system = await runSystemTransform(hooks, [merged, "header moved"]);
+    expect(system.some((s) => s.includes("<name>native</name>"))).toBe(false);
+    expect(system[0]).toBe("header moved");
+    expect(system[system.length - 1]?.endsWith(INJECTED_BLOCK_TRAILER)).toBe(true);
+  });
+
+  test("first turn with no captured message injects pins only", async () => {
+    const hooks = await makeHooks({ pins: ["alpha-plugin:normal-skill"] });
+    const system = await runSystemTransform(hooks, ["header"]);
+    const block = system[system.length - 1] as string;
+    expect(block).toContain("<name>alpha-plugin:normal-skill</name>");
+    // No ranked entries without a captured user message.
+    const entryCount = block.split("\n").filter((l) => l.startsWith("  <skill>")).length;
+    expect(entryCount).toBe(1);
+  });
+
+  test("bad repoRoot degrades push to a no-op (pull-first), never throws", async () => {
+    const hooks = await SkillDiscoveryPlugin(stubInput(), {
+      repoRoot: join(fixtureRoot, "does-not-exist"),
+      endpoint: DEAD_ENDPOINT,
+    });
+    const system = await runSystemTransform(hooks, ["header", NATIVE_BLOCK]);
+    // Defensive strip still ran; failed injection appends nothing.
+    expect(system).toEqual(["header"]);
+  });
+});
+
+describe("experimental.chat.messages.transform — ranking-input capture", () => {
+  test("latest user message drives the injected ranking", async () => {
+    const hooks = await makeHooks();
+    await runMessagesTransform(hooks, [
+      userMessage("commit staged changes to git"),
+      assistantMessage("done"),
+      userMessage("render architecture diagrams from my notes"),
+    ] as MessagesOutput["messages"]);
+    const system = await runSystemTransform(hooks, ["header"]);
+    const block = system[system.length - 1] as string;
+    const first = block.split("\n").find((l) => l.startsWith("  <skill>"));
+    expect(first).toContain("<name>gamma-plugin:folded-description</name>");
+  });
+
+  test("a trailing assistant message keeps the previous user capture (one-turn-stale contract)", async () => {
+    const hooks = await makeHooks();
+    await runMessagesTransform(hooks, [
+      userMessage("inspect JSON payloads from the API"),
+      assistantMessage("looking"),
+    ] as MessagesOutput["messages"]);
+    const system = await runSystemTransform(hooks, []);
+    const block = system[0] as string;
+    const first = block.split("\n").find((l) => l.startsWith("  <skill>"));
+    expect(first).toContain("<name>beta-plugin:no-name</name>");
+  });
+
+  test("pins come first, ranked results fill k after pins, deduped", async () => {
+    const hooks = await makeHooks({ pins: ["alpha-plugin:normal-skill"], k: 2 });
+    await runMessagesTransform(hooks, [
+      userMessage("render architecture diagrams from my notes"),
+    ] as MessagesOutput["messages"]);
+    const system = await runSystemTransform(hooks, []);
+    const block = system[0] as string;
+    const ids = block
+      .split("\n")
+      .filter((l) => l.startsWith("  <skill>"))
+      .map((l) => /<name>([^<]+)<\/name>/.exec(l)?.[1]);
+    expect(ids).toEqual(["alpha-plugin:normal-skill", "gamma-plugin:folded-description"]);
+  });
+
+  test("a ranked hit that duplicates a pin is deduped", async () => {
+    const hooks = await makeHooks({ pins: ["gamma-plugin:folded-description"], k: 3 });
+    await runMessagesTransform(hooks, [
+      userMessage("render architecture diagrams from my notes"),
+    ] as MessagesOutput["messages"]);
+    const system = await runSystemTransform(hooks, []);
+    const block = system[0] as string;
+    const ids = block
+      .split("\n")
+      .filter((l) => l.startsWith("  <skill>"))
+      .map((l) => /<name>([^<]+)<\/name>/.exec(l)?.[1]);
+    // The pin is also the top ranked hit; excludeIds keeps it out of the
+    // ranked arm and renderInjectedBlock dedupes — exactly one copy.
+    expect(ids.filter((id) => id === "gamma-plugin:folded-description")).toHaveLength(1);
+  });
+
+  test("unknown pins are skipped without breaking injection", async () => {
+    const hooks = await makeHooks({ pins: ["nope:missing", "alpha-plugin:normal-skill"] });
+    const system = await runSystemTransform(hooks, []);
+    const block = system[0] as string;
+    expect(block).toContain("<name>alpha-plugin:normal-skill</name>");
+    expect(block).not.toContain("nope:missing");
+  });
+});

--- a/adapters/tests/opencode-binding.test.ts
+++ b/adapters/tests/opencode-binding.test.ts
@@ -11,12 +11,11 @@
  * with zero network.
  */
 
-import { beforeAll, describe, expect, test } from "bun:test";
-import { cpSync, existsSync, mkdtempSync, readdirSync, renameSync } from "node:fs";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { cpSync, existsSync, mkdtempSync, readdirSync, renameSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import type { Hooks, PluginInput, ToolContext } from "@opencode-ai/plugin";
-import type { Model, Part } from "@opencode-ai/sdk";
 import {
   AVAILABLE_SKILLS_CLOSE,
   AVAILABLE_SKILLS_OPEN,
@@ -44,6 +43,17 @@ beforeAll(() => {
     if (existsSync(src)) renameSync(src, join(fixtureRoot, entry.name, "skills"));
   }
 });
+
+afterAll(() => rmSync(fixtureRoot, { recursive: true, force: true }));
+
+// Types derived from the plugin package's own hook surface — no direct
+// @opencode-ai/sdk import (it is not a declared dependency of adapters/;
+// relying on hoisting of the plugin package's transitive dep would be a
+// phantom dependency).
+type SystemTransformInput = Parameters<NonNullable<Hooks["experimental.chat.system.transform"]>>[0];
+type Model = SystemTransformInput["model"];
+type MessagesOutput = Parameters<NonNullable<Hooks["experimental.chat.messages.transform"]>>[1];
+type Part = MessagesOutput["messages"][number]["parts"][number];
 
 const STUB_MODEL = { modelID: "stub", providerID: "stub" } as unknown as Model;
 const STUB_TOOL_CONTEXT = {
@@ -84,12 +94,17 @@ function assistantMessage(text: string): { info: { role: "assistant" }; parts: P
   };
 }
 
-type MessagesOutput = Parameters<NonNullable<Hooks["experimental.chat.messages.transform"]>>[1];
-
+/**
+ * Runs the hook and returns the ORIGINAL array — never `output.system`.
+ * Upstream request.ts keeps reading its local `system` array after the
+ * trigger (Plugin.trigger does no copy-back), so only in-place mutation of
+ * the original array reference is observed by real OpenCode. Asserting on
+ * the original reference is what pins that contract; asserting on
+ * `output.system` would let a reassignment bug pass silently.
+ */
 async function runSystemTransform(hooks: Hooks, system: string[]): Promise<string[]> {
-  const output = { system };
-  await hooks["experimental.chat.system.transform"]?.({ model: STUB_MODEL }, output);
-  return output.system;
+  await hooks["experimental.chat.system.transform"]?.({ model: STUB_MODEL }, { system });
+  return system;
 }
 
 async function runMessagesTransform(hooks: Hooks, messages: MessagesOutput["messages"]) {
@@ -233,9 +248,44 @@ describe("search_skills tool", () => {
 
 describe("experimental.chat.system.transform — strip + inject", () => {
   const NATIVE_BLOCK = `${AVAILABLE_SKILLS_OPEN}\n  <skill><name>native</name><description>d</description><location>/x</location></skill>\n${AVAILABLE_SKILLS_CLOSE}`;
+  /** Captures a user message so the push channel has a ranking input. */
+  async function captureMessage(hooks: Hooks): Promise<void> {
+    await runMessagesTransform(hooks, [
+      userMessage("render architecture diagrams from my notes"),
+    ] as MessagesOutput["messages"]);
+  }
 
-  test("native block element is stripped and one adapter block appended", async () => {
+  test("mutates the passed system array in place — reassignment would be invisible upstream", async () => {
     const hooks = await makeHooks();
+    await captureMessage(hooks);
+    const system = ["header", NATIVE_BLOCK];
+    const output = { system };
+    await hooks["experimental.chat.system.transform"]?.({ model: STUB_MODEL }, output);
+    // Same reference: upstream reads its local array, not output.system.
+    expect(output.system).toBe(system);
+    expect(system.some((s) => s.includes("<name>native</name>"))).toBe(false);
+    expect(system[system.length - 1]?.endsWith(INJECTED_BLOCK_TRAILER)).toBe(true);
+  });
+
+  test("real call-site shape: one pre-joined element — only the native block span is removed", async () => {
+    // Upstream request.ts joins agent prompt + env + native skills block +
+    // instructions into a SINGLE array element before the hook fires.
+    // Whole-element filtering would delete the entire system prompt here.
+    const hooks = await makeHooks();
+    await captureMessage(hooks);
+    const joined = `You are opencode.\n<env>cwd: /x</env>\n${NATIVE_BLOCK}\ntrailing instructions`;
+    const system = await runSystemTransform(hooks, [joined]);
+    expect(system[0]).toContain("You are opencode.");
+    expect(system[0]).toContain("<env>cwd: /x</env>");
+    expect(system[0]).toContain("trailing instructions");
+    expect(system[0]).not.toContain("<name>native</name>");
+    expect(system[0]).not.toContain(AVAILABLE_SKILLS_OPEN);
+    expect(system[system.length - 1]?.endsWith(INJECTED_BLOCK_TRAILER)).toBe(true);
+  });
+
+  test("native block as its own element is removed entirely and one adapter block appended", async () => {
+    const hooks = await makeHooks();
+    await captureMessage(hooks);
     const system = await runSystemTransform(hooks, ["You are opencode.", NATIVE_BLOCK, "cwd: /x"]);
     const withBlock = system.filter((s) => s.includes(AVAILABLE_SKILLS_OPEN));
     expect(withBlock).toHaveLength(1); // only the adapter's own block survives
@@ -245,8 +295,17 @@ describe("experimental.chat.system.transform — strip + inject", () => {
     expect(system).toContain("cwd: /x");
   });
 
+  test("malformed (unclosed) native block: element left untouched, never truncated", async () => {
+    const hooks = await makeHooks();
+    await captureMessage(hooks);
+    const unclosed = `header\n${AVAILABLE_SKILLS_OPEN}\n  <skill><name>native</name></skill>\ntrailing`;
+    const system = await runSystemTransform(hooks, [unclosed]);
+    expect(system[0]).toBe(unclosed);
+  });
+
   test("block absent (permission.skill deny did its job): elements untouched, block appended", async () => {
     const hooks = await makeHooks();
+    await captureMessage(hooks);
     const system = await runSystemTransform(hooks, ["header", "body"]);
     expect(system.slice(0, 2)).toEqual(["header", "body"]);
     expect(system).toHaveLength(3);
@@ -255,13 +314,23 @@ describe("experimental.chat.system.transform — strip + inject", () => {
 
   test("positions collapsed: the block is found by content, never by index", async () => {
     const hooks = await makeHooks();
+    await captureMessage(hooks);
     // Simulates a pre-collapsed / reordered array: the native block rides
     // inside a merged element at a non-canonical position.
     const merged = `environment details\n${NATIVE_BLOCK}\ntrailing instructions`;
     const system = await runSystemTransform(hooks, [merged, "header moved"]);
     expect(system.some((s) => s.includes("<name>native</name>"))).toBe(false);
-    expect(system[0]).toBe("header moved");
+    expect(system[0]).toContain("environment details");
+    expect(system[0]).toContain("trailing instructions");
+    expect(system[1]).toBe("header moved");
     expect(system[system.length - 1]?.endsWith(INJECTED_BLOCK_TRAILER)).toBe(true);
+  });
+
+  test("no pins and no captured message: nothing is injected (no empty block + false trailer)", async () => {
+    const hooks = await makeHooks(); // default pins: []
+    const system = await runSystemTransform(hooks, ["header", NATIVE_BLOCK]);
+    // Defensive strip still runs; the push is skipped entirely.
+    expect(system).toEqual(["header"]);
   });
 
   test("first turn with no captured message injects pins only", async () => {
@@ -297,6 +366,28 @@ describe("experimental.chat.messages.transform — ranking-input capture", () =>
     const block = system[system.length - 1] as string;
     const first = block.split("\n").find((l) => l.startsWith("  <skill>"));
     expect(first).toContain("<name>gamma-plugin:folded-description</name>");
+  });
+
+  test("parts marked ignored are excluded from the ranking capture", async () => {
+    const hooks = await makeHooks();
+    await runMessagesTransform(hooks, [
+      {
+        info: { role: "user" },
+        parts: [
+          {
+            type: "text",
+            text: "render architecture diagrams from my notes",
+            ignored: true,
+          } as unknown as Part,
+          { type: "text", text: "inspect JSON payloads from the API" } as unknown as Part,
+        ],
+      },
+    ] as MessagesOutput["messages"]);
+    const system = await runSystemTransform(hooks, []);
+    const block = system[0] as string;
+    const first = block.split("\n").find((l) => l.startsWith("  <skill>"));
+    // The ignored diagrams text must not drive ranking; the JSON text does.
+    expect(first).toContain("<name>beta-plugin:no-name</name>");
   });
 
   test("a trailing assistant message keeps the previous user capture (one-turn-stale contract)", async () => {


### PR DESCRIPTION
## What

The OpenCode plugin binding (`adapters/opencode/`) over the discovery core landed in #2089. Implements ADR-0022 §2's OpenCode half.

- **Pull** (stable API): `search_skills` via the plugin `tool: {}` surface (zod args), returning top-k `{name, description, path}`; OpenCode reads Claude Code SKILL.md natively, so no content conversion.
- **Suppression**: primary is consumer-side `"permission": {"skill": "deny"}` (stable config; removes both the `<available_skills>` system-prompt block and the native tool), with a defensive in-plugin strip as backup.
- **Push** (guarded): `experimental.chat.system.transform` injects pins + ranked top-k; declared unconditionally since unknown hooks are silently never called on older versions, plus a non-gating `/global/health` version log. Ranking input is captured from `experimental.chat.messages.transform` (one-turn-stale caveat documented in-code).

### Two blockers caught in review

Both were found by adversarial review against upstream source, not by tests:

1. **Reassigning `output.system` silently no-ops.** Upstream reads its local `system` array after `plugin.trigger` with no copy-back, so both the strip and the push were being discarded. Now mutates in place (`length = 0; push(...)`), and the test harness returns the *original* array reference so the suite pins the in-place contract.
2. **The whole-element strip would have deleted the entire system prompt.** Upstream pre-joins the whole prompt into a single array element, so dropping any element containing `<available_skills>` removes everything — in exactly the scenario the strip exists for. Replaced with substring removal (`stripAvailableSkillsBlocks` in `core/render.ts`, shared with the pi binding's strip semantics); elements are only removed if they become empty.

Plus 5 lower-severity fixes (phantom `@opencode-ai/sdk` test import, empty-block push on a first turn with no pins, unfiltered `ignored` text parts, missing import-restriction coverage for `opencode/`, fixture tmpdir leak) in `e15d3a69`.

## Verification

- `bun test`: 121 pass / 0 fail; `tsc --noEmit`, `biome ci`: clean
- Smoke eval still `=== GATE === STATUS=PASS` (in-tier hit@5 0.370, excluded 0.694, ADAPTER_TOKENS=608)
- Import-restriction test now covers `opencode/` (`node:*` / relative / `@opencode-ai/plugin` only)

Closes #2091

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5iwac3d7LWd8Jr9iBArXv