### PR TITLE
fix(session-plugin): session-end-nudge uses the collector's scope ladder

### DIFF
--- a/session-plugin/hooks/session-end-nudge.sh
+++ b/session-plugin/hooks/session-end-nudge.sh
@@ -62,22 +62,41 @@ user_turns=${user_turns:-0}
 [ "$user_turns" -lt 6 ] && exit 0
 
 # Something to capture into: taskwarrior (wrap destination) or a distillable
-# surface in the repo (distill target). Resolve the repo root via git so
-# worktrees match their parent repo's surface. SESSION_NUDGE_TASK_BIN is a
-# test seam — point it at a nonexistent path to simulate "no taskwarrior".
+# surface in the repo (distill target). SESSION_NUDGE_TASK_BIN is a test
+# seam — point it at a nonexistent path to simulate "no taskwarrior".
+#
+# Taskwarrior availability delegates open-task detection to the shared
+# collector's --summary mode (scripts/session-survey.sh) — the same
+# project-scope ladder session-spinup-nudge.sh already uses (exact slug →
+# git-remote-resolved project → ancestor slug → all-projects fallback, with
+# confidence and prefix-sibling guards). A raw `task project:$(basename $cwd)`
+# query both under-counts (never fires when basename≠slug) and over-counts
+# (taskwarrior's own CLI `project:` filter is a PREFIX match, so
+# `project:comfyui` also sweeps in `comfyui-nodes` tasks) — the collector's
+# hierarchy-aware jq scoping avoids both (#2359).
 task_bin="${SESSION_NUDGE_TASK_BIN:-task}"
 has_surface=0
 has_open_tasks=0
 if command -v "$task_bin" >/dev/null 2>&1; then
     has_surface=1
-    # Read-only query for open/active tasks in the current project.
-    # Uses 'export' (not 'list') so it exits 0 on empty — parallel-safe.
-    if [ -n "$cwd" ]; then
-        repo_root_tw=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || echo "$cwd")
-        proj=$(basename "$repo_root_tw")
-        task_count=$("$task_bin" project:"$proj" '(status:pending or +ACTIVE)' export 2>/dev/null \
-            | jq 'length' 2>/dev/null || echo 0)
-        [ "${task_count:-0}" -gt 0 ] && has_open_tasks=1
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    collector="$script_dir/../scripts/session-survey.sh"
+    if [ -f "$collector" ]; then
+        summary=$(SESSION_SURVEY_TASK_BIN="$task_bin" \
+                  bash "$collector" --summary --project-dir "$cwd" 2>/dev/null || echo "")
+        get() { printf '%s\n' "$summary" | grep -m1 "^$1=" | cut -d= -f2- || echo ""; }
+        open_tasks=$(get OPEN_TASKS)
+        recent_tasks=$(get RECENT_TASK_COUNT)
+        task_scope=$(get TASK_SCOPE)
+        project_confidence=$(get PROJECT_CONFIDENCE)
+        if [ "${open_tasks:-0}" -gt 0 ] 2>/dev/null || [ "${recent_tasks:-0}" -gt 0 ] 2>/dev/null; then
+            has_open_tasks=1
+        elif [ "$task_scope" != "none" ] && [ "$project_confidence" = "low" ]; then
+            # A low-confidence zero is an unqueried project, never a clean
+            # queue (session-end/SKILL.md, session-spinup/SKILL.md Step 1c) —
+            # suppress the CONCLUSION that nothing's open, not the cue.
+            has_open_tasks=1
+        fi
     fi
 elif [ -n "$cwd" ] && [ -d "$cwd" ]; then
     repo_root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || echo "$cwd")
@@ -100,7 +119,7 @@ touch "$state_file"
 
 task_cue=""
 if [ "$has_open_tasks" = 1 ]; then
-    task_cue=" Also mention a taskwarrior state-sync pass: check which tasks are still open or active (task project:<name> '(status:pending or +ACTIVE)' export | jq '.[]'), offer to mark done / update statuses / add follow-up tasks — use stable UUIDs from 'task +LATEST uuids' when referencing specific tasks."
+    task_cue=" Also mention that a taskwarrior state-sync pass looks worth offering."
 fi
 
 reason="The user is winding down the session. Briefly offer to run the session-plugin:session-end orchestrator — it surveys the session once, previews which end-of-session passes qualify (session-wrap loose-thread capture, session-distill durable learnings, /feedback:session plugin feedback) and runs only what the user confirms in a single prompt.${task_cue} Offer only — never run it without explicit user confirmation. If nothing follow-up-worthy surfaced this session, acknowledge the wind-down and end."

