### PR TITLE
refactor(tools-plugin): apply the demoted body-section mandates

### DIFF
--- a/tools-plugin/skills/cli-smoke-recipes/SKILL.md
+++ b/tools-plugin/skills/cli-smoke-recipes/SKILL.md
@@ -4,7 +4,7 @@ description: "CLI smoke recipes: expose pure-function modules via subcommands wi
 allowed-tools: Read, Grep, Glob, TodoWrite
 model: sonnet
 created: 2026-04-24
-modified: 2026-05-09
+modified: 2026-08-15
 reviewed: 2026-04-24
 ---
 
@@ -18,7 +18,7 @@ Every pure-function module that transforms data should be reachable from the she
 |---------------------|------------|
 | Designing a new module with a clear input → output contract | Internal helper with no stable interface |
 | Adding CLI exposure to an existing library | Code whose only consumer is another in-process module |
-| Authoring justfile recipes for bulk verification | One-off scripts |
+| Authoring justfile recipes for bulk verification | One-off scripts, or recipe syntax generally — use `justfile-expert` |
 | Deciding if a feature is complete | Implementation is purely experimental |
 
 ## The Pattern

--- a/tools-plugin/skills/d2-diagrams/SKILL.md
+++ b/tools-plugin/skills/d2-diagrams/SKILL.md
@@ -5,7 +5,7 @@ user-invocable: false
 allowed-tools: Bash(d2 *), Read, Write, Grep, Glob, TodoWrite
 model: sonnet
 created: 2025-12-26
-modified: 2026-07-18
+modified: 2026-08-15
 reviewed: 2026-07-18
 ---
 
@@ -15,8 +15,8 @@ Expert in generating diagrams from declarative text definitions using D2 - a mod
 
 ## When to Use This Skill
 
-| Use this skill when... | Use Mermaid instead when... |
-|------------------------|-----------------------------|
+| Use this skill when... | Use `mermaid-diagrams` instead when... |
+|------------------------|----------------------------------------|
 | Rich styling with classes and themes | Embedding diagrams in GitHub Markdown |
 | Complex nested container layouts | Simple flowcharts with minimal styling |
 | Architecture diagrams with icons | Diagrams that render natively in docs platforms |
@@ -59,6 +59,9 @@ d2 diagram.d2 diagram.svg
 
 # Convert to PNG
 d2 diagram.d2 diagram.png
+
+# Convert to PNG at 2x resolution
+d2 --scale 2 diagram.d2 diagram.png
 
 # Convert to PDF
 d2 diagram.d2 diagram.pdf
