### PR TITLE
docs(readme): point questions and ideas at Discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,18 @@ consumer repo: [`dotfiles/docs/justfile-architecture.md`](https://github.com/lau
 Justfile authoring/auditing for both repos is governed by this marketplace's
 `tools-plugin:justfile-expert` and `configure-plugin:configure-justfile`.
 
+## Questions and Ideas
+
+[Discussions](https://github.com/laurigates/claude-plugins/discussions) is the place to ask things in the open:
+
+| Category | For |
+|----------|-----|
+| [Q&A](https://github.com/laurigates/claude-plugins/discussions/categories/q-a) | How do I do X, why does a skill behave this way, is Z supported |
+| [Ideas](https://github.com/laurigates/claude-plugins/discussions/categories/ideas) | A plugin or skill you would like to exist, before it is a concrete request |
+| [Show and tell](https://github.com/laurigates/claude-plugins/discussions/categories/show-and-tell) | What you built with these plugins |
+
+Use [issues](https://github.com/laurigates/claude-plugins/issues) for a defect or a concrete feature request, and please do not open a pull request just to ask a question.
+
 ## Development
 
 Plugins use [release-please](https://github.com/googleapis/release-please) for automated versioning. Use conventional commits to trigger releases:


### PR DESCRIPTION
## What

Adds a **Questions and Ideas** section to `README.md`, between the ecosystem diagram and the development notes, naming the three Discussions categories in use and what each is for.

## Why

Discussions is enabled on this repo, but nothing in the README linked to it, so a reader could only see two ways to make contact: open an issue, or email. Both have happened, and one person opened a pull request to ask a question rather than to propose a change.

An empty Discussions tab that nothing points at reads as a feature somebody switched on and abandoned. A link from the README is what turns it into a channel.

## How

A short table mapping category to purpose, plus one line separating it from the issue tracker: issues stay for defects and concrete feature requests.

All four links were checked and return 200. The category slugs (`q-a`, `ideas`, `show-and-tell`) come from the repository's own GraphQL `discussionCategories` response, not from guessing the URL shape.

The Terraform side is laurigates/gitops#269, which pins `has_discussions = true` so an apply cannot silently turn the tab off and leave these links pointing at a 404. The org-wide `SUPPORT.md` routing is laurigates/.github#53.

Refs laurigates/gitops#269

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBUBSLB4DHAAumFzfZT56Y
