### PR TITLE
docs(github-actions-plugin): separate CODEOWNERS ownership from merge enforcement

### DIFF
--- a/.claude/rules/github-actions-security.md
+++ b/.claude/rules/github-actions-security.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-06-15
-modified: 2026-06-24
+modified: 2026-08-23
 reviewed: 2026-07-04
 paths:
   - ".github/workflows/**"
@@ -26,9 +26,35 @@ secure-use item this repo already manages via Renovate) and `workflow-naming.md`
 | 4 | **OIDC over long-lived secrets** | For cloud auth, use `id-token: write` + the provider's OIDC login action instead of storing static cloud credentials as secrets. |
 | 5 | **Guard `pull_request_target`** | It runs in the **base** repo context with secrets and a write-capable token. Never check out *and build/execute* untrusted PR head code in the same job, and never expose secrets to steps that touch PR content. |
 | 6 | **Mask & scope secrets** | `${{ secrets.* }}` only — never plaintext. `::add-mask::` any derived sensitive value. Don't wrap secrets in JSON/XML/YAML (breaks redaction). Register transformed secrets. |
-| 7 | **CODEOWNERS on workflows** | Add `/.github/workflows/` to `.github/CODEOWNERS` so workflow edits require a designated reviewer. |
+| 7 | **CODEOWNERS on workflows** | Add `/.github/workflows/` to `.github/CODEOWNERS` so those paths have a named owner and GitHub auto-requests their review. Making it a *gate* additionally needs branch protection's "Require review from Code Owners" — see the solo-maintainer caveat below before enabling it. |
 | 8 | **Constrain Actions' write power** | Prefer the repo setting that blocks Actions from creating/approving PRs unless a workflow genuinely needs it. |
 | 9 | **Avoid self-hosted runners on public repos** | GitHub-hosted (ephemeral) runners by default; if self-hosted is unavoidable, use just-in-time ephemeral runners and runner groups. |
+
+## CODEOWNERS: ownership and enforcement are two separate things
+
+Item 7 has two halves that are easy to conflate, and conflating them is how a
+security improvement becomes a merge block.
+
+| | `.github/CODEOWNERS` alone | Plus "Require review from Code Owners" |
+|---|---|---|
+| Names an owner per path | yes | yes |
+| Auto-requests their review on a PR | yes | yes |
+| **Blocks the merge until they approve** | no | yes |
+
+The file on its own is pure upside. The branch-protection setting is where the
+judgement lives, because **GitHub does not count a PR author's own approval
+toward the code-owner requirement**. On a repo where the code owner is also the
+author of nearly every PR — a solo maintainer, or a team whose CODEOWNERS names
+one person for a path only they touch — enabling it means every such PR needs
+either a second reviewer who does not exist or an admin bypass on each merge.
+
+So the setting is worth enabling when the owner list contains someone other
+than the usual author (a second maintainer, or a bot account that can approve),
+and worth leaving off when it does not. Leaving it off does not make the
+CODEOWNERS file pointless: ownership and auto-requested review still apply.
+
+This repo has it deliberately **off** for that reason; the decision and its
+revisit condition are recorded at the top of `.github/CODEOWNERS`.
 
 ## Script injection: the load-bearing pattern
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,23 @@
 # Code owners for CI-integrity surfaces.
 #
-# Required by `.claude/rules/github-actions-security.md` checklist item 7:
-# workflow edits should require review from a designated owner, because a
+# Rationale (`.claude/rules/github-actions-security.md` checklist item 7): a
 # workflow change can grant itself permissions, exfiltrate secrets, or disable
-# the very gates that would catch it.
+# the very gates that would catch it, so those paths want a named owner.
 #
-# NOTE: this file only has teeth once branch protection on `main` enables
-# "Require review from Code Owners". Adding the file alone changes nothing.
+# WHAT THIS FILE DOES HERE: it assigns ownership and makes GitHub auto-request
+# review from @laurigates on a PR touching these paths. That is the whole
+# effect, and it is the intended one.
+#
+# "Require review from Code Owners" on `main` is deliberately OFF, and should
+# stay off while this repo has a single maintainer. GitHub does not let a PR
+# author's own approval satisfy the code-owner requirement, and @laurigates is
+# both the sole owner here and the author of nearly every PR -- so enabling it
+# would mean every PR needs a second reviewer who does not exist, or an admin
+# bypass on each merge. That converts a review aid into a merge block without
+# adding a reviewer.
+#
+# Revisit when a second maintainer (or a bot account that can approve) is added
+# to the owner list: at that point the setting starts gating something real.
 
 # Everything, as the backstop.
 *                           @laurigates

