### PR TITLE
feat(health-plugin): add the cross-scope promotion_candidate verdict

### DIFF
--- a/health-plugin/README.md
+++ b/health-plugin/README.md
@@ -93,6 +93,7 @@ one document shape, and each check names the kinds it applies to explicitly:
 | `agent_discovery_misfire` | ERROR | agent | `*-plugin/agents` directories present but zero agent files — discovery is broken, not the tree clean |
 | `semantic_overlap_*` | WARN | rule, skill | Differently-worded rules or skills covering one topic |
 | `rule_covered_by_skill` | INFO | rule | A resident rule whose content a skill already carries |
+| `promotion_candidate` | INFO | rule, claude_md | The same guidance at two scopes with no declared parent — a candidate for `/agent-patterns:meta-promote`. **Semantic tier only** |
 | `always_loaded_budget` | WARN | rule, claude_md | The every-turn surface creeping past its ceiling |
 | `review_staleness` | WARN | all four | An artifact changed after its declared `reviewed:` date |
 | `frontmatter_coverage` | INFO | rule | Rules with no `reviewed:` date, so staleness cannot be tracked |
@@ -102,6 +103,24 @@ is very often duplication that is *correct* — a vendored clone and its upstrea
 or one package copied into two places — and the analyzer cannot tell that from a
 divergence. Two `.claude/rules/` scopes, and two `*-plugin/agents/*.md` in one
 marketplace, are both live and both loaded, so duplication there really is drift.
+
+**`promotion_candidate` and the threshold that cannot do the job alone.**
+`T_PROMOTE = 0.88` sits below `T_SEMANTIC = 0.91` because at 0.91 this root
+yields zero findings — shipping at the drift threshold would ship the verdict
+inert. But the score is not what makes it precise: the declared hierarchy
+(`offload-to-deterministic-substrate` at two scopes, 0.8994) outscores the
+genuine candidate (`auto-mode` ← `claude-code-auto-mode`, 0.8990) by 0.0004. No
+cut separates them; `structural_pair` does. Two further constraints carry more
+weight than the number — an **ancestor** test, because `scope_rank` is depth and
+would otherwise pair unrelated repos (69 → 22 pairs at `~/repos`), and a
+**500-char floor**, because near-empty redirect stubs score 0.88–0.98 against
+each other (22 → 12).
+
+Known limitation: a hierarchy declared in a **third** document is invisible —
+`structural_pair` reads only the two documents in the pair. The six
+`ForumViriumHelsinki/.github` pairs are exactly this shape, declared in that
+workspace's own `CLAUDE.md`. Closing it needs a third-document signal with its
+own calibration. Run the expensive tier with `just config-drift-semantic`.
 
 Agents are discovered through the same **recursive pruned walk** as every other
 kind (`*-plugin/agents`), not a depth-anchored glob: the SessionStart probe scans

--- a/health-plugin/hooks/config-drift-probe.sh
+++ b/health-plugin/hooks/config-drift-probe.sh
@@ -214,6 +214,15 @@ fi
 #   reach every CLAUDE.md at a portfolio root, so deep pairs rely on the paths in
 #   the finding.
 #
+# `promotion_candidate` -> `/agent-patterns:meta-promote`, checked against that
+# skill's inventory rather than its title. meta-promote's Target/Sources table
+# is `<scope>/.claude/{rules,skills,commands,agents}/` and `<scope>/*/.claude/{...}/`
+# -- which is exactly the two scoped kinds this finding can name, since
+# PROMOTION_KINDS excludes the plugin-namespaced ones. The CLAUDE.md caveat that
+# re-routed `duplicate_claude_md_lexical` away from this skill applies to the
+# claude_md half here too, and the finding's own `paths` (child first) do that
+# locating. Promoting a rule up a scope ladder IS this skill's stated operation.
+#
 # `agent_discovery_misfire` routes to `/health:check` with the rest of the
 # "the probe itself is broken" family (`coverage_metric_broken`,
 # `corpus_unreadable`): its fix site is this analyzer, not the corpus.
