### PR TITLE
feat(agent-patterns-plugin): cover the stale cached git MCP source

### DIFF
--- a/agent-patterns-plugin/skills/mcp-management/SKILL.md
+++ b/agent-patterns-plugin/skills/mcp-management/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-07-09
 reviewed: 2026-07-09
 name: mcp-management
-description: Install and configure MCP servers for Claude Code. Use when adding/enabling servers, updating .mcp.json, managing OAuth remote servers, or troubleshooting connections.
+description: Install, configure and troubleshoot MCP servers. Use when adding/enabling servers, editing .mcp.json, fixing OAuth, or when a server runs stale code after an upstream fix.
 user-invocable: false
 allowed-tools: Bash(jq *), Bash(find *), Read, Write, Edit, Grep, Glob, AskUserQuestion
 ---
@@ -91,6 +91,49 @@ Quick OAuth triage:
 | Step-up auth loop | Scope mismatch | Revoke and re-authorize |
 | Discovery fails | Server down or URL wrong | Verify server URL and connectivity |
 | Cache stale | Server changed OAuth config | Disable/enable server to refresh |
+
+## Stale cached git source
+
+A server registered from a **git URL** rather than a published package serves a
+**cached commit**, so an upstream fix never arrives:
+
+```jsonc
+"pal": {
+  "command": "uvx",
+  "args": ["--from", "git+https://github.com/owner/repo.git", "pal-mcp-server"]
+}
+```
+
+`uvx` resolves the ref to a commit **once**, builds it, and caches by that
+commit. Later spawns reuse the build and do **not** re-fetch the branch head. So
+after a fix merges to the server's `main`, every client keeps running the old
+code — and the symptom is misattributed: you restart the client, the bug
+persists, and you suspect the fix, the registration, or the environment.
+
+**Confirm** by comparing the cached checkout's commit against upstream:
+
+```sh
+fd -H '<a-file-from-the-repo>' "$(uv cache dir)/git-v0/checkouts"   # .../<hash>/<commit>/...
+git ls-remote https://github.com/<owner>/<repo>.git refs/heads/main
+```
+
+A cached `<commit>` that is not the current head is the confirmation.
+
+**Fix** — refresh, then restart the client so it re-spawns from the new build:
+
+```sh
+uvx --refresh --from git+https://github.com/<owner>/<repo>.git <pkg> </dev/null
+```
+
+`</dev/null` feeds EOF so a **stdio** server exits after building instead of
+hanging for requests; the rebuild happens during resolve, so the cache is warm
+even if the process is then killed.
+
+**Durable fix — publish and pin.** This footgun exists *only* for an unpinned
+git source. Once the server is on PyPI, register it as `uvx <pkg>` (or
+`uvx <pkg>@<version>`): a version bump re-resolves cleanly and there is no
+cached-head-went-stale failure at all. Prefer the `git+` form only as an interim
+before the first publish.
 
 ## Configuration Patterns
 


### PR DESCRIPTION
## What

Adds a `## Stale cached git source` section to `mcp-management`, covering a failure mode the skill mentions `uvx` five times without addressing.

## The failure

A server registered from a **git URL** rather than a published package serves a **cached commit**:

```jsonc
"pal": {
  "command": "uvx",
  "args": ["--from", "git+https://github.com/owner/repo.git", "pal-mcp-server"]
}
```

`uvx` resolves the ref to a commit once, builds it, and caches by that commit. Later spawns reuse the build and never re-fetch the branch head — so after a fix merges upstream, every client keeps running the old code.

It is silent and **misattributed**: you restart the client, the bug persists, and you suspect the fix, the registration, or the environment. Observed against a git-registered `pal-mcp-server` whose running build predated the relevant code entirely, while the registration and credentials were both correct.

The section carries the confirm step (compare the cached checkout's commit against `git ls-remote`), the fix (`uvx --refresh … </dev/null`, then restart the client so it re-spawns), and the durable fix: **publish and pin**. The footgun exists *only* for an unpinned git source — once the server is on PyPI, a version bump re-resolves cleanly and the failure cannot occur.

## Placement and description

Its own section rather than a Troubleshooting table row, because the reader arrives with a symptom that does not look cache-shaped — "the fix didn't work" — and a one-line row would not be found from there.

The description gains the symptom clause, since a skill that carries guidance but never fires on it is unreachable:

> …fixing OAuth, **or when a server runs stale code after an upstream fix.**

The first draft of that description came in at 230 chars, inside the WARN band. Trimmed elsewhere to **171**, comfortably under the 200-char listing-budget target. Body is 8,396 chars, under the 10,000 WARN threshold. `plugin-compliance-check.sh agent-patterns-plugin` reports no recommendation against this skill.

## Follow-up (deliberately not bundled)

This is half of a cross-repo pair. The portfolio rule `uvx-git-mcp-stale-cache.md` (~750 tok/turn, always loaded) becomes a pointer stub once this merges — **in that order**, so the stub never points at a skill that does not yet carry the material. That PR lands in `repos-claude-config` after this one.

Found by the portfolio-wide rules/skills audit.
