### PR TITLE
refactor(agent-patterns-plugin): land the Tier C schema and prose deltas, no harness

### DIFF
--- a/agent-patterns-plugin/README.md
+++ b/agent-patterns-plugin/README.md
@@ -143,6 +143,7 @@ Dispatch contract for any workflow that spawns more than one agent in parallel �
 - Authoring agent prompts that need file/read/output budgets
 - Defining the mandatory Return Contract every parallel agent must emit on exit
 - Recovering from silent agent exits or worktree collisions
+- Mapping the Return Contract onto workflow primitives (a JSON Schema on the `agent()` call; `parallel()` as the barrier) before reaching for a harness
 
 #### `multi-model-delegation`
 Protocol for consulting *other* models (kimi, glm, gemini, gpt via the PAL MCP gateway) on design and judgment work — the complement of `parallel-agent-dispatch`, which delegates *work* to Claude subagents.
@@ -198,7 +199,8 @@ Verify an implementation meets its acceptance criteria by running the suite firs
 
 **Features:**
 - Execute-first: runs suite + typecheck + lint before any verdict
-- Per-criterion ledger grounding each requirement in execution evidence (PASS/FAIL/PARTIAL/UNVERIFIED)
+- `LEDGER` schema binding the verifier's output: one row per criterion, `verdict` enum (PASS/FAIL/PARTIAL/UNVERIFIED) grounded in execution evidence
+- Required `sequenceMatchesProduction` enum on every row — makes "I did not check the production call sequence" unrepresentable
 - Intent-starved isolated opus verifier — grades behaviour, not the author's rationale
 - Over-correction triage guarding both "pass broken code" and "fail correct code"
 

--- a/agent-patterns-plugin/skills/execution-grounded-review/SKILL.md
+++ b/agent-patterns-plugin/skills/execution-grounded-review/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "diff|PR|files to verify; optional --criteria <file> of acceptanc
 allowed-tools: Agent, Read, Glob, Grep, Bash(git diff *), Bash(git log *), Bash(gh pr view *), Bash(npm *), Bash(npx *), Bash(uv run *), Bash(pytest *), Bash(cargo *), Bash(go test *), TodoWrite
 model: opus
 created: 2026-06-22
-modified: 2026-07-28
+modified: 2026-08-07
 compatibility: claude-code
 reviewed: 2026-07-05
 ---
@@ -91,7 +91,64 @@ nothing to ground a verdict in. Each criterion is one ledger row in Step 3.
 ### Step 3: Dispatch the intent-starved verifier
 
 One `Agent`, `model: opus`, reading **only** the criteria, the diff, and the
