### PR TITLE
feat(scripts): resolve every plugin:skill citation against disk

### DIFF
--- a/.claude/rules/skill-argument-handling.md
+++ b/.claude/rules/skill-argument-handling.md
@@ -19,7 +19,7 @@ it at scale and the haiku-vs-opus delta that calibrates the sweep.
 Companion to `skill-development.md` (the `$ARGUMENTS` / `$N` substitution
 table), `skill-execution-structure.md` (the `## Parameters` section), and
 `skill-quality.md` (description length). The canonical fixes that motivated this
-rule are `git-plugin:git-issue` (issue URLs/`#N`) and `project-plugin:refocus`
+rule are `git-plugin:git-issue` (issue URLs/`#N`) and `project-plugin:project-refocus`
 (optional focus directive).
 
 ## The 9-axis rubric

--- a/.github/workflows/lint-context-commands.yml
+++ b/.github/workflows/lint-context-commands.yml
@@ -16,6 +16,13 @@ on:
       - 'scripts/audit-skill-descriptions.py'
       - 'scripts/lint-taskwarrior-tags.sh'
       - 'scripts/lint-package-references.sh'
+      # Ground-truth sources for check-skill-references.sh, not just its
+      # citation sites: a skill rename breaks live citations without editing
+      # any citing file, so agents/ and .claude/rules/ must trigger the job.
+      - '**/agents/*.md'
+      - '.claude/rules/*.md'
+      - 'scripts/check-skill-references.sh'
+      - 'scripts/tests/test-check-skill-references.sh'
       - '.github/workflows/lint-context-commands.yml'
   push:
     branches:
@@ -74,3 +81,9 @@ jobs:
 
       - name: Lint skill files for nonexistent package references (npm/PyPI/crates/etc.)
         run: ./scripts/lint-package-references.sh
+
+      - name: Skill-reference resolver self-test
+        run: ./scripts/tests/test-check-skill-references.sh
+
+      - name: Resolve every plugin:skill / plugin:agent citation against disk
+        run: ./scripts/check-skill-references.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -364,6 +364,23 @@ repos:
         language: system
         files: '^(scripts/(lint-mcp-tool-references\.sh|tests/test-lint-mcp-tool-references\.sh)|agent-patterns-plugin/skills/multi-model-delegation/SKILL\.md)$'
         pass_filenames: false
+      - id: check-skill-references
+        name: every plugin:skill / plugin:agent citation resolves to an artifact on disk
+        entry: ./scripts/check-skill-references.sh
+        language: script
+        # Must cover every path the walk reads (see the script's COVERAGE
+        # header) plus the ground-truth sources, because a RENAME changes what
+        # resolves without touching any citing file: a trigger listing only
+        # citation sites would stay silent on exactly the commit that breaks
+        # them. `agents/` and `.claude/rules/` are here for that reason.
+        files: '(SKILL\.md|skill\.md|REFERENCE\.md|\.workflow\.js|^[a-z-]+-plugin/agents/.*\.md|^\.claude/rules/.*\.md|^scripts/check-skill-references\.sh)$'
+        pass_filenames: false
+      - id: test-check-skill-references
+        name: skill-reference resolver detects, stays narrow, and fails loudly on an empty tree
+        entry: bash ./scripts/tests/test-check-skill-references.sh
+        language: system
+        files: '^scripts/(check-skill-references\.sh|tests/test-check-skill-references\.sh)$'
+        pass_filenames: false
       - id: lint-package-references
         name: lint skill files for references to nonexistent packages (npm/PyPI/crates/etc.)
         entry: ./scripts/lint-package-references.sh

--- a/configure-plugin/skills/multi-repo-discipline/SKILL.md
+++ b/configure-plugin/skills/multi-repo-discipline/SKILL.md
@@ -159,7 +159,7 @@ from the authoritative PR description.
 
 - `configure-plugin:config-sync` — mechanical propagation that this rule gates
 - `agent-patterns-plugin:parallel-agent-dispatch` — Return Contract's "Orchestrator action needed" field carries cross-repo diffs
-- `agent-patterns-plugin:agent-coworker-detection` — concurrent-writer detection in shared checkouts
+- `git-plugin:git-coworker-check` — concurrent-writer detection in shared checkouts
 - `.claude/rules/docs-currency.md` — same-commit discipline (applies to each repo individually)
 
 > Evidence: multi-repo sessions where downstream propagation was auto-committed

