### PR TITLE
docs(health-plugin): record that pluginUsage.usageCount counts hook fires

### DIFF
--- a/.claude/rules/plugin-usage-telemetry.md
+++ b/.claude/rules/plugin-usage-telemetry.md
@@ -1,0 +1,103 @@
+---
+created: 2026-08-15
+modified: 2026-08-15
+reviewed: 2026-08-15
+paths:
+  - "health-plugin/**"
+  - "evaluate-plugin/**"
+---
+# `pluginUsage.usageCount` Counts Hook Fires, Not Plugin Value
+
+`~/.claude.json` carries a `pluginUsage` map — `usageCount`, `lastUsedAt`,
+`lastUsedNumStartups` per installed plugin. It reads like a "how much is this
+plugin earning its catalog cost?" counter. It is not one: **hook fires are
+counted in the same number as skill, agent, and command deliveries**, and the
+hook term runs three to four orders of magnitude ahead. A plugin that has
+delivered nothing but registers one `SessionStart` hook outranks a hookless
+plugin that really was invoked, by roughly 20×.
+
+## The measurement
+
+Measured 2026-08-15 against `~/.claude.json`, correlated with each plugin's
+declared hooks. Hook declarations resolve **two ways** — an inline `hooks`
+object in `.claude-plugin/plugin.json`, or a `"hooks": "./hooks.json"` **string
+reference** to a sibling file — and reading only the inline form scores six
+plugins here (`git-plugin`, `terraform-plugin`, `blueprint-plugin`,
+`code-quality-plugin`, `codebase-attributes-plugin`, `agent-patterns-plugin`)
+as declaring none, which inverts the correlation.
+
+| Plugin | `usageCount` | Hook entries | Matcher |
+|---|---:|---:|---|
+| `hooks-plugin` | 207,210 | 12 across 8 events | per-tool-call |
+| `git-plugin` | 64,107 | 3 (via `hooks.json`) | `PreToolUse: Bash` |
+| `blueprint-plugin` | 13,204 | 22 (via `hooks.json`) | path-scoped `docs/**` |
+| `session-plugin` | 5,474 | 2 | `SessionStart` + `Stop` |
+| `health-plugin` | 1,536 | 1 | `SessionStart` |
+| `agent-patterns-plugin` | 24 | 2 (via `hooks.json`) | `PreCompact` |
+| `project-plugin` | 67 | **none** | — |
+| `tools-plugin` | 6 | **none** | — |
+
+The separation is clean: every plugin above 126 declares hooks; every one of the
+30 hookless plugins sits at or below 67. Two rows refine the mechanism past
+"has hooks":
+
+- **Entry count does not drive it.** `blueprint-plugin`'s 22 path-scoped entries
+  earn a fifth of `git-plugin`'s 3 broad ones. What multiplies is *matcher
+  breadth × event frequency*.
+- **A rare event ranks below no hooks at all.** `agent-patterns-plugin` declares
+  2 `PreCompact` hooks and sits at 24 — under three hookless plugins. So a low
+  count is not evidence of no hooks either; the counter tracks **trigger
+  cadence** and nothing else.
+
+Corroborating: the `SessionStart`-only cohort (`configure`, `health`,
+`taskwarrior`, `evaluate`, `session`) all share the identical `lastUsedAt`
+millisecond `1786786648800` — one session-start event dispatching five plugin
+hooks in lockstep. And the counter moves while you read it: `hooks-plugin` went
+206,856 → 207,137 → 207,210 over one working session, tracking tool calls rather
+than any use of the plugin.
+
+## Nothing in this repo reads it — keep it that way
+
+A repo-wide search for `pluginUsage` / `usageCount` across `*.md`, `*.sh`,
+`*.py`, and `*.json` returns **zero** hits. In particular
+`health-plugin:health-check` does **not** consume it:
+
+| Scope | Reads |
+|---|---|
+| `--scope=runtime` | `~/.claude.json`, but only for **bloat** — dead `projects[]`, dead `githubRepoPaths[*]`, orphaned `disabledMcpServers[]`, duplicate MCP names |
+| `--scope=usage` | `~/.claude/projects/*/*.jsonl` **session transcripts**, mining skill/agent invocation recency (never-fired, dormant) |
+
+So no normalization work is owed anywhere. This rule exists so the counter is
+not *newly* wired into a ranking by someone who reads it as a value signal — the
+tempting consumers being `health-plugin`'s audit scopes and `evaluate-plugin`'s
+effectiveness measurement.
+
+## The delivery signal, and its exact spelling
+
+Per-call attribution in the session transcripts measures delivery directly.
+**The keys are lowercase-first**, and the capitalized spelling matches nothing:
+
+| Field | Non-empty calls | Distinct values |
+|---|---:|---:|
+| `attributionAgent` | 5,562 | 5 |
+| `attributionSkill` | 3,607 | 25 |
+| `attributionPlugin` | 2,880 | 9 |
+| `attributionMcpServer` / `attributionMcpTool` | 320 | — |
+
+Measured over the 200 most-recent transcripts (56,598 lines, 21,298 carrying a
+`tool_use`). Scanning for `AttributionPlugin` instead returns **0** — a clean
+zero that reads exactly like "the field is never populated", which is why the
+control matters (`~/.claude/rules/never-fabricate-test-identifiers.md`).
+
+`attributionAgent` is populated — in fact it is the **most** common of the three
+(`workflow-subagent` 2,955, `general-purpose` 2,077, `Explore` 400,
+`feedback-plugin:friction-learner` 91, `Plan` 39). A `--scope=usage` run already
+reads agent dispatch from `Agent`/`Task` `subagent_type` events; this field is
+the per-call complement, not a gap.
+
+## Related
+
+- `health-plugin:health-check` — `--scope=usage` (transcript mining) and `--scope=runtime` (`~/.claude.json` bloat); neither touches the counter
+- `.claude/rules/skill-evaluation.md` — how skill *effectiveness* is actually measured (with-skill vs baseline delta), the question the counter looks like it answers
+- `.claude/rules/context-engineering.md` — the catalog-cost question a delivery signal would inform
+- `~/.claude/rules/never-fabricate-test-identifiers.md` — the capitalized-spelling zero above is this trap in miniature

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ Claude Code plugin collection providing skills and agents for development workfl
 | `.claude/rules/gitattributes.md` | `.gitattributes` conventions — `merge=union` only for one-line-per-entry append-only files, `linguist-generated` for build output (always safe), LF normalization; the `configure-gitattributes` skill + `resolve-additive-conflicts.py` pre-pass |
 | `.claude/rules/task-id-stability.md` | Taskwarrior numeric IDs renumber after every close — resolve the immutable UUID once and mutate by UUID, including *within* a single skill's own multi-step lifecycle, not just across bulk loops |
 | `.claude/rules/generated-fleet-drift.md` | Auditing a generated fleet — divergence is not automatically drift: it is bidirectional (never auto-apply template → instance), an identically-diverging cohort signals intent, and undeclared intent is unauditable |