--- a/github-actions-plugin/skills/github-actions-auth-security/REFERENCE.md
+++ b/github-actions-plugin/skills/github-actions-auth-security/REFERENCE.md
@@ -1,0 +1,134 @@
+# GitHub Actions Authentication and Security - Reference
+
+Commit-security verification, the full pre-deployment/monitoring/incident-response checklist, and per-provider troubleshooting for Claude Code GitHub Actions workflows.
+
+## Commit Security
+
+**Automatic Commit Signing**:
+```yaml
+# Commits are automatically signed by Claude Code
+permissions:
+  contents: write  # Enables signed commits
+
+# Verify commit signature
+- run: git verify-commit HEAD
+```
+
+**Commit Verification**:
+```bash
+# Check commit signature
+git log --show-signature
+
+# Verify specific commit
+git verify-commit <commit-sha>
+
+# Check author
+git log --format='%an <%ae>' HEAD^..HEAD
+```
+
+## Security Checklist
+
+### Pre-Deployment
+- [ ] All credentials use GitHub secrets
+- [ ] Explicit `permissions:` block, read-only default + per-job escalation
+- [ ] Repo default `GITHUB_TOKEN` permission set to read-only
+- [ ] Untrusted run-context values pass through an `env:` var (no `${{ … }}` in `run:`)
+- [ ] Third-party actions SHA-pinned (Renovate-managed — see `version-pinning.md`)
+- [ ] `/.github/workflows/` listed in `.github/CODEOWNERS` (ownership + auto-requested review; see the caveat below before making it a merge gate)
+- [ ] Actions blocked from creating/approving PRs unless a workflow needs it
+- [ ] Input validation implemented
+- [ ] Branch protection rules enabled
+- [ ] Security scanning enabled
+
+#### CODEOWNERS: ownership vs. enforcement
+
+`.github/CODEOWNERS` alone names an owner per path and makes GitHub
+auto-request their review — pure upside, enable it anywhere. Turning it into a
+merge **gate** is a separate branch-protection setting, "Require review from
+Code Owners", and that one needs a look at who the owners are first.
+
+**GitHub does not count a PR author's own approval toward the code-owner
+requirement.** So on a repo where the listed owner is also the author of nearly
+every PR touching those paths — a solo maintainer, or a path only one
+team member ever edits — enabling it means each of those PRs needs a second
+reviewer who does not exist, or an admin bypass on every merge. The setting
+stops being a review aid and becomes a merge block.
+
+Enable it when the owner list contains someone other than the usual author (a
+second maintainer, or a bot account that can approve); leave it off when it does
+not, and record that as a decision rather than an oversight. Either way the
+CODEOWNERS file keeps earning its place.
+
+### Monitoring
+- [ ] Workflow logs reviewed regularly
+- [ ] Unusual activity monitored
+- [ ] API usage tracked
+- [ ] Failed authentication attempts logged
+- [ ] Commit signatures verified
+
+### Incident Response
+- [ ] Secret rotation procedure documented
+- [ ] Access revocation process defined
+- [ ] Audit trail maintained
+- [ ] Security contact established
+- [ ] Recovery plan documented
+
+## Troubleshooting
+
+### Authentication Failures
+```bash
+# Verify secret exists
+# Settings → Secrets and variables → Actions
+
+# Check secret name matches workflow
+anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+# Validate API key format
+# Should start with: sk-ant-api03-
+
+# Test API key locally
+curl https://api.anthropic.com/v1/messages \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{"model":"claude-3-5-sonnet-20241022","max_tokens":10,"messages":[{"role":"user","content":"test"}]}'
+```
+
+### Permission Denied Errors
+```yaml
+# Ensure proper permissions
+permissions:
+  contents: write       # For code changes
+  pull-requests: write  # For PR operations
+  issues: write         # For issue operations
+  actions: read         # For CI/CD access
+
+# Check branch protection rules
+# Settings → Branches → Branch protection rules
+
+# Verify GitHub App installation
+# Settings → Installations → Claude
+```
+
+### AWS Bedrock Issues
+```bash
+# Verify IAM role
+aws sts get-caller-identity
+
+# Check Bedrock access
+aws bedrock list-foundation-models --region us-east-1
+
+# Test OIDC configuration
+# Ensure trust policy includes GitHub OIDC provider
+```
+
+### Vertex AI Issues
+```bash
+# Verify service account
+gcloud auth list
+
+# Check Vertex AI permissions
+gcloud projects get-iam-policy $GCP_PROJECT_ID
+
+# Test Vertex AI access
+gcloud ai models list --region=us-central1
+```