@@ -241,6 +250,7 @@ done < <(printf '%s' "$OUT" | jq -r '
      "semantic_overlap_rule_rule":   "/agent-patterns:meta-promote",
      "semantic_overlap_rule_skill":  "/health:skill-audit",
      "semantic_overlap_skill_skill": "/health:skill-audit",
+     "promotion_candidate":          "/agent-patterns:meta-promote",
      "rule_covered_by_skill":        "/agent-patterns:meta-context-diet",
      "always_loaded_budget":         "/agent-patterns:meta-context-diet",
      "review_staleness":             "/health:skill-audit",

--- a/health-plugin/scripts/config-drift.py
+++ b/health-plugin/scripts/config-drift.py
@@ -84,6 +84,16 @@ SEMANTIC_KINDS = ("rule", "skill")
 # `check_lexical_dupes` for why the comparison is partitioned rather than pooled.
 LEXICAL_KINDS = ("rule", "agent", "claude_md")
 
+# The kinds the PROMOTION pass compares. Exactly the SCOPED kinds: a rule and a
+# CLAUDE.md both live at a point in a directory ladder, so "the same thing is
+# said at two levels, keep the higher one" names a real operation on them.
+# Skills and agents are namespaced by their plugin and carry `SCOPE_PLUGIN`,
+# whose `scope_rank` is None -- there is no parent scope to promote into, so
+# they are excluded by the sentinel rather than by this tuple alone (the pass
+# re-checks the rank, because a kind list is a policy and a None rank is a
+# fact).
+PROMOTION_KINDS = ("rule", "claude_md")
+
 # A file whose presence DECLARES that the tree it heads is a generator template
 # rather than live configuration. See `_is_generator_template`.
 #
@@ -127,6 +137,50 @@ CREATE_PKG = re.compile(r"^create-.")
 # distribution was 0.94:2 0.92:9 0.90:32 0.88:70 0.86:88, i.e. the actionable
 # signal sits above ~0.91 and the tail below it is unusable.
 T_SEMANTIC = 0.91  # cosine over title+head
+
+# PROMOTION threshold. Measured 2026-08-29 with `--calibrate`, not guessed.
+#
+# Two corpora, both including `~/.claude/rules` (HOME_RULES is unconditional).
+# Calibrated at `~/repos` (505 promotable docs / 141 scopes / 76,120 cross-scope
+# pairs); SHIPS to run at `claude-plugins` (101 docs / 4 scopes / 2,642 pairs),
+# where the whole above-band set is n=1. Cumulative counts, cross-scope only:
+#
+#   claude-plugins  RAW    0.94:0  0.92:0  0.90:0  0.88:2   0.86:3
+#   claude-plugins  NOVEL  0.94:0  0.92:0  0.90:0  0.88:1   0.86:2
+#   repos           RAW    0.94:27 0.92:39 0.90:61 0.88:101 0.86:170
+#   repos           NOVEL  0.94:6  0.92:7  0.90:7  0.88:19  0.86:28
+#
+# 0.88 sits inside the separating interval (0.8721, 0.8990] measured at the ship
+# root, with a 0.027 margin to the nearest adjudicated non-candidate. The band
+# is BELOW T_SEMANTIC for a measured reason rather than a severity argument: at
+# 0.91 -- and still at 0.90 -- `claude-plugins` yields ZERO promotion findings,
+# so shipping this at T_SEMANTIC ships it inert at the only root it runs at. The
+# one genuine candidate there (`user-global::claude-code-auto-mode` <-
+# `portfolio::auto-mode`, 0.8990, different names, no cross-reference in either
+# direction) is the highest promotion signal in that corpus. Going lower is
+# worse, not merely noisier: 0.87 admits `agent-and-tool-selection` <-
+# `workflow-model-effort`, adjudicated as two different documents sharing a
+# topic, and 0.86 adds nothing at either root.
+#
+# THE THRESHOLD IS NOT CARRYING THE PRECISION -- the discriminators are, and
+# the measurement says so twice. The nearest pair to the genuine candidate is
+# `offload-to-deterministic-substrate` against itself one scope up at 0.8994,
+# i.e. 0.0004 ABOVE it: no threshold can separate those two, and only
+# `structural_pair` does. Rank-strict admits 69 pairs at `~/repos`/0.88, of
+# which 47 are unrelated cross-repo siblings; the ancestor constraint cuts that
+# to 22 and removes zero adjudicated candidates, and MIN_PROMOTABLE_CHARS cuts
+# 22 -> 12 by dropping near-empty `@AGENTS.md` redirect stubs in a vendored
+# clone. See `check_promotion_candidates` for both.
+T_PROMOTE = 0.88  # cosine over title+head, cross-scope, promotable kinds only
+
+# A document too short to have a topic. Cosine between two near-empty documents
+# is meaningless and runs HIGH: 10 of the 22 ancestor-constrained survivors at
+# `~/repos`/0.88 were 11-128 byte `@AGENTS.md` redirect stubs in a vendored
+# upstream clone, scoring 0.879-0.975 against each other. The floor costs
+# nothing measurable -- the smallest genuine candidate is 662 chars, and only 5
+# of 101 docs at `claude-plugins` (27 of 505 at `~/repos`) fall below it.
+MIN_PROMOTABLE_CHARS = 500
+
 T_LEXICAL = 0.45  # 3-gram Jaccard over full body
 T_COVERAGE = 0.55  # rule topic already covered by a skill
 BUDGET_TOKENS = 55_000  # always-loaded ceiling before it is a finding
@@ -1112,7 +1166,226 @@ def check_rule_covered_by_skill(rules, skills, waivers) -> list[Finding]:
     return sorted(out, key=lambda x: (not x.get("always_loaded"), -x.get("score", 0)))
 
 
-def check_semantic_dupes(items, waivers, cache_path: Path) -> list[Finding]:
+def structural_pair(a: dict, b: dict) -> bool:
+    """Relationships that are correct by design, not drift.
+
+    Two shapes dominate the high-cosine band and neither is a defect:
+    a pointer stub scores ~0.92 against the very skill it delegates to, and
+    deliberately cross-referenced sibling rules ("Sibling: pr-merge-hazards.md")
+    score ~0.93. Flagging either trains the reader to ignore the report.
+
+    Hoisted to module scope from inside `check_semantic_dupes` so
+    `check_promotion_candidates` can CALL it. It answers ONE question -- "is
+    this similarity by design?" -- pairwise and statelessly, and it is the ONLY
+    suppressor on both axes. A promotion-specific prose discriminator was built
+    on top of it and then removed: measured over both corpora it changed no
+    emitted finding at either root, and its scope-level binders over-suppressed
+    (see `check_promotion_candidates` for the measurement and the residual gap).
+    Anything added here widens BOTH axes at once, so a widening motivated by one
+    has to be calibrated against the other.
+
+    Known mechanical limits on the promotion axis, measured and stated rather
+    than assumed away:
+
+    * It reads only the two documents in the pair, so a hierarchy declared in a
+      THIRD file is invisible to it. At `~/repos` that is the entire six-pair
+      `ForumViriumHelsinki` family, whose "generated from the `.github` repo
+      source" declaration lives in the workspace CLAUDE.md rather than in
+      either copy.
+    * For a `claude_md`, `Path(y["path"]).name` is always the literal
+      `"CLAUDE.md"` -- a string that appears in nearly every document ABOUT
+      Claude configuration. 14 of 27 ancestor cross-scope pairs >=0.86
+      involving a claude_md at `~/repos` are suppressed by that literal alone.
+      The `` `{name}` `` arm cannot compensate, because a claude_md's `name` is
+      a relative path (`laurigates/comfyui-nodes/comfyui-touch-shim`) and never
+      the basename a rule would backtick. The arm is simultaneously over-broad
+      and inert on that kind.
+
+    Left as-is deliberately: narrowing it here changes what the SEMANTIC pass
+    suppresses, which is a separate calibration with its own corpus.
+    """
+    for x, y in ((a, b), (b, a)):
+        if x.get("stub") and y["kind"] == "skill" and y["name"] in x["body"][:700]:
+            return True
+        if Path(y["path"]).name in x["body"] or f"`{y['name']}`" in x["body"][:1500]:
+            return True
+    return False
+
+
+def check_promotion_candidates(items, sim, waivers) -> tuple[list[Finding], int, int]:
+    """Same thing said at two scope levels — a candidate for promotion upward.
+
+    Returns `(findings, pairs_considered, hierarchies_declared)`.
+
+    A candidate is a pair (child, parent) where ALL of these hold:
+
+      1. both kinds are in `PROMOTION_KINDS`
+      2. `scope_rank(child) > scope_rank(parent)` STRICTLY
+      3. neither carries `SCOPE_PLUGIN` (i.e. neither rank is None)
+      4. the parent's scope is an ANCESTOR of the child's
+      5. both documents are at least `MIN_PROMOTABLE_CHARS` long
+      6. `sim(child, parent) >= T_PROMOTE`
+      7. NOT `structural_pair(child, parent)`
+      8. NOT waived
+
+    SAME-NAME PAIRS ARE DELIBERATELY NOT SKIPPED, and this is the one place
+    where this check and `check_semantic_dupes` must differ. That function skips
+    `a["name"] == b["name"]` because for the DRIFT question a same-name pair is
+    already owned by the cheap tier. For the PROMOTION question the same-name
+    pair is the CANONICAL SHAPE — one rule copied down the ladder is exactly
+    what "promote this" means. Do not "fix" this by copying the drift skip over:
+    measured, keeping same-name pairs adds 41 findings at `~/repos`/0.88 and
+    exactly ONE at `claude-plugins`, and that one is
+    `offload-to-deterministic-substrate`, which `structural_pair` already
+    removes. The cost is bounded; the shape it buys is the whole point.
+
+    STRICT rank, condition 2: a tie is SKIPPED rather than reported. Two rules
+    at the same depth have no parent between them, so "promote to the parent"
+    names no operation and the finding's recommendation would be undefined. The
+    pair is still counted in `pairs_considered` — a skip that also vanishes from
+    the denominator is indistinguishable from a check that never opened it.
+
+    The tie skip is NOT redundant with condition 4, and a test that pins it has
+    to be built so that it isn't. For two scopes at equal depth under a project
+    root, `_ancestor_scope` is already false, so removing the tie skip changes
+    nothing there — a mutation dropping `if ra == rb: continue` survives such a
+    case. It only bites when the parent side is `user-global` or `portfolio`,
+    which `_ancestor_scope` accepts unconditionally: two `user-global` rules
+    both rank 0, and without the tie skip one is reported as promotable into its
+    own scope. That is the shape `test-config-drift.sh` case 22h pins.
+
+    Condition 4 exists because `scope_rank` IS DEPTH, NOT ANCESTRY. Any deeper
+    scope outranks any shallower one, including an unrelated repo's. Measured at
+    `~/repos`/0.88: rank-strict alone yields 69 pairs, 47 of them cross-repo
+    siblings (`FVH/podio-mcp::document-management` "promoted into"
+    `laurigates/comfyui-nodes/...::document-management` at 0.96 — two unrelated
+    trees, no ladder between them). The constraint cuts 69 -> 22 and removes
+    zero adjudicated candidates. `user-global` and `portfolio` are ancestors of
+    everything by construction; every other scope must be a path prefix.
+
+    Condition 5 is the degenerate-document floor — see MIN_PROMOTABLE_CHARS.
+
+    SEVERITY IS `info`, on three grounds and not one. It is a SUGGESTION to a
+    human, never a defect — the corpus is working as intended either way.
+    `--gate` returns 2 only on `error`, so a style suggestion cannot fail CI.
+    And the probe hook forwards `.[:4]` after `sort_by(.rank, .kind)`, so `info`
+    ranks last and this cannot crowd a real `error` out of the nudge's budget.
+    Precedent in this same file: `rule_covered_by_skill`.
+
+    `sim` is a CALLABLE, not a matrix, and that is a test-seam decision rather
+    than a style one. `test-config-drift.sh` is listed in
+    `scripts/required-to-run-tests.txt`, where a SKIP is an ERROR, and neither
+    numpy nor fastembed is installed for the system `python3` both real callers
+    invoke. A test needing the real model would force that required gate to skip
+    on every runner. With the similarity injected (`--sim-fixture`), the
+    discriminator, the tie skip, scope ordering, the finding shape and the
+    `--gate` interaction are all exercisable in the stdlib tier.
+
+    KNOWN LIMITATION, recorded rather than closed: `structural_pair` reads only
+    the two documents in the pair, so a hierarchy DECLARED IN A THIRD DOCUMENT
+    leaks through as a candidate. At `~/repos` that is the six
+    `ForumViriumHelsinki/.github` <- `ForumViriumHelsinki` pairs
+    (`application-structure`, `deploy-values`, `local-development`,
+    `ci-cd-workflows`, `dependency-automation`, `github-metadata-hygiene`,
+    0.94-0.97): the declaration lives in `ForumViriumHelsinki/CLAUDE.md` --
+    "Workspace rules in `.claude/rules/` are generated from the .github repo
+    source -- edit the source, not the generated files" -- which is neither end
+    of any of those pairs.
+
+    Closing it needs a THIRD-DOCUMENT declaration signal (a scope's own
+    CLAUDE.md vouching for a whole rules directory), and that is its own
+    calibration with its own false-positive surface -- not a widening of
+    `structural_pair`. A pairwise prose discriminator was tried instead and
+    measured over both corpora: it suppressed 42 pairs at `claude-plugins` and
+    60 at `~/repos`, NONE of them above T_PROMOTE, i.e. it changed no emitted
+    finding at either root -- while binding to a SCOPE rather than a document,
+    so one sentence in one child exempted it from every rule in the parent
+    scope. It was cut. Do not re-add a variant of it without a measurement
+    showing it moves an emitted finding.
+
+    The gap does not bite at the ship root: 4 scopes, the whole above-band set
+    is n=1, and that one pair is genuine.
+    """
+    docs = [d for d in items if d["kind"] in PROMOTION_KINDS]
+
+    out: list[Finding] = []
+    considered = 0
+    declared = 0
+    for a, b in combinations(docs, 2):
+        ra, rb = a["scope_rank"], b["scope_rank"]
+        if ra is None or rb is None:
+            continue  # SCOPE_PLUGIN: no ladder, so not a considered pair at all
+        considered += 1
+        if ra == rb:
+            continue
+        parent, child = (a, b) if ra < rb else (b, a)
+        if not _ancestor_scope(parent, child):
+            continue
+        if min(child["chars"], parent["chars"]) < MIN_PROMOTABLE_CHARS:
+            continue
+        s = sim(child, parent)
+        if s < T_PROMOTE:
+            continue
+        if structural_pair(child, parent):
+            declared += 1
+            continue
+        if waivers.waived(child, parent):
+            continue
+        out.append(
+            Finding(
+                "info",
+                "promotion_candidate",
+                # THE SUMMARY STATES THE OBSERVATION, NOT THE ACTION. What was
+                # measured is two documents covering the same topic at two rungs
+                # of the ladder with no declared relationship between them;
+                # whether the lower one should MOVE depends on why it exists,
+                # which this check cannot see. `proposed_parent` carries the
+                # suggestion, and a reader who wants it reads it there.
+                (
+                    f"{child['scope']}:{child['name']} is {s:.0%} similar to "
+                    f"{parent['scope']}:{parent['name']} one scope up, and "
+                    f"neither declares the other -- review whether the lower "
+                    f"copy still earns its own scope"
+                ),
+                score=round(s, 3),
+                # CHILD FIRST. `render_report` prints only `paths[:2]` and the
+                # probe hook forwards the summary, so the order is the only
+                # thing telling a reader which end moves.
+                paths=[child["path"], parent["path"]],
+                # Index-aligned with `paths`, so a consumer can label the two
+                # ends without re-deriving a scope from a path.
+                scopes=[child["scope"], parent["scope"]],
+                proposed_parent=parent["scope"],
+            )
+        )
+    return sorted(out, key=lambda x: -x["score"]), considered, declared
+
+
+def _ancestor_scope(parent: dict, child: dict) -> bool:
+    """True when `parent`'s scope sits ABOVE `child`'s on the same ladder.
+
+    `user-global` and `portfolio` are above every scope by construction — they
+    are the two rungs every project scope hangs off. Anything else has to be a
+    literal path prefix; sibling repos at equal or differing depth share no
+    ladder, so no promotion between them is possible.
+    """
+    ps, cs = parent["scope"], child["scope"]
+    if ps in ("user-global", "portfolio"):
+        return True
+    return cs.startswith(ps + "/")
+
+
+def _embed_matrix(items, cache_path: Path):
+    """Normalized embedding vectors for `items`, warmed through the disk cache.
+
+    Hoisted out of `check_semantic_dupes` so the promotion pass can share both
+    the cache file and the keying rules rather than re-implementing them. The
+    cache is content-keyed, so two calls over overlapping item sets (rules are
+    in both) cost one embedding each.
+
+    numpy and fastembed are imported FUNCTION-LOCALLY, exactly as before:
+    nothing in the cheap tier may pull them in.
+    """
     import numpy as np
     from fastembed import TextEmbedding
 
@@ -1157,26 +1430,63 @@ def check_semantic_dupes(items, waivers, cache_path: Path) -> list[Finding]:
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         cache_path.write_text(json.dumps(cache))
 
-    def structural_pair(a: dict, b: dict) -> bool:
-        """Relationships that are correct by design, not drift.
-
-        Two shapes dominate the high-cosine band and neither is a defect:
-        a pointer stub scores ~0.92 against the very skill it delegates to, and
-        deliberately cross-referenced sibling rules ("Sibling: pr-merge-hazards.md")
-        score ~0.93. Flagging either trains the reader to ignore the report.
-        """
-        for x, y in ((a, b), (b, a)):
-            if x.get("stub") and y["kind"] == "skill" and y["name"] in x["body"][:700]:
-                return True
-            if (
-                Path(y["path"]).name in x["body"]
-                or f"`{y['name']}`" in x["body"][:1500]
-            ):
-                return True
-        return False
-
     vecs = np.array([cache[k] for k in keys], dtype="float32")
     vecs /= np.linalg.norm(vecs, axis=1, keepdims=True) + 1e-9
+    return vecs
+
+
+def cosine_sim_fn(items, cache_path: Path):
+    """A `sim(a, b) -> float` callable over `items`, backed by the embed cache.
+
+    The promotion pass filters on rank, ancestry and length BEFORE it needs a
+    score, so a lazy per-pair dot product is both cheaper and smaller than the
+    full N x N matrix `check_semantic_dupes` builds for its own exhaustive
+    sweep. Rows are keyed by `id()` rather than by content hash: two documents
+    in this corpus can be byte-identical (that is precisely the promotion shape
+    being looked for), so a content hash is not a unique row key here.
+    """
+    vecs = _embed_matrix(items, cache_path)
+    row = {id(it): i for i, it in enumerate(items)}
+
+    def sim(a: dict, b: dict) -> float:
+        return float(vecs[row[id(a)]] @ vecs[row[id(b)]])
+
+    return sim
+
+
+def fixture_sim_fn(fixture_path: Path):
+    """A `sim(a, b)` callable reading precomputed scores from a JSON fixture.
+
+    THE TEST SEAM, and the reason `check_promotion_candidates` takes a callable
+    at all. `health-plugin/scripts/tests/test-config-drift.sh` is listed in
+    `scripts/required-to-run-tests.txt`, where a SKIP is an ERROR; numpy and
+    fastembed are absent from the system `python3` that both real callers
+    invoke. Injecting the scores is what keeps the whole verdict -- the
+    discriminator, the tie skip, scope ordering, the finding shape, the
+    `--gate` interaction -- inside the stdlib tier instead of behind a model
+    download.
+
+    Format: `{"<hash-a>|<hash-b>": 0.93}`, where each hash is the document's
+    `hash` field (`sha(body)`, 16 hex chars) and the two are sorted, so the
+    caller need not know which side the scan will call parent. A missing pair
+    scores 0.0 -- below every threshold, so an incomplete fixture under-reports
+    rather than inventing a finding.
+
+    Stdlib `json` only, and no module-scope import is added for it.
+    """
+    raw = json.loads(fixture_path.read_text())
+    table = {k: float(v) for k, v in raw.items()}
+
+    def sim(a: dict, b: dict) -> float:
+        return table.get("|".join(sorted((a["hash"], b["hash"]))), 0.0)
+
+    return sim
+
+
+def check_semantic_dupes(items, waivers, cache_path: Path) -> list[Finding]:
+    import numpy as np
+
+    vecs = _embed_matrix(items, cache_path)
     sim = vecs @ vecs.T
     out = []
     for i, j in zip(*np.triu_indices(len(items), k=1)):
@@ -1200,6 +1510,88 @@ def check_semantic_dupes(items, waivers, cache_path: Path) -> list[Finding]:
                 )
             )
     return sorted(out, key=lambda x: -x["score"])
