### PR TITLE
feat(code-quality-plugin): add parallel-sweep rename map and auditor briefing to bulk-sweep-classify

### DIFF
--- a/code-quality-plugin/README.md
+++ b/code-quality-plugin/README.md
@@ -21,7 +21,7 @@ This plugin provides comprehensive code quality tools including automated code r
 | `/code:dep-audit` | Audit dependencies for security vulnerabilities, outdated packages, and license compliance |
 | `/code:test-quality` | Analyze test suite quality — detect test smells, empty assertions, flaky patterns |
 | `/code:complexity` | Analyze code complexity metrics — cyclomatic, cognitive, function length, coupling |
-| `/code-quality:bulk-sweep-classify` | Route a bulk sweep by target: code renames go through `ast-grep-search` structurally; prose/docs sweeps use the four-category classify-then-transform discipline with allowlist-aware verification |
+| `/code-quality:bulk-sweep-classify` | Route a bulk sweep by target: code renames go through `ast-grep-search` structurally; prose/docs sweeps use the four-category classify-then-transform discipline with allowlist-aware verification; parallel sweeps resolve a central rename map before dispatch and brief auditors with the artifact's purpose |
 | `ast-grep-search` | AST-based code search for structural pattern matching |
 
 ## Agents

--- a/code-quality-plugin/skills/bulk-sweep-classify/SKILL.md
+++ b/code-quality-plugin/skills/bulk-sweep-classify/SKILL.md
@@ -3,7 +3,7 @@ name: bulk-sweep-classify
 description: "Classify every regex match before a bulk find-replace/syntax-modernization sweep — four match categories, scoped transform, allowlist-aware verification. Use when bulk-renaming commands/tools/paths or migrating syntax across many files."
 allowed-tools: Bash, Read, Grep, Edit
 created: 2026-07-05
-modified: 2026-07-06
+modified: 2026-08-08
 reviewed: 2026-07-06
 ---
 
@@ -137,6 +137,67 @@ into corrupting a category-3 design or rewriting a category-4 record just to for
 the count to zero. Enumerate the preserved buckets up front, then verify the grep
 returns *only* those.
 
+## Parallelizing a Sweep — Resolve the Rename Map Before Dispatch
+
+When a sweep is large enough to fan out across parallel agents, a second failure
+mode appears on top of the four categories: **the agents disagree with each
+other.** Each one classifies its own borderline matches, each one is locally
+defensible, and the result is a codebase that is internally inconsistent — every
+file compiles on its own, the whole does not.
+
+Fix it by resolving every cross-file naming decision **before** dispatch, into a
+single explicit **rename map**: old → new, plus an explicit **do-NOT-rename**
+list (the category 2–4 tokens from Step 3). Brief that map **verbatim** into
+every agent's prompt — not paraphrased, not summarized per agent.
+
+| Property you need | What guarantees it |
+|---|---|
+| Every agent renames the same tokens the same way | The map, resolved centrally once and copied verbatim |
+| No two agents edit the same file | File grouping — **disjointness only** |
+
+That split is the point. Agreement is hard to extract from independent agents
+and trivial to get from a shared artifact, so move it out of the agents
+entirely; grouping then only has to guarantee disjointness, a much weaker and
+easier property than consensus.
+
+The do-NOT-rename list is not padding — it is the contract's teeth. An agent
+that "helpfully" extends the rename to a look-alike commits exactly the
+category-2/3 corruption this skill exists to prevent, and a parallel agent
+commits it out of your sight.
+
+**The success signal is an agent *refusing* a rename.** In a 112-file
+`Trends → Foresight` sweep (ForumViriumHelsinki/thelma PR #1263, which also
+renamed a Postgres enum `TrendType → ForesightType`), agents correctly left
+`LinkableEntityType` alone — it contains the target word but was not in the map.
+A run where no agent declines anything usually means the map was never actually
+constraining them.
+
+Dispatch mechanics (worktree collisions, scope overflow, silent exits) belong to
+`agent-patterns-plugin:parallel-agent-dispatch`; the rename map is the
+sweep-specific payload you hand it.
+
+## Brief Adversarial Auditors With the Artifact's Purpose, Not Just the Transform
+
+When adversarial or verification agents audit a sweep, a prompt containing only
+the transform contract — "rename X to Y across these files" — gives them no way
+to tell a deliberate change from scope creep. So they flag the change's own
+reason for existing.
+
+Every auditor prompt needs **both**:
+
+| Brief the auditor with | Because without it |
+|---|---|
+| The transform contract (rename map + do-NOT-rename list) | It cannot check the sweep did what was agreed |
+| What the artifact is **for**, and what is deliberately in scope | It reports the PR's central purpose as unjustified scope creep |
+
+In the thelma sweep above, all three auditors flagged the PR's central purpose
+that way, and **10 of 25 findings were false positives** traceable to that one
+omission — expensive to triage precisely because each read as a legitimate
+concern.
+
+See `agent-patterns-plugin:adversarial-review` for the review pass itself; this
+is the sweep-specific brief to attach to it.
+
 ## Agentic Optimizations
 
 | Context | Command |
