### PR TITLE
fix(comfyui-plugin): remove personal-install details from public skills

### DIFF
--- a/comfyui-plugin/skills/comfy-corpus-validation/SKILL.md
+++ b/comfyui-plugin/skills/comfy-corpus-validation/SKILL.md
@@ -120,7 +120,7 @@ Ground truth is **regenerated on demand, never committed** — a committed
 snapshot is just another stale secondary source.
 
 ```
-COMFY_SSH_HOST=popos.intra.lakuz.com just corpus-check
+COMFY_SSH_HOST=<your-comfyui-host> just corpus-check
 ```
 
 Two halves, split because only one of them needs a GPU box:

--- a/comfyui-plugin/skills/comfy-image-utils/SKILL.md
+++ b/comfyui-plugin/skills/comfy-image-utils/SKILL.md
@@ -257,7 +257,7 @@ LoadAndResizeImage (kjnodes) ─► image_path (STRING, full path)
                                        │
                                        ▼ (bare basename, no path, no ext)
                           JoinStringMulti (kjnodes)
-                          in_1: "nsfw/%date:yyyy-MM-dd%/%date:hhmmss%_%ksampler.sampler_name%_%ksampler.scheduler%_s%ksampler.seed%_"
+                          in_1: "<bucket>/%date:yyyy-MM-dd%/%date:hhmmss%_%ksampler.sampler_name%_%ksampler.scheduler%_s%ksampler.seed%_"
                           in_2: <bare basename>   # the <descriptor> segment
                                        │
                                        ▼
@@ -266,9 +266,9 @@ LoadAndResizeImage (kjnodes) ─► image_path (STRING, full path)
 
 `%date:%` tokens pass through verbatim into the SaveImage prefix
 substitution (resolved at save time). String manipulation chain lives
-in `comfy-math-strings`; the save node lives in easy-use. The full
-required prefix shape (mandatory sampler/scheduler/seed) is the "Output
-filename_prefix convention" in `.claude/rules/editing-workflow-json.md`.
+in `comfy-math-strings`; the save node lives in easy-use. The prefix
+convention itself is per-install — see "Naming conventions are
+per-install" in `comfy-workflow-json`.
 
 ### Caption a folder of images for batch dataset prep
 

--- a/comfyui-plugin/skills/comfy-math-strings/SKILL.md
+++ b/comfyui-plugin/skills/comfy-math-strings/SKILL.md
@@ -223,12 +223,11 @@ SD/Flux/Wan latent alignment automatically.
 ### Filename templating
 
 `SaveImage.filename_prefix` accepts `%date:yyyy-MM-dd%` / `%date:hhmmss%`
-substitution plus `%NodeName.widget%`. The **required shape** (mandatory
-sampler/scheduler/seed run-signature) is the "Output filename_prefix
-convention" in `.claude/rules/editing-workflow-json.md`; its "SaveImage
-filename substitution" section covers the native syntax. When the native
-substitution isn't enough (e.g. you need to strip an extension from a
-source filename), assemble the prefix via:
+substitution plus `%NodeName.widget%`. A run-signature shape
+(sampler/scheduler/seed) keeps runs distinguishable, but the exact
+convention is per-install — see "Naming conventions are per-install" in
+`comfy-workflow-json`. When the native substitution isn't enough (e.g. you
+need to strip an extension from a source filename), assemble the prefix via:
 
 ```
 LoadAndResizeImage ──► image_path (STRING, kjnodes)
@@ -241,7 +240,7 @@ LoadAndResizeImage ──► image_path (STRING, kjnodes)
                             │
                             ▼ (basename without ext, STRING)
               JoinStringMulti (kjnodes)
-                 in_1: "nsfw/%date:yyyy-MM-dd%/%date:hhmmss%_%ksampler.sampler_name%_%ksampler.scheduler%_s%ksampler.seed%_"
+                 in_1: "<bucket>/%date:yyyy-MM-dd%/%date:hhmmss%_%ksampler.sampler_name%_%ksampler.scheduler%_s%ksampler.seed%_"
                  in_2: <stripped basename>   # the <descriptor> segment
                             │
                             ▼

--- a/comfyui-plugin/skills/comfy-metadata/SKILL.md
+++ b/comfyui-plugin/skills/comfy-metadata/SKILL.md
@@ -86,20 +86,23 @@ from `summary.samplers[0]` and the source file's mtime.
 
 `summarize()` covers the API `prompt`, but `extract()["workflow"]` (the
 UI form) carries data the summarizer doesn't surface — most usefully
-**save-node widgets**. A workflow that wrote itself to `nsfw/<date>/…`
-self-labels its outputs:
+**save-node widgets**. A workflow that wrote itself to a dedicated output
+bucket (`<bucket>/<date>/…`) self-labels its outputs, so the prefix is a
+free classification signal:
 
 ```python
