### PR TITLE
fix(session-plugin): blueprint auto-drain gate honors task_registry .enabled

### DIFF
--- a/scripts/plugin-compliance-check.sh
+++ b/scripts/plugin-compliance-check.sh
@@ -440,6 +440,37 @@ check_skill_body() {
       done
     fi
 
+    # Regression: session-end's blueprint auto-drain gate (the jq check that
+    # auto-confirms the feature-tracker-sync pass) must require ALL THREE of
+    # autonomy_level >= 1, task_registry[...].enabled == true, AND
+    # task_registry[...].auto_run == true — not just the first and third. A
+    # manifest task the owner disabled (`enabled: false`) must never auto-run
+    # unattended just because `auto_run: true` and `autonomy_level >= 1`
+    # (issue #2358). The check pins the LITERAL jq gate command line (matched
+    # by "jq -r" + "autonomy_level" together, which is unique to the fenced
+    # gate — "autonomy_level" also appears once in surrounding prose but never
+    # on a "jq -r" line) rather than a bare substring search anywhere in the
+    # body, so prose that merely *mentions* "enabled" without wiring it into
+    # the actual filter still fails. This is also the negative guard against
+    # the old two-field form (autonomy_level + auto_run, no enabled check)
+    # silently reappearing via a bulk edit.
+    if [ "$skill_name" = "session-end" ]; then
+      gate_line=$(grep -E "jq -r .*autonomy_level" "$skill_file" || true)
+      if [ -z "$gate_line" ]; then
+        issues+=("❌ ${plugin}/${skill_name}: SKILL.md must retain the blueprint auto-drain jq gate line (autonomy_level/enabled/auto_run check, issue #2358)")
+        has_errors=true
+      else
+        if ! grep -q '\.enabled == true' <<<"$gate_line"; then
+          issues+=("❌ ${plugin}/${skill_name}: the blueprint auto-drain jq gate must pin task_registry[...].enabled == true (not just autonomy_level + auto_run) — a manifest that omits 'enabled' must read as disabled (issue #2358)")
+          has_errors=true
+        fi
+        if ! grep -q 'auto_run == true' <<<"$gate_line"; then
+          issues+=("❌ ${plugin}/${skill_name}: the blueprint auto-drain jq gate must pin task_registry[...].auto_run == true (issue #2358)")
+          has_errors=true
+        fi
+      fi
+    fi
+
     # Regression: the upstream issue/PR candidate pass detects candidates at
     # the session boundary and ROUTES each one — it never files blind. The
     # two load-bearing invariants: (1) the track-for-later path survives

--- a/scripts/tests/test-plugin-compliance-check.sh
+++ b/scripts/tests/test-plugin-compliance-check.sh
@@ -212,6 +212,61 @@ assert_contains "heading without a table is still detected" \
   "$out_heading" "is not followed by a markdown table within 10 lines"
 assert_absent "heading without a table does NOT emit a ❌ issue" "$out_heading" "❌"
 
+# --------------------------------------------------------------------------
+# Regression test for the session-end blueprint auto-drain gate (issue #2358).
+#
+# The jq gate that auto-confirms the Blueprint tracker-sync pass must require
+# ALL THREE of autonomy_level >= 1, task_registry[...].enabled == true, and
+# task_registry[...].auto_run == true — not just the first and third. A task
+# the owner disabled (`enabled: false`) must never auto-run unattended just
+# because `auto_run: true` and `autonomy_level >= 1`.
+#
+# THE SEMANTIC INVARIANT UNDER TEST: the two-field form (autonomy_level +
+# auto_run, missing the enabled check) must be REJECTED (❌, exit 1), and the
+# three-field form must PASS clean. A syntactic pin on "the string 'enabled'
+# appears somewhere in the body" would be insufficient — prose that merely
+# mentions "enabled" without wiring it into the actual jq filter must still
+# fail, so the fixture below carries prose naming "enabled" beside a gate line
+# that omits the check from the filter itself.
+make_session_end_skill() {
+  local gate_line="$1"
+  local dir="$root/$PLUGIN/skills/session-end"
+  mkdir -p "$dir"
+  {
+    printf -- '---\n'
+    printf 'name: session-end\n'
+    printf 'description: Fixture session-end. Use when exercising the compliance self-test.\n'
+    printf 'allowed-tools: Read\n'
+    printf 'created: 2026-08-11\n'
+    printf 'modified: 2026-08-11\n'
+    printf 'reviewed: 2026-08-11\n'
+    printf -- '---\n\n'
+    printf '# session-end\n\n'
+    printf 'Blueprint tracker-sync qualifies when UNDRAINED_COUNT >= 1 and delegates\n'
+    printf 'via --drain-wave. The gate checks the manifest'"'"'s enabled field.\n\n'
+    printf 'Upstream candidates always route through workflow-verify-before-filing.\n\n'
+    printf '```sh\n%s\n```\n' "$gate_line"
+  } > "$dir/SKILL.md"
+}
+
+# --- The regression: old two-field form (no enabled check) must FAIL --------
+rm -rf "${root:?}/$PLUGIN/skills/headingonly"
+make_session_end_skill 'jq -r '"'"'if ((.automation.autonomy_level // 0) >= 1) and (.task_registry["feature-tracker-sync"].auto_run == true) then "auto" else "ask" end'"'"' docs/blueprint/manifest.json 2>/dev/null'
+run_check; out_twofield="$OUT"; rc_twofield="$RC"
+
+assert_eq "old two-field gate (no enabled check) exits 1" "$rc_twofield" "1"
+assert_contains "old two-field gate is flagged by name" \
+  "$out_twofield" "session-end: the blueprint auto-drain jq gate must pin task_registry[...].enabled == true"
+
+# --- Guard integrity: the correct three-field form must PASS clean ---------
+rm -rf "${root:?}/$PLUGIN/skills/session-end"
+make_session_end_skill 'jq -r '"'"'if ((.automation.autonomy_level // 0) >= 1) and (.task_registry["feature-tracker-sync"].enabled == true) and (.task_registry["feature-tracker-sync"].auto_run == true) then "auto" else "ask" end'"'"' docs/blueprint/manifest.json 2>/dev/null'
+run_check; out_threefield="$OUT"; rc_threefield="$RC"
+
+assert_eq "three-field gate exits 0" "$rc_threefield" "0"
+assert_absent "three-field gate raises no auto-drain gate issue" \
+  "$out_threefield" "blueprint auto-drain jq gate"
+
 echo "---"
 echo "passed: $pass, failed: $fail"
 [ "$fail" -eq 0 ]

--- a/session-plugin/skills/session-end/SKILL.md
+++ b/session-plugin/skills/session-end/SKILL.md
@@ -93,14 +93,20 @@ failure mode.
 
 **Blueprint auto-drain (ADR-0020 level 1):** when the qualifying repo's
 `docs/blueprint/manifest.json` has `automation.autonomy_level` ≥ 1 **and**
+`task_registry["feature-tracker-sync"].enabled == true` **and**
 `task_registry["feature-tracker-sync"].auto_run == true`, the Blueprint
 tracker-sync pass is **auto-confirmed**: leave it out of the Step 3 question,
 run it in Step 4 order without asking, and report a one-line receipt in Step 5
 (`Blueprint tracker-sync: drained N WO(s) automatically (auto_run)`). All other
-passes still go through the Step 3 confirmation. Check the gate with:
+passes still go through the Step 3 confirmation. The gate requires all three —
+a task the owner disabled (`enabled: false`) must never auto-run unattended
+even when `auto_run: true` and `autonomy_level >= 1` (issue #2358). The
+`enabled` check uses `== true`, not `!= false`: a manifest that omits the
+`enabled` key entirely reads as disabled (the safe default), consistent with
+how `// 0` already defaults a missing `autonomy_level`. Check the gate with:
 
 ```sh
-jq -r 'if ((.automation.autonomy_level // 0) >= 1) and (.task_registry["feature-tracker-sync"].auto_run == true) then "auto" else "ask" end' docs/blueprint/manifest.json 2>/dev/null
+jq -r 'if ((.automation.autonomy_level // 0) >= 1) and (.task_registry["feature-tracker-sync"].enabled == true) and (.task_registry["feature-tracker-sync"].auto_run == true) then "auto" else "ask" end' docs/blueprint/manifest.json 2>/dev/null
 ```
 
 If **nothing** qualifies, say so in one line and end — no preview, no


### PR DESCRIPTION
## Summary

Fixes #2358 — `session-end`'s blueprint auto-drain gate ignored the manifest's `task_registry["feature-tracker-sync"].enabled` field, so a task the owner explicitly disabled (`enabled: false`) still auto-ran unattended whenever `auto_run: true` and `autonomy_level >= 1`.

**Fix (`session-plugin/skills/session-end/SKILL.md`):** the auto-confirm jq gate now requires all three conditions before evaluating to `"auto"`:

- `(.automation.autonomy_level // 0) >= 1`
- `.task_registry["feature-tracker-sync"].enabled == true`
- `.task_registry["feature-tracker-sync"].auto_run == true`

Otherwise the gate falls back to `"ask"`. The `enabled` check uses `== true` rather than `!= false`, so a manifest that omits the `enabled` key entirely reads as disabled (the safe default) — consistent with how `// 0` already defaults a missing `autonomy_level`.

**Regression guard (`scripts/plugin-compliance-check.sh`, `check_skill_body()`):** a new block scoped to the `session-end` skill locates the literal jq gate command line (matched on `jq -r` + `autonomy_level`, which only occurs on the actual gate line — `autonomy_level` also appears once in surrounding prose but never on a `jq -r` line) and asserts it pins both `.enabled == true` and `auto_run == true`. This is both the positive assertion and the negative guard against the old two-field form silently reappearing via a bulk edit — a check that only asserted "the string `enabled` appears somewhere in the body" would pass on prose mentioning `enabled` without it being wired into the actual jq filter, so the guard specifically inspects the gate line's own text.

**Test (`scripts/tests/test-plugin-compliance-check.sh`):** extends the existing sandbox-repo harness with two new cases for a `session-end` fixture skill:
1. The old two-field gate form (`autonomy_level` + `auto_run`, no `enabled` check) → asserted to exit 1 and be flagged by name.
2. The corrected three-field gate form → asserted to exit 0 with no auto-drain-gate issue raised.

Mutation-verified: with the `plugin-compliance-check.sh` change reverted, these two new test cases fail (2/16 → 14 passed / 2 failed); with the fix applied, all 16 pass.

## This repo's own manifest

Checked `docs/blueprint/manifest.json`'s `task_registry["feature-tracker-sync"]`: `enabled: true`, `auto_run: false`. Since `auto_run` is already `false`, both the old and new gate evaluate to `"ask"` — no behavior change here, so the manifest was **not** modified.

## Scope

Only `session-plugin/`, `scripts/plugin-compliance-check.sh`, and `scripts/tests/test-plugin-compliance-check.sh` were touched — no `blueprint-plugin/` files.

## Test plan

- [x] `just lint-compliance` — passes, no new ❌ issues (pre-existing ⚠️ recommendations only)
- [x] `just lint-shell` — 0 errors (pre-existing warnings only, unrelated files)
- [x] `bash scripts/tests/test-plugin-compliance-check.sh` — 16/16 pass
- [x] `./scripts/run-skill-script-tests.sh` — same failures/skips as on `origin/main` (environment-only: missing `ast-grep`/`cargo-generate`/`task` CLI in this sandbox; verified identical before/after via `git stash`)
- [x] Mutation-verified: reverting the `plugin-compliance-check.sh` guard makes the two new test cases fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJqsYc8voEa6AA5Tib3Htu)_