### PR TITLE
feat(adapters): freeze the ADR-0022 cutover threshold at 0.57

### DIFF
--- a/adapters/CUTOVER.md
+++ b/adapters/CUTOVER.md
@@ -1,0 +1,162 @@
+# Cutover gate — freezing the adapter threshold
+
+The go/no-go gate for [#2093](https://github.com/laurigates/claude-plugins/issues/2093)
+(remove the pi tier system) and
+[#2094](https://github.com/laurigates/claude-plugins/issues/2094) (retire the
+rulesync export). Per the `tool-migration-cutover` rule and ADR-0022, neither
+cutover may proceed until the adapter is **observed operational on the shipping
+configuration** — not merely configured.
+
+This procedure runs **locally, never in CI**. CI's `GATE STATUS` asserts only
+that the eval machinery ran; it never evaluates the cutover threshold.
+
+> Until 2026-07 this document existed only in an ephemeral scratchpad, while
+> 20+ shipped source files cited it as "DESIGN §5.6". It now lives in the repo.
+
+## Status
+
+**Frozen 2026-07-22** at `main_hit_at_k_min = 0.57`, measured 0.6727 on the
+hybrid ranker over the 55-task main stratum (commit `8fa66076`). Both cutovers
+are unblocked by a green gate; executing them is separate work.
+
+## 1. The measurement
+
+```
+ollama pull nomic-embed-text
+cd adapters && bun eval/run-eval.ts --with-embeddings
+```
+
+Read `HIT_AT_K` off `=== RETRIEVAL_MAIN ===`. The run is only admissible if
+**all** of these hold on the *same* run:
+
+| Signal | Required | Why |
+|---|---|---|
+| `MODE=` | `hybrid` | The BM25 smoke ranker is not what the bindings ship |
+| `DEGRADED_QUERIES=` | `0` | Per-query embedding failures are invisible otherwise (see Guards) |
+| `=== GATE === STATUS=` | `PASS` | Machinery ran; schema + integrity invariants hold |
+
+Use a **cold cache** so the corpus is genuinely embedded this run:
+
+```
+mv "${XDG_CACHE_HOME:-$HOME/.cache}/claude-plugins-adapters/embeddings" /tmp/emb-bak
+```
+
+## 2. The check that cannot be faked
+
+If `--with-embeddings` produces byte-identical rankings to the BM25 run, the
+embedding side contributed nothing regardless of what `MODE=` claims:
+
+```
+bun eval/run-eval.ts --with-embeddings | tee /tmp/hybrid.out
+bun eval/run-eval.ts | tee /tmp/smoke.out
+diff <(jq -S '[.perTask[]|{id,rankedIds}]' "$HYBRID_JSON") <(jq -S '[.perTask[]|{id,rankedIds}]' "$SMOKE_JSON") && echo "IDENTICAL — investigate"
+```
+
+At the 2026-07-22 freeze, 70 of 71 tasks ranked differently. Cross-check that
+the cache materialized with the right model — a bm25-only run **never** writes
+this file:
+
+```
+jq '{model, dims, n: (.entries|length)}' "${XDG_CACHE_HOME:-$HOME/.cache}/claude-plugins-adapters/embeddings/"*.json
+```
+
+## 3. Derive the threshold
+
+**`floor((measured − 0.10) × 100) / 100`** on the main stratum. Floor, not
+round. At the freeze: `floor((0.6727 − 0.10) × 100) / 100 = 0.57`.
+
+## 4. Freeze it
+
+Replace the `status` string in `eval/tasks.json` `gate.cutover_thresholds`
+**wholesale** with `main_hit_at_k_min` plus its provenance. `validateTaskSet`
+enforces exactly-one-of (`status` containing "unfrozen" | numeric threshold),
+the `[0, 1]` range, an allow-list of keys, and the presence of every
+provenance field:
+
+| Field | Why it is provenance, not decoration |
+|---|---|
+| `measured_main_hit_at_k`, `margin` | Lets a successor re-derive the number without re-running |
+| `mode` | The threshold is hybrid-scoped; a BM25 run reports `NA_BM25` |
+| `embedding_model`, `embedding_model_digest` | A model swap invalidates the measurement |
+| `embedding_dimensions`, `prefix_scheme` | **Both participate in the cache key** — changing either silently re-embeds the corpus and moves the measurement |
+| `corpus_entries`, `task_count_main_stratum` | The denominators the rate is over |
+| `frozen_at`, `frozen_commit`, `procedure` | When, against what tree, by what method |
+
+## 5. Guards — why a hybrid run cannot silently be a BM25 run
+
+Three independent levels, all raising **gate issues** (so a fake hybrid run
+reports `GATE STATUS=FAIL`, not a clean `PASS`):
+
+1. **Mode.** The smoke-mode invariant was one-directional: only
+   `!withEmbeddings && mode !== "bm25-only"` was checked, so a
+   `--with-embeddings` run that fell back to `bm25-only` still printed
+   `STATUS=PASS` and exited 0. The converse is now checked too.
+2. **Per-query degradation.** `core/search.ts` deliberately swallows per-query
+   embedding failures so search never hard-fails on the soft dependency — which
+   means `mode` alone is **not** a sufficient signal: the probe and corpus batch
+   can succeed (→ `mode === "hybrid"`) while every query silently falls back.
+   `SkillIndex.degradedQueries` counts them; any non-zero count under
+   `--with-embeddings` is a gate issue. `tests/search-degradation.test.ts`
+   stands up a stub serving valid vectors for `search_document:` and 500s for
+   `search_query:` to reach exactly that state.
+3. **Score shape.** RRF is hard-capped at `2/RRF_K = 0.0333`; raw BM25 tops
+   ~1–10. A "hybrid" run whose max score exceeds 0.05 is not hybrid.
+
+## 6. Stratification is pinned to tags, not to `pi/tiers.yaml`
+
+`partitionByStratum(scores)` takes **no `repoRoot`** by construction. The
+earlier tiers-derived partition would have inverted the gate: when #2093
+deletes `pi/tiers.yaml`, the in-tier metrics became `null` and the frozen
+threshold would evaluate **FAIL forever** — breaking exactly when it is meant
+to authorize the deletion.
+
+Pinning to the task set's own `stratum:` tags redefines both strata:
+
+| | tiers.yaml-derived (retired) | tag-pinned (current) |
+|---|---|---|
+| main / in-tier | 27 tasks | **55** (paraphrase 32 + ambiguity 15 + terse 8) |
+| headroom / excluded | 36 tasks | **8** (`stratum:excluded`) |
+
+`RETRIEVAL_MAIN` now means exactly *hybrid retrieval quality on the main
+positives* and asserts nothing about any baseline. The ADR §5.2 property that
+"in-tier baseline reachability is 1.0 by construction" is **retired** — do not
+reason from it. The pre-freeze BM25-only figure (in-tier hit@5 0.370) is on the
+old 27-task denominator and must not be reused.
+
+`derivePiBaseline` survives only for the informational `BASELINE_PI_TOKENS`
+figure and the token-calibration meta-test, both of which already degrade to
+`NA` / `skipIf` when `pi/tiers.yaml` disappears.
+
+## 7. Refuted constructions
+
+Recorded, not silently deleted (`validate-adversarial-constructions`).
+
+- **Zero-delta membership gate** (v1 draft — refuted 2026-07-19 by review
+  simulation). Construction: `gate: { min_hit_at_k_delta: 0 }` against baseline
+  listing membership, asserted in CI. Why it failed: in-tier baseline
+  membership was 100% **by construction** (a task was in-tier iff its expected
+  skill was in the installed set), so zero delta demanded adapter hit@5 = 100%;
+  the BM25 smoke ranker measured 44.4% (16/36). The aggregate reading
+  (55.6% vs 57.1%) also failed, and committed exactly the strata-mixing the
+  design forbids. Meta-test 1 was blind to the degeneracy because its "correct
+  variant" was the oracle, not the shipping ranker. Resolution: the CI/local
+  gate split, plus §6's tag pinning which removes the membership coupling
+  entirely.
+- **`neg_floor` scalar** (v1 draft — refuted in the same simulation).
+  Construction: negatives pass when no skill scores above a single `neg_floor`
+  in `tasks.json`. Why it failed: `search()` returns rank-derived RRF scores in
+  hybrid mode (~1/61..2/61, essentially query-independent) and unbounded raw
+  BM25 scores in smoke mode — **different units per mode** — and measured
+  negative top-1 scores fully overlap positive ones even within one mode. The
+  push channel also applies no floor, so the metric referenced a mechanism that
+  does not exist. Resolution: report-only margin distributions; a floor is
+  deferred until the push channel actually has one. (The 2026-07-22 hybrid run
+  reproduces the overlap: neg P50 0.0010 vs pos P50 0.0010.)
+
+## 8. Still open for #2094
+
+The `BASELINE_OC_TOKENS_ESTIMATED` figure is a pi-template proxy,
+**uncalibrated** — OpenCode embeds its listing in a different template. A real
+OpenCode measurement session (mirroring the pi 111 tok/skill measurement, with
+its own ±20% calibration assertion) remains a #2094 prerequisite. This freeze
+does not supply it.

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -19,6 +19,7 @@ OpenCode binding (`opencode/`) in
 | Path | What |
 |------|------|
 | `core/` | Indexer (marketplace scan + DIY frontmatter parse + compatibility filter), BM25 (Lucene IDF, k1=1.2, b=0.75), ollama `/api/embed` client (`search_document:`/`search_query:` prefixes, BM25 fallback), RRF fusion (k=60), L2-normalized Float32Array vector index, XDG content-hash embedding cache, shared render templates |
+| `CUTOVER.md` | The #2093/#2094 gate: measurement procedure, the frozen threshold + provenance, the hybrid-integrity guards, and the refuted gate constructions |
 | `eval/` | `tasks.json` (committed golden task set, k=5), `run-eval.ts` runner, ranker seam (`hybrid \| bm25Only \| embeddingOnly \| random(seed) \| oracle \| nameSubstring \| descriptionSubstring`), baseline derivation (`pi/tiers.yaml` + the export-opencode glob, computed offline), `results/` (gitignored per-run output) |
 | `pi/` | pi binding (#2090) — default-exported extension factory: `search_skills` pull tool + `before_agent_start` push injection, `skill-discovery.json` config |
 | `opencode/` | OpenCode binding (#2091) — named `SkillDiscoveryPlugin` plugin: `search_skills` tool (pull), `experimental.chat.system.transform` push injection + defensive listing strip, `experimental.chat.messages.transform` ranking-input capture, `[path, options]` tuple config |
@@ -165,22 +166,49 @@ in-repo).
 `bun eval/run-eval.ts` emits the structured contract (DESIGN §5.3):
 
 ```
-=== RETRIEVAL_IN_TIER === HIT_AT_1= HIT_AT_K= MRR= BASELINE_ARM=PRESENT|ABSENT
-=== RETRIEVAL_EXCLUDED_STRATUM === HIT_AT_1= HIT_AT_K= MRR=
+=== EVAL === MODE=hybrid|bm25-only K= TASKS= DEGRADED_QUERIES=
+=== RETRIEVAL_MAIN === HIT_AT_1= HIT_AT_K= MRR= TASKS=
+=== RETRIEVAL_HEADROOM === HIT_AT_1= HIT_AT_K= MRR= TASKS=
 === NEGATIVES === TOP1_MARGIN_NEG_P50= ... (report-only)
-=== TOKENS === BASELINE_PI_TOKENS= BASELINE_OC_TOKENS_ESTIMATED= ADAPTER_TOKENS=
-=== CUTOVER === STATUS=UNFROZEN|PASS|FAIL   (informational; frozen only by the §5.6 procedure)
-=== GATE === STATUS=PASS|FAIL               (machinery only — the CI assertion)
+=== TOKENS === BASELINE_PI_TOKENS= BASELINE_OC_TOKENS_ESTIMATED= ADAPTER_TOKENS= BASELINE_ARM=PRESENT|ABSENT
+=== CUTOVER === STATUS=UNFROZEN|PASS|FAIL|NA_BM25   (informational; see CUTOVER.md)
+=== GATE === STATUS=PASS|FAIL                       (machinery only — the CI assertion)
 ```
+
+The two strata are pinned to the task set's own `stratum:` tags, never derived
+from `pi/tiers.yaml` — `RETRIEVAL_MAIN` is paraphrase + ambiguity + terse (55
+tasks), `RETRIEVAL_HEADROOM` is `stratum:excluded` (8). `MAIN` means exactly
+*retrieval quality on the main positives* and asserts nothing about any
+baseline. The threshold is hybrid-scoped, so the BM25-only CI run reports
+`CUTOVER STATUS=NA_BM25` rather than a bogus `FAIL`.
 
 Retrieval/token metrics are informational in CI; the correctness teeth are
 the meta-tests in `tests/eval-meta.test.ts` (random-fails-every-seed /
 oracle-passes, substring-ranker separation, per-skill token calibration
-111±20%, trigram leakage lint, schema checks). The #2093/#2094 cutover
-thresholds are frozen only by the documented local hybrid-simulation
-procedure, never by CI. `BASELINE_OC_TOKENS_ESTIMATED` is a pi-template
-proxy, uncalibrated — a real OpenCode measurement session is a #2094
-prerequisite.
+111±20%, trigram leakage lint, schema checks, hybrid-integrity guards).
+The #2093/#2094 cutover threshold is frozen only by the local procedure in
+[`CUTOVER.md`](CUTOVER.md), never by CI. `BASELINE_OC_TOKENS_ESTIMATED` is a
+pi-template proxy, uncalibrated — a real OpenCode measurement session is a
+#2094 prerequisite.
+
+## Freezing the cutover threshold
+
+Full procedure, guards, and the refuted constructions:
+[`CUTOVER.md`](CUTOVER.md). Frozen 2026-07-22 at `main_hit_at_k_min = 0.57`
+(measured 0.6727 hybrid). The measurement:
+
+```
+ollama pull nomic-embed-text
+mv "${XDG_CACHE_HOME:-$HOME/.cache}/claude-plugins-adapters/embeddings" /tmp/emb-bak
+cd adapters && bun eval/run-eval.ts --with-embeddings
+```
+
+A run is admissible only if the *same* run reports `MODE=hybrid`,
+`DEGRADED_QUERIES=0`, and `GATE STATUS=PASS`. Three guards make a fake hybrid
+run a `GATE FAIL` instead of a silent pass: the mode check (both directions),
+the per-query degradation counter (`core/search.ts` swallows those failures
+for the shipping path, so `mode` alone is not sufficient), and a score-shape
+check (RRF caps at 0.0333; raw BM25 tops ~1–10).
 
 To regenerate the BM25 reference fixture (only when deliberately taking a
 fresh corpus snapshot): `uv run tests/gen-bm25-reference.py`.
@@ -193,5 +221,6 @@ fresh corpus snapshot): `uv run tests/gen-bm25-reference.py`.
   from this checkout.
 - Not a replacement for the still-operational `pi/tiers.yaml` +
   `scripts/install-pi.sh` and rulesync export pipelines — those stay