+
+
+# ----------------------------------------------------------------- calibration
+CALIBRATION_BANDS = (0.94, 0.92, 0.90, 0.88, 0.86)
+
+
+def _band_histogram(scores) -> str:
+    """The cumulative histogram spelling used by the T_SEMANTIC/T_PROMOTE comments.
+
+    Cumulative, not per-bucket: `0.90:32` means "32 pairs at or above 0.90", so
+    a reader picking a threshold reads the yield of that threshold directly off
+    the row instead of summing buckets.
+    """
+    return " ".join(
+        f"{b}:{sum(1 for s in scores if s >= b)}" for b in CALIBRATION_BANDS
+    )
+
+
+def emit_calibration(corpus, cache_path: Path, root: Path) -> None:
+    """Dev-only: measure the promotion-band distribution over this root.
+
+    Not wired into any caller and not part of any tier -- it is how T_PROMOTE
+    was set, kept in the shipped file so the next person can re-derive the
+    number instead of trusting the comment above it. Imports numpy/fastembed
+    only through `_embed_matrix`, i.e. function-locally, exactly like
+    `check_semantic_dupes`.
+
+    Three bands per kind-pair, each one a strictly narrower predicate, so the
+    contribution of every discriminator is visible rather than asserted:
+
+    * RAW     -- every cross-scope, rank-strict pair of promotable kinds.
+    * NOVEL   -- RAW minus same-name minus `structural_pair`. The same
+                 definition the T_SEMANTIC comment uses, so the two constants'
+                 calibrations are comparable.
+    * SHIPPED -- what `check_promotion_candidates` actually emits: same-name
+                 KEPT, `structural_pair` suppressed, ancestor-constrained,
+                 `MIN_PROMOTABLE_CHARS`-floored.
+
+    NOVEL is reported despite the shipped check not using it because it is the
+    contrast that shows what keeping same-name pairs costs -- at this repo's
+    root that difference is a single pair, and it is one `structural_pair`
+    removes anyway.
+    """
+    docs = [d for k in PROMOTION_KINDS for d in corpus[k]]
+    sim = cosine_sim_fn(docs, cache_path)
+
+    raw: dict[str, list[float]] = {}
+    novel: dict[str, list[float]] = {}
+    shipped: dict[str, list[float]] = {}
+    for a, b in combinations(docs, 2):
+        ra, rb = a["scope_rank"], b["scope_rank"]
+        if ra is None or rb is None or ra == rb:
+            continue
+        parent, child = (a, b) if ra < rb else (b, a)
+        key = "_".join(sorted((a["kind"], b["kind"])))
+        s = sim(child, parent)
+        raw.setdefault(key, []).append(s)
+        if a["name"] != b["name"] and not structural_pair(a, b):
+            novel.setdefault(key, []).append(s)
+        if (
+            _ancestor_scope(parent, child)
+            and min(child["chars"], parent["chars"]) >= MIN_PROMOTABLE_CHARS
+            and not structural_pair(child, parent)
+        ):
+            shipped.setdefault(key, []).append(s)
+
+    print("=== CONFIG DRIFT CALIBRATION ===")
+    print(f"ROOT={root}")
+    print(f"BANDS={' '.join(str(b) for b in CALIBRATION_BANDS)}")
+    for kind in PROMOTION_KINDS:
+        print(f"DOCS_{kind.upper()}={len(corpus[kind])}")
+    print(f"PROMOTABLE_DOCS={len(docs)}")
+    print(f"SCOPES={len({d['scope'] for d in docs})}")
+    print(f"CROSS_SCOPE_PAIRS={sum(len(v) for v in raw.values())}")
+    for label, table in (("RAW", raw), ("NOVEL", novel), ("SHIPPED", shipped)):
+        for key in sorted(set(raw) | set(novel) | set(shipped)):
+            scores = table.get(key, [])
+            print(f"{label}_{key.upper()}={_band_histogram(scores)} n={len(scores)}")
+        allscores = [s for v in table.values() for s in v]
+        print(f"{label}_ALL={_band_histogram(allscores)} n={len(allscores)}")
+    print(f"T_PROMOTE={T_PROMOTE}")
+    print("=== END CONFIG DRIFT CALIBRATION ===")
 
 
 # ---------------------------------------------------------------------- output
