### PR TITLE
chore(comfyui-plugin): reclassify a fleet-policy entry and record the gesture contract

### DIFF
--- a/comfyui-plugin/skills/comfyui-node-scaffold/SKILL.md
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/SKILL.md
@@ -76,7 +76,7 @@ is not proof of its option source" for the overlap gate.
 |---------|----------|-------|-----------|
 | `frontend` (default) | No Python needed — pure widget UX (seed/numeric keypad, prompt editor, tooltips, enum recipes). | Empty `NODE_CLASS_MAPPINGS`; widget-intercept modal in `src/index.ts`. Like sampler-info / touch-numeric. | **imports** the kit |
 | `backend` | Needs to read disk / serve thumbnails / add a node (model thumbnails, file listings). | Adds `<module>.py` (node + aiohttp endpoints, ComfyUI-bundled libs only) + a `tests/conftest.py` that stubs aiohttp/server so pytest is green. Like gallery-loader. | **imports** the kit |
-| `gesture` | The UX is a **canvas interaction**, not a widget — pinch/drag/long-press on nodes or groups (resize, move, region-box). | Empty `NODE_CLASS_MAPPINGS`; a canvas pointer layer in `src/index.ts` with exported pure geometry helpers. Like touch-resize. | **no kit** |
+| `gesture` | The UX is a **canvas interaction**, not a widget — drag/long-press on nodes or groups (resize, move, region-box). Must be recognizable on the **first** `pointerdown` — see the contract in variants.md. | Empty `NODE_CLASS_MAPPINGS`; a canvas pointer layer in `src/index.ts` with exported pure geometry helpers. Like touch-resize's corner grab-handles. | **no kit** |
 | `shim` | The pack's whole job is **injecting scoped CSS / registering commands** to paper over upstream frontend bugs — no modal, no widget hook. | Empty `NODE_CLASS_MAPPINGS`; a `SHIMS` registry in `src/index.ts` with `applyCssShim`/`removeCssShim`, one managed `<style>` per shim driven by a boolean setting, + a jsdom lifecycle smoke test. Like comfyui-touch-shim. | **no kit** |
 
 **Decision rule:** `frontend`/`backend` **with** `--widgets` for a per-widget
@@ -132,8 +132,12 @@ Then implement, and wire up infra:
    "@laurigates/comfy-modal-kit"` for search, `openModalShell` for the dialog).
    For the `backend` variant, fill in `<module>.py`'s node + endpoints; widen
    `ALLOWED_EXTENSIONS` explicitly for any new file type read off disk. For the
-   `gesture` variant, tune the pinch layer
-   (`selectedNodes`/`nodeScreenRect`/`scaledSize`). For the `shim` variant,
+   `gesture` variant, tune the pointer layer
+   (`selectedNodes`/`nodeScreenRect`/`scaledSize`) — and read the
+   first-`pointerdown` contract in
+   [references/variants.md](references/variants.md) before keeping the emitted
+   skeleton's two-finger pinch, which touch-resize removed as unfixable. For the
+   `shim` variant,
    replace the placeholder `SHIMS` entry — link the upstream issue, point the
    selector at a stable `data-testid`, keep each shim fail-soft.
 2. **Add the repo to `gitops/repositories.tf`** with `comfy_registry = true`

--- a/comfyui-plugin/skills/comfyui-node-scaffold/fleet-policy.toml
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/fleet-policy.toml
@@ -92,7 +92,7 @@ reason = "Vitest harness (jsdom/node environment, app.js alias). Divergence chan
 
 [files."biome.json"]
 policy = "managed"
-reason = "Lint/format rules AND the biome schema pin, which must stay in lockstep with .pre-commit-config.yaml, CI and the justfile."
+reason = "Lint/format rules AND the biome schema pin, which must stay in lockstep with .pre-commit-config.yaml, CI and the justfile. Stays managed BECAUSE of that pin. Measured 2026-08-13: the current 8/13 drift is pure formatter REFLOW (packs expand `\"complexity\": { ... }` across lines; the template collapses it) — the pin itself is a uniform 2.4.15 in 12 of 13 packs, with comfyui-touch-tooltips on 2.4.16 from the same Renovate bump noted under .pre-commit-config.yaml. Reflow is semantically inert: re-render the template through the pinned biome before assuming a rule changed."
 
 [files.".pre-commit-config.yaml"]
 policy = "managed"
