### PR TITLE
refactor(typescript-plugin): apply the demoted body-section mandates

### DIFF
--- a/typescript-plugin/skills/biome-tooling/SKILL.md
+++ b/typescript-plugin/skills/biome-tooling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 created: 2025-12-16
-modified: 2026-05-09
+modified: 2026-07-28
 reviewed: 2025-12-16
 name: biome-tooling
 description: "Biome all-in-one JS/TS formatter and linter, 15-20x faster than ESLint/Prettier. Use when setting up formatting/linting or migrating from ESLint+Prettier."
@@ -12,14 +12,7 @@ allowed-tools: Glob, Grep, Read, Bash, Edit, Write, TodoWrite, WebFetch, WebSear
 
 Biome is a modern, performant toolchain for JavaScript, TypeScript, and related web languages. It combines formatting, linting, and import organization into a single tool that's **15-20x faster** than ESLint/Prettier.
 
-## When to Use This Skill
-
-| Use this skill when... | Use another approach when... |
-|------------------------|------------------------------|
-| Starting a new JS/TS project | Need specific ESLint plugins (React hooks, a11y) |
-| Want zero-config formatting/linting | Have complex custom ESLint rules |
-| Need fast CI/CD pipelines | Need framework-specific rules (Next.js, Nuxt) |
-| Migrating from ESLint+Prettier | Legacy codebase with heavy ESLint customization |
+**Keep ESLint alongside** when the project needs plugin-only rules (React hooks, a11y), framework-specific rules (Next.js, Nuxt), or carries heavy custom ESLint configuration.
 
 **Hybrid approach**: Use Biome for formatting, ESLint for specialized linting.
 

--- a/typescript-plugin/skills/bun-add/SKILL.md
+++ b/typescript-plugin/skills/bun-add/SKILL.md
@@ -4,7 +4,7 @@ args: <package> [--dev] [--exact]
 allowed-tools: Bash, Read
 argument-hint: package-name [--dev] [--exact]
 created: 2025-12-20
-modified: 2026-05-09
+modified: 2026-07-28
 reviewed: 2025-12-20
 name: bun-add
 ---
@@ -50,17 +50,10 @@ bun add --exact react@18.2.0
 
 # Add to specific workspace
 bun add lodash --cwd packages/utils
+
+# Preview without writing package.json
+bun add --dry-run zod
 ```
-
-## Agentic Optimizations
-
-| Context | Command |
-|---------|---------|
-| Add runtime dep | `bun add <package>` |
-| Add dev dep | `bun add --dev <package>` |
-| Pin exact version | `bun add --exact <package>` |
-| Add to workspace | `bun add <package> --cwd <path>` |
-| Preview changes | `bun add --dry-run <package>` |
 
 ## Post-add
 

--- a/typescript-plugin/skills/bun-build/SKILL.md
+++ b/typescript-plugin/skills/bun-build/SKILL.md
@@ -4,7 +4,7 @@ args: <entry> [--compile] [--minify]
 allowed-tools: Bash, Read
 argument-hint: ./src/index.ts [--compile] [--minify]
 created: 2025-12-20
-modified: 2026-05-09
+modified: 2026-07-28
 reviewed: 2025-12-20
 name: bun-build
 ---
@@ -58,16 +58,6 @@ bun build $ENTRY --target=bun --outdir=dist
 # Node.js
 bun build $ENTRY --target=node --outdir=dist
 ```
-
-## Agentic Optimizations
-
-| Context | Command |
-|---------|---------|
-| Prod bundle | `bun build ./src/index.ts --outdir=dist --minify --sourcemap=external` |
-| Compile to exe | `bun build --compile --minify ./app.ts --outfile myapp` |
-| Dev bundle | `bun build ./src/index.ts --outdir=dist --sourcemap=inline` |
-| Browser target | `bun build ./src/index.ts --target=browser --outdir=dist` |
-| Node target | `bun build ./src/index.ts --target=node --outdir=dist` |
 
 ## Post-build
 

