### PR TITLE
docs(git-plugin): scope the branch-audit warning to pre-repair copies

### DIFF
--- a/git-plugin/agents/git-ops.md
+++ b/git-plugin/agents/git-ops.md
@@ -203,16 +203,24 @@ git remote prune origin
 ```
 
 **On `just -g branch-audit`** (the encoded dotfiles recipe): it is a convenience for
-producing a paste-ready delete list, **not** the classification authority — and older
-copies of it are actively wrong. Measured 2026-08-04 (issue #2268), its REVIEW bucket was
-**~90% false** on two real repos: 191 REVIEW rows of which 174 had actually landed on
-`laurigates/claude-plugins` (91%), and 245 of which 216 had landed on
-`ForumViriumHelsinki/infrastructure` (88%). Both defects were the two named above — it
+producing a paste-ready delete list, **not** the classification authority — and **copies
+predating 2026-08-04 are actively wrong**. Measured that day (issue #2268), the pre-repair
+recipe's REVIEW bucket was **~90% false** on two real repos: 191 REVIEW rows of which 174
+had actually landed on `laurigates/claude-plugins` (91%), and 245 of which 216 had landed
+on `ForumViriumHelsinki/infrastructure` (88%). Both defects were the two named above — it
 used `merge-tree` as the *primary* signal, and paged `gh pr list --limit 500` against
-repos holding 1881 and 1684 PRs. **Verify anything it puts in REVIEW against the ladder
-before acting on it**, and treat its MERGED bucket as a starting point, not a verdict.
-The recipe lives in a private dotfiles repo, so this marketplace can neither version nor
-regression-test it.
+repos holding 1881 and 1684 PRs.
+
+**The recipe was repaired the same day** and now walks the same ladder in the same order:
+a MERGED PR first (authoritative, with the PR window raised past the repo's PR count),
+then `git cherry` (patch-equivalence, requiring rc 0 before an empty `+` set counts as
+landed), then `merge-tree` as **positive-containment** proof only — a match proves
+containment, a non-match proves nothing. Nothing in the output distinguishes a repaired
+copy from a pre-repair one, so **confirm the local recipe reads PR state before any
+git-side test** before trusting its REVIEW bucket, and treat its MERGED bucket as a
+starting point, not a verdict. The recipe lives in a private dotfiles repo, so this
+marketplace can neither version nor regression-test it; the repaired ladder above is
+reported from the recipe's own comments.
 
 Related: `~/.claude/rules/pr-merge-hazards.md` #1 (why `--merged` misses squash-merges,
 and why tree-containment is a one-way signal); `.claude/rules/gh-json-fields.md` (the


### PR DESCRIPTION
## What

Scopes `git-ops.md`'s warning about `just -g branch-audit` to **copies predating
2026-08-04**, and documents the repaired three-step ladder the recipe walks today.

## Why

Two documents currently give opposite answers to "is this branch already merged?":

- `~/.claude/rules/pr-merge-hazards.md` (always-loaded, not in this repo) points at
  `just -g branch-audit` as *the* encoded recipe to use.
- `git-plugin/agents/git-ops.md` said it is "not the classification authority",
  citing 174/191 (91%) and 216/245 (88%) false REVIEW rows.

Those figures are the **pre-repair** state. The recipe's own comments record them as the
measurements that motivated two fixes landed on 2026-08-04 — PR state checked first with
the window raised past the repo's PR count, and `merge-tree` demoted to positive-proof-only.
So the agent doc was warning about a version that no longer exists, while the rule pointed
at the repaired one.

The cost was concrete: "is this branch merged to main?" was asked by hand twice in recent
sessions rather than trusting the recipe.

## What stays

The warning keeps real content — an older `git.just` still has the broken behaviour, and
nothing in the recipe's output tells the two apart. The one-way inference caveat is
preserved verbatim in substance: a `merge-tree` match proves containment, a non-match
proves nothing.

## Provenance

The recipe lives in a private dotfiles repo this marketplace can neither version nor
regression-test. The repaired ladder described here is reported from that recipe's own
comments, quoted into the authoring session — not independently verified from this repo.

Context: #2268 recorded the original measurement.
