### PR TITLE
ci: declare explicit permissions on the thin reusable-workflow callers

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,16 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+# Explicit least-privilege grant. A called workflow cannot escalate above its
+# caller, and a caller `permissions:` block sets every UNLISTED scope to `none` —
+# so this must mirror the reusable's own declaration exactly. Verified against
+# laurigates/.github at authoring time.
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
 jobs:
   review:
     uses: laurigates/.github/.github/workflows/reusable-claude-review.yml@main

--- a/.github/workflows/enforce-conventional-commits.yml
+++ b/.github/workflows/enforce-conventional-commits.yml
@@ -7,6 +7,13 @@ on:
       - edited
       - synchronize
 
+# Explicit least-privilege grant. A called workflow cannot escalate above its
+# caller, and a caller `permissions:` block sets every UNLISTED scope to `none` —
+# so this must mirror the reusable's own declaration exactly. Verified against
+# laurigates/.github at authoring time.
+permissions:
+  pull-requests: write
+
 jobs:
   conventional-commits:
     uses: laurigates/.github/.github/workflows/reusable-enforce-conventional-commits.yml@main

--- a/.github/workflows/fix-release-conflicts.yml
+++ b/.github/workflows/fix-release-conflicts.yml
@@ -9,6 +9,15 @@ on:
     - cron: "23,53 * * * *"
   workflow_dispatch: {}
 
+# Explicit least-privilege grant. A called workflow cannot escalate above its
+# caller, and a caller `permissions:` block sets every UNLISTED scope to `none` —
+# so this must mirror the reusable's own declaration exactly. Verified against
+# laurigates/.github at authoring time.
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
 jobs:
   fix-conflicts:
     uses: laurigates/.github/.github/workflows/reusable-fix-release-conflicts.yml@main

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -26,6 +26,16 @@ on:
           - debug
           - warn
 
+# Explicit least-privilege grant. A called workflow cannot escalate above its
+# caller, and a caller `permissions:` block sets every UNLISTED scope to `none` —
+# so this must mirror the reusable's own declaration exactly. Verified against
+# laurigates/.github at authoring time.
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  packages: read
+
 jobs:
   renovate:
     uses: laurigates/.github/.github/workflows/reusable-renovate.yml@main


### PR DESCRIPTION
Prerequisite for flipping this repo's `default_workflow_permissions` to `read`.

## Why

Four workflows are **bare callers** of reusables in `laurigates/.github` that declare write permissions internally. A called workflow **cannot escalate above its caller**, so once the repo default becomes `read`, all four break — including `enforce-conventional-commits`, which produces the `conventional-commits` check we intend to make required.

## What each block grants

Read from each reusable's **own** `permissions:` declaration in `laurigates/.github`, not inferred:

| Caller | Grant |
|---|---|
| `claude-code-review.yml` | `contents: read`, `pull-requests: write`, `issues: write`, `id-token: write` |
| `enforce-conventional-commits.yml` | `pull-requests: write` |
| `fix-release-conflicts.yml` | `contents: write`, `pull-requests: write`, `actions: write` |
| `renovate.yml` | `contents: write`, `pull-requests: write`, `issues: write`, **`packages: read`** |

### `packages: read` on renovate is load-bearing

A caller `permissions:` block sets every **unlisted** scope to `none`. `reusable-renovate.yml` declares `packages: read`, so omitting it would have capped that to `none` and silently broken Renovate the moment the default flipped — a failure with **no error at the caller**. It was absent from the original plan's table; reading the reusable rather than copying the table is what caught it.

## Scope

Six workflows inspected. The other two — `claude.yml` and `clear-autorelease-labels.yml` — already carry **job-level** `permissions:` blocks and are deliberately left alone.

## Wedge risk: none

While the repo default is still `write`, an explicit block that grants ≤ the default is a **no-op grant-wise**. This lands safely on its own; the default flip is a separate, later change so a mistake here is visible before it can block anything.

## Verification

- `actionlint` clean on all four.
- `renovate.yml` and `fix-release-conflicts.yml` have `workflow_dispatch`, so they can be exercised directly after merge.
- `enforce-conventional-commits` runs on this PR itself.
- ⚠️ **`claude-code-review.yml` cannot be verified live** — it is `disabled_manually` in the Actions UI (confirmed via `gh api .../actions/workflows`) and has no `workflow_dispatch` trigger. It is the template `configure-plugin` ships downstream, so it must still be correct; flagged as the one unverifiable item in this PR.
