### PR TITLE
docs(agent-patterns-plugin): a refuted model claim can still mark a real gap

### DIFF
--- a/agent-patterns-plugin/skills/multi-model-delegation/SKILL.md
+++ b/agent-patterns-plugin/skills/multi-model-delegation/SKILL.md
@@ -5,8 +5,8 @@ user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite, mcp__pal__listmodels, mcp__pal__chat, mcp__pal__consensus, mcp__pal__thinkdeep
 model: opus
 created: 2026-07-17
-modified: 2026-07-27
-reviewed: 2026-07-27
+modified: 2026-07-28
+reviewed: 2026-07-28
 ---
 
 # Multi-Model Delegation
@@ -100,6 +100,42 @@ the good parts from the runner-up; reject what doesn't fit and say why.
 > overruled** — grade bands stack a second set of magic thresholds on the
 > weights and quantize away the fine ordering the score exists to produce.
 > The models produced the *question*; the repo produced the *answer*.
+
+### Step 7: When a claim is refuted, ask the second question
+
+Step 5 adjudicates *"is this claim true?"* against the code. When the answer
+is **no**, the instinct is to discard the claim and move on. Don't — ask the
+second question first:
+
+> **"Why couldn't the test suite answer this?"**
+
+That question survives a wrong claim. A confident, specific, *false* finding
+usually points at something real — not the defect it names, but the **absence
+of a gate that would have settled it in seconds**. The claim dies; the gap it
+exposed does not.
+
+The move: add the gate that decides the question, then **kill-test it by
+swapping in the reviewer's proposed value**. If the reviewer was right, the
+gate goes red and you have found a real bug. If they were wrong, it goes red
+on *their* version and green on yours — converting an argument into a
+permanent, mechanical answer, so neither the next reviewer nor the next
+session can re-litigate it.
+
+> Canonical case (loractl verbosity review, 2026-07): `kimi-k2.7-code` claimed
+> `flag_directives` emitted a `loractl=` tracing target matching nothing —
+> because the *package* is `loractl-cli` — which would make the entire `-v`
+> ladder inert. It was **wrong**: `[[bin]] name = "loractl"`, so `module_path!`
+> roots at `loractl`, and a live `-v` run had already printed `INFO` lines. But
+> the claim was *unfalsifiable from the suite*, because the unit test asserted
+> the directive **string** and never that the filter matched a real event. Fix:
+> a spawned-binary test pair (`-v` must show INFO, default must not), then a
+> kill-test swapping in the reviewer's `loractl_cli=` — which fails it. Wrong
+> claim, real gap, permanent gate.
+
+The generalization beyond model reviews: **a test that asserts the shape of a
+value rather than the behaviour it produces cannot settle a question about
+that behaviour** — it passes whether the wiring works or not. Those are
+exactly the tests an outside reviewer's wrong guess will find for you.
 
 ## When It's Worth the Tokens
 


### PR DESCRIPTION
## What

Adds **Step 7** to `agent-patterns-plugin/skills/multi-model-delegation`: when adjudication refutes a model's claim, ask the second question before discarding it.

## Why

The skill's Step 5 ("adjudicate against the code, not taste") is the step that makes a consult worth its tokens — but it stops at *"is this claim true?"*. When the answer is **no**, the instinct is to bin the claim and move on, and that throws away most of its value.

> **"Why couldn't the test suite answer this?"**

A confident, specific, **false** review finding usually points at something real — not the defect it names, but the **absence of a gate that would have settled it in seconds**. The claim dies; the gap it exposed does not.

The prescribed move: add the gate that decides the question, then **kill-test it by swapping in the reviewer's proposed value**. If they were right, it goes red and you found a bug. If they were wrong, it goes red on *their* version and green on yours — converting an argument into a permanent, mechanical answer neither the next reviewer nor the next session can re-litigate.

## Evidence

From a three-model review of loractl [#165](https://github.com/laurigates/loractl/pull/165) (gpt-5.3-codex / gemini-3.5-flash / kimi-k2.7-code, identical briefs, one model per provider):

`kimi-k2.7-code` claimed `flag_directives` emitted a `loractl=` tracing target matching nothing — because the *package* is `loractl-cli` — which would have made the entire `-v` verbosity ladder inert. It was **wrong**: `[[bin]] name = "loractl"`, so `module_path!` roots at `loractl`, and a live `-v` run had already printed `INFO` lines.

But the claim was **unfalsifiable from the suite**: the unit test asserted the directive *string* and never that the filter matched a real event. Fixed with a spawned-binary test pair (`-v` must show INFO, default must not), then kill-tested by swapping in the reviewer's own `loractl_cli=` — which fails it. Wrong claim, real gap, permanent gate.

The same consult also produced three genuine bugs the models converged on, so this isn't a rule about ignoring reviewers — it's about extracting value from the ones who are wrong.

## The generalization

**A test that asserts the shape of a value rather than the behaviour it produces cannot settle a question about that behaviour** — it passes whether the wiring works or not. Those are exactly the tests an outside reviewer's wrong guess will find for you.

## Why here and not the user-global rule

`~/.claude/rules/multi-model-delegation.md` is the natural home, but the dotfiles repo's always-loaded context budget is at **109,998 of 110,000 bytes** — the pre-commit gate rejects any addition. Its own remedy list prescribes "split content into an on-demand skill", and the mechanics already live in this skill. Global rule left untouched (0 bytes added).

Placed as Step 7 in The Protocol, immediately after the Step 6 canonical case, so it reads in sequence with the adjudication steps it extends. `modified`/`reviewed` frontmatter bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdgQJBkvbfMLVd6Qh6SX1j