### PR TITLE
refactor(feedback-plugin): drop inert memory: user from friction-learner

### DIFF
--- a/.claude/rules/agent-development.md
+++ b/.claude/rules/agent-development.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-02-25
-modified: 2026-07-03
-reviewed: 2026-07-04
+modified: 2026-07-21
+reviewed: 2026-07-21
 paths:
   - "**/agents/**"
   - "**/git_repo_agent/**"
@@ -311,6 +311,15 @@ When `git worktree remove` fails (e.g., gitignored build artifacts or in-progres
 
 ## Persistent Agent Memory
 
+> **This repo deliberately does not use agent `memory:` (and keeps Claude's auto
+> memory disabled).** Durable knowledge lives in **curated rules and skills** —
+> version-controlled, reviewable, and deliberately steerable — not in an opaque
+> per-agent `MEMORY.md` that accretes without a gate. This is `docs/PRINCIPLES.md`
+> §5 ("Codify the fix; don't promise to remember"): the substrate remembers so
+> the agent doesn't have to. The section below documents the Claude Code feature
+> for completeness; treat it as reference, not a recommendation. No agent in this
+> repo sets `memory:`, and no `MEMORY.md` is tracked.
+
 The `memory` field enables per-agent persistent memory that survives across conversations:
 
 ```yaml
@@ -318,7 +327,6 @@ The `memory` field enables per-agent persistent memory that survives across conv
 name: code-reviewer
 memory: user
 ---
-Update your agent memory with patterns, conventions, and recurring issues you discover.
 ```
 
 | Scope | Location | Use When |
@@ -355,7 +363,7 @@ For rules an agent **must not forget** between threads — the friction-mining o
 
 ### Auto Memory Pattern
 
-The auto memory directory (`~/.claude/projects/<project>/memory/`) is loaded into every conversation. Use it to persist cross-session knowledge:
+Claude's auto memory directory (`~/.claude/projects/<project>/memory/`) is loaded into every conversation when enabled:
 
 ```
 ~/.claude/projects/<project>/memory/
@@ -364,7 +372,7 @@ The auto memory directory (`~/.claude/projects/<project>/memory/`) is loaded int
 └── debugging.md       # Project-specific debugging notes
 ```
 
-Agents can read and write to auto memory files to build on knowledge across sessions.
+**This repo keeps auto memory disabled** and captures cross-session knowledge as curated rules and skills instead (see the stance note under "Persistent Agent Memory" above, and `session-plugin:session-distill` for the capture→rule/skill path). The pattern is documented here as reference only.
 
 ## Agent Teams (Multi-Agent Collaboration)
 

--- a/feedback-plugin/agents/friction-learner.md
+++ b/feedback-plugin/agents/friction-learner.md
@@ -12,9 +12,8 @@ color: "#E53E3E"
 tools: Bash(python3 *), Bash(jq *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git branch *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(gh pr *), Bash(gh issue *), Bash(find *), Read, Write, Edit, Glob, Grep, TodoWrite
 context: fork
 maxTurns: 40
-memory: user
 created: 2026-04-16
-modified: 2026-06-28
+modified: 2026-07-21
 reviewed: 2026-04-28
 ---
 


### PR DESCRIPTION
## What

- Remove `memory: user` from `feedback-plugin/agents/friction-learner.md`.
- Reframe the "Persistent Agent Memory" and "Auto Memory Pattern" sections in `.claude/rules/agent-development.md` as reference-only, with an explicit stance note.

## Why

While tracing whether `MEMORY.md` was a leftover, the investigation found:

- **No `MEMORY.md` file has ever been tracked** in the repo (verified across recovered history).
- `friction-learner` was the **only** agent declaring `memory: user`, present since its creation (#1051) — but its **body never reads or writes agent memory**. It was a declared-but-inert frontmatter flag.
- The mechanism is in direct tension with `docs/PRINCIPLES.md §5` ("Codify the fix; don't promise to remember" — the substrate remembers so the agent doesn't have to).

The maintainer keeps Claude's auto memory disabled and prefers curating durable knowledge as **rules and skills** — deliberate, version-controlled, steerable levers — rather than opaque per-agent memory that accretes without a gate.

## Changes

- `friction-learner.md`: drop `memory: user`; bump `modified:` to 2026-07-21.
- `agent-development.md`: add a stance note under "Persistent Agent Memory" (repo deliberately does not use agent `memory:` / auto memory; documented for completeness only), reframe "Auto Memory Pattern" as reference-only pointing at `session-plugin:session-distill` for the capture→rule/skill path; remove the endorsing example line; bump `modified:`/`reviewed:`.

## Verification

- `check-agent-model.sh` ✅ (21/21 on opus)
- `check-agent-tool-selection.sh` ✅ (21/21 have Tool Selection)
- `check-driver-freshness.sh` ✅ (driver fresh)
- No agent sets `memory:` after the change; no stale docs claim friction-learner uses persistent memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAyNsiRGUWeVa1D26C4sPq

---
_Generated by [Claude Code](https://claude.ai/code/session_01EAyNsiRGUWeVa1D26C4sPq)_