### PR TITLE
refactor(rules): trim conventional-commits.md off the always-loaded surface

### DIFF
--- a/.claude/rules/conventional-commits.md
+++ b/.claude/rules/conventional-commits.md
@@ -1,354 +1,66 @@
 ---
 created: 2026-02-14
-modified: 2026-02-14
-reviewed: 2026-02-14
+modified: 2026-07-29
+reviewed: 2026-07-29
 ---
 
 # Conventional Commits Standards
 
-Both commit messages and PR titles must follow conventional commit format to drive release-please automation and maintain consistent git history.
+Commit messages **and PR titles** follow `<type>(<scope>): <subject>`. This is
+not cosmetic: release-please parses them to decide version bumps, and a
+**squash-merge lands the PR title** — not the individual commit subjects — as
+the commit message on `main`. So a non-conventional PR title silently breaks
+release automation even when every commit inside it was perfectly formatted.
 
-## Format
+Subjects are imperative, lowercase after the colon, no trailing period.
 
-```
-<type>(<scope>): <subject>
+## Types and the bump each triggers
 
-[optional body]
+| Type | Use case | release-please bump |
+|------|----------|---------------------|
+| `feat` | New feature | **Minor** |
+| `fix` | Bug fix | **Patch** |
+| `perf` | Performance improvement | **Patch** |
+| `refactor` | Code restructure, no behaviour change | None |
+| `docs` | Documentation only | None |
+| `test` | Test changes | None |
+| `ci` | CI/CD configuration | None |
+| `build` | Build system or dependencies | None |
+| `chore` | Maintenance, tooling | None |
+| `revert` | Revert a previous commit | Varies with the reverted type |
 
-[optional footer(s)]
-```
+A `!` before the colon (`feat(api)!: redesign endpoints`) or a
+`BREAKING CHANGE:` footer forces a **major** bump regardless of type.
 
-## Types
+## Scope is the package name (monorepo)
 
