### PR TITLE
ci(workflows): upload the Claude execution transcript from the audit jobs

### DIFF
--- a/.github/workflows/golden-set-evaluation.yml
+++ b/.github/workflows/golden-set-evaluation.yml
@@ -336,7 +336,7 @@ jobs:
       # from colliding with the first attempt's artifact.
       - name: Upload Claude execution transcript
         if: always() && steps.sweep.outputs.execution_file != ''
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@v4
         with:
           name: claude-execution-sweep-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ steps.sweep.outputs.execution_file }}

--- a/.github/workflows/golden-set-evaluation.yml
+++ b/.github/workflows/golden-set-evaluation.yml
@@ -326,19 +326,58 @@ jobs:
             appears in the results table. If the sweep could not run at all,
             say so plainly in one line and open no issue.
 
+      # The transcript is the raw SDK message stream. The action redacts it only
+      # on the way into the step summary (format-turns.ts:185/:437 and run.ts:141
+      # at v1), not in the file it writes. None of the tools granted above is
+      # path-scoped — `Bash(cat *)` can read /proc/self/environ, where the CLI's
+      # children inherit the OAuth token — so before the file leaves the runner
+      # the job's own tokens are scrubbed by literal value and the token shapes
+      # the action's redactSecrets() knows are scrubbed by pattern. Public-repo
+      # artifacts are readable by any signed-in GitHub user, and log masking
+      # does not reach them.
+      - name: Redact the Claude execution transcript
+        id: redact
+        if: always() && steps.sweep.outputs.execution_file != ''
+        env:
+          TRANSCRIPT: ${{ steps.sweep.outputs.execution_file }}
+          REDACTED: ${{ runner.temp }}/claude-execution-redacted.json
+          SECRET_1: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          SECRET_2: ${{ github.token }}
+        run: |
+          python3 - <<'PY'
+          import os, re
+          text = open(os.environ["TRANSCRIPT"], encoding="utf-8").read()
+          for key in ("SECRET_1", "SECRET_2"):
+              value = os.environ.get(key, "")
+              if len(value) >= 8:
+                  text = text.replace(value, "[REDACTED_" + key + "]")
+          patterns = [
+              (r"gh[pousr]_[A-Za-z0-9]{36,255}", "[REDACTED_GITHUB_TOKEN]"),
+              (r"github_pat_[A-Za-z0-9_]{22,255}", "[REDACTED_GITHUB_TOKEN]"),
+              (r"sk-ant-[A-Za-z0-9_-]{20,}", "[REDACTED_ANTHROPIC_KEY]"),
+              (r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b", "[REDACTED_AWS_KEY_ID]"),
+              (r"xox[abpsr]-[A-Za-z0-9-]{10,}", "[REDACTED_SLACK_TOKEN]"),
+              (r"eyJ[A-Za-z0-9_-]{10,2000}\.eyJ[A-Za-z0-9_-]{10,4000}\.[A-Za-z0-9_-]{10,2000}\b", "[REDACTED_JWT]"),
+          ]
+          for pattern, label in patterns:
+              text = re.sub(pattern, label, text)
+          open(os.environ["REDACTED"], "w", encoding="utf-8").write(text)
+          PY
+          echo "path=${REDACTED}" >> "$GITHUB_OUTPUT"
+
       # The action's per-call transcript — its `execution_file` output,
       # $RUNNER_TEMP/claude-execution-output.json — so a run's denied tool
       # calls can be read after the fact (#2493; the shape is the same as the
       # agentic-audit upload in scheduled-audits.yml). `always()` keeps the
-      # upload when the Claude step fails; the output guard skips it when that
+      # upload when the Claude step fails; the redacted-path guard skips it when that
       # step died before the file existed, because upload-artifact fails
       # outright on an empty `path`. run_attempt in the name keeps a re-run
       # from colliding with the first attempt's artifact.
       - name: Upload Claude execution transcript
-        if: always() && steps.sweep.outputs.execution_file != ''
+        if: always() && steps.redact.outputs.path != ''
         uses: actions/upload-artifact@v4
         with:
           name: claude-execution-sweep-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ steps.sweep.outputs.execution_file }}
