### PR TITLE
feat: absorb nine always-loaded user rules as skills and two hooks

### DIFF
--- a/.claude/rules/agent-coworker-detection.md
+++ b/.claude/rules/agent-coworker-detection.md
@@ -239,7 +239,8 @@ agents that had already succeeded**, opening a **duplicate PR** (#1858 dup of
 worktree agents. Recover them with a **fresh, sequential dispatch** (one Opus
 agent doing the remainder one-at-a-time, or a small re-run waved ≤3) — which also
 dodges the burst rate-limit that caused the original failures
-(`~/.claude/rules/tool-use-patterns.md`). Before any recovery dispatch, check
+(`agent-patterns-plugin:parallel-agent-dispatch` § Concurrent Rate-Limit Risk).
+Before any recovery dispatch, check
 `gh pr list --search "issue-<N>"` so you don't open a duplicate.
 
 ## Limitations

--- a/.claude/rules/generated-fleet-drift.md
+++ b/.claude/rules/generated-fleet-drift.md
@@ -15,7 +15,7 @@ eventually audits the gap. The failure this rule prevents is the audit's *first
 move*: reading "differs from the template" as "wrong". It usually isn't, and
 acting on that reading is how an audit becomes a regression.
 
-Sibling of `~/.claude/rules/scaffold-fix-backport.md` (fix the class, not the
+Sibling of `code-quality-plugin:code-scaffold-backport` (fix the class, not the
 instance). This is its inverse: **don't push the class over an instance whose
 divergence was deliberate.**
 
@@ -99,7 +99,7 @@ sceptically; the script is the easy part.**
 
 ## Related
 
-- `~/.claude/rules/scaffold-fix-backport.md` — the inverse (fix the generator, not just the instance)
+- `code-quality-plugin:code-scaffold-backport` — the inverse (fix the generator, not just the instance)
 - `.claude/rules/drift-detection-triggering.md` — *triggering* a sweep; this rule is about classifying what it finds
 - `.claude/rules/offload-to-deterministic-substrate.md` — why the sweep is a script and the classification is not
 - `comfyui-plugin/skills/comfyui-node-scaffold/fleet-policy.toml` — the reference policy, with per-entry rationale

--- a/.claude/rules/gh-json-fields.md
+++ b/.claude/rules/gh-json-fields.md
@@ -94,11 +94,11 @@ wall-clock deadline.** Observed 2026-07-30: two such loops burned a 6m40s and a
 ### Gating on an expected check *count* is brittle
 
 The companion advice "wait for nothing-pending **and** at least N checks" (see
-`~/.claude/rules/pr-merge-hazards.md`) guards a real race — zero-pending is
-trivially true before jobs register. But a hardcoded `N` breaks on
-**path-filtered** workflows: the same repo yields 7 checks for a PR touching
-`*-plugin/**` and 5 for one touching only `.claude/rules/**`, so `-ge 6` waits
-forever on a perfectly green PR.
+`git-plugin:git-merge-hazards`, which carries the CI check-*registration*
+race) guards a real race — zero-pending is trivially true before jobs
+register. But a hardcoded `N` breaks on **path-filtered** workflows: the same
+repo yields 7 checks for a PR touching `*-plugin/**` and 5 for one touching
+only `.claude/rules/**`, so `-ge 6` waits forever on a perfectly green PR.
 
 Derive the expectation instead of hardcoding it — poll until the check count is
 **stable across two consecutive reads** with nothing pending, and bound the

--- a/.claude/rules/regression-testing.md
+++ b/.claude/rules/regression-testing.md
@@ -89,6 +89,27 @@ The audit script in this repo is the canonical example — it pairs a human repo
 
 ## Known Regressions (Documented Bugs)
 
+> **Rows are dated records — quotes are preserved as written.** Several rows
+> quote user-global rules that `laurigates/dotfiles` #353 later promoted into
+> marketplace skills; the rule files survive as pointer stubs at the same
+> paths, so every citation still resolves, but the quoted prose now lives in
+> the skill. Current homes: `pr-merge-hazards.md` →
+> `git-plugin:git-merge-hazards`, `documentation-authoring.md` →
+> `documentation-plugin:docs-single-source`, `taskwarrior-tracking.md` →
+> `taskwarrior-plugin:task-add` + `session-plugin:session-wrap`,
+> `scaffold-fix-backport.md` → `code-quality-plugin:code-scaffold-backport`,
+> `repo-deletion-safety.md` → `git-plugin:git-repo-delete-check`,
+> `verify-upstream-before-patching.md` → `git-plugin:git-upstream-fix-check`,
+> `read-issue-thread-before-contributing.md` → `git-plugin:git-issue-scoping`,
+> `verify-machine-facts-before-publishing.md` →
+> `documentation-plugin:docs-verify-machine-facts`. One live-scope caveat: the
+> `#2268` row states that `check-branch-containment-guidance.sh` rules 1–4
+> scan `git-plugin/**/*.md` only "so … `pr-merge-hazards.md` stay[s] free to
+> quote the broken forms while TEACHING them". That still holds for the
+> **stub**, but `git-plugin/skills/git-merge-hazards/SKILL.md` now teaches the
+> same traps from *inside* the scanned corpus and is deliberately **not**
+> exempted — it complies instead (see that script's header comment).
+
 | Issue | Root Cause | Check Added | Fixed In |
 |-------|-----------|-------------|----------|
 | `gh repo view` in context command fails with TLS/x509 error | Uses GitHub GraphQL API; fails in proxy/offline/cert-error environments | `lint-context-commands.sh` rule `gh-api-in-context` | PR #799 |

--- a/.claude/rules/shell-scripting.md
+++ b/.claude/rules/shell-scripting.md
@@ -374,8 +374,8 @@ abc123def:refs/heads/x        # correct
 ```
 
 This lands squarely on the **push-by-explicit-SHA** discipline that
-`~/.claude/rules/git-hazards.md` and `pr-merge-hazards.md` mandate for shared
-checkouts — the one command shape most likely to carry `<sha>:refs/heads/...`:
+`~/.claude/rules/git-hazards.md` and `git-plugin:git-merge-hazards` mandate for
+shared checkouts — the one command shape most likely to carry `<sha>:refs/heads/...`:
 
 ```
 # Wrong under zsh — git rejects it with a confusing "src refspec ... does not match any"

--- a/.claude/rules/skill-consolidation.md
+++ b/.claude/rules/skill-consolidation.md
@@ -114,5 +114,5 @@ description carries the traceability instead.
 - `skill-development.md` — creating skills, granularity decision
 - `skill-quality.md` — size limits, description length band (≤200)
 - `skill-naming.md` — `plugin:skill` namespacing (the cross-plugin reference form)
-- `verify-upstream-before-patching` (user rule) / repo debugging discipline — the "verify the premise before acting" principle this rule applies to refactors
+- `git-plugin:git-upstream-fix-check` / repo debugging discipline — the "verify the premise before acting" principle this rule applies to refactors
 - `/plugin-authoring` § Plugin Lifecycle — the **plugin**-level add/delete checklist (distinct from skill-level)

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ the rules, skills, and hooks that embody it.
 
 | Plugin | Skills | Description |
 |--------|--------|-------------|
-| **code-quality-plugin** | 15 | Code review, refactoring, linting, static analysis, debugging methodology |
+| **code-quality-plugin** | 16 | Code review, refactoring, linting, static analysis, debugging methodology, scaffold back-porting |
 | **software-design-plugin** | 6 | Software design methodology - deep modules, design by contract, GoF pattern selection, legacy seams, pseudocode |
 | **evaluate-plugin** | 7 + 3 agents | Skill evaluation and benchmarking - test effectiveness, grade results |
 | **codebase-attributes-plugin** | 3 | Structured codebase health attributes with severity-based agent routing |
@@ -110,7 +110,7 @@ the rules, skills, and hooks that embody it.
 
 | Plugin | Skills | Description |
 |--------|--------|-------------|
-| **git-plugin** | 38 + 1 agent | Git workflows - commits, branches, PRs, worktrees, release-please |
+| **git-plugin** | 42 + 1 agent | Git workflows - commits, branches, PRs, worktrees, release-please, merge/deletion hazards, issue scoping |
 
 ### CI/CD
 
@@ -136,7 +136,7 @@ the rules, skills, and hooks that embody it.
 |--------|--------|-------------|
 | **blog-plugin** | 2 | Blog post creation - project logs, technical write-ups |
 | **communication-plugin** | 2 | Communication formatting - Google Chat, ticket drafting |
-| **documentation-plugin** | 5 | Documentation generation - API docs, README, knowledge graphs |
+| **documentation-plugin** | 8 | Documentation generation - API docs, README, LaTeX PDFs, single-source linking, machine-fact verification, fetch fallbacks |
 | **prose-plugin** | 2 | Prose transformation - synthesis, distillation, tone, clarity |
 
 ### UX & Components

--- a/agent-patterns-plugin/skills/meta-local-notes/SKILL.md
+++ b/agent-patterns-plugin/skills/meta-local-notes/SKILL.md
@@ -157,10 +157,10 @@ Every one of those was caught by a probe, and none by reading.
 - `meta-context-diet` — a different axis: moving always-loaded content to
   on-demand skills. That is about a file's **load cost**; this is about its
   **truth**.
-- `verify-machine-facts-before-publishing` (user rules) — the inverse direction:
+- `documentation-plugin:docs-verify-machine-facts` — the inverse direction:
   keep host-specific readings *out* of org docs. Here: keep org-doc findings out
   of host-specific notes.
-- `documentation-authoring` (user rules) — link, don't duplicate. The local file
+- `documentation-plugin:docs-single-source` — link, don't duplicate. The local file
   should point at the ADR, never restate it.
 - `diagnose-at-the-failure-point` (user rules) — probe the thing; don't reason
   about whether it is still true.

--- a/agent-patterns-plugin/skills/parallel-agent-dispatch/references/failure-recovery.md
+++ b/agent-patterns-plugin/skills/parallel-agent-dispatch/references/failure-recovery.md
@@ -240,3 +240,66 @@ follow-up cleanly closed the gap left by a rate-limited cascade agent.
 | Wave returns with one or two `Rate limited` agents | Recovery-dispatch the missed slice; do not retry the whole wave |
 | Same agent rate-limits twice in a row | Smaller scope or staggered dispatch — the wave size is still too high |
 | Burst killed agents at **startup** (worktree fan-out died before committing) | `git worktree prune` + delete the empty leftover branches before the reduced-concurrency retry — else each agent's `git switch -c <branch>` collides with the orphaned ref |
+
+### Burst limit vs session usage limit
+
+The table above covers the **server burst limit** — many agents dispatched at
+once, refused by the API. A **session usage limit** kills a wave the same way
+but for a different reason, and the two want different first moves: the burst
+limit wants lower concurrency on an immediate retry, the usage limit wants a
+wait. The wreckage they leave is identical, so the audit step below applies to
+either.
+
+The burst-limit signature:
+
+Spawning many agents simultaneously — a `Workflow` `parallel()`/`pipeline()`
+of N agents, or N `Agent` calls in one message — can trip a **server-side
+burst rate limit** (`API Error: Server is temporarily limiting requests (not
+your usage limit) · Rate limited`), distinct from your usage quota. When it
+fires, the agents die after their retries and `parallel()` returns them as
+`null` — **every agent's startup tokens wasted** (observed: 7 Opus auditors,
+628 k tokens, all killed at 18 s).
+
+Mitigations for this class already live above and in
+[`../SKILL.md`](../SKILL.md) § Concurrent Rate-Limit Risk — safe starting
+concurrency by agent profile, sequential waves over one big fan-out,
+backoff-and-retry rather than task failure, and `git worktree prune` before a
+reduced-concurrency retry after a startup kill. They are not restated here. The
+one mitigation that is not a dispatch tactic — for deterministic, mechanical
+work (parsing, counting, audits, frontmatter scans), prefer a single inline
+`python3`/`rg` pass over an agent fan-out — belongs to
+`.claude/rules/offload-to-deterministic-substrate.md`, not to this skill.
+
+### Session usage limit — audit remote, then recover
+
+The **session usage limit** ("You've hit your session limit · resets <time>")
+kills in-flight subagents the same way the burst limit does: each agent dies
+on a terminal API error at whatever stage it had reached — some after pushing
+a branch and opening a PR, some mid-edit, some before starting. A `Workflow`
+run reports them under `failures`; completed siblings' results survive in the
+run's journal.
+
+Recovery protocol (observed 2026-07: a 14-agent PR sweep lost 7 agents to the
+limit and recovered fully):
+
+1. **Wait out the reset** — the limit message names the reset time; nothing
+   recovers before it.
+2. **Audit remote state before resuming** — dead agents may have half-landed
+   their work: `gh pr list --state open` plus `git ls-remote --heads origin`
+   show which branches/PRs already exist. A re-run agent that pushes an
+   already-pushed branch hits a non-fast-forward reject, and one that
+   re-creates an existing PR duplicates it — brief agents to check first, or
+   verify the remote is clean yourself.
+3. **Resume only what actually caches.** `Workflow({scriptPath,
+   resumeFromRunId})` replays completed **ordinary** agents from cache (cache
+   key: unchanged prompt + opts) at zero cost, so re-dispatching those from
+   scratch re-pays their tokens. It does **not** hold for `isolation:
+   "worktree"` agents: one that already succeeded is **re-executed** on resume
+   and re-fires its side effects — an agent that opened a PR opens a duplicate
+   (PR #1858 dup of #1857; issue
+   [#1868](https://github.com/laurigates/claude-plugins/issues/1868)). Recover
+   those with a fresh **sequential** re-dispatch of only the dead agents, after
+   the step-2 audit confirms no PR is already open. See
+   [`../SKILL.md`](../SKILL.md) § "Resuming a workflow: `resumeFromRunId`
+   re-runs succeeded worktree agents" and
+   `.claude/rules/agent-coworker-detection.md`.

--- a/blueprint-plugin/skills/blueprint-autonomy-level3/REFERENCE.md
+++ b/blueprint-plugin/skills/blueprint-autonomy-level3/REFERENCE.md
@@ -30,7 +30,7 @@ execution — this repo dogfoods at level 1 and cannot exercise it.
 | `.github/blueprint/get-automation-config.sh` | `scripts/get-automation-config.sh` | Manifest automation-block reader |
 
 The scripts are the source of truth in the plugin; a re-run of the skill
-re-syncs any drift (`--check` reports it). Per `scaffold-fix-backport`, fix a
+re-syncs any drift (`--check` reports it). Per `code-quality-plugin:code-scaffold-backport`, fix a
 bug in the plugin script/template, not in a consumer's copy.
 
 ## The manifest gate + budgets

--- a/blueprint-plugin/skills/blueprint-autonomy-level3/SKILL.md
+++ b/blueprint-plugin/skills/blueprint-autonomy-level3/SKILL.md
@@ -78,7 +78,7 @@ done
 
 Report the table and stop. `DRIFT`/`ABSENT` → advise re-running without
 `--check` to re-sync (the templates are the source of truth; per
-`scaffold-fix-backport`, a fix to the plugin template re-lands here on re-run).
+`code-quality-plugin:code-scaffold-backport`, a fix to the plugin template re-lands here on re-run).
 
 ### Step 3 (install mode): copy templates + scripts
 

--- a/code-quality-plugin/README.md
+++ b/code-quality-plugin/README.md
@@ -15,6 +15,7 @@ This plugin provides comprehensive code quality tools including automated code r
 | `/code:antipatterns` | Analyze codebase for anti-patterns and code smells using ast-grep |
 | `/code:lint` | Universal linter - auto-detects and runs appropriate linting tools (with `--fix` for autofix) |
 | `/code:dry-consolidation` | Find and extract duplicated code into shared, tested abstractions |
+| `/code:scaffold-backport` | Back-port an instance fix into the generator that produced it — cookiecutter/copier template, justfile `new-*` recipe, scaffolding skill — so the next generation isn't born with the same bug |
 | `/code:docs-quality` | Analyze documentation quality - PRDs, ADRs, PRPs, CLAUDE.md, and .claude/rules/ |
 | `/code:hidden-failures` | Detect hidden failures — swallowed errors (empty catch, `\|\| true`, `2>/dev/null`, floating promises, ignored Go/Rust errors) and silent degradation (ops succeed with zero results); `--track errors\|degradation\|both` |
 | `/code:dead-code` | Detect dead code, unused exports, unreachable branches, and orphaned files |

--- a/code-quality-plugin/skills/code-scaffold-backport/SKILL.md
+++ b/code-quality-plugin/skills/code-scaffold-backport/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: code-scaffold-backport
+description: Back-port an instance fix into the generator that produced it — cookiecutter, scaffold, `new-*` recipe. Use when fixing, reviewing, or auditing a generated file.
+allowed-tools: Read, Grep, Glob, Edit, Bash, TodoWrite
+created: 2026-08-19
+modified: 2026-08-19
+reviewed: 2026-08-19
+---
+
+# Back-Port Instance Fixes Into Their Scaffold/Generator
+
+## When to Use This Skill
+
+| Situation | Skill |
+|-----------|-------|
+| Fixing, reviewing, or auditing a file a generator emitted — cookiecutter/copier template, justfile `new-*` recipe, a `*-scaffold` skill, a "copy the example app" doc | **This skill** — patch the generator in the same sweep |
+| Repeated code inside one codebase, with no generator behind it | `code-quality-plugin:dry-consolidation` |
+| Auditing a whole fleet of generated instances against their template | The inverse direction — `.claude/rules/generated-fleet-drift.md`; an instance may legitimately be *ahead* of the template, so never auto-apply template → instance |
+
+When fixing something that was *generated* — a site scaffolded by a
+justfile recipe, a repo from a cookiecutter template, a config from a
+`new-*` skill — check whether the bug came from the generator, and if
+so, fix the generator **in the same sweep**. A fix applied only to the
+deployed instance leaves every future generation broken in the same
+way, and the gap is invisible until the next person scaffolds.
+
+## The failure mode
+
+Canonical case (FVH `sites` monorepo, 2026-06): two PRs fixed the
+deployed `example-static` site — `service.targetPort: 8080` for the
+non-root nginx image, numeric `runAsUser` for Kyverno — but the
+`just new-site` template that had produced those broken values was
+never touched. Every subsequently scaffolded site would have shipped
+with chart-default port-80 probes against an 8080 listener: pod never
+Ready, stuck `Progressing`, no error anywhere. Found and back-ported
+only weeks later during a readiness audit (sites#11).
+
+The shape is always the same:
+
+1. An instance misbehaves; someone fixes the instance. PR merges, done.
+2. The generator still emits the pre-fix content.
+3. The next generation reproduces the bug — often for someone without
+   the context of fix #1.
+
+## The rule
+
+- **When fixing a generated artifact**, ask: "did the generator produce
+  this bug?" If yes, patch the generator template in the same PR (or an
+  immediately linked one) — not as a someday follow-up.
+- **When reviewing a fix to a known-scaffolded file** (e.g.
+  `deploy/values.yaml` in a monorepo with a `new-*` recipe, anything
+  under a directory a cookiecutter emits), check the template for the
+  same defect before approving.
+- **When auditing a scaffold for readiness**, diff the template's output
+  against the oldest working instance — accumulated instance-only fixes
+  show up as the delta.
+
+## Where generators hide
+
+- justfile `new-*` recipes with heredoc templates
+- `cookiecutter/` directories and copier templates
+- Claude skills that scaffold (`*-scaffold`, `configure-*`)
+- "Copy the example app" docs — the example *is* the generator; fixes to
+  forks of it don't propagate back
+
+## Verify
+
+After back-porting, generate a throwaway instance and diff it against
+the fixed real instance — the relevant blocks should match:
+
+```
+just new-site zz-smoke-test
+diff <(yq ... sites/zz-smoke-test/deploy/values.yaml) <(yq ... sites/example-static/deploy/values.yaml)
+```
+
+Clean up the throwaway (including any registry/config files the recipe
+mutated) before committing.
+
+## Rationale
+
+This is DRY applied to provenance: the template is the source of truth
+for new instances, so a fix that skips it creates a silently diverging
+copy. The cost asymmetry is stark — back-porting at fix time is one
+extra edit with full context in hand; discovering it later costs a
+broken deploy, a re-diagnosis from scratch, and usually a different
+person's afternoon.

--- a/docs/PLUGIN-MAP.md
+++ b/docs/PLUGIN-MAP.md
@@ -34,7 +34,7 @@ The development loop: plan, code, commit, ship.
 | Plugin | Skills | Purpose |
 |--------|--------|---------|
 | blueprint-plugin | 35 | PRD/ADR/PRP/TRP methodology, `/blueprint:execute` auto-pilot, ambient autonomy levels (`/blueprint:autopilot`, `/blueprint:autonomy-level3`), monorepo portfolio tracking, story-audit/reconcile |
-| git-plugin | 38 + 1 agent | Commits, branches, PRs, issues, forks, worktrees, release-please |
+| git-plugin | 42 + 1 agent | Commits, branches, PRs, issues, forks, worktrees, release-please, merge hazards, issue scoping, upstream-fix and repo-deletion checks |
 | project-plugin | 7 | Project init, modernization, maintenance |
 | session-plugin | 4 | Session bookends: spinup briefing, wrap capture, end orchestrator, distill |
 | agents-plugin | 1 + 12 agents | Task delegation to specialized agents |
@@ -46,9 +46,9 @@ Automated quality enforcement.
 | Plugin | Skills | Purpose |
 |--------|--------|---------|
 | testing-plugin | 17 | Test execution, TDD, Vitest, Playwright, Playwright CLI, mutation testing |
-| code-quality-plugin | 15 | Review, refactoring, linting, ast-grep, debugging, silent degradation, dead code, dep audit, test quality, complexity, bulk-sweep classification |
+| code-quality-plugin | 16 | Review, refactoring, linting, ast-grep, debugging, silent degradation, dead code, dep audit, test quality, complexity, bulk-sweep classification, scaffold back-port |
 | software-design-plugin | 6 | Deep modules, design by contract, GoF pattern selection, legacy seams, design by pseudocode |
-| documentation-plugin | 5 | API docs, README generation, knowledge graphs |
+| documentation-plugin | 8 | API docs, README generation, LaTeX PDFs, single-source linking, machine-fact verification, WebFetch fallbacks |
 | evaluate-plugin | 7 + 3 agents | Skill evaluation, benchmarking, quality improvement |
 
 ### Tier 3+ - Pick What Applies
@@ -171,9 +171,9 @@ Install based on your project's tech stack and domain.
 | Plugin | Install when... |
 |--------|-----------------|
 | codebase-attributes-plugin | You want structured health attributes, severity-based agent routing, or a health dashboard |
-| code-quality-plugin | You want code review, refactoring, linting, dead code detection, dependency auditing, test quality analysis, or complexity metrics |
+| code-quality-plugin | You want code review, refactoring, linting, dead code detection, dependency auditing, test quality analysis, complexity metrics, or scaffold back-porting |
 | software-design-plugin | You're designing a module/API, placing contracts, selecting a design pattern, taming legacy code, or refining a routine before coding |
-| documentation-plugin | You need generated docs, knowledge graphs |
+| documentation-plugin | You need generated docs, LaTeX PDFs, or guardrails that keep published docs from drifting |
 | typescript-plugin | Project uses TypeScript or JavaScript |
 | python-plugin | Project uses Python |
 | rust-plugin | Project uses Rust |

--- a/docs/PRINCIPLES.md
+++ b/docs/PRINCIPLES.md
@@ -40,7 +40,7 @@ single source of truth instead of restating it. A runnable artifact (a skill, a
 recipe, a script) *is* its own documentation — link to it rather than maintaining
 a parallel prose copy by hand.
 
-**Embodied by:** `documentation-authoring`, `docs-currency` →
+**Embodied by:** `documentation-plugin:docs-single-source`, `docs-currency` →
 `blueprint-docs-currency` (code and its docs land in the same commit), the
 "reference the source, don't transcribe the list" convention across rules. This
 doc itself follows the rule: the README links here rather than embedding a copy.
@@ -67,8 +67,8 @@ result compiles." A WebFetch summary is not the issue thread. Check the ground
 truth — `origin/main`, the IaC, the full comment thread, the upstream HEAD —
 before patching, branching, or publishing.
 
-**Embodied by:** `verify-upstream-before-patching`,
-`read-issue-thread-before-contributing`, `concurrent-session-pr-check`,
+**Embodied by:** `git-plugin:git-upstream-fix-check`,
+`git-plugin:git-issue-scoping`, `concurrent-session-pr-check`,
 `shared-checkout-branch-isolation`, `squash-merge-orphans-post-merge-commits`,
 `textual-merge-duplicates-identical-additions`, `tool-migration-cutover` (verify
 the replacement is *operational*, not merely configured).

--- a/docs/diagrams/plugin-relationships.d2
+++ b/docs/diagrams/plugin-relationships.d2
@@ -85,7 +85,7 @@ core: {
     style.stroke-width: 3
   }
   git: {
-    label: "git\n38 skills + 1 agent"
+    label: "git\n42 skills + 1 agent"
     shape: rectangle
     class: core
   }
@@ -119,12 +119,12 @@ quality: {
     class: quality
   }
   code-quality: {
-    label: "code-quality\n15 skills"
+    label: "code-quality\n16 skills"
     shape: rectangle
     class: quality
   }
   documentation: {
-    label: "documentation\n5 skills"
+    label: "documentation\n8 skills"
     shape: rectangle
     class: quality
   }

--- a/documentation-plugin/README.md
+++ b/documentation-plugin/README.md
@@ -4,7 +4,7 @@ Documentation generation, synchronization, and knowledge management for Claude C
 
 ## Overview
 
-Comprehensive documentation tooling for generating API references, maintaining README files, synchronizing docs with codebase, creating decommission plans, and building knowledge graphs from technical documentation.
+Comprehensive documentation tooling for generating API references, maintaining README files, synchronizing docs with codebase, creating decommission plans, converting Markdown to LaTeX PDFs, and keeping published docs honest — link to the single source of truth, verify machine-read facts, and recover failed doc fetches.
 
 ## Skills
 
@@ -13,9 +13,11 @@ Comprehensive documentation tooling for generating API references, maintaining R
 | `/docs:sync` | Synchronize documentation with actual skills, commands, and agents in codebase |
 | `/docs:generate` | Update project documentation from code annotations |
 | `/docs:decommission` | Generate comprehensive service decommission documentation |
-| `/docs:knowledge-graph` | Build knowledge graph from Obsidian vault documentation |
 | `/docs:latex` | Convert Markdown documents to professional LaTeX with TikZ visualizations and compile to PDF |
+| `/docs:fetch-fallbacks` | Recover a failed WebFetch: strip the query, `raw.githubusercontent`, `gh api`, context7/WebSearch |
 | `claude-blog-sources` | Access Claude Blog for latest features, patterns, and best practices |
+| `docs-single-source` | Link docs to the single source of truth instead of restating it |
+| `docs-verify-machine-facts` | Verify machine-read values (`scutil`, `route`, `ifconfig`, local config) against the authoritative IaC before publishing |
 
 ## Agents
 
@@ -98,15 +100,22 @@ Produces professional documents with:
 - Professional tables with booktabs
 - Hyperlinked table of contents
 
-### Build Knowledge Graph
+### Recover a Failed Doc Fetch
 
-Create a searchable knowledge graph from technical documentation:
+When a `WebFetch` returns 404/403 or times out, walk the fallback ladder instead of retrying the same URL:
 
 ```bash
-/docs:knowledge-graph
+/docs:fetch-fallbacks
 ```
 
-Processes Obsidian vault documentation and builds a comprehensive knowledge graph for semantic search and pattern recognition.
+Reads the failure signature and applies the matching fallback — strip the query string, rewrite to `raw.githubusercontent.com`, fall back to `gh api repos/<owner>/<repo>/contents/<path>`, then context7 or `WebSearch`. Stops at two attempts.
+
+### Keep Published Docs Honest
+
+Two reference skills load automatically while you write:
+
+- `docs-single-source` — link to the single source of truth rather than restating it, so the copy cannot drift
+- `docs-verify-machine-facts` — check values read off your own host (`ifconfig`, `scutil --dns`, `route get`, local config) against the authoritative IaC before they reach shared docs
 
 ## Workflow Integration
 
@@ -116,6 +125,7 @@ Processes Obsidian vault documentation and builds a comprehensive knowledge grap
 2. Use `/docs:generate` to extract API docs from code
 3. Keep docs in sync with `/docs:sync` after changes
 4. Research patterns with `claude-blog-sources` skill
+5. Link rather than duplicate (`docs-single-source`) and verify host-read facts (`docs-verify-machine-facts`) before publishing
 
 ### Service Lifecycle
 

--- a/documentation-plugin/skills/docs-fetch-fallbacks/SKILL.md
+++ b/documentation-plugin/skills/docs-fetch-fallbacks/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: docs-fetch-fallbacks
+description: "WebFetch 404/403/timeout fallback ladder: strip query, raw.githubusercontent, `gh api`, context7/WebSearch. Use when a doc or GitHub URL fetch fails."
+allowed-tools: WebFetch, WebSearch, Bash(gh api *), Read
+created: 2026-08-19
+modified: 2026-08-19
+reviewed: 2026-08-19
+---
+
+# /docs:fetch-fallbacks
+
+A failed `WebFetch` is not a signal to retry the same URL. Re-issuing an
+identical request costs a round trip and returns the identical failure — the
+path is wrong, the resource is gated, or the host is slow, and none of those
+change between attempts. Read the failure signature, apply the fallback that
+matches it, and stop at two attempts.
+
+## Execution
+
+### Step 1: Read the failure signature
+
+Note the status **and** the URL shape before acting — the same status means
+different things depending on where it lands:
+
+| Observed | What it actually means |
+|---|---|
+| `404` on a URL carrying `?ref=`, `?v=`, or tracking params | The path is fine; the query is not |
+| `404` on `github.com/<owner>/<repo>/blob/<ref>/<path>` | An HTML view URL, not a content URL |
+| `404` on a repo path with no host problem | The content is reachable through the API, not the web UI |
+| `403` with an empty body on a public docs page | Bot/UA gating, not authorization |
+| `403` on a `github.com` URL | The resource needs authentication |
+| A timeout with no status at all | Host slow or unreachable — needs a different source, not a retry |
+
+### Step 2: Apply the matching fallback
+
+| Failure | Try |
+|---|---|
+| 404 on a docs page with `?ref=…` | Strip query string |
+| 404 on a GitHub blob URL | Switch to `raw.githubusercontent.com` URL |
+| 404 on a repo path | `gh api repos/<owner>/<repo>/contents/<path>` |
+| 403 on a public docs page | Try once with a different UA or a search engine |
+| 403 on a GitHub URL | Use `gh api` (authenticated) |
+| Timeout | One retry, then fall back to context7 / WebSearch |
+
+If two attempts both fail, surface the failure in the response — do
+not loop.
+
+### Step 3: Worked example — a GitHub blob URL
+
+`WebFetch` returns 404 on:
+
+```
+https://github.com/laurigates/claude-plugins/blob/main/README.md?plain=1
+```
+
+Two things are wrong at once. Fix them cheapest-first rather than jumping to
+the authenticated call:
+
+1. **Strip the query** → still 404, so the query was not the whole problem.
+2. **Swap the host** →
+   `https://raw.githubusercontent.com/laurigates/claude-plugins/main/README.md`
+   — this is the fetch that succeeds for a public repo.
+3. **Still 404 or 403?** The repo is private or rate-limited. Authenticate
+   instead of guessing at more URL shapes:
+
+```bash
+gh api repos/laurigates/claude-plugins/contents/README.md \
+  -H "Accept: application/vnd.github.raw+json"
+```
+
+That is attempt two. There is no attempt three.
+
+For the full URL → `gh` command mapping (pulls, issues, commits, contents at a
+given ref), see `git-plugin:gh-cli-agentic` § GitHub URL Resolution — it owns
+that table. This skill covers only the recovery path after a fetch has failed.
+
+### Step 4: Surface the failure
+
+If the fallback also fails, say so in the response: name the URL, the status,
+and the fallback already tried. A third attempt with a cosmetically different
+URL is the failure mode this skill exists to prevent — the caller can supply a
+working URL far more cheaply than you can guess one.
+
+When the content is documentation for a named library or framework, context7
+and `WebSearch` are the fallback *source*, not another attempt at the same URL.

--- a/documentation-plugin/skills/docs-single-source/SKILL.md
+++ b/documentation-plugin/skills/docs-single-source/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: docs-single-source
+description: Link docs to the single source of truth instead of restating it. Use when writing or restructuring docs, editing a README/CLAUDE.md, or copying a list that lives in code.
+allowed-tools: Read, Grep, Glob, Edit, TodoWrite
+created: 2026-08-19
+modified: 2026-08-19
+reviewed: 2026-08-19
+---
+
+# Documentation: Link, Don't Duplicate
+
+Write documentation that **points to the single source of truth** instead of
+restating it. A fact copied into a second place is a fact that will drift — the
+copy goes stale the moment the original changes, and nothing flags it. This is
+DRY applied to prose.
+
+## The principle
+
+- **Link from where the reader starts.** Put a short pointer at the entry point
+  someone actually lands on (CLAUDE.md, README, a top-level index) that links to
+  the deep doc. Don't reproduce the deep doc at the entry point.
+- **One canonical home per fact.** Each piece of information lives in exactly one
+  authoritative place; everywhere else references it.
+- **A runnable artifact is its own doc.** When a skill, playbook, justfile
+  recipe, or script both *does* the thing and *explains* it, that artifact is the
+  documentation. Link to it — do not write a parallel prose copy that has to be
+  kept in sync by hand.
+- **Reference the authoritative source, not a hand-copy.** When you must
+  enumerate (repos, packages, endpoints, flags), point at the source that's
+  already maintained — e.g. "the `comfy_registry = true` entries in
+  `repositories.tf`" — rather than transcribing a list that silently falls out of
+  date.
+
+## When this bites
+
+| Smell | Why it drifts | Do instead |
+|---|---|---|
+| A hand-maintained list mirroring config/code | The source changes; the list doesn't | Reference the source ("see the X entries in Y") |
+| A command sequence copied into a doc *and* a script | One gets edited, the other rots | Keep it in the script; the doc links to it |
+| The same workflow as prose *and* as a skill/playbook | Two copies, two truths | The skill is the doc; link to it |
+| A config table duplicated across two READMEs | Updates land in one | One canonical doc; the other links |
+| Re-explaining at the entry point what a deeper doc already covers | Entry point and deep doc disagree over time | Short pointer + link |
+
+## When duplication is acceptable
+
+- A one-line *summary* at the entry point (with a link to the full source) is a
+  signpost, not duplication. Keep it to the gist, not the detail.
+- Small, stable facts (a default value cited inline) can be repeated when
+  restating is clearer than a link — but prefer the link if the fact can change.
+
+## Litmus test before adding docs
+
+Ask: *"Does this fact already live somewhere authoritative?"* If yes, link to it.
+If you're about to type a second copy of something that exists elsewhere, stop
+and reference the original. The best documentation edit is often a pointer, not a
+paragraph.
+
+## Rationale
+
+Duplicated documentation doesn't just waste effort — it actively misleads,
+because a stale copy still reads as authoritative. Linking from entry points
+keeps docs discoverable without creating mirror copies that diverge. Referencing
+the source-of-truth means the docs can't go stale relative to it, because there's
+only one truth. This is the prose analogue of DRY (`~/.claude/rules/code-quality.md`) and the
+docs-side complement of `~/.claude/rules/local-ci-parity.md` (one definition, consumed in many
+places).
+
+## Related
+
+- `blueprint-plugin:blueprint-docs-currency` — the timing sibling: code and
+  the docs describing it land in the same commit.
+- `documentation-plugin:docs-sync` — the mechanical catalog reconciler that
+  repairs drift after the fact in generated skill/command/agent tables.
+- `code-quality-plugin:dry-consolidation` — the code-side analogue (clone
+  detection and shared-abstraction extraction over source).

--- a/documentation-plugin/skills/docs-verify-machine-facts/SKILL.md
+++ b/documentation-plugin/skills/docs-verify-machine-facts/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: docs-verify-machine-facts
+description: Verify machine-read values (scutil, route, ifconfig, local config) against the authoritative IaC before publishing. Use when org or outward-facing docs quote DNS names, IPs, endpoints, or versions read off your own host.
+allowed-tools: Read, Grep, Glob, Edit, TodoWrite
+created: 2026-08-19
+modified: 2026-08-19
+reviewed: 2026-08-19
+---
+
+# Verify Machine-Read Facts Against the Org Source-of-Truth Before Publishing
+
+When documenting infrastructure from values read off **your own machine**
+— `ifconfig`, `scutil --dns`, `route get`, `netstat -rn`, `defaults
+read`, a local config file — those readings can carry **personal or
+host-specific artifacts** that are not org facts. Publishing them to
+shared documentation silently passes off your home network (or a stale
+local override, or another VPN) as the organization's configuration.
+
+## The failure mode
+
+A diagnostic session reads the live state of a tool on your laptop, the
+output looks authoritative, and environment-specific lines get lifted
+verbatim into an org doc:
+
+1. You run `scutil --dns` / `route get` to investigate a VPN/tunnel.
+2. The output interleaves **multiple** resolvers and routes — the org
+   tunnel's *and* your home network's, your other VPN's, a local
+   `/etc/hosts` override.
+3. You document the interesting values without separating "this is the
+   org's" from "this is mine."
+4. The doc now tells every reader that the org's internal DNS domain is
+   `intra.lakuz.com` with resolvers `100.95.0.251–.254` — which was the
+   **author's home LAN**, not the org's anything.
+
+The tell: the value is specific and plausible, so reviewers don't
+question it — it reads as researched fact. The leak surfaces only when
+someone who knows the real environment says "that's not ours."
+
+> Canonical break (2026-06): an FVH Twingate troubleshooting DevGuide
+> published `intra.lakuz.com` + `100.95.0.x` as the org's internal DNS.
+> Both were the author's home network, picked up from a `scutil --dns`
+> dump where the home resolver sat in `resolver #1` above the Twingate
+> overlay. The real FVH resource domains (`*.dataportal.fi`, `*.fvh.io`,
+> `*.cluster.local`) live in `twingate/resources.tf`. Corrected in a
+> follow-up commit after the user caught it.
+
+## The rule
+
+Before a machine-read value lands in **org / shared / outward-facing**
+documentation, cross-check it against the **authoritative source** —
+not the local readout:
+
+- **Network/DNS/routing facts** → the IaC that defines them
+  (`twingate/resources.tf`, Terraform, the DHCP/DNS config), not
+  `scutil`/`route`/`ifconfig` on one host.
+- **Endpoints, domains, IP ranges** → the config that provisions them,
+  not what resolved on your machine this session.
+- **Versions, flags, paths** → the project's manifest/lockfile, not what
+  happens to be installed locally.
+
+If you cannot tie a specific value to an authoritative source, either
+**omit it** or **describe the mechanism instead of the literal**. The
+mechanism is environment-independent and cannot leak:
+
+```
+# Leaky — pins host-specific literals as if they were org facts
+Internal DNS resolvers: 100.95.0.251–.254 ; search domain intra.lakuz.com
+
+# Safe — verifiable mechanism, no machine-specific artifact
+Twingate resolves configured resource domains (*.dataportal.fi, *.fvh.io,
+*.cluster.local — see twingate/resources.tf) into the 100.96/12 overlay.
+Verify by resolving the name: the answer should be a 100.96.x address.
+```
+
+## Separating yours from theirs in a multi-source readout
+
+`scutil --dns`, `netstat -rn`, and `route get` show **all** active
+resolvers/routes interleaved. To attribute a line correctly:
+
+- A value reachable only **through the tunnel interface** (`utunN`) is
+  the org's; a value on `en0`/Wi-Fi is local.
+- Cross-reference the route table: the org tunnel's routes point at the
+  tunnel interface and match the IaC's resource ranges. Home/local
+  resolvers route via your LAN gateway.
+- When in doubt, the IaC is authoritative over any local readout.
+
+## Stale, not just misattributed
+
+A fact true when drafted can be false when published. Re-derive mutable ones
+(dates, versions, IDs, counts) in the breath that publishes. 2026-08: a draft
+held through two review rounds needed a rolled-over date and 2 of 11 version
+IDs fixed at post time.
+
+## Relationship to sibling rules
+
+- `git-plugin:git-upstream-fix-check` — same instinct (check the
+  authoritative source before acting) applied to vendored code.
+- `documentation-plugin:docs-single-source` — link to the source-of-truth rather than
+  transcribing; a value you can't link to the source is a value you
+  probably shouldn't hardcode.
+- The `agent-patterns-plugin:cold-read-gate` pattern — an outside reader
+  catches what the author, steeped in their own environment, cannot see is
+  host-specific.
+
+## Rationale
+
+A wrong machine-read literal in shared docs is worse than no value: it
+is confidently specific, so it propagates as fact and misleads everyone
+who can't independently check it. The cost of verification is one lookup
+against the IaC at authoring time; the cost of skipping it is a
+published leak (sometimes of personal infrastructure) and a re-do once
+someone with ground truth notices. Prefer the verifiable mechanism over
+the convenient literal whenever the literal came from your own host.

--- a/documentation-plugin/skills/docs-verify-machine-facts/SKILL.md
+++ b/documentation-plugin/skills/docs-verify-machine-facts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-verify-machine-facts
-description: Verify machine-read values (scutil, route, ifconfig, local config) against the authoritative IaC before publishing. Use when org or outward-facing docs quote DNS names, IPs, endpoints, or versions read off your own host.
+description: Verify machine-read values (scutil, route, ifconfig, local config) against the authoritative IaC before publishing. Use when org docs quote DNS names, IPs, endpoints, or versions read off this host.
 allowed-tools: Read, Grep, Glob, Edit, TodoWrite
 created: 2026-08-19
 modified: 2026-08-19

--- a/git-plugin/README.md
+++ b/git-plugin/README.md
@@ -29,7 +29,9 @@ See [`docs/flow.md`](docs/flow.md) for a diagram of how the skills fit together.
 | `/git:derive-docs` | Analyze git history to derive undocumented rules, PRDs, ADRs, and PRPs |
 | `/git:upstream-pr` | Submit clean PRs to upstream repositories from fork work |
 | `/git:upstream-pr-diverged` | Heavy-divergence fork-to-upstream PR workflow — patch-id eligibility, re-derive fallback, commit-message scrubbing, pre-flight regression check |
+| `/git:upstream-fix-check` | Check whether a bug in vendored, tarball-installed, or forked code is already fixed upstream before patching it — `gh api contents` lookups, stale-repo read, and when to skip the check |
 | `/git:coworker-check` | Detect another agent working in the same repo clone before destructive git ops |
+| `/git:repo-delete-check` | Verify a repo's work survives deletion — remote, unpushed commits, stashes — then offer a push or tar backup |
 | `/git:pr-sync-check` | Check whether the current PR branch is still live and in sync (merged / behind / changes-requested) before building on it |
 | `/git:pr-watch` | Subscribe to a PR's activity and react to review comments and CI as they arrive (delegates reactions to `/git:pr-feedback` / `/git:fix-pr`) |
 
@@ -64,8 +66,10 @@ Three composable skills that can be invoked individually or combined based on us
 | `git-commit-trailers` | Commit trailer conventions — release-please trailers (BREAKING CHANGE, Release-As), attribution (Co-authored-by, Signed-off-by), git interpret-trailers |
 | `git-branch-pr-workflow` | Git branching and PR workflow patterns |
 | `git-rebase-patterns` | Advanced rebase techniques (--reapply-cherry-picks, --update-refs, --onto, stacked PRs) |
+| `git-merge-hazards` | Traps in GitHub's merge machinery — squash-merge detection authority order, stacked-base auto-close, push-by-SHA races, merging over red CI, negated closing keywords |
 | `git-repo-detection` | Detect GitHub repository name and owner from git remotes |
 | `git-security-checks` | Security checks before staging files |
+| `git-issue-scoping` | Read an issue's full comment thread and re-verify its cited `file:line` evidence at HEAD before scoping a PR or plan |
 | `github-issue-autodetect` | Auto-detect issues that changes may fix/close for proper commit linkage |
 | `github-issue-writing` | Create well-structured GitHub issues with clear titles and acceptance criteria |
 | `github-labels` | Discover and apply labels to GitHub PRs and issues |

--- a/git-plugin/agents/git-ops.md
+++ b/git-plugin/agents/git-ops.md
@@ -193,8 +193,8 @@ branch whose merged PR falls outside reads as "no PR" and is silently misclassif
 **`git merge-tree` is step 3, and it proves containment only in the positive direction.**
 Once `main` drifts over the same files, merging an already-landed branch back would
 re-introduce its older versions, so the trees differ and merge-tree reports "not
-contained" for work that fully landed (`~/.claude/rules/pr-merge-hazards.md` #1). A match
-proves containment; a non-match proves nothing.
+contained" for work that fully landed (`git-plugin:git-merge-hazards`, which carries the
+detection authority order). A match proves containment; a non-match proves nothing.
 
 `git remote prune origin` is unaffected by all of this and always safe:
 
@@ -222,9 +222,9 @@ starting point, not a verdict. The recipe lives in a private dotfiles repo, so t
 marketplace can neither version nor regression-test it; the repaired ladder above is
 reported from the recipe's own comments.
 
-Related: `~/.claude/rules/pr-merge-hazards.md` #1 (why `--merged` misses squash-merges,
-and why tree-containment is a one-way signal); `.claude/rules/gh-json-fields.md` (the
-`--limit` default-cap trap and the `state` / `mergedAt` fields).
+Related: `git-plugin:git-merge-hazards` (why `--merged` misses squash-merges, and why
+tree-containment is a one-way signal); `.claude/rules/gh-json-fields.md` (the `--limit`
+default-cap trap and the `state` / `mergedAt` fields).
 
 ## Conflict Resolution Strategy
 

