### PR TITLE
fix(hooks-plugin): anchor secret-protection reader verbs at a word boundary

### DIFF
--- a/hooks-plugin/hooks/secret-protection.sh
+++ b/hooks-plugin/hooks/secret-protection.sh
@@ -113,26 +113,37 @@ ${OVERRIDE_NOTE}"
   # the only `.env` is inside a grep pattern (issue #2444). Same greediness
   # class as the `.*` → `[A-Za-z0-9_]*` narrowing documented above (#1580).
   #
-  # The verb group is anchored at a word start with `(^|[^A-Za-z])`, so a verb
-  # cannot match inside an ordinary English word. Without it `regardless`,
-  # `unless`, `thread`, `encode` and `furthermore` each supplied a verb, and
-  # prose that went on to mention `.env.integration` — a commit-message heredoc
-  # describing config precedence — was blocked as a sensitive-file read (issue
-  # #2597). `\b` / `\<` would be shorter but are GNU extensions; this hook may
-  # run under BSD grep (macOS), GNU grep (CI) or ugrep, and `(^|[^A-Za-z])` is
-  # POSIX ERE that all three accept. The alternative captures one leading
-  # non-letter character, which is trimmed from `$match` below before the block
-  # message; the template exemption re-greps from `${pattern}` and never sees it.
-  reader_verbs='(cat|head|tail|less|more|nano|vim|vi|code|read)'
+  # The verb group is anchored at a word start — `(^VERB|[^A-Za-z]VERB)` — so
+  # a verb cannot match inside an ordinary English word. Without it
+  # `regardless`, `unless`, `thread`, `encode` and `furthermore` each supplied a
+  # verb, and prose that went on to mention `.env.integration` — a
+  # commit-message heredoc describing config precedence — was blocked as a
+  # sensitive-file read (issue #2597).
+  #
+  # The anchor's shape is measured, not stylistic. The hook may run under BSD
+  # grep 2.6.0 (macOS), GNU grep (CI) or ugrep, and they disagree on the
+  # shorter forms: `(^|[^A-Za-z])VERB` is a compile error in ugrep ("empty
+  # expression") that the trailing `|| true` swallows, leaving `$match` empty
+  # and every reader-verb block failing open; `\b`/`\<` compile everywhere, but
+  # ugrep's `-o` then returns `cat .env` for `cat .env.example`, so the template
+  # exemption below never sees the suffix and a template read is blocked. The
+  # explicit alternation behaves the same on all three. Its second branch
+  # captures one boundary character, trimmed from `$match` before the block
+  # message; the exemption re-greps from `${pattern}` and never sees it.
+  #
+  # The anchor also stops binaries whose name merely ends in a verb from
+  # matching by accident (`nvim`, `gcat`, `zless`, …); the common ones are
+  # listed explicitly so the fix does not narrow what was blocked before.
+  reader_verbs='(cat|gcat|zcat|head|ghead|tail|gtail|less|zless|more|nano|vim|nvim|gvim|vi|code|read)'
   for pattern in '\.env\b' '\.ssh/' '\.aws/credentials' '\.kube/config' '\.docker/config\.json' 'credentials\.json' 'secrets\.json'; do
     # Capture the matched substring (verb + path) rather than a bare boolean, so
     # the block message can name what tripped it and the exemption below can
     # inspect the actual path argument.
-    match=$(echo "$COMMAND" | grep -oE "(^|[^A-Za-z])${reader_verbs}[[:space:]]+[^|;&]*${pattern}[^[:space:]|;&'\"]*" | head -1 || true)
+    match=$(echo "$COMMAND" | grep -oE "(^${reader_verbs}|[^A-Za-z]${reader_verbs})[[:space:]]+[^|;&]*${pattern}[^[:space:]|;&'\"]*" | head -1 || true)
     [ -z "$match" ] && continue
-    # Drop the single boundary character the `(^|[^A-Za-z])` alternative
-    # captured (a space, `;`, `(`, quote, …); at start-of-line it captured
-    # nothing and the match already begins with the verb.
+    # Drop the single boundary character the second alternative captured (a
+    # space, `;`, `(`, quote, …); a start-of-line match begins with the verb
+    # and is left alone.
     match="${match#[!A-Za-z]}"
 
     # .env.example / .env.sample / .env.template are templates committed by

