### PR TITLE
fix(hooks-plugin): diagnose a shell-variable --repo, not just a shell-variable PR selector, in external-pr-merge-guard

### DIFF
--- a/hooks-plugin/hooks/external-pr-merge-guard.sh
+++ b/hooks-plugin/hooks/external-pr-merge-guard.sh
@@ -66,6 +66,13 @@ deny() {
 # ---------------------------------------------------------------------------
 PR_SELECTOR=""
 PR_REPO=""
+# Set to a backtick when the structural scan detects that a bare backtick
+# command substitution mid-argument truncated the merge statement (see the
+# TRUNCATED marker below) — folded into the shell-variable/backtick case
+# switch below alongside PR_SELECTOR and PR_REPO so a truncated value denies
+# for the same reason an unresolved `$var` does, instead of resolving (and
+# possibly ALLOWing) against the wrong PR or repo.
+TRUNC_MARK=""
 
 case "$TOOL_NAME" in
   mcp__github__merge_pull_request)
@@ -300,7 +307,27 @@ case "$TOOL_NAME" in
             if (nxt == "" || nxt == " " || nxt == "\t") {
               segm = substr(cm, e); sego = substr(co, e)
               gsub(/\n/, " ", segm); gsub(/\n/, " ", sego)
+              # Was this statement cut short by a BARE backtick used as a VALUE
+              # among the merge arguments themselves (gh pr merge 5 -R "cmd"
+              # with backticks instead of quotes around cmd), rather than one
+              # that legitimately WRAPS the whole invocation (backticks around
+              # the entire "gh pr merge 5", already handled: selector/repo
+              # come through clean there because the backtick delimits the
+              # statement, not a mid-argument value)? A wrapping backtick
+              # immediately PRECEDES this statement (buf[a-1] == BT); a
+              # value-truncating one does not. Losing the distinction silently
+              # drops everything after the backtick, including a --repo/-R
+              # value or the selector itself, so gh pr view ends up resolving
+              # the WRONG PR or repo and can come back trusted while the real,
+              # substituted target is not.
+              trunc = 0
+              if (b < n) {
+                delimc = substr(buf, b + 1, 1)
+                prevc = (a > 1) ? substr(buf, a - 1, 1) : ""
+                if (delimc == BT && prevc != BT) trunc = 1
+              }
               print "KIND=merge"; print "SEG=" sego; print "MSEG=" segm
+              if (trunc) print "TRUNCATED=1"
               exit
             }
           }
@@ -341,6 +368,11 @@ case "$TOOL_NAME" in
         # token) and read back from the original at the same offsets.
         MERGE_SEG=$(printf '%s\n' "$DETECT" | sed -n 's/^SEG=//p')
         MERGE_MSEG=$(printf '%s\n' "$DETECT" | sed -n 's/^MSEG=//p')
+        # A bare backtick truncated the statement mid-argument (see the awk
+        # comment above the TRUNCATED marker) — mark it so PR_SELECTOR/PR_REPO,
+        # however they parse out below, are treated as unresolved rather than
+        # as clean values that happen to be short.
+        if printf '%s\n' "$DETECT" | grep -q '^TRUNCATED=1$'; then TRUNC_MARK='`'; fi
         # Passed via the environment, not `awk -v`: -v applies backslash escape
         # processing to the value, which would mangle a command containing one.
         PARSED=$(SEG="$MERGE_SEG" MSEG="$MERGE_MSEG" awk '
@@ -411,6 +443,19 @@ case "$TOOL_NAME" in
     ;;
 esac
 
+# A bare backtick truncated the merge statement mid-argument (see the
+# TRUNCATED marker in the structural pass above). Deny BEFORE attempting any
+# `gh pr view` lookup below: PR_SELECTOR/PR_REPO at this point may be a clean,
+# resolvable value that is simply the WRONG one (e.g. empty, meaning "current
+# branch's PR" — not the PR the substituted value actually names), so letting
+# the lookup proceed could resolve successfully against the wrong PR/repo and
+# come back trusted while the real, substituted target is not.
+if [ -n "$TRUNC_MARK" ]; then
+  WHAT="${PR_REPO:+$PR_REPO}${PR_SELECTOR:+#$PR_SELECTOR}"
+  [ -z "$WHAT" ] && WHAT="the current branch's PR"
+  deny "Refusing to merge ${WHAT}: a backtick command substitution in the PR selector or --repo/-R value cut off part of this merge command before this hook could read it, so this hook cannot tell whose PR it is (and cannot even be sure it would be checking the right PR or repo). Merges of PRs authored by anyone other than the repo owner or a bot are not permitted from an agent. Resolve the command substitution to its literal value first, then merge with literal values one at a time — each will be checked individually."
+fi
+
 # ---------------------------------------------------------------------------
 # Resolve the author and classify.
 # ---------------------------------------------------------------------------
@@ -437,9 +482,17 @@ WHAT="${PR_REPO:+$PR_REPO}${PR_SELECTOR:+#$PR_SELECTOR}"
 [ -z "$WHAT" ] && WHAT="the current branch's PR"
 
 if [ -z "$META" ]; then
-  case "$PR_SELECTOR" in
+  # Test BOTH the selector and the repo for an unresolved shell variable or
+  # command substitution — either one, alone, makes `gh pr view` unable to
+  # resolve who authored the PR. Checking $PR_SELECTOR alone missed the case
+  # where the selector is a literal PR number but --repo/-R carries a shell
+  # variable (`gh pr merge 464 -R $R`): that used to fall through to the
+  # generic branch below and get blamed on "bad PR number, wrong repo, or no
+  # network" — plausible-sounding but wrong, and its retry hint echoed the
+  # unexpanded $R right back at the caller (issue #2449).
+  case "${PR_SELECTOR}${PR_REPO}" in
     *'$'*|*'`'*)