--- a/scripts/check-skill-references.sh
+++ b/scripts/check-skill-references.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Resolve every `<name>-plugin:<artifact>` citation against the skills and
+# agents that actually exist on disk.
+#
+# Skills, rules and REFERENCE files cite sibling artifacts by their
+# plugin-qualified ID ("invoke `git-plugin:git-commit`"). Nothing validates
+# those strings: rename a skill directory, or delete one, and every citation
+# keeps reading as authoritative while pointing at an ID the Skill tool cannot
+# resolve. The agent burns a round trip on `Skill(...)` -> "not found" and then
+# reinvents whatever the cited skill encoded — the exact failure the citation
+# existed to prevent.
+#
+# This is a RESOLUTION check, not a denylist: ground truth is rebuilt from the
+# tree on every run, so a rename is caught the moment it lands without anyone
+# adding an entry here. Contrast `lint-mcp-tool-references.sh`, which must
+# enumerate bad names because the MCP servers' tool lists are not on disk.
+#
+# GROUND TRUTH — an ID resolves if it matches either:
+#   * `<plugin>/skills/<name>/SKILL.md`  -> `<plugin>:<name>`
+#   * `<plugin>/agents/<name>.md`        -> `<plugin>:<name>`
+# There are no `commands/` directories in this repo; add a third arm here if
+# that changes.
+#
+# COVERAGE — what this script reads. It is NOT repo-wide:
+#   * `SKILL.md` / `skill.md` / `REFERENCE.md` anywhere in the repo
+#   * `*.workflow.js` — workflow scripts bundled beside a skill, which carry
+#     skill IDs in their agent prompts
+#   * `.claude/rules/*.md` — always-loaded rules that route the agent to a
+#     skill by ID. A dead ID here misroutes every session, so unlike the MCP
+#     linter (which excludes rules because they cite broken tool names on
+#     purpose) this scan includes them. The two intentional-broken-citation
+#     shapes that live in rules are handled by the allowlist below.
+# Deliberately OUT of scope:
+#   * `docs/**` — ADRs and benchmark judgments are immutable records. ADR-0007
+#     cites `git-plugin:commit`, a pre-rename name that was correct when the
+#     decision was written; "fixing" it would falsify the record.
+#   * `CHANGELOG.md` — release-please generated, and a changelog entry about a
+#     rename necessarily names the old ID.
+#   * `README.md` / `docs/PLUGIN-MAP.md` counts — already covered by
+#     `check-docs-index.sh`; this script must not double-gate them.
+#
+# Lines starting with `>` (markdown blockquote) are skipped, matching
+# `lint-mcp-tool-references.sh`, so a callout can cite a dead ID as an example.
+#
+# Exit codes:
+#   0 - every citation resolves
+#   1 - one or more dead citations found
+set -euo pipefail
+
+errors=0
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Citation shape. Two guards earn their keep, both found by running this
+# against the tree:
+#   * LEFT BOUNDARY `(^|[^A-Za-z0-9_-])` — without it the prose word
+#     "Cross-plugin:" yields a phantom `ross-plugin:`. The class must exclude
+#     UPPER case too; `[^a-z0-9_-]` still matches the `C` and re-admits it.
+#   * NON-EMPTY NAME `[a-z0-9-]+` — a bare `<plugin>:` prefix is not a
+#     citation. Without the `+`, the changelog heading `**testing-plugin:**`
+#     and the shell line `echo "macos-plugin: not Darwin"` both register as
+#     dead IDs (7 of the 9 false positives on the first run).
+# The leading boundary character is captured by `grep -o` and stripped after;
+# it is never `[a-z]`, so `s/^[^a-z]+//` cannot eat part of a real ID.
+id_re='(^|[^A-Za-z0-9_-])[a-z][a-z0-9-]*-plugin:[a-z0-9-]+'
+
+# Enter the scan root before discovery so the relative paths `find .` emits
+# resolve for the reads below too. A discovery subshell that cd'd while the
+# consumer ran in the caller's cwd is the silent no-scan class of #2219/#2290.
+cd "$repo_root" || exit 1
+
+# Allowlist of citation PREFIXES that are correct despite not resolving. Each
+# entry is a `case` glob matched against the extracted ID.
+allowlist=(
+  # `my-plugin:` is the placeholder namespace used by authoring examples
+  # (agent-development.md, obsidian dev-tools). It names no real plugin by
+  # design — a doc showing "how to cite a skill" needs a stand-in.
+  'my-plugin:*'
+
+  # A trailing `-` is the extractor hitting a glob form in prose, e.g.
+  # `typescript-plugin:bun-*` in regression-testing.md, which cites a FAMILY
+  # of skills rather than one ID. The bare stem never resolves and should not.
+  '*-'
+)
+
+allowed() {
+  local id="$1" pat
+  for pat in "${allowlist[@]}"; do
+    # shellcheck disable=SC2254  # glob matching of $pat is intentional
+    case "$id" in
+      $pat) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+# Build ground truth. A plain sorted file + `grep -qxF` keeps this working on
+# bash 3.2 (macOS default), which has no associative arrays.
+truth="$(mktemp)"
+trap 'rm -f "$truth"' EXIT
+
+{
+  find . -type f -name 'SKILL.md' \
+    -not -path './.claude/worktrees/*' -not -path './dist/*' \
+    -not -path '*/node_modules/*' -print |
+    sed -n 's#^\./\([^/]*\)/skills/\([^/]*\)/SKILL\.md$#\1:\2#p'
+  find . -type f -name '*.md' -path '*/agents/*' \
+    -not -path './.claude/worktrees/*' -not -path './dist/*' \
+    -not -path '*/node_modules/*' -print |
+    sed -n 's#^\./\([^/]*\)/agents/\([^/]*\)\.md$#\1:\2#p'
+} | sort -u >"$truth"
+
+truth_count="$(wc -l <"$truth" | tr -d ' ')"
+
+# A ground truth of zero means the walk found nothing — a broken scan, not a
+# clean tree. Fail loudly rather than pass every citation by vacuous default
+# (the empty-negative trap: an unrun check and a passing check look identical).
+if [ "$truth_count" -eq 0 ]; then
+  printf "ERROR: resolved 0 skills/agents on disk -- the discovery walk is broken, not the tree clean\n" >&2
+  exit 1
+fi
+
+while IFS= read -r -d '' file; do
+  while IFS=: read -r line_no content; do
+    # Blockquote callouts cite dead IDs on purpose.
+    case "$content" in
+      '>'* | *[[:space:]]'>'*) continue ;;
+    esac
+    # A single line may carry several citations.
+    while IFS= read -r id; do
+      [ -n "$id" ] || continue
+      allowed "$id" && continue
+      grep -qxF "$id" "$truth" && continue
+      printf "ERROR [dead-skill-reference]: %s:%s\n" "${file#./}" "$line_no"
+      printf "  Found: %s\n" "$id"
+      # Offer the closest surviving ID under the same plugin, if there is one.
+      plugin="${id%%:*}"
+      name="${id#*:}"
+      suggestion="$(grep "^${plugin}:" "$truth" | grep -- "$name" | head -1 || true)"
+      if [ -n "$suggestion" ]; then
+        printf "  Fix:   did you mean %s ?\n\n" "$suggestion"
+      else
+        printf "  Fix:   no skill or agent with this ID exists; check %s/skills/ and %s/agents/\n\n" "$plugin" "$plugin"
+      fi
+      errors=$((errors + 1))
+    done < <(printf '%s\n' "$content" | grep -oE "$id_re" | sed -E 's/^[^a-z]+//' || true)
+  done < <(grep -nE "$id_re" "$file" || true)
+# dist/ is gitignored OpenCode export output and worktree clones are copies of
+# sources already scanned — findings there have no fix site. Same pruning as
+# lint-mcp-tool-references.sh.
+done < <(find . -type f \
+  \( -name 'SKILL.md' -o -name 'skill.md' -o -name 'REFERENCE.md' \
+  -o -name '*.workflow.js' -o -path './.claude/rules/*.md' \) \
+  -not -path './.claude/worktrees/*' \
+  -not -path './dist/*' \
+  -not -path '*/node_modules/*' \
+  -print0)
+
+if [ "$errors" -gt 0 ]; then
+  printf "Found %d dead skill/agent reference(s) against %s IDs on disk\n" "$errors" "$truth_count"
+  exit 1
+fi
+
+printf "All skill/agent references resolve (%s IDs on disk)\n" "$truth_count"
+exit 0

