### PR TITLE
fix(taskwarrior-plugin): prune repo copies from the citation-drift walk

### DIFF
--- a/taskwarrior-plugin/scripts/tests/test-task-id-stability.sh
+++ b/taskwarrior-plugin/scripts/tests/test-task-id-stability.sh
@@ -162,9 +162,18 @@ fi
 repo_root="$(cd "${PLUGIN_DIR}/.." && pwd)"
 self_path="${SCRIPT_DIR}/$(basename "${BASH_SOURCE[0]}")"
 regression_log="${repo_root}/.claude/rules/regression-testing.md"
+# Prune generated/cloned COPIES of the repo, not just .git/ — otherwise this
+# walk re-finds the two deliberately-excluded files under every copy of them.
+# Both exclusions below are by ABSOLUTE path, so a copy at a different path
+# defeats them: `.claude/worktrees/<agent>/` (a full clone per agent worktree,
+# incl. OTHER concurrent sessions') and `dist/` (gitignored rulesync export)
+# each carry their own regression-testing.md and their own copy of this test.
+# Invisible in CI, which checks out neither — the #1492 / #1548 / #2214 / #2290
+# class, local-developer-only by construction.
 stale_hits="$(grep -rl "taskwarrior-bulk-operations" "$repo_root" \
-    --include='*.md' --include='*.sh' 2>/dev/null \
-    | grep -v '/\.git/' | grep -vF "$self_path" | grep -vF "$regression_log" || true)"
+    --include='*.md' --include='*.sh' \
+    --exclude-dir='.git' --exclude-dir='worktrees' --exclude-dir='dist' 2>/dev/null \
+    | grep -vF "$self_path" | grep -vF "$regression_log" || true)"
 if [ -z "$stale_hits" ]; then
     check "no stale 'taskwarrior-bulk-operations.md' citations remain" "absent" "absent"
 else


### PR DESCRIPTION
## What

`test-task-id-stability.sh` Part 3 (the citation-drift guard) fails for any
developer who has an agent worktree or a built `dist/` on disk.

## Why

The walk pruned only `/.git/`:

```sh
grep -rl "taskwarrior-bulk-operations" "$repo_root" --include='*.md' --include='*.sh' \
  | grep -v '/\.git/' | grep -vF "$self_path" | grep -vF "$regression_log"
```

Both exclusions match by **absolute path**, so every *copy* of those two files
at a different path defeats them. Two copy sources exist locally:

| Path | What it is |
|---|---|
| `.claude/worktrees/<agent>/` | a full clone per agent worktree — including other concurrent sessions' |
| `dist/` | the gitignored rulesync / OpenCode export |

Observed failure named 10 paths, **all** of them copies of the same two
deliberately-excluded files. It is also unactionable as reported: the fix site
is always the tracked original, and the next export or agent dispatch recreates
the copies.

The tree is genuinely clean — `git grep -l taskwarrior-bulk-operations` over
tracked files returns exactly the two intended self-references (this test, and
`regression-testing.md`'s Known Regressions row), both citing the stale filename
deliberately as historical record.

## Why CI never caught it

A fresh checkout has neither worktrees nor a built `dist/`, so
`test-skill-scripts.yml` stayed green while the suite was red locally. Same
class as #1492, #1548, #2214, #2290 — a walk descending into generated or cloned
content — and local-developer-only by construction, like #2214 and #2141.

## Fix

Prune `worktrees` and `dist` alongside `.git` via `--exclude-dir`.

## Verification, both directions

- **Clean tree**: `25 passed, 0 failed` (was `24 passed, 1 failed`)
- **Guard integrity**: planting a file that genuinely cites
  `.claude/rules/taskwarrior-bulk-operations.md` is still caught **by name** —
  `24 passed, 1 failed`. The prune drops copies, not findings, so this is not a
  muted check.
- `bash scripts/run-skill-script-tests.sh` goes `FAILED=1 STATUS=ERROR` →
  `FAILED=0`.
