### PR TITLE
refactor(bevy-plugin): split bevy-game-engine into a references/ sidecar

### DIFF
--- a/bevy-plugin/README.md
+++ b/bevy-plugin/README.md
@@ -26,6 +26,11 @@ Core Bevy development expertise including:
 
 **Use when**: Building games with Bevy, working with entities/components/systems, implementing game features, or when the user mentions Bevy, game development in Rust, or 2D/3D games.
 
+`SKILL.md` carries the ECS core, app structure, and the command set; the detail
+is split across `references/` so a run loads only the material its path needs
+(`input.md`, `assets-and-states.md`, `events.md`, `project-architecture.md`).
+The pointer table in `SKILL.md` names each one.
+
 ### bevy-ecs-patterns
 
 Advanced ECS patterns and techniques:

--- a/bevy-plugin/skills/bevy-game-engine/SKILL.md
+++ b/bevy-plugin/skills/bevy-game-engine/SKILL.md
@@ -1,6 +1,6 @@
 ---
 created: 2025-12-16
-modified: 2026-05-09
+modified: 2026-08-07
 reviewed: 2025-12-16
 name: bevy-game-engine
 description: "Bevy game engine: ECS, rendering, input, and asset management. Use when building Bevy games, working with entities/components/systems, or mentioning Rust gamedev or 2D/3D games."
@@ -39,6 +39,19 @@ Expert knowledge for developing games with Bevy, the data-driven game engine bui
 - **3D Rendering**: PBR materials, meshes, lighting, shadows, cameras
 - **UI**: bevy_ui for in-game interfaces
 - **Shaders**: Custom WGSL shaders and render pipelines
+
+## Reference Files
+
+The ECS core, project setup, and the command set below are everything a first
+pass needs. Follow one link when the task calls for it — nothing under
+`references/` is loaded unless you open it.
+
+| Path you are on | File | Carries |
+|---|---|---|
+| Reading player input | [`references/input.md`](references/input.md) | `ButtonInput` keyboard/mouse polling, pressed vs just-pressed, cursor position, gamepad and rebinding pointers |
+| Loading assets, or driving the state machine | [`references/assets-and-states.md`](references/assets-and-states.md) | `AssetServer` handles and `LoadState` gating, `States` enum, `OnEnter`/`OnExit`/`run_if(in_state)`, `NextState` timing |
+| Decoupling two systems that must communicate | [`references/events.md`](references/events.md) | `#[derive(Event)]`, `EventWriter`/`EventReader`, `add_event` registration, the two-frame buffer and ordering caveat |
+| Laying out a growing game, or chasing frame time | [`references/project-architecture.md`](references/project-architecture.md) | Directory layout, plugin/marker-component organization, query-filter and profiling guidance, bundles and system sets |
 
 ## Key Capabilities
 