-| Type | Use Case | Version Bump | Example |
-|------|----------|--------------|---------|
-| `feat` | New feature | Minor | `feat(auth): add OAuth2 support` |
-| `fix` | Bug fix | Patch | `fix(api): handle timeout edge case` |
-| `perf` | Performance improvement | Patch | `perf(db): optimize query indexing` |
-| `refactor` | Code restructure (no behavior change) | None | `refactor(core): simplify error handling` |
-| `docs` | Documentation only | None | `docs(readme): update installation steps` |
-| `test` | Test changes | None | `test(auth): add OAuth flow tests` |
-| `ci` | CI/CD configuration | None | `ci(workflows): add release automation` |
-| `build` | Build system or dependencies | None | `build(deps): upgrade TypeScript to v5` |
-| `chore` | Maintenance, tooling | None | `chore(deps): update dev dependencies` |
-| `revert` | Revert previous commit | Varies | `revert: feat(auth): add OAuth2 support` |
-
-## Type Selection Decision Tree
-
-```
-What changed?
-├─ New functionality added? → feat
-├─ Bug fixed? → fix
-├─ Performance improved? → perf
-├─ Code restructured (behavior unchanged)? → refactor
-├─ Documentation updated? → docs
-├─ Tests added/modified? → test
-├─ CI/CD changed? → ci
-├─ Build/deps changed? → build
-├─ Everything else (cleanup, setup)? → chore
-└─ Reverting a prior commit? → revert
-```
-
-## Scope
-
-Optional component or area identifier. Choose from:
-
-### Scope Selection Rules
-
-1. **Use consistent scopes** - Look at recent commits to match existing scope names
-2. **Keep short** - 1-3 words, kebab-case
-3. **Be specific** - Name the component/feature affected
-4. **Omit if unclear** - Bare `feat:` is better than vague scope
-
-### Discovering Scopes
-
-```bash
-# Show most common scopes in recent commits
-git log --format='%s' -n 50 | grep -oE '\([^)]+\)' | sort | uniq -c | sort -rn
-
-# Or from PRs (for repository patterns)
-gh pr list --state merged -L 30 --json title | jq -r '.[].title' | grep -oE '\([^)]+\)' | sort | uniq -c | sort -rn
-```
-
-### Common Scope Examples
-
-| Scope | Use For |
-|-------|---------|
-| `auth` | Authentication, authorization |
-| `api` | API endpoints, routes |
-| `ui` | User interface, components |
-| `db` | Database, queries, migrations |
-| `test` | Testing infrastructure |
-| `docs` | Documentation |
-| `config` | Configuration files |
-| `deps` | Dependencies, package management |
-| `workflow` | Git workflows, PR handling |
-
-## Subject
-
-The subject line comes after the colon and scope.
-
-### Subject Requirements
-
-- **Imperative mood**: "add" not "adds" or "added"
-- **Lowercase start**: After type/scope, begin with lowercase letter
-- **No period**: Don't end with punctuation
-- **Concise**: Ideally under 50 characters
-- **Descriptive**: Clearly states what changed
-
-### Subject Examples
-
-| ❌ Bad | ✅ Good |
-|--------|---------|
-| `Added login button` | `add login button` |
-| `Fixes the null pointer issue.` | `fix null pointer in auth service` |
-| `Update` | `update dependencies` |
-| `Changed API response format` | `change API response to return timestamps` |
-| `Adds OAuth2 Support` | `add OAuth2 support` |
-
-### Pattern Templates
-
-- **Feature**: `feat(<scope>): add <what>`
-- **Bug fix**: `fix(<scope>): resolve <what>`
-- **Improvement**: `perf(<scope>): optimize <what>`
-- **Refactor**: `refactor(<scope>): simplify <what>`
-- **Docs**: `docs(<scope>): update <what>`
-
-## Breaking Changes
-
-Breaking changes trigger a major version bump and are marked with a `!` suffix before the colon.
-
-### Syntax
-
-```
-feat(api)!: redesign authentication endpoints
-feat!: require Node.js 18+
-fix(db)!: remove deprecated query method
-```
-
-### In Commit Body
-
-For longer explanation, include footer:
-
-```
-feat(api)!: remove deprecated /v1/users endpoint
-
-BREAKING CHANGE: /v1/users endpoint has been removed. Use /v2/users instead.
-- Old endpoint accepted GET requests returning user profile
-- New endpoint requires POST with JSON body
-- See migration guide: docs/migration/v1-to-v2.md
-```
-
-## Issue References
-
-Link commits to GitHub issues using footer keywords:
-
-| Keyword | Effect | Use Case |
-|---------|--------|----------|
-| `Fixes #N` | Closes issue when merged | Bug fixes |
-| `Closes #N` | Closes issue when merged | Features (non-bugs) |
-| `Refs #N` | Links without closing | Partial work, references |
-
-### Syntax
-
-```bash
-git commit -m "feat(auth): add OAuth2 support
-
-Closes #123
-Refs #456"
-```
-
-Multiple issues:
-```bash
-git commit -m "fix(api): handle timeout edge case
-
-Fixes #100
-Fixes #101
-Refs #102"
-```
-
-## Commit Body
-
-Optional detailed explanation after a blank line. Include:
-
-- **What changed** and why
-- **Context** for the change
-- **Trade-offs** or decisions made
-- **Issue links** (Fixes/Closes/Refs)
-
-```
-feat(auth): add OAuth2 support
-
-Previously, authentication was only available via basic auth,
-limiting enterprise adoption. This adds OAuth2 support for
-better security and federated identity management.
-
-Implements:
-- OAuth2 authorization code flow
-- Token refresh handling
-- Scope-based permission validation
-
-Closes #123
-Refs #456
-```
-
-## Scoped Commits in Monorepos
-
-For monorepos with multiple packages, include the package name as the scope:
+release-please decides **which package to release** from the scope, so here the
+scope must be the plugin directory name:
 
 ```
 feat(blueprint-plugin): add new command syntax
 fix(git-plugin): handle merge conflicts
-docs(configure-plugin): update README
-build(packages): upgrade TypeScript to v5
 ```
 