+          path: ${{ steps.redact.outputs.path }}
           retention-days: 14
           if-no-files-found: warn

--- a/.github/workflows/golden-set-evaluation.yml
+++ b/.github/workflows/golden-set-evaluation.yml
@@ -338,6 +338,9 @@ jobs:
       - name: Redact the Claude execution transcript
         id: redact
         if: always() && steps.sweep.outputs.execution_file != ''
+        # A redaction failure leaves the path output unset, so the upload below
+        # is skipped; the audit's own result stays what the Claude step made it.
+        continue-on-error: true
         env:
           TRANSCRIPT: ${{ steps.sweep.outputs.execution_file }}
           REDACTED: ${{ runner.temp }}/claude-execution-redacted.json
@@ -351,16 +354,21 @@ jobs:
               value = os.environ.get(key, "")
               if len(value) >= 8:
                   text = text.replace(value, "[REDACTED_" + key + "]")
+          # The same classes as the action's redactSecrets() (sanitizer.ts at v1).
+          # Python's re has no variable-width lookbehind, so the AWS rule keeps
+          # the preceding boundary as a capture instead: start of line, a JSON
+          # escape, an ANSI colour code, or any non-alphanumeric character.
           patterns = [
               (r"gh[pousr]_[A-Za-z0-9]{36,255}", "[REDACTED_GITHUB_TOKEN]"),
-              (r"github_pat_[A-Za-z0-9_]{22,255}", "[REDACTED_GITHUB_TOKEN]"),
+              (r"github_pat_[A-Za-z0-9_]{11,221}\b", "[REDACTED_GITHUB_TOKEN]"),
               (r"sk-ant-[A-Za-z0-9_-]{20,}", "[REDACTED_ANTHROPIC_KEY]"),
-              (r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b", "[REDACTED_AWS_KEY_ID]"),
               (r"xox[abpsr]-[A-Za-z0-9-]{10,}", "[REDACTED_SLACK_TOKEN]"),
               (r"eyJ[A-Za-z0-9_-]{10,2000}\.eyJ[A-Za-z0-9_-]{10,4000}\.[A-Za-z0-9_-]{10,2000}\b", "[REDACTED_JWT]"),
           ]
           for pattern, label in patterns:
               text = re.sub(pattern, label, text)
+          aws = r"(^|\\[nrtbf\"\\/]|\\u[0-9a-fA-F]{4}|\[[0-9;]*m|[^A-Za-z0-9])((?:AKIA|ASIA)[A-Z0-9]{16})\b"
+          text = re.sub(aws, lambda m: m.group(1) + "[REDACTED_AWS_KEY_ID]", text, flags=re.M)
           open(os.environ["REDACTED"], "w", encoding="utf-8").write(text)
           PY
           echo "path=${REDACTED}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/golden-set-evaluation.yml
+++ b/.github/workflows/golden-set-evaluation.yml
@@ -207,6 +207,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run the Tier-2 cross-model sweep
+        id: sweep
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -324,3 +325,20 @@ jobs:
             Confirm exactly one issue was created and that every swept skill
             appears in the results table. If the sweep could not run at all,
             say so plainly in one line and open no issue.
+
+      # The action's per-call transcript — its `execution_file` output,
+      # $RUNNER_TEMP/claude-execution-output.json — so a run's denied tool
+      # calls can be read after the fact (#2493; the shape is the same as the
+      # agentic-audit upload in scheduled-audits.yml). `always()` keeps the
+      # upload when the Claude step fails; the output guard skips it when that
+      # step died before the file existed, because upload-artifact fails
+      # outright on an empty `path`. run_attempt in the name keeps a re-run
+      # from colliding with the first attempt's artifact.
+      - name: Upload Claude execution transcript
+        if: always() && steps.sweep.outputs.execution_file != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: claude-execution-sweep-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.sweep.outputs.execution_file }}
+          retention-days: 14
+          if-no-files-found: warn

