### PR TITLE
fix(tools-plugin): resolve or name a non-literal `help=` instead of dropping it

### DIFF
--- a/tools-plugin/scripts/just-recipe-help.py
+++ b/tools-plugin/scripts/just-recipe-help.py
@@ -303,6 +303,38 @@ def _keyword(node) -> "tuple[object, bool]":
         return "<unparseable>", False
 
 
+def _help_display(node):
+    """A help= node as displayable text, or None.
+
+    An f-string's literal parts ARE the help text -- in the tree this was built
+    against, 13 of 15 non-literal `help=` are f-strings, and dumping their
+    source with a "read the source" marker hides text that is right there.
+    Each interpolation renders as `{expr}`, visibly unresolved rather than
+    silently wrong: argparse substitutes a runtime value and this cannot.
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):
+        parts = []
+        for v in node.values:
+            if isinstance(v, ast.Constant):
+                parts.append(str(v.value))
+            elif isinstance(v, ast.FormattedValue):
+                parts.append("{" + ast.unparse(v.value) + "}")
+            else:  # pragma: no cover
+                parts.append("{...}")
+        return "".join(parts)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        # `'...Scales: ' + ', '.join(sorted(SCALES))` -- keep the literal half
+        # and placeholder the computed one, same convention as an f-string.
+        sides = []
+        for side in (node.left, node.right):
+            shown = _help_display(side)
+            sides.append(shown if shown is not None else "{" + ast.unparse(side) + "}")
+        return "".join(sides)
+    return None
+
+
 def scan_arguments(path):
     """Every add_argument in a script, grouped by subcommand, in source order.
 
@@ -384,6 +416,14 @@ def scan_arguments(path):
                 lit: dict = {}
                 for k in call.keywords:
                     if k.arg:
+                        if k.arg == "help":
+                            # An f-string or a concatenation carries
+                            # its own text; take it rather than the
+                            # source expression.
+                            shown = _help_display(k.value)
+                            if shown is not None:
+                                kw["help"], lit["help"] = shown, True
+                                continue
                         kw[k.arg], lit[k.arg] = _keyword(k.value)
                 group(current[0])["args"].append((flags, kw, lit))
                 continue

