### PR TITLE
refactor(skills): disambiguate cluster-6 skill descriptions

### DIFF
--- a/communication-plugin/skills/ticket-drafting-guidelines/SKILL.md
+++ b/communication-plugin/skills/ticket-drafting-guidelines/SKILL.md
@@ -1,9 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-05-09
+modified: 2026-08-15
 reviewed: 2026-04-25
 name: ticket-drafting-guidelines
-description: Guidelines for drafting GitHub issues using What/Why/How format. Use when creating issues, drafting tickets, or writing bug reports with concise and positive framing.
+description: "What/Why/How prose structure and neutral, positive register for issues, PR descriptions, and tickets. Use when wording a ticket body, tightening prose, or applying house tone."
 user-invocable: false
 allowed-tools: Read, Grep, WebFetch
 ---
@@ -19,6 +19,7 @@ Expert guidance for drafting clear, concise, and well-structured tickets for Git
 | Drafting a GitHub issue, bug report, or feature request with What/Why/How structure | Posting a status update or announcement to a Google Chat channel |
 | Writing a PR description or technical ticket with reference links | Converting Markdown headers and bold to Google Chat's single-asterisk syntax |
 | Structuring a refactoring task or migration plan with concrete steps | Reformatting meeting notes or release notes for chat consumption |
+| Wording the body text — What/Why/How sections, tone, reference links | Use `git-plugin:github-issue-writing` for the GitHub issue artifact itself: `[Type] Component:` title format, bug/feature templates, `gh issue create` |
 
 ## Core Expertise
 

--- a/configure-plugin/README.md
+++ b/configure-plugin/README.md
@@ -52,7 +52,7 @@ merged into their configure siblings' `REFERENCE.md` files
 |-------|-------------|
 | `configure-workflows` | GitHub Actions CI/CD workflows |
 | `configure-reusable-workflows` | Install Claude-powered reusable workflows (security, quality, a11y) |
-| `configure-release-please` | Release-please workflow configuration |
+| `configure-release-please` | Release-please workflow, manifest, and config for a **single-package** repo (monorepo component tags live in `git-plugin:release-please-configuration`) |
 | `configure-pre-commit` | Pre-commit hooks for project standards |
 | `configure-github-pages` | GitHub Pages deployment |
 | `configure-argocd-automerge` | Auto-merge workflow for ArgoCD Image Updater branches |

--- a/configure-plugin/skills/configure-release-please/SKILL.md
+++ b/configure-plugin/skills/configure-release-please/SKILL.md
@@ -1,8 +1,8 @@
 ---
 created: 2025-12-16
-modified: 2026-07-05
+modified: 2026-08-15
 reviewed: 2026-06-24
-description: "release-please workflow setup and auditing. Use when configuring release-please, upgrading release-please-action, or adding a package to a monorepo config."
+description: "release-please workflow file, manifest, and config for a single-package repo — setup and compliance audit. Use when adding release-please or upgrading release-please-action."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, WebSearch, WebFetch
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"

--- a/configure-plugin/skills/configure-select/SKILL.md
+++ b/configure-plugin/skills/configure-select/SKILL.md
@@ -1,8 +1,8 @@
 ---
 created: 2025-12-22
-modified: 2026-07-05
+modified: 2026-08-15
 reviewed: 2026-07-05
-description: "Interactive selector for infrastructure standards. Use when setting up specific components or building infrastructure incrementally instead of running /configure:all."
+description: "Pick-a-component menu for infrastructure standards — configures only the selected ones. Use when setting up one or a few named components (linting, CI, containers, tests)."
 allowed-tools: Glob, Grep, Read, Write, Edit, Bash, AskUserQuestion, TodoWrite, SlashCommand
 args: "[--check-only] [--fix]"
 argument-hint: "[--check-only] [--fix]"