-      deny "Refusing to merge ${WHAT}: the PR selector is a shell variable, so this hook cannot tell whose PR it is. Merges of PRs authored by anyone other than the repo owner or a bot are not permitted from an agent. Resolve the PR numbers first (gh pr list --json number,author) and merge them one literal number at a time — each will be checked individually." ;;
+      deny "Refusing to merge ${WHAT}: the PR selector or repo is a shell variable, so this hook cannot tell whose PR it is. Merges of PRs authored by anyone other than the repo owner or a bot are not permitted from an agent. Resolve shell variables to their literal values first (gh pr list --json number,author to find PR numbers; check which repo you mean if --repo/-R was a variable), then merge with literal values one at a time — each will be checked individually." ;;
     *)
       deny "Refusing to merge ${WHAT}: could not read the PR's author (gh pr view returned nothing — bad PR number, wrong repo, or no network). 'Cannot verify' is not 'safe', so this is denied rather than allowed. Check the PR exists and is reachable (gh pr view ${PR_SELECTOR:-} ${PR_REPO:+--repo $PR_REPO}), then retry." ;;
   esac

--- a/hooks-plugin/hooks/test-external-pr-merge-guard.sh
+++ b/hooks-plugin/hooks/test-external-pr-merge-guard.sh
@@ -126,6 +126,10 @@ ck "unrelated tool"        ALLOW "$(run '{"tool_name":"Read","tool_input":{"file
 
 echo "== trusted authors merge freely =="
 ck "own PR"  ALLOW "$(STUB_AUTHOR=laurigates run "$(bash_json 'gh pr merge 42 --squash')")"
+# Case C (issue #2449): fully literal selector AND literal --repo must still
+# be permitted silently — the fix must not regress the non-denial path.
+ck "own PR, literal --repo (case C)" ALLOW \
+   "$(STUB_AUTHOR=laurigates run "$(bash_json 'gh pr merge 123 --repo laurigates/claude-plugins --squash')")"
 export STUB_AUTHOR='app/laurigates-release-please' STUB_ISBOT=true
 ck "bot, gh-pr-view rendering (app/, is_bot true)" ALLOW "$(run "$(bash_json 'gh pr merge 42 --squash')")"
 export STUB_AUTHOR='dependabot[bot]' STUB_ISBOT=false
