### PR TITLE
feat(pi): export marketplace subagents for pi-subagents

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -564,6 +564,16 @@ repos:
         language: system
         files: '^scripts/(export-opencode-agents\.py|export-opencode\.sh|install-opencode\.sh|tests/test-export-opencode-agents\.sh)$'
         pass_filenames: false
+      - id: test-export-pi-agents
+        name: pi subagent export regression (#2633)
+        entry: bash ./scripts/tests/test-export-pi-agents.sh
+        language: system
+        # The justfile is in scope because the suite asserts the recipes exist,
+        # are additive, and that setup-pi wires them in — a change to any of
+        # those three is what breaks the install path, not a change to the
+        # script alone.
+        files: '^(scripts/(export-pi-agents\.py|tests/test-export-pi-agents\.sh)|justfile)$'
+        pass_filenames: false
       - id: test-export-opencode-hooks
         name: opencode hook-plugin export regression (#1605)
         entry: bash ./scripts/tests/test-export-opencode-hooks.sh

--- a/adapters/package.json
+++ b/adapters/package.json
@@ -2,7 +2,15 @@
   "name": "@laurigates/claude-plugins-adapters",
   "private": true,
   "type": "module",
-  "description": "Harness-agnostic skill-discovery core + eval harness for ADR-0022 (pi/OpenCode bindings land in #2090/#2091)",
+  "description": "Harness-agnostic skill-discovery core, eval harness, and runtime bindings for pi and OpenCode (ADR-0022)",
+  "keywords": [
+    "pi-package"
+  ],
+  "pi": {
+    "extensions": [
+      "./pi/index.ts"
+    ]
+  },
   "scripts": {
     "check": "bunx tsc --noEmit && bunx biome ci .",
     "eval": "bun eval/run-eval.ts",

--- a/docs/pi-export.md
+++ b/docs/pi-export.md
@@ -5,6 +5,15 @@ Run this marketplace's skills inside **pi** ([pi.dev](https://pi.dev),
 ollama). The sibling of [`opencode-export.md`](opencode-export.md) — same goal
 (local-model testing of our skills), a much thinner pipeline.
 
+> **Why the `-export.md` suffix, when pi exports nothing here?** The name mirrors
+> the OpenCode sibling so the pair stays findable together — but for **skills**
+> pi has no static export step at all. It reads `SKILL.md` in place through the
+> runtime adapter ([`../adapters/pi/`](../adapters/pi/), ADR-0022), and nothing
+> is copied into `~/.pi/agent/skills/`. So this file is the pi **adapter** doc
+> that happens to carry the sibling's name. (OpenCode's export is real: it
+> projects **subagents and hooks**, because OpenCode reads neither
+> `.claude/agents/` nor `hooks.json` — skills reach it through the same adapter.)
+
 > **The tier installer is gone (#2093).** Skill discovery is now the
 > **ADR-0022 adapter**'s job: `pi/tiers.yaml`, `scripts/install-pi.sh`,
 > `scripts/check-pi-tiers.sh` and the `install-pi` / `install-pi-domain` /

--- a/docs/pi-export.md
+++ b/docs/pi-export.md
@@ -88,6 +88,9 @@ list` manage — so `pi list` will not show it; that is expected, not a failure.
 adapters/pi/index.ts ──▶ ~/.pi/agent/settings.json extensions[]  (just pi-adapter-register)
                          (search_skills pull + ranked top-k push, ~600 tok/turn)
 
+.claude/agents/*.md   ──▶ dist/pi/agents ──▶ ~/.pi/agent/agents/    (just export-pi-agents)
+                         (21 subagents; pi does not read .claude/agents/)
+
 mlx_lm.server ──▶ models.json ──▶ pi --model mlx-local/<id>
 ```
 
@@ -145,9 +148,9 @@ don't understand the `developer` role reasoning-capable models use
 (`supportsDeveloperRole: false` sends the system prompt as a plain system
 message), nor `reasoning_effort` (`supportsReasoningEffort: false`).
 
-`just setup-pi` runs the adapter prereq check, registers the adapter, then
-prints this block (with your `pi_model` / `pi_port` interpolated) plus the run
-command.
+`just setup-pi` runs the adapter prereq check, registers the adapter, installs
+the subagents (§ Subagents), then prints this block (with your `pi_model` /
+`pi_port` interpolated) plus the run command.
 
 ### 4. Run pi against the local model
 
@@ -163,16 +166,73 @@ what makes this useful for local-model testing. The adapter's retrieval quality
 on exactly that question is what the eval harness measures
 ([`../adapters/README.md`](../adapters/README.md) § eval).
 
+## Subagents (`just export-pi-agents`)
+
+Subagents are the one surface pi **cannot** read in place: it never looks at
+`.claude/agents/`, so all 21 marketplace agents stay invisible until they are
+projected into pi-subagents' frontmatter (#2633). `just setup-pi` does this;
+the recipes are standalone too:
+
+```
+just export-pi-agents              # -> dist/pi/agents/*.md (source read-only, output reproducible)
+just install-pi-agents             # -> ~/.pi/agent/agents/   (additive, global scope)
+just install-pi-agents .pi/agents  # -> project scope, which overrides global
+```
+
+`install-pi-agents` self-skips with a hint when `@tintinweb/pi-subagents` is not
+installed — pi ignores `.pi/agents/` entirely without it, so installing anyway
+would look like it worked and change nothing. Re-running is safe: the copy is
+additive (your own agent files are never removed) and it takes its input from a
+fresh export in a temp dir.
+
+### What survives, and the two edges that do not
+
+pi's agent schema is close to Claude Code's, so most of the projection is a
+rename (`maxTurns` → `max_turns`) rather than a loss:
+
+| Claude Code | pi | Note |
+|---|---|---|
+| `Read`, `Write`, `Edit` | `read`, `write`, `edit` | |
+| `Glob` | `find` | pi's file-pattern search |
+| `Grep` | `grep` | |
+| `Bash(cmd *)` | `bash` | **scope dropped** — see below |
+| `Agent(a, b)` | `allowed_subagents: a, b` | nesting; default-off and separate from `tools:` |
+| `skills: [a, b]` | `skills: a, b` | both preload; pi's list form also drops the inherited rest |
+| `model`, `color`, `thinking`, `maxTurns` | same, `max_turns` | `model: opus` resolves fuzzily in pi; a provider without it reports `(unavailable, fallback: inherit)` |
+| `TodoWrite`, `TaskOutput`, `WebFetch`, `WebSearch` | *dropped* | no pi built-in exists |
+| `context: fork` | *dropped* | a pi subagent is **always** its own session — fork-isolation is pi's default, and `inherit_context:` is the opposite direction, so no mapping is asserted |
+
+The exporter reports rather than silently adjusts. On the corpus today it prints
+`WIDENED_BASH=142` (every scoped `Bash(git diff *)` grant becomes an unscoped
+`bash`, because pi's `tools:` is a name-only allowlist — that is a **privilege
+widening**, and a property of the target schema, not something this repo can
+narrow), `MODEL_PINS=21`, `AGENTS_WITH_NESTING=1`, and `DROPPED_TOOLS=` /
+`DROPPED_KEYS=` naming each loss per agent.
+
+`WebFetch`/`WebSearch` *can* be reached as `ext:pi-web-search/web_search`, but a
+single `ext:` entry flips pi's extension tools into explicit-allowlist mode — the
+agent would silently lose everything else the adapter exposes, `search_skills`
+among it — so it is left to a human as an opt-in rather than applied here.
+
+### Verifying it landed
+
+`/agents` in a pi session lists every agent type it loaded, project and global.
+`scripts/tests/test-export-pi-agents.sh` is the offline half: it executes the
+exporter against a fixture and pins the mapping, the widening/drop reports, the
+skip-on-missing-description path, and the emitted tool names against pi's seven
+built-ins (an unknown `tools:` entry is a hard `tools-error:` in pi).
+
 ## Out of scope (deferred)
 
-- **Agent / prompt / hook porting.** Hooks especially are selective: only the
-  *safety* hooks would earn a pi `pi.on` port; the style nudges are noise on a
-  different harness.
+- **Hook porting (#2634).** Selective: only the *safety* hooks would earn a pi
+  `pi.on` port; the style nudges are noise on a different harness. pi never
+  evaluates a Claude Code `hooks.json`, so those guards are inert there today.
+- **Prompt templates.** Nothing in the marketplace uses that surface yet.
 
 ## Related
 
 - [`../adapters/README.md`](../adapters/README.md) § pi — the adapter (source of truth for skill discovery)
 - [`../adapters/CUTOVER.md`](../adapters/CUTOVER.md) — the eval gate that authorized retiring the tier installer
 - [`adrs/0022-adapter-over-export-for-foreign-harnesses.md`](adrs/0022-adapter-over-export-for-foreign-harnesses.md) — adapter-over-export decision
-- [`opencode-export.md`](opencode-export.md) — the sibling harness: same adapter for skills, plus an agent/hook export pi does not need
+- [`opencode-export.md`](opencode-export.md) — the sibling harness: same adapter for skills, plus its own subagent/hook export
 - [pi custom-provider docs](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/custom-provider.md) — upstream `models.json` schema

--- a/justfile
+++ b/justfile
@@ -384,18 +384,67 @@ oc-adapter-unregister target=opencode_config:
 # Local-model defaults (overridable via environment or `just pi_model=… <recipe>`).
 pi_model := env_var_or_default("PI_MODEL", "mlx-community/Qwen3.6-35B-A3B-4bit")
 pi_port := env_var_or_default("PI_PORT", "8080")
+# Where `install-pi-agents` writes projected subagents. Global by default; a
+# project that keeps its own agents in .pi/agents/ overrides the global ones
+# (pi resolves project > workspace > global).
+pi_agents_dir := env_var_or_default("PI_AGENTS_DIR", "~/.pi/agent/agents")
 
 # Serve the local model via mlx-lm (OpenAI-compatible /v1 on the configured port)
 [group: "pi"]
 serve-pi-model:
     mlx_lm.server --model {{pi_model}} --port {{pi_port}}
 
+# Subagents are the one surface pi cannot read in place: it does not look at
+# `.claude/agents/`, so all 21 marketplace agents stay invisible until projected
+# into pi-subagents' frontmatter (#2633). Skills are NOT exported — the adapter
+# serves those (ADR-0022). See docs/pi-export.md § Subagents.
+# Project marketplace subagents into pi-subagents' agent format (output: dist/pi)
+[group: "pi"]
+export-pi-agents out="dist/pi":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    out="{{out}}"
+    case "$out" in /*) ;; *) out="{{justfile_directory()}}/$out" ;; esac
+    python3 "{{justfile_directory()}}/scripts/export-pi-agents.py" "{{justfile_directory()}}" "$out"
+
+# Additive: agents you wrote yourself under <target> are preserved — never an
+# rm -rf of a shared directory. No-op with a hint when @tintinweb/pi-subagents is
+# absent, because pi ignores .pi/agents/ entirely without it: installing anyway
+# would look like it worked and change nothing.
+# Install exported subagents into a pi agents dir (default: global)
+[group: "pi"]
+install-pi-agents target=pi_agents_dir:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    target="{{target}}"
+    if [ "${target#\~}" != "$target" ]; then
+        target="$HOME${target#\~}"
+    fi
+    agent_home="${PI_CODING_AGENT_DIR:-$HOME/.pi/agent}"
+    if ! grep -q 'pi-subagents' "$agent_home/settings.json" 2>/dev/null \
+        && [ ! -d "$agent_home/npm/node_modules/@tintinweb/pi-subagents" ]; then
+        echo "SKIP: @tintinweb/pi-subagents is not installed — pi ignores $target without it"
+        echo "      install it with: pi install npm:@tintinweb/pi-subagents"
+        exit 0
+    fi
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' EXIT
+    python3 "{{justfile_directory()}}/scripts/export-pi-agents.py" \
+        "{{justfile_directory()}}" "$tmp" >/dev/null
+    mkdir -p "$target"
+    cp "$tmp"/agents/*.md "$target/"
+    echo "installed $(find "$target" -maxdepth 1 -name '*.md' | wc -l | tr -d ' ') subagent file(s) in $target"
+    echo "(project scope .pi/agents/ overrides this; add one with: just install-pi-agents .pi/agents)"
+
 # Registers the ADR-0022 skill-discovery adapter (prereq-checked first), then
 # prints the local-provider models.json block + run next steps. Skill discovery
 # is the adapter's job — the tier installer it replaced was removed in #2093.
-# Wire pi up end to end: register the adapter, then print the model next steps
+# `install-pi-agents` self-skips (with a hint) when @tintinweb/pi-subagents is
+# absent, so wiring it in needs no conditional here; the adapter is prereq-checked
+# first.
+# Wire pi up end to end: register the adapter, project the subagents, print next steps
 [group: "pi"]
-setup-pi: pi-adapter-check pi-adapter-register
+setup-pi: pi-adapter-check pi-adapter-register install-pi-agents
     @echo ""
     @echo "Next steps:"
     @echo "  1. Install the server:  uv tool install mlx-lm"
@@ -407,3 +456,4 @@ setup-pi: pi-adapter-check pi-adapter-register
     @echo "  4. Run pi:              cd <project> && pi --model mlx-local/{{pi_model}}"
     @echo "     (the adapter is registered, so no -e flag is needed)"
     @echo "  5. Undo the wiring:     just pi-adapter-unregister"
+    @echo "     (subagents: just install-pi-agents — needs @tintinweb/pi-subagents)"

--- a/scripts/export-pi-agents.py
+++ b/scripts/export-pi-agents.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Project this marketplace's subagents into pi-subagents' agent format.
+
+Why this exists when pi needs no *skill* export: pi reads Claude Code
+`SKILL.md` in place through the ADR-0022 adapter (`adapters/pi/`), but it does
+**not** read `.claude/agents/` — so all 21 marketplace subagents are invisible
+in pi until they are projected into one of pi-subagents' three discovery
+locations (`<cwd>/.pi/agents/`, `<cwd>/.agents/agents/`, or
+`$PI_CODING_AGENT_DIR/agents/`, default `~/.pi/agent/agents/`).
+
+Unlike the OpenCode projection (#2094), pi's agent schema is *rich*: `model`,
+`tools`, `color`, `thinking`, `max_turns`, and nested delegation all have real
+fields, so almost everything survives. The two edges that do not are lossy, and
+both are reported rather than adjusted silently:
+
+  1. **`Bash(<cmd> *)` scope is dropped.** pi's `tools:` is a name-only
+     allowlist — there is no per-command scoping in the schema — so a scoped
+     Claude Code grant becomes an unscoped `bash`. That is a *privilege
+     widening* (143 entries across the corpus today), counted as
+     `WIDENED_BASH=` and listed per agent. Nothing in this repo can narrow it;
+     it is a property of the target schema.
+  2. **Claude-Code-only tools are dropped**, because no pi built-in exists for
+     them: `TodoWrite`, `TaskOutput`, `WebFetch`, `WebSearch`, `NotebookEdit`.
+     They are reported as `DROPPED_TOOLS=` per agent.
+     `WebFetch`/`WebSearch` *could* be reached as `ext:` selectors (the tool is
+     provided by the optional `pi-web-search` extension), but a single `ext:`
+     entry flips pi's extension tools into explicit-allowlist mode — the agent
+     would silently lose everything else the adapter exposes (`search_skills`
+     among it) — so that is left as an explicit opt-in for a human, not applied
+     here.
+
+Tool mapping (`pi` 0.84.1: `BUILTIN_TOOL_NAMES` = `createCodingTools` +
+`createReadOnlyTools` = read, bash, edit, write, grep, find, ls):
+
+    Read  -> read      Write -> write    Edit -> edit
+    Glob  -> find      Grep  -> grep     Bash(...) -> bash
+    Agent(a, b) -> allowed_subagents: a, b   (nesting, not a built-in grant)
+    skills: [a, b] -> skills: a, b           (both preload into the agent's prompt)
+    "*" / all -> "*"   none / "" -> none
+
+Two source fields are deliberately **not** mapped, and are reported instead:
+`context:` (10 agents) because pi has no counterpart to assert — a pi subagent
+always runs in its own session, so Claude Code's fork-isolation is pi's default,
+while pi's `inherit_context:` is the *opposite* direction and inferring it would
+be a guess; and any future unknown field, which lands in `DROPPED_KEYS=` rather
+than vanishing.
+
+Usage: export-pi-agents.py <repo-root> <out-dir>
+Emits <out-dir>/agents/<name>.md plus a KEY=VALUE report.
+"""
+
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - PyYAML is a hard dependency of the repo
+    print("ERROR=PyYAML not available (pip install pyyaml)", file=sys.stderr)
+    sys.exit(1)
+
+# pi's built-in tool names, from `createCodingTools()` + `createReadOnlyTools()`
+# in @earendil-works/pi-coding-agent (dist/core/tools/index.js). A `tools:`
+# entry outside this set is an error in pi ("tools-error:…"), so the exporter
+# validates against it rather than trusting the map.
+PI_BUILTIN_TOOLS = ("read", "bash", "edit", "write", "grep", "find", "ls")
+
+# Claude Code tool name -> pi built-in. Absent names are handled explicitly
+# below (Bash/Agent are transformed; the rest are reported as dropped).
+TOOL_MAP = {
+    "Read": "read",
+    "Write": "write",
+    "Edit": "edit",
+    "Glob": "find",
+    "Grep": "grep",
+}
+
+# No pi built-in equivalent. Kept as a named tuple so the report can say which
+# one went missing rather than just how many.
+DROPPED_TOOLS = ("TodoWrite", "TaskOutput", "WebFetch", "WebSearch", "NotebookEdit")
+
+# Source frontmatter keys this projection owns; anything else is reported as a
+# dropped key so a new field cannot be added to an agent and vanish silently.
+# `context` is intentionally absent from both tuples: it is a real Claude Code
+# field (agent-development.md: `fork` = isolated context) with no pi counterpart
+# to assert, so it is reported alongside genuinely unknown keys.
+MAPPED_KEYS = (
+    "name",
+    "description",
+    "model",
+    "color",
+    "thinking",
+    "maxTurns",
+    "tools",
+    "skills",
+)
+IGNORED_KEYS = ("created", "modified", "reviewed")
+
+
+def split_frontmatter(text: str) -> tuple[dict, str]:
+    """Return (frontmatter, body). Raises ValueError on a missing/broken block."""
+    if not text.startswith("---\n"):
+        raise ValueError("no frontmatter block at line 1")
+    end = text.find("\n---\n", 3)
+    if end == -1:
+        raise ValueError("unterminated frontmatter block")
+    front = yaml.safe_load(text[4:end]) or {}
+    if not isinstance(front, dict):
+        raise ValueError("frontmatter is not a mapping")
+    return front, text[end + 5 :]
+
+
+def split_tools(raw: object) -> list[str]:
+    """Split a Claude Code `tools:` value, respecting parentheses.
+
+    Claude Code writes `tools: Read, Grep, Bash(git diff *), Agent(a, b)`, so a
+    naive comma split turns `Agent(a, b)` into two bogus entries — and would
+    turn a nested-agent list into tool names. Depth 0 is the only place a comma
+    separates two entries.
+    """
+    if raw is None:
+        return []
+    if isinstance(raw, (list, tuple)):
+        return [str(item).strip() for item in raw if str(item).strip()]
+    text = str(raw)
+    if text.strip() in ("", "none"):
+        return []
+    entries, depth, current = [], 0, []
+    for ch in text:
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth = max(0, depth - 1)
+        if ch == "," and depth == 0:
+            entries.append("".join(current).strip())
+            current = []
+        else:
+            current.append(ch)
+    entries.append("".join(current).strip())
+    return [entry for entry in entries if entry]
+
+
+def translate_tools(raw: object) -> tuple[list[str], list[str], list[str], int]:
+    """Return (built-ins, allowed_subagents, dropped, widened_bash_count).
+
+    `Agent(...)` is not a tool grant in pi — it is the nested-delegation
+    allowlist (`allowed_subagents`), which is default-off and deliberately
+    separate from `tools:`. Mapping it to a tool name would be a silent no-op.
+    """
+    builtins: list[str] = []
+    nested: list[str] = []
+    dropped: list[str] = []
+    widened = 0
+
+    for entry in split_tools(raw):
+        if entry in ("*", "all"):
+            return list(PI_BUILTIN_TOOLS), nested, dropped, widened
+        if entry.lower() == "none":
+            continue
+        name, _, args = entry.partition("(")
+        name = name.strip()
+        args = args.rstrip(")").strip()
+        if name == "Bash":
+            # Scoped or not, pi only understands the name.
+            if args:
+                widened += 1
+            if "bash" not in builtins:
+                builtins.append("bash")
+        elif name == "Agent":
+            nested.extend(a.strip() for a in args.split(",") if a.strip())
+        elif name == "Task":
+            # Claude Code's pre-rename spelling of a subagent dispatch; the
+            # allowlist semantics are the same as Agent(...).
+            nested.extend(a.strip() for a in args.split(",") if a.strip())
+        elif name in TOOL_MAP:
+            mapped = TOOL_MAP[name]
+            if mapped not in builtins:
+                builtins.append(mapped)
+        elif name in DROPPED_TOOLS:
+            if name not in dropped:
+                dropped.append(name)
+        else:
+            # Unknown name: report it as dropped rather than emit it, because
+            # an unknown `tools:` entry is a hard error in pi.
+            if name not in dropped:
+                dropped.append(name)
+
+    return builtins, nested, dropped, widened
+
+
+def render(
+    front: dict, body: str, fallback_name: str
+) -> tuple[str, int, list[str], list[str], bool]:
+    """Return (file text, widened_bash count, dropped tools, builtins, has_nesting)."""
+    out: dict = {}
+    out["name"] = front.get("name") or fallback_name
+    # A source `description: |` block folds to one logical line here. Whitespace
+    # only differs, and a folded multi-line YAML scalar would make the emitted
+    # header depend on the reader's folding support — pi shows this string in its
+    # agent listing, so one line is both cleaner and safer.
+    out["description"] = " ".join(str(front["description"]).split())
+    for key in ("color", "model", "thinking"):
+        if front.get(key):
+            out[key] = front[key]
+    if front.get("maxTurns") is not None:
+        # pi's spelling; `maxTurns` would be ignored as an unknown key.
+        out["max_turns"] = int(front["maxTurns"])
+
+    builtins, nested, dropped, widened = translate_tools(front.get("tools"))
+    # `tools: none` is the one value where omitting the key is NOT equivalent:
+    # an omitted `tools:` grants all 7 built-ins in pi, which is the right
+    # reading of an absent key (Claude Code inherits all there too) but the
+    # opposite of an explicit none. Emit it so the narrowing survives.
+    raw_tools = front.get("tools")
+    explicit_none = isinstance(raw_tools, str) and raw_tools.strip().lower() == "none"
+    if builtins:
+        out["tools"] = ", ".join(builtins)
+    elif explicit_none:
+        out["tools"] = "none"
+    if nested:
+        # Dedupe, preserving declaration order.
+        out["allowed_subagents"] = ", ".join(dict.fromkeys(nested))
+    skills = front.get("skills")
+    if isinstance(skills, (list, tuple)) and skills:
+        # Claude Code: "skill names to preload into agent context at startup"
+        # (agent-development.md § Frontmatter Fields). pi's list form preloads
+        # those skills AND does not inherit the parent's rest — the preload
+        # intent is shared, the inheritance edge is not, and pi is the narrower
+        # of the two. Left in on that basis; `skills: true` (the pi default) is
+        # never emitted, so an agent that declares none keeps inheriting.
+        out["skills"] = ", ".join(str(skill) for skill in skills)
+
+    # width=10**6: never wrap. A wrapped plain scalar is valid YAML *only* if the
+    # reader implements flow folding, and a description split across lines is not
+    # worth betting on the reader for. allow_unicode keeps an em dash literal
+    # rather than `\u2014`, which a non-unescaping reader would show verbatim.
+    header = yaml.safe_dump(
+        out, default_flow_style=False, sort_keys=False, width=10**6, allow_unicode=True
+    )
+    return (
+        f"---\n{header}---\n{body.lstrip(chr(10))}",
+        widened,
+        dropped,
+        builtins,
+        bool(nested),
+    )
+
+
+def main(repo_root: Path, out_dir: Path) -> int:
+    agents_out = out_dir / "agents"
+    agents_out.mkdir(parents=True, exist_ok=True)
+
+    sources = sorted(repo_root.glob("*-plugin/agents/*.md"))
+    written, skipped = 0, []
+    widened_total, nested_total, model_pins = 0, 0, 0
+    dropped_by_tool: dict[str, int] = {}
+    dropped_keys: dict[str, list[str]] = {}
+
+    for src in sources:
+        rel = src.relative_to(repo_root)
+        try:
+            front, body = split_frontmatter(src.read_text(encoding="utf-8"))
+            if not front.get("description"):
+                # pi routes subagents by description; emitting one without it
+                # produces an agent the model can never be told to pick.
+                skipped.append(f"{rel}: no description")
+                continue
+            # Rendered inside the try: one malformed agent must be SKIPPED and
+            # reported, never a traceback that aborts the other 20.
+            text, widened, dropped, builtins, has_nesting = render(
+                front, body, src.stem
+            )
+        except (ValueError, TypeError, yaml.YAMLError) as exc:
+            skipped.append(f"{rel}: {exc}")
+            continue
+        (agents_out / src.name).write_text(text, encoding="utf-8")
+        written += 1
+        widened_total += widened
+        if front.get("model"):
+            model_pins += 1
+        if has_nesting:
+            nested_total += 1
+        for tool in dropped:
+            dropped_by_tool[tool] = dropped_by_tool.get(tool, 0) + 1
+        extra = [
+            key for key in front if key not in MAPPED_KEYS and key not in IGNORED_KEYS
+        ]
+        if extra:
+            dropped_keys[str(rel)] = [str(key) for key in extra]
+
+        # Guard integrity: validate the emitted tool names against pi's built-in
+        # set. A mapper bug must fail loudly here, not produce an agent that pi
+        # rejects at load time with `tools-error:…`.
+        for name in builtins:
+            if name not in PI_BUILTIN_TOOLS:
+                print(
+                    f"ERROR=emitted unknown pi tool {name!r} for {rel}",
+                    file=sys.stderr,
+                )
+                return 1
+
+    print("=== PI AGENT EXPORT ===")
+    print(f"SOURCE={repo_root}")
+    print(f"OUTPUT={agents_out}")
+    print(f"SOURCE_AGENTS={len(sources)}")
+    print(f"OUTPUT_AGENTS={written}")
+    print(f"SKIPPED_AGENTS={len(skipped)}")
+    print(f"MODEL_PINS={model_pins}")
+    print(f"AGENTS_WITH_NESTING={nested_total}")
+    print(f"WIDENED_BASH={widened_total}")
+    print(
+        "DROPPED_TOOLS="
+        + ",".join(f"{k}:{v}" for k, v in sorted(dropped_by_tool.items()))
+    )
+    for name, keys in sorted(dropped_keys.items()):
+        print(f"DROPPED_KEYS={name}:{','.join(keys)}")
+    for entry in skipped:
+        print(f"SKIPPED={entry}")
+    if skipped:
+        print("STATUS=WARN")
+        print(f"ISSUE_COUNT={len(skipped)}")
+    else:
+        print("STATUS=OK")
+        print("ISSUE_COUNT=0")
+    print("=== END PI AGENT EXPORT ===")
+    return 1 if skipped else 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("usage: export-pi-agents.py <repo-root> <out-dir>", file=sys.stderr)
+        sys.exit(2)
+    sys.exit(main(Path(sys.argv[1]).resolve(), Path(sys.argv[2]).resolve()))

--- a/scripts/tests/test-export-pi-agents.sh
+++ b/scripts/tests/test-export-pi-agents.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# Regression test for scripts/export-pi-agents.py (#2633).
+#
+# The projection is the only thing standing between 21 marketplace subagents and
+# invisibility in pi: pi does not read `.claude/agents/`, so an exporter that
+# silently drops a tool, misnames a field, or emits a name pi rejects produces
+# agents that either under-perform or fail to load with `tools-error:…`. None of
+# that raises an error anywhere else, which is why this suite executes the
+# exporter rather than grepping it.
+#
+# Guards:
+#   A. Claude Code tool names translate to pi's built-ins, order preserved
+#   B. `Agent(a, b)` becomes `allowed_subagents:` (nesting), not a tool grant
+#   C. scoped `Bash(cmd *)` widens to `bash` and is REPORTED (`WIDENED_BASH=`)
+#   D. Claude-Code-only tools are dropped and REPORTED, never emitted
+#   E. `maxTurns` -> `max_turns`, `skills:` list preserved, unknown keys reported
+#   F. an agent with no description is SKIPPED and reported, never emitted bare
+#   G. the prompt body survives verbatim and the header round-trips as YAML
+#   H. every emitted tool name is one of pi's 7 built-ins (the schema contract)
+#   I. the justfile recipes exist, are additive, and the export has no network step
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+exporter="$repo_root/scripts/export-pi-agents.py"
+justfile="$repo_root/justfile"
+
+pass_count=0
+fail_count=0
+assert() {
+  if [ "$2" = "true" ]; then
+    pass_count=$((pass_count + 1))
+  else
+    echo "FAIL: $1" >&2
+    fail_count=$((fail_count + 1))
+  fi
+}
+
+if ! python3 -c 'import yaml' 2>/dev/null; then
+  echo "SKIP: PyYAML not available"
+  exit 0
+fi
+
+fixture="$(mktemp -d)"
+[ -n "$fixture" ] || { echo "mktemp failed" >&2; exit 1; }
+trap 'rm -rf "$fixture"' EXIT
+
+# --- fixture marketplace -----------------------------------------------------
+mkdir -p "$fixture/src/demo-plugin/agents"
+cat > "$fixture/src/demo-plugin/agents/worker.md" <<'MD'
+---
+name: worker
+model: opus
+color: "#7B1FA2"
+description: |
+  Does the work.
+  Wrapped across lines on purpose.
+tools: Glob, Grep, Read, Edit, Write, Bash(git diff *), Bash(git log *), Bash, Agent(reviewer, tester), TodoWrite, WebFetch
+skills:
+  - alpha-skill
+  - beta-skill
+context: fork
+maxTurns: 20
+created: 2026-01-24
+modified: 2026-06-28
+reviewed: 2026-06-28
+---
+
+# Worker Agent
+
+Body line one.
+
+| a | b |
+|---|---|
+| 1 | 2 |
+MD
+
+# `tools: "*"` is the wildcard spelling; it must expand to every built-in, not
+# to whatever the map happens to contain.
+cat > "$fixture/src/demo-plugin/agents/wildcard.md" <<'MD'
+---
+name: wildcard
+description: Declares the wildcard tool scope.
+tools: "*"
+maxTurns: 5
+---
+
+# Wildcard Agent
+MD
+
+# `tools: none` is the one value where an omitted key is NOT equivalent: no key
+# grants all 7 built-ins in pi, so dropping it here would widen the agent.
+cat > "$fixture/src/demo-plugin/agents/no-tools.md" <<'MD'
+---
+name: no-tools
+description: Declares no built-in tools at all.
+tools: none
+---
+
+# No Tools Agent
+MD
+
+# No description — pi routes subagents by description, so emitting this bare
+# would produce an agent the model can never be told to pick.
+cat > "$fixture/src/demo-plugin/agents/nameless.md" <<'MD'
+---
+name: nameless
+model: opus
+---
+
+# Nameless
+MD
+
+echo "=== TEST A/B/C/D/E: projection of a full-frontmatter agent ==="
+export_out="$(python3 "$exporter" "$fixture/src" "$fixture/out" 2>&1)"
+export_rc=$?
+out_agent="$fixture/out/agents/worker.md"
+assert "worker.md is emitted" "$([ -f "$out_agent" ] && echo true || echo false)"
+
+# Order is preserved as declared (Glob, Grep, Read, Edit, Write -> find, grep,
+# read, edit, write) and `bash` follows the first Bash(...) entry it came from.
+assert "tools translate to pi built-ins, in declaration order" \
+  "$(python3 - "$out_agent" <<'PY'
+import sys, yaml
+t = open(sys.argv[1]).read()
+fm = yaml.safe_load(t[4:t.find("\n---\n", 3)])
+print("true" if fm.get("tools") == "find, grep, read, edit, write, bash" else "false")
+PY
+)"
+
+assert "Agent(a, b) becomes allowed_subagents, not a tool" \
+  "$(python3 - "$out_agent" <<'PY'
+import sys, yaml
+t = open(sys.argv[1]).read()
+fm = yaml.safe_load(t[4:t.find("\n---\n", 3)])
+ok = fm.get("allowed_subagents") == "reviewer, tester"
+print("true" if ok and "agent" not in str(fm.get("tools", "")).lower() else "false")
+PY
+)"
+
+assert "maxTurns -> max_turns; skills list preserved; unreviewed keys dropped" \
+  "$(python3 - "$out_agent" <<'PY'
+import sys, yaml
+t = open(sys.argv[1]).read()
+fm = yaml.safe_load(t[4:t.find("\n---\n", 3)])
+ok = (
+    fm.get("max_turns") == 20
+    and fm.get("skills") == "alpha-skill, beta-skill"
+    and "maxTurns" not in fm
+    and "created" not in fm
+    and "modified" not in fm
+    and "reviewed" not in fm
+)
+print("true" if ok else "false")
+PY
+)"
+
+# Guard integrity: the two assertions above are equalities, so a dropped key is
+# already excluded — assert the drops by NAME so a loosened comparison cannot
+# quietly readmit them, and assert `context` is reported rather than mapped.
+assert "Claude-Code-only tools are NOT emitted" \
+  "$(python3 - "$out_agent" <<'PY'
+import sys, yaml
+t = open(sys.argv[1]).read()
+fm = yaml.safe_load(t[4:t.find("\n---\n", 3)])
+bad = {"TodoWrite", "WebFetch", "TaskOutput", "WebSearch", "context"}
+print("true" if not (bad & set(fm)) else "false")
+PY
+)"
+
+# Two scoped Bash(..) entries plus one bare `Bash`: the count is of entries whose
+# scope was dropped, not of `bash` occurrences in the output (which is one).
+assert "scoped Bash(..) widening is reported per entry (WIDENED_BASH=2)" \
+  "$(case "$export_out" in *"WIDENED_BASH=2"*) echo true ;; *) echo false ;; esac)"
+
+assert "dropped tools are reported by name, never silent" \
+  "$(case "$export_out" in *"DROPPED_TOOLS="*"TodoWrite:1"*) case "$export_out" in *"WebFetch:1"*) echo true ;; *) echo false ;; esac ;; *) echo false ;; esac)"
+
+assert "unmapped source keys are reported (DROPPED_KEYS names context)" \
+  "$(case "$export_out" in *"DROPPED_KEYS=demo-plugin/agents/worker.md:context"*) echo true ;; *) echo false ;; esac)"
+
+echo "=== TEST F/G/H: skips, body fidelity, and the pi tool-name contract ==="
+assert "description-less agent is SKIPPED, not emitted" \
+  "$([ ! -f "$fixture/out/agents/nameless.md" ] && echo true || echo false)"
+assert "the skip is reported (never silent) and non-zero" \
+  "$(case "$export_out" in *"SKIPPED_AGENTS=1"*"nameless.md"*) [ "$export_rc" -ne 0 ] && echo true || echo false ;; *) echo false ;; esac)"
+
+assert "prompt body survives verbatim" \
+  "$(python3 - "$out_agent" <<'PY'
+import sys
+t = open(sys.argv[1]).read()
+body = t[t.find("\n---\n", 3) + 5:]
+print("true" if body.strip().startswith("# Worker Agent")
+      and "| 1 | 2 |" in body else "false")
+PY
+)"
+
+# The multi-line `description: |` must arrive as ONE logical line: no folded
+# scalar, no escaped unicode, no trailing newline artefact.
+assert "a block-scalar description lands as a single line" \
+  "$(python3 - "$out_agent" <<'PY'
+import sys, yaml
+t = open(sys.argv[1]).read()
+end = t.find("\n---\n", 3)
+fm = yaml.safe_load(t[4:end])
+desc = fm.get("description", "")
+print("true" if desc == "Does the work. Wrapped across lines on purpose." else "false")
+PY
+)"
+
+# THE schema contract: pi's `tools:` is a name-only allowlist and an unknown
+# entry is a hard error at load time. Assert against the built-in set
+# (createCodingTools + createReadOnlyTools, pi 0.84.1) by name, not by count.
+assert "every emitted tool is one of pi's 7 built-ins" \
+  "$(python3 - "$out_agent" <<'PY'
+import sys, yaml
+PI_BUILTINS = {"read", "bash", "edit", "write", "grep", "find", "ls"}
+t = open(sys.argv[1]).read()
+fm = yaml.safe_load(t[4:t.find("\n---\n", 3)])
+emitted = {tool.strip() for tool in str(fm.get("tools", "")).split(",") if tool.strip()}
+print("true" if emitted and emitted <= PI_BUILTINS else "false")
+PY
+)"
+
+assert "tools: '*' expands to all 7 built-ins" \
+  "$(python3 - "$fixture/out/agents/wildcard.md" <<'PY'
+import sys, yaml
+PI_BUILTINS = {"read", "bash", "edit", "write", "grep", "find", "ls"}
+t = open(sys.argv[1]).read()
+fm = yaml.safe_load(t[4:t.find("\n---\n", 3)])
+emitted = {tool.strip() for tool in str(fm.get("tools", "")).split(",") if tool.strip()}
+print("true" if emitted == PI_BUILTINS else "false")
+PY
+)"
+
+# The negative direction of the same key: an omitted `tools:` grants all 7 in
+# pi, so `none` must survive as `none` rather than being dropped.
+assert "tools: none stays none (it must not widen to all built-ins)" \
+  "$(python3 - "$fixture/out/agents/no-tools.md" <<'PY'
+import sys, yaml
+t = open(sys.argv[1]).read()
+fm = yaml.safe_load(t[4:t.find("\n---\n", 3)])
+print("true" if fm.get("tools") == "none" else "false")
+PY
+)"
+
+echo "=== TEST I: recipes exist, install is additive, no network step ==="
+assert "justfile carries export-pi-agents and install-pi-agents" \
+  "$(grep -q '^export-pi-agents' "$justfile" && grep -q '^install-pi-agents' "$justfile" && echo true || echo false)"
+assert "setup-pi wires the export in" \
+  "$(grep -qE '^setup-pi:.*install-pi-agents' "$justfile" && grep -A 25 '^install-pi-agents' "$justfile" | grep -q 'export-pi-agents.py' && echo true || echo false)"
+# The install must never rm -rf the target: ~/.pi/agent/agents/ is shared with
+# agents the user wrote, and a clobbering install is unrecoverable.
+# shellcheck disable=SC2016  # $target is a literal to match in the justfile, not an expansion
+assert "install-pi-agents does not rm -rf its target" \
+  "$(grep -A 20 '^install-pi-agents' "$justfile" | grep -qE 'rm -rf "?\$?\{?target|rm -rf \$target' && echo false || echo true)"
+assert "the exporter invokes no bunx/npx/network step" \
+  "$(grep -qE '(bunx|npx)[[:space:]]|npm install|curl ' "$exporter" && echo false || echo true)"
+
+echo ""
+echo "=== SUMMARY ==="
+echo "PASSED=$pass_count"
+echo "FAILED=$fail_count"
+if [ "$fail_count" -eq 0 ]; then
+  echo "STATUS=OK"
+  exit 0
+fi
+echo "STATUS=FAIL"
+exit 1


### PR DESCRIPTION
Closes #2633
Closes #2635

## Why

Pi reads `SKILL.md` in place through the ADR-0022 adapter, so **skills** needed no projection. **Subagents** did: pi never looks at `.claude/agents/`, so all 21 marketplace agents were invisible there — the `Agent` tool offered only pi's own built-ins. `docs/pi-export.md` called agent porting "out of scope (deferred)"; with `@tintinweb/pi-subagents` installed that position is stale, because its agent schema is close to Claude Code's and most of the projection is a rename rather than a loss.

## What

**#2635 — adapter metadata + a real packaging fix** (`d0fdab2d`)

- `adapters/package.json` description now states what the package *is* (both bindings landed), not what was pending.
- Declared the pi package manifest (`keywords: ["pi-package"]`, `pi.extensions: ["./pi/index.ts"]`). **Load-bearing, not decorative**: pi 0.84.1's `resolveExtensionEntries()` falls back to `<root>/index.ts`, which this package does not have — so `pi install ./adapters` registered the package and loaded *no* extension. Its `extensions` entries are `resolve()`d and `existsSync`-checked, so a file path is accepted, not only a directory. Confirmed by installing into a throwaway `PI_CODING_AGENT_DIR`.
- `docs/pi-export.md` explains the `-export.md` filename against ADR-0022 (pi has no *skill* export step). Corrects an earlier claim: OpenCode's export projects **subagents and hooks**, not skills.

**#2633 — the subagent export** (`c5593f2b`)

- `scripts/export-pi-agents.py`: `maxTurns` → `max_turns`, `Read/Write/Edit/Glob/Grep` → `read/write/edit/find/grep`, `Bash(<scope>)` → `bash`, `Agent(a, b)` → `allowed_subagents: a, b` (nesting, deliberately not a tool grant), `skills:` lists preserved, `model`/`color`/`thinking` passed through. The splitter is paren-aware — a naive comma split turns `Agent(a, b)` into two bogus tool names.
- `just export-pi-agents` / `just install-pi-agents`, wired into `just setup-pi`. The install is additive (never `rm -rf`s the shared `~/.pi/agent/agents/`) and self-skips with a hint when `@tintinweb/pi-subagents` is absent, since pi ignores `.pi/agents/` entirely without it.
- `scripts/tests/test-export-pi-agents.sh`: 19 assertions that **execute** the exporter against a fixture, wired into pre-commit beside the OpenCode sibling's suite.
- Docs: new § Subagents; the "Out of scope" list now names only hooks (#2634) and prompt templates.

## The two lossy edges (reported, never silent)

| Edge | Measured | Why nothing here can narrow it |
|---|---|---|
| `WIDENED_BASH` | **142** | pi's `tools:` is a name-only allowlist — no per-command scoping exists in the schema, so `Bash(git diff *)` becomes unscoped `bash`. This is a **privilege widening** and a property of the target, not a bug in the projection. |
| `DROPPED_TOOLS` | `TodoWrite:21`, `TaskOutput:2`, `WebFetch:1`, `WebSearch:1` | No pi built-in exists. `WebFetch`/`WebSearch` *can* be reached as `ext:pi-web-search/…`, but a single `ext:` entry flips pi's extension tools into explicit-allowlist mode — the agent would silently lose `search_skills` and everything else the adapter exposes. Left as a human opt-in rather than applied here. |

`context: fork` (10 agents) is likewise reported rather than mapped: a pi subagent is *always* its own session, so fork-isolation is pi's default, while `inherit_context:` is the opposite direction — inferring either would be a guess.

## Verification

- `just export-pi-agents` on the real corpus: **21/21** agents, `SKIPPED_AGENTS=0`, `MODEL_PINS=21`, `AGENTS_WITH_NESTING=1`.
- `just install-pi-agents <dir>` is additive — a pre-existing user agent file survives (22 files after install).
- `pre-commit run --files <all changed>`: **exit 0**, 12 hooks passed (ruff check/format, shellcheck, lint-shell-scripts, the new suite, just-recipe-help, version-pin + workflow-model guards).
- New suite: **19/19**, `STATUS=OK`, including `tools: none` (must not widen to all 7) and `tools: "*"` (must expand to exactly the 7 built-ins from `createCodingTools` + `createReadOnlyTools`).

**Not verified — the one gap:** a live pi dispatch of an exported agent. That needs a fresh pi session (`/agents` lists what loaded), and this environment cannot import pi-subagents' loader because its `@earendil-works/*` peer deps are not installed under `~/.pi/agent/npm/`. The offline suite pins the schema contract instead (field names + the 7-built-in tool allowlist, since an unknown `tools:` entry is a hard `tools-error:` in pi).

## Reviewer notes

- `model: opus` is passed through verbatim. On a local-model-only pi setup every dispatch will flag `(unavailable, fallback: inherit)` and run on the parent's model; on a setup with an Anthropic provider it resolves. Preserved rather than stripped so the authored pin is not silently mutated — worth a second opinion if local-model runs are the main use.
- Both commits are root-level (`scripts/`, `justfile`, `docs/`, `adapters/`) — no release-please package, so nothing publishes.