### PR TITLE
docs(rules): capture the fleet-drift and PR-polling lessons from the pack sweep

### DIFF
--- a/.claude/rules/generated-fleet-drift.md
+++ b/.claude/rules/generated-fleet-drift.md
@@ -1,0 +1,106 @@
+---
+created: 2026-07-31
+modified: 2026-07-31
+reviewed: 2026-07-31
+paths:
+  - "**/*fleet*"
+  - "**/*scaffold*"
+  - "**/*drift*"
+---
+# Auditing a Generated Fleet: Divergence Is Not Automatically Drift
+
+When a generator (`scaffold.py`, a cookiecutter, a `new-*` recipe) has produced
+many instances, the instances diverge from the template over time and someone
+eventually audits the gap. The failure this rule prevents is the audit's *first
+move*: reading "differs from the template" as "wrong". It usually isn't, and
+acting on that reading is how an audit becomes a regression.
+
+Sibling of `~/.claude/rules/scaffold-fix-backport.md` (fix the class, not the
+instance). This is its inverse: **don't push the class over an instance whose
+divergence was deliberate.**
+
+## The three findings, in the order they bite
+
+### 1. Drift is bidirectional — so never auto-apply template → instance
+
+An instance is often **ahead** of the template. Renovate bumps a pin, someone
+lands a cost fix, a bug gets patched where it hurt. A sync script that treats
+the template as authoritative silently reverts all of it, across every instance
+at once, and the revert looks like a tidy-up commit.
+
+> Measured 2026-07-30 (13 ComfyUI packs): all 13 were **ahead** of the scaffold
+> on `release-please.yml` (`ubuntu-slim`, `release-please-action@v5`); the
+> template was ahead on `RELEASE-CHECKLIST.md`; `tests/js/__mocks__/app.js` was
+> pack-owned and not drift at all. One direction would have been wrong for each.
+
+**The audit reports; a human classifies the direction.** That is the whole
+reason `check-fleet-drift.py` has no `--fix`.
+
+### 2. A *cohort* diverging identically is a signal of intent
+
+One instance differing is probably rot. **Several instances differing the same
+way — especially if they landed together — is a pattern, and the prior should be
+"this encodes something" until you have checked.**
+
+> Four of the 13 packs used a blue accent where the scaffold emits orange. It was
+> called drift. It was in fact documented one skill over
+> (`comfy-registry-lifecycle`: glyph colour encodes the sub-family — `#ffb02e`
+> touch/interaction, `#6ba6ff` info/gallery). Acting on the "drift" reading
+> restyled four published packs and erased the signal; the `rg` that would have
+> settled it took seconds.
+
+Before filing a divergence as drift, grep the sibling skills/docs for the value
+itself (`rg '#6ba6ff'`). Cheap, and it is the step that was skipped.
+
+### 3. Undeclared intent is unauditable — declare it to make it checkable
+
+A checker that only diffs against the template **structurally cannot** judge a
+per-instance divergence: deliberate and drifted produce the *same diff*. So the
+honest default becomes "ignore this file", and the rule goes unenforced forever
+— which is exactly how the regression above shipped past a green checker.
+
+The fix is not a smarter diff. **Declare the intent in the policy, then check
+each instance against its own declaration** rather than against the template.
+
+```toml
+# fleet-policy.toml
+[subfamily]
+comfyui-sampler-info = "info"   # now checkable: its icon AND banner must be blue
+```
+
+An instance missing from the declaration is an **ERROR**, not a skip — otherwise
+a new instance silently opts out of the check.
+
+## Per-file authority, not one global policy
+
+Blanket byte-identity produces permanent false ERRORs on files instances
+legitimately extend. Classify each emitted path:
+
+| Policy | Meaning |
+|---|---|
+| `managed` | Byte-identity is the invariant. *Direction is still a human call.* |
+| `shared` | Must be consistent across instances, but the fleet leads and the template back-ports. |
+| `seed` | Template is a starting point only; never compared. |
+
+Getting these wrong is the likeliest defect — three of the first-pass
+classifications here were wrong (`.gitignore`, `.gitattributes`, and
+`.release-please-manifest.json`, which holds each instance's live version and
+would have ERRORed on every released pack forever). **Review the policy file
+sceptically; the script is the easy part.**
+
+## Two operational cautions
+
+- **Verify the invariant holds across the corpus *before* writing the gate.** A
+  gate that is red on arrival for legitimate content gets disabled, correctness
+  notwithstanding.
+- **A checker that reports a large pre-existing backlog is only useful if the
+  backlog is worked.** If the weekly issue says the same thing for a month, the
+  signal is dead regardless of whether it is right.
+
+## Related
+
+- `~/.claude/rules/scaffold-fix-backport.md` — the inverse (fix the generator, not just the instance)
+- `.claude/rules/drift-detection-triggering.md` — *triggering* a sweep; this rule is about classifying what it finds
+- `.claude/rules/offload-to-deterministic-substrate.md` — why the sweep is a script and the classification is not
+- `comfyui-plugin/skills/comfyui-node-scaffold/fleet-policy.toml` — the reference policy, with per-entry rationale
+- `comfyui-plugin/skills/comfyui-node-scaffold/scripts/check-fleet-drift.py` — the reference implementation