--- a/session-plugin/hooks/test-session-end-nudge.sh
+++ b/session-plugin/hooks/test-session-end-nudge.sh
@@ -197,13 +197,18 @@ run_hook_with_task_bin() {
           bash "$HOOK" 2>/dev/null || true
 }
 
-# Create a mock task binary that returns a non-empty task list when queried.
+# Positive control: a genuine wind-down in a repo whose taskwarrior project
+# slug matches the cwd basename exactly (TASK_SCOPE=project,
+# PROJECT_CONFIDENCE=high) with a real open task. Every regression case below
+# is paired against this control.
 MOCK_TASK_DIR=$(mktemp -d) || { echo "mktemp -d failed" >&2; exit 1; }
-cat > "$MOCK_TASK_DIR/task" <<'MOCK'
+REPO_WITH_RULES_BASENAME=$(basename "$REPO_WITH_RULES")
+cat > "$MOCK_TASK_DIR/task" <<MOCK
 #!/bin/sh
-# Minimal task stub: 'export' returns one pending task; all other calls are no-ops.
-case "$*" in
-  *export*) printf '[{"id":1,"description":"open task","status":"pending","uuid":"00000000-0000-0000-0000-000000000001"}]\n' ;;
+# Minimal task stub: 'export' returns one pending task scoped to the repo's
+# own basename (a confident direct match); all other calls are no-ops.
+case "\$*" in
+  *export*) printf '[{"id":1,"description":"open task","status":"pending","uuid":"00000000-0000-0000-0000-000000000001","project":"$REPO_WITH_RULES_BASENAME"}]\n' ;;
   *) exit 0 ;;
 esac
 MOCK
@@ -211,10 +216,9 @@ chmod +x "$MOCK_TASK_DIR/task"
 
 TRANSCRIPT=$(make_transcript 10 "im done for now")
 output=$(run_hook_with_task_bin "$MOCK_TASK_DIR/task" "sess-tw-tasks" "$REPO_WITH_RULES" "$TRANSCRIPT")
-assert_contains "open tasks → reason mentions taskwarrior sync cue" 'taskwarrior' "$output"
-assert_contains "open tasks → reason still references session-plugin:session-end" 'session-plugin:session-end' "$output"
-assert_contains "open tasks → reason still instructs offer-only" 'never run it without explicit user confirmation' "$output"
-assert_contains "open tasks → reason mentions stable UUID pattern" 'task +LATEST uuids' "$output"
+assert_contains "positive control: open tasks → reason mentions taskwarrior sync cue" 'taskwarrior' "$output"
+assert_contains "positive control: reason still references session-plugin:session-end" 'session-plugin:session-end' "$output"
+assert_contains "positive control: reason still instructs offer-only" 'never run it without explicit user confirmation' "$output"
 
 # When the task stub returns an empty list, the sync cue must NOT appear.
 MOCK_TASK_EMPTY_DIR=$(mktemp -d) || { echo "mktemp -d failed" >&2; exit 1; }
@@ -232,14 +236,120 @@ chmod +x "$MOCK_TASK_EMPTY_DIR/task"
 output=$(run_hook_with_task_bin "$MOCK_TASK_EMPTY_DIR/task" "sess-tw-empty" "$REPO_WITH_RULES" "$TRANSCRIPT")
 # Hook must still fire (tasks stub means taskwarrior is "present" → has_surface=1)
 assert_contains "empty task list → hook still fires" '"decision":"block"' "$output"
-# But the taskwarrior sync cue text must not appear in the reason
-if echo "$output" | grep -q 'task +LATEST uuids'; then
-    printf "  FAIL: empty task list should NOT include UUID sync cue\n"; FAIL=$((FAIL + 1))
+# A confidently-empty store (TASK_SCOPE=project, PROJECT_CONFIDENCE=high, no
+# tasks anywhere) must not include the taskwarrior sync cue at all — the
+# counter-control proving the low-confidence handling below doesn't fire
+# unconditionally.
+if echo "$output" | grep -q 'taskwarrior'; then
+    printf "  FAIL: confidently-empty store should NOT include the taskwarrior sync cue\n"; FAIL=$((FAIL + 1))
 else