--- a/typescript-plugin/skills/bun-test/SKILL.md
+++ b/typescript-plugin/skills/bun-test/SKILL.md
@@ -4,7 +4,7 @@ args: "[pattern] [--coverage] [--bail] [--watch]"
 allowed-tools: Bash, BashOutput, Read
 argument-hint: "[test-pattern] [--coverage] [--bail] [--watch]"
 created: 2025-12-20
-modified: 2026-05-09
+modified: 2026-07-28
 reviewed: 2025-12-20
 name: bun-test
 ---
@@ -42,6 +42,11 @@ bun test --dots --bail=1 $PATTERN
 bun test --dots --coverage $PATTERN
 ```
 
+**Filter by test name (not file path):**
+```bash
+bun test --dots --bail=1 -t "pattern"
+```
+
 **Watch mode:**
 ```bash
 bun test --watch $PATTERN
@@ -59,16 +64,6 @@ bun test --reporter=junit --reporter-outfile=junit.xml $PATTERN
 | `.` | Test passed |
 | `F` | Test failed |
 | `S` | Test skipped |
-
-## Agentic Optimizations
-
-| Context | Command |
-|---------|---------|
-| Quick test | `bun test --dots --bail=1` |
-| Filtered test | `bun test --dots --bail=1 -t "pattern"` |
-| With coverage | `bun test --dots --coverage` |
-| CI output | `bun test --reporter=junit --reporter-outfile=junit.xml` |
-| Watch mode | `bun test --watch` |
 
 ## Post-test
 

--- a/typescript-plugin/skills/knip-dead-code/SKILL.md
+++ b/typescript-plugin/skills/knip-dead-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 created: 2025-12-16
-modified: 2026-05-09
+modified: 2026-07-28
 reviewed: 2025-12-16
 name: knip-dead-code
 description: "Knip dead-code detector for JS/TS: unused files, deps, exports, types. Use when cleaning up codebases, finding dead exports, or enforcing dependency hygiene in CI."
@@ -12,14 +12,7 @@ allowed-tools: Glob, Grep, Read, Bash, Edit, Write, TodoWrite, WebFetch, WebSear
 
 Knip is a comprehensive tool for finding unused code, dependencies, and exports in JavaScript and TypeScript projects. It helps maintain clean codebases and catch dead code before it accumulates.
 
-## When to Use This Skill
-
-| Use this skill when... | Use another approach when... |
-|------------------------|------------------------------|
-| Finding unused dependencies | Removing unused CSS (use PurgeCSS) |
-| Detecting unused exports in libraries | Finding runtime dead code paths |
-| Cleaning up codebases after refactors | Optimizing bundle size (use bundler tree-shaking) |
-| Enforcing dependency hygiene in CI | Detecting duplicate dependencies (use npm-dedupe) |
+Knip finds *statically* unreachable code. Reach for a different tool for unused CSS (PurgeCSS), runtime dead code paths, bundle-size trimming (bundler tree-shaking), or duplicate dependencies (npm-dedupe).
 
 ## Core Expertise
 

--- a/typescript-plugin/skills/nodejs-development/SKILL.md
+++ b/typescript-plugin/skills/nodejs-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 created: 2025-12-16
-modified: 2026-05-09
+modified: 2026-07-28
 reviewed: 2025-12-16
 name: nodejs-development
 description: "Node.js development with Bun, Vite, Vue 3, Pinia, TypeScript. Use when the user mentions Node.js, Bun, Vite, Vue, Pinia, npm, pnpm, or modern JS/TS frameworks."
@@ -24,19 +24,6 @@ Expert knowledge for modern JavaScript/TypeScript development with focus on high
 | Managing npm/Bun dependencies | No - use `bun-package-manager` | `bun-add` for quick additions |
 | Debugging TypeScript/JS applications | No - use `typescript-debugging` | N/A |
 | Error monitoring with Sentry | No - use `typescript-sentry` | N/A |
