### PR TITLE
docs(rules): grep -r on a single file omits the filename on GNU, not BSD

### DIFF
--- a/.claude/rules/shell-scripting.md
+++ b/.claude/rules/shell-scripting.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-01-18
-modified: 2026-03-02
-reviewed: 2026-03-02
+modified: 2026-08-08
+reviewed: 2026-08-08
 requires: bash 5+
 paths:
   - "**/*.sh"
@@ -399,6 +399,34 @@ Even with bash 5+, some CLI tools differ between macOS (BSD) and Linux (GNU). Us
 | `date` | `date -j -f "%Y-%m-%d %H:%M:%S" "$d 00:00:00"` | `date -d "$d 00:00:00"` | Pin the time component (see below) |
 | `sed -i` | `sed -i ''` | `sed -i` | Use `sed -i.bak` + `rm` |
 | `grep -P` | Not available | PCRE support | Use `grep -E` (extended regex) |
+| `grep -r <one file>` | Prints `file:line:text` | Prints `line:text` | Always pass `-H` (see below) |
+
+#### `grep -r` on a *single* file omits the filename on GNU, keeps it on BSD
+
+A guard that greps a **file list** and parses `FILE:LINE:TEXT` works on macOS and
+silently mis-parses on Linux **whenever the list happens to hold one entry**:
+GNU grep drops the filename prefix for a single file argument, BSD keeps it. The
+parse then shifts by one field and reads the line number as the filename.
+
+```sh
+# Wrong — correct on BSD, off-by-one-field on GNU when "${files[@]}" has one element
+grep -rn -F "$pattern" "${files[@]}"       # GNU single-file: "2:gh api ..."
+
+# Right — -H forces the prefix on both
+grep -rHn -F "$pattern" "${files[@]}"      # always: "./path/run.sh:2:gh api ..."
+```
+
+The failure is **invisible locally and only reproduces in CI**, which is the
+whole hazard: `scripts/check-dead-api-endpoints.sh` was 17/17 green on macOS and
+failed one assertion on the first Linux run, reporting `FILE=2`. Nothing short
+of running on both platforms catches it — a fixture cannot, because the fixture
+runs on whichever grep the author has.
+
+Same shape as the `date` traps below: a default that differs by implementation,
+where the portable form costs one flag. **Pass `-H` in any `grep` whose output
+you parse by field**, regardless of how many files you expect — "expect" is
+doing load-bearing work in that sentence, and a fixture with one file is exactly
+the case that triggers it.
 
 #### BSD `date` fills unspecified time fields with the *current* time
 


### PR DESCRIPTION
## What

Adds a `grep` row and a subsection to `shell-scripting.md`'s existing **GNU vs BSD Tool Differences** section.

`grep -r` on a **single** file argument prints `line:text` on GNU and `file:line:text` on BSD. A guard that greps a file list and parses `FILE:LINE:TEXT` therefore works on macOS and silently mis-parses on Linux **whenever the list happens to hold one entry** — the parse shifts a field and reads the line number as the filename.

```sh
grep -rn  -F "$pattern" "${files[@]}"   # GNU, one file: "2:gh api ..."
grep -rHn -F "$pattern" "${files[@]}"   # both:          "./path/run.sh:2:gh api ..."
```

## Distilled from a live break, not a hypothetical

`scripts/check-dead-api-endpoints.sh` (#2321) was **17/17 green on macOS** and failed one assertion on its first Linux CI run, reporting `FILE=2`.

The part worth writing down is that **a fixture cannot catch this class** — the fixture runs on whichever grep the author has, so the local suite is green by construction. Running on both platforms is the only detector. That is also why it is stated as an unconditional rule rather than a "when you have multiple files" caveat: "expect one file" is doing load-bearing work in the buggy version, and a single-entry list is exactly the trigger.

It sits beside the two BSD `date` traps because it is the same shape — an implementation-dependent default where the portable form costs one flag.

## Cost

None on the always-loaded surface. `shell-scripting.md` is path-scoped to `**/*.sh` and `scripts/**`, so it loads only when shell is in play. `check-context-engineering.py --strict` still exits 0.

`modified:` / `reviewed:` bumped, per the frontmatter convention this repo's own `check-docs-index.sh` Check 5 enforces.