-    printf "  PASS: empty task list does NOT include UUID sync cue\n"; PASS=$((PASS + 1))
+    printf "  PASS: confidently-empty store does NOT include the taskwarrior sync cue\n"; PASS=$((PASS + 1))
 fi
 
 rm -rf "$MOCK_TASK_DIR" "$MOCK_TASK_EMPTY_DIR"
+rm -f "$TRANSCRIPT"
+
+# ── #2359: scope-ladder delegation regression tests ─────────────────────────
+#
+# session-end-nudge.sh used to decide the taskwarrior-sync cue with its own
+# raw `task project:$(basename $cwd) ... export` query — bypassing the
+# project-scope ladder session-survey.sh (and session-spinup-nudge.sh) already
+# implement correctly. That caused silent under-counting (nudge never fires
+# when basename≠slug) and over-counting (a taskwarrior CLI `project:` prefix
+# filter sweeps in a sibling project's tasks, e.g. `comfyui` matching
+# `comfyui-nodes` tasks too). These three cases pin the fix; each is paired
+# against the positive control above (a correctly-slugged repo with real open
+# tasks still fires the cue).
+echo ""
+echo "scope-ladder delegation (#2359):"
+
+EXTRA_REPOS_DIR=$(mktemp -d) || { echo "mktemp -d failed" >&2; exit 1; }
+trap 'rm -rf "$TEST_HOME" "$REPO_WITH_RULES" "$REPO_PLAIN" "$MOCK_TASK_DIR" "$MOCK_TASK_EMPTY_DIR" "$EXTRA_REPOS_DIR"' EXIT
+
+# Case 1: basename differs from the taskwarrior project slug (remote-resolved).
+# Mirrors session-spinup-nudge.sh's chezmoi-src fixture (#2271).
+REPO_CHEZMOI="$EXTRA_REPOS_DIR/chezmoi-src"
+git init -q "$REPO_CHEZMOI"
+git -C "$REPO_CHEZMOI" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+git -C "$REPO_CHEZMOI" remote add origin https://github.com/u/dotfiles.git
+CHEZMOI_TASK_DIR=$(mktemp -d) || { echo "mktemp -d failed" >&2; exit 1; }
+# Simulates real taskwarrior: a `project:<slug>` filter for the WRONG
+# (basename-derived) slug matches nothing, while the correct slug or an
+# unfiltered export sees the task — pins the under-counting hazard.
+cat > "$CHEZMOI_TASK_DIR/task" <<'MOCK'
+#!/bin/sh
+case "$*" in
+  *'project:chezmoi-src'*) printf '[]\n' ;;
+  *'project:dotfiles'*) printf '[{"id":1,"description":"chezmoi apply drift","status":"pending","uuid":"00000000-0000-0000-0000-000000000002","project":"dotfiles"}]\n' ;;
+  *export*) printf '[{"id":1,"description":"chezmoi apply drift","status":"pending","uuid":"00000000-0000-0000-0000-000000000002","project":"dotfiles"}]\n' ;;
+  *) exit 0 ;;
+esac
+MOCK
+chmod +x "$CHEZMOI_TASK_DIR/task"
+TRANSCRIPT=$(make_transcript 10 "im done for now")
+output=$(run_hook_with_task_bin "$CHEZMOI_TASK_DIR/task" "sess-chezmoi" "$REPO_CHEZMOI" "$TRANSCRIPT")
+assert_contains "basename≠slug (remote-resolved) still fires the task cue" 'taskwarrior' "$output"
+rm -f "$TRANSCRIPT"
+
+# Case 2: the slug has a prefix sibling (comfyui vs comfyui-nodes) — the hook
+# must never rely on a `project:` filter, which taskwarrior's own CLI treats
+# as a PREFIX match and would sweep the sibling's tasks in.
+REPO_COMFYUI="$EXTRA_REPOS_DIR/comfyui"
+git init -q "$REPO_COMFYUI"
+git -C "$REPO_COMFYUI" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+COMFYUI_TASK_DIR=$(mktemp -d) || { echo "mktemp -d failed" >&2; exit 1; }
+COMFYUI_TASK_LOG="$COMFYUI_TASK_DIR/invocations.log"
+: > "$COMFYUI_TASK_LOG"
+cat > "$COMFYUI_TASK_DIR/task" <<MOCK
+#!/bin/sh
+echo "\$*" >> "$COMFYUI_TASK_LOG"
+case "\$*" in
+  *'project:'*) printf '[{"id":1,"description":"sibling task","status":"pending","uuid":"00000000-0000-0000-0000-000000000003","project":"comfyui-nodes"}]\n' ;;
+  *export*) printf '[{"id":1,"description":"sibling task 1","status":"pending","uuid":"00000000-0000-0000-0000-000000000003","project":"comfyui-nodes"},{"id":2,"description":"sibling task 2","status":"pending","uuid":"00000000-0000-0000-0000-000000000004","project":"comfyui-nodes"}]\n' ;;
+  *) exit 0 ;;
+esac
+MOCK
+chmod +x "$COMFYUI_TASK_DIR/task"
+TRANSCRIPT=$(make_transcript 10 "im done for now")
+output=$(run_hook_with_task_bin "$COMFYUI_TASK_DIR/task" "sess-comfyui" "$REPO_COMFYUI" "$TRANSCRIPT")
+if grep -q 'project:' "$COMFYUI_TASK_LOG"; then
+    printf "  FAIL: prefix-sibling repo — hook must never pass a project: filter to task\n"; FAIL=$((FAIL + 1))
+else
+    printf "  PASS: prefix-sibling repo — no project: filter passed (avoids the sibling-sweep hazard)\n"; PASS=$((PASS + 1))
+fi
+if [ -s "$COMFYUI_TASK_LOG" ]; then
+    printf "  PASS: prefix-sibling repo — task binary was actually invoked\n"; PASS=$((PASS + 1))
+else
+    printf "  FAIL: prefix-sibling repo — task binary was never invoked (test is vacuous)\n"; FAIL=$((FAIL + 1))
+fi
+rm -f "$TRANSCRIPT"
+
+# Case 3: PROJECT_CONFIDENCE=low does not silence the cue — a low-confidence
+# zero is an unqueried project, never a clean queue (the suppress-don't-
+# conclude convention session-end/SKILL.md and session-spinup/SKILL.md
+# already apply). Repo slug matches nothing; tasks exist only under an
+# unrelated project (no remote/ancestor resolution possible), forcing
+# TASK_SCOPE=all-projects-fallback / PROJECT_CONFIDENCE=low with
+# OPEN_TASKS=0.
+REPO_UNRELATED="$EXTRA_REPOS_DIR/widget-service"
+git init -q "$REPO_UNRELATED"
+git -C "$REPO_UNRELATED" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+UNRELATED_TASK_DIR=$(mktemp -d) || { echo "mktemp -d failed" >&2; exit 1; }
+# Same realism as the chezmoi stub: a `project:<slug>` filter for the
+# (unmatched) basename-derived slug returns nothing.
+cat > "$UNRELATED_TASK_DIR/task" <<'MOCK'
+#!/bin/sh
+case "$*" in
+  *'project:widget-service'*) printf '[]\n' ;;
+  *'project:totally-unrelated-project'*) printf '[{"id":1,"description":"unrelated task","status":"pending","uuid":"00000000-0000-0000-0000-000000000005","project":"totally-unrelated-project"}]\n' ;;
+  *export*) printf '[{"id":1,"description":"unrelated task","status":"pending","uuid":"00000000-0000-0000-0000-000000000005","project":"totally-unrelated-project"}]\n' ;;
+  *) exit 0 ;;
+esac
+MOCK
+chmod +x "$UNRELATED_TASK_DIR/task"
+TRANSCRIPT=$(make_transcript 10 "im done for now")
+output=$(run_hook_with_task_bin "$UNRELATED_TASK_DIR/task" "sess-unrelated" "$REPO_UNRELATED" "$TRANSCRIPT")
+assert_contains "PROJECT_CONFIDENCE=low (unqueried project) still fires the task cue" 'taskwarrior' "$output"
 rm -f "$TRANSCRIPT"
 
 echo ""