@@ -101,10 +101,6 @@ reason = "Carries the biome pin that must match biome.json/CI. comfyui-touch-too
 [files."RELEASE-CHECKLIST.md"]
 policy = "managed"
 reason = "Release procedure. Currently 13/13 drift with the TEMPLATE ahead (packs predate the finishing-pass section) — the clearest template-leads case in the fleet."
-
-[files.".github/workflows/clear-autorelease-labels.yml"]
-policy = "managed"
-reason = "release-please label hygiene. No legitimate per-pack variation."
 
 [files.".github/workflows/publish.yml"]
 policy = "managed"
@@ -121,6 +117,10 @@ reason = "All 13 packs are ahead of the template (ubuntu-slim + release-please-a
 [files.".gitignore"]
 policy = "shared"
 reason = "Packs legitimately APPEND pack-specific entries (comfyui-sampler-info ignores tmp/ and docs/blueprint/work-orders/). Byte-identity would be a permanent false ERROR; fleet-consistency is the real invariant."
+
+[files.".github/workflows/clear-autorelease-labels.yml"]
+policy = "shared"
+reason = "Was `managed`, which reported 10 ERRORs for work the fleet had already done. Measured 2026-08-13: 9 of the 12 packs that carry the file have converted it to a thin caller for laurigates/.github's reusable-clear-autorelease-labels.yml; the 3 that still match the template byte-for-byte are the LAGGARDS, and comfyui-image-browser has none. The template is the old inline workflow_dispatch version, so this is a fleet-leads/back-port case exactly like release-please.yml above — not a per-pack divergence to reconcile. Under `shared` the 3 laggards plus the absent one surface as SHARED_MINORITY and the template gets one BACKPORT signal."
 
 [files.".gitattributes"]
 policy = "shared"

--- a/comfyui-plugin/skills/comfyui-node-scaffold/references/variants.md
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/references/variants.md
@@ -29,6 +29,49 @@ absent, so the native control always survives. Pure math (distance, hit-test,
 scale-clamp) lives in exported, unit-tested helpers; DOM/canvas wiring stays
 below them. It has **no** `@laurigates/comfy-modal-kit` dependency.
 
