### PR TITLE
docs(comfyui-plugin): record persistent per-publisher Discord thread convention

### DIFF
--- a/comfyui-plugin/skills/comfy-registry-lifecycle/SKILL.md
+++ b/comfyui-plugin/skills/comfy-registry-lifecycle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-07-07
-modified: 2026-08-07
+modified: 2026-08-13
 reviewed: 2026-07-07
 name: comfy-registry-lifecycle
 description: >-
@@ -286,10 +286,18 @@ Comfy-Org/ComfyUI-Manager#2927):
     trimmed — allowlist it in the hygiene test with a justification and
     cite it in the appeal.
 - **Appeal via Discord first — it's processed faster.** Post the
-  re-review request as a message in the Comfy Org Discord
-  `SUPPORT/#security-review-council` channel (no markdown tables, keep
-  under the 2,000-char message limit); use a GitHub issue on
-  `Comfy-Org/registry-backend` as the durable record and link the two.
+  re-review request in a **persistent per-publisher thread** (e.g.
+  `Publisher <name> — re-review`) in the Comfy Org Discord
+  `SUPPORT/#security-review-council` channel, not as a loose channel
+  message: the channel is a firehose of automated flagged-release
+  notifications, so a bare message is unfindable within hours and a
+  multi-round appeal (a reply days later, the next release re-flagged)
+  loses its history. Reuse the same thread for every appeal. Keep the
+  message under the 2,000-char limit with no markdown tables — fitting a
+  multi-pack appeal usually costs several trim passes, so put the
+  version-ID table and per-finding detail in a GitHub issue on
+  `Comfy-Org/registry-backend` as the durable record and have the
+  Discord message link to it rather than duplicate it.
 - **Then verify by publishing**: a republish re-runs the scan, so the
   definitive test of any fix is the next release's verdict via
   `api.comfy.org/nodes/<id>/versions?include_status_reason=true`.


### PR DESCRIPTION
## Problem

`comfyui-plugin/skills/comfy-registry-lifecycle/SKILL.md`'s appeal bullet said to post the re-review request **as a message** in the Comfy Org Discord `SUPPORT/#security-review-council` channel. From #2348:

> In practice a bare message is hard to find again: that channel carries a continuous stream of automated flagged-release notifications, so an appeal scrolls away within hours and follow-up replies are unfindable.
>
> This matters because appeals are not one-shot: a re-review request gets a reply days later, the next release re-flags, and the same conversation continues. Without a stable thread each round starts from nothing.

Observed 2026-08 while appealing 13 flagged packs. The same session also found that the 2,000-char limit cost **four** trim passes (2,649 → 1,974 chars), which is what motivates splitting the version-ID table out to the GitHub issue instead of duplicating it in Discord.

## Change

One bullet, in the "Flagged versions" section. Before:

```
- **Appeal via Discord first — it's processed faster.** Post the
  re-review request as a message in the Comfy Org Discord
  `SUPPORT/#security-review-council` channel (no markdown tables, keep
  under the 2,000-char message limit); use a GitHub issue on
  `Comfy-Org/registry-backend` as the durable record and link the two.
```

After:

```
- **Appeal via Discord first — it's processed faster.** Post the
  re-review request in a **persistent per-publisher thread** (e.g.
  `Publisher <name> — re-review`) in the Comfy Org Discord
  `SUPPORT/#security-review-council` channel, not as a loose channel
  message: the channel is a firehose of automated flagged-release
  notifications, so a bare message is unfindable within hours and a
  multi-round appeal (a reply days later, the next release re-flagged)
  loses its history. Reuse the same thread for every appeal. Keep the
  message under the 2,000-char limit with no markdown tables — fitting a
  multi-pack appeal usually costs several trim passes, so put the
  version-ID table and per-finding detail in a GitHub issue on
  `Comfy-Org/registry-backend` as the durable record and have the
  Discord message link to it rather than duplicate it.
```

Both constraints the skill already documented are **preserved, not replaced**: no markdown tables, and the 2,000-char message limit. The GitHub-issue-as-durable-record advice is kept and sharpened — it now says *what* belongs in the issue (the version-ID table, per-finding detail) and that Discord should link rather than duplicate.

`modified:` bumped to 2026-08-13. Nothing else in the skill or plugin is touched.

## Verification

Pure skill-prose change — no script to test.

- `./scripts/plugin-compliance-check.sh comfyui-plugin` → overall ⚠️, **no ❌**, exit 0. The two ⚠️ columns (Descriptions, Size) are pre-existing across the whole plugin: 8 skills including this one are over the 200-char description band, and 11 skills including this one are over the 10,000-char body advisory. This skill was already at ~22.2k chars before the edit (ceiling is 26,000), so no threshold is newly crossed.
- `./scripts/lint-context-commands.sh` → `All context commands OK`.
- No compliance guard pins tokens in `comfy-registry-lifecycle` (`grep comfy-registry-lifecycle scripts/plugin-compliance-check.sh` → no match), so no guard needed repointing.

Fixes #2348


---
_Generated by [Claude Code](https://claude.ai/code/session_01XauNJSTERATYqQsAxdEi1b)_