### PR TITLE
refactor(rules): trim gh-json-fields.md off the always-loaded surface

### DIFF
--- a/.claude/rules/gh-json-fields.md
+++ b/.claude/rules/gh-json-fields.md
@@ -1,26 +1,26 @@
 ---
 created: 2026-05-11
-modified: 2026-06-22
-reviewed: 2026-07-04
+modified: 2026-07-29
+reviewed: 2026-07-29
 ---
 
 # `gh --json` Field Names
 
-The GitHub CLI's `--json` flag accepts a comma-separated list of field
-names. Invalid names exit 1 and dump the available field list — but
-that's a *runtime* failure, not a syntax check. Get the field name
-right the first time.
+An invalid `--json` field name exits 1 at *runtime* and dumps the full available
+field list — so don't guess: read that list, or `gh pr help json-fields` /
+`gh <cmd> --help`. Common field sets per command: `git-plugin:gh-cli-agentic`.
 
 ## The `merged` mistake
 
-The single most-common mistake (6 of 10 `Unknown JSON field` errors in
-the W20 window, and recurring at 4 sessions in W23, across 6+4 distinct
-sessions) is asking for a field called `merged`:
+The single most-common mistake is asking for a field called `merged`:
 
 ```
 # Wrong — there is no `merged` field on the PR JSON object
 gh pr view 42 --json number,merged --jq '.merged'
 # → Exit 1: Unknown JSON field: "merged"
+
+# Right
+gh pr view 42 --json state --jq '.state == "MERGED"'
 ```
 
 PR merge state lives on the `state` field (a string enum) or the
@@ -37,44 +37,6 @@ PR merge state lives on the `state` field (a string enum) or the
 | Mergeable now? | `mergeable` | n/a | `MERGEABLE` / `CONFLICTING` / `UNKNOWN` | n/a |
 | Auto-merge enabled? | `autoMergeRequest` | n/a | object or `null` | n/a |
 
-Common idioms:
-
-```bash
-# Is the PR merged?
-gh pr view 42 --json state --jq '.state == "MERGED"'
-
-# When was it merged (or null)?
-gh pr view 42 --json mergedAt --jq '.mergedAt'
-
-# Find merged PRs in last month
-gh pr list --state merged --limit 100 --json number,title,mergedAt
-```
-
-## How to discover field names
-
-If you don't know the field name, **don't guess**. Two reliable ways
-to find it:
-
-1. **Run with one valid field, then read the error if any new field
-   is rejected.** The error message lists every available field:
-
-   ```bash
-   gh pr view 42 --json number,merged
-   # → Unknown JSON field: "merged"
-   # → Available fields: additions, assignees, author, autoMergeRequest,
-   #   baseRefName, baseRefOid, body, changedFiles, closed, closedAt, ...
-   ```
-
-   That list is authoritative. Pick the right field from it.
-
-2. **Use the help output:**
-
-   ```bash
-   gh pr view --help     # lists --json flag + field discovery hint
-   gh pr list --help
-   gh issue view --help
-   ```
-
 ## Other commonly-mistaken field names
 
 | Want | You might try | Correct field |
@@ -86,17 +48,15 @@ to find it:
 | Has Pages enabled? | `hasPages` on PR/issue | Query repo: `gh repo view --json hasPagesEnabled` |
 | Base repository | `baseRepository` on a PR | `baseRefRepositoryNameWithOwner` or query separately |
 
-These were all observed in the W20 window. The unifying theme: GitHub's
-GraphQL schema uses **camelCase**, not snake_case, and PR/issue
-objects don't carry every property of their parent repository.
+The unifying theme, which generalises past this list: GitHub's GraphQL schema is
+**camelCase**, not snake_case, and PR/issue objects don't carry every property of
+their parent repository.
 
-## CI check fields (W23 additions)
+## CI check fields
 
-Asking a PR object directly about its CI checks does not work — there
-is no flat `conclusion`, `checksStatus`, or `checkRuns` field on the PR
-itself. Check status lives in **`statusCheckRollup`**, an array of one
-entry per check, each with its own `conclusion`, `name`, `startedAt`,
-`completedAt`, `detailsUrl`, etc.
+There is no flat `conclusion`, `checksStatus`, or `checkRuns` field on a PR.
+Check status lives in **`statusCheckRollup`**, an array of one entry per check,
+each with its own `conclusion`, `status`, `name`, `detailsUrl`, etc.
 
 | Want to know | You might try | Correct field on PR |
 |---|---|---|
@@ -105,36 +65,10 @@ entry per check, each with its own `conclusion`, `name`, `startedAt`,
 | Which checks failed? | `--json conclusion,name` | `--json statusCheckRollup --jq '.statusCheckRollup[] \| select(.conclusion == "FAILURE") \| .name'` |
 | Conclusion of one specific check | (no flat field) | `--json statusCheckRollup --jq '.statusCheckRollup[] \| select(.name == "test") \| .conclusion'` |
 