### PR DESCRIPTION
## Summary

session-plugin/hooks/session-end-nudge.sh decided whether to mention a taskwarrior sync pass using its own raw `task project:$(basename $cwd) '(status:pending or +ACTIVE)' export` query, bypassing the project-scope ladder that session-survey.sh (and session-spinup-nudge.sh) already implement correctly. This caused two silent failures: under-counting, where the nudge never fired when the cwd basename differed from the real taskwarrior project slug, and over-counting, where taskwarrior's own CLI `project:` filter is a prefix match, so a wrong slug like `comfyui` would also sweep in `comfyui-nodes` tasks.

The hook now delegates to `session-survey.sh --summary --project-dir "$cwd"`, mirroring session-spinup-nudge.sh's exact pattern (same `SESSION_NUDGE_TASK_BIN` test seam mapped onto `SESSION_SURVEY_TASK_BIN`), and reads `OPEN_TASKS`, `RECENT_TASK_COUNT`, `TASK_SCOPE`, and `PROJECT_CONFIDENCE` from the collector's `--summary` output. A low-confidence zero (`TASK_SCOPE != "none"` and `PROJECT_CONFIDENCE=low`) is treated as "unqueried project, worth the offer" rather than a confident clean queue — the same suppress-don't-conclude convention already documented in `session-end/SKILL.md` and `session-spinup/SKILL.md` Step 1c.