--- a/git-plugin/README.md
+++ b/git-plugin/README.md
@@ -20,7 +20,7 @@ See [`docs/flow.md`](docs/flow.md) for a diagram of how the skills fit together.
 | `/git:issue-hierarchy` | Manage sub-issues and native `blocked_by` / `blocking` dependencies between issues |
 | `/git:issue-manage` | Administrative operations: transfer, pin, lock, develop branches, bulk ops, custom fields |
 | `/git:triage` | Batch triage open issues and PRs: scan, categorize (implemented/stale/ready-to-merge/needs-fix), cross-link, optionally close or merge with --auto-close / --auto-merge |
-| `/git:fix-pr` | Analyze and fix failing PR checks |
+| `/git:fix-pr` | Reproduce a PR's failing checks locally, patch the code, and push the fix |
 | `/git:pr-feedback` | Review PR workflow results and comments, address substantive feedback from reviewers |
 | `/git:conflicts` | Resolve merge conflicts with zdiff3, rerere, and modern git tooling |
 | `/git:resolve-conflicts` | Resolve merge conflicts in PRs automatically |

--- a/git-plugin/skills/gh-workflow-monitoring/SKILL.md
+++ b/git-plugin/skills/gh-workflow-monitoring/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: gh-workflow-monitoring
-description: Monitor GitHub Actions runs with blocking watch commands instead of polling loops. Use when waiting for CI after push, following a workflow to completion, or diagnosing failed runs with --log-failed.
+description: "`gh run watch` — block until a GitHub Actions run finishes, no polling loop. Use when waiting for CI after a push or following a triggered workflow to completion."
 user-invocable: false
 allowed-tools: Bash(gh run *), Bash(gh workflow *), Bash(gh pr *), Read
 created: 2025-01-16
-modified: 2026-07-15
+modified: 2026-08-15
 reviewed: 2026-04-25
 ---
 
@@ -16,7 +16,7 @@ reviewed: 2026-04-25
 |---|---|
 | Watching a workflow run until it completes via blocking `gh run watch` | Use `gh-cli-agentic` for one-shot JSON queries of run/PR check state |
 | Waiting for CI after a push, or triggering a workflow and following progress | Use `git-fix-pr` to diagnose AND auto-correct failing checks on a PR |
-| Diagnosing a failed run with `gh run view --log-failed` | Use `git-pr-feedback` to address reviewer comments rather than CI failures |
+| Chaining on a run's outcome with `gh run watch --exit-status` | Use `github-actions-plugin:github-actions-inspection` to read a finished run's logs and stack traces |
 | Finding the latest in-progress run for a workflow | Use `gh-cli-agentic` to list completed runs by status filter |
 
 Watch and monitor GitHub Actions workflow runs using `gh run watch` - a blocking command that follows runs until completion without needing timeouts or polling.

--- a/git-plugin/skills/git-fix-pr/SKILL.md
+++ b/git-plugin/skills/git-fix-pr/SKILL.md
@@ -1,12 +1,12 @@
 ---
 created: 2025-12-16
