### PR TITLE
docs(rules): gate worktree cleanup on agent completion, not PR state

### DIFF
--- a/.claude/rules/agent-coworker-detection.md
+++ b/.claude/rules/agent-coworker-detection.md
@@ -185,6 +185,24 @@ already gone) over enumerating-and-force-removing live ones. When unsure who own
 a worktree, leave it — a stale worktree costs disk; a force-removed one can cost a
 coworker their afternoon.
 
+**Correct scoping is not sufficient — "all PRs merged" is not the completion
+signal.** Observed 2026-08-15: a cleanup obeying every rule above (scoped to the
+session's own six agent IDs by name, plain `git worktree remove`, no `--force`)
+still killed two live peers' shells. Non-force removal *did* hold the data line —
+it refuses on a dirty tree, so all six were provably clean and nothing was lost —
+but an agent whose PR has merged is not necessarily **done**: one was mid-rebase,
+another was messaging a peer, and a third (skipped only because its worktree was
+`locked`) ran on for two more hours. `SendMessage` to a removed worktree also
+fails permanently (*"cannot be resumed: its worktree no longer exists"*), so the
+peer cannot even be warned.
+
+- **Gate removal on the agent-completion notification, never on PR state.** The
+  harness reports each agent's completion; merged PRs say nothing about whether
+  the agent has more to do.
+- **Announce before removing shared state**, or simply don't — worktree cleanup
+  is never urgent, and deferring it to the next session costs only disk.
+- A `locked` worktree is a live-work signal. Leave it.
+
 ## Integration Points
 
 | Where | How |

--- a/.claude/rules/context-engineering.md
+++ b/.claude/rules/context-engineering.md
@@ -19,7 +19,17 @@ This rule is **path-scoped on purpose.** It is authoring guidance, not an
 every-turn invariant, so it loads only when you are editing a skill, a rule, or
 `CLAUDE.md` — which is the rule it is asking you to follow.
 
-## What the measurement found
+## What the measurement found (2026-07 snapshot)
+
+> **These are the figures as measured in 2026-07 — they are a dated record, not
+> current state, and several have since moved.** Re-measured 2026-08-15:
+> **412** tracked plugin skills (not 242), **3** `references/` directories (not
+> zero), and the C5 always-loaded surface at **~89,000 chars / ~22,262 tokens**
+> (not ~24,600). Cite the re-measurement, not this table, when scoping work —
+> issues #2140/#2141/#2143 all carry figures derived from the snapshot below.
+> Note also that three scanners give three legitimate skill counts
+> (`check-context-engineering.py` includes repo-internal `.claude/skills/`), so
+> any count must name the scanner that produced it.
 
 | Dim | Shift | Judged mean | Verdict |
 |---|---|---|---|
@@ -59,10 +69,12 @@ means a `plugin:skill` name reference, never a shared `REFERENCE.md`
 file owns, link instead — and note that `git-commit` scored C4 = 2 for restating
 a table it *already linked to*.
 
-**Split long skills across files, not into one sidecar.** The corpus has 129
-single `REFERENCE.md` files and zero `references/` directories; the post asks to
+**Split long skills across files, not into one sidecar.** The post asks to
 "divide it into many files and split them out". Split by the path that needs the
-detail, so a scoped run loads only its own material.
+detail, so a scoped run loads only its own material. As of 2026-08-15 the corpus
+has **130** single `REFERENCE.md` files and **3** `references/` directories — the
+shape exists now (`agent-patterns-plugin:parallel-agent-dispatch` is the
+reference implementation, #2143), so copy it rather than inventing a layout.
 
 **Spend constraint tokens where violation is expensive.** The measured pattern
 in text that earned its tokens: it names a non-obvious, costly failure **and says


### PR DESCRIPTION
Two distillations from a 2026-08-15 triage session.

## 1. `agent-coworker-detection.md` — a gap the existing rule did not cover

The cleanup rule already says: scope to your own session's worktrees by name,
never `--force`, prefer `git worktree prune`, leave anything you don't own.

**That was followed exactly, and still killed two live peers' shells.**

What held: non-force `git worktree remove` refuses on a dirty tree, so all six
removed worktrees were provably clean and **no work was lost** — the data line
is where the current rule is strong.

What was missing is a *timing* signal. The removal was gated on "all PRs
merged", which is not the same claim as "all agents done":

| Peer | State when its worktree was removed |
|---|---|
| `pi-retire` | mid-rebase, pre-push (its PR #2404 had already merged) |
| `cluster6` | mid-`SendMessage` to a peer |
| `pad-split` | **skipped** — only because its worktree was `locked`; it ran 2 more hours |

`SendMessage` into a removed worktree fails permanently (*"cannot be resumed:
its worktree no longer exists"*), so the peer cannot even be warned afterward.

Adds three lines to the existing § *Cleanup*: gate on the agent-completion
notification rather than PR state, announce before removing shared state or
simply defer it (cleanup is never urgent), and treat `locked` as a live-work
signal.

## 2. `context-engineering.md` — three figures that are cited as authority and are false

Issues #2140/#2141/#2143 scope their work from this rule's numbers. Re-measured
2026-08-15:

| Claim in the rule | Actual |
|---|---|
| 242 skills are one flat file | **412** tracked plugin skills |
| 0 `references/` dirs | **3** (#2143 shipped the reference implementation) |
| ~24,600 tokens always-loaded | **~89,000 chars / ~22,262 tokens** |

The 2026-07 measurement **table is left intact** — it is a dated record of what
the benchmark found, and rewriting it would destroy the audit trail. Instead its
heading now says so and points at the re-measurement. The separate
**present-tense** claim in the authoring rules ("the corpus has … zero
`references/` directories") *is* corrected, because it reads as current state and
is now wrong.

Also records a trap this session hit: three scanners give three legitimate skill
counts (`check-context-engineering.py` includes repo-internal `.claude/skills/`),
so any count must name the scanner that produced it.

## Cost

+707 chars on the always-loaded surface (`C5_UNSCOPED_RULE_CHARS` 75,023 →
75,730), ~7% of the 10,361 chars of remaining headroom — worth stating plainly
since #2140 is actively trying to shrink that surface.
`check-context-engineering.py --strict` exits 0.
