### PR TITLE
feat(testing-plugin): ship the test-analyze classify-and-act harness template

### DIFF
--- a/testing-plugin/skills/test-analyze/SKILL.md
+++ b/testing-plugin/skills/test-analyze/SKILL.md
@@ -4,8 +4,8 @@ args: "<results-path> [--type <test-type>] [--focus <area>]"
 argument-hint: "Path to test results (e.g., ./test-results/), optional --type and --focus filters"
 allowed-tools: Task, Read, Glob, Grep, TodoWrite
 created: 2025-12-16
-modified: 2026-08-07
-reviewed: 2026-08-07
+modified: 2026-08-08
+reviewed: 2026-08-08
 name: test-analyze
 agent: general-purpose
 context: fork
@@ -88,6 +88,8 @@ Analyzes test results from any testing framework, uses Zen planner to create a s
 
 **This table is the single source of truth for delegation.** Every `subagent_type` this skill dispatches is listed here; no other section restates it. The values are plugin-qualified `plugin:agent` IDs — the form the `Task`/`Agent` tool resolves for plugin-provided agents (a bare name only resolves for user- or project-level agents in `~/.claude/agents/` or `.claude/agents/`).
 
+It is also the contract the workflow harness's `category` enum and `AGENT_FOR` map encode — **edit them together.** `scripts/check-subagent-types.sh` fails CI if any value here stops resolving to a real `agents-plugin/agents/*.md`.
+
 | Issue category | Triggers | Dispatch | Focus to pass |
 |---|---|---|---|
 | Accessibility violations | WCAG, ARIA, colour contrast, keyboard nav | `subagent_type: agents-plugin:review` | WCAG 2.1 compliance, semantic HTML, ARIA best practices |
@@ -98,6 +100,43 @@ Analyzes test results from any testing framework, uses Zen planner to create a s
 | Integration failures | Failing behaviour needing root-cause diagnosis | `subagent_type: agents-plugin:debug` | Root cause, minimal fix, verification |
 | Build / CI failures | Pipeline errors, dependency issues | `subagent_type: agents-plugin:ci` | GitHub Actions, dependency management, caching |
 | Documentation gaps | Missing docs, outdated examples | `subagent_type: agents-plugin:docs` | API docs, test documentation, migration guides |
+
+## Workflow harness (template)
+
+`workflows/test-analyze.workflow.js` ships beside this skill. **It is a TEMPLATE to adapt,
+not a script to run verbatim.** Read it, then rewrite it for the work in front of you.
+
+**Adapt freely:** the agent prompts, the severity vocabulary, the result-file globs and
+format hints for your test framework, the `--focus` weighting, and the verification
+command each plan agent is told to emit.
+
+**Preserve across any adaptation:** (a) the fan-out width comes from the `AGENT_FOR`
+table above — one agent per *agent type*, never a prose "for each failure", which is what
+caps the harness at 8 concurrent agents; (b) the `category` and `severity` enums in
+`RoutedFailuresSchema`, which force every failure either onto a route or into
+`unroutable[]` with a stated reason instead of the nearest-looking row; (c) the
+`parallel()` barrier before Synthesize — group agents emit `depends_on` edges pointing at
+failures in *other* groups, so the ordering only exists once every group has returned.
+
+**Skip the harness when:** there are fewer than 5 routable failures — the script returns
+`{mode:'inline'}` at that floor, because below it one opus agent per category costs more
+than the linear pass. That floor is a hard bound, not a tunable knob. The steps below
+remain the authoritative description of *what* each stage must produce; the harness only
+fixes *how* the work is split.
+
+Two consequences worth stating inline:
+
+- **The harness surrenders `mcp__pal__planner`.** A workflow script cannot reach MCP
+  tools, so the dependency edges in the merged plan are *inferred by the group agents*,
+  not planned. A run that genuinely needs PAL planning (Step 2 below) should stay inline.
+- **`context: fork` stays, and it is not what justifies the harness.** The pin lives in
+  `scripts/plugin-compliance-check.sh` (the `context: fork` guard list, currently around
+  lines 898–914) and is unchanged by this template. Per
+  `.claude/rules/workflow-vs-skill.md` § "The `context: fork` corollary", fork already
+  bought context isolation for free — so this harness has to earn its tokens by
+  **splitting** the planning work across agent types behind a real barrier, which it does.
+  The `parallel()` width is capped at the fixed agent-type set (8) precisely so it does
+  not become the wide fan-out `.claude/rules/skill-fork-context.md` warns about.
 
 ## Output
 