@@ -237,6 +241,40 @@ ck "inside backticks, assigned"       DENY "$(run "$(bash_json 'X=`gh pr merge 2
 ck "inside backticks, as an argument" DENY "$(run "$(bash_json 'echo `gh pr merge 2231`')")"
 ck "inside \$( ) substitution"        DENY "$(run "$(bash_json 'result=$(gh pr merge 2231)')")"
 
+echo "== a bare backtick VALUE truncates the statement, unlike a WRAPPING one (issue #2449) =="
+# A backtick used to compute a --repo/-R value (or the selector itself) is NOT
+# the same as backticks wrapping the WHOLE invocation (denied above via clean
+# selector extraction, since the wrapping backtick delimits the statement
+# boundary, not a mid-argument value). Before this fix, a value-position
+# backtick silently truncated the statement and dropped everything after it —
+# so the hook went on to query `gh pr view` for the WRONG PR/repo (empty
+# selector reads as "current branch", empty repo reads as "cwd"), which could
+# resolve successfully and ALLOW while the real, substituted target was never
+# checked. The regression assertion is therefore not just DENY but that
+# `gh pr view` was never even called — a bare DENY here could still hide a
+# wrong-target lookup underneath it.
+BT_LOG="$TMPDIR/backtick.log"
+: > "$BT_LOG"
+STUB_LOG="$BT_LOG" run "$(bash_json 'gh pr merge 464 -R `echo owner/repo` --squash')" >/dev/null
+unset STUB_LOG
+ck "backtick VALUE in --repo/-R"      DENY "$LAST_VERDICT"
+ck_reason "explains the truncation"   "backtick"
+if grep -q '^pr view' "$BT_LOG"; then
+    printf '  FAIL backtick-in-repo truncation still queried gh pr view (wrong-target lookup)\n'; FAIL=$((FAIL + 1))
+else
+    printf '  ok   backtick-in-repo truncation denied before any gh pr view lookup\n'; PASS=$((PASS + 1))
+fi
+
+: > "$BT_LOG"
+STUB_LOG="$BT_LOG" run "$(bash_json 'gh pr merge `echo 464` --repo owner/repo --squash')" >/dev/null
+unset STUB_LOG
+ck "backtick VALUE as the selector"   DENY "$LAST_VERDICT"
+if grep -q '^pr view' "$BT_LOG"; then
+    printf '  FAIL backtick-selector truncation still queried gh pr view (wrong-target lookup)\n'; FAIL=$((FAIL + 1))
+else
+    printf '  ok   backtick-selector truncation denied before any gh pr view lookup\n'; PASS=$((PASS + 1))
+fi
+
 echo "== a wrapper that RUNS the merge does not hide it =="
 # Wrapper flags that take a SEPARATE value push the command word past the point
 # a flags-only stripper reaches; a wrapper executes whatever follows it.
@@ -341,6 +379,33 @@ ck "gh api user fails"     DENY "$(STUB_NO_ME=1 run "$(bash_json 'gh pr merge 22
 run "$(bash_json 'for n in 1 2; do gh pr merge $n --squash; done')" >/dev/null
 ck "shell-variable selector"         DENY "$LAST_VERDICT"
 ck_reason "explains the loop case"   "shell variable"
+# Case A (issue #2449): a LITERAL PR number but a shell-variable --repo/-R.
+# `gh pr view` can't resolve `-R $R` either, but the old code switched only on
+# $PR_SELECTOR (literal "464" here) and fell into the generic "bad PR number,
+# wrong repo, or no network" branch — plausible-sounding but wrong, and its
+# retry hint echoed the unexpanded `$R` straight back at the caller.
+# shellcheck disable=SC2016  # the literal $R must reach the hook unexpanded
+run "$(bash_json 'gh pr merge 464 -R $R --squash --delete-branch')" >/dev/null
+ck "shell-variable --repo (case A)"        DENY "$LAST_VERDICT"
+ck_reason "explains the repo case"         "shell variable"
+case "$LAST_REASON" in
+    *'bad PR number, wrong repo, or no network'*)
+        printf '  FAIL case A got the generic "bad PR number" message, not the shell-variable one\n'
+        FAIL=$((FAIL + 1)) ;;
+    *) printf '  ok   case A did not get the generic message\n'; PASS=$((PASS + 1)) ;;
+esac
+# The old generic branch's retry hint was a literal copy-pasteable command —
+# `gh pr view ${PR_SELECTOR:-} ${PR_REPO:+--repo $PR_REPO}` — which, given a
+# variable --repo, rendered as `gh pr view 464 --repo $R`: a command that, run
+# literally, still references an unexpanded (and out-of-scope) $R. The WHAT
+# header ("Refusing to merge $R#464: ...") legitimately echoes the caller's
+# text for identification — only a *suggested command* containing the raw
+# variable is the bug this checks for.
+case "$LAST_REASON" in
+    *'--repo $R'*|*'gh pr view'*'$R'*)
+        printf '  FAIL case A retry hint echoes the unexpanded $R as a runnable command\n'; FAIL=$((FAIL + 1)) ;;
+    *) printf '  ok   case A retry hint does not echo unexpanded $R as a runnable command\n'; PASS=$((PASS + 1)) ;;
+esac
 unset STUB_AUTHOR STUB_NUM STUB_TITLE
 
 echo "== operator escape hatch =="