-  authoritative until the eval gate passes and #2093/#2094 execute their
-  documented cutover steps.
+  authoritative until #2093/#2094 execute their documented cutover steps.
+  The eval gate now passes (frozen 2026-07-22), so those issues are
+  unblocked, but nothing in this package removes the incumbents.

--- a/adapters/core/search.ts
+++ b/adapters/core/search.ts
@@ -40,6 +40,19 @@ export class SkillIndex {
   readonly mode: "hybrid" | "bm25-only";
   readonly warnings: string[];
 
+  /**
+   * Count of queries that fell back to BM25 because their embedding failed.
+   *
+   * The shipping path deliberately swallows per-query embedding failures, so
+   * `mode` alone is NOT a sufficient signal that a run was actually hybrid:
+   * an index can report `mode === "hybrid"` while every individual query
+   * degraded. The eval raises a gate issue on any non-zero count, so a
+   * threshold can never be frozen from a partly-BM25 run.
+   */
+  degradedQueries = 0;
+  /** Message of the most recent per-query embedding failure (diagnosis aid). */
+  lastDegradeReason: string | null = null;
+
   private readonly bm25: Bm25Index;
   private readonly idToIdx: Map<string, number>;
   private readonly embedOpts: EmbedOptions | null;
@@ -141,8 +154,12 @@ export class SkillIndex {
         embedList = this.cosineRank(queryVec)
           .map(({ docIdx, score }) => ({ id: (this.entries[docIdx] as SkillEntry).id, score }))
           .filter((item) => inCandidates(item.id));
-      } catch {
+      } catch (error) {
         // Per-query embedding failure degrades this query to BM25-only.
+        // Swallowed for the shipping path (search never hard-fails on the
+        // embedding side) but counted so the eval can see it.
+        this.degradedQueries++;
+        this.lastDegradeReason = error instanceof Error ? error.message : String(error);
         embedList = null;
       }
       fused =

--- a/adapters/eval/run-eval.ts
+++ b/adapters/eval/run-eval.ts
@@ -4,13 +4,13 @@
  * Smoke mode (default) is BM25-only, zero network — CI has no ollama and the
  * smoke gate must never flake on the soft dependency. `--with-embeddings`
  * exercises hybrid fusion when an endpoint is reachable (local dev; the
- * configuration the cutover thresholds are derived on, §5.6).
+ * configuration the cutover threshold is derived on — see adapters/CUTOVER.md).
  *
  * All retrieval/token metrics are informational in CI. `GATE STATUS` asserts
  * only that the eval *machinery* ran (tasks parse + schema-validate, index
- * builds, every task scored, per-mode invariants hold); the correctness
- * teeth live in tests/eval-meta.test.ts. CI never gates on the cutover
- * thresholds — that comparison is the §5.6 local procedure.
+ * builds, every task scored, per-mode and hybrid-integrity invariants hold);
+ * the correctness teeth live in tests/eval-meta.test.ts. CI never gates on the
+ * cutover threshold — that comparison is the local procedure in CUTOVER.md.
  */
 
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -32,8 +32,126 @@ export const TASKS_PATH = join(EVAL_DIR, "tasks.json");
 
 const TAG_RE = /^(stratum|domain):[a-z0-9-]+$/;
 