--- a/.claude/rules/gh-json-fields.md
+++ b/.claude/rules/gh-json-fields.md
@@ -70,6 +70,40 @@ are *not* failures — so a naive `all(. == "SUCCESS")` reports red on a PR that
 merely pending or has a skipped job. When you only need the pass/fail signal,
 `gh pr checks <n> --required` exits non-zero on any failure or pending check.
 
+## Polling a PR: `mergeStateStatus` never settles on a merged PR
+
+A wait-for-CI loop written as *"poll until `mergeStateStatus` leaves `UNKNOWN`"*
+**never exits if the PR merges while you wait** — a merged PR keeps reporting
+`mergeStateStatus=UNKNOWN` and `mergeable=UNKNOWN` forever. In a repo where
+automation can merge a PR out from under you (release-please auto-merge), that
+is not a corner case.
+
+```bash
+# Wrong — spins forever once the PR is merged by anything but this loop
+until ms=$(gh pr view "$N" -R "$R" --json mergeStateStatus --jq .mergeStateStatus); [ "$ms" != "UNKNOWN" ]; do sleep 10; done
+
+# Right — MERGED is also a terminal state
+until s=$(gh pr view "$N" -R "$R" --json state,mergeStateStatus --jq '"\(.state)|\(.mergeStateStatus)"'); \
+      [ "${s%%|*}" = "MERGED" ] || [ "${s##*|}" != "UNKNOWN" ]; do sleep 20; done
+```
+
+**Always give a PR poll a terminal-state escape (`state=MERGED`/`CLOSED`) and a
+wall-clock deadline.** Observed 2026-07-30: two such loops burned a 6m40s and a
+10m timeout, one because the PR had already merged, the other per the next trap.
+
+### Gating on an expected check *count* is brittle
+
+The companion advice "wait for nothing-pending **and** at least N checks" (see
+`~/.claude/rules/pr-merge-hazards.md`) guards a real race — zero-pending is
+trivially true before jobs register. But a hardcoded `N` breaks on
+**path-filtered** workflows: the same repo yields 7 checks for a PR touching
+`*-plugin/**` and 5 for one touching only `.claude/rules/**`, so `-ge 6` waits
+forever on a perfectly green PR.
+
+Derive the expectation instead of hardcoding it — poll until the check count is
+**stable across two consecutive reads** with nothing pending, and bound the
+whole loop with a deadline.
+
 ## Default list cap: pass `--limit` when counting or verifying state
 
 `gh issue list` / `gh pr list` default to **30 items**. When the intent is to

--- a/.claude/rules/shell-scripting.md
+++ b/.claude/rules/shell-scripting.md
@@ -357,6 +357,39 @@ Exclude `.claude-plugin` (hidden metadata directory) from `*-plugin` globs:
 find . -maxdepth 1 -type d -name '*-plugin' -not -name '.claude-plugin' -print0
 ```
 
+### zsh Eats `:x` After an Unbraced Parameter — Brace SHAs in Refspecs
+
+The Bash **tool** runs commands under the user's shell, which on this machine is
+**zsh**. zsh applies *history modifiers* to an unbraced parameter expansion, so
+`"$var:refs/..."` silently loses the `:r` — it is parsed as `${var}` with the
+`:r` (rootname) modifier applied. bash leaves it alone, so the bug appears only
+in the interactive/agent path, never in a `#!/usr/bin/env bash` script.
+
+```
+$ zsh -c 'sha=abc123def; print -r -- "$sha:refs/heads/x"'
+abc123defefs/heads/x          # the ":r" was consumed — note the missing ':r'
+
+$ zsh -c 'sha=abc123def; print -r -- "${sha}:refs/heads/x"'
+abc123def:refs/heads/x        # correct
+```
+
+This lands squarely on the **push-by-explicit-SHA** discipline that
+`~/.claude/rules/git-hazards.md` and `pr-merge-hazards.md` mandate for shared
+checkouts — the one command shape most likely to carry `<sha>:refs/heads/...`:
+
+```
+# Wrong under zsh — git rejects it with a confusing "src refspec ... does not match any"
+git push --force-with-lease origin "$sha:refs/heads/$branch"
+
+# Right — brace every parameter followed by ':'
+git push --force-with-lease origin "${sha}:refs/heads/${branch}"
+```
+
+The failure is loud (`error: src refspec … does not match any`) but the *reason*
+is not: the printed refspec looks almost right, and the natural reading is that
+the SHA is bad. **Brace any parameter immediately followed by `:`** — cheap,
+and it makes the same line correct in both shells.
+
 ### GNU vs BSD Tool Differences
 
 Even with bash 5+, some CLI tools differ between macOS (BSD) and Linux (GNU). Use portable patterns for:

