### PR TITLE
chore(scripts): retire the bare-Bash detector from infra-compliance-check

### DIFF
--- a/scripts/infra-compliance-check.sh
+++ b/scripts/infra-compliance-check.sh
@@ -216,14 +216,28 @@ while IFS= read -r -d '' wf; do
   fi
 done < <(find .github/workflows -maxdepth 1 -name '*.yml' -print0 2>/dev/null | sort -z)
 
-# Broad Bash permissions in skills
-while IFS= read -r -d '' skill_file; do
-  at_field=$(head -50 "$skill_file" 2>/dev/null | grep -m1 "^allowed-tools:" | sed 's/^[^:]*:[[:space:]]*//' || echo "")
-  if echo "$at_field" | grep -qE '(^|,\s*)Bash(\s*,|$)' 2>/dev/null; then
-    security_total=$((security_total+1))
-    security_rows+=("🟡 | ${skill_file#./} | Broad Bash permission (no command pattern)")
-  fi
-done < <(find . -path '*/skills/*' \( -iname "SKILL.md" -o -iname "skill.md" \) -print0 2>/dev/null)
+# NOTE: a "Broad Bash permission (no command pattern)" 🟡 check used to sit here,
+# flagging every skill whose `allowed-tools` grants a bare unscoped `Bash`. It was
+# REMOVED deliberately — do not reinstate it.
+#
+# A bare `Bash` in a *skill's* `allowed-tools` is the ratified house standard, not a
+# finding (see `.claude/rules/agentic-permissions.md`). Skill frontmatter can only
+# SUBTRACT from the session's grants, never add, so enumerating narrow
+# `Bash(<command> *)` patterns there buys no safety the settings.json layer isn't
+# already providing — while costing a permission prompt for every command the author
+# failed to predict. Narrow patterns belong in `settings.json`, which is where they
+# actually gate anything.
+#
+# Left in place, this check scored the repo down for following its own standard: it
+# fired on 191 of 408 SKILL.md files and inflated `security_total` once per offender
+# while never incrementing `security_pass`, so the Security Posture score fell as the
+# corpus grew more compliant. Its `find . -path '*/skills/*'` also had no
+# `.claude/worktrees/` or `dist/` prune, so it re-walked every agent worktree clone
+# and the rulesync build output (the #1492 / #1548 / #2214 class) — the >120s runtime
+# and a double count.
+#
+# The real defect worth linting is the opposite one: a `Bash` grant in a skill that
+# runs no shell at all. That is `scripts/check-unused-bash-grant.sh`, not this file.
 
 ##########
 # Scoring


### PR DESCRIPTION
## Why now

`scheduled-audits.yml` runs this script on `0 9 1 * *` — **next fire 2026-08-01 09:00 UTC**. Without this, the monthly audit issue asserts that 191 skills are insecure, in the same week the convention they follow is being written down.

## The defect

The Security Posture section flagged every skill whose `allowed-tools` grants a bare unscoped `Bash` as 🟡 *"Broad Bash permission (no command pattern)"*. That is the house standard, not a finding — so the check **scored the repo down for following its own convention**.

Measured on the current corpus:

| | findings | Security posture | Overall |
|---|---|---|---|
| before | **191** | **1/15** (26/217 clean) | 78/100 |
| after | 0 | **15/15** (26/26 clean) | 92/100 |

Note the direction: the loop incremented `security_total` once per offender but **never** incremented `security_pass`, so the score got *worse* as the corpus grew more compliant. 191 of 408 SKILL.md files were dragging a 15-point category down to 1.

## Why bare `Bash` is correct in a skill

Skill frontmatter can only **subtract** from the session's grants, never add. So enumerating narrow `Bash(<command> *)` patterns in a skill's `allowed-tools` buys no safety the `settings.json` layer isn't already providing — while costing a permission prompt for every command the author failed to predict. Narrow patterns belong in `settings.json`, which is where they actually gate anything.

(The convention is being written down explicitly in the follow-up that reconciles `agentic-permissions.md` and `skill-development.md`, which currently disagree. This PR removes the detector that contradicts both.)

## It was also the >120s hang

The block's walk had no `.claude/worktrees/` or `dist/` prune — the #1492 / #1548 / #2214 class:

```bash
find . -path '*/skills/*' \( -iname "SKILL.md" -o -iname "skill.md" \) -print0
```

Each agent worktree is a full repo clone. In a checkout with **63** worktrees this walked ~26,000 files instead of ~408, and the whole script **timed out past 120s**:

```
PRE-FIX,  shared checkout (63 worktrees): TIMEOUT >120,000 ms
PRE-FIX,  clean tree:                      12,345 ms
FIXED,    clean tree:                       4,959 ms
```

It was the **only** unbounded recursive walk in the file — every remaining `find` is `-maxdepth 1` or scoped to a single plugin's `skills/` dir, so runtime no longer scales with worktree count. This subsumes what was scoped as a separate prune fix.

## What replaces it

A comment in its place explaining why it must not be reinstated, and pointing at the lint that catches the defect actually worth catching: **a `Bash` grant in a skill that runs no shell at all**. That check ships separately as `scripts/check-unused-bash-grant.sh`.

`shellcheck` clean.