+/**
+ * The headroom stratum — positives whose expected skill was never in any
+ * curated install set. Everything else positive is the main stratum, so a
+ * newly added stratum lands in main by default (partition stays covering).
+ */
+const HEADROOM_STRATA = new Set(["stratum:excluded"]);
+
+/** Every key `gate.cutover_thresholds` may carry (CUTOVER.md "Freeze"). */
+const THRESHOLD_KEYS = new Set([
+  "status",
+  "main_hit_at_k_min",
+  "measured_main_hit_at_k",
+  "margin",
+  "mode",
+  "embedding_model",
+  "embedding_model_digest",
+  "embedding_dimensions",
+  "prefix_scheme",
+  "corpus_entries",
+  "task_count_main_stratum",
+  "frozen_at",
+  "frozen_commit",
+  "procedure",
+]);
+
+/** Provenance a frozen (numeric) threshold must carry to be interpretable. */
+const REQUIRED_PROVENANCE_KEYS = [
+  "measured_main_hit_at_k",
+  "margin",
+  "mode",
+  "embedding_model",
+  "embedding_model_digest",
+  "embedding_dimensions",
+  "prefix_scheme",
+  "corpus_entries",
+  "task_count_main_stratum",
+  "frozen_at",
+  "frozen_commit",
+  "procedure",
+] as const;
+
 export function loadTaskSet(path: string = TASKS_PATH): TaskSet {
   return JSON.parse(readFileSync(path, "utf8")) as TaskSet;
+}
+
+/**
+ * Validate the freeze block itself. The failure this exists to prevent: a
+ * misspelled threshold key (`main_hit_at_k_mim`) would otherwise leave the
+ * cutover silently and permanently UNFROZEN — a green gate that asserts
+ * nothing. An unknown key is a GATE FAIL, not a shrug.
+ */
+function validateThresholds(thresholds: Record<string, unknown>): string[] {
+  const errors: string[] = [];
+  for (const key of Object.keys(thresholds)) {
+    if (!THRESHOLD_KEYS.has(key)) {
+      errors.push(`cutover_thresholds: unknown key ${JSON.stringify(key)}`);
+    }
+  }
+
+  const unfrozen = typeof thresholds.status === "string" && thresholds.status.includes("unfrozen");
+  const frozen = typeof thresholds.main_hit_at_k_min === "number";
+  if (unfrozen === frozen) {
+    errors.push(
+      "cutover_thresholds: need exactly one of a status containing 'unfrozen' " +
+        "or a numeric main_hit_at_k_min",
+    );
+  }
+
+  if (frozen) {
+    const min = thresholds.main_hit_at_k_min as number;
+    if (!Number.isFinite(min) || min < 0 || min > 1) {
+      errors.push(`cutover_thresholds: main_hit_at_k_min ${min} outside [0, 1]`);
+    }
+    for (const key of REQUIRED_PROVENANCE_KEYS) {
+      if (!(key in thresholds)) {
+        errors.push(`cutover_thresholds: frozen threshold missing provenance field ${key}`);
+      }
+    }
+  }
+  return errors;
+}
+
+/**
+ * Decide the cutover verdict. Pure so the freeze can be table-tested.
+ *
+ * **Numeric-first precedence**: a leftover `status: "unfrozen"` string can
+ * never mask a frozen number. The frozen threshold is hybrid-scoped — the
+ * default BM25-only CI run reports NA_BM25, never a bogus FAIL.
+ */
+export function computeCutoverStatus(
+  thresholds: Record<string, unknown>,
+  mode: "hybrid" | "bm25-only",
+  mainHitAtK: number,
+): "UNFROZEN" | "PASS" | "FAIL" | "NA_BM25" {
+  if (typeof thresholds.main_hit_at_k_min === "number") {
+    if (mode !== "hybrid") return "NA_BM25";
+    return mainHitAtK >= thresholds.main_hit_at_k_min ? "PASS" : "FAIL";
+  }
+  return "UNFROZEN";
+}
+
+/**
+ * Partition positives into the main and headroom strata using the task set's
+ * own `stratum:` tags.
+ *
+ * Takes no repoRoot **by construction**: the partition must not depend on
+ * `pi/tiers.yaml`, which #2093 deletes. A tiers-derived partition would make
+ * the frozen threshold evaluate FAIL forever at exactly the moment the gate
+ * is meant to authorize that deletion.
+ */
+export function partitionByStratum(scores: TaskScore[]): {
+  main: TaskScore[];
+  headroom: TaskScore[];
+} {
+  const positive = scores.filter((s) => !s.task.negative);
+  const isHeadroom = (s: TaskScore) => (s.task.tags ?? []).some((t) => HEADROOM_STRATA.has(t));
+  return {
+    main: positive.filter((s) => !isHeadroom(s)),
+    headroom: positive.filter(isHeadroom),
+  };
 }
 
 /**
@@ -49,6 +167,8 @@ export function validateTaskSet(tasks: TaskSet): string[] {
     tasks.gate.cutover_thresholds === null
   ) {
     errors.push("gate block missing cutover_thresholds");
+  } else {
+    errors.push(...validateThresholds(tasks.gate.cutover_thresholds));
   }
   if (tasks.k !== DEFAULT_K) {
     errors.push(`tasks.k (${tasks.k}) !== DEFAULT_K (${DEFAULT_K})`);
@@ -81,7 +201,7 @@ export function validateTaskSet(tasks: TaskSet): string[] {
   return errors;
 }
 
-interface TaskScore {
+export interface TaskScore {
   task: EvalTask;
   rankedIds: string[];
   scores: number[];
@@ -102,15 +222,17 @@ export interface EvalRun {
   mode: "hybrid" | "bm25-only";
   k: number;
   baselineArm: "PRESENT" | "ABSENT";
-  inTier: StratumMetrics | null;
-  excluded: StratumMetrics;
+  /** Non-nullable by design — the partition is tag-pinned, never tiers-derived. */
+  main: StratumMetrics;
+  headroom: StratumMetrics;
+  degradedQueries: number;
   negMargins: number[];
   posMargins: number[];
   baselinePiTokens: number | null;
   baselineOcTokensEstimated: number;
   adapterTokens: number;
   scores: TaskScore[];