-modified: 2026-06-18
+modified: 2026-08-15
 reviewed: 2026-04-25
 allowed-tools: Bash(gh pr checks *), Bash(gh pr view *), Bash(gh run view *), Bash(gh run list *), Bash(gh repo view *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(pre-commit *), Bash(npm run *), Bash(uv run *), Read, Edit, Grep, Glob, TodoWrite, mcp__github__pull_request_read
 args: "[pr-number] [--auto-fix] [--push]"
 argument-hint: "[pr-number] [--auto-fix] [--push]"
 disable-model-invocation: true
-description: "Analyze and fix failing PR checks. Use when asked to fix a PR, resolve red CI checks, auto-fix lint/test failures, or reproduce CI errors locally before pushing."
+description: "Failing PR checks — reproduce locally, patch the code, push the fix. Use when asked to fix a PR, resolve red CI, or auto-fix lint/test failures."
 name: git-fix-pr
 ---
 

--- a/git-plugin/skills/git-issue-hierarchy/SKILL.md
+++ b/git-plugin/skills/git-issue-hierarchy/SKILL.md
@@ -1,9 +1,9 @@
 ---
 created: 2026-03-19
-modified: 2026-06-18
+modified: 2026-08-15
 reviewed: 2026-04-25
 name: git-issue-hierarchy
-description: "Manage GitHub sub-issues and dependencies (blocked_by/blocking). Use when breaking issues into sub-tasks, checking progress, or viewing a dependency graph."
+description: "GitHub sub-issues and blocked_by/blocking links. Use when breaking an issue into sub-tasks, checking parent progress, or viewing a dependency graph."
 args: "<parent-issue (number | #N | URL)> [--add <N...>] [--remove <N...>] [--create \"title\"] [--status] [--deps] [--blocking] [--block <N>] [--blocked-by <N>] [--unblock <N>]"
 argument-hint: "<parent-issue (number|#N|URL)> [--add N] [--status] [--deps] [--blocked-by N]"
 user-invocable: true

--- a/git-plugin/skills/git-issue-manage/SKILL.md
+++ b/git-plugin/skills/git-issue-manage/SKILL.md
@@ -1,9 +1,9 @@
 ---
 created: 2026-03-19
-modified: 2026-06-15
+modified: 2026-08-15
 reviewed: 2026-06-15
 name: git-issue-manage
-description: "GitHub issue admin operations. Use when transferring issues, pinning, locking discussions, creating dev branches from issues, bulk ops, or managing custom fields."
+description: "Transfer, pin, lock, or open a dev branch from a GitHub issue. Use when moving an issue between repos, pinning or locking it, or bulk-editing custom fields."
 args: "<operation> <issue-numbers...> [options]"
 argument-hint: <transfer|pin|lock|develop|bulk|fields> <issue-numbers...>
 user-invocable: true

--- a/git-plugin/skills/git-issue/SKILL.md
+++ b/git-plugin/skills/git-issue/SKILL.md
@@ -1,9 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-08-13
+modified: 2026-08-15
 reviewed: 2026-08-13
 allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git switch *), Bash(git fetch *), Bash(git pull *), Bash(git stash *), Bash(gh issue *), Bash(gh pr *), Bash(gh repo *), Bash(gh label *), Bash(gh api *), Bash(pre-commit *), Read, Edit, Write, Grep, Glob, TodoWrite, AskUserQuestion, Task, mcp__github__create_pull_request, mcp__github__issue_read, mcp__github__list_issues
-description: "Process GitHub issues end-to-end with TDD and parallel work. Use when asked to work on an issue, fix issue #N, pick issues to tackle, or batch-process several."
+description: "GitHub issue to PR end-to-end — branch, TDD implementation, PR — one issue or several in parallel. Use when asked to work on an issue, fix issue #N, or batch-process several."
 args: "[issues... (number | #N | URL)] [--auto] [--filter <label>] [--limit <n>] [--parallel] [--labels <l1,l2>]"
 argument-hint: "[issues... (number | #N | URL)] [--auto] [--filter <label>] [--limit <n>] [--parallel] [--labels <l1,l2>]"
 disable-model-invocation: true

--- a/git-plugin/skills/git-triage/SKILL.md
+++ b/git-plugin/skills/git-triage/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: git-triage
-description: "Triage GitHub issues and PRs — cross-link, flag stale items, recommend actions. Use when grooming the backlog, pre-release cleanup, or asked to triage issues/PRs."
+description: "Backlog sweep over open issues and PRs — staleness, cross-links, close/merge recommendations, no code changes. Use when grooming the backlog, deciding what to close, or pre-release cleanup."
 args: "[--type issues|prs|both] [--batch N] [--repo owner/name] [--days-stale-issue N] [--days-stale-pr N] [--auto-close] [--auto-merge] [--oldest-first]"
 argument-hint: "--type both --batch 10 (defaults: days-stale-issue=90, days-stale-pr=30, current repo)"
 allowed-tools: Bash(bash *), Bash(gh issue *), Bash(gh pr *), Bash(gh api *), Bash(gh repo *), Bash(git log *), Bash(rg *), Read, Grep, Glob, AskUserQuestion, TodoWrite
 created: 2026-04-22
