### PR TITLE
fix(comfyui-plugin): back-port the registry-health Pending guard, stop emitting renovate.yml

### DIFF
--- a/comfyui-plugin/skills/comfyui-node-scaffold/fleet-policy.toml
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/fleet-policy.toml
@@ -66,6 +66,17 @@ reason = "Strict TS compiler settings. Divergence means one pack typechecks unde
 policy = "managed"
 reason = "Dependency-update policy. Divergence silently changes which pins Renovate manages."
 
+# `.github/workflows/renovate.yml` deliberately has NO entry, and must not get
+# one back. Each pack ran TWO Renovate runners — the gitops-managed autodiscover
+# App (`app/laurigates-renovate`) and this repo-local workflow calling
+# reusable-renovate.yml as `app/github-actions` — so every pack carried two open
+# "Dependency Dashboard" issues. The workflow was deleted fleet-wide on
+# 2026-08-16 and the scaffold no longer emits it; renovate.json above is what
+# configures the surviving App. The manifest cannot express "must be absent"
+# (VALID_POLICIES is managed/seed/shared/block), and an entry for a path the
+# generator no longer emits is only a STALE_POLICY_ENTRY warning, so absence
+# from this table is the whole mechanism.
+
 [files."tests/test_publish_hygiene.py"]
 policy = "managed"
 reason = "The registry publish gate. Intended to be byte-identical fleet-wide and had NO gate at all before this checker — the motivating case."
@@ -77,10 +88,6 @@ reason = "Ambient type shims for the ComfyUI frontend. Divergence means one pack
 [files.".github/workflows/registry-health.yml"]
 policy = "managed"
 reason = "Scheduled registry-listing health probe. Identical by construction across packs."
-
-[files.".github/workflows/renovate.yml"]
-policy = "managed"
-reason = "Renovate runner. Divergence changes update cadence for one pack only."
 
 [files."knip.json"]
 policy = "managed"

--- a/comfyui-plugin/skills/comfyui-node-scaffold/references/implementing-the-pack.md
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/references/implementing-the-pack.md
@@ -11,8 +11,11 @@ A repo where `just check` (typecheck + build + lint + test) passes from the
 first commit: `pyproject.toml` (`[tool.comfy]` metadata with `includes =
 ["web/dist"]` and `Icon`/`Banner` wired to the raw-GitHub PNG URLs, ruff config,
 dev deps), `.github/workflows/` (`ci.yml`, `publish.yml`, `release-please.yml`,
-`renovate.yml`, `registry-health.yml`, `clear-autorelease-labels.yml`),
-`renovate.json` (Renovate, **not** dependabot), strict `tsconfig.json`,
+`registry-health.yml`, `clear-autorelease-labels.yml`),
+`renovate.json` (Renovate, **not** dependabot — configuring the gitops-managed
+autodiscover App; there is deliberately no repo-local `renovate.yml`, which
+would be a second runner opening its own Dependency Dashboard issue), strict
+`tsconfig.json`,
 `biome.json`, `knip.json`, `.pre-commit-config.yaml`,
 `release-please-config.json` (carrying the `uv.lock` `toml` updater) + manifest,
 `vitest.config.js`, `package.json`

--- a/comfyui-plugin/skills/comfyui-node-scaffold/scaffold.py
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/scaffold.py
@@ -2102,50 +2102,6 @@ RENOVATE_JSON = """\
 }
 """
 
