### PR TITLE
fix(git-plugin): stop hiding reactive skills from the model catalog

### DIFF
--- a/git-plugin/skills/git-conflicts/SKILL.md
+++ b/git-plugin/skills/git-conflicts/SKILL.md
@@ -4,7 +4,6 @@ description: "Resolve merge conflicts file-by-file. Use when a merge/rebase has 
 allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git show *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git merge *), Bash(git checkout *), Bash(git rebase *), Bash(git restore *), Bash(git config *), Bash(git rerere *), Bash(gh pr *), Read, Edit, Grep, Glob, TodoWrite
 args: "[file-or-pr] [--ours] [--theirs] [--push]"
 argument-hint: file path, PR number, --ours, --theirs, or --push
-disable-model-invocation: true
 created: 2026-03-01
 modified: 2026-06-18
 reviewed: 2026-05-23

--- a/git-plugin/skills/git-fix-pr/SKILL.md
+++ b/git-plugin/skills/git-fix-pr/SKILL.md
@@ -5,7 +5,6 @@ reviewed: 2026-04-25
 allowed-tools: Bash(gh pr checks *), Bash(gh pr view *), Bash(gh run view *), Bash(gh run list *), Bash(gh repo view *), Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(pre-commit *), Bash(npm run *), Bash(uv run *), Read, Edit, Grep, Glob, TodoWrite, mcp__github__pull_request_read
 args: "[pr-number] [--auto-fix] [--push]"
 argument-hint: "[pr-number] [--auto-fix] [--push]"
-disable-model-invocation: true
 description: "Failing PR checks — reproduce locally, patch the code, push the fix. Use when asked to fix a PR, resolve red CI, or auto-fix lint/test failures."
 name: git-fix-pr
 ---


### PR DESCRIPTION
## What

9 of 38 skills in `git-plugin/skills/` carried `disable-model-invocation: true`,
which removes a skill from the model's available-skills catalog — it can then
only be reached by the user typing `/git-plugin:<name>`. That is a strong
outlier: the next-highest plugin has 3, and the marketplace total is 26 across
11 plugins.

This PR drops the flag on the two skills that are **reactive to a repo state the
model itself observes**, keeps it on the other seven, and records the verdict for
all nine in a new `## Invocation` section of `git-plugin/README.md` so the next
audit reads the record instead of re-deriving it.

## Why

Analysis of 243 session-opening prompts found the same micro-chore asked three
separate times, near-verbatim:

- "lets resolve the pull conflicts"
- "lets deal with the pull merge conflicts"
- "lets solve the pull merge issue"

`git-conflicts`' own description is
`"Resolve merge conflicts file-by-file. Use when a merge/rebase has conflicts, a
PR can't merge, \"fix conflicts\" is requested, or branches have diverged."` — a
near-verbatim match that could never fire, because the flag hid it from the
catalog. Meanwhile `git-plugin:release-please-pr-workflow` **is** catalog-present,
mentions conflicts in its description, and prescribes close-and-recreate — the
wrong remedy for a local merge conflict.

Prior precedent for this class: #1843 dropped the same flag from
`feedback-plugin:feedback-session` because it made the skill unreachable to an
orchestrator that needed to invoke it.

## Criteria

- **Keep** when the skill performs a chained or irreversible mutation the user
  should consciously trigger, or takes a required argument the model would
  otherwise have to invent.
- **Drop** when the skill is reactive to a repo state the model can observe for
  itself, and a user would reasonably expect it offered without knowing its name.

## Decisions

| Skill | Verdict | Reason |
|-------|---------|--------|
| `git-api-pr` | keep | Requires `<file...>` and a `--title` the model would have to invent; creates a remote branch and PR with no local commit to review first |
| `git-commit-push-pr` | keep | Chained mutation — commit, push, and PR creation in one non-interactive pass |
| `git-conflicts` | **drop** | Reactive to a conflicted tree the model already observes; the three prompts above match its description almost verbatim |
| `git-derive-docs` | keep | Bulk generative writer over `.claude/rules/` and `docs/`; needs an explicit `--rules`/`--prd`/`--adr`/`--prp` mode |
| `git-fix-pr` | **drop** | Reactive to a red PR check the model already observes when it reads CI status |
| `git-issue` | keep | Takes a required issue reference, then branches, implements, and opens a PR; `--parallel` fans out subagents. Already invoked by hand as `/git-plugin:git-issue <number>` |
| `git-maintain` | keep | Destructive maintenance — `gc`, repack, branch pruning, stash deletion, `git rm` |
| `git-pr-feedback` | keep | Posts replies and resolves threads on reviewers' PRs by default, and can open follow-up issues; `--all` fans out worktree subagents that push |
| `git-upstream-pr` | keep | Cherry-picks, resets, and pushes to a fork, then opens a PR against a third-party upstream |

## Verification

- `git diff` confirms exactly the two intended `disable-model-invocation: true`
  lines were removed and no other frontmatter key was disturbed.
- All 38 `git-plugin` `SKILL.md` frontmatters re-parsed with PyYAML — valid, and
  the touched two have identical key sets minus that one key.
- A `grep` for the flag across `git-plugin/skills/` returns exactly the 7 files
  the table marks *keep*.
- Local pre-commit suite passes (skill-description audit, compliance guards,
  context-command execution sandbox).

**Catalog verification is pending.** Confirming that these two skills now appear
in a live Claude Code session's available-skills catalog requires a local session
with the marketplace installed; this branch was prepared in a cloud environment
with no access to that. The check will be done locally before merge.

## Note for review

`git-pr-feedback` was the closest call. It is reactive to observable state
(`CHANGES_REQUESTED`, unresolved threads) and all its arguments are optional, so
the "drop" criterion partly fits — and the catalog-present `git-pr-watch` tells
the agent to "address it via `/git:pr-feedback`", which the flag blocks. It keeps
the flag because its **default** path posts replies and resolves threads on other
people's PRs, and `--all` pushes from fanned-out worktree subagents. Worth a
second opinion.

## Out of scope

No change to skill bodies, `allowed-tools`, descriptions, or any other
frontmatter key. No overlap with #2429 (`git-plugin/agents/git-ops.md`).