@@ -1274,6 +1666,13 @@ def main() -> int:
         action="store_true",
         help="probe mode: never spawn git; read cached dates only. Sub-second.",
     )
+    ap.add_argument(
+        "--calibrate",
+        action="store_true",
+        help="dev-only: print the promotion-band distribution and exit. Needs the model.",
+    )
+    # Hidden: a TEST SEAM, not an operator flag. See `fixture_sim_fn`.
+    ap.add_argument("--sim-fixture", help=argparse.SUPPRESS)
     args = ap.parse_args()
 
     root = Path(args.root).expanduser().resolve()
@@ -1282,6 +1681,9 @@ def main() -> int:
         return 3
 
     corpus, unreadable, templates_excluded, agent_dirs = collect(root)
+    if args.calibrate:
+        emit_calibration(corpus, Path(args.cache).expanduser(), root)
+        return 0
     rules = corpus["rule"]
     skills = corpus["skill"]
     agents = corpus["agent"]
@@ -1321,6 +1723,28 @@ def main() -> int:
         datecache_path.parent.mkdir(parents=True, exist_ok=True)
         datecache_path.write_text(json.dumps(datecache))
 
+    # The two promotion counters are emitted ONLY when the promotion pass ran.
+    # `even at 0` means "ran and found none"; ABSENT means "did not run", and
+    # the cheap tier must keep saying the second. A `PROMOTION_PAIRS_CONSIDERED=0`
+    # printed by `--fast --no-embed` would read as a clean promotable corpus
+    # scanned, which is the false all-clear the counter exists to prevent -- the
+    # same distinction `SEMANTIC_PASS=off` already draws for its own tier.
+    promotion_counts: dict[str, int] = {}
+    promotable = [d for k in PROMOTION_KINDS for d in corpus[k]]
+
+    if args.sim_fixture:
+        # Test seam. The similarity is injected, so the promotion verdict runs
+        # in the stdlib tier with no model; `check_semantic_dupes` is untouched
+        # and still obeys --no-embed.
+        promo, considered, declared = check_promotion_candidates(
+            promotable, fixture_sim_fn(Path(args.sim_fixture).expanduser()), waivers
+        )
+        findings += promo
+        promotion_counts = {
+            "promotion_pairs_considered": considered,
+            "hierarchies_declared": declared,
+        }
+
     if not args.no_embed:
         try:
             # SEMANTIC_KINDS, not `rules + skills` spelled out: the exclusion of
@@ -1332,6 +1756,22 @@ def main() -> int:
                 waivers,
                 Path(args.cache).expanduser(),
             )