-modified: 2026-06-18
+modified: 2026-08-15
 reviewed: 2026-06-14
 ---
 

--- a/git-plugin/skills/github-issue-writing/SKILL.md
+++ b/git-plugin/skills/github-issue-writing/SKILL.md
@@ -1,12 +1,9 @@
 ---
 created: 2026-01-30
-modified: 2026-04-29
+modified: 2026-08-15
 reviewed: 2026-04-29
 name: github-issue-writing
-description: |
-  Create well-structured GitHub issues with clear titles, descriptions, and
-  acceptance criteria. Use when filing bugs, requesting features, or structuring
-  issue content.
+description: "GitHub issue body and `[Type] Component:` title — bug/feature templates, repro steps, acceptance criteria. Use when filing a bug or feature request with gh."
 user-invocable: false
 allowed-tools: Bash(gh issue *), Bash(gh label *), Bash(gh repo *), Read, Grep, Glob, TodoWrite
 ---
@@ -23,6 +20,7 @@ Create well-structured, actionable GitHub issues.
 | Structuring an issue body with reproduction steps, scope, and definition of done | Use `github-issue-autodetect` to link existing issues from staged diffs |
 | Choosing the `[Type] Component: Description` title format | Use `github-pr-title` to author the conventional title for the PR that fixes it |
 | Designing a feature-request issue before implementation begins | Use `git-issue-manage` for transfer/pin/lock/develop-branch admin operations |
+| Assembling the GitHub issue itself — title format, templates, `gh issue create` | Use `communication-plugin:ticket-drafting-guidelines` for the What/Why/How prose structure and house tone of the body text |
 
 ## Issue Title Format
 

--- a/git-plugin/skills/github-labels/SKILL.md
+++ b/git-plugin/skills/github-labels/SKILL.md
@@ -1,9 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-05-09
+modified: 2026-08-15
 reviewed: 2026-04-01
 name: github-labels
-description: "Discover and apply GitHub labels via gh CLI. Use when asked to label a PR/issue, list available labels, or create new labels for a repository."
+description: "GitHub labels via gh CLI — list, apply, create. Use when labeling a PR or issue, checking which labels a repo has, or creating a new label."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/git-plugin/skills/release-please-pr-workflow/SKILL.md
+++ b/git-plugin/skills/release-please-pr-workflow/SKILL.md
@@ -1,9 +1,9 @@
 ---
 created: 2026-01-09
-modified: 2026-05-09
+modified: 2026-08-15
 reviewed: 2026-04-25
 name: release-please-pr-workflow
-description: Manage release-please PR merging for monorepos — batch merging, conflict resolution via PR closure/recreation, iterative processing. Use when merging release PRs, handling PR conflicts, or managing release automation in monorepos.
+description: "Merging release-please release PRs — batch merge, conflict resolution by closing and recreating the PR. Use when release PRs pile up or a release PR conflicts."
 user-invocable: false
 allowed-tools: Bash, Read, TodoWrite
 ---

--- a/github-actions-plugin/skills/github-actions-inspection/SKILL.md
+++ b/github-actions-plugin/skills/github-actions-inspection/SKILL.md
@@ -1,9 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-04-25
+modified: 2026-08-15
 reviewed: 2026-04-25
 name: github-actions-inspection
-description: "Inspect GitHub Actions runs, analyze logs, debug failures. Use when investigating CI/CD failures, checking workflow status, or debugging GitHub Actions issues."
+description: "Read a finished GitHub Actions run's logs — failing step, stack trace, test output, rerun failed jobs. Use when a CI run already failed and you need the error out of the log."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob, mcp__github
 ---