### PR DESCRIPTION
## Summary

`hooks-plugin/hooks/external-pr-merge-guard.sh` fails closed (correctly) when
`gh pr view` can't resolve a PR, but its diagnostic message only checked
`$PR_SELECTOR` for an unresolved shell variable — not `$PR_REPO`, which is
extracted just a few lines earlier and already rendered into the `WHAT`
context line.

**Case A from #2449** (`gh pr merge 464 -R $R --squash --delete-branch` —
literal PR number, variable repo) fell into the *generic* "bad PR number,
wrong repo, or no network" branch instead of the tailored "shell variable"
one, and that generic branch's retry hint echoed the unexpanded `$R` straight
back at the caller as part of a suggested command to run.

## Fix

- Switch on `"${PR_SELECTOR}${PR_REPO}"` instead of `"$PR_SELECTOR"` alone, so
  either one containing a shell variable (`$…`) or backtick trips the
  tailored message. Reworded the message to cover both the selector and the
  repo.

## A second gap found while auditing the issue's own suggested edge cases

The issue asked me to also check `--repo=$VAR` and command substitution
`$(...)` in either position. Both of those turned out to already be handled
(if a little accidentally for `$(...)`, via a leftover `$` character left in
the captured token when `(` splits the parser's statement boundary).

But auditing that same code path surfaced a **more serious, related gap**: a
**bare backtick** used as a `--repo`/`-R` or selector *value* (as opposed to
backticks *wrapping the whole `gh pr merge …` invocation*, which the parser
already handles correctly by design) truncates the structural parser's
statement mid-argument and silently drops everything after it. Before this
fix:

```
gh pr merge 464 -R `echo owner/repo` --squash
```

resolved to `PR_SELECTOR=464`, `PR_REPO=""` — the hook then queried
`gh pr view 464` against the **current-branch repo**, not the real target.
If that lookup happened to resolve to a trusted PR, the guard would **allow**
the command while the real, substituted target went completely unchecked —
a fail-*open*, not fail-closed. Confirmed via a local repro against the
unpatched hook (empty `gh` call log, silent ALLOW).

Fixed by adding a `TRUNCATED` marker to the awk structural pass: a
value-truncating backtick is distinguished from a legitimately *wrapping*
one by checking whether the merge statement itself began immediately after
an opening backtick (wrapping — safe, selector/repo extraction stays clean)
versus starting elsewhere and hitting a backtick mid-argument (truncating —
now denied *before* any `gh` lookup is attempted, so there's no wrong-target
query at all).

## Testing

- TDD: added the failing regression cases first (confirmed red against the
  unpatched hook via `git stash`), then applied the fix, confirmed green.
- `bash hooks-plugin/hooks/test-external-pr-merge-guard.sh` — **116 passed, 0
  failed** (105 pre-existing + 11 new: 3 for Case A's message/retry-hint, 1
  for Case C's literal-repo allow-path regression guard, 5 for the backtick
  truncation gap, plus their `ck_reason`/lookup-log sub-assertions).
- `bash scripts/lint-shell-scripts.sh` — 0 errors, 0 warnings.
- Manually confirmed (outside the test file) that `--repo=$VAR` and
  `$(...)` in either the selector or repo position were already denied
  correctly with no wrong-target `gh` lookup.

## Acceptance criteria

- [x] Case A (`gh pr merge 464 -R $R --squash --delete-branch`) now gets the
      tailored "shell variable" message.
- [x] Case B (`gh pr merge $N --repo owner/repo --squash`) still gets the
      tailored message (no regression — pre-existing test).
- [x] Case C (fully literal `gh pr merge 123 --repo owner/repo --squash`) is
      still permitted with no output (added an explicit regression test for
      this, since the literal-`--repo` allow path had no prior coverage).
- [x] The retry hint no longer echoes an unexpanded shell variable back as a
      runnable command.
- [x] `test-external-pr-merge-guard.sh` passes, extended with regression
      cases for Case A and the backtick-truncation gap.
- [x] TDD: failing tests added first, confirmed red, then fixed, confirmed
      green.

## Files touched

Only the two files named in scope:
- `hooks-plugin/hooks/external-pr-merge-guard.sh`
- `hooks-plugin/hooks/test-external-pr-merge-guard.sh`

Fixes #2449


---
_Generated by [Claude Code](https://claude.ai/code/session_01RJMRBgk1DpgZWYyQYSFCxH)_