--- a/git-plugin/skills/git-issue-scoping/SKILL.md
+++ b/git-plugin/skills/git-issue-scoping/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: git-issue-scoping
+description: "Read an issue's full comment thread and re-verify its cited evidence at HEAD. Use when scoping a PR or plan from a GitHub issue, or before filing or reversing one in your own tracker."
+allowed-tools: Read, Grep, Glob, Bash(gh issue *), Bash(gh pr *), Bash(gh api *), Bash(git log *), TodoWrite
+created: 2026-08-19
+modified: 2026-08-19
+reviewed: 2026-08-19
+---
+
+# Git Issue Scoping
+
+Invoke before building a PR, plan, or prototype off a GitHub issue — including
+issues in repos you own, and before filing or reversing one in your own tracker.
+
+Before building a PR (or even an approach) off a GitHub issue, **read every
+comment in the thread** — not a fetched summary, not just the body. Issues that
+look like simple feature requests are often where the maintainer has already
+**converged on a specific design** with other experts. A summary compresses
+exactly the part that matters: the decided mechanism, the agreed scope, and the
+work someone has already volunteered to do.
+
+**Applies to repos you own too** (§ *Your own tracker*): the deference part is
+about upstream, but the load-bearing part is that a tracker records decisions
+past-you made and no longer remembers.
+
+## The trap
+
+`WebFetch` (and any "summarize this issue" step) returns a *compressed* view. It
+faithfully captures the issue **body** and headline asks, but silently drops the
+back-and-forth in the comments where the real decisions live. You then design
+against the body's framing, build a prototype, and discover — only if you go
+back and read the comments — that:
+
+- the maintainer picked a **different mechanism** than the obvious one,
+- the **scope** (MUST / WANT / NICE / OUT) was explicitly bounded,
+- a dependency was **already prototyped** by a collaborator (and may be
+  unreleased, so half your plan isn't even buildable yet),
+- your "open questions" were **already answered** in the thread — so asking them
+  reads as not having done the homework.
+
+> Canonical break (jnv #114 → PR #116, 2026-06): a WebFetch summary presented the
+> issue as "extend completion beyond JSON paths." The actual 33-comment thread was
+> a design discussion in which the maintainer and the jaq author had converged on
+> **token-based segmentation** (jaq's `load::lex` token trees) plus a new `yield`
+> filter (an *unmerged* jaq PR) for the in-paren case, with an explicit scope
+> ladder. We built a byte-scanner PoC and a PR body that re-litigated settled
+> questions — caught only when the user asked "did we check all the comments?"
+> The PR had to be reframed before it was safe to surface.
+
+## The rule
+
+When an issue is the basis for a contribution, read the comments **first**:
+
+```sh
+gh issue view <n> --repo <owner>/<repo> --json title,body,author,comments \
+  --jq '.body, (.comments[] | "--- " + .author.login + " ---\n" + .body)'
+```
+
+Specifically extract, before writing any code:
+
+1. **Decided mechanism** — has the maintainer chosen an implementation approach?
+   Build *that*, or explicitly propose an alternative knowing theirs exists.
+2. **Scope ladder** — MUST / WANT / NICE / OUT. Don't attempt OUT; don't skip MUST.
+3. **Dependencies in flight** — linked PRs/branches a collaborator is building.
+   Check their state (`gh pr view` → merged? released?) before depending on them.
+4. **Who's driving** — if the maintainer is mid-collaboration with another expert,
+   a drive-by PR may duplicate their work. Ask whether a contribution is welcome
+   *before* investing, and frame the PR as building on the thread, not restarting it.
+
+If you only have a summary and a gap has passed, **re-read the live thread** before
+acting — the discussion may have moved.
+
+## Your own tracker — search before filing, read before reversing
+
+No maintainer to defer to is exactly why this gets skipped. Two failures:
+
+1. **Search before filing** — a well-researched duplicate is still a duplicate,
+   and the better write-up makes it *harder* to spot as one.
+   `gh issue list -R <o>/<r> --state all --search "<kw>" --json number,title,state`
+2. **Read before reversing** — an old issue records not just a problem but a
+   *decision with its reasoning*, including decisions to **defer**. Shipping the
+   deferred option because it is obviously better silently overrides a choice
+   made with context you no longer have.
+
+> Observed 2026-08 (pal-mcp-server), ten minutes apart: filed a detailed issue
+> duplicating a month-old one that had already diagnosed the same broken publish
+> pipeline — then merged a PR doing the very migration that issue **explicitly
+> deferred**. Neither was caught by review; both surfaced only from listing open
+> issues afterwards.
+
+The tell: calling something "the obvious fix" on a subsystem broken long enough
+for someone to have written about it — long-broken means *investigated*. When
+reversing a decision, say so on the PR and issue, quoting the old reasoning, so
+the next reader sees a decision changed rather than forgotten.
+
+## An issue's cited evidence expires — re-verify every line before acting on it
+
+Distinct from the sections above, which are about *discussion* you failed to
+read. Here you read everything, and the issue is simply **out of date**: it
+cites `file.ts:230` and asserts what is there, and between filing and today
+some unrelated PR fixed it. A well-written issue makes this worse — precise
+line numbers and quoted snippets read as verified fact, and the better the
+write-up, the less anyone re-checks it.
+
+> Observed 2026-08-13 (thelma #1055). A security issue's central claim was
+> "no `responseSchema` enforcement on the Gemini call — `gemini.ts:230` does
+> not pass it." True when filed on 05-13; false by the time it was worked.
+> #1060 had added it in between. The issue even listed *"`responseSchema`
+> enforcement is deliberately removed (currently absent)"* as a trigger to
+> re-evaluate — so writing the doc from the issue verbatim would have shipped
+> a threat model asserting the absence of the control that was by then its
+> primary defence, and inverted one of its own triggers.
+
+- **Re-read every file:line the issue cites, at HEAD, before writing anything
+  from it.** The issue is a *claim about the code*, and the code is the
+  authority — same instinct as `diagnose-at-the-failure-point.md`.
+- **Date the gap.** `gh issue view <n> --json createdAt` against
+  `git log -S'<symbol>' -- <path>` finds the PR that moved it. An issue older
+  than a few weeks on an active file should be assumed stale until checked.
+- **Report the correction in the PR that acts on it**, so the next reader sees
+  the issue's evidence was superseded rather than silently contradicted.
+- Corollary for *filing*: prefer citing behaviour and symbols over line
+  numbers, which rot fastest.
+
+## When it bites
+
+- Any external contribution scoped from an issue, especially a popular repo where
+  maintainers discuss design in comments.
+- **Acting on an issue filed weeks or months ago against a file that has since
+  changed** — the evidence is stale even though the thread is complete.
+- **Your own repo**, when the tracker is the last place you think to look.
+- Resuming work on an issue days later from a cached summary.
+- Letting an early `WebFetch`/research step stand in for the primary source.
+
+## Related
+
+- `~/.claude/rules/verify-upstream-before-patching.md` — same instinct (check
+  the authoritative source before acting) for vendored code; this is the
+  issue-thread analogue.
+- `~/.claude/rules/tool-use-patterns.md` (WebFetch) — a summary is lossy; for a
+  decision that gates real work, go to the full source, not the fetched digest.
+- `git-plugin:git-issue` — the consumer: the end-to-end issue→PR workflow that
+  scopes from the issue thread this skill teaches you to read in full.
+
+## Rationale
+
+The cost asymmetry is stark: reading the thread is one `gh issue view` and a few
+minutes; skipping it costs a misaligned prototype, a PR that signals you didn't
+read the discussion, and a reframe-or-close under the maintainer's eye. The full
+thread is the spec; the summary is a lossy proxy for it.

--- a/git-plugin/skills/git-issue/SKILL.md
+++ b/git-plugin/skills/git-issue/SKILL.md
@@ -229,7 +229,12 @@ Recommended: Run Groups 1, 2, 3 in parallel (3 agents)
 
 #### Standard Flow (Sequential or Single Issue)
 
-1. **Fetch issue details**: `gh issue view $N --json title,body,state,assignees,labels`
+1. **Fetch issue details AND the comment thread**:
+   `gh issue view $N --json title,body,state,assignees,labels,comments`
+   The `comments` field is not optional — the body is the opening position, not the
+   decision. Scope from `git-plugin:git-issue-scoping`, which carries the full protocol
+   (re-verify cited evidence at HEAD; a later comment may have narrowed, reversed, or
+   already resolved the ask).
 2. **Capture issue labels** for later PR creation
 3. **Identify requirements** and acceptance criteria
 4. **Plan the implementation** approach

--- a/git-plugin/skills/git-merge-hazards/SKILL.md
+++ b/git-plugin/skills/git-merge-hazards/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: git-merge-hazards
+description: Traps in GitHub's merge machinery. Use when merging a PR, merging a stacked PR chain, auditing whether a branch really landed, or merging over red CI.
+allowed-tools: Read, Grep, Glob, Bash(gh pr *), Bash(gh issue *), Bash(gh api *), Bash(git cherry *), Bash(git merge-tree *), Bash(git rev-parse *), Bash(git log *), Bash(git reflog *), Bash(git rebase *), Bash(git push *), Bash(git fetch *), Bash(just *), Bash(bash *), TodoWrite
+created: 2026-08-19
+modified: 2026-08-19
+reviewed: 2026-08-19
+---
+
+# Git Merge Hazards
+
+Read before merging a PR, merging a stacked PR chain, auditing whether a branch
+really landed, or merging over red CI. The body below is the verbatim text of
+the promoted `~/.claude/rules/pr-merge-hazards.md` rule.
+
+Three notes that are *not* part of that body:
+
+- Two gates below — §1's merged-ness authority order and the whole of §4 — are
+  also reproduced verbatim in the `pr-merge-hazards.md` stub, because they are
+  read *while* the decision is being made. Edit both copies together.
+- §1 overlaps `git-plugin:deadbranch` Step 1.5 ("Reclassify squash-merged
+  branches"), which carries the same three signals scoped to branch cleanup.
+- The two encoded recipes cited in §1 and §2 below are the author's own (a
+  `just -g` recipe in `laurigates/dotfiles`, and a sweep script in
+  `laurigates/claude-plugins`), not commands a plugin consumer already has.
+  Read the authority ladder in §1 as the instruction; the recipe is a
+  convenience, and its REVIEW bucket measured ~90% false positives (#2268).
+
+Four traps in GitHub's merge machinery, one law: "PR merged" says nothing about
+*content* — and a red check is not proof of failure. Each: the trap, the
+5-second check, the fix. Sibling: `~/.claude/rules/git-hazards.md` (local git).
+
+## 1. `--merged` misses squash-merged branches
+
+A squash-merge collapses a branch into one fresh-SHA commit on `main`, so the
+branch's own commits are never ancestors — `git branch --merged` (and any
+ancestry check) reports it **unmerged**. "Files identical to main" also fails
+once `main` drifts the same files.
+
+- **Check**, in order of authority:
+  - `gh pr list --state all --head <branch> --json state` → a MERGED PR is
+    **authoritative**. Reach for this first; the git-side checks below are all
+    one-way.
+  - `git cherry main <branch>` → marks a commit `-` when a patch-equivalent
+    commit is already upstream, `+` when it is not. Survives squash **and**
+    cherry-pick, and does not care that `main` drifted.
+  - `git merge-tree --write-tree main <branch>` equals `git rev-parse main^{tree}`
+    → contained. **A match proves containment; a non-match proves nothing.**
+- **Not immune to drift** (corrected 2026-07): once `main` moves on over the same
+  files, merging an already-merged branch back would re-introduce its older
+  versions, so the trees differ and merge-tree reports **not contained** for work
+  that fully landed. Observed reporting three merged branches as unmerged. Same
+  trap as "files identical to main". Use the PR state or `git cherry` to decide;
+  keep merge-tree only as a positive-containment shortcut.
+- **Fix**: use the encoded recipe rather than re-deriving: `just -g branch-audit`
+  (in `private_dot_config/just/git.just`) prints MERGED vs REVIEW + a paste-ready delete.
+- A non-match is "review", **not** proof of unmerged — don't force the count to zero.
+
+## 2. Merging a stacked base auto-CLOSES the child PR
+
+When PR B is based on PR A's branch, merging A and deleting its branch
+auto-closes B (GitHub does **not** retarget it), and a closed PR whose base
+branch is gone **cannot be reopened**.
+
+- **Fix — order matters**: retarget the child **first**, while the base PR is open:
+  1. `gh pr edit <child> --base main`
+  2. `gh pr merge <base> --squash --delete-branch`
+  3. `git rebase --onto origin/main <old-base-tip> <child-branch>` (drops the
+     already-squashed base commits) + `git push --force-with-lease`
+  4. merge the child.
+- **If already auto-closed**: the head branch survives — rebase as above,
+  `gh pr create` fresh, comment "Superseded by #new" on the closed one.
+- **Nothing tells you this happened.** The auto-close is silent: no failed
+  check, no notification, and the PR list just looks one shorter. claude-plugins
+  #2049 sat stranded for a day; a sweep then found 26 dead branches, two carrying
+  work that had **never had a PR opened at all** (so no event ever fired for
+  them either). A scheduled sweep is the only thing that finds this class —
+  an event handler on `pull_request: closed` is too late by construction (the
+  base ref is already deleted, so the reopen window is gone) and is blind to
+  never-PR'd branches. `claude-plugins scripts/check-stranded-work.sh` is the
+  encoded audit; it takes `--repo`, so one run sweeps the portfolio.
+- **Telling an accident from a decision**: a closed-unmerged PR whose base ref
+  **404s** was auto-closed; one whose base ref is still **alive** was closed by a
+  human (duplicate/superseded). That single check is the discriminator — 11 of
+  those 26 branches were deliberate closes and must not be resurrected.
+
+## 3. Stacked-chain merges: push by SHA, never `HEAD:` — and expect auto-close races
+
+Working down a stacked-PR chain (retarget child → merge base → rebase child →
+force-push → merge, per #2) has three traps of its own (observed 2026-07,
+claude-plugins #1979→#1987):
+
+- **`HEAD:` in a push refspec is a race in a shared checkout.** HEAD is
+  process-global repo state; a coworker session can move it *between two of
+  your Bash calls*. Observed: rebase left HEAD at the child's new tip; by the
+  next call HEAD was `main`'s tip, so `git push --force-with-lease origin
+  HEAD:<child-branch>` overwrote the branch with main. Resolve the tip to an
+  **explicit SHA in the same command that creates it** and push
+  `git push --force-with-lease origin <sha>:<branch>`.
+- **An empty-diff force-push auto-closes the PR — and a closed PR whose *head*
+  moved after closing cannot be reopened.** Sibling of #2's
+  base-branch-deleted variant. GitHub saw the branch == main, closed the PR,
+  and refused `gh pr reopen` because the head ref had moved since closing.
+- **A single mergeability read after a force-push is a race.** GitHub
+  recomputes `mergeable` asynchronously; `gh pr merge` right after a push
+  fails with "not mergeable" on a perfectly clean PR. Poll
+  `gh pr view <n> --json mergeable` until it leaves `UNKNOWN`.
+- **Waiting for CI races check *registration*, not just completion.** A loop on
+  "zero pending checks" can exit **immediately** after a push/`update-branch`:
+  zero pending is trivially true before the jobs are registered. Observed
+  2026-07: `state=CLEAN` on a **single** check while three CI jobs had not yet
+  appeared — merging there merges untested. Gate on **both** nothing-pending
+  **and** `--jq 'length'` ≥ the expected check count. Same root cause as the
+  mergeability race above: an async field read once, too early.
+
+- **Check** before every force-push: `git log --oneline origin/main..<sha>` —
+  expect *exactly* the child's commits, nothing more, never empty.
+- **Recovery** when auto-closed: the rebased commits survive in local objects
+  (`git reflog`) — `git push --force-with-lease origin <sha>:<branch>`, open a
+  fresh PR from the branch, comment "Superseded by #new" on the closed one.
+
+## 4. A red PR may still be mergeable — `UNSTABLE` is not `BLOCKED`
+
+`mergeStateStatus` separates **required** failing checks (`BLOCKED` — merge
+refused) from merely-present ones (`UNSTABLE` — plain `gh pr merge` works), so
+`--admin` on an `UNSTABLE` PR takes a privilege you didn't need. Read it first.
+
+Merging over red needs **two** checks: `--json files` (config/docs can't break
+a compile) **and** the same check already failing on `main`. Either alone is a
+guess — and a stale-green `main` lies, so check `createdAt` (2026-07: a "green"
+run was 21 days old; main hadn't compiled for three weeks).
+
+
+## 5. A **negated** closing keyword still closes the issue
+
+GitHub matches `close|fixes|resolves|…` + an issue reference without parsing the
+sentence around it, so the natural way to *disclaim* closure closes the issue.
+Markdown emphasis between verb and number doesn't break the match either:
+
+```
+Does **not** close #162   →   GitHub reads `close #162`, and closes it
+```
+
+- **Check**: `gh issue view <n> --json closedByPullRequestsReferences` names the
+  closer; a `closedAt` one second after a merge is automation, not a decision.
+- **Fix**: never let a closing verb precede an issue number you don't mean to
+  close — `Related: #162`, `Unblocks #162`, or `#162 stays open — it needs …`.
+- **Recovery**: `gh issue reopen` works (nothing was deleted, unlike #2), then
+  comment so the next reader doesn't re-derive it.
+
+The damage is a **false status report**: 2026-08-05, a PR body written to
+disclaim closure closed loractl #162 at merge, and the session reported it open
+for two turns afterward. Like #2, GitHub does this silently — only re-reading
+issue state from the API catches it.

--- a/git-plugin/skills/git-repo-delete-check/SKILL.md
+++ b/git-plugin/skills/git-repo-delete-check/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: git-repo-delete-check
+description: "Verify a repo's work survives deletion — remote, unpushed commits, stashes — then offer a push or tar backup. Use when asked to rm -rf, delete, or prune a git checkout."
+allowed-tools: Bash(git -C *), Bash(git remote *), Bash(git status *), Bash(git log *), Bash(git stash *), Bash(git branch *), Bash(du *), Bash(tar *), Bash(mkdir *), Read, Glob, AskUserQuestion, TodoWrite
+created: 2026-08-19
+modified: 2026-08-19
+reviewed: 2026-08-19
+---
+
+# /git:repo-delete-check
+
+Run this before any deletion of a git checkout — `rm -rf`, a cleanup
+sweep over old clones, or a disk-space prune.
+
+Before `rm -rf`'ing a git repository, verify that its work is preserved
+somewhere else. A local checkout that has no remote is the *only* copy —
+deletion is permanent and silently destroys committed history plus all
+uncommitted work.
+
+## Preflight check
+
+```
+git -C <repo> remote -v
+```
+
+| Output | Meaning | Action |
+|---|---|---|
+| Has `origin <url>` | Pushed work lives on the remote | Local delete is safe; uncommitted work and unpushed commits are still lost — surface them first |
+| Empty / no output | **Local-only repo** | Stop. The repo's entire history is in this checkout |
+
+Always run this check before deleting, even when the user has explicitly
+said "delete this repo" — they may not realize a particular checkout is
+local-only.
+
+## When the repo is local-only
+
+Surface the situation and offer three options, in increasing
+destructiveness, before doing anything:
+
+1. **Push to a new GitHub repo first.** Preserves the work on the
+   remote, then the local checkout can be deleted safely. Requires
+   creating the GitHub repo (or knowing it exists empty).
+2. **Tar to a labelled backup.** `tar -czf
+   ~/Backups/<name>-$(date -I).tar.gz <repo>`. Preserves the work on
+   disk under a date-stamped name; the local checkout can then be
+   deleted.
+3. **Delete with no backup.** Confirm the user genuinely wants the work
+   gone — including any uncommitted files, branches, and stashes.
+
+Default when the user says a generic "go" / "yes" without specifying:
+option 2 (tar backup, then delete). It preserves the work without
+requiring remote setup or losing anything, and the backup can be
+deleted later when confidence builds.
+
+## Also surface before deleting
+
+Even when a remote exists, these conditions warrant a pause:
+
+- **Uncommitted changes.** `git status --porcelain` is non-empty —
+  those files are not on any remote.
+- **Unpushed commits.** `git log @{u}..HEAD --oneline` is non-empty —
+  those commits exist only locally.
+- **Stashes.** `git stash list` is non-empty — stashes are pure
+  working-copy state.
+- **Untracked branches.** `git branch -vv` shows branches without
+  upstreams — those branches' commits may be local-only.
+
+If any are present, list them in the same message as the deletion
+prompt so the user can decide knowing what disappears.
+
+## Rationale
+
+The general system-prompt rule ("destructive operations need
+confirmation") covers the *spirit*. This rule is the *concrete check*
+to run before nuking a repo: the failure mode of skipping it is
+silent permanent data loss, with no way to recover.
+
+## Related
+
+- `git-plugin:git-coworker-check` — is another agent writing here? (different
+  question, same safety-diagnostic shape)
+- `git-plugin:git-maintain` — maintenance *inside* a surviving repo
+- `git-plugin:deadbranch` — deleting branches, not the checkout
+- `macos-plugin:macos-disk-usage` — the likely caller when disk pressure
+  prompts a clone cleanup

--- a/git-plugin/skills/git-upstream-fix-check/SKILL.md
+++ b/git-plugin/skills/git-upstream-fix-check/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: git-upstream-fix-check
+description: "Check upstream HEAD before patching vendored, tarball-installed, or forked code. Use when patching a dependency, custom node, or fork you don't own."
+allowed-tools: Bash(gh api *), Bash(gh issue *), Bash(gh pr *), Bash(gh repo *), Bash(base64 *), Read, Grep, Glob
+created: 2026-08-19
+modified: 2026-08-19
+reviewed: 2026-08-19
+---
+
+# /git:upstream-fix-check
+
+Fires when you are about to edit third-party code inside the project — a path
+under `vendor/`, `site-packages/`, `node_modules/`, `custom_nodes/`,
+`third_party/`, or a fork checkout. Every command below is GitHub-specific
+(`gh`); vendored code from GitLab/Codeberg/sourcehut has no recipe here. See
+`git-plugin:gh-cli-agentic` for the raw `gh api contents` command form,
+`git-plugin:git-fork-workflow` once you have confirmed upstream carries the fix,
+`git-plugin:git-upstream-pr` for the contribute-back handoff, and
+`workflow-orchestration-plugin:workflow-verify-before-filing` for the different
+case of a *backlog* of N accumulated bug candidates you are about to file.
+
+Before patching third-party code that lives inside the project (a
+custom ComfyUI node, a vendored library, a tarball-installed package,
+a fork checkout), check whether the bug is already fixed upstream.
+A 30-second `gh` lookup often replaces a 30-minute patch and a PR
+the maintainer will close as duplicate.
+
+## Quick checks
+
+```sh
+# Read one file at upstream HEAD without cloning
+gh api repos/<owner>/<repo>/contents/<path> --jq '.content' | base64 -d
+
+# See what changed since the local copy's version
+gh api repos/<owner>/<repo>/contents/<path>?ref=<sha-or-tag> ...
+
+# Default branch + last activity (catches dead repos)
+gh api repos/<owner>/<repo> --jq '{default_branch, pushed_at, updated_at}'
+
+# Issues / PRs about the same symptom
+gh issue list -R <owner>/<repo> --state all --limit 30 --search "<keyword>"
+gh issue view <n> -R <owner>/<repo> --json title,body,state,closedAt,comments
+gh pr list   -R <owner>/<repo> --state all --limit 20
+```
+
+If the most recent push is months old and the issue tracker shows
+similar bug reports closed-without-merge, the project is effectively
+stale — patch locally and move on. If there's recent activity AND
+the file at master no longer matches the local copy, prefer upgrading
+the install over patching the snapshot.
+
+## When this matters most
+
+- **Tarball-installed packs without `.git`.** Common with package
+  managers that snapshot rather than clone (ComfyUI-Manager,
+  pip wheel installs, vendored deps, `npm pack`-style installs).
+  Local version is pinned at install time and may be many releases
+  behind, so the obvious bug may be obviously fixed upstream.
+- **Forks with diverged history.** The bug may already be fixed on
+  upstream `main` but never pulled into the fork. Check upstream
+  before deciding whether to patch the fork or rebase it.
+- **Linter / formatter / generator output checked into the repo.**
+  Patching the output is usually wrong — find the generator's bug
+  upstream instead.
+
+## When to skip the check
+
+- The bug is in a file the project clearly owns and authored (not
+  a vendor / generated / installed path).
+- You already know upstream's state from a recent session.
+- The local install has explicit downstream patches you'd lose by
+  upgrading. (In that case still skim upstream issues for context,
+  but don't auto-upgrade.)
+
+## Rationale
+
+Patching a stale snapshot creates two debts: the patch itself, and a
+hidden upgrade footgun (your patch silently reverts the next time
+something re-fetches the snapshot). Verifying upstream first either
+(a) confirms the patch is necessary AND surfaces it for an upstream
+PR, or (b) reveals an upgrade is the actual fix.

--- a/hooks-plugin/.claude-plugin/plugin.json
+++ b/hooks-plugin/.claude-plugin/plugin.json
@@ -29,7 +29,9 @@
     "branch-protection",
     "event-logger",
     "permissions",
-    "checkpoint"
+    "checkpoint",
+    "repo-deletion-safety",
+    "branch-base"
   ],
   "hooks": {
     "SessionStart": [
@@ -61,6 +63,16 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/branch-protection.sh",
+            "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/repo-deletion-safety.sh",
+            "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/branch-base-guard.sh",
             "timeout": 5000
           },
           {

--- a/hooks-plugin/README.md
+++ b/hooks-plugin/README.md
@@ -142,6 +142,47 @@ A PreToolUse hook that blocks write operations on protected branches (main, mast
 
 **Toggle:** `export CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1` in your shell environment (e.g. in a personal repo, dotfiles, or main-branch-dev workflow). This is a **human-operator** opt-in — inline prefixes like `CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1 git commit ...` on a Bash command are intentionally not honored, so that agents cannot self-serve the bypass. When blocked on a protected branch, an agent should follow `.claude/rules/handling-blocked-hooks.md` and delegate to the user instead.
 
+### repo-deletion-safety.sh
+
+A PreToolUse hook that blocks `rm -rf` on a git repository whose history exists nowhere else — no remote, or a remote that has never been pushed to. Such a delete destroys committed history, the working tree, every stash and every unpushed branch with a strictly empty recovery path, which is why it is a hard block rather than a nudge. The advisory counterpart is the `git-plugin:git-repo-delete-check` skill (`/git:repo-delete-check`).
+
+| Target of `rm -r`/`-rf`/`--recursive` | Behavior |
+|---------------------------------------|----------|
+| Repo root with no remote (tier 1a) | **Blocked** (exit 2) |
+| Repo root whose remote has never been pushed to (tier 1b) | **Blocked** (exit 2) |
+| A plain directory holding such repos (scanned to depth 3, capped at 20) | **Blocked** per offending repo |
+| Remote-backed repo with uncommitted / unpushed / stashed work (tier 2) | `ask` — **opt-in**, off by default |
+| A path *inside* a repo, a linked worktree, a submodule, a symlink | Allowed — the operand must be a repo **root** |
+| Repos under `/tmp`, `/private/tmp`, `/var/folders`, `$TMPDIR` | Allowed by default |
+| A repo with an existing `<basename>-*.tar.*` in the backup dir | Allowed — this is what makes the block self-extinguishing |
+
+The block message names three remediations (push, tar to `$CLAUDE_REPO_BACKUP_DIR`, or delegate to the user); performing either of the first two changes the world state the hook reads, so the retried `rm -rf` succeeds with no override. Fails **open** on unresolvable operands (`$VAR`, `$(…)`, globs, `{}`) and on remote-exec commands; sibling verbs (`git clean -xdff`, `trash`, `mv`, `rmdir`, `shred`, `find … -delete`) are out of scope. Full enumerated gap list in [`hooks/README.md`](hooks/README.md#repo-deletion-safetysh).
+
+**Toggle:** `export CLAUDE_HOOKS_DISABLE_REPO_DELETION_SAFETY=1` in your shell environment. Like branch protection, a **human-operator** opt-in — an inline `VAR=1 rm -rf …` prefix is intentionally not honored (the statement parser strips leading assignments), so agents cannot self-serve the bypass. Tuning: `CLAUDE_REPO_BACKUP_DIR` (default `$HOME/Backups`), `CLAUDE_HOOKS_REPO_DELETION_TMP_EXEMPT` (default `1`), `CLAUDE_HOOKS_REPO_DELETION_WARN_DIRTY` (default `0`).
+
+**Tests:** `bash hooks-plugin/hooks/test-repo-deletion-safety.sh` (hermetic — all fixtures under `mktemp -d`).
+
+### branch-base-guard.sh
+
+A PreToolUse hook that nudges before cutting a new branch from a local default branch that is **ahead of its remote** — `git-hazards.md` trap #2: unpushed commits on local `main` ride into the new branch, get bundled into its PR under an unrelated title, and a squash-merge hides them everywhere except the file list.
+
+| Aspect | Detail |
+|--------|--------|
+| Tier | **Nudge** (`permissionDecision: "ask"`), never a deny — nothing here is irreversible. Same tier as `git-plugin`'s `check-branch-sync-on-push.sh` |
+| Fires on | `git switch -c/-C/--create/--force-create`, `git checkout -b/-B`, `git worktree add … -b/-B` |
+| Only when | HEAD *is* the resolved default branch, **and** no explicit start-point was given, **and** local `<default>` is ≥1 commit ahead of `origin/<default>` |
+| Exempt | An explicit start-point (`git switch -c feat/x origin/main` — the hook's own suggested fix), `--track`/`-t`, feature-branch bases, in-sync defaults, no `origin`, detached HEAD, all `git branch` forms, quoted mentions, remote-exec |
+| Default branch | **Resolved** (`refs/remotes/origin/HEAD`, then a probed `main`/`master`), never hardcoded |
+| Dedup | At most one nudge per session+repo+default per TTL; silent when the ahead-count is 0 |
+| Network | None by default — a stale `origin/<default>` can only *overstate* the count |
+| Auto mode | Does **not** defer: auto mode's classifier has no notion of which base a branch is cut from |
+
+Known gaps: bare `git branch <name>` is deliberately out of scope (listing/deleting/`-vv` dominate its use, so disambiguating creation costs more false positives than the coverage buys); a never-fetched `origin/<default>` can overstate the count; cutting from an equally-ahead feature branch is uncovered.
+
+**Toggle:** `export CLAUDE_HOOKS_DISABLE_BRANCH_BASE_GUARD=1` in your shell environment — the documented answer for a repo that legitimately develops on its default branch (dotfiles, personal repos). Human-operator opt-in; an inline prefix is intentionally ignored. Tuning: `CLAUDE_HOOKS_BRANCH_BASE_TTL` (default `300` seconds), `CLAUDE_HOOKS_BRANCH_BASE_FETCH` (default `0`).
+
+**Tests:** `bash hooks-plugin/hooks/test-branch-base-guard.sh` (hermetic — fixture repos under `mktemp -d`).
+
 ### external-pr-merge-guard.sh
 
 A PreToolUse hook that refuses to let an agent merge a pull request authored by anyone other than the authenticated user or a bot.
@@ -440,6 +481,8 @@ Every hook can be individually enabled or disabled via environment variables. Se
 |------|-----------------|---------|
 | secret-protection.sh | `CLAUDE_HOOKS_DISABLE_SECRET_PROTECTION=1` | Enabled |
 | branch-protection.sh | `CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION=1` | Enabled |
+| repo-deletion-safety.sh | `CLAUDE_HOOKS_DISABLE_REPO_DELETION_SAFETY=1` | Enabled |
+| branch-base-guard.sh | `CLAUDE_HOOKS_DISABLE_BRANCH_BASE_GUARD=1` | Enabled |
 | external-pr-merge-guard.sh | `CLAUDE_HOOKS_DISABLE_EXTERNAL_PR_MERGE=1` | Enabled |
 | auto-checkpoint.sh | `CLAUDE_HOOKS_DISABLE_AUTO_CHECKPOINT=1` | Enabled |
 | permission-auto-approve.sh | `CLAUDE_HOOKS_DISABLE_PERMISSION_AUTO=1` | Enabled |

--- a/hooks-plugin/docs/feature-flags.md
+++ b/hooks-plugin/docs/feature-flags.md
@@ -2,8 +2,8 @@
 
 A single index of the **environment variables that toggle or tune plugin
 behavior** across this marketplace. Without it, the flags are discoverable only
-by grepping the hook sources — exactly the drift `documentation-authoring.md`
-warns against.
+by grepping the hook sources — exactly the drift
+`documentation-plugin:docs-single-source` warns against.
 
 Each row points at its **source file**, which is the authoritative definition
 (default value + logic). This catalog is a signpost, not a second copy of the
@@ -42,6 +42,8 @@ explicit action, not an env flag. Their own opt-out knobs are listed below.
 |---|---|---|
 | `CLAUDE_HOOKS_DISABLE_SECRET_PROTECTION` | Blocking access to secret files / env-var exposure | `hooks/secret-protection.sh` |
 | `CLAUDE_HOOKS_DISABLE_BRANCH_PROTECTION` | Blocking writes on `main`/`master` (**human-operator only** — inline prefixes are ignored so agents can't self-serve) | `hooks/branch-protection.sh` |
+| `CLAUDE_HOOKS_DISABLE_REPO_DELETION_SAFETY` | Blocking `rm -rf` of a git repo with no remote / an unpushed remote (**human-operator only** — inline prefixes are ignored so agents can't self-serve) | `hooks/repo-deletion-safety.sh` |
+| `CLAUDE_HOOKS_DISABLE_BRANCH_BASE_GUARD` | The `ask` nudge before cutting a branch from a local default branch that is ahead of its remote (**human-operator only**; the documented answer for a repo that legitimately develops on its default branch) | `hooks/branch-base-guard.sh` |
 | `CLAUDE_HOOKS_DISABLE_EXTERNAL_PR_MERGE` | Blocking merges of PRs authored by someone other than you or a bot (**human-operator only** — inline prefixes are ignored so agents can't self-serve) | `hooks/external-pr-merge-guard.sh` |
 | `CLAUDE_HOOKS_DISABLE_AUTO_CHECKPOINT` | Auto-stash checkpoint before destructive git/`rm -rf` ops | `hooks/auto-checkpoint.sh` |
 | `CLAUDE_HOOKS_DISABLE_PERMISSION_AUTO` | Auto-approve/deny of safe/dangerous ops at PermissionRequest | `hooks/permission-auto-approve.sh` |
@@ -84,6 +86,11 @@ explicit action, not an env flag. Their own opt-out knobs are listed below.
 | `CLAUDE_HOOKS_EVENT_LOGGER_VERBOSE` | off | Log full JSON input (vs one-line summary) | `hooks/event-logger.sh` |
 | `CLAUDE_HOOKS_TEST_TIMEOUT` | `45` (s) | Test-verification timeout | `hooks/test-verification.sh` |
 | `CLAUDE_HOOKS_BRANCH_SYNC_TTL` | `300` (s) | Per-session+branch sync-check cache TTL | `git-plugin/hooks/check-branch-sync-on-push.sh` |
+| `CLAUDE_HOOKS_BRANCH_BASE_TTL` | `300` (s) | Per-session+repo+default branch-base nudge dedup window | `hooks/branch-base-guard.sh` |
+| `CLAUDE_HOOKS_BRANCH_BASE_FETCH` | `0` | `1` runs `git fetch --quiet origin <default>` on a cache miss for a fresher ahead-count | `hooks/branch-base-guard.sh` |
+| `CLAUDE_HOOKS_REPO_DELETION_TMP_EXEMPT` | `1` | `0` also guards repos under `/tmp`, `/private/tmp`, `/var/folders`, `$TMPDIR` | `hooks/repo-deletion-safety.sh` |
+| `CLAUDE_HOOKS_REPO_DELETION_WARN_DIRTY` | `0` | `1` enables the tier-2 `ask` on a remote-backed repo carrying uncommitted/unpushed/stashed work | `hooks/repo-deletion-safety.sh` |
+| `CLAUDE_REPO_BACKUP_DIR` | `$HOME/Backups` | Where an existing `<basename>-*.tar.*` clears the repo-deletion block; also the dir named in the block message | `hooks/repo-deletion-safety.sh` |
 | `CLAUDE_TASKWARRIOR_DRIFT_STALE_TTL` | `14400` (s) | Age before a `+ACTIVE` claim counts as stale | `hooks/taskwarrior-drift-probe.sh` |
 | `CLAUDE_TASKWARRIOR_DRIFT_STALE_LIMIT` | `50` | Max stale claims reported | `hooks/taskwarrior-drift-probe.sh` |
 | `CLAUDE_TASKWARRIOR_DRIFT_CACHE_DIR` | `$TMPDIR/claude-taskwarrior-drift` | Drift-probe cache location | `scripts/drain-ghsync-queue.sh` |

--- a/hooks-plugin/hooks/README.md
+++ b/hooks-plugin/hooks/README.md
@@ -399,3 +399,205 @@ rm -rf /tmp/claude-stash-baselines/test-123.d
 The baseline is a per-session **directory** (`<session_id>.d/`), so `rm -f` on the
 flat path removes nothing the hooks write — that path only ever matches a
 pre-#2306 legacy baseline.
+
+---
+
+## repo-deletion-safety.sh
+
+A PreToolUse hook that blocks `rm -rf` on a git repository whose history exists
+nowhere else — no remote, or a remote that has never been pushed to.
+
+### Why This Hook Exists
+
+`rm -rf` on such a checkout destroys committed history, the working tree, every
+stash and every unpushed branch in one stroke. There is no reflog, no
+`git fsck --lost-found`, no PR and no coworker's clone to recover from. This is
+the one deletion shape with a strictly empty recovery path, which is why it is a
+hard block (exit 2) rather than a nudge — see
+[`.claude/rules/hook-block-vs-nudge.md`](../../.claude/rules/hook-block-vs-nudge.md)
+and the source skill `git-plugin:git-repo-delete-check`.
+
+The block is **self-extinguishing**: it names three remediations (push, tar to
+`$CLAUDE_REPO_BACKUP_DIR`, or delegate to the user), and performing either of the
+first two changes the world state the hook reads, so the retried `rm -rf`
+succeeds on the next attempt with no override. That property is what keeps the
+same-session repeat-block rate near zero.
+
+### Commands Blocked
+
+| Condition | Behavior |
+|-----------|----------|
+| `rm -r`/`-rf`/`-fr`/`--recursive` on a repo **root** with no remote (tier 1a) | **Blocked** (exit 2) |
+| Same, on a repo whose remote has never been pushed to — no `refs/remotes` (tier 1b) | **Blocked** (exit 2) |
+| Same, on a plain directory that *holds* repos (scanned to depth 3, capped at 20 hits) | **Blocked** per offending repo |
+| A remote-backed repo carrying uncommitted / unpushed / stashed work (tier 2) | `permissionDecision: "ask"` — **opt-in**, off by default |
+
+The operand must be a repo **root**: the hook compares
+`git rev-parse --absolute-git-dir` against `<dir>/.git` (or `<dir>` for a bare
+repo). That single predicate excludes subdirectories, linked worktrees and
+submodules, whose `.git` resolves elsewhere. Leading `VAR=value` assignments and
+`sudo`/`command`/`env`/`nice` wrappers are stripped before classification, so an
+inline bypass attempt is still classified as the `rm` it is. Safety blocks
+deliberately fire inside compound commands and pipelines — only the
+context-budget read-blocks were narrowed to whole-command scope (#2148).
+
+### Safe Commands (Not Blocked)
+
+- `rm -rf node_modules` / `dist` / any path **inside** a repo — not a repo root.
+- A linked worktree or a submodule directory — `--absolute-git-dir` points into the parent.
+- A symlink to a repo — `rm -rf link` removes the link, not the target.
+- `rm -f <file>` and any `rm` with no recursion flag.
+- Repos under `/tmp`, `/private/tmp`, `/var/folders`, `$TMPDIR` (default; see Configuration).
+- A repo for which a dated `<basename>-*.tar.*` already exists in `$CLAUDE_REPO_BACKUP_DIR`.
+- The command text appearing inside a quoted string (`git commit -m "rm -rf old"`).
+- Remote-exec first tokens: `ssh`, `scp`, `rsync`, `docker`, `podman`, `kubectl`, `nerdctl` (#1900).
+
+### Known Gaps
+
+The hook **fails open** by design; a reader must not over-trust it. Uncovered, in
+full:
+
+| Gap | Why |
+|-----|-----|
+| Unresolvable operands — `$VAR`, `$(…)`, backticks, `{}` from `find -exec` | The hook cannot know the target, so it declines to guess |
+| Globs — `rm -rf repo/*` | Without `dotglob`, `*` does not match `.git`, so history survives; but `rm -rf repo/.[!.]*` therefore **slips through**. Accepted |
+| Symlinks | `rm` removes the link, not the repo |
+| Remote-exec commands | The deletion targets a filesystem this hook cannot inspect |
+| Temp dirs, by default | This repo's own fixtures create remote-less repos under `mktemp -d` and clean them up with `rm -rf` |
+| A remote whose URL is itself a local path | Counts as "has a remote" and clears the block — not decidable inside a hook |
+| Sibling deletion verbs | `git clean -xdff`, `trash`, `mv repo /tmp`, `rmdir`, `shred`, `find … -delete` are **out of scope** |
+
+### Configuration
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `CLAUDE_HOOKS_DISABLE_REPO_DELETION_SAFETY` | unset | `1` disables the hook. Honored **only** from the operator's exported shell environment — an inline `VAR=1 rm -rf …` prefix is not honored (the parser strips leading assignments), so do not self-serve it |
+| `CLAUDE_REPO_BACKUP_DIR` | `$HOME/Backups` | Where an existing `<basename>-*.tar.*` clears the block; also the directory named in the block message |
+| `CLAUDE_HOOKS_REPO_DELETION_TMP_EXEMPT` | `1` | `0` also guards repos under `/tmp`, `/private/tmp`, `/var/folders`, `$TMPDIR` |
+| `CLAUDE_HOOKS_REPO_DELETION_WARN_DIRTY` | `0` | `1` enables the tier-2 `ask` on a remote-backed repo carrying uncommitted / unpushed / stashed work |
+
+### Testing
+
+```bash
+# Blocks (exit 2). The fixture lives under mktemp -d, which the hook exempts by
+# DEFAULT — CLAUDE_HOOKS_REPO_DELETION_TMP_EXEMPT=0 is what makes it a real test.
+T=$(mktemp -d) && git init -q "$T/lonely" && git -C "$T/lonely" commit -q --allow-empty -m init
+echo "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"rm -rf $T/lonely\"},\"cwd\":\"$T\"}" \
+  | CLAUDE_HOOKS_REPO_DELETION_TMP_EXEMPT=0 bash hooks-plugin/hooks/repo-deletion-safety.sh; echo $?   # 2
+
+# Same command with the default tmp exemption: allowed.
+echo "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"rm -rf $T/lonely\"},\"cwd\":\"$T\"}" \
+  | bash hooks-plugin/hooks/repo-deletion-safety.sh; echo $?                                          # 0
+rm -rf "$T"
+
+# A path inside a repo is never a repo root: allowed.
+echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf node_modules"},"cwd":"'"$PWD"'"}' \
+  | bash hooks-plugin/hooks/repo-deletion-safety.sh; echo $?                                          # 0
+
+bash hooks-plugin/hooks/test-repo-deletion-safety.sh   # 57 passed, 0 failed
+```
+
+### Exit Codes
+
+- **0**: Command allowed — or the opt-in tier-2 `ask` envelope was printed on stdout.
+- **2**: Tier-1 block via the standard `block()` convention; the message is shown to Claude.
+
+Tier 2 deliberately does **not** use `block()`: it prints a `PreToolUse`
+`permissionDecision: "ask"` JSON envelope and exits 0.
+
+---
+
+## branch-base-guard.sh
+
+A PreToolUse hook that nudges before cutting a new branch from a local default
+branch that is **ahead of its remote** — `git-hazards.md` trap #2: unpushed
+commits on local `main` ride into the new branch, get bundled into that branch's
+PR under an unrelated title, and a squash-merge hides them everywhere except the
+file list.
+
+### Why This Hook Exists
+
+Nothing here is irreversible — the worst case is a PR whose file list is wider
+than its title, fixable with a single `git rebase --onto`. So this is a **nudge**
+(`permissionDecision: "ask"`), never a deny, matching the tier of its sibling
+`git-plugin/hooks/check-branch-sync-on-push.sh`. It fires at most once per
+session+repo+default per TTL, stays completely silent when the ahead-count is 0,
+and self-extinguishes once `main` is pushed or the branch is cut from
+`origin/<default>`.
+
+The default branch is **resolved** (`refs/remotes/origin/HEAD`, then a probed
+`main`/`master` fallback), never hardcoded — `origin/HEAD` is unset in most agent
+worktrees, `--single-branch` clones and CI checkouts, so the fallback is the
+usual path rather than the exception.
+
+Unlike `branch-protection.sh`, this hook does **not** defer under permission mode
+`"auto"`: auto mode's classifier reasons about protected-branch writes and
+force-pushes and has no notion of which base a branch is cut from, so deferring
+would leave the hazard ungated rather than avoid a double-gate.
+
+### When It Nudges
+
+`git switch -c/-C/--create/--force-create <b>`, `git checkout -b/-B <b>`, and
+`git worktree add … -b/-B <b>` — when **all** of:
+
+1. HEAD is the resolved default branch,
+2. no explicit start-point was given, and
+3. local `<default>` is ≥1 commit ahead of `origin/<default>`.
+
+### Safe Commands (Not Nudged)
+
+- Any create with an explicit start-point — `git switch -c feat/x origin/main`. This is the hook's own suggested fix and is exempt **by design**; getting it wrong would make the corrected command re-trigger the nudge.
+- `--track` / `-t <upstream>` forms.
+- Creating from a feature branch (stacking is deliberate).
+- A default branch already in sync; repos with no `origin`; detached HEAD.
+- `git switch <b>` / `git checkout <b>` with no create flag; **all** `git branch` forms.
+- The command appearing inside a quoted string (`git commit -m "git switch -c x"`) — quoted segments are scrubbed before matching.
+- `ssh` / `docker` / `podman` / `kubectl` / `nerdctl` remote-exec.
+
+### Known Gaps
+
+- **Bare `git branch <name>` is deliberately out of scope.** Listing, deleting and `-vv` dominate its real-world use, so disambiguating creation costs more false positives than the coverage buys.
+- A **stale** `refs/remotes/origin/<default>` that was never fetched can **overstate** — never understate — the ahead-count. Opt into a fetch with `CLAUDE_HOOKS_BRANCH_BASE_FETCH=1`.
+- Cutting from an equally-ahead **feature** branch is not covered.
+
+### Configuration
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `CLAUDE_HOOKS_DISABLE_BRANCH_BASE_GUARD` | unset | `1` disables the hook entirely. The documented answer for a repo that legitimately develops on its default branch (dotfiles, personal repos). Honored only from the operator's exported shell environment — an inline `VAR=1 git switch -c …` prefix is intentionally ignored |
+| `CLAUDE_HOOKS_BRANCH_BASE_TTL` | `300` | Dedup window (seconds) per session+repo+default |
+| `CLAUDE_HOOKS_BRANCH_BASE_FETCH` | `0` | `1` runs `git fetch --quiet origin <default>` on a cache miss before measuring — a network round-trip for a fresher ahead-count |
+
+### Testing
+
+The nudge needs a local default branch that is ahead of its remote, so the
+fixture below builds one. Running the snippets against an arbitrary checkout
+usually prints nothing — a feature branch, or a `main` in sync, is exempt.
+
+```bash
+T=$(mktemp -d) && git init -q --bare "$T/origin.git" && git init -q -b main "$T/repo" \
+  && git -C "$T/repo" -c user.email=t@t -c user.name=T commit -q --allow-empty -m init \
+  && git -C "$T/repo" remote add origin "$T/origin.git" && git -C "$T/repo" push -q -u origin main \
+  && git -C "$T/repo" -c user.email=t@t -c user.name=T commit -q --allow-empty -m "stray commit on main"
+
+# Nudges (prints the `ask` envelope) — local main is ahead of origin/main:
+echo "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git switch -c feat/x\"},\"cwd\":\"$T/repo\",\"session_id\":\"t1\"}" \
+  | bash hooks-plugin/hooks/branch-base-guard.sh; echo $?   # envelope on stdout, exit 0
+
+# Silent — the suggested fix must never re-trigger the nudge:
+echo "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git switch -c feat/x origin/main\"},\"cwd\":\"$T/repo\",\"session_id\":\"t2\"}" \
+  | bash hooks-plugin/hooks/branch-base-guard.sh; echo $?   # no output, exit 0
+rm -rf "$T"
+
+bash hooks-plugin/hooks/test-branch-base-guard.sh   # 59 passed, 0 failed
+```
+
+Use a distinct `session_id` per invocation, or the TTL dedup silences the second
+call regardless of its content.
+
+### Exit Codes
+
+Always **0**. The nudge is signalled by a `PreToolUse`
+`permissionDecision: "ask"` JSON envelope on stdout; absence of output means
+"allow silently". This hook deliberately does not use the `block()` / exit-2
+convention.

--- a/hooks-plugin/hooks/branch-base-guard.sh
+++ b/hooks-plugin/hooks/branch-base-guard.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+# PreToolUse hook for the Bash tool — nudges before cutting a new branch from a
+# local default branch that is ahead of its remote.
+#
+# Problem (git-hazards.md trap #2 — "Unpushed commits on local `main` ride into
+# new branches"): branching off a local `main` that still holds unpushed commits
+# inherits them. The new branch's PR then bundles those stray commits under an
+# unrelated title, and a squash-merge hides them everywhere except the file
+# list.
+#
+# Strategy:
+#   1. Guard: fires only on branch-CREATING forms — `git switch -c/-C/--create/
+#      --force-create`, `git checkout -b/-B`, `git worktree add ... -b/-B`.
+#      Quoted segments are scrubbed before matching so a commit message that
+#      merely mentions the command is inert. Bare `git branch <name>` is
+#      deliberately out of scope: listing/deleting/-vv dominate its real-world
+#      use, so distinguishing creation costs more false positives than the
+#      coverage buys.
+#   2. Resolve the repo dir in precedence order: an explicit `git -C <path>` in
+#      the command (#1389) > the hook input's `.cwd`, i.e. the worktree the Bash
+#      command actually runs in (#1695) > the hook process's own cwd.
+#   3. Exemption 1 (load-bearing): an explicit start-point was given
+#      (`git switch -c feat/x origin/main`). The hook's OWN suggested fix has
+#      that shape — get this wrong and the corrected command re-triggers the
+#      nudge, producing the infinite ask loop that is exactly the repeat-block
+#      pathology which demoted the find/grep/ls guards.
+#   4. Exemption 2: nudge only when HEAD *is* the resolved default branch.
+#      Stacking a branch off a feature branch is deliberate.
+#   5. Dedup: at most one nudge per session+repo+default per TTL. The window is
+#      claimed BEFORE the work, so a killed run degrades to "no check" rather
+#      than re-polling on every call.
+#   6. If local <default> is ahead of origin/<default>, emit
+#      permissionDecision:"ask" — a nudge, never a hard deny. Nothing here is
+#      irreversible (worst case is a PR whose file list is wider than its title,
+#      fixable with a single `git rebase --onto`), and repos that legitimately
+#      develop on their default branch must never be dead-ended.
+#
+# The default branch is RESOLVED (refs/remotes/origin/HEAD, then a probed
+# main/master fallback), never hardcoded to `main` — origin/HEAD is unset in
+# most agent worktrees, --single-branch clones and CI checkouts, so the fallback
+# is the usual path rather than the exception.
+#
+# No `git fetch` in the default path: a stale origin/<default> can only
+# OVERSTATE the ahead-count, the suggested fix contains the fetch anyway, and a
+# network round-trip on every branch creation is a poor trade against the 5000ms
+# timeout. Opt in with CLAUDE_HOOKS_BRANCH_BASE_FETCH=1.
+#
+# Unlike branch-protection.sh, this hook does NOT defer under permission_mode
+# "auto": auto mode's classifier reasons about protected-branch writes and
+# force-pushes and has no notion of which base a branch is cut from, so
+# deferring would leave the hazard ungated rather than avoid double-gating.
+#
+# Known gaps (documented, not oversights): a *stale* origin/<default> that was
+# never fetched, cutting from an equally-ahead feature branch, and bare
+# `git branch <name>` are all uncovered.
+#
+# Opt out: CLAUDE_HOOKS_DISABLE_BRANCH_BASE_GUARD=1 — the documented answer for
+#   a repo that legitimately develops on its default branch (dotfiles, personal
+#   repos). Honored only from the operator's exported shell environment: an
+#   inline `VAR=1 git switch -c ...` prefix sets it for the child command, not
+#   for this hook process, and the statement parser strips leading VAR=value
+#   assignments so a bypass attempt is still classified as a branch creation.
+# TTL override (seconds): CLAUDE_HOOKS_BRANCH_BASE_TTL (default 300)
+# Fresher ahead-count:    CLAUDE_HOOKS_BRANCH_BASE_FETCH=1
+#
+# This hook asks via a JSON envelope rather than blocking with exit 2, so it
+# deliberately does not use the block() convention.
+#
+# Matches: Bash
+
+# Not `set -e`: git probes exit non-zero routinely (symbolic-ref on a detached
+# HEAD, rev-parse outside a repo), and every such probe here is guarded.
+set -uo pipefail
+
+# Human-operator escape hatch — see header comment for why an inline prefix on
+# the guarded command cannot reach this check.
+[ "${CLAUDE_HOOKS_DISABLE_BRANCH_BASE_GUARD:-}" = "1" ] && exit 0
+
+# Degrade silently when a dependency is missing — never fail the user's command.
+command -v jq >/dev/null 2>&1 || exit 0
+command -v git >/dev/null 2>&1 || exit 0
+
+INPUT=$(cat)
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || echo "")
+[ "$TOOL_NAME" = "Bash" ] || exit 0
+COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")
+[ -n "$COMMAND" ] || exit 0
+HOOK_CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null || echo "")
+SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // "nosession"' 2>/dev/null || echo "nosession")
+
+# Remote-exec suppression (#1900 precedent): the command targets another
+# filesystem that `git -C` here cannot inspect.
+case "$(printf '%s' "$COMMAND" | awk 'NR==1{print $1}')" in
+    ssh|docker|podman|kubectl|nerdctl) exit 0 ;;
+esac
+
+# ── ask(): the JSON-envelope nudge. Escape with jq, never by hand. ────────────
+ask() {
+    local reason="$1" json_reason
+    json_reason=$(printf '%s' "$reason" | jq -Rs .)
+    printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":%s}}\n' \
+        "$json_reason"
+    exit 0
+}
+
+# ── Statement splitting ───────────────────────────────────────────────────────
+# Split $COMMAND on UNQUOTED `;`, `&&`, `||`, `|`, `&`, `(`, `)` and newline.
+# Quote state is tracked so a delimiter inside a string does not split.
+split_statements() {
+    awk '
+    BEGIN { SQ = sprintf("%c", 39) }
+    {
+        s = ""; q = ""; n = length($0)
+        for (i = 1; i <= n; i++) {
+            c = substr($0, i, 1)
+            if (q != "") { s = s c; if (c == q) q = ""; continue }
+            if (c == "\"" || c == SQ) { q = c; s = s c; continue }
+            if (c == "\\") { s = s c; i++; if (i <= n) s = s substr($0, i, 1); continue }
+            if (c == ";" || c == "(" || c == ")") { print s; s = ""; continue }
+            if (c == "|") { if (substr($0, i + 1, 1) == "|") i++; print s; s = ""; continue }
+            if (c == "&") { if (substr($0, i + 1, 1) == "&") i++; print s; s = ""; continue }
+            s = s c
+        }
+        print s
+    }'
+}
+
+# Blank out quoted segments so `git commit -m "git switch -c x"` is inert.
+# check-branch-sync-on-push.sh's regex lacks this; do not inherit the weakness.
+scrub_quotes() {
+    sed -E "s/'[^']*'/''/g; s/\"[^\"]*\"/\"\"/g"
+}
+
+# Branch-creating forms only. This is a PRE-FILTER — parse_statement below is
+# authoritative about whether a create flag and a start-point are present.
+TRIGGER_RE='(^|[;&|(]|&&[[:space:]]*|\|\|[[:space:]]*|[[:space:]])git([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+(switch[[:space:]]+(-c|-C|--create|--force-create)|checkout[[:space:]]+(-b|-B)|worktree[[:space:]]+add[[:space:]]+[^[:space:]]*[[:space:]]*(-b|-B))'
+
+# ── Statement parse (authoritative) ──────────────────────────────────────────
+# Sets: MODE, NEW_BRANCH, START_POINT, GIT_C_PATH. Returns 1 when the statement
+# is not a branch creation.
+MODE=""; NEW_BRANCH=""; START_POINT=""; GIT_C_PATH=""
+
+unquote() {
+    local s="${1-}"
+    s="${s//\'/}"
+    s="${s//\"/}"
+    printf '%s' "$s"
+}
+
+parse_statement() {
+    local stmt="$1" t create_re i n
+    local -a raw=() pos=()
+    read -r -a raw <<<"$stmt"
+    n=${#raw[@]}
+    [ "$n" -gt 0 ] || return 1
+
+    MODE=""; NEW_BRANCH=""; START_POINT=""; GIT_C_PATH=""
+
+    # Strip leading `VAR=value` assignments and sudo/command/env/nice wrappers,
+    # so an inline-bypass attempt is still classified as a branch creation.
+    i=0
+    while [ "$i" -lt "$n" ]; do
+        t=$(unquote "${raw[$i]}")
+        case "$t" in
+            [A-Za-z_]*=*) i=$((i + 1)); continue ;;
+            sudo|command|env|nice) i=$((i + 1)); continue ;;
+        esac
+        break
+    done
+
+    [ "$(unquote "${raw[$i]:-}")" = "git" ] || return 1
+    i=$((i + 1))
+
+    # Global git options before the subcommand. -C/-c/--git-dir/... take a value.
+    while [ "$i" -lt "$n" ]; do
+        t=$(unquote "${raw[$i]}")
+        case "$t" in
+            -C) GIT_C_PATH=$(unquote "${raw[$((i + 1))]:-}"); i=$((i + 2)); continue ;;
+            -c|--git-dir|--work-tree|--namespace|--exec-path|--config-env)
+                i=$((i + 2)); continue ;;
+            -*) i=$((i + 1)); continue ;;
+            *) break ;;
+        esac
+    done
+
+    case "$(unquote "${raw[$i]:-}")" in
+        switch)   MODE="switch";   create_re='^(-c|-C|--create|--force-create)$' ;;
+        checkout) MODE="checkout"; create_re='^(-b|-B)$' ;;
+        worktree) MODE="worktree"; create_re='^(-b|-B)$' ;;
+        *) return 1 ;;
+    esac
+    i=$((i + 1))
+
+    if [ "$MODE" = "worktree" ]; then
+        [ "$(unquote "${raw[$i]:-}")" = "add" ] || return 1
+        i=$((i + 1))
+    fi
+
+    local created=0
+    while [ "$i" -lt "$n" ]; do
+        t=$(unquote "${raw[$i]}")
+        [ "$t" = "--" ] && break
+        if [[ "$t" =~ $create_re ]]; then
+            created=1
+            NEW_BRANCH=$(unquote "${raw[$((i + 1))]:-}")
+            i=$((i + 2)); continue
+        fi
+        case "$t" in
+            --create=*|--force-create=*)
+                created=1; NEW_BRANCH="${t#*=}"; i=$((i + 1)); continue ;;
+            # Value-taking flags whose argument must NOT be read as a
+            # start-point. `-t`/`--track` take no separate value, so their
+            # following token IS the start-point and must stay positional.
+            --orphan|--reason) i=$((i + 2)); continue ;;
+            -*) i=$((i + 1)); continue ;;
+        esac
+        pos+=("$t")
+        i=$((i + 1))
+    done
+
+    [ "$created" -eq 1 ] || return 1
+
+    # switch/checkout: the branch name was the create flag's value, so the first
+    # positional is the start-point. `worktree add -b <branch> <path> [<ref>]`
+    # spends the first positional on the worktree PATH.
+    if [ "$MODE" = "worktree" ]; then
+        START_POINT="${pos[1]-}"
+    else
+        START_POINT="${pos[0]-}"
+    fi
+    return 0
+}
+
+# ── Find the branch-creating statement ───────────────────────────────────────
+MATCHED=""
+while IFS= read -r stmt; do
+    [ -n "$stmt" ] || continue
+    printf '%s' "$stmt" | scrub_quotes | grep -Eq "$TRIGGER_RE" || continue
+    if parse_statement "$stmt"; then
+        MATCHED="$stmt"
+        break
+    fi
+done < <(printf '%s' "$COMMAND" | split_statements)
+
+[ -n "$MATCHED" ] || exit 0
+
+# ── EXEMPTION 1 (load-bearing): an explicit start-point was given ────────────
+# `git switch -c feat/x origin/main` is the hook's own suggested fix. It must
+# never re-trigger the nudge.
+[ -n "$START_POINT" ] && exit 0
+
+# ── Repo dir: `git -C <path>` (#1389) > input .cwd (#1695) > process cwd ─────
+REPO_DIR="${GIT_C_PATH:-${HOOK_CWD:-}}"
+if [ -n "$REPO_DIR" ]; then
+    git -C "$REPO_DIR" rev-parse --git-dir >/dev/null 2>&1 || exit 0
+else
+    git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+    REPO_DIR="$PWD"
+fi
+
+# ── EXEMPTION 2: only nudge when HEAD *is* the resolved default branch ──────
+BRANCH=$(git -C "$REPO_DIR" symbolic-ref --short HEAD 2>/dev/null || echo "")
+[ -n "$BRANCH" ] || exit 0   # detached HEAD
+
+DEFAULT=$(git -C "$REPO_DIR" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##' || echo "")
+if [ -z "$DEFAULT" ]; then
+    for candidate in main master; do
+        if git -C "$REPO_DIR" rev-parse --verify --quiet "refs/remotes/origin/$candidate" >/dev/null 2>&1; then
+            DEFAULT="$candidate"
+            break
+        fi
+    done
+fi
+[ -n "$DEFAULT" ] || exit 0                 # no origin / no resolvable default
+[ "$BRANCH" = "$DEFAULT" ] || exit 0        # stacking off a feature branch is deliberate
+git -C "$REPO_DIR" rev-parse --verify --quiet "refs/remotes/origin/$DEFAULT" >/dev/null 2>&1 || exit 0
+
+# ── Dedup: one nudge per session+repo+default per TTL ────────────────────────
+TTL="${CLAUDE_HOOKS_BRANCH_BASE_TTL:-300}"
+case "$TTL" in ''|*[!0-9]*) TTL=300 ;; esac
+SID=$(printf '%s' "$SESSION_ID" | tr -cd 'a-zA-Z0-9_-'); SID="${SID:-nosession}"
+ROOT=$(git -C "$REPO_DIR" rev-parse --show-toplevel 2>/dev/null || echo "$REPO_DIR")
+KEY=$(printf '%s@%s' "$ROOT" "$DEFAULT" | tr -cd 'a-zA-Z0-9_.@-' | tail -c 100)
+KEY="${KEY:-repo}"
+CACHE="${TMPDIR:-/tmp}/claude-branch-base/$SID/$KEY"
+now=$(date +%s 2>/dev/null || echo 0)
+case "$now" in ''|*[!0-9]*) now=0 ;; esac
+if [ -f "$CACHE" ]; then
+    last=$(cat "$CACHE" 2>/dev/null || echo 0)
+    case "$last" in ''|*[!0-9]*) last=0 ;; esac
+    if [ "$last" -gt 0 ] && [ "$now" -gt 0 ] && [ $((now - last)) -lt "$TTL" ]; then
+        exit 0
+    fi
+fi
+# Claim the window BEFORE the work: a killed run degrades to "no check" rather
+# than re-polling on every subsequent call.
+mkdir -p "$(dirname "$CACHE")" 2>/dev/null || true
+printf '%s' "$now" > "$CACHE" 2>/dev/null || true
+
+# ── Measure (no network in the default path) ─────────────────────────────────
+if [ "${CLAUDE_HOOKS_BRANCH_BASE_FETCH:-0}" = "1" ]; then
+    git -C "$REPO_DIR" fetch --quiet origin "$DEFAULT" >/dev/null 2>&1 || true
+fi
+AHEAD=$(git -C "$REPO_DIR" rev-list --count "refs/remotes/origin/$DEFAULT..HEAD" 2>/dev/null || echo 0)
+case "$AHEAD" in ''|*[!0-9]*) AHEAD=0 ;; esac
+[ "$AHEAD" -gt 0 ] || exit 0
+
+SUBJECTS=$(git -C "$REPO_DIR" log --oneline -3 "refs/remotes/origin/$DEFAULT..HEAD" 2>/dev/null || echo "")
+BRANCH_LABEL="${NEW_BRANCH:-<branch>}"
+
+REASON="Local '$DEFAULT' is $AHEAD commit(s) ahead of origin/$DEFAULT, and you are about to cut '$BRANCH_LABEL' from it. Those commits ride into the new branch and get bundled into its PR under an unrelated title — a squash-merge hides them everywhere except the file list (git-hazards.md trap #2).
+
+Commits that would ride along:
+$SUBJECTS
+
+Cut from the remote instead:
+  git fetch origin && git switch -c $BRANCH_LABEL origin/$DEFAULT
+Verify at any time with:
+  git log --oneline origin/$DEFAULT..$DEFAULT
+
+Approve if carrying those commits is intentional (stacked branch, or this repo develops on $DEFAULT). Silence this guard permanently by exporting CLAUDE_HOOKS_DISABLE_BRANCH_BASE_GUARD=1 from your shell."
+
+ask "$REASON"

