### PR TITLE
ci: make the three would-be-required contexts report unconditionally

### DIFF
--- a/.github/workflows/enforce-conventional-commits.yml
+++ b/.github/workflows/enforce-conventional-commits.yml
@@ -93,3 +93,20 @@ jobs:
           "automate":"ci","automates":"ci","automated":"ci",
           "deploy":"ci","deploys":"ci","deployed":"ci"
         }
+
+  # In-repo gate whose context name we own.
+  #
+  # The check GitHub publishes for the job above is `conventional-commits / Fix PR
+  # title` — `<caller job id> / <reusable job NAME>`. Segment 2 lives in
+  # laurigates/.github@main, unpinned, so a rename THERE silently renames the
+  # required context HERE and every PR wedges with no signal. Pinning the `uses:`
+  # to a SHA does not help: the pin-bump PR is itself the rename.
+  #
+  # `gate` is defined in this file, so its context is `gate` no matter what the
+  # reusable calls its jobs. Require THIS, not the composite name.
+  gate:
+    needs: conventional-commits
+    runs-on: ubuntu-slim
+    steps:
+      - name: Conventional-commit check passed
+        run: echo "conventional-commits passed"

--- a/.github/workflows/plugin-pr-checks.yml
+++ b/.github/workflows/plugin-pr-checks.yml
@@ -3,18 +3,18 @@ name: "Plugin: PR checks"
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - '*-plugin/**'
-      - '.claude-plugin/marketplace.json'
-      - '**/skills/**'
-      # Workflow changes must trigger the agent-model and workflow-model guards
-      # (both run unconditionally below) — workflow model/effort drift lives here.
-      - '.github/workflows/**'
-      # The ruff lint/format gate below is the repo's only Python check, so a
-      # PR touching Python outside a plugin (scripts/, vault-agent/,
-      # git-repo-agent/, experiments/) has to reach it too.
-      - '**/*.py'
-      - 'ruff.toml'
+    # NO `paths:` filter — deliberately.
+    #
+    # `compliance` is a REQUIRED status check. A path-filtered workflow does not
+    # run at all on a non-matching PR, so the context is never REPORTED — and a
+    # required check that never reports blocks the merge permanently, with no
+    # bypass (`bypass_actors` is empty). A PR touching only `scripts/*.sh` and
+    # `.claude/rules/**` is exactly that shape and is a routine PR here.
+    #
+    # Gating moved to the job/step level instead: the `changed` step below
+    # computes `plugin_count` / `skill_count` and the expensive work is already
+    # `if:`-gated on them, so a non-matching PR reports a fast trivially-green
+    # context rather than never reporting one.
 
 concurrency:
   group: plugin-pr-checks-${{ github.event.pull_request.number }}

--- a/.github/workflows/validate-plugin-configs.yml
+++ b/.github/workflows/validate-plugin-configs.yml
@@ -2,13 +2,12 @@ name: "Plugin: Validate configs"
 
 on:
   pull_request:
-    paths:
-      - '*-plugin/**'
-      - 'release-please-config.json'
-      - '.release-please-manifest.json'
-      - '.claude-plugin/marketplace.json'
-      - 'docs/PLUGIN-MAP.md'
-      - 'scripts/sync-plugin-configs.py'
+    # NO `paths:` filter — deliberately. `validate` is a REQUIRED status check,
+    # and a path-filtered workflow never RUNS on a non-matching PR, so the
+    # context is never reported and the merge blocks permanently with no bypass.
+    # Relevance is decided at job level by the `relevant` step below, which makes
+    # the context report `success` (trivially) instead of never reporting.
+    # The `push` filter is unaffected: nothing requires a context on push.
   push:
     branches:
       - main
@@ -44,11 +43,45 @@ jobs:
       - uses: actions/checkout@v6
         with:
           token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN || github.token }}