-A single `statusCheckRollup[].conclusion` is one of: `SUCCESS`,
-`FAILURE`, `NEUTRAL`, `CANCELLED`, `SKIPPED`, `TIMED_OUT`,
-`ACTION_REQUIRED`, `STALE`, `STARTUP_FAILURE`, or `null` (still
-running). `status` is one of `QUEUED`, `IN_PROGRESS`, `COMPLETED`,
-`WAITING`, `PENDING`, `REQUESTED`.
-
-For the lighter "did CI pass" check that doesn't need per-check
-detail, `gh pr checks <number>` (without `--json`) returns a
-human-readable summary and exits non-zero on failure — sometimes that
-exit code is the only signal you actually need:
-
-```bash
-# Exit 0 iff all checks passed; exit 1 on any failure or pending
-if gh pr checks 42 --required; then
-  echo "all required checks passed"
-fi
-```
-
-## Edge case: `--jq` on a null field
-
-`mergedAt` is `null` for unmerged PRs. Plain `--jq '.mergedAt'` prints
-`null` (literally the string `null`). For a boolean test:
-
-```bash
-# Right - explicit null check
-gh pr view 42 --json mergedAt --jq '.mergedAt != null'
-
-# Wrong - test "the string null"
-gh pr view 42 --json mergedAt --jq '.mergedAt | length > 0'
-```
+`conclusion` is `null` while a check is still running, and `SKIPPED` / `NEUTRAL`
+are *not* failures — so a naive `all(. == "SUCCESS")` reports red on a PR that is
+merely pending or has a skipped job. When you only need the pass/fail signal,
+`gh pr checks <n> --required` exits non-zero on any failure or pending check.
 
 ## Default list cap: pass `--limit` when counting or verifying state
 
@@ -151,6 +85,10 @@ gh issue list --state open --json number --jq 'map(select(.number == 1392))'
 # Right — explicit limit above the expected count
 gh issue list --state open --limit 100 --json number,state
 ```
+
+Symptom signature: a state check reports an issue closed/missing, but
+`gh issue view <N>` shows it OPEN — the list was paginated, the direct view is
+authoritative.
 
 ### `--state closed` includes MERGED PRs — so a big `--limit` still may not reach
 
@@ -178,11 +116,6 @@ gh pr list --head <branch> --state all --json number,state,mergedAt   # per-bran
 gh search prs --repo <o>/<r> --state closed --merged=false --limit 100
 ```
 