+| `.claude/rules/plugin-usage-telemetry.md` | `~/.claude.json`'s `pluginUsage.usageCount` counts **hook fires**, so it ranks trigger cadence rather than plugin value — nothing in this repo reads it (incl. `health-check --scope=usage`, which mines transcripts); the delivery signal is the **lowercase-first** `attributionPlugin`/`attributionSkill`/`attributionAgent` |
 
 ## Authoring Skills and Plugins
 

--- a/health-plugin/skills/health-check/SKILL.md
+++ b/health-plugin/skills/health-check/SKILL.md
@@ -188,6 +188,8 @@ Parse `STATUS=`, `HISTORY_AVAILABLE=`, `TRANSCRIPTS_SCANNED=`, `SKILLS_ENABLED=`
 
 The usage scope mines local session transcripts (`~/.claude/projects/*/*.jsonl`) for skill- and agent-invocation recency: **never-fired** skills/agents (installed but zero invocations in history) and **dormant** skills/agents (last invoked more than the window ago). Agent invocations are read from `Agent`/`Task` `tool_use` events keyed by `subagent_type`. Findings are **advisory review candidates**, not a delete list — a skill or agent can be correct yet rarely needed (recovery, migration, on-demand subagents gated behind a parent skill). The audit is **read-only** (no `--fix` path).
 
