### PR TITLE
docs(multi-model-delegation): add the direct OpenCode Go gateway mechanics

### DIFF
--- a/agent-patterns-plugin/skills/multi-model-delegation/REFERENCE.md
+++ b/agent-patterns-plugin/skills/multi-model-delegation/REFERENCE.md
@@ -1,0 +1,48 @@
+# Multi-Model Delegation - Reference
+
+Edge-case mechanics for consulting foreign models: diagnosing an empty
+deferred-tool lookup, and driving the OpenCode Go gateway directly when PAL's
+MCP server is unreachable.
+
+## `No matching deferred tools found` has two causes
+
+Do not read that message as proof the prefix is wrong — under the **correct**
+prefix it means something else entirely, and the two want different responses:
+
+| What you observe | Cause | Do this |
+|---|---|---|
+| The prefix you tried is not the key `claude mcp list` reports | Wrong prefix | Retry with the reported key |
+| The **correct** prefix also finds nothing, PAL's tools never appear in any deferred-tool reminder, yet `claude mcp list` says Connected | The server's tools were never registered *in this session* — likely it connected after session start | Restart the session, or drive the server directly over stdio JSON-RPC (issue #2437) |
+
+One trap in that direct-stdio workaround, worth stating because its symptom
+misleads: **keep stdin open until the response arrives.**
+`subprocess.run(..., input=...)` closes stdin after writing, so the server shuts
+down mid-call and returns an empty result that looks exactly like a hung or
+non-responding model rather than a transport error.
+
+## Calling the OpenCode Go Gateway Directly
+
+PAL is the normal route. When its MCP server is not connected to the session,
+the same models are reachable at `https://opencode.ai/zen/go/v1/chat/completions`
+with `OPENCODE_API_KEY` — the endpoint PAL's own `opencode_go` provider uses.
+Three mechanics bite there that do not bite through PAL, all measured on
+`qwen3.8-flash` reviewing GitHub Actions diffs (2026-09):
+
+| Mechanic | Symptom | Fix |
+|---|---|---|
+| **models.dev's catalogue is not the gateway's catalogue**, and neither is PAL's pinned `conf/opencode_go_models.json` | A model the user names is "not in the list", so you substitute a near-miss id and review with the wrong model. Observed: `qwen3.8-flash` was absent from models.dev's `opencode` provider *and* from PAL's pinned config, while the gateway's own `/v1/models` served it. The reverse also holds — models.dev listed `gemini-3.8-flash`, which the gateway rejects with `Model … is not supported` | Enumerate from the gateway itself: `curl -s $URL/models -H "Authorization: Bearer $OPENCODE_API_KEY"`. A pinned config and a third-party index are both snapshots; only the gateway answers for what it serves |
+| **A non-streaming request hangs on a long generation** | `http=000` after the full `--max-time`, zero bytes, no error body — indistinguishable from a network fault. Measured: a 24 KB payload hung for the full 900 s, while a 33 KB payload of *trivial* content returned 200 in 2.4 s, so payload size is the wrong suspect | Send `"stream": true` and read the SSE deltas. The same request that hung then streamed 3.8 MB |
+| **A reasoning model can spend its whole budget reasoning and emit nothing** | The stream never reaches `[DONE]` and `content` is empty while `reasoning_content` runs to six figures. Measured on a 15 KB diff: **179,283 chars of reasoning, 0 chars of content** | Cut the input until each call is small enough to answer — per file, then per hunk (~4.5 KB worked). Chunks are independent, so run them concurrently; raising `max_tokens` does not help, because the budget is going to reasoning |
+
+Two consequences for the protocol. **A chunked review is partial by
+construction**: record how many chunks failed and say so wherever the findings
+are used — absence of a finding in a region that never returned is not evidence
+that region is clean. And **an empty findings array from a broken reviewer is
+indistinguishable from a clean review**, so control-test the harness against a
+diff with a defect you planted before trusting any negative
+(`agent-patterns-plugin:tool-result-traps`).
+
+**Isolate a model failure with controlled probes before believing your first
+theory.** The intuitive suspects (big prompt, file attachments) were innocent
+twice — a bug filed on either would have sent the maintainer down the wrong
+path. A two-word prompt plus the one suspect parameter settles it in one call.

--- a/agent-patterns-plugin/skills/multi-model-delegation/SKILL.md
+++ b/agent-patterns-plugin/skills/multi-model-delegation/SKILL.md
@@ -53,21 +53,8 @@ different key gets that key in the prefix instead. Every
 `mcp__pal-mcp-server__*` name below assumes that registration — substitute the
 key `claude mcp list` reports.
 
-### `No matching deferred tools found` has two causes
-
-Do not read that message as proof the prefix is wrong — under the **correct**
-prefix it means something else entirely, and the two want different responses:
-
-| What you observe | Cause | Do this |
-|---|---|---|
-| The prefix you tried is not the key `claude mcp list` reports | Wrong prefix | Retry with the reported key |
-| The **correct** prefix also finds nothing, PAL's tools never appear in any deferred-tool reminder, yet `claude mcp list` says Connected | The server's tools were never registered *in this session* — likely it connected after session start | Restart the session, or drive the server directly over stdio JSON-RPC (issue #2437) |
-
-One trap in that direct-stdio workaround, worth stating because its symptom
-misleads: **keep stdin open until the response arrives.**
-`subprocess.run(..., input=...)` closes stdin after writing, so the server shuts
-down mid-call and returns an empty result that looks exactly like a hung or
-non-responding model rather than a transport error.
+If a lookup under the correct prefix still finds nothing, see
+[REFERENCE.md](REFERENCE.md) — that message has a second cause.
 
 ## When to Use This Skill
 
@@ -193,32 +180,9 @@ exactly the tests an outside reviewer's wrong guess will find for you.
 | `model_used` is **untrustworthy under concurrency** | Three *concurrent* `chat` calls returned `model_used` values rotated across each other while `provider_used` stayed request-consistent | Verify independence via `provider_used`, and pick models on **different providers** — a silently same-model pair breaks the disagreement-is-the-payload logic. [pal#68](https://github.com/laurigates/pal-mcp-server/issues/68) |
 | Registry models get retired upstream mid-consult | A `listmodels`-listed id 404s ("no longer available") | Pick a same-provider fallback *before* dispatching, and re-send the **identical** brief — a reworded one breaks the invariant |
 
-## Calling the OpenCode Go Gateway Directly
-
-PAL is the normal route. When its MCP server is not connected to the session,
-the same models are reachable at `https://opencode.ai/zen/go/v1/chat/completions`
-with `OPENCODE_API_KEY` — the endpoint PAL's own `opencode_go` provider uses.
-Three mechanics bite there that do not bite through PAL, all measured on
-`qwen3.8-flash` reviewing GitHub Actions diffs (2026-09):
-
-| Mechanic | Symptom | Fix |
-|---|---|---|
-| **models.dev's catalogue is not the gateway's catalogue**, and neither is PAL's pinned `conf/opencode_go_models.json` | A model the user names is "not in the list", so you substitute a near-miss id and review with the wrong model. Observed: `qwen3.8-flash` was absent from models.dev's `opencode` provider *and* from PAL's pinned config, while the gateway's own `/v1/models` served it. The reverse also holds — models.dev listed `gemini-3.8-flash`, which the gateway rejects with `Model … is not supported` | Enumerate from the gateway itself: `curl -s $URL/models -H "Authorization: Bearer $OPENCODE_API_KEY"`. A pinned config and a third-party index are both snapshots; only the gateway answers for what it serves |
-| **A non-streaming request hangs on a long generation** | `http=000` after the full `--max-time`, zero bytes, no error body — indistinguishable from a network fault. Measured: a 24 KB payload hung for the full 900 s, while a 33 KB payload of *trivial* content returned 200 in 2.4 s, so payload size is the wrong suspect | Send `"stream": true` and read the SSE deltas. The same request that hung then streamed 3.8 MB |
-| **A reasoning model can spend its whole budget reasoning and emit nothing** | The stream never reaches `[DONE]` and `content` is empty while `reasoning_content` runs to six figures. Measured on a 15 KB diff: **179,283 chars of reasoning, 0 chars of content** | Cut the input until each call is small enough to answer — per file, then per hunk (~4.5 KB worked). Chunks are independent, so run them concurrently; raising `max_tokens` does not help, because the budget is going to reasoning |
-
-Two consequences for the protocol above. **A chunked review is partial by
-construction**: record how many chunks failed and say so wherever the findings
-are used — absence of a finding in a region that never returned is not evidence
-that region is clean. And **an empty findings array from a broken reviewer is
-indistinguishable from a clean review**, so control-test the harness against a
-diff with a defect you planted before trusting any negative
-(`agent-patterns-plugin:tool-result-traps`).
-
-**Isolate a model failure with controlled probes before believing your first
-theory.** The intuitive suspects (big prompt, file attachments) were innocent
-twice — a bug filed on either would have sent the maintainer down the wrong
-path. A two-word prompt plus the one suspect parameter settles it in one call.
+When PAL's MCP server is not connected, the same models are reachable directly
+over the OpenCode Go gateway — see [REFERENCE.md](REFERENCE.md) for that route's
+three failure modes.
 
 ## The Curated Excerpt Bundle
 
@@ -260,3 +224,7 @@ briefs. Build one file and attach *it* to every model:
   artifact, by an isolated Claude reviewer
 - `verify-before-plan` — the same adjudicate-against-reality instinct,
   applied to orchestrator premises before a dispatch
+
+For the second cause of an empty deferred-tool lookup and the direct OpenCode Go
+gateway route (model enumeration, streaming, reasoning-budget exhaustion), see
+[REFERENCE.md](REFERENCE.md).

--- a/agent-patterns-plugin/skills/multi-model-delegation/SKILL.md
+++ b/agent-patterns-plugin/skills/multi-model-delegation/SKILL.md
@@ -5,7 +5,7 @@ user-invocable: false
 allowed-tools: Read, Glob, Grep, TodoWrite, mcp__pal-mcp-server__listmodels, mcp__pal-mcp-server__chat, mcp__pal-mcp-server__consensus, mcp__pal-mcp-server__thinkdeep
 model: opus
 created: 2026-07-17
-modified: 2026-08-21
+modified: 2026-09-05
 reviewed: 2026-08-21
 ---
 
@@ -192,6 +192,28 @@ exactly the tests an outside reviewer's wrong guess will find for you.
 | `working_directory_absolute_path` must live inside `PAL_WORKSPACE_ROOT` | A scratchpad path outside the repo is rejected: `must reside within the PAL workspace root` | Work in `<repo>/tmp/<consult>/`, never a system temp dir |
 | `model_used` is **untrustworthy under concurrency** | Three *concurrent* `chat` calls returned `model_used` values rotated across each other while `provider_used` stayed request-consistent | Verify independence via `provider_used`, and pick models on **different providers** — a silently same-model pair breaks the disagreement-is-the-payload logic. [pal#68](https://github.com/laurigates/pal-mcp-server/issues/68) |
 | Registry models get retired upstream mid-consult | A `listmodels`-listed id 404s ("no longer available") | Pick a same-provider fallback *before* dispatching, and re-send the **identical** brief — a reworded one breaks the invariant |
+
+## Calling the OpenCode Go Gateway Directly
+
+PAL is the normal route. When its MCP server is not connected to the session,
+the same models are reachable at `https://opencode.ai/zen/go/v1/chat/completions`
+with `OPENCODE_API_KEY` — the endpoint PAL's own `opencode_go` provider uses.
+Three mechanics bite there that do not bite through PAL, all measured on
+`qwen3.8-flash` reviewing GitHub Actions diffs (2026-09):
+
+| Mechanic | Symptom | Fix |
+|---|---|---|
+| **models.dev's catalogue is not the gateway's catalogue**, and neither is PAL's pinned `conf/opencode_go_models.json` | A model the user names is "not in the list", so you substitute a near-miss id and review with the wrong model. Observed: `qwen3.8-flash` was absent from models.dev's `opencode` provider *and* from PAL's pinned config, while the gateway's own `/v1/models` served it. The reverse also holds — models.dev listed `gemini-3.8-flash`, which the gateway rejects with `Model … is not supported` | Enumerate from the gateway itself: `curl -s $URL/models -H "Authorization: Bearer $OPENCODE_API_KEY"`. A pinned config and a third-party index are both snapshots; only the gateway answers for what it serves |
+| **A non-streaming request hangs on a long generation** | `http=000` after the full `--max-time`, zero bytes, no error body — indistinguishable from a network fault. Measured: a 24 KB payload hung for the full 900 s, while a 33 KB payload of *trivial* content returned 200 in 2.4 s, so payload size is the wrong suspect | Send `"stream": true` and read the SSE deltas. The same request that hung then streamed 3.8 MB |
+| **A reasoning model can spend its whole budget reasoning and emit nothing** | The stream never reaches `[DONE]` and `content` is empty while `reasoning_content` runs to six figures. Measured on a 15 KB diff: **179,283 chars of reasoning, 0 chars of content** | Cut the input until each call is small enough to answer — per file, then per hunk (~4.5 KB worked). Chunks are independent, so run them concurrently; raising `max_tokens` does not help, because the budget is going to reasoning |
+
+Two consequences for the protocol above. **A chunked review is partial by
+construction**: record how many chunks failed and say so wherever the findings
+are used — absence of a finding in a region that never returned is not evidence
+that region is clean. And **an empty findings array from a broken reviewer is
+indistinguishable from a clean review**, so control-test the harness against a
+diff with a defect you planted before trusting any negative
+(`agent-patterns-plugin:tool-result-traps`).
 
 **Isolate a model failure with controlled probes before believing your first
 theory.** The intuitive suspects (big prompt, file attachments) were innocent


### PR DESCRIPTION
## What

Adds a `## Calling the OpenCode Go Gateway Directly` section to
`agent-patterns-plugin/skills/multi-model-delegation`, covering three mechanics that bite when PAL's
MCP server is not connected to the session and you reach the same models at the gateway PAL's own
`opencode_go` provider uses.

## Why

The skill's existing "PAL Mechanics That Bite" table assumes the MCP route. That route is not always
available — a session with no `pal-mcp-server` connected still has `OPENCODE_API_KEY` and the same
catalogue behind it — and the direct path fails in ways the MCP path does not. Each of the three
below cost real time before it was understood, and none is inferable from the endpoint being
OpenAI-compatible.

## The three, and how each was established

**The catalogue you enumerate from is not the catalogue the gateway serves.** A user asked for
`qwen3.8-flash`. It was absent from models.dev's `opencode` provider *and* from PAL's pinned
`conf/opencode_go_models.json`, whose nearest entries are `qwen3.7-max` / `qwen3.6-plus`. The
gateway's own `/v1/models` served it. The reverse also holds: models.dev listed `gemini-3.8-flash`,
which the gateway rejects with `Model gemini-3.8-flash is not supported`. Both snapshots were wrong
in opposite directions, and substituting a plausible near-miss id would have reviewed with a
different model than the one requested, silently.

**A non-streaming request hangs on a long generation.** `http=000` after the full `--max-time`, zero
bytes, no error body. The obvious suspect is payload size, and it is wrong: a 24 KB real payload hung
for the full 900 s while a 33 KB payload of trivial padding returned 200 in 2.4 s. The same request
streamed 3.8 MB with `"stream": true`.

**A reasoning model can spend its entire budget reasoning and emit nothing.** On a 15 KB diff,
`qwen3.8-flash` produced **179,283 characters of `reasoning_content` and zero characters of
`content`**, never reaching `[DONE]`. Raising `max_tokens` does not help, because the budget is going
to reasoning. Cutting the input to ~4.5 KB per call did; the chunks are independent, so they run
concurrently.

## Two consequences recorded for the protocol

Both follow from chunking and neither is obvious from it:

- **A chunked review is partial by construction.** Chunks fail individually (10 of 33 did, on the
  session this came from). The failed-chunk count has to travel with the findings, or a region that
  never returned reads as a region with nothing wrong in it.
- **An empty findings array from a broken reviewer is indistinguishable from a clean review.** The
  harness needs a planted-defect control before any negative is trusted — the existing
  `agent-patterns-plugin:tool-result-traps` law, which this path violates in a new way.

## Verification

- `just lint-compliance` — exit 0. `multi-model-delegation` is not flagged; the warnings in the
  output are pre-existing on `typescript-plugin` and `workflow-orchestration-plugin`.
- `just lint-context-commands` — `All context commands OK`.
- Pre-commit ran the full guard suite on commit: docs-index audit `STATUS=OK` (skill and agent counts
  match disk), skill-description audits, MCP tool-reference denylist, dead-endpoint and
  delegation-reachability guards all passed.
- SKILL.md is 16,703 chars, under the 26,000 ceiling.

The `nudge-plugin-readme-currency` hook fired advisory-only. Not acted on deliberately: this adds a
section to an existing skill without changing its description, its frontmatter tools, or the plugin's
skill count, so `agent-patterns-plugin/README.md` has nothing to restate. The docs-index audit agrees.

## What this does not cover

Everything above was measured against one model (`qwen3.8-flash`) on one workload (GitHub Actions
diffs), in September 2026. The streaming and unbounded-reasoning behaviours are plausibly general to
reasoning models on that gateway but were not re-measured on `glm-*`, `kimi-*`, or `minimax-*`, and
the ~4.5 KB chunk size is what worked rather than a derived threshold. The catalogue-drift finding is
a property of the snapshots as of that date and will not stay true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
