### PR TITLE
ci(sync): authenticate the prompt-sync workflows as a GitHub App

### DIFF
--- a/.github/workflows/sync-git-repo-agent-prompts.yml
+++ b/.github/workflows/sync-git-repo-agent-prompts.yml
@@ -9,11 +9,15 @@ name: "Sync: git-repo-agent prompts"
 # so they must be refreshed here (where the plugin sources live) and pushed to
 # the standalone repo whenever an upstream skill changes.
 #
-# Cross-repo push needs a token with contents + pull-requests write on
-# laurigates/git-repo-agent, stored as the GIT_REPO_AGENT_SYNC_TOKEN secret
-# (a fine-scoped PAT or a GitHub App token). Until that secret is provisioned
-# this runs on manual dispatch only; uncomment the `push:` trigger below to make
-# it event-driven once the secret exists.
+# Cross-repo push authenticates as the laurigates-prompt-sync GitHub App, whose
+# credentials gitops pushes here (PROMPT_SYNC_CLIENT_ID variable +
+# PROMPT_SYNC_PRIVATE_KEY secret; gitops repositories.tf `prompt_sync = true`).
+# The App is installed on git-repo-agent and vault-agent ONLY — never on this
+# repo — and the token below is scoped by `repositories:` to git-repo-agent
+# alone, so it can neither write here nor reach vault-agent.
+#
+# Until an observed dispatch run proves the token works end to end this stays on
+# manual dispatch only; uncomment the `push:` trigger below afterwards.
 
 on:
   workflow_dispatch:
@@ -55,12 +59,32 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # Minted only when there is something to push, so a no-op run never
+      # requests a token. `repositories:` narrows the installation token to the
+      # single target repo.
+      #
+      # app-id, not client-id: v3 marks `app-id` deprecated in favour of
+      # `client-id`, but actionlint v1.7.12 (the latest release, pinned in
+      # .pre-commit-config.yaml and plugin-pr-checks.yml) has stale metadata for
+      # this action and rejects `client-id` as an undefined input. A numeric App
+      # ID is a valid JWT issuer, so this works; gitops pushes
+      # PROMPT_SYNC_CLIENT_ID alongside for the coordinated swap (gitops#206).
+      - name: Mint a prompt-sync App token for git-repo-agent
+        id: app-token
+        if: steps.diff.outputs.changed == 'true'
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.PROMPT_SYNC_APP_ID }}
+          private-key: ${{ secrets.PROMPT_SYNC_PRIVATE_KEY }}
+          owner: laurigates
+          repositories: git-repo-agent
+
       - name: Checkout git-repo-agent
         if: steps.diff.outputs.changed == 'true'
         uses: actions/checkout@v6
         with:
           repository: laurigates/git-repo-agent