+> **This scope does not read `~/.claude.json`'s `pluginUsage.usageCount`, and must not start.** That counter tallies **hook fires** in the same number as skill/agent/command deliveries, so it ranks a plugin by hook-trigger cadence rather than by use — see [`.claude/rules/plugin-usage-telemetry.md`](../../../.claude/rules/plugin-usage-telemetry.md). Transcript mining is the delivery signal; the `runtime` scope's use of `~/.claude.json` is unrelated (file bloat only).
+
 > **Local-leaning.** Session history is local and long-lived, so this scope is near-useless in a remote/web sandbox (a fresh clone has ≤1 transcript). It emits `STATUS=SKIP` with `HISTORY_AVAILABLE=false` when there are fewer than two transcripts rather than reporting every skill as never-fired. If `TRANSCRIPTS_SCANNED>0` but zero tool calls parse, it emits `STATUS=WARN TYPE=schema_drift` (the transcript JSON shape changed) instead of a bogus all-never-fired result.
 
 ### Step 3: Report findings


### PR DESCRIPTION
## What

Records that `~/.claude.json`'s `pluginUsage.usageCount` counts **hook fires**, so it cannot be read as a plugin-value signal. Three files:

- `.claude/rules/plugin-usage-telemetry.md` — new, `paths:`-scoped
- `health-plugin/skills/health-check/SKILL.md` — one clarifying callout at the `--scope=usage` description
- `CLAUDE.md` — one pointer row

**The issue body is partly wrong and this PR says so rather than implementing it as written.** Two of its claims did not survive verification, and one of its measurements was reproduced but with a materially different reading.

## Verified independently

Everything below was re-measured against this machine on 2026-08-15, not carried over from the issue.

### 1. The counter tracks hook cadence — confirmed, with a correction to the method

The issue's own table lists `git-plugin`, `terraform-plugin`, `blueprint-plugin` and `code-quality-plugin` nowhere, and `codebase-attributes-plugin` / `agent-patterns-plugin` are absent too. The reason matters: hook declarations resolve **two ways** — an inline `hooks` object in `.claude-plugin/plugin.json`, or a `"hooks": "./hooks.json"` **string reference** to a sibling file. Reading only the inline form scores those six as declaring no hooks, which inverts the correlation for the second-largest counter in the whole map (`git-plugin`, 64,107).

Resolving both forms gives a clean separation — every plugin above 126 declares hooks; all 30 hookless plugins sit at or below 67:

| Plugin | `usageCount` | Hook entries | Matcher |
|---|---:|---:|---|
| `hooks-plugin` | 207,210 | 12 across 8 events | per-tool-call |
| `git-plugin` | 64,107 | 3 (via `hooks.json`) | `PreToolUse: Bash` |
| `blueprint-plugin` | 13,204 | 22 (via `hooks.json`) | path-scoped `docs/**` |
| `session-plugin` | 5,474 | 2 | `SessionStart` + `Stop` |
| `health-plugin` | 1,536 | 1 | `SessionStart` |
| `agent-patterns-plugin` | 24 | 2 (via `hooks.json`) | `PreCompact` |
| `project-plugin` | 67 | none | — |
| `tools-plugin` | 6 | none | — |

My `hooks-plugin` reading is **207,210**, against the issue's 164,694. Not a discrepancy — the counter climbs continuously. It moved 206,856 → 207,137 → 207,210 across this session alone, which is itself the cleanest evidence that it tracks tool calls rather than any use of the plugin.

Two rows refine the mechanism past "has hooks", and neither is in the issue:

- **Entry count does not drive it.** `blueprint-plugin`'s 22 path-scoped entries earn a fifth of `git-plugin`'s 3 broad ones. What multiplies is *matcher breadth × event frequency*.
- **A rare event ranks below no hooks at all.** `agent-patterns-plugin` declares 2 `PreCompact` hooks and sits at 24 — under three hookless plugins. So a low count is not evidence of no hooks either.

The `SessionStart`-only cohort sharing one `lastUsedAt` millisecond (`1786786648800`) reproduced exactly as described.

### 2. `health-check` does not read the counter — no normalization is owed

Confirmed, and more strongly than the issue's "How" section assumes. A repo-wide search for `pluginUsage` / `usageCount` across `*.md`, `*.sh`, `*.py` and `*.json` returns **zero hits**. Nothing anywhere reads it.

