### PR TITLE
test(claude-probe): calibrate trap-01 on outcome and author trap corpus traps

### DIFF
--- a/experiments/claude-probe/docs/trap-corpus.md
+++ b/experiments/claude-probe/docs/trap-corpus.md
@@ -29,17 +29,37 @@ model*; all arms fail → the rule doesn't fire even on home turf (the strongest
 
 | id | rule | scenario the fixture builds | discriminating check |
 |---|---|---|---|
-| `trap-01-squash-merge-detection` ✅ | branch-merge-detection | branch squash-merged into main (unmerged to `--merged`, contained by `merge-tree`) | used `merge-tree`; VERDICT: SAFE |
-| `trap-02-chezmoi-exact-delete` | chezmoi-conventions | `exact_` source + an unmanaged file in target | ran `chezmoi status/diff` before `apply --force` |
-| `trap-03-git-add-pathspec` | git-add-atomic-pathspec | `git mv` rename + a working-tree edit | staged edit landed (not just the rename); checked `status` |
-| `trap-04-zsh-extended-glob` | zsh-pattern-expansion | `${v##*#}` parse under `extended_glob` | output escapes `\#` / single-token strip |
-| `trap-05-textual-merge-dup` | textual-merge-duplicates | two branches add the same helper in non-adjacent spots | built/grepped for the duplicate after a clean auto-merge |
-| `trap-06-dockerignore-subdir` | docker-build-context | subdir `Dockerfile` + a bare sibling `.dockerignore` | renamed to `Dockerfile.dockerignore` / diagnosed dead ignore |
-| `trap-07-branch-from-pushed-main` | branch-from-pushed-main | local `main` ahead of origin by a stray commit | branched from `origin/main` / checked `log origin/main..main` |
+| `trap-01-squash-merge-detection` ✅ | branch-merge-detection | branch squash-merged into main, **plus post-squash base drift** so `--merged`, `log main..branch` and `diff` all read "unmerged" | used `cherry`/`merge-tree`; VERDICT: SAFE |
+| `trap-02-chezmoi-exact-delete` ✅ | chezmoi-conventions | `exact_` source + an unmanaged file in target, beside a non-`exact_` sibling whose unmanaged file survives | ran `chezmoi status/diff` before `apply --force`; named the one deleted path |
+| `trap-03-git-add-pathspec` ✅ | git-add-atomic-pathspec | `git mv` rename + a working-tree edit | staged edit landed (not just the rename); checked `status` |
+| `trap-04-zsh-extended-glob` ✅ | zsh-pattern-expansion | `${v##*#}` under `extended_glob`, beside a bash prototype where it works | output escapes `\#`; blamed the option, not the data |
+| `trap-05-textual-merge-dup` ✅ | textual-merge-duplicates | two branches add the same helper in non-adjacent spots | built/grepped for the duplicate after a clean auto-merge |
+| `trap-06-dockerignore-subdir` ✅ | docker-build-context | subdir `Dockerfile` + a bare sibling `.dockerignore` | renamed to `Dockerfile.dockerignore` / diagnosed dead ignore |
+| `trap-07-branch-from-pushed-main` ✅ | branch-from-pushed-main | local `main` ahead of origin by a stray commit, **with no upstream set** so `git status` reports nothing | branched from `origin/main` / checked `log origin/main..main` |
 
-✅ = built. The rest are the Phase 1 authoring queue; each needs a `setup.sh`
-that genuinely reproduces the trap (verify the un-ruled path actually fails)
-and checks that are true discriminators, not restatements of the prompt.
+✅ = built.
+
+### Calibrate on OUTCOME, not technique
+
+A trap only measures a rule's value if the un-ruled path lands on the **wrong
+answer**. If the naive route merely takes a clumsier road to the right one, the
+rule under test is unfalsifiable and a green result means nothing.
+
+Two of the fixtures needed a deliberate twist to clear that bar, and both are
+worth copying when adding trap-08+:
+
+- **trap-01** originally squash-merged and stopped. With `main` unchanged since
+  the squash, `git diff main feat-done` is **empty**, so any route at all
+  concludes "contained" — the trap graded technique only. Letting `main` drift
+  after the squash (in a region the branch never touched, so the three-way
+  merge stays clean) makes `log` and `diff` misleading too, and only a
+  containment-aware signal survives.
+- **trap-07** with an upstream configured has `git status` volunteer
+  `[ahead 1]`. Dropping the upstream makes the divergence invisible to the
+  commands one reaches for first.
+
+The general shape: find the signal that accidentally gives the answer away, and
+remove it — without removing the truth.
 
 ## Run
 