--- a/github-actions-plugin/skills/github-actions-auth-security/SKILL.md
+++ b/github-actions-plugin/skills/github-actions-auth-security/SKILL.md
@@ -208,30 +208,6 @@ permissions:
   pull-requests: write   # Comments only, no commits
 ```
 
-### Commit Security
-
-**Automatic Commit Signing**:
-```yaml
-# Commits are automatically signed by Claude Code
-permissions:
-  contents: write  # Enables signed commits
-
-# Verify commit signature
-- run: git verify-commit HEAD
-```
-
-**Commit Verification**:
-```bash
-# Check commit signature
-git log --show-signature
-
-# Verify specific commit
-git verify-commit <commit-sha>
-
-# Check author
-git log --format='%an <%ae>' HEAD^..HEAD
-```
-
 ### Script Injection (Untrusted Workflow Input)
 
 Distinct from *prompt* injection below. Any run-context value an external user
@@ -332,113 +308,6 @@ jobs:
 See `.claude/rules/github-actions-security.md` for the full `pull_request_target`
 guidance and the rest of the secure-use checklist.
 
-## Security Checklist
-
-### Pre-Deployment
-- [ ] All credentials use GitHub secrets
-- [ ] Explicit `permissions:` block, read-only default + per-job escalation
-- [ ] Repo default `GITHUB_TOKEN` permission set to read-only
-- [ ] Untrusted run-context values pass through an `env:` var (no `${{ … }}` in `run:`)
-- [ ] Third-party actions SHA-pinned (Renovate-managed — see `version-pinning.md`)
-- [ ] `/.github/workflows/` listed in `.github/CODEOWNERS` (ownership + auto-requested review; see the caveat below before making it a merge gate)
-- [ ] Actions blocked from creating/approving PRs unless a workflow needs it
-- [ ] Input validation implemented
-- [ ] Branch protection rules enabled
-- [ ] Security scanning enabled
-
-#### CODEOWNERS: ownership vs. enforcement
-
-`.github/CODEOWNERS` alone names an owner per path and makes GitHub
-auto-request their review — pure upside, enable it anywhere. Turning it into a
-merge **gate** is a separate branch-protection setting, "Require review from
-Code Owners", and that one needs a look at who the owners are first.
-
-**GitHub does not count a PR author's own approval toward the code-owner
-requirement.** So on a repo where the listed owner is also the author of nearly
-every PR touching those paths — a solo maintainer, or a path only one
-team member ever edits — enabling it means each of those PRs needs a second
-reviewer who does not exist, or an admin bypass on every merge. The setting
-stops being a review aid and becomes a merge block.
-
-Enable it when the owner list contains someone other than the usual author (a
-second maintainer, or a bot account that can approve); leave it off when it does
-not, and record that as a decision rather than an oversight. Either way the
-CODEOWNERS file keeps earning its place.
-
-### Monitoring
-- [ ] Workflow logs reviewed regularly
-- [ ] Unusual activity monitored
-- [ ] API usage tracked
-- [ ] Failed authentication attempts logged
-- [ ] Commit signatures verified
-
-### Incident Response
-- [ ] Secret rotation procedure documented
-- [ ] Access revocation process defined
-- [ ] Audit trail maintained
-- [ ] Security contact established
-- [ ] Recovery plan documented
-
-## Troubleshooting
-
-### Authentication Failures
-```bash
-# Verify secret exists
-# Settings → Secrets and variables → Actions
-
-# Check secret name matches workflow
-anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-
-# Validate API key format
-# Should start with: sk-ant-api03-
-
-# Test API key locally
-curl https://api.anthropic.com/v1/messages \
-  -H "x-api-key: $ANTHROPIC_API_KEY" \
-  -H "anthropic-version: 2023-06-01" \
-  -d '{"model":"claude-3-5-sonnet-20241022","max_tokens":10,"messages":[{"role":"user","content":"test"}]}'
-```
-
-### Permission Denied Errors
-```yaml
-# Ensure proper permissions
-permissions:
-  contents: write       # For code changes
-  pull-requests: write  # For PR operations
-  issues: write         # For issue operations
-  actions: read         # For CI/CD access
-
-# Check branch protection rules
-# Settings → Branches → Branch protection rules
-
-# Verify GitHub App installation
-# Settings → Installations → Claude
-```
-
-### AWS Bedrock Issues
-```bash
-# Verify IAM role
-aws sts get-caller-identity
-
-# Check Bedrock access
-aws bedrock list-foundation-models --region us-east-1
-
-# Test OIDC configuration
-# Ensure trust policy includes GitHub OIDC provider
-```
-
-### Vertex AI Issues
-```bash
-# Verify service account
-gcloud auth list
-
-# Check Vertex AI permissions
-gcloud projects get-iam-policy $GCP_PROJECT_ID
-
-# Test Vertex AI access
-gcloud ai models list --region=us-central1
-```
-
 ## Quick Reference
 
 ### Authentication Setup Commands
@@ -478,5 +347,7 @@ git verify-commit HEAD
 | Anthropic API | `ANTHROPIC_API_KEY` | - |
 | AWS Bedrock | `AWS_ROLE_ARN` | `AWS_REGION` |
 | Vertex AI | `GCP_CREDENTIALS`, `GCP_PROJECT_ID` | `VERTEX_REGION` |
+
+For commit-signature verification, the full security checklist (including CODEOWNERS guidance), and per-provider troubleshooting, see [REFERENCE.md](REFERENCE.md).
 
 For workflow design patterns, see the claude-code-github-workflows skill. For MCP server configuration, see the github-actions-mcp-config skill.

--- a/github-actions-plugin/skills/github-actions-auth-security/SKILL.md
+++ b/github-actions-plugin/skills/github-actions-auth-security/SKILL.md
@@ -340,11 +340,30 @@ guidance and the rest of the secure-use checklist.
 - [ ] Repo default `GITHUB_TOKEN` permission set to read-only
 - [ ] Untrusted run-context values pass through an `env:` var (no `${{ … }}` in `run:`)
 - [ ] Third-party actions SHA-pinned (Renovate-managed — see `version-pinning.md`)
-- [ ] `/.github/workflows/` listed in `.github/CODEOWNERS`
+- [ ] `/.github/workflows/` listed in `.github/CODEOWNERS` (ownership + auto-requested review; see the caveat below before making it a merge gate)
 - [ ] Actions blocked from creating/approving PRs unless a workflow needs it
 - [ ] Input validation implemented
 - [ ] Branch protection rules enabled
 - [ ] Security scanning enabled
+
+#### CODEOWNERS: ownership vs. enforcement
+
+`.github/CODEOWNERS` alone names an owner per path and makes GitHub
+auto-request their review — pure upside, enable it anywhere. Turning it into a
+merge **gate** is a separate branch-protection setting, "Require review from
+Code Owners", and that one needs a look at who the owners are first.
+
+**GitHub does not count a PR author's own approval toward the code-owner
+requirement.** So on a repo where the listed owner is also the author of nearly
+every PR touching those paths — a solo maintainer, or a path only one
+team member ever edits — enabling it means each of those PRs needs a second
+reviewer who does not exist, or an admin bypass on every merge. The setting
+stops being a review aid and becomes a merge block.
+
+Enable it when the owner list contains someone other than the usual author (a
+second maintainer, or a bot account that can approve); leave it off when it does
+not, and record that as a decision rather than an oversight. Either way the
+CODEOWNERS file keeps earning its place.
 
 ### Monitoring
 - [ ] Workflow logs reviewed regularly


### PR DESCRIPTION
Follow-up to #2477, which added `.github/CODEOWNERS`. The prose shipped with it
overstated what the file does on its own, and this corrects it in the three
places that carry the claim.

## The wrong claim

`.claude/rules/github-actions-security.md` checklist item 7 said adding
`/.github/workflows/` to CODEOWNERS makes those edits **"require a designated
reviewer"**. That is only true once branch protection's *"Require review from
Code Owners"* is also enabled — and that setting carries a trap the prose never
mentioned:

> **GitHub does not count a PR author's own approval toward the code-owner
> requirement.**

So on a repo where the listed owner is also the author of nearly every PR
touching those paths — a solo maintainer, or a path only one team member ever
edits — enabling it means each of those PRs needs a second reviewer who does not
exist, or an admin bypass on every merge. The review aid becomes a merge block.

## What changed

| File | Change |
|---|---|
| `.claude/rules/github-actions-security.md` | Item 7 reworded to claim only what the file alone does, plus a new section separating the three effects (names an owner / auto-requests review / blocks the merge) and stating when the branch-protection half is worth enabling |
| `github-actions-plugin/skills/github-actions-auth-security/` | The same caveat as a `#### CODEOWNERS: ownership vs. enforcement` subsection — other repos consume this skill and would otherwise inherit the misreading |
| `.github/CODEOWNERS` | Header rewritten from *"this file only has teeth once branch protection … enables 'Require review from Code Owners'"* to a record of the deliberate **off** decision and its revisit condition |

