### PR TITLE
fix(testing): distinguish bun's native runner from the project's test script

### DIFF
--- a/testing-plugin/agents/test-runner.md
+++ b/testing-plugin/agents/test-runner.md
@@ -5,7 +5,7 @@ color: "#4CAF50"
 description: |
   Run tests and report results. Detects the project's test framework, executes tests with
   agentic-optimized flags, and returns a concise summary to the orchestrator.
-tools: Glob, Grep, Read, Bash(npm test *), Bash(npm run test *), Bash(npx vitest *), Bash(npx jest *), Bash(yarn test *), Bash(bun test *), Bash(pytest *), Bash(python -m pytest *), Bash(cargo test *), Bash(go test *), Bash(just *), TodoWrite
+tools: Glob, Grep, Read, Bash(npm test *), Bash(npm run test *), Bash(npx vitest *), Bash(npx jest *), Bash(yarn test *), Bash(bun test *), Bash(bun run test *), Bash(pytest *), Bash(python -m pytest *), Bash(cargo test *), Bash(go test *), Bash(just *), TodoWrite
 maxTurns: 12
 created: 2026-02-12
 modified: 2026-09-02
@@ -69,6 +69,15 @@ Check these files to determine the test framework:
 | `go.mod` | go test | Go |
 | `justfile` with `test` recipe | just test | Any |
 
+**A `test` script in `package.json` outranks the runner you infer from the
+lockfile.** Read it before choosing a command: `"test": "vitest run"` means the
+project's tests are vitest's, whatever package manager installs them. Run it
+through the manager (`bun run test`, `npm test`) rather than invoking a runner
+directly.
+
+This bites hardest with bun, because `bun test` and `bun run test` are **two
+different test runners** — see the warning under Agentic-Optimized Commands.
+
 ## Agentic-Optimized Commands
 
 Use compact output flags to minimize context usage:
@@ -78,10 +87,25 @@ Use compact output flags to minimize context usage:
 | pytest | `pytest -x -q --tb=short` | Fail fast, quiet, short tracebacks |
 | vitest | `npx vitest run --reporter=dot --bail=1` | Dot output, stop on first failure |
 | jest | `npx jest --bail --silent` | Stop on failure, silent output |
-| bun test | `bun test --bail=1` | Stop on first failure |
+| bun (project script) | `bun run test` | Runs `package.json`'s `test` script — the project's own runner |
+| bun (native runner) | `bun test --bail=1` | Only when there is no `test` script; stop on first failure |
 | cargo test | `cargo test -- --format=terse` | Terse output |
 | go test | `go test -count=1 -short -failfast ./...` | No caching, short mode, fail fast |
 | unittest | `python -m unittest discover -q` | Quiet discovery mode |
+
+> **`bun test` is not `bun run test`.** `bun run test` executes the `test`
+> script in `package.json`. `bun test` ignores that script and runs **bun's own
+> built-in test runner**, which uses its own file-discovery globs — so it
+> collects a different set of files and reports a different result.
+>
+> The failure is loud but misattributed: you get a wall of real-looking
+> failures and conclude the suite is broken. Measured 2026-09-04 on a bun +
+> vitest repo at one commit — `bun test` reported 428 tests across 37 files
+> with 27 failures and 5 errors; `bun run test` (the `vitest run` the project
+> actually defines) reported 520 tests across 28 files, all passing.
+>
+> When `package.json` defines a `test` script, always go through `bun run test`.
+> Reach for `bun test` only when there is no such script.
 
 ### With Coverage
 


### PR DESCRIPTION
## What

`testing-plugin/agents/test-runner.md` listed a single bun row —
`bun test --bail=1` — with nothing saying that `bun test` and `bun run test`
are different test runners.

- `bun run test` executes the `test` script in `package.json`.
- `bun test` **ignores that script** and runs bun's own built-in test runner,
  which discovers files by its own globs.

So in any bun repo whose `package.json` says `"test": "vitest run"` — the
common shape — the documented command runs a different runner over a different
file set than the project's suite.

## Why

The failure is loud but misattributed. You get a wall of real-looking failures
and conclude the suite is broken, or that a change you just made broke it.
Nothing in the output says "you invoked the wrong runner".

Measured 2026-09-04 on a bun + vitest repo, same commit, back to back:

| Command | Files | Tests | Result |
|---|---|---|---|
| `bun test` | 37 | 428 | 27 fail, 5 errors |
| `bun run test` | 28 | 520 | all pass |

The tripwire that caught it was the file count, not the failures — 37 files
where the project has 28.

## How

Three changes to the agent, all in `test-runner.md`:

- **Detection.** A `test` script in `package.json` outranks the runner inferred
  from the lockfile; run it through the manager rather than invoking a runner
  directly. The existing detection table maps `package.json` with a vitest dep
  → vitest but never says how to *invoke* it, which is where the bun ambiguity
  slipped in.
- **Commands.** Split the one bun row into the project-script form
  (`bun run test`) and the native-runner form (`bun test --bail=1`), the latter
  scoped to repos with no `test` script, plus a blockquote with the measurement
  above.
- **Frontmatter.** Add `Bash(bun run test *)`. The allowlist already carried
  `Bash(bun test *)` and was missing the other, so the correct command needed a
  permission prompt while the trap ran unprompted — a small nudge toward the
  wrong one.

## Scope

One file, +26/−2. No behaviour change to any other agent or skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFeGUDXpZH73SxytPfcKCf
