### PR TITLE
fix(comfyui-plugin): scaffold standalone packs onto the Touch Tools hub

### DIFF
--- a/comfyui-plugin/skills/comfyui-node-scaffold/SKILL.md
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/SKILL.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-06-04
-modified: 2026-08-07
+modified: 2026-08-13
 reviewed: 2026-07-29
 name: comfyui-node-scaffold
 description: >-
@@ -81,7 +81,9 @@ is not proof of its option source" for the overlap gate.
 
 **Decision rule:** `frontend`/`backend` **with** `--widgets` for a per-widget
 modal; `frontend`/`backend` **without** `--widgets` for a standalone modal opened
-from the toolbar/command palette; `gesture` when the interaction is on the
+from the shared **Touch Tools** hub (the family's one action-bar button — a
+scaffolded pack contributes a chooser row, never a button of its own); `gesture`
+when the interaction is on the
 canvas/node frame itself (no widget to hook); `shim` when the pack only injects
 scoped CSS / registers commands to paper over an upstream frontend bug (no modal,
 no widget). Add `backend` only when the feature
@@ -130,6 +132,10 @@ Then implement, and wire up infra:
 1. **Implement the modal** in `src/index.ts` — tune `TARGET_WIDGETS` and replace
    the `openPicker` stub with the real modal body (`import { fuzzyRank } from
    "@laurigates/comfy-modal-kit"` for search, `openModalShell` for the dialog).
+   For the standalone-modal shape, keep the Touch Tools hub wiring intact and
+   swap the placeholder `pi pi-th-large` icon for a fitting PrimeIcon — see
+   [references/variants.md](references/variants.md) § "The Touch Tools hub
+   contract".
    For the `backend` variant, fill in `<module>.py`'s node + endpoints; widen
    `ALLOWED_EXTENSIONS` explicitly for any new file type read off disk. For the
    `gesture` variant, tune the pinch layer

--- a/comfyui-plugin/skills/comfyui-node-scaffold/references/variants.md
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/references/variants.md
@@ -10,14 +10,36 @@ the `gesture` and `shim` skeletons actually contain.
 (`frontend` / `backend`), passing `--widgets a,b` emits the **widget-intercept**
 `src/index.ts` (`TARGET_WIDGETS` + `openPicker` + `widget.onPointerDown`).
 **Omitting `--widgets`** emits a **standalone-modal** `src/index.ts` instead — a
-`registerExtension` skeleton with an `actionBarButtons` entry + a
-`command`/`menuCommand` that calls an exported `openShell()` (no `TARGET_WIDGETS`,
-no per-widget hook). Use the standalone skeleton for a manager / dashboard /
-gallery-actions panel whose modal is launched from the app chrome rather than a
-node widget (e.g. comfyui-touch-manager). It still imports the modal kit, and it
+`registerExtension` skeleton wired to the **Touch Tools hub** via the kit's
+`makeHubEntry` + `installHubButton` + `registerHubEntry`, calling an exported
+`openShell()` (no `TARGET_WIDGETS`, no per-widget hook). Use the standalone
+skeleton for a manager / dashboard / gallery-actions panel whose modal is
+launched from the app chrome rather than a node widget (e.g.
+comfyui-touch-manager). It still imports the modal kit, and it
 ships a **jsdom modal-mount smoke test** (`jsdom` added to `devDependencies`)
 that asserts `openShell()` populates the modal body — the empty-modal gap that
 otherwise passes pure-helper unit tests.
+
+### The Touch Tools hub contract (standalone modals)
+
+The family owns **exactly one** action-bar button — the Touch Tools hub — and
+every chrome-launched pack contributes a *row* to the chooser behind it rather
+than a button of its own. The kit builds the `registerExtension` fields so the
+conventions cannot drift (comfy-modal-kit ADR-0002, after three packs hand-rolled
+them three ways: three menu paths, three command-id casings, three icon systems).
+Three rules the generated skeleton already follows — keep them when you edit it:
+
+| Rule | Why |
+|---|---|
+| Spread `...entry` and `...installHubButton()` as **siblings**; never hand-merge | They are key-disjoint by design. A second spread carrying `commands` orphans the pack's command: the menu row vanishes, and a keybinding on the orphaned id is re-added at boot with no `isRegistered` gate, squatting the combo and throwing on press |
+| Call `registerHubEntry()` from **`setup()`**, not module scope | Every extension file is imported regardless of the disable list, but only enabled extensions get `setup()` — module-scope registration lists packs the user has **disabled** |
+| Icons are **PrimeIcons** (`pi pi-*`) | The only format guaranteed to render for a runtime-loaded extension. An iconify/lucide class renders nothing; no pack in the family uses one |
+
+Settings belong under the family's shared `Touch Tools` category
+(`FAMILY_SETTINGS_CATEGORY`). Give each setting a **three-element** `category`
+array with a distinct third element: two settings sharing an identical full
+array silently collapse into one — the first vanishes from the dialog while its
+value stays stored.
 
 ## The gesture variant
 

