### PR TITLE
fix(scripts): follow the relocated PAL reference in the MCP lint test

### DIFF
--- a/scripts/tests/test-lint-mcp-tool-references.sh
+++ b/scripts/tests/test-lint-mcp-tool-references.sh
@@ -311,6 +311,25 @@ rm -rf "$fx"
 # "No matching deferred tools found" result proves the prefix was wrong.
 # ---------------------------------------------------------------------------
 skill="$repo_root/agent-patterns-plugin/skills/multi-model-delegation/SKILL.md"
+skill_ref="$repo_root/agent-patterns-plugin/skills/multi-model-delegation/REFERENCE.md"
+
+# Two assertions below search SKILL.md *and* REFERENCE.md. #2601 moved the
+# ToolSearch-miss cause table and the stdio caveat into REFERENCE.md, leaving a
+# pointer behind ("that message has a second cause"), but the assertions kept
+# looking only at SKILL.md — so CASE 9 had been red on main ever since, and a
+# permanently-red case teaches the suite to be ignored.
+#
+# What CASE 9 is for is that the GUIDANCE exists somewhere a reader following
+# the skill will reach; REFERENCE.md is part of the skill, and which of the two
+# files carries a given detail is an editorial call this test should not pin.
+# The three entry-point assertions above stay SKILL.md-only on purpose: the
+# prefix derivation, `claude mcp list`, and the user-scope path must be on the
+# page the reader lands on, not one hop away.
+in_skill_docs() {
+  grep -q "$1" "$skill" && return 0
+  [ -f "$skill_ref" ] && grep -q "$1" "$skill_ref"
+}
+
 if [ -f "$skill" ]; then
   if grep -q 'registered under' "$skill"; then
     ok "multi-model-delegation documents the prefix as derived from the registration"
@@ -332,13 +351,13 @@ if [ -f "$skill" ]; then
       "expected the ~/.claude.json user-scope path to be named"
   fi
   # Problem 4: the issue's own evidence is that the CORRECT prefix also missed.
-  if grep -q 'has two causes' "$skill"; then
+  if in_skill_docs 'has two causes'; then
     ok "multi-model-delegation splits the two causes of a ToolSearch miss"
   else
     bad "multi-model-delegation splits the two causes of a ToolSearch miss" \
       "expected the correct-prefix-also-misses case to be documented"
   fi
-  if grep -q 'stdin open until the response arrives' "$skill"; then
+  if in_skill_docs 'stdin open until the response arrives'; then
     ok "multi-model-delegation records the reporter's stdio workaround caveat"
   else
     bad "multi-model-delegation records the reporter's stdio workaround caveat" \


### PR DESCRIPTION
## What

Points two CASE 9 assertions in `scripts/tests/test-lint-mcp-tool-references.sh` at `REFERENCE.md` as well as `SKILL.md`, fixing the `test` job that has been red on `main`.

## Why

CASE 9 asserts that `multi-model-delegation` documents both causes of a `No matching deferred tools found` result, and the stdin-stays-open caveat for the direct-stdio workaround. It searched `SKILL.md` only.

#2601 moved that material into the skill's `REFERENCE.md` and left a pointer behind:

> If a lookup under the correct prefix still finds nothing, see [REFERENCE.md](REFERENCE.md) — that message has a second cause.

The test wasn't updated. Both assertions have failed since, so `test` reports `FAILURE` on every PR:

```
FAIL: multi-model-delegation splits the two causes of a ToolSearch miss
FAIL: multi-model-delegation records the reporter's stdio workaround caveat
PASSED=18 FAILED=2
```

A permanently-red case is worse than no case — it trains everyone to read `test` as "red as usual" and to merge past it, which is exactly what a regression suite must not become.

## Why the test and not the docs

My first read was that #2601 had dropped the content, and I was about to restore it verbatim into `SKILL.md` from `e6ec35f6^`. The pointer sentence in the current `SKILL.md` is what corrected that — the content is intact at `REFERENCE.md:7` and `:18`. This was a relocation, not a deletion, so restoring would have duplicated it.

What CASE 9 exists to protect is that a reader following the skill *reaches* the guidance. `REFERENCE.md` is part of the skill, and which of the two files carries a given detail is an editorial call the test should not pin.

The three entry-point assertions stay `SKILL.md`-only on purpose: the prefix derivation, `claude mcp list`, and the user-scope registration must be on the page the reader lands on, not one hop away.

## Verification

Control-tested rather than assumed green — a widened search can pass by no longer being able to fail:

| State | Result |
|---|---|
| As shipped | `PASSED=20 FAILED=0` |
| Both strings edited out of `REFERENCE.md` (absent from **both** files) | `PASSED=18 FAILED=2` — the same two assertions |
| Restored | `PASSED=20 FAILED=0` |

`shellcheck` clean.

## Related

Found while verifying #2627, whose `test` job was red for this reason and not because of its own changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LK8CtveSowcPhWHq5RbKrP