-
-## Agentic Optimizations
-
-| Context | Command |
-|---------|---------|
-| Create Vue+TS project | `bun create vite my-app --template vue-ts` |
-| Dev server | `bun dev` |
-| Production build | `bun build` |
-| Lint and format | `bun run check` |
-| Run tests | `bun run test` |
-| Node.js debug | `node --inspect script.js` |
-| Bun debug | `bun --inspect script.ts` |
-| CPU profile | `node --prof script.js` |
 
 ## Core Expertise
 

--- a/typescript-plugin/skills/typescript-sentry/SKILL.md
+++ b/typescript-plugin/skills/typescript-sentry/SKILL.md
@@ -4,23 +4,13 @@ description: Error monitoring and performance with Sentry SDK for Bun/Node.js/Ne
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2026-01-22
-modified: 2026-05-09
+modified: 2026-07-28
 reviewed: 2026-01-22
 ---
 
 # TypeScript Sentry
 
-## When to Use This Skill
-
-| Use this skill when... | Use another approach when... |
-|------------------------|------------------------------|
-| Adding error monitoring to a project | Setting up logging (use a logger library) |
-| Instrumenting performance spans | Monitoring infrastructure metrics (use Prometheus/Grafana) |
-| Setting up cron job monitoring | Setting up uptime monitoring (use Pingdom/UptimeRobot) |
-| Configuring source maps for Sentry | Debugging errors locally (use debugger) |
-| Adding structured logging to Sentry | Configuring project-level Sentry compliance (use `/configure:sentry`) |
-| Setting up profiling, replay, or enrichment helpers | Managing Sentry project settings in the dashboard |
-| Implementing error/transaction filtering | Creating Sentry alerting rules |
+This skill covers the **SDK-side** work: capture, spans, cron monitors, source maps, profiling, filtering. For project-level Sentry compliance (DSN hygiene, sourcemap-upload wiring in CI) use `/configure:sentry`; for local step-through debugging use `typescript-debugging`.
 
 ## Core Expertise
 

--- a/typescript-plugin/skills/typescript-strict/SKILL.md
+++ b/typescript-plugin/skills/typescript-strict/SKILL.md
@@ -1,6 +1,6 @@
 ---
 created: 2025-12-16
-modified: 2026-05-09
+modified: 2026-07-28
 reviewed: 2025-12-16
 name: typescript-strict
 description: "TypeScript strict mode: tsconfig.json, strict flags, Bundler/NodeNext moduleResolution, verbatimModuleSyntax. Use when setting up TS or migrating to stricter type safety."
@@ -11,15 +11,6 @@ allowed-tools: Glob, Grep, Read, Bash, Edit, Write, TodoWrite, WebFetch, WebSear
 # TypeScript Strict Mode
 
 Modern TypeScript configuration with strict type checking for maximum safety and developer experience. This guide focuses on TypeScript 5.x best practices for 2025.
-
-## When to Use This Skill
-
-| Use this skill when... | Use another approach when... |
-|------------------------|------------------------------|
-| Setting up a new TypeScript project | Debugging runtime errors (use debugger) |
-| Migrating to stricter type safety | Configuring build tools (use bundler docs) |
-| Choosing moduleResolution strategy | Writing application logic |
-| Enabling noUncheckedIndexedAccess | Optimizing bundle size (use bundler skills) |
 
 ## Core Expertise
 


### PR DESCRIPTION
`Refs #2141` (2 of 45 affected directories; the remaining 43 stay deferred)

Applies `.claude/rules/context-engineering.md` § Supersedes to `typescript-plugin`. PR #2198 already demoted `check_skill_when_to_use()` from ERROR to advisory (verified on disk: `plugin-compliance-check.sh:1397` is headed `# Check 8: "When to Use This Skill" section presence — ADVISORY (issue #2141)` and both branches `return 1`), so removing either section no longer fails the lint.