-captured execution-evidence file — not the author's reasoning. Template:
+captured execution-evidence file — not the author's reasoning. Bind its output
+to the `LEDGER` schema below and paste that schema **verbatim** into the brief:
+a schema forces a determinate answer on every row where prose lets a row go
+quietly unanswered.
+
+#### The `LEDGER` schema
+
+```json
+{
+  "type": "object",
+  "required": ["rows", "coverage", "verdict"],
+  "properties": {
+    "rows": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["criterion", "evidence", "verdict", "sequenceMatchesProduction"],
+        "properties": {
+          "criterion": { "type": "string" },
+          "evidence": { "type": "string" },
+          "verdict": { "enum": ["PASS", "FAIL", "PARTIAL", "UNVERIFIED"] },
+          "sequenceMatchesProduction": { "enum": ["yes", "no", "not-applicable"] }
+        }
+      }
+    },
+    "coverage": { "type": "string" },
+    "verdict": { "enum": ["pass", "fail"] }
+  }
+}
+```
+
+`evidence` is the test name / `file:line` / observed output drawn from the
+execution-evidence file, or the literal `none`. `coverage` is
+`<#rows with PASS/FAIL evidence> / <total rows>`.
+
+| Row verdict | Meaning |
+|---|---|
+| `PASS` | execution evidence demonstrates the criterion holds |
+| `FAIL` | execution evidence demonstrates it is violated — name the concrete failing input/test |
+| `PARTIAL` | covered for some inputs; a *stated* edge case is unhandled |
+| `UNVERIFIED` | no execution exercises this criterion (a coverage gap) — never pass a row because the code "looks right" |
+
+**`sequenceMatchesProduction` is required on every row**, and that requirement
+is the entire gain of the schema. Step 3a's check is the one a verifier skips
+silently when it is only prose, because a green test *looks* like evidence — a
+required enum makes "I did not check" unrepresentable.
+
+| Value | When |
+|---|---|
+| `yes` | the test's operation sequence reproduces the real production call path |
+| `no` | the test passes over a shorter or rearranged sequence than production uses → the row's `verdict` becomes `UNVERIFIED` |
+| `not-applicable` | the criterion makes no round-trip / determinism / reproducibility / idempotence claim |
+
+The overall `verdict` is `pass` only when every row is `PASS` **and** no row is
+`sequenceMatchesProduction: "no"`. Any `FAIL`, any `UNVERIFIED`, or any sequence
+divergence makes it `fail`.
+
+Template:
 
 ```
 subagent_type: general-purpose
@@ -107,25 +164,20 @@ prompt: |
   Do NOT read the author's plan, commit narrative, or rationale — grade the
   behaviour, not the intent.
 
-  Build a ledger with ONE row per criterion:
-    CRITERION=<n: the criterion text>
-    EVIDENCE=<the test name / file:line / observed output that demonstrates it,
-              drawn from the execution evidence — or "none">
-    VERDICT=PASS|FAIL|PARTIAL|UNVERIFIED
-      PASS        — execution evidence demonstrates the criterion holds
-      FAIL        — execution evidence demonstrates it is violated (name the
-                    concrete failing input/test)
-      PARTIAL     — covered for some inputs, a stated edge case is unhandled
-      UNVERIFIED  — no execution exercises this criterion (a COVERAGE GAP; do
-                    NOT pass it on the basis that the code "looks right")
+  Emit ONE object conforming to this schema, with one row per criterion:
+    <paste the LEDGER schema verbatim>
 
-  Then:
-    COVERAGE=<#criteria with PASS/FAIL evidence> / <total criteria>
-    VERDICT: exactly one of `pass` | `fail`.
-      `pass` requires every criterion PASS with execution evidence.
-      Any FAIL, or any UNVERIFIED criterion, makes the overall verdict `fail`.
+  For every row, decide `sequenceMatchesProduction` explicitly: identify what
+  real call sequence exercises the claim in production and confirm the test
+  reproduces that sequence, not just a convenient shorter one.
   Cite evidence for every row. Your final message is the deliverable.
 ```
+
+> **No workflow harness here — deliberately.** The schema is the whole delta;
+> agent count stays at one. This skill is the Pillar-1 oracle other loops
+> delegate their stop condition to, so a fan-out design would multiply through
+> every iteration of every loop in the repo — the one place where per-invocation
+> cost compounds rather than adds (`.claude/rules/workflow-vs-skill.md`).
 
 For several independent targets, dispatch one verifier per target in a
 single-message parallel `Agent` batch — except on a `[1m]` model, where the
@@ -157,7 +209,8 @@ deferred state at the *same relative point in each stream*, so the round-trip
 passing test is real; it just exercises the one ordering that can't see the bug.
 
 Grade such a claim `UNVERIFIED` until the test reproduces the production
-sequence, even though a green test exists.
+sequence, even though a green test exists — that is the row whose
+`sequenceMatchesProduction` is `no`.
 
 ### Step 4: Triage against over-correction
 
@@ -204,4 +257,7 @@ human, not to keep grinding.
 - `workflow-orchestration-plugin:workflow-checkpoint-refactor` — a loop whose
   phase gate delegates its independent verdict here
 - `.claude/rules/loop-integrity.md` — Pillar 1: a loop's stop condition is judged
-  by an independent verifier like this one, not the worker
+  by an independent verifier like this one, not the worker. **Keep this literal
+  path in the body**: `scripts/check-loop-integrity.sh` requires the token
+  `loop-integrity.md` in this file, so a later "tighten the Related section" edit
+  that drops it fails the build.

--- a/agent-patterns-plugin/skills/parallel-agent-dispatch/REFERENCE.md
+++ b/agent-patterns-plugin/skills/parallel-agent-dispatch/REFERENCE.md
@@ -7,7 +7,7 @@ these links.
 
 | Path you are on | File | Carries |
 |---|---|---|