-          # For PRs, checkout the head branch so we can push fixes
-          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+          # Check out the PR head by SHA, not by BRANCH NAME.
+          #
+          # `ref: github.head_ref` resolves the branch at checkout time, so it
+          # races a force-push. release-please force-pushes its branch on every
+          # reconciliation, which made `validate` fail INTERMITTENTLY on
+          # `release-please--branches--main` while sibling runs on the same branch
+          # passed. An intermittent failure on a REQUIRED check wedges
+          # unpredictably, which is worse than a constant one.
+          #
+          # The SHA is pinned in the event payload, so the read-only pass below is
+          # deterministic regardless of what the branch does mid-run. Pushing back
+          # is handled explicitly in the autofix step.
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          fetch-depth: 0
+
+      - name: Determine relevance
+        id: relevant
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Job-level replacement for the removed `on.pull_request.paths` filter.
+          # Same path set — the difference is that an irrelevant PR now REPORTS a
+          # green context instead of never reporting one.
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          CHANGED="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" || true)"
+          if printf '%s\n' "$CHANGED" | grep -qE '^([^/]+-plugin/|release-please-config\.json$|\.release-please-manifest\.json$|\.claude-plugin/marketplace\.json$|docs/PLUGIN-MAP\.md$|scripts/sync-plugin-configs\.py$)'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No plugin-config-relevant paths changed; reporting success without validating."
+          fi
 
       - name: Check plugin configs are in sync
         id: check
+        if: steps.relevant.outputs.relevant == 'true'
         run: |
           python3 scripts/sync-plugin-configs.py 2>&1 | tee /tmp/sync-output.txt
           exit "${PIPESTATUS[0]}"
@@ -56,7 +89,11 @@ jobs:
 
       - name: Auto-fix and push (pull_request)
         id: autofix
-        if: github.event_name == 'pull_request' && steps.check.outcome == 'failure'
+        if: |
+          steps.relevant.outputs.relevant == 'true'
+          && github.event_name == 'pull_request'
+          && steps.check.outcome == 'failure'
+          && !startsWith(github.head_ref, 'release-please--')
         env:
           # Bind the untrusted head ref to an env var rather than interpolating
           # ${{ github.head_ref }} into the script directly (script-injection
@@ -92,7 +129,7 @@ jobs:
           echo "::notice::Auto-fixed plugin config sync issues and pushed to PR branch"
 
       - name: Post comment about auto-fix
-        if: github.event_name == 'pull_request' && steps.autofix.outputs.has_changes == 'true'
+        if: steps.relevant.outputs.relevant == 'true' && github.event_name == 'pull_request' && steps.autofix.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN || github.token }}
         run: |
@@ -115,7 +152,12 @@ jobs:
           gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/comment.md
 
       - name: Fail if no auto-fix available (pull_request)
-        if: github.event_name == 'pull_request' && steps.check.outcome == 'failure' && steps.autofix.outputs.has_changes == 'false'
+        if: |
+          steps.relevant.outputs.relevant == 'true'
+          && github.event_name == 'pull_request'
+          && steps.check.outcome == 'failure'
+          && steps.autofix.outputs.has_changes == 'false'
+          && !startsWith(github.head_ref, 'release-please--')
         run: |
           echo "::error::Plugin configs out of sync but --fix produced no changes. Manual intervention required."
           echo ""
@@ -123,8 +165,27 @@ jobs:
           cat /tmp/sync-output.txt
           exit 1
 
+      - name: Fail without pushing (release-please branch)
+        # The autofix path is deliberately skipped on `release-please--*` heads —
+        # pushing to a release-please branch by hand fights the bot. But skipping
+        # it must NOT make a genuine sync failure disappear: without this step the
+        # required `validate` context would report success on a real defect.
+        # Surface it and fail; a human fixes it on main, and release-please
+        # reconciles. (Never `continue-on-error` here — that reports success.)
+        if: |
+          steps.relevant.outputs.relevant == 'true'
+          && github.event_name == 'pull_request'
+          && steps.check.outcome == 'failure'
+          && startsWith(github.head_ref, 'release-please--')
+        run: |
+          echo "::error::Plugin configs out of sync on a release-please branch."
+          echo "Not auto-pushing (that would fight release-please). Fix on main instead."
+          echo ""
+          cat /tmp/sync-output.txt
+          exit 1
+
       - name: Auto-fix (workflow_dispatch only)
