### PR TITLE
refactor(rules): promote CLAUDE.md authoring procedures into a skill

### DIFF
--- a/.claude/rules/skill-consolidation.md
+++ b/.claude/rules/skill-consolidation.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-05-29
-modified: 2026-06-10
-reviewed: 2026-07-04
+modified: 2026-07-29
+reviewed: 2026-07-29
 paths:
   - "**/SKILL.md"
   - "**/skill.md"
@@ -70,7 +70,8 @@ What is skill-scoped (update on merge/delete) vs what is **not**:
 Skills are **not** individually registered anywhere a plugin is — adding or
 deleting a skill needs no `marketplace.json` / release-config edit. (A
 subagent's generic "deletion checklist" got this wrong; verify against the
-actual `Plugin Lifecycle` section of `CLAUDE.md`, which is plugin-scoped.)
+actual `Plugin Lifecycle` section of the `/plugin-authoring` skill, which is
+plugin-scoped.)
 
 Mechanics:
 
@@ -114,4 +115,4 @@ description carries the traceability instead.
 - `skill-quality.md` — size limits, description length band (≤200)
 - `skill-naming.md` — `plugin:skill` namespacing (the cross-plugin reference form)
 - `verify-upstream-before-patching` (user rule) / repo debugging discipline — the "verify the premise before acting" principle this rule applies to refactors
-- `CLAUDE.md` § Plugin Lifecycle — the **plugin**-level add/delete checklist (distinct from skill-level)
+- `/plugin-authoring` § Plugin Lifecycle — the **plugin**-level add/delete checklist (distinct from skill-level)