-RENOVATE_YML = """\
-name: Renovate
-
-on:
-  schedule:
-    - cron: '17 */2 * * *'
-  workflow_dispatch:
-    inputs:
-      dryRun:
-        description: 'Dry run mode'
-        required: false
-        default: 'false'
-        type: choice
-        options:
-          - 'false'
-          - 'full'
-          - 'lookup'
-      logLevel:
-        description: 'Log level'
-        required: false
-        default: 'info'
-        type: choice
-        options:
-          - info
-          - debug
-          - warn
-
-# Explicit grant so the run works even when the repo's default workflow
-# permissions are read-only (the reusable workflow needs write to open
-# dependency PRs and the Dependency Dashboard issue).
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  packages: read
-
-jobs:
-  renovate:
-    uses: laurigates/.github/.github/workflows/reusable-renovate.yml@main
-    with:
-      dry-run: ${{ inputs.dryRun || 'false' }}
-      log-level: ${{ inputs.logLevel || 'info' }}
-"""
-
 # The `uv.lock` extra-file is load-bearing, not decoration. release-please's
 # `python` release-type bumps `pyproject.toml` but has no native uv.lock support
 # (googleapis/release-please#2561), and uv records the project's OWN version in
@@ -2629,19 +2585,36 @@ BANNER_SVG = """\
 # Registry health monitor — flags a pack whose Active registry version has been
 # Flagged (falls back to the previous Active version on install). Mirrors the
 # sibling packs' registry-health.yml.
+#
+# The Pending guard before the `gh issue close` block is load-bearing: the
+# registry scan is async, so a run triggered right after Publish sees
+# NodeVersionStatusPending, and `problem` is deliberately empty inside the 6h
+# grace window. Without the early `exit 0` the close path ran on that empty
+# `problem` and closed the tracking issue with "is **Active**" while the
+# registry still said Pending (observed 2026-08-16: comfyui-gallery-loader
+# 0.1.29 closed issue #106 at 16:39:39Z against a Pending API response).
 REGISTRY_HEALTH_YML = r"""name: Registry health
 
 # Feedback loop for Comfy Registry publishing. Checks that the version this
 # repo currently declares (pyproject.toml) is actually Active in the registry.
-# Fails (red X + notification) and opens/updates a tracking issue when that
-# version is Flagged, stuck Pending, or missing — and warns when a phantom
-# higher version sits ahead of it in the registry. Closes the issue once the
-# release is healthy.
+#
+# Two visible outputs:
+#   1. A commit status "Comfy Registry / scan" on the release commit — the
+#      registry verdict shows up as a check (green Active / red Flagged /
+#      yellow pending) next to CI in the Actions + commit UI.
+#   2. A tracking issue (label registry-health) opened/updated when the version
+#      is Flagged, stuck Pending, or missing, and closed once it goes Active.
+#
+# The registry security scan is async: a freshly published version is Pending
+# for a while before it flips to Active or Flagged. So a run triggered right
+# after Publish polls for a bounded window until the version leaves Pending,
+# instead of reporting a premature "pending, fine". Schedule/dispatch runs
+# evaluate once and defer to the pending grace window.
 
 on:
   workflow_dispatch:
   schedule:
-    - cron: "17 7 * * *" # daily 07:17 UTC
+    - cron: "17 7 * * *" # daily 07:17 UTC (backstop for scans slower than the poll window)
   workflow_run:
     workflows: ["Publish to Comfy Registry"]
     types: [completed]
@@ -2649,6 +2622,7 @@ on:
 permissions:
   contents: read
   issues: write
+  statuses: write # emit the "Comfy Registry / scan" commit status
 
 jobs:
   check:
@@ -2662,26 +2636,62 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PENDING_GRACE_HOURS: "6" # scan normally completes well under this
           ISSUE_LABEL: "registry-health"
+          # Commit the status to the release commit that triggered Publish;
+          # otherwise (schedule/dispatch) to the checked-out HEAD.
+          STATUS_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          STATUS_CONTEXT: "Comfy Registry / scan"
+          # Bounded post-publish poll (workflow_run only): wait for the async
+          # scan to leave Pending. 20 x 90s ≈ 30 min; slower scans defer to the
+          # daily schedule. A stuck Pending is still caught by the grace check.
+          POLL_ATTEMPTS: "20"
+          POLL_INTERVAL_SECS: "90"
         run: |
           set -euo pipefail
 
           node_id=$(grep -m1 -E '^name'    pyproject.toml | sed -E 's/.*"([^"]+)".*/\1/')
           ver=$(grep    -m1 -E '^version' pyproject.toml | sed -E 's/.*"([^"]+)".*/\1/')
           [ -n "$node_id" ] && [ -n "$ver" ] || { echo "::error::cannot read name/version from pyproject.toml"; exit 1; }
