### PR TITLE
fix(health-plugin): normalize path to paths, ship the conformant status block, delete emit_probe

### DIFF
--- a/health-plugin/README.md
+++ b/health-plugin/README.md
@@ -50,10 +50,14 @@ them would be adopting a bug rather than a contract.
 
 Two properties are load-bearing and easy to break:
 
-- **`fingerprint` folds a singular `path` into the path set.** Read as "`paths`
-  only", every finding carrying `path` collapses to one fingerprint per kind, so
-  the second broken pointer stub in a corpus is invisible in every delta report
-  forever.
+- **`fingerprint` folds a singular `path` into the path set.** `config-drift.py`
+  no longer emits `path` — every construction site passes `paths=[...]` — but
+  `probe-delta.py` builds `Finding`s from an arbitrary JSON document, so the
+  singular spelling still arrives from outside this repo: a saved report, a
+  baseline recorded before the normalisation, an older installed plugin. Read as
+  "`paths` only", every such finding collapses to one fingerprint per kind and
+  the second of them is invisible in every delta report forever. Folding both
+  spellings is also what made the normalisation itself baseline-neutral.
 - **`Baseline` records the root it was taken at.** Fingerprints are built from
   absolute paths, so a baseline recorded at one root and compared at another
   yields a disjoint set — every finding new *and* every old one resolved. A root

--- a/health-plugin/hooks/config-drift-probe.sh
+++ b/health-plugin/hooks/config-drift-probe.sh
@@ -161,6 +161,31 @@ fi
 # so a greedy probe crowds out its siblings. Findings are collapsed by kind:
 # 74 stale-review entries must read as one actionable nudge, not 74 identical
 # ones.
+#
+# The `fix` map below is now the SINGLE SOURCE for kind -> remediation-skill.
+# It used to be one of two copies: config-drift.py carried a `--format=probe`
+# renderer with its own map, which no caller ever invoked and which had already
+# drifted (it was missing `coverage_metric_broken` and
+# `semantic_overlap_rule_skill`, both of which this one has). That renderer and
+# its `--format` choice were deleted, so this map is load-bearing rather than a
+# duplicate: adding a `kind` to config-drift.py without adding a row here routes
+# it to the `/health:check` fallback silently.
+#
+# The map is therefore COMPLETE over every kind the analyzer can emit, and
+# `test-probe-lib.sh` TEST N3 pins that: it derives the kind set from
+# config-drift.py's own `Finding(...)` call sites and asserts each has an
+# explicit row here. `corpus_unreadable` and `semantic_pass_unavailable` were
+# the two that fell through to the fallback; both now route explicitly to
+# `/health:check`, which is where a reader of either goes anyway — the point is
+# that the routing is a decision on the page rather than a default nobody chose.
+#
+# `semantic_overlap_skill_rule` is ABSENT ON PURPOSE and is not a gap. The
+# f-string `semantic_overlap_{a[kind]}_{b[kind]}` in `check_semantic_dupes` is
+# fed `rules + skills` (rules first) and iterates `np.triu_indices(k=1)`, so `a`
+# is always the LOWER index: a cross-kind pair is always (rule, skill) and never
+# (skill, rule). Adding the row would look like completeness and would in fact
+# pin a kind that cannot be produced. If that call ever stops concatenating
+# rules-then-skills, the kind becomes reachable and TEST N3 fails.
 while IFS=$'\t' read -r severity kind summary remediation; do
     [ -n "$kind" ] || continue
     drift_add_finding "$severity" "$kind" "$summary" "$remediation"
@@ -169,6 +194,7 @@ done < <(printf '%s' "$OUT" | jq -r '
   def fix:
     {"broken_pointer_stub":          "/agent-patterns:meta-promote",
      "coverage_metric_broken":       "/health:check",
+     "corpus_unreadable":            "/health:check",
      "duplicate_rule_lexical":       "/agent-patterns:meta-promote",
      "semantic_overlap_rule_rule":   "/agent-patterns:meta-promote",
      "semantic_overlap_rule_skill":  "/health:skill-audit",
@@ -176,6 +202,7 @@ done < <(printf '%s' "$OUT" | jq -r '
      "rule_covered_by_skill":        "/agent-patterns:meta-context-diet",
      "always_loaded_budget":         "/agent-patterns:meta-context-diet",
      "review_staleness":             "/health:skill-audit",
+     "semantic_pass_unavailable":    "/health:check",
      "frontmatter_coverage":         "/agent-patterns:meta-context-diet"}[.kind] // "/health:check";
   [.findings[]]
   | group_by(.kind)

--- a/health-plugin/scripts/config-drift.py
+++ b/health-plugin/scripts/config-drift.py
@@ -41,7 +41,14 @@ from pathlib import Path
 # `lib.probe`, not `probe`: sys.path[0] is this script's directory, and PEP 420
 # implicit namespace packages resolve the dotted form from there. Do not add an
 # __init__.py and do not touch sys.path.
-from lib.probe import Finding, Waivers, render_json, sha
+from lib.probe import (
+    Finding,
+    Waivers,
+    render_json,
+    render_report,
+    render_status,
+    sha,
+)
 
 HOME_RULES = Path.home() / ".claude" / "rules"
 SKIP_PARTS = {"node_modules", "dist", "worktrees", ".git", "__pycache__", "tmp"}
@@ -416,7 +423,7 @@ def check_stub_integrity(rules, skills) -> list[Finding]:
                     "error",
                     "broken_pointer_stub",
                     f"{r['name']} points at skill '{target or '(none named)'}' which does not exist",
-                    path=r["path"],
+                    paths=[r["path"]],
                 )
             )
     return out
@@ -457,7 +464,7 @@ def check_review_staleness(items, cache: dict, allow_spawn: bool) -> list[Findin
                     "warn",
                     "review_staleness",
                     f"{it['name']} changed {gap}d after its declared reviewed:{rv}",
-                    path=it["path"],
+                    paths=[it["path"]],
                     gap_days=gap,
                 )
             )
@@ -677,93 +684,36 @@ def check_semantic_dupes(items, waivers, cache_path: Path) -> list[Finding]:
 
 
 # ---------------------------------------------------------------------- output
-# DELIBERATE, not an oversight: `lib.probe.render_status` already emits the
-# conformant block (`ISSUE_COUNT=` plus the closing `=== END ... ===`) that the
-# renderer below lacks, and this PR keeps `emit_status` / `emit_report`
-# byte-identical so `--format=json` and `--format=status` can be `cmp`-verified
-# against the pre-extraction analyzer on the real corpus. Two status renderers
-# coexist for exactly one PR; the follow-up that normalises the shape switches
-# this call site over and deletes this one.
+# Every renderer now lives in `lib.probe`. The local `emit_status` that used to
+# sit here emitted neither the `ISSUE_COUNT=` roll-up nor the closing
+# `=== END CONFIG DRIFT ===` delimiter that
+# `.claude/rules/structured-script-output.md` marks required, so a rollup could
+# not tell where this probe's block ended; `render_status` emits both, and its
+# two keyword-only parameters carry the only differences between this caller and
+# probe-delta's (see that function's docstring).
+#
+# `emit_probe` and the `--format=probe` choice were deleted here rather than
+# ported: no caller invoked them. `hooks/config-drift-probe.sh` consumes
+# `--format=json` and derives kind -> remediation-skill in jq, which is now the
+# single source for that mapping rather than one of two copies.
 def emit_status(findings, counts):
