### PR TITLE
feat(health-plugin): add config-drift probe for rules/skills corpus hygiene

### DIFF
--- a/health-plugin/.claude-plugin/plugin.json
+++ b/health-plugin/.claude-plugin/plugin.json
@@ -12,6 +12,11 @@
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/health-drift-probe.sh",
             "timeout": 3000
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/config-drift-probe.sh",
+            "timeout": 3000
           }
         ]
       }

--- a/health-plugin/README.md
+++ b/health-plugin/README.md
@@ -35,6 +35,44 @@ These internal skills are auto-discoverable but not user-invocable — use `/hea
 | Script | Description |
 |--------|-------------|
 | `prune-claude-config.py` | Remove orphaned projects and cached data from `~/.claude.json` |
+| `config-drift.py` | Audit the rules/skills corpus itself for duplication, broken pointer stubs, review staleness, and always-loaded budget |
+
+### `config-drift.py`
+
+Answers a question the other health checks do not: **is the configuration
+corpus self-consistent?** It compares rules against each other and against the
+skill corpus, rather than validating any one file in isolation.
+
+| Check | Severity | Catches |
+|---|---|---|
+| `broken_pointer_stub` | ERROR | A "Promoted to a skill: invoke `x`" rule whose target no longer exists |
+| `duplicate_rule_lexical` | WARN | Byte-identical or near-identical rules across scopes |
+| `semantic_overlap_*` | WARN | Differently-worded rules or skills covering one topic |
+| `rule_covered_by_skill` | INFO | A resident rule whose content a skill already carries |
+| `always_loaded_budget` | WARN | The every-turn surface creeping past its ceiling |
+| `review_staleness` | WARN | An artifact changed after its declared `reviewed:` date |
+
+Two cost tiers, because a SessionStart probe cannot pay for a model:
+
+```
+config-drift.py --fast --no-embed --format=json    # 0.05s, pure stdlib, no git spawn
+config-drift.py --format=report                    # + embeddings, scheduled use
+```
+
+`--fast` reads cached last-change dates only; the cache is keyed by **content
+hash**, never mtime, so it cannot go stale and cannot be invalidated by a
+checkout that rewrites timestamps.
+
+**Waivers.** Deliberate duplication is suppressed via
+`~/.claude/config-drift-waivers.json`, keyed by both sides' content hashes — so
+a waiver expires the moment either file is edited. Without that, a recurring
+report re-lists its known-accepted findings until you stop reading it.
+
+**Semantic threshold.** The embedding pass is calibrated to cosine ≥ 0.91 with
+same-name and structural pairs excluded. This is not a default worth changing
+casually: at 0.86 on a real 884-document corpus it emitted 491 findings, of
+which 290 were same-name pairs the cheap tier already owns. Everything here is
+one genre of document, so baseline similarity is high.
 
 ## Use Cases
 

--- a/health-plugin/hooks/config-drift-probe.sh
+++ b/health-plugin/hooks/config-drift-probe.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# config-drift-probe.sh — SessionStart probe for Claude rules/skills hygiene.
+#
+# Surfaces drift in the configuration corpus itself: a pointer stub naming a
+# skill that no longer exists, byte-identical duplicate rules across scopes, a
+# rule whose topic an existing skill already covers, and an always-loaded
+# budget that has crept past its ceiling.
+#
+# Mounts the EXISTING sweep (../scripts/config-drift.py) on the existing
+# drift-protocol trigger. Per .claude/rules/drift-detection-triggering.md the
+# missing piece for this class was never the logic, only the trigger, so this
+# file deliberately contains no analysis of its own -- it shells out and
+# forwards findings.
+#
+# Cost: runs `--fast --no-embed`, which is pure stdlib, spawns no git, and
+# measured 0.05s over 342 rules + 549 skills. That needs no TTL debounce -- the
+# debounce guidance in drift-detection-triggering.md is about NETWORK
+# round-trips, and this probe makes none. The expensive semantic pass (an
+# embedding model) is scheduled-only and never runs here.
+#
+# Opt-out: CLAUDE_HOOKS_DISABLE_DRIFT_NUDGE=1 (honoured by the aggregator too),
+# or CLAUDE_HOOKS_DISABLE_CONFIG_DRIFT=1 for this probe alone.
+
+set -uo pipefail
+
+if [ "${CLAUDE_HOOKS_DISABLE_CONFIG_DRIFT:-0}" = "1" ]; then
+    exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Same fallback chain as health-drift-probe.sh: the monorepo-relative path only
+# resolves in a checkout of claude-plugins, not in an installed plugin.
+PROTO_LIB="${SCRIPT_DIR}/../../hooks-plugin/hooks/lib/drift-protocol.sh"
+if [ ! -f "$PROTO_LIB" ]; then
+    for candidate in \
+        "${CLAUDE_PLUGIN_ROOT:-}/../hooks-plugin/hooks/lib/drift-protocol.sh" \
+        "$HOME/.claude/plugins/hooks-plugin/hooks/lib/drift-protocol.sh"; do
+        if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+            PROTO_LIB="$candidate"
+            break
+        fi
+    done
+fi
+if [ ! -f "$PROTO_LIB" ]; then
+    exit 0
+fi
+# shellcheck source=../../hooks-plugin/hooks/lib/drift-protocol.sh
+# shellcheck disable=SC1091  # PROTO_LIB resolves at runtime via fallback chain
+. "$PROTO_LIB"
+
+drift_init "config-drift"
+
+ANALYZER="${SCRIPT_DIR}/../scripts/config-drift.py"
+if [ ! -f "$ANALYZER" ] || ! command -v python3 >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+    drift_emit
+    exit 0
+fi
+
+# --fast: read cached git dates only, never spawn git. --no-embed: no model, no
+# download. Both keep this inside a SessionStart budget.
+OUT=$(python3 "$ANALYZER" --root "${DRIFT_CWD:-.}" --fast --no-embed --format=json 2>/dev/null)
+if [ -z "$OUT" ] || ! printf '%s' "$OUT" | jq empty >/dev/null 2>&1; then
+    # Emit nothing rather than a false all-clear (drift-detection-triggering.md:
+    # never act on uncertainty).
+    drift_emit
+    exit 0
+fi
+
+# Forward at most 4 findings. The aggregator caps at 5 lines across ALL plugins,
+# so a greedy probe crowds out its siblings. Findings are collapsed by kind:
+# 74 stale-review entries must read as one actionable nudge, not 74 identical
+# ones.
+while IFS=$'\t' read -r severity kind summary remediation; do
+    [ -n "$kind" ] || continue
+    drift_add_finding "$severity" "$kind" "$summary" "$remediation"
+done < <(printf '%s' "$OUT" | jq -r '
+  def rank: {"error":0,"warn":1,"info":2}[.severity] // 3;
+  def fix:
+    {"broken_pointer_stub":          "/agent-patterns:meta-promote",
+     "coverage_metric_broken":       "/health:check",
+     "duplicate_rule_lexical":       "/agent-patterns:meta-promote",
+     "semantic_overlap_rule_rule":   "/agent-patterns:meta-promote",
+     "semantic_overlap_rule_skill":  "/health:skill-audit",
+     "semantic_overlap_skill_skill": "/health:skill-audit",
+     "rule_covered_by_skill":        "/agent-patterns:meta-context-diet",
+     "always_loaded_budget":         "/agent-patterns:meta-context-diet",
+     "review_staleness":             "/health:skill-audit",
+     "frontmatter_coverage":         "/agent-patterns:meta-context-diet"}[.kind] // "/health:check";
+  [.findings[]]
+  | group_by(.kind)
+  | map( (.[0] | . + {rank: rank, fix: fix}) as $head
+       | $head + {summary: (if length > 1
+                            then ($head.summary + " (+\(length - 1) more of this kind)")
+                            else $head.summary end)} )
+  | sort_by(.rank, .kind)
+  | .[:4][]
+  | [.severity, .kind, .summary, .fix] | @tsv
+')
+
+drift_emit

--- a/health-plugin/scripts/config-drift.py
+++ b/health-plugin/scripts/config-drift.py
@@ -1,0 +1,702 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["fastembed>=0.4", "numpy>=1.26"]
+# ///
+"""config-drift — continuous hygiene check for Claude rules and skills.
+
+Design notes (why it is shaped this way):
+
+* Two cost tiers. Integrity + lexical + staleness checks are pure stdlib and run
+  in well under a second, so they can fire on every SessionStart. The semantic
+  (embedding) pass needs a model and is scheduled-only. `--no-embed` selects the
+  cheap tier; nothing in the cheap tier imports fastembed or numpy.
+
+* Cache keyed by content SHA-256, never mtime. mtime moves on checkout, touch,
+  and chezmoi apply without the content changing; a hash cannot lie. Timestamps
+  are used for a different job entirely -- `reviewed:` staleness policy.
+
+* Waivers expire themselves. A waiver records both sides' content hashes, so
+  editing either side revives the finding. This is what keeps a recurring report
+  from decaying into noise you learn to skip.
+
+Exit codes: 0 clean, 1 warnings, 2 errors (CI gate), 3 internal failure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from itertools import combinations
+from pathlib import Path
+
+HOME_RULES = Path.home() / ".claude" / "rules"
+SKIP_PARTS = {"node_modules", "dist", "worktrees", ".git", "__pycache__", "tmp"}
+EMBED_MODEL = "BAAI/bge-small-en-v1.5"
+EMBED_CHARS = 2000
+
+# Thresholds. Deliberately conservative: this tool surfaces, a human decides.
+# Calibrated against the live corpus, not guessed. At 0.86 the semantic pass
+# emitted 491 findings, of which 290 were same-name pairs the cheap tier already
+# owns and most of the rest were genre noise -- every document here is "Claude
+# config markdown about tooling", so baseline cosine is high. Novel-pair score
+# distribution was 0.94:2 0.92:9 0.90:32 0.88:70 0.86:88, i.e. the actionable
+# signal sits above ~0.91 and the tail below it is unusable.
+T_SEMANTIC = 0.91  # cosine over title+head
+T_LEXICAL = 0.45  # 3-gram Jaccard over full body
+T_COVERAGE = 0.55  # rule topic already covered by a skill
+BUDGET_TOKENS = 55_000  # always-loaded ceiling before it is a finding
+STALE_DAYS = 120  # reviewed: older than this many days behind a change
+
+STOP = set(
+    """a an the and or but if then else for of to in on at by with from as is are was were be been
+    it its this that these those not no do does did can could should would may might must will you
+    your we our they their its me my when what which who how why use used using than there here
+    into over under out up down off about via per each any all some more most other same such only
+    just also very well make made get got take see run one two file files code claude rule rules
+    skill skills use-when when-to""".split()
+)
+
+
+# --------------------------------------------------------------------- helpers
+def sha(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8", "replace")).hexdigest()[:16]
+
+
+def toks(text: str) -> list[str]:
+    return [
+        w for w in re.findall(r"[a-z][a-z0-9_-]{2,}", text.lower()) if w not in STOP
+    ]
+
+
+def shingles(text: str, n: int = 3) -> set[str]:
+    t = toks(text)
+    return {" ".join(t[i : i + n]) for i in range(max(0, len(t) - n + 1))}
+
+
+def jaccard(a: set, b: set) -> float:
+    return len(a & b) / len(a | b) if a and b else 0.0
+
+
+def frontmatter(body: str) -> dict[str, str]:
+    if not body.startswith("---"):
+        return {}
+    parts = body.split("---", 2)
+    if len(parts) < 3:
+        return {}
+    return {
+        k: v.strip().strip("\"'")
+        for k, v in re.findall(r"^([a-z_]+):[ \t]*(.*)$", parts[1], re.M)
+    }
+
+
+def git_last_change(path: Path) -> str | None:
+    try:
+        out = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(path.parent),
+                "log",
+                "-1",
+                "--format=%cs",
+                "--",
+                path.name,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        ).stdout.strip()
+        return out or None
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def changed_since(root: Path, ref: str) -> set[str]:
+    """Paths touched since a git ref, for delta-only reporting."""
+    changed: set[str] = set()
+    for repo in {p.parent.parent for p in root.rglob(".git") if p.name == ".git"} | {
+        root
+    }:
+        try:
+            out = subprocess.run(
+                ["git", "-C", str(repo), "diff", "--name-only", ref, "--"],
+                capture_output=True,
+                text=True,
+                timeout=20,
+            )
+            if out.returncode == 0:
+                changed |= {
+                    str((repo / line).resolve()) for line in out.stdout.split() if line
+                }
+        except (OSError, subprocess.SubprocessError):
+            continue
+    return changed
+
+
+def walk(root: Path):
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [
+            d for d in dirnames if d not in SKIP_PARTS and not d.startswith(".venv")
+        ]
+        yield Path(dirpath), filenames
+
+
+# ------------------------------------------------------------------- inventory
+def collect(root: Path) -> tuple[list[dict], list[dict]]:
+    rules, skills = [], []
+
+    rule_paths = sorted(HOME_RULES.glob("*.md")) if HOME_RULES.is_dir() else []
+    for dirpath, filenames in walk(root):
+        if dirpath.match("*/.claude/rules"):
+            rule_paths += [dirpath / f for f in filenames if f.endswith(".md")]
+        if (
+            "SKILL.md" in filenames
+            and f"{os.sep}skills{os.sep}" in f"{dirpath}{os.sep}"
+        ):
+            p = dirpath / "SKILL.md"
+            body = p.read_text(encoding="utf-8", errors="replace")
+            fm = frontmatter(body)
+            skills.append(
+                {
+                    "kind": "skill",
+                    "path": str(p),
+                    "name": p.parent.name,
+                    "title": p.parent.name,
+                    "body": body,
+                    "fm": fm,
+                    "desc": fm.get("description", ""),
+                    "chars": len(body),
+                    "hash": sha(body),
+                }
+            )
+
+    for p in sorted(set(rule_paths)):
+        body = p.read_text(encoding="utf-8", errors="replace")
+        fm = frontmatter(body)
+        scope = (
+            "user-global"
+            if str(p).startswith(str(HOME_RULES))
+            else "portfolio"
+            if p.parent.parent.parent == root
+            else str(p).split("/.claude/rules/")[0].replace(str(root) + "/", "")
+        )
+        title = next(
+            (line[2:].strip() for line in body.splitlines() if line.startswith("# ")),
+            p.stem,
+        )
+        rules.append(
+            {
+                "kind": "rule",
+                "path": str(p),
+                "name": p.stem,
+                "title": title,
+                "body": body,
+                "fm": fm,
+                "scope": scope,
+                "always_loaded": scope in ("user-global", "portfolio"),
+                "chars": len(body),
+                "hash": sha(body),
+                "stub": "romoted to a skill" in body[:700],
+            }
+        )
+    return rules, skills
+
+
+# -------------------------------------------------------------------- waivers
+def _canon(p: str) -> str:
+    """Canonicalise a path for waiver matching.
+
+    Waiver files are hand-written, so a side may be spelled `~/repos/...` or
+    `/var/...` while the scan resolves it to `/private/var/...` (macOS symlinks
+    every temp and `/var` path). Comparing raw strings silently fails to match
+    and the waiver looks ignored, which is indistinguishable from a bug.
+    """
+    return os.path.realpath(os.path.expanduser(p))
+
+
+def load_waivers(path: Path) -> dict[tuple[str, str], dict]:
+    if not path.is_file():
+        return {}
+    try:
+        raw = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return {(_canon(w["a"]), _canon(w["b"])): w for w in raw.get("waivers", [])}
+
+
+def waived(waivers, a: dict, b: dict) -> bool:
+    """A waiver holds only while BOTH sides are byte-identical to when it was filed."""
+    pa, pb = _canon(a["path"]), _canon(b["path"])
+    for key in ((pa, pb), (pb, pa)):
+        w = waivers.get(key)
+        if not w:
+            continue
+        ha, hb = (
+            (w.get("a_hash"), w.get("b_hash"))
+            if key[0] == pa
+            else (w.get("b_hash"), w.get("a_hash"))
+        )
+        if ha == a["hash"] and hb == b["hash"]:
+            return True
+    return False
+
+
+# --------------------------------------------------------------------- checks
+def check_stub_integrity(rules, skills) -> list[dict]:
+    known = {s["name"] for s in skills}
+    out = []
+    for r in rules:
+        if not r["stub"]:
+            continue
+        refs = re.findall(r"`([a-z0-9:-]+)`", r["body"][:700])
+        target = refs[0].split(":")[-1] if refs else None
+        if target not in known:
+            out.append(
+                {
+                    "severity": "error",
+                    "kind": "broken_pointer_stub",
+                    "summary": f"{r['name']} points at skill '{target or '(none named)'}' which does not exist",
+                    "path": r["path"],
+                }
+            )
+    return out
+
+
+def check_review_staleness(items, cache: dict, allow_spawn: bool) -> list[dict]:
+    """Compare each item's declared `reviewed:` against its real last-change date.
+
+    One `git log` per file is ~10ms and there are ~900 files, which is far too
+    slow for a SessionStart probe. The date is cached under `path:content-hash`:
+    a file whose content is unchanged cannot have a new last-change date, so the
+    cache is correct by construction rather than by TTL. In fast mode (the probe)
+    a cache miss is skipped rather than spawning git, so the probe stays sub-second
+    and the scheduled run is what warms the cache.
+    """
+    out = []
+    for it in items:
+        rv = it["fm"].get("reviewed")
+        if not rv or not re.fullmatch(r"\d{4}-\d{2}-\d{2}", rv):
+            continue
+        key = f"{it['path']}:{it['hash']}"
+        if key in cache:
+            changed = cache[key]
+        elif allow_spawn:
+            changed = git_last_change(Path(it["path"]))
+            cache[key] = changed
+        else:
+            continue
+        if not changed:
+            continue
+        try:
+            gap = (dt.date.fromisoformat(changed) - dt.date.fromisoformat(rv)).days
+        except ValueError:
+            continue
+        if gap > STALE_DAYS:
+            out.append(
+                {
+                    "severity": "warn",
+                    "kind": "review_staleness",
+                    "summary": f"{it['name']} changed {gap}d after its declared reviewed:{rv}",
+                    "path": it["path"],
+                    "gap_days": gap,
+                }
+            )
+    return sorted(out, key=lambda x: -x["gap_days"])
+
+
+def check_budget(rules) -> list[dict]:
+    # A rule in a user-global/portfolio scope is NOT unconditionally injected if
+    # it carries `paths:` frontmatter -- it loads only when a matching file is
+    # read. Counting those inflates the budget by ~24% on this portfolio (13 of
+    # 67 rules, ~12,200 tok). Confirmed empirically: path-scoped rules are absent
+    # from the initial context injection and arrive later as reminders.
+    always = [r for r in rules if r["always_loaded"] and "paths" not in r["fm"]]
+    tokens = sum(r["chars"] for r in always) // 4
+    if tokens <= BUDGET_TOKENS:
+        return []
+    worst = sorted(always, key=lambda r: -r["chars"])[:3]
+    return [
+        {
+            "severity": "warn",
+            "kind": "always_loaded_budget",
+            "summary": (
+                f"{len(always)} always-loaded rules cost ~{tokens:,} tok/turn "
+                f"(budget {BUDGET_TOKENS:,}); heaviest: "
+                + ", ".join(
+                    f"{r['name']}(~{r['chars'] // 4 // 100 * 100:,})" for r in worst
+                )
+            ),
+            "tokens": tokens,
+        }
+    ]
+
+
+def check_frontmatter(rules) -> list[dict]:
+    missing = [r for r in rules if not r["fm"].get("reviewed")]
+    if not missing:
+        return []
+    return [
+        {
+            "severity": "info",
+            "kind": "frontmatter_coverage",
+            "summary": f"{len(missing)}/{len(rules)} rules carry no reviewed: date, so staleness cannot be tracked for them",
+        }
+    ]
+
+
+def check_lexical_dupes(rules, waivers) -> list[dict]:
+    for r in rules:
+        r["_sh"] = shingles(r["body"])
+    out = []
+    for a, b in combinations(rules, 2):
+        s = jaccard(a["_sh"], b["_sh"])
+        if s >= T_LEXICAL and not waived(waivers, a, b):
+            out.append(
+                {
+                    "severity": "warn",
+                    "kind": "duplicate_rule_lexical",
+                    "summary": f"{a['scope']}:{a['name']} and {b['scope']}:{b['name']} are {s:.0%} lexically identical",
+                    "score": round(s, 3),
+                    "paths": [a["path"], b["path"]],
+                }
+            )
+    return sorted(out, key=lambda x: -x["score"])
+
+
+def check_rule_covered_by_skill(rules, skills, waivers) -> list[dict]:
+    """Topic containment: how much of a rule's vocabulary a skill already carries.
+
+    Full-body Jaccard is the wrong metric here and silently returns zero -- a
+    SKILL.md is 5-20x a rule's length, so the union swamps the intersection.
+    Containment is asymmetric and correct. Control-tested: every already-promoted
+    pointer stub must score above threshold against its own skill.
+    """
+
+    def tset(text):
+        return {w for w in toks(text) if len(w) > 3}
+
+    for s in skills:
+        s["_t"] = tset(
+            s["name"].replace("-", " ") + " " + s["desc"] + " " + s["body"][:6000]
+        )
+    out, control_hits, control_total = [], 0, 0
+    for r in rules:
+        topic = tset(
+            r["name"].replace("-", " ") + " " + r["title"] + " " + r["body"][:1200]
+        )
+        if len(topic) < 6:
+            continue
+        best = max(
+            ((len(topic & s["_t"]) / len(topic), s) for s in skills),
+            key=lambda x: x[0],
+            default=(0.0, None),
+        )
+        score, skill = best
+        if r["stub"]:
+            control_total += 1
+            control_hits += score >= T_COVERAGE
+            continue
+        if score >= T_COVERAGE and skill and not waived(waivers, r, skill):
+            out.append(
+                {
+                    "severity": "info",
+                    "kind": "rule_covered_by_skill",
+                    "summary": (
+                        f"{r['scope']}:{r['name']} is {score:.0%} covered by skill "
+                        f"{skill['name']} -- candidate for a pointer stub"
+                    ),
+                    "score": round(score, 3),
+                    "paths": [r["path"], skill["path"]],
+                    "always_loaded": r["always_loaded"],
+                }
+            )
+    # Control gate: if the known-good stubs do not surface, the metric is broken
+    # and its output must not be trusted (never-fabricate-test-identifiers).
+    if control_total and control_hits < max(1, int(0.7 * control_total)):
+        out = [
+            {
+                "severity": "error",
+                "kind": "coverage_metric_broken",
+                "summary": (
+                    f"containment metric failed its control: only {control_hits}/{control_total} "
+                    "known pointer stubs detected -- coverage findings suppressed"
+                ),
+            }
+        ]
+    return sorted(out, key=lambda x: (not x.get("always_loaded"), -x.get("score", 0)))
+
+
+def check_semantic_dupes(items, waivers, cache_path: Path) -> list[dict]:
+    import numpy as np
+    from fastembed import TextEmbedding
+
+    cache = {}
+    if cache_path.is_file():
+        try:
+            cache = json.loads(cache_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            cache = {}
+
+    need = [it for it in items if it["hash"] not in cache]
+    if need:
+        model = TextEmbedding(model_name=EMBED_MODEL)
+        texts = [
+            f"{it['title']}\n{it.get('desc', '')}\n{it['body'][:EMBED_CHARS]}"
+            for it in need
+        ]
+        for it, vec in zip(need, model.embed(texts)):
+            cache[it["hash"]] = [round(float(x), 6) for x in vec]
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(json.dumps(cache))
+
+    def structural_pair(a: dict, b: dict) -> bool:
+        """Relationships that are correct by design, not drift.
+
+        Two shapes dominate the high-cosine band and neither is a defect:
+        a pointer stub scores ~0.92 against the very skill it delegates to, and
+        deliberately cross-referenced sibling rules ("Sibling: pr-merge-hazards.md")
+        score ~0.93. Flagging either trains the reader to ignore the report.
+        """
+        for x, y in ((a, b), (b, a)):
+            if x.get("stub") and y["kind"] == "skill" and y["name"] in x["body"][:700]:
+                return True
+            if (
+                Path(y["path"]).name in x["body"]
+                or f"`{y['name']}`" in x["body"][:1500]
+            ):
+                return True
+        return False
+
+    vecs = np.array([cache[it["hash"]] for it in items], dtype="float32")
+    vecs /= np.linalg.norm(vecs, axis=1, keepdims=True) + 1e-9
+    sim = vecs @ vecs.T
+    out = []
+    for i, j in zip(*np.triu_indices(len(items), k=1)):
+        s = float(sim[i, j])
+        a, b = items[i], items[j]
+        # Same-name pairs belong to the cheap tier (name-collision + lexical);
+        # re-reporting them here would double-count every generated rule.
+        if a["name"] == b["name"] or structural_pair(a, b):
+            continue
+        if s >= T_SEMANTIC and not waived(waivers, a, b):
+            out.append(
+                {
+                    "severity": "warn",
+                    "kind": f"semantic_overlap_{a['kind']}_{b['kind']}",
+                    "summary": (
+                        f"{a['kind']} {a['name']} and {b['kind']} {b['name']} "
+                        f"are {s:.0%} semantically similar"
+                    ),
+                    "score": round(s, 3),
+                    "paths": [a["path"], b["path"]],
+                }
+            )
+    return sorted(out, key=lambda x: -x["score"])
+
+
+# ---------------------------------------------------------------------- output
+def emit_status(findings, counts):
+    print("=== CONFIG DRIFT ===")
+    for k, v in counts.items():
+        print(f"{k.upper()}={v}")
+    by_kind: dict[str, int] = {}
+    for f in findings:
+        by_kind[f["kind"]] = by_kind.get(f["kind"], 0) + 1
+    for k, v in sorted(by_kind.items()):
+        print(f"FINDING_{k.upper()}={v}")
+    errs = sum(1 for f in findings if f["severity"] == "error")
+    warns = sum(1 for f in findings if f["severity"] == "warn")
+    print(f"ERRORS={errs}\nWARNINGS={warns}")
+    # OK / WARN / ERROR per .claude/rules/structured-script-output.md, not
+    # PASS/FAIL -- orchestrating skills grep for the house vocabulary.
+    print("STATUS=" + ("ERROR" if errs else "WARN" if warns else "OK"))
+
+
+def emit_probe(findings):
+    """drift-protocol shape: severity/kind/summary/remediation_skill."""
+    remediation = {
+        "broken_pointer_stub": "/agent-patterns:meta-promote",
+        "duplicate_rule_lexical": "/agent-patterns:meta-promote",
+        "semantic_overlap_rule_rule": "/agent-patterns:meta-promote",
+        "semantic_overlap_skill_skill": "/health:skill-audit",
+        "rule_covered_by_skill": "/agent-patterns:meta-context-diet",
+        "always_loaded_budget": "/agent-patterns:meta-context-diet",
+        "review_staleness": "/health:skill-audit",
+        "frontmatter_coverage": "/agent-patterns:meta-context-diet",
+    }
+    ranked = sorted(
+        findings, key=lambda f: {"error": 0, "warn": 1, "info": 2}[f["severity"]]
+    )
+    print(
+        json.dumps(
+            {
+                "plugin": "config-drift",
+                "checked_at": dt.datetime.now(dt.timezone.utc).isoformat(
+                    timespec="seconds"
+                ),
+                "findings": [
+                    {
+                        "severity": f["severity"],
+                        "kind": f["kind"],
+                        "summary": f["summary"],
+                        "remediation_skill": remediation.get(
+                            f["kind"], "/health:check"
+                        ),
+                    }
+                    for f in ranked[:5]
+                ],
+            },
+            indent=1,
+        )
+    )
+
+
+def emit_report(findings, counts):
+    print("# Claude config drift report\n")
+    print(f"_{dt.datetime.now().isoformat(timespec='seconds')}_\n")
+    print("| Metric | Value |\n|---|---|")
+    for k, v in counts.items():
+        print(f"| {k.replace('_', ' ')} | {v} |")
+    print()
+    for sev in ("error", "warn", "info"):
+        group = [f for f in findings if f["severity"] == sev]
+        if not group:
+            continue
+        print(f"\n## {sev.upper()} ({len(group)})\n")
+        for f in group[:40]:
+            print(f"- **{f['kind']}** — {f['summary']}")
+            for p in f.get("paths", [])[:2]:
+                print(f"  - `{p}`")
+        if len(group) > 40:
+            print(f"\n_…{len(group) - 40} more suppressed._")
+
+
+# ------------------------------------------------------------------------ main
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    # Defaults to the current directory, not a hardcoded portfolio path -- this
+    # ships as a plugin and cannot assume anyone's layout. The SessionStart probe
+    # passes the drift protocol's own cwd. User-global rules under
+    # ~/.claude/rules are always scanned regardless of --root, because they load
+    # in every session no matter which project is open.
+    ap.add_argument("--root", default=".")
+    ap.add_argument(
+        "--format", choices=["status", "probe", "report", "json"], default="status"
+    )
+    ap.add_argument(
+        "--no-embed",
+        action="store_true",
+        help="cheap tier only: integrity, lexical, staleness. No model, no download.",
+    )
+    ap.add_argument(
+        "--since",
+        metavar="REF",
+        help="only report findings touching files changed since this git ref",
+    )
+    ap.add_argument(
+        "--waivers", default=str(Path.home() / ".claude" / "config-drift-waivers.json")
+    )
+    ap.add_argument(
+        "--cache",
+        default=str(Path.home() / ".cache" / "config-drift" / "embeddings.json"),
+    )
+    ap.add_argument(
+        "--gate",
+        action="store_true",
+        help="exit 2 on any error-severity finding (CI use)",
+    )
+    ap.add_argument(
+        "--fast",
+        action="store_true",
+        help="probe mode: never spawn git; read cached dates only. Sub-second.",
+    )
+    args = ap.parse_args()
+
+    root = Path(args.root).expanduser().resolve()
+    if not root.is_dir():
+        print(f"root not found: {root}", file=sys.stderr)
+        return 3
+
+    rules, skills = collect(root)
+    waivers = load_waivers(Path(args.waivers).expanduser())
+
+    findings: list[dict] = []
+    findings += check_stub_integrity(rules, skills)
+    findings += check_budget(rules)
+    findings += check_lexical_dupes(rules, waivers)
+    findings += check_rule_covered_by_skill(rules, skills, waivers)
+    findings += check_frontmatter(rules)
+
+    datecache_path = Path(args.cache).expanduser().with_name("gitdates.json")
+    datecache: dict = {}
+    if datecache_path.is_file():
+        try:
+            datecache = json.loads(datecache_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            datecache = {}
+    before = len(datecache)
+    findings += check_review_staleness(
+        rules + skills, datecache, allow_spawn=not args.fast
+    )
+    if len(datecache) != before:
+        datecache_path.parent.mkdir(parents=True, exist_ok=True)
+        datecache_path.write_text(json.dumps(datecache))
+
+    if not args.no_embed:
+        try:
+            findings += check_semantic_dupes(
+                rules + skills, waivers, Path(args.cache).expanduser()
+            )
+        except Exception as exc:  # noqa: BLE001 - degrade loudly, never silently
+            findings.append(
+                {
+                    "severity": "info",
+                    "kind": "semantic_pass_unavailable",
+                    "summary": f"semantic pass skipped: {type(exc).__name__}: {exc}",
+                }
+            )
+
+    if args.since:
+        touched = changed_since(root, args.since)
+        findings = [
+            f
+            for f in findings
+            if not f.get("paths") or any(p in touched for p in f["paths"])
+        ]
+
+    always = [r for r in rules if r["always_loaded"] and "paths" not in r["fm"]]
+    counts = {
+        "rules": len(rules),
+        "skills": len(skills),
+        "scopes": len({r["scope"] for r in rules}),
+        "always_loaded_rules": len(always),
+        "always_loaded_tokens": sum(r["chars"] for r in always) // 4,
+        "pointer_stubs": sum(1 for r in rules if r["stub"]),
+        "waivers_active": len(waivers),
+        "semantic_pass": "off" if args.no_embed else "on",
+    }
+
+    {
+        "status": emit_status,
+        "probe": lambda f, c: emit_probe(f),
+        "report": emit_report,
+        "json": lambda f, c: print(json.dumps({"counts": c, "findings": f}, indent=1)),
+    }[args.format](findings, counts)
+
+    errs = sum(1 for f in findings if f["severity"] == "error")
+    if args.gate and errs:
+        return 2
+    return 1 if any(f["severity"] in ("error", "warn") for f in findings) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/health-plugin/scripts/tests/test-config-drift.sh
+++ b/health-plugin/scripts/tests/test-config-drift.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# test-config-drift.sh — regression suite for health-plugin/scripts/config-drift.py
+#
+# SEMANTIC, not syntactic: every case EXECUTES the analyzer against a planted
+# fixture corpus and asserts on its structured output. A grep for a threshold
+# constant or a function name would pass against a checker that never runs --
+# the #1417 -> #1819 lesson (a syntactic pin on a semantic property let a
+# non-working command ship twice).
+#
+# Isolation: HOME is redirected to the fixture root, so the suite reads the
+# fixture's ~/.claude/rules and writes its caches there, never the real ones.
+# Every case runs --fast, so the analyzer spawns no git at all and the
+# shared-checkout git hazards (#1692/#1745) cannot arise.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ANALYZER="${SCRIPT_DIR}/../config-drift.py"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "SKIP: python3 not available"
+    exit 0
+fi
+if [ ! -f "$ANALYZER" ]; then
+    echo "FAIL: analyzer not found at $ANALYZER"
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+
+ok()   { PASS=$((PASS + 1)); printf '  ok   %s\n' "$1"; }
+bad()  { FAIL=$((FAIL + 1)); printf '  FAIL %s\n     wanted: %s\n     got:    %s\n' "$1" "$2" "$3"; }
+
+# if/else, not `A && B || C` — in an assertion helper the short-circuit form
+# runs `bad` whenever `ok` returns non-zero, which silently double-reports.
+assert_eq() {
+    if [ "$2" = "$3" ]; then ok "$1"; else bad "$1" "$3" "$2"; fi
+}
+assert_contains() {
+    case "$2" in
+        *"$3"*) ok "$1" ;;
+        *) bad "$1" "output containing '$3'" "$(printf '%s' "$2" | head -c 200)" ;;
+    esac
+}
+assert_ge() {
+    if [ "${2:-0}" -ge "$3" ] 2>/dev/null; then ok "$1 ($2)"; else bad "$1" ">=$3" "${2:-<empty>}"; fi
+}
+
+# --- fixture corpus -------------------------------------------------------
+FIXROOT=$(mktemp -d)
+if [ -z "$FIXROOT" ] || [ ! -d "$FIXROOT" ]; then
+    echo "FAIL: could not create fixture root"
+    exit 1
+fi
+trap 'rm -rf "$FIXROOT"' EXIT
+
+mkdir -p "$FIXROOT/home/.claude/rules"
+mkdir -p "$FIXROOT/proj/repo-a/.claude/rules"
+mkdir -p "$FIXROOT/proj/repo-b/.claude/rules"
+mkdir -p "$FIXROOT/proj/some-plugin/skills/widget-wrangling"
+
+cat > "$FIXROOT/proj/some-plugin/skills/widget-wrangling/SKILL.md" <<'SKILL'
+---
+name: widget-wrangling
+description: Wrangle widgets across the fleet. Use when calibrating widget torque or auditing widget inventory.
+---
+# widget-wrangling
+Calibrating widget torque requires the fleet inventory. Audit widget torque
+calibration across every widget in the inventory before adjusting any widget.
+SKILL
+
+run() { python3 "$ANALYZER" --root "$FIXROOT/proj" --no-embed --fast --format=json 2>/dev/null; }
+run_status() { python3 "$ANALYZER" --root "$FIXROOT/proj" --no-embed --fast --format=status 2>/dev/null; }
+count_kind() { printf '%s' "$1" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(sum(1 for f in d["findings"] if f["kind"]==sys.argv[1]))' "$2" 2>/dev/null || echo ERR; }
+count_key()  { printf '%s' "$1" | python3 -c 'import json,sys; print(json.load(sys.stdin)["counts"][sys.argv[1]])' "$2" 2>/dev/null || echo ERR; }
+
+export HOME="$FIXROOT/home"
+
+echo "TEST 1: empty corpus is OK, not an error"
+out=$(run_status)
+assert_contains "empty corpus reports STATUS=OK" "$out" "STATUS=OK"
+python3 "$ANALYZER" --root "$FIXROOT/proj" --no-embed --fast --format=status >/dev/null 2>&1
+assert_eq "empty corpus exits 0" "$?" "0"
+
+echo "TEST 2: duplicate rules across scopes (three-point ladder)"
+# A checker that reports a duplicate unconditionally, or never, passes only one
+# of these three rungs.
+cat > "$FIXROOT/proj/repo-a/.claude/rules/alpha.md" <<'RULE'
+# Alpha
+The torque calibration procedure requires the fleet inventory manifest before
+any widget adjustment is attempted on the assembly line.
+RULE
+out=$(run)
+assert_eq "one rule, no duplicate reported" "$(count_kind "$out" duplicate_rule_lexical)" "0"
+
+cp "$FIXROOT/proj/repo-a/.claude/rules/alpha.md" "$FIXROOT/proj/repo-b/.claude/rules/beta.md"
+out=$(run)
+assert_eq "identical rule in a second scope is reported once" "$(count_kind "$out" duplicate_rule_lexical)" "1"
+
+rm "$FIXROOT/proj/repo-b/.claude/rules/beta.md"
+out=$(run)
+assert_eq "removing the copy clears the finding" "$(count_kind "$out" duplicate_rule_lexical)" "0"
+
+echo "TEST 3: waiver suppresses, and expires when either side changes"
+cp "$FIXROOT/proj/repo-a/.claude/rules/alpha.md" "$FIXROOT/proj/repo-b/.claude/rules/beta.md"
+hash_of() { python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],encoding="utf-8").read().encode()).hexdigest()[:16])' "$1"; }
+ha=$(hash_of "$FIXROOT/proj/repo-a/.claude/rules/alpha.md")
+hb=$(hash_of "$FIXROOT/proj/repo-b/.claude/rules/beta.md")
+WAIVERS="$FIXROOT/waivers.json"
+python3 - "$WAIVERS" "$FIXROOT/proj/repo-a/.claude/rules/alpha.md" "$ha" "$FIXROOT/proj/repo-b/.claude/rules/beta.md" "$hb" <<'PY'
+import json, sys
+p, a, ha, b, hb = sys.argv[1:6]
+json.dump({"waivers": [{"a": a, "b": b, "a_hash": ha, "b_hash": hb,
+                        "reason": "deliberate for the test"}]}, open(p, "w"))
+PY
+out=$(python3 "$ANALYZER" --root "$FIXROOT/proj" --no-embed --fast --format=json --waivers "$WAIVERS" 2>/dev/null)
+assert_eq "waived pair is suppressed" "$(count_kind "$out" duplicate_rule_lexical)" "0"
+
+printf '\nAn edit that changes the content.\n' >> "$FIXROOT/proj/repo-b/.claude/rules/beta.md"
+out=$(python3 "$ANALYZER" --root "$FIXROOT/proj" --no-embed --fast --format=json --waivers "$WAIVERS" 2>/dev/null)
+assert_eq "editing either side revives the finding" "$(count_kind "$out" duplicate_rule_lexical)" "1"
+rm "$FIXROOT/proj/repo-b/.claude/rules/beta.md"
+
+echo "TEST 4: pointer-stub integrity"
+cat > "$FIXROOT/home/.claude/rules/widget-stuff.md" <<'RULE'
+# Widget Stuff
+
+Promoted to a skill: invoke `widget-wrangling` before calibrating widget
+torque — it carries the fleet inventory procedure.
+RULE
+out=$(run)
+assert_eq "a stub naming a real skill is not flagged" "$(count_kind "$out" broken_pointer_stub)" "0"
+
+cat > "$FIXROOT/home/.claude/rules/ghost-stuff.md" <<'RULE'
+# Ghost Stuff
+
+Promoted to a skill: invoke `no-such-skill-anywhere` before doing the thing —
+it carries the whole procedure.
+RULE
+out=$(run)
+assert_eq "a stub naming a missing skill is an error" "$(count_kind "$out" broken_pointer_stub)" "1"
+python3 "$ANALYZER" --root "$FIXROOT/proj" --no-embed --fast --gate --format=status >/dev/null 2>&1
+assert_eq "--gate exits 2 on a broken stub" "$?" "2"
+rm "$FIXROOT/home/.claude/rules/ghost-stuff.md"
+
+echo "TEST 5: path-scoped rules are not counted as always-loaded"
+# The bug this pins: `paths:` parses to an EMPTY string value (its globs are on
+# following lines), so a truthiness test silently counts every scoped rule as
+# unconditional -- a ~24% over-count on the real corpus.
+cat > "$FIXROOT/home/.claude/rules/scoped.md" <<'RULE'
+---
+created: 2026-01-01
+modified: 2026-01-01
+paths:
+  - "**/*.tf"
+---
+# Scoped
+Terraform state locking behaves differently under a remote backend, and the
+lock is not released when the process is killed mid-apply.
+RULE
+out=$(run)
+scoped_tokens=$(count_key "$out" always_loaded_tokens)
+rm "$FIXROOT/home/.claude/rules/scoped.md"
+out=$(run)
+unscoped_tokens=$(count_key "$out" always_loaded_tokens)
+assert_eq "a paths:-scoped rule adds nothing to the always-loaded budget" "$scoped_tokens" "$unscoped_tokens"
+
+echo "TEST 6: guard integrity — the corpus is actually being read"
+# Without this, every 'not flagged' assertion above would also pass against an
+# analyzer that discovered nothing at all.
+out=$(run)
+rules=$(count_key "$out" rules)
+skills=$(count_key "$out" skills)
+assert_ge "fixture rules were discovered" "$rules" 2
+assert_ge "fixture skills were discovered" "$skills" 1
+assert_contains "semantic pass is reported off under --no-embed" "$(run_status)" "SEMANTIC_PASS=off"
+
+echo "TEST 7: --fast spawns no git"
+# Proven by putting a poisoned `git` first on PATH: if the analyzer shells out,
+# the marker file appears.
+GITDIR="$FIXROOT/fakebin"
+mkdir -p "$GITDIR"
+cat > "$GITDIR/git" <<'STUB'
+#!/usr/bin/env bash
+touch "$GIT_CALLED_MARKER"
+exit 0
+STUB
+chmod +x "$GITDIR/git"
+export GIT_CALLED_MARKER="$FIXROOT/git-was-called"
+rm -f "$GIT_CALLED_MARKER"
+PATH="$GITDIR:$PATH" python3 "$ANALYZER" --root "$FIXROOT/proj" --no-embed --fast --format=status >/dev/null 2>&1
+if [ ! -f "$GIT_CALLED_MARKER" ]; then
+    ok "--fast never invokes git"
+else
+    bad "--fast never invokes git" "no git call" "git was invoked"
+fi
+
+echo "TEST 8: unknown argument is rejected, not swallowed"
+if python3 "$ANALYZER" --root "$FIXROOT/proj" --no-such-flag >/dev/null 2>&1; then
+    bad "unknown flag exits non-zero" "non-zero exit" "exit 0"
+else
+    ok "unknown flag exits non-zero"
+fi
+
+echo
+echo "=== CONFIG DRIFT TESTS ==="
+echo "PASSED=$PASS"
+echo "FAILED=$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+    echo "STATUS=FAIL"
+    exit 1
+fi
+echo "STATUS=OK"
+exit 0

--- a/scripts/required-to-run-tests.txt
+++ b/scripts/required-to-run-tests.txt
@@ -38,3 +38,12 @@ blueprint-plugin/scripts/tests/test-check-manifest-schema.sh
 # silent skip returns it to exactly the state it was written to escape.
 taskwarrior-plugin/skills/task-add/scripts/tests/test-uuid-capture.sh
 taskwarrior-plugin/scripts/tests/test-task-id-stability.sh
+
+# python3  (no install step needed — plugin-compliance-check.sh already
+# depends on it, so the runner always has it)
+#
+# config-drift's ONLY skip condition is a missing python3. On this runner that
+# can't legitimately happen, so a SKIP here never means "optional dependency
+# absent by design" — it means the suite stopped executing, and the probe it
+# backs would go on reporting a clean corpus without having opened one.
+health-plugin/scripts/tests/test-config-drift.sh


### PR DESCRIPTION
## What

A SessionStart probe plus analyzer that audit the **configuration corpus against itself**, rather than validating any single file. This is the question the existing health checks do not ask.

| Check | Severity | Catches |
|---|---|---|
| `broken_pointer_stub` | ERROR | A "Promoted to a skill: invoke `x`" rule whose target skill no longer exists |
| `duplicate_rule_lexical` | WARN | Byte-identical or near-identical rules across scopes |
| `semantic_overlap_*` | WARN | Differently-worded rules/skills covering one topic |
| `rule_covered_by_skill` | INFO | A resident rule whose content a skill already carries |
| `always_loaded_budget` | WARN | The every-turn surface creeping past its ceiling |
| `review_staleness` | WARN | An artifact changed after its declared `reviewed:` date |

## Why a probe and not a skill

Per `.claude/rules/drift-detection-triggering.md`, the gap for this class was never the logic — it was the trigger. So the probe contains **no analysis of its own**: it shells out to `config-drift.py` and forwards at most four findings, collapsed by kind so a long tail reads as one nudge instead of crowding out sibling plugins (the aggregator caps at five lines across all plugins).

## Cost

Two tiers, because a SessionStart probe cannot pay for a model.

```
--fast --no-embed    0.05s   pure stdlib, no git spawn, no model    <- what the probe runs
(default)            ~4s     + embeddings                           <- scheduled/manual only
```

Measured over 342 rules and 549 skills. No TTL debounce: the debounce guidance in `drift-detection-triggering.md` is about **network** round-trips, and this probe makes none.

## Design decisions worth reviewing

**Caches are keyed by content SHA-256, never mtime.** mtime moves on checkout and `chezmoi apply` without the content changing, so a hash cache is correct by construction rather than by TTL. Timestamps are used for a different job entirely — comparing a declared `reviewed:` date against when the file actually last changed.

**Waivers expire themselves.** A waiver records both sides' content hashes, so editing either side revives the finding. Without that property a recurring report re-lists its known-accepted findings until nobody reads it — the failure mode that makes periodic audits worthless.

**The semantic threshold is calibrated, not guessed.** On a real 884-document corpus at cosine 0.86 it emitted **491** findings: 290 were same-name pairs the cheap tier already owns, and most of the rest were genre noise, since every document here is Claude config markdown about tooling. At **0.91**, with same-name and structural pairs excluded, it emits **9** — all genuine cross-plugin ambiguity the lexical pass cannot reach (`bun-publishing` ↔ `bun-publish`, `configure-dead-code` ↔ `code-dead-code`, `blueprint-development` ↔ `blueprint-generate-rules`).

Two shapes are excluded as **structural, not drift**: a pointer stub scores ~0.92 against the very skill it delegates to, and deliberately cross-referenced siblings (`git-hazards` ↔ `pr-merge-hazards`) score ~0.93. Flagging either trains the reader to ignore the report.

**Default `--root` is `.`, not a hardcoded portfolio path** — this ships as a plugin and cannot assume anyone's layout. User-global rules under `~/.claude/rules` are always scanned regardless, because they load in every session whatever project is open.

## Test

`health-plugin/scripts/tests/test-config-drift.sh` — 16 assertions, auto-discovered by `run-skill-script-tests.sh`, and declared in `scripts/required-to-run-tests.txt` so a skip is an ERROR rather than a warning.

Semantic, not syntactic: every case **executes** the analyzer against planted fixtures. A grep for a threshold constant would pass against a checker that never runs — the #1417 → #1819 lesson.

- Duplicate detection is pinned on a **three-point ladder** (absent → present → absent again), so neither a checker that always reports nor one that never reports can pass.
- **Guard integrity:** a case asserts the fixture corpus was actually discovered (`rules>=2`, `skills>=1`). Without it, every "not flagged" assertion would pass against an analyzer that read nothing — the `SCANNED_EMPTY` hole found in the `check-*.sh` guards by #2255/#2290.
- The waiver case asserts both directions: suppressed while hashes match, revived after an edit.
- `--fast` is proven to spawn no git by putting a poisoned `git` first on `PATH` and asserting the marker file never appears.
- Empty corpus reports `STATUS=OK` and exits 0 — a checker that errors on an empty corpus gets disabled.

Isolation: `HOME` is redirected to the fixture root, so the suite never reads the real `~/.claude/rules` or writes real caches, and every case runs `--fast`, so no git is spawned at all and the shared-checkout hazards (#1692/#1745) cannot arise.

## Two defects the suite caught during development

Both were fixed here rather than shipped, and both are the reason the test is executable rather than a grep:

1. `STATUS` emitted `PASS`/`FAIL` instead of the `OK`/`WARN`/`ERROR` vocabulary in `structured-script-output.md`, so orchestrating skills grepping the house vocabulary would have seen nothing.
2. Waiver matching compared **raw path strings**. A waiver written as `~/repos/...` never matched a scan that resolved the same file through a symlink (`/var` → `/private/var` on macOS) — indistinguishable from the waiver being ignored. Both sides are now canonicalised.

## Not in this PR

The scheduled tier (a `.routines/` LaunchAgent running the full pass weekly and reporting only the delta) lives in a different repo and depends on this analyzer landing at a stable path first. Tracked as #2319 rather than bundled — that issue also carries the one-time-backlog decision (74 `review_staleness` findings on the current corpus) that must be made before the scheduled tier is switched on.

