### PR TITLE
chore(configure-mcp): drop cclsp, point at the native LSP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ claude plugin install laurigates-claude-plugins/testing-plugin
 Use the included justfile for quick MCP server configuration:
 
 ```bash
-# Set up all MCP servers and cclsp
+# Set up all MCP servers
 just claude-setup
 
 # Or install individual servers

--- a/configure-plugin/skills/configure-mcp/REFERENCE.md
+++ b/configure-plugin/skills/configure-mcp/REFERENCE.md
@@ -36,13 +36,6 @@ Use these JSON configurations when adding servers to `.mcp.json`:
   "sequential-thinking": {
     "command": "npx",
     "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
-  },
-  "cclsp": {
-    "command": "npx",
-    "args": ["-y", "cclsp@latest"],
-    "env": {
-      "CCLSP_CONFIG_PATH": "./cclsp.json"
-    }
   }
 }
 ```
@@ -78,36 +71,16 @@ Use `${VAR_NAME}` references in `.mcp.json` — never hardcode tokens.
 - `argocd-mcp` - ArgoCD GitOps deployment management (requires `ARGOCD_SERVER`, `ARGOCD_AUTH_TOKEN`)
 - `sentry` - Sentry error tracking and monitoring (requires `SENTRY_AUTH_TOKEN`)
 
-**Code Intelligence (optional):**
-- `cclsp` - LSP navigation (find-references, go-to-definition, rename) for TS/Python/Rust projects
+**Code intelligence** is no longer an MCP concern. Claude Code has a native LSP
+client; language servers come from the official `*-lsp` plugins (`rust-analyzer-lsp`,
+`typescript-lsp`, `pyright-lsp`, `gopls-lsp`, `clangd-lsp`, ...), enabled per user
+rather than per project. Do not add an LSP bridge to `.mcp.json`.
 
-## cclsp Setup Details
-
-When installing `cclsp`, create `cclsp.json` in the project root with language servers based on detected project files:
-
-| Files Present | Language Server Entry |
-|---------------|----------------------|
-| `*.ts`, `*.tsx`, `*.js`, `*.jsx` | `{"extensions": ["js", "ts", "jsx", "tsx", "mjs", "cjs"], "command": ["typescript-language-server", "--stdio"], "rootDir": "."}` |
-| `*.py` | `{"extensions": ["py", "pyi"], "command": ["pylsp"], "rootDir": "."}` |
-| `*.go` | `{"extensions": ["go"], "command": ["gopls", "serve"], "rootDir": "."}` |
-| `*.rs` | `{"extensions": ["rs"], "command": ["rust-analyzer"], "rootDir": "."}` |
-
-Write `cclsp.json` with detected servers:
-```json
-{
-  "servers": [
-    // entries based on detected languages
-  ]
-}
-```
-
-Add `cclsp.json` to `.gitignore` (machine-specific language server paths).
-
-Required language server installations:
-- TypeScript: `npm i -g typescript-language-server`
-- Python: `pip install python-lsp-server`
-- Go: `go install golang.org/x/tools/gopls@latest`
-- Rust: Install via `rustup component add rust-analyzer`
+Known trap: those plugins declare `lspServers` only in the marketplace's
+`marketplace.json`, while the runtime reads it from the installed plugin's
+`.claude-plugin/plugin.json` — so they install inert, with
+`getAllLspServers returned 0 server(s)` and no warning. Upstream:
+anthropics/claude-code#15148.
 
 ## Report Templates
 

--- a/configure-plugin/skills/configure-mcp/SKILL.md
+++ b/configure-plugin/skills/configure-mcp/SKILL.md
@@ -75,7 +75,7 @@ Based on the flags:
 
 - **`--core`**: Select `context7` and `sequential-thinking`.
 - **`--server <name>`**: Select the named server(s). Validate against the available servers in [REFERENCE.md](REFERENCE.md).
-- **No flags (interactive)**: Show the user what's installed vs available. Use AskUserQuestion to ask which servers to add. Suggest servers based on project context (e.g., suggest `playwright` if `playwright.config.*` exists, suggest `cclsp` if large TS/Python/Rust codebase).
+- **No flags (interactive)**: Show the user what's installed vs available. Use AskUserQuestion to ask which servers to add. Suggest servers based on project context (e.g., suggest `playwright` if `playwright.config.*` exists).
 
 If all requested servers are already installed, report "All servers already configured" and stop.
 
@@ -87,8 +87,6 @@ For each selected server:
 2. If `.mcp.json` doesn't exist, create it with `{"mcpServers": {}}`.
 3. Merge the server config into the existing `mcpServers` object. Preserve existing servers.
 4. Write the updated `.mcp.json` with proper JSON formatting.
-
-If `cclsp` is selected, also set up `cclsp.json` (see [REFERENCE.md](REFERENCE.md) for language detection and setup details).
 
 Handle git tracking:
 - Check if `.mcp.json` is in `.gitignore`.


### PR DESCRIPTION
## What

Removes `cclsp` from the `configure-mcp` skill — the suggestion heuristic, the `.mcp.json` entry, the `cclsp.json` setup section — and replaces it with a pointer to Claude Code's native LSP client.

## Why

This is the **generator** behind the `cclsp.json` files being removed across the portfolio (laurigates/loractl#228, laurigates/comfyui-nodes#81, laurigates/foundryvtt-mcp#223, ForumViriumHelsinki/thelma#1346, laurigates/dotfiles#389). Cleaning the instances without fixing the skill means the next `/configure-mcp` run re-adds cclsp to a repo it was just removed from.

Claude Code's native LSP client covers cclsp's surface — `goToDefinition`, `findReferences`, `hover`, `documentSymbol`, `workspaceSymbol`, `goToImplementation`, call hierarchy — via the official `*-lsp` plugins, enabled per user rather than per project. `rename_symbol` is the one capability without a native equivalent.

## Also documented

REFERENCE.md now records the trap that made those plugins look unsupported: they declare `lspServers` only in the marketplace's `marketplace.json`, while the runtime reads it from the installed plugin's `.claude-plugin/plugin.json`, so they install inert with `getAllLspServers returned 0 server(s)` and no warning. Upstream: [anthropics/claude-code#15148](https://github.com/anthropics/claude-code/issues/15148).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ciyCd7QKmbxMS6WNHvUmQ