--- a/hooks-plugin/hooks/repo-deletion-safety.sh
+++ b/hooks-plugin/hooks/repo-deletion-safety.sh
@@ -1,0 +1,434 @@
+#!/usr/bin/env bash
+# PreToolUse hook for the Bash tool — blocks `rm -rf` on a git repository whose
+# history exists nowhere else.
+#
+# Problem it prevents: `rm -rf` on a checkout with no remote (or with a remote
+# that has never been pushed to) destroys committed history, the working tree,
+# every stash and every unpushed branch in one stroke. There is no reflog, no
+# `git fsck --lost-found`, no PR and no coworker's clone to recover from — this
+# is the one failure mode with a strictly empty recovery path, which is why it
+# is a hard block rather than a nudge (source: `git-plugin:git-repo-delete-check`,
+# "the failure mode of skipping it is silent permanent data loss, with no way
+# to recover" — that skill is the deliberate, invoke-before-deleting half of
+# this guard; the `~/.claude/rules/repo-deletion-safety.md` user rule it was
+# promoted out of is now a pointer stub, dotfiles #353).
+#
+# Strategy:
+#   1. Guard: opt-out env var, jq/git availability, tool_name == Bash.
+#   2. Suppress remote-exec commands (ssh/scp/rsync/docker/podman/kubectl/
+#      nerdctl) — they target a filesystem this hook cannot inspect (#1900).
+#   3. Cheap regex pre-filter for an `rm -<flags>` invocation; bail when absent.
+#   4. Authoritative parse: split the command into statements on *unquoted*
+#      `&&`, `||`, `;`, `|` and newlines; per statement strip leading
+#      `VAR=value` assignments plus sudo/command/env/nice, require the command
+#      word to be exactly `rm`, and require at least one recursion flag
+#      (-r/-R/-rf/-fr/--recursive). Safety blocks deliberately fire inside
+#      compound commands and pipelines — only the context-budget read-blocks
+#      were narrowed to whole-command scope (#2148).
+#   5. Per operand that resolves to a real directory, decide whether deleting it
+#      destroys history: it must be a repo ROOT, i.e.
+#      `git rev-parse --absolute-git-dir` equals "<dir>/.git" or "<dir>". That
+#      one predicate excludes subdirectories, linked worktrees and submodules
+#      (whose `.git` is a gitfile pointing into the parent). An operand that is
+#      a *parent* of repos is scanned to depth 3, capped at 20 hits.
+#   6. Tier 1 (exit 2): the repo has no remote (1a), or a remote that has never
+#      been pushed to (1b). The message carries the source skill's three-option
+#      remediation and is SELF-EXTINGUISHING — pushing, or writing the backup
+#      tarball, changes the world state this hook reads, so the retried
+#      `rm -rf` succeeds on the next attempt with no override. That property is
+#      what keeps the same-session repeat-block rate near zero.
+#   7. Tier 2 (opt-in, `ask`): a remote-backed repo that still carries
+#      uncommitted / unpushed / stashed work. Off by default — agents delete
+#      dirty clones and worktrees constantly and no *history* is at risk there,
+#      so a default-on prompt would be pure tax.
+#
+# Fails OPEN by design. Never blocked: unresolvable operands ($VAR, $(...),
+# globs, `{}` from `find -exec`), symlinks (rm removes the link, not the
+# target), non-directories, and — by default — anything under a temp directory
+# (this repo's own fixtures create remote-less repos under mktemp -d and clean
+# them up with `rm -rf`). Sibling deletion verbs (`git clean -xdff`, `trash`,
+# `mv`, `rmdir`, `shred`, `find … -delete`) are out of scope. See
+# hooks/README.md for the full enumerated gap list.
+#
+# Opt out: CLAUDE_HOOKS_DISABLE_REPO_DELETION_SAFETY=1 — honored only when the
+#   human operator has it in the *process* environment. An inline
+#   `CLAUDE_HOOKS_DISABLE_REPO_DELETION_SAFETY=1 rm -rf …` prefix sets it for
+#   the child command, never for this hook process, and the statement parser
+#   strips leading `VAR=value` assignments so the bypass attempt is still
+#   classified as an `rm`. Do not self-serve it.
+# Tuning:
+#   CLAUDE_REPO_BACKUP_DIR                 (default "$HOME/Backups") — where an
+#       existing `<basename>-*.tar.*` clears the block, and the directory named
+#       in the block message.
+#   CLAUDE_HOOKS_REPO_DELETION_TMP_EXEMPT  (default 1) — 0 also guards repos
+#       under /tmp, /private/tmp, /var/folders and $TMPDIR.
+#   CLAUDE_HOOKS_REPO_DELETION_WARN_DIRTY  (default 0) — 1 enables the tier-2
+#       `ask` on a remote-backed repo carrying uncommitted/unpushed/stashed work.
+#
+# Matches: Bash
+# Exit codes: 0 = allow (or tier-2 envelope printed), 2 = block.
+# Tier 1 blocks through the standard block() convention. The opt-in tier 2
+# instead prints a PreToolUse permissionDecision:"ask" JSON envelope and exits
+# 0, so that path deliberately does not use the block() convention.
+
+# Not `set -e`: git probes exit non-zero routinely (rev-parse on a non-repo,
+# remote/for-each-ref on an unrelated dir) and every substitution below is
+# individually guarded with `|| true` / `|| return 0`.
+set -uo pipefail
+
+# Human-operator escape hatch. Only honored from the exported shell
+# environment; see the header for why an inline prefix cannot reach it.
+[ "${CLAUDE_HOOKS_DISABLE_REPO_DELETION_SAFETY:-}" = "1" ] && exit 0
+
+# Degrade silently when a dependency is missing — never fail a user's command
+# because the hook's toolchain is incomplete.
+command -v jq >/dev/null 2>&1 || exit 0
+command -v git >/dev/null 2>&1 || exit 0
+
+INPUT=$(cat)
+
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || echo "")
+[ "$TOOL_NAME" = "Bash" ] || exit 0
+
+COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")
+[ -n "$COMMAND" ] || exit 0
+
+# The directory the Bash command actually runs in — relative operands resolve
+# against it, not against the hook process's own cwd (#1695).
+HOOK_CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null || echo "")
+
+# Remote-exec suppression (#1900): the deletion happens on another filesystem,
+# where a coincidentally-named local path must not be consulted.
+FIRST_TOKEN=$(printf '%s' "$COMMAND" | awk 'NF{print $1; exit}' 2>/dev/null || echo "")
+case "$FIRST_TOKEN" in
+    ssh|scp|rsync|docker|podman|kubectl|nerdctl) exit 0 ;;
+esac
+
+# Cheap pre-filter: an `rm` with at least one flag, optionally behind
+# sudo/command or leading VAR=value assignments, at a statement boundary.
+PREFILTER_RE='(^|[;&|(]|&&|\|\||[[:space:]])(sudo[[:space:]]+|command[[:space:]]+|[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*rm[[:space:]]+-'
+printf '%s' "$COMMAND" | grep -Eq "$PREFILTER_RE" || exit 0
+
+block() {
+    echo "$1" >&2
+    exit 2
+}
+
+ask() {
+    local reason="$1" json_reason
+    json_reason=$(printf '%s' "$reason" | jq -Rs .)
+    printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":%s}}\n' "$json_reason"
+    exit 0
+}
+
+BACKUP_DIR="${CLAUDE_REPO_BACKUP_DIR:-${HOME:-/tmp}/Backups}"
+TMP_EXEMPT="${CLAUDE_HOOKS_REPO_DELETION_TMP_EXEMPT:-1}"
+WARN_DIRTY="${CLAUDE_HOOKS_REPO_DELETION_WARN_DIRTY:-0}"
+TMPROOT="${TMPDIR:-/tmp}"
+TMPROOT="${TMPROOT%/}"
+
+# ── Command parsing ───────────────────────────────────────────────────────────
+
+# Split $1 into statements on unquoted `;`, `&`, `|` runs and newlines.
+# Quote- and backslash-aware so that a separator inside a quoted argument
+# (`git commit -m "cleanup; rm -rf old"`) never manufactures a statement.
+# Result lands in the global array STATEMENTS.
+split_statements() {
+    local s="$1" cur="" i=0 n c q=""
+    n=${#s}
+    STATEMENTS=()
+    while [ "$i" -lt "$n" ]; do
+        c="${s:$i:1}"
+        if [ -n "$q" ]; then
+            if [ "$c" = '\' ] && [ "$q" = '"' ]; then
+                cur+="$c"
+                i=$((i + 1))
+                [ "$i" -lt "$n" ] && { cur+="${s:$i:1}"; i=$((i + 1)); }
+                continue
+            fi
+            cur+="$c"
+            [ "$c" = "$q" ] && q=""
+            i=$((i + 1))
+            continue
+        fi
+        case "$c" in
+            "'"|'"')
+                q="$c"; cur+="$c"; i=$((i + 1)) ;;
+            '\')
+                cur+="$c"; i=$((i + 1))
+                [ "$i" -lt "$n" ] && { cur+="${s:$i:1}"; i=$((i + 1)); } ;;
+            ';'|'&'|'|'|$'\n')
+                STATEMENTS+=("$cur"); cur=""
+                while [ "$i" -lt "$n" ]; do
+                    case "${s:$i:1}" in
+                        ';'|'&'|'|'|$'\n') i=$((i + 1)) ;;
+                        *) break ;;
+                    esac
+                done ;;
+            *)
+                cur+="$c"; i=$((i + 1)) ;;
+        esac
+    done
+    STATEMENTS+=("$cur")
+}
+
+# Split one statement into shell words, honoring quotes and backslashes and
+# stripping the quote characters. Result lands in the global array TOKENS.
+tokenize() {
+    local s="$1" cur="" i=0 n c q="" started=0
+    n=${#s}
+    TOKENS=()
+    while [ "$i" -lt "$n" ]; do
+        c="${s:$i:1}"
+        if [ -n "$q" ]; then
+            if [ "$c" = '\' ] && [ "$q" = '"' ]; then
+                i=$((i + 1))
+                [ "$i" -lt "$n" ] && { cur+="${s:$i:1}"; i=$((i + 1)); }
+                continue
+            fi
+            if [ "$c" = "$q" ]; then q=""; else cur+="$c"; fi
+            i=$((i + 1))
+            continue
+        fi
+        case "$c" in
+            "'"|'"')
+                q="$c"; started=1; i=$((i + 1)) ;;
+            '\')
+                i=$((i + 1))
+                [ "$i" -lt "$n" ] && { cur+="${s:$i:1}"; started=1; i=$((i + 1)); } ;;
+            ' '|$'\t')
+                [ "$started" -eq 1 ] && { TOKENS+=("$cur"); cur=""; started=0; }
+                i=$((i + 1)) ;;
+            *)
+                cur+="$c"; started=1; i=$((i + 1)) ;;
+        esac
+    done
+    [ "$started" -eq 1 ] && TOKENS+=("$cur")
+    return 0
+}
+
+# ── Repo classification ───────────────────────────────────────────────────────
+
+# True only when deleting $1 destroys git history. `--absolute-git-dir` equals
+# "$dir/.git" for a normal repo root and "$dir" for a bare repo (or for the
+# .git directory itself); it is something else entirely — …/.git/worktrees/N,
+# …/.git/modules/N, or the PARENT repo's .git — in every case where deleting
+# $dir destroys nothing. Preferred over `[ -d "$1/.git" ]` for exactly that
+# reason.
+is_repo_root() {
+    local d="$1" gd
+    gd=$(git -C "$d" rev-parse --absolute-git-dir 2>/dev/null) || return 1
+    [ -n "$gd" ] || return 1
+    [ "$gd" = "$d/.git" ] || [ "$gd" = "$d" ]
+}
+
+# Echo a verdict token for repo root $1, or nothing when deletion is safe:
+#   (empty)              — history lives elsewhere, or a backup tarball exists
+#   no_remote            — tier 1a: no remote at all; this is the only copy
+#   remote_never_pushed  — tier 1b: a remote is configured but nothing reached it
+#   dirty|U|P|S|B        — tier 2 (opt-in): remote-backed but work is unsaved
+classify() {
+    local d="$1" base u p s b
+    base=$(basename "$d")
+
+    # ESCAPE — a dated backup tarball for this repo already exists. This is what
+    # makes option 2 of the block message self-extinguishing.
+    ls "$BACKUP_DIR/$base"-*.tar.* >/dev/null 2>&1 && return 0
+
+    # TIER 1a — no remote at all.
+    [ -z "$(git -C "$d" remote 2>/dev/null || true)" ] && { echo "no_remote"; return 0; }
+
+    # TIER 1b — a remote is configured but nothing was ever pushed to it.
+    [ -z "$(git -C "$d" for-each-ref --count=1 refs/remotes 2>/dev/null || true)" ] &&
+        { echo "remote_never_pushed"; return 0; }
+
+    # TIER 2 — opt-in. History is on the remote; only local-only work is at risk.
+    [ "$WARN_DIRTY" = "1" ] || return 0
+    u=$(git -C "$d" status --porcelain 2>/dev/null | wc -l | tr -d '[:space:]')
+    p=$(git -C "$d" log --oneline '@{u}..HEAD' 2>/dev/null | wc -l | tr -d '[:space:]')
+    s=$(git -C "$d" stash list 2>/dev/null | wc -l | tr -d '[:space:]')
+    b=$(git -C "$d" branch -vv 2>/dev/null | grep -vc '\[' || true)
+    case "$u" in ''|*[!0-9]*) u=0 ;; esac
+    case "$p" in ''|*[!0-9]*) p=0 ;; esac
+    case "$s" in ''|*[!0-9]*) s=0 ;; esac
+    case "$b" in ''|*[!0-9]*) b=0 ;; esac
+    if [ "$u" -gt 0 ] || [ "$p" -gt 0 ] || [ "$s" -gt 0 ] || [ "$b" -gt 0 ]; then
+        echo "dirty|$u|$p|$s|$b"
+    fi
+    return 0
+}
+
+emit_block() {
+    local abs="$1" verdict="$2" base cause
+    base=$(basename "$abs")
+    case "$verdict" in
+        no_remote) cause="no remote configured" ;;
+        remote_never_pushed) cause="a remote that has never been pushed to" ;;
+        *) cause="no off-machine copy of its history" ;;
+    esac
+    block "BLOCKED: '$abs' is a git repository with $cause.
+This checkout is the ONLY copy of its history — \`rm -rf\` here is permanent and unrecoverable.
+
+Preserve the work first, then re-run the delete (this block clears itself once either succeeds):
+  1. Push to a remote:  git -C '$abs' remote add origin <url> && git -C '$abs' push -u origin --all
+  2. Tar to a labelled backup (the default when the user just says \"go\"):
+     mkdir -p '$BACKUP_DIR' && tar -czf '$BACKUP_DIR/$base-\$(date -I).tar.gz' '$abs'
+  3. Delete with no backup — confirm with the user that the work, including any
+     uncommitted files, branches and stashes, is genuinely disposable, then ask them
+     to run the command themselves per .claude/rules/handling-blocked-hooks.md.
+Invoke \`git-plugin:git-repo-delete-check\` to walk the full preflight (unpushed
+commits, stashes, upstream-less branches) before choosing between them.
+Do not self-serve CLAUDE_HOOKS_DISABLE_REPO_DELETION_SAFETY — it is honored only from the operator's shell environment."
+}
+
+emit_ask() {
+    local abs="$1" verdict="$2" rest u p s b
+    rest="${verdict#dirty|}"
+    u="${rest%%|*}"; rest="${rest#*|}"
+    p="${rest%%|*}"; rest="${rest#*|}"
+    s="${rest%%|*}"; b="${rest##*|}"
+    ask "'$abs' is a git repository backed by a remote, so its pushed history survives this deletion — but local-only work would not:
+  uncommitted changes (git status --porcelain): $u
+  unpushed commits (git log @{u}..HEAD):        $p
+  stashes (git stash list):                     $s
+  branches with no upstream (git branch -vv):   $b
+
+Approve if that work is genuinely disposable. To preserve it first:
+  git -C '$abs' status --porcelain && git -C '$abs' push --all origin
+Silence this class of prompt with CLAUDE_HOOKS_REPO_DELETION_WARN_DIRTY=0 (it is already off by default)."
+}
+
+decide() {
+    local d="$1" verdict
+    verdict=$(classify "$d")
+    case "$verdict" in
+        "") return 0 ;;
+        dirty\|*) emit_ask "$d" "$verdict" ;;
+        *) emit_block "$d" "$verdict" ;;
+    esac
+}
+
+# ── Operand inspection ────────────────────────────────────────────────────────
+
+check_path() {
+    local p="$1" target abs gd root
+
+    # Flags and the `--` separator are not paths.
+    case "$p" in --|-*) return 0 ;; esac
+
+    # Unresolvable operands — $VAR, $(…), `…`, and `{}` from find -exec. The
+    # hook cannot know the target, so it fails open rather than guessing.
+    case "$p" in *'$'*|*'`'*) return 0 ;; esac
+
+    # Globs. Without dotglob, `*` does not match `.git`, so `rm -rf repo/*`
+    # leaves history intact; and expanding an arbitrary glob inside a 5s hook is
+    # unbounded. `{}` from `find -exec` lands here too.
+    case "$p" in *'*'*|*'?'*|*'['*|*'{'*) return 0 ;; esac
+
+    # Leading ~ only — a mid-path tilde is literal.
+    case "$p" in
+        '~') p="${HOME:-}" ;;
+        '~/'*) p="${HOME:-}${p#\~}" ;;
+    esac
+    [ -n "$p" ] || return 0
+
+    # Relative operands resolve against the cwd the Bash command runs in.
+    target="$p"
+    case "$target" in
+        /*) ;;
+        *) [ -n "$HOOK_CWD" ] && target="${HOOK_CWD%/}/$target" ;;
+    esac
+
+    # A symlink: `rm -rf link` removes the link, not the repo it points at.
+    [ -L "${target%/}" ] && return 0
+
+    # Not a directory (or missing) → nothing to destroy.
+    abs=$(cd "$target" 2>/dev/null && pwd -P) || return 0
+    [ -n "$abs" ] || return 0
+
+    if [ "$TMP_EXEMPT" = "1" ]; then
+        case "$abs" in
+            /tmp/*|/private/tmp/*|/var/folders/*|"$TMPROOT"/*) return 0 ;;
+        esac
+    fi
+
+    # (a) the operand is itself a repo root (or a bare repo / a .git dir).
+    if is_repo_root "$abs"; then
+        decide "$abs"
+        return 0
+    fi
+
+    # (b) the operand is a PARENT holding repos — bounded scan so a
+    # `rm -rf ~/repos` over a large tree cannot blow the hook timeout. If it
+    # does time out, the non-2 exit is non-blocking: fail open, correctly.
+    while IFS= read -r gd; do
+        [ -n "$gd" ] || continue
+        root=$(dirname "$gd")
+        is_repo_root "$root" || continue
+        decide "$root"
+    done < <(find "$abs" -maxdepth 3 -type d -name .git 2>/dev/null | head -20)
+
+    return 0
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+STATEMENTS=()
+TOKENS=()
+split_statements "$COMMAND"
+
+for stmt in ${STATEMENTS[@]+"${STATEMENTS[@]}"}; do
+    # Trim leading whitespace and subshell parens.
+    while :; do
+        case "$stmt" in
+            [[:space:]]*|'('*) stmt="${stmt#?}" ;;
+            *) break ;;
+        esac
+    done
+    case "$stmt" in *')') stmt="${stmt%)}" ;; esac
+    [ -n "$stmt" ] || continue
+
+    tokenize "$stmt"
+    [ "${#TOKENS[@]}" -gt 0 ] || continue
+
+    # Strip leading `VAR=value` assignments and command wrappers so an inline
+    # bypass attempt is still classified as the `rm` it is.
+    idx=0
+    while [ "$idx" -lt "${#TOKENS[@]}" ]; do
+        case "${TOKENS[$idx]}" in
+            [A-Za-z_]*=*|sudo|command|env|nice) idx=$((idx + 1)) ;;
+            *) break ;;
+        esac
+    done
+    [ "$idx" -lt "${#TOKENS[@]}" ] || continue
+
+    # The statement's command word must be exactly `rm` — this is what makes a
+    # quoted occurrence (`git commit -m "rm -rf old"`) inert.
+    [ "${TOKENS[$idx]}" = "rm" ] || continue
+
+    # At least one recursion flag. `rm -f file` can never destroy a directory.
+    has_recursive=0
+    j=$((idx + 1))
+    while [ "$j" -lt "${#TOKENS[@]}" ]; do
+        case "${TOKENS[$j]}" in
+            --recursive) has_recursive=1 ;;
+            --*) ;;
+            -*[rR]*)
+                rest="${TOKENS[$j]#-}"
+                case "$rest" in
+                    *[!a-zA-Z]*) ;;
+                    *) has_recursive=1 ;;
+                esac ;;
+        esac
+        j=$((j + 1))
+    done
+    [ "$has_recursive" -eq 1 ] || continue
+
+    j=$((idx + 1))
+    while [ "$j" -lt "${#TOKENS[@]}" ]; do
+        check_path "${TOKENS[$j]}"
+        j=$((j + 1))
+    done
+done
+
+exit 0

--- a/hooks-plugin/hooks/test-branch-base-guard.sh
+++ b/hooks-plugin/hooks/test-branch-base-guard.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+# Regression tests for branch-base-guard.sh
+#
+# Run: bash hooks-plugin/hooks/test-branch-base-guard.sh
+# Exit 0 = all tests pass, Exit 1 = failures
+#
+# The hook always exits 0 and signals a nudge by emitting a PreToolUse
+# permissionDecision:"ask" JSON envelope on stdout, so assertions read that
+# stdout rather than exit codes.
+#
+# Covers:
+#   - EXEMPTION 1 (the most important test in the file): the hook's OWN
+#     suggested fix `git switch -c feat/x origin/main` must NOT re-trigger it,
+#     or the nudge becomes an infinite ask loop.
+#   - Value-taking-flag parsing: `--track` / `-t <upstream>` leave the
+#     start-point positional and therefore visible.
+#   - Default-branch RESOLUTION: a `master`-default fixture must still nudge
+#     (a hardcoded `main` fails here).
+#   - EXEMPTION 2: HEAD must be the resolved default branch.
+#   - Trigger surface: switch -c/-C, checkout -b/-B, worktree add -b.
+#   - Quote scrubbing, remote-exec suppression, `git -C` repo resolution
+#     (#1389), non-repo cwd, opt-out env var, TTL dedup.
+#
+# Every make_json call mints a FRESH session_id — the TTL cache would otherwise
+# turn the second assertion in each group into a silent "none".
+set -uo pipefail
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/branch-base-guard.sh"
+PASS=0
+FAIL=0
+
+WORK=$(mktemp -d) || { echo "mktemp -d failed" >&2; exit 1; }
+trap 'rm -rf "$WORK"' EXIT
+
+# Keep the hook's TTL cache inside the fixture tree so a run never touches the
+# developer's real /tmp cache (and so each run starts cold).
+export TMPDIR="$WORK/tmpcache"
+mkdir -p "$TMPDIR"
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+# setup_repo <dir> <default-branch> <unpushed-commits>
+setup_repo() {
+    local dir="$1" br="$2" extra="$3" i
+    mkdir -p "$dir"
+    git -C "$dir" init -q
+    git -C "$dir" config commit.gpgsign false
+    git -C "$dir" config user.email "test@test.com"
+    git -C "$dir" config user.name "Test"
+    git -C "$dir" commit --allow-empty -m "initial" -q
+    git -C "$dir" branch -m "$br" 2>/dev/null || git -C "$dir" checkout -b "$br" -q
+    git init -q --bare "$dir.git"
+    git -C "$dir" remote add origin "$dir.git"
+    git -C "$dir" push -q origin "$br"
+    git -C "$dir" fetch -q origin
+    i=1
+    while [ "$i" -le "$extra" ]; do
+        git -C "$dir" commit --allow-empty -m "feat: unpushed $i" -q
+        i=$((i + 1))
+    done
+}
+
+AHEAD="$WORK/ahead"          # default main, 2 unpushed commits on main
+CLEAN="$WORK/clean"          # default main, 0 unpushed commits
+MASTERD="$WORK/masterd"      # default master, 2 unpushed commits on master
+FEATURE="$WORK/feature"      # ahead main, but HEAD parked on feat/y
+DETACH="$WORK/detach"        # ahead main, detached HEAD
+NOREMOTE="$WORK/noremote"    # no origin at all
+
+setup_repo "$AHEAD" main 2
+setup_repo "$CLEAN" main 0
+setup_repo "$MASTERD" master 2
+setup_repo "$FEATURE" main 2
+git -C "$FEATURE" checkout -b feat/y -q
+setup_repo "$DETACH" main 2
+git -C "$DETACH" checkout --detach -q
+
+mkdir -p "$NOREMOTE"
+git -C "$NOREMOTE" init -q
+git -C "$NOREMOTE" config commit.gpgsign false
+git -C "$NOREMOTE" config user.email "test@test.com"
+git -C "$NOREMOTE" config user.name "Test"
+git -C "$NOREMOTE" commit --allow-empty -m "initial" -q
+git -C "$NOREMOTE" branch -m main 2>/dev/null || git -C "$NOREMOTE" checkout -b main -q
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+make_json_sid() {   # $1 command, $2 cwd, $3 session_id
+    jq -nc --arg cmd "$1" --arg cwd "$2" --arg sid "$3" \
+        '{tool_name:"Bash",tool_input:{command:$cmd},cwd:$cwd,session_id:$sid}'
+}
+
+make_json() {       # $1 command, $2 cwd (default: the ahead fixture)
+    make_json_sid "$1" "${2:-$AHEAD}" "test-$RANDOM-$RANDOM-$RANDOM"
+}
+
+decision_of() {     # $1 hook stdout
+    if [ -z "$1" ]; then
+        printf 'none'
+    else
+        printf '%s' "$1" | jq -r '.hookSpecificOutput.permissionDecision // "none"' 2>/dev/null \
+            || printf 'parse_error'
+    fi
+}
+
+assert_decision() { # $1 desc, $2 expected, $3 json
+    local desc="$1" want="$2" json="$3" out got
+    out=$(printf '%s' "$json" | bash "$HOOK" 2>/dev/null)
+    got=$(decision_of "$out")
+    if [ "$got" = "$want" ]; then
+        printf "  PASS: %s\n" "$desc"; PASS=$((PASS + 1))
+    else
+        printf "  FAIL: %s (expected %s, got %s)\n" "$desc" "$want" "$got"; FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_decision_env() { # $1 desc, $2 expected, $3 json, $4 VAR=value
+    local desc="$1" want="$2" json="$3" envassign="$4" out got
+    out=$(printf '%s' "$json" | env "$envassign" bash "$HOOK" 2>/dev/null)
+    got=$(decision_of "$out")
+    if [ "$got" = "$want" ]; then
+        printf "  PASS: %s\n" "$desc"; PASS=$((PASS + 1))
+    else
+        printf "  FAIL: %s (expected %s, got %s)\n" "$desc" "$want" "$got"; FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_reason_contains() { # $1 desc, $2 needle, $3 json
+    local desc="$1" needle="$2" json="$3" out reason
+    out=$(printf '%s' "$json" | bash "$HOOK" 2>/dev/null)
+    reason=$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecisionReason // ""' 2>/dev/null || echo "")
+    case "$reason" in
+        *"$needle"*) printf "  PASS: %s\n" "$desc"; PASS=$((PASS + 1)) ;;
+        *) printf "  FAIL: %s (reason lacks '%s')\n" "$desc" "$needle"; FAIL=$((FAIL + 1)) ;;
+    esac
+}
+
+assert_exit() {     # $1 desc, $2 expected exit, $3 json
+    local desc="$1" want="$2" json="$3" got=0
+    printf '%s' "$json" | bash "$HOOK" >/dev/null 2>&1 || got=$?
+    if [ "$got" -eq "$want" ]; then
+        printf "  PASS: %s\n" "$desc"; PASS=$((PASS + 1))
+    else
+        printf "  FAIL: %s (expected exit %d, got %d)\n" "$desc" "$want" "$got"; FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "=== branch-base-guard hook tests ==="
+
+# ── THE decisive test: the suggested fix must never re-trigger the nudge ─────
+echo ""
+echo "EXEMPTION 1 — explicit start-point (the hook's own suggested fix):"
+assert_decision "git switch -c feat/x origin/main (the suggested fix) → silent" \
+    none "$(make_json "git switch -c feat/x origin/main")"
+assert_decision "git fetch origin && git switch -c feat/x origin/main → silent" \
+    none "$(make_json "git fetch origin && git switch -c feat/x origin/main")"
+assert_decision "git checkout -b feat/x origin/main → silent" \
+    none "$(make_json "git checkout -b feat/x origin/main")"
+assert_decision "git switch -c feat/x abc1234 (sha start-point) → silent" \
+    none "$(make_json "git switch -c feat/x abc1234")"
+assert_decision "git switch -c feat/x main (branch start-point) → silent" \
+    none "$(make_json "git switch -c feat/x main")"
+assert_decision "git switch -C feat/x origin/main (force-create + start-point) → silent" \
+    none "$(make_json "git switch -C feat/x origin/main")"
+assert_decision "git switch --create feat/x origin/main (long form) → silent" \
+    none "$(make_json "git switch --create feat/x origin/main")"
+assert_decision "git worktree add -b feat/x ../wt origin/main → silent" \
+    none "$(make_json "git worktree add -b feat/x ../wt origin/main")"
+
+echo ""
+echo "value-taking-flag parsing (start-point still seen):"
+assert_decision "git switch -c feat/x --track origin/main → silent" \
+    none "$(make_json "git switch -c feat/x --track origin/main")"
+assert_decision "git switch -c feat/x -t origin/main → silent" \
+    none "$(make_json "git switch -c feat/x -t origin/main")"
+assert_decision "git checkout -b feat/x --no-track origin/main → silent" \
+    none "$(make_json "git checkout -b feat/x --no-track origin/main")"
+
+# ── The nudge fires ──────────────────────────────────────────────────────────
+echo ""
+echo "nudge fires on ahead-main (no start-point):"
+assert_decision "git switch -c feat/x → ask" ask "$(make_json "git switch -c feat/x")"
+assert_decision "git checkout -b feat/x → ask" ask "$(make_json "git checkout -b feat/x")"
+assert_decision "git switch -C feat/x (force-create) → ask" ask "$(make_json "git switch -C feat/x")"
+assert_decision "git checkout -B feat/x (force-create) → ask" ask "$(make_json "git checkout -B feat/x")"
+assert_decision "git switch --create feat/x (long form) → ask" ask "$(make_json "git switch --create feat/x")"
+assert_decision "git worktree add -b feat/x ../wt → ask" ask "$(make_json "git worktree add -b feat/x ../wt")"
+assert_decision "git worktree add ../wt -b feat/x (flag after path) → ask" \
+    ask "$(make_json "git worktree add ../wt -b feat/x")"
+assert_decision "git fetch origin && git switch -c feat/x (compound) → ask" \
+    ask "$(make_json "git fetch origin && git switch -c feat/x")"
+assert_decision "cd repo; git switch -c feat/x (semicolon compound) → ask" \
+    ask "$(make_json "cd . ; git switch -c feat/x")"
+assert_decision "sudo-prefixed create → ask" ask "$(make_json "sudo git switch -c feat/x")"
+assert_decision "inline opt-out prefix is NOT honored → ask" \
+    ask "$(make_json "CLAUDE_HOOKS_DISABLE_BRANCH_BASE_GUARD=1 git switch -c feat/x")"
+assert_decision "git -C <repo> switch -c feat/x from an unrelated cwd → ask (#1389)" \
+    ask "$(make_json "git -C $AHEAD switch -c feat/x" "/tmp")"
+assert_exit "hook still exits 0 when it nudges" 0 "$(make_json "git switch -c feat/x")"
+
+echo ""
+echo "reason content:"
+assert_reason_contains "reason names the new branch" "feat/x" "$(make_json "git switch -c feat/x")"
+assert_reason_contains "reason carries the ahead count (2)" "2 commit(s) ahead" "$(make_json "git switch -c feat/x")"
+assert_reason_contains "reason carries the literal suggested fix" \
+    "git switch -c feat/x origin/main" "$(make_json "git switch -c feat/x")"
+assert_reason_contains "reason names the verify command" \
+    "git log --oneline origin/main..main" "$(make_json "git switch -c feat/x")"
+assert_reason_contains "reason cites the source rule" "trap #2" "$(make_json "git switch -c feat/x")"
+
+# ── Default-branch resolution (a hardcoded `main` fails this group) ──────────
+echo ""
+echo "default-branch resolution (master-default repo):"
+assert_decision "master-default repo, ahead master → ask" \
+    ask "$(make_json "git switch -c feat/x" "$MASTERD")"
+assert_reason_contains "reason names origin/master, not origin/main" \
+    "origin/master" "$(make_json "git switch -c feat/x" "$MASTERD")"
+assert_reason_contains "suggested fix cuts from origin/master" \
+    "git switch -c feat/x origin/master" "$(make_json "git switch -c feat/x" "$MASTERD")"
+
+# ── Exemption 2 and the silent cases ────────────────────────────────────────
+echo ""
+echo "EXEMPTION 2 and repo-state exemptions (silent):"
+assert_decision "HEAD on a feature branch → silent (stacking is deliberate)" \
+    none "$(make_json "git switch -c feat/x" "$FEATURE")"
+assert_decision "default branch in sync (0 ahead) → silent" \
+    none "$(make_json "git switch -c feat/x" "$CLEAN")"
+assert_decision "repo with no origin → silent" \
+    none "$(make_json "git switch -c feat/x" "$NOREMOTE")"
+assert_decision "detached HEAD → silent" \
+    none "$(make_json "git switch -c feat/x" "$DETACH")"
+assert_decision "cwd is not a git repo → silent" \
+    none "$(make_json "git switch -c feat/x" "/tmp")"
+
+# ── Non-triggering commands ─────────────────────────────────────────────────
+echo ""
+echo "non-triggering commands (silent):"
+assert_decision "git switch feat/x (no -c) → silent" none "$(make_json "git switch feat/x")"
+assert_decision "git checkout main → silent" none "$(make_json "git checkout main")"
+assert_decision "git branch -a → silent" none "$(make_json "git branch -a")"
+assert_decision "git branch -d old → silent" none "$(make_json "git branch -d old")"
+assert_decision "git branch -vv → silent" none "$(make_json "git branch -vv")"
+assert_decision "git branch newbranch → silent (documented out-of-scope gap)" \
+    none "$(make_json "git branch newbranch")"
+assert_decision "git status → silent" none "$(make_json "git status")"
+assert_decision "ls -la → silent" none "$(make_json "ls -la")"
+assert_decision "git worktree add ../wt (no -b) → silent" none "$(make_json "git worktree add ../wt")"
+assert_decision "git worktree list → silent" none "$(make_json "git worktree list")"
+assert_decision "empty command → silent" none \
+    "$(make_json_sid "" "$AHEAD" "test-empty-$RANDOM")"
+assert_decision "non-Bash tool_name → silent" none \
+    "$(jq -nc --arg cwd "$AHEAD" '{tool_name:"Read",tool_input:{command:"git switch -c feat/x"},cwd:$cwd,session_id:"t-read"}')"
+
+echo ""
+echo "quote scrubbing (the command appears inside a string):"
+assert_decision 'git commit -m "git switch -c feat/x" → silent' \
+    none "$(make_json 'git commit -m "git switch -c feat/x"')"
+assert_decision "echo 'git checkout -b x' → silent" \
+    none "$(make_json "echo 'git checkout -b x'")"
+assert_decision 'git commit -m "feat: git worktree add -b x ../wt" → silent' \
+    none "$(make_json 'git commit -m "feat: git worktree add -b x ../wt"')"
+
+echo ""
+echo "remote-exec suppression (#1900):"
+assert_decision "ssh host 'git switch -c feat/x' → silent" \
+    none "$(make_json "ssh host 'git switch -c feat/x'")"
+assert_decision "docker exec c git checkout -b feat/x → silent" \
+    none "$(make_json "docker exec c git checkout -b feat/x")"
+assert_decision "kubectl exec p -- git switch -c feat/x → silent" \
+    none "$(make_json "kubectl exec p -- git switch -c feat/x")"
+
+# ── Opt-out and dedup ───────────────────────────────────────────────────────
+echo ""
+echo "opt-out from the process environment:"
+assert_decision_env "CLAUDE_HOOKS_DISABLE_BRANCH_BASE_GUARD=1 exported → silent" \
+    none "$(make_json "git switch -c feat/x")" "CLAUDE_HOOKS_DISABLE_BRANCH_BASE_GUARD=1"
+
+echo ""
+echo "TTL dedup (one nudge per session+repo+default):"
+DEDUP_JSON=$(make_json_sid "git switch -c feat/x" "$AHEAD" "dedup-session-fixed")
+assert_decision "first invocation in a session → ask" ask "$DEDUP_JSON"
+assert_decision "second identical invocation in the same session → silent" none "$DEDUP_JSON"
+assert_decision_env "TTL=0 disables the dedup window → ask again" \
+    ask "$DEDUP_JSON" "CLAUDE_HOOKS_BRANCH_BASE_TTL=0"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/hooks-plugin/hooks/test-repo-deletion-safety.sh
+++ b/hooks-plugin/hooks/test-repo-deletion-safety.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+# Regression tests for repo-deletion-safety.sh
+#
+# Run: bash hooks-plugin/hooks/test-repo-deletion-safety.sh
+# Exit 0 = all tests pass, Exit 1 = failures
+#
+# Covers:
+#   - Tier 1a (no remote) and 1b (remote configured, never pushed) → exit 2
+#   - Flag forms (-rf / -fr / -r -f / --recursive) and prefix stripping
+#     (sudo / command / env / leading VAR=value), including the decisive
+#     anti-self-serve case: an inline
+#     CLAUDE_HOOKS_DISABLE_REPO_DELETION_SAFETY=1 prefix is NOT honored
+#   - Safety blocks fire inside compound commands (not narrowed like the
+#     context-budget read-blocks of #2148)
+#   - The false-positive set that matters more than the positives: a path
+#     INSIDE a repo, linked worktrees, symlinks, non-repos, globs,
+#     unresolvable $VAR / $(…) / {} operands, remote-exec (#1900), and the
+#     command text appearing inside a quoted string
+#   - Tier 2 (opt-in `ask` on a remote-backed but dirty repo), default-off
+#   - The self-extinguishing backup escape, and silent degradation when git
+#     is unavailable or the tool is not Bash
+set -uo pipefail
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/repo-deletion-safety.sh"
+PASS=0
+FAIL=0
+
+WORK=$(mktemp -d) || { echo "mktemp -d failed" >&2; exit 1; }
+NOGIT_BIN=$(mktemp -d) || { echo "mktemp -d failed" >&2; exit 1; }
+trap 'rm -rf "$WORK" "$NOGIT_BIN"' EXIT
+
+mkdir -p "$WORK/home" "$WORK/backups" "$WORK/plain"
+
+# The fixture tree lives under mktemp -d, which the hook exempts by DEFAULT.
+# Turning the exemption off is what makes every positive assertion below real
+# rather than a silent false pass.
+HOOK_ENV=(
+    HOME="$WORK/home"
+    CLAUDE_REPO_BACKUP_DIR="$WORK/backups"
+    CLAUDE_HOOKS_REPO_DELETION_TMP_EXEMPT=0
+)
+
+new_repo() { # $1 dir
+    git -C "$1" init -q
+    git -C "$1" config commit.gpgsign false
+    git -C "$1" config user.email "test@test.com"
+    git -C "$1" config user.name "Test"
+    git -C "$1" commit --allow-empty -m "initial" -q
+    git -C "$1" branch -M main >/dev/null 2>&1 || true
+}
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+# lonely: a repo with NO remote — the headline case.
+mkdir -p "$WORK/lonely"; new_repo "$WORK/lonely"
+echo "# readme" > "$WORK/lonely/README.md"
+git -C "$WORK/lonely" add README.md
+git -C "$WORK/lonely" commit -q -m "docs: readme"
+
+# backed: a repo with a real bare origin and pushed refs. The `wt/` and
+# `node_modules/` fixtures live inside it, so they are gitignored (committed
+# BEFORE the push) to keep the tier-2 "clean tree" assertion honest.
+mkdir -p "$WORK/backed"; new_repo "$WORK/backed"
+printf 'wt/\nnode_modules/\ndirty.txt\n' > "$WORK/backed/.gitignore"
+git -C "$WORK/backed" add .gitignore
+git -C "$WORK/backed" commit -q -m "chore: ignore fixture dirs"
+git init -q --bare "$WORK/origin.git"
+git -C "$WORK/backed" remote add origin "$WORK/origin.git"
+git -C "$WORK/backed" push -q -u origin main
+git -C "$WORK/backed" fetch -q origin
+git -C "$WORK/backed" worktree add --detach "$WORK/backed/wt" -q >/dev/null 2>&1
+mkdir -p "$WORK/backed/node_modules"
+
+# added-never-pushed: tier 1b — a remote is configured but nothing reached it.
+mkdir -p "$WORK/added-never-pushed"; new_repo "$WORK/added-never-pushed"
+git -C "$WORK/added-never-pushed" remote add origin "$WORK/never-created.git"
+
+# bare.git: a remote-less bare repo is also the only copy of its history.
+git init -q --bare "$WORK/bare.git"
+
+# parent/inner: a remote-less repo one level below a plain directory.
+mkdir -p "$WORK/parent/inner"; new_repo "$WORK/parent/inner"
+
+# link: a symlink to a remote-less repo.
+ln -s "$WORK/lonely" "$WORK/link"
+
+# A PATH containing jq but NOT git, for the degradation assertion.
+ln -s "$(command -v jq)" "$NOGIT_BIN/jq"
+ln -s "$(command -v cat)" "$NOGIT_BIN/cat"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+make_json() { # $1 command, $2 cwd
+    jq -nc --arg cmd "$1" --arg cwd "${2:-$WORK}" --arg sid "test-$RANDOM-$RANDOM" \
+        '{tool_name:"Bash",tool_input:{command:$cmd},cwd:$cwd,session_id:$sid}'
+}
+
+assert_exit() { # $1 desc, $2 want-exit, $3 json, [extra VAR=val ...]
+    local d="$1" want="$2" json="$3"
+    shift 3
+    local got=0
+    # Here-string, not a pipe: the hook may exit before reading stdin (missing
+    # git, non-Bash tool), and a pipe would then hand the writer SIGPIPE and
+    # report 141 as if the hook had failed.
+    env "${HOOK_ENV[@]}" "$@" bash "$HOOK" >/dev/null 2>&1 <<<"$json" || got=$?
+    if [ "$got" -eq "$want" ]; then
+        printf "  PASS: %s\n" "$d"; PASS=$((PASS + 1))
+    else
+        printf "  FAIL: %s (expected exit %d, got %d)\n" "$d" "$want" "$got"; FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_decision() { # $1 desc, $2 want-decision, $3 json, [extra VAR=val ...]
+    local d="$1" want="$2" json="$3"
+    shift 3
+    local out got
+    out=$(env "${HOOK_ENV[@]}" "$@" bash "$HOOK" 2>/dev/null <<<"$json")
+    if [ -z "$out" ]; then
+        got=none
+    else
+        got=$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecision // "none"' 2>/dev/null || echo parse_error)
+    fi
+    if [ "$got" = "$want" ]; then
+        printf "  PASS: %s\n" "$d"; PASS=$((PASS + 1))
+    else
+        printf "  FAIL: %s (expected %s, got %s)\n" "$d" "$want" "$got"; FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_stderr_contains() { # $1 desc, $2 needle, $3 json
+    local d="$1" needle="$2" json="$3"
+    local err
+    err=$(env "${HOOK_ENV[@]}" bash "$HOOK" 2>&1 >/dev/null <<<"$json" || true)
+    case "$err" in
+        *"$needle"*) printf "  PASS: %s\n" "$d"; PASS=$((PASS + 1)) ;;
+        *) printf "  FAIL: %s (stderr missing %s)\n" "$d" "$needle"; FAIL=$((FAIL + 1)) ;;
+    esac
+}
+
+echo "=== repo-deletion-safety hook tests ==="
+
+# ── Tier 1a: remote-less repo → block ─────────────────────────────────────────
+echo ""
+echo "tier 1a — remote-less repo (block, exit 2):"
+assert_exit "rm -rf on a remote-less repo blocks" 2 "$(make_json "rm -rf $WORK/lonely")"
+assert_exit "trailing slash is normalised" 2 "$(make_json "rm -rf $WORK/lonely/")"
+assert_exit "relative operand resolves against hook cwd" 2 "$(make_json "rm -rf lonely" "$WORK")"
+assert_exit "the .git dir of a remote-less repo blocks" 2 "$(make_json "rm -rf $WORK/lonely/.git")"
+assert_exit "remote-less bare repo blocks" 2 "$(make_json "rm -rf $WORK/bare.git")"
+
+# ── Flag forms ────────────────────────────────────────────────────────────────
+echo ""
+echo "recursion flag forms (block, exit 2):"
+assert_exit "rm -fr blocks" 2 "$(make_json "rm -fr $WORK/lonely")"
+assert_exit "rm -r -f blocks" 2 "$(make_json "rm -r -f $WORK/lonely")"
+assert_exit "rm -R blocks" 2 "$(make_json "rm -R $WORK/lonely")"
+assert_exit "rm --recursive --force blocks" 2 "$(make_json "rm --recursive --force $WORK/lonely")"
+assert_exit "rm -rf -- <path> blocks (-- separator)" 2 "$(make_json "rm -rf -- $WORK/lonely")"
+
+# ── Prefix stripping ──────────────────────────────────────────────────────────
+echo ""
+echo "command prefixes are stripped (block, exit 2):"
+assert_exit "sudo rm -rf blocks" 2 "$(make_json "sudo rm -rf $WORK/lonely")"
+assert_exit "command rm -rf blocks" 2 "$(make_json "command rm -rf $WORK/lonely")"
+assert_exit "env rm -rf blocks" 2 "$(make_json "env rm -rf $WORK/lonely")"
+assert_exit "inline opt-out prefix is NOT honored" 2 \
+    "$(make_json "CLAUDE_HOOKS_DISABLE_REPO_DELETION_SAFETY=1 rm -rf $WORK/lonely")"
+
+# ── Compound commands ─────────────────────────────────────────────────────────
+echo ""
+echo "safety blocks fire inside compound commands (block, exit 2):"
+assert_exit "cd /tmp && rm -rf <repo> blocks" 2 "$(make_json "cd /tmp && rm -rf $WORK/lonely")"
+assert_exit "make clean && rm -rf <repo> blocks" 2 "$(make_json "make clean && rm -rf $WORK/lonely")"
+assert_exit "; separated statement blocks" 2 "$(make_json "ls -1; rm -rf $WORK/lonely")"
+assert_exit "|| separated statement blocks" 2 "$(make_json "test -d x || rm -rf $WORK/lonely")"
+assert_exit "newline separated statement blocks" 2 "$(make_json "ls -1
+rm -rf $WORK/lonely")"
+assert_exit "subshell statement blocks" 2 "$(make_json "(cd /tmp && rm -rf $WORK/lonely)")"
+
+# ── Tier 1b and the parent scan ───────────────────────────────────────────────
+echo ""
+echo "tier 1b + parent scan (block, exit 2):"
+assert_exit "remote added but never pushed blocks" 2 "$(make_json "rm -rf $WORK/added-never-pushed")"
+assert_exit "parent dir holding a remote-less repo blocks" 2 "$(make_json "rm -rf $WORK/parent")"
+assert_exit "multi-operand: second operand still fires" 2 "$(make_json "rm -rf $WORK/plain $WORK/lonely")"
+
+# ── Block message content ─────────────────────────────────────────────────────
+echo ""
+echo "block message carries the three-option remediation:"
+assert_stderr_contains "names the blocked path" "$WORK/lonely" "$(make_json "rm -rf $WORK/lonely")"
+assert_stderr_contains "option 1 — push to a remote" "push -u origin --all" "$(make_json "rm -rf $WORK/lonely")"
+assert_stderr_contains "option 2 — tar to a labelled backup" "$WORK/backups/lonely-" "$(make_json "rm -rf $WORK/lonely")"
+assert_stderr_contains "option 3 — delegate per handling-blocked-hooks" "handling-blocked-hooks.md" "$(make_json "rm -rf $WORK/lonely")"
+assert_stderr_contains "warns against self-serving the opt-out" "Do not self-serve" "$(make_json "rm -rf $WORK/lonely")"
+
+# ── False positives: the half that matters ────────────────────────────────────
+echo ""
+echo "false positives (allow, exit 0):"
+assert_exit "repo with a pushed remote is not blocked" 0 "$(make_json "rm -rf $WORK/backed")"
+assert_exit "a path INSIDE a repo is not blocked" 0 "$(make_json "rm -rf $WORK/backed/node_modules")"
+assert_exit "a linked worktree is not blocked" 0 "$(make_json "rm -rf $WORK/backed/wt")"
+assert_exit "the .git of a remote-backed repo is not blocked" 0 "$(make_json "rm -rf $WORK/backed/.git")"
+assert_exit "a plain non-repo directory is not blocked" 0 "$(make_json "rm -rf $WORK/plain")"
+assert_exit "a missing path is not blocked" 0 "$(make_json "rm -rf $WORK/does-not-exist")"
+assert_exit "a symlink to a repo is not blocked" 0 "$(make_json "rm -rf $WORK/link")"
+assert_exit "rm -f (no recursion) is not blocked" 0 "$(make_json "rm -f $WORK/lonely/README.md")"
+assert_exit "rm without flags is not blocked" 0 "$(make_json "rm $WORK/lonely/README.md")"
+assert_exit "a glob operand is skipped" 0 "$(make_json "rm -rf $WORK/lonely/*")"
+# shellcheck disable=SC2016  # literal $SOME_VAR is the point of the assertion
+assert_exit "an unexpanded \$VAR operand fails open" 0 "$(make_json 'rm -rf "$SOME_VAR"')"
+# shellcheck disable=SC2016
+assert_exit "a \$(…) operand fails open" 0 "$(make_json 'rm -rf $(mktemp -d)')"
+assert_exit "find -exec {} fails open" 0 "$(make_json 'find . -name build -exec rm -rf {} \;')"
+assert_exit "ssh remote-exec is suppressed" 0 "$(make_json "ssh host 'rm -rf $WORK/lonely'")"
+assert_exit "docker remote-exec is suppressed" 0 "$(make_json "docker exec c rm -rf $WORK/lonely")"
+assert_exit "quoted occurrence in echo does not fire" 0 "$(make_json "echo \"rm -rf $WORK/lonely\"")"
+assert_exit "quoted occurrence in a commit message does not fire" 0 \
+    "$(make_json "git commit -m \"rm -rf the old repo\"")"
+assert_exit "a separator inside a quoted string does not split" 0 \
+    "$(make_json "git commit -m \"cleanup; rm -rf $WORK/lonely\"")"
+assert_exit "temp-dir exemption (default on) allows a remote-less repo" 0 \
+    "$(make_json "rm -rf $WORK/lonely")" CLAUDE_HOOKS_REPO_DELETION_TMP_EXEMPT=1
+
+# ── Tier 2: opt-in ask on a dirty but remote-backed repo ──────────────────────
+echo ""
+echo "tier 2 — dirty remote-backed repo (opt-in ask):"
+assert_decision "clean tree with WARN_DIRTY=1 stays silent" none \
+    "$(make_json "rm -rf $WORK/backed")" CLAUDE_HOOKS_REPO_DELETION_WARN_DIRTY=1
+echo "scratch" > "$WORK/backed/untracked.txt"
+assert_decision "untracked file with WARN_DIRTY=1 asks" ask \
+    "$(make_json "rm -rf $WORK/backed")" CLAUDE_HOOKS_REPO_DELETION_WARN_DIRTY=1
+assert_decision "same dirty tree is silent by default (WARN_DIRTY unset)" none \
+    "$(make_json "rm -rf $WORK/backed")"
+assert_exit "tier 2 never escalates to exit 2" 0 \
+    "$(make_json "rm -rf $WORK/backed")" CLAUDE_HOOKS_REPO_DELETION_WARN_DIRTY=1
+rm -f "$WORK/backed/untracked.txt"
+
+# ── Degradation ───────────────────────────────────────────────────────────────
+echo ""
+echo "degradation (allow silently, exit 0):"
+assert_exit "non-Bash tool passes through" 0 \
+    "$(jq -nc --arg cmd "rm -rf $WORK/lonely" --arg cwd "$WORK" \
+        '{tool_name:"Read",tool_input:{command:$cmd},cwd:$cwd,session_id:"x"}')"
+assert_exit "empty command passes through" 0 \
+    "$(jq -nc --arg cwd "$WORK" '{tool_name:"Bash",tool_input:{command:""},cwd:$cwd,session_id:"x"}')"
+assert_exit "non-rm command passes through" 0 "$(make_json "ls -la $WORK/lonely")"
+assert_exit "operator opt-out from the environment is honored" 0 \
+    "$(make_json "rm -rf $WORK/lonely")" CLAUDE_HOOKS_DISABLE_REPO_DELETION_SAFETY=1
+
+GOT=0
+env "${HOOK_ENV[@]}" PATH="$NOGIT_BIN" "$BASH" "$HOOK" >/dev/null 2>&1 \
+    <<<"$(make_json "rm -rf $WORK/lonely")" || GOT=$?
+if [ "$GOT" -eq 0 ]; then
+    printf "  PASS: %s\n" "missing git degrades silently"; PASS=$((PASS + 1))
+else
+    printf "  FAIL: %s (expected exit 0, got %d)\n" "missing git degrades silently" "$GOT"; FAIL=$((FAIL + 1))
+fi
+
+# ── Self-extinguishing backup escape (run last: it clears the block) ──────────
+echo ""
+echo "self-extinguishing backup escape (allow, exit 0):"
+touch "$WORK/backups/lonely-2026-08-19.tar.gz"
+assert_exit "an existing dated backup tarball clears the block" 0 "$(make_json "rm -rf $WORK/lonely")"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/scripts/check-agent-tool-selection.sh
+++ b/scripts/check-agent-tool-selection.sh
@@ -41,7 +41,7 @@
 # `just -g branch-audit` recipe is a convenience, not the authority — its REVIEW
 # bucket measured ~90% false on two real repos (issue #2268). The routing/caveat
 # side of that is guarded by scripts/check-branch-containment-guidance.sh.
-# See `~/.claude/rules/pr-merge-hazards.md` #1.
+# See `git-plugin:git-merge-hazards` (the detection authority order).
 #
 # Detection is a per-line shape denylist (the accepted form for this repo's
 # denylist lints — see issue #2009, which deliberately did NOT migrate them to
@@ -162,7 +162,7 @@ for agent_file in "${agent_files[@]}"; do
     echo "   \`git merge-tree\` is a positive-containment shortcut only, never primary;" >&2
     echo "   \`just -g branch-audit\` is a convenience whose REVIEW bucket measured ~90%" >&2
     echo "   false on two repos (issue #2268) — verify its REVIEW rows against the ladder." >&2
-    echo "   See ~/.claude/rules/pr-merge-hazards.md #1." >&2
+    echo "   See the git-plugin:git-merge-hazards skill for the full ladder." >&2
     errors=$((errors + 1))
     continue
   fi

--- a/scripts/check-branch-containment-guidance.sh
+++ b/scripts/check-branch-containment-guidance.sh
@@ -13,7 +13,8 @@
 #   ForumViriumHelsinki/infrastructure 245 REVIEW rows, 216 had landed (88%)
 # Two silent defects caused it, and both are what this guard pins:
 #   1. `git merge-tree` used as the PRIMARY signal. Per
-#      `~/.claude/rules/pr-merge-hazards.md` #1 tree-containment is one-way:
+#      `git-plugin:git-merge-hazards` (and the surviving
+#      `~/.claude/rules/pr-merge-hazards.md` stub) tree-containment is one-way:
 #      once the base drifts over the same files the trees differ for work that
 #      fully landed, so a non-match proves NOTHING. 132 branches lost this way.
 #   2. `gh pr list --limit 500` against repos holding 1881 and 1684 PRs. Any
@@ -54,10 +55,20 @@
 #
 # Deliberately NARROW so the check does not become noise that gets disabled:
 #   - Rules 1-4 scan `git-plugin/**/*.md` only. That is where the routing an
-#     agent acts on lives. `.claude/rules/gh-json-fields.md` and
-#     `~/.claude/rules/pr-merge-hazards.md` TEACH these traps and must be free
-#     to quote the broken forms verbatim — the same instruction-vs-explanation
-#     discrimination `check-agent-tool-selection.sh` already makes.
+#     agent acts on lives. `.claude/rules/gh-json-fields.md` and the
+#     `~/.claude/rules/pr-merge-hazards.md` stub sit OUTSIDE that corpus and so
+#     are free to quote the broken forms verbatim while TEACHING them — the
+#     same instruction-vs-explanation discrimination
+#     `check-agent-tool-selection.sh` already makes.
+#     `git-plugin/skills/git-merge-hazards/SKILL.md` (the skill that rule was
+#     promoted into, dotfiles #353) teaches the same traps but lives INSIDE the
+#     scanned corpus, and is deliberately NOT exempted: it is now the most-read
+#     containment guidance this plugin ships, so it must satisfy the same
+#     ladder-ordering and caveat-token rules as the agents. It passes today
+#     (verified: STATUS=OK over 53 git-plugin files) because it leads with the
+#     authoritative `gh pr list ... --head` line and carries the
+#     `positive-containment`, `REVIEW bucket` and `#2268` tokens. Exempting it
+#     would blind the guard to the very file most likely to be edited.
 #   - Rule 5 scans `*-plugin/**/*.md` (any plugin can hand out a `gh pr list`),
 #     but fires only when the line ALSO asks for `state`/`mergedAt`, i.e. is a
 #     containment/merged-state determination. A scope-discovery listing such as
