### PR TITLE
docs(git-plugin): cover the inverse direction in release-please-protection

### DIFF
--- a/git-plugin/README.md
+++ b/git-plugin/README.md
@@ -76,7 +76,7 @@ Three composable skills that can be invoked individually or combined based on us
 | `github-pr-title` | Craft effective PR titles using conventional commit format |
 | `git-derive-docs` | Derive undocumented rules, PRDs, ADRs, PRPs from git commit history |
 | `release-please-configuration` | Release-please **monorepo** strategy — component tags, per-package extra-files, tag migration (single-repo standards live in configure-plugin) |
-| `release-please-protection` | Prevent manual edits to release-please managed files |
+| `release-please-protection` | Prevent manual edits to release-please managed files, and keep generated artifacts from depending on them |
 | `release-please-pr-workflow` | Batch merge release-please PRs with conflict handling |
 | `git-fork-workflow` | Fork management, upstream sync, divergence detection, cross-fork PRs |
 

--- a/git-plugin/skills/release-please-protection/SKILL.md
+++ b/git-plugin/skills/release-please-protection/SKILL.md
@@ -1,9 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-05-09
+modified: 2026-08-20
 reviewed: 2026-04-25
 name: release-please-protection
-description: "Block manual edits to release-please files (CHANGELOG, version fields). Use when editing changelogs, bumping versions, or releasing to avoid conflicting with automation."
+description: "Block manual edits to release-please files (CHANGELOG, version fields), and stop committed generated artifacts from deriving from them. Use when editing changelogs, bumping versions, releasing, or wiring a version file into a generated doc/PDF/header."
 user-invocable: false
 allowed-tools: Read, Grep, Glob
 ---
@@ -232,6 +232,68 @@ chore(scope): brief description
 Maintenance work that doesn't affect functionality.
 Examples: dependency updates, refactoring, docs.
 ```
+
+## The Inverse Direction: Never Generate a Committed Artifact From a Managed File
+
+Everything above protects release-please's files **from** you. This protects your
+files **from** them, and it is the direction nobody guards.
+
+A version file is written by the release pipeline on a cadence you do not
+control. So when a **committed, generated artifact** derives from one — a
+rendered PDF, a generated header, a badge, a docs page baked at build time — a
+release bump silently invalidates it. Path-filtered CI makes it worse: the
+freshness check almost certainly does not list the version file among its
+trigger paths, so it never runs and never reports the staleness.
+
+Then the loop closes. Regenerating the artifact is itself a commit; if its type
+is releasable (or the repo releases on any change to that package), release-please
+turns the fix into the **next** release, which invalidates the artifact again:
+
+| Step | What happens |
+|---|---|
+| 1 | Release bumps the version file |
+| 2 | The committed artifact now renders the *previous* version |
+| 3 | Regenerating it is a commit release-please can release |
+| 4 | → step 1 |
+
+The tell is a repo where someone periodically lands a "resync the generated
+docs" commit and nobody can say why it keeps coming back.
+
+### Do not fix it by widening the trigger paths
+
+The obvious fix — add the version file to the freshness check's `on: paths:` —
+is wrong. The guard would then run on **every release PR and fail it**, because
+that PR's committed artifact genuinely predates the version it introduces. An
+automated release becomes a hand-held one: regenerate, push, then merge.
+
+### The fix
+
+Prefer, in order:
+
+1. **Remove the version from the artifact.** Usually the artifact's real payload
+   (wiring, API surface, instructions) has nothing to do with the release
+   number. Cheapest, and it deletes the failure mode instead of managing it.
+2. **Regenerate inside the release commit** — release-please `extra-files` or a
+   post-bump hook — so the artifact and the bump land atomically. Keeps the
+   version; most moving parts.
+
+Reading the version at *compile* time does **not** fix it on its own: the
+committed artifact still embeds the old string.
+
+### The test
+
+Before letting any input feed a generated, committed artifact, ask: **who writes
+this file — a human, or the release pipeline?** If the pipeline owns it, it does
+not belong among the inputs. Apply the same question to a scaffold or generator
+template, or the next generated artifact reintroduces the coupling.
+
+> Evidence: `laurigates/mcu-tinkering-lab#439`. A Typst build guide printed a
+> version generated from `version.txt`. The drift guard's trigger paths covered
+> the C header and the generated `.typ` but not `version.txt`, so five separate
+> hand-resyncs landed over three weeks and each one minted the release that
+> staled the guide again. Fixed in `laurigates/mcu-tinkering-lab#470` by dropping
+> the version from the generated file, verified by bumping the version and
+> confirming both the generated file and the PDF came out byte-identical.
 
 ## Integration with Other Skills
 


### PR DESCRIPTION
## What

Adds a section to `git-plugin:release-please-protection` covering the dependency direction it currently misses, and updates the skill description + README catalog line to match.

## Why

The skill today protects release-please's files **from** being edited. It says nothing about the opposite: a committed, **generated** artifact deriving **from** a managed version file. That direction is unguarded, and it forms a loop that does not converge on its own:

1. Release bumps the version file
2. The committed artifact now renders the *previous* version
3. Regenerating it is itself a releasable commit
4. → 1

Path-filtered CI is what hides it. A freshness/drift check almost never lists the version file among its `on: paths:`, so it never runs and never reports the staleness — the artifact self-heals only when an unrelated PR happens to touch a file that *is* on the trigger paths. The tell in a repo is a periodic "resync the generated docs" commit that nobody can explain.

## What the section adds

- The loop, as a table, so it's recognizable from the symptom
- **Why the obvious fix is wrong**: adding the version file to the trigger paths makes the guard fail *every release PR*, whose artifact genuinely predates the version it introduces — an automated release becomes a hand-held one
- The two fixes that work (drop the version from the artifact; regenerate inside the release commit via `extra-files`/post-bump), ranked
- The one that looks like a fix and isn't: reading the version at compile time still leaves the old string in the *committed* artifact
- A one-question test for any new input to a generated artifact — *who writes this file, a human or the release pipeline?* — and a note to apply it to the scaffold/generator too, or the next generated artifact reintroduces the coupling

## Evidence

`laurigates/mcu-tinkering-lab#439`. A Typst build guide printed a version generated from `version.txt`. The drift guard's trigger paths covered the C header and the generated `.typ` but not `version.txt`, so **five separate hand-resyncs landed over three weeks**, each one minting the release that staled the guide again. Landed as `laurigates/mcu-tinkering-lab#470`, which dropped the version from the generated file — verified by bumping the version and confirming both the generated file and the compiled PDF came out byte-identical, with a negative control proving the drift guard could still fail on a real pin change.

## Scope

Documentation only, one existing skill. No new skill, no behavior change, no permission or hook changes. `Update Over Add`: this is a missing direction in a skill that already owns the topic, not its own subject.