**No pinned tokens were at risk.** `grep -rn` over `scripts/` (excluding `/tests/`) for every one of the 17 skill directory names plus `typescript-plugin` returns exactly one hit — a comment in `plugin-compliance-check.sh:1009` about `comfyui-node-scaffold` emitting a "TypeScript + bun-build pack", which is not a pin on this plugin. `check-agent-failure-contract.sh`, `check-loop-integrity.sh`, and `check-subagent-types.sh` pin nothing here.

## Per-skill decisions (all 17)

| Skill | When-to-Use | Agentic Opts | Reason |
|---|---|---|---|
| `bun-add` | **kept** | **dropped** | Table routes against `bun-package-manager` for install-all/remove/workspace — a real 3-way confusion with `bun-install`. AO table was the same five commands as `## Examples` in a second format; `--dry-run` (its only unique row) moved into the Examples block. |
| `bun-install` | **kept** | *(none)* | Table is a direct `Use bun-add instead when…` contrast, plus pointers to `bun-lockfile-update`/`bun-outdated`. Load-bearing. |
| `bun-package-manager` | **kept** | **kept** | Umbrella skill; its table is the routing hub for `bun-add`/`bun-test`/`bun-development`/`bun-publishing`/`bun-lockfile-update`. AO table is a flags digest over an ~88-line command section. |
| `bun-outdated` | **kept** | *(none)* | `Use bun-lockfile-update instead when…` — the read-only/mutating split between a genuinely confusable pair. |
| `bun-lockfile-update` | **kept** | *(none)* | The other half of that pair; contrasts against both `bun-outdated` and `bun-install`. |
| `bun-test` | **kept** | **dropped** | Table routes to `bun-development` (config) and `typescript-debugging` (step-through). AO table restated `## Execution` verbatim with `$PATTERN` substituted; the one unique row (`-t "pattern"` name filter) became a fourth Execution block. |
| `bun-build` | **kept** | **dropped** | Table routes to `bun-development` for pipelines and `bun run build`. All five AO rows already existed in `## Execution` + `## Build Targets` with a literal path in place of `$ENTRY` — pure duplication. |
| `bun-debug` | **kept** | *(none)* | `Use typescript-debugging instead when…` plus `bun-test`/`bun-build` pointers. This is the pair most likely to mis-fire. |
| `bun-development` | **kept** | **kept** | Umbrella; table routes to `nodejs-development`, `bun-test`, `bun-build`, `bun-package-manager`, `bun-publishing`, `typescript-debugging`. AO table is a distilled index across a 280-line body. |
| `bun-publish` | **kept** | *(none)* | `bun-publish` vs `bun-publishing` differ by two characters — the table is the only thing separating the single action from the workflow guide. |
| `bun-publishing` | **kept** | **kept** | Other half of that near-identical-name pair. AO table is the `npm publish` flag set (`--dry-run`/`--access`/`--provenance`) that is the skill's payload. |
| `typescript-debugging` | **kept** | **kept** | Table routes to `typescript-sentry` (prod) and `bun-development`/`bun-test`; `bun-debug` is its close sibling. AO table carries the non-obvious invocations (`bun:jsc` heapStats one-liner, `BUN_CONFIG_VERBOSE_FETCH`, `MIMALLOC_SHOW_STATS`). |
| `nodejs-development` | **kept** | **dropped** | Table draws the Vite/Vue-vs-Bun-runtime line against `bun-development` and four others. AO table repeated `## Essential Commands` row for row (all 8 rows), 15 lines above it. |
| `biome-tooling` | **dropped** | **kept** | Table contrasted Biome against ESLint/Prettier — tool selection, not skill routing; no sibling in this plugin lints JS/TS. Description already fires on "setting up formatting/linting or migrating from ESLint+Prettier". The "when you still need ESLint" cases were preserved as a sentence beside the existing **Hybrid approach** note. AO table is the `biome check` flag surface — the payload. |
| `knip-dead-code` | **dropped** | **kept** | Table pointed at PurgeCSS / tree-shaking / npm-dedupe — external tools. Preserved as one sentence. AO table is the `bunx knip` flag set. |
| `typescript-strict` | **dropped** | **kept** | Rows were generic filler ("Writing application logic", "use bundler docs"). Nothing preserved. AO table is small but is the only place `bunx tsc --noEmit` / `--showConfig` appear. |
| `typescript-sentry` | **dropped** | **kept** | Contrasts were external (Prometheus, Pingdom). The one real routing row (`/configure:sentry`) plus a `typescript-debugging` pointer were preserved as a lead sentence. AO table is the per-runtime `@sentry/*` install matrix + sourcemap upload commands. |

