### PR TITLE
docs(benchmarks): appraise agent-skill research and derive a provisional rubric

### DIFF
--- a/docs/benchmarks/2026-08-agent-skills-research/README.md
+++ b/docs/benchmarks/2026-08-agent-skills-research/README.md
@@ -11,6 +11,10 @@ design — see the binding constraints at the top of [`rubric.md`](rubric.md).
 |---|---|
 | [`appraisal.md`](appraisal.md) | Critical evaluation of arXiv:2608.14036 and the two adjacent papers — what holds, what to discount, and why |
 | [`rubric.md`](rubric.md) | 8 provisional quality dimensions, each traced to a finding and graded for evidence strength |
+| [`results.md`](results.md) | The 16 golden-set canaries scored against the rubric — reliability, per-dimension profiles, and two findings |
+| [`judgments/`](judgments/) | 32 raw judge records (2 per canary) with scores, rationales, and verbatim evidence |
+| `quote_check.py` | Falsifier: resolves every evidence quote against its source file |
+| `summarize.py` | Rolls judgments into per-dimension profiles; deliberately computes no per-skill total |
 | `README.md` | This file — the convergence check |
 
 ## Source set
@@ -32,14 +36,20 @@ quality→outcome relationships. Detail in [`appraisal.md`](appraisal.md) §3.7.
 
 ## Convergence check: did we independently arrive at the same conclusions?
 
-Broadly **yes** — 6 of 8 dimensions converged, several of them predating the
+Broadly **yes** — 5 of 8 dimensions converged, several of them predating the
 paper by months. One divergence is defensible on a cost model the papers do not
-model. One is a genuine gap.
+model, and two are genuine gaps.
+
+> **Revised 2026-08-21 after measurement.** This section was first written from
+> a reading of our rules. Scoring the 16 golden-set canaries
+> ([`results.md`](results.md)) contradicted the D2 row and put a caveat on D4.
+> The pre-measurement claims are preserved in the table so the correction is
+> visible rather than silently rewritten.
 
 | Dim | Our position | Verdict |
 |---|---|---|
 | **D1** Procedural anchoring | `skill-execution-structure.md` (2026-03-02) — "when a skill reads like a specification document, the model summarizes what it could do instead of doing it. **This is the most common skill authoring mistake.**" Prescribes `Phase N:` → `Step N: <verb>`, imperative openers, reference data moved out. | **Converged, 5 months early.** We independently named procedure-vs-description as *the* primary failure. The paper quantifies it (65.7% vs 4.5%); we identified it and built the fix. |
-| **D2** Outcome annotation | Not a stated rule, but pervasive practice. Rules carry dated failure provenance with observed cost — `loop-integrity.md`, `agent-coworker-detection.md` ("force-removed ~24 peer worktrees"), `gh-json-fields.md` § "The `merged` mistake". | **Converged in practice, unstated as principle.** Our provenance discipline is *richer* than the paper's synthetic skills. But `skill-quality.md` § Writing Style pushes toward positive framing, creating an unresolved tension (rubric D2 note). |
+| **D2** Outcome annotation | Dated failure provenance with observed cost is pervasive in `.claude/rules/` — `loop-integrity.md`, `agent-coworker-detection.md` ("force-removed ~24 peer worktrees"), `gh-json-fields.md` § "The `merged` mistake" — but **not** in skill bodies. | **Corrected 2026-08-21 by measurement — see [`results.md`](results.md) Finding 4.** This row originally claimed convergence. Scoring the canaries put D2 at the corpus's **lowest mean (3.09)**, with `file-generator` at 1.5 and `cli-wrapper` at 2.0. The provenance lives in the *rules*, not the *skills* — i.e. in the layer that is absent when the procedure actually fires. Against a grade-B ablated finding (0.7462 → 0.4000), this is the corpus's genuine weak axis. |
 | **D3** Execution-layer specificity | `agentic-optimization.md`, `structured-script-output.md`, and exact-command discipline throughout — `task-id-stability.md`'s `task +LATEST uuids` vs the silently-empty `_get uuid` is precisely this dimension. | **Converged strongly.** A repo strength. The paper's largest measured win (env failures 5.3%→0.2%) is the thing our rules obsess over. |
 | **D4** Adaptation latitude | `hook-block-vs-nudge.md` — block for safety, nudge for style; a hard block "dead-ends subagents lacking the tool." `bash-tool-replacements.md` demoted `find`/`grep`/`ls` from blocks to nudges. | **Converged — and we are ahead.** The paper measures skill-caused failures at 10.0% vs <1%. We independently found the same pathology *and* built a local empirical metric for it: **same-session repeat-block rate**, which drove the #1871/#1909/#2036 demotions and caught #2148's regression (46.3% break from a 6.3–20.0% band). The literature has no equivalent. |
 | **D5** Budget discipline | `skill-quality.md`: target ≤10,000 chars (~2,500 tok), ERROR at 26,000 chars (~6,500 tok). | **Divergent, defensibly.** Our ceiling is **~4.3× the SkillsBench ecosystem median** (~1.5k tokens) and our target ~1.7×. But `context-engineering.md` makes the point the papers miss entirely: a `SKILL.md` body is paid *only when the skill fires*, whereas unscoped rules are paid **every turn** — so ranking cuts by `always-loaded cost × frequency` is a strictly better cost model than raw size. We are less strict on the axis the papers measure and stricter on an axis they ignore. |
@@ -51,9 +61,17 @@ model. One is a genuine gap.
 
 | | Count |
 |---|---|
-| Converged (some ahead of the literature) | 6 — D1, D2, D3, D4, D6, D7 |
+| Converged (some ahead of the literature) | 5 — D1, D3, D4, D6, D7 |
 | Divergent but defensible | 1 — D5 |
-| Genuine gap | 1 — D8 |
+| Genuine gaps | 2 — D2 (corrected by measurement), D8 |
+
+> **This scorecard was revised after measurement.** D2 was originally counted as
+> converged on the strength of `.claude/rules/` examples; scoring the 16 canaries
+> showed skill bodies do not carry that provenance. See
+> [`results.md`](results.md) Finding 4. D4 also now carries a caveat: it scored
+> 4–5 across every canary with zero inter-judge disagreement, so it currently
+> discriminates nothing and cannot be counted as evidence of convergence
+> either way (Finding 2).
 
 ---
 

