### PR TITLE
ci: derive PR labels from the diff and the conventional-commit title

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -21,7 +21,7 @@ When adding a workflow, pick the existing domain that fits or extend the table b
 | `Claude:` | Claude Code-driven workflows (PR reviews, @-mentions, scheduled reviews) |
 | `Plugin:` | Plugin infrastructure — PR checks, config validation, skill operations, scheduled audits |
 | `Release:` | release-please ecosystem — version bumps, changelog, release-PR doc audit, conflict repair, stuck-label cleanup |
-| `PR:` | Cross-cutting PR governance — conflict resolution, conventional-commit enforcement |
+| `PR:` | Cross-cutting PR governance — labelling, conflict resolution, conventional-commit enforcement |
 | `Auto-fix:` | Autonomous CI failure remediation triggered by `workflow_run` |
 | `Test:` | Repo test suites — skill-local regression tests, the adapters (skill-discovery core) suite |
 | `Sync:` | Cross-repo artifact sync — regenerate compiled prompts for the extracted agent CLIs and PR them to their standalone repos |
@@ -35,6 +35,7 @@ Claude: @mentions
 Claude: Changelog review
 Claude: PR review
 Claude: Research radar
+PR: Auto-label
 PR: Auto-resolve conflicts
 PR: Enforce conventional commits
 Plugin: Enablement drift