@@ -414,18 +417,6 @@ commit -> done
 ```
 
 For additional patterns (Database ERD, Kubernetes Deployment), special shapes (sql_table, class, code blocks), layers, theme categories, and a full D2 vs Mermaid comparison, see [REFERENCE.md](REFERENCE.md).
-
-## Agentic Optimizations
-
-| Context | Command |
-|---------|---------|
-| Quick SVG | `d2 diagram.d2 diagram.svg` |
-| Live preview | `d2 --watch --browser diagram.d2` |
-| Dark theme | `d2 --dark-theme 200 diagram.d2 output.svg` |
-| Sketch style | `d2 --sketch diagram.d2 output.svg` |
-| ELK layout | `d2 -l elk diagram.d2 output.svg` |
-| List themes | `d2 themes` |
-| PNG export | `d2 --scale 2 diagram.d2 output.png` |
 
 ## Quick Reference
 

--- a/tools-plugin/skills/hf-downloads/SKILL.md
+++ b/tools-plugin/skills/hf-downloads/SKILL.md
@@ -3,7 +3,7 @@ name: hf-downloads
 description: "Hugging Face model downloads without filling root disk — HF_HOME/xet cache redirection, token/gated-repo auth, staging pattern. Use when downloading HF models, hf download errors, ENOSPC during downloads, or GatedRepoError/401s."
 allowed-tools: Bash, Read
 created: 2026-07-05
-modified: 2026-07-05
+modified: 2026-08-15
 reviewed: 2026-07-05
 ---
 
@@ -11,14 +11,7 @@ reviewed: 2026-07-05
 
 Download Hugging Face models to a big disk without filling root, authenticate against gated repos, and verify transfers — the failure modes that make multi-GB `hf download` runs abort or 401.
 
-## When to Use This Skill
-
-| Use this skill when... | Skip it when... |
-|------------------------|-----------------|
-| Downloading multi-GB HF models (`*.safetensors`, GGUF) to a specific disk | A tiny file where cache size is irrelevant |
-| `hf download` fails with `No space left on device` (ENOSPC) mid-transfer | Disk-full recovery in general (use `macos-plugin:macos-disk-usage`) |
-| A gated download 401s with `GatedRepoError` even though `hf auth whoami` works | Non-HF downloads (`curl`, `wget`, git-lfs from elsewhere) |
-| Deciding where to stage a large download so it doesn't fill root | The tool is not `huggingface_hub` / `hf` |
+Scoped to `huggingface_hub` / `hf`. For disk-full recovery in general — reclaiming space, hunting what filled the disk — use `macos-plugin:macos-disk-usage` instead.
 
 ## The Core Trap: `--local-dir` Does Not Cover Transfer State
 

--- a/tools-plugin/skills/justfile-expert/SKILL.md
+++ b/tools-plugin/skills/justfile-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 created: 2025-12-16
-modified: 2026-05-09
+modified: 2026-08-15
 reviewed: 2026-02-06
 name: justfile-expert
 description: Just command runner expertise — Justfile syntax, recipes, parameters, modules, shebang recipes. Use when authoring justfiles, project commands, or task automation.
@@ -20,9 +20,9 @@ Expert knowledge for Just command runner, recipe development, and task automatio
 | Creating/editing justfiles for task automation | Need build system with incremental compilation → Make |
 | Writing cross-platform project commands | Need tool version management bundled → mise tasks |
 | Adding shebang recipes (Python, Node, Ruby, etc.) | Already using mise for all project tooling |
-| Configuring dotenv loading and settings | Simple one-off shell scripts → Bash directly |
+| Configuring dotenv loading and settings | Authoring the shell itself (pipes, traps, arg parsing) → `shell-expert` |
 | Setting up CI/CD with just recipes | Project already has extensive Makefile |
-| Standardizing recipes across projects | Need Docker-specific workflows → docker-compose |
+| Standardizing recipes across projects | Exposing a module for bulk smoke-testing → `cli-smoke-recipes` |
 
 ## Core Expertise
 

--- a/tools-plugin/skills/mermaid-diagrams/SKILL.md
+++ b/tools-plugin/skills/mermaid-diagrams/SKILL.md
@@ -5,7 +5,7 @@ user-invocable: false
 allowed-tools: Bash, Read, Write, Grep, Glob, TodoWrite
 model: sonnet
 created: 2025-12-26
-modified: 2026-05-09
+modified: 2026-08-15
 reviewed: 2026-04-25
 ---
 
@@ -81,6 +81,13 @@ mmdc -i diagram.mmd -o diagram.png -w 1920 -H 1080
 
 # Scale factor
 mmdc -i diagram.mmd -o diagram.png -s 2
+```
+
+### Batch Rendering
+
+```bash
+# Render every .mmd in the directory to a sibling .svg
+for f in *.mmd; do mmdc -i "$f" -o "${f%.mmd}.svg"; done
 ```
 
 ## Diagram Types