--- a/docs/benchmarks/2026-08-agent-skills-research/README.md
+++ b/docs/benchmarks/2026-08-agent-skills-research/README.md
@@ -1,0 +1,132 @@
+# 2026-08 Agent-Skill Research Synthesis
+
+Appraisal of published agent-skill research, a rubric derived from it, and an
+honest check of whether this marketplace's conventions independently converged
+with the literature.
+
+**Status: exploratory. Nothing here is wired into a lint, a gate, or CI**, by
+design — see the binding constraints at the top of [`rubric.md`](rubric.md).
+
+| File | Contents |
+|---|---|
+| [`appraisal.md`](appraisal.md) | Critical evaluation of arXiv:2608.14036 and the two adjacent papers — what holds, what to discount, and why |
+| [`rubric.md`](rubric.md) | 8 provisional quality dimensions, each traced to a finding and graded for evidence strength |
+| `README.md` | This file — the convergence check |
+
+## Source set
+
+| Paper | Date | Role |
+|---|---|---|
+| [Demystifying Agent Skills: Why They Work—Until They Don't](https://arxiv.org/abs/2608.14036) | 2026-08-14 | Primary. Mechanism and failure taxonomy |
+| [SkillsBench](https://arxiv.org/abs/2602.12670) | 2026-02, rev. 06 | Effect size; the only published quality rubric |
+| [Skill Coverage](https://arxiv.org/abs/2606.20659) | 2026-06-09 | Instruction-adherence metric |
+
+## The one-line verdict on the study
+
+**Sound mechanism study, weak headline effect, and — decisively for our purpose —
+skill quality was never an independent variable in any of the three papers.**
+So the rubric is inference from mechanism findings, not measured
+quality→outcome relationships. Detail in [`appraisal.md`](appraisal.md) §3.7.
+
+---
+
+## Convergence check: did we independently arrive at the same conclusions?
+
+Broadly **yes** — 6 of 8 dimensions converged, several of them predating the
+paper by months. One divergence is defensible on a cost model the papers do not
+model. One is a genuine gap.
+
+| Dim | Our position | Verdict |
+|---|---|---|
+| **D1** Procedural anchoring | `skill-execution-structure.md` (2026-03-02) — "when a skill reads like a specification document, the model summarizes what it could do instead of doing it. **This is the most common skill authoring mistake.**" Prescribes `Phase N:` → `Step N: <verb>`, imperative openers, reference data moved out. | **Converged, 5 months early.** We independently named procedure-vs-description as *the* primary failure. The paper quantifies it (65.7% vs 4.5%); we identified it and built the fix. |
+| **D2** Outcome annotation | Not a stated rule, but pervasive practice. Rules carry dated failure provenance with observed cost — `loop-integrity.md`, `agent-coworker-detection.md` ("force-removed ~24 peer worktrees"), `gh-json-fields.md` § "The `merged` mistake". | **Converged in practice, unstated as principle.** Our provenance discipline is *richer* than the paper's synthetic skills. But `skill-quality.md` § Writing Style pushes toward positive framing, creating an unresolved tension (rubric D2 note). |
+| **D3** Execution-layer specificity | `agentic-optimization.md`, `structured-script-output.md`, and exact-command discipline throughout — `task-id-stability.md`'s `task +LATEST uuids` vs the silently-empty `_get uuid` is precisely this dimension. | **Converged strongly.** A repo strength. The paper's largest measured win (env failures 5.3%→0.2%) is the thing our rules obsess over. |
+| **D4** Adaptation latitude | `hook-block-vs-nudge.md` — block for safety, nudge for style; a hard block "dead-ends subagents lacking the tool." `bash-tool-replacements.md` demoted `find`/`grep`/`ls` from blocks to nudges. | **Converged — and we are ahead.** The paper measures skill-caused failures at 10.0% vs <1%. We independently found the same pathology *and* built a local empirical metric for it: **same-session repeat-block rate**, which drove the #1871/#1909/#2036 demotions and caught #2148's regression (46.3% break from a 6.3–20.0% band). The literature has no equivalent. |
+| **D5** Budget discipline | `skill-quality.md`: target ≤10,000 chars (~2,500 tok), ERROR at 26,000 chars (~6,500 tok). | **Divergent, defensibly.** Our ceiling is **~4.3× the SkillsBench ecosystem median** (~1.5k tokens) and our target ~1.7×. But `context-engineering.md` makes the point the papers miss entirely: a `SKILL.md` body is paid *only when the skill fires*, whereas unscoped rules are paid **every turn** — so ranking cuts by `always-loaded cost × frequency` is a strictly better cost model than raw size. We are less strict on the axis the papers measure and stricter on an axis they ignore. |
+| **D6** Retrieval distinctness | Description band (~120–150 chars, trigger keywords front-loaded), `skillListingBudgetFraction`, and the pi adapter's `search_skills` + ranked top-k with a frozen gate at `main_hit_at_k_min = 0.57`. | **Converged and ahead.** `adapters/eval/` is effectively RQ4 run continuously in production over ~400 skills, reporting hit@1 / hit@k / MRR. See the caveat below — the paper partially *undercuts* the premise. |
+| **D7** Scope focus | `skill-consolidation.md`, and C4 single-source-of-truth in `context-engineering.md`. | **Converged conceptually**, though we have no equivalent of SkillsBench's "at most three modules" threshold, and "module" does not map cleanly onto our layout. |
+| **D8** Constraint checkability | `regression-testing.md` (every fixed bug gets a script check) and `evals.json` typed checks. | **Genuine gap.** We verify that *bugs stay fixed* and that *outputs match expectations*. We do not verify that a skill's own instructions were **followed in a trajectory**. Skill Coverage's finding that agents cover only 38.66–45.51% of extracted constraints suggests this blind spot is large. |
+
+### Scorecard
+
+| | Count |
+|---|---|
+| Converged (some ahead of the literature) | 6 — D1, D2, D3, D4, D6, D7 |
+| Divergent but defensible | 1 — D5 |
+| Genuine gap | 1 — D8 |
+
+---
+
+## Two findings that should actually change something
+
+Everything above is confirmation. These two are new information.
+
+### 1. Pool growth did not hurt task success — this is reassuring, and it complicates the adapter's rationale
+
+RQ4: as the pool grew 5 → 100, **actual-use precision collapsed 29.6% → 3.3%
+while task success stayed flat (36.4% → 39.3%)**. The authors conclude exact
+skill matching is *"neither sufficient nor strictly necessary."*
+
+For a ~400-skill marketplace the headline reading is **good news**: catalog
+growth is not, on this evidence, degrading outcomes.
+
+The complication is narrower and worth stating plainly. `adapters/CUTOVER.md`
+freezes a cutover gate on `main_hit_at_k_min = 0.57` — a **retrieval-quality**
+threshold. RQ4 suggests retrieval precision and task success can decouple
+badly, so a retrieval metric may be a weak proxy for the outcome we care about.
+
+This does **not** invalidate the adapter. Its primary justification was a
+*token-budget* problem — ~9,900 standing tokens over ~95 curated skills reduced
+to ~600 while reaching all ~400 — and that argument is untouched by RQ4. What
+deserves revisiting is only the implicit assumption that a higher `hit_at_k`
+translates into better task outcomes. On current evidence that link is
+unestablished in either direction.
+
+### 2. Skills cause failures that raw execution does not
+
+SC3: `skill_guidance_misapplied_or_ignored` + `timeout_budget_exhaustion` at
+**10.0% of skill trials vs <1% of raw trials**. This is a direct measurement
+(evidence grade A), not a coded inference.
+
+The framing matters: a skill is not a free addition. It removes execution-layer
+failures (D3) and introduces invocation-layer ones. Our `hook-block-vs-nudge.md`
+litigation test — *what does this exempt?* — is the closest thing we have to a
+control on it, and it currently applies to hooks rather than to skills
+generally.
+
+---
+
+## What would make this rubric trustworthy
+
+In priority order (expanded in [`rubric.md`](rubric.md) § Validation):
+
+1. **A study that varies skill quality and measures outcomes.** Nobody has run
+   it. Until then the rubric generates hypotheses, not grades.
+2. **Local ablation.** `skill-evaluation.md` Tier 2 already computes
+   with-skill − baseline deltas across a golden set. Scoring those canaries on
+   this rubric and correlating D-scores against measured deltas would be our
+   first *local* evidence, at the cost of one matrix run. This is the cheapest
+   real validation available to us.
+3. **More papers.** Two of three search-summary figures checked during this
+   appraisal were **wrong** ([`appraisal.md`](appraisal.md) §5) — extend this
+   synthesis only from primary sources.
+
+## Deterministic-check roadmap
+
+Not a backlog — nothing here should be built before validation. Full table in
+[`rubric.md`](rubric.md).
+
+| Priority | Check | Why it's first |
+|---|---|---|
+| 1 | **D5** ecosystem-median comparator | Arithmetic over data `check_skill_size()` already computes |
+| 2 | **D6** sibling-confusability report | High value, and `adapters/core/` already has the embedding + BM25 machinery to do nearest-neighbour cosine over descriptions |
+| — | Everything else | Waits for validation |
+
+## Related
+
+- `.claude/rules/skill-execution-structure.md` — D1, converged independently
+- `.claude/rules/hook-block-vs-nudge.md` — D4, where we lead the literature
+- `.claude/rules/context-engineering.md` — the cost model that justifies the D5 divergence
+- `.claude/rules/skill-evaluation.md` — the Tier 2 machinery that would validate this
+- `adapters/CUTOVER.md` — the retrieval gate RQ4 bears on
+- `docs/benchmarks/2026-07-context-engineering/` — the frozen-rubric methodology copied here

--- a/docs/benchmarks/2026-08-agent-skills-research/appraisal.md
+++ b/docs/benchmarks/2026-08-agent-skills-research/appraisal.md
@@ -1,0 +1,252 @@
+# Appraisal — "Demystifying Agent Skills: Why They Work—Until They Don't"
+
+**Primary paper:** [arXiv:2608.14036](https://arxiv.org/abs/2608.14036) — Jiang,
+Huang, Xing, Wu, Gao, Cao, Wang, Liu, Li. Submitted **2026-08-14**.
+
+**Appraised:** 2026-08-21. **Verdict: methodologically strong for its actual
+claim, routinely over-read for the claim people want it to make.**
+
+This document evaluates the study on its own terms and positions it against the
+two adjacent papers. The rubric derived from it is
+[`rubric.md`](rubric.md); read this file first, because the rubric's usable
+strength is capped by what is established here.
+
+---
+
+## 1. What the paper actually claims
+
+The paper is **not** a skill-quality study. It is a *mechanism* study asking
+"when do skills help, and through what pathway" — deliberately, in its own
+framing, rather than "measuring aggregate task success."
+
+| RQ | Question | Headline result |
+|---|---|---|
+| RQ1 | Does *representation* matter, holding content fixed? | Skills beat workflow memory by **+6.06 pp**, 95% bootstrap CI **[+0.76, +11.36]** |
+| RQ2 | Do success/failure annotations matter? | Removing them degrades quality **0.7462 → 0.4000** (Gemini, 3s2f mixture) |
+| RQ3 | Do skills transfer across harnesses? | Codex-built skills retain utility when evaluated in Gemini CLI |
+| RQ4 | Does retrieval scale? | Pool 5→100: actual-use precision **29.6% → 3.3%**; task success **36.4% → 39.3%** (flat) |
+
+Mechanism decomposition: **procedural anchoring 65.7%** of skill effectiveness
+vs **explicit knowledge injection 4.5%**.
+
+Taxonomy: 12 modes in 3 categories — SC1 guided success, SC2 execution &
+verification failures, SC3 invocation & budget failures.
+
+---
+
+## 2. The design virtue that makes this paper worth reading
+
+**The control ladder isolates representation from content.** Three arms:
+
+| Arm | Content | Form |
+|---|---|---|
+| Raw | none | — |
+| Workflow memory | the trajectories | appended as procedural memory |
+| Skill | *the same* trajectories | distilled into a standardized `SKILL.md` |
+
+This is the thing almost every other skills evaluation gets wrong. Comparing
+skill-vs-nothing conflates *having the knowledge* with *having it packaged as a
+skill*. By holding the source trajectories fixed and varying only the wrapper,
+RQ1 measures the packaging itself. That single design choice is why this paper
+can say anything about skill *authoring* at all.
+
+Three further credits:
+
+- **Human validation of the LLM coding.** 714 trajectory–label checks, **95.8%
+  exact agreement, Cohen's κ = 0.952**. Most LLM-as-annotator papers skip this.
+- **Cross-harness transfer tested** (RQ3), not assumed.
+- **Honest, specific self-reported limitations** — the ~3% sampling rate, the
+  terminal/tool-use domain restriction, the limited model-configuration count,
+  and the RQ4 model substitution are all disclosed by the authors, not
+  discovered by this appraisal.
+
+---
+
+## 3. Where to discount it
+
+Ranked by how much they should change your reading.
+
+### 3.1 The 65.7% / 4.5% split is a coding artifact, not a causal measurement
+
+This is the most-quoted number in the paper and the weakest-supported one.
+
+It comes from an **LLM open-coding pass over 240 sampled trajectories (~3% of
+8,135 records)**, with Claude Sonnet 4.6 assigning mechanism labels. The human
+validation is real but measures the **wrong thing for this purpose**: the
+annotator checked that labels were "grounded in the recorded agent behavior" and
+independently re-mapped the 238 labels to canonical modes. κ = 0.952 is
+therefore **taxonomy-mapping agreement**, not validation that the original
+mechanism attribution was causally correct.
+
+So "65.7% of effectiveness comes from procedural anchoring" is more accurately:
+*65.7% of a 3% sample was labeled procedural-anchoring by an LLM, and a human
+agreed that label was consistently mapped.* The direction is credible. The
+precision of the ratio is not.
+
+**Compounding factor:** trajectories were truncated for coding to a **6,000-char
+head + 12,000-char tail**. Mid-trajectory behavior is invisible to the coder.
+Procedural anchoring shows up early (the agent orients and commits to a plan);
+knowledge injection can occur anywhere. The truncation window plausibly biases
+the split in exactly the observed direction. The paper does not test for this.
+
+### 3.2 The headline effect is weak and the CI nearly touches zero
+
+**+6.06 pp, 95% CI [+0.76, +11.36].** The lower bound is +0.76 — statistically
+distinguishable from zero, but only just, and the interval spans a 15× range in
+effect size. The interval is consistent with skills-over-workflow-memory being a
+rounding error *or* being substantial. Any claim resting on "skills beat
+equivalent unstructured context" should be held loosely.
+
+### 3.3 RQ4's retrieval finding is self-undercutting — and this matters most to us
+
+The abstract frames retrieval as "a significant bottleneck." The data is more
+interesting than that:
+
+| Pool size | Actual-use precision | Task success |
+|---|---|---|
+| 5 | 29.6% | 36.4% |
+| 100 | 3.3% | 39.3% |
+
+Precision collapsed by ~9×. **Success did not move** (and drifted slightly
+*up*). The paper's own reading is that exact skill matching is "neither
+sufficient nor strictly necessary."
+
+For a ~400-skill marketplace this is the single most decision-relevant result
+in the paper, and it points **against** the panic reading. Growing the pool
+20× did not degrade task outcomes. What degraded was the *tidiness* of the
+match — the agent stopped picking the designated skill and still did fine.
+
+Two caveats before anyone relaxes: this was measured on SkillsBench tasks with
+native task–skill annotations (well-specified tasks, a clean ground-truth
+mapping), and "actual-use precision" presupposes there is one correct skill per
+task — a framing that fits a benchmark better than it fits real workflows where
+several skills legitimately apply.
+
+### 3.4 RQ4 sits on different substrate than RQ1–RQ3
+
+GPT-5.3-Codex became unavailable mid-study; RQ4 used **GPT-5.4** instead. The
+authors handle this correctly and say so explicitly — RQ4 "is therefore
+interpreted only through within-pairing comparisons." But the practical
+consequence is that **the mechanism findings and the retrieval findings do not
+compose**. You cannot chain "anchoring is 65.7% of the benefit" with "precision
+falls to 3.3%" into a single quantitative story; they are measured on different
+model substrate.
+
+### 3.5 The skills studied are LLM-distilled, not human-authored
+
+Skills were **distilled by Claude from 5 prior trajectories** on a fixed-budget
+composition grid (5s0f … 0s5f). They are synthetic artifacts generated from a
+handful of runs.
+
+Our skills are hand-written, iterated over months, carry issue provenance, and
+are cross-linked into a rule system. Generalizing from "LLM-distilled 5-trajectory
+skill" to "curated marketplace skill" is an **inference, not a finding**. It is
+a reasonable inference — but it is the load-bearing assumption under every use
+of this paper as authoring guidance, including our rubric.
+
+### 3.6 Domain restriction
+
+Terminal- and tool-using benchmarks (Terminal-Bench 2.0, Terminal-Bench Pro,
+SkillsBench). Authors state it "does not cover... long-horizon web interaction
+or open-ended collaboration."
+
+Our catalog is partially in-domain (CLI wrappers, git operations, scripted
+checks) and partially out (multi-agent orchestration, review workflows,
+long-running loops, documentation curation). Weight the rubric accordingly per
+skill.
+
+### 3.7 The decisive limitation for our purpose: quality was never a variable
+
+**The study varies representation, annotation, harness, and pool size. It never
+varies skill quality.** There is no high-quality vs low-quality arm.
+
+Therefore the paper **cannot directly support any claim of the form "skills with
+property P outperform skills without P."** Every quality indicator in our rubric
+is derived by *inference* from a mechanism finding — "anchoring drives the
+benefit, therefore skills should be anchor-shaped" — not from a measured
+quality→outcome relationship.
+
+This is the honest ceiling on the whole exercise and is restated at the top of
+the rubric.
+
+---
+
+## 4. The three-paper picture
+
+The papers form a chain rather than competing with each other.
+
+| Paper | Question | Design | What it gives us |
+|---|---|---|---|
+| **SkillsBench** [2602.12670](https://arxiv.org/abs/2602.12670) (Feb 2026, rev. Jun; Li + 76 co-authors) | *Do* skills work? | 87 tasks / 8 domains, paired no-skill vs curated-skill, 18 model–harness configs | Effect size (33.9% → 50.5%, +16.6 pp); the only **explicit quality rubric**; ecosystem audit |
+| **Demystifying** [2608.14036](https://arxiv.org/abs/2608.14036) (Aug 2026) | *Why*, and when not? | 3-arm contrastive, 8,135 trials, coded taxonomy | Mechanism (anchoring ≫ knowledge); failure taxonomy; retrieval scaling |
+| **Skill Coverage** [2606.20659](https://arxiv.org/abs/2606.20659) (Jun 2026; Tan, Huang, Sun) | Was the skill *followed*? | Constraint extraction from NL → per-constraint pass/fail over trajectory | A **test-adequacy metric**; coverage measured at only **38.66–45.51%** |
+
+### SkillsBench's quality rubric (Appendix A.3)
+
+The one piece of directly-quality-relevant prior art. Four dimensions, 0–3 each,
+**max 12**:
+
+- **Completeness** — presence of required components
+- **Clarity** — readability and organization
+- **Specificity** — actionable vs vague guidance
+- **Examples** — presence and quality of examples
+
+Ecosystem mean **6.2/12 (SD 2.8)** over **47,150 audited skills**; benchmark
+skills scored **10.1/12** (top quartile selected).
+
+**Its own limitation mirrors ours:** quality was used as a *selection filter* to
+remove variance, not manipulated as an independent variable. So even the paper
+that scores quality does not demonstrate that its rubric predicts outcomes.
+Nobody has yet run the study we would actually want.
+
+Two SkillsBench structural findings *are* directly usable:
+
+- **Focused beats exhaustive** — "Focused Skills with at most three modules
+  outperform larger or exhaustive bundles."
+- **Ecosystem skills are small** — median `SKILL.md` **~1.5k tokens**, median
+  total under **2.5k tokens**.
+
+### Skill Coverage is the most convertible to a deterministic check
+
+Its two-stage method — extract behavioral constraints from natural-language
+instructions, then assert each against the trajectory — is close to something we
+could build on `evals.json`. Its finding that agents covered only **38.66–45.51%**
+of extracted constraints, and that *strengthening the failed instructions*
+recovered **16.0%** of tasks, is the most actionable single result across all
+three papers.
+
+---
+
+## 5. A provenance warning from doing this appraisal
+
+Search-engine AI summaries of these papers were **materially wrong** and would
+have corrupted the rubric had they not been checked against primary sources:
+
+| Claim in search summary | Primary source |
+|---|---|
+| SkillsBench: "84 tasks spanning 11 domains" | **87 tasks across 8 domains** |
+| SkillsBench: "+16.2 pp" | **+16.6 pp** |
+| The 12-point rubric was initially attributed from a summary alone | Real, but only confirmed by fetching Appendix A.3 directly |
+
+Every figure in this appraisal and the rubric was taken from the arXiv abstract
+or HTML body. **When extending this rubric with further studies, fetch the
+paper.** Two of three summary-derived figures checked were wrong.
+
+---
+
+## 6. Bottom line
+
+| Question | Answer |
+|---|---|
+| Is the study sound? | **Yes, for a mechanism study.** The 3-arm control is genuinely good design and the human-validation step is above field norm. |
+| Is the headline effect strong? | **No.** +6.06 pp with CI [+0.76, +11.36] is weak and wide. |
+| Is the 65.7%/4.5% split trustworthy? | **Directionally yes, numerically no.** ~3% LLM-coded sample, truncated inputs, validation measured mapping consistency rather than attribution validity. |
+| Does it justify a quality rubric? | **Only by inference.** Quality was never a variable in any of the three papers. |
+| What should change our behaviour? | The **failure taxonomy** (SC3: skills cause 10.0% misapplication failures vs <1% raw) and the **flat-success-under-pool-growth** result. Both are direct measurements, not coded inferences. |
+| Confidence in the derived rubric | **Signal, not grade.** Sufficient to generate hypotheses about our catalog; insufficient to rank or gate skills. |
+
+## Related
+
+- [`rubric.md`](rubric.md) — the derived rubric and its per-dimension evidence grades
+- [`README.md`](README.md) — how our existing rules already line up
+- `docs/benchmarks/2026-07-context-engineering/rubric.md` — the frozen-rubric methodology this exercise copies

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/blueprint-execute_j1.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/blueprint-execute_j1.json
@@ -1,0 +1,72 @@
+{
+  "unit": "blueprint-plugin/skills/blueprint-execute/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "multi-step-orchestrator",
+  "judge_id": "j1",
+  "dimensions": {
+    "D1": {
+      "score": 4,
+      "rationale": "The spine is an ordered, first-match-wins ladder of ten numbered state checks, each with a concrete condition and a committed action plus an explicit Exit, preceded by a parallel context-gathering phase. It falls short of 5 only because a declarative tail (Idempotency Guarantees, Integration with Existing Commands, the closing Note) sits in the always-loaded body without feeding any step; moving those to the sidecar would have made it exemplary.",
+      "evidence": [
+        {"quote": "Run through these checks in order, executing the first matching action:"},
+        {"quote": "**If NOT initialized**: Run `/blueprint:init`, then **Exit**."}
+      ]
+    },
+    "D2": {
+      "score": 2,
+      "rationale": "Nothing records a path that was tried and failed, a symptom to recognise, or a cost. The one guardrail-shaped sentence is a constraint on quiet mode, and the Idempotency table asserts safety properties rather than reporting observed consequences; there is no guidance for a malformed manifest, a stale hash, or an action that half-completes. Attaching even one observed failure to the step it threatens would move this to 3.",
+      "evidence": [
+        {"quote": "Quiet mode never skips confirmation gates that guard writes"},
+        {"quote": "| State detection is read-only | Only reads files until action is chosen |"}
+      ]
+    },
+    "D3": {
+      "score": 4,
+      "rationale": "Most steps carry exact invocations rather than descriptions: literal jq filters against a named manifest path, an explicit current format version, explicit schedule semantics (daily = >24h), a bundled config script resolved via CLAUDE_SKILL_DIR, and a full read-modify-write for the registry entry. It is not a 5 because expected output shapes are never stated, tool preconditions (jq present, manifest parseable) are unstated with no way to tell one is unmet, and Step 4 is the one check given no command at all.",
+      "evidence": [
+        {"quote": "jq -r '.task_registry | to_entries[] | select(.value.enabled == true) | select(.value.auto_run == true) | .key' docs/blueprint/manifest.json"},
+        {"quote": "Check each generated rule hash against manifest:"}
+      ]
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "The opening table names four situations where this skill is the wrong choice and routes each to a specific named alternative, the body reaffirms that direct commands remain available, and Step 10 gives the procedure a graceful exit when no action is detectable. It stops short of 5 because there is no guidance for the case where the detection ladder itself is wrong for the repository, only for the case where the user already knows which command they want.",
+      "evidence": [
+        {"quote": "Use blueprint-upgrade instead when you know you need to migrate"},
+        {"quote": "This meta command **delegates** to existing blueprint commands rather than replacing them."}
+      ]
+    },
+    "D5": {
+      "score": 4,
+      "rationale": "Body is 8,768 characters (~2,192 tokens), roughly 1.5x the ~1.5k ecosystem median, but the material is coherent to one procedure and the genuinely bulky parts (all AskUserQuestion prompt templates, four worked examples, common workflows, sync details) are deferred to a linked REFERENCE.md that is never loaded unless needed. Trimming the non-consuming declarative tail would put the body at the median and earn a 5.",
+      "evidence": [
+        {"quote": "For detailed AskUserQuestion templates, examples, and common workflows, see [REFERENCE.md](REFERENCE.md)."}
+      ]
+    },
+    "D6": {
+      "score": 5,
+      "rationale": "The description names the distinguishing condition rather than just the topic: it is the entry point invoked with no subcommand, and it quotes the literal utterances that select it. Against the obvious near siblings in a blueprint family (a status viewer, an initialiser, an upgrader) the choice is decidable from the description alone, without opening any body.",
+      "evidence": [
+        {"quote": "Blueprint meta command: determine and execute the next logical action."},
+        {"quote": "Use when asked 'what's next?', 'continue blueprint', or 'run blueprint' without a subcommand."}
+      ]
+    },
+    "D7": {
+      "score": 5,
+      "rationale": "One entry condition (invoked without a subcommand) and one procedure (detect state, execute exactly one action, exit). Everything else present serves it: the interaction-mode resolution governs the prompts inside the ladder, the registry update is the post-action bookkeeping for whichever branch fired, and the optimization table is a list of shortcuts into the same flow. No section reads as a second procedure that could stand alone.",
+      "evidence": [
+        {"quote": "Executes ONE action per run, then exits"}
+      ]
+    },
+    "D8": {
+      "score": 4,
+      "rationale": "Most instructions decompose into transcript-observable conditions: a named command was run, a specific slash command was invoked, exactly one action executed before exit, the registry entry was updated with the given jq. It misses 5 because several steps are dispositional with no observable correlate, notably the consolidation of Phase 0 findings and 'Report results briefly', and the stale-hash comparison in Step 4 defines no checkable operation.",
+      "evidence": [
+        {"quote": "Consolidate findings into unified context: git quality, documentation coverage, blueprint health, actionable items."},
+        {"quote": "**If NOT initialized**: Run `/blueprint:init`, then **Exit**."}
+      ]
+    }
+  },
+  "body_chars": 8768,
+  "sidecars": ["REFERENCE.md"]
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/blueprint-execute_j2.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/blueprint-execute_j2.json
@@ -1,0 +1,70 @@
+{
+  "unit": "blueprint-plugin/skills/blueprint-execute/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "multi-step-orchestrator",
+  "judge_id": "j2",
+  "dimensions": {
+    "D1": {
+      "score": 4,
+      "rationale": "The spine is an explicit ordered dispatch: ten numbered state checks, each with a command and an if/then action terminating in Exit, introduced by an imperative first-match directive. It falls short of 5 because roughly a quarter of the body (Idempotency Guarantees, Integration with Existing Commands, Agentic Optimizations, the closing Note) is declarative framing that no step consumes and that is not deferred to the sidecar.",
+      "evidence": [
+        {"quote": "Run through these checks in order, executing the first matching action:"},
+        {"quote": "**If NOT initialized**: Run `/blueprint:init`, then **Exit**."}
+      ]
+    },
+    "D2": {
+      "score": 2,
+      "rationale": "No failure mode is named anywhere: no step says what a wrong or absent result looks like, what happens when jq/manifest parsing fails, or what a mis-detected state costs. The only outcome-adjacent material is a boundary statement in Interaction Mode and a guarantees table, both asserted rather than observed, so this sits just above the pure-unlabelled-assertion anchor. Naming even one observed misfire per step (e.g. what a stale-hash false positive did) would move it up.",
+      "evidence": [
+        {"quote": "Quiet mode never skips confirmation gates that guard writes"},
+        {"quote": "**Concept**: Run this command anytime to automatically determine what should happen next in your blueprint workflow. Safe to run repeatedly - it's idempotent and will always figure out the right action."}
+      ]
+    },
+    "D3": {
+      "score": 4,
+      "rationale": "Most steps carry an exact runnable invocation with real paths and full jq expressions, and the initialization/upgrade preconditions are stated as literal detection commands plus a pinned version constant, so a reader can tell mechanically when a precondition is unmet. It is not a 5 because no expected output shape is given for any command and Step 4 (stale/modified hash comparison) is prose only, with no invocation at all.",
+      "evidence": [
+        {"quote": "test -f docs/blueprint/manifest.json"},
+        {"quote": "jq -r '.task_registry | to_entries[] | select(.value.enabled == true) | select(.value.auto_run == true) | .key' docs/blueprint/manifest.json"}
+      ]
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "The opening table pairs every applicability row with a named alternative skill, and the closing section plus the optimizations table explicitly tell the reader to bypass this orchestrator and invoke the specific command directly. It stops short of 5 because it never addresses the case where the auto-detection itself picks wrongly for the situation; the only in-flow fallback is Step 10 deferring to status.",
+      "evidence": [
+        {"quote": "| Use this skill when... | Use blueprint-status instead when... |"},
+        {"quote": "Users can still run specific commands directly when they know what they want."}
+      ]
+    },
+    "D5": {
+      "score": 3,
+      "rationale": "Body is 8,769 chars (~2,192 tokens), roughly 1.5x the ~1.5k ecosystem median, but the material is coherent to the single dispatch procedure and there is real, signposted deferral: a 7,845-char REFERENCE.md holds all ten AskUserQuestion templates, four worked examples, workflows, and the sync/schedule detail. The residue that keeps it off 5 is the non-procedural tail that could equally have been deferred.",
+      "evidence": []
+    },
+    "D6": {
+      "score": 5,
+      "rationale": "The description names the exact distinguishing condition against its own siblings - invocation without a subcommand - alongside the literal trigger phrases, so a reader choosing between this and blueprint-status/blueprint-init/blueprint-upgrade can decide from the description alone. The 'meta command' framing further separates it from every concrete blueprint-* sibling without opening any body.",
+      "evidence": [
+        {"quote": "Use when asked 'what's next?', 'continue blueprint', or 'run blueprint' without a subcommand."}
+      ]
+    },
+    "D7": {
+      "score": 4,
+      "rationale": "One procedure with one entry condition - detect state, execute exactly one action, exit - and the ten steps plus the post-action registry write all serve it. It is not a 5 because the Interaction Mode block is a cross-cutting automation policy (resolving a shared config script, citing an ADR) that reads as adjacent material capable of standing alone rather than as a step of this dispatch.",
+      "evidence": [
+        {"quote": "| Single action execution | Executes ONE action per run, then exits |"},
+        {"quote": "Before any closing `AskUserQuestion` menu, resolve the automation config:"}
+      ]
+    },
+    "D8": {
+      "score": 4,
+      "rationale": "Most instructions decompose into discrete conditions an observer could confirm from a transcript: a specific command run, a version threshold compared, a named slash command delegated to, and a single-action-then-exit invariant. A handful remain dispositional or unobservable - 'Report results briefly', 'Consolidate findings into unified context', and the uninstrumented hash comparison in Step 4 - which keeps it off 5.",
+      "evidence": [
+        {"quote": "**If manifest version < 3.0.0**: Run `/blueprint:upgrade`, then **Exit**."},
+        {"quote": "| Single action execution | Executes ONE action per run, then exits |"}
+      ]
+    }
+  },
+  "body_chars": 8769,
+  "sidecars": ["REFERENCE.md"]
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/blueprint-prp-create_j1.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/blueprint-prp-create_j1.json
@@ -1,0 +1,69 @@
+{
+  "unit": "blueprint-plugin/skills/blueprint-prp-create/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "multi-step-orchestrator",
+  "judge_id": "j1",
+  "dimensions": {
+    "D1": {
+      "score": 4,
+      "rationale": "The spine is an ordered, imperatively-opened eight-step procedure with a real decision point that loops back on a numeric gate, and the bulk reference material (PRP structure, task categorization, checklists) is deferred to REFERENCE.md. It falls short of 5 because Steps 2-3 are enumerations of what to gather rather than committed actions, and the framing block plus the When-to-Use table sit before the procedure without feeding any step.",
+      "evidence": [
+        {"quote": "Execute the complete PRP creation workflow:"},
+        {"quote": "### Step 6: Score confidence across dimensions"},
+        {"quote": "If score < 7 → Return to Steps 2-3 to fill gaps."}
+      ]
+    },
+    "D2": {
+      "score": 3,
+      "rationale": "There is a genuine outcome signal wired into a step - the confidence gate labels the low-score path as risky and prescribes a remediation loop - but it is asserted as a threshold rather than recorded from an observed failure, and no step names a symptom or a cost of getting it wrong. The 'Known Gotchas' material the skill demands is a requirement placed on the artifact being authored, not a failure record for this procedure.",
+      "evidence": []
+    },
+    "D3": {
+      "score": 4,
+      "rationale": "Preconditions are stated with the exact detection command and the exact failure response, output paths and ID format are literal, and the Agentic Optimizations table gives copy-pasteable invocations. It is not a 5 because the exact shape of the produced artifact and of the Step 8 report are described only as bulleted content lists, with the concrete structure pushed into the sidecar.",
+      "evidence": [
+        {"quote": "- Blueprint initialized: !`find . -path '*/docs/blueprint/*' -maxdepth 3 -name 'manifest.json' -type f`"},
+        {"quote": "1. If Blueprint not initialized → Error: \"Run `/blueprint:init` first\""},
+        {"quote": "- Next ID = last_prp + 1 (format: `PRP-NNN`)"}
+      ]
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "A When-to-Use table names four out-of-scope conditions and, for the nearest sibling, routes explicitly to the alternative skill; the sub-threshold branch additionally offers an explicit escape from the procedure's own gate. It stops short of 5 because two of the four out-of-scope rows say only that the skill does not apply without naming what to do instead, and nothing covers the case where the procedure itself is wrong for the situation.",
+      "evidence": [
+        {"quote": "| Creating new feature implementation packet | Executing an existing PRP (use `/blueprint:prp-execute`) |"}
+      ]
+    },
+    "D5": {
+      "score": 5,
+      "rationale": "7,358 characters is roughly 1.8k tokens - close to the ~1.5k ecosystem median - and the material that would have blown that budget (full PRP document template, task-categorization rules, review checklist, curated-rule authoring) is explicitly deferred to a single on-demand REFERENCE.md, referenced by anchor from the steps that consume it.",
+      "evidence": [
+        {"quote": "For PRP document structure, task categorization, review checklists, and curated-rule creation guidance, see [REFERENCE.md](REFERENCE.md)."}
+      ]
+    },
+    "D6": {
+      "score": 4,
+      "rationale": "The description leads with the creation verb and the artifact acronym and names distinguishing conditions (subagent execution, TDD, confidence scoring), so choosing between it and its obvious sibling is decidable without opening either body. It is not a 5 because the trigger vocabulary ('research, context, validation gates', 'planning a feature packet') would overlap heavily with a sibling planning-document skill in the same family, where only the acronym separates them.",
+      "evidence": [
+        {"quote": "Create a PRP (Product Requirement Prompt) with research, context, and validation gates. Use when planning a feature packet for subagent execution with TDD and confidence scoring."}
+      ]
+    },
+    "D7": {
+      "score": 5,
+      "rationale": "One entry condition (a named feature to be packaged) drives one procedure end to end: research, draft, score, review, report. Nothing present stands alone as an independent procedure - even the scoring and the closing hand-off exist to gate and route the single artifact this skill produces.",
+      "evidence": [
+        {"quote": "Execute the complete PRP creation workflow:"}
+      ]
+    },
+    "D8": {
+      "score": 4,
+      "rationale": "Most instructions decompose into transcript-visible conditions: a file written at a literal path, an ID computed as last_prp + 1, a manifest registry updated, a numeric score compared against an explicit threshold, and a loop-back taken when it fails. It is not a 5 because the inputs to that threshold are subjective 1-10 ratings and two review-checklist items ('Is pseudocode clear enough', 'Confidence score is honest') have no observable correlate.",
+      "evidence": [
+        {"quote": "Calculate overall score as average of dimensions. Target: 7+ for execution, 9+ for subagent delegation."},
+        {"quote": "- Next ID = last_prp + 1 (format: `PRP-NNN`)"}
+      ]
+    }
+  },
+  "body_chars": 7358,
+  "sidecars": ["REFERENCE.md"]
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/blueprint-prp-create_j2.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/blueprint-prp-create_j2.json
@@ -1,0 +1,76 @@
+{
+  "unit": "blueprint-plugin/skills/blueprint-prp-create/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "multi-step-orchestrator",
+  "judge_id": "j2",
+  "dimensions": {
+    "D1": {
+      "score": 5,
+      "rationale": "The body's spine is eight numbered, verb-led steps under an imperative opener, each consuming its declarative material in place, with a real control-flow decision point that loops back on a failed threshold. The only non-step material is a short definition block, a sibling-disambiguation table, and a command table; the bulk of reference detail (PRP structure, task categorization, checklists) is deferred to a sidecar. Turning the steps into descriptions of phases, or inlining the PRP template, would have dropped this.",
+      "evidence": [
+        {"quote": "Execute the complete PRP creation workflow:"},
+        {"quote": "### Step 1: Verify prerequisites and understand requirements"},
+        {"quote": "If score < 7 → Return to Steps 2-3 to fill gaps."}
+      ]
+    },
+    "D2": {
+      "score": 2,
+      "rationale": "Almost every instruction is an unlabelled assertion: nothing records a path that was tried and failed, a symptom to recognise, or what a failure cost. Two faint traces of outcome exist — one branch is annotated as risky, and one checklist item cites a concrete bad artifact ('somewhere in...') — but neither is tied to an observed consequence, and the only 'gotchas' language concerns content the produced PRP should contain rather than failure modes of this procedure. Attaching an observed symptom and cost to the steps that threaten them (e.g. what a low-confidence PRP actually does to a subagent run) would move this up.",
+      "evidence": [
+        {"quote": "- Execute anyway (risky) → Proceed with warning"},
+        {"quote": "- [ ] All file paths are explicit (not \"somewhere in...\")"}
+      ]
+    },
+    "D3": {
+      "score": 4,
+      "rationale": "Environment preconditions are concrete and detectable: the Context block runs real discovery commands, and Step 1 states the unmet-precondition branch with the exact remedy command. Output location, ID format, and the compact command table are all literal. It stops short of 5 because the exact expected output shape of the produced document (frontmatter, section list) lives in the sidecar rather than being pinned inline, and the commands' expected outputs are not shown.",
+      "evidence": [
+        {"quote": "- Blueprint initialized: !`find . -path '*/docs/blueprint/*' -maxdepth 3 -name 'manifest.json' -type f`"},
+        {"quote": "1. If Blueprint not initialized → Error: \"Run `/blueprint:init` first\""},
+        {"quote": "- Next ID = last_prp + 1 (format: `PRP-NNN`)"}
+      ]
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "A two-column table names four conditions under which the skill should not be applied, and the sharpest one routes to a named sibling skill instead; the low-confidence branch also gives four explicit exits, including abandoning and saving incomplete. It falls short of 5 because two of the 'use alternative when' rows state only the condition without naming what to do instead, and nothing addresses the case where the procedure itself is wrong for the situation.",
+      "evidence": [
+        {"quote": "| Creating new feature implementation packet | Executing an existing PRP (use `/blueprint:prp-execute`) |"},
+        {"quote": "| Want comprehensive research and documentation | Quick prototyping without formal requirements |"}
+      ]
+    },
+    "D5": {
+      "score": 5,
+      "rationale": "The body is 6,871 characters (~1,718 tokens), essentially at the ~1.5k ecosystem median, and the heavy material — full PRP template, task categorization rules, review checklist, confidence rubric detail, curated-rule authoring — is pushed to a single on-demand REFERENCE.md that the body links by name at four separate step sites plus a closing pointer. Every invocation pays only for the procedure.",
+      "evidence": [
+        {"quote": "For PRP document structure, task categorization, review checklists, and curated-rule creation guidance, see [REFERENCE.md](REFERENCE.md)."},
+        {"quote": "Create `docs/prps/[feature-name].md` with frontmatter and sections"}
+      ]
+    },
+    "D6": {
+      "score": 4,
+      "rationale": "The description front-loads the artifact type with its expansion, the creation verb, and three distinguishing attributes (validation gates, TDD, confidence scoring), which makes it decidable against the obvious near siblings — an execute counterpart and a PRD/ADR authoring skill — without opening either body. It is not a 5 because 'planning a feature packet for subagent execution' shares real vocabulary with a work-order-style sibling, so that one boundary still needs the body.",
+      "evidence": [
+        {"quote": "description: Create a PRP (Product Requirement Prompt) with research, context, and validation gates. Use when planning a feature packet for subagent execution with TDD and confidence scoring."}
+      ]
+    },
+    "D7": {
+      "score": 5,
+      "rationale": "One procedure with one entry condition: produce a PRP document for a named feature. Research, ID allocation, drafting, scoring, validation and reporting are all stages of that single artifact's production, not independently invocable procedures, and the one adjacent capability (creating curated rule entries) is conditional and delegated to a named sibling skill rather than bundled.",
+      "evidence": [
+        {"quote": "Execute the complete PRP creation workflow:"},
+        {"quote": "Create `docs/prps/[feature-name].md` with frontmatter and sections"}
+      ]
+    },
+    "D8": {
+      "score": 4,
+      "rationale": "Most instructions decompose into conditions an observer could confirm from a transcript: the file was created at the stated path, the ID was derived as last_prp+1, the manifest registry was updated, four dimensions were scored, and the sub-7 branch was actually taken. A minority are dispositional with no observable correlate — notably whether the score is 'honest' and whether pseudocode is 'clear enough' — which keeps it off 5.",
+      "evidence": [
+        {"quote": "If score < 7 → Return to Steps 2-3 to fill gaps."},
+        {"quote": "- Next ID = last_prp + 1 (format: `PRP-NNN`)"},
+        {"quote": "- [ ] Confidence score is honest"}
+      ]
+    }
+  },
+  "body_chars": 6871,
+  "sidecars": ["REFERENCE.md"]
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/code-review_j1.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/code-review_j1.json
@@ -1,0 +1,65 @@
+{
+  "unit": "code-quality-plugin/skills/code-review/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "convention-enforcer",
+  "judge_id": "j1",
+  "dimensions": {
+    "D1": {
+      "score": 4,
+      "rationale": "The spine is an explicit ordered procedure: a single imperative delegation directive, a file-discovery step, then nine numbered steps that end in a verification gate, a scoring step and a report step. It falls short of 5 because steps 1-5 are category checklists of analysis topics rather than actions with decision points, and the trailing Agent Teams and Related Configure Skills sections are declarative material no step consumes.",
+      "evidence": [
+        {"quote": "**Delegate this task to the `agents-plugin:review` agent.**"},
+        {"quote": "7. **Re-verify each candidate finding** (false-positive gate — run BEFORE reporting):"}
+      ]
+    },
+    "D2": {
+      "score": 4,
+      "rationale": "Two failure modes are attached to the steps that threaten them rather than parked in a generic gotchas section: the false-positive gate names why an unverified claim decays, and the confidence scale names the cost of shipping ungrounded findings. It stops short of 5 because the consequences are asserted rather than recorded as observed symptoms with a measured cost, so a reader cannot recognise the failure by its signature.",
+      "evidence": [
+        {"quote": "still says what the finding claims (line numbers drift; assumptions decay)."},
+        {"quote": "guess, and guesses erode trust in the review."}
+      ]
+    },
+    "D3": {
+      "score": 3,
+      "rationale": "The main path is concrete: explicit glob patterns for discovery, a named subagent type, fixed severity and confidence enums, and a stated reporting threshold. But there are no exact invocations, no literal report template or schema, and no environment or lifecycle preconditions (nor any way to tell one is unmet); it also names the Agent tool while the frontmatter grants Task, an execution-layer detail left for the reader to reconcile.",
+      "evidence": []
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "The opening table does more than state a boundary: every out-of-scope case is paired with the named skill to use instead, and the Agent Teams section supplies an explicit escape from its own elaboration. It is not a 5 because nothing addresses the case where this procedure itself is the wrong instrument for the situation at hand — every row assumes some review skill applies.",
+      "evidence": [
+        {"quote": "| Running an end-to-end review across quality, security, perf, and tests | Walking a manual security/correctness checklist → `code-review-checklist` |"},
+        {"quote": "This is optional — the skill works without agent teams for standard reviews."}
+      ]
+    },
+    "D5": {
+      "score": 4,
+      "rationale": "The body measures 6,238 characters, roughly 1,560 estimated tokens, which sits essentially on the ~1.5k ecosystem median, and everything present is coherent to the one review procedure. It is not a 5 because there is no on-demand deferral layer at all: the only sidecar is scripts/tests (a regression harness), so the severity rubric, confidence scale and re-verification detail are all paid for on every invocation rather than being loadable on demand.",
+      "evidence": [
+        {"quote": "## Confidence Scale"}
+      ]
+    },
+    "D6": {
+      "score": 3,
+      "rationale": "The name and description are topically unambiguous and front-load real trigger vocabulary (reviewing code, OWASP, SOLID, perf bottlenecks, test gaps), but they share substantial surface with siblings the skill itself names — a checklist variant, an antipattern scanner and a test-quality auditor. The distinguishing condition (delegated end-to-end review producing one consolidated report, versus a manual checklist walk) appears only in the body, so choosing between them from descriptions alone is not decidable.",
+      "evidence": []
+    },
+    "D7": {
+      "score": 3,
+      "rationale": "One dominant procedure with one entry condition, and the five analysis domains all feed a single report rather than standing alone. It is held at 3 by adjacent secondary material: an apply-fixes step that is a mutation procedure rather than a review one (and which the skill's own table routes to a separate refactor skill), plus an optional parallel-teammate mode and a trailing configure-skill referral list.",
+      "evidence": []
+    },
+    "D8": {
+      "score": 4,
+      "rationale": "A large share of the guidance decomposes into transcript-observable conditions: every reported finding must carry a verified file:line plus a severity and confidence, low-confidence items must not appear as findings, and the report must be ranked most-severe first — an observer can check each against the output. It is not a 5 because several instructions remain dispositional with no observable correlate, notably the analysis categories and the fix-application step.",
+      "evidence": [
+        {"quote": "carry a verified `file:line`, a severity, and a confidence."},
+        {"quote": "The reporting threshold is **Medium**: report High and Medium findings; do not"},
+        {"quote": "6. **Apply fixes** where appropriate and safe"}
+      ]
+    }
+  },
+  "body_chars": 6238,
+  "sidecars": ["scripts/tests/test-code-review-rubric-depth.sh"]
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/code-review_j2.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/code-review_j2.json
@@ -1,0 +1,70 @@
+{
+  "unit": "code-quality-plugin/skills/code-review/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "convention-enforcer",
+  "judge_id": "j2",
+  "dimensions": {
+    "D1": {
+      "score": 4,
+      "rationale": "The spine is an imperative delegation directive followed by an ordered 9-step sequence with real decision points (a re-verification gate that runs BEFORE reporting, a confidence threshold that drops findings). Most declarative material is consumed by a step: the Severity Rubric feeds step 8, the Confidence Scale feeds step 8, the Re-verification Pass feeds step 7. It falls short of 5 because steps 1-5 are bare topic taxonomies rather than actions, and one block is pure background feeding no step.",
+      "evidence": [
+        {"quote": "Delegate this task to the `agents-plugin:review` agent."},
+        {"quote": "The agent has expertise in:"}
+      ]
+    },
+    "D2": {
+      "score": 4,
+      "rationale": "The false-positive failure mode is attached to the step that threatens it, with a named mechanism for how it arises and a named cost for shipping it. That is outcome-annotated guidance bound to a step rather than a detached gotchas section. It is not a 5 because the annotation covers one failure class only: steps 1-6 and the report step carry no failure signal, and no symptom is described from observation.",
+      "evidence": [
+        {"quote": "line numbers drift; assumptions decay"},
+        {"quote": "guesses erode trust in the review."}
+      ]
+    },
+    "D3": {
+      "score": 3,
+      "rationale": "Concrete for the main path: a named tool and subagent_type, literal glob patterns for discovery, and a report whose per-finding fields are named. But there are no exact invocations, no report schema or template, no environment or lifecycle preconditions, and nothing on how to tell a precondition is unmet (e.g. what to do if the named agent is unavailable). This sits squarely at the anchor-3 description.",
+      "evidence": []
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "The opening table names four conditions under which this skill is the wrong choice and routes each to a specific named alternative, and the optional agent-teams path is explicitly marked as skippable. It stops short of 5 because there is no escape from the procedure itself: nothing covers the case where the delegated-review approach is wrong for the situation, or what to do when the agent returns nothing usable.",
+      "evidence": [
+        {"quote": "Walking a manual security/correctness checklist → `code-review-checklist`"},
+        {"quote": "This is optional — the skill works without agent teams for standard reviews."}
+      ]
+    },
+    "D5": {
+      "score": 4,
+      "rationale": "Body is 6,239 chars, roughly 1,560 estimated tokens, which lands essentially on the ~1.5k ecosystem median, and the material is dense and coherent to the one procedure: rubrics are compressed into four- and three-row tables rather than prose. The only sidecar is a regression test script, so there is no on-demand content file, which is the one clause of the 5 anchor it does not meet, though at this size nothing obviously needs deferring.",
+      "evidence": [
+        {"quote": "| **Low** | Style, naming, minor readability, or a nit with no behavioral impact. Optional. |"}
+      ]
+    },
+    "D6": {
+      "score": 2,
+      "rationale": "The name is the most generic possible label for its domain, and the description enumerates dimensions (SOLID, test gaps, perf, security) that are exactly the vocabulary of its near siblings. The skill's own body concedes this: it needs a four-row table to separate itself from code-review-checklist, code-antipatterns, code-test-quality and code-refactor. The distinguishing condition (end-to-end delegated multi-dimension review versus a manual checklist or a single-concern scan) never reaches the description, so the choice is not decidable without opening the body.",
+      "evidence": [
+        {"quote": "description: Code review for quality, security, performance, and architecture. Use when reviewing code, auditing OWASP, checking SOLID, or finding perf bottlenecks and test gaps."},
+        {"quote": "Auditing test code quality on its own → `code-test-quality`"}
+      ]
+    },
+    "D7": {
+      "score": 4,
+      "rationale": "One procedure with one entry condition (a path to review); the five analysis dimensions are stages of a single review rather than independent procedures, and the rubric, confidence scale and re-verification sections all serve the same report. It is not a 5 because the agent-teams section is a second, parallel execution strategy that could plausibly stand alone, and the closing configure-skill pointers serve nothing in the procedure.",
+      "evidence": [
+        {"quote": "For comprehensive review of large codebases, spawn specialized review teammates in parallel:"}
+      ]
+    },
+    "D8": {
+      "score": 4,
+      "rationale": "Most instructions decompose into transcript-observable conditions: a per-finding output contract, an explicit reporting threshold, most-severe-first ordering, and a re-read of the cited location before a finding survives. An observer could check each against a trajectory. It is not a 5 because several steps remain dispositional with no observable correlate, notably the fix-application step and the closing recommendation item.",
+      "evidence": [
+        {"quote": "carry a verified `file:line`, a severity, and a confidence."},
+        {"quote": "The reporting threshold is **Medium**"},
+        {"quote": "where appropriate and safe"}
+      ]
+    }
+  },
+  "body_chars": 6239,
+  "sidecars": ["scripts/", "scripts/tests/test-code-review-rubric-depth.sh"]
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/configure-readme_j1.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/configure-readme_j1.json
@@ -1,0 +1,66 @@
+{
+  "unit": "configure-plugin/skills/configure-readme/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "file-generator",
+  "judge_id": "j1",
+  "dimensions": {
+    "D1": {
+      "score": 4,
+      "rationale": "The spine is an explicit imperative workflow: an 'Execute this...' opener followed by ten numbered, verb-led steps (Detect, Analyze, Generate, Apply, Handle, Detect, Generate, Update, Validate, Report), with a real decision point that halts the run under --check-only. Declarative material (package-manager command table, style levels) sits inside the step that consumes it, and templates/report formats are pushed to REFERENCE.md. It falls short of 5 because several steps state an outcome rather than an action ('Print a section-by-section compliance report', 'Include content quality checks') and the Output/Agentic sections restate the procedure declaratively.",
+      "evidence": [
+        {"quote": "Execute this README configuration workflow:"},
+        {"quote": "If `--check-only` is set, stop here."}
+      ]
+    },
+    "D2": {
+      "score": 2,
+      "rationale": "Almost every instruction is an unlabelled assertion: nothing records which approaches were tried, what a failure looks like in progress, or what a mistake costs. The only outcome-shaped material is a fallback branch for missing package metadata and a 'warn only' link check, neither of which names an observed symptom or consequence. It is above a 1 because those two branches at least acknowledge a failure condition, but there is no gotchas section and no failure is attached to the step it threatens.",
+      "evidence": [
+        {"quote": "**Fallback detection** when no package file matches:"}
+      ]
+    },
+    "D3": {
+      "score": 3,
+      "rationale": "The main path is concrete: the Context block runs real shell probes, Step 6 tabulates exact install/run/test/build commands per package manager, Step 7 gives a full tree invocation with exclusions, and Step 8 gives the literal YAML keys to write. What is missing is the 5-level material: the exact shape of the compliance report and results report is deferred rather than stated, and no precondition is made testable at execution time (nothing says how to tell that `tree` is absent, or what to do then), so edge conditions and setup checks are left to the reader.",
+      "evidence": []
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "The opening table is a two-column applicability boundary: each 'use this skill when' row is paired with a concrete out-of-scope case AND the named alternative to use instead (/configure:docs, /configure:github-pages, direct file editing, release-please). Flags such as --check-only and --no-logo give further escapes from parts of the procedure. It is not a 5 because there is no provision for the case where the skill's own guidance is wrong for the project at hand - e.g. a repo whose README is deliberately non-standard - only for cases that belong to a sibling skill.",
+      "evidence": [
+        {"quote": "Writing detailed API documentation — use `/configure:docs`"}
+      ]
+    },
+    "D5": {
+      "score": 4,
+      "rationale": "Body is 7,610 characters, roughly 1,900 tokens - above the ~1.5k ecosystem median but the same order of magnitude, and the excess is genuinely bounded by four explicit hand-offs to a single REFERENCE.md sidecar (~10k chars) holding the templates, badge URL patterns, package-file examples and report formats that most runs never need. It is not a 5 because material that no step consumes still rides in the always-loaded body: the Style Levels expansion is duplicated in the sidecar, and the Output plus Agentic Optimizations sections largely restate the procedure.",
+      "evidence": [
+        {"quote": "For the full README template and badge URL patterns, see [REFERENCE.md](REFERENCE.md)."}
+      ]
+    },
+    "D6": {
+      "score": 4,
+      "rationale": "The name and description are anchored on a single named artifact and a named service - README.md and shields.io - plus three concrete triggers (creating, auditing missing sections, adding badges). Against the plausible siblings this skill itself names, a reader can decide from the description alone: API documentation and a docs site do not read as 'README.md ... shields.io badges'. It stops short of 5 because it does not state its own boundary (nothing signals that detailed API docs or a docs site belong elsewhere); that disambiguation lives in the body's first table, not in the trigger surface.",
+      "evidence": [
+        {"quote": "README.md with logo, badges, features, tech stack sections. Use when creating a README, auditing missing sections, or adding shields.io badges."}
+      ]
+    },
+    "D7": {
+      "score": 4,
+      "rationale": "One procedure with one entry condition - produce or audit a README for the current project - and the audit path is a prefix of the generate path rather than a second bundled workflow. Detection, section analysis, command discovery, tree generation and validation all feed the single artifact. It is short of 5 because two steps serve a concern outside README production: writing the shared .project-standards.yaml component record, and the asset-creation branch that makes directories and recommends third-party logo tooling.",
+      "evidence": [
+        {"quote": "Update `.project-standards.yaml`:"}
+      ]
+    },
+    "D8": {
+      "score": 4,
+      "rationale": "Most instructions decompose into conditions an observer could check in a transcript: the flag-conditioned halt, the twelve-item section checklist, a fixed tree invocation, the literal YAML keys written to .project-standards.yaml, and four named validations in Step 9. The deduction from 5 is a residue of dispositional guidance with no observable correlate - Step 5's 'suggest' clauses and Step 10's 'recommended next steps' - plus Step 3's unspecified 'content quality checks', which cannot be scored pass or fail from a trajectory.",
+      "evidence": [
+        {"quote": "If `--check-only` is set, stop here."},
+        {"quote": "Suggest creating a simple text-based placeholder or using emoji heading"}
+      ]
+    }
+  },
+  "body_chars": 7610,
+  "sidecars": ["REFERENCE.md"]
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/configure-readme_j2.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/configure-readme_j2.json
@@ -1,0 +1,66 @@
+{
+  "unit": "configure-plugin/skills/configure-readme/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "file-generator",
+  "judge_id": "j2",
+  "dimensions": {
+    "D1": {
+      "score": 4,
+      "rationale": "The spine is an explicit ten-step imperative sequence under an execution directive, with real decision points (early exit on --check-only, conditional apply on --fix, conditional logo handling), and bulk reference material is pushed to REFERENCE.md. It falls short of 5 because some declarative blocks (the When-to-Use table, the Output restatement, the Agentic Optimizations command catalogue) do not feed any step; folding or deferring those would move it up.",
+      "evidence": [
+        {"quote": "Execute this README configuration workflow:"},
+        {"quote": "If `--check-only` is set, stop here."}
+      ]
+    },
+    "D2": {
+      "score": 2,
+      "rationale": "There is no gotchas/warnings section and no step carries a failure identity: nothing says which approach was tried, what breaks, what the symptom looks like, or what it costs. The single outcome-shaped signal is a contingency branch for absent package files, which anticipates a condition without naming an observed failure or its consequence. Naming, per step, what goes wrong (e.g. a tree binary that is absent, a badge URL that renders broken, a logo path that 404s) would raise this.",
+      "evidence": [
+        {"quote": "**Fallback detection** when no package file matches:"}
+      ]
+    },
+    "D3": {
+      "score": 4,
+      "rationale": "Commands are exact and copy-pasteable rather than paraphrased (the tree invocation with its ignore list, the per-package-manager command table, the literal .project-standards.yaml block), and the Context block auto-detects environment state before execution. It is not a 5 because setup preconditions are unstated - nothing says tree must be installed or how to tell when it is not - and the exact output shapes for the compliance and results reports live only in the sidecar.",
+      "evidence": [
+        {"quote": "tree -L 2 -I 'node_modules|target|__pycache__|.git|dist|build' --dirsfirst"},
+        {"quote": "- README exists: !`find . -maxdepth 1 -name 'README.md'`"}
+      ]
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "The opening table is a genuine two-column applicability boundary: five rows each name a condition where this skill is the wrong tool and name the alternative to use instead, and flags like --no-logo and --check-only give in-procedure latitude. It stops short of 5 because there is no escape once the procedure is underway - nothing tells the reader what to do if the generated standard-style README is simply wrong for this project.",
+      "evidence": [
+        {"quote": "Writing detailed API documentation — use `/configure:docs`"}
+      ]
+    },
+    "D5": {
+      "score": 4,
+      "rationale": "The always-loaded body is 7609 characters (~1900 tokens), moderately above the ~1.5k ecosystem median, and deferral is real and repeated - templates, badge URL patterns, package-file examples, and both report formats are all pointed at a single on-demand REFERENCE.md rather than inlined. It is not a 5 because the Style Levels table is duplicated in both body and sidecar and the Output/Agentic Optimizations sections restate material already covered by the steps.",
+      "evidence": [
+        {"quote": "For the full README template and badge URL patterns, see [REFERENCE.md](REFERENCE.md)."}
+      ]
+    },
+    "D6": {
+      "score": 4,
+      "rationale": "The description names a concrete artifact (README.md) plus distinctive contents (logo, badges, tech stack, shields.io) and three concrete triggers, so it is decidable against plausible siblings like a docs-generation or a docs-hosting skill without opening either body. It is not a 5 because the distinguishing condition is implied by the artifact name rather than stated - the description never says what it is not for, so a sibling that also touches README content would need the body to separate.",
+      "evidence": [
+        {"quote": "README.md with logo, badges, features, tech stack sections. Use when creating a README, auditing missing sections, or adding shields.io badges."}
+      ]
+    },
+    "D7": {
+      "score": 4,
+      "rationale": "One artifact, one procedure: every step from metadata detection through validation and reporting serves generating or auditing a single README, and the audit path is an early exit from that same procedure rather than a second bundled workflow. It is short of 5 because standards-tracking is an adjacent concern serving an external orchestrator that could plausibly stand alone.",
+      "evidence": [
+        {"quote": "### Step 8: Update standards tracking"}
+      ]
+    },
+    "D8": {
+      "score": 3,
+      "rationale": "Much of the procedure decomposes into observable conditions - a twelve-item section checklist, an exact tree invocation, a literal YAML block to write, a hard stop on --check-only - so a transcript would show whether they happened. Against that, several instructions are dispositional (suggest a placeholder logo, suggest tools, offer suggestions for improvement, include content quality checks) with no observable correlate, which is exactly the mixed picture the anchor describes.",
+      "evidence": []
+    }
+  },
+  "body_chars": 7609,
+  "sidecars": ["REFERENCE.md"]
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/docs-generate_j1.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/docs-generate_j1.json
@@ -1,0 +1,67 @@
+{
+  "unit": "documentation-plugin/skills/docs-generate/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "file-generator",
+  "judge_id": "j1",
+  "dimensions": {
+    "D1": {
+      "score": 3,
+      "rationale": "There is an identifiable ordered procedure: an imperative delegation opener followed by four numbered steps with flag-conditional branches. But it is mixed with substantial declarative material that feeds no step (the agent-expertise list, the optional Agent Teams table), and steps 3-4 are wish-lists rather than actions. Committing the standards and expertise material to concrete step outputs, or deferring it, would move this up.",
+      "evidence": []
+    },
+    "D2": {
+      "score": 1,
+      "rationale": "Nothing in the body records a failure, a symptom, or a cost. Every instruction is an unlabelled assertion of what good output looks like, with no indication of which approaches were tried, what breaks, or how a reader would recognise a failing run in progress. A single attached failure mode (e.g. what a docstring-less codebase produces, or what a non-conventional-commit history does to the changelog step) would lift it.",
+      "evidence": [
+        {"quote": "3. **Follow documentation standards**:"},
+        {"quote": "- Clear, concise language"}
+      ]
+    },
+    "D3": {
+      "score": 2,
+      "rationale": "Environment detection is genuinely concrete - real find invocations probe for manifests, existing docs, and source files - and the delegation names an exact tool and subagent identifier. But the main path, the actual documentation generation, is entirely paraphrased: no exact command, no expected output shape, no file paths written, and no statement of what an unmet precondition (no docstrings, no conventional commits, no docs framework) looks like. Naming the produced artifacts and their formats concretely would move it to 3 or above.",
+      "evidence": [
+        {"quote": "Project files: !`find . -maxdepth 1"},
+        {"quote": "- Create API reference from docstrings"}
+      ]
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "The opening table states the applicability boundary in both directions and, for each out-of-scope case, names the sibling to use instead (docs-sync, docs-decommission, docs-latex); the Agent Teams section additionally marks itself optional and tells the reader when a single agent suffices. It stops short of 5 because it never addresses the case where its own procedure is the wrong answer at all - a repository with no extractable docstrings or a non-conventional-commit history gets no exit.",
+      "evidence": [
+        {"quote": "| Producing a CHANGELOG from conventional-commit history | Preparing a service teardown checklist (use docs-decommission) |"},
+        {"quote": "This is optional — the skill works with a single agent for most projects."}
+      ]
+    },
+    "D5": {
+      "score": 4,
+      "rationale": "The body is 3422 characters, roughly 855 tokens - well under the ~1.5k ecosystem median - with no sidecar files, so nothing is loaded that a run cannot reach. It falls short of exemplary only because part of that small budget is spent on material no step consumes (the capability list and the optional teams table) rather than on the execution detail D3 finds missing.",
+      "evidence": [
+        {"quote": "- `--api`: Generate API reference documentation"},
+        {"quote": "The agent has expertise in:"}
+      ]
+    },
+    "D6": {
+      "score": 4,
+      "rationale": "The name plus description names the input sources (code annotations, docstrings, git history) and the three concrete output artifacts, which is a real discriminator against a sibling that reconciles or converts existing docs. It is not a 5 because the leading phrase is generic enough that a sibling named docs-sync or docs-update would overlap on a description read; the distinguishing condition is present but stated as source material rather than as an explicit contrast.",
+      "evidence": [
+        {"quote": "Generate or update docs from code annotations, docstrings, and git history. Use when wanting API reference, README from code, or CHANGELOG from conventional commits."}
+      ]
+    },
+    "D7": {
+      "score": 2,
+      "rationale": "Three largely independent procedures are bundled behind three flags: docstring extraction into an API reference, README rewriting from code analysis, and changelog synthesis from commit history. They share a topic and a preliminary codebase scan, but no dominant procedure exists and a --api invocation still carries the README and changelog branches. Splitting the changelog path, which shares almost nothing mechanically with docstring extraction, would raise this.",
+      "evidence": [
+        {"quote": "If `--changelog`:"},
+        {"quote": "If no flags: Generate all documentation"}
+      ]
+    },
+    "D8": {
+      "score": 3,
+      "rationale": "Some instructions decompose into observable constraints - the delegation target, the flag-to-branch mapping, and the required output summary would all be visible in a transcript. Others are purely dispositional with no observable correlate (clear, concise language; consistent formatting; accurate cross-references; suggested improvements), so an observer could not determine from a trajectory whether step 3 was followed at all.",
+      "evidence": []
+    }
+  },
+  "body_chars": 3422,
+  "sidecars": []
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/docs-generate_j2.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/docs-generate_j2.json
@@ -1,0 +1,67 @@
+{
+  "unit": "documentation-plugin/skills/docs-generate/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "file-generator",
+  "judge_id": "j2",
+  "dimensions": {
+    "D1": {
+      "score": 3,
+      "rationale": "There is an identifiable ordered procedure (delegate, then four numbered stages with real branch points on --api/--readme/--changelog), but it is mixed with substantial declarative material that feeds no step: an expertise list for the delegated agent, a dispositional 'documentation standards' stage, and an optional Agent Teams table. Moving the declarative blocks out and making each stage a concrete action the invoker performs would raise it; losing the numbered ordering would drop it.",
+      "evidence": []
+    },
+    "D2": {
+      "score": 1,
+      "rationale": "Every instruction is an unlabelled assertion. Nothing in the body names a failure mode, a symptom, a path that was tried and abandoned, or what a bad outcome looks like - not even for obvious hazards like a repo with no conventional commits or no docstrings. A single 'if X, you will see Y' attached to a step would have lifted this off the floor.",
+      "evidence": [
+        {"quote": "**Delegate this task to the `agents-plugin:docs` agent.**"},
+        {"quote": "3. **Follow documentation standards**:"}
+      ]
+    },
+    "D3": {
+      "score": 2,
+      "rationale": "The Context block carries real executable find invocations, which keeps this off the floor, but the actual work of the skill is entirely at description level: no generator command, no expected output shape, no file paths, and no way to tell whether a precondition is met. It even asks the caller to pass a 'detected documentation framework' without specifying how detection happens.",
+      "evidence": [
+        {"quote": "- Ensure badges are current"},
+        {"quote": "- Detected documentation framework (if any)"}
+      ]
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "The opening table does more than state a boundary - it names four out-of-scope situations and routes each to a specific alternative skill (docs-sync, docs-decommission, docs-latex), and the Agent Teams section explicitly marks itself optional with the default case named. It stops short of 5 because there is no escape from the procedure itself: no guidance for the case where delegation to the docs agent is the wrong move, or where the generated output should not be trusted.",
+      "evidence": [
+        {"quote": "| Producing a CHANGELOG from conventional-commit history | Preparing a service teardown checklist (use docs-decommission) |"},
+        {"quote": "This is optional — the skill works with a single agent for most projects."}
+      ]
+    },
+    "D5": {
+      "score": 4,
+      "rationale": "The body is 3,423 characters (~855 tokens), comfortably under the ~1.5k ecosystem median, and the expensive work is pushed onto a delegated agent rather than carried inline. No sidecar files exist, but at this size none is needed. It is not a 5 because part of the smallness comes from vagueness (see D3) rather than from a deliberate deferral structure.",
+      "evidence": [
+        {"quote": "**Delegate this task to the `agents-plugin:docs` agent.**"}
+      ]
+    },
+    "D6": {
+      "score": 4,
+      "rationale": "The description names both the inputs (code annotations, docstrings, git history) and the three concrete artifacts, which makes it decidable against most plausible siblings without opening the body. It falls short of 5 because the lead phrase 'Generate or update docs' overlaps heavily with any docs-sync/docs-refresh sibling, so the disambiguation rests on the second half of the sentence surviving a read.",
+      "evidence": [
+        {"quote": "description: Generate or update docs from code annotations, docstrings, and git history. Use when wanting API reference, README from code, or CHANGELOG from conventional commits."}
+      ]
+    },
+    "D7": {
+      "score": 2,
+      "rationale": "Three coequal deliverables are bundled behind one entry point - API reference from docstrings, README from code analysis, and CHANGELOG from git history - with different inputs, different outputs, and no dominant procedure among them. A --changelog invocation pays for the API and README branches it will never use. The shared analyze/summarise spine and the small per-branch cost keep it off the floor.",
+      "evidence": [
+        {"quote": "- `--api`: Generate API reference documentation"},
+        {"quote": "- `--changelog`: Update CHANGELOG.md from git history"},
+        {"quote": "If no flags: Generate all documentation"}
+      ]
+    },
+    "D8": {
+      "score": 3,
+      "rationale": "The delegation instruction and the flag branches are checkable in a transcript - an observer can see whether the docs agent was dispatched and whether the named files were produced. But a whole stage is dispositional with no observable correlate, and the summary stage asks for 'suggested improvements' with no criterion. Replacing the standards stage with checkable conditions would raise this.",
+      "evidence": []
+    }
+  },
+  "body_chars": 3423,
+  "sidecars": []
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/evaluate-legibility_j1.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/evaluate-legibility_j1.json
@@ -1,0 +1,79 @@
+{
+  "unit": "evaluate-plugin/skills/evaluate-legibility/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "weak-model-gate",
+  "judge_id": "j1",
+  "dimensions": {
+    "D1": {
+      "score": 5,
+      "rationale": "The spine is a four-step imperative procedure (resolve prompt -> dispatch reader -> triage -> report) opened by an explicit execution directive, with a concrete decision point at Step 1 and a decision table consumed by Step 3. The declarative material is small and either feeds a step (the verdict vocabulary, the triage table) or is explicitly deferred elsewhere, including the dispatch rationale and the prompt text itself.",
+      "evidence": [
+        {"quote": "Execute this legibility gate:"},
+        {"quote": "### Step 1: Resolve the prompt"},
+        {"quote": "See that skill for the dispatch rationale; this skill does"}
+      ]
+    },
+    "D2": {
+      "score": 4,
+      "rationale": "Failure modes are attached to the steps they threaten: Step 2 names the way the dispatch is spoiled (enriching the reader's context destroys the measurement) and Step 3 carries a table of concrete false-positive symptoms a reader can recognise mid-run. What is missing for a 5 is any recorded consequence or cost of an observed failure - the guidance says which paths are wrong but never what going wrong actually cost.",
+      "evidence": [
+        {"quote": "it is the measurement instrument, not a delegate"},
+        {"quote": "Do not add context, do not let it"},
+        {"quote": "The cold reader cannot know the invocation context, so some complaints are"},
+        {"quote": "Test artifact — ignore it"}
+      ]
+    },
+    "D3": {
+      "score": 5,
+      "rationale": "It gives the exact script invocation, the exact dispatch shape (subagent_type, model, prompt source), the exact delimiters the prompt arrives between, and the exact fields the reader must return. It also states how to detect an unmet precondition and what to do then, rather than assuming the resolve step succeeded.",
+      "evidence": [
+        {"quote": "Task subagent_type: general-purpose"},
+        {"quote": "report the `ERROR=` line and stop"},
+        {"quote": "| Resolve path + emit prompt | `bash evaluate-plugin/skills/evaluate-legibility/scripts/emit-legibility-prompt.sh --plugin-skill <plugin/skill>` |"}
+      ]
+    },
+    "D4": {
+      "score": 5,
+      "rationale": "The When-to-Use table pairs each out-of-scope condition with a named alternative (executability, structural lint, outward-artifact gating, effectiveness benchmarking), and the skill additionally provides an escape from its own output: the verdict is declared advisory because the instrument is non-deterministic, and Step 3 instructs the operator to discard the tool's own findings when they are artifacts of isolation.",
+      "evidence": [
+        {"quote": "The verdict is **advisory, not a CI gate**: haiku is non-deterministic, so a"},
+        {"quote": "| Checking a SKILL.md reads clearly to a fresh agent | Testing whether the skill *executes* correctly -> `/evaluate:matrix` |"},
+        {"quote": "Test artifact — ignore it"}
+      ]
+    },
+    "D5": {
+      "score": 5,
+      "rationale": "The body is 5,165 characters (~1.3k tokens), at or just under the ecosystem median, and the bulk of the material a run would otherwise carry - the reader persona and the full dispatch prompt - is deferred to a single sidecar script that the Context block invokes. The dispatch rationale is deferred by name reference to a sibling skill rather than restated.",
+      "evidence": [
+        {"quote": "The Context block above ran `emit-legibility-prompt.sh`, which resolved the"},
+        {"quote": "See that skill for the dispatch rationale; this skill does"}
+      ]
+    },
+    "D6": {
+      "score": 4,
+      "rationale": "The description names the artifact (a SKILL.md), the instrument (a zero-context agent reader), and the two questions it answers (when to invoke, how to start), which separates it cleanly from an executability or effectiveness sibling. It falls short of 5 only because it shares its distinctive 'cold-read' framing with a near sibling, so telling this apart from a generic cold-read gate rests on the reader noticing the SKILL.md/agent-reader qualifier rather than on an explicitly stated contrast.",
+      "evidence": [
+        {"quote": "Cold-read a SKILL.md with a zero-context agent reader to check its intent is legible."}
+      ]
+    },
+    "D7": {
+      "score": 5,
+      "rationale": "One entry condition - a single named plugin/skill target - and one procedure: dispatch a cold reader at that file, triage its complaints, report. The parameters, triage table, quick reference and optimisation rows all serve that single flow; nothing else is bundled in.",
+      "evidence": [
+        {"quote": "Dispatch an isolated, zero-context **agent reader** at a single `SKILL.md` and"},
+        {"quote": "| `<plugin/skill-name>` | required | Target skill as `plugin-name/skill-name` |"}
+      ]
+    },
+    "D8": {
+      "score": 5,
+      "rationale": "Nearly every instruction decomposes into a transcript-observable condition: exactly one subagent dispatched at the named model, no added context, the three named fields captured, the verdict printed with each blocking question and its quoted phrase, the advisory caveat stated, and no edit made to the target file. A reviewer with only the trajectory could mark each of these satisfied or violated.",
+      "evidence": [
+        {"quote": "Do **not** edit the skill"},
+        {"quote": "Do not add context, do not let it"},
+        {"quote": "Task subagent_type: general-purpose"}
+      ]
+    }
+  },
+  "body_chars": 5165,
+  "sidecars": ["scripts/emit-legibility-prompt.sh"]
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/evaluate-legibility_j2.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/evaluate-legibility_j2.json
@@ -1,0 +1,71 @@
+{
+  "unit": "evaluate-plugin/skills/evaluate-legibility/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "weak-model-gate",
+  "judge_id": "j2",
+  "dimensions": {
+    "D1": {
+      "score": 5,
+      "rationale": "The spine is an imperative four-step procedure opened by an explicit execution directive, with concrete branch points (STATUS=ERROR -> stop; genuine gap vs test artifact). The declarative material that remains (the triage table, the verdict-field table) is consumed by the step it sits in or by the reporting step, and the dispatch rationale is explicitly not restated. Mixing in background prose that fed no step would have moved this down.",
+      "evidence": [
+        {"quote": "Execute this legibility gate:"},
+        {"quote": "If `STATUS=ERROR`, report the `ERROR=` line and stop (bad argument or missing SKILL.md)."}
+      ]
+    },
+    "D2": {
+      "score": 4,
+      "rationale": "Failure modes are attached to the steps they threaten rather than parked in a generic gotchas section: Step 3 carries a two-column table of observed false-positive symptoms from the reader ('What is plugin X?' when X is in frontmatter, REFERENCE.md absent) so the reader can recognise the artifact in progress, and the advisory caveat names haiku non-determinism as the cause. What holds it below 5 is that no failure is costed from observed practice - the symptoms are named, but not what a mis-triage actually cost.",
+      "evidence": [
+        {"quote": "artifacts of reading a skill in isolation. Triage before recommending changes:"},
+        {"quote": "The verdict is **advisory, not a CI gate**: haiku is non-deterministic, so a `needs-revision` is a prompt to look, never a merge block."}
+      ]
+    },
+    "D3": {
+      "score": 4,
+      "rationale": "It gives the exact script invocation, the exact delimiters the output is bracketed by, the exact dispatch block (subagent_type plus model), an exact return schema, and an explicit unmet-precondition test via STATUS=ERROR - well past leaving edge conditions to the reader. It stops short of 5 on a real wiring drift: Step 1 asserts the Context block ran emit-legibility-prompt.sh, but the declared Context command is a find over SKILL.md files, so the PROMPT block Step 1 tells the agent to read is not actually produced by the section it points at.",
+      "evidence": [
+        {"quote": "| Resolve path + emit prompt | `bash evaluate-plugin/skills/evaluate-legibility/scripts/emit-legibility-prompt.sh --plugin-skill <plugin/skill>` |"},
+        {"quote": "`verdict` of `clear` or `needs-revision`."}
+      ]
+    },
+    "D4": {
+      "score": 5,
+      "rationale": "The When to Use table pairs every applicability boundary with a named destination instead of just declaring scope - executability goes to /evaluate:matrix, structural lint to the compliance script, outward human artifacts to cold-read-gate, effectiveness to /evaluate:skill. It also supplies an escape from its own output: the verdict is declared advisory rather than binding, and Step 3 instructs the reader to discard the instrument's own complaints when they are artifacts of isolation.",
+      "evidence": [
+        {"quote": "| Checking a SKILL.md reads clearly to a fresh agent | Testing whether the skill *executes* correctly -> `/evaluate:matrix` |"},
+        {"quote": "The verdict is **advisory, not a CI gate**: haiku is non-deterministic, so a `needs-revision` is a prompt to look, never a merge block."}
+      ]
+    },
+    "D5": {
+      "score": 5,
+      "rationale": "The always-loaded body is 5164 characters, about 1291 tokens - at the ~1.5k ecosystem median - and the bulk of the detail is genuinely deferred: the reader prompt itself lives in the sibling emit-legibility-prompt.sh rather than inline, and the dispatch rationale is pointed at another skill by name with an explicit refusal to restate it. Nothing in the body is paid for by a run that never uses it.",
+      "evidence": [
+        {"quote": "See that skill for the dispatch rationale; this skill does not restate it."}
+      ]
+    },
+    "D6": {
+      "score": 4,
+      "rationale": "The description names the discriminating mechanism (a zero-context agent reader) and the discriminating question (does the skill say when to invoke it and how to start), which separates it cleanly from executability and effectiveness siblings on a description read alone. It shares the cold-read vocabulary with a plausible near sibling that gates outward artifacts for a human reader; 'a SKILL.md' narrows it, but that one contrast leans on knowing the sibling's own wording rather than being stated here.",
+      "evidence": [
+        {"quote": "Cold-read a SKILL.md with a zero-context agent reader to check its intent is legible. Use when validating whether a skill says clearly when to invoke it and how to start."}
+      ]
+    },
+    "D7": {
+      "score": 5,
+      "rationale": "One procedure with one entry condition: a single plugin/skill-name target, dispatched to one reader, triaged, reported. Every section serves that one path - Parameters declares the single argument, the two Agentic Optimizations rows are the emit script and its test, and the Quick Reference defines exactly the four fields Step 4 prints. No second procedure is bundled in.",
+      "evidence": [
+        {"quote": "Dispatch an isolated, zero-context **agent reader** at a single `SKILL.md` and ask it the only two questions that matter for reuse:"}
+      ]
+    },
+    "D8": {
+      "score": 5,
+      "rationale": "Nearly every instruction decomposes into a condition an observer could check in a transcript: exactly one Task subagent on haiku, no added context and no repo exploration by the reader, the three named fields captured, the advisory framing stated in the report, one quoted blocking phrase and one recommendation per gap, and an explicit prohibition on editing the target. The only dispositional element is the triage judgement itself, and even that is backed by an enumerated row list.",
+      "evidence": [
+        {"quote": "Do not add context, do not let it explore the repo. Capture its final message:"},
+        {"quote": "Do **not** edit the skill"}
+      ]
+    }
+  },
+  "body_chars": 5164,
+  "sidecars": ["scripts/emit-legibility-prompt.sh"]
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/evaluate-matrix_j1.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/evaluate-matrix_j1.json
@@ -1,0 +1,72 @@
+{
+  "unit": "evaluate-plugin/skills/evaluate-matrix/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "weak-model-gate",
+  "judge_id": "j1",
+  "dimensions": {
+    "D1": {
+      "score": 4,
+      "rationale": "The spine is an imperative five-step procedure opened by a direct execution directive, with real decision points inside steps (stop if no evals.json; judge only on deferral; skip the baseline under a flag). It falls short of 5 because two late tables carry declarative material no step consumes: Quick Reference restates the Parameters table almost verbatim, and Agentic Optimizations lists a command (inspect_eval.sh) the procedure never calls. Folding those into the steps or the sidecar would make it a 5.",
+      "evidence": [
+        {"quote": "Execute this cross-model matrix:"},
+        {"quote": "### Step 2: Run the matrix (serialized)"}
+      ]
+    },
+    "D2": {
+      "score": 4,
+      "rationale": "Two failure modes are attached to the exact steps they threaten and each names both the observed symptom and its cost: the missing-fixture case names the wrong verdict it produces, and the parallel-dispatch case names the rate-limit cascade. It is not a 5 because Steps 1, 4 and 5 carry no such annotation - nothing says what a mis-aggregated matrix or a mis-fired executability flag looks like in progress.",
+      "evidence": [
+        {"quote": "a false negative that poisons this gate"},
+        {"quote": "`[1m]` models hit cascading rate limits with concurrent subagents"}
+      ]
+    },
+    "D3": {
+      "score": 5,
+      "rationale": "Every stage is an exact invocation with real flags, the environment is pinned (CLAUDE_PLUGIN_ROOT, exact model ids, run-dir scaffold and teardown), and the machine-readable handoffs are named by key rather than described (WORKDIR=, JUDGE_PENDING > 0), with numeric verdict thresholds for the two flags. The unmet-precondition case is explicit and terminal, and the full schema is deferred to a sidecar rather than paraphrased.",
+      "evidence": [
+        {"quote": "Parse `WORKDIR=`; the subagent operates there."},
+        {"quote": "Pinned model ids: `opus`=`claude-opus-4-8`, `sonnet`=`claude-sonnet-4-6`,"},
+        {"quote": "Only if it reports `JUDGE_PENDING > 0`, dispatch the `eval-grader` agent"}
+      ]
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "A four-row table names conditions under which this is the wrong skill and routes each to a specific named alternative, and Step 1 gives a hard stop with a redirect when the entry condition is unmet. It stops short of 5 because there is no escape from the procedure once running - nothing tells the reader what to do if the matrix verdict itself looks wrong for the situation (e.g. a haiku failure the reader believes is an artifact rather than a real executability gap).",
+      "evidence": [
+        {"quote": "Checking whether the SKILL.md *reads* clearly -> `/evaluate:legibility`"},
+        {"quote": "point at `/evaluate:skill --create-evals`"}
+      ]
+    },
+    "D5": {
+      "score": 5,
+      "rationale": "The body is 6,876 characters, about 1,719 estimated tokens - essentially at the ecosystem median - while the expensive material is genuinely deferred: the eval schema to a references file, the design rationale to a docs file, and all mechanics to scripts the steps invoke rather than inline. Nothing large is paid for on invocations that do not need it.",
+      "evidence": [
+        {"quote": "([`references/schemas.md`](../../references/schemas.md))"}
+      ]
+    },
+    "D6": {
+      "score": 5,
+      "rationale": "The description names the discriminating condition rather than the topic: 'executability' versus comprehension, cross-model with real execution, weak-model focus. Against the plausible siblings in the same family (a legibility gate, a single-model effectiveness check, an improver) the choice is decidable from the description alone - the phrase 'not just comprehend it' rules out the nearest neighbour explicitly.",
+      "evidence": [
+        {"quote": "Use when checking whether a weak model can actually do a skill, not just comprehend it."}
+      ]
+    },
+    "D7": {
+      "score": 5,
+      "rationale": "One procedure with one entry condition (a target skill that has an evals.json), and every section feeds it: parameters bind the loop, the five steps run and grade and render it, and the Minimal Provable Increment is a narrowed instance of the same run rather than a second procedure. Nothing bundled here could stand alone as separate work.",
+      "evidence": [
+        {"quote": "Run the matrix for **`git-plugin/git-commit` only**"}
+      ]
+    },
+    "D8": {
+      "score": 5,
+      "rationale": "Nearly every instruction decomposes into a condition an observer could check in a transcript: which commands ran with which flags, whether dispatches were sequential or batched, whether the judge fired only on a named deferral count, whether the aggregate file carries the named fields, and whether the flag was called out. There is no dispositional filler - no 'consider', no 'be careful' - to leave unverifiable.",
+      "evidence": [
+        {"quote": "**Serialize** the dispatches — one at a time, never a parallel batch."},
+        {"quote": "Only if it reports `JUDGE_PENDING > 0`, dispatch the `eval-grader` agent"}
+      ]
+    }
+  },
+  "body_chars": 6876,
+  "sidecars": []
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/evaluate-matrix_j2.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/evaluate-matrix_j2.json
@@ -1,0 +1,71 @@
+{
+  "unit": "evaluate-plugin/skills/evaluate-matrix/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "weak-model-gate",
+  "judge_id": "j2",
+  "dimensions": {
+    "D1": {
+      "score": 4,
+      "rationale": "The spine is an imperative five-step sequence opened by an explicit execution directive, each step carrying a concrete command or dispatch and a decision point (absent evals.json stops the run; JUDGE_PENDING gates the judge). It falls short of 5 because two declarative tables (Parameters and Quick Reference) restate the same three flags, so some always-loaded material feeds no step that the other table did not already feed.",
+      "evidence": [
+        {"quote": "Execute this cross-model matrix:"},
+        {"quote": "Only if it reports `JUDGE_PENDING > 0`, dispatch the `eval-grader` agent"}
+      ]
+    },
+    "D2": {
+      "score": 4,
+      "rationale": "Two failure modes are attached to the exact steps they threaten and each names the symptom and what it costs: skipping the fixture yields a haiku failure that is a false negative poisoning the gate, and parallel dispatch triggers cascading rate limits on [1m] models. It is not a 5 because the grading, aggregation and rendering steps carry no comparable outcome annotation, so the coverage is partial rather than systematic.",
+      "evidence": [
+        {"quote": "without one a context-needing skill fails on haiku purely for lack"},
+        {"quote": "a false negative that poisons this gate"},
+        {"quote": "`[1m]` models hit cascading rate limits with concurrent subagents"}
+      ]
+    },
+    "D3": {
+      "score": 5,
+      "rationale": "Every step gives an exact invocation with real flags (prepare_run.sh, apply_fixture.sh, grade_deterministic.py, render_matrix_report.py), names the exact output token to parse and the lifecycle obligation around it (WORKDIR, teardown), pins concrete model ids, and states the numeric thresholds the report emits. The unmet-precondition case is explicit: a missing evals.json is detected, reported, redirected, and the run stops.",
+      "evidence": [
+        {"quote": "Parse `WORKDIR=`; the subagent operates there."},
+        {"quote": "Only if it reports `JUDGE_PENDING > 0`, dispatch the `eval-grader` agent"}
+      ]
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "A four-row table names conditions under which this skill is the wrong tool and routes each to a specific alternative, and Step 1 provides a real exit when the entry condition is unmet. It stops short of 5 because it never addresses the case where the procedure itself is wrong for the situation at hand (for example a skill whose evals exist but cannot be executed honestly), offering no judgement latitude beyond the enumerated redirects.",
+      "evidence": [
+        {"quote": "Checking whether the SKILL.md *reads* clearly -> `/evaluate:legibility`"}
+      ]
+    },
+    "D5": {
+      "score": 5,
+      "rationale": "The body is 6876 characters, roughly 1.7k estimated tokens, close to the ecosystem median for a skill that must carry five executable steps. Detail that would have inflated it is genuinely deferred to on-demand files: the evals.json schema and the full cross-model design are linked, not restated, and the skill explicitly reuses shared scripts rather than duplicating them.",
+      "evidence": [
+        {"quote": "([`references/schemas.md`](../../references/schemas.md))."}
+      ]
+    },
+    "D6": {
+      "score": 5,
+      "rationale": "The description names the distinguishing condition rather than the topic: cross-model, real execution, weak model, and an explicit contrast with mere comprehension. Against the obvious near siblings (a legibility gate, a single-model effectiveness run) the choice is decidable from the description alone without opening either body.",
+      "evidence": [
+        {"quote": "Use when checking whether a weak model can actually do a skill, not just comprehend it."}
+      ]
+    },
+    "D7": {
+      "score": 4,
+      "rationale": "One procedure with one entry condition dominates: resolve evals, run the matrix, grade, aggregate, render. The Minimal Provable Increment section is adjacent secondary material addressed to whoever is bringing the harness up rather than to an invoker running the gate, so a fraction of every invocation pays for bootstrapping guidance it will not use.",
+      "evidence": [
+        {"quote": "Run the matrix for **`git-plugin/git-commit` only**"}
+      ]
+    },
+    "D8": {
+      "score": 5,
+      "rationale": "The instructions decompose into discrete conditions an observer could check in a transcript: dispatches serialized rather than batched, the subagent model field set to the loop model, the deterministic grader run before any judge, the judge dispatched only on a nonzero JUDGE_PENDING, the artifact written to a named path, and the executability flag explicitly called out in the printed report. Each would be visibly satisfied or violated.",
+      "evidence": [
+        {"quote": "Only if it reports `JUDGE_PENDING > 0`, dispatch the `eval-grader` agent"},
+        {"quote": "Parse `WORKDIR=`; the subagent operates there."}
+      ]
+    }
+  },
+  "body_chars": 6876,
+  "sidecars": []
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/fd-file-finding_j1.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/fd-file-finding_j1.json
@@ -1,0 +1,62 @@
+{
+  "unit": "tools-plugin/skills/fd-file-finding/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "cli-wrapper",
+  "judge_id": "j1",
+  "dimensions": {
+    "D1": {
+      "score": 2,
+      "rationale": "The body is a flag-and-example catalogue organised by feature area (Basic Usage, Advanced Filtering, Execution, Quick Reference) with no ordered steps, no decision points inside the work, and no committed sequence of actions; a reader finishes knowing what fd can do rather than what to do first. It is lifted just above anchor 1 because every catalogue entry is a concrete executable command and the opening routing tables act as a single up-front decision point. Adding an ordered 'narrow, then filter, then execute' spine consuming these commands would move it to 4-5.",
+      "evidence": [
+        {"quote": "Fast parallel execution (written in Rust)"},
+        {"quote": "| Use this skill when... | Use rg-code-search instead when... |"}
+      ]
+    },
+    "D2": {
+      "score": 1,
+      "rationale": "Nothing in the body records a failure: there is no gotchas section, no symptom, no cost, and no indication that any listed path was ever tried and found wanting. The one 'Note' is a bare preference assertion with an unquantified rationale rather than an observed consequence, and the closing line is pure endorsement. Attaching even one named failure (e.g. what -x does on filenames with spaces, or what gitignore-awareness silently hides) to the step it threatens would move this up.",
+      "evidence": [
+        {"quote": "**Note:** Use `--format '{//}'` instead of piping to xargs - it's faster and simpler."},
+        {"quote": "This makes fd the preferred tool for fast, intuitive file finding in development workflows."}
+      ]
+    },
+    "D3": {
+      "score": 3,
+      "rationale": "Commands are exact, copy-pasteable, and correctly flagged for the main path, and the --format placeholder table specifies the shape of one output mode. But no expected output is shown for any invocation, and there are no environment or lifecycle preconditions at all (no availability check, no note on how fd is named or invoked in different environments, no way to tell a precondition is unmet). That is precisely the anchor-3 profile: concrete for the main path, edge conditions and setup left to the reader.",
+      "evidence": []
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "The skill states its non-application conditions unusually well for a CLI wrapper: two opening tables route away to named sibling skills for content search and JSON processing, and a dedicated section names four conditions under which a different tool entirely is correct. It stops short of 5 because it never addresses the case where its own guidance is wrong for the situation at hand and offers no exit from itself once the reader is inside the procedure.",
+      "evidence": [
+        {"quote": "**When to Use find Instead**"},
+        {"quote": "POSIX compatibility required"},
+        {"quote": "| Use this skill when... | Use jq-json-processing instead when... |"}
+      ]
+    },
+    "D5": {
+      "score": 3,
+      "rationale": "The body is 9,117 characters, roughly 2,280 tokens, about 1.5x the ~1.5k ecosystem median, with no sidecar files at all so nothing is deferred. It is not many multiples of the median and every section is coherent to the one tool, which is the anchor-3 case. Working against it: the closing 'Common Command Patterns' section largely restates examples given earlier, and one invocation is repeated four times, so a slice of the always-loaded cost is duplicated material.",
+      "evidence": []
+    },
+    "D6": {
+      "score": 4,
+      "rationale": "The description front-loads the concrete tool name and then names the discriminating axis (searching for files by name, extension, or pattern), which is exactly what separates it from a content-search sibling without opening either body. It falls short of 5 because 'searching for files ... across directories' still overlaps substantially with any plausible generic file-discovery or glob sibling; the tool name, not the stated condition, does most of the disambiguation work there.",
+      "evidence": [
+        {"quote": "fd fast file finding: smart defaults, gitignore-aware, parallel. Use when searching for files by name, extension, or pattern across directories."}
+      ]
+    },
+    "D7": {
+      "score": 3,
+      "rationale": "One tool and one broad topic, but the body carries adjacent material that could plausibly stand alone as its own entry condition: batch command execution over results, destructive cleanup operations, output reformatting, and integration with a second search tool. Most invocations will want the find-and-filter half and pay for the execute-and-delete half, which is the anchor-3 shape of one dominant subject with detachable secondary material.",
+      "evidence": []
+    },
+    "D8": {
+      "score": 3,
+      "rationale": "A minority of statements decompose into checkable conditions an observer could verify in a transcript (whether --format was used instead of an xargs pipe, whether -t f was passed, whether -j 1 was used). The majority of the body is illustrative example commands from which no obligation can be extracted at all, and the remaining directives are hedged or unobservable. That mix is the anchor-3 case.",
+      "evidence": []
+    }
+  },
+  "body_chars": 9117,
+  "sidecars": []
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/fd-file-finding_j2.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/fd-file-finding_j2.json
@@ -1,0 +1,60 @@
+{
+  "unit": "tools-plugin/skills/fd-file-finding/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "cli-wrapper",
+  "judge_id": "j2",
+  "dimensions": {
+    "D1": {
+      "score": 1,
+      "rationale": "The body is a topically-grouped option catalogue: advantages list, flag sections (type, depth, hidden, size, mtime), a placeholder table, a flags quick-reference, and a closing pitch. There is no ordered sequence of steps and no decision point that commits the reader to an action; a reader finishes knowing about fd's surface area, not what to do first. Numbering the invocation path (detect scope, choose filter, verify result count, then act) with named decision points would move this up.",
+      "evidence": [
+        {"quote": "- Fast parallel execution (written in Rust)"},
+        {"quote": "This makes fd the preferred tool for fast, intuitive file finding in development workflows."}
+      ]
+    },
+    "D2": {
+      "score": 1,
+      "rationale": "No failure mode is recorded anywhere: no symptom, no cost, no path that was tried and abandoned. The one comparative claim is an unlabelled preference assertion with no observed consequence attached, and the destructive examples (fd -e pyc -x rm, fd node_modules -t d -x rm -rf) carry no warning about what a mis-scoped pattern deletes. Attaching an observed symptom to even one or two steps would raise this.",
+      "evidence": [
+        {"quote": "**Note:** Use `--format '{//}'` instead of piping to xargs - it's faster and simpler."}
+      ]
+    },
+    "D3": {
+      "score": 3,
+      "rationale": "Invocations are exact and copy-pasteable throughout, and the placeholder table ({}, {/}, {//}, {.}) does specify output shape for the --format path. But nothing states environment or lifecycle preconditions (is fd installed, which version, what the gitignore/hidden defaults silently exclude), the expected output shape of a plain search is never shown, and there is no way to tell an unmet precondition from an empty result set.",
+      "evidence": []
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "The skill states where it does not apply and names the replacement in three places: two When-to-Use tables routing content search to rg-code-search and JSON work to jq-json-processing, a Best Practices block naming four conditions that belong to find instead, and an inline note on when xargs is the right tool after all. It stops short of 5 only because it never addresses the case where its own guidance is wrong for the situation at hand.",
+      "evidence": [
+        {"quote": "**When to Use find Instead**"},
+        {"quote": "# When xargs IS useful: complex pipelines or non-fd inputs"}
+      ]
+    },
+    "D5": {
+      "score": 3,
+      "rationale": "Body is 9,119 chars, roughly 2,280 estimated tokens, so about 1.5x the ~1.5k SKILL.md median but within the <2.5k total-token median given there are no sidecars. The material is coherent to one topic, which is what the anchor asks for at 3. Working against it: nothing is deferred (no REFERENCE.md exists) and several commands are repeated verbatim across the Path-Based, Best Practices, and Common Command Patterns sections, so a share of the always-loaded cost is duplication.",
+      "evidence": []
+    },
+    "D6": {
+      "score": 4,
+      "rationale": "The description front-loads the tool name and then names the distinguishing condition explicitly (files by name, extension, or pattern), which is what separates it from a content-search sibling without opening either body. It falls short of 5 because a plausible sibling covering glob/path matching would share nearly all of that vocabulary; the discriminator is really the tool name rather than the stated condition.",
+      "evidence": [
+        {"quote": "fd fast file finding: smart defaults, gitignore-aware, parallel. Use when searching for files by name, extension, or pattern across directories."}
+      ]
+    },
+    "D7": {
+      "score": 3,
+      "rationale": "One dominant subject (locating files with fd) with adjacent secondary material that could plausibly stand alone: the -x/-X batch-execution section, the cleanup/deletion recipes, the output-format placeholder reference, and the fd-plus-rg integration block are each a separate downstream activity from finding. Nothing here is off-topic, but a run that just needs an extension search pays for the execution and cleanup material too.",
+      "evidence": []
+    },
+    "D8": {
+      "score": 3,
+      "rationale": "Some instructions decompose into observable conditions: whether --format '{//}' was used instead of an xargs pipe, or whether -t f narrowed the type, would both be visible in a transcript. Others are dispositional with no observable correlate: 'when possible', 'if order matters', and 'leverage gitignore' cannot be scored from a trajectory, and the bulk of the body is catalogue rather than instruction, so there is little to extract as a constraint in the first place.",
+      "evidence": []
+    }
+  },
+  "body_chars": 9119,
+  "sidecars": []
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/git-cli-agentic_j1.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/git-cli-agentic_j1.json
@@ -1,0 +1,71 @@
+{
+  "unit": "git-plugin/skills/git-cli-agentic/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "cli-wrapper",
+  "judge_id": "j1",
+  "dimensions": {
+    "D1": {
+      "score": 1,
+      "rationale": "The body is a command catalogue organised by git subcommand (Status/Diff/Log/Branch/Remote/Staging/Commit/Push), with lookup tables of status codes and format placeholders. There is no ordered sequence of steps and no decision point that commits the reader to an action; the closing 'Best Practices' list is five standalone maxims, not a procedure. Adding even a short ordered path (detect state, choose output mode, parse, act) would move this up.",
+      "evidence": [
+        {"quote": "Optimized git commands for AI agent consumption using porcelain output and stable formats."},
+        {"quote": "| Placeholder | Meaning |"}
+      ]
+    },
+    "D2": {
+      "score": 3,
+      "rationale": "Two guidance points carry real outcome information attached to the command they threaten: the heredoc note names the exact corruption ('the backslash survives into the commit message') and the context-expression note names the blocking mechanism. Everything else is unlabelled assertion, and one hazard is only gestured at ('use carefully'). That mix is what anchor 3 describes.",
+      "evidence": []
+    },
+    "D3": {
+      "score": 4,
+      "rationale": "Invocations are exact and copy-pasteable, and three of them publish their exact output shape (porcelain v2 record grammar, numstat field order, rev-list column order), plus a status-code and placeholder table for parsing. It also states the environment assumption up front (cwd is the repo) and when the -C flag is actually needed. It stops short of 5 because no precondition failure is made detectable: nothing says how the branch-tracking or remote commands behave when there is no upstream or no remote configured.",
+      "evidence": [
+        {"quote": "**Numstat Format**: `<added>\\t<deleted>\\t<filename>`"},
+        {"quote": "# Output: <behind>\\t<ahead>"}
+      ]
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "The opening table is a genuine routing surface: each row names a condition under which this skill does not apply and names the specific sibling to use instead, across four adjacent skills. It falls short of 5 only because there is no escape from the skill itself - no guidance for the case where the porcelain approach is the wrong tool or the documented output shape does not match what the reader sees.",
+      "evidence": [
+        {"quote": "| Writing scriptable `git status/diff/log` calls in porcelain or `--format` mode | Use `gh-cli-agentic` for `gh` JSON queries against the GitHub API |"}
+      ]
+    },
+    "D5": {
+      "score": 4,
+      "rationale": "The always-loaded body is 6,743 characters (~1.69k tokens), essentially at the ~1.5k ecosystem median and well under the ~2.5k total median, with no sidecar files at all. It is not a 5 because there is zero progressive disclosure: a run that only needs porcelain status parsing still loads the remote, staging, commit and push sections. At this size that cost is small, which is why it does not drag the score lower.",
+      "evidence": [
+        {"quote": "## Push Operations"},
+        {"quote": "## Remote Operations"}
+      ]
+    },
+    "D6": {
+      "score": 4,
+      "rationale": "The description front-loads distinguishing tokens a sibling would not carry - porcelain=v2, --numstat, custom --format placeholders - so the machine-parsing purpose is decidable without opening the body, and it separates cleanly from a commit-workflow or gh-JSON sibling. Not a 5 because 'status/diff/log' and 'branch tracking info' are generic enough that a sibling git-log or git-diff skill would still contest part of the trigger surface.",
+      "evidence": [
+        {"quote": "Git commands with porcelain and machine-readable output for agent workflows. Use when scripting status/diff/log, porcelain=v2, --numstat counts, custom --format placeholders, or branch tracking info."}
+      ]
+    },
+    "D7": {
+      "score": 2,
+      "rationale": "The dominant material is one coherent thing - machine-readable read output - but the file also carries staging, commit-message authoring, push refspecs, gh-CLI combination and context-expression error handling, each usable independently of the porcelain thesis. The scope leak is self-evident: the skill's own routing table sends staging and commit-message structure to a different skill, and then ships Staging and Commit sections anyway.",
+      "evidence": [
+        {"quote": "| Needing `--porcelain=v2` status, `--numstat` diff counts, or custom `--format` log placeholders | Use `git-commit-workflow` for staging conventions and commit message structure |"},
+        {"quote": "## Staging Operations"},
+        {"quote": "## Commit Operations"}
+      ]
+    },
+    "D8": {
+      "score": 4,
+      "rationale": "Almost every instruction reduces to a literal command form an observer could look for in a transcript - which flag was passed, which of two commands was chosen, whether a suppressor was appended - so violations are visible rather than inferred. It is not a 5 because one hazard is purely dispositional and one constraint is ambiguous against the skill's own examples (the always-add rule is not honoured by the context block shown two sections earlier).",
+      "evidence": [
+        {"quote": "**Prefer git switch/restore** over checkout for clarity"},
+        {"quote": "4. **Always add 2>/dev/null fallback** in context expressions"},
+        {"quote": "# Amend last commit (use carefully)"}
+      ]
+    }
+  },
+  "body_chars": 6743,
+  "sidecars": []
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/git-cli-agentic_j2.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/git-cli-agentic_j2.json
@@ -1,0 +1,69 @@
+{
+  "unit": "git-plugin/skills/git-cli-agentic/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "cli-wrapper",
+  "judge_id": "j2",
+  "dimensions": {
+    "D1": {
+      "score": 2,
+      "rationale": "The spine is a topic-partitioned command catalogue (Status / Diff / Log / Branch / Remote / Staging / Commit / Push), each section a fenced list of alternative invocations with no ordering, no entry step, and no decision point that selects between them. Nothing commits the reader to a sequence; the closest thing to procedure is a five-item 'Best Practices' list of maxims. It rises above anchor 1 only because the declarative material is itself executable commands rather than background prose. An ordered 'detect state, then choose the parse mode, then emit' spine — or even a routing step in front of the catalogue — would move it up.",
+      "evidence": [
+        {"quote": "Optimized git commands for AI agent consumption using porcelain output and stable formats."},
+        {"quote": "## Commit Operations"}
+      ]
+    },
+    "D2": {
+      "score": 3,
+      "rationale": "Two places carry genuine outcome signal attached to the step they threaten: the heredoc block names the exact corruption a wrong escape produces, and the context-expression section names why the obvious alternative is unavailable. Everything else — roughly forty commands — is unlabelled assertion, with the one hazard flagged only dispositionally ('use carefully'). That mix lands squarely on the anchor-3 reading: some outcome signal, thin and unsystematic.",
+      "evidence": []
+    },
+    "D3": {
+      "score": 4,
+      "rationale": "This is the skill's strongest axis: exact invocations throughout, plus the expected output shape spelled out for the non-obvious ones (a literal porcelain-v2 record layout, a status-code table, the numstat and rev-list field orders, a format-placeholder table), and an explicit environment precondition stating that the working directory is the repo and naming the exact condition under which -C is required. It stops short of 5 because it never says how to tell a precondition is unmet, and it contradicts itself at the execution layer — Best Practice 4 mandates a 2>/dev/null fallback in context expressions while none of the three context examples directly above it carries one.",
+      "evidence": [
+        {"quote": "The `-C` flag is only needed when targeting a different repository from your current directory:"},
+        {"quote": "**Status Codes**:"}
+      ]
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "The opening table is a genuine four-row escape hatch: each row names a condition under which this skill is the wrong choice and names the specific alternative to use instead, which is most of what anchor 5 asks for. It falls short of 5 because there is no exit from the guidance when the guidance itself is wrong for the situation — no note on when porcelain parsing is the wrong tool, or what to do when a documented output shape does not match what the local git emits.",
+      "evidence": [
+        {"quote": "Use `gh-cli-agentic` for `gh` JSON queries against the GitHub API"},
+        {"quote": "Use `git-branch-pr-workflow` for the broader branch + PR design choices"}
+      ]
+    },
+    "D5": {
+      "score": 4,
+      "rationale": "Body is 6,742 characters, ~1,685 estimated tokens — essentially at the ~1.5k ecosystem median, and the directory holds no sidecars at all, so there is nothing an invocation pays for that it did not ask to load. It is not a 5 only on the anchor's second clause: with no on-demand file, the body has no deferral surface, so the two operation clusters that most runs will not use (staging/commit/push) are paid for on every invocation and any growth is paid in full.",
+      "evidence": [
+        {"quote": "## Agentic Optimizations"}
+      ]
+    },
+    "D6": {
+      "score": 4,
+      "rationale": "The description does real discriminating work by naming flag-level triggers rather than a topic: porcelain=v2, --numstat, custom --format placeholders. Against a plausible sibling those tokens decide the choice without opening either body. It is not a 5 because the leading clause ('Git commands ... for agent workflows') shares vocabulary with any git skill in a large pool, and the trigger list includes 'status/diff/log' which a general-purpose git skill would also claim; the distinguishing condition is present but arrives after the generic framing.",
+      "evidence": [
+        {"quote": "Use when scripting status/diff/log, porcelain=v2, --numstat counts, custom --format placeholders, or branch tracking info."}
+      ]
+    },
+    "D7": {
+      "score": 2,
+      "rationale": "The stated scope is machine-readable read operations, but the body also carries Staging, Commit, and Push sections — mutation workflows whose output is not parsed and which the skill's own routing table explicitly delegates elsewhere. That is not merely adjacent secondary material; it is material the skill tells you to get from another skill, and then supplies anyway, so an invocation aimed at porcelain parsing pays for a commit-message heredoc recipe. Deleting those three sections, or dropping the delegation row, would resolve the contradiction in either direction.",
+      "evidence": [
+        {"quote": "Use `git-commit-workflow` for staging conventions and commit message structure"},
+        {"quote": "## Commit Operations"}
+      ]
+    },
+    "D8": {
+      "score": 4,
+      "rationale": "Almost every instruction decomposes into an observable condition — a named flag either appears in the transcript's command or it does not, and the Agentic Optimizations table is a literal context-to-command mapping an observer can check row by row. A few residual dispositional items keep it off 5: 'use carefully' has no observable correlate, and the 'prefer switch/restore over checkout for clarity' maxim is checkable only if the transcript happens to contain the relevant operation.",
+      "evidence": [
+        {"quote": "1. **Use porcelain v2** for status when parsing programmatically"},
+        {"quote": "# Amend last commit (use carefully)"}
+      ]
+    }
+  },
+  "body_chars": 6742,
+  "sidecars": []
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/git-commit_j1.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/git-commit_j1.json
@@ -1,0 +1,71 @@
+{
+  "unit": "git-plugin/skills/git-commit/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "convention-enforcer",
+  "judge_id": "j1",
+  "dimensions": {
+    "D1": {
+      "score": 4,
+      "rationale": "The spine is a five-step ordered Workflow (Assess State, Stage, Run Pre-commit Hooks, Detect Issues, Create Commit), each step carrying runnable commands and at least one decision point (hook config present, confidence tiers for issue matching). It falls short of 5 because a declarative tail (Composability, Best Practices, Issue References) sits after the procedure without any step consuming it and without deferral to a sidecar.",
+      "evidence": [
+        {"quote": "### 1. Assess State"},
+        {"quote": "## Composability"}
+      ]
+    },
+    "D2": {
+      "score": 4,
+      "rationale": "The heredoc warning is exemplary outcome annotation attached to the exact step it threatens: it names the observed symptom (a literal backslash in the message), where it shows up (git log), and the cost (an --amend to clean up). It stops short of 5 because the separate Error Handling section states failure states as bare templates with no observed consequence, and the remaining steps carry no failure identities.",
+      "evidence": [
+        {"quote": "produces a literal backslash in the commit message that survives into"}
+      ]
+    },
+    "D3": {
+      "score": 4,
+      "rationale": "Every step gives an exact invocation rather than a paraphrase, including machine-readable flags, and the skill specifies the exact shape of the report it must emit plus literal strings for the no-changes and merge-conflict states. Held at 4 because environment/lifecycle preconditions are thin: only the .pre-commit-config.yaml existence check is stated, with nothing on gh authentication, remote presence, or how to detect those preconditions unmet.",
+      "evidence": [
+        {"quote": "git status --porcelain=v2 --branch"},
+        {"quote": "gh issue list --state open --json number,title,labels --limit 30"}
+      ]
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "It names several conditions under which this procedure is not the right one and says what to run instead (push, chained commit+push+PR, the broader workflow skill), and it carries a genuine abort condition with a concrete alternative action when the branch state has changed underneath. It is not a 5 because there is no escape for the case where the convention itself is wrong for the repository (e.g. a project not using conventional commits or issue references).",
+      "evidence": [
+        {"quote": "| Staging and committing without pushing or opening a PR | Use `git-commit-push-pr` to chain commit + push + PR creation in one step |"},
+        {"quote": "stop and reconcile (branch off the updated default, or"}
+      ]
+    },
+    "D5": {
+      "score": 5,
+      "rationale": "The body measures 5,308 characters (~1,327 tokens), at or just under the ~1.5k ecosystem median, and the only sidecar in the directory is evals.json, so nothing heavy is loaded per invocation. Detail that would have bloated it is deferred by explicit pointer to on-demand material (trailer conventions to a sibling skill, the full conventional-commit reference to a linked rules file).",
+      "evidence": [
+        {"quote": "For trailer conventions (Co-authored-by, Signed-off-by, BREAKING CHANGE, Release-As), see **git-commit-trailers** skill."}
+      ]
+    },
+    "D6": {
+      "score": 4,
+      "rationale": "The description front-loads literal trigger phrases and then names an explicit distinguishing condition plus the sibling to use instead, which makes the commit-vs-push choice decidable without opening either body. It stops short of 5 because it does not separate itself from a plausible same-named sibling covering broader staging and message-convention guidance; that boundary is only stated inside the body.",
+      "evidence": [
+        {"quote": "Local commits only — see git-push for remote."}
+      ]
+    },
+    "D7": {
+      "score": 4,
+      "rationale": "One procedure with one entry condition: produce a local commit. Nothing independent is bundled, and the reference tables feed the message-composition step directly. Held at 4 because a Composability section plus a second trigger-phrase orientation block duplicate the framing already carried by the leading decision table and do not serve the procedure's execution.",
+      "evidence": [
+        {"quote": "## Composability"}
+      ]
+    },
+    "D8": {
+      "score": 4,
+      "rationale": "Most instructions decompose into transcript-observable conditions: the heredoc form is either used or not, the escape is either present or not, the subject is either under 72 characters or not, an issue trailer is either present or not. It is not a 5 because several remaining directives are dispositional with no observable correlate, notably the logical-change rule and the high/medium confidence tiers for matching staged changes to issues.",
+      "evidence": [
+        {"quote": "Use HEREDOC directly in the git commit command."},
+        {"quote": "4. **Keep subject under 72 chars** - Better display in git log"},
+        {"quote": "1. **One logical change per commit** - Easier to review and revert"}
+      ]
+    }
+  },
+  "body_chars": 5308,
+  "sidecars": ["evals.json"]
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/git-commit_j2.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/git-commit_j2.json
@@ -1,0 +1,73 @@
+{
+  "unit": "git-plugin/skills/git-commit/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "convention-enforcer",
+  "judge_id": "j2",
+  "dimensions": {
+    "D1": {
+      "score": 4,
+      "rationale": "The spine is an ordered five-step workflow (Assess State, Stage Changes, Run Pre-commit Hooks, Detect Related Issues, Create Commit), each carrying concrete commands and at least one real decision point. It falls short of 5 because a meaningful tail of the body is declarative and feeds no step: a numbered Best Practices list, a Composability section about other skills, and two separate 'when to use' blocks. Folding those into the steps or deferring them would move it to 5.",
+      "evidence": [
+        {"quote": "If `.pre-commit-config.yaml` exists:"},
+        {"quote": "1. **One logical change per commit** - Easier to review and revert"}
+      ]
+    },
+    "D2": {
+      "score": 4,
+      "rationale": "One failure mode is annotated exactly as the finding prescribes: the heredoc escaping note is attached to the step it threatens, names the observable symptom (a literal backslash visible in git log) and its cost (an --amend to clean up). The rest is weaker: the Error Handling section lists symptoms without the consequence or the observed cost, and the 're-stage after formatters' hazard states the fix without naming what going wrong looks like.",
+      "evidence": [
+        {"quote": "produces a literal backslash in the commit message that survives into `git log` and needs an `--amend` to clean up."},
+        {"quote": "# If hooks modify files (formatters), re-stage:"}
+      ]
+    },
+    "D3": {
+      "score": 4,
+      "rationale": "Commands are exact and flag-complete rather than paraphrased, the commit invocation is given as a literal quoted heredoc, and an Output section fixes the expected report shape. It stops short of 5 because environment preconditions are only partly covered: the pre-commit config check is explicit, but there is no test for gh availability/auth or for a missing remote before Step 4 runs, and no expected output shape is given for the diagnostic commands themselves.",
+      "evidence": [
+        {"quote": "git status --porcelain=v2 --branch"},
+        {"quote": "gh issue list --state open --json number,title,labels --limit 30"}
+      ]
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "The skill states its scope limit and, unusually, says what to do instead in each case: a table routes four adjacent intents to named alternative skills, and a pre-commit gate names verdicts under which the procedure must stop and reconcile rather than proceed. It is not a 5 because there is no general escape for the case where the procedure itself is wrong for the situation - every exit named is a pre-enumerated one.",
+      "evidence": [
+        {"quote": "Use `git-commit-push-pr` to chain commit + push + PR creation in one step"},
+        {"quote": "`pr_merged` or `behind` — stop and reconcile"}
+      ]
+    },
+    "D5": {
+      "score": 5,
+      "rationale": "The body measures 5311 characters, about 1330 tokens - below the ~1.5k ecosystem median - and there is no sidecar bloat (the only other file is evals.json, not disclosure material). Detail that would have inflated it is pushed out by name: trailer conventions to a sibling skill, issue-detection patterns to another, and the full conventional-commit reference to an external rules file. Nothing here is paid for by runs that do not use it.",
+      "evidence": [
+        {"quote": "For trailer conventions (Co-authored-by, Signed-off-by, BREAKING CHANGE, Release-As), see **git-commit-trailers** skill."}
+      ]
+    },
+    "D6": {
+      "score": 4,
+      "rationale": "The description front-loads concrete trigger phrases and then names the distinguishing condition against its most confusable sibling - local-only versus remote - which makes the git-push choice decidable without opening either body. It is not a 5 because the same description does not separate it from a broader staging/message-convention sibling that the body itself acknowledges; that call still needs the body.",
+      "evidence": [
+        {"quote": "Local commits only — see git-push for remote."},
+        {"quote": "Use `git-commit-workflow` for the broader staging + message convention guidance"}
+      ]
+    },
+    "D7": {
+      "score": 4,
+      "rationale": "One entry condition ('commit') and one procedure, with the scope boundary stated explicitly so push and PR creation stay out. The secondary material - a composability map of other skills' chains and a general Best Practices list - is adjacent rather than integral and could stand alone, which is what keeps it off 5, but it is small and does not constitute a second bundled procedure.",
+      "evidence": [
+        {"quote": "This skill creates **local commits only**. For remote operations:"}
+      ]
+    },
+    "D8": {
+      "score": 4,
+      "rationale": "Most instructions decompose into discretely observable conditions: use a heredoc for the message, do not backslash-escape inside a quoted heredoc, keep the subject under 72 chars, run the exact listed commands, re-stage after formatter hooks. A minority are dispositional or judgement-bound - 'one logical change per commit' and the high/medium confidence issue-matching tiers - which an observer could not adjudicate from a transcript.",
+      "evidence": [
+        {"quote": "**IMPORTANT:** Use HEREDOC directly in the git commit command."},
+        {"quote": "4. **Keep subject under 72 chars** - Better display in git log"},
+        {"quote": "- Directory/component matches (medium confidence)"}
+      ]
+    }
+  },
+  "body_chars": 5311,
+  "sidecars": ["evals.json"]
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/github-pr-title_j1.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/github-pr-title_j1.json
@@ -1,0 +1,66 @@
+{
+  "unit": "git-plugin/skills/github-pr-title/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "convention-enforcer",
+  "judge_id": "j1",
+  "dimensions": {
+    "D1": {
+      "score": 2,
+      "rationale": "The body is a reference catalogue of the conventional-commits format — type table, scope examples, subject rules, breaking-change and revert forms, a template table — with no ordered sequence of steps a reader is committed to executing. The nearest thing to a procedure is a one-line decision tree and two discovery commands; a numbered 'detect the change type, derive the scope, compose, validate' flow would have moved this to 3 or above.",
+      "evidence": [
+        {"quote": "**Decision tree:** Feature → `feat` | Bug → `fix`"},
+        {"quote": "## Quick Reference"}
+      ]
+    },
+    "D2": {
+      "score": 3,
+      "rationale": "A Bad/Good example table records what malformed titles look like, and a 'Why This Matters' section asserts the consequences of the convention (release-please bumps, squash-merge commit messages). But no failure is attached to the step it threatens and none names an observed cost — this is outcome signal asserted rather than witnessed, which is exactly the middle anchor.",
+      "evidence": []
+    },
+    "D3": {
+      "score": 4,
+      "rationale": "The output format is pinned exactly, including its edge forms (breaking-change `!` placement, revert prefix), and the commands are literal and copy-runnable rather than paraphrased. It stops short of 5 because there are no environment or lifecycle preconditions at all — nothing about gh auth, a missing remote, or what the discovery pipeline prints when a repo has no scoped titles.",
+      "evidence": [
+        {"quote": "gh pr edit N --title \"new title\""},
+        {"quote": "feat(api)!: remove deprecated endpoints"}
+      ]
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "The opening table is a genuine two-column scope boundary: each row that says when to use this skill is paired with a named alternative for the adjacent case (full PR creation, commit messages, issue titles, repairing a local commit), so a reader who falls outside the scope is routed rather than stranded. It falls short of 5 because the convention itself is stated as unconditional ('PR titles MUST follow conventional commits') with no case in which this guidance is the wrong guidance.",
+      "evidence": [
+        {"quote": "Use `github-issue-writing` for issue titles (different `[Type] Component:` format)"}
+      ]
+    },
+    "D5": {
+      "score": 5,
+      "rationale": "The body is 4,206 characters (~1,051 tokens), below the ~1.5k ecosystem median, and it twice defers the exhaustive format guide to an on-demand rules file rather than inlining it. Every invocation pays only for the type table, the subject rules, and the templates — the material a title actually needs.",
+      "evidence": [
+        {"quote": "See [Conventional Commits Standards](../../.claude/rules/conventional-commits.md) for comprehensive format guide."}
+      ]
+    },
+    "D6": {
+      "score": 3,
+      "rationale": "The name and the description's opening clause name the artifact ('PR titles'), which is topically clear, but the trigger surface shares its whole vocabulary with a plausible commit-message sibling ('conventional commits format') and with a PR-creation sibling ('Use when creating PRs'). Choosing between this and either sibling on descriptions alone is not decidable; the body's When-to-Use table is what disambiguates.",
+      "evidence": []
+    },
+    "D7": {
+      "score": 5,
+      "rationale": "One artifact, one entry condition: everything present — format spec, type selection, scope discovery, subject rules, breaking/revert forms, templates, the edit command — serves producing or repairing a single PR title. Even the four rows of the applicability table are four situations for the same one job, and no independent second procedure is bundled in.",
+      "evidence": [
+        {"quote": "Craft clear PR titles using conventional commits format."},
+        {"quote": "Renaming an existing PR title to fix release-please version-bump detection"}
+      ]
+    },
+    "D8": {
+      "score": 5,
+      "rationale": "Almost every instruction is a discrete predicate over the produced title: matches `<type>(<scope>): <subject>`, imperative mood, lowercase after the colon, no terminal punctuation, under 50 characters, `!` before the colon for breaking changes. An observer with only the PR title in a transcript could mark each one satisfied or violated without interpretation, and the one soft phrase ('Keep concise') is bounded by a character count in the same line.",
+      "evidence": [
+        {"quote": "- **No period**: Don't end with punctuation"},
+        {"quote": "- **Under 50 chars**: Keep concise"}
+      ]
+    }
+  },
+  "body_chars": 4206,
+  "sidecars": []
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/github-pr-title_j2.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/github-pr-title_j2.json
@@ -1,0 +1,86 @@
+{
+  "unit": "git-plugin/skills/github-pr-title/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "convention-enforcer",
+  "judge_id": "j2",
+  "dimensions": {
+    "D1": {
+      "score": 2,
+      "rationale": "The body is a reference document about conventional commits, not an executable procedure: format spec, a type/version-bump table, subject rules, a Bad/Good example table, breaking-change and revert syntax, a templates table, a rationale section, and a commands table. There are no ordered steps and no committed sequence of actions; the only procedural artifact is a single-line decision tree for picking a type. Numbered steps that consumed the tables (detect changed dirs -> pick type -> discover scope -> compose -> apply via gh pr edit) would have moved this up.",
+      "evidence": [
+        {
+          "quote": "**Decision tree:** Feature → `feat` | Bug → `fix`"
+        },
+        {
+          "quote": "## Why This Matters"
+        }
+      ]
+    },
+    "D2": {
+      "score": 3,
+      "rationale": "There is a real outcome signal: a Bad/Good example table showing what a rejected title looks like, and a CRITICAL note naming the consequence (release-please automation and squash-merge history). But the consequences are asserted rather than observed, no cost or symptom is given, and nothing records which alternatives were tried and failed. This is consistent with the anchor for a warnings section that is asserted without observed consequence.",
+      "evidence": []
+    },
+    "D3": {
+      "score": 4,
+      "rationale": "Execution detail is strong on the two axes that matter here: the output format is specified exactly (the `<type>(<scope>): <subject>` shape, the `!` breaking-change position, the revert form, the per-type version-bump result), and the commands are copy-pasteable full invocations rather than paraphrases. It falls short of 5 because no expected output shape is shown for any command and no environment preconditions are stated (gh auth, jq availability, an origin/main ref, whether the repo actually squash-merges), nor how to tell one is unmet.",
+      "evidence": [
+        {
+          "quote": "gh pr list --state merged -L 30 --json title | jq -r '.[].title' | grep -oE '\\([^)]+\\)' | sort | uniq -c | sort -rn"
+        },
+        {
+          "quote": "- **Under 50 chars**: Keep concise"
+        }
+      ]
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "The When-to-Use table is a genuine four-row boundary statement: every row names a condition that falls outside this skill and the named alternative to use instead (git-pr, git-commit-workflow, github-issue-writing, git-commit). What is missing is an escape from its own core prescription: the format is stated as an unconditional MUST, with no guidance for a repository that does not use conventional commits or release-please, so a reader in that situation is given no exit.",
+      "evidence": [
+        {
+          "quote": "Use `github-issue-writing` for issue titles (different `[Type] Component:` format)"
+        },
+        {
+          "quote": "**CRITICAL:** PR titles must follow conventional commit format."
+        }
+      ]
+    },
+    "D5": {
+      "score": 5,
+      "rationale": "The body is 4,206 characters, roughly 1,050 estimated tokens, comfortably at or under the ~1.5k ecosystem median, and the directory holds no sidecars to add to that. Detail is explicitly deferred twice to an external conventional-commits reference rather than inlined, so an invocation pays only for the format, the type table and the commands.",
+      "evidence": [
+        {
+          "quote": "For detailed rules, patterns, and troubleshooting, see [Conventional Commits Standards](../../.claude/rules/conventional-commits.md)."
+        }
+      ]
+    },
+    "D6": {
+      "score": 3,
+      "rationale": "The name and the leading clause of the description name the artifact precisely (PR titles) and the mechanism (release-please), which separates it cleanly from a commit-message sibling. But the stated trigger, 'Use when creating PRs', is exactly what a full PR-creation sibling would also claim, and the body itself concedes such a sibling exists; deciding between them on the descriptions alone is not reliable. The vocabulary (conventional commits, consistent git history) is also shared with the commit-message sibling.",
+      "evidence": []
+    },
+    "D7": {
+      "score": 5,
+      "rationale": "Every section serves one entry condition: producing or repairing a conventional-commit PR title. Type selection, scope discovery, subject rules, breaking changes, reverts, templates and the command table are all sub-parts of that single act, and none could stand alone as a separate skill. The rationale section is the only non-operational material and it still argues for the same one procedure.",
+      "evidence": [
+        {
+          "quote": "Craft clear PR titles using conventional commits format."
+        }
+      ]
+    },
+    "D8": {
+      "score": 5,
+      "rationale": "The guidance is essentially a lint specification: prefix matches an enumerated type, optional parenthesised scope, colon-space, lowercase first letter, no trailing period, under fifty characters, `!` immediately before the colon for breaking changes. Each of these is a discrete condition an observer could mark satisfied or violated against the title in a transcript, and the Bad/Good table pins the one soft rule (imperative mood) to concrete token-level examples. Almost nothing is dispositional.",
+      "evidence": [
+        {
+          "quote": "- **No period**: Don't end with punctuation"
+        },
+        {
+          "quote": "- **Under 50 chars**: Keep concise"
+        }
+      ]
+    }
+  },
+  "body_chars": 4206,
+  "sidecars": []
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/jq-json-processing_j1.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/jq-json-processing_j1.json
@@ -1,0 +1,66 @@
+{
+  "unit": "tools-plugin/skills/jq-json-processing/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "cli-wrapper",
+  "judge_id": "j1",
+  "dimensions": {
+    "D1": {
+      "score": 1,
+      "rationale": "The body is a flat option catalogue: an expertise blurb, then ten command-listing sections and a Quick Reference of operators and functions. There is no ordered sequence of actions anywhere - a reader finishes knowing what jq can do, with no committed procedure to execute. Even one imperative spine (detect input shape, build filter, verify output) with the catalogue deferred would have moved this up sharply.",
+      "evidence": [
+        {"quote": "Expert knowledge for processing, querying, and transforming JSON data using jq, the lightweight and flexible command-line JSON processor."},
+        {"quote": "## Core Expertise"},
+        {"quote": "### Operators"}
+      ]
+    },
+    "D2": {
+      "score": 3,
+      "rationale": "A Troubleshooting section names recognisable failure states (Invalid JSON, Empty Results, Type Errors, Performance Issues) and gives a debugging command for each, which is a real outcome signal. But it sits detached at the end rather than attached to the guidance it threatens, and nothing records what was actually tried, what failed, or what the failure cost.",
+      "evidence": []
+    },
+    "D3": {
+      "score": 4,
+      "rationale": "Every example is a complete, runnable invocation with concrete flags rather than a paraphrase, and the skill states its environment precondition explicitly (install per platform, then verify) plus a checkable validity probe on the input. It falls short of 5 because expected output shapes are described in comments rather than shown, so a reader cannot compare a real result against a stated shape.",
+      "evidence": [
+        {"quote": "jq empty file.json  # Returns exit code 0 if valid"},
+        {"quote": "## Installation"}
+      ]
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "Two explicit tables open the skill naming the conditions under which it does not apply and the named alternative to reach for instead (yq-yaml-processing for YAML/comment-preserving edits, nushell-data-processing for multi-format or aggregation work). It stops short of 5 only because there is no escape for the case where jq is right but this guidance is wrong for the situation.",
+      "evidence": [
+        {"quote": "| Use this skill when... | Use yq-yaml-processing instead when... |"},
+        {"quote": "| Parsing `gh`, `curl`, or `kubectl -o json` responses | Editing YAML in place while preserving comments |"}
+      ]
+    },
+    "D5": {
+      "score": 2,
+      "rationale": "The body is ~10,790 characters (~2,700 tokens), roughly 1.8x the ~1.5k ecosystem median, and the directory holds no sidecar at all - so every invocation pays in full for material most runs never touch, including platform install commands and an external links section. It is not many multiples of the median, which keeps it off a 1, but deferral here is zero rather than partial.",
+      "evidence": [
+        {"quote": "## Installation"},
+        {"quote": "## Resources"}
+      ]
+    },
+    "D6": {
+      "score": 3,
+      "rationale": "The name and the front-loaded 'jq JSON processing' make the tool unmistakable, but the trigger clause that follows is generic JSON work (parsing files, filtering arrays/objects, transforming structures, extracting fields) that a sibling JSON-capable data skill would match just as well. The skill itself concedes this by spending its first two tables disambiguating against two named siblings - work the description does not do.",
+      "evidence": []
+    },
+    "D7": {
+      "score": 2,
+      "rationale": "Everything shares the tool, but the sections are independent use cases rather than one procedure: log analysis, CSV/JSON conversion, config-file editing, cross-tool piping, troubleshooting, and installation each stand alone and each is paid for on every load. There is no single entry condition and no dominant procedure the rest of the material serves.",
+      "evidence": [
+        {"quote": "## Integration with Other Tools"},
+        {"quote": "### Log Analysis"}
+      ]
+    },
+    "D8": {
+      "score": 3,
+      "rationale": "The command examples decompose cleanly into observable constraints - whether -r or -c was passed, whether jq empty was run - so an observer could check them from a transcript. The Best Practices section that carries the actual guidance is the other half: several entries are dispositional preferences with no observable correlate, so a trajectory could satisfy or violate them invisibly.",
+      "evidence": []
+    }
+  },
+  "body_chars": 10790,
+  "sidecars": []
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/jq-json-processing_j2.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/jq-json-processing_j2.json
@@ -1,0 +1,67 @@
+{
+  "unit": "tools-plugin/skills/jq-json-processing/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "cli-wrapper",
+  "judge_id": "j2",
+  "dimensions": {
+    "D1": {
+      "score": 1,
+      "rationale": "The body is a categorised command catalogue with no ordered procedure anywhere: no numbered steps, no imperative openers, no decision points that commit the reader to a next action. It opens by declaring itself knowledge rather than a procedure, and the closest thing to sequencing is a dispositional bullet ('Start simple, build complexity incrementally'). A reader finishes knowing about jq's operator surface with no committed sequence of actions; an ordered detect-shape then select-filter then verify spine would have moved this up.",
+      "evidence": [
+        {"quote": "Expert knowledge for processing, querying, and transforming JSON data using jq, the lightweight and flexible command-line JSON processor."},
+        {"quote": "## Core Expertise"},
+        {"quote": "- Query and filter JSON with path expressions"},
+        {"quote": "Start simple, build complexity incrementally"}
+      ]
+    },
+    "D2": {
+      "score": 3,
+      "rationale": "Outcome signal exists as a dedicated Troubleshooting section organised by symptom (Invalid JSON, Empty Results, Type Errors, Performance Issues) plus an Error Handling block under Best Practices, so failure is anticipated rather than ignored. But it is detached from any step it threatens, and no failure is annotated with an observed consequence or cost. That is consistent with the findings without exceeding them.",
+      "evidence": []
+    },
+    "D3": {
+      "score": 4,
+      "rationale": "Nearly every line is an exact, runnable invocation rather than a paraphrase, and the skill goes further than the main path: it states an environment precondition with a way to check it (install commands plus a version probe), names an external dependency for the in-place-edit path, and gives one exact machine-readable outcome (an exit code) for validation. It falls short of 5 because expected output shapes are never shown for any query, so the reader cannot tell a correct result from a silently-empty one except in the validation case.",
+      "evidence": [
+        {"quote": "# Verify installation"},
+        {"quote": "# In-place edit (use sponge from moreutils)"},
+        {"quote": "jq empty file.json  # Returns exit code 0 if valid"}
+      ]
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "Two explicit comparison tables sit at the top naming when NOT to use this skill and what to reach for instead (yq for YAML and comment-preserving edits, nushell for multi-format and group-by work), which is more than a bare scope statement. It stops short of 5 because there is no exit for the case where jq is the right tool but this guidance is wrong for the situation at hand.",
+      "evidence": [
+        {"quote": "| Use this skill when... | Use yq-yaml-processing instead when... |"},
+        {"quote": "| One-off pipeline transforms that fit in a single expression | Multi-step transforms that span JSON, YAML, CSV, and TOML |"}
+      ]
+    },
+    "D5": {
+      "score": 2,
+      "rationale": "The body is 10,788 characters, roughly 2,697 estimated tokens — about 1.8x the ~1.5k ecosystem median — and the directory contains SKILL.md alone, so there is zero deferral: every invocation pays for the installation instructions, external links, and CSV/log/config application sections that most runs never touch. It is not many multiples of the median, so not a 1, but neither anchor-3 escape applies: the material is a topic catalogue rather than one procedure, and nothing is deferred to a sidecar.",
+      "evidence": [
+        {"quote": "## Installation"},
+        {"quote": "- **jq Playground**: https://jqplay.org/"}
+      ]
+    },
+    "D6": {
+      "score": 4,
+      "rationale": "The name and description front-load the tool and the data format ('jq JSON processing'), which is the distinguishing condition against the most plausible near sibling, a YAML processor — that choice is decidable without opening either body. It is not a 5 because the trigger vocabulary ('parsing JSON files, filtering arrays/objects, transforming structures') is generic enough to also match a general data-processing sibling that handles JSON, and the body's own comparison table shows such a sibling exists; separating them needs the body.",
+      "evidence": [
+        {"quote": "description: \"jq JSON processing: query, filter, transform JSON. Use when parsing JSON files, filtering arrays/objects, transforming structures, or extracting fields from JSON.\""}
+      ]
+    },
+    "D7": {
+      "score": 3,
+      "rationale": "Everything present is one tool used one way — compose a filter and run it — so there is no genuinely independent second procedure bundled in. But a substantial tail of adjacent secondary material (installation, integration with other CLIs, and three application-domain sections for API responses, config files, and log analysis) could plausibly stand alone, which is exactly the anchor-3 shape.",
+      "evidence": []
+    },
+    "D8": {
+      "score": 3,
+      "rationale": "A meaningful share of instructions decompose into observable conditions — use -c for compact output, use -r for raw strings, use the ? operator for optional access, check existence with has() — each of which would be visibly present or absent in a transcript. An equally large share is dispositional with no observable correlate ('Start simple, build complexity incrementally', 'Consider jq -c for faster processing', 'Add comments in shell scripts'), which is the anchor-3 mix.",
+      "evidence": []
+    }
+  },
+  "body_chars": 10788,
+  "sidecars": []
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/parallel-agent-dispatch_j1.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/parallel-agent-dispatch_j1.json
@@ -1,0 +1,66 @@
+{
+  "unit": "agent-patterns-plugin/skills/parallel-agent-dispatch/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "multi-step-orchestrator",
+  "judge_id": "j1",
+  "dimensions": {
+    "D1": {
+      "score": 4,
+      "rationale": "The spine is the dispatch lifecycle in order (preflight -> scope budget -> return contract -> self-verification -> reviewer verification), each pillar opening with an imperative and a concrete decision point, and closing with an Orchestrator Checklist. It falls short of 5 because a substantial minority of the body is declarative hazard narrative (the nested-repo, GIT_DIR-export, scratchpad-collision, and resume sections) that reads as knowledge about the harness rather than as a step, even though most of it terminates in an instruction.",
+      "evidence": [
+        {"quote": "Before spawning, the orchestrator must verify:"},
+        {"quote": "Every agent prompt must declare:"}
+      ]
+    },
+    "D2": {
+      "score": 5,
+      "rationale": "Nearly every instruction is anchored to an observed failure with its symptom and its cost, attached to the step it threatens: the loud-failure contract names the exact one-word final messages seen and what the harness then does with the worktree; the cwd-reset guardrail names the post-run signal that reveals silent main-repo mutation; the batch-manifest rule cites a batch that completed ~5 of ~23 items invisibly. A reader can recognise each failure while it is happening.",
+      "evidence": [
+        {"quote": "so the harness reads \"no changes\", cleans up the worktree, and the work is lost."},
+        {"quote": "a changed branch or new dirty state is silent main-repo mutation."}
+      ]
+    },
+    "D3": {
+      "score": 5,
+      "rationale": "Preconditions are stated with the exact command that tests them and the exact reading that means 'unmet' (clean-tree check, branch-name availability across local/worktree/remote, session-repo vs target-repo toplevel comparison, empty-vs-dirty worktree discrimination), and environment/lifecycle constraints are explicit (tool surface absent in a sub-agent sandbox, CLAUDE_CODE_REMOTE push delegation, the skill_listing injection tax per agentType). The verbatim return schema itself is deferred to a sidecar, but its fields and the heading it must appear under are named inline.",
+      "evidence": [
+        {"quote": "git -C <worktree> log --oneline origin/main..HEAD"},
+        {"quote": "| SKILL.md description rewrites | `python3 scripts/audit-skill-descriptions.py --strict-all` |"}
+      ]
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "It opens with a four-row table naming the conditions under which a sibling skill applies instead, and several sections give a do-this-instead branch rather than a single mandate (lead-pushes exceptions, agentType selection where paying the catalog tax is correct, SendMessage-resume vs fresh re-dispatch, rate-limit signal treated as backoff rather than failure). It stops short of 5 because there is no escape for the case where this guidance itself is the wrong frame for the situation.",
+      "evidence": [
+        {"quote": "| Use this skill when... | Use `agent-teams` instead when... |"}
+      ]
+    },
+    "D5": {
+      "score": 3,
+      "rationale": "The body is 24,604 characters, roughly 6.2k estimated tokens, about four times the ecosystem median, but the material is one coherent dispatch procedure and the detail is genuinely deferred: a thin REFERENCE.md index routes to four references/*.md files (~43KB) split by the path a run is on, so an invocation loads only the recovery or hazard material it needs. That is squarely the 'larger than median but partially deferred' anchor rather than an undeferred bundle.",
+      "evidence": []
+    },
+    "D6": {
+      "score": 4,
+      "rationale": "The description names the artifact type (dispatch contract), the trigger conditions (fanning out concurrent agents, authoring a lead prompt), and three specific hazards it owns, which discriminates it from a generic multi-agent skill. It is not a 5 because a plausible sibling about agent teams or wave dispatch shares most of its vocabulary, and the body itself carries a When-to-Use table to do that disambiguation, implying the description alone does not fully decide it.",
+      "evidence": [
+        {"quote": "description: Dispatch contract for spawning parallel agents covering worktree collisions, scope overflow, and silent exits. Use when fanning out concurrent agents or authoring a lead prompt."}
+      ]
+    },
+    "D7": {
+      "score": 3,
+      "rationale": "One dominant procedure with a single entry condition (more than one agent running in parallel), and the five pillars plus the recovery sections are contingent branches of that same lifecycle. Adjacent material could plausibly stand alone, though: reviewer-agent verification, the read-only agentType selection with its context-budget economics, and the concurrency/rate-limit sizing table are each their own concern, and most invocations pay for all of them while using one.",
+      "evidence": []
+    },
+    "D8": {
+      "score": 5,
+      "rationale": "Instructions decompose into discrete, transcript-observable conditions, and the skill closes with a checklist that is literally that decomposition (clean tree, unique branch per agent, budgets present in each prompt, schema included verbatim, every return parsed). Even the softer sizing guidance carries numbers (2-3 heavy agents, up to 5 light), so an observer could check compliance rather than judge disposition.",
+      "evidence": [
+        {"quote": "- [ ] Each prompt includes the Return Contract schema verbatim"},
+        {"quote": "- [ ] Working tree clean; no conflicting worktrees"}
+      ]
+    }
+  },
+  "body_chars": 24604,
+  "sidecars": ["REFERENCE.md", "references/dispatch-contract.md", "references/brief-templates.md", "references/failure-recovery.md", "references/worktree-hazards.md"]
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/parallel-agent-dispatch_j2.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/parallel-agent-dispatch_j2.json
@@ -1,0 +1,71 @@
+{
+  "unit": "agent-patterns-plugin/skills/parallel-agent-dispatch/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "multi-step-orchestrator",
+  "judge_id": "j2",
+  "dimensions": {
+    "D1": {
+      "score": 4,
+      "rationale": "The spine is imperative and ordered: a preflight gate that can refuse to proceed, then per-prompt requirements, then a mandatory return contract, then verification passes, closing with a checkbox checklist that re-serialises the whole thing as actions. It falls short of 5 because several long hazard narratives (nested-repo isolation, GIT_DIR export leak, deleted worktree) read as background that no step directly consumes, even though a sidecar link sits beside each.",
+      "evidence": [
+        {"quote": "Before spawning, the orchestrator must verify:"},
+        {"quote": "If any check fails, **refuse to dispatch** and report the blocker."},
+        {"quote": "Every agent prompt must declare:"}
+      ]
+    },
+    "D2": {
+      "score": 5,
+      "rationale": "Nearly every instruction is welded to an observed failure with its symptom and its cost, and each is attached to the step it threatens rather than pooled in a gotchas appendix. A reader can recognise the failure while it is happening (a one-word final message, a batch that reports done at a fifth of its assignment) rather than only afterwards.",
+      "evidence": [
+        {"quote": "so the harness reads \"no changes\", cleans up the worktree, and the work is lost."},
+        {"quote": "invisible until `knip` was re-run"}
+      ]
+    },
+    "D3": {
+      "score": 5,
+      "rationale": "Preconditions are stated as runnable checks with the exact command and the exact condition that means unmet (empty porcelain output, a bare-repo report, a toplevel that differs from the session repo), and recovery gives the literal two-command discrimination between an empty and a dirty worktree. Environment and lifecycle are explicit: tool availability differing inside a sub-agent sandbox, inherited git env that overrides -C, concurrency ceilings by agent profile.",
+      "evidence": [
+        {"quote": "Main working tree is clean (`git status --porcelain` empty)"},
+        {"quote": "env -u GIT_DIR -u GIT_WORK_TREE git -C"},
+        {"quote": "git -C <worktree> status --porcelain"}
+      ]
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "It opens with an explicit boundary table that names the out-of-scope cases and routes each to a named alternative, and several sub-procedures carry their own conditional exits (dispatch from a sub-agent only under a stated condition; scale concurrency down rather than treating a rate limit as failure). It stops short of 5 because there is no escape for the case where the contract itself is the wrong frame for the situation — every exit routes to another named procedure.",
+      "evidence": [
+        {"quote": "Single-agent delegation or one-off subagent spawn"},
+        {"quote": "**Sub-agent orchestrator**: only when the team's outputs need not feed back"},
+        {"quote": "Prefer **sequential waves of small batches**"}
+      ]
+    },
+    "D5": {
+      "score": 3,
+      "rationale": "The body is 24,998 characters, roughly 6.2k tokens — about four times the ecosystem median — but the deferral machinery is real and well shaped: a thin REFERENCE.md index plus four references/ files split by the path that needs them, with the heavy material (schemas, salvage routines, per-hazard detail) sitting there rather than inline. What remains is coherent to the single dispatch procedure, which is exactly the anchor-3 condition; it is not near the median, so it is not a 5.",
+      "evidence": []
+    },
+    "D6": {
+      "score": 4,
+      "rationale": "The description names the distinguishing condition (fanning out concurrent agents, or authoring a lead prompt) and pins three concrete failure classes, so choosing it over a nearby teams/single-delegation skill is decidable without opening the body. It is a 4 rather than 5 because 'concurrent agents' vocabulary is shared with the sibling it explicitly defers to, so a reader weighing the two on descriptions alone still leans on the failure-class list to break the tie.",
+      "evidence": [
+        {"quote": "Dispatch contract for spawning parallel agents covering worktree collisions, scope overflow, and silent exits. Use when fanning out concurrent agents or authoring a lead prompt."}
+      ]
+    },
+    "D7": {
+      "score": 3,
+      "rationale": "One dominant procedure (pre-dispatch gate, brief contents, return contract) carries the file, but several adjacent blocks have their own entry conditions and could stand alone: recovering a missing return, deciding whether to kill a thrashing agent and salvage its worktree, and selecting an agentType on token-cost grounds. They are all downstream of dispatching, so this is not a topic bundle — just broader than one entry condition.",
+      "evidence": []
+    },
+    "D8": {
+      "score": 5,
+      "rationale": "Almost every instruction decomposes into a condition an observer could confirm from a transcript — was the tree clean before the spawn, does each prompt carry the schema verbatim, did every agent emit a Result block — and the closing checklist renders the whole procedure as discrete checkboxes. A handful of dispositional phrasings ('start conservative') are outnumbered by hard, binary requirements such as refusing to dispatch on a failed check.",
+      "evidence": [
+        {"quote": "- [ ] Working tree clean; no conflicting worktrees"},
+        {"quote": "- [ ] Each prompt includes the Return Contract schema verbatim"},
+        {"quote": "If any check fails, **refuse to dispatch** and report the blocker."}
+      ]
+    }
+  },
+  "body_chars": 24998,
+  "sidecars": ["REFERENCE.md", "references/brief-templates.md", "references/dispatch-contract.md", "references/failure-recovery.md", "references/worktree-hazards.md"]
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/rg-code-search_j1.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/rg-code-search_j1.json
@@ -1,0 +1,66 @@
+{
+  "unit": "tools-plugin/skills/rg-code-search/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "cli-wrapper",
+  "judge_id": "j1",
+  "dimensions": {
+    "D1": {
+      "score": 1,
+      "rationale": "The body is an option catalogue organised by feature area (Basic Usage, Advanced Patterns, Advanced Filtering, Output Formatting, Quick Reference) with no ordered steps, no numbered sequence, and no decision points that commit the reader to an action. It opens with a bullet list of tool properties rather than anything to execute. A single ordered procedure with concrete branch points - even a three-step 'narrow scope, then search, then refine' spine - would have moved this to 3.",
+      "evidence": [
+        {"quote": "**ripgrep Advantages**"},
+        {"quote": "- Extremely fast (written in Rust)"},
+        {"quote": "### Essential Options"}
+      ]
+    },
+    "D2": {
+      "score": 1,
+      "rationale": "Every line is an unlabelled assertion or a bare command with a trailing comment; there is no warnings section, no gotcha, no named failure symptom, and nothing indicating which invocations were tried and abandoned. The closest thing to a caution is a generic tips list that asserts preferences without any observed consequence attached. Attaching even one concrete failure ('-U with .* backtracks and hangs on large files', 'rg skips .gitignore'd paths so your match silently disappears') to the step it threatens would have earned a 3.",
+      "evidence": [
+        {"quote": "- Prefer rg over grep for speed and smart defaults"},
+        {"quote": "- Escape regex special characters in patterns"}
+      ]
+    },
+    "D3": {
+      "score": 3,
+      "rationale": "Invocations are exact and copy-pasteable across the main path, and output-shaping flags (--vimgrep, --json, --heading, -c) are named, which is real execution-layer content. But no expected output is ever shown, no installation or version precondition is stated, and there is no way to tell that a precondition is unmet - the reader learns the flags, not what a successful or failed run looks like.",
+      "evidence": []
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "The skill states its scope boundary twice at the top against two named siblings and again at the bottom against grep, and in each case it says what to reach for instead rather than only where it stops. It falls short of 5 because it offers no escape from itself: there is no guidance for the case where the rg-shaped approach is simply wrong for the situation at hand (structural/AST matching, binary-safe scanning, a search too large to eyeball) beyond the two sibling redirects.",
+      "evidence": [
+        {"quote": "**When to Use grep Instead**"},
+        {"quote": "- POSIX compatibility required"},
+        {"quote": "- Piped input (stdin)"},
+        {"quote": "| Searching source code or text-encoded files | Extracting strings from compiled binaries or firmware |"}
+      ]
+    },
+    "D5": {
+      "score": 2,
+      "rationale": "The body is 9,928 characters (~2,482 tokens), roughly 1.7x the ~1.5k ecosystem median, and the directory contains no sidecar of any kind, so every invocation pays the full cost. A substantial share of that is material a typical search run never touches - memory-map tuning, thread counts, occurrence histograms, and a scripted vim search-and-replace pipeline - all of which are exactly what an on-demand REFERENCE.md exists to hold. It is not many multiples of the median, so not a 1; a thinned body with the tuning and analysis blocks deferred would be a 5.",
+      "evidence": [
+        {"quote": "## Performance Optimization"},
+        {"quote": "### Stats and Analysis"},
+        {"quote": "rg pattern --mmap"}
+      ]
+    },
+    "D6": {
+      "score": 3,
+      "rationale": "The description front-loads the concrete tool name ('ripgrep (rg)') which is a genuine discriminator, and the skill name matches. But the trigger clause - searching for text patterns, code snippets, multi-file analysis - is vocabulary any plausible sibling code-search skill would claim, and the actual distinguishing condition (content search by line-oriented regex, as against filename search or AST-structural matching) appears only in the body's decision tables, not in the description. Choosing between this and a near sibling from descriptions alone would require the tool name to already be in the user's request.",
+      "evidence": []
+    },
+    "D7": {
+      "score": 3,
+      "rationale": "Content search is clearly the dominant procedure and most sections serve it. Three blocks are adjacent secondary material that could each stand alone: a mutation workflow driving sed -i and scripted vim, a match-frequency analysis block, and a performance-tuning block - none of which is content search, and the first has a different risk profile entirely. It is not a 1 because these do not fragment the skill into independent equals; a body confined to search with the mutation and tuning material elsewhere would be a 5.",
+      "evidence": []
+    },
+    "D8": {
+      "score": 3,
+      "rationale": "A handful of instructions decompose into observable conditions a transcript would show - escape regex metacharacters, pass -u for ignored files, exclude vendor directories by glob, prefer rg over grep - and each would be visibly satisfied or violated. The bulk of the body, however, is a menu of options rather than instructions at all, so there is nothing for an observer to check compliance against; and the Best Practices lists are dispositional groupings ('code analysis and auditing') with no observable correlate.",
+      "evidence": []
+    }
+  },
+  "body_chars": 9928,
+  "sidecars": []
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/rg-code-search_j2.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/rg-code-search_j2.json
@@ -1,0 +1,64 @@
+{
+  "unit": "tools-plugin/skills/rg-code-search/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "cli-wrapper",
+  "judge_id": "j2",
+  "dimensions": {
+    "D1": {
+      "score": 1,
+      "rationale": "The body is a flag catalogue organised by feature area (Basic Usage, Advanced Patterns, Advanced Filtering, Output Formatting, Quick Reference) with no ordered steps, no decision points, and no committed sequence of actions anywhere. It opens with a bullet list of tool properties and closes with a marketing sentence rather than an outcome. An identifiable ordered procedure (even 'Step 1: narrow scope, Step 2: choose type filter, Step 3: widen if empty') would have moved it to 3.",
+      "evidence": [
+        {"quote": "## Core Expertise"},
+        {"quote": "- Extremely fast (written in Rust)"},
+        {"quote": "This makes rg the preferred tool for fast, powerful code search in development workflows."}
+      ]
+    },
+    "D2": {
+      "score": 1,
+      "rationale": "Every line is an unlabelled assertion of what a flag does. There is no warnings/gotchas section, no failure symptom, and no cost attached to any choice - nothing records that a search returned nothing because .gitignore hid the file, that -U multiline patterns blow up on large files, or that the xargs pipelines break on paths with spaces. The 'Tips' bullets are the closest thing and they still name no observed consequence. Any single named failure with its symptom would have moved it toward 3.",
+      "evidence": [
+        {"quote": "- Escape regex special characters in patterns"}
+      ]
+    },
+    "D3": {
+      "score": 3,
+      "rationale": "Commands are exact and copy-pasteable throughout, including output-format flags (--vimgrep, --json, --count-matches), which covers the main path well. But no expected output shape is ever shown, there are no environment preconditions (no install check, no way to tell rg is absent or too old for -U), and edge conditions are left to the reader. That is precisely the anchor-3 shape.",
+      "evidence": []
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "The skill opens with two explicit not-this-skill tables routing to fd-file-finding and binary-analysis, and later names four conditions under which to reach for grep instead - each stating what to use instead, not merely that the skill stops. What holds it below 5 is the absence of any escape for the case where the guidance itself is wrong for the situation (e.g. what to do when a documented flag is unavailable in the installed rg, or when the search legitimately needs a different tool entirely).",
+      "evidence": [
+        {"quote": "| Use this skill when... | Use fd-file-finding instead when... |"},
+        {"quote": "**When to Use grep Instead**"},
+        {"quote": "- POSIX compatibility required"}
+      ]
+    },
+    "D5": {
+      "score": 2,
+      "rationale": "Body is 9,929 chars (~2,482 tokens), about 1.65x the ~1.5k-token ecosystem median, with zero deferral: the directory contains only SKILL.md, no REFERENCE.md, references/ or scripts/. Some of that mass is pure internal duplication - the Quick Reference 'Essential Options' table restates -t, -g, -i, -s, -l, -c, -A, -B, -C, -U, -u and --replace, all of which already appeared with the same examples earlier in the body - so a portion of every invocation's budget buys the same content twice. Extracting the flag tables and the replace/stats/performance material to a sidecar would have moved it to 4-5.",
+      "evidence": [
+        {"quote": "### Essential Options"},
+        {"quote": "| `-t TYPE` | File type filter | `rg -t py pattern` |"},
+        {"quote": "rg pattern -t py            # Python files only"}
+      ]
+    },
+    "D6": {
+      "score": 3,
+      "rationale": "The description front-loads a genuinely distinctive token ('ripgrep (rg)') so it is topically unmistakable, but the trigger clause - 'searching for text patterns, code snippets, or doing multi-file analysis' - is vocabulary any content-search sibling would also claim, and 'multi-file analysis' is generic enough to overlap a structural-search or file-finding skill. The strongest evidence that the description does not decide it: the actual disambiguation against fd-file-finding and binary-analysis lives in the body's first two tables, which is where a reader has to go to choose.",
+      "evidence": []
+    },
+    "D7": {
+      "score": 3,
+      "rationale": "One dominant procedure (search code contents with rg) with adjacent secondary material that could plausibly stand alone: a search-and-replace section that hands off to sed and an interactive vim pipeline, a stats/analysis section built on sort|uniq|awk, and a performance-tuning section on threads and mmap. Most invocations will use the search half and pay for all of it, but every section still shares the one entry condition, so this is not a bundle of unrelated procedures.",
+      "evidence": []
+    },
+    "D8": {
+      "score": 3,
+      "rationale": "The few normative statements are checkable in a transcript - whether -u was used for hidden files, whether an exclusion glob was passed, whether rg was chosen over grep - and the command examples are concrete enough that following them is observable. But most of the body imposes no constraint at all (a catalogue has nothing to violate), and the 'When to Use rg' list ('Code analysis and auditing', 'Refactoring support') has no observable correlate whatsoever. That mix is the anchor-3 shape.",
+      "evidence": []
+    }
+  },
+  "body_chars": 9929,
+  "sidecars": []
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/session-end_j1.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/session-end_j1.json
@@ -1,0 +1,72 @@
+{
+  "unit": "session-plugin/skills/session-end/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "ask-user-question",
+  "judge_id": "j1",
+  "dimensions": {
+    "D1": {
+      "score": 5,
+      "rationale": "The spine is an imperative five-step sequence (survey, qualify, confirm, sequence, report) opened by a direct execution directive, with concrete decision points at each step (qualify gates, a numbered run order, an early exit). The declarative material that is present (survey key semantics, the distill-vs-feedback seam) is consumed by a named later step rather than sitting as background; only the short auto-surfacing note is free-floating, which is not enough to pull it below the top anchor.",
+      "evidence": [
+        {"quote": "Execute this orchestration."},
+        {"quote": "### Step 2: Qualify each pass"}
+      ]
+    },
+    "D2": {
+      "score": 5,
+      "rationale": "Failure modes are attached to the steps they threaten and each names an observed symptom and its cost: omitting --with-dedup makes a guard run against nothing, a freeform y/n confirmation fires Stop hooks mid-confirmation, a low-confidence zero is an unqueried project rather than a clean queue, and a prefix-sibling slug sends follow-ups to a queue nobody reads. A reader can recognise each failure while it is happening.",
+      "evidence": [
+        {"quote": "without it the section is always empty and the guard silently runs against nothing"},
+        {"quote": "fires Stop hooks mid-confirmation (the race that motivated this orchestrator)"}
+      ]
+    },
+    "D3": {
+      "score": 5,
+      "rationale": "It gives exact invocations (full collector command with flags, a jq gate expression, the drain-wave re-derivation pipeline), names the exact output keys and their enumerated values (TASK_SCOPE, PROJECT_CONFIDENCE, GH_READY, UNDRAINED_COUNT), and states preconditions plus how to tell one is unmet, including a per-cause remediation table for an unqueried GitHub. Lifecycle gaps (plugin not installed, no transcript, no gh CLI) each get a stated fallback.",
+      "evidence": [
+        {"quote": "bash \"${CLAUDE_SKILL_DIR}/../../scripts/session-survey.sh\" --with-commits --with-blueprint --with-dedup"},
+        {"quote": "It always ships with `GH_FAIL_REASON=`, which says *why* GitHub went unqueried"}
+      ]
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "It states scope boundaries and routes each out-of-scope case to a named alternative (single pass to the individual skill, single-task close to task-done), provides a clean whole-skill exit when nothing qualifies, and degrades explicitly when a cross-plugin dependency is absent. It stops short of the top anchor because there is no provision for the case where the orchestration itself is the wrong frame; every escape routes to another prescribed skill or to silence.",
+      "evidence": [
+        {"quote": "If **nothing** qualifies, say so in one line and end"},
+        {"quote": "Cross-plugin: if `blueprint-plugin` isn't installed, note it and skip"}
+      ]
+    },
+    "D5": {
+      "score": 2,
+      "rationale": "The always-loaded body is 14,447 chars (~3.6k tokens), roughly 2.4x the ~1.5k ecosystem median, and there are no sidecars at all, so nothing is deferred. Much of the bulk is contingency detail most invocations never reach, notably a six-row remediation table for GitHub query failures and a long exposition of survey scoping keys; a references file would have carried these at zero cost to the common path.",
+      "evidence": [
+        {"quote": "| `no-remote` | The repo has no GitHub remote |"}
+      ]
+    },
+    "D6": {
+      "score": 4,
+      "rationale": "The description names the distinguishing condition directly, calling itself an orchestrator and enumerating the four passes it sequences, which separates it from its plausible siblings (session-wrap, session-distill, feedback-session) on a description read. It falls short of 5 because the trigger clause itself is generic and shared vocabulary with those siblings, so the disambiguation rests on the reader weighting the orchestrator framing over the trigger phrase.",
+      "evidence": [
+        {"quote": "End-of-session orchestrator. Previews which of wrap/distill/feedback/taskwarrior-sync qualify, single confirm, then sequence."}
+      ]
+    },
+    "D7": {
+      "score": 4,
+      "rationale": "There is one dominant procedure with one entry condition (winding down), and the multi-pass content is the point of an orchestrator rather than a bundle of unrelated topics. The adjacent material that could stand alone is the hook auto-surfacing section, which documents how the skill gets offered and how to silence it rather than any step of the procedure.",
+      "evidence": [
+        {"quote": "A Stop hook (`hooks/session-end-nudge.sh`) offers this skill at most once per session when the user's own messages carry a wind-down phrase."},
+        {"quote": "Pre-silence: `touch ~/.cache/claude-session-end-nudge/<session_id>`."}
+      ]
+    },
+    "D8": {
+      "score": 4,
+      "rationale": "Most instructions decompose into transcript-observable conditions: exactly one multiSelect question, a numbered execution order, addressing tasks by UUID, counted thresholds on named digest keys, and a one-line receipt for the auto-confirmed pass. It stops short of 5 because two qualify gates rest on unobservable judgement (a durable generalizable learning emerged, a plugin behaved notably well or badly) that only a mechanical corroborant partly grounds.",
+      "evidence": [
+        {"quote": "Then **one AskUserQuestion** (multiSelect) listing the qualifying passes"},
+        {"quote": "Never use volatile numeric IDs"}
+      ]
+    }
+  },
+  "body_chars": 14447,
+  "sidecars": []
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/session-end_j2.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/session-end_j2.json
@@ -1,0 +1,75 @@
+{
+  "unit": "session-plugin/skills/session-end/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "ask-user-question",
+  "judge_id": "j2",
+  "dimensions": {
+    "D1": {
+      "score": 5,
+      "rationale": "The spine is an ordered, imperative five-step procedure (survey, qualify, confirm, sequence, report) opened with an explicit execution directive, and Step 4 even numbers the delegated passes with ordering rationale. Declarative material (the qualify table, the GH_FAIL_REASON table, the distill/feedback seam) is consumed by a named step rather than sitting as background; only the short Auto-surfacing note is free-standing, which is not enough to pull it below exemplary.",
+      "evidence": [
+        {"quote": "Execute this orchestration. **Not fully automatic by design**"},
+        {"quote": "### Step 4: Sequence the confirmed passes"}
+      ]
+    },
+    "D2": {
+      "score": 5,
+      "rationale": "Failure modes are attached to the exact step they threaten and each names an observed symptom plus its cost: the freeform-confirmation race that motivated the orchestrator, the drown-in-signals effect of offering empty passes, and the false-clean-queue reading of a low-confidence zero. A reader can recognise each failure while it is happening rather than only after.",
+      "evidence": [
+        {"quote": "ending the turn fires Stop hooks mid-confirmation (the race that motivated this orchestrator)"},
+        {"quote": "offering an empty pass is the drown-in-signals failure mode"},
+        {"quote": "a low-confidence zero is an unqueried project, never a clean queue"}
+      ]
+    },
+    "D3": {
+      "score": 5,
+      "rationale": "It gives exact invocations with flags and path variables, names the exact digest keys to read (TASK_SCOPE, PROJECT_CONFIDENCE, GH_READY, UNDRAINED_COUNT), and supplies a literal jq one-liner for the auto-drain gate. Crucially it also says how to tell a precondition is unmet and what each unmet cause implies, via the six-row GH_FAIL_REASON remediation table. It stops just short of showing a literal sample digest, but the key-level contract is unambiguous.",
+      "evidence": [
+        {"quote": "bash \"${CLAUDE_SKILL_DIR}/../../scripts/session-survey.sh\" --with-commits --with-blueprint --with-dedup"},
+        {"quote": "| `auth` | The token is missing, expired, or lacks a scope | Tell the user to run `gh auth login`; re-running is futile."}
+      ]
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "It states three concrete out-of-scope conditions with the skill to use instead, defines a clean exit when nothing qualifies, and degrades gracefully when a collector or a cross-plugin dependency is unavailable. It falls short of 5 because there is no explicit provision for the case where the orchestration itself is the wrong shape for the moment - the only escape hatch inside the flow is the AskUserQuestion 'Other' option.",
+      "evidence": [
+        {"quote": "Only loose threads to capture → `session-plugin:session-wrap` directly"},
+        {"quote": "If **nothing** qualifies, say so in one line and end — no preview, no question."},
+        {"quote": "treat a SKIP as \"no mechanical signal, judge conceptually only\""}
+      ]
+    },
+    "D5": {
+      "score": 2,
+      "rationale": "The body is 14,448 chars (~3.6k tokens), roughly 2.4x the ~1.5k ecosystem median, and the directory contains no sidecar of any kind - deferral is zero. Much of the bulk is contingency detail most invocations never reach: a six-row GitHub-failure remediation table, prefix-sibling slug caveats, and a blueprint auto-drain gate with its own jq command. Any of these three blocks would defer cleanly to an on-demand file.",
+      "evidence": [
+        {"quote": "**Remediating `GH_READY=false`.** It always ships with `GH_FAIL_REASON=`,"},
+        {"quote": "`UNDRAINED_COUNT` ≥ 1 in the Step 1 digest's `BLUEPRINT` section"}
+      ]
+    },
+    "D6": {
+      "score": 5,
+      "rationale": "The description names its role (orchestrator), enumerates the exact sibling passes it coordinates, and states the distinguishing mechanic - preview, single confirm, then sequence - plus the trigger phrase. Choosing between this and session-wrap or session-distill is decidable from the description alone, without opening either body.",
+      "evidence": [
+        {"quote": "Previews which of wrap/distill/feedback/taskwarrior-sync qualify, single confirm, then sequence."}
+      ]
+    },
+    "D7": {
+      "score": 4,
+      "rationale": "There is one entry condition (winding down a session) and one dominant procedure, and the four delegated passes are invoked rather than restated. It is held off 5 because the taskwarrior-sync pass is spelled out inline as a complete per-task procedure of its own, which the skill itself concedes has a standalone sibling, and the blueprint auto-drain gate adds a second self-contained branch.",
+      "evidence": [
+        {"quote": "One survey, one preview, one confirmation"},
+        {"quote": "| Taskwarrior sync | (inline, no sub-skill) | Close done tasks, update statuses"}
+      ]
+    },
+    "D8": {
+      "score": 5,
+      "rationale": "Nearly every instruction decomposes into a transcript-observable condition: a specific collector invocation with specific flags, numeric qualify thresholds on named digest keys, exactly one AskUserQuestion in multiSelect form, a fixed execution order for the confirmed passes, and UUID-only task addressing. An observer could check each of these against a trajectory without interpretation.",
+      "evidence": [
+        {"quote": "Then **one AskUserQuestion** (multiSelect) listing the qualifying passes"},
+        {"quote": "`UNDRAINED_COUNT` ≥ 1 in the Step 1 digest's `BLUEPRINT` section"}
+      ]
+    }
+  },
+  "body_chars": 14448,
+  "sidecars": []
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/session-wrap_j1.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/session-wrap_j1.json
@@ -1,0 +1,70 @@
+{
+  "unit": "session-plugin/skills/session-wrap/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "ask-user-question",
+  "judge_id": "j1",
+  "dimensions": {
+    "D1": {
+      "score": 4,
+      "rationale": "The spine is a five-step imperative procedure (Survey, Categorise, Preview and confirm, Apply, Report) opened with an explicit execution directive, and worked examples are pushed to REFERENCE.md. It falls short of 5 because roughly half the body is policy prose that precedes the procedure (Configuration, Destinations, the signal filter, the tracker-dedup section); that material is consumed by Step 2/Step 4, but a reader meets it as declarative doctrine before any step exists. Interleaving the policy into the steps that use it, or deferring more of it, would move this to 5.",
+      "evidence": [
+        {"quote": "Execute this wrap workflow:"},
+        {"quote": "### Step 1: Survey"}
+      ]
+    },
+    "D2": {
+      "score": 5,
+      "rationale": "Failure modes are bound to the specific steps they threaten and carry observed symptoms and costs: Step 3 names the Stop-hook race with the consequence and the fact that it was observed in production, and Step 1 names what a missing flag silently does to the dedup check. The skill also opens by naming the failure it exists to prevent, so a reader can recognise each failure while it is happening rather than after.",
+      "evidence": [
+        {"quote": "Never end the turn on a freeform \"Apply? (y/n)\" text question: ending the turn fires Stop hooks, which can inject content and split the confirmation (this raced the old nudge hook in production)."},
+        {"quote": "without it the section is always empty and the check silently passes against nothing."}
+      ]
+    },
+    "D3": {
+      "score": 5,
+      "rationale": "Invocations are exact and copyable (the survey collector with its flags, task done/annotate/add forms, rc.confirmation:no variants), the digest's expected field names are named (PRS, GITHUB_DRIFT, PR_n_STALE_DAYS, DETECTION=ambiguous), and the environment preconditions are explicit including how to tell one is unmet and what each unmet value implies. The GH_READY/GH_FAIL_REASON passage is the strongest instance: it distinguishes 'unqueried' from 'nothing open' and routes each failure reason to a different action.",
+      "evidence": [
+        {"quote": "bash \"${CLAUDE_SKILL_DIR}/../../scripts/session-survey.sh\" --with-commits --with-dedup"},
+        {"quote": "`false` means `PRS`/`GITHUB_DRIFT` are present but **unqueried**, not \"nothing open\""}
+      ]
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "It names three conditions under which a different skill should run, states that out-of-scope sessions get only the taskwarrior pass, tells the agent to skip the journal by default when scope is unclear and to ask once when genuinely ambiguous, and supplies a fallback path when a dependency plugin is absent. It stops short of 5 because every escape is about the situation or a missing dependency; there is no exit for the case where the procedure's own guidance is wrong for the session at hand.",
+      "evidence": [
+        {"quote": "Capturing reusable *learnings* (rules/recipes)"},
+        {"quote": "**Graceful degradation**: if `workflow-orchestration-plugin` is not installed"},
+        {"quote": "Ask once if genuinely ambiguous."}
+      ]
+    },
+    "D5": {
+      "score": 3,
+      "rationale": "The body is 10,337 characters, about 2,584 estimated tokens, roughly 1.7x the ~1.5k ecosystem median, with one REFERENCE.md sidecar (~7.4KB) carrying the config schema, journal mechanics, signal-filter examples and edge cases, linked from three points in the body. That is above median but coherent to a single procedure and genuinely partially deferred, which is the anchor-3 description almost verbatim; it is not near the median, so it does not reach 5.",
+      "evidence": []
+    },
+    "D6": {
+      "score": 3,
+      "rationale": "The description front-loads concrete destinations (taskwarrior, journal, GitHub issues) and literal trigger phrases, which is topically clear. But it shares heavy vocabulary with the siblings the body itself names, session-end and session-distill, and 'done for now' would plausibly retrieve either; the distinguishing condition (this is capture only, not the full pass including distill/feedback) appears in the body's When-to-Use table rather than in the description, so choosing between them needs the body.",
+      "evidence": []
+    },
+    "D7": {
+      "score": 4,
+      "rationale": "One entry condition (the user winds down) and one procedure; the four destinations are branches of a single categorisation table rather than independent procedures, and the upstream-candidate path is delegated to other skills by name rather than inlined. It is not a 5 because a short Auto-surfacing section documents the Stop hook and its opt-out, which serves discovery and configuration rather than the wrap procedure a reader invoked the skill to run.",
+      "evidence": [
+        {"quote": "Execute this wrap workflow:"},
+        {"quote": "## Auto-surfacing"}
+      ]
+    },
+    "D8": {
+      "score": 5,
+      "rationale": "Nearly every instruction decomposes into a condition an observer could check in a transcript: ordering constraints, exclusivity constraints, a prohibition on a specific turn-ending question shape, a required pre-add lookup against named digest sections, and even a numeric shape check on the output. The one judgment-heavy part, the signal filter, is given a two-clause litmus plus that count bound rather than left dispositional.",
+      "evidence": [
+        {"quote": "Annotate **before** closing."},
+        {"quote": "New taskwarrior task **or** journal todo (not both)"},
+        {"quote": "3-6 items per wrap is the right shape; 10+ means the filter is too loose."}
+      ]
+    }
+  },
+  "body_chars": 10337,
+  "sidecars": ["REFERENCE.md"]
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/judgments/session-wrap_j2.json
+++ b/docs/benchmarks/2026-08-agent-skills-research/judgments/session-wrap_j2.json
@@ -1,0 +1,71 @@
+{
+  "unit": "session-plugin/skills/session-wrap/SKILL.md",
+  "unit_kind": "skill_body",
+  "pattern": "ask-user-question",
+  "judge_id": "j2",
+  "dimensions": {
+    "D1": {
+      "score": 4,
+      "rationale": "The spine is an explicit imperative five-step sequence (Survey, Categorise, Preview and confirm, Apply, Report) with concrete decision points, and the declarative blocks that precede it (Destinations, the signal filter, the tracker-dedup table) are each consumed by a named step. It falls short of 5 because a substantial fraction of the body is read as standing knowledge before any step begins, and the closing Auto-surfacing section describes hook behaviour that feeds no step.",
+      "evidence": [
+        {"quote": "Execute this wrap workflow:"},
+        {"quote": "### Step 1: Survey"}
+      ]
+    },
+    "D2": {
+      "score": 5,
+      "rationale": "Failure modes are attached to the steps they threaten and carry observed symptoms and consequences: the confirmation step names a real production incident and the mechanism that caused it, and Step 1 explains what silently goes wrong when a flag is omitted or a precondition is unmet. The opening paragraph also names the cost of not doing the procedure at all.",
+      "evidence": [
+        {"quote": "(this raced the old nudge hook in production). AskUserQuestion keeps the turn open — no Stop event, no race."},
+        {"quote": "without it the section is always"}
+      ]
+    },
+    "D3": {
+      "score": 5,
+      "rationale": "It gives the exact collector invocation with flags, exact taskwarrior command forms including the non-interactive variants, and names the exact digest keys and section headers it expects back (PRS, GITHUB_DRIFT, GH_READY, DETECTION=ambiguous). Crucially it tells the reader how to distinguish an unmet precondition from a clean result, enumerating each failure reason and the different response each warrants.",
+      "evidence": [
+        {"quote": "bash \"${CLAUDE_SKILL_DIR}/../../scripts/session-survey.sh\" --with-commits --with-dedup"},
+        {"quote": "| Batch close by UUID | `task rc.confirmation:no <uuid> done` |"}
+      ]
+    },
+    "D4": {
+      "score": 4,
+      "rationale": "It opens by routing three neighbouring intents elsewhere, scopes the journal destination out when the session does not match, and supplies an explicit degradation path when a depended-on plugin is absent (including refusing to proceed unverified). It stops short of 5 because it does not contemplate the case where its own signal filter is the wrong lens for the session — the escape offered is ambiguity handling and an 'Adjust first' option rather than guidance for abandoning the procedure.",
+      "evidence": [
+        {"quote": "| User says \"wrap up\", \"session wrap\", \"done for now\" | Full end-of-session pass incl. distill/feedback → `session-plugin:session-end` |"},
+        {"quote": "unclear — better than spamming it. Ask once if genuinely ambiguous."},
+        {"quote": "never file unverified"}
+      ]
+    },
+    "D5": {
+      "score": 4,
+      "rationale": "The body is ~10,335 characters (~2,580 tokens), roughly 1.7x the ~1.5k ecosystem median, but the material is coherent to one procedure and deferral is real and repeated: the config schema, the worked filter examples, and the journal append mechanics are all pushed into a single on-demand REFERENCE.md rather than carried inline. Not a 5 only because the always-loaded body still sits well above the median despite that deferral.",
+      "evidence": [
+        {"quote": "mechanics in [REFERENCE.md](REFERENCE.md). GitHub: one issue per"}
+      ]
+    },
+    "D6": {
+      "score": 3,
+      "rationale": "The description is topically clear and front-loads concrete destinations plus literal trigger phrases, but 'End-of-session capture' shares almost all of its vocabulary with the plausible sibling it explicitly defers to; choosing between a wrap and a full end-of-session pass is decided by the body's first table, not by the description.",
+      "evidence": []
+    },
+    "D7": {
+      "score": 4,
+      "rationale": "One procedure with one entry condition — everything from the destinations table through the filter to the five steps feeds the same wrap pass, and the upstream-candidate handling is a branch inside Step 4 rather than an independent procedure. It is not a 5 because the Auto-surfacing section documents a Stop hook's behaviour that no step consumes, and the upstream file-now hand-off chain is a self-contained sub-workflow most invocations will never reach.",
+      "evidence": [
+        {"quote": "| Upstream candidate (third-party repo) | Per-candidate routing in Step 4 (track for later **or** verify-then-file) |"}
+      ]
+    },
+    "D8": {
+      "score": 4,
+      "rationale": "Most instructions decompose into transcript-observable conditions: confirm via AskUserQuestion rather than ending the turn, annotate before closing, address tasks by resolved UUID, check a candidate against the digest sections before adding, one issue per follow-up. The central signal filter is irreducibly judgemental ('log only what the user would miss tomorrow'), but even that is given an observable proxy in the item-count bound, which is why this is 4 rather than 3.",
+      "evidence": [
+        {"quote": "Resolve numeric task IDs to UUIDs at read time (`task _get <id>.uuid`)"},
+        {"quote": "Then confirm with **AskUserQuestion** — options like \"Apply\", \"Apply"},
+        {"quote": "3-6 items per wrap is the right shape; 10+ means the filter is too loose."}
+      ]
+    }
+  },
+  "body_chars": 10335,
+  "sidecars": ["REFERENCE.md"]
+}

--- a/docs/benchmarks/2026-08-agent-skills-research/quote_check.py
+++ b/docs/benchmarks/2026-08-agent-skills-research/quote_check.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""quote_check.py — mechanically verify every judgment's evidence quotes.
+
+The integrity rule this enforces (rubric.md, "How to score"):
+
+    Every score of 1, 2, 4, or 5 requires a verbatim quote from the unit,
+    reproduced exactly so it can be mechanically string-matched against the
+    file. A score you cannot quote for must be a 3.
+
+A judge that fabricates or paraphrases evidence produces confident, unfalsifiable
+findings — the exact failure mode an anchored rubric is supposed to prevent. This
+script is the falsifier: it reads every judgments/*.json, resolves each quote
+against the unit file on disk, and reports any that do not match.
+
+Normalisation is deliberately minimal — whitespace runs collapse and smart
+quotes/dashes fold to ASCII, because a judge retyping a line will differ there
+and nowhere else that matters. Everything else must match exactly.
+
+Provenance: copied verbatim from
+docs/benchmarks/2026-07-context-engineering/quote_check.py. It is duplicated
+rather than shared because each benchmark's copy defaults to its own
+judgments/ directory and is frozen alongside its own rubric; if the checking
+logic changes, both copies must be updated together.
+
+Exit 1 if any quote fails to match or any extreme score lacks evidence.
+
+    python3 quote_check.py [--project-dir PATH] [--judgments DIR]
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import re
+import sys
+
+EXTREME_SCORES = {1, 2, 4, 5}
+FOLD = {
+    "‘": "'",
+    "’": "'",
+    "“": '"',
+    "”": '"',
+    "–": "-",
+    "—": "-",
+    "…": "...",
+    " ": " ",
+}
+
+
+def normalise(text: str) -> str:
+    for src, dst in FOLD.items():
+        text = text.replace(src, dst)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def main() -> int:
+    here = os.path.dirname(os.path.abspath(__file__))
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--project-dir", default=os.path.abspath(os.path.join(here, "..", "..", ".."))
+    )
+    ap.add_argument("--judgments", default=os.path.join(here, "judgments"))
+    args = ap.parse_args()
+
+    cache: dict[str, str] = {}
+    checked = failed = missing_evidence = 0
+    problems: list[str] = []
+
+    for path in sorted(glob.glob(os.path.join(args.judgments, "*.json"))):
+        name = os.path.basename(path)
+        try:
+            data = json.load(open(path, encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            problems.append(f"{name}: unreadable ({exc})")
+            failed += 1
+            continue
+
+        unit = data.get("unit", "")
+        unit_path = os.path.join(args.project_dir, unit)
+        if unit not in cache:
+            try:
+                cache[unit] = normalise(
+                    open(unit_path, encoding="utf-8", errors="replace").read()
+                )
+            except OSError:
+                cache[unit] = ""
+                problems.append(f"{name}: unit file not found: {unit}")
+        haystack = cache[unit]
+
+        for dim, body in sorted(data.get("dimensions", {}).items()):
+            score = body.get("score")
+            evidence = body.get("evidence") or []
+            if isinstance(score, int) and score in EXTREME_SCORES and not evidence:
+                missing_evidence += 1
+                problems.append(f"{name} {dim}: score {score} with no evidence quote")
+            for item in evidence:
+                quote = normalise(item.get("quote", ""))
+                checked += 1
+                if not quote:
+                    failed += 1
+                    problems.append(f"{name} {dim}: empty quote")
+                elif quote not in haystack:
+                    failed += 1
+                    problems.append(
+                        f"{name} {dim}: quote not found in {unit}: {quote[:110]!r}"
+                    )
+
+    print("=== QUOTE CHECK ===")
+    print(f"JUDGMENT_FILES={len(glob.glob(os.path.join(args.judgments, '*.json')))}")
+    print(f"QUOTES_CHECKED={checked}")
+    print(f"QUOTES_VERIFIED={checked - failed}")
+    print(f"QUOTES_FAILED={failed}")
+    print(f"EXTREME_SCORES_WITHOUT_EVIDENCE={missing_evidence}")
+    print(f"STATUS={'OK' if failed == 0 and missing_evidence == 0 else 'ERROR'}")
+    print(f"ISSUE_COUNT={len(problems)}")
+    if problems:
+        print("ISSUES:")
+        for p in problems:
+            print(f"  - {p}")
+    print("=== END QUOTE CHECK ===")
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/benchmarks/2026-08-agent-skills-research/results.md
+++ b/docs/benchmarks/2026-08-agent-skills-research/results.md
@@ -1,0 +1,198 @@
+# Results — Golden-Set Canaries Scored Against the 2026-08 Rubric
+
+**Run date:** 2026-08-21. **Units:** the 16 Tier-2 canaries in
+`evaluate-plugin/golden-set.json`. **Rubric:** [`rubric.md`](rubric.md), 8
+dimensions. **Appraisal that caps interpretation:** [`appraisal.md`](appraisal.md).
+
+**These are profiles, not grades.** No per-skill total is computed anywhere —
+`summarize.py` has no code path that sums a skill's dimensions, because the
+source studies never varied skill quality as an independent variable.
+
+---
+
+## Method
+
+| Element | Value |
+|---|---|
+| Judges | 2 independent per canary (`j1`, `j2`), 32 total |
+| Judge isolation | Cold read. Each judge was forbidden to consult `.claude/rules/`, `CLAUDE.md`, or any repo convention doc, and forbidden to compare skills to one another |
+| Anti-circularity | Anchors trace only to published findings. House conventions are the thing under test, so they could not also be the yardstick |
+| Adjudication | A third judge fired only where the pair differed by ≥2 on a dimension |
+| Evidence rule | Any score ≠ 3 required a verbatim quote, mechanically string-matched against the source |
+| Agents | 32 completed, 0 errors, 0 empty results |
+
+### Integrity check
+
+```
+QUOTES_CHECKED=398   QUOTES_VERIFIED=398   QUOTES_FAILED=0
+EXTREME_SCORES_WITHOUT_EVIDENCE=0   STATUS=OK
+```
+
+Every one of 398 evidence quotes resolves character-for-character against the
+SKILL.md it was drawn from. No fabricated or paraphrased evidence, and no
+extreme score asserted without support. `quote_check.py` is the falsifier and it
+found nothing to falsify.
+
+---
+
+## Finding 1 — the rubric is reliably applicable
+
+| Metric | Value |
+|---|---|
+| Dimension-pairs compared | 128 |
+| Exact agreement | **110 (85.9%)** |
+| Within one point | **128 (100.0%)** |
+| Disagreements ≥ 2 points | **0** |
+| Applicability (`n/a`) disagreements | 0 |
+| Adjudications triggered | **0** |
+
+Two independent cold readers, scoring 16 skills on 8 dimensions with no
+communication, never differed by more than a single point. The adjudication
+stage was built and never fired.
+
+**What this licenses:** the rubric has good *inter-rater reliability* — it means
+the same thing to different readers. That is a real and non-trivial property; a
+rubric that fails it produces noise regardless of how good its anchors are.
+
+**What this does not license:** reliability is not validity. Two readers
+agreeing precisely does not make the thing they agree on predictive of skill
+effectiveness. The rubric could be reliably measuring something that does not
+matter. Establishing validity still requires the ablation in
+[`rubric.md`](rubric.md) § Validation.
+
+---
+
+## Finding 2 — D4 has zero variance and is a weak instrument
+
+| | D4 (adaptation latitude) |
+|---|---|
+| Range across 16 canaries | **4 to 5** — no skill scored below 4 |
+| Mean inter-judge gap | **0.00** — both judges agreed exactly, on every skill |
+
+Every canary scored 4 or 5, and the two judges never disagreed by even one
+point. Two readings:
+
+1. **Genuine corpus strength.** Plausible — this repo's culture pushes hard on
+   "when to use something else", and the judges' quotes bear that out
+   (`fd-file-finding` carries two sibling-routing tables plus a "use `find`
+   instead" section).
+2. **The anchor is too easy to satisfy.** A dimension that never discriminates
+   is not measuring anything, however good the underlying finding is.
+
+**These are not separable from this run.** A dimension with no variance and no
+disagreement cannot tell you which it is. Before D4 is trusted, it needs
+anchors re-cut against skills known to be rigid — and the honest reading today
+is that **D4 currently carries no information**, despite resting on one of the
+paper's strongest measurements (grade A: skill-caused failures 10.0% vs <1%).
+
+---
+
+## Per-dimension profile
+
+| Dim | Name | Mean | Min | Max | Reading |
+|---|---|---|---|---|---|
+| D1 | procedural-anchoring | **3.28** | 1 | 5 | **Widest spread in the set.** Bimodal by archetype — see Finding 3 |
+| D2 | outcome-annotation | **3.09** | 1 | 5 | **Lowest mean.** See Finding 4, which corrects an earlier claim |
+| D3 | execution-specificity | 3.94 | 2 | 5 | Strong, consistent with the repo's exact-command discipline |
+| D4 | adaptation-latitude | 4.06 | 4 | 5 | No variance — see Finding 2 |
+| D5 | budget-discipline | 3.75 | 2 | 5 | Spread; the low end is large bodies with no sidecar |
+| D6 | retrieval-distinctness | 3.84 | 2.5 | 5 | Solid; weakest where siblings share vocabulary |
+| D7 | scope-focus | 3.69 | 2 | 5 | Low end is multi-path bundles |
+| D8 | constraint-checkability | 4.03 | 3 | 5 | Strongest floor — nothing scored below 3 |
+
+## Per-archetype profile
+
+| Pattern | D1 | D2 | D3 | D4 | D5 | D6 | D7 | D8 |
+|---|---|---|---|---|---|---|---|---|
+| weak-model-gate | 4.5 | 4.0 | 4.8 | 4.5 | **5.0** | 4.5 | 4.8 | **5.0** |
+| ask-user-question | 4.5 | **5.0** | **5.0** | 4.0 | 2.8 | 3.8 | 4.0 | 4.5 |
+| multi-step-orchestrator | 4.2 | 3.2 | 4.3 | 4.0 | 3.8 | 4.3 | 4.2 | 4.3 |
+| convention-enforcer | 3.3 | 3.7 | 3.7 | 4.0 | 4.7 | 3.2 | 4.2 | 4.3 |
+| file-generator | 3.5 | **1.5** | 2.8 | 4.0 | 4.0 | 4.0 | 3.0 | 3.2 |
+| cli-wrapper | **1.2** | 2.0 | 3.5 | 4.0 | 2.8 | 3.6 | 2.6 | 3.2 |
+
+---
+
+## Finding 3 — CLI wrappers are shaped as the mode the paper says contributes least
+
+`cli-wrapper` scores **D1 = 1.2**, against a corpus mean of 3.28. All four —
+`rg-code-search`, `jq-json-processing`, `fd-file-finding`, `git-cli-agentic` —
+are flag catalogues with no ordered procedure. Judge language, independently
+arrived at:
+
+> "A well-scoped flag catalogue with unusually strong 'use something else
+> instead' boundaries, but no procedure and no failure knowledge whatsoever."
+
+> "An exemplary set of exact, runnable commands … wrapped around zero
+> procedure: the body is a flat ten-section option catalogue."
+
+Mapped onto the paper's mechanism split, these skills are almost pure
+**knowledge injection** — the pathway credited with **4.5%** of skill
+effectiveness — and carry almost none of the **procedural anchoring** credited
+with **65.7%**.
+
+**This is a hypothesis, not a defect.** Three reasons to hold it loosely:
+
+- A CLI wrapper's job may legitimately *be* reference. The rubric cannot tell
+  "wrong shape" from "different job", and D1's anchor does not exempt reference-
+  shaped skills.
+- The mechanism split is the paper's **weakest-supported number** (evidence
+  grade C — ~3% LLM-coded sample, truncated inputs). Finding 3 inherits that.
+- These same skills score **D4 = 4.0** — they are unusually good at routing to
+  the right sibling, which is real value the D1 score does not capture.
+
+The testable version: if D1 predicts effectiveness, the four CLI wrappers should
+show smaller with-skill − baseline deltas than the orchestrators. We have the
+machinery to check that and have not run it.
+
+## Finding 4 — a correction to the D2 convergence claim
+
+[`README.md`](README.md) originally recorded D2 as **"Converged in practice"**,
+asserting our provenance discipline was *richer* than the paper's synthetic
+skills, citing `loop-integrity.md`, `agent-coworker-detection.md`, and
+`gh-json-fields.md`.
+
+**The canary data does not support that claim for skills.** D2 is the corpus's
+**lowest-scoring dimension (mean 3.09)**, with `file-generator` at **1.5** and
+`cli-wrapper` at **2.0**. `docs-generate` scored **1** — "records no failure
+mode anywhere". `configure-readme` scored **2** — "no failure mode, symptom, or
+cost is attached to any step."
+
+The error was one of artifact class: every example cited was a
+`.claude/rules/*.md` file, not a `SKILL.md`. **The failure provenance lives in
+the rules; the skills mostly do not carry it.** Since the rules are always-
+loaded-when-scoped and the skills are what fires at invocation time, guidance
+sits in the layer that is *not* present when the procedure runs.
+
+That is a more interesting finding than the original claim, and it is the one
+dimension where the corpus looks genuinely weak against a **grade-B, directly-
+ablated** result (0.7462 → 0.4000). `README.md` has been corrected.
+
+---
+
+## What this run does and does not establish
+
+| Question | Answer |
+|---|---|
+| Is the rubric reliably applicable? | **Yes** — 85.9% exact, 100% within one point, 0 adjudications |
+| Is evidence trustworthy? | **Yes** — 398/398 quotes verified mechanically |
+| Does it predict effectiveness? | **Unknown.** No study varied quality; no local ablation has been run |
+| Can it rank or gate skills? | **No.** Reliability without validity, and D4 carries no information |
+| What is the sharpest signal? | D1 on CLI wrappers (Finding 3) and D2 corpus-wide (Finding 4) |
+| Cheapest next step | Correlate these D-scores against Tier-2 with-skill − baseline deltas |
+
+**The correlation half remains blocked.** Only `git-commit` has an `evals.json`,
+and no Tier-2 matrix results are committed, so D-scores cannot yet be regressed
+against measured deltas. That gap — not more papers — is what stands between
+this rubric and being trustworthy.
+
+## Reproduce
+
+```bash
+python3 docs/benchmarks/2026-08-agent-skills-research/quote_check.py   # falsify evidence
+python3 docs/benchmarks/2026-08-agent-skills-research/summarize.py     # regenerate profiles
+```
+
+Raw judgments: [`judgments/`](judgments/) — 32 files, `<slug>_j1.json` /
+`<slug>_j2.json`, each carrying per-dimension scores, rationales, and verbatim
+evidence.

--- a/docs/benchmarks/2026-08-agent-skills-research/rubric.md
+++ b/docs/benchmarks/2026-08-agent-skills-research/rubric.md
@@ -1,0 +1,266 @@
+# Derived Rubric — Agent-Skill Quality Indicators (2026-08 research synthesis)
+
+**Status: PROVISIONAL — signal only, not a grade.**
+Derived 2026-08-21 from three papers; see [`appraisal.md`](appraisal.md) for the
+critical evaluation that caps how hard this may be leaned on.
+
+## Read this before scoring anything
+
+**No study in the source set varied skill quality as an independent variable.**
+SkillsBench used quality as a *selection filter* (top quartile, to remove
+variance); Demystifying varied representation, annotation, harness and pool
+size; Skill Coverage measured instruction adherence, not quality. So every
+dimension below is an **inference** from a mechanism or failure finding — "X
+drives the benefit, therefore skills shaped like X should be better" — and none
+is a measured quality→outcome relationship.
+
+Consequences, which are binding:
+
+1. **Do not gate, rank, or block on these scores.** Not in CI, not in review.
+2. **Do not aggregate to a single number.** A total invites exactly the
+   ranking use case that the evidence cannot support. Score per dimension,
+   report as a profile.
+3. **A low score is a hypothesis, not a defect.** It means "this skill is
+   shaped unlike what the mechanism findings predict works" — which may be
+   correct for its domain.
+
+### Anti-circularity constraint
+
+**Every anchor below traces to a published finding, never to a house rule.**
+This rubric exists partly to test whether our conventions independently
+converged with the literature. If our conventions were also the yardstick, the
+comparison would be worthless. Where a house rule happens to agree, that
+agreement is a *result*, recorded in [`README.md`](README.md) — it is not an
+input here.
+
+### Scoring mechanics (inherited from the 2026-07 frozen-rubric precedent)
+
+- Each dimension scores **1–5**; anchors defined at **1, 3, 5**; 2 and 4 interpolate.
+- **3 = consistent with the findings.** **5 = exemplary.** **1 = shaped against the findings.**
+- **Any score other than 3 requires a verbatim quote** from the skill, reproduced
+  exactly so it can be string-matched. A score you cannot quote for is a 3.
+- Score against anchors **first**, before comparing skills to each other.
+- Record `n/a` where a dimension does not apply. Do not invent a score.
+
+### Evidence grade, per dimension
+
+| Grade | Meaning |
+|---|---|
+| **A** | Direct measurement in a controlled arm; not sample-coded |
+| **B** | Measured, but with a disclosed confound, wide CI, or benchmark-specific framing |
+| **C** | Inferred from LLM-coded sample or from a structural observation, not a controlled result |
+
+---
+
+## D1 — Procedural anchoring
+
+**Does the body read as an executable procedure, or as declarative knowledge?**
+
+*Provenance:* Demystifying — procedural anchoring **65.7%** of skill
+effectiveness vs explicit knowledge injection **4.5%**; "skills work when noisy
+trajectories become procedural anchors that stabilize execution."
+**Evidence grade: C** (3% LLM-coded sample; truncated coding window plausibly
+biases toward early-visible anchoring — see appraisal §3.1).
+
+| Score | Anchor |
+|---|---|
+| 1 | Body is predominantly facts, background, or option catalogues. A reader finishes knowing *about* the topic with no committed sequence of actions. |
+| 3 | Contains an identifiable ordered procedure, though mixed with substantial declarative material that does not feed a step. |
+| 5 | The spine is an ordered sequence of imperative steps with concrete decision points. Declarative material is present only where a step consumes it, or is deferred to a sidecar. |
+
+---
+
+## D2 — Outcome-annotated guidance
+
+**Does guidance record what failed, why, and what the failure cost?**
+
+*Provenance:* Demystifying RQ2 — stripping success/failure identities while
+preserving the same trajectories degraded skill quality **0.7462 → 0.4000**
+(Gemini, 3s2f). Effect concentrates where source evidence mixes successes and
+failures.
+**Evidence grade: B** (controlled ablation, but a single reported
+model×mixture cell).
+
+| Score | Anchor |
+|---|---|
+| 1 | Instructions are unlabelled assertions. Nothing indicates which paths were tried, which failed, or what the failure looked like. |
+| 3 | Some outcome signal — a warnings or gotchas section — but disconnected from specific steps, or asserted without observed consequence. |
+| 5 | Failure modes are attached to the steps they threaten, each naming the observed symptom and its cost, so the reader can recognise the failure in progress. |
+
+> **Known tension with the positive-framing convention.** This dimension
+> rewards explicit failure content; `skill-quality.md` § Writing Style directs
+> authors toward positive guidance. These conflict less than they appear —
+> RQ2 concerns *outcome labelling of evidence*, not prose polarity, and a
+> failure can be documented in positive voice ("re-run once to confirm; a
+> second failure is real"). Flagged rather than resolved: resolving it needs
+> an ablation we have not run.
+
+---
+
+## D3 — Execution-layer specificity
+
+**Does it address environment, format, and lifecycle concretely enough to
+prevent mechanical failure?**
+
+*Provenance:* Demystifying SC2 reductions, raw → skill: environment
+infrastructure **5.3% → 0.2%**, output format/schema mismatch **7.4% → 3.2%**,
+background service lifecycle **2.7% → 0.8%**. This is where skills delivered
+their largest measured wins.
+**Evidence grade: A** (direct arm-to-arm measurement).
+
+| Score | Anchor |
+|---|---|
+| 1 | Operates at description level. Commands are paraphrased, formats implied, environment assumptions unstated. |
+| 3 | Gives concrete commands or formats for the main path; edge conditions, exact output shapes, and setup preconditions left to the reader. |
+| 5 | Exact invocations, exact expected output shape, and explicit environment/lifecycle preconditions — including how to tell the precondition is unmet. |
+
+---
+
+## D4 — Adaptation latitude
+
+**Does it say when *not* to apply, and provide an escape from itself?**
+
+*Provenance:* Demystifying SC3 — skills introduce failure modes absent from raw
+execution: `skill_guidance_misapplied_or_ignored` and `timeout_budget_exhaustion`
+at **10.0% of skill trials vs <1% raw**; skills "fail under brittle assumptions
+and incompatible contexts"; over-rigid formatting produces "mechanical
+application without contextual judgment."
+**Evidence grade: A** (direct rate comparison between arms).
+
+The counterweight to D1 and D3 — this is the dimension a rubric optimised for
+prescriptiveness would drive to zero.
+
+| Score | Anchor |
+|---|---|
+| 1 | Unconditional. Presents its procedure as always-correct, with no stated scope limit and no exit. |
+| 3 | States a scope or applicability boundary, but gives no guidance for the case that falls outside it. |
+| 5 | Names the conditions under which the procedure does not apply, and says what to do instead — including the case where the guidance itself is wrong for the situation. |
+
+---
+
+## D5 — Budget discipline
+
+**Is it small enough not to consume the budget it is meant to save?**
+
+*Provenance:* Demystifying — timeout/budget exhaustion **10.6%** under workflow
+memory vs **4.4%** under skills; distillation is part of the mechanism, not
+incidental. SkillsBench ecosystem structure — median `SKILL.md` **~1.5k tokens**,
+median total **<2.5k tokens**; "Focused Skills with at most three modules
+outperform larger or exhaustive bundles."
+**Evidence grade: B** (timeout rates measured directly; the token medians are
+descriptive ecosystem statistics, not an outcome-linked threshold).
+
+| Score | Anchor |
+|---|---|
+| 1 | Body is many multiples of ecosystem median with no deferral, so every invocation pays for material most runs never use. |
+| 3 | Body is larger than ecosystem median but material is coherent to one procedure, or partially deferred. |
+| 5 | Body is at or near ecosystem median for the always-loaded portion, with detail deferred to on-demand files. |
+
+> **Calibration note.** The ~1.5k-token median describes what the ecosystem
+> *is*, not what performs best — SkillsBench never tested size against outcome.
+> Treat "above median" as a prompt to check deferral, never as a defect.
+
+---
+
+## D6 — Retrieval distinctness
+
+**Is this skill discriminable from its siblings in a large pool?**
+
+*Provenance:* Demystifying RQ4 — pool 5→100 drops actual-use precision **29.6%
+→ 3.3%**; failure includes "semantic confusion when retrieval pools contain
+similar-sounding but distinct skills."
+**Evidence grade: B, with an important sign caveat** — in the same experiment
+**task success stayed flat (36.4% → 39.3%)** as precision collapsed, and the
+authors conclude exact matching is "neither sufficient nor strictly necessary."
+So precision loss is demonstrated; that it *costs task outcomes* is not.
+
+| Score | Anchor |
+|---|---|
+| 1 | Trigger surface is generic or overlaps a sibling's almost entirely; nothing distinguishes the two on a description read. |
+| 3 | Trigger surface is topically clear but shares substantial vocabulary with a sibling; disambiguation needs the body. |
+| 5 | Trigger surface names the distinguishing condition, so the correct choice between it and its nearest sibling is decidable without opening either body. |
+
+---
+
+## D7 — Scope focus
+
+**One coherent procedure, or an exhaustive bundle?**
+
+*Provenance:* SkillsBench — "Focused Skills with at most three modules
+outperform larger or exhaustive bundles"; **2–3 skills optimal** per task with
+diminishing returns past four.
+**Evidence grade: B** (measured in SkillsBench, but "module" is not defined in
+terms that map cleanly onto our layout).
+
+| Score | Anchor |
+|---|---|
+| 1 | Bundles several independent procedures that share only a topic; most invocations use one and pay for all. |
+| 3 | One dominant procedure with adjacent secondary material that could plausibly stand alone. |
+| 5 | One procedure with one entry condition. Everything present serves that procedure. |
+
+---
+
+## D8 — Constraint checkability
+
+**Can its instructions be extracted as discrete constraints and observed in a
+trajectory?**
+
+*Provenance:* Skill Coverage — constraint extraction + per-constraint pass/fail;
+agent trajectories covered only **38.66–45.51%** of extracted constraints;
+strengthening failed instructions recovered **16.0%** of tasks across five
+configurations.
+**Evidence grade: B** (measured on SkillsBench; the metric is newly proposed and
+not independently replicated).
+
+| Score | Anchor |
+|---|---|
+| 1 | Guidance is stated so that no observer could determine from a transcript whether it was followed. |
+| 3 | Some instructions are checkable; others are dispositional ("be careful", "consider") with no observable correlate. |
+| 5 | Instructions decompose into discrete conditions each of which would be visibly satisfied or violated in a transcript. |
+
+---
+
+## Deterministic-check convertibility
+
+The user-facing point of the exercise: which dimensions could eventually harden
+into a script. **None of these should be built until the rubric is validated
+against more studies** — this is a roadmap, not a backlog.
+
+| Dim | Convertible? | Mechanism | Cost |
+|---|---|---|---|
+| **D6** | **Best candidate** | Nearest-neighbour cosine over skill descriptions; flag pairs above a similarity threshold as confusable. `adapters/core/` **already has the embedding and BM25 machinery**, and `adapters/eval/` already reports hit@1 / hit@k / MRR over the full corpus — a sibling-confusability report is largely a new query over existing infrastructure. | Low |
+| **D5** | **Already partly built** | `check_skill_size()` gates characters. Adding an ecosystem-median comparator (~1.5k tokens) is arithmetic on data we already compute. | Very low |
+| **D2** | Partial | Presence of provenance markers — issue refs, dated observations, symptom/cost pairs — is greppable. Detects *presence*, never *quality*. | Low |
+| **D1** | Heuristic only | Imperative-verb ratio and numbered-step density are computable; both are gameable and would misfire on legitimately reference-shaped skills. | Medium |
+| **D4** | Heuristic only | Detect exemption/boundary language ("does not apply when", "instead"). Presence-only, same limitation as D2. | Low |
+| **D7** | Weak | Count top-level procedures / distinct entry conditions. Structure is too varied for a reliable parse. | Medium |
+| **D8** | Indirect | Constraint extraction needs a model, but extracted constraints could ride the existing `evals.json` typed-check schema as assertions. Closest thing to a genuinely new capability. | High |
+| **D3** | Not convertible | Semantic. Requires judging whether a command is *correct*, not whether one is present. | — |
+
+**Recommended sequencing if this is ever pursued:** D5 comparator (trivial,
+uses existing data) → D6 confusability report (high value, existing embedding
+infrastructure) → everything else waits for validation.
+
+## Validation this rubric still needs
+
+To move from *signal* to *grade*, in priority order:
+
+1. **A quality-as-variable study.** The gap all three papers share. Until
+   something manipulates skill quality and measures outcomes, every dimension
+   here is inference.
+2. **Internal ablation.** We have the machinery — `skill-evaluation.md` Tier 2
+   with-skill − baseline deltas across a golden set. Scoring canaries on this
+   rubric and correlating D-scores against measured deltas would be the first
+   *local* evidence, and would cost only a matrix run.
+3. **Replication of the retrieval result at our scale**, since the flat-success
+   finding is the one that most affects a ~400-skill catalog and it currently
+   rests on one benchmark with a substituted model.
+4. **Resolution of the D2 / positive-framing tension**, which needs its own
+   ablation.
+
+## Related
+
+- [`appraisal.md`](appraisal.md) — critical evaluation; the cap on this rubric's strength
+- [`README.md`](README.md) — where our conventions independently converged, and where they diverge
+- `.claude/rules/skill-evaluation.md` — the Tier 2 machinery item 2 above would use
+- `docs/benchmarks/2026-07-context-engineering/rubric.md` — the frozen-rubric methodology copied here

--- a/docs/benchmarks/2026-08-agent-skills-research/summarize.py
+++ b/docs/benchmarks/2026-08-agent-skills-research/summarize.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""summarize.py — roll up canary judgments into per-dimension profiles.
+
+Deliberately does NOT compute a per-skill total, average, or rank. The rubric
+(rubric.md, "Read this before scoring anything") forbids aggregation because no
+source study varied skill quality as an independent variable, so a total would
+imply a ranking the evidence cannot support. This script enforces that
+structurally: there is no code path that sums a skill's dimensions.
+
+Per-DIMENSION distributions across the corpus are computed and are legitimate —
+they describe where the corpus sits on one research-derived axis, which is the
+actual question. Per-SKILL totals are not.
+
+Emits the repo's structured-script-output contract
+(.claude/rules/structured-script-output.md).
+
+    python3 summarize.py [--judgments DIR]
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import statistics
+import sys
+from collections import defaultdict
+
+DIMS = ["D1", "D2", "D3", "D4", "D5", "D6", "D7", "D8"]
+
+DIM_NAMES = {
+    "D1": "procedural-anchoring",
+    "D2": "outcome-annotation",
+    "D3": "execution-specificity",
+    "D4": "adaptation-latitude",
+    "D5": "budget-discipline",
+    "D6": "retrieval-distinctness",
+    "D7": "scope-focus",
+    "D8": "constraint-checkability",
+}
+
+
+def load(judgments_dir):
+    """Return {slug: {judge_id: record}}."""
+    by_skill = defaultdict(dict)
+    for path in sorted(glob.glob(os.path.join(judgments_dir, "*.json"))):
+        base = os.path.basename(path)[: -len(".json")]
+        if "_" not in base:
+            continue
+        slug, judge = base.rsplit("_", 1)
+        try:
+            by_skill[slug][judge] = json.load(open(path, encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            print(f"# unreadable {base}: {exc}", file=sys.stderr)
+    return by_skill
+
+
+def score_of(record, dim):
+    if not record:
+        return None
+    body = record.get("dimensions", {}).get(dim)
+    if not isinstance(body, dict):
+        return None
+    return body.get("score")
+
+
+def numeric(v):
+    return v if isinstance(v, int) else None
+
+
+def main() -> int:
+    here = os.path.dirname(os.path.abspath(__file__))
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--judgments", default=os.path.join(here, "judgments"))
+    args = ap.parse_args()
+
+    by_skill = load(args.judgments)
+    if not by_skill:
+        print("=== CANARY RUBRIC SUMMARY ===")
+        print("SKILLS=0")
+        print("STATUS=ERROR")
+        print("=== END CANARY RUBRIC SUMMARY ===")
+        return 1
+
+    # --- Per-skill profile (no totals) -------------------------------------
+    print("=== CANARY RUBRIC SUMMARY ===")
+    print(f"SKILLS={len(by_skill)}")
+    print(f"DIMENSIONS={len(DIMS)}")
+    print("AGGREGATION=disabled-by-design (no per-skill totals; see rubric.md)")
+    print()
+
+    print("=== PER_SKILL_PROFILES ===")
+    print("# final = adjudicated score where present, else j1/j2 when they agree,")
+    print("#         else the pair shown as j1/j2 with no resolution")
+    for slug in sorted(by_skill):
+        judges = by_skill[slug]
+        pattern = ""
+        for rec in judges.values():
+            if rec.get("pattern"):
+                pattern = rec["pattern"]
+                break
+        cells = []
+        for d in DIMS:
+            j1 = score_of(judges.get("j1"), d)
+            j2 = score_of(judges.get("j2"), d)
+            adj = score_of(judges.get("adj"), d)
+            if adj is not None:
+                cells.append(f"{d}={adj}*")
+            elif j1 == j2 and j1 is not None:
+                cells.append(f"{d}={j1}")
+            else:
+                cells.append(f"{d}={j1}/{j2}")
+        print(f"SKILL={slug} PATTERN={pattern} " + " ".join(cells))
+    print()
+
+    # --- Per-dimension distribution ----------------------------------------
+    print("=== PER_DIMENSION_DISTRIBUTION ===")
+    print("# resolved score per skill per dimension; mean is across SKILLS on ONE axis")
+    dim_scores = defaultdict(list)
+    dim_na = defaultdict(int)
+    for slug, judges in by_skill.items():
+        for d in DIMS:
+            adj = numeric(score_of(judges.get("adj"), d))
+            j1 = score_of(judges.get("j1"), d)
+            j2 = score_of(judges.get("j2"), d)
+            if adj is not None:
+                dim_scores[d].append(adj)
+                continue
+            n1, n2 = numeric(j1), numeric(j2)
+            if n1 is not None and n2 is not None:
+                dim_scores[d].append((n1 + n2) / 2)
+            elif n1 is not None:
+                dim_scores[d].append(n1)
+            elif n2 is not None:
+                dim_scores[d].append(n2)
+            else:
+                dim_na[d] += 1
+
+    for d in DIMS:
+        vals = dim_scores[d]
+        if vals:
+            mean = statistics.mean(vals)
+            lo, hi = min(vals), max(vals)
+            print(
+                f"DIM={d} NAME={DIM_NAMES[d]} N={len(vals)} MEAN={mean:.2f} "
+                f"MIN={lo} MAX={hi} NA={dim_na[d]}"
+            )
+        else:
+            print(f"DIM={d} NAME={DIM_NAMES[d]} N=0 NA={dim_na[d]}")
+    print()
+
+    # --- Inter-judge reliability -------------------------------------------
+    print("=== INTER_JUDGE_RELIABILITY ===")
+    print("# does the rubric mean the same thing to two independent readers?")
+    exact = within1 = compared = applicability = 0
+    per_dim_gap = defaultdict(list)
+    for slug, judges in by_skill.items():
+        for d in DIMS:
+            j1 = score_of(judges.get("j1"), d)
+            j2 = score_of(judges.get("j2"), d)
+            if j1 is None or j2 is None:
+                continue
+            n1, n2 = numeric(j1), numeric(j2)
+            if n1 is None or n2 is None:
+                if j1 != j2:
+                    applicability += 1
+                    compared += 1
+                else:
+                    exact += 1
+                    within1 += 1
+                    compared += 1
+                continue
+            compared += 1
+            gap = abs(n1 - n2)
+            per_dim_gap[d].append(gap)
+            if gap == 0:
+                exact += 1
+            if gap <= 1:
+                within1 += 1
+
+    if compared:
+        print(f"PAIRS_COMPARED={compared}")
+        print(f"EXACT_AGREEMENT={exact} ({100.0 * exact / compared:.1f}%)")
+        print(f"WITHIN_ONE_POINT={within1} ({100.0 * within1 / compared:.1f}%)")
+        print(f"APPLICABILITY_DISAGREEMENTS={applicability}")
+        for d in DIMS:
+            gaps = per_dim_gap[d]
+            if gaps:
+                print(
+                    f"DIM={d} NAME={DIM_NAMES[d]} MEAN_GAP={statistics.mean(gaps):.2f} "
+                    f"MAX_GAP={max(gaps)} DISPUTED={sum(1 for g in gaps if g >= 2)}"
+                )
+    else:
+        print("PAIRS_COMPARED=0")
+    print()
+
+    # --- Per-pattern view ---------------------------------------------------
+    print("=== PER_PATTERN ===")
+    print("# skill archetypes from golden-set.json; per-dimension means within archetype")
+    by_pattern = defaultdict(lambda: defaultdict(list))
+    for slug, judges in by_skill.items():
+        pattern = ""
+        for rec in judges.values():
+            if rec.get("pattern"):
+                pattern = rec["pattern"]
+                break
+        if not pattern:
+            continue
+        for d in DIMS:
+            adj = numeric(score_of(judges.get("adj"), d))
+            n1 = numeric(score_of(judges.get("j1"), d))
+            n2 = numeric(score_of(judges.get("j2"), d))
+            if adj is not None:
+                by_pattern[pattern][d].append(adj)
+            elif n1 is not None and n2 is not None:
+                by_pattern[pattern][d].append((n1 + n2) / 2)
+
+    for pattern in sorted(by_pattern):
+        cells = []
+        for d in DIMS:
+            vals = by_pattern[pattern][d]
+            cells.append(f"{d}={statistics.mean(vals):.1f}" if vals else f"{d}=-")
+        print(f"PATTERN={pattern} " + " ".join(cells))
+    print()
+
+    adjudicated = sum(1 for s in by_skill.values() if "adj" in s)
+    print(f"ADJUDICATED_SKILLS={adjudicated}")
+    print("STATUS=OK")
+    print("=== END CANARY RUBRIC SUMMARY ===")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/benchmarks/2026-08-agent-skills-research/summarize.py
+++ b/docs/benchmarks/2026-08-agent-skills-research/summarize.py
@@ -197,7 +197,9 @@ def main() -> int:
 
     # --- Per-pattern view ---------------------------------------------------
     print("=== PER_PATTERN ===")
-    print("# skill archetypes from golden-set.json; per-dimension means within archetype")
+    print(
+        "# skill archetypes from golden-set.json; per-dimension means within archetype"
+    )
     by_pattern = defaultdict(lambda: defaultdict(list))
     for slug, judges in by_skill.items():
         pattern = ""


### PR DESCRIPTION
Adds `docs/benchmarks/2026-08-agent-skills-research/` — an appraisal of recent agent-skill research, a rubric derived from it, a convergence check against this marketplace's conventions, and the 16 golden-set canaries scored against that rubric.

**Nothing here is wired into a lint, gate, or CI path.** This is exploratory signal.

## Contents

| File | Purpose |
|---|---|
| `appraisal.md` | Critical evaluation of [arXiv:2608.14036](https://arxiv.org/abs/2608.14036) plus [SkillsBench](https://arxiv.org/abs/2602.12670) and [Skill Coverage](https://arxiv.org/abs/2606.20659) |
| `rubric.md` | 8 provisional dimensions, each traced to a finding, evidence-graded A/B/C |
| `results.md` | The canary scoring run — reliability, per-dimension profiles, four findings |
| `judgments/` | 32 raw judge records (2 per canary) with scores, rationales, verbatim evidence |
| `quote_check.py` | Falsifier: resolves every evidence quote against its source file |
| `summarize.py` | Rolls judgments into per-dimension profiles; computes no per-skill total |
| `README.md` | The convergence check |

## Study appraisal

Sound mechanism study — the 3-arm control (raw / workflow-memory / skill, holding source trajectories fixed) genuinely isolates representation from content, which most skill evaluations conflate. Human validation of the LLM coding (κ = 0.952) is above field norm.

Discounted on four points:

- Headline effect is **+6.06 pp, CI [+0.76, +11.36]** — weak, and the interval spans a 15× range.
- The much-quoted **65.7% / 4.5%** anchoring-vs-knowledge split is an LLM open-coding artifact over a ~3% sample with truncated inputs; the human validation measured taxonomy-mapping agreement, not attribution validity.
- RQ4 ran on substituted model substrate, so the retrieval and mechanism findings do not compose.
- Skills studied were LLM-distilled from 5 trajectories, not human-authored.

**Decisive limitation:** no study in the source set varied skill quality as an independent variable. Every rubric dimension is inference from a mechanism finding, not a measured quality→outcome relationship. The rubric states this as a binding constraint and is marked do-not-aggregate.

## Canary scoring run

Two independent cold-read judges per canary (32 agents, 0 errors), each forbidden to consult `.claude/rules/` or `CLAUDE.md` so the repo's own conventions could not serve as the yardstick for a rubric whose purpose is to test them.

**Integrity:** all 398 evidence quotes resolve character-for-character against their source `SKILL.md`. No extreme score asserted without evidence.

1. **The rubric is reliably applicable** — 85.9% exact inter-judge agreement, 100% within one point, zero disagreements of 2+. The adjudication stage never fired. This establishes reliability, not validity.
2. **D4 (adaptation latitude) has zero variance** — every canary scored 4–5, mean inter-judge gap 0.00. It currently discriminates nothing, and this run cannot distinguish "corpus strength" from "anchor too easy".
3. **CLI wrappers score D1 = 1.2** against a corpus mean of 3.28 — all four are flag catalogues with no ordered procedure, mapping onto the pathway credited with 4.5% rather than 65.7%. Held as a hypothesis: the rubric cannot distinguish "wrong shape" from "different job", and that split is the paper's weakest-supported number.
4. **A correction.** `README.md` originally recorded D2 (outcome annotation) as converged, citing `.claude/rules/` examples. Measurement puts it at the corpus's **lowest mean (3.09)** — `file-generator` 1.5, `cli-wrapper` 2.0, `docs-generate` 1. The failure provenance lives in the rules, not the skills: the layer that is absent when the procedure actually fires.

## Convergence result (revised after measurement)

**5 of 8 converged, 1 divergent-but-defensible, 2 genuine gaps.** The pre-measurement claim is left visible in the table rather than silently rewritten.

- **Converged early** — `skill-execution-structure.md` (2026-03-02) independently named procedure-over-description as "the most common skill authoring mistake" five months before the paper quantified the mechanism.
- **Ahead of the literature** — `hook-block-vs-nudge.md` found the skill-caused-failure pathology *and* built a local empirical metric for it (same-session repeat-block rate) that the literature has no equivalent of. Caveated by finding 2 above.
- **Divergent, defensibly** — our 26,000-char ceiling is ~4.3× the SkillsBench ecosystem median, but `context-engineering.md` ranks cuts by `always-loaded cost × frequency`, a cost model the papers do not consider.
- **Gaps** — D2 (above) and D8: we verify bugs stay fixed and outputs match, never that a skill's instructions were followed in a trajectory. Skill Coverage measured constraint coverage at 38.66–45.51%.

## Also worth noting

**Pool growth did not hurt task success.** Precision collapsed 29.6% → 3.3% from pool 5 → 100 while success stayed flat (36.4% → 39.3%). Reassuring for a ~400-skill catalog. It does complicate the `main_hit_at_k_min = 0.57` gate in `adapters/CUTOVER.md`, which is a retrieval-quality proxy — though the adapter's token-budget justification (~9,900 → ~600 standing tokens) is untouched.

## What remains blocked

The correlation half of the validation: only `git-commit` carries an `evals.json` and no Tier-2 matrix results are committed, so these D-scores cannot yet be regressed against measured with-skill deltas. That gap — not more papers — is what stands between this rubric and being trustworthy.

## Note on sourcing

Two of three search-summary figures checked during the appraisal were wrong (SkillsBench task/domain counts and effect size). All figures came from arXiv abstracts or HTML bodies; §5 of the appraisal records this so future extensions use primary sources only.

## Validation

`pre-commit` passes on all added files. `ruff check .` and `ruff format --check .` pass across 143 files. `quote_check.py` reports `STATUS=OK` (398/398). Docs-only change under `docs/`, so no plugin package releases.