### PR TITLE
fix(health-plugin): parse block scalars, widened keys and the closing fence in frontmatter()

### DIFF
--- a/health-plugin/scripts/config-drift.py
+++ b/health-plugin/scripts/config-drift.py
@@ -84,16 +84,128 @@ def jaccard(a: set, b: set) -> float:
     return len(a & b) / len(a | b) if a and b else 0.0
 
 
+FM_KEY = re.compile(r"^([A-Za-z_][A-Za-z0-9_-]*):[ \t]*(.*)$")
+# A block-scalar indicator is `|` or `>` optionally carrying a chomping sign
+# and/or an explicit indentation digit, optionally followed by a comment:
+# `|`, `|-`, `>+`, `|2`, `|2-`, `| # notes`. Exact-set membership captured
+# every suffixed form as a VALUE -- `description: |2` yielded the string `|2`,
+# truthy junk with the same shape as the original empty-block bug.
+FM_BLOCK = re.compile(r"^[|>][-+]?\d?[-+]?[ \t]*(#.*)?$")
+FM_FENCE = re.compile(r"^---[ \t]*$")
+
+
+def _unquote(raw: str) -> str:
+    """Remove ONE matched surrounding quote pair, and only a matched pair.
+
+    `raw.strip("\"'")` strips a character CLASS from both ends independently, so
+    a value that merely ends in a quote character loses it:
+    `path|PR|file|plan description; optional 'focus on X'` -> the trailing `'`,
+    and `'<files...> --title "type(scope): description"'` -> both the outer `'`
+    and the `"` newly exposed beneath it.
+    """
+    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in "\"'":
+        return raw[1:-1]
+    return raw
+
+
 def frontmatter(body: str) -> dict[str, str]:
+    """Read the top-level scalar keys out of a document's YAML frontmatter.
+
+    Deliberately a line scanner rather than a YAML parser -- consumers need
+    top-level keys and nothing else, and four properties are load-bearing:
+
+    * The frontmatter ends at the first closing fence LINE, never at the first
+      `---` SUBSTRING. A `---` thematic break inside a description (118 files
+      here have one) or an inline `--- separator` truncated the block and
+      dropped every key after it, including `paths:` -- which silently billed a
+      path-scoped rule to the always-loaded budget.
+    * A key is only recognised at column 0. That is what stops a list item, or
+      a `key: value` line inside a block-scalar body, from shadowing a real
+      key.
+    * A bare-empty value stays the empty string. `paths:` carries its globs on
+      the following lines, and consumers test it for KEY PRESENCE, never
+      truthiness -- so a path-scoped rule must add nothing to the always-loaded
+      budget. Only an explicit block-scalar indicator slurps what follows;
+      indented list items are never absorbed as a continuation.
+    * A block scalar's body, and a plain scalar's indented continuation lines,
+      are joined with single spaces. The value feeds an embedding text and a
+      description field, not a YAML round-trip.
+    * The block must OPEN like frontmatter, not merely be delimited like it.
+      The closing-fence scan runs to the end of the document, so a file with no
+      frontmatter that opens with a `---` thematic break and carries another one
+      later had its prose read as the block -- and prose says `Note:` and
+      `Rationale:` at column 0. Requiring the FIRST non-blank line to be a key
+      confines the scan to real frontmatter. It has to be the first line rather
+      than the first non-comment one, because a markdown `# Heading` and a YAML
+      `# comment` are the same string: skipping comments walks straight past the
+      heading and back into the prose. The cost is that frontmatter opening with
+      a YAML comment parses to {}; 0 of the 757 fenced documents in this corpus
+      do that, and the failure it buys off is silent (prose supplying a `paths:`
+      drops a rule out of the always-loaded budget).
+    """
     if not body.startswith("---"):
         return {}
-    parts = body.split("---", 2)
-    if len(parts) < 3:
+    all_lines = body.splitlines()
+    close = next(
+        (i for i in range(1, len(all_lines)) if FM_FENCE.match(all_lines[i])), None
+    )
+    if close is None:
         return {}
