### PR TITLE
refactor(health-plugin): extract the finding/waiver/delta contract into lib/probe.py

### DIFF
--- a/health-plugin/README.md
+++ b/health-plugin/README.md
@@ -36,6 +36,39 @@ These internal skills are auto-discoverable but not user-invocable — use `/hea
 |--------|-------------|
 | `prune-claude-config.py` | Remove orphaned projects and cached data from `~/.claude.json` |
 | `config-drift.py` | Audit the rules/skills corpus itself for duplication, broken pointer stubs, review staleness, and always-loaded budget |
+| `probe-delta.py` | Report only what is NEW since a probe's last run — reads any probe's `--format=json` on stdin against a recorded baseline |
+| `lib/probe.py` | The finding / waiver / delta contract both of the above share. Stdlib only, imported as `from lib.probe import …` |
+
+### `lib/probe.py` — the shared contract
+
+What a probe must agree with other probes about, and nothing else: the
+`Finding` shape, `fingerprint` (identity across runs), `Waivers` (pair-keyed,
+self-expiring), `Baseline`/`Delta`, and the `STATUS=`/`ISSUE_COUNT=` renderers.
+Thresholds, the corpus walk and the `check_*` functions deliberately stay in
+`config-drift.py` — those are one probe's opinion, and a second probe adopting
+them would be adopting a bug rather than a contract.
+
+Two properties are load-bearing and easy to break:
+
+- **`fingerprint` folds a singular `path` into the path set.** Read as "`paths`
+  only", every finding carrying `path` collapses to one fingerprint per kind, so
+  the second broken pointer stub in a corpus is invisible in every delta report
+  forever.
+- **`Baseline` records the root it was taken at.** Fingerprints are built from
+  absolute paths, so a baseline recorded at one root and compared at another
+  yields a disjoint set — every finding new *and* every old one resolved. A root
+  or schema mismatch loads as `None`, so the caller records a fresh baseline and
+  stays silent.
+
+### `probe-delta.py`
+
+```
+config-drift.py --format=json | probe-delta.py --probe config-drift --root <abs> --record
+```
+
+First run records the baseline and says nothing. Later runs report only new
+findings; an empty or unparseable input is `STATUS=ERROR TYPE=analyzer_failed`,
+never a clean sweep.
 
 ### `config-drift.py`
 

--- a/health-plugin/hooks/config-drift-probe.sh
+++ b/health-plugin/hooks/config-drift-probe.sh
@@ -57,12 +57,102 @@ if [ ! -f "$ANALYZER" ] || ! command -v python3 >/dev/null 2>&1 || ! command -v 
     exit 0
 fi
 
+# The analyzer's stderr is CAPTURED, not discarded. Discarding it made a dead
+# analyzer indistinguishable from a clean corpus: on empty output this block
+# fell through to a bare `drift_emit`, whose empty `findings` array IS the
+# "checked, no drift" verdict per hooks-plugin/hooks/lib/drift-protocol.sh, and
+# the hook exited 0. The analyzer now imports `lib.probe`, so it CAN die before
+# printing anything (ModuleNotFoundError, a syntax error in the module) — a
+# failure class the import-free version could not have. This hook introduced the
+# consumer, so it owes the detection.
+ERRFILE=$(mktemp) || ERRFILE=""
+if [ -n "$ERRFILE" ]; then
+    trap 'rm -f "$ERRFILE"' EXIT
+fi
+
 # --fast: read cached git dates only, never spawn git. --no-embed: no model, no
 # download. Both keep this inside a SessionStart budget.
-OUT=$(python3 "$ANALYZER" --root "${DRIFT_CWD:-.}" --fast --no-embed --format=json 2>/dev/null)
+if [ -n "$ERRFILE" ]; then
+    OUT=$(python3 "$ANALYZER" --root "${DRIFT_CWD:-.}" --fast --no-embed --format=json 2>"$ERRFILE")
+else
+    OUT=$(python3 "$ANALYZER" --root "${DRIFT_CWD:-.}" --fast --no-embed --format=json 2>/dev/null)
+fi
+ANALYZER_RC=$?
+
 if [ -z "$OUT" ] || ! printf '%s' "$OUT" | jq empty >/dev/null 2>&1; then
-    # Emit nothing rather than a false all-clear (drift-detection-triggering.md:
-    # never act on uncertainty).
+    # THE OUTPUT IS THE DISCRIMINATOR, NOT THE EXIT CODE. `--format=json` prints
+    # its document unconditionally — an empty corpus still yields
+    # `{"findings": [], ...}` — so empty-or-unparseable stdout is by itself
+    # proof the analyzer did not complete. The exit code cannot narrow that:
+    # exit 1 is NORMAL (returned for any error/warn finding, alongside a full
+    # document, which never reaches this branch), and exit 0 with nothing on
+    # stdout is a truncated or 0-byte analyzer — an interrupted plugin install,
+    # a partial write. There is no benign exit-0-with-unparseable-output case.
+    #
+    # Gating on `[ "$ANALYZER_RC" -ne 0 ]` here therefore let exit-0 emptiness
+    # fall through to a bare `drift_emit`, whose empty `findings` array IS the
+    # "checked, no drift" verdict per hooks-plugin/hooks/lib/drift-protocol.sh —
+    # a false all-clear written by a dead analyzer. So: always report. The exit
+    # code and stderr only choose the wording and the severity.
+
+    # Prefer the last line that LOOKS like a Python exception over the last line
+    # outright. A traceback's exception line is not reliably last: `atexit`
+    # handlers, CPython's `Exception ignored in: <_io.TextIOWrapper ...>` at
+    # interpreter shutdown, and wrapping python3 shims (mise/asdf/uv) all write
+    # after it, and `tail -n 1` then names that noise and DISCARDS the real
+    # exception. `tail -n 1` stays as the fallback for a non-Python failure
+    # (a shim that cannot find an interpreter writes no exception at all).
+    DETAIL=""
+    if [ -n "$ERRFILE" ] && [ -s "$ERRFILE" ]; then
+        DETAIL=$(grep -E '^[A-Za-z_.]*(Error|Exception):' "$ERRFILE" 2>/dev/null | tail -n 1)
+        [ -n "$DETAIL" ] || DETAIL=$(tail -n 1 "$ERRFILE" 2>/dev/null)
+        DETAIL=$(printf '%s' "$DETAIL" | tr -d '\000' | cut -c1-300)
+    fi
+
+    SEVERITY="error"
+    KIND="analyzer_failed"
+    SUMMARY="config-drift analyzer failed: ${DETAIL:-analyzer exited $ANALYZER_RC with no parseable output}"
+
+    if [ "$ANALYZER_RC" = "3" ]; then
+        # Exit 3 is config-drift.py's ARGUMENT-VALIDATION return (`root not
+        # found`), not a failure — the analyzer is healthy and is refusing a bad
+        # --root. A `cwd` that is not a directory would otherwise raise a
+        # permanent `error`/`analyzer_failed` nudge claiming the analyzer is
+        # broken, and send the reader to `/health:check` to look for a bug that
+        # is not there.
+        SEVERITY="warn"
+        KIND="analyzer_bad_root"
+        SUMMARY="config-drift skipped: ${DETAIL:-root not found}"
+    else
+        case "$DETAIL" in
+            FileNotFoundError:* | NotADirectoryError:* | IsADirectoryError:* | \
+                PermissionError:* | UnicodeDecodeError:* | OSError:*)
+                # The analyzer is fine; a file in the CORPUS could not be read.
+                #
+                # This arm is a BACKSTOP, not the primary path. `collect()` no
+                # longer crashes on an unreadable corpus file: it skips the entry
+                # and the analyzer reports it itself as a `corpus_unreadable`
+                # finding, which is strictly better (the sweep still runs, and
+                # every unreadable path is named rather than just the first).
+                # What reaches here is an uncaught read from somewhere else in
+                # the analyzer. Do not delete it on the grounds that nothing
+                # currently reaches it — the cost is one `case` arm, and the
+                # failure it catches is otherwise reported as "the analyzer
+                # failed", which points the reader at the wrong artifact.
+                # "the analyzer failed" points the reader at the wrong artifact,
+                # and `error` pins this to slot 1 of the aggregator's 5 lines
+                # (drift-aggregator.sh sorts error first, across ALL plugins) on
+                # every SessionStart until a human finds the file. The exception
+                # text carries the offending path, which is what actually locates
+                # it.
+                SEVERITY="warn"
+                KIND="corpus_unreadable"
+                SUMMARY="config-drift could not read a file in the config corpus: $DETAIL"
+                ;;
+        esac
+    fi
+
+    drift_add_finding "$SEVERITY" "$KIND" "$SUMMARY" "/health:check"
     drift_emit
     exit 0
 fi

--- a/health-plugin/scripts/config-drift.py
+++ b/health-plugin/scripts/config-drift.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
-import hashlib
 import json
 import os
 import re
@@ -35,6 +34,14 @@ import subprocess
 import sys
 from itertools import combinations
 from pathlib import Path
+
+# The finding / waiver / delta CONTRACT lives in a stdlib-only sibling module so
+# a second probe can share it; the similarity computation and every threshold
+# below stay here, because they are this probe's opinion rather than a contract.
+# `lib.probe`, not `probe`: sys.path[0] is this script's directory, and PEP 420
+# implicit namespace packages resolve the dotted form from there. Do not add an
+# __init__.py and do not touch sys.path.
+from lib.probe import Finding, Waivers, render_json, sha
 
 HOME_RULES = Path.home() / ".claude" / "rules"
 SKIP_PARTS = {"node_modules", "dist", "worktrees", ".git", "__pycache__", "tmp"}
@@ -65,10 +72,6 @@ STOP = set(
 
 
 # --------------------------------------------------------------------- helpers
-def sha(text: str) -> str:
-    return hashlib.sha256(text.encode("utf-8", "replace")).hexdigest()[:16]
-
-
 def toks(text: str) -> list[str]:
     return [
         w for w in re.findall(r"[a-z][a-z0-9_-]{2,}", text.lower()) if w not in STOP
@@ -261,8 +264,55 @@ def walk(root: Path):
 
 
 # ------------------------------------------------------------------- inventory
-def collect(root: Path) -> tuple[list[dict], list[dict]]:
+def _read_corpus_file(p: Path, unreadable: list[str]) -> str | None:
+    """Read one corpus file, or None when it cannot be read.
+
+    `collect()` walks user-controlled trees, and a `.claude/rules/` directory is
+    routinely a symlink farm (chezmoi, stow). An unresolvable symlink makes
+    `read_text()` raise FileNotFoundError from inside the INVENTORY pass, which
+    aborts the whole run before a single finding is produced -- so one dangling
+    link costs the entire sweep, in every scope, until a human finds it. Skipping
+    the unreadable entry degrades the corpus by one file instead.
+
+    Skipping is NOT swallowing: the path is recorded in `unreadable`, and
+    `check_corpus_unreadable()` turns that into a finding. Degrading silently
+    would be the worse bug -- a corpus two thirds of which failed to open would
+    report a clean sweep, which is exactly the false all-clear this probe
+    exists to prevent, one layer down from the hook that guards against it.
+    """
+    try:
+        return p.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        unreadable.append(str(p))
+        return None
+
+
+def check_corpus_unreadable(unreadable) -> list[Finding]:
+    """Report corpus files the inventory pass could not open.
+
+    `warn`, not `error`: the sweep still ran and its other findings stand. The
+    aggregator sorts `error` first across every plugin and caps the nudge at
+    five lines, so an `error` here would pin a dangling symlink to slot 1 on
+    every session start. The paths are in the summary because they are what
+    locates the file -- a remediation skill cannot find it for you.
+    """
+    if not unreadable:
+        return []
+    shown = ", ".join(unreadable[:3])
+    more = f" (+{len(unreadable) - 3} more)" if len(unreadable) > 3 else ""
+    return [
+        Finding(
+            "warn",
+            "corpus_unreadable",
+            f"{len(unreadable)} corpus file(s) could not be read and were skipped: {shown}{more}",
+            paths=sorted(unreadable),
+        )
+    ]
+
+
+def collect(root: Path) -> tuple[list[dict], list[dict], list[str]]:
     rules, skills = [], []
+    unreadable: list[str] = []
 
     rule_paths = sorted(HOME_RULES.glob("*.md")) if HOME_RULES.is_dir() else []
     for dirpath, filenames in walk(root):
@@ -273,7 +323,9 @@ def collect(root: Path) -> tuple[list[dict], list[dict]]:
             and f"{os.sep}skills{os.sep}" in f"{dirpath}{os.sep}"
         ):
             p = dirpath / "SKILL.md"
-            body = p.read_text(encoding="utf-8", errors="replace")
+            body = _read_corpus_file(p, unreadable)
+            if body is None:
+                continue
             fm = frontmatter(body)
             skills.append(
                 {
@@ -290,7 +342,9 @@ def collect(root: Path) -> tuple[list[dict], list[dict]]:
             )
 
     for p in sorted(set(rule_paths)):
-        body = p.read_text(encoding="utf-8", errors="replace")
+        body = _read_corpus_file(p, unreadable)
+        if body is None:
+            continue
         fm = frontmatter(body)
         scope = (
             "user-global"
@@ -318,46 +372,7 @@ def collect(root: Path) -> tuple[list[dict], list[dict]]:
                 "stub": "romoted to a skill" in body[:700],
             }
         )
-    return rules, skills
-
-
-# -------------------------------------------------------------------- waivers
-def _canon(p: str) -> str:
-    """Canonicalise a path for waiver matching.
-
-    Waiver files are hand-written, so a side may be spelled `~/repos/...` or
-    `/var/...` while the scan resolves it to `/private/var/...` (macOS symlinks
-    every temp and `/var` path). Comparing raw strings silently fails to match
-    and the waiver looks ignored, which is indistinguishable from a bug.
-    """
-    return os.path.realpath(os.path.expanduser(p))
-
-
-def load_waivers(path: Path) -> dict[tuple[str, str], dict]:
-    if not path.is_file():
-        return {}
-    try:
-        raw = json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError):
-        return {}
-    return {(_canon(w["a"]), _canon(w["b"])): w for w in raw.get("waivers", [])}
-
-
-def waived(waivers, a: dict, b: dict) -> bool:
-    """A waiver holds only while BOTH sides are byte-identical to when it was filed."""
-    pa, pb = _canon(a["path"]), _canon(b["path"])
-    for key in ((pa, pb), (pb, pa)):
-        w = waivers.get(key)
-        if not w:
-            continue
-        ha, hb = (
-            (w.get("a_hash"), w.get("b_hash"))
-            if key[0] == pa
-            else (w.get("b_hash"), w.get("a_hash"))
-        )
-        if ha == a["hash"] and hb == b["hash"]:
-            return True
-    return False
+    return rules, skills, unreadable
 
 
 # --------------------------------------------------------------------- checks
@@ -388,7 +403,7 @@ def _stub_target(head: str, known: set[str]) -> str | None:
     return refs[0] if refs else None
 
 
-def check_stub_integrity(rules, skills) -> list[dict]:
+def check_stub_integrity(rules, skills) -> list[Finding]:
     known = {s["name"] for s in skills}
     out = []
     for r in rules:
@@ -397,17 +412,17 @@ def check_stub_integrity(rules, skills) -> list[dict]:
         target = _stub_target(r["body"][:700], known)
         if target not in known:
             out.append(
-                {
-                    "severity": "error",
-                    "kind": "broken_pointer_stub",
-                    "summary": f"{r['name']} points at skill '{target or '(none named)'}' which does not exist",
-                    "path": r["path"],
-                }
+                Finding(
+                    "error",
+                    "broken_pointer_stub",
+                    f"{r['name']} points at skill '{target or '(none named)'}' which does not exist",
+                    path=r["path"],
+                )
             )
     return out
 
 
