### PR TITLE
fix(hooks-plugin): inspect all reader matches for secret protection (#2611)

### DIFF
--- a/hooks-plugin/hooks/secret-protection.sh
+++ b/hooks-plugin/hooks/secret-protection.sh
@@ -137,34 +137,41 @@ ${OVERRIDE_NOTE}"
   # merely ends in a verb (`multitail`, `lolcat`) is not matched any more.
   reader_verbs='(cat|gcat|zcat|bzcat|xzcat|head|ghead|tail|gtail|less|zless|more|nano|vim|nvim|gvim|mvim|vi|code|read)'
   for pattern in '\.env\b' '\.ssh/' '\.aws/credentials' '\.kube/config' '\.docker/config\.json' 'credentials\.json' 'secrets\.json'; do
-    # Capture the matched substring (verb + path) rather than a bare boolean, so
-    # the block message can name what tripped it and the exemption below can
-    # inspect the actual path argument.
-    match=$(echo "$COMMAND" | grep -oE "(^${reader_verbs}|[^A-Za-z]${reader_verbs})[[:space:]]+[^|;&]*${pattern}[^[:space:]|;&'\"]*" | head -1 || true)
-    [ -z "$match" ] && continue
-    # Drop the single boundary character the second alternative captured (a
-    # space, `;`, `(`, quote, …); a start-of-line match begins with the verb
-    # and is left alone.
-    match="${match#[!A-Za-z]}"
+    # Capture the matched substrings (verb + path) rather than a bare boolean,
+    # so the block message can name what tripped it and the exemption below can
+    # inspect the actual path argument. Inspect every match across the command
+    # rather than just the first: taking only `head -1` let a real secret read
+    # slip past if preceded by an exempted template in a chained command, e.g.
+    # `cat .env.example; cat .env` (issue #2611).
+    matches=$(echo "$COMMAND" | grep -oE "(^${reader_verbs}|[^A-Za-z]${reader_verbs})[[:space:]]+[^|;&]*${pattern}[^[:space:]|;&'\"]*" || true)
+    [ -z "$matches" ] && continue
 
-    # .env.example / .env.sample / .env.template are templates committed by
-    # convention, not secrets. check_sensitive_path() already exempts them on
-    # the Read/Edit/Write path; without the same exemption here, `cat
-    # .env.example` was blocked while `Read`ing the identical file was allowed
-    # (issue #2444). Scoped to the .env pattern to mirror check_sensitive_path()
-    # exactly — the other patterns keep no exemption.
-    #
-    # The exemption requires *every* .env token in the matched region to be a
-    # template. Inspecting only the last one would let a real secret hide behind
-    # a template in the same statement (`cat .env .env.example`).
-    if [ "$pattern" = '\.env\b' ]; then
-      env_tokens=$(echo "$match" | grep -oE "${pattern}[^[:space:]|;&'\"]*" || true)
-      non_template=$(echo "$env_tokens" | grep -vE '\.(example|sample|template)$' || true)
-      [ -n "$env_tokens" ] && [ -z "$non_template" ] && continue
-    fi
+    while IFS= read -r match; do
+      [ -z "$match" ] && continue
+      # Drop the single boundary character the second alternative captured (a
+      # space, `;`, `(`, quote, …); a start-of-line match begins with the verb
+      # and is left alone.
+      match="${match#[!A-Za-z]}"
 
-    block "BLOCKED: Command accesses a sensitive file matching '${pattern}' (matched: '${match}').
+      # .env.example / .env.sample / .env.template are templates committed by
+      # convention, not secrets. check_sensitive_path() already exempts them on
+      # the Read/Edit/Write path; without the same exemption here, `cat
+      # .env.example` was blocked while `Read`ing the identical file was allowed
+      # (issue #2444). Scoped to the .env pattern to mirror check_sensitive_path()
+      # exactly — the other patterns keep no exemption.
+      #
+      # The exemption requires *every* .env token in the matched region to be a
+      # template. Inspecting only the last one would let a real secret hide behind
+      # a template in the same statement (`cat .env .env.example`).
+      if [ "$pattern" = '\.env\b' ]; then
+        env_tokens=$(echo "$match" | grep -oE "${pattern}[^[:space:]|;&'\"]*" || true)
+        non_template=$(echo "$env_tokens" | grep -vE '\.(example|sample|template)$' || true)
+        [ -n "$env_tokens" ] && [ -z "$non_template" ] && continue
+      fi
+
+      block "BLOCKED: Command accesses a sensitive file matching '${pattern}' (matched: '${match}').
 ${OVERRIDE_NOTE}"
+    done <<< "$matches"
   done
 fi
 

--- a/hooks-plugin/hooks/test-secret-protection.sh
+++ b/hooks-plugin/hooks/test-secret-protection.sh
@@ -17,6 +17,9 @@
 #     Binaries that used to match only because their name ends in a verb
 #     (`nvim`, `gcat`, `zless`, `bzcat`, `xzcat`, `mvim`) are listed explicitly
 #     and stay blocked.
+#   - All reader matches across a command are inspected: taking only `head -1`
+#     let a real secret read pass undetected if preceded by an exempted template
+#     in a chained command (`cat .env.example; cat .env`) (issue #2611).
 set -euo pipefail
 
 HOOK="$(cd "$(dirname "$0")" && pwd)/secret-protection.sh"
@@ -279,6 +282,29 @@ assert_matched_text() {
 assert_matched_text \
     "ls -la; less .env reports the match from the verb, not the separator" "less ${env_token}" \
     "ls -la; less ${env_token}"
+
+# ── all reader matches inspected: template exemption cannot mask secrets (#2611)
+# Taking only `head -1` let a real secret read pass undetected if preceded by
+# an exempted template in a chained command (`cat .env.example; cat .env`).
+# Every reader match across the command must be evaluated.
+echo ""
+echo "all reader matches inspected; template exemption does not mask secrets:"
+
+assert_exit \
+    "cat .env.example; cat .env is blocked" 2 \
+    "cat ${env_token}.example; cat ${env_token}"
+
+assert_exit \
+    "cat .env.example && cat .env is blocked" 2 \
+    "cat ${env_token}.example && cat ${env_token}"
+
+assert_exit \
+    "cat .env.sample; cat .env.local is blocked" 2 \
+    "cat ${env_token}.sample; cat ${env_token}.local"
+
+assert_exit \
+    "cat .env.example; echo done is allowed" 0 \
+    "cat ${env_token}.example; echo done"
 
 # ── block-message framing: operator-only, not a self-serve bypass ────────────
 # Regression: every block message used to end "Set


### PR DESCRIPTION
Closes #2611

Iterates across all reader regex matches in `hooks-plugin/hooks/secret-protection.sh` instead of taking `| head -1`, ensuring commands like `cat .env.example; cat .env` or `cat .env.sample && cat .env.local` cannot bypass secret protection behind an initial template match.

Verified: added 4 regression test cases in `hooks-plugin/hooks/test-secret-protection.sh` (54 passed, 0 failed, shellcheck clean).