-        if: github.event_name == 'workflow_dispatch' && inputs.fix && steps.check.outcome == 'failure'
+        if: steps.relevant.outputs.relevant == 'true' && github.event_name == 'workflow_dispatch' && inputs.fix && steps.check.outcome == 'failure'
         run: |
           python3 scripts/sync-plugin-configs.py --fix
 


### PR DESCRIPTION
Prerequisite for adding required status checks. Without it, requiring `compliance` / `validate` would make the repo **permanently unmergeable** for a whole class of routine PR, with no bypass (`bypass_actors` is empty).

## The mechanism

A path-filtered workflow does not **run** on a non-matching PR, so its context is never **reported** — and GitHub blocks on a required check that never reports. There is no timeout and no override.

## This is measured, not hypothetical

The original plan assumed both checks were safe to require because they appeared on five recent PRs. That was a **biased sample** — all five touched plugin paths. Three PRs from this very series prove it:

| PR | Touched | Checks received |
|---|---|---|
| #2250 | `scripts/infra-compliance-check.sh` | `conventional-commits`, `doc-audit`(skipped) — **no `compliance`, no `validate`** |
| #2252 | `scripts/**` + `.claude/rules/**` | same |
| #2253 | `.claude/rules/**` only | same |
| #2256 | `.github/workflows/**` | `compliance` ✓ but **no `validate`** |

A `scripts/*.sh` + `.claude/rules/**` PR matches **neither** filter. That is the exact shape of Item 2's work.

## Changes

### 1. Drop `on.pull_request.paths` from both workflows

`push` filters untouched — nothing requires a context on push. Gating moves to job/step level so an irrelevant PR reports a **trivially-green** context instead of never reporting one.

- `plugin-pr-checks.yml` already step-gates its expensive work on `plugin_count` / `skill_count` and already sets `fetch-depth: 0`, so it needed only the filter removal.
- `validate-plugin-configs.yml` gains an equivalent `relevant` step over the **same path set**, with every downstream step gated on it.

### 2. Fix the release-please race

The checkout used `ref: github.head_ref` — a **branch name**, resolved at checkout time, so it raced release-please's force-push. That is why `validate` failed **intermittently** on `release-please--branches--main` while sibling runs on the same branch passed. An intermittent failure on a *required* check wedges unpredictably, which is worse than a constant one.

Now checks out `github.event.pull_request.head.sha` — pinned in the event payload — so the read-only pass is deterministic.

Autofix-and-push is skipped on `release-please--*` heads (pushing there fights the bot), but a dedicated step still **fails** on a genuine sync error there rather than letting the skip hide it. `continue-on-error` is deliberately not used for this — it reports success.

### 3. Own the third context (`gate`)

The published context is `conventional-commits / Fix PR title` — `<caller job id> / <reusable job name>`. **Segment 2 lives in `laurigates/.github@main`, unpinned**, so a rename there silently renames the required context here and every PR wedges with no signal.

Pinning `uses:` to a SHA does **not** fix this — the pin-bump PR *is* the rename. So this adds a `gate` job defined in *this* file (`needs: conventional-commits`), whose context name we own. The ruleset will require `gate`.

## Gates before proceeding to the permissions flip and the ruleset

1. A **docs-only** PR — all three contexts present with a conclusion.
2. A **scripts-only** PR (`scripts/*.sh` + `.pre-commit-config.yaml`) — Item 2's exact shape.
3. A **real** `release-please--branches--main` PR green on `validate`. It is a race; a synthetic test will not reproduce it.

Gate 1 also empirically confirms the assumption this whole change rests on — that GitHub treats a `skipped`/trivially-green check as satisfying a required check while a never-reported one blocks. That distinction is the entire fix, so it gets verified rather than trusted.

`actionlint` clean on all three files.
