### PR TITLE
refactor(testing-plugin): disambiguate the test-runner skill descriptions (cluster 1)

### DIFF
--- a/project-plugin/README.md
+++ b/project-plugin/README.md
@@ -43,7 +43,7 @@ Analyze project state and continue development where you left off.
 **Note:** Generic skill. For blueprint-driven projects, `/blueprint:execute` can pick and run the next logical action; `/project:continue` resumes hands-on TDD coding.
 
 ### `/project:test-loop`
-Run automated TDD cycle: test → fix → refactor.
+Test-fix-refactor loop that edits code between runs until the suite is green, bounded by `--max-cycles` (test → fix → refactor).
 
 **Features:**
 - Detects test command from project structure

--- a/project-plugin/skills/project-test-loop/SKILL.md
+++ b/project-plugin/skills/project-test-loop/SKILL.md
@@ -1,10 +1,10 @@
 ---
-description: Automated TDD test-fix-refactor cycle until tests pass. Use when looping on failing tests, running a TDD cycle, or driving RED/GREEN/REFACTOR until green.
+description: "Test-fix-refactor loop that edits code between runs until the suite is green, bounded by --max-cycles. Use when asked to make failing tests pass or drive a TDD RED/GREEN/REFACTOR cycle."
 args: "[test-pattern] [--max-cycles <N>]"
 argument-hint: "Optional test pattern to focus on; --max-cycles <N> to cap iterations (default 10)"
 allowed-tools: Read, Edit, Bash, Bash(bash *)
 created: 2025-12-16
-modified: 2026-09-02
+modified: 2026-09-05
 reviewed: 2026-09-02
 name: project-test-loop
 ---

--- a/testing-plugin/README.md
+++ b/testing-plugin/README.md
@@ -10,10 +10,10 @@ This plugin provides comprehensive testing support including test runners, TDD w
 
 | Skill | Description |
 |-------|-------------|
-| `test-run` | Run the project's tests once — whole suite or a name pattern, framework auto-detected |
+| `test-run` | Run the project's tests — whole suite or a name pattern, framework auto-detected |
 | `test-quick` | Unit tier only — skips slow, integration, and E2E tests for sub-30s feedback |
 | `test-focus` | One test file, fail-fast — headed/debug and serial single-worker modes |
-| `test-full` | Every tier in pyramid order — unit, integration, E2E — with coverage |
+| `test-full` | Every tier in pyramid order — unit, integration, E2E; coverage optional |
 | `test-setup` | Configure testing infrastructure with CI/CD integration |
 | `test-consult` | Consult test-architecture agent for testing strategy |
 | `test-report` | Cached results from the last run — pass/fail, coverage, history, flaky tests — no re-run |

--- a/testing-plugin/README.md
+++ b/testing-plugin/README.md
@@ -10,15 +10,15 @@ This plugin provides comprehensive testing support including test runners, TDD w
 
 | Skill | Description |
 |-------|-------------|
-| `test-run` | Universal test runner - auto-detects and runs appropriate testing framework |
-| `test-quick` | Fast unit tests only (skip slow/integration/E2E) |
-| `test-focus` | Run single test file with fail-fast mode for rapid iteration |
-| `test-full` | Complete test suite including integration and E2E tests |
+| `test-run` | Run the project's tests once — whole suite or a name pattern, framework auto-detected |
+| `test-quick` | Unit tier only — skips slow, integration, and E2E tests for sub-30s feedback |
+| `test-focus` | One test file, fail-fast — headed/debug and serial single-worker modes |
+| `test-full` | Every tier in pyramid order — unit, integration, E2E — with coverage |
 | `test-setup` | Configure testing infrastructure with CI/CD integration |
 | `test-consult` | Consult test-architecture agent for testing strategy |
-| `test-report` | Show test status from last run (without re-executing) |
+| `test-report` | Cached results from the last run — pass/fail, coverage, history, flaky tests — no re-run |
 | `test-analyze` | Analyze test results for patterns and improvements |
-| `test-tier-selection` | Determine appropriate test tier (unit, integration, e2e) |
+| `test-tier-selection` | Decide which tier a change needs (unit / integration / E2E); runs nothing itself |
 | `test-quality-analysis` | Analyze and improve test quality |
 | `test-strategy-review` | Audit whether a green suite actually tests what you aim for (adversarial + tests-hidden cold read, verified) |
 | `property-based-testing` | Property-based testing with fast-check (TS/JS) and Hypothesis (Python) |

--- a/testing-plugin/skills/test-focus/SKILL.md
+++ b/testing-plugin/skills/test-focus/SKILL.md
@@ -1,11 +1,11 @@
 ---
 created: 2026-01-19
