### PR TITLE
fix(hooks-plugin): confine the awk file-modification block to one pipe segment

### DIFF
--- a/hooks-plugin/hooks/bash-antipatterns.sh
+++ b/hooks-plugin/hooks/bash-antipatterns.sh
@@ -299,7 +299,15 @@ See .claude/rules/bash-tool-replacements.md for the full table."
 fi
 
 # Check for awk used for file modifications
-if echo "$COMMAND" | grep -Eq "awk\s+.*>\s*['\"]?[^|]+" && \
+#
+# Condition 1 must confine the span between `awk` and the redirect to a SINGLE
+# pipe segment (`[^|]*`, not `.*`). The old greedy `awk\s+.*>` crossed pipes, so
+# a read-only `awk` upstream of a DOWNSTREAM redirect —
+# `… | awk -F/ '{print $1}' | sort -u > "$f"`, where `sort` does the writing —
+# was blocked as if awk were rewriting the file (issue #2131). The trailing
+# `[^|]+` only ever constrained the chars AFTER `>`, never the span before it.
+# `awk\s+[^|]*>` still matches the true positive `awk '…' data.txt > "$f"`.
+if echo "$COMMAND" | grep -Eq "awk\s+[^|]*>\s*['\"]?[^|]+" && \
    echo "$COMMAND" | grep -Eq "(>|>>)\s*['\"]?\\\$"; then
     block "REMINDER: Use the Edit tool instead of 'awk' for file modifications. The Edit tool is safer and more precise."
 fi

--- a/hooks-plugin/hooks/test-bash-antipatterns.sh
+++ b/hooks-plugin/hooks/test-bash-antipatterns.sh
@@ -657,6 +657,68 @@ assert_exit \
     "GUARD: grep chain over a .output file (no source-file operand) still blocks" 2 \
     "grep -n Error run.output | grep -v warn | sed s/a/b/"
 
+# ── awk file-modification block must not span a pipe (issue #2131) ────────────
+# Regression: condition 1's greedy `awk\s+.*>` crossed the pipe, so a READ-ONLY
+# awk upstream of a DOWNSTREAM redirect — `… | awk -F/ '{print $1}' | sort -u >
+# "$f"`, where `sort` is the writer — was blocked as if awk rewrote the file.
+# The trailing `[^|]+` only ever constrained the chars AFTER `>`, never the span
+# before it. Confining that span to one pipe segment (`awk\s+[^|]*>`) keeps the
+# true positive (`awk '…' file > "$f"`) and drops the false positive. Rows below
+# are the issue's reproduction table plus the >> and non-variable variants.
+echo ""
+echo "awk block confines itself to one pipe segment; awk-owned redirects still block (#2131):"
+
+# Single-quoted awk programs (the form the issue reported) can't live in a
+# single-quoted bash string, so build these command strings via heredocs.
+awk_downstream_redirect_cmd=$(cat <<'OUTER'
+chezmoi managed 2>/dev/null | awk -F/ '{print $1}' | sort -u > "$SP/chezmoi-toplevel.txt"
+OUTER
+)
+awk_uniq_redirect_cmd=$(cat <<'OUTER'
+cat access.log | awk '{print $2}' | sort | uniq -c > "$DEST/counts.txt"
+OUTER
+)
+awk_no_redirect_cmd=$(cat <<'OUTER'
+chezmoi managed | awk -F/ '{print $1}' | sort -u
+OUTER
+)
+awk_owns_redirect_cmd=$(cat <<'OUTER'
+awk '{print $1}' data.txt > "$OUT/f.txt"
+OUTER
+)
+awk_owns_append_cmd=$(cat <<'OUTER'
+awk '{print $1}' data.txt >> "$OUT/f.txt"
+OUTER
+)
+awk_literal_target_cmd=$(cat <<'OUTER'
+awk '{print $1}' data.txt > out.txt
+OUTER
+)
+
+assert_exit_complex \
+    "read-only awk upstream of a downstream redirect is allowed (#2131 exact repro)" 0 \
+    "$awk_downstream_redirect_cmd"
+
+assert_exit_complex \
+    "read-only awk mid-pipeline, uniq -c writes to a var path, is allowed (#2131)" 0 \
+    "$awk_uniq_redirect_cmd"
+
+assert_exit_complex \
+    "read-only awk with no redirect at all is allowed (#2131)" 0 \
+    "$awk_no_redirect_cmd"
+
+assert_exit_complex \
+    "GUARD: awk owning the redirect to a var path still blocks (#2131)" 2 \
+    "$awk_owns_redirect_cmd"
+
+assert_exit_complex \
+    "GUARD: awk owning an append redirect to a var path still blocks (#2131)" 2 \
+    "$awk_owns_append_cmd"
+
+assert_exit_complex \
+    "awk redirecting to a literal (non-variable) path is allowed (condition 2 unchanged)" 0 \
+    "$awk_literal_target_cmd"
+
 # ── git push -u colon-refspec footgun, no-colon form allowed (issue #1600) ────
 # Regression: the push -u detector blocked the legitimate no-colon form
 # `git push -u origin feat/x` (which pushes feat/x, never touching main) on a


### PR DESCRIPTION
## What changed

`hooks-plugin/hooks/bash-antipatterns.sh` — the "awk used for file modifications" guard, condition 1:

```diff
-if echo "$COMMAND" | grep -Eq "awk\s+.*>\s*['\"]?[^|]+" && \
+if echo "$COMMAND" | grep -Eq "awk\s+[^|]*>\s*['\"]?[^|]+" && \
```

Plus a comment recording why the span must stay inside one pipe segment, and six executable regression cases in `hooks-plugin/hooks/test-bash-antipatterns.sh`. No other behaviour touched.

