### PR TITLE
fix(git-plugin): cut branches from origin/main in git-issue, not local main

### DIFF
--- a/git-plugin/skills/git-issue/SKILL.md
+++ b/git-plugin/skills/git-issue/SKILL.md
@@ -1,8 +1,8 @@
 ---
 created: 2025-12-16
-modified: 2026-06-15
-reviewed: 2026-06-15
-allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git switch *), Bash(git pull *), Bash(git stash *), Bash(gh issue *), Bash(gh pr *), Bash(gh repo *), Bash(gh label *), Bash(gh api *), Bash(pre-commit *), Read, Edit, Write, Grep, Glob, TodoWrite, AskUserQuestion, Task, mcp__github__create_pull_request, mcp__github__issue_read, mcp__github__list_issues
+modified: 2026-08-13
+reviewed: 2026-08-13
+allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git switch *), Bash(git fetch *), Bash(git pull *), Bash(git stash *), Bash(gh issue *), Bash(gh pr *), Bash(gh repo *), Bash(gh label *), Bash(gh api *), Bash(pre-commit *), Read, Edit, Write, Grep, Glob, TodoWrite, AskUserQuestion, Task, mcp__github__create_pull_request, mcp__github__issue_read, mcp__github__list_issues
 description: "Process GitHub issues end-to-end with TDD and parallel work. Use when asked to work on an issue, fix issue #N, pick issues to tackle, or batch-process several."
 args: "[issues... (number | #N | URL)] [--auto] [--filter <label>] [--limit <n>] [--parallel] [--labels <l1,l2>]"
 argument-hint: "[issues... (number | #N | URL)] [--auto] [--filter <label>] [--limit <n>] [--parallel] [--labels <l1,l2>]"
@@ -41,7 +41,7 @@ Parse these parameters from the command:
 
 ## Your Task
 
-Process GitHub issues using a TDD workflow with the **main-branch development pattern**.
+Process GitHub issues using a TDD workflow, cutting each issue's branch **from `origin/main`**.
 
 ---
 
@@ -223,7 +223,7 @@ Recommended: Run Groups 1, 2, 3 in parallel (3 agents)
 ### Step 1: Prepare Working Directory
 
 1. **Ensure clean working directory** (commit or stash if needed)
-2. **Switch to main and pull latest**: `git switch main && git pull`
+2. **Fetch the remote**: `git fetch origin` — never rely on local `main` being current
 
 ### Step 2: For Each Issue (or Parallel Group)
 
@@ -233,6 +233,11 @@ Recommended: Run Groups 1, 2, 3 in parallel (3 agents)
 2. **Capture issue labels** for later PR creation
 3. **Identify requirements** and acceptance criteria
 4. **Plan the implementation** approach
+5. **Cut the branch from `origin/main`**: `git switch -c fix/issue-$N origin/main`
+
+Base the branch on `origin/main`, never on local `main` — local `main` may carry
+unpushed commits that would ride into this issue's PR (see
+`git-branch-pr-workflow` § "Branch Comparison: Always Use origin/main").
 
 #### TDD Workflow
 
@@ -253,7 +258,7 @@ Recommended: Run Groups 1, 2, 3 in parallel (3 agents)
 
 1. **Stage changes**: `git add -u` and `git add <new-files>`
 2. **Run pre-commit** if configured
-3. **Commit on main** with message format:
+3. **Commit on the issue branch** with message format:
 
 ```
 <type>: <description>
@@ -263,7 +268,8 @@ Recommended: Run Groups 1, 2, 3 in parallel (3 agents)
 Fixes #N
 ```
 
-4. **Push to remote issue branch**: `git push origin main:fix/issue-$N`
+4. **Verify the branch carries only this issue's commits**: `git log --oneline origin/main..HEAD`
+5. **Push the issue branch**: `git push -u origin fix/issue-$N`
 
 #### Create PR
 
@@ -286,7 +292,8 @@ When `--parallel` is specified:
 2. For each parallel group, spawn a Task agent:
 
 ```
-Agent tool with subagent_type: "general-purpose", prompt: "Process issue #N with TDD workflow..."
+Agent tool with subagent_type: "general-purpose", prompt: "Process issue #N with TDD workflow.
+Cut the branch with `git fetch origin && git switch -c fix/issue-N origin/main` — never from local main..."
 ```
 
 3. Wait for all agents to complete
@@ -320,19 +327,29 @@ Fixes #125
 
 ---
 
-## Main-Branch Development Pattern
+## Branch-From-Remote Pattern
+
+Cut every issue branch from `origin/main`, never from local `main`:
 
 ```bash
-# All work stays on main
-git switch main && git pull
+git fetch origin
+git switch -c fix/issue-$N origin/main
 
-# ... make changes, commit on main ...
+# ... make changes, commit on the branch ...
 
-git push origin main:fix/issue-$N    # Push to remote feature branch
+git log --oneline origin/main..HEAD    # verify: only your commit(s)
+git push -u origin fix/issue-$N
 
 # Create PR: head=fix/issue-$N, base=main
-# Continue on main for next issue
+# Next issue: git fetch origin && git switch -c fix/issue-$M origin/main
 ```