--- a/justfile
+++ b/justfile
@@ -50,6 +50,15 @@ lint-context-engineering *args:
 lint-shell *args:
     ./scripts/lint-shell-scripts.sh {{args}}
 
+# Deliberately NOT in lint-all: it needs the pack repos checked out locally
+# (~/repos/laurigates/comfyui-nodes), so on any other machine — and in CI — it
+# would report a clean no-op and make lint-all look greener than it is. The
+# scheduled sweep is .github/workflows/fleet-drift-audit.yml.
+# Report drift between the ComfyUI pack fleet and the scaffold template
+[group: "lint"]
+lint-fleet-drift *args:
+    ./comfyui-plugin/skills/comfyui-node-scaffold/scripts/check-fleet-drift.py {{args}}
+
 # Run all lint checks
 [group: "lint"]
 lint-all: lint-context-commands lint-compliance lint-health lint-infra lint-taskwarrior-tags lint-shell lint-context-engineering


### PR DESCRIPTION
Session distillation from the 2026-07-30 ComfyUI pack-fleet sweep (#1877 → #2226 / #2233 / #2238 / #2243 / #2247). Four artifacts, each with a concrete failure behind it — nothing speculative.

## `.claude/rules/generated-fleet-drift.md` (new, `paths:`-scoped)

Auditing a generated fleet: **"differs from the template" is not "wrong"**, and the audit's *first move* is where it goes wrong. Three findings, each measured during the sweep:

1. **Drift is bidirectional** — all 13 packs were *ahead* of the scaffold on `release-please.yml`, so a template→pack sync would have reverted `ubuntu-slim` and `release-please-action@v5` across 13 repos in one tidy-looking commit.
2. **A *cohort* diverging identically signals intent.** Four packs shared a blue accent that was documented one skill over (`comfy-registry-lifecycle`). Reading it as drift restyled four *published* packs and erased the signal; the `rg` that would have settled it took seconds.
3. **Undeclared intent is unauditable.** A template diff cannot distinguish deliberate from drifted — they produce the same diff — so the honest default becomes "ignore this file" and the rule goes unenforced forever. The intent has to be *declared* before it can be checked.

Also records that per-file authority beats one global policy, and that **three of my own first-pass classifications were wrong** (`.gitignore`, `.gitattributes`, `.release-please-manifest.json` — the last holds each pack's live version and would have ERRORed on every released pack forever). The policy file is the thing to review sceptically, not the script.

Sibling of `~/.claude/rules/scaffold-fix-backport.md`: that says *fix the class, not the instance*; this says *don't push the class over an instance whose divergence was deliberate*.

## `.claude/rules/gh-json-fields.md`

A **merged PR reports `mergeStateStatus=UNKNOWN` forever**, so "poll until it leaves UNKNOWN" never exits if anything else merges the PR — which happens routinely here, since release-please auto-merges. Cost a 6m40s timeout.

Also: gating on an expected check **count** is brittle. Path-filtered workflows yield 5 checks for one PR and 7 for another, so a hardcoded `-ge 6` waited out a 10m timeout on a perfectly green PR.

## `.claude/rules/shell-scripting.md`

zsh applies **history modifiers to an unbraced parameter**, so `"\$sha:refs/..."` silently loses the `:r` — and that is exactly the push-by-explicit-SHA shape `git-hazards.md` mandates for shared checkouts. bash is unaffected, so it only bites on the interactive/agent path.

```
$ zsh -c 'sha=abc123def; print -r -- "$sha:refs/heads/x"'
abc123defefs/heads/x          # the ':r' was consumed
```

## `justfile`

`just lint-fleet-drift` wrapping `check-fleet-drift.py`. **Deliberately not in `lint-all`** — it needs the pack repos checked out locally, so elsewhere (and in CI) it reports a clean no-op and would make `lint-all` look greener than it is.

## Verification

- `just --list` shows the recipe with the right doc line
- `check-context-engineering.py --strict`: `C5_ALWAYS_LOADED_CHARS=87425` / budget 100000 — the new rule is `paths:`-scoped so it is not always-loaded
- `check-docs-index.sh`: no `rule_reviewed` finding (frontmatter dates present)
- Only these 4 paths touched; a concurrent session's in-flight `hooks-plugin` work in the shared checkout was left untouched (authored in a worktree off `origin/main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)