### PR TITLE
fix(adapters): handle empty prompts, empty injected blocks, and path resolution in pi adapter (#2632)

### DIFF
--- a/adapters/core/embeddings.ts
+++ b/adapters/core/embeddings.ts
@@ -24,8 +24,8 @@ export const QUERY_PREFIX = "search_query: ";
  */
 export const PREFIX_SCHEME = `${DOCUMENT_PREFIX}/${QUERY_PREFIX}`;
 
-/** 3 s on the initial probe (embed one short string at build). */
-export const PROBE_TIMEOUT_MS = 3_000;
+/** 15 s on the initial probe (embed one short string at build; handles Ollama cold-load). */
+export const PROBE_TIMEOUT_MS = 15_000;
 /** 30 s on the batch call. */
 export const BATCH_TIMEOUT_MS = 30_000;
 

--- a/adapters/core/search.ts
+++ b/adapters/core/search.ts
@@ -190,8 +190,6 @@ export class SkillIndex {
  */
 export async function buildIndex(opts: IndexOptions): Promise<SkillIndex> {
   const target = opts.target ?? "foreign";
-  const { entries, warnings } = scanSkills(opts.repoRoot, target);
-
   const embedOpts: EmbedOptions = {
     endpoint: opts.embed?.endpoint ?? DEFAULT_ENDPOINT,
     model: opts.embed?.model ?? DEFAULT_MODEL,
@@ -199,15 +197,22 @@ export async function buildIndex(opts: IndexOptions): Promise<SkillIndex> {
   };
   const dims = opts.embed?.dimensions ?? DEFAULT_DIMENSIONS;
 
-  if (opts.embed?.disabled) {
-    return new SkillIndex(entries, warnings, "bm25-only", null, null, dims);
-  }
-
-  if (!(await probeEndpoint(embedOpts))) {
-    return new SkillIndex(entries, warnings, "bm25-only", null, null, dims);
-  }
+  let entries: SkillEntry[] = [];
+  let warnings: string[] = [];
 
   try {
+    const scanned = scanSkills(opts.repoRoot, target);
+    entries = scanned.entries;
+    warnings = scanned.warnings;
+
+    if (opts.embed?.disabled) {
+      return new SkillIndex(entries, warnings, "bm25-only", null, null, dims);
+    }
+
+    if (entries.length === 0 || !(await probeEndpoint(embedOpts))) {
+      return new SkillIndex(entries, warnings, "bm25-only", null, null, dims);
+    }
+
     const filePath = cacheFilePath(opts.repoRoot, opts.cacheDir);
     const cached = loadCache(filePath);
     const cacheValid = cached !== null && cached.model === embedOpts.model && cached.dims === dims;
@@ -253,8 +258,10 @@ export async function buildIndex(opts: IndexOptions): Promise<SkillIndex> {
 
     const matrix = toNormalizedMatrix(rows as number[][], dims);
     return new SkillIndex(entries, warnings, "hybrid", embedOpts, matrix, dims);
-  } catch {
-    // Batch-embed or cache failure after a successful probe: degrade.
-    return new SkillIndex(entries, warnings, "bm25-only", null, null, dims);
+  } catch (error) {
+    // Scan failure, batch-embed, or cache failure: degrade gracefully.
+    const message = error instanceof Error ? error.message : String(error);
+    const allWarnings = entries.length === 0 ? [`scan failed: ${message}`, ...warnings] : warnings;
+    return new SkillIndex(entries, allWarnings, "bm25-only", null, null, dims);
   }
 }

--- a/adapters/pi/index.ts
+++ b/adapters/pi/index.ts
@@ -138,10 +138,15 @@ export async function buildTurnSystemPrompt(
 ): Promise<{ systemPrompt: string; warnings: string[] }> {
   const { resolved: pins, warnings } = resolvePins(ctx.config.pins, ctx.index.entries);
   const filters = pins.length > 0 ? { excludeIds: pins.map((pin) => pin.id) } : undefined;
-  const ranked = await ctx.index.search(userPrompt, ctx.config.k, filters);
+  const ranked =
+    userPrompt.trim().length === 0 ? [] : await ctx.index.search(userPrompt, ctx.config.k, filters);
+  const stripped = stripAvailableSkillsBlock(systemPrompt);
+  if (pins.length + ranked.length === 0) {
+    return { systemPrompt: stripped, warnings };
+  }
   const block = renderInjectedBlock(pins, ranked, ctx.config.k);
   return {
-    systemPrompt: injectSkillsBlock(stripAvailableSkillsBlock(systemPrompt), block),
+    systemPrompt: injectSkillsBlock(stripped, block),
     warnings,
   };
 }

--- a/adapters/tests/embeddings.test.ts
+++ b/adapters/tests/embeddings.test.ts
@@ -14,6 +14,7 @@ import {
   embedBatch,
   embedDocuments,
   embedQuery,
+  PROBE_TIMEOUT_MS,
   probeEndpoint,
 } from "../core/embeddings.ts";
 import { buildIndex } from "../core/search.ts";
@@ -151,6 +152,24 @@ describe("fallback matrix", () => {
     });
     expect(index.mode).toBe("bm25-only");
     expect(state.receivedInputs).toEqual([]);
+  });
+
+  test("PROBE_TIMEOUT_MS is 15_000 ms to accommodate cold Ollama model load (#2632)", () => {
+    expect(PROBE_TIMEOUT_MS).toBe(15_000);
+  });
+
+  test("invalid or missing repoRoot yields bm25-only empty index without throwing ENOENT (#2632)", async () => {
+    const index = await buildIndex({
+      repoRoot: join(fixtureRoot, "nonexistent-dir-for-test"),
+      embed: { endpoint, model: "mock-embed", dimensions: DIMS },
+      cacheDir,
+    });
+    expect(index.mode).toBe("bm25-only");
+    expect(index.entries).toEqual([]);
+    expect(index.warnings).toHaveLength(1);
+    expect(index.warnings[0]).toContain("scan failed");
+    const results = await index.search("anything", 3);
+    expect(results).toEqual([]);
   });
 });
 

