### PR TITLE
feat(feedback-plugin): log skill invocations for the slow loop to target

### DIFF
--- a/.claude/rules/plugin-usage-telemetry.md
+++ b/.claude/rules/plugin-usage-telemetry.md
@@ -1,10 +1,11 @@
 ---
 created: 2026-08-15
-modified: 2026-08-15
-reviewed: 2026-08-15
+modified: 2026-08-20
+reviewed: 2026-08-20
 paths:
   - "health-plugin/**"
   - "evaluate-plugin/**"
+  - "feedback-plugin/**"
 ---
 # `pluginUsage.usageCount` Counts Hook Fires, Not Plugin Value
 
@@ -95,8 +96,41 @@ control matters (`~/.claude/rules/never-fabricate-test-identifiers.md`).
 reads agent dispatch from `Agent`/`Task` `subagent_type` events; this field is
 the per-call complement, not a gap.
 
+## Transcripts expire — the durable signal is `~/.claude/skill-usage.jsonl`
+
+Transcript mining is correct but **bounded by retention**. Measured 2026-08-20:
+1,134 files under `~/.claude/projects` reached back only to 2026-07-22, and a
+full sweep of them found 57 distinct skills used out of 420 in the marketplace.
+That 363-skill remainder is a *floor*, not a verdict — anything used before the
+window is indistinguishable from never used.
+
+`feedback-plugin/hooks/skill-usage-log.sh` (`PreToolUse(Skill|SlashCommand)` +
+`UserPromptSubmit`, **opt-in** via `CLAUDE_HOOKS_ENABLE_SKILL_USAGE_LOG=1`)
+appends one JSONL record per invocation to `~/.claude/skill-usage.jsonl`, which
+no retention policy trims. `feedback-plugin/scripts/skill_usage_report.py` reads
+it — merging the expiring transcripts on `--include-transcripts` — and
+`friction-learner` Step 1b consumes that to target which skills the weekly slow
+loop analyses. It lives in `feedback-plugin` rather than `hooks-plugin` because
+the log has one consumer and that consumer is the feedback loop; a telemetry
+file nothing reads is the failure this rule already documents.
+
+Two traps it exists to avoid re-deriving:
+
+- **Filesystem `atime` is not a usage signal on macOS.** Reading a file does not
+  update `atime` on this APFS volume (verified: write, sleep 2s, `cat`, `atime`
+  unchanged), and all 2,038 `SKILL.md` files under `~/.claude/plugins` have
+  `atime == mtime` — install time, not use time. Zero files anywhere have
+  `atime > mtime`.
+- **A `PreToolUse` hook alone under-counts.** A user-typed `/plugin:skill` never
+  reaches a tool; the client expands it into the prompt, so only
+  `UserPromptSubmit` sees it. In the sweep above, 11 of the 57 used skills
+  appeared *only* by that path — `session-end`, `git-issue`, `project-refocus`
+  and `health-check` among them.
+
 ## Related
 
+- `feedback-plugin/hooks/skill-usage-log.sh` — the durable per-invocation log described above
+- `feedback-plugin/scripts/skill_usage_report.py` — its consumer; `friction-learner` Step 1b
 - `health-plugin:health-check` — `--scope=usage` (transcript mining) and `--scope=runtime` (`~/.claude.json` bloat); neither touches the counter
 - `.claude/rules/skill-evaluation.md` — how skill *effectiveness* is actually measured (with-skill vs baseline delta), the question the counter looks like it answers
 - `.claude/rules/context-engineering.md` — the catalog-cost question a delivery signal would inform

--- a/feedback-plugin/.claude-plugin/plugin.json
+++ b/feedback-plugin/.claude-plugin/plugin.json
@@ -15,7 +15,8 @@
     "skill-quality",
     "github-issues",
     "continuous-improvement",
-    "friction-learner"
+    "friction-learner",
+    "skill-usage"
   ],
   "hooks": {
     "PreToolUse": [
@@ -25,6 +26,27 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/check-open-pr.sh",
+            "timeout": 15
+          }
+        ]
+      },
+      {
+        "matcher": "Skill|SlashCommand",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/skill-usage-log.sh",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/skill-usage-log.sh",
             "timeout": 15
           }
         ]

--- a/feedback-plugin/README.md
+++ b/feedback-plugin/README.md
@@ -14,6 +14,53 @@ Session feedback analysis — capture per-session skill bugs as GitHub issues, a
 |-------|-------------|
 | `friction-learner` | The **slow loop**: read open `session-feedback` issues as pre-registered signal, parse last week of transcripts, cluster interruptions/hook-blocks/rejections, corroborate/escalate clusters against the fast-loop issues, propose rule/skill/hook fixes, reproduce-and-verify each fix where safe, open one PR per target repo cross-linking the fast-loop issues |
 
+## Hooks
+
+| Hook | Event | Default |
+|------|-------|---------|
+| `check-open-pr.sh` | `PreToolUse: Bash` | Enabled |
+| `skill-usage-log.sh` | `PreToolUse: Skill\|SlashCommand` + `UserPromptSubmit` | **Opt-in** |
+
+### Skill-usage log (opt-in)
+
+```bash
+export CLAUDE_HOOKS_ENABLE_SKILL_USAGE_LOG=1
+```
+
+Appends one JSONL record per skill invocation to `~/.claude/skill-usage.jsonl`,
+so usage history outlives transcript retention. Opt-in because every turn pays a
+`UserPromptSubmit` fire and the log is only useful to someone who intends to
+analyse it later; custom path via `CLAUDE_SKILL_USAGE_LOG`.
+
+It fires on **two** events, because skills arrive by two different paths:
+
+| Event | Path | Record `src` |
+|-------|------|--------------|
+| `PreToolUse` (`Skill`, `SlashCommand`) | The model invokes a skill | `tool` |
+| `UserPromptSubmit` | The user types `/plugin:skill` | `slash` |
+
+A user-typed slash command never reaches a tool — the client expands it into the
+prompt itself — so a `PreToolUse` hook alone misses every one of them. In a
+1,134-session transcript sweep, 11 of the 57 used skills appeared *only* by that
+path.
+
+Each record carries `ts`, `src`, `skill`, `plugin`, `args` (+ untruncated
+`args_len`), `session`, `cwd`, `repo`, `branch`, `permission_mode`, `effort`.
+The hook never writes to stdout — a `UserPromptSubmit` hook's stdout is injected
+into the model's context — and rotates at 16 MB.
+
+### Skill usage report
+
+```bash
+python3 feedback-plugin/scripts/skill_usage_report.py --since 30d --include-transcripts
+```
+
+Merges the durable log with the (expiring) transcripts and buckets the installed
+catalog into `active` / `dormant` / `never`, emitting the `KEY=VALUE` diagnostic
+convention plus `--json` for an agent. `friction-learner` Step 1b reads it to
+decide **which** skills are worth analysing — see the caveats there; `never` is a
+floor bounded by `COVERAGE_SINCE`, not a verdict.
+
 ### Friction learner
 
 Spawn via the Agent tool or wire to a weekly cron:

--- a/feedback-plugin/agents/friction-learner.md
+++ b/feedback-plugin/agents/friction-learner.md
@@ -119,6 +119,27 @@ The parser emits one friction event per line:
 {"session": "…", "ts": "…", "kind": "hook_block|tool_error|user_reject|user_interrupt|plan_mode|push_to_pr_branch", "signature": "…", "tool": "…", "evidence": "…"}
 ```
 
+### Step 1b: Pull skill usage, to target the analysis (optional)
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/skill_usage_report.py" \
+  --since 30d --include-transcripts --json > /tmp/skill-usage.json
+```
+
+Reads `~/.claude/skill-usage.jsonl` (written by the opt-in `skill-usage-log.sh`
+hook) and backfills from the expiring transcripts. Use it to **decide which
+skills are worth analysing**, not as a friction source of its own:
+
+| Report bucket | What it means for this run |
+|---|---|
+| `active` with friction clusters | Prioritise — a skill in daily use whose guidance is costing round-trips |
+| `active`, no clusters | Working; leave alone |
+| `dormant` | Deprioritise a fix here; a rule change lands on nobody |
+| `never` | **Not** evidence the skill is bad — read `coverage_since` first, then treat it as a *description/triggering* question (does it say when to invoke it?), which is `evaluate-plugin:evaluate-legibility`'s job, not this agent's |
+
+`STATUS=NO_DATA` means the hook is not enabled and no transcripts were read —
+that is not "no skills were used". Skip this step rather than reporting zeros.
+
 ### Step 2: Cluster by signature
 
 ```bash
@@ -304,3 +325,6 @@ Clusters found: 7 (3 actionable)
 - Modify settings.json hooks (proposes them; user applies)
 - Send webhook notifications
 - Rewrite existing rules (only adds a new dated rule file; humans consolidate later)
+- Judge a skill's *value* from its usage count — the report ranks recency and
+  reach so the analysis can be targeted; a never-invoked skill raises a
+  description/triggering question, not a delete recommendation

--- a/feedback-plugin/hooks/skill-usage-log.sh
+++ b/feedback-plugin/hooks/skill-usage-log.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Skill-usage logger — appends one JSONL record per skill invocation so usage
+# survives transcript rotation and is cheap to aggregate.
+#
+# Two events, because skills arrive by two different paths:
+#   PreToolUse(Skill|SlashCommand) → model-invoked skill      (src=tool)
+#   UserPromptSubmit               → user-typed /command      (src=slash)
+# A user-typed slash command never reaches a tool: the client expands it into
+# the prompt itself, so a PreToolUse hook alone misses every one of them.
+#
+# Output: ~/.claude/skill-usage.jsonl  (override: CLAUDE_SKILL_USAGE_LOG)
+# Opt in:  CLAUDE_HOOKS_ENABLE_SKILL_USAGE_LOG=1  (disabled by default)
+#
+# Consumed by scripts/skill_usage_report.py, which the weekly `friction-learner`
+# slow loop reads to decide WHICH skills are worth analysing.
+#
+# NEVER write to stdout. A UserPromptSubmit hook's stdout is injected into the
+# model's context, so any output here would leak into every single turn.
+#
+# No -e: telemetry must never break a turn. Every failure path exits 0.
+set -uo pipefail
+
+# Opt-in guard — disabled by default. Every turn pays a UserPromptSubmit fire,
+# and the log is only useful to someone who intends to analyse it later.
+[ "${CLAUDE_HOOKS_ENABLE_SKILL_USAGE_LOG:-0}" = "1" ] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+INPUT=$(cat)
+
+FIELDS=$(printf '%s' "$INPUT" | jq -r '
+    [ .hook_event_name // "-",
+      .tool_name       // "-",
+      .session_id      // "-",
+      .cwd             // "-",
+      .permission_mode // "-",
+      (.effort.level   // "-") ] | @tsv' 2>/dev/null) || exit 0
+IFS=$'\t' read -r EVENT TOOL SESSION CWD MODE EFFORT <<< "$FIELDS"
+
+SKILL=""
+ARGS=""
+SRC=""
+
+case "$EVENT" in
+    PreToolUse)
+        case "$TOOL" in
+            Skill | SlashCommand) ;;
+            *) exit 0 ;;
+        esac
+        # Skill tool: {"skill": "...", "args": "..."} (args optional).
+        # SlashCommand tool: {"command": "/name ..."}.
+        SKILL=$(printf '%s' "$INPUT" | jq -r '.tool_input.skill // .tool_input.command // ""' 2>/dev/null)
+        ARGS=$(printf '%s' "$INPUT" | jq -r '.tool_input.args // ""' 2>/dev/null)
+        SKILL=${SKILL#/}
+        SRC="tool"
+        ;;
+    UserPromptSubmit)
+        PROMPT=$(printf '%s' "$INPUT" | jq -r '.prompt // ""' 2>/dev/null)
+        # Accept both the raw typed form ("/git:git-pr fix") and the wrapped
+        # form some clients expand it into (<command-name>/git:git-pr</...>).
+        if [[ "$PROMPT" == *"<command-name>"* ]]; then
+            PROMPT=${PROMPT#*<command-name>}
+            PROMPT=${PROMPT%%</command-name>*}
+        fi
+        PROMPT=${PROMPT#"${PROMPT%%[![:space:]]*}"}
+        [[ "$PROMPT" == /* ]] || exit 0
+        FIRST=${PROMPT%%[[:space:]]*}
+        SKILL=${FIRST#/}
+        ARGS=${PROMPT#"$FIRST"}
+        ARGS=${ARGS#"${ARGS%%[![:space:]]*}"}
+        SRC="slash"
+        ;;
+    *) exit 0 ;;
+esac
+
+# A bare "/" or an empty tool_input yields nothing to attribute.
+[ -n "$SKILL" ] || exit 0
+# Guard against a path being mistaken for a command ("/tmp/foo.txt ...").
+case "$SKILL" in */*) exit 0 ;; esac
+
+PLUGIN="-"
+case "$SKILL" in *:*) PLUGIN=${SKILL%%:*} ;; esac
+
+ARGS_LEN=${#ARGS}
+ARGS=${ARGS:0:300}
+
+REPO="-"
+BRANCH="-"
+# Guard the path: git -C "" silently falls back to the process CWD.
+if [ -n "$CWD" ] && [ "$CWD" != "-" ] && [ -d "$CWD" ]; then
+    TOP=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null) || TOP=""
+    if [ -n "$TOP" ]; then
+        REPO=$(basename "$TOP")
+        BRANCH=$(git -C "$CWD" branch --show-current 2>/dev/null) || BRANCH=""
+        [ -n "$BRANCH" ] || BRANCH="-"
+    fi
+fi
+
+TS=$(date -Iseconds 2>/dev/null || date '+%Y-%m-%dT%H:%M:%S')
+LOG="${CLAUDE_SKILL_USAGE_LOG:-$HOME/.claude/skill-usage.jsonl}"
+mkdir -p "$(dirname "$LOG")" 2>/dev/null || exit 0
+
+# Rotate at 16 MB so the log can never grow unbounded.
+if [ -f "$LOG" ]; then
+    SIZE=$(wc -c < "$LOG" 2>/dev/null | tr -d ' ')
+    if [ "${SIZE:-0}" -gt 16777216 ] 2>/dev/null; then
+        mv -f "$LOG" "$LOG.1" 2>/dev/null || true
+    fi
+fi
+
+# jq -nc does the JSON escaping, so an arg containing quotes or newlines can
+# never corrupt the log.
+jq -nc \
+    --arg ts "$TS" \
+    --arg src "$SRC" \
+    --arg skill "$SKILL" \
+    --arg plugin "$PLUGIN" \
+    --arg args "$ARGS" \
+    --argjson args_len "$ARGS_LEN" \
+    --arg session "$SESSION" \
+    --arg cwd "$CWD" \
+    --arg repo "$REPO" \
+    --arg branch "$BRANCH" \
+    --arg mode "$MODE" \
+    --arg effort "$EFFORT" \
+    '{v: 1, ts: $ts, src: $src, skill: $skill, plugin: $plugin,
+      args: $args, args_len: $args_len, session: $session,
+      cwd: $cwd, repo: $repo, branch: $branch,
+      permission_mode: $mode, effort: $effort}' >> "$LOG" 2>/dev/null || true
+
+exit 0

--- a/feedback-plugin/hooks/test-skill-usage-log.sh
+++ b/feedback-plugin/hooks/test-skill-usage-log.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Regression tests for skill-usage-log.sh
+#
+# Verifies that the logger:
+#  - Records a model-invoked skill (PreToolUse Skill) with plugin split out.
+#  - Records a user-typed slash command (UserPromptSubmit), raw and wrapped.
+#  - Ignores non-skill tools, plain prompts, and bare "/" or path-like tokens.
+#  - Emits valid JSON even when args contain quotes and newlines.
+#  - Writes NOTHING to stdout on any path — a UserPromptSubmit hook's stdout is
+#    injected into the model's context, so a stray byte leaks into every turn.
+#  - Stays silent when CLAUDE_HOOKS_ENABLE_SKILL_USAGE_LOG is unset (opt-in).
+#
+# The payload shapes below are taken from real transcripts, not invented:
+# `{"skill": "...", "args": "..."}` is the observed Skill tool_input in
+# ~/.claude/projects/**/*.jsonl (170 occurrences, 108 of them with args).
+#
+# Run: bash hooks-plugin/hooks/test-skill-usage-log.sh
+# Exit 0 = all tests pass, Exit 1 = failures
+set -uo pipefail
+
+HOOK="$(dirname "$0")/skill-usage-log.sh"
+PASS=0
+FAIL=0
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+LOG="$WORK/skill-usage.jsonl"
+
+# Run the hook on one payload; returns its stdout, appends to $LOG.
+run_hook() {
+    printf '%s' "$1" \
+        | CLAUDE_SKILL_USAGE_LOG="$LOG" \
+          CLAUDE_HOOKS_ENABLE_SKILL_USAGE_LOG=1 \
+          bash "$HOOK" 2>/dev/null
+}
+
+reset_log() { : > "$LOG"; }
+records() { [ -f "$LOG" ] && wc -l < "$LOG" | tr -d ' ' || echo 0; }
+last_field() { jq -r "$1" < "$LOG" | tail -1; }
+
+check() {
+    local desc="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $desc"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: $desc"
+        echo "        expected: $expected"
+        echo "        actual:   $actual"
+    fi
+}
+
+echo "=== skill-usage-log.sh ==="
+
+# --- 1. Model-invoked skill via the Skill tool -------------------------------
+reset_log
+OUT=$(run_hook '{"hook_event_name":"PreToolUse","tool_name":"Skill","session_id":"sess-1","cwd":"/tmp","permission_mode":"default","tool_input":{"skill":"git-plugin:git-pr","args":"draft"}}')
+check "Skill tool logs one record" "1" "$(records)"
+check "  skill recorded" "git-plugin:git-pr" "$(last_field '.skill')"
+check "  plugin split out" "git-plugin" "$(last_field '.plugin')"
+check "  src=tool" "tool" "$(last_field '.src')"
+check "  args recorded" "draft" "$(last_field '.args')"
+check "  session recorded" "sess-1" "$(last_field '.session')"
+check "  no stdout" "" "$OUT"
+
+# --- 2. Skill tool without args (observed shape) -----------------------------
+reset_log
+run_hook '{"hook_event_name":"PreToolUse","tool_name":"Skill","session_id":"s","cwd":"/tmp","tool_input":{"skill":"git-plugin:deadbranch"}}' >/dev/null
+check "Skill tool without args still logs" "1" "$(records)"
+check "  args empty, length 0" "0" "$(last_field '.args_len')"
+
+# --- 3. Unnamespaced skill ---------------------------------------------------
+reset_log
+run_hook '{"hook_event_name":"PreToolUse","tool_name":"Skill","session_id":"s","cwd":"/tmp","tool_input":{"skill":"artifact-design"}}' >/dev/null
+check "unnamespaced skill logs plugin=-" "-" "$(last_field '.plugin')"
+
+# --- 4. Non-skill tool is ignored -------------------------------------------
+reset_log
+OUT=$(run_hook '{"hook_event_name":"PreToolUse","tool_name":"Bash","session_id":"s","cwd":"/tmp","tool_input":{"command":"ls"}}')
+check "Bash tool logs nothing" "0" "$(records)"
+check "  no stdout" "" "$OUT"
+
+# --- 5. User-typed slash command --------------------------------------------
+reset_log
+OUT=$(run_hook '{"hook_event_name":"UserPromptSubmit","session_id":"s","cwd":"/tmp","prompt":"/session-plugin:session-end wrap it up"}')
+check "slash command logs one record" "1" "$(records)"
+check "  skill recorded" "session-plugin:session-end" "$(last_field '.skill')"
+check "  src=slash" "slash" "$(last_field '.src')"
+check "  args recorded" "wrap it up" "$(last_field '.args')"
+check "  no stdout (context-injection guard)" "" "$OUT"
+
+# --- 6. Wrapped <command-name> form -----------------------------------------
+reset_log
+run_hook '{"hook_event_name":"UserPromptSubmit","session_id":"s","cwd":"/tmp","prompt":"<command-message>x</command-message>\n<command-name>/git-plugin:git-triage</command-name>"}' >/dev/null
+check "wrapped command-name form parsed" "git-plugin:git-triage" "$(last_field '.skill')"
+
+# --- 7. Plain prompts and path-like tokens are ignored -----------------------
+reset_log
+run_hook '{"hook_event_name":"UserPromptSubmit","session_id":"s","cwd":"/tmp","prompt":"what does this repo do?"}' >/dev/null
+check "plain prompt logs nothing" "0" "$(records)"
+run_hook '{"hook_event_name":"UserPromptSubmit","session_id":"s","cwd":"/tmp","prompt":"/tmp/foo.txt is the file"}' >/dev/null
+check "path-like first token logs nothing" "0" "$(records)"
+run_hook '{"hook_event_name":"UserPromptSubmit","session_id":"s","cwd":"/tmp","prompt":"/"}' >/dev/null
+check "bare slash logs nothing" "0" "$(records)"
+
+# --- 8. Unrelated events are ignored ----------------------------------------
+reset_log
+run_hook '{"hook_event_name":"SessionStart","session_id":"s","cwd":"/tmp"}' >/dev/null
+check "SessionStart logs nothing" "0" "$(records)"
+
+# --- 9. Hostile args stay valid JSON ----------------------------------------
+reset_log
+run_hook '{"hook_event_name":"PreToolUse","tool_name":"Skill","session_id":"s","cwd":"/tmp","tool_input":{"skill":"x:y","args":"he said \"hi\"\nthen {\"a\":1}"}}' >/dev/null
+check "quotes/newlines in args stay one valid record" "1" "$(records)"
+if jq -e . < "$LOG" >/dev/null 2>&1; then
+    check "  record parses as JSON" "ok" "ok"
+else
+    check "  record parses as JSON" "ok" "invalid"
+fi
+
+# --- 10. Opt-in guard --------------------------------------------------------
+# Unset explicitly: the developer's shell may export the opt-in var, which would
+# make this pass locally for the wrong reason.
+reset_log
+printf '%s' '{"hook_event_name":"PreToolUse","tool_name":"Skill","session_id":"s","cwd":"/tmp","tool_input":{"skill":"a:b"}}' \
+    | env -u CLAUDE_HOOKS_ENABLE_SKILL_USAGE_LOG CLAUDE_SKILL_USAGE_LOG="$LOG" bash "$HOOK" >/dev/null 2>&1
+check "disabled by default (opt-in)" "0" "$(records)"
+
+# --- 11. Control: the fixture itself is capable of failing -------------------
+# Without this, every "logs nothing" assertion above would also pass if the
+# hook were broken outright.
+reset_log
+run_hook '{"hook_event_name":"PreToolUse","tool_name":"Skill","session_id":"s","cwd":"/tmp","tool_input":{"skill":"control:probe"}}' >/dev/null
+check "control: harness observes a real write" "control:probe" "$(last_field '.skill')"
+
+echo
+echo "Passed: $PASS  Failed: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/feedback-plugin/scripts/skill_usage_report.py
+++ b/feedback-plugin/scripts/skill_usage_report.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Rank skills by last use, so the slow loop can target its analysis.
+
+Reads two sources and merges them, newest-wins per skill:
+
+  1. ``~/.claude/skill-usage.jsonl`` — the durable per-invocation log written by
+     ``hooks/skill-usage-log.sh`` (opt-in). Never trimmed, so it is the source
+     that accumulates.
+  2. ``~/.claude/projects/**/*.jsonl`` — session transcripts, mined for
+     ``attributionSkill`` and ``Skill`` tool calls (``--include-transcripts``).
+     These EXPIRE, which is the whole reason source 1 exists; use them to
+     backfill history predating the hook.
+
+Against the installed skill catalog this yields three buckets:
+
+  active    used inside the window
+  dormant   used, but not inside the window
+  never     in the catalog with no record in either source
+
+`never` is a FLOOR, not a verdict. A skill last used before the earliest record
+in either source is indistinguishable from one never used — the report prints
+COVERAGE_SINCE so the reader can tell how far back "never" actually reaches.
+
+Output follows .claude/rules/structured-script-output.md (KEY=VALUE inside
+=== SECTION === delimiters); --json emits the same data for an agent to consume.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+HOME = Path(os.path.expanduser("~"))
+DEFAULT_LOG = HOME / ".claude" / "skill-usage.jsonl"
+DEFAULT_TRANSCRIPTS = HOME / ".claude" / "projects"
+# The marketplace checkout this script ships inside: <repo>/feedback-plugin/scripts/
+DEFAULT_CATALOG = Path(__file__).resolve().parents[2]
+
+# Whitespace-tolerant: live transcripts are compact ("k":"v"), but any producer
+# using json.dumps defaults emits ("k": "v") and would silently never match.
+ATTRIBUTION_RE = re.compile(r'"attributionSkill"\s*:\s*"([^"]+)"')
+TIMESTAMP_RE = re.compile(r'"timestamp"\s*:\s*"([^"]+)"')
+
+
+def parse_since(spec: str) -> timedelta:
+    """Accept 7d / 24h / 90m, matching friction_parse.py's --since."""
+    m = re.fullmatch(r"(\d+)([dhm])", spec.strip())
+    if not m:
+        raise argparse.ArgumentTypeError(f"expected e.g. 30d, 24h, 90m — got {spec!r}")
+    n, unit = int(m.group(1)), m.group(2)
+    return {"d": timedelta(days=n), "h": timedelta(hours=n), "m": timedelta(minutes=n)}[
+        unit
+    ]
+
+
+def normalize_ts(raw: str) -> str:
+    """ISO 8601 → UTC ISO 8601, so log (local offset) and transcript (Z) sort together."""
+    if not raw:
+        return ""
+    try:
+        dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return ""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+def record(usage: dict, skill: str, ts: str, source: str) -> None:
+    if not skill or not ts:
+        return
+    entry = usage.setdefault(
+        skill, {"skill": skill, "last": "", "count": 0, "sources": set()}
+    )
+    entry["count"] += 1
+    entry["sources"].add(source)
+    if ts > entry["last"]:
+        entry["last"] = ts
+
+
+def read_log(path: Path, usage: dict) -> int:
+    """Read the hook's JSONL log (plus one rotation) into `usage`."""
+    lines = 0
+    for candidate in (path, path.with_suffix(path.suffix + ".1")):
+        if not candidate.is_file():
+            continue
+        with candidate.open(errors="replace") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                lines += 1
+                record(
+                    usage, rec.get("skill", ""), normalize_ts(rec.get("ts", "")), "log"
+                )
+    return lines
+
+
+def read_transcripts(root: Path, usage: dict) -> int:
+    """Mine transcripts for attributionSkill and Skill tool calls."""
+    files = 0
+    for path in root.glob("**/*.jsonl"):
+        files += 1
+        try:
+            fh = path.open(errors="replace")
+        except OSError:
+            continue
+        with fh:
+            for line in fh:
+                has_attr = '"attributionSkill"' in line
+                has_skill = '"Skill"' in line
+                if not (has_attr or has_skill):
+                    continue
+                ts_match = TIMESTAMP_RE.search(line)
+                ts = normalize_ts(ts_match.group(1) if ts_match else "")
+                if has_attr:
+                    m = ATTRIBUTION_RE.search(line)
+                    if m:
+                        record(usage, m.group(1), ts, "transcript")
+                if has_skill:
+                    try:
+                        rec = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    content = (rec.get("message") or {}).get("content")
+                    if not isinstance(content, list):
+                        continue
+                    for block in content:
+                        if (
+                            isinstance(block, dict)
+                            and block.get("type") == "tool_use"
+                            and block.get("name") == "Skill"
+                        ):
+                            name = (block.get("input") or {}).get("skill")
+                            record(usage, name or "", ts, "transcript")
+    return files
+
+
+def read_catalog(roots: list[Path]) -> set[str]:
+    """Enumerate installed skills as `plugin:skill` (or bare name for root SKILL.md)."""
+    catalog: set[str] = set()
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for skill_md in root.glob("*/skills/*/SKILL.md"):
+            plugin = skill_md.parents[2].name
+            # Project-scoped skills under .claude/skills/ are invoked by bare
+            # name — namespacing them as ".claude:x" would never match a record.
+            catalog.add(
+                skill_md.parent.name
+                if plugin.startswith(".")
+                else f"{plugin}:{skill_md.parent.name}"
+            )
+        for skill_md in root.glob("*/SKILL.md"):
+            catalog.add(skill_md.parent.name)
+    return catalog
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--log", type=Path, default=DEFAULT_LOG, help="hook log path")
+    ap.add_argument("--since", default="30d", help="active window (default 30d)")
+    ap.add_argument(
+        "--catalog", type=Path, action="append", help="marketplace root (repeatable)"
+    )
+    ap.add_argument("--transcripts", type=Path, default=DEFAULT_TRANSCRIPTS)
+    ap.add_argument(
+        "--include-transcripts",
+        action="store_true",
+        help="backfill from expiring transcripts",
+    )
+    ap.add_argument(
+        "--top", type=int, default=25, help="rows in the ranked section (0 = all)"
+    )
+    ap.add_argument(
+        "--json", action="store_true", help="emit JSON instead of KEY=VALUE"
+    )
+    args = ap.parse_args()
+
+    usage: dict = {}
+    log_records = read_log(args.log, usage)
+    transcript_files = (
+        read_transcripts(args.transcripts, usage) if args.include_transcripts else 0
+    )
+
+    catalog = read_catalog(args.catalog or [DEFAULT_CATALOG])
+    cutoff = (datetime.now(timezone.utc) - parse_since(args.since)).isoformat()
+
+    rows = sorted(usage.values(), key=lambda r: r["last"], reverse=True)
+    for row in rows:
+        row["sources"] = sorted(row["sources"])
+        row["in_catalog"] = row["skill"] in catalog
+    active = [r for r in rows if r["last"] >= cutoff]
+    dormant = [r for r in rows if r["last"] < cutoff]
+    never = sorted(catalog - set(usage))
+    coverage_since = rows[-1]["last"] if rows else ""
+
+    if args.json:
+        json.dump(
+            {
+                "window": args.since,
+                "coverage_since": coverage_since,
+                "log_records": log_records,
+                "transcript_files": transcript_files,
+                "catalog": len(catalog),
+                "active": active,
+                "dormant": dormant,
+                "never": never,
+            },
+            sys.stdout,
+            indent=2,
+        )
+        print()
+        return 0
+
+    limit = None if args.top == 0 else args.top
+    print("=== SKILL USAGE ===")
+    print(f"LOG={args.log}")
+    print(f"LOG_RECORDS={log_records}")
+    print(f"TRANSCRIPT_FILES={transcript_files}")
+    print(f"WINDOW={args.since}")
+    print(f"COVERAGE_SINCE={coverage_since or '-'}")
+    print(f"CATALOG_SKILLS={len(catalog)}")
+    print(f"ACTIVE={len(active)}")
+    print(f"DORMANT={len(dormant)}")
+    print(f"NEVER_SEEN={len(never)}")
+    if log_records == 0 and not args.include_transcripts:
+        # Distinguish "nothing used" from "nothing recorded" — an empty log and a
+        # quiet month produce identical bucket counts otherwise.
+        print("STATUS=NO_DATA")
+        print(
+            "HINT=enable CLAUDE_HOOKS_ENABLE_SKILL_USAGE_LOG=1, or pass --include-transcripts"
+        )
+    else:
+        print("STATUS=OK")
+    print(f"ISSUE_COUNT={len(never)}")
+    print("=== END SKILL USAGE ===")
+
+    print()
+    print("=== RANKED BY LAST USE ===")
+    for row in rows[:limit]:
+        flag = "" if row["in_catalog"] else "\tuncatalogued"
+        print(f"{row['last'][:16]}\t{row['count']}\t{row['skill']}{flag}")
+    print("=== END RANKED BY LAST USE ===")
+
+    print()
+    print("=== NEVER SEEN ===")
+    for name in never[:limit]:
+        print(name)
+    if limit is not None and len(never) > limit:
+        print(f"... {len(never) - limit} more (--top 0 for all)")
+    print("=== END NEVER SEEN ===")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/feedback-plugin/scripts/tests/test-friction-parse.sh
+++ b/feedback-plugin/scripts/tests/test-friction-parse.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Runner shim for the friction_* Python regression suites.
+# Runner shim for this plugin's Python regression suites.
 #
 # The suites themselves are Python (`test_friction_*.py`), but
 # scripts/run-skill-script-tests.sh (and the `Test: Skill scripts` CI workflow)
@@ -21,7 +21,10 @@ fi
 failed=0
 total=0
 
-for suite in "$TESTS_DIR"/test_friction_*.py; do
+# Glob is test_*.py, not test_friction_*.py: skill_usage_report's suite lives
+# here too, and a name-scoped glob is exactly the allowlist drift this shim
+# exists to prevent (a suite that matches no glob runs nowhere).
+for suite in "$TESTS_DIR"/test_*.py; do
   [ -f "$suite" ] || continue
   total=$((total + 1))
   echo "=== $(basename "$suite") ==="

--- a/feedback-plugin/scripts/tests/test_skill_usage_report.py
+++ b/feedback-plugin/scripts/tests/test_skill_usage_report.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Regression tests for skill_usage_report.py.
+
+Run: python3 feedback-plugin/scripts/tests/test_skill_usage_report.py
+
+The fixtures mirror shapes taken from real data, not invented ones: the hook log
+record is what hooks/skill-usage-log.sh emits, and the transcript lines carry
+`attributionSkill` plus a `Skill` tool_use block as observed in
+~/.claude/projects/**/*.jsonl.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPORT = HERE.parent / "skill_usage_report.py"
+
+FAILURES: list[str] = []
+
+
+def check(desc: str, expected, actual) -> None:
+    if expected == actual:
+        print(f"  PASS: {desc}")
+    else:
+        FAILURES.append(desc)
+        print(
+            f"  FAIL: {desc}\n        expected: {expected!r}\n        actual:   {actual!r}"
+        )
+
+
+def iso(days_ago: float) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat()
+
+
+def write_log(path: Path, entries: list[tuple[str, str]]) -> None:
+    with path.open("w") as fh:
+        for skill, ts in entries:
+            fh.write(
+                json.dumps({"v": 1, "ts": ts, "src": "tool", "skill": skill}) + "\n"
+            )
+
+
+def make_catalog(root: Path, skills: list[tuple[str, str]]) -> None:
+    for plugin, skill in skills:
+        d = root / plugin / "skills" / skill
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "SKILL.md").write_text("---\nname: x\n---\n")
+
+
+def run_report(log: Path, catalog: Path, *extra: str) -> dict:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(REPORT),
+            "--log",
+            str(log),
+            "--catalog",
+            str(catalog),
+            "--json",
+            *extra,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(proc.stdout)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        log = tmp_path / "skill-usage.jsonl"
+        catalog = tmp_path / "marketplace"
+        empty_transcripts = tmp_path / "no-transcripts"
+        empty_transcripts.mkdir()
+        make_catalog(
+            catalog,
+            [
+                ("git-plugin", "git-pr"),
+                ("git-plugin", "git-triage"),
+                ("x-plugin", "unused"),
+            ],
+        )
+
+        print("=== bucketing ===")
+        write_log(
+            log, [("git-plugin:git-pr", iso(1)), ("git-plugin:git-triage", iso(45))]
+        )
+        out = run_report(
+            log, catalog, "--since", "30d", "--transcripts", str(empty_transcripts)
+        )
+        check("catalog enumerated", 3, out["catalog"])
+        check(
+            "recent use is active",
+            ["git-plugin:git-pr"],
+            [r["skill"] for r in out["active"]],
+        )
+        check(
+            "old use is dormant",
+            ["git-plugin:git-triage"],
+            [r["skill"] for r in out["dormant"]],
+        )
+        check("catalogued but unseen is never", ["x-plugin:unused"], out["never"])
+        check("log records counted", 2, out["log_records"])
+
+        print("=== counts and recency ===")
+        write_log(
+            log,
+            [
+                ("git-plugin:git-pr", iso(5)),
+                ("git-plugin:git-pr", iso(2)),
+                ("git-plugin:git-pr", iso(9)),
+            ],
+        )
+        out = run_report(
+            log, catalog, "--since", "30d", "--transcripts", str(empty_transcripts)
+        )
+        row = out["active"][0]
+        check("invocations counted", 3, row["count"])
+        check("last use is the newest, not the last line", True, row["last"] > iso(3))
+
+        print("=== rotation is read ===")
+        write_log(log, [("git-plugin:git-pr", iso(1))])
+        write_log(
+            log.with_suffix(log.suffix + ".1"), [("git-plugin:git-triage", iso(2))]
+        )
+        out = run_report(
+            log, catalog, "--since", "30d", "--transcripts", str(empty_transcripts)
+        )
+        check("rotated log merged", 2, out["log_records"])
+
+        print("=== transcript backfill ===")
+        # An expiring transcript carries the same skill by two encodings.
+        proj = tmp_path / "projects" / "p"
+        proj.mkdir(parents=True)
+        ts = iso(3)
+        (proj / "s.jsonl").write_text(
+            json.dumps({"timestamp": ts, "attributionSkill": "x-plugin:unused"})
+            + "\n"
+            + json.dumps(
+                {
+                    "timestamp": ts,
+                    "message": {
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "name": "Skill",
+                                "input": {"skill": "x-plugin:unused"},
+                            }
+                        ]
+                    },
+                }
+            )
+            + "\n"
+        )
+        write_log(log, [("git-plugin:git-pr", iso(1))])
+        log.with_suffix(log.suffix + ".1").unlink()
+        out = run_report(
+            log, catalog, "--since", "30d", "--transcripts", str(proj.parent)
+        )
+        # git-triage has no record in either source here, so it stays "never"
+        # in both runs; x-plugin:unused is the one the backfill should rescue.
+        check(
+            "transcripts ignored unless asked",
+            ["git-plugin:git-triage", "x-plugin:unused"],
+            out["never"],
+        )
+        out = run_report(
+            log,
+            catalog,
+            "--since",
+            "30d",
+            "--transcripts",
+            str(proj.parent),
+            "--include-transcripts",
+        )
+        check(
+            "backfilled skill leaves never-bucket",
+            ["git-plugin:git-triage"],
+            out["never"],
+        )
+        check("transcript files counted", 1, out["transcript_files"])
+
+        print("=== empty log is distinguishable from no usage ===")
+        log.write_text("")
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(REPORT),
+                "--log",
+                str(log),
+                "--catalog",
+                str(catalog),
+                "--transcripts",
+                str(empty_transcripts),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        check("STATUS=NO_DATA on an empty log", True, "STATUS=NO_DATA" in proc.stdout)
+        check(
+            "hint names the opt-in var",
+            True,
+            "CLAUDE_HOOKS_ENABLE_SKILL_USAGE_LOG" in proc.stdout,
+        )
+
+        print("=== control: the harness can observe a real difference ===")
+        # Without this, every assertion above would also pass against a report
+        # that always emitted empty buckets.
+        write_log(log, [("git-plugin:git-pr", iso(1))])
+        out = run_report(
+            log, catalog, "--since", "30d", "--transcripts", str(empty_transcripts)
+        )
+        check("control: one active row", 1, len(out["active"]))
+
+    print()
+    if FAILURES:
+        print(f"FAILED={len(FAILURES)}")
+        print("STATUS=ERROR")
+        return 1
+    print("FAILED=0")
+    print("STATUS=OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks-plugin/docs/feature-flags.md
+++ b/hooks-plugin/docs/feature-flags.md
@@ -28,6 +28,7 @@ Three shapes:
 | `CLAUDE_HOOKS_ENABLE_BASH_ANTIPATTERNS_TEACH` | PostToolUse "teach" hook — augments tool output with a non-blocking nudge instead of blocking (carries the `find→Glob` and other soft nudges) | hooks · `hooks/bash-antipatterns-teach.sh` |
 | `CLAUDE_HOOKS_ENABLE_CALENDAR_ESTIMATES` | Stop hook nudging the agent to restate estimates in tokens / effort tiers instead of calendar time | hooks · `hooks/no-calendar-estimates.sh` |
 | `CLAUDE_HOOKS_ENABLE_EVENT_LOGGER` | Dev/debug hook logging every hook event to a file | hooks · `hooks/event-logger.sh` |
+| `CLAUDE_HOOKS_ENABLE_SKILL_USAGE_LOG` | Appends one JSONL record per skill invocation to `~/.claude/skill-usage.jsonl` (`PreToolUse: Skill\|SlashCommand` + `UserPromptSubmit`), so usage outlives transcript retention. Read by `feedback-plugin/scripts/skill_usage_report.py` | feedback · `hooks/skill-usage-log.sh` |
 | `CLAUDE_HOOKS_BASH_ANTIPATTERNS_NO_ASTGREP` | Forces the bash-antipatterns read/write detectors' no-op (ast-grep-absent) path even when ast-grep is installed — the structural cat/head/tail-read, echo/printf/cat-write, sed -i, and task-output detectors are skipped; safety/regex blocks still fire. Used by the regression suite to exercise fail-open (#2008) | hooks · `hooks/bash-antipatterns.sh` |
 
 **Non-env opt-in:** the taskwarrior **native hooks** (`on-modify`, `on-exit`
@@ -84,6 +85,7 @@ explicit action, not an env flag. Their own opt-out knobs are listed below.
 |---|---|---|---|
 | `CLAUDE_HOOKS_EVENT_LOG` | `~/.claude/hook-events.log` | Event-logger output path | `hooks/event-logger.sh` |
 | `CLAUDE_HOOKS_EVENT_LOGGER_VERBOSE` | off | Log full JSON input (vs one-line summary) | `hooks/event-logger.sh` |
+| `CLAUDE_SKILL_USAGE_LOG` | `~/.claude/skill-usage.jsonl` | Skill-usage log path (rotates to `<path>.1` at 16 MB) | `feedback-plugin/hooks/skill-usage-log.sh` |
 | `CLAUDE_HOOKS_TEST_TIMEOUT` | `45` (s) | Test-verification timeout | `hooks/test-verification.sh` |
 | `CLAUDE_HOOKS_BRANCH_SYNC_TTL` | `300` (s) | Per-session+branch sync-check cache TTL | `git-plugin/hooks/check-branch-sync-on-push.sh` |
 | `CLAUDE_HOOKS_BRANCH_BASE_TTL` | `300` (s) | Per-session+repo+default branch-base nudge dedup window | `hooks/branch-base-guard.sh` |


### PR DESCRIPTION
## What

An opt-in `feedback-plugin` hook that appends one JSONL record per skill invocation to `~/.claude/skill-usage.jsonl`, a report script that buckets the installed catalog against it, and a `friction-learner` step that reads the report to decide which skills the weekly slow loop analyses.

## Why

Skill usage was only reconstructable from session transcripts, which expire. Measured 2026-08-20: 1,134 files under `~/.claude/projects` reached back 29 days, and a full sweep found 57 distinct skills used out of 420 — the 363-skill remainder is a floor, not a verdict.

Filesystem `atime` is not an alternative, and this was verified rather than assumed: reading a file does not update `atime` on this APFS volume (write, sleep 2s, `cat`, unchanged), and all 2,038 `SKILL.md` files under `~/.claude/plugins` have `atime == mtime` — install time. Zero files anywhere have `atime > mtime`.

## How

**Two events, because skills arrive by two paths.** A user-typed `/plugin:skill` never reaches a tool — the client expands it into the prompt — so `PreToolUse(Skill|SlashCommand)` alone under-counts. In the sweep, 11 of the 57 used skills appeared *only* by the `UserPromptSubmit` path: `session-end`, `git-issue`, `project-refocus`, `health-check` among them.

**Opt-in** (`CLAUDE_HOOKS_ENABLE_SKILL_USAGE_LOG=1`): every turn pays a `UserPromptSubmit` fire, and the log is only useful to someone who intends to analyse it.

**In `feedback-plugin`, not `hooks-plugin`**: the log has one consumer and that consumer is the feedback loop. A telemetry file nothing reads is the exact failure `.claude/rules/plugin-usage-telemetry.md` already documents.

`skill_usage_report.py` merges the durable log with the expiring transcripts and buckets the catalog into `active` / `dormant` / `never`, emitting the `KEY=VALUE` convention plus `--json`. `friction-learner` Step 1b routes each bucket: an `active` skill with friction clusters is prioritised, a `dormant` one deprioritised, and a `never` one raises a description/triggering question for `evaluate-legibility` — never a delete recommendation. `never` is reported against `COVERAGE_SINCE` so the reader can see how far back it reaches, and `STATUS=NO_DATA` distinguishes "the hook is off" from "no skills were used".

## Verification

- `feedback-plugin/hooks/test-skill-usage-log.sh` — 26 assertions. Both invocation paths, `args` truncation with the untruncated length preserved, ignored events, JSON validity under quotes/newlines, the opt-in guard, and **no stdout on any path** (a `UserPromptSubmit` hook's stdout is injected into the model's context). Payload shapes are taken from real transcripts, not invented: `{skill, args}` is the observed `Skill` `tool_input` in 170 occurrences.
- `feedback-plugin/scripts/tests/test_skill_usage_report.py` — bucketing, recency-vs-line-order, rotation, transcript backfill, and the empty-log/no-usage distinction.
- Each suite ends with a control proving the harness can observe a real write, so no "logs nothing" assertion can pass vacuously.
- One parser defect was found *by* these tests and fixed rather than papered over: the `attributionSkill` regex assumed compact JSON with no space after the colon.
- `feedback-plugin/scripts/tests/test-friction-parse.sh` now globs `test_*.py` rather than `test_friction_*.py` — a name-scoped glob is the allowlist drift that shim exists to prevent.

## Known unrelated failure

`hooks-plugin/hooks/test-repo-deletion-safety.sh` fails one assertion on macOS, on `main`, before this branch: *temp-dir exemption (default on) allows a remote-less repo*. The hook resolves the target with `pwd -P`, so a `/var/folders/...` sandbox becomes `/private/var/folders/...`, which matches none of the four exemption prefixes (`/private/tmp/*` covers only tmp). Linux CI gets `/tmp/...` and passes, which is why it shipped in c5f79b7. Left out of this PR deliberately — different concern, different plugin. Related: #2465.