--- a/.claude/skills/plugin-authoring/SKILL.md
+++ b/.claude/skills/plugin-authoring/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: plugin-authoring
+description: Add, modify, or delete a skill or plugin in this repo — frontmatter shape, the seven metadata files a plugin touches, and the create/delete checklists. Use when creating a new skill or plugin, removing one, or asking which files a plugin change must update.
+allowed-tools: Read, Edit, Write, Grep, Glob, Bash(mkdir *), Bash(jq *), Bash(git log *), Bash(bash scripts/check-docs-index.sh *), Bash(bash scripts/plugin-compliance-check.sh *), TodoWrite
+argument-hint: (no args)
+created: 2026-07-29
+modified: 2026-07-29
+reviewed: 2026-07-29
+---
+
+# /plugin-authoring
+
+The authoring procedures for this marketplace: how to create a skill, how to
+create a plugin, what to update when either changes, and how to delete one
+without leaving dangling metadata.
+
+Promoted out of `CLAUDE.md` (issue #2140) because all four are **procedures with
+a clear trigger** — they do not need to be resident when the user is debugging a
+hook. `CLAUDE.md` keeps only the repo blurb, the rules index, and the gotchas.
+
+Detailed patterns live in the rules this skill names; it is the sequence, not a
+second copy of them.
+
+## Creating New Skills
+
+See `.claude/rules/skill-development.md` for detailed patterns.
+
+> **Note (Claude Code 2.1.157):** plugins placed in `.claude/skills` are now auto-loaded without a marketplace entry — handy for local or quick one-off plugins. This repo's *published* plugins still use the full marketplace + release-please lifecycle described in Plugin Lifecycle below.
+
+### Quick Start
+
+1. Create skill directory: `mkdir -p <plugin>/skills/<skill-name>`
+2. Create `skill.md` with YAML frontmatter:
+   ```yaml
+   ---
+   name: <Skill Name>
+   description: <1-2 sentence description>
+   allowed-tools: Bash, Read, Grep, Glob, TodoWrite
+   created: YYYY-MM-DD
+   modified: YYYY-MM-DD
+   reviewed: YYYY-MM-DD
+   ---
+   ```
+3. Follow content structure: Core Expertise → Commands → Patterns → Quick Reference
+4. Include agentic optimizations table
+5. Update all metadata files (see Plugin Lifecycle section)
+
+### Skill Granularity Decision
+
+| Choose... | When... |
+|-----------|---------|
+| Single skill | Operations are related and share context |
+| Multiple skills | Distinct workflows, different user intents |
+
+Example: `bun-package-manager` (deps) vs `bun-development` (run/test/build)
+
+## Creating User-Invocable Skills
+
+Skills are invocable via `/plugin:skill-name` syntax. See `.claude/rules/skill-naming.md` for naming conventions.
+
+1. Create skill directory: `mkdir -p <plugin>/skills/<skill-name>`
+2. Create `SKILL.md` with YAML frontmatter:
+   ```yaml
+   ---
+   name: <skill-name>
+   description: What it does. Use when...
+   args: <arg-spec>
+   allowed-tools: Bash, Read
+   argument-hint: human hint
+   created: YYYY-MM-DD
+   modified: YYYY-MM-DD
+   reviewed: YYYY-MM-DD
+   ---
+   ```
+3. Include: Context → Execution → Post-actions
+
+## Plugin Lifecycle
+
+### Files to Update
+
+When creating, modifying, or deleting a plugin, update these files:
+
+| File | Location | Action |
+|------|----------|--------|
+| `plugin.json` | `<plugin>/.claude-plugin/plugin.json` | Create/update plugin manifest |
+| `README.md` | `<plugin>/README.md` | Create/update plugin documentation |
+| `marketplace.json` | `.claude-plugin/marketplace.json` | Add/update/remove plugin entry |
+| `release-please-config.json` | Root | Add/remove plugin package config |
+| `.release-please-manifest.json` | Root | Add/remove plugin version entry |
+| `PLUGIN-MAP.md` | `docs/PLUGIN-MAP.md` | Add/remove plugin from navigation map |
+| `settings.json` | `.claude/settings.json` | Add/remove the plugin in `enabledPlugins` (`<plugin>@laurigates-claude-plugins`) — enforced by the `Plugin: Enablement drift` check |
+
+### Creating a New Plugin
+
+> **Quick scaffold (Claude Code 2.1.157):** `claude plugin init <name>` scaffolds a new plugin in `.claude/skills` (auto-loaded, no marketplace entry needed). Use it for local/quick plugins; for plugins published from this repo, follow the full marketplace + release-please steps below.
+
+1. Create plugin directory structure (see Project Structure in `CLAUDE.md`)
+2. Create `.claude-plugin/plugin.json` with required fields
+3. Create `README.md` with plugin documentation
+4. Add entry to `.claude-plugin/marketplace.json` (under the `plugins` array):
+   ```json
+   {
+     "name": "new-plugin",
+     "source": "./new-plugin",
+     "description": "Plugin description",
+     "version": "1.0.0",
+     "keywords": ["keyword1", "keyword2"],
+     "category": "category-name"
+   }
+   ```
+   Note: marketplace.json has structure `{ "name": "...", "plugins": [...] }` — add to the `plugins` array.
+5. Add to `release-please-config.json`:
+   ```json
+   "new-plugin": {
+     "component": "new-plugin",
+     "release-type": "simple",
+     "extra-files": [
+       {"type": "json", "path": ".claude-plugin/plugin.json", "jsonpath": "$.version"}
+     ],
+     "changelog-sections": [
+       {"type": "feat", "section": "Features"},
+       {"type": "fix", "section": "Bug Fixes"},
+       {"type": "perf", "section": "Performance"},
+       {"type": "refactor", "section": "Code Refactoring"},
+       {"type": "docs", "section": "Documentation"}
+     ]
+   }
+   ```
+6. Add to `.release-please-manifest.json`:
+   ```json
+   "new-plugin": "1.0.0"
+   ```
+7. Enable it in `.claude/settings.json` so the repo dogfoods it:
+   ```json
+   "enabledPlugins": { "new-plugin@laurigates-claude-plugins": true }
+   ```
+   The `Plugin: Enablement drift` check (`scripts/check-enabled-plugins-drift.sh`) fails CI if a marketplace plugin is left disabled.
+
+### Deleting a Plugin
+
+1. Remove plugin directory
+2. Remove entry from `.claude-plugin/marketplace.json`
+3. Remove package from `release-please-config.json`
+4. Remove version from `.release-please-manifest.json`
+5. Remove the `<plugin>@laurigates-claude-plugins` key from `.claude/settings.json` `enabledPlugins`
+
+## Development Workflow
+
+1. **Research documentation** - Use context7, web search
+2. **Plan skill structure** - Decide granularity, scope
+3. **Write skills** - Follow standard structure
+4. **Update all metadata files** - See Plugin Lifecycle section
+5. **Commit early** - Use conventional commit format (see `.claude/rules/conventional-commits.md`)
+6. **Test** - Verify skills load and work
+7. **Create PR** - Use conventional commit format for title (drives automation)
+
+## Verify
+
+After a plugin add or delete, the two guards that catch dangling metadata:
+
+```
+bash scripts/check-docs-index.sh
+bash scripts/plugin-compliance-check.sh
+```
+
+`check-docs-index.sh` cross-checks the plugin set and per-plugin skill/agent
+counts against disk across `README.md`, `docs/PLUGIN-MAP.md`, and the d2
+diagram — use `/docs-refresh` to repair count drift it reports.
+
+## Related
+
+- `.claude/rules/skill-development.md` — skill creation patterns
+- `.claude/rules/skill-naming.md` — namespace conventions for user-invocable skills
+- `.claude/rules/skill-quality.md` — size limits, required sections, quality checklist
+- `.claude/rules/plugin-structure.md` — plugin.json schema and directory layout
+- `.claude/rules/release-please.md` — version management and changelog automation
+- `.claude/rules/conventional-commits.md` — the commit/PR-title format that drives release-please
+- `.claude/rules/skill-consolidation.md` — merging or deleting skills (distinct from the plugin-level checklist here)
+- `/docs-refresh` — repairs catalog count drift after a skill or plugin lands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,58 +70,9 @@ Claude Code plugin collection providing skills and agents for development workfl
 | `.claude/rules/gitattributes.md` | `.gitattributes` conventions — `merge=union` only for one-line-per-entry append-only files, `linguist-generated` for build output (always safe), LF normalization; the `configure-gitattributes` skill + `resolve-additive-conflicts.py` pre-pass |
 | `.claude/rules/task-id-stability.md` | Taskwarrior numeric IDs renumber after every close — resolve the immutable UUID once and mutate by UUID, including *within* a single skill's own multi-step lifecycle, not just across bulk loops |
 
-## Creating New Skills
+## Authoring Skills and Plugins
 
-See `.claude/rules/skill-development.md` for detailed patterns.
-
-> **Note (Claude Code 2.1.157):** plugins placed in `.claude/skills` are now auto-loaded without a marketplace entry — handy for local or quick one-off plugins. This repo's *published* plugins still use the full marketplace + release-please lifecycle described in Plugin Lifecycle below.
-
-### Quick Start
-
-1. Create skill directory: `mkdir -p <plugin>/skills/<skill-name>`
-2. Create `skill.md` with YAML frontmatter:
-   ```yaml
-   ---
-   name: <Skill Name>
-   description: <1-2 sentence description>
-   allowed-tools: Bash, Read, Grep, Glob, TodoWrite
-   created: YYYY-MM-DD
-   modified: YYYY-MM-DD
-   reviewed: YYYY-MM-DD
-   ---
-   ```
-3. Follow content structure: Core Expertise → Commands → Patterns → Quick Reference
-4. Include agentic optimizations table
-5. Update all metadata files (see Plugin Lifecycle section)
-
-### Skill Granularity Decision
-
-| Choose... | When... |
-|-----------|---------|
-| Single skill | Operations are related and share context |
-| Multiple skills | Distinct workflows, different user intents |
-
-Example: `bun-package-manager` (deps) vs `bun-development` (run/test/build)
-
-## Creating User-Invocable Skills
-
-Skills are invocable via `/plugin:skill-name` syntax. See `.claude/rules/skill-naming.md` for naming conventions.
-
-1. Create skill directory: `mkdir -p <plugin>/skills/<skill-name>`
-2. Create `SKILL.md` with YAML frontmatter:
-   ```yaml
-   ---
-   name: <skill-name>
-   description: What it does. Use when...
-   args: <arg-spec>
-   allowed-tools: Bash, Read
-   argument-hint: human hint
-   created: YYYY-MM-DD
-   modified: YYYY-MM-DD
-   reviewed: YYYY-MM-DD
-   ---
-   ```
-3. Include: Context → Execution → Post-actions
+Invoke `/plugin-authoring` — it carries the create-a-skill and create-a-user-invocable-skill frontmatter shapes, the seven metadata files a plugin add/delete must touch, and the development workflow. All four are procedures with a clear trigger, so they live in a skill rather than here (#2140).
 
 ## Agentic Optimization
 
@@ -141,76 +92,6 @@ Key principles:
 | Language-focused | `typescript-plugin` | Language ecosystem skills |
 | Workflow-focused | `git-plugin` | Git/GitHub operations |
 | Infrastructure | `configure-plugin` | Configuration automation |
-
-## Plugin Lifecycle
-
-### Files to Update
-
-When creating, modifying, or deleting a plugin, update these files:
-
-| File | Location | Action |
-|------|----------|--------|
-| `plugin.json` | `<plugin>/.claude-plugin/plugin.json` | Create/update plugin manifest |
-| `README.md` | `<plugin>/README.md` | Create/update plugin documentation |
-| `marketplace.json` | `.claude-plugin/marketplace.json` | Add/update/remove plugin entry |
-| `release-please-config.json` | Root | Add/remove plugin package config |
-| `.release-please-manifest.json` | Root | Add/remove plugin version entry |
-| `PLUGIN-MAP.md` | `docs/PLUGIN-MAP.md` | Add/remove plugin from navigation map |
-| `settings.json` | `.claude/settings.json` | Add/remove the plugin in `enabledPlugins` (`<plugin>@laurigates-claude-plugins`) — enforced by the `Plugin: Enablement drift` check |
-
-### Creating a New Plugin
-
-> **Quick scaffold (Claude Code 2.1.157):** `claude plugin init <name>` scaffolds a new plugin in `.claude/skills` (auto-loaded, no marketplace entry needed). Use it for local/quick plugins; for plugins published from this repo, follow the full marketplace + release-please steps below.
-
-1. Create plugin directory structure (see Project Structure above)
-2. Create `.claude-plugin/plugin.json` with required fields
-3. Create `README.md` with plugin documentation
-4. Add entry to `.claude-plugin/marketplace.json` (under the `plugins` array):
-   ```json
-   {
-     "name": "new-plugin",
-     "source": "./new-plugin",
-     "description": "Plugin description",
-     "version": "1.0.0",
-     "keywords": ["keyword1", "keyword2"],
-     "category": "category-name"
-   }
-   ```
-   Note: marketplace.json has structure `{ "name": "...", "plugins": [...] }` — add to the `plugins` array.
-5. Add to `release-please-config.json`:
-   ```json
-   "new-plugin": {
-     "component": "new-plugin",
-     "release-type": "simple",
-     "extra-files": [
-       {"type": "json", "path": ".claude-plugin/plugin.json", "jsonpath": "$.version"}
-     ],
-     "changelog-sections": [
-       {"type": "feat", "section": "Features"},
-       {"type": "fix", "section": "Bug Fixes"},
-       {"type": "perf", "section": "Performance"},
-       {"type": "refactor", "section": "Code Refactoring"},
-       {"type": "docs", "section": "Documentation"}
-     ]
-   }
-   ```
-6. Add to `.release-please-manifest.json`:
-   ```json
-   "new-plugin": "1.0.0"
-   ```
-7. Enable it in `.claude/settings.json` so the repo dogfoods it:
-   ```json
-   "enabledPlugins": { "new-plugin@laurigates-claude-plugins": true }
-   ```
-   The `Plugin: Enablement drift` check (`scripts/check-enabled-plugins-drift.sh`) fails CI if a marketplace plugin is left disabled.
-
-### Deleting a Plugin
-
-1. Remove plugin directory
-2. Remove entry from `.claude-plugin/marketplace.json`
-3. Remove package from `release-please-config.json`
-4. Remove version from `.release-please-manifest.json`
-5. Remove the `<plugin>@laurigates-claude-plugins` key from `.claude/settings.json` `enabledPlugins`
 
 ## Git Workflow
 
@@ -247,16 +128,6 @@ Refs #99"
 # PR title must also be conventional
 gh pr create --title "feat(git-plugin): add new workflow"
 ```
-
-## Development Workflow
-
-1. **Research documentation** - Use context7, web search
-2. **Plan skill structure** - Decide granularity, scope
-3. **Write skills** - Follow standard structure
-4. **Update all metadata files** - See Plugin Lifecycle section
-5. **Commit early** - Use conventional commit format (see Git Workflow section)
-6. **Test** - Verify skills load and work
-7. **Create PR** - Use conventional commit format for title (drives automation)
 
 ## Local-model export
 

--- a/scripts/check-docs-index.sh
+++ b/scripts/check-docs-index.sh
@@ -312,7 +312,7 @@ if [ "$emit_issue_body" = true ]; then
       echo "| $sev | \`$typ\` | $msg |"
     done
     echo ""
-    echo "See \`.claude/rules\` and the Plugin Lifecycle section of CLAUDE.md. Tracked under the recurring Layer 1 audit (#1460)."
+    echo "See \`.claude/rules\` and the Plugin Lifecycle section of the \`/plugin-authoring\` skill. Tracked under the recurring Layer 1 audit (#1460)."
   fi
 else
   echo "=== DOCS INDEX AUDIT ==="


### PR DESCRIPTION
Promotes the four authoring procedures out of `CLAUDE.md` into a repo-internal skill. Slice A of #2140 — the highest-value cut the context-engineering benchmark identified.

## Why

`CLAUDE.md` is paid for on **every turn of every session**. Four of its sections — `Creating New Skills`, `Creating User-Invocable Skills`, `Plugin Lifecycle`, `Development Workflow` — are procedures with a clear trigger: they only matter when someone actually authors a skill or plugin, and are dead weight when the user is debugging a hook.

Both context-engineering benchmark judges reached this independently and named the same remedy:

> Promote the authoring procedures (Quick Start, Creating User-Invocable Skills, Plugin Lifecycle, Development Workflow) into one plugin-authoring skill referenced by name, leaving CLAUDE.md as repo blurb plus rules index plus gotchas.
> — `docs/benchmarks/2026-07-context-engineering/judgments/claude-md_j2.json`

`## Plugin Lifecycle` carries verdict `promote-to-skill` in both judgment files.

## Numbers

| | Before | After |
|---|---|---|
| `CLAUDE.md` chars | 18,230 | **13,366** (−4,864) |
| `C5_ALWAYS_LOADED_CHARS` | 99,600 | **94,736** |
| Headroom under the 100,000 ratchet | 400 | **5,264** |

The ratchet had 400 characters of headroom — the next rule or CLAUDE.md addition would have broken it. (Measured in isolation against `main`; #2211 and #2212 cut the same budget further on their own branches.)

## Where it went, and why there

`.claude/skills/plugin-authoring/SKILL.md` — a **repo-internal meta-skill**, not a published plugin. The content is entirely about *this* repo's plumbing (`marketplace.json`, `release-please-config.json`, the enablement-drift gate) and would be noise in any consumer. It matches the existing `.claude/skills/docs-refresh` precedent.

Verified this incurs no metadata debt: every relevant guard scopes discovery to `*-plugin/` directories — `audit-skill-descriptions.py` `find_skills()` (`root.glob("*-plugin")`), `plugin-compliance-check.sh:17`, `check-docs-index.sh:91` — and `check-context-command-execution.sh` excludes `.claude/skills/` by name. So no marketplace entry, release-please package, `PLUGIN-MAP.md` row, or diagram node is owed.

Content moved **verbatim**. The only edits are two now-cross-file pointers (`see Project Structure above` → `in CLAUDE.md`; `see Git Workflow section` → `.claude/rules/conventional-commits.md`) and an added `## Verify` section naming the two guards that catch dangling metadata.

## What deliberately stayed in CLAUDE.md

The benchmark's counter-finding: the gotchas are the part that earns always-loaded tokens. Untouched — the blueprint constrained-dogfooding table with its `disabled_reason` warning, the consumer-only autonomy-level-3 caveat, the deliberately non-matching `blueprint` commit scope, the pi skill-listing budget caveat, the rules index, and `Project Structure` / `Plugin Organization` / `Git Workflow` / `Conventions`.

## Inbound references repointed in the same commit

Grepped for every reference to the moved headings; two were live and both are updated here rather than left dangling:

- `scripts/check-docs-index.sh:315` — its remediation hint
- `.claude/rules/skill-consolidation.md` — two references to `CLAUDE.md § Plugin Lifecycle`

The `docs/benchmarks/` JSON mentions are an immutable measurement record and are intentionally untouched.

## Verification

```
python3 scripts/check-context-engineering.py --strict   # exit 0, C5=94736
bash scripts/check-docs-index.sh                        # STATUS=OK, 44/44 rules indexed
bash scripts/plugin-compliance-check.sh                 # exit 0, zero ❌
bash scripts/check-agent-failure-contract.sh            # exit 0
bash scripts/check-loop-integrity.sh --strict           # STATUS=OK ISSUE_COUNT=0
bash scripts/check-subagent-types.sh                    # STATUS=WARN ISSUE_COUNT=6 — pre-existing
```

The 6 `check-subagent-types.sh` warnings are pre-existing bare-but-resolvable names in `evaluate-plugin` / `testing-plugin`, untouched by this change.

## One hook was skipped, and it found a real bug

`check-version-pin-coverage` was skipped via `SKIP=` (the other 57 pre-commit hooks ran and passed). It fails on `dist/opencode/skills/configure-surface/SKILL.md` — a **gitignored, stale rulesync build artifact** predating #2175, not anything in this diff.

That is a guard defect, filed separately: `check-version-pin-coverage.sh:178` prunes `.claude/worktrees/` but not `dist/`, while its sibling `lint-context-commands.sh:63` explicitly excludes `dist/`. Because `dist/` is never committed, CI cannot see it — so it silently blocks *local* commits for anyone holding a stale export, the same local-only-invisible shape as #2141.

Refs #2140
