### PR TITLE
docs(testing-plugin): hand-rolled mutation harnesses can report the wrong check

### DIFF
--- a/testing-plugin/skills/mutation-testing/SKILL.md
+++ b/testing-plugin/skills/mutation-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 created: 2025-12-16
-modified: 2026-05-09
+modified: 2026-08-17
 reviewed: 2025-12-16
 name: mutation-testing
 description: "Mutation testing with Stryker (TS/JS) and mutmut (Python). Use when finding weak tests that pass on mutated code, or improving test quality through mutation analysis."
@@ -123,6 +123,86 @@ Status: 45/50 mutants killed (90%)
 - Killed: 45 (tests caught the mutation)
 - Survived: 5 (tests passed despite mutation)
 ```
+
+## Hand-rolled harnesses report LESS than Stryker and mutmut do
+
+Everything above assumes a framework. Plenty of real mutation testing is a
+hand-rolled loop instead — apply a mutation, run one assertion, catch the
+failure — typically because the thing under test is a **build-time check in a
+generator or builder** rather than a unit test suite.
+
+That loop is worth writing. But it drops the one piece of bookkeeping the
+frameworks give you for free: **Stryker and mutmut tell you *which test* killed
+each mutant.** A hand-rolled harness usually reports only *that something*
+failed, and "something failed" is indistinguishable from "the check I am testing
+failed". Three ways that goes wrong, all observed in one session:
+
+### 1. An earlier check masks the one under test
+
+```
+run(mutate_frame_count, "check P: off-grid length")
+  -> CAUGHT: "beat 'x' asks for 20 words in 5.42 s (3.69 words/s, ceiling 3.0)"
+```
+
+Reported as caught; the message is from **check N**, a words-per-second rule that
+fires before the grid check ever runs. Check P was never exercised. The mutation
+tripped a different assertion on the way past.
+
+**Always print and read the failure message, never just the pass/fail.** If the
+message does not name the check you are testing, the mutation did not reach it.
+
+### 2. The mutation has to be one ONLY the target check can see
+
+Fixing the above is not "mutate harder" — it is choosing a mutation that no
+earlier check can intercept:
+
+| Testing | Bad mutation | Works |
+|---|---|---|
+| an off-grid frame count | any beat (a talky one trips the words/sec check first) | a **wordless** beat |
+| a cast-shrink rule | a beat whose prose also names the removed character (trips the alias check) | a beat where only the count changes |
+
+This is the same discipline as isolating a variable in an A/B: the mutation is
+the independent variable, and anything else it perturbs is a confound.
+
+### 3. Mutating a table leaves import-time derived state stale
+
+The subtlest one, and it caused two of the three maskings. Modules commonly build
+lookup dicts from a table **at import**:
+
+```python
+SEGMENTS = (...)
+_SEG_OF = {beat: name for name, beats, _ in SEGMENTS for beat in beats}
+```
+
+Monkeypatching `SEGMENTS` in the harness leaves `_SEG_OF` describing the *old*
+table, so the first check that consults it fails with a stale-lookup error —
+masking everything downstream:
+
+```python
+mod.SEGMENTS = new_table
+mod._SEG_OF = {b: n for n, ids, _ in mod.SEGMENTS for b in ids}   # REQUIRED
+```
+
+**Rebuild every derived structure you can find, or reload the module.** Grep for
+comprehensions over the table you mutated.
+
+### The consequence for a green table
+
+A harness that prints CAUGHT for every mutation is often quoted as proof the
+suite is sound. It proves something weaker:
+
+> An all-CAUGHT table proves each **mutation** was caught by **some** assertion.
+> It never proves the assertion you meant was the one that caught it — nor that
+> any individual assertion is capable of failing.
+
+Two cheap additions close most of the gap:
+
+- **A deliberate no-op mutation** the harness *should* miss. A table where
+  everything is CAUGHT is indistinguishable from a broken harness; one expected
+  MISS tells them apart.
+- **Assert on the message, not just the exception.** Match the mutation to an
+  expected substring of the failure, so a masked result is a harness failure
+  rather than a silent pass.
 
 ## Mutation Score Targets
 


### PR DESCRIPTION
## What

Adds a **"Hand-rolled harnesses report LESS than Stryker and mutmut do"** section
to `testing-plugin:mutation-testing`.

The skill currently covers the two frameworks only. Both report **which test
killed each mutant** — and that single piece of bookkeeping is what a hand-rolled
mutation loop drops, which is where the failure mode below lives.

## Why

Plenty of real mutation testing is a hand-rolled loop (apply a mutation, run one
assertion, catch the failure), typically because the thing under test is a
**build-time check in a generator/builder** rather than a unit-test suite. That
loop usually reports only *that something failed*, which is indistinguishable
from *the check I am testing failed*.

Three concrete traps, all observed in one session:

1. **An earlier check masks the one under test.** A mutation aimed at an
   off-grid-length check reported `CAUGHT` — with a message from a
   words-per-second check that fires first. The target check was never
   exercised.
2. **The mutation must be one only the target check can see.** Fixing (1) is not
   "mutate harder", it is picking a mutation no earlier assertion intercepts —
   e.g. test an off-grid length on a *wordless* item so the words/sec rule
   cannot fire. Same discipline as isolating a variable in an A/B.
3. **Mutating a table leaves import-time derived state stale.** Monkeypatching a
   module-level table leaves the dicts built from it at import describing the old
   table, so the first check consulting one fails with a stale-lookup error and
   masks everything downstream. **Two of the three maskings were this.**

Plus the consequence for how a green table should be read:

> An all-CAUGHT table proves each *mutation* was caught by *some* assertion. It
> never proves the assertion you meant was the one that caught it.

and two cheap mitigations (a deliberate no-op mutation that *should* be MISSED;
asserting on the failure message rather than just the exception).

## Evidence

Found while mutation-testing ~20 build-time checks in a ComfyUI/MiniMax-H3
workflow builder (`comfyui-workspace`, 2026-08-17). Three separate mutations
reported `CAUGHT` from the wrong assertion; re-running each in isolation showed
one was genuine, one was the test's own fault, and one required rebuilding a
derived dict before the target check could be reached.

The same session also found four ways a build-time check can be *structurally*
unable to fail (self-referential sets, a constant compared against a list built
from it, an assertion satisfied by generated text). Those are recorded
project-locally; only the mutation-interpretation half is promoted here, since it
is what this skill is about.

## Scope

Docs only — one new section, `modified:` frontmatter date bumped. No change to
the skill's topic, so the plugin README catalog line is untouched.

---

**On the plugin-README nudge:** the pre-commit hook advises updating
`testing-plugin/README.md` alongside a skill change. Deliberately not done here —
the README carries a one-line catalog entry per skill
(`| mutation-testing | Mutation testing for quality validation |`) and this
change adds a section *within* the skill's existing topic rather than altering
what it is for, so the entry is still accurate. Happy to add one if you'd rather
the catalog reflect the hand-rolled-harness coverage.
