### PR TITLE
feat(health-plugin): widen the config-drift corpus to agents and CLAUDE.md

### DIFF
--- a/health-plugin/README.md
+++ b/health-plugin/README.md
@@ -77,22 +77,60 @@ never a clean sweep.
 ### `config-drift.py`
 
 Answers a question the other health checks do not: **is the configuration
-corpus self-consistent?** It compares rules against each other and against the
-skill corpus, rather than validating any one file in isolation.
+corpus self-consistent?** It compares documents against each other and against
+the skill corpus, rather than validating any one file in isolation.
 
-| Check | Severity | Catches |
-|---|---|---|
-| `broken_pointer_stub` | ERROR | A "Promoted to a skill: invoke `x`" rule whose target no longer exists |
-| `duplicate_rule_lexical` | WARN | Byte-identical or near-identical rules across scopes |
-| `semantic_overlap_*` | WARN | Differently-worded rules or skills covering one topic |
-| `rule_covered_by_skill` | INFO | A resident rule whose content a skill already carries |
-| `always_loaded_budget` | WARN | The every-turn surface creeping past its ceiling |
-| `review_staleness` | WARN | An artifact changed after its declared `reviewed:` date |
+The corpus is four kinds — `.claude/rules/*.md` (plus `~/.claude/rules`),
+`*/skills/*/SKILL.md`, `*-plugin/agents/*.md`, and `CLAUDE.md`. All four share
+one document shape, and each check names the kinds it applies to explicitly:
+
+| Check | Severity | Kinds | Catches |
+|---|---|---|---|
+| `broken_pointer_stub` | ERROR | rule | A "Promoted to a skill: invoke `x`" rule whose target no longer exists |
+| `duplicate_rule_lexical` | WARN | rule | Byte-identical or near-identical rules across scopes |
+| `duplicate_agent_lexical` | WARN | agent | Two agent prompts that have converged |
+| `duplicate_claude_md_lexical` | INFO | claude_md | Two CLAUDE.md carrying the same guidance |
+| `agent_discovery_misfire` | ERROR | agent | `*-plugin/agents` directories present but zero agent files — discovery is broken, not the tree clean |
+| `semantic_overlap_*` | WARN | rule, skill | Differently-worded rules or skills covering one topic |
+| `rule_covered_by_skill` | INFO | rule | A resident rule whose content a skill already carries |
+| `always_loaded_budget` | WARN | rule, claude_md | The every-turn surface creeping past its ceiling |
+| `review_staleness` | WARN | all four | An artifact changed after its declared `reviewed:` date |
+| `frontmatter_coverage` | INFO | rule | Rules with no `reviewed:` date, so staleness cannot be tracked |
+
+`duplicate_claude_md_lexical` is INFO rather than WARN because a CLAUDE.md pair
+is very often duplication that is *correct* — a vendored clone and its upstream,
+or one package copied into two places — and the analyzer cannot tell that from a
+divergence. Two `.claude/rules/` scopes, and two `*-plugin/agents/*.md` in one
+marketplace, are both live and both loaded, so duplication there really is drift.
+
+Agents are discovered through the same **recursive pruned walk** as every other
+kind (`*-plugin/agents`), not a depth-anchored glob: the SessionStart probe scans
+the session cwd, and a portfolio root sits one or two levels above where plugins
+live. `AGENT_DIRS=` is the denominator that makes `AGENTS=0` legible — beside a
+nonzero `AGENT_DIRS` it is a misfire, beside `AGENT_DIRS=0` it is a clean tree.
+
+The lexical comparison is **partitioned by kind** — each kind is compared only
+against itself. A high Jaccard between an agent prompt and a rule is not a
+duplicate rule, and pooling costs 9x the partitioned run on this corpus.
+`LEXICAL_PAIRS=` in the status block reports how many pairs were compared, so
+the partition is assertable rather than implicit.
+
+A `CLAUDE.md` holding **generator template** payload is excluded — it is content
+for a repo that does not exist yet, not configuration that loads anywhere. Two
+signals *declare* a template and are sufficient alone: an unrendered path
+component (`{{cookiecutter.project_slug}}/`), or a generator manifest
+(`cargo-generate.toml` / `cookiecutter.json` / `copier.y{a,}ml` / `cruft.json`)
+at a **strict ancestor**. Two more only *suggest* it and need each other: a
+`template`/`templates` path component, and either a manifest sitting beside the
+document or an npm `create-*` parent. A bare `templates/` component is never
+enough on its own — a Flask or Django `app/templates/` is a Jinja directory whose
+CLAUDE.md is live configuration. The root's own `CLAUDE.md` is never excluded.
+`CLAUDE_MD_TEMPLATES_EXCLUDED=` is emitted even at 0.
 
 Two cost tiers, because a SessionStart probe cannot pay for a model:
 
 ```
-config-drift.py --fast --no-embed --format=json    # 0.05s, pure stdlib, no git spawn
+config-drift.py --fast --no-embed --format=json    # 0.33s, pure stdlib, no git spawn
 config-drift.py --format=report                    # + embeddings, scheduled use
 ```
 

--- a/health-plugin/hooks/config-drift-probe.sh
+++ b/health-plugin/hooks/config-drift-probe.sh
@@ -12,11 +12,17 @@
 # file deliberately contains no analysis of its own -- it shells out and
 # forwards findings.
 #
-# Cost: runs `--fast --no-embed`, which is pure stdlib, spawns no git, and
-# measured 0.05s over 342 rules + 549 skills. That needs no TTL debounce -- the
-# debounce guidance in drift-detection-triggering.md is about NETWORK
-# round-trips, and this probe makes none. The expensive semantic pass (an
-# embedding model) is scheduled-only and never runs here.
+# Cost: runs `--fast --no-embed`, which is pure stdlib and spawns no git.
+# Measured 2026-08-29 at this repo's root -- 0.33s wall (best of 5) over a
+# corpus of 98 rules + 422 skills + 21 agents + 3 CLAUDE.md. The former figure
+# here, 0.05s over "342 rules + 549 skills", named a corpus this root does not
+# have and was an order of magnitude off (#2530).
+#
+# The no-debounce conclusion is UNCHANGED and the argument for it survives the
+# correction: the debounce guidance in drift-detection-triggering.md is about
+# NETWORK round-trips, and this probe makes none -- it reads local files and
+# a local cache. The expensive semantic pass (an embedding model) is
+# scheduled-only and never runs here.
 #
 # Opt-out: CLAUDE_HOOKS_DISABLE_DRIFT_NUDGE=1 (honoured by the aggregator too),
 # or CLAUDE_HOOKS_DISABLE_CONFIG_DRIFT=1 for this probe alone.
@@ -179,6 +185,39 @@ fi
 # `/health:check`, which is where a reader of either goes anyway — the point is
 # that the routing is a decision on the page rather than a default nobody chose.
 #
+# A ROW IS ONLY CORRECT IF THE TARGET CAN SEE THE FINDING'S CORPUS. The two
+# widened duplicate kinds were first routed to `/agent-patterns:meta-promote` by
+# copying the `duplicate_rule_lexical` row, which reads as safe and is not.
+# meta-promote builds its inventory from `<scope>/.claude/{rules,skills,commands,
+# agents}/` and `<scope>/*/.claude/{...}/` (SKILL.md § "Build the scope
+# inventory", Target/Sources/Upstream table). A repo-root CLAUDE.md is in
+# NEITHER layer, and a plugin agent at `*-plugin/agents/*.md` is not under
+# `.claude/agents/` either -- so both rows named a skill that structurally cannot
+# open the files the finding is about. The rule row IS correct, which is exactly
+# why copying it looked safe.
+#
+# Re-routed against each target's own inventory logic, not its description:
+#
+# * `duplicate_agent_lexical` -> `/agents:analyze`. Its Step 3 gap analysis
+#   carries "Consolidation opportunities: Multiple agents that could be merged"
+#   -- the literal action a near-identical agent pair calls for -- and its
+#   inventory is agent FILES rather than `.claude/agents/`. Caveat worth naming:
+#   its Context block globs `agents-plugin/agents/*` specifically, which is 12 of
+#   this marketplace's 21 agents, so the finding's own `paths` do the locating
+#   for the other 9. Widening that glob to `*/agents/*.md` belongs in
+#   agents-plugin, not here.
+# * `duplicate_claude_md_lexical` -> `/agent-patterns:meta-context-diet`. Its
+#   Context block is `find . -maxdepth 3 -name 'CLAUDE.md'` and its Step 1 globs
+#   CLAUDE.md during execution -- it is the only skill in the catalog whose
+#   inventory is CLAUDE.md files -- and its per-item dispositions include
+#   consolidate. Same caveat, from the other direction: `-maxdepth 3` does not
+#   reach every CLAUDE.md at a portfolio root, so deep pairs rely on the paths in
+#   the finding.
+#
+# `agent_discovery_misfire` routes to `/health:check` with the rest of the
+# "the probe itself is broken" family (`coverage_metric_broken`,
+# `corpus_unreadable`): its fix site is this analyzer, not the corpus.
+#
 # `semantic_overlap_skill_rule` is ABSENT ON PURPOSE and is not a gap. The
 # f-string `semantic_overlap_{a[kind]}_{b[kind]}` in `check_semantic_dupes` is
 # fed `rules + skills` (rules first) and iterates `np.triu_indices(k=1)`, so `a`
