### PR TITLE
docs(git-plugin): record the disable-model-invocation audit

### DIFF
--- a/git-plugin/README.md
+++ b/git-plugin/README.md
@@ -76,6 +76,34 @@ Three composable skills that can be invoked individually or combined based on us
 | `release-please-pr-workflow` | Batch merge release-please PRs with conflict handling |
 | `git-fork-workflow` | Fork management, upstream sync, divergence detection, cross-fork PRs |
 
+## Invocation
+
+Most skills here are catalog-present: Claude can offer them when the situation
+matches their `description`. A few carry `disable-model-invocation: true`, which
+removes the skill from the catalog entirely — it is then reachable only when the
+user types `/git-plugin:<name>`.
+
+The rule this plugin applies:
+
+- **Keep the flag** when the skill performs a chained or irreversible mutation
+  the user should consciously trigger, or takes a required argument the model
+  would otherwise have to invent.
+- **Drop the flag** when the skill is reactive to a repo state the model can
+  observe for itself, and a user would reasonably expect it offered without
+  knowing its name.
+
+| Skill | `disable-model-invocation` | Why |
+|-------|---------------------------|-----|
+| `git-api-pr` | keep | Requires `<file...>` and a `--title` the model would have to invent; creates a remote branch and PR with no local commit to review first |
+| `git-commit-push-pr` | keep | Chained mutation — commit, push, and PR creation in one non-interactive pass |
+| `git-conflicts` | **removed** | Reactive to a conflicted tree the model already observes; user phrasings ("fix the merge conflicts") match its description almost verbatim |
+| `git-derive-docs` | keep | Bulk generative writer over `.claude/rules/` and `docs/`; needs an explicit `--rules`/`--prd`/`--adr`/`--prp` mode |
+| `git-fix-pr` | **removed** | Reactive to a red PR check the model already observes when it reads CI status |
+| `git-issue` | keep | Takes a required issue reference, then branches, implements, and opens a PR; `--parallel` fans out subagents. Invoked by hand as `/git-plugin:git-issue <number>` |
+| `git-maintain` | keep | Destructive maintenance — `gc`, repack, branch pruning, stash deletion, `git rm` |
+| `git-pr-feedback` | keep | Posts replies and resolves threads on reviewers' PRs by default, and can open follow-up issues; `--all` fans out worktree subagents that push |
+| `git-upstream-pr` | keep | Cherry-picks, resets, and pushes to a fork, then opens a PR against a third-party upstream |
+
 ## Agent
 
 | Agent | Description |


### PR DESCRIPTION
## What

Adds an `## Invocation` section to `git-plugin/README.md` recording, per skill,
whether `disable-model-invocation: true` is kept and why.

This is the record half of the audit whose code half landed in #2434. That PR
merged while this commit was still local, so it arrives separately.

## Why

`disable-model-invocation: true` removes a skill from the model's
available-skills catalog — it is then reachable only when the user types
`/git-plugin:<name>`. `git-plugin` had 9 of 38 skills flagged, a strong outlier
(next-highest plugin: 3; marketplace total: 26 across 11 plugins). Nothing in
the repo recorded why any individual flag was there, so each audit re-derived
the same nine judgements from scratch. This section is that derivation, written
down once.

## Criteria recorded

- **Keep** when the skill performs a chained or irreversible mutation the user
  should consciously trigger, or takes a required argument the model would
  otherwise have to invent.
- **Drop** when the skill is reactive to a repo state the model can observe for
  itself, and a user would reasonably expect it offered without knowing its name.

Two skills were dropped under that rule in #2434 (`git-conflicts`,
`git-fix-pr`); the other seven keep the flag. The table gives one line of
reasoning each.

## Verification

- `grep -rn "disable-model-invocation" git-plugin/skills/` on this branch
  returns exactly the 7 files the table marks *keep* — the table and the tree
  agree.
- Documentation only: no skill frontmatter, body, or `allowed-tools` touched.
  `git diff --stat` against `main` is one file, 28 insertions.

## Note carried over from #2434

`git-pr-feedback` was the closest call. It is reactive to observable state
(`CHANGES_REQUESTED`, unresolved threads) and all its arguments are optional, so
the drop criterion partly fits — and the catalog-present `git-pr-watch` tells the
agent to "address it via `/git:pr-feedback`", which the flag blocks. It keeps the
flag because its **default** path posts replies and resolves threads on other
people's PRs, and `--all` pushes from fanned-out worktree subagents. Worth a
second opinion; the table states the reasoning so a reversal is a visible edit
rather than a silent one.