--- a/testing-plugin/skills/test-analyze/workflows/test-analyze.workflow.js
+++ b/testing-plugin/skills/test-analyze/workflows/test-analyze.workflow.js
@@ -1,0 +1,215 @@
+/**
+ * test-analyze — classify-and-act harness.
+ *
+ * TEMPLATE, not a runnable script. Read `../SKILL.md` § "Workflow harness
+ * (template)" before adapting it; invoking this file against empty `args`
+ * spends real opus agents to discover that it is a template.
+ *
+ * Shape: classify-and-act (docs/plans/dynamic-workflow-migration.md §4).
+ *   Parse+classify (1 agent)  →  plan per agent type (≤8 in parallel)  →  synthesize (1 agent)
+ *
+ * Three things are structure, not preference (see SKILL.md for the full framing):
+ *   1. The fan-out width is `AGENT_FOR`'s key set — a fixed table of agent types
+ *      that exist on disk, never a count the model invents.
+ *   2. `category` / `severity` are closed enums, so every failure either routes
+ *      or lands in `unroutable[]` with a stated reason.
+ *   3. `parallel()` is a real barrier: `depends_on` edges cross groups, so
+ *      sequencing cannot happen inside a group.
+ *
+ * Classify is deliberately MERGED into parse: an 8-row lookup plus a 4-value
+ * enum is something the parse agent can do while it already holds the failures.
+ * A separate classifier agent would be pure overhead.
+ *
+ * `mcp__pal__planner` is NOT available inside a workflow. The dependency edges
+ * below are *inferred* by the group agents, not planned. A run that genuinely
+ * needs PAL planning belongs on the inline path in SKILL.md.
+ */
+
+// --- The contract this harness shares with SKILL.md § Subagent Routing -------
+// Editing either side alone breaks the skill. The keys are the table's "Issue
+// category" column; the values are its "Dispatch" column, in the
+// plugin-qualified `plugin:agent` form the Task/Agent tool resolves for a
+// plugin-provided agent. Every value below is backed by a real
+// `agents-plugin/agents/<name>.md` — `scripts/check-subagent-types.sh` is the
+// guard that keeps the SKILL.md side honest.
+const AGENT_FOR = {
+  accessibility: 'agents-plugin:review',
+  security: 'agents-plugin:security-audit',
+  performance: 'agents-plugin:performance',
+  quality: 'agents-plugin:refactor',
+  flaky: 'agents-plugin:test',
+  integration: 'agents-plugin:debug',
+  ci: 'agents-plugin:ci',
+  docs: 'agents-plugin:docs',
+};
+
+const CATEGORIES = Object.keys(AGENT_FOR); // 8 — the structural fan-out cap
+const SEVERITIES = ['critical', 'high', 'medium', 'low'];
+
+// A failure count below this stays on the inline path in SKILL.md. HARD FLOOR,
+// not a knob: below it, one opus agent per category costs more than the linear
+// pass it replaces.
+const INLINE_FLOOR = 5;
+
+const RoutedFailuresSchema = {
+  type: 'object',
+  required: ['failures', 'unroutable'],
+  properties: {
+    failures: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['id', 'test', 'message', 'category', 'severity'],
+        properties: {
+          id: { type: 'string' },
+          test: { type: 'string' },
+          file: { type: 'string' },
+          message: { type: 'string' },
+          stack_head: { type: 'string' },
+          category: { type: 'string', enum: CATEGORIES },
+          severity: { type: 'string', enum: SEVERITIES },
+        },
+      },
+    },
+    // Anything that fits no category lands here WITH a reason, rather than
+    // being forced into the nearest-looking row.
+    unroutable: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['id', 'test', 'reason'],
+        properties: {
+          id: { type: 'string' },
+          test: { type: 'string' },
+          reason: { type: 'string' },
+        },
+      },
+    },
+  },
+};
+
+const PlanSchema = {
+  type: 'object',
+  required: ['agentType', 'items'],
+  properties: {
+    agentType: { type: 'string' },
+    items: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['id', 'objective', 'success_criteria', 'verification'],
+        properties: {
+          id: { type: 'string' },
+          objective: { type: 'string' },
+          success_criteria: { type: 'string' },
+          // Failure ids, which may belong to ANOTHER group — this is why the
+          // barrier below exists.
+          depends_on: { type: 'array', items: { type: 'string' } },
+          verification: { type: 'string' },
+        },
+      },
+    },
+  },
+};
+
+const FixPlanSchema = {
+  type: 'object',
+  required: ['ordered_steps', 'unroutable'],
+  properties: {
+    ordered_steps: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['id', 'agentType', 'objective', 'verification'],
+        properties: {
+          id: { type: 'string' },
+          agentType: { type: 'string' },
+          objective: { type: 'string' },
+          success_criteria: { type: 'string' },
+          verification: { type: 'string' },
+        },
+      },
+    },
+    unroutable: { type: 'array', items: { type: 'object' } },
+    dropped_groups: { type: 'array', items: { type: 'string' } },
+  },
+};
+
+// --- Stage 1: parse + classify (one agent, no separate classifier) -----------
+phase('Parse + classify');
+const parsed = await agent(
+  `Read every result file under ${args.resultsPath}.
+   ${args.testType ? `Test type: ${args.testType}.` : 'Auto-detect the result format (JUnit XML, JSON, TAP, plain text).'}
+   ${args.focusArea ? `Prioritise failures related to: ${args.focusArea}.` : ''}
+
+   Per failure emit {id, test, file, message, stack_head, category, severity}.
+   category MUST be one of: ${CATEGORIES.join(', ')}.
+   severity MUST be one of: ${SEVERITIES.join(', ')}.
+   A failure that fits no category goes to unroutable[] with a stated reason —
+   do NOT force it into the nearest-looking category.`,
+  { label: 'parse', schema: RoutedFailuresSchema, model: 'opus', effort: 'medium' },
+);
+
+const failures = (parsed && parsed.failures) || [];
+const unroutable = (parsed && parsed.unroutable) || [];
+
+if (failures.length < INLINE_FLOOR) {
+  log(`only ${failures.length} routable failures — use the inline path in SKILL.md`);
+  return { mode: 'inline', failures, unroutable };
+}
+
+// --- Stage 2: act, one agent per AGENT TYPE (not per category, not per failure)
+// Grouping by agent type is what bounds the fan-out at CATEGORIES.length.
+const groups = Object.values(
+  failures.reduce((acc, f) => {
+    const at = AGENT_FOR[f.category];
+    if (!at) return acc; // schema-enforced; belt and braces
+    (acc[at] ??= { at, items: [] }).items.push(f);
+    return acc;
+  }, {}),
+);
+
+phase('Act');
+const plans = await parallel(
+  groups.map((g) => () =>
+    agent(
+      `You own these failures ONLY — do not comment on any others.
+       For each, emit: objective, success_criteria, depends_on (failure ids that
+       must be fixed first — ids from OTHER groups are expected and welcome),
+       and a verification command that re-runs just this failure.
+       ${JSON.stringify(g.items)}`,
+      {
+        label: `plan:${g.at}`,
+        phase: 'plan',
+        schema: PlanSchema,
+        agentType: g.at,
+        model: 'opus',
+        effort: 'low',
+      },
+    ),
+  ),
+);
+// BARRIER: sequencing resolves depends_on edges ACROSS groups, so it cannot
+// start until every group has returned.
+
+// A dead agent resolves to null. Surface which group was lost instead of
+// silently shipping a plan that is missing a whole agent type.
+const returned = plans.filter((p) => p && p.items);
+const droppedGroups = groups
+  .map((g) => g.at)
+  .filter((at) => !returned.some((p) => p.agentType === at));
+if (droppedGroups.length) log(`plan agents returned nothing for: ${droppedGroups.join(', ')}`);
+
+// --- Stage 3: synthesize one ordered plan ------------------------------------
+phase('Synthesize');
+return await agent(
+  `Merge these per-agent-type plans into ONE ordered fix plan. Topologically
+   sequence the depends_on edges the group agents emitted; those edges are
+   INFERRED by the group agents, not planned (mcp__pal__planner is not available
+   here), so state any cycle or unresolvable edge rather than guessing an order.
+   Carry unroutable failures through untouched so they stay visible.
+   ${droppedGroups.length ? `These agent types returned nothing and their failures are NOT covered: ${droppedGroups.join(', ')}. List them in dropped_groups.` : ''}
+   unroutable: ${JSON.stringify(unroutable)}
+   plans: ${JSON.stringify(returned)}`,
+  { label: 'synthesize', schema: FixPlanSchema, model: 'opus', effort: 'medium' },
+);


