### PR TITLE
fix(health-plugin): resolve a stub's target by its invoke phrase, not the first backtick

### DIFF
--- a/health-plugin/scripts/config-drift.py
+++ b/health-plugin/scripts/config-drift.py
@@ -249,14 +249,40 @@ def waived(waivers, a: dict, b: dict) -> bool:
 
 
 # --------------------------------------------------------------------- checks
+def _stub_target(head: str, known: set[str]) -> str | None:
+    """Resolve which skill a pointer stub delegates to.
+
+    "First backticked token" was wrong: a stub's own title routinely contains an
+    incidental backticked term, and that word won it. A real stub reading
+    "# Git-Based `uvx` MCP Servers ... invoke `agent-patterns-plugin:mcp-management`"
+    resolved to the skill `uvx`, which does not exist — a false ERROR on a
+    perfectly good stub, which is the failure mode most likely to get an
+    integrity check switched off.
+
+    Three passes, most specific first:
+      1. the token following `invoke` — the house phrasing every stub uses
+      2. any backticked token that names a real skill
+      3. the first backticked token, so a genuinely broken stub still reports
+         a name rather than "(none named)"
+    """
+    m = re.search(r"invoke\s+`([a-z0-9:_-]+)`", head)
+    if m:
+        return m.group(1).split(":")[-1]
+
+    refs = [t.split(":")[-1] for t in re.findall(r"`([a-z0-9:_-]+)`", head)]
+    for ref in refs:
+        if ref in known:
+            return ref
+    return refs[0] if refs else None
+
+
 def check_stub_integrity(rules, skills) -> list[dict]:
     known = {s["name"] for s in skills}
     out = []
     for r in rules:
         if not r["stub"]:
             continue
-        refs = re.findall(r"`([a-z0-9:-]+)`", r["body"][:700])
-        target = refs[0].split(":")[-1] if refs else None
+        target = _stub_target(r["body"][:700], known)
         if target not in known:
             out.append(
                 {

--- a/health-plugin/scripts/tests/test-config-drift.sh
+++ b/health-plugin/scripts/tests/test-config-drift.sh
@@ -144,6 +144,32 @@ python3 "$ANALYZER" --root "$FIXROOT/proj" --no-embed --fast --gate --format=sta
 assert_eq "--gate exits 2 on a broken stub" "$?" "2"
 rm "$FIXROOT/home/.claude/rules/ghost-stuff.md"
 
+# The false positive this check actually produced in use: the stub's TITLE
+# carries an incidental backticked term, and "first backticked token" picked
+# that instead of the delegation target. Verbatim shape of the real stub.
+cat > "$FIXROOT/home/.claude/rules/titled-stuff.md" <<'RULE'
+# Git-Based `uvx` Widget Servers Serve a Stale Cached Commit
+
+Promoted to a skill: invoke `some-plugin:widget-wrangling` when a widget
+server appears to run stale code — it carries the whole recipe.
+RULE
+out=$(run)
+assert_eq "a backticked term in the title does not win over the invoke target" \
+    "$(count_kind "$out" broken_pointer_stub)" "0"
+
+# Guard integrity: the fix must not resolve EVERYTHING to something valid.
+# Same title shape, but the invoke target is genuinely missing.
+cat > "$FIXROOT/home/.claude/rules/titled-broken.md" <<'RULE'
+# Git-Based `uvx` Widget Servers Serve a Stale Cached Commit
+
+Promoted to a skill: invoke `some-plugin:no-such-skill-at-all` when a widget
+server appears to run stale code — it carries the whole recipe.
+RULE
+out=$(run)
+assert_eq "a broken invoke target is still caught despite a resolvable title term" \
+    "$(count_kind "$out" broken_pointer_stub)" "1"
+rm "$FIXROOT/home/.claude/rules/titled-stuff.md" "$FIXROOT/home/.claude/rules/titled-broken.md"
+
 echo "TEST 5: path-scoped rules are not counted as always-loaded"
 # The bug this pins: `paths:` parses to an EMPTY string value (its globs are on
 # following lines), so a truthiness test silently counts every scoped rule as


### PR DESCRIPTION
## The false positive

`config-drift`'s stub-integrity check took the **first backticked token** in a rule's opening as the skill it delegates to. A pointer stub's own *title* routinely carries an incidental backticked term, and that word won.

Found in use rather than in theory, on the very next stub written after #2318 merged:

```markdown
# Git-Based `uvx` MCP Servers Serve a Stale Cached Commit

Promoted to a skill: invoke `agent-patterns-plugin:mcp-management` when an MCP
server appears to run stale code after an upstream fix ...
```

It resolved to the skill **`uvx`**, reported `broken_pointer_stub` at ERROR, and would have exited 2 under `--gate`.

A false ERROR on a correct stub matters more than a miss here: it is the failure mode most likely to get an integrity check switched off, and this one sits on the SessionStart path where it is seen constantly.

## The fix

Three passes, most specific first:

1. the token following `` invoke `…` `` — the house phrasing every stub in this portfolio uses
2. any backticked token that names a real skill
3. the first backticked token, so a genuinely broken stub still reports a *name* rather than `(none named)`

Pass 3 is deliberate. Falling back to "no target found" would turn a broken stub's message from actionable into useless.

## Verification

Mutation-verified — both new assertions fail against the old heuristic (16 passed / 2 failed) and pass with the fix (18/18):

| Case | Old | New |
|---|---|---|
| Title carries `` `uvx` ``, invoke names a real skill | ERROR (wrong) | clean |
| Title carries `` `uvx` ``, invoke names a **missing** skill | ERROR (right, wrong reason) | ERROR |

The second is the **guard-integrity half**. Without it, a "fix" that resolved everything to something valid — or simply stopped reporting — would pass the first case and look correct. It uses the identical title shape so the only variable is whether the invoke target exists.

`shellcheck` clean, `ruff check` and `ruff format --check` clean.

## Why this is a good sign

The tool caught a defect in its own heuristic within an hour of shipping, on real input, and the defect was in the direction that matters least dangerously — a false alarm rather than a silent miss. That is roughly the behaviour you want from a new guard's first week.