--- a/scripts/tests/test-check-skill-references.sh
+++ b/scripts/tests/test-check-skill-references.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016  # file-level: backticked skill IDs in the planted fixtures are literal markdown, not command substitution
+# Regression test for scripts/check-skill-references.sh
+#
+# The linter resolves every `<name>-plugin:<artifact>` citation against the
+# skills and agents on disk. Two genuine dead citations motivated it:
+# `configure-plugin:multi-repo-discipline` cited a nonexistent
+# `agent-patterns-plugin:agent-coworker-detection`, and
+# `.claude/rules/skill-argument-handling.md` cited `project-plugin:refocus`
+# after the skill was renamed to `project-plugin:project-refocus`.
+#
+# SEMANTIC, not syntactic: every case EXECUTES a copy of the real linter
+# against a planted fixture tree and asserts on its verdict. Grepping the
+# linter for a regex would pass against an extractor that matches nothing --
+# and a checker that scans zero files exits 0 exactly like a clean tree.
+#
+# Detection is the cheap half. Three others are weighted equally:
+#
+#   NARROWNESS — the first run of this linter against the real tree produced 9
+#   false positives out of 11 findings. All were extractor artifacts: the prose
+#   word "Cross-plugin:" yielded a phantom `ross-plugin:`, and a bare
+#   `<plugin>:` prefix with no name (`**testing-plugin:**`, and the shell line
+#   `echo "macos-plugin: not Darwin"`) registered as a dead ID. Both shapes are
+#   pinned below; a checker that re-admits them gets reverted rather than used.
+#
+#   COVERAGE — the walk is not repo-wide (see the linter's COVERAGE header).
+#   `.claude/rules/*.md` must be scanned (a dead ID in an always-loaded rule
+#   misroutes every session) and `docs/**` must NOT be (ADR-0007 cites the
+#   pre-rename `git-plugin:commit`, which is correct for an immutable record).
+#
+#   NON-VACUITY — a broken discovery walk finds zero skills and then resolves
+#   every citation against an empty ground truth, passing everything. The
+#   linter must fail loudly on an empty truth set instead.
+#
+# Exit codes: 0 all assertions pass, 1 otherwise.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+linter="$repo_root/scripts/check-skill-references.sh"
+
+pass=0
+fail=0
+
+ok() {
+  printf '  PASS: %s\n' "$1"
+  pass=$((pass + 1))
+}
+
+bad() {
+  printf '  FAIL: %s\n' "$1"
+  printf '        %s\n' "${2:-}"
+  fail=$((fail + 1))
+}
+
+# Base fixture: one real skill and one real agent, so ground truth is non-empty
+# and the clean-tree control is meaningful. The linter resolves its scan root as
+# `dirname "$0"/..`, so the copy must live under <fixture>/scripts/.
+make_fixture() {
+  local dir
+  dir="$(mktemp -d)"
+  [ -n "$dir" ] || {
+    printf 'mktemp -d failed\n' >&2
+    exit 1
+  }
+  mkdir -p "$dir/scripts" \
+    "$dir/demo-plugin/skills/real-skill" \
+    "$dir/demo-plugin/agents" \
+    "$dir/.claude/rules" \
+    "$dir/docs/adrs"
+  cp "$linter" "$dir/scripts/check-skill-references.sh"
+  chmod +x "$dir/scripts/check-skill-references.sh"
+  printf -- '---\nname: real-skill\n---\n\nBody.\n' \
+    >"$dir/demo-plugin/skills/real-skill/SKILL.md"
+  printf -- '---\nname: real-agent\n---\n\nBody.\n' \
+    >"$dir/demo-plugin/agents/real-agent.md"
+  printf '%s' "$dir"
+}
+
+fixture="$(make_fixture)"
+trap 'rm -rf "$fixture"' EXIT
+
+# run_case <label> <expect: flag|clean> <relative-path> <file-body>
+# Plants one file, runs the linter, asserts the verdict, then removes the file
+# so cases stay independent.
+run_case() {
+  local label="$1" expect="$2" rel="$3" body="$4" out status
+  mkdir -p "$fixture/$(dirname "$rel")"
+  printf '%s\n' "$body" >"$fixture/$rel"
+  out="$("$fixture/scripts/check-skill-references.sh" 2>&1)"
+  status=$?
+  rm -f "$fixture/$rel"
+
+  case "$expect" in
+    flag)
+      if [ "$status" -ne 0 ]; then
+        ok "$label"
+      else
+        bad "$label" "expected a finding, linter exited 0: $out"
+      fi
+      ;;
+    clean)
+      if [ "$status" -eq 0 ]; then
+        ok "$label"
+      else
+        bad "$label" "expected no finding, linter exited $status: $out"
+      fi
+      ;;
+  esac
+}
+
+printf 'test-check-skill-references\n'
+
+# --- control: the base fixture alone must be clean -------------------------
+if out="$("$fixture/scripts/check-skill-references.sh" 2>&1)"; then
+  ok "control: fixture with only resolvable artifacts exits 0"
+else
+  bad "control: clean fixture" "$out"
+fi
+
+# --- detection --------------------------------------------------------------
+run_case "detects a dead skill ID in a SKILL.md" flag \
+  "demo-plugin/skills/other/SKILL.md" \
+  'See `demo-plugin:no-such-skill` for details.'
+
+run_case "detects a dead ID in an always-loaded rule (.claude/rules IS scanned)" flag \
+  ".claude/rules/demo.md" \
+  'Invoke `demo-plugin:no-such-skill` before editing.'
+
+run_case "detects a dead ID in a REFERENCE.md" flag \
+  "demo-plugin/skills/real-skill/REFERENCE.md" \
+  'Related: `demo-plugin:no-such-skill`.'
+
+# --- resolution: real artifacts must not be flagged -------------------------
+run_case "a citation resolving to a real SKILL.md is clean" clean \
+  "demo-plugin/skills/other/SKILL.md" \
+  'See `demo-plugin:real-skill` for details.'
+
+run_case "a citation resolving to a real agent is clean" clean \
+  "demo-plugin/skills/other/SKILL.md" \
+  'Dispatch `demo-plugin:real-agent` for this.'
+
+# --- narrowness: the 9 false positives from the first real run --------------
+# The GLUED form is the one that needs the left-boundary guard. With a space
+# after the colon the non-empty-name guard already rejects it, so a spaced
+# fixture passes even against a linter with no boundary check at all — it would
+# assert nothing. Here `Cross-plugin:real-skill` yields the phantom
+# `ross-plugin:real-skill` (unresolvable, so: a finding) the moment the
+# boundary class is dropped or narrowed to `[^a-z0-9_-]`, which still admits
+# the uppercase `C`.
+run_case "prose 'Cross-plugin:<word>' does not yield a phantom ross-plugin ID" clean \
+  "demo-plugin/skills/other/SKILL.md" \
+  'Cross-plugin:real-skill coordination is out of scope here.'
+
+run_case "a bare '<plugin>:' prefix with no name is not a citation" clean \
+  "demo-plugin/skills/other/SKILL.md" \
+  'The changelog carries `**testing-plugin:**` as a heading.'
+
+run_case "a shell line echoing '<plugin>: message' is not a citation" clean \
+  "demo-plugin/skills/other/SKILL.md" \
+  'test "$(uname -s)" = "Darwin" || { echo "macos-plugin: not Darwin"; exit 1; }'
+
+# --- allowlist --------------------------------------------------------------
+run_case "the my-plugin: authoring placeholder is allowed" clean \
+  "demo-plugin/skills/other/SKILL.md" \
+  'Cite a skill as `my-plugin:code-reviewer` in your own plugin.'
+
+run_case "a glob family form (bun-*) is allowed" clean \
+  "demo-plugin/skills/other/SKILL.md" \
+  'The `typescript-plugin:bun-*` skills cover this.'
+
+# --- coverage boundaries ----------------------------------------------------
+run_case "docs/ is deliberately out of scope (ADRs cite pre-rename IDs)" clean \
+  "docs/adrs/0007-demo.md" \
+  'The command was `demo-plugin:no-such-skill` at the time of this decision.'
+
+run_case "a blockquote callout may cite a dead ID as an example" clean \
+  "demo-plugin/skills/other/SKILL.md" \
+  '> Formerly `demo-plugin:no-such-skill`, now renamed.'
+
+# --- non-vacuity ------------------------------------------------------------
+empty="$(mktemp -d)"
+mkdir -p "$empty/scripts"
+cp "$linter" "$empty/scripts/check-skill-references.sh"
+chmod +x "$empty/scripts/check-skill-references.sh"
+out="$("$empty/scripts/check-skill-references.sh" 2>&1)"
+status=$?
+if [ "$status" -ne 0 ] && printf '%s' "$out" | grep -q 'discovery walk is broken'; then
+  ok "empty ground truth fails loudly instead of passing vacuously"
+else
+  bad "empty ground truth" "expected exit!=0 naming a broken walk, got $status: $out"
+fi
+rm -rf "$empty"
+
+# --- cwd independence (the silent no-scan class of #2219/#2290) -------------
+printf 'See `demo-plugin:no-such-skill`.\n' \
+  >"$fixture/demo-plugin/skills/real-skill/REFERENCE.md"
+out="$(cd / && "$fixture/scripts/check-skill-references.sh" 2>&1)"
+status=$?
+rm -f "$fixture/demo-plugin/skills/real-skill/REFERENCE.md"
+if [ "$status" -ne 0 ]; then
+  ok "scans correctly when invoked from an unrelated cwd"
+else
+  bad "cwd independence" "linter found nothing when run from /: $out"
+fi
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
## What