### PR DESCRIPTION
## What changed

Two related but separable pieces of #2170. Only one of them turned out to need code.

### 1. The harness template (this PR's actual change)

- **`testing-plugin/skills/test-analyze/workflows/test-analyze.workflow.js`** — the classify-and-act harness from [`docs/plans/dynamic-workflow-migration.md`](docs/plans/dynamic-workflow-migration.md) §4: parse+classify (1 agent) → plan per agent type (≤8 in `parallel()`) → synthesize (1 agent). This is the repo's **first** bundled `*.workflow.js`.
- **`testing-plugin/skills/test-analyze/SKILL.md`** — the `## Workflow harness (template)` framing section, landing in the **same commit** (docs-currency), plus a one-line annotation on the routing table naming it as the contract the workflow's `category` enum and `AGENT_FOR` map encode.

Both corrections the issue bakes in are honoured:

- **Classify is merged into Parse.** An 8-row lookup plus a 4-value severity enum is something the parse agent does while it already holds the failures; there is no separate classifier agent.
- **`AGENT_FOR` is keyed off agent names that actually exist** — in the plugin-qualified `plugin:agent` form, mirroring the SKILL.md routing table one-for-one (the sketch's bare names would land as WARNs under `check-subagent-types.sh`'s unqualified rule and contradict `~/.claude/rules/agent-and-tool-selection.md`).