--- a/.github/workflows/scheduled-audits.yml
+++ b/.github/workflows/scheduled-audits.yml
@@ -210,22 +210,61 @@ jobs:
             )"
             ```
 
+      # The transcript is the raw SDK message stream. The action redacts it only
+      # on the way into the step summary (format-turns.ts:185/:437 and run.ts:141
+      # at v1), not in the file it writes. None of the tools granted above is
+      # path-scoped — `Bash(cat *)` can read /proc/self/environ, where the CLI's
+      # children inherit the OAuth token — so before the file leaves the runner
+      # the job's own tokens are scrubbed by literal value and the token shapes
+      # the action's redactSecrets() knows are scrubbed by pattern. Public-repo
+      # artifacts are readable by any signed-in GitHub user, and log masking
+      # does not reach them.
+      - name: Redact the Claude execution transcript
+        id: redact
+        if: always() && steps.audit.outputs.execution_file != ''
+        env:
+          TRANSCRIPT: ${{ steps.audit.outputs.execution_file }}
+          REDACTED: ${{ runner.temp }}/claude-execution-redacted.json
+          SECRET_1: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          SECRET_2: ${{ github.token }}
+        run: |
+          python3 - <<'PY'
+          import os, re
+          text = open(os.environ["TRANSCRIPT"], encoding="utf-8").read()
+          for key in ("SECRET_1", "SECRET_2"):
+              value = os.environ.get(key, "")
+              if len(value) >= 8:
+                  text = text.replace(value, "[REDACTED_" + key + "]")
+          patterns = [
+              (r"gh[pousr]_[A-Za-z0-9]{36,255}", "[REDACTED_GITHUB_TOKEN]"),
+              (r"github_pat_[A-Za-z0-9_]{22,255}", "[REDACTED_GITHUB_TOKEN]"),
+              (r"sk-ant-[A-Za-z0-9_-]{20,}", "[REDACTED_ANTHROPIC_KEY]"),
+              (r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b", "[REDACTED_AWS_KEY_ID]"),
+              (r"xox[abpsr]-[A-Za-z0-9-]{10,}", "[REDACTED_SLACK_TOKEN]"),
+              (r"eyJ[A-Za-z0-9_-]{10,2000}\.eyJ[A-Za-z0-9_-]{10,4000}\.[A-Za-z0-9_-]{10,2000}\b", "[REDACTED_JWT]"),
+          ]
+          for pattern, label in patterns:
+              text = re.sub(pattern, label, text)
+          open(os.environ["REDACTED"], "w", encoding="utf-8").write(text)
+          PY
+          echo "path=${REDACTED}" >> "$GITHUB_OUTPUT"
+
       # The action's per-call transcript — its `execution_file` output,
       # $RUNNER_TEMP/claude-execution-output.json. Run 33517717893 (2026-09-01)
       # closed with permission_denials_count: 6 and uploaded nothing, so the six
       # denied calls could not be identified afterwards (#2493). `always()`
-      # keeps the upload when the Claude step fails; the output guard skips it
+      # keeps the upload when the Claude step fails; the redacted-path guard skips it
       # when that step was skipped or died before the file existed — the action
       # sets the output only if the file exists, and upload-artifact fails
       # outright on an empty `path`. run_attempt in the name keeps a re-run
       # from colliding with the first attempt's artifact (v4 artifacts are
       # immutable).
       - name: Upload Claude execution transcript
-        if: always() && steps.audit.outputs.execution_file != ''
+        if: always() && steps.redact.outputs.path != ''
         uses: actions/upload-artifact@v4
         with:
           name: claude-execution-agentic-audit-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ steps.audit.outputs.execution_file }}
+          path: ${{ steps.redact.outputs.path }}
           retention-days: 14
           if-no-files-found: warn
 

--- a/.github/workflows/scheduled-audits.yml
+++ b/.github/workflows/scheduled-audits.yml
@@ -222,6 +222,9 @@ jobs:
       - name: Redact the Claude execution transcript
         id: redact
         if: always() && steps.audit.outputs.execution_file != ''
+        # A redaction failure leaves the path output unset, so the upload below
+        # is skipped; the audit's own result stays what the Claude step made it.
+        continue-on-error: true
         env:
           TRANSCRIPT: ${{ steps.audit.outputs.execution_file }}
           REDACTED: ${{ runner.temp }}/claude-execution-redacted.json
@@ -235,16 +238,21 @@ jobs:
               value = os.environ.get(key, "")
               if len(value) >= 8:
                   text = text.replace(value, "[REDACTED_" + key + "]")
+          # The same classes as the action's redactSecrets() (sanitizer.ts at v1).
+          # Python's re has no variable-width lookbehind, so the AWS rule keeps
+          # the preceding boundary as a capture instead: start of line, a JSON
+          # escape, an ANSI colour code, or any non-alphanumeric character.
           patterns = [
               (r"gh[pousr]_[A-Za-z0-9]{36,255}", "[REDACTED_GITHUB_TOKEN]"),
-              (r"github_pat_[A-Za-z0-9_]{22,255}", "[REDACTED_GITHUB_TOKEN]"),
+              (r"github_pat_[A-Za-z0-9_]{11,221}\b", "[REDACTED_GITHUB_TOKEN]"),
               (r"sk-ant-[A-Za-z0-9_-]{20,}", "[REDACTED_ANTHROPIC_KEY]"),
-              (r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b", "[REDACTED_AWS_KEY_ID]"),
               (r"xox[abpsr]-[A-Za-z0-9-]{10,}", "[REDACTED_SLACK_TOKEN]"),
               (r"eyJ[A-Za-z0-9_-]{10,2000}\.eyJ[A-Za-z0-9_-]{10,4000}\.[A-Za-z0-9_-]{10,2000}\b", "[REDACTED_JWT]"),
           ]
           for pattern, label in patterns:
               text = re.sub(pattern, label, text)
+          aws = r"(^|\\[nrtbf\"\\/]|\\u[0-9a-fA-F]{4}|\[[0-9;]*m|[^A-Za-z0-9])((?:AKIA|ASIA)[A-Z0-9]{16})\b"
+          text = re.sub(aws, lambda m: m.group(1) + "[REDACTED_AWS_KEY_ID]", text, flags=re.M)
           open(os.environ["REDACTED"], "w", encoding="utf-8").write(text)
           PY
           echo "path=${REDACTED}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/scheduled-audits.yml
+++ b/.github/workflows/scheduled-audits.yml
@@ -113,6 +113,7 @@ jobs:
 
       - name: Claude Agentic Quality Audit
         if: steps.check_issue.outputs.exists == 'false'
+        id: audit
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -208,6 +209,25 @@ jobs:
             EOF
             )"
             ```