+BUCKET = "<bucket>/"          # whatever prefix your install sorts into
+
 ex = comfy_meta.extract(p)
 workflow = ex.get("workflow") or {}
 for n in workflow.get("nodes", []) or []:
     wv = n.get("widgets_values")
     # SaveImage / SaveWEBM: list[0] is the filename_prefix
-    if isinstance(wv, list) and wv and isinstance(wv[0], str) and wv[0].startswith("nsfw/"):
-        return "nsfw"
+    if isinstance(wv, list) and wv and isinstance(wv[0], str) and wv[0].startswith(BUCKET):
+        return BUCKET.rstrip("/")
     # VHS_VideoCombine: dict["filename_prefix"]
-    if isinstance(wv, dict) and str(wv.get("filename_prefix", "")).startswith("nsfw/"):
-        return "nsfw"
+    if isinstance(wv, dict) and str(wv.get("filename_prefix", "")).startswith(BUCKET):
+        return BUCKET.rstrip("/")
 ```
 
 `rename_outputs.py`'s NSFW classifier combines this self-label signal

--- a/comfyui-plugin/skills/comfy-workflow-layout/SKILL.md
+++ b/comfyui-plugin/skills/comfy-workflow-layout/SKILL.md
@@ -172,7 +172,7 @@ Once the user confirms one workflow lays out cleanly, the rest in the
 same bucket usually follow. Batch with `--in-place`:
 
 ```
-for f in user/default/workflows/nsfw/2026-05/*.json; do
+for f in user/default/workflows/<bucket>/2026-05/*.json; do
   case "$f" in *-laidout.json) continue ;; esac
   .venv/bin/python scripts/layout_workflow.py --in-place --verify "$f"
 done


### PR DESCRIPTION
## What

Six spots in `comfyui-plugin` leaked details of one personal ComfyUI install into this public repo, and two of them pointed at a file that exists in no checkout.

| Skill | Was | Now |
|---|---|---|
| `comfy-corpus-validation` | `COMFY_SSH_HOST=<private hostname> just corpus-check` | `<your-comfyui-host>` placeholder |
| `comfy-math-strings` | personal `filename_prefix` template verbatim + pointer to `.claude/rules/editing-workflow-json.md` | `<bucket>/…` + pointer to `comfy-workflow-json` |
| `comfy-image-utils` | same template + same dead pointer | same fix |
| `comfy-workflow-layout` | personal output bucket in an example glob | `<bucket>/` |
| `comfy-metadata` | personal bucket hardcoded in a classifier snippet | `BUCKET` constant |

## Why

Two separate defects that happened to sit in the same lines.

**Leakage.** A save-node naming convention is not a portable ComfyUI fact — `comfy-workflow-json` already says exactly this in its "Naming conventions are per-install" section, and genericizing costs nothing pedagogically. One promotion pass produced that correct genericized copy and these leaky ones alongside it.

**Dead pointers.** Both citations of `.claude/rules/editing-workflow-json.md` resolve to nothing — that rule exists in neither the authoring workspace nor the GPU box, having been renamed at some point after the text was written. A reader following the link gets nothing, which is worse than no citation.

The `comfy-metadata` change also makes that example reusable rather than copy-and-edit, since the bucket is now a named constant.

## Verification

```
rg -n 'popos|intra\.lakuz|/Users/lgates|/mnt/sabrent' comfyui-plugin/   # none
rg -n 'nsfw' comfyui-plugin/                                            # none
rg -n 'editing-workflow-json' comfyui-plugin/                           # none
```

`comfyui-plugin/README.md` is clean of all three patterns, so the README-currency nudge on the commit is advisory — no documented behavior changed.

Found by an 8-agent workflow auditing knowledge duplication across the ComfyUI estate; the workflow flagged four of these, and a follow-up grep caught the two in `comfy-workflow-layout` and `comfy-metadata`.
