### PR TITLE
fix(comfyui-plugin): rewrite the gesture skeleton onto a first-pointerdown hit test

### DIFF
--- a/comfyui-plugin/skills/comfyui-node-scaffold/SKILL.md
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/SKILL.md
@@ -139,10 +139,10 @@ Then implement, and wire up infra:
    For the `backend` variant, fill in `<module>.py`'s node + endpoints; widen
    `ALLOWED_EXTENSIONS` explicitly for any new file type read off disk. For the
    `gesture` variant, tune the pointer layer
-   (`selectedNodes`/`nodeScreenRect`/`scaledSize`) — and read the
-   first-`pointerdown` contract in
-   [references/variants.md](references/variants.md) before keeping the emitted
-   skeleton's two-finger pinch, which touch-resize removed as unfixable. For the
+   (`selectedNodes`/`nodeScreenRect`/`hitHandle`/`resizedGeometry`) and
+   re-measure `CONFIG.handleHitRadius` against this pack's handle placement,
+   keeping the gesture recognizable on the first `pointerdown` per the contract
+   in [references/variants.md](references/variants.md). For the
    `shim` variant,
    replace the placeholder `SHIMS` entry — link the upstream issue, point the
    selector at a stable `data-testid`, keep each shim fail-soft.

--- a/comfyui-plugin/skills/comfyui-node-scaffold/references/invocation.md
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/references/invocation.md
@@ -22,7 +22,7 @@ python3 ${CLAUDE_SKILL_DIR}/scaffold.py --name comfyui-touch-manager --display "
 Canvas-gesture pack (resize/move/region — no widget, no modal, no kit):
 
 ```sh
-python3 ${CLAUDE_SKILL_DIR}/scaffold.py --name comfyui-touch-resize --display "Touch Resize" --desc "Selection-gated pinch-to-resize for ComfyUI nodes and groups on touch devices." --variant gesture
+python3 ${CLAUDE_SKILL_DIR}/scaffold.py --name comfyui-touch-resize --display "Touch Resize" --desc "Selection-gated corner grab-handle resize for ComfyUI nodes and groups on touch." --variant gesture
 ```
 
 CSS/shim pack (scoped `<style>` injection + commands — no modal, no widget, no kit):

--- a/comfyui-plugin/skills/comfyui-node-scaffold/references/variants.md
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/references/variants.md
@@ -43,24 +43,26 @@ value stays stored.
 
 ## The gesture variant
 
-The `gesture` variant intercepts the **canvas pointer stream** (capture-phase
-`pointerdown`/`move`/`up` on `app.canvas.canvas`), hit-tests against selected
-nodes/groups in screen space (via `ds.scale`/`ds.offset`), and acts only when
-the gesture lands on a selected target. It is a no-op when `app.canvas` is
-absent, so the native control always survives. Pure math (distance, hit-test,
-scale-clamp) lives in exported, unit-tested helpers; DOM/canvas wiring stays
-below them. It has **no** `@laurigates/comfy-modal-kit` dependency.
+The `gesture` variant intercepts the **canvas pointer stream** (window-capture
+`pointerdown`/`move`/`up`), hit-tests against selected nodes/groups in screen
+space (via `ds.scale`/`ds.offset`), and acts only when the **first**
+`pointerdown` lands on a grab target of a selected node. It is a no-op when
+`app.canvas` is absent, so the native control always survives. Pure math
+(handle placement, hit-test, clamped resize) lives in exported, unit-tested
+helpers; DOM/canvas wiring stays below them. It has **no**
+`@laurigates/comfy-modal-kit` dependency.
 
 ### A gesture must be recognizable on the FIRST `pointerdown`
 
 **This is the design constraint for the whole variant, and the emitted skeleton