@@ -16,7 +16,7 @@ allowed-tools: Bash, Read, Grep, Glob, mcp__github
 |---|---|
 | Pulling status, logs, and conclusions from `gh run` for a failing workflow | Authoring or modifying a workflow YAML file — see claude-code-github-workflows |
 | Diagnosing flaky tests, timeouts, or auth-permission errors in a CI run | Searching upstream OSS issues for a library bug — see github-issue-search |
-| Rerunning failed jobs, watching in-progress runs, or extracting error lines | Building a workflow that auto-fixes CI failures — see github-workflow-auto-fix |
+| Rerunning failed jobs or extracting error lines from a completed run | Use `git-plugin:gh-workflow-monitoring` to block until an in-progress run finishes, or `git-plugin:git-fix-pr` to patch and push the fix |
 
 Expert knowledge for inspecting, debugging, and troubleshooting GitHub Actions workflow runs using gh CLI and GitHub API.
 

--- a/project-plugin/skills/project-continue/SKILL.md
+++ b/project-plugin/skills/project-continue/SKILL.md
@@ -1,10 +1,10 @@
 ---
-description: Resume development from current project state. Use when the user asks to continue work, pick up where we left off, find the next task, or resume a TDD cycle after a break.
+description: "Next task from the feature tracker and PRDs, then implement it. Use when resuming coding in a blueprint project, picking the next tracker task, or resuming a TDD cycle after a break."
 args: "[--task <id>] [--skip-status]"
 argument-hint: "--task to resume specific task, --skip-status to skip state analysis"
 allowed-tools: Read, Bash(git status *), Bash(git log *), Bash(git branch *), Grep, Glob, Edit, Write
 created: 2025-12-16
-modified: 2026-06-05
+modified: 2026-08-15
 reviewed: 2026-06-05
 name: project-continue
 ---
@@ -16,6 +16,7 @@ name: project-continue
 | Use this skill when... | Use project-discovery instead when... |
 |---|---|
 | Resuming work on a known project with PRDs and feature-tracker state | Entering an unfamiliar codebase needing orientation on tooling/structure |
+| Reading tracker state and then implementing the next task in this repo | Use `session-plugin:session-spinup` instead for a read-only briefing of open tasks, PRs, and journal todos that edits nothing |
 | Picking the next task off the feature tracker after a break | Use project-test-loop instead when the next step is iterating on failing tests |
 | Asking "what's next" in a project with established blueprint state | Use project-init instead when no project structure exists yet |
 | Resuming a TDD session and beginning implementation yourself | Use `/blueprint:execute` instead when you want blueprint to pick and run the next logical blueprint action (derive/sync/work-order) rather than continue coding |

--- a/session-plugin/skills/session-spinup/SKILL.md
+++ b/session-plugin/skills/session-spinup/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: session-spinup
-description: Read-only session-start briefing of open tasks, git state, journal todos. Use when user says spin up, what was I doing, or pick up where I left off.
+description: Read-only session-start briefing of open tasks, git state, journal todos — reports, never edits code. Use when user says spin up, what was I doing, or pick up where I left off.
 allowed-tools: Bash(bash *), Read, TodoWrite
 created: 2026-05-13
-modified: 2026-08-09
+modified: 2026-08-15
 compatibility: claude-code
 reviewed: 2026-06-24
 ---


### PR DESCRIPTION
## What

Cluster 6 of #2244 — the "tail" of description-only fixes. 15 skill descriptions rewritten across six colliding intent clusters, plus three `## When to Use` rows and two plugin-README rows so the prose agrees with the new boundaries.

**Zero skills retired, merged, or deleted.** Cluster 1's proposed retirement of five `testing-plugin` runners plus `project-plugin:project-test-loop` is out of scope and needs its own approval; `testing-plugin` is untouched.

## Why

Each of these clusters had two or more skills describing the same user intent in near-identical language, so the router resolved the collision by momentum and the specialists never fired. The rewrite rule from the issue, in priority order:

- lead with the **artifact or object**, not the verb
- **name the discriminator** where siblings share a domain
- **delete territory** a skill does not own

