### PR TITLE
docs: refresh plugin catalog counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ the rules, skills, and hooks that embody it.
 | Plugin | Skills | Description |
 |--------|--------|-------------|
 | **code-quality-plugin** | 15 | Code review, refactoring, linting, static analysis, debugging methodology |
-| **software-design-plugin** | 5 | Software design methodology - deep modules, design by contract, GoF pattern selection, legacy seams, pseudocode |
+| **software-design-plugin** | 6 | Software design methodology - deep modules, design by contract, GoF pattern selection, legacy seams, pseudocode |
 | **evaluate-plugin** | 7 + 3 agents | Skill evaluation and benchmarking - test effectiveness, grade results |
 | **codebase-attributes-plugin** | 3 | Structured codebase health attributes with severity-based agent routing |
 | **feedback-plugin** | 1 | Session feedback analysis - capture skill bugs and enhancements as issues |

--- a/docs/PLUGIN-MAP.md
+++ b/docs/PLUGIN-MAP.md
@@ -47,7 +47,7 @@ Automated quality enforcement.
 |--------|--------|---------|
 | testing-plugin | 17 | Test execution, TDD, Vitest, Playwright, Playwright CLI, mutation testing |
 | code-quality-plugin | 15 | Review, refactoring, linting, ast-grep, debugging, silent degradation, dead code, dep audit, test quality, complexity, bulk-sweep classification |
-| software-design-plugin | 5 | Deep modules, design by contract, GoF pattern selection, legacy seams, design by pseudocode |
+| software-design-plugin | 6 | Deep modules, design by contract, GoF pattern selection, legacy seams, design by pseudocode |
 | documentation-plugin | 5 | API docs, README generation, knowledge graphs |
 | evaluate-plugin | 7 + 3 agents | Skill evaluation, benchmarking, quality improvement |
 


### PR DESCRIPTION
## Problem

`scripts/check-docs-index.sh` (run by the CI `test` job, via `test-check-docs-index.sh`'s "real repo is clean" assertion) was failing on every PR in this repo, including two unrelated PRs opened in this same run (#2376/#2377):

```
STATUS=WARN
ISSUE_COUNT=2
ISSUES:
  - SEVERITY=WARN TYPE=doc_count_drift MSG=README.md:103 states software-design-plugin has 5 skills but 6 exist on disk
  - SEVERITY=WARN TYPE=doc_count_drift MSG=PLUGIN-MAP.md:50 states software-design-plugin has 5 skills but 6 exist on disk
```

`software-design-plugin/skills/` has 6 skills on disk (`design-by-contract`, `design-deep-modules`, `design-diy-vs-dependency`, `design-legacy-seams`, `design-patterns`, `design-pseudocode`) — a 6th skill (`design-diy-vs-dependency`) landed without its README.md/PLUGIN-MAP.md counts being bumped. I verified this reproduces identically on a clean `origin/main` checkout, so it's pre-existing drift, not caused by any in-flight PR.

## Change

Two one-line count corrections, via the repo's own `docs-refresh` skill:

- `README.md:103` — software-design-plugin skill count `5` → `6`
- `docs/PLUGIN-MAP.md:50` — software-design-plugin skill count `5` → `6`

No d2 diagram change needed — `software-design-plugin` doesn't have a node in `docs/diagrams/plugin-relationships.d2`. No README intro-line total change needed — it already states "400+ skills" and `TOTAL_SKILLS=409`, so 400 is still the correct rounded-down figure.

## Verification

```
$ bash scripts/check-docs-index.sh --strict
=== DOCS INDEX AUDIT ===
RULES_ON_DISK=45
RULES_IN_TABLE=45
MARKETPLACE_PLUGINS=44
TOTAL_SKILLS=409
TOTAL_AGENTS=21
DIAGRAM_NODES=33
RULES_CHECKED=45
STATUS=OK
ISSUE_COUNT=0
=== END DOCS INDEX AUDIT ===
exit=0
```

No `Fixes #` — this wasn't filed as an issue; found while diagnosing an unrelated CI failure on #2377.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XauNJSTERATYqQsAxdEi1b)_