--- a/tools-plugin/scripts/just-recipe-help.py
+++ b/tools-plugin/scripts/just-recipe-help.py
@@ -321,6 +321,21 @@ def scan_arguments(path):
     list that looks complete.
     """
     tree = ast.parse(path.read_text(errors="replace"))
+
+    # String constants, so a `help=SOME_NAME` resolves to its text rather
+    # than being dropped. Every scope, not just module level: the constant
+    # is usually a local of the function that builds the parser.
+    constants: dict = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if (
+            isinstance(target, ast.Name)
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+        ):
+            constants.setdefault(target.id, node.value.value)
     groups: dict = {}
     unresolved = 0
     # The sub-parser most recently assigned; None means the main parser. A
@@ -381,10 +396,10 @@ def scan_arguments(path):
                     visit(inner)
 
     visit(tree.body)
-    return groups, unresolved
+    return groups, unresolved, constants
 
 
-def render_argument(flags, kw, lit):
+def render_argument(flags, kw, lit, constants=None):
     """One argument as a signature line plus its indented help text."""
     action = kw.get("action", "")
     if not flags[0].startswith("-"):
@@ -410,11 +425,34 @@ def render_argument(flags, kw, lit):
 
     out = [f"  {sig:<32}{'  '.join(notes)}".rstrip()]
     helptext = kw.get("help")
-    if isinstance(helptext, str) and lit.get("help"):
-        for para in helptext.split("\n"):
+    if helptext is None:
+        return out
+    if lit.get("help"):
+        for para in str(helptext).split("\n"):
             para = para.strip()
             if para:
                 out.append(f"      {para}")
+        return out
+
+    # A NON-LITERAL help=, e.g. `help=_rung_help`. Resolved from the
+    # module's own constants where possible; NAMED where not.
+    #
+    # It used to be dropped in silence, which is the exact under-report
+    # this tool refuses everywhere else: the flag printed bare, and was
+    # indistinguishable from one that genuinely has no help. It slipped
+    # past `unresolved` because that counts unreadable flag NAMES, and
+    # the name here is fine -- so nothing refused either.
+    resolved = constants.get(helptext) if constants else None
+    if resolved is not None:
+        for para in resolved.split("\n"):
+            para = para.strip()
+            if para:
+                out.append(f"      {para}")
+    else:
+        out.append(
+            f"      (help is `{helptext}`, which is not a literal and not a "
+            f"module constant -- read the source)"
+        )
     return out
 
 
@@ -424,7 +462,7 @@ def print_flags(path, label):
         print(f"FLAGS  not scanned: {label} is a shell script, not argparse.")
         return 0
     try:
-        groups, unresolved = scan_arguments(path)
+        groups, unresolved, constants = scan_arguments(path)
     except SyntaxError as e:
         print(f"FLAGS  CANNOT READ: {label} does not parse ({e}).", file=sys.stderr)
         return 3
@@ -450,7 +488,7 @@ def print_flags(path, label):
         else:
             print(f"SUBCOMMAND  {name}" + (f"  -- {g['help']}" if g["help"] else ""))
         for flags, kw, lit in g["args"]:
-            for line in render_argument(flags, kw, lit):
+            for line in render_argument(flags, kw, lit, constants):
                 print(line)
         if not g["args"] and name is not None:
             print("  (no flags of its own)")

--- a/tools-plugin/scripts/just-recipe-help.py
+++ b/tools-plugin/scripts/just-recipe-help.py
@@ -338,7 +338,8 @@ def _help_display(node):
 def scan_arguments(path):
     """Every add_argument in a script, grouped by subcommand, in source order.
 
