### PR TITLE
fix(github-actions-plugin): drop the eval-task trigram from the inspection description

### DIFF
--- a/github-actions-plugin/skills/github-actions-inspection/SKILL.md
+++ b/github-actions-plugin/skills/github-actions-inspection/SKILL.md
@@ -3,7 +3,7 @@ created: 2025-12-16
 modified: 2026-08-15
 reviewed: 2026-04-25
 name: github-actions-inspection
-description: "Read a finished GitHub Actions run's logs — failing step, stack trace, test output, rerun failed jobs. Use when a CI run already failed and you need the error out of the log."
+description: "Failing step, stack trace, and test output from a completed GitHub Actions run; rerun failed jobs. Use when a CI check finished red and you need the error extracted from its log."
 user-invocable: false
 allowed-tools: Bash, Read, Grep, Glob, mcp__github
 ---


### PR DESCRIPTION
## What

Reword `github-actions-plugin:github-actions-inspection`'s description so it shares no token trigram with eval task `t-amb-013`. Fixes the red `adapters/tests/eval-meta.test.ts` → *"4. leakage lint (deterministic) > no non-negative task shares a token trigram with a target's name+description"* that my #2401 left on `main`.

One file, one line.

## The defect

#2401 rewrote the description to lead with the artifact, and the phrase it chose — **"a finished GitHub Actions run's logs"** — appears verbatim in `t-amb-013`'s prompt:

> CI went red on main — pull the failed workflow **run's logs** and figure out which step broke and why.

`adapters/core/bm25.ts`'s `tokenize()` splits on `[^a-z0-9]+`, so `run's` becomes `run` + `s`, and both texts yield the trigram **`run s logs`**:

```
- []
+ [
+   "t-amb-013 vs github-actions-plugin:github-actions-inspection: run s logs",
+ ]
```

Not a tokenizer artifact worth waving away. The same tokenizer feeds BM25 retrieval, so `run`/`s`/`logs` in both prompt and description really does boost the expected skill — and `t-amb-013` is tagged `stratum:ambiguity`, whose entire purpose is that `github-actions-inspection` vs `gh-workflow-monitoring` vs `finops-workflows` should be a **hard** call. A verbatim phrase match makes it trivially winnable, so retrieval numbers over that stratum stop measuring ambiguity.

## Before / after

| | |
|---|---|
| **was** | `Read a finished GitHub Actions run's logs — failing step, stack trace, test output, rerun failed jobs. Use when a CI run already failed and you need the error out of the log.` |
| **now** | `Failing step, stack trace, and test output from a completed GitHub Actions run; rerun failed jobs. Use when a CI check finished red and you need the error extracted from its log.` |

The rewrite keeps everything #2401 was for: artifact-led, symptom nouns (`failing step`, `stack trace`, `test output`), and the three-way red-CI discriminator against `gh-workflow-monitoring` (wait for a run) and `git-fix-pr` (patch and push). 178 chars, within the ≤200 band, literal `Use when` intact.

## Which side moved, and why

`reconcile.sh`-style options were both available — reword the description, or reword `t-amb-013`'s prompt. The description moved, on three grounds:

1. **The eval task is the measurement instrument**; the skill description is the thing being measured. Bending the instrument to fit the measurement is backwards.
2. **`t-amb-013`'s prompt is a realistic user utterance** — *"pull the failed workflow run's logs"* is exactly how someone asks for this. Rewriting it to dodge a description makes the eval less realistic, and would need redoing every time a description changes.
3. **The description is the newcomer** — authored 2026-08-15 in #2401; the task predates it.

## Verification

| Gate | Result |
|---|---|
| `bun test tests/eval-meta.test.ts` | **31 pass / 0 fail** (was 30 pass / **1 fail**) |
| `just adapters-test` (full suite) | **178 pass / 2 skip / 0 fail** |
| `just adapters-check` (`tsc --noEmit` + `biome ci`) | clean, 34 files |
| `python3 scripts/audit-skill-descriptions.py --strict-all` | **exit 0** — 410 skills, `NEEDS FIX 0` |
| `just lint-compliance` | **0 ❌**; no warning naming this skill |
| Description length | 178 chars (OK band), `Use when` present |
| `git log --oneline origin/main..HEAD` | exactly one commit |

Reproduced at the failure point before diagnosing — `bun test` against a clean checkout of `origin/main` with `bun install --frozen-lockfile` in `adapters/`, which is what surfaced the exact offending trigram rather than taking the report on faith.

## Note for the maintainer: the trigger gap is by design, and I did not change it

`.github/workflows/test-adapters.yml` triggers on `adapters/**`, `pi/tiers.yaml`, and its own path — so #2401, which touched only skill files, never ran `Test: Adapters`. That is not an oversight. The workflow's own header says so:

> The weekly cron surfaces corpus drift (skill-description edits, tier moves outside `adapters/**`) on main with correct attribution rather than on the next unrelated adapters PR.

So this incident is the documented design working as intended: the breakage is corpus drift from outside `adapters/**`, and it was meant to be caught on `main` with correct attribution — which is exactly what happened, just by a human peer rather than by the cron.

I deliberately did **not** widen the `paths:` filter. Adding `**/skills/**/SKILL.md` would run the adapters suite on nearly every PR in this repo (~400 skills), which is a real cost change the author already weighed and decided against.

The residual cost worth your decision, not mine: between cron runs, a skill-description PR can leave `main` red for up to **7 days**, and the next unrelated `adapters/**` PR inherits a red suite it did not cause. If that trade is worth revisiting, the cheap middle option is a `paths:`-filtered job that runs only `bun test tests/eval-meta.test.ts` (131 ms) on skill-file PRs, leaving the full suite on its current triggers. Happy to file that as an issue rather than decide it here.

## Not in scope

Nothing else from #2401 is touched. The other 14 descriptions it rewrote are unaffected — the leakage lint reports them all clean, and the full adapters suite is green.

Refs #2244