## Before / after

### 1. Session resume — `session-spinup` (21/259) vs `project-continue` (6/0)

Both claimed the literal phrase *"pick up where we left off"*. The discriminator is that spinup **reports and edits nothing**, while project-continue **reads tracker state and then writes code**.

| Skill | |
|---|---|
| `session-plugin:session-spinup` | **was:** `Read-only session-start briefing of open tasks, git state, journal todos. Use when user says spin up, what was I doing, or pick up where I left off.` |
| | **now:** `Read-only session-start briefing of open tasks, git state, journal todos — reports, never edits code. Use when user says spin up, what was I doing, or pick up where I left off.` |
| `project-plugin:project-continue` | **was:** `Resume development from current project state. Use when the user asks to continue work, pick up where we left off, find the next task, or resume a TDD cycle after a break.` |
| | **now:** `Next task from the feature tracker and PRDs, then implement it. Use when resuming coding in a blueprint project, picking the next tracker task, or resuming a TDD cycle after a break.` |

`project-continue` releases the contested phrase entirely and leads with the artifacts its body actually reads (`docs/prds/`, `docs/blueprint/feature-tracker.json`). A `When to Use` row was added routing the read-only cross-project briefing back to `session-spinup`.

### 2. Issue triage — `git-issue` (48/234) vs `git-triage` (28/11), with three siblings at 0/0

| Skill | |
|---|---|
| `git-plugin:git-issue` | **was:** `Process GitHub issues end-to-end with TDD and parallel work. Use when asked to work on an issue, fix issue #N, pick issues to tackle, or batch-process several.` |
| | **now:** `GitHub issue to PR end-to-end — branch, TDD implementation, PR — one issue or several in parallel. Use when asked to work on an issue, fix issue #N, or batch-process several.` |
| `git-plugin:git-triage` | **was:** `Triage GitHub issues and PRs — cross-link, flag stale items, recommend actions. Use when grooming the backlog, pre-release cleanup, or asked to triage issues/PRs.` |
| | **now:** `Backlog sweep over open issues and PRs — staleness, cross-links, close/merge recommendations, no code changes. Use when grooming the backlog, deciding what to close, or pre-release cleanup.` |
| `git-plugin:git-issue-hierarchy` | **was:** `Manage GitHub sub-issues and dependencies (blocked_by/blocking). Use when breaking issues into sub-tasks, checking progress, or viewing a dependency graph.` |
| | **now:** `GitHub sub-issues and blocked_by/blocking links. Use when breaking an issue into sub-tasks, checking parent progress, or viewing a dependency graph.` |
| `git-plugin:git-issue-manage` | **was:** `GitHub issue admin operations. Use when transferring issues, pinning, locking discussions, creating dev branches from issues, bulk ops, or managing custom fields.` |
| | **now:** `Transfer, pin, lock, or open a dev branch from a GitHub issue. Use when moving an issue between repos, pinning or locking it, or bulk-editing custom fields.` |
| `git-plugin:github-labels` | **was:** `Discover and apply GitHub labels via gh CLI. Use when asked to label a PR/issue, list available labels, or create new labels for a repository.` |
| | **now:** `GitHub labels via gh CLI — list, apply, create. Use when labeling a PR or issue, checking which labels a repo has, or creating a new label.` |

`git-issue` drops *"pick issues to tackle"*; the split is now **implement** (git-issue) vs **dispose of** (git-triage). `git-issue-manage` replaces the category noun *"admin operations"* with the four concrete operations its `args` enum already names.

### 3. Issue filing — `github-issue-writing` (4/12) vs `ticket-drafting-guidelines` (5/13)

The even split the issue calls a per-session coin flip. Reading both bodies gives a real discriminator: `github-issue-writing` owns the **GitHub artifact** (`[Type] Component:` title format, bug/feature templates, `gh issue create` — it holds `Bash(gh issue *)`), while `ticket-drafting-guidelines` owns the **prose structure and register** applied to issues, PR descriptions *and* docs (it holds no `gh` tools at all — `Read, Grep, WebFetch`).