**Totals:** When-to-Use 13 kept / 4 dropped. Agentic Optimizations 8 kept / 4 dropped (5 skills never had one). No description was lengthened — the plugin's five pre-existing 201–300-char WARN entries are unchanged and none crosses the 300-char ERROR band.

## Character delta

Measured as characters, not bytes, per `.claude/rules/skill-quality.md`:

```
python3 -c "import io,glob;print(sum(len(io.open(f,encoding='utf-8',errors='surrogateescape').read()) for f in glob.glob('typescript-plugin/skills/*/SKILL.md')))"
```

**85,134 → 82,230 characters (−2,904, −3.4%)** across the plugin's 17 `SKILL.md` files.

## Verification

`plugin-compliance-check.sh typescript-plugin` — **no ❌**:

```
| Plugin | plugin.json | Frontmatter | Body | Marketplace | Release Config | Bash Patterns | Descriptions | When-to-Use | Size | Overall |
| typescript-plugin | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
```

All ⚠️ are advisory: five pre-existing description-length WARNs (unchanged by this PR), the four intentional new "no When-to-Use section" recommendations, and two pre-existing >10,000-char size WARNs (`typescript-debugging`, `bun-lockfile-update`).

```
$ bash scripts/check-agent-failure-contract.sh
OK: loud-failure contract, hook-thrashing heuristic, and WIP-salvage discrimination present in agent-patterns dispatch skills

$ bash scripts/check-loop-integrity.sh --strict
=== LOOP INTEGRITY ===
RULE_PRESENT=true
STATUS=OK
ISSUE_COUNT=0
=== END LOOP INTEGRITY ===

$ bash scripts/check-subagent-types.sh ; echo EXIT=$?
EXIT=0        # only pre-existing unqualified-name WARNs, none in typescript-plugin

$ python3 scripts/audit-skill-descriptions.py --strict-length ; echo EXIT=$?
typescript-plugin                   17        0       0        0     17
EXIT=0

$ python3 scripts/check-context-engineering.py --strict ; echo EXIT=$?
C4_BOILERPLATE_AGENTIC_OPTIMIZATIONS_SKILLS=254
C4_BOILERPLATE_AGENTIC_OPTIMIZATIONS_CHARS=130975
C4_BOILERPLATE_AGENTIC_OPTIMIZATIONS_PCT=4.3
C4_BOILERPLATE_WHEN_TO_USE_SKILLS=404
C4_BOILERPLATE_WHEN_TO_USE_CHARS=278939
C4_BOILERPLATE_WHEN_TO_USE_PCT=9.2
C5_ALWAYS_LOADED_CHARS=99362
C5_ALWAYS_LOADED_EST_TOKENS=24840
C5_ALWAYS_LOADED_BUDGET=100000
STATUS=WARN
EXIT=0
```

**C5 number:** `C5_ALWAYS_LOADED_CHARS=99362` (~24,840 est. tokens) against a 100,000-char budget — under the ratchet, exit 0. `STATUS=WARN` is driven by 12 unscoped `.claude/rules/*.md` files, which this PR does not touch. The C4 boilerplate counters moved from 407→404 skills / 257→254 skills as the three-and-four dropped sections came out (the counter counts skills that still carry each section).

## No regression check

Not a bug fix — this is a behaviour-preserving `refactor` applying an already-landed rule change, so `.claude/rules/regression-testing.md` does not apply and no Known Regressions row is added.
