### PR TITLE
chore(scripts): probe required-check reporting on a scripts-only PR

### DIFF
--- a/scripts/check-unused-bash-grant.sh
+++ b/scripts/check-unused-bash-grant.sh
@@ -289,3 +289,4 @@ if [ "$issues" -gt 0 ] && [ "$strict" -eq 1 ]; then
   exit 1
 fi
 exit 0
+# probe: required-check reporting gate (PR closed unmerged)


### PR DESCRIPTION
Throwaway probe, **will be closed unmerged**. Gate 2: a `scripts/*.sh`-only PR — the exact shape of Item 2's work, and the shape that received neither `compliance` nor `validate` on #2250/#2252/#2253.