### PR TITLE
feat(hooks-plugin): refuse agent merges of external-contributor PRs

### DIFF
--- a/hooks-plugin/.claude-plugin/plugin.json
+++ b/hooks-plugin/.claude-plugin/plugin.json
@@ -67,6 +67,21 @@
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/auto-checkpoint.sh",
             "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/external-pr-merge-guard.sh",
+            "timeout": 15000
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__github__merge_pull_request",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/external-pr-merge-guard.sh",
+            "timeout": 15000
           }
         ]
       },

--- a/hooks-plugin/README.md
+++ b/hooks-plugin/README.md
@@ -125,6 +125,30 @@ A PreToolUse hook that blocks write operations on protected branches (main, mast
 
 **Toggle:** `export CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1` in your shell environment (e.g. in a personal repo, dotfiles, or main-branch-dev workflow). This is a **human-operator** opt-in — inline prefixes like `CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 git commit ...` on a Bash command are intentionally not honored, so that agents cannot self-serve the bypass. When blocked on a protected branch, an agent should follow `.claude/rules/handling-blocked-hooks.md` and delegate to the user instead.
 
+### external-pr-merge-guard.sh
+
+A PreToolUse hook that refuses to let an agent merge a pull request authored by anyone other than the authenticated user or a bot.
+
+A public repo attracts drive-by PRs, and merge tooling is built for bulk-merging your *own* and bots' PRs. A stranger's PR riding that bulk reflex is merged code nobody read — and a PR that adds a workflow, a hook, or a shell script executes on merge. Deciding whether an outside contribution is trustworthy is a human judgement call, so the agent path is closed and pointed at the human one.
+
+| Author of the PR | Behavior |
+|------------------|----------|
+| The authenticated user (`gh api user`) | Allowed silently |
+| A bot — `is_bot`, an `app/<name>` login, or a `<name>[bot]` login | Allowed silently |
+| Anyone else | **Denied**, naming the author, their `author_association`, and which touched paths execute |
+| Not determinable (no network, unresolvable `$var` selector, bad PR number) | **Denied** — "cannot verify" is not "safe" |
+| Any non-merge command | Allowed, immediately |
+
+Covers every merge route: `gh pr merge` (in any flag order, inside a compound command, with or without `--repo`), `gh api ... /pulls/N/merge`, and the GitHub MCP `merge_pull_request` tool. `--admin` does not bypass it.
+
+**Does not defer to auto mode**, unlike `branch-protection.sh`. Auto mode's classifier models destructive-git and protected-branch risk; it has no notion of PR *authorship trust*, so deferring would leave the gap open rather than avoid a double-gate.
+
+The human-side counterpart lives in the `ghsq`/`ghrb` zsh wrappers (dotfiles): external PRs are hidden from the merge picker by default (`ghsq -x` includes them, marked `⚠`) and merging one requires typing `merge` — never a single keypress, and never swept up by `a`=all.
+
+**Toggle:** `export CLAUDE_HOOKS_DISABLE_EXTERNAL_PR_MERGE=1` in your shell environment. Like branch protection, this is a **human-operator** opt-in — an inline `CLAUDE_HOOKS_DISABLE_EXTERNAL_PR_MERGE=1 gh pr merge ...` prefix is intentionally not honored, so agents cannot self-serve the bypass.
+
+**Tests:** `bash hooks-plugin/hooks/test-external-pr-merge-guard.sh` (hermetic — `gh` is stubbed).
+
 ### auto-checkpoint.sh
 
 A PreToolUse hook that creates a git stash checkpoint before destructive operations.
@@ -369,6 +393,7 @@ Every hook can be individually enabled or disabled via environment variables. Se
 |------|-----------------|---------|
 | secret-protection.sh | `CLAUDE_HOOKS_DISABLE_SECRET_PROTECTION=1` | Enabled |
 | branch-protection.sh | `CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1` | Enabled |
+| external-pr-merge-guard.sh | `CLAUDE_HOOKS_DISABLE_EXTERNAL_PR_MERGE=1` | Enabled |
 | auto-checkpoint.sh | `CLAUDE_HOOKS_DISABLE_AUTO_CHECKPOINT=1` | Enabled |
 | permission-auto-approve.sh | `CLAUDE_HOOKS_DISABLE_PERMISSION_AUTO=1` | Enabled |
 | task-completeness.sh | `CLAUDE_HOOKS_DISABLE_TASK_COMPLETENESS=1` | Enabled |

--- a/hooks-plugin/docs/feature-flags.md
+++ b/hooks-plugin/docs/feature-flags.md
@@ -42,6 +42,7 @@ explicit action, not an env flag. Their own opt-out knobs are listed below.
 |---|---|---|
 | `CLAUDE_HOOKS_DISABLE_SECRET_PROTECTION` | Blocking access to secret files / env-var exposure | `hooks/secret-protection.sh` |
 | `CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION` | Blocking writes on `main`/`master` (**human-operator only** — inline prefixes are ignored so agents can't self-serve) | `hooks/branch-protection.sh` |
+| `CLAUDE_HOOKS_DISABLE_EXTERNAL_PR_MERGE` | Blocking merges of PRs authored by someone other than you or a bot (**human-operator only** — inline prefixes are ignored so agents can't self-serve) | `hooks/external-pr-merge-guard.sh` |
 | `CLAUDE_HOOKS_DISABLE_AUTO_CHECKPOINT` | Auto-stash checkpoint before destructive git/`rm -rf` ops | `hooks/auto-checkpoint.sh` |
 | `CLAUDE_HOOKS_DISABLE_PERMISSION_AUTO` | Auto-approve/deny of safe/dangerous ops at PermissionRequest | `hooks/permission-auto-approve.sh` |
 | `CLAUDE_HOOKS_DISABLE_PERMISSION_REQUEST` | The permission-request hook | `skills/hooks-permission-request-hook/` |

--- a/hooks-plugin/hooks/external-pr-merge-guard.sh
+++ b/hooks-plugin/hooks/external-pr-merge-guard.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# PreToolUse hook — refuses to let an agent merge a PR authored by someone other
+# than the repo operator or a known bot.
+#
+# Why this exists: a public repo attracts drive-by PRs, and the merge tooling
+# (both the human `ghsq`/`ghrb` wrappers and an agent's `gh pr merge`) is built
+# for bulk-merging your OWN and bots' PRs. A stranger's PR riding that bulk
+# reflex is merged code you never read — and PRs that add a workflow, a hook, or
+# a shell script execute on merge. Vetting an external contribution is a human
+# judgement call, so the agent path is closed and pointed at the human one.
+#
+# Behavior:
+#   - `gh pr merge`, `gh api -X PUT .../pulls/N/merge`, and the GitHub MCP
+#     merge_pull_request tool are checked.
+#   - Author == the authenticated user, or a bot → allowed silently.
+#   - Anyone else → denied, with the author, the association, and which touched
+#     paths execute, plus the human command to run instead.
+#   - Author cannot be determined (network, an unresolvable `$var` selector in a
+#     loop, a bad PR number) → denied. "Can't verify" is not "safe".
+#   - Any command that is not a merge → allowed, immediately.
+#
+# Deliberately does NOT defer to permission mode "auto" (unlike
+# branch-protection.sh). Auto mode's classifier models destructive-git and
+# protected-branch risk; it has no notion of PR *authorship trust*, so deferring
+# would not be avoiding a double-gate, it would be leaving the gap open.
+#
+# Toggle: a human operator can export CLAUDE_HOOKS_DISABLE_EXTERNAL_PR_MERGE=1
+# in their shell environment. The toggle is only honored when set in the process
+# environment — inline prefixes like
+# `CLAUDE_HOOKS_DISABLE_EXTERNAL_PR_MERGE=1 gh pr merge 5` on the command line
+# are intentionally NOT honored, so agents cannot self-serve the bypass.
+#
+# Matches: Bash, mcp__github__merge_pull_request
+# Detects: gh pr merge / gh api PUT pulls/N/merge / MCP merge_pull_request
+# Allows: your own PRs, bot PRs (release-please, renovate, dependabot, …), and
+#         every non-merge command
+
+set -euo pipefail
+
+# Human-operator escape hatch: only honored from the process environment.
+[ "${CLAUDE_HOOKS_DISABLE_EXTERNAL_PR_MERGE:-}" = "1" ] && exit 0
+
+command -v gh >/dev/null 2>&1 || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+INPUT=$(cat)
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty')
+HOOK_CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty')
+
+deny() {
+  local reason="$1" json_reason
+  json_reason=$(printf '%s' "$reason" | jq -Rs .)
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$json_reason"
+  exit 0
+}
+
+# ---------------------------------------------------------------------------
+# Work out which PR (if any) this tool call would merge.
+#   PR_SELECTOR — number / URL / branch, or empty to mean "current branch's PR"
+#   PR_REPO     — OWNER/REPO, or empty for the repo at the cwd
+# ---------------------------------------------------------------------------
+PR_SELECTOR=""
+PR_REPO=""
+
+case "$TOOL_NAME" in
+  mcp__github__merge_pull_request)
+    PR_SELECTOR=$(printf '%s' "$INPUT" | jq -r '.tool_input.pullNumber // .tool_input.pull_number // empty')
+    OWNER=$(printf '%s' "$INPUT" | jq -r '.tool_input.owner // empty')
+    REPO=$(printf '%s' "$INPUT" | jq -r '.tool_input.repo // empty')
+    [ -n "$OWNER" ] && [ -n "$REPO" ] && PR_REPO="$OWNER/$REPO"
+    ;;
+  Bash)
+    COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty')
+    [ -z "$COMMAND" ] && exit 0
+
+    # Fast bail-out: the overwhelming majority of Bash calls are not merges.
+    # Allow leading `VAR=value` assignments so an inline-bypass attempt is still
+    # recognised as a merge rather than slipping past this filter.
+    if ! printf '%s' "$COMMAND" | grep -Eq 'gh[[:space:]]+pr[[:space:]]+merge|pulls/[^/[:space:]]+/merge'; then
+      exit 0
+    fi
+
+    # `gh api ... repos/O/R/pulls/N/merge` (any method; PUT is the merge verb,
+    # but a bare `gh api <path>` on that route also merges via POST-less PUT
+    # default in some wrappers, so don't gate on the method).
+    API_PATH=$(printf '%s' "$COMMAND" | grep -oE 'repos/[^/[:space:]]+/[^/[:space:]]+/pulls/[0-9]+/merge' | head -1 || true)
+    if [ -n "$API_PATH" ]; then
+      PR_REPO=$(printf '%s' "$API_PATH" | awk -F/ '{print $2"/"$3}')
+      PR_SELECTOR=$(printf '%s' "$API_PATH" | awk -F/ '{print $5}')
+    else
+      # Isolate the `gh pr merge` invocation: take everything after the literal
+      # `merge`, stopping at the first shell operator so a trailing `&& echo ok`
+      # cannot be mistaken for the PR selector.
+      SEGMENT=$(printf '%s' "$COMMAND" \
+        | sed -n 's/.*gh[[:space:]]\{1,\}pr[[:space:]]\{1,\}merge[[:space:]]*//p' \
+        | sed 's/[;&|].*//' || true)
+
+      # First positional token, skipping flags AND the values of the flags that
+      # take one. Without the skip list, `gh pr merge --subject "feat: x" 5`
+      # would read `feat:` as the PR selector and check the wrong (or no) PR.
+      PR_SELECTOR=$(printf '%s\n' "$SEGMENT" | awk '
+        BEGIN { split("-b --body -F --body-file -m --match-head-commit -R --repo -s --subject --author-email -t --title", v, " ")
+                for (i in v) valued[v[i]] = 1 }
+        { for (i = 1; i <= NF; i++) {
+            if (skip)              { skip = 0; continue }
+            if ($i ~ /^-/)         { if ($i in valued) skip = 1; continue }
+            print $i; exit
+        } }')
+      # --repo/-R may appear either as a separate token or as --repo=OWNER/REPO.
+      PR_REPO=$(printf '%s\n' "$SEGMENT" | awk '
+        { for (i = 1; i <= NF; i++) {
+            if (($i == "-R" || $i == "--repo") && (i + 1) <= NF) { print $(i+1); exit }
+            if ($i ~ /^--repo=/) { sub(/^--repo=/, "", $i); print $i; exit }
+        } }')
+    fi
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Resolve the author and classify.
+# ---------------------------------------------------------------------------
+# Every gh lookup below must run in the directory the tool call targets, so a
+# `gh pr merge` with no --repo resolves the repo the agent is actually in. cd
+# once here rather than wrapping each call in `cd "$GH_DIR" && gh … || true`,
+# which folds a cd failure into the same `|| true` as a gh failure (SC2015).
+GH_DIR="${HOOK_CWD:-.}"
+[ -d "$GH_DIR" ] || GH_DIR="."
+cd "$GH_DIR" || exit 0
+
+ME=$(gh api user --jq '.login' 2>/dev/null || true)
+
+VIEW_ARGS=()
+[ -n "$PR_SELECTOR" ] && VIEW_ARGS+=("$PR_SELECTOR")
+[ -n "$PR_REPO" ] && VIEW_ARGS+=(--repo "$PR_REPO")
+
+META=$(gh pr view "${VIEW_ARGS[@]}" \
+        --json number,title,author,url \
+        --jq '[(.number|tostring), .author.login, (.author.is_bot|tostring), .title, .url] | @tsv' \
+        </dev/null 2>/dev/null || true)
+
+WHAT="${PR_REPO:+$PR_REPO}${PR_SELECTOR:+#$PR_SELECTOR}"
+[ -z "$WHAT" ] && WHAT="the current branch's PR"
+
+if [ -z "$META" ]; then
+  case "$PR_SELECTOR" in
+    *'$'*|*'`'*)
+      deny "Refusing to merge ${WHAT}: the PR selector is a shell variable, so this hook cannot tell whose PR it is. Merges of PRs authored by anyone other than the repo owner or a bot are not permitted from an agent. Resolve the PR numbers first (gh pr list --json number,author) and merge them one literal number at a time — each will be checked individually." ;;
+    *)
+      deny "Refusing to merge ${WHAT}: could not read the PR's author (gh pr view returned nothing — bad PR number, wrong repo, or no network). 'Cannot verify' is not 'safe', so this is denied rather than allowed. Check the PR exists and is reachable (gh pr view ${PR_SELECTOR:-} ${PR_REPO:+--repo $PR_REPO}), then retry." ;;
+  esac
+fi
+
+IFS=$'\t' read -r PR_NUM AUTHOR IS_BOT TITLE URL <<< "$META"
+
+if [ -z "$ME" ]; then
+  deny "Refusing to merge ${PR_REPO:-this repo}#${PR_NUM} (\"${TITLE}\"): could not determine the authenticated GitHub user (gh api user failed), so authorship cannot be checked against you. Denied rather than guessed. Fix gh auth (gh auth status) and retry."
+fi
+
+# A bot author renders differently depending on which gh subcommand produced it:
+# `gh pr view` gives is_bot=true with login "app/<name>"; the search API gives
+# is_bot=false with a "<name>[bot]" login. Accept every spelling — missing one
+# would flag release-please/renovate/dependabot as strangers and make this guard
+# noise that gets disabled.
+IS_TRUSTED=0
+[ "$AUTHOR" = "$ME" ] && IS_TRUSTED=1
+[ "$IS_BOT" = "true" ] && IS_TRUSTED=1
+case "$AUTHOR" in *'[bot]'|app/*) IS_TRUSTED=1 ;; esac
+
+[ "$IS_TRUSTED" = "1" ] && exit 0
+
+# ---------------------------------------------------------------------------
+# External author — build a denial that carries the facts a reviewer needs.
+# ---------------------------------------------------------------------------
+SLUG="$PR_REPO"
+if [ -z "$SLUG" ]; then
+  SLUG=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)
+fi
+
+ASSOC=""
+if [ -n "$SLUG" ]; then
+  ASSOC=$(gh api "repos/$SLUG/pulls/$PR_NUM" --jq '.author_association' </dev/null 2>/dev/null || true)
+fi
+
+# Which touched paths actually execute something? That is the difference between
+# "a typo fix" and "code that runs in CI or on the operator's machine".
+RISKY=$(gh pr view "${VIEW_ARGS[@]}" --json files --jq '.files[].path' </dev/null 2>/dev/null \
+  | awk '
+      /^\.github\/(workflows|actions)\// { print "    " $0 "  (CI executes this)"; next }
+      /\.(sh|bash|zsh)$/                 { print "    " $0 "  (shell)"; next }
+      /(^|\/)hooks\//                    { print "    " $0 "  (hook — runs on the operator machine)"; next }
+      /(^|\/)\.claude\//                 { print "    " $0 "  (Claude Code config / permissions)"; next }
+      /^(package\.json|pyproject\.toml|Cargo\.toml|mise\.toml|[jJ]ustfile|Makefile|Dockerfile|\.pre-commit-config\.yaml)$/ { print "    " $0 "  (build / tooling entry point)"; next }
+    ' || true)
+
+REASON="Refusing to merge ${SLUG:-this repo}#${PR_NUM} — it was written by someone else.
+
+  PR       ${SLUG:-?}#${PR_NUM}  \"${TITLE}\"
+  author   ${AUTHOR}${ASSOC:+  (${ASSOC})}
+  you      ${ME}
+  ${URL}"
+
+if [ -n "$RISKY" ]; then
+  REASON="${REASON}
+
+  This PR touches paths that EXECUTE:
+${RISKY}"
+fi
+
+REASON="${REASON}
+
+Vetting an outside contribution is a human judgement call, so an agent does not merge it. Do this instead:
+  1. Review it and report what it actually changes — read the diff (gh pr diff ${PR_NUM}${SLUG:+ --repo $SLUG}), and for any added CI action or dependency, say where the code comes from, whether the ref is pinned to a commit SHA or a mutable tag, and what it downloads or sends at runtime.
+  2. Leave the merge to the user: 'ghsq -x' shows external PRs and requires a typed confirmation, or 'gh pr merge ${PR_NUM}${SLUG:+ --repo $SLUG} --squash --delete-branch' run by them.
+
+Do not retry with different flags or a different merge route — this hook checks them all. Do not prefix CLAUDE_HOOKS_DISABLE_EXTERNAL_PR_MERGE=1 onto the command; it is only honored from the operator's own shell environment. See .claude/rules/handling-blocked-hooks.md."
+
+deny "$REASON"

--- a/hooks-plugin/hooks/test-external-pr-merge-guard.sh
+++ b/hooks-plugin/hooks/test-external-pr-merge-guard.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Regression tests for external-pr-merge-guard.sh
+#
+# Verifies the hook denies merges of PRs authored by anyone other than the
+# authenticated user or a bot, allows the trusted cases silently, and fails
+# CLOSED when authorship cannot be established.
+#
+# The hook contract: emit
+#   {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny",...}}
+# on stdout and exit 0 to block; exit 0 with no output to allow.
+#
+# `gh` is stubbed on PATH so the tests are hermetic — no network, no real repo.
+# The stub is driven by STUB_* env vars, mirroring the four author shapes that
+# actually occur in the wild:
+#   own login          → trusted
+#   app/<name>         + is_bot true   → trusted  (`gh pr view` bot rendering)
+#   <name>[bot]        + is_bot false  → trusted  (search-API bot rendering)
+#   anyone else                        → DENIED
+#
+# Run: bash hooks-plugin/hooks/test-external-pr-merge-guard.sh
+# Exit 0 = all tests pass, Exit 1 = failures
+set -euo pipefail
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/external-pr-merge-guard.sh"
+PASS=0
+FAIL=0
+
+TMPDIR=$(mktemp -d) || { echo "mktemp -d failed" >&2; exit 1; }
+# Guard the rm -rf target explicitly: an empty TMPDIR would make the trap
+# resolve to the CWD in a shared checkout (see check-git-sandbox-guards.sh).
+if [ -z "$TMPDIR" ] || [ ! -d "$TMPDIR" ]; then
+    echo "bad TMPDIR" >&2
+    exit 1
+fi
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# ---- gh stub -------------------------------------------------------------
+mkdir -p "$TMPDIR/bin"
+cat > "$TMPDIR/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+args="$*"
+case "$args" in
+  "api user --jq .login")
+      [ -n "${STUB_NO_ME:-}" ] && exit 1
+      printf '%s\n' "${STUB_ME-laurigates}" ;;
+  "repo view --json nameWithOwner"*)
+      printf '%s\n' "${STUB_SLUG-laurigates/claude-plugins}" ;;
+  *"--json number,title,author,url"*)
+      [ -n "${STUB_VIEW_FAIL:-}" ] && exit 1
+      # Real `gh pr view '$n'` cannot resolve an unexpanded shell variable —
+      # model that, or the loop case would look resolvable and the test would
+      # assert against the wrong denial path.
+      case "$args" in *'$'*) exit 1 ;; esac
+      printf '%s\t%s\t%s\t%s\t%s\n' "${STUB_NUM-42}" "${STUB_AUTHOR-laurigates}" \
+        "${STUB_ISBOT-false}" "${STUB_TITLE-a title}" "https://example.invalid/pr" ;;
+  *"pulls/"*"--jq .author_association")
+      printf '%s\n' "${STUB_ASSOC-FIRST_TIME_CONTRIBUTOR}" ;;
+  *"--json files"*)
+      printf '%s\n' ${STUB_FILES-.github/workflows/x.yml} ;;
+  *) echo "gh stub: unhandled: $args" >&2; exit 1 ;;
+esac
+STUB
+chmod +x "$TMPDIR/bin/gh"
+
+# ---- harness -------------------------------------------------------------
+# run <json> → prints "DENY"/"ALLOW" and sets $LAST_VERDICT + $LAST_REASON.
+#
+# NOTE: the globals only survive when `run` is called DIRECTLY. Calling it as
+# "$(run ...)" spawns a subshell, so any assertion on $LAST_REASON afterwards
+# would read a stale value from an earlier direct call — which silently passed
+# the wrong test. Assertions on the reason text therefore call `run` directly
+# and read $LAST_VERDICT instead of capturing stdout.
+LAST_REASON=""
+LAST_VERDICT=""
+run() {
+    local json="$1" out
+    out=$(printf '%s' "$json" | PATH="$TMPDIR/bin:$PATH" bash "$HOOK" 2>/dev/null || true)
+    LAST_REASON=$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null || true)
+    if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then LAST_VERDICT=DENY; else LAST_VERDICT=ALLOW; fi
+    echo "$LAST_VERDICT"
+}
+
+bash_json() { printf '{"tool_name":"Bash","cwd":"%s","tool_input":{"command":%s}}' "$TMPDIR" "$(printf '%s' "$1" | jq -Rs .)"; }
+
+ck() { # ck <desc> <expected> <actual>
+    if [ "$2" = "$3" ]; then printf '  ok   %s\n' "$1"; PASS=$((PASS + 1))
+    else printf '  FAIL %s — expected %s got %s\n' "$1" "$2" "$3"; FAIL=$((FAIL + 1)); fi
+}
+ck_reason() { # ck_reason <desc> <substring>
+    case "$LAST_REASON" in
+        *"$2"*) printf '  ok   %s\n' "$1"; PASS=$((PASS + 1)) ;;
+        *) printf '  FAIL %s — reason lacked %s\n' "$1" "$2"; FAIL=$((FAIL + 1)) ;;
+    esac
+}
+
+echo "== non-merge commands are untouched =="
+ck "git status"            ALLOW "$(run "$(bash_json 'git status')")"
+ck "gh pr view"            ALLOW "$(run "$(bash_json 'gh pr view 42')")"
+ck "gh pr list"            ALLOW "$(run "$(bash_json 'gh pr list --json number')")"
+ck "gh pr create"          ALLOW "$(run "$(bash_json 'gh pr create --title x')")"
+ck "unrelated tool"        ALLOW "$(run '{"tool_name":"Read","tool_input":{"file_path":"/x"}}')"
+
+echo "== trusted authors merge freely =="
+ck "own PR"  ALLOW "$(STUB_AUTHOR=laurigates run "$(bash_json 'gh pr merge 42 --squash')")"
+export STUB_AUTHOR='app/laurigates-release-please' STUB_ISBOT=true
+ck "bot, gh-pr-view rendering (app/, is_bot true)" ALLOW "$(run "$(bash_json 'gh pr merge 42 --squash')")"
+export STUB_AUTHOR='dependabot[bot]' STUB_ISBOT=false
+ck "bot, search rendering ([bot], is_bot false)"   ALLOW "$(run "$(bash_json 'gh pr merge 42 --squash')")"
+unset STUB_AUTHOR STUB_ISBOT
+
+echo "== external author is denied on every merge route =="
+export STUB_AUTHOR=joshua-trustabl STUB_NUM=2231 STUB_TITLE='Add Trustabl security scanning to CI'
+ck "gh pr merge <n>"                  DENY "$(run "$(bash_json 'gh pr merge 2231 --squash --delete-branch')")"
+ck "flags before the number"          DENY "$(run "$(bash_json 'gh pr merge --squash 2231')")"
+ck "no number (current branch PR)"    DENY "$(run "$(bash_json 'gh pr merge --squash')")"
+ck "--repo form"                      DENY "$(run "$(bash_json 'gh pr merge 2231 --repo laurigates/claude-plugins --squash')")"
+ck "--repo=OWNER/REPO form"           DENY "$(run "$(bash_json 'gh pr merge 2231 --repo=laurigates/claude-plugins --squash')")"
+ck "inside a compound command"        DENY "$(run "$(bash_json 'cd /tmp && gh pr merge 2231 --squash && echo done')")"
+ck "gh api PUT .../merge"             DENY "$(run "$(bash_json 'gh api -X PUT repos/laurigates/claude-plugins/pulls/2231/merge')")"
+ck "MCP merge_pull_request"           DENY "$(run '{"tool_name":"mcp__github__merge_pull_request","cwd":"'"$TMPDIR"'","tool_input":{"owner":"laurigates","repo":"claude-plugins","pullNumber":2231}}')"
+ck "--admin does not bypass"          DENY "$(run "$(bash_json 'gh pr merge 2231 --admin --squash')")"
+
+echo "== a flag VALUE is not mistaken for the PR selector =="
+# Without the value-flag skip list, `--subject "feat: x"` would be read as the
+# selector, checking the wrong PR (or none) and letting the merge through.
+ck "--subject with a value"  DENY "$(run "$(bash_json 'gh pr merge --squash --subject "feat: x" 2231')")"
+ck "-b with a value"         DENY "$(run "$(bash_json 'gh pr merge --squash -b "body text" 2231')")"
+
+echo "== the denial carries what a reviewer needs =="
+run "$(bash_json 'gh pr merge 2231 --squash')" >/dev/null
+ck_reason "names the author"          "joshua-trustabl"
+ck_reason "names you"                 "laurigates"
+ck_reason "shows the association"     "FIRST_TIME_CONTRIBUTOR"
+ck_reason "flags the CI path"         "CI executes this"
+ck_reason "gives the human route"     "ghsq -x"
+ck_reason "forbids self-serve bypass" "only honored from the operator"
+
+echo "== executable-path flagging =="
+STUB_FILES='README.md' run "$(bash_json 'gh pr merge 2231 --squash')" >/dev/null
+case "$LAST_REASON" in
+    *"EXECUTE"*) printf '  FAIL benign paths must not be flagged as executing\n'; FAIL=$((FAIL + 1)) ;;
+    *) printf '  ok   benign paths not flagged as executing\n'; PASS=$((PASS + 1)) ;;
+esac
+STUB_FILES='hooks-plugin/hooks/x.sh' run "$(bash_json 'gh pr merge 2231 --squash')" >/dev/null
+ck_reason "shell path flagged" "hooks-plugin/hooks/x.sh"
+
+echo "== fails CLOSED when authorship cannot be established =="
+# `run` called directly (not in $()) so $LAST_REASON survives for ck_reason.
+STUB_VIEW_FAIL=1 run "$(bash_json 'gh pr merge 2231 --squash')" >/dev/null
+ck "gh pr view fails"                      DENY "$LAST_VERDICT"
+ck_reason "explains the unverifiable case" "Cannot verify"
+ck "gh api user fails"     DENY "$(STUB_NO_ME=1 run "$(bash_json 'gh pr merge 2231 --squash')")"
+# shellcheck disable=SC2016  # the literal $n must reach the hook unexpanded
+run "$(bash_json 'for n in 1 2; do gh pr merge $n --squash; done')" >/dev/null
+ck "shell-variable selector"         DENY "$LAST_VERDICT"
+ck_reason "explains the loop case"   "shell variable"
+unset STUB_AUTHOR STUB_NUM STUB_TITLE
+
+echo "== operator escape hatch =="
+out=$(printf '%s' "$(bash_json 'gh pr merge 2231 --squash')" \
+      | STUB_AUTHOR=joshua-trustabl CLAUDE_HOOKS_DISABLE_EXTERNAL_PR_MERGE=1 \
+        PATH="$TMPDIR/bin:$PATH" bash "$HOOK" 2>/dev/null || true)
+if [ -z "$out" ]; then printf '  ok   env toggle disables the guard\n'; PASS=$((PASS + 1))
+else printf '  FAIL env toggle did not disable the guard\n'; FAIL=$((FAIL + 1)); fi
+# An INLINE prefix must NOT work — that is an agent self-serving the bypass.
+ck "inline prefix does not bypass" DENY \
+   "$(STUB_AUTHOR=joshua-trustabl run "$(bash_json 'CLAUDE_HOOKS_DISABLE_EXTERNAL_PR_MERGE=1 gh pr merge 2231 --squash')")"
+
+echo
+printf '%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What

Adds `hooks-plugin/hooks/external-pr-merge-guard.sh`, a PreToolUse hook that refuses to let an agent merge a PR authored by anyone other than the authenticated user or a bot.

Covers every merge route — `gh pr merge` (any flag order, inside a compound command, with or without `--repo`), `gh api .../pulls/N/merge`, and MCP `merge_pull_request`. `--admin` does not bypass it.

## Why

This repo is public, so it attracts drive-by PRs, but the merge tooling is built for bulk-merging *our own and bots'* PRs. A stranger's PR riding that reflex is merged code nobody read — and a PR that adds a workflow, a hook, or a shell script **executes on merge**.

Not hypothetical: **#1222** was merged from a `FIRST_TIME_CONTRIBUTOR` with no review and no comments. It rewrote `task-completeness.sh` — a Stop hook that runs locally — shipped a broken TODO scan that had to be repaired in #1229, and flipped the file mode `100755 → 100644`, which is still un-restored today. One un-vetted merge, two defects, neither noticed at merge time.

## Three details worth reviewing

- **A bot author renders three different ways**, and getting this wrong in either direction breaks the guard. `gh pr view` reports `is_bot=true` with an `app/<name>` login; the search API reports **`is_bot=false`** with a `<name>[bot]` login and `type=Bot`. Keying on `is_bot` alone would flag release-please/renovate/dependabot as strangers, making the guard noise that gets disabled. All four spellings are accepted.
- **The PR selector is parsed past value-taking flags.** Without the skip list, `gh pr merge --subject "feat: x" 5` reads `feat:` as the selector and checks the wrong PR (or none) — i.e. it would let the merge through. Covered by a test.
- **It deliberately does not defer to permission mode `auto`**, unlike `branch-protection.sh`. Auto mode models destructive-git and protected-branch risk; it has no notion of PR *authorship trust*, so deferring would leave the gap open rather than avoid a double-gate.

## Fails closed

If authorship cannot be established — no network, a `$var` selector in a loop, a bad PR number — the merge is **denied**, not allowed. "Cannot verify" is not "safe".

## Verification

`hooks-plugin/hooks/test-external-pr-merge-guard.sh` — hermetic, `gh` stubbed on PATH:

```
$ bash hooks-plugin/hooks/test-external-pr-merge-guard.sh
34 passed, 0 failed
```

Also exercised against live data in this repo: denies #2231 (external, correctly flagging that it touches `.github/workflows/`), allows #2237 (mine) silently with zero output. `shellcheck` clean at every severity; all pre-commit hooks pass.

## Human-side counterpart

The matching guard for the interactive path lives in the dotfiles `ghsq`/`ghrb` wrappers: external PRs are hidden from the merge picker by default (`ghsq -x` includes them, marked `⚠`), and merging one requires typing `merge` — never a keypress, and never swept up by `a`=all.

Refs #2231

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXmv48FuSrSLh9CKha7d3R