--- a/hooks-plugin/hooks/secret-protection.sh
+++ b/hooks-plugin/hooks/secret-protection.sh
@@ -120,9 +120,8 @@ ${OVERRIDE_NOTE}"
   # commit-message heredoc describing config precedence — was blocked as a
   # sensitive-file read (issue #2597).
   #
-  # The anchor's shape is measured, not stylistic. The hook may run under BSD
-  # grep 2.6.0 (macOS), GNU grep (CI) or ugrep, and they disagree on the
-  # shorter forms: `(^|[^A-Za-z])VERB` is a compile error in ugrep ("empty
+  # The hook may run under BSD grep 2.6.0 (macOS), GNU grep (CI) or ugrep, and
+  # they disagree on the shorter anchor forms: `(^|[^A-Za-z])VERB` is a compile error in ugrep ("empty
   # expression") that the trailing `|| true` swallows, leaving `$match` empty
   # and every reader-verb block failing open; `\b`/`\<` compile everywhere, but
   # ugrep's `-o` then returns `cat .env` for `cat .env.example`, so the template
@@ -134,7 +133,9 @@ ${OVERRIDE_NOTE}"
   # The anchor also stops binaries whose name merely ends in a verb from
   # matching by accident (`nvim`, `gcat`, `zless`, …); the common ones are
   # listed explicitly so the fix does not narrow what was blocked before.
-  reader_verbs='(cat|gcat|zcat|head|ghead|tail|gtail|less|zless|more|nano|vim|nvim|gvim|vi|code|read)'
+  # Anything else whose name merely ends in a verb (`multitail`, `lolcat`) is
+  # not matched any more.
+  reader_verbs='(cat|gcat|zcat|bzcat|xzcat|head|ghead|tail|gtail|less|zless|more|nano|vim|nvim|gvim|mvim|vi|code|read)'
   for pattern in '\.env\b' '\.ssh/' '\.aws/credentials' '\.kube/config' '\.docker/config\.json' 'credentials\.json' 'secrets\.json'; do
     # Capture the matched substring (verb + path) rather than a bare boolean, so
     # the block message can name what tripped it and the exemption below can

--- a/hooks-plugin/hooks/secret-protection.sh
+++ b/hooks-plugin/hooks/secret-protection.sh
@@ -121,20 +121,20 @@ ${OVERRIDE_NOTE}"
   # sensitive-file read (issue #2597).
   #
   # The hook may run under BSD grep 2.6.0 (macOS), GNU grep (CI) or ugrep, and
-  # they disagree on the shorter anchor forms: `(^|[^A-Za-z])VERB` is a compile error in ugrep ("empty
-  # expression") that the trailing `|| true` swallows, leaving `$match` empty
-  # and every reader-verb block failing open; `\b`/`\<` compile everywhere, but
-  # ugrep's `-o` then returns `cat .env` for `cat .env.example`, so the template
-  # exemption below never sees the suffix and a template read is blocked. The
-  # explicit alternation behaves the same on all three. Its second branch
-  # captures one boundary character, trimmed from `$match` before the block
-  # message; the exemption re-greps from `${pattern}` and never sees it.
+  # they disagree on the shorter anchor forms. `(^|[^A-Za-z])VERB` is a compile
+  # error in ugrep 6.0.0 ("empty expression") that the trailing `|| true`
+  # swallows, leaving `$match` empty and every reader-verb block failing open.
+  # `\b`/`\<` compile everywhere, but ugrep's `-o` (6.0.0 and 7.8.4) then
+  # returns `cat .env` for `cat .env.example`, so the template exemption below
+  # never sees the suffix and a template read is blocked. The explicit
+  # alternation behaves the same on all three. Its second branch captures one
+  # boundary character, trimmed from `$match` before the block message; the
+  # exemption re-greps from `${pattern}` and never sees it.
   #
   # The anchor also stops binaries whose name merely ends in a verb from