## The decision for this repo

*"Require review from Code Owners"* on `main` stays **off** while this repo has
a single maintainer, and the CODEOWNERS header now records that as a decision
rather than leaving it readable as an oversight. The revisit condition is
explicit: a second maintainer, or a bot account that can approve, joins the
owner list — at that point the setting starts gating something real.

Leaving it off does not make the file pointless. It still assigns ownership on
the CI-integrity paths (`/.github/`, `/scripts/`, the release-please config)
and makes GitHub auto-request review on a PR touching them.

## Note on the second commit

`53e3ed4` was pushed by the **`split` workflow**, not by hand: my edit took
`github-actions-auth-security/SKILL.md` to 14,437 chars, over the 10,000-char
recommendation band, and the skill-splitter extracted the reference material
into a new `REFERENCE.md`. That is why this PR shows four changed files rather
than three.

The split is clean, and both halves were checked rather than assumed:

- The whole security checklist moved to `REFERENCE.md` **together with** the
  new caveat, so the checklist item's "see the caveat below" still resolves
  within that file — no dangling pointer.
- `SKILL.md` retains a pointer that names the moved content explicitly
  (*"the full security checklist (including CODEOWNERS guidance) … see
  REFERENCE.md"*).
- Both literals `plugin-compliance-check.sh` pins for this skill
  (`Script Injection`, `PR_TITLE`) stayed in `SKILL.md`, so the #2477 guard
  still has something to assert on.
- `SKILL.md` dropped 14,437 → **10,609 chars**.

## Verification

Documentation only — no workflow, script, or skill behaviour changes.

- `plugin-compliance-check.sh` — no ❌ before or after the split. The three
  `github-actions-plugin` ⚠️ size recommendations are pre-existing; the split
  shrank the one this PR touched.
- `check-docs-index.sh --strict`, `check-workflow-labels.sh`,
  `check-workflow-model.sh`, `check-actionlint-version-sync.sh --strict`,
  `check-delegation-reachability.sh`, `check-branch-containment-guidance.sh`,
  `check-driver-freshness.sh` — all exit 0.
- `pre-commit` — all hooks pass on the authored commit.
- CI on `53e3ed4`: `compliance`, `gate`, `split`, `conventional-commits`,
  `validate`, `lint` all green; `doc-audit` skipped by its path filter, as
  expected for a docs-only diff.

`docs:` type, so release-please raises no version bump despite the diff
touching `github-actions-plugin/`.

Refs #2477