### PR TITLE
fix(session-plugin): resolve pack worktree to pack scope and correct comments (#2602, #2604)

### DIFF
--- a/session-plugin/scripts/session-survey.sh
+++ b/session-plugin/scripts/session-survey.sh
@@ -403,14 +403,17 @@ else
   # A draft of this fix omitted this guard on the reasoning that a git failing
   # here fails for the outer repo too, which is false: the failure is per-repo.
   # End the walk, leave the checkout where it is. Pinned by AP8e.
+  decl_target="$walk_start"
   while IFS= read -r outer_root; do
     [ -n "$own_common" ] || break
     [ -n "$outer_root" ] || continue
     outer_common=$(git_common_dir_of "$outer_root" 2>/dev/null) || outer_common=""
-    # Cannot ask, so do not move the answer. `--git-common-dir` predates git 2.5,
-    # and a repo git refuses to answer for — dubious ownership, an unreadable
-    # `.git` — fails it too. That failure is per-REPO, not per-binary: one git
-    # can answer for `outer` and `sub` and refuse for `mid`.
+    # Cannot ask, so do not move the answer. Git older than 2.5 lacks
+    # `--git-common-dir` (arrived in git 2.5, commit c7b3a3d2fe), so the probe
+    # fails; a git that refuses the probe for one repo while answering for
+    # others (reproduced with a stub) fails it too. That failure is per-REPO,
+    # not per-binary: one git can answer for `outer` and `sub` and refuse
+    # for `mid`.
     #
     # So END the walk rather than skip a rung. Without the discriminator this
     # rung cannot be classified — linked worktree or nested repo, unknown — and
@@ -432,7 +435,12 @@ else
     # every worktree-isolated agent report its main checkout's state. `continue`
     # rather than `break`: the main checkout is the SAME repo, so a container of
     # IT is still a container of this session's repo and is worth finding.
-    [ "$outer_common" != "$own_common" ] || continue
+    # Update the declaration target so any outer container is asked about the
+    # main checkout, not the worktree (#2602).
+    if [ "$outer_common" = "$own_common" ]; then
+      decl_target="$outer_root"
+      continue
+    fi
     # A declared containment (ignored or tracked) SETTLES it: the outer repo
     # asserts this checkout is a legitimate member of its layout, so the
     # checkout is the session's repo and there is nothing to resolve.
@@ -443,7 +451,7 @@ else
     # `mid` declared it, the walk continued, and `outer` (which declares
     # nothing) was resolved to, so the digest carried `outer`'s branch for a
     # session sitting two levels in. That is #2441's own failure aimed outward.
-    if outer_repo_declares "$outer_root" "$walk_start"; then
+    if outer_repo_declares "$outer_root" "$decl_target"; then
       git_outer_root=""
       break
     fi
@@ -459,7 +467,7 @@ else
     # wanted the workspace's state — but a session genuinely working IN the
     # nested fork is served the outer repo, so the rows stay a caveat.
     git_confidence="low"
-    git_nested_repo=$(sanitize_name "$walk_start")
+    git_nested_repo=$(sanitize_name "$decl_target")
     git_root=$(sanitize_name "$git_outer_root")
     git_state_dir="$git_outer_root"
   fi

--- a/session-plugin/scripts/tests/test-session-survey.sh
+++ b/session-plugin/scripts/tests/test-session-survey.sh
@@ -1927,6 +1927,47 @@ check_line "AP5: a tracked containment is not re-resolved" "$out" "GIT_SCOPE=rep
 check_line "AP5: and keeps its confidence" "$out" "GIT_CONFIDENCE=high"
 check_line "AP5: and reports the inner repo's own branch" "$out" "BRANCH=ap-tracked-sub"
 
+# --- AP5b: a linked worktree inside a declared pack resolves to pack scope (#2602)
+# When an outer portfolio repo tracks or declares a pack, but does not declare
+# the pack's linked worktree, walking up from the worktree must ask whether the
+# outer repo declares the pack's main checkout, not the worktree path. Without
+# this, the worktree continue skips the main checkout but tests the worktree
+# path against the portfolio, fails the declaration test, and re-resolves to
+# the portfolio root instead of the pack.
+AP_PWT="$SANDBOX/ap-pack-worktree"
+AP_PWT_PACK="$AP_PWT/pack"
+AP_PWT_WT="$AP_PWT_PACK/wt-fix"
+mkrepo "$AP_PWT"
+git -C "$AP_PWT" branch -M ap-portfolio-branch
+mkdir -p "$AP_PWT_PACK"
+printf 'x\n' > "$AP_PWT_PACK/f.txt"
+git -C "$AP_PWT" add pack/f.txt
+git -C "$AP_PWT" commit -q -m "track pack"
+mkrepo "$AP_PWT_PACK"
+git -C "$AP_PWT_PACK" branch -M ap-pack-branch
+git -C "$AP_PWT_PACK" worktree add -q "$AP_PWT_WT" -b ap-pack-wt-branch 2>/dev/null
+# Fixture validity: the portfolio tracks the pack, but not the worktree.
+check_eq "AP5b: fixture — the outer repo tracks the pack" \
+  "$(git -C "$AP_PWT" ls-files --error-unmatch -- "$AP_PWT_PACK" >/dev/null 2>&1 && echo tracked || echo untracked)" \
+  "tracked"
+check_eq "AP5b: fixture — the outer repo does not track the worktree" \
+  "$(git -C "$AP_PWT" ls-files --error-unmatch -- "$AP_PWT_WT" >/dev/null 2>&1 && echo tracked || echo untracked)" \
+  "untracked"
+# Baseline: the pack's main checkout reports pack scope.
+out=$(run_ap "$AP_PWT_PACK")
+check_line "AP5b: baseline — pack main checkout reports GIT_SCOPE=repo" "$out" "GIT_SCOPE=repo"
+check_line "AP5b: baseline — pack main checkout reports its own branch" "$out" "BRANCH=ap-pack-branch"
+# The decisive case: running from the pack's linked worktree resolves to the
+# pack scope (GIT_SCOPE=repo), matching the main checkout, with its own branch.
+out=$(run_ap "$AP_PWT_WT")
+check_line "AP5b: pack worktree reports GIT_SCOPE=repo" "$out" "GIT_SCOPE=repo"
+check_line "AP5b: and keeps its confidence" "$out" "GIT_CONFIDENCE=high"
+check_line "AP5b: and reports the worktree's own branch" "$out" "BRANCH=ap-pack-wt-branch"
+check_absent "AP5b: never the portfolio root's branch" "$out" "BRANCH=ap-portfolio-branch"
+check_absent "AP5b: never the pack main checkout's branch" "$out" "BRANCH=ap-pack-branch"
+check_absent "AP5b: and names no outer repo" "$out" "GIT_ROOT="
+check_absent "AP5b: and names no nested checkout" "$out" "GIT_NESTED_REPO="
+
 # --- AP6: no git repo at all is its own rung -------------------------------
 AP_NOGIT="$SANDBOX/ap-nogit"
 mkdir -p "$AP_NOGIT"
@@ -2011,9 +2052,10 @@ check_absent "AP8b: and names no outer repo" "$out" "GIT_ROOT="
 
 # --- AP8c: an unanswerable common-dir probe never moves the answer ----------
 # A CHARACTERIZATION test, not a guard pin — no single line is solely
-# responsible, and it is deliberately mutation-neutral. `--git-common-dir`
-# predates git 2.5 and a damaged repo can fail it; the contract is that a git
-# which cannot answer leaves the checkout where it is rather than re-resolving
+# responsible, and it is deliberately mutation-neutral. Git older than 2.5 lacks
+# `--git-common-dir` (arrived in git 2.5, commit c7b3a3d2fe), so the probe
+# fails; the contract is that a git which cannot answer leaves the checkout
+# where it is rather than re-resolving
 # on a discriminator it never got. That degradation is conservative only because
 # the verdict now RE-RESOLVES — under the earlier flag-only design the same
 # silence was a missed caveat, which is why it is worth pinning now and was not
@@ -2050,8 +2092,9 @@ check_line "AP8c: and a real nesting degrades to leaving the checkout alone" "$o
 
 # --- AP8d/AP8e: the probe fails PER REPO, not per binary --------------------
 # AP8c's stub rejects `--git-common-dir` for EVERY repo, so it exercises only
-# the uniform-failure case. The real failure is per-repo — dubious ownership or
-# an unreadable `.git` on ONE rung — and one git then answers for `outer` and
+# the uniform-failure case. That failure can also be per-repo — git <2.5, plus
+# a git that refuses the probe for one repo while answering for others
+# (reproduced with a stub) — and one git then answers for `outer` and
 # `sub` while refusing for `mid`. This stub rejects the probe for exactly one
 # named repo and delegates the rest, so which rung is unanswerable is the only
 # variable. Paths are compared physically because the walk resolves them that


### PR DESCRIPTION
Closes #2602
Closes #2604

1. Update `session-plugin/scripts/session-survey.sh` so when stepping out of a worktree, `decl_target` tracks the main checkout path, ensuring outer repos that declare the pack maintain pack scope (`GIT_SCOPE=repo`) rather than resolving to portfolio root.
2. Correct git 2.5 comments in `session-survey.sh` and `test-session-survey.sh`.
3. Added test case AP5b in `session-plugin/scripts/tests/test-session-survey.sh`.

Verified: all 649 tests pass in `test-session-survey.sh`, shellcheck and lint-shell clean.