-  # matching by accident (`nvim`, `gcat`, `zless`, …); the common ones are
-  # listed explicitly so the fix does not narrow what was blocked before.
-  # Anything else whose name merely ends in a verb (`multitail`, `lolcat`) is
-  # not matched any more.
+  # matching by accident. The common ones (`nvim`, `gcat`, `zless`, …) are
+  # listed explicitly so those reads stay blocked; anything else whose name
+  # merely ends in a verb (`multitail`, `lolcat`) is not matched any more.
   reader_verbs='(cat|gcat|zcat|bzcat|xzcat|head|ghead|tail|gtail|less|zless|more|nano|vim|nvim|gvim|mvim|vi|code|read)'
   for pattern in '\.env\b' '\.ssh/' '\.aws/credentials' '\.kube/config' '\.docker/config\.json' 'credentials\.json' 'secrets\.json'; do
     # Capture the matched substring (verb + path) rather than a bare boolean, so

--- a/hooks-plugin/hooks/secret-protection.sh
+++ b/hooks-plugin/hooks/secret-protection.sh
@@ -112,13 +112,28 @@ ${OVERRIDE_NOTE}"
   # secret at all, e.g. `... | head -1); grep -nE '\.env|PATTERN' "$f"`, where
   # the only `.env` is inside a grep pattern (issue #2444). Same greediness
   # class as the `.*` → `[A-Za-z0-9_]*` narrowing documented above (#1580).
+  #
+  # The verb group is anchored at a word start with `(^|[^A-Za-z])`, so a verb
+  # cannot match inside an ordinary English word. Without it `regardless`,
+  # `unless`, `thread`, `encode` and `furthermore` each supplied a verb, and
+  # prose that went on to mention `.env.integration` — a commit-message heredoc
+  # describing config precedence — was blocked as a sensitive-file read (issue
+  # #2597). `\b` / `\<` would be shorter but are GNU extensions; this hook may
+  # run under BSD grep (macOS), GNU grep (CI) or ugrep, and `(^|[^A-Za-z])` is
+  # POSIX ERE that all three accept. The alternative captures one leading
+  # non-letter character, which is trimmed from `$match` below before the block
+  # message; the template exemption re-greps from `${pattern}` and never sees it.
   reader_verbs='(cat|head|tail|less|more|nano|vim|vi|code|read)'
   for pattern in '\.env\b' '\.ssh/' '\.aws/credentials' '\.kube/config' '\.docker/config\.json' 'credentials\.json' 'secrets\.json'; do
     # Capture the matched substring (verb + path) rather than a bare boolean, so
     # the block message can name what tripped it and the exemption below can
     # inspect the actual path argument.
-    match=$(echo "$COMMAND" | grep -oE "${reader_verbs}[[:space:]]+[^|;&]*${pattern}[^[:space:]|;&'\"]*" | head -1 || true)
+    match=$(echo "$COMMAND" | grep -oE "(^|[^A-Za-z])${reader_verbs}[[:space:]]+[^|;&]*${pattern}[^[:space:]|;&'\"]*" | head -1 || true)
     [ -z "$match" ] && continue
+    # Drop the single boundary character the `(^|[^A-Za-z])` alternative
+    # captured (a space, `;`, `(`, quote, …); at start-of-line it captured
+    # nothing and the match already begins with the verb.
+    match="${match#[!A-Za-z]}"
 
     # .env.example / .env.sample / .env.template are templates committed by
     # convention, not secrets. check_sensitive_path() already exempts them on

--- a/hooks-plugin/hooks/test-secret-protection.sh
+++ b/hooks-plugin/hooks/test-secret-protection.sh
@@ -15,7 +15,8 @@
 #     `read` inside `thread`, `code` inside `encode` no longer supply the verb,
 #     so prose mentioning a `.env.<x>` token is NOT blocked (issue #2597).
 #     Binaries that used to match only because their name ends in a verb
-#     (`nvim`, `gcat`, `zless`, `bzcat`, `mvim`) are listed explicitly and stay blocked.
+#     (`nvim`, `gcat`, `zless`, `bzcat`, `xzcat`, `mvim`) are listed explicitly
+#     and stay blocked.
 set -euo pipefail
 
 HOOK="$(cd "$(dirname "$0")" && pwd)/secret-protection.sh"
@@ -255,6 +256,10 @@ assert_exit \
 assert_exit \
     "mvim .env (previously a sub-word match) is still blocked" 2 \
     "mvim ${env_token}"
+
+assert_exit \
+    "xzcat .env.prod (previously a sub-word match) is still blocked" 2 \
+    "xzcat ${env_token}.prod"
 
 # The block message names what tripped it. The anchor's second alternative
 # captures one boundary character ahead of the verb; the hook trims it, so the