--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -1,0 +1,150 @@
+name: "PR: Auto-label"
+
+# Applies the repo's routing labels to every PR, whoever opened it: the
+# per-plugin `<name>-plugin` label from the directories touched, plus a
+# conventional-commit type label derived from the PR title.
+#
+# Why a workflow rather than an instruction: the label conventions live in
+# `repos/.claude/rules/github-metadata-hygiene.md` and
+# `repos/laurigates/.claude/rules/github-metadata-hygiene.md` — ANCESTOR
+# directories of this repo. An interactive session run from inside
+# ~/repos/laurigates/claude-plugins loads both; a scheduled cloud routine gets
+# a bare checkout where neither path exists, so its PRs arrived unlabelled
+# (work-on-claude-plugins-issues, 2026-08). Deriving the labels from the diff
+# means no agent — routine, subagent, Renovate, or human — has to remember.
+#
+# `pull_request_target` (not `pull_request`) so a fork PR still gets a token
+# with `pull-requests: write`. Safe here ONLY because this job never checks out
+# or executes PR code — it reads the changed-file list over the API and calls
+# `gh pr edit`. Do not add an `actions/checkout` step to this workflow.
+# See `.claude/rules/github-actions-security.md`.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+# Explicit top-level least-privilege grant. Without one, a second job added
+# here would silently inherit the repo-default token scope instead of this set.
+permissions:
+  contents: read
+  pull-requests: write
+
+# Per-PR group: a rapid push sequence should settle on the final diff rather
+# than race. Cancellation is safe because labelling is additive and idempotent
+# — a cancelled run loses nothing the next one won't redo.
+concurrency:
+  group: pr-auto-label-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: Derive and apply labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Untrusted input bound to an env var, never interpolated into the
+          # script body — a PR title is attacker-controlled on a fork PR.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          files=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
+          if [ -z "$files" ]; then
+            echo "No changed files reported; nothing to label."
+            exit 0
+          fi
+
+          wanted=""
+          add() {
+            case " ${wanted} " in
+              *" $1 "*) ;;
+              *) wanted="${wanted:+${wanted} }$1" ;;
+            esac
+          }
+
+          # Path-derived labels. The per-plugin label is the top-level
+          # directory name verbatim, which is the routing convention in
+          # `laurigates/.claude/rules/github-metadata-hygiene.md`.
+          while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            top="${f%%/*}"
+            case "$top" in
+              # `.claude-plugin/` is the hidden marketplace-metadata directory,
+              # not a plugin — the same exclusion `.claude/rules/shell-scripting.md`
+              # § Plugin Directory Discovery applies to every `*-plugin` glob.
+              # Caught by a control run over real PRs, which minted a
+              # `.claude-plugin` label before this guard existed.
+              .*) ;;
+              *-plugin)
+                # Require an actual path separator so a stray top-level file
+                # named `x-plugin` cannot mint a label.
+                [ "$top" != "$f" ] && add "$top"
+                ;;
+            esac
+            case "$f" in
+              .github/workflows/*|.github/actions/*) add "github-actions" ;;
+              .claude/rules/*|.claude-plugin/*|scripts/*|justfile) add "plugin-infrastructure" ;;
+              docs/*) add "docs" ;;
+            esac
+          done <<<"$files"
+
+          # Type label from the conventional-commit prefix. The PR title is the
+          # commit message on squash-merge, so it is already required to be
+          # conventional (`.claude/rules/conventional-commits.md`).
+          commit_type="${PR_TITLE%%:*}"   # "feat(scope)!: x" -> "feat(scope)!"
+          commit_type="${commit_type%%(*}" # -> "feat"
+          commit_type="${commit_type%!}"   # "feat!" -> "feat"
+          case "$commit_type" in
+            feat|perf) add "enhancement" ;;
+            fix)       add "bug" ;;
+            docs)      add "docs" ;;
+            refactor)  add "refactor" ;;
+            chore|build|ci|test) add "chore" ;;
+            *) echo "::notice::PR title carries no recognised conventional-commit type; no type label applied." ;;
+          esac
+
+          if [ -z "$wanted" ]; then
+            echo "No labels derived for this diff."
+            exit 0
+          fi
+
+          # `gh pr edit --add-label "a,b"` hard-fails if ANY name is unknown to
+          # the repo, and the failure lands after all the real work. Resolve
+          # existence first. Per-plugin labels are created ad-hoc on demand
+          # (they are deliberately NOT in gitops/labels.tf); anything else that
+          # is missing is dropped with a warning rather than invented here.
+          # --limit well above the current label count: the default is 30, and
+          # a truncated page makes an existing label read as missing
+          # (`.claude/rules/gh-json-fields.md` § Default list cap).
+          existing=$(gh label list -R "$REPO" --limit 500 --json name --jq '.[].name')
+
+          apply=""
+          for l in $wanted; do
+            if grep -qxF "$l" <<<"$existing"; then
+              apply="${apply:+${apply},}$l"
+              continue
+            fi
+            case "$l" in
+              *-plugin)
+                gh label create "$l" -R "$REPO" \
+                  --color "BFD4F2" \
+                  --description "${l%-plugin} plugin related"
+                apply="${apply:+${apply},}$l"
+                ;;
+              *)
+                echo "::warning::Label '$l' does not exist in ${REPO}; skipping it."
+                ;;
+            esac
+          done
+
+          if [ -z "$apply" ]; then
+            echo "No applicable labels survived resolution."
+            exit 0
+          fi
+
+          echo "Applying: ${apply}"
+          gh pr edit "$PR_NUMBER" -R "$REPO" --add-label "$apply"


### PR DESCRIPTION
## What

Adds `PR: Auto-label`, a workflow that derives a PR's labels from its diff and its title:

| Source | Label |
|---|---|
| Top-level `<name>-plugin/` directory touched | `<name>-plugin` (created ad-hoc if absent) |
| `.github/workflows/`, `.github/actions/` | `github-actions` |
| `.claude/rules/`, `.claude-plugin/`, `scripts/`, `justfile` | `plugin-infrastructure` |
| `docs/` | `docs` |
| Title prefix `feat`/`perf` → `enhancement`, `fix` → `bug`, `docs`, `refactor`, `chore`/`build`/`ci`/`test` → `chore` | type label |

Labels are only ever added, never removed, so a hand-applied label survives.

## Why

PRs opened by the **"Resolve claude-plugins repo issues"** scheduled routine arrived unlabelled, while interactive PRs from this repo got labels automatically.

The labelling conventions live in `repos/.claude/rules/github-metadata-hygiene.md` and `repos/laurigates/.claude/rules/github-metadata-hygiene.md` — **ancestor** directories of this repo. A session run from inside the checkout loads both through the working-directory chain. The routine gets a bare clone in an isolated cloud session where neither path exists, so no labelling instruction reached it. Its own prompt specifies title format, `--body-file`, `Fixes #<n>`, ready-not-draft and CI verification, and says nothing about labels.

Deriving them from the diff means no agent — routine, subagent, Renovate, or human — has to carry the convention.

## How it was verified

The shipped `run` block was extracted from the YAML (not retyped) and executed against five real PRs, with `gh pr edit` and `gh label create` stubbed behind a sentinel and `gh api` left live:

| PR | Derived |
|---|---|
| #2534 `chore: release main` | `plugin-infrastructure, health-plugin, chore` |
| #2533 `fix(hooks-plugin): …` | `plugin-infrastructure, hooks-plugin, bug` |
| #2526 `docs(repo): …` | `docs` |
| #2520 `feat(prose): …` | `plugin-infrastructure, github-actions, hooks-plugin, prose-plugin, enhancement` (creates `prose-plugin`) |
| #2519 `docs(agent-patterns): …` | `agent-patterns-plugin, docs` |

Controls: a non-conventional title yields the path labels plus a `::notice::` and no type label; `feat(repo)!:` maps to `enhancement`.

**That control caught a real bug before it shipped** — `.claude-plugin/`, the hidden marketplace-metadata directory, matches `*-plugin` and minted a bogus `.claude-plugin` label. Now excluded, the same way `.claude/rules/shell-scripting.md` § Plugin Directory Discovery excludes it from every `*-plugin` glob.

## Security notes

`pull_request_target` rather than `pull_request` so a fork PR still gets a token with `pull-requests: write`. Safe **only** because the job never checks out or executes PR code — it reads the changed-file list over the API and calls `gh pr edit`. The workflow header says so; do not add an `actions/checkout` step to it.

The untrusted PR title is bound to an `env:` variable and referenced as a quoted shell variable, per `.claude/rules/github-actions-security.md` § Script injection. Top-level least-privilege `permissions:` block. Green on `actionlint`, `check-workflow-labels.sh`, `check-workflow-model.sh` and `check-workflow-script-triggers.sh`.

## Note on this PR's own labels

`pull_request_target` runs the workflow file from the **base** branch, which does not have this workflow yet — so this PR will not label itself. The first PR opened after merge is the operational signal.

## Follow-up outside this repo

`~/.claude/scheduled-tasks/work-on-claude-plugins-issues/SKILL.md` Step 6 was updated in the same session to set `--assignee`/`--label` at creation time and to read `gh label list` first (`gh pr create --label` hard-fails when any name is unknown, after the PR already exists). It is told not to retry a failed label call, since this workflow covers it. That file is machine-local and not tracked here.