-          echo "Node: $node_id  declared version: $ver"
+          echo "Node: $node_id  declared version: $ver  status-sha: ${STATUS_SHA}"
+
+          dash="https://registry.comfy.org/nodes/${node_id}"
+
+          # Publish a commit status so the registry verdict is a visible check.
+          # <state> in {pending,success,failure}, <description> short free text.
+          set_status() {
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/statuses/${STATUS_SHA}" \
+              -f state="$1" \
+              -f context="${STATUS_CONTEXT}" \
+              -f description="$2" \
+              -f target_url="$dash" >/dev/null 2>&1 \
+              || echo "::warning::could not set commit status ($1: $2)"
+          }
 
           # include_status_reason=true returns the security-scan findings JSON
           # (issue_type/file_path/description) — the closed feedback loop for
           # Flagged versions (scanner notifications otherwise land only in the
           # Comfy Org Discord #security-review-council channel).
-          curl -fsS "https://api.comfy.org/nodes/${node_id}/versions?include_status_reason=true" -o versions.json
+          fetch() {
+            curl -fsS "https://api.comfy.org/nodes/${node_id}/versions?include_status_reason=true" -o versions.json
+          }
 
-          status=$(jq -r --arg v "$ver" '.[] | select(.version==$v) | .status' versions.json)
-          created=$(jq -r --arg v "$ver" '.[] | select(.version==$v) | .createdAt' versions.json)
+          # Poll only right after a publish; wait until the version appears AND
+          # leaves Pending, or the window expires. Other triggers evaluate once.
+          status=""; created=""
+          for i in $(seq 1 "${POLL_ATTEMPTS}"); do
+            fetch
+            status=$(jq  -r --arg v "$ver" '.[] | select(.version==$v) | .status'    versions.json)
+            created=$(jq -r --arg v "$ver" '.[] | select(.version==$v) | .createdAt' versions.json)
+            if [ -n "$status" ] && [ "$status" != "NodeVersionStatusPending" ]; then break; fi
+            [ "${GITHUB_EVENT_NAME}" = "workflow_run" ] || break
+            if [ "$i" -lt "${POLL_ATTEMPTS}" ]; then
+              echo "attempt ${i}/${POLL_ATTEMPTS}: status=${status:-missing} — waiting ${POLL_INTERVAL_SECS}s"
+              set_status pending "Registry scan running (${status:-uploading})…"
+              sleep "${POLL_INTERVAL_SECS}"
+            fi
+          done
+
           highest=$(jq -r '.[].version' versions.json | sort -V | tail -1)
-
           body=$(mktemp); problem=""
-          dash="https://registry.comfy.org/nodes/${node_id}"
 
           if [ -z "$status" ]; then
             problem="missing"
@@ -2725,6 +2735,15 @@ jobs:
             [ -n "$problem" ] || problem="phantom-ahead"
           fi
 