--- a/hooks-plugin/hooks/test-secret-protection.sh
+++ b/hooks-plugin/hooks/test-secret-protection.sh
@@ -14,6 +14,8 @@
 #   - Reader verbs are anchored at a word start: `less` inside `regardless`,
 #     `read` inside `thread`, `code` inside `encode` no longer supply the verb,
 #     so prose mentioning a `.env.<x>` token is NOT blocked (issue #2597).
+#     Binaries that used to match only because their name ends in a verb
+#     (`nvim`, `gcat`, `zless`) are listed explicitly and stay blocked.
 set -euo pipefail
 
 HOOK="$(cd "$(dirname "$0")" && pwd)/secret-protection.sh"
@@ -224,12 +226,46 @@ assert_exit \
     "read < ${env_token}"
 
 assert_exit \
-    "ls -la; less .env (verb after ';' — the anchor's one-char alternative) is still blocked" 2 \
+    "ls -la; less .env (verb after ';') is still blocked" 2 \
     "ls -la; less ${env_token}"
 
 assert_exit \
-    "less .env (start-of-line verb — the anchor's ^ alternative) is still blocked" 2 \
+    "less .env (start-of-line verb) is still blocked" 2 \
     "less ${env_token}"
+
+# Before the anchor these matched by accident (`vim` inside `nvim`, `cat`
+# inside `gcat`, `less` inside `zless`); they are now listed verbs, so the
+# anchor must not have narrowed what was blocked.
+assert_exit \
+    "nvim .env (listed verb, previously a sub-word match) is still blocked" 2 \
+    "nvim ${env_token}"
+
+assert_exit \
+    "gcat .env (coreutils prefix, previously a sub-word match) is still blocked" 2 \
+    "gcat ${env_token}"
+
+assert_exit \
+    "zless .env.local (previously a sub-word match) is still blocked" 2 \
+    "zless ${env_token}.local"
+
+# The block message names what tripped it. The anchor's second alternative
+# captures one boundary character ahead of the verb; the hook trims it, so the
+# quoted match must start at the verb and not at the separator before it.
+assert_matched_text() {
+    local desc="$1" expected="$2" cmd="$3"
+    local json out
+    json=$(jq -nc --arg cmd "$cmd" '{tool_name:"Bash",tool_input:{command:$cmd}}')
+    out=$(printf '%s' "$json" | bash "$HOOK" 2>&1 || true)
+    if echo "$out" | grep -qF "matched: '${expected}'"; then
+        printf "  PASS: %s\n" "$desc"; PASS=$((PASS + 1))
+    else
+        printf "  FAIL: %s (message was: %s)\n" "$desc" "$(echo "$out" | head -1)"; FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_matched_text \
+    "ls -la; less .env reports the match from the verb, not the separator" "less ${env_token}" \
+    "ls -la; less ${env_token}"
 
 # ── block-message framing: operator-only, not a self-serve bypass ────────────
 # Regression: every block message used to end "Set

--- a/hooks-plugin/hooks/test-secret-protection.sh
+++ b/hooks-plugin/hooks/test-secret-protection.sh
@@ -11,6 +11,9 @@
 #     `.*` greediness that bridged `$(date)` to a distant `FE_KEYCLOAK_URL` is
 #     fixed (issue #1580).
 #   - Sensitive file reads (.env, .ssh, credentials) are still blocked.
+#   - Reader verbs are anchored at a word start: `less` inside `regardless`,
+#     `read` inside `thread`, `code` inside `encode` no longer supply the verb,
+#     so prose mentioning a `.env.<x>` token is NOT blocked (issue #2597).
 set -euo pipefail
 
 HOOK="$(cd "$(dirname "$0")" && pwd)/secret-protection.sh"
@@ -161,6 +164,72 @@ assert_exit \
 assert_exit \
     "head README.md; cat ~/.ssh/id_ed25519 (real key read after ';') is still blocked" 2 \
     "head -5 README.md; cat ~/.ssh/id_ed25519"
+
+# ── reader verbs are anchored at a word start (issue #2597) ──────────────────
+# `regardless`, `nevertheless`, `unless` end in `less`; `thread` in `read`;
+# `encode` in `code`; `furthermore` in `more`. With no word-start anchor each
+# supplied a reader verb, and any later `.env.<x>` token in the same statement
+# (a commit-message heredoc, for instance) was blocked as a sensitive-file read.
+# The `.env` token is assembled at runtime so the commands below never carry
+# the literal as a whole; the hook still receives the fully assembled string.
+echo ""
+echo "reader verbs do not match inside English words; real reads still blocked:"
+
+env_token="$(printf '.%s' env)"
+
+assert_exit \
+    "'regardless of the .env.integration value' (prose, no read) is allowed" 0 \
+    "regardless of the ${env_token}.integration value"
+
+assert_exit \
+    "'nevertheless the .env.local pin holds' (prose, no read) is allowed" 0 \
+    "nevertheless the ${env_token}.local pin holds"
+
+assert_exit \
+    "'unless the .env file is present' (prose, no read) is allowed" 0 \
+    "unless the ${env_token} file is present"
+
+assert_exit \
+    "'the thread that writes .env.ci' (prose, no read) is allowed" 0 \
+    "the thread that writes ${env_token}.ci"
+
+assert_exit \
+    "'we encode the .env.prod secret name' (prose, no read) is allowed" 0 \
+    "we encode the ${env_token}.prod secret name"
+
+assert_exit \
+    "'furthermore the .env.test override' (prose, no read) is allowed" 0 \
+    "furthermore the ${env_token}.test override"
+
+# True-positive controls: the anchor must not let a genuine read through, at
+# start-of-line, after a separator, or with a redirect instead of an argument.
+assert_exit \
+    "cat .env (start-of-line verb) is still blocked" 2 \
+    "cat ${env_token}"
+
+assert_exit \
+    "head -5 .env.production is still blocked" 2 \
+    "head -5 ${env_token}.production"
+
+assert_exit \
+    "less .env.local is still blocked" 2 \
+    "less ${env_token}.local"
+
+assert_exit \
+    "tail -f .env.prod is still blocked" 2 \
+    "tail -f ${env_token}.prod"
+
+assert_exit \
+    "read < .env (redirect, not an argument) is still blocked" 2 \
+    "read < ${env_token}"
+
+assert_exit \
+    "ls -la; less .env (verb after ';' — the anchor's one-char alternative) is still blocked" 2 \
+    "ls -la; less ${env_token}"
+
+assert_exit \
+    "less .env (start-of-line verb — the anchor's ^ alternative) is still blocked" 2 \
+    "less ${env_token}"
 
 # ── block-message framing: operator-only, not a self-serve bypass ────────────
 # Regression: every block message used to end "Set

--- a/hooks-plugin/hooks/test-secret-protection.sh
+++ b/hooks-plugin/hooks/test-secret-protection.sh
@@ -15,7 +15,7 @@
 #     `read` inside `thread`, `code` inside `encode` no longer supply the verb,
 #     so prose mentioning a `.env.<x>` token is NOT blocked (issue #2597).
 #     Binaries that used to match only because their name ends in a verb
-#     (`nvim`, `gcat`, `zless`) are listed explicitly and stay blocked.
+#     (`nvim`, `gcat`, `zless`, `bzcat`, `mvim`) are listed explicitly and stay blocked.
 set -euo pipefail
 
 HOOK="$(cd "$(dirname "$0")" && pwd)/secret-protection.sh"
@@ -247,6 +247,14 @@ assert_exit \
 assert_exit \
     "zless .env.local (previously a sub-word match) is still blocked" 2 \
     "zless ${env_token}.local"
+
+assert_exit \
+    "bzcat .env (previously a sub-word match) is still blocked" 2 \
+    "bzcat ${env_token}"
+
+assert_exit \
+    "mvim .env (previously a sub-word match) is still blocked" 2 \
+    "mvim ${env_token}"
 
 # The block message names what tripped it. The anchor's second alternative
 # captures one boundary character ahead of the verb; the hook trims it, so the


### PR DESCRIPTION
## What

`hooks-plugin/hooks/secret-protection.sh`: the Bash-path reader-verb regex is anchored at a word start — `(^${reader_verbs}|[^A-Za-z]${reader_verbs})[[:space:]]+…` — and the one boundary character the second branch captures is trimmed from `$match` (`${match#[!A-Za-z]}`) before it reaches the block message. The verb list gains the binaries that were blocked before only because their names end in a listed verb: `gcat`, `zcat`, `bzcat`, `xzcat`, `ghead`, `gtail`, `zless`, `nvim`, `gvim`, `mvim`. The secret-env-var echo check, the `printenv`/`env` dump check, `check_sensitive_path()` and the template-exemption logic are unchanged; the exemption re-greps from `${pattern}` inside `$match`, so it never sees the boundary character. The inline comment beside the #1580 and #2444 notes records why this anchor shape and not `\b`, `\<` or `(^|[^A-Za-z])`, and names the trade the anchor makes.

`hooks-plugin/hooks/test-secret-protection.sh`: 20 new cases. The six prose strings from the issue must exit 0; seven real reads stay at exit 2 — `cat .env`, `head -5 .env.production`, `less .env.local`, `tail -f .env.prod`, `read < .env`, a chained `ls -la; less .env` and a start-of-line `less .env`; six reads that matched by accident before stay blocked — `nvim .env`, `gcat .env`, `zless .env.local`, `bzcat .env`, `mvim .env`, `xzcat .env.prod`; and one case reads the block message to assert the trimmed `matched:` text. The new cases assemble the dotenv token at runtime (`printf '.%s' env`); the pre-existing cases carry it literally, as they did on `main`.

## Why

`reader_verbs='(cat|head|tail|less|more|nano|vim|vi|code|read)'` had no word-start anchor, and its only call site is the `grep -oE` on the match line (`git grep -n reader_verbs origin/main -- hooks-plugin` returns the definition and that call, nothing else). `regardless`, `nevertheless` and `unless` supplied `less`; `thread` supplied `read`; `encode` supplied `code`; `furthermore` supplied `more`. Any later `.env.<x>` token in the same statement was then blocked as a sensitive-file read, with the sub-word verb quoted in the match text. The issue hit it writing a commit-message heredoc about Docker Compose `env_file` precedence, then again on the `echo … | grep -oE` probe that reproduces it.

The first revision used `(^|[^A-Za-z])` and stated that `\b` and `\<` are GNU extensions; review measured both claims false. BSD grep 2.6.0 accepts `\b` and `\<`, and this same invocation already relies on `\.env\b`. ugrep 6.0.0 rejects `(^|[^A-Za-z])` as an empty alternative (7.8.4, the build Claude Code ships as its Bash-tool `grep`, compiles it), and because the pipeline ends in `|| true` the error was silent: `$match` stayed empty and, with ugrep 6.0.0 as `grep`, every reader-verb block failed open (20 of 43 cases). `\b` is not the replacement: it compiles on all three greps, but ugrep's `-o` (6.0.0 and 7.8.4) returns the match truncated at the pattern's own `\b`, so the template exemption never sees a `.example` suffix and template reads are blocked (5 cases). The explicit alternation behaves the same on BSD grep, GNU grep and both ugrep versions.

## Reproduction

Each command fed to the hook as a `{"tool_name":"Bash","tool_input":{"command":…}}` payload on stdin, dotenv token assembled at runtime:

| Command | origin/main (54ad0dab) | this branch |
|---|---|---|
| `regardless of the .env.integration value` | exit 2, `matched: 'less of the .env.integration'` | exit 0 |
| `nevertheless the .env.local pin holds` | exit 2, `matched: 'less the .env.local'` | exit 0 |
| `unless the .env file is present` | exit 2, `matched: 'less the .env'` | exit 0 |
| `the thread that writes .env.ci` | exit 2, `matched: 'read that writes .env.ci'` | exit 0 |
| `we encode the .env.prod secret name` | exit 2, `matched: 'code the .env.prod'` | exit 0 |
| `furthermore the .env.test override` | exit 2, `matched: 'more the .env.test'` | exit 0 |
| `cat .env` | exit 2 | exit 2, `matched: 'cat .env'` |
| `head -5 .env.production` | exit 2 | exit 2 |
| `less .env.local` | exit 2 | exit 2 |
| `tail -f .env.prod` | exit 2 | exit 2 |
| `read < .env` | exit 2 | exit 2 |
| `ls -la; less .env` | exit 2 | exit 2, `matched: 'less .env'` (boundary character trimmed) |
| `less .env` | exit 2 | exit 2 |
| `nvim .env` | exit 2 (`vim` inside `nvim`) | exit 2 (listed verb) |
| `gcat .env` | exit 2 (`cat` inside `gcat`) | exit 2 (listed verb) |
| `zless .env.local` | exit 2 (`less` inside `zless`) | exit 2 (listed verb) |
| `bzcat .env` | exit 2 (`cat` inside `bzcat`) | exit 2 (listed verb) |
| `mvim .env` | exit 2 (`vim` inside `mvim`) | exit 2 (listed verb) |
| `xzcat .env.prod` | exit 2 (`cat` inside `xzcat`) | exit 2 (listed verb) |

Any other binary whose name merely ends in a listed verb (`multitail`, `lolcat`, `pcat`, …) matched by accident on `main` and does not now; the ten added to the list are the ones in common use on macOS and Linux.

## Gates

All rows run on the final commit, `ac76ffa6`.

| Command | Result |
|---|---|
| `bash hooks-plugin/hooks/test-secret-protection.sh` — `grep` resolves to `/usr/bin/grep` (BSD grep 2.6.0) | `Results: 50 passed, 0 failed` (30 at origin/main) |
| Same suite under GNU grep 3.11 (`docker run --rm -v <hooks>:/h:ro alpine:3.20`, `apk add grep jq bash`) | `Results: 50 passed, 0 failed` |
| Same suite with ugrep 6.0.0 symlinked as `grep` (grep emu mode) | `Results: 49 passed, 1 failed` — the two-argument template-then-secret case, which fails identically against the origin/main hook under ugrep (29/30) |
| `shellcheck hooks-plugin/hooks/secret-protection.sh hooks-plugin/hooks/test-secret-protection.sh` | exit 0, no findings |
| `pre-commit run` on both files, at commit | shellcheck, hardcoded-secrets, shell-scripting.md, mktemp sandbox guard, feature-flags catalog and `secret-protection hook regression` all Passed |
| Mutation: anchor removed from the `grep -oE` line in a scratch copy | `Results: 44 passed, 6 failed` — the six prose cases, under BSD and GNU grep |
| Mutation: the `${match#[!A-Za-z]}` trim removed | `Results: 49 passed, 1 failed` — the matched-text case, `matched: ' less .env'` |
| Mutation: `bzcat\|xzcat\|` dropped from the verb list | `Results: 48 passed, 2 failed` — the `bzcat` and `xzcat` cases |
| Manual probes, JSON payload on stdin, ugrep as `grep` | real read exit 2; prose exit 0; `nvim` exit 2 |

## Fix round 1

Review verdict on `6bb3e3ff`: changes-required — one blocker, three majors. The blocker was the ugrep compile error described above. `c934ef91` replaces the anchor with the explicit alternation, keeps the trim and pins it with the matched-text case, rewrites the hook comment from the measurements, and lists the verb-suffixed binaries so the common cases stay blocked; that trade is stated under Reproduction. The earlier claim that no command string in the test file carries the dotenv literal was an overclaim — sixteen pre-existing cases do — and is reworded.

## Fix round 2

Two review lenses on `c934ef91` reproduced every gate, including the anchor-form matrix under all three greps, and found one body error (this file has no `curl|bash` pattern — that check lives in `bash-antipatterns.sh` — so the sentence now names the checks the file has) and one inverted figure (20 of 43 cases failed open under the round-1 anchor, not 23). `33a56b14` adds `bzcat`, `xzcat` and `mvim`, which the review measured as newly unblocked, with pinning cases. The pre-existing first-match fail-open the review found — a template read followed by a real read in one command — predates this PR and is filed as #2611, together with the `${PAGER:-less}` expansion-terminated form found in round 3.

## Fix round 3

Review of `33a56b14` approved with nits: `xzcat` had no pinning case (dropping it alone left the suite green), the comment's "does not narrow what was blocked before" contradicted the sentence after it, the compile-error claim holds for ugrep 6.0.0 but not 7.8.4, and two comment lines were over-long. `ac76ffa6` pins `xzcat`, rewords the paragraph to "the common cases stay blocked", names the ugrep versions, and re-wraps the lines.

Closes #2597

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DhfHZTFhAWSmtpTRLstuY1
