### PR TITLE
refactor(agent-patterns-plugin): apply the demoted body-section mandates

### DIFF
--- a/agent-patterns-plugin/skills/adversarial-review/SKILL.md
+++ b/agent-patterns-plugin/skills/adversarial-review/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "path|PR|file|plan description; optional 'focus on X'"
 allowed-tools: Agent, Read, Glob, Grep, Bash(git diff *), Bash(git log *), Bash(gh pr view *), TodoWrite
 model: opus
 created: 2026-06-21
-modified: 2026-07-18
+modified: 2026-07-28
 compatibility: claude-code
 reviewed: 2026-06-21
 ---
@@ -156,15 +156,6 @@ review can't resolve.
 | Using a weak model "to be tougher" | Opus — subtle faults are a reasoning task (inverse of cold-read-gate) |
 | Restating each lens's checklist inline | Delegate to the owning skill; this is a posture, not a checklist |
 | Looping until the reviewer goes silent | One revise round; persistent faults = structural problem |
-
-## Agentic Optimizations
-
-| Context | Command |
-|---|---|
-| Review current diff, no target given | `git diff HEAD` as the target; state the default |
-| Review a PR | `gh pr view <N> --json title,body,files` then diff |
-| Single lens, isolated reviewer | One `Agent(subagent_type: general-purpose, model: opus)` |
-| Multiple lenses, not on `[1m]` | Parallel `Agent` batch, one per lens |
 
 ## Related
 

--- a/agent-patterns-plugin/skills/agent-teams/SKILL.md
+++ b/agent-patterns-plugin/skills/agent-teams/SKILL.md
@@ -5,7 +5,7 @@ user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 model: opus
 created: 2026-03-03
-modified: 2026-07-18
+modified: 2026-07-28
 compatibility: claude-code
 reviewed: 2026-06-23
 ---
@@ -144,16 +144,6 @@ In web sessions (`CLAUDE_CODE_REMOTE=true`):
 - Sub-agents (teammates) may encounter TLS errors on `git push` — delegate all push/PR operations to the lead.
 - Each teammate runs in its own process context.
 - Worktree isolation is recommended for independent filesystem changes.
-
-## Agentic Optimizations
-
-| Context | Approach |
-|---------|----------|
-| Quick parallel review | Spawn 2–4 teammates, assign tasks |
-| Large codebase split | Assign directory subsets as separate tasks |
-| Long-running work | Background teammates, poll via TaskList |
-| Minimize API cost | Prefer `message` over `broadcast` |
-| Fast shutdown | Send a `shutdown_request` to each teammate (no team teardown needed) |
 
 ## Quick Reference
 

--- a/agent-patterns-plugin/skills/custom-agent-definitions/SKILL.md
+++ b/agent-patterns-plugin/skills/custom-agent-definitions/SKILL.md
@@ -4,7 +4,7 @@ description: Write and configure custom agent definitions in Claude Code agents/
 user-invocable: false
 allowed-tools: Bash(cat *), Read, Write, Edit, Glob, Grep, TodoWrite
 created: 2026-01-20
-modified: 2026-07-18
+modified: 2026-07-28
 compatibility: claude-code
 reviewed: 2026-06-14
 ---
