### PR TITLE
fix(git-plugin): exit early on branch-deletion pushes in pr-metadata hook

### DIFF
--- a/git-plugin/hooks/check-pr-metadata-on-push.sh
+++ b/git-plugin/hooks/check-pr-metadata-on-push.sh
@@ -28,6 +28,30 @@ CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 if [ -z "$COMMAND" ]; then exit 0; fi
 if ! echo "$COMMAND" | grep -qE '(^|\s|&&\s*|;\s*)git\s+push\b'; then exit 0; fi
 
+# Guard: branch deletions carry nothing to reconcile (issue #2351).
+# `git push origin --delete <b>`, `git push origin -d <b>`, and the
+# colon-prefix refspec `git push origin :<b>` all push zero commits, so
+# none of the three checks below (title accuracy, description currency,
+# issue references) has anything to act on. Deleting a merged branch is
+# routine post-merge cleanup, and blocking it only leaves stale branches
+# behind — the opposite of this hook's intent.
+#
+# Scoped to the `git push` segment (the last one, matching the branch
+# detection below) so a `-d` or a leading `:` elsewhere in a chained
+# command — `git push origin feat && rmdir -d /tmp/x` — cannot exempt a
+# real commit push.
+PUSH_SEGMENT=$(printf '%s' "$COMMAND" | perl -ne '
+    next unless /.*(git\s+push\b.*)$/;
+    my $seg = $1;
+    # Trim anything after the push at the next shell separator
+    $seg =~ s/\s*(?:&&|\|\||;|\|).*$//;
+    print $seg;
+' 2>/dev/null || true)
+if [ -n "$PUSH_SEGMENT" ] && printf '%s' "$PUSH_SEGMENT" \
+    | grep -qE '(^|[[:space:]])(--delete|-d|\+?:[^[:space:]]+)([[:space:]]|$)'; then
+    exit 0
+fi
+
 # Guard: skip if not in a git repo
 if [ -z "$CWD" ] || ! git -C "$CWD" rev-parse --git-dir >/dev/null 2>&1; then exit 0; fi
 
@@ -70,7 +94,7 @@ fi
 if [ -z "$PUSH_BRANCH" ]; then exit 0; fi
 
 # Check for an existing open PR on this branch
-PR_JSON=$(gh pr view "$PUSH_BRANCH" --repo "$(git -C "$CWD" remote get-url origin 2>/dev/null || true)" --json title,body,number,url,updatedAt 2>/dev/null || true)
+PR_JSON=$(gh pr view "$PUSH_BRANCH" --repo "$(git -C "$CWD" remote get-url origin 2>/dev/null || true)" --json title,body,number,url,updatedAt,state 2>/dev/null || true)
 
 # Guard: no open PR for this branch
 if [ -z "$PR_JSON" ] || [ "$PR_JSON" = "null" ]; then exit 0; fi
@@ -80,9 +104,16 @@ PR_TITLE=$(echo "$PR_JSON" | jq -r '.title // empty')
 PR_BODY=$(echo "$PR_JSON" | jq -r '.body // empty')
 PR_URL=$(echo "$PR_JSON" | jq -r '.url // empty')
 PR_UPDATED_AT=$(echo "$PR_JSON" | jq -r '.updatedAt // empty')
+PR_STATE=$(echo "$PR_JSON" | jq -r '.state // empty')
 
 # Guard: couldn't parse PR data
 if [ -z "$PR_NUMBER" ] || [ -z "$PR_TITLE" ]; then exit 0; fi
+
+# Guard: a merged PR's metadata is a historical record (issue #2351).
+# Prompting to reconcile it invites rewriting the description of something
+# already reviewed and landed. Read the `state` enum, never a `merged`
+# boolean — there is no such field (.claude/rules/gh-json-fields.md).
+if [ "$PR_STATE" = "MERGED" ]; then exit 0; fi
 
 # Resolve the ref to inspect for commits and bypass-timestamp comparison.
 # When the push command names a branch other than the running shell's

--- a/git-plugin/hooks/test-check-pr-metadata-on-push.sh
+++ b/git-plugin/hooks/test-check-pr-metadata-on-push.sh
@@ -292,6 +292,72 @@ PATH="$MOCK_BIN:$PATH" MOCK_PR_JSON="$MOCK_PR_JSON" \
 
 git -C "$TMPDIR" checkout feature -q
 
+# ── Branch deletions carry no metadata to reconcile (issue #2351) ─────────
+# Regression test: `git push origin --delete <branch>` (and its `-d` and
+# colon-refspec equivalents) pushes no commits, so none of the hook's three
+# checks (title accuracy, description currency, issue references) have
+# anything to act on. The hook must exit 0 before touching gh.
+#
+# Each case uses a PR whose updatedAt is OLDER than the branch's latest
+# commit — i.e. the exact state that blocks a normal push — so a passing
+# test proves the deletion detection fired, not the retry-aware bypass.
+echo ""
+echo "branch deletion pushes exit early (#2351):"
+
+MOCK_PR_JSON=$(jq -n --arg t "$PR_PAST" \
+    '{number:42,title:"feat: x",body:"body",url:"https://example/42",updatedAt:$t,state:"OPEN"}')
+
+PATH="$MOCK_BIN:$PATH" MOCK_PR_JSON="$MOCK_PR_JSON" \
+    assert_exit "git push origin --delete <branch> is allowed (#2351)" 0 \
+    "$(make_json "git push origin --delete feature")"
+
+PATH="$MOCK_BIN:$PATH" MOCK_PR_JSON="$MOCK_PR_JSON" \
+    assert_exit "git push origin -d <branch> is allowed (#2351)" 0 \
+    "$(make_json "git push origin -d feature")"
+
+PATH="$MOCK_BIN:$PATH" MOCK_PR_JSON="$MOCK_PR_JSON" \
+    assert_exit "git push origin :<branch> is allowed (#2351)" 0 \
+    "$(make_json "git push origin :feature")"
+
+PATH="$MOCK_BIN:$PATH" MOCK_PR_JSON="$MOCK_PR_JSON" \
+    assert_exit "git push origin :refs/heads/<branch> is allowed (#2351)" 0 \
+    "$(make_json "git push origin :refs/heads/feature")"
+
+# Counter-tests: the deletion detection must not swallow real commit pushes.
+PATH="$MOCK_BIN:$PATH" MOCK_PR_JSON="$MOCK_PR_JSON" \
+    assert_exit "normal push still blocks (deletion detection not over-broad)" 2 \
+    "$(make_json "git push origin feature")"
+
+PATH="$MOCK_BIN:$PATH" MOCK_PR_JSON="$MOCK_PR_JSON" \
+    assert_exit "--dry-run push still blocks (not mistaken for -d)" 2 \
+    "$(make_json "git push --dry-run origin feature")"
+
+PATH="$MOCK_BIN:$PATH" MOCK_PR_JSON="$MOCK_PR_JSON" \
+    assert_exit "HEAD:<branch> refspec still blocks (colon is not leading)" 2 \
+    "$(make_json "git push origin HEAD:feature")"
+
+PATH="$MOCK_BIN:$PATH" MOCK_PR_JSON="$MOCK_PR_JSON" \
+    assert_exit "-d in a chained non-push command still blocks" 2 \
+    "$(make_json "git push origin feature && rmdir -d /tmp/nope")"
+
+# ── Merged PRs are a historical record (issue #2351) ──────────────────────
+# A merged PR's metadata is finished; prompting to edit it invites rewriting
+# the description of something already reviewed and landed.
+echo ""
+echo "merged PR metadata is not reconciled (#2351):"
+
+MOCK_PR_JSON=$(jq -n --arg t "$PR_PAST" \
+    '{number:42,title:"feat: x",body:"body",url:"https://example/42",updatedAt:$t,state:"MERGED"}')
+PATH="$MOCK_BIN:$PATH" MOCK_PR_JSON="$MOCK_PR_JSON" \
+    assert_exit "push to a branch whose PR is MERGED is allowed (#2351)" 0 \
+    "$(make_json "git push origin feature")"
+
+MOCK_PR_JSON=$(jq -n --arg t "$PR_PAST" \
+    '{number:42,title:"feat: x",body:"body",url:"https://example/42",updatedAt:$t,state:"OPEN"}')
+PATH="$MOCK_BIN:$PATH" MOCK_PR_JSON="$MOCK_PR_JSON" \
+    assert_exit "push to a branch whose PR is OPEN still blocks" 2 \
+    "$(make_json "git push origin feature")"
+
 rm -rf "$MOCK_BIN"
 
 # ── Summary ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`git-plugin/hooks/check-pr-metadata-on-push.sh` fired on `git push origin --delete <branch>` and demanded the PR description be reconciled before allowing it. A deletion pushes **no commits**, so none of the hook's three checks (title accuracy, description currency, issue references) has anything to act on — the only way through was to edit an already-merged PR's body purely to bump its `updatedAt`.

The situation it fires in is routine post-merge cleanup, and the branch being deleted is one whose PR is already merged — precisely when its metadata is finished and should not be touched. `pr-merge-hazards.md` and `check-stranded-work.sh` actively encourage sweeping dead branches, so the hook opposed a practice the same plugin family recommends. Observed effect: stale branches accumulating, the opposite of the hook's intent.

Distinct from the closed prior reports (#1041, #1400, #1419, #1431), which are all about *pushing commits*.

## Change

Two early exits in `check-pr-metadata-on-push.sh`:

| Exit | Trigger | Rationale |
|------|---------|-----------|
| Deletion refspec | `--delete`, `-d`, `:<branch>`, `:refs/heads/<branch>` | Zero commits pushed — nothing to reconcile |
| Merged PR | `state == "MERGED"` | A merged PR's metadata is a historical record; prompting to edit it invites rewriting something already reviewed and landed |

Deletion detection runs **before** any `git` or `gh` work, so a deletion push costs nothing. It is scoped to the `git push` **segment** (the last one, matching the hook's existing branch-detection behaviour), so a `-d` or a leading `:` elsewhere in a chained command — `git push origin feat && rmdir -d /tmp/x` — cannot exempt a real commit push.

The merged-PR guard reads the `state` enum, never a `merged` boolean — there is no such field (`.claude/rules/gh-json-fields.md`). It required only adding `state` to the existing `gh pr view --json` field list; no new API call.

## No regression on commit-push behaviour

The hook's actual purpose is untouched. The retry-aware bypass (#1041), the author-date semantics that survive a rebase (#1400), and the cross-branch `PUSH_REF` resolution (#1419) all still hold, and the new cases carry explicit counter-tests:

- normal `git push origin <branch>` still blocks
- `--dry-run` still blocks (not mistaken for `-d`)
- `HEAD:<branch>` still blocks (the colon is not leading)
- `-d` in a chained non-push command still blocks
- a PR in state `OPEN` still blocks

## Tests

Nine regression cases added to `git-plugin/hooks/test-check-pr-metadata-on-push.sh` (`.claude/rules/regression-testing.md`). The four deletion cases deliberately use a PR whose `updatedAt` **predates** the branch's latest commit — the exact state that blocks a normal push — so a pass proves the deletion detection fired rather than the retry-aware bypass.

TDD order: tests added first and confirmed failing (5 failures), then the fix.

```
$ bash git-plugin/hooks/test-check-pr-metadata-on-push.sh
...
branch deletion pushes exit early (#2351):
  PASS: git push origin --delete <branch> is allowed (#2351)
  PASS: git push origin -d <branch> is allowed (#2351)
  PASS: git push origin :<branch> is allowed (#2351)
  PASS: git push origin :refs/heads/<branch> is allowed (#2351)
  PASS: normal push still blocks (deletion detection not over-broad)
  PASS: --dry-run push still blocks (not mistaken for -d)
  PASS: HEAD:<branch> refspec still blocks (colon is not leading)
  PASS: -d in a chained non-push command still blocks

merged PR metadata is not reconciled (#2351):
  PASS: push to a branch whose PR is MERGED is allowed (#2351)
  PASS: push to a branch whose PR is OPEN still blocks

Results: 33 passed, 0 failed, 0 skipped
```

`bash scripts/lint-shell-scripts.sh` reports 0 errors (the 9 warnings are pre-existing, all in `macos-plugin`).

Fixes #2351


---
_Generated by [Claude Code](https://claude.ai/code/session_01SF5pG1HpfhAgoLRaD7yWnG)_