### PR TITLE
docs(git-plugin): extend merge-hazards with the zsh refspec trap and two closing-keyword forms

### DIFF
--- a/git-plugin/skills/git-merge-hazards/SKILL.md
+++ b/git-plugin/skills/git-merge-hazards/SKILL.md
@@ -87,7 +87,7 @@ branch is gone **cannot be reopened**.
 ## 3. Stacked-chain merges: push by SHA, never `HEAD:` — and expect auto-close races
 
 Working down a stacked-PR chain (retarget child → merge base → rebase child →
-force-push → merge, per #2) has three traps of its own (observed 2026-07,
+force-push → merge, per #2) has several traps of its own (observed 2026-07,
 claude-plugins #1979→#1987):
 
 - **`HEAD:` in a push refspec is a race in a shared checkout.** HEAD is
@@ -97,6 +97,26 @@ claude-plugins #1979→#1987):
   HEAD:<child-branch>` overwrote the branch with main. Resolve the tip to an
   **explicit SHA in the same command that creates it** and push
   `git push --force-with-lease origin <sha>:<branch>`.
+- **Brace that variable — `"$sha:<branch>"` is a zsh word-modifier expansion.**
+  Stock zsh (reproduces under `zsh -f`) eats the character after the colon as a
+  history modifier whenever it happens to be one, silently rewriting the
+  refspec the bullet above just told you to use:
+
+  | Written | zsh actually sends | |
+  |---|---|---|
+  | `"$sha:refs/heads/x"` | `<sha>efs/heads/x` | `:r` |
+  | `"$sha:feat/x"` | `at/x` | `:f`+`:e` |
+  | `"$sha:chore/x"` | `<sha>hore/x` | `:c` |
+  | `"$sha:test/x"` / `release/` / `ci/` / `hotfix/` / `refactor/` | mangled | `:t :r :c :h :r` |
+  | `"$sha:style/x"` | **hard error** `bad substitution` | `:s` |
+  | `"$sha:fix/x"` / `docs/` / `perf/` / `build/` / `main` | correct | not modifiers |
+
+  Half the conventional-commit prefixes break and half don't, which is why it
+  reads as a baffling one-off instead of a rule. Always
+  `git push --force-with-lease origin "${sha}:<branch>"`. Observed 2026-08
+  pushing `feat/justfile-pr-triage`: `src refspec <sha>efs/heads/… does not
+  match any` — the error names a ref you never typed, so it looks like a stale
+  SHA rather than a quoting bug.
 - **An empty-diff force-push auto-closes the PR — and a closed PR whose *head*
   moved after closing cannot be reopened.** Sibling of #2's
   base-branch-deleted variant. GitHub saw the branch == main, closed the PR,
@@ -147,6 +167,61 @@ Does **not** close #162   →   GitHub reads `close #162`, and closes it
   close — `Related: #162`, `Unblocks #162`, or `#162 stays open — it needs …`.
 - **Recovery**: `gh issue reopen` works (nothing was deleted, unlike #2), then
   comment so the next reader doesn't re-derive it.
+
+### It is not only negation — plain past tense in a follow-ups section does it
+
+The rule above reads as "watch out for the word *not*". The trap is wider: **any**
+closing verb adjacent to a reference matches, including one merely *describing*
+what already happened, and including a reference wrapped in a **markdown link**.
+
+> Observed 2026-08-16 (comfyui-nodes fleet). A PR body's follow-ups section
+> asked for an issue to be re-opened, describing it as one this bug had
+> **closed** on a false premise. GitHub matched the closing verb against the
+> bracketed cross-repo link that followed it and closed the issue on merge — a
+> line whose entire purpose was to request a re-open. The author had cited this
+> very rule earlier in the same session.
+
+Three amplifiers:
+
+- **A bracketed cross-repo link still matches.** A closing verb followed by a
+  markdown-linked `owner/repo#N` is a match, and a naive audit regex like
+  `keyword\s+[\w./-]*#\d+` misses it on the `[` — then reports the body clean.
+- **A shared fleet body multiplies it.** The same text went into 13 sweep PRs, so
+  13 merges each targeted the same issue.
+- **The actor is *you*, not a bot** — the timeline reads `closed by <you>` seconds
+  after the merge. Don't rule out a closing keyword because no bot appears.
+
+### And not only assertion — a keyword you are *quoting* still fires
+
+The two forms above are sentences that *mean* something about an issue. The
+third means nothing about it at all: the keyword appears inside an **example, a
+fixture, or a regex you are documenting**. GitHub does not care that the line is
+inside backticks, a code fence, or a sentence whose subject is the audit itself.
+
+> Observed 2026-08-17 (FVH `infrastructure` #2213). A PR body's verification
+> section reported that a closing-keyword scan returned zero hits, and quoted
+> its two control fixtures inline as evidence. The scan it was reporting on had
+> genuinely passed — on the *ADR file*. Run against the PR body, the same regex
+> matched the body's own worked examples, which would have closed an unrelated
+> issue on merge. Caught only because the scan was re-run against the artefact
+> about to be published, rather than the one it was describing.
+
+Two things generalise:
+
+- **Scan the artefact you are about to publish, not the one you were auditing.**
+  A PR body, an issue comment, and a rules file each need their own pass; a clean
+  result on one says nothing about the others.
+- **Do not reproduce the fixture in prose that ships.** Describe it — "control-
+  tested against a bare reference and a bracketed cross-repo link, both found" —
+  and keep the literal strings in the throwaway file. Documenting the trap is
+  the one context where you are *guaranteed* to type the trap.
+
+**Audit the body before merging, with a control.** Scan every PR you are about to
+merge for a closing verb adjacent to an issue reference, allowing an optional
+`[` and an optional `owner/repo` between them, and prove the scan works by
+confirming it finds a reference you *know* is there. A negative from an
+unvalidated regex is worth nothing — the first audit run in the case above
+reported the fleet clean.
 
 The damage is a **false status report**: 2026-08-05, a PR body written to
 disclaim closure closed loractl #162 at merge, and the session reported it open


### PR DESCRIPTION
## What

Adds three findings to `git-plugin/skills/git-merge-hazards`: the zsh refspec-quoting trap in section 3, and two further closing-keyword forms in section 5.

## Why

These were written against the always-loaded `pr-merge-hazards` rule in the dotfiles repo *while* that rule's body was being promoted into this skill. The promotion took the section bodies as they stood on main, so the additions landed in a copy that no longer carries them — the skill has been missing all three since.

**Section 3 — brace the variable.** The section already says to push by explicit SHA rather than `HEAD:`. Unquoted, that advice backfires: stock zsh reads the character after the colon in `"$sha:branch"` as a history modifier. Roughly half the conventional-commit prefixes break and half don't, which is why it reads as a baffling one-off rather than a rule:

| Written | zsh actually sends | |
|---|---|---|
| `"$sha:refs/heads/x"` | `<sha>efs/heads/x` | `:r` |
| `"$sha:feat/x"` | `at/x` | `:f`+`:e` |
| `"$sha:style/x"` | **hard error** `bad substitution` | `:s` |
| `"$sha:fix/x"` / `docs/` / `main` | correct | not modifiers |

The failure names a ref that was never typed, so it looks like a stale SHA rather than a quoting bug.

**Section 5 — it is not only negation, and not only assertion.** The section currently reads as "watch out for the word *not*". Two wider forms:

- A closing verb merely *describing* what already happened still matches, including through a markdown link. A follow-ups line requesting a re-open closed the very issue it was about — and because the body was shared across a 13-PR sweep, each merge targeted it again.
- A keyword inside a quoted example, fixture, or regex fires too. A PR's verification section reporting a clean closing-keyword scan matched its own worked examples; the scan had genuinely passed, but against a different file than the one being published.

Adds the audit-with-a-control step, because in that case the first audit run reported the fleet clean on an unvalidated regex.

## How

Edits to one `SKILL.md`. No behaviour change, no other files touched.

Two deliberate choices worth flagging for review:

1. **The case studies describe their fixtures instead of reproducing them.** This file ships, and the second finding is exactly that documenting the trap is where you are guaranteed to type it. The literal fixtures stayed in a throwaway file.
2. **Section 3's "three traps of its own" is relaxed to "several"** — it lists four bullets on main today, five with this change, so the count was already wrong before this PR.

The scanner used to check this PR's own body was control-tested first against a bare reference, a bracketed cross-repo link, and a negated form, and confirmed to ignore `Related:` / `Unblocks` — per the step this PR adds.
