### PR TITLE
docs(comfyui): a widget name is not proof of its option source

### DIFF
--- a/comfyui-plugin/README.md
+++ b/comfyui-plugin/README.md
@@ -190,7 +190,9 @@ screenshot pipeline like `comfyui-gallery-loader`.
 ComfyUI frontend/backend facts for writing or patching a custom node's code:
 pack layout (vanilla `web/js/` and TS+bun-build), hiding a widget correctly,
 the `widget.serialize = false` + append-last rule for non-persisted widgets,
-DOM event isolation on the canvas, endpoint/subfolder-safety patterns, the
+DOM event isolation on the canvas, why a widget's *name* is not proof its
+options come from `folder_paths` (and the overlap gate that keeps a pack from
+hijacking a hardcoded combo), endpoint/subfolder-safety patterns, the
 tooltip lookup chain, canvas hit-testing, and how to verify an undocumented
 LiteGraph/Vue API against the frontend's own sourcemap instead of guessing.
 

--- a/comfyui-plugin/skills/comfyui-node-authoring/SKILL.md
+++ b/comfyui-plugin/skills/comfyui-node-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-07-07
-modified: 2026-07-07
+modified: 2026-08-04
 reviewed: 2026-07-07
 name: comfyui-node-authoring
 description: >-
@@ -148,6 +148,59 @@ scrollEl.addEventListener("wheel", (e) => {
     e.stopPropagation();
 }, { passive: false });
 ```
+
+## A widget name is not proof of its option source
+
+Matching widgets **by name** is what makes a usability pack generic across node
+packs — any node exposing `lora_name` gets the LoRA picker, whatever its node
+type. But a name is a *convention*, not a contract: a third-party node can
+hardcode a combo under a canonical name, and its options then have nothing to do
+with `folder_paths`.
+
+**The split that decides whether you need a gate:**
+
+| The modal renders… | Risk | Gate needed |
+|---|---|---|
+| The widget's **own** `options.values` (reformatted, filtered, searchable) | none — you show what the node offers | no |
+| Content from an **external** source (a `folder_paths` listing, an endpoint, a corpus) | you can replace the node's only valid choices with values it rejects | **yes** |
+
+> Evidence (2026-08, `comfyui-model-gallery` #66): ComfyUI-Frame-Interpolation's
+> **RIFE VFI** node hardcodes `ckpt_name` to `rife47.pth`, `rife49.pth`,
+> `rife417.pth`, `rife426.pth`, `sudo_rife4_269…pth` — weights living in that
+> pack's own `ckpts/` dir. The gallery matched the name, listed
+> `models/checkpoints` instead, and offered two diffusion checkpoints the node
+> cannot load. Zero overlap between the two sets, which is exactly the signal.
+
+**The gate: require the widget's own values to overlap the external source.**
+
+```ts
+// names = the external source's contents for this category; null when unknown
+function optionsMatchSource(w, names) {
+  if (!names) return true;                       // source unknown — stay optimistic
+  const values = w?.options?.values;
+  if (!Array.isArray(values) || values.length === 0) return true;
+  return values.some((v) => names.has((v ?? "").toString()));
+}
+```
+
+Four things make it work in practice:
+
+- **Prime the source per category at enhance time** (fire-and-forget, once), so
+  the check answers **synchronously** when the user taps. A gate that has to
+  await a fetch mid-pointer-event is a gate that opens the wrong modal first.
+- **Decide at tap time, not patch time.** The listing arrives asynchronously and
+  a node's options can be rebuilt by a definition refresh, so test inside the
+  opener, not in the `if` that decides whether to patch.
+- **Decline by returning `false`** from the `patchWidgetPointer` opener — that
+  falls through to the native control, preserving the additive contract. Do not
+  skip patching entirely; you still want the tooltip/callback enhancements.
+- **Stay optimistic on unknown.** Unknown source or an empty `values` array must
+  open the modal, exactly as before the gate existed. A conservative default
+  silently withholds the feature whenever the backend is unreachable — a
+  regression that presents as "the pack stopped working" with no error.
+
+Partial overlap is a pass, not a failure: a stale entry alongside real files
+(a deleted model still listed in a loaded workflow) is normal.
 
 ## Reusing core endpoints
 

--- a/comfyui-plugin/skills/comfyui-node-scaffold/SKILL.md
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/SKILL.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-06-04
-modified: 2026-07-29
+modified: 2026-08-04
 reviewed: 2026-07-29
 name: comfyui-node-scaffold
 description: >-
@@ -58,6 +58,14 @@ fallback, never breaks serialized workflows); the modal is **touch-first** (16px
 inputs, big tap targets, momentum scroll). The modal primitives come from
 `@laurigates/comfy-modal-kit` (`openModalShell` / `fuzzyRank` /
 `highlightMatches`) — **imported, not copied** — and `bun build` inlines them.
+
+**Name-matching needs a gate when the modal's content is external.** The emitted
+`TARGET_WIDGETS` set matches on name alone, which is correct for a modal that
+renders the widget's *own* `options.values`. If your pack instead fills the modal
+from a `folder_paths` listing, an endpoint, or a corpus, a node that hardcodes a
+combo under the same name (RIFE VFI's `ckpt_name`) has its only valid choices
+replaced with values it rejects — see `comfyui-node-authoring` § "A widget name
+is not proof of its option source" for the overlap gate.
 
 ## Four variants
 


### PR DESCRIPTION
## The pattern

Every mobile-first ComfyUI usability pack matches widgets **by name** — that is what makes the pack generic across node packs, and both `comfyui-node-scaffold` ("The vein") and each pack's own `CLAUDE.md` state it as the design. Neither said what the convention does *not* buy you: a name is a convention, not a contract. A third-party node can hardcode a combo under a canonical name, and its options then have nothing to do with `folder_paths`.

## Evidence

`laurigates/comfyui-model-gallery#66`. ComfyUI-Frame-Interpolation's **RIFE VFI** node hardcodes `ckpt_name` (`CKPT_NAME_VER_DICT` in `vfi_models/rife/__init__.py`); those weights live in that pack's own `ckpts/` dir. Read off the live install:

| Source | Values |
|---|---|
| `RIFE VFI.ckpt_name` (`/object_info`) | `sudo_rife4_269.662_testV1_scale1.pth`, `rife47.pth`, `rife49.pth`, `rife417.pth`, `rife426.pth` |
| `/model_gallery/list?category=checkpoints` | `10Eros_v1-fp8mixed_learned.safetensors`, `HiDream/hidream_o1_image_dev_fp8_scaled.safetensors` |

The gallery matched the name, listed `models/checkpoints`, and offered the user two diffusion checkpoints the node cannot load — while suppressing the five it accepts. The zero overlap between those sets is the discriminator the fix uses.

## What this PR adds

**`comfyui-node-authoring`** — a new section, *"A widget name is not proof of its option source"*. It first splits the cases, because most packs need no gate at all:

- Modal renders the widget's **own** `options.values` → no risk, no gate.
- Modal content comes from an **external** source (a `folder_paths` listing, an endpoint, a corpus) → gate required.

I checked this against the fleet rather than assuming it: of the packs matching widgets by name, only `comfyui-model-gallery` sources modal content externally. `comfyui-filename-prefix` targets `filename_prefix` and edits the widget's own value in place, so it cannot hijack anything — the narrower rule is the correct one.

Then the gate, with the four details that only surfaced during implementation:

- **Prime the external source per category at enhance time** so the check answers synchronously at tap — a gate that awaits a fetch mid-pointer-event opens the wrong modal first.
- **Decide at tap time, not patch time** — the listing arrives asynchronously and options can be rebuilt by a definition refresh.
- **Decline by returning `false`** from the `patchWidgetPointer` opener, which falls through to the native control (the additive contract). Still patch the widget — the tooltip/callback enhancements are unaffected.
- **Stay optimistic on unknown** — unknown source or empty `values` must open, or an unreachable backend silently withholds the feature and presents as "the pack stopped working" with no error.

**`comfyui-node-scaffold`** — "The vein" asserted name-matching with no caveat, and `scaffold.py` emits `TARGET_WIDGETS` into every new pack. Per `scaffold-fix-backport.md` the generator gets the cross-reference in the same sweep rather than diverging silently from the pack where the fix landed.

**`comfyui-plugin/README.md`** — the authoring skill's catalog entry names the new topic.

## Verification

The gate ships in `comfyui-model-gallery` v0.1.21 with seven unit tests on the pure predicate (RIFE case, partial overlap, unknown listing, empty values, non-string values); `just check` green there. Pre-commit hooks pass on this branch.
