### PR TITLE
fix(hooks-plugin): match a bare cd into a scratch prefix in scratch_ctx

### DIFF
--- a/hooks-plugin/hooks/bash-antipatterns.sh
+++ b/hooks-plugin/hooks/bash-antipatterns.sh
@@ -456,8 +456,18 @@ See .claude/rules/bash-tool-replacements.md for the full table."
     # already stripped), matching the other regex detectors below: a `cd /tmp/...`
     # that appears only inside a heredoc body or an explanatory comment is data,
     # not shell state, and must not grant the exemption (#2106's class).
+    #
+    # The `cd` branch ends in a BOUNDARY CLASS, not a trailing slash (W35
+    # friction, Refs #2422). Requiring `(/private)?/tmp/` meant a bare
+    # `cd /tmp && sed -i ...` — no subdirectory — never matched, so the
+    # exemption the block message advertises was unreachable for that shape in
+    # every deployed version 2.8.5 -> 2.10.2. `(/|"|$|[[:space:]]|[;&|])` accepts
+    # the bare form while still refusing `cd /tmpfoo`, which a bare prefix match
+    # would have wrongly exempted. The variable branch keeps its trailing slash:
+    # a variable value is consumed as `"$SP/f.py"`, so the slash is part of the
+    # shape it matches.
     scratch_ctx() {
-        echo "$COMMAND_SHELL_ONLY" | grep -Eq '(^|[;&|])[[:space:]]*cd[[:space:]]+"?((/private)?/tmp/|/var/folders/)' || \
+        echo "$COMMAND_SHELL_ONLY" | grep -Eq '(^|[;&|])[[:space:]]*cd[[:space:]]+"?((/private)?/tmp|/var/folders)(/|"|$|[[:space:]]|[;&|])' || \
         echo "$COMMAND_SHELL_ONLY" | grep -Eq '(^|[[:space:];&|])[A-Za-z_][A-Za-z0-9_]*="?((/private)?/tmp/|/var/folders/)'
     }
 

--- a/hooks-plugin/hooks/test-bash-antipatterns.sh
+++ b/hooks-plugin/hooks/test-bash-antipatterns.sh
@@ -1541,6 +1541,40 @@ assert_exit \
     "E: cd into a /var/folders temp dir is allowed" 0 \
     "cd /var/folders/ab/T/gen && sed -i '' 's/a/b/' gen.conf"
 
+# B2-B5 (W35 friction): the predicate above required a trailing SLASH after the
+# scratch prefix (`(/private)?/tmp/`), so a BARE `cd /tmp` — no subdirectory —
+# still blocked, and the exemption the block message advertises was unreachable
+# for that shape. Byte-identical across every deployed version 2.8.5 -> 2.10.2.
+# Fixed by replacing the trailing slash with a boundary class
+# `(/|"|$|[[:space:]]|[;&|])`, which is also what keeps B6 (`/tmpfoo`) blocking.
+assert_exit \
+    "B2: bare 'cd /tmp' (no subdir) is allowed (W35)" 0 \
+    "cd /tmp && sed -i '' 's/a/b/' f.py"
+
+assert_exit \
+    "B3: bare 'cd /private/tmp' (no subdir) is allowed (W35)" 0 \
+    "cd /private/tmp && sed -i '' 's/a/b/' f.py"
+
+assert_exit \
+    "B4: bare 'cd /tmp' separated by ';' is allowed (W35)" 0 \
+    "cd /tmp; sed -i '' 's/a/b/' f.py"
+
+assert_exit_complex \
+    "B5: quoted bare 'cd \"/tmp\"' is allowed (W35)" 0 \
+    'cd "/tmp" && sed -i "" "s/a/b/" f.py'
+
+assert_exit \
+    "GUARD INTEGRITY (B6): 'cd /tmpfoo' is NOT a scratch prefix, still blocked (W35)" 2 \
+    "cd /tmpfoo && sed -i '' 's/a/b/' f.py"
+
+assert_exit \
+    "GUARD INTEGRITY (B7): 'cd /private/tmpfoo' still blocked (W35)" 2 \
+    "cd /private/tmpfoo && sed -i '' 's/a/b/' f.py"
+
+assert_exit \
+    "GUARD INTEGRITY (B8): 'cd /var/foldersX/y' still blocked (W35)" 2 \
+    "cd /var/foldersX/y && sed -i '' 's/a/b/' f.py"
+
 assert_exit \
     "GUARD INTEGRITY (D): cd into a repo, relative sed target, still blocked" 2 \
     "cd ~/repos/x && sed -i '' 's/a/b/' src/f.py"


### PR DESCRIPTION
## What

`scratch_ctx()` in `hooks-plugin/hooks/bash-antipatterns.sh` required a **trailing slash** after the scratch prefix:

```
cd[[:space:]]+"?((/private)?/tmp/|/var/folders/)
```

So `cd /tmp/work && sed -i '' 's/a/b/' f.py` was exempted, but a **bare** `cd /tmp && sed -i …` (and `cd /private/tmp && …`) still blocked — the scratch-path exemption the block message advertises ("In-place edits of scratch files under /tmp are allowed.") was unreachable for that shape.

## Why

