### PR TITLE
ci(sync): enable the push triggers and add a force dispatch input

### DIFF
--- a/.github/workflows/sync-git-repo-agent-prompts.yml
+++ b/.github/workflows/sync-git-repo-agent-prompts.yml
@@ -16,17 +16,25 @@ name: "Sync: git-repo-agent prompts"
 # repo — and the token below is scoped by `repositories:` to git-repo-agent
 # alone, so it can neither write here nor reach vault-agent.
 #
-# Until an observed dispatch run proves the token works end to end this stays on
-# manual dispatch only; uncomment the `push:` trigger below afterwards.
+# Verified operational 2026-08-18: a dispatch run minted a token and opened
+# laurigates/git-repo-agent#4, so the `push:` trigger below is live. Use the
+# `force` dispatch input to re-exercise the token path when there is no drift —
+# without it a no-drift run skips every step and exits green, which is
+# indistinguishable from a broken token.
 
 on:
   workflow_dispatch:
-  # push:
-  #   branches: [main]
-  #   paths:
-  #     - '*/skills/*/SKILL.md'
-  #     - 'git-repo-agent/scripts/compile_prompts.py'
-  #     - 'git-repo-agent/src/git_repo_agent/prompts/compiler.py'
+    inputs:
+      force:
+        description: "Mint the token and check out the target even if the compiled prompts are unchanged (verifies the App token path)."
+        type: boolean
+        default: false
+  push:
+    branches: [main]
+    paths:
+      - '*/skills/*/SKILL.md'
+      - 'git-repo-agent/scripts/compile_prompts.py'
+      - 'git-repo-agent/src/git_repo_agent/prompts/compiler.py'
 
 permissions:
   contents: read
@@ -52,8 +60,13 @@ jobs:
         # git status --porcelain, not git diff --quiet: a NEW skill added to
         # the compiler's bundle map emits a new UNTRACKED per-skill fragment,
         # which `git diff` cannot see — the sync would silently skip it.
+        env:
+          FORCE: ${{ inputs.force }}
         run: |
-          if [ -z "$(git status --porcelain -- git-repo-agent/src/git_repo_agent/prompts/generated/)" ]; then
+          if [ "$FORCE" = "true" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo 'Forced: exercising the token path regardless of drift.' >> "$GITHUB_STEP_SUMMARY"
+          elif [ -z "$(git status --porcelain -- git-repo-agent/src/git_repo_agent/prompts/generated/)" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/sync-vault-agent-prompts.yml
+++ b/.github/workflows/sync-vault-agent-prompts.yml
@@ -17,17 +17,25 @@ name: "Sync: vault-agent prompts"
 # repo — and the token below is scoped by `repositories:` to vault-agent alone,
 # so it can neither write here nor reach git-repo-agent.
 #
-# Until an observed dispatch run proves the token works end to end this stays on
-# manual dispatch only; uncomment the `push:` trigger below afterwards.
+# The `push:` trigger below is live. Verify with the `force` dispatch input
+# rather than a plain dispatch: vault-agent's artifacts are often already
+# current, and a no-drift run skips every step and exits green — which is
+# indistinguishable from a broken token. `force` mints the token and checks
+# out the target regardless, so the credential path is actually exercised.
 
 on:
   workflow_dispatch:
-  # push:
-  #   branches: [main]
-  #   paths:
-  #     - 'obsidian-plugin/skills/*/SKILL.md'
-  #     - 'vault-agent/scripts/compile_prompts.py'
-  #     - 'vault-agent/src/vault_agent/prompts/compiler.py'
+    inputs:
+      force:
+        description: "Mint the token and check out the target even if the compiled prompts are unchanged (verifies the App token path)."
+        type: boolean
+        default: false
+  push:
+    branches: [main]
+    paths:
+      - 'obsidian-plugin/skills/*/SKILL.md'
+      - 'vault-agent/scripts/compile_prompts.py'
+      - 'vault-agent/src/vault_agent/prompts/compiler.py'
 
 permissions:
   contents: read
@@ -53,8 +61,13 @@ jobs:
         # git status --porcelain, not git diff --quiet: a NEW skill added to
         # SUBAGENT_SKILLS emits a new UNTRACKED per-skill fragment, which
         # `git diff` cannot see — the sync would silently skip it.
+        env:
+          FORCE: ${{ inputs.force }}
         run: |
-          if [ -z "$(git status --porcelain -- vault-agent/src/vault_agent/prompts/generated/)" ]; then
+          if [ "$FORCE" = "true" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo 'Forced: exercising the token path regardless of drift.' >> "$GITHUB_STEP_SUMMARY"
+          elif [ -z "$(git status --porcelain -- vault-agent/src/vault_agent/prompts/generated/)" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What

- **Enables the `push:` triggers** on both prompt-sync workflows (commented out since July).
- **Adds a `force` boolean dispatch input** to both.

## Why the triggers can go live now

The gate was never "the config looks right" — it was an observed run. That happened today: a dispatch minted a `laurigates-prompt-sync` App token, checked out the target, and opened **laurigates/git-repo-agent#4** (+2128/−1781 across 22 files, all under `prompts/generated/`, CI green, since merged). The App's installation covers both target repos, confirmed by the owner.

So the sync is operational, not merely configured, and the event-driven trigger is warranted.

## Why `force` earns its place

Today's vault-agent run is the argument. It went **green having done nothing**:

| Step | Outcome |
|---|---|
| Detect changes | `changed=false` |
| Mint App token | skipped |
| Checkout vault-agent | skipped |
| Open sync PR | skipped |

Its artifacts were already current, so the credential path never executed — and a success tick from a run that skipped every meaningful step is indistinguishable from one whose token is broken. That ambiguity is structural: a workflow you can only test when drift happens to exist is a workflow you cannot test on demand.

`force` sets `changed=true`, so the token is minted and the target checked out regardless of drift. With nothing to commit, `create-pull-request` opens nothing — the point is that the **mint and checkout steps run**, which is the credential proof.

## Correctness notes

- `inputs.force` evaluates to empty on `push` events, so event-driven runs are governed by the drift check exactly as before.
- Read through an `env:` var rather than interpolated into the `run:` block, per `github-actions-security.md`.
- Path filters were restored byte-identical to their previously-commented values — verified by parsing the YAML and printing them, not by eye.

## Verification

- `actionlint` clean on both files.
- Both parse with `['push', 'workflow_dispatch']` and the intended `paths`.
- Merging this PR touches only `.github/workflows/`, which matches neither path filter, so it will not self-trigger.

After merge I'll dispatch the vault-agent workflow with `force=true` to close the one remaining unproven link.

Refs #1017, #1973

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHj3bQBrztqJrAm18Wd6AT