-Symptom signature: a state check reports an issue closed/missing, but
-`gh issue view <N>` shows it OPEN — the list was paginated, the direct view is
-authoritative. (Observed 2026-06-21: a 39-issue repo's open-state check missed
-two issues that were genuinely open.)
-
 ## Search qualifiers: `head:` is exact-match, not a prefix
 
 `gh pr list --search "head:<X>"` (and the underlying GitHub search `head:`
@@ -204,17 +137,10 @@ COUNT=$(gh pr list --state all --limit 200 --json headRefName,createdAt \
 Note `gh pr list --head "<branch>"` (the flag, not the search qualifier) **is**
 an exact-branch filter and is correct for "PRs on this one branch". Reserve the
 `--search "head:"` form for a known full branch name; reach for `--json
-headRefName` + `startswith` whenever you mean a **prefix**. (Observed 2026-07-18:
-a level-3 daily-budget count keyed on `--search "head:blueprint/wo-"` was always
-0, so the budget never enforced — caught only by an adversarial review, not by
-CI.)
+headRefName` + `startswith` whenever you mean a **prefix**.
 
 ## Related
 
 - `.claude/rules/github-metadata-hygiene.md` (parent
   `laurigates/CLAUDE.md`) — when to query PR metadata at all
-- `gh pr help json-fields` — official field reference (when available)
-- W20 friction findings: original `merged` rule (10 events / 10
-  sessions). Held at near-zero for W21-W22, then 8 events / 8 sessions
-  in W23 (4× `merged`, 2× `conclusion`, 1× `checksStatus`, 1×
-  `issueType`) prompted this extension.
+- `git-plugin:gh-cli-agentic` — common `--json` field sets and agent-facing `gh` recipes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Claude Code plugin collection providing skills and agents for development workfl
 | `.claude/rules/github-actions-security.md` | **GitHub Actions secure-use baseline** — least-privilege `GITHUB_TOKEN`, script-injection env-var indirection, `pull_request_target` hazards, CODEOWNERS on workflows; the checklist every workflow-scaffolding skill follows |
 | `.claude/rules/workflow-model-effort.md` | **Workflow Claude model/effort standard** — every `.github/workflows` invocation pins `--model opus` + explicit `--effort` (cost-economics, not the subagent-contamination argument); enforced by `check-workflow-model.sh` |
 | `.claude/rules/bash-tool-replacements.md` | `find`/`grep`/`rg`/`cat`/`head`/`tail` → dedicated tools; when the Bash form is genuinely fine |
-| `.claude/rules/gh-json-fields.md` | Correct `gh --json` field names (PR `state`/`mergedAt`, not `merged`); how to discover field lists |
+| `.claude/rules/gh-json-fields.md` | Correct `gh --json` field names (PR `state`/`mergedAt`, not `merged`); `--limit` and `head:` truncation traps |
 | `.claude/rules/structured-script-output.md` | `=== HEADER ===` / `KEY=VALUE` / `STATUS=` convention for diagnostic shell scripts |
 | `.claude/rules/typer-cli-completion.md` | Bypass `shellingham` in Python/Typer CLIs by adding an explicit `completion <shell>` subcommand using Click's `get_completion_class` |
 | `.claude/rules/terminology.md` | Glossary of development terms with strong intent (scoping, review, parallelism, work state, code ops, requirements) — positive definitions with *Use when* disambiguation |


### PR DESCRIPTION
Slice of #2140. `.claude/rules/gh-json-fields.md` is one of 12 **unscoped** rule files, so it is injected into every turn of every session. This trims it to free budget under the `check-context-engineering.py --strict` ratchet.

## Result

| Metric | Before | After |
|---|---|---|
| `gh-json-fields.md` chars | 9,494 | 7,095 (**-25.3%**) |
| `C5_ALWAYS_LOADED_CHARS` | 99,600 | **97,212** |
| Headroom under the 100,000 ceiling | 400 | **2,788** |
| `ISSUE_COUNT_C5` | 7 | 6 |

## Strategy

Per `.claude/rules/context-engineering.md`, text earns its always-loaded tokens when it "names a non-obvious, costly failure **and says why**". This file has a measured track record — per `regression-testing.md`, the `merged`-field rule "named the exact substitution (`state == \"MERGED\"`) and drove that friction class from 10/10 sessions to 0/0 in one week." The concrete substitution is what teaches, not the prose around it.

So: **keep every wrong→right substitution, cut the scaffolding.**

## What was cut

- **"How to discover field names" walkthrough** → one line, plus a `git-plugin:gh-cli-agentic` name reference for common field sets. (That skill does not own the discovery procedure itself, so the mechanism was compressed rather than delegated; it does own the common `--json` field sets, which is what the reference points at.)
- **"Edge case: `--jq` on a null field"** — removed because **the claim was false**. It labelled `.mergedAt | length > 0` as wrong, but jq's `null | length` is `0`, so that form returns the identical boolean to `.mergedAt != null` in both the null and ISO-string cases. Verified before removing:

  ```
  $ echo '{"mergedAt": null}' | jq '.mergedAt | length > 0'                    # false
  $ echo '{"mergedAt": "2026-01-01T00:00:00Z"}' | jq '.mergedAt | length > 0'  # true
  ```

  A rule teaching a non-existent trap was costing ~360 chars every turn.
- **W20/W23 friction-window epidemiology and provenance footnotes** — bookkeeping about when the rule was written, not teaching.
- **"Common idioms" bash block** — redundant with the PR state reference table directly above it.
- **Bare `statusCheckRollup` enum listing** → replaced with one line naming the actual trap it implied but never stated: `conclusion` is `null` while running and `SKIPPED`/`NEUTRAL` are not failures, so a naive `all(. == "SUCCESS")` reports red on a merely-pending or skipped-job PR.

## What was kept deliberately

Every trap that names a costly, non-obvious failure with a concrete fix:

- the `merged`-field trap and its `state`/`mergedAt` substitution
- the PR state reference table
- the `statusCheckRollup` substitutions
- the `--limit` default-30 truncation trap
- the `--state closed` includes-MERGED-PRs trap (with its measured 4-vs-15 evidence)
- the `head:` search-qualifier exact-match trap

The camelCase-not-snake_case generalisation was kept and its "observed in W20" provenance dropped — the generalisation is the part that transfers past the enumerated list.

## Verification

```
$ python3 -c "import io,sys;print(len(io.open(sys.argv[1],encoding='utf-8',errors='surrogateescape').read()))" .claude/rules/gh-json-fields.md
7095

$ python3 scripts/check-context-engineering.py --strict   # exit 0
C5_CLAUDE_MD_CHARS=18241
C5_UNSCOPED_RULES=12
C5_ALWAYS_LOADED_CHARS=97212
C5_ALWAYS_LOADED_BUDGET=100000
ISSUE_COUNT_C5=6

$ bash scripts/check-docs-index.sh
RULES_ON_DISK=44
RULES_IN_TABLE=44
RULES_CHECKED=44
STATUS=OK
ISSUE_COUNT=0
```

No script pins this file's prose by literal string (`grep -rn 'gh-json-fields' scripts/ .pre-commit-config.yaml .claude/` finds only two comment mentions and four sibling-rule filename references). All headings referenced elsewhere are unchanged; frontmatter `modified:`/`reviewed:` bumped to 2026-07-29, and the CLAUDE.md Rules-table row description updated to match the file's current scope.

Refs #2140