-    Returns (groups, unresolved). `groups` maps a subcommand name (or None for
+    Returns (groups, unresolved, constants). `groups` maps a subcommand name
+    (or None for
     the main parser) to {"help": str, "args": [...]}.
 
     Every add_parser is registered up front, EVEN IF IT TAKES NO ARGUMENTS: a
@@ -414,11 +415,12 @@ def scan_arguments(path):
                         parsers[bound] = sub_name
                         # Only a BOUND declaration moves the fallback
                         # cursor, so a flagless add_parser written between
-                        # a parser and its flags cannot steal them. No
-                        # mutation row pins this line: receiver dispatch
-                        # below already answers correctly for every
-                        # receiver the scan can see, so removing it
-                        # changes nothing observable.
+                        # a parser and its flags cannot steal them.
+                        #
+                        # This IS observable, contrary to a note that
+                        # stood here: an untracked receiver falls back to
+                        # the cursor, and then an unbound add_parser in
+                        # between changes the answer.
                         current[0] = sub_name
                     for k in call.keywords:
                         # Same treatment as add_argument's help= below.
@@ -442,6 +444,16 @@ def scan_arguments(path):
                         parsers[bound] = None
                     current[0] = None
                     continue
+                # Any OTHER call rebinding a tracked name invalidates it.
+                # `p = _build(ap)` is not a construction this scan knows,
+                # and a stale entry OUTRANKS the cursor -- so a second
+                # function reusing the local name filed its flags under a
+                # subcommand of a different parser. The map is flat and
+                # module-wide, so forgetting is the safe move: the
+                # fallback is a guess, a stale entry is a confident wrong
+                # answer.
+                if bound is not None:
+                    parsers.pop(bound, None)
 
             # An add_argument is only ever a bare expression statement.
             if isinstance(st, ast.Assign):
@@ -486,7 +498,10 @@ def scan_arguments(path):
             # neither reported nor counted, so it vanished. Position
             # matters too -- a Try is written body / handlers / orelse /
             # finalbody, and this scan promises source order.
-            for field in ("body", "handlers", "orelse", "finalbody"):
+            # `cases` is ast.Match's arm list -- the same under-report one
+            # node type over. A Match has none of the other fields, so its
+            # position here does not matter.
+            for field in ("body", "handlers", "orelse", "finalbody", "cases"):
                 inner = getattr(st, field, None)
                 if isinstance(inner, list):
                     visit(inner)
@@ -547,7 +562,7 @@ def render_argument(flags, kw, lit, constants=None):
     else:
         out.append(
             f"      (help is `{helptext}`, which is not a literal and not a "
-            f"module constant -- read the source)"
+            f"resolvable name -- read the source)"
         )
     return out
 

--- a/tools-plugin/scripts/just-recipe-help.py
+++ b/tools-plugin/scripts/just-recipe-help.py
@@ -380,29 +380,45 @@ def scan_arguments(path):
     def visit(stmts):
         nonlocal unresolved
         for st in stmts:
+            # An add_parser is detected whether or not its result is bound.
+            # `sub.add_parser("status", help="...")` with no assignment is the
+            # idiomatic spelling for a subcommand that takes no flags -- and
+            # reading only ast.Assign made exactly those vanish from the help,
+            # which is the same disappearance the flagless-subcommand handling
+            # exists to prevent.
+            call = None
             if isinstance(st, ast.Assign) and isinstance(st.value, ast.Call):
-                f = st.value.func
+                call = st.value
+            elif isinstance(st, ast.Expr) and isinstance(st.value, ast.Call):
+                call = st.value
+            if call is not None:
+                f = call.func
                 fname = f.attr if isinstance(f, ast.Attribute) else getattr(f, "id", "")
                 if (
                     fname == "add_parser"
-                    and st.value.args
-                    and isinstance(st.value.args[0], ast.Constant)
+                    and call.args
+                    and isinstance(call.args[0], ast.Constant)
                 ):
-                    current[0] = st.value.args[0].value
+                    current[0] = call.args[0].value
                     g = group(current[0])
-                    for k in st.value.keywords:
-                        if k.arg == "help" and isinstance(k.value, ast.Constant):
-                            g["help"] = k.value.value
+                    for k in call.keywords:
+                        # Same treatment as add_argument's help= below.
+                        # Requiring a Constant here left the class closed on one
+                        # keyword site and open on its twin: an f-string
+                        # subcommand help printed NO description, and a
+                        # subcommand's one line is the only thing describing it.
+                        if k.arg == "help":
+                            shown = _help_display(k.value)
+                            if shown is not None:
+                                g["help"] = shown
                     continue
                 if fname == "ArgumentParser":
                     current[0] = None
                     continue
 
-            call = (
-                st.value
-                if isinstance(st, ast.Expr) and isinstance(st.value, ast.Call)
-                else None
-            )
+            # An add_argument is only ever a bare expression statement.
+            if isinstance(st, ast.Assign):
+                call = None
             if (
                 call is not None
                 and isinstance(call.func, ast.Attribute)

--- a/tools-plugin/scripts/just-recipe-help.py
+++ b/tools-plugin/scripts/just-recipe-help.py
@@ -372,6 +372,12 @@ def scan_arguments(path):
     unresolved = 0
     # The sub-parser most recently assigned; None means the main parser. A
     # one-element list so the nested visit() can rebind it without `nonlocal`.
+    # Which parser each VARIABLE refers to: name -> subcommand, or None for
+    # the main parser. Dispatching on the receiver rather than on source
+    # order is what makes an add_argument land on the parser it was
+    # actually called on. `current` survives only as the fallback for a
+    # receiver nothing assigned in this scan.
+    parsers: dict = {}
     current: list = [None]
 
     def group(name):
@@ -387,8 +393,11 @@ def scan_arguments(path):
             # which is the same disappearance the flagless-subcommand handling
             # exists to prevent.
             call = None
+            bound = None
             if isinstance(st, ast.Assign) and isinstance(st.value, ast.Call):
                 call = st.value
+                if len(st.targets) == 1 and isinstance(st.targets[0], ast.Name):
+                    bound = st.targets[0].id
             elif isinstance(st, ast.Expr) and isinstance(st.value, ast.Call):
                 call = st.value
             if call is not None:
@@ -399,8 +408,18 @@ def scan_arguments(path):
                     and call.args
                     and isinstance(call.args[0], ast.Constant)
                 ):
-                    current[0] = call.args[0].value
-                    g = group(current[0])
+                    sub_name = call.args[0].value
+                    g = group(sub_name)
+                    if bound is not None:
+                        parsers[bound] = sub_name
+                        # Only a BOUND declaration moves the fallback
+                        # cursor, so a flagless add_parser written between
+                        # a parser and its flags cannot steal them. No
+                        # mutation row pins this line: receiver dispatch
+                        # below already answers correctly for every
+                        # receiver the scan can see, so removing it
+                        # changes nothing observable.
+                        current[0] = sub_name
                     for k in call.keywords:
                         # Same treatment as add_argument's help= below.
                         # Requiring a Constant here left the class closed on one
@@ -409,10 +428,18 @@ def scan_arguments(path):
                         # subcommand's one line is the only thing describing it.
                         if k.arg == "help":
                             shown = _help_display(k.value)
+                            if shown is None and isinstance(k.value, ast.Name):
+                                # The same constants map add_argument's
+                                # help gets, so a bare name resolves here
+                                # too rather than leaving the subcommand
+                                # with no line at all.
+                                shown = constants.get(k.value.id)
                             if shown is not None:
                                 g["help"] = shown
                     continue
                 if fname == "ArgumentParser":
+                    if bound is not None:
+                        parsers[bound] = None
                     current[0] = None
                     continue
 
@@ -441,12 +468,25 @@ def scan_arguments(path):
                                 kw["help"], lit["help"] = shown, True
                                 continue
                         kw[k.arg], lit[k.arg] = _keyword(k.value)
-                group(current[0])["args"].append((flags, kw, lit))
+                # Dispatch on the RECEIVER (`p.add_argument` -> whatever `p`
+                # was last assigned), falling back to the source-order
+                # cursor only for a receiver this scan never saw assigned.
+                recv = call.func.value
+                owner = (
+                    parsers.get(recv.id, current[0])
+                    if isinstance(recv, ast.Name)
+                    else current[0]
+                )
+                group(owner)["args"].append((flags, kw, lit))
                 continue
 
             # Recurse into compound statements so an add_argument inside a
             # function, an `if`, or a loop is still seen, in source order.
-            for field in ("body", "orelse", "finalbody"):
+            # `handlers` matters: an add_argument under `except ...:` was
+            # neither reported nor counted, so it vanished. Position
+            # matters too -- a Try is written body / handlers / orelse /
+            # finalbody, and this scan promises source order.
+            for field in ("body", "handlers", "orelse", "finalbody"):
                 inner = getattr(st, field, None)
                 if isinstance(inner, list):
                     visit(inner)

--- a/tools-plugin/scripts/tests/test-just-recipe-help.sh
+++ b/tools-plugin/scripts/tests/test-just-recipe-help.sh
@@ -261,6 +261,58 @@ assert "J: an indirect help= is not an unreadable flag NAME, so no refusal" \
 assert "J: and it did not silently become a refusal either" \
   "$(printf '%s' "$ind_out" | grep -q 'REFUSING' && echo false || echo true)"
 
+# ---- K: a flag is filed under the parser it was CALLED on, not the last one
+# Source order files `--x` under whichever parser was declared most recently;
+# only the receiver says `run`. A flag printed beneath a subcommand that does
+# not accept it is worse than an omission — it looks authoritative, and a
+# reader who copies the signature gets a command that fails.
+mkdir -p "$tmp/recv/scripts"
+cat >"$tmp/recv/justfile" <<'JUSTFILE'
+# Wrap a script that declares its parsers before populating them.
+run *ARGS:
+    @python3 scripts/recv.py {{ARGS}}
+JUSTFILE
+cat >"$tmp/recv/scripts/recv.py" <<'PYEOF'
+"""Declares subcommands first, then adds their flags."""
+import argparse
+
+LAST_DESC = "declared after run's flags exist"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers()
+    p_run = sub.add_parser("run", help="the first one")
+    sub.add_parser("status", help="flagless, declared in between")
+    p_last = sub.add_parser("last", help=LAST_DESC)
+    p_run.add_argument("--x", help="belongs to run")
+    p_last.add_argument("--y", help="belongs to last")
+    try:
+        import fancy
+    except ImportError:
+        ap.add_argument("--fallback", help="only without fancy")
+    return ap.parse_args()
+PYEOF
+recv_out="$(cd "$tmp/recv" && python3 "$helper" run 2>&1)"
+# awk, not `sed -n '/a/,/b/p'` — a sed range INCLUDES its terminator, so the
+# status block ran on into `last` and picked up its --y. The assertion failed
+# on correct output, which is the wrong way round for a test.
+block() { printf '%s' "$recv_out" | awk -v s="SUBCOMMAND  $1" '
+  index($0, s) == 1 { f = 1; next } /^SUBCOMMAND/ { f = 0 } /^FLAGS/ { f = 0 } f'; }
+assert "K: --x is filed under run, not under the last-declared parser" \
+  "$(contains "$(block run)" "\-\-x")"
+assert "K: --y is filed under last" "$(contains "$(block last)" "\-\-y")"
+assert "K: the flagless subcommand in between accepts nothing" \
+  "$(printf '%s' "$(block status)" | grep -q -- '--' && echo false || echo true)"
+assert "K: and says so rather than printing an empty section" \
+  "$(contains "$(block status)" "no flags of its own")"
+assert "K: an add_argument inside an except handler is seen at all" \
+  "$(contains "$recv_out" "\-\-fallback")"
+# A subcommand help bound to a NAME. add_argument's help resolves through the
+# constants map; add_parser's did not, so the subcommand printed as a bare name.
+assert "K: a subcommand help bound to a name resolves through the constants" \
+  "$(contains "$recv_out" "declared after run's flags exist")"
+
 # ------------------------- I: a flagless subcommand is still listed by name
 wrapped_out="$(cd "$tmp/good" && python3 "$helper" wrapped 2>&1)"
 assert "I: a subcommand WITH flags is listed" \

--- a/tools-plugin/scripts/tests/test-just-recipe-help.sh
+++ b/tools-plugin/scripts/tests/test-just-recipe-help.sh
@@ -347,6 +347,28 @@ assert "I: and its f-string help is rendered, same as a flag's" \
 assert "I: the {{SCRIPTS}} interpolation resolved to a real path" \
   "$(contains "$wrapped_out" "worker count")"
 
+# --- L: show_script reads a .py's docstring and does not parse a .sh as one
+# TWO-SIDED on purpose. Asserting only the .sh arm proves nothing is
+# OVER-parsed and never that anything is parsed: dropping the suffix check
+# silently removes the module docstring from every Python script — the headline
+# half of what this command prints — while the .sh assertions still hold.
+cp "$tmp/good/scripts/tool.py" "$tmp/good/scripts/doc_example.py"
+cat >"$tmp/good/scripts/plain.sh" <<'SHEOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo hi
+SHEOF
+sh_out="$(cd "$tmp/good" && python3 "$helper" plain.sh 2>&1)"
+py_out="$(cd "$tmp/good" && python3 "$helper" doc_example.py 2>&1)"
+assert "L: a shell script is not reported as broken Python" \
+  "$(printf '%s' "$sh_out" | grep -q 'does not parse' && echo false || echo true)"
+assert "L: and says what it actually is" \
+  "$(contains "$sh_out" "is a shell script, not argparse")"
+assert "L: a Python script still gets its NOTES section" \
+  "$(contains "$py_out" "NOTES")"
+assert "L: with the module docstring in it" \
+  "$(contains "$py_out" "A tool with subcommands")"
+
 # ---------------------------------------------------------------- summary
 echo "PASSED=$pass_count FAILED=$fail_count"
 [ "$fail_count" -eq 0 ] || exit 1

--- a/tools-plugin/scripts/tests/test-just-recipe-help.sh
+++ b/tools-plugin/scripts/tests/test-just-recipe-help.sh
@@ -205,6 +205,41 @@ assert "H: and the refusal exits 3" \
 assert "H: no partial flag list is printed alongside the refusal" \
   "$(printf '%s' "$dyn_out" | grep -q -- '--readable' && echo false || echo true)"
 
+# ------------- J: an indirect help= is resolved or named, but never dropped
+# `help=SOME_CONSTANT` used to print the flag bare, indistinguishable from a
+# flag with no help at all — the same under-report the tool refuses elsewhere,
+# which slipped through because `unresolved` counts unreadable flag NAMES and
+# the name is fine here. Two-sided: asserting only that the resolvable case
+# resolves would pass against an implementation that still drops the other.
+mkdir -p "$tmp/indirect/scripts"
+cat >"$tmp/indirect/justfile" <<'JUSTFILE'
+# Wrap a script whose help text is held in a constant.
+run *ARGS:
+    @python3 scripts/indirect.py {{ARGS}}
+JUSTFILE
+cat >"$tmp/indirect/scripts/indirect.py" <<'PYEOF'
+"""Holds its help text in a local, the usual way."""
+import argparse
+
+
+def main():
+    blurb = "the text that must survive"
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--resolvable", help=blurb)
+    ap.add_argument("--opaque", help="x".join(["a", "b"]))
+    return ap.parse_args()
+PYEOF
+ind_out="$(cd "$tmp/indirect" && python3 "$helper" run 2>&1)"
+ind_rc=$?
+assert "J: a constant help= is resolved to its text" \
+  "$(contains "$ind_out" "the text that must survive")"
+assert "J: an unresolvable help= is NAMED, not dropped" \
+  "$(contains "$ind_out" "not a literal")"
+assert "J: an indirect help= is not an unreadable flag NAME, so no refusal" \
+  "$([ "$ind_rc" = "0" ] && echo true || echo false)"
+assert "J: and it did not silently become a refusal either" \
+  "$(printf '%s' "$ind_out" | grep -q 'REFUSING' && echo false || echo true)"
+
 # ------------------------- I: a flagless subcommand is still listed by name
 wrapped_out="$(cd "$tmp/good" && python3 "$helper" wrapped 2>&1)"
 assert "I: a subcommand WITH flags is listed" \

--- a/tools-plugin/scripts/tests/test-just-recipe-help.sh
+++ b/tools-plugin/scripts/tests/test-just-recipe-help.sh
@@ -221,20 +221,36 @@ cat >"$tmp/indirect/scripts/indirect.py" <<'PYEOF'
 """Holds its help text in a local, the usual way."""
 import argparse
 
+LIMIT = 5
+
 
 def main():
     blurb = "the text that must survive"
     ap = argparse.ArgumentParser()
     ap.add_argument("--resolvable", help=blurb)
-    ap.add_argument("--opaque", help="x".join(["a", "b"]))
+    ap.add_argument("--fstring", help=f"cap at {LIMIT} items")
+    ap.add_argument("--concat", help="scales: " + ", ".join(["a"]))
+    ap.add_argument("--opaque", help=some_call())
     return ap.parse_args()
 PYEOF
 ind_out="$(cd "$tmp/indirect" && python3 "$helper" run 2>&1)"
 ind_rc=$?
 assert "J: a constant help= is resolved to its text" \
   "$(contains "$ind_out" "the text that must survive")"
-assert "J: an unresolvable help= is NAMED, not dropped" \
-  "$(contains "$ind_out" "not a literal")"
+# NOT `contains "cap at {LIMIT} items"` — that is VACUOUS. When the rendering
+# is broken the marker prints the f-string's SOURCE, which contains the very
+# same substring, so the assertion passes either way. (Caught by mutating
+# `shown = _help_display(...)` to `None` and watching the suite stay green.)
+# Exactly ONE flag here is genuinely opaque, so the marker must appear once.
+marker_count="$(printf '%s' "$ind_out" | grep -c 'not a literal')"
+assert "J: only the opaque flag falls back to the marker (got $marker_count)" \
+  "$([ "$marker_count" = "1" ] && echo true || echo false)"
+assert "J: the f-string's text is rendered, not its source expression" \
+  "$(printf '%s' "$ind_out" | grep -q "f'cap at" && echo false || echo true)"
+assert "J: with the interpolation left as a visible placeholder" \
+  "$(contains "$ind_out" "cap at {LIMIT} items")"
+assert "J: a concatenation keeps its literal half" \
+  "$(contains "$ind_out" "scales: ")"
 assert "J: an indirect help= is not an unreadable flag NAME, so no refusal" \
   "$([ "$ind_rc" = "0" ] && echo true || echo false)"
 assert "J: and it did not silently become a refusal either" \

--- a/tools-plugin/scripts/tests/test-just-recipe-help.sh
+++ b/tools-plugin/scripts/tests/test-just-recipe-help.sh
@@ -89,6 +89,8 @@ cat >"$tmp/good/scripts/tool.py" <<'PYEOF'
 """A tool with subcommands, one of which takes no flags."""
 import argparse
 
+WHAT = "the cached scores"
+
 
 def main():
     ap = argparse.ArgumentParser()
@@ -97,6 +99,9 @@ def main():
     p.add_argument("--jobs", type=int, default=4, help="worker count")
     p = sub.add_parser("status", help="report only")
     p.set_defaults(fn=None)
+    # UNASSIGNED, the idiomatic spelling when a subcommand takes no flags --
+    # reading only ast.Assign made these vanish entirely.
+    sub.add_parser("bare", help=f"reads {WHAT}")
     return ap.parse_args()
 PYEOF
 
@@ -264,6 +269,10 @@ assert "I: a subcommand with NO flags is still listed" \
   "$(contains "$wrapped_out" "SUBCOMMAND  status")"
 assert "I: and is marked as having none, not silently empty" \
   "$(contains "$wrapped_out" "no flags of its own")"
+assert "I: an UNASSIGNED add_parser is listed, not silently dropped" \
+  "$(contains "$wrapped_out" "SUBCOMMAND  bare")"
+assert "I: and its f-string help is rendered, same as a flag's" \
+  "$(contains "$wrapped_out" "reads {WHAT}")"
 assert "I: the {{SCRIPTS}} interpolation resolved to a real path" \
   "$(contains "$wrapped_out" "worker count")"
 

--- a/tools-plugin/scripts/tests/test-just-recipe-help.sh
+++ b/tools-plugin/scripts/tests/test-just-recipe-help.sh
@@ -291,7 +291,20 @@ def main():
         import fancy
     except ImportError:
         ap.add_argument("--fallback", help="only without fancy")
+    match "x":
+        case "x":
+            ap.add_argument("--from-match", help="ast.Match keeps arms in cases")
     return ap.parse_args()
+
+
+def other():
+    # Rebinds the SAME local name main() used for the "run" sub-parser, from a
+    # call this scan does not recognise. A stale mapping would file --stale
+    # under "run"; the name must be forgotten so it falls back to the cursor,
+    # which the ArgumentParser line above just reset to the main parser.
+    ap2 = argparse.ArgumentParser()
+    p_run = build_somehow(ap2)
+    p_run.add_argument("--stale")
 PYEOF
 recv_out="$(cd "$tmp/recv" && python3 "$helper" run 2>&1)"
 # awk, not `sed -n '/a/,/b/p'` — a sed range INCLUDES its terminator, so the
@@ -312,6 +325,12 @@ assert "K: an add_argument inside an except handler is seen at all" \
 # constants map; add_parser's did not, so the subcommand printed as a bare name.
 assert "K: a subcommand help bound to a name resolves through the constants" \
   "$(contains "$recv_out" "declared after run's flags exist")"
+assert "K: an add_argument inside a match arm is seen (ast.Match uses cases)" \
+  "$(contains "$recv_out" "ast.Match keeps arms in cases")"
+# A stale `parsers` entry OUTRANKS the cursor, so a name rebound by a call this
+# scan does not recognise must forget its old parser rather than keep it.
+assert "K: a rebound name does not file its flags under the old subcommand" \
+  "$(printf '%s' "$(block run)" | grep -q -- '\-\-stale' && echo false || echo true)"
 
 # ------------------------- I: a flagless subcommand is still listed by name
 wrapped_out="$(cd "$tmp/good" && python3 "$helper" wrapped 2>&1)"


### PR DESCRIPTION
## What

`just-recipe-help.py` dropped a non-literal `help=` in silence. It now resolves
one, or names it — and renders an f-string's own text.

## Why

The flag printed bare, indistinguishable from a flag that genuinely has no
help. That is the exact under-report this tool refuses everywhere else, and it
got past the refusal because `unresolved` counts unreadable flag **names** —
the name is fine here, only the text is indirect.

Found by review on laurigates/comfyui-nodes#165, where the tool was first
built, against the copy this one was generalised from. Live instance there:

```
SUBCOMMAND  slots  -- the render-level paired slot test
  --rung RUNG
```

with the source binding a two-line explanation to `_rung_help`.

## How

Two commits, because the first fix was correct and a poor result.

**`96b72ade`** — `scan_arguments` collects string constants from *every* scope
(the constant is usually a local of the function that builds the parser) and
returns them. A resolvable help is printed; an unresolvable one is **named**,
with its source expression, so the reader learns there is text to go and read.

**`40de1af5`** — a marker is a poor answer when the sentence is right there. In
the tree this was built against, 13 of 15 non-literal `help=` are f-strings.
Their literal parts *are* the help text, so they are now rendered, with each
interpolation shown as `{expr}`:

```
--limit LIMIT
    cap images processed (preview defaults to {PREVIEW_LIMIT})
```

The placeholder stays unresolved deliberately — argparse substitutes a runtime
value and a static read cannot, so showing the expression is honest where
showing a guess would not be. A concatenation with a computed half gets the
same treatment. Result upstream: **15 of 15** display their text.

## The test was vacuous, and the teeth check is what said so

Worth calling out, because the first version of these assertions looked fine:

```sh
assert "J: an f-string help= is rendered" "$(contains "$ind_out" "cap at {LIMIT} items")"
```

That passes **whether or not the rendering works** — the broken path prints the
f-string's *source*, which contains that same substring. Mutating
`shown = _help_display(...)` to `None` left the suite green.

It now asserts the marker appears **exactly once** across four flags, and that
the f-string's source spelling is absent. The same fix went upstream, where the
equivalent assertion had been passing only via an incidental check on a
different flag.

## Verification

- 29 assertions, up from 22.
- Teeth-checked: three mutations — constant not resolved, marker removed,
  f-string not rendered — each CAUGHT by the assertion it names, control MISSED.

Note the `test` check is expected red for reasons unrelated to this PR — see
#2618, a suite that has been failing on `main` independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147YE9fuCKttGe9MxASqy4x