-    print("=== CONFIG DRIFT ===")
-    for k, v in counts.items():
-        print(f"{k.upper()}={v}")
-    by_kind: dict[str, int] = {}
-    for f in findings:
-        by_kind[f["kind"]] = by_kind.get(f["kind"], 0) + 1
-    for k, v in sorted(by_kind.items()):
-        print(f"FINDING_{k.upper()}={v}")
-    errs = sum(1 for f in findings if f["severity"] == "error")
-    warns = sum(1 for f in findings if f["severity"] == "warn")
-    print(f"ERRORS={errs}\nWARNINGS={warns}")
-    # OK / WARN / ERROR per .claude/rules/structured-script-output.md, not
-    # PASS/FAIL -- orchestrating skills grep for the house vocabulary.
-    print("STATUS=" + ("ERROR" if errs else "WARN" if warns else "OK"))
-
-
-# DEAD CODE, deliberately retained for THIS PR only. No caller invokes
-# `--format=probe`: hooks/config-drift-probe.sh consumes `--format=json` and
-# re-derives the remediation map in jq. It stays because this PR's whole claim
-# is that no output changed, and deleting a public `--format` choice would turn
-# a byte-identity refactor into a CLI-surface removal. #2527b deletes it and the
-# `"probe"` choice together, as an intentional change with its own rationale.
-def emit_probe(findings):
-    """drift-protocol shape: severity/kind/summary/remediation_skill."""
-    remediation = {
-        "broken_pointer_stub": "/agent-patterns:meta-promote",
-        "duplicate_rule_lexical": "/agent-patterns:meta-promote",
-        "semantic_overlap_rule_rule": "/agent-patterns:meta-promote",
-        "semantic_overlap_skill_skill": "/health:skill-audit",
-        "rule_covered_by_skill": "/agent-patterns:meta-context-diet",
-        "always_loaded_budget": "/agent-patterns:meta-context-diet",
-        "review_staleness": "/health:skill-audit",
-        "frontmatter_coverage": "/agent-patterns:meta-context-diet",
-    }
-    ranked = sorted(
-        findings, key=lambda f: {"error": 0, "warn": 1, "info": 2}[f["severity"]]
-    )
+    # severity_prefix="": `findings` here is EVERY finding this run produced,
+    # not a delta subset, so the counters keep the bare `ERRORS=`/`WARNINGS=`
+    # names a rollup already greps for.
+    # list_issues=False: the optional per-finding block would append one line
+    # per finding, and a real corpus run reports 60+ of them.
+    # What that costs the reader: `ISSUE_COUNT=` spans ALL THREE severities, so
+    # it exceeds `ERRORS + WARNINGS` by however many `info` findings fired
+    # (a real run: ERRORS=0 WARNINGS=60 ISSUE_COUNT=66 — one
+    # frontmatter_coverage and five rule_covered_by_skill). Read as "actionable
+    # issues" it over-counts, and with the ISSUES: block suppressed there is no
+    # in-block way to see the split. `--format=json` is the machine-readable
+    # answer to "which ones?".
     print(
-        json.dumps(
-            {
-                "plugin": "config-drift",
-                "checked_at": dt.datetime.now(dt.timezone.utc).isoformat(
-                    timespec="seconds"
-                ),
-                "findings": [
-                    {
-                        "severity": f["severity"],
-                        "kind": f["kind"],
-                        "summary": f["summary"],
-                        "remediation_skill": remediation.get(
-                            f["kind"], "/health:check"
-                        ),
-                    }
-                    for f in ranked[:5]
-                ],
-            },
-            indent=1,
+        render_status(
+            "CONFIG DRIFT", findings, counts, severity_prefix="", list_issues=False
         )
     )
-
-
-def emit_report(findings, counts):
-    print("# Claude config drift report\n")
-    print(f"_{dt.datetime.now().isoformat(timespec='seconds')}_\n")
-    print("| Metric | Value |\n|---|---|")
-    for k, v in counts.items():
-        print(f"| {k.replace('_', ' ')} | {v} |")
-    print()
-    for sev in ("error", "warn", "info"):
-        group = [f for f in findings if f["severity"] == sev]
-        if not group:
-            continue
-        print(f"\n## {sev.upper()} ({len(group)})\n")
-        for f in group[:40]:
-            print(f"- **{f['kind']}** — {f['summary']}")
-            for p in f.get("paths", [])[:2]:
-                print(f"  - `{p}`")
-        if len(group) > 40:
-            print(f"\n_…{len(group) - 40} more suppressed._")
 
 
 # ------------------------------------------------------------------------ main
@@ -777,9 +727,7 @@ def main() -> int:
     # ~/.claude/rules are always scanned regardless of --root, because they load
     # in every session no matter which project is open.
     ap.add_argument("--root", default=".")
-    ap.add_argument(
-        "--format", choices=["status", "probe", "report", "json"], default="status"
-    )
+    ap.add_argument("--format", choices=["status", "report", "json"], default="status")
     ap.add_argument(
         "--no-embed",
         action="store_true",
@@ -855,6 +803,28 @@ def main() -> int:
             )
 
     if args.since:
+        # KNOWN AND ACCEPTED: `--since` can never surface a finding about
+        # `~/.claude/rules`. `HOME_RULES` is scanned regardless of `--root`
+        # (those rules load in every session), but `changed_since` walks only
+        # `root.rglob(".git")` plus `root` — a home-rule path is outside every
+        # repo it asks, so it can never enter `touched`, and every home-rule
+        # finding is dropped here. Before the finding-shape normalisation the
+        # two singular-`path` kinds escaped through the `not f.get("paths")`
+        # arm by accident; now they are filtered like everything else, which is
+        # the CONSISTENT behaviour, not a new bug.
+        #
+        # Left as-is deliberately. `--since` means "findings whose files
+        # changed in this git range", and a home rule is not in the range — it
+        # is not in a repo at all. Making it an exception would mean either
+        # re-admitting pathless findings (which is the bug that was just fixed)
+        # or special-casing HOME_RULES to "always touched", which reports a
+        # standing condition as a change and defeats the flag. The cost is
+        # real and worth naming: the always-loaded home rules are the
+        # highest-value slice of the corpus (51 rules, ~39k tok/turn on this
+        # machine), and `--since` is structurally blind to them. No caller
+        # passes `--since` today; the flag is for a reviewer scoping a diff,
+        # who has the unfiltered run available. Pinned by `test-probe-lib.sh`
+        # TEST N6 so this is a recorded decision, not a drift.
         touched = changed_since(root, args.since)
         findings = [
             f
@@ -876,8 +846,12 @@ def main() -> int:
 
     {
         "status": emit_status,
-        "probe": lambda f, c: emit_probe(f),
-        "report": emit_report,
+        # The timestamp is computed HERE, not inside the renderer: nothing in
+        # lib.probe reads a clock, which is what lets a renderer be compared
+        # against itself across two runs.
+        "report": lambda f, c: print(
+            render_report(f, c, dt.datetime.now().isoformat(timespec="seconds"))
+        ),
         "json": lambda f, c: print(render_json(f, c, indent=1)),
     }[args.format](findings, counts)
 

--- a/health-plugin/scripts/lib/probe.py
+++ b/health-plugin/scripts/lib/probe.py
@@ -24,13 +24,14 @@ What is contract, and why:
   either side may be spelled first; a probe that only tried one orientation
   would silently ignore half the file.
 * `Baseline` / `Delta` — remembering what was already reported.
-* `render_status` / `render_json` / `exit_code` — the output contract an
-  orchestrating skill greps. `render_status` emits the shape
+* `render_status` / `render_report` / `render_json` / `exit_code` — the output
+  contract an orchestrating skill greps. `render_status` emits the shape
   `.claude/rules/structured-script-output.md` mandates: `=== SECTION ===` /
   `=== END SECTION ===` delimiters, uppercase `KEY=VALUE` lines, an
   `ISSUE_COUNT=` roll-up, and a `STATUS=` drawn from `OK|WARN|ERROR` and no
   other word — a rollup matches that alternation, so a fourth verdict is
-  invisible rather than distinct.
+  invisible rather than distinct. `render_report` is the human-facing markdown
+  view of the same finding list.
 
 Stdlib only, and deliberately NO PEP-723 dependency block: both real callers
 (`hooks/config-drift-probe.sh` and the test suite) invoke a bare `python3`,
@@ -91,6 +92,12 @@ class Finding:
             raise ValueError(f"kind must match {_KIND_RE.pattern}, got {kind!r}")
         if not summary:
             raise ValueError("summary must be non-empty")
+        # Still live after config-drift normalised its two singular sites to
+        # `paths=[...]`: `probe-delta.py:_parse` builds Findings from an
+        # arbitrary JSON document (a saved report, an older installed plugin's
+        # output), so `path=` can still arrive from outside this repo. The
+        # `fingerprint` fold below depends on exactly one spelling being
+        # present, so the guard has to outlive the call sites that motivated it.
         if "path" in extra and "paths" in extra:
             raise ValueError(
                 "a finding carries `path` OR `paths`, never both — "
@@ -343,12 +350,22 @@ def render_json(findings, counts, indent: int = 1) -> str:
     )
 
 
-def render_status(section: str, findings, counts) -> str:
+def render_status(
+    section: str,
+    findings,
+    counts,
+    *,
+    severity_prefix: str = "NEW_",
+    list_issues: bool = True,
+) -> str:
     """A conformant `structured-script-output.md` block.
 
     Conformant means it carries the closing `=== END <section> ===` delimiter
-    and an `ISSUE_COUNT=` roll-up, which config-drift's own `emit_status` does
-    not — that one predates the convention and is kept byte-identical for now.
+    and an `ISSUE_COUNT=` roll-up. This is now the ONLY status renderer:
+    `config-drift.py`'s own `emit_status` lacked both of those lines and was
+    retired into this function, which is why the two keyword-only parameters
+    below exist — they are the difference between the two callers, and nothing
+    else about the block differs.
 
     `STATUS` is `OK` / `WARN` / `ERROR` and nothing else. That vocabulary is
     fixed by `.claude/rules/structured-script-output.md`, and a rollup greps
@@ -359,16 +376,48 @@ def render_status(section: str, findings, counts) -> str:
     wants to say more says it in `counts` (`FIRST_RUN=true`, `NEW=0`), where a
     new key adds information instead of breaking an existing match.
 
-    The severity counters are `NEW_ERRORS=` / `NEW_WARNINGS=`, not
-    `ERRORS=` / `WARNINGS=`, because `findings` here is the SUBSET the caller
-    chose to render while its `counts` carries the full total —
-    `config-drift.py`'s `emit_status` already writes `ERRORS=`/`WARNINGS=` over
-    the whole set, so reusing those names would give a combined-log rollup two
-    contradictory answers to one `grep '^ERRORS='`.
+    `severity_prefix` answers "is `findings` the whole set, or a subset?", and
+    that is the only question the key name encodes. `probe-delta.py` renders
+    the NEW findings while its `counts` carries the total, so it keeps the
+    default `NEW_ERRORS=`/`NEW_WARNINGS=`; `config-drift.py --format=status`
+    renders every finding it produced, so it passes `severity_prefix=""` and
+    writes the bare `ERRORS=`/`WARNINGS=` it has always written. Sharing one
+    name across both would give a combined-log rollup two contradictory answers
+    to one `grep '^ERRORS='` — which is the reason the prefix exists at all,
+    not an argument for forcing every caller onto the prefixed form.
+
+    `ISSUE_COUNT=` is the one key that CANNOT be split that way, and the
+    collision is deliberate. `.claude/rules/structured-script-output.md` mandates
+    the literal `ISSUE_COUNT=` in every conformant block, so two conformant
+    blocks in one combined log necessarily both emit it and a naive
+    `grep -m1 '^ISSUE_COUNT='` returns whichever section printed first —
+    config-drift's FULL count where it used to return probe-delta's NEW count,
+    because config-drift's block carried no `ISSUE_COUNT=` at all before this
+    renderer became its only one. Renaming the key would fix the grep and break
+    conformance, which is the wrong trade: the rollup that matters reads
+    `ISSUE_COUNT=` per section.
+
+    The resolution is the `=== END <section> ===` delimiter this renderer also
+    emits, and which config-drift's retired `emit_status` did not. With both
+    delimiters present a parser can bracket a section and read the keys inside
+    it, so section-aware parsing is possible for the first time and a correct
+    parser is strictly better off than before. Only a parser that greps the
+    whole log for a bare key regresses, and that parser was already unable to
+    tell two sections apart.
+
+    `list_issues` selects whether the optional `ISSUES:` block is emitted.
+    `structured-script-output.md` marks that block optional, and a probe whose
+    finding list is corpus-sized (config-drift routinely reports 60+ review
+    staleness entries) turns a two-line roll-up into a scrolling wall — the
+    machine-readable answer to "what exactly?" is `--format=json`.
     """
     lines = [f"=== {section} ==="]
     for key, value in counts.items():
         lines.append(f"{key.upper()}={value}")
+    # `sorted` for the kind counters but the caller's own order for `counts`:
+    # `counts` is a hand-ordered summary (rules, skills, scopes, ...) whose
+    # sequence is meaningful to a reader, while `by_kind` is derived and needs a
+    # deterministic order that does not depend on which finding fired first.
     by_kind: dict[str, int] = {}
     for f in findings:
         by_kind[f["kind"]] = by_kind.get(f["kind"], 0) + 1
@@ -376,11 +425,11 @@ def render_status(section: str, findings, counts) -> str:
         lines.append(f"FINDING_{kind.upper()}={n}")
     errs = sum(1 for f in findings if f["severity"] == "error")
     warns = sum(1 for f in findings if f["severity"] == "warn")
-    lines.append(f"NEW_ERRORS={errs}")
-    lines.append(f"NEW_WARNINGS={warns}")
+    lines.append(f"{severity_prefix}ERRORS={errs}")
+    lines.append(f"{severity_prefix}WARNINGS={warns}")
     lines.append("STATUS=" + ("ERROR" if errs else "WARN" if warns else "OK"))
     lines.append(f"ISSUE_COUNT={len(findings)}")
-    if findings:
+    if findings and list_issues:
         lines.append("ISSUES:")
         for f in findings:
             lines.append(
@@ -388,3 +437,42 @@ def render_status(section: str, findings, counts) -> str:
             )
     lines.append(f"=== END {section} ===")
     return "\n".join(lines)
+
+
+def render_report(findings, counts, now: str) -> str:
+    """The human-facing markdown report for a finding list.
+
+    `now` is passed IN rather than read here: nothing else in this module calls
+    a clock, and a renderer that does cannot be compared against itself across
+    two runs (`compare-ref-output.sh` excludes this format for exactly that
+    reason). The caller owns the timestamp.
+
+    Three details are load-bearing rather than incidental:
+
+    * `paths[:2]` — a finding may carry many paths (`corpus_unreadable` carries
+      every unreadable file); two locate it, the rest are noise in a report a
+      human reads top to bottom.
+    * the `[:40]` per-severity cap plus its `_…N more suppressed._` line — the
+      count is what stops a truncated section reading as a complete one.
+    * the em-dash (U+2014) between kind and summary. It is the visual break
+      that makes a long summary scannable; a hyphen collides with the markdown
+      list bullets nested underneath.
+    """
+    parts = [
+        "# Claude config drift report\n",
+        f"_{now}_\n",
+        "| Metric | Value |\n|---|---|",
+    ]
+    parts += [f"| {k.replace('_', ' ')} | {v} |" for k, v in counts.items()]
+    parts.append("")
+    for sev in ("error", "warn", "info"):
+        group = [f for f in findings if f["severity"] == sev]
+        if not group:
+            continue
+        parts.append(f"\n## {sev.upper()} ({len(group)})\n")
+        for f in group[:40]:
+            parts.append(f"- **{f['kind']}** — {f['summary']}")
+            parts += [f"  - `{p}`" for p in f.get("paths", [])[:2]]
+        if len(group) > 40:
+            parts.append(f"\n_…{len(group) - 40} more suppressed._")
+    return "\n".join(parts)

--- a/health-plugin/scripts/tests/compare-ref-output.sh
+++ b/health-plugin/scripts/tests/compare-ref-output.sh
@@ -1,30 +1,52 @@
 #!/usr/bin/env bash
-# compare-ref-output.sh — byte-identity gate for the config-drift contract extraction.
+# compare-ref-output.sh — compare this analyzer's output against an arbitrary git ref.
+#
+# WHAT IT IS
+# A general differential harness: extract `config-drift.py` (and `lib/probe.py`)
+# AS THEY WERE at BASE_REF, run that copy and the working-tree copy BACK-TO-BACK
+# over the same corpora, and `cmp` the bytes. Refactors of this analyzer — nine
+# finding-construction sites, three renderers, two caches, a two-orientation
+# waiver lookup — have no cheap total oracle other than the output itself, so
+# this is how a no-op refactor is shown to be a no-op.
+#
+# WHAT A PASS MEANS, AND WHEN IT MEANS NOTHING
+# `STATUS=OK` is "the two copies agree", nothing more. It is evidence about a
+# refactor only when BASE_REF predates the change under test and no DELIBERATE
+# output change sits between them. Three states, all reachable and all correct:
+#
+#   1. BASE_REF is older AND an intentional output change landed in between
+#      -> STATUS=FAIL, exit 1. CORRECT. The output changed on purpose; the
+#      differences are the change. Read the diff, do not "fix" the script.
+#      (`origin/main` is in this state against any ref predating the finding-
+#      shape normalisation: `path=` became `paths=[...]`, so `--format=json`
+#      and `--format=status` both moved by design.)
+#   2. BASE_REF resolves to the working tree's own bytes — the default state
+#      once a PR merges, since BASE_REF defaults to origin/main
+#      -> STATUS=HARNESS_ERROR, exit 2. The gate would otherwise compare a file
+#      with itself and report green having compared nothing. Pass an older ref.
+#   3. BASE_REF is genuinely comparable — an older ref with no intended output
+#      change in between -> STATUS=OK, exit 0, and the refactor is a no-op.
+#
+# So there is no ref at which this script is expected to be green forever, and
+# a red run is not by itself a defect. Establish which of the three states you
+# are in before acting on the result.
 #
 # DELIBERATELY NOT NAMED test-*.sh. `scripts/run-skill-script-tests.sh` discovers
-# `*/scripts/tests/test-*.sh`, and this script is only meaningful while the base
-# ref it compares against is still resolvable. Once that ref ages out of the
-# clone (or the follow-up PR normalises the finding shape ON PURPOSE), a
-# discovered test would go red for a reason nobody can act on — a gate everyone
-# learns to bypass. Run it by hand, as the acceptance check for the extraction.
+# `*/scripts/tests/test-*.sh`. States 1 and 2 above are both normal and both
+# non-zero, so a discovered test would go red for a reason nobody can act on —
+# a gate everyone learns to bypass. Run it by hand, against a ref you chose.
 #
-# WHAT IT PROVES
-# Moving nine finding-construction sites, three renderers, two caches and a
-# two-orientation waiver lookup has no cheap total oracle other than the output
-# itself. So: check out the analyzer AS IT WAS at the base ref, run it and the
-# current one BACK-TO-BACK over the same corpus, and `cmp` the bytes.
-#
-#   --format=report and --format=probe are EXCLUDED: both embed
-#   `datetime.now()`, so two runs of the SAME file differ whenever the clock
-#   ticks between them and the comparison would assert nothing.
+#   --format=report is EXCLUDED: it embeds `datetime.now()`, so two runs of the
+#   SAME file differ whenever the clock ticks between them and the comparison
+#   would assert nothing.
 #
 # TWO CORPORA, because the real ones do not reach most of the code
 # ------------------------------------------------------------------
 # At this repo's root and the portfolio root, only four of the nine
 # construction sites ever fire: review_staleness, rule_covered_by_skill,
 # frontmatter_coverage and duplicate_rule_lexical. A comparison over those
-# alone leaves `broken_pointer_stub` (the ONLY site passing a singular `path=`,
-# i.e. exactly where "kwargs order == dict-literal order" could break),
+# alone leaves `broken_pointer_stub` (a single-element `paths=[...]`, and the
+# site whose kwargs order the finding-shape normalisation moved),
 # `always_loaded_budget` (the only `tokens=`) and `coverage_metric_broken`
 # unexercised — and with no `~/.claude/config-drift-waivers.json` on this
 # machine, the two-orientation waiver lookup and `_canon` are not exercised
@@ -70,11 +92,11 @@
 #
 # TWO WAYS THIS GATE STOPS MEANING ANYTHING, both HARNESS_ERROR:
 #   * the ref AGES OUT of the clone — loud, `git show` fails, already handled.
-#   * the ref becomes IDENTICAL to the working tree — SILENT, and it happens
-#     FIRST: BASE_REF defaults to origin/main, so the moment this PR merges,
-#     `cmp` compares the analyzer with itself and reports 7 green assertions
-#     having compared nothing. Identity is asserted against right after the
-#     extraction, below.
+#   * the ref becomes IDENTICAL to the working tree — SILENT, and it is the
+#     DEFAULT state between PRs: BASE_REF defaults to origin/main, so as soon
+#     as a branch merges, `cmp` compares the analyzer with itself and would
+#     report green assertions having compared nothing (state 2 above). Identity
+#     is asserted against right after the extraction, below.
 #
 # Usage: bash health-plugin/scripts/tests/compare-ref-output.sh [BASE_REF]
 #        BASE_REF defaults to $BASE_REF, then origin/main.

--- a/health-plugin/scripts/tests/test-probe-lib.sh
+++ b/health-plugin/scripts/tests/test-probe-lib.sh
@@ -508,26 +508,329 @@ assert_eq "CONTROL: without --no-embed the embed path IS reached" \
 rm -f "$EMBED_IMPORT_MARKER"
 unset EMBED_IMPORT_MARKER
 
-echo "TEST j: current bugs pinned deliberately (inverted by the follow-up PR)"
-# j1. `--since <ref>` keeps `not f.get("paths")` as its escape hatch, and a
-# singular-`path` finding has no `paths` key -- so a broken_pointer_stub whose
-# file was NOT touched survives the filter while a paths-carrying duplicate is
-# correctly dropped. The follow-up PR normalises path -> paths, which INVERTS
-# this assertion; when it does, this case is the record of what changed.
+echo "TEST j: the two singular-path bugs are FIXED (assertions inverted in place)"
+# #2536 pinned these two as PINNED BUG assertions because its claim was that no
+# output changed. #2527b normalises the two singular `path=` construction sites
+# to `paths=[...]`, and both bugs fall out AS A CONSEQUENCE rather than as
+# separate edits. The assertions are inverted IN PLACE, so the behaviour change
+# reads as two flipped lines rather than a deleted case and an unrelated new one.
+kinds() { printf '%s' "$1" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(sum(1 for f in d["findings"] if f["kind"]==sys.argv[1]))' "$2" 2>/dev/null || echo ERR; }
+stub_paths() { printf '%s' "$1" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(" ".join(p for f in d["findings"] if f["kind"]=="broken_pointer_stub" for p in f.get("paths",[])))' 2>/dev/null || echo ERR; }
+
+# j1. `--since <ref>` filters on `not f.get("paths") or any(p in touched ...)`.
+# A singular-`path` finding has no `paths` key, so `not f.get("paths")` was True
+# and it was NEVER filtered -- it rode through every delta-only report as though
+# its file had been touched. Both halves are asserted, because "always filtered"
+# passes the drop half on its own and destroys the feature.
+#
+# The RETAIN half needs a REAL git repo: `changed_since` resolves touched paths
+# with `git diff --name-only <ref>`, so a non-repo fixture yields an empty
+# touched-set and every path-carrying finding drops for the wrong reason. An
+# inherited absolute GIT_DIR/GIT_WORK_TREE overrides `git -C`, so neutralise the
+# whole family first (#1745) -- this block runs before the D2/D3 fixtures that
+# do the same.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY \
+      GIT_COMMON_DIR GIT_NAMESPACE GIT_PREFIX
+SINCE_ROOT="$FIXROOT/since/proj"
+SINCE_HOME="$FIXROOT/since/home"
+mkdir -p "$SINCE_ROOT/.claude/rules" "$SINCE_HOME/.claude/rules"
+# Names chosen so neither is a SUBSTRING of the other: `touched`/`untouched`
+# would make every `assert_contains "...touched-stub.md"` match both.
+cat > "$SINCE_ROOT/.claude/rules/edited-stub.md" <<'RULE'
+# Edited Stub
+
+Promoted to a skill: invoke `no-such-skill-edited` before doing the thing —
+it carries the whole procedure.
+RULE
+cat > "$SINCE_ROOT/.claude/rules/pristine-stub.md" <<'RULE'
+# Pristine Stub
+
+Promoted to a skill: invoke `no-such-skill-pristine` before doing the thing —
+it carries the whole procedure.
+RULE
+git -C "$SINCE_ROOT" init -q >/dev/null 2>&1
+git -C "$SINCE_ROOT" -c user.email=t@t -c user.name=t add -A >/dev/null 2>&1
+git -C "$SINCE_ROOT" -c user.email=t@t -c user.name=t \
+    -c commit.gpgsign=false -c core.hooksPath=/dev/null \
+    commit -q -m baseline >/dev/null 2>&1
+printf '\nAn edit that changes the file but not its broken target.\n' \
+    >> "$SINCE_ROOT/.claude/rules/edited-stub.md"
+
+out=$(HOME="$SINCE_HOME" python3 "$ANALYZER" --root "$SINCE_ROOT" --no-embed --fast \
+    --format=json 2>/dev/null)
+# FIXTURE VALIDITY: without --since both stubs must fire, or the filtered count
+# below is 1 because only one finding ever existed.
+assert_eq "FIXTURE: both broken stubs are found with no --since" \
+    "$(kinds "$out" broken_pointer_stub)" "2"
+
+out=$(HOME="$SINCE_HOME" python3 "$ANALYZER" --root "$SINCE_ROOT" --no-embed --fast \
+    --format=json --since HEAD 2>/dev/null)
+assert_eq "--since now FILTERS a singular-path stub whose file was NOT touched" \
+    "$(kinds "$out" broken_pointer_stub)" "1"
+assert_contains "--since RETAINS the stub whose file WAS touched" \
+    "$(stub_paths "$out")" "edited-stub.md"
+assert_absent "the untouched stub's path is gone from the report" \
+    "$(stub_paths "$out")" "pristine-stub.md"
+
+# The original CONTROL stays: a paths-carrying finding in a NON-repo corpus has
+# an empty touched-set, so it is still correctly dropped.
 out=$(python3 "$ANALYZER" --root "$FIXROOT/proj" --no-embed --fast --format=json \
     --since HEAD 2>/dev/null)
-kinds() { printf '%s' "$1" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(sum(1 for f in d["findings"] if f["kind"]==sys.argv[1]))' "$2" 2>/dev/null || echo ERR; }
-assert_eq "PINNED BUG: --since retains an untouched singular-path stub finding" \
-    "$(kinds "$out" broken_pointer_stub)" "1"
-assert_eq "CONTROL: --since correctly drops an untouched paths-carrying finding" \
+assert_eq "CONTROL: --since still drops an untouched paths-carrying finding" \
     "$(kinds "$out" duplicate_rule_lexical)" "0"
+assert_eq "the untouched singular-path stub is dropped here too" \
+    "$(kinds "$out" broken_pointer_stub)" "0"
 
-# j2. emit_report prints `f.get("paths", [])[:2]` only, so a singular-`path`
-# finding's file is never shown -- the reader is told a stub is broken and not
-# which one. Also inverted by the follow-up PR.
+# TEST N6: --since is STRUCTURALLY BLIND to ~/.claude/rules. Pinned, not fixed.
+# HOME_RULES is scanned regardless of --root, but changed_since() walks only
+# root.rglob(".git") plus root -- so a home-rule path is outside every repo it
+# asks and can never enter `touched`. Pre-normalisation the two singular-`path`
+# kinds escaped through the `not f.get("paths")` arm by accident; now they are
+# filtered like everything else. See the reasoning at the filter in
+# config-drift.py: this is a recorded decision, and a change to it should fail
+# here rather than pass silently.
+cat > "$SINCE_HOME/.claude/rules/home-stub.md" <<'RULE'
+# Home Stub
+
+Promoted to a skill: invoke `no-such-skill-home` before doing the thing —
+it carries the whole procedure.
+RULE
+out=$(HOME="$SINCE_HOME" python3 "$ANALYZER" --root "$SINCE_ROOT" --no-embed --fast \
+    --format=json 2>/dev/null)
+# FIXTURE VALIDITY: the home rule must be in the corpus at all. Without this the
+# --since assertion below passes against an analyzer that never read HOME_RULES.
+assert_eq "FIXTURE: the home-rule stub fires with no --since (3 stubs now)" \
+    "$(kinds "$out" broken_pointer_stub)" "3"
+assert_contains "FIXTURE: the home-rule stub's path is in the unfiltered report" \
+    "$(stub_paths "$out")" "home-stub.md"
+# Without this the case does not pin HOME-ness at all. Move the fixture into
+# $SINCE_ROOT and every assertion below still passes -- an UNTRACKED file inside
+# the repo is dropped by the same filter for a different reason, because
+# `changed_since` uses `git diff --name-only HEAD`, which never lists untracked
+# paths. The drop assertion's own wording ("no repo contains its path") would
+# then be satisfied by a case where one does.
+assert_eq "FIXTURE: the home-rule stub's path is OUTSIDE the sandbox repo" \
+    "$(printf '%s' "$(stub_paths "$out")" | tr ' ' '\n' | grep -c "^$SINCE_HOME/")" "1"
+
+out=$(HOME="$SINCE_HOME" python3 "$ANALYZER" --root "$SINCE_ROOT" --no-embed --fast \
+    --format=json --since HEAD 2>/dev/null)
+assert_absent "--since drops the home-rule finding (no repo contains its path)" \
+    "$(stub_paths "$out")" "home-stub.md"
+# CONTROL: the same filtered run must still RETAIN the in-repo touched stub, or
+# "drops the home rule" is satisfied by a filter that drops everything.
+assert_contains "CONTROL: the touched in-repo stub survives the same filter" \
+    "$(stub_paths "$out")" "edited-stub.md"
+
+# j2. `render_report` prints `f.get("paths", [])[:2]`, so a singular-`path`
+# finding's file was never shown -- the reader was told a stub is broken and not
+# which one. Inverted with N1: the path is now printed.
 rep=$(python3 "$ANALYZER" --root "$FIXROOT/proj" --no-embed --fast --format=report 2>/dev/null)
 assert_contains "the report does list the broken stub finding" "$rep" "broken_pointer_stub"
-assert_absent "PINNED BUG: --format=report never prints that stub's path" "$rep" "$STUB_PATH"
+assert_contains "--format=report now prints that stub's path" "$rep" "$STUB_PATH"
+
+# The LARGER half of the same change: `review_staleness` also carried a singular
+# `path` pre-N1, and it is the bulk of a real report (60 of 66 findings on this
+# portfolio; the path lines in `render_report` went 10 -> 50). Asserting only
+# the stub case leaves that half unpinned.
+#
+# It needs a REAL git repo and NO --fast: check_review_staleness reads a git
+# commit date, and in fast mode a cache miss is SKIPPED rather than spawned, so
+# the finding would never fire. SINCE_ROOT is already an initialised sandbox
+# repo, and the git-env family was neutralised above (#1745).
+cat > "$SINCE_ROOT/.claude/rules/stale-review.md" <<'RULE'
+---
+reviewed: 2000-01-01
+---
+# Stale Review
+
+Provisioning the kiln requires the glaze schedule before any bisque firing is
+scheduled on the studio calendar.
+RULE
+git -C "$SINCE_ROOT" -c user.email=t@t -c user.name=t add -A >/dev/null 2>&1
+git -C "$SINCE_ROOT" -c user.email=t@t -c user.name=t \
+    -c commit.gpgsign=false -c core.hooksPath=/dev/null \
+    commit -q -m stale >/dev/null 2>&1
+srep=$(HOME="$SINCE_HOME" python3 "$ANALYZER" --root "$SINCE_ROOT" --no-embed \
+    --format=report 2>/dev/null)
+# FIXTURE VALIDITY: the finding has to exist before its path line can be
+# asserted -- a report missing the whole section passes an absence check.
+assert_contains "FIXTURE: the review_staleness finding fires without --fast" \
+    "$srep" "review_staleness"
+assert_contains "--format=report prints the review_staleness path too" \
+    "$srep" "stale-review.md"
+# CONTROL: it is the INDENTED backticked path line render_report emits for
+# `paths`, not an incidental mention of the filename in the summary (the summary
+# names the rule as `stale-review`, with no extension). The absolute prefix is
+# not asserted: --root is `.resolve()`d, so macOS reports /private/var/... where
+# the fixture was created at /var/....
+# shellcheck disable=SC2016  # the single quotes are deliberate: this is a
+# literal ERE (backticks, `\.`) that must reach grep unexpanded.
+assert_eq "the path is rendered as a paths line, not just named in prose" \
+    "$(printf '%s\n' "$srep" | grep -cE '^  - `.*/\.claude/rules/stale-review\.md`$')" "1"
+
+echo "TEST k: --format=status is the conformant structured-script-output block"
+st=$(python3 "$ANALYZER" --root "$FIXROOT/proj" --no-embed --fast --format=status 2>/dev/null)
+# No `|| echo ERR` tail: the analyzer exits 1 whenever it has findings, and
+# under `pipefail` that fails the whole pipeline, so the fallback would append
+# ERR to a perfectly good count.
+json_n=$(python3 "$ANALYZER" --root "$FIXROOT/proj" --no-embed --fast --format=json 2>/dev/null \
+    | python3 -c 'import json,sys; print(len(json.load(sys.stdin)["findings"]))' 2>/dev/null)
+assert_contains "status carries the opening delimiter"   "$st" "=== CONFIG DRIFT ==="
+assert_contains "status now carries the ISSUE_COUNT roll-up" "$st" "ISSUE_COUNT=$json_n"
+assert_contains "status now carries the closing delimiter"   "$st" "=== END CONFIG DRIFT ==="
+assert_eq "STATUS is drawn from OK|WARN|ERROR and nothing else" \
+    "$(printf '%s\n' "$st" | grep -cE '^STATUS=(OK|WARN|ERROR)$')" "1"
+# The two quirks that are NOT bugs, pinned so the shared renderer cannot quietly
+# normalise them away. (1) the header block keeps the CALLER's order -- a sorted
+# one would put ALWAYS_LOADED_RULES first, not RULES.
+assert_eq "the counts header keeps the caller's order, unsorted" \
+    "$(printf '%s\n' "$st" | sed -n '2p' | cut -d= -f1)" "RULES"
+# (2) the derived FINDING_* counters ARE sorted, so the block does not depend on
+# which finding happened to fire first.
+assert_eq "FIXTURE: more than one FINDING_* line exists to be ordered" \
+    "$([ "$(printf '%s\n' "$st" | grep -c '^FINDING_')" -ge 2 ] && echo yes || echo no)" "yes"
+assert_eq "FINDING_* lines are sorted by kind" \
+    "$(printf '%s\n' "$st" | grep '^FINDING_' | LC_ALL=C sort -c >/dev/null 2>&1 && echo sorted || echo unsorted)" "sorted"
+# This caller renders EVERY finding, not a delta subset, so the severity
+# counters keep their bare names -- probe-delta's NEW_* prefix answers a
+# different question and a rollup grepping '^ERRORS=' must not get both.
+assert_eq "the full-set counters stay ERRORS=/WARNINGS=" \
+    "$(printf '%s\n' "$st" | grep -cE '^(ERRORS|WARNINGS)=')" "2"
+assert_eq "no NEW_ERRORS=/NEW_WARNINGS= line appears here" \
+    "$(printf '%s\n' "$st" | grep -cE '^NEW_(ERRORS|WARNINGS)=')" "0"
+# The optional per-finding block is suppressed: a real corpus run reports 60+.
+assert_absent "the corpus-sized ISSUES: block is not emitted" "$st" "ISSUES:"
+# The status/report key transforms differ and both are deliberate.
+assert_contains "status upper-cases count keys"        "$st"  "ALWAYS_LOADED_RULES="
+assert_contains "the report humanises the same keys"   "$rep" "| always loaded rules |"
+assert_absent  "the report does not emit KEY=VALUE"    "$rep" "ALWAYS_LOADED_RULES="
+
+echo "TEST l: --format=probe is gone, and the three survivors still work"
+err=$(python3 "$ANALYZER" --root "$FIXROOT/proj" --no-embed --fast --format=probe 2>&1)
+rc=$?
+assert_eq "--format=probe is rejected (argparse exit 2)" "$rc" "2"
+assert_contains "the rejection names the removed choice" "$err" "invalid choice: 'probe'"
+assert_absent "no probe document is emitted alongside the rejection" "$err" "remediation_skill"
+for fmt in status report json; do
+    python3 "$ANALYZER" --root "$FIXROOT/proj" --no-embed --fast --format="$fmt" >/dev/null 2>&1
+    frc=$?
+    assert_eq "CONTROL: --format=$fmt still runs (exit 0/1)" \
+        "$([ "$frc" -le 1 ] && echo yes || echo "no (rc=$frc)")" "yes"
+done
+
+echo "TEST m: normalising path -> paths is FINGERPRINT-NEUTRAL"
+# This is the property that decides whether N1 was safe to ship at all: every
+# baseline in existence was recorded from findings carrying a singular `path`.
+# #2536's fingerprint() folds the singular into the path set precisely so this
+# normalisation cannot invalidate them.
+cat > "$FIXROOT/fpneutral.py" <<'PY'
+from lib.probe import Finding, fingerprint
+
+a = Finding("error", "broken_pointer_stub", "s", path="/x")
+b = Finding("error", "broken_pointer_stub", "s", paths=["/x"])
+print("STUB_EQUAL %s" % (fingerprint(a) == fingerprint(b)))
+# CONTROL: a fingerprint that ignored paths entirely would also report EQUAL.
+c = Finding("error", "broken_pointer_stub", "s", paths=["/y"])
+print("STUB_DIFFERS %s" % (fingerprint(a) != fingerprint(c)))
+# review_staleness carries a trailing gap_days that must not enter the identity:
+# the same file drifting further must stay the SAME standing finding.
+d = Finding("warn", "review_staleness", "s", path="/x", gap_days=9)
+e = Finding("warn", "review_staleness", "s", paths=["/x"], gap_days=400)
+print("STALENESS_EQUAL %s" % (fingerprint(d) == fingerprint(e)))
+PY
+out=$(py "$FIXROOT/fpneutral.py")
+assert_contains "path='/x' and paths=['/x'] fingerprint identically" "$out" "STUB_EQUAL True"
+assert_contains "CONTROL: a different path still fingerprints differently" "$out" "STUB_DIFFERS True"
+assert_contains "the same fold holds for the review_staleness shape" "$out" "STALENESS_EQUAL True"
+
+# ...and end to end, which is the claim that actually matters: a baseline
+# recorded from the PRE-N1 document must see nothing new and nothing resolved
+# when compared against the POST-N1 analyzer over the same corpus.
+AFT="$FIXROOT/fp-after.json"
+BEF="$FIXROOT/fp-before.json"
+python3 "$ANALYZER" --root "$FIXROOT/proj" --no-embed --fast --format=json > "$AFT" 2>/dev/null
+# The pre-N1 document is RECONSTRUCTED rather than produced by `git show`-ing the
+# old analyzer: a ref-dependent case in a DISCOVERED test goes vacuous the moment
+# this PR merges (origin/main would then BE the post-N1 analyzer and the
+# comparison would assert nothing) -- the silent-identity trap
+# compare-ref-output.sh documents. The reconstruction is a pure DOCUMENT
+# transform of the shipped output, its fidelity is asserted below as fixture
+# validity, and where the genuine pre-N1 analyzer is still reachable it is
+# byte-compared against this reconstruction.
+python3 - "$AFT" "$BEF" <<'PY'
+import json, sys
+
+doc = json.load(open(sys.argv[1]))
+for f in doc["findings"]:
+    p = f.get("paths")
+    if f["kind"] in ("broken_pointer_stub", "review_staleness") and isinstance(p, list) and len(p) == 1:
+        # Rebuild the key IN PLACE, not appended: the pre-N1 sites emitted
+        # severity, kind, summary, path[, gap_days] in that order, and
+        # Finding.to_dict() takes its order from the kwargs.
+        rebuilt = {("path" if k == "paths" else k): (p[0] if k == "paths" else v) for k, v in f.items()}
+        f.clear()
+        f.update(rebuilt)
+# The trailing newline is part of the shape: the analyzer's document reaches a
+# file through `print(render_json(...))`, and `json.dump` alone would leave the
+# byte comparison below failing on nothing but a missing final "\n".
+open(sys.argv[2], "w").write(json.dumps(doc, indent=1) + "\n")
+PY
+singular_of() { python3 -c 'import json,sys; print(sum(1 for f in json.load(open(sys.argv[1]))["findings"] if "path" in f))' "$1" 2>/dev/null || echo ERR; }
+assert_eq "FIXTURE: the reconstructed pre-N1 document carries singular path keys" \
+    "$([ "$(singular_of "$BEF")" -ge 1 ] && echo yes || echo "no ($(singular_of "$BEF"))")" "yes"
+assert_eq "FIXTURE: the current document carries none" "$(singular_of "$AFT")" "0"
+
+# Where the genuine pre-N1 analyzer is still reachable, prove the reconstruction
+# IS that analyzer's output rather than a plausible model of it.
+GENUINE="$FIXROOT/genuine"
+CHECKOUT="$(cd "${SCRIPTS_DIR}/../.." && pwd)"
+mkdir -p "$GENUINE/lib"
+if git -C "$CHECKOUT" show "origin/main:health-plugin/scripts/config-drift.py" \
+        > "$GENUINE/config-drift.py" 2>/dev/null \
+   && git -C "$CHECKOUT" show "origin/main:health-plugin/scripts/lib/probe.py" \
+        > "$GENUINE/lib/probe.py" 2>/dev/null \
+   && grep -q 'path=r\["path"\]' "$GENUINE/config-drift.py"; then
+    python3 "$GENUINE/config-drift.py" --root "$FIXROOT/proj" --no-embed --fast \
+        --format=json > "$FIXROOT/fp-genuine.json" 2>/dev/null
+    assert_eq "the reconstruction is byte-identical to the genuine pre-N1 output" \
+        "$(cmp -s "$FIXROOT/fp-genuine.json" "$BEF" && echo identical || echo differs)" "identical"
+else
+    echo "  note  genuine pre-N1 analyzer unreachable at origin/main — reconstruction stands on its fixture-validity assertions"
+fi
+
+BL="$FIXROOT/fp-baseline.json"
+rm -f "$BL"
+out=$(python3 "$DELTA" --findings "$BEF" --baseline "$BL" --probe config-drift \
+    --root "$FIXROOT/proj" 2>&1)
+assert_contains "the pre-N1 document records a baseline" "$out" "FIRST_RUN=true"
+out=$(python3 "$DELTA" --findings "$AFT" --baseline "$BL" --probe config-drift \
+    --root "$FIXROOT/proj" 2>&1)
+assert_contains "a PRE-N1 baseline sees ZERO new findings post-N1" "$out" "NEW=0"
+assert_contains "...and ZERO resolved"                             "$out" "RESOLVED=0"
+assert_contains "so the normalisation invalidated no baseline"     "$out" "STATUS=OK"
+assert_eq "every finding is CARRIED, not silently dropped" \
+    "$([ "$(printf '%s\n' "$out" | grep -m1 '^CARRIED=' | cut -d= -f2)" -ge 1 ] && echo yes || echo no)" "yes"
+
+# GUARD INTEGRITY: a delta that never reports anything would pass all four of
+# those. Move ONE path in the pre-N1 document and the delta must notice.
+BEF2="$FIXROOT/fp-before-moved.json"
+python3 - "$BEF" "$BEF2" <<'PY'
+import json, sys
+
+doc = json.load(open(sys.argv[1]))
+for f in doc["findings"]:
+    if f["kind"] == "broken_pointer_stub":
+        f["path"] = f["path"] + ".moved"
+open(sys.argv[2], "w").write(json.dumps(doc, indent=1) + "\n")
+PY
+BL2="$FIXROOT/fp-baseline-moved.json"
+rm -f "$BL2"
+python3 "$DELTA" --findings "$BEF2" --baseline "$BL2" --probe config-drift \
+    --root "$FIXROOT/proj" >/dev/null 2>&1
+out=$(python3 "$DELTA" --findings "$AFT" --baseline "$BL2" --probe config-drift \
+    --root "$FIXROOT/proj" 2>&1)
+assert_contains "GUARD INTEGRITY: a genuinely moved path IS reported new" "$out" "NEW=1"
+assert_contains "GUARD INTEGRITY: ...and the stale record resolves"       "$out" "RESOLVED=1"
 
 # =====================================================================
 # Round-2 repair regressions (D1-D5). Every case EXECUTES the failing
@@ -866,6 +1169,143 @@ assert_eq "CONTROL fixture is non-vacuous: the clean corpus was actually read" \
     "$(printf '%s' "$clean_out" | jq -r '.counts.rules' 2>/dev/null)" "1"
 assert_eq "CONTROL: a corpus with no unreadable file emits no corpus_unreadable" \
     "$(printf '%s' "$clean_out" | jq -r '[.findings[] | select(.kind=="corpus_unreadable")] | length' 2>/dev/null)" "0"
+
+echo "TEST N2: ISSUE_COUNT= collides across probes BY DESIGN, and the delimiter resolves it"
+# `.claude/rules/structured-script-output.md` mandates the literal
+# `ISSUE_COUNT=` in every conformant block, so two conformant blocks in one
+# combined log necessarily both emit it. `severity_prefix` exists because
+# `ERRORS=` COULD be split per probe; `ISSUE_COUNT=` cannot be, without leaving
+# the block non-conformant. Pinned here so the collision reads as a deliberate
+# consequence of conformance rather than an accident nobody measured.
+N2ROOT="$FIXROOT/proj"
+cd_status=$(python3 "$ANALYZER" --root "$N2ROOT" --no-embed --fast --format=status 2>/dev/null)
+N2JSON="$FIXROOT/n2-findings.json"
+N2BL="$FIXROOT/n2-baseline.json"
+rm -f "$N2BL"
+python3 "$ANALYZER" --root "$N2ROOT" --no-embed --fast --format=json > "$N2JSON" 2>/dev/null
+# Run the delta TWICE: the first records the baseline, so the second reports a
+# NEW count of 0 while config-drift reports the FULL corpus count. That gap is
+# what a naive grep gets wrong.
+python3 "$DELTA" --findings "$N2JSON" --baseline "$N2BL" --probe config-drift \
+    --root "$N2ROOT" >/dev/null 2>&1
+delta_status=$(python3 "$DELTA" --findings "$N2JSON" --baseline "$N2BL" --probe config-drift \
+    --root "$N2ROOT" 2>&1)
+COMBINED="$FIXROOT/n2-combined.log"
+printf '%s\n%s\n' "$delta_status" "$cd_status" > "$COMBINED"
+
+assert_eq "BOTH conformant blocks emit an ISSUE_COUNT= line" \
+    "$(grep -c '^ISSUE_COUNT=' "$COMBINED")" "2"
+cd_n=$(printf '%s\n' "$cd_status" | grep -m1 '^ISSUE_COUNT=' | cut -d= -f2)
+dl_n=$(printf '%s\n' "$delta_status" | grep -m1 '^ISSUE_COUNT=' | cut -d= -f2)
+# FIXTURE VALIDITY: a corpus where the two counts coincide asserts nothing about
+# a collision.
+assert_eq "FIXTURE: the two counts genuinely differ (full set vs delta)" \
+    "$([ "$cd_n" != "$dl_n" ] && echo yes || echo "no (both $cd_n)")" "yes"
+assert_eq "a naive grep -m1 over a combined log returns whichever printed FIRST" \
+    "$(grep -m1 '^ISSUE_COUNT=' "$COMBINED" | cut -d= -f2)" "$dl_n"
+# The resolution: both blocks now carry `=== END <section> ===`, so a parser can
+# bracket a section and read the key inside it. config-drift's block carried no
+# closing delimiter (and no ISSUE_COUNT= at all) before render_status became its
+# only renderer, so section-aware parsing is possible for the first time.
+assert_eq "each section is bracketed by its own closing delimiter" \
+    "$(grep -c '^=== END ' "$COMBINED")" "2"
+assert_eq "section-aware parsing reads the ANALYZER's own ISSUE_COUNT" \
+    "$(awk '/^=== CONFIG DRIFT ===$/{f=1} f&&/^ISSUE_COUNT=/{print;exit}' "$COMBINED" | cut -d= -f2)" \
+    "$cd_n"
+assert_eq "section-aware parsing reads the DELTA's own ISSUE_COUNT" \
+    "$(awk '/^=== CONFIG-DRIFT DELTA ===$/{f=1} f&&/^ISSUE_COUNT=/{print;exit}' "$COMBINED" | cut -d= -f2)" \
+    "$dl_n"
+
+echo "TEST N3: the hook's jq fix map covers every kind the analyzer can emit"
+# The map in hooks/config-drift-probe.sh is the SINGLE SOURCE for
+# kind -> remediation-skill since --format=probe was deleted, and a kind with no
+# row falls to the "/health:check" fallback SILENTLY. Both sides are read out of
+# the shipped files -- the kind set from config-drift.py's own `Finding(...)`
+# call sites via the AST, the map keys out of the hook's own text -- so neither
+# is a retyped copy (never-fabricate-test-identifiers.md § extract the code).
+cat > "$FIXROOT/mapcover.py" <<'MAPCOVER'
+import ast
+import itertools
+import re
+import sys
+
+src = open(sys.argv[1]).read()
+hook = open(sys.argv[2]).read()
+tree = ast.parse(src)
+
+# The two values `Finding(... f"semantic_overlap_{a['kind']}_{b['kind']}" ...)`
+# can interpolate, read off collect()'s own dict literals rather than assumed.
+item_kinds = set()
+for node in ast.walk(tree):
+    if isinstance(node, ast.Dict):
+        for k, v in zip(node.keys, node.values):
+            if (
+                isinstance(k, ast.Constant)
+                and k.value == "kind"
+                and isinstance(v, ast.Constant)
+                and isinstance(v.value, str)
+            ):
+                item_kinds.add(v.value)
+
+kinds = set()
+for node in ast.walk(tree):
+    if not (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "Finding"
+        and len(node.args) >= 2
+    ):
+        continue
+    arg = node.args[1]
+    if isinstance(arg, ast.Constant):
+        kinds.add(arg.value)
+    elif isinstance(arg, ast.JoinedStr):
+        tmpl = "".join(
+            p.value if isinstance(p, ast.Constant) else "{}" for p in arg.values
+        )
+        for combo in itertools.product(sorted(item_kinds), repeat=tmpl.count("{}")):
+            kinds.add(tmpl.format(*combo))
+    else:
+        kinds.add("UNPARSEABLE_KIND_ARG")
+
+m = re.search(r"def fix:\s*\{(.*?)\}\[\.kind\]", hook, re.S)
+mapped = set(re.findall(r'"([a-z0-9_]+)"\s*:', m.group(1))) if m else set()
+
+# UNREACHABLE, and deliberately unmapped: check_semantic_dupes is fed
+# `rules + skills` and iterates np.triu_indices(k=1), so `a` is always the lower
+# index -- a cross-kind pair is always (rule, skill), never (skill, rule).
+unreachable = {"semantic_overlap_skill_rule"}
+reachable = kinds - unreachable
+
+print("ITEM_KINDS %s" % ",".join(sorted(item_kinds)))
+print("DERIVED_N %d" % len(kinds))
+print("REACHABLE_N %d" % len(reachable))
+print("MAPPED_N %d" % len(mapped))
+print("MISSING %s" % (",".join(sorted(reachable - mapped)) or "NONE"))
+print("UNEMITTABLE_ROWS %s" % (",".join(sorted(mapped - kinds)) or "NONE"))
+print("UNREACHABLE_ABSENT %s" % (not (unreachable & mapped)))
+# CONTROL: the membership test must be able to FAIL. A kind that does not exist
+# must not be reported as mapped.
+print("CONTROL_FABRICATED_MAPPED %s" % ("no_such_kind_at_all" in mapped))
+MAPCOVER
+out=$(python3 "$FIXROOT/mapcover.py" "$ANALYZER" "$HOOK_SRC" 2>&1)
+# FIXTURE VALIDITY first: an AST walk that matched nothing satisfies "no missing
+# kinds" trivially, and a regex that matched no map keys satisfies "no unmapped
+# rows" the same way.
+assert_contains "the item kinds are derived, not assumed" "$out" "ITEM_KINDS rule,skill"
+assert_contains "FIXTURE: the derivation found every construction site" "$out" "DERIVED_N 13"
+assert_contains "FIXTURE: 12 of those kinds are reachable" "$out" "REACHABLE_N 12"
+assert_contains "FIXTURE: the map's keys were actually parsed out of the hook" "$out" "MAPPED_N 12"
+assert_absent "every Finding( kind argument was parseable" "$out" "UNPARSEABLE_KIND_ARG"
+assert_contains "CONTROL: a fabricated kind is not reported as mapped" \
+    "$out" "CONTROL_FABRICATED_MAPPED False"
+# The claim itself.
+assert_contains "every emittable kind has an EXPLICIT row (none falls to the fallback)" \
+    "$out" "MISSING NONE"
+assert_contains "the map carries no row for a kind the analyzer cannot emit" \
+    "$out" "UNEMITTABLE_ROWS NONE"
+assert_contains "semantic_overlap_skill_rule stays unmapped (triu makes it unreachable)" \
+    "$out" "UNREACHABLE_ABSENT True"
 
 echo
 echo "=== PROBE LIB TESTS ==="


### PR DESCRIPTION
Closes #2527. The companion to #2536 — and its mirror image: **that PR's claim
was that no output changed; this one's is that output changes in exactly four
ways**, with every difference adjudicated.

## The four changes

| # | Change | Consequence |
|---|---|---|
| 1 | `path` → `paths` at `broken_pointer_stub` and `review_staleness` | `--since` filters them for the first time; `emit_report` renders their paths |
| 2 | `--format=status` uses the conformant `render_status` | gains the required `ISSUE_COUNT=` and `=== END CONFIG DRIFT ===` |
| 3 | `emit_probe` and the `probe` choice deleted | deferred out of #2536, where it would have been an output change |
| 4 | `emit_report` → `lib.probe.render_report` | renderer lives with the contract |

## Two bugs die as a consequence, not as separate edits

**`--since` never filtered the singular-path findings.** The filter reads
`if not f.get("paths") or …`, and those findings had no `paths`, so the guard
was vacuously true. Measured on the real corpus: `--since HEAD~3` returned
**61** findings on `main` with all 60 `review_staleness` leaking through, and
returns **1** now. Both halves checked — the untouched file is dropped *and* a
touched one is retained.

**`emit_report` never rendered their paths**, since it iterates
`f.get("paths", [])[:2]`. Path lines on the real corpus: **10 → 50**.

## Fingerprint neutrality is why this landed second

#2536's `fingerprint` folds a singular `path` into the path set precisely so
this rename invalidates no recorded baseline. Verified on the **real** corpus,
not a fixture: a baseline recorded from the pre-normalization analyzer,
compared against the post-normalization document, reports
`NEW=0 RESOLVED=0 CARRIED=73`.

Had these two PRs landed in the other order, every baseline in existence would
have gone stale silently.

## Adjudication

Structural JSON diff at both real roots, base vs branch:

- **67 findings changed shape**, equal to the `review_staleness` +
  `broken_pointer_stub` count — so nothing else moved.
- 0 findings appeared or disappeared; 0 changed summary, score or severity.
- `status` gains exactly two lines.

## Two consequences documented rather than changed

**`ISSUE_COUNT` spans all three severities**, so it exceeds `ERRORS + WARNINGS`
by the info tier (66 vs 60 here), and `list_issues=False` leaves no in-block way
to see the split. It also now collides with `probe-delta`'s count in a combined
log — the class `severity_prefix` exists to prevent, but the rule mandates the
literal `ISSUE_COUNT=` in every conformant block, so two conformant blocks
collide by construction. The closing delimiter this PR adds is what makes
section-aware parsing possible for the first time; only a naive `grep -m1`
regresses.

**`--since` can now never surface a finding about `~/.claude/rules`.**
`HOME_RULES` is scanned regardless of `--root`, but `changed_since` walks only
the root's git repos, so a home-rule path cannot enter `touched`. The
pre-normalization escape was an accident of the missing `paths` key, not a
feature, and both alternatives are worse: re-admitting pathless findings is the
bug just fixed, and treating `HOME_RULES` as always-touched reports a standing
condition as a change. Pinned by a test so it is a decision on the record —
this excludes 51 always-loaded rules (~39k tok/turn), which is worth knowing.

## The hook's remediation map is now load-bearing

With `emit_probe` gone, the hook's jq map is the single source for
kind → remediation by elimination. It was missing `corpus_unreadable` and
`semantic_pass_unavailable`. Both added — and a test now **AST-walks
`config-drift.py` for `Finding(...)` call sites** and asserts every emittable
kind has an explicit row, rather than trusting a hand-copied list.
`semantic_overlap_skill_rule` stays unmapped and is asserted *absent*:
`triu_indices(k=1)` over `rules + skills` makes it unreachable.

## Evidence

| Check | Result |
|---|---|
| `test-probe-lib.sh` | 192/0 (+23) |
| `test-config-drift.sh` | 61/0 |
| Structural JSON diff, both roots | only the four intended changes |
| Fingerprint neutrality, real corpus | `NEW=0 RESOLVED=0 CARRIED=73` |
| ruff / format / shellcheck / sandbox-guards | clean |

`compare-ref-output.sh` keeps its behaviour and loses a stale header (it named
`--format=probe`, which this PR deletes). It is a general differential harness
now, with its three states named: an older ref across an intentional change
FAILs **and that is correct**; a ref identical to the working tree is a
`HARNESS_ERROR`; only a genuinely comparable ref can pass. All three verified by
construction.

## What the mutation pass caught

One new assertion did **not** pin what its wording claimed. The home-rules case
passed with the fixture moved *into* the sandbox repo — because an untracked
file is dropped by the same filter for a different reason (`git diff
--name-only HEAD` never lists untracked paths). An assertion reading "no repo
contains its path" was satisfied by a case where one did. Fixed and re-verified:
the added assertion is now the only failure under that mutation.

Refs #2319