-          token: ${{ secrets.GIT_REPO_AGENT_SYNC_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           path: _standalone
 
       - name: Copy regenerated prompts into the standalone checkout
@@ -75,7 +99,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           path: _standalone
-          token: ${{ secrets.GIT_REPO_AGENT_SYNC_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           branch: sync/generated-prompts
           delete-branch: true
           commit-message: "chore: sync compiled prompts from claude-plugins"

--- a/.github/workflows/sync-vault-agent-prompts.yml
+++ b/.github/workflows/sync-vault-agent-prompts.yml
@@ -10,11 +10,15 @@ name: "Sync: vault-agent prompts"
 # sources live) and pushed to the standalone repo whenever an upstream skill
 # changes.
 #
-# Cross-repo push needs a token with contents + pull-requests write on
-# laurigates/vault-agent, stored as the VAULT_AGENT_SYNC_TOKEN secret
-# (a fine-scoped PAT or a GitHub App token). Until that secret is provisioned
-# this runs on manual dispatch only; uncomment the `push:` trigger below to make
-# it event-driven once the secret exists.
+# Cross-repo push authenticates as the laurigates-prompt-sync GitHub App, whose
+# credentials gitops pushes here (PROMPT_SYNC_CLIENT_ID variable +
+# PROMPT_SYNC_PRIVATE_KEY secret; gitops repositories.tf `prompt_sync = true`).
+# The App is installed on git-repo-agent and vault-agent ONLY — never on this
+# repo — and the token below is scoped by `repositories:` to vault-agent alone,
+# so it can neither write here nor reach git-repo-agent.
+#
+# Until an observed dispatch run proves the token works end to end this stays on
+# manual dispatch only; uncomment the `push:` trigger below afterwards.
 
 on:
   workflow_dispatch:
@@ -56,12 +60,32 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # Minted only when there is something to push, so a no-op run never
+      # requests a token. `repositories:` narrows the installation token to the
+      # single target repo.
+      #
+      # app-id, not client-id: v3 marks `app-id` deprecated in favour of
+      # `client-id`, but actionlint v1.7.12 (the latest release, pinned in
+      # .pre-commit-config.yaml and plugin-pr-checks.yml) has stale metadata for
+      # this action and rejects `client-id` as an undefined input. A numeric App
+      # ID is a valid JWT issuer, so this works; gitops pushes
+      # PROMPT_SYNC_CLIENT_ID alongside for the coordinated swap (gitops#206).
+      - name: Mint a prompt-sync App token for vault-agent
+        id: app-token
+        if: steps.diff.outputs.changed == 'true'
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.PROMPT_SYNC_APP_ID }}
+          private-key: ${{ secrets.PROMPT_SYNC_PRIVATE_KEY }}
+          owner: laurigates
+          repositories: vault-agent
+
       - name: Checkout vault-agent
         if: steps.diff.outputs.changed == 'true'
         uses: actions/checkout@v6
         with:
           repository: laurigates/vault-agent
-          token: ${{ secrets.VAULT_AGENT_SYNC_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           path: _standalone
 
       - name: Copy regenerated prompts into the standalone checkout
@@ -76,7 +100,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           path: _standalone
-          token: ${{ secrets.VAULT_AGENT_SYNC_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           branch: sync/generated-prompts
           delete-branch: true
           commit-message: "chore: sync compiled prompts from claude-plugins"


### PR DESCRIPTION
> Pairs with **laurigates/gitops#263**, which manages the App credentials. This PR is safe to merge in either order but is **inert until that one applies** — the workflows are `workflow_dispatch`-only and would fail on an empty `app-id`, exactly as they fail today on a missing PAT.

## What

Replaces the two never-provisioned per-target PATs with a token minted from a `laurigates-prompt-sync` GitHub App.

- Mints via `actions/create-github-app-token@v3`, scoped with `owner:` + `repositories:` to the **single** target repo, and passes it to both the cross-repo `actions/checkout` and `peter-evans/create-pull-request`.
- The mint step carries the same `changed == 'true'` guard as the steps that use it, so a run with no prompt drift never requests a token at all.
- Header comments rewritten to describe the App and its installation instead of the PAT.

## Why

Both workflows have been `workflow_dispatch`-only with **zero runs since July**, blocked on `GIT_REPO_AGENT_SYNC_TOKEN` / `VAULT_AGENT_SYNC_TOKEN`. That is the unmet gate holding #1017 Phase 2 and #1973 Phase 3 — the monorepo copies of `git-repo-agent/` and `vault-agent/` can't be removed until the sync that replaces them is demonstrably working.

An App also avoids two long-lived PATs to rotate by hand, and matches how this account already does cross-repo automation (release-please, Renovate).

## Blast radius

The App is installed on `git-repo-agent` and `vault-agent` **only — never on this repo**. So:

- A token minted **in** claude-plugins **cannot write to** claude-plugins.
- The git-repo-agent sync cannot reach vault-agent, and vice versa.

Permissions are Contents R/W and Pull requests R/W. `permissions:` on the job stays `contents: read` — the App token, not `GITHUB_TOKEN`, does the cross-repo write.

## `app-id`, not `client-id` — and why that's deliberate

`create-github-app-token@v3` **does** declare `client-id` and marks `app-id` `deprecationMessage: "Use 'client-id' instead."` (read from `action.yml` at the `v3` tag, not from memory). So `client-id` was the intent.

It fails our own gate. **actionlint v1.7.12 has stale metadata for this action** — it rejects `client-id` as an undefined input while still reporting `app-id` as required:

```
missing input "app-id" which is required by action "actions/create-github-app-token@v3"
input "client-id" is not defined in action "actions/create-github-app-token@v3"
```

v1.7.12 is the latest actionlint release, so there is nothing to bump to, and we run it un-suppressed in both `.pre-commit-config.yaml` and `plugin-pr-checks.yml` (whose comments record that previous `-ignore` args were deliberately *removed*). Adding a suppression to a shared lint config for a transient upstream data lag is the worse trade. A numeric App ID is a valid JWT issuer, so `app-id` works today; gitops#263 pushes `PROMPT_SYNC_CLIENT_ID` alongside so the swap is one line per workflow when the linter catches up (tracked with gitops#206).

## Verification

- `actionlint` clean on both files — and control-tested: corrupting the input name makes it fail, so the clean result reflects an actual inspection rather than a skipped file.
- `yaml.safe_load` parses both.
- Repo-wide grep confirms no `*_SYNC_TOKEN` reference survives anywhere.

Not verified, and can't be from here: that the token actually works. That needs the gitops apply plus one dispatch run.

## After merge

The `push:` triggers stay commented out until a dispatch run is **observed** opening a PR on a target repo — `tool-migration-cutover`'s verify-operational gate, which has never been satisfied for these workflows. Note the failure mode when checking: a run with no prompt drift skips the checkout and PR steps and still exits green, indistinguishable from a broken token. Confirm the **Checkout** step ran.

Refs #1017, #1973

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHj3bQBrztqJrAm18Wd6AT