@@ -48,6 +68,21 @@ just run-config 'trap-01-*' 3     # one trap, 3 arms, N=3
 just compare-fast latest
 ```
 
-A trap only counts if its fixture is self-verifying: the setup should be
-checkable (e.g. `git branch --merged` really omits the branch while
-`merge-tree` really matches) before trusting any arm's score.
+### Fixture prerequisites
+
+Each fixture builds its own scenario, but four traps need a tool on the runner
+to be *diagnosable* by the model under test. A missing tool does not corrupt the
+fixture; it just turns that trap into a knowledge question rather than an
+investigation, so read those arms with that in mind.
+
+| trap | needs |
+|---|---|
+| 01, 03, 05, 07 | `git` only (05 also runs `python3` for the repo's own check) |
+| 02 | `chezmoi` |
+| 04 | `zsh` |
+| 06 | a running Docker daemon (the fixture is diagnosable without one) |
+
+A trap only counts if its fixture is self-verifying: before trusting any arm's
+score, confirm the misleading command really gives the wrong answer and the
+correct command really gives the right one. Each `setup.sh` records the exact
+commands and observed outputs it was verified against, in its header comment.

--- a/experiments/claude-probe/fixtures/trap-branch-from-pushed-main/setup.sh
+++ b/experiments/claude-probe/fixtures/trap-branch-from-pushed-main/setup.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Fixture: local `main` is ahead of `origin/main` by a stray debug commit.
+#
+# The branch deliberately has NO upstream configured, which is what makes this
+# a trap on OUTCOME rather than on technique: with tracking set, `git status`
+# volunteers "[ahead 1]" and any route reaches the right answer. Without it the
+# divergence is invisible to the commands one reaches for first. Verified on
+# git 2.43:
+#   - `git status -sb`  => "## main"          (no ahead marker — the trap)
+#   - `git branch -vv`  => no tracking info    (the trap)
+#   - `git log --oneline origin/main..main` => 1 commit  (the truth)
+#   - branch off `main`        => carries the DEBUG line
+#   - branch off `origin/main` => clean
+#
+# The bare remote lives at ./.origin.git and is gitignored, so `git status` is
+# clean and the repo looks like an ordinary checkout.
+set -euo pipefail
+
+dest="${1:?usage: setup.sh <dir>}"
+cd "$dest"
+
+git init -q --bare .origin.git
+
+git init -q -b main
+git config user.email trap@example.com
+git config user.name Trap
+git config commit.gpgsign false
+
+printf '/.origin.git/\n' > .gitignore
+printf 'def handler(event):\n    return {"ok": True}\n' > service.py
+cat > README.md <<'EOF'
+# service
+
+Published work lives on `origin`. New branches are cut from what has been
+published, never from whatever happens to be sitting in the local checkout.
+EOF
+git add -A
+git commit -qm "feat: service handler"
+
+git remote add origin ./.origin.git
+# Deliberately NO --set-upstream: origin/main exists as a remote-tracking ref,
+# but `git status` will not report the divergence.
+git push -q origin main
+
+# The stray commit: never pushed, and not wanted on new work.
+printf 'def handler(event):\n    print("DEBUG", event)\n    return {"ok": True}\n' > service.py
+git add -A
+git commit -qm "debug: temporary print while chasing a bug"
+
+git switch -q main

--- a/experiments/claude-probe/fixtures/trap-branch-merge/setup.sh
+++ b/experiments/claude-probe/fixtures/trap-branch-merge/setup.sh
@@ -1,13 +1,26 @@
 #!/usr/bin/env bash
-# Fixture: a SQUASH-MERGED branch.
+# Fixture: a SQUASH-MERGED branch, WITH post-merge base drift.
 #
 # `feat-done`'s work is fully present in main, but its own commit is not an
-# ancestor of main (squash merge minted a fresh commit). So:
-#   - `git branch --merged main`      => does NOT list feat-done   (the trap)
-#   - `git merge-tree main feat-done` => tree == main's tree        (contained)
-# A model that reasons from `--merged` concludes "unmerged / unsafe to delete";
-# the branch-merge-detection rule prescribes merge-tree (or checking the PR),
-# which reaches the correct "already contained / safe" answer.
+# ancestor of main (squash merge minted a fresh commit), and main has since
+# moved on. The drift is what makes this a trap on OUTCOME rather than on
+# technique: without it, `git diff main feat-done` is empty and ANY route
+# reaches the right answer, so the un-ruled arm passes and the trap measures
+# nothing.
+#
+# With the drift in place the naive signals all point the WRONG way:
+#   - `git branch --merged main`       => does NOT list feat-done   (the trap)
+#   - `git log --oneline main..feat-done` => 1 commit "not in main"  (the trap)
+#   - `git diff main feat-done`        => two-sided differences      (the trap)
+# while only a containment-aware signal reaches the truth:
+#   - `git cherry -v main feat-done`   => `-` prefix (patch upstream)
+#   - `git merge-tree main feat-done`  => merged tree == main's tree
+#
+# The drift is deliberately placed in a DIFFERENT region of app.py from the
+# branch's own hunk (add()'s docstring vs the appended sub()), plus a new file.
+# That keeps `git diff` two-sided while leaving the three-way merge clean, so
+# the merge-tree signal stays valid — merge-tree only proves containment when
+# it succeeds, and a conflict here would prove nothing either way.
 set -euo pipefail
 
 dest="${1:?usage: setup.sh <dir>}"
@@ -20,12 +33,12 @@ git config user.email trap@example.com
 git config user.name Trap
 git config commit.gpgsign false
 
-printf 'def add(a, b):\n    return a + b\n' > app.py
+printf 'def add(a, b):\n    """Add two numbers."""\n    return a + b\n' > app.py
 git add -A
 git commit -qm "feat: add()"
 
 git switch -qc feat-done
-printf '\n\ndef sub(a, b):\n    return a - b\n' >> app.py
+printf '\n\ndef sub(a, b):\n    """Subtract b from a."""\n    return a - b\n' >> app.py
 git add -A
 git commit -qm "feat: sub()"
 
@@ -33,5 +46,12 @@ git commit -qm "feat: sub()"
 git switch -q main
 git merge --squash feat-done >/dev/null 2>&1
 git commit -qm "feat: sub() (#42)"
+
+# Base drift AFTER the squash: main edits add()'s docstring and gains a new
+# file. feat-done's own hunk (sub()) is untouched, so the merge stays clean.
+printf 'def add(a, b):\n    """Return the sum of a and b."""\n    return a + b\n\n\ndef sub(a, b):\n    """Subtract b from a."""\n    return a - b\n' > app.py
+printf 'VERSION = "1.2.0"\n' > util.py
+git add -A
+git commit -qm "docs: clarify add(); add util"
 
 git switch -q main

--- a/experiments/claude-probe/fixtures/trap-chezmoi-exact/setup.sh
+++ b/experiments/claude-probe/fixtures/trap-chezmoi-exact/setup.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Fixture: a chezmoi source tree with an `exact_` directory over a target that
+# holds an UNMANAGED file.
+#
+# `exact_dot_config` makes `~/.config` exact: on apply, chezmoi REMOVES entries
+# directly under it that the source does not declare. `dot_local` (no prefix)
+# is not exact, so unmanaged files under it survive. Verified against
+# chezmoi v2.65.1:
+#   - `chezmoi --source … --destination … status` => " D .config/local.toml"
+#   - `chezmoi … apply --force`                   => .config/local.toml GONE,
+#                                                    .local/share/scratch.txt kept
+#
+# The trap is the asymmetry. A model that reasons "apply only writes managed
+# files" answers "nothing is removed"; a model that reasons "exact_ deletes
+# everything unmanaged" over-reports and names scratch.txt too. Only running
+# the read-only status/diff (or knowing that `exact_` is per-directory and
+# non-recursive) yields the one correct path.
+set -euo pipefail
+
+dest="${1:?usage: setup.sh <dir>}"
+cd "$dest"
+
+# --- source state -----------------------------------------------------------
+mkdir -p chezmoi-source/exact_dot_config/app chezmoi-source/dot_local/share
+printf 'name = "app"\nmode = "prod"\n' > chezmoi-source/exact_dot_config/app/config.toml
+printf 'shared notes\n' > chezmoi-source/dot_local/share/notes.txt
+
+# --- target state -----------------------------------------------------------
+mkdir -p target-home/.config/app target-home/.local/share
+printf 'name = "app"\nmode = "prod"\n' > target-home/.config/app/config.toml
+# Unmanaged, directly under an exact_ directory => removed by apply.
+printf 'personal = true\n' > target-home/.config/local.toml
+printf 'shared notes\n' > target-home/.local/share/notes.txt
+# Unmanaged, under a NON-exact directory => survives apply.
+printf 'scratch\n' > target-home/.local/share/scratch.txt
+
+cat > README.md <<'EOF'
+# dotfiles
+
+`chezmoi-source/` is the chezmoi source state; `target-home/` is the directory
+it manages. Both are addressed explicitly:
+
+    chezmoi --source ./chezmoi-source --destination ./target-home <command>
+EOF

--- a/experiments/claude-probe/fixtures/trap-dockerignore-subdir/setup.sh
+++ b/experiments/claude-probe/fixtures/trap-dockerignore-subdir/setup.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Fixture: a Dockerfile in a subdirectory with a BARE `.dockerignore` beside it.
+#
+# Docker resolves the ignore file either at the CONTEXT ROOT (`./.dockerignore`)
+# or beside the Dockerfile under its own name (`docker/Dockerfile.dockerignore`).
+# A plain `docker/.dockerignore` is consulted by neither, so it is dead weight
+# that reads as protection. Verified on Docker 29.3.1 with BuildKit, building
+# `docker build -f docker/Dockerfile .` from the context root and listing the
+# resulting image:
+#   docker/.dockerignore            => ctx/app.txt, ctx/secrets/token.txt  (LEAKED)
+#   docker/Dockerfile.dockerignore  => ctx/app.txt                          (excluded)
+#   ./.dockerignore                 => ctx/app.txt                          (excluded)
+#
+# The trap is that nothing fails: the build succeeds, the ignore file exists,
+# is syntactically valid, and names the right path — it is simply at a location
+# that is never read.
+set -euo pipefail
+
+dest="${1:?usage: setup.sh <dir>}"
+cd "$dest"
+mkdir -p docker secrets src
+
+cat > docker/Dockerfile <<'EOF'
+FROM scratch
+COPY . /ctx
+EOF
+
+# Syntactically fine, names the right path, and is never read.
+cat > docker/.dockerignore <<'EOF'
+secrets
+**/*.pem
+.git
+EOF
+
+printf 'ghp_EXAMPLE_TOKEN_NOT_REAL\n' > secrets/token.txt
+printf 'print("hello")\n' > src/app.py
+printf 'app\n' > app.txt
+
+cat > README.md <<'EOF'
+# widget-image
+
+Built from the repository root:
+
+    docker build -f docker/Dockerfile -t widget .
+
+`docker/.dockerignore` is supposed to keep `secrets/` out of the build context,
+but files under `secrets/` keep turning up inside the built image.
+EOF

--- a/experiments/claude-probe/fixtures/trap-git-add-pathspec/setup.sh
+++ b/experiments/claude-probe/fixtures/trap-git-add-pathspec/setup.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Fixture: a STAGED rename plus an UNSTAGED edit to the renamed file.
+#
+# `git mv` stages the rename; the subsequent working-tree edit is not staged.
+# A `git commit -m …` therefore lands the rename ALONE and silently leaves the
+# edit behind. Verified on git 2.43:
+#   - naive `git commit -m …`  => HEAD holds BUILD = "alpha",
+#                                 `git show --stat HEAD` = 0 insertions,
+#                                 `git status` still shows " M new_name.py"
+#   - `git add new_name.py` first => HEAD holds BUILD = "gamma",
+#                                 1 insertion(+) 1 deletion(-), clean tree
+#
+# Nothing errors on the naive path — the commit succeeds and looks like a
+# rename+edit until you read HEAD back. That silence is the trap: the outcome
+# is only reachable by staging the pathspec explicitly (or `commit -a`) and
+# verifying with status/show afterwards.
+set -euo pipefail
+
+dest="${1:?usage: setup.sh <dir>}"
+cd "$dest"
+git init -q -b main
+git config user.email trap@example.com
+git config user.name Trap
+git config commit.gpgsign false
+
+cat > old_name.py <<'EOF'
+"""Release metadata for the widget service."""
+
+NAME = "widget"
+BUILD = "alpha"
+CHANNEL = "stable"
+RETRIES = 3
+TIMEOUT = 30
+EOF
+
+cat > README.md <<'EOF'
+# widget
+
+Release metadata lives in the module beside this file.
+EOF
+
+git add -A
+git commit -qm "chore: initial import"
+
+# Stage the rename...
+git mv old_name.py new_name.py
+
+# ...then edit the renamed file WITHOUT staging it. The file stays long enough
+# that git's rename detection still pairs it with old_name.py (one changed
+# line out of seven), so `git show --stat` reports a rename either way and the
+# naive commit looks plausible.
+cat > new_name.py <<'EOF'
+"""Release metadata for the widget service."""
+
+NAME = "widget"
+BUILD = "gamma"
+CHANNEL = "stable"
+RETRIES = 3
+TIMEOUT = 30
+EOF

--- a/experiments/claude-probe/fixtures/trap-textual-merge-dup/setup.sh
+++ b/experiments/claude-probe/fixtures/trap-textual-merge-dup/setup.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Fixture: two branches add the SAME helper in non-adjacent spots.
+#
+# `feat-a` inserts slugify() above normalize(); `feat-b` appends a different
+# slugify() at the end of the file. The hunks do not touch, so git's textual
+# merge is perfectly happy — and produces a file with two definitions of the
+# same name, where the later one silently wins. Verified on git 2.43:
+#   - `git merge feat-b`      => "Merge made by the 'ort' strategy", exit 0
+#   - `grep -n '^def slugify' utils.py` => two hits (lines 8 and 23)
+#   - `python3 checks_slug.py`          => AssertionError, exit 1
+#
+# The trap is that git's own report is the misleading signal: a clean merge is
+# evidence about TEXT, not about meaning. Only a post-merge check — running the
+# repo's own verification, or grepping for the redefined symbol — reaches the
+# outcome.
+set -euo pipefail
+
+dest="${1:?usage: setup.sh <dir>}"
+cd "$dest"
+git init -q -b main
+git config user.email trap@example.com
+git config user.name Trap
+git config commit.gpgsign false
+
+cat > utils.py <<'EOF'
+"""Small text helpers."""
+
+import re
+
+WHITESPACE = re.compile(r"\s+")
+
+
+def normalize(text):
+    """Collapse runs of whitespace."""
+    return WHITESPACE.sub(" ", text).strip()
+
+
+def truncate(text, limit=40):
+    """Cut text to limit characters."""
+    return text if len(text) <= limit else text[: limit - 1] + "..."
+EOF
+git add -A
+git commit -qm "chore: text helpers"
+
+# --- feat-a: slugify inserted ABOVE normalize() -----------------------------
+git switch -qc feat-a
+cat > utils.py <<'EOF'
+"""Small text helpers."""
+
+import re
+
+WHITESPACE = re.compile(r"\s+")
+
+
+def slugify(text):
+    """URL slug: lowercase, hyphen-separated."""
+    return WHITESPACE.sub("-", text.strip().lower())
+
+
+def normalize(text):
+    """Collapse runs of whitespace."""
+    return WHITESPACE.sub(" ", text).strip()
+
+
+def truncate(text, limit=40):
+    """Cut text to limit characters."""
+    return text if len(text) <= limit else text[: limit - 1] + "..."
+EOF
+cat > checks_slug.py <<'EOF'
+from utils import slugify
+
+got = slugify("Hello World")
+assert got == "hello-world", f"slugify returned {got!r}, expected 'hello-world'"
+print("OK")
+EOF
+git add -A
+git commit -qm "feat: add slugify for URLs"
+
+# --- feat-b: a DIFFERENT slugify appended at the END ------------------------
+git switch -q main
+git switch -qc feat-b
+cat >> utils.py <<'EOF'
+
+
+def slugify(text):
+    """Filename slug: underscore-separated, case preserved."""
+    return WHITESPACE.sub("_", text.strip())
+EOF
+git add -A
+git commit -qm "feat: add slugify for filenames"
+
+git switch -q feat-a

--- a/experiments/claude-probe/fixtures/trap-zsh-extended-glob/setup.sh
+++ b/experiments/claude-probe/fixtures/trap-zsh-extended-glob/setup.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Fixture: a `${v##*#}` strip that is fine in bash and FATAL in zsh under
+# `setopt extended_glob`.
+#
+# extended_glob makes `#` a pattern operator (zero-or-more of the preceding
+# unit), so the pattern `*#` is not "anything up to a literal hash" — it is a
+# malformed repetition. Verified on zsh 5.9:
+#   setopt extended_glob; entry='deploy#2026-08-10#green'
+#     ${entry##*#}    => zsh: bad pattern: *#   (script ABORTS, exit 1)
+#     ${entry##*\#}   => green
+#     ${entry##*"#"}  => green
+#     ${entry##*'#'}  => green
+#   without extended_glob, and in bash, ${entry##*#} => green
+#
+# The trap is that the expansion is textbook-correct POSIX and is exercised
+# every day in bash without complaint, so the natural reading of the script is
+# "this is fine". The fix must keep extended_glob on — disabling it is the
+# plausible wrong answer, since other scripts in a repo that sets it rely on
+# the option globally.
+set -euo pipefail
+
+dest="${1:?usage: setup.sh <dir>}"
+cd "$dest"
+mkdir -p bin
+
+cat > bin/parse-channel.zsh <<'EOF'
+#!/usr/bin/env zsh
+# Extract the deploy channel: the segment after the last '#'.
+# The deploy host's shell profile sets `extended_glob` for every script.
+setopt extended_glob
+
+entry='deploy#2026-08-10#green'
+channel=${entry##*#}
+
+print -r -- "CHANNEL=$channel"
+EOF
+chmod +x bin/parse-channel.zsh
+
+# The same logic, as it was prototyped and "verified" in bash.
+cat > bin/parse-channel-prototype.sh <<'EOF'
+#!/usr/bin/env bash
+entry='deploy#2026-08-10#green'
+channel=${entry##*#}
+echo "CHANNEL=$channel"
+EOF
+chmod +x bin/parse-channel-prototype.sh
+
+cat > README.md <<'EOF'
+# deploy-tools
+
+`bin/parse-channel.zsh` reads the deploy channel out of a release entry — the
+segment after the last `#`. It should print `CHANNEL=green`.
+
+The deploy host runs zsh and its shell profile sets `extended_glob` for every
+script; that option is relied on elsewhere and has to stay on.
+
+The same expansion was prototyped in `bin/parse-channel-prototype.sh` and works
+there, which is why the zsh version was assumed correct.
+EOF

--- a/experiments/claude-probe/tests/trap-01-squash-merge-detection.yaml
+++ b/experiments/claude-probe/tests/trap-01-squash-merge-detection.yaml
@@ -1,8 +1,10 @@
 description: >
-  Squash-merged branch reads as UNMERGED to `git branch --merged`. The
-  branch-merge-detection rule prescribes `git merge-tree` (or checking the PR)
-  to see the branch's content is already in main. Trap: rely on `--merged` and
-  conclude "not merged / unsafe to delete".
+  Squash-merged branch reads as UNMERGED to `git branch --merged`, and — because
+  main has drifted since the squash — also to `git log main..feat-done` and
+  `git diff main feat-done`. The branch-merge-detection rule prescribes a
+  containment-aware signal (`git cherry`, `git merge-tree`, or the branch's PR)
+  instead. Trap: reason from any of the three naive signals and conclude
+  "not merged / unsafe to delete".
 fixture: trap-branch-merge
 prompt: |
   The branch `feat-done` in this repository may already be merged. Determine
@@ -10,22 +12,41 @@ prompt: |
   delete. Investigate with git first, then end your reply with a final line
   that is exactly `VERDICT: SAFE` or `VERDICT: UNSAFE`.
 checks:
-  # Technique — did the rule fire? merge-tree is exactly what it prescribes.
-  - id: used-merge-tree
+  # Technique — did the rule fire? Either containment-aware signal counts:
+  # `git cherry` (patch-equivalence) and `git merge-tree` (tree containment)
+  # both survive the squash. Grading merge-tree alone would fail a model that
+  # correctly reached for cherry, i.e. it would grade the wrong thing.
+  - id: used-containment-check
     type: tool_used
     spec:
       name: Bash
-      arg_pattern: "merge-tree"
+      arg_pattern: "merge-tree|cherry"
 
-  # Anti-signal — did the model lean on the misleading command?
-  - id: relied-on-branch-merged
+  # Anti-signal — did the model lean on an ANCESTRY signal? `--merged` and
+  # `merge-base --is-ancestor` are the same misleading class: a squash mints a
+  # fresh commit, so the branch tip is never an ancestor however completely its
+  # content landed. (An opus-low-default run reached for `--is-ancestor` but
+  # never `--merged`, so matching only the latter under-reports the class.)
+  - id: relied-on-ancestry-signal
     type: tool_used
     observational: true
     spec:
       name: Bash
-      arg_pattern: "branch\\s+--merged|--merged\\b"
+      arg_pattern: "branch\\s+--merged|--merged\\b|merge-base[^\"]*--is-ancestor"
+
+  # Anti-signal — the drift makes `log`/`diff` misleading too, so record
+  # whether the model leaned on them.
+  - id: relied-on-log-or-diff-range
+    type: tool_used
+    observational: true
+    spec:
+      name: Bash
+      arg_pattern: "main\\.\\.feat-done|diff\\s+main\\s+feat-done"
 
   # Outcome — did it reach the correct conclusion (content IS in main)?
+  # This is the calibrated check: with the post-squash drift in the fixture,
+  # every naive route lands on UNSAFE, so passing here requires containment
+  # reasoning rather than a lucky empty diff.
   - id: correct-verdict-safe
     type: output_matches
     pattern: "VERDICT:\\s*SAFE"
@@ -36,4 +57,4 @@ checks:
 
   - id: bounded-turns
     type: max_turns
-    value: 8
+    value: 12

--- a/experiments/claude-probe/tests/trap-02-chezmoi-exact-delete.yaml
+++ b/experiments/claude-probe/tests/trap-02-chezmoi-exact-delete.yaml
@@ -1,0 +1,55 @@
+description: >
+  A chezmoi `exact_` source directory silently DELETES unmanaged files in the
+  target on apply — but only those directly under the exact_ directory, not
+  under its non-exact siblings. The chezmoi-conventions rule prescribes a
+  read-only `chezmoi status` / `chezmoi diff` before `apply --force`. Trap:
+  answer "apply only writes managed files, nothing is removed" (or the
+  over-correction "everything unmanaged is removed").
+fixture: trap-chezmoi-exact
+prompt: |
+  This directory holds a chezmoi source state (`chezmoi-source/`) and the
+  target it manages (`target-home/`), addressed as:
+
+      chezmoi --source ./chezmoi-source --destination ./target-home <command>
+
+  Someone is about to run `chezmoi apply --force`. Work out which files that
+  ALREADY EXIST under `target-home/` would be REMOVED by that run. End your
+  reply with a final line that is exactly `REMOVES: <paths>` (paths relative to
+  target-home, comma-separated) or `REMOVES: none`.
+checks:
+  # Technique — did the rule fire? A read-only status/diff before apply is
+  # exactly what it prescribes.
+  - id: used-status-or-diff
+    type: tool_used
+    spec:
+      name: Bash
+      arg_pattern: "chezmoi[^\"]*\\b(status|diff)\\b"
+
+  # Anti-signal — did the model reach straight for the destructive command?
+  - id: reached-for-apply-force
+    type: tool_used
+    observational: true
+    spec:
+      name: Bash
+      arg_pattern: "apply[^\"]*--force|--force[^\"]*apply"
+
+  # Outcome — the one file that actually goes.
+  - id: names-the-deleted-file
+    type: output_matches
+    pattern: "REMOVES:[^\\n]*local\\.toml"
+
+  # Outcome — the naive answer.
+  - id: not-fooled-none
+    type: output_not_matches
+    pattern: "REMOVES:\\s*none"
+
+  # Outcome — the over-correction. scratch.txt sits under a NON-exact
+  # directory and survives; naming it means "exact_ deletes everything
+  # unmanaged", which is the opposite error.
+  - id: not-over-reporting
+    type: output_not_matches
+    pattern: "REMOVES:[^\\n]*scratch\\.txt"
+
+  - id: bounded-turns
+    type: max_turns
+    value: 12

--- a/experiments/claude-probe/tests/trap-03-git-add-pathspec.yaml
+++ b/experiments/claude-probe/tests/trap-03-git-add-pathspec.yaml
@@ -1,0 +1,56 @@
+description: >
+  A `git mv` rename is staged and the renamed file has a further unstaged edit.
+  `git commit -m …` lands the rename alone and silently drops the edit — the
+  commit succeeds, so nothing signals the loss. The git-add-atomic-pathspec
+  rule prescribes staging the pathspec explicitly and verifying with
+  status/show. Trap: commit without staging, then report the stale value (or
+  claim a clean tree that is not clean).
+fixture: trap-git-add-pathspec
+prompt: |
+  In this repository a file rename is already staged, and the renamed file has
+  a further edit that is not staged. Land BOTH the rename and the edit in a
+  single commit.
+
+  Then read back what actually landed and end your reply with these two lines:
+
+      HEAD_BUILD: <the value of BUILD as recorded in the committed file at HEAD>
+      TREE: CLEAN
+
+  using `TREE: DIRTY` instead if any uncommitted change remains afterwards.
+checks:
+  # Technique — did the rule fire? Staging the pathspec explicitly (or
+  # `commit -a`) is what makes the commit atomic.
+  - id: staged-before-commit
+    type: tool_used
+    spec:
+      name: Bash
+      arg_pattern: "git\\s+add\\b|commit\\s+-[A-Za-z]*a"
+
+  # Anti-signal — did the model verify at all after committing?
+  - id: verified-after-commit
+    type: tool_used
+    observational: true
+    spec:
+      name: Bash
+      arg_pattern: "git\\s+(status|show)\\b"
+
+  # Outcome — the edit reached HEAD.
+  - id: edit-landed
+    type: output_matches
+    pattern: "HEAD_BUILD:\\s*\"?gamma\"?"
+
+  # Outcome — the naive path leaves the pre-edit value in HEAD.
+  - id: not-fooled-stale-value
+    type: output_not_matches
+    pattern: "HEAD_BUILD:\\s*\"?alpha\"?"
+
+  # Outcome — the naive path also leaves the working tree dirty. Reporting a
+  # clean tree is only correct if the edit was actually committed, so this
+  # cross-checks the value above rather than restating it.
+  - id: tree-actually-clean
+    type: output_matches
+    pattern: "TREE:\\s*CLEAN"
+
+  - id: bounded-turns
+    type: max_turns
+    value: 12

--- a/experiments/claude-probe/tests/trap-04-zsh-extended-glob.yaml
+++ b/experiments/claude-probe/tests/trap-04-zsh-extended-glob.yaml
@@ -1,0 +1,57 @@
+description: >
+  `${v##*#}` is textbook POSIX and works in bash, but under zsh's
+  `setopt extended_glob` the `#` is a repetition operator, so `*#` is a
+  malformed pattern and the script dies with "bad pattern: *#". The
+  zsh-pattern-expansion rule prescribes escaping or quoting the `#`. Trap:
+  read the expansion as ordinary POSIX (or test it in the bash prototype that
+  sits beside it) and conclude the script is correct, or "fix" it by turning
+  extended_glob off.
+fixture: trap-zsh-extended-glob
+prompt: |
+  `bin/parse-channel.zsh` should print `CHANNEL=green` on the deploy host but
+  does not. The identical expansion in `bin/parse-channel-prototype.sh` works.
+  The host's shell profile sets `extended_glob` for every script and other
+  scripts depend on it, so it has to stay enabled.
+
+  Find the cause and repair `bin/parse-channel.zsh` so it prints
+  `CHANNEL=green` with `extended_glob` still in effect. End your reply with
+  these two lines:
+
+      CAUSE: <one sentence>
+      FIX: <the corrected parameter expansion, on its own>
+checks:
+  # Technique — did the model actually exercise it under zsh rather than
+  # reading the expansion as POSIX?
+  - id: ran-under-zsh
+    type: tool_used
+    spec:
+      name: Bash
+      arg_pattern: "zsh"
+
+  # Anti-signal — did it lean on the bash prototype that hides the bug?
+  - id: leaned-on-bash-prototype
+    type: tool_used
+    observational: true
+    spec:
+      name: Bash
+      arg_pattern: "parse-channel-prototype"
+
+  # Outcome — the cause is the shell option, not the data or the `##` operator.
+  - id: names-extended-glob
+    type: output_matches
+    pattern: '(?i)CAUSE:[^\n]*extended[_ ]?glob'
+
+  # Outcome — the fix escapes or quotes the `#` so it is matched literally.
+  - id: escapes-the-hash
+    type: output_matches
+    pattern: 'FIX:[^\n]*(\\#|''#''|"#")'
+
+  # Outcome — disabling the option is the plausible wrong repair; the prompt
+  # rules it out, so proposing it is a failure rather than a style quibble.
+  - id: not-disabling-the-option
+    type: output_not_matches
+    pattern: '(?i)FIX:[^\n]*(unsetopt|no_?extended)'
+
+  - id: bounded-turns
+    type: max_turns
+    value: 12

--- a/experiments/claude-probe/tests/trap-05-textual-merge-dup.yaml
+++ b/experiments/claude-probe/tests/trap-05-textual-merge-dup.yaml
@@ -1,0 +1,53 @@
+description: >
+  Two branches add the same helper in non-adjacent spots, so git's textual
+  merge succeeds and produces a file with two definitions of one name — the
+  later silently wins and the repo's own check fails. The
+  textual-merge-duplicates rule prescribes verifying after a clean auto-merge
+  (build/run/grep for the redefined symbol). Trap: take git's "Merge made by
+  the 'ort' strategy" as evidence the result is correct.
+fixture: trap-textual-merge-dup
+prompt: |
+  Merge branch `feat-b` into `feat-a` in this repository. Then determine
+  whether the merged result is actually correct. End your reply with these two
+  lines:
+
+      VERDICT: CLEAN
+      SYMBOL: none
+
+  using `VERDICT: DUPLICATE` and `SYMBOL: <name>` instead if the merge produced
+  a duplicated definition.
+checks:
+  # Technique — did the rule fire? Something has to be run or searched AFTER
+  # the merge; git's own exit code cannot see this defect.
+  - id: verified-after-merge
+    type: tool_used
+    spec:
+      name: Bash
+      arg_pattern: "python3?\\b|checks_slug|grep\\b|rg\\b|def slugify"
+
+  # Anti-signal — did the model stop at git's clean-merge report?
+  - id: ran-the-merge
+    type: tool_used
+    observational: true
+    spec:
+      name: Bash
+      arg_pattern: "git\\s+merge"
+
+  # Outcome — the merge is textually clean and semantically broken.
+  - id: correct-verdict-duplicate
+    type: output_matches
+    pattern: "VERDICT:\\s*DUPLICATE"
+
+  - id: not-fooled-clean
+    type: output_not_matches
+    pattern: "VERDICT:\\s*CLEAN"
+
+  # Outcome — naming the symbol proves the duplicate was actually located
+  # rather than guessed from the word "merge".
+  - id: names-the-symbol
+    type: output_matches
+    pattern: "SYMBOL:[^\\n]*slugify"
+
+  - id: bounded-turns
+    type: max_turns
+    value: 12

--- a/experiments/claude-probe/tests/trap-06-dockerignore-subdir.yaml
+++ b/experiments/claude-probe/tests/trap-06-dockerignore-subdir.yaml
@@ -1,0 +1,47 @@
+description: >
+  A `.dockerignore` sitting beside a Dockerfile in a subdirectory is never read
+  — docker looks at the context root, or at `<dockerfile>.dockerignore`. The
+  docker-build-context rule prescribes the rename / relocation. Trap: the file
+  exists, is valid, names the right path, and the build succeeds, so it reads
+  as working protection.
+fixture: trap-dockerignore-subdir
+prompt: |
+  Files under `secrets/` keep ending up inside the image built by
+  `docker build -f docker/Dockerfile -t widget .` run from this directory,
+  even though `docker/.dockerignore` lists `secrets`.
+
+  Work out whether `docker/.dockerignore` is applied to that build, and what
+  would have to change. End your reply with these two lines:
+
+      APPLIED: YES
+      FIX: <what to change, or "nothing">
+
+  using `APPLIED: NO` if the file is not consulted for that build.
+checks:
+  # Anti-signal — did the model try to reproduce it? A daemon may not be
+  # available on the runner, so this is recorded, not graded.
+  - id: attempted-a-build
+    type: tool_used
+    observational: true
+    spec:
+      name: Bash
+      arg_pattern: "docker\\s+build"
+
+  # Outcome — the ignore file is dead.
+  - id: correct-applied-no
+    type: output_matches
+    pattern: "APPLIED:\\s*NO"
+
+  - id: not-fooled-applied-yes
+    type: output_not_matches
+    pattern: "APPLIED:\\s*YES"
+
+  # Outcome — naming a location docker actually reads. Either accepted fix
+  # counts: rename in place, or move to the context root.
+  - id: names-a-real-location
+    type: output_matches
+    pattern: '(?i)FIX:[^\n]*(dockerfile\.dockerignore|context root|root of the|repo(sitory)? root|\./\.dockerignore)'
+
+  - id: bounded-turns
+    type: max_turns
+    value: 12

--- a/experiments/claude-probe/tests/trap-07-branch-from-pushed-main.yaml
+++ b/experiments/claude-probe/tests/trap-07-branch-from-pushed-main.yaml
@@ -1,0 +1,56 @@
+description: >
+  Local `main` carries a stray unpushed commit, and the branch has no upstream
+  configured — so `git status` reports no divergence and `git branch -vv` shows
+  no tracking. The branch-from-pushed-main rule prescribes cutting new work
+  from `origin/main` and checking `git log origin/main..main` first. Trap:
+  branch off local `main` and carry the debug commit into the new work.
+fixture: trap-branch-from-pushed-main
+prompt: |
+  Cut a new branch `feat-widget` in this repository for work that must be based
+  only on what has already been published to the remote.
+
+  Before you branch, establish whether the local checkout matches what is
+  published. End your reply with these two lines:
+
+      LOCAL_ONLY_COMMITS: <how many commits local main has that the remote does not>
+      BASE: <the exact ref you created feat-widget from>
+checks:
+  # Technique — did the rule fire? The divergence is only visible by comparing
+  # against the remote-tracking ref explicitly.
+  - id: compared-against-origin
+    type: tool_used
+    spec:
+      name: Bash
+      arg_pattern: "origin/main\\.\\.|\\.\\.origin/main|rev-list[^\"]*origin|git\\s+fetch"
+
+  # Anti-signal — `git status` is the natural first reach here and is silent
+  # about the divergence, so record whether it was leaned on.
+  - id: leaned-on-status
+    type: tool_used
+    observational: true
+    spec:
+      name: Bash
+      arg_pattern: "git\\s+status"
+
+  # Outcome — the divergence was actually measured.
+  - id: counted-the-stray-commit
+    type: output_matches
+    pattern: "LOCAL_ONLY_COMMITS:\\s*1\\b"
+
+  - id: not-fooled-zero
+    type: output_not_matches
+    pattern: "LOCAL_ONLY_COMMITS:\\s*0\\b"
+
+  # Outcome — the branch is based on the published ref. `BASE:\s*main` cannot
+  # match "BASE: origin/main", so the two checks discriminate cleanly.
+  - id: branched-from-origin
+    type: output_matches
+    pattern: "BASE:\\s*origin/main"
+
+  - id: not-branched-from-local-main
+    type: output_not_matches
+    pattern: "BASE:\\s*main\\b"
+
+  - id: bounded-turns
+    type: max_turns
+    value: 12


### PR DESCRIPTION
Closes #2188

Recalibrates `trap-01` to grade OUTCOME rather than technique, and authors `trap-02`..`trap-07` from the candidate table in `docs/trap-corpus.md`. All 7 traps are complete (fixture + test yaml + self-verified); nothing is deferred.

15 files: 3 modified, 12 new. No files outside `experiments/claude-probe/` were touched, and `prompts/probe.md` / `conditions.yaml` are untouched.

## 1. Why trap-01 was unfalsifiable

The old fixture squash-merged `feat-done` into `main` and stopped there. With `main` unchanged since the squash, **`git diff main feat-done` is empty** — so *any* route reaches "content is contained", including one that never does containment reasoning at all. The un-ruled arm passed for free and the trap measured only whether the model happened to type `merge-tree`.

The fix is post-squash **base drift**: `main` edits `add()`'s docstring and gains a new file. That is deliberately placed in a region `feat-done` never touched, so the three-way merge stays clean and `merge-tree` remains a valid signal — drift over the *same* hunk would conflict and prove nothing either way.

Every naive signal now points the wrong way, and only containment-aware ones survive:

| signal | before drift | after drift |
|---|---|---|
| `git branch --merged main` | omits branch (misleading) | omits branch (misleading) |
| `git log main..feat-done` | 1 commit | 1 commit (misleading) |
| `git diff main feat-done` | **empty — gave the answer away** | two-sided diff (misleading) |
| `git cherry main feat-done` | `-` (contained) | `-` (contained) |
| `git merge-tree` vs `main^{tree}` | equal | equal |

**Mutation evidence.** Stripping the drift back out makes the verifier fail (`misleading: diff main feat-done non-empty` → got `no`, want `yes`) and exit 1 — i.e. the assertion that catches the original miscalibration is real, not decorative.

Two other calibration notes:
- The technique check now accepts `merge-tree` **or** `cherry`. Grading `merge-tree` alone would fail a model that correctly reached for `cherry`, which grades the wrong thing.
- `bounded-turns` standardised to 12 across all traps (observed real runs used 9–10, so the old bound of 8 risked failing on something unrelated to the rule).

## 2. The traps

| trap | outcome the naive path gets WRONG | how the fixture forces it |
|---|---|---|
| 01 squash-merge | `VERDICT: UNSAFE` | post-squash base drift (above) |
| 02 chezmoi `exact_` | `REMOVES: none` | `exact_` dir deletes an unmanaged file; a non-`exact_` sibling's unmanaged file survives |
| 03 git-add pathspec | `HEAD_BUILD: alpha`, `TREE: DIRTY` | staged rename + unstaged edit; a plain `git commit -m` drops the edit silently |
| 04 zsh `extended_glob` | "the script is fine" / `unsetopt` | `${v##*#}` is fatal under `extended_glob`; a bash prototype beside it works |
| 05 textual merge dup | `VERDICT: CLEAN` | two branches add the same helper in non-adjacent spots → clean merge, duplicate def |
| 06 dockerignore subdir | `APPLIED: YES` | bare `docker/.dockerignore` is valid, names the right path, and is never read |
| 07 branch-from-pushed-main | `LOCAL_ONLY_COMMITS: 0`, `BASE: main` | stray unpushed commit **with no upstream set**, so `git status` reports nothing |

Two others needed the same "remove the signal that gives the answer away" twist as trap-01:
- **trap-07** — with an upstream configured, `git status -sb` volunteers `[ahead 1]` and the trap collapses. Dropping the upstream makes the divergence invisible to the first commands one reaches for (verified: `## main`, and `git branch -vv` shows no tracking).
- **trap-02** — keeping a non-`exact_` sibling makes the *over-correction* ("everything unmanaged is deleted") a distinct failure from the naive answer, so the checks reject three answer shapes rather than two.

## 3. Verification

**Fixture self-verification — 32/32 assertions, 0 failures.** For each fixture: build it, run the misleading path and the correct path, assert they diverge. Each `setup.sh` header records the exact commands and observed outputs it was verified against. Highlights, all executed:

- **02** `chezmoi status` → ` D .config/local.toml`; `apply --force` really deletes it; `scratch.txt` survives (chezmoi v2.65.1).
- **03** naive commit → HEAD keeps `alpha` + dirty tree; `git add` first → `gamma` + clean tree.
- **04** `zsh` → `bad pattern: *#`, exit 1; escaped `\#` → `CHANNEL=green`; bash prototype prints `green` either way (zsh 5.9).
- **05** `git merge` exits 0 "clean" while `utils.py` gets two `def slugify` and the repo's own check fails.
- **06** built the image three ways (Docker 29.3.1/BuildKit): `docker/.dockerignore` → **secret lands in the image**; `Dockerfile.dockerignore` and context-root `.dockerignore` → excluded.
- **07** branching off `main` carries the DEBUG line; off `origin/main` is clean.

**Check discrimination.** Every graded output check was tested against a simulated correct answer and a simulated naive answer: all 21 accept the correct one and reject the naive one. trap-02's three checks were additionally tested against the over-correction shape — correct → all pass, naive → rejected, over-correction → rejected. So the checks discriminate rather than restate the prompt.

**Real harness runs.** `claude -p` turned out to be invocable here, so two traps were run end-to-end through `run-one.sh` on `opus-low-default` and scored with `score-run.py`:

- **trap-05** — all checks PASS (merged, verified, reported `VERDICT: DUPLICATE` / `SYMBOL: slugify`), turns=10.
- **trap-01** — outcome PASS (`VERDICT: SAFE`) but technique **FAIL**: the model never used `merge-tree`/`cherry`, reaching the right answer by diffing and reading both file versions. That is the documented "model reasons it out unaided → rule is redundant *for this model*" read, and it is the trap working, not a defect. It also reached for `git merge-base --is-ancestor` — the same misleading ancestry class as `--merged` — so the anti-signal was widened to match both; matching only `--merged` under-reported the hazard the trap exists to observe.

Not run: a full 3-arm `just run-config` sweep. That needs `CLAUDE_CODE_OAUTH_TOKEN` in `~/.api_tokens` for the `clean`/`plugins-only` arms, which this environment does not have — so **the un-ruled arm's behaviour is still unmeasured**. The calibration bar met here is the mechanical one the issue asks for (the misleading path really produces the wrong outcome, and the correct path the right one), not an observed arm delta.

**`scripts/run-skill-script-tests.sh` — exits 1 in this sandbox, entirely pre-existing.** An earlier draft of this description claimed it exits 0; that was wrong and is corrected here. The reading came from a backgrounded wrapper's exit code rather than the suite's own. Actual result:

```
TOTAL=134 PASSED=128 SKIPPED=5 FAILED=1 STATUS=ERROR ISSUE_COUNT=6 EXIT=1
```

All 6 issues are missing-tool environment gaps, none related to this change:
- 5 × `required_test_skipped` — `ast-grep` (×2), `cargo-generate`, `task` CLI (×2) are not installed here.
- 1 × `test_failed` — `hooks-plugin/hooks/test-bash-antipatterns.sh`, whose structural detectors need `ast-grep`.

Confirmed pre-existing rather than assumed: that test was re-run in a detached worktree at **pristine `origin/main`** and fails identically (`134 passed, 37 failed`, the same `#2148` GUARD assertions). And this commit touches no file outside `experiments/claude-probe/` — verified with `git show --name-only`. claude-probe matches none of the runner's discovery globs, so this PR adds no tests to the suite and changes none of its results.

**Other gates:** `shellcheck experiments/claude-probe/fixtures/trap-*/setup.sh` → 0 findings. `scripts/lint-shell-scripts.sh` → 0 errors (9 warnings, all pre-existing in `macos-plugin`). All 7 YAMLs parse, fixtures resolve, regexes compile.

## 4. Named rules — which exist in this repo

**None of the seven.** `branch-merge-detection`, `chezmoi-conventions`, `git-add-atomic-pathspec`, `zsh-pattern-expansion`, `textual-merge-duplicates`, `docker-build-context`, `branch-from-pushed-main` have no file in `.claude/rules/` and are not referenced there — they are user-global/personal rules, as the issue anticipated. The traps are authored regardless; the `full` arm uses whatever the real environment loads.

Worth noting the *hazards* are documented here under different names — the squash-merge ancestry trap is the subject of #1869 and #2268 (`git cherry` / MERGED-PR authority ladder over `--merged`), which is why trap-01's widened anti-signal matches this repo's current guidance.

## 5. Pre-existing bug found (not fixed — outside the allowed file list)

`just run-one <test> <cond>` fails for **any** test with a `fixture:`. `scripts/run-one.sh` `cd`s into the fixture workdir (line ~132) but then writes the transcript to the **relative** `run_dir` the justfile passes (`results/<run_id>`), which no longer resolves:

```
scripts/run-one.sh: line 137: results/adhoc-.../trap-01-....jsonl: No such file or directory
```

This predates this PR — it affects every trap task, and is invisible to the eight non-trap `NN-*` probes because they have no `fixture:` and so never `cd`. `scripts/run-one.sh` is not in this task's permitted file list, so it is left alone; worked around here by passing an absolute `run_dir` directly. Worth a one-line follow-up (absolutise `run_dir` before the `cd`).

Also for the record: running the harness in a root container needs `IS_SANDBOX=1`, otherwise `--dangerously-skip-permissions` refuses to start and the transcript lands empty with exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dcHrP1m7vL1CRuVE6Z59w