@@ -222,17 +229,6 @@ docker run --rm -v "$(pwd)":/data minlag/mermaid-cli -i /data/diagram.mmd -o /da
 # With UID for correct permissions
 docker run -u $UID --rm -v "$(pwd)":/data minlag/mermaid-cli -i /data/diagram.mmd
 ```
-
-## Agentic Optimizations
-
-| Context | Command |
-|---------|---------|
-| Quick SVG | `mmdc -i diagram.mmd -o diagram.svg` |
-| PNG with transparency | `mmdc -i diagram.mmd -o diagram.png -b transparent` |
-| High-res PNG | `mmdc -i diagram.mmd -o diagram.png -s 2` |
-| Dark theme | `mmdc -i diagram.mmd -o diagram.svg -t dark` |
-| Batch process | `for f in *.mmd; do mmdc -i "$f" -o "${f%.mmd}.svg"; done` |
-| Stdin pipe | `echo 'graph TD; A-->B' \| mmdc --input - -o out.svg` |
 
 ## Quick Reference
 

--- a/tools-plugin/skills/yq-yaml-processing/SKILL.md
+++ b/tools-plugin/skills/yq-yaml-processing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 created: 2025-12-16
-modified: 2026-05-04
+modified: 2026-08-15
 reviewed: 2025-12-16
 name: yq-yaml-processing
 description: "yq YAML processing: query, filter, transform YAML. Use when parsing configs, modifying Kubernetes manifests or GitHub Actions workflows, or transforming YAML."
@@ -15,12 +15,12 @@ Expert knowledge for processing, querying, and transforming YAML data using yq v
 
 ## When to Use This Skill
 
-| Use this skill when... | Use another tool instead when... |
+| Use this skill when... | Use another skill instead when... |
 |------------------------|----------------------------------|
-| Querying or modifying YAML files | Processing JSON only (use jq) |
-| Updating Kubernetes manifests | Full Kubernetes management (use kubectl) |
-| Processing GitHub Actions workflows | XML processing (use xmlstarlet) |
-| Merging YAML configurations | Complex data transformations (use scripting) |
+| Querying or modifying YAML files | The input is JSON only — use `jq-json-processing` |
+| Editing YAML in place while preserving comments and key order | Multi-step transforms spanning YAML, JSON, CSV, TOML — use `nushell-data-processing` |
+| Targeted updates to a Kubernetes manifest or Actions workflow | Full Kubernetes management (use kubectl); XML (use xmlstarlet) |
+| Merging YAML configurations | Aggregating or grouping across many files — use `nushell-data-processing` |
 
 ## Core Expertise
 
@@ -129,17 +129,15 @@ yq eval-all 'select(fileIndex == 0) * select(fileIndex == 1)' base.yaml override
 yq eval-all '. as $item ireduce ({}; . *+ $item)' base.yaml override.yaml
 ```
 
-## Agentic Optimizations
+### JSON Output (for piping)
 
-| Context | Command |
-|---------|---------|
-| Read field | `yq '.field' file.yaml` |
-| Update in-place | `yq -i '.field = "value"' file.yaml` |
-| YAML to JSON | `yq -o=json '.' file.yaml` |
-| Compact JSON | `yq -o=json -I=0 '.' file.yaml` |
-| Filter documents | `yq 'select(.kind == "Deployment")' file.yaml` |
-| Merge configs | `yq eval-all 'select(fileIndex == 0) * select(fileIndex == 1)' base.yaml override.yaml` |
-| Validate YAML | `yq '.' file.yaml` |
+```bash
+# YAML to JSON
+yq -o=json '.' file.yaml
+
+# Compact single-line JSON — the form to pipe into jq or a tool that reads stdin
+yq -o=json -I=0 '.' file.yaml
+```
 
 ## Quick Reference
 


### PR DESCRIPTION
`Refs #2141` (3 of 45 affected directories; the remaining 42 stay deferred — `python-plugin` is the next slice)

Applies [`.claude/rules/context-engineering.md`](../blob/main/.claude/rules/context-engineering.md) § Supersedes to `tools-plugin`. PR #2198 already demoted `check_skill_when_to_use()` from ERROR to advisory (verified on disk — `plugin-compliance-check.sh` now emits `⚠️ … no '## When to Use This Skill' section — recommended where sibling skills compete`), so removing either section no longer fails the lint.