@@ -192,10 +231,13 @@ while IFS=$'\t' read -r severity kind summary remediation; do
 done < <(printf '%s' "$OUT" | jq -r '
   def rank: {"error":0,"warn":1,"info":2}[.severity] // 3;
   def fix:
-    {"broken_pointer_stub":          "/agent-patterns:meta-promote",
+    {"agent_discovery_misfire":      "/health:check",
+     "broken_pointer_stub":          "/agent-patterns:meta-promote",
      "coverage_metric_broken":       "/health:check",
      "corpus_unreadable":            "/health:check",
      "duplicate_rule_lexical":       "/agent-patterns:meta-promote",
+     "duplicate_agent_lexical":      "/agents:analyze",
+     "duplicate_claude_md_lexical":  "/agent-patterns:meta-context-diet",
      "semantic_overlap_rule_rule":   "/agent-patterns:meta-promote",
      "semantic_overlap_rule_skill":  "/health:skill-audit",
      "semantic_overlap_skill_skill": "/health:skill-audit",

--- a/health-plugin/scripts/config-drift.py
+++ b/health-plugin/scripts/config-drift.py
@@ -3,7 +3,12 @@
 # requires-python = ">=3.11"
 # dependencies = ["fastembed>=0.4", "numpy>=1.26"]
 # ///
-"""config-drift — continuous hygiene check for Claude rules and skills.
+"""config-drift — continuous hygiene check for the Claude configuration corpus.
+
+The corpus is four document kinds: `.claude/rules/*.md` (plus `~/.claude/rules`),
+`*/skills/*/SKILL.md`, `*-plugin/agents/*.md`, and `CLAUDE.md`. All four share
+ONE document shape (`_doc`), and every check names the kinds it applies to
+explicitly — see the check x kind matrix assembled in `main()`.
 
 Design notes (why it is shaped this way):
 
@@ -54,6 +59,65 @@ HOME_RULES = Path.home() / ".claude" / "rules"
 SKIP_PARTS = {"node_modules", "dist", "worktrees", ".git", "__pycache__", "tmp"}
 EMBED_MODEL = "BAAI/bge-small-en-v1.5"
 EMBED_CHARS = 2000
+
+# Scope sentinel for the kinds that are NOT promotable. A skill and an agent are
+# namespaced by their plugin, not scoped to a directory tree, so "promote it to
+# the parent scope" names no operation for them -- there is no parent scope to
+# promote into. `scope_rank` is None for this sentinel rather than a number,
+# because the obvious falsy default (0) is `user-global`, i.e. the MOST promoted
+# rank there is: the exact wrong reading. #2528b consumes the rank; it is
+# computed here so the document shape is settled in one place.
+SCOPE_PLUGIN = "plugin"
+
+# The kinds the SEMANTIC pass compares. Agents and CLAUDE.md are deliberately
+# EXCLUDED in this PR. T_SEMANTIC below is 0.91 because it was calibrated
+# against rule/skill markdown -- the threshold comment there says outright that
+# baseline cosine is high *because every document is one genre*, so an agent
+# prompt (a second-person instruction sheet) and a CLAUDE.md (a repo overview)
+# are two further genres whose own baselines are unmeasured. Per-kind
+# calibration is #2528b. `test-probe-lib.sh` TEST N3 reads this tuple out of the
+# source to expand the `semantic_overlap_{a}_{b}` f-string, so widening it here
+# widens that coverage assertion rather than silently escaping it.
+SEMANTIC_KINDS = ("rule", "skill")
+
+# The kinds the LEXICAL pass compares -- each against ITSELF only. See
+# `check_lexical_dupes` for why the comparison is partitioned rather than pooled.
+LEXICAL_KINDS = ("rule", "agent", "claude_md")
+
+# A file whose presence DECLARES that the tree it heads is a generator template
+# rather than live configuration. See `_is_generator_template`.
+#
+# `cruft.json` is here because cruft-managed cookiecutter templates are the
+# common case and cruft does NOT ship a `cookiecutter.json` of its own -- so the
+# original four-entry list missed the majority shape of the very ecosystem it
+# was written for.
+GENERATOR_MANIFESTS = (
+    "cargo-generate.toml",
+    "cookiecutter.json",
+    "copier.yml",
+    "copier.yaml",
+    "cruft.json",
+)
+
+# A path COMPONENT still carrying a template placeholder. The docstring of
+# `_is_generator_template` declines an unrendered-marker scan over a document's
+# CONTENT -- a CLAUDE.md legitimately quotes `{{ }}` while documenting a
+# template rather than being one. A directory NAME carries no such ambiguity:
+# nothing renders it, nobody quotes prose in it, and `{{cookiecutter.x}}/` is
+# the literal on-disk name cookiecutter/copier/cruft ship.
+UNRENDERED_MARKERS = ("{{", "{%")
+
+# Directory names that are template payload BY CONVENTION -- plural for
+# cargo-generate/`templates/`, singular for npm's `create-*` packages and
+# copier's `_subdirectory: template`. Conventional, not declarative: a Flask or
+# Django `app/templates/` is a Jinja directory and its CLAUDE.md is live
+# configuration, so a bare match here is never sufficient on its own.
+TEMPLATE_DIR_NAMES = ("templates", "template")
+
+# npm's `create-*` convention: `packages/create-widget/template/` is the payload
+# `npm create widget` copies out. The parent's name is the corroboration a bare
+# `template/` component lacks.
+CREATE_PKG = re.compile(r"^create-.")
 
 # Thresholds. Deliberately conservative: this tool surfaces, a human decides.
 # Calibrated against the live corpus, not guessed. At 0.86 the semantic pass
@@ -271,6 +335,184 @@ def walk(root: Path):
 
 
 # ------------------------------------------------------------------- inventory
+def _scope_rank(scope: str) -> int | None:
+    """How far a scope is from the top of the tree; None when not promotable.
+
+    0 user-global, 1 portfolio, then 2 + one per path separator for a nested
+    scope, so a deeper rule always outranks a shallower one. `SCOPE_PLUGIN`
+    yields None -- see the sentinel's own comment for why a number would be a
+    lie rather than a default.
+    """
+    if scope == SCOPE_PLUGIN:
+        return None
+    if scope == "user-global":
+        return 0
+    if scope == "portfolio":
+        return 1
+    return 2 + scope.count("/")
+
+
+def _doc(
+    kind: str,
+    path: Path,
+    name: str,
+    title: str,
+    body: str,
+    fm: dict,
+    scope: str,
+    always_loaded: bool,
+    stub: bool = False,
+) -> dict:
+    """One document, in the shape EVERY kind uses.
+
+    Before this the two kinds carried different key sets -- 11 for a rule, 9 for
+    a skill -- so any check touching `scope` was rule-only BY ACCIDENT rather
+    than by design, and `structural_pair` already had to write `x.get("stub")`
+    to survive a skill. With four kinds that arrangement stops being survivable:
+    a missing key reads as falsy, and "this kind has no stubs" and "this kind
+    was never given the key" become indistinguishable at every call site. One
+    shape means a check that must not apply to a kind is guarded EXPLICITLY (see
+    the kind guards on `check_stub_integrity`, `check_frontmatter` and
+    `check_rule_covered_by_skill`), which is auditable; a shape mismatch is not.
+
+    `desc` is now populated for every kind from `description:`. No rule in this
+    corpus carries one today (0 of 98, measured), so this is embed-neutral now;
+    if a rule grows one it starts contributing to the embed text, which is
+    correct, and the embedding cache is keyed on the embed TEXT so it
+    self-invalidates rather than serving a vector computed from the old text.
+    """
+    return {
+        "kind": kind,
+        "path": str(path),
+        "name": name,
+        "title": title,
+        "body": body,
+        "fm": fm,
+        "desc": fm.get("description", ""),
+        "scope": scope,
+        "scope_rank": _scope_rank(scope),
+        "always_loaded": always_loaded,
+        "chars": len(body),
+        "hash": sha(body),
+        "stub": stub,
+    }
+
+
+def _heading_title(body: str, fallback: str) -> str:
+    """The document's first `# ` heading, or `fallback`."""
+    return next(
+        (line[2:].strip() for line in body.splitlines() if line.startswith("# ")),
+        fallback,
+    )
+
+
+def _is_generator_template(dirpath: Path, root: Path) -> bool:
+    """True when `dirpath` holds generator-template payload, not live config.
+
+    A template's CLAUDE.md is not configuration that loads anywhere -- it is
+    payload a generator copies into a repo that does not exist yet. Ingesting it
+    puts an unrendered document into the corpus, where it can only produce
+    findings whose fix site is a template nobody is editing.
+
+    The predicate this replaced was wrong in BOTH directions, and the
+    over-exclude half is the worse one because it silently drops live
+    configuration:
+
+    * It matched only the PLURAL `templates`, so `packages/create-widget/
+      template/CLAUDE.md` -- npm's `create-*` convention, and copier's
+      `_subdirectory: template` -- was ingested unrendered.
+    * `cruft.json` was not a manifest, so a cruft-managed cookiecutter tree
+      (the common case) declared nothing.
+    * A bare `templates` component fired at any depth with no corroboration, so
+      EVERY repo with a Flask/Django `app/templates/` lost its CLAUDE.md.
+    * The manifest walk ran before the `cur == root` termination, so a manifest
+      at the root excluded the root's OWN CLAUDE.md -- a template repo's own
+      root document is live config for whoever maintains the template.
+
+    The replacement separates signals that DECLARE from signals that merely
+    SUGGEST, and requires corroboration for the latter:
+
+    | | Signal | Sufficient alone? |
+    |---|---|---|
+    | 0 | `dirpath == root` | Never a template -- see below |
+    | A | a path COMPONENT carries `{{` / `{%` | yes, declarative |
+    | B | a manifest at a STRICT ANCESTOR of `dirpath` | yes, declarative |
+    | C | a manifest at `dirpath` ITSELF | no -- corroboration |
+    | D | a `template` / `templates` path component | no -- corroboration |
+    | E | a `create-*` parent of that component | no -- corroboration |
+
+    Rule 0: the tree you point `--root` at is the tree you are working in, and
+    its own CLAUDE.md loads on every turn there whatever the repo generates.
+
+    A and B are declarative because something in the tree SAYS "template": an
+    unrendered directory name is not a name anyone typed, and a manifest heading
+    an ancestor puts `dirpath` INSIDE a declared template tree.
+
+    C is deliberately NOT declarative on its own, and that is the fix for the
+    `my-copier-template/CLAUDE.md` case at any scope rather than only at the
+    root. A manifest sitting BESIDE a document heads that tree; the document is
+    the template repo's own front matter, not the payload. Flat layouts
+    (cargo-generate, copier without `_subdirectory`) do make the manifest's own
+    directory the payload -- which is why C excludes when corroborated by D, the
+    shape the real instance here has (`foundryvtt-plugin/templates/
+    foundryvtt-module/` carries `cargo-generate.toml` beside its CLAUDE.md).
+
+    D alone is the false positive that motivated the redesign. It excludes only
+    with C or E beside it.
+
+    A is a COMPONENT scan, not a CONTENT scan. The content scan stays declined
+    for the reason it always was -- `scripts/check-unrendered-templates.sh` owns
+    that signal for a different purpose, and a CLAUDE.md quoting `{{ }}` while
+    DOCUMENTING a template would be dropped with no way to tell. A directory
+    name carries no such ambiguity.
+
+    KNOWN RESIDUAL, stated rather than hidden: signal B's ancestor walk includes
+    `root`, so pointing `--root` at a template repo still excludes every
+    NON-root CLAUDE.md in it. That is correct for a whole-repo template (copier
+    with no `_subdirectory`, cookiecutter's payload directory) and conservative
+    for a `_subdirectory` one, and it is bounded to a repo whose own root
+    declares itself a template. Rule 0 protects the one document that certainly
+    still loads.
+
+    Note this is COLLECTOR-LOCAL and `templates` is deliberately NOT added to
+    SKIP_PARTS. Executed: a global skip drops
+    `obsidian-plugin/skills/templates/SKILL.md`, a genuine frontmattered skill,
+    which in turn silently breaks `check_stub_integrity` for any pointer stub
+    that delegates to it -- a broken-stub ERROR manufactured by the exclusion.
+    """
+    try:
+        parts = dirpath.relative_to(root).parts
+    except ValueError:
+        return False
+    # Rule 0. `relative_to` yields () only for the root itself.
+    if not parts:
+        return False
+
+    # Signal A.
+    if any(mark in part for part in parts for mark in UNRENDERED_MARKERS):
+        return True
+
+    # Signals B and C, from one walk. `root` is INCLUDED as an ancestor (see the
+    # known residual above); `dirpath` itself is recorded separately because it
+    # is corroboration, not a declaration.
+    manifest_here = any((dirpath / m).is_file() for m in GENERATOR_MANIFESTS)
+    cur = dirpath
+    while cur != root and cur.parent != cur:
+        cur = cur.parent
+        if any((cur / m).is_file() for m in GENERATOR_MANIFESTS):
+            return True  # Signal B
+
+    # Signals D and E -- conventional, so one of C/E has to stand beside D.
+    for i, part in enumerate(parts):
+        if part not in TEMPLATE_DIR_NAMES:
+            continue
+        if manifest_here:
+            return True  # C + D
+        if i > 0 and CREATE_PKG.match(parts[i - 1]):
+            return True  # D + E
+    return False
+
+
 def _read_corpus_file(p: Path, unreadable: list[str]) -> str | None:
     """Read one corpus file, or None when it cannot be read.
 
@@ -317,12 +559,110 @@ def check_corpus_unreadable(unreadable) -> list[Finding]:
     ]
 
 
-def collect(root: Path) -> tuple[list[dict], list[dict], list[str]]:
-    rules, skills = [], []
-    unreadable: list[str] = []
+def check_agent_discovery_misfire(agents, agent_dirs: int) -> list[Finding]:
+    """Agent DIRECTORIES present but ZERO agent FILES is a MISFIRE, not clean.
 
+    The discriminator this repo standardises on (#2219/#2290): a guard that did
+    not run and a guard that found nothing look identical unless one of them
+    says so. `scripts/check-agent-model.sh` implements it for this exact shape
+    and exits 1 on it; the vocabulary below is deliberately its vocabulary, so a
+    reader who has seen one recognises the other.
+
+    THE DENOMINATOR IS `*-plugin/agents` DIRECTORIES, NOT PLUGIN DIRECTORIES.
+    The first draft of this check counted plugin directories and was a false
+    positive on sight: 36 of this repo's 49 plugin directories define no agents
+    at all, and a single-plugin repo carrying only skills is entirely ordinary,
+    so "plugins > 0 and agents == 0" would raise a permanent ERROR on most
+    trees. It fired on this suite's own empty-corpus case, which is how it was
+    caught. `agents/` directories are the real denominator: a directory that
+    exists and yields nothing is a mismatch between how directories are found
+    and how files are found, and that mismatch IS the bug class.
+
+    It is not hypothetical. Until the depth-anchored `root.glob(
+    "*-plugin/agents/*.md")` was replaced (see `collect`), this analyzer
+    reported `AGENTS=0` at `~/repos` and `~/repos/laurigates` -- both roots the
+    SessionStart probe actually runs at, both holding 21 agents below 8
+    `*-plugin/agents` directories -- and nothing in the output distinguished
+    that from a tree with no agents in it. The directory count comes from the
+    pruned walk while the file count came from the glob, so this check would
+    have fired on it. Now that both come from the same walk it is a TRIPWIRE
+    rather than a live detector: it fires if file discovery is ever re-anchored
+    away from directory discovery again, which is the regression that shipped.
+
+    Known false positive, small and named: an `agents/` directory holding no
+    `.md` at all. That is itself an anomaly worth a line.
+
+    `error`, not `warn`, and the aggregator's slot-1 cost is the point rather
+    than a side effect. The sibling `coverage_metric_broken` is the precedent in
+    this same file: when a metric is broken its output must not be trusted, and
+    the finding that says so outranks the findings it invalidates. Unlike
+    `corpus_unreadable` (`warn`, because the sweep still ran and can keep
+    reporting a dangling symlink forever), this one clears itself the moment
+    discovery works again.
+    """
+    if agents or not agent_dirs:
+        return []
+    return [
+        Finding(
+            "error",
+            "agent_discovery_misfire",
+            (
+                f"Found {agent_dirs} plugin agent director(ies) below the root but "
+                "ZERO agent files. This is a discovery misfire, not a clean tree "
+                "— the agent kind checked nothing, so AGENTS=0 and every agent "
+                "finding is uninformative"
+            ),
+        )
+    ]
+
+
+def collect(root: Path) -> tuple[dict[str, list[dict]], list[str], int, int]:
+    """Inventory the four document kinds under `root` (plus `~/.claude/rules`).
+
+    Returns `(corpus, unreadable, templates_excluded, agent_dirs)` where
+    `corpus` is keyed by kind. A dict rather than a widening tuple: every check
+    below takes the kinds it applies to by name, which is what makes the
+    check x kind matrix readable at the call site in `main()`.
+    """
+    rules, skills, agents, claude_mds = [], [], [], []
+    unreadable: list[str] = []
+    templates_excluded = 0
+    agent_dirs = 0
+
+    agent_paths: list[Path] = []
     rule_paths = sorted(HOME_RULES.glob("*.md")) if HOME_RULES.is_dir() else []
+    claude_md_paths: list[Path] = []
     for dirpath, filenames in walk(root):
+        # Agents come from the SAME pruned walk every other kind uses, matched
+        # with `dirpath.match("*-plugin/agents")`.
+        #
+        # This was `root.glob("*-plugin/agents/*.md")` -- pinned to depth 2 while
+        # rules, skills and CLAUDE.md were all recursive. At `~/repos` and
+        # `~/repos/laurigates`, both documented Claude Code working roots and
+        # both roots where `hooks/config-drift-probe.sh` actually runs (it passes
+        # `--root "${DRIFT_CWD:-.}"`, the session cwd), the glob matched NOTHING:
+        # 247 rules / 561 skills / 0 agents at `laurigates`, 367 / 591 / 0 at
+        # `repos`, against 21 real agents below each. The entire agent widening
+        # was inert exactly where the probe fires, and reported a bare
+        # `AGENTS=0` indistinguishable from "this tree has no agents".
+        #
+        # The old comment defended the glob against a `dirpath.name == "agents"`
+        # walk, on the grounds that two of the ten such directories here are
+        # Python source packages (`git-repo-agent/src/git_repo_agent/agents`,
+        # `vault-agent/src/vault_agent/agents`) where a stray `README.md` would
+        # be silently ingested as an agent prompt. That argument is real and it
+        # is preserved -- but it buys the `*-plugin/` PREFIX, not the DEPTH
+        # ANCHOR. Measured with this predicate at `~/repos/laurigates`: exactly
+        # 21, both source packages excluded, depth-independent. It is also still
+        # the same definition of "an agent" that `scripts/check-agent-model.sh`
+        # and `scripts/check-agent-tool-selection.sh` use.
+        #
+        # `.claude-plugin` is excluded explicitly: `Path.match` is fnmatch-based,
+        # so `*` DOES match a leading dot, and the marketplace metadata directory
+        # would otherwise qualify as a plugin.
+        if dirpath.match("*-plugin/agents") and dirpath.parent.name != ".claude-plugin":
+            agent_dirs += 1
+            agent_paths += [dirpath / f for f in filenames if f.endswith(".md")]
         if dirpath.match("*/.claude/rules"):
             rule_paths += [dirpath / f for f in filenames if f.endswith(".md")]
         if (
@@ -333,26 +673,28 @@ def collect(root: Path) -> tuple[list[dict], list[dict], list[str]]:
             body = _read_corpus_file(p, unreadable)
             if body is None:
                 continue
-            fm = frontmatter(body)
             skills.append(
-                {
-                    "kind": "skill",
-                    "path": str(p),
-                    "name": p.parent.name,
-                    "title": p.parent.name,
-                    "body": body,
-                    "fm": fm,
-                    "desc": fm.get("description", ""),
-                    "chars": len(body),
-                    "hash": sha(body),
-                }
+                _doc(
+                    "skill",
+                    p,
+                    p.parent.name,
+                    p.parent.name,
+                    body,
+                    frontmatter(body),
+                    SCOPE_PLUGIN,
+                    always_loaded=False,
+                )
             )
+        if "CLAUDE.md" in filenames:
+            if _is_generator_template(dirpath, root):
+                templates_excluded += 1
+            else:
+                claude_md_paths.append(dirpath / "CLAUDE.md")
 
     for p in sorted(set(rule_paths)):
         body = _read_corpus_file(p, unreadable)
         if body is None:
             continue
-        fm = frontmatter(body)
         scope = (
             "user-global"
             if str(p).startswith(str(HOME_RULES))
@@ -360,26 +702,73 @@ def collect(root: Path) -> tuple[list[dict], list[dict], list[str]]:
             if p.parent.parent.parent == root
             else str(p).split("/.claude/rules/")[0].replace(str(root) + "/", "")
         )
-        title = next(
-            (line[2:].strip() for line in body.splitlines() if line.startswith("# ")),
-            p.stem,
-        )
         rules.append(
-            {
-                "kind": "rule",
-                "path": str(p),
-                "name": p.stem,
-                "title": title,
-                "body": body,
-                "fm": fm,
-                "scope": scope,
-                "always_loaded": scope in ("user-global", "portfolio"),
-                "chars": len(body),
-                "hash": sha(body),
-                "stub": "romoted to a skill" in body[:700],
-            }
+            _doc(
+                "rule",
+                p,
+                p.stem,
+                _heading_title(body, p.stem),
+                body,
+                frontmatter(body),
+                scope,
+                always_loaded=scope in ("user-global", "portfolio"),
+                stub="romoted to a skill" in body[:700],
+            )
         )
-    return rules, skills, unreadable
+
+    for p in sorted(set(agent_paths)):
+        body = _read_corpus_file(p, unreadable)
+        if body is None:
+            continue
+        agents.append(
+            _doc(
+                "agent",
+                p,
+                p.stem,
+                _heading_title(body, p.stem),
+                body,
+                frontmatter(body),
+                SCOPE_PLUGIN,
+                always_loaded=False,
+            )
+        )
+
+    for p in sorted(set(claude_md_paths)):
+        body = _read_corpus_file(p, unreadable)
+        if body is None:
+            continue
+        rel = p.parent.relative_to(root)
+        name = "." if rel == Path(".") else rel.as_posix()
+        # The `# ` heading fallback rules use is kept, and a path-derived label
+        # is needed on top of it: 2 of the 3 CLAUDE.md here carry no frontmatter
+        # at all and their H1 is literally `# CLAUDE.md`, which identifies
+        # nothing when three of them appear in one report.
+        title = _heading_title(body, "")
+        if title.lower() in ("", "claude.md", "claude"):
+            title = f"CLAUDE.md ({name})"
+        claude_mds.append(
+            _doc(
+                "claude_md",
+                p,
+                name,
+                title,
+                body,
+                frontmatter(body),
+                "portfolio" if p.parent == root else name,
+                # Only a CLAUDE.md at the root loads on every turn. A nested one
+                # (`experiments/*/CLAUDE.md`) loads when a session opens that
+                # directory, which is not the always-loaded budget's question.
+                always_loaded=p.parent == root,
+            )
+        )
+
+    corpus = {
+        "rule": rules,
+        "skill": skills,
+        "agent": agents,
+        "claude_md": claude_mds,
+    }
+    return corpus, unreadable, templates_excluded, agent_dirs
 
 
 # --------------------------------------------------------------------- checks
@@ -410,11 +799,21 @@ def _stub_target(head: str, known: set[str]) -> str | None:
     return refs[0] if refs else None
 
 
-def check_stub_integrity(rules, skills) -> list[Finding]:
+def check_stub_integrity(docs, skills) -> list[Finding]:
+    """Pointer stubs are a RULE convention; the guard is on the kind, not the flag.
+
+    Guarded on `kind == "rule"` rather than on `stub` alone even though only
+    rules are passed today. `stub` is the literal substring `"romoted to a
+    skill"` in the first 700 characters, and a CLAUDE.md or an agent prompt that
+    *quotes* that phrase -- describing the convention rather than following it,
+    which is exactly what a repo's own CLAUDE.md does -- would set the flag and
+    then fail resolution as a broken stub. The kind is the fact; the substring
+    is a heuristic for it.
+    """
     known = {s["name"] for s in skills}
     out = []
-    for r in rules:
-        if not r["stub"]:
+    for r in docs:
+        if r["kind"] != "rule" or not r["stub"]:
             continue
         target = _stub_target(r["body"][:700], known)
         if target not in known:
@@ -438,6 +837,24 @@ def check_review_staleness(items, cache: dict, allow_spawn: bool) -> list[Findin
     cache is correct by construction rather than by TTL. In fast mode (the probe)
     a cache miss is skipped rather than spawning git, so the probe stays sub-second
     and the scheduled run is what warms the cache.
+
+    THE SKIP IS SILENT, AND IT SCOPES EVERY CLAIM MADE ABOUT THIS CHECK IN
+    `--fast`. A cache miss under `allow_spawn=False` produces no finding and no
+    counter movement, so a kind with zero keys in the live gitdates cache is
+    invisible to the cheap tier while looking exactly like a kind that was
+    evaluated and found current.
+
+    That is not hypothetical for the kinds this PR added: the live cache carried
+    0 agent and 0 CLAUDE.md keys, so `--fast` skipped every one of them. The
+    "existing counters unchanged" acceptance result for the widening was taken in
+    `--fast` and is therefore a CHEAP-TIER result only. Re-measured non-fast
+    against a scratch cache at this repo's root, the scheduled tier gains exactly
+    one finding: `FINDING_REVIEW_STALENESS` 67 -> 68, `WARNINGS` 67 -> 68,
+    `ISSUE_COUNT` 73 -> 74. It is GENUINE -- `claude-plugins/CLAUDE.md` is 125
+    days past its declared `reviewed: 2026-04-21` -- and is not suppressed.
+
+    Not a coverage gap on the agent side: the same non-fast run warmed 21 agent
+    keys, so all 21 agents WERE evaluated and are genuinely inside STALE_DAYS.
     """
     out = []
     for it in items:
@@ -471,26 +888,39 @@ def check_review_staleness(items, cache: dict, allow_spawn: bool) -> list[Findin
     return sorted(out, key=lambda x: -x["gap_days"])
 
 
-def check_budget(rules) -> list[Finding]:
-    # A rule in a user-global/portfolio scope is NOT unconditionally injected if
-    # it carries `paths:` frontmatter -- it loads only when a matching file is
-    # read. Counting those inflates the budget by ~24% on this portfolio (13 of
-    # 67 rules, ~12,200 tok). Confirmed empirically: path-scoped rules are absent
-    # from the initial context injection and arrive later as reminders.
-    always = [r for r in rules if r["always_loaded"] and "paths" not in r["fm"]]
-    tokens = sum(r["chars"] for r in always) // 4
+def always_loaded_docs(docs) -> list[dict]:
+    """The documents that really are injected on every turn.
+
+    A rule in a user-global/portfolio scope is NOT unconditionally injected if
+    it carries `paths:` frontmatter -- it loads only when a matching file is
+    read. Counting those inflates the budget by ~24% on this portfolio (13 of
+    67 rules, ~12,200 tok). Confirmed empirically: path-scoped rules are absent
+    from the initial context injection and arrive later as reminders.
+
+    The root CLAUDE.md qualifies on the same terms and for the same reason: it
+    is injected on every turn, so leaving it out understates the standing cost
+    by its full size. `always_loaded` is set at collection time
+    (`p.parent == root`), so a nested `experiments/*/CLAUDE.md` never reaches
+    here.
+    """
+    return [d for d in docs if d["always_loaded"] and "paths" not in d["fm"]]
+
+
+def check_budget(docs) -> list[Finding]:
+    always = always_loaded_docs(docs)
+    tokens = sum(d["chars"] for d in always) // 4
     if tokens <= BUDGET_TOKENS:
         return []
-    worst = sorted(always, key=lambda r: -r["chars"])[:3]
+    worst = sorted(always, key=lambda d: -d["chars"])[:3]
     return [
         Finding(
             "warn",
             "always_loaded_budget",
             (
-                f"{len(always)} always-loaded rules cost ~{tokens:,} tok/turn "
+                f"{len(always)} always-loaded documents cost ~{tokens:,} tok/turn "
                 f"(budget {BUDGET_TOKENS:,}); heaviest: "
                 + ", ".join(
-                    f"{r['name']}(~{r['chars'] // 4 // 100 * 100:,})" for r in worst
+                    f"{d['name']}(~{d['chars'] // 4 // 100 * 100:,})" for d in worst
                 )
             ),
             tokens=tokens,
@@ -499,6 +929,17 @@ def check_budget(rules) -> list[Finding]:
 
 
 def check_frontmatter(rules) -> list[Finding]:
+    """RULE frontmatter coverage. Agents and CLAUDE.md are excluded on purpose.
+
+    Agents: 21 of 21 already carry `reviewed:`, so widening this reports `0/21`
+    -- a finding that can never fire is dead code that reads as coverage.
+    CLAUDE.md: 2 of the 3 here carry no frontmatter AT ALL, by convention, so
+    the finding would be permanent and unactionable.
+
+    The summary's denominator therefore stays `/N rules` and is NOT silently
+    widened to "documents": the number a reader acts on has to name the set it
+    was counted over.
+    """
     missing = [r for r in rules if not r["fm"].get("reviewed")]
     if not missing:
         return []
@@ -511,23 +952,93 @@ def check_frontmatter(rules) -> list[Finding]:
     ]
 
 
-def check_lexical_dupes(rules, waivers) -> list[Finding]:
-    for r in rules:
-        r["_sh"] = shingles(r["body"])
-    out = []
-    for a, b in combinations(rules, 2):
-        s = jaccard(a["_sh"], b["_sh"])
-        if s >= T_LEXICAL and not waivers.waived(a, b):
-            out.append(
-                Finding(
-                    "warn",
-                    "duplicate_rule_lexical",
-                    f"{a['scope']}:{a['name']} and {b['scope']}:{b['name']} are {s:.0%} lexically identical",
-                    score=round(s, 3),
-                    paths=[a["path"], b["path"]],
+def _lexical_finding(kind: str, summary: str, score: float, paths: list) -> Finding:
+    """The duplicate-<kind>-lexical finding, spelled out per kind.
+
+    Three near-identical branches rather than one `f"duplicate_{kind}_lexical"`,
+    deliberately. The kind strings have to be LITERALS at the construction site:
+    `test-probe-lib.sh` TEST N3 AST-walks this file for `Finding(...)` calls to
+    derive the set of kinds the analyzer can emit, and asserts every one has an
+    explicit row in the probe hook's remediation map -- an interpolated kind is
+    either unparseable there or expands over the wrong domain. It also means a
+    grep for a kind lands on the code that emits it.
+
+    SEVERITY IS NOT UNIFORM ACROSS THE THREE, and the split is about what the
+    duplication MEANS rather than about report real-estate:
+
+    * `rule` -> warn. Two `.claude/rules/` scopes are both live configuration
+      and both load, so an identical rule in each really is a promotion
+      candidate. Duplication here is drift by construction.
+    * `agent` -> warn. Two `*-plugin/agents/*.md` in one marketplace are both
+      live, both listed, and a near-identical pair is genuine redundancy a
+      reader has to disambiguate at dispatch time.
+    * `claude_md` -> INFO. A CLAUDE.md pair is very often duplication that is
+      CORRECT: a vendored clone and its upstream, or one package copied into two
+      places. Measured at `~/repos`, the top pair is a byte-identical CLAUDE.md
+      between the vendored `external/facedancer` clone and the user's own
+      `mcu-tinkering-lab` package -- expected, not drift. The analyzer cannot
+      tell a vendored copy from a divergence, and `warn` asserts the second.
+
+    What this does NOT buy, stated because the obvious reading is wrong: it does
+    not restore `rule_covered_by_skill` to the SessionStart nudge. The hook
+    forwards `.[:4]` after `sort_by(.rank, .kind)`, and with five kinds present
+    one is dropped whatever the severities are -- within `info`,
+    `frontmatter_coverage` beats `rule_covered_by_skill` on the alphabetical
+    tiebreak either way. Measured at `~/repos` and `~/repos/laurigates`, before
+    and after: the forwarded SET is unchanged. What changes is the ORDER, and
+    specifically slot 1, which stops being a vendored-clone artifact and becomes
+    real drift again. The cap and the sort are shared across every plugin and
+    are not this probe's to change.
+    """
+    if kind == "rule":
+        return Finding(
+            "warn", "duplicate_rule_lexical", summary, score=score, paths=paths
+        )
+    if kind == "agent":
+        return Finding(
+            "warn", "duplicate_agent_lexical", summary, score=score, paths=paths
+        )
+    return Finding(
+        "info", "duplicate_claude_md_lexical", summary, score=score, paths=paths
+    )
+
+
+def check_lexical_dupes(corpus, waivers) -> tuple[list[Finding], int]:
+    """Jaccard over 3-gram shingles, PARTITIONED by kind.
+
+    Two reasons, and the second is the one that matters. Cost, measured on this
+    corpus (best of 5, rules-only baseline 129.7ms): pooling rules + agents +
+    CLAUDE.md into one `combinations()` costs +62.3ms (7,381 pairs), against
+    +6.6ms partitioned (4,966 pairs) -- 9x, on the stage that already dominates
+    the cheap tier the SessionStart probe runs. Meaning: a high Jaccard between
+    an agent prompt and a rule is not a "duplicate rule", and the finding kind
+    has no sensible cross-kind spelling -- `duplicate_rule_agent_lexical` would
+    route to a remediation that does not exist.
+
+    Returns the findings AND the number of pairs compared, so the partition is
+    observable in the counts block (`LEXICAL_PAIRS=`) rather than being an
+    invisible implementation detail that a later pooling could undo silently.
+    """
+    out: list[Finding] = []
+    pairs = 0
+    for kind in LEXICAL_KINDS:
+        docs = corpus.get(kind, [])
+        for d in docs:
+            d["_sh"] = shingles(d["body"])
+        for a, b in combinations(docs, 2):
+            pairs += 1
+            s = jaccard(a["_sh"], b["_sh"])
+            if s >= T_LEXICAL and not waivers.waived(a, b):
+                out.append(
+                    _lexical_finding(
+                        kind,
+                        f"{a['scope']}:{a['name']} and {b['scope']}:{b['name']} "
+                        f"are {s:.0%} lexically identical",
+                        round(s, 3),
+                        [a["path"], b["path"]],
+                    )
                 )
-            )
-    return sorted(out, key=lambda x: -x["score"])
+    return sorted(out, key=lambda x: -x["score"]), pairs
 
 
 def check_rule_covered_by_skill(rules, skills, waivers) -> list[Finding]:
@@ -537,6 +1048,14 @@ def check_rule_covered_by_skill(rules, skills, waivers) -> list[Finding]:
     SKILL.md is 5-20x a rule's length, so the union swamps the intersection.
     Containment is asymmetric and correct. Control-tested: every already-promoted
     pointer stub must score above threshold against its own skill.
+
+    RULES ONLY -- do not widen this to agents or CLAUDE.md. The control gate at
+    the bottom counts pointer STUBS, and agents and CLAUDE.md have none by
+    construction, so including them leaves `control_hits` unchanged while
+    inflating nothing... except that any future stub-shaped text in them would
+    dilute `control_total` toward the 0.7 threshold. Tripping that gate emits
+    `coverage_metric_broken` and SUPPRESSES EVERY coverage finding: a one-line
+    widening here silently disables an existing check rather than extending it.
     """
 
     def tset(text):
@@ -762,16 +1281,24 @@ def main() -> int:
         print(f"root not found: {root}", file=sys.stderr)
         return 3
 
-    rules, skills, unreadable = collect(root)
+    corpus, unreadable, templates_excluded, agent_dirs = collect(root)
+    rules = corpus["rule"]
+    skills = corpus["skill"]
+    agents = corpus["agent"]
+    claude_mds = corpus["claude_md"]
     waivers = Waivers.load(Path(args.waivers).expanduser())
 
+    # The check x kind matrix, guarded explicitly at every call site. Each
+    # check's own docstring carries the reason it takes the kinds it takes.
     findings: list[Finding] = []
     findings += check_stub_integrity(rules, skills)
-    findings += check_budget(rules)
-    findings += check_lexical_dupes(rules, waivers)
+    findings += check_budget(rules + claude_mds)
+    lexical, lexical_pairs = check_lexical_dupes(corpus, waivers)
+    findings += lexical
     findings += check_rule_covered_by_skill(rules, skills, waivers)
     findings += check_frontmatter(rules)
     findings += check_corpus_unreadable(unreadable)
+    findings += check_agent_discovery_misfire(agents, agent_dirs)
 
     datecache_path = Path(args.cache).expanduser().with_name("gitdates.json")
     datecache: dict = {}
@@ -781,8 +1308,14 @@ def main() -> int:
         except (OSError, json.JSONDecodeError):
             datecache = {}
     before = len(datecache)
+    # Staleness applies to every kind unchanged. Agents earn it: 21 of 21 carry
+    # both `reviewed:` and `modified:`, and they are in-repo so `git_last_change`
+    # resolves. CLAUDE.md is included on the same terms even though it will
+    # almost never fire -- the check is a no-op for a document with no
+    # `reviewed:` date, so excluding it would buy nothing and would have to be
+    # revisited the moment one gained a date.
     findings += check_review_staleness(
-        rules + skills, datecache, allow_spawn=not args.fast
+        rules + skills + agents + claude_mds, datecache, allow_spawn=not args.fast
     )
     if len(datecache) != before:
         datecache_path.parent.mkdir(parents=True, exist_ok=True)
@@ -790,8 +1323,14 @@ def main() -> int:
 
     if not args.no_embed:
         try:
+            # SEMANTIC_KINDS, not `rules + skills` spelled out: the exclusion of
+            # agents and CLAUDE.md is a calibration decision (see the constant),
+            # and it has to be readable from the constant rather than inferred
+            # from which lists happen to be concatenated here.
             findings += check_semantic_dupes(
-                rules + skills, waivers, Path(args.cache).expanduser()
+                [d for k in SEMANTIC_KINDS for d in corpus[k]],
+                waivers,
+                Path(args.cache).expanduser(),
             )
         except Exception as exc:  # noqa: BLE001 - degrade loudly, never silently
             findings.append(
@@ -832,14 +1371,40 @@ def main() -> int:
             if not f.get("paths") or any(p in touched for p in f["paths"])
         ]
 
-    always = [r for r in rules if r["always_loaded"] and "paths" not in r["fm"]]
+    always = always_loaded_docs(rules + claude_mds)
     counts = {
         "rules": len(rules),
         "skills": len(skills),
+        "agents": len(agents),
+        # The DENOMINATOR for AGENTS, emitted EVEN AT 0 for the same reason the
+        # exclusion counter below is. `AGENTS=0` alone cannot distinguish "this
+        # tree has no agents" from "discovery misfired" -- which is exactly the
+        # state the depth-anchored glob left `~/repos` in. `AGENTS=0` beside
+        # `AGENT_DIRS=8` reads as a misfire on sight, `AGENTS=0` beside
+        # `AGENT_DIRS=0` reads as a clean tree, and
+        # `check_agent_discovery_misfire` turns the first pair into a finding.
+        # Plugin directories would be the WRONG denominator: most plugins define
+        # no agents, so most trees would read as a misfire.
+        "agent_dirs": agent_dirs,
+        "claude_mds": len(claude_mds),
+        # Emitted EVEN AT 0. An exclusion that reports nothing is
+        # indistinguishable from a collector that stopped finding anything to
+        # exclude -- and from one that stopped finding CLAUDE.md at all.
+        "claude_md_templates_excluded": templates_excluded,
+        # Rules only, deliberately: this is the scope LADDER's width, and skills
+        # and agents are namespaced by plugin rather than scoped.
         "scopes": len({r["scope"] for r in rules}),
-        "always_loaded_rules": len(always),
-        "always_loaded_tokens": sum(r["chars"] for r in always) // 4,
+        # Split by kind rather than merged, so the CLAUDE.md the budget newly
+        # includes is visible as its own line instead of an unexplained jump in
+        # ALWAYS_LOADED_TOKENS.
+        "always_loaded_rules": sum(1 for d in always if d["kind"] == "rule"),
+        "always_loaded_claude_md": sum(1 for d in always if d["kind"] == "claude_md"),
+        "always_loaded_tokens": sum(d["chars"] for d in always) // 4,
         "pointer_stubs": sum(1 for r in rules if r["stub"]),
+        # Makes the lexical partition assertable: pooled it would be
+        # N(N-1)/2 over every kind, partitioned it is the sum of each kind's own
+        # n(n-1)/2.
+        "lexical_pairs": lexical_pairs,
         "waivers_active": len(waivers),
         "semantic_pass": "off" if args.no_embed else "on",
     }

--- a/health-plugin/scripts/tests/test-config-drift.sh
+++ b/health-plugin/scripts/tests/test-config-drift.sh
@@ -808,6 +808,813 @@ python3 "$EMBED_DRIVER" "$ANALYZER" "$EMBED_CACHE" "$EMBED_LOG" "new description
     "BAAI/bge-large-en-v1.5" >/dev/null 2>&1
 assert_eq "swapping the embedding model re-embeds every item" "$(log_lines)" "5"
 
+# --- helpers for the widened corpus -----------------------------------------
+finding_paths() {
+    printf '%s' "$1" | python3 -c 'import json,sys
+d = json.load(sys.stdin)
+print("\n".join(p for f in d["findings"] for p in f.get("paths", [])))' 2>/dev/null
+}
+count_worktree_paths() {
+    finding_paths "$1" | awk '/\/\.claude\/worktrees\//{n++} END{print n+0}'
+}
+fm_coverage_summary() {
+    printf '%s' "$1" | python3 -c 'import json,sys
+d = json.load(sys.stdin)
+print(next((f["summary"] for f in d["findings"] if f["kind"] == "frontmatter_coverage"), "<none>"))' 2>/dev/null
+}
+# Appends spaces until the file length is a multiple of 4. The budget is
+# `sum(chars) // 4`, and floor((S + c) / 4) == floor(S / 4) + c // 4 holds
+# EXACTLY when c is a multiple of 4 -- otherwise the delta depends on the rest
+# of the corpus and "raises it by exactly chars // 4" is not a testable claim.
+pad_to_multiple_of_4() {
+    local f="$1" n
+    n=$(wc -c < "$f" | tr -d ' ')
+    while [ $((n % 4)) -ne 0 ]; do printf ' ' >> "$f"; n=$((n + 1)); done
+}
+
+echo "TEST 13: agent-worktree copies are pruned, and the control proves discovery works"
+# The pin, not new logic: SKIP_PARTS already contains `worktrees`, and the agent
+# GLOB is anchored at depth 2 (`*-plugin/agents/*.md`) so a worktree copy is
+# three levels deeper than it can reach. Both are load-bearing for four kinds
+# now, and neither was asserted.
+out=$(run)
+wt_rules=$(count_key "$out" rules)
+wt_skills=$(count_key "$out" skills)
+wt_agents=$(count_key "$out" agents)
+wt_claude=$(count_key "$out" claude_mds)
+wt_pairs=$(count_key "$out" lexical_pairs)
+
+WT="$FIXROOT/proj/.claude/worktrees/agent-deadbeef"
+mkdir -p "$WT/repo-a/.claude/rules" "$WT/some-plugin/agents" \
+         "$WT/some-plugin/skills/widget-wrangling"
+cp "$FIXROOT/proj/repo-a/.claude/rules/alpha.md" "$WT/repo-a/.claude/rules/alpha.md"
+cp "$FIXROOT/proj/some-plugin/skills/widget-wrangling/SKILL.md" \
+   "$WT/some-plugin/skills/widget-wrangling/SKILL.md"
+cat > "$WT/some-plugin/agents/helper.md" <<'AGENT'
+---
+name: helper
+description: A helper agent inside an agent worktree.
+reviewed: 2026-01-01
+---
+# helper
+Calibrate widget torque against the fleet inventory manifest before adjusting
+any widget on the assembly line.
+AGENT
+cat > "$WT/CLAUDE.md" <<'CMD'
+# CLAUDE.md
+A CLAUDE.md inside an agent worktree clone. It must never enter the corpus.
+CMD
+
+out=$(run)
+assert_eq "a worktree rule copy is not counted"      "$(count_key "$out" rules)"      "$wt_rules"
+assert_eq "a worktree skill copy is not counted"     "$(count_key "$out" skills)"     "$wt_skills"
+assert_eq "a worktree agent copy is not counted"     "$(count_key "$out" agents)"     "$wt_agents"
+assert_eq "a worktree CLAUDE.md copy is not counted" "$(count_key "$out" claude_mds)" "$wt_claude"
+assert_eq "a worktree copy adds no lexical pairs"    "$(count_key "$out" lexical_pairs)" "$wt_pairs"
+assert_eq "no finding names a path inside .claude/worktrees/" "$(count_worktree_paths "$out")" "0"
+
+# CONTROL, weighted equally: the SAME files at non-worktree paths must move
+# every one of those counts. Without it "unchanged" also passes against a
+# collector that discovers nothing at all.
+mkdir -p "$FIXROOT/proj/repo-c/.claude/rules" "$FIXROOT/proj/other-plugin/agents" \
+         "$FIXROOT/proj/other-plugin/skills/gadget-gauging" "$FIXROOT/proj/nested-doc"
+cp "$WT/repo-a/.claude/rules/alpha.md" "$FIXROOT/proj/repo-c/.claude/rules/alpha.md"
+cp "$WT/some-plugin/skills/widget-wrangling/SKILL.md" \
+   "$FIXROOT/proj/other-plugin/skills/gadget-gauging/SKILL.md"
+cp "$WT/some-plugin/agents/helper.md" "$FIXROOT/proj/other-plugin/agents/helper.md"
+cp "$WT/CLAUDE.md" "$FIXROOT/proj/nested-doc/CLAUDE.md"
+out=$(run)
+assert_eq "CONTROL: the same rule outside a worktree IS counted"      "$(count_key "$out" rules)"      "$((wt_rules + 1))"
+assert_eq "CONTROL: the same skill outside a worktree IS counted"     "$(count_key "$out" skills)"     "$((wt_skills + 1))"
+assert_eq "CONTROL: the same agent outside a worktree IS counted"     "$(count_key "$out" agents)"     "$((wt_agents + 1))"
+assert_eq "CONTROL: the same CLAUDE.md outside a worktree IS counted" "$(count_key "$out" claude_mds)" "$((wt_claude + 1))"
+
+rm -rf "$WT" "$FIXROOT/proj/repo-c" "$FIXROOT/proj/other-plugin" "$FIXROOT/proj/nested-doc"
+out=$(run)
+assert_eq "cleanup restores the rule count" "$(count_key "$out" rules)" "$wt_rules"
+
+echo "TEST 14: agents -- three-rung lexical ladder, plus the partition proof"
+# A checker that reports a duplicate unconditionally, or never, passes exactly
+# one of the three rungs.
+mkdir -p "$FIXROOT/proj/some-plugin/agents" "$FIXROOT/proj/other-plugin/agents"
+cat > "$FIXROOT/proj/some-plugin/agents/torque-auditor.md" <<'AGENT'
+---
+name: torque-auditor
+description: Audit widget torque across the fleet.
+reviewed: 2026-01-01
+---
+# torque-auditor
+Audit the torque calibration of every widget against the fleet inventory
+manifest. Read the manifest first, then walk the assembly line and record the
+torque reading for each widget before proposing any adjustment.
+AGENT
+out=$(run)
+assert_eq "one agent, no duplicate reported" "$(count_kind "$out" duplicate_agent_lexical)" "0"
+assert_eq "the agent was discovered" "$(count_key "$out" agents)" "1"
+
+# W1, asserted directly: discovery is a depth-anchored GLOB, not a walk for a
+# directory NAMED `agents`. Two directories in the real corpus are Python source
+# packages (`*/src/*/agents/`); a walk predicate ingests any stray `.md` landing
+# in one as an agent prompt, silently.
+mkdir -p "$FIXROOT/proj/some-plugin/src/some_plugin/agents"
+cat > "$FIXROOT/proj/some-plugin/src/some_plugin/agents/README.md" <<'PKGDOC'
+# agents
+This is a Python source package, not an agent prompt directory.
+PKGDOC
+out=$(run)
+assert_eq "a .md in a source package named 'agents' is not an agent" \
+    "$(count_key "$out" agents)" "1"
+rm -rf "$FIXROOT/proj/some-plugin/src"
+
+sed 's/proposing any adjustment/proposing a single adjustment/' \
+    "$FIXROOT/proj/some-plugin/agents/torque-auditor.md" \
+    > "$FIXROOT/proj/other-plugin/agents/torque-auditor-copy.md"
+out=$(run)
+assert_eq "a near-identical agent in a second plugin is reported once" \
+    "$(count_kind "$out" duplicate_agent_lexical)" "1"
+assert_eq "an agent duplicate is not spelled as a rule duplicate" \
+    "$(count_kind "$out" duplicate_rule_lexical)" "0"
+
+rm "$FIXROOT/proj/other-plugin/agents/torque-auditor-copy.md"
+out=$(run)
+assert_eq "removing the copy clears the finding" "$(count_kind "$out" duplicate_agent_lexical)" "0"
+
+# PARTITION PROOF: an agent whose body is byte-identical to a RULE. Pooled into
+# one combinations() this pair scores 1.0 and fires; partitioned it is never
+# compared, and there is no cross-kind kind name it could be spelled with.
+cp "$FIXROOT/proj/repo-a/.claude/rules/alpha.md" \
+   "$FIXROOT/proj/other-plugin/agents/rule-clone.md"
+out=$(run)
+assert_eq "an agent byte-identical to a rule yields no duplicate_rule_lexical" \
+    "$(count_kind "$out" duplicate_rule_lexical)" "0"
+assert_eq "an agent byte-identical to a rule yields no duplicate_agent_lexical" \
+    "$(count_kind "$out" duplicate_agent_lexical)" "0"
+# Non-vacuity: the agent partition really did run over both agents (1 pair), so
+# the two zeros above are a partition result rather than a dead comparison.
+assert_eq "the agent partition compared its own pair" \
+    "$(count_key "$out" agents)" "2"
+rm "$FIXROOT/proj/other-plugin/agents/rule-clone.md"
+
+echo "TEST 15: CLAUDE.md -- three-rung lexical ladder, and the budget"
+mkdir -p "$FIXROOT/proj/nest-a" "$FIXROOT/proj/nest-b"
+cat > "$FIXROOT/proj/nest-a/CLAUDE.md" <<'CMD'
+# CLAUDE.md
+
+This directory holds the assembly-line simulation harness. Run the harness from
+the repository root, never from inside this directory, because the fixture
+paths are resolved relative to the root and the harness will silently produce
+an empty report otherwise.
+CMD
+out=$(run)
+assert_eq "one CLAUDE.md, no duplicate reported" "$(count_kind "$out" duplicate_claude_md_lexical)" "0"
+assert_eq "the nested CLAUDE.md was discovered" "$(count_key "$out" claude_mds)" "1"
+
+sed 's/an empty report otherwise/an empty report in that case/' \
+    "$FIXROOT/proj/nest-a/CLAUDE.md" > "$FIXROOT/proj/nest-b/CLAUDE.md"
+out=$(run)
+assert_eq "a near-identical CLAUDE.md is reported once" \
+    "$(count_kind "$out" duplicate_claude_md_lexical)" "1"
+
+rm "$FIXROOT/proj/nest-b/CLAUDE.md"
+out=$(run)
+assert_eq "removing the copy clears the finding" "$(count_kind "$out" duplicate_claude_md_lexical)" "0"
+
+# Budget: only a ROOT CLAUDE.md is always-loaded.
+out=$(run)
+base_tokens=$(count_key "$out" always_loaded_tokens)
+assert_eq "a NESTED CLAUDE.md is not always-loaded" "$(count_key "$out" always_loaded_claude_md)" "0"
+
+cat > "$FIXROOT/proj/CLAUDE.md" <<'CMD'
+---
+created: 2026-01-01
+modified: 2026-01-01
+reviewed: 2026-01-01
+---
+# Assembly Line
+
+The fleet inventory manifest is the source of truth for widget torque. Every
+adjustment is recorded against the manifest, and the manifest is regenerated
+nightly from the assembly-line telemetry feed.
+CMD
+pad_to_multiple_of_4 "$FIXROOT/proj/CLAUDE.md"
+root_chars=$(wc -c < "$FIXROOT/proj/CLAUDE.md" | tr -d ' ')
+# FIXTURE VALIDITY: the exact-delta claim below is only well-posed for a
+# multiple of 4 (see pad_to_multiple_of_4).
+assert_eq "FIXTURE: the root CLAUDE.md length is a multiple of 4" "$((root_chars % 4))" "0"
+out=$(run)
+assert_eq "a root CLAUDE.md sets ALWAYS_LOADED_CLAUDE_MD=1" "$(count_key "$out" always_loaded_claude_md)" "1"
+assert_eq "a root CLAUDE.md raises always_loaded_tokens by exactly chars // 4" \
+    "$(count_key "$out" always_loaded_tokens)" "$((base_tokens + root_chars / 4))"
+rm "$FIXROOT/proj/CLAUDE.md"
+out=$(run)
+assert_eq "removing the root CLAUDE.md restores the token budget" \
+    "$(count_key "$out" always_loaded_tokens)" "$base_tokens"
+assert_eq "a nested CLAUDE.md raises the budget by 0" "$(count_key "$out" always_loaded_tokens)" "$base_tokens"
+
+echo "TEST 16: generator-template exclusion, both polarities"
+out=$(run)
+base_claude=$(count_key "$out" claude_mds)
+base_skills=$(count_key "$out" skills)
+assert_eq "the exclusion counter is emitted even at 0" "$(count_key "$out" claude_md_templates_excluded)" "0"
+
+# Signal 1 + 2 together: a `templates` path component AND a manifest sibling.
+mkdir -p "$FIXROOT/proj/some-plugin/templates/thing"
+printf '[values]\nname = "x"\n' > "$FIXROOT/proj/some-plugin/templates/thing/cargo-generate.toml"
+cat > "$FIXROOT/proj/some-plugin/templates/thing/CLAUDE.md" <<'CMD'
+# CLAUDE.md
+Guidance for the generated module. Nothing here loads in any real session.
+CMD
+out=$(run)
+assert_eq "a templates/ CLAUDE.md with a manifest is excluded" "$(count_key "$out" claude_mds)" "$base_claude"
+assert_eq "the exclusion is reported" "$(count_key "$out" claude_md_templates_excluded)" "1"
+
+# Signal 2 ALONE: a manifest at an ancestor, no `templates` component anywhere.
+mkdir -p "$FIXROOT/proj/scaffold-x/inner"
+printf '{"project_name": "x"}\n' > "$FIXROOT/proj/scaffold-x/cookiecutter.json"
+cat > "$FIXROOT/proj/scaffold-x/inner/CLAUDE.md" <<'CMD'
+# CLAUDE.md
+Guidance for the generated project. A manifest at an ancestor declares this a
+template tree even though no directory is named templates.
+CMD
+out=$(run)
+assert_eq "a manifest at an ancestor alone excludes it" "$(count_key "$out" claude_mds)" "$base_claude"
+assert_eq "both exclusions are reported" "$(count_key "$out" claude_md_templates_excluded)" "2"
+
+# A `templates` component ALONE no longer excludes -- it is a CONVENTIONAL
+# signal and needs corroboration. This assertion is INVERTED from the version
+# that shipped with the widening, deliberately: the uncorroborated component
+# match fired at any depth and took out every repo with a Flask/Django
+# `app/templates/`, which is live configuration. TEST 20 carries that fixture and
+# the full both-polarity matrix; this row is here so the exclusion counter's
+# arithmetic below stays readable in one place.
+mkdir -p "$FIXROOT/proj/other-plugin/templates/bare"
+cat > "$FIXROOT/proj/other-plugin/templates/bare/CLAUDE.md" <<'CMD'
+# CLAUDE.md
+A template tree that ships no generator manifest at all.
+CMD
+out=$(run)
+assert_eq "a templates/ component ALONE is NOT excluded (needs corroboration)" \
+    "$(count_key "$out" claude_mds)" "$((base_claude + 1))"
+assert_eq "so the exclusion count stays at two" "$(count_key "$out" claude_md_templates_excluded)" "2"
+
+# THE ASSERTION THAT KILLS THE SKIP_PARTS IMPLEMENTATION: a real skill whose
+# directory is literally named `templates`. Reproduces the shape of the live
+# obsidian-plugin/skills/templates/SKILL.md. Adding `templates` to SKIP_PARTS
+# passes every exclusion assertion above and silently drops this skill -- which
+# also breaks check_stub_integrity for any stub that delegates to it.
+mkdir -p "$FIXROOT/proj/other-plugin/skills/templates"
+cat > "$FIXROOT/proj/other-plugin/skills/templates/SKILL.md" <<'SKILL'
+---
+name: templates
+description: Create and apply note templates. Use when scaffolding a vault note from a template.
+---
+# templates
+Scaffold a vault note from a stored template, filling the date and title fields
+from the current context.
+SKILL
+out=$(run)
+assert_eq "a skill directory named 'templates' is STILL discovered" \
+    "$(count_key "$out" skills)" "$((base_skills + 1))"
+
+# And a pointer stub delegating to it still resolves -- the second-order damage
+# a global skip would do.
+cat > "$FIXROOT/home/.claude/rules/templates-stub.md" <<'RULE'
+# Note Templates
+
+Promoted to a skill: invoke `other-plugin:templates` when scaffolding a vault
+note — it carries the field-filling procedure.
+RULE
+out=$(run)
+assert_eq "a stub delegating to the 'templates' skill still resolves" \
+    "$(count_kind "$out" broken_pointer_stub)" "0"
+rm "$FIXROOT/home/.claude/rules/templates-stub.md"
+
+# An ordinary CLAUDE.md -- no marker, no manifest -- IS discovered.
+mkdir -p "$FIXROOT/proj/plain-dir"
+cat > "$FIXROOT/proj/plain-dir/CLAUDE.md" <<'CMD'
+# CLAUDE.md
+An ordinary nested CLAUDE.md at a path with no template signal of any kind.
+CMD
+out=$(run)
+assert_eq "an ordinary CLAUDE.md IS discovered" "$(count_key "$out" claude_mds)" "$((base_claude + 2))"
+assert_eq "discovering it excludes nothing new" "$(count_key "$out" claude_md_templates_excluded)" "2"
+rm -rf "$FIXROOT/proj/some-plugin/templates" "$FIXROOT/proj/scaffold-x" \
+       "$FIXROOT/proj/other-plugin/templates" "$FIXROOT/proj/plain-dir"
+
+echo "TEST 17: the kind guards, as negative assertions"
+out=$(run)
+guard_missing=$(missing_reviewed "$out")
+guard_covered=$(count_kind "$out" rule_covered_by_skill)
+guard_stubs=$(count_kind "$out" broken_pointer_stub)
+
+# check_frontmatter is RULE-only. An agent with no reviewed: must not enter the
+# numerator, and the denominator must keep naming the set it counted.
+cat > "$FIXROOT/proj/other-plugin/agents/undated.md" <<'AGENT'
+---
+name: undated
+description: An agent carrying no reviewed: date at all.
+---
+# undated
+Walk the assembly line and record every torque reading.
+AGENT
+out=$(run)
+assert_eq "an agent with no reviewed: does not move frontmatter_coverage" \
+    "$(missing_reviewed "$out")" "$guard_missing"
+assert_contains "the frontmatter_coverage denominator still reads 'rules'" \
+    "$(fm_coverage_summary "$out")" " rules carry no reviewed:"
+
+# check_stub_integrity is guarded on the KIND, not on the `stub` substring. A
+# CLAUDE.md quoting the house phrasing is describing the convention, not
+# following it.
+mkdir -p "$FIXROOT/proj/quoting-dir"
+cat > "$FIXROOT/proj/quoting-dir/CLAUDE.md" <<'CMD'
+# CLAUDE.md
+
+House convention: a rule that has been promoted to a skill opens with
+"Promoted to a skill: invoke `some-skill-that-does-not-exist`" and nothing else.
+CMD
+out=$(run)
+assert_eq "a CLAUDE.md quoting the stub phrasing is not a broken stub" \
+    "$(count_kind "$out" broken_pointer_stub)" "$guard_stubs"
+
+# check_rule_covered_by_skill is RULE-only, and BOTH halves of that guard need
+# a fixture that would really fire if it were widened -- an agent the metric
+# simply scores low is not evidence about the guard.
+#
+# (i) a near-copy of the SKILL carrying NO stub phrasing. Widened, its
+#     containment is far above T_COVERAGE and it emits rule_covered_by_skill.
+cat > "$FIXROOT/proj/other-plugin/agents/widget-wrangling-clone.md" <<'AGENT'
+---
+name: widget-wrangling-clone
+description: Wrangle widgets across the fleet. Use when calibrating widget torque or auditing widget inventory.
+reviewed: 2026-01-01
+---
+# widget-wrangling-clone
+Calibrating widget torque requires the fleet inventory. Audit widget torque
+calibration across every widget in the inventory before adjusting any widget.
+AGENT
+# (ii) two stub-SHAPED agents naming nothing that exists and sharing no
+#     vocabulary with any skill. Widened by an implementation that also computed
+#     `stub` for every kind, they enter the CONTROL set and fail containment:
+#     control_hits/control_total falls to 1/3, under the 0.7 gate, which emits
+#     coverage_metric_broken and SUPPRESSES every coverage finding -- an
+#     existing check silently disabled by a one-line widening.
+for n in 1 2; do
+    cat > "$FIXROOT/proj/other-plugin/agents/stubby-$n.md" <<AGENT
+---
+name: stubby-$n
+description: Placeholder $n.
+reviewed: 2026-01-01
+---
+# stubby-$n
+
+Promoted to a skill: invoke \`no-such-skill-$n\` before harvesting the orchard,
+because the almanac tabulates rainfall by parish and the ledger reconciles
+tithes quarterly against the parish register.
+AGENT
+done
+out=$(run)
+assert_eq "an agent overlapping a skill yields no rule_covered_by_skill" \
+    "$(count_kind "$out" rule_covered_by_skill)" "$guard_covered"
+assert_eq "the coverage control gate is not tripped" \
+    "$(count_kind "$out" coverage_metric_broken)" "0"
+assert_eq "and no agent is reported as a broken stub either" \
+    "$(count_kind "$out" broken_pointer_stub)" "$guard_stubs"
+rm "$FIXROOT/proj/other-plugin/agents/undated.md" \
+   "$FIXROOT/proj/other-plugin/agents/widget-wrangling-clone.md" \
+   "$FIXROOT/proj/other-plugin/agents/stubby-1.md" \
+   "$FIXROOT/proj/other-plugin/agents/stubby-2.md"
+rm -rf "$FIXROOT/proj/quoting-dir"
+
+echo "TEST 18: the lexical partition, asserted structurally rather than by timing"
+# A fixture corpus is tiny, so a wall-clock bound would prove nothing. The
+# partition has an exact arithmetic signature instead: the sum of each kind's
+# own n(n-1)/2, which for any corpus with two non-empty lexical kinds is
+# strictly less than the pooled N(N-1)/2.
+mkdir -p "$FIXROOT/proj/repo-b/.claude/rules" "$FIXROOT/proj/nest-b"
+cat > "$FIXROOT/proj/repo-b/.claude/rules/gamma.md" <<'RULE'
+# Gamma
+The nightly telemetry feed regenerates the fleet inventory manifest, and a
+manual edit to the manifest is overwritten at the next run.
+RULE
+cat > "$FIXROOT/proj/other-plugin/agents/line-walker.md" <<'AGENT'
+---
+name: line-walker
+description: Walk the assembly line and report anomalies.
+reviewed: 2026-01-01
+---
+# line-walker
+Walk the assembly line end to end and report any station whose telemetry feed
+has stopped reporting.
+AGENT
+cat > "$FIXROOT/proj/nest-b/CLAUDE.md" <<'CMD'
+# CLAUDE.md
+A second nested CLAUDE.md, sharing no vocabulary with the first: this one
+documents the release checklist and the tag naming convention.
+CMD
+out=$(run)
+n_rules=$(count_key "$out" rules)
+n_agents=$(count_key "$out" agents)
+n_claude=$(count_key "$out" claude_mds)
+expected=$(( n_rules * (n_rules - 1) / 2 + n_agents * (n_agents - 1) / 2 + n_claude * (n_claude - 1) / 2 ))
+total=$(( n_rules + n_agents + n_claude ))
+pooled=$(( total * (total - 1) / 2 ))
+# FIXTURE VALIDITY: with fewer than two non-empty kinds the two formulas
+# coincide and the assertion below is vacuous.
+assert_eq "FIXTURE: all three lexical kinds are non-empty" \
+    "$([ "$n_rules" -gt 0 ] && [ "$n_agents" -gt 0 ] && [ "$n_claude" -gt 0 ] && echo yes || echo no)" "yes"
+if [ "$expected" -lt "$pooled" ]; then
+    ok "FIXTURE: the partitioned and pooled counts genuinely differ ($expected vs $pooled)"
+else
+    bad "FIXTURE: the partitioned and pooled counts genuinely differ" "expected < pooled" "$expected >= $pooled"
+fi
+assert_eq "LEXICAL_PAIRS equals the sum of each kind's own n(n-1)/2" \
+    "$(count_key "$out" lexical_pairs)" "$expected"
+if [ "$(count_key "$out" lexical_pairs)" != "$pooled" ]; then
+    ok "LEXICAL_PAIRS is NOT the pooled N(N-1)/2"
+else
+    bad "LEXICAL_PAIRS is NOT the pooled N(N-1)/2" "not $pooled" "$pooled"
+fi
+rm "$FIXROOT/proj/repo-b/.claude/rules/gamma.md" \
+   "$FIXROOT/proj/other-plugin/agents/line-walker.md" \
+   "$FIXROOT/proj/nest-b/CLAUDE.md"
+
+# --- helpers for the D1/D2/D4 cases ----------------------------------------
+finding_field() {
+    printf '%s' "$1" | python3 -c 'import json,sys
+d = json.load(sys.stdin)
+print(next((f[sys.argv[2]] for f in d["findings"] if f["kind"] == sys.argv[1]), "<none>"))' \
+        "$2" "$3" 2>/dev/null || echo ERR
+}
+# An isolated root gets an EMPTY home: $FIXROOT/home carries pointer stubs whose
+# target skill exists only in $FIXROOT/proj, so leaving HOME pointed there would
+# manufacture a broken_pointer_stub ERROR in every isolated root and make the
+# --gate assertions below exit 2 for the wrong reason.
+mkdir -p "$FIXROOT/empty-home/.claude/rules"
+run_root() { HOME="$FIXROOT/empty-home" python3 "$ANALYZER" --root "$1" --no-embed --fast --format=json 2>/dev/null; }
+
+echo "TEST 19: agent discovery is depth-INDEPENDENT, and a misfire is distinguishable"
+# THE DEFECT: discovery was `root.glob("*-plugin/agents/*.md")` -- pinned to
+# depth 2 while rules, skills and CLAUDE.md all came from the recursive pruned
+# walk. `hooks/config-drift-probe.sh` passes `--root "${DRIFT_CWD:-.}"`, the
+# session cwd, and `~/repos` / `~/repos/laurigates` are documented Claude Code
+# working roots one and two levels ABOVE where the plugins live. Measured
+# pre-fix: 247 rules / 561 skills / 0 agents at `laurigates`, 367 / 591 / 0 at
+# `repos`, against 21 real agents below each. The whole agent widening was inert
+# exactly where the probe fires.
+out=$(run)
+base_agents=$(count_key "$out" agents)
+base_agent_dirs=$(count_key "$out" agent_dirs)
+# FIXTURE VALIDITY: without an agent already in the corpus, "one more was found"
+# would also pass against a collector that found exactly one thing by luck.
+assert_ge "FIXTURE: the corpus already holds an agent" "$base_agents" 1
+assert_ge "FIXTURE: the corpus already holds an agents/ directory" "$base_agent_dirs" 1
+
+mkdir -p "$FIXROOT/proj/portfolio/nested-plugin/agents"
+cat > "$FIXROOT/proj/portfolio/nested-plugin/agents/deep-helper.md" <<'AGENT'
+---
+name: deep-helper
+description: An agent two levels below the scan root.
+reviewed: 2026-01-01
+---
+# deep-helper
+Read the fleet inventory manifest, then walk the assembly line and record the
+torque reading for every station before proposing an adjustment.
+AGENT
+out=$(run)
+assert_eq "an agent BELOW the root's immediate children IS discovered" \
+    "$(count_key "$out" agents)" "$((base_agents + 1))"
+assert_eq "and its agents/ directory is counted at that depth too" \
+    "$(count_key "$out" agent_dirs)" "$((base_agent_dirs + 1))"
+# The two CONTROLs below assert against whatever discovery just reported, NOT
+# against `base_agents + 1`: coupling them to the depth fix would make them fail
+# as a knock-on whenever the depth assertion fails, and a control that cannot
+# pass while the thing beside it fails is not a control.
+deep_agents=$(count_key "$out" agents)
+deep_agent_dirs=$(count_key "$out" agent_dirs)
+
+# CONTROL, weighted equally with the assertion above: the `*-plugin/` PREFIX is
+# what the old comment's source-package argument actually bought, and dropping
+# the depth anchor must not drop that too. Both shapes below are the real ones
+# (`git-repo-agent/src/git_repo_agent/agents`, `vault-agent/src/vault_agent/agents`)
+# -- a directory NAMED `agents` inside a Python source package, at a depth the
+# old glob could never have reached either.
+mkdir -p "$FIXROOT/proj/portfolio/nested-plugin/src/nested_plugin/agents"
+cat > "$FIXROOT/proj/portfolio/nested-plugin/src/nested_plugin/agents/README.md" <<'PKGDOC'
+# agents
+A Python source package. Its `.md` is documentation, not an agent prompt.
+PKGDOC
+mkdir -p "$FIXROOT/proj/portfolio/some-repo-agent/src/some_repo_agent/agents"
+cat > "$FIXROOT/proj/portfolio/some-repo-agent/src/some_repo_agent/agents/README.md" <<'PKGDOC'
+# agents
+A second Python source package, in a repo whose own name ends in `-agent`.
+PKGDOC
+out=$(run)
+assert_eq "CONTROL: a source package named 'agents' is still NOT an agent dir" \
+    "$(count_key "$out" agents)" "$deep_agents"
+
+# CONTROL: `Path.match` is fnmatch-based, so `*` DOES match a leading dot and
+# `.claude-plugin` would otherwise qualify as a plugin.
+mkdir -p "$FIXROOT/proj/.claude-plugin/agents"
+cat > "$FIXROOT/proj/.claude-plugin/agents/marketplace-helper.md" <<'AGENT'
+---
+name: marketplace-helper
+description: Marketplace metadata, not a plugin agent.
+---
+# marketplace-helper
+Nothing here is an agent prompt.
+AGENT
+out=$(run)
+assert_eq "CONTROL: .claude-plugin/agents is not an agent directory" \
+    "$(count_key "$out" agents)" "$deep_agents"
+assert_eq "CONTROL: .claude-plugin/agents is not counted as an agents/ directory" \
+    "$(count_key "$out" agent_dirs)" "$deep_agent_dirs"
+
+# THE MISFIRE DISCRIMINATOR (#2219/#2290, and `scripts/check-agent-model.sh`
+# implements it for this exact shape). `AGENTS=0` alone cannot tell "this tree
+# has no agents" from "discovery misfired" -- which is precisely the state the
+# depth-anchored glob left `~/repos` in, silently, for the whole life of the
+# widening. The denominator is `*-plugin/agents` DIRECTORIES, not plugin
+# directories: most plugins define no agents (36 of 49 here), so the plugin-dir
+# form is a false positive on almost every tree. It fired on TEST 1's own
+# empty-corpus fixture, which is how that draft was caught. Three rungs below,
+# so a check that reports the misfire unconditionally or never passes exactly
+# one of them.
+MISFIRE="$FIXROOT/misfire"
+mkdir -p "$MISFIRE/foo-plugin/agents" "$MISFIRE/bar-plugin/agents" \
+         "$MISFIRE/foo-plugin/skills/thing"
+cat > "$MISFIRE/foo-plugin/skills/thing/SKILL.md" <<'SKILL'
+---
+name: thing
+description: Do the thing. Use when the thing needs doing.
+---
+# thing
+Do the thing against the fleet inventory manifest.
+SKILL
+printf 'placeholder\n' > "$MISFIRE/foo-plugin/agents/.gitkeep"
+mout=$(run_root "$MISFIRE")
+assert_eq "agents/ directories present and ZERO agent files raises the misfire" \
+    "$(count_kind "$mout" agent_discovery_misfire)" "1"
+assert_eq "the misfire is an error, not a warn" \
+    "$(finding_field "$mout" agent_discovery_misfire severity)" "error"
+assert_contains "it speaks the house vocabulary" \
+    "$(finding_field "$mout" agent_discovery_misfire summary)" \
+    "discovery misfire, not a clean tree"
+assert_eq "AGENT_DIRS names the denominator that makes it a misfire" \
+    "$(count_key "$mout" agent_dirs)" "2"
+assert_eq "FIXTURE: the misfire root really did report zero agents" \
+    "$(count_key "$mout" agents)" "0"
+HOME="$FIXROOT/empty-home" python3 "$ANALYZER" --root "$MISFIRE" --no-embed --fast --gate --format=status >/dev/null 2>&1
+assert_eq "--gate exits 2 on a discovery misfire" "$?" "2"
+
+# Rung 2: an agent file clears it. Without this, an unconditional misfire
+# finding passes every assertion above.
+cat > "$MISFIRE/foo-plugin/agents/real.md" <<'AGENT'
+---
+name: real
+description: A real agent in the misfire root.
+---
+# real
+Walk the assembly line and record every torque reading.
+AGENT
+mout=$(run_root "$MISFIRE")
+assert_eq "an agent file below an agents/ directory clears the misfire" \
+    "$(count_kind "$mout" agent_discovery_misfire)" "0"
+assert_eq "and the agent is counted" "$(count_key "$mout" agents)" "1"
+
+# Rung 3, the OTHER polarity, and the one the first draft got wrong: a plugin
+# that simply defines no agents is NOT a misfire. 36 of this repo's 49 plugin
+# directories are in exactly that state, so a check keyed on plugin directories
+# would fire on almost every tree and be trained away within a week.
+NOAGENTS="$FIXROOT/noagents"
+mkdir -p "$NOAGENTS/solo-plugin/skills/thing"
+cat > "$NOAGENTS/solo-plugin/skills/thing/SKILL.md" <<'SKILL'
+---
+name: thing
+description: Do the thing. Use when the thing needs doing.
+---
+# thing
+Do the thing against the fleet inventory manifest.
+SKILL
+nout=$(run_root "$NOAGENTS")
+assert_eq "a plugin with skills but no agents/ directory raises no misfire" \
+    "$(count_kind "$nout" agent_discovery_misfire)" "0"
+assert_eq "and reports the denominator as 0, emitted even at 0" \
+    "$(count_key "$nout" agent_dirs)" "0"
+assert_eq "FIXTURE: that root really was scanned (its skill was found)" \
+    "$(count_key "$nout" skills)" "1"
+
+out=$(run)
+assert_eq "the main fixture -- agents/ dirs AND agents -- raises no misfire" \
+    "$(count_kind "$out" agent_discovery_misfire)" "0"
+
+rm -rf "$FIXROOT/proj/portfolio" "$FIXROOT/proj/.claude-plugin" "$MISFIRE" "$NOAGENTS"
+
+echo "TEST 20: the generator-template predicate, as a both-polarity MATRIX"
+# The predicate was wrong in BOTH directions and the over-exclude half is the
+# worse one -- it silently drops LIVE configuration. Each case below is its own
+# root, so the verdict is exact per fixture rather than inferred from a delta,
+# and every row asserts BOTH the kept count and the excluded count so a
+# predicate that excluded everything and one that excluded nothing each fail
+# roughly half the matrix.
+#
+#   root                                     kept  excluded  which half
+#   packages/create-widget/template/            0       1     under-excluded
+#   scaff/{{cookiecutter.project_slug}}/        0       1     under-excluded
+#   webapp/app/templates/                       1       0     OVER-excluded
+#   my-copier-template/ (nested)                1       0     OVER-excluded
+#   my-copier-template/ (as --root)             1       2     OVER-excluded
+#   flat cargo-generate template                0       1     must STILL exclude
+#   ordinary nested dir                         1       0     must STILL keep
+MROOT="$FIXROOT/tmplmatrix"
+
+# 20a. UNDER-EXCLUDED: singular `template/` under an npm `create-*` package.
+# The old predicate matched only the PLURAL `templates`, so this unrendered
+# document entered the corpus. Also copier's `_subdirectory: template` shape.
+mkdir -p "$MROOT/a/packages/create-widget/template"
+cat > "$MROOT/a/packages/create-widget/template/CLAUDE.md" <<'CMD'
+# CLAUDE.md
+Payload `npm create widget` copies into a repo that does not exist yet.
+CMD
+o=$(run_root "$MROOT/a")
+assert_eq "a singular template/ under a create-* package is excluded" "$(count_key "$o" claude_mds)" "0"
+assert_eq "...and the exclusion is reported" "$(count_key "$o" claude_md_templates_excluded)" "1"
+
+# 20b. UNDER-EXCLUDED: an unrendered path component, corroborated by cruft.json
+# -- which was not in the manifest list at all, though cruft-managed cookiecutter
+# templates are the common case.
+mkdir -p "$MROOT/b/scaff/{{cookiecutter.project_slug}}"
+printf '{"template": "https://example.invalid/t.git"}\n' > "$MROOT/b/scaff/cruft.json"
+cat > "$MROOT/b/scaff/{{cookiecutter.project_slug}}/CLAUDE.md" <<'CMD'
+# CLAUDE.md
+An UNRENDERED document whose own directory is literally a placeholder.
+CMD
+o=$(run_root "$MROOT/b")
+assert_eq "an unrendered path component is excluded" "$(count_key "$o" claude_mds)" "0"
+assert_eq "...and the exclusion is reported" "$(count_key "$o" claude_md_templates_excluded)" "1"
+# ...and cruft.json alone, at an ancestor, is now a declaration in its own right.
+mkdir -p "$MROOT/b2/scaff/inner"
+printf '{"template": "https://example.invalid/t.git"}\n' > "$MROOT/b2/scaff/cruft.json"
+cat > "$MROOT/b2/scaff/inner/CLAUDE.md" <<'CMD'
+# CLAUDE.md
+Below a cruft-managed template root, with no unrendered component anywhere.
+CMD
+o=$(run_root "$MROOT/b2")
+assert_eq "cruft.json at an ancestor excludes on its own" "$(count_key "$o" claude_mds)" "0"
+# ...and the unrendered-component signal ALONE, with no manifest anywhere. The
+# two fixtures above are each corroborated by cruft.json, so the ancestor-manifest
+# signal excludes the document before the unrendered one is ever consulted --
+# deleting the unrendered signal outright left both suites green (mutation M4).
+# An assertion that names one signal while measuring another pins nothing.
+mkdir -p "$MROOT/b3/scaff/{{cookiecutter.project_slug}}"
+cat > "$MROOT/b3/scaff/{{cookiecutter.project_slug}}/CLAUDE.md" <<'CMD'
+# CLAUDE.md
+Unrendered directory name, and deliberately NO generator manifest anywhere.
+CMD
+o=$(run_root "$MROOT/b3")
+assert_eq "an unrendered component excludes with NO manifest anywhere" \
+    "$(count_key "$o" claude_mds)" "0"
+assert_eq "...and that exclusion is reported" \
+    "$(count_key "$o" claude_md_templates_excluded)" "1"
+# Guard integrity: the same tree with a rendered directory name must be KEPT,
+# or the two assertions above pass against a predicate that excludes everything.
+mkdir -p "$MROOT/b4/scaff/my-project"
+cat > "$MROOT/b4/scaff/my-project/CLAUDE.md" <<'CMD'
+# CLAUDE.md
+Same shape, rendered directory name, no manifest. Ordinary live configuration.
+CMD
+o=$(run_root "$MROOT/b4")
+assert_eq "CONTROL: the same tree with a rendered name is KEPT" \
+    "$(count_key "$o" claude_mds)" "1"
+
+# 20c. OVER-EXCLUDED: a Flask/Django Jinja directory. The bare component match
+# fired at ANY depth with no corroborating manifest, so every repo with an
+# `app/templates/` silently lost its CLAUDE.md.
+mkdir -p "$MROOT/c/webapp/app/templates"
+cat > "$MROOT/c/webapp/app/templates/CLAUDE.md" <<'CMD'
+# CLAUDE.md
+A Jinja template directory in a live web app. This file is live configuration.
+CMD
+o=$(run_root "$MROOT/c")
+assert_eq "a Jinja app/templates/ CLAUDE.md is KEPT" "$(count_key "$o" claude_mds)" "1"
+assert_eq "...and nothing is reported as excluded" "$(count_key "$o" claude_md_templates_excluded)" "0"
+
+# 20d. OVER-EXCLUDED: a template repo's OWN root document is live config for
+# whoever maintains the template. Asserted at BOTH scopes, because fixing it
+# only at `dirpath == root` would leave the verdict depending on where you
+# happened to point --root -- the same depth-anchoring disease as TEST 19.
+mkdir -p "$MROOT/d/my-copier-template"
+printf '_subdirectory: template\n' > "$MROOT/d/my-copier-template/copier.yml"
+cat > "$MROOT/d/my-copier-template/CLAUDE.md" <<'CMD'
+# CLAUDE.md
+The template repo's own root document -- how to MAINTAIN this template.
+CMD
+o=$(run_root "$MROOT/d")
+assert_eq "a NESTED template repo's own root CLAUDE.md is KEPT" "$(count_key "$o" claude_mds)" "1"
+assert_eq "...and nothing is reported as excluded" "$(count_key "$o" claude_md_templates_excluded)" "0"
+
+mkdir -p "$MROOT/d/my-copier-template/template" "$MROOT/d/my-copier-template/docs"
+cat > "$MROOT/d/my-copier-template/template/CLAUDE.md" <<'CMD'
+# CLAUDE.md
+Payload, below the manifest that declares this tree a template.
+CMD
+cat > "$MROOT/d/my-copier-template/docs/CLAUDE.md" <<'CMD'
+# CLAUDE.md
+Also below the declaring manifest.
+CMD
+o=$(run_root "$MROOT/d/my-copier-template")
+assert_eq "with --root ON the template repo, its own CLAUDE.md is still KEPT" \
+    "$(count_key "$o" claude_mds)" "1"
+# KNOWN RESIDUAL, pinned as a recorded decision rather than left to be
+# rediscovered: a manifest at the root still excludes everything BELOW it. That
+# is correct for a whole-repo template and conservative for a `_subdirectory`
+# one; only the root's own document -- the one that certainly still loads in
+# that session -- is protected.
+assert_eq "RESIDUAL: documents below a declaring root manifest are still excluded" \
+    "$(count_key "$o" claude_md_templates_excluded)" "2"
+
+# 20e. GUARD INTEGRITY: the real shape in this repo must STILL be excluded.
+# `foundryvtt-plugin/templates/foundryvtt-module/` carries cargo-generate.toml
+# BESIDE its CLAUDE.md -- a flat layout where the manifest's own directory is the
+# payload. Manifest-beside-the-document is corroboration, not a declaration, so
+# it is the `templates` component that tips it.
+mkdir -p "$MROOT/e/some-plugin/templates/some-module"
+printf '[template]\ncargo_generate_version = ">=0.23.0"\n' \
+    > "$MROOT/e/some-plugin/templates/some-module/cargo-generate.toml"
+cat > "$MROOT/e/some-plugin/templates/some-module/CLAUDE.md" <<'CMD'
+# CLAUDE.md
+A flat cargo-generate template: the manifest's own directory is the payload.
+CMD
+o=$(run_root "$MROOT/e")
+assert_eq "the flat cargo-generate shape is STILL excluded" "$(count_key "$o" claude_mds)" "0"
+assert_eq "...and the exclusion is reported" "$(count_key "$o" claude_md_templates_excluded)" "1"
+
+# ...while the SAME manifest-beside-the-document, without the conventional
+# component, is kept. This is the pair that proves corroboration is really
+# required rather than the manifest being sufficient on its own.
+mkdir -p "$MROOT/e2/some-plugin/scaffolds/some-module"
+printf '[template]\ncargo_generate_version = ">=0.23.0"\n' \
+    > "$MROOT/e2/some-plugin/scaffolds/some-module/cargo-generate.toml"
+cat > "$MROOT/e2/some-plugin/scaffolds/some-module/CLAUDE.md" <<'CMD'
+# CLAUDE.md
+A manifest beside a document, with no conventional component to corroborate it.
+CMD
+o=$(run_root "$MROOT/e2")
+assert_eq "a manifest BESIDE a document, uncorroborated, KEEPS it" "$(count_key "$o" claude_mds)" "1"
+
+# 20f. GUARD INTEGRITY, the plain case: an ordinary nested CLAUDE.md with no
+# template signal of any kind. Without this row, every "KEPT" assertion above
+# would also pass against a predicate that excluded nothing at all -- and
+# without 20a/20b/20e, every "excluded" assertion would pass against one that
+# excluded everything.
+mkdir -p "$MROOT/f/plain/nested"
+cat > "$MROOT/f/plain/nested/CLAUDE.md" <<'CMD'
+# CLAUDE.md
+An ordinary nested CLAUDE.md at a path with no template signal of any kind.
+CMD
+o=$(run_root "$MROOT/f")
+assert_eq "an ordinary nested CLAUDE.md is KEPT" "$(count_key "$o" claude_mds)" "1"
+assert_eq "...and nothing is reported as excluded" "$(count_key "$o" claude_md_templates_excluded)" "0"
+
+rm -rf "$MROOT"
+
+echo "TEST 21: duplicate severity is per kind, and the split is asserted both ways"
+# `warn` asserts drift. For a CLAUDE.md pair that is very often wrong: a
+# vendored clone and its upstream are byte-identical BY DESIGN, and the analyzer
+# cannot tell that from a divergence. Measured at ~/repos, the top pair is
+# exactly that (a vendored `external/facedancer` clone against the user's own
+# `mcu-tinkering-lab` package). Two `.claude/rules/` scopes, and two
+# `*-plugin/agents/*.md` in one marketplace, are both live and both loaded --
+# duplication there IS drift.
+mkdir -p "$FIXROOT/proj/repo-b/.claude/rules" "$FIXROOT/proj/nest-b" \
+         "$FIXROOT/proj/other-plugin/agents"
+cp "$FIXROOT/proj/repo-a/.claude/rules/alpha.md" "$FIXROOT/proj/repo-b/.claude/rules/beta.md"
+sed 's/proposing any adjustment/proposing a single adjustment/' \
+    "$FIXROOT/proj/some-plugin/agents/torque-auditor.md" \
+    > "$FIXROOT/proj/other-plugin/agents/torque-auditor-copy.md"
+sed 's/an empty report otherwise/an empty report in that case/' \
+    "$FIXROOT/proj/nest-a/CLAUDE.md" > "$FIXROOT/proj/nest-b/CLAUDE.md"
+out=$(run)
+# FIXTURE VALIDITY first: all three findings must actually exist, or every
+# severity assertion below reads "<none>" and the case asserts nothing.
+assert_eq "FIXTURE: a rule duplicate fired" "$(count_kind "$out" duplicate_rule_lexical)" "1"
+assert_eq "FIXTURE: an agent duplicate fired" "$(count_kind "$out" duplicate_agent_lexical)" "1"
+assert_eq "FIXTURE: a CLAUDE.md duplicate fired" "$(count_kind "$out" duplicate_claude_md_lexical)" "1"
+assert_eq "a duplicate RULE is a warn" \
+    "$(finding_field "$out" duplicate_rule_lexical severity)" "warn"
+assert_eq "a duplicate AGENT is a warn" \
+    "$(finding_field "$out" duplicate_agent_lexical severity)" "warn"
+assert_eq "a duplicate CLAUDE.md is INFO, not warn" \
+    "$(finding_field "$out" duplicate_claude_md_lexical severity)" "info"
+# The severity split moves the roll-up, so pin the arithmetic rather than the
+# label alone: an implementation that emitted the right string on a finding the
+# renderer still counted as a warning would pass the three rows above.
+assert_contains "the CLAUDE.md duplicate is counted as an info, not a warning" \
+    "$(run_status)" "FINDING_DUPLICATE_CLAUDE_MD_LEXICAL=1"
+rm "$FIXROOT/proj/repo-b/.claude/rules/beta.md" \
+   "$FIXROOT/proj/other-plugin/agents/torque-auditor-copy.md" \
+   "$FIXROOT/proj/nest-b/CLAUDE.md"
+
 echo
 echo "=== CONFIG DRIFT TESTS ==="
 echo "PASSED=$PASS"

--- a/health-plugin/scripts/tests/test-probe-lib.sh
+++ b/health-plugin/scripts/tests/test-probe-lib.sh
@@ -1234,18 +1234,26 @@ hook = open(sys.argv[2]).read()
 tree = ast.parse(src)
 
 # The two values `Finding(... f"semantic_overlap_{a['kind']}_{b['kind']}" ...)`
-# can interpolate, read off collect()'s own dict literals rather than assumed.
+# can interpolate, read off the analyzer's own SEMANTIC_KINDS assignment rather
+# than assumed. That tuple is what `main()` feeds `check_semantic_dupes`, so it
+# IS the interpolation domain -- and it is now the only honest source for it:
+# the corpus carries four kinds but only two reach the semantic pass, so the
+# former derivation (every `"kind": <const>` dict literal in the file) would
+# expand 4x4 and demand map rows for twelve kinds the analyzer cannot emit.
+# Since the shared `_doc()` constructor landed there are no such dict literals
+# left either, so that derivation would now yield the EMPTY set and expand to
+# nothing -- passing "no missing kinds" vacuously.
 item_kinds = set()
 for node in ast.walk(tree):
-    if isinstance(node, ast.Dict):
-        for k, v in zip(node.keys, node.values):
-            if (
-                isinstance(k, ast.Constant)
-                and k.value == "kind"
-                and isinstance(v, ast.Constant)
-                and isinstance(v.value, str)
-            ):
-                item_kinds.add(v.value)
+    if isinstance(node, ast.Assign) and any(
+        isinstance(t, ast.Name) and t.id == "SEMANTIC_KINDS" for t in node.targets
+    ):
+        if isinstance(node.value, (ast.Tuple, ast.List)):
+            item_kinds.update(
+                e.value
+                for e in node.value.elts
+                if isinstance(e, ast.Constant) and isinstance(e.value, str)
+            )
 
 kinds = set()
 for node in ast.walk(tree):
@@ -1292,10 +1300,10 @@ out=$(python3 "$FIXROOT/mapcover.py" "$ANALYZER" "$HOOK_SRC" 2>&1)
 # FIXTURE VALIDITY first: an AST walk that matched nothing satisfies "no missing
 # kinds" trivially, and a regex that matched no map keys satisfies "no unmapped
 # rows" the same way.
-assert_contains "the item kinds are derived, not assumed" "$out" "ITEM_KINDS rule,skill"
-assert_contains "FIXTURE: the derivation found every construction site" "$out" "DERIVED_N 13"
-assert_contains "FIXTURE: 12 of those kinds are reachable" "$out" "REACHABLE_N 12"
-assert_contains "FIXTURE: the map's keys were actually parsed out of the hook" "$out" "MAPPED_N 12"
+assert_contains "the semantic-pass kinds are derived from SEMANTIC_KINDS, not assumed" "$out" "ITEM_KINDS rule,skill"
+assert_contains "FIXTURE: the derivation found every construction site" "$out" "DERIVED_N 16"
+assert_contains "FIXTURE: 15 of those kinds are reachable" "$out" "REACHABLE_N 15"
+assert_contains "FIXTURE: the map's keys were actually parsed out of the hook" "$out" "MAPPED_N 15"
 assert_absent "every Finding( kind argument was parseable" "$out" "UNPARSEABLE_KIND_ARG"
 assert_contains "CONTROL: a fabricated kind is not reported as mapped" \
     "$out" "CONTROL_FABRICATED_MAPPED False"
@@ -1306,6 +1314,203 @@ assert_contains "the map carries no row for a kind the analyzer cannot emit" \
     "$out" "UNEMITTABLE_ROWS NONE"
 assert_contains "semantic_overlap_skill_rule stays unmapped (triu makes it unreachable)" \
     "$out" "UNREACHABLE_ABSENT True"
+
+echo "TEST N4: every remediation row names a skill that can SEE its finding's corpus"
+# The defect this pins: the two widened duplicate kinds were routed to
+# `/agent-patterns:meta-promote` by copying the `duplicate_rule_lexical` row.
+# meta-promote builds its inventory from `<scope>/.claude/{rules,skills,commands,
+# agents}/` and `<scope>/*/.claude/{...}/`. A repo-root CLAUDE.md is in NEITHER
+# layer, and a plugin agent at `*-plugin/agents/*.md` is not under
+# `.claude/agents/` either -- so both rows named a skill that structurally cannot
+# open the file the finding is about. The rule row IS correct, which is exactly
+# why copying it read as safe.
+#
+# SEMANTIC, not a spelling check: the map is parsed out of the SHIPPED hook, the
+# target is RESOLVED to a real SKILL.md on disk, and that skill's own inventory
+# text is what is asserted on. A grep for the string "meta-context-diet" would
+# pass against a row naming a skill that does not exist.
+MARKETPLACE_ROOT="$(cd "${SCRIPTS_DIR}/../.." && pwd)"
+cat > "$FIXROOT/routing.py" <<'ROUTING'
+import re
+import sys
+from pathlib import Path
+
+hook, marketplace = sys.argv[1], Path(sys.argv[2])
+m = re.search(r"def fix:\s*\{(.*?)\}\[\.kind\]", Path(hook).read_text(), re.S)
+rows = dict(re.findall(r'"([a-z0-9_]+)"\s*:\s*"([^"]+)"', m.group(1))) if m else {}
+
+# Inventory probes, spelled once. Each is a literal a skill's own Context block
+# or discovery step uses to NAME the corpus it opens -- not a description.
+AGENT_GLOBS = ("agents/*", "agents-plugin/agents", "-plugin/agents", "*/agents/")
+DOT_CLAUDE_INVENTORY = ".claude/{rules,skills,commands,agents}/"
+
+
+def sees_claude_md(body):
+    return "CLAUDE.md" in body
+
+
+def sees_plugin_agents(body):
+    return any(g in body for g in AGENT_GLOBS)
+
+
+def resolve(cmd):
+    """`/ns:name` -> the SKILL.md that serves it, or None.
+
+    The house spelling drops the plugin's leading segment (`health-check` is
+    `/health:check`), so both the bare name and the `ns-name` join are tried.
+    """
+    ns, _, name = cmd.lstrip("/").partition(":")
+    for candidate in (name, ns + "-" + name):
+        for skill in marketplace.glob("*-plugin/skills/" + candidate + "/SKILL.md"):
+            return skill
+    return None
+
+
+for kind in sorted(rows):
+    cmd = rows[kind]
+    skill = resolve(cmd)
+    state = "RESOLVED" if skill else "UNRESOLVED"
+    print("ROW %s %s %s" % (kind, cmd, state))
+    if skill is None:
+        continue
+    body = skill.read_text()
+    print("SEES_CLAUDE_MD %s %s" % (kind, sees_claude_md(body)))
+    print("SEES_PLUGIN_AGENTS %s %s" % (kind, sees_plugin_agents(body)))
+
+# FIXTURE VALIDITY for the claim that meta-promote was the WRONG target: read
+# its own inventory and show it names neither widened corpus.
+mp = resolve("/agent-patterns:meta-promote")
+mp_body = mp.read_text() if mp else ""
+print("META_PROMOTE_RESOLVED %s" % bool(mp))
+print("META_PROMOTE_SEES_PLUGIN_AGENTS %s" % sees_plugin_agents(mp_body))
+print("META_PROMOTE_INVENTORY_IS_DOT_CLAUDE %s" % (DOT_CLAUDE_INVENTORY in mp_body))
+ROUTING
+rout=$(python3 "$FIXROOT/routing.py" "$HOOK_SRC" "$MARKETPLACE_ROOT" 2>&1)
+
+# FIXTURE VALIDITY first: an unresolvable target makes every "SEES_" line absent,
+# which would satisfy an assert_absent trivially.
+assert_contains "the agent-duplicate row resolves to a real skill" \
+    "$rout" "ROW duplicate_agent_lexical /agents:analyze RESOLVED"
+assert_contains "the CLAUDE.md-duplicate row resolves to a real skill" \
+    "$rout" "ROW duplicate_claude_md_lexical /agent-patterns:meta-context-diet RESOLVED"
+# The claim: each target's own inventory names the corpus its finding is about.
+assert_contains "the CLAUDE.md-duplicate target inventories CLAUDE.md files" \
+    "$rout" "SEES_CLAUDE_MD duplicate_claude_md_lexical True"
+assert_contains "the agent-duplicate target inventories agent files" \
+    "$rout" "SEES_PLUGIN_AGENTS duplicate_agent_lexical True"
+# CONTROL, and the reason the original routing looked safe: the rule row is
+# still meta-promote, and meta-promote is still the right answer for it. Without
+# this, a map that routed everything to /health:check would pass the two rows
+# above by never naming meta-promote at all.
+assert_contains "CONTROL: the RULE duplicate still routes to meta-promote" \
+    "$rout" "ROW duplicate_rule_lexical /agent-patterns:meta-promote RESOLVED"
+# FIXTURE VALIDITY for the defect itself: meta-promote's inventory really is
+# `.claude/`-scoped and names neither widened corpus.
+assert_contains "FIXTURE: meta-promote resolves" "$rout" "META_PROMOTE_RESOLVED True"
+assert_contains "FIXTURE: meta-promote's inventory is the .claude/ tree" \
+    "$rout" "META_PROMOTE_INVENTORY_IS_DOT_CLAUDE True"
+assert_contains "FIXTURE: meta-promote never inventories plugin agents" \
+    "$rout" "META_PROMOTE_SEES_PLUGIN_AGENTS False"
+# Every row must at least resolve -- a remediation naming a skill that does not
+# exist is a dead pointer whichever corpus it could see.
+assert_absent "no remediation row names a skill that does not exist" "$rout" "UNRESOLVED"
+
+echo "TEST N5: the SessionStart nudge, through the hook's OWN jq pipeline"
+# `duplicate_claude_md_lexical` sorts alphabetically first among the warns, so at
+# both portfolio roots the widening put it in slot 1 and the displacing finding
+# was a byte-identical CLAUDE.md between a VENDORED clone and its source --
+# expected duplication, not drift. Demoting it to `info` is the fix for the
+# HEADLINE. It is NOT a fix for the displacement, and this case pins both halves
+# so the distinction stays a recorded decision rather than a hope.
+#
+# The pipeline is EXTRACTED from the shipped hook, never retyped: a retyped copy
+# is not the code under test (never-fabricate-test-identifiers.md).
+python3 - "$HOOK_SRC" > "$FIXROOT/forward.jq" <<'EXTRACT'
+import re
+import sys
+
+src = open(sys.argv[1]).read()
+m = re.search(r"(def rank:.*?\| \[\.severity, \.kind, \.summary, \.fix\] \| @tsv)", src, re.S)
+if not m:
+    sys.exit("could not extract the forwarding pipeline from the hook")
+print(m.group(1))
+EXTRACT
+if [ ! -s "$FIXROOT/forward.jq" ]; then
+    bad "FIXTURE: the forwarding pipeline was extracted from the hook" "non-empty jq" "empty"
+elif ! command -v jq >/dev/null 2>&1; then
+    ok "SKIP: jq not available for the forwarding-pipeline case"
+else
+    ok "FIXTURE: the forwarding pipeline was extracted from the hook"
+    # Reproduces the ~/repos kind histogram measured 2026-08-29 with --fast
+    # --no-embed: 7 duplicate_claude_md_lexical, 14 duplicate_rule_lexical,
+    # 71 review_staleness, 19 rule_covered_by_skill, 1 frontmatter_coverage.
+    # Severities are read from the ANALYZER rather than typed here, so a future
+    # severity change moves this fixture with it.
+    python3 - "$ANALYZER" > "$FIXROOT/histogram.json" <<'HIST'
+import importlib.util
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(sys.argv[1])))
+spec = importlib.util.spec_from_file_location("config_drift", sys.argv[1])
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+# The two duplicate kinds' severities come from the shipped constructor.
+dup = {
+    k: mod._lexical_finding(k, "s", 0.9, ["/a", "/b"])["severity"]
+    for k in ("rule", "agent", "claude_md")
+}
+counts = {
+    ("duplicate_claude_md_lexical", dup["claude_md"]): 7,
+    ("duplicate_rule_lexical", dup["rule"]): 14,
+    ("review_staleness", "warn"): 71,
+    ("rule_covered_by_skill", "info"): 19,
+    ("frontmatter_coverage", "info"): 1,
+}
+findings = [
+    {"severity": sev, "kind": kind, "summary": f"{kind} #{i}"}
+    for (kind, sev), n in counts.items()
+    for i in range(n)
+]
+json.dump({"findings": findings, "counts": {}}, sys.stdout)
+HIST
+    fwd=$(jq -r -f "$FIXROOT/forward.jq" < "$FIXROOT/histogram.json" 2>&1)
+    slot1=$(printf '%s\n' "$fwd" | sed -n '1p' | cut -f2)
+    forwarded=$(printf '%s\n' "$fwd" | cut -f2 | sort | tr '\n' ',')
+
+    assert_eq "FIXTURE: the cap forwards exactly 4 rows" \
+        "$(printf '%s\n' "$fwd" | grep -c .)" "4"
+    # The half the demotion DOES buy: slot 1 is real drift, not a vendored-clone
+    # artifact. Pre-demotion this was duplicate_claude_md_lexical at both roots.
+    assert_eq "slot 1 is the RULE duplicate, not the CLAUDE.md duplicate" \
+        "$slot1" "duplicate_rule_lexical"
+    assert_contains "the CLAUDE.md duplicate is still forwarded, below the warns" \
+        "$forwarded" "duplicate_claude_md_lexical"
+    # The half it does NOT buy, pinned so nobody claims otherwise: with five
+    # kinds and a cap of four, one is dropped whatever the severities are, and
+    # within `info` frontmatter_coverage beats rule_covered_by_skill on the
+    # alphabetical tiebreak either way. The cap and the sort are shared across
+    # every plugin and are not this probe's to change.
+    assert_absent "RECORDED: rule_covered_by_skill is still displaced by the cap" \
+        "$forwarded" "rule_covered_by_skill"
+    # Guard integrity: the two rows above are about ORDER, so a pipeline that
+    # forwarded nothing, or forwarded them in a fixed order regardless of
+    # severity, must fail something. Re-run with the CLAUDE.md duplicate forced
+    # back to `warn` and require slot 1 to move -- that is the pre-fix behaviour,
+    # reproduced rather than asserted.
+    warn_slot1=$(python3 -c '
+import json, sys
+d = json.load(open(sys.argv[1]))
+for f in d["findings"]:
+    if f["kind"] == "duplicate_claude_md_lexical":
+        f["severity"] = "warn"
+json.dump(d, sys.stdout)
+' "$FIXROOT/histogram.json" | jq -r -f "$FIXROOT/forward.jq" | sed -n '1p' | cut -f2)
+    assert_eq "CONTROL: at warn severity it takes slot 1 again (the pre-fix state)" \
+        "$warn_slot1" "duplicate_claude_md_lexical"
+fi
 
 echo
 echo "=== PROBE LIB TESTS ==="


### PR DESCRIPTION
Refs #2528 (the widening half; the promotion verdict and per-kind semantic
calibration are #2528b). Closes #2530.

Adds `agent` and `claude_md` to a corpus that has only ever held rules and
skills. **Commands are deliberately absent** — verified zero `.md` under any
`commands/` directory; the migration is complete and archived, so the kind
would have been a check reporting `STATUS=OK` over an empty corpus.

## Acceptance is numeric

"No new findings" is vacuous. At the claude-plugins root:

```
              BEFORE                    AFTER
RULES=98                        RULES=98
SKILLS=422                      SKILLS=422
                                AGENTS=21                      ← new
                                AGENT_DIRS=8                   ← new
                                CLAUDE_MDS=3                   ← new
                                CLAUDE_MD_TEMPLATES_EXCLUDED=1 ← new
ALWAYS_LOADED_RULES=51          ALWAYS_LOADED_RULES=51
                                ALWAYS_LOADED_CLAUDE_MD=1      ← new
ALWAYS_LOADED_TOKENS=39235      ALWAYS_LOADED_TOKENS=42858     ← +3623
                                LEXICAL_PAIRS=4966             ← new
FINDING_REVIEW_STALENESS=67     FINDING_REVIEW_STALENESS=67
FINDING_RULE_COVERED_BY_SKILL=5 FINDING_RULE_COVERED_BY_SKILL=5
FINDING_FRONTMATTER_COVERAGE=1  FINDING_FRONTMATTER_COVERAGE=1
ERRORS=0 WARNINGS=67            ERRORS=0 WARNINGS=67
STATUS=WARN ISSUE_COUNT=73      STATUS=WARN ISSUE_COUNT=73
```

The one pre-existing counter that moves is the deliberate change: the root
`CLAUDE.md` is genuinely injected every turn and was omitted from the budget, so
the old figure **understated the standing cost by 9.2%**. The delta is exactly
`14494 // 4`, and `ALWAYS_LOADED_CLAUDE_MD=1` makes the split visible.

## The defect that mattered most

The first implementation discovered agents with
`root.glob("*-plugin/agents/*.md")` — anchored at depth 2, while every other
kind comes from the recursive walk:

| `--root` | RULES | SKILLS | AGENTS | actually present |
|---|---|---|---|---|
| `claude-plugins` | 98 | 422 | 21 | 21 |
| `~/repos/laurigates` | 247 | 561 | **0** | 21 |
| `~/repos` | 367 | 591 | **0** | 21 |

The SessionStart probe runs `--root "${DRIFT_CWD:-.}"` — the session cwd — and
`~/repos` is a documented working root. **The entire widening was inert exactly
where the probe runs**, reporting a bare `AGENTS=0` indistinguishable from "this
tree has no agents". Every acceptance number was measured at the one root where
the bug is invisible.

Fixed by discovering through the pruned walk with a `*-plugin/agents`
predicate — the prefix is what excluded the two Python source packages named
`agents`; the depth was never doing that work. Now **21 at all three roots**,
with the file list byte-identical to `find`.

The predicate also excludes `.claude-plugin` explicitly: `Path.match` is
fnmatch-based, so `*` matches a leading dot and the old glob was ingesting
`.claude-plugin/agents/*.md`.

`agent_discovery_misfire` is the discriminator the repo standardises on
(#2219/#2290). Its denominator is agent **directories**, not plugin directories
— the first draft used plugin dirs and the suite caught it, since 36 of 49
plugins define no agents and it would have raised a permanent error on nearly
every tree. Control: run against all **78 real repos** under `~/repos` → zero
misfires.

## The template predicate was wrong in both directions

| fixture | expected | before | after |
|---|---|---|---|
| `packages/create-widget/template/` | exclude | kept ✗ | ✓ |
| `scaff/{{cookiecutter.project_slug}}/` + `cruft.json` | exclude | kept ✗ | ✓ |
| `webapp/app/templates/` | **keep** | excluded ✗ | ✓ |
| `my-copier-template/` own root | **keep** | excluded ✗ | ✓ |
| `my-copier-template/template/` | exclude | ✓ | ✓ |
| foundryvtt scaffold | exclude | ✓ | ✓ |

The over-broad half is the worse one — it **silently drops live configuration**
from any repo with a Flask/Django `app/templates/`, and from a template repo's
own root. Redesigned as a declare/suggest split: an unrendered path *component*
or a manifest at a **strict ancestor** is sufficient; a `template`/`templates`
component or a manifest beside the document only corroborates.

**The counters could not have caught this.** Before and after report identical
`CLAUDE_MDS` and `CLAUDE_MD_TEMPLATES_EXCLUDED` over the fixture tree while
ingesting *opposite* documents.

`templates` is never added to `SKIP_PARTS` — that drops
`obsidian-plugin/skills/templates/SKILL.md`, a real skill, and breaks
`check_stub_integrity` for anything delegating to it. A test asserts that skill
is still discovered so the approach cannot return.

## Guards that prevent silently disabling an existing check

`check_rule_covered_by_skill` skips both new kinds: its control gate counts
`stub` rules, so kinds that have none dilute `control_total` toward the 0.7
threshold and trip `coverage_metric_broken` — which suppresses **all** coverage
findings. Verified by mutation: it does trip, at 1/3.

`check_frontmatter` skips them too (agents: 21/21 already carry `reviewed:`, so
the finding can never fire; CLAUDE.md: 2 of 3 lack frontmatter by convention).

## Severity, and a premise that turned out false

`duplicate_claude_md_lexical` is `info`; `duplicate_agent_lexical` stays `warn`.
A duplicate CLAUDE.md is often *correct* duplication (a vendored clone and its
upstream) and the analyzer cannot tell that from divergence; two agents in one
marketplace are both live.

This does **not** restore `rule_covered_by_skill` to the SessionStart nudge,
which was the hope — with five kinds and a cap of four, one is dropped whatever
the severities are. What it buys is slot 1, so the nudge leads with a rule
duplicate rather than a vendored clone. Both halves are pinned.

## Remediation routes to skills that can see the corpus

`meta-promote` inventories `<scope>/.claude/{rules,skills,commands,agents}/` —
which contains neither a repo-root CLAUDE.md nor `*-plugin/agents/*.md`. Copying
the `duplicate_rule_lexical` row would have sent the reader to a skill
structurally blind to the finding. Each target verified by reading its inventory
logic, not its description.

## The acceptance claim is scoped to the cheap tier

The live gitdates cache holds **0 agent and 0 CLAUDE.md keys**, so `--fast`
skips every new-kind document. Non-fast with a scratch cache gains exactly one
finding: `review_staleness` on `claude-plugins/CLAUDE.md`, **125 days** past its
declared `reviewed: 2026-04-21`. Genuine, not suppressed. The same run warmed 21
agent keys, so all 21 agents were evaluated and are inside `STALE_DAYS`.

## Evidence

| Check | Result |
|---|---|
| `test-config-drift.sh` | 157/0 (+27) |
| `test-probe-lib.sh` | 206/0 (+15) |
| Discovery, 3 roots | AGENTS 21/21/21, byte-identical to `find` |
| Misfire control | 0 across 78 real repos |
| Template matrix | 6/6 (was 2/6) |
| Mutation | 9 mutants, all killed |
| Partition cost | +6.6ms partitioned vs +62.3ms pooled |
| ruff / format / shellcheck / sandbox-guards | clean |

One mutant survived the first pass and is worth recording: the
unrendered-component signal could be **deleted outright** with both suites
green, because its fixture was corroborated by a manifest at an ancestor — the
assertion named for one signal was measuring another. Now pinned by a
manifest-free fixture with a rendered-name control.

Also closes #2530: the probe claimed 0.05s over a corpus this root does not
have. Re-measured at 0.33s over 98 rules + 422 skills + 21 agents + 3 CLAUDE.md.
The no-debounce conclusion and its reasoning are kept verbatim.