+
+      # The action's per-call transcript — its `execution_file` output,
+      # $RUNNER_TEMP/claude-execution-output.json. Run 33517717893 (2026-09-01)
+      # closed with permission_denials_count: 6 and uploaded nothing, so the six
+      # denied calls could not be identified afterwards (#2493). `always()`
+      # keeps the upload when the Claude step fails; the output guard skips it
+      # when that step was skipped or died before the file existed — the action
+      # sets the output only if the file exists, and upload-artifact fails
+      # outright on an empty `path`. run_attempt in the name keeps a re-run
+      # from colliding with the first attempt's artifact (v4 artifacts are
+      # immutable).
+      - name: Upload Claude execution transcript
+        if: always() && steps.audit.outputs.execution_file != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: claude-execution-agentic-audit-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.audit.outputs.execution_file }}
+          retention-days: 14
+          if-no-files-found: warn
 
   audit-liveness:
     # Watches the workflows whose only output is an issue, for the case where

--- a/.github/workflows/scheduled-audits.yml
+++ b/.github/workflows/scheduled-audits.yml
@@ -222,7 +222,7 @@ jobs:
       # immutable).
       - name: Upload Claude execution transcript
         if: always() && steps.audit.outputs.execution_file != ''
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@v4
         with:
           name: claude-execution-agentic-audit-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ steps.audit.outputs.execution_file }}

