### PR TITLE
docs(repo): record the Layer-2 documentation audit cadence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,8 @@ Claude Code plugin collection providing skills and agents for development workfl
 | `.claude/rules/generated-fleet-drift.md` | Auditing a generated fleet — divergence is not automatically drift: it is bidirectional (never auto-apply template → instance), an identically-diverging cohort signals intent, and undeclared intent is unauditable |
 | `.claude/rules/plugin-usage-telemetry.md` | `~/.claude.json`'s `pluginUsage.usageCount` counts **hook fires**, so it ranks trigger cadence rather than plugin value — nothing in this repo reads it (incl. `health-check --scope=usage`, which mines transcripts); the delivery signal is the **lowercase-first** `attributionPlugin`/`attributionSkill`/`attributionAgent` |
 
+**Auditing these docs:** [`docs/audits/README.md`](docs/audits/README.md) records the Layer 1 (automated, monthly) / Layer 2 (quarterly + milestone-triggered) cadence and holds past findings artifacts.
+
 ## Authoring Skills and Plugins
 
 Invoke `/plugin-authoring` — it carries the create-a-skill and create-a-user-invocable-skill frontmatter shapes, the seven metadata files a plugin add/delete must touch, and the development workflow. All four are procedures with a clear trigger, so they live in a skill rather than here (#2140).

--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -1,0 +1,68 @@
+# Documentation audits
+
+This directory holds dated, read-only audit artifacts — findings documents, not
+fixes. An audit records what was wrong at a point in time and links the issues
+that track remediation; the edits themselves land in separate PRs.
+
+Naming follows the one artifact already here,
+`project-plugin-phase1-audit-2026-06-04.md`: `<scope>-<what>-YYYY-MM-DD.md`.
+
+## Two layers
+
+The top-level documentation audit (issue #1460) splits into a mechanical half
+and a judgment half. Both matter: a complete index pointing at stale prose is
+still broken.
+
+| | Layer 1 — mechanical drift | Layer 2 — content health |
+|---|---|---|
+| Question | Do the maps agree with the territory? | Is the prose accurate, current, and coherent? |
+| Mechanism | `scripts/check-docs-index.sh` | Human/agent read-through over four doc clusters |
+| Output | Structured `STATUS=`/`ISSUE_COUNT=` findings | Per-cluster follow-up issues, plus a dated artifact here |
+| Fixer | The `/docs-refresh` project skill | Whoever picks up the filed issues |
+
+### Layer 1 — automated, no cadence decision needed
+
+`scripts/check-docs-index.sh` runs seven zero-false-positive checks (rules index,
+plugin-map agreement, per-plugin counts, d2 diagram nodes, `reviewed:`
+frontmatter, rendered diagram SVG, README skill rows). It is wired in twice:
+
+- **`docs-index` job in `.github/workflows/scheduled-audits.yml`** — scheduled
+  monthly (`cron: '19 9 1 * *'`), auto-opening a `docs-index`-labelled issue when
+  drift is found and filing nothing when clean.
+- **`.github/workflows/plugin-pr-checks.yml`** — `--strict`, ungated, on every
+  PR, so drift cannot merge.
+
+Nothing here needs scheduling by hand. (The 2026-06-28 cadence decision described
+this job as weekly; the workflow's schedule has since been consolidated to
+monthly.)
+
+### Layer 2 — quarterly, plus milestone-triggered
+
+Layer 2 cannot be scripted, so it needs a recorded cadence. Run it:
+
+- **Quarterly**, and additionally
+- **On a milestone**, whichever comes first:
+  - a Claude Code **major version**, or
+  - crossing a **plugin-count threshold** — each +10 plugins.
+
+A pass is a fan-out with one reviewer per cluster, read-only, each returning
+contradictions / stale sections / coverage gaps / redundancy with `file:line`
+evidence:
+
+| Cluster | Scope |
+|---|---|
+| A — front door & maps | `README.md`, `CLAUDE.md`, `docs/PLUGIN-MAP.md`, `docs/PRINCIPLES.md` |
+| B — rules coherence | `.claude/rules/*.md` |
+| C — legacy docs | the non-blueprint `docs/*.md` |
+| D — blueprint & decisions | `docs/blueprint/` — ADRs, PRDs, PRPs |
+
+The deliverable is **follow-up issues, one per cluster** — not a fix-everything
+PR — reconciled into a dated findings document in this directory. Mechanical
+drift stays with Layer 1 so reviewers spend judgment only
+(`.claude/rules/offload-to-deterministic-substrate.md`).
+
+## Related
+
+- Issue [#1460](https://github.com/laurigates/claude-plugins/issues/1460) — where both layers and this cadence were decided
+- `.claude/skills/docs-refresh/SKILL.md` — the fixer that consumes Layer 1 findings
+- `.claude/rules/docs-currency.md` — code and its docs land in the same commit


### PR DESCRIPTION
## What

Adds `docs/audits/README.md` recording the documentation-audit cadence, plus a one-line pointer from `CLAUDE.md`. This is **Step 6 of #1460 only**.

## Why now

You were asked on #1460 which of the two remaining steps to take, and answered on 2026-08-24:

> 1. A. Yes, now, as a small independent docs PR.
> 2. I'll trigger it manually at some point

So Step 6 ships here and **Step 5 (the four-cluster read-through) is untouched** — hence `Refs`, not `Closes`. The cadence recorded is your own wording from the 2026-06-28 comment: Layer 2 runs **quarterly, plus milestone-triggered** (a Claude Code major version, or each +10 plugins).

## One correction to the decision text

The 2026-06-28 comment describes Layer 1 as running **weekly**. It doesn't — `.github/workflows/scheduled-audits.yml` is `cron: '19 9 1 * *'`, **monthly on the 1st**, and `git log -L` on that line shows monthly across at least its last two touches. The README states monthly and carries a one-line parenthetical noting the earlier description, so the discrepancy is recorded rather than silently corrected. Flag if you'd rather the schedule move to match the decision instead of the other way round.

Everything else in the decision text checked out: the `docs-index` job name, the labelled auto-open on drift, the ungated `--strict` step in `plugin-pr-checks.yml`, the seven checks, the single existing artifact and the naming convention it implies, and clusters A–D.

## The `CLAUDE.md` line

Placed directly after the Rules table, in the docs-index part of the file:

```markdown
**Auditing these docs:** [`docs/audits/README.md`](docs/audits/README.md) records the Layer 1 (automated, monthly) / Layer 2 (quarterly + milestone-triggered) cadence and holds past findings artifacts.
```

It deliberately contains no `.claude/rules/*.md` string, so `check-docs-index.sh` Check 1 — which greps all of `CLAUDE.md` for that pattern bidirectionally against disk — is unaffected.

`CLAUDE.md` is on the always-loaded context surface, so the addition is held to one line and the ratchet was verified:

| Check | Result |
|---|---|
| `check-context-engineering.py --strict` | **exit 0** — `C5_ALWAYS_LOADED_CHARS=91449` / budget `100000`, `C5_CLAUDE_MD_CHARS=14697` |
| `scripts/check-docs-index.sh --strict` | exit 0, `STATUS=OK ISSUE_COUNT=0`, `RULES_ON_DISK=46 RULES_IN_TABLE=46` |
| `scripts/check-prose-house-style.sh --strict` | exit 0, `STATUS=OK` |
| `run-skill-script-tests.sh --only 'scripts/tests/test-check-docs-index.sh'` | exit 0, `PASSED=1 FAILED=0` |
| `pre-commit run --files CLAUDE.md docs/audits/README.md` | exit 0 |

(The overall `STATUS=WARN` from the context-engineering run is pre-existing and corpus-wide — 193 C1/C2/C3/C6 findings; `--strict` errors only on the C5 ratchet, which passes.)

## Deliberately out of scope

- The `README.md` plugin/skill count drift you measured on 2026-08-24 ("400+" vs 419) — Layer-1 drift owned by `/docs-refresh`, and folding a mechanical refresh into a decision record would muddy both.
- The generated-counts proposal from that same comment — a new design question, not part of the answered Step 6.
- Two malformed orphan table rows at the end of `CLAUDE.md` — pre-existing; the pointer was placed well clear of them rather than appended into them.
- Step 5 itself.

Refs #1460

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSPUbAp8KVZVE4VmNdCVnq)_