### PR TITLE
docs(rules): correct how release-please routes commits to packages

### DIFF
--- a/.claude/rules/conventional-commits.md
+++ b/.claude/rules/conventional-commits.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-02-14
-modified: 2026-07-29
-reviewed: 2026-07-29
+modified: 2026-08-07
+reviewed: 2026-08-07
 ---
 
 # Conventional Commits Standards
@@ -32,21 +32,31 @@ Subjects are imperative, lowercase after the colon, no trailing period.
 A `!` before the colon (`feat(api)!: redesign endpoints`) or a
 `BREAKING CHANGE:` footer forces a **major** bump regardless of type.
 
-## Scope is the package name (monorepo)
+## Scope is a label; the files touched decide what releases
 
-release-please decides **which package to release** from the scope, so here the
-scope must be the plugin directory name:
+Three inputs, routinely conflated:
 
-```
-feat(blueprint-plugin): add new command syntax
-fix(git-plugin): handle merge conflicts
-```
+| Input | Decides |
+|-------|---------|
+| Commit **type** (`feat`, `fix`, …) | the bump **size** |
+| **Files touched** | **which packages** bump |
+| **Scope** | the changelog label — nothing else |
 
-`release-please-config.json` declares 44 plugin components and **no root (`.`)
-package**, so a scope that matches no package — including an unscoped bare
-`feat:` — produces no release at all. That is the usual reason a merged `feat`
-never cut a version, and it is also used deliberately (see the `blueprint`
-scope in `CLAUDE.md`, which exists precisely because it matches nothing).
+`release-please-config.json` is a 44-package manifest keyed by plugin
+directory, so a commit is routed to **every package whose directory it
+touches**. A scope matching no package does *not* suppress the release:
+
+| Commit | Released |
+|--------|----------|
+| `fix(testing-plugin): …` (#2196) | code-quality-plugin, documentation-plugin, testing-plugin — patch |
+| `feat(scripts): …` (#2254) | comfyui-plugin, migration-patterns-plugin, testing-plugin — minor |
+| `feat(repo): …` (#1971) | all five plugin dirs it touched — minor |
+
+Still write the scope as the plugin directory name: it is what readers see, and
+a wrong one mislabels every package the commit touched (`code-quality-plugin`
+1.22.1 carries `**testing-plugin:**`). But do not rely on it to *contain* a
+release. To keep a plugin unpublished, change no files under its directory, or
+use a type that does not bump.
 
 ## Issue references
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,7 @@ This repo runs `blueprint-plugin` against itself in a deliberately constrained m
 | `feat(blueprint-plugin): …` | Minor version bump on the published plugin | Skill changes inside `blueprint-plugin/` |
 | `fix(blueprint-plugin): …` | Patch version bump | Bug fixes inside `blueprint-plugin/` |
 
-The `blueprint` scope (no `-plugin` suffix) intentionally does **not** match any release-please package, so dogfooding maintenance never accidentally publishes the plugin.
+What keeps dogfooding from publishing the plugin is the `chore` **type** (no bump) plus keeping edits under `docs/blueprint/` — **not** the `blueprint` scope. release-please routes by files touched, not by scope (`.claude/rules/conventional-commits.md`), so `fix(blueprint): …` on a file inside `blueprint-plugin/` **would** publish.
 
 ## Conventions
 

--- a/docs/blueprint/README.md
+++ b/docs/blueprint/README.md
@@ -73,7 +73,7 @@ Curated AI context lives in `.claude/rules/` (hand-written here); the former `ai
 | `feat(blueprint-plugin): …` | Minor version bump on `blueprint-plugin` | Skill changes inside `blueprint-plugin/` |
 | `fix(blueprint-plugin): …` | Patch version bump | Bug fixes inside `blueprint-plugin/` |
 
-The unscoped `blueprint` scope deliberately exists separately from `blueprint-plugin` so dogfooding maintenance never accidentally publishes the plugin.
+The `blueprint` scope exists to keep dogfooding commits legible in the changelog — it is **not** what stops them publishing the plugin. release-please routes a commit to every package whose directory it touches, regardless of scope (`.claude/rules/conventional-commits.md`). What actually protects the plugin is the `chore` **type** (no bump) plus keeping these edits under `docs/blueprint/`. A `fix(blueprint): …` touching a file inside `blueprint-plugin/` **would** publish.
 
 ## Re-enabling tasks
 


### PR DESCRIPTION
Three docs stated that release-please decides **which package to release** from the commit *scope*, and that a scope matching no package produces no release at all. Both are false in this repo, and one of them is load-bearing as a safety belief.

## The actual mechanism

`release-please-config.json` is a 44-package manifest keyed by plugin directory. Commits are routed to **every package whose directory they touch**. Three inputs, routinely conflated:

| Input | Decides |
|-------|---------|
| Commit **type** (`feat`, `fix`, …) | the bump **size** |
| **Files touched** | **which packages** bump |
| **Scope** | the changelog label — nothing else |

## Verified against release history, not docs

| Commit | Scope matches a package? | Released |
|--------|---|----------|
| `fix(testing-plugin): …` ([#2196](https://github.com/laurigates/claude-plugins/issues/2196)) | yes | code-quality-plugin 1.22.1, documentation-plugin 1.10.1, testing-plugin 3.17.1 — patch |
| `feat(scripts): …` ([#2254](https://github.com/laurigates/claude-plugins/issues/2254)) | **no** | comfyui-plugin, migration-patterns-plugin, testing-plugin — **minor** |
| `feat(repo): …` ([#1971](https://github.com/laurigates/claude-plugins/issues/1971)) | **no** | all five plugin dirs it touched — **minor** |

`code-quality-plugin` 1.22.1's changelog entry is labelled `**testing-plugin:**` — the scope travelled as a label into a package it does not name.

## The safety belief this corrects

`CLAUDE.md` and `docs/blueprint/README.md` both claimed the unscoped `blueprint` scope is what stops dogfooding maintenance publishing `blueprint-plugin`. It is not. The protection is the `chore` **type** (no bump) plus keeping edits under `docs/blueprint/`. A `fix(blueprint): …` touching a file inside `blueprint-plugin/` **would** publish.

That is the one worth landing — the rest is accuracy, this one is a guard someone could rely on.

## Consequence for #2277

[#2277](https://github.com/laurigates/claude-plugins/pull/2277)'s body offers three options (merge-as-is and cut the others manually / retitle / split into four PRs) for containing a release to one plugin. All three answer a constraint that does not exist: squash-merging it as titled already bumps all four plugins it touches. Rebase-merging would be slightly worse — it lands a `chore(hooks): checkpoint …` commit on `main` for no release benefit.

## Scope of this change

Docs only. Touches no plugin directory, so nothing releases — which is itself consistent with the corrected model.

- `.claude/rules/conventional-commits.md` — § rewritten; net +22 lines on an always-loaded surface, C5 ratchet still passes
- `CLAUDE.md` — one sentence
- `docs/blueprint/README.md` — one sentence

Swept the corpus for other instances of both claims; `git-plugin:release-please-configuration` was checked and is accurate (it documents component tags, not scope routing).

Refs #2277