### PR TITLE
fix(session-plugin): session-end and session-wrap request GITHUB_DRIFT via --with-dedup

### DIFF
--- a/scripts/plugin-compliance-check.sh
+++ b/scripts/plugin-compliance-check.sh
@@ -488,6 +488,29 @@ check_skill_body() {
       fi
     fi
 
+    # Regression: session-end and session-wrap both read the collector's
+    # GITHUB_DRIFT section as a dedup guard (redundant-tracker test / Step 4
+    # taskwarrior-sync), but session-survey.sh only populates GITHUB_DRIFT when
+    # invoked with --with-dedup — without the flag the section is always empty
+    # and the guard silently runs against nothing (issue #2357). Semantic
+    # pairing check, not a bare string search: a body referencing GITHUB_DRIFT
+    # must carry --with-dedup on EVERY session-survey.sh invocation LINE, so a
+    # skill that merely mentions --with-dedup in explanatory prose (without
+    # putting it on the actual command) still fails.
+    if [ "$skill_name" = "session-end" ] || [ "$skill_name" = "session-wrap" ]; then
+      if grep -q "GITHUB_DRIFT" "$skill_file"; then
+        local invocation_lines missing_dedup_lines
+        invocation_lines=$(grep -v '^[[:space:]]*>' "$skill_file" | grep "session-survey\.sh" || true)
+        if [ -n "$invocation_lines" ]; then
+          missing_dedup_lines=$(printf '%s\n' "$invocation_lines" | grep -v -- '--with-dedup' || true)
+          if [ -n "$missing_dedup_lines" ]; then
+            issues+=("❌ ${plugin}/${skill_name}: SKILL.md references GITHUB_DRIFT but at least one session-survey.sh invocation line is missing --with-dedup (issue #2357)")
+            has_errors=true
+          fi
+        fi
+      fi
+    fi
+
     # Regression: session-distill's mechanical substrate is distill-survey.sh —
     # the read-only collector that mines the session transcript for recipe
     # candidates / hot files / process groupings so the skill judges instead of

--- a/scripts/tests/test-plugin-compliance-check.sh
+++ b/scripts/tests/test-plugin-compliance-check.sh
@@ -241,30 +241,6 @@ make_session_wrap_fixture() {
     printf -- '---\n'
     printf 'name: session-wrap\n'
     printf 'description: Fixture session-wrap. Use when exercising the compliance self-test.\n'
-# --------------------------------------------------------------------------
-# Regression test for the session-end blueprint auto-drain gate (issue #2358).
-#
-# The jq gate that auto-confirms the Blueprint tracker-sync pass must require
-# ALL THREE of autonomy_level >= 1, task_registry[...].enabled == true, and
-# task_registry[...].auto_run == true — not just the first and third. A task
-# the owner disabled (`enabled: false`) must never auto-run unattended just
-# because `auto_run: true` and `autonomy_level >= 1`.
-#
-# THE SEMANTIC INVARIANT UNDER TEST: the two-field form (autonomy_level +
-# auto_run, missing the enabled check) must be REJECTED (❌, exit 1), and the
-# three-field form must PASS clean. A syntactic pin on "the string 'enabled'
-# appears somewhere in the body" would be insufficient — prose that merely
-# mentions "enabled" without wiring it into the actual jq filter must still
-# fail, so the fixture below carries prose naming "enabled" beside a gate line
-# that omits the check from the filter itself.
-make_session_end_skill() {
-  local gate_line="$1"
-  local dir="$root/$PLUGIN/skills/session-end"
-  mkdir -p "$dir"
-  {
-    printf -- '---\n'
-    printf 'name: session-end\n'
-    printf 'description: Fixture session-end. Use when exercising the compliance self-test.\n'
     printf 'allowed-tools: Read\n'
     printf 'created: 2026-08-11\n'
     printf 'modified: 2026-08-11\n'
@@ -318,6 +294,37 @@ assert_absent "with --with-dedup on the invocation line, no #2357 finding" \
 assert_eq "with --with-dedup, session-wrap fixture exits 0" "$rc_fixed" "0"
 
 rm -rf "${root:?}/$PLUGIN/skills/session-wrap"
+
+
+# --------------------------------------------------------------------------
+# Regression test for the session-end blueprint auto-drain gate (issue #2358).
+#
+# The jq gate that auto-confirms the Blueprint tracker-sync pass must require
+# ALL THREE of autonomy_level >= 1, task_registry[...].enabled == true, and
+# task_registry[...].auto_run == true — not just the first and third. A task
+# the owner disabled (`enabled: false`) must never auto-run unattended just
+# because `auto_run: true` and `autonomy_level >= 1`.
+#
+# THE SEMANTIC INVARIANT UNDER TEST: the two-field form (autonomy_level +
+# auto_run, missing the enabled check) must be REJECTED (❌, exit 1), and the
+# three-field form must PASS clean. A syntactic pin on "the string 'enabled'
+# appears somewhere in the body" would be insufficient — prose that merely
+# mentions "enabled" without wiring it into the actual jq filter must still
+# fail, so the fixture below carries prose naming "enabled" beside a gate line
+# that omits the check from the filter itself.
+make_session_end_skill() {
+  local gate_line="$1"
+  local dir="$root/$PLUGIN/skills/session-end"
+  mkdir -p "$dir"
+  {
+    printf -- '---\n'
+    printf 'name: session-end\n'
+    printf 'description: Fixture session-end. Use when exercising the compliance self-test.\n'
+    printf 'allowed-tools: Read\n'
+    printf 'created: 2026-08-11\n'
+    printf 'modified: 2026-08-11\n'
+    printf 'reviewed: 2026-08-11\n'
+    printf -- '---\n\n'
     printf '# session-end\n\n'
     printf 'Blueprint tracker-sync qualifies when UNDRAINED_COUNT >= 1 and delegates\n'
     printf 'via --drain-wave. The gate checks the manifest'"'"'s enabled field.\n\n'

--- a/scripts/tests/test-plugin-compliance-check.sh
+++ b/scripts/tests/test-plugin-compliance-check.sh
@@ -212,6 +212,89 @@ assert_contains "heading without a table is still detected" \
   "$out_heading" "is not followed by a markdown table within 10 lines"
 assert_absent "heading without a table does NOT emit a ❌ issue" "$out_heading" "❌"
 
+# ============================================================================
+# session-end / session-wrap: GITHUB_DRIFT requires --with-dedup (issue #2357)
+#
+# session-survey.sh only populates its GITHUB_DRIFT section when invoked with
+# --with-dedup — omitted, the section is always empty and any dedup guard that
+# reads it (redundant-tracker test, taskwarrior-sync) silently runs against
+# nothing. The regression guard must be SEMANTIC: it asserts --with-dedup is on
+# the actual session-survey.sh invocation LINE, not merely that the substring
+# "--with-dedup" appears anywhere in the file (which a body could satisfy with
+# explanatory prose while the real command stays broken).
+#
+# The fixture is named literally "session-wrap" because check_skill_body()
+# keys this rule off the skill directory's basename. It also carries the other
+# session-wrap-scoped tokens (+upstream / workflow-verify-before-filing / "is
+# its own tracker" / "annotate the existing task") so those UNRELATED checks
+# stay green and every ❌ assertion below is attributable to this rule alone.
+# ============================================================================
+
+make_session_wrap_fixture() {
+  # make_session_wrap_fixture <survey-invocation-line> <extra-body-line>
+  local invocation="$1"
+  local extra="${2:-}"
+  local dir="$root/$PLUGIN/skills/session-wrap"
+  rm -rf "$dir"
+  mkdir -p "$dir"
+  {
+    printf -- '---\n'
+    printf 'name: session-wrap\n'
+    printf 'description: Fixture session-wrap. Use when exercising the compliance self-test.\n'
+    printf 'allowed-tools: Read\n'
+    printf 'created: 2026-08-11\n'
+    printf 'modified: 2026-08-11\n'
+    printf 'reviewed: 2026-08-11\n'
+    printf -- '---\n\n'
+    printf '# Fixture session-wrap\n\n'
+    printf '## When to Use This Skill\n\n'
+    printf '| Use this skill when... | Use another skill when... |\n'
+    printf '|---|---|\n'
+    printf '| Exercising the fixture | Doing anything real |\n\n'
+    printf '## Execution\n\n'
+    printf 'Run the shared collector:\n\n'
+    printf '```sh\n%s\n```\n\n' "$invocation"
+    printf 'The GITHUB_DRIFT section is what the redundant-tracker test\n'
+    printf 'below reads: an open PR or assigned issue is its own tracker,\n'
+    printf 'so annotate the existing task instead of adding a duplicate.\n'
+    printf 'Track an upstream candidate with +upstream, or route it through\n'
+    printf 'workflow-verify-before-filing before filing anything.\n\n'
+    if [ -n "$extra" ]; then
+      printf '%s\n' "$extra"
+    fi
+  } > "$dir/SKILL.md"
+}
+
+# --- The regression: GITHUB_DRIFT referenced, invocation missing --with-dedup
+make_session_wrap_fixture \
+  'bash "${CLAUDE_SKILL_DIR}/../../scripts/session-survey.sh" --with-commits'
+run_check; out_missing="$OUT"; rc_missing="$RC"
+
+assert_contains "missing --with-dedup on the invocation line is flagged ❌" \
+  "$out_missing" "SKILL.md references GITHUB_DRIFT but at least one session-survey.sh invocation line is missing --with-dedup"
+assert_contains "missing --with-dedup names the issue (#2357)" "$out_missing" "#2357"
+
+# --- Guard integrity: the string alone (prose, not on the command line) must
+# NOT satisfy the check — proves this is a semantic pairing, not a bare grep.
+make_session_wrap_fixture \
+  'bash "${CLAUDE_SKILL_DIR}/../../scripts/session-survey.sh" --with-commits' \
+  'Note: pass --with-dedup to populate GITHUB_DRIFT.'
+run_check; out_prose_only="$OUT"; rc_prose_only="$RC"
+
+assert_contains "--with-dedup) in prose alone still flags the invocation line" \
+  "$out_prose_only" "SKILL.md references GITHUB_DRIFT but at least one session-survey.sh invocation line is missing --with-dedup"
+
+# --- The fix: --with-dedup on the actual invocation line clears the finding
+make_session_wrap_fixture \
+  'bash "${CLAUDE_SKILL_DIR}/../../scripts/session-survey.sh" --with-commits --with-dedup'
+run_check; out_fixed="$OUT"; rc_fixed="$RC"
+
+assert_absent "with --with-dedup on the invocation line, no #2357 finding" \
+  "$out_fixed" "missing --with-dedup"
+assert_eq "with --with-dedup, session-wrap fixture exits 0" "$rc_fixed" "0"
+
+rm -rf "${root:?}/$PLUGIN/skills/session-wrap"
+
 echo "---"
 echo "passed: $pass, failed: $fail"
 [ "$fail" -eq 0 ]

--- a/session-plugin/skills/session-end/SKILL.md
+++ b/session-plugin/skills/session-end/SKILL.md
@@ -59,11 +59,18 @@ and follow-ups land in a near-empty sibling. `PROJECT_EXACT_TASKS` is
 always present: the slug alone, without its `.` subprojects.
 
 ```sh
-bash "${CLAUDE_SKILL_DIR}/../../scripts/session-survey.sh" --with-commits --with-blueprint
+bash "${CLAUDE_SKILL_DIR}/../../scripts/session-survey.sh" --with-commits --with-blueprint --with-dedup
 ```
 
 Pass `--project <name>` to override the detected project. Hand the digest
-to the confirmed passes in Step 4 so they don't re-survey. Plus the
+to the confirmed passes in Step 4 so they don't re-survey. `--with-dedup`
+is what populates the `GITHUB_DRIFT` section that Step 4's taskwarrior-sync
+redundancy test reads — without it the section is always empty and the
+guard silently runs against nothing. That section also carries `GH_READY`:
+`false` means it is present but **unqueried** (no `gh` CLI or
+unauthenticated), the same "not clean, just not asked" signal as
+`PROJECT_CONFIDENCE=low` above — don't treat an empty `GITHUB_DRIFT` under
+`GH_READY=false` as evidence there's nothing to dedup against. Plus the
 conversation: what finished, what's hanging, what was learned, what
 plugin/skill friction or wins occurred.
 
@@ -189,7 +196,7 @@ already in the transcript. Pre-silence:
 
 | Context | Command |
 |---|---|
-| One-pass survey (detection + git + PRs + tasks-with-UUIDs + commits + blueprint tracker state) | `bash "${CLAUDE_SKILL_DIR}/../../scripts/session-survey.sh" --with-commits --with-blueprint` |
+| One-pass survey (detection + git + PRs + tasks-with-UUIDs + commits + blueprint tracker state + GitHub-drift dedup) | `bash "${CLAUDE_SKILL_DIR}/../../scripts/session-survey.sh" --with-commits --with-blueprint --with-dedup` |
 | Trust the task count? | `TASK_SCOPE=` + `PROJECT_CONFIDENCE=` in the `TASKWARRIOR` section (`low` ⇒ re-run with `--project <slug>` before treating 0 as clean) |
 | Distill qualify signal (recipe/hot-file/process counts) | `bash "${CLAUDE_SKILL_DIR}/../../scripts/distill-survey.sh" --session-id "${CLAUDE_SESSION_ID}" --summary` |
 | Re-derive the drain wave before delegating | `task bpid.any: status:completed export \| jq …` intersected with tracker `tasks.pending` (Step 4.3) |

--- a/session-plugin/skills/session-wrap/SKILL.md
+++ b/session-plugin/skills/session-wrap/SKILL.md
@@ -106,14 +106,20 @@ emitting each task with its **stable UUID** so Steps 2/4 never operate on
 a volatile numeric ID:
 
 ```sh
-bash "${CLAUDE_SKILL_DIR}/../../scripts/session-survey.sh" --with-commits
+bash "${CLAUDE_SKILL_DIR}/../../scripts/session-survey.sh" --with-commits --with-dedup
 ```
 
 Pass `--project <name>` when the config naming map maps the cwd to a
 project other than the repo basename; when detection is ambiguous
 (`DETECTION=ambiguous`) and unclear, list `task _projects` and ask once.
-Then read the conversation itself — what was kicked off but not finished,
-discussed but not done.
+`--with-dedup` populates `GITHUB_DRIFT`, which the "Don't duplicate an
+existing tracker" section below reads — without it the section is always
+empty and the check silently passes against nothing. That section's
+`GH_READY` matters too: `false` means `PRS`/`GITHUB_DRIFT` are present but
+**unqueried** (no `gh` CLI or unauthenticated), not "nothing open" — never
+treat an empty section under `GH_READY=false` as license to add a task
+that duplicates an untracked PR/issue. Then read the conversation itself —
+what was kicked off but not finished, discussed but not done.
 
 ### Step 2: Categorise
 
@@ -195,7 +201,7 @@ running. Pre-silence for a session:
 
 | Context | Command |
 |---|---|
-| Survey (detection + git + PRs + tasks-with-UUIDs + commits) | `bash "${CLAUDE_SKILL_DIR}/../../scripts/session-survey.sh" --with-commits` |
+| Survey (detection + git + PRs + tasks-with-UUIDs + commits + GitHub-drift dedup) | `bash "${CLAUDE_SKILL_DIR}/../../scripts/session-survey.sh" --with-commits --with-dedup` |
 | Batch close by UUID | `task rc.confirmation:no <uuid> done` |
 | Add a task | `task rc.confirmation:no add project:<name> +<tag> '<desc>'` |
 | Known projects | `task _projects` |


### PR DESCRIPTION
Fixes #2357

Summary

session-survey.sh only populates its GITHUB_DRIFT section when invoked with --with-dedup. Both session-end/SKILL.md and session-wrap/SKILL.md build a dont duplicate an existing GitHub tracked issue into a taskwarrior task guard on that sections contents, but neither passed --with-dedup when invoking the collector, so the guard silently ran against an always empty section. Only session-spinup/SKILL.md passed the flag before this change.

Changes

- session-end/SKILL.md: added --with-dedup to the Step 1 Execution invocation of session-survey.sh and to the matching Agentic Optimizations table row. Added a clause noting that GH_READY=false means GITHUB_DRIFT is present but unqueried, mirroring the existing PROJECT_CONFIDENCE=low handling, so an empty section under GH_READY=false is never treated as evidence there is nothing to dedup against.
- session-wrap/SKILL.md: same flag addition to its Step 1 Execution invocation and Agentic Optimizations row, plus the matching GH_READY=false clause next to the existing Dont duplicate an existing tracker section (which already reads GITHUB_DRIFT and PRS).
- scripts/plugin-compliance-check.sh (check_skill_body): added a semantic regression guard scoped to session-end and session-wrap. It asserts that any SKILL.md body referencing GITHUB_DRIFT also carries --with-dedup on every session-survey.sh invocation LINE, not merely as a substring anywhere in the file (a body that only mentions --with-dedup in explanatory prose still fails, proving this is a semantic pairing check and not a bare grep).
- scripts/tests/test-plugin-compliance-check.sh: extended with a fixture case named literally session-wrap (the check keys off the skill directory basename). Three cases: (1) GITHUB_DRIFT referenced with no --with-dedup on the invocation line raises the new finding, (2) --with-dedup present only in prose (not on the invocation line) still raises it, proving the semantic pairing, and (3) --with-dedup on the actual invocation line clears the finding and the fixture exits 0.

This issue is distinct from #2355 (already separately handled) — nothing here is about project-slug scoping, only the missing flag.

Repro (per the acceptance criteria)

Verified locally in this sandbox, where gh is not installed:

bash session-plugin/scripts/session-survey.sh --with-commits | grep -c '=== GITHUB_DRIFT ==='
→ 0

bash session-plugin/scripts/session-survey.sh --with-commits --with-dedup | grep -c '=== GITHUB_DRIFT ==='
→ 1

The GITHUB_DRIFT section header appears exactly once --with-dedup is passed, confirming the issue's claim and confirming this does not require gh to be present — with gh absent, the section still emits with GH_READY=false, ASSIGNED_ISSUES=0, DRIFT_COUNT=0, STATUS=OK rather than being omitted. This matches the acceptance criteria's expectation.

Testing

- bash scripts/tests/test-plugin-compliance-check.sh — 17/17 pass, including the three new session-wrap fixture cases. Mutation-verified: with the new check block removed, exactly the three positive-detection assertions fail (14 pass / 3 fail) while the fix and negative-control assertions still pass, confirming the guard is load-bearing.
- just lint-compliance — exit 0, zero ❌ issues repo-wide; session-plugin's Body column is ✅ confirming the real session-end/session-wrap bodies pass the new guard after the fix (WARN-level size/description recommendations for those skills are pre-existing and unrelated).
- bash session-plugin/scripts/tests/test-session-survey.sh — PASS=322 FAIL=0 (unaffected by this change; the collector script itself was not modified).
- just test-skill-scripts — session-plugin and scripts/tests/test-plugin-compliance-check.sh all PASS. The one FAILED entry in that run (hooks-plugin/hooks/test-bash-antipatterns.sh) and several SKIPs (ast-grep/cargo-generate/task CLI not installed in this sandbox) are pre-existing environment gaps, verified by re-running that same test against origin/main with these changes stashed — it fails identically (138 passed, 37 failed) with no changes present.
- just lint-shell — 0 errors, 9 pre-existing warnings in an unrelated plugin (macos-plugin), unaffected by this change.

Branched from a fresh git fetch origin && git switch -c … origin/main, so the diff is against current main content (the two sibling PRs for #2358/#2359 mentioned in the task description had not yet landed on origin/main at the time this branch was cut — git log shows no commits referencing #2358 or #2359 on origin/main, so nothing needed to be rebased onto).

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJqsYc8voEa6AA5Tib3Htu)_