-    return {
-        k: v.strip().strip("\"'")
-        for k, v in re.findall(r"^([a-z_]+):[ \t]*(.*)$", parts[1], re.M)
-    }
+
+    fm: dict[str, str] = {}
+    lines = all_lines[1:close]
+    opener = next((x for x in lines if x.strip()), None)
+    if opener is None or not FM_KEY.match(opener):
+        return {}
+    i = 0
+    while i < len(lines):
+        m = FM_KEY.match(lines[i])
+        i += 1
+        if not m:
+            continue
+        key, raw = m.group(1), m.group(2).strip()
+        if not FM_BLOCK.match(raw):
+            # Plain scalar: absorb indented continuation lines, which YAML folds
+            # into the same value. Without this a value wrapped over two lines
+            # was captured truncated -- worse than being missed, because the
+            # fragment looks like a complete value.
+            cont: list[str] = []
+            while i < len(lines):
+                nxt = lines[i]
+                if not nxt.strip() or not nxt[:1].isspace():
+                    break
+                stripped = nxt.strip()
+                # A comment line is never scalar content -- not in YAML and not
+                # here. Skip it without ending the value: absorbing it appended
+                # the comment to `reviewed:`, which then failed its
+                # \d{4}-\d{2}-\d{2} gate and dropped the file out of the
+                # staleness check while still counting as reviewed.
+                if stripped.startswith("#"):
+                    i += 1
+                    continue
+                # A `- ` item belongs to a list (`paths:`) and an indented
+                # `key:` opens a nested mapping -- but both are only possible
+                # under a key whose INLINE value is empty. Once a value sits on
+                # the key's own line YAML permits neither, so every indented
+                # line there is continuation, and breaking on one truncated the
+                # value (a wrapped URL, a dash-led clause) exactly as the
+                # missing-continuation bug did.
+                if not raw and (stripped.startswith("- ") or FM_KEY.match(stripped)):
+                    break
+                cont.append(stripped)
+                i += 1
+            joined = " ".join([raw, *cont]).strip() if cont else raw
+            fm[key] = _unquote(joined)
+            continue
+        block: list[str] = []
+        while i < len(lines):
+            nxt = lines[i]
+            if nxt.strip() and not nxt[:1].isspace():
+                break
+            block.append(nxt.strip())
+            i += 1
+        fm[key] = " ".join(w for w in block if w).strip()
+    return fm
 
 
 def git_last_change(path: Path) -> str | None:
@@ -470,15 +582,37 @@ def check_semantic_dupes(items, waivers, cache_path: Path) -> list[dict]:
         except (OSError, json.JSONDecodeError):
             cache = {}
 
-    need = [it for it in items if it["hash"] not in cache]
+    # The cache is keyed on a hash of the EMBED TEXT, not on it["hash"] (the raw
+    # file bytes). A change to title/desc/body must self-invalidate: parsing a
+    # `description:` that the bytes already contained changes the embedded text
+    # without changing the file, so a bytes-keyed cache serves a vector computed
+    # from the old text and the findings become cache-state dependent -- a cold
+    # cache and a warm cache disagree on the same commit.
+    #
+    # it["hash"] is deliberately left alone: it keys the gitdates cache
+    # (f"{path}:{hash}") and expires waivers (a_hash/b_hash), both of which mean
+    # "the file's bytes", so folding desc into it would spuriously expire every
+    # waiver and every cached git date.
+    #
+    # Entries keyed on a superseded embed text are never read again and become
+    # dead weight in the cache file; the file is a cache, so pruning it is
+    # deleting it.
+    #
+    # EMBED_MODEL is part of the key for the same reason the text is: it is an
+    # input to the vector. Keyed on text alone, swapping the model served the
+    # previous model's vectors and every cosine was then computed across two
+    # embedding spaces -- the same defect one level up, and silent.
+    embed_texts = [
+        f"{it['title']}\n{it.get('desc', '')}\n{it['body'][:EMBED_CHARS]}"
+        for it in items
+    ]
+    keys = [sha(f"{EMBED_MODEL}\n{t}") for t in embed_texts]
+    need: dict[str, str] = {k: t for k, t in zip(keys, embed_texts) if k not in cache}
     if need:
         model = TextEmbedding(model_name=EMBED_MODEL)
-        texts = [
-            f"{it['title']}\n{it.get('desc', '')}\n{it['body'][:EMBED_CHARS]}"
-            for it in need
-        ]
-        for it, vec in zip(need, model.embed(texts)):
-            cache[it["hash"]] = [round(float(x), 6) for x in vec]
+        need_keys = list(need)
+        for k, vec in zip(need_keys, model.embed([need[k] for k in need_keys])):
+            cache[k] = [round(float(x), 6) for x in vec]
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         cache_path.write_text(json.dumps(cache))
 
@@ -500,7 +634,7 @@ def check_semantic_dupes(items, waivers, cache_path: Path) -> list[dict]:
                 return True
         return False
 
-    vecs = np.array([cache[it["hash"]] for it in items], dtype="float32")
+    vecs = np.array([cache[k] for k in keys], dtype="float32")
     vecs /= np.linalg.norm(vecs, axis=1, keepdims=True) + 1e-9
     sim = vecs @ vecs.T
     out = []

--- a/health-plugin/scripts/tests/test-config-drift.sh
+++ b/health-plugin/scripts/tests/test-config-drift.sh
@@ -229,6 +229,572 @@ else
     ok "unknown flag exits non-zero"
 fi
 
