### PR TITLE
docs(readme): refresh workflow-orchestration-plugin skill count to 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ the rules, skills, and hooks that embody it.
 | **macos-plugin** | 8 | macOS dev tooling - kitty session persistence, LaunchServices health, incident postmortems, APFS disk-usage / space recovery, performance triage and benchmark suite, dead-keybinding debug |
 | **taskwarrior-plugin** | 9 | Taskwarrior coordination for multi-agent work - parallel-safe queries, urgency scoring |
 | **tools-plugin** | 15 | General utilities - fd, rg, jq, shell, ImageMagick, d2 |
-| **workflow-orchestration-plugin** | 4 | Workflow orchestration - preflight checks, checkpoint refactoring |
+| **workflow-orchestration-plugin** | 5 | Workflow orchestration - preflight checks, checkpoint refactoring |
 
 ### Game Development
 


### PR DESCRIPTION
Refreshes `workflow-orchestration-plugin` skill count in README.md (4 -> 5) following PR #2626, resolving `test-check-docs-index.sh` failure in CI.