## Verified root cause

Confirmed against the file on `main` before editing (not taken on trust from the issue). The guard lives at lines 301–305 and is two conditions:

1. `awk\s+.*>\s*['\"]?[^|]+` — awk followed by a redirect
2. `(>|>>)\s*['\"]?\$` — the redirect target is a variable path

Condition 1's `.*` is greedy and crosses `|`, so `awk … | sort -u > "$f"` matches even though the redirect belongs to `sort`. The trailing `[^|]+` constrains only the characters *after* `>` — never the span between `awk` and `>`, which is where the pipe sits. Reproduced live against the unmodified hook:

```
exit=2  row1: awk read-only upstream, sort writes (expect 0)   ← false positive
exit=2  row2: awk itself redirects (expect 2)
exit=0  row3: no redirect at all (expect 0)
```

After the fix, all three rows match the expected column (`0 / 2 / 0`).

`awk\s+[^|]*>` still matches the true positives `awk '…' data.txt > "$f"` and its `>>` form; condition 2 is unchanged, so a redirect to a literal (non-variable) path is still allowed as before.

## Sibling-guard audit

The issue asked for a look at the other regexes with the same greedy-`.*` shape. Findings:

| Guard | Same shape? | Verdict |
|---|---|---|
| Commit-file guard, `cat\s*>\s*[^\|]*commit` (line ~318) | **No** | The redirect is anchored adjacent to `cat` (`\s*>`), so it cannot be a downstream command's redirect, and `[^\|]*` already stops at a pipe. |
| Commit-file guard, `(cat\|echo\|printf)\s*>\s*/tmp/.*<<.*EOF` (line ~319) | **No** | The redirect is again adjacent to its own command. The trailing `.*<<.*EOF` can span, but it is a "a heredoc appears later" existence check, not redirect-ownership — no false positive of this class. Both arms are additionally gated on a real `git commit`/`git tag` plus a conventional-commit token. |
| `sed`/`cut`/`awk` grep-chain guard, `grep.*\|.*grep.*\|.*(sed\|cut\|awk)` (line ~471) | **No** | Spanning pipes is the *intent* here — it is a chain detector, and it requires two literal pipes. Probed a source-file grep chain (allowed) and a task-output scrape (still blocked): both correct. |
| git index-lock chain, `git\s+(add\|…)\b.*&&.*git\s+\S+` (line ~508) | **No** | Spans `&&` by design, same reasoning. |
| Broad-staging guard, `^\s*git\s+(.+\s+)?add\s+(-A\|--all\|\.)` (line ~483) | **Yes, but not fixed here** | `.+` does span a pipe: `git log --oneline \| grep add -A 3` blocks today (verified, exit 2). Left alone deliberately — this is a *safety* block where over-matching is the conservative direction, the trigger form is contrived, and every narrowing I tried loses real coverage (`[^\|;&]+` drops `git status && git add -A`; `[^\|]+` drops `git … \| … ; git add -A`). A correct fix means re-anchoring `add` to its own `git` token, which changes the safety guard's matching surface and deserves its own issue rather than riding along on a one-regex bug fix. |

Also observed while reproducing (out of scope, not changed): this guard scans raw `$COMMAND`, not `COMMAND_NO_STRINGS`, so an `awk … > "$f"` *mentioned inside a quoted `gh issue create --body`* still blocks — which is why filing the original issue was itself blocked. The fix here removes the pipeline variant of that (the reported command no longer matches even as prose), but the string-literal axis is a separate concern from the greedy-span bug.

## Test evidence

New section in `test-bash-antipatterns.sh` (six cases: the issue's three reproduction rows, plus the `>>` append true positive, a second read-only-awk pipeline whose writer is `uniq -c`, and a literal-target case pinning condition 2):

```
awk block confines itself to one pipe segment; awk-owned redirects still block (#2131):
  PASS: read-only awk upstream of a downstream redirect is allowed (#2131 exact repro)
  PASS: read-only awk mid-pipeline, uniq -c writes to a var path, is allowed (#2131)
  PASS: read-only awk with no redirect at all is allowed (#2131)
  PASS: GUARD: awk owning the redirect to a var path still blocks (#2131)
  PASS: GUARD: awk owning an append redirect to a var path still blocks (#2131)
  PASS: awk redirecting to a literal (non-variable) path is allowed (condition 2 unchanged)
```

The cases are executable (each pipes real hook JSON through `bash-antipatterns.sh` and asserts the exit code), not a grep for a literal — and they are proven non-tautological: replaying the same suite against `HEAD`'s pre-fix hook in a sandbox fails exactly the two cases the bug caused.

```
# pre-fix hook + new tests
  FAIL: read-only awk upstream of a downstream redirect is allowed (#2131 exact repro) (expected exit 0, got 2)
  FAIL: read-only awk mid-pipeline, uniq -c writes to a var path, is allowed (#2131) (expected exit 0, got 2)
Results: 154 passed, 2 failed
```

Full suites on this branch:

| Check | Result |
|---|---|
| `hooks-plugin/hooks/test-bash-antipatterns.sh` | **156 passed, 0 failed** (was 150; +6) |
| `hooks-plugin/hooks/test-bash-antipatterns-git-env-isolation.sh` | 3 passed, 0 failed |
| `hooks-plugin/hooks/test-bash-antipatterns-teach.sh` | 29 passed, 0 failed |
| `just lint-shell` | 0 errors, 9 warnings (all pre-existing, in `macos-plugin`) |
| `shellcheck` on both changed files | exit 0 |
| `pre-commit run --files <both changed files>` | all applicable hooks Passed |

Closes #2131

🤖 Generated with [Claude Code](https://claude.com/claude-code)