-modified: 2026-05-09
+modified: 2026-09-05
 reviewed: 2026-04-25
 allowed-tools: Bash, Read, Grep, Glob, TodoWrite
 args: "<file-path> [--serial] [--debug]"
 argument-hint: "<file-path> [--serial] [--debug]"
-description: "Run one test file fail-fast for rapid TDD — Playwright, Vitest, Jest, pytest, cargo, go test. Use when iterating on a failing spec, headed/debug mode, or serial WebGL tests."
+description: "One test file, fail-fast — Playwright, Vitest, Jest, pytest, cargo, go test. Use when running a single spec file, headed/debug mode, or serial single-worker WebGL tests."
 name: test-focus
 ---
 

--- a/testing-plugin/skills/test-full/SKILL.md
+++ b/testing-plugin/skills/test-full/SKILL.md
@@ -1,11 +1,11 @@
 ---
 created: 2025-12-16
-modified: 2026-07-04
+modified: 2026-09-05
 reviewed: 2026-04-25
 allowed-tools: Task, TodoWrite
 args: "[--coverage] [--parallel] [--report]"
 argument-hint: "[--coverage] [--parallel] [--report]"
-description: "Run complete test suite in pyramid order — unit, integration, E2E. Use when running all tests before a PR, generating coverage reports, or doing pre-commit verification."
+description: "Every tier in pyramid order — unit, then integration, then E2E — with coverage. Use when running all tests before a PR or commit, or generating a coverage report."
 name: test-full
 agent: general-purpose
 context: fork

--- a/testing-plugin/skills/test-full/SKILL.md
+++ b/testing-plugin/skills/test-full/SKILL.md
@@ -5,7 +5,7 @@ reviewed: 2026-04-25
 allowed-tools: Task, TodoWrite
 args: "[--coverage] [--parallel] [--report]"
 argument-hint: "[--coverage] [--parallel] [--report]"
-description: "Every tier in pyramid order — unit, then integration, then E2E — with coverage. Use when running all tests before a PR or commit, or generating a coverage report."
+description: "Every tier in pyramid order — unit, then integration, then E2E. Use when running all tests before a PR or commit, or generating a coverage report."
 name: test-full
 agent: general-purpose
 context: fork

--- a/testing-plugin/skills/test-quick/SKILL.md
+++ b/testing-plugin/skills/test-quick/SKILL.md
@@ -1,11 +1,11 @@
 ---
 created: 2025-12-16
-modified: 2026-06-18
+modified: 2026-09-05
 reviewed: 2026-04-25
 allowed-tools: Task, TodoWrite
 args: "[path] [--watch] [--affected]"
 argument-hint: "[path] [--watch] [--affected]"
-description: "Run fast unit tests only, skip slow/integration/E2E. Use when checking units after a change, running affected tests since last commit, watch mode TDD, or sub-30s feedback."
+description: "Unit tier only — skips slow, integration, and E2E tests for sub-30s feedback. Use when checking units after a change, running tests affected since the last commit, or unit watch mode."
 name: test-quick
 ---
 

--- a/testing-plugin/skills/test-report/SKILL.md
+++ b/testing-plugin/skills/test-report/SKILL.md
@@ -1,11 +1,11 @@
 ---
 created: 2025-12-16
-modified: 2026-05-09
+modified: 2026-09-05
 reviewed: 2026-04-25
 allowed-tools: Read, Glob, Bash(git *)
 args: "[--history] [--coverage] [--flaky]"
 argument-hint: "[--history] [--coverage] [--flaky]"
-description: "Show cached test status without re-running. Use when checking test health, standup status, coverage summary, history, or identifying flaky tests from recent runs."
+description: "Cached results from the last test run, no re-run — pass/fail counts, existing coverage report, history, flaky tests. Use when asked for current test status or standup health."
 name: test-report
 ---
 

--- a/testing-plugin/skills/test-run/SKILL.md
+++ b/testing-plugin/skills/test-run/SKILL.md
@@ -1,11 +1,11 @@
 ---
 created: 2025-12-16
-modified: 2026-06-18
+modified: 2026-09-05
 reviewed: 2026-04-25
 allowed-tools: Task, TodoWrite
 args: "[test-pattern] [--coverage] [--watch]"
 argument-hint: "[test-pattern] [--coverage] [--watch]"
-description: "Universal test runner auto-detecting pytest, vitest, jest, cargo, go test. Use when running tests, targeting a file/pattern, running with coverage, or watch-mode dev loops."
+description: "Run the project's tests once — auto-detects pytest, vitest, jest, cargo, go test; whole suite or a name pattern. Use when asked to run the tests and no tier, single file, or fix cycle is named."
 name: test-run
 ---
 

