### PR TITLE
fix(evaluate-plugin): make context-engineering ordering test deterministic

### DIFF
--- a/evaluate-plugin/skills/evaluate-context-engineering/scripts/tests/test-check-context-engineering.sh
+++ b/evaluate-plugin/skills/evaluate-context-engineering/scripts/tests/test-check-context-engineering.sh
@@ -59,10 +59,26 @@ value_of() {
 # target the real shared .git instead of the throwaway dir.
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR GIT_NAMESPACE GIT_PREFIX
 
-fixture="$(mktemp -d)"
+# One throwaway parent; every sandbox repo below it carries a DETERMINISTIC,
+# legible basename. The scanner sorts the portfolio breakdown by repo name, so
+# random `mktemp -d` basenames made both the ordering assertion's outcome and
+# its failure message depend on three random suffixes (#2563). The parent stays
+# unique so concurrent runs cannot collide.
+sandbox="$(mktemp -d)"
 # Guard the empty-mktemp vector (#1692): `git -C ""` falls back to the CWD.
-[ -n "$fixture" ] || { echo "FAIL: mktemp -d returned empty" >&2; exit 1; }
-trap 'rm -rf "$fixture"' EXIT
+[ -n "$sandbox" ] || { echo "FAIL: mktemp -d returned empty" >&2; exit 1; }
+[ -d "$sandbox" ] || { echo "FAIL: mktemp -d dir missing" >&2; exit 1; }
+trap 'rm -rf "$sandbox"' EXIT
+
+# The three portfolio roots straddle the ASCII case boundary ON PURPOSE:
+# byte order is 'B' (0x42) < 'a' (0x61) < 'g' (0x67), while a case-insensitive
+# collation orders them alpha < Beta < gamma. Any comparison that is not byte
+# order therefore yields a different sequence on EVERY run, rather than only
+# when three random suffixes happen to straddle.
+fixture="$sandbox/alpha-primary"
+fixture2="$sandbox/Beta-secondary"
+fixture3="$sandbox/gamma-tertiary"
+mkdir -p "$fixture"
 
 # --- fixture: two skills and two rules with deliberately known properties ----
 
@@ -231,9 +247,6 @@ assert "--target scopes to one skill" "$(value_of "$target_out" SKILL_COUNT)" "1
 # two properties that make the number trustworthy — order-independence and
 # ERROR visibility.
 
-fixture2="$(mktemp -d)"
-[ -n "$fixture2" ] || { echo "FAIL: mktemp -d returned empty" >&2; exit 1; }
-trap 'rm -rf "$fixture" "$fixture2"' EXIT
 mkdir -p "$fixture2/.claude/rules"
 printf 'y%.0s' $(seq 1 300) >"$fixture2/CLAUDE.md"
 printf 'z%.0s' $(seq 1 200) >"$fixture2/.claude/rules/second-unscoped.md"
@@ -257,9 +270,6 @@ assert_true "portfolio emits a per-repo breakdown line for the --also repo" \
 # Order-independence: the determinism contract must survive --also being passed
 # in any order, or two CI runs of an unchanged tree disagree. Needs a THIRD repo
 # so there are two --also args to actually swap.
-fixture3="$(mktemp -d)"
-[ -n "$fixture3" ] || { echo "FAIL: mktemp -d returned empty" >&2; exit 1; }
-trap 'rm -rf "$fixture" "$fixture2" "$fixture3"' EXIT
 mkdir -p "$fixture3/.claude/rules"
 printf 'w%.0s' $(seq 1 100) >"$fixture3/CLAUDE.md"
 
@@ -272,13 +282,7 @@ assert "portfolio JSON is stable across runs" "$pf_hash_a" "$pf_hash_c"
 # Two --also roots sharing a basename must still sort deterministically: a
 # stable sort keyed on the name alone would fall back to argument order, which
 # is exactly the non-determinism this scanner exists to rule out.
-dup_root_a="$(mktemp -d)" || { echo 'FATAL: mktemp failed' >&2; exit 1; }
-[ -n "$dup_root_a" ] || { echo 'FATAL: empty mktemp dir' >&2; exit 1; }
-[ -d "$dup_root_a" ] || { echo 'FATAL: mktemp dir missing' >&2; exit 1; }
-dup_root_b="$(mktemp -d)" || { echo 'FATAL: mktemp failed' >&2; exit 1; }
-[ -n "$dup_root_b" ] || { echo 'FATAL: empty mktemp dir' >&2; exit 1; }
-[ -d "$dup_root_b" ] || { echo 'FATAL: mktemp dir missing' >&2; exit 1; }
-dup_a="$dup_root_a/config"; dup_b="$dup_root_b/config"
+dup_a="$sandbox/dup-parent-a/config"; dup_b="$sandbox/dup-parent-b/config"
 mkdir -p "$dup_a/.claude/rules" "$dup_b/.claude/rules"
 printf 'a%.0s' $(seq 1 100) >"$dup_a/CLAUDE.md"
 printf 'b%.0s' $(seq 1 900) >"$dup_b/CLAUDE.md"
@@ -288,11 +292,21 @@ assert "same-basename roots sort deterministically" "$dup_hash_a" "$dup_hash_b"
 rm -rf "$dup_a" "$dup_b"
 
 # The breakdown is sorted by repo name, so the emitted order is independent of
-# the order the roots were supplied in.
+# the order the roots were supplied in. The roots are passed here in a THIRD
+# order (primary, gamma, Beta) that matches neither the expected sequence nor
+# its reverse, so a scanner that dropped the sort and fell back to argument
+# order fails this.
+#
+# The expectation is the literal byte-ordered sequence, not `printf … | sort`
+# (#2563): the scanner compares Python strings, i.e. by code point, while the
+# shell's `sort` collates per the ambient locale — case-insensitively under
+# en_US.UTF-8 / macOS. The two disagree on exactly the case-straddling names
+# above ('B' 0x42 < 'a' 0x61), so the old self-referential expectation failed
+# roughly half of all runs, depending only on the random `mktemp` suffixes.
 sorted_repos="$("$scanner" --project-dir "$fixture" --also "$fixture3" --also "$fixture2" 2>&1 \
   | grep -oE '^  - REPO=[^ ]+' | sed 's/^  - REPO=//')"
 assert "breakdown is emitted in repo-name order" \
-  "$sorted_repos" "$(printf '%s\n' "$sorted_repos" | sort)"
+  "$sorted_repos" "$(printf '%s\n' "$(basename "$fixture2")" "$(basename "$fixture")" "$(basename "$fixture3")")"
 
 # The gate itself.
 "$scanner" --project-dir "$fixture" --also "$fixture2" --portfolio-budget 10 --strict >/dev/null 2>&1


### PR DESCRIPTION
The *"breakdown is emitted in repo-name order"* case in `test-check-context-engineering.sh` failed roughly half of all runs on clean `main`, independent of any change.

## Cause

The scanner sorts the portfolio breakdown with Python's `sorted()`, which compares by **code point** (`B` 0x42 < `a` 0x61). The test built its expectation by piping the scanner's own output back through the shell's `sort`, which collates per the **ambient locale** — case-insensitive under `en_US.UTF-8`/macOS. The names being compared were `mktemp -d` basenames, i.e. random, so the two orderings agreed only when the suffixes happened not to straddle a case boundary.

**The scanner was always right; the expectation was wrong.** The scanner is untouched by this PR.

## Fix

Both remedies the issue proposes, since they address different halves:

- **Deterministic basenames.** One `mktemp -d` parent (so concurrent runs still cannot collide) holding `alpha-primary`, `Beta-secondary`, `gamma-tertiary`. They straddle the case boundary deliberately, so a non-byte-order comparison now diverges on *every* run rather than half of them — and a failure names something meaningful instead of three random `tmp.*` strings. Collapsing five `mktemp -d` calls into one also removed four duplicated `#1692` guard blocks and three overlapping `trap`s.
- **Locale-independent expectation.** The expected sequence is written out in byte order rather than derived from the scanner's own output via `| sort`, so it depends on neither `sort` nor the locale.

## Verification

- **20/20** `PASS=42 FAIL=0` under the ambient collation, and **20/20** again under a case-insensitive `sort` shim.
- **The assertion still bites**, confirmed by two mutations (both reverted; scanner byte-identical afterwards):
  - drop the sort, so output follows argument order → `PASS=39 FAIL=3`
  - `key=r["repo"].lower()` → `PASS=41 FAIL=1` — this is precisely the regression the *old* expectation would have blessed under a case-insensitive locale
- The sandbox roots are passed in a third order matching neither the expected sequence nor its reverse, so an argument-order fallback cannot coincidentally pass.
- `just lint-shell`: 0 errors (9 pre-existing warnings, all in `macos-plugin`). `pre-commit run --files <path>`: exit 0, including the `#1692` mktemp-guard and shellcheck hooks.

## One note for review

This container's locale is `POSIX` and `locale -a` offers only `C`/`C.utf8`, so **the flake cannot reproduce here natively** — a naive 20-run loop would have passed against the unfixed code. (`LC_ALL=en_US.UTF-8` silently falls back to C rather than erroring, which is its own trap.) The failure was therefore reproduced deterministically two ways: case-straddling fixture names, and a `sort -f` shim simulating the reporter's collation. The shim reproduces the issue's exact `want` ordering for the original three `tmp.*` names.

The consequence worth carrying forward: because the runner's locale decides whether this class of bug is observable at all, a green CI run on the old code was never evidence of correctness. The new assertion is locale-independent, so that gap is closed rather than papered over.

Fixes #2563

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3qqVxAZrwT2faQo6KJTPe

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3qqVxAZrwT2faQo6KJTPe)_