### PR TITLE
fix(agent-patterns-plugin): relocate parallel-agent-dispatch material into references/ and document the deleted-worktree hazard

### DIFF
--- a/agent-patterns-plugin/skills/parallel-agent-dispatch/REFERENCE.md
+++ b/agent-patterns-plugin/skills/parallel-agent-dispatch/REFERENCE.md
@@ -7,10 +7,10 @@ these links.
 
 | Path you are on | File | Carries |
 |---|---|---|
-| Composing the dispatch call and the brief's scaffolding | [`references/dispatch-contract.md`](references/dispatch-contract.md) | Return Contract schema (verbatim), failure mode → schema field, the contract as workflow primitives (JSON Schema + `parallel()` barrier, and their cost gate), Skill-less `agentType` evidence (`skill_listing` tax) |
+| Composing the dispatch call and the brief's scaffolding | [`references/dispatch-contract.md`](references/dispatch-contract.md) | Return Contract schema (verbatim), failure mode → schema field, the contract as workflow primitives (the prose→primitive mapping table, JSON Schema + `parallel()` barrier, and their cost gate), Skill-less `agentType` evidence (`skill_listing` tax) |
 | Writing a refactor / bulk-edit brief | [`references/brief-templates.md`](references/brief-templates.md) | Refactor-brief template, completion manifest (#1601), verbatim-patch discipline, agent self-verification and reviewer-agent evidence |
 | An agent stalled, was cut off, went idle, was killed, or was rate-limited | [`references/failure-recovery.md`](references/failure-recovery.md) | Commit/push stall salvage, WIP salvage before re-dispatch (#1491), idle-without-report (#2039), `TaskStop` recovery + kill thresholds, rate-limit recovery-dispatch |
-| Setting up worktree isolation, or a git write went somewhere unexpected | [`references/worktree-hazards.md`](references/worktree-hazards.md) | cwd-reset guardrail (#1480), `GIT_DIR`-export leak (#1692), nested-repo isolation (#1838), target-branch preflight (#1969) |
+| Setting up worktree isolation, or a git write went somewhere unexpected | [`references/worktree-hazards.md`](references/worktree-hazards.md) | cwd-reset guardrail (#1480), `GIT_DIR`-export leak (#1692), nested-repo isolation (#1838), shared scratchpad collisions (#2370), deleted worktree kills the shell (#2372), target-branch preflight (#1969) |
 
 This file is an index only. Add new reference material to the file whose path
 needs it — or a new `references/*.md` plus a row here — rather than growing this

--- a/agent-patterns-plugin/skills/parallel-agent-dispatch/SKILL.md
+++ b/agent-patterns-plugin/skills/parallel-agent-dispatch/SKILL.md
@@ -5,7 +5,7 @@ user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite
 model: opus
 created: 2026-04-21
-modified: 2026-08-07
+modified: 2026-08-15
 compatibility: claude-code
 reviewed: 2026-07-05
 ---
@@ -60,15 +60,14 @@ If any check fails, **refuse to dispatch** and report the blocker. Do not
 "clean up" uncommitted user work — surface it and ask.
 
 **Target-branch preflight (#1969).** `isolation: "worktree"` auto-names the
-branch; renaming onto a **fixed** conventional target name another session's
-worktree already holds is refused only at the end-of-task rename, deep into
-the run (real case: two sessions both reached PR-open → duplicate-PR
-reconcile). Before dispatching — or as the agent's *first* step — check the
-name is free (`git branch -a --list "$target"`, `git worktree list`,
-`git ls-remote --heads origin "$target"`); any hit ⇒ another session may own
-this task — **stop and reconcile**, not race to a duplicate PR
-(`.claude/rules/concurrent-session-pr-check.md`). **Mitigation:** push via
-explicit refspec (`git push origin HEAD:$target`) instead of renaming. See
+branch; renaming onto a **fixed** conventional name another session's worktree
+already holds is refused only at the end-of-task rename, deep into the run (real
+case: two sessions both reached PR-open → duplicate-PR reconcile). Check the name
+is free first (`git branch -a --list "$target"`, `git worktree list`,
+`git ls-remote --heads origin "$target"`); any hit ⇒ **stop and reconcile**, not
+race to a duplicate PR (`.claude/rules/concurrent-session-pr-check.md`).
+**Mitigation:** push via explicit refspec (`git push origin HEAD:$target`)
+instead of renaming. See
 [references/worktree-hazards.md → Target-branch preflight](references/worktree-hazards.md#target-branch-preflight-1969).
 
 **Transient worktree leaks (#1319).** While a wave runs, a file a child wrote
@@ -90,53 +89,34 @@ guardrail](references/worktree-hazards.md#worktree-cwd-reset-guardrail-1480)) �
 a changed branch or new dirty state is silent main-repo mutation.
 
 **`GIT_DIR`/`GIT_WORK_TREE` export leak (#1692 sibling).** A worktree reporting
-`core.bare = true` (`fatal: this operation must be run in a work tree`) is
-shared-checkout corruption — **STOP and report it**; never "work around" it by
-exporting `GIT_DIR`/`GIT_WORK_TREE`, which **override `git -C`** so every later
-git call (and any git-shelling test/hook subprocess) targets the shared common
-config, breaking **all** sibling worktrees at once. A subprocess that must run
-git in a sandbox neutralizes inherited env first:
+`core.bare = true` is shared-checkout corruption — **STOP and report it**; never
+"work around" it by exporting `GIT_DIR`/`GIT_WORK_TREE`, which **override
+`git -C`** so every later git call targets the shared common config, breaking
+**all** sibling worktrees at once. A subprocess that must run git in a sandbox
+neutralizes inherited env first:
 `env -u GIT_DIR -u GIT_WORK_TREE git -C "$dir" …`. See
 [references/worktree-hazards.md → GIT_DIR-export leak](references/worktree-hazards.md#worktree-git_dir-export-leak-1692).
 
 **Nested-repo workspaces — `isolation: "worktree"` isolates the *outer* repo (#1838).**
 The harness worktrees the **session's** repo, not the repo the agent was told to
-edit. In a nested-repo / portfolio layout the target files live in an independent
-nested repo that is **absent** from that worktree, so the agent's only path to
-them is the shared checkout — which the Edit-tool isolation guard correctly
-blocks. Detect it before dispatch: `git -C <target-dir> rev-parse --show-toplevel`
-≠ `git rev-parse --show-toplevel`. When they differ, either create the **nested**
-repo's worktree explicitly off its own `origin/main` and point the agent there, or
-brief the agent to do so as its *first* step. See
+edit, so in a portfolio layout the target files are **absent** from the worktree
+and the agent's only path to them is the shared checkout — which the Edit-tool
+isolation guard correctly blocks. Detect it before dispatch:
+`git -C <target-dir> rev-parse --show-toplevel` ≠ `git rev-parse --show-toplevel`;
+when they differ, isolate the **nested** repo explicitly. See
 [references/worktree-hazards.md → Nested-repo isolation](references/worktree-hazards.md#nested-repo-worktree-isolation-1838)
-for detection script and rules.
+for the detection script and rules.
 
-**Concurrent agents default to the *same* scratchpad path — assign distinct ones.**
-The session scratchpad directory is shared across sibling subagents, so two
-agents told to "make your own clone" independently pick the identical path and
-end up operating **one working tree**. Nothing errors: one agent's `git switch`
-moves `HEAD` under the other, so its edits land on the peer's branch and both
-PRs can carry each other's hunks. A per-file `git diff` cannot separate
-interleaved hunks in a co-modified file, so the extracted patch looks correct
-while carrying someone else's work.
+**Concurrent agents default to the *same* scratchpad path (#2370).** Sibling
+subagents share the session scratchpad, so two agents each told to "make your own
+clone" pick the identical path and silently operate **one working tree**. Give
+each an explicit, distinct path (`<scratchpad>/<agent-name>`) whenever they work
+outside worktree isolation — which the nested-repo case above forces. See
+[references/worktree-hazards.md → Shared scratchpad collisions](references/worktree-hazards.md#shared-scratchpad-collisions-2370).
 
-Give every concurrent agent an **explicit, distinct** working path in its
-prompt — `<scratchpad>/<agent-name>` — rather than letting each choose. This
-applies whenever agents work outside worktree isolation, which the nested-repo
-case above forces them into.
-
-Recovery, if it already happened: rebuild in a fresh clone and **re-apply your
-changes by hand**. Do not copy files out of the shared tree — co-modified files
-carry the peer's hunks with them. Leave the shared tree dirty rather than
-reverting it; a revert destroys the peer's uncommitted work. Verify with
-`git log --oneline origin/main..HEAD` plus `--stat` that the branch holds only
-your commits and only your paths.
-
-> Observed 2026-08: two agents fixing different defects in the same MCP server
-> collided this way. Each caught a real error in the other's cleanup — one
-> nearly shipped a merge warning that would have broken the build if acted on,
-> the other a verification `grep` that would have cried wolf. Neither shipped
-> contaminated, but only because they were talking to each other.
+**A deleted worktree kills the agent's shell, not its reasoning (#2372).** Every
+Bash call then fails, and a spawned subagent inherits the same dead cwd. See
+[references/worktree-hazards.md → Deleted worktree](references/worktree-hazards.md#deleted-worktree-kills-the-shell-not-the-agent-2372).
 
 ### 2. Scope Budget (per-agent prompt rules)
 
@@ -215,17 +195,9 @@ blocker, push what you have, open a draft PR, and tell me exactly what stopped
 you."** Optional enforcement: a `SubagentStop` hook that flags sub-~20-char or
 bare-surrender final messages (see `hooks-plugin`).
 
-#### The same contract, expressed as workflow primitives
-
-A harness does not replace this contract; it turns what prose can only *request*
-into what a runtime *enforces*:
-
-| Here (prose) | Workflow primitive |
-|---|---|
-| The `## Result` schema pasted into each brief | a **JSON Schema** on the `agent()` call — validated, so a one-word surrender cannot parse |
-| "every returned summary parsed" (Orchestrator Checklist) | `parallel()` — the barrier that line already assumes |
-
-Cautions and the cost gate before reaching for one:
+A workflow harness does not replace this contract; it turns what prose can only
+*request* into what a runtime *enforces*. The prose→primitive mapping, its two
+cautions, and the cost gate before reaching for one:
 [references/dispatch-contract.md → Workflow primitives](references/dispatch-contract.md#the-return-contract-as-workflow-primitives).
 
 ### 4. Agent self-verification in bulk-edit briefs

--- a/agent-patterns-plugin/skills/parallel-agent-dispatch/references/dispatch-contract.md
+++ b/agent-patterns-plugin/skills/parallel-agent-dispatch/references/dispatch-contract.md
@@ -49,8 +49,15 @@ Why each Return Contract field exists — the observed failure mode it catches.
 | Concurrent rate-limit cascade | `status: partial` + recovery-dispatch follow-up agent on the unfinished slice |
 ## The Return Contract as workflow primitives
 
-`SKILL.md` § Return Contract carries the mapping table; this is what to weigh
-before turning it into a harness.
+A harness does not replace this contract; it turns what prose can only *request*
+into what a runtime *enforces*:
+
+| Here (prose) | Workflow primitive |
+|---|---|
+| The `## Result` schema pasted into each brief | a **JSON Schema** on the `agent()` call — validated, so a one-word surrender cannot parse |
+| "every returned summary parsed" (Orchestrator Checklist) | `parallel()` — the barrier that line already assumes |
+
+What to weigh before turning that mapping into a harness:
 
 - **A schema-bound agent has no partial result.** An `agent()` bound to a
   `StructuredOutput` schema that is cut off *before* it emits — a rate-limit

--- a/agent-patterns-plugin/skills/parallel-agent-dispatch/references/worktree-hazards.md
+++ b/agent-patterns-plugin/skills/parallel-agent-dispatch/references/worktree-hazards.md
@@ -3,8 +3,9 @@
 The individually-rare, collectively-expensive ways `isolation: "worktree"`
 fails to isolate what you meant: a cwd reset writing to the main checkout, an
 exported `GIT_DIR` hijacking every sibling worktree, a nested repo the harness
-never worktreed, and a fixed target branch another session already holds.
-Entry point: [`../SKILL.md`](../SKILL.md) § Worktree Preflight.
+never worktreed, two agents colliding in one shared scratchpad clone, a worktree
+deleted out from under a live agent, and a fixed target branch another session
+already holds. Entry point: [`../SKILL.md`](../SKILL.md) § Worktree Preflight.
 
 ## Worktree cwd-reset guardrail (#1480)
 
@@ -112,6 +113,81 @@ target_root=$(git -C "<target-dir>" rev-parse --show-toplevel)
 | When the target's enclosing repo ≠ the session repo, do not assume `isolation: "worktree"` isolated the target. | The harness worktrees the session repo; the nested repo is absent from it. |
 | (a) Create the **nested repo's** worktree explicitly off its own `origin/main` and point the agent at that path; **or** (b) brief the agent to `git -C <nested-repo> fetch && git -C <nested-repo> worktree add <path> origin/main` as its first step. | Both give the agent a real isolated checkout of the repo it edits, instead of the blocked shared checkout. |
 | Have the agent operate inside that nested-repo worktree (prefix `git -C "$WORKTREE"`, per the #1480 cwd-reset rule) and open its PR from there. | Keeps the work isolated and avoids the shared-checkout collisions `shared-checkout-branch-isolation.md` guards against. |
+
+## Shared scratchpad collisions (#2370)
+
+The session scratchpad directory is shared across sibling subagents, so two
+agents told to "make your own clone" independently pick the identical path and
+end up operating **one working tree**. Nothing errors: one agent's `git switch`
+moves `HEAD` under the other, so its edits land on the peer's branch and both
+PRs can carry each other's hunks. A per-file `git diff` cannot separate
+interleaved hunks in a co-modified file, so the extracted patch looks correct
+while carrying someone else's work.
+
+Give every concurrent agent an **explicit, distinct** working path in its
+prompt — `<scratchpad>/<agent-name>` — rather than letting each choose. This
+applies whenever agents work outside worktree isolation, which the nested-repo
+case above forces them into.
+
+Recovery, if it already happened: rebuild in a fresh clone and **re-apply your
+changes by hand**. Do not copy files out of the shared tree — co-modified files
+carry the peer's hunks with them. Leave the shared tree dirty rather than
+reverting it; a revert destroys the peer's uncommitted work. Verify with
+`git log --oneline origin/main..HEAD` plus `--stat` that the branch holds only
+your commits and only your paths.
+
+> Observed 2026-08: two agents fixing different defects in the same MCP server
+> collided this way. Each caught a real error in the other's cleanup — one
+> nearly shipped a merge warning that would have broken the build if acted on,
+> the other a verification `grep` that would have cried wolf. Neither shipped
+> contaminated, but only because they were talking to each other.
+
+## Deleted worktree kills the shell, not the agent (#2372)
+
+An isolation worktree removed **while its agent is still running** takes the
+agent's shell with it. The trigger for the reported occurrence is unknown — this
+section records the observed behaviour and its consequences only, not a cause.
+
+### The failure signature is a total Bash refusal, not a permission denial
+
+Once the worktree directory is gone, **every** Bash call fails, including a bare
+`echo` — the agent's cwd no longer exists, so nothing can be executed from it.
+The refusal reads like an ordinary permission-style denial, which is what makes
+it easy to misread: the natural response to one denied command is to reword it
+and try again, and every reword is denied identically. A bare `echo` is the
+cheapest probe that separates the two readings — if that fails too, the failure
+is environmental (the shell has no working directory) rather than specific to
+the command that was refused.
+
+The agent's other faculties are unaffected. It can still reason, read its own
+context, and send messages — so it can keep producing confident, specific
+conclusions it has no remaining way to verify. In the reported occurrence one
+agent in that state emitted a precise merge-order warning ("PR B needs three
+lines hand-edited or it won't compile") that was wrong, and the orchestrator had
+to disprove it empirically by performing the merge in a throwaway clone; acting
+on the warning would have caused the breakage it claimed to prevent.
+
+### A spawned subagent inherits the same dead cwd
+
+Delegation is **not** a workaround. An agent that tries to route around the dead
+working directory by spawning a child gets a child with the same dead cwd, and
+the child can execute nothing either. In the reported occurrence that attempt
+burned ~137k tokens and performed zero work. Nothing warns about this in
+advance, so an agent in this state can spend a large share of its remaining
+budget rediscovering it.
+
+The corollary for dispatch: **uncommitted work in a worktree is only as safe as
+the worktree.** Both agents in the reported occurrence had already pushed before
+the deletion, so nothing was lost — the same failure minutes earlier would have
+stranded uncommitted work in a directory that no longer exists. This is the same
+asymmetry the WIP-checkpoint instruction in
+[`../SKILL.md`](../SKILL.md) § Handling a Missing Return already trades on:
+committed work survives, uncommitted work does not.
+
+Related but distinct: `../SKILL.md` § "Resuming agents: SendMessage loses
+worktree isolation" (#1546) and the `resumeFromRunId` re-run hazard (#1868) both
+concern *resume* semantics. This is the worktree disappearing under a live agent.
+
 ## Target-branch preflight (#1969)
 
 `isolation: "worktree"` names the fresh worktree's branch **automatically** (an

--- a/docs/benchmarks/2026-07-context-engineering/README.md
+++ b/docs/benchmarks/2026-07-context-engineering/README.md
@@ -49,3 +49,19 @@ just lint-context-engineering          # Channel M card
 The C5 ratchet (`--strict`) is the one part that gates CI: it errors when the
 always-loaded surface exceeds its declared budget, so the every-session cost
 cannot grow silently. Everything else is report-only.
+
+## Quote-gate drift since the snapshot
+
+The 150 quotes were verified against the tree as it stood at the benchmark run.
+Judged files keep changing afterwards, so `quote_check.py` is a **drift log**,
+not a build gate — a failed quote means the file moved on, not that the judgment
+was fabricated. Record each drift here as it is caused, so a later reader can
+tell an ordinary edit from a broken audit trail.
+
+| Date | Change | Effect on the gate |
+|---|---|---|
+| 2026-08-15 | **#2143** relocation: the #2283 workflow-primitives table → `references/dispatch-contract.md`, the #2370 scratchpad-collision block → `references/worktree-hazards.md`, plus pointer-shortening on the #1480/#1692/#1838/#1969 Pillar-1 hazards in `parallel-agent-dispatch/SKILL.md` (26,491 → 24,998 chars, clearing the `plugin-compliance-check.sh` size ERROR). | **None.** 138 verified / 12 failed before and after, same 12 — no relocated line was a verified quote. Both judges' C1/C2/C4/C6 evidence sits outside the moved blocks. |
+
+The 12 pre-existing failures predate this table and are ordinary drift on
+`CLAUDE.md`, `comfy-node`, `test-tier-selection`, and one
+`parallel-agent-dispatch` C1 quote (reworded by the #2207 `references/` split).


### PR DESCRIPTION
Two issues that both edit `agent-patterns-plugin/skills/parallel-agent-dispatch/`, landed together so they cannot conflict.

## Part 1 — #2143: clear the repo's only compliance ❌

`SKILL.md` was **26,491 chars** against the 26,000-char ceiling — the single ❌ in `just lint-compliance` on `main`. The `references/` split already landed in #2207, so this is a **relocation into the existing structure**, not a new architecture. No guidance changed; every relocated paragraph moved verbatim.

| Moved out of the entry point | To | Left behind |
|---|---|---|
| The #2283 prose→primitive mapping table | `references/dispatch-contract.md` § "The Return Contract as workflow primitives" — which already held that section's two cautions and cost gate, and pointed *back* at SKILL.md for the table | One-line pointer |
| The #2370 shared-scratchpad-collision block (mechanism, recovery, observed case) | `references/worktree-hazards.md` § "Shared scratchpad collisions (#2370)" | One-line pointer |
| Pointer prose on the #1480 / #1692 / #1838 / #1969 Pillar-1 hazards | *(already fully in `references/worktree-hazards.md`)* — shortened in place | Tightened pointers |

The fourth row is the issue's own judged target ("move the rare worktree-hazard case studies out of the entry point, leaving one-line pointers behind"). All four hazards already had complete reference sections, so nothing was lost — only the duplicated prose in the entry point.

**26,491 → 24,998 chars** (~1,000 headroom). `REFERENCE.md` stays the thin index; both rows updated to name the material each file now owns.

## Part 2 — #2372: document the deleted-worktree hazard

Option A of the issue's decision comment — the **two purely descriptive items only**, added to `references/worktree-hazards.md`:

1. **The failure signature is a total Bash refusal, not a permission denial.** Once the worktree is gone every Bash call fails, including a bare `echo` — which reads like an ordinary denial, so the natural response (reword and retry) is denied identically. The agent's reasoning and messaging are unaffected, so it can keep emitting confident conclusions it has no way to verify; in the reported case it produced a specific, *wrong* merge-order warning that had to be disproved empirically.
2. **A spawned subagent inherits the same dead cwd.** Delegation is not an escape hatch — ~137k tokens, zero work in the reported case, with nothing warning about it in advance.

Both are true regardless of the (still unknown) trigger, and neither changes behaviour.

**Deliberately NOT implemented:** the issue's third suggestion, instructing an agent to treat all-Bash-failure as terminal and stop. One incident does not calibrate that false-positive/false-negative boundary. It stays on #2372 for a later pass with more evidence.

## Verification

| Gate | Before | After |
|---|---|---|
| `plugin-compliance-check.sh` | exit 1, **1 ❌** (`26491 chars > 26000`) | **exit 0, 0 ❌** — `agent-patterns-plugin` row ❌ → ⚠️ (pre-existing size/description warnings only) |
| `check-agent-failure-contract.sh` | OK | **OK** — all 23 pinned SKILL.md literals + the reference-file and index-integrity markers survive |
| `quote_check.py` | 138 verified / 12 failed | **138 verified / 12 failed — the same 12** |

The quote gate is **unchanged**: no relocated line was one of the 150 verified evidence quotes. Both judges' C1/C2/C4/C6 evidence sits outside the moved blocks. The 12 failures are pre-existing drift on `CLAUDE.md`, `comfy-node`, `test-tier-selection`, and one `parallel-agent-dispatch` C1 quote reworded by the earlier #2207 split.

Because that gate is a drift log rather than a build gate, this PR adds a **"Quote-gate drift since the snapshot"** table to `docs/benchmarks/2026-07-context-engineering/README.md` recording this change as a no-drift entry — so a later reader can tell an ordinary edit from a broken audit trail, per the instruction on #2143.

## Out of scope

The 56-skill flat-large-body backlog (`check-context-engineering.py --json` → `flat_large_body`) stays on #2143's "then the rest" queue as separate incremental PRs.

Closes #2143
Closes #2372