--- a/testing-plugin/skills/test-run/SKILL.md
+++ b/testing-plugin/skills/test-run/SKILL.md
@@ -5,7 +5,7 @@ reviewed: 2026-04-25
 allowed-tools: Task, TodoWrite
 args: "[test-pattern] [--coverage] [--watch]"
 argument-hint: "[test-pattern] [--coverage] [--watch]"
-description: "Run the project's tests once — auto-detects pytest, vitest, jest, cargo, go test; whole suite or a name pattern. Use when asked to run the tests and no tier, single file, or fix cycle is named."
+description: "Run the project's tests — auto-detects pytest, vitest, jest, cargo, go test; whole suite or a name pattern. Use when asked to run the tests and no tier, single file, or fix cycle is named."
 name: test-run
 ---
 

--- a/testing-plugin/skills/test-tier-selection/SKILL.md
+++ b/testing-plugin/skills/test-tier-selection/SKILL.md
@@ -1,9 +1,9 @@
 ---
 created: 2025-12-16
-modified: 2026-07-31
+modified: 2026-09-05
 reviewed: 2026-04-25
 name: test-tier-selection
-description: "Auto-select test tiers based on change scope — unit for small, full suite for large. Use when running tests, discussing testing strategy, or after code modifications."
+description: "Decide which test tier a change needs — unit, integration, or E2E — from its scope; runs nothing itself. Use when deciding how much of the suite to run after a change."
 user-invocable: false
 allowed-tools: Read, Glob, Grep
 ---


### PR DESCRIPTION
## What

Cluster 1 of #2244. The frontmatter `description:` of the six `testing-plugin` runners — `test-run`, `test-quick`, `test-full`, `test-focus`, `test-tier-selection`, `test-report` — and of `project-plugin:project-test-loop` is rewritten so each leads with the one axis that separates it from the other six. `modified:` is bumped to 2026-09-05 on each. The six matching `testing-plugin/README.md` skill rows and the `project-plugin/README.md` test-loop one-liner are updated in the same commit so the READMEs describe the same boundaries (`docs-currency.md`).

Description-only, per the 2026-08-15 decision on the issue: no skill is retired or merged, and no body text changes. Cluster 6 landed in #2401; clusters 2–5 stay open.

## Why