@@ -114,140 +127,6 @@ impl Plugin for GamePlugin {
 }
 ```
 
-**Input Handling**
-```rust
-fn player_input(
-    keyboard: Res<ButtonInput<KeyCode>>,
-    mut query: Query<&mut Velocity, With<Player>>,
-) {
-    let mut direction = Vec2::ZERO;
-
-    if keyboard.pressed(KeyCode::KeyW) { direction.y += 1.0; }
-    if keyboard.pressed(KeyCode::KeyS) { direction.y -= 1.0; }
-    if keyboard.pressed(KeyCode::KeyA) { direction.x -= 1.0; }
-    if keyboard.pressed(KeyCode::KeyD) { direction.x += 1.0; }
-
-    for mut velocity in &mut query {
-        velocity.0 = direction.normalize_or_zero() * 200.0;
-    }
-}
-
-// Mouse input
-fn mouse_click(
-    mouse: Res<ButtonInput<MouseButton>>,
-    windows: Query<&Window>,
-) {
-    if mouse.just_pressed(MouseButton::Left) {
-        if let Some(position) = windows.single().cursor_position() {
-            println!("Clicked at: {:?}", position);
-        }
-    }
-}
-```
-
-**Asset Loading**
-```rust
-#[derive(Resource)]
-struct GameAssets {
-    player_sprite: Handle<Image>,
-    font: Handle<Font>,
-    sound: Handle<AudioSource>,
-}
-
-fn load_assets(
-    mut commands: Commands,
-    asset_server: Res<AssetServer>,
-) {
-    commands.insert_resource(GameAssets {
-        player_sprite: asset_server.load("sprites/player.png"),
-        font: asset_server.load("fonts/game.ttf"),
-        sound: asset_server.load("sounds/jump.ogg"),
-    });
-}
-
-// Check if assets are loaded
-fn check_assets_loaded(
-    asset_server: Res<AssetServer>,
-    assets: Res<GameAssets>,
-    mut next_state: ResMut<NextState<GameState>>,
-) {
-    use bevy::asset::LoadState;
-
-    if asset_server.get_load_state(&assets.player_sprite) == Some(LoadState::Loaded) {
-        next_state.set(GameState::Playing);
-    }
-}
-```
-
-**Game States**
-```rust
-#[derive(States, Debug, Clone, Eq, PartialEq, Hash, Default)]
-enum GameState {
-    #[default]
-    Loading,
-    Menu,
-    Playing,
-    Paused,
-    GameOver,
-}
-
-fn setup_states(app: &mut App) {
-    app.init_state::<GameState>()
-       .add_systems(OnEnter(GameState::Menu), setup_menu)
-       .add_systems(OnExit(GameState::Menu), cleanup_menu)
-       .add_systems(Update, menu_input.run_if(in_state(GameState::Menu)))
-       .add_systems(Update, game_logic.run_if(in_state(GameState::Playing)));
-}
-
-fn pause_game(
-    keyboard: Res<ButtonInput<KeyCode>>,
-    state: Res<State<GameState>>,
-    mut next_state: ResMut<NextState<GameState>>,
-) {
-    if keyboard.just_pressed(KeyCode::Escape) {
-        match state.get() {
-            GameState::Playing => next_state.set(GameState::Paused),
-            GameState::Paused => next_state.set(GameState::Playing),
-            _ => {}
-        }
-    }
-}
-```
-
-**Events**
-```rust
-#[derive(Event)]
-struct CollisionEvent {
-    entity_a: Entity,
-    entity_b: Entity,
-}
-
-#[derive(Event)]
-struct ScoreEvent(u32);
-
-fn detect_collisions(
-    mut collision_events: EventWriter<CollisionEvent>,
-    query: Query<(Entity, &Transform, &Collider)>,
-) {
-    // Collision detection logic
-    for [(entity_a, transform_a, _), (entity_b, transform_b, _)] in query.iter_combinations() {
-        if colliding(transform_a, transform_b) {
-            collision_events.send(CollisionEvent { entity_a, entity_b });
-        }
-    }
-}
-
-fn handle_collisions(
-    mut collision_events: EventReader<CollisionEvent>,
-    mut score_events: EventWriter<ScoreEvent>,
-) {
-    for event in collision_events.read() {
-        // Handle collision
-        score_events.send(ScoreEvent(10));
-    }
-}
-```
-
 ## Essential Commands
 
 ```bash
@@ -276,77 +155,6 @@ cargo add bevy_rapier2d       # 2D physics
 cargo add bevy_rapier3d       # 3D physics
 cargo add bevy_asset_loader   # Asset loading helpers
 cargo add leafwing-input-manager  # Advanced input
