### PR TITLE
fix(scripts): fix misplaced heredoc terminator in plugin-compliance-check

### DIFF
--- a/scripts/plugin-compliance-check.sh
+++ b/scripts/plugin-compliance-check.sh
@@ -196,7 +196,10 @@ check_skill_frontmatter() {
     # below cannot catch it — a SafeLoader subclass that rejects duplicates is
     # required to match rulesync's (js-yaml) strictness. (just export-opencode)
     local yaml_err
-    yaml_err=$(python3 - "$skill_file" <<'PY' 2>&1 || true)
+    # The closing `)` MUST sit AFTER the `PY` terminator, not on this line:
+    # with `... <<'PY' 2>&1 || true)` bash treats the substitution as complete
+    # before the heredoc body, warning "unterminated here-document" on every run.
+    yaml_err=$(python3 - "$skill_file" 2>&1 <<'PY' || true
 import sys, yaml
 path = sys.argv[1]
 with open(path) as fh:
@@ -232,6 +235,7 @@ for field in ('args', 'argument-hint'):
     if field in fm and not isinstance(fm[field], str):
         print(f"WRONG_TYPE: {field} parses as {type(fm[field]).__name__}, not str — quote the value")
 PY
+)
     if [ -n "$yaml_err" ]; then
       while IFS= read -r line; do
         [ -z "$line" ] && continue

--- a/scripts/tests/test-plugin-compliance-frontmatter-dupkey.sh
+++ b/scripts/tests/test-plugin-compliance-frontmatter-dupkey.sh
@@ -86,6 +86,12 @@ assert_contains "duplicate modified: key is flagged as a parse error" "$out" \
   "duplicated mapping key: 'modified'"
 assert_absent "clean skill (one of each key) is not flagged" "$out" \
   "dupkey-plugin/clean: SKILL.md frontmatter PARSE_ERROR"
+# The heredoc feeding python3 above is opened inside a command substitution. If
+# the closing `)` is placed on the heredoc's OPENING line, bash parses the
+# substitution as complete before the body and warns on every single run. The
+# check still behaves correctly, so only stderr betrays it. (#2448)
+assert_absent "no unterminated here-document warning on stderr" "$out" \
+  "unterminated here-document"
 
 echo "---"
 echo "passed: $pass, failed: $fail"


### PR DESCRIPTION
## Problem

Every run of `scripts/plugin-compliance-check.sh` printed:

```
scripts/plugin-compliance-check.sh: line 199: warning: command substitution: 1 unterminated here-document
```

In `check_skill_frontmatter()` the command substitution closed its `)` on the heredoc's **opening** line:

```bash
yaml_err=$(python3 - "$skill_file" <<'PY' 2>&1 || true)
import sys, yaml
...
PY
```

bash parses the substitution as already complete at the `)`, then finds the heredoc body sitting outside it — hence the warning on every invocation.

## Fix

Move the `)` after the `PY` terminator:

```bash
yaml_err=$(python3 - "$skill_file" 2>&1 <<'PY' || true
import sys, yaml
...
PY
)
```

Three lines of comment added at the site so the next editor doesn't reintroduce it. Total diff: **11 insertions, 1 deletion**.

## Zero behaviour change

This is purely cosmetic — the check always worked, because the heredoc body did still reach python on stdin. Verified rather than assumed:

- Findings are **byte-identical** before and after (`diff` of the pre-fix script at `HEAD` vs. the fixed one) on `git-plugin` and `hooks-plugin`.
- The duplicate-frontmatter-key gate — the one thing that structurally depends on python receiving the heredoc body — still flags a duplicate `modified:` and still leaves a clean skill alone.

## Verification

| Check | Result |
|---|---|
| `bash -n scripts/plugin-compliance-check.sh` | clean (was: the warning) |
| `bash scripts/plugin-compliance-check.sh 2>&1 \| grep 'unterminated here-document'` | no output (was: exactly 1 line) |
| `test-plugin-compliance-frontmatter-dupkey.sh` | 3/3 pass (both original cases green) |
| `test-plugin-compliance-check.sh` | 21/21 pass |
| `test-plugin-compliance-skill-size.sh` | 8/8 pass |
| `shellcheck` on both touched files | clean, exit 0 |
| `scripts/lint-shell-scripts.sh` | 0 errors (9 warnings, all pre-existing in `macos-plugin`, untouched here) |

## Regression coverage

Per `.claude/rules/regression-testing.md`, no new test file — the existing `test-plugin-compliance-frontmatter-dupkey.sh` already captures the check's combined stdout+stderr, so **one** `assert_absent` on the warning string pins it, next to the gate that proves the heredoc body still reaches python.

The assertion is proven **non-vacuous**: the same fixture run emits the warning against the pre-fix script (`grep -c` → 1), so it fails without this fix rather than passing trivially.

Note: I did not add a row to the Known Regressions table in `.claude/rules/regression-testing.md` — this change was scoped to the check script and its test. Happy to add one if you'd like it recorded there.

Fixes #2448

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6fed9LbSgomLTAyzhDBbf)_