-does not yet satisfy it.** The skeleton still demonstrates a two-finger pinch;
-`comfyui-touch-resize` shipped exactly that, then removed it as unfixable in
-`feat!: replace the pinch gesture with corner grab-handles` (touch-resize #58).
-Treat the skeleton's pinch as a worked example to *replace*, not a pattern to
-extend — rewriting it is tracked upstream.
+satisfies it**: `hitHandle()` classifies the very first `pointerdown` against
+the corner grab-handles of each selected node, and a hit is suppressed at
+window capture (`stopPropagation` + `preventDefault`) before the event can
+reach LiteGraph. `comfyui-touch-resize` reached the same shape the hard way —
+it shipped a two-finger pinch first and removed it in `feat!: replace the pinch
+gesture with corner grab-handles` (touch-resize #58).
 
-The root cause is structural, not a bug that can be patched:
+The root cause of that removal is structural, not a bug that can be patched:
 
 > A pinch is not recognizable until the **second** finger lands, by which point
 > the first finger's `pointerdown` has already reached LiteGraph and opened a
@@ -73,7 +75,8 @@ transaction — move-stream suppression, a wheel interceptor,
 hit-tested on the **first** `pointerdown` is suppressed before LiteGraph opens
 any transaction, so there is no half-open state to recover.
 
-Two further traps that a pinch design walks into, both real:
+Two further traps, both real, and both things the emitted skeleton already
+avoids — keep them avoided as you extend it:
 
 - **`Comfy.SimpleTouchSupport` keeps a module-global `touchCount`** (`+=` on
   `touchstart`, `-=` on `touchend`) and patches `LGraphCanvas.processMouseDown`
@@ -92,7 +95,10 @@ Place hit targets by **measurement, not guess**: body-corner handles land ~17px
 from the first input/output slots — inside the hit radius — so tapping a slot on
 a selected node grabs a handle instead of starting a link drag. Tracing the full
 outline instead puts them ~21px from the collapse toggle and ~45px from the
-slots. Cap the hit radius accordingly and record the ceiling in `CONFIG`.
+slots. Cap the hit radius accordingly and record the ceiling in `CONFIG` — the
+skeleton emits `CONFIG.handleHitRadius` for exactly that, seeded at 18px from
+touch-resize's measurements. Those constants are that pack's tuning; re-measure
+against your own handle placement rather than inheriting the number.
 
 ## The shim variant
 

--- a/comfyui-plugin/skills/comfyui-node-scaffold/scaffold.py
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/scaffold.py
@@ -39,7 +39,7 @@ Canvas-gesture pack (touch-resize shape — no widget, no modal, no kit):
     python3 scaffold.py \
         --name comfyui-touch-resize \
         --display "Touch Resize" \
-        --desc "Selection-gated pinch-to-resize for ComfyUI nodes and groups on touch devices." \
+        --desc "Selection-gated corner grab-handle resize for ComfyUI nodes and groups on touch." \
         --variant gesture
 """
 
@@ -606,12 +606,22 @@ INDEX_TS_GESTURE = """\
 // EXT_NAME below. See ADR-0001.
 //
 // Pattern ("the gesture vein"): instead of intercepting a single widget,
-// this pack adds a CANVAS-LEVEL pointer layer. A two-finger pinch whose
-// centroid lands inside a *selected* node (single tap selects it) resizes
-// that node and suppresses the native canvas zoom for the gesture's
-// duration. Additive + mobile-first: if app.canvas or the pointer model is
+// this pack adds a CANVAS-LEVEL pointer layer. A *selected* node (single tap
+// selects it) grows corner grab-handles; a drag that starts on one resizes
+// the node. Additive + mobile-first: if app.canvas or the pointer model is
 // absent it does nothing and native corner-handle resize still works.
-// Resize only writes node.size (already serialized) so no workflow breaks.
+// Resize writes node.pos/node.size (already serialized) so no workflow breaks.
+//
+// THE DESIGN CONSTRAINT: the gesture must be recognizable on the FIRST
+// pointerdown. Anything that needs a second finger or a move stream to
+// classify — a pinch, a swipe, a two-finger rotate — is unrecognizable until
+// after the first pointerdown has already reached LiteGraph and opened a
+// node-drag or canvas-pan transaction, leaving a half-open state that cannot
+// be unwound cleanly. comfyui-touch-resize shipped a pinch, root-caused this,
+// and replaced it with these grab-handles (touch-resize#58). A target
+// hit-tested on the first pointerdown is suppressed BEFORE LiteGraph sees the
+// event, so there is no transaction to recover from and none of the
+// move-stream / wheel / touch-action hedges that recovery needs.
 //
 // This variant has NO @@MODAL_KIT_PKG@@ dependency — there is no widget to
 // hook and no modal to open. Pure geometry helpers are exported and
@@ -630,6 +640,17 @@ const EXT_NAME = "@@NAME@@";
 // LiteGraph.NODE_TITLE_HEIGHT = 30 (confirm against the frontend sourcemap).
 const DEFAULT_TITLE_HEIGHT = 30;
 
+// Tuning. Measure, do not guess: on touch-resize, handles placed at the BODY
+// corners land ~17px from the first input/output slots, so a radius above that
+// steals slot taps (link drags) on a selected node; tracing the full node
+// outline instead puts them ~21px from the collapse toggle and ~45px from the
+// slots. Re-measure for this pack's handle placement and keep the ceiling here
+// rather than in the hit-test call site.
+const CONFIG = {
+  /** Screen-space grab radius around each corner handle, in px. */
+  handleHitRadius: 18,
+};
+
 // ============================================================
 // Types
 // ============================================================
@@ -645,6 +666,9 @@ interface Rect {
 /** A 2-tuple of [x, y] / [w, h] used throughout the geometry. */
 type Vec2 = [number, number];
 
+/** Which corner a grab-handle sits on. */
+export type Corner = "nw" | "ne" | "sw" | "se";
+
 /** The narrow node surface this pack reaches into. */
 interface GestureNode {
   pos: Vec2;
@@ -656,19 +680,6 @@ interface GestureNode {
 // ============================================================
 // Pure helpers (unit-tested in tests/js)
 // ============================================================
-
-/** Euclidean distance between two {x, y} pointers. */
-export function pinchDistance(a: { x: number; y: number }, b: { x: number; y: number }): number {
-  return Math.hypot(a.x - b.x, a.y - b.y);
-}
-
-/** Midpoint between two {x, y} pointers. */
-export function centroid(
-  a: { x: number; y: number },
-  b: { x: number; y: number },
-): { x: number; y: number } {
-  return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
-}
 
 /** Is screen point (x, y) inside rect {x, y, w, h}? */
 export function pointInRect(x: number, y: number, rect: Rect): boolean {
@@ -692,12 +703,60 @@ export function nodeScreenRect(
   };
 }
 
+/** The four corner grab-handle centres of a screen-space rect. */
+export function cornerHandles(rect: Rect): { corner: Corner; x: number; y: number }[] {
+  return [
+    { corner: "nw", x: rect.x, y: rect.y },
+    { corner: "ne", x: rect.x + rect.w, y: rect.y },
+    { corner: "sw", x: rect.x, y: rect.y + rect.h },
+    { corner: "se", x: rect.x + rect.w, y: rect.y + rect.h },
+  ];
+}
+
 /**
- * New [w, h] after a uniform pinch scale, clamped to a minimum.
- * ratio = currentPinchDistance / startPinchDistance; minSize = [minW, minH].
+ * Which corner handle of `rect` the screen point (x, y) grabs, or null.
+ * This is the whole recognizer: it runs on the FIRST pointerdown, so the
+ * gesture is classified before LiteGraph can open a competing transaction.
+ * Nearest handle wins, so overlapping radii on a small node stay predictable.
  */
-export function scaledSize(startSize: Vec2, ratio: number, minSize: Vec2 = [0, 0]): Vec2 {
-  return [Math.max(minSize[0], startSize[0] * ratio), Math.max(minSize[1], startSize[1] * ratio)];
+export function hitHandle(x: number, y: number, rect: Rect, radius: number): Corner | null {
+  let best: Corner | null = null;
+  let bestDist = radius;
+  for (const h of cornerHandles(rect)) {
+    const d = Math.hypot(x - h.x, y - h.y);
+    if (d <= bestDist) {
+      bestDist = d;
+      best = h.corner;
+    }
+  }
+  return best;
+}
+
+/**
+ * New {pos, size} after dragging `corner` by (dx, dy) CANVAS units, clamped to
+ * a minimum. Dragging a west/north corner moves the opposite edge, so `pos`
+ * shifts by exactly the size delta — clamping both together keeps the anchored
+ * corner still once the minimum is reached.
+ */
+export function resizedGeometry(
+  startPos: Vec2,
+  startSize: Vec2,
+  corner: Corner,
+  dx: number,
+  dy: number,
+  minSize: Vec2 = [0, 0],
+): { pos: Vec2; size: Vec2 } {
+  const west = corner === "nw" || corner === "sw";
+  const north = corner === "nw" || corner === "ne";
+  const w = Math.max(minSize[0], west ? startSize[0] - dx : startSize[0] + dx);
+  const h = Math.max(minSize[1], north ? startSize[1] - dy : startSize[1] + dy);
+  return {
+    pos: [
+      west ? startPos[0] + (startSize[0] - w) : startPos[0],
+      north ? startPos[1] + (startSize[1] - h) : startPos[1],
+    ],
+    size: [w, h],
+  };
 }
 
 /** Selected nodes as an array, defensively across LiteGraph variants. */
@@ -721,11 +780,16 @@ export function selectedNodes(canvas: unknown): GestureNode[] {
 // Wiring (DOM + canvas; browser-matrix tested)
 // ============================================================
 
-interface PinchLock {
+interface DragLock {
+  pointerId: number;
   node: GestureNode;
-  startDist: number;
+  corner: Corner;
+  startX: number;
+  startY: number;
+  startPos: Vec2;
   startSize: Vec2;
   minSize: Vec2;
+  scale: number;
 }
 
 function installGestureLayer(): void {
@@ -744,85 +808,109 @@ function installGestureLayer(): void {
     return;
   }
 
-  const pointers = new Map<number, { x: number; y: number }>();
-  let lock: PinchLock | null = null;
+  let drag: DragLock | null = null;
 
   const localPoint = (e: PointerEvent): { x: number; y: number } => {
     const r = el.getBoundingClientRect();
     return { x: e.clientX - r.left, y: e.clientY - r.top };
   };
 
-  function tryStartPinch(): void {
-    if (pointers.size !== 2 || lock) return;
-    const [p1, p2] = [...pointers.values()] as [{ x: number; y: number }, { x: number; y: number }];
-    const c = centroid(p1, p2);
-    const scale = canvas?.ds?.scale ?? 1;
-    const offset = canvas?.ds?.offset ?? ([0, 0] as Vec2);
-    for (const node of selectedNodes(canvas)) {
-      if (pointInRect(c.x, c.y, nodeScreenRect(node, scale, offset))) {
-        const minSize: Vec2 = typeof node.computeSize === "function" ? node.computeSize() : [0, 0];
-        lock = {
-          node,
-          startDist: pinchDistance(p1, p2) || 1,
-          startSize: [node.size[0], node.size[1]],
-          minSize,
-        };
-        return;
-      }
-    }
-  }
-
-  el.addEventListener(
+  // Listen at WINDOW CAPTURE, not on the canvas element. Capture descends from
+  // the root, so this runs before ANY listener bound on the canvas whatever
+  // order they registered in — a capture listener added to the canvas itself
+  // during setup() would fire after LiteGraph's, far too late to suppress it.
+  // Pointer events only: never set `touch-action`, and never swallow
+  // touchstart/touchend. Comfy.SimpleTouchSupport keeps a module-global
+  // touchCount (+= on touchstart, -= on touchend) and short-circuits
+  // LGraphCanvas.processMouseDown while it is truthy; swallowing one side
+  // drives it NEGATIVE — also truthy — and the canvas stops responding to taps
+  // until resetTouchState fires on visibilitychange ("recovers only by
+  // switching apps"). A pointer-only layer keeps it balanced by construction.
+  window.addEventListener(
     "pointerdown",
     (e) => {
-      pointers.set(e.pointerId, localPoint(e));
-      tryStartPinch();
-      if (lock) e.stopImmediatePropagation(); // suppress native pinch-zoom
+      if (drag || e.target !== el) return;
+      const p = localPoint(e);
+      const scale = canvas?.ds?.scale ?? 1;
+      const offset = canvas?.ds?.offset ?? ([0, 0] as Vec2);
+      for (const node of selectedNodes(canvas)) {
+        const corner = hitHandle(
+          p.x,
+          p.y,
+          nodeScreenRect(node, scale, offset),
+          CONFIG.handleHitRadius,
+        );
+        if (!corner) continue;
+        drag = {
+          pointerId: e.pointerId,
+          node,
+          corner,
+          startX: p.x,
+          startY: p.y,
+          startPos: [node.pos[0], node.pos[1]],
+          startSize: [node.size[0], node.size[1]],
+          minSize: typeof node.computeSize === "function" ? node.computeSize() : [0, 0],
+          scale,
+        };
+        // Claimed here, on the first pointerdown, before the event reaches the
+        // canvas — so LiteGraph never opens a node-drag or canvas-pan
+        // transaction and there is nothing to unwind on pointerup.
+        e.stopPropagation();
+        e.preventDefault();
+        return;
+      }
     },
     true,
   );
 
-  el.addEventListener(
+  // No suppression on move/up: the pointerdown never reached LiteGraph, so it
+  // has no transaction in flight and its own move handling is already inert.
+  window.addEventListener(
     "pointermove",
     (e) => {
-      if (!pointers.has(e.pointerId)) return;
-      pointers.set(e.pointerId, localPoint(e));
-      if (!lock || pointers.size < 2) return;
-      const [p1, p2] = [...pointers.values()] as [
-        { x: number; y: number },
-        { x: number; y: number },
-      ];
-      const ratio = pinchDistance(p1, p2) / lock.startDist;
-      const [w, h] = scaledSize(lock.startSize, ratio, lock.minSize);
-      lock.node.size[0] = w;
-      lock.node.size[1] = h;
-      lock.node.onResize?.(lock.node.size);
+      if (!drag || e.pointerId !== drag.pointerId) return;
+      const p = localPoint(e);
+      const dx = (p.x - drag.startX) / (drag.scale || 1);
+      const dy = (p.y - drag.startY) / (drag.scale || 1);
+      const next = resizedGeometry(
+        drag.startPos,
+        drag.startSize,
+        drag.corner,
+        dx,
+        dy,
+        drag.minSize,
+      );
+      // ASSIGN, never mutate in place. `node.size[0] = w` bypasses LGraphNode's
+      // pos/size setters and therefore the Vue layout store they feed
+      // (useLayoutMutations.moveNode / .resizeNode), so the canvas and the
+      // store silently disagree.
+      drag.node.pos = next.pos;
+      drag.node.size = next.size;
+      drag.node.onResize?.(next.size);
       canvas?.setDirty?.(true, true);
-      e.stopImmediatePropagation();
     },
     true,
   );
 
-  const endPointer = (e: PointerEvent): void => {
-    pointers.delete(e.pointerId);
-    if (pointers.size < 2) lock = null;
+  const endDrag = (e: PointerEvent): void => {
+    if (drag && e.pointerId === drag.pointerId) drag = null;
   };
-  el.addEventListener("pointerup", endPointer, true);
-  el.addEventListener("pointercancel", endPointer, true);
+  window.addEventListener("pointerup", endDrag, true);
+  window.addEventListener("pointercancel", endDrag, true);
 
-  console.log(`[${EXT_NAME}] gesture layer installed — pinch a selected node to resize`);
+  console.log(`[${EXT_NAME}] gesture layer installed — drag a selected node's corner to resize`);
 }
 
 app.registerExtension({
   name: "comfy.@@SHORT@@",
   async setup() {
     installGestureLayer();
+    // TODO: measure this pack's handle placement against the node's real slot
+    //   geometry and re-tune CONFIG.handleHitRadius (see the note above it).
     // TODO: groups — extend selectedNodes()/nodeScreenRect() to graph._groups
-    //   (group.pos/group.size; no title bar) so a pinch resizes groups too.
-    // TODO: discoverability — draw a faint corner affordance on selected nodes
-    //   (canvas onDrawForeground) so the pinch gesture is learnable.
-    // TODO: optional anisotropic mode — decompose the two-finger vector into
-    //   independent W/H instead of uniform scale (behind a config flag).
+    //   (group.pos/group.size; no title bar) so a drag resizes groups too.
+    // TODO: discoverability — draw the corner handles on selected nodes
+    //   (canvas onDrawForeground) so the grab targets are visible, not guessed.
   },
 });
 """
@@ -1351,25 +1439,45 @@ import { describe, expect, it } from "vitest";
 // Vitest transpiles TypeScript, so the test imports the `.ts` source directly
 // (no build step). Importing the module also confirms the registerExtension
 // wiring loads cleanly against tests/js/__mocks__/app.js.
-import { pinchDistance, pointInRect, scaledSize } from "../../src/index.ts";
+import { hitHandle, pointInRect, resizedGeometry } from "../../src/index.ts";
 
 // Smoke tests so `bun run test` is green from the first commit. Exercise the
-// pure gesture helpers. Add a jsdom test for installGestureLayer's pointer
-// handling as the real resize logic lands.
+// pure gesture helpers — the recognizer (hitHandle) and the geometry it feeds.
+// Add a jsdom test for installGestureLayer's pointerdown handling as the real
+// gesture lands; the invariant worth asserting there is that a pointerdown
+// which grabs a handle is suppressed before it can reach the canvas.
 describe("@@NAME@@ gesture helpers", () => {
-  it("measures pinch distance", () => {
-    expect(pinchDistance({ x: 0, y: 0 }, { x: 3, y: 4 })).toBe(5);
-  });
+  const rect = { x: 10, y: 10, w: 100, h: 50 };
 
   it("hit-tests a screen point against a rect", () => {
-    const rect = { x: 10, y: 10, w: 100, h: 50 };
     expect(pointInRect(50, 30, rect)).toBe(true);
     expect(pointInRect(5, 30, rect)).toBe(false);
   });
 
-  it("uniform-scales and clamps to a minimum size", () => {
-    expect(scaledSize([200, 100], 1.5)).toEqual([300, 150]);
-    expect(scaledSize([200, 100], 0.1, [120, 60])).toEqual([120, 60]);
+  it("recognises a corner grab on the first pointerdown", () => {
+    expect(hitHandle(12, 12, rect, 18)).toBe("nw");
+    expect(hitHandle(108, 58, rect, 18)).toBe("se");
+    // A press in the node body is NOT a handle grab — it must fall through to
+    // LiteGraph so tapping/dragging a selected node still works.
+    expect(hitHandle(60, 35, rect, 18)).toBeNull();
+  });
+
+  it("resizes from a south-east drag without moving the anchor", () => {
+    const { pos, size } = resizedGeometry([0, 0], [200, 100], "se", 40, 20);
+    expect(pos).toEqual([0, 0]);
+    expect(size).toEqual([240, 120]);
+  });
+
+  it("moves pos when a north-west corner is dragged, and clamps together", () => {
+    expect(resizedGeometry([100, 100], [200, 100], "nw", 50, 25)).toEqual({
+      pos: [150, 125],
+      size: [150, 75],
+    });
+    // Past the minimum both stop: size clamps and pos stops following.
+    expect(resizedGeometry([100, 100], [200, 100], "nw", 500, 500, [120, 60])).toEqual({
+      pos: [180, 140],
+      size: [120, 60],
+    });
   });
 });
 """
@@ -2860,24 +2968,28 @@ def build_file_map(
         ctx["VEIN"] = (
             "A mobile-first ComfyUI usability pack in the *gesture* vein: instead "
             "of intercepting a single widget, a frontend extension adds a "
-            "CANVAS-LEVEL pointer layer. A two-finger pinch whose centroid lands "
-            "inside a **selected** node (single tap selects it) resizes that node "
-            "and suppresses the native canvas zoom for the gesture's duration. The "
-            "enhancement is **additive** (no-op fallback if `app.canvas` or the "
-            "pointer model is absent — native corner-handle resize still works), "
-            "**touch-first**, and never breaks serialized workflows (it only writes "
-            "`node.size`, which is already serialized). Pure geometry helpers are "
-            "exported from `src/index.ts` and unit-tested; DOM/canvas wiring stays "
-            "below them."
+            "CANVAS-LEVEL pointer layer. A **selected** node (single tap selects "
+            "it) grows corner grab-handles; a drag starting on one resizes the "
+            "node. The gesture is recognized on the **first** `pointerdown` and "
+            "suppressed there, so LiteGraph never opens a competing node-drag or "
+            "canvas-pan transaction. The enhancement is **additive** (no-op "
+            "fallback if `app.canvas` or the pointer model is absent — native "
+            "corner-handle resize still works), **touch-first**, and never breaks "
+            "serialized workflows (it only writes `node.pos` / `node.size`, both "
+            "already serialized). Pure geometry helpers are exported from "
+            "`src/index.ts` and unit-tested; DOM/canvas wiring stays below them."
         )
         ctx["EXT_ROW_DESC"] = (
             "The extension: canvas pointer layer + exported pure geometry helpers."
         )
         ctx["HOOK_RULE"] = (
-            "**Canvas pointer model is version-sensitive.** The pinch layer reads "
-            "`app.canvas` / `ds.scale` / `ds.offset` and the pointer-event stream. "
-            "Keep the no-op fallback (do nothing when they are absent) so native "
-            "corner-handle resize always works."
+            "**A gesture must be recognizable on the first `pointerdown`.** The "
+            "layer reads `app.canvas` / `ds.scale` / `ds.offset`, hit-tests that "
+            "first event, and suppresses it at window capture — no move-stream "
+            "classification, and never a `touch-action` override (that unbalances "
+            "`Comfy.SimpleTouchSupport`'s `touchCount`). Write geometry by "
+            "assignment (`node.size = [w, h]`), never in place. Keep the no-op "
+            "fallback so native corner-handle resize always works."
         )
         ctx["FAMILY_BLURB"] = (
             "> touch-friendly gestures and HTML modals that replace clunky native\n"
@@ -3513,8 +3625,10 @@ def main() -> int:
         "  just check                              # typecheck + build + lint + test should pass green\n"
         "\nThen:\n"
         + (
-            "  - tune the pinch layer in src/index.ts "
-            "(selectedNodes/nodeScreenRect/scaledSize; groups + affordance TODOs)\n"
+            "  - tune the pointer layer in src/index.ts (selectedNodes/"
+            "nodeScreenRect/hitHandle/resizedGeometry; keep the gesture "
+            "recognizable on the FIRST pointerdown; re-measure "
+            "CONFIG.handleHitRadius; groups + affordance TODOs)\n"
             if args.variant == "gesture"
             else "  - implement the CSS shims in src/index.ts (replace the placeholder "
             "SHIMS entry; link the upstream issue, keep each shim fail-soft — no "

--- a/comfyui-plugin/skills/comfyui-node-scaffold/scripts/tests/test-finishing-pass.sh
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/scripts/tests/test-finishing-pass.sh
@@ -570,5 +570,115 @@ PY
     fi
 fi
 
+# 17. the gesture skeleton is recognizable on the FIRST pointerdown (issue
+#     #2383). The emitted skeleton demonstrated a two-finger pinch, which
+#     comfyui-touch-resize shipped and then removed as unfixable AS DESIGNED
+#     (touch-resize#58): a pinch is not recognizable until the SECOND finger
+#     lands, by which point the first finger's pointerdown has already reached
+#     LiteGraph and opened a node-drag or canvas-pan transaction. Everything
+#     else in that module existed only to unwind the half-open transaction —
+#     including the `if (lock) e.stopImmediatePropagation()` hedge. Every
+#     gesture pack scaffolded from it inherited a defect class the family had
+#     already root-caused and abandoned.
+GS="$WORK/comfyui-fp-gesture-shape"
+python3 "$SCAFFOLD" --name comfyui-fp-gesture-shape --display "FP Gesture Shape" \
+    --desc "Drag a selected node's corner handle to resize it" \
+    --variant gesture --dir "$WORK" >/dev/null 2>&1
+GS_SRC="$GS/src/index.ts"
+GS_TEST="$GS/tests/js/index.test.js"
+
+# Guard integrity first: without a non-empty, helper-exporting source every
+# "does not contain X" assertion below passes against a generator that emits
+# nothing at all.
+check "gesture variant emits src/index.ts" "yes" \
+    "$([ -s "$GS_SRC" ] && echo yes || echo no)"
+check "gesture variant emits tests/js/index.test.js" "yes" \
+    "$([ -s "$GS_TEST" ] && echo yes || echo no)"
+check "  ...exporting pure geometry helpers" "yes" \
+    "$(grep -qE '^export function ' "$GS_SRC" && echo yes || echo no)"
+
+# The defect lives in CODE, not in prose: the skeleton is expected to keep
+# NAMING the removed pinch so the next author learns why it went (the same
+# instruction-vs-explanation split check-agent-tool-selection.sh makes), so
+# every negative below runs against a comment-stripped view of the file.
+code_only() { # code_only <file> — source with // and /* */ comments removed
+    python3 - "$1" <<'PY'
+import re, sys
+src = open(sys.argv[1], encoding="utf-8").read()
+src = re.sub(r"/\*.*?\*/", "", src, flags=re.S)
+sys.stdout.write("".join(re.sub(r"//.*$", "", ln) + "\n" for ln in src.splitlines()))
+PY
+}
+for f in "$GS_SRC" "$GS_TEST"; do
+    CODE="$(code_only "$f")"
+    check "no pinch* symbol in $(basename "$f")" "yes" \
+        "$(grep -qi 'pinch' <<<"$CODE" && echo no || echo yes)"
+    check "no stopImmediatePropagation hedge in $(basename "$f")" "yes" \
+        "$(grep -q 'stopImmediatePropagation' <<<"$CODE" && echo no || echo yes)"
+done
+# Guard integrity for code_only(): the rationale must SURVIVE in the comments,
+# or the negatives above are satisfied by a skeleton that simply deleted the
+# explanation along with the code.
+check "the skeleton still records why the pinch went" "yes" \
+    "$(grep -q 'touch-resize#58' "$GS_SRC" && echo yes || echo no)"
+
+# The contract the replacement must satisfy (references/variants.md § "A
+# gesture must be recognizable on the FIRST pointerdown"). Each of these is a
+# real invariant, not a spelling: a skeleton that dropped `pinch` but kept
+# recognizing the gesture off a move stream would pass the negatives above.
+check "the gesture is recognized on pointerdown" "yes" \
+    "$(grep -q '"pointerdown"' "$GS_SRC" && echo yes || echo no)"
+# A capture listener on an ANCESTOR precedes listeners bound on the canvas
+# element whatever order they registered in; a same-element capture listener
+# added at setup() fires AFTER LiteGraph's, too late to suppress anything.
+GS_CODE="$(code_only "$GS_SRC")"
+check "  ...at window capture, ahead of LiteGraph's own canvas listener" "yes" \
+    "$(grep -q 'window.addEventListener(' <<<"$GS_CODE" && echo yes || echo no)"
+check "  ...and not on the canvas element, where it would register too late" "yes" \
+    "$(grep -q 'el.addEventListener(' <<<"$GS_CODE" && echo no || echo yes)"
+check "  ...by hit-testing that first event" "yes" \
+    "$(grep -q 'hitHandle' <<<"$GS_CODE" && echo yes || echo no)"
+# touch-action would unbalance Comfy.SimpleTouchSupport's module-global
+# touchCount — the "recovers only by switching apps" symptom.
+check "  ...pointer-events only, never setting touch-action" "yes" \
+    "$(grep -qi 'touchAction\|touch-action' <<<"$GS_CODE" && echo no || echo yes)"
+check "  ...and never intercepting touchstart/touchend" "yes" \
+    "$(grep -q 'touchstart\|touchend' <<<"$GS_CODE" && echo no || echo yes)"
+# In-place writes bypass LGraphNode's pos/size setters and the Vue layout
+# store they feed (useLayoutMutations.moveNode/.resizeNode).
+check "  ...assigning geometry, never mutating in place" "yes" \
+    "$(grep -qE '\.(size|pos) = ' <<<"$GS_CODE" && echo yes || echo no)"
+check "  ...and never writing size[0]/pos[0] in place" "yes" \
+    "$(grep -qE '\.(size|pos)\[[01]\] =' <<<"$GS_CODE" && echo no || echo yes)"
+# The whole layer stays a no-op when the canvas is absent, so the native
+# corner-handle resize always survives.
+check "  ...no-op when app.canvas is absent" "yes" \
+    "$(grep -q 'gesture layer not installed' "$GS_SRC" && echo yes || echo no)"
+# The hit radius is capped and the ceiling is recorded, per the measurement in
+# variants.md (body-corner handles land ~17px from the first slots).
+check "  ...with a capped hit radius in CONFIG" "yes" \
+    "$(grep -q 'handleHitRadius' "$GS_SRC" && echo yes || echo no)"
+
+# The emitted vitest suite must exercise the new helpers, or the pack ships a
+# green suite that tests nothing the skeleton still contains.
+check "the emitted suite tests hitHandle" "yes" \
+    "$(grep -q 'hitHandle' "$GS_TEST" && echo yes || echo no)"
+check "the emitted suite tests resizedGeometry" "yes" \
+    "$(grep -q 'resizedGeometry' "$GS_TEST" && echo yes || echo no)"
+# Every symbol the suite imports must actually be exported by the source —
+# an import of a deleted helper is a red suite in every generated pack.
+GS_MISSING="$(python3 - "$GS_SRC" "$GS_TEST" <<'PY'
+import re, sys
+src = open(sys.argv[1], encoding="utf-8").read()
+test = open(sys.argv[2], encoding="utf-8").read()
+exported = set(re.findall(r"^export function (\w+)", src, re.M))
+imported = set()
+for block in re.findall(r"import \{([^}]*)\} from \"\.\./\.\./src/index\.ts\"", test):
+    imported |= {s.strip() for s in block.split(",") if s.strip()}
+print(",".join(sorted(imported - exported)))
+PY
+)"
+check "every helper the suite imports is exported by src/index.ts" "" "$GS_MISSING"
+
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary

`comfyui-node-scaffold`'s `gesture` variant emitted a two-finger pinch — the exact shape `comfyui-touch-resize` shipped and then removed as unfixable **as designed** (touch-resize#58). A pinch is not recognizable until the *second* finger lands, by which point the first finger's `pointerdown` has already reached LiteGraph and opened a node-drag or canvas-pan transaction; everything else in that module (including the emitted `if (lock) e.stopImmediatePropagation()` hedge) existed only to unwind the half-open state. Every gesture pack scaffolded today inherited a defect class the family had already root-caused and abandoned.

The skeleton now recognizes the gesture on the **first** `pointerdown`:

- `hitHandle()` hit-tests corner grab-handles of each selected node and a hit is suppressed at **window capture** (`stopPropagation` + `preventDefault`). Window capture, not the canvas element: capture descends from the root, so it precedes any listener bound on the canvas whatever order they registered in — a same-element capture listener added during `setup()` fires *after* LiteGraph's, too late to suppress anything.
- With nothing to unwind, the move-stream / wheel / `touch-action` hedges are gone.

Contract from `references/variants.md`, all now satisfied by the emitted code:

| Contract | How the skeleton meets it |
|---|---|
| Recognizable on the first `pointerdown` | `hitHandle()` classifies that one event; hit ⇒ suppressed before LiteGraph sees it |
| Pointer-events only, never `touch-action` | No `touch-action`, no `touchstart`/`touchend` interception, so `Comfy.SimpleTouchSupport`'s module-global `touchCount` stays balanced (the "recovers only by switching apps" symptom) |
| Assign geometry, never mutate in place | `node.pos = …` / `node.size = …`, so `LGraphNode`'s setters and the Vue layout store they feed are not bypassed |
| Pure helpers exported + unit-tested | `cornerHandles` / `hitHandle` / `resizedGeometry` / `pointInRect` / `nodeScreenRect` / `selectedNodes`, 4 vitest cases |
| No-op when `app.canvas` is absent | Unchanged early return; native corner-handle resize always survives |
| Hit radius capped, ceiling recorded | `CONFIG.handleHitRadius = 18`, with touch-resize's ~17px/~45px measurement in the comment and a TODO to re-measure per pack |

`pinchDistance` / `centroid` / `scaledSize` / `PinchLock` / `tryStartPinch` are replaced by `cornerHandles` / `hitHandle` / `resizedGeometry` / `DragLock`. The pack-specific constants from touch-resize are *not* copied in — only the shape, per the issue.

Docs: `SKILL.md` and `references/variants.md` drop the "example to replace" caveat #2382 added; `references/invocation.md` and the `scaffold.py` docstring stop describing touch-resize as a pinch pack.

## Test plan

**Regression check** — block 17 of `scripts/tests/test-finishing-pass.sh` **executes** the generator and asserts against a *comment-stripped* view of the emitted source. The skeleton is expected to keep **naming** the removed pinch so the next author learns why it went (the instruction-vs-explanation split `check-agent-tool-selection.sh` makes), so a prose mention is allowed while a code use is not. Guard integrity: the emitted source must be non-empty and export helpers, the rationale must survive in the comments (`touch-resize#58`), and every symbol the emitted suite imports must be exported by the emitted source — without those, "does not contain X" passes against a generator that emits nothing.

- **Mutation-verified**: **12** assertions fail against the pre-fix generator (`git show HEAD:scaffold.py`), **0** against the fixed one.
- **All four skill suites green**: `test-fleet-drift.sh` 58/0, `test-finishing-pass.sh` 85/0 (was 73), `test-standalone-variant.sh` 9/0, `test-shim-variant.sh` 13/0.
- **Generated pack verified end-to-end** (scaffolded `--variant gesture`, `bun install`): `bun run typecheck` clean, `bun run build` bundles, `bun run test` 4/4, `biome check` 0 errors (2 pre-existing schema-version infos), `knip` clean.
- `just lint-shell` 0 errors; `check-fleet-drift.py` `STATUS=OK ISSUE_COUNT=0`; `scaffold.py --verify` unchanged.
- `just lint-compliance` reports one ❌ — `agent-patterns-plugin/parallel-agent-dispatch` over the 26,000-char ceiling — which is **pre-existing on `main`** and untouched by this diff (the change is confined to `comfyui-plugin/skills/comfyui-node-scaffold/`).

Fixes #2383


---
_Generated by [Claude Code](https://claude.ai/code/session_01HVLpcUroVGndknVjQCqaeH)_