### PR TITLE
docs(agent-patterns-plugin): assign concurrent agents distinct scratchpad paths

### DIFF
--- a/agent-patterns-plugin/skills/parallel-agent-dispatch/SKILL.md
+++ b/agent-patterns-plugin/skills/parallel-agent-dispatch/SKILL.md
@@ -111,6 +111,33 @@ brief the agent to do so as its *first* step. See
 [references/worktree-hazards.md → Nested-repo isolation](references/worktree-hazards.md#nested-repo-worktree-isolation-1838)
 for detection script and rules.
 
+**Concurrent agents default to the *same* scratchpad path — assign distinct ones.**
+The session scratchpad directory is shared across sibling subagents, so two
+agents told to "make your own clone" independently pick the identical path and
+end up operating **one working tree**. Nothing errors: one agent's `git switch`
+moves `HEAD` under the other, so its edits land on the peer's branch and both
+PRs can carry each other's hunks. A per-file `git diff` cannot separate
+interleaved hunks in a co-modified file, so the extracted patch looks correct
+while carrying someone else's work.
+
+Give every concurrent agent an **explicit, distinct** working path in its
+prompt — `<scratchpad>/<agent-name>` — rather than letting each choose. This
+applies whenever agents work outside worktree isolation, which the nested-repo
+case above forces them into.
+
+Recovery, if it already happened: rebuild in a fresh clone and **re-apply your
+changes by hand**. Do not copy files out of the shared tree — co-modified files
+carry the peer's hunks with them. Leave the shared tree dirty rather than
+reverting it; a revert destroys the peer's uncommitted work. Verify with
+`git log --oneline origin/main..HEAD` plus `--stat` that the branch holds only
+your commits and only your paths.
+
+> Observed 2026-08: two agents fixing different defects in the same MCP server
+> collided this way. Each caught a real error in the other's cleanup — one
+> nearly shipped a merge warning that would have broken the build if acted on,
+> the other a verification `grep` that would have cried wolf. Neither shipped
+> contaminated, but only because they were talking to each other.
+
 ### 2. Scope Budget (per-agent prompt rules)
 
 Every agent prompt must declare:


### PR DESCRIPTION
## What

Adds one preflight to `parallel-agent-dispatch`: **concurrent sibling agents must be given distinct working paths.**

The session scratchpad directory is shared across sibling subagents. Two agents each told to "make your own clone" independently pick the *identical* path and end up operating one working tree. Nothing errors — one agent's `git switch` moves `HEAD` under the other, its edits land on the peer's branch, and both PRs can carry each other's hunks.

## Why it's not already covered

The skill has a strong nested-repo entry (#1838) explaining that `isolation: "worktree"` isolates the *outer* repo. That hazard is precisely what pushes agents **out** of worktree isolation and into ad-hoc clones — and there the guidance stops. The new section sits directly after it for that reason.

## Evidence

Two agents fixing different defects in the same MCP server collided this way this session. The interesting part is the detection difficulty: a per-file `git diff` **cannot** separate interleaved hunks in a co-modified file, so the patch one agent extracted looked correct while silently carrying five of the peer's lines into its PR.

Each caught a real error in the other's cleanup — one nearly shipped a merge-order warning that would have broken the build had it been acted on, the other a verification `grep` that would have cried wolf on a legitimate `#comments` URL fragment. Neither shipped contaminated, but only because they were talking to each other. Without that, both PRs would have merged carrying the other's work.

## What the section adds

- **Preflight**: give every concurrent agent an explicit `<scratchpad>/<agent-name>` in its prompt rather than letting each choose.
- **Recovery**: rebuild in a fresh clone and re-apply changes *by hand*. Do not copy files out of the shared tree — co-modified files carry the peer's hunks. Leave the shared tree dirty rather than reverting it; a revert destroys the peer's uncommitted work.
- **Verification**: `git log --oneline origin/main..HEAD` plus `--stat`, so a branch is confirmed to hold only your commits and only your paths.

27 added lines, one file. No behaviour change to the skill's existing guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