@@ -127,15 +127,6 @@ agent: security-auditor
    [#1550](https://github.com/laurigates/claude-plugins/issues/1550)).
 
 Worked YAML for each practice is in [REFERENCE.md → Best-practice snippets](REFERENCE.md#best-practice-snippets).
-
-## Agentic Optimizations
-
-| Context | Configuration |
-|---------|---------------|
-| Exploratory research | `context: fork`, minimal read-only tools |
-| Security analysis | `context: fork`, `disallowedTools: Bash, Write, Edit` |
-| Quick lookups | minimal tools |
-| Complex implementation | `model: sonnet`, full tools |
 
 ## Quick Reference
 

--- a/agent-patterns-plugin/skills/execution-grounded-review/SKILL.md
+++ b/agent-patterns-plugin/skills/execution-grounded-review/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "diff|PR|files to verify; optional --criteria <file> of acceptanc
 allowed-tools: Agent, Read, Glob, Grep, Bash(git diff *), Bash(git log *), Bash(gh pr view *), Bash(npm *), Bash(npx *), Bash(uv run *), Bash(pytest *), Bash(cargo *), Bash(go test *), TodoWrite
 model: opus
 created: 2026-06-22
-modified: 2026-07-18
+modified: 2026-07-28
 compatibility: claude-code
 reviewed: 2026-07-05
 ---
@@ -191,15 +191,6 @@ human, not to keep grinding.
 | Feeding the verifier the author's plan/rationale | Intent-starved inputs — criteria + diff + execution evidence only |
 | Inventing requirements the spec never stated | Triage (Step 4) — FAIL only on listed criteria |
 | Looping until the verifier goes quiet | One revise round; persistent fail = structural problem |
-
-## Agentic Optimizations
-
-| Context | Command |
-|---|---|
-| Verify current change, no target given | `git diff HEAD` as the target; state the default |
-| Verify a PR | `gh pr view <N> --json title,body,files` then diff |
-| Capture execution evidence | `npm test -- --bail=1 2>&1 \| tee /tmp/evidence.txt` (or `uv run pytest -q`) |
-| Single target, isolated verifier | One `Agent(subagent_type: general-purpose, model: opus)` |
 
 ## Related
 

--- a/agent-patterns-plugin/skills/mcp-code-execution/SKILL.md
+++ b/agent-patterns-plugin/skills/mcp-code-execution/SKILL.md
@@ -4,7 +4,7 @@ description: Scaffold the code execution pattern for MCP-based agents. Use when 
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2026-02-08
-modified: 2026-06-14
+modified: 2026-07-28
 reviewed: 2026-06-14
 ---
 
@@ -97,17 +97,6 @@ The agent loop becomes: explore `servers/` → generate code → execute in sand
 | Audit logging of all executions | Recommended |
 | Read-only access to `servers/` | Recommended |
 | Scoped write access to `workspace/` only | Recommended |
-
-## Agentic Optimizations
-
-| Context | Approach |
-|---------|----------|
-| Many tools (50+) | Use progressive discovery via file tree |
-| Large intermediate data | Filter in sandbox, return summaries |
-| Multi-step workflows | Generate single code block with control flow |
-| Sensitive data pipelines | Enable PII tokenization in MCP client |
-| Long-running tasks | Use `workspace/` for state persistence |
-| Repeated operations | Extract to `skills/` for reuse |
 
 ## Quick Reference
 

--- a/agent-patterns-plugin/skills/plugin-settings/SKILL.md
+++ b/agent-patterns-plugin/skills/plugin-settings/SKILL.md
@@ -4,7 +4,7 @@ description: Configure per-project plugin settings via .claude/plugin-name.local
 user-invocable: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 created: 2026-03-06
-modified: 2026-07-18
+modified: 2026-07-28
 compatibility: claude-code
 reviewed: 2026-03-06
 ---
@@ -13,15 +13,7 @@ reviewed: 2026-03-06
 
 Per-project plugin configuration using `.claude/plugin-name.local.md` files with YAML frontmatter for structured settings and markdown body for additional context.
 
-## When to Use This Skill
-
-| Use plugin settings when... | Use alternatives when... |
-|-----------------------------|--------------------------|
-| Plugin needs per-project configuration | Settings are global (use `~/.claude/settings.json`) |
-| Hooks need runtime enable/disable control | Hook behavior is always-on |
-| Agent state persists between sessions | State is ephemeral within a session |
-| Users customize plugin behavior per-project | Plugin has no configurable behavior |
-| Configuration includes prose/prompts alongside structured data | All config is purely structured (use `.json`) |
+Reach for a different mechanism when the settings are **global** (`~/.claude/settings.json`) or **purely structured** with no prose/prompt content (a plain `.json` file). The `.local.md` form earns its keep when config must carry prompts or instructions alongside structured fields.
 
 ## File Structure
 
@@ -190,12 +182,3 @@ When adding settings to a plugin:
 | Validate values | Check numeric ranges, enum membership |
 | File permissions | Settings files should be user-readable only (`chmod 600`) |
 | Restart notice | Document that hook-related changes need a Claude Code restart |
-
-## Agentic Optimizations
-
-| Context | Command |
-|---------|---------|
-| Check settings exist | `[[ -f ".claude/plugin.local.md" ]]` |
-| Extract single field | `head -50 file \| grep -m1 "^field:" \| sed 's/^[^:]*:[[:space:]]*//'` |
-| Extract body | `awk '/^---$/{i++; next} i>=2' file` |
-| Quick enable check | `[[ "$(extract_field file enabled)" == "true" ]]` |


### PR DESCRIPTION
Refs #2141 (2 of 45 affected directories; the remaining 43 stay deferred)

Applies `.claude/rules/context-engineering.md` § Supersedes to `agent-patterns-plugin`. PR #2198 already demoted `check_skill_when_to_use()` from ERROR to advisory, so removing these sections no longer fails the lint (confirmed on disk: `plugin-compliance-check.sh:1397` is commented `ADVISORY (issue #2141)` and pushes a `⚠️` recommendation).

## The judgement, per skill

This plugin is the archetypal **"confusable siblings"** case the demotion carved out. Four review skills, four dispatch skills, three MCP skills, and four `meta-*` skills each name their competitors by name in the When-to-Use contrast column — removing those tables would let the wrong skill fire. So 18 of 19 tables stay, and the win comes from `Agentic Optimizations`.

| Skill | When-to-Use | Agentic-Opts | Reason |
|---|---|---|---|
| `adversarial-review` | kept | **dropped** | Table routes against `code-review` / `verify-before-plan` / `cold-read-gate` / security-audit. AO rows restated `## Parameters` (the `git diff` default) and the `[1m]` caveat already at line 100 + Related. |
| `agent-teams` | kept | **dropped** | Routes team-vs-subagent. AO rows restated the Communication table (`message` vs `broadcast`, `shutdown_request`) and `TaskList` claiming. |
| `cold-read-gate` | kept | n/a | Distinguishes outward-bound gating from internal notes; the Skip column is the anti-trigger. |
| `custom-agent-definitions` | kept | **dropped** | Routes against `agent-teams` / `parallel-agent-dispatch` / `meta-audit`. AO rows restated Context Forking + Tool Access — and advertised `model: sonnet` for "complex implementation", contradicting the always-Opus subagent standard. |
| `exclusive-lock-dispatch` | kept | n/a | Contrast column *is* the `parallel-agent-dispatch` boundary. |
| `execution-grounded-review` | kept | **dropped** | Routes against `code-review` / `adversarial-review` / `verify-before-plan` / `cold-read-gate`. AO rows restated `## Parameters` and Step 1's evidence capture. |
| `expose-tunable-knob` | kept | n/a | No competing sibling, **but** the Skip column carries four substantive anti-triggers (objective computable criterion, first attempt, binary/structural param, no fast redeploy path) the description cannot hold. Dropping it would make the skill over-fire. |
| `mcp-code-execution` | kept | **dropped** | Routes against `mcp-management`. AO rows restated Key Patterns and the Security Checklist. |
| `mcp-management` | kept | **kept** | Routes against `configure-mcp`. AO table is real `jq` one-liners over `.mcp.json` — CLI payload. |
| `mcp-server-authoring` | kept | **kept** | Routes against `mcp-management` / `configure-mcp` / `mcp-code-execution`. AO table is the `uv run ruff/pytest/mcp dev` quality gate — CLI payload. |
| `meta-assimilate` | kept | n/a | Routes against `custom-agent-definitions` / `meta-audit`. |
| `meta-audit` | kept | n/a | Routes against `custom-agent-definitions` / `meta-assimilate`. |
| `meta-context-diet` | kept | n/a | Routes against `meta-promote` / `session-distill` / `health-skill-audit`. |
| `meta-promote` | kept | n/a | Routes against `meta-assimilate` / `meta-audit` / `custom-agent-definitions`. |
| `multi-model-delegation` | kept | **kept** | Routes foreign-model consults away from `parallel-agent-dispatch` / `agent-teams` / `adversarial-review`. AO table is the PAL tool-routing map (`listmodels` → `chat` → `consensus` → `thinkdeep`) — the payload for a tool wrapper. |
| `parallel-agent-dispatch` | kept | n/a | **Untouched.** ~23,400 chars against a 26,000 ceiling, ~34 pinned tokens across `SKILL.md` + `REFERENCE.md`. No clear win; high blast radius. |
| `plugin-settings` | **dropped** | **dropped** | The only skill with no competing sibling — its table was a mechanism-choice list, not skill routing. AO rows restated the `extract_field` / `awk` snippets already in Reading Settings. |
| `verify-before-plan` | kept | n/a | Skip column is the sequencing boundary against `parallel-agent-dispatch`. |
| `wave-based-dispatch` | kept | n/a | Three-way table separating it from `parallel-agent-dispatch` and `exclusive-lock-dispatch`. |

**Content moved, not deleted.** `plugin-settings` lost its table but keeps its two non-obvious signals as a lead paragraph: global settings belong in `~/.claude/settings.json`, purely-structured config in a plain `.json`. No `REFERENCE.md` was created — nothing warranted one.

**Pin safety.** Every pinned literal was located before editing. Three lived inside or adjacent to a dropped table and were verified to survive elsewhere: `` temperature` for kimi `` (`multi-model-delegation:152`, gotchas table — AO kept anyway), `execution evidence` (`execution-grounded-review`, 10 further occurrences), `shutdown_request` (`agent-teams:89`, Communication table). No surviving prose was rewrapped.

## Character delta

Measured as **characters** (decoded UTF-8), not bytes:

```
before 178987
after  176292
delta   -2695
```

Corpus-level C4, measured before and after on the same scanner:

| Metric | Before | After |
|---|---|---|
| `C4_BOILERPLATE_WHEN_TO_USE_SKILLS` | 408 | **407** |
| `C4_BOILERPLATE_WHEN_TO_USE_CHARS` | 281216 | **280617** |
| `C4_BOILERPLATE_AGENTIC_OPTIMIZATIONS_SKILLS` | 258 | **252** |
| `C4_BOILERPLATE_AGENTIC_OPTIMIZATIONS_CHARS` | 132495 | **130115** |

## Verification

`plugin-compliance-check.sh agent-patterns-plugin` — no ❌:

```
| Plugin | plugin.json | Frontmatter | Body | Marketplace | Release Config | Bash Patterns | Descriptions | When-to-Use | Size | Overall |
| agent-patterns-plugin | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
```

The `When-to-Use` ⚠️ is the intended advisory for `plugin-settings`; the `Descriptions` ⚠️ (`expose-tunable-knob` at 233 chars) and every `Size` ⚠️ are pre-existing on `main`.

```
$ bash scripts/check-agent-failure-contract.sh
OK: loud-failure contract, hook-thrashing heuristic, and WIP-salvage discrimination present in agent-patterns dispatch skills
EXIT=0

$ bash scripts/check-loop-integrity.sh --strict
=== LOOP INTEGRITY ===
RULE_PRESENT=true
STATUS=OK
ISSUE_COUNT=0
=== END LOOP INTEGRITY ===
EXIT=0

$ bash scripts/check-subagent-types.sh
AGENT_COUNT=23  FILES_SCANNED=555  REFS_CHECKED=33
UNRESOLVABLE=0  UNQUALIFIED=6  STATUS=WARN  ISSUE_COUNT=6
EXIT=0
```

(All six `UNQUALIFIED` warnings are pre-existing and in `evaluate-plugin` / `testing-plugin`, not this plugin.)

```
$ python3 scripts/audit-skill-descriptions.py --strict-length
Audited 407 skills across 44 plugins
Trigger axis:  OK 407 (100.0%)  NEEDS FIX 0
Length axis:   IDEAL 62  OK 319  WARN 26  ERROR 0
agent-patterns-plugin               19        0       0        0     19
EXIT=0

$ python3 scripts/check-context-engineering.py --strict
C5_ALWAYS_LOADED_CHARS=99362
C5_ALWAYS_LOADED_EST_TOKENS=24840
C5_ALWAYS_LOADED_BUDGET=100000
STATUS=WARN
ISSUE_COUNT=187
EXIT=0
```

**C5 number: 24,840 est. tokens (99,362 chars) against a 100,000-char budget — unchanged by this PR.** C5 measures `CLAUDE.md` + unscoped `.claude/rules/**`; skill bodies do not contribute to it. Only C4 moved.

## Regression check

No `Known Regressions` row is needed — this is not a bug fix. The demotion is already gated by `scripts/tests/test-plugin-compliance-check.sh` (#2141), and every pinned literal by `check-agent-failure-contract.sh` / `check-loop-integrity.sh`.

## Two corrections to the brief

- The issue states `## Agentic Optimizations` covers **257** skills; the scanner on `main` reports **258** (`C4_BOILERPLATE_AGENTIC_OPTIMIZATIONS_SKILLS=258`). Off by one.
- The issue states `## When to Use This Skill` is at **407/407**. The scanner reports **408** on `main` — its scan set includes the repo-internal `.claude/skills/` meta-skills, which `audit-skill-descriptions.py` (407 across 44 plugins) excludes. The two 407s are different sets.
