### PR TITLE
ci: run orchestration-only jobs on ubuntu-slim

### DIFF
--- a/.github/workflows/auto-resolve-conflicts.yml
+++ b/.github/workflows/auto-resolve-conflicts.yml
@@ -23,7 +23,8 @@ permissions:
 
 jobs:
   find-conflicts:
-    runs-on: ubuntu-latest
+    # Orchestration only (scripts + `gh`) — 1-CPU slim runner is 3x cheaper.
+    runs-on: ubuntu-slim
     outputs:
       matrix: ${{ steps.find.outputs.matrix }}
       has_conflicts: ${{ steps.find.outputs.has_conflicts }}

--- a/.github/workflows/obsidian-cli-changelog.yml
+++ b/.github/workflows/obsidian-cli-changelog.yml
@@ -25,7 +25,8 @@ env:
 
 jobs:
   check-cli-doc:
-    runs-on: ubuntu-latest
+    # Orchestration only (scripts + `gh`) — 1-CPU slim runner is 3x cheaper.
+    runs-on: ubuntu-slim
     outputs:
       has_updates: ${{ steps.compare.outputs.has_updates }}
       latest_sha: ${{ steps.fetch.outputs.latest_sha }}

--- a/.github/workflows/plugin-enablement-drift.yml
+++ b/.github/workflows/plugin-enablement-drift.yml
@@ -30,7 +30,8 @@ permissions:
 
 jobs:
   drift:
-    runs-on: ubuntu-latest
+    # Orchestration only (scripts + `gh`) — 1-CPU slim runner is 3x cheaper.
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/research-radar.yml
+++ b/.github/workflows/research-radar.yml
@@ -24,7 +24,8 @@ permissions:
 
 jobs:
   gather:
-    runs-on: ubuntu-latest
+    # Orchestration only (scripts + `gh`) — 1-CPU slim runner is 3x cheaper.
+    runs-on: ubuntu-slim
     outputs:
       candidate_count: ${{ steps.fetch.outputs.candidate_count }}
       should_skip: ${{ steps.existing.outputs.should_skip }}

--- a/.github/workflows/scheduled-audits.yml
+++ b/.github/workflows/scheduled-audits.yml
@@ -12,7 +12,8 @@ permissions:
 
 jobs:
   blueprint-health:
-    runs-on: ubuntu-latest
+    # Orchestration only (scripts + `gh`) — 1-CPU slim runner is 3x cheaper.
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -50,7 +51,8 @@ jobs:
             --body-file /tmp/issue-body.md
 
   infra-compliance:
-    runs-on: ubuntu-latest
+    # Orchestration only (scripts + `gh`) — 1-CPU slim runner is 3x cheaper.
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -241,7 +243,8 @@ jobs:
             ```
 
   docs-index:
-    runs-on: ubuntu-latest
+    # Orchestration only (scripts + `gh`) — 1-CPU slim runner is 3x cheaper.
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/stranded-work-audit.yml
+++ b/.github/workflows/stranded-work-audit.yml
@@ -29,7 +29,8 @@ permissions:
 
 jobs:
   stranded-work:
-    runs-on: ubuntu-latest
+    # Orchestration only (scripts + `gh`) — 1-CPU slim runner is 3x cheaper.
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/sync-git-repo-agent-prompts.yml
+++ b/.github/workflows/sync-git-repo-agent-prompts.yml
@@ -29,7 +29,8 @@ permissions:
 
 jobs:
   sync:
-    runs-on: ubuntu-latest
+    # Orchestration only (scripts + `gh`) — 1-CPU slim runner is 3x cheaper.
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout claude-plugins
         uses: actions/checkout@v6

--- a/.github/workflows/sync-vault-agent-prompts.yml
+++ b/.github/workflows/sync-vault-agent-prompts.yml
@@ -30,7 +30,8 @@ permissions:
 
 jobs:
   sync:
-    runs-on: ubuntu-latest
+    # Orchestration only (scripts + `gh`) — 1-CPU slim runner is 3x cheaper.
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout claude-plugins
         uses: actions/checkout@v6


### PR DESCRIPTION
## What

Move 10 orchestration-only jobs across 8 workflows from `ubuntu-latest` to `ubuntu-slim`.

| Workflow | Job(s) moved | Left on `ubuntu-latest` |
|---|---|---|
| `plugin-enablement-drift.yml` | `drift` | — |
| `stranded-work-audit.yml` | `stranded-work` | — |
| `scheduled-audits.yml` | `blueprint-health`, `infra-compliance`, `docs-index` | `agentic-audit` |
| `obsidian-cli-changelog.yml` | `check-cli-doc` | `claude-review` |
| `auto-resolve-conflicts.yml` | `find-conflicts` | `resolve` |
| `research-radar.yml` | `gather` | `claude-assess` |
| `sync-git-repo-agent-prompts.yml` | `sync` | — |
| `sync-vault-agent-prompts.yml` | `sync` | — |

## Why

This repo is **71% of the portfolio's Actions minutes** — 58,411 of 81,420 standard-Linux minutes in 2026, and the trend is compounding: 8.7k (May) → 18.4k (Jun) → **27.9k (Jul)**, with July the first month to incur net charges.

`ubuntu-slim` is $0.002/min vs $0.006/min — 3x cheaper. Every job moved here is scripts + `gh` + `uv`/`bun`, with no compilation, no Docker, no `sudo`/`apt`, and no parallelism-dependent step (checked: no `xargs -P`, `parallel`, or `-j<N>`). `uv` and `bun` are downloaded by their setup actions on *both* images, so losing slim's absent tool cache costs nothing here.

## Verification

This repo has already run `release-please.yml`, `validate-plugin-configs.yml`, and `lint-context-commands.yml` on `ubuntu-slim` since 2026-03 — ~1.2–1.5k min/month, no failures. This extends a proven configuration rather than introducing one.

Each edit was applied by script and re-parsed as YAML, asserting the target jobs read `ubuntu-slim` and every sibling job still reads `ubuntu-latest`.

## What deliberately stays

- All `claude-code-action` jobs (`agentic-audit`, `claude-review`, `resolve`, `claude-assess`, plus `claude.yml`, `plugin-pr-checks`, `release-pr-doc-audit`, `skill-splitter`, `github-workflow-auto-fix`). Slim is plausible for these — they are API-wait-bound, not CPU-bound — but unproven, and they are the long-running jobs, so a regression would be expensive. Worth a measured trial separately.
- `test-skill-scripts.yml` and `test-adapters.yml` — genuine test suites where 1 CPU could be a real slowdown.
- `renovate.yml` — `renovatebot/github-action` runs Renovate in a Docker container; slim has no Docker daemon.

Companion PRs: laurigates/.github#44 (shared reusable workflows) and a 23-repo `release-please` sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UuZtyXzArr3RU2APRD6Q31