--- a/.github/workflows/workflow-model-audit.yml
+++ b/.github/workflows/workflow-model-audit.yml
@@ -233,6 +233,9 @@ jobs:
       - name: Redact the Claude execution transcript
         id: redact
         if: always() && steps.audit.outputs.execution_file != ''
+        # A redaction failure leaves the path output unset, so the upload below
+        # is skipped; the audit's own result stays what the Claude step made it.
+        continue-on-error: true
         env:
           TRANSCRIPT: ${{ steps.audit.outputs.execution_file }}
           REDACTED: ${{ runner.temp }}/claude-execution-redacted.json
@@ -246,16 +249,21 @@ jobs:
               value = os.environ.get(key, "")
               if len(value) >= 8:
                   text = text.replace(value, "[REDACTED_" + key + "]")
+          # The same classes as the action's redactSecrets() (sanitizer.ts at v1).
+          # Python's re has no variable-width lookbehind, so the AWS rule keeps
+          # the preceding boundary as a capture instead: start of line, a JSON
+          # escape, an ANSI colour code, or any non-alphanumeric character.
           patterns = [
               (r"gh[pousr]_[A-Za-z0-9]{36,255}", "[REDACTED_GITHUB_TOKEN]"),
-              (r"github_pat_[A-Za-z0-9_]{22,255}", "[REDACTED_GITHUB_TOKEN]"),
+              (r"github_pat_[A-Za-z0-9_]{11,221}\b", "[REDACTED_GITHUB_TOKEN]"),
               (r"sk-ant-[A-Za-z0-9_-]{20,}", "[REDACTED_ANTHROPIC_KEY]"),
-              (r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b", "[REDACTED_AWS_KEY_ID]"),
               (r"xox[abpsr]-[A-Za-z0-9-]{10,}", "[REDACTED_SLACK_TOKEN]"),
               (r"eyJ[A-Za-z0-9_-]{10,2000}\.eyJ[A-Za-z0-9_-]{10,4000}\.[A-Za-z0-9_-]{10,2000}\b", "[REDACTED_JWT]"),
           ]
           for pattern, label in patterns:
               text = re.sub(pattern, label, text)
+          aws = r"(^|\\[nrtbf\"\\/]|\\u[0-9a-fA-F]{4}|\[[0-9;]*m|[^A-Za-z0-9])((?:AKIA|ASIA)[A-Z0-9]{16})\b"
+          text = re.sub(aws, lambda m: m.group(1) + "[REDACTED_AWS_KEY_ID]", text, flags=re.M)
           open(os.environ["REDACTED"], "w", encoding="utf-8").write(text)
           PY
           echo "path=${REDACTED}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/workflow-model-audit.yml
+++ b/.github/workflows/workflow-model-audit.yml
@@ -221,19 +221,58 @@ jobs:
             )"
             ```
 
+      # The transcript is the raw SDK message stream. The action redacts it only
+      # on the way into the step summary (format-turns.ts:185/:437 and run.ts:141
+      # at v1), not in the file it writes. None of the tools granted above is
+      # path-scoped — `Bash(cat *)` can read /proc/self/environ, where the CLI's
+      # children inherit the OAuth token — so before the file leaves the runner
+      # the job's own tokens are scrubbed by literal value and the token shapes
+      # the action's redactSecrets() knows are scrubbed by pattern. Public-repo
+      # artifacts are readable by any signed-in GitHub user, and log masking
+      # does not reach them.
+      - name: Redact the Claude execution transcript
+        id: redact
+        if: always() && steps.audit.outputs.execution_file != ''
+        env:
+          TRANSCRIPT: ${{ steps.audit.outputs.execution_file }}
+          REDACTED: ${{ runner.temp }}/claude-execution-redacted.json
+          SECRET_1: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          SECRET_2: ${{ github.token }}
+        run: |
+          python3 - <<'PY'
+          import os, re
+          text = open(os.environ["TRANSCRIPT"], encoding="utf-8").read()
+          for key in ("SECRET_1", "SECRET_2"):
+              value = os.environ.get(key, "")
+              if len(value) >= 8:
+                  text = text.replace(value, "[REDACTED_" + key + "]")
+          patterns = [
+              (r"gh[pousr]_[A-Za-z0-9]{36,255}", "[REDACTED_GITHUB_TOKEN]"),
+              (r"github_pat_[A-Za-z0-9_]{22,255}", "[REDACTED_GITHUB_TOKEN]"),
+              (r"sk-ant-[A-Za-z0-9_-]{20,}", "[REDACTED_ANTHROPIC_KEY]"),
+              (r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b", "[REDACTED_AWS_KEY_ID]"),
+              (r"xox[abpsr]-[A-Za-z0-9-]{10,}", "[REDACTED_SLACK_TOKEN]"),
+              (r"eyJ[A-Za-z0-9_-]{10,2000}\.eyJ[A-Za-z0-9_-]{10,4000}\.[A-Za-z0-9_-]{10,2000}\b", "[REDACTED_JWT]"),
+          ]
+          for pattern, label in patterns:
+              text = re.sub(pattern, label, text)
+          open(os.environ["REDACTED"], "w", encoding="utf-8").write(text)
+          PY
+          echo "path=${REDACTED}" >> "$GITHUB_OUTPUT"
+
       # The action's per-call transcript — its `execution_file` output,
       # $RUNNER_TEMP/claude-execution-output.json — so a run's denied tool
       # calls can be read after the fact (#2493; the shape is the same as the
       # agentic-audit upload in scheduled-audits.yml). `always()` keeps the
-      # upload when the Claude step fails; the output guard skips it when that
+      # upload when the Claude step fails; the redacted-path guard skips it when that
       # step was skipped or died before the file existed, because
       # upload-artifact fails outright on an empty `path`. run_attempt in the
       # name keeps a re-run from colliding with the first attempt's artifact.
       - name: Upload Claude execution transcript
-        if: always() && steps.audit.outputs.execution_file != ''
+        if: always() && steps.redact.outputs.path != ''
         uses: actions/upload-artifact@v4
         with:
           name: claude-execution-workflow-model-audit-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ steps.audit.outputs.execution_file }}
+          path: ${{ steps.redact.outputs.path }}
           retention-days: 14
           if-no-files-found: warn

--- a/.github/workflows/workflow-model-audit.yml
+++ b/.github/workflows/workflow-model-audit.yml
@@ -231,7 +231,7 @@ jobs:
       # name keeps a re-run from colliding with the first attempt's artifact.
       - name: Upload Claude execution transcript
         if: always() && steps.audit.outputs.execution_file != ''
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@v4
         with:
           name: claude-execution-workflow-model-audit-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ steps.audit.outputs.execution_file }}

--- a/.github/workflows/workflow-model-audit.yml
+++ b/.github/workflows/workflow-model-audit.yml
@@ -220,3 +220,20 @@ jobs:
             EOF
             )"
             ```