+          # Map the verdict onto the visible commit status.
+          if [ -n "$problem" ]; then
+            set_status failure "${problem}: v${ver}"
+          elif [ "$status" = "NodeVersionStatusPending" ]; then
+            set_status pending "Scan still running (v${ver}) — awaiting next check"
+          else
+            set_status success "Active in registry (v${ver})"
+          fi
+
           gh label create "$ISSUE_LABEL" --color FBCA04 --description "Comfy Registry publish health" --force >/dev/null 2>&1 || true
           existing=$(gh issue list --label "$ISSUE_LABEL" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
 
@@ -2734,6 +2753,11 @@ jobs:
             else gh issue create --title "Registry: release ${ver} not healthy (${problem})" --label "$ISSUE_LABEL" --body-file "$body"; fi
             echo "::error::release ${ver} is ${problem}"
             exit 1
+          fi
+
+          if [ "$status" = "NodeVersionStatusPending" ]; then
+            echo "::notice::${ver} still Pending after poll window — deferring to the next scheduled run"
+            exit 0
           fi
 
           if [ -n "$existing" ]; then
@@ -3137,7 +3161,6 @@ def build_file_map(
         ".github/workflows/ci.yml": CI_YML,
         ".github/workflows/publish.yml": PUBLISH_YML,
         ".github/workflows/release-please.yml": RELEASE_PLEASE_YML,
-        ".github/workflows/renovate.yml": RENOVATE_YML,
         ".github/workflows/registry-health.yml": REGISTRY_HEALTH_YML,
         ".github/workflows/clear-autorelease-labels.yml": CLEAR_AUTORELEASE_YML,
         "docs/blueprint/adrs/0001-adopt-typescript-bun-build.md": ADR_0001,

--- a/comfyui-plugin/skills/comfyui-node-scaffold/scripts/tests/test-finishing-pass.sh
+++ b/comfyui-plugin/skills/comfyui-node-scaffold/scripts/tests/test-finishing-pass.sh
@@ -11,7 +11,7 @@
 #   2. pyproject [tool.comfy] Icon/Banner point at the raw-GitHub PNG URLs
 #      (never the old empty `Icon = ""`)
 #   3. registry-health.yml + clear-autorelease-labels.yml workflows emitted
-#   4. renovate.json emitted; NO dependabot.yml anywhere
+#   4. renovate.json emitted; NO dependabot.yml and NO renovate.yml anywhere
 #   5. justfile carries a `just assets` recipe (svg -> png rasterize)
 #   6. README '## What it does' is no longer a bare TODO stub
 #   7. the finishing-pass audit prints (icon/banner emitted + screenshot follow-up)
@@ -132,6 +132,14 @@ if [ -f "$PACK/.github/dependabot.yml" ]; then
     check "no dependabot.yml emitted" "absent" "present"
 else
     check "no dependabot.yml emitted" "absent" "absent"
+fi
+# A repo-local renovate.yml is a SECOND runner beside the gitops-managed
+# autodiscover App, so every pack carried two open "Dependency Dashboard"
+# issues. Deleted fleet-wide 2026-08-16; this pins the generator to match.
+if [ -f "$PACK/.github/workflows/renovate.yml" ]; then
+    check "no renovate.yml workflow emitted" "absent" "present"
+else
+    check "no renovate.yml workflow emitted" "absent" "absent"
 fi
 
 # 5. `just assets` rasterize recipe.


### PR DESCRIPTION
## What

Back-ports two fixes that landed across all 13 ComfyUI pack repos today into
`comfyui-node-scaffold`, the generator that emits them.

1. **`registry-health.yml`** — the template gains the Pending guard the fleet
   now runs.
2. **`.github/workflows/renovate.yml`** — the scaffold no longer emits it.

## Why

Both were fixed only on the deployed instances, so every future
`/comfy-node` scaffold would have been born with them
(`~/.claude/rules/scaffold-fix-backport.md`).

### 1. A false "Active" close

The workflow's close path ran whenever its `problem` variable was empty, and
`problem` stays empty for a version that is merely Pending inside the 6h grace
window. So a freshly published version closed its own tracking issue with
"Resolved: `<v>` is **Active** and highest in the registry" while the registry
still reported `NodeVersionStatusPending`.

Reproduced live on 2026-08-16: publishing `comfyui-gallery-loader` 0.1.29
closed issue #106 at 16:39:39Z with that message while the API returned
Pending at the same moment.

The corrected workflow was not newly written — `comfyui-touch-manager` already
had it and the fleet PR back-ported that copy. Versus the old template it adds:

- a bounded post-publish poll (20 x 90s) that waits for the async scan to leave
  Pending,
- a `Comfy Registry / scan` commit status (hence `statuses: write`),
- an early `exit 0` on Pending, placed **before** the `gh issue close` block.

### 2. A duplicate Renovate runner

Each pack ran two live runners — the gitops-managed autodiscover App
(`app/laurigates-renovate`, kept) and the repo-local `renovate.yml` calling
`reusable-renovate.yml` as `app/github-actions` (deleted) — so every pack
carried two open "Dependency Dashboard" issues. `renovate.json` is untouched
and still configures the surviving App.

## How

| File | Change |
| --- | --- |
| `scaffold.py` | `REGISTRY_HEALTH_YML` body replaced with the fleet's corrected workflow; `RENOVATE_YML` and its file-map entry removed |
| `fleet-policy.toml` | `[files.".github/workflows/renovate.yml"]` section removed, with a comment recording why it must not come back |
| `references/implementing-the-pack.md` | `renovate.yml` dropped from the emitted-workflows list |
| `scripts/tests/test-finishing-pass.sh` | new assertion: no `renovate.yml` workflow emitted |

The template body was **extracted** from
`comfyui-touch-manager/.github/workflows/registry-health.yml` by script, never
retyped (`~/.claude/rules/never-fabricate-test-identifiers.md`).

### Why the policy section is removed rather than inverted

`check-fleet-drift.py` declares `VALID_POLICIES = {"managed", "seed", "shared",
"block"}` — the manifest has no way to say "must be absent". It also only
compares paths it *derives* from the generator's rendered file map, so once the
scaffold stops emitting `renovate.yml` the path leaves that set and a retained
entry degrades to a `STALE_POLICY_ENTRY` **warning** rather than enforcing
anything. Absence from the table is the whole mechanism, which is why it is now
documented in place.

## Verification

**The emitted `registry-health.yml` is byte-identical to the canonical file** —
scaffolded a throwaway pack into a temp dir and diffed:

```
$ diff -u comfyui-touch-manager/.github/workflows/registry-health.yml \
          $TMP/comfyui-zz-throwaway/.github/workflows/registry-health.yml
BYTE-IDENTICAL
2304e16537105f153801147c97a2e15f6783683116b1aa6aa9ca63b60637c3cf  (canonical)
2304e16537105f153801147c97a2e15f6783683116b1aa6aa9ca63b60637c3cf  (emitted)
```

That sha256 is also what all 13 packs carry. The throwaway's
`.github/workflows/` holds `ci.yml`, `clear-autorelease-labels.yml`,
`publish.yml`, `registry-health.yml`, `release-please.yml` — no `renovate.yml`
— and `renovate.json` is present. The scaffold wrote nothing outside the temp
dir (both `claude-plugins` and the fleet root stayed clean apart from the four
files above).

**Fleet-drift checker, before → after**, run against the live 13-pack fleet.
Exactly 26 rows disappear and nothing else in the report moves:

```
-MANAGED_DRIFT_COUNT=73
+MANAGED_DRIFT_COUNT=47
-MANAGED_DRIFT=<13 packs>|.github/workflows/registry-health.yml|differs
-MANAGED_DRIFT=<13 packs>|.github/workflows/renovate.yml|absent
-ISSUE_COUNT=100
+ISSUE_COUNT=74
```

`STATUS` stays `ERROR` on pre-existing, out-of-scope drift this PR does not
touch: `publish.yml` (9), `.pre-commit-config.yaml` (8),
`RELEASE-CHECKLIST.md` (13), `biome.json` (8), `knip.json` (3),
`src/comfyui-shims.d.ts` (1), `vitest.config.js` (5), plus 23
`SHARED_MINORITY` and 4 `BACKPORT` warnings. No new drift is introduced.

**Tests.** All four scaffold suites green: `test-finishing-pass.sh` 86/0,
`test-fleet-drift.sh` 58/0, `test-shim-variant.sh` 13/0,
`test-standalone-variant.sh` 9/0. `just lint-compliance` exits 0 with no
finding naming `comfyui-node-scaffold`.

**The new assertion was mutation-tested** rather than trusted for being green —
re-adding the file-map entry turns it red for the right reason:

```
FAIL: no renovate.yml workflow emitted
85 passed, 1 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ph3BsniNbHPLbww6TjXPrz
