### PR TITLE
docs(tools-plugin): warn that just's {{...}} interpolates unquoted

### DIFF
--- a/tools-plugin/skills/justfile-expert/SKILL.md
+++ b/tools-plugin/skills/justfile-expert/SKILL.md
@@ -135,11 +135,45 @@ recipe-name:
 ```just
 build target:
     @echo "Building {{target}}..."
-    cd {{target}} && make
+    cd {{quote(target)}} && make
 
 test *args:
     uv run pytest {{args}}
 ```
+
+**Interpolation is UNQUOTED — quote anything that can contain spaces**
+
+`{{...}}` splices raw text into the recipe body *before* the shell parses it,
+so a value carrying spaces or quotes word-splits. This bites hardest on the
+`*args` passthrough above, because the error is reported by the *called
+program* rather than by just, which makes it read like a bug in the tool:
+
+```just
+# Trap — one argument with spaces arrives as several
+caption *ARGS:
+    ./tool.py {{ARGS}}
+```
+
+```
+$ just caption ./data "the subject's face"
+tool.py: error: unrecognized arguments: subjects face
+```
+
+The outer shell consumed the quotes (taking the apostrophe with them) and
+`the` / `subject's` / `face` arrived as three separate argv entries. Name the
+parameters that can contain spaces and run them through `quote()`, which emits
+a properly shell-escaped literal:
+
+```just
+# Correct — named params are quoted; trailing flags still pass through
+caption DIR SUBJECT="" *ARGS:
+    ./tool.py {{quote(DIR)}} {{quote(SUBJECT)}} {{ARGS}}
+```
+
+`quote()` covers embedded spaces, `'`, `"`, and `$`. Keep `{{ARGS}}` bare —
+that is what lets several trailing flags expand as separate words — and accept
+its corollary: an individual passthrough flag's value must not contain spaces.
+When one might, promote it to a named parameter too.
 
 **Recipe Dependencies**
 ```just
@@ -427,7 +461,10 @@ cargo install just-mcp
 - Prefer `set dotenv-load` for configuration
 - Use modules for large projects (>20 recipes)
 - Include variadic `*args` for passthrough flexibility
-- Quote all variables in shell commands
+- Quote all variables in shell commands — `{{...}}` interpolates **unquoted**,
+  so wrap any parameter that can contain spaces in `quote()` (see
+  "Interpolation is UNQUOTED" above); bare `{{args}}` is correct only for
+  space-free passthrough flags
 
 ## Comparison with Alternatives
 


### PR DESCRIPTION
## What

Adds a subsection to `tools-plugin:justfile-expert` explaining that just's `{{...}}` interpolation is **unquoted**, and shows the `quote()` fix.

## Why

The skill already recommends the pattern that carries this trap, without warning about it:

> - Include variadic `*args` for passthrough flexibility
> - Quote all variables in shell commands

"Quote all variables" reads as advice about *shell* quoting inside the recipe body. It doesn't convey that `{{...}}` splices raw text in **before** the shell parses the line — so a parameter containing spaces word-splits, and the outer shell consumes the quotes on the way in.

What makes it expensive is the attribution: the error surfaces from the *called program*, so it looks like a bug in the tool rather than in the recipe.

```
$ just caption ./data "the subject's face"
tool.py: error: unrecognized arguments: subjects face
```

Three argv entries instead of one, and the apostrophe silently gone.

## The fix documented

```just
# Trap
caption *ARGS:
    ./tool.py {{ARGS}}

# Correct — named params quoted; trailing flags still pass through
caption DIR SUBJECT="" *ARGS:
    ./tool.py {{quote(DIR)}} {{quote(SUBJECT)}} {{ARGS}}
```

The section also states the corollary explicitly — `{{ARGS}}` must stay **bare** (that's what lets several trailing flags expand as separate words), which means an individual passthrough flag's value can't contain spaces; promote it to a named parameter when it might.

## Changes

- New "Interpolation is UNQUOTED — quote anything that can contain spaces" subsection under **Essential Syntax**, placed directly after the `test *args:` example that introduces the pattern.
- Cross-linked from the **Critical Guidelines** bullet that recommends `*args`, so the warning is reachable from the advice that leads into it.
- Quoted the pre-existing `cd {{target}} && make` example, which had the same defect and sat immediately above the new section.

No skill added or removed, and `justfile-expert`'s catalog description is unchanged, so `tools-plugin/README.md` needs no update (the advisory currency nudge doesn't apply here).

## Evidence

Found while building a dataset-captioning recipe in `laurigates/comfyui-nodes`. A multi-word subject argument shattered into a dozen "unrecognized arguments" on the first real invocation, and the apostrophes in `"the subject's lips and mouth shape"` were eaten by the shell — several minutes lost to suspecting argparse before the recipe was the culprit. Fixed there with exactly the `quote()` shape documented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AihEc2RuPSe9qUpbDx4SyJ