This supersedes #1156 for these 15 skills. **#1156 is not wrong and is untouched by this PR** — it standardised these tables correctly for the model era it was written in, and has been closed-as-completed since 2026-04-25 (by #1188–#1191). This is the same question re-measured against Claude 5 guidance, not a retraction.

## Per-skill decisions (all 15)

| Skill | When-to-Use | Agentic Opts | Reason |
|---|---|---|---|
| `binary-analysis` | **kept** | *(none)* | Contrast column already names two real siblings — `rg-code-search` (searching text-encoded files) and `jq-json-processing` (already-structured data). "Search this file for strings" is a genuine 3-way routing decision. |
| `cli-smoke-recipes` | **kept** *(sharpened)* | *(none)* | The Skip column carries four substantive anti-triggers (internal helper, in-process-only consumer, one-off script, purely experimental) that the description — "Use when designing data-transform modules" — would over-fire without. Sharpened: the justfile row now names `justfile-expert`, which genuinely competes on the recipe-authoring half. |
| `d2-diagrams` | **kept** *(sharpened)* | **dropped** | `mermaid-diagrams` is the archetypal competing sibling; the header said "Use Mermaid instead" (the tool) and now names the skill. AO dropped: 6 of 7 rows were byte-identical to `## Essential Commands` (see evidence below); the one unique row (`--scale 2` PNG) moved into Basic Rendering. |
| `deps-install` | **kept** | *(none)* | Two contrast blocks naming `justfile-expert` and `shell-expert` — both real siblings, both plausible for "install these deps". |
| `fd-file-finding` | **kept** | *(none)* | `fd` vs `rg` is the single most confusable pair in the plugin; the table also routes to `jq-json-processing`. |
| `generate-image` | **kept** | *(none)* | Routes against `imagemagick-conversion` (existing image vs new image) and `mermaid-diagrams`/`d2-diagrams` (photo vs diagram). All three are in-plugin siblings. |
| `hf-downloads` | **dropped** | **kept** | The only skill with no competing sibling — nothing else in `tools-plugin` downloads anything. Its 228-char description already carries every trigger the table's left column carried (`downloading HF models, hf download errors, ENOSPC during downloads, GatedRepoError/401s`). The one routing row worth keeping — general disk-full recovery → `macos-plugin:macos-disk-usage` — was preserved as a lead sentence. AO kept: the `HF_HOME=… hf download … --local-dir` and `export HF_TOKEN="$(cat …)"` incantations *are* the skill's payload. |
| `imagemagick-conversion` | **kept** | *(none)* | Right column already names `generate-image` and `github-actions-plugin:github-social-preview` inline. |
| `jq-json-processing` | **kept** | *(none)* | Two blocks against `yq-yaml-processing` and `nushell-data-processing`. The jq/yq/nushell triangle is the plugin's densest routing cluster. |
| `justfile-expert` | **kept** *(sharpened)* | **kept** | Table kept — `shell-expert`, `cli-smoke-recipes` and `deps-install` all compete — but its right column named only external tools (Make, mise, Bash, docker-compose). Two rows now name the real in-plugin siblings. AO kept: the body is about justfile *syntax*; the AO table is the only place the `just` **CLI's own flags** (`--dry-run`, `--evaluate`, `--dump --dump-format json`, `--choose`) appear. |
| `mermaid-diagrams` | **kept** | **dropped** | Other half of the `d2-diagrams` pair. AO dropped: 5 of 6 rows byte-identical to `## Essential Commands`; the unique batch-render loop became a `### Batch Rendering` block. |
| `nushell-data-processing` | **kept** | **kept** | Routes against `jq-json-processing` and `yq-yaml-processing`. AO kept for a non-obvious reason: every body example is an *inside-nushell* pipeline in a ```nushell fence (`open data.json \| to json -r`), so the AO table is the **only** place the `nu -c '…'` shell-invocation shape appears — which is the form an agent actually calls. |
| `rg-code-search` | **kept** | *(none)* | Two blocks against `fd-file-finding` and `binary-analysis`. |
| `shell-expert` | **kept** | *(none)* | Two blocks against `justfile-expert` and `jq-json-processing`. |
| `yq-yaml-processing` | **kept** *(sharpened)* | **dropped** | Table kept but its right column pointed at bare tool names ("use jq", "use scripting"); it now names `jq-json-processing` and `nushell-data-processing` — the latter replacing the vague "complex data transformations (use scripting)", which is what nushell actually is. AO dropped: 5 of 7 rows restate the body. The two genuinely-agentic rows (`-o=json`, `-o=json -I=0`) were preserved as a `### JSON Output (for piping)` block. |