+echo "TEST 9: guard integrity -- nothing indented or list-shaped is a top-level key"
+# What this case pins is the GUARD, not either named bug. Both decoys below are
+# indented, and the original `^([a-z_]+):` anchor already rejected indented
+# lines, so this case contributes zero regression protection for the
+# block-scalar or `paths:` defects: run the whole suite against the pre-fix
+# parser and it reports PASSED=26 FAILED=4, with all four failures in TEST 10.
+# What it does kill, measured by mutating the shipped parser: 9b fails (2
+# assertions) against a parser that strips a leading `- ` before matching. 9a is
+# shielded twice -- by the column-0 anchor AND by the block-slurp loop that
+# consumes those lines before the key matcher ever sees them -- so a bare
+# lstrip() mutant passes the whole suite 51/51, and 9a only fires once the block
+# indicator ALSO stops matching (lstrip + a dead FM_BLOCK fails 9a, 9b, and four
+# of TEST 10).
+#
+# Two frontmatter keys have a consequence in --format=json that a parser change
+# can actually move: `paths` (key presence -> always_loaded_rules /
+# always_loaded_tokens) and `reviewed` (value truthiness -> the
+# frontmatter_coverage numerator). Every case below is expressed through one of
+# those two.
+missing_reviewed() { printf '%s' "$1" | python3 -c 'import json,sys; d=json.load(sys.stdin); s=next((f["summary"] for f in d["findings"] if f["kind"]=="frontmatter_coverage"), "0/0"); print(s.split("/")[0])' 2>/dev/null || echo ERR; }
+
+out=$(run)
+base_rules=$(count_key "$out" always_loaded_rules)
+base_missing=$(missing_reviewed "$out")
+
+# 9a. GUARD INTEGRITY: nothing inside a block-scalar body is a top-level key.
+# The body carries a `paths:` line and a `reviewed:` line at block indentation
+# plus a list item. A parser that read either would (a) drop this rule from the
+# always-loaded set and (b) stop counting it as missing a reviewed: date.
+cat > "$FIXROOT/home/.claude/rules/blockscalar.md" <<'RULE'
+---
+created: 2026-01-01
+description: |
+  Calibrate widget torque against the fleet inventory manifest. Use when a
+  widget reports a torque fault on the assembly line.
+  paths: "**/*.tf"
+  reviewed: 2026-01-01
+  - "**/*.tfvars"
+---
+# Block Scalar
+Two lines of the block-scalar body above look like top-level keys and one looks
+like a list item. None of them is a key.
+RULE
+out=$(run)
+assert_eq "a paths: line inside a block-scalar body does not scope the rule" \
+    "$(count_key "$out" always_loaded_rules)" "$((base_rules + 1))"
+assert_eq "a reviewed: line inside a block-scalar body is not captured" \
+    "$(missing_reviewed "$out")" "$((base_missing + 1))"
+
+# NOTE: the POSITIVE half -- that a block scalar's BODY is extracted rather
+# than the empty string after the indicator -- has no assertion here, because
+# it has no observable consequence in --format=json. NOT because `description`
+# has no consumer: config-drift.py's containment metric builds a token set from
+# `name + desc + body[:6000]`. The conclusion survives for a different reason --
+# a skill's `body` is the WHOLE file including its frontmatter, so tokens(desc)
+# is always a subset of tokens(body) and the union cannot move however desc is
+# parsed. `reviewed:` is the only key whose value reaches the output on its own,
+# and only through a truthiness test; the pre-fix parser captured the literal
+# `|`, which is truthy, so an assertion phrased that way passes against the bug
+# (verified by running this suite against the pre-fix parser). The positive half
+# is pinned in TEST 10 instead.
+
+# 9b. GUARD INTEGRITY: a flush-left YAML list item is not a key either. If the
+# leading `- ` were stripped before matching, both decoys below would land.
+cat > "$FIXROOT/home/.claude/rules/listitem.md" <<'RULE'
+---
+created: 2026-01-01
+tags:
+- reviewed: 2026-01-01
+- paths: "**/*.tf"
+---
+# List Item
+A flush-left list whose items are shaped exactly like top-level keys.
+RULE
+out=$(run)
+assert_eq "a flush-left list item does not scope the rule" \
+    "$(count_key "$out" always_loaded_rules)" "$((base_rules + 2))"
+assert_eq "a flush-left list item is not captured as reviewed:" \
+    "$(missing_reviewed "$out")" "$((base_missing + 2))"
+
+# 9c. paths: still parses such that the KEY is present -- the constraint the
+# block-scalar fix had to preserve. This is TEST 5's invariant restated as a
+# rule count, so a scoped rule and an unscoped one are asserted in one pass.
+# Its blind spot, and TEST 5's: consumers read KEY PRESENCE, so the naive fix
+# (slurp the indented lines under any empty value) leaves `paths` present with
+# a glob-list value and passes both. That the value stays "" is pinned in
+# TEST 10, which is the only case that fails against that mutation.
+before_rules=$(count_key "$out" always_loaded_rules)
+before_tokens=$(count_key "$out" always_loaded_tokens)
+cat > "$FIXROOT/home/.claude/rules/scoped-again.md" <<'RULE'
+---
+created: 2026-01-01
+paths:
+  - "**/*.tf"
+---
+# Scoped Again
+Terraform state locking behaves differently under a remote backend, and the
+lock is not released when the process is killed mid-apply.
+RULE
+out=$(run)
+assert_eq "fm still carries the paths KEY (scoped rule is not always-loaded)" \
+    "$(count_key "$out" always_loaded_rules)" "$before_rules"
+assert_eq "a paths:-scoped rule still adds nothing to the token budget" \
+    "$(count_key "$out" always_loaded_tokens)" "$before_tokens"
+rm "$FIXROOT/home/.claude/rules/scoped-again.md" \
+   "$FIXROOT/home/.claude/rules/blockscalar.md" \
+   "$FIXROOT/home/.claude/rules/listitem.md"
+
+echo "TEST 10: widened key pattern -- executed directly, see note"
+# `allowed-tools`, `argument-hint` and `maxTurns` have NO consumer inside the
+# analyzer. `description` does have one even under --no-embed -- the containment
+# metric's token set at config-drift.py's `tset(name + desc + body[:6000])` --
+# but a skill's body is the whole file including its frontmatter, so tokens(desc)
+# is a subset of tokens(body) and no parse of it can move the token set. Nothing
+# in --format=json output changes when any of these are captured, so there is no
+# consequence to assert on and none is invented here. This case instead loads
+# the SHIPPED frontmatter() out of the analyzer file and feeds it real input --
+# still semantic (the real function, real frontmatter), never a grep for a name.
+fm_get() {
+    python3 - "$ANALYZER" "$1" "$2" <<'PYFM'
+import importlib.util
+import sys
+
+spec = importlib.util.spec_from_file_location("config_drift", sys.argv[1])
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+print(mod.frontmatter(sys.argv[2]).get(sys.argv[3], "<absent>"))
+PYFM
+}
+
+FM_BODY='---
+name: widget-wrangling
+allowed-tools: Bash, Read
+argument-hint: "[flags]"
+maxTurns: 5
+description: |
+  Wrangle widgets across the fleet.
+  reviewed: 2026-01-01
+paths:
+  - "**/*.tf"
+---
+# widget-wrangling
+'
+assert_eq "a hyphenated key is captured" "$(fm_get "$FM_BODY" allowed-tools)" "Bash, Read"
+assert_eq "a second hyphenated key is captured and unquoted" "$(fm_get "$FM_BODY" argument-hint)" "[flags]"
+assert_eq "a camelCase key is captured" "$(fm_get "$FM_BODY" maxTurns)" "5"
+assert_eq "a block-scalar body is joined, not left empty" \
+    "$(fm_get "$FM_BODY" description)" "Wrangle widgets across the fleet. reviewed: 2026-01-01"
+assert_eq "paths: after a block scalar is present and empty" "$(fm_get "$FM_BODY" paths)" ""
+# `reviewed` is a key a real document carries and this fixture does NOT declare
+# at top level, so an implementation that read the indented decoy line would
+# emit it. The former decoy asserted on `not-a-key` -- the VALUE of the decoy
+# line, a name no implementation could ever emit -- so it passed against
+# `def frontmatter(b): return {}`, and even a parser that DID read the indented
+# line would have had `paths` overwritten two lines later by the real column-0
+# key, leaving the property unobservable.
+assert_eq "a block-scalar body line is not a top-level key" "$(fm_get "$FM_BODY" reviewed)" "<absent>"
+
+# D4. `raw.strip("\"'")` strips a character CLASS from both ends, not a matched
+# pair, so a value that merely ENDS in a quote character loses it. Both bodies
+# below are the verbatim frontmatter lines of live skills:
+# agent-patterns-plugin/skills/adversarial-review (trailing ') and
+# git-plugin/skills/git-api-pr (a matched '...' pair whose last inner character
+# is a " that the class strip then eats as well).
+FM_TRAILING_QUOTE='---
+name: adversarial-review
+argument-hint: path|PR|file|plan description; optional '"'"'focus on X'"'"'
+---
+# adversarial-review
+'
+assert_eq "an unmatched trailing quote survives" \
+    "$(fm_get "$FM_TRAILING_QUOTE" argument-hint)" "path|PR|file|plan description; optional 'focus on X'"
+
+FM_NESTED_QUOTE='---
+name: git-api-pr
+argument-hint: '"'"'<files...> --title "type(scope): description"'"'"'
+---
+# git-api-pr
+'
+assert_eq "only the matched outer pair is stripped, not the quote beneath it" \
+    "$(fm_get "$FM_NESTED_QUOTE" argument-hint)" '<files...> --title "type(scope): description"'
+
+# D5. A plain scalar continued over indented lines. Verbatim from
+# git-plugin/skills/git-derive-docs/SKILL.md:5-7 -- the widened key regex turned
+# "key absent" into "key present but truncated, with a dangling comma", which is
+# worse, because the fragment reads as a complete value.
+FM_CONTINUATION='---
+name: git-derive-docs
+allowed-tools: Bash(bash *), Bash(git log *),
+               Bash(git show *), Bash(git rev-list *),
+               Read, Grep, Glob
+description: A short one-line description.
+paths:
+  - "**/*.tf"
+---
+# git-derive-docs
+'
+assert_eq "a multi-line plain scalar is joined, not truncated at the first line" \
+    "$(fm_get "$FM_CONTINUATION" allowed-tools)" \
+    "Bash(bash *), Bash(git log *), Bash(git show *), Bash(git rev-list *), Read, Grep, Glob"
+# Guard integrity for D5: absorbing continuations must not swallow the NEXT
+# top-level key, and must not turn `paths:` (bare-empty, followed by `- ` list
+# items) into its glob list -- the constraint TEST 5 and TEST 9c pin from the
+# analyzer side.
+assert_eq "continuation absorption stops at the next top-level key" \
+    "$(fm_get "$FM_CONTINUATION" description)" "A short one-line description."
+assert_eq "continuation absorption does not swallow a paths: list" \
+    "$(fm_get "$FM_CONTINUATION" paths)" ""
+
+# D6. A block indicator may carry a chomping sign, an explicit indentation
+# digit, and a trailing comment. Exact-set membership recognised only the six
+# bare spellings, so `|2` and `| # notes` were captured as VALUES -- truthy
+# junk, the original bug's shape wearing a different string.
+FM_INDICATOR_DIGIT='---
+name: widget-wrangling
+description: |2
+  Wrangle widgets across the fleet.
+paths:
+  - "**/*.tf"
+---
+# widget-wrangling
+'
+assert_eq "an explicit-indentation indicator is not captured as the value" \
+    "$(fm_get "$FM_INDICATOR_DIGIT" description)" "Wrangle widgets across the fleet."
+
+FM_INDICATOR_COMMENT='---
+name: widget-wrangling
+description: | # keep the line breaks
+  Wrangle widgets across the fleet.
+paths:
+  - "**/*.tf"
+---
+# widget-wrangling
+'
+assert_eq "a commented indicator is not captured as the value" \
+    "$(fm_get "$FM_INDICATOR_COMMENT" description)" "Wrangle widgets across the fleet."
+assert_eq "a commented indicator still leaves paths: present and empty" \
+    "$(fm_get "$FM_INDICATOR_COMMENT" paths)" ""
+
+# D8. A comment line is never scalar content. Absorbing it as a continuation
+# appended the comment to the value; for `reviewed:` that broke the
+# \d{4}-\d{2}-\d{2} gate at check_review_staleness, so the file was skipped by
+# the staleness check while check_frontmatter still counted it as reviewed --
+# a rule that reads as reviewed and can never be reported stale. All three
+# expectations below are PyYAML 6.0.3's, verified against it.
+FM_COMMENT_LINE='---
+reviewed: 2020-01-01
+  # re-verified against the live corpus
+paths:
+  # terraform only
+  - "**/*.tf"
+---
+# t
+'
+assert_eq "an indented comment is not absorbed into the value it follows" \
+    "$(fm_get "$FM_COMMENT_LINE" reviewed)" "2020-01-01"
+assert_eq "an indented comment does not make paths: truthy" \
+    "$(fm_get "$FM_COMMENT_LINE" paths)" ""
+
+# D9. `- ` and a nested `key:` can only follow a key whose INLINE value is
+# empty; once a value sits on the key's own line YAML permits neither, so every
+# indented line there is continuation. Breaking on one truncated the value --
+# the same defect D5 fixed, wearing the guard that fixed it. Both bodies below
+# are valid YAML and both were truncated at the first line.
+FM_CONT_URL='---
+name: x
+description: See the upstream note at
+  https://example.com/docs for the rest.
+paths:
+  - "**/*.tf"
+---
+# x
+'
+assert_eq "a continuation starting with a word-colon token is not a nested key" \
+    "$(fm_get "$FM_CONT_URL" description)" \
+    "See the upstream note at https://example.com/docs for the rest."
+assert_eq "the D9 body still leaves paths: present and empty" \
+    "$(fm_get "$FM_CONT_URL" paths)" ""
+
+FM_CONT_DASH='---
+name: x
+description: Some text that continues
+  - and this dash line is part of it
+---
+# x
+'
+assert_eq "a continuation starting with a dash is not a list item" \
+    "$(fm_get "$FM_CONT_DASH" description)" \
+    "Some text that continues - and this dash line is part of it"
+
+# D10. The closing-fence scan runs to the end of the document, so a file with
+# NO frontmatter that opens with a `---` thematic break and carries another one
+# later had its prose read as the block. Prose says `Note:` at column 0, and the
+# widened key pattern captures it -- a prose `paths:` would silently drop the
+# rule out of the always-loaded budget. The heading is why the opener test
+# cannot skip comment lines: `# Title` and a YAML comment are the same string.
+FM_PROSE_BLOCK='---
+
+# Title
+
+Note: prose, not a key.
+paths: neither is this
+---
+
+section
+'
+assert_eq "prose between two thematic breaks is not frontmatter" \
+    "$(fm_get "$FM_PROSE_BLOCK" Note)" "<absent>"
+assert_eq "prose between two thematic breaks cannot supply paths:" \
+    "$(fm_get "$FM_PROSE_BLOCK" paths)" "<absent>"
+# Guard integrity: the opener test must not reject real frontmatter. Without
+# this, "<absent>" above would also pass against a parser that returns {}.
+assert_eq "real frontmatter still parses after the opener test" \
+    "$(fm_get "$FM_BODY" name)" "widget-wrangling"
+
+# The cost of the opener test, pinned so it stays a decision rather than a
+# surprise: frontmatter whose first non-blank line is a YAML comment parses to
+# {}. That is a real narrowing, not a free win. It is accepted because the
+# alternative reopens the prose-as-frontmatter hole above -- a markdown
+# `# Heading` and a YAML comment are byte-identical, so no opener test can
+# admit one and reject the other. 0 of 757 fenced documents in this corpus open
+# with a comment, and the failure is visible (every key vanishes, so the file
+# reports as missing `reviewed:`) rather than silent like the bug it replaces.
+FM_COMMENT_FIRST='---
+# just a note
+name: widget-wrangling
+---
+# widget-wrangling
+'
+assert_eq "frontmatter opening with a YAML comment parses to {} (accepted cost)" \
+    "$(fm_get "$FM_COMMENT_FIRST" name)" "<absent>"
+
+echo "TEST 11: a --- inside frontmatter does not truncate it, via the analyzer"
+# The bug: frontmatter() ended the block at the first `---` SUBSTRING anywhere
+# in the body, not at the closing fence LINE. Every key after an inner `---` was
+# dropped -- including `paths:`, so a path-scoped rule was billed to the
+# always-loaded budget (always_loaded_rules 0 -> 1). 118 files in this corpus
+# already use a bare `---` line as a thematic break in prose.
+out=$(run)
+base_all_rules=$(count_key "$out" always_loaded_rules)
+base_all_tokens=$(count_key "$out" always_loaded_tokens)
+base_total_rules=$(count_key "$out" rules)
+
+cat > "$FIXROOT/home/.claude/rules/thematic-break.md" <<'RULE'
+---
+created: 2026-01-01
+description: |
+  Calibrate widget torque against the fleet inventory manifest.
+
+  ---
+
+  The separator above is a thematic break in prose, not the end of the
+  frontmatter block.
+paths:
+  - "**/*.tf"
+---
+# Thematic Break
+Terraform state locking behaves differently under a remote backend, and the
+lock is not released when the process is killed mid-apply.
+RULE
+out=$(run)
+# Guard integrity: without this, every "unchanged" assertion below would also
+# pass against an analyzer that never discovered the fixture at all.
+assert_eq "the thematic-break fixture was discovered" \
+    "$(count_key "$out" rules)" "$((base_total_rules + 1))"
+assert_eq "a --- thematic break does not drop paths: (rule count)" \
+    "$(count_key "$out" always_loaded_rules)" "$base_all_rules"
+assert_eq "a --- thematic break does not drop paths: (token budget)" \
+    "$(count_key "$out" always_loaded_tokens)" "$base_all_tokens"
+rm "$FIXROOT/home/.claude/rules/thematic-break.md"
+
+# The same defect fires with no block scalar at all: a `---` substring on a
+# plain value line truncated the frontmatter just as hard.
+cat > "$FIXROOT/home/.claude/rules/inline-break.md" <<'RULE'
+---
+created: 2026-01-01
+description: Use the --- separator form when splitting the manifest
+paths:
+  - "**/*.tf"
+---
+# Inline Break
+Terraform state locking behaves differently under a remote backend, and the
+lock is not released when the process is killed mid-apply.
+RULE
+out=$(run)
+assert_eq "the inline-break fixture was discovered" \
+    "$(count_key "$out" rules)" "$((base_total_rules + 1))"
+assert_eq "an inline --- in a plain value does not drop paths: (rule count)" \
+    "$(count_key "$out" always_loaded_rules)" "$base_all_rules"
+assert_eq "an inline --- in a plain value does not drop paths: (token budget)" \
+    "$(count_key "$out" always_loaded_tokens)" "$base_all_tokens"
+# ...and the value itself survives intact rather than being cut at the `---`.
+assert_eq "an inline --- does not truncate the value it sits in" \
+    "$(fm_get "$(cat "$FIXROOT/home/.claude/rules/inline-break.md")" description)" \
+    "Use the --- separator form when splitting the manifest"
+rm "$FIXROOT/home/.claude/rules/inline-break.md"
+
+# A document with NO closing fence must parse to {}. That is the contract the
+# pre-fix parser honoured only by accident -- it returned {} when the body held
+# fewer than two `---` SUBSTRINGS, so an unterminated block carrying a couple of
+# inline dashes (below) parsed as though it were fenced, and yielded a truncated
+# `description`. Ending at a fence LINE makes the contract hold for the reason
+# it states.
+FM_NO_FENCE='---
+description: a --- b --- c
+name: unterminated
+'
+assert_eq "a document with no closing fence still yields nothing" \
+    "$(fm_get "$FM_NO_FENCE" description)" "<absent>"
+
+echo "TEST 12: the embedding cache self-invalidates when the embed text changes"
+# The bug: the cache was keyed on it["hash"] -- a sha of the raw FILE BYTES --
+# while the vector was computed from "title\ndesc\nbody". A frontmatter fix
+# changes `desc` for files whose bytes did not change, so a warm cache kept
+# serving vectors computed from the old text: the fix was inert exactly where it
+# mattered, and semantic_overlap findings became cache-state dependent (a cold
+# cache and a warm cache disagreed on the same commit).
+#
+# check_semantic_dupes imports numpy and fastembed. Neither is a dependency of
+# the cheap tier this suite exercises, so both are stubbed -- but the function
+# under test is the SHIPPED one, loaded out of the analyzer file, and the stub
+# embedder LOGS every text it is handed, so the assertions are about what was
+# actually re-embedded rather than about the cache's shape.
+EMBED_DRIVER="$FIXROOT/embed-driver.py"
+cat > "$EMBED_DRIVER" <<'PYDRIVER'
+import hashlib
+import importlib.util
+import json
+import math
+import pathlib
+import sys
+import types
+
+analyzer, cache_path, log_path, desc_a = sys.argv[1:5]
+
+
+class Arr:
+    """Just enough of an ndarray for check_semantic_dupes' five operations."""
+
+    def __init__(self, rows):
+        self.rows = [[float(x) for x in r] for r in rows]
+
+    def __add__(self, scalar):
+        return Arr([[x + scalar for x in r] for r in self.rows])
+
+    def __itruediv__(self, other):
+        for row, denom in zip(self.rows, other.rows):
+            for k in range(len(row)):
+                row[k] /= denom[0]
+        return self
+
+    @property
+    def T(self):
+        return Arr([list(col) for col in zip(*self.rows)])
+
+    def __matmul__(self, other):
+        return Arr(
+            [
+                [
+                    sum(a[k] * other.rows[k][j] for k in range(len(a)))
+                    for j in range(len(other.rows[0]))
+                ]
+                for a in self.rows
+            ]
+        )
+
+    def __getitem__(self, ij):
+        return self.rows[ij[0]][ij[1]]
+
+
+np = types.ModuleType("numpy")
+np.array = lambda rows, dtype=None: Arr(rows)
+np.triu_indices = lambda n, k=0: (
+    [i for i in range(n) for j in range(n) if j >= i + k],
+    [j for i in range(n) for j in range(n) if j >= i + k],
+)
+linalg = types.ModuleType("numpy.linalg")
+linalg.norm = lambda a, axis=None, keepdims=False: Arr(
+    [[math.sqrt(sum(x * x for x in row))] for row in a.rows]
+)
+np.linalg = linalg
+sys.modules["numpy"] = np
+sys.modules["numpy.linalg"] = linalg
+
+
+class TextEmbedding:
+    def __init__(self, model_name=None):
+        pass
+
+    def embed(self, texts):
+        with open(log_path, "a", encoding="utf-8") as fh:
+            for text in texts:
+                fh.write(json.dumps(text) + "\n")
+        for text in texts:
+            digest = hashlib.sha256(text.encode()).digest()
+            yield [1.0, float(digest[0]), float(digest[1])]
+
+
+fastembed = types.ModuleType("fastembed")
+fastembed.TextEmbedding = TextEmbedding
+sys.modules["fastembed"] = fastembed
+
+spec = importlib.util.spec_from_file_location("config_drift", analyzer)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+# Two skills whose FILE BYTES never change across runs. Only alpha's parsed
+# `desc` moves -- exactly the shape of a frontmatter repair.
+items = [
+    {
+        "kind": "skill",
+        "path": "/fixture/alpha/SKILL.md",
+        "name": "alpha",
+        "title": "alpha",
+        "body": "Alpha body about widget torque calibration.",
+        "desc": desc_a,
+        "hash": "aaaaaaaaaaaaaaaa",
+        "fm": {},
+    },
+    {
+        "kind": "skill",
+        "path": "/fixture/beta/SKILL.md",
+        "name": "beta",
+        "title": "beta",
+        "body": "Beta body about fleet inventory manifests.",
+        "desc": "beta description",
+        "hash": "bbbbbbbbbbbbbbbb",
+        "fm": {},
+    },
+]
+
+if len(sys.argv) > 5:
+    mod.EMBED_MODEL = sys.argv[5]
+
+mod.check_semantic_dupes(items, {}, pathlib.Path(cache_path))
+print("CACHE_KEYS=%d" % len(json.loads(pathlib.Path(cache_path).read_text())))
+PYDRIVER
+
+EMBED_CACHE="$FIXROOT/embeddings.json"
+EMBED_LOG="$FIXROOT/embed-log.jsonl"
+rm -f "$EMBED_CACHE" "$EMBED_LOG"
+log_lines() { [ -f "$EMBED_LOG" ] && grep -c '' "$EMBED_LOG" || echo 0; }
+
+python3 "$EMBED_DRIVER" "$ANALYZER" "$EMBED_CACHE" "$EMBED_LOG" "old description" >/dev/null 2>&1
+assert_eq "a cold cache embeds both items" "$(log_lines)" "2"
+
+# Guard integrity: without this, "the changed item is re-embedded" would also
+# pass against a cache that never hits and re-embeds everything every run.
+python3 "$EMBED_DRIVER" "$ANALYZER" "$EMBED_CACHE" "$EMBED_LOG" "old description" >/dev/null 2>&1
+assert_eq "an unchanged run re-embeds nothing" "$(log_lines)" "2"
+
+cache_keys=$(python3 "$EMBED_DRIVER" "$ANALYZER" "$EMBED_CACHE" "$EMBED_LOG" "new description" 2>/dev/null | grep '^CACHE_KEYS=' | cut -d= -f2)
+assert_eq "changing desc alone re-embeds exactly that item" "$(log_lines)" "3"
+assert_eq "the re-embedded text carries the new desc" \
+    "$(tail -n 1 "$EMBED_LOG" | grep -c 'new description')" "1"
+assert_eq "the superseded vector is kept under its own key, not overwritten" "$cache_keys" "3"
+
+# The model is an input to the vector exactly as the text is. Keyed on text
+# alone, swapping EMBED_MODEL hit the cache for every item and served the
+# previous model's vectors -- every cosine then computed across two embedding
+# spaces, silently, with no output the operator could tell apart. Same defect
+# the text-keying fixed, one level up.
+python3 "$EMBED_DRIVER" "$ANALYZER" "$EMBED_CACHE" "$EMBED_LOG" "new description" \
+    "BAAI/bge-large-en-v1.5" >/dev/null 2>&1
+assert_eq "swapping the embedding model re-embeds every item" "$(log_lines)" "5"
+
 echo
 echo "=== CONFIG DRIFT TESTS ==="
 echo "PASSED=$PASS"


