### PR TITLE
fix(scripts): match a merged PR by tip SHA when head-branch name lookup misses

### DIFF
--- a/scripts/check-stranded-work.sh
+++ b/scripts/check-stranded-work.sh
@@ -97,6 +97,24 @@ collect() {
       base="$(jq -r '.[0].baseRefName' <<<"$pr_json")"
       # A 404 on the base ref is the auto-close fingerprint.
       gh api "repos/$repo/branches/$base" >/dev/null 2>&1 || base_exists=false
+    else
+      # No PR matches this branch by NAME. Before concluding no PR was ever
+      # opened, check whether the branch's tip SHA matches a MERGED PR's
+      # headRefOid — the PR may have been opened from a differently-named head
+      # ref (claude-plugins #2411: a squash-merged PR opened from an
+      # emoji-named branch whose tip SHA equals this branch's tip, but whose
+      # name never matches). git-side signals (git cherry, ancestry) also read
+      # "unmerged" for a squash-merge, so the SHA match is the only thing that
+      # can disambiguate here.
+      sha_pr_json="$(gh pr list -R "$repo" --state all --limit 100 --search "$sha" \
+        --json number,state,mergedAt,headRefOid 2>/dev/null || echo '[]')"
+      sha_match="$(jq -r --arg sha "$sha" \
+        '([.[] | select(.headRefOid == $sha and .state == "MERGED")])[0].number // ""' \
+        <<<"$sha_pr_json")"
+      if [ -n "$sha_match" ]; then
+        pr_number="$sha_match"
+        pr_merged=true
+      fi
     fi
 
     jq -nc --arg repo "$repo" --arg branch "$branch" --arg sha "$sha" \

--- a/scripts/tests/test-check-stranded-work.sh
+++ b/scripts/tests/test-check-stranded-work.sh
@@ -130,5 +130,57 @@ grep -q 'Auto-closed with unlanded work' <<<"$body" && pass "issue body has auto
 grep -q "Pushed but never PR'd"          <<<"$body" && pass "issue body has never-PR'd section" || fail "missing never-PR'd section"
 grep -q 'cannot be reopened'             <<<"$body" && pass "issue body states PR cannot be reopened" || fail "missing reopen warning"
 
+# 10. Regression for #2411: a PR opened from a DIFFERENTLY-NAMED head ref must
+#     still classify as landed, not stranded_no_pr. classify() alone can't
+#     exercise this — the fix lives in collect()'s gh lookups — so this stubs
+#     `gh`/`git` on PATH and runs the real script end-to-end, reproducing the
+#     exact #2124 case from the issue (an emoji-named head ref whose tip SHA
+#     equals claude/pr-2124-merge-midrgh's tip, but whose name never matches).
+stub_dir="$tmp/stubs"
+mkdir -p "$stub_dir"
+
+cat > "$stub_dir/gh" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  "repo view o/r --json defaultBranchRef --jq .defaultBranchRef.name")
+    echo "main" ;;
+  "api repos/o/r/branches --paginate --jq .[].name")
+    echo "claude/pr-2124-merge-midrgh" ;;
+  "api repos/o/r/branches/claude/pr-2124-merge-midrgh --jq .commit.sha")
+    echo "4d2504df566ba7ceff95acb3401c16adfdec21c4" ;;
+  "api repos/o/r/commits/4d2504df566ba7ceff95acb3401c16adfdec21c4 --jq .commit.committer.date[0:10]")
+    echo "2026-07-27" ;;
+  "api repos/o/r/compare/main...claude/pr-2124-merge-midrgh --jq .ahead_by")
+    echo "3" ;;
+  "pr list -R o/r --head claude/pr-2124-merge-midrgh --state all --limit 1 --json number,state,mergedAt,baseRefName")
+    echo "[]" ;;
+  "pr list -R o/r --state all --limit 100 --search 4d2504df566ba7ceff95acb3401c16adfdec21c4 --json number,state,mergedAt,headRefOid")
+    echo '[{"number":2124,"state":"MERGED","mergedAt":"2026-07-27T11:14:41Z","headRefOid":"4d2504df566ba7ceff95acb3401c16adfdec21c4"}]' ;;
+  *)
+    echo "STUB: unhandled gh call: $*" >&2
+    exit 1 ;;
+esac
+STUB
+chmod +x "$stub_dir/gh"
+
+cat > "$stub_dir/git" <<'STUB'
+#!/usr/bin/env bash
+# Force collect() into the gh-api ahead-count fallback (branch not fetched
+# locally), so the fixture doesn't need a real git object for the fake SHA.
+exit 1
+STUB
+chmod +x "$stub_dir/git"
+
+sha_out="$(PATH="$stub_dir:$PATH" "$check" --repo o/r 2>&1)"
+
+if grep -q 'VERDICT=stranded_no_pr' <<<"$sha_out"; then
+  fail "PR opened from a differently-named head ref (#2124 shape) was WRONGLY reported as stranded_no_pr"
+else
+  pass "PR opened from a differently-named head ref is matched by tip SHA and not reported as stranded"
+fi
+
+grep -q '^LANDED=1$' <<<"$sha_out" && pass "SHA-matched merged PR counted as LANDED" || fail "SHA-matched merged PR not counted as LANDED (got: $(grep '^LANDED=' <<<"$sha_out"))"
+grep -q '^STRANDED_NO_PR=0$' <<<"$sha_out" && pass "STRANDED_NO_PR=0 after SHA fallback match" || fail "STRANDED_NO_PR nonzero after SHA fallback match (got: $(grep '^STRANDED_NO_PR=' <<<"$sha_out"))"
+
 [ "$fail" -eq 0 ] && echo "ALL TESTS PASSED" || echo "SOME TESTS FAILED"
 exit "$fail"


### PR DESCRIPTION
## Summary

- `check-stranded-work.sh` classified a branch as `stranded_no_pr` whenever no PR matched it **by head-branch name**, with no fallback to matching the branch's tip SHA against candidate PRs' `headRefOid`.
- A PR opened from a **differently-named** head ref (e.g. an emoji-named branch on the far side of a squash-merge) was therefore reported as unlanded work even though it had already merged — this false positive stood for 12 days as #2267 before being tracked down.
- Before emitting `stranded_no_pr`, `collect()` now falls back to searching for a **MERGED** PR whose `headRefOid` equals the branch's tip SHA. `git cherry` / ancestry already read "unmerged" for a squash-merge, so the SHA match is the only signal that can disambiguate this case (per `.claude/rules/pr-merge-hazards.md` #1: a MERGED PR is authoritative).

## Test plan

- [x] Added a regression test that stubs `gh`/`git` on `PATH` and runs the real script end-to-end, reproducing the exact #2124 shape from the issue (name lookup misses, tip SHA matches a MERGED PR) — asserts the branch is classified `landed`, not `stranded_no_pr`.
- [x] `bash scripts/tests/test-check-stranded-work.sh` — all 21 assertions pass (18 pre-existing + 3 new).
- [x] `bash scripts/lint-shell-scripts.sh scripts/check-stranded-work.sh scripts/tests/test-check-stranded-work.sh` — 0 errors, 0 warnings.

Fixes #2411

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQnWDk8E73mypNc1yY2L1W)_