--- a/adapters/tests/pi-binding.test.ts
+++ b/adapters/tests/pi-binding.test.ts
@@ -359,6 +359,50 @@ describe("buildTurnSystemPrompt / handleBeforeAgentStart", () => {
     expect(event.systemPrompt).toBe(PROMPT_WITH_BLOCK); // input untouched
     expect(systemPromptOptions).toEqual({ cwd: "/work/dir" });
   });
+
+  test("empty or whitespace prompt does not query the index (#2632)", async () => {
+    const index = stubIndex();
+    await buildTurnSystemPrompt(PROMPT_WITH_BLOCK, "   ", { index, config });
+    expect(index.calls).toHaveLength(0);
+
+    await buildTurnSystemPrompt(PROMPT_WITH_BLOCK, "", { index, config });
+    expect(index.calls).toHaveLength(0);
+  });
+
+  test("no pins and empty/whitespace prompt injects nothing (#2632)", async () => {
+    const index = stubIndex();
+    const { systemPrompt } = await buildTurnSystemPrompt(PROMPT_WITH_BLOCK, "  \t\n ", {
+      index,
+      config: { ...config, pins: [] },
+    });
+    expect(index.calls).toHaveLength(0);
+    expect(systemPrompt).not.toContain(AVAILABLE_SKILLS_OPEN);
+    expect(systemPrompt).not.toContain(INJECTED_BLOCK_TRAILER);
+  });
+
+  test("no pins and no search matches injects nothing (#2632)", async () => {
+    const emptyIndex: SkillSearchIndex = {
+      entries: [],
+      search: async () => [],
+    };
+    const { systemPrompt } = await buildTurnSystemPrompt(PROMPT_WITH_BLOCK, "some prompt", {
+      index: emptyIndex,
+      config: { ...config, pins: [] },
+    });
+    expect(systemPrompt).not.toContain(AVAILABLE_SKILLS_OPEN);
+    expect(systemPrompt).not.toContain(INJECTED_BLOCK_TRAILER);
+  });
+
+  test("pins present with empty prompt injects pins only without querying index (#2632)", async () => {
+    const index = stubIndex();
+    const { systemPrompt } = await buildTurnSystemPrompt(PROMPT_WITH_BLOCK, "", {
+      index,
+      config,
+    });
+    expect(index.calls).toHaveLength(0);
+    expect(systemPrompt).toContain(AVAILABLE_SKILLS_OPEN);
+    expect(systemPrompt).toContain("c:two");
+  });
 });
 
 // --- session warning emission ---------------------------------------------

--- a/justfile
+++ b/justfile
@@ -200,7 +200,7 @@ pi-adapter-register:
     ext="{{justfile_directory()}}/adapters/pi/index.ts"
     settings="${PI_SETTINGS:-$HOME/.pi/agent/settings.json}"
     mkdir -p "$(dirname "$settings")"
-    [ -f "$settings" ] || echo '{}' > "$settings"
+    [ -s "$settings" ] || echo '{}' > "$settings"
     if jq -e --arg ext "$ext" '(.extensions // []) | index($ext) != null' "$settings" >/dev/null; then
         echo "already registered in $settings:"
         echo "  $ext"


### PR DESCRIPTION
Closes #2632

1. Guard empty/whitespace prompts from querying index and injecting arbitrary skills in `adapters/pi/index.ts`.
2. Suppress empty `<available_skills>` XML block when no skills match and no pins exist.
3. Wrap `scanSkills` in `try/catch` in `adapters/core/search.ts` to gracefully handle invalid/moved repoRoot.
4. Use `[ -s "$settings" ]` in `justfile` (`pi-adapter-register`) to prevent 0-byte settings corruption.
5. Increase Ollama probe timeout from 3s to 15s in `adapters/core/embeddings.ts`.

Verified: all 183 bun tests pass, tsc and biome pass.