+
+      # The action's per-call transcript — its `execution_file` output,
+      # $RUNNER_TEMP/claude-execution-output.json — so a run's denied tool
+      # calls can be read after the fact (#2493; the shape is the same as the
+      # agentic-audit upload in scheduled-audits.yml). `always()` keeps the
+      # upload when the Claude step fails; the output guard skips it when that
+      # step was skipped or died before the file existed, because
+      # upload-artifact fails outright on an empty `path`. run_attempt in the
+      # name keeps a re-run from colliding with the first attempt's artifact.
+      - name: Upload Claude execution transcript
+        if: always() && steps.audit.outputs.execution_file != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: claude-execution-workflow-model-audit-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.audit.outputs.execution_file }}
+          retention-days: 14
+          if-no-files-found: warn


### PR DESCRIPTION
## What

Each of the three Claude-invoking audit jobs — `agentic-audit` in `scheduled-audits.yml`, `workflow-model-audit`, and `sweep` in `golden-set-evaluation.yml` — gains two steps after its Claude step: a redaction step that reads the action's per-call transcript (`steps.<id>.outputs.execution_file`, `$RUNNER_TEMP/claude-execution-output.json`) and writes a scrubbed copy, then `actions/upload-artifact@v4` on that copy, named `claude-execution-<job>-<run_id>-<run_attempt>`, `retention-days: 14`, `if-no-files-found: warn`. The scheduled-audits Claude step gets `id: audit` and the golden-set one `id: sweep` so the output is addressable; `workflow-model-audit` already had `id: audit`. Prompts, `--allowedTools`, `--max-turns`, crons, label steps and every job's `permissions:` are unchanged; artifact upload uses the runner's own token, not `GITHUB_TOKEN`.