+### A gesture must be recognizable on the FIRST `pointerdown`
+
+**This is the design constraint for the whole variant, and the emitted skeleton
+does not yet satisfy it.** The skeleton still demonstrates a two-finger pinch;
+`comfyui-touch-resize` shipped exactly that, then removed it as unfixable in
+`feat!: replace the pinch gesture with corner grab-handles` (touch-resize #58).
+Treat the skeleton's pinch as a worked example to *replace*, not a pattern to
+extend — rewriting it is tracked upstream.
+
+The root cause is structural, not a bug that can be patched:
+
+> A pinch is not recognizable until the **second** finger lands, by which point
+> the first finger's `pointerdown` has already reached LiteGraph and opened a
+> node-drag or canvas-pan transaction.
+
+Everything else in that module existed only to paper over the half-open
+transaction — move-stream suppression, a wheel interceptor,
+`touchstart`/`touchmove` hedges, `touch-action: none`, a synthetic
+`pointercancel`, and manual clearing of six canvas-level drag flags. A target
+hit-tested on the **first** `pointerdown` is suppressed before LiteGraph opens
+any transaction, so there is no half-open state to recover.
+
+Two further traps that a pinch design walks into, both real:
+
+- **`Comfy.SimpleTouchSupport` keeps a module-global `touchCount`** (`+=` on
+  `touchstart`, `-=` on `touchend`) and patches `LGraphCanvas.processMouseDown`
+  to return early whenever it is truthy. Swallowing `touchstart` at window
+  capture while letting `touchend` through drives the count **negative** — also
+  truthy — and the canvas stops responding to taps until `resetTouchState` fires
+  on `visibilitychange`. That is the "recovers only by switching apps" symptom.
+  A pointer-events-only layer that never sets `touch-action` keeps the count
+  balanced by construction.
+- **Write geometry by assignment, never in-place** (`obj.size = [w, h]`, not
+  `obj.size[0] = w`). In-place mutation bypasses `LGraphNode`'s `pos`/`size`
+  setters and therefore the Vue layout store they feed
+  (`useLayoutMutations.moveNode`/`.resizeNode`).
+
+Place hit targets by **measurement, not guess**: body-corner handles land ~17px
+from the first input/output slots — inside the hit radius — so tapping a slot on
+a selected node grabs a handle instead of starting a link drag. Tracing the full
+outline instead puts them ~21px from the collapse toggle and ~45px from the
+slots. Cap the hit radius accordingly and record the ceiling in `CONFIG`.
+
 ## The shim variant
 
 The `shim` variant is a home for **small, individually-toggleable stopgap


### PR DESCRIPTION
## What

Two small corrections to `comfyui-node-scaffold`, both found while auditing the template against the live 13-pack fleet at `origin/main`.

## 1. `clear-autorelease-labels.yml` is fleet-led, not `managed`

It was `managed`, so the drift checker reported **10 ERRORs for work the fleet had already done**. Measured across all 13 packs:

| State | Packs |
|---|---|
| Thin caller for `laurigates/.github`'s reusable workflow | **9** |
| Old inline `workflow_dispatch` (== the template) | 3 |
| Absent | 1 (comfyui-image-browser) |

So the 9 are ahead and the 3 matching the template are the **laggards** — a fleet-leads/back-port case exactly like `release-please.yml` directly above it, not a per-pack divergence to reconcile.

Effect of moving it to `shared`:

```
before:  MANAGED_DRIFT x10                     (ERROR)
after:   SHARED_MINORITY x4 + BACKPORT x1      (WARN)
         managed drift 59 -> 49, issues 81 -> 76
```

`STATUS=ERROR` still holds on the genuine remaining drift (RELEASE-CHECKLIST.md 13/13 etc.), so nothing is masked, and image-browser's absence still surfaces as its own minority group.

`biome.json` **stays `managed`** — it carries the schema pin — but now records that the current 8/13 drift is pure formatter *reflow*: the pin is a uniform 2.4.15 in 12 of 13 packs (tooltips' 2.4.16 is the Renovate bump already noted under `.pre-commit-config.yaml`). That saves the next reader from re-deriving that a rule changed when none did.

## 2. The gesture variant's exemplar was stale — materially, not cosmetically

`SKILL.md` described the shape as **pinch** and named `comfyui-touch-resize` as the model. touch-resize *removed* the pinch in `feat!: replace the pinch gesture with corner grab-handles` (touch-resize#58) after root-causing it as unfixable **as designed**:

> A pinch is not recognizable until the SECOND finger lands, by which point the first finger's `pointerdown` has already reached LiteGraph and opened a node-drag or canvas-pan transaction.

Every hedge in that module — move-stream suppression, wheel interceptor, `touchstart`/`touchmove` hedges, `touch-action: none`, synthetic `pointercancel`, manual clearing of six canvas drag flags — existed only to paper over that half-open transaction. The scaffold still emits that shape, including a `stopImmediatePropagation()` to "suppress native pinch-zoom".

`references/variants.md` now carries the contract a gesture pack must meet:

- **Hit-test on the FIRST `pointerdown`**, so the event is suppressed before LiteGraph opens any transaction.
- The **`Comfy.SimpleTouchSupport` negative-`touchCount`** trap — swallowing `touchstart` while letting `touchend` through drives the module-global count negative (also truthy), and the canvas stops responding to taps until `visibilitychange`. That is the "recovers only by switching apps" symptom.
- **Assign geometry, never mutate in place** — `obj.size[0] = w` bypasses `LGraphNode`'s setters and the Vue layout store they feed.
- **Measure hit-target placement**: body-corner handles sit ~17px from the first slots (inside the hit radius), so they steal link drags; tracing the outline puts them ~45px away.

## Scope

Docs and policy only — **the generator still emits the pinch skeleton**, now flagged as a worked example to replace. Rewriting `INDEX_TS_GESTURE` onto a hit-tested single-pointer drag is tracked separately (#2383), deliberately kept out of this PR so it gets its own verification pass.

## Verification

All four skill suites pass: fleet-drift **58**, finishing-pass **64**, standalone **9**, shim **13**. The drift-count deltas above are from before/after runs of `check-fleet-drift.py`.

## Note on ordering

Branched from `main` independently of #2381, which touches nearby lines in `SKILL.md`. Either merge order works; if GitHub flags a conflict, merge #2381 first and this rebases cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5JUEXaqdxurwjkvy7btFP
