### PR TITLE
fix(scripts): use a here-string in the drift test so pipefail cannot fake a failure

### DIFF
--- a/scripts/tests/test-check-enabled-plugins-drift.sh
+++ b/scripts/tests/test-check-enabled-plugins-drift.sh
@@ -17,8 +17,15 @@ ok() { echo "PASS: $1"; pass=$((pass + 1)); }
 ko() { echo "FAIL: $1"; fail=$((fail + 1)); }
 
 # assert_has <desc> <text> <needle>  — text contains needle
+#
+# Here-string, NOT `printf … | grep -q`: under `set -o pipefail` (line 8) a
+# `grep -q` that matches closes the pipe while printf is still writing, printf
+# takes SIGPIPE, and pipefail reports the pipeline as 141 — so a MATCHING
+# assertion reports FAIL. It is size-dependent (small inputs fit the 64 KiB pipe
+# buffer and pass), which is why this was green locally and red in CI on exactly
+# the two assertions with the largest text. See ~/.claude/rules/shell-pipefail-grep-q.md.
 assert_has() {
-  if printf '%s' "$2" | grep -q -- "$3"; then ok "$1"; else ko "$1"; fi
+  if grep -q -- "$3" <<<"$2"; then ok "$1"; else ko "$1"; fi
 }
 
 # assert_lacks <desc> <text>  — text is empty


### PR DESCRIPTION
## What

`assert_has` in `scripts/tests/test-check-enabled-plugins-drift.sh` used
`printf '%s' "$2" | grep -q -- "$3"` under `set -o pipefail`, so a **matching**
assertion could be reported as `FAIL`.

## Why it happens

`grep -q` closes its stdin on the first match. `printf` is still writing, takes
`SIGPIPE`, and exits 141 — `pipefail` then makes the whole pipeline 141, so the
`if` takes the false branch even though the needle was found.

It is size-dependent, and that is why it looked like flakiness: when the text
fits the 64 KiB pipe buffer `printf` finishes before `grep` closes the pipe, so
small inputs pass. The suite was **12/12 locally** and red in CI on exactly the
two assertions with the largest payloads — `enabled_plugin_dangling` and
`--issue-body populated on drift` — each preceded in the log by
`printf: write error: Broken pipe`.

Control, identical matching input both ways:

```
set -o pipefail; printf '%s' "$(seq 1 100000)" | grep -q '^5$'   # exit 141
set -o pipefail; grep -q '^5$' <<<"$(seq 1 100000)"              # exit 0
```

## Fix

Feed `grep` with a here-string, so there is no upstream writer to receive
SIGPIPE. `pipefail` is load-bearing elsewhere in the script, so the fix is the
single pipeline rather than the option.

## Verification

- `bash scripts/tests/test-check-enabled-plugins-drift.sh` → `12 passed, 0 failed`
- The guard under test (`check-enabled-plugins-drift.sh`) is unchanged — the
  defect was in the harness, not in the thing it exercises.

## Impact

Correction to an earlier draft of this description: `drift` is **not** a
required check. The ruleset's required contexts are `validate`, `gate` and
`compliance`, and release PR #2400 merged via auto-merge at 10:06:47Z with
`drift` red — so this was not blocking the release.

What it actually costs: `drift` fails on **every** PR that runs it, for a defect
in the test harness rather than any real enablement drift. A check that is
permanently red is a check nobody reads, which is how a genuine
`plugin_not_enabled` or `enabled_plugin_dangling` finding would go unnoticed.

Refs `~/.claude/rules/shell-pipefail-grep-q.md`.