+
+**Why not commit on local `main`:** unpushed commits on local `main` ride into
+the next branch cut from it and land in an unrelated PR — visible only in the
+file list once squashed. Basing on `origin/main` makes the local `main` state
+irrelevant. This matches `git-branch-pr-workflow` § "Branch Comparison: Always
+Use origin/main" (rule 3: *base PRs on `origin/main` when creating branches*)
+and `~/.claude/rules/git-hazards.md` #2.
 
 ---
 


### PR DESCRIPTION
## Problem

`git-plugin/skills/git-issue/SKILL.md` prescribed committing the fix **on local `main`** and pushing to a remote feature branch:

> ### Step 1: Prepare Working Directory
> 2. **Switch to main and pull latest**: `git switch main && git pull`

> ## Main-Branch Development Pattern
> ```bash
> # All work stays on main
> git switch main && git pull
>
> # ... make changes, commit on main ...
>
> git push origin main:fix/issue-$N    # Push to remote feature branch
> ```

That contradicts `~/.claude/rules/git-hazards.md` #2 — *"Unpushed commits on local `main` ride into new branches. **Rule**: cut PR branches from the remote, always: `git fetch origin && git switch -c <branch> origin/main`."*

The skill's pattern produces exactly the state that rule exists to prevent: after the commit, local `main` is ahead of `origin/main` by the fix, and the next branch cut from local `main` inherits it and bundles it into an unrelated PR — visible only in the file list once squashed. Nothing in the skill returned `main` to `origin/main` afterwards.

It also compounds `shared-checkout-branch-isolation`: `main` is the branch a coworker session is most likely to be sitting on, so it is the maximally contended place to commit.

## Change

One file: `git-plugin/skills/git-issue/SKILL.md`.

| Site | Before | After |
|---|---|---|
| `## Your Task` | "with the **main-branch development pattern**" | "cutting each issue's branch **from `origin/main`**" |
| Step 1 | `git switch main && git pull` | `git fetch origin` — never rely on local `main` being current |
| Step 2, Standard Flow | (no branch step) | new step 5: `git switch -c fix/issue-$N origin/main` |
| Commit and Push | "Commit on main" → `git push origin main:fix/issue-$N` | commit on the issue branch → `git log --oneline origin/main..HEAD` → `git push -u origin fix/issue-$N` |
| `## Main-Branch Development Pattern` | main-branch recipe | renamed `## Branch-From-Remote Pattern`, carrying the issue's suggested snippet verbatim |
| Step 3, parallel dispatch | generic prompt | prompt now tells each agent to branch from `origin/main` |
| frontmatter `allowed-tools` | no `git fetch` | added `Bash(git fetch *)` (the new pattern needs it) |

The replacement pattern is the issue's suggested fix as written:

```bash
git fetch origin
git switch -c fix/issue-$N origin/main
# ... make changes, commit ...
git log --oneline origin/main..HEAD    # verify: only your commit(s)
git push -u origin fix/issue-$N
```

## Consistency with the sibling skill

Per the acceptance criteria, the wording is aligned with `git-branch-pr-workflow` § *"Branch Comparison: Always Use origin/main"*, whose **rule 3** is literally *"Base PRs on `origin/main` when creating branches: `git switch -c feat/foo origin/main`"*, and whose verification form is `git fetch origin main` + `git log origin/main..HEAD`. Both the new Step 2 note and the renamed section cite that section by name so the two skills stay tied together.

**One caveat worth flagging (not fixed here, out of scope):** `git-branch-pr-workflow` is not *itself* fully consistent. Alongside the origin/main rules above it still carries a `## Main-Branch Development (Preferred)` section (`git push origin main:feat/auth-oauth2`) and a "Main-branch development … no local feature branches needed" line. So this PR makes `git-issue` consistent with the sibling's **origin/main** guidance while the sibling's own main-branch sections remain a separate contradiction. Happy to file a follow-up for `git-branch-pr-workflow` if you want the plugin fully reconciled.

## Verification

Documentation/prose only — no executable script changed, so there is nothing for `just lint-shell` to cover here. Instead:

- `scripts/lint-context-commands.sh` → `All context commands OK`
- `scripts/plugin-compliance-check.sh git-plugin` → no ❌; only pre-existing ⚠️ (size/description WARN bands that predate this change)
- `scripts/check-branch-containment-guidance.sh` → `STATUS=OK ISSUE_COUNT=0` (49 git-plugin files scanned)
- `scripts/check-unused-bash-grant.sh --strict` → `STATUS=OK ISSUE_COUNT=0`
- Grepped the whole file for `switch main` / `git pull` on main / any remaining "main as a working branch" reference: none left; the only surviving `main` mentions are `origin/main`, the PR `base: main`, and the prose explaining why local `main` is the hazard.

Fixes #2375

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XauNJSTERATYqQsAxdEi1b)_