All seven described the same intent — "run tests" — in overlapping words, so the text carried no phrase a router could use to prefer one over another. Read from disk on `origin/main` (the issue's inventory heads match the disk text):

| Shared claim | Carried before by | After |
|---|---|---|
| the unqualified trigger "Use when running tests" | `test-run`, `test-tier-selection` | `test-run` only ("asked to run the tests"); `test-quick` and `test-full` keep qualified forms — "tests affected since the last commit", "all tests before a PR" |
| coverage | `test-run`, `test-full`, `test-report` ("coverage summary") | `test-full` generates a report; `test-report` reads an existing one; `test-run` drops the claim |
| watch mode | `test-run`, `test-quick` | `test-quick` only |
| TDD | `test-focus`, `test-quick`, `project-test-loop` | `project-test-loop` only |
| "failing spec" / "failing tests" | `test-focus`, `project-test-loop` | `project-test-loop` only; `test-focus` says "a single spec file" |
| "after code modifications" / "after a change" | `test-quick`, `test-tier-selection` | both keep it with different verbs — `test-quick` runs, `test-tier-selection` decides |
| "discussing testing strategy" | `test-tier-selection` (territory of `test-consult`) | dropped |

The rewrite rule is the issue's: lead with the discriminator, name it, delete territory a sibling owns. `test-run` also gains the literal phrase "run the project's tests" the issue asks for, so it has a phrase to win with against the workflow skills that mention TDD in passing.

## Reproduction

Before/after text, read from each `SKILL.md` on disk. Lengths are characters. Six descriptions stay in the OK band (151–200) and `test-full` sits at 146, inside the audit's accepted range and carries exactly one literal `Use when`.

| Skill | | chars |
|---|---|---|
| `testing-plugin:test-run` | **was:** `Universal test runner auto-detecting pytest, vitest, jest, cargo, go test. Use when running tests, targeting a file/pattern, running with coverage, or watch-mode dev loops.` | 172 |
| | **now:** `Run the project's tests — auto-detects pytest, vitest, jest, cargo, go test; whole suite or a name pattern. Use when asked to run the tests and no tier, single file, or fix cycle is named.` | 188 |
| `testing-plugin:test-quick` | **was:** `Run fast unit tests only, skip slow/integration/E2E. Use when checking units after a change, running affected tests since last commit, watch mode TDD, or sub-30s feedback.` | 171 |
| | **now:** `Unit tier only — skips slow, integration, and E2E tests for sub-30s feedback. Use when checking units after a change, running tests affected since the last commit, or unit watch mode.` | 183 |
| `testing-plugin:test-full` | **was:** `Run complete test suite in pyramid order — unit, integration, E2E. Use when running all tests before a PR, generating coverage reports, or doing pre-commit verification.` | 169 |
| | **now:** `Every tier in pyramid order — unit, then integration, then E2E. Use when running all tests before a PR or commit, or generating a coverage report.` | 146 |
| `testing-plugin:test-focus` | **was:** `Run one test file fail-fast for rapid TDD — Playwright, Vitest, Jest, pytest, cargo, go test. Use when iterating on a failing spec, headed/debug mode, or serial WebGL tests.` | 173 |
| | **now:** `One test file, fail-fast — Playwright, Vitest, Jest, pytest, cargo, go test. Use when running a single spec file, headed/debug mode, or serial single-worker WebGL tests.` | 169 |
| `testing-plugin:test-tier-selection` | **was:** `Auto-select test tiers based on change scope — unit for small, full suite for large. Use when running tests, discussing testing strategy, or after code modifications.` | 166 |
| | **now:** `Decide which test tier a change needs — unit, integration, or E2E — from its scope; runs nothing itself. Use when deciding how much of the suite to run after a change.` | 167 |
| `testing-plugin:test-report` | **was:** `Show cached test status without re-running. Use when checking test health, standup status, coverage summary, history, or identifying flaky tests from recent runs.` | 162 |
| | **now:** `Cached results from the last test run, no re-run — pass/fail counts, existing coverage report, history, flaky tests. Use when asked for current test status or standup health.` | 174 |
| `project-plugin:project-test-loop` | **was:** `Automated TDD test-fix-refactor cycle until tests pass. Use when looping on failing tests, running a TDD cycle, or driving RED/GREEN/REFACTOR until green.` | 154 |
| | **now:** `Test-fix-refactor loop that edits code between runs until the suite is green, bounded by --max-cycles. Use when asked to make failing tests pass or drive a TDD RED/GREEN/REFACTOR cycle.` | 185 |

Net length is +45 characters over the seven (1167 → 1212, recounted from the `origin/main`…`HEAD` diff). The lengths are not tightened on purpose: #2244 lands before #2119, so shortening waits for that pass.

## Routing spot-check

Harness: `experiments/skill-catalog-routing`, arm `haiku-C4` — the full-description catalog (the harness's ~20.7k-token upper anchor) on its cheapest model — copied into a scratch directory so the committed catalogs and task set were untouched. Two catalogs were built with the harness's own `build-catalogs.py`: one from `origin/main` (`54ad0dab`, 423 entries) and one from this branch. Eight new tasks span the seven skills, two of them for `test-run` (a bare run, and a name pattern); `check-tasks.py --strict` reports `ERROR_COUNT=0 WARN_COUNT=0` on the set. One run per task per arm: 16 `claude -p` calls, all exit 0.

| # | Prompt (abridged) | Gold | Before: pick → runner-up | After: pick → runner-up |
|---|---|---|---|---|
| s01 | Run the tests for this repo and tell me what fails | test-run | test-run → test-full | test-run → test-full |
| s02 | Run only the unit tests covering what I touched since my last commit; skip anything slow | test-quick | test-quick → test-tier-selection | test-quick → test-tier-selection |
| s03 | Before I open the PR, run everything (unit, integration, E2E) and give me a coverage report | test-full | test-full → test-run | test-full → NONE |
| s04 | Run tests/e2e/login.spec.ts on its own, stop at the first failure, headed | test-focus | test-focus → NONE | test-focus → test-run |
| s05 | I touched three API files and a migration; how much of the suite does this change need? | test-tier-selection | test-tier-selection → NONE | test-tier-selection → NONE |
| s06 | State of the tests from the last run, no re-run, numbers for standup | test-report | test-report → NONE | test-report → NONE |
| s07 | Suite is red; keep fixing the code and re-running until it passes, cap at five rounds | project-test-loop | project-test-loop → `agents-plugin:debug` (not a catalog id) | project-test-loop → test-run |
| s08 | Run only the tests whose names match "auth", a normal run | test-run | test-run → test-focus | test-run → test-focus |

Top-1 is 8/8 in both arms and no prompt has two descriptions tied after. It also means this instrument shows no top-1 movement: a forced-choice classifier over the full 423-entry catalog already resolved these eight prompts with the old text at N=1. What moved is the runner-up column. s03's runner-up leaves the cluster (`test-run` no longer competes for the coverage prompt). s07's before-runner-up `agents-plugin:debug` is not a catalog id — `agents-plugin` ships one skill, `agents-analyze`, and `debug.md` is an agent — so the router emitted it against the prompt's own no-invented-ids rule; after, the runner-up is `test-run`, inside the test family. Two runner-ups persist on both sides — s01 → `test-full` and s08 → `test-focus`: a bare "run the tests" sits next to "every tier", and "tests matching a name" next to "one file". The picks are correct in both cases; the adjacency remains.

Two caveats on the instrument. The router is the harness's classifier prompt, not Claude Code's auto-invocation matcher, and the issue's evidence is usage counts, which this run does not measure. And `score-run.py` marked 14 of the 16 correct picks `correct=0`: haiku emitted ids in the repo's `plugin:skill` form while the scorer matches `plugin/skill` literally, so the table reads the `predicted` column directly. That separator gap is a harness follow-up and is not changed here.

## Gates

Rows 1–3 re-measured in fix round 2 at `3ce231ea`; rows 4–6 are round-1 results at `99e48c52`, on descriptions that differ from the current ones only by the two phrases round 2 removed.

| Command | Measured result |
|---|---|
| `python3 scripts/audit-skill-descriptions.py --strict-all` | exit 0 — `Audited 423 skills across 44 plugins`, `OK 423 (100.0%)`, `NEEDS FIX 0`; `--json` reports the seven at `category=OK`, `length_category=OK` for six and `IDEAL` for `test-full` (146 chars, at the IDEAL ceiling); lengths 146–188, `auto_invokable=True` |
| `python3 scripts/audit-skill-descriptions.py --strict-length` | exit 0 — `ERROR (>300 chars) 0` |
| `pre-commit run --files` on the three files round 2 touched (`test-run`, `test-full`, `testing-plugin/README.md`) | exit 0 — 20 hooks Passed, 0 Failed; both description audits Passed, `check-docs-index` `STATUS=OK`, `nudge-plugin-readme-currency` `STATUS=OK` |
| `bash scripts/plugin-compliance-check.sh testing-plugin project-plugin` | `diff` against the same command run in a `git archive origin/main` export is empty — testing-plugin Descriptions ⚠️ from the pre-existing `test-strategy-review` 236-char row on both sides, project-plugin ✅ throughout |
| `grep -o 'Use when'` over each of the seven `description:` lines | count 1 for all seven |
| routing spot-check (above) | 8/8 top-1 before, 8/8 after, 0 ties after; not re-run in fix rounds 1 or 2 — the round-1 verifier reproduced it with 16 fresh calls at `99e48c52` (8/8 both arms, 0 ties); the round-2 verifier's cold read at `3ce231ea` found no new tie |

## Fix round 1

Body-only; the head commit stays `99e48c52`. Review found one factual error here: the net description length read "+51", and the table's own numbers sum to 1167 → 1233 = +66. Corrected, with the recount method stated. The other edits from the same review: the C4 arm was labelled "the cheapest documented arm" when it is the harness's highest-token catalog (haiku is the cheap part); the s07 before-runner-up `agents-plugin:debug` was described as an agent from another plugin without saying it is not a catalog id at all; the first Why row now names the literal unqualified trigger two skills shared, since the new `test-quick` and `test-full` still contain "running tests" in qualified form — the commit body's three-claimant count reads `test-quick`'s old "running affected tests" as a claimant, the table counts the literal trigger; the `git log` commit-count row and the `## Also touched` section are dropped, one because the page renders it and the other because both READMEs are inside this group's path list.

## Fix round 2

`3ce231ea` drops two words the round-1 review flagged as drift between a description and its `args:`. `test-run` no longer says it runs the tests "once" — its `--watch` flag is a loop — and `test-full` no longer says "with coverage", since its `--coverage` is optional; the `Use when` clause still names generating a coverage report, which is the routing discriminator. The two README rows follow. With those words gone, the `## When to Use` body rows the review listed ("Generating coverage in the standard run", "Running watch-mode TDD on unit tests", "Running tests for one specific framework run") describe capabilities the descriptions no longer deny, so the body stays untouched and nothing is parked on #2244 for them. The routing spot-check was not re-run in round 2; the verifier's cold read at this commit covers it.

Refs #2244

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DhfHZTFhAWSmtpTRLstuY1

