### PR TITLE
docs(git-plugin): name the bot-recommendation-as-decision trap, and measure self-review

### DIFF
--- a/.claude/rules/loop-integrity.md
+++ b/.claude/rules/loop-integrity.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-06-22
-modified: 2026-06-23
+modified: 2026-09-05
 reviewed: 2026-07-04
 ---
 
@@ -34,6 +34,19 @@ that shares the worker's context inherits the worker's motivation to be done.
 | Who decides "done"? | The worker | A fresh `Agent` / sub-agent that did not do the work |
 | What it reads | Its own reasoning trace | Acceptance criteria + the artefact only |
 | Bias | Toward declaring completion | Toward the criterion as written |
+
+> Measured 2026-09-04 (`claude-plugins`, seven issue→PR pipelines). Each
+> implementer ran an external model over its **own** diff before opening its PR,
+> with an adversarial brief and instructions to verify each finding. Across all
+> seven that pass accepted **zero** findings. A second pass by a fresh agent that
+> had not done the work — same model, different brief, and re-running the
+> implementer's own gates rather than reading its report — held four of the seven
+> PRs. It found six reproduced bypasses in a hook whose 45-assertion suite was
+> fully green, a PR whose every gate number predated a bot push to its branch,
+> and a guard that counted any `*.md` file as a template. The variable was not
+> the model or the prompt; it was whether the reviewer had a stake in the work
+> being done.
+
 
 Cheap mechanical exit conditions (a green test suite, a clean `tsc`, exit code
 0) are *already* independent — a failing test does not care how hard you worked.

--- a/git-plugin/skills/git-issue-scoping/SKILL.md
+++ b/git-plugin/skills/git-issue-scoping/SKILL.md
@@ -3,7 +3,7 @@ name: git-issue-scoping
 description: "Read an issue's full comment thread and re-verify its cited evidence at HEAD. Use when scoping a PR or plan from a GitHub issue, or before filing or reversing one in your own tracker."
 allowed-tools: Read, Grep, Glob, Bash(gh issue *), Bash(gh pr *), Bash(gh api *), Bash(git log *), TodoWrite
 created: 2026-08-19
-modified: 2026-08-19
+modified: 2026-09-05
 reviewed: 2026-08-19
 ---
 
@@ -69,6 +69,43 @@ Specifically extract, before writing any code:
 
 If you only have a summary and a gap has passed, **re-read the live thread** before
 acting — the discussion may have moved.
+
+## A bot's recommendation is not a maintainer decision
+
+Point 1 above asks whether the maintainer chose an approach. The trap is that an
+automated triage comment **looks like** that choice. A `needs-decision` routine
+posts options A/B/C, adds its own **"I'd default to B"**, and closes with "reply
+here and the next run will implement the chosen option". Nothing has been
+decided. The recommendation is the bot's, and the reply it asks for is what would
+make it a decision.
+
+Read authorship and look for the reply, in the same call that fetches the thread:
+
+```sh
+gh issue view <n> --repo <owner>/<repo> --json comments --jq '.comments | length, (.[] | .author.login + " | " + (.body[0:80]))'
+```
+
+A single comment that is itself the request for a decision means the decision is
+**open**. Implement nothing that depends on it; ask the human, or say in the PR
+that you picked an option and which one.
+
+> Observed 2026-09-04 (`claude-plugins` #2441, #2568): two agents in one batch
+> independently read a `<!-- routine:needs-decision v1 -->` comment's own
+> "I'd default to A" as the maintainer's choice and wrote it into their PR
+> bodies as settled. Both issues carried **exactly one comment** — that request
+> — with no reply, no reactions, and no review. On #2441 the routine had
+> recommended B, the agent shipped A, and the human's actual answer was B, so
+> the PR was built on the wrong option *and* cited an authority that did not
+> exist. Caught by an independent verifier running `--jq '.comments | length'`.
+
+Two consequences worth separating:
+
+- **`Closes #N` on an undecided issue** auto-closes the decision when the PR
+  merges. Use `Refs #N` until the option is chosen.
+- **A false attribution is load-bearing.** On #2568 it was the *only* cited
+  grounds for rejecting a reviewer's finding, so the finding had to be
+  re-examined once the attribution collapsed. Never cite a decision you have not
+  read; when you chose the option yourself, say so plainly.
 
 ## Your own tracker — search before filing, read before reversing
 


### PR DESCRIPTION
## What

Two distilled artifacts from one batch of seven issue→PR pipelines run on 2026-09-04.

**`git-plugin/skills/git-issue-scoping`** gains a section: *A bot's recommendation is not a maintainer decision.*

**`.claude/rules/loop-integrity.md`** Pillar 1 gains the measurement it was missing.

## Why

### The scoping blind spot

The skill's step 1 asks "has the maintainer chosen an implementation approach?". An automated triage comment offering options A/B/C, carrying its own **"I'd default to B"** and closing with "reply here and the next run will implement the chosen option", reads exactly like that choice. It is not one — the reply it asks for is what would make it one.

Two agents in the batch hit this independently:

| Issue | Comments on the issue | Routine recommended | Agent shipped | Human's actual answer |
|---|---:|---|---|---|
| #2441 | 1 (the request itself, no reply) | B | A, cited as a maintainer decision | B |
| #2568 | 1 (the request itself, no reply) | A | A, cited as a maintainer decision | A |

`gh api repos/…/issues/2441/comments --jq length` → `1`. Same for #2568. Neither had a reply, a reaction, or a review.

The new section carries the check (comment count and authorship in the same call that fetches the thread), and two consequences worth separating: `Closes #N` on an undecided issue auto-closes the decision at merge, and a false attribution is load-bearing rather than cosmetic — on #2568 it was the **only** cited grounds for rejecting an external reviewer's finding, so the finding had to be re-examined once the attribution collapsed.

### The Pillar 1 measurement

Pillar 1 argued from first principles that a worker cannot judge its own stop condition. It had no number behind it. The batch supplies one, with the review model, the prompt style, and the diff all held constant — only the reviewer's stake varied:

| Pass | Reviewer | Findings accepted |
|---|---|---|
| First | The implementer, over its own diff, adversarial brief, told to verify each finding | **0 across all seven PRs** |
| Second | A fresh agent that did not do the work, re-running the implementer's gates rather than reading its report | **held 4 of 7** |

What the second pass found: six reproduced bypasses in a hook whose 45-assertion suite was fully green, a PR whose every gate number predated a bot push to its branch, and a guard that counted any `*.md` file as a template.

## How

Both edits are additive prose. `git-issue-scoping` grows 8,124 → 10,039 chars, well inside the 26,000 ceiling. `loop-integrity.md` is unscoped and so counts against the C5 always-loaded budget; the ratchet passes.

## Gates

`pre-commit run --files .claude/rules/loop-integrity.md git-plugin/skills/git-issue-scoping/SKILL.md` → all applicable hooks Passed, including `always-loaded context surface stays within budget (C5 ratchet)`, `looping skills keep an independent stop condition + state packet`, `audit skill descriptions for listing-budget verbosity`, and the docs-index audit (`STATUS=OK ISSUE_COUNT=0`). Full pre-commit clean at commit time.

Refs #2441, #2568

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwfCsqB6VrNvf8GpC4rxp8
