### PR TITLE
fix(scripts): unbreak main — two independent defects in the #2219 guard work

### DIFF
--- a/scripts/check-version-pin-coverage.sh
+++ b/scripts/check-version-pin-coverage.sh
@@ -211,17 +211,25 @@ files_scanned=${#scan_files[@]}
 # Plugin directories present but no skill markdown discovered means the scan
 # misfired (a prune that swallowed the root); no plugin directories at all means
 # there is genuinely nothing to audit.
-plugin_dir_count=$(find . -maxdepth 1 -type d -name '*-plugin' -not -name '.claude-plugin' 2>/dev/null | wc -l | tr -d ' ')
+# The population signal is a plugin dir that actually HAS a skills/ tree, not a
+# plugin dir per se. A plugin carrying only templates/ (or only agents/) is a
+# legitimate zero-markdown corpus, and counting it made a template-only tree
+# report a misfire it had not suffered. A prune that swallows the scan root
+# still fires: every real plugin dir has skills/, so the count stays > 0.
+plugin_dir_count=$(find . -maxdepth 2 -type d -name 'skills' -not -path '*/.claude/worktrees/*' -not -path '*/dist/*' 2>/dev/null | wc -l | tr -d ' ')
+# Recorded as a normal ERROR issue rather than an early exit. The misfire is a
+# verdict about the MARKDOWN corpus only, and the scaffold-template scan below
+# (#2222) is independent of it — reading its own file set and emitting its own
+# TEMPLATE_* counters. Exiting here suppressed that scan entirely, so a
+# template-only tree (plugin dirs + templates, no skill markdown) reported
+# neither counter and any consumer reading TEMPLATE_FILES_SCANNED got an empty
+# string. Falling through keeps the check loud: the ERROR still forces
+# STATUS=ERROR and `--strict` still exits 1, via the normal report path.
+# The markdown parse block below is already gated on `files_scanned > 0`, so it
+# no-ops on an empty corpus without needing a second guard.
 if [ "$files_scanned" -eq 0 ] && [ "$plugin_dir_count" -gt 0 ]; then
-  echo "=== VERSION PIN COVERAGE ==="
-  echo "FILES_SCANNED=0"
-  echo "PLUGIN_DIRS=$plugin_dir_count"
-  echo "STATUS=ERROR"
-  echo "ISSUE_COUNT=1"
-  echo "ISSUES:"
-  echo "  - SEVERITY=ERROR TYPE=nothing_scanned MSG=$plugin_dir_count plugin dirs but zero skill markdown discovered; scan misfired (see #2219)"
-  echo "=== END VERSION PIN COVERAGE ==="
-  exit 1
+  add_issue ERROR nothing_scanned \
+    "$plugin_dir_count plugin dirs but zero skill markdown discovered; scan misfired (see #2219)"
 fi
 
 # Fence-awareness comes from a real markdown parse (tree-sitter via the shared
@@ -498,6 +506,7 @@ fi
 # --- Output -------------------------------------------------------------------
 echo "=== VERSION PIN COVERAGE ==="
 echo "FILES_SCANNED=$files_scanned"
+echo "PLUGIN_DIRS=$plugin_dir_count"
 echo "USES_COVERED=$uses_covered"
 echo "FROM_COVERED=$from_covered"
 echo "IMAGE_COVERED=$image_covered"

--- a/scripts/tests/test-guard-worktree-root-discovery.sh
+++ b/scripts/tests/test-guard-worktree-root-discovery.sh
@@ -42,6 +42,15 @@ assert() {
 is_true() { [ "$1" = "true" ] && echo true || echo false; }
 contains() { printf '%s' "$1" | grep -q -- "$2" && echo true || echo false; }
 
+# Whole-LINE match. Required for NEGATIVE assertions over KEY=VALUE output:
+# `contains` is an unanchored substring test, so asserting "does not report
+# FILES_SCANNED=0" against a guard that legitimately emits BOTH
+# `FILES_SCANNED=1` and `TEMPLATE_FILES_SCANNED=0` matches inside the SECOND
+# key and fires on correct behaviour. A here-string (not a pipe) keeps this
+# safe under `set -o pipefail` — `grep -q` closes stdin on first match and a
+# piped writer would take SIGPIPE (141). See shell-pipefail-grep-q.md.
+contains_line() { grep -qxF -- "$2" <<<"$1" && echo true || echo false; }
+
 # Build a fixture whose ROOT PATH is worktree-shaped, exactly like a real
 # `<repo>/.claude/worktrees/agent-<id>` checkout.
 fx="$(mktemp -d)"
@@ -94,7 +103,7 @@ out="$(bash "$repo_root/scripts/check-unused-bash-grant.sh" --project-dir "$wt" 
 assert "check-unused-bash-grant: exits 0 from a worktree-shaped root" "$(is_true "$([ $rc -eq 0 ] && echo true)")"
 assert "check-unused-bash-grant: reports a NON-ZERO scan count" "$(contains "$out" 'SKILLS_SCANNED=1')"
 assert "check-unused-bash-grant: does not report SKILLS_SCANNED=0" \
-  "$([ "$(contains "$out" 'SKILLS_SCANNED=0')" = false ] && echo true || echo false)"
+  "$([ "$(contains_line "$out" 'SKILLS_SCANNED=0')" = false ] && echo true || echo false)"
 
 # The zero-scan discriminator: plugin dirs present but nothing discovered is a
 # MISFIRE and must be loud, not a green "nothing to do".
@@ -118,7 +127,7 @@ if command -v uv >/dev/null 2>&1; then
   out="$(bash "$repo_root/scripts/check-version-pin-coverage.sh" --project-dir "$wt" 2>&1)"; rc=$?
   assert "check-version-pin-coverage: reports a NON-ZERO scan count" "$(contains "$out" 'FILES_SCANNED=1')"
   assert "check-version-pin-coverage: does not report FILES_SCANNED=0" \
-    "$([ "$(contains "$out" 'FILES_SCANNED=0')" = false ] && echo true || echo false)"
+    "$([ "$(contains_line "$out" 'FILES_SCANNED=0')" = false ] && echo true || echo false)"
 else
   echo "SKIP: uv not on PATH — check-version-pin-coverage needs it to parse markdown"
 fi


### PR DESCRIPTION
**Unblocks every open PR**, including release-please's `chore: release main` (#2296). `compliance` is a required check and it is red on `main` for PRs touching none of the implicated files.

There are **two** independent defects. The first was reported by two rebasing agents; the second only surfaced after fixing the first, because it was hidden behind it.

---

## Defect 1 — an unanchored negative assertion

`scripts/tests/test-guard-worktree-root-discovery.sh` (#2290) asserts *"does not report `FILES_SCANNED=0`"* with an **unanchored** `grep -q`. `check-version-pin-coverage.sh` legitimately emits **both**:

```
FILES_SCANNED=1            <- correct: the fixture skill WAS discovered
TEMPLATE_FILES_SCANNED=0   <- correct: no template files in the fixture
```

The needle matches **inside** the second key, so the assertion fires on correct behaviour.

**Fix:** a `contains_line()` helper (`grep -qxF`). The sibling `SKILLS_SCANNED=0` assertion has the identical shape and is converted too — latent today, one new `*_SKILLS_SCANNED` key away from firing.

Verified in both directions, because a negative assertion that can never match also passes:

| Input | Expect | Result |
|---|---|---|
| healthy (`FILES_SCANNED=1` + `TEMPLATE_FILES_SCANNED=0`) | not flagged | `false` ✅ |
| genuinely zero (`FILES_SCANNED=0`) | **still caught** | `true` ✅ |
| old unanchored form on healthy output | (the bug) | `true` ✅ |

Here-string not pipe: `grep -q` closes stdin on first match and a piped writer takes SIGPIPE (141) under `pipefail` (`shell-pipefail-grep-q.md`).

---

## Defect 2 — a cross-PR interaction that neither PR could have caught

- **#2287** added the scaffold-template scan (`TEMPLATE_FILES_SCANNED` / `TEMPLATE_PINS_COVERED`)
- **#2290** added a `nothing_scanned` guard that **exits 1 early** when plugin dirs exist but zero skill markdown is found

The early exit sits **above** the template scan. On a template-only tree the scan never ran and neither counter was emitted, so consumers read an *empty string* rather than a number — `test-check-version-pin-coverage.sh` TEST I failed 5 assertions with `[: : integer expected`.

Each PR was green alone. The interaction exists only once both are on `main`, and CI tested each against a `main` lacking the other.

**Fix, two parts:**

1. The misfire is recorded via `add_issue ERROR nothing_scanned` and falls through to the normal report instead of exiting. Still loud — the ERROR forces `STATUS=ERROR` and `--strict` still exits 1 — but the independent template scan now runs. The markdown parse block was already gated on `files_scanned > 0`, so it no-ops unchanged. `PLUGIN_DIRS=` moves into the normal report so nothing is lost.
2. The population signal is now a plugin dir that actually **has a `skills/` tree**, not a plugin dir per se. A plugin carrying only `templates/` is a legitimate zero-markdown corpus; counting it made a template-only tree report a misfire it had not suffered.

Verified both directions, since a discriminator that never fires would also pass:

| Fixture | Expect | Result |
|---|---|---|
| `skills/` tree present, zero markdown | `nothing_scanned` ERROR | ✅ teeth retained |
| templates only, no `skills/` | no misfire **and** template scan runs | ✅ `TEMPLATE_FILES_SCANNED=1`, flat unmanaged pin still flagged |

A prune that swallows the scan root — #2219's actual defect — still fires, because every real plugin dir has a `skills/` tree.

---

## Verification

- `test-check-version-pin-coverage.sh` → **37 passed, 0 failed** (was 32/5)
- `test-guard-worktree-root-discovery.sh` → **21 passed, 0 failed** (was 20/1)
- Real repo: `FILES_SCANNED=593 PLUGIN_DIRS=45 TEMPLATE_FILES_SCANNED=5 TEMPLATE_PINS_COVERED=22 STATUS=WARN ISSUE_COUNT=14` — the documented post-#2214 baseline
- `shellcheck` clean; pre-commit green including both guards' own hooks

Both defects reproduced on an unmodified checkout of `main` before any edit.

Refs #2219, Refs #2222