-  cutoverStatus: "UNFROZEN" | "PASS" | "FAIL";
+  cutoverStatus: "UNFROZEN" | "PASS" | "FAIL" | "NA_BM25";
   gateStatus: "PASS" | "FAIL";
   gateIssues: string[];
 }
@@ -171,6 +293,9 @@ export async function runEval(options: {
   withEmbeddings: boolean;
   tasksPath?: string;
   repoRoot?: string;
+  /** Override the embedding endpoint (guard tests point at a dead port). */
+  embedEndpoint?: string;
+  embedModel?: string;
 }): Promise<EvalRun> {
   const repoRoot = options.repoRoot ?? REPO_ROOT;
   const gateIssues: string[] = [];
@@ -183,15 +308,41 @@ export async function runEval(options: {
   const index = await buildIndex({
     repoRoot,
     target: "foreign",
-    embed: { disabled: !options.withEmbeddings },
+    embed: {
+      disabled: !options.withEmbeddings,
+      ...(options.embedEndpoint !== undefined ? { endpoint: options.embedEndpoint } : {}),
+      ...(options.embedModel !== undefined ? { model: options.embedModel } : {}),
+    },
   });
   if (index.entries.length === 0) gateIssues.push("index built with zero entries");
   if (!options.withEmbeddings && index.mode !== "bm25-only") {
     gateIssues.push(`smoke mode invariant violated: mode=${index.mode}`);
   }
+  // The smoke invariant above is one-directional: without this, a
+  // --with-embeddings run that silently fell back still printed STATUS=PASS.
+  if (options.withEmbeddings && index.mode !== "hybrid") {
+    gateIssues.push(`--with-embeddings requested but index degraded: mode=${index.mode}`);
+  }
 
   const scores = await scoreTasks(index, taskSet.tasks, k);
   if (scores.length !== taskSet.tasks.length) gateIssues.push("not every task scored");
+
+  // Per-query embedding failures leave mode === "hybrid" and are otherwise
+  // invisible (core/search.ts swallows them for the shipping path). A
+  // threshold derived from a partly-BM25 run would be fiction.
+  if (options.withEmbeddings && index.degradedQueries > 0) {
+    gateIssues.push(
+      `${index.degradedQueries} queries degraded to BM25 (last: ${index.lastDegradeReason})`,
+    );
+  }
+
+  // Score-shape sanity: RRF is hard-capped at 2/RRF_K = 0.0333, while raw
+  // BM25 tops ~1-10. A hybrid run whose scores look like BM25 is not hybrid,
+  // whatever `mode` claims.
+  const maxScore = scores.reduce((acc, s) => Math.max(acc, ...s.scores), 0);
+  if (options.withEmbeddings && maxScore > 0.05) {
+    gateIssues.push(`hybrid run has BM25-shaped scores (max=${maxScore.toFixed(4)} > 0.05)`);
+  }
 
   // Baselines (runtime-derived, never stored per task).
   const piBaseline: BaselineSet | null = derivePiBaseline(repoRoot);
@@ -201,20 +352,13 @@ export async function runEval(options: {
   const positive = scores.filter((s) => !s.task.negative);
   const negative = scores.filter((s) => s.task.negative);
 
-  // A task is in-tier iff its expected skill is in the installed set — so
-  // baseline reachability is constant 1.0 on that stratum by construction
-  // (DESIGN §5.2 "honest reading"). With the baseline absent, everything
-  // degrades to headroom-only reporting.
-  let inTierScores: TaskScore[] = [];
-  let excludedScores: TaskScore[] = positive;
-  if (piBaseline !== null) {
-    inTierScores = positive.filter((s) =>
-      s.task.expected_skills.some((id) => piBaseline.ids.has(id)),
-    );
-    excludedScores = positive.filter(
-      (s) => !s.task.expected_skills.some((id) => piBaseline.ids.has(id)),
-    );
-  }
+  // Tag-pinned partition (CUTOVER.md). RETRIEVAL_MAIN means exactly "hybrid
+  // retrieval quality on the main positives" and asserts nothing about any
+  // baseline — the DESIGN §5.2 "in-tier baseline reachability is 1.0 by
+  // construction" reading is retired along with the tiers-derived stratum.
+  const { main: mainScores, headroom: headroomScores } = partitionByStratum(scores);
+  if (mainScores.length === 0) gateIssues.push("main stratum is empty");
+  if (headroomScores.length === 0) gateIssues.push("headroom stratum is empty");
 
   // Metric B — standing tokens/turn (chars/4 over the shared render).
   const baselinePiTokens = piBaseline === null ? null : listingTokens(piBaseline.skills).total;
@@ -233,25 +377,18 @@ export async function runEval(options: {
     toolDescriptionTokens + (positive.length > 0 ? Math.round(injectedSum / positive.length) : 0);
 
   // Cutover block — informational; numeric thresholds exist only after the
-  // §5.6 freeze procedure.
+  // CUTOVER.md freeze procedure.
   const thresholds = taskSet.gate?.cutover_thresholds ?? {};
-  let cutoverStatus: EvalRun["cutoverStatus"] = "UNFROZEN";
-  const inTierMetrics = piBaseline === null ? null : aggregate(inTierScores);
-  if (typeof thresholds.status === "string" && thresholds.status.includes("unfrozen")) {
-    cutoverStatus = "UNFROZEN";
-  } else if (typeof thresholds.in_tier_hit_at_k_min === "number") {
-    cutoverStatus =
-      inTierMetrics !== null && inTierMetrics.hitAtK >= thresholds.in_tier_hit_at_k_min
-        ? "PASS"
-        : "FAIL";
-  }
+  const mainMetrics = aggregate(mainScores);
+  const cutoverStatus = computeCutoverStatus(thresholds, index.mode, mainMetrics.hitAtK);
 
   return {
     mode: index.mode,
     k,
     baselineArm,
-    inTier: inTierMetrics,
-    excluded: aggregate(excludedScores),
+    main: mainMetrics,
+    headroom: aggregate(headroomScores),
+    degradedQueries: index.degradedQueries,
     negMargins: negative.map((s) => s.top1Margin).filter((m): m is number => m !== null),
     posMargins: positive.map((s) => s.top1Margin).filter((m): m is number => m !== null),
     baselinePiTokens,
@@ -270,24 +407,20 @@ function fmt(value: number | null): string {
 
 export function renderReport(run: EvalRun): string {
   const lines: string[] = [];
-  lines.push(`=== EVAL === MODE=${run.mode} K=${run.k} TASKS=${run.scores.length}`);
-  if (run.inTier !== null) {
-    lines.push(
-      `=== RETRIEVAL_IN_TIER === HIT_AT_1=${fmt(run.inTier.hitAt1)} HIT_AT_K=${fmt(run.inTier.hitAtK)} MRR=${fmt(run.inTier.mrr)} BASELINE_ARM=${run.baselineArm}`,
-    );
-  } else {
-    lines.push(
-      `=== RETRIEVAL_IN_TIER === HIT_AT_1=NA HIT_AT_K=NA MRR=NA BASELINE_ARM=${run.baselineArm}`,
-    );
-  }
   lines.push(
-    `=== RETRIEVAL_EXCLUDED_STRATUM === HIT_AT_1=${fmt(run.excluded.hitAt1)} HIT_AT_K=${fmt(run.excluded.hitAtK)} MRR=${fmt(run.excluded.mrr)}`,
+    `=== EVAL === MODE=${run.mode} K=${run.k} TASKS=${run.scores.length} DEGRADED_QUERIES=${run.degradedQueries}`,
+  );
+  lines.push(
+    `=== RETRIEVAL_MAIN === HIT_AT_1=${fmt(run.main.hitAt1)} HIT_AT_K=${fmt(run.main.hitAtK)} MRR=${fmt(run.main.mrr)} TASKS=${run.main.taskCount}`,
+  );
+  lines.push(
+    `=== RETRIEVAL_HEADROOM === HIT_AT_1=${fmt(run.headroom.hitAt1)} HIT_AT_K=${fmt(run.headroom.hitAtK)} MRR=${fmt(run.headroom.mrr)} TASKS=${run.headroom.taskCount}`,
   );
   lines.push(
     `=== NEGATIVES === TOP1_MARGIN_NEG_P50=${fmt(percentile(run.negMargins, 50))} TOP1_MARGIN_NEG_P90=${fmt(percentile(run.negMargins, 90))} TOP1_MARGIN_POS_P50=${fmt(percentile(run.posMargins, 50))} TOP1_MARGIN_POS_P90=${fmt(percentile(run.posMargins, 90))}`,
   );
   lines.push(
-    `=== TOKENS === BASELINE_PI_TOKENS=${run.baselinePiTokens ?? "NA"} BASELINE_OC_TOKENS_ESTIMATED=${run.baselineOcTokensEstimated} ADAPTER_TOKENS=${run.adapterTokens}`,
+    `=== TOKENS === BASELINE_PI_TOKENS=${run.baselinePiTokens ?? "NA"} BASELINE_OC_TOKENS_ESTIMATED=${run.baselineOcTokensEstimated} ADAPTER_TOKENS=${run.adapterTokens} BASELINE_ARM=${run.baselineArm}`,
   );
   lines.push(`=== CUTOVER === STATUS=${run.cutoverStatus}`);
   lines.push(`=== GATE === STATUS=${run.gateStatus}`);

--- a/adapters/eval/tasks.json
+++ b/adapters/eval/tasks.json
@@ -3,7 +3,19 @@
   "k": 5,
   "gate": {
     "cutover_thresholds": {
-      "status": "unfrozen — derive via the documented hybrid-simulation procedure before #2093/#2094"
+      "main_hit_at_k_min": 0.57,
+      "measured_main_hit_at_k": 0.6727,
+      "margin": 0.1,
+      "mode": "hybrid",
+      "embedding_model": "nomic-embed-text",
+      "embedding_model_digest": "sha256:0a109f422b47e3a30ba2b10eca18548e944e8a23073ee3f3e947efcf3c45e59f",
+      "embedding_dimensions": 768,
+      "prefix_scheme": "search_document: /search_query: ",
+      "corpus_entries": 363,
+      "task_count_main_stratum": 55,
+      "frozen_at": "2026-07-22",
+      "frozen_commit": "8fa6607694dcda0cc23e7d70265c424b38373ff5",
+      "procedure": "adapters/CUTOVER.md"
     }
   },
   "tasks": [

--- a/adapters/tests/eval-meta.test.ts
+++ b/adapters/tests/eval-meta.test.ts
@@ -1,8 +1,9 @@
 /**
  * Eval meta-tests (DESIGN §5.5) — the CI teeth, per
  * validate-adversarial-constructions (both halves: broken-fails AND
- * correct-passes). The cutover comparison itself is the §5.6 local
- * procedure, not CI.
+ * correct-passes). The cutover comparison itself is the local procedure in
+ * adapters/CUTOVER.md, not CI — but the guards that make that procedure
+ * trustworthy (describe 6) are CI teeth like the rest.
  */
 
 import { beforeAll, describe, expect, test } from "bun:test";
@@ -28,7 +29,15 @@ import {
   oracleRanker,
   randomRanker,
 } from "../eval/rankers.ts";
-import { loadTaskSet, TASKS_PATH, validateTaskSet } from "../eval/run-eval.ts";
+import {
+  computeCutoverStatus,
+  loadTaskSet,
+  partitionByStratum,
+  runEval,
+  TASKS_PATH,
+  type TaskScore,
+  validateTaskSet,
+} from "../eval/run-eval.ts";
 
 const REPO_ROOT = resolve(import.meta.dir, "..", "..");
 
@@ -233,5 +242,200 @@ describe("4. leakage lint (deterministic)", () => {
       }
     }
     expect(offenders).toEqual([]);
+  });
+});
+
+describe("6. hybrid-integrity guards", () => {
+  const stub = (task: EvalTask): TaskScore => ({
+    task,
+    rankedIds: [],
+    scores: [],
+    hitAt1: false,
+    hitAtK: false,
+    reciprocalRank: 0,
+    top1Margin: null,
+  });
+  const allScores = taskSet.tasks.map(stub);
+
+  // --- stratification: properties, not pinned counts -----------------------
+
+  test("every task carries exactly one stratum: tag", () => {
+    const offenders = taskSet.tasks
+      .filter((t) => (t.tags ?? []).filter((tag) => tag.startsWith("stratum:")).length !== 1)
+      .map((t) => t.id);
+    expect(offenders).toEqual([]);
+  });
+
+  test("partition is disjoint, covers every positive, and excludes negatives", () => {
+    const { main, headroom } = partitionByStratum(allScores);
+    const mainIds = new Set(main.map((s) => s.task.id));
+    const headroomIds = new Set(headroom.map((s) => s.task.id));
+    const positiveIds = new Set(positiveTasks.map((t) => t.id));
+
+    expect([...mainIds].filter((id) => headroomIds.has(id))).toEqual([]);
+    expect(mainIds.size + headroomIds.size).toBe(positiveIds.size);
+    expect([...mainIds, ...headroomIds].filter((id) => !positiveIds.has(id))).toEqual([]);
+    expect(main.concat(headroom).filter((s) => s.task.negative)).toEqual([]);
+  });
+
+  test("both strata are non-degenerate (a threshold over an empty stratum is meaningless)", () => {
+    const { main, headroom } = partitionByStratum(allScores);
+    expect(main.length).toBeGreaterThanOrEqual(10);
+    expect(headroom.length).toBeGreaterThanOrEqual(5);
+  });
+
+  test("partitionByStratum takes no repoRoot — structurally cannot read pi/tiers.yaml (#2093)", () => {
+    expect(partitionByStratum.length).toBe(1);
+  });
+
+  // --- computeCutoverStatus: every branch, incl. the adversarial typo ------
+
+  const FROZEN = { main_hit_at_k_min: 0.6 };
+  const UNFROZEN = { status: "unfrozen — derive via the documented procedure" };
+
+  const cases: Array<{
+    name: string;
+    thresholds: Record<string, unknown>;
+    mode: "hybrid" | "bm25-only";
+    hitAtK: number;
+    expected: ReturnType<typeof computeCutoverStatus>;
+  }> = [
+    {
+      name: "frozen, hybrid, above",
+      thresholds: FROZEN,
+      mode: "hybrid",
+      hitAtK: 0.7,
+      expected: "PASS",
+    },
+    {
+      name: "frozen, hybrid, exactly at",
+      thresholds: FROZEN,
+      mode: "hybrid",
+      hitAtK: 0.6,
+      expected: "PASS",
+    },
+    {
+      name: "frozen, hybrid, below",
+      thresholds: FROZEN,
+      mode: "hybrid",
+      hitAtK: 0.5,
+      expected: "FAIL",
+    },
+    {
+      name: "frozen, bm25-only → NA_BM25, never a bogus FAIL",
+      thresholds: FROZEN,
+      mode: "bm25-only",
+      hitAtK: 0.1,
+      expected: "NA_BM25",
+    },
+    {
+      name: "unfrozen, hybrid",
+      thresholds: UNFROZEN,
+      mode: "hybrid",
+      hitAtK: 0.9,
+      expected: "UNFROZEN",
+    },
+    {
+      name: "unfrozen, bm25-only",
+      thresholds: UNFROZEN,
+      mode: "bm25-only",
+      hitAtK: 0.9,
+      expected: "UNFROZEN",
+    },
+    {
+      name: "numeric-first: a leftover 'unfrozen' string cannot mask a frozen number",
+      thresholds: { ...UNFROZEN, ...FROZEN },
+      mode: "hybrid",
+      hitAtK: 0.5,
+      expected: "FAIL",
+    },
+    {
+      name: "adversarial typo: misspelled key does NOT silently pass as frozen",
+      thresholds: { main_hit_at_k_mim: 0.6 },
+      mode: "hybrid",
+      hitAtK: 0.1,
+      expected: "UNFROZEN",
+    },
+  ];
+
+  for (const c of cases) {
+    test(`computeCutoverStatus — ${c.name}`, () => {
+      expect(computeCutoverStatus(c.thresholds, c.mode, c.hitAtK)).toBe(c.expected);
+    });
+  }
+
+  // --- the freeze block is itself validated --------------------------------
+
+  const withThresholds = (thresholds: Record<string, unknown>) => ({
+    ...taskSet,
+    gate: { cutover_thresholds: thresholds },
+  });
+  const FULL_PROVENANCE = {
+    main_hit_at_k_min: 0.6,
+    measured_main_hit_at_k: 0.7,
+    margin: 0.1,
+    mode: "hybrid",
+    embedding_model: "nomic-embed-text",
+    embedding_model_digest: "sha256:abc",
+    embedding_dimensions: 768,
+    prefix_scheme: "search_document: /search_query: ",
+    corpus_entries: 400,
+    task_count_main_stratum: 55,
+    frozen_at: "2026-07-22",
+    frozen_commit: "deadbeef",
+    procedure: "adapters/CUTOVER.md",
+  };
+
+  test("the shipped task set validates clean", () => {
+    expect(validateTaskSet(taskSet)).toEqual([]);
+  });
+
+  test("a misspelled threshold key is a GATE FAIL, not a silent permanent UNFROZEN", () => {
+    const errors = validateTaskSet(withThresholds({ main_hit_at_k_mim: 0.6 }));
+    expect(errors.some((e) => e.includes("unknown key"))).toBe(true);
+  });
+
+  test("neither status nor numeric threshold is rejected", () => {
+    expect(validateTaskSet(withThresholds({})).some((e) => e.includes("exactly one of"))).toBe(
+      true,
+    );
+  });
+
+  test("both status and numeric threshold is rejected", () => {
+    const errors = validateTaskSet(
+      withThresholds({ ...FULL_PROVENANCE, status: "unfrozen — stale" }),
+    );
+    expect(errors.some((e) => e.includes("exactly one of"))).toBe(true);
+  });
+
+  test("an out-of-range threshold is rejected", () => {
+    const errors = validateTaskSet(withThresholds({ ...FULL_PROVENANCE, main_hit_at_k_min: 1.5 }));
+    expect(errors.some((e) => e.includes("outside [0, 1]"))).toBe(true);
+  });
+
+  test("a frozen threshold must carry its provenance", () => {
+    const { embedding_model_digest, frozen_commit, ...partial } = FULL_PROVENANCE;
+    const errors = validateTaskSet(withThresholds(partial));
+    expect(errors.some((e) => e.includes("embedding_model_digest"))).toBe(true);
+    expect(errors.some((e) => e.includes("frozen_commit"))).toBe(true);
+  });
+
+  test("a fully-provenanced frozen block validates clean", () => {
+    expect(validateTaskSet(withThresholds(FULL_PROVENANCE))).toEqual([]);
+  });
+
+  // --- a fake hybrid run cannot report GATE PASS ---------------------------
+
+  test("--with-embeddings against a dead endpoint is a GATE FAIL, not a silent BM25 PASS", async () => {
+    const run = await runEval({
+      withEmbeddings: true,
+      repoRoot: REPO_ROOT,
+      // Reserved-for-testing port: dead on any dev machine, so this never
+      // goes hybrid just because the author happens to be running ollama.
+      embedEndpoint: "http://127.0.0.1:1",
+    });
+    expect(run.mode).toBe("bm25-only");
+    expect(run.gateStatus).toBe("FAIL");
+    expect(run.gateIssues.some((i) => i.includes("index degraded"))).toBe(true);
   });
 });

--- a/adapters/tests/search-degradation.test.ts
+++ b/adapters/tests/search-degradation.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Per-query embedding degradation is observable (CUTOVER.md "Guards").
+ *
+ * The shipping path deliberately swallows per-query embedding failures so
+ * search never hard-fails on the soft dependency. That makes `index.mode`
+ * an INSUFFICIENT signal that a run was actually hybrid: the build-time
+ * probe and the corpus batch can both succeed (→ mode "hybrid") while every
+ * subsequent query fails and silently falls back to BM25. A cutover
+ * threshold derived from such a run would be fiction.
+ *
+ * The stub below is the only deterministic way to reach that state: it
+ * serves valid vectors for `search_document:` inputs (so probe + corpus
+ * embedding succeed) and 500s for `search_query:` inputs (so every query
+ * degrades). Asserting `mode === "hybrid"` AND `degradedQueries > 0` in the
+ * same run is the proof that the counter carries information `mode` does not.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { cpSync, existsSync, mkdtempSync, readdirSync, renameSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_DIMENSIONS, DOCUMENT_PREFIX, QUERY_PREFIX } from "../core/embeddings.ts";
+import { buildIndex } from "../core/search.ts";
+
+const FIXTURE_SRC = join(import.meta.dir, "fixtures", "mini-marketplace-src");
+
+/** Deterministic unit-ish vector; content-dependent so rows are not identical. */
+function fakeVector(seed: number): number[] {
+  return Array.from({ length: DEFAULT_DIMENSIONS }, (_, i) => Math.sin((i + 1) * (seed + 1)));
+}
+
+let fixtureRoot = "";
+let cacheDir = "";
+let server: ReturnType<typeof Bun.serve>;
+let endpoint = "";
+/** Flipped per test to choose whether query embedding succeeds. */
+let failQueries = true;
+
+beforeAll(() => {
+  fixtureRoot = mkdtempSync(join(tmpdir(), "degrade-marketplace-"));
+  cpSync(FIXTURE_SRC, fixtureRoot, { recursive: true });
+  for (const entry of readdirSync(fixtureRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const src = join(fixtureRoot, entry.name, "skilldirs");
+    if (existsSync(src)) renameSync(src, join(fixtureRoot, entry.name, "skills"));
+  }
+  // Never touch the real XDG cache — a cached corpus would skip the batch.
+  cacheDir = mkdtempSync(join(tmpdir(), "degrade-cache-"));
+
+  server = Bun.serve({
+    port: 0,
+    async fetch(request) {
+      const body = (await request.json()) as { input: string[] };
+      const inputs = body.input;
+      const isQuery = inputs.some((text) => text.startsWith(QUERY_PREFIX));
+      if (isQuery && failQueries) {
+        return new Response("upstream exploded", { status: 500 });
+      }
+      if (!inputs.every((t) => t.startsWith(DOCUMENT_PREFIX) || t.startsWith(QUERY_PREFIX))) {
+        return new Response(JSON.stringify({ error: "missing task prefix" }), { status: 200 });
+      }
+      return Response.json({ embeddings: inputs.map((_, i) => fakeVector(i)) });
+    },
+  });
+  endpoint = `http://localhost:${server.port}`;
+});
+
+afterAll(() => {
+  server.stop(true);
+});
+
+describe("per-query embedding degradation", () => {
+  test("mode stays 'hybrid' while every query degrades — mode alone is not a sufficient signal", async () => {
+    failQueries = true;
+    const index = await buildIndex({
+      repoRoot: fixtureRoot,
+      embed: { endpoint, dimensions: DEFAULT_DIMENSIONS },
+      cacheDir,
+    });
+
+    // Document-side succeeded, so the index believes it is hybrid...
+    expect(index.mode).toBe("hybrid");
+    expect(index.degradedQueries).toBe(0);
+
+    const results = await index.search("commit some work", 5);
+
+    // ...but the query degraded, and search still returned BM25 results.
+    expect(index.mode).toBe("hybrid");
+    expect(index.degradedQueries).toBe(1);
+    expect(index.lastDegradeReason).toContain("500");
+    expect(results.length).toBeGreaterThan(0);
+
+    await index.search("another query", 5);
+    expect(index.degradedQueries).toBe(2);
+  });
+
+  test("a genuinely healthy endpoint leaves the counter at zero", async () => {
+    failQueries = false;
+    const index = await buildIndex({
+      repoRoot: fixtureRoot,
+      embed: { endpoint, dimensions: DEFAULT_DIMENSIONS },
+      cacheDir,
+    });
+
+    expect(index.mode).toBe("hybrid");
+    await index.search("commit some work", 5);
+    await index.search("another query", 5);
+
+    expect(index.degradedQueries).toBe(0);
+    expect(index.lastDegradeReason).toBeNull();
+  });
+});

--- a/docs/adrs/0022-adapter-over-export-for-foreign-harnesses.md
+++ b/docs/adrs/0022-adapter-over-export-for-foreign-harnesses.md
@@ -180,11 +180,45 @@ shared discovery core, and the export pipelines are superseded.
 | [#2090](https://github.com/laurigates/claude-plugins/issues/2090) | pi binding (hybrid push+pull) | eval vs tier baseline |
 | [#2091](https://github.com/laurigates/claude-plugins/issues/2091) | OpenCode binding (pull-first) | eval vs rulesync baseline |
 | [#2092](https://github.com/laurigates/claude-plugins/issues/2092) | `compatibility` frontmatter sweep | precedes cutovers |
-| [#2093](https://github.com/laurigates/claude-plugins/issues/2093) | Remove pi tier system | gated on #2090 |
-| [#2094](https://github.com/laurigates/claude-plugins/issues/2094) | Retire rulesync export | gated on #2091 |
+| [#2093](https://github.com/laurigates/claude-plugins/issues/2093) | Remove pi tier system | gate frozen + PASS (2026-07-22) |
+| [#2094](https://github.com/laurigates/claude-plugins/issues/2094) | Retire rulesync export | gate frozen + PASS; OC token calibration still outstanding |
+
+## Amendment (2026-07-22) — the cutover gate is tag-pinned and frozen
+
+The gate threshold was measured on the shipping hybrid configuration and frozen
+at `main_hit_at_k_min = 0.57` (measured 0.6727, margin 0.10) in
+`adapters/eval/tasks.json`. #2093 and #2094 are now unblocked by a green gate;
+the incumbents remain fully operational until those issues execute their own
+cutover steps (`tool-migration-cutover`).
+
+Two decisions in this ADR are superseded:
+
+1. **The eval's stratification is pinned to the task set's own `stratum:`
+   tags, not derived from `pi/tiers.yaml`.** A tiers-derived partition would
+   have inverted the gate: #2093 deletes that file, at which point the in-tier
+   metrics went `null` and the frozen threshold would have evaluated FAIL
+   forever — failing precisely when it is meant to authorize the deletion.
+   `partitionByStratum` therefore takes no `repoRoot` at all, so the coupling
+   cannot return. The strata are consequently much larger and differently
+   composed (main 27 → **55**, headroom 36 → **8**).
+
+2. **The "in-tier baseline reachability is 1.0 by construction" reading is
+   retired.** With membership no longer defining the stratum, `RETRIEVAL_MAIN`
+   means exactly *hybrid retrieval quality on the main positives* and asserts
+   nothing about any baseline. Reachability-delta reasoning against the pi
+   listing no longer applies; `derivePiBaseline` survives only for the
+   informational token figure and the calibration meta-test, both of which
+   already degrade cleanly when `pi/tiers.yaml` disappears.
+
+The procedure, its guards against a hybrid run that is silently BM25, and the
+refuted gate constructions now live in `adapters/CUTOVER.md` — previously they
+existed only in an ephemeral scratchpad while shipped source cited them as
+"DESIGN §5.6".
 
 ## References
 
+- `adapters/CUTOVER.md` — the cutover gate procedure, frozen threshold, and
+  refuted constructions
 - `docs/pi-export.md` — the measured listing-cost data and the original
   "skill-search extension" deferral this ADR supersedes
 - `docs/opencode-export.md` — the rulesync pipeline being retired


### PR DESCRIPTION
Measures the ADR-0022 adapter on its **shipping** configuration and freezes the result, unblocking #2093 and #2094. It stops there — neither cutover is executed here.

## The measurement

`RETRIEVAL_MAIN` hit@5 = **0.6727** (37/55) on the hybrid ranker, 363 foreign index entries, `nomic-embed-text` @ 768 dims. Frozen at `floor((0.6727 − 0.10) × 100) / 100` = **0.57**.

Admissible under all three guards on the same run: `MODE=hybrid`, `DEGRADED_QUERIES=0`, `GATE STATUS=PASS`. Cross-checked with a cold cache, and against the BM25 run — 70 of 71 tasks ranked differently, so the embedding side demonstrably contributed.

Every prior measurement was BM25-only; the hybrid path had never actually been run.

## Three findings that reshaped the work

**1. A frozen threshold would have inverted at #2093.** The eval derived its in-tier stratum from `pi/tiers.yaml` at runtime. When #2093 deletes that file, the metrics went `null` and the cutover check would evaluate **FAIL forever** — breaking exactly when it is meant to authorize the deletion. `partitionByStratum` now takes no `repoRoot` at all, so the coupling cannot return, and `EvalRun.main` is non-nullable as the proof.

Pinning to the task set's own `stratum:` tags moves both strata a lot:

| | tiers.yaml-derived | tag-pinned |
|---|---|---|
| main | 27 tasks | **55** (paraphrase 32 + ambiguity 15 + terse 8) |
| headroom | 36 tasks | **8** (`stratum:excluded`) |

`RETRIEVAL_MAIN` now means *retrieval quality on the main positives* and asserts nothing about any baseline. The ADR §5.2 "reachability is 1.0 by construction" reading is retired in an amendment.

**2. A hybrid run could silently be a BM25 run.** The smoke invariant was one-directional, so a `--with-embeddings` run that fell back still printed `STATUS=PASS` and exited 0. Worse, per-query embedding failures (`core/search.ts`, bare `catch {}`) left `mode === "hybrid"` and were completely invisible. A threshold derived from such a run would be fiction. Three independent guards now raise gate issues: mode (both directions), a per-query degradation counter, and a score-shape check (RRF caps at 0.0333; raw BM25 tops ~1–10).

`tests/search-degradation.test.ts` proves the counter carries information `mode` does not — a stub serving valid vectors for `search_document:` and 500s for `search_query:` reaches `mode === "hybrid"` with every query degraded.

**3. The procedure existed only in `/tmp`.** 20+ shipped files cited "DESIGN §N" for a document never tracked in git. It now lives in `adapters/CUTOVER.md`, including the two refuted gate constructions (kept, not deleted).

## Also

- Vocabulary renamed pre-freeze while it is still free: `RETRIEVAL_IN_TIER` → `RETRIEVAL_MAIN`, `RETRIEVAL_EXCLUDED_STRATUM` → `RETRIEVAL_HEADROOM`, `in_tier_hit_at_k_min` → `main_hit_at_k_min`. CI greps only the `GATE` line.
- `validateTaskSet` allow-lists threshold keys, so a misspelled `main_hit_at_k_mim` is a **GATE FAIL** rather than a silent permanent `UNFROZEN`. `computeCutoverStatus` is pure and numeric-first, so a leftover `"unfrozen"` string cannot mask a frozen number, and reports `NA_BM25` in CI rather than a bogus `FAIL`.

## Verification

`bunx tsc --noEmit`, `bunx biome ci .`, `bun test` (178 pass / 0 fail), smoke run `GATE=PASS` + `CUTOVER=NA_BM25`, hybrid run `MODE=hybrid` / `DEGRADED_QUERIES=0` / `GATE=PASS` / `CUTOVER=PASS`.

## Not in scope

`pi/tiers.yaml`, `scripts/install-pi.sh`, `scripts/check-pi-tiers.sh`, the justfile `pi` group, `scripts/export-opencode.sh`, and both export docs stay fully operational (`tool-migration-cutover`). #2094 additionally still needs the real OpenCode token-calibration session — `BASELINE_OC_TOKENS_ESTIMATED` remains an uncalibrated pi-template proxy.

Refs #2093
Refs #2094

🤖 Generated with [Claude Code](https://claude.com/claude-code)