--- a/comfyui-plugin/skills/comfyui-node-scaffold/scaffold.py
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/scaffold.py
@@ -75,7 +75,12 @@ PUBLISHER_DEFAULT = "laurigates"
 # A caret range on a 0.x version is minor-locked (`^0.10.0` == `>=0.10.0
 # <0.11.0`), so a kit minor is a deliberate bump here, not a silent float.
 MODAL_KIT_PKG = "@laurigates/comfy-modal-kit"
-MODAL_KIT_VERSION = "^0.10.0"
+# 0.12.0, not 0.10.x: the standalone-modal template registers with the Touch
+# Tools hub (`makeHubEntry` / `installHubButton` / `registerHubEntry`), which
+# landed in 0.11.0. Because the caret is minor-locked on 0.x, `^0.10.0` could
+# not resolve the hub AT ALL — a pack scaffolded against it fails to typecheck
+# on those imports.
+MODAL_KIT_VERSION = "^0.12.0"
 
 # Pinned tool versions — kept in ONE place so the biome pin can never drift
 # between biome.json, the pre-commit hook, CI, and the justfile. The previous
@@ -486,30 +491,32 @@ INDEX_TS_STANDALONE = """\
 //
 // TypeScript source in `src/`, built to ESM via `bun build` and emitted to
 // `web/dist/` (served at /extensions/@@NAME@@/index.js — the pack directory
-// name IS the URL segment). Do not rename the pack dir without syncing
-// EXT_NAME below (used for log prefixes and any /@@PY_MODULE@@/ fetches).
-// See ADR-0001.
+// name IS the URL segment). Renaming the pack dir also changes any
+// /@@PY_MODULE@@/ fetch path you add below. See ADR-0001.
 //
 // Pattern ("the standalone-modal vein"): instead of intercepting a per-node
-// widget, this pack opens a STANDALONE modal from the app chrome — an action-bar
-// button plus a command (palette/hotkey-bindable) and a menu entry. There are
-// NO target widgets to hook (a manager, dashboard, or gallery-actions panel),
-// so there is no TARGET_WIDGETS / onPointerDown wrapping. Additive + mobile-first.
+// widget, this pack opens a STANDALONE modal from the app chrome — a command
+// (palette/hotkey-bindable), a menu entry under Extensions > Touch Tools, and a
+// row in the shared Touch Tools chooser. There are NO target widgets to hook (a
+// manager, dashboard, or gallery-actions panel), so there is no TARGET_WIDGETS /
+// onPointerDown wrapping. Additive + mobile-first.
 //
 // The shared modal primitives come from @@MODAL_KIT_PKG@@. They are NOT copied
 // into this pack — `bun build` INLINES the imported code into web/dist. To add
 // fuzzy search to the modal, import the matcher from the same package:
 //   import { fuzzyRank, highlightMatches } from "@@MODAL_KIT_PKG@@";
 //   fuzzyRank(query, [primaryField, ...otherFields]) -> { score, primaryMatches } | null
-import { openModalShell } from "@@MODAL_KIT_PKG@@";
+import {
+  installHubButton,
+  makeHubEntry,
+  openModalShell,
+  registerHubEntry,
+} from "@@MODAL_KIT_PKG@@";
 // ComfyUI serves its frontend API at runtime from `/scripts/app.js`. The
 // emitted import string stays `/scripts/app.js` (bun's `--external '/scripts/*'`
 // keeps it unbundled); the type is supplied via a `paths` mapping in
 // tsconfig.json that points the import at `src/comfyui-shims.d.ts`. See ADR-0001.
 import { app } from "/scripts/app.js";
-
-const EXT_NAME = "@@NAME@@";
-const OPEN_COMMAND_ID = "@@SHORT@@.open";
 
 // ============================================================
 // Modal
@@ -541,45 +548,49 @@ export function openShell(): ReturnType<typeof openModalShell> {
   return modal;
 }
 
-function openShellSafe(): void {
-  try {
-    openShell();
-  } catch (e) {
-    console.warn(`[${EXT_NAME}] open failed`, e);
-  }
-}
-
 // ============================================================
 // Wiring — launch the modal from the app chrome, not a node widget
 // ============================================================
 
+// The family's chrome entry point, built by the kit rather than hand-written.
+// makeHubEntry bakes in the conventions ADR-0002 fixed after three packs each
+// hand-rolled these fields three different ways: the shared submenu
+// (Extensions > Touch Tools), kebab `<short-name>.<action>` command ids,
+// PrimeIcons — the ONLY icon format guaranteed to render for a runtime-loaded
+// extension — and one safe-open boundary so a throwing opener becomes a
+// copyable error toast instead of an exception inside ComfyUI's dispatch.
+//
+// Pick an icon from https://primeng.org/icons (`pi pi-*`). Do NOT use an
+// iconify/lucide class here: nothing in the family does, and it will not render.
+const entry = makeHubEntry({
+  id: "@@SHORT@@.open",
+  label: "@@DISPLAY@@",
+  icon: "pi pi-th-large",
+  tooltip: "Open @@DISPLAY@@",
+  description: "@@DESC@@",
+  failSummary: "@@DISPLAY@@ failed to open",
+  open: openShell,
+});
+
 app.registerExtension({
   name: "comfy.@@SHORT@@",
-  // An action-bar button in the top bar. `icon` is required — swap the lucide
-  // class for one that fits the pack (see comfyui-frontend-types for the set).
-  actionBarButtons: [
-    {
-      icon: "icon-[lucide--layout-dashboard]",
-      label: "@@DISPLAY@@",
-      tooltip: "Open @@DISPLAY@@",
-      onClick: openShellSafe,
-    },
-  ],
-  // A command (command palette / hotkey-bindable) that opens the same modal.
-  commands: [
-    {
-      id: OPEN_COMMAND_ID,
-      label: "Open @@DISPLAY@@",
-      function: openShellSafe,
-    },
-  ],
-  // A menu-bar entry pointing at the command above.
-  menuCommands: [
-    {
-      path: ["Extensions", "@@DISPLAY@@"],
-      commands: [OPEN_COMMAND_ID],
-    },
-  ],
+  // TWO SIBLING SPREADS, and their key-disjointness is the guarantee — do NOT
+  // hand-merge the arrays. makeHubEntry returns only `commands` / `menuCommands`
+  // (plus the inert `hubEntry` field); installHubButton returns only
+  // `actionBarButtons`, or `{}` once another inlined kit copy has already
+  // claimed the single family button. The family owns exactly ONE action-bar
+  // button — the Touch Tools hub — so adding a per-pack button here would be a
+  // second one competing for the same scarce corner on a phone.
+  ...entry,
+  ...installHubButton(),
+  setup() {
+    // Registered HERE, not at module evaluation. Every extension file is
+    // imported regardless of the disable list (extensionService.ts:55-67) while
+    // invokeExtensionsAsync only iterates `enabledExtensions` (:214) — so
+    // registering at module scope would list this pack in the chooser even when
+    // the user has disabled it.
+    registerHubEntry(entry.hubEntry);
+  },
 });
 """
 