Pricing stays structural, not tunable: the hard `failures.length < 5` floor returns `{mode:'inline'}`, and the fan-out width is `Object.keys(AGENT_FOR)` — 8, by construction.

`context: fork` frontmatter is **unchanged**. Per `workflow-vs-skill.md` § "The `context: fork` corollary" the framing does not claim context relief (fork already bought that for free); it argues **splitting** — eight agent-typed groups reasoning in parallel behind a real barrier, where `depends_on` edges cross groups and therefore cannot be sequenced inside one. The framing cites the guard-list pin's current location and leaves it alone, so no rule/guard-list edit is needed here.

### 2. The stale agent-type names — already fixed, verified, not re-done

Acceptance item 1 of #2170 says this "should land regardless". It **already landed in PR #2196**, as the issue's own trailing correction notes. Diffed the table against disk rather than taking that on trust:

| Table value | `agents-plugin/agents/*.md` |
|---|---|
| `agents-plugin:review` | `review.md` ✅ |
| `agents-plugin:security-audit` | `security-audit.md` ✅ |
| `agents-plugin:performance` | `performance.md` ✅ |
| `agents-plugin:refactor` | `refactor.md` ✅ |
| `agents-plugin:test` | `test.md` ✅ |
| `agents-plugin:debug` | `debug.md` ✅ |
| `agents-plugin:ci` | `ci.md` ✅ |
| `agents-plugin:docs` | `docs.md` ✅ |

All 8 resolve; the two prose copies of the table are already collapsed into one. The required regression check (`.claude/rules/regression-testing.md`) also already exists **and covers this file** — confirmed by mutation rather than by reading the glob (see Verification). So there was nothing to fix and nothing to extend; writing a second guard would double-gate.

## Verification (actual output)

```
$ bash scripts/check-workflow-js-model.sh --strict
=== WORKFLOW JS MODEL/EFFORT ===
FILES_SCANNED=1
SCANNED_EMPTY=false
AGENT_CALLS=3
PYTHON3_AVAILABLE=true
STATUS=OK
ISSUE_COUNT=0
ERROR_COUNT=0
WARN_COUNT=0
EXEMPTED_CALLS=0
=== END WORKFLOW JS MODEL/EFFORT ===
EXIT=0
```

