### PR TITLE
feat(tools-plugin): document what `just --list` renders, and a tool that reads it

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -209,6 +209,12 @@ repos:
         language: system
         files: '^scripts/(check-subagent-types\.sh|tests/test-check-subagent-types\.sh)$'
         pass_filenames: false
+      - id: test-just-recipe-help
+        name: just recipe-help / --list description regression
+        entry: bash ./tools-plugin/scripts/tests/test-just-recipe-help.sh
+        language: system
+        files: '^tools-plugin/scripts/(just-recipe-help\.py|tests/test-just-recipe-help\.sh)$'
+        pass_filenames: false
       - id: check-unrendered-templates
         name: no unrendered {{ if }} template conditionals in skill bodies (#2265)
         entry: ./scripts/check-unrendered-templates.sh

--- a/tools-plugin/scripts/just-recipe-help.py
+++ b/tools-plugin/scripts/just-recipe-help.py
@@ -1,0 +1,647 @@
+#!/usr/bin/env python3
+"""What does this just recipe take? -- the flag list, without opening the script.
+
+`just --list` renders ONE line per recipe, and a justfile that keeps its
+reasoning in the comment block above each recipe cannot show it there. Worse,
+with no `[doc()]` attribute just falls back to that block's LAST line -- almost
+always the tail of an example -- so a well-commented justfile lists as a wall
+of fragments and the flags of the tool a recipe wraps are reachable only by
+opening it.
+
+Two mechanical reasons the obvious escapes do not work:
+
+  1. `just <recipe> --help` is REFUSED BY JUST for any recipe with a required
+     positional: "got 1 positional argument but takes at least 2". There is no
+     bare-help spelling for such a recipe.
+  2. Supplying dummy positionals does reach the tool -- and a script whose
+     argparse sits behind a module-scope import of a heavy dependency raises
+     ImportError before argparse ever runs, so --help is unreachable on any
+     checkout without that dependency installed.
+
+So this reads the SHIPPED SOURCE rather than running it: the recipe's own
+comment block out of the justfile, and the flags out of the script's AST. It
+imports nothing but the stdlib and needs no virtualenv, so it answers the same
+everywhere.
+
+It is NOT a substitute for argparse's own output and must not drift into one.
+Where the tool's dependencies are installed its own --help is authoritative,
+and this prints the exact command that reaches it.
+
+USAGE
+    just-recipe-help.py <recipe>        # comment block + flags for one recipe
+    just-recipe-help.py <script.py>     # one script by name
+    just-recipe-help.py --audit         # recipes with no [doc()] summary
+    just-recipe-help.py --justfile PATH --audit
+
+Wire it into the justfile it documents so it is reachable the way everything
+else is:
+
+    [doc("What a recipe takes: its notes plus the flags of the script it runs.")]
+    help *ARGS:
+        @python3 scripts/just-recipe-help.py {{ARGS}}
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+
+DOC = __doc__ or ""
+
+#: A recipe header at column 0: `name PARAMS:` or `name PARAMS: dependency`.
+#:
+#: `(?!=)` is what excludes a `NAME := value` assignment, and it is the ONLY
+#: thing that may: the params MUST be allowed to contain `=`, because a default
+#: value is spelled `PYBIN="python3"`. Forbidding `=` in the params silently
+#: drops every recipe that takes a default -- an under-report that reads
+#: exactly like a justfile with fewer recipes in it, which is why
+#: test-just-recipe-help.sh diffs this parse against `just --summary`.
+RECIPE_RE = re.compile(r"^(?P<name>[a-z0-9_][a-z0-9_-]*)(?P<params>[^:\n]*):(?!=)")
+
+DOC_RE = re.compile(r'^\[doc\("(?P<text>.*)"\)\]$')
+
+#: A path ending in .py or .sh anywhere in a recipe body, including the
+#: `{{var}}` interpolations a justfile uses to build one.
+SCRIPT_RE = re.compile(r"[\w./{}()\- ]*?[\w\-]+\.(?:py|sh)")
+
+#: `{{ anything }}`
+INTERP_RE = re.compile(r"\{\{[^}]*\}\}")
+
+
+# --------------------------------------------------------------- the justfile
+
+
+def find_justfile(explicit=None):
+    """The justfile to read: --justfile, else the nearest one at or above cwd."""
+    if explicit:
+        p = pathlib.Path(explicit).expanduser().resolve()
+        if not p.is_file():
+            raise SystemExit(f"just-recipe-help: no justfile at {p}")
+        return p
+    here = pathlib.Path.cwd().resolve()
+    for d in (here, *here.parents):
+        for name in ("justfile", "Justfile", ".justfile", "JUSTFILE"):
+            p = d / name
+            if p.is_file():
+                return p
+    raise SystemExit(
+        f"just-recipe-help: no justfile at or above {here}. Pass --justfile PATH."
+    )
+
+
+def just_variables(justfile):
+    """Resolved justfile variables, from `just --evaluate`.
+
+    This is the one place the tool shells out, and it is optional: without it a
+    `{{SCRIPTS}}/foo.py` body cannot be resolved to a path and the basename
+    search below takes over. Failing soft matters more than resolving every
+    path -- a missing `just` must not turn the whole tool off.
+    """
+    if shutil.which("just") is None:
+        return {}
+    try:
+        out = subprocess.run(
+            ["just", "--justfile", str(justfile), "--evaluate"],
+            capture_output=True,
+            text=True,
+            timeout=20,
+            cwd=str(justfile.parent),
+            env={**os.environ, "NO_COLOR": "1"},
+        )
+    except (OSError, subprocess.SubprocessError):
+        return {}
+    if out.returncode != 0:
+        return {}
+    variables = {}
+    for line in out.stdout.splitlines():
+        m = re.match(r'^(\w+)\s*:=\s*"(.*)"$', line.strip())
+        if m:
+            variables[m.group(1)] = m.group(2)
+    return variables
+
+
+class Recipe:
+    """One recipe, with everything `just --list` throws away."""
+
+    def __init__(self, name, params, doc, comment, body, line, attrs=()):
+        self.name = name
+        self.params = params.strip()
+        self.doc = doc  # the [doc("...")] summary, or ""
+        self.comment = comment  # the whole preceding # block, verbatim
+        self.body = body
+        self.line = line
+        self.attrs = list(attrs)
+
+    @property
+    def private(self):
+        """Hidden from `just --list` and `--summary` -- so it has nothing to
+        summarise there, and the audit must not demand a [doc()] for it.
+
+        TWO mechanisms, and the second is easy to miss: the `[private]`
+        attribute, and a LEADING UNDERSCORE, which just acts on by itself. A
+        `_helper:` with no attribute is absent from both listings. Checking
+        only the attribute makes the parse disagree with `just --summary` on
+        any justfile using the underscore convention.
+        """
+        return any(
+            a.strip() == "[private]" for a in self.attrs
+        ) or self.name.startswith("_")
+
+    @property
+    def needs_doc(self):
+        """Would `just --list` show nothing, or a fragment? -> (bool, why).
+
+        Two criteria this deliberately does NOT use, both tried and both wrong:
+
+        "has no [doc()]" flags every well-written justfile in existence -- a
+        single-line comment is a good description and just renders it
+        faithfully. "has a MULTI-line block" is nearly as bad: the careful way
+        to write one is a long block ending in a deliberate one-line summary,
+        exactly so `--list` shows that. Flagging it punishes the right habit,
+        and a gate that fires on everything is one nobody reads.
+
+        What IS mechanically a fragment is the shape of the last line, since
+        that is the only line just shows:
+        """
+        if self.private or self.doc:
+            return None
+        lines = [line for line in self.comment.splitlines() if line.strip()]
+        if not lines:
+            return "no comment block -- the listing is blank"
+        last = lines[-1].lstrip("#")
+        body = last.strip()
+        if not body:
+            return "the block's last line is empty"
+        # An indented line is a sub-item of the one above it, never a summary.
+        if last.startswith("  "):
+            return "the last line is indented, so it is a sub-item"
+        # A command example, which is what a block most often ends with.
+        if re.match(r"(just|\$|\./|uv|bun|npm|cargo|go|python3?|docker)\s", body):
+            return "the last line is a command example"
+        # A sentence continuing from the line above. A description does not
+        # begin lowercase; a wrapped clause almost always does.
+        if body[0].islower():
+            return "the last line continues a sentence from the line above"
+        return None
+
+    def script_token(self):
+        """The raw `.py`/`.sh` token in the body, interpolations intact."""
+        m = SCRIPT_RE.search(self.body)
+        return m.group(0).strip() if m else None
+
+
+def parse_justfile(text):
+    """Every recipe with its attributes, preceding comment block, and body.
+
+    Written against the source rather than `just --dump --dump-format json`
+    on purpose: the dump discards the comment block entirely, and the comment
+    block is the thing this tool exists to surface.
+    """
+    lines = text.splitlines()
+    recipes = {}
+    for i, line in enumerate(lines):
+        m = RECIPE_RE.match(line)
+        if not m:
+            continue
+
+        # Walk back over any attribute lines, then over the contiguous comment
+        # block. A blank line ends the block -- which is also just's own rule
+        # for which comment becomes a recipe's description.
+        j = i - 1
+        doc = ""
+        attrs = []
+        while j >= 0 and lines[j].startswith("["):
+            attrs.append(lines[j])
+            d = DOC_RE.match(lines[j].strip())
+            if d:
+                doc = d.group("text")
+            j -= 1
+        comment = []
+        while j >= 0 and lines[j].startswith("#"):
+            comment.append(lines[j])
+            j -= 1
+        comment.reverse()
+
+        k = i + 1
+        body = []
+        while k < len(lines) and (
+            lines[k].startswith((" ", "\t")) or not lines[k].strip()
+        ):
+            body.append(lines[k])
+            k += 1
+
+        recipes[m.group("name")] = Recipe(
+            m.group("name"),
+            m.group("params"),
+            doc,
+            "\n".join(comment).rstrip(),
+            "\n".join(body),
+            i + 1,
+            attrs,
+        )
+    return recipes
+
+
+def resolve_script(token, justfile, variables):
+    """A body's script token -> (path, pattern).
+
+    Exactly one of the two is set. `pattern` means the recipe builds its script
+    NAME from a parameter (`build_{{piece}}_workflow.py`), so there is no single
+    flag list -- reporting that is not the same as reporting no script at all,
+    and conflating them hides whole families of tool.
+    """
+    if token is None:
+        return None, None
+
+    resolved = token
+    for var, value in variables.items():
+        resolved = resolved.replace("{{%s}}" % var, value)
+        resolved = resolved.replace("{{ %s }}" % var, value)
+    for fn in ("source_directory()", "justfile_directory()", "invocation_directory()"):
+        resolved = resolved.replace("{{%s}}" % fn, str(justfile.parent))
+        resolved = resolved.replace("{{ %s }}" % fn, str(justfile.parent))
+
+    basename = resolved.rsplit("/", 1)[-1]
+    if INTERP_RE.search(basename):
+        # A parameterised NAME. Anything still interpolated in the directory
+        # part is fine -- the basename is what decides there is no one script.
+        return None, basename
+
+    # Strip any unresolved directory interpolation and try the path as given,
+    # then relative to the justfile, then by basename anywhere beneath it.
+    candidate = pathlib.Path(INTERP_RE.sub("", resolved).replace("//", "/"))
+    for p in (candidate, justfile.parent / candidate):
+        if p.is_file():
+            return p.resolve(), None
+    matches = sorted(justfile.parent.rglob(basename))
+    if len(matches) == 1:
+        return matches[0].resolve(), None
+    return None, None
+
+
+# ---------------------------------------------------------- the argparse scan
+
+
+def _keyword(node) -> "tuple[object, bool]":
+    """A keyword argument as (value, was_a_literal).
+
+    Both halves are needed: `action="store_true"` has to compare equal to the
+    Python string, while `default=PYBIN` has to print as the source text and
+    not as the string `'PYBIN'`.
+    """
+    if isinstance(node, ast.Constant):
+        return node.value, True
+    try:
+        return ast.unparse(node), False
+    except Exception:  # pragma: no cover
+        return "<unparseable>", False
+
+
+def scan_arguments(path):
+    """Every add_argument in a script, grouped by subcommand, in source order.
+
+    Returns (groups, unresolved). `groups` maps a subcommand name (or None for
+    the main parser) to {"help": str, "args": [...]}.
+
+    Every add_parser is registered up front, EVEN IF IT TAKES NO ARGUMENTS: a
+    subcommand whose whole interface is its name is precisely the one a reader
+    cannot recover from anywhere else, and building the groups from
+    add_argument alone drops it silently.
+
+    `unresolved` counts add_argument calls whose flag name is not a literal --
+    ones this scan CANNOT report. It is returned rather than swallowed because
+    an under-reported flag list is indistinguishable from a script that
+    genuinely lacks the flag, so the caller refuses instead of printing a short
+    list that looks complete.
+    """
+    tree = ast.parse(path.read_text(errors="replace"))
+    groups: dict = {}
+    unresolved = 0
+    # The sub-parser most recently assigned; None means the main parser. A
+    # one-element list so the nested visit() can rebind it without `nonlocal`.
+    current: list = [None]
+
+    def group(name):
+        return groups.setdefault(name, {"help": "", "args": []})
+
+    def visit(stmts):
+        nonlocal unresolved
+        for st in stmts:
+            if isinstance(st, ast.Assign) and isinstance(st.value, ast.Call):
+                f = st.value.func
+                fname = f.attr if isinstance(f, ast.Attribute) else getattr(f, "id", "")
+                if (
+                    fname == "add_parser"
+                    and st.value.args
+                    and isinstance(st.value.args[0], ast.Constant)
+                ):
+                    current[0] = st.value.args[0].value
+                    g = group(current[0])
+                    for k in st.value.keywords:
+                        if k.arg == "help" and isinstance(k.value, ast.Constant):
+                            g["help"] = k.value.value
+                    continue
+                if fname == "ArgumentParser":
+                    current[0] = None
+                    continue
+
+            call = (
+                st.value
+                if isinstance(st, ast.Expr) and isinstance(st.value, ast.Call)
+                else None
+            )
+            if (
+                call is not None
+                and isinstance(call.func, ast.Attribute)
+                and call.func.attr == "add_argument"
+            ):
+                if not call.args or not isinstance(call.args[0], ast.Constant):
+                    unresolved += 1
+                    continue
+                flags = [a.value for a in call.args if isinstance(a, ast.Constant)]
+                kw: dict = {}
+                lit: dict = {}
+                for k in call.keywords:
+                    if k.arg:
+                        kw[k.arg], lit[k.arg] = _keyword(k.value)
+                group(current[0])["args"].append((flags, kw, lit))
+                continue
+
+            # Recurse into compound statements so an add_argument inside a
+            # function, an `if`, or a loop is still seen, in source order.
+            for field in ("body", "orelse", "finalbody"):
+                inner = getattr(st, field, None)
+                if isinstance(inner, list):
+                    visit(inner)
+
+    visit(tree.body)
+    return groups, unresolved
+
+
+def render_argument(flags, kw, lit):
+    """One argument as a signature line plus its indented help text."""
+    action = kw.get("action", "")
+    if not flags[0].startswith("-"):
+        sig = flags[0]
+    else:
+        metavar = kw.get("metavar")
+        if action in ("store_true", "store_false", "count", "help", "version"):
+            metavar = ""
+        elif kw.get("choices") is not None:
+            metavar = "{%s}" % str(kw["choices"]).strip("[]").replace("'", "")
+        elif metavar is None:
+            metavar = flags[-1].lstrip("-").replace("-", "_").upper()
+        sig = ", ".join(flags) + (f" {metavar}" if metavar else "")
+
+    notes = []
+    if kw.get("required") is True:
+        notes.append("REQUIRED")
+    if kw.get("nargs"):
+        notes.append(f"nargs {kw['nargs']}")
+    if "default" in kw and kw["default"] is not None:
+        d = repr(kw["default"]) if lit.get("default") else kw["default"]
+        notes.append(f"default {d}")
+
+    out = [f"  {sig:<32}{'  '.join(notes)}".rstrip()]
+    helptext = kw.get("help")
+    if isinstance(helptext, str) and lit.get("help"):
+        for para in helptext.split("\n"):
+            para = para.strip()
+            if para:
+                out.append(f"      {para}")
+    return out
+
+
+def print_flags(path, label):
+    """The argparse surface of one script."""
+    if path.suffix != ".py":
+        print(f"FLAGS  not scanned: {label} is a shell script, not argparse.")
+        return 0
+    try:
+        groups, unresolved = scan_arguments(path)
+    except SyntaxError as e:
+        print(f"FLAGS  CANNOT READ: {label} does not parse ({e}).", file=sys.stderr)
+        return 3
+    if unresolved:
+        print(
+            f"FLAGS  REFUSING to print a partial list: {unresolved} "
+            f"add_argument call(s) in",
+            file=sys.stderr,
+        )
+        print(
+            f"       {label} name their flag dynamically and cannot be read "
+            f"statically.",
+            file=sys.stderr,
+        )
+        print("       Run the script's own --help instead.", file=sys.stderr)
+        return 3
+
+    if not groups:
+        print(f"FLAGS  none -- {label} defines no argparse arguments.")
+    for name, g in groups.items():
+        if name is None:
+            print(f"FLAGS  ({label})")
+        else:
+            print(f"SUBCOMMAND  {name}" + (f"  -- {g['help']}" if g["help"] else ""))
+        for flags, kw, lit in g["args"]:
+            for line in render_argument(flags, kw, lit):
+                print(line)
+        if not g["args"] and name is not None:
+            print("  (no flags of its own)")
+        print()
+    return 0
+
+
+# ----------------------------------------------------------------- the output
+
+
+def show(recipe, justfile, variables, prefix):
+    print(f"just {prefix}{recipe.name} {recipe.params}".rstrip())
+    if recipe.doc:
+        print(f"    {recipe.doc}")
+    print(f"    {justfile}:{recipe.line}")
+
+    token = recipe.script_token()
+    path, pattern = resolve_script(token, justfile, variables)
+    if path:
+        try:
+            print(f"    {path.relative_to(justfile.parent)}")
+        except ValueError:
+            print(f"    {path}")
+    print()
+
+    if recipe.comment:
+        print("NOTES  (the recipe's own comment block, verbatim)")
+        for line in recipe.comment.splitlines():
+            print(f"  {line}")
+    else:
+        print("NOTES  none -- this recipe has no comment block in the justfile.")
+    print()
+
+    if pattern:
+        glob = INTERP_RE.sub("*", pattern)
+        found = sorted(p.name for p in justfile.parent.rglob(glob))
+        print("FLAGS  this recipe builds its script name from a parameter:")
+        print(f"         {pattern}")
+        print("       so there is no single flag list. The scripts matching it")
+        print("       in this checkout, each readable by name:\n")
+        for f in found:
+            print(f"         just {prefix}help {f}")
+        if not found:
+            print(f"         (none match {glob} here)")
+        return 0
+
+    if not path:
+        if token:
+            print("FLAGS  the recipe names a script this tool could not locate:")
+            print(f"         {token}")
+            print("       Read the body:  just --show " + recipe.name)
+            return 3
+        print("FLAGS  none to read: this recipe runs inline shell or a fixed")
+        print("       command rather than forwarding to one script. Read its")
+        print("       body:  just --show " + recipe.name)
+        return 0
+
+    rc = print_flags(path, path.name)
+    if rc:
+        return rc
+
+    # Spell out the required positionals: without them just refuses the call
+    # before the script is reached, which is half of why this tool exists.
+    tail = [
+        p
+        for p in recipe.params.split()
+        if not p.startswith(("*", "+")) and "=" not in p
+    ]
+    print("Argparse's own text, where the script's dependencies are installed:")
+    print("  " + " ".join(["just", f"{prefix}{recipe.name}", *tail, "--help"]))
+    return 0
+
+
+def show_script(name, justfile):
+    """A script asked for by name: its docstring, then its flags."""
+    matches = sorted(justfile.parent.rglob(name))
+    if not matches:
+        print(f"no script named {name!r} under {justfile.parent}.", file=sys.stderr)
+        return 2
+    path = matches[0]
+    try:
+        rel = path.relative_to(justfile.parent)
+    except ValueError:  # pragma: no cover
+        rel = path
+    print(f"{rel}\n")
+    if path.suffix == ".py":
+        try:
+            doc = ast.get_docstring(ast.parse(path.read_text(errors="replace")))
+        except SyntaxError as e:
+            doc = f"(does not parse: {e})"
+        if doc:
+            print("NOTES  (the script's own module docstring)")
+            for line in doc.splitlines():
+                print(f"  {line}")
+        else:
+            print("NOTES  none -- this script has no module docstring.")
+        print()
+    return print_flags(path, str(rel))
+
+
+def audit(recipes, justfile):
+    """Which recipes `just --list` cannot summarise.
+
+    A recipe with no [doc()] falls back to the LAST LINE of its comment block.
+    Where that block carries examples or caveats the line is a fragment, so the
+    listing reads as noise and stops being scanned.
+
+    Only genuinely at-risk recipes are reported -- see Recipe.needs_doc. A
+    one-line comment is a good description and is left alone, because a gate
+    that fires on every well-written justfile is a gate nobody reads.
+    """
+    listed = [r for r in recipes.values() if not r.private]
+    missing = [(r, r.needs_doc) for r in listed if r.needs_doc]
+    print(f"{justfile}")
+    print(
+        f"{len(recipes)} recipe(s), {len(listed)} listed by `just --list`; "
+        f"{len(missing)} with an unusable description."
+    )
+    for r, why in sorted(missing, key=lambda t: t[0].name):
+        fallback = r.comment.splitlines()[-1].lstrip("# ").strip() if r.comment else ""
+        print(f"  {r.name:26} {why}")
+        if fallback:
+            print(f"  {'':26} --list shows: {fallback[:60]}")
+    if missing:
+        print(
+            '\nAdd a [doc("one line")] above each. The comment block stays '
+            "where it\nis -- `just help <recipe>` is what prints it."
+        )
+        return 1
+    return 0
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=DOC.splitlines()[0])
+    ap.add_argument(
+        "target",
+        nargs="?",
+        help="the recipe, or a script name, to explain; omit for this tool's own usage",
+    )
+    ap.add_argument(
+        "--justfile",
+        help="the justfile to read (default: the nearest one at or above the cwd)",
+    )
+    ap.add_argument(
+        "--module",
+        default="",
+        help="module prefix to print in example commands, e.g. "
+        "'lab::' for a recipe reached as `just lab::build`",
+    )
+    ap.add_argument(
+        "--audit",
+        action="store_true",
+        help="report recipes with no [doc()] summary, and exit "
+        "non-zero if any are missing",
+    )
+    a = ap.parse_args(argv)
+
+    justfile = find_justfile(a.justfile)
+    text = justfile.read_text()
+    recipes = parse_justfile(text)
+    if not recipes:
+        # An empty parse of a non-empty justfile is a broken parser, not a
+        # justfile with no recipes. Raising is the difference between the two.
+        raise SystemExit(
+            f"just-recipe-help: parsed 0 recipes from "
+            f"{len(text.splitlines())} lines of {justfile}. The parser is "
+            f"broken, not the justfile."
+        )
+
+    if a.audit:
+        return audit(recipes, justfile)
+
+    if not a.target:
+        print(DOC.strip())
+        print(f"\n{justfile}\n{len(recipes)} recipes. List them with: just --list")
+        return 0
+
+    prefix = a.module
+    if a.target in recipes:
+        return show(recipes[a.target], justfile, just_variables(justfile), prefix)
+
+    if a.target.endswith((".py", ".sh")):
+        return show_script(a.target, justfile)
+
+    print(f"no recipe or script {a.target!r} in {justfile}. Recipes:", file=sys.stderr)
+    for n, r in sorted(recipes.items()):
+        if not r.private:
+            print(f"  {n}", file=sys.stderr)
+    print("\nA script name also works, e.g. `just help build.py`.", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools-plugin/scripts/tests/test-just-recipe-help.sh
+++ b/tools-plugin/scripts/tests/test-just-recipe-help.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# Regression test for tools-plugin/scripts/just-recipe-help.py
+#
+# The defect this guards: `just --list` shows ONE line per recipe, and with no
+# `[doc()]` attribute that line is the LAST line of the comment block above the
+# recipe. In a justfile whose blocks carry examples, the listing degrades into
+# fragments and nothing reports it. The helper surfaces the block and the
+# wrapped tool's flags; the audit is the gate.
+#
+# Every bug this helper can have is an UNDER-REPORT — a recipe not parsed, a
+# subcommand not registered, a flag not read — and an under-report reads
+# exactly like a justfile or script with less in it. So the tests below are
+# mostly two-sided: each asserts the tool FINDS the thing and, where it
+# matters, that it does not find it when it is absent.
+#
+# Guards:
+#   A. the parse agrees exactly with `just --summary` (the independent control)
+#   B. a recipe whose params carry a DEFAULT (`PYBIN="python3"`) is not dropped
+#      — the first draft forbade `=` and silently parsed 48 of 57 recipes
+#   C. `:=` assignments are not mistaken for recipes
+#   D. a `_`-prefixed recipe counts as private with NO [private] attribute,
+#      because just hides it from --list and --summary by itself
+#   E. audit is SILENT on a well-authored justfile (a gate that fires on
+#      everything is one nobody reads)
+#   F. audit CATCHES each fragment shape by name: indented sub-item, command
+#      example, lowercase continuation, missing block
+#   G. an empty parse of a non-empty justfile raises rather than reporting none
+#   H. a dynamically-named flag makes the tool REFUSE, not print a short list
+#   I. a subcommand with no flags of its own is still listed
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+helper="$script_dir/../just-recipe-help.py"
+
+pass_count=0
+fail_count=0
+
+assert() {
+  if [ "$2" = "true" ]; then
+    pass_count=$((pass_count + 1))
+  else
+    echo "FAIL: $1" >&2
+    fail_count=$((fail_count + 1))
+  fi
+}
+
+contains() { printf '%s' "$1" | grep -q -- "$2" && echo true || echo false; }
+
+tmp="$(mktemp -d)"
+# mktemp can fail; an empty $tmp would make every path below resolve to / .
+if [ -z "$tmp" ] || [ ! -d "$tmp" ]; then
+  echo "FAIL: could not create a sandbox" >&2
+  exit 1
+fi
+trap 'rm -rf "$tmp"' EXIT
+
+# --------------------------------------------------------------- the fixture
+# A justfile exercising every shape at once.
+mkdir -p "$tmp/good/scripts"
+cat >"$tmp/good/justfile" <<'JUSTFILE'
+SCRIPTS := justfile_directory() / "scripts"
+
+# One line, which is a perfectly good description.
+build:
+    @echo build
+
+# A long block whose author knew the rule and ended it with a summary.
+#   just deploy --dry-run
+# Deploy the current build to staging.
+[doc("Deploy the current build to staging.")]
+deploy target="staging":
+    @echo {{target}}
+
+# A recipe taking a default, which the first draft dropped entirely.
+[doc("Run the suite under a chosen interpreter.")]
+test PYBIN="python3" *ARGS:
+    @{{PYBIN}} -c "print(1)"
+
+# Hidden from --list by the underscore alone, with no [private] attribute.
+_helper:
+    @echo helper
+
+[doc("Wraps a real script, so its flags are readable.")]
+wrapped *ARGS:
+    @python3 {{SCRIPTS}}/tool.py {{ARGS}}
+JUSTFILE
+
+cat >"$tmp/good/scripts/tool.py" <<'PYEOF'
+"""A tool with subcommands, one of which takes no flags."""
+import argparse
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers()
+    p = sub.add_parser("run", help="do the thing")
+    p.add_argument("--jobs", type=int, default=4, help="worker count")
+    p = sub.add_parser("status", help="report only")
+    p.set_defaults(fn=None)
+    return ap.parse_args()
+PYEOF
+
+# ------------------------------- A/B/C/D: the parse, against just's own parse
+if command -v just >/dev/null 2>&1; then
+  theirs="$(cd "$tmp/good" && just --summary 2>/dev/null | tr ' ' '\n' | sort)"
+  mine="$(cd "$tmp/good" && python3 "$helper" --audit 2>/dev/null | head -2)"
+  assert "A: just --summary is non-empty, so the control is not vacuous" \
+    "$([ -n "$theirs" ] && echo true || echo false)"
+  # `just --summary` lists 4 (build deploy test wrapped); _helper is hidden.
+  assert "A: just hides the _-prefixed recipe from --summary" \
+    "$([ "$(printf '%s\n' "$theirs" | grep -c .)" = "4" ] && echo true || echo false)"
+  assert "D: the helper agrees — 5 parsed, 4 listed" \
+    "$(contains "$mine" "5 recipe(s), 4 listed")"
+else
+  echo "SKIP: just is not installed; A and D cannot be controlled" >&2
+fi
+
+parsed="$(cd "$tmp/good" && python3 "$helper" test 2>&1)"
+assert "B: a recipe whose params carry a default is parsed" \
+  "$(contains "$parsed" 'test PYBIN="python3" \*ARGS')"
+
+# Capture first, then match. Piping into `grep -q` under `set -o pipefail`
+# reports the PYTHON exit status (2, "no such recipe") as the pipeline's, so
+# the assertion reads false on the very output that proves it correct.
+notfound="$(cd "$tmp/good" && python3 "$helper" scripts 2>&1)"
+assert "C: the SCRIPTS := assignment is not parsed as a recipe" \
+  "$(contains "$notfound" "no recipe or script")"
+assert "C: and the four real recipes are offered instead" \
+  "$(contains "$notfound" "wrapped")"
+
+# ---------------------------------------------- E: silent on a good justfile
+audit_good="$(cd "$tmp/good" && python3 "$helper" --audit 2>&1)"
+rc_good=$?
+assert "E: a well-authored justfile produces no findings" \
+  "$(contains "$audit_good" "0 with an unusable description")"
+assert "E: and exits 0" "$([ "$rc_good" = "0" ] && echo true || echo false)"
+
+# ----------------------------------------- F: catches each fragment shape
+mkdir -p "$tmp/bad"
+cat >"$tmp/bad/justfile" <<'JUSTFILE'
+# Render the thing.
+#   just indented --flag
+indented:
+    @echo hi
+
+# Render the thing.
+# just example-cmd --flag
+example-cmd:
+    @echo hi
+
+# Render the thing, which takes a while and is
+# worth doing before lunch.
+continued:
+    @echo hi
+
+no-comment:
+    @echo hi
+JUSTFILE
+
+audit_bad="$(cd "$tmp/bad" && python3 "$helper" --audit 2>&1)"
+rc_bad=$?
+assert "F: all four bad shapes are reported" \
+  "$(contains "$audit_bad" "4 with an unusable description")"
+assert "F: an indented last line is named as a sub-item" \
+  "$(contains "$audit_bad" "indented, so it is a sub-item")"
+assert "F: a command example is named as one" \
+  "$(contains "$audit_bad" "is a command example")"
+assert "F: a lowercase continuation is named as one" \
+  "$(contains "$audit_bad" "continues a sentence")"
+assert "F: a missing block is named as a blank listing" \
+  "$(contains "$audit_bad" "no comment block")"
+assert "F: and exits non-zero" "$([ "$rc_bad" = "1" ] && echo true || echo false)"
+
+# ---------------------------------- G: an empty parse raises, never reports 0
+mkdir -p "$tmp/empty"
+cat >"$tmp/empty/justfile" <<'JUSTFILE'
+# only comments here
+# and nothing that looks like a recipe
+JUSTFILE
+empty_out="$(cd "$tmp/empty" && python3 "$helper" --audit 2>&1)"
+assert "G: an empty parse of a non-empty justfile names the parser" \
+  "$(contains "$empty_out" "parser is")"
+
+# ------------------------------- H: a flag it cannot read makes it REFUSE
+mkdir -p "$tmp/dyn/scripts"
+cat >"$tmp/dyn/justfile" <<'JUSTFILE'
+# Wrap a script whose flags are built in a loop.
+run *ARGS:
+    @python3 scripts/dyn.py {{ARGS}}
+JUSTFILE
+cat >"$tmp/dyn/scripts/dyn.py" <<'PYEOF'
+"""Builds its flag names dynamically."""
+import argparse
+ap = argparse.ArgumentParser()
+for name in ("--a", "--b"):
+    ap.add_argument(name)
+ap.add_argument("--readable")
+PYEOF
+dyn_out="$(cd "$tmp/dyn" && python3 "$helper" run 2>&1)"
+dyn_rc=$?
+assert "H: a dynamically-named flag is refused, not partially listed" \
+  "$(contains "$dyn_out" "REFUSING")"
+assert "H: and the refusal exits 3" \
+  "$([ "$dyn_rc" = "3" ] && echo true || echo false)"
+assert "H: no partial flag list is printed alongside the refusal" \
+  "$(printf '%s' "$dyn_out" | grep -q -- '--readable' && echo false || echo true)"
+
+# ------------------------- I: a flagless subcommand is still listed by name
+wrapped_out="$(cd "$tmp/good" && python3 "$helper" wrapped 2>&1)"
+assert "I: a subcommand WITH flags is listed" \
+  "$(contains "$wrapped_out" "SUBCOMMAND  run")"
+assert "I: a subcommand with NO flags is still listed" \
+  "$(contains "$wrapped_out" "SUBCOMMAND  status")"
+assert "I: and is marked as having none, not silently empty" \
+  "$(contains "$wrapped_out" "no flags of its own")"
+assert "I: the {{SCRIPTS}} interpolation resolved to a real path" \
+  "$(contains "$wrapped_out" "worker count")"
+
+# ---------------------------------------------------------------- summary
+echo "PASSED=$pass_count FAILED=$fail_count"
+[ "$fail_count" -eq 0 ] || exit 1
+echo "STATUS=OK"

--- a/tools-plugin/skills/justfile-expert/REFERENCE.md
+++ b/tools-plugin/skills/justfile-expert/REFERENCE.md
@@ -257,7 +257,10 @@ set allow-duplicate-recipes
 # Allow duplicate variables (last wins)
 set allow-duplicate-variables
 
-# Fail on first error in recipe
+# Search PARENT directories for a recipe this justfile does not define.
+# NOT error handling and nothing to do with failing fast: a child justfile
+# with this set resolves `just parent-recipe` from its parent's justfile.
+# MODULES DO NOT INHERIT IT -- `just sub::parent-recipe` still fails.
 set fallback
 
 # Use working directory for imports

--- a/tools-plugin/skills/justfile-expert/SKILL.md
+++ b/tools-plugin/skills/justfile-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 created: 2025-12-16
-modified: 2026-08-15
+modified: 2026-09-06
 reviewed: 2026-02-06
 name: justfile-expert
 description: Just command runner expertise — Justfile syntax, recipes, parameters, modules, shebang recipes. Use when authoring justfiles, project commands, or task automation.
@@ -107,19 +107,26 @@ clean-all: clean
 - **`set quiet`**: Suppress command echoing
 
 **Recipe Attributes**
-- **`[private]`**: Hide from `--list` output
+- **`[doc("text")]`**: The `--list` description. Overrides the comment above the
+  recipe; bare **`[doc]`** suppresses it. See "What `--list` Shows" below —
+  without this attribute only the comment block's LAST line is used
+- **`[private]`**: Hide from `--list` and `--summary` output
 - **`[no-cd]`**: Don't change directory
 - **`[no-exit-message]`**: Suppress exit messages
 - **`[unix]`** / **`[windows]`** / **`[linux]`** / **`[macos]`**: Platform-specific recipes
 - **`[positional-arguments]`**: Per-recipe positional args
 - **`[confirm]`** / **`[confirm("message")]`**: Require confirmation before running
-- **`[group: "name"]`**: Group recipes in `--list` output
+- **`[group: "name"]`** / **`[group("name")]`**: Section recipes in `--list`; both
+  spellings work, and `--groups` lists the group names
 - **`[working-directory: "path"]`**: Run in specific directory
 
 **Module System**
 - **`mod name`**: Declare submodule
 - **`mod name 'path'`**: Custom module path
 - **Invocation**: `just module::recipe` or `just module recipe`
+- **`set fallback` is NOT inherited by a module.** The parent may fall through to
+  *its* parent, but `just sub::parent-recipe` fails with `justfile does not
+  contain recipe`. A module's recipes resolve only within that module
 
 ## Essential Syntax
 
@@ -174,6 +181,54 @@ caption DIR SUBJECT="" *ARGS:
 that is what lets several trailing flags expand as separate words — and accept
 its corollary: an individual passthrough flag's value must not contain spaces.
 When one might, promote it to a named parameter too.
+
+**What `--list` Shows Is ONE Line, and It Is Not Your Comment Block**
+
+`just --list` renders a single description per recipe. With no `[doc]`
+attribute it takes the **last line** of the comment block immediately above the
+recipe — not the first line, and not the block:
+
+| Above the recipe | `--list` shows |
+|---|---|
+| `[doc("Build the release bundle.")]` | that text |
+| a comment block, no attribute | **only its last line** |
+| bare `[doc]` | nothing |
+| nothing | nothing |
+
+So "add a comment before each recipe" is **not** the same as documenting it. A
+block that ends in an example or a caveat — the normal way to write one — lists
+as that fragment:
+
+```just
+# Pitch-correct the singing in an MP4. Video is stream-copied.
+#   just autotune take.mp4 out.mp4 --key C:minor
+autotune IN OUT *FLAGS:
+```
+```
+$ just --list
+    autotune IN OUT *FLAGS   # just autotune take.mp4 out.mp4 --key C:minor
+```
+
+**Add `[doc("one line")]` as soon as a recipe's comment block exceeds one
+line.** The block stays where it is and keeps carrying the detail; the
+attribute is the only thing `--list` reads.
+
+**The block binds by ADJACENCY, and reassignment is silent.** A blank line ends
+a block, so inserting a recipe between a block and the recipe it describes
+hands the block to the newcomer — the original then lists blank, and nothing
+warns. Re-read `just --list` after inserting a recipe into an existing file.
+
+**A recipe with a required positional has no `--help` form.** `recipe *ARGS:`
+forwards `--help` to the underlying tool, but just refuses the call before the
+tool runs once a positional is required:
+
+```
+$ just autotune --help
+error: recipe `autotune` got 1 positional argument but takes at least 2
+```
+
+There is no bare-help spelling for such a recipe. Put the flags in its `[doc]`
+or comment block, or add a `help` recipe that prints them.
 
 **Recipe Dependencies**
 ```just
@@ -448,9 +503,11 @@ cargo install just-mcp
 
 **Recipe Development Workflow**
 1. **Name clearly**: Use descriptive, verb-based names (`build`, `test`, `deploy`)
-2. **Document always**: Add comment before each recipe
+2. **Document what `--list` reads**: a one-line comment is enough; anything
+   longer needs `[doc("...")]`, or the listing shows only the block's last line
 3. **Use defaults**: Provide sensible default parameter values
-4. **Group logically**: Organize with section comments
+4. **Group logically**: section comments for the file, `[group("name")]` for the
+   listing — a flat `--list` stops being scannable somewhere around 20 recipes
 5. **Hide internals**: Mark helper recipes as `[private]`
 6. **Test portability**: Verify on all target platforms
 
@@ -460,6 +517,10 @@ cargo install just-mcp
 - Use shebang recipes for multi-line logic
 - Prefer `set dotenv-load` for configuration
 - Use modules for large projects (>20 recipes)
+- Give a recipe a `[doc("...")]` when its comment block's last line would not
+  read as a description on its own — `--list` shows only that line (see "What
+  `--list` Shows" above). To find them:
+  `python3 "${CLAUDE_PLUGIN_ROOT}/scripts/just-recipe-help.py" --audit`
 - Include variadic `*args` for passthrough flexibility
 - Quote all variables in shell commands — `{{...}}` interpolates **unquoted**,
   so wrap any parameter that can contain spaces in `quote()` (see


### PR DESCRIPTION
## What

Corrects `justfile-expert` on what `just --list` actually renders, fixes a
factually wrong `set fallback` description, and adds
`tools-plugin/scripts/just-recipe-help.py` — a recipe's comment block plus the
argparse surface of the script it wraps.

## Why

`just --list` shows **one line** per recipe. With no `[doc()]` attribute that
line is the **last line** of the comment block above the recipe — not the
first, and not the block. Neither the skill nor its 1028-line `REFERENCE.md`
mentioned `[doc]` at all, while Best Practices said *"Document always: add
comment before each recipe."* Followed literally, that advice degrades a
listing silently: a block ending in an example lists as the example.

Observed in `laurigates/comfyui-nodes` `lab/justfile` — 47 of 59 recipes
listing a fragment, and one listing **nothing**, because its comment block had
been separated from it by a later insertion and was being attributed to the
recipe above:

```
cadence +ARGS       # one you have to think about every time.
test-sweep PYBIN=   # is belt-and-braces here and load-bearing everywhere else.
orphans *FLAGS      #                                   <- nothing at all
```

## Corrections

| | |
|---|---|
| `set fallback` | documented as *"Fail on first error in recipe"*. It is not error handling — it makes `just` search **parent directories** for a recipe this justfile does not define. Verified: a child justfile with it set resolves `just parent-recipe` from the parent |
| `[doc]` | absent from the attribute list. Added, with bare `[doc]` (suppresses) and the comment fallback |
| `[private]` | also hides from `--summary`, not just `--list` |
| `[group]` | both spellings work (`[group: "x"]` and `[group("x")]`), and `--groups` lists them |
| `mod` | does **not** inherit `set fallback` — `just sub::parent-recipe` fails |

Plus a new section on the `--list` contract: the fallback table, the
**adjacency** binding (a blank line ends a block; inserting a recipe between a
block and its recipe silently reassigns it), and the fact that a recipe with a
required positional has **no `--help` form** — `just` refuses the call before
the tool runs, so `just recipe --help` is not an escape hatch.

Every claim verified against `just` 1.58.0 rather than recalled.

## The tool

The flags of a wrapped script were reachable only by opening it, and both
escapes are closed: `--help` is refused for a recipe with a positional, and
supplying dummies hits an argparse that sits behind a module-scope
`import numpy` on a checkout without it.

So `just-recipe-help.py` reads the **shipped source** — the comment block from
the justfile, the flags from the script's AST. Stdlib only, so it answers the
same where the dependencies are absent, which is exactly where `--help` cannot.
It resolves `{{VAR}}` paths through `just --evaluate` when `just` is present and
falls back to a basename search when it is not.

## The audit criterion took three attempts

This is the part worth reviewing. `--audit` reports recipes whose rendered line
is unusable — and two more obvious rules were tried and rejected:

| Criterion | Result |
|---|---|
| "has no `[doc()]`" | flags **33 of 33** recipes in this repo's own justfile. A gate that fires on everything is one nobody reads |
| "has a multi-line comment block" | punishes the careful habit of ending a long block with a deliberate one-line summary — which `config-drift-calibrate` in this repo already does |
| **shape of the rendered line** | indented sub-item / command example / lowercase continuation / no block at all |

Measured with the shipped rule: **0 findings** on this repo's justfile, **47 of
59** on the known-bad one, each with a named reason.

## Verification

- `tools-plugin/scripts/tests/test-just-recipe-help.sh` — 22 assertions, wired
  into `.pre-commit-config.yaml`.
- **Teeth-checked**: four mutations — the params-with-`=` regex, the `_`-prefix
  privacy rule, the fragment criterion, the unreadable-flag refusal — each
  CAUGHT by the assertion it names, with a control correctly MISSED.
- `scripts/plugin-compliance-check.sh` exits 0.
- Run against three unrelated justfiles (this repo's, `comfyui-nodes` root, and
  `lab/`) rather than only the one it was built from.

Two notes for the reviewer:

- `ruff format` reformatted the script on first commit and **un-anchored one
  mutation** — it reported `BAD ANCHOR`, not a pass. Re-anchored and re-verified.
- `justfile-expert/SKILL.md` is now 17,865 chars against the 26,000 ceiling. The
  "consider extracting" advisory at 10,000 was already firing before this change
  (14,994); the compliance check exits 0. The `--list` contract is a correctness
  rule, so it belongs in the body rather than `REFERENCE.md`, but the MCP
  integration section below it is a fair candidate for extraction later.

A companion PR updates `configure-plugin:configure-justfile` to audit what
`--list` renders instead of whether a comment exists. Split because a
squash-merge lands the **PR title**, so one PR spanning both plugins would
apply a single release type to both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147YE9fuCKttGe9MxASqy4x