Adds `scripts/check-skill-references.sh`, which rebuilds the set of skill and agent IDs from the tree on every run and resolves every `<name>-plugin:<artifact>` citation against it. Fixes the two dead citations it found.

## Why

Skills, rules and REFERENCE files cite sibling artifacts by their plugin-qualified ID (``invoke `git-plugin:git-commit` ``). Nothing validated those strings. Rename a skill directory and every citation keeps reading as authoritative while pointing at an ID the Skill tool cannot resolve — the agent spends a round trip on `Skill(...)` → "not found", then reinvents whatever the cited skill encoded, which is the failure the citation existed to prevent.

There are **244 distinct citations across 1,065 tracked `.md`/`.json` files**, so this is not a hypothetical surface.

This is a **resolution** check, not a denylist. Ground truth comes off disk each run, so a rename is caught the commit it lands with no list to maintain. `lint-mcp-tool-references.sh` must enumerate bad names because MCP servers' tool lists are not on disk; here they are.

## The two dead citations

| Site | Cited | Actual |
|---|---|---|
| `configure-plugin/skills/multi-repo-discipline/SKILL.md:162` | `agent-patterns-plugin:agent-coworker-detection` | `git-plugin:git-coworker-check` — "Detect coworker Claude agents in a shared checkout". No agent-patterns skill of that shape exists. |
| `.claude/rules/skill-argument-handling.md:22` | `project-plugin:refocus` | `project-plugin:project-refocus` (renamed) |

