### PR TITLE
docs: probe required-check reporting on a docs-only PR

### DIFF
--- a/docs/pi-export.md
+++ b/docs/pi-export.md
@@ -173,3 +173,5 @@ what makes this useful for local-model testing.
 - [`../pi/tiers.yaml`](../pi/tiers.yaml) — the tier classification (source of truth)
 - [`opencode-export.md`](opencode-export.md) — the sibling local-model export (heavier rulesync pipeline)
 - [pi custom-provider docs](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/custom-provider.md) — upstream `models.json` schema
+
+<!-- probe: required-check reporting gate (PR closed unmerged) -->


### PR DESCRIPTION
Throwaway probe, **will be closed unmerged**. Gate 1 of the required-status-check rollout: a docs-only PR must now receive `compliance`, `validate` and `gate` **with a conclusion**, where before #2258 it received none of them.