### PR TITLE
fix(git-plugin): skip PR metadata check when the branch's only PR is closed

### DIFF
--- a/git-plugin/README.md
+++ b/git-plugin/README.md
@@ -118,7 +118,7 @@ The rule this plugin applies:
 | Hook | Event | Purpose |
 |------|-------|---------|
 | `validate-pr-issue-links.sh` | PreToolUse (Bash) | Enforce issue-closing links on PR creation |
-| `check-pr-metadata-on-push.sh` | PreToolUse (Bash) | Remind to align PR title/body with commits before push |
+| `check-pr-metadata-on-push.sh` | PreToolUse (Bash) | Remind to align PR title/body with commits before push. Fires only for an **`OPEN`** PR — a branch whose PR is `MERGED` or `CLOSED` pushes through, since finished metadata is a historical record |
 | `check-branch-sync-on-push.sh` | PreToolUse (Bash) | Nudge (`ask`) before `commit`/`push` when the branch is behind origin or its PR is merged/closed. Cached per session+branch; opt out with `CLAUDE_HOOKS_DISABLE_BRANCH_SYNC=1`, tune TTL with `CLAUDE_HOOKS_BRANCH_SYNC_TTL` |
 | `git-drift-probe.sh` | SessionStart | Surface `pr_merged` / `branch_behind` / `changes_requested` drift on the current branch via the consolidated drift nudge |
 

--- a/git-plugin/hooks/check-pr-metadata-on-push.sh
+++ b/git-plugin/hooks/check-pr-metadata-on-push.sh
@@ -109,11 +109,27 @@ PR_STATE=$(echo "$PR_JSON" | jq -r '.state // empty')
 # Guard: couldn't parse PR data
 if [ -z "$PR_NUMBER" ] || [ -z "$PR_TITLE" ]; then exit 0; fi
 
-# Guard: a merged PR's metadata is a historical record (issue #2351).
-# Prompting to reconcile it invites rewriting the description of something
-# already reviewed and landed. Read the `state` enum, never a `merged`
-# boolean — there is no such field (.claude/rules/gh-json-fields.md).
-if [ "$PR_STATE" = "MERGED" ]; then exit 0; fi
+# Guard: only an OPEN PR has metadata worth reconciling (issues #2351, #2545).
+#
+# `gh pr view <branch>` returns the most recent PR associated with the branch
+# *regardless of state*, so both finished states reach here:
+#
+#   MERGED (#2351) — the metadata is a historical record. Prompting to
+#     reconcile it invites rewriting the description of something already
+#     reviewed and landed.
+#   CLOSED (#2545) — a branch reused after its PR was closed is permanently
+#     tripped by that dead PR. Worse, the remedy this hook prescribes ("edit
+#     the PR title or body, THEN push") forces editing a closed PR's metadata
+#     purely to bump `updatedAt` past the new commit — the only escape, and
+#     one that vandalises a closed PR's record to unblock unrelated work.
+#
+# Enumerate the finished states rather than testing `!= OPEN`, so a response
+# with no `state` (an older gh, or a mocked/partial payload) keeps the legacy
+# blocking behaviour instead of failing open into a blanket allow.
+#
+# Read the `state` enum, never a `merged` boolean — there is no such field
+# (.claude/rules/gh-json-fields.md).
+if [ "$PR_STATE" = "MERGED" ] || [ "$PR_STATE" = "CLOSED" ]; then exit 0; fi
 
 # Resolve the ref to inspect for commits and bypass-timestamp comparison.
 # When the push command names a branch other than the running shell's

--- a/git-plugin/hooks/test-check-pr-metadata-on-push.sh
+++ b/git-plugin/hooks/test-check-pr-metadata-on-push.sh
@@ -358,6 +358,48 @@ PATH="$MOCK_BIN:$PATH" MOCK_PR_JSON="$MOCK_PR_JSON" \
     assert_exit "push to a branch whose PR is OPEN still blocks" 2 \
     "$(make_json "git push origin feature")"
 