### PR DESCRIPTION
Prerequisite for #2528. `frontmatter()` in `config-drift.py` mis-parses two
YAML shapes, and fixing it surfaced a third bug that is live today.

## What was wrong

**Block scalars parsed to the empty string.** `description: |` captured `"|"`,
not the body. 6 of the 21 agent definitions in this repo use that form, so
widening the corpus to agents (#2528) would have embedded 6 empty descriptions.

**The key pattern could not match real keys.** `^([a-z_]+):` misses `maxTurns`,
`allowed-tools`, `argument-hint`.

**The closing fence was found by substring, not by line.** `body.split("---", 2)`
ends the frontmatter at the first `---` *anywhere*, so a `---` thematic break
inside a description drops every key after it — including `paths:`, which
silently bills a path-scoped rule to the always-loaded budget
(`always_loaded_rules` 0 → 1, measured). 118 files in this corpus already use a
bare `---` line in prose. It fires with no block scalar at all:
`description: Use the --- separator form` yields `{'description': 'Use the'}`.

## What changed

`frontmatter()` is now a line scanner with four load-bearing properties, each
documented in its docstring and pinned by a test:

- the block ends at the first closing fence **line**;
- a key is recognised only at column 0, so a list item or a `key:` inside a
  block-scalar body cannot shadow a real key;
- a bare-empty value stays `""` — `paths:` must keep its **key present**,
  because consumers test presence, never truthiness;
- block-scalar bodies and indented plain-scalar continuations are joined with
  single spaces.

Also: the embedding cache is now keyed on a hash of the embed text plus
`EMBED_MODEL`, rather than on the raw file bytes. `desc` feeds the embed text,
so parsing a description that the bytes already contained changes what gets
embedded without changing the file — a bytes-keyed cache kept serving the old
vector, which made findings depend on cache warmth. `it["hash"]` is deliberately
untouched: it also keys the gitdates cache and expires waivers, both of which
mean "the file's bytes".

## Evidence

| Check | Result |
|---|---|
| `test-config-drift.sh` | **61/61**, `STATUS=OK` |
| `--format=json --fast --no-embed` vs `origin/main` | **byte-identical**, 19,431 bytes |
| Differential vs PyYAML 6.0.3, all 964 fenced files | 0 missing keys, 0 spurious keys, 0 truncated values |
| Old→new key-set diff, same 964 files | 0 files lost a key |
| `ruff@0.15.8 check` / `format --check` | clean |
| `check-git-sandbox-guards.sh --strict` | `STATUS=OK`, 369 scripts |
| `shellcheck`, `lint-shell-scripts.sh` | clean (9 pre-existing warnings, all `macos-plugin`) |

**Byte-identical output is the expected result, and it is not evidence the
change does nothing.** Agents are not in `collect()` until #2528, and no rule or
skill in the corpus currently has a `---` inside its frontmatter — so today's
findings genuinely should not move. The direct-call assertions in TEST 10–12 are
what pin the behaviour change; the corpus diff only shows nothing regressed.

Mutation verification: seven mutants, each undoing one repair, run against the
real file rather than a hand-neutered copy. Every repair has at least one
assertion that dies to its own mutant, and no assertion survives the null
`def frontmatter(body): return {}`.

## Accepted cost

Frontmatter whose first non-blank line is a YAML comment now parses to `{}`.
This is a real narrowing, taken deliberately: a markdown `# Heading` and a YAML
comment are byte-identical, so no opener test can admit one and reject the
other, and admitting it reopens the prose-as-frontmatter hole. 0 of 757 fenced
documents in the corpus open with a comment, and the failure is visible (every
key vanishes, so the file reports as missing `reviewed:`) rather than silent
like the bug it replaces. Pinned by an assertion so it stays a decision.

## Review note

Four defects in this change were found by an adversarial pass *after* the suite
was green and the corpus diff was byte-identical — including one introduced by
the continuation-absorb repair itself (an indented comment was folded into
`reviewed:`, so `check_review_staleness` skipped the file while
`check_frontmatter` still counted it as reviewed, proven end-to-end on a git
fixture). Green tests plus an unchanged corpus diff were not sufficient here;
both were blind to it.

Refs #2528, #2530