+            # PROMOTION_KINDS is a DIFFERENT set from SEMANTIC_KINDS, so this is
+            # a second embedding pass rather than a filter over the first. It is
+            # not a second embedding COST: the cache is keyed on the embed text,
+            # so every rule is already warm from the call above and only the
+            # CLAUDE.md vectors are new.
+            if not args.sim_fixture:
+                promo, considered, declared = check_promotion_candidates(
+                    promotable,
+                    cosine_sim_fn(promotable, Path(args.cache).expanduser()),
+                    waivers,
+                )
+                findings += promo
+                promotion_counts = {
+                    "promotion_pairs_considered": considered,
+                    "hierarchies_declared": declared,
+                }
         except Exception as exc:  # noqa: BLE001 - degrade loudly, never silently
             findings.append(
                 Finding(
@@ -1407,6 +1847,18 @@ def main() -> int:
         "lexical_pairs": lexical_pairs,
         "waivers_active": len(waivers),
         "semantic_pass": "off" if args.no_embed else "on",
+        # Present only when the promotion pass ran -- see the comment above
+        # `promotion_counts`. PROMOTION_PAIRS_CONSIDERED is the pair UNIVERSE
+        # (both kinds promotable, neither rank None), counted BEFORE the tie
+        # skip and every suppression, so a suppression test's "0 findings" has
+        # a denominator that proves the check opened a corpus.
+        # HIERARCHIES_DECLARED counts pairs that cleared T_PROMOTE and were then
+        # suppressed by `structural_pair` -- i.e. findings that were withheld,
+        # not pairs that were merely looked at. It is exactly that one
+        # suppressor's yield: a hierarchy declared in a THIRD document is
+        # invisible to it and is NOT counted here (see
+        # `check_promotion_candidates`, KNOWN LIMITATION).
+        **promotion_counts,
     }
 
     {

--- a/health-plugin/scripts/tests/test-config-drift.sh
+++ b/health-plugin/scripts/tests/test-config-drift.sh
@@ -1615,6 +1615,446 @@ rm "$FIXROOT/proj/repo-b/.claude/rules/beta.md" \
    "$FIXROOT/proj/other-plugin/agents/torque-auditor-copy.md" \
    "$FIXROOT/proj/nest-b/CLAUDE.md"
 
+echo "TEST 22: promotion candidates -- the verdict, its discriminator, and its guards"
+# THE VERDICT: the same thing said at two levels of the scope ladder is a
+# candidate for promotion to the higher one. T_PROMOTE = 0.88, measured (see the
+# constant's comment). Every case below injects the similarity through the
+# hidden `--sim-fixture` seam, because `test-config-drift.sh` is listed in
+# `scripts/required-to-run-tests.txt` where a SKIP is an ERROR and neither numpy
+# nor fastembed is installed for the system python3 -- a case needing the real
+# model would force that required gate to skip on every runner.
+# `pwd -P` resolves the symlink macOS puts in front of every mktemp path
+# (/var -> /private/var). The analyzer resolves its --root, so the paths in a
+# finding come back canonicalised; without this the child-first assertion
+# below compares two spellings of the same file.
+PROOT=$(cd "$(mktemp -d)" && pwd -P)
+mkdir -p "$PROOT/home/.claude/rules" "$PROOT/tie-home/.claude/rules" \
+         "$PROOT/tie" "$PROOT/proj/.claude/rules" \
+         "$PROOT/proj/alpha-repo/.claude/rules" \
+         "$PROOT/proj/beta-repo/deep/.claude/rules"
+
+# The similarity table is keyed by CONTENT HASH, and every fixture edit below
+# changes a hash -- so the table is rewritten from the files themselves on every
+# case rather than carried forward. Retyping a hash would be exactly the
+# fabricated-identifier trap (`never-fabricate-test-identifiers.md`): a stale key
+# scores 0.0, which is indistinguishable from "correctly suppressed".
+write_sim() {  # write_sim <out.json> [<fileA> <fileB> <score>]...
+    python3 - "$@" <<'PYSIM'
+import hashlib, json, sys
+out, rest = sys.argv[1], sys.argv[2:]
+def h(p):
+    return hashlib.sha256(
+        open(p, encoding="utf-8", errors="replace").read().encode("utf-8", "replace")
+    ).hexdigest()[:16]
+table = {}
+for i in range(0, len(rest), 3):
+    a, b, s = rest[i], rest[i + 1], rest[i + 2]
+    table["|".join(sorted((h(a), h(b))))] = float(s)
+json.dump(table, open(out, "w"))
+PYSIM
+}
+SIM="$PROOT/sim.json"
+run_promo() {  # run_promo <root> [extra analyzer args...]
+    HOME="$PROOT/home" python3 "$ANALYZER" --root "$1" --no-embed --fast \
+        --format=json --sim-fixture "$SIM" "${@:2}" 2>/dev/null
+}
+promo_field() { finding_field "$1" promotion_candidate "$2"; }
+promo_parents() {
+    printf '%s' "$1" | python3 -c 'import json,sys
+d = json.load(sys.stdin)
+print(",".join(sorted({f["proposed_parent"] for f in d["findings"]
+                       if f["kind"] == "promotion_candidate"})))' 2>/dev/null || echo ERR
+}
+promo_paths_len() {
+    printf '%s' "$1" | python3 -c 'import json,sys
+d = json.load(sys.stdin)
+print(next((len(f["paths"]) for f in d["findings"] if f["kind"] == "promotion_candidate"), -1))' 2>/dev/null || echo ERR
+}
+
+# --- 22a. TRUE POSITIVE ------------------------------------------------------
+# Two rules, two scopes, DIFFERENT names, neither referencing the other. Bodies
+# are lexically dissimilar on purpose so `duplicate_rule_lexical` stays quiet and
+# the only thing that can produce a finding is the injected cosine.
+PARENT="$PROOT/home/.claude/rules/torque-baseline.md"
+CHILD="$PROOT/proj/alpha-repo/.claude/rules/spindle-notes.md"
+cat > "$PARENT" <<'RULE'
+---
+reviewed: 2026-08-01
+---
+# Torque Baseline
+
+Every assembly line records a torque baseline before the first shift of the
+week. The baseline is captured from the calibration jig, logged against the
+jig's serial number, and signed off by whoever ran the jig that morning.
+
+A baseline older than seven shifts is treated as absent: the jig drifts with
+ambient temperature, and a stale figure reads as authoritative while being
+wrong. Re-run the jig rather than extrapolating from the previous week.
+
+When two baselines disagree by more than four percent, neither is used. The
+discrepancy is escalated and the line runs on the manufacturer default until a
+third capture agrees with one of them.
+RULE
+cat > "$CHILD" <<'RULE'
+---
+reviewed: 2026-08-01
+---
+# Spindle Notes
+
+Before a shift opens, the spindle head is measured against the reference gauge
+and the reading is written into the shift log beside the gauge identifier and
+the operator initials.
+
+Readings more than a week old count as missing. Ambient conditions move the
+gauge, so an old number looks trustworthy while describing a machine that no
+longer exists. Take a fresh reading instead of projecting the last one forward.
+
+Two readings that differ by four percent or more cancel each other out. The
+head then runs at the vendor default until a further measurement corroborates
+one of the two.
+RULE
+write_sim "$SIM" "$CHILD" "$PARENT" 0.93
+out=$(run_promo "$PROOT/proj")
+assert_eq "a cross-scope pair above T_PROMOTE is one promotion_candidate" \
+    "$(count_kind "$out" promotion_candidate)" "1"
+assert_eq "...at severity info, so --gate cannot fail CI on it" \
+    "$(promo_field "$out" severity)" "info"
+assert_eq "...carrying exactly two paths" "$(promo_paths_len "$out")" "2"
+assert_eq "...CHILD first, because emit_report prints only paths[:2]" \
+    "$(printf '%s' "$out" | python3 -c 'import json,sys
+print(next(f["paths"][0] for f in json.load(sys.stdin)["findings"] if f["kind"] == "promotion_candidate"))')" \
+    "$CHILD"
+assert_eq "...naming the higher scope as proposed_parent" \
+    "$(promo_field "$out" proposed_parent)" "user-global"
+assert_eq "...with scopes index-aligned to paths" \
+    "$(printf '%s' "$out" | python3 -c 'import json,sys
+print(",".join(next(f["scopes"] for f in json.load(sys.stdin)["findings"] if f["kind"]=="promotion_candidate")))')" \
+    "alpha-repo,user-global"
+assert_ge "GUARD: pairs were actually considered" \
+    "$(count_key "$out" promotion_pairs_considered)" 1
+assert_eq "GUARD: nothing was suppressed as declared in the positive case" \
+    "$(count_key "$out" hierarchies_declared)" "0"
+
+# --- 22b. --gate does not fail on an info-only run ---------------------------
+# The whole reason the severity is `info`. A style suggestion that turns CI red
+# gets the check switched off, and `--gate` returning 2 here would do exactly
+# that on the first scheduled run that found a candidate.
+gate_out=$(run_promo "$PROOT/proj" --gate --format=status)
+gate_rc=0
+run_promo "$PROOT/proj" --gate >/dev/null 2>&1 || gate_rc=$?
+assert_contains "FIXTURE: the gate run really did produce the finding" \
+    "$gate_out" "FINDING_PROMOTION_CANDIDATE=1"
+assert_contains "FIXTURE: ...and produced no error-severity finding" "$gate_out" "ERRORS=0"
+assert_eq "a run whose only finding is promotion_candidate exits 0 under --gate" \
+    "$gate_rc" "0"
+
+# --- 22c. the declared-hierarchy control (the required control) --------------
+# The pair from 22a, unchanged except that the child now names the parent's
+# file, which is what `structural_pair` reads. It is the ONLY suppressor on this
+# axis and it is doing work the threshold cannot: the nearest real pair to the
+# genuine candidate in the calibration corpus
+# (`offload-to-deterministic-substrate` against itself one scope up, 0.8994)
+# sits 0.0004 ABOVE it, so no number separates them.
+#
+# A pairwise PROSE discriminator (a phrase like "the shared baseline lives one
+# level up", bound to the parent's scope) was built alongside this and then cut:
+# measured over both corpora it suppressed 42 pairs at `claude-plugins` and 60
+# at `~/repos` with NONE above T_PROMOTE, so it moved no emitted finding, while
+# binding to a scope rather than a document -- one sentence exempted its child
+# from every rule in the parent scope. There is deliberately no case here for a
+# declaration that names no file; that shape is now a KNOWN LIMITATION recorded
+# in `check_promotion_candidates`, not a behaviour.
+python3 - "$CHILD" <<'PY'
+import sys
+p = sys.argv[1]
+body = open(p, encoding="utf-8").read()
+open(p, "w", encoding="utf-8").write(
+    body.replace(
+        "# Spindle Notes\n",
+        "# Spindle Notes\n\nThe canonical statement lives at "
+        "`~/.claude/rules/torque-baseline.md`; this file holds the deltas.\n",
+    )
+)
+PY
+write_sim "$SIM" "$CHILD" "$PARENT" 0.93
+out=$(run_promo "$PROOT/proj")
+assert_eq "a child naming the parent's file is not a promotion candidate" \
+    "$(count_kind "$out" promotion_candidate)" "0"
+assert_eq "...and the suppression is counted, not silent" \
+    "$(count_key "$out" hierarchies_declared)" "1"
+assert_ge "GUARD: the pair was still considered" \
+    "$(count_key "$out" promotion_pairs_considered)" 1
+
+rm "$PARENT" "$CHILD"
+
+# --- 22e. the release-please shape: same basename, BELOW threshold ------------
+# Two scopes, one basename, genuinely different documents (a policy and a
+# package layout). Measured at 0.8114 in the calibration corpus, i.e. below any
+# candidate threshold. It must not fire -- and the second half proves the reason
+# is the SCORE and not the name, because the identical pair at 0.93 does fire.
+RP_PARENT="$PROOT/proj/.claude/rules/release-please.md"
+RP_CHILD="$PROOT/proj/beta-repo/deep/.claude/rules/release-please.md"
+cat > "$RP_PARENT" <<'RULE'
+---
+reviewed: 2026-08-01
+---
+# Release Automation Policy
+
+Generated release metadata is never hand-edited. The changelog, the version
+fields and the manifest are outputs; editing an output makes the next generated
+run conflict with a human decision nobody recorded.
+
+When a version needs to move for a reason the tool cannot infer, record the
+reason in a commit footer and let the tool re-derive the number. The commit
+footer survives; a hand-typed version does not.
+
+An override applied by hand is invisible to the next generated run, so the two
+disagree from that point on and the disagreement is discovered at release time
+rather than at review time. Prefer the footer even when it feels heavier.
+RULE
+cat > "$RP_CHILD" <<'RULE'
+---
+reviewed: 2026-08-01
+---
+# Package Layout In This Monorepo
+
+Forty-four package directories are keyed by plugin name. A commit is routed to
+every package whose directory it touches, so a scope string that matches no
+package suppresses nothing at all.
+
+To keep one package unpublished, change no file beneath its directory. The
+scope is a changelog label; the file list is what decides which packages move.
+
+A label naming a directory the commit never touched still renders in the
+changelog of whatever it did touch, so a mislabelled entry misdescribes every
+package it reached. Read the file list before choosing the label.
+RULE
+write_sim "$SIM" "$RP_CHILD" "$RP_PARENT" 0.81
+out=$(run_promo "$PROOT/proj")
+assert_eq "a same-basename pair BELOW threshold is not a candidate" \
+    "$(count_kind "$out" promotion_candidate)" "0"
+assert_ge "GUARD: it was considered, not skipped before scoring" \
+    "$(count_key "$out" promotion_pairs_considered)" 1
+assert_eq "GUARD: ...and it was the score, not a declared hierarchy" \
+    "$(count_key "$out" hierarchies_declared)" "0"
+write_sim "$SIM" "$RP_CHILD" "$RP_PARENT" 0.93
+out=$(run_promo "$PROOT/proj")
+assert_eq "the SAME pair above threshold fires -- same-name pairs are NOT skipped" \
+    "$(count_kind "$out" promotion_candidate)" "1"
+# Bracket T_PROMOTE tightly. The fixtures above only pin it to [0.82, 0.93]:
+# 0.81 must not fire and 0.93 must, so any constant in between passes the suite
+# and a -0.05 drift lands inside the gap undetected (mutation M7 survived on
+# exactly that). These two straddle the shipped 0.88 by one hundredth each, so
+# the band becomes (0.87, 0.89] and the constant is pinned to its own value
+# rather than to a range nobody chose.
+write_sim "$SIM" "$RP_CHILD" "$RP_PARENT" 0.87
+out=$(run_promo "$PROOT/proj")
+assert_eq "0.87 is BELOW the shipped threshold and does not fire" \
+    "$(count_kind "$out" promotion_candidate)" "0"
+assert_ge "GUARD: the 0.87 pair was scored, not skipped before scoring" \
+    "$(count_key "$out" promotion_pairs_considered)" 1
+write_sim "$SIM" "$RP_CHILD" "$RP_PARENT" 0.89
+out=$(run_promo "$PROOT/proj")
+assert_eq "0.89 is ABOVE it and does fire" \
+    "$(count_kind "$out" promotion_candidate)" "1"
+rm "$RP_PARENT" "$RP_CHILD"
+
+# --- 22f. scope ordering and the ancestor constraint --------------------------
+# One name at three scopes, ordered so the lowest RANK and the alphabetically
+# first DISAGREE: ranks are portfolio(1) < alpha-repo(2) < beta-repo/deep(3),
+# while alphabetically "alpha-repo" < "beta-repo/deep" < "portfolio". A check
+# that sorted scopes as strings would name `alpha-repo` as the parent.
+#
+# It also pins the ancestor constraint: three scopes give three rank-strict
+# pairs, but `alpha-repo` is not an ancestor of `beta-repo/deep` -- they are
+# siblings -- so that pair must not appear. Rank is DEPTH, not ancestry, and at
+# `~/repos`/0.88 rank alone admitted 47 unrelated cross-repo pairs out of 69.
+F_TOP="$PROOT/proj/.claude/rules/fleet-manifest.md"
+F_MID="$PROOT/proj/alpha-repo/.claude/rules/fleet-manifest.md"
+F_LOW="$PROOT/proj/beta-repo/deep/.claude/rules/fleet-manifest.md"
+cat > "$F_TOP" <<'RULE'
+---
+reviewed: 2026-08-01
+---
+# Fleet Manifest
+
+The manifest enumerates every chassis currently in service together with the
+depot that holds its paperwork. It is regenerated nightly from the depot
+returns and is authoritative for billing.
+
+A chassis missing from two consecutive regenerations is retired automatically,
+because a gap of that length means the depot stopped reporting rather than that
+the vehicle briefly left service.
+
+Retirement is reversible for thirty days, after which the paperwork is archived
+and a returning chassis is enrolled as new. Depots are notified on the day a
+retirement lands so a reporting outage can be corrected before that window shuts.
+RULE
+cat > "$F_MID" <<'RULE'
+---
+reviewed: 2026-08-01
+---
+# Fleet Manifest
+
+Trailers are tracked separately from tractors here. Each entry pairs a plate
+with the yard responsible for it, and the pairing is what the invoicing run
+reads at the end of the month.
+
+An entry absent from two runs in a row is closed out; a two-run absence
+indicates the yard has stopped filing, not a short trip away from base.
+
+A closed entry can be reopened within a month; past that the plate is released
+and a returning trailer is registered afresh. Yards receive a notice the day a
+closure lands so a filing gap can be repaired before the plate is released.
+RULE
+cat > "$F_LOW" <<'RULE'
+---
+reviewed: 2026-08-01
+---
+# Fleet Manifest
+
+Loading cranes carry their own register. A row binds a serial number to the
+site holding its inspection certificate, and that binding drives the quarterly
+charge raised against the site.
+
+A serial that fails to appear twice running is struck off, since two silent
+quarters mean the site has ceased filing rather than that the crane moved.
+
+A struck serial may be reinstated for one further quarter; beyond that the
+certificate lapses and the crane requires a fresh inspection. Sites are told the
+quarter a strike is recorded so a filing lapse can be repaired in time.
+RULE
+write_sim "$SIM" "$F_MID" "$F_TOP" 0.93 "$F_LOW" "$F_TOP" 0.93 "$F_LOW" "$F_MID" 0.93
+out=$(run_promo "$PROOT/proj")
+assert_eq "three scopes, but only ANCESTOR pairs are candidates" \
+    "$(count_kind "$out" promotion_candidate)" "2"
+assert_eq "...both naming the lowest-RANK scope, not the alphabetically first" \
+    "$(promo_parents "$out")" "portfolio"
+
+rm "$F_TOP" "$F_MID" "$F_LOW"
+
+# --- 22h. a scope_rank TIE is skipped, and still counted ---------------------
+# Two rules at the SAME scope have no parent between them, so "promote to the
+# parent" names no operation and the recommendation would be undefined.
+#
+# THE TIE HAS TO BE PINNED WHERE IT IS LOAD-BEARING. Two sibling scopes at equal
+# depth under a project root are ALREADY rejected by the ancestor constraint, so
+# a tie case built there passes whether or not the tie skip exists -- a mutation
+# deleting `if ra == rb: continue` survives it, which is exactly what an earlier
+# version of this case measured. The skip decides something only when the parent
+# side is `user-global` or `portfolio`, which `_ancestor_scope` accepts
+# unconditionally: without it, a `user-global` rule is reported as promotable
+# into `user-global`. So both rules live in a HOME rules dir -- same scope, both
+# rank 0 -- with the root left empty, which also makes the denominator exact:
+# the universe is one pair, so `considered == 1` with zero findings proves the
+# skip rather than an empty corpus. The injected score is 0.99, far above
+# threshold, so nothing but the tie can be doing the suppressing.
+TIE_A="$PROOT/tie-home/.claude/rules/one.md"
+TIE_B="$PROOT/tie-home/.claude/rules/two.md"
+cat > "$TIE_A" <<'RULE'
+---
+reviewed: 2026-08-01
+---
+# Coolant Schedule
+
+Coolant is drained on the first Monday of each quarter and the sump is wiped
+before refilling. The drained volume is logged so a slow leak shows up as a
+shortfall against the previous quarter rather than as a sudden failure.
+
+Refilling past the upper mark is treated as an error and reported, because the
+overflow path routes into the swarf tray and contaminates the filtrate.
+
+A quarter skipped for a shutdown is recorded as skipped rather than left blank,
+so the next drain is compared against the last actual reading instead of
+against a gap that reads like a missing log entry.
+RULE
+cat > "$TIE_B" <<'RULE'
+---
+reviewed: 2026-08-01
+---
+# Filter Rotation
+
+Filters rotate on a three-station cycle and each station is stamped with the
+date it entered service. Stamping at entry, not at removal, is what makes a
+skipped rotation visible in the record instead of merely absent from it.
+
+A station left in place beyond two cycles is pulled regardless of apparent
+condition; visual inspection does not detect the failure mode that matters.
+
+A cycle deferred for a shutdown is stamped as deferred rather than omitted, so
+the following rotation is measured from the last real entry instead of from a
+hole that looks like a lost stamp.
+RULE
+write_sim "$SIM" "$TIE_A" "$TIE_B" 0.99
+run_tie() {  # run_tie -- HOME is the tie corpus; the root is deliberately bare
+    HOME="$PROOT/tie-home" python3 "$ANALYZER" --root "$PROOT/tie" \
+        --no-embed --fast --format=json --sim-fixture "$SIM" 2>/dev/null
+}
+tie_out=$(run_tie)
+assert_eq "GUARD: the tie pair is the entire considered universe" \
+    "$(count_key "$tie_out" promotion_pairs_considered)" "1"
+assert_eq "a scope_rank tie is skipped rather than reported" \
+    "$(count_kind "$tie_out" promotion_candidate)" "0"
+assert_eq "GUARD: ...and not because it was called a declared hierarchy" \
+    "$(count_key "$tie_out" hierarchies_declared)" "0"
+# THE CONTROL: the same two documents, one of them moved one rung DOWN so the
+# ranks differ and nothing else changes. It fires -- which is what makes the
+# three rows above an assertion about the TIE rather than about this pair.
+mkdir -p "$PROOT/tie/repo-x/.claude/rules"
+mv "$TIE_B" "$PROOT/tie/repo-x/.claude/rules/two.md"
+TIE_B="$PROOT/tie/repo-x/.claude/rules/two.md"
+write_sim "$SIM" "$TIE_A" "$TIE_B" 0.99
+tie_out=$(run_tie)
+assert_eq "CONTROL: the same pair one rung apart IS a candidate" \
+    "$(count_kind "$tie_out" promotion_candidate)" "1"
+assert_eq "CONTROL: ...promoting toward the shallower scope" \
+    "$(promo_field "$tie_out" proposed_parent)" "user-global"
+rm -rf "$PROOT/tie" "$PROOT/tie-home/.claude/rules"
+
+# --- 22i. the degenerate-document floor --------------------------------------
+# Cosine between two near-empty documents is meaningless and runs HIGH: 10 of
+# the 22 ancestor-constrained survivors at `~/repos`/0.88 were 11-128 byte
+# `@AGENTS.md` redirect stubs scoring 0.879-0.975 against each other. Both
+# halves are asserted -- suppressed while short, reported once padded past
+# MIN_PROMOTABLE_CHARS -- so the floor cannot silently become "suppress
+# everything".
+SHORT_P="$PROOT/home/.claude/rules/pointer-a.md"
+SHORT_C="$PROOT/proj/alpha-repo/.claude/rules/pointer-b.md"
+printf -- '---\nreviewed: 2026-08-01\n---\n# Pointer A\n\n@AGENTS.md\n' > "$SHORT_P"
+printf -- '---\nreviewed: 2026-08-01\n---\n# Pointer B\n\n@AGENTS.md\n' > "$SHORT_C"
+write_sim "$SIM" "$SHORT_C" "$SHORT_P" 0.97
+out=$(run_promo "$PROOT/proj")
+assert_eq "a pair of degenerate short documents is not a candidate" \
+    "$(count_kind "$out" promotion_candidate)" "0"
+assert_ge "GUARD: it was considered" "$(count_key "$out" promotion_pairs_considered)" 1
+python3 - "$SHORT_P" "$SHORT_C" <<'PY'
+import sys
+# Pad each side past MIN_PROMOTABLE_CHARS with DIFFERENT filler, so the pair
+# clears the length floor without becoming a lexical duplicate.
+for path, word in zip(sys.argv[1:3], ("alpha", "bravo")):
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write("\n" + " ".join(f"{word}{i}" for i in range(140)) + "\n")
+PY
+write_sim "$SIM" "$SHORT_C" "$SHORT_P" 0.97
+out=$(run_promo "$PROOT/proj")
+assert_eq "the SAME pair padded past the floor IS a candidate" \
+    "$(count_kind "$out" promotion_candidate)" "1"
+rm "$SHORT_P" "$SHORT_C"
+
+# --- 22j. the counters are ABSENT when the pass did not run ------------------
+# `even at 0` means "ran and found none"; the cheap tier must keep saying
+# "did not run". A `PROMOTION_PAIRS_CONSIDERED=0` printed by --fast --no-embed
+# would read as a clean promotable corpus scanned -- the false all-clear the
+# counter exists to prevent.
+cheap=$(HOME="$PROOT/home" python3 "$ANALYZER" --root "$PROOT/proj" --no-embed \
+    --fast --format=json 2>/dev/null)
+assert_eq "the cheap tier emits no PROMOTION_PAIRS_CONSIDERED at all" \
+    "$(count_key "$cheap" promotion_pairs_considered)" "ERR"
+assert_eq "...nor HIERARCHIES_DECLARED" \
+    "$(count_key "$cheap" hierarchies_declared)" "ERR"
+
+rm -rf "$PROOT"
+
 echo
 echo "=== CONFIG DRIFT TESTS ==="
 echo "PASSED=$PASS"

--- a/health-plugin/scripts/tests/test-probe-lib.sh
+++ b/health-plugin/scripts/tests/test-probe-lib.sh
@@ -1301,9 +1301,9 @@ out=$(python3 "$FIXROOT/mapcover.py" "$ANALYZER" "$HOOK_SRC" 2>&1)
 # kinds" trivially, and a regex that matched no map keys satisfies "no unmapped
 # rows" the same way.
 assert_contains "the semantic-pass kinds are derived from SEMANTIC_KINDS, not assumed" "$out" "ITEM_KINDS rule,skill"
-assert_contains "FIXTURE: the derivation found every construction site" "$out" "DERIVED_N 16"
-assert_contains "FIXTURE: 15 of those kinds are reachable" "$out" "REACHABLE_N 15"
-assert_contains "FIXTURE: the map's keys were actually parsed out of the hook" "$out" "MAPPED_N 15"
+assert_contains "FIXTURE: the derivation found every construction site" "$out" "DERIVED_N 17"
+assert_contains "FIXTURE: 16 of those kinds are reachable" "$out" "REACHABLE_N 16"
+assert_contains "FIXTURE: the map's keys were actually parsed out of the hook" "$out" "MAPPED_N 16"
 assert_absent "every Finding( kind argument was parseable" "$out" "UNPARSEABLE_KIND_ARG"
 assert_contains "CONTROL: a fabricated kind is not reported as mapped" \
     "$out" "CONTROL_FABRICATED_MAPPED False"

--- a/justfile
+++ b/justfile
@@ -64,6 +64,39 @@ lint-fleet-drift *args:
 lint-all: lint-context-commands lint-compliance lint-health lint-infra lint-taskwarrior-tags lint-shell lint-context-engineering
 
 ####################
+# Config drift
+####################
+
+# The EXPENSIVE tier of config-drift: semantic overlap + promotion candidates.
+#
+# Deliberately NOT in lint-all and NOT reachable from the SessionStart probe.
+# It runs the analyzer through `uv run --script` because the PEP-723 block at
+# the top of config-drift.py declares fastembed + numpy, and neither is
+# installed for the bare `python3` the probe hook and the test suite invoke —
+# so this is the only supported way to reach the embedding pass. First run
+# downloads the BAAI/bge-small-en-v1.5 model; later runs read
+# ~/.cache/config-drift/embeddings.json, which is content-keyed and warm.
+#
+# It existed only as a command line in a PR body before this recipe.
+#
+# Exits 1 whenever any warn-severity finding exists, which on a real corpus is
+# the normal state (review_staleness alone accounts for ~67). That is the
+# analyzer's standing contract, not a fault in this recipe — read the report,
+# and use `--gate` (exit 2 on error only) for a CI gate.
+# Semantic-tier config drift: embedding overlap and promotion candidates
+[group: "lint"]
+config-drift-semantic *args:
+    uv run --script ./health-plugin/scripts/config-drift.py --format=report {{args}}
+
+# Re-derive the T_PROMOTE distribution over a corpus (dev-only; see the
+# constant's comment for the numbers this produced on 2026-08-29). Point --root
+# at a wider tree to calibrate against it: `just config-drift-calibrate --root ~/repos`
+# Measure the promotion-band distribution used to set T_PROMOTE
+[group: "lint"]
+config-drift-calibrate *args:
+    uv run --script ./health-plugin/scripts/config-drift.py --calibrate {{args}}
+
+####################
 # Testing
 ####################
 


### PR DESCRIPTION
Closes #2528. The last of the five-PR sequence (#2531, #2536, #2538, #2541).

Surfaces a rule or `CLAUDE.md` saying the same thing at two scopes with no
declared parent — a candidate for `/agent-patterns:meta-promote`. Semantic tier
only, so it adds nothing to the SessionStart path.

## The threshold is calibrated, and it cannot do the job alone

Measured cross-scope distributions, recorded in the source in the form the
`T_SEMANTIC` comment already uses:

```
claude-plugins  RAW    0.94:0  0.92:0  0.90:0  0.88:2  0.86:3     n=2,642
~/repos         RAW    0.94:27 0.92:39 0.90:61 0.88:101 0.86:170  n=76,120
~/repos         SHIPPED (ancestor + 500ch)  0.94:7 0.92:8 0.90:10 0.88:12
```

**`T_PROMOTE = 0.88`**, below `T_SEMANTIC = 0.91` for a stronger reason than
severity: **at 0.91 the shipping root yields zero findings, and at 0.90 it still
yields zero.** Shipping at the drift threshold would ship the verdict inert. The
separating interval is `(0.8721, 0.8990]` — a 0.027 margin to the nearest
adjudicated non-candidate.

The decisive measurement is that no threshold can do this:

| pair | score | truth |
|---|---|---|
| `offload-to-deterministic-substrate` ×2 | **0.8994** | declared hierarchy |
| `auto-mode` ← `claude-code-auto-mode` | **0.8990** | genuine candidate |

**0.0004 apart, wrong way round.** The discriminator carries the precision, not
the number.

## Every pair above threshold, adjudicated

Shipping root — the complete set is one:

| score | pair | verdict |
|---|---|---|
| 0.899 | `portfolio:auto-mode` ← `user-global:claude-code-auto-mode` | **genuine** |

Verified mechanically that neither names the other (`grep` in both directions).
At `~/repos` the shipped predicate yields 12, of which 5 are genuine, 6 are the
ForumViriumHelsinki generated-copy family (see the limitation below), and 1 is
two documents sharing a topic.

## Two constraints the issue did not list, both from measurement

**Ancestor constraint.** `scope_rank` is *depth*, not ancestry, so any deeper
scope outranks any shallower one — including unrelated repos. At `~/repos`:
69 pairs → 22, removing **zero** adjudicated candidates. 47 of the 69 were
cross-repo siblings.

**`MIN_PROMOTABLE_CHARS = 500`.** Ten of the 22 survivors were 11–128 byte
`@AGENTS.md` redirect stubs in a vendored clone, scoring 0.879–0.975 *against
each other*. 22 → 12; the smallest genuine candidate is 662 chars.

## What this PR deliberately does not ship

It originally carried a prose-phrase declaration detector and family
propagation. Measurement over both corpora:

| discriminator | claude-plugins | ~/repos |
|---|---|---|
| `structural_pair` (pre-existing) | 63 total, **1** ≥ T_PROMOTE | 1619 total, **16** ≥ T_PROMOTE |
| `_declares_up` (new) | 42 total, **0** | 60 total, **0** |
| family propagation (new) | 0 total, **0** | 32 total, **0** |

**Neither changed a single emitted finding at either root.** And `_declares_up`
bound to a *scope* rather than a document, so one sentence in
`offload-to-deterministic-substrate` exempted it from all 42 user-global rules —
dropping a genuine 0.93 candidate against an unrelated parent **and** recording
it as `HIERARCHIES_DECLARED=1`. A withheld-finding counter reporting a false
all-clear. Its motivating docstring example was also backwards on the data: two
of "the other three" `github-metadata-hygiene` pairs were already covered by
`structural_pair`, and the third declares pairwise.

Both are deleted. The finding set and both counters are **identical before and
after the cut at both roots**, which is the direct evidence they emitted
nothing.

**Known limitation, recorded rather than patched:** a hierarchy declared in a
*third* document is invisible, because `structural_pair` reads only the two
documents in the pair. The six `ForumViriumHelsinki/.github` pairs are exactly
that shape — declared in `ForumViriumHelsinki/CLAUDE.md` ("Workspace rules in
`.claude/rules/` are generated from the `.github` repo source"). Closing it
needs a third-document signal with its own calibration. It does not bite at the
shipping root.

## Design points

- **Same-name pairs are NOT skipped**, unlike `check_semantic_dupes` — a
  same-basename rule at two scopes is the canonical promotion shape.
- **Ties in `scope_rank` skip the pair** rather than emit a finding whose
  recommendation is undefined.
- **Severity `info`**, so `--gate` cannot fail CI on a suggestion.
- **`--sim-fixture`** injects precomputed similarity keyed by content hash, so
  the discriminator, scope ordering, tie handling, finding shape and the
  `--gate` interaction are all exercised in the **stdlib tier**. That is not
  cosmetic: `test-config-drift.sh` is in `required-to-run-tests.txt` where a
  SKIP is an ERROR, and numpy is absent from the system `python3`, so a test
  needing the real model would force that gate to skip on every runner.
- **`just config-drift-semantic`** gives the expensive tier a discoverable entry
  point.

## Evidence

| Check | Result |
|---|---|
| `test-config-drift.sh` | 190/0 (+33) |
| `test-probe-lib.sh` | 206/0 |
| Findings before/after the cut, both roots | identical set, identical counters |
| Mutation | 8 mutants, all killed |
| ruff / format / shellcheck / sandbox-guards | clean |

**Cheap tier unchanged, verified by control:** `origin/main`'s analyzer against
the same warm cache reports the identical `68/74`. The delta versus #2541's
recorded baseline is #2541's *own predicted finding*
(`claude-plugins/CLAUDE.md`, 130 days past `reviewed: 2026-04-21`) surfacing as
the gitdates cache warms — cache state, not code.

Two mutants survived earlier passes and are now pinned. A `scope_rank` tie: the
previous fixture placed both rules where the **ancestor constraint** rejected
them before the tie skip could run, so it asserted nothing. And `T_PROMOTE`
itself, which the suite bounded only to `[0.82, 0.93]` — fixtures at 0.87 and
0.89 now bracket it to its own value.