+# ── Closed-unmerged PRs are equally finished (issue #2545) ────────────────
+# `gh pr view <branch>` returns the most recent PR on the branch regardless
+# of state, so a long-closed PR permanently trips the check on a branch that
+# is reused for later work. The remedy the block message prescribes — "edit
+# the PR title or body" — then forces editing a CLOSED PR's metadata purely
+# to bump its updatedAt, which is what the reporter had to do to unblock.
+#
+# The bypass is deliberately not what saves these: PR_PAST is older than the
+# branch's latest commit, i.e. the exact state that blocks a normal push, so
+# a passing test proves the state guard fired.
+echo ""
+echo "closed-unmerged PR metadata is not reconciled (#2545):"
+
+MOCK_PR_JSON=$(jq -n --arg t "$PR_PAST" \
+    '{number:364,title:"Release 2.3.0",body:"body",url:"https://example/364",updatedAt:$t,state:"CLOSED"}')
+PATH="$MOCK_BIN:$PATH" MOCK_PR_JSON="$MOCK_PR_JSON" \
+    assert_exit "push to a branch whose only PR is CLOSED is allowed (#2545)" 0 \
+    "$(make_json "git push origin feature")"
+
+# A branch reused after its PR closed: the colon-refspec deletion form the
+# reporter was blocked on must also pass (belt and braces with #2351).
+PATH="$MOCK_BIN:$PATH" MOCK_PR_JSON="$MOCK_PR_JSON" \
+    assert_exit "deleting a branch whose only PR is CLOSED is allowed (#2545)" 0 \
+    "$(make_json "git push origin :refs/heads/feature")"
+
+# Counter-test: an unrecognised state must not silently disable the hook.
+# Only MERGED/CLOSED are known-finished; anything else keeps blocking so a
+# future gh state enum cannot turn the guard into a blanket allow.
+MOCK_PR_JSON=$(jq -n --arg t "$PR_PAST" \
+    '{number:42,title:"feat: x",body:"body",url:"https://example/42",updatedAt:$t,state:"OPEN"}')
+PATH="$MOCK_BIN:$PATH" MOCK_PR_JSON="$MOCK_PR_JSON" \
+    assert_exit "OPEN PR still blocks after the CLOSED guard (#2545)" 2 \
+    "$(make_json "git push origin feature")"
+
+# Counter-test: a response with no state field at all keeps legacy blocking
+# behaviour rather than failing open.
+MOCK_PR_JSON=$(jq -n --arg t "$PR_PAST" \
+    '{number:42,title:"feat: x",body:"body",url:"https://example/42",updatedAt:$t}')
+PATH="$MOCK_BIN:$PATH" MOCK_PR_JSON="$MOCK_PR_JSON" \
+    assert_exit "absent state field still blocks (no fail-open) (#2545)" 2 \
+    "$(make_json "git push origin feature")"
+
 rm -rf "$MOCK_BIN"
 
 # ── Summary ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`check-pr-metadata-on-push.sh` blocked every push to a branch whose only PR was **`CLOSED`**.

`gh pr view <branch>` returns the most recent PR associated with a branch *regardless of state*, so a long-closed PR permanently tripped the check on any branch reused for later work. The hook already requested `state` and guarded `MERGED` (#2351), but left `CLOSED` unhandled.

The consequence was worse than a spurious block: the remedy the hook prescribes — *"edit the PR title or body, THEN push"* — was the **only** escape, so unblocking meant vandalising a closed PR's metadata purely to bump its `updatedAt` past the new commit. That is what the reporter had to do.

## Change

`git-plugin/hooks/check-pr-metadata-on-push.sh` — extend the finished-state guard to cover `CLOSED` alongside `MERGED`:

```sh
if [ "$PR_STATE" = "MERGED" ] || [ "$PR_STATE" = "CLOSED" ]; then exit 0; fi
```

Both states are enumerated deliberately rather than testing `!= OPEN`. A payload with **no** `state` field (an older `gh`, or a partial response) then keeps the legacy blocking behaviour instead of failing open into a blanket allow — four existing tests depend on that, and a fail-open guard would silently disable the hook on any future `gh` schema surprise.

Reads the `state` enum, never a `merged` boolean — there is no such field (`.claude/rules/gh-json-fields.md`).

The reporter's alternative suggestion (`gh pr list --head <b> --state open`) was not taken: it is a larger behavioural change to branch/fork resolution, where the state guard is a two-token diff on machinery already in place for #2351.

## Tests

Four regression cases added to `git-plugin/hooks/test-check-pr-metadata-on-push.sh` (`.claude/rules/regression-testing.md`):

| Case | Expect |
|---|---|
| Push to a branch whose only PR is `CLOSED` | allowed |
| Deleting a branch whose only PR is `CLOSED` | allowed |
| `OPEN` PR after the new guard | still blocks |
| Absent `state` field | still blocks (no fail-open) |

Each uses a PR whose `updatedAt` **predates** the branch's latest commit — the exact state that blocks a normal push — so a pass proves the state guard fired rather than the retry-aware bypass masking it.

```
$ bash git-plugin/hooks/test-check-pr-metadata-on-push.sh
Results: 37 passed, 0 failed, 0 skipped
```

Confirmed failing before the fix (`FAIL: push to a branch whose only PR is CLOSED is allowed (#2545)`, exit 2 vs 0) and passing after. `pre-commit run --files <changed>` is green, including `shellcheck` and the `shell-scripting.md` conventions guard; `scripts/lint-shell-scripts.sh` reports 0 errors.

## Docs

`git-plugin/README.md`'s hook table now states the hook fires only for an `OPEN` PR, landing with the code per `.claude/rules/docs-currency.md`.

Fixes #2545

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dm4cPXQcZpfbywfPjfX8F8)_