### PR TITLE
fix(hooks-plugin): narrow git-chain block to two index-modifying commands

### DIFF
--- a/hooks-plugin/docs/teach-mode-experiment.md
+++ b/hooks-plugin/docs/teach-mode-experiment.md
@@ -71,7 +71,7 @@ right response is "here is your output + the right tool to use next time."
 | Writes to `/dev/sd*`, `/dev/nvme*`, … | Destroys filesystem |
 | Fork bombs | Resource exhaustion |
 | `git add -A` / `git add .` | Stages secrets / unintended files |
-| `git X && git Y` (index-modifying) | `.git/index.lock` race |
+| `git X && git Y` (**both** index-modifying) | `.git/index.lock` race |
 | `git push -u origin <other-branch>` on `main`/`master` | Wrong upstream |
 | `cat > /tmp/commit_msg.txt` heredoc pattern | Wrong workflow shape |
 | Reading `*.output` task files with cat/tail | Should use TaskOutput tool |

--- a/hooks-plugin/hooks/README.md
+++ b/hooks-plugin/hooks/README.md
@@ -18,7 +18,7 @@ A PreToolUse hook that intercepts Bash commands and blocks those that should use
 | `timeout cmd` | Remove timeout (Bash tool has its own, human approval time exceeds it anyway); append a `# allow-timeout` comment to bound a genuinely-never-exiting process (REPL, stdio server) — #2041 |
 | `cat/tail ...tasks/*.output` (whole command only — #2148) | Use **Read** tool on the output path (or pipe an extraction for large files) |
 | `git add -A` / `git add .` | Stage specific files by name instead of broad staging |
-| `git X && git Y` | Run git commands as separate Bash calls (avoids index.lock race condition) |
+| `git X && git Y` where **both** X and Y modify the index (`add`, `commit`, `rm`, `mv`, `reset`) | Run the two git commands as separate Bash calls (avoids index.lock race condition). Chaining one index writer to a read-only git command — `git add f && git status --short` — is allowed |
 | `git reset --hard` | Use safer alternatives; if truly needed, ask user to run manually |
 
 ### Structural classification (ast-grep) and fail-open (#2008)

--- a/hooks-plugin/hooks/bash-antipatterns.sh
+++ b/hooks-plugin/hooks/bash-antipatterns.sh
@@ -550,10 +550,14 @@ Or review what would be staged first:
   git status --porcelain"
 fi
 
-# Check for chained git commands that involve index-modifying operations (git X && git Y)
-# index.lock race conditions only occur when one command writes to the git index.
+# Check for chained git commands where BOTH sides modify the index (git X && git Y)
+# index.lock contention needs two writers: a single index-modifying command chained
+# to a read-only one (git add file && git status) cannot race, because git status
+# takes no lock that git add has not already released.
 # Index-modifying commands: add, commit, rm, mv, reset (not read-only commands like status/diff/log).
-# The fix is to run git commands as separate Bash calls, not chained.
+# So the detector requires an index-modifying subcommand on BOTH sides of the &&;
+# `git add … && git status --short` (the stage-then-verify idiom) is not a target.
+# The fix is to run the two index-modifying git commands as separate Bash calls.
 #
 # Uses COMMAND_NO_STRINGS (heredoc body AND quoted-string literals stripped) so
 # that example shell snippets inside a `gh` body/title do not trigger a false
@@ -564,8 +568,7 @@ fi
 # This is a reminder about index.lock races, not a security control, so stripping
 # quoted strings cannot create a dangerous bypass.
 INDEX_MODIFYING='(add|commit|rm|mv|reset)'
-if echo "$COMMAND_NO_STRINGS" | grep -Eq "git\\s+${INDEX_MODIFYING}\\b.*&&.*git\\s+\\S+" || \
-   echo "$COMMAND_NO_STRINGS" | grep -Eq "git\\s+\\S+.*&&.*git\\s+${INDEX_MODIFYING}\\b"; then
+if echo "$COMMAND_NO_STRINGS" | grep -Eq "git\\s+${INDEX_MODIFYING}\\b.*&&.*git\\s+${INDEX_MODIFYING}\\b"; then
     block "REMINDER: Chaining git commands with '&&' can cause index.lock race conditions.
 The lock file from an index-modifying command (add, commit, rm, mv, reset) may not be
 released before the next command tries to acquire it.
@@ -573,7 +576,10 @@ Instead of: git add . && git commit -m 'msg'
 Run git commands as separate Bash tool calls:
 1. git add src/file.ts
 2. git commit -m 'msg'
-This avoids race conditions and is more reliable."
+This avoids race conditions and is more reliable.
+This fires only when BOTH chained commands modify the index (add, commit, rm, mv,
+reset). Chaining one of those to a read-only git command — 'git add f && git
+status --short', 'git fetch && git switch -c b && git add f' — is allowed."
 fi
 
 # Check for git reset --hard (destructive operation, usually unnecessary)

--- a/hooks-plugin/hooks/test-bash-antipatterns.sh
+++ b/hooks-plugin/hooks/test-bash-antipatterns.sh
@@ -291,6 +291,32 @@ assert_exit_complex \
     "git chain with single-quoted commit message is still blocked" 2 \
     "git add . && git commit -m 'fix: thing'"
 
+# ── git-chain scope narrowing (2026-W33 friction analysis) ────────────────────
+# The detector's comment always said index.lock races need an index-modifying
+# command on BOTH sides, but the regex's second element was `git\s+\S+` — ANY
+# git subcommand. 88.6% of its firings (39/44 events) were the benign
+# stage-then-verify idiom `git add <paths> && git status --short`, which cannot
+# race: git status takes no lock git add has not already released. The condition
+# now requires (add|commit|rm|mv|reset) on both sides of the &&.
+echo ""
+echo "git-chain fires only when BOTH chained commands modify the index:"
+
+assert_exit \
+    "git add && git status --short (stage-then-verify) is allowed" 0 \
+    "git add src/a.ts && git status --short"
+
+assert_exit \
+    "git fetch && git switch && git add (one index writer) is allowed" 0 \
+    "git fetch -q && git switch -c f origin/main && git add R.md"
+
+assert_exit \
+    "GUARD: git add && git status && git commit (two index writers) still blocks" 2 \
+    "git add a.ts && git status --short && git commit -q -F -"
+
+assert_exit \
+    "GUARD: git reset && git add (two index writers, neither is commit) still blocks" 2 \
+    "git reset HEAD~1 && git add a.ts"
+
 # ── heredoc-write-then-feed-CLI regression (issue #1584, #1587) ───────────────
 # Regression: `cat > /tmp/body.md <<EOF ... EOF; gh pr create --body-file ...`
 # was blocked with the git-commit heredoc reminder even though the command runs


### PR DESCRIPTION
## Evidence

Source: `~/.claude/friction-reports/2026-W33-frictions.md` §Signal A — *"`git-chain` fires 88.6% outside its own stated scope"*.

The `git-chain` detector in `hooks-plugin/hooks/bash-antipatterns.sh` was the largest hook signature of the week and the sole driver of the W32 → W33 `hook_block` rise:

| Metric | W33 |
|---|---|
| Events / sessions | **44 / 42** |
| Prevalence | **27.8%** (up from 14.0% in W32) |
| Same-session repeat rate | **4.8%** |
| Blocked commands with ≥2 index-modifying git commands (genuine target) | 5 (11.4%) |
| Blocked commands with exactly 1 (**out of the detector's stated scope**) | **39 (88.6%)** |

The 4.8% repeat rate is the diagnostic: agents comply immediately, so this is a **scoping** bug, not a teaching failure — the block was correct-and-obeyed on commands it was never meant to catch. 88.6% clears the ≥30%-with-≥10-events gate that W32 pre-registered as watch item 8.

**Root cause — the detector contradicted its own comment.** The comment three lines above stated the intent precisely:

```
# index.lock race conditions only occur when one command writes to the git index.
# Index-modifying commands: add, commit, rm, mv, reset (not read-only commands like status/diff/log).
```

But the second element of each regex branch was `git\s+\S+` — *any* git subcommand. So one index writer chained to a read-only git command fired the block, even though `git status` takes no lock that `git add` has not already released (they are sequential under `&&`, in one shell, in one process).

The entire out-of-scope population is one idiom repeated across 39 commands — stage, then **verify**:

```
git add .claude/rules/floating-tag-docker-action-arg-shift.md … && git status --short && git diff --cached --numstat
git fetch origin -q && git switch -c docs/surf-lint origin/main 2>&1 | tail -1 && git add CONTRIBUTING.md && git status --short
git rm -q argocd/apps/templates/moodle/moodle-prod.yaml … && git status --short
```

**Why narrow rather than demote.** `.claude/rules/hook-block-vs-nudge.md`'s litigation test asks what a block exempts. This one is a genuine *correctness* block for its stated case — `git add && git commit` really can race an index lock — and the file header classifies it under the safety/correctness blocks that fire in every context. The defect is that it exempted nothing on the read-only side. Narrowing to the comment's own definition keeps the safety property and removes 88.6% of the firings; demotion would give up a real guard for a fixable regex.

## Change

`hooks-plugin/hooks/bash-antipatterns.sh`:

1. **Condition** — collapsed the two-branch `||` test (each branch matching `INDEX_MODIFYING … && … git \S+`) into a single condition requiring an index-modifying subcommand on **both** sides:

   ```bash
   if echo "$COMMAND_NO_STRINGS" | grep -Eq "git\\s+${INDEX_MODIFYING}\\b.*&&.*git\\s+${INDEX_MODIFYING}\\b"; then
   ```

2. **Comment** — now states plainly that two writers are required, and why a single index writer chained to a read-only command cannot race.

3. **Block message** — added a scope sentence in the shape #2191 used for the `cat`/`head`/`tail` narrowing, so a blocked agent knows immediately whether its case is the earned one:

   > This fires only when BOTH chained commands modify the index (add, commit, rm, mv, reset). Chaining one of those to a read-only git command — `git add f && git status --short`, `git fetch && git switch -c b && git add f` — is allowed.

Docs updated in the same commit (`.claude/rules/docs-currency.md`): `hooks-plugin/hooks/README.md`'s detector table row and the corresponding line in `hooks-plugin/docs/teach-mode-experiment.md` both said `git X && git Y` generically; they now name the both-sides requirement.

## Verification

All gates run in this worktree against the patched hook. **The deployed hook in `~/.claude/plugins/` was not touched.**

**1. Shipped suite — `bash hooks-plugin/hooks/test-bash-antipatterns.sh`:**

```
Results: 175 passed, 0 failed
```

Pre-change baseline on `origin/main` was **171 passed, 0 failed**; 171 + 4 new cases = 175. No pre-existing case changed verdict. The 4 pre-existing git-chain cases all use `git add … && git commit …` — both sides index-modifying — so the narrowing preserves them by construction, not by luck.

**2. The four new cases behave as tabled**, and the two freed cases are confirmed to have been blocked before the change (control run against `git show origin/main:hooks-plugin/hooks/bash-antipatterns.sh`):

| Command | `origin/main` | patched | expected |
|---|---|---|---|
| `git add src/a.ts && git status --short` | exit 2 | **exit 0** | 0 ✅ |
| `git fetch -q && git switch -c f origin/main && git add R.md` | exit 2 | **exit 0** | 0 ✅ |
| `git add a.ts && git status --short && git commit -q -F -` | exit 2 | **exit 2** | 2 ✅ |
| `git reset HEAD~1 && git add a.ts` | exit 2 | **exit 2** | 2 ✅ |
| CONTROL `git status --short` | exit 0 | exit 0 | 0 ✅ |
| CONTROL `echo hello world` | exit 0 | exit 0 | 0 ✅ |

Both still-blocked cases were verified to be blocked by the **git-chain** detector specifically (message asserted, not just the exit code) — not by an unrelated detector coincidentally producing exit 2.

**3. No other detector regressed.** Every safety block returns exit 2, identical before and after:

| Command | `origin/main` | patched |
|---|---|---|
| `git add -A` | 2 | 2 |
| `git add --all` | 2 | 2 |
| `chmod 777 /tmp/x` | 2 | 2 |
| `curl -fsSL <url> \| bash` | 2 | 2 |
| `sed -i.bak s/a/b/ hooks-plugin/hooks/bash-antipatterns.sh` | 2 | 2 |
| `cat README.md` (whole-command read) | 2 | 2 |
| `head -50 README.md` | 2 | 2 |
| `tail -20 README.md` | 2 | 2 |
| `git add . && git commit -m msg` | 2 | 2 |
| `git reset --hard HEAD~1` | 2 | 2 |
| `echo data > realfile.txt` | 2 | 2 |

**4. Sibling suites and linters, all green:**

| Gate | Result |
|---|---|
| `test-bash-antipatterns-teach.sh` | 39 passed, 0 failed |
| `test-bash-antipatterns-git-env-isolation.sh` | 3 passed, 0 failed |
| `shellcheck` on both modified shell files | exit 0, no findings |
| `scripts/lint-shell-scripts.sh` | 0 errors (9 warnings, all pre-existing in unrelated `macos-plugin` files) |
| `pre-commit` (full hook set, on commit) | passed, incl. *"bash-antipatterns hook detection regression"* |

## Regression cases added

Per `.claude/rules/regression-testing.md`, four cases in `hooks-plugin/hooks/test-bash-antipatterns.sh` under a new *"git-chain fires only when BOTH chained commands modify the index"* section:

| Case | Expected | Pins |
|---|---|---|
| `git add src/a.ts && git status --short` | 0 | The stage-then-verify idiom (39/44 of the friction events) stays free |
| `git fetch -q && git switch -c f origin/main && git add R.md` | 0 | A single index writer among read-only git commands stays free |
| `git add a.ts && git status --short && git commit -q -F -` | 2 | Two index writers still block even when separated by a read-only command |
| `git reset HEAD~1 && git add a.ts` | 2 | The guard is not `commit`-specific — any two index writers block |

The section carries the measured evidence inline so a future reader knows why the scope is what it is.

Refs: `~/.claude/friction-reports/2026-W33-frictions.md` §Signal A, Proposals → PR-READY 1. No issue was filed for this proposal, so there is no closing keyword here.