The predicate is byte-identical across every deployed version 2.8.5 → 2.10.2, so this affects all of them. It is the surviving gap left by #2422 (merged), found by the 2026-W35 friction analysis.

## How

The prefix alternation now ends in a boundary class rather than a literal slash:

```diff
-cd[[:space:]]+"?((/private)?/tmp/|/var/folders/)
+cd[[:space:]]+"?((/private)?/tmp|/var/folders)(/|"|$|[[:space:]]|[;&|])
```

`(/|"|$|[[:space:]]|[;&|])` accepts the bare form while still refusing `cd /tmpfoo` — which a plain prefix match would have wrongly exempted. Constraints held:

- The predicate still scans **`COMMAND_SHELL_ONLY`** (heredoc bodies and trailing `#` comments already stripped), never raw `$COMMAND`, so a `cd /tmp/…` living only in a heredoc body or a comment does not grant the exemption (#2106's class).
- The **variable branch is untouched** — its value is consumed as `"$SP/f.py"`, so the trailing slash is part of the shape it matches.
- No widening beyond the boundary class. No surviving gap found among the shapes tested.

## Verification — 21-case matrix, 21/21

Run against the **shipped** hook (JSON on stdin, no retyped logic), post-fix and pre-fix:

| # | Case | Want | Post-fix | Pre-fix (HEAD) |
|---|------|------|----------|----------------|
| 1 | `cd /tmp && sed -i '' 's/a/b/' f.py` — **the fix** | ALLOW | PASS | **FAIL** (BLOCK) |
| 2 | `cd /private/tmp && sed -i '' 's/a/b/' f.py` — **the fix** | ALLOW | PASS | **FAIL** (BLOCK) |
| 3 | `cd /var/folders/xy/zz && sed -i '' 's/a/b/' f.py` | ALLOW | PASS | PASS |
| 4 | `cd /private/tmp/claude-502/foo && sed -i …` (regression guard) | ALLOW | PASS | PASS |
| 5 | `sed -i '' 's/a/b/' /private/tmp/foo.py` (regression guard) | ALLOW | PASS | PASS |
| 6 | `cd "/tmp" && sed -i …` (boundary: closing quote) | ALLOW | PASS | **FAIL** (BLOCK) |
| 7 | `cd /tmp; sed -i …` (boundary: semicolon) | ALLOW | PASS | **FAIL** (BLOCK) |
| 8 | `cd /var/folders/ab/T/gen && sed -i '' 's/a/b/' gen.conf` | ALLOW | PASS | PASS |
| 9 | `SP=/private/tmp/…/scratchpad; sed -i "" … "$SP/f.py"` (variable branch untouched) | ALLOW | PASS | PASS |
| 10 | `sed -i.bak 's/old/new/' /tmp/scratch/wg-config.txt` (literal arg) | ALLOW | PASS | PASS |
| 11 | **CONTROL PAIR** `git add f && git status --short` | ALLOW | PASS | PASS |
| 12 | **CONTROL** `cd /tmpfoo && sed -i …` | BLOCK | PASS | PASS |
| 13 | **CONTROL** `cd /private/tmpfoo && sed -i …` | BLOCK | PASS | PASS |
| 14 | **CONTROL** `cd /var/foldersX/y && sed -i …` | BLOCK | PASS | PASS |
| 15 | **CONTROL** `cd ~/repos/x && sed -i '' 's/a/b/' src/f.py` | BLOCK | PASS | PASS |
| 16 | **CONTROL** `cd /tmp/x` only in a **heredoc body**, real repo `sed -i` outside | BLOCK | PASS | PASS |
| 17 | **CONTROL** `cd /tmp/x` only in a trailing **`#` comment**, real repo `sed -i` | BLOCK | PASS | PASS |
| 18 | **CONTROL** `cd ~/repos/x && sed -i … f.py 2>/tmp/log` (only /tmp is a redirect) | BLOCK | PASS | PASS |
| 19 | **CONTROL PAIR** `git add f && git commit -m x` | BLOCK | PASS | PASS |
| 20 | **CONTROL** `git add -A` | BLOCK | PASS | PASS |
| 21 | **CONTROL** `cat file.txt` (whole-command read) | BLOCK | PASS | PASS |

**Post-fix: 21/21. Pre-fix: 17/21**, failing exactly the four bare-`cd` shapes. Every must-still-BLOCK control holds in both directions, so the patch is not permissive — in particular #12–#14 are what the boundary class buys over a plain prefix match.

## Regression test

Extended the existing harness `hooks-plugin/hooks/test-bash-antipatterns.sh` (no new framework), adding rows **B2–B8** alongside the existing A–F scratch-exemption matrix:

- B2 bare `cd /tmp`, B3 bare `cd /private/tmp`, B4 `cd /tmp;`, B5 quoted `cd "/tmp"` — must ALLOW
- B6 `cd /tmpfoo`, B7 `cd /private/tmpfoo`, B8 `cd /var/foldersX/y` — GUARD INTEGRITY, must BLOCK

Suite results: **238 passed, 0 failed** with the fix. Against the pre-fix hook the suite scores **234/238**, failing exactly B2–B5 while B6–B8 pass — so the new rows pin the bug, not the fix. `shellcheck -S warning` clean on both files.

Refs #2422