@@ -152,3 +213,5 @@ returns *only* those.
 - `verify-upstream-before-patching` / `read-issue-thread-before-contributing` — establish authoritative *intent* before acting, don't trust a surface signal
 - `git-hazards` — an automated pass reporting success is not proof the *result* is correct; verify the content, not the exit code
 - `code-quality-plugin:ast-grep-search` — structural search/replace when the pattern depends on AST shape rather than text
+- `agent-patterns-plugin:parallel-agent-dispatch` — the dispatch contract a fanned-out sweep rides on; the rename map is the payload you brief into it
+- `agent-patterns-plugin:adversarial-review` — the audit pass; brief it with the artifact's purpose, not only the transform contract


### PR DESCRIPTION
## What

Extends the existing `code-quality-plugin:bulk-sweep-classify` skill with two sections. Additive — no existing content was rewritten, and the skill's own regression test (`scripts/tests/test-bulk-sweep-classify.sh`, 11 checks) still passes.

**1. Parallelizing a Sweep — Resolve the Rename Map Before Dispatch**

Once a sweep fans out across parallel agents, a failure mode appears that the four-category discipline alone doesn't cover: the agents disagree with each other about borderline renames. Each decision is locally defensible, and the result is a codebase that compiles file-by-file but not as a whole.

The fix is to resolve every cross-file naming decision *before* dispatch into a single explicit **rename map** (old → new, plus an explicit do-NOT-rename list drawn from the skill's category 2–4 buckets), and brief that map **verbatim** into every agent's prompt. That moves agreement out of the agents and into a shared artifact — so file grouping then only has to guarantee **disjointness**, a much weaker and easier property than getting independent agents to converge.

The section also names the success signal, because it's counter-intuitive: **an agent refusing a rename is the contract working.** A run where nobody declines anything usually means the map wasn't actually constraining them.

**2. Brief Adversarial Auditors With the Artifact's Purpose, Not Just the Transform**

An auditor given only the transform contract ("rename X to Y across these files") has no way to distinguish a deliberate change from scope creep — so it flags the change's own reason for existing. Every auditor prompt needs both the transform contract *and* a statement of what the artifact is FOR and what is deliberately in scope.

## Why it's reusable beyond one repo

Neither section is language-, framework-, or repo-specific. The first is a property of fanning *any* cross-file decision out to independent agents: consensus is expensive to obtain from agents and free to obtain from a pre-resolved artifact. The second is a property of *any* adversarial review whose brief omits intent — the auditor's only available frame becomes "is this in the diff contract?", so purpose-driven changes read as creep.

Both sit naturally in this skill because it already owns the "the regex sees text, the transform needs semantics" discipline; the rename map is just that classification resolved once and shared, rather than re-derived per agent.

## Where it was used

A 112-file `Trends → Foresight` rename in `ForumViriumHelsinki/thelma` ([PR #1263](https://github.com/ForumViriumHelsinki/thelma/pull/1263)), which also renamed a Postgres enum `TrendType → ForesightType`. The skill's existing four-category discipline is what kept that sweep from corrupting an enum *value*; these two things it did not yet cover.

Evidence cited in the sections:

| Observation | What it demonstrates |
|---|---|
| 112 files across parallel agents, one central rename map | Disjoint file grouping was sufficient once agreement was pre-resolved |
| Agents declined to rename `LinkableEntityType` — contains the target word, not in the map | The do-NOT-rename list held against an agent "helpfully" extending scope |
| All three adversarial auditors flagged the PR's central purpose as scope creep; **10 of 25 findings** were false positives from that one omission | Cost of briefing auditors with the transform contract alone |

## Also in this PR

- Cross-links added to `Related`: `agent-patterns-plugin:parallel-agent-dispatch` (dispatch mechanics — the rename map is the sweep-specific payload it carries) and `agent-patterns-plugin:adversarial-review` (the review pass itself).
- `code-quality-plugin/README.md` catalog line extended to mention the new guidance (the pre-commit README-currency nudge fired; addressed in the same commit).
- Frontmatter `modified:` bumped to 2026-08-08, matching the repo's convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DvcEm3GrLgboEaKA24evDG