@@ -2878,14 +2889,16 @@ def build_file_map(
         )
     elif standalone:
         ctx["DEP_FLOOR_NOTE"] = (
-            "Floor tied to the registerExtension action-bar/command API."
+            "Floor tied to the Touch Tools hub API (`makeHubEntry` / "
+            "`installHubButton` / `registerHubEntry`), added in kit 0.11.0."
         )
         ctx["WHAT_DESC"] = "the modal it opens and how the user launches it"
         ctx["VEIN"] = (
             "A mobile-first ComfyUI usability pack in the *standalone-modal* vein: "
             "instead of intercepting a per-node widget, a frontend extension opens "
-            "a STANDALONE modal from the app chrome — an action-bar button plus a "
-            "command (palette/hotkey-bindable) and a menu entry. There are **no "
+            "a STANDALONE modal from the app chrome — a command "
+            "(palette/hotkey-bindable), a menu entry under Extensions > Touch "
+            "Tools, and a row in the shared Touch Tools chooser. There are **no "
             "target widgets to hook** (a manager, dashboard, or gallery-actions "
             "panel), so there is no `TARGET_WIDGETS` / `onPointerDown` wrapping. "
             "The modal is **touch-first** (16px inputs to avoid iOS zoom, big tap "
@@ -2895,13 +2908,18 @@ def build_file_map(
             "exported so the jsdom mount test can prove the modal body renders."
         )
         ctx["EXT_ROW_DESC"] = (
-            "The extension: action-bar/command launcher + modal (consumes the kit)."
+            "The extension: Touch Tools hub entry + modal (consumes the kit)."
         )
         ctx["HOOK_RULE"] = (
-            "**Launcher API is version-sensitive.** The modal opens from "
-            "`registerExtension`'s `actionBarButtons` / `commands` / `menuCommands`. "
-            "If a future frontend renames or drops one, keep at least one launcher "
-            "(button OR command) wired so the modal stays reachable."
+            "**Launcher fields come from the kit, not by hand.** `makeHubEntry` "
+            "builds `commands` / `menuCommands`; `installHubButton` builds the "
+            "family's single `actionBarButtons` entry. The two results are "
+            "KEY-DISJOINT and must be spread as siblings, never hand-merged — a "
+            "second spread carrying `commands` would orphan this pack's command "
+            "(the menu row vanishes, and a user keybinding on the orphaned id is "
+            "re-added at boot with no isRegistered gate, squatting its combo and "
+            "throwing on press). Do not add a per-pack action-bar button: the "
+            "family owns exactly one, the Touch Tools hub."
         )
         ctx["FAMILY_BLURB"] = (
             "> touch-friendly HTML modals launched from the toolbar/command palette\n"


### PR DESCRIPTION
## What

Rewires the scaffold's **standalone-modal** variant onto the shared **Touch Tools hub**, and bumps the `comfy-modal-kit` pin from `^0.10.0` to `^0.12.0`.

## Why

The template was pre-ADR-0002 — it hand-wrote `actionBarButtons` / `commands` / `menuCommands`, which is precisely the drift [comfy-modal-kit ADR-0002](https://github.com/laurigates/comfy-modal-kit/blob/main/docs/blueprint/adrs/0002-family-launcher-conventions-and-shell-overlay.md) was written to eliminate. Checked against `origin/main` on all 13 packs, a pack scaffolded today shipped three defects:

| Emitted before | The live fleet | Consequence |
|---|---|---|
| Its own `actionBarButtons` entry | Family owns exactly ONE button — the Touch Tools hub (kit 0.11.0) | A second button competing for the same scarce corner on a phone |
| `icon: "icon-[lucide--layout-dashboard]"` | **0 of 13** packs use lucide; kit documents PrimeIcons as the only format guaranteed to render for a runtime-loaded extension | Button renders iconless |
| `menuCommands` path `["Extensions", "<Display>"]` | `FAMILY_MENU_PATH = ["Extensions", "Touch Tools"]` | Per-pack menu path — an ADR-0002 driver |

The pin was a hard blocker on its own: a caret on a `0.x` version is **minor-locked**, so `^0.10.0` could not resolve the hub *at all*. The generator's own pin comment already frames a kit minor as a deliberate bump.

`installHubButton()` returns `{}` for every caller after the first, so this is safe with any mix of installed packs.

## How

- `makeHubEntry` + `installHubButton` spread as **siblings** (key-disjoint by design — hand-merging orphans the pack's command, vanishing the menu row and leaving a keybinding that squats its combo and throws on press).
- `registerHubEntry` called from `setup()`, not module scope, so a **disabled** pack does not appear in the chooser.
- Drops the hand-rolled `openShellSafe` (the kit's safeOpen boundary replaces it) and the then-unused `EXT_NAME` — `noUnusedLocals: true` would have failed the generated pack.
- Documents the contract in `references/variants.md` § "The Touch Tools hub contract", including the settings-category collapse trap (two settings sharing an identical full `category` array silently collapse — the first vanishes while its value stays stored).

## Verification

Generated a standalone pack against kit 0.12.0 and ran the real gates:

- `bun install` → resolves `@laurigates/comfy-modal-kit@0.12.0`
- `bun run typecheck` → **exit 0**, and no cast needed at the registration boundary on the `~1.45.0` frontend-types pin
- `bun run build` → bundles the hub: **8** `Touch Tools` hits, **1** `cmk-hub-style`, **0** `lucide` in `web/dist/index.js`
- `bun run test` → green

All four skill suites pass: standalone **9**, shim **13**, finishing-pass **64**, fleet-drift **58**.

Three `tests/test_publish_hygiene.py` failures seen while verifying are a **harness artifact, not a regression** — an unmodified `origin/main` scaffold fails the same three identically (they shell out to `git ls-files` and expect artwork, and the temp dir was neither a git repo nor had icons).

## Not in scope

The gesture variant's stale pinch exemplar and two `fleet-policy.toml` reclassifications follow in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5JUEXaqdxurwjkvy7btFP