Three details, each read from the actions' sources at their pinned refs:

- Guards. The redaction step runs on `always() && steps.<id>.outputs.execution_file != ''` with `continue-on-error: true`; the upload on `always() && steps.redact.outputs.path != ''`. At the `v1` tag (annotated, commit `d75b94d5`), `src/entrypoints/run.ts` sets `execution_file` only when the transcript exists — `if (claudeResult.executionFile)` on the success path, `setExecutionFileOutputIfPresent()` (an `existsSync` check) in the `catch` path. `actions/upload-artifact` fails the step on an empty `path` (`core.getInput(Inputs.Path, {required: true})` in `src/upload/input-helper.ts` at v4.6.2). A bare `always()` would fail `agentic-audit` every month an audit issue is already open: the Claude step is skipped, the output is empty, and the upload would run anyway. Both guards keep the upload when the Claude step fails; a redaction failure leaves the path output unset, so the upload is skipped and the audit's own result stands.
- `actions/upload-artifact@v4`, tag-form like every other remote `uses:` in this repo's own workflows (17 distinct refs, including the one sibling `upload-artifact@v4` in `research-radar.yml`); `.claude/rules/version-pinning.md` reserves the SHA-plus-comment shape for the copy-pasteable examples inside skills. `v4` resolves to `ea165f8d` today (v4.6.2); v5–v7 exist and are held for dashboard approval in `renovate.json`, which is also why the sibling sits at v4. `run_attempt` is in the artifact name because v4 artifacts are immutable, so a re-run of a failed job would otherwise collide with the first attempt's upload.
- Redaction. The transcript file is the raw SDK message stream: the action runs `redactSecrets()` only on the copy it writes into the step summary (`src/entrypoints/format-turns.ts:185` and `:437`, plus the `run.ts:141` fallback, at `d75b94d5`), while `base-action/src/execution-file.ts` writes the file unredacted. None of the tools the three prompts grant is path-scoped — `Bash(cat *)` can read `/proc/self/environ`, where the CLI's Bash children inherit the OAuth token, and `golden-set-evaluation` grants `Bash(bash *)` and `Bash(python3 *)` — and public-repo artifacts are downloadable by any signed-in GitHub user, outside log masking. The redaction step scrubs the job's own two tokens (`secrets.CLAUDE_CODE_OAUTH_TOKEN`, `github.token`) by literal value, then the token classes `redactSecrets()` (`src/github/utils/sanitizer.ts` at `d75b94d5`) knows by pattern — GitHub `ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_` and `github_pat_` (11–221 chars, as the action's), `sk-ant-`, `AKIA`/`ASIA` (with the action's JSON-escape and ANSI-code boundaries, expressed as a captured prefix because Python's `re` has no variable-width lookbehind), `xox*-`, JWT — and writes `$RUNNER_TEMP/claude-execution-redacted.json`. The literal pass covers the two tokens these jobs hold; the pattern pass covers the classes the action redacts in its own summary.

## Why

#2493 is a four-box checklist over the first post-fix scheduled run of each audit. For run 33517717893 (2026-09-01, `schedule`), the `agentic-audit` job was green, with a result block of `subtype: success`, `is_error: false`, `num_turns: 18` of a 25 cap, `permission_denials_count: 6`. Issue #2557 was filed inside the job window with the `agentic-audit` label. The run went red only on the sibling `docs-index` job, whose unquoted label colour `5319e7` was coerced to a YAML float and 422'd on `gh label create` — fixed by #2576. `gh api repos/laurigates/claude-plugins/actions/runs/33517717893/artifacts` returns `total_count: 0`: the transcript was never kept, so the six denied calls cannot be identified. #2576 argued from measurement that a healthy run can carry denials from correctly-blocked tools; whether these six are that kind is not decidable from the run as it stands. `workflow-model-audit` last ran 2026-08-08 and `golden-set-evaluation` 2026-08-15, both pre-fix, so their 8 Sep and 15 Sep runs are the first post-fix runs for rows 2 and 3 and will carry the transcript.

## Gates

All rows run on the final commit, `77c80299`.

| command | measured result |
|---|---|
| `pre-commit run --files .github/workflows/scheduled-audits.yml .github/workflows/workflow-model-audit.yml .github/workflows/golden-set-evaluation.yml` | exit 0; Passed: Detect hardcoded secrets; Lint GitHub Actions workflow files (actionlint); golden-set sweep cannot report green on a fraction silently; every Claude workflow pins opus + explicit effort (`check-workflow-model.sh`); workflow-run scripts are reachable from its path triggers; actionlint pins agree between pre-commit and CI; every attached GitHub label is provisioned in-workflow (`check-workflow-labels.sh`). Every other hook: Skipped (no files to check) |
| `actionlint` on the three files, directly | exit 0, no findings |
| Redaction self-test: the heredoc extracted from the shipped YAML, run against a planted transcript with an `sk-ant-oat01-…` value and a `ghs_…` value as `SECRET_1`/`SECRET_2`, an `AKIA…` id directly after a JSON `\n` escape, an `ASIA…` id directly after an ANSI reset code, an `AKIA…` id after a space, and a 12-character `github_pat_…` | every planted token replaced by its `[REDACTED_…]` label (three AWS ids); `PAKIA…`, a URL path containing `AKIA`, a 40-hex sha and `plain=hello` preserved; output parses as JSON |
| `grep -nE 'execution_file|steps.redact.outputs.path'` across the three files | one redaction step and one upload step per Claude job, each on an existing id: scheduled-audits `steps.audit`; workflow-model-audit `steps.audit`; golden-set-evaluation `steps.sweep` |
| `grep -rn 'upload-artifact@' .github/workflows` | four refs, all `actions/upload-artifact@v4` (the three new steps and `research-radar.yml:135`) |
| `gh api repos/anthropics/claude-code-action/contents/action.yml?ref=v1` | `outputs.execution_file.value: ${{ steps.run.outputs.execution_file }}`; `v1` dereferences to commit `d75b94d5ad426cb8546e6628b6f5f19b84e5cce1` |

## Fix round 1

Review left one consistency nit on `c8eabc4d`: the three new steps were the only SHA-pinned `uses:` in `.github/workflows`, against 17 tag-form remote refs. `8525eabd` switches them to `@v4`; Renovate manages both forms.

## Fix round 2

Review of `8525eabd` reproduced every gate and found the earlier body's safety argument for an unredacted upload false: it said the prompts grant no tool that reads outside the checkout, and none of the granted tools is path-scoped. `08eb7913` adds the redaction step described under What and guards the upload on its output.

## Fix round 3

Review of `08eb7913` ran the heredoc against planted transcripts and found two rules narrower than the action's: the AWS rule's plain `\b` missed an id directly after a JSON `\n` escape or an ANSI code, and the `github_pat_` minimum was 22 where the action's is 11. `77c80299` carries both over (the AWS boundary as a captured prefix), adds `continue-on-error: true` to the redaction step so an instrumentation failure cannot turn a green audit red, and the self-test row above now includes those cases. The three earlier commit messages describe the SHA pin, the raw upload and the first redaction pass respectively; the squash-merge lands this body.

Refs #2493

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DhfHZTFhAWSmtpTRLstuY1