-| Composing the dispatch call and the brief's scaffolding | [`references/dispatch-contract.md`](references/dispatch-contract.md) | Return Contract schema (verbatim), failure mode → schema field, Skill-less `agentType` evidence (`skill_listing` tax) |
+| Composing the dispatch call and the brief's scaffolding | [`references/dispatch-contract.md`](references/dispatch-contract.md) | Return Contract schema (verbatim), failure mode → schema field, the contract as workflow primitives (JSON Schema + `parallel()` barrier, and their cost gate), Skill-less `agentType` evidence (`skill_listing` tax) |
 | Writing a refactor / bulk-edit brief | [`references/brief-templates.md`](references/brief-templates.md) | Refactor-brief template, completion manifest (#1601), verbatim-patch discipline, agent self-verification and reviewer-agent evidence |
 | An agent stalled, was cut off, went idle, was killed, or was rate-limited | [`references/failure-recovery.md`](references/failure-recovery.md) | Commit/push stall salvage, WIP salvage before re-dispatch (#1491), idle-without-report (#2039), `TaskStop` recovery + kill thresholds, rate-limit recovery-dispatch |
 | Setting up worktree isolation, or a git write went somewhere unexpected | [`references/worktree-hazards.md`](references/worktree-hazards.md) | cwd-reset guardrail (#1480), `GIT_DIR`-export leak (#1692), nested-repo isolation (#1838), target-branch preflight (#1969) |

--- a/agent-patterns-plugin/skills/parallel-agent-dispatch/SKILL.md
+++ b/agent-patterns-plugin/skills/parallel-agent-dispatch/SKILL.md
@@ -5,7 +5,7 @@ user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 model: opus
 created: 2026-04-21
-modified: 2026-07-29
+modified: 2026-08-07
 compatibility: claude-code
 reviewed: 2026-07-05
 ---
@@ -187,6 +187,19 @@ the only thing I can act on — a one-word summary loses all your work. On any
 blocker, push what you have, open a draft PR, and tell me exactly what stopped
 you."** Optional enforcement: a `SubagentStop` hook that flags sub-~20-char or
 bare-surrender final messages (see `hooks-plugin`).
+
+#### The same contract, expressed as workflow primitives
+
+A harness does not replace this contract; it turns what prose can only *request*
+into what a runtime *enforces*:
+
+| Here (prose) | Workflow primitive |
+|---|---|
+| The `## Result` schema pasted into each brief | a **JSON Schema** on the `agent()` call — validated, so a one-word surrender cannot parse |
+| "every returned summary parsed" (Orchestrator Checklist) | `parallel()` — the barrier that line already assumes |
+
+Cautions and the cost gate before reaching for one:
+[references/dispatch-contract.md → Workflow primitives](references/dispatch-contract.md#the-return-contract-as-workflow-primitives).
 
 ### 4. Agent self-verification in bulk-edit briefs
 

--- a/agent-patterns-plugin/skills/parallel-agent-dispatch/references/dispatch-contract.md
+++ b/agent-patterns-plugin/skills/parallel-agent-dispatch/references/dispatch-contract.md
@@ -47,6 +47,32 @@ Why each Return Contract field exists — the observed failure mode it catches.
 | Budget overrun | `status: partial` + explicit deferred list beats a truncated claim of success |
 | Pre-commit hook stall at commit time | `worktree: dirty: <files>` + `status: failed` with `Orchestrator action needed` naming the hook that blocked |
 | Concurrent rate-limit cascade | `status: partial` + recovery-dispatch follow-up agent on the unfinished slice |
+## The Return Contract as workflow primitives
+
+`SKILL.md` § Return Contract carries the mapping table; this is what to weigh
+before turning it into a harness.
+
+- **A schema-bound agent has no partial result.** An `agent()` bound to a
+  `StructuredOutput` schema that is cut off *before* it emits — a rate-limit
+  storm, a context exhaustion — is reported to the caller as a hard parse
+  failure, not as partial output, even when substantial work was done inside its
+  context window (issue
+  [#1463](https://github.com/laurigates/claude-plugins/issues/1463)). The prose
+  contract degrades more gracefully: a worktree still holds the work, and the
+  empty-vs-dirty discrimination in
+  [failure-recovery.md](failure-recovery.md) recovers it. Cap schema-bound waves
+  and stagger their launches —
+  `workflow-orchestration-plugin:workflow-wave-dispatch` § Schema-Constrained
+  Agents Under Rate-Limit Storms owns those numbers.
+- **`parallel()` is a barrier, not a speedup.** Its value here is that no stage
+  may begin before every branch of the previous one returned. If the "barrier"
+  is really a summary the last agent could have written inline, the harness
+  bought nothing.
+- **The cost gate.** A harness costs **one opus agent per fan-out unit, per
+  invocation** — `.claude/rules/workflow-vs-skill.md` is the gate, and it
+  rejects a harness for *this* skill: it is reference doctrine with no execution
+  body of its own, so there is no N to enumerate and no stage to barrier.
+
 ## Skill-less agentType — evidence
 
 `SKILL.md` § "Skill-less agentType for Read-Only Fan-Out" carries the routing

--- a/workflow-orchestration-plugin/skills/workflow-wave-dispatch/SKILL.md
+++ b/workflow-orchestration-plugin/skills/workflow-wave-dispatch/SKILL.md
@@ -4,7 +4,7 @@ description: Sequential-wave dispatch for multi-agent work with cross-task depen
 user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 created: 2026-04-24
-modified: 2026-06-23
+modified: 2026-08-07
 reviewed: 2026-06-23
 ---
 
@@ -152,6 +152,7 @@ referenced — never restated — when scheduling waves:
 | Dispatching wave N+1 after a gate failure to "patch over it" | Fix in place, retry the gate; revert and re-brief if unrecoverable |
 | Scheduling extensions before the foundation they import | Foundation in the earliest implementation wave, extensions later |
 | Running the lock-holder concurrently with its consumers | Lock-holder alone in its wave; downstream reads pre-dumped artefacts |
+| Enforcing the wave boundary by discipline alone | Express it as a `parallel()` barrier |
 
 ## Related
 


### PR DESCRIPTION
Tier C of the dynamic-workflow migration (#2174): three skills **survived** adversarial triage, and for all three the honest outcome is a schema or prose edit — **not** a workflow harness. The shared finding is the point: *surviving triage is not the same as deserving a `.js`.*

**No `.js` file ships in any of the four deltas.**

## 1. `agent-patterns-plugin/execution-grounded-review` — the schema, not the harness

Binds the intent-starved verifier's output to a `LEDGER` JSON Schema whose rows require **`sequenceMatchesProduction`** (`yes` | `no` | `not-applicable`), alongside the existing `verdict` enum. The overall verdict is `pass` only when every row is `PASS` **and** no row is `sequenceMatchesProduction: "no"`.

That required field is the entire gain. Step 3a's production-call-sequence check (#1968) is exactly the check a verifier skips *silently* when it is only prose — a green test looks like evidence. A required enum makes "I did not check" unrepresentable, at **zero added agents**.

*Why no harness:* this skill is the Pillar-1 oracle that other loops delegate their stop condition to (`.claude/rules/loop-integrity.md`). A fan-out design multiplies through **every iteration of every loop in the repo** — the one place in this codebase where per-invocation cost compounds rather than adds. The skill body now carries that reasoning in a callout so the next reader does not re-litigate it.

**Build-fragility note landed with the delta:** the Related entry now states inline that the literal token `loop-integrity.md` must stay in the body, because `scripts/check-loop-integrity.sh` requires it (verified at line 74 of the current script — the issue's `:74` citation still holds). A later "tighten the Related section" edit would otherwise fail the build with no clue why.

## 2. `agents-plugin/agents-analyze` — **no-op: no drift evidence found**

The delta was explicitly conditional: chunk the forked agent's TodoWrite list **only if goal drift across ~40 plugins is actually observed**. I looked, found no evidence, and left the skill untouched rather than invent a fix.

| Where I looked | Result |
|---|---|
| `gh issue list` / `gh search issues` for `agents-analyze`, all states | 17 hits, **none** reporting drift, truncation, or incomplete coverage. All are `context: fork` rollout (#980, #1667, #1971, #2165), changelog reviews, or this migration's own issues |
| `git log` on `agents-plugin/skills/agents-analyze/` (20 commits) | Every commit is metadata: frontmatter, description-length trims, `context: fork` rollout, always-Opus reconciliation. **No bug-fix commit** for incomplete or drifting analysis |
| `.claude/rules/regression-testing.md` "Known Regressions" table | One `agents-analyze` row, and it is the `context: fork` rollout (#1667). No coverage/drift entry — meaningful, since that table records defects for many sibling skills |
| The skill body itself | **There is no TodoWrite step to chunk.** `TodoWrite` appears only in `allowed-tools`; the body's Steps 1–5 never build a per-plugin todo list. "Chunk the existing TodoWrite list" would have meant *inventing* the list first |

The plan itself hedges the row (*"If goal drift across 40 plugins is real…"*, `docs/plans/dynamic-workflow-migration.md` row 11). Absent evidence, the correct outcome is the recorded no-op. If drift is observed later, the fix stays cheap and stays inside the already-forked agent.

This still resolves half of #2165 by construction: with no harness, `agents-analyze`'s `context: fork` pin needs no reconciliation.

## 3. `workflow-orchestration-plugin/workflow-wave-dispatch` — one table row

| Mistake | Correction |
|---|---|
| Enforcing the wave boundary by discipline alone | Express it as a `parallel()` barrier |

Nothing more. This is the sharpest finding of the evaluation: the proposed harness required a fixed `args.waves` array, which **is** writing wave N+1's plan before wave N's gate has run — the exact thing the skill forbids, twice, in its own body. The harness would have encoded a violation of the doctrine it was meant to serve. So the doctrine gains the one line that makes the barrier expressible, and the harness stays unwritten.

## 4. `agent-patterns-plugin/parallel-agent-dispatch` — Return Contract → workflow primitives

A short section under § Return Contract mapping the prose contract onto the two primitives it already implies:

- the `## Result` schema pasted into each brief → a **JSON Schema** on the `agent()` call, so a one-word surrender (#1422) *cannot parse* rather than merely violating a request;
- *"every returned summary parsed"* from the Orchestrator Checklist → **`parallel()`**, the barrier that line already assumes.

The cautions and the cost gate live in `references/dispatch-contract.md` § "The Return Contract as workflow primitives" (schema-bound agents have **no partial result** when cut off — #1463; `parallel()` is a barrier, not a speedup; and `.claude/rules/workflow-vs-skill.md` rejects a harness for this skill, which is reference doctrine with no execution body, hence no N to enumerate). `REFERENCE.md`'s index row was repointed in the same commit.

## Release scope

Squash-merge lands only this PR title's scope. It is `refactor(...)`, so **no plugin version bumps** — which is correct for all three touched plugins. Plugins changed:

| Plugin | Changed | Bumps? |
|---|---|---|
| `agent-patterns-plugin` | `execution-grounded-review/SKILL.md`, `parallel-agent-dispatch/{SKILL.md,REFERENCE.md,references/dispatch-contract.md}`, `README.md` | No (`refactor`) |
| `workflow-orchestration-plugin` | `workflow-wave-dispatch/SKILL.md` (one table row) | No — changed without appearing in the PR scope, and deliberately not bumped |
| `agents-plugin` | **untouched** (see §2) | — |

## Checks

| Check | Result |
|---|---|
| `bash scripts/check-loop-integrity.sh` | `STATUS=OK ISSUE_COUNT=0`, exit 0 |
| `bash scripts/plugin-compliance-check.sh` | exit 0, **zero ❌** |
| `bash scripts/run-skill-script-tests.sh` | `TOTAL=85 FAILED=0 STATUS=OK` |
| `bash scripts/check-agent-failure-contract.sh` | OK — all pinned literals in `parallel-agent-dispatch` survive |
| `bash scripts/check-docs-index.sh` | `STATUS=WARN`, 1 issue — pre-existing (`generated-fleet-drift.md` from #2261), untouched here |
| `bash scripts/check-version-pin-coverage.sh` | `STATUS=OK` |
| `python3 scripts/audit-skill-descriptions.py --strict-length` | clean |
| pre-commit (full hook set, on commit) | passed |

### Size budgets

| Skill | Before | After | Ceiling |
|---|---|---|---|
| `execution-grounded-review` | 11,511 | 13,828 | 26,000 (WARN band both sides) |
| `parallel-agent-dispatch` | 24,184 | 24,849 | 26,000 — **1,151 chars headroom** |
| `workflow-wave-dispatch` | 8,287 | 8,378 | 26,000 (OK) |

`parallel-agent-dispatch` is the tight one. #2174's extraction pass deliberately created ~2,600 chars of headroom there; this delta spends ~665 of it, so the SKILL-side addition was kept to a two-row table with the detail in `references/`. Anything further on that skill should extract before it adds.

Closes #2173
