### PR TITLE
docs(tools-plugin): warn that bare hf download fetches the whole repo

### DIFF
--- a/scripts/plugin-compliance-check.sh
+++ b/scripts/plugin-compliance-check.sh
@@ -843,6 +843,23 @@ check_skill_body() {
       done
     fi
 
+    # Regression (#2409): hf-downloads must document that the FILENAMES
+    # argument is load-bearing — a bare `hf download <repo>` with no file
+    # silently fetches the whole repo (demo/, examples/, obsolete/ included,
+    # no confirmation), which is exactly the surprise-disk-write mistake the
+    # skill exists to prevent. It must also offer a listing recipe so
+    # dropping the file argument is never the natural move for "what's in
+    # this repo?". A bulk edit that trims the warning or the listing recipe
+    # would silently restore the trap, so assert both survive.
+    if [ "$skill_name" = "hf-downloads" ]; then
+      for token in "required in practice" "list_repo_files"; do
+        if ! grep -qF "$token" "$skill_file"; then
+          issues+=("❌ ${plugin}/${skill_name}: SKILL.md must retain token '${token}' (bare 'hf download <repo>' fetches the whole repo — see #2409)")
+          has_errors=true
+        fi
+      done
+    fi
+
     # Regression: github-actions-auth-security must document the GitHub Actions
     # script-injection mitigation (distinct from Claude *prompt* injection):
     # untrusted run-context values bound to an intermediate `env:` variable and

--- a/tools-plugin/skills/hf-downloads/SKILL.md
+++ b/tools-plugin/skills/hf-downloads/SKILL.md
@@ -3,7 +3,7 @@ name: hf-downloads
 description: "Hugging Face model downloads without filling root disk — HF_HOME/xet cache redirection, token/gated-repo auth, staging pattern. Use when downloading HF models, hf download errors, ENOSPC during downloads, or GatedRepoError/401s."
 allowed-tools: Bash, Read
 created: 2026-07-05
-modified: 2026-08-15
+modified: 2026-08-16
 reviewed: 2026-07-05
 ---
 
@@ -21,11 +21,27 @@ Scoped to `huggingface_hub` / `hf`. For disk-full recovery in general — reclai
 hf download <repo> <file> --local-dir /big/disk/staging
 ```
 
+The `<file>` argument is **required in practice**, not optional: `hf download <repo>` with no file downloads the **entire repo**, including any `demo/`, `examples/`, or `obsolete/` directories it carries — there is no listing or confirmation step first. To see what's in a repo before downloading, use the listing recipe below rather than dropping the file argument.
+
 The final file lands on `/big/disk/`, but the xet chunks stage under `~/.cache/huggingface/xet/`. Xet is HF's newer transfer protocol: it stages compressed blocks under `~/.cache` while reconstructing the file, and those staged blocks are **roughly file-sized**. On a small root disk the symptom is:
 
 ```
 OSError: I/O error: IO Error: No space left on device (os error 28)
 ```
+
+## Listing a Repo's Files Before Downloading
+
+Reaching for a bare `hf download <repo>` to see what a repo contains fetches the whole thing instead — there is no listing subcommand. Use one of these instead:
+
+```sh
+# List files without downloading anything
+python3 -c "from huggingface_hub import HfApi; print('\n'.join(HfApi().list_repo_files('<repo>')))"
+
+# Download only a subset by glob, skipping demo/examples/obsolete directories
+hf download <repo> --include 'model.safetensors' --include '*.json' --local-dir /big/disk/staging
+```
+
+`--include` / `--exclude` accept glob patterns and compose (`--exclude 'demo/*' --exclude 'obsolete/*'` to keep everything else). Prefer naming the files you want over excluding the ones you don't — the file argument stays load-bearing either way.
 
 ## Fix: `HF_HOME` Is the Umbrella
 


### PR DESCRIPTION
## Summary

- `tools-plugin:hf-downloads` never stated what a bare `hf download <repo>` (no file argument) does: it silently fetches the **entire repo** — including any `demo/`, `examples/`, or `obsolete/` directories — with no listing step, size estimate, or confirmation. Every example in the skill happened to pass a file, so a reader following the skill was fine, but the skill's whole premise is avoiding surprise multi-GB writes and this is exactly that mistake with no guardrail.
- Hit live 2026-08-15: a bare-form pull grabbed 3.2 GB pulling four projection matrices, because the repo also carried a `demo/` folder and an `obsolete/` directory.
- Added a warning at the point the download form is introduced (the `<file>` argument is load-bearing, not optional), plus a "Listing a Repo's Files" section offering `HfApi().list_repo_files()` for a pure listing and `--include`/`--exclude` globs for a filtered pull — so dropping the file argument is never the natural move for "what's in this repo?".
- Added a `plugin-compliance-check.sh` regression guard (`check_skill_body()`) asserting the warning and the listing recipe survive future bulk edits.

## Test plan

- [x] Mutation-verified the new compliance guard: stripping the warning token makes it fire `❌ ... must retain token 'required in practice'`; restoring the file clears it.
- [x] `./scripts/plugin-compliance-check.sh tools-plugin` — Body column ✅, no new errors (pre-existing WARNs on description length / When-to-Use / size are unrelated).
- [x] `bash scripts/tests/test-plugin-compliance-check.sh` — 21/21 pass.
- [x] `bash scripts/lint-shell-scripts.sh scripts/plugin-compliance-check.sh` — 0 errors, 0 warnings.

Fixes #2409

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQnWDk8E73mypNc1yY2L1W)_