-```
-
-## Project Structure
-
-```
-my_game/
-├── Cargo.toml
-├── assets/
-│   ├── sprites/
-│   ├── fonts/
-│   ├── sounds/
-│   └── shaders/
-└── src/
-    ├── main.rs
-    ├── lib.rs           # Optional library crate
-    ├── plugins/
-    │   ├── mod.rs
-    │   ├── player.rs
-    │   ├── enemy.rs
-    │   └── ui.rs
-    ├── components/
-    │   └── mod.rs
-    ├── resources/
-    │   └── mod.rs
-    ├── systems/
-    │   └── mod.rs
-    └── events/
-        └── mod.rs
-```
-
-## Best Practices
-
-**Performance**
-- Use `Query` filters (`With<T>`, `Without<T>`) to narrow iteration
-- Avoid `Query::iter()` when you need specific entities
-- Use `Changed<T>` and `Added<T>` filters for reactive systems
-- Profile with `bevy_diagnostic` and Tracy
-- Use asset preprocessing for production builds
-
-**Code Organization**
-- Group related components, systems, and events into plugins
-- Use marker components for entity classification
-- Keep systems focused and single-purpose
-- Use resources for global game state
-- Prefer events over direct component modification for decoupling
-
-**Common Patterns**
-```rust
-// Marker components
-#[derive(Component)]
-struct Enemy;
-
-#[derive(Component)]
-struct Bullet;
-
-// Component bundles for common entity types
-#[derive(Bundle)]
-struct EnemyBundle {
-    enemy: Enemy,
-    health: Health,
-    sprite: SpriteBundle,
-}
-
-// System sets for ordering
-#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
-enum GameSet {
-    Input,
-    Movement,
-    Collision,
-    Render,
-}
 ```
 
 ## Agentic Optimizations

--- a/bevy-plugin/skills/bevy-game-engine/references/assets-and-states.md
+++ b/bevy-plugin/skills/bevy-game-engine/references/assets-and-states.md
@@ -1,0 +1,95 @@
+# Assets and Game States
+
+Reference material for [`bevy-game-engine`](../SKILL.md). Load this when loading
+assets, or when driving the game's state machine — the two pair up, because the
+canonical loading screen is a state that exits once its handles resolve.
+
+## Asset loading
+
+```rust
+#[derive(Resource)]
+struct GameAssets {
+    player_sprite: Handle<Image>,
+    font: Handle<Font>,
+    sound: Handle<AudioSource>,
+}
+
+fn load_assets(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+) {
+    commands.insert_resource(GameAssets {
+        player_sprite: asset_server.load("sprites/player.png"),
+        font: asset_server.load("fonts/game.ttf"),
+        sound: asset_server.load("sounds/jump.ogg"),
+    });
+}
+
+// Check if assets are loaded
+fn check_assets_loaded(
+    asset_server: Res<AssetServer>,
+    assets: Res<GameAssets>,
+    mut next_state: ResMut<NextState<GameState>>,
+) {
+    use bevy::asset::LoadState;
+
+    if asset_server.get_load_state(&assets.player_sprite) == Some(LoadState::Loaded) {
+        next_state.set(GameState::Playing);
+    }
+}
+```
+
+`asset_server.load()` returns immediately with a `Handle<T>`; the load is
+asynchronous. Hold the handles in a `Resource` so they are not dropped (a
+dropped handle can unload the asset), and gate the transition out of the loading
+state on `get_load_state`.
+
+For declarative loading states and collection derives, add `bevy_asset_loader`
+(see the essential-commands block in [`SKILL.md`](../SKILL.md)).
+
+## Game states
+
+```rust
+#[derive(States, Debug, Clone, Eq, PartialEq, Hash, Default)]
+enum GameState {
+    #[default]
+    Loading,
+    Menu,
+    Playing,
+    Paused,
+    GameOver,
+}
+
+fn setup_states(app: &mut App) {
+    app.init_state::<GameState>()
+       .add_systems(OnEnter(GameState::Menu), setup_menu)
+       .add_systems(OnExit(GameState::Menu), cleanup_menu)
+       .add_systems(Update, menu_input.run_if(in_state(GameState::Menu)))
+       .add_systems(Update, game_logic.run_if(in_state(GameState::Playing)));
+}
+
+fn pause_game(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    state: Res<State<GameState>>,
+    mut next_state: ResMut<NextState<GameState>>,
+) {
+    if keyboard.just_pressed(KeyCode::Escape) {
+        match state.get() {
+            GameState::Playing => next_state.set(GameState::Paused),
+            GameState::Paused => next_state.set(GameState::Playing),
+            _ => {}
+        }
+    }
+}
+```
+
+Three scheduling hooks carry most state work:
+
+| Hook | Runs |
+|------|------|
+| `OnEnter(S)` | Once, when the state becomes `S` — spawn the screen |
+| `OnExit(S)` | Once, when the state leaves `S` — despawn the screen |
+| `.run_if(in_state(S))` | Every frame the state is `S` — the conditional systems |
+
+`NextState` is applied at the state-transition point in the schedule, not
+immediately, so a system that sets it still finishes the current frame.

--- a/bevy-plugin/skills/bevy-game-engine/references/events.md
+++ b/bevy-plugin/skills/bevy-game-engine/references/events.md
@@ -1,0 +1,46 @@
+# Events
+
+Reference material for [`bevy-game-engine`](../SKILL.md). Load this when
+decoupling two systems that must communicate without one querying the other's
+components.
+
+```rust
+#[derive(Event)]
+struct CollisionEvent {
+    entity_a: Entity,
+    entity_b: Entity,
+}
+
+#[derive(Event)]
+struct ScoreEvent(u32);
+
+fn detect_collisions(
+    mut collision_events: EventWriter<CollisionEvent>,
+    query: Query<(Entity, &Transform, &Collider)>,
+) {
+    // Collision detection logic
+    for [(entity_a, transform_a, _), (entity_b, transform_b, _)] in query.iter_combinations() {
+        if colliding(transform_a, transform_b) {
+            collision_events.send(CollisionEvent { entity_a, entity_b });
+        }
+    }
+}
+
+fn handle_collisions(
+    mut collision_events: EventReader<CollisionEvent>,
+    mut score_events: EventWriter<ScoreEvent>,
+) {
+    for event in collision_events.read() {
+        // Handle collision
+        score_events.send(ScoreEvent(10));
+    }
+}
+```
+
+Register each event type on the app (`app.add_event::<CollisionEvent>()`) — the
+`EventWriter`/`EventReader` params panic at startup otherwise.
+
+Events are double-buffered and dropped after two frames, so a reader that runs
+before its writer in the schedule reads the event one frame late. When the
+latency matters, order the systems explicitly (`.after(detect_collisions)`) —
+see the `bevy-ecs-patterns` skill for system ordering and sets.

--- a/bevy-plugin/skills/bevy-game-engine/references/input.md
+++ b/bevy-plugin/skills/bevy-game-engine/references/input.md
@@ -1,0 +1,52 @@
+# Input Handling
+
+Reference material for [`bevy-game-engine`](../SKILL.md). Load this when
+reading player input — keyboard, mouse, or gamepad.
+
+## Keyboard
+
+```rust
+fn player_input(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    mut query: Query<&mut Velocity, With<Player>>,
+) {
+    let mut direction = Vec2::ZERO;
+
+    if keyboard.pressed(KeyCode::KeyW) { direction.y += 1.0; }
+    if keyboard.pressed(KeyCode::KeyS) { direction.y -= 1.0; }
+    if keyboard.pressed(KeyCode::KeyA) { direction.x -= 1.0; }
+    if keyboard.pressed(KeyCode::KeyD) { direction.x += 1.0; }
+
+    for mut velocity in &mut query {
+        velocity.0 = direction.normalize_or_zero() * 200.0;
+    }
+}
+```
+
+`ButtonInput<T>` distinguishes three states: `pressed()` (held this frame),
+`just_pressed()` (edge on this frame), and `just_released()`.
+
+## Mouse
+
+```rust
+fn mouse_click(
+    mouse: Res<ButtonInput<MouseButton>>,
+    windows: Query<&Window>,
+) {
+    if mouse.just_pressed(MouseButton::Left) {
+        if let Some(position) = windows.single().cursor_position() {
+            println!("Clicked at: {:?}", position);
+        }
+    }
+}
+```
+
+Cursor position comes from the `Window` component, not from the input resource,
+and is `None` while the cursor is outside the window.
+
+## Gamepad and advanced input
+
+Gamepad buttons and axes follow the same `ButtonInput` / `Axis` resource shape.
+For rebindable actions, layered input contexts, and multi-device abstraction,
+add `leafwing-input-manager` (see the essential-commands block in
+[`SKILL.md`](../SKILL.md)).

--- a/bevy-plugin/skills/bevy-game-engine/references/project-architecture.md
+++ b/bevy-plugin/skills/bevy-game-engine/references/project-architecture.md
@@ -1,0 +1,83 @@
+# Project Architecture
+
+Reference material for [`bevy-game-engine`](../SKILL.md). Load this when laying
+out a growing game — where files go, how to group systems, and what to reach for
+when the frame budget slips.
+
+## Project structure
+
+```
+my_game/
+├── Cargo.toml
+├── assets/
+│   ├── sprites/
+│   ├── fonts/
+│   ├── sounds/
+│   └── shaders/
+└── src/
+    ├── main.rs
+    ├── lib.rs           # Optional library crate
+    ├── plugins/
+    │   ├── mod.rs
+    │   ├── player.rs
+    │   ├── enemy.rs
+    │   └── ui.rs
+    ├── components/
+    │   └── mod.rs
+    ├── resources/
+    │   └── mod.rs
+    ├── systems/
+    │   └── mod.rs
+    └── events/
+        └── mod.rs
+```
+
+`assets/` is resolved relative to the working directory at run time, not
+compiled in — ship it alongside the binary.
+
+## Performance
+
+- Use `Query` filters (`With<T>`, `Without<T>`) to narrow iteration
+- Avoid `Query::iter()` when you need specific entities
+- Use `Changed<T>` and `Added<T>` filters for reactive systems
+- Profile with `bevy_diagnostic` and Tracy
+- Use asset preprocessing for production builds
+
+## Code organization
+
+- Group related components, systems, and events into plugins
+- Use marker components for entity classification
+- Keep systems focused and single-purpose
+- Use resources for global game state
+- Prefer events over direct component modification for decoupling
+
+## Common patterns
+
+```rust
+// Marker components
+#[derive(Component)]
+struct Enemy;
+
+#[derive(Component)]
+struct Bullet;
+
+// Component bundles for common entity types
+#[derive(Bundle)]
+struct EnemyBundle {
+    enemy: Enemy,
+    health: Health,
+    sprite: SpriteBundle,
+}
+
+// System sets for ordering
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+enum GameSet {
+    Input,
+    Movement,
+    Collision,
+    Render,
+}
+```
+
+For archetype layout, parallel query iteration, change-detection mechanics, and
+system-set scheduling in depth, use the `bevy-ecs-patterns` skill.


### PR DESCRIPTION
## What

`bevy-plugin/skills/bevy-game-engine/SKILL.md` sat at **10,189 chars** — 189 over the 10,000-char WARN threshold — with **no sidecar at all**. Split into a multi-file `references/` directory.

| | Chars | ~Tokens |
|---|---|---|
| SKILL.md before | 10,189 | ~2,547 |
| SKILL.md after | **6,492** | ~1,623 |
| Headroom under the WARN line | **3,508** | |

`plugin-compliance-check.sh` no longer lists `bevy-plugin/bevy-game-engine` in the size WARN band, and `check-context-engineering.py` no longer reports it as `C3 flat_large_body`.

## Why `references/`, not a single `REFERENCE.md`

Per `.claude/rules/skill-quality.md` § `references/` and `.claude/rules/context-engineering.md` C3. The corpus has 129 single sidecars and — before this — one `references/` split (#2143, `parallel-agent-dispatch`). A single sidecar defers content but is all-or-nothing; a reader wanting one topic loads every table in the file.

## The seams

Split by **consumer path**, not by size — a reader wanting one topic opens exactly one file.

| references/ | Path that needs it | Carries |
|---|---|---|
| `input.md` | Reading player input | `ButtonInput` keyboard/mouse polling, pressed vs just-pressed, cursor position, gamepad/rebinding pointers |
| `assets-and-states.md` | Loading assets, or driving the state machine | `AssetServer` handles + `LoadState` gating, `States` enum, `OnEnter`/`OnExit`/`run_if(in_state)`, `NextState` timing |
| `events.md` | Decoupling two systems that must communicate | `#[derive(Event)]`, `EventWriter`/`EventReader`, `add_event` registration, two-frame buffer + ordering caveat |
| `project-architecture.md` | Laying out a growing game, or chasing frame time | Directory layout, plugin/marker-component organization, query-filter + profiling guidance, bundles and system sets |