-def check_review_staleness(items, cache: dict, allow_spawn: bool) -> list[dict]:
+def check_review_staleness(items, cache: dict, allow_spawn: bool) -> list[Finding]:
     """Compare each item's declared `reviewed:` against its real last-change date.
 
     One `git log` per file is ~10ms and there are ~900 files, which is far too
@@ -438,18 +453,18 @@ def check_review_staleness(items, cache: dict, allow_spawn: bool) -> list[dict]:
             continue
         if gap > STALE_DAYS:
             out.append(
-                {
-                    "severity": "warn",
-                    "kind": "review_staleness",
-                    "summary": f"{it['name']} changed {gap}d after its declared reviewed:{rv}",
-                    "path": it["path"],
-                    "gap_days": gap,
-                }
+                Finding(
+                    "warn",
+                    "review_staleness",
+                    f"{it['name']} changed {gap}d after its declared reviewed:{rv}",
+                    path=it["path"],
+                    gap_days=gap,
+                )
             )
     return sorted(out, key=lambda x: -x["gap_days"])
 
 
-def check_budget(rules) -> list[dict]:
+def check_budget(rules) -> list[Finding]:
     # A rule in a user-global/portfolio scope is NOT unconditionally injected if
     # it carries `paths:` frontmatter -- it loads only when a matching file is
     # read. Counting those inflates the budget by ~24% on this portfolio (13 of
@@ -461,54 +476,54 @@ def check_budget(rules) -> list[dict]:
         return []
     worst = sorted(always, key=lambda r: -r["chars"])[:3]
     return [
-        {
-            "severity": "warn",
-            "kind": "always_loaded_budget",
-            "summary": (
+        Finding(
+            "warn",
+            "always_loaded_budget",
+            (
                 f"{len(always)} always-loaded rules cost ~{tokens:,} tok/turn "
                 f"(budget {BUDGET_TOKENS:,}); heaviest: "
                 + ", ".join(
                     f"{r['name']}(~{r['chars'] // 4 // 100 * 100:,})" for r in worst
                 )
             ),
-            "tokens": tokens,
-        }
+            tokens=tokens,
+        )
     ]
 
 
-def check_frontmatter(rules) -> list[dict]:
+def check_frontmatter(rules) -> list[Finding]:
     missing = [r for r in rules if not r["fm"].get("reviewed")]
     if not missing:
         return []
     return [
-        {
-            "severity": "info",
-            "kind": "frontmatter_coverage",
-            "summary": f"{len(missing)}/{len(rules)} rules carry no reviewed: date, so staleness cannot be tracked for them",
-        }
+        Finding(
+            "info",
+            "frontmatter_coverage",
+            f"{len(missing)}/{len(rules)} rules carry no reviewed: date, so staleness cannot be tracked for them",
+        )
     ]
 
 
-def check_lexical_dupes(rules, waivers) -> list[dict]:
+def check_lexical_dupes(rules, waivers) -> list[Finding]:
     for r in rules:
         r["_sh"] = shingles(r["body"])
     out = []
     for a, b in combinations(rules, 2):
         s = jaccard(a["_sh"], b["_sh"])
-        if s >= T_LEXICAL and not waived(waivers, a, b):
+        if s >= T_LEXICAL and not waivers.waived(a, b):
             out.append(
-                {
-                    "severity": "warn",
-                    "kind": "duplicate_rule_lexical",
-                    "summary": f"{a['scope']}:{a['name']} and {b['scope']}:{b['name']} are {s:.0%} lexically identical",
-                    "score": round(s, 3),
-                    "paths": [a["path"], b["path"]],
-                }
+                Finding(
+                    "warn",
+                    "duplicate_rule_lexical",
+                    f"{a['scope']}:{a['name']} and {b['scope']}:{b['name']} are {s:.0%} lexically identical",
+                    score=round(s, 3),
+                    paths=[a["path"], b["path"]],
+                )
             )
     return sorted(out, key=lambda x: -x["score"])
 
 
-def check_rule_covered_by_skill(rules, skills, waivers) -> list[dict]:
+def check_rule_covered_by_skill(rules, skills, waivers) -> list[Finding]:
     """Topic containment: how much of a rule's vocabulary a skill already carries.
 
     Full-body Jaccard is the wrong metric here and silently returns zero -- a
@@ -541,37 +556,37 @@ def check_rule_covered_by_skill(rules, skills, waivers) -> list[dict]:
             control_total += 1
             control_hits += score >= T_COVERAGE
             continue