```
$ bash scripts/tests/test-check-workflow-js-model.sh
test-check-workflow-js-model.sh: 68 passed, 0 failed
```

```
$ bash scripts/check-loop-integrity.sh
=== LOOP INTEGRITY ===
RULE_PRESENT=true
STATUS=OK
ISSUE_COUNT=0
=== END LOOP INTEGRITY ===
EXIT=0
```

```
$ bash scripts/plugin-compliance-check.sh testing-plugin
| testing-plugin | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | ⚠️ | ⚠️ |

### Recommendations
- ⚠️ testing-plugin/test-strategy-review: description is 236 chars — over the 200-char target band
- ⚠️ testing-plugin/test-analyze: SKILL.md is 11559 chars (~2889 tokens, >10000) — consider extracting
```

Both ⚠️ are non-blocking (the script exits 0). The `test-strategy-review` one is pre-existing and untouched. The `test-analyze` one **is caused by this PR** — see "Things I did not do" below.

**Guard-coverage proof for item 2 (mutation, then reverted):**

```
$ # temporarily rewrote one row to the pre-#2196 `code-review`
$ bash scripts/check-subagent-types.sh
UNRESOLVABLE=1
STATUS=ERROR
  - SEVERITY=ERROR TYPE=unresolvable_subagent_type FILE=testing-plugin/skills/test-analyze/SKILL.md VALUE=code-review MSG=no agents/code-review.md in any plugin
$ # file restored
$ bash scripts/check-subagent-types.sh
UNRESOLVABLE=0
```

```
$ bash scripts/tests/test-check-subagent-types.sh
Passed: 31  Failed: 0
```

Pre-commit ran on the commit: every hook passed except one, see below. `scripts/lint-shell-scripts.sh` was not run — this PR touches no `.sh`.

## Pre-existing failure, not caused by this PR

`check-branch-containment-guidance` fails on **`git-plugin/CHANGELOG.md`** (`ladder_missing`, `branch_audit_uncaveated` at line 8). Verified pre-existing: it reproduces on a clean tree at `origin/main` (`23e1b133`) with nothing of mine applied, and this PR touches no `git-plugin` file. The changelog is release-please-generated, and its entry for the #2268 fix quotes `branch-audit` without the caveat the guard now demands. The commit was made with `SKIP=check-branch-containment-guidance` for that hook only; every other hook ran and passed. Worth a separate fix (the guard probably wants to skip release-please-managed `CHANGELOG.md`).

Also noticed in passing, not fixed here: `scripts/check-subagent-types.sh` is wired into `.pre-commit-config.yaml` but into **no** CI workflow — the same class of wiring gap #2219 tracks.

## Things I did not do, deliberately

- **No `context:` frontmatter edit**, and therefore no `skill-fork-context.md` / `plugin-compliance-check.sh` guard-list edit. The issue notes whichever of #2170 / #2172 lands first pays for that; this one does not need it, because the framing argues splitting rather than context relief and the pin is left where it is.
- **No new regression script.** The bug fix half of the issue had already landed with its guard; a second check would double-gate (`offload-to-deterministic-substrate.md` § Cautions).
- **SKILL.md crossed the size WARN band** — 8,957 → 11,559 chars, because of the framing section. That is a ⚠️ recommendation, well under the 26,000-char ERROR ceiling, and the framing is the content `workflow-vs-skill.md` mandates. Flagging it rather than trimming the mandated snippet; if the reviewer prefers, the two "consequences" bullets are the trimmable part.
- **`testing-plugin/README.md` not updated** (an advisory pre-commit nudge fired). The README's skill table is unchanged — `test-analyze` is already listed and its user-facing description did not change.

## Not verified

The harness is a template and was **not executed** — there is no workflow runtime in CI, and the repo had zero bundled `.workflow.js` before this, so there is no precedent run to compare against. What is verified is everything `check-workflow-js-model.sh` can see statically (opus + explicit effort on all 3 `agent()` calls, the `<purpose>.workflow.js` name, reachability from a sibling `## Workflow harness (template)` section that names the file) plus a read-through against the §4 sketch. The `agent()` / `parallel()` / `phase()` / `log()` call shapes follow the migration plan's sketches, which are the repo's authoritative source for that API — they have not been run against a live `Workflow` harness.

Closes #2170