@@ -128,7 +139,7 @@ git_plugin_excluded=0
 # is_generated_changelog <file> — true for a release-please-generated changelog.
 #
 # STRUCTURAL, not a hardcoded path list. A filename allowlist is the maintenance
-# trap `.claude/rules/documentation-authoring.md` warns about: it goes stale the
+# trap `documentation-plugin:docs-single-source` warns about: it goes stale the
 # moment a plugin is added, and nothing flags the drift. Release-please instead
 # has a recognisable heading SHAPE, and every generated changelog carries it:
 #

--- a/scripts/check-feature-flags-catalog.sh
+++ b/scripts/check-feature-flags-catalog.sh
@@ -4,7 +4,8 @@
 #
 # The catalog is a hand-maintained index, so a newly-added CLAUDE_HOOKS_* /
 # CLAUDE_TASKWARRIOR_* flag can silently land in a hook without a catalog entry —
-# exactly the drift documentation-authoring.md warns about. This makes the check
+# exactly the drift `documentation-plugin:docs-single-source` warns about. This
+# makes the check
 # deterministic instead of relying on someone re-running the regeneration grep.
 #
 # The check: every flag READ in a plugin source must appear in the catalog. A

--- a/session-plugin/skills/session-wrap/SKILL.md
+++ b/session-plugin/skills/session-wrap/SKILL.md
@@ -169,7 +169,7 @@ two equal-weight options (no default lean):
 - *Track for later* → `task add project:<name> +upstream '<desc — name
   the upstream repo + what/why>'`. No outward action; the `+upstream`
   tag is where "file this upstream" work surfaces later