**Assets and states share a file** because they are one path in practice: the canonical loading screen is a state that exits once its handles resolve, and the moved `check_assets_loaded` example spans both. Splitting them would put half of one worked example in each file.

**No `rendering.md`.** The issue suggested one, but the body carries no rendering detail beyond a four-bullet capability list — that file would have meant writing new, unverified Bevy API content rather than splitting existing material. The bullets stay in the body's concept map. Worth a separate issue if the gap should be filled.

## What stays in SKILL.md

A self-sufficient entry point: the when-to-use table (kept — two sibling skills compete for the same intent, exactly the case `context-engineering.md` says it earns its tokens), the Core Expertise concept map, ECS fundamentals, app structure, the essential-commands block, the agentic-optimizations table, and a **pointer table naming each reference file and what it carries**.

The `cargo generate --git .../bevy_new_2d` guidance added by #2205 is untouched — it corrected genuinely stale advice (`cargo new my_game`) and is the reason the file crossed in the first place.

All moved content is **verbatim**; short orienting prose was added around each block so a reference file reads standalone (e.g. why handles must be held in a `Resource`, why `add_event` is required, the `OnEnter`/`OnExit`/`run_if` table).

## Checks run

| Check | Result |
|---|---|
| `bash scripts/plugin-compliance-check.sh` | `bevy-plugin` row all ✅ except the two pre-existing ⚠️ columns; **`bevy-game-engine` no longer in the size-WARN list** |
| `python3 scripts/audit-skill-structure.py` | exit 0, no `bevy` findings (174 lines, 92 fenced-code lines — both under thresholds) |
| `just lint-context-engineering` | `STATUS=WARN` (repo baseline); **`bevy-game-engine` absent from the C3 `flat_large_body` list** — only the sibling `bevy-ecs-patterns` remains |
| `bash scripts/lint-context-commands.sh` | `All context commands OK` |
| `bash scripts/check-skill-filename-case.sh` | `STATUS=OK` |
| pre-commit (on commit) | passed |

`bevy-ecs-patterns` (12,146 chars) is still in the WARN band — the issue names it as a companion, but it is out of scope here and left for a follow-up.

## Docs

`bevy-plugin/README.md` updated in the same commit (`.claude/rules/docs-currency.md`) to name the `references/` split and point at the SKILL.md pointer table, rather than duplicating the per-file descriptions.

Closes #2225
