### PR TITLE
feat(evaluate-plugin): sum the always-loaded surface across repos (--also)

### DIFF
--- a/.claude/rules/context-engineering.md
+++ b/.claude/rules/context-engineering.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-07-26
-modified: 2026-07-26
-reviewed: 2026-07-26
+modified: 2026-08-31
+reviewed: 2026-08-31
 paths:
   - "**/SKILL.md"
   - "**/skills/**"
@@ -63,6 +63,24 @@ unscoped rule is the exception and should say why. If it reads as a procedure
 with a trigger ("when releasing", "before a destructive op"), it is a skill —
 promote it via `agent-patterns-plugin:meta-context-diet`.
 
+**`paths:` fires only when a matching file is EDITED — it cannot scope a rule
+whose hazard fires on a command.** This is the trap that decides most scoping
+calls, and getting it wrong silently disarms a guard while the budget number
+improves. Sort the rule by what triggers its failure, not by what it talks
+about:
+
+| The failure happens when you… | Lever | Example |
+|---|---|---|
+| edit a file of a known shape | `paths:` glob | zsh keybindings, `.gitattributes`, chezmoi naming prefixes |
+| run a command | **stays unscoped**, kept lean, detail in a linked doc | `chezmoi apply` deleting unmanaged files; `re-add` skipping templates |
+| act on intent ("diagnose CI", "release") | promote to a **skill** | `ai-review-max-turns`, `multirepo-ci-cd` |
+| any turn, unprompted | stays unscoped — it is a real invariant | never merge a stranger's PR |
+
+A rule that talks about chezmoi is not automatically edit-triggered: an apply
+that destroys data can touch no source file at all. When a single rule mixes
+both (dotfiles' 20 KB `chezmoi-conventions.md` did), **split it** along that
+line rather than scoping the whole thing.
+
 **Guidance lives in exactly one place, and the others name it.** Cross-plugin
 means a `plugin:skill` name reference, never a shared `REFERENCE.md`
 (`skill-consolidation.md`). If you catch yourself restating a table that another
@@ -110,9 +128,34 @@ Verify it against the installed Claude Code version before changing anything.
 | Layer | Mechanism |
 |---|---|
 | Measurement | `just lint-context-engineering` (Channel M, report-only) |
-| Ratchet | `check-context-engineering.py --strict` — **ERROR** when the always-loaded surface exceeds its budget. Pre-commit on `CLAUDE.md` / `.claude/rules/**`, plus CI |
+| Ratchet (this repo) | `check-context-engineering.py --strict` — **ERROR** when the always-loaded surface exceeds its budget. Pre-commit on `CLAUDE.md` / `.claude/rules/**`, plus CI |
+| Ratchet (portfolio) | `check-context-engineering.py --also <repo> --portfolio-budget N` — sums the C5 surface across repos. Run from the portfolio root: `just context-budget-strict` |
 | Audit | `/evaluate:context-engineering [target] --judge` |
 | Cadence | Re-run on each model release (`skill-evaluation.md` Tier 2 trigger) |
+
+### The per-repo budget cannot see what a session pays
+
+A repo's own C5 budget is blind to the cost of loading several repos side by
+side, which is what a portfolio session actually does. Measured 2026-08-31,
+before this rule's scoping pass: `claude-plugins` at 23% of its own 100,000-char
+budget, `dotfiles` and `repos-claude-config` with no gate at all, and a stacked
+surface of **180,021 chars (~45,000 tokens)** paid before the first user word.
+No single repo's ratchet could fire.
+
+`--also` closes that: it sums the C5 surface (CLAUDE.md + unscoped rules) across
+roots and gates the total. Only C5 aggregates — C1–C4 and C6 measure authoring
+quality inside one marketplace and stay scoped to `--project-dir`. The budget is
+a ratchet, so it is set just above the measured total (155,000 as of 2026-08-31,
+against 150,313) and lowered as scoping work lands; a generous default would
+make it decorative.
+
+Two properties keep the number trustworthy, both pinned by
+`tests/test-check-context-engineering.sh`: the breakdown is sorted by repo name
+so `--also` order cannot change the output, and the portfolio ERROR sorts ahead
+of every WARN so `--max-issues` can never truncate away the reason a run is red.
+The portfolio-root recipe **fails closed** when a repo is missing rather than
+measuring fewer of them — a short total passes the budget and reads exactly like
+a green run.
 
 The ratchet is the only hard gate. It exists so the every-session surface cannot
 grow back silently — the failure mode that produced a 1.67 on C5 in the first

--- a/evaluate-plugin/skills/evaluate-context-engineering/SKILL.md
+++ b/evaluate-plugin/skills/evaluate-context-engineering/SKILL.md
@@ -79,8 +79,16 @@ python3 "${CLAUDE_SKILL_DIR}/scripts/check-context-engineering.py" --top 10
 Add `--target <plugin-or-skill-path>` when the user scoped the run, and
 `--always-loaded-budget <N>` when they passed `--budget`.
 
-Read the `KEY=VALUE` block. `STATUS=ERROR` means only one thing: the
-always-loaded surface is over budget. Every other finding is a `WARN` candidate,
+When the user asks about the cost of a **session that loads several repos**
+(a portfolio checkout, sibling repos open together), add one `--also <repo>`
+per extra root plus `--portfolio-budget <N>`. Only the C5 surface is summed;
+C1–C4 and C6 stay scoped to `--project-dir`, since they measure authoring
+quality inside one marketplace. `--also` and `--target` are mutually exclusive.
+
+Read the `KEY=VALUE` block. `STATUS=ERROR` means only one thing: an
+always-loaded surface is over budget — the primary repo's, or the portfolio's
+(`C5_PORTFOLIO_*`, with a per-repo `C5_PORTFOLIO_BREAKDOWN`). ERRORs are always
+listed first, so `--max-issues` never hides the reason. Every other finding is a `WARN` candidate,
 not a verdict.
 
 ### Step 2: Report the C1–C6 card
@@ -137,6 +145,7 @@ files. This skill measures and recommends; it does not rewrite.
 | One plugin | `... --target git-plugin` |
 | Machine-readable | `... --json` |
 | CI ratchet (exit 1 over budget) | `... --strict` |
+| Portfolio budget across repos | `... --also ../dotfiles --also ../repos-claude-config --portfolio-budget 155000` |
 | Full issue list | `... --max-issues 0` |
 | Determinism check | `... --json \| sha256sum` (must be stable across runs) |
 

--- a/evaluate-plugin/skills/evaluate-context-engineering/scripts/check-context-engineering.py
+++ b/evaluate-plugin/skills/evaluate-context-engineering/scripts/check-context-engineering.py
@@ -35,6 +35,20 @@ Output: structured KEY=VALUE per .claude/rules/structured-script-output.md.
   --always-loaded-budget N   chars; ERROR above it (default 100000). The ratchet
                              that stops the every-session surface growing.
   --project-dir PATH         repo root (default: this script's parent)
+  --also PATH                extra repo root whose always-loaded (C5) surface
+                             counts toward one shared budget. Repeatable.
+  --portfolio-budget N       chars; ERROR when the summed C5 surface across
+                             --project-dir + every --also exceeds it.
+
+WHY --also EXISTS
+A per-repo C5 budget cannot see the cost a *session* actually pays. When one
+session loads several repos side by side, each repo can sit well inside its own
+budget while the stacked always-loaded surface is several times either. --also
+sums the surfaces so the portfolio total is gated by something.
+
+Only the C5 surface is summed. Skill-level dimensions (C1-C4, C6) stay scoped
+to --project-dir: they measure authoring quality inside one marketplace, which
+does not aggregate meaningfully across unrelated repos.
 """
 
 from __future__ import annotations
@@ -321,6 +335,39 @@ def analyse_rule(root: str, rel: str) -> dict:
     }
 
 
+def always_loaded_surface(root: str) -> dict:
+    """C5 surface for one repo root: CLAUDE.md + every rule with no `paths:`.
+
+    Deliberately does NOT call discover(): that walks the whole tree for
+    SKILL.md files, and an --also root may contain large unrelated checkouts
+    (vendored clones, archives). Only .claude/rules/ and CLAUDE.md are read.
+
+    Repo identity is the basename, never the absolute path — the determinism
+    contract forbids absolute paths in output.
+    """
+    rules_dir = os.path.join(root, ".claude", "rules")
+    rel_rules = sorted(
+        os.path.relpath(os.path.join(rules_dir, f), root)
+        for f in (os.listdir(rules_dir) if os.path.isdir(rules_dir) else [])
+        if f.endswith(".md")
+    )
+    rules = [analyse_rule(root, p) for p in rel_rules]
+    unscoped = [r for r in rules if not r["path_scoped"]]
+    claude_md = os.path.join(root, "CLAUDE.md")
+    claude_md_chars = len(read_text(claude_md)) if os.path.isfile(claude_md) else 0
+    unscoped_chars = sum(r["chars"] for r in unscoped)
+    total = claude_md_chars + unscoped_chars
+    return {
+        "repo": os.path.basename(os.path.normpath(root)),
+        "claude_md_chars": claude_md_chars,
+        "rules_total": len(rules),
+        "unscoped_rules": len(unscoped),
+        "unscoped_rule_chars": unscoped_chars,
+        "always_loaded_chars": total,
+        "always_loaded_est_tokens": total // 4,
+    }
+
+
 # ------------------------------------------------------- C4 shingle overlap
 
 
@@ -383,6 +430,28 @@ def overlap_pairs(units: dict[str, set[int]]) -> tuple[list[dict], int]:
 
 
 # ------------------------------------------------------------------- reporting
+
+
+def portfolio_issues(portfolio: dict | None) -> list[dict]:
+    """ERROR when the stacked C5 surface exceeds the portfolio budget."""
+    if not portfolio or portfolio["always_loaded_chars"] <= portfolio["budget"]:
+        return []
+    repos = ", ".join(
+        f"{r['repo']}={r['always_loaded_chars']}" for r in portfolio["repos"]
+    )
+    return [
+        {
+            "severity": "ERROR",
+            "dim": "C5",
+            "type": "portfolio_always_loaded_over_budget",
+            "unit": "portfolio",
+            "msg": (
+                f"stacked always-loaded surface {portfolio['always_loaded_chars']} chars "
+                f"across {len(portfolio['repos'])} repos exceeds budget "
+                f"{portfolio['budget']} ({repos})"
+            ),
+        }
+    ]
 
 
 def build_issues(
@@ -543,6 +612,21 @@ def emit_text(data: dict, n_top: int, max_issues: int) -> None:
     out(f"C5_ALWAYS_LOADED_EST_TOKENS={t['c5_always_loaded_est_tokens']}\n")
     out(f"C5_ALWAYS_LOADED_BUDGET={t['c5_always_loaded_budget']}\n")
 
+    pf = data.get("portfolio")
+    if pf:
+        out(f"C5_PORTFOLIO_REPOS={len(pf['repos'])}\n")
+        out(f"C5_PORTFOLIO_ALWAYS_LOADED_CHARS={pf['always_loaded_chars']}\n")
+        out(f"C5_PORTFOLIO_ALWAYS_LOADED_EST_TOKENS={pf['always_loaded_est_tokens']}\n")
+        out(f"C5_PORTFOLIO_BUDGET={pf['budget']}\n")
+        out("C5_PORTFOLIO_BREAKDOWN:\n")
+        for r in pf["repos"]:
+            out(
+                f"  - REPO={r['repo']} CHARS={r['always_loaded_chars']}"
+                f" EST_TOKENS={r['always_loaded_est_tokens']}"
+                f" CLAUDE_MD_CHARS={r['claude_md_chars']}"
+                f" UNSCOPED_RULES={r['unscoped_rules']}/{r['rules_total']}\n"
+            )
+
     out(f"C6_SKILLS_WITH_SCRIPTS={t['c6_skills_with_scripts']}\n")
     out(f"C6_PROSE_PROCEDURE_NO_SCRIPT={t['c6_prose_procedure_no_script']}\n")
 
@@ -614,7 +698,27 @@ def main() -> int:
     ap.add_argument("--top", type=int, default=10)
     ap.add_argument("--max-issues", type=int, default=40, help="0 = no cap")
     ap.add_argument("--always-loaded-budget", type=int, default=100_000)
+    ap.add_argument(
+        "--also",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="extra repo root whose C5 surface counts toward the portfolio budget",
+    )
+    ap.add_argument(
+        "--portfolio-budget",
+        type=int,
+        default=None,
+        help="chars; default n_repos * --always-loaded-budget. A real ratchet "
+        "passes an explicit value measured just above current.",
+    )
     args = ap.parse_args()
+
+    if args.also and args.target:
+        ap.error(
+            "--also and --target are mutually exclusive: --target drops "
+            "rules and CLAUDE.md, which is the whole C5 surface"
+        )
 
     root = os.path.abspath(args.project_dir)
     skill_paths, rule_paths, claude_md = discover(root, args.target)
@@ -652,7 +756,48 @@ def main() -> int:
             "pct": round(100 * chars / total_body, 1) if total_body else 0.0,
         }
 
+    portfolio = None
+    if args.also:
+        also_roots = []
+        for path in args.also:
+            ap_root = os.path.abspath(path)
+            if not os.path.isdir(ap_root):
+                sys.exit(f"--also: not a directory: {path}")
+            also_roots.append(ap_root)
+        # Sorted so two runs over an unchanged set are byte-identical regardless
+        # of the order --also was passed in. Basename alone is not a safe key:
+        # two checkouts can share one (~/a/config and ~/b/config), and a stable
+        # sort would then fall back to argument order. Tie-breaking on every
+        # emitted field means entries that still tie are byte-identical, so the
+        # output cannot depend on argument order either way.
+        repos = sorted(
+            [always_loaded_surface(r) for r in [root, *also_roots]],
+            key=lambda r: (
+                r["repo"],
+                r["always_loaded_chars"],
+                r["claude_md_chars"],
+                r["rules_total"],
+                r["unscoped_rules"],
+                r["unscoped_rule_chars"],
+            ),
+        )
+        chars = sum(r["always_loaded_chars"] for r in repos)
+        portfolio = {
+            "repos": repos,
+            "always_loaded_chars": chars,
+            "always_loaded_est_tokens": chars // 4,
+            "budget": (
+                args.portfolio_budget
+                if args.portfolio_budget is not None
+                else len(repos) * args.always_loaded_budget
+            ),
+        }
+
     issues = build_issues(skills, rules, always_loaded, args.always_loaded_budget)
+    issues += portfolio_issues(portfolio)
+    # ERRORs first so --max-issues can never truncate the reason STATUS is ERROR.
+    # Stable, so within-severity order (and the determinism contract) is intact.
+    issues.sort(key=lambda i: i["severity"] != "ERROR")
     status = (
         "ERROR"
         if any(i["severity"] == "ERROR" for i in issues)
@@ -662,6 +807,7 @@ def main() -> int:
     data = {
         "schema_version": SCHEMA_VERSION,
         "status": status,
+        "portfolio": portfolio,
         "totals": {
             "skill_count": len(skills),
             # Published marketplace skills, excluding repo-local `.claude/skills/*`.

--- a/evaluate-plugin/skills/evaluate-context-engineering/scripts/tests/test-check-context-engineering.sh
+++ b/evaluate-plugin/skills/evaluate-context-engineering/scripts/tests/test-check-context-engineering.sh
@@ -224,5 +224,103 @@ assert "default project-dir finds the repo root from CWD" "$(value_of "$default_
 target_out="$("$scanner" --project-dir "$fixture" --target demo-plugin/skills/lean-skill 2>&1)"
 assert "--target scopes to one skill" "$(value_of "$target_out" SKILL_COUNT)" "1"
 
+# --- portfolio C5 budget (--also) --------------------------------------------
+# A per-repo budget cannot see what a session that loads several repos side by
+# side actually pays: each repo sits inside its own budget while the stacked
+# surface is several times either. Guards the aggregation, the gate, and the
+# two properties that make the number trustworthy — order-independence and
+# ERROR visibility.
+
+fixture2="$(mktemp -d)"
+[ -n "$fixture2" ] || { echo "FAIL: mktemp -d returned empty" >&2; exit 1; }
+trap 'rm -rf "$fixture" "$fixture2"' EXIT
+mkdir -p "$fixture2/.claude/rules"
+printf 'y%.0s' $(seq 1 300) >"$fixture2/CLAUDE.md"
+printf 'z%.0s' $(seq 1 200) >"$fixture2/.claude/rules/second-unscoped.md"
+# A scoped rule in the second repo must NOT count toward the portfolio total.
+cat >"$fixture2/.claude/rules/second-scoped.md" <<'RULE_EOF'
+---
+paths:
+  - "**/*.ts"
+---
+# Scoped — excluded from the always-loaded surface.
+RULE_EOF
+
+pf_out="$("$scanner" --project-dir "$fixture" --also "$fixture2" --max-issues 0 2>&1)"
+primary_c5="$(value_of "$out" C5_ALWAYS_LOADED_CHARS)"
+assert "portfolio counts both repos" "$(value_of "$pf_out" C5_PORTFOLIO_REPOS)" "2"
+assert "portfolio sums the two surfaces" \
+  "$(value_of "$pf_out" C5_PORTFOLIO_ALWAYS_LOADED_CHARS)" "$((primary_c5 + 500))"
+assert_true "portfolio emits a per-repo breakdown line for the --also repo" \
+  "$(printf '%s' "$pf_out" | grep -qE "^  - REPO=$(basename "$fixture2") CHARS=500 " && echo true || echo false)"
+
+# Order-independence: the determinism contract must survive --also being passed
+# in any order, or two CI runs of an unchanged tree disagree. Needs a THIRD repo
+# so there are two --also args to actually swap.
+fixture3="$(mktemp -d)"
+[ -n "$fixture3" ] || { echo "FAIL: mktemp -d returned empty" >&2; exit 1; }
+trap 'rm -rf "$fixture" "$fixture2" "$fixture3"' EXIT
+mkdir -p "$fixture3/.claude/rules"
+printf 'w%.0s' $(seq 1 100) >"$fixture3/CLAUDE.md"
+
+pf_hash_a="$("$scanner" --project-dir "$fixture" --also "$fixture2" --also "$fixture3" --json | sha256sum | cut -d' ' -f1)"
+pf_hash_b="$("$scanner" --project-dir "$fixture" --also "$fixture3" --also "$fixture2" --json | sha256sum | cut -d' ' -f1)"
+assert "portfolio JSON is identical when --also order is swapped" "$pf_hash_a" "$pf_hash_b"
+pf_hash_c="$("$scanner" --project-dir "$fixture" --also "$fixture2" --also "$fixture3" --json | sha256sum | cut -d' ' -f1)"
+assert "portfolio JSON is stable across runs" "$pf_hash_a" "$pf_hash_c"
+
+# Two --also roots sharing a basename must still sort deterministically: a
+# stable sort keyed on the name alone would fall back to argument order, which
+# is exactly the non-determinism this scanner exists to rule out.
+dup_a="$(mktemp -d)/config"; dup_b="$(mktemp -d)/config"
+mkdir -p "$dup_a/.claude/rules" "$dup_b/.claude/rules"
+printf 'a%.0s' $(seq 1 100) >"$dup_a/CLAUDE.md"
+printf 'b%.0s' $(seq 1 900) >"$dup_b/CLAUDE.md"
+dup_hash_a="$("$scanner" --project-dir "$fixture" --also "$dup_a" --also "$dup_b" --json | sha256sum | cut -d' ' -f1)"
+dup_hash_b="$("$scanner" --project-dir "$fixture" --also "$dup_b" --also "$dup_a" --json | sha256sum | cut -d' ' -f1)"
+assert "same-basename roots sort deterministically" "$dup_hash_a" "$dup_hash_b"
+rm -rf "$dup_a" "$dup_b"
+
+# The breakdown is sorted by repo name, so the emitted order is independent of
+# the order the roots were supplied in.
+sorted_repos="$("$scanner" --project-dir "$fixture" --also "$fixture3" --also "$fixture2" 2>&1 \
+  | grep -oE '^  - REPO=[^ ]+' | sed 's/^  - REPO=//')"
+assert "breakdown is emitted in repo-name order" \
+  "$sorted_repos" "$(printf '%s\n' "$sorted_repos" | sort)"
+
+# The gate itself.
+"$scanner" --project-dir "$fixture" --also "$fixture2" --portfolio-budget 10 --strict >/dev/null 2>&1
+assert "--strict exits 1 over the portfolio budget" "$?" "1"
+"$scanner" --project-dir "$fixture" --also "$fixture2" --portfolio-budget 999999 --strict >/dev/null 2>&1
+assert "--strict exits 0 under the portfolio budget" "$?" "0"
+
+# A repo inside its OWN budget can still bust the portfolio budget — the whole
+# reason this mode exists. Primary budget generous, portfolio budget tight.
+split_out="$("$scanner" --project-dir "$fixture" --also "$fixture2" \
+  --always-loaded-budget 999999 --portfolio-budget 10 --max-issues 0 2>&1)"
+assert "per-repo pass + portfolio fail yields ERROR" "$(value_of "$split_out" STATUS)" "ERROR"
+assert_true "portfolio ERROR names the offending repos" \
+  "$(printf '%s' "$split_out" | grep -qE 'TYPE=portfolio_always_loaded_over_budget.*'"$(basename "$fixture2")"'=500' && echo true || echo false)"
+
+# ERROR must outrank WARNs in the listing: --max-issues could otherwise truncate
+# away the only line explaining why STATUS=ERROR.
+trunc_out="$("$scanner" --project-dir "$fixture" --also "$fixture2" --portfolio-budget 10 --max-issues 1 2>&1)"
+assert_true "ERROR is listed first, never truncated by --max-issues" \
+  "$(printf '%s' "$trunc_out" | grep -A1 '^ISSUES:' | grep -qE 'SEVERITY=ERROR.*portfolio_always_loaded_over_budget' && echo true || echo false)"
+
+# --also and --target are mutually exclusive: --target drops rules and CLAUDE.md,
+# which is the entire C5 surface, so the portfolio total would silently be wrong.
+"$scanner" --project-dir "$fixture" --also "$fixture2" --target demo-plugin/skills/lean-skill >/dev/null 2>&1
+assert "--also with --target is rejected" "$?" "2"
+
+# A non-existent --also root must fail loudly, not silently contribute 0.
+"$scanner" --project-dir "$fixture" --also "$fixture/definitely-not-here" >/dev/null 2>&1
+assert "--also on a missing path exits 1" "$?" "1"
+
+# Without --also the portfolio keys must be absent entirely (no behaviour change
+# for every existing caller).
+assert_true "no --also means no portfolio keys" \
+  "$(printf '%s' "$out" | grep -qE '^C5_PORTFOLIO' && echo false || echo true)"
+
 echo "PASS=$pass_count FAIL=$fail_count"
 [ "$fail_count" -eq 0 ]


### PR DESCRIPTION
## The gap

A per-repo C5 budget cannot see the cost a **session** actually pays. Measured 2026-08-31 across the three Claude-config repos:

| Repo | Always-loaded | Own gate |
|---|---|---|
| claude-plugins | ~23.0k tok | ✅ at **23%** of its 100,000-char budget |
| repos-claude-config | ~12.8k tok | ❌ none |
| dotfiles | ~9.2k tok | ❌ none |
| **stacked** | **~45.0k tok** | **nothing could fire** |

The every-session surface this dimension exists to bound was growing in the one place nothing measured. `--also` closes that.

## What it does

`--also PATH` (repeatable) sums the C5 surface — `CLAUDE.md` + rules with no `paths:` glob — across roots and gates the total with `--portfolio-budget`. Emits `C5_PORTFOLIO_*` plus a per-repo `C5_PORTFOLIO_BREAKDOWN`.

Only C5 aggregates. C1–C4 and C6 measure authoring quality inside one marketplace and stay scoped to `--project-dir`; summing them across unrelated repos would be meaningless.

Without `--also`, output is byte-identical to before — the portfolio keys are absent entirely, which is asserted.

## Three properties that keep the number trustworthy

Each is pinned by an executable test, and each test was **control-tested** — I broke the behaviour and confirmed the assertion fails, so none of them is a test that passes for the wrong reason.

1. **The breakdown sorts on every emitted field, not on the repo basename.** Two checkouts can share a basename (`~/a/config`, `~/b/config`), and a stable sort keyed on the name alone falls back to argument order — non-determinism in the one script whose headline contract is that two runs over an unchanged tree are byte-identical. I introduced this defect in the first pass and caught it re-reading the diff; it is fixed and tested.
2. **The portfolio ERROR sorts ahead of every WARN.** Otherwise `--max-issues 40` truncates away the only line explaining why `STATUS=ERROR` — a red run with no visible cause.
3. **`--also` and `--target` are rejected together.** `--target` drops rules and `CLAUDE.md`, which is the *entire* C5 surface, so the total would be silently wrong rather than absent.

`always_loaded_surface()` deliberately does not call `discover()`: that walks the tree for `SKILL.md`, and an `--also` root may contain large unrelated checkouts (the portfolio root has `external/`).

## The rule change

`context-engineering.md` gains the distinction that decided the scoping work in the sibling repos:

> **`paths:` fires only when a matching file is EDITED — it cannot scope a rule whose hazard fires on a command.**

Getting that backwards silently disarms a guard while the budget number improves. The rule now sorts candidates by *what triggers the failure* — edit / command / intent / every turn — and says to split a rule that mixes them, which is what the companion dotfiles PR does to a 20 KB `chezmoi-conventions.md` whose apply-time hazards can fire without touching any source file.

## Verification

- `tests/test-check-context-engineering.sh`: **42 pass, 0 fail** (was 24 — 18 new assertions).
- `run-skill-script-tests.sh --only '*evaluate-context-engineering*'`: `STATUS=OK`, discovered and passed.
- Full suite exits 0 (5 pre-existing `required_test_skipped` ERRORs from tools absent in this sandbox: ast-grep, cargo-generate, task CLI — unrelated to this change).
- `ruff check` + `ruff format --check` clean; this repo's own C5 ratchet still exits 0.

Companion PRs: laurigates/dotfiles#392 (scoping + the chezmoi split), laurigates/repos-claude-config#35 (the `just context-budget` wiring, which consumes these flags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rTMFif8HeRJqG8yX85Su6

---
_Generated by [Claude Code](https://claude.ai/code/session_016rTMFif8HeRJqG8yX85Su6)_