### PR TITLE
docs(comfyui-plugin): surface include_status_reason in an agentic-optimization row

### DIFF
--- a/comfyui-plugin/skills/comfy-registry-lifecycle/SKILL.md
+++ b/comfyui-plugin/skills/comfy-registry-lifecycle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-07-07
-modified: 2026-08-13
+modified: 2026-08-14
 reviewed: 2026-07-07
 name: comfy-registry-lifecycle
 description: >-
@@ -477,6 +477,12 @@ curl -sI https://raw.githubusercontent.com/<owner>/<repo>/main/icon.png   # 200 
 gh run list -R <owner>/<repo> --workflow=publish.yml -L1                  # release/success
 curl -s https://api.comfy.org/nodes/<id>/versions                        # new version present
 ```
+
+## Agentic Optimizations
+
+| Context | Command |
+|---|---|
+| Read scan verdicts | `curl -s "https://api.comfy.org/nodes/<id>/versions?include_status_reason=true" \| jq -c '.[] \| select(.status == "NodeVersionStatusFlagged") \| {version, status_reason}'` |
 
 ## Verify
 


### PR DESCRIPTION
## Summary

`comfy-registry-lifecycle` documents the undocumented public API param `?include_status_reason=true` in **prose** (security-scan section) — the one call that turns `NodeVersionStatusFlagged` from an opaque verdict into an actionable finding, since the publisher dashboard shows nothing and the `registry.comfy.org/admin/nodeversions` links are staff-only (403).

A reader skimming for a *command* can miss it. This adds an `## Agentic Optimizations` table (the skill had none) carrying that read at the altitude people actually look:

```
curl -s "https://api.comfy.org/nodes/<id>/versions?include_status_reason=true" | jq -c '.[] | select(.status == "NodeVersionStatusFlagged") | {version, status_reason}'
```

`-c` per `.claude/rules/agentic-optimization.md`; the `select` narrows to the versions that are actually stuck, since `status_reason` is `null` on Active ones.

## Preserved as-is

Per the issue's "Suggested Action", both load-bearing pieces are untouched:

- the **undocumented-param** note plus the explicit statement that the dashboard and admin links are dead ends for publishers
- **"Any finding flags the version — severity is irrelevant."** (the observed findings were `severity: low`, which would otherwise read as ignorable)

This is an addition, not a rewrite — the only other change is the `modified:` frontmatter date.

## Verification

- `just lint-compliance` — no new findings for this skill. Its two ⚠️ entries (description 214 chars; body size) are pre-existing, and the body is 22,938 chars, still well under the 26,000 ceiling. The single ❌ in the run is a pre-existing size error in `agent-patterns-plugin/parallel-agent-dispatch`, untouched here.
- The `jq` filter was executed against a fixture response (Active + Flagged versions) — parses clean, exit 0, emits only the flagged entry.
- Table separator style (`|---|---|`) matches the file's two existing tables; inline pipes escaped as `\|`.

Fixes #2346


---
_Generated by [Claude Code](https://claude.ai/code/session_01HVLpcUroVGndknVjQCqaeH)_