-Release-please uses scoped commits to determine which packages to release.
+`release-please-config.json` declares 44 plugin components and **no root (`.`)
+package**, so a scope that matches no package — including an unscoped bare
+`feat:` — produces no release at all. That is the usual reason a merged `feat`
+never cut a version, and it is also used deliberately (see the `blueprint`
+scope in `CLAUDE.md`, which exists precisely because it matches nothing).
 
-## PR Titles
+## Issue references
 
-**PR titles MUST follow conventional commit format.** This ensures:
+Footer keywords, one per line, after a blank line in the commit body:
 
-1. Consistent git history when using "squash and merge"
-2. Accurate changelog generation by release-please
-3. Clear communication of changes via PR list
+| Keyword | Effect |
+|---------|--------|
+| `Fixes #N` | Closes the issue on merge (bug fixes) |
+| `Closes #N` | Closes the issue on merge (features) |
+| `Refs #N` | Links without closing |
 
-### PR Title Checklist
+## Related
 
-- [ ] Starts with valid type (`feat`, `fix`, `docs`, etc.)
-- [ ] Includes scope if applicable: `type(scope):`
-- [ ] Subject is concise and clear
-- [ ] Uses lowercase after colon
-- [ ] No trailing period
-- [ ] Subject under 50 characters
-
-### Examples
-
-```
-feat(auth): add OAuth2 support
-fix(api): handle null response in serializer
-docs(readme): update installation steps
-refactor(core): simplify error handling
-perf(db): optimize query performance
-```
-
-## Commit Messages vs PR Titles
-
-| Aspect | Commit Message | PR Title |
-|--------|----------------|----------|
-| Format | Must be conventional | Must be conventional |
-| Body | Optional detailed explanation | N/A (use PR description) |
-| Scope | Specific component | Specific component |
-| When created | Local commit | On PR creation/update |
-| Auto-linking | To issues (Fixes/Refs) | Separate PR description |
-| Purpose | Individual change | Aggregated changes |
-
-### Workflow
-
-1. **Create commits** with conventional format and issue links
-2. **Push to branch**
-3. **Create PR** with title matching `git log --format='%s'` of commits being merged
-4. **Use PR description** for context on multiple commits
-
-## Release-Please Integration
-
-Conventional commits drive automated versioning:
-
-### Version Bump Logic
-
-```
-Any commit with feat: → Minor version bump
-Any commit with fix: or perf: → Patch version bump
-Any commit with !: → Major version bump
-Docs, test, ci, build, chore → No version bump
-```
-
-### CHANGELOG Generation
-
-Commits are grouped in CHANGELOG by type:
-
-```markdown
-## Features
-- add OAuth2 support (abc1234)
-- add timeout configuration (def5678)
-
-## Bug Fixes
-- fix null pointer in auth service (ghi9012)
-- resolve timing issue in scheduler (jkl3456)
-
-## Performance
-- optimize database query performance (mno7890)
-```
-
-## Validation
-
-### Pre-commit Hooks
-
-Ensure commits follow conventional format:
-
-```bash
-# List recent commits to verify format
-git log --oneline -n 10
-
-# Check commit format
-git log -1 --format='%s'  # Should match pattern
-```
-
-### PR Title Validation
-
-Before merging, verify:
-```bash
-# Get PR title
-gh pr view --json title --jq '.title'
-
-# Verify it matches conventional format
-```
-
-## Emergency Commits
-
-When immediate action is needed (hotfixes, reverts):
-
-1. Still use conventional format
-2. Reference related issues in footer
-3. Document reason for urgency in commit body
-
-```
-fix(critical): patch XSS vulnerability in auth
-
-CRITICAL: This XSS vulnerability allows token theft.
-Apply immediately to all environments.
-
-Affected versions: 1.2.0-1.2.3
-Fix: Properly escape OAuth callback URL
-
-Fixes #500
-```
-
-## Troubleshooting
-
-### Commit message has wrong format
-
-Fix the commit:
-```bash
-# If not yet pushed
-git commit --amend -m "feat(scope): new message"
-
-# If pushed (rebase or force-push as needed)
-git rebase -i HEAD~1
-# Edit the commit message
-```
-
-### PR title doesn't match commits
-
-Update PR title:
-```bash
-gh pr edit <NUMBER> --title "feat(scope): new title"
-```
-
-### Release-please didn't detect change
-
-Verify:
-1. Commit message starts with valid type
-2. Type matches `feat`, `fix`, `perf`, `refactor`, `docs`, `test`, `ci`, `build`, `chore`, or `revert`
-3. Scope matches package name (in monorepos)
-
+- `git-plugin:git-commit-workflow` — staging, composing a message, repairing a wrong one
+- `git-plugin:github-pr-title` — PR-title checklist and repair
+- `git-plugin:git-commit-trailers` — `BREAKING CHANGE`, `Co-authored-by`, `Signed-off-by`
+- `git-plugin:release-please-configuration` — adding a package so a new scope can release