-  (`taskwarrior-tracking.md`).
+  (`taskwarrior-plugin:task-add`).
 - *File now* → hand off, in order:
   1. `workflow-orchestration-plugin:workflow-verify-before-filing` —
      verify the bug still exists at upstream HEAD **and** dedup against
@@ -179,8 +179,7 @@ two equal-weight options (no default lean):
      (`public-export-sanitization.md`).
   3. File the issue (`git-plugin:github-issue-writing`) or open the
      local-fix backport. When commenting on an **existing** issue, read
-     the full thread first
-     (`~/.claude/rules/read-issue-thread-before-contributing.md`).
+     the full thread first (`git-plugin:git-issue-scoping`).
 
   **Graceful degradation**: if `workflow-orchestration-plugin` is not
   installed (mirrors the `feedback-plugin` / `blueprint-plugin`

--- a/taskwarrior-plugin/README.md
+++ b/taskwarrior-plugin/README.md
@@ -21,7 +21,7 @@ Both systems stay in sync via UDAs (`ghid`, `ghpr`) and tags (`+gh`, `+pr_ready`
 
 | Skill | Purpose |
 |-------|---------|
-| `/taskwarrior:task-add` | File a task with bpid / bpdoc / bpms fields; auto-tags `project:` from the current repo; offers GitHub issue linkage when a remote is detected |
+| `/taskwarrior:task-add` | File a task with bpid / bpdoc / bpms fields; auto-tags `project:` from the current repo and verifies the slug really exists (`project:` is a **prefix** match, so a non-empty `task project:<slug> list` never proves it); offers GitHub issue linkage when a remote is detected |
 | `/taskwarrior:task-claim` | Claim a pending task as in-flight: marks it `+ACTIVE` (`task start`), stamps identity UDAs (`agent` / `pid` / `host` / `branch` / `worktree`), and writes a `/git:coworker-check` session marker so destructive git ops in the clone are guarded |
 | `/taskwarrior:task-release` | Release an active claim without closing: stops the `+ACTIVE` clock, annotates the handoff state, drains `pid`, and drops the coworker-check marker. Pairs with `task-claim` for pause / handoff |
 | `/taskwarrior:task-done` | Close a task, annotate with commit hash, drain the linked feature-tracker entry; auto-stops the `+ACTIVE` claim and offers to close the linked GitHub issue |

--- a/taskwarrior-plugin/skills/task-add/SKILL.md
+++ b/taskwarrior-plugin/skills/task-add/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: task-add
-description: Add a taskwarrior task with blueprint linkage and optional GitHub issue. Use when adding coordination tasks, linking a blueprint WO, or mirroring a GitHub issue locally.
+description: File a taskwarrior task with a verified project slug and blueprint/GitHub linkage. Use when logging cross-session follow-ups, confirming a project slug, or mirroring a GitHub issue.
 args: "[description] [project:<name>] [--no-project] [due:<date>] [scheduled:<date>] [wait:<date>] [recur:<freq>] [until:<date>]"
-allowed-tools: Bash(task *), Bash(git config *), Bash(git rev-parse *), Bash(gh auth *), Bash(gh issue *), Bash(gh api *), Bash(bash *), Read, TodoWrite
+allowed-tools: Bash(task *), Bash(jq *), Bash(git config *), Bash(git rev-parse *), Bash(gh auth *), Bash(gh issue *), Bash(gh api *), Bash(bash *), Read, TodoWrite
 argument-hint: short task description
 created: 2026-04-24
-modified: 2026-06-20
-reviewed: 2026-06-20
+modified: 2026-08-19
+reviewed: 2026-08-19
 ---
 
 # /taskwarrior:task-add
@@ -43,7 +43,7 @@ Parse `$ARGUMENTS`:
 - Optional `--no-project` to file the task without any project (cross-cutting work).
 - Optional inline `bpid:WO-012` / `bpdoc:docs/wo/012.md` / `bpms:M6` / `ghid:145` / `ghpr:99` fields.
 - Optional native scheduling fields (prefer these over manual `+blocked*` bookkeeping):
-  - `due:<date>` — deadline. Feeds urgency and surfaces the task as `+DUE` / `+OVERDUE` in `task-coordinate` / `task-status`.
+  - `due:<date>` — deadline. Feeds urgency and surfaces the task as `+DUE` / `+OVERDUE` in `task-coordinate` / `task-status`. Set it only for real deadlines — the queue is a queue, not a calendar.
   - `scheduled:<date>` — earliest start. The task only becomes `+READY` once this date passes, so future work stays out of dispatch candidates.
   - `wait:<date>` — hide the task entirely until the date. Use for "blocked on merge until X" instead of a hand-managed `+blocked_on_merge` tag — taskwarrior auto-unhides it.
   - `recur:<freq>` (e.g. `weekly`, `monthly`) with a `due:` — repeating maintenance chores. Requires `due:`.
@@ -78,6 +78,34 @@ Cross-check the resolved name against `Known projects` and reuse the
 exact spelling when it matches (case-insensitive) — taskwarrior treats
 `MyRepo` and `myrepo` as different projects.
 
+#### `project:` is a PREFIX match — a populated result does not prove the slug
+
+`task project:comfyui list` returns every task in `comfyui-nodes`,
+`comfyui-touch-connect`, and any other project starting with that string.
+Nothing in the output says so. A slug you just invented therefore *looks*
+verified the moment a sibling shares its prefix, which is the whole trap:
+the confirming evidence and a false positive are byte-identical.
+
+> Observed twice (2026-08-08, comfyui-nodes). A commit titled "point the
+> backlog at `project:comfyui`, **the slug that exists**" moved the documented
+> slug to the one project that was nearly empty — 60 tasks sat under
+> `comfyui-nodes`, 1 under `comfyui` — because `task project:comfyui list`
+> showed all 60. A later session read that doc, filed four follow-ups into the
+> near-empty sibling, and only caught it when a survey script printed the
+> per-project counts side by side.
+
+**To check a slug is real, read the exact value — never a filter that matches
+its own prefix:**
+
+```sh
+task export | jq -r '[.[].project] | group_by(.) | map({p:.[0], n:length}) | sort_by(-.n)[]'
+```
+
+Corollaries: prefer `task <uuid> modify project:<slug>` when consolidating
+(numeric ids shift); and a *new* project slug is silently created on first
+`add`, so a typo never errors — it just starts a parallel backlog that the
+prefix match then hides.
+
 ## Execution
 
 Execute this workflow:
@@ -102,6 +130,15 @@ bash "${CLAUDE_SKILL_DIR}/../../scripts/ensure-udas.sh"
 Identity UDAs are not set by `task-add` itself — `/taskwarrior:task-claim`
 stamps them when an agent picks the task up. The same script backs the
 SessionStart drift-probe, so the install logic is single-sourced.
+
+#### Bootstrap — no rc file
+
+If `task` errors with "Cannot proceed without rc file":
+
+```sh
+mkdir -p ~/.local/share/task
+echo "data.location=~/.local/share/task" > ~/.taskrc
+```
 
 ### Step 2: Detect GitHub mode
 

--- a/taskwarrior-plugin/skills/task-claim/SKILL.md
+++ b/taskwarrior-plugin/skills/task-claim/SKILL.md
@@ -5,8 +5,8 @@ args: "<task-id> [--no-coworker-marker] [--force]"
 allowed-tools: Bash(task *), Bash(git rev-parse *), Bash(git branch *), Bash(git config *), Bash(hostname *), Bash(jq *), Bash(bash *), Read, TodoWrite
 argument-hint: task id (required)
 created: 2026-05-09
-modified: 2026-05-22
-reviewed: 2026-05-22
+modified: 2026-08-19
+reviewed: 2026-08-19
 ---
 
 # /taskwarrior:task-claim
@@ -85,6 +85,12 @@ Read the JSON. Decide:
 | `start` is set and `--force` not passed | Abort. Report current `agent` / `pid` / `host` / `branch` so the user can either `--force` or pick another task. |
 | `start` is set and `--force` passed | Annotate with takeover notice (Step 6) and proceed. |
 | `start` is unset | Proceed cleanly. |
+
+#### Read a task's annotations before working it
+
+`task list` truncates them, hiding what past sessions established:
+`task <uuid> export | jq -r '.[0].annotations[].description'`. 2026-08: a
+session re-derived and announced a finding task 48517b52 already held.
 
 ### Step 3: Coworker-check claim (default on)
 


### PR DESCRIPTION
Marketplace half of [laurigates/dotfiles#353](https://github.com/laurigates/dotfiles/issues/353). Paired with laurigates/dotfiles#378, which trims the rules these skills replace — **merge this one first**, since those stubs point here.

## What lands

**Seven new skills**, each the verbatim body of a rule that previously loaded into every session of every project:

| Skill | Promoted from | Trigger |
|---|---|---|
| `git-plugin:git-merge-hazards` | `pr-merge-hazards.md` | merging a PR, a stacked chain, or over red CI |
| `git-plugin:git-issue-scoping` | `read-issue-thread-before-contributing.md` | scoping a contribution from a GitHub issue |
| `git-plugin:git-upstream-fix-check` | `verify-upstream-before-patching.md` | patching vendored / tarball-installed / forked code |
| `git-plugin:git-repo-delete-check` | `repo-deletion-safety.md` | about to `rm -rf` a git checkout |
| `documentation-plugin:docs-verify-machine-facts` | `verify-machine-facts-before-publishing.md` | org docs quoting values read off your own host |
| `documentation-plugin:docs-single-source` | `documentation-authoring.md` | writing or restructuring docs |
| `documentation-plugin:docs-fetch-fallbacks` | `tool-use-patterns.md` (WebFetch section) | a doc or GitHub URL fetch failed |
| `code-quality-plugin:code-scaffold-backport` | `scaffold-fix-backport.md` | fixing something a generator produced |

**Two merges into existing skills** — the rule was already largely covered, so nothing new was created:

- `taskwarrior-plugin:task-add` / `task-claim` ← the `project:` prefix-match trap, the no-rc bootstrap, read-annotations-first
- `agent-patterns-plugin:parallel-agent-dispatch` ← the fan-out burst-limit and usage-limit recovery sections

**Two PreToolUse hooks** (`hooks-plugin`), turning prose into deterministic enforcement:

| Hook | Tier | Guards |
|---|---|---|
| `repo-deletion-safety.sh` | **block** (exit 2) | `rm -rf` of a checkout whose history exists nowhere else; self-extinguishing once you push or write the tar backup |
| `branch-base-guard.sh` | **nudge** (`ask`) | cutting a branch from a local default branch that is ahead of its remote (`git-hazards.md` trap #2) |

The block/nudge split is argued rather than assumed, per `.claude/rules/hook-block-vs-nudge.md`. Branch-base is a nudge because nothing it prevents is irreversible, branch creation is high-frequency, and local-main-ahead is the *normal* steady state in main-branch-dev repos — a hard block there would be permanently disabled.

## Why "cannot have drifted" is checkable, not hoped

Every body was moved by script, never retyped, then diffed against a pre-change snapshot. The only edits inside a moved body are sibling-rule path requalifications (`git-hazards.md` → `~/.claude/rules/git-hazards.md`), since the text no longer sits beside those rules. Each is listed in its commit.

One paragraph was **deliberately not** copied verbatim: the resident `tool-use-patterns.md` claimed `resumeFromRunId` replays completed agents from cache at zero cost, which contradicts `agent-coworker-detection.md` — a succeeded `isolation: "worktree"` agent is re-executed on resume and re-fires its side effects (duplicate PR #1858 of #1857, issue #1868). Promoting it verbatim would have carried a live bug into the skill.

## Regression the promotion would otherwise have caused

`git-plugin:git-issue` Step 2 fetched `--json title,body,state,assignees,labels` — body only, no comments. That is verbatim the trap `read-issue-thread-before-contributing` prevented on every turn *while it was resident*. Demoting it to a pull-loaded skill without fixing the highest-traffic issue entry point would have been a net regression, so `comments` is added and the step points at the scoping skill.

## Verification

| Check | Result |
|---|---|
| `check-docs-index.sh --strict` | `STATUS=OK ISSUE_COUNT=0` (was WARN/9) |
| `check-feature-flags-catalog.sh` | `STATUS=OK MISSING_COUNT=0` (was **ERROR/6** — the new hooks' flags were uncatalogued) |
| `check-plugin-readme-currency.sh` | `STATUS=OK ISSUE_COUNT=0` |
| `check-branch-containment-guidance.sh` | `STATUS=OK ISSUE_COUNT=0` |
| `test-repo-deletion-safety.sh` | 57 passed, 0 failed |
| `test-branch-base-guard.sh` | 59 passed, 0 failed |
| `lint-shell-scripts.sh` | 0 errors; 9 warnings, all pre-existing |
| `shellcheck` (both new hooks + tests) | clean, no suppressions |

Both hook suites include mutation checks — hardcoding `main` as the default branch fails 3 assertions, and disabling the suggested-fix exemption fails 11 — so the guards are provably load-bearing rather than vacuously green.

## Known-red, pre-existing, not from this change

`hooks-plugin/hooks/test-bash-antipatterns.sh` fails 19 assertions in this container. Cause: the hook probes `command -v sg` as an ast-grep fallback and finds `/usr/bin/sg`, which is shadow-utils' "run a command with a different group ID" — so structural detection silently no-ops and the blocks fail open. `bash-antipatterns.sh` and its test are byte-identical to `origin/main`. Worth a separate issue: the `sg` probe should verify the binary is actually ast-grep.

## Left for a follow-up

- `docs/diagrams/plugin-relationships.svg` not regenerated — `d2` is not installed here. The `.d2` source is correct; the committed `.svg` still renders the old counts.
- `documentation-plugin/.claude-plugin/plugin.json` still carries a `knowledge-graph` keyword for a skill that has no directory (the README row is removed in this PR).
- `repo-deletion-safety.sh`'s block message still inlines the three-option remediation that also lives in `git-repo-delete-check`. Trimming it collides with two things — option 2's tar command is what makes the block self-extinguishing, and the test suite pins all three options by literal — so it needs a hook+test change, not a text edit.

Refs laurigates/dotfiles#353