## Scope

`.claude/rules/*.md` **is** scanned — a dead ID in an always-loaded rule misroutes every session. This differs from `lint-mcp-tool-references.sh`, which excludes rules because they cite broken tool names on purpose.

`docs/**` is **excluded** — ADRs and benchmark judgments are immutable records. ADR-0007 cites the pre-rename `git-plugin:commit`, which was correct when the decision was written; "fixing" it would falsify the record. README/PLUGIN-MAP counts stay with `check-docs-index.sh` rather than being double-gated here.

## The 9 false positives

The first run against the tree returned 11 findings. Nine were my extractor, not the tree:

- the prose word `Cross-plugin:` yielded a phantom `ross-plugin:` (no left word boundary)
- a bare `<plugin>:` prefix with no name matched the changelog heading `**testing-plugin:**` and the shell line `echo "macos-plugin: not Darwin"`

Both shapes are now pinned by the test suite. Worth noting for review: the boundary class must exclude **uppercase** too — `[^a-z0-9_-]` still admits the `C` in `Cross-plugin:` and re-opens the phantom.

## Test suite

`scripts/tests/test-check-skill-references.sh` — 15 cases, executing a copy of the linter against planted fixtures rather than grepping it. Covers detection, resolution, both narrowness regressions, the allowlist, the `docs/` scope boundary, blockquote exemption, cwd-independence (#2219/#2290), and a **non-vacuity** guard: a broken discovery walk finds zero skills and then resolves every citation against an empty ground truth, so the linter fails loudly on an empty truth set instead of passing everything.

The suite was mutation-checked against four broken linters — dropping the left-boundary guard, narrowing it to `[^a-z0-9_-]`, neutering the error counter, and breaking the discovery walk each turn it red against a green baseline.

## Verification

- `shellcheck` clean on both scripts; `actionlint` clean on the workflow
- `pre-commit run` over the changed files: exit 0, with both new hooks confirmed **Passed** rather than skipped
- Control: planting a dead citation makes the hook exit 1 and name it
- Ground truth is 423 plugin skills + 21 agents, matching `check-docs-index.sh`. The linter's status line says 446 because the walk also picks up the 2 repo-scoped `.claude/skills/` entries; those yield IDs of the form `.claude:x`, which the citation regex cannot produce, so they are inert and cannot mask a dead citation.

## Trigger scope

Pre-commit and CI triggers include `agents/` and `.claude/rules/` as well as citation sites, because a rename breaks live citations **without editing any citing file** — a trigger listing only citation sites would stay silent on exactly the commit that breaks them.

The advisory `nudge-plugin-readme-currency` hook flagged `configure-plugin`; the change there is a one-word citation fix in a Related list and does not affect documented behavior, so no README update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LK8CtveSowcPhWHq5RbKrP