| Scope | Reads |
|---|---|
| `--scope=runtime` | `~/.claude.json`, but only for **bloat** — dead `projects[]`, dead `githubRepoPaths[*]`, orphaned `disabledMcpServers[]`, duplicate MCP names |
| `--scope=usage` | `~/.claude/projects/*/*.jsonl` **session transcripts** — never-fired and dormant skills/agents |

So the issue's second "How" bullet (normalize the hook term inside `health-check`) has no target. The `--scope=usage` mechanism was verified by reading both `SKILL.md` and `scripts/check-usage.sh`. This also makes the maintainer's Question 1 (Option A vs B for normalizing the counter) moot — there is nothing to normalize. The rule instead exists so the counter is not *newly* wired into a ranking by a future reader.

### 3. The attribution fields are lowercase-first, and `attributionAgent` is **not** empty

This is the correction with the most consequence for anyone acting on the issue.

The issue names `AttributionPlugin` / `AttributionSkill` / `AttributionAgent`. Scanning 200 transcripts for those exact strings returns **0 attributed calls** — a clean, well-formed zero that reads exactly like "the harness never populates these". A recursive key scan with a control (21,298 lines carrying a `tool_use`, so the scan provably works) shows the real keys are **lowercase-first**:

| Field | Non-empty calls | Distinct values |
|---|---:|---:|
| `attributionAgent` | 5,562 | 5 |
| `attributionSkill` | 3,607 | 25 |
| `attributionPlugin` | 2,880 | 9 |
| `attributionMcpServer` / `attributionMcpTool` | 320 | — |

The issue states "`AttributionAgent` was empty across all 29,071 calls sampled, so agent dispatch needs a different source." **It is populated, and it is the most common of the three** — `workflow-subagent` 2,955, `general-purpose` 2,077, `Explore` 400, `feedback-plugin:friction-learner` 91, `Plan` 39. The most likely explanation for the original empty result is the capitalized spelling, which matches nothing. No different source is needed.

I have carried the caveat the task asked for, but inverted to match the measurement: the rule records that the field *is* populated and names the exact spelling, since a capitalized query silently returns zero.

## The `paths:` decision

Scoped to `health-plugin/**` and `evaluate-plugin/**`.

Rules **without** `paths:` load into every session. There are currently 12 such files totalling 74,580 chars, and #2140 is actively shrinking that surface. Measured with the repo's own ratchet, before and after:

```
C5_UNSCOPED_RULES=12
C5_UNSCOPED_RULE_CHARS=74580     # byte-identical before and after this PR
C5_ALWAYS_LOADED_CHARS=88747     # budget 100000
```

Scoping keeps the always-loaded surface **unchanged**. Unscoped, this rule would have added 5,313 chars (13 files / ~79,900), spending 7% of the remaining headroom before the ERROR ceiling on a rule that is inert unless someone is editing telemetry-consuming code. The two globs cover the only plausible consumers: `health-plugin`'s audit scopes and `evaluate-plugin`'s effectiveness measurement. The `CLAUDE.md` row (371 chars) is the always-loaded cost actually paid, and it is what makes the rule discoverable from a session that has not opened either plugin.

## Deliberately not done

Per the maintainer's Question 2 default (Option A), this PR does not touch `evaluate-plugin`'s catalog entries. Whether its 7 skills + 3 agents earn their listing cost is a separate, outward-facing call, and the counter reading 1,412 was never evidence either way. Worth noting the issue's supporting figure is now weaker than it looked: `attributionAgent` **does** carry agent dispatches, so "zero of its 3 agents ever dispatched" rests on a field that reads empty only under the wrong spelling. That question deserves a re-measurement with the corrected key before anyone retires anything.

## Verification

- `just lint-compliance` — the only ❌ is the pre-existing `agent-patterns-plugin/parallel-agent-dispatch` size finding on `main` (26,491 chars, being fixed separately). No new ❌; `health-plugin` and `evaluate-plugin` rows are ✅ apart from pre-existing size/description ⚠️.
- `scripts/check-docs-index.sh` — `STATUS=OK ISSUE_COUNT=0`, `RULES_ON_DISK=46` == `RULES_IN_TABLE=46` (new rule counted and indexed).
- `scripts/check-context-engineering.py --strict` — exit 0, always-loaded surface unchanged.
- Rebased onto `f29be691` (#2393) so CI runs against the current `main` rather than the base the branch was cut from.

Closes #2245