**Totals:** When-to-Use 14 kept / 1 dropped, 4 of the kept ones sharpened to name real in-plugin siblings. Agentic Optimizations 3 kept / 3 dropped (9 skills never had one).

## The AO drops are measured, not asserted

The steer for `tools-plugin` is to keep more AO tables than elsewhere, because it is full of CLI wrappers. The three drops were each checked row-by-row against the body rather than by category:

| Skill | Rows | Verbatim duplicates of `## Essential Commands` | Unique rows (all preserved in the body) |
|---|---|---|---|
| `d2-diagrams` | 7 | 6 — `d2 diagram.d2 diagram.svg`, `--watch --browser`, `--dark-theme 200`, `--sketch`, `-l elk`, `d2 themes` | `--scale 2` PNG → moved into Basic Rendering |
| `mermaid-diagrams` | 6 | 5 — `-i/-o` SVG, `-b transparent`, `-s 2`, `-t dark`, stdin pipe | the batch `for f in *.mmd` loop → new `### Batch Rendering` |
| `yq-yaml-processing` | 7 | 5 — read field, `-i` update, `select(.kind …)`, `eval-all` merge, and "Validate YAML" which is row 1 repeated | `-o=json` and `-o=json -I=0` → new `### JSON Output (for piping)` |

Note the three canonical CLI wrappers the rule names as the keep-case — `rg`, `fd`, `jq` — carry **no** AO section in this plugin today, so the category argument alone would not have been consistent either way.

**No content was deleted.** Every unique command from a dropped table survives in the body; the four sharpened tables lost no anti-trigger (`cli-smoke-recipes` keeps "One-off scripts" alongside the new sibling name).

## Pin safety

`grep -rn` over `scripts/` (excluding `/tests/`) for `tools-plugin` plus all 15 skill directory names returns exactly two hits, both **comments** and neither a pin on a section this PR touches:

- `check-unrendered-templates.sh:13` — names `deps-install` in a historical comment (#2265); that file is untouched here.
- `check-context-command-execution.sh:202` — names `binary-analysis:204` and its `` `Rar!` `` table cell (#1744); that file is untouched here.

`plugin-compliance-check.sh` `check_skill_body()` pins nothing in `tools-plugin`.

## Two corrections to the issue's evidence

The issue is weeks old and its counts have drifted. Re-measured on `main` today:

| Issue states | Measured today | Note |
|---|---|---|
| `## When to Use This Skill` at **407 / 407** | **406** (`check-context-engineering.py`) of **410** skills (`audit-skill-descriptions.py`, 44 plugins) | Three different denominators are in play — the two scanners use different scan sets (`check-context-engineering.py` includes repo-internal `.claude/skills/`, `audit-skill-descriptions.py` does not). PR #2201 flagged this as 407-vs-408; it has since moved again. Neither is 407/407, and compliance is no longer universal. |
| `## Agentic Optimizations` on **257** skills | **250** | Drifted down as earlier slices of this issue landed (#2200, #2201). |

No file this PR touches had already been fixed by a later commit — `git log -3` on all six shows the most recent change is #2264 (a justfile `{{...}}` quoting note), unrelated to either section.

## Character delta

Measured as characters (decoded UTF-8), not bytes, per `.claude/rules/skill-quality.md`:

```
python3 -c "import io,glob;print(sum(len(io.open(f,encoding='utf-8',errors='surrogateescape').read()) for f in glob.glob('tools-plugin/skills/*/SKILL.md')))"
```

**115,380 → 114,223 characters (−1,157, −1.0%)** across the plugin's 15 `SKILL.md` files.

The saving is modest by design: 14 of 15 When-to-Use tables survived the sibling test, and the four sharpened tables grew slightly (`justfile-expert` 14,964 → 15,006) because naming a real sibling costs more characters than naming a tool. That is the trade the rule asks for — the table is kept precisely where it earns its tokens.

Corpus-level C4, measured before and after on the same scanner:

| Metric | Before | After |
|---|---|---|
| `C4_BOILERPLATE_WHEN_TO_USE_SKILLS` | 406 | **405** |
| `C4_BOILERPLATE_WHEN_TO_USE_CHARS` | 280,278 | **279,923** |
| `C4_BOILERPLATE_AGENTIC_OPTIMIZATIONS_SKILLS` | 250 | **247** |
| `C4_BOILERPLATE_AGENTIC_OPTIMIZATIONS_CHARS` | 130,344 | **128,963** |

Both deltas match the edits exactly (−1 and −3 skills).

## Verification

`audit-skill-descriptions.py --strict-all` — the hard precondition, green:

```
$ python3 scripts/audit-skill-descriptions.py --strict-all
Audited 410 skills across 44 plugins
Trigger axis (auto-invocation matchability):
  OK           410  (100.0%)
  NEEDS FIX      0  (  0.0%)
EXIT=0
```

`plugin-compliance-check.sh tools-plugin` — **no ❌**:

```
| Plugin | plugin.json | Frontmatter | Body | Marketplace | Release Config | Bash Patterns | Descriptions | When-to-Use | Size | Overall |
| tools-plugin | ✅ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
```

Every ⚠️ is advisory and all but one are pre-existing: `generate-image` missing `argument-hint`, `hf-downloads` description at 228 chars, three >10,000-char size warnings (`rg-code-search`, `justfile-expert`, `jq-json-processing`). The one new ⚠️ is the intended `hf-downloads: SKILL.md has no '## When to Use This Skill' section` recommendation.

`just lint-compliance` (whole repo) — the **only** ❌ is the pre-existing `agent-patterns-plugin/parallel-agent-dispatch` size overrun (26,491 chars) already being fixed elsewhere. This PR adds no new ❌.

```
$ just lint-context-engineering
C5_ALWAYS_LOADED_CHARS=88379
C5_ALWAYS_LOADED_EST_TOKENS=22094
C5_ALWAYS_LOADED_BUDGET=100000
STATUS=WARN
ISSUE_COUNT=191
EXIT=0
```

**C5 is unchanged by this PR** (88,379 chars / ~22,094 est. tokens against a 100,000-char budget — under the ratchet, exit 0). C5 measures `CLAUDE.md` + unscoped `.claude/rules/**`; skill bodies do not contribute to it. `STATUS=WARN` is driven by 12 unscoped rule files this PR does not touch. Only C4 moved.

Other guards, all green:

```
$ bash scripts/check-unrendered-templates.sh          # STATUS=OK ISSUE_COUNT=0
$ bash scripts/check-unused-bash-grant.sh --strict    # SKILLS_SCANNED=410 STATUS=OK ISSUE_COUNT=0
$ bash scripts/tests/test-plugin-compliance-check.sh  # passed: 21, failed: 0
```

`check-version-pin-coverage.sh` reports its pre-existing `STATUS=WARN ISSUE_COUNT=14` (unchanged; #2214).

## Notes

- **No regression check is added.** This is a behaviour-preserving `refactor` applying an already-landed rule change, not a bug fix, so `.claude/rules/regression-testing.md` does not apply and no Known Regressions row is warranted.
- **No plugin README update.** The pre-commit currency nudge fired advisorily; the change adds, removes and renames no skill and alters no documented invocation, so `tools-plugin/README.md` has nothing to reconcile.
- The branch was rebased onto `origin/main` after f29be691 landed, so CI runs against current main.
