### PR TITLE
fix(hooks-plugin): name the external-job case in the calendar-estimate nudge

### DIFF
--- a/hooks-plugin/README.md
+++ b/hooks-plugin/README.md
@@ -288,6 +288,8 @@ Documentation files (`*.md`, `*.mdx`, `*.rst`, `*.txt`) and vendor/generated pat
 
 A Stop hook that nudges the agent to restate work in tokens, effort tier (low/medium/high/xhigh/max), tool-call count, or files/lines to touch rather than human calendar time (hours, days, weeks, months). AI work doesn't map to human time units; quoting calendar estimates is consistently misleading. It deliberately does not ask for a remaining-context figure — the model cannot measure it, and prompting it to think about its remaining budget invites context anxiety.
 
+The message carries a second branch for **external machine work the agent measured rather than paced** — a CI run, a build, a model download, a render, a long test suite. That quantity is wall-clock by nature (a property of the hardware, not of the agent), and none of the effort units can express it, so the nudge asks for rate × quantity with the measurement named (`3870 frames at a measured 1.0 s/frame, so about 65 minutes`) instead of a unit swap. The matcher is deliberately **not** narrowed to skip measured rates — it still fires there, and the message says how to phrase it honestly (#2574).
+
 | Aspect | Detail |
 |--------|--------|
 | Type | `command` (deterministic regex on the last assistant message) |
@@ -296,7 +298,7 @@ A Stop hook that nudges the agent to restate work in tokens, effort tier (low/me
 | Detection | Future-modal + estimation verb + number + time unit (`will/would/should/'ll … take/require/need … N minutes/hours/…`); explicit markers (`ETA`, `estimated`, `approximately`, `roughly`, `expect … N minutes/hours/…`) |
 | Skips | Past-tense observations (`took 2 hours`), frequency (`every 3 hours`), config values (`30-second timeout`), unit-less numbers |
 | Shape | One nudge per response — the `stop_hook_active` guard accepts the agent's revised response silently |
-| Reason | Carries positive guidance inline so the rule ships self-contained with the plugin (no `.claude/rules/` dependency in consuming repos) |
+| Reason | Carries positive guidance inline so the rule ships self-contained with the plugin (no `.claude/rules/` dependency in consuming repos) — both branches: effort units, and rate × quantity for measured external jobs |
 
 ### test-verification.sh
 

--- a/hooks-plugin/hooks/no-calendar-estimates.sh
+++ b/hooks-plugin/hooks/no-calendar-estimates.sh
@@ -7,7 +7,13 @@
 # first detection; the agent revises; the stop_hook_active guard accepts the
 # revised response silently. The reason text carries the positive guidance
 # inline so it ships self-contained with the plugin — consumers don't need a
-# separate .claude/rules/ file.
+# separate .claude/rules/ file. That guidance has two branches: agent *effort*
+# restates in tokens / effort tier / tool calls; external machine work the agent
+# *measured* (a CI run, build, model download, render, long test suite) really
+# is wall-clock and restates as rate x quantity with the measurement named
+# (#2574). The matcher stays deliberately broad — it still fires on a measured
+# rate, and the message tells the reader how to phrase it honestly rather than
+# offering only units that cannot express it.
 #
 # Opt-in: set CLAUDE_HOOKS_ENABLE_CALENDAR_ESTIMATES=1 to enable.
 set -uo pipefail
@@ -79,7 +85,7 @@ PATTERN_FUTURE="(will|would|should|could|may|might|'ll|going to|gonna)[^.!?]*(ta
 PATTERN_MARKER="(ETA|estimate|estimated|estimating|expect|expects|expected|approximately|roughly|around)[^.!?]*([0-9]+|a few|several|many|couple)[^.!?]*(minute|hour|day|week|month|year)s?"
 
 if echo "$LAST_RESPONSE" | grep -qiE "$PATTERN_FUTURE|$PATTERN_MARKER"; then
-    REASON="Avoid quoting AI work in calendar time (hours, days, weeks, months) — it does not map to agent effort and consistently misleads. Restate the estimate as tokens consumed, effort tier (low / medium / high / xhigh / max), tool-call count, or files / lines to touch."
+    REASON="Avoid quoting AI work in calendar time (hours, days, weeks, months) — it does not map to agent effort and consistently misleads. Restate the estimate as tokens consumed, effort tier (low / medium / high / xhigh / max), tool-call count, or files / lines to touch. Exception: external machine work you measured rather than paced yourself (a CI run, a build, a model download, a render, a long test suite) genuinely is wall-clock — state it as rate × quantity with the measurement named, e.g. \"3870 frames at a measured 1.0 s/frame, so about 65 minutes\"."
     # shellcheck disable=SC2016  # jq expression, not shell expansion
     jq -n --arg reason "$REASON" '{"decision": "block", "reason": $reason}'
     exit 0

--- a/hooks-plugin/hooks/test-no-calendar-estimates.sh
+++ b/hooks-plugin/hooks/test-no-calendar-estimates.sh
@@ -126,6 +126,17 @@ assert_blocks "approximately 5 hours"               "Approximately 5 hours of en
 assert_blocks "expect this in 2 weeks"              "Expect this work in 2 weeks if priorities hold."
 assert_blocks "roughly 4 hours"                     "Roughly 4 hours to finish the migration."
 
+# ── control: the matcher is deliberately NOT narrowed (issue #2574) ───────────
+# The reporter's exact blocked text. #2574 asked for the *message* to name the
+# external-machine-work case (option 1), explicitly NOT for the matcher to stop
+# firing near a measured rate (option 2 — a re-scoping decision with its own
+# evidence bar, see .claude/rules/hook-block-vs-nudge.md). This control goes red
+# if a future change silently narrows PATTERN_FUTURE / PATTERN_MARKER.
+echo ""
+echo "matcher stays unnarrowed (#2574 control):"
+assert_blocks "measured render extrapolation still blocks" \
+    "Roughly 70–80 minutes for 3870 frames at a measured 1.0 s/frame."
+
 # ── past-tense and observational mentions SHOULD pass ─────────────────────────
 echo ""
 echo "past-tense and observational mentions pass:"
@@ -168,6 +179,32 @@ if echo "$out" | grep -q "context-window"; then
 else
     printf "  PASS: reason does not ask for a remaining-context figure\n"
     PASS=$((PASS + 1))
+fi
+
+# Regression (#2574): the offered units could not express external machine work
+# the agent *measured* rather than *paced* — a render, CI run, build, model
+# download, or long test suite. The reason must name that case and say how to
+# phrase it (rate x quantity, measurement named), or the block is a dead end.
+echo ""
+echo "block reason names the external-machine-work case (#2574):"
+for token in "external" "measured" "rate" "render" "CI run"; do
+    if echo "$out" | grep -q "$token"; then
+        printf "  PASS: reason mentions '%s'\n" "$token"
+        PASS=$((PASS + 1))
+    else
+        printf "  FAIL: reason missing '%s' (output: %s)\n" "$token" "$out"
+        FAIL=$((FAIL + 1))
+    fi
+done
+
+# The emitted block must stay valid JSON even though the reason carries an
+# em-dash, parentheses, quotes and a multiplication sign.
+if echo "$out" | jq -e '.decision == "block" and (.reason | length > 0)' >/dev/null 2>&1; then
+    printf "  PASS: emitted block parses as valid JSON\n"
+    PASS=$((PASS + 1))
+else
+    printf "  FAIL: emitted block is not valid JSON (output: %s)\n" "$out"
+    FAIL=$((FAIL + 1))
 fi
 
 # ── summary ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
The calendar-estimate Stop hook blocked *"roughly 70–80 minutes for 3870 frames"* — a figure extrapolated from a **measured** rate (90 frames in 1m31s ≈ 1.0 s/frame), not a prediction of agent pace. None of the units the message offered (tokens, effort tier, tool calls, files touched) can express how long a GPU takes to render a fixed number of frames. That quantity is wall-clock by nature: a property of the hardware, not of the agent.

The message now carries a second branch for external machine work the agent *measures* rather than *paces* — CI runs, builds, model downloads, renders, long test suites — and gives the phrasing.

## The change

Existing guidance intact; one sentence appended to `REASON`:

> …or files / lines to touch. **Exception: external machine work you measured rather than paced yourself (a CI run, a build, a model download, a render, a long test suite) genuinely is wall-clock — state it as rate × quantity with the measurement named, e.g. "3870 frames at a measured 1.0 s/frame, so about 65 minutes".**

This keeps the hook's design constraint from its own header comment — the reason text carries the positive guidance inline so it ships self-contained, with no separate `.claude/rules/` file to consult.

## The matcher is deliberately unchanged

This is option 1 of the two the issue proposes, and only option 1. `PATTERN_FUTURE` and `PATTERN_MARKER` are byte-for-byte identical to `origin/main`:

- `git diff origin/main -- <hook> | grep -c -E '^[+-]PATTERN_(FUTURE|MARKER)='` → **0**
- SHA256 of the `^PATTERN_` lines is `26e8eceb…c25fc` both before and after

So the hook **still blocks** the reporter's text. That is intended. Narrowing what a guard refuses is a re-scoping decision with its own evidence bar (`.claude/rules/hook-block-vs-nudge.md`), not something to take as a default. What changes is that the block stops being a dead end: the reader is now told how to say the thing honestly, instead of being offered only units that cannot express it.

## Verification

- `bash hooks-plugin/hooks/test-no-calendar-estimates.sh` → **33 passed, 0 failed** (was 28). The five new content assertions went red against the unmodified hook first, then green.
- **JSON validity actually exercised, not assumed**: a fixture transcript containing the reporter's exact blocked text was fed through the hook and piped to `jq .`. It parses, and the em-dash, parentheses, escaped quotes and the multibyte `×` all survive. A `jq -e` assertion now pins this.
- **A control** asserts `Roughly 70–80 minutes for 3870 frames at a measured 1.0 s/frame.` still blocks. It passed before this change too — that is the point: it pins the option-1-not-option-2 decision so a future silent narrowing of the regexes goes red.
- `just lint-shell`: 0 errors (9 pre-existing warnings, all in `macos-plugin`). `pre-commit run --files` on all three paths passed, shellcheck included.

## Docs

`hooks-plugin/README.md:289` does not quote the message verbatim, but it reproduces the unit list in the same order, and its framing ("restate in [units] rather than calendar time") would have become wrong by omission. Updated in the same commit per `.claude/rules/docs-currency.md`. `hooks-plugin/docs/feature-flags.md` mentions the hook without enumerating units — left alone.

## One caveat on that control, worth knowing before you rely on it

**`hooks-plugin/hooks/test-no-calendar-estimates.sh` is not run by CI or pre-commit.** I verified this independently of the agent that found it: the file appears in neither `.pre-commit-config.yaml` nor `scripts/required-to-run-tests.txt`, while its sibling `test-bash-antipatterns.sh` is in both (`.pre-commit-config.yaml:573-577`, `required-to-run-tests.txt:35`).

So the control described above does not currently protect anything automatically — it only fires when someone runs the file by hand. Wiring it in is a one-entry change to `.pre-commit-config.yaml` mirroring the `test-bash-antipatterns` block, but it starts running a suite on every contributor's commit and is a separate concern from this issue, so it is deliberately **not** in this PR. A task suggestion carries the exact entry.

Fixes #2574

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3qqVxAZrwT2faQo6KJTPe

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3qqVxAZrwT2faQo6KJTPe)_