-        if score >= T_COVERAGE and skill and not waived(waivers, r, skill):
+        if score >= T_COVERAGE and skill and not waivers.waived(r, skill):
             out.append(
-                {
-                    "severity": "info",
-                    "kind": "rule_covered_by_skill",
-                    "summary": (
+                Finding(
+                    "info",
+                    "rule_covered_by_skill",
+                    (
                         f"{r['scope']}:{r['name']} is {score:.0%} covered by skill "
                         f"{skill['name']} -- candidate for a pointer stub"
                     ),
-                    "score": round(score, 3),
-                    "paths": [r["path"], skill["path"]],
-                    "always_loaded": r["always_loaded"],
-                }
+                    score=round(score, 3),
+                    paths=[r["path"], skill["path"]],
+                    always_loaded=r["always_loaded"],
+                )
             )
     # Control gate: if the known-good stubs do not surface, the metric is broken
     # and its output must not be trusted (never-fabricate-test-identifiers).
     if control_total and control_hits < max(1, int(0.7 * control_total)):
         out = [
-            {
-                "severity": "error",
-                "kind": "coverage_metric_broken",
-                "summary": (
+            Finding(
+                "error",
+                "coverage_metric_broken",
+                (
                     f"containment metric failed its control: only {control_hits}/{control_total} "
                     "known pointer stubs detected -- coverage findings suppressed"
                 ),
-            }
+            )
         ]
     return sorted(out, key=lambda x: (not x.get("always_loaded"), -x.get("score", 0)))
 
 
-def check_semantic_dupes(items, waivers, cache_path: Path) -> list[dict]:
+def check_semantic_dupes(items, waivers, cache_path: Path) -> list[Finding]:
     import numpy as np
     from fastembed import TextEmbedding
 
@@ -645,23 +660,30 @@ def check_semantic_dupes(items, waivers, cache_path: Path) -> list[dict]:
         # re-reporting them here would double-count every generated rule.
         if a["name"] == b["name"] or structural_pair(a, b):
             continue
-        if s >= T_SEMANTIC and not waived(waivers, a, b):
+        if s >= T_SEMANTIC and not waivers.waived(a, b):
             out.append(
-                {
-                    "severity": "warn",
-                    "kind": f"semantic_overlap_{a['kind']}_{b['kind']}",
-                    "summary": (
+                Finding(
+                    "warn",
+                    f"semantic_overlap_{a['kind']}_{b['kind']}",
+                    (
                         f"{a['kind']} {a['name']} and {b['kind']} {b['name']} "
                         f"are {s:.0%} semantically similar"
                     ),
-                    "score": round(s, 3),
-                    "paths": [a["path"], b["path"]],
-                }
+                    score=round(s, 3),
+                    paths=[a["path"], b["path"]],
+                )
             )
     return sorted(out, key=lambda x: -x["score"])
 
 
 # ---------------------------------------------------------------------- output
+# DELIBERATE, not an oversight: `lib.probe.render_status` already emits the
+# conformant block (`ISSUE_COUNT=` plus the closing `=== END ... ===`) that the
+# renderer below lacks, and this PR keeps `emit_status` / `emit_report`
+# byte-identical so `--format=json` and `--format=status` can be `cmp`-verified
+# against the pre-extraction analyzer on the real corpus. Two status renderers
+# coexist for exactly one PR; the follow-up that normalises the shape switches
+# this call site over and deletes this one.
 def emit_status(findings, counts):
     print("=== CONFIG DRIFT ===")
     for k, v in counts.items():
@@ -679,6 +701,12 @@ def emit_status(findings, counts):
     print("STATUS=" + ("ERROR" if errs else "WARN" if warns else "OK"))
 
 
+# DEAD CODE, deliberately retained for THIS PR only. No caller invokes
+# `--format=probe`: hooks/config-drift-probe.sh consumes `--format=json` and
+# re-derives the remediation map in jq. It stays because this PR's whole claim
+# is that no output changed, and deleting a public `--format` choice would turn
+# a byte-identity refactor into a CLI-surface removal. #2527b deletes it and the
+# `"probe"` choice together, as an intentional change with its own rationale.
 def emit_probe(findings):
     """drift-protocol shape: severity/kind/summary/remediation_skill."""
     remediation = {
@@ -786,15 +814,16 @@ def main() -> int:
         print(f"root not found: {root}", file=sys.stderr)
         return 3
 
-    rules, skills = collect(root)
-    waivers = load_waivers(Path(args.waivers).expanduser())
+    rules, skills, unreadable = collect(root)
+    waivers = Waivers.load(Path(args.waivers).expanduser())
 
-    findings: list[dict] = []
+    findings: list[Finding] = []
     findings += check_stub_integrity(rules, skills)
     findings += check_budget(rules)
     findings += check_lexical_dupes(rules, waivers)
     findings += check_rule_covered_by_skill(rules, skills, waivers)
     findings += check_frontmatter(rules)
+    findings += check_corpus_unreadable(unreadable)
 
     datecache_path = Path(args.cache).expanduser().with_name("gitdates.json")
     datecache: dict = {}
@@ -818,11 +847,11 @@ def main() -> int:
             )
         except Exception as exc:  # noqa: BLE001 - degrade loudly, never silently
             findings.append(
-                {
-                    "severity": "info",
-                    "kind": "semantic_pass_unavailable",
-                    "summary": f"semantic pass skipped: {type(exc).__name__}: {exc}",
-                }
+                Finding(
+                    "info",
+                    "semantic_pass_unavailable",
+                    f"semantic pass skipped: {type(exc).__name__}: {exc}",
+                )
             )
 
     if args.since:
@@ -849,7 +878,7 @@ def main() -> int:
         "status": emit_status,
         "probe": lambda f, c: emit_probe(f),
         "report": emit_report,
-        "json": lambda f, c: print(json.dumps({"counts": c, "findings": f}, indent=1)),
+        "json": lambda f, c: print(render_json(f, c, indent=1)),
     }[args.format](findings, counts)
 
     errs = sum(1 for f in findings if f["severity"] == "error")

--- a/health-plugin/scripts/lib/probe.py
+++ b/health-plugin/scripts/lib/probe.py
@@ -1,0 +1,390 @@
+"""probe — the finding / waiver / delta contract shared by drift probes.
+
+This module holds the parts of a probe that OTHER probes must agree with, and
+nothing else. The similarity computation, the thresholds, the corpus walk and
+the seven `check_*` functions stay in `config-drift.py`: they are one probe's
+opinion, and a second probe adopting them would be adopting a bug, not a
+contract.
+
+What is contract, and why:
+
+* `sha` — sha256 truncated to 16 hex chars. The truncation LENGTH is the
+  contract. A waiver records both sides' content hashes and a baseline record
+  is keyed by a fingerprint built from the same helper, so two probes
+  truncating differently cannot share a waiver file or a baseline.
+* `Finding` — one shape for a reported problem, dict-compatible so existing
+  consumers keep reading `f["kind"]` / `f.get("paths")` unchanged. Key order in
+  `to_dict()` comes from the `**extra` kwargs order, so a call site reproduces
+  its own dict literal by construction rather than against a hand-maintained
+  canonical key list.
+* `fingerprint` — identity of a finding ACROSS runs, so a delta report can say
+  "this one is new" without diffing prose. It deliberately folds a singular
+  `path` into the path set (see the function).
+* `Waivers` — the two-orientation lookup. A waiver file is hand-written, so
+  either side may be spelled first; a probe that only tried one orientation
+  would silently ignore half the file.
+* `Baseline` / `Delta` — remembering what was already reported.
+* `render_status` / `render_json` / `exit_code` — the output contract an
+  orchestrating skill greps. `render_status` emits the shape
+  `.claude/rules/structured-script-output.md` mandates: `=== SECTION ===` /
+  `=== END SECTION ===` delimiters, uppercase `KEY=VALUE` lines, an
+  `ISSUE_COUNT=` roll-up, and a `STATUS=` drawn from `OK|WARN|ERROR` and no
+  other word — a rollup matches that alternation, so a fourth verdict is
+  invisible rather than distinct.
+
+Stdlib only, and deliberately NO PEP-723 dependency block: both real callers
+(`hooks/config-drift-probe.sh` and the test suite) invoke a bare `python3`,
+bypassing the uv shebang, so a dependency block would resolve only on the
+unused path. A broken import here fails SILENTLY — the hook treats empty
+analyzer output as "no findings" — which is why this file must never grow an
+import that a bare interpreter cannot satisfy.
+
+Import it as `from lib.probe import ...`: `sys.path[0]` is the SCRIPT's
+directory (`health-plugin/scripts`), not `lib/`, and PEP 420 implicit
+namespace packages resolve `lib.probe` from there. There is no `__init__.py`
+and there must not be one — nothing under `*-plugin/scripts/` is a package.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from pathlib import Path
+
+BASELINE_SCHEMA = 1
+
+_SEVERITIES = ("error", "warn", "info")
+# A SHAPE check, not an enum: `semantic_overlap_{a}_{b}` is a dynamic f-string,
+# so the set of legal kinds is not enumerable here.
+_KIND_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+# --------------------------------------------------------------------- hashing
+def sha(text: str) -> str:
+    """sha256 of `text`, truncated to 16 hex chars.
+
+    The 16 is contract. Waiver hashes and fingerprints both flow through this
+    helper, so a probe that truncated to 12 or 20 would produce a waiver file
+    and a baseline no other probe could read.
+    """
+    return hashlib.sha256(text.encode("utf-8", "replace")).hexdigest()[:16]
+
+
+# -------------------------------------------------------------------- findings
+class Finding:
+    """One reported problem, dict-compatible on read.
+
+    `__getitem__` / `get` exist so a consumer written against dict literals —
+    a sort lambda, a renderer, a `--since` filter — keeps working unchanged.
+    Key order in `to_dict()` is the order the caller passed `**extra`, which is
+    what lets each construction site reproduce its former dict literal exactly.
+    """
+
+    __slots__ = ("severity", "kind", "summary", "extra")
+
+    def __init__(self, severity: str, kind: str, summary: str, **extra):
+        if severity not in _SEVERITIES:
+            raise ValueError(f"severity must be one of {_SEVERITIES}, got {severity!r}")
+        if not isinstance(kind, str) or not _KIND_RE.match(kind):
+            raise ValueError(f"kind must match {_KIND_RE.pattern}, got {kind!r}")
+        if not summary:
+            raise ValueError("summary must be non-empty")
+        if "path" in extra and "paths" in extra:
+            raise ValueError(
+                "a finding carries `path` OR `paths`, never both — "
+                "fingerprint() folds the singular into the set and two "
+                "spellings of the same fact would double-count"
+            )
+        self.severity = severity
+        self.kind = kind
+        self.summary = summary
+        self.extra = extra
+
+    def __getitem__(self, key):
+        if key in ("severity", "kind", "summary"):
+            return getattr(self, key)
+        return self.extra[key]
+
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def __contains__(self, key) -> bool:
+        return key in ("severity", "kind", "summary") or key in self.extra
+
+    def to_dict(self) -> dict:
+        return {
+            "severity": self.severity,
+            "kind": self.kind,
+            "summary": self.summary,
+            **self.extra,
+        }
+
+    def __repr__(self) -> str:
+        return f"Finding({self.severity!r}, {self.kind!r}, {self.summary!r}, **{self.extra!r})"
+
+
+def fingerprint(finding) -> str:
+    """Stable identity of a finding across runs: kind + its path set.
+
+    The singular `path` key is FOLDED into the path set. Read naively as
+    "paths only", every `broken_pointer_stub` (which carries `path`) would
+    collapse to one fingerprint per kind, so the second broken stub in a corpus
+    would be invisible in every delta report forever. Folding both is also what
+    makes a later normalisation of `path` -> `paths` fingerprint-neutral.
+
+    A finding with no path at all — `always_loaded_budget`,
+    `frontmatter_coverage`, `coverage_metric_broken`,
+    `semantic_pass_unavailable` — gets one stable fingerprint per kind. That is
+    correct: a changing token count or a different exception message must not
+    make the same standing condition look new on every run.
+    """
+    paths = list(finding.get("paths") or [])
+    single = finding.get("path")
+    if single:
+        paths.append(single)
+    return sha(finding["kind"] + "\0" + "\0".join(sorted(set(paths))))
+
+
+# --------------------------------------------------------------------- waivers
+class Waivers:
+    """Pair-keyed waivers that expire when either side's content changes."""
+
+    __slots__ = ("_by_pair",)
+
+    def __init__(self, by_pair=None):
+        self._by_pair = dict(by_pair or {})
+
+    @staticmethod
+    def _canon(path: str) -> str:
+        """Canonicalise a path for waiver matching.
+
+        Waiver files are hand-written, so a side may be spelled `~/repos/...`
+        or `/var/...` while the scan resolves it to `/private/var/...` (macOS
+        symlinks every temp and `/var` path). Comparing raw strings silently
+        fails to match and the waiver looks ignored, which is
+        indistinguishable from a bug.
+        """
+        return os.path.realpath(os.path.expanduser(path))
+
+    @classmethod
+    def load(cls, path) -> "Waivers":
+        path = Path(path)
+        if not path.is_file():
+            return cls({})
+        try:
+            raw = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return cls({})
+        return cls(
+            {
+                (cls._canon(w["a"]), cls._canon(w["b"])): w
+                for w in raw.get("waivers", [])
+            }
+        )
+
+    def __len__(self) -> int:
+        return len(self._by_pair)
+
+    def waived(self, a: dict, b: dict) -> bool:
+        """A waiver holds only while BOTH sides are byte-identical to when it was filed.
+
+        Both orientations are tried, and the recorded hash pair is swapped to
+        match whichever orientation hit — a waiver filed as (a, b) must still
+        suppress the pair when the scan happens to yield (b, a).
+        """
+        pa, pb = self._canon(a["path"]), self._canon(b["path"])
+        for key in ((pa, pb), (pb, pa)):
+            w = self._by_pair.get(key)
+            if not w:
+                continue
+            ha, hb = (
+                (w.get("a_hash"), w.get("b_hash"))
+                if key[0] == pa
+                else (w.get("b_hash"), w.get("a_hash"))
+            )
+            if ha == a["hash"] and hb == b["hash"]:
+                return True
+        return False
+
+
+# -------------------------------------------------------------- baseline/delta
+class Delta:
+    """What changed between a baseline and the current findings."""
+
+    __slots__ = ("first_run", "new", "resolved", "carried")
+
+    def __init__(self, first_run: bool, new: list, resolved: list, carried: list):
+        self.first_run = first_run
+        self.new = new
+        self.resolved = resolved
+        self.carried = carried
+
+
+class Baseline:
+    """The set of findings a probe has already reported, keyed by fingerprint.
+
+    `root` is load-bearing, not bookkeeping. Fingerprints are built from
+    ABSOLUTE paths, so a baseline recorded at one root and compared at another
+    yields a DISJOINT set: every current finding new, every stored one
+    resolved — a maximally noisy false report. `load` returns None on a root
+    (or schema) mismatch exactly as it does for a missing file, so the caller
+    records fresh and stays silent instead.
+    """
+
+    __slots__ = ("probe", "root", "recorded_at", "findings", "loaded")
+
+    def __init__(self, probe, root, recorded_at, findings=None, loaded=False):
+        self.probe = probe
+        self.root = str(root)
+        self.recorded_at = recorded_at
+        self.findings = dict(findings or {})
+        self.loaded = loaded
+
+    @classmethod
+    def load(cls, path, root=None, probe=None) -> "Baseline | None":
+        """Read a baseline, or None when it cannot be trusted.
+
+        None for: missing, unreadable, unparseable, wrong schema, wrong root,
+        wrong probe, or a `findings` block that is not a mapping. Every one of
+        those means "compare nothing", never "everything is new".
+        """
+        try:
+            raw = json.loads(Path(path).read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return None
+        if not isinstance(raw, dict):
+            return None
+        if raw.get("schema") != BASELINE_SCHEMA:
+            return None
+        if root is not None and raw.get("root") != str(root):
+            return None
+        if probe is not None and raw.get("probe") != probe:
+            return None
+        findings = raw.get("findings")
+        if not isinstance(findings, dict):
+            return None
+        return cls(
+            raw.get("probe"),
+            raw.get("root"),
+            raw.get("recorded_at"),
+            findings,
+            loaded=True,
+        )
+
+    def record(self, findings) -> "Baseline":
+        """Replace the stored records with the given findings."""
+        self.findings = {
+            fingerprint(f): {
+                "severity": f["severity"],
+                "kind": f["kind"],
+                "summary": f["summary"],
+            }
+            for f in findings
+        }
+        return self
+
+    def save(self, path) -> None:
+        """Write atomically: temp file in the same directory, then os.replace.
+
+        The consumer is an unattended scheduled job that can be killed
+        mid-write, and a truncated baseline that still parses as `{}` would
+        report the whole corpus as new on the next run.
+        """
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_name(path.name + ".tmp")
+        tmp.write_text(
+            json.dumps(
+                {
+                    "schema": BASELINE_SCHEMA,
+                    "probe": self.probe,
+                    "root": self.root,
+                    "recorded_at": self.recorded_at,
+                    "findings": self.findings,
+                },
+                indent=1,
+            ),
+            encoding="utf-8",
+        )
+        os.replace(tmp, path)
+
+    def delta(self, findings) -> Delta:
+        seen: dict[str, object] = {}
+        for f in findings:
+            seen.setdefault(fingerprint(f), f)
+        new = [f for fp, f in seen.items() if fp not in self.findings]
+        carried = [f for fp, f in seen.items() if fp in self.findings]
+        resolved = [rec for fp, rec in self.findings.items() if fp not in seen]
+        return Delta(not self.loaded, new, resolved, carried)
+
+
+# --------------------------------------------------------------------- output
+def exit_code(findings, gate: bool = False) -> int:
+    """0 clean, 1 anything error-or-warn, 2 gate + at least one error.
+
+    Exit 3 (root not a directory) deliberately stays in the caller: that is
+    argument validation, not a statement about findings.
+    """
+    errs = sum(1 for f in findings if f["severity"] == "error")
+    if gate and errs:
+        return 2
+    return 1 if any(f["severity"] in ("error", "warn") for f in findings) else 0
+
+
+def render_json(findings, counts, indent: int = 1) -> str:
+    """The `--format=json` document: counts first, then the findings array."""
+    return json.dumps(
+        {"counts": counts, "findings": [f.to_dict() for f in findings]}, indent=indent
+    )
+
+
+def render_status(section: str, findings, counts) -> str:
+    """A conformant `structured-script-output.md` block.
+
+    Conformant means it carries the closing `=== END <section> ===` delimiter
+    and an `ISSUE_COUNT=` roll-up, which config-drift's own `emit_status` does
+    not — that one predates the convention and is kept byte-identical for now.
+
+    `STATUS` is `OK` / `WARN` / `ERROR` and nothing else. That vocabulary is
+    fixed by `.claude/rules/structured-script-output.md`, and a rollup greps
+    `STATUS=(OK|WARN|ERROR)`: a fourth word (`CLEAN`, `FAIL`, `GOOD`) does not
+    read as a distinction, it drops the section out of the table silently.
+    There is deliberately no override parameter — a caller rendering an empty
+    list is `OK`, which is what "nothing new" already means. A consumer that
+    wants to say more says it in `counts` (`FIRST_RUN=true`, `NEW=0`), where a
+    new key adds information instead of breaking an existing match.
+
+    The severity counters are `NEW_ERRORS=` / `NEW_WARNINGS=`, not
+    `ERRORS=` / `WARNINGS=`, because `findings` here is the SUBSET the caller
+    chose to render while its `counts` carries the full total —
+    `config-drift.py`'s `emit_status` already writes `ERRORS=`/`WARNINGS=` over
+    the whole set, so reusing those names would give a combined-log rollup two
+    contradictory answers to one `grep '^ERRORS='`.
+    """
+    lines = [f"=== {section} ==="]
+    for key, value in counts.items():
+        lines.append(f"{key.upper()}={value}")
+    by_kind: dict[str, int] = {}
+    for f in findings:
+        by_kind[f["kind"]] = by_kind.get(f["kind"], 0) + 1
+    for kind, n in sorted(by_kind.items()):
+        lines.append(f"FINDING_{kind.upper()}={n}")
+    errs = sum(1 for f in findings if f["severity"] == "error")
+    warns = sum(1 for f in findings if f["severity"] == "warn")
+    lines.append(f"NEW_ERRORS={errs}")
+    lines.append(f"NEW_WARNINGS={warns}")
+    lines.append("STATUS=" + ("ERROR" if errs else "WARN" if warns else "OK"))
+    lines.append(f"ISSUE_COUNT={len(findings)}")
+    if findings:
+        lines.append("ISSUES:")
+        for f in findings:
+            lines.append(
+                f"  - SEVERITY={f['severity'].upper()} TYPE={f['kind']} MSG={f['summary']}"
+            )
+    lines.append(f"=== END {section} ===")
+    return "\n".join(lines)

--- a/health-plugin/scripts/probe-delta.py
+++ b/health-plugin/scripts/probe-delta.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""probe-delta — report only the findings a probe has not reported before.
+
+Reads a probe's `--format=json` document on stdin (or from a file) and compares
+it against a stored baseline, so a recurring report says "one new thing" rather
+than repeating a corpus-sized list that a reader learns to skip.
+
+    python3 probe-delta.py --findings - --baseline <path> --probe config-drift \\
+        --root <abs> [--record] [--section "CONFIG DRIFT DELTA"]
+
+Behaviour:
+
+* No baseline — or one recorded at a different root, or under a different
+  schema — records fresh and reports `STATUS=OK FIRST_RUN=true`. A baseline
+  from another root would compare two disjoint fingerprint sets and call every
+  finding new AND every stored one resolved, so refusing to compare is the only
+  honest answer.
+* Nothing new: `STATUS=OK NEW=0 ISSUE_COUNT=0`.
+* New findings: `STATUS=WARN`/`ERROR`, rendering ONLY the new ones, counted by
+  `NEW_ERRORS=`/`NEW_WARNINGS=` — deliberately not the `ERRORS=`/`WARNINGS=`
+  that `config-drift.py --format=status` writes over the FULL finding set.
+* Empty or unparseable input: `STATUS=ERROR TYPE=analyzer_failed`, never a
+  clean sweep. An analyzer that died and one that found nothing produce the
+  same empty stdout; reporting the latter would launder a broken probe into a
+  green report.
+
+This is the second consumer of `lib.probe`, and it touches no `check_*` code —
+that is the claim the extraction makes: the finding/waiver/delta contract is
+separable from the similarity computation that produced the findings.
+
+Stdlib only, invoked with a bare `python3`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+
+# See lib/probe.py's module docstring for why this is the dotted namespace form.
+from lib.probe import Baseline, Finding, exit_code, render_status
+
+
+def _now() -> str:
+    """The module never calls now() itself — timestamps come from the caller."""
+    return dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds")
+
+
+def _analyzer_failed(section: str, probe: str, root: str, msg: str) -> str:
+    return "\n".join(
+        [
+            f"=== {section} ===",
+            f"PROBE={probe}",
+            f"ROOT={root}",
+            "FIRST_RUN=false",
+            "STATUS=ERROR",
+            "TYPE=analyzer_failed",
+            "ISSUE_COUNT=1",
+            f"MSG={msg}",
+            f"=== END {section} ===",
+        ]
+    )
+
+
+def _parse(raw: str) -> list:
+    """Turn a probe's JSON document into Findings, or raise.
+
+    Accepts the full `{"counts": ..., "findings": [...]}` document and a bare
+    findings array, because a caller piping `jq .findings` is the obvious thing
+    to do and failing on it would be a papercut with no upside.
+    """
+    payload = json.loads(raw)
+    items = payload.get("findings") if isinstance(payload, dict) else payload
+    if not isinstance(items, list):
+        raise ValueError("no findings array in input")
+    out = []
+    for d in items:
+        extra = {k: v for k, v in d.items() if k not in ("severity", "kind", "summary")}
+        out.append(Finding(d["severity"], d["kind"], d["summary"], **extra))
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "--findings",
+        default="-",
+        help="path to a probe's --format=json output, or - for stdin",
+    )
+    ap.add_argument("--baseline", required=True, help="path to the baseline file")
+    ap.add_argument(
+        "--probe", required=True, help="probe name recorded in the baseline"
+    )
+    ap.add_argument(
+        "--root", required=True, help="absolute root the findings were collected at"
+    )
+    ap.add_argument(
+        "--record",
+        action="store_true",
+        help="update the baseline after reporting (a first run always records)",
+    )
+    ap.add_argument("--section", default=None, help="section header for the report")
+    # argparse rejects an unknown argument with usage on stderr and exit 2,
+    # which is the contract here -- a swallowed flag is how a bounded run turns
+    # into an unbounded one.
+    args = ap.parse_args()
+
+    section = args.section or f"{args.probe.upper()} DELTA"
+    root = str(Path(args.root).expanduser().resolve())
+
+    if args.findings == "-":
+        raw = sys.stdin.read()
+    else:
+        try:
+            raw = Path(args.findings).read_text(encoding="utf-8")
+        except OSError as exc:
+            print(
+                _analyzer_failed(section, args.probe, root, f"unreadable input: {exc}")
+            )
+            return 1
+
+    if not raw.strip():
+        print(_analyzer_failed(section, args.probe, root, "empty analyzer output"))
+        return 1
+    try:
+        findings = _parse(raw)
+    except (ValueError, TypeError, AttributeError, KeyError) as exc:
+        print(
+            _analyzer_failed(section, args.probe, root, f"{type(exc).__name__}: {exc}")
+        )
+        return 1
+
+    baseline = Baseline.load(args.baseline, root=root, probe=args.probe)
+    if baseline is None:
+        baseline = Baseline(args.probe, root, _now())
+    delta = baseline.delta(findings)
+
+    # On a first run every finding is trivially "new", which is noise rather
+    # than news -- record it and stay silent.
+    reported = [] if delta.first_run else delta.new
+
+    counts = {
+        "probe": args.probe,
+        "root": root,
+        "first_run": "true" if delta.first_run else "false",
+        "total_findings": len(findings),
+        "new": len(reported),
+        "resolved": len(delta.resolved),
+        "carried": len(delta.carried),
+    }
+
+    if delta.first_run or args.record:
+        try:
+            Baseline(args.probe, root, _now()).record(findings).save(args.baseline)
+            counts["baseline_written"] = "true"
+        except OSError as exc:
+            counts["baseline_written"] = "failed"
+            counts["baseline_error"] = type(exc).__name__
+
+    # No STATUS override: `render_status` derives OK/WARN/ERROR, and OK over an
+    # empty `reported` list IS "nothing new". The distinction a reader wants —
+    # nothing new vs. nothing at all vs. never run before — is carried by
+    # `NEW=`, `TOTAL_FINDINGS=` and `FIRST_RUN=` above, which add a key rather
+    # than putting a fourth word where a rollup greps for three.
+    print(render_status(section, reported, counts))
+    return exit_code(reported)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/health-plugin/scripts/tests/compare-ref-output.sh
+++ b/health-plugin/scripts/tests/compare-ref-output.sh
@@ -1,0 +1,464 @@
+#!/usr/bin/env bash
+# compare-ref-output.sh — byte-identity gate for the config-drift contract extraction.
+#
+# DELIBERATELY NOT NAMED test-*.sh. `scripts/run-skill-script-tests.sh` discovers
+# `*/scripts/tests/test-*.sh`, and this script is only meaningful while the base
+# ref it compares against is still resolvable. Once that ref ages out of the
+# clone (or the follow-up PR normalises the finding shape ON PURPOSE), a
+# discovered test would go red for a reason nobody can act on — a gate everyone
+# learns to bypass. Run it by hand, as the acceptance check for the extraction.
+#
+# WHAT IT PROVES
+# Moving nine finding-construction sites, three renderers, two caches and a
+# two-orientation waiver lookup has no cheap total oracle other than the output
+# itself. So: check out the analyzer AS IT WAS at the base ref, run it and the
+# current one BACK-TO-BACK over the same corpus, and `cmp` the bytes.
+#
+#   --format=report and --format=probe are EXCLUDED: both embed
+#   `datetime.now()`, so two runs of the SAME file differ whenever the clock
+#   ticks between them and the comparison would assert nothing.
+#
+# TWO CORPORA, because the real ones do not reach most of the code
+# ------------------------------------------------------------------
+# At this repo's root and the portfolio root, only four of the nine
+# construction sites ever fire: review_staleness, rule_covered_by_skill,
+# frontmatter_coverage and duplicate_rule_lexical. A comparison over those
+# alone leaves `broken_pointer_stub` (the ONLY site passing a singular `path=`,
+# i.e. exactly where "kwargs order == dict-literal order" could break),
+# `always_loaded_budget` (the only `tokens=`) and `coverage_metric_broken`
+# unexercised — and with no `~/.claude/config-drift-waivers.json` on this
+# machine, the two-orientation waiver lookup and `_canon` are not exercised
+# either. So a SYNTHETIC root is built under `mktemp -d` with `HOME` redirected
+# (which is what puts `HOME_RULES` and the default waiver path under our
+# control) and compared the same way.
+#
+# The synthetic corpus is guarded: after the comparison, the AFTER-side JSON is
+# asserted to contain every kind it was built to fire, and to be missing the
+# two waived pairs while still reporting the expired one. Without that guard a
+# fixture that silently stopped firing would still `cmp` clean — an empty run
+# and a working one produce the same verdict, and only the guard tells them
+# apart (`~/.claude/rules/never-fabricate-test-identifiers.md`).
+#
+# NOT exercised, deliberately: `semantic_overlap_*` and (therefore)
+# `semantic_pass_unavailable` as an embed-path finding. The semantic pass needs
+# numpy + fastembed, which a bare `python3` — the interpreter both real callers
+# use — does not have, and installing them to fire one construction site would
+# make this acceptance check depend on a download. It is acceptable because
+# `semantic_overlap_*` carries the SAME key shape as the verified
+# `duplicate_rule_lexical` (`severity, kind, summary, score, paths`, in that
+# order), so the property under test — the emitted key order comes from the
+# call site's kwargs — is already pinned by a site with an identical signature.
+#
+# `test-probe-lib.sh` TEST b constructs that shape BY HAND, so it is a retyped
+# copy of the call site, not the call site (never-fabricate-test-identifiers.md
+# § extract the code, don't retype it): a wrong kwarg name or order in the
+# shipped `check_semantic_dupes` would leave it green. The site was instead
+# verified by EXECUTION during review — the shipped function was loaded out of
+# both origin/main and this branch with stubbed numpy/fastembed and forced
+# similarity, and emitted byte-identical findings. Treat this exclusion as
+# "verified once by hand", not "covered by a test".
+#
+# `git show`, not `git worktree add`: no worktree is registered in this shared
+# checkout, and registering one would expose this run to the coworker-collision
+# hazards in .claude/rules/agent-coworker-detection.md for no benefit — a single
+# file read out of a ref cannot collide with anything.
+#
+# STATUS vocabulary: this script predates and sits outside the
+# `structured-script-output.md` OK/WARN/ERROR rollup (it is hand-run, not
+# discovered), and keeps its own FAIL/OK words. `STATUS=HARNESS_ERROR` (exit 2)
+# is a THIRD outcome on purpose — see below.
+#
+# TWO WAYS THIS GATE STOPS MEANING ANYTHING, both HARNESS_ERROR:
+#   * the ref AGES OUT of the clone — loud, `git show` fails, already handled.
+#   * the ref becomes IDENTICAL to the working tree — SILENT, and it happens
+#     FIRST: BASE_REF defaults to origin/main, so the moment this PR merges,
+#     `cmp` compares the analyzer with itself and reports 7 green assertions
+#     having compared nothing. Identity is asserted against right after the
+#     extraction, below.
+#
+# Usage: bash health-plugin/scripts/tests/compare-ref-output.sh [BASE_REF]
+#        BASE_REF defaults to $BASE_REF, then origin/main.
+#
+# Exit: 0 identical, 1 a real content difference, 2 the harness itself failed.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+AFTER="${REPO_ROOT}/health-plugin/scripts/config-drift.py"
+REL="health-plugin/scripts/config-drift.py"
+LIB_REL="health-plugin/scripts/lib/probe.py"
+BASE_REF="${1:-${BASE_REF:-origin/main}}"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "SKIP: python3 not available"
+    exit 0
+fi
+
+TMP=$(mktemp -d) || { echo "FAIL: mktemp failed" >&2; exit 1; }
+if [ -z "$TMP" ] || [ ! -d "$TMP" ]; then
+    echo "FAIL: could not create scratch dir" >&2
+    exit 1
+fi
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+HARNESS=0
+
+# harness_fail <msg...> — the harness could not produce a trustworthy BEFORE
+# side. Distinct from FAIL on purpose: a harness that cannot run the baseline
+# must never be able to report a CONTENT difference, because "the baseline
+# produced 0 bytes" and "the baseline produced a different report" look
+# identical downstream of `cmp`.
+harness_fail() {
+    HARNESS=$((HARNESS + 1))
+    printf '  HARNESS ERROR %s\n' "$1"
+    shift
+    for line in "$@"; do
+        printf '     %s\n' "$line"
+    done
+}
+
+finish() {
+    echo "PASSED=$PASS"
+    echo "FAILED=$FAIL"
+    echo "HARNESS_ERRORS=$HARNESS"
+    if [ "$HARNESS" -gt 0 ]; then
+        echo "STATUS=HARNESS_ERROR"
+        echo "=== END CONFIG DRIFT REF COMPARISON ==="
+        exit 2
+    fi
+    if [ "$FAIL" -gt 0 ]; then
+        echo "STATUS=FAIL"
+        echo "=== END CONFIG DRIFT REF COMPARISON ==="
+        exit 1
+    fi
+    echo "STATUS=OK"
+    echo "=== END CONFIG DRIFT REF COMPARISON ==="
+    exit 0
+}
+
+echo "=== CONFIG DRIFT REF COMPARISON ==="
+echo "BASE_REF=$BASE_REF"
+echo "BEFORE_SHA=$(git -C "$REPO_ROOT" rev-parse --short "${BASE_REF}" 2>/dev/null || echo unknown)"
+
+BEFORE="$TMP/config-drift.py"
+if ! git -C "$REPO_ROOT" show "${BASE_REF}:${REL}" > "$BEFORE" 2>"$TMP/git.err"; then
+    harness_fail "cannot read ${BASE_REF}:${REL}" "$(sed -n '1,3p' "$TMP/git.err")"
+    finish
+fi
+
+# The BEFORE analyzer imports `lib.probe` from its own directory (sys.path[0])
+# for every ref at or after this PR. Extracting only config-drift.py into a
+# scratch dir with no lib/ makes it die with `ModuleNotFoundError: No module
+# named 'lib'` — 0 bytes on stdout, exit 1 — and exit 1 is ALSO what a healthy
+# run with warn-severity findings returns, so the exit-code guard below would
+# pass and `cmp` would report the entire report as newly added. Extract the
+# module too, when the ref has one; a ref that predates it (origin/main today)
+# simply has no such path and needs nothing.
+if git -C "$REPO_ROOT" cat-file -e "${BASE_REF}:${LIB_REL}" 2>/dev/null; then
+    mkdir -p "$TMP/lib"
+    if ! git -C "$REPO_ROOT" show "${BASE_REF}:${LIB_REL}" > "$TMP/lib/probe.py" 2>"$TMP/git.err"; then
+        harness_fail "cannot read ${BASE_REF}:${LIB_REL}" "$(sed -n '1,3p' "$TMP/git.err")"
+        finish
+    fi
+    echo "BEFORE_LIB=extracted"
+else
+    echo "BEFORE_LIB=absent-at-ref"
+fi
+
+# `cmp` will happily compare a file with itself and call it a pass. BASE_REF
+# defaults to origin/main, so once this PR lands the baseline IS the analyzer
+# under test and every re-run reports PASSED=7 FAILED=0 STATUS=OK having
+# compared nothing — the gate self-neutralizes, silently, at the moment it stops
+# being able to prove anything. That is a HARNESS ERROR, not a pass: the harness
+# could not produce a trustworthy BEFORE side.
+if cmp -s "$BEFORE" "$AFTER"; then
+    harness_fail "baseline at $BASE_REF is byte-identical to the analyzer under test — nothing is being compared" \
+        "pass an OLDER ref: bash $0 <ref-before-the-extraction>"
+    finish
+fi
+
+# compare <label> <root> <fmt> [home]
+#   Runs BEFORE and AFTER back-to-back with identical flags and compares bytes.
+#   `home` redirects HOME for BOTH runs, which is how the synthetic root gets a
+#   controlled HOME_RULES and default waiver path.
+#   Publishes the AFTER stdout path as $LAST_AFTER; the synthetic-coverage guard
+#   below reads it rather than reconstructing the filename itself.
+LAST_AFTER=""
+compare() {
+    local label="$1" root="$2" fmt="$3" home="${4:-}"
+    local tag
+    tag=$(printf '%s' "$label" | tr -c 'A-Za-z0-9' '_')
+    local b_out="$TMP/before.$tag" a_out="$TMP/after.$tag"
+    local b_rc a_rc
+
+    # Back-to-back, same flags, same caches (--fast never writes the git-date
+    # cache, so the real cache is read-only here and both runs see it warm --
+    # which is what keeps the staleness findings in the comparison).
+    if [ -n "$home" ]; then
+        HOME="$home" python3 "$BEFORE" --root "$root" --fast --no-embed "--format=$fmt" > "$b_out" 2>"$TMP/b.err"
+        b_rc=$?
+        HOME="$home" python3 "$AFTER" --root "$root" --fast --no-embed "--format=$fmt" > "$a_out" 2>"$TMP/a.err"
+        a_rc=$?
+    else
+        python3 "$BEFORE" --root "$root" --fast --no-embed "--format=$fmt" > "$b_out" 2>"$TMP/b.err"
+        b_rc=$?
+        python3 "$AFTER" --root "$root" --fast --no-embed "--format=$fmt" > "$a_out" 2>"$TMP/a.err"
+        a_rc=$?
+    fi
+    LAST_AFTER="$a_out"
+
+    # The BEFORE side is the ORACLE, and it is untrustworthy on TWO channels.
+    # Both are classified here and return WITHOUT reaching cmp, because
+    # harness_fail's contract is that a harness which cannot run the baseline
+    # must never be able to report a CONTENT difference.
+    #
+    # Channel 2 (empty stdout) is not a heuristic: both --format=json and
+    # --format=status print unconditionally, so a BEFORE run that produced 0
+    # bytes DID NOT RUN. Reaching cmp with it makes the entire AFTER report look
+    # newly added — 6 content FAILs and 0 harness errors, exactly the outcome
+    # the docstring above says must be impossible. Stderr alone does not catch
+    # it: a base ref whose analyzer is `import sys; sys.exit(1)` writes nothing
+    # anywhere.
+    if [ ! -s "$b_out" ]; then
+        harness_fail "$label — the BEFORE (oracle) run produced 0 bytes on stdout; --format=$fmt prints unconditionally, so the baseline did not run" \
+            "exit $b_rc" \
+            "$(sed -n '1,4p' "$TMP/b.err")"
+        return 2
+    fi
+    if [ -s "$TMP/b.err" ]; then
+        harness_fail "$label — the BEFORE (oracle) run wrote to stderr; its output cannot be trusted" \
+            "exit $b_rc, $(wc -c < "$b_out" | tr -d ' ') bytes on stdout" \
+            "$(sed -n '1,4p' "$TMP/b.err")"
+        return 2
+    fi
+
+    if [ "$b_rc" != "$a_rc" ]; then
+        FAIL=$((FAIL + 1))
+        printf '  FAIL %s\n     exit code %s -> %s\n' "$label" "$b_rc" "$a_rc"
+        return 1
+    fi
+    if cmp -s "$b_out" "$a_out"; then
+        PASS=$((PASS + 1))
+        printf '  ok   %s (exit %s, %s bytes identical)\n' "$label" "$a_rc" "$(wc -c < "$a_out" | tr -d ' ')"
+    else
+        FAIL=$((FAIL + 1))
+        printf '  FAIL %s\n' "$label"
+        diff -u "$b_out" "$a_out" | head -40 | sed 's/^/     /'
+        return 1
+    fi
+    if [ -s "$TMP/a.err" ]; then
+        FAIL=$((FAIL + 1))
+        printf '  FAIL %s wrote to stderr\n' "$label"
+        sed -n '1,5p' "$TMP/a.err" | sed 's/^/     /'
+        return 1
+    fi
+    return 0
+}
+
+# ------------------------------------------------------------- the real roots
+# The two roots the probe actually runs at: this repo, and the portfolio root
+# whose corpus is ~4x larger and spans several scopes.
+ROOTS=("$REPO_ROOT")
+if [ -d "$HOME/repos/laurigates" ]; then
+    ROOTS+=("$HOME/repos/laurigates")
+else
+    echo "  note  portfolio root $HOME/repos/laurigates absent — comparing repo root only"
+fi
+
+for root in "${ROOTS[@]}"; do
+    for fmt in json status; do
+        compare "$fmt @ $root" "$root" "$fmt"
+        [ "$HARNESS" -gt 0 ] && finish
+    done
+done
+
+# -------------------------------------------------------- the synthetic root
+SYNTH=$(mktemp -d) || { echo "FAIL: mktemp failed" >&2; HARNESS=$((HARNESS + 1)); finish; }
+if [ -z "$SYNTH" ] || [ ! -d "$SYNTH" ]; then
+    harness_fail "could not create the synthetic fixture root"
+    finish
+fi
+trap 'rm -rf "$TMP" "$SYNTH"' EXIT
+
+SYNTH_HOME="$SYNTH/home"
+SYNTH_RULES="$SYNTH_HOME/.claude/rules"
+mkdir -p "$SYNTH_RULES" "$SYNTH/proj/some-plugin/skills/quilting-loom-calibration"
+
+# A skill with vocabulary disjoint from every rule below. Its job is to make
+# `known` non-empty (so `_stub_target` runs its real resolution passes) while
+# scoring far under T_COVERAGE against the stub, which is what makes the
+# coverage control MISS and fires `coverage_metric_broken`.
+cat > "$SYNTH/proj/some-plugin/skills/quilting-loom-calibration/SKILL.md" <<'SKILL'
+---
+name: quilting-loom-calibration
+description: Calibrate a quilting loom. Use when the shuttle tension drifts or the heddle spacing needs re-seating.
+---
+# quilting-loom-calibration
+Shuttle tension, heddle spacing and warp beam alignment on a quilting loom.
+Re-seat the heddle before adjusting shuttle tension on any warp beam.
+SKILL
+
+# A pointer stub naming a skill that does not exist. Fires TWO sites at once:
+#   * broken_pointer_stub — the only construction site passing a singular
+#     `path=` kwarg, so this is the one place the "emitted key order is the
+#     kwargs order" property is testable end-to-end for a singular path.
+#   * coverage_metric_broken — the stub is the coverage control, and its topic
+#     vocabulary (below) is disjoint from the only skill, so the control scores
+#     0/1 and the metric declares itself broken.
+{
+    echo "# Ghost Stub"
+    echo
+    echo "Promoted to a skill: invoke \`no-such-skill-anywhere\` before doing the thing —"
+    echo "it carries the whole procedure."
+    echo
+    python3 -c 'print(" ".join("stubtopic%03d" % i for i in range(60)))'
+} > "$SYNTH_RULES/ghost-stub.md"
+
+# Three duplicate pairs and three always-loaded heavyweights, generated with
+# disjoint token streams so the only pairs above T_LEXICAL are the intended
+# ones. No randomness and no timestamps anywhere: the corpus must be
+# byte-stable across the two back-to-back runs or the comparison asserts
+# nothing.
+python3 - "$SYNTH_RULES" <<'PY'
+import pathlib
+import sys
+
+rules = pathlib.Path(sys.argv[1])
+
+
+def body(title, prefix, n):
+    words = " ".join("%s%05d" % (prefix, i) for i in range(n))
+    return "# %s\n\n%s\n" % (title, words)
+
+
+# Duplicate pairs: identical within a pair (Jaccard 1.0, well over T_LEXICAL
+# 0.45), disjoint across pairs. Names chosen so the sorted-path scan order is
+# a-then-b, which is what makes "waiver written (b, a)" a real reverse-lookup.
+for slug, prefix in (("one", "dupone"), ("two", "duptwo"), ("three", "dupthree")):
+    text = body("Duplicate %s" % slug, prefix, 400)
+    (rules / ("dup-%s-a.md" % slug)).write_text(text)
+    (rules / ("dup-%s-b.md" % slug)).write_text(text)
+
+# Always-loaded budget: user-global scope with no `paths:` frontmatter, so every
+# one of these counts. BUDGET_TOKENS is 55,000 and tokens are chars // 4, so the
+# corpus needs > 220,000 chars. Distinct sizes keep the "heaviest: ..." top-3
+# ordering deterministic.
+for name, prefix, n in (
+    ("budget-heavy", "alphaword", 11000),
+    ("budget-mid", "betaword", 8000),
+    ("budget-light", "gammaword", 5000),
+):
+    (rules / ("%s.md" % name)).write_text(body(name, prefix, n))
+PY
+
+# The waiver file, exercising all three paths through `Waivers.waived`:
+#   pair one   — forward (a, b), spelled with `~/` so `_canon` must expanduser
+#   pair two   — reverse (b, a), so the lookup must hit the swapped key AND
+#                swap the recorded hash pair to match
+#   pair three — forward, with a deliberately stale `a_hash`, so the waiver
+#                EXPIRES and the finding must still be reported
+# `_canon` also has to realpath: mktemp hands out /var/... which macOS resolves
+# to /private/var/..., and a raw string compare would silently never match.
+python3 - "$SYNTH_RULES" "$SYNTH_HOME/.claude/config-drift-waivers.json" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+rules = pathlib.Path(sys.argv[1])
+out = pathlib.Path(sys.argv[2])
+
+
+def sha(path):
+    # sha256 truncated to 16 hex chars — the length is the contract (lib/probe.py).
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+
+
+def p(slug, side):
+    return rules / ("dup-%s-%s.md" % (slug, side))
+
+
+waivers = [
+    # forward, `~/`-spelled
+    {
+        "a": "~/.claude/rules/dup-one-a.md",
+        "b": "~/.claude/rules/dup-one-b.md",
+        "a_hash": sha(p("one", "a")),
+        "b_hash": sha(p("one", "b")),
+    },
+    # reverse: filed as (b, a) while the scan yields (a, b)
+    {
+        "a": str(p("two", "b")),
+        "b": str(p("two", "a")),
+        "a_hash": sha(p("two", "b")),
+        "b_hash": sha(p("two", "a")),
+    },
+    # expired: the file changed since the waiver was filed
+    {
+        "a": str(p("three", "a")),
+        "b": str(p("three", "b")),
+        "a_hash": "0000000000000000",
+        "b_hash": sha(p("three", "b")),
+    },
+]
+out.parent.mkdir(parents=True, exist_ok=True)
+out.write_text(json.dumps({"waivers": waivers}, indent=1))
+PY
+
+SYNTH_JSON=""
+for fmt in json status; do
+    compare "$fmt @ synthetic" "$SYNTH/proj" "$fmt" "$SYNTH_HOME"
+    [ "$HARNESS" -gt 0 ] && finish
+    # Take the path from compare() rather than re-deriving it from the label:
+    # a guard that reconstructs its own input path can silently read nothing.
+    [ "$fmt" = json ] && SYNTH_JSON="$LAST_AFTER"
+done
+
+# Guard: the synthetic corpus must actually fire what it was built to fire. A
+# fixture that silently stopped producing findings would `cmp` clean and this
+# whole section would assert nothing.
+if [ -z "$SYNTH_JSON" ] || [ ! -s "$SYNTH_JSON" ]; then
+    harness_fail "synthetic AFTER json output is missing — the coverage guard cannot run"
+    finish
+fi
+guard=$(python3 - "$SYNTH_JSON" <<'PY'
+import json
+import sys
+
+kinds = [f["kind"] for f in json.load(open(sys.argv[1]))["findings"]]
+summaries = [
+    f["summary"] for f in json.load(open(sys.argv[1]))["findings"]
+]
+want = [
+    "broken_pointer_stub",
+    "always_loaded_budget",
+    "coverage_metric_broken",
+    "duplicate_rule_lexical",
+    "frontmatter_coverage",
+]
+missing = [k for k in want if k not in kinds]
+# Waiver orientations: pairs one and two are waived and must be ABSENT; pair
+# three's waiver is expired and must still be REPORTED. Asserting only the
+# absences would pass against a lexical check that stopped running at all, so
+# the expired pair is the control.
+dupes = " ".join(s for s, k in zip(summaries, kinds) if k == "duplicate_rule_lexical")
+if "dup-one" in dupes:
+    missing.append("!forward-waiver-not-applied")
+if "dup-two" in dupes:
+    missing.append("!reverse-waiver-not-applied")
+if "dup-three" not in dupes:
+    missing.append("!expired-waiver-suppressed-anyway")
+print(",".join(missing) if missing else "OK")
+PY
+)
+if [ "$guard" = "OK" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok   synthetic corpus fires every targeted site (waivers: forward, reverse, expired)\n'
+else
+    harness_fail "the synthetic fixture no longer exercises what it claims" "unmet: $guard"
+fi
+
+finish

--- a/health-plugin/scripts/tests/test-config-drift.sh
+++ b/health-plugin/scripts/tests/test-config-drift.sh
@@ -350,7 +350,15 @@ echo "TEST 10: widened key pattern -- executed directly, see note"
 fm_get() {
     python3 - "$ANALYZER" "$1" "$2" <<'PYFM'
 import importlib.util
+import os
 import sys
+
+# A real invocation (`python3 config-drift.py`) puts the ANALYZER's own
+# directory on sys.path as sys.path[0], which is how its stdlib-only
+# `from lib.probe import ...` resolves. Loading the module by file location out
+# of a `python3 -` script does not, so the harness has to reproduce that entry
+# itself -- otherwise this case dies on an ImportError no real caller can hit.
+sys.path.insert(0, os.path.dirname(os.path.abspath(sys.argv[1])))
 
 spec = importlib.util.spec_from_file_location("config_drift", sys.argv[1])
 mod = importlib.util.module_from_spec(spec)
@@ -731,6 +739,11 @@ fastembed = types.ModuleType("fastembed")
 fastembed.TextEmbedding = TextEmbedding
 sys.modules["fastembed"] = fastembed
 
+# Same reason as the fm_get loader above: a file-location import does not get
+# the analyzer's directory on sys.path, so `from lib.probe import ...` would
+# fail here for a reason no real invocation can produce.
+sys.path.insert(0, str(pathlib.Path(analyzer).resolve().parent))
+
 spec = importlib.util.spec_from_file_location("config_drift", analyzer)
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
@@ -763,7 +776,7 @@ items = [
 if len(sys.argv) > 5:
     mod.EMBED_MODEL = sys.argv[5]
 
-mod.check_semantic_dupes(items, {}, pathlib.Path(cache_path))
+mod.check_semantic_dupes(items, mod.Waivers({}), pathlib.Path(cache_path))
 print("CACHE_KEYS=%d" % len(json.loads(pathlib.Path(cache_path).read_text())))
 PYDRIVER
 

--- a/health-plugin/scripts/tests/test-probe-lib.sh
+++ b/health-plugin/scripts/tests/test-probe-lib.sh
@@ -1,0 +1,879 @@
+#!/usr/bin/env bash
+# test-probe-lib.sh — regression suite for health-plugin/scripts/lib/probe.py
+#
+# SEMANTIC, not syntactic: every case EXECUTES the shipped module (or a script
+# that imports it) and asserts on real behaviour. A grep for `sys.path` or for a
+# function name would pass against a module that no consumer can import — and a
+# broken import here fails SILENTLY, because the SessionStart hook reads empty
+# analyzer output as "no findings". That is the highest-risk defect in the
+# extraction, so case (a) is a reachability test with its own control rather
+# than a spelling check.
+#
+# Isolation: HOME is redirected to the fixture root, so every case reads the
+# fixture's ~/.claude/rules and writes its caches there, never the real ones.
+# Every analyzer invocation passes --fast, so no git is spawned and the
+# shared-checkout git hazards (#1692/#1745) cannot arise.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ANALYZER="${SCRIPTS_DIR}/config-drift.py"
+DELTA="${SCRIPTS_DIR}/probe-delta.py"
+LIBFILE="${SCRIPTS_DIR}/lib/probe.py"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "SKIP: python3 not available"
+    exit 0
+fi
+for f in "$ANALYZER" "$DELTA" "$LIBFILE"; do
+    if [ ! -f "$f" ]; then
+        echo "FAIL: missing $f"
+        exit 1
+    fi
+done
+
+PASS=0
+FAIL=0
+
+ok()  { PASS=$((PASS + 1)); printf '  ok   %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL %s\n     wanted: %s\n     got:    %s\n' "$1" "$2" "$3"; }
+
+# if/else, not `A && B || C` — in an assertion helper the short-circuit form
+# runs `bad` whenever `ok` returns non-zero, which silently double-reports.
+assert_eq() {
+    if [ "$2" = "$3" ]; then ok "$1"; else bad "$1" "$3" "$2"; fi
+}
+assert_contains() {
+    case "$2" in
+        *"$3"*) ok "$1" ;;
+        *) bad "$1" "output containing '$3'" "$(printf '%s' "$2" | head -c 300)" ;;
+    esac
+}
+assert_absent() {
+    case "$2" in
+        *"$3"*) bad "$1" "output WITHOUT '$3'" "$(printf '%s' "$2" | head -c 300)" ;;
+        *) ok "$1" ;;
+    esac
+}
+
+# --- fixture corpus -------------------------------------------------------
+# The guard is spelled in check-git-sandbox-guards.sh's recognised form
+# (`[ -n ]`/`[ -d ]` within two lines of the assignment), not an equivalent
+# negated one: this file now runs real git ops in a sandbox (the D2/D3 gate
+# fixtures), so an empty $FIXROOT would put `git -C ""` on the shared checkout
+# (issue #1692).
+FIXROOT=$(mktemp -d) || { echo "FAIL: mktemp failed"; exit 1; }
+if [ -z "$FIXROOT" ] || [ ! -d "$FIXROOT" ]; then
+    echo "FAIL: could not create fixture root"
+    exit 1
+fi
+trap 'rm -rf "$FIXROOT"' EXIT
+
+mkdir -p "$FIXROOT/home/.claude/rules"
+mkdir -p "$FIXROOT/proj/repo-a/.claude/rules"
+mkdir -p "$FIXROOT/proj/repo-b/.claude/rules"
+mkdir -p "$FIXROOT/proj/some-plugin/skills/widget-wrangling"
+export HOME="$FIXROOT/home"
+
+cat > "$FIXROOT/proj/some-plugin/skills/widget-wrangling/SKILL.md" <<'SKILL'
+---
+name: widget-wrangling
+description: Wrangle widgets across the fleet. Use when calibrating widget torque or auditing widget inventory.
+---
+# widget-wrangling
+Calibrating widget torque requires the fleet inventory. Audit widget torque
+calibration across every widget in the inventory before adjusting any widget.
+SKILL
+
+cat > "$FIXROOT/proj/repo-a/.claude/rules/alpha.md" <<'RULE'
+# Alpha
+The torque calibration procedure requires the fleet inventory manifest before
+any widget adjustment is attempted on the assembly line.
+RULE
+cp "$FIXROOT/proj/repo-a/.claude/rules/alpha.md" "$FIXROOT/proj/repo-b/.claude/rules/beta.md"
+
+STUB_PATH="$FIXROOT/home/.claude/rules/ghost-stuff.md"
+cat > "$STUB_PATH" <<'RULE'
+# Ghost Stuff
+
+Promoted to a skill: invoke `no-such-skill-anywhere` before doing the thing —
+it carries the whole procedure.
+RULE
+
+# Run a python program that lives OUTSIDE the scripts dir, with the scripts dir
+# on PYTHONPATH. PEP 420 resolves `lib.probe` from a path entry exactly as it
+# does from sys.path[0], so this exercises the same resolution the real callers
+# get without needing to plant a file inside the shipped tree.
+py() { PYTHONPATH="$SCRIPTS_DIR" python3 "$1" 2>&1; }
+
+echo "TEST a: import reachability from an unrelated cwd"
+# The analyzer is invoked by the hook with an absolute path from whatever cwd
+# the session happens to be in. A relative-import regression would make it print
+# nothing and exit non-zero -- which the hook cannot tell from "no findings".
+out=$(cd / && python3 "$ANALYZER" --root "$FIXROOT/proj" --no-embed --fast --format=status 2>&1)
+rc=$?
+assert_eq "analyzer runs from cd / with an absolute path (exit 0/1, not an ImportError)" \
+    "$([ "$rc" -le 1 ] && echo yes || echo "no (rc=$rc)")" "yes"
+assert_contains "analyzer emitted its section header" "$out" "=== CONFIG DRIFT ==="
+# CONTROL: without this, "the analyzer ran" would also pass against an analyzer
+# that no longer imports lib.probe at all.
+ctl=$(cd / && PYTHONPATH="$SCRIPTS_DIR" python3 -c 'from lib.probe import Finding; print("IMPORT_OK", Finding("info","x_kind","s")["kind"])' 2>&1)
+assert_contains "a direct 'from lib.probe import Finding' resolves and constructs" "$ctl" "IMPORT_OK x_kind"
+# ...and the namespace form works under the REAL invocation shape too: sys.path[0]
+# is the script's directory, with no PYTHONPATH help.
+ctl2=$(cd / && python3 "$DELTA" --help 2>&1)
+assert_contains "probe-delta.py imports lib.probe via sys.path[0] under bare python3" "$ctl2" "--baseline"
+
+echo "TEST b: key order per kind comes from **extra, not a canonical list"
+cat > "$FIXROOT/keyorder.py" <<'PY'
+from lib.probe import Finding
+
+shapes = [
+    ("broken_pointer_stub", Finding("error", "broken_pointer_stub", "s", path="/p")),
+    ("review_staleness", Finding("warn", "review_staleness", "s", path="/p", gap_days=9)),
+    ("always_loaded_budget", Finding("warn", "always_loaded_budget", "s", tokens=1)),
+    ("frontmatter_coverage", Finding("info", "frontmatter_coverage", "s")),
+    ("duplicate_rule_lexical", Finding("warn", "duplicate_rule_lexical", "s", score=0.5, paths=["/a", "/b"])),
+    ("rule_covered_by_skill", Finding("info", "rule_covered_by_skill", "s", score=0.6, paths=["/a", "/b"], always_loaded=True)),
+    ("coverage_metric_broken", Finding("error", "coverage_metric_broken", "s")),
+    ("semantic_overlap_rule_skill", Finding("warn", "semantic_overlap_rule_skill", "s", score=0.92, paths=["/a", "/b"])),
+    ("semantic_pass_unavailable", Finding("info", "semantic_pass_unavailable", "s")),
+]
+for name, f in shapes:
+    print("SHAPE %s %s" % (name, ",".join(f.to_dict())))
+
+# CONTROL: the same kind with the kwargs in a DIFFERENT order must emit a
+# DIFFERENT key order. Without it, every assertion above would also pass
+# against a to_dict() that returned a fixed schema per kind.
+swapped = Finding("warn", "review_staleness", "s", gap_days=9, path="/p")
+print("CONTROL %s" % ",".join(swapped.to_dict()))
+PY
+out=$(py "$FIXROOT/keyorder.py")
+assert_contains "broken_pointer_stub key order"        "$out" "SHAPE broken_pointer_stub severity,kind,summary,path"
+assert_contains "review_staleness key order"           "$out" "SHAPE review_staleness severity,kind,summary,path,gap_days"
+assert_contains "always_loaded_budget key order"       "$out" "SHAPE always_loaded_budget severity,kind,summary,tokens"
+assert_contains "frontmatter_coverage key order"       "$out" "SHAPE frontmatter_coverage severity,kind,summary"
+assert_contains "duplicate_rule_lexical key order"     "$out" "SHAPE duplicate_rule_lexical severity,kind,summary,score,paths"
+assert_contains "rule_covered_by_skill key order"      "$out" "SHAPE rule_covered_by_skill severity,kind,summary,score,paths,always_loaded"
+assert_contains "coverage_metric_broken key order"     "$out" "SHAPE coverage_metric_broken severity,kind,summary"
+assert_contains "semantic_overlap_rule_skill key order" "$out" "SHAPE semantic_overlap_rule_skill severity,kind,summary,score,paths"
+assert_contains "semantic_pass_unavailable key order"  "$out" "SHAPE semantic_pass_unavailable severity,kind,summary"
+assert_contains "CONTROL: reordered kwargs emit a different key order" \
+    "$out" "CONTROL severity,kind,summary,gap_days,path"
+
+echo "TEST b2: Finding validates its own shape"
+cat > "$FIXROOT/validate.py" <<'PY'
+from lib.probe import Finding
+
+def rejects(label, fn):
+    try:
+        fn()
+    except ValueError:
+        print("REJECTED %s" % label)
+    else:
+        print("ACCEPTED %s" % label)
+
+rejects("bad_severity", lambda: Finding("critical", "k_kind", "s"))
+rejects("bad_kind_case", lambda: Finding("warn", "Kind", "s"))
+rejects("bad_kind_dash", lambda: Finding("warn", "some-kind", "s"))
+rejects("empty_summary", lambda: Finding("warn", "k_kind", ""))
+rejects("path_and_paths", lambda: Finding("warn", "k_kind", "s", path="/a", paths=["/b"]))
+# A dynamic f-string kind is legal -- the check is a SHAPE, not an enum.
+print("DYNAMIC %s" % Finding("warn", "semantic_overlap_rule_skill", "s")["kind"])
+PY
+out=$(py "$FIXROOT/validate.py")
+assert_contains "an unknown severity is rejected"        "$out" "REJECTED bad_severity"
+assert_contains "an uppercase kind is rejected"          "$out" "REJECTED bad_kind_case"
+assert_contains "a hyphenated kind is rejected"          "$out" "REJECTED bad_kind_dash"
+assert_contains "an empty summary is rejected"           "$out" "REJECTED empty_summary"
+assert_contains "path and paths together are rejected"   "$out" "REJECTED path_and_paths"
+assert_contains "a dynamic semantic_overlap_* kind is accepted" "$out" "DYNAMIC semantic_overlap_rule_skill"
+
+echo "TEST c: waivers match in both orientations and expire on either side"
+cat > "$FIXROOT/waivers.py" <<'PY'
+import json
+import os
+import sys
+
+from lib.probe import Waivers
+
+root = sys.argv[1]
+a = {"path": os.path.join(root, "a.md"), "hash": "aaaaaaaaaaaaaaaa"}
+b = {"path": os.path.join(root, "b.md"), "hash": "bbbbbbbbbbbbbbbb"}
+
+def write(entry):
+    p = os.path.join(root, "waivers.json")
+    with open(p, "w", encoding="utf-8") as fh:
+        json.dump({"waivers": [entry]}, fh)
+    return p
+
+forward = write({"a": a["path"], "b": b["path"],
+                 "a_hash": a["hash"], "b_hash": b["hash"], "reason": "test"})
+w = Waivers.load(forward)
+print("LEN %d" % len(w))
+print("FORWARD %s" % w.waived(a, b))
+print("REVERSED_LOOKUP %s" % w.waived(b, a))
+mutated = dict(b, hash="cccccccccccccccc")
+print("MUTATED %s" % w.waived(a, mutated))
+
+# The waiver filed the OTHER way round: (b, a). The scan still yields (a, b),
+# so a probe that tried one orientation only would silently ignore the file.
+reversed_file = write({"a": b["path"], "b": a["path"],
+                       "a_hash": b["hash"], "b_hash": a["hash"], "reason": "test"})
+w2 = Waivers.load(reversed_file)
+print("REVERSED_ENTRY %s" % w2.waived(a, b))
+# ...and the hash pair must be swapped to match the orientation that hit, not
+# compared positionally.
+print("REVERSED_ENTRY_MUTATED %s" % w2.waived(a, mutated))
+print("MISSING_FILE %d" % len(Waivers.load(os.path.join(root, "nope.json"))))
+PY
+out=$(PYTHONPATH="$SCRIPTS_DIR" python3 "$FIXROOT/waivers.py" "$FIXROOT" 2>&1)
+assert_contains "one waiver loads"                          "$out" "LEN 1"
+assert_contains "waived while both hashes match"            "$out" "FORWARD True"
+assert_contains "waived when the pair is looked up (b, a)"  "$out" "REVERSED_LOOKUP True"
+assert_contains "NOT waived after mutating one side's hash" "$out" "MUTATED False"
+assert_contains "waived when the ENTRY is stored (b, a)"    "$out" "REVERSED_ENTRY True"
+assert_contains "the reversed entry still expires on a hash change" "$out" "REVERSED_ENTRY_MUTATED False"
+assert_contains "a missing waiver file loads as empty"      "$out" "MISSING_FILE 0"
+
+echo "TEST d: fingerprint same/different ladder"
+# The `different` half is load-bearing: without it a fingerprint() that returned
+# a constant would pass every `same` case below.
+cat > "$FIXROOT/fp.py" <<'PY'
+from lib.probe import Finding, fingerprint as fp
+
+base = Finding("warn", "duplicate_rule_lexical", "a and b are 60% identical",
+               score=0.6, paths=["/x/a.md", "/y/b.md"])
+print("SAME_REORDER %s" % (fp(base) == fp(Finding(
+    "warn", "duplicate_rule_lexical", "a and b are 60% identical",
+    score=0.6, paths=["/y/b.md", "/x/a.md"]))))
+print("SAME_SCORE %s" % (fp(base) == fp(Finding(
+    "warn", "duplicate_rule_lexical", "a and b are 60% identical",
+    score=0.91, paths=["/x/a.md", "/y/b.md"]))))
+print("SAME_SUMMARY %s" % (fp(base) == fp(Finding(
+    "warn", "duplicate_rule_lexical", "completely different prose",
+    score=0.6, paths=["/x/a.md", "/y/b.md"]))))
+
+stale = Finding("warn", "review_staleness", "r changed 200d after", path="/x/r.md", gap_days=200)
+print("SAME_GAP %s" % (fp(stale) == fp(Finding(
+    "warn", "review_staleness", "r changed 900d after", path="/x/r.md", gap_days=900))))
+
+budget_a = Finding("warn", "always_loaded_budget", "51 rules cost ~39,000 tok", tokens=39000)
+budget_b = Finding("warn", "always_loaded_budget", "52 rules cost ~41,000 tok", tokens=41000)
+print("SAME_BUDGET %s" % (fp(budget_a) == fp(budget_b)))
+
+print("DIFF_KIND %s" % (fp(base) != fp(Finding(
+    "warn", "duplicate_rule_lexical_x", "a and b are 60% identical",
+    score=0.6, paths=["/x/a.md", "/y/b.md"]))))
+print("DIFF_PATH %s" % (fp(base) != fp(Finding(
+    "warn", "duplicate_rule_lexical", "a and b are 60% identical",
+    score=0.6, paths=["/x/a.md", "/y/c.md"]))))
+
+# The singular-path collision. Read naively as "paths only", these two collapse
+# to ONE fingerprint and the second broken stub is invisible in every delta
+# report forever.
+s1 = Finding("error", "broken_pointer_stub", "one points at a ghost", path="/x/one.md")
+s2 = Finding("error", "broken_pointer_stub", "two points at a ghost", path="/x/two.md")
+print("DIFF_SINGULAR_PATH %s" % (fp(s1) != fp(s2)))
+# ...and a singular `path` must fold into the same set a `paths` list would give.
+print("FOLDED %s" % (fp(s1) == fp(Finding(
+    "error", "broken_pointer_stub", "one points at a ghost", paths=["/x/one.md"]))))
+# Pathless kinds get one stable fingerprint per kind, and different kinds differ.
+print("DIFF_PATHLESS_KINDS %s" % (fp(Finding("info", "frontmatter_coverage", "s"))
+                                  != fp(Finding("error", "coverage_metric_broken", "s"))))
+PY
+out=$(py "$FIXROOT/fp.py")
+assert_contains "same: reordered paths"                       "$out" "SAME_REORDER True"
+assert_contains "same: changed score"                         "$out" "SAME_SCORE True"
+assert_contains "same: changed summary"                       "$out" "SAME_SUMMARY True"
+assert_contains "same: changed gap_days"                      "$out" "SAME_GAP True"
+assert_contains "same: always_loaded_budget at other token counts" "$out" "SAME_BUDGET True"
+assert_contains "different: changed kind"                     "$out" "DIFF_KIND True"
+assert_contains "different: changed one path"                 "$out" "DIFF_PATH True"
+assert_contains "different: two stubs on DIFFERENT files"     "$out" "DIFF_SINGULAR_PATH True"
+assert_contains "a singular path folds into the path set"     "$out" "FOLDED True"
+assert_contains "different pathless kinds do not collide"     "$out" "DIFF_PATHLESS_KINDS True"
+
+echo "TEST e: delta three-point ladder"
+cat > "$FIXROOT/delta.py" <<'PY'
+import os
+import sys
+
+from lib.probe import Baseline, Finding
+
+root = sys.argv[1]
+path = os.path.join(root, "baseline.json")
+here = "/corpus"
+
+f1 = Finding("error", "broken_pointer_stub", "one", path="/corpus/one.md")
+f2 = Finding("warn", "review_staleness", "two", path="/corpus/two.md", gap_days=200)
+f3 = Finding("error", "broken_pointer_stub", "three", path="/corpus/three.md")
+
+b = Baseline.load(path, root=here, probe="p")
+print("NO_BASELINE %s" % (b is None))
+b = b or Baseline("p", here, "2026-01-01T00:00:00+00:00")
+d = b.delta([f1, f2])
+print("FIRST_RUN %s" % d.first_run)
+b.record([f1, f2]).save(path)
+
+b2 = Baseline.load(path, root=here, probe="p")
+d2 = b2.delta([f1, f2])
+print("UNCHANGED new=%d resolved=%d carried=%d first_run=%s"
+      % (len(d2.new), len(d2.resolved), len(d2.carried), d2.first_run))
+
+d3 = b2.delta([f1, f2, f3])
+print("ADDED new=%d resolved=%d kind=%s"
+      % (len(d3.new), len(d3.resolved), d3.new[0]["kind"] if d3.new else "-"))
+
+d4 = b2.delta([f1])
+print("REMOVED new=%d resolved=%d" % (len(d4.new), len(d4.resolved)))
+PY
+out=$(PYTHONPATH="$SCRIPTS_DIR" python3 "$FIXROOT/delta.py" "$FIXROOT" 2>&1)
+assert_contains "no baseline on disk loads as None"       "$out" "NO_BASELINE True"
+assert_contains "a fresh baseline reports first_run"      "$out" "FIRST_RUN True"
+assert_contains "unchanged: nothing new, nothing resolved" "$out" "UNCHANGED new=0 resolved=0 carried=2 first_run=False"
+assert_contains "one extra finding is exactly 1 new"      "$out" "ADDED new=1 resolved=0 kind=broken_pointer_stub"
+assert_contains "removing one finding is exactly 1 resolved" "$out" "REMOVED new=0 resolved=1"
+
+echo "TEST f: baseline durability"
+cat > "$FIXROOT/durable.py" <<'PY'
+import json
+import os
+import sys
+
+from lib.probe import BASELINE_SCHEMA, Baseline, Finding
+
+root = sys.argv[1]
+d = os.path.join(root, "baselines")
+path = os.path.join(d, "nested", "b.json")
+here = "/corpus"
+f1 = Finding("error", "broken_pointer_stub", "one", path="/corpus/one.md")
+
+# save() must mkdir -p; a scheduled job's state dir does not exist on run one.
+Baseline("p", here, "2026-01-01T00:00:00+00:00").record([f1]).save(path)
+print("ROUNDTRIP %s" % (Baseline.load(path, root=here, probe="p") is not None))
+print("TMP_LEFT %s" % sorted(x for x in os.listdir(os.path.dirname(path)) if x.endswith(".tmp")))
+
+corrupt = os.path.join(d, "corrupt.json")
+with open(corrupt, "w", encoding="utf-8") as fh:
+    fh.write('{"schema": 1, "findings": {')   # truncated mid-write
+print("CORRUPT %s" % (Baseline.load(corrupt, root=here, probe="p") is None))
+
+raw = json.loads(open(path, encoding="utf-8").read())
+print("SCHEMA_FIELD %s" % (raw["schema"] == BASELINE_SCHEMA))
+
+wrong_root = os.path.join(d, "wrongroot.json")
+with open(wrong_root, "w", encoding="utf-8") as fh:
+    json.dump(dict(raw, root="/somewhere/else"), fh)
+b = Baseline.load(wrong_root, root=here, probe="p")
+print("ROOT_MISMATCH %s" % (b is None))
+
+bad_schema = os.path.join(d, "schema99.json")
+with open(bad_schema, "w", encoding="utf-8") as fh:
+    json.dump(dict(raw, schema=99), fh)
+print("SCHEMA_MISMATCH %s" % (Baseline.load(bad_schema, root=here, probe="p") is None))
+
+# Guard integrity: a root/schema mismatch must be indistinguishable from a
+# missing file at the CALLER, and the caller's answer is "record fresh and stay
+# silent" -- never "every finding is new".
+b = Baseline.load(wrong_root, root=here, probe="p") or Baseline("p", here, "t")
+print("MISMATCH_IS_FIRST_RUN %s" % b.delta([f1]).first_run)
+print("MISSING %s" % (Baseline.load(os.path.join(d, "nope.json"), root=here) is None))
+PY
+out=$(PYTHONPATH="$SCRIPTS_DIR" python3 "$FIXROOT/durable.py" "$FIXROOT" 2>&1)
+assert_contains "a saved baseline round-trips"                   "$out" "ROUNDTRIP True"
+assert_contains "no .tmp file is left behind after save()"        "$out" "TMP_LEFT []"
+assert_contains "a truncated baseline loads as None, not {}"      "$out" "CORRUPT True"
+assert_contains "the schema version is recorded"                  "$out" "SCHEMA_FIELD True"
+assert_contains "a ROOT mismatch loads as None (not 'all new')"   "$out" "ROOT_MISMATCH True"
+assert_contains "schema 99 loads as None"                         "$out" "SCHEMA_MISMATCH True"
+assert_contains "a mismatch degrades to a silent first run"       "$out" "MISMATCH_IS_FIRST_RUN True"
+assert_contains "a missing baseline loads as None"                "$out" "MISSING True"
+
+echo "TEST g/i: probe-delta is a second consumer with a conformant block"
+FINDINGS_JSON="$FIXROOT/findings.json"
+BASELINE_JSON="$FIXROOT/probe-delta-baseline.json"
+python3 "$ANALYZER" --root "$FIXROOT/proj" --no-embed --fast --format=json > "$FINDINGS_JSON" 2>/dev/null
+# Guard integrity: the planted corpus must actually produce findings, or every
+# ISSUE_COUNT assertion below is satisfied by an analyzer that found nothing.
+planted=$(python3 -c 'import json,sys; print(len(json.load(open(sys.argv[1]))["findings"]))' "$FINDINGS_JSON")
+assert_eq "the fixture corpus produces a NON-EMPTY finding set" \
+    "$([ "${planted:-0}" -ge 2 ] && echo yes || echo "no ($planted)")" "yes"
+
+out=$(cd / && python3 "$DELTA" --findings "$FINDINGS_JSON" --baseline "$BASELINE_JSON" \
+    --probe config-drift --root "$FIXROOT/proj" --section "CONFIG DRIFT DELTA" 2>&1)
+rc=$?
+assert_eq "first run exits 0" "$rc" "0"
+assert_contains "opening delimiter"      "$out" "=== CONFIG DRIFT DELTA ==="
+assert_contains "closing delimiter"      "$out" "=== END CONFIG DRIFT DELTA ==="
+assert_contains "STATUS= is present"     "$out" "STATUS=OK"
+assert_contains "ISSUE_COUNT= is present" "$out" "ISSUE_COUNT=0"
+assert_contains "first run is announced" "$out" "FIRST_RUN=true"
+# structured-script-output.md fixes the verdict vocabulary at OK|WARN|ERROR. A
+# rollup greps that alternation, so a fourth word (the `CLEAN` this renderer
+# used to emit) drops the whole section out of the table with no error anywhere.
+assert_eq "STATUS is drawn from OK|WARN|ERROR and nothing else" \
+    "$(printf '%s\n' "$out" | grep -cE '^STATUS=(OK|WARN|ERROR)$')" "1"
+assert_eq "exactly one STATUS= line is emitted" \
+    "$(printf '%s\n' "$out" | grep -c '^STATUS=')" "1"
+# The delta's severity counters are computed over the NEW findings while
+# `counts` carries the total, so they must not reuse the key names
+# config-drift's own emit_status writes over the FULL set — a combined-log
+# rollup grepping '^ERRORS=' would otherwise get two contradictory answers.
+assert_contains "the delta counts new errors under its own key"   "$out" "NEW_ERRORS=0"
+assert_contains "the delta counts new warnings under its own key" "$out" "NEW_WARNINGS=0"
+assert_eq "no bare ERRORS= line collides with emit_status" \
+    "$(printf '%s\n' "$out" | grep -cE '^(ERRORS|WARNINGS)=')" "0"
+assert_eq "the first run wrote a baseline" "$([ -s "$BASELINE_JSON" ] && echo yes || echo no)" "yes"
+assert_contains "the first run carried the whole corpus forward" "$out" "TOTAL_FINDINGS=$planted"
+
+out=$(cd / && python3 "$DELTA" --findings "$FINDINGS_JSON" --baseline "$BASELINE_JSON" \
+    --probe config-drift --root "$FIXROOT/proj" --section "CONFIG DRIFT DELTA" 2>&1)
+assert_contains "an unchanged second run is OK"     "$out" "STATUS=OK"
+assert_contains "an unchanged second run has 0 new" "$out" "NEW=0"
+assert_contains "an unchanged second run carries them" "$out" "CARRIED=$planted"
+
+# Plant one more broken stub: exactly one NEW finding must surface, and only it.
+cat > "$FIXROOT/home/.claude/rules/second-ghost.md" <<'RULE'
+# Second Ghost
+
+Promoted to a skill: invoke `also-no-such-skill` before doing the other thing —
+it carries the whole procedure.
+RULE
+python3 "$ANALYZER" --root "$FIXROOT/proj" --no-embed --fast --format=json > "$FIXROOT/findings2.json" 2>/dev/null
+out=$(cd / && python3 "$DELTA" --findings "$FIXROOT/findings2.json" --baseline "$BASELINE_JSON" \
+    --probe config-drift --root "$FIXROOT/proj" --section "CONFIG DRIFT DELTA" 2>&1)
+rc=$?
+assert_contains "one new finding is reported"        "$out" "NEW=1"
+assert_contains "ISSUE_COUNT reflects the new set"   "$out" "ISSUE_COUNT=1"
+assert_contains "the report names the new stub only" "$out" "TYPE=broken_pointer_stub"
+assert_absent  "the carried findings are not re-listed" "$out" "TYPE=review_staleness"
+assert_contains "an error-severity delta is ERROR"   "$out" "STATUS=ERROR"
+assert_contains "the new error is counted under NEW_ERRORS" "$out" "NEW_ERRORS=1"
+assert_eq "a non-empty delta still emits no bare ERRORS= line" \
+    "$(printf '%s\n' "$out" | grep -cE '^(ERRORS|WARNINGS)=')" "0"
+assert_eq "an error-severity delta exits 1" "$rc" "1"
+rm -f "$FIXROOT/home/.claude/rules/second-ghost.md"
+
+# A root the baseline was NOT recorded at must degrade to a silent first run,
+# never to "every finding is new plus every old one resolved".
+out=$(cd / && python3 "$DELTA" --findings "$FINDINGS_JSON" --baseline "$BASELINE_JSON" \
+    --probe config-drift --root "$FIXROOT" --section "CONFIG DRIFT DELTA" 2>&1)
+assert_contains "a root mismatch reports FIRST_RUN=true" "$out" "FIRST_RUN=true"
+assert_contains "a root mismatch stays OK"               "$out" "STATUS=OK"
+
+echo "TEST i2: empty / unparseable analyzer output is ERROR, never a clean sweep"
+out=$(cd / && printf '' | python3 "$DELTA" --findings - --baseline "$FIXROOT/e.json" \
+    --probe config-drift --root "$FIXROOT/proj" 2>&1)
+rc=$?
+assert_contains "empty stdin reports analyzer_failed" "$out" "TYPE=analyzer_failed"
+assert_contains "empty stdin is ERROR"                "$out" "STATUS=ERROR"
+assert_absent  "empty stdin never reports a clean verdict" "$out" "STATUS=OK"
+assert_eq "empty stdin exits non-zero" "$([ "$rc" -ne 0 ] && echo yes || echo no)" "yes"
+assert_eq "empty stdin wrote no baseline" "$([ -e "$FIXROOT/e.json" ] && echo yes || echo no)" "no"
+
+out=$(cd / && printf 'not json at all' | python3 "$DELTA" --findings - --baseline "$FIXROOT/u.json" \
+    --probe config-drift --root "$FIXROOT/proj" 2>&1)
+assert_contains "unparseable stdin reports analyzer_failed" "$out" "TYPE=analyzer_failed"
+assert_contains "unparseable stdin closing delimiter"       "$out" "=== END CONFIG-DRIFT DELTA ==="
+
+echo "TEST i3: an unknown argument exits 2 with usage (#2057)"
+err=$(cd / && python3 "$DELTA" --findings - --baseline "$FIXROOT/x.json" --probe p \
+    --root "$FIXROOT/proj" --no-such-flag </dev/null 2>&1)
+rc=$?
+assert_eq "unknown flag exits 2" "$rc" "2"
+assert_contains "unknown flag prints usage" "$err" "usage: probe-delta.py"
+
+echo "TEST h: the cheap tier imports neither fastembed nor numpy"
+POISON="$FIXROOT/poison"
+mkdir -p "$POISON"
+for mod in numpy fastembed; do
+    cat > "$POISON/$mod.py" <<'PY'
+import os
+open(os.environ["EMBED_IMPORT_MARKER"], "a").close()
+PY
+done
+export EMBED_IMPORT_MARKER="$FIXROOT/embed-import-happened"
+rm -f "$EMBED_IMPORT_MARKER"
+PYTHONPATH="$POISON" python3 "$ANALYZER" --root "$FIXROOT/proj" --no-embed --fast --format=status >/dev/null 2>&1
+assert_eq "--no-embed imports neither numpy nor fastembed" \
+    "$([ -f "$EMBED_IMPORT_MARKER" ] && echo present || echo absent)" "absent"
+# CONTROL: without this, the assertion above would also pass against an analyzer
+# whose embed path is unreachable for some entirely different reason.
+rm -f "$EMBED_IMPORT_MARKER"
+PYTHONPATH="$POISON" python3 "$ANALYZER" --root "$FIXROOT/proj" --fast --format=status >/dev/null 2>&1
+assert_eq "CONTROL: without --no-embed the embed path IS reached" \
+    "$([ -f "$EMBED_IMPORT_MARKER" ] && echo present || echo absent)" "present"
+rm -f "$EMBED_IMPORT_MARKER"
+unset EMBED_IMPORT_MARKER
+
+echo "TEST j: current bugs pinned deliberately (inverted by the follow-up PR)"
+# j1. `--since <ref>` keeps `not f.get("paths")` as its escape hatch, and a
+# singular-`path` finding has no `paths` key -- so a broken_pointer_stub whose
+# file was NOT touched survives the filter while a paths-carrying duplicate is
+# correctly dropped. The follow-up PR normalises path -> paths, which INVERTS
+# this assertion; when it does, this case is the record of what changed.
+out=$(python3 "$ANALYZER" --root "$FIXROOT/proj" --no-embed --fast --format=json \
+    --since HEAD 2>/dev/null)
+kinds() { printf '%s' "$1" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(sum(1 for f in d["findings"] if f["kind"]==sys.argv[1]))' "$2" 2>/dev/null || echo ERR; }
+assert_eq "PINNED BUG: --since retains an untouched singular-path stub finding" \
+    "$(kinds "$out" broken_pointer_stub)" "1"
+assert_eq "CONTROL: --since correctly drops an untouched paths-carrying finding" \
+    "$(kinds "$out" duplicate_rule_lexical)" "0"
+
+# j2. emit_report prints `f.get("paths", [])[:2]` only, so a singular-`path`
+# finding's file is never shown -- the reader is told a stub is broken and not
+# which one. Also inverted by the follow-up PR.
+rep=$(python3 "$ANALYZER" --root "$FIXROOT/proj" --no-embed --fast --format=report 2>/dev/null)
+assert_contains "the report does list the broken stub finding" "$rep" "broken_pointer_stub"
+assert_absent "PINNED BUG: --format=report never prints that stub's path" "$rep" "$STUB_PATH"
+
+# =====================================================================
+# Round-2 repair regressions (D1-D5). Every case EXECUTES the failing
+# condition; every negative carries its control, because a hook that always
+# reports failure -- or a gate that always harness-errors -- passes the naive
+# form of each of these.
+# =====================================================================
+
+REPO_ROOT="$(cd "${SCRIPTS_DIR}/../.." && pwd)"
+PROTO_SRC="${REPO_ROOT}/hooks-plugin/hooks/lib/drift-protocol.sh"
+HOOK_SRC="${REPO_ROOT}/health-plugin/hooks/config-drift-probe.sh"
+
+if ! command -v jq >/dev/null 2>&1 || [ ! -f "$PROTO_SRC" ] || [ ! -f "$HOOK_SRC" ]; then
+    echo "  note  skipping hook/gate regressions (need jq + drift-protocol.sh + the hook)"
+else
+    # The hook is copied into a fixture tree so its own relative resolution
+    # (SCRIPT_DIR/../scripts/config-drift.py) picks up a STUB analyzer. The
+    # shipped hook file is copied byte-for-byte -- never retyped -- so the thing
+    # under test is the thing that ships.
+    HK="$FIXROOT/hookfix"
+    mkdir -p "$HK/health-plugin/hooks" "$HK/health-plugin/scripts" \
+             "$HK/hooks-plugin/hooks/lib" "$HK/sig" "$HK/cwd"
+    cp "$HOOK_SRC" "$HK/health-plugin/hooks/config-drift-probe.sh"
+    cp "$PROTO_SRC" "$HK/hooks-plugin/hooks/lib/drift-protocol.sh"
+    STUB="$HK/health-plugin/scripts/config-drift.py"
+
+    # run_hook <session-tag> -> sets HOOK_RC and HOOK_FINDINGS (compact JSON
+    # array, or the literal "NO-SIGNAL-FILE" when the probe wrote nothing).
+    run_hook() {
+        local tag="$1"
+        rm -rf "$HK/sig/$tag"
+        printf '{"session_id":"%s","cwd":"%s"}' "$tag" "$HK/cwd" \
+            | CLAUDE_DRIFT_SIGNALS_DIR="$HK/sig" \
+              bash "$HK/health-plugin/hooks/config-drift-probe.sh" >/dev/null 2>&1
+        HOOK_RC=$?
+        if [ -f "$HK/sig/$tag/config-drift.json" ]; then
+            HOOK_FINDINGS=$(jq -c '.findings' "$HK/sig/$tag/config-drift.json" 2>/dev/null || echo BAD-JSON)
+        else
+            HOOK_FINDINGS="NO-SIGNAL-FILE"
+        fi
+    }
+
+    echo "TEST D1: an analyzer that exits 0 with nothing usable is never a clean sweep"
+    # --format=json prints unconditionally, so empty output IS the proof the
+    # analyzer did not run. Pre-repair both of these fell through to a bare
+    # drift_emit, whose empty findings array IS the "checked, no drift" verdict
+    # (hooks-plugin/hooks/lib/drift-protocol.sh) -- a false all-clear signed by a
+    # dead analyzer. Reproduces a truncated / 0-byte analyzer: an interrupted
+    # plugin install, a partial write.
+    : > "$STUB"
+    run_hook d1-empty
+    assert_eq "exit 0 + EMPTY stdout does not write the clean-sweep empty array" \
+        "$([ "$HOOK_FINDINGS" = "[]" ] && echo clean-sweep-verdict || echo reported)" "reported"
+    assert_contains "exit 0 + EMPTY stdout reports the analyzer as failed" \
+        "$HOOK_FINDINGS" '"kind":"analyzer_failed"'
+    assert_eq "exit 0 + EMPTY stdout emits exactly one finding" \
+        "$(printf '%s' "$HOOK_FINDINGS" | jq 'length' 2>/dev/null)" "1"
+    # A SessionStart probe reports drift; it never fails the session. Reporting
+    # the dead analyzer must not become a non-zero exit.
+    assert_eq "the hook still exits 0 while reporting the dead analyzer" "$HOOK_RC" "0"
+
+    printf 'print("this is not json")\n' > "$STUB"
+    run_hook d1-nonjson
+    assert_contains "exit 0 + NON-JSON stdout reports the analyzer as failed" \
+        "$HOOK_FINDINGS" '"kind":"analyzer_failed"'
+
+    # CONTROL. Without it, every assertion above is satisfied by a hook that
+    # cries analyzer_failed unconditionally -- which would bury the real findings
+    # under a permanent false alarm and is a worse bug than the one being fixed.
+    cat > "$STUB" <<'PY'
+import json, sys
+print(json.dumps({"findings": [{"severity": "warn", "kind": "review_staleness",
+                                "summary": "42 rules unreviewed"}],
+                  "counts": {}}))
+sys.exit(1)
+PY
+    run_hook d1-healthy
+    assert_absent "CONTROL: a HEALTHY analyzer (exit 1 + full JSON) is not called failed" \
+        "$HOOK_FINDINGS" 'analyzer_failed'
+    assert_contains "CONTROL: a healthy analyzer's own findings are forwarded" \
+        "$HOOK_FINDINGS" '"kind":"review_staleness"'
+
+    # CONTROL 2: a genuinely CLEAN corpus must still produce the empty-array
+    # "checked, no drift" verdict -- the repair must not make emptiness itself
+    # suspicious, only emptiness on STDOUT.
+    cat > "$STUB" <<'PY'
+import json
+print(json.dumps({"findings": [], "counts": {}}))
+PY
+    run_hook d1-clean
+    assert_eq "CONTROL: a clean corpus still writes the empty findings array" \
+        "$HOOK_FINDINGS" "[]"
+
+    echo "TEST D4: the summary names the exception, not whatever wrote last"
+    # atexit handlers, CPython's shutdown chatter, and a wrapping python3 shim
+    # (mise/asdf/uv -- this machine uses mise) all write AFTER the traceback, so
+    # `tail -n 1` names the noise and discards the real cause.
+    cat > "$STUB" <<'PY'
+import sys
+print("Traceback (most recent call last):", file=sys.stderr)
+print('  File "config-drift.py", line 271, in collect', file=sys.stderr)
+print("RuntimeError: the corpus index is corrupt", file=sys.stderr)
+print("[gc] cleaning up temporary buffers", file=sys.stderr)
+sys.exit(1)
+PY
+    run_hook d4-trailing
+    assert_contains "the exception line is reported even when it is not last" \
+        "$HOOK_FINDINGS" "RuntimeError: the corpus index is corrupt"
+    assert_absent "the trailing atexit noise is not reported as the summary" \
+        "$HOOK_FINDINGS" "cleaning up temporary buffers"
+
+    # CONTROL: a failure with NO exception-shaped line must still report
+    # something -- the fallback to tail -n 1 has to survive. A shim that cannot
+    # find an interpreter writes no traceback at all.
+    cat > "$STUB" <<'PY'
+import sys
+print("mise: no python3 runtime installed for this directory", file=sys.stderr)
+sys.exit(1)
+PY
+    run_hook d4-noexc
+    assert_contains "CONTROL: with no exception-shaped line, the last line is used" \
+        "$HOOK_FINDINGS" "mise: no python3 runtime installed"
+
+    echo "TEST D5: argument and corpus errors are not packaged as analyzer failures"
+    # (a) exit 3 is config-drift.py's ARGUMENT VALIDATION return (`root not
+    # found`), not a failure. A cwd that is not a directory produced a permanent
+    # error/analyzer_failed nudge blaming a healthy analyzer.
+    cat > "$STUB" <<'PY'
+import sys
+print("root not found: /nope/not/a/dir", file=sys.stderr)
+sys.exit(3)
+PY
+    run_hook d5-badroot
+    assert_contains "exit 3 gets its own kind"      "$HOOK_FINDINGS" '"kind":"analyzer_bad_root"'
+    assert_contains "exit 3 is warn, not error"     "$HOOK_FINDINGS" '"severity":"warn"'
+    assert_absent  "exit 3 is not analyzer_failed"  "$HOOK_FINDINGS" 'analyzer_failed'
+
+    # (b) An unresolvable symlink under any .claude/rules/ is a CORPUS problem.
+    # Symlinked rules directories are normal under chezmoi/stow, and
+    # drift-aggregator.sh sorts error first and caps at MAX_LINES=5 across ALL
+    # plugins -- so error/analyzer_failed occupied slot 1 of 5 on every
+    # SessionStart, with a remediation that would not locate the file.
+    cat > "$STUB" <<'PY'
+import sys
+print("Traceback (most recent call last):", file=sys.stderr)
+print('  File "config-drift.py", line 296, in collect', file=sys.stderr)
+print("FileNotFoundError: [Errno 2] No such file or directory: "
+      "'/Users/x/.claude/rules/dangling.md'", file=sys.stderr)
+sys.exit(1)
+PY
+    run_hook d5-corpus
+    assert_contains "a file-read exception gets its own kind" \
+        "$HOOK_FINDINGS" '"kind":"corpus_unreadable"'
+    assert_contains "a file-read exception is warn, not error" \
+        "$HOOK_FINDINGS" '"severity":"warn"'
+    assert_contains "the summary blames the CORPUS, not the analyzer" \
+        "$HOOK_FINDINGS" "could not read a file in the config corpus"
+    assert_contains "the offending path survives into the summary" \
+        "$HOOK_FINDINGS" "dangling.md"
+
+    # CONTROL for both (a) and (b): a GENUINE analyzer failure must stay at
+    # error/analyzer_failed. Without this, downgrading everything to warn passes
+    # every assertion above while silencing the failure class the hook exists to
+    # surface.
+    cat > "$STUB" <<'PY'
+import sys
+print("Traceback (most recent call last):", file=sys.stderr)
+print("ModuleNotFoundError: No module named 'lib'", file=sys.stderr)
+sys.exit(1)
+PY
+    run_hook d5-genuine
+    assert_contains "CONTROL: an import error is still error/analyzer_failed" \
+        "$HOOK_FINDINGS" '"kind":"analyzer_failed"'
+    assert_contains "CONTROL: an import error is still severity error" \
+        "$HOOK_FINDINGS" '"severity":"error"'
+
+    # ---------------------------------------------------------------- the gate
+    # compare-ref-output.sh resolves REPO_ROOT as SCRIPT_DIR/../../.. and reads
+    # the baseline out of git, so the fixture reproduces that layout exactly.
+    # HOME is already redirected to $FIXROOT/home, so $HOME/repos/laurigates does
+    # not exist and only the fixture root is compared.
+    GATE_SRC="${REPO_ROOT}/health-plugin/scripts/tests/compare-ref-output.sh"
+    if [ ! -f "$GATE_SRC" ]; then
+        echo "  note  skipping D2/D3 (compare-ref-output.sh absent)"
+    else
+        # An inherited absolute GIT_DIR / GIT_WORK_TREE OVERRIDES `git -C`, so a
+        # leaked one would point every sandbox git op below at the shared
+        # checkout (issue #1745). Neutralise the whole family before any of them.
+        unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY \
+              GIT_COMMON_DIR GIT_NAMESPACE GIT_PREFIX
+
+        # build_gate_fixture <before-body-file> <after-body-file> -> GATE_DIR
+        build_gate_fixture() {
+            local before="$1" after="$2"
+            GATE_DIR=$(mktemp -d) || return 1
+            [ -n "$GATE_DIR" ] && [ -d "$GATE_DIR" ] || return 1
+            mkdir -p "$GATE_DIR/health-plugin/scripts/tests"
+            cp "$GATE_SRC" "$GATE_DIR/health-plugin/scripts/tests/compare-ref-output.sh"
+            cp "$before" "$GATE_DIR/health-plugin/scripts/config-drift.py"
+            git -C "$GATE_DIR" init -q
+            git -C "$GATE_DIR" -c user.email=t@t -c user.name=t add -A >/dev/null 2>&1
+            git -C "$GATE_DIR" -c user.email=t@t -c user.name=t \
+                -c commit.gpgsign=false -c core.hooksPath=/dev/null \
+                commit -q -m baseline >/dev/null 2>&1
+            cp "$after" "$GATE_DIR/health-plugin/scripts/config-drift.py"
+        }
+        run_gate() {
+            GATE_OUT=$(bash "$GATE_DIR/health-plugin/scripts/tests/compare-ref-output.sh" HEAD 2>&1)
+            GATE_RC=$?
+        }
+
+        echo "TEST D2: a baseline that produced 0 bytes is a harness error, never a content diff"
+        # A base ref whose analyzer dies before printing writes NOTHING on either
+        # stream, so the stderr guard alone never fires -- and cmp then reports
+        # the whole AFTER report as newly added: content FAILs, 0 harness errors,
+        # exactly the outcome harness_fail's own docstring says is impossible.
+        cat > "$FIXROOT/gate-dead.py" <<'PY'
+import sys
+sys.exit(1)
+PY
+        cat > "$FIXROOT/gate-live.py" <<'PY'
+import sys
+print("{}")
+sys.exit(1)
+PY
+        build_gate_fixture "$FIXROOT/gate-dead.py" "$FIXROOT/gate-live.py"
+        run_gate
+        assert_contains "an empty baseline is classified as a harness error" \
+            "$GATE_OUT" "0 bytes on stdout"
+        assert_contains "an empty baseline reports STATUS=HARNESS_ERROR" "$GATE_OUT" "STATUS=HARNESS_ERROR"
+        assert_contains "an empty baseline reports no content failures"   "$GATE_OUT" "FAILED=0"
+        assert_eq "an empty baseline exits 2, not 1" "$GATE_RC" "2"
+        rm -rf "$GATE_DIR"
+
+        # CONTROL: a baseline that DID run and genuinely differs must still be
+        # reported as a content FAIL. Without this, classifying every difference
+        # as a harness error passes the assertions above and destroys the gate.
+        cat > "$FIXROOT/gate-live2.py" <<'PY'
+import sys
+print("{\"different\": true}")
+sys.exit(1)
+PY
+        build_gate_fixture "$FIXROOT/gate-live.py" "$FIXROOT/gate-live2.py"
+        run_gate
+        assert_contains "CONTROL: a real content difference is still a FAIL" \
+            "$GATE_OUT" "  FAIL json @"
+        assert_absent "CONTROL: a real content difference is NOT a harness error" \
+            "$GATE_OUT" "HARNESS ERROR json @"
+        rm -rf "$GATE_DIR"
+
+        echo "TEST D3: a baseline identical to the analyzer under test compares nothing"
+        # BASE_REF defaults to origin/main, so this is the state the gate enters
+        # the moment this PR merges -- and it is silent: 7 green assertions over
+        # a file compared with itself.
+        build_gate_fixture "$FIXROOT/gate-live.py" "$FIXROOT/gate-live.py"
+        run_gate
+        assert_contains "an identical baseline is a harness error" \
+            "$GATE_OUT" "byte-identical to the analyzer under test"
+        assert_contains "an identical baseline reports STATUS=HARNESS_ERROR" "$GATE_OUT" "STATUS=HARNESS_ERROR"
+        assert_contains "an identical baseline scores no passes"             "$GATE_OUT" "PASSED=0"
+        assert_eq "an identical baseline exits 2, not 0" "$GATE_RC" "2"
+        rm -rf "$GATE_DIR"
+
+        # CONTROL: files that genuinely DIFFER must still be compared, even when
+        # their output is identical. Without it, "always harness-error" passes
+        # every D3 assertion and the gate never compares anything again.
+        cat > "$FIXROOT/gate-live-cmt.py" <<'PY'
+# a comment that changes the file but not a byte of its output
+import sys
+print("{}")
+sys.exit(1)
+PY
+        build_gate_fixture "$FIXROOT/gate-live.py" "$FIXROOT/gate-live-cmt.py"
+        run_gate
+        assert_absent "CONTROL: differing files are not called byte-identical" \
+            "$GATE_OUT" "byte-identical to the analyzer under test"
+        assert_contains "CONTROL: differing files with identical output still PASS" \
+            "$GATE_OUT" "  ok   json @"
+        rm -rf "$GATE_DIR"
+    fi
+fi
+
+echo "TEST D5c: an unreadable corpus file costs that file, not the whole sweep"
+# collect() read every rule and skill unguarded, so ONE dangling symlink under
+# any .claude/rules/ aborted the inventory before a single finding existed --
+# and symlinked rules dirs are normal under chezmoi/stow.
+DR="$FIXROOT/dangling"
+mkdir -p "$DR/home/.claude/rules" "$DR/proj/repo-c/.claude/rules"
+cat > "$DR/proj/repo-c/.claude/rules/ghost-c.md" <<'RULE'
+# Ghost C
+
+Promoted to a skill: invoke `no-such-skill-at-all` before doing the thing —
+it carries the whole procedure.
+RULE
+cat > "$DR/proj/repo-c/.claude/rules/plain-c.md" <<'RULE'
+# Plain C
+Ordinary readable prose about torque calibration on the assembly line.
+RULE
+ln -s "$DR/proj/repo-c/.claude/rules/gone-forever.md" \
+      "$DR/proj/repo-c/.claude/rules/dangling-c.md"
+[ -e "$DR/proj/repo-c/.claude/rules/dangling-c.md" ] && echo "  note  fixture symlink unexpectedly resolves"
+
+out=$(HOME="$DR/home" python3 "$ANALYZER" --root "$DR/proj" --no-embed --fast \
+    --format=json 2>"$DR/err")
+rc=$?
+# Exit code alone is not the test: an unguarded read_text raises, python exits 1,
+# and 1 is ALSO the analyzer's normal "found something" return -- so the
+# discriminator is the traceback on stderr.
+assert_eq "the run survives a dangling symlink (exit 0/1, not a traceback)" \
+    "$([ "$rc" -le 1 ] && [ ! -s "$DR/err" ] && echo yes || echo "no (rc=$rc, stderr=$(tail -n 1 "$DR/err" 2>/dev/null))")" "yes"
+assert_eq "the run emits a parseable document" \
+    "$(printf '%s' "$out" | jq -e 'has("findings")' >/dev/null 2>&1 && echo yes || echo no)" "yes"
+# CONTROL: the corpus must still be ANALYZED, not merely survived. A run that
+# skipped everything would also be parseable and exit cleanly.
+assert_eq "CONTROL: both readable rules are still inventoried" \
+    "$(printf '%s' "$out" | jq -r '.counts.rules' 2>/dev/null)" "2"
+assert_contains "CONTROL: the readable stub's finding still fires" "$out" "broken_pointer_stub"
+
+# Skipping is not swallowing. Degrading by one file SILENTLY is the worse bug:
+# a corpus two thirds of which failed to open would report a clean sweep, which
+# is the same false all-clear the hook repair (D1) exists to prevent, one layer
+# down. So the skip must be REPORTED, and it must name the path -- nothing else
+# locates the file for the reader.
+assert_contains "the skipped file is reported, not silently dropped" "$out" "corpus_unreadable"
+assert_eq "the unreadable path is named in the finding" \
+    "$(printf '%s' "$out" | jq -r '[.findings[] | select(.kind=="corpus_unreadable") | .paths[]] | map(select(endswith("dangling-c.md"))) | length' 2>/dev/null)" "1"
+assert_eq "it is warn, not error (the aggregator sorts error first across all plugins, cap 5)" \
+    "$(printf '%s' "$out" | jq -r '.findings[] | select(.kind=="corpus_unreadable") | .severity' 2>/dev/null)" "warn"
+# CONTROL: a corpus with nothing unreadable must NOT emit it -- otherwise the
+# three assertions above pass against an analyzer that always cries wolf, and
+# every clean SessionStart would carry a phantom warning.
+mkdir -p "$DR/clean/repo-d/.claude/rules"
+cp "$DR/proj/repo-c/.claude/rules/plain-c.md" "$DR/clean/repo-d/.claude/rules/plain-d.md"
+clean_out=$(HOME="$DR/home" python3 "$ANALYZER" --root "$DR/clean" --no-embed --fast --format=json 2>/dev/null)
+assert_eq "CONTROL fixture is non-vacuous: the clean corpus was actually read" \
+    "$(printf '%s' "$clean_out" | jq -r '.counts.rules' 2>/dev/null)" "1"
+assert_eq "CONTROL: a corpus with no unreadable file emits no corpus_unreadable" \
+    "$(printf '%s' "$clean_out" | jq -r '[.findings[] | select(.kind=="corpus_unreadable")] | length' 2>/dev/null)" "0"
+
+echo
+echo "=== PROBE LIB TESTS ==="
+echo "PASSED=$PASS"
+echo "FAILED=$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+    echo "STATUS=FAIL"
+    exit 1
+fi
+echo "STATUS=OK"
+exit 0

--- a/scripts/required-to-run-tests.txt
+++ b/scripts/required-to-run-tests.txt
@@ -53,6 +53,12 @@ taskwarrior-plugin/scripts/tests/test-task-id-stability.sh
 # absent by design" — it means the suite stopped executing, and the probe it
 # backs would go on reporting a clean corpus without having opened one.
 health-plugin/scripts/tests/test-config-drift.sh
+#
+# Same reasoning for the contract module the probe now imports: its ONLY
+# skip condition is a missing python3, and a broken `from lib.probe import ...`
+# fails SILENTLY (the hook reads empty analyzer output as "no findings"), so a
+# skip here would retire the one gate that can see it.
+health-plugin/scripts/tests/test-probe-lib.sh
 
 # git  (no install step needed — the runner checks out the repo with git, so
 # this test's only dependency is always present)


### PR DESCRIPTION
Closes the first half of #2527. Unblocks #2319, whose acceptance criteria are
entirely delta-reporting behaviour and which has had no fingerprint
implementation to live in.

## What moved, and what deliberately did not

`health-plugin/scripts/lib/probe.py` — stdlib only, **no PEP-723 block**. Both
real callers (`hooks/config-drift-probe.sh`, `scripts/tests/test-config-drift.sh`)
invoke a bare `python3`, bypassing the `uv run --script` shebang, so a
dependency block would resolve only on the unused path.

Imported as `from lib.probe import …`, **not** `import probe`: `sys.path[0]` is
the script's directory, not `lib/`, and PEP 420 implicit namespace packages
resolve the dotted form from there. Verified under bare `python3` from an
unrelated cwd and under `uv run --script`; the flat form raises
`ModuleNotFoundError` in both.

| Moved (contract) | Stayed (this probe's opinion) |
|---|---|
| `sha` — the 16-char truncation waiver hashes *and* fingerprints both depend on | `toks`/`shingles`/`jaccard`, `frontmatter`, `walk`/`collect` |
| `_canon`/`load_waivers`/`waived` → `Waivers` | `git_last_change`, `changed_since`, `_stub_target` |
| **new** `Finding`, `fingerprint`, `Baseline`/`Delta` | all seven `check_*` |
| **new** `render_status`/`render_json`/`exit_code` | every threshold |

A shared threshold would be wrong for every other probe, so none moved.

## Two design points that are easy to get wrong

**`fingerprint` folds a singular `path` into the path set.** Read as "`paths`
only", two `broken_pointer_stub` findings on different rules collapse to one
fingerprint and the second is invisible in every delta report forever. Folding
both also makes #2527b's `path`→`paths` normalization fingerprint-neutral — a
property that exists only if this PR lands first.

**`Baseline` records its root.** Fingerprints are built from absolute paths, so
a baseline recorded at one root and compared at another yields a *disjoint*
set: every finding new **and** every old one resolved, a maximally noisy false
report on the first cross-root run. A root or schema mismatch loads as `None`,
so the caller records fresh and stays silent.

## This PR owes a detection it did not previously need

`origin/main`'s analyzer imports nothing and cannot die before producing
output. This one can — so `config-drift-probe.sh` gained the failure path.

Previously an analyzer that produced nothing led to `drift_emit` writing
`"findings": []`, which per `drift-protocol.sh` **is** the "checked, no drift"
verdict — indistinguishable downstream from a clean corpus. It now reports
`analyzer_failed`, keyed on **empty-or-unparseable output rather than the exit
code**: `--format=json` prints unconditionally, so empty output is by itself
proof the analyzer never ran. (Gating on a non-zero exit missed the truncated-
analyzer case, which exits 0.)

Two further packagings, because an `error` here is expensive — the aggregator
sorts errors first across every plugin at a five-line cap, so a wrong one
occupies slot 1 on every session start until a human finds it:

- Exit 3 (bad root) is `warn`/`analyzer_bad_root`. The analyzer is healthy; the
  caller passed a bad root.
- An unreadable corpus file is **skipped and reported** (`corpus_unreadable`,
  `warn`, naming the path) rather than aborting the sweep. Symlinked rules
  directories are normal under chezmoi/stow, and one dangling link previously
  cost the entire run. Skipping silently would have been worse — a corpus two
  thirds of which failed to open would report a clean sweep.

## Evidence

| Check | Result |
|---|---|
| `--format=json` / `status` / `probe` vs `origin/main` | **byte-identical**, both real roots + a synthetic root |
| Independent review sweep | **68 root × format pairs**, zero divergences |
| Synthetic corpora | every construction site the real corpus cannot reach |
| Waivers | forward, reverse `(b,a)`, expired-hash, and `_canon` path forms |
| Malformed waiver files | identical exception class, message and exit code |
| `test-probe-lib.sh` | 133/133 |
| `test-config-drift.sh` | 61/61 |
| `compare-ref-output.sh` | 7/7, `HARNESS_ERRORS=0` |
| ruff / format / shellcheck / sandbox-guards | clean |

**Byte-identity is necessary, not sufficient, and the gate says so.** It shows
nothing regressed on the corpus as it exists today; it cannot show the contract
is right. The direct-call assertions do that.

## `emit_probe` is retained despite having no caller

Deleting a public `--format` choice is an output change, and this PR's whole
claim is that none occurred (`--format=probe` would have gone from a JSON
document to `exit 2`). It carries a comment saying so; #2527b removes it and
the `probe` choice together as a deliberate change.

## What review caught after the suite was green

Three rounds. The first found the extraction correct and the **harness** wrong:

- `compare-ref-output.sh` would have failed on its **first use after merge** —
  it extracts only `config-drift.py` into a scratch dir with no `lib/`, and the
  resulting `ModuleNotFoundError` exits 1 exactly like a legitimate
  `STATUS=WARN` run, so it reported a *content difference*. It captured the
  baseline's stderr and never read it.
- `BASE_REF` defaults to `origin/main`, so once this lands the gate would have
  compared the analyzer **against itself** — seven green assertions having
  compared nothing. The header anticipated the ref ageing out; identity happens
  first, and silently.
- The gate never exercised `broken_pointer_stub`, the only site passing
  singular `path=` — precisely where the kwargs-order property could break.

All three are fixed: the gate now extracts `lib/probe.py` when present, treats
an unrunnable or byte-identical baseline as a **harness error** (exit 2, never
a content difference), and compares a synthetic root firing the sites the real
corpus cannot reach. Mutation-verified — each repair has an assertion that dies
to its own mutant, and none survives a null `lib/probe.py`.

Refs #2527, #2319