The duplicated per-task guidance embedded in the cue string (the raw `task project:<name> ... export | jq '.[]'` query plus the `task +LATEST uuids` reminder) is removed and replaced with a short "a taskwarrior state-sync pass looks worth offering" clause — it carried the same prefix-match hazard as agent-facing guidance, and duplicated the item-level confirmation flow #2356 centralizes.

## Latency observation (acceptance criterion 3)

Timed `session-survey.sh --summary --project-dir <this repo>` directly in the sandbox (no `gh`, no `task` on PATH):

- No taskwarrior, no gh: **42ms**
- With a stubbed `task` binary returning one open task: **68ms**

Both are sub-second and match the already-shipped `session-spinup-nudge.sh`'s usage of the same collector call (which runs at SessionStart, a tighter budget than this Stop hook). No fallback path was added — the collector call replaces the raw query outright, per the acceptance criteria's "if fast, just replace it outright" branch. If `gh` happens to be present in a real environment, `--summary` mode does launch one `gh issue list` job, but it's bounded by the collector's own per-call watchdog (`SESSION_SURVEY_GH_TIMEOUT`, default 4s) — the same bound `session-spinup-nudge.sh` already relies on, well inside a Stop hook's default 600s timeout.

## Regression coverage

Three new test cases in `test-session-end-nudge.sh` (23 assertions total, up from 17), each verified to fail for the right reason against the pre-fix hook before the fix landed:

1. **Basename ≠ slug (remote-resolved)** — a repo named `chezmoi-src` with `origin` pointing at `.../dotfiles.git` and a task filed under `project:dotfiles` still fires the cue. Against the old hook, a `project:chezmoi-src` filter (simulating real taskwarrior's project-filter semantics) returns nothing, so the cue never fires — reproducing the under-counting bug.
2. **Prefix siblings (`comfyui` vs `comfyui-nodes`)** — asserts the task binary is invoked with no `project:` filter at all, which is what avoids taskwarrior CLI's own prefix-match hazard (`project:comfyui` also matching `comfyui-nodes`). Against the old hook, the query does carry a `project:` filter.
3. **PROJECT_CONFIDENCE=low does not silence the cue** — a repo whose slug matches nothing (no remote/ancestor resolution), with tasks only under an unrelated project, forces `TASK_SCOPE=all-projects-fallback` / `PROJECT_CONFIDENCE=low` with `OPEN_TASKS=0`; the cue still fires (suppress-don't-conclude).

Each case is paired against a positive control (the pre-existing "open tasks" test, hardened to use a project field matching the repo's own basename so it's a genuine confident direct match, `TASK_SCOPE=project` / `PROJECT_CONFIDENCE=high`) and a counter-control (a confidently-empty store, `PROJECT_CONFIDENCE=high` with zero tasks anywhere, must NOT include the cue — proving the low-confidence handling doesn't fire unconditionally).

## Test plan

- [x] `bash session-plugin/hooks/test-session-end-nudge.sh` — 23/23 pass
- [x] `bash session-plugin/scripts/tests/test-session-survey.sh` — 322/322 pass (untouched, confirms the shared collector still behaves)
- [x] `bash session-plugin/hooks/test-session-spinup-nudge.sh` — 18/18 pass (untouched sibling hook, confirms no cross-contamination)
- [x] `just lint-shell` — 0 errors (9 pre-existing warnings in `macos-plugin`, unrelated)
- [x] `bash scripts/run-skill-script-tests.sh --root .` — full repo-wide sweep run; all three `session-plugin` test files pass. The one FAILED entry (`hooks-plugin/hooks/test-bash-antipatterns.sh`) and several SKIPs (`ast-grep`, `cargo-generate`, `task` CLI) are pre-existing environment gaps in this sandbox, unrelated to this change — `hooks-plugin` was not touched by this PR.

Fixes #2359


---
_Generated by [Claude Code](https://claude.ai/code/session_01EJqsYc8voEa6AA5Tib3Htu)_