### PR DESCRIPTION
Slice of #2140 (F1: the always-loaded surface). One file, revertible in isolation.

## Why

`.claude/rules/conventional-commits.md` carries no `paths:` glob, so it is injected into **every turn of every session**. At 9,202 chars it was one of the largest unscoped rules, and the ratchet (`check-context-engineering.py --strict`, ceiling 100,000) had **400 chars of headroom** — the next rule addition would have broken it.

Most of the file's mass restated things a Claude 5 model already knows (what imperative mood is, that `feat` means a feature) or duplicated procedures `git-plugin` skills already own.

## Result

| Metric | Before | After |
|---|---|---|
| File chars | 9,202 | 2,541 |
| `C5_ALWAYS_LOADED_CHARS` | 99,600 | **92,939** |
| Ratchet headroom | 400 | 7,061 |

## What was cut, and where it lives now

| Removed | Now |
|---|---|
| Type-selection decision tree | Restated the Types table verbatim — needed nobody |
| Generic scope table (`auth`/`api`/`ui`/`db`) + `git log \| grep -oE` scope discovery | `git-plugin:git-commit-workflow` |
| Subject requirements / examples / pattern templates | Model default; one line survives |
| Long worked examples (breaking change, commit body, issue footers) | One line each |
| PR-title checklist + examples | `git-plugin:github-pr-title` |
| Commit-vs-PR-title comparison table, CHANGELOG sample, validation commands, emergency-commit section | Obvious or trivially re-derivable |
| Whole **Troubleshooting** section | Procedure-with-a-trigger, i.e. skill-shaped — `git-plugin:git-commit-workflow` / `github-pr-title` |

## What was deliberately kept

Per the issue's counter-findings, these are repo-specific and a model gets them wrong without them:

- The **type → release-please bump** mapping, folded into a single table with `!` / `BREAKING CHANGE` as the major-bump path.
- **Scope == plugin package name** in this monorepo.
- **A squash-merge lands the PR title**, not the commit subjects.
- The `Fixes`/`Closes`/`Refs` table — `git-commit/SKILL.md` and `github-pr-title/SKILL.md` both link *here* as its single owner (the benchmark's own recommendation is that those skills delete their copies and keep the pointer), so deleting it here would have inverted the fix.

## One claim sharpened while trimming

`release-please-config.json` declares 44 plugin components and **no root (`.`) package**, so an unscoped bare `feat:` releases nothing. The old text advised *"bare `feat:` is better than a vague scope"* — wrong in this repo. This is also the mechanism behind the deliberate `blueprint` no-release scope documented in `CLAUDE.md`.

## Not done on purpose

**No `paths:` glob was added.** Conventional-commit format matters on turns where nobody has opened a file, so path-scoping would silently deactivate the rule. The gain here is entirely from cutting restated content.

## Verification

```
$ python3 scripts/check-context-engineering.py --strict
C5_ALWAYS_LOADED_CHARS=92939
C5_ALWAYS_LOADED_EST_TOKENS=23234
C5_ALWAYS_LOADED_BUDGET=100000
exit 0

$ bash scripts/check-docs-index.sh
RULES_ON_DISK=44 / RULES_IN_TABLE=44 / RULES_CHECKED=44
STATUS=OK  ISSUE_COUNT=0
exit 0
```

`modified:`/`reviewed:` bumped to 2026-07-29. The CLAUDE.md Rules-table row still describes the file accurately, so it is untouched.

Refs #2140