| Skill | |
|---|---|
| `git-plugin:github-issue-writing` | **was:** `Create well-structured GitHub issues with clear titles, descriptions, and acceptance criteria. Use when filing bugs, requesting features, or structuring issue content.` |
| | **now:** `` GitHub issue body and `[Type] Component:` title — bug/feature templates, repro steps, acceptance criteria. Use when filing a bug or feature request with gh. `` |
| `communication-plugin:ticket-drafting-guidelines` | **was:** `Guidelines for drafting GitHub issues using What/Why/How format. Use when creating issues, drafting tickets, or writing bug reports with concise and positive framing.` |
| | **now:** `What/Why/How prose structure and neutral, positive register for issues, PR descriptions, and tickets. Use when wording a ticket body, tightening prose, or applying house tone.` |

Both gained a `When to Use` row cross-referencing the other by `plugin:skill` name (cross-plugin, so a name reference rather than a shared file — `.claude/rules/skill-consolidation.md` §2).

### 4. Repo onboarding — `configure-select`

The old description positioned itself as *"instead of running /configure:all"*, which no router can resolve. Replaced with a positive discriminator: **one or a few named components** vs all of them.

| Skill | |
|---|---|
| `configure-plugin:configure-select` | **was:** `Interactive selector for infrastructure standards. Use when setting up specific components or building infrastructure incrementally instead of running /configure:all.` |
| | **now:** `Pick-a-component menu for infrastructure standards — configures only the selected ones. Use when setting up one or a few named components (linting, CI, containers, tests).` |

`configure-all`, `configure-repo`, and `configure-status` were read and left alone — each already leads with its own discriminator.

### 5. release-please split across `configure-plugin` and `git-plugin`

`configure-release-please`'s description claimed *"adding a package to a monorepo config"* — territory its own body explicitly assigns to `git-plugin:release-please-configuration` ("For the single-repo workflow/manifest/config shape … use `configure-plugin:configure-release-please`"). Deleting that clause makes the description match the body.

| Skill | |
|---|---|
| `configure-plugin:configure-release-please` | **was:** `release-please workflow setup and auditing. Use when configuring release-please, upgrading release-please-action, or adding a package to a monorepo config.` |
| | **now:** `release-please workflow file, manifest, and config for a single-package repo — setup and compliance audit. Use when adding release-please or upgrading release-please-action.` |
| `git-plugin:release-please-pr-workflow` | **was:** `Manage release-please PR merging for monorepos — batch merging, conflict resolution via PR closure/recreation, iterative processing. Use when merging release PRs, handling PR conflicts, or managing release automation in monorepos.` (230 chars, WARN) |
| | **now:** `Merging release-please release PRs — batch merge, conflict resolution by closing and recreating the PR. Use when release PRs pile up or a release PR conflicts.` (159 chars) |

`release-please-configuration` and `release-please-protection` were read and **deliberately left unchanged** — both already lead with the artifact and name symptom nouns (`duplicate-tag`, `no-bump`); `release-please-configuration` is close to the model case the issue holds up.

### 6. Red-CI ownership

| Skill | |
|---|---|
| `git-plugin:git-fix-pr` | **was:** `Analyze and fix failing PR checks. Use when asked to fix a PR, resolve red CI checks, auto-fix lint/test failures, or reproduce CI errors locally before pushing.` |
| | **now:** `Failing PR checks — reproduce locally, patch the code, push the fix. Use when asked to fix a PR, resolve red CI, or auto-fix lint/test failures.` |
| `git-plugin:gh-workflow-monitoring` | **was:** `Monitor GitHub Actions runs with blocking watch commands instead of polling loops. Use when waiting for CI after push, following a workflow to completion, or diagnosing failed runs with --log-failed.` |
| | **now:** `` `gh run watch` — block until a GitHub Actions run finishes, no polling loop. Use when waiting for CI after a push or following a triggered workflow to completion. `` |
| `github-actions-plugin:github-actions-inspection` | **was:** `Inspect GitHub Actions runs, analyze logs, debug failures. Use when investigating CI/CD failures, checking workflow status, or debugging GitHub Actions issues.` |
| | **now:** `Read a finished GitHub Actions run's logs — failing step, stack trace, test output, rerun failed jobs. Use when a CI run already failed and you need the error out of the log.` |

Three-way split: **wait** for a run in progress (`gh-workflow-monitoring`) / **read** a finished run's logs (`github-actions-inspection`) / **patch and push** (`git-fix-pr`). `gh-workflow-monitoring` gives up its `--log-failed` diagnosis clause, and its `When to Use` row now routes log reading to `github-actions-inspection`; the reciprocal row was added there.

## Deferred

- **`health-check` / `health-skill-audit` meta-audit** — the sixth sub-item of cluster 6. Skipped entirely: another agent is editing `health-plugin/skills/health-check/SKILL.md` in the same wave, and `health-plugin/` is untouched here. Needs a follow-up PR.
- **`testing-plugin:test-analyze`** — the fourth claimant in the red-CI cluster (*"triaging failing tests"*). `testing-plugin` is out of scope for this PR, so the red-CI split is three-way rather than four-way and one residual overlap remains.
- **Cluster 1 retirements** — five `testing-plugin` runners plus `project-plugin:project-test-loop`. Explicitly out of scope; needs its own approval.

## Where the issue's recommendation looks wrong

**`git-issue` cannot be absorbing traffic from the router.** It carries `disable-model-invocation: true`, so the model never auto-selects it — its 48/234 comes entirely from explicit `/git:issue` invocation. Whatever is starving `git-triage`, `git-issue-hierarchy`, `git-issue-manage`, and `github-labels`, it is not `git-issue` winning a description match against them. The same applies to `git-fix-pr` in the red-CI cluster (also `disable-model-invocation: true`).

This does not make the rewrites pointless — a *human* choosing between `/git:issue` and `/git:triage` reads the same text, and the four 0/0 siblings still compete with each other and with auto-invokable skills. But it does mean the cluster's usage counts cannot be read as router-collision evidence for those two, and a routing spot-check measuring "does the specialist fire now" will show nothing for them by construction. Worth reflecting in how cluster 4 (`git-commit-push-pr`, 48/71) is diagnosed before acting on it.

## Caveats honored

- **#1278** — every rewritten description keeps the literal `Use when` phrase. `scripts/audit-skill-descriptions.py --strict-all` reports `NEEDS FIX 0` across all 410 skills.
- **Block-scalar extraction trap** — `github-issue-writing`'s description was a `|` block scalar (one of the 21 the issue's inventory mis-captured). It was read from disk, not from the issue's quoted text, and converted to a quoted single line so the trap cannot recur for this skill. `github-pr-title`, the other in-repo block scalar named in the caveat, belongs to cluster 4 and was left alone.
- **`comfyui-plugin` / `foundryvtt-plugin`** — untouched, per the caveat that neither slice was meaningfully audited.

## Verification

| Gate | Result |
|---|---|
| `python3 scripts/audit-skill-descriptions.py --strict-all` | **exit 0** — 410 skills, `OK 410 (100.0%)`, `NEEDS FIX 0` |
| `just lint-compliance` | one ❌ — the **pre-existing** `agent-patterns-plugin/parallel-agent-dispatch` size error, byte-identical to the `origin/main` baseline. **No new ❌.** |
| Description length band | all 15 land ≤200 chars; 3 in the IDEAL ≤150 band. No new WARN; `release-please-pr-workflow` **clears** an existing WARN (230 → 159). |
| Pre-commit (full hook set) | all applicable hooks Passed; only the advisory `nudge-plugin-readme-currency` INFO, addressed by the two README rows in this commit. |
| `git log --oneline origin/main..